### PR TITLE
fix(telegram): preserve fenced code languages

### DIFF
--- a/extensions/telegram/src/format.test.ts
+++ b/extensions/telegram/src/format.test.ts
@@ -96,9 +96,9 @@ describe("markdownToTelegramHtml", () => {
     expect(res.match(/<blockquote>/g)).toHaveLength(2);
   });
 
-  it("renders fenced code blocks", () => {
+  it("renders fenced code language for Telegram pre/code", () => {
     const res = markdownToTelegramHtml("```js\nconst x = 1;\n```");
-    expect(res).toBe("<pre><code>const x = 1;\n</code></pre>");
+    expect(res).toBe('<pre><code class="language-js">const x = 1;\n</code></pre>');
   });
 
   it("properly nests overlapping bold and autolink (#4071)", () => {

--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -6,6 +6,7 @@ import {
   markdownToIR,
   type MarkdownLinkSpan,
   type MarkdownIR,
+  type MarkdownStyleSpan,
   renderMarkdownIRChunksWithinLimit,
 } from "openclaw/plugin-sdk/text-chunking";
 import { renderMarkdownWithMarkers } from "openclaw/plugin-sdk/text-chunking";
@@ -25,6 +26,14 @@ function escapeHtml(text: string): string {
 
 function escapeHtmlAttr(text: string): string {
   return escapeHtml(text).replace(/"/g, "&quot;");
+}
+
+function buildTelegramCodeBlockOpen(span: MarkdownStyleSpan): string {
+  const language = span.language?.trim();
+  if (!language) {
+    return "<pre><code>";
+  }
+  return `<pre><code class="language-${escapeHtmlAttr(language)}">`;
 }
 
 /**
@@ -67,7 +76,7 @@ function renderTelegramHtml(ir: MarkdownIR): string {
       italic: { open: "<i>", close: "</i>" },
       strikethrough: { open: "<s>", close: "</s>" },
       code: { open: "<code>", close: "</code>" },
-      code_block: { open: "<pre><code>", close: "</code></pre>" },
+      code_block: { open: buildTelegramCodeBlockOpen, close: "</code></pre>" },
       spoiler: { open: "<tg-spoiler>", close: "</tg-spoiler>" },
       blockquote: { open: "<blockquote>", close: "</blockquote>" },
     },
@@ -180,13 +189,13 @@ const TELEGRAM_SIMPLE_HTML_TAGS = new Set([
   "s",
   "strike",
   "del",
-  "code",
   "pre",
   "tg-spoiler",
   "blockquote",
 ]);
 const TELEGRAM_ATTR_HTML_TAG_PATTERNS = new Map([
   ["a", /^\s+href="[^"]+"\s*$/],
+  ["code", /^(?:\s+class="language-[^"]+")?\s*$/],
   ["span", /^\s+class="tg-spoiler"\s*$/],
   ["tg-emoji", /^\s+emoji-id="[^"]+"\s*$/],
   ["tg-time", /^\s+datetime="[^"]+"\s*$/],

--- a/src/markdown/ir.ts
+++ b/src/markdown/ir.ts
@@ -20,6 +20,7 @@ type RenderEnv = {
 type MarkdownToken = {
   type: string;
   content?: string;
+  info?: string;
   children?: MarkdownToken[];
   attrs?: [string, string][];
   attrGet?: (name: string) => string | null;
@@ -40,6 +41,7 @@ export type MarkdownStyleSpan = {
   start: number;
   end: number;
   style: MarkdownStyle;
+  language?: string;
 };
 
 export type MarkdownLinkSpan = {
@@ -53,6 +55,10 @@ export type MarkdownIR = {
   styles: MarkdownStyleSpan[];
   links: MarkdownLinkSpan[];
 };
+
+function copyStyleSpanMetadata(span: MarkdownStyleSpan): Pick<MarkdownStyleSpan, "language"> {
+  return span.language === undefined ? {} : { language: span.language };
+}
 
 export type MarkdownTableData = {
   headers: string[];
@@ -325,7 +331,12 @@ function renderInlineCode(state: RenderState, content: string) {
   target.styles.push({ start, end: start + content.length, style: "code" });
 }
 
-function renderCodeBlock(state: RenderState, content: string) {
+function normalizeCodeBlockLanguage(info: string | undefined): string | undefined {
+  const language = info?.trim().split(/\s+/, 1)[0]?.trim();
+  return language ? language : undefined;
+}
+
+function renderCodeBlock(state: RenderState, content: string, info?: string) {
   let code = content ?? "";
   if (!code.endsWith("\n")) {
     code = `${code}\n`;
@@ -333,7 +344,13 @@ function renderCodeBlock(state: RenderState, content: string) {
   const target = resolveRenderTarget(state);
   const start = target.text.length;
   target.text += code;
-  target.styles.push({ start, end: start + code.length, style: "code_block" });
+  const language = normalizeCodeBlockLanguage(info);
+  target.styles.push({
+    start,
+    end: start + code.length,
+    style: "code_block",
+    ...(language === undefined ? {} : { language }),
+  });
   if (state.env.listStack.length === 0) {
     target.text += "\n";
   }
@@ -397,7 +414,12 @@ function trimCell(cell: TableCell): TableCell {
     const sliceStart = Math.max(0, span.start - start);
     const sliceEnd = Math.min(trimmedLength, span.end - start);
     if (sliceEnd > sliceStart) {
-      trimmedStyles.push({ start: sliceStart, end: sliceEnd, style: span.style });
+      trimmedStyles.push({
+        start: sliceStart,
+        end: sliceEnd,
+        style: span.style,
+        ...copyStyleSpanMetadata(span),
+      });
     }
   }
   const trimmedLinks: MarkdownLinkSpan[] = [];
@@ -422,6 +444,7 @@ function appendCell(state: RenderState, cell: TableCell) {
       start: start + span.start,
       end: start + span.end,
       style: span.style,
+      ...copyStyleSpanMetadata(span),
     });
   }
   for (const link of cell.links) {
@@ -732,7 +755,7 @@ function renderTokens(tokens: MarkdownToken[], state: RenderState): void {
         break;
       case "code_block":
       case "fence":
-        renderCodeBlock(state, token.content ?? "");
+        renderCodeBlock(state, token.content ?? "", token.info);
         break;
       case "html_block":
       case "html_inline":
@@ -834,7 +857,7 @@ function clampStyleSpans(spans: MarkdownStyleSpan[], maxLength: number): Markdow
     const start = Math.max(0, Math.min(span.start, maxLength));
     const end = Math.max(start, Math.min(span.end, maxLength));
     if (end > start) {
-      clamped.push({ start, end, style: span.style });
+      clamped.push({ start, end, style: span.style, ...copyStyleSpanMetadata(span) });
     }
   }
   return clamped;
@@ -869,6 +892,7 @@ function mergeStyleSpans(spans: MarkdownStyleSpan[]): MarkdownStyleSpan[] {
     if (
       prev &&
       prev.style === span.style &&
+      prev.language === span.language &&
       // Blockquotes are container blocks. Adjacent blockquote spans should not merge or
       // consecutive blockquotes can "style bleed" across the paragraph boundary.
       (span.start < prev.end || (span.start === prev.end && span.style !== "blockquote"))
@@ -912,6 +936,7 @@ function sliceStyleSpans(
       start: bounds.start - start,
       end: bounds.end - start,
       style: span.style,
+      ...copyStyleSpanMetadata(span),
     });
   }
   return mergeStyleSpans(sliced);

--- a/src/markdown/render.ts
+++ b/src/markdown/render.ts
@@ -1,7 +1,7 @@
 import type { MarkdownIR, MarkdownLinkSpan, MarkdownStyle, MarkdownStyleSpan } from "./ir.js";
 
 export type RenderStyleMarker = {
-  open: string;
+  open: string | ((span: MarkdownStyleSpan) => string);
   close: string;
 };
 
@@ -44,6 +44,10 @@ function sortStyleSpans(spans: MarkdownStyleSpan[]): MarkdownStyleSpan[] {
     }
     return (STYLE_RANK.get(a.style) ?? 0) - (STYLE_RANK.get(b.style) ?? 0);
   });
+}
+
+function renderStyleMarkerOpen(marker: RenderStyleMarker, span: MarkdownStyleSpan): string {
+  return typeof marker.open === "function" ? marker.open(span) : marker.open;
 }
 
 export function renderMarkdownWithMarkers(ir: MarkdownIR, options: RenderOptions): string {
@@ -153,7 +157,7 @@ export function renderMarkdownWithMarkers(ir: MarkdownIR, options: RenderOptions
         }
         openingItems.push({
           end: span.end,
-          open: marker.open,
+          open: renderStyleMarkerOpen(marker, span),
           close: marker.close,
           kind: "style",
           style: span.style,


### PR DESCRIPTION
## Summary
- Preserve fenced code block language info in the markdown IR.
- Allow render markers to derive opening tags from style spans.
- Emit Telegram `<pre><code class="language-X">` blocks while keeping unlabeled fences unchanged.

## Tests
- `node --import tsx -e 'import { markdownToTelegramHtml } from "./extensions/telegram/src/format.ts"; console.log(markdownToTelegramHtml("```js\nconst x = 1;\n```"));'`
- `node --import tsx -e 'import { markdownToTelegramHtml } from "./extensions/telegram/src/format.ts"; console.log(JSON.stringify(markdownToTelegramHtml("```\nplain\n```"))); console.log(JSON.stringify(markdownToTelegramHtml("```js title\nplain\n```")));'`
- `node scripts/run-vitest.mjs extensions/telegram/src/format.test.ts --reporter=verbose`
- `node scripts/run-vitest.mjs src/markdown/render-aware-chunking.test.ts src/markdown/ir.table-code.test.ts extensions/telegram/src/format.test.ts --reporter=verbose`
- `node scripts/run-oxlint.mjs src/markdown/ir.ts src/markdown/render.ts extensions/telegram/src/format.ts extensions/telegram/src/format.test.ts`
- `node_modules/.bin/oxfmt --check --threads=1 src/markdown/ir.ts src/markdown/render.ts extensions/telegram/src/format.ts extensions/telegram/src/format.test.ts`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo && node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo`
- `git diff --check`

## Real behavior proof
Behavior addressed: Telegram markdown rendering now emits `class="language-js"` for a ` ```js ` fenced code block and leaves unlabeled fences as `<pre><code>`.
Real environment tested: Local macOS checkout with Node/tsx and repo-local test/type/lint tools.
Exact steps or command run after this patch: See Tests section above.
Evidence after fix: Direct `markdownToTelegramHtml` probe printed `<pre><code class="language-js">const x = 1;\n</code></pre>`; unlabeled fence probe printed `<pre><code>plain\n</code></pre>`.
Observed result after fix: Targeted tests, lint, format check, type checks, and whitespace check passed where completed.
What was not tested: Live Telegram Bot API rendering/UI copy button behavior was not exercised.

Fixes #10519
