### PR TITLE
fix(mistral): opt into prompt_cache_key transport gate (#83709)

### DIFF
--- a/extensions/mistral/api.test.ts
+++ b/extensions/mistral/api.test.ts
@@ -32,6 +32,10 @@ function reasoningEffortMap(model: unknown): Record<string, string> | undefined 
   return readCompat<{ reasoningEffortMap?: Record<string, string> }>(model)?.reasoningEffortMap;
 }
 
+function supportsPromptCacheKey(model: unknown): boolean | undefined {
+  return readCompat<{ supportsPromptCacheKey?: boolean }>(model)?.supportsPromptCacheKey;
+}
+
 const MISTRAL_REASONING_EFFORT_MAP = {
   off: "none",
   minimal: "none",
@@ -49,6 +53,7 @@ describe("resolveMistralCompatPatch", () => {
       supportsStore: false,
       supportsReasoningEffort: true,
       maxTokensField: "max_tokens",
+      supportsPromptCacheKey: true,
       reasoningEffortMap: MISTRAL_REASONING_EFFORT_MAP,
     });
   });
@@ -58,6 +63,7 @@ describe("resolveMistralCompatPatch", () => {
       supportsStore: false,
       supportsReasoningEffort: true,
       maxTokensField: "max_tokens",
+      supportsPromptCacheKey: true,
       reasoningEffortMap: MISTRAL_REASONING_EFFORT_MAP,
     });
   });
@@ -77,6 +83,8 @@ describe("applyMistralModelCompat", () => {
     expect(supportsReasoningEffort(normalized)).toBe(false);
     expect(maxTokensField(normalized)).toBe("max_tokens");
     expect(reasoningEffortMap(normalized)).toBeUndefined();
+    // Regression for #83709: Mistral compat patch must opt the transport gate in.
+    expect(supportsPromptCacheKey(normalized)).toBe(true);
   });
 
   it("applies reasoning compat for mistral-small-latest", () => {
@@ -126,6 +134,7 @@ describe("applyMistralModelCompat", () => {
         supportsStore: false,
         supportsReasoningEffort: false,
         maxTokensField: "max_tokens" as const,
+        supportsPromptCacheKey: true,
       },
     };
     expect(applyMistralModelCompat(model)).toBe(model);

--- a/extensions/mistral/api.ts
+++ b/extensions/mistral/api.ts
@@ -15,9 +15,15 @@ const MISTRAL_MAX_TOKENS_FIELD = "max_tokens";
 export const MISTRAL_MODEL_TRANSPORT_PATCH = {
   supportsStore: false,
   maxTokensField: MISTRAL_MAX_TOKENS_FIELD,
+  // Mistral's chat completion API accepts `prompt_cache_key`; cached prefix tokens
+  // are billed at 10% of the standard input price. Without this flag the transport
+  // gate in openai-transport-stream (compat.supportsPromptCacheKey === true) never
+  // fires for Mistral, so usage.cached_tokens stays at 0. See #83709.
+  supportsPromptCacheKey: true,
 } as const satisfies {
   supportsStore: boolean;
   maxTokensField: "max_tokens";
+  supportsPromptCacheKey: boolean;
 };
 
 const MISTRAL_SMALL_LATEST_REASONING_EFFORT_MAP: Record<string, string> = {
@@ -38,6 +44,7 @@ export function resolveMistralCompatPatch(model: { id?: string }): {
   supportsStore: boolean;
   supportsReasoningEffort: boolean;
   maxTokensField: "max_tokens";
+  supportsPromptCacheKey: boolean;
   reasoningEffortMap?: Record<string, string>;
 } {
   const reasoningEnabled =
@@ -58,6 +65,7 @@ function compatMatchesResolved(
     compat?.supportsStore === expected.supportsStore &&
     compat?.supportsReasoningEffort === expected.supportsReasoningEffort &&
     compat?.maxTokensField === expected.maxTokensField &&
+    compat?.supportsPromptCacheKey === expected.supportsPromptCacheKey &&
     compat?.reasoningEffortMap === expected.reasoningEffortMap
   );
 }


### PR DESCRIPTION
Fixes #83709.

Mistral's chat completion API supports `prompt_cache_key` and bills cached prefix tokens at 10% of the standard input price ([Mistral docs](https://docs.mistral.ai/studio-api/conversations/advanced/prompt-caching)). But `MISTRAL_MODEL_TRANSPORT_PATCH` did not set `supportsPromptCacheKey`, so the transport gate in `openai-transport-stream` (`compat.supportsPromptCacheKey === true`) never fired for Mistral models — `prompt_cache_key` was never sent and `usage.prompt_tokens_details.cached_tokens` stayed at 0 for every turn even when a stable system-prompt / workspace prefix was being resent.

## Changes

- `extensions/mistral/api.ts`: add `supportsPromptCacheKey: true` to `MISTRAL_MODEL_TRANSPORT_PATCH`, extend the `as const satisfies` type literal, the `resolveMistralCompatPatch` return type, and the `compatMatchesResolved` idempotency check so re-normalization stays a no-op.
- `extensions/mistral/api.test.ts`: update the existing `resolveMistralCompatPatch` exact-equality assertions to include the new field, normalize the "already-normalized" reference compat, and add a regression assertion that `applyMistralModelCompat({})` exposes `supportsPromptCacheKey: true`.

Diff stat: 2 files, +17 LOC.

## Real behavior proof

- **Behavior or issue addressed:** Sanitized issue evidence — installed dist of v2026.5.12 omits `supportsPromptCacheKey` from `MISTRAL_MODEL_TRANSPORT_PATCH`; the transport gate is wired on that exact field; agents using `mistral-medium-2508` report `cached_tokens: 0` for every turn.

- **Real environment tested:** Local Node 22.x. Probe at `/tmp/probe_83709.mjs` (a) parses the patched `extensions/mistral/api.ts` and verifies the source-level invariants (field declared in the patch const with the literal value `true`, included in the `as const satisfies` type literal, included in the `resolveMistralCompatPatch` return type, compared inside `compatMatchesResolved`), then (b) replays the transport-stream gate `(compat.supportsPromptCacheKey && cacheRetention !== "none" && options?.sessionId)` against both the patched and the unpatched compat shapes.

- **Exact steps or command run after this patch:** `node /tmp/probe_83709.mjs`

- **Evidence after fix:**

```
PASS: supportsPromptCacheKey: true present in patch const
PASS: supportsPromptCacheKey: boolean in satisfies type literal
PASS: resolveMistralCompatPatch return type includes the new field
PASS: compatMatchesResolved compares supportsPromptCacheKey
PASS: transport gate fires only when cacheRetention!=none AND sessionId present
PASS: old shape (no supportsPromptCacheKey) does not fire — confirms #83709 root cause

ALL CASES PASS
```

- **Observed result after fix:** Patched Mistral compat opts into the transport gate; gate fires for `cacheRetention != "none"` with a `sessionId` (the normal session heartbeat path) and is skipped when either guard fails. Unpatched (pre-fix) shape confirms the root cause — the gate is silently dropped.

- **What was not tested:** Live request against `api.mistral.ai` measuring `usage.prompt_tokens_details.cached_tokens > 0` after a warm prefix — that requires a Mistral API key and a repeated-prefix workload, which I cannot run from this branch. The source-level probe + the regression test exercise the exact predicate that gates `params.prompt_cache_key = options.sessionId` in `openai-transport-stream`.

## Audit (per CLAUDE rules — all 5 steps)

- **Existing-helper check:** Reuses the existing `MISTRAL_MODEL_TRANSPORT_PATCH` const, the existing `compat.supportsPromptCacheKey === true` predicate in `openai-transport-stream.ts`, and the existing `compatMatchesResolved` idempotency helper. No new predicate introduced. PASS
- **Shared-helper caller check:** `MISTRAL_MODEL_TRANSPORT_PATCH` has 3 callers: `api.ts:46` (spread inside `resolveMistralCompatPatch`), `provider-compat.ts:61` (return from `contributeMistralResolvedModelCompat`), `api.test.ts` (multiple `toEqual` references). All three already expect the full patch shape; the new field is additive. The `resolveMistralCompatPatch` return type advertises the new field so downstream `applyMistralModelCompat` stays type-safe. PASS
- **Broader-fix rival scan:** No open PRs touch `MISTRAL_MODEL_TRANSPORT_PATCH`. `gh pr list --search 'supportsPromptCacheKey in:title,body'` returns no Mistral-related rivals. PASS
- **Recent-merge audit:** `git log --oneline -10 -- extensions/mistral/api.ts extensions/mistral/provider-compat.ts` shows the most recent touch is `e1061a8b46 test(live): tolerate provider drift in release checks` — unrelated. PASS
- **Prototype-pollution scan:** N/A — no external-input key copying.
