### PR TITLE
Parallelize Telegram topic buffers and outbound fairness

### DIFF
--- a/extensions/telegram/src/account-throttler.test.ts
+++ b/extensions/telegram/src/account-throttler.test.ts
@@ -1,5 +1,17 @@
-import { beforeEach, describe, expect, it } from "vitest";
-import { clearAccountThrottlersForTest, getOrCreateAccountThrottler } from "./account-throttler.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearAccountThrottlersForTest,
+  createTelegramAccountThrottler,
+  getOrCreateAccountThrottler,
+} from "./account-throttler.js";
+
+function deferred<T>() {
+  let resolve: (value: T) => void;
+  const promise = new Promise<T>((innerResolve) => {
+    resolve = innerResolve;
+  });
+  return { promise, resolve: resolve! };
+}
 
 describe("getOrCreateAccountThrottler", () => {
   beforeEach(() => {
@@ -13,5 +25,95 @@ describe("getOrCreateAccountThrottler", () => {
 
     expect(second).toBe(first);
     expect(other).not.toBe(first);
+  });
+
+  it("round-robins group topic requests before entering the Telegram throttler", async () => {
+    const firstGate = deferred<void>();
+    const entered: string[] = [];
+    const throttler = createTelegramAccountThrottler(
+      () => async (prev, method, payload, signal) => prev(method, payload, signal),
+    );
+    const prev = vi.fn(async (_method: string, payload: unknown) => {
+      const request = payload as { message_thread_id?: number; text?: string };
+      entered.push(`${request.message_thread_id}:${request.text}`);
+      if (entered.length === 1) {
+        await firstGate.promise;
+      }
+      return request.text;
+    });
+
+    const first = throttler(
+      prev,
+      "sendMessage",
+      { chat_id: -100123, message_thread_id: 10, text: "first" },
+      undefined,
+    );
+    await vi.waitFor(() => expect(entered).toEqual(["10:first"]));
+
+    const secondSameTopic = throttler(
+      prev,
+      "sendMessage",
+      { chat_id: -100123, message_thread_id: 10, text: "second" },
+      undefined,
+    );
+    const otherTopic = throttler(
+      prev,
+      "sendMessage",
+      { chat_id: -100123, message_thread_id: 20, text: "other" },
+      undefined,
+    );
+    await Promise.resolve();
+
+    expect(entered).toEqual(["10:first"]);
+    firstGate.resolve();
+    await vi.waitFor(() => expect(entered.length).toBeGreaterThanOrEqual(2));
+    expect(entered[1]).toBe("20:other");
+    await Promise.all([first, secondSameTopic, otherTopic]);
+
+    expect(entered).toEqual(["10:first", "20:other", "10:second"]);
+  });
+
+  it("uses edited message ids as lanes when Telegram omits topic ids", async () => {
+    const firstGate = deferred<void>();
+    const entered: string[] = [];
+    const throttler = createTelegramAccountThrottler(
+      () => async (prev, method, payload, signal) => prev(method, payload, signal),
+    );
+    const prev = vi.fn(async (_method: string, payload: unknown) => {
+      const request = payload as { message_id?: number; text?: string };
+      entered.push(`${request.message_id}:${request.text}`);
+      if (entered.length === 1) {
+        await firstGate.promise;
+      }
+      return request.text;
+    });
+
+    const first = throttler(
+      prev,
+      "editMessageText",
+      { chat_id: -100123, message_id: 101, text: "first-edit" },
+      undefined,
+    );
+    await vi.waitFor(() => expect(entered).toEqual(["101:first-edit"]));
+
+    const secondSameMessage = throttler(
+      prev,
+      "editMessageText",
+      { chat_id: -100123, message_id: 101, text: "second-edit" },
+      undefined,
+    );
+    const otherMessage = throttler(
+      prev,
+      "editMessageText",
+      { chat_id: -100123, message_id: 202, text: "other-edit" },
+      undefined,
+    );
+
+    firstGate.resolve();
+    await vi.waitFor(() => expect(entered.length).toBeGreaterThanOrEqual(2));
+    expect(entered[1]).toBe("202:other-edit");
+    await Promise.all([first, secondSameMessage, otherMessage]);
+
+    expect(entered).toEqual(["101:first-edit", "202:other-edit", "101:second-edit"]);
   });
 });

--- a/extensions/telegram/src/account-throttler.ts
+++ b/extensions/telegram/src/account-throttler.ts
@@ -1,8 +1,155 @@
 import { apiThrottler } from "./bot.runtime.js";
 
 type ApiThrottlerTransformer = ReturnType<typeof apiThrottler>;
+type TelegramApiPayload = {
+  chat_id?: unknown;
+  direct_messages_topic_id?: unknown;
+  message_id?: unknown;
+  message_thread_id?: unknown;
+};
+type QueuedApiRequest<T> = {
+  run: () => Promise<T>;
+  resolve: (value: T) => void;
+  reject: (err: unknown) => void;
+};
+
+class GroupFairQueue {
+  private readonly lanes = new Map<string, Array<QueuedApiRequest<unknown>>>();
+  private laneOrder: string[] = [];
+  private nextLaneIndex = 0;
+  private running = false;
+
+  enqueue<T>(laneKey: string, run: () => Promise<T>): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      const request: QueuedApiRequest<unknown> = {
+        run,
+        resolve: resolve as (value: unknown) => void,
+        reject,
+      };
+      const existing = this.lanes.get(laneKey);
+      if (existing) {
+        existing.push(request);
+      } else {
+        this.lanes.set(laneKey, [request]);
+        this.laneOrder.push(laneKey);
+      }
+      this.start();
+    });
+  }
+
+  private start(): void {
+    if (this.running) {
+      return;
+    }
+    this.running = true;
+    void this.drain();
+  }
+
+  private async drain(): Promise<void> {
+    try {
+      while (true) {
+        const request = this.takeNext();
+        if (!request) {
+          return;
+        }
+        try {
+          request.resolve(await request.run());
+        } catch (err) {
+          request.reject(err);
+        }
+      }
+    } finally {
+      this.running = false;
+      if (this.laneOrder.length > 0) {
+        this.start();
+      }
+    }
+  }
+
+  private takeNext(): QueuedApiRequest<unknown> | undefined {
+    for (let scanned = 0; scanned < this.laneOrder.length; scanned += 1) {
+      this.nextLaneIndex %= this.laneOrder.length;
+      const laneKey = this.laneOrder[this.nextLaneIndex];
+      const queue = this.lanes.get(laneKey);
+      if (!queue || queue.length === 0) {
+        this.lanes.delete(laneKey);
+        this.laneOrder.splice(this.nextLaneIndex, 1);
+        if (this.laneOrder.length === 0) {
+          this.nextLaneIndex = 0;
+          return undefined;
+        }
+        continue;
+      }
+
+      const request = queue.shift();
+      this.nextLaneIndex += 1;
+      return request;
+    }
+    return undefined;
+  }
+}
 
 const throttlerByToken = new Map<string, ApiThrottlerTransformer>();
+
+function readNumericId(value: unknown): number | undefined {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? Math.trunc(value) : undefined;
+  }
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const numeric = Number(value.trim());
+  return Number.isFinite(numeric) ? Math.trunc(numeric) : undefined;
+}
+
+function readPayload(payload: unknown): TelegramApiPayload | undefined {
+  return payload && typeof payload === "object" ? (payload as TelegramApiPayload) : undefined;
+}
+
+function resolveGroupChatKey(payload: TelegramApiPayload): string | undefined {
+  const chatId = readNumericId(payload.chat_id);
+  return chatId !== undefined && chatId < 0 ? String(chatId) : undefined;
+}
+
+function resolveForumLaneKey(payload: TelegramApiPayload): string {
+  const threadId = readNumericId(payload.message_thread_id);
+  if (threadId !== undefined) {
+    return `topic:${threadId}`;
+  }
+  const directTopicId = readNumericId(payload.direct_messages_topic_id);
+  if (directTopicId !== undefined) {
+    return `direct-topic:${directTopicId}`;
+  }
+  const messageId = readNumericId(payload.message_id);
+  if (messageId !== undefined) {
+    return `message:${messageId}`;
+  }
+  return "main";
+}
+
+export function createTelegramAccountThrottler(
+  createThrottler: () => ApiThrottlerTransformer = apiThrottler,
+): ApiThrottlerTransformer {
+  const baseThrottler = createThrottler();
+  const fairQueuesByChat = new Map<string, GroupFairQueue>();
+
+  return (prev, method, payload, signal) => {
+    const apiPayload = readPayload(payload);
+    const groupChatKey = apiPayload ? resolveGroupChatKey(apiPayload) : undefined;
+    if (!apiPayload || !groupChatKey) {
+      return baseThrottler(prev, method, payload, signal);
+    }
+
+    let fairQueue = fairQueuesByChat.get(groupChatKey);
+    if (!fairQueue) {
+      fairQueue = new GroupFairQueue();
+      fairQueuesByChat.set(groupChatKey, fairQueue);
+    }
+
+    const laneKey = resolveForumLaneKey(apiPayload);
+    return fairQueue.enqueue(laneKey, () => baseThrottler(prev, method, payload, signal));
+  };
+}
 
 export function getOrCreateAccountThrottler(
   token: string,
@@ -10,7 +157,7 @@ export function getOrCreateAccountThrottler(
 ): ApiThrottlerTransformer {
   let throttler = throttlerByToken.get(token);
   if (!throttler) {
-    throttler = createThrottler();
+    throttler = createTelegramAccountThrottler(createThrottler);
     throttlerByToken.set(token, throttler);
   }
   return throttler;

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -195,7 +195,7 @@ export const registerTelegramHandlers = ({
   };
 
   const mediaGroupBuffer = new Map<string, BufferedMediaGroupEntry>();
-  let mediaGroupProcessing: Promise<void> = Promise.resolve();
+  const mediaGroupProcessingByKey = new Map<string, Promise<void>>();
   const messageCache = createTelegramMessageCache({
     persistedPath: resolveTelegramMessageCachePath(
       telegramDeps.resolveStorePath(cfg.session?.store),
@@ -210,7 +210,21 @@ export const registerTelegramHandlers = ({
     timer: ReturnType<typeof setTimeout>;
   };
   const textFragmentBuffer = new Map<string, TextFragmentEntry>();
-  let textFragmentProcessing: Promise<void> = Promise.resolve();
+  const textFragmentProcessingByKey = new Map<string, Promise<void>>();
+
+  const queueBufferedProcessing = async (
+    processingByKey: Map<string, Promise<void>>,
+    key: string,
+    task: () => Promise<void>,
+  ) => {
+    const previous = processingByKey.get(key) ?? Promise.resolve();
+    const current = previous.then(task).catch(() => undefined);
+    processingByKey.set(key, current);
+    await current;
+    if (processingByKey.get(key) === current) {
+      processingByKey.delete(key);
+    }
+  };
 
   const debounceMs = resolveInboundDebounceMs({ cfg, channel: "telegram" });
   const FORWARD_BURST_DEBOUNCE_MS = 80;
@@ -864,12 +878,9 @@ export const registerTelegramHandlers = ({
   };
 
   const queueTextFragmentFlush = async (entry: TextFragmentEntry) => {
-    textFragmentProcessing = textFragmentProcessing
-      .then(async () => {
-        await flushTextFragments(entry);
-      })
-      .catch(() => undefined);
-    await textFragmentProcessing;
+    await queueBufferedProcessing(textFragmentProcessingByKey, entry.key, async () => {
+      await flushTextFragments(entry);
+    });
   };
 
   const runTextFragmentFlush = async (entry: TextFragmentEntry) => {
@@ -1613,12 +1624,7 @@ export const registerTelegramHandlers = ({
         // Not appendable (or limits exceeded): flush buffered entry first, then continue normally.
         clearTimeout(existing.timer);
         textFragmentBuffer.delete(key);
-        textFragmentProcessing = textFragmentProcessing
-          .then(async () => {
-            await flushTextFragments(existing);
-          })
-          .catch(() => undefined);
-        await textFragmentProcessing;
+        await queueTextFragmentFlush(existing);
       }
 
       const shouldStart = text.length >= TELEGRAM_TEXT_FRAGMENT_START_THRESHOLD_CHARS;
@@ -1647,7 +1653,9 @@ export const registerTelegramHandlers = ({
     // Media group handling - buffer multi-image messages
     const mediaGroupId = msg.media_group_id;
     if (mediaGroupId) {
-      const existing = mediaGroupBuffer.get(mediaGroupId);
+      const threadId = resolvedThreadId ?? dmThreadId;
+      const mediaGroupKey = `media:${chatId}:${threadId ?? "main"}:${mediaGroupId}`;
+      const existing = mediaGroupBuffer.get(mediaGroupKey);
       if (existing) {
         clearTimeout(existing.timer);
         existing.messages.push({ msg, ctx });
@@ -1656,13 +1664,10 @@ export const registerTelegramHandlers = ({
           promptContextMinTimestampMs,
         );
         existing.timer = setTimeout(async () => {
-          mediaGroupBuffer.delete(mediaGroupId);
-          mediaGroupProcessing = mediaGroupProcessing
-            .then(async () => {
-              await processMediaGroup(existing);
-            })
-            .catch(() => undefined);
-          await mediaGroupProcessing;
+          mediaGroupBuffer.delete(mediaGroupKey);
+          await queueBufferedProcessing(mediaGroupProcessingByKey, mediaGroupKey, async () => {
+            await processMediaGroup(existing);
+          });
         }, mediaGroupTimeoutMs);
       } else {
         const entry: BufferedMediaGroupEntry = {
@@ -1679,16 +1684,13 @@ export const registerTelegramHandlers = ({
           topicConfig,
           ...promptContextBoundaryOptions(promptContextMinTimestampMs),
           timer: setTimeout(async () => {
-            mediaGroupBuffer.delete(mediaGroupId);
-            mediaGroupProcessing = mediaGroupProcessing
-              .then(async () => {
-                await processMediaGroup(entry);
-              })
-              .catch(() => undefined);
-            await mediaGroupProcessing;
+            mediaGroupBuffer.delete(mediaGroupKey);
+            await queueBufferedProcessing(mediaGroupProcessingByKey, mediaGroupKey, async () => {
+              await processMediaGroup(entry);
+            });
           }, mediaGroupTimeoutMs),
         };
-        mediaGroupBuffer.set(mediaGroupId, entry);
+        mediaGroupBuffer.set(mediaGroupKey, entry);
       }
       return;
     }

--- a/extensions/telegram/src/bot.media.downloads-media-file-path-no-file-download.e2e.test.ts
+++ b/extensions/telegram/src/bot.media.downloads-media-file-path-no-file-download.e2e.test.ts
@@ -435,6 +435,97 @@ describe("telegram media groups", () => {
     },
     MEDIA_GROUP_TEST_TIMEOUT_MS,
   );
+
+  it(
+    "flushes same-id forum topic media groups in parallel",
+    async () => {
+      const originalLoadConfig = telegramBotDepsForTest.getRuntimeConfig;
+      telegramBotDepsForTest.getRuntimeConfig = (() => ({
+        channels: {
+          telegram: {
+            dmPolicy: "open",
+            allowFrom: ["*"],
+            groupPolicy: "open",
+            groups: { "*": { requireMention: false } },
+          },
+        },
+      })) as typeof telegramBotDepsForTest.getRuntimeConfig;
+
+      const runtimeError = vi.fn();
+      const { handler, replySpy } = await createBotHandlerWithOptions({ runtimeError });
+      const fetchSpy = mockTelegramPngDownload();
+      let releaseFirstReply: (() => void) | undefined;
+      const firstReplyStarted = new Promise<void>((resolve) => {
+        replySpy.mockImplementationOnce(async (_ctx, opts?: { onReplyStart?: () => unknown }) => {
+          await opts?.onReplyStart?.();
+          resolve();
+          await new Promise<void>((release) => {
+            releaseFirstReply = release;
+          });
+          return undefined;
+        });
+      });
+
+      try {
+        await Promise.all([
+          handler({
+            message: {
+              chat: { id: -10042, type: "supergroup" as const, is_forum: true },
+              from: { id: 777, is_bot: false, first_name: "Ada" },
+              message_id: 31,
+              message_thread_id: 101,
+              caption: "Topic one album",
+              date: 1736380800,
+              media_group_id: "album-shared-by-telegram",
+              photo: [{ file_id: "topic1photo" }],
+            },
+            me: { username: "openclaw_bot" },
+            getFile: async () => ({ file_path: "photos/topic1.jpg" }),
+          }),
+          handler({
+            message: {
+              chat: { id: -10042, type: "supergroup" as const, is_forum: true },
+              from: { id: 777, is_bot: false, first_name: "Ada" },
+              message_id: 32,
+              message_thread_id: 202,
+              caption: "Topic two album",
+              date: 1736380801,
+              media_group_id: "album-shared-by-telegram",
+              photo: [{ file_id: "topic2photo" }],
+            },
+            me: { username: "openclaw_bot" },
+            getFile: async () => ({ file_path: "photos/topic2.jpg" }),
+          }),
+        ]);
+
+        await firstReplyStarted;
+        expect(replySpy).toHaveBeenCalledTimes(1);
+        await vi.waitFor(
+          () => {
+            expect(replySpy).toHaveBeenCalledTimes(2);
+          },
+          { timeout: MEDIA_GROUP_WAIT_TIMEOUT_MS, interval: 2 },
+        );
+
+        const firstPayload = replyPayload(replySpy, 0);
+        const secondPayload = replyPayload(replySpy, 1);
+        expect([firstPayload.Body, secondPayload.Body]).toEqual(
+          expect.arrayContaining([
+            expect.stringContaining("Topic one album"),
+            expect.stringContaining("Topic two album"),
+          ]),
+        );
+        expect(firstPayload.MediaPaths).toHaveLength(1);
+        expect(secondPayload.MediaPaths).toHaveLength(1);
+        expect(runtimeError).not.toHaveBeenCalled();
+      } finally {
+        releaseFirstReply?.();
+        fetchSpy.mockRestore();
+        telegramBotDepsForTest.getRuntimeConfig = originalLoadConfig;
+      }
+    },
+    MEDIA_GROUP_TEST_TIMEOUT_MS,
+  );
 });
 
 describe("telegram forwarded bursts", () => {

--- a/extensions/telegram/src/bot.media.stickers-and-fragments.e2e.test.ts
+++ b/extensions/telegram/src/bot.media.stickers-and-fragments.e2e.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { telegramBotDepsForTest } from "./bot.media.e2e-harness.js";
 import {
   TELEGRAM_TEST_TIMINGS,
   cacheStickerSpy,
@@ -202,6 +203,10 @@ describe("telegram text fragments", () => {
   });
 
   const TEXT_FRAGMENT_TEST_TIMEOUT_MS = process.platform === "win32" ? 45_000 : 20_000;
+  const TEXT_FRAGMENT_PARALLEL_WAIT_TIMEOUT_MS = Math.max(
+    2_000,
+    TELEGRAM_TEST_TIMINGS.textFragmentGapMs * 10,
+  );
 
   it(
     "buffers near-limit text and processes sequential parts as one message",
@@ -245,6 +250,88 @@ describe("telegram text fragments", () => {
         expect(payload.RawBody).toContain(part2.slice(0, 32));
       } finally {
         setTimeoutSpy.mockRestore();
+      }
+    },
+    TEXT_FRAGMENT_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "flushes different forum topic fragments in parallel",
+    async () => {
+      const originalLoadConfig = telegramBotDepsForTest.getRuntimeConfig;
+      telegramBotDepsForTest.getRuntimeConfig = (() => ({
+        channels: {
+          telegram: {
+            dmPolicy: "open",
+            allowFrom: ["*"],
+            groupPolicy: "open",
+            groups: { "*": { requireMention: false } },
+          },
+        },
+      })) as typeof telegramBotDepsForTest.getRuntimeConfig;
+
+      const runtimeError = vi.fn();
+      const { handler, replySpy } = await createBotHandlerWithOptions({ runtimeError });
+      let releaseFirstReply: (() => void) | undefined;
+      const firstReplyStarted = new Promise<void>((resolve) => {
+        replySpy.mockImplementationOnce(async (_ctx, opts?: { onReplyStart?: () => unknown }) => {
+          await opts?.onReplyStart?.();
+          resolve();
+          await new Promise<void>((release) => {
+            releaseFirstReply = release;
+          });
+          return undefined;
+        });
+      });
+
+      try {
+        await handler({
+          message: {
+            chat: { id: -10042, type: "supergroup", is_forum: true },
+            from: { id: 777, is_bot: false, first_name: "Ada" },
+            message_id: 20,
+            message_thread_id: 101,
+            date: 1736380800,
+            text: `topic-one ${"A".repeat(4050)}`,
+          },
+          me: { username: "openclaw_bot" },
+          getFile: async () => ({}),
+        });
+
+        await handler({
+          message: {
+            chat: { id: -10042, type: "supergroup", is_forum: true },
+            from: { id: 777, is_bot: false, first_name: "Ada" },
+            message_id: 21,
+            message_thread_id: 202,
+            date: 1736380801,
+            text: `topic-two ${"B".repeat(4050)}`,
+          },
+          me: { username: "openclaw_bot" },
+          getFile: async () => ({}),
+        });
+
+        await firstReplyStarted;
+        expect(replySpy).toHaveBeenCalledTimes(1);
+        await vi.waitFor(
+          () => {
+            expect(replySpy).toHaveBeenCalledTimes(2);
+          },
+          { timeout: TEXT_FRAGMENT_PARALLEL_WAIT_TIMEOUT_MS, interval: 2 },
+        );
+
+        const firstPayload = replySpy.mock.calls.at(0)?.[0] as { RawBody?: string };
+        const secondPayload = replySpy.mock.calls.at(1)?.[0] as { RawBody?: string };
+        expect([firstPayload.RawBody, secondPayload.RawBody]).toEqual(
+          expect.arrayContaining([
+            expect.stringContaining("topic-one"),
+            expect.stringContaining("topic-two"),
+          ]),
+        );
+        expect(runtimeError).not.toHaveBeenCalled();
+      } finally {
+        releaseFirstReply?.();
+        telegramBotDepsForTest.getRuntimeConfig = originalLoadConfig;
       }
     },
     TEXT_FRAGMENT_TEST_TIMEOUT_MS,


### PR DESCRIPTION
Superseded by the consolidated Telegram forum-topic flow PR.

This draft is being closed so the complete fix, root cause, before proof, and live after proof live in one review thread. The replacement PR carries this buffer/outbound-fairness work plus the topic-identity fix from #83789.

Sensitive-data check before close: no password/token/API-key shaped values were found in this PR body/comments. The replacement PR uses redacted live identifiers.