### PR TITLE
plugins: Allow trusted plugin keyed state

### DIFF
--- a/src/plugin-state/plugin-state-store.runtime.test.ts
+++ b/src/plugin-state/plugin-state-store.runtime.test.ts
@@ -6,12 +6,17 @@ import type { PluginRuntime } from "../plugins/runtime/types.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { resetPluginStateStoreForTests } from "./plugin-state-store.js";
 
-function createPluginRecord(id: string, origin: PluginRecord["origin"] = "bundled"): PluginRecord {
+function createPluginRecord(
+  id: string,
+  origin: PluginRecord["origin"] = "bundled",
+  opts: { trustedOfficialInstall?: boolean } = {},
+): PluginRecord {
   return {
     id,
     name: id,
     source: `/plugins/${id}/index.ts`,
     origin,
+    trustedOfficialInstall: opts.trustedOfficialInstall,
     enabled: true,
     status: "loaded",
     toolNames: [],
@@ -87,6 +92,22 @@ describe("plugin runtime state proxy", () => {
     });
   });
 
+  it("allows trusted official global plugins to use keyed state", async () => {
+    await withOpenClawTestState({ label: "plugin-state-trusted-global" }, async () => {
+      const registry = createTestPluginRegistry();
+      const record = createPluginRecord("slack", "global", { trustedOfficialInstall: true });
+      registry.registry.plugins.push(record);
+      const api = registry.createApi(record, { config: {} });
+
+      const store = api.runtime.state.openKeyedStore<{ plugin: string }>({
+        namespace: "runtime",
+        maxEntries: 10,
+      });
+      await expect(store.register("thread", { plugin: "slack" })).resolves.toBeUndefined();
+      await expect(store.lookup("thread")).resolves.toEqual({ plugin: "slack" });
+    });
+  });
+
   it("rejects external plugins in this release", () => {
     const registry = createTestPluginRegistry();
     const record = createPluginRecord("external-plugin", "workspace");
@@ -95,6 +116,17 @@ describe("plugin runtime state proxy", () => {
 
     expect(() =>
       api.runtime.state.openKeyedStore({ namespace: "runtime", maxEntries: 10 }),
-    ).toThrow("openKeyedStore is only available for bundled plugins");
+    ).toThrow("openKeyedStore is only available for trusted plugins");
+  });
+
+  it("rejects untrusted global plugins", () => {
+    const registry = createTestPluginRegistry();
+    const record = createPluginRecord("external-plugin", "global");
+    registry.registry.plugins.push(record);
+    const api = registry.createApi(record, { config: {} });
+
+    expect(() =>
+      api.runtime.state.openKeyedStore({ namespace: "runtime", maxEntries: 10 }),
+    ).toThrow("openKeyedStore is only available for trusted plugins");
   });
 });

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -51,7 +51,6 @@ import {
 import { buildPluginApi } from "./api-builder.js";
 import { normalizeRegisteredChannelPlugin } from "./channel-validation.js";
 import { CODEX_APP_SERVER_EXTENSION_RUNTIME_ID } from "./codex-app-server-extension-factory.js";
-import { getPluginCompatRecord } from "./compat/registry.js";
 import type { CodexAppServerExtensionFactory } from "./codex-app-server-extension-types.js";
 import {
   isReservedCommandName,
@@ -63,6 +62,7 @@ import {
   getRegisteredCompactionProvider,
   registerCompactionProvider,
 } from "./compaction-provider.js";
+import { getPluginCompatRecord } from "./compat/registry.js";
 import { sendPluginSessionAttachment } from "./host-hook-attachments.js";
 import {
   clearPluginRunContext,
@@ -2421,9 +2421,9 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
               const record =
                 pluginRuntimeRecordById.get(pluginId) ??
                 registry.plugins.find((entry) => entry.id === pluginId);
-              if (record?.origin !== "bundled") {
+              if (record?.origin !== "bundled" && record?.trustedOfficialInstall !== true) {
                 throw new Error(
-                  "openKeyedStore is only available for bundled plugins in this release.",
+                  "openKeyedStore is only available for trusted plugins in this release.",
                 );
               }
               return createPluginStateKeyedStore<T>(pluginId, options);


### PR DESCRIPTION
## Summary

Fixes #83762.

This PR allows `runtime.state.openKeyedStore()` for trusted official plugin installs in addition to bundled plugins. That keeps untrusted global/workspace plugins blocked while letting official externalized channel plugins such as Slack, Discord, Matrix, and MS Teams use their existing host-backed persistent state when installed globally.

## Root Cause

The plugin runtime proxy only allowed keyed state for records with `origin === "bundled"`. Official channel plugins can now be loaded as trusted global installs, so their persistent state paths caught the runtime error and degraded to in-memory state.

## Changes

- Permit keyed state when `record.trustedOfficialInstall === true`.
- Update the runtime error wording from bundled-only to trusted-plugin access.
- Add coverage for trusted global access and untrusted global/workspace rejection.

## Validation

- `pnpm exec vitest run src/plugin-state/plugin-state-store.runtime.test.ts extensions/slack/src/sent-thread-cache.test.ts extensions/discord/src/components.test.ts extensions/matrix/src/approval-reactions.test.ts extensions/msteams/src/sent-message-cache.test.ts`
- `pnpm test:contracts:plugins`
- `pnpm test:contracts:channels`
- `pnpm check`
- `codex review --base origin/main` (no findings)

## AI Assistance

This PR was prepared with Codex assistance. I reviewed the diff and validation results before submission.
