### PR TITLE
fix(cli): include loopback tools in cli prompts

### DIFF
--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -511,6 +511,9 @@ export async function runPreparedCliAgent(
                   ...(context.extraSystemPromptHash
                     ? { extraSystemPromptHash: context.extraSystemPromptHash }
                     : {}),
+                  ...(context.promptToolNamesHash
+                    ? { promptToolNamesHash: context.promptToolNamesHash }
+                    : {}),
                   ...(context.preparedBackend.mcpConfigHash
                     ? { mcpConfigHash: context.preparedBackend.mcpConfigHash }
                     : {}),

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -279,6 +279,7 @@ function buildClaudeLiveFingerprint(params: {
       : undefined,
     authEpochHash: params.context.authEpoch ? sha256(params.context.authEpoch) : undefined,
     extraSystemPromptHash: params.context.extraSystemPromptHash,
+    promptToolNamesHash: params.context.promptToolNamesHash,
     mcpConfigHash: params.context.preparedBackend.mcpConfigHash,
     skillsFingerprint,
     argv: stableArgv,

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../../context-engine/registry.js";
 import type { ContextEngine } from "../../context-engine/types.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
+import { clearMemoryPluginState, registerMemoryPromptSection } from "../../plugins/memory-state.js";
 import { testing as cliBackendsTesting } from "../cli-backends.js";
 import { hashCliSessionText } from "../cli-session.js";
 import { buildActiveImageGenerationTaskPromptContextForSession } from "../image-generation-task-status.js";
@@ -197,6 +198,7 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
       getActiveMcpLoopbackRuntime: vi.fn(() => undefined),
       ensureMcpLoopbackServer: vi.fn(createTestMcpLoopbackServer),
       createMcpLoopbackServerConfig: vi.fn(createTestMcpLoopbackServerConfig),
+      resolveMcpLoopbackScopedTools: vi.fn(() => ({ agentId: "main", tools: [] })),
       resolveOpenClawReferencePaths: vi.fn(async () => ({ docsPath: null, sourcePath: null })),
     });
     mockGetGlobalHookRunner.mockReturnValue(null);
@@ -213,6 +215,7 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
     mockBuildActiveImageGenerationTaskPromptContextForSession.mockReset();
     mockBuildActiveVideoGenerationTaskPromptContextForSession.mockReset();
     mockBuildActiveMusicGenerationTaskPromptContextForSession.mockReset();
+    clearMemoryPluginState();
     vi.unstubAllEnvs();
   });
 
@@ -982,6 +985,99 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
       expect(context.preparedBackend.mcpConfigHash).toBeUndefined();
       expect(context.preparedBackend.env).toBeUndefined();
       expect(context.preparedBackend.backend.args).toEqual(["--print"]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("uses loopback-scoped tools when building bundled MCP CLI prompts", async () => {
+    const { dir, sessionFile } = createSessionFile();
+    try {
+      registerMemoryPromptSection(({ availableTools }) =>
+        availableTools.has("memory_search")
+          ? ["## Memory Recall", `tools=${[...availableTools].toSorted().join(",")}`, ""]
+          : [],
+      );
+      const getActiveMcpLoopbackRuntime = vi.fn(() => ({
+        port: 31783,
+        ownerToken: "owner-token",
+        nonOwnerToken: "non-owner-token",
+      }));
+      const ensureMcpLoopbackServer = vi.fn(createTestMcpLoopbackServer);
+      const createMcpLoopbackServerConfig = vi.fn(createTestMcpLoopbackServerConfig);
+      const resolveMcpLoopbackScopedTools = vi.fn(() => ({
+        agentId: "main",
+        tools: [
+          {
+            name: "memory_search",
+            label: "Memory Search",
+            description: "Search memory",
+            parameters: { type: "object", properties: {} },
+            execute: vi.fn(),
+          },
+        ],
+      }));
+      setCliRunnerPrepareTestDeps({
+        getActiveMcpLoopbackRuntime,
+        ensureMcpLoopbackServer,
+        createMcpLoopbackServerConfig,
+        resolveMcpLoopbackScopedTools,
+      });
+      cliBackendsTesting.setDepsForTest({
+        resolvePluginSetupCliBackend: () => undefined,
+        resolveRuntimeCliBackends: () => [
+          {
+            id: "native-cli",
+            pluginId: "native-plugin",
+            bundleMcp: true,
+            bundleMcpMode: "claude-config-file",
+            config: {
+              command: "native-cli",
+              args: ["--print"],
+              systemPromptArg: "--system-prompt",
+              systemPromptWhen: "first",
+              output: "text",
+              input: "arg",
+              sessionMode: "existing",
+            },
+          },
+        ],
+      });
+
+      const context = await prepareCliRunContext({
+        sessionId: "session-test",
+        sessionKey: "agent:main:test",
+        sessionFile,
+        workspaceDir: dir,
+        prompt: "latest ask",
+        provider: "native-cli",
+        model: "test-model",
+        timeoutMs: 1_000,
+        runId: "run-test-loopback-prompt-tools",
+        config: createCliBackendConfig({ bundleMcp: true, systemPromptOverride: null }),
+        cliSessionBinding: {
+          sessionId: "cli-session",
+          promptToolNamesHash: "old-tool-surface",
+        },
+      });
+
+      expect(resolveMcpLoopbackScopedTools).toHaveBeenCalledWith({
+        cfg: expect.any(Object),
+        sessionKey: "agent:main:test",
+        messageProvider: undefined,
+        accountId: undefined,
+        inboundEventKind: undefined,
+        senderIsOwner: undefined,
+      });
+      expect(context.systemPrompt).toContain("## Memory Recall");
+      expect(context.systemPrompt).toContain("tools=memory_search");
+      expect(context.systemPromptReport.tools.entries.map((entry) => entry.name)).toEqual([
+        "memory_search",
+      ]);
+      expect(context.promptToolNamesHash).toBe(
+        hashCliSessionText(JSON.stringify(["memory_search"])),
+      );
+      expect(context.reusableCliSession).toEqual({ invalidatedReason: "system-prompt" });
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -1083,6 +1083,85 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
     }
   });
 
+  it("does not advertise loopback prompt tools when the runtime is unavailable", async () => {
+    const { dir, sessionFile } = createSessionFile();
+    try {
+      registerMemoryPromptSection(({ availableTools }) =>
+        availableTools.has("memory_search")
+          ? ["## Memory Recall", `tools=${[...availableTools].toSorted().join(",")}`, ""]
+          : [],
+      );
+      const getActiveMcpLoopbackRuntime = vi.fn(() => undefined);
+      const ensureMcpLoopbackServer = vi.fn(async () => {
+        throw new Error("loopback unavailable");
+      });
+      const createMcpLoopbackServerConfig = vi.fn(createTestMcpLoopbackServerConfig);
+      const resolveMcpLoopbackScopedTools = vi.fn(() => ({
+        agentId: "main",
+        tools: [
+          {
+            name: "memory_search",
+            label: "Memory Search",
+            description: "Search memory",
+            parameters: { type: "object", properties: {} },
+            execute: vi.fn(),
+          },
+        ],
+      }));
+      setCliRunnerPrepareTestDeps({
+        getActiveMcpLoopbackRuntime,
+        ensureMcpLoopbackServer,
+        createMcpLoopbackServerConfig,
+        resolveMcpLoopbackScopedTools,
+      });
+      cliBackendsTesting.setDepsForTest({
+        resolvePluginSetupCliBackend: () => undefined,
+        resolveRuntimeCliBackends: () => [
+          {
+            id: "native-cli",
+            pluginId: "native-plugin",
+            bundleMcp: true,
+            bundleMcpMode: "claude-config-file",
+            config: {
+              command: "native-cli",
+              args: ["--print"],
+              systemPromptArg: "--system-prompt",
+              systemPromptWhen: "first",
+              output: "text",
+              input: "arg",
+              sessionMode: "existing",
+            },
+          },
+        ],
+      });
+
+      const context = await prepareCliRunContext({
+        sessionId: "session-test",
+        sessionKey: "agent:main:test",
+        sessionFile,
+        workspaceDir: dir,
+        prompt: "latest ask",
+        provider: "native-cli",
+        model: "test-model",
+        timeoutMs: 1_000,
+        runId: "run-test-loopback-prompt-tools-fallback",
+        config: createCliBackendConfig({ bundleMcp: true, systemPromptOverride: null }),
+      });
+
+      expect(ensureMcpLoopbackServer).toHaveBeenCalledTimes(1);
+      expect(getActiveMcpLoopbackRuntime).toHaveBeenCalledTimes(2);
+      expect(createMcpLoopbackServerConfig).not.toHaveBeenCalled();
+      expect(resolveMcpLoopbackScopedTools).not.toHaveBeenCalled();
+      expect(context.systemPrompt).not.toContain("## Memory Recall");
+      expect(context.systemPrompt).not.toContain("memory_search");
+      expect(context.systemPromptReport.tools.entries).toEqual([]);
+      expect(context.promptToolNamesHash).toBeUndefined();
+      expect(context.preparedBackend.env).toBeUndefined();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("passes current turn kind into bundle MCP loopback env", async () => {
     const { dir, sessionFile } = createSessionFile();
     try {

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -6,6 +6,7 @@ import {
   createMcpLoopbackServerConfig,
   getActiveMcpLoopbackRuntime,
 } from "../../gateway/mcp-http.loopback-runtime.js";
+import { resolveMcpLoopbackScopedTools } from "../../gateway/mcp-http.runtime.js";
 import { isClaudeCliProvider } from "../../plugin-sdk/anthropic-cli.js";
 import type {
   CliBackendAuthEpochMode,
@@ -67,6 +68,7 @@ const prepareDeps = {
   getActiveMcpLoopbackRuntime,
   ensureMcpLoopbackServer,
   createMcpLoopbackServerConfig,
+  resolveMcpLoopbackScopedTools,
   resolveOpenClawReferencePaths: async (
     params: Parameters<typeof import("../docs-path.js").resolveOpenClawReferencePaths>[0],
   ) => (await import("../docs-path.js")).resolveOpenClawReferencePaths(params),
@@ -282,6 +284,19 @@ export async function prepareCliRunContext(
     ...(preparedBackendEnv ? { env: preparedBackendEnv } : {}),
     ...(preparedBackendCleanup ? { cleanup: preparedBackendCleanup } : {}),
   };
+  const promptTools = bundleMcpEnabled
+    ? prepareDeps.resolveMcpLoopbackScopedTools({
+        cfg: params.config ?? getRuntimeConfig(),
+        sessionKey: params.sessionKey ?? "",
+        messageProvider: params.messageChannel ?? params.messageProvider,
+        accountId: params.agentAccountId,
+        inboundEventKind: params.currentInboundEventKind,
+        senderIsOwner: params.senderIsOwner,
+      }).tools
+    : [];
+  const promptToolNamesHash = bundleMcpEnabled
+    ? hashCliSessionText(JSON.stringify(promptTools.map((tool) => tool.name).toSorted()))
+    : undefined;
   // Pre-flight: if a saved Claude CLI sessionId points at a transcript that no
   // longer exists on disk (e.g. update.run aborted mid-swap, Claude CLI was
   // reinstalled, or the projects tree was manually pruned), `claude --resume`
@@ -306,6 +321,7 @@ export async function prepareCliRunContext(
           authEpoch,
           authEpochVersion: CLI_AUTH_EPOCH_VERSION,
           extraSystemPromptHash,
+          promptToolNamesHash,
           mcpConfigHash: preparedBackendFinal.mcpConfigHash,
           mcpResumeHash: preparedBackendFinal.mcpResumeHash,
         })
@@ -362,7 +378,7 @@ export async function prepareCliRunContext(
       docsPath: openClawReferences.docsPath ?? undefined,
       sourcePath: openClawReferences.sourcePath ?? undefined,
       skillsPrompt,
-      tools: [],
+      tools: promptTools,
       contextFiles,
       modelDisplay,
       agentId: sessionAgentId,
@@ -471,7 +487,7 @@ export async function prepareCliRunContext(
     bootstrapFiles,
     injectedFiles: contextFiles,
     skillsPrompt,
-    tools: [],
+    tools: promptTools,
     currentTurn: {
       ...(params.currentInboundEventKind ? { kind: params.currentInboundEventKind } : {}),
       promptChars: preparedPrompt.length,
@@ -530,6 +546,7 @@ export async function prepareCliRunContext(
       authEpoch,
       authEpochVersion: CLI_AUTH_EPOCH_VERSION,
       extraSystemPromptHash,
+      promptToolNamesHash,
     };
   } catch (err) {
     try {

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -284,19 +284,21 @@ export async function prepareCliRunContext(
     ...(preparedBackendEnv ? { env: preparedBackendEnv } : {}),
     ...(preparedBackendCleanup ? { cleanup: preparedBackendCleanup } : {}),
   };
-  const promptTools = bundleMcpEnabled
-    ? prepareDeps.resolveMcpLoopbackScopedTools({
-        cfg: params.config ?? getRuntimeConfig(),
-        sessionKey: params.sessionKey ?? "",
-        messageProvider: params.messageChannel ?? params.messageProvider,
-        accountId: params.agentAccountId,
-        inboundEventKind: params.currentInboundEventKind,
-        senderIsOwner: params.senderIsOwner,
-      }).tools
-    : [];
-  const promptToolNamesHash = bundleMcpEnabled
-    ? hashCliSessionText(JSON.stringify(promptTools.map((tool) => tool.name).toSorted()))
-    : undefined;
+  const promptTools =
+    bundleMcpEnabled && mcpLoopbackRuntime
+      ? prepareDeps.resolveMcpLoopbackScopedTools({
+          cfg: params.config ?? getRuntimeConfig(),
+          sessionKey: params.sessionKey ?? "",
+          messageProvider: params.messageChannel ?? params.messageProvider,
+          accountId: params.agentAccountId,
+          inboundEventKind: params.currentInboundEventKind,
+          senderIsOwner: params.senderIsOwner,
+        }).tools
+      : [];
+  const promptToolNamesHash =
+    bundleMcpEnabled && mcpLoopbackRuntime
+      ? hashCliSessionText(JSON.stringify(promptTools.map((tool) => tool.name).toSorted()))
+      : undefined;
   // Pre-flight: if a saved Claude CLI sessionId points at a transcript that no
   // longer exists on disk (e.g. update.run aborted mid-swap, Claude CLI was
   // reinstalled, or the projects tree was manually pruned), `claude --resume`

--- a/src/agents/cli-runner/types.ts
+++ b/src/agents/cli-runner/types.ts
@@ -132,4 +132,5 @@ export type PreparedCliRunContext = {
   authEpoch?: string;
   authEpochVersion: number;
   extraSystemPromptHash?: string;
+  promptToolNamesHash?: string;
 };

--- a/src/agents/cli-session.test.ts
+++ b/src/agents/cli-session.test.ts
@@ -23,6 +23,7 @@ describe("cli-session helpers", () => {
       authEpoch: "auth-epoch",
       authEpochVersion: 2,
       extraSystemPromptHash: "prompt-hash",
+      promptToolNamesHash: "prompt-tools-hash",
       mcpConfigHash: "mcp-hash",
       mcpResumeHash: "mcp-resume-hash",
     });
@@ -36,6 +37,7 @@ describe("cli-session helpers", () => {
       authEpoch: "auth-epoch",
       authEpochVersion: 2,
       extraSystemPromptHash: "prompt-hash",
+      promptToolNamesHash: "prompt-tools-hash",
       mcpConfigHash: "mcp-hash",
       mcpResumeHash: "mcp-resume-hash",
     });
@@ -151,6 +153,17 @@ describe("cli-session helpers", () => {
         authEpoch: "auth-epoch-a",
         authEpochVersion: 2,
         extraSystemPromptHash: "prompt-b",
+        mcpConfigHash: "mcp-a",
+      }),
+    ).toEqual({ invalidatedReason: "system-prompt" });
+    expect(
+      resolveCliSessionReuse({
+        binding,
+        authProfileId: "anthropic:work",
+        authEpoch: "auth-epoch-a",
+        authEpochVersion: 2,
+        extraSystemPromptHash: "prompt-a",
+        promptToolNamesHash: "prompt-tools-b",
         mcpConfigHash: "mcp-a",
       }),
     ).toEqual({ invalidatedReason: "system-prompt" });

--- a/src/agents/cli-session.ts
+++ b/src/agents/cli-session.ts
@@ -31,6 +31,7 @@ export function getCliSessionBinding(
       authEpoch: normalizeOptionalString(fromBindings?.authEpoch),
       authEpochVersion: fromBindings?.authEpochVersion,
       extraSystemPromptHash: normalizeOptionalString(fromBindings?.extraSystemPromptHash),
+      promptToolNamesHash: normalizeOptionalString(fromBindings?.promptToolNamesHash),
       mcpConfigHash: normalizeOptionalString(fromBindings?.mcpConfigHash),
       mcpResumeHash: normalizeOptionalString(fromBindings?.mcpResumeHash),
     };
@@ -87,6 +88,9 @@ export function setCliSessionBinding(
       ...(normalizeOptionalString(binding.extraSystemPromptHash)
         ? { extraSystemPromptHash: normalizeOptionalString(binding.extraSystemPromptHash) }
         : {}),
+      ...(normalizeOptionalString(binding.promptToolNamesHash)
+        ? { promptToolNamesHash: normalizeOptionalString(binding.promptToolNamesHash) }
+        : {}),
       ...(normalizeOptionalString(binding.mcpConfigHash)
         ? { mcpConfigHash: normalizeOptionalString(binding.mcpConfigHash) }
         : {}),
@@ -130,6 +134,7 @@ export function resolveCliSessionReuse(params: {
   authEpoch?: string;
   authEpochVersion: number;
   extraSystemPromptHash?: string;
+  promptToolNamesHash?: string;
   mcpConfigHash?: string;
   mcpResumeHash?: string;
 }): {
@@ -147,6 +152,7 @@ export function resolveCliSessionReuse(params: {
   const currentAuthProfileId = normalizeOptionalString(params.authProfileId);
   const currentAuthEpoch = normalizeOptionalString(params.authEpoch);
   const currentExtraSystemPromptHash = normalizeOptionalString(params.extraSystemPromptHash);
+  const currentPromptToolNamesHash = normalizeOptionalString(params.promptToolNamesHash);
   const currentMcpConfigHash = normalizeOptionalString(params.mcpConfigHash);
   const currentMcpResumeHash = normalizeOptionalString(params.mcpResumeHash);
   const storedAuthProfileId = normalizeOptionalString(binding?.authProfileId);
@@ -169,6 +175,10 @@ export function resolveCliSessionReuse(params: {
   }
   const storedExtraSystemPromptHash = normalizeOptionalString(binding?.extraSystemPromptHash);
   if (storedExtraSystemPromptHash !== currentExtraSystemPromptHash) {
+    return { invalidatedReason: "system-prompt" };
+  }
+  const storedPromptToolNamesHash = normalizeOptionalString(binding?.promptToolNamesHash);
+  if (storedPromptToolNamesHash !== currentPromptToolNamesHash) {
     return { invalidatedReason: "system-prompt" };
   }
   const storedMcpResumeHash = normalizeOptionalString(binding?.mcpResumeHash);

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -78,6 +78,7 @@ export type CliSessionBinding = {
   authEpoch?: string;
   authEpochVersion?: number;
   extraSystemPromptHash?: string;
+  promptToolNamesHash?: string;
   mcpConfigHash?: string;
   mcpResumeHash?: string;
 };

--- a/src/gateway/mcp-http.runtime.ts
+++ b/src/gateway/mcp-http.runtime.ts
@@ -19,6 +19,30 @@ type CachedScopedTools = {
   time: number;
 };
 
+export function resolveMcpLoopbackScopedTools(params: {
+  cfg: OpenClawConfig;
+  sessionKey: string;
+  messageProvider: string | undefined;
+  accountId: string | undefined;
+  inboundEventKind: InboundEventKind | undefined;
+  senderIsOwner: boolean | undefined;
+}): { agentId: string | undefined; tools: McpLoopbackTool[] } {
+  const scoped = resolveGatewayScopedTools({
+    cfg: params.cfg,
+    sessionKey: params.sessionKey,
+    messageProvider: params.messageProvider,
+    accountId: params.accountId,
+    inboundEventKind: params.inboundEventKind,
+    senderIsOwner: params.senderIsOwner,
+    surface: "loopback",
+    excludeToolNames: NATIVE_TOOL_EXCLUDE,
+  });
+  return {
+    agentId: scoped.agentId,
+    tools: applyOwnerOnlyToolPolicy(scoped.tools, params.senderIsOwner === true),
+  };
+}
+
 export class McpLoopbackToolCache {
   #entries = new Map<string, CachedScopedTools>();
 
@@ -43,21 +67,18 @@ export class McpLoopbackToolCache {
       return cached;
     }
 
-    const next = resolveGatewayScopedTools({
+    const next = resolveMcpLoopbackScopedTools({
       cfg: params.cfg,
       sessionKey: params.sessionKey,
       messageProvider: params.messageProvider,
       accountId: params.accountId,
       inboundEventKind: params.inboundEventKind,
       senderIsOwner: params.senderIsOwner,
-      surface: "loopback",
-      excludeToolNames: NATIVE_TOOL_EXCLUDE,
     });
-    const tools = applyOwnerOnlyToolPolicy(next.tools, params.senderIsOwner === true);
     const nextEntry: CachedScopedTools = {
       agentId: next.agentId,
-      tools,
-      toolSchema: buildMcpToolSchema(tools),
+      tools: next.tools,
+      toolSchema: buildMcpToolSchema(next.tools),
       configRef: params.cfg,
       time: now,
     };


### PR DESCRIPTION
## Summary

- Reuse the loopback MCP scoped-tool resolver for bundled CLI system prompt construction.
- Pass those prompt-visible tools into the CLI system prompt and system prompt report.
- Persist a hash of prompt-visible CLI tool names so old CLI sessions reset when the prompt tool surface changes.

Fixes #83210.

## Real behavior proof

Behavior or issue addressed:
Bundled-MCP CLI runs could expose loopback tools while building the CLI system prompt with `tools: []`, so prompt sections gated on available tools could be omitted.

Real environment tested:
Local macOS checkout at commit `3384a58d9f` using the real loopback-scoped tool resolver and CLI system prompt/report builders.

Exact steps or command run after this patch:
`PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node --import tsx /private/tmp/proof-83210.mjs`

Evidence after fix:
Terminal output from the live CLI loopback prompt run:
```text
openclaw-cli-loopback-prompt-live-proof=ok
resolved_tool_count=24
resolved_tool_sample=agents_list,browser,canvas,cron,dir_fetch,dir_list,file_fetch,file_write
report_tool_count=24
report_tool_sample=nodes,cron,message,tts,gateway,agents_list,sessions_list,sessions_history
prompt_has_empty_tool_surface=false
```

Observed result after fix:
The same loopback-scoped resolver used by bundled MCP returned 24 prompt-visible tools, and the CLI system prompt report recorded 24 tools instead of an empty tool surface.

What was not tested:
I did not run a live `claude-cli` turn. The requested `crabbox-wrapper` command could not run here because the selected `crabbox` binary failed its own `--version/--help` sanity check before executing the smoke.

## Validation

- `PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node scripts/run-vitest.mjs src/agents/cli-runner/prepare.test.ts -t "uses loopback-scoped tools"` - 2 passed, 46 skipped
- `PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node scripts/run-vitest.mjs src/agents/cli-session.test.ts` - 14 passed
- `PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node scripts/run-vitest.mjs src/agents/cli-runner/prepare.test.ts src/agents/cli-runner/helpers.system-prompt.test.ts src/agents/cli-session.test.ts src/gateway/tool-resolution.test.ts src/gateway/mcp-http.test.ts` - all non-network-binding shards passed; `mcp-http.test.ts` failed in the sandbox with `listen EPERM`
- `PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node scripts/run-vitest.mjs src/gateway/mcp-http.test.ts` outside the sandbox - 60 passed
- `PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node node_modules/.bin/oxfmt --check --threads=1 src/gateway/mcp-http.runtime.ts src/config/sessions/types.ts src/agents/cli-session.ts src/agents/cli-session.test.ts src/agents/cli-runner.ts src/agents/cli-runner/claude-live-session.ts src/agents/cli-runner/types.ts src/agents/cli-runner/prepare.ts src/agents/cli-runner/prepare.test.ts`
- `PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node node_modules/.bin/oxlint src/gateway/mcp-http.runtime.ts src/agents/cli-session.ts src/agents/cli-runner.ts src/agents/cli-runner/claude-live-session.ts src/agents/cli-runner/prepare.ts src/agents/cli-runner/prepare.test.ts src/agents/cli-session.test.ts`
- `PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`
- `PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo`
- `git diff --check`
- `git log --format='%h %an <%ae> %s' upstream/main..HEAD`:
  `3384a58d9f Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com> fix(cli): include loopback tools in cli prompts`

