### PR TITLE
fix(heartbeat-runner): add wakeGuard pre-flight hook to skip no-op wakes (OME-332)

### DIFF
--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -2059,6 +2059,12 @@ export function startHeartbeatRunner(opts: {
   abortSignal?: AbortSignal;
   runOnce?: typeof runHeartbeatOnce;
   stableSchedulerSeed?: string;
+  /**
+   * Optional pre-flight guard called before waking a targeted agent session.
+   * Return `{ skip: true }` to suppress the wake (e.g. no actionable tickets,
+   * or the stored assignee does not match the current heartbeat run context).
+   */
+  wakeGuard?: (agentId: string, sessionKey: string | undefined) => Promise<{ skip: boolean }>;
 }): HeartbeatRunner {
   const runtime = opts.runtime ?? defaultRuntime;
   const runOnce = opts.runOnce ?? runHeartbeatOnce;
@@ -2310,6 +2316,9 @@ export function startHeartbeatRunner(opts: {
         const deferral = evaluateWakeDeferral(targetAgent, now, reason, intent);
         if (deferral.defer) {
           return { status: "skipped", reason: deferral.reason };
+        }
+        if (opts.wakeGuard && (await opts.wakeGuard(targetAgent.agentId, requestedSessionKey)).skip) {
+          return { status: "skipped", reason: "wake-guard" };
         }
         try {
           const res = await runOnce({


### PR DESCRIPTION
## Problem (OME-332)

The `startHeartbeatRunner` wake dispatch path calls `runOnce` for every targeted agent/session without checking whether that agent actually has actionable work. On installations with an orchestration layer (e.g. Paperclip/Ronen brainOS), agents were being woken on every heartbeat interval even when:
- their ticket queue was empty, OR
- the wake context's stored assignee (`heartbeat_runs.contextSnapshot.assigneeAgentId`) didn't match the current agent

This caused no-op LLM invocations on every heartbeat cycle.

## Fix

Add an optional `wakeGuard` hook to `startHeartbeatRunner` opts:

```ts
wakeGuard?: (agentId: string, sessionKey: string | undefined) => Promise<{ skip: boolean }>;
```

The guard fires after deferral evaluation and before `runOnce` in the targeted wake path. Returning `{ skip: true }` suppresses the wake with reason `'wake-guard'`. Callers can use this to:
- Call `getActionableTickets(agentId)` and skip if the result is empty
- Validate `contextSnapshot.assigneeAgentId === agentId` and skip on mismatch

## Properties

- **3-line change** at the dispatch site (the hook plumbing adds a few more in the opts type)
- **100% opt-in**: existing callers not providing `wakeGuard` see zero behaviour change
- **No new dependencies**: the hook is a plain async callback
- Tested: TypeScript compiles; existing heartbeat-runner tests continue to pass (no behaviour change for non-guard path)

## Related

- OME-332: Fix cloud-adapter wake-loop hitting Friday's blocked queue (no-op wakes)
- OME-335: Draft execute.js wake-routing PR

> ⚠️ DRAFT — Omer review needed before merging