### PR TITLE
fix(deepseek): normalize mcp union tool schemas

### DIFF
--- a/extensions/deepseek/index.test.ts
+++ b/extensions/deepseek/index.test.ts
@@ -222,6 +222,51 @@ describe("deepseek provider plugin", () => {
     expect(replayPolicy?.validateAnthropicTurns).toBe(true);
   });
 
+  it("owns DeepSeek tool schema compatibility for MCP union schemas", async () => {
+    const provider = await registerSingleProviderPlugin(deepseekPlugin);
+    const mcpTool = {
+      name: "unusual-whales__get_balance_sheet_screener",
+      description: "",
+      parameters: {
+        type: "object",
+        properties: {
+          date: {
+            anyOf: [{ type: "string" }, { type: "integer" }],
+          },
+          period: {
+            oneOf: [{ type: "string" }, { type: "null" }],
+          },
+        },
+      },
+      execute: () => undefined,
+    } as never;
+
+    const normalized = provider.normalizeToolSchemas?.({
+      provider: "deepseek",
+      modelId: "deepseek-v4-pro",
+      modelApi: "openai-completions",
+      model: deepSeekV4Model("deepseek-v4-pro"),
+      tools: [mcpTool],
+    } as never);
+
+    expect(normalized?.[0]?.parameters).toEqual({
+      type: "object",
+      properties: {
+        date: { type: "string" },
+        period: { type: "string", nullable: true },
+      },
+    });
+    expect(
+      provider.inspectToolSchemas?.({
+        provider: "deepseek",
+        modelId: "deepseek-v4-pro",
+        modelApi: "openai-completions",
+        model: deepSeekV4Model("deepseek-v4-pro"),
+        tools: normalized ?? [],
+      } as never),
+    ).toStrictEqual([]);
+  });
+
   it("advertises max thinking levels for DeepSeek V4 models only", async () => {
     const provider = await registerSingleProviderPlugin(deepseekPlugin);
     const resolveThinkingProfile = requireThinkingProfileResolver(provider);

--- a/extensions/deepseek/index.ts
+++ b/extensions/deepseek/index.ts
@@ -1,6 +1,7 @@
 import { readConfiguredProviderCatalogEntries } from "openclaw/plugin-sdk/provider-catalog-shared";
 import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
 import { buildProviderReplayFamilyHooks } from "openclaw/plugin-sdk/provider-model-shared";
+import { buildProviderToolCompatFamilyHooks } from "openclaw/plugin-sdk/provider-tools";
 import { applyDeepSeekConfig, DEEPSEEK_DEFAULT_MODEL_REF } from "./onboard.js";
 import { buildDeepSeekProvider } from "./provider-catalog.js";
 import { createDeepSeekV4ThinkingWrapper } from "./stream.js";
@@ -49,6 +50,7 @@ export default defineSingleProviderPluginEntry({
       family: "openai-compatible",
       dropReasoningFromHistory: false,
     }),
+    ...buildProviderToolCompatFamilyHooks("deepseek"),
     wrapStreamFn: (ctx) => createDeepSeekV4ThinkingWrapper(ctx.streamFn, ctx.thinkingLevel),
     resolveThinkingProfile: ({ modelId }) => resolveDeepSeekV4ThinkingProfile(modelId),
     isModernModelRef: ({ modelId }) => Boolean(resolveDeepSeekV4ThinkingProfile(modelId)),

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1677,7 +1677,21 @@ export async function runEmbeddedAttempt(
       ownerOnlyToolAllowlist: params.ownerOnlyToolAllowlist,
       warn: (message) => log.warn(message),
     });
-    const uncompactedEffectiveTools = [...tools, ...filteredBundledTools];
+    const normalizedBundledTools =
+      filteredBundledTools.length > 0
+        ? normalizeAgentRuntimeTools({
+            runtimePlan: params.runtimePlan,
+            tools: filteredBundledTools,
+            provider: params.provider,
+            config: params.config,
+            workspaceDir: effectiveWorkspace,
+            env: process.env,
+            modelId: params.modelId,
+            modelApi: params.model.api,
+            model: params.model,
+          })
+        : filteredBundledTools;
+    const uncompactedEffectiveTools = [...tools, ...normalizedBundledTools];
     let effectiveTools = uncompactedEffectiveTools;
     const catalogToolHookContext = {
       agentId: sessionAgentId,

--- a/src/plugin-sdk/provider-tools.test.ts
+++ b/src/plugin-sdk/provider-tools.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
   buildProviderToolCompatFamilyHooks,
+  inspectDeepSeekToolSchemas,
   findOpenAIStrictSchemaViolations,
   inspectGeminiToolSchemas,
   inspectOpenAIToolSchemas,
+  normalizeDeepSeekToolSchemas,
   normalizeGeminiToolSchemas,
   normalizeOpenAIToolSchemas,
 } from "./provider-tools.js";
@@ -30,6 +32,11 @@ describe("buildProviderToolCompatFamilyHooks", () => {
   it("covers the tool compat family matrix", () => {
     const cases = [
       {
+        family: "deepseek" as const,
+        normalizeToolSchemas: normalizeDeepSeekToolSchemas,
+        inspectToolSchemas: inspectDeepSeekToolSchemas,
+      },
+      {
         family: "gemini" as const,
         normalizeToolSchemas: normalizeGeminiToolSchemas,
         inspectToolSchemas: inspectGeminiToolSchemas,
@@ -47,6 +54,69 @@ describe("buildProviderToolCompatFamilyHooks", () => {
       expect(hooks.normalizeToolSchemas).toBe(testCase.normalizeToolSchemas);
       expect(hooks.inspectToolSchemas).toBe(testCase.inspectToolSchemas);
     }
+  });
+
+  it("collapses anyOf and oneOf unions for the deepseek family", () => {
+    const hooks = buildProviderToolCompatFamilyHooks("deepseek");
+    const tools = [
+      {
+        name: "unusual-whales__get_balance_sheet_screener",
+        description: "",
+        parameters: {
+          type: "object",
+          properties: {
+            date: {
+              description: "Balance sheet date",
+              anyOf: [{ type: "string" }, { type: "integer" }],
+            },
+            ticker: {
+              oneOf: [{ type: "string" }, { type: "null" }],
+            },
+          },
+          required: ["date"],
+        },
+      },
+    ] as never;
+
+    const normalized = hooks.normalizeToolSchemas({
+      provider: "deepseek",
+      modelId: "deepseek-v4-pro",
+      modelApi: "openai-completions",
+      model: {
+        provider: "deepseek",
+        api: "openai-completions",
+        id: "deepseek-v4-pro",
+      } as never,
+      tools,
+    });
+
+    expect(normalized[0]?.parameters).toEqual({
+      type: "object",
+      properties: {
+        date: {
+          description: "Balance sheet date",
+          type: "string",
+        },
+        ticker: {
+          type: "string",
+          nullable: true,
+        },
+      },
+      required: ["date"],
+    });
+    expect(
+      hooks.inspectToolSchemas({
+        provider: "deepseek",
+        modelId: "deepseek-v4-pro",
+        modelApi: "openai-completions",
+        model: {
+          provider: "deepseek",
+          api: "openai-completions",
+          id: "deepseek-v4-pro",
+        } as never,
+        tools: normalized,
+      }),
+    ).toStrictEqual([]);
   });
 
   it("normalizes parameter-free and typed-object schemas for the openai family", () => {

--- a/src/plugin-sdk/provider-tools.ts
+++ b/src/plugin-sdk/provider-tools.ts
@@ -394,13 +394,127 @@ export function inspectOpenAIToolSchemas(
   return [];
 }
 
-export type ProviderToolCompatFamily = "gemini" | "openai";
+export const DEEPSEEK_UNSUPPORTED_SCHEMA_KEYWORDS = new Set(["anyOf", "oneOf"]);
+
+function isNullSchemaVariant(schema: unknown): boolean {
+  if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
+    return false;
+  }
+  const record = schema as Record<string, unknown>;
+  if (record.type === "null") {
+    return true;
+  }
+  if (Array.isArray(record.type) && record.type.length === 1 && record.type[0] === "null") {
+    return true;
+  }
+  if ("const" in record && record.const === null) {
+    return true;
+  }
+  return Array.isArray(record.enum) && record.enum.length === 1 && record.enum[0] === null;
+}
+
+function normalizeDeepSeekSchema(schema: unknown): unknown {
+  if (Array.isArray(schema)) {
+    let changed = false;
+    const normalized = schema.map((entry) => {
+      const next = normalizeDeepSeekSchema(entry);
+      changed ||= next !== entry;
+      return next;
+    });
+    return changed ? normalized : schema;
+  }
+  if (!schema || typeof schema !== "object") {
+    return schema;
+  }
+
+  const record = schema as Record<string, unknown>;
+  const unionKey = Array.isArray(record.anyOf)
+    ? "anyOf"
+    : Array.isArray(record.oneOf)
+      ? "oneOf"
+      : undefined;
+
+  let changed = false;
+  const normalized: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(record)) {
+    if (key === "anyOf" || key === "oneOf") {
+      if (key === unionKey) {
+        changed = true;
+        continue;
+      }
+    }
+    const next = normalizeDeepSeekSchema(value);
+    normalized[key] = next;
+    changed ||= next !== value;
+  }
+
+  if (!unionKey) {
+    return changed ? normalized : schema;
+  }
+
+  const variants = record[unionKey] as unknown[];
+  const normalizedVariants = variants.map((entry) => normalizeDeepSeekSchema(entry));
+  const nonNullVariants = normalizedVariants.filter((entry) => !isNullSchemaVariant(entry));
+  const selected = nonNullVariants[0] ?? normalizedVariants[0];
+  if (!selected || typeof selected !== "object" || Array.isArray(selected)) {
+    return normalized;
+  }
+
+  const merged = {
+    ...(selected as Record<string, unknown>),
+    ...normalized,
+  };
+  if (nonNullVariants.length < normalizedVariants.length) {
+    merged.nullable = true;
+  }
+  return merged;
+}
+
+export function normalizeDeepSeekToolSchemas(
+  ctx: ProviderNormalizeToolSchemasContext,
+): AnyAgentTool[] {
+  return ctx.tools.map((tool) => {
+    if (!tool.parameters || typeof tool.parameters !== "object") {
+      return tool;
+    }
+    const parameters = normalizeDeepSeekSchema(tool.parameters);
+    return parameters === tool.parameters
+      ? tool
+      : {
+          ...tool,
+          parameters: parameters as TSchema,
+        };
+  });
+}
+
+export function inspectDeepSeekToolSchemas(
+  ctx: ProviderNormalizeToolSchemasContext,
+): ProviderToolSchemaDiagnostic[] {
+  return ctx.tools.flatMap((tool, toolIndex) => {
+    const violations = findUnsupportedSchemaKeywords(
+      tool.parameters,
+      `${tool.name}.parameters`,
+      DEEPSEEK_UNSUPPORTED_SCHEMA_KEYWORDS,
+    );
+    if (violations.length === 0) {
+      return [];
+    }
+    return [{ toolName: tool.name, toolIndex, violations }];
+  });
+}
+
+export type ProviderToolCompatFamily = "deepseek" | "gemini" | "openai";
 
 export function buildProviderToolCompatFamilyHooks(family: ProviderToolCompatFamily): {
   normalizeToolSchemas: (ctx: ProviderNormalizeToolSchemasContext) => AnyAgentTool[];
   inspectToolSchemas: (ctx: ProviderNormalizeToolSchemasContext) => ProviderToolSchemaDiagnostic[];
 } {
   switch (family) {
+    case "deepseek":
+      return {
+        normalizeToolSchemas: normalizeDeepSeekToolSchemas,
+        inspectToolSchemas: inspectDeepSeekToolSchemas,
+      };
     case "gemini":
       return {
         normalizeToolSchemas: normalizeGeminiToolSchemas,


### PR DESCRIPTION
Fixes #83361.

Behavior or issue addressed:
- Bundle MCP tools could be materialized after provider tool-schema normalization, so DeepSeek requests could still receive raw MCP `anyOf`/`oneOf` schemas.
- DeepSeek rejects these schemas with `400 Invalid schema`, as reported for Unusual Whales MCP tools.
- This keeps the compatibility policy provider-owned by adding a DeepSeek tool-schema hook, then runs provider normalization over materialized bundled tools before they are included in the final effective tool set.

## Real behavior proof
Behavior or issue addressed: DeepSeek-bound MCP tool schemas with `anyOf`/`oneOf` unions are normalized before provider submission, so the final tool parameter payload no longer contains the union keywords that triggered the reported DeepSeek `400 Invalid schema`.

Real environment tested: Local OpenClaw checkout on macOS using the production provider-tool compatibility helper imported from `src/plugin-sdk/provider-tools.ts`. This exercises the runtime schema payload that OpenClaw produces immediately before provider transport; no mocked provider response is involved in this command.

Exact steps or command run after this patch:
```console
PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node --import tsx -e 'import { buildProviderToolCompatFamilyHooks } from "./src/plugin-sdk/provider-tools.ts"; const hooks = buildProviderToolCompatFamilyHooks("deepseek"); const tools = [{ name: "unusual-whales__get_balance_sheet_screener", description: "", parameters: { type: "object", properties: { date: { anyOf: [{ type: "string" }, { type: "integer" }] }, period: { oneOf: [{ type: "string" }, { type: "null" }] } }, required: ["date"] } }]; const normalized = hooks.normalizeToolSchemas({ provider: "deepseek", modelId: "deepseek-v4-pro", modelApi: "openai-completions", model: { provider: "deepseek", api: "openai-completions", id: "deepseek-v4-pro" }, tools }); console.log(JSON.stringify(normalized[0].parameters, null, 2)); console.log(JSON.stringify(hooks.inspectToolSchemas({ provider: "deepseek", modelId: "deepseek-v4-pro", modelApi: "openai-completions", model: { provider: "deepseek", api: "openai-completions", id: "deepseek-v4-pro" }, tools: normalized }), null, 2));'
```

Evidence after fix:
```json
{
  "type": "object",
  "properties": {
    "date": {
      "type": "string"
    },
    "period": {
      "type": "string",
      "nullable": true
    }
  },
  "required": [
    "date"
  ]
}
[]
```

Observed result after fix: The Unusual Whales-style `date.anyOf` payload is emitted as `{ "type": "string" }`, the nullable `period.oneOf` payload is emitted as `{ "type": "string", "nullable": true }`, and DeepSeek schema diagnostics return `[]`. That is the provider-bound schema shape after the fix.

What was not tested: A live DeepSeek API request with a real Unusual Whales MCP server, because credentials and server access were not available in this environment.

## Validation
Focused provider/plugin validation:
```console
PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node scripts/run-vitest.mjs src/plugin-sdk/provider-tools.test.ts extensions/deepseek/index.test.ts

Test Files  2 passed (2)
Tests  19 passed (19)
```

Full validation:
```console
PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node scripts/run-vitest.mjs src/agents/pi-bundle-mcp-tools.materialize.test.ts src/agents/runtime-plan/tools.test.ts src/agents/pi-embedded-runner/tool-schema-runtime.test.ts extensions/deepseek/index.test.ts src/plugin-sdk/provider-tools.test.ts src/agents/pi-tools.schema.test.ts

Test Files  9 passed (9)
Tests  96 passed (96)
```

Other checks:
```console
PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node_modules/.bin/oxfmt --check --threads=1 extensions/deepseek/index.ts extensions/deepseek/index.test.ts src/plugin-sdk/provider-tools.ts src/plugin-sdk/provider-tools.test.ts src/agents/pi-embedded-runner/run/attempt.ts
git diff --check
git log --format='%h %an <%ae> %s' upstream/main..HEAD
```

Commit author verification:
```console
455941e999 Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com> fix(deepseek): normalize mcp union tool schemas
```
