### PR TITLE
fix(opencode-go): strip per-message reasoning fields for kimi-k2.{5,6} (#83812)

### DIFF
--- a/extensions/opencode-go/stream.test.ts
+++ b/extensions/opencode-go/stream.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from "vitest";
+import { createOpencodeGoKimiNoReasoningWrapper } from "./stream.js";
+
+type StreamFnArgs = Parameters<
+  NonNullable<ReturnType<typeof createOpencodeGoKimiNoReasoningWrapper>>
+>;
+
+function captureStrippedPayload(model: { provider: string; id: string }, payload: unknown) {
+  const seen: { payload: unknown }[] = [];
+  const baseStreamFn = vi.fn((_model, _context, options) => {
+    options?.onPayload?.(payload, _model);
+    seen.push({ payload });
+    return Promise.resolve({ result: "ok" });
+  }) as unknown as NonNullable<StreamFnArgs[0]> extends never ? never : never;
+  // The compile-time type for baseStreamFn requires a heavy import surface; cast
+  // via unknown is the standard pattern in adjacent vitest files.
+  const wrapper = createOpencodeGoKimiNoReasoningWrapper(
+    baseStreamFn as unknown as Parameters<typeof createOpencodeGoKimiNoReasoningWrapper>[0],
+  );
+  return { wrapper, baseStreamFn, seen };
+}
+
+describe("createOpencodeGoKimiNoReasoningWrapper (#83812)", () => {
+  it("strips reasoning_details on replayed assistant messages for kimi-k2.6", async () => {
+    const payload: Record<string, unknown> = {
+      model: "kimi-k2.6",
+      reasoning: { effort: "medium" },
+      reasoning_effort: "high",
+      messages: [
+        { role: "system", content: "you are helpful" },
+        {
+          role: "assistant",
+          content: "let me think",
+          reasoning_details: [{ type: "reasoning.text", text: "internal" }],
+          reasoning_content: "internal again",
+          reasoning: "ditto",
+          reasoning_text: "ditto2",
+        },
+        { role: "user", content: "ok" },
+      ],
+    };
+    const { wrapper } = captureStrippedPayload({ provider: "opencode-go", id: "kimi-k2.6" }, payload);
+    expect(wrapper).toBeDefined();
+    await wrapper!({ provider: "opencode-go", id: "kimi-k2.6" } as never, {} as never, {} as never);
+
+    expect(payload.reasoning).toBeUndefined();
+    expect(payload.reasoning_effort).toBeUndefined();
+    const replayed = (payload.messages as Record<string, unknown>[])[1]!;
+    expect(replayed.reasoning_details).toBeUndefined();
+    expect(replayed.reasoning_content).toBeUndefined();
+    expect(replayed.reasoning).toBeUndefined();
+    expect(replayed.reasoning_text).toBeUndefined();
+    // Non-reasoning fields must survive.
+    expect(replayed.role).toBe("assistant");
+    expect(replayed.content).toBe("let me think");
+  });
+
+  it("walks array-shaped message content parts", async () => {
+    const payload: Record<string, unknown> = {
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "answer", reasoning_details: [{ type: "x" }] },
+            { type: "tool_use", reasoning: "inner" },
+          ],
+        },
+      ],
+    };
+    const { wrapper } = captureStrippedPayload({ provider: "opencode-go", id: "kimi-k2.5" }, payload);
+    await wrapper!({ provider: "opencode-go", id: "kimi-k2.5" } as never, {} as never, {} as never);
+    const parts = ((payload.messages as Record<string, unknown>[])[0]!.content as Record<string, unknown>[]);
+    expect(parts[0]!.reasoning_details).toBeUndefined();
+    expect(parts[0]!.text).toBe("answer");
+    expect(parts[1]!.reasoning).toBeUndefined();
+    expect(parts[1]!.type).toBe("tool_use");
+  });
+
+  it("also strips per-message reasoning from input[] (Responses-style payload)", async () => {
+    const payload: Record<string, unknown> = {
+      input: [
+        {
+          role: "assistant",
+          reasoning_details: [{ type: "x" }],
+          reasoning: "hidden",
+        },
+      ],
+    };
+    const { wrapper } = captureStrippedPayload({ provider: "opencode-go", id: "kimi-k2.6" }, payload);
+    await wrapper!({ provider: "opencode-go", id: "kimi-k2.6" } as never, {} as never, {} as never);
+    const item = (payload.input as Record<string, unknown>[])[0]!;
+    expect(item.reasoning_details).toBeUndefined();
+    expect(item.reasoning).toBeUndefined();
+    expect(item.role).toBe("assistant");
+  });
+
+  it("does not touch payloads for unrelated opencode-go models", async () => {
+    const payload: Record<string, unknown> = {
+      reasoning: "kept",
+      messages: [{ role: "assistant", reasoning_details: [{ type: "x" }] }],
+    };
+    const { wrapper } = captureStrippedPayload(
+      { provider: "opencode-go", id: "deepseek-v4-pro" },
+      payload,
+    );
+    await wrapper!(
+      { provider: "opencode-go", id: "deepseek-v4-pro" } as never,
+      {} as never,
+      {} as never,
+    );
+    // The wrapper short-circuits to underlying for non-Kimi IDs; nothing should be touched.
+    expect(payload.reasoning).toBe("kept");
+    expect((payload.messages as Record<string, unknown>[])[0]!.reasoning_details).toBeDefined();
+  });
+});

--- a/extensions/opencode-go/stream.test.ts
+++ b/extensions/opencode-go/stream.test.ts
@@ -39,20 +39,20 @@ describe("createOpencodeGoKimiNoReasoningWrapper (#83812)", () => {
         { role: "user", content: "ok" },
       ],
     };
-    const { wrapper } = captureStrippedPayload({ provider: "opencode-go", id: "kimi-k2.6" }, payload);
+    const { wrapper } = captureStrippedPayload(
+      { provider: "opencode-go", id: "kimi-k2.6" },
+      payload,
+    );
     expect(wrapper).toBeDefined();
     await wrapper!({ provider: "opencode-go", id: "kimi-k2.6" } as never, {} as never, {} as never);
 
     expect(payload.reasoning).toBeUndefined();
     expect(payload.reasoning_effort).toBeUndefined();
-    const replayed = (payload.messages as Record<string, unknown>[])[1]!;
-    expect(replayed.reasoning_details).toBeUndefined();
-    expect(replayed.reasoning_content).toBeUndefined();
-    expect(replayed.reasoning).toBeUndefined();
-    expect(replayed.reasoning_text).toBeUndefined();
-    // Non-reasoning fields must survive.
-    expect(replayed.role).toBe("assistant");
-    expect(replayed.content).toBe("let me think");
+    expect(payload.messages).toEqual([
+      { role: "system", content: "you are helpful" },
+      { role: "assistant", content: "let me think" },
+      { role: "user", content: "ok" },
+    ]);
   });
 
   it("walks array-shaped message content parts", async () => {
@@ -67,13 +67,17 @@ describe("createOpencodeGoKimiNoReasoningWrapper (#83812)", () => {
         },
       ],
     };
-    const { wrapper } = captureStrippedPayload({ provider: "opencode-go", id: "kimi-k2.5" }, payload);
+    const { wrapper } = captureStrippedPayload(
+      { provider: "opencode-go", id: "kimi-k2.5" },
+      payload,
+    );
     await wrapper!({ provider: "opencode-go", id: "kimi-k2.5" } as never, {} as never, {} as never);
-    const parts = ((payload.messages as Record<string, unknown>[])[0]!.content as Record<string, unknown>[]);
-    expect(parts[0]!.reasoning_details).toBeUndefined();
-    expect(parts[0]!.text).toBe("answer");
-    expect(parts[1]!.reasoning).toBeUndefined();
-    expect(parts[1]!.type).toBe("tool_use");
+    expect(payload.messages).toEqual([
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "answer" }, { type: "tool_use" }],
+      },
+    ]);
   });
 
   it("also strips per-message reasoning from input[] (Responses-style payload)", async () => {
@@ -86,12 +90,12 @@ describe("createOpencodeGoKimiNoReasoningWrapper (#83812)", () => {
         },
       ],
     };
-    const { wrapper } = captureStrippedPayload({ provider: "opencode-go", id: "kimi-k2.6" }, payload);
+    const { wrapper } = captureStrippedPayload(
+      { provider: "opencode-go", id: "kimi-k2.6" },
+      payload,
+    );
     await wrapper!({ provider: "opencode-go", id: "kimi-k2.6" } as never, {} as never, {} as never);
-    const item = (payload.input as Record<string, unknown>[])[0]!;
-    expect(item.reasoning_details).toBeUndefined();
-    expect(item.reasoning).toBeUndefined();
-    expect(item.role).toBe("assistant");
+    expect(payload.input).toEqual([{ role: "assistant" }]);
   });
 
   it("does not touch payloads for unrelated opencode-go models", async () => {
@@ -110,6 +114,6 @@ describe("createOpencodeGoKimiNoReasoningWrapper (#83812)", () => {
     );
     // The wrapper short-circuits to underlying for non-Kimi IDs; nothing should be touched.
     expect(payload.reasoning).toBe("kept");
-    expect((payload.messages as Record<string, unknown>[])[0]!.reasoning_details).toBeDefined();
+    expect(payload.messages).toEqual([{ role: "assistant", reasoning_details: [{ type: "x" }] }]);
   });
 });

--- a/extensions/opencode-go/stream.ts
+++ b/extensions/opencode-go/stream.ts
@@ -21,10 +21,54 @@ export function createOpencodeGoDeepSeekV4Wrapper(
   });
 }
 
+// opencode-go/kimi-k2.{5,6} reject any reasoning-shaped field in the request
+// body. Stock OpenClaw preserves reasoning_details on replayed assistant
+// messages for these model IDs (see REASONING_CONTENT_REPLAY_MODEL_IDS in
+// openai-transport-stream.ts), so the provider returns
+// `400 Extra inputs are not permitted, field: 'messages[5].reasoning_details'`
+// after a few turns. The DeepSeek-V4 wrapper next to this one only handles
+// root-level params — the per-message replay needs its own pass. See #83812.
+const KIMI_PER_MESSAGE_REASONING_FIELDS = [
+  "reasoning_details",
+  "reasoning_content",
+  "reasoning",
+  "reasoning_text",
+] as const;
+
+function stripPerMessageReasoning(message: unknown): void {
+  if (!message || typeof message !== "object") {
+    return;
+  }
+  const record = message as Record<string, unknown>;
+  for (const field of KIMI_PER_MESSAGE_REASONING_FIELDS) {
+    if (field in record) {
+      delete record[field];
+    }
+  }
+  const content = record.content;
+  if (Array.isArray(content)) {
+    for (const part of content) {
+      stripPerMessageReasoning(part);
+    }
+  }
+}
+
 function stripReasoningParams(payloadObj: Record<string, unknown>): void {
   delete payloadObj.reasoning;
   delete payloadObj.reasoning_effort;
   delete payloadObj.reasoningEffort;
+  const messages = payloadObj.messages;
+  if (Array.isArray(messages)) {
+    for (const message of messages) {
+      stripPerMessageReasoning(message);
+    }
+  }
+  const input = payloadObj.input;
+  if (Array.isArray(input)) {
+    for (const message of input) {
+      stripPerMessageReasoning(message);
+    }
+  }
 }
 
 export function createOpencodeGoKimiNoReasoningWrapper(


### PR DESCRIPTION
Fixes #83812.

`createOpencodeGoKimiNoReasoningWrapper` (`extensions/opencode-go/stream.ts`) already strips root-level `reasoning` / `reasoning_effort` / `reasoningEffort` from outbound requests for opencode-go's Kimi-family models. But stock OpenClaw preserves `messages[].reasoning_details` on replayed assistant turns for these model IDs — `kimi-k2.5` and `kimi-k2.6` are in `REASONING_CONTENT_REPLAY_MODEL_IDS` (`src/agents/openai-transport-stream.ts`), so `shouldPreserveReasoningContentReplay` returns `true` and the assistant-message sanitizer leaves the field intact. After a few turns the provider rejects the request:

```
400 Error from provider: Extra inputs are not permitted,
field: 'messages[5].reasoning_details'
```

The DeepSeek-V4 sibling wrapper next to this one only operates on root-level params, so per-message replay needs its own pass.

## Changes

- `extensions/opencode-go/stream.ts`: extend the existing `stripReasoningParams` payload patch (already gated on `isOpencodeGoKimiNoReasoningModelId`) to walk `payload.messages[]` and `payload.input[]` and strip per-message reasoning fields (`reasoning_details`, `reasoning_content`, `reasoning`, `reasoning_text`). Array-shaped `content` parts on each message are walked recursively. Root-level strip is preserved.
- `extensions/opencode-go/stream.test.ts`: new vitest file with 4 regression cases — replayed `reasoning_details` on `kimi-k2.6`, array-shaped content parts on `kimi-k2.5`, Responses-style `input[]` entries, and a "non-Kimi opencode-go model is untouched" guard.

Diff stat: 2 files, +159 LOC (most of it test coverage; the production change is +44 LOC).

## Real behavior proof

- **Behavior or issue addressed:** Sanitized issue evidence — opencode-go/kimi-k2.6 returns `400 Extra inputs are not permitted, field: 'messages[N].reasoning_details'` once a conversation has at least one replayed assistant turn that carried reasoning. The issue's local hotfix walks `messages[]` and `input[]` and strips the same 4 field names.

- **Real environment tested:** Local Node 22.x. Probe at `/tmp/probe_83812.mjs` (a) parses the patched `stream.ts` and verifies the field list is complete, the per-message walker is declared, and `stripReasoningParams` iterates both `messages[]` and `input[]` while preserving the original root-level deletions; (b) replays the patched strip against a realistic payload — root-level `reasoning` / `reasoning_effort`, a replayed assistant message with all 4 reasoning shapes, an array-shaped user content part with `reasoning` leakage, and an `input[]` entry — and asserts every reasoning field is removed while non-reasoning fields (`role`, `content`, `text`, `type`) survive; (c) replays the pre-fix shape (root-only strip) and confirms it leaves `messages[0].reasoning_details` intact — the exact field path the provider rejects.

- **Exact steps or command run after this patch:** `node /tmp/probe_83812.mjs`

- **Evidence after fix:**

```
PASS: all 4 per-message reasoning field names declared
PASS: stripPerMessageReasoning helper declared
PASS: stripReasoningParams iterates payload.messages
PASS: stripReasoningParams iterates payload.input
PASS: root-level strip preserved (no regression vs prior behavior)
PASS: replay: realistic payload strips all 4 reasoning shapes from messages[], messages[].content[], and input[], preserves non-reasoning fields
PASS: old shape (root-only strip) preserves messages[].reasoning_details — confirms issue's HTTP 400 path

ALL CASES PASS
```

- **Observed result after fix:** A multi-turn opencode-go/kimi-k2.6 chat that previously hit `400 Extra inputs are not permitted, field: 'messages[N].reasoning_details'` no longer carries any reasoning-shaped field at any depth of the request payload (root, `messages[]`, `messages[].content[]`, `input[]`). Models outside the Kimi no-reasoning set (e.g. `deepseek-v4-pro`) short-circuit before the wrapper runs, so the strip never touches their payloads.

- **What was not tested:** Live request against `https://opencode.ai/zen/go/v1` with `kimi-k2.6` after a multi-turn replay — that requires an opencode-go account and is what the reporter's local hotfix confirmed. The probe replays both the patched and pre-fix shapes against the exact field path named in the provider error, and the vitest regression cases exercise the public `createOpencodeGoKimiNoReasoningWrapper` contract on the same shape.

## Audit (per CLAUDE rules — all 5 steps)

- **Existing-helper check:** The reasoning-field list (`reasoning_details`, `reasoning_content`, `reasoning`, `reasoning_text`) is the same set as `COMPLETIONS_REASONING_REPLAY_FIELDS` in `src/agents/openai-transport-stream.ts:2857`, but that constant is module-private. Inlining a 4-name const in this plugin file matches the established pattern of self-contained provider wrappers in `extensions/`. The strip is implemented via the existing `streamWithPayloadPatch` helper already imported here — no new framework. PASS
- **Shared-helper caller check:** `stripReasoningParams` has exactly one caller (the wrapper that closes over it, two lines below). Behavior change is additive: the new per-message walk runs only on payloads that already pass the `isOpencodeGoKimiNoReasoningModelId` gate. PASS
- **Broader-fix rival scan:** `gh pr list --search '83812 in:title,body'` and `gh pr list --search 'reasoning_details in:title,body'` both return no open PRs. PASS
- **Recent-merge audit:** `git log --oneline -10 -- extensions/opencode-go/stream.ts` shows `e1061a8b46 test(live): tolerate provider drift in release checks` — unrelated. PASS
- **Prototype-pollution scan:** The walker reads `message.content` and the message keys, then uses `delete msg[FIELD]` where `FIELD` comes from a hard-coded constant. No external-input key copying. PASS
