### PR TITLE
Keep queued user turns after Telegram supersedes

### DIFF
--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -942,6 +942,35 @@ describe("createFollowupRunner runtime config", () => {
     expect(call.abortSignal).toBe(abortController.signal);
   });
 
+  it("does not inherit source abort signals for queued user followups", async () => {
+    const sourceAbortController = new AbortController();
+    sourceAbortController.abort();
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [],
+      meta: {},
+    });
+    const runner = createFollowupRunner({
+      opts: { abortSignal: sourceAbortController.signal },
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      defaultModel: "openai/gpt-5.4",
+    });
+
+    await runner(
+      createQueuedRun({
+        currentInboundEventKind: "user_request",
+        run: {
+          provider: "openai",
+          model: "gpt-5.4",
+          sourceReplyDeliveryMode: "message_tool_only",
+        },
+      }),
+    );
+
+    const call = requireLastMockCallArg(runEmbeddedPiAgentMock, "run embedded pi agent");
+    expect(call.abortSignal).toBeUndefined();
+  });
+
   it("keeps queued delivery correlations active during followup agent runs", async () => {
     const events: string[] = [];
     runEmbeddedPiAgentMock.mockImplementationOnce(async () => {

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -419,7 +419,7 @@ export function createFollowupRunner(params: {
         sessionId: run.sessionId,
         sessionKey: replySessionKey ?? "",
         resetTriggered: false,
-        upstreamAbortSignal: queued.abortSignal ?? opts?.abortSignal,
+        upstreamAbortSignal: queued.abortSignal,
       });
       const runId = crypto.randomUUID();
       const shouldSurfaceToControlUi = isInternalMessageChannel(
@@ -654,7 +654,7 @@ export function createFollowupRunner(params: {
                     agentAccountId: run.agentAccountId,
                     senderIsOwner: run.senderIsOwner,
                     disableTools: opts?.disableTools,
-                    abortSignal: queued.abortSignal ?? opts?.abortSignal,
+                    abortSignal: queued.abortSignal,
                   },
                   transformResult: (rawResult) =>
                     isRoomEventCliRun && rawResult.meta.agentMeta
@@ -742,7 +742,7 @@ export function createFollowupRunner(params: {
                 bashElevated: run.bashElevated,
                 timeoutMs: run.timeoutMs,
                 runId,
-                abortSignal: queued.abortSignal ?? opts?.abortSignal,
+                abortSignal: queued.abortSignal,
                 images: queuedImages,
                 imageOrder: queuedImageOrder,
                 allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -1593,6 +1593,7 @@ describe("runPreparedReply media-only handling", () => {
   it("queues active room events as followups instead of steering fake prompts", async () => {
     const queueSettings = await import("./queue/settings-runtime.js");
     const piRuntime = await import("../../agents/pi-embedded.runtime.js");
+    const abortController = new AbortController();
     vi.mocked(queueSettings.resolveQueueSettings).mockReturnValueOnce({
       mode: "steer",
       debounceMs: 500,
@@ -1610,6 +1611,7 @@ describe("runPreparedReply media-only handling", () => {
 
     await runPreparedReply(
       baseParams({
+        opts: { abortSignal: abortController.signal },
         ctx: {
           Body: "ambient",
           RawBody: "ambient",
@@ -1638,7 +1640,56 @@ describe("runPreparedReply media-only handling", () => {
     expect(call.resolvedQueue.mode).toBe("steer");
     expect(call.followupRun.prompt).toBe("[OpenClaw room event]");
     expect(call.followupRun.currentInboundEventKind).toBe("room_event");
+    expect(call.followupRun.abortSignal).toBe(abortController.signal);
     expect(call.followupRun.currentInboundContext?.text).toContain("Current event:");
+  });
+
+  it("detaches queued user requests from superseded source abort signals", async () => {
+    const queueSettings = await import("./queue/settings-runtime.js");
+    const piRuntime = await import("../../agents/pi-embedded.runtime.js");
+    const abortController = new AbortController();
+    vi.mocked(queueSettings.resolveQueueSettings).mockReturnValueOnce({
+      mode: "collect",
+      debounceMs: 500,
+      cap: 20,
+      dropPolicy: "summarize",
+    });
+    vi.mocked(piRuntime.resolveActiveEmbeddedRunSessionId)
+      .mockReturnValueOnce("active-session")
+      .mockReturnValueOnce("active-session");
+    vi.mocked(piRuntime.isEmbeddedPiRunActive).mockReturnValueOnce(true);
+    vi.mocked(piRuntime.isEmbeddedPiRunStreaming).mockReturnValueOnce(true);
+    vi.mocked(buildInboundUserContextPrefix).mockReturnValueOnce("user request context");
+
+    await runPreparedReply(
+      baseParams({
+        opts: { abortSignal: abortController.signal },
+        ctx: {
+          Body: "@bot keep this",
+          RawBody: "@bot keep this",
+          CommandBody: "@bot keep this",
+          Provider: "telegram",
+          Surface: "telegram",
+          ChatType: "group",
+        },
+        sessionCtx: {
+          Body: "@bot keep this",
+          BodyStripped: "@bot keep this",
+          Provider: "telegram",
+          Surface: "telegram",
+          ChatType: "group",
+          InboundEventKind: "user_request",
+          MessageSid: "994",
+          SenderName: "Alice",
+        },
+      }),
+    );
+
+    const call = requireLastRunReplyAgentCall();
+    expect(call.shouldFollowup).toBe(true);
+    expect(call.isActive).toBe(true);
+    expect(call.followupRun.currentInboundEventKind).toBe("user_request");
+    expect(call.followupRun.abortSignal).toBeUndefined();
   });
 
   it("queues active room events instead of interrupting active user requests", async () => {

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -1044,12 +1044,14 @@ export async function runPreparedReply(
       imageOrder: opts?.imageOrder,
     }),
   );
+  const queuedFollowupAbortSignal =
+    inboundEventKind === "room_event" ? opts?.abortSignal : undefined;
   const followupRun = {
     prompt: queuedBody,
     transcriptPrompt: transcriptCommandBody,
     currentInboundEventKind: inboundEventKind,
     currentInboundContext,
-    abortSignal: opts?.abortSignal,
+    ...(queuedFollowupAbortSignal ? { abortSignal: queuedFollowupAbortSignal } : {}),
     deliveryCorrelations: opts?.queuedDeliveryCorrelations,
     queuedLifecycle: opts?.queuedFollowupLifecycle,
     messageId: sessionCtx.MessageSidFull ?? sessionCtx.MessageSid,


### PR DESCRIPTION
## Summary

- Detach queued `user_request` followups from the source-channel abort signal once they have been accepted into the reply queue.
- Keep `room_event` followups tied to their source abort signal so ambient/current-event work can still be canceled by the admission fence.
- Stop the followup runner from reintroducing the original source `opts.abortSignal` when executing a queued item; queued execution now uses only the abort metadata carried on that queued item.

## Root Cause

Queued followups were built with `opts.abortSignal` unconditionally. In Telegram topics, a later user turn can supersede the source reply fence while an earlier turn is still active. That made an already accepted `user_request` followup look aborted before it drained. The followup runner also fell back to the captured source `opts.abortSignal`, so omitting the signal on the queued object alone was not sufficient.

## Real behavior proof

Behavior addressed: Telegram topic user messages accepted while another turn is active should remain queued and run after the active turn, even if the source reply fence is later superseded.

Real environment tested: temp worktree `/tmp/openclaw-topic-followups.hEwtrg` for the patch and focused tests; current live local Telegram gateway for current-chat proof; real local gateway runtime logs reviewed from `/tmp/openclaw/openclaw-2026-05-18.log` and topic session trajectories under `~/.openclaw/agents/main/sessions`.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/auto-reply/reply/get-reply-run.media-only.test.ts src/auto-reply/reply/followup-runner.test.ts src/auto-reply/reply/queue.collect.test.ts extensions/telegram/src/bot-message-dispatch.test.ts`; `jq -r 'select((.message // "") | test("topic:8185|threadId=8185")) | select(.time >= "2026-05-18T19:40:00") | [.time, .message] | @tsv' /tmp/openclaw/openclaw-2026-05-18.log`; and redacted runtime-log review of the original Telegram-topic failure window.

Evidence after fix: focused regression proof shows old code failed and PR head passed. On old code with only the new regression tests applied, `node scripts/run-vitest.mjs src/auto-reply/reply/get-reply-run.media-only.test.ts src/auto-reply/reply/followup-runner.test.ts` failed with `Test Files 2 failed (2)` and `Tests 2 failed | 110 passed (112)`, including `expected AbortSignal { aborted: true } to be undefined` and `expected AbortSignal { aborted: false } to be undefined`. On PR head `695478dc167f6cd54cfe318fe037837494bf832a`, the same command passed with `Test Files 2 passed (2)` and `Tests 112 passed (112)`.

Current live Telegram topic proof from the active patched gateway shows the current chat receiving topic messages and sending replies back into the same Telegram topic after the patch:

```text
2026-05-18T19:41:31.880-04:00  Inbound message telegram:group:-<redacted>:topic:8185 -> @vacs_tars_bot (group, 12 chars)
2026-05-18T19:41:51.482-04:00  telegram outbound send ok accountId=default chatId=-<redacted> messageId=100708 operation=sendMessage deliveryKind=text threadId=8185 chunkCount=1
2026-05-18T19:43:23.393-04:00  Inbound message telegram:group:-<redacted>:topic:8185 -> @vacs_tars_bot (group, 42 chars)
2026-05-18T19:46:27.188-04:00  telegram outbound send ok accountId=default chatId=-<redacted> messageId=100749 operation=sendMessage deliveryKind=text threadId=8185 chunkCount=1
2026-05-18T19:46:28.027-04:00  telegram outbound send ok accountId=default chatId=-<redacted> messageId=100750 operation=sendMessage deliveryKind=text threadId=8185 chunkCount=1
```

The active live runtime also contains the patched abort contract:

```text
dist/get-reply-DqVR3pSa.js: queuedFollowupAbortSignal = inboundEventKind === "room_event" ? opts?.abortSignal : void 0
dist/agent-runner.runtime-CAMJHMX1.js: upstreamAbortSignal: queued.abortSignal
dist/agent-runner.runtime-CAMJHMX1.js: abortSignal: queued.abortSignal
```

Redacted runtime log excerpt from the original real OpenClaw Telegram-topic failure window showed multiple topic inbounds while active queued work was present, followed by prompt-stage app-server closures and queued topic diagnostics:

```text
2026-05-18T17:42:08.017-04:00  Inbound message telegram:group:-<redacted>:topic:24 -> <redacted>
2026-05-18T17:43:07.782-04:00  Inbound message telegram:group:-<redacted>:topic:24 -> <redacted>
2026-05-18T17:43:28.862-04:00  Inbound message telegram:group:-<redacted>:topic:5907 -> <redacted>
2026-05-18T17:43:43.340-04:00  embedded run failover decision runId=11c4451e-4ab6-4dad-b6ef-edfde684a0cd stage=prompt aborted=false rawErrorPreview="codex app-server client closed before turn completed"
2026-05-18T17:43:43.379-04:00  embedded run failover decision runId=df0003ed-4b49-4be0-8a12-71e1b450eee7 stage=prompt aborted=false rawErrorPreview="codex app-server client closed before turn completed"
2026-05-18T17:44:55.514-04:00  liveness warning ... active=...topic:24(processing/embedded_run,q=2,...)|...topic:5907(processing/embedded_run,q=1,...) queued=...topic:24(processing/embedded_run,q=2,...)
2026-05-18T17:59:02.652-04:00  long-running session ... topic:8428 state=processing queueDepth=1 reason=queued_behind_active_work classification=long_running
```

Additional redacted trajectory evidence showed repeated Telegram topic abort endings matching the loss mode this patch removes for queued user requests:

```text
externalAbort=true / "Reply operation aborted by user" counts by Telegram topic trajectory:
11 topic:24
9  topic:26866
6  topic:5907
4  topic:8428
4  topic:22684
4  topic:10174
```

Observed result after fix: queued `user_request` followups no longer carry or inherit the supersedable source abort signal; queued `room_event` followups still preserve their abort signal and continue to be skipped when that signal is already aborted. Focused regression tests pass, and the current live Telegram topic chat shows post-patch inbound topic messages receiving outbound `threadId=8185` replies from the active patched gateway.

What was not tested: Mantis Telegram Desktop visible proof did not capture because the Telegram bot connection was conflicted and proof messages did not reach OpenClaw. No video/artifact proof from Mantis or Crabbox is attached. Discord was not retested beyond the reporter's confirmation that a Discord server channel was not reproducing the same issue. The current live Telegram log proof is from the operator's active gateway, not a controlled baseline/candidate A/B desktop recording.

## Verification

- `pnpm install --frozen-lockfile` to install dependencies in the temp worktree only after the Vitest wrapper could not resolve `vitest/package.json`.
- `git diff --check`
- `node scripts/run-vitest.mjs src/auto-reply/reply/get-reply-run.media-only.test.ts src/auto-reply/reply/followup-runner.test.ts src/auto-reply/reply/queue.collect.test.ts extensions/telegram/src/bot-message-dispatch.test.ts` -> `Test Files 4 passed (4)`, `Tests 220 passed (220)`.
- Rebased onto current `origin/main` (`d761b98adc6ff2c824b95d0b2a7a54dfa1177d18`) and reran the same focused test command -> `Test Files 4 passed (4)`, `Tests 220 passed (220)`.
- Current live gateway log inspection for topic `8185` showed inbound Telegram topic messages followed by outbound `threadId=8185` replies from the active patched runtime.
- `AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --mode local` reported findings against untouched files (`src/auto-reply/inbound-debounce.ts`, `extensions/telegram/src/sequential-key.ts`). I rejected those as not applicable after `git diff --name-only` showed this branch only touches reply-runner files. Manual review did find the followup-runner fallback path, which is fixed here. A second autoreview rerun was stopped after about five minutes because it again expanded into broad unrelated GitHub search instead of completing a local-diff review.

## What was not tested

- Mantis Telegram Desktop visible proof / Crabbox proof was attempted but blocked by a conflicted Telegram bot connection.
- Broad `pnpm check` was not run from this Codex worktree.