### PR TITLE
hotfix(codex): default visible replies to automatic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ Docs: https://docs.openclaw.ai
 - Codex app-server: keep native code mode available without forcing code-mode-only so OpenClaw dynamic tool turns complete through the app-server tool bridge. Fixes #83109. Thanks @daswass.
 - Release stability: recover stale session diagnostics and Codex OAuth fallback state so stuck runs and reused refresh tokens clear without blocking follow-up work. (#83503) Thanks @100yenadmin.
 - Messages/TTS: apply TTS directives before message-tool sends reach core, gateway, or plugin delivery so opt-in message-tool rooms and proactive sends attach voice notes instead of leaking raw tags. Fixes #81598. Thanks @CG-Intelligence-Agent-Jack and @CoronovirusG10.
-- Messages/Codex: keep Codex direct/source chats on message-tool visible delivery by default while documenting and testing `messages.visibleReplies: "automatic"` as the old-mode opt-out; channel wildcard model overrides now apply to direct chats before harness delivery defaults.
+- Messages/Codex: default Codex direct/source chats to automatic visible final delivery, document how to keep tool-only behavior with `messages.visibleReplies: "message_tool"`, and keep channel wildcard model overrides applying to direct chats before harness delivery defaults.
 - Memory/QMD: keep archived session transcript hits visible after QMD export while preserving normal `.md` session ids that only resemble archive names. (#83518; fixes #83506) Thanks @tanshanshan.
 - Codex app-server: preserve network access for sandboxed Codex code-mode turns when the OpenClaw sandbox allows outbound egress. Fixes #83347. Thanks @YusukeIt0.
 - QA-Lab: keep the OTLP smoke decoder independent of removed OpenTelemetry generated-root internals.

--- a/docs/channels/groups.md
+++ b/docs/channels/groups.md
@@ -51,7 +51,7 @@ If the message tool is unavailable under the active tool policy, OpenClaw falls
 back to automatic visible replies instead of silently suppressing the response.
 `openclaw doctor` warns about this mismatch.
 
-For direct chats and any other source event, use `messages.visibleReplies: "message_tool"` to apply the same tool-only visible-reply behavior globally. Some harnesses, including Codex, also default direct/source chats to message-tool delivery when this is unset. Set `messages.visibleReplies: "automatic"` to force the old automatic final-reply path. `messages.groupChat.visibleReplies` remains the more specific override for group/channel rooms.
+For direct chats and any other source event, use `messages.visibleReplies: "message_tool"` to apply the same tool-only visible-reply behavior globally. Codex direct/source chats now default to automatic visible final replies when `messages.visibleReplies` is unset. Keep `messages.visibleReplies: "message_tool"` when you want the old tool-only direct/source behavior. `messages.groupChat.visibleReplies` remains the more specific override for group/channel rooms.
 
 This replaces the old pattern of forcing the model to answer `NO_REPLY` for most lurk-mode turns. In tool-only mode, doing nothing visible simply means not calling the message tool.
 

--- a/docs/gateway/config-channels.md
+++ b/docs/gateway/config-channels.md
@@ -787,7 +787,7 @@ See the full channel index: [Channels](/channels).
 
 Group messages default to **require mention** (metadata mention or safe regex patterns). Applies to WhatsApp, Telegram, Discord, Google Chat, and iMessage group chats.
 
-Visible replies are controlled separately. Normal group and channel requests default to automatic final delivery: final assistant text posts through the legacy visible reply path. Some harnesses, including Codex, default direct/source chats to message-tool delivery so visible output only posts after the agent calls `message(action=send)`. If the model returns final text without calling the message tool, that final text stays private and the gateway verbose log records suppressed payload metadata.
+Visible replies are controlled separately. Normal group and channel requests default to automatic final delivery: final assistant text posts through the legacy visible reply path. Direct/source chats also default to automatic final delivery unless you override `messages.visibleReplies` or the selected runtime/harness says otherwise. If the model returns final text without calling the message tool in `message_tool` mode, that final text stays private and the gateway verbose log records suppressed payload metadata.
 
 Tool-only visible replies require a model/runtime that reliably calls tools, and are recommended for shared ambient rooms on latest-generation models such as GPT 5.5. If
 the session log shows assistant text with `didSendViaMessagingTool: false`, the
@@ -827,7 +827,7 @@ The gateway hot-reloads `messages` config after the file is saved. Restart only 
 
 `messages.groupChat.unmentionedInbound: "room_event"` submits unmentioned always-on group/channel messages as quiet room context on supported channels. Mentioned messages, commands, and direct messages remain user requests. See [Ambient room events](/channels/ambient-room-events) for complete Discord, Slack, and Telegram examples.
 
-`messages.visibleReplies` is the global source-event default; `messages.groupChat.visibleReplies` overrides it for group/channel source events. When `messages.visibleReplies` is unset, direct/source chats use the selected runtime or harness default. The Codex harness defaults direct/source chats to message-tool delivery; set `messages.visibleReplies: "automatic"` to use automatic final delivery. Channel allowlists and mention gating still decide whether an event is processed.
+`messages.visibleReplies` is the global source-event default; `messages.groupChat.visibleReplies` overrides it for group/channel source events. When `messages.visibleReplies` is unset, direct/source chats use the selected runtime or harness default. The Codex harness now defaults direct/source chats to automatic final delivery. Set `messages.visibleReplies: "message_tool"` when you need tool-only visible output for direct/source chats. Channel allowlists and mention gating still decide whether an event is processed.
 
 #### DM history limits
 

--- a/docs/plugins/codex-harness-runtime.md
+++ b/docs/plugins/codex-harness-runtime.md
@@ -48,11 +48,9 @@ newly selected model.
 ## Visible replies and heartbeats
 
 When a direct/source chat turn runs through the Codex harness, visible replies
-default to the message tool: final assistant text stays private unless the
-agent calls `message(action="send")`. This matches GPT models well because they
-can decide whether source-channel output is useful. Set
-`messages.visibleReplies: "automatic"` to restore the old mode where final
-assistant text posts automatically.
+default to automatic final delivery. Set `messages.visibleReplies: "message_tool"`
+when you want tool-only delivery where final assistant text stays private unless
+the agent calls `message(action="send")`.
 
 Codex heartbeat turns also get `heartbeat_respond` in the searchable OpenClaw
 tool catalog by default, so the agent can record whether the wake should stay

--- a/extensions/codex/harness.ts
+++ b/extensions/codex/harness.ts
@@ -24,7 +24,8 @@ export function createCodexAppServerAgentHarness(options?: {
     id: options?.id ?? "codex",
     label: options?.label ?? "Codex agent harness",
     deliveryDefaults: {
-      sourceVisibleReplies: "message_tool",
+      // Default to automatic delivery so direct chats behave as expected unless overridden by config.
+      sourceVisibleReplies: "automatic",
     },
     supports: (ctx) => {
       const provider = ctx.provider.trim().toLowerCase();

--- a/extensions/codex/index.test.ts
+++ b/extensions/codex/index.test.ts
@@ -73,7 +73,7 @@ describe("codex plugin", () => {
     expect(agentHarnessRegistration.id).toBe("codex");
     expect(agentHarnessRegistration.label).toBe("Codex agent harness");
     expect(agentHarnessRegistration.deliveryDefaults).toEqual({
-      sourceVisibleReplies: "message_tool",
+      sourceVisibleReplies: "automatic",
     });
     expect(typeof agentHarnessRegistration.dispose).toBe("function");
     expect(mediaProviderRegistration?.id).toBe("codex");
@@ -121,7 +121,7 @@ describe("codex plugin", () => {
   it("only claims the codex provider by default", () => {
     const harness = createCodexAppServerAgentHarness();
 
-    expect(harness.deliveryDefaults?.sourceVisibleReplies).toBe("message_tool");
+    expect(harness.deliveryDefaults?.sourceVisibleReplies).toBe("automatic");
     expect(
       harness.supports({ provider: "codex", modelId: "gpt-5.4", requestedRuntime: "auto" })
         .supported,

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -5286,6 +5286,43 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
   });
 
+  it("lets config force message-tool-only Codex direct source delivery", async () => {
+    setNoAbort();
+    registerAgentHarness({
+      id: "codex",
+      label: "Codex",
+      deliveryDefaults: { sourceVisibleReplies: "automatic" },
+      supports: () => ({ supported: true, priority: 100 }),
+      runAttempt: vi.fn(async () => ({}) as never),
+    });
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      agentHarnessId: "codex",
+      sendPolicy: "allow",
+    };
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      expect(opts?.sourceReplyDeliveryMode).toBe("message_tool_only");
+      return { text: "private final reply" } satisfies ReplyPayload;
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        ChatType: "direct",
+        CommandSource: undefined,
+        SessionKey: "agent:main:main",
+      }),
+      cfg: { messages: { visibleReplies: "message_tool" } } as OpenClawConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+    expect(result.queuedFinal).toBe(false);
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+  });
+
   it("uses Codex direct source delivery defaults before a session entry exists", async () => {
     setNoAbort();
     registerAgentHarness({


### PR DESCRIPTION
AI-assisted: yes (prepared with Codex).

## Summary

- Problem: The Codex harness defaulted `sourceVisibleReplies` to `message_tool`.
- Why it matters: In direct Telegram chats this did not match the expected visible-reply behavior, which made replies fail to surface as expected.
- What changed: Switched the Codex harness default to `automatic` and updated the existing Codex plugin tests to assert the new default.
- What did NOT change (scope boundary): No channel runtime logic, no dispatch core logic, and no config schema changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Integrations
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes # (none)
- Related # (none)
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Codex direct-chat replies in Telegram were not surfacing as expected with the harness default set to `message_tool`.
- Real environment tested: Real OpenClaw local/dev setup using the Codex harness in a Telegram direct chat, on branch `hotfix/codex-visible-replies-automatic`. Sensitive identifiers redacted.
- Exact steps or command run after this patch:
  1. Start OpenClaw on this branch with the Telegram direct-chat setup already connected.
  2. Send prompts to the Codex agent in a real Telegram direct conversation.
  3. Confirm that assistant replies surface visibly in the same Telegram thread.
- Evidence after fix (redacted copied live output from the real Telegram direct chat on this branch):
  - User: "Is the main branch the correct target according to the CONTRIBUTING doc?"
  - Assistant: "Yes, `main` looks like the correct target."
  - User: "Let's make sure our PR matches their template"
  - Assistant: "The PR body now matches their template structure and is marked AI-assisted: <https://github.com/openclaw/openclaw/pull/83814>"
  - User: "Go ahead with adding the before and after proof, just make sure there isn't any sensitive or private information"
  - Assistant: visible reply delivered in the same Telegram direct thread (this proof update).
- Observed result after fix: On the patched branch, multiple assistant replies were delivered visibly in the same Telegram direct chat thread instead of disappearing behind message-tool-specific routing.
- What was not tested: Telegram group chats, non-Telegram channels, and explicit `sourceVisibleReplies` override configurations.
- Before evidence (redacted): Prior to this patch, the issue being worked was that replies were "not coming through Telegram as expected" in the same real setup. I do not have a sanitized raw before-patch transcript attached here, so this before evidence is a human-reported symptom summary rather than a pasted log.

## Root Cause (if applicable)

- Root cause: The Codex harness was introduced with `sourceVisibleReplies: "message_tool"`, which was too specific for the expected direct-chat delivery behavior in Telegram.
- Missing detection / guardrail: The existing test only asserted the configured default value; there was no real-behavior proof or direct-chat integration coverage validating that the chosen default produced visible replies in Telegram.
- Contributing context (if known): `extensions/codex/harness.ts` was introduced with `message_tool` in commit `1b82c0e3`; this PR changes that default to `automatic`.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] End-to-end test
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] Existing coverage already sufficient
- Target test or file: A Telegram direct-chat proof/e2e scenario for Codex-visible replies; current unit assertion lives in `extensions/codex/index.test.ts`.
- Scenario the test should lock in: A Codex harness reply in a Telegram direct chat should surface as a normal visible reply when no explicit override is configured.
- Why this is the smallest reliable guardrail: The bug is about runtime reply delivery semantics in a real channel, not just the literal constant stored in plugin registration.
- Existing test that already covers this (if any): `extensions/codex/index.test.ts` now asserts the harness default is `automatic`.
- If no new test is added, why not: This hotfix keeps the code change minimal and updates the existing plugin assertion only; durable Telegram direct-chat proof should be added as follow-up coverage.

## User-visible / Behavior Changes

Codex direct-chat reply delivery now defaults to `automatic` visible replies unless a config override says otherwise.

## Diagram (if applicable)

```text
Before:
[user prompt in Telegram direct chat] -> [Codex harness default = message_tool] -> [reply delivery did not match expected visible direct reply behavior]

After:
[user prompt in Telegram direct chat] -> [Codex harness default = automatic] -> [reply surfaces as expected unless overridden]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux (author local/dev environment)
- Runtime/container: OpenClaw 2026.5.12 local/dev runtime
- Model/provider: Codex via OpenAI Codex runtime
- Integration/channel (if any): Telegram direct chat
- Relevant config (redacted): No explicit `sourceVisibleReplies` override on the Codex harness

### Steps

1. Check out this branch and start OpenClaw with Telegram direct-chat connectivity.
2. Send prompts to the Codex harness in a real Telegram direct conversation.
3. Verify that assistant replies appear visibly in the same Telegram thread.

### Expected

- The reply is delivered using automatic visible-reply behavior by default.

### Actual

- Assistant replies were delivered visibly in the same Telegram direct thread for repeated real prompts after this patch.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Real Telegram direct-chat interaction on this patched branch produced visible assistant replies for multiple prompts in the same thread.
- Edge cases checked: Repeated prompts across several turns in the same direct conversation.
- What you did **not** verify: Group chats, other channels, explicit config overrides, or a separate automated Telegram e2e test.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Another Codex usage path may have implicitly depended on `message_tool` semantics.
  - Mitigation: The change is narrowly scoped to the Codex harness default and remains overrideable by config.
