### PR TITLE
fix(memory-wiki): preserve fs-safe write diagnostics

### DIFF
--- a/extensions/memory-wiki/src/bridge.test.ts
+++ b/extensions/memory-wiki/src/bridge.test.ts
@@ -346,6 +346,51 @@ describe("syncMemoryWikiBridgeSources", () => {
     await expect(fs.readFile(externalTarget, "utf8")).resolves.toBe("external target\n");
   });
 
+  it("reports non-symlink bridge source write safety failures without symlink wording", async () => {
+    const workspaceDir = await createBridgeWorkspace("not-file-workspace");
+    const { rootDir: vaultDir, config } = await createVault({
+      rootDir: nextCaseRoot("not-file-vault"),
+      config: {
+        vaultMode: "bridge",
+        bridge: {
+          enabled: true,
+          readMemoryArtifacts: true,
+          indexMemoryRoot: true,
+        },
+      },
+    });
+    const memoryPath = path.join(workspaceDir, "MEMORY.md");
+    await fs.writeFile(memoryPath, "# Durable Memory\n", "utf8");
+    registerBridgeArtifacts([
+      {
+        kind: "memory-root",
+        workspaceDir,
+        relativePath: "MEMORY.md",
+        absolutePath: memoryPath,
+        agentIds: ["main"],
+        contentType: "markdown",
+      },
+    ]);
+    const appConfig: OpenClawConfig = {
+      agents: {
+        list: [{ id: "main", default: true, workspace: workspaceDir }],
+      },
+    };
+    const first = await syncMemoryWikiBridgeSources({ config, appConfig });
+    const pagePath = first.pagePaths[0] ?? "";
+    const pageAbsPath = path.join(vaultDir, pagePath);
+    await fs.rm(pageAbsPath);
+    await fs.mkdir(pageAbsPath);
+    await fs.writeFile(path.join(pageAbsPath, "child.md"), "blocking child\n", "utf8");
+    await fs.writeFile(memoryPath, "# Updated Durable Memory\n", "utf8");
+
+    const second = syncMemoryWikiBridgeSources({ config, appConfig });
+    await expect(second).rejects.toThrow(
+      /Refusing to write imported source page \((not-empty|not-file|path-mismatch)\): sources\//u,
+    );
+    await expect(second).rejects.not.toThrow("through symlink");
+  });
+
   it("replaces bridge source page hardlinks without clobbering their target", async () => {
     const workspaceDir = await createBridgeWorkspace("hardlink-workspace");
     const { rootDir: vaultDir, config } = await createVault({

--- a/extensions/memory-wiki/src/bridge.test.ts
+++ b/extensions/memory-wiki/src/bridge.test.ts
@@ -346,10 +346,14 @@ describe("syncMemoryWikiBridgeSources", () => {
     await expect(fs.readFile(externalTarget, "utf8")).resolves.toBe("external target\n");
   });
 
-  it("reports non-symlink bridge source write safety failures without symlink wording", async () => {
-    const workspaceDir = await createBridgeWorkspace("not-file-workspace");
+  async function createDirectoryCollisionFixture(params: {
+    workspaceName: string;
+    vaultName: string;
+    populateDirectory?: boolean;
+  }) {
+    const workspaceDir = await createBridgeWorkspace(params.workspaceName);
     const { rootDir: vaultDir, config } = await createVault({
-      rootDir: nextCaseRoot("not-file-vault"),
+      rootDir: nextCaseRoot(params.vaultName),
       config: {
         vaultMode: "bridge",
         bridge: {
@@ -381,14 +385,39 @@ describe("syncMemoryWikiBridgeSources", () => {
     const pageAbsPath = path.join(vaultDir, pagePath);
     await fs.rm(pageAbsPath);
     await fs.mkdir(pageAbsPath);
-    await fs.writeFile(path.join(pageAbsPath, "child.md"), "blocking child\n", "utf8");
+    if (params.populateDirectory) {
+      await fs.writeFile(path.join(pageAbsPath, "child.md"), "blocking child\n", "utf8");
+    }
     await fs.writeFile(memoryPath, "# Updated Durable Memory\n", "utf8");
+    return { appConfig, config, pageAbsPath };
+  }
+
+  it("reports non-symlink bridge source write safety failures without symlink wording", async () => {
+    const { appConfig, config } = await createDirectoryCollisionFixture({
+      workspaceName: "not-file-workspace",
+      vaultName: "not-file-vault",
+      populateDirectory: true,
+    });
 
     const second = syncMemoryWikiBridgeSources({ config, appConfig });
     await expect(second).rejects.toThrow(
       /Refusing to write imported source page \((not-empty|not-file|path-mismatch)\): sources\//u,
     );
     await expect(second).rejects.not.toThrow("through symlink");
+  });
+
+  it("does not remove empty directory bridge source collisions as hardlinks", async () => {
+    const { appConfig, config, pageAbsPath } = await createDirectoryCollisionFixture({
+      workspaceName: "empty-directory-workspace",
+      vaultName: "empty-directory-vault",
+    });
+
+    const second = syncMemoryWikiBridgeSources({ config, appConfig });
+    await expect(second).rejects.toThrow(
+      /Refusing to write imported source page \((not-file|path-mismatch)\): sources\//u,
+    );
+    await expect(second).rejects.not.toThrow("through symlink");
+    await expect(fs.stat(pageAbsPath)).resolves.toSatisfy((stat) => stat.isDirectory());
   });
 
   it("replaces bridge source page hardlinks without clobbering their target", async () => {

--- a/extensions/memory-wiki/src/source-page-shared.ts
+++ b/extensions/memory-wiki/src/source-page-shared.ts
@@ -8,6 +8,23 @@ import {
 
 type ImportedSourceState = Parameters<typeof shouldSkipImportedSourceWrite>[0]["state"];
 
+type FileStatLike = {
+  isFile?: unknown;
+  nlink?: unknown;
+};
+
+function isRegularFileStat(value: unknown): value is FileStatLike & { nlink: number } {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const stat = value as FileStatLike;
+  const isFile =
+    typeof stat.isFile === "function"
+      ? (stat.isFile as () => boolean).call(stat)
+      : stat.isFile === true;
+  return isFile && typeof stat.nlink === "number";
+}
+
 export async function writeImportedSourcePage(params: {
   vaultRoot: string;
   syncKey: string;
@@ -51,7 +68,7 @@ export async function writeImportedSourcePage(params: {
   const existing = pageStat ? await vault.readText(params.pagePath).catch(() => "") : "";
   if (existing !== rendered) {
     try {
-      if (pageStat && pageStat.isFile && pageStat.nlink > 1) {
+      if (isRegularFileStat(pageStat) && pageStat.nlink > 1) {
         await vault.remove(params.pagePath);
       }
       await vault.write(params.pagePath, rendered);

--- a/extensions/memory-wiki/src/source-page-shared.ts
+++ b/extensions/memory-wiki/src/source-page-shared.ts
@@ -51,12 +51,18 @@ export async function writeImportedSourcePage(params: {
   const existing = pageStat ? await vault.readText(params.pagePath).catch(() => "") : "";
   if (existing !== rendered) {
     try {
-      if (pageStat && pageStat.nlink > 1) {
+      if (pageStat && pageStat.isFile && pageStat.nlink > 1) {
         await vault.remove(params.pagePath);
       }
       await vault.write(params.pagePath, rendered);
     } catch (error) {
       if (error instanceof FsSafeError) {
+        if (error.code !== "symlink" && error.code !== "path-alias") {
+          throw new Error(
+            `Refusing to write imported source page (${error.code}): ${params.pagePath}: ${error.message}`,
+            { cause: error },
+          );
+        }
         throw new Error(
           `Refusing to write imported source page through symlink: ${params.pagePath}`,
           { cause: error },


### PR DESCRIPTION
## Summary

- Preserve the symlink-specific imported source page refusal only for `symlink` and `path-alias` fs-safe failures.
- Surface the concrete fs-safe code/message for other imported source write failures.
- Normalize the source-page stat shape before hardlink cleanup so directories are never treated as hardlink-safe regular files.
- Add an empty-directory regression proving directory collisions remain in place and report the concrete fs-safe diagnostic.

Fixes #83740.

## Real behavior proof

Behavior or issue addressed:
Memory Wiki bridge imported-source writes previously converted every `FsSafeError` from the guarded write path into `Refusing to write imported source page through symlink`, even when the failure was not symlink-related. The first PR revision also used a truthy `pageStat.isFile` guard, which could treat `fs.Stats#isFile` methods as regular-file evidence for directories.

Real environment tested:
Local macOS checkout at commit `465628459b` using a real temporary Memory Wiki bridge vault and workspace, the plugin SDK memory-host artifact registry, and the actual `syncMemoryWikiBridgeSources()` flow.

Exact steps or command run after this patch:
`PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node --import tsx /tmp/proof-83776.mjs`

Evidence after fix:
```text
openclaw-memory-wiki-live-proof=ok
generated_page=sources/bridge-bridge-workspace-2e41477f-memory-2d62c497.md
caught_message=Refusing to write imported source page (not-file): sources/bridge-bridge-workspace-2e41477f-memory-2d62c497.md: not a file
contains_symlink_wording=false
directory_still_present=true
error_has_not_file_code=true
```

Observed result after fix:
The real bridge sync created an imported source page, the generated page was replaced with an empty directory, and the next bridge sync reported the concrete fs-safe `not-file` diagnostic. The stale symlink wording was absent, and the directory remained present, proving the hardlink cleanup branch did not remove a directory collision.

What was not tested:
I did not run a full long-lived Gateway process with the Memory Wiki plugin loaded; the proof uses the real bridge sync implementation directly against a real temporary vault/workspace.

## Validation

- `PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node scripts/run-vitest.mjs extensions/memory-wiki/src/bridge.test.ts -t "non-symlink|empty directory|hardlinks"` - 3 passed, 7 skipped
- `PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node scripts/run-vitest.mjs extensions/memory-wiki/src/bridge.test.ts` - 10 passed
- `PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH pnpm tsgo:test:src`
- `PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node_modules/.bin/oxfmt --check --threads=1 extensions/memory-wiki/src/source-page-shared.ts extensions/memory-wiki/src/bridge.test.ts`
- `git diff --check`
- `git log --format='%h %an <%ae> %s' upstream/main..HEAD`:
  - `465628459b Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com> fix(memory-wiki): normalize source page stat guard`
  - `8e61aafbd6 Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com> fix(memory-wiki): preserve fs-safe write diagnostics`
