### PR TITLE
test(release): guard Discord delivery origin packaging

### DIFF
--- a/scripts/check-openclaw-package-tarball.mjs
+++ b/scripts/check-openclaw-package-tarball.mjs
@@ -82,7 +82,15 @@ const REQUIRED_TARBALL_ENTRIES = ["dist/control-ui/index.html"];
 const REQUIRED_TARBALL_ENTRY_PREFIXES = ["dist/control-ui/assets/"];
 const LEGACY_PACKAGE_ACCEPTANCE_COMPAT_MAX = { year: 2026, month: 4, day: 25 };
 const LEGACY_LOCAL_BUILD_METADATA_COMPAT_MAX = { year: 2026, month: 4, day: 26 };
+const DISCORD_SUBAGENT_DELIVERY_ORIGIN_MIN_VERSION = { year: 2026, month: 5, day: 18 };
 const FORBIDDEN_LOCAL_BUILD_METADATA_FILES = new Set(LOCAL_BUILD_METADATA_DIST_PATHS);
+const DISCORD_SUBAGENT_HOOK_SOURCE_MARKER = "//#region extensions/discord/src/subagent-hooks.ts";
+const DISCORD_SUBAGENT_DELIVERY_ORIGIN_MARKERS = [
+  "threadBindingReady: true",
+  "deliveryOrigin",
+  "to: `channel:${binding.threadId}`",
+  "threadId: binding.threadId",
+];
 
 const LEGACY_OMITTED_PRIVATE_QA_INVENTORY_PREFIXES = [
   "dist/extensions/qa-channel/",
@@ -144,6 +152,11 @@ function isLegacyLocalBuildMetadataCompatVersion(version) {
   return parsed ? compareCalver(parsed, LEGACY_LOCAL_BUILD_METADATA_COMPAT_MAX) <= 0 : false;
 }
 
+function isDiscordSubagentDeliveryOriginRequiredVersion(version) {
+  const parsed = parseCalver(version);
+  return parsed ? compareCalver(parsed, DISCORD_SUBAGENT_DELIVERY_ORIGIN_MIN_VERSION) >= 0 : false;
+}
+
 function readTarEntry(entryPath) {
   const candidates = [
     path.join(extractDir, entryPath),
@@ -155,6 +168,36 @@ function readTarEntry(entryPath) {
     }
   }
   return "";
+}
+
+function collectPackagedDiscordSubagentDeliveryOriginErrors() {
+  if (!isDiscordSubagentDeliveryOriginRequiredVersion(packageVersion)) {
+    return [];
+  }
+
+  const discordSubagentHookFiles = normalized.filter((entry) => {
+    if (!entry.startsWith("dist/") || !entry.endsWith(".js")) {
+      return false;
+    }
+    return readTarEntry(entry).includes(DISCORD_SUBAGENT_HOOK_SOURCE_MARKER);
+  });
+  if (discordSubagentHookFiles.length === 0) {
+    return [
+      "packaged dist is missing the compiled Discord subagent hook; expected source marker extensions/discord/src/subagent-hooks.ts.",
+    ];
+  }
+
+  const hasDeliveryOriginContract = discordSubagentHookFiles.some((entry) => {
+    const source = readTarEntry(entry);
+    return DISCORD_SUBAGENT_DELIVERY_ORIGIN_MARKERS.every((marker) => source.includes(marker));
+  });
+  if (hasDeliveryOriginContract) {
+    return [];
+  }
+
+  return [
+    `packaged Discord subagent hook omits deliveryOrigin for bound thread spawns; rebuild dist so ${discordSubagentHookFiles.join(", ")} returns the bound thread delivery origin.`,
+  ];
 }
 
 for (const entry of normalized) {
@@ -260,6 +303,7 @@ errors.push(
     imports: packageDistImports ?? undefined,
   }),
 );
+errors.push(...collectPackagedDiscordSubagentDeliveryOriginErrors());
 
 if (errors.length > 0) {
   fs.rmSync(extractDir, { recursive: true, force: true });

--- a/scripts/openclaw-npm-postpublish-verify.ts
+++ b/scripts/openclaw-npm-postpublish-verify.ts
@@ -53,6 +53,14 @@ const MAX_INSTALLED_ROOT_PACKAGE_JSON_BYTES = 1024 * 1024;
 const MAX_INSTALLED_ROOT_DIST_JS_BYTES = 6 * 1024 * 1024;
 const MAX_INSTALLED_ROOT_DIST_JS_FILES = 5000;
 const ROOT_DIST_JAVASCRIPT_MODULE_FILE_RE = /\.(?:c|m)?js$/u;
+const DISCORD_SUBAGENT_HOOK_SOURCE_MARKER = "//#region extensions/discord/src/subagent-hooks.ts";
+const DISCORD_SUBAGENT_DELIVERY_ORIGIN_MARKERS = [
+  "threadBindingReady: true",
+  "deliveryOrigin",
+  "to: `channel:${binding.threadId}`",
+  "threadId: binding.threadId",
+];
+const DISCORD_SUBAGENT_DELIVERY_ORIGIN_MIN_VERSION = { year: 2026, month: 5, day: 18 };
 const OPTIONAL_OR_EXTERNALIZED_RUNTIME_IMPORTS = new Set([
   // Optional A2UI markdown renderer. The Canvas host bundle catches the missing
   // package and falls back when the optional renderer is unavailable.
@@ -131,8 +139,44 @@ export function collectInstalledPackageErrors(params: {
   errors.push(...collectInstalledContextEngineRuntimeErrors(params.packageRoot));
   errors.push(...collectInstalledPluginSdkZodArtifactErrors(params.packageRoot));
   errors.push(...collectInstalledRootDependencyManifestErrors(params.packageRoot));
+  if (shouldVerifyDiscordSubagentDeliveryOrigin(params.expectedVersion)) {
+    errors.push(...collectInstalledDiscordSubagentDeliveryOriginErrors(params.packageRoot));
+  }
 
   return errors;
+}
+
+function parseCalverForVerification(
+  version: string,
+): { year: number; month: number; day: number } | null {
+  const match = /^(\d{4})\.(\d{1,2})\.(\d{1,2})(?:[-+].*)?$/u.exec(version);
+  if (!match) {
+    return null;
+  }
+  return {
+    year: Number(match[1]),
+    month: Number(match[2]),
+    day: Number(match[3]),
+  };
+}
+
+function compareCalverForVerification(
+  left: { year: number; month: number; day: number },
+  right: { year: number; month: number; day: number },
+): number {
+  for (const key of ["year", "month", "day"] as const) {
+    if (left[key] !== right[key]) {
+      return left[key] - right[key];
+    }
+  }
+  return 0;
+}
+
+function shouldVerifyDiscordSubagentDeliveryOrigin(version: string): boolean {
+  const parsed = parseCalverForVerification(version);
+  return parsed
+    ? compareCalverForVerification(parsed, DISCORD_SUBAGENT_DELIVERY_ORIGIN_MIN_VERSION) >= 0
+    : false;
 }
 
 function collectInstalledBundledExtensionIds(packageRoot: string): Set<string> {
@@ -213,6 +257,43 @@ export function collectInstalledContextEngineRuntimeErrors(packageRoot: string):
     }
   }
   return errors;
+}
+
+export function collectInstalledDiscordSubagentDeliveryOriginErrors(packageRoot: string): string[] {
+  const distRoot = join(packageRoot, "dist");
+  const discordSubagentHookFiles: string[] = [];
+
+  for (const filePath of listDistJavaScriptFiles(packageRoot)) {
+    const fileStat = lstatSync(filePath);
+    if (!fileStat.isFile() || fileStat.size > MAX_INSTALLED_ROOT_DIST_JS_BYTES) {
+      continue;
+    }
+    const source = readFileSync(filePath, "utf8");
+    if (source.includes(DISCORD_SUBAGENT_HOOK_SOURCE_MARKER)) {
+      discordSubagentHookFiles.push(filePath);
+    }
+  }
+
+  if (discordSubagentHookFiles.length === 0) {
+    return [
+      "installed package is missing the compiled Discord subagent hook; expected source marker extensions/discord/src/subagent-hooks.ts.",
+    ];
+  }
+
+  const hasDeliveryOriginContract = discordSubagentHookFiles.some((filePath) => {
+    const source = readFileSync(filePath, "utf8");
+    return DISCORD_SUBAGENT_DELIVERY_ORIGIN_MARKERS.every((marker) => source.includes(marker));
+  });
+  if (hasDeliveryOriginContract) {
+    return [];
+  }
+
+  const relativeFiles = discordSubagentHookFiles
+    .map((filePath) => relative(distRoot, filePath).replaceAll("\\", "/"))
+    .toSorted((left, right) => left.localeCompare(right));
+  return [
+    `installed package Discord subagent hook omits deliveryOrigin for bound thread spawns; rebuild dist so ${relativeFiles.join(", ")} returns the bound thread delivery origin.`,
+  ];
 }
 
 function resolveInstalledDistRelativeImport(params: {

--- a/test/openclaw-npm-postpublish-verify.test.ts
+++ b/test/openclaw-npm-postpublish-verify.test.ts
@@ -7,6 +7,7 @@ import {
   buildPublishedInstallScenarios,
   collectInstalledBundledRuntimeSidecarPaths,
   collectInstalledContextEngineRuntimeErrors,
+  collectInstalledDiscordSubagentDeliveryOriginErrors,
   collectInstalledPluginSdkZodArtifactErrors,
   collectInstalledRootDependencyManifestErrors,
   collectInstalledPackageErrors,
@@ -141,6 +142,69 @@ describe("collectInstalledContextEngineRuntimeErrors", () => {
       );
 
       expect(collectInstalledContextEngineRuntimeErrors(packageRoot)).toStrictEqual([]);
+    } finally {
+      rmSync(packageRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("collectInstalledDiscordSubagentDeliveryOriginErrors", () => {
+  function makeInstalledPackageRoot(): string {
+    return mkdtempSync(join(tmpdir(), "openclaw-postpublish-discord-hook-"));
+  }
+
+  function writeInstalledFile(packageRoot: string, relativePath: string, contents: string): void {
+    const filePath = join(packageRoot, ...relativePath.split("/"));
+    mkdirSync(dirname(filePath), { recursive: true });
+    writeFileSync(filePath, contents, "utf8");
+  }
+
+  it("rejects installed packages whose Discord subagent hook lacks deliveryOrigin", () => {
+    const packageRoot = makeInstalledPackageRoot();
+
+    try {
+      writeInstalledFile(
+        packageRoot,
+        "dist/subagent-hooks-OLD.js",
+        `//#region extensions/discord/src/subagent-hooks.ts
+async function handleDiscordSubagentSpawning() {
+  return { status: "ok", threadBindingReady: true };
+}
+`,
+      );
+
+      expect(collectInstalledDiscordSubagentDeliveryOriginErrors(packageRoot)).toEqual([
+        "installed package Discord subagent hook omits deliveryOrigin for bound thread spawns; rebuild dist so subagent-hooks-OLD.js returns the bound thread delivery origin.",
+      ]);
+    } finally {
+      rmSync(packageRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts installed packages whose Discord subagent hook returns deliveryOrigin", () => {
+    const packageRoot = makeInstalledPackageRoot();
+
+    try {
+      writeInstalledFile(
+        packageRoot,
+        "dist/subagent-hooks-CURRENT.js",
+        `//#region extensions/discord/src/subagent-hooks.ts
+async function handleDiscordSubagentSpawning() {
+  return {
+    status: "ok",
+    threadBindingReady: true,
+    deliveryOrigin: {
+      channel: "discord",
+      accountId: account.accountId,
+      to: \`channel:\${binding.threadId}\`,
+      threadId: binding.threadId,
+    },
+  };
+}
+`,
+      );
+
+      expect(collectInstalledDiscordSubagentDeliveryOriginErrors(packageRoot)).toStrictEqual([]);
     } finally {
       rmSync(packageRoot, { recursive: true, force: true });
     }

--- a/test/scripts/check-openclaw-package-tarball.test.ts
+++ b/test/scripts/check-openclaw-package-tarball.test.ts
@@ -208,4 +208,55 @@ describe("check-openclaw-package-tarball", () => {
       "2026.4.26",
     );
   });
+
+  it("rejects packaged Discord subagent hooks without deliveryOrigin", () => {
+    withTarball(
+      ["dist/subagent-hooks-OLD.js"],
+      {
+        "dist/subagent-hooks-OLD.js": `//#region extensions/discord/src/subagent-hooks.ts
+async function handleDiscordSubagentSpawning() {
+  return { status: "ok", threadBindingReady: true };
+}
+`,
+      },
+      (tarball) => {
+        const result = spawnSync("node", [CHECK_SCRIPT, tarball], { encoding: "utf8" });
+
+        expect(result.status).not.toBe(0);
+        expect(result.stderr).toContain(
+          "packaged Discord subagent hook omits deliveryOrigin for bound thread spawns",
+        );
+      },
+      "2026.5.18",
+    );
+  });
+
+  it("accepts packaged Discord subagent hooks with bound thread deliveryOrigin", () => {
+    withTarball(
+      ["dist/subagent-hooks-CURRENT.js"],
+      {
+        "dist/subagent-hooks-CURRENT.js": `//#region extensions/discord/src/subagent-hooks.ts
+async function handleDiscordSubagentSpawning() {
+  return {
+    status: "ok",
+    threadBindingReady: true,
+    deliveryOrigin: {
+      channel: "discord",
+      accountId: account.accountId,
+      to: \`channel:\${binding.threadId}\`,
+      threadId: binding.threadId,
+    },
+  };
+}
+`,
+      },
+      (tarball) => {
+        const result = spawnSync("node", [CHECK_SCRIPT, tarball], { encoding: "utf8" });
+
+        expect(result.status, result.stderr).toBe(0);
+        expect(result.stdout).toContain("OpenClaw package tarball integrity passed.");
+      },
+      "2026.5.18",
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- Problem: source `main` includes the Discord `deliveryOrigin` fix from #83172, but the published `openclaw@2026.5.18` package can still ship a stale compiled Discord hook without that return contract.
- What changed: package tarball integrity and npm post-publish verification now reject 2026.5.18-or-newer packages whose compiled Discord subagent hook omits the bound-thread `deliveryOrigin` return.
- Scope boundary: no runtime behavior change to the Discord hook itself; this is a release/package guard for the already-merged source fix.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #83772
- Related #83170
- Related #83172
- [x] This PR fixes a bug or regression

## Root Cause

The Discord source hook was fixed in #83172, but release/package verification did not assert that the compiled package artifact actually contained the `deliveryOrigin` contract. A clean install of `openclaw@2026.5.18` could therefore pass verification while still carrying the old compiled hook.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Release/package verification test
  - [ ] End-to-end test
- Target files:
  - `scripts/check-openclaw-package-tarball.mjs`
  - `scripts/openclaw-npm-postpublish-verify.ts`
- Scenario locked in: for 2026.5.18-or-newer packages, the compiled Discord subagent hook must include `threadBindingReady: true`, `deliveryOrigin`, `to: \`channel:${binding.threadId}\``, and `threadId: binding.threadId`.

## User-visible / Behavior Changes

No direct runtime behavior change. The package/release pipeline will now fail stale package artifacts that would preserve the Discord initial child-delivery bug after a clean install.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Real behavior proof

- Behavior or issue addressed: The release/package verification must catch stale compiled Discord package bytes that omit `deliveryOrigin` for bound thread child spawns, the failure mode seen in the published `openclaw@2026.5.18` package.
- Real environment tested: Local macOS OpenClaw checkout on PR head `bd35247a`, Node/npm/pnpm, the real published `openclaw@2026.5.18` package from npm, and a freshly built package artifact from this checkout.
- Exact steps or command run after this patch: Ran the patched tarball verifier against the real stale published tarball, ran the patched postpublish verifier against a real stale published install, built fresh current package bytes with `pnpm build`, `pnpm ui:build`, inventory write, and `npm pack`, then ran the patched tarball verifier against both the freshly built current artifact and a version-adjusted `2026.5.18` copy of that artifact.
- Evidence after fix: Terminal transcript / copied live output from the patched verifier:

```text
$ node scripts/check-openclaw-package-tarball.mjs .artifacts/pr83774-proof/openclaw-2026.5.18.tgz
OpenClaw package tarball integrity failed:
packaged Discord subagent hook omits deliveryOrigin for bound thread spawns; rebuild dist so dist/subagent-hooks-BVCiy5nf.js returns the bound thread delivery origin.

$ node --import tsx scripts/openclaw-npm-postpublish-verify.ts 2026.5.18
openclaw-npm-postpublish-verify: fresh-exact failed:
- installed package Discord subagent hook omits deliveryOrigin for bound thread spawns; rebuild dist so subagent-hooks-BVCiy5nf.js returns the bound thread delivery origin.

$ node scripts/check-openclaw-package-tarball.mjs .artifacts/pr83774-proof/openclaw-2026.5.17.tgz
OpenClaw package tarball integrity passed.

$ node scripts/check-openclaw-package-tarball.mjs .artifacts/pr83774-proof/openclaw-current-built-versioned-2026.5.18.tgz
OpenClaw package tarball integrity passed.
```
- Observed result after fix: The patched guard rejects the real stale `openclaw@2026.5.18` tarball/install and accepts freshly built current package bytes, including the version-adjusted `2026.5.18` artifact that exercises the new guard threshold.
- What was not tested: No full npm publish was performed; this proof covers the package tarball and postpublish verification surfaces changed by this PR.

## Repro + Verification

### Observed stale package

A clean global install of `openclaw@2026.5.18` exposed a compiled Discord hook that returned only `threadBindingReady: true` from `subagent_spawning` and omitted `deliveryOrigin`, despite #83172 being merged in source.

### Real package artifact proof

The local npm config has a `before` date, so the stale published-package proof explicitly used `npm_config_before=` and `npm_config_min_release_age=0` to allow resolving the real `openclaw@2026.5.18` package.

#### Patched tarball verifier rejects the real stale published tarball

```bash
env npm_config_before= npm_config_min_release_age=0 npm pack openclaw@2026.5.18 --pack-destination .artifacts/pr83774-proof
node scripts/check-openclaw-package-tarball.mjs .artifacts/pr83774-proof/openclaw-2026.5.18.tgz
```

Result: expected failure, status `1`.

```text
OpenClaw package tarball integrity failed:
packaged Discord subagent hook omits deliveryOrigin for bound thread spawns; rebuild dist so dist/subagent-hooks-BVCiy5nf.js returns the bound thread delivery origin.
```

#### Patched postpublish verifier rejects the real stale published install

```bash
env npm_config_before= npm_config_min_release_age=0 node --import tsx scripts/openclaw-npm-postpublish-verify.ts 2026.5.18
```

Result: expected failure, status `1`.

```text
openclaw-npm-postpublish-verify: fresh-exact failed:
- installed package Discord subagent hook omits deliveryOrigin for bound thread spawns; rebuild dist so subagent-hooks-BVCiy5nf.js returns the bound thread delivery origin.
```

#### Patched tarball verifier accepts freshly built current package bytes

```bash
pnpm build
pnpm ui:build
node --import tsx -e 'import { writePackageDistInventory } from "./src/infra/package-dist-inventory.ts"; await writePackageDistInventory(process.cwd()); console.log("inventory_written_after_ui")'
npm pack --ignore-scripts --json --pack-destination .artifacts/pr83774-proof
node scripts/check-openclaw-package-tarball.mjs .artifacts/pr83774-proof/openclaw-2026.5.17.tgz
```

Result: pass, status `0`.

```text
OpenClaw package tarball integrity passed.
```

I also re-packed the same freshly built current artifact with only `package/package.json` version changed to `2026.5.18`, so the new guard threshold is exercised against current compiled bytes instead of skipped by the repo's current `2026.5.17` package version.

```bash
node scripts/check-openclaw-package-tarball.mjs .artifacts/pr83774-proof/openclaw-current-built-versioned-2026.5.18.tgz
```

Result: pass, status `0`.

```text
OpenClaw package tarball integrity passed.
```

Current compiled Discord hook proof from the fresh build:

```text
dist/subagent-hooks-BV-t44NS.js:7://#region extensions/discord/src/subagent-hooks.ts
dist/subagent-hooks-BV-t44NS.js:65:      threadBindingReady: true,
dist/subagent-hooks-BV-t44NS.js:66:      deliveryOrigin: {
dist/subagent-hooks-BV-t44NS.js:69:        to: `channel:${binding.threadId}`,
dist/subagent-hooks-BV-t44NS.js:70:        threadId: binding.threadId
```

### Unit and hygiene checks

```bash
pnpm test test/scripts/check-openclaw-package-tarball.test.ts test/openclaw-npm-postpublish-verify.test.ts
git diff --check
```

Result:

- `test/scripts/check-openclaw-package-tarball.test.ts` and `test/openclaw-npm-postpublish-verify.test.ts`: 35 tests passed.
- `git diff --check`: clean.