### PR TITLE
fix(agents): preserve inbound context in runtime-only prompt

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -829,6 +829,43 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     expect(contextCompiled?.data?.systemPrompt).toContain("internal heartbeat event");
   });
 
+  it("preserves channel inbound context (reply target) in runtime-only prompt submissions", async () => {
+    // Regression for #83767: when transcriptPrompt is empty (runtime-only path),
+    // currentInboundContext used to be dropped, hiding the Telegram/Discord reply
+    // target from the model. The fix passes inbound context through unconditionally
+    // while runtime-generated context still goes to the system prompt.
+    let seenPrompt: string | undefined;
+
+    await createContextEngineAttemptRunner({
+      contextEngine: createContextEngineBootstrapAndAssemble(),
+      sessionKey,
+      tempPaths,
+      attemptOverrides: {
+        prompt: "internal runtime event",
+        transcriptPrompt: "",
+        currentInboundContext: {
+          text: [
+            "Reply target of current user message (untrusted, for context):",
+            "```json",
+            '{"text":"earlier message body"}',
+            "```",
+          ].join("\n"),
+        },
+      },
+      sessionPrompt: async (session, prompt) => {
+        seenPrompt = prompt;
+        session.messages = [
+          ...session.messages,
+          { role: "assistant", content: "done", timestamp: 2 },
+        ];
+      },
+    });
+
+    expect(seenPrompt).toContain("Reply target of current user message");
+    expect(seenPrompt).toContain("earlier message body");
+    expect(seenPrompt).toContain("Continue the OpenClaw runtime event.");
+  });
+
   it("submits suppressed room event context as the model prompt", async () => {
     let seenPrompt: string | undefined;
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -3618,7 +3618,10 @@ export async function runEmbeddedAttempt(
               : "runtime-event",
           });
           const promptForModel = buildCurrentInboundPrompt({
-            context: promptSubmission.runtimeOnly ? undefined : params.currentInboundContext,
+            // Channel-level inbound context (reply target, mention metadata) must reach
+            // the model even on runtime-only turns. Only `runtimeContext` (plugin/hook
+            // derived) is relocated to the system prompt in the branch below — see #83767.
+            context: params.currentInboundContext,
             prompt: promptSubmission.prompt,
           });
           const runtimeSystemContext = promptSubmission.runtimeSystemContext?.trim();


### PR DESCRIPTION
## Summary

Fixes #83767.

In `runEmbeddedAttempt`, channel-level `currentInboundContext` (Telegram/Discord reply target body, mention metadata, room-event context) was unconditionally dropped from the model-visible prompt whenever `promptSubmission.runtimeOnly` was true.

Only `runtimeContext` (plugin/hook-derived, hidden) was supposed to be relocated to the system prompt in that branch — but the same conditional swept up channel inbound context as well. Result: a user replying to an earlier message and mentioning the bot got an answer with no awareness of the replied-to message body.

## Change

`src/agents/pi-embedded-runner/run/attempt.ts`:

```diff
 const promptForModel = buildCurrentInboundPrompt({
-  context: promptSubmission.runtimeOnly ? undefined : params.currentInboundContext,
+  context: params.currentInboundContext,
   prompt: promptSubmission.prompt,
 });
```

The existing runtime-system-context branch immediately below still handles relocation of plugin/hook context to the system prompt, so hidden runtime context does not leak into the transcript.

## Regression test

Adds a test in `attempt.spawn-workspace.context-engine.test.ts` exercising the exact gap identified in #83767: a runtime-only turn (`transcriptPrompt: ""`) with non-empty `currentInboundContext` carrying a reply target. The test asserts the reply-target block reaches the model prompt alongside the runtime-event marker.

This complements existing coverage:
- "submits runtime-only context through system prompt without visible prompt" (no inbound context)
- "submits suppressed room event context as the model prompt" (room event with `suppressNextUserMessagePersistence: true`, which is the `model-prompt` mode, not runtime-only)

The previous suite had no scenario where both `runtimeOnly: true` and `currentInboundContext` were present.

## Acceptance criteria (per issue review)

- [ ] `node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts`
- [ ] `node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run/runtime-context-prompt.test.ts`
- [ ] `node scripts/run-vitest.mjs src/auto-reply/reply/get-reply-run.media-only.test.ts`

(Local validation requires workspace setup; relying on CI.)

## Versions affected

- Last good: 2026.5.12
- Broken: 2026.5.18 (commit `50a2481`)
- Originating commit (per issue review): `1912be8619fb`
