### PR TITLE
fix(ui): keep delete confirm in viewport

### DIFF
--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -537,8 +537,7 @@ details.msg-meta:not([open]) .msg-meta__details {
 }
 
 .chat-delete-confirm {
-  position: absolute;
-  bottom: calc(100% + 6px);
+  position: fixed;
   background: var(--card, #1a1a1a);
   border: 1px solid var(--border, rgba(255, 255, 255, 0.1));
   border-radius: var(--radius-md, 8px);
@@ -551,11 +550,11 @@ details.msg-meta:not([open]) .msg-meta__details {
 }
 
 .chat-delete-confirm--left {
-  right: 0;
+  transform-origin: top right;
 }
 
 .chat-delete-confirm--right {
-  left: 0;
+  transform-origin: top left;
 }
 
 .chat-delete-confirm__text {

--- a/ui/src/ui/chat/grouped-render.test.ts
+++ b/ui/src/ui/chat/grouped-render.test.ts
@@ -388,6 +388,50 @@ function openDeleteConfirm(deleteButton: HTMLButtonElement) {
   deleteButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
 }
 
+function domRect(params: {
+  left?: number;
+  top?: number;
+  width?: number;
+  height?: number;
+}): DOMRect {
+  const left = params.left ?? 0;
+  const top = params.top ?? 0;
+  const width = params.width ?? 0;
+  const height = params.height ?? 0;
+  const rect = {
+    x: left,
+    y: top,
+    left,
+    top,
+    width,
+    height,
+    right: left + width,
+    bottom: top + height,
+    toJSON: () => rect,
+  };
+  return rect as DOMRect;
+}
+
+function stubDeleteConfirmGeometry(params: {
+  trigger: { left: number; top: number; width: number; height: number };
+  popover: { width: number; height: number };
+  viewport: { width: number; height: number };
+}) {
+  vi.stubGlobal("innerWidth", params.viewport.width);
+  vi.stubGlobal("innerHeight", params.viewport.height);
+  vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function (
+    this: HTMLElement,
+  ) {
+    if (this.classList.contains("chat-group-delete")) {
+      return domRect(params.trigger);
+    }
+    if (this.classList.contains("chat-delete-confirm")) {
+      return domRect(params.popover);
+    }
+    return domRect({});
+  });
+}
+
 function clickDeleteButtonIconPath(deleteButton: HTMLButtonElement) {
   const icon = document.createElementNS("http://www.w3.org/2000/svg", "svg");
   const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
@@ -567,6 +611,64 @@ describe("grouped chat rendering", () => {
       "chat-delete-confirm",
       "chat-delete-confirm--right",
     ]);
+  });
+
+  it("places the delete confirm below the trigger near the top viewport edge", () => {
+    stubDeleteConfirmGeometry({
+      trigger: { left: 20, top: 4, width: 24, height: 24 },
+      popover: { width: 200, height: 96 },
+      viewport: { width: 320, height: 240 },
+    });
+    const fixture = renderDeleteConfirmFixture();
+
+    openDeleteConfirm(fixture.deleteButton);
+
+    const popover = expectElement(
+      fixture.container,
+      ".chat-delete-confirm",
+      HTMLElement,
+    );
+    expect(popover.dataset.placement).toBe("below");
+    expect(popover.style.top).toBe("34px");
+    expect(popover.style.left).toBe("20px");
+  });
+
+  it("places the delete confirm above the trigger near the bottom viewport edge", () => {
+    stubDeleteConfirmGeometry({
+      trigger: { left: 20, top: 190, width: 24, height: 24 },
+      popover: { width: 200, height: 80 },
+      viewport: { width: 320, height: 240 },
+    });
+    const fixture = renderDeleteConfirmFixture();
+
+    openDeleteConfirm(fixture.deleteButton);
+
+    const popover = expectElement(
+      fixture.container,
+      ".chat-delete-confirm",
+      HTMLElement,
+    );
+    expect(popover.dataset.placement).toBe("above");
+    expect(popover.style.top).toBe("104px");
+    expect(popover.style.left).toBe("20px");
+  });
+
+  it("clamps the delete confirm horizontally inside narrow viewports", () => {
+    stubDeleteConfirmGeometry({
+      trigger: { left: 260, top: 120, width: 24, height: 24 },
+      popover: { width: 200, height: 80 },
+      viewport: { width: 320, height: 240 },
+    });
+    const fixture = renderDeleteConfirmFixture();
+
+    openDeleteConfirm(fixture.deleteButton);
+
+    const popover = expectElement(
+      fixture.container,
+      ".chat-delete-confirm",
+      HTMLElement,
+    );
+    expect(popover.style.left).toBe("112px");
   });
 
   it("removes the delete confirm outside-click listener when Cancel dismisses it", () => {

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -613,6 +613,8 @@ function renderMessageMeta(meta: GroupMeta | null) {
 }
 
 const SKIP_DELETE_CONFIRM_KEY = "openclaw:skipDeleteConfirm";
+const DELETE_CONFIRM_VIEWPORT_MARGIN_PX = 8;
+const DELETE_CONFIRM_TRIGGER_GAP_PX = 6;
 
 type DeleteConfirmSide = "left" | "right";
 
@@ -633,6 +635,57 @@ function dismissDeleteConfirm(element: Element) {
     return;
   }
   element.remove();
+}
+
+function resolveViewportSize() {
+  const viewport = window.visualViewport;
+  return {
+    width: viewport?.width ?? window.innerWidth ?? document.documentElement.clientWidth,
+    height: viewport?.height ?? window.innerHeight ?? document.documentElement.clientHeight,
+  };
+}
+
+function clampDeleteConfirmPosition(value: number, min: number, max: number) {
+  if (max < min) {
+    return min;
+  }
+  return Math.min(Math.max(value, min), max);
+}
+
+function placeDeleteConfirmPopover(
+  trigger: HTMLElement,
+  popover: HTMLElement,
+  side: DeleteConfirmSide,
+) {
+  const triggerRect = trigger.getBoundingClientRect();
+  const popoverRect = popover.getBoundingClientRect();
+  const viewport = resolveViewportSize();
+  const margin = DELETE_CONFIRM_VIEWPORT_MARGIN_PX;
+  const gap = DELETE_CONFIRM_TRIGGER_GAP_PX;
+  const popoverWidth = Math.min(popoverRect.width, viewport.width - margin * 2);
+  const popoverHeight = Math.min(popoverRect.height, viewport.height - margin * 2);
+  const spaceAbove = triggerRect.top - margin - gap;
+  const spaceBelow = viewport.height - triggerRect.bottom - margin - gap;
+  const placeBelow = spaceAbove < popoverHeight && spaceBelow >= spaceAbove;
+  const desiredLeft =
+    side === "left" ? triggerRect.right - popoverWidth : triggerRect.left;
+  const left = clampDeleteConfirmPosition(
+    desiredLeft,
+    margin,
+    viewport.width - margin - popoverWidth,
+  );
+  const desiredTop = placeBelow
+    ? triggerRect.bottom + gap
+    : triggerRect.top - gap - popoverHeight;
+  const top = clampDeleteConfirmPosition(
+    desiredTop,
+    margin,
+    viewport.height - margin - popoverHeight,
+  );
+
+  popover.style.left = `${Math.round(left)}px`;
+  popover.style.top = `${Math.round(top)}px`;
+  popover.dataset.placement = placeBelow ? "below" : "above";
 }
 
 function renderDeleteButton(onDelete: () => void, side: DeleteConfirmSide) {
@@ -668,6 +721,7 @@ function renderDeleteButton(onDelete: () => void, side: DeleteConfirmSide) {
             </div>
           `;
           wrap.appendChild(popover);
+          placeDeleteConfirmPopover(btn, popover, side);
 
           const cancel = popover.querySelector(".chat-delete-confirm__cancel")!;
           const yes = popover.querySelector(".chat-delete-confirm__yes")!;
@@ -705,6 +759,7 @@ function renderDeleteButton(onDelete: () => void, side: DeleteConfirmSide) {
 
           requestAnimationFrame(() => {
             if (!dismissed && popover.isConnected) {
+              placeDeleteConfirmPopover(btn, popover, side);
               document.addEventListener("click", closeOnOutside, true);
             }
           });


### PR DESCRIPTION
## Related issue

Related #50277

## Summary

- Position the chat delete confirmation popover relative to the viewport instead of the scroll container.
- Choose above or below the delete button based on available vertical space.
- Clamp the popover horizontally so it remains reachable on narrow viewports.
- Add focused jsdom geometry coverage for top-edge, bottom-edge, and narrow-width placement.

## User-visible behavior

The delete confirmation popover in Control UI chat should remain visible and reachable when deleting messages near the top or edges of the chat viewport.

## Real behavior proof

- Behavior or issue addressed: Control UI grouped chat delete confirmation could render out of reach when opened near the top or horizontal viewport edges because it was absolutely positioned inside the scrollable chat area. This patch positions the popover against the viewport, flips it above or below the delete button, and clamps it inside viewport margins.
- Real environment tested: Local OpenClaw checkout at `4a0465007c` on Raspberry Pi-class Linux host, Node `v22.21.1`, Chromium `142.0.7444.175`, using the PR's `.chat-delete-confirm` markup/CSS and viewport-placement code path.
- Exact steps or command run after this patch:

```bash
chromium --headless=new --disable-gpu --no-sandbox --force-device-scale-factor=1 --window-size=360,640 --dump-dom file:///tmp/openclaw-delete-confirm-proof.html
```

- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Terminal output excerpt from Chromium:

```text
OpenClaw Control UI delete-confirm viewport proof
viewport=500x553
top-edge: placement=below left=90 top=38 withinViewport=true
bottom-edge: placement=above left=12 top=86 withinViewport=true
horizontal-edge: placement=below left=104 top=130 withinViewport=true
```

- Observed result after fix: In Chromium, the delete confirmation popover remains inside the viewport margins for top-edge, bottom-edge, and horizontal-edge cases. The top-edge case opens below the trigger, the bottom-edge case opens above the trigger, and the horizontal-edge case stays within the right boundary.
- What was not tested: Full gateway-backed dashboard click path on this Raspberry Pi-class host; dependency installation was intentionally avoided. Visual screenshot capture was not attached because copied browser output is the supplied proof.

## Supplemental validation

- `git diff --check` exited 0 locally with no whitespace errors.
- GitHub Actions `checks-node-core-ui` passed on head `4a0465007c`.
- GitHub Actions `check-test-types` passed on head `4a0465007c` after adding `this: HTMLElement` to the test geometry mock.

## AI-assisted

AI-assisted: yes. I reviewed the diff and understand the change scope.