### PR TITLE
fix(skills): refresh snapshots when watch roots change

### DIFF
--- a/src/agents/skills/refresh-state.ts
+++ b/src/agents/skills/refresh-state.ts
@@ -1,6 +1,6 @@
 export type SkillsChangeEvent = {
   workspaceDir?: string;
-  reason: "watch" | "manual" | "remote-node" | "config-change";
+  reason: "watch" | "watch-targets" | "manual" | "remote-node" | "config-change";
   changedPath?: string;
 };
 

--- a/src/agents/skills/refresh.test.ts
+++ b/src/agents/skills/refresh.test.ts
@@ -151,4 +151,30 @@ describe("ensureSkillsWatcher", () => {
       ]);
     },
   );
+
+  it("refreshes skills snapshots when watched skill roots change", () => {
+    const seen: SkillsChangeEvent[] = [];
+    refreshModule.registerSkillsChangeListener((change) => {
+      seen.push(change);
+    });
+    refreshModule.ensureSkillsWatcher({
+      workspaceDir: "/tmp/workspace",
+      config: { skills: { load: { extraDirs: ["/tmp/shared-a"] } } },
+    });
+
+    refreshModule.ensureSkillsWatcher({
+      workspaceDir: "/tmp/workspace",
+      config: { skills: { load: { extraDirs: ["/tmp/shared-b"] } } },
+    });
+
+    expect(watchMock).toHaveBeenCalledTimes(2);
+    expect(createdWatchers[0]?.close).toHaveBeenCalledTimes(1);
+    expect(seen).toEqual([
+      {
+        workspaceDir: "/tmp/workspace",
+        reason: "watch-targets",
+        changedPath: expect.stringContaining("/tmp/shared-b"),
+      },
+    ]);
+  });
 });

--- a/src/agents/skills/refresh.ts
+++ b/src/agents/skills/refresh.ts
@@ -127,6 +127,7 @@ export function ensureSkillsWatcher(params: { workspaceDir: string; config?: Ope
   if (existing && existing.pathsKey === pathsKey && existing.debounceMs === debounceMs) {
     return;
   }
+  const watchTargetsChanged = existing ? existing.pathsKey !== pathsKey : false;
   if (existing) {
     watchers.delete(workspaceDir);
     if (existing.timer) {
@@ -174,6 +175,13 @@ export function ensureSkillsWatcher(params: { workspaceDir: string; config?: Ope
   });
 
   watchers.set(workspaceDir, state);
+  if (watchTargetsChanged) {
+    bumpSkillsSnapshotVersion({
+      workspaceDir,
+      reason: "watch-targets",
+      changedPath: pathsKey,
+    });
+  }
 }
 
 export async function resetSkillsRefreshForTest(): Promise<void> {

--- a/src/auto-reply/reply/session-updates.test.ts
+++ b/src/auto-reply/reply/session-updates.test.ts
@@ -37,7 +37,7 @@ const {
   })),
   ensureSkillsWatcherMock: vi.fn(),
   getSkillsSnapshotVersionMock: vi.fn(() => 0),
-  shouldRefreshSnapshotForVersionMock: vi.fn(() => false),
+  shouldRefreshSnapshotForVersionMock: vi.fn((_cached?: number, _next?: number) => false),
   getRemoteSkillEligibilityMock: vi.fn(() => ({
     platforms: [],
     hasBin: () => false,
@@ -59,6 +59,9 @@ vi.mock("../../agents/skills.js", () => ({
 
 vi.mock("../../agents/skills/refresh.js", () => ({
   ensureSkillsWatcher: ensureSkillsWatcherMock,
+}));
+
+vi.mock("../../agents/skills/refresh-state.js", () => ({
   getSkillsSnapshotVersion: getSkillsSnapshotVersionMock,
   shouldRefreshSnapshotForVersion: shouldRefreshSnapshotForVersionMock,
 }));
@@ -195,6 +198,31 @@ describe("ensureSkillSnapshot", () => {
       cfg: {},
     });
     expect(buildWorkspaceSkillSnapshotMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("reads the skills snapshot version after watcher-side invalidation", async () => {
+    vi.stubEnv("OPENCLAW_TEST_FAST", "0");
+    getSkillsSnapshotVersionMock.mockReturnValue(0);
+    ensureSkillsWatcherMock.mockImplementation(() => {
+      getSkillsSnapshotVersionMock.mockReturnValue(5);
+    });
+    shouldRefreshSnapshotForVersionMock.mockImplementation((cached = 0, next = 0) => cached < next);
+
+    await ensureSkillSnapshot({
+      sessionEntry: testSessionEntry("sess-1", strippedSnapshot()),
+      sessionStore: {},
+      sessionKey: "main",
+      isFirstTurnInSession: false,
+      workspaceDir: TEST_WORKSPACE_DIR,
+      cfg: { skills: { load: { extraDirs: ["/tmp/shared-skills"] } } },
+    });
+
+    expect(shouldRefreshSnapshotForVersionMock).toHaveBeenCalledWith(0, 5);
+    expect(buildWorkspaceSkillSnapshotMock).toHaveBeenCalledTimes(1);
+    const [[, snapshotParams]] = buildWorkspaceSkillSnapshotMock.mock.calls as unknown as Array<
+      [string, { snapshotVersion?: number }]
+    >;
+    expect(snapshotParams.snapshotVersion).toBe(5);
   });
 
   it("invalidates cache when non-skills config gates change", async () => {

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -259,9 +259,9 @@ export async function ensureSkillSnapshot(params: {
       agentId: sessionAgentId,
     }),
   });
-  const snapshotVersion = getSkillsSnapshotVersion(workspaceDir);
   const existingSnapshot = nextEntry?.skillsSnapshot;
   ensureSkillsWatcher({ workspaceDir, config: cfg });
+  const snapshotVersion = getSkillsSnapshotVersion(workspaceDir);
   const shouldRefreshSnapshot =
     shouldRefreshSnapshotForVersion(existingSnapshot?.version, snapshotVersion) ||
     !matchesSkillFilter(existingSnapshot?.skillFilter, skillFilter);


### PR DESCRIPTION
## Summary
- invalidate skills snapshots when `ensureSkillsWatcher` rebuilds because the watched root set changed
- read the snapshot version after watcher setup so same-turn watcher invalidation is visible to existing sessions
- add regression coverage for watch-root changes and the session refresh ordering

Fixes #83782.

## Required audits
- Existing-helper check: reused existing `bumpSkillsSnapshotVersion`, `getSkillsSnapshotVersion`, and watcher state; no new invalidation framework.
- Shared-helper caller check: checked `session-updates.ts`, `agent-command.ts`, `config-reload.ts`, and `refresh-state.ts`; only `session-updates.ts` calls `ensureSkillsWatcher`, so it needs the post-watcher version read.
- Broader-fix rival scan: #82365 covers config fingerprint/session refresh, but does not touch watcher root-set invalidation in `refresh.ts`; #83799 was closed because it was over-broad and failing.

## Real behavior proof

- **Behavior or issue addressed:** Changing the watched skill root set now bumps the workspace skills snapshot version with reason `watch-targets`, so existing sessions can observe a new snapshot version after `ensureSkillsWatcher` runs.
- **Real environment tested:** Local OpenClaw checkout at `/home/chenglunhu/code/openclaw`, Node v22.22.0, branch `fix-skills-watch-targets-snapshot-83782`, commit `aa0a569c02489243903fd808c1e1b8559f31d8c6`.
- **Exact steps or command run after this patch:** Start a watcher for a real temporary workspace with `skills.load.extraDirs=[shared-a]`, start it again for the same workspace with `skills.load.extraDirs=[shared-b]`, read `getSkillsSnapshotVersion(workspaceDir)` before/after, and record emitted skills change events.

```bash
node --import tsx -e 'import { ensureSkillsWatcher, getSkillsSnapshotVersion, registerSkillsChangeListener, resetSkillsRefreshForTest } from "./src/agents/skills/refresh.ts"; const ws = `/tmp/openclaw-watch-proof-${process.pid}`; const events = []; registerSkillsChangeListener((event) => events.push(event)); const before = getSkillsSnapshotVersion(ws); ensureSkillsWatcher({ workspaceDir: ws, config: { skills: { load: { extraDirs: [`${ws}/shared-a`] } } } }); const afterFirst = getSkillsSnapshotVersion(ws); ensureSkillsWatcher({ workspaceDir: ws, config: { skills: { load: { extraDirs: [`${ws}/shared-b`] } } } }); const afterSecond = getSkillsSnapshotVersion(ws); await resetSkillsRefreshForTest(); console.log(JSON.stringify({ before, afterFirst, afterSecond, increasedOnRootChange: afterSecond > afterFirst, events }, null, 2));'
```

- **Evidence after fix:** Terminal output from the real local OpenClaw checkout:

```json
{
  "before": 0,
  "afterFirst": 0,
  "afterSecond": 1779146070842,
  "increasedOnRootChange": true,
  "events": [
    {
      "workspaceDir": "/tmp/openclaw-watch-proof-1201369",
      "reason": "watch-targets",
      "changedPath": "/home/chenglunhu/.agents/skills|/home/chenglunhu/.openclaw/skills|/home/chenglunhu/code/openclaw/dist/extensions/browser/skills|/home/chenglunhu/code/openclaw/extensions/qqbot/skills|/tmp/openclaw-watch-proof-1201369/.agents/skills|/tmp/openclaw-watch-proof-1201369/shared-b|/tmp/openclaw-watch-proof-1201369/skills"
    }
  ]
}
```

- **Observed result after fix:** The second watcher setup emitted a `watch-targets` event and increased the workspace snapshot version from `0` to `1779146070842`. That is the missing invalidation signal for existing sessions.
- **What was not tested:** I did not run a live Gateway plus Claude CLI session or inspect a generated `--plugin-dir` mount. The direct proof covers the underlying watcher/version signal and regression tests cover the session-side version read ordering.

Supplemental verification:
- `node scripts/run-vitest.mjs src/agents/skills/refresh.test.ts`
- `node scripts/run-vitest.mjs src/auto-reply/reply/session-updates.test.ts`
- `node scripts/run-vitest.mjs src/gateway/config-reload.test.ts`
- `node scripts/run-vitest.mjs src/agents/skills/refresh.test.ts src/auto-reply/reply/session-updates.test.ts src/gateway/config-reload.test.ts`
- `pnpm check:test-types`
- `pnpm lint:core`
- `node scripts/check.mjs`
- `git diff --check`

## Risk
- Correctness: low; only bumps snapshot version when an existing watcher is rebuilt for a different path set.
- Performance: low; no extra filesystem scan beyond the existing watcher rebuild.
- Backward compatibility: additive change to internal `SkillsChangeEvent.reason` union.
- What I did not change: skill discovery, plugin skill mounting, config reload invalidation policy, or watcher file-event behavior.