### PR TITLE
fix(telegram): guard rendered media caption length

### DIFF
--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -29,7 +29,7 @@ import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import { loadWebMedia } from "openclaw/plugin-sdk/web-media";
 import { resolveTelegramInlineButtons, type TelegramInlineButtons } from "../button-types.js";
-import { splitTelegramCaption } from "../caption.js";
+import { splitTelegramRenderedCaption } from "../caption.js";
 import {
   markdownToTelegramChunks,
   markdownToTelegramHtml,
@@ -350,12 +350,14 @@ async function deliverMediaReply(params: {
     });
     const fileName = media.fileName ?? (isGif ? "animation.gif" : "file");
     const file = new InputFile(media.buffer, fileName);
-    const { caption, followUpText } = splitTelegramCaption(
+    const {
+      caption,
+      renderedCaption: htmlCaption,
+      followUpText,
+    } = splitTelegramRenderedCaption(
       isFirstMedia ? (params.reply.text ?? undefined) : undefined,
+      (caption) => renderTelegramHtmlText(caption, { tableMode: params.tableMode }),
     );
-    const htmlCaption = caption
-      ? renderTelegramHtmlText(caption, { tableMode: params.tableMode })
-      : undefined;
     if (followUpText) {
       pendingFollowUpText = followUpText;
     }

--- a/extensions/telegram/src/caption.ts
+++ b/extensions/telegram/src/caption.ts
@@ -13,3 +13,26 @@ export function splitTelegramCaption(text?: string): {
   }
   return { caption: trimmed, followUpText: undefined };
 }
+
+export function splitTelegramRenderedCaption(
+  text: string | undefined,
+  renderCaption: (caption: string) => string,
+): {
+  caption?: string;
+  renderedCaption?: string;
+  followUpText?: string;
+} {
+  const split = splitTelegramCaption(text);
+  if (!split.caption) {
+    return split;
+  }
+  const renderedCaption = renderCaption(split.caption);
+  if (renderedCaption.length > TELEGRAM_MAX_CAPTION_LENGTH) {
+    return {
+      caption: undefined,
+      renderedCaption: undefined,
+      followUpText: split.caption,
+    };
+  }
+  return { caption: split.caption, renderedCaption, followUpText: undefined };
+}

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -13,7 +13,7 @@ import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { normalizeTelegramApiRoot } from "./api-root.js";
 import { buildTypingThreadParams } from "./bot/helpers.js";
 import type { TelegramInlineButtons } from "./button-types.js";
-import { splitTelegramCaption } from "./caption.js";
+import { splitTelegramRenderedCaption } from "./caption.js";
 import { resolveTelegramFetch } from "./fetch.js";
 import { renderTelegramHtmlText, splitTelegramHtmlChunks } from "./format.js";
 import { buildInlineKeyboard } from "./inline-keyboard.js";
@@ -809,17 +809,18 @@ export async function sendMessageTelegram(
       media.fileName ?? (isGif ? "animation.gif" : inferFilename(kind ?? "document")) ?? "file";
     const file = new InputFileCtor(media.buffer, fileName);
     let caption: string | undefined;
+    let htmlCaption: string | undefined;
     let followUpText: string | undefined;
 
     if (isVideoNote) {
       caption = undefined;
       followUpText = text.trim() ? text : undefined;
     } else {
-      const split = splitTelegramCaption(text);
+      const split = splitTelegramRenderedCaption(text, renderHtmlText);
       caption = split.caption;
       followUpText = split.followUpText;
+      htmlCaption = split.renderedCaption;
     }
-    const htmlCaption = caption ? renderHtmlText(caption) : undefined;
     // If text exceeds Telegram's caption limit, send media without caption
     // then send text as a separate follow-up message.
     const needsSeparateText = Boolean(followUpText);

--- a/extensions/telegram/src/voice.test.ts
+++ b/extensions/telegram/src/voice.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import { splitTelegramCaption, TELEGRAM_MAX_CAPTION_LENGTH } from "./caption.js";
+import {
+  splitTelegramCaption,
+  splitTelegramRenderedCaption,
+  TELEGRAM_MAX_CAPTION_LENGTH,
+} from "./caption.js";
 import { resolveTelegramVoiceSend } from "./voice.js";
 
 describe("splitTelegramCaption", () => {
@@ -22,6 +26,25 @@ describe("splitTelegramCaption", () => {
     expect(splitTelegramCaption(text)).toEqual({
       caption: undefined,
       followUpText: text,
+    });
+  });
+
+  it("moves captions that exceed the limit after rendering into follow-up text", () => {
+    const text = "&".repeat(300);
+    expect(
+      splitTelegramRenderedCaption(text, (caption) => caption.replaceAll("&", "&amp;")),
+    ).toEqual({
+      caption: undefined,
+      renderedCaption: undefined,
+      followUpText: text,
+    });
+  });
+
+  it("returns rendered captions when they stay within the limit", () => {
+    expect(splitTelegramRenderedCaption(" hello ", (caption) => `<b>${caption}</b>`)).toEqual({
+      caption: "hello",
+      renderedCaption: "<b>hello</b>",
+      followUpText: undefined,
     });
   });
 });


### PR DESCRIPTION
## Summary
- add a rendered-caption splitter for Telegram media captions
- move captions to follow-up text when Telegram HTML rendering expands them beyond 1024 chars
- apply the guard to direct Telegram media send and reply media delivery

## Repro
`"&".repeat(300)` is 300 raw chars but renders to 1500 HTML chars as `&amp;`, so it must not be sent as a Telegram caption.

Fixes #83815

## Tests
- `git diff --check`
- `npx --yes tsx -e ...` helper smoke passed
- `npx --yes vitest@4.1.5 run extensions/telegram/src/voice.test.ts` could not run in this checkout because repo dev deps are not installed and Vitest config imports local `vitest/config`.
