### PR TITLE
codex: surface deferred dynamic tool names

### DIFF
--- a/apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift
+++ b/apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift
@@ -819,7 +819,8 @@ private struct TriggerPhraseHelpRow: View {
                 .padding(.top, 1)
 
             Text(
-                "OpenClaw reacts when any trigger appears in a transcription. Keep phrases short to avoid false positives."
+                "OpenClaw reacts when any trigger appears in a transcription. " +
+                    "Keep phrases short to avoid false positives.",
             )
                 .font(.footnote)
                 .foregroundStyle(.secondary)

--- a/apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift
+++ b/apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift
@@ -820,8 +820,7 @@ private struct TriggerPhraseHelpRow: View {
 
             Text(
                 "OpenClaw reacts when any trigger appears in a transcription. " +
-                    "Keep phrases short to avoid false positives.",
-            )
+                    "Keep phrases short to avoid false positives.")
                 .font(.footnote)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)

--- a/apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift
+++ b/apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift
@@ -818,7 +818,9 @@ private struct TriggerPhraseHelpRow: View {
                 .frame(width: 18)
                 .padding(.top, 1)
 
-            Text("OpenClaw reacts when any trigger appears in a transcription. Keep phrases short to avoid false positives.")
+            Text(
+                "OpenClaw reacts when any trigger appears in a transcription. Keep phrases short to avoid false positives."
+            )
                 .font(.footnote)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -980,7 +980,9 @@ export async function runCodexAppServerAttempt(
     historyMessages =
       (await readMirroredSessionHistoryMessages(activeSessionFile)) ?? historyMessages;
   }
-  const baseDeveloperInstructions = buildDeveloperInstructions(params);
+  const baseDeveloperInstructions = buildDeveloperInstructions(params, {
+    dynamicTools: toolBridge.specs,
+  });
   // Keep OpenClaw user-editable context in the turn input so native Codex
   // system/developer instructions remain the higher-priority policy layer.
   const workspaceBootstrapContext = await buildCodexWorkspaceBootstrapContext({

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -68,6 +68,52 @@ describe("Codex app-server native code mode config", () => {
     );
   });
 
+  it("summarizes deferred dynamic tool names in developer instructions", () => {
+    const instructions = buildDeveloperInstructions(createAttemptParams({ provider: "openai" }), {
+      dynamicTools: [
+        {
+          name: "message",
+          description: "Send a message",
+          inputSchema: { type: "object" },
+        },
+        {
+          name: "music_generate",
+          description: "Create music",
+          inputSchema: { type: "object" },
+          namespace: "openclaw",
+          deferLoading: true,
+        },
+        {
+          name: "image_generate",
+          description: "Create images",
+          inputSchema: { type: "object" },
+          namespace: "openclaw",
+          deferLoading: true,
+        },
+      ],
+    });
+
+    expect(instructions).toContain(
+      "Deferred searchable OpenClaw dynamic tools available: image_generate, music_generate.",
+    );
+    expect(instructions).toContain("Use `tool_search` to load exact callable specs before use.");
+    expect(instructions).not.toContain("message,");
+  });
+
+  it("keeps developer instructions compact when no dynamic tools are deferred", () => {
+    const instructions = buildDeveloperInstructions(createAttemptParams({ provider: "openai" }), {
+      dynamicTools: [
+        {
+          name: "message",
+          description: "Send a message",
+          inputSchema: { type: "object" },
+        },
+      ],
+    });
+
+    expect(instructions).not.toContain("Deferred searchable OpenClaw dynamic tools available");
+  });
+
   it("keeps OpenClaw skill catalogs out of developer instructions", () => {
     const params = createAttemptParams({ provider: "openai" });
     params.skillsSnapshot = {

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -261,6 +261,7 @@ export async function startOrResumeThread(params: {
               threadId: binding.threadId,
               authProfileId,
               appServer: params.appServer,
+              dynamicTools: params.dynamicTools,
               developerInstructions: params.developerInstructions,
               config: resumeConfig,
               nativeCodeModeEnabled: params.nativeCodeModeEnabled,
@@ -585,7 +586,9 @@ export function buildThreadStartParams(
       nativeCodeModeOnlyEnabled: options.nativeCodeModeOnlyEnabled,
     }),
     ...(options.nativeCodeModeEnabled === false ? { environments: [] } : {}),
-    developerInstructions: options.developerInstructions ?? buildDeveloperInstructions(params),
+    developerInstructions:
+      options.developerInstructions ??
+      buildDeveloperInstructions(params, { dynamicTools: options.dynamicTools }),
     dynamicTools: options.dynamicTools,
     experimentalRawEvents: true,
     persistExtendedHistory: true,
@@ -598,6 +601,7 @@ export function buildThreadResumeParams(
     threadId: string;
     authProfileId?: string;
     appServer: CodexAppServerRuntimeOptions;
+    dynamicTools?: CodexDynamicToolSpec[];
     developerInstructions?: string;
     config?: JsonObject;
     nativeCodeModeEnabled?: boolean;
@@ -623,7 +627,9 @@ export function buildThreadResumeParams(
       nativeCodeModeEnabled: options.nativeCodeModeEnabled,
       nativeCodeModeOnlyEnabled: options.nativeCodeModeOnlyEnabled,
     }),
-    developerInstructions: options.developerInstructions ?? buildDeveloperInstructions(params),
+    developerInstructions:
+      options.developerInstructions ??
+      buildDeveloperInstructions(params, { dynamicTools: options.dynamicTools }),
     persistExtendedHistory: true,
   };
 }
@@ -820,19 +826,40 @@ function compareJsonFingerprint(left: JsonValue, right: JsonValue): number {
   return JSON.stringify(left).localeCompare(JSON.stringify(right));
 }
 
-export function buildDeveloperInstructions(params: EmbeddedRunAttemptParams): string {
+export function buildDeveloperInstructions(
+  params: EmbeddedRunAttemptParams,
+  options: { dynamicTools?: readonly CodexDynamicToolSpec[] } = {},
+): string {
   const nativeCommandGuidance = listRegisteredPluginAgentPromptGuidance({
     surface: "codex_app_server",
     includeLegacyGlobalGuidance: false,
   }).join("\n");
   const sections = [
     "Running inside OpenClaw. Use OpenClaw dynamic tools for OpenClaw-owned messaging, cron, sessions, media, gateway, and nodes capabilities when available.",
+    buildDeferredDynamicToolManifest(options.dynamicTools),
     "Use Codex native `spawn_agent` for Codex subagents. Use OpenClaw `sessions_spawn` only for OpenClaw or ACP delegation; if it is not already loaded, search for `sessions_spawn` in the `openclaw` dynamic tool namespace before calling it.",
     buildVisibleReplyInstruction(params),
     nativeCommandGuidance,
     params.extraSystemPrompt,
   ];
   return sections.filter((section) => typeof section === "string" && section.trim()).join("\n\n");
+}
+
+function buildDeferredDynamicToolManifest(
+  dynamicTools: readonly CodexDynamicToolSpec[] | undefined,
+): string | undefined {
+  const deferredToolNames = [
+    ...new Set(
+      (dynamicTools ?? [])
+        .filter((tool) => tool.deferLoading === true)
+        .map((tool) => tool.name.trim())
+        .filter(Boolean),
+    ),
+  ].toSorted((left, right) => left.localeCompare(right));
+  if (deferredToolNames.length === 0) {
+    return undefined;
+  }
+  return `Deferred searchable OpenClaw dynamic tools available: ${deferredToolNames.join(", ")}. Use \`tool_search\` to load exact callable specs before use.`;
 }
 
 function buildVisibleReplyInstruction(params: EmbeddedRunAttemptParams): string {

--- a/extensions/codex/test-api.ts
+++ b/extensions/codex/test-api.ts
@@ -43,7 +43,9 @@ export function buildCodexHarnessPromptSnapshot(params: {
   config?: JsonObject;
   promptText?: string;
 }): CodexHarnessPromptSnapshot {
-  const developerInstructions = buildDeveloperInstructions(params.attempt);
+  const developerInstructions = buildDeveloperInstructions(params.attempt, {
+    dynamicTools: params.dynamicTools,
+  });
   return {
     developerInstructions,
     threadStartParams: buildThreadStartParams(params.attempt, {

--- a/src/test-utils/bundled-plugin-public-surface.ts
+++ b/src/test-utils/bundled-plugin-public-surface.ts
@@ -132,11 +132,11 @@ export const loadBundledPluginPublicSurfaceSync: BundledPluginPublicSurfaceLoade
   });
 };
 
-export const loadBundledPluginPublicSurfaceSourceSync: BundledPluginPublicSurfaceLoader = <
-  T extends object,
->(
-  params,
-): T => {
+// oxlint-disable-next-line typescript/no-unnecessary-type-parameters -- Test loaders use caller-supplied module surface types.
+export function loadBundledPluginPublicSurfaceSourceSync<T extends object>(params: {
+  pluginId: string;
+  artifactBasename: string;
+}): T {
   const modulePath = resolveVitestSourceModulePath(
     resolveBundledPluginPublicModulePath({
       pluginId: params.pluginId,
@@ -151,7 +151,7 @@ export const loadBundledPluginPublicSurfaceSourceSync: BundledPluginPublicSurfac
     pluginSdkResolution: "src",
   });
   return loader(modulePath) as T;
-};
+}
 
 export const loadBundledPluginPublicSurface: AsyncBundledPluginPublicSurfaceLoader = (params) => {
   const metadata = findBundledPluginMetadata(params.pluginId);

--- a/src/test-utils/bundled-plugin-public-surface.ts
+++ b/src/test-utils/bundled-plugin-public-surface.ts
@@ -10,6 +10,10 @@ import {
   findBundledPluginMetadataById,
   type BundledPluginMetadata,
 } from "../plugins/bundled-plugin-metadata.js";
+import {
+  getCachedPluginSourceModuleLoader,
+  type PluginModuleLoaderCache,
+} from "../plugins/plugin-module-loader-cache.js";
 import { normalizeBundledPluginArtifactSubpath } from "../plugins/public-surface-runtime.js";
 import { resolveLoaderPackageRoot } from "../plugins/sdk-alias.js";
 
@@ -20,6 +24,7 @@ const OPENCLAW_PACKAGE_ROOT =
   }) ?? fileURLToPath(new URL("../..", import.meta.url));
 
 type BundledPluginPublicSurfaceMetadata = Pick<BundledPluginMetadata, "dirName">;
+const sourceModuleLoaders: PluginModuleLoaderCache = new Map();
 
 function isSafeBundledPluginDirName(pluginId: string): boolean {
   return /^[a-z0-9][a-z0-9._-]*$/u.test(pluginId);
@@ -125,6 +130,27 @@ export const loadBundledPluginPublicSurfaceSync: BundledPluginPublicSurfaceLoade
     dirName: metadata.dirName,
     artifactBasename: normalizeBundledPluginArtifactSubpath(params.artifactBasename),
   });
+};
+
+export const loadBundledPluginPublicSurfaceSourceSync: BundledPluginPublicSurfaceLoader = <
+  T extends object,
+>(
+  params,
+): T => {
+  const modulePath = resolveVitestSourceModulePath(
+    resolveBundledPluginPublicModulePath({
+      pluginId: params.pluginId,
+      artifactBasename: params.artifactBasename,
+    }),
+  );
+  const loader = getCachedPluginSourceModuleLoader({
+    cache: sourceModuleLoaders,
+    modulePath,
+    importerUrl: import.meta.url,
+    loaderFilename: import.meta.url,
+    pluginSdkResolution: "src",
+  });
+  return loader(modulePath) as T;
 };
 
 export const loadBundledPluginPublicSurface: AsyncBundledPluginPublicSurfaceLoader = (params) => {

--- a/src/test-utils/bundled-plugin-public-surface.ts
+++ b/src/test-utils/bundled-plugin-public-surface.ts
@@ -132,11 +132,10 @@ export const loadBundledPluginPublicSurfaceSync: BundledPluginPublicSurfaceLoade
   });
 };
 
-// oxlint-disable-next-line typescript/no-unnecessary-type-parameters -- Test loaders use caller-supplied module surface types.
-export function loadBundledPluginPublicSurfaceSourceSync<T extends object>(params: {
+export function loadBundledPluginPublicSurfaceSourceSync(params: {
   pluginId: string;
   artifactBasename: string;
-}): T {
+}): object {
   const modulePath = resolveVitestSourceModulePath(
     resolveBundledPluginPublicModulePath({
       pluginId: params.pluginId,
@@ -150,7 +149,7 @@ export function loadBundledPluginPublicSurfaceSourceSync<T extends object>(param
     loaderFilename: import.meta.url,
     pluginSdkResolution: "src",
   });
-  return loader(modulePath) as T;
+  return loader(modulePath) as object;
 }
 
 export const loadBundledPluginPublicSurface: AsyncBundledPluginPublicSurfaceLoader = (params) => {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -219,16 +219,16 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 10111
   },
   "openClawDeveloperInstructions": {
-    "chars": 2506,
-    "roughTokens": 627
+    "chars": 2774,
+    "roughTokens": 694
   },
   "totalTextOnly": {
-    "chars": 25901,
-    "roughTokens": 6476
+    "chars": 26169,
+    "roughTokens": 6543
   },
   "totalWithDynamicToolsJson": {
-    "chars": 66344,
-    "roughTokens": 16586
+    "chars": 66612,
+    "roughTokens": 16653
   },
   "userInputText": {
     "chars": 1747,
@@ -414,6 +414,8 @@ Approval policy is currently never. Do not provide the `sandbox_permissions` for
 
 ````text
 Running inside OpenClaw. Use OpenClaw dynamic tools for OpenClaw-owned messaging, cron, sessions, media, gateway, and nodes capabilities when available.
+
+Deferred searchable OpenClaw dynamic tools available: agents_list, cron, gateway, nodes, session_status, sessions_history, sessions_list, sessions_send, sessions_spawn, subagents, tts, web_fetch, web_search. Use `tool_search` to load exact callable specs before use.
 
 Use Codex native `spawn_agent` for Codex subagents. Use OpenClaw `sessions_spawn` only for OpenClaw or ACP delegation; if it is not already loaded, search for `sessions_spawn` in the `openclaw` dynamic tool namespace before calling it.
 

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -219,16 +219,16 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 10054
   },
   "openClawDeveloperInstructions": {
-    "chars": 1482,
-    "roughTokens": 371
+    "chars": 1750,
+    "roughTokens": 438
   },
   "totalTextOnly": {
-    "chars": 24377,
-    "roughTokens": 6095
+    "chars": 24645,
+    "roughTokens": 6162
   },
   "totalWithDynamicToolsJson": {
-    "chars": 64595,
-    "roughTokens": 16149
+    "chars": 64863,
+    "roughTokens": 16216
   },
   "userInputText": {
     "chars": 1247,
@@ -414,6 +414,8 @@ Approval policy is currently never. Do not provide the `sandbox_permissions` for
 
 ````text
 Running inside OpenClaw. Use OpenClaw dynamic tools for OpenClaw-owned messaging, cron, sessions, media, gateway, and nodes capabilities when available.
+
+Deferred searchable OpenClaw dynamic tools available: agents_list, cron, gateway, nodes, session_status, sessions_history, sessions_list, sessions_send, sessions_spawn, subagents, tts, web_fetch, web_search. Use `tool_search` to load exact callable specs before use.
 
 Use Codex native `spawn_agent` for Codex subagents. Use OpenClaw `sessions_spawn` only for OpenClaw or ACP delegation; if it is not already loaded, search for `sessions_spawn` in the `openclaw` dynamic tool namespace before calling it.
 

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -220,16 +220,16 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 10328
   },
   "openClawDeveloperInstructions": {
-    "chars": 1482,
-    "roughTokens": 371
+    "chars": 1769,
+    "roughTokens": 443
   },
   "totalTextOnly": {
-    "chars": 26004,
-    "roughTokens": 6501
+    "chars": 26291,
+    "roughTokens": 6573
   },
   "totalWithDynamicToolsJson": {
-    "chars": 67317,
-    "roughTokens": 16830
+    "chars": 67604,
+    "roughTokens": 16901
   },
   "userInputText": {
     "chars": 1485,
@@ -415,6 +415,8 @@ Approval policy is currently never. Do not provide the `sandbox_permissions` for
 
 ````text
 Running inside OpenClaw. Use OpenClaw dynamic tools for OpenClaw-owned messaging, cron, sessions, media, gateway, and nodes capabilities when available.
+
+Deferred searchable OpenClaw dynamic tools available: agents_list, cron, gateway, heartbeat_respond, nodes, session_status, sessions_history, sessions_list, sessions_send, sessions_spawn, subagents, tts, web_fetch, web_search. Use `tool_search` to load exact callable specs before use.
 
 Use Codex native `spawn_agent` for Codex subagents. Use OpenClaw `sessions_spawn` only for OpenClaw or ACP delegation; if it is not already loaded, search for `sessions_spawn` in the `openclaw` dynamic tool namespace before calling it.
 

--- a/test/helpers/agents/happy-path-prompt-snapshots.ts
+++ b/test/helpers/agents/happy-path-prompt-snapshots.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import type { Api, Model } from "@earendil-works/pi-ai";
+import { createJiti } from "jiti";
 import { resolveHeartbeatPromptForResponseTool } from "../../../src/auto-reply/heartbeat.js";
 import {
   buildDirectChatContext,
@@ -21,7 +22,7 @@ import type {
 } from "../../../src/plugin-sdk/agent-harness-runtime.js";
 import { normalizeAgentRuntimeTools } from "../../../src/plugin-sdk/agent-harness-runtime.js";
 import { createOpenClawCodingTools } from "../../../src/plugin-sdk/agent-harness.js";
-import { loadBundledPluginTestApiSync } from "../../../src/test-utils/bundled-plugin-public-surface.js";
+import { resolveBundledPluginPublicModulePath } from "../../../src/test-utils/bundled-plugin-public-surface.js";
 import {
   CODEX_MODEL_PROMPT_FIXTURE_DIR,
   CODEX_RUNTIME_HAPPY_PATH_PROMPT_SNAPSHOT_DIR,
@@ -114,7 +115,22 @@ type PromptScenario = {
   toolSnapshotFile: string;
 };
 
-const codexApi = loadBundledPluginTestApiSync("codex") as CodexPromptSnapshotApi;
+function loadCodexPromptSnapshotApi(): CodexPromptSnapshotApi {
+  const publicModulePath = resolveBundledPluginPublicModulePath({
+    pluginId: "codex",
+    artifactBasename: "test-api.js",
+  });
+  // Prompt snapshots are source drift guards; stale built plugin output must not mask TS changes.
+  const sourceModulePath = publicModulePath.replace(/\.js$/u, ".ts");
+  const modulePath = fs.existsSync(sourceModulePath) ? sourceModulePath : publicModulePath;
+  const load = createJiti(import.meta.url, {
+    fsCache: false,
+    moduleCache: false,
+  });
+  return load(modulePath) as CodexPromptSnapshotApi;
+}
+
+const codexApi = loadCodexPromptSnapshotApi();
 
 const CODEX_WORKSPACE_BOOTSTRAP_CONTEXT_FILES = [
   {

--- a/test/helpers/agents/happy-path-prompt-snapshots.ts
+++ b/test/helpers/agents/happy-path-prompt-snapshots.ts
@@ -1,7 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
 import type { Api, Model } from "@earendil-works/pi-ai";
-import { createJiti } from "jiti";
 import { resolveHeartbeatPromptForResponseTool } from "../../../src/auto-reply/heartbeat.js";
 import {
   buildDirectChatContext,
@@ -22,7 +21,7 @@ import type {
 } from "../../../src/plugin-sdk/agent-harness-runtime.js";
 import { normalizeAgentRuntimeTools } from "../../../src/plugin-sdk/agent-harness-runtime.js";
 import { createOpenClawCodingTools } from "../../../src/plugin-sdk/agent-harness.js";
-import { resolveBundledPluginPublicModulePath } from "../../../src/test-utils/bundled-plugin-public-surface.js";
+import { loadBundledPluginPublicSurfaceSourceSync } from "../../../src/test-utils/bundled-plugin-public-surface.js";
 import {
   CODEX_MODEL_PROMPT_FIXTURE_DIR,
   CODEX_RUNTIME_HAPPY_PATH_PROMPT_SNAPSHOT_DIR,
@@ -115,22 +114,10 @@ type PromptScenario = {
   toolSnapshotFile: string;
 };
 
-function loadCodexPromptSnapshotApi(): CodexPromptSnapshotApi {
-  const publicModulePath = resolveBundledPluginPublicModulePath({
-    pluginId: "codex",
-    artifactBasename: "test-api.js",
-  });
-  // Prompt snapshots are source drift guards; stale built plugin output must not mask TS changes.
-  const sourceModulePath = publicModulePath.replace(/\.js$/u, ".ts");
-  const modulePath = fs.existsSync(sourceModulePath) ? sourceModulePath : publicModulePath;
-  const load = createJiti(import.meta.url, {
-    fsCache: false,
-    moduleCache: false,
-  });
-  return load(modulePath) as CodexPromptSnapshotApi;
-}
-
-const codexApi = loadCodexPromptSnapshotApi();
+const codexApi = loadBundledPluginPublicSurfaceSourceSync({
+  pluginId: "codex",
+  artifactBasename: "test-api.js",
+}) as CodexPromptSnapshotApi;
 
 const CODEX_WORKSPACE_BOOTSTRAP_CONTEXT_FILES = [
   {


### PR DESCRIPTION
## Summary
- add a compact developer-instruction manifest listing deferred searchable OpenClaw dynamic tool names
- include the manifest for Codex app-server thread start/resume fallback paths and normal run attempts
- cover deferred-tool and no-deferred-tool instruction rendering in thread lifecycle tests

## Test plan
- `mise exec node@22.22.2 -- pnpm vitest run extensions/codex/src/app-server/thread-lifecycle.test.ts`
- `mise exec node@22.22.2 -- pnpm exec tsc --noEmit --pretty false --project tsconfig.json`