### PR TITLE
fix(push): set valid VAPID subject default so iOS PWA push works

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -215,7 +215,7 @@ Override the VAPID keypair through env vars on the Gateway process when you want
 
 - `OPENCLAW_VAPID_PUBLIC_KEY`
 - `OPENCLAW_VAPID_PRIVATE_KEY`
-- `OPENCLAW_VAPID_SUBJECT` (defaults to `mailto:openclaw@localhost`)
+- `OPENCLAW_VAPID_SUBJECT` (defaults to `https://openclaw.ai`; must be a valid `mailto:` or `https:` URI)
 
 The Control UI uses these scope-gated Gateway methods to register and test browser subscriptions:
 

--- a/src/infra/push-web.test.ts
+++ b/src/infra/push-web.test.ts
@@ -58,7 +58,7 @@ describe("resolveVapidKeys", () => {
     const keys = await resolveVapidKeys(tmpDir);
     expect(keys.publicKey).toBe("test-public-key-base64url");
     expect(keys.privateKey).toBe("test-private-key-base64url");
-    expect(keys.subject).toMatch(/^mailto:/);
+    expect(keys.subject).toBe("https://openclaw.ai");
 
     // Second call returns same keys.
     const keys2 = await resolveVapidKeys(tmpDir);
@@ -211,7 +211,7 @@ describe("sending", () => {
     expect(result.ok).toBe(true);
     expect(vi.mocked(webPush.setVapidDetails)).toHaveBeenCalledTimes(1);
     expect(vi.mocked(webPush.setVapidDetails)).toHaveBeenCalledWith(
-      "mailto:openclaw@localhost",
+      "https://openclaw.ai",
       "test-public-key-base64url",
       "test-private-key-base64url",
     );

--- a/src/infra/push-web.ts
+++ b/src/infra/push-web.ts
@@ -36,7 +36,7 @@ const WEB_PUSH_STATE_FILENAME = "push/web-push-subscriptions.json";
 const VAPID_KEYS_FILENAME = "push/vapid-keys.json";
 const MAX_ENDPOINT_LENGTH = 2048;
 const MAX_KEY_LENGTH = 512;
-const DEFAULT_VAPID_SUBJECT = "mailto:openclaw@localhost";
+const DEFAULT_VAPID_SUBJECT = "https://openclaw.ai";
 
 const withLock = createAsyncLock();
 


### PR DESCRIPTION
Fixes #83134.

## Summary

Default VAPID `sub` claim was `mailto:openclaw@localhost`, which Apple's Web Push service rejects with `403 BadJwtToken` — iOS PWA push silently fails for any operator that hasn't set `OPENCLAW_VAPID_SUBJECT`. Default changed to `https://openclaw.ai` (valid `https:` URI; accepted by Apple and Mozilla). Operator override via env unchanged.

## Why it was `mailto:openclaw@localhost`

Plausible placeholder, not nonsense. Introduced in #44590 when Web Push first landed. `mailto:openclaw@localhost` is syntactically valid (`localhost` is a legal hostname; the `web-push` library accepts it client-side) and works against Mozilla autopush and Google FCM, which are lenient about `sub`. Apple's `web.push.apple.com` is the strict one and rejects non-routable subjects — the original PR's testing likely didn't cover iOS Safari, so it shipped.

## Verification

- `node scripts/run-vitest.mjs src/infra/push-web.test.ts` — 13/13 pass
- `git diff --check` — clean

Behavior addressed: VAPID `sub` default now satisfies Apple Web Push validation.
Real environment tested: focused unit tests covering `resolveVapidKeys` and `setVapidDetails` against the mocked `web-push` runtime. Live Apple `web.push.apple.com` validation against the new default was not re-run locally; the original `403 BadJwtToken` for `mailto:openclaw@localhost` was reproduced by the reporter.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/infra/push-web.test.ts`
Evidence after fix: 13/13 tests pass; default `subject` is `https://openclaw.ai`; `setVapidDetails` receives `https://openclaw.ai` for direct sends and broadcasts.
Observed result after fix: tests green; default subject is a valid `https:` URI accepted by Apple/Mozilla per the `web-push` README.
What was not tested: end-to-end iOS PWA push against `web.push.apple.com` with a real subscription — would benefit from operator verification before/after upgrade.