### PR TITLE
fix(update): repair managed npm plugin peers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/update: repair managed npm plugin `openclaw` peer links during post-core convergence and reject stale or wrong-target peer links before restart. (#83794) Thanks @fuller-stack-dev.
 - Codex app-server: disable native Code Mode when the effective exec host is `node` and keep OpenClaw `exec`/`process` available, so `/exec host=node` routes shell commands through the selected node instead of the gateway. Fixes #85012. (#85090) Thanks @sahilsatralkar.
 - Gateway: defer provider auth-state prewarm until after startup readiness so early gateway tool/session requests are not blocked by provider auth discovery. (#85272) Thanks @dutifulbob.
 - Agents/Codex: show the first plan update as a transient chat status notice without counting it as final assistant content.

--- a/src/cli/update-cli/plugin-payload-validation.test.ts
+++ b/src/cli/update-cli/plugin-payload-validation.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resolveOpenClawPackageRootSync } from "../../infra/openclaw-root.js";
 import { runPluginPayloadSmokeCheck } from "./plugin-payload-validation.js";
 
 describe("runPluginPayloadSmokeCheck", () => {
@@ -26,6 +27,25 @@ describe("runPluginPayloadSmokeCheck", () => {
       await fs.mkdir(path.dirname(target), { recursive: true });
       await fs.writeFile(target, mainContent, "utf8");
     }
+  }
+
+  function resolveTestHostRoot(): string {
+    const hostRoot = resolveOpenClawPackageRootSync({
+      argv1: process.argv[1],
+      moduleUrl: import.meta.url,
+      cwd: process.cwd(),
+    });
+    expect(hostRoot).toBeTruthy();
+    return hostRoot!;
+  }
+
+  async function linkOpenClawPeerToHost(dir: string): Promise<void> {
+    await fs.mkdir(path.join(dir, "node_modules"), { recursive: true });
+    await fs.symlink(resolveTestHostRoot(), path.join(dir, "node_modules", "openclaw"), "junction");
+  }
+
+  async function resolveRealPath(target: string): Promise<string> {
+    return await fs.realpath(target).catch(() => target);
   }
 
   it("reports ok for a record whose package.json + main file exist", async () => {
@@ -164,6 +184,127 @@ describe("runPluginPayloadSmokeCheck", () => {
       records: { codex: { source: "npm", installPath: dir } },
       env: {},
     });
+    expect(result.failures).toEqual([]);
+  });
+
+  it("reports a failure when an openclaw peer link is missing", async () => {
+    const dir = path.join(tmpRoot, "codex");
+    await writePackage(
+      dir,
+      {
+        name: "@openclaw/codex",
+        main: "dist/index.js",
+        peerDependencies: { openclaw: ">=2026.5.18-beta.1" },
+      },
+      "export default {};\n",
+    );
+
+    const result = await runPluginPayloadSmokeCheck({
+      records: { codex: { source: "npm", installPath: dir } },
+      env: {},
+    });
+
+    expect(result.failures).toStrictEqual([
+      {
+        pluginId: "codex",
+        installPath: dir,
+        reason: "missing-openclaw-peer-link",
+        detail: `Plugin declares peerDependency "openclaw" but peer link audit failed: missing ${path.join(
+          dir,
+          "node_modules",
+          "openclaw",
+        )}.`,
+      },
+    ]);
+  });
+
+  it("reports a failure when an openclaw peer link is a stale real directory", async () => {
+    const dir = path.join(tmpRoot, "codex");
+    await writePackage(
+      dir,
+      {
+        name: "@openclaw/codex",
+        main: "dist/index.js",
+        peerDependencies: { openclaw: ">=2026.5.18-beta.1" },
+      },
+      "export default {};\n",
+    );
+    const stalePeerDir = path.join(dir, "node_modules", "openclaw");
+    await fs.mkdir(stalePeerDir, { recursive: true });
+
+    const result = await runPluginPayloadSmokeCheck({
+      records: { codex: { source: "npm", installPath: dir } },
+      env: {},
+    });
+
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0]).toMatchObject({
+      pluginId: "codex",
+      installPath: dir,
+      reason: "missing-openclaw-peer-link",
+    });
+    expect(result.failures[0]?.detail).toContain(`${stalePeerDir} points to`);
+    expect(result.failures[0]?.detail).toContain(
+      `instead of ${await resolveRealPath(resolveTestHostRoot())}`,
+    );
+  });
+
+  it("reports a failure when an openclaw peer link points at the wrong package root", async () => {
+    const dir = path.join(tmpRoot, "codex");
+    await writePackage(
+      dir,
+      {
+        name: "@openclaw/codex",
+        main: "dist/index.js",
+        peerDependencies: { openclaw: ">=2026.5.18-beta.1" },
+      },
+      "export default {};\n",
+    );
+    const wrongHostRoot = path.join(tmpRoot, "old-openclaw");
+    await fs.mkdir(wrongHostRoot, { recursive: true });
+    await fs.mkdir(path.join(dir, "node_modules"), { recursive: true });
+    await fs.symlink(wrongHostRoot, path.join(dir, "node_modules", "openclaw"), "junction");
+
+    const result = await runPluginPayloadSmokeCheck({
+      records: { codex: { source: "npm", installPath: dir } },
+      env: {},
+    });
+
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0]).toMatchObject({
+      pluginId: "codex",
+      installPath: dir,
+      reason: "missing-openclaw-peer-link",
+    });
+    expect(result.failures[0]?.detail).toContain(
+      `${path.join(
+        dir,
+        "node_modules",
+        "openclaw",
+      )} points to ${await resolveRealPath(wrongHostRoot)} instead of ${await resolveRealPath(
+        resolveTestHostRoot(),
+      )}`,
+    );
+  });
+
+  it("accepts an openclaw peer link when it resolves to the host package root", async () => {
+    const dir = path.join(tmpRoot, "codex");
+    await writePackage(
+      dir,
+      {
+        name: "@openclaw/codex",
+        main: "dist/index.js",
+        peerDependencies: { openclaw: ">=2026.5.18-beta.1" },
+      },
+      "export default {};\n",
+    );
+    await linkOpenClawPeerToHost(dir);
+
+    const result = await runPluginPayloadSmokeCheck({
+      records: { codex: { source: "npm", installPath: dir } },
+      env: {},
+    });
+
     expect(result.failures).toEqual([]);
   });
 

--- a/src/cli/update-cli/plugin-payload-validation.ts
+++ b/src/cli/update-cli/plugin-payload-validation.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import type { PluginInstallRecord } from "../../config/types.plugins.js";
 import { resolvePackageExtensionEntries, type PackageManifest } from "../../plugins/manifest.js";
 import { validatePackageExtensionEntriesForInstall } from "../../plugins/package-entry-resolution.js";
+import { auditOpenClawPeerDependencyLink } from "../../plugins/plugin-peer-link.js";
 import { resolveUserPath } from "../../utils.js";
 
 export type PluginPayloadSmokeFailureReason =
@@ -11,7 +12,8 @@ export type PluginPayloadSmokeFailureReason =
   | "missing-package-json"
   | "invalid-package-json"
   | "missing-main-entry"
-  | "missing-extension-entry";
+  | "missing-extension-entry"
+  | "missing-openclaw-peer-link";
 
 export type PluginPayloadSmokeFailure = {
   pluginId: string;
@@ -100,6 +102,21 @@ export async function runPluginPayloadSmokeCheck(params: {
       continue;
     }
 
+    if (manifestDeclaresOpenClawPeer(manifest)) {
+      const peerIssue = await auditOpenClawPeerDependencyLink({
+        packageDir: installPath,
+        packageName: manifest.name ?? pluginId,
+      });
+      if (peerIssue) {
+        failures.push({
+          pluginId,
+          installPath,
+          reason: "missing-openclaw-peer-link",
+          detail: `Plugin declares peerDependency "openclaw" but peer link audit failed: ${peerIssue.reason}.`,
+        });
+      }
+    }
+
     const extensionResolution = resolvePackageExtensionEntries(manifest);
     if (extensionResolution.status === "invalid" || extensionResolution.status === "empty") {
       failures.push({
@@ -149,6 +166,16 @@ export async function runPluginPayloadSmokeCheck(params: {
   }
 
   return { checked, failures };
+}
+
+function manifestDeclaresOpenClawPeer(manifest: PackageManifest): boolean {
+  const peerDependencies = (manifest as { peerDependencies?: unknown }).peerDependencies;
+  return (
+    typeof peerDependencies === "object" &&
+    peerDependencies !== null &&
+    !Array.isArray(peerDependencies) &&
+    typeof (peerDependencies as Record<string, unknown>).openclaw === "string"
+  );
 }
 
 async function safeStat(target: string): Promise<import("node:fs").Stats | null> {

--- a/src/cli/update-cli/post-core-plugin-convergence.test.ts
+++ b/src/cli/update-cli/post-core-plugin-convergence.test.ts
@@ -5,11 +5,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   repairMissingConfiguredPluginInstalls: vi.fn(),
+  relinkOpenClawPeerDependenciesInManagedNpmRoot: vi.fn(),
   runPluginPayloadSmokeCheck: vi.fn(),
 }));
 
 vi.mock("../../commands/doctor/shared/missing-configured-plugin-install.js", () => ({
   repairMissingConfiguredPluginInstalls: mocks.repairMissingConfiguredPluginInstalls,
+}));
+vi.mock("../../plugins/plugin-peer-link.js", () => ({
+  relinkOpenClawPeerDependenciesInManagedNpmRoot:
+    mocks.relinkOpenClawPeerDependenciesInManagedNpmRoot,
 }));
 vi.mock("./plugin-payload-validation.js", () => ({
   runPluginPayloadSmokeCheck: mocks.runPluginPayloadSmokeCheck,
@@ -32,6 +37,12 @@ describe("runPostCorePluginConvergence", () => {
       changes: [],
       warnings: [],
       records: {},
+    });
+    mocks.relinkOpenClawPeerDependenciesInManagedNpmRoot.mockResolvedValue({
+      checked: 0,
+      attempted: 0,
+      repaired: 0,
+      skipped: 0,
     });
     mocks.runPluginPayloadSmokeCheck.mockResolvedValue({ checked: [], failures: [] });
   });
@@ -135,6 +146,36 @@ describe("runPostCorePluginConvergence", () => {
     expect(result.installRecords).toEqual({
       discord: { source: "npm", installPath: "/p/discord" },
     });
+  });
+
+  it("repairs managed npm openclaw peer links before payload smoke checks", async () => {
+    mocks.repairMissingConfiguredPluginInstalls.mockResolvedValue({
+      changes: [],
+      warnings: [],
+      records: { codex: { source: "npm", installPath: "/p/codex" } },
+    });
+    mocks.relinkOpenClawPeerDependenciesInManagedNpmRoot.mockResolvedValue({
+      checked: 1,
+      attempted: 1,
+      repaired: 1,
+      skipped: 0,
+    });
+
+    const result = await runPostCorePluginConvergence({
+      cfg: { plugins: { entries: { codex: { enabled: true } } } } as unknown as OpenClawConfig,
+      env: { OPENCLAW_STATE_DIR: "/tmp/openclaw-state" },
+    });
+
+    expect(mocks.relinkOpenClawPeerDependenciesInManagedNpmRoot).toHaveBeenCalledWith({
+      npmRoot: "/tmp/openclaw-state/npm",
+      logger: {},
+    });
+    expect(result.changes).toEqual([
+      "Repaired OpenClaw host peer link(s) for 1 managed npm plugin package(s).",
+    ]);
+    expect(
+      mocks.relinkOpenClawPeerDependenciesInManagedNpmRoot.mock.invocationCallOrder[0],
+    ).toBeLessThan(mocks.runPluginPayloadSmokeCheck.mock.invocationCallOrder[0]);
   });
 
   it("forwards baselineInstallRecords to repair so sync/npm in-memory mutations are preserved", async () => {

--- a/src/cli/update-cli/post-core-plugin-convergence.ts
+++ b/src/cli/update-cli/post-core-plugin-convergence.ts
@@ -3,6 +3,8 @@ import { UPDATE_POST_CORE_CONVERGENCE_ENV } from "../../commands/doctor/shared/u
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../../config/types.plugins.js";
 import { normalizePluginsConfig, resolveEffectiveEnableState } from "../../plugins/config-state.js";
+import { resolveDefaultPluginNpmDir } from "../../plugins/install-paths.js";
+import { relinkOpenClawPeerDependenciesInManagedNpmRoot } from "../../plugins/plugin-peer-link.js";
 import { pruneStaleLocalBundledPluginInstallRecords } from "../../plugins/stale-local-bundled-plugin-install-records.js";
 import {
   resolveTrustedSourceLinkedOfficialClawHubSpec,
@@ -42,6 +44,38 @@ export type PostCoreConvergenceResult = {
 const REPAIR_GUIDANCE = "Run `openclaw doctor --fix` to retry plugin repair.";
 const inspectGuidance = (pluginId: string) =>
   `Run \`openclaw plugins inspect ${pluginId} --runtime --json\` for details.`;
+
+async function repairManagedNpmOpenClawPeerLinks(params: {
+  env: NodeJS.ProcessEnv;
+}): Promise<{ changes: string[]; warnings: PostCoreConvergenceWarning[] }> {
+  try {
+    const result = await relinkOpenClawPeerDependenciesInManagedNpmRoot({
+      npmRoot: resolveDefaultPluginNpmDir(params.env),
+      logger: {},
+    });
+    return {
+      changes:
+        result.repaired > 0
+          ? [
+              `Repaired OpenClaw host peer link(s) for ${result.repaired} managed npm plugin package(s).`,
+            ]
+          : [],
+      warnings: [],
+    };
+  } catch (err) {
+    const message = `Failed to repair managed npm OpenClaw host peer links: ${err instanceof Error ? err.message : String(err)}`;
+    return {
+      changes: [],
+      warnings: [
+        {
+          reason: message,
+          message,
+          guidance: [REPAIR_GUIDANCE],
+        },
+      ],
+    };
+  }
+}
 
 /**
  * Mandatory post-core convergence pass. Runs AFTER the core package files
@@ -85,6 +119,8 @@ export async function runPostCorePluginConvergence(params: {
     message,
     guidance: [REPAIR_GUIDANCE],
   }));
+  const peerLinkRepair = await repairManagedNpmOpenClawPeerLinks({ env });
+  warnings.push(...peerLinkRepair.warnings);
 
   const records: Record<string, PluginInstallRecord> = repair.records;
   // Filter the smoke-check input to active records ONLY: configured /
@@ -111,6 +147,7 @@ export async function runPostCorePluginConvergence(params: {
         (record) => `Removed stale local bundled plugin install record "${record.pluginId}".`,
       ) ?? []),
       ...repair.changes,
+      ...peerLinkRepair.changes,
     ],
     warnings,
     errored: warnings.length > 0,

--- a/src/plugins/installed-plugin-index-record-reader.ts
+++ b/src/plugins/installed-plugin-index-record-reader.ts
@@ -136,14 +136,58 @@ function buildRecoveredManagedNpmInstallRecords(
   return records;
 }
 
+function recordsShareInstallPath(
+  left: PluginInstallRecord | undefined,
+  right: PluginInstallRecord,
+): boolean {
+  if (!left?.installPath || !right.installPath) {
+    return false;
+  }
+  return path.resolve(left.installPath) === path.resolve(right.installPath);
+}
+
+function readInstallRecordVersion(record: PluginInstallRecord | undefined): string | undefined {
+  return record?.resolvedVersion ?? record?.version;
+}
+
+function mergeRecoveredManagedNpmRecord(params: {
+  persisted: PluginInstallRecord | undefined;
+  recovered: PluginInstallRecord;
+}): PluginInstallRecord {
+  const persistedVersion = readInstallRecordVersion(params.persisted);
+  const recoveredVersion = readInstallRecordVersion(params.recovered);
+  if (
+    params.persisted?.source === "npm" &&
+    recordsShareInstallPath(params.persisted, params.recovered) &&
+    recoveredVersion &&
+    persistedVersion !== recoveredVersion
+  ) {
+    const next: PluginInstallRecord = {
+      ...params.persisted,
+      ...params.recovered,
+    };
+    delete next.integrity;
+    delete next.shasum;
+    delete next.resolvedAt;
+    delete next.installedAt;
+    return next;
+  }
+  return params.persisted ?? params.recovered;
+}
+
 function mergeRecoveredManagedNpmInstallRecords(
   persisted: Record<string, PluginInstallRecord> | null,
   options: InstalledPluginIndexStoreOptions,
 ): Record<string, PluginInstallRecord> {
-  return {
-    ...buildRecoveredManagedNpmInstallRecords(options),
-    ...persisted,
-  };
+  const recovered = buildRecoveredManagedNpmInstallRecords(options);
+  const merged: Record<string, PluginInstallRecord> = { ...persisted };
+  for (const [pluginId, record] of Object.entries(recovered)) {
+    merged[pluginId] = mergeRecoveredManagedNpmRecord({
+      persisted: merged[pluginId],
+      recovered: record,
+    });
+  }
+  return merged;
 }
 
 function extractPluginInstallRecordsFromPersistedInstalledPluginIndex(

--- a/src/plugins/installed-plugin-index-records.test.ts
+++ b/src/plugins/installed-plugin-index-records.test.ts
@@ -269,6 +269,56 @@ describe("plugin index install records store", () => {
     });
   });
 
+  it("recovers managed npm metadata when the persisted record points at an older package version", async () => {
+    const stateDir = makeStateDir();
+    const codexDir = writeManagedNpmPlugin({
+      stateDir,
+      packageName: "@openclaw/codex",
+      pluginId: "codex",
+      version: "2026.5.18-beta.1",
+    });
+    const candidate = createPluginCandidate(stateDir, "codex");
+    await writePersistedInstalledPluginIndexInstallRecords(
+      {
+        codex: {
+          source: "npm",
+          spec: "@openclaw/codex@2026.5.16-beta.1",
+          installPath: codexDir,
+          version: "2026.5.16-beta.1",
+          resolvedName: "@openclaw/codex",
+          resolvedVersion: "2026.5.16-beta.1",
+          resolvedSpec: "@openclaw/codex@2026.5.16-beta.1",
+          integrity: "sha512-stale",
+          shasum: "stale",
+          installedAt: "2026-05-16T01:42:54.609Z",
+          resolvedAt: "2026-05-16T01:42:52.981Z",
+        },
+      },
+      { stateDir, candidates: [candidate] },
+    );
+
+    const loaded = await loadInstalledPluginIndexInstallRecords({ stateDir });
+    const record = expectRecordFields(loaded.codex, {
+      source: "npm",
+      spec: "@openclaw/codex@2026.5.18-beta.1",
+      installPath: codexDir,
+      version: "2026.5.18-beta.1",
+      resolvedName: "@openclaw/codex",
+      resolvedVersion: "2026.5.18-beta.1",
+      resolvedSpec: "@openclaw/codex@2026.5.18-beta.1",
+    });
+    expect(record.integrity).toBeUndefined();
+    expect(record.shasum).toBeUndefined();
+    expect(record.installedAt).toBeUndefined();
+    expect(record.resolvedAt).toBeUndefined();
+
+    const loadedSync = loadInstalledPluginIndexInstallRecordsSync({ stateDir });
+    expectRecordFields(loadedSync.codex, {
+      version: "2026.5.18-beta.1",
+      resolvedVersion: "2026.5.18-beta.1",
+    });
+  });
+
   it("preserves git install resolution fields in persisted records", async () => {
     const stateDir = makeStateDir();
     const candidate = createPluginCandidate(stateDir, "git-demo");

--- a/src/plugins/plugin-peer-link.ts
+++ b/src/plugins/plugin-peer-link.ts
@@ -14,7 +14,7 @@ type RelinkManagedNpmRootResult = {
   skipped: number;
 };
 
-type OpenClawPeerLinkAuditIssue = {
+export type OpenClawPeerLinkAuditIssue = {
   packageName: string;
   packageDir: string;
   reason: string;
@@ -110,13 +110,18 @@ function managedPackageNameFromDir(params: { npmRoot: string; packageDir: string
 
 async function auditOpenClawPeerDependency(params: {
   hostRoot: string;
-  npmRoot: string;
   packageDir: string;
+  npmRoot?: string;
+  packageName?: string;
 }): Promise<OpenClawPeerLinkAuditIssue | null> {
-  const packageName = managedPackageNameFromDir({
-    npmRoot: params.npmRoot,
-    packageDir: params.packageDir,
-  });
+  const packageName =
+    params.packageName ??
+    (params.npmRoot
+      ? managedPackageNameFromDir({
+          npmRoot: params.npmRoot,
+          packageDir: params.packageDir,
+        })
+      : path.basename(params.packageDir));
   const nodeModulesDir = path.join(params.packageDir, "node_modules");
   try {
     const existing = await fs.lstat(nodeModulesDir);
@@ -156,6 +161,30 @@ async function auditOpenClawPeerDependency(params: {
     };
   }
   return null;
+}
+
+export async function auditOpenClawPeerDependencyLink(params: {
+  packageDir: string;
+  packageName?: string;
+}): Promise<OpenClawPeerLinkAuditIssue | null> {
+  const packageName = params.packageName ?? path.basename(params.packageDir);
+  const hostRoot = resolveOpenClawPackageRootSync({
+    argv1: process.argv[1],
+    moduleUrl: import.meta.url,
+    cwd: process.cwd(),
+  });
+  if (!hostRoot) {
+    return {
+      packageName,
+      packageDir: params.packageDir,
+      reason: "could not locate openclaw package root",
+    };
+  }
+  return await auditOpenClawPeerDependency({
+    hostRoot,
+    packageDir: params.packageDir,
+    packageName,
+  });
 }
 
 async function ensureRealNodeModulesDir(params: {


### PR DESCRIPTION
## Summary
- recover managed npm install records from the actual managed package when a persisted npm record points at the same path but an older version
- relink managed npm `openclaw` peer dependencies during post-core convergence before payload smoke checks run
- validate `openclaw` peer links with the existing host-root realpath audit semantics, including stale real directory and wrong-target regressions

## Review follow-up
- Addressed ClawSweeper P2 by exporting and reusing `auditOpenClawPeerDependencyLink` from `plugin-peer-link.ts` in the payload smoke check.
- The passing peer-link smoke test now requires a symlink that resolves to the current host package root.
- Added regressions for a stale real `node_modules/openclaw` directory and a symlink pointing at the wrong package root.

## Real behavior proof
**Behavior or issue addressed:** Managed npm plugins that declare `peerDependencies.openclaw` can fail after an upgrade when the plugin-local `node_modules/openclaw` host-package link is missing, stale, or pointed at the wrong host root. This proof covers stale install-record recovery, before/after peer repair, and the stricter stale-directory guard.

**Real environment tested:** Local OpenClaw source checkout on the rebased PR branch, running against the real source modules with `pnpm exec tsx`. The managed npm root was sandboxed under a temporary `OPENCLAW_STATE_DIR`; private local filesystem paths are redacted as `[TMP_OPENCLAW_STATE]`.

**Exact steps or command run after this patch:** Ran `pnpm exec tsx --tsconfig tsconfig.json <inline managed-npm peer repair proof>`. The script created a sandboxed managed npm package declaring `peerDependencies.openclaw`, seeded a stale persisted install record (`2026.5.16-beta.1`), loaded recovered install records, ran `runPluginPayloadSmokeCheck` before repair, ran `relinkOpenClawPeerDependenciesInManagedNpmRoot`, ran `runPluginPayloadSmokeCheck` after repair, audited the resulting peer link, and separately checked a stale real-directory collision.

**Evidence after fix:** Terminal output from the after-fix proof run:

```text
REAL BEHAVIOR PROOF: managed npm OpenClaw peer repair
stateDir=[TMP_OPENCLAW_STATE]
managedPackage=@proof/openclaw-peer-plugin
flow=relinkOpenClawPeerDependenciesInManagedNpmRoot (doctor/post-core repair primitive)
persistedVersion=2026.5.16-beta.1
recoveredVersion=2026.5.18-beta.1
recoveredSpec=@proof/openclaw-peer-plugin@2026.5.18-beta.1
staleIntegrityCleared=true
beforeSmokeFailures=1
beforeSmoke=[{"reason":"missing-openclaw-peer-link","detailHasMissingPeer":true,"detailHasWrongTarget":false}]
repairResult={"checked":1,"attempted":1,"repaired":1,"skipped":0}
installRecordRetained=true
afterSmokeFailures=0
afterPeerAudit=ok
staleRealDirectoryFailures=1
staleRealDirectorySmoke=[{"reason":"missing-openclaw-peer-link","detailHasMissingPeer":false,"detailHasWrongTarget":true}]
```

**Observed result after fix:** The stale persisted install record was recovered to `2026.5.18-beta.1` and stale integrity metadata was dropped. Before repair, payload smoke found one `missing-openclaw-peer-link` failure. The managed npm relinker checked one package, attempted one repair, repaired one link, and skipped zero. After repair, payload smoke reported zero failures and the peer audit returned `ok`. A stale real `node_modules/openclaw` directory still failed smoke validation with the wrong-target signal.

**What was not tested:** I did not mutate Jay's live `~/.openclaw` runtime or run a production networked `openclaw update`; the proof used an isolated managed npm state so the live gateway/config/secrets were not touched.

## Testing
- `node scripts/test-projects.mjs src/plugins/installed-plugin-index-records.test.ts src/plugins/plugin-peer-link.test.ts src/cli/update-cli/plugin-payload-validation.test.ts src/cli/update-cli/post-core-plugin-convergence.test.ts`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.src.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-src.tsbuildinfo`
- `pnpm exec oxlint src/plugins/plugin-peer-link.ts src/cli/update-cli/plugin-payload-validation.ts src/cli/update-cli/plugin-payload-validation.test.ts src/cli/update-cli/post-core-plugin-convergence.ts src/cli/update-cli/post-core-plugin-convergence.test.ts src/plugins/installed-plugin-index-record-reader.ts src/plugins/installed-plugin-index-records.test.ts`