### PR TITLE
[codex] Surface subagent progress drafts

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -1605,6 +1605,60 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(editMessageTelegram).not.toHaveBeenCalled();
   });
 
+  it("uses native tool-progress drafts in progress mode without answer-draft duplication", async () => {
+    const nativeDraft = createNativeToolProgressDraft();
+    createNativeTelegramToolProgressDraft.mockReturnValue(nativeDraft);
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+        await dispatcherOptions.deliver({ text: "Done." }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: {
+        streaming: {
+          mode: "progress",
+          preview: { nativeToolProgress: true, nativeToolProgressAllowFrom: ["123"] },
+          progress: { label: "Working" },
+        },
+      },
+    });
+
+    expect(createNativeTelegramToolProgressDraft).toHaveBeenCalled();
+    expect(nativeDraft.update).toHaveBeenCalledWith("Working\n🛠️ Exec");
+    expect(answerDraftStream.update).not.toHaveBeenCalledWith("Working\n`🛠️ Exec`");
+    expectDeliveredReply(0, { text: "Done." });
+  });
+
+  it("does not start progress drafts from empty item updates", async () => {
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onItemEvent?.({ kind: "analysis", title: "Reasoning" });
+        await replyOptions?.onItemEvent?.({ kind: "analysis", title: "Reasoning" });
+        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+        await dispatcherOptions.deliver({ text: "Done." }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: { streaming: { mode: "progress", progress: { label: "Working" } } },
+    });
+
+    expect(answerDraftStream.update).toHaveBeenCalledTimes(1);
+    expect(answerDraftStream.update).toHaveBeenCalledWith("Working\n`🛠️ Exec`");
+    expect(answerDraftStream.update).not.toHaveBeenCalledWith("Working");
+    expectDeliveredReply(0, { text: "Done." });
+  });
+
   it("does not restart progress drafts after final answer delivery", async () => {
     const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -1634,8 +1634,8 @@ describe("dispatchTelegramMessage draft streaming", () => {
     });
 
     expect(createNativeTelegramToolProgressDraft).toHaveBeenCalled();
-    expect(nativeDraft.update).toHaveBeenCalledWith("Working\n🛠️ Exec");
-    expect(answerDraftStream.update).not.toHaveBeenCalledWith("Working\n`🛠️ Exec`");
+    expect(nativeDraft.update).toHaveBeenCalledWith("Working\n\n🛠️ Exec");
+    expect(answerDraftStream.update).not.toHaveBeenCalledWith("Working\n\n`🛠️ Exec`");
     expect(nativeDraft.freeze).toHaveBeenCalled();
     expectDeliveredReply(0, { text: "Done." });
     expect(nativeDraft.freeze.mock.invocationCallOrder[0]).toBeLessThan(
@@ -1699,9 +1699,9 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(sendMessageDraft).toHaveBeenCalledWith(
       123,
       expect.any(Number),
-      "Working\n🛠️ Exec",
+      "Working\n\n🛠️ Exec",
       { message_thread_id: 777 },
-      expect.any(AbortSignal),
+      expect.any(Object),
     );
     expect(draftSignal?.aborted).toBe(true);
     expectDeliveredReply(0, { text: "Done." });
@@ -1726,7 +1726,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     });
 
     expect(answerDraftStream.update).toHaveBeenCalledTimes(1);
-    expect(answerDraftStream.update).toHaveBeenCalledWith("Working\n`🛠️ Exec`");
+    expect(answerDraftStream.update).toHaveBeenCalledWith("Working\n\n`🛠️ Exec`");
     expect(answerDraftStream.update).not.toHaveBeenCalledWith("Working");
     expectDeliveredReply(0, { text: "Done." });
   });

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -7,6 +7,7 @@ import {
   createTestDraftStream,
 } from "./draft-stream.test-helpers.js";
 import { notifyTelegramInboundEventOutboundSuccess } from "./inbound-event-delivery.js";
+import { createNativeTelegramToolProgressDraft as createNativeTelegramToolProgressDraftActual } from "./native-tool-progress-draft.js";
 
 type DispatchReplyWithBufferedBlockDispatcherArgs = Parameters<
   TelegramBotDeps["dispatchReplyWithBufferedBlockDispatcher"]
@@ -1632,6 +1633,70 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(createNativeTelegramToolProgressDraft).toHaveBeenCalled();
     expect(nativeDraft.update).toHaveBeenCalledWith("Working\n🛠️ Exec");
     expect(answerDraftStream.update).not.toHaveBeenCalledWith("Working\n`🛠️ Exec`");
+    expectDeliveredReply(0, { text: "Done." });
+  });
+
+  it("delivers the final answer when native tool-progress draft sends are slow", async () => {
+    let draftSignal: AbortSignal | undefined;
+    const sendMessageDraft = vi.fn(
+      async (
+        _chatId: number | string,
+        _draftId: number,
+        _text: string,
+        _params?: Record<string, unknown>,
+        signal?: AbortSignal,
+      ) => {
+        draftSignal = signal;
+        return await new Promise((resolve, reject) => {
+          signal?.addEventListener(
+            "abort",
+            () => {
+              const err = new Error("aborted");
+              err.name = "AbortError";
+              reject(err);
+            },
+            { once: true },
+          );
+        });
+      },
+    );
+    const bot = createBot();
+    (bot.api as Bot["api"] & { sendMessageDraft: typeof sendMessageDraft }).sendMessageDraft =
+      sendMessageDraft;
+    setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+        await dispatcherOptions.deliver({ text: "Done." }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({
+      bot,
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: {
+        streaming: {
+          mode: "progress",
+          preview: { nativeToolProgress: true, nativeToolProgressAllowFrom: ["123"] },
+          progress: { label: "Working" },
+        },
+      },
+      telegramDeps: {
+        ...telegramDepsForTest,
+        createNativeTelegramToolProgressDraft: createNativeTelegramToolProgressDraftActual,
+      },
+    });
+
+    expect(sendMessageDraft).toHaveBeenCalledWith(
+      123,
+      expect.any(Number),
+      "Working\n🛠️ Exec",
+      { message_thread_id: 777 },
+      expect.any(AbortSignal),
+    );
+    expect(draftSignal?.aborted).toBe(true);
     expectDeliveredReply(0, { text: "Done." });
   });
 

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -302,6 +302,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     createSequencedTestDraftStream(startMessageId);
   const createNativeToolProgressDraft = (updateResult = true) => ({
     update: vi.fn(async () => updateResult),
+    freeze: vi.fn(),
     stop: vi.fn(),
   });
 
@@ -1262,6 +1263,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(createNativeTelegramToolProgressDraft).toHaveBeenCalledWith(
       expect.objectContaining({
         chatId: 123,
+        mode: "status-with-typing",
         thread: { id: 777, scope: "dm" },
       }),
     );
@@ -1270,6 +1272,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(1, "Done ");
     expect(answerDraftStream.update).toHaveBeenLastCalledWith("Done answer.");
     expect(answerDraftStream.update).not.toHaveBeenCalledWith(expect.stringContaining("Exec"));
+    expect(nativeDraft.freeze).toHaveBeenCalled();
     expect(nativeDraft.stop).toHaveBeenCalled();
   });
 
@@ -1633,7 +1636,11 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(createNativeTelegramToolProgressDraft).toHaveBeenCalled();
     expect(nativeDraft.update).toHaveBeenCalledWith("Working\n🛠️ Exec");
     expect(answerDraftStream.update).not.toHaveBeenCalledWith("Working\n`🛠️ Exec`");
+    expect(nativeDraft.freeze).toHaveBeenCalled();
     expectDeliveredReply(0, { text: "Done." });
+    expect(nativeDraft.freeze.mock.invocationCallOrder[0]).toBeLessThan(
+      deliverReplies.mock.invocationCallOrder[0],
+    );
   });
 
   it("delivers the final answer when native tool-progress draft sends are slow", async () => {

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -616,6 +616,7 @@ export const dispatchTelegramMessage = async ({
           chatId,
           thread: threadSpec,
           log: logVerbose,
+          mode: "status-with-typing",
         })
       : undefined;
   let streamToolProgressSuppressed = false;
@@ -815,7 +816,7 @@ export const dispatchTelegramMessage = async ({
     resetDraftLaneState(lane);
   };
   const rotateAnswerLaneAfterToolProgress = async () => {
-    nativeToolProgressDraft?.stop();
+    nativeToolProgressDraft?.freeze();
     if (!activeAnswerDraftIsToolProgressOnly) {
       return false;
     }
@@ -827,7 +828,7 @@ export const dispatchTelegramMessage = async ({
     return true;
   };
   const prepareAnswerLaneForText = async () => {
-    nativeToolProgressDraft?.stop();
+    nativeToolProgressDraft?.freeze();
     if (await rotateAnswerLaneAfterToolProgress()) {
       return;
     }
@@ -1239,6 +1240,7 @@ export const dispatchTelegramMessage = async ({
       payload: ReplyPayload,
       text: string,
     ): Promise<LaneDeliveryResult> => {
+      nativeToolProgressDraft?.freeze();
       if (activeAnswerDraftIsToolProgressOnly) {
         await rotateAnswerLaneAfterToolProgress();
       } else {

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -680,6 +680,9 @@ export const dispatchTelegramMessage = async ({
     if (streamMode !== "progress" && !streamToolProgressEnabled) {
       return false;
     }
+    if (streamToolProgressEnabled && !normalized) {
+      return false;
+    }
     const shouldUpdateProgressLines =
       streamToolProgressEnabled && !streamToolProgressSuppressed && Boolean(normalized);
     if (!shouldUpdateProgressLines && streamMode !== "progress") {

--- a/extensions/telegram/src/native-tool-progress-draft.test.ts
+++ b/extensions/telegram/src/native-tool-progress-draft.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createNativeTelegramToolProgressDraft } from "./native-tool-progress-draft.js";
 
 describe("createNativeTelegramToolProgressDraft", () => {
@@ -11,6 +11,10 @@ describe("createNativeTelegramToolProgressDraft", () => {
         _params?: Record<string, unknown>,
       ) => implementation?.(),
     );
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
 
   it("returns undefined when the Bot API client has no sendMessageDraft method", () => {
     const draft = createNativeTelegramToolProgressDraft({
@@ -36,9 +40,15 @@ describe("createNativeTelegramToolProgressDraft", () => {
     const firstDraftId = sendMessageDraft.mock.calls[0]?.[1];
     expect(firstDraftId).toEqual(expect.any(Number));
     expect(firstDraftId).not.toBe(0);
-    expect(sendMessageDraft).toHaveBeenLastCalledWith(123, firstDraftId, "Running command", {
-      message_thread_id: 456,
-    });
+    expect(sendMessageDraft).toHaveBeenLastCalledWith(
+      123,
+      firstDraftId,
+      "Running command",
+      {
+        message_thread_id: 456,
+      },
+      expect.any(AbortSignal),
+    );
   });
 
   it("stops after a Telegram rejection so callers can fall back silently", async () => {
@@ -58,5 +68,129 @@ describe("createNativeTelegramToolProgressDraft", () => {
 
     expect(sendMessageDraft).toHaveBeenCalledTimes(1);
     expect(log).toHaveBeenCalledWith(expect.stringContaining("disabled"));
+  });
+
+  it("coalesces rapid progress updates into the latest pending native draft", async () => {
+    vi.useFakeTimers();
+    const sendMessageDraft = createSendMessageDraftMock();
+    const draft = createNativeTelegramToolProgressDraft({
+      api: { sendMessageDraft },
+      chatId: 123,
+      minUpdateIntervalMs: 1_000,
+    } as never);
+
+    expect(draft).toBeDefined();
+    await expect(draft?.update("Starting")).resolves.toBe(true);
+    await expect(draft?.update("Reading files")).resolves.toBe(true);
+    await expect(draft?.update("Running tests")).resolves.toBe(true);
+
+    expect(sendMessageDraft).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(999);
+    expect(sendMessageDraft).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(sendMessageDraft).toHaveBeenCalledTimes(2);
+    const draftId = sendMessageDraft.mock.calls[0]?.[1];
+    expect(sendMessageDraft).toHaveBeenLastCalledWith(
+      123,
+      draftId,
+      "Running tests",
+      undefined,
+      expect.any(AbortSignal),
+    );
+  });
+
+  it("does not send overlapping native draft updates while a prior update is in flight", async () => {
+    vi.useFakeTimers();
+    let resolveFirstSend: ((value: unknown) => void) | undefined;
+    const sendMessageDraft = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirstSend = resolve;
+          }),
+      )
+      .mockResolvedValue(undefined);
+    const draft = createNativeTelegramToolProgressDraft({
+      api: { sendMessageDraft },
+      chatId: 123,
+      minUpdateIntervalMs: 1_000,
+    } as never);
+
+    expect(draft).toBeDefined();
+    const firstUpdate = draft?.update("Starting");
+    await expect(draft?.update("Running tests")).resolves.toBe(true);
+
+    expect(sendMessageDraft).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(sendMessageDraft).toHaveBeenCalledTimes(1);
+
+    resolveFirstSend?.(undefined);
+    await firstUpdate;
+    await vi.waitFor(() => expect(sendMessageDraft).toHaveBeenCalledTimes(2));
+    const draftId = sendMessageDraft.mock.calls[0]?.[1];
+    expect(sendMessageDraft).toHaveBeenLastCalledWith(
+      123,
+      draftId,
+      "Running tests",
+      undefined,
+      expect.any(AbortSignal),
+    );
+  });
+
+  it("cancels queued native draft updates when stopped", async () => {
+    vi.useFakeTimers();
+    const sendMessageDraft = createSendMessageDraftMock();
+    const draft = createNativeTelegramToolProgressDraft({
+      api: { sendMessageDraft },
+      chatId: 123,
+      minUpdateIntervalMs: 1_000,
+    } as never);
+
+    expect(draft).toBeDefined();
+    await expect(draft?.update("Starting")).resolves.toBe(true);
+    await expect(draft?.update("Running tests")).resolves.toBe(true);
+    draft?.stop();
+
+    await vi.runAllTimersAsync();
+
+    expect(sendMessageDraft).toHaveBeenCalledTimes(1);
+  });
+
+  it("aborts an in-flight native draft update when stopped", async () => {
+    let inFlightSignal: AbortSignal | undefined;
+    const sendMessageDraft = vi.fn(
+      async (
+        _chatId: number | string,
+        _draftId: number,
+        _text?: string,
+        _params?: Record<string, unknown>,
+        signal?: AbortSignal,
+      ) => {
+        inFlightSignal = signal;
+        return await new Promise((resolve, reject) => {
+          signal?.addEventListener("abort", () => {
+            const err = new Error("aborted");
+            err.name = "AbortError";
+            reject(err);
+          });
+        });
+      },
+    );
+    const log = vi.fn();
+    const draft = createNativeTelegramToolProgressDraft({
+      api: { sendMessageDraft },
+      chatId: 123,
+      log,
+    } as never);
+
+    expect(draft).toBeDefined();
+    const update = draft?.update("Starting");
+    draft?.stop();
+
+    await expect(update).resolves.toBe(false);
+    expect(inFlightSignal?.aborted).toBe(true);
+    expect(log).not.toHaveBeenCalled();
   });
 });

--- a/extensions/telegram/src/native-tool-progress-draft.test.ts
+++ b/extensions/telegram/src/native-tool-progress-draft.test.ts
@@ -11,6 +11,11 @@ describe("createNativeTelegramToolProgressDraft", () => {
         _params?: Record<string, unknown>,
       ) => implementation?.(),
     );
+  const createSendChatActionMock = () =>
+    vi.fn(
+      async (_chatId: number | string, _action: string, _params?: Record<string, unknown>) =>
+        undefined,
+    );
 
   afterEach(() => {
     vi.useRealTimers();
@@ -51,6 +56,118 @@ describe("createNativeTelegramToolProgressDraft", () => {
     );
   });
 
+  it("uses Telegram's native thinking placeholder in smooth-thinking mode", async () => {
+    vi.useFakeTimers();
+    const sendMessageDraft = createSendMessageDraftMock();
+    const draft = createNativeTelegramToolProgressDraft({
+      api: { sendMessageDraft },
+      chatId: 123,
+      mode: "smooth-thinking",
+      thinkingKeepAliveMs: 20,
+    } as never);
+
+    expect(draft).toBeDefined();
+    await expect(draft?.update("Running command")).resolves.toBe(true);
+    await expect(draft?.update("Reading files")).resolves.toBe(true);
+
+    expect(sendMessageDraft).toHaveBeenCalledTimes(1);
+    const firstDraftId = sendMessageDraft.mock.calls[0]?.[1];
+    expect(sendMessageDraft).toHaveBeenLastCalledWith(
+      123,
+      firstDraftId,
+      "",
+      undefined,
+      expect.any(AbortSignal),
+    );
+
+    await vi.advanceTimersByTimeAsync(19);
+    expect(sendMessageDraft).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(sendMessageDraft).toHaveBeenCalledTimes(2);
+    expect(sendMessageDraft).toHaveBeenLastCalledWith(
+      123,
+      firstDraftId,
+      "",
+      undefined,
+      expect.any(AbortSignal),
+    );
+  });
+
+  it("streams status text while keeping Telegram's native typing indicator alive", async () => {
+    vi.useFakeTimers();
+    const sendMessageDraft = createSendMessageDraftMock();
+    const sendChatAction = createSendChatActionMock();
+    const draft = createNativeTelegramToolProgressDraft({
+      api: { sendMessageDraft, sendChatAction },
+      chatId: 123,
+      mode: "status-with-typing",
+      typingKeepAliveMs: 20,
+    } as never);
+
+    expect(draft).toBeDefined();
+    await expect(draft?.update("Working\n🛠️ Exec")).resolves.toBe(true);
+
+    expect(sendMessageDraft).toHaveBeenCalledWith(
+      123,
+      expect.any(Number),
+      "Working\n🛠️ Exec",
+      undefined,
+      expect.any(AbortSignal),
+    );
+    await vi.advanceTimersByTimeAsync(0);
+    expect(sendChatAction).toHaveBeenCalledWith(123, "typing", undefined);
+
+    await vi.advanceTimersByTimeAsync(19);
+    expect(sendChatAction).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(sendChatAction).toHaveBeenCalledTimes(2);
+    expect(sendChatAction).toHaveBeenLastCalledWith(123, "typing", undefined);
+  });
+
+  it("cancels status typing keepalives when frozen", async () => {
+    vi.useFakeTimers();
+    const sendMessageDraft = createSendMessageDraftMock();
+    const sendChatAction = createSendChatActionMock();
+    const draft = createNativeTelegramToolProgressDraft({
+      api: { sendMessageDraft, sendChatAction },
+      chatId: 123,
+      mode: "status-with-typing",
+      typingKeepAliveMs: 20,
+    } as never);
+
+    expect(draft).toBeDefined();
+    await expect(draft?.update("Working")).resolves.toBe(true);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(sendChatAction).toHaveBeenCalledTimes(1);
+    draft?.freeze();
+
+    await vi.runAllTimersAsync();
+
+    expect(sendChatAction).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels smooth-thinking keepalives when frozen", async () => {
+    vi.useFakeTimers();
+    const sendMessageDraft = createSendMessageDraftMock();
+    const draft = createNativeTelegramToolProgressDraft({
+      api: { sendMessageDraft },
+      chatId: 123,
+      mode: "smooth-thinking",
+      thinkingKeepAliveMs: 20,
+    } as never);
+
+    expect(draft).toBeDefined();
+    await expect(draft?.update("Running command")).resolves.toBe(true);
+    draft?.freeze();
+
+    await vi.runAllTimersAsync();
+    await expect(draft?.update("Late progress")).resolves.toBe(false);
+
+    expect(sendMessageDraft).toHaveBeenCalledTimes(1);
+  });
+
   it("stops after a Telegram rejection so later updates can fall back silently", async () => {
     const sendMessageDraft = createSendMessageDraftMock(async () => {
       throw new Error("Bad Request: method is unavailable");
@@ -76,6 +193,7 @@ describe("createNativeTelegramToolProgressDraft", () => {
     const draft = createNativeTelegramToolProgressDraft({
       api: { sendMessageDraft },
       chatId: 123,
+      idleUpdateDelayMs: 1_000,
       minUpdateIntervalMs: 1_000,
     } as never);
 
@@ -113,7 +231,7 @@ describe("createNativeTelegramToolProgressDraft", () => {
     await expect(draft?.update("Running checks")).resolves.toBe(true);
 
     expect(sendMessageDraft).toHaveBeenCalledTimes(1);
-    await vi.advanceTimersByTimeAsync(1_199);
+    await vi.advanceTimersByTimeAsync(899);
     expect(sendMessageDraft).toHaveBeenCalledTimes(1);
 
     await vi.advanceTimersByTimeAsync(1);
@@ -214,6 +332,26 @@ describe("createNativeTelegramToolProgressDraft", () => {
     draft?.stop();
 
     await vi.runAllTimersAsync();
+
+    expect(sendMessageDraft).toHaveBeenCalledTimes(1);
+  });
+
+  it("freezes native draft progress before final delivery without flushing queued text", async () => {
+    vi.useFakeTimers();
+    const sendMessageDraft = createSendMessageDraftMock();
+    const draft = createNativeTelegramToolProgressDraft({
+      api: { sendMessageDraft },
+      chatId: 123,
+      minUpdateIntervalMs: 1_000,
+    } as never);
+
+    expect(draft).toBeDefined();
+    await expect(draft?.update("Starting")).resolves.toBe(true);
+    await expect(draft?.update("Running tests")).resolves.toBe(true);
+    draft?.freeze();
+
+    await vi.runAllTimersAsync();
+    await expect(draft?.update("Late progress")).resolves.toBe(false);
 
     expect(sendMessageDraft).toHaveBeenCalledTimes(1);
   });

--- a/extensions/telegram/src/native-tool-progress-draft.test.ts
+++ b/extensions/telegram/src/native-tool-progress-draft.test.ts
@@ -51,7 +51,7 @@ describe("createNativeTelegramToolProgressDraft", () => {
     );
   });
 
-  it("stops after a Telegram rejection so callers can fall back silently", async () => {
+  it("stops after a Telegram rejection so later updates can fall back silently", async () => {
     const sendMessageDraft = createSendMessageDraftMock(async () => {
       throw new Error("Bad Request: method is unavailable");
     });
@@ -63,11 +63,11 @@ describe("createNativeTelegramToolProgressDraft", () => {
     } as never);
 
     expect(draft).toBeDefined();
-    await expect(draft?.update("Running command")).resolves.toBe(false);
+    await expect(draft?.update("Running command")).resolves.toBe(true);
+    await vi.waitFor(() => expect(log).toHaveBeenCalledWith(expect.stringContaining("disabled")));
     await expect(draft?.update("Still running")).resolves.toBe(false);
 
     expect(sendMessageDraft).toHaveBeenCalledTimes(1);
-    expect(log).toHaveBeenCalledWith(expect.stringContaining("disabled"));
   });
 
   it("coalesces rapid progress updates into the latest pending native draft", async () => {
@@ -119,7 +119,7 @@ describe("createNativeTelegramToolProgressDraft", () => {
     } as never);
 
     expect(draft).toBeDefined();
-    const firstUpdate = draft?.update("Starting");
+    await expect(draft?.update("Starting")).resolves.toBe(true);
     await expect(draft?.update("Running tests")).resolves.toBe(true);
 
     expect(sendMessageDraft).toHaveBeenCalledTimes(1);
@@ -127,7 +127,6 @@ describe("createNativeTelegramToolProgressDraft", () => {
     expect(sendMessageDraft).toHaveBeenCalledTimes(1);
 
     resolveFirstSend?.(undefined);
-    await firstUpdate;
     await vi.waitFor(() => expect(sendMessageDraft).toHaveBeenCalledTimes(2));
     const draftId = sendMessageDraft.mock.calls[0]?.[1];
     expect(sendMessageDraft).toHaveBeenLastCalledWith(
@@ -186,11 +185,31 @@ describe("createNativeTelegramToolProgressDraft", () => {
     } as never);
 
     expect(draft).toBeDefined();
-    const update = draft?.update("Starting");
+    await expect(draft?.update("Starting")).resolves.toBe(true);
     draft?.stop();
 
-    await expect(update).resolves.toBe(false);
+    await vi.waitFor(() => expect(inFlightSignal?.aborted).toBe(true));
     expect(inFlightSignal?.aborted).toBe(true);
     expect(log).not.toHaveBeenCalled();
+  });
+
+  it("does not make callers wait for slow native draft network sends", async () => {
+    let resolveSend: ((value: unknown) => void) | undefined;
+    const sendMessageDraft = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          resolveSend = resolve;
+        }),
+    );
+    const draft = createNativeTelegramToolProgressDraft({
+      api: { sendMessageDraft },
+      chatId: 123,
+    } as never);
+
+    expect(draft).toBeDefined();
+    await expect(draft?.update("Starting")).resolves.toBe(true);
+    expect(sendMessageDraft).toHaveBeenCalledTimes(1);
+
+    resolveSend?.(undefined);
   });
 });

--- a/extensions/telegram/src/native-tool-progress-draft.test.ts
+++ b/extensions/telegram/src/native-tool-progress-draft.test.ts
@@ -100,6 +100,33 @@ describe("createNativeTelegramToolProgressDraft", () => {
     );
   });
 
+  it("uses a conservative default cadence for visible native draft refreshes", async () => {
+    vi.useFakeTimers();
+    const sendMessageDraft = createSendMessageDraftMock();
+    const draft = createNativeTelegramToolProgressDraft({
+      api: { sendMessageDraft },
+      chatId: 123,
+    } as never);
+
+    expect(draft).toBeDefined();
+    await expect(draft?.update("Starting")).resolves.toBe(true);
+    await expect(draft?.update("Running checks")).resolves.toBe(true);
+
+    expect(sendMessageDraft).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(4_999);
+    expect(sendMessageDraft).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(sendMessageDraft).toHaveBeenCalledTimes(2);
+    expect(sendMessageDraft).toHaveBeenLastCalledWith(
+      123,
+      expect.any(Number),
+      "Running checks",
+      undefined,
+      expect.any(AbortSignal),
+    );
+  });
+
   it("does not send overlapping native draft updates while a prior update is in flight", async () => {
     vi.useFakeTimers();
     let resolveFirstSend: ((value: unknown) => void) | undefined;

--- a/extensions/telegram/src/native-tool-progress-draft.test.ts
+++ b/extensions/telegram/src/native-tool-progress-draft.test.ts
@@ -100,7 +100,7 @@ describe("createNativeTelegramToolProgressDraft", () => {
     );
   });
 
-  it("uses a conservative default cadence for visible native draft refreshes", async () => {
+  it("flushes the latest native draft update after a short quiet window", async () => {
     vi.useFakeTimers();
     const sendMessageDraft = createSendMessageDraftMock();
     const draft = createNativeTelegramToolProgressDraft({
@@ -113,7 +113,7 @@ describe("createNativeTelegramToolProgressDraft", () => {
     await expect(draft?.update("Running checks")).resolves.toBe(true);
 
     expect(sendMessageDraft).toHaveBeenCalledTimes(1);
-    await vi.advanceTimersByTimeAsync(4_999);
+    await vi.advanceTimersByTimeAsync(1_199);
     expect(sendMessageDraft).toHaveBeenCalledTimes(1);
 
     await vi.advanceTimersByTimeAsync(1);
@@ -122,6 +122,40 @@ describe("createNativeTelegramToolProgressDraft", () => {
       123,
       expect.any(Number),
       "Running checks",
+      undefined,
+      expect.any(AbortSignal),
+    );
+  });
+
+  it("forces an occasional native draft refresh when progress never goes quiet", async () => {
+    vi.useFakeTimers();
+    const sendMessageDraft = createSendMessageDraftMock();
+    const draft = createNativeTelegramToolProgressDraft({
+      api: { sendMessageDraft },
+      chatId: 123,
+      idleUpdateDelayMs: 1_200,
+      minUpdateIntervalMs: 5_000,
+    } as never);
+
+    expect(draft).toBeDefined();
+    await expect(draft?.update("Starting")).resolves.toBe(true);
+    await expect(draft?.update("Step 1")).resolves.toBe(true);
+
+    for (let index = 2; index <= 5; index += 1) {
+      await vi.advanceTimersByTimeAsync(1_000);
+      await expect(draft?.update(`Step ${index}`)).resolves.toBe(true);
+      expect(sendMessageDraft).toHaveBeenCalledTimes(1);
+    }
+
+    await vi.advanceTimersByTimeAsync(999);
+    expect(sendMessageDraft).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(sendMessageDraft).toHaveBeenCalledTimes(2);
+    expect(sendMessageDraft).toHaveBeenLastCalledWith(
+      123,
+      expect.any(Number),
+      "Step 5",
       undefined,
       expect.any(AbortSignal),
     );

--- a/extensions/telegram/src/native-tool-progress-draft.ts
+++ b/extensions/telegram/src/native-tool-progress-draft.ts
@@ -3,7 +3,8 @@ import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { buildTelegramThreadParams, type TelegramThreadSpec } from "./bot/helpers.js";
 
 const TELEGRAM_NATIVE_DRAFT_MAX_CHARS = 4096;
-const TELEGRAM_NATIVE_DRAFT_MIN_UPDATE_INTERVAL_MS = 5_000;
+const TELEGRAM_NATIVE_DRAFT_IDLE_UPDATE_DELAY_MS = 1_200;
+const TELEGRAM_NATIVE_DRAFT_MAX_UPDATE_INTERVAL_MS = 5_000;
 const TELEGRAM_DRAFT_ID_STATE_KEY = Symbol.for("openclaw.telegramNativeDraftIdState");
 
 type TelegramSendMessageDraft = (
@@ -54,6 +55,7 @@ export function createNativeTelegramToolProgressDraft(params: {
   chatId: Parameters<Bot["api"]["sendMessage"]>[0];
   thread?: TelegramThreadSpec | null;
   log?: (message: string) => void;
+  idleUpdateDelayMs?: number;
   minUpdateIntervalMs?: number;
 }): NativeTelegramToolProgressDraft | undefined {
   const sendMessageDraft = resolveSendMessageDraftApi(params.api);
@@ -63,14 +65,24 @@ export function createNativeTelegramToolProgressDraft(params: {
 
   const draftId = allocateTelegramDraftId();
   const threadParams = buildTelegramThreadParams(params.thread) ?? {};
-  const rawMinUpdateIntervalMs =
-    params.minUpdateIntervalMs ?? TELEGRAM_NATIVE_DRAFT_MIN_UPDATE_INTERVAL_MS;
-  const minUpdateIntervalMs = Math.max(
+  const rawIdleUpdateDelayMs =
+    params.idleUpdateDelayMs ?? TELEGRAM_NATIVE_DRAFT_IDLE_UPDATE_DELAY_MS;
+  const idleUpdateDelayMs = Math.max(
     0,
     Math.trunc(
-      Number.isFinite(rawMinUpdateIntervalMs)
-        ? rawMinUpdateIntervalMs
-        : TELEGRAM_NATIVE_DRAFT_MIN_UPDATE_INTERVAL_MS,
+      Number.isFinite(rawIdleUpdateDelayMs)
+        ? rawIdleUpdateDelayMs
+        : TELEGRAM_NATIVE_DRAFT_IDLE_UPDATE_DELAY_MS,
+    ),
+  );
+  const rawMaxUpdateIntervalMs =
+    params.minUpdateIntervalMs ?? TELEGRAM_NATIVE_DRAFT_MAX_UPDATE_INTERVAL_MS;
+  const maxUpdateIntervalMs = Math.max(
+    0,
+    Math.trunc(
+      Number.isFinite(rawMaxUpdateIntervalMs)
+        ? rawMaxUpdateIntervalMs
+        : TELEGRAM_NATIVE_DRAFT_MAX_UPDATE_INTERVAL_MS,
     ),
   );
   let stopped = false;
@@ -80,12 +92,18 @@ export function createNativeTelegramToolProgressDraft(params: {
   let inFlightText: string | undefined;
   let inFlightAbortController: AbortController | undefined;
   let queuedText: string | undefined;
-  let queuedTimer: ReturnType<typeof setTimeout> | undefined;
+  let firstQueuedAt = 0;
+  let idleQueuedTimer: ReturnType<typeof setTimeout> | undefined;
+  let maxQueuedTimer: ReturnType<typeof setTimeout> | undefined;
 
-  const clearQueuedTimer = () => {
-    if (queuedTimer !== undefined) {
-      clearTimeout(queuedTimer);
-      queuedTimer = undefined;
+  const clearQueuedTimers = () => {
+    if (idleQueuedTimer !== undefined) {
+      clearTimeout(idleQueuedTimer);
+      idleQueuedTimer = undefined;
+    }
+    if (maxQueuedTimer !== undefined) {
+      clearTimeout(maxQueuedTimer);
+      maxQueuedTimer = undefined;
     }
   };
 
@@ -116,7 +134,8 @@ export function createNativeTelegramToolProgressDraft(params: {
         }
         stopped = true;
         queuedText = undefined;
-        clearQueuedTimer();
+        firstQueuedAt = 0;
+        clearQueuedTimers();
         params.log?.(`telegram native tool-progress draft disabled: ${formatErrorMessage(err)}`);
         return false;
       })
@@ -126,17 +145,18 @@ export function createNativeTelegramToolProgressDraft(params: {
         }
         inFlight = undefined;
         inFlightText = undefined;
-        scheduleQueuedSend();
+        scheduleQueuedSendAfterInFlight();
       });
   };
 
   const flushQueuedSend = (): boolean => {
-    clearQueuedTimer();
+    clearQueuedTimers();
     if (stopped || inFlight || !queuedText) {
       return false;
     }
     const nextText = queuedText;
     queuedText = undefined;
+    firstQueuedAt = 0;
     if (nextText === lastSentText) {
       return true;
     }
@@ -144,16 +164,52 @@ export function createNativeTelegramToolProgressDraft(params: {
     return true;
   };
 
-  function scheduleQueuedSend() {
-    if (stopped || inFlight || queuedTimer !== undefined || !queuedText) {
+  function scheduleQueuedSend(options?: { resetIdle?: boolean }) {
+    if (stopped || inFlight || !queuedText) {
       return;
     }
-    const elapsedMs = lastSendStartedAt > 0 ? Date.now() - lastSendStartedAt : minUpdateIntervalMs;
-    const delayMs = Math.max(0, minUpdateIntervalMs - elapsedMs);
-    queuedTimer = setTimeout(() => {
-      queuedTimer = undefined;
+    const now = Date.now();
+    if (firstQueuedAt <= 0) {
+      firstQueuedAt = now;
+    }
+    if (options?.resetIdle && idleQueuedTimer !== undefined) {
+      clearTimeout(idleQueuedTimer);
+      idleQueuedTimer = undefined;
+    }
+    if (idleQueuedTimer === undefined) {
+      idleQueuedTimer = setTimeout(() => {
+        idleQueuedTimer = undefined;
+        flushQueuedSend();
+      }, idleUpdateDelayMs);
+    }
+    if (maxQueuedTimer === undefined) {
+      const elapsedMs = now - firstQueuedAt;
+      const delayMs = Math.max(0, maxUpdateIntervalMs - elapsedMs);
+      maxQueuedTimer = setTimeout(() => {
+        maxQueuedTimer = undefined;
+        flushQueuedSend();
+      }, delayMs);
+    }
+  }
+
+  function queueSend(text: string) {
+    queuedText = text;
+    if (firstQueuedAt <= 0) {
+      firstQueuedAt = Date.now();
+    }
+    scheduleQueuedSend({ resetIdle: true });
+  }
+
+  function scheduleQueuedSendAfterInFlight() {
+    if (stopped || !queuedText) {
+      return;
+    }
+    const elapsedMs = lastSendStartedAt > 0 ? Date.now() - lastSendStartedAt : maxUpdateIntervalMs;
+    if (elapsedMs >= maxUpdateIntervalMs) {
       flushQueuedSend();
-    }, delayMs);
+      return;
+    }
+    scheduleQueuedSend();
   }
 
   return {
@@ -175,14 +231,14 @@ export function createNativeTelegramToolProgressDraft(params: {
         sendNow(normalizedText);
         return true;
       }
-      queuedText = normalizedText;
-      scheduleQueuedSend();
+      queueSend(normalizedText);
       return true;
     },
     stop: () => {
       stopped = true;
       queuedText = undefined;
-      clearQueuedTimer();
+      firstQueuedAt = 0;
+      clearQueuedTimers();
       inFlightAbortController?.abort();
       inFlightAbortController = undefined;
     },

--- a/extensions/telegram/src/native-tool-progress-draft.ts
+++ b/extensions/telegram/src/native-tool-progress-draft.ts
@@ -3,7 +3,7 @@ import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { buildTelegramThreadParams, type TelegramThreadSpec } from "./bot/helpers.js";
 
 const TELEGRAM_NATIVE_DRAFT_MAX_CHARS = 4096;
-const TELEGRAM_NATIVE_DRAFT_MIN_UPDATE_INTERVAL_MS = 750;
+const TELEGRAM_NATIVE_DRAFT_MIN_UPDATE_INTERVAL_MS = 5_000;
 const TELEGRAM_DRAFT_ID_STATE_KEY = Symbol.for("openclaw.telegramNativeDraftIdState");
 
 type TelegramSendMessageDraft = (

--- a/extensions/telegram/src/native-tool-progress-draft.ts
+++ b/extensions/telegram/src/native-tool-progress-draft.ts
@@ -3,8 +3,10 @@ import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { buildTelegramThreadParams, type TelegramThreadSpec } from "./bot/helpers.js";
 
 const TELEGRAM_NATIVE_DRAFT_MAX_CHARS = 4096;
-const TELEGRAM_NATIVE_DRAFT_IDLE_UPDATE_DELAY_MS = 1_200;
-const TELEGRAM_NATIVE_DRAFT_MAX_UPDATE_INTERVAL_MS = 5_000;
+const TELEGRAM_NATIVE_DRAFT_IDLE_UPDATE_DELAY_MS = 900;
+const TELEGRAM_NATIVE_DRAFT_MAX_UPDATE_INTERVAL_MS = 2_500;
+const TELEGRAM_NATIVE_DRAFT_THINKING_KEEPALIVE_MS = 20_000;
+const TELEGRAM_NATIVE_DRAFT_TYPING_KEEPALIVE_MS = 4_000;
 const TELEGRAM_DRAFT_ID_STATE_KEY = Symbol.for("openclaw.telegramNativeDraftIdState");
 
 type TelegramSendMessageDraft = (
@@ -19,10 +21,20 @@ type TelegramSendMessageDraft = (
   signal?: AbortSignal,
 ) => Promise<unknown>;
 
+type TelegramSendChatAction = (
+  chatId: Parameters<Bot["api"]["sendChatAction"]>[0],
+  action: Parameters<Bot["api"]["sendChatAction"]>[1],
+  params?: Parameters<Bot["api"]["sendChatAction"]>[2],
+  signal?: AbortSignal,
+) => Promise<unknown>;
+
 export type NativeTelegramToolProgressDraft = {
   update: (text: string) => Promise<boolean>;
+  freeze: () => void;
   stop: () => void;
 };
+
+export type NativeTelegramToolProgressDraftMode = "text" | "smooth-thinking" | "status-with-typing";
 
 function resolveSendMessageDraftApi(api: Bot["api"]): TelegramSendMessageDraft | undefined {
   const sendMessageDraft = (api as Bot["api"] & { sendMessageDraft?: TelegramSendMessageDraft })
@@ -31,6 +43,15 @@ function resolveSendMessageDraftApi(api: Bot["api"]): TelegramSendMessageDraft |
     return undefined;
   }
   return sendMessageDraft.bind(api as object);
+}
+
+function resolveSendChatActionApi(api: Bot["api"]): TelegramSendChatAction | undefined {
+  const sendChatAction = (api as Bot["api"] & { sendChatAction?: TelegramSendChatAction })
+    .sendChatAction;
+  if (typeof sendChatAction !== "function") {
+    return undefined;
+  }
+  return sendChatAction.bind(api as object);
 }
 
 function allocateTelegramDraftId(): number {
@@ -55,16 +76,22 @@ export function createNativeTelegramToolProgressDraft(params: {
   chatId: Parameters<Bot["api"]["sendMessage"]>[0];
   thread?: TelegramThreadSpec | null;
   log?: (message: string) => void;
+  mode?: NativeTelegramToolProgressDraftMode;
   idleUpdateDelayMs?: number;
+  maxUpdateIntervalMs?: number;
   minUpdateIntervalMs?: number;
+  thinkingKeepAliveMs?: number;
+  typingKeepAliveMs?: number;
 }): NativeTelegramToolProgressDraft | undefined {
   const sendMessageDraft = resolveSendMessageDraftApi(params.api);
   if (!sendMessageDraft) {
     return undefined;
   }
+  const sendChatAction = resolveSendChatActionApi(params.api);
 
   const draftId = allocateTelegramDraftId();
   const threadParams = buildTelegramThreadParams(params.thread) ?? {};
+  const mode = params.mode ?? "text";
   const rawIdleUpdateDelayMs =
     params.idleUpdateDelayMs ?? TELEGRAM_NATIVE_DRAFT_IDLE_UPDATE_DELAY_MS;
   const idleUpdateDelayMs = Math.max(
@@ -76,7 +103,9 @@ export function createNativeTelegramToolProgressDraft(params: {
     ),
   );
   const rawMaxUpdateIntervalMs =
-    params.minUpdateIntervalMs ?? TELEGRAM_NATIVE_DRAFT_MAX_UPDATE_INTERVAL_MS;
+    params.maxUpdateIntervalMs ??
+    params.minUpdateIntervalMs ??
+    TELEGRAM_NATIVE_DRAFT_MAX_UPDATE_INTERVAL_MS;
   const maxUpdateIntervalMs = Math.max(
     0,
     Math.trunc(
@@ -85,7 +114,30 @@ export function createNativeTelegramToolProgressDraft(params: {
         : TELEGRAM_NATIVE_DRAFT_MAX_UPDATE_INTERVAL_MS,
     ),
   );
+  const rawThinkingKeepAliveMs =
+    params.thinkingKeepAliveMs ?? TELEGRAM_NATIVE_DRAFT_THINKING_KEEPALIVE_MS;
+  const thinkingKeepAliveMs = Math.max(
+    0,
+    Math.trunc(
+      Number.isFinite(rawThinkingKeepAliveMs)
+        ? rawThinkingKeepAliveMs
+        : TELEGRAM_NATIVE_DRAFT_THINKING_KEEPALIVE_MS,
+    ),
+  );
+  const rawTypingKeepAliveMs =
+    params.typingKeepAliveMs ?? TELEGRAM_NATIVE_DRAFT_TYPING_KEEPALIVE_MS;
+  const typingKeepAliveMs = Math.max(
+    0,
+    Math.trunc(
+      Number.isFinite(rawTypingKeepAliveMs)
+        ? rawTypingKeepAliveMs
+        : TELEGRAM_NATIVE_DRAFT_TYPING_KEEPALIVE_MS,
+    ),
+  );
   let stopped = false;
+  let frozen = false;
+  let hasSentDraft = false;
+  let typingInFlight = false;
   let lastSentText: string | undefined;
   let lastSendStartedAt = 0;
   let inFlight: Promise<boolean> | undefined;
@@ -95,6 +147,8 @@ export function createNativeTelegramToolProgressDraft(params: {
   let firstQueuedAt = 0;
   let idleQueuedTimer: ReturnType<typeof setTimeout> | undefined;
   let maxQueuedTimer: ReturnType<typeof setTimeout> | undefined;
+  let thinkingKeepAliveTimer: ReturnType<typeof setTimeout> | undefined;
+  let typingKeepAliveTimer: ReturnType<typeof setTimeout> | undefined;
 
   const clearQueuedTimers = () => {
     if (idleQueuedTimer !== undefined) {
@@ -107,9 +161,84 @@ export function createNativeTelegramToolProgressDraft(params: {
     }
   };
 
-  const sendNow = (text: string): void => {
+  const clearThinkingKeepAliveTimer = () => {
+    if (thinkingKeepAliveTimer !== undefined) {
+      clearTimeout(thinkingKeepAliveTimer);
+      thinkingKeepAliveTimer = undefined;
+    }
+  };
+
+  const clearTypingKeepAliveTimer = () => {
+    if (typingKeepAliveTimer !== undefined) {
+      clearTimeout(typingKeepAliveTimer);
+      typingKeepAliveTimer = undefined;
+    }
+  };
+
+  const sendTypingAction = () => {
+    if (!sendChatAction || stopped || frozen || typingInFlight) {
+      return;
+    }
+    typingInFlight = true;
+    void sendChatAction(
+      params.chatId,
+      "typing",
+      Object.keys(threadParams).length > 0
+        ? (threadParams as Parameters<Bot["api"]["sendChatAction"]>[2])
+        : undefined,
+    )
+      .catch((err) => {
+        params.log?.(`telegram native typing indicator failed: ${formatErrorMessage(err)}`);
+      })
+      .finally(() => {
+        typingInFlight = false;
+      });
+  };
+
+  const scheduleTypingKeepAlive = () => {
+    if (mode !== "status-with-typing" || stopped || frozen || typingKeepAliveMs <= 0) {
+      return;
+    }
+    clearTypingKeepAliveTimer();
+    typingKeepAliveTimer = setTimeout(() => {
+      typingKeepAliveTimer = undefined;
+      if (stopped || frozen) {
+        return;
+      }
+      sendTypingAction();
+      scheduleTypingKeepAlive();
+    }, typingKeepAliveMs);
+  };
+
+  const startTypingKeepAlive = () => {
+    if (mode !== "status-with-typing") {
+      return;
+    }
+    sendTypingAction();
+    scheduleTypingKeepAlive();
+  };
+
+  const scheduleThinkingKeepAlive = () => {
+    if (mode !== "smooth-thinking" || stopped || frozen || thinkingKeepAliveMs <= 0) {
+      return;
+    }
+    clearThinkingKeepAliveTimer();
+    thinkingKeepAliveTimer = setTimeout(() => {
+      thinkingKeepAliveTimer = undefined;
+      if (stopped || frozen) {
+        return;
+      }
+      if (inFlight) {
+        scheduleThinkingKeepAlive();
+        return;
+      }
+      sendNow("", { force: true });
+    }, thinkingKeepAliveMs);
+  };
+
+  const sendNow = (text: string, options?: { force?: boolean }): void => {
     const abortController = new AbortController();
-    if (stopped) {
+    if (stopped || frozen) {
       return;
     }
     inFlightText = text;
@@ -124,12 +253,17 @@ export function createNativeTelegramToolProgressDraft(params: {
     )
       .then(() => {
         if (!stopped) {
+          hasSentDraft = true;
           lastSentText = text;
+          if (mode === "smooth-thinking" && options?.force) {
+            scheduleThinkingKeepAlive();
+          }
+          startTypingKeepAlive();
         }
         return true;
       })
       .catch((err) => {
-        if (stopped && abortController.signal.aborted) {
+        if ((stopped || frozen) && abortController.signal.aborted) {
           return false;
         }
         stopped = true;
@@ -145,13 +279,15 @@ export function createNativeTelegramToolProgressDraft(params: {
         }
         inFlight = undefined;
         inFlightText = undefined;
-        scheduleQueuedSendAfterInFlight();
+        if (!frozen) {
+          scheduleQueuedSendAfterInFlight();
+        }
       });
   };
 
   const flushQueuedSend = (): boolean => {
     clearQueuedTimers();
-    if (stopped || inFlight || !queuedText) {
+    if (stopped || frozen || inFlight || !queuedText) {
       return false;
     }
     const nextText = queuedText;
@@ -165,7 +301,7 @@ export function createNativeTelegramToolProgressDraft(params: {
   };
 
   function scheduleQueuedSend(options?: { resetIdle?: boolean }) {
-    if (stopped || inFlight || !queuedText) {
+    if (stopped || frozen || inFlight || !queuedText) {
       return;
     }
     const now = Date.now();
@@ -201,7 +337,7 @@ export function createNativeTelegramToolProgressDraft(params: {
   }
 
   function scheduleQueuedSendAfterInFlight() {
-    if (stopped || !queuedText) {
+    if (stopped || frozen || !queuedText) {
       return;
     }
     const elapsedMs = lastSendStartedAt > 0 ? Date.now() - lastSendStartedAt : maxUpdateIntervalMs;
@@ -212,10 +348,27 @@ export function createNativeTelegramToolProgressDraft(params: {
     scheduleQueuedSend();
   }
 
+  const freeze = () => {
+    frozen = true;
+    queuedText = undefined;
+    firstQueuedAt = 0;
+    clearQueuedTimers();
+    clearThinkingKeepAliveTimer();
+    clearTypingKeepAliveTimer();
+    inFlightAbortController?.abort();
+    inFlightAbortController = undefined;
+  };
+
   return {
     update: async (text: string): Promise<boolean> => {
-      if (stopped) {
+      if (stopped || frozen) {
         return false;
+      }
+      if (mode === "smooth-thinking") {
+        if (!hasSentDraft && !inFlight) {
+          sendNow("", { force: true });
+        }
+        return true;
       }
       const normalizedText = normalizeDraftText(text);
       if (!normalizedText) {
@@ -227,20 +380,17 @@ export function createNativeTelegramToolProgressDraft(params: {
       if (normalizedText === inFlightText || normalizedText === queuedText) {
         return true;
       }
-      if (!lastSentText && !inFlight) {
+      if (!hasSentDraft && !inFlight) {
         sendNow(normalizedText);
         return true;
       }
       queueSend(normalizedText);
       return true;
     },
+    freeze,
     stop: () => {
       stopped = true;
-      queuedText = undefined;
-      firstQueuedAt = 0;
-      clearQueuedTimers();
-      inFlightAbortController?.abort();
-      inFlightAbortController = undefined;
+      freeze();
     },
   };
 }

--- a/extensions/telegram/src/native-tool-progress-draft.ts
+++ b/extensions/telegram/src/native-tool-progress-draft.ts
@@ -3,6 +3,7 @@ import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { buildTelegramThreadParams, type TelegramThreadSpec } from "./bot/helpers.js";
 
 const TELEGRAM_NATIVE_DRAFT_MAX_CHARS = 4096;
+const TELEGRAM_NATIVE_DRAFT_MIN_UPDATE_INTERVAL_MS = 750;
 const TELEGRAM_DRAFT_ID_STATE_KEY = Symbol.for("openclaw.telegramNativeDraftIdState");
 
 type TelegramSendMessageDraft = (
@@ -14,6 +15,7 @@ type TelegramSendMessageDraft = (
     parse_mode?: "HTML";
     entities?: unknown[];
   },
+  signal?: AbortSignal,
 ) => Promise<unknown>;
 
 export type NativeTelegramToolProgressDraft = {
@@ -52,6 +54,7 @@ export function createNativeTelegramToolProgressDraft(params: {
   chatId: Parameters<Bot["api"]["sendMessage"]>[0];
   thread?: TelegramThreadSpec | null;
   log?: (message: string) => void;
+  minUpdateIntervalMs?: number;
 }): NativeTelegramToolProgressDraft | undefined {
   const sendMessageDraft = resolveSendMessageDraftApi(params.api);
   if (!sendMessageDraft) {
@@ -60,8 +63,97 @@ export function createNativeTelegramToolProgressDraft(params: {
 
   const draftId = allocateTelegramDraftId();
   const threadParams = buildTelegramThreadParams(params.thread) ?? {};
+  const rawMinUpdateIntervalMs =
+    params.minUpdateIntervalMs ?? TELEGRAM_NATIVE_DRAFT_MIN_UPDATE_INTERVAL_MS;
+  const minUpdateIntervalMs = Math.max(
+    0,
+    Math.trunc(
+      Number.isFinite(rawMinUpdateIntervalMs)
+        ? rawMinUpdateIntervalMs
+        : TELEGRAM_NATIVE_DRAFT_MIN_UPDATE_INTERVAL_MS,
+    ),
+  );
   let stopped = false;
   let lastSentText: string | undefined;
+  let lastSendStartedAt = 0;
+  let inFlight: Promise<boolean> | undefined;
+  let inFlightText: string | undefined;
+  let inFlightAbortController: AbortController | undefined;
+  let queuedText: string | undefined;
+  let queuedTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const clearQueuedTimer = () => {
+    if (queuedTimer !== undefined) {
+      clearTimeout(queuedTimer);
+      queuedTimer = undefined;
+    }
+  };
+
+  const sendNow = async (text: string): Promise<boolean> => {
+    const abortController = new AbortController();
+    try {
+      if (stopped) {
+        return false;
+      }
+      inFlightText = text;
+      inFlightAbortController = abortController;
+      lastSendStartedAt = Date.now();
+      inFlight = sendMessageDraft(
+        params.chatId,
+        draftId,
+        text,
+        Object.keys(threadParams).length > 0 ? threadParams : undefined,
+        abortController.signal,
+      ).then(() => true);
+      const sent = await inFlight;
+      if (stopped) {
+        return false;
+      }
+      lastSentText = text;
+      return sent;
+    } catch (err) {
+      if (stopped && abortController.signal.aborted) {
+        return false;
+      }
+      stopped = true;
+      queuedText = undefined;
+      clearQueuedTimer();
+      params.log?.(`telegram native tool-progress draft disabled: ${formatErrorMessage(err)}`);
+      return false;
+    } finally {
+      if (inFlightAbortController === abortController) {
+        inFlightAbortController = undefined;
+      }
+      inFlight = undefined;
+      inFlightText = undefined;
+      scheduleQueuedSend();
+    }
+  };
+
+  const flushQueuedSend = async (): Promise<boolean> => {
+    clearQueuedTimer();
+    if (stopped || inFlight || !queuedText) {
+      return false;
+    }
+    const nextText = queuedText;
+    queuedText = undefined;
+    if (nextText === lastSentText) {
+      return true;
+    }
+    return await sendNow(nextText);
+  };
+
+  function scheduleQueuedSend() {
+    if (stopped || inFlight || queuedTimer !== undefined || !queuedText) {
+      return;
+    }
+    const elapsedMs = lastSendStartedAt > 0 ? Date.now() - lastSendStartedAt : minUpdateIntervalMs;
+    const delayMs = Math.max(0, minUpdateIntervalMs - elapsedMs);
+    queuedTimer = setTimeout(() => {
+      queuedTimer = undefined;
+      void flushQueuedSend();
+    }, delayMs);
+  }
 
   return {
     update: async (text: string): Promise<boolean> => {
@@ -75,23 +167,22 @@ export function createNativeTelegramToolProgressDraft(params: {
       if (normalizedText === lastSentText) {
         return true;
       }
-      try {
-        await sendMessageDraft(
-          params.chatId,
-          draftId,
-          normalizedText,
-          Object.keys(threadParams).length > 0 ? threadParams : undefined,
-        );
-        lastSentText = normalizedText;
+      if (normalizedText === inFlightText || normalizedText === queuedText) {
         return true;
-      } catch (err) {
-        stopped = true;
-        params.log?.(`telegram native tool-progress draft disabled: ${formatErrorMessage(err)}`);
-        return false;
       }
+      if (!lastSentText && !inFlight) {
+        return await sendNow(normalizedText);
+      }
+      queuedText = normalizedText;
+      scheduleQueuedSend();
+      return true;
     },
     stop: () => {
       stopped = true;
+      queuedText = undefined;
+      clearQueuedTimer();
+      inFlightAbortController?.abort();
+      inFlightAbortController = undefined;
     },
   };
 }

--- a/extensions/telegram/src/native-tool-progress-draft.ts
+++ b/extensions/telegram/src/native-tool-progress-draft.ts
@@ -89,48 +89,48 @@ export function createNativeTelegramToolProgressDraft(params: {
     }
   };
 
-  const sendNow = async (text: string): Promise<boolean> => {
+  const sendNow = (text: string): void => {
     const abortController = new AbortController();
-    try {
-      if (stopped) {
-        return false;
-      }
-      inFlightText = text;
-      inFlightAbortController = abortController;
-      lastSendStartedAt = Date.now();
-      inFlight = sendMessageDraft(
-        params.chatId,
-        draftId,
-        text,
-        Object.keys(threadParams).length > 0 ? threadParams : undefined,
-        abortController.signal,
-      ).then(() => true);
-      const sent = await inFlight;
-      if (stopped) {
-        return false;
-      }
-      lastSentText = text;
-      return sent;
-    } catch (err) {
-      if (stopped && abortController.signal.aborted) {
-        return false;
-      }
-      stopped = true;
-      queuedText = undefined;
-      clearQueuedTimer();
-      params.log?.(`telegram native tool-progress draft disabled: ${formatErrorMessage(err)}`);
-      return false;
-    } finally {
-      if (inFlightAbortController === abortController) {
-        inFlightAbortController = undefined;
-      }
-      inFlight = undefined;
-      inFlightText = undefined;
-      scheduleQueuedSend();
+    if (stopped) {
+      return;
     }
+    inFlightText = text;
+    inFlightAbortController = abortController;
+    lastSendStartedAt = Date.now();
+    inFlight = sendMessageDraft(
+      params.chatId,
+      draftId,
+      text,
+      Object.keys(threadParams).length > 0 ? threadParams : undefined,
+      abortController.signal,
+    )
+      .then(() => {
+        if (!stopped) {
+          lastSentText = text;
+        }
+        return true;
+      })
+      .catch((err) => {
+        if (stopped && abortController.signal.aborted) {
+          return false;
+        }
+        stopped = true;
+        queuedText = undefined;
+        clearQueuedTimer();
+        params.log?.(`telegram native tool-progress draft disabled: ${formatErrorMessage(err)}`);
+        return false;
+      })
+      .finally(() => {
+        if (inFlightAbortController === abortController) {
+          inFlightAbortController = undefined;
+        }
+        inFlight = undefined;
+        inFlightText = undefined;
+        scheduleQueuedSend();
+      });
   };
 
-  const flushQueuedSend = async (): Promise<boolean> => {
+  const flushQueuedSend = (): boolean => {
     clearQueuedTimer();
     if (stopped || inFlight || !queuedText) {
       return false;
@@ -140,7 +140,8 @@ export function createNativeTelegramToolProgressDraft(params: {
     if (nextText === lastSentText) {
       return true;
     }
-    return await sendNow(nextText);
+    sendNow(nextText);
+    return true;
   };
 
   function scheduleQueuedSend() {
@@ -151,7 +152,7 @@ export function createNativeTelegramToolProgressDraft(params: {
     const delayMs = Math.max(0, minUpdateIntervalMs - elapsedMs);
     queuedTimer = setTimeout(() => {
       queuedTimer = undefined;
-      void flushQueuedSend();
+      flushQueuedSend();
     }, delayMs);
   }
 
@@ -171,7 +172,8 @@ export function createNativeTelegramToolProgressDraft(params: {
         return true;
       }
       if (!lastSentText && !inFlight) {
-        return await sendNow(normalizedText);
+        sendNow(normalizedText);
+        return true;
       }
       queuedText = normalizedText;
       scheduleQueuedSend();

--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -367,7 +367,7 @@ describe("handleToolExecutionEnd sessions_spawn progress", () => {
     const meta = requireString(event.data?.meta, "subagent meta");
     expect(title).not.toContain(rawSecret);
     expect(meta).not.toContain(rawSecret);
-    expect(title.length).toBeLessThanOrEqual(80);
+    expect(title.length).toBeLessThanOrEqual(120);
   });
 });
 

--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -280,6 +280,97 @@ describe("handleToolExecutionEnd cron.add commitment tracking", () => {
   });
 });
 
+describe("handleToolExecutionEnd sessions_spawn progress", () => {
+  it("emits a keyed subagent item when a subagent run is accepted", async () => {
+    const { ctx, onAgentEvent } = createTestContext();
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "sessions_spawn",
+        toolCallId: "tool-subagent-1",
+        args: {
+          label: "Worker A",
+          task: "inspect the diff",
+        },
+      } as never,
+    );
+
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "sessions_spawn",
+        toolCallId: "tool-subagent-1",
+        isError: false,
+        result: {
+          details: {
+            status: "accepted",
+            childSessionKey: "agent:main:subagent:child-1",
+            runId: "run-child-1",
+          },
+        },
+      } as never,
+    );
+
+    expect(onAgentEvent).toHaveBeenCalledWith({
+      stream: "item",
+      data: expect.objectContaining({
+        itemId: "subagent:agent:main:subagent:child-1",
+        phase: "start",
+        kind: "subagent",
+        status: "running",
+        name: "sessions_spawn",
+        meta: "Worker A: running",
+      }),
+    });
+    expect(ctx.state.itemActiveIds.has("subagent:agent:main:subagent:child-1")).toBe(true);
+  });
+
+  it("redacts task fallback text before emitting subagent start progress", async () => {
+    const { ctx, onAgentEvent } = createTestContext();
+    const rawSecret = "super-secret-token-1234567890";
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "sessions_spawn",
+        toolCallId: "tool-subagent-secret",
+        args: {
+          task: `inspect TOKEN=${rawSecret} before reporting`,
+        },
+      } as never,
+    );
+
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "sessions_spawn",
+        toolCallId: "tool-subagent-secret",
+        isError: false,
+        result: {
+          details: {
+            status: "accepted",
+            childSessionKey: "agent:main:subagent:child-secret",
+          },
+        },
+      } as never,
+    );
+
+    const event = requireEvent(
+      onAgentEvent.mock.calls.map(([payload]) => payload as CapturedAgentEvent),
+      (payload) => payload.stream === "item" && payload.data?.kind === "subagent",
+      "subagent progress",
+    );
+    const title = requireString(event.data?.title, "subagent title");
+    const meta = requireString(event.data?.meta, "subagent meta");
+    expect(title).not.toContain(rawSecret);
+    expect(meta).not.toContain(rawSecret);
+    expect(title.length).toBeLessThanOrEqual(80);
+  });
+});
+
 describe("handleToolExecutionEnd mutating failure recovery", () => {
   it("clears edit failure when the retry succeeds through common file path aliases", async () => {
     const { ctx } = createTestContext();

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -44,6 +44,10 @@ import {
   sanitizeToolResult,
 } from "./pi-embedded-subscribe.tools.js";
 import { inferToolMetaFromArgs } from "./pi-embedded-utils.js";
+import {
+  buildSubagentProgressSummary,
+  resolveSubagentProgressLabel,
+} from "./subagent-progress-label.js";
 import { buildToolMutationState, isSameToolMutationAction } from "./tool-mutation.js";
 import { normalizeToolName } from "./tool-policy.js";
 
@@ -183,6 +187,35 @@ function readToolResultDetailsRecord(result: unknown): Record<string, unknown> |
   return details && typeof details === "object" && !Array.isArray(details)
     ? (details as Record<string, unknown>)
     : undefined;
+}
+
+function buildSubagentSpawnItemData(params: {
+  toolCallId: string;
+  args: Record<string, unknown>;
+  result: unknown;
+  startedAt?: number;
+}): AgentItemEventData | undefined {
+  const details = readToolResultDetailsRecord(params.result);
+  if (!details || readStringValue(details.status) !== "accepted") {
+    return undefined;
+  }
+  const childSessionKey = readStringValue(details.childSessionKey);
+  const childRunId = readStringValue(details.runId);
+  const label = readStringValue(params.args.label);
+  const taskName = readStringValue(params.args.taskName);
+  const task = readStringValue(params.args.task);
+  const title = resolveSubagentProgressLabel([label, taskName, task]);
+  return {
+    itemId: `subagent:${childSessionKey ?? childRunId ?? params.toolCallId}`,
+    phase: "start",
+    kind: "subagent",
+    title,
+    status: "running",
+    name: "sessions_spawn",
+    meta: buildSubagentProgressSummary({ label: title, statusLabel: "running" }),
+    toolCallId: params.toolCallId,
+    startedAt: params.startedAt,
+  };
 }
 
 function readExecToolDetails(result: unknown): ExecToolDetails | null {
@@ -1051,6 +1084,17 @@ export async function handleToolExecutionEnd(
       : {}),
   };
   emitTrackedItemEvent(ctx, itemData);
+  if (!isToolError && toolName === "sessions_spawn") {
+    const subagentItemData = buildSubagentSpawnItemData({
+      toolCallId,
+      args: startArgs,
+      result: sanitizedResult,
+      startedAt: startData?.startTime,
+    });
+    if (subagentItemData) {
+      emitTrackedItemEvent(ctx, subagentItemData);
+    }
+  }
   void ctx.params.onAgentEvent?.({
     stream: "tool",
     data: {

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
@@ -590,6 +590,109 @@ describe("subscribeEmbeddedPiSession", () => {
     });
   });
 
+  it("surfaces subagent completion internal events as transient item progress", () => {
+    const onAgentEvent = vi.fn();
+    createSubscribedHarness({
+      runId: "run",
+      sessionKey: "agent:main:telegram:dm",
+      onAgentEvent,
+      internalEvents: [
+        {
+          type: "task_completion",
+          source: "subagent",
+          childSessionKey: "agent:main:subagent:child-1",
+          announceType: "subagent task",
+          taskLabel: "Worker A",
+          status: "ok",
+          statusLabel: "completed; ready for parent review",
+          result: "done",
+          replyInstruction: "Reply normally.",
+        },
+      ],
+    });
+
+    expect(onAgentEvent).toHaveBeenCalledWith({
+      stream: "item",
+      sessionKey: "agent:main:telegram:dm",
+      data: {
+        itemId: "subagent:agent:main:subagent:child-1",
+        phase: "end",
+        kind: "subagent",
+        title: "Worker A",
+        status: "completed",
+        name: "sessions_spawn",
+        summary: "Worker A: completed; ready for parent review",
+      },
+    });
+  });
+
+  it("does not report unknown subagent completions as successful progress", () => {
+    const onAgentEvent = vi.fn();
+    createSubscribedHarness({
+      runId: "run",
+      sessionKey: "agent:main:telegram:dm",
+      onAgentEvent,
+      internalEvents: [
+        {
+          type: "task_completion",
+          source: "subagent",
+          childSessionKey: "agent:main:subagent:child-unknown",
+          announceType: "subagent task",
+          taskLabel: "Worker B",
+          status: "unknown",
+          statusLabel: "finished with unknown status",
+          result: "unknown",
+          replyInstruction: "Reply normally.",
+        },
+      ],
+    });
+
+    expect(onAgentEvent).toHaveBeenCalledWith({
+      stream: "item",
+      sessionKey: "agent:main:telegram:dm",
+      data: expect.objectContaining({
+        itemId: "subagent:agent:main:subagent:child-unknown",
+        phase: "end",
+        kind: "subagent",
+        title: "Worker B",
+        status: "blocked",
+        summary: "Worker B: finished with unknown status",
+      }),
+    });
+  });
+
+  it("redacts subagent completion labels before transient item progress", () => {
+    const onAgentEvent = vi.fn();
+    const rawSecret = "super-secret-token-1234567890";
+    createSubscribedHarness({
+      runId: "run",
+      sessionKey: "agent:main:telegram:dm",
+      onAgentEvent,
+      internalEvents: [
+        {
+          type: "task_completion",
+          source: "subagent",
+          childSessionKey: "agent:main:subagent:child-secret",
+          announceType: "subagent task",
+          taskLabel: `inspect TOKEN=${rawSecret}`,
+          status: "ok",
+          statusLabel: `completed with TOKEN=${rawSecret}`,
+          result: "done",
+          replyInstruction: "Reply normally.",
+        },
+      ],
+    });
+
+    const payload = onAgentEvent.mock.calls[0]?.[0] as
+      | { data?: { title?: unknown; summary?: unknown } }
+      | undefined;
+    expect(payload?.data?.title).toEqual(expect.any(String));
+    expect(payload?.data?.summary).toEqual(expect.any(String));
+    expect(payload?.data?.title).not.toContain(rawSecret);
+    expect(payload?.data?.summary).not.toContain(rawSecret);
+    expect(String(payload?.data?.title).length).toBeLessThanOrEqual(80);
+  });
+
   it.each([
     {
       label: "music",

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
@@ -690,7 +690,7 @@ describe("subscribeEmbeddedPiSession", () => {
     expect(payload?.data?.summary).toEqual(expect.any(String));
     expect(payload?.data?.title).not.toContain(rawSecret);
     expect(payload?.data?.summary).not.toContain(rawSecret);
-    expect(String(payload?.data?.title).length).toBeLessThanOrEqual(80);
+    expect(String(payload?.data?.title).length).toBeLessThanOrEqual(120);
   });
 
   it.each([

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -43,6 +43,10 @@ import { isPromiseLike } from "./pi-embedded-subscribe.promise.js";
 import { filterToolResultMediaUrls } from "./pi-embedded-subscribe.tools.js";
 import type { SubscribeEmbeddedPiSessionParams } from "./pi-embedded-subscribe.types.js";
 import { stripDowngradedToolCallText, THINKING_TAG_SCAN_RE } from "./pi-embedded-utils.js";
+import {
+  buildSubagentProgressSummary,
+  resolveSubagentProgressLabel,
+} from "./subagent-progress-label.js";
 import { hasNonzeroUsage, normalizeUsage, type UsageLike } from "./usage.js";
 
 const STREAM_STRIPPED_BLOCK_TAG_NAMES = [
@@ -115,6 +119,55 @@ function collectPendingMediaFromInternalEvents(
     }
   }
   return pending;
+}
+
+function normalizeInternalTaskCompletionStatus(status: string) {
+  switch (status) {
+    case "ok":
+      return "completed";
+    case "timeout":
+    case "error":
+      return "failed";
+    case "unknown":
+      return "blocked";
+    default:
+      return "blocked";
+  }
+}
+
+function emitInternalTaskCompletionProgress(params: SubscribeEmbeddedPiSessionParams): void {
+  const events = params.internalEvents?.filter(
+    (event) => event.type === "task_completion" && event.source === "subagent",
+  );
+  if (!events?.length) {
+    return;
+  }
+  for (const event of events) {
+    const title = resolveSubagentProgressLabel([event.taskLabel]);
+    const data = {
+      itemId: `subagent:${event.childSessionKey}`,
+      phase: "end",
+      kind: "subagent",
+      title,
+      status: normalizeInternalTaskCompletionStatus(event.status),
+      name: "sessions_spawn",
+      summary: buildSubagentProgressSummary({
+        label: event.taskLabel,
+        statusLabel: event.statusLabel,
+      }),
+    };
+    emitAgentEvent({
+      runId: params.runId,
+      stream: "item",
+      data,
+      ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+    });
+    void params.onAgentEvent?.({
+      stream: "item",
+      data,
+      ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+    });
+  }
 }
 
 export type { SubscribeEmbeddedPiSessionParams } from "./pi-embedded-subscribe.types.js";
@@ -214,6 +267,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
   const pendingBlockReplyTasks = new Set<Promise<void>>();
   const replyDirectiveAccumulator = createStreamingDirectiveAccumulator();
   const partialReplyDirectiveAccumulator = createStreamingDirectiveAccumulator();
+  emitInternalTaskCompletionProgress(params);
   const shouldAllowSilentTurnText = (text: string | undefined) =>
     Boolean(text && isSilentReplyText(text, SILENT_REPLY_TOKEN));
   const emitBlockReplySafely = (

--- a/src/agents/subagent-progress-label.ts
+++ b/src/agents/subagent-progress-label.ts
@@ -1,8 +1,8 @@
 import { redactToolDetail } from "../logging/redact.js";
 import { truncateUtf16Safe } from "../utils.js";
 
-const SUBAGENT_PROGRESS_LABEL_MAX_CHARS = 80;
-const SUBAGENT_PROGRESS_STATUS_MAX_CHARS = 140;
+const SUBAGENT_PROGRESS_LABEL_MAX_CHARS = 120;
+const SUBAGENT_PROGRESS_STATUS_MAX_CHARS = 220;
 
 function sanitizeSubagentProgressText(
   value: string | undefined,

--- a/src/agents/subagent-progress-label.ts
+++ b/src/agents/subagent-progress-label.ts
@@ -1,0 +1,46 @@
+import { redactToolDetail } from "../logging/redact.js";
+import { truncateUtf16Safe } from "../utils.js";
+
+const SUBAGENT_PROGRESS_LABEL_MAX_CHARS = 80;
+const SUBAGENT_PROGRESS_STATUS_MAX_CHARS = 140;
+
+function sanitizeSubagentProgressText(
+  value: string | undefined,
+  maxChars: number,
+): string | undefined {
+  const compact = value?.replace(/\s+/g, " ").trim();
+  if (!compact) {
+    return undefined;
+  }
+  const redacted = redactToolDetail(compact).replace(/\s+/g, " ").trim();
+  if (!redacted) {
+    return undefined;
+  }
+  return truncateUtf16Safe(redacted, maxChars);
+}
+
+export function sanitizeSubagentProgressLabel(value: string | undefined): string | undefined {
+  return sanitizeSubagentProgressText(value, SUBAGENT_PROGRESS_LABEL_MAX_CHARS);
+}
+
+export function resolveSubagentProgressLabel(candidates: readonly (string | undefined)[]): string {
+  for (const candidate of candidates) {
+    const label = sanitizeSubagentProgressLabel(candidate);
+    if (label) {
+      return label;
+    }
+  }
+  return "Sub-agent";
+}
+
+export function buildSubagentProgressSummary(params: {
+  label: string | undefined;
+  statusLabel: string | undefined;
+}): string {
+  const label = sanitizeSubagentProgressLabel(params.label) ?? "Sub-agent";
+  const status = sanitizeSubagentProgressText(
+    params.statusLabel,
+    SUBAGENT_PROGRESS_STATUS_MAX_CHARS,
+  );
+  return status ? `${label}: ${status}` : label;
+}

--- a/src/plugin-sdk/channel-streaming.test.ts
+++ b/src/plugin-sdk/channel-streaming.test.ts
@@ -453,6 +453,30 @@ describe("channel-streaming", () => {
     expect(
       formatChannelProgressDraftLine({
         event: "item",
+        itemId: "subagent:1",
+        itemKind: "subagent",
+        meta: "Worker A: running",
+      }),
+    ).toBe("🧑‍🔧 Sub-agent: Worker A: running");
+    expect(
+      formatChannelProgressDraftLine({
+        event: "item",
+        itemId: "subagent:1",
+        itemKind: "subagent",
+        progressText: "Worker A: completed; ready for parent review",
+      }),
+    ).toBe("🧑‍🔧 Sub-agent: Worker A: completed; ready for parent review");
+    expect(
+      buildChannelProgressDraftLine({
+        event: "item",
+        itemId: "subagent:1",
+        itemKind: "subagent",
+        progressText: "Worker A running",
+      })?.id,
+    ).toBe("subagent:1");
+    expect(
+      formatChannelProgressDraftLine({
+        event: "item",
         itemKind: "analysis",
         title: "Reasoning",
       }),

--- a/src/plugin-sdk/channel-streaming.ts
+++ b/src/plugin-sdk/channel-streaming.ts
@@ -293,6 +293,7 @@ function buildNamedProgressLine(
   metas: readonly (string | undefined | null)[] | undefined,
   options?: ChannelProgressLineOptions,
   fields?: {
+    id?: string;
     status?: string;
   },
 ): ChannelProgressDraftLine | undefined {
@@ -311,6 +312,7 @@ function buildNamedProgressLine(
     ? text.slice(prefix.length + 2).trim()
     : compactCommandPrefix;
   return {
+    ...(fields?.id ? { id: fields.id } : {}),
     kind,
     text,
     label: display.label,
@@ -329,6 +331,8 @@ function itemKindToToolName(kind: string | undefined): string | undefined {
       return "apply_patch";
     case "search":
       return "web_search";
+    case "subagent":
+      return "sessions_spawn";
     case "tool":
       return "tool_call";
     default:
@@ -433,6 +437,7 @@ export function buildChannelProgressDraftLine(
       }
       if (name) {
         return buildNamedProgressLine(input.event, name, [meta], options, {
+          id: input.itemId,
           status: input.status,
         });
       }


### PR DESCRIPTION
## Summary

- surfaces accepted `sessions_spawn` work as keyed transient sub-agent progress items
- converts subagent completion internal events into transient progress updates
- redacts and caps subagent labels/status summaries before they can reach channel progress drafts
- maps `subagent` progress items to the existing `sessions_spawn` display entry so Telegram native draft previews can render them
- smooths Telegram native tool-progress drafts by coalescing rapid updates, skipping empty `Working`-only drafts, aborting in-flight native draft requests during teardown, keeping slow native draft sends off the final-answer delivery path, and reducing visible draft-field rebuild/flicker during long checks

## Boundary / safety

- Draft PR intentionally stays draft.
- Follow-up to merged Telegram native draft lane from #83622.
- Native Telegram progress drafts stay default-off and DM-only behind `preview.nativeToolProgress` plus optional `preview.nativeToolProgressAllowFrom`.
- Final answers, media, errors, buttons, and approvals stay on the normal durable Telegram send path.
- Native draft failures fall back/no-op without blocking final delivery; rollback is disabling `preview.nativeToolProgress`.

## Current status

- Branch head: `c1a3135767`
- PR state: draft, open, mergeable in the latest GitHub check
- Last rebased merge base: `aef93881af`
- Current local `origin/main` observed after that rebase: `5e0850fc54`; final rebase is still pending before marking ready for review.
- Pending maintainer proof: real Telegram DM/native draft video or equivalent visible behavior proof showing no duplicate progress bubble, reduced draft-field rebuild/flicker during long checks, no draft-field flicker after final delivery, and no final-answer delay from slow native draft sends.

## Validation

Latest local validation:

- `git diff --check origin/main...HEAD`
- `node scripts/run-vitest.mjs extensions/telegram/src/native-tool-progress-draft.test.ts extensions/telegram/src/bot-message-dispatch.test.ts src/plugin-sdk/channel-streaming.test.ts src/agents/pi-embedded-subscribe.handlers.tools.test.ts src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts`
- Result: 7 test files / 274 tests passed

Earlier runtime smoke from this branch's runtime code path:

- `CI=true node scripts/tsdown-build.mjs && node scripts/runtime-postbuild.mjs && node scripts/build-stamp.mjs && node scripts/runtime-postbuild-stamp.mjs`
- `openclaw gateway status --deep --require-rpc`
- `openclaw gateway health --json`

## Maintainer notes

- This PR is scoped to subagent/sessions progress routing plus Telegram native draft lifecycle behavior.
- No final answer text is moved into native drafts.
- The main remaining risk is user-visible Telegram client behavior, so the PR should stay draft until the DM/native draft proof is captured against a test bot or equivalent controlled setup.
