### PR TITLE
test(android): poll for stale TLS probe cleanup in auth test

### DIFF
--- a/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
@@ -376,7 +376,23 @@ class GatewayBootstrapAuthTest {
 
       runtime.disconnect()
       probeResult.complete(GatewayTlsProbeResult(fingerprintSha256 = "aaaaaaaa"))
-      Thread.sleep(100)
+      var staleProbeCleared = false
+      repeat(300) {
+        if (runtime.pendingGatewayTrust.value == null &&
+          desiredBootstrapToken(runtime, "nodeSession") == null
+        ) {
+          staleProbeCleared = true
+          return@repeat
+        }
+        Thread.sleep(10)
+      }
+      if (!staleProbeCleared) {
+        error(
+          "Timed out waiting for stale TLS probe cleanup after disconnect; " +
+            "pendingGatewayTrust=${runtime.pendingGatewayTrust.value}, " +
+            "desiredBootstrapToken=${desiredBootstrapToken(runtime, "nodeSession")}",
+        )
+      }
 
       assertNull(runtime.pendingGatewayTrust.value)
       assertNull(desiredBootstrapToken(runtime, "nodeSession"))

--- a/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
@@ -12,6 +12,8 @@ import ai.openclaw.app.protocol.OpenClawTalkCommand
 import ai.openclaw.app.voice.TalkModeManager
 import android.Manifest
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
@@ -367,32 +369,28 @@ class GatewayBootstrapAuthTest {
             probeResult.await()
           },
         )
+      val runtimeScope = readField<CoroutineScope>(runtime, "scope")
+      val existingJobs =
+        runtimeScope.coroutineContext[Job]
+          ?.children
+          ?.toSet()
+          .orEmpty()
 
       runtime.connect(
         endpoint,
         NodeRuntime.GatewayConnectAuth(token = "shared-token", bootstrapToken = null, password = null),
       )
       probeStarted.await()
+      val probeJob =
+        runtimeScope.coroutineContext[Job]
+          ?.children
+          ?.singleOrNull { it !in existingJobs }
+          ?: error("Expected one TLS probe job")
 
       runtime.disconnect()
       probeResult.complete(GatewayTlsProbeResult(fingerprintSha256 = "aaaaaaaa"))
-      var staleProbeCleared = false
-      repeat(300) {
-        if (runtime.pendingGatewayTrust.value == null &&
-          desiredBootstrapToken(runtime, "nodeSession") == null
-        ) {
-          staleProbeCleared = true
-          return@repeat
-        }
-        Thread.sleep(10)
-      }
-      if (!staleProbeCleared) {
-        error(
-          "Timed out waiting for stale TLS probe cleanup after disconnect; " +
-            "pendingGatewayTrust=${runtime.pendingGatewayTrust.value}, " +
-            "desiredBootstrapToken=${desiredBootstrapToken(runtime, "nodeSession")}",
-        )
-      }
+      // Join the owning coroutine so assertions run after its stale-attempt guard.
+      probeJob.join()
 
       assertNull(runtime.pendingGatewayTrust.value)
       assertNull(desiredBootstrapToken(runtime, "nodeSession"))


### PR DESCRIPTION
## What Problem This Solves

`GatewayBootstrapAuthTest.connect_ignoresStaleTlsProbeAfterDisconnect` used a fixed 100 ms delay before checking that a completed TLS probe could not restore stale connection state. That timing assumption made the test vulnerable to scheduler and runner load.

## Why This Change Was Made

The final test snapshots the runtime scope's existing child jobs, starts the delayed TLS probe, identifies the single newly created probe job, and joins that exact job after disconnecting and completing the probe. Assertions therefore run only after the stale-attempt guard has executed, without a production-only test seam or a poll on fields that `disconnect()` clears synchronously.

## User Impact

No runtime behavior change. This makes the Android TLS recovery regression test deterministic and reduces CI flakiness.

## Evidence

- `GatewayBootstrapAuthTest`: 21 tests passed, 0 failures.
- Android ktlint passed.
- `git diff --check` passed.
- Fresh exact-tree autoreview: no actionable findings, 0.97 confidence.
- Exact-head hosted CI: 18 passed, 23 intentionally skipped, 0 failed on `a6c794e218b1b4c0b626c46de685e6f596a16abc`.
