### PR TITLE
Fix Telegram topic identity without forum flag

### DIFF
--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -1940,6 +1940,7 @@ export const registerTelegramHandlers = ({
         chatType: callbackMessage.chat.type,
         isGroup,
         isForum: callbackMessage.chat.is_forum,
+        isTopicMessage: callbackMessage.is_topic_message,
         getChat,
       });
       const senderId = callback.from?.id ? String(callback.from.id) : "";
@@ -2600,6 +2601,7 @@ export const registerTelegramHandlers = ({
       chatType: msg.chat.type,
       isGroup,
       isForum: msg.chat.is_forum,
+      isTopicMessage: msg.is_topic_message,
       getChat,
     });
     const normalizedMsg = withResolvedTelegramForumFlag(msg, isForum);
@@ -2735,6 +2737,7 @@ export const registerTelegramHandlers = ({
       chatType: msg.chat.type,
       isGroup,
       isForum: msg.chat.is_forum,
+      isTopicMessage: msg.is_topic_message,
       getChat,
     });
     const normalizedMsg = withResolvedTelegramForumFlag(msg, isForum);

--- a/extensions/telegram/src/bot-message-context.topic-agentid.test.ts
+++ b/extensions/telegram/src/bot-message-context.topic-agentid.test.ts
@@ -91,6 +91,35 @@ describe("buildTelegramMessageContext per-topic agentId routing", () => {
     expect(ctxB?.ctxPayload?.SessionKey).not.toBe(ctxC?.ctxPayload?.SessionKey);
   });
 
+  it("preserves topic routing when Telegram omits chat.is_forum", async () => {
+    const resolveTelegramGroupConfig = vi.fn(() => ({
+      groupConfig: { requireMention: false },
+      topicConfig: { agentId: "zu" },
+    }));
+    const ctx = await buildTelegramMessageContextForTest({
+      message: {
+        message_id: 1,
+        chat: {
+          id: -1001234567890,
+          type: "supergroup",
+          title: "Forum",
+        },
+        date: 1700000000,
+        text: "@bot hello",
+        is_topic_message: true,
+        message_thread_id: 3,
+        from: { id: 42, first_name: "Alice" },
+      },
+      options: { forceWasMentioned: true },
+      resolveGroupActivation: () => true,
+      resolveTelegramGroupConfig,
+    });
+
+    expect(resolveTelegramGroupConfig).toHaveBeenCalledWith(-1001234567890, 3);
+    expect(ctx?.ctxPayload?.SessionKey).toContain("agent:zu:");
+    expect(ctx?.ctxPayload?.SessionKey).toContain("telegram:group:-1001234567890:topic:3");
+  });
+
   it("ignores whitespace-only agentId and uses group-level agent", async () => {
     const ctx = await buildForumContext({
       topicConfig: { agentId: "   ", systemPrompt: "Be nice" },

--- a/extensions/telegram/src/bot-message-context.ts
+++ b/extensions/telegram/src/bot-message-context.ts
@@ -160,6 +160,7 @@ export const buildTelegramMessageContext = async ({
     chatType: msg.chat.type,
     isGroup,
     isForum: extractTelegramForumFlag(msg.chat),
+    isTopicMessage: msg.is_topic_message,
     getChat: getChatApi,
   });
   const threadSpec = resolveTelegramThreadSpec({

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -378,6 +378,7 @@ async function resolveTelegramNativeCommandThreadContext(params: {
     chatType: msg.chat.type,
     isGroup,
     isForum: extractTelegramForumFlag(msg.chat),
+    isTopicMessage: msg.is_topic_message,
     getChat,
   });
   const threadSpec = resolveTelegramThreadSpec({

--- a/extensions/telegram/src/bot/helpers.test.ts
+++ b/extensions/telegram/src/bot/helpers.test.ts
@@ -68,6 +68,36 @@ describe("resolveTelegramForumFlag", () => {
     expect(getChat).toHaveBeenCalledWith(-100789);
   });
 
+  it("uses supergroup topic-message metadata before getChat lookup", async () => {
+    const getChat = vi.fn(async () => {
+      throw new Error("lookup should not run");
+    });
+    await expect(
+      resolveTelegramForumFlag({
+        chatId: -100987,
+        chatType: "supergroup",
+        isGroup: true,
+        isTopicMessage: true,
+        getChat,
+      }),
+    ).resolves.toBe(true);
+    expect(getChat).not.toHaveBeenCalled();
+  });
+
+  it("does not treat private DM topic metadata as forum metadata", async () => {
+    const getChat = vi.fn(async () => ({ is_forum: true }));
+    await expect(
+      resolveTelegramForumFlag({
+        chatId: 123456,
+        chatType: "private",
+        isGroup: false,
+        isTopicMessage: true,
+        getChat,
+      }),
+    ).resolves.toBe(false);
+    expect(getChat).not.toHaveBeenCalled();
+  });
+
   it("reuses resolved forum metadata for later supergroup updates", async () => {
     const getChat = vi.fn(async () => ({ is_forum: true }));
     const params = {

--- a/extensions/telegram/src/bot/helpers.ts
+++ b/extensions/telegram/src/bot/helpers.ts
@@ -121,18 +121,35 @@ export function extractTelegramForumFlag(value: unknown): boolean | undefined {
   return typeof forum === "boolean" ? forum : undefined;
 }
 
+export function resolveTelegramMessageForumFlagHint(params: {
+  chatType?: Chat["type"];
+  isForum?: boolean;
+  isTopicMessage?: boolean;
+}): boolean | undefined {
+  if (params.chatType === "supergroup" && params.isTopicMessage === true) {
+    return true;
+  }
+  return typeof params.isForum === "boolean" ? params.isForum : undefined;
+}
+
 export async function resolveTelegramForumFlag(params: {
   chatId: string | number;
   chatType?: Chat["type"];
   isGroup: boolean;
   isForum?: boolean;
+  isTopicMessage?: boolean;
   getChat?: TelegramGetChat;
 }): Promise<boolean> {
-  if (typeof params.isForum === "boolean") {
+  const forumHint = resolveTelegramMessageForumFlagHint({
+    chatType: params.chatType,
+    isForum: params.isForum,
+    isTopicMessage: params.isTopicMessage,
+  });
+  if (typeof forumHint === "boolean") {
     if (params.isGroup && params.chatType === "supergroup") {
-      cacheTelegramForumFlag(params.chatId, params.isForum);
+      cacheTelegramForumFlag(params.chatId, forumHint);
     }
-    return params.isForum;
+    return forumHint;
   }
   if (!params.isGroup || params.chatType !== "supergroup" || !params.getChat) {
     return false;

--- a/extensions/telegram/src/sequential-key.ts
+++ b/extensions/telegram/src/sequential-key.ts
@@ -9,7 +9,10 @@ import {
   isAbortRequestText,
   isBtwRequestText,
 } from "openclaw/plugin-sdk/command-primitives-runtime";
-import { resolveTelegramForumThreadId } from "./bot/helpers.js";
+import {
+  resolveTelegramForumThreadId,
+  resolveTelegramMessageForumFlagHint,
+} from "./bot/helpers.js";
 
 const TELEGRAM_READ_ONLY_STATUS_COMMAND_KEYS = new Set([
   "commands",
@@ -137,8 +140,11 @@ export function getTelegramSequentialKey(ctx: TelegramSequentialKeyContext): str
   }
   const isGroup = msg?.chat?.type === "group" || msg?.chat?.type === "supergroup";
   const messageThreadId = msg?.message_thread_id;
-  const isForum =
-    msg?.chat?.is_forum ?? (msg?.chat?.type === "supergroup" && msg?.is_topic_message === true);
+  const isForum = resolveTelegramMessageForumFlagHint({
+    chatType: msg?.chat?.type,
+    isForum: msg?.chat?.is_forum,
+    isTopicMessage: msg?.is_topic_message,
+  });
   const threadId = isGroup
     ? resolveTelegramForumThreadId({ isForum, messageThreadId })
     : messageThreadId;


### PR DESCRIPTION
Superseded by the consolidated Telegram forum-topic flow PR.

This draft is being closed so the complete fix, root cause, before proof, and live after proof live in one review thread. The replacement PR carries the same topic-identity fix plus the buffer and outbound-fairness fixes.

Sensitive-data check before close: no password/token/API-key shaped values were found in this PR body/comments. Live chat ids were removed from this body; the replacement PR uses redacted live identifiers.