### PR TITLE
fix(cli): preserve numeric config set record keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -218,6 +218,7 @@ Docs: https://docs.openclaw.ai
 - CLI/update: guide root-owned npm install EACCES recovery by stopping the managed Gateway before manual package replacement, then reinstalling and restarting the service. Fixes #83747. (#83757) Thanks @brokemac79.
 - Twitch: register refreshing chat tokens with Twurple's chat intent so automatic token refresh keeps chat access available. (#83750) Thanks @TurboTheTurtle.
 - Agents/subagents: keep collect-mode announce queues batching unresolved-origin items with compatible same-route messages and resume collection after a true cross-channel drain when a later compatible batch remains. Fixes #83577.
+- CLI/config: preserve numeric-looking record keys such as Discord guild IDs when creating missing config containers with `config set`. (#83769) Thanks @TurboTheTurtle.
 - Skills: refresh existing session skill snapshots when watched skill roots change, so changed extra skill directories take effect without starting a new session. Fixes #83782. (#83800) Thanks @hclsys.
 - Providers/Anthropic: preserve native image input for current Claude model rows when stale local catalog data marks them text-only. (#83756) Thanks @TurboTheTurtle.
 - Providers/Anthropic: preserve Claude 4 image capability when configured model refs resolve through a stale local catalog row. (#83756) Thanks @TurboTheTurtle.

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -1262,6 +1262,36 @@ describe("config cli", () => {
       });
     });
 
+    it("keeps numeric config set path segments as object keys for Discord guild records", async () => {
+      const resolved: OpenClawConfig = {
+        channels: {
+          discord: {
+            enabled: true,
+          },
+        },
+      } as unknown as OpenClawConfig;
+      setSnapshot(resolved, resolved);
+
+      await runConfigCommand([
+        "config",
+        "set",
+        "channels.discord.guilds.1495587801394184362.requireMention",
+        "true",
+        "--strict-json",
+      ]);
+
+      expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
+      const written = firstWrittenConfig() as {
+        channels?: { discord?: { guilds?: unknown } };
+      };
+      expect(written.channels?.discord?.guilds).toEqual({
+        "1495587801394184362": {
+          requireMention: true,
+        },
+      });
+      expect(Array.isArray(written.channels?.discord?.guilds)).toBe(false);
+    });
+
     it("fails early when unsupported mutable paths are assigned SecretRef objects (builder mode)", async () => {
       const resolved: OpenClawConfig = {
         gateway: { port: 18789 },

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -181,6 +181,27 @@ function createPluginMetadataSnapshot(
   };
 }
 
+function configRecordWithRequireMentionSchema() {
+  return {
+    type: "object",
+    additionalProperties: {
+      type: "object",
+      properties: {
+        requireMention: { type: "boolean" },
+      },
+    },
+  };
+}
+
+function configChannelSchemaWithRecord(recordKey: string) {
+  return {
+    type: "object",
+    properties: {
+      [recordKey]: configRecordWithRequireMentionSchema(),
+    },
+  };
+}
+
 function setConfigMutationShapeSchema() {
   mockReadBestEffortRuntimeConfigSchema.mockResolvedValue({
     schema: {
@@ -205,34 +226,8 @@ function setConfigMutationShapeSchema() {
         channels: {
           type: "object",
           properties: {
-            discord: {
-              type: "object",
-              properties: {
-                guilds: {
-                  type: "object",
-                  additionalProperties: {
-                    type: "object",
-                    properties: {
-                      requireMention: { type: "boolean" },
-                    },
-                  },
-                },
-              },
-            },
-            telegram: {
-              type: "object",
-              properties: {
-                groups: {
-                  type: "object",
-                  additionalProperties: {
-                    type: "object",
-                    properties: {
-                      requireMention: { type: "boolean" },
-                    },
-                  },
-                },
-              },
-            },
+            discord: configChannelSchemaWithRecord("guilds"),
+            telegram: configChannelSchemaWithRecord("groups"),
           },
         },
       },

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -181,6 +181,68 @@ function createPluginMetadataSnapshot(
   };
 }
 
+function setConfigMutationShapeSchema() {
+  mockReadBestEffortRuntimeConfigSchema.mockResolvedValue({
+    schema: {
+      $schema: "http://json-schema.org/draft-07/schema#",
+      type: "object",
+      properties: {
+        agents: {
+          type: "object",
+          properties: {
+            list: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  id: { type: "string" },
+                  name: { type: "string" },
+                },
+              },
+            },
+          },
+        },
+        channels: {
+          type: "object",
+          properties: {
+            discord: {
+              type: "object",
+              properties: {
+                guilds: {
+                  type: "object",
+                  additionalProperties: {
+                    type: "object",
+                    properties: {
+                      requireMention: { type: "boolean" },
+                    },
+                  },
+                },
+              },
+            },
+            telegram: {
+              type: "object",
+              properties: {
+                groups: {
+                  type: "object",
+                  additionalProperties: {
+                    type: "object",
+                    properties: {
+                      requireMention: { type: "boolean" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    uiHints: {},
+    version: "test",
+    generatedAt: "2026-03-25T00:00:00.000Z",
+  });
+}
+
 function setExternalFeishuSchema() {
   mockLoadPluginMetadataSnapshot.mockReturnValue(
     createPluginMetadataSnapshot({
@@ -1262,7 +1324,8 @@ describe("config cli", () => {
       });
     });
 
-    it("keeps numeric config set path segments as object keys for Discord guild records", async () => {
+    it("keeps numeric config set path segments as object keys for schema-backed Discord guild records", async () => {
+      setConfigMutationShapeSchema();
       const resolved: OpenClawConfig = {
         channels: {
           discord: {
@@ -1290,6 +1353,52 @@ describe("config cli", () => {
         },
       });
       expect(Array.isArray(written.channels?.discord?.guilds)).toBe(false);
+    });
+
+    it("keeps numeric config set path segments as object keys for other schema-backed records", async () => {
+      setConfigMutationShapeSchema();
+      const resolved: OpenClawConfig = {
+        channels: {
+          telegram: {
+            enabled: true,
+          },
+        },
+      } as unknown as OpenClawConfig;
+      setSnapshot(resolved, resolved);
+
+      await runConfigCommand([
+        "config",
+        "set",
+        "channels.telegram.groups.1495587801394184362.requireMention",
+        "true",
+        "--strict-json",
+      ]);
+
+      expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
+      const written = firstWrittenConfig() as {
+        channels?: { telegram?: { groups?: unknown } };
+      };
+      expect(written.channels?.telegram?.groups).toEqual({
+        "1495587801394184362": {
+          requireMention: true,
+        },
+      });
+      expect(Array.isArray(written.channels?.telegram?.groups)).toBe(false);
+    });
+
+    it("still creates arrays for schema-backed numeric list indexes", async () => {
+      setConfigMutationShapeSchema();
+      const resolved: OpenClawConfig = {};
+      setSnapshot(resolved, resolved);
+
+      await runConfigCommand(["config", "set", "agents.list.0.id", '"tech"', "--strict-json"]);
+
+      expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
+      const written = firstWrittenConfig() as {
+        agents?: { list?: unknown };
+      };
+      expect(written.agents?.list).toEqual([{ id: "tech" }]);
+      expect(Array.isArray(written.agents?.list)).toBe(true);
     });
 
     it("fails early when unsupported mutable paths are assigned SecretRef objects (builder mode)", async () => {

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -459,26 +459,122 @@ function getAtPath(root: unknown, path: PathSegment[]): { found: boolean; value?
   return { found: true, value: current };
 }
 
-type PathPattern = readonly string[];
-
-const CONFIG_SET_NUMERIC_OBJECT_KEY_PARENT_PATHS: readonly PathPattern[] = [
-  ["channels", "discord", "dms"],
-  ["channels", "discord", "guilds"],
-  ["channels", "discord", "guilds", "*", "channels"],
-  ["channels", "discord", "guilds", "*", "toolsBySender"],
-  ["channels", "discord", "guilds", "*", "channels", "*", "toolsBySender"],
-];
+type JsonSchemaRecord = {
+  type?: unknown;
+  properties?: unknown;
+  additionalProperties?: unknown;
+  items?: unknown;
+  anyOf?: unknown;
+  oneOf?: unknown;
+  allOf?: unknown;
+};
 
 type SetAtPathOptions = {
   numericObjectKeys?: boolean;
-  numericObjectKeyParentPaths?: readonly PathPattern[];
+  schema?: JsonSchemaRecord;
 };
 
-function pathMatchesPattern(path: readonly PathSegment[], pattern: PathPattern): boolean {
+function isSchemaRecord(value: unknown): value is JsonSchemaRecord {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function schemaTypes(schema: JsonSchemaRecord): Set<string> {
+  if (typeof schema.type === "string") {
+    return new Set([schema.type]);
+  }
+  if (Array.isArray(schema.type)) {
+    return new Set(schema.type.filter((entry): entry is string => typeof entry === "string"));
+  }
+  return new Set();
+}
+
+function schemaAlternatives(schema: JsonSchemaRecord): JsonSchemaRecord[] {
+  const alternatives: JsonSchemaRecord[] = [schema];
+  for (const key of ["anyOf", "oneOf", "allOf"] as const) {
+    const entries = schema[key];
+    if (!Array.isArray(entries)) {
+      continue;
+    }
+    for (const entry of entries) {
+      if (isSchemaRecord(entry)) {
+        alternatives.push(...schemaAlternatives(entry));
+      }
+    }
+  }
+  return alternatives;
+}
+
+function schemaLooksArray(schema: JsonSchemaRecord): boolean {
+  return schemaTypes(schema).has("array") || isSchemaRecord(schema.items);
+}
+
+function schemaLooksObject(schema: JsonSchemaRecord): boolean {
+  const types = schemaTypes(schema);
   return (
-    path.length === pattern.length &&
-    path.every((segment, index) => pattern[index] === "*" || pattern[index] === segment)
+    types.has("object") ||
+    isSchemaRecord(schema.properties) ||
+    schema.additionalProperties === true ||
+    isSchemaRecord(schema.additionalProperties)
   );
+}
+
+function propertySchema(schema: JsonSchemaRecord, segment: PathSegment): JsonSchemaRecord[] {
+  const schemas: JsonSchemaRecord[] = [];
+  for (const alternative of schemaAlternatives(schema)) {
+    if (schemaLooksArray(alternative)) {
+      if (isIndexSegment(segment) && isSchemaRecord(alternative.items)) {
+        schemas.push(alternative.items);
+      }
+      continue;
+    }
+    const properties = isSchemaRecord(alternative.properties)
+      ? (alternative.properties as Record<string, unknown>)
+      : undefined;
+    const explicit = properties?.[segment];
+    if (isSchemaRecord(explicit)) {
+      schemas.push(explicit);
+      continue;
+    }
+    if (isSchemaRecord(alternative.additionalProperties)) {
+      schemas.push(alternative.additionalProperties);
+    }
+  }
+  return schemas;
+}
+
+function schemasAtPath(schema: JsonSchemaRecord | undefined, path: readonly PathSegment[]) {
+  if (!schema) {
+    return [];
+  }
+  let schemas = [schema];
+  for (const segment of path) {
+    schemas = schemas.flatMap((candidate) => propertySchema(candidate, segment));
+    if (schemas.length === 0) {
+      return [];
+    }
+  }
+  return schemas;
+}
+
+function schemaPrefersArrayAtPath(
+  schema: JsonSchemaRecord | undefined,
+  path: readonly PathSegment[],
+): boolean | undefined {
+  const candidates = schemasAtPath(schema, path).flatMap((candidate) =>
+    schemaAlternatives(candidate),
+  );
+  if (candidates.length === 0) {
+    return undefined;
+  }
+  const hasArray = candidates.some((candidate) => schemaLooksArray(candidate));
+  const hasObject = candidates.some((candidate) => schemaLooksObject(candidate));
+  if (hasArray && !hasObject) {
+    return true;
+  }
+  if (hasObject && !hasArray) {
+    return false;
+  }
+  return undefined;
 }
 
 function shouldCreateArrayForMissingPathSegment(params: {
@@ -491,12 +587,9 @@ function shouldCreateArrayForMissingPathSegment(params: {
     return false;
   }
   const parentPath = params.path.slice(0, params.segmentIndex + 1);
-  if (
-    params.options?.numericObjectKeyParentPaths?.some((pattern) =>
-      pathMatchesPattern(parentPath, pattern),
-    )
-  ) {
-    return false;
+  const schemaPreference = schemaPrefersArrayAtPath(params.options?.schema, parentPath);
+  if (schemaPreference !== undefined) {
+    return schemaPreference;
   }
   return true;
 }
@@ -1678,6 +1771,14 @@ function formatAutoManagedMetaError(paths: readonly PathSegment[][]): string {
   ].join("\n");
 }
 
+async function loadConfigMutationSchema(): Promise<JsonSchemaRecord | undefined> {
+  try {
+    return structuredClone((await readBestEffortRuntimeConfigSchema()).schema) as JsonSchemaRecord;
+  } catch {
+    return undefined;
+  }
+}
+
 function collectDryRunSchemaErrors(params: { config: OpenClawConfig }): ConfigSetDryRunError[] {
   const validated = validateConfigObjectRawWithPlugins(params.config);
   if (validated.ok) {
@@ -1768,6 +1869,7 @@ async function runConfigOperations(params: {
   // instead of snapshot.config (runtime-merged with defaults).
   // This prevents runtime defaults from leaking into the written config file (issue #6070)
   const next = structuredClone(snapshot.resolved) as Record<string, unknown>;
+  const mutationSchema = await loadConfigMutationSchema();
   const unsetPaths: PathSegment[][] = [];
   const explicitSetPaths: PathSegment[][] = [];
   for (const operation of operations) {
@@ -1780,7 +1882,7 @@ async function runConfigOperations(params: {
     if (operation.mutation === "merge" || (options.merge && operation.mutation !== "replace")) {
       mergeAtPath(next, operation.setPath, operation.value, {
         numericObjectKeys: params.successMode === "patch",
-        numericObjectKeyParentPaths: CONFIG_SET_NUMERIC_OBJECT_KEY_PARENT_PATHS,
+        schema: mutationSchema,
       });
     } else {
       assertNonDestructiveReplacement({
@@ -1791,7 +1893,7 @@ async function runConfigOperations(params: {
       });
       setAtPath(next, operation.setPath, operation.value, {
         numericObjectKeys: params.successMode === "patch",
-        numericObjectKeyParentPaths: CONFIG_SET_NUMERIC_OBJECT_KEY_PARENT_PATHS,
+        schema: mutationSchema,
       });
     }
   }

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -459,7 +459,47 @@ function getAtPath(root: unknown, path: PathSegment[]): { found: boolean; value?
   return { found: true, value: current };
 }
 
-type SetAtPathOptions = { numericObjectKeys?: boolean };
+type PathPattern = readonly string[];
+
+const CONFIG_SET_NUMERIC_OBJECT_KEY_PARENT_PATHS: readonly PathPattern[] = [
+  ["channels", "discord", "dms"],
+  ["channels", "discord", "guilds"],
+  ["channels", "discord", "guilds", "*", "channels"],
+  ["channels", "discord", "guilds", "*", "toolsBySender"],
+  ["channels", "discord", "guilds", "*", "channels", "*", "toolsBySender"],
+];
+
+type SetAtPathOptions = {
+  numericObjectKeys?: boolean;
+  numericObjectKeyParentPaths?: readonly PathPattern[];
+};
+
+function pathMatchesPattern(path: readonly PathSegment[], pattern: PathPattern): boolean {
+  return (
+    path.length === pattern.length &&
+    path.every((segment, index) => pattern[index] === "*" || pattern[index] === segment)
+  );
+}
+
+function shouldCreateArrayForMissingPathSegment(params: {
+  path: readonly PathSegment[];
+  segmentIndex: number;
+  next?: PathSegment;
+  options?: SetAtPathOptions;
+}): boolean {
+  if (!params.next || params.options?.numericObjectKeys || !isIndexSegment(params.next)) {
+    return false;
+  }
+  const parentPath = params.path.slice(0, params.segmentIndex + 1);
+  if (
+    params.options?.numericObjectKeyParentPaths?.some((pattern) =>
+      pathMatchesPattern(parentPath, pattern),
+    )
+  ) {
+    return false;
+  }
+  return true;
+}
 
 function setAtPath(
   root: Record<string, unknown>,
@@ -471,7 +511,12 @@ function setAtPath(
   for (let i = 0; i < path.length - 1; i += 1) {
     const segment = path[i];
     const next = path[i + 1];
-    const nextIsIndex = !options?.numericObjectKeys && Boolean(next && isIndexSegment(next));
+    const nextIsIndex = shouldCreateArrayForMissingPathSegment({
+      path,
+      segmentIndex: i,
+      next,
+      options,
+    });
     if (Array.isArray(current)) {
       if (!isIndexSegment(segment)) {
         throw new Error(`Expected numeric index for array segment "${segment}"`);
@@ -1425,7 +1470,11 @@ function collectDryRunRefs(params: {
     if (!ref) {
       continue;
     }
-    if (includeAllDiscoveredRefs || targetPaths.has(target.path) || providerAliases.has(ref.provider)) {
+    if (
+      includeAllDiscoveredRefs ||
+      targetPaths.has(target.path) ||
+      providerAliases.has(ref.provider)
+    ) {
       refsByKey.set(secretRefKey(ref), ref);
     }
   }
@@ -1731,6 +1780,7 @@ async function runConfigOperations(params: {
     if (operation.mutation === "merge" || (options.merge && operation.mutation !== "replace")) {
       mergeAtPath(next, operation.setPath, operation.value, {
         numericObjectKeys: params.successMode === "patch",
+        numericObjectKeyParentPaths: CONFIG_SET_NUMERIC_OBJECT_KEY_PARENT_PATHS,
       });
     } else {
       assertNonDestructiveReplacement({
@@ -1741,6 +1791,7 @@ async function runConfigOperations(params: {
       });
       setAtPath(next, operation.setPath, operation.value, {
         numericObjectKeys: params.successMode === "patch",
+        numericObjectKeyParentPaths: CONFIG_SET_NUMERIC_OBJECT_KEY_PARENT_PATHS,
       });
     }
   }

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -488,7 +488,14 @@ function schemaTypes(schema: JsonSchemaRecord): Set<string> {
   return new Set();
 }
 
-function schemaAlternatives(schema: JsonSchemaRecord): JsonSchemaRecord[] {
+function schemaAlternatives(
+  schema: JsonSchemaRecord,
+  seen = new Set<JsonSchemaRecord>(),
+): JsonSchemaRecord[] {
+  if (seen.has(schema)) {
+    return [];
+  }
+  seen.add(schema);
   const alternatives: JsonSchemaRecord[] = [schema];
   for (const key of ["anyOf", "oneOf", "allOf"] as const) {
     const entries = schema[key];
@@ -497,7 +504,7 @@ function schemaAlternatives(schema: JsonSchemaRecord): JsonSchemaRecord[] {
     }
     for (const entry of entries) {
       if (isSchemaRecord(entry)) {
-        alternatives.push(...schemaAlternatives(entry));
+        alternatives.push(...schemaAlternatives(entry, seen));
       }
     }
   }
@@ -505,7 +512,11 @@ function schemaAlternatives(schema: JsonSchemaRecord): JsonSchemaRecord[] {
 }
 
 function schemaLooksArray(schema: JsonSchemaRecord): boolean {
-  return schemaTypes(schema).has("array") || isSchemaRecord(schema.items);
+  return (
+    schemaTypes(schema).has("array") ||
+    isSchemaRecord(schema.items) ||
+    Array.isArray(schema.items)
+  );
 }
 
 function schemaLooksObject(schema: JsonSchemaRecord): boolean {
@@ -522,8 +533,14 @@ function propertySchema(schema: JsonSchemaRecord, segment: PathSegment): JsonSch
   const schemas: JsonSchemaRecord[] = [];
   for (const alternative of schemaAlternatives(schema)) {
     if (schemaLooksArray(alternative)) {
-      if (isIndexSegment(segment) && isSchemaRecord(alternative.items)) {
-        schemas.push(alternative.items);
+      if (isIndexSegment(segment)) {
+        const index = Number.parseInt(segment, 10);
+        const indexedItem = Array.isArray(alternative.items)
+          ? alternative.items[index]
+          : alternative.items;
+        if (isSchemaRecord(indexedItem)) {
+          schemas.push(indexedItem);
+        }
       }
       continue;
     }


### PR DESCRIPTION
Fixes #83331.

Behavior or issue addressed:
- `openclaw config set channels.discord.guilds.<snowflake>.requireMention true` could create `guilds` as an array because the next path segment was all digits.
- Discord guild IDs and other channel IDs are numeric-looking strings for record/object fields, so the path writer now consults the runtime config schema before choosing an object vs array container for missing parents.
- This preserves numeric array-index behavior for schema-backed lists such as `agents.list.0.*`, while keeping schema-backed records such as `channels.discord.guilds.<id>` and `channels.telegram.groups.<id>` as object keys.

## Real behavior proof
Behavior or issue addressed: `config set` now preserves numeric-looking record keys under schema-backed object fields instead of materializing those parents as arrays, while still creating arrays for schema-backed list paths.

Real environment tested: Local OpenClaw checkout on macOS using the real source CLI entrypoint (`node --import tsx src/entry.ts`) with `OPENCLAW_CONFIG_PATH` and `OPENCLAW_STATE_DIR` pointed at a mktemp directory. The command wrote an actual temp `openclaw.json`; no production user config was modified.

Exact steps or command run after this patch:
```console
tmp=$(mktemp -d)
config=$tmp/openclaw.json
printf '{"channels":{"discord":{"enabled":true}},"agents":{}}\n' > "$config"
export PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH
export OPENCLAW_CONFIG_PATH="$config"
export OPENCLAW_STATE_DIR="$tmp/state"
echo "OPENCLAW_CONFIG_PATH=$OPENCLAW_CONFIG_PATH"
node --import tsx src/entry.ts config set channels.discord.guilds.1495587801394184362.requireMention true --strict-json
node --import tsx src/entry.ts config set channels.telegram.groups.1495587801394184362.requireMention true --strict-json
node --import tsx src/entry.ts config set agents.list.0.id '"tech"' --strict-json
python3 - <<'PY' "$config" "$tmp"
import json,sys
cfg=json.load(open(sys.argv[1]))
dguilds=cfg['channels']['discord']['guilds']
tgroups=cfg['channels']['telegram']['groups']
print('config_path=', sys.argv[1])
print('config_under_mktemp=', sys.argv[1].startswith(sys.argv[2]+'/'))
print('discord_guilds_is_array=', isinstance(dguilds, list))
print('discord_guild_keys=', list(dguilds.keys()))
print('discord_requireMention=', dguilds['1495587801394184362']['requireMention'])
print('telegram_groups_is_array=', isinstance(tgroups, list))
print('telegram_group_keys=', list(tgroups.keys()))
print('telegram_requireMention=', tgroups['1495587801394184362']['requireMention'])
print('agents_list_is_array=', isinstance(cfg['agents']['list'], list))
print('agents_list=', cfg['agents']['list'])
PY
```

Evidence after fix:
```console
OPENCLAW_CONFIG_PATH=/var/folders/65/9nwck85148n01vx6sgp1mn3w0000gn/T/tmp.fJnfT3x1ed/openclaw.json
Updated channels.discord.guilds.1495587801394184362.requireMention. Restart the gateway to apply.
Updated channels.telegram.groups.1495587801394184362.requireMention. Restart the gateway to apply.
Updated agents.list.0.id. Restart the gateway to apply.
config_path= /var/folders/65/9nwck85148n01vx6sgp1mn3w0000gn/T/tmp.fJnfT3x1ed/openclaw.json
config_under_mktemp= True
discord_guilds_is_array= False
discord_guild_keys= ['1495587801394184362']
discord_requireMention= True
telegram_groups_is_array= False
telegram_group_keys= ['1495587801394184362']
telegram_requireMention= True
agents_list_is_array= True
agents_list= [{'id': 'tech'}]
Config write anomaly: /var/folders/65/9nwck85148n01vx6sgp1mn3w0000gn/T/tmp.fJnfT3x1ed/openclaw.json (missing-meta-before-write)
```

Observed result after fix:
- Real CLI writes against a mktemp config kept `channels.discord.guilds.1495587801394184362` as an object key (`discord_guilds_is_array=False`).
- The same schema-backed logic also kept `channels.telegram.groups.1495587801394184362` as an object key (`telegram_groups_is_array=False`).
- A schema-backed list path still created an array for `agents.list.0.id` (`agents_list_is_array=True`, `agents_list=[{'id': 'tech'}]`).

What was not tested: A globally installed packaged `openclaw` binary. The patched source CLI entrypoint was tested with a real temp config file, and the normal test harness covers the same mutation path without touching user config.

## Validation
Focused regression:
```console
PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node scripts/run-vitest.mjs src/cli/config-cli.test.ts -t "numeric config set path segments|schema-backed numeric list indexes"

Test Files  1 passed (1)
Tests  3 passed | 95 skipped (98)
```

Full validation:
```console
PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH pnpm tsgo:test:src
PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node scripts/run-vitest.mjs src/cli/config-cli.test.ts
PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node_modules/.bin/oxfmt --check --threads=1 src/cli/config-cli.ts src/cli/config-cli.test.ts
PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node_modules/.bin/oxlint src/cli/config-cli.ts src/cli/config-cli.test.ts
git diff --check

Test Files  1 passed (1)
Tests  98 passed (98)
All matched files use the correct format.
Found 0 warnings and 0 errors.
```

Commit author verification:
```console
b46046b8e6 Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com> fix(cli): use schema for numeric config path containers
6fb04b8643 Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com> fix(cli): preserve numeric config set record keys
```
