### PR TITLE
Fix Telegram forum topic parallel flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Docs: https://docs.openclaw.ai
 
 - Memory/search: scan the JS-side fallback vector path (used when the sqlite-vec index is unavailable or has a mismatched dimension) in bounded rowid batches and yield to the event loop between batches so large chunk tables can no longer pin the Node.js main thread for multi-second windows. Also keeps the SQL prepared statement rooted in a local so node:sqlite cannot finalize it mid-scan under heap pressure. Fixes #81172. Thanks @dev23xyz-oss.
 - Memory Wiki: preserve fs-safe diagnostics when bridge source page writes fail for non-symlink filesystem safety reasons, so directory collisions are reported with the underlying error code. (#83776) Thanks @TurboTheTurtle.
+- Telegram: keep forum topics from blocking sibling topic traffic by routing inbound serialization, media/text buffers, and account API queues on topic-aware lanes. (#83829)
 - CLI/update: bypass npm freshness filters consistently during managed package and plugin installs so freshly published release plugins remain installable. Thanks @jalehman.
 - CLI/update: guide root-owned npm install EACCES recovery by stopping the managed Gateway before manual package replacement, then reinstalling and restarting the service. Fixes #83747. (#83757) Thanks @brokemac79.
 - Agents/subagents: keep collect-mode announce queues batching unresolved-origin items with compatible same-route messages and resume collection after a true cross-channel drain when a later compatible batch remains. Fixes #83577.

--- a/extensions/telegram/src/account-throttler.test.ts
+++ b/extensions/telegram/src/account-throttler.test.ts
@@ -1,5 +1,19 @@
-import { beforeEach, describe, expect, it } from "vitest";
-import { clearAccountThrottlersForTest, getOrCreateAccountThrottler } from "./account-throttler.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearAccountThrottlersForTest,
+  createTelegramAccountThrottler,
+  getOrCreateAccountThrottler,
+} from "./account-throttler.js";
+
+type TelegramPreviousCall = Parameters<ReturnType<typeof createTelegramAccountThrottler>>[0];
+
+function deferred<T>() {
+  let resolve: (value: T) => void;
+  const promise = new Promise<T>((innerResolve) => {
+    resolve = innerResolve;
+  });
+  return { promise, resolve: resolve! };
+}
 
 describe("getOrCreateAccountThrottler", () => {
   beforeEach(() => {
@@ -13,5 +27,95 @@ describe("getOrCreateAccountThrottler", () => {
 
     expect(second).toBe(first);
     expect(other).not.toBe(first);
+  });
+
+  it("round-robins group topic requests before entering the Telegram throttler", async () => {
+    const firstGate = deferred<void>();
+    const entered: string[] = [];
+    const throttler = createTelegramAccountThrottler(
+      () => async (prev, method, payload, signal) => prev(method, payload, signal),
+    );
+    const prev = vi.fn(async (_method: string, payload: unknown) => {
+      const request = payload as { message_thread_id?: number; text?: string };
+      entered.push(`${request.message_thread_id}:${request.text}`);
+      if (entered.length === 1) {
+        await firstGate.promise;
+      }
+      return { ok: true, result: request.text ?? "" };
+    }) as unknown as TelegramPreviousCall;
+
+    const first = throttler(
+      prev,
+      "sendMessage",
+      { chat_id: -100123, message_thread_id: 10, text: "first" },
+      undefined,
+    );
+    await vi.waitFor(() => expect(entered).toEqual(["10:first"]));
+
+    const secondSameTopic = throttler(
+      prev,
+      "sendMessage",
+      { chat_id: -100123, message_thread_id: 10, text: "second" },
+      undefined,
+    );
+    const otherTopic = throttler(
+      prev,
+      "sendMessage",
+      { chat_id: -100123, message_thread_id: 20, text: "other" },
+      undefined,
+    );
+    await Promise.resolve();
+
+    expect(entered).toEqual(["10:first"]);
+    firstGate.resolve();
+    await vi.waitFor(() => expect(entered.length).toBeGreaterThanOrEqual(2));
+    expect(entered[1]).toBe("20:other");
+    await Promise.all([first, secondSameTopic, otherTopic]);
+
+    expect(entered).toEqual(["10:first", "20:other", "10:second"]);
+  });
+
+  it("uses edited message ids as lanes when Telegram omits topic ids", async () => {
+    const firstGate = deferred<void>();
+    const entered: string[] = [];
+    const throttler = createTelegramAccountThrottler(
+      () => async (prev, method, payload, signal) => prev(method, payload, signal),
+    );
+    const prev = vi.fn(async (_method: string, payload: unknown) => {
+      const request = payload as { message_id?: number; text?: string };
+      entered.push(`${request.message_id}:${request.text}`);
+      if (entered.length === 1) {
+        await firstGate.promise;
+      }
+      return { ok: true, result: request.text ?? "" };
+    }) as unknown as TelegramPreviousCall;
+
+    const first = throttler(
+      prev,
+      "editMessageText",
+      { chat_id: -100123, message_id: 101, text: "first-edit" },
+      undefined,
+    );
+    await vi.waitFor(() => expect(entered).toEqual(["101:first-edit"]));
+
+    const secondSameMessage = throttler(
+      prev,
+      "editMessageText",
+      { chat_id: -100123, message_id: 101, text: "second-edit" },
+      undefined,
+    );
+    const otherMessage = throttler(
+      prev,
+      "editMessageText",
+      { chat_id: -100123, message_id: 202, text: "other-edit" },
+      undefined,
+    );
+
+    firstGate.resolve();
+    await vi.waitFor(() => expect(entered.length).toBeGreaterThanOrEqual(2));
+    expect(entered[1]).toBe("202:other-edit");
+    await Promise.all([first, secondSameMessage, otherMessage]);
+
+    expect(entered).toEqual(["101:first-edit", "202:other-edit", "101:second-edit"]);
   });
 });

--- a/extensions/telegram/src/account-throttler.ts
+++ b/extensions/telegram/src/account-throttler.ts
@@ -1,8 +1,155 @@
 import { apiThrottler } from "./bot.runtime.js";
 
 type ApiThrottlerTransformer = ReturnType<typeof apiThrottler>;
+type TelegramApiPayload = {
+  chat_id?: unknown;
+  direct_messages_topic_id?: unknown;
+  message_id?: unknown;
+  message_thread_id?: unknown;
+};
+type QueuedApiRequest<T> = {
+  run: () => Promise<T>;
+  resolve: (value: T) => void;
+  reject: (err: unknown) => void;
+};
+
+class GroupFairQueue {
+  private readonly lanes = new Map<string, Array<QueuedApiRequest<unknown>>>();
+  private laneOrder: string[] = [];
+  private nextLaneIndex = 0;
+  private running = false;
+
+  enqueue<T>(laneKey: string, run: () => Promise<T>): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      const request: QueuedApiRequest<unknown> = {
+        run,
+        resolve: resolve as (value: unknown) => void,
+        reject,
+      };
+      const existing = this.lanes.get(laneKey);
+      if (existing) {
+        existing.push(request);
+      } else {
+        this.lanes.set(laneKey, [request]);
+        this.laneOrder.push(laneKey);
+      }
+      this.start();
+    });
+  }
+
+  private start(): void {
+    if (this.running) {
+      return;
+    }
+    this.running = true;
+    void this.drain();
+  }
+
+  private async drain(): Promise<void> {
+    try {
+      while (true) {
+        const request = this.takeNext();
+        if (!request) {
+          return;
+        }
+        try {
+          request.resolve(await request.run());
+        } catch (err) {
+          request.reject(err);
+        }
+      }
+    } finally {
+      this.running = false;
+      if (this.laneOrder.length > 0) {
+        this.start();
+      }
+    }
+  }
+
+  private takeNext(): QueuedApiRequest<unknown> | undefined {
+    for (let scanned = 0; scanned < this.laneOrder.length; scanned += 1) {
+      this.nextLaneIndex %= this.laneOrder.length;
+      const laneKey = this.laneOrder[this.nextLaneIndex];
+      const queue = this.lanes.get(laneKey);
+      if (!queue || queue.length === 0) {
+        this.lanes.delete(laneKey);
+        this.laneOrder.splice(this.nextLaneIndex, 1);
+        if (this.laneOrder.length === 0) {
+          this.nextLaneIndex = 0;
+          return undefined;
+        }
+        continue;
+      }
+
+      const request = queue.shift();
+      this.nextLaneIndex += 1;
+      return request;
+    }
+    return undefined;
+  }
+}
 
 const throttlerByToken = new Map<string, ApiThrottlerTransformer>();
+
+function readNumericId(value: unknown): number | undefined {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? Math.trunc(value) : undefined;
+  }
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const numeric = Number(value.trim());
+  return Number.isFinite(numeric) ? Math.trunc(numeric) : undefined;
+}
+
+function readPayload(payload: unknown): TelegramApiPayload | undefined {
+  return payload && typeof payload === "object" ? (payload as TelegramApiPayload) : undefined;
+}
+
+function resolveGroupChatKey(payload: TelegramApiPayload): string | undefined {
+  const chatId = readNumericId(payload.chat_id);
+  return chatId !== undefined && chatId < 0 ? String(chatId) : undefined;
+}
+
+function resolveForumLaneKey(payload: TelegramApiPayload): string {
+  const threadId = readNumericId(payload.message_thread_id);
+  if (threadId !== undefined) {
+    return `topic:${threadId}`;
+  }
+  const directTopicId = readNumericId(payload.direct_messages_topic_id);
+  if (directTopicId !== undefined) {
+    return `direct-topic:${directTopicId}`;
+  }
+  const messageId = readNumericId(payload.message_id);
+  if (messageId !== undefined) {
+    return `message:${messageId}`;
+  }
+  return "main";
+}
+
+export function createTelegramAccountThrottler(
+  createThrottler: () => ApiThrottlerTransformer = apiThrottler,
+): ApiThrottlerTransformer {
+  const baseThrottler = createThrottler();
+  const fairQueuesByChat = new Map<string, GroupFairQueue>();
+
+  return (prev, method, payload, signal) => {
+    const apiPayload = readPayload(payload);
+    const groupChatKey = apiPayload ? resolveGroupChatKey(apiPayload) : undefined;
+    if (!apiPayload || !groupChatKey) {
+      return baseThrottler(prev, method, payload, signal);
+    }
+
+    let fairQueue = fairQueuesByChat.get(groupChatKey);
+    if (!fairQueue) {
+      fairQueue = new GroupFairQueue();
+      fairQueuesByChat.set(groupChatKey, fairQueue);
+    }
+
+    const laneKey = resolveForumLaneKey(apiPayload);
+    return fairQueue.enqueue(laneKey, () => baseThrottler(prev, method, payload, signal));
+  };
+}
 
 export function getOrCreateAccountThrottler(
   token: string,
@@ -10,7 +157,7 @@ export function getOrCreateAccountThrottler(
 ): ApiThrottlerTransformer {
   let throttler = throttlerByToken.get(token);
   if (!throttler) {
-    throttler = createThrottler();
+    throttler = createTelegramAccountThrottler(createThrottler);
     throttlerByToken.set(token, throttler);
   }
   return throttler;

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -195,7 +195,7 @@ export const registerTelegramHandlers = ({
   };
 
   const mediaGroupBuffer = new Map<string, BufferedMediaGroupEntry>();
-  let mediaGroupProcessing: Promise<void> = Promise.resolve();
+  const mediaGroupProcessingByKey = new Map<string, Promise<void>>();
   const messageCache = createTelegramMessageCache({
     persistedPath: resolveTelegramMessageCachePath(
       telegramDeps.resolveStorePath(cfg.session?.store),
@@ -210,7 +210,21 @@ export const registerTelegramHandlers = ({
     timer: ReturnType<typeof setTimeout>;
   };
   const textFragmentBuffer = new Map<string, TextFragmentEntry>();
-  let textFragmentProcessing: Promise<void> = Promise.resolve();
+  const textFragmentProcessingByKey = new Map<string, Promise<void>>();
+
+  const queueBufferedProcessing = async (
+    processingByKey: Map<string, Promise<void>>,
+    key: string,
+    task: () => Promise<void>,
+  ) => {
+    const previous = processingByKey.get(key) ?? Promise.resolve();
+    const current = previous.then(task).catch(() => undefined);
+    processingByKey.set(key, current);
+    await current;
+    if (processingByKey.get(key) === current) {
+      processingByKey.delete(key);
+    }
+  };
 
   const debounceMs = resolveInboundDebounceMs({ cfg, channel: "telegram" });
   const FORWARD_BURST_DEBOUNCE_MS = 80;
@@ -864,12 +878,9 @@ export const registerTelegramHandlers = ({
   };
 
   const queueTextFragmentFlush = async (entry: TextFragmentEntry) => {
-    textFragmentProcessing = textFragmentProcessing
-      .then(async () => {
-        await flushTextFragments(entry);
-      })
-      .catch(() => undefined);
-    await textFragmentProcessing;
+    await queueBufferedProcessing(textFragmentProcessingByKey, entry.key, async () => {
+      await flushTextFragments(entry);
+    });
   };
 
   const runTextFragmentFlush = async (entry: TextFragmentEntry) => {
@@ -1613,12 +1624,7 @@ export const registerTelegramHandlers = ({
         // Not appendable (or limits exceeded): flush buffered entry first, then continue normally.
         clearTimeout(existing.timer);
         textFragmentBuffer.delete(key);
-        textFragmentProcessing = textFragmentProcessing
-          .then(async () => {
-            await flushTextFragments(existing);
-          })
-          .catch(() => undefined);
-        await textFragmentProcessing;
+        await queueTextFragmentFlush(existing);
       }
 
       const shouldStart = text.length >= TELEGRAM_TEXT_FRAGMENT_START_THRESHOLD_CHARS;
@@ -1647,7 +1653,9 @@ export const registerTelegramHandlers = ({
     // Media group handling - buffer multi-image messages
     const mediaGroupId = msg.media_group_id;
     if (mediaGroupId) {
-      const existing = mediaGroupBuffer.get(mediaGroupId);
+      const threadId = resolvedThreadId ?? dmThreadId;
+      const mediaGroupKey = `media:${chatId}:${threadId ?? "main"}:${mediaGroupId}`;
+      const existing = mediaGroupBuffer.get(mediaGroupKey);
       if (existing) {
         clearTimeout(existing.timer);
         existing.messages.push({ msg, ctx });
@@ -1656,13 +1664,10 @@ export const registerTelegramHandlers = ({
           promptContextMinTimestampMs,
         );
         existing.timer = setTimeout(async () => {
-          mediaGroupBuffer.delete(mediaGroupId);
-          mediaGroupProcessing = mediaGroupProcessing
-            .then(async () => {
-              await processMediaGroup(existing);
-            })
-            .catch(() => undefined);
-          await mediaGroupProcessing;
+          mediaGroupBuffer.delete(mediaGroupKey);
+          await queueBufferedProcessing(mediaGroupProcessingByKey, mediaGroupKey, async () => {
+            await processMediaGroup(existing);
+          });
         }, mediaGroupTimeoutMs);
       } else {
         const entry: BufferedMediaGroupEntry = {
@@ -1679,16 +1684,13 @@ export const registerTelegramHandlers = ({
           topicConfig,
           ...promptContextBoundaryOptions(promptContextMinTimestampMs),
           timer: setTimeout(async () => {
-            mediaGroupBuffer.delete(mediaGroupId);
-            mediaGroupProcessing = mediaGroupProcessing
-              .then(async () => {
-                await processMediaGroup(entry);
-              })
-              .catch(() => undefined);
-            await mediaGroupProcessing;
+            mediaGroupBuffer.delete(mediaGroupKey);
+            await queueBufferedProcessing(mediaGroupProcessingByKey, mediaGroupKey, async () => {
+              await processMediaGroup(entry);
+            });
           }, mediaGroupTimeoutMs),
         };
-        mediaGroupBuffer.set(mediaGroupId, entry);
+        mediaGroupBuffer.set(mediaGroupKey, entry);
       }
       return;
     }
@@ -1940,6 +1942,7 @@ export const registerTelegramHandlers = ({
         chatType: callbackMessage.chat.type,
         isGroup,
         isForum: callbackMessage.chat.is_forum,
+        isTopicMessage: callbackMessage.is_topic_message,
         getChat,
       });
       const senderId = callback.from?.id ? String(callback.from.id) : "";
@@ -2600,6 +2603,7 @@ export const registerTelegramHandlers = ({
       chatType: msg.chat.type,
       isGroup,
       isForum: msg.chat.is_forum,
+      isTopicMessage: msg.is_topic_message,
       getChat,
     });
     const normalizedMsg = withResolvedTelegramForumFlag(msg, isForum);
@@ -2735,6 +2739,7 @@ export const registerTelegramHandlers = ({
       chatType: msg.chat.type,
       isGroup,
       isForum: msg.chat.is_forum,
+      isTopicMessage: msg.is_topic_message,
       getChat,
     });
     const normalizedMsg = withResolvedTelegramForumFlag(msg, isForum);

--- a/extensions/telegram/src/bot-message-context.topic-agentid.test.ts
+++ b/extensions/telegram/src/bot-message-context.topic-agentid.test.ts
@@ -91,6 +91,35 @@ describe("buildTelegramMessageContext per-topic agentId routing", () => {
     expect(ctxB?.ctxPayload?.SessionKey).not.toBe(ctxC?.ctxPayload?.SessionKey);
   });
 
+  it("preserves topic routing when Telegram omits chat.is_forum", async () => {
+    const resolveTelegramGroupConfig = vi.fn(() => ({
+      groupConfig: { requireMention: false },
+      topicConfig: { agentId: "zu" },
+    }));
+    const ctx = await buildTelegramMessageContextForTest({
+      message: {
+        message_id: 1,
+        chat: {
+          id: -1001234567890,
+          type: "supergroup",
+          title: "Forum",
+        },
+        date: 1700000000,
+        text: "@bot hello",
+        is_topic_message: true,
+        message_thread_id: 3,
+        from: { id: 42, first_name: "Alice" },
+      },
+      options: { forceWasMentioned: true },
+      resolveGroupActivation: () => true,
+      resolveTelegramGroupConfig,
+    });
+
+    expect(resolveTelegramGroupConfig).toHaveBeenCalledWith(-1001234567890, 3);
+    expect(ctx?.ctxPayload?.SessionKey).toContain("agent:zu:");
+    expect(ctx?.ctxPayload?.SessionKey).toContain("telegram:group:-1001234567890:topic:3");
+  });
+
   it("ignores whitespace-only agentId and uses group-level agent", async () => {
     const ctx = await buildForumContext({
       topicConfig: { agentId: "   ", systemPrompt: "Be nice" },

--- a/extensions/telegram/src/bot-message-context.ts
+++ b/extensions/telegram/src/bot-message-context.ts
@@ -160,6 +160,7 @@ export const buildTelegramMessageContext = async ({
     chatType: msg.chat.type,
     isGroup,
     isForum: extractTelegramForumFlag(msg.chat),
+    isTopicMessage: msg.is_topic_message,
     getChat: getChatApi,
   });
   const threadSpec = resolveTelegramThreadSpec({

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -378,6 +378,7 @@ async function resolveTelegramNativeCommandThreadContext(params: {
     chatType: msg.chat.type,
     isGroup,
     isForum: extractTelegramForumFlag(msg.chat),
+    isTopicMessage: msg.is_topic_message,
     getChat,
   });
   const threadSpec = resolveTelegramThreadSpec({

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -241,7 +241,7 @@ describe("createTelegramBot", () => {
   it("installs grammY throttler", () => {
     createTelegramBot({ token: "tok" });
     expect(throttlerSpy).toHaveBeenCalledTimes(1);
-    expect(useSpy).toHaveBeenCalledWith("throttler");
+    expect(useSpy).toHaveBeenCalledWith(expect.any(Function));
   });
 
   it("reuses the grammY throttler for the same token", () => {

--- a/extensions/telegram/src/bot.media.downloads-media-file-path-no-file-download.e2e.test.ts
+++ b/extensions/telegram/src/bot.media.downloads-media-file-path-no-file-download.e2e.test.ts
@@ -435,6 +435,97 @@ describe("telegram media groups", () => {
     },
     MEDIA_GROUP_TEST_TIMEOUT_MS,
   );
+
+  it(
+    "flushes same-id forum topic media groups in parallel",
+    async () => {
+      const originalLoadConfig = telegramBotDepsForTest.getRuntimeConfig;
+      telegramBotDepsForTest.getRuntimeConfig = (() => ({
+        channels: {
+          telegram: {
+            dmPolicy: "open",
+            allowFrom: ["*"],
+            groupPolicy: "open",
+            groups: { "*": { requireMention: false } },
+          },
+        },
+      })) as typeof telegramBotDepsForTest.getRuntimeConfig;
+
+      const runtimeError = vi.fn();
+      const { handler, replySpy } = await createBotHandlerWithOptions({ runtimeError });
+      const fetchSpy = mockTelegramPngDownload();
+      let releaseFirstReply: (() => void) | undefined;
+      const firstReplyStarted = new Promise<void>((resolve) => {
+        replySpy.mockImplementationOnce(async (_ctx, opts?: { onReplyStart?: () => unknown }) => {
+          await opts?.onReplyStart?.();
+          resolve();
+          await new Promise<void>((release) => {
+            releaseFirstReply = release;
+          });
+          return undefined;
+        });
+      });
+
+      try {
+        await Promise.all([
+          handler({
+            message: {
+              chat: { id: -10042, type: "supergroup" as const, is_forum: true },
+              from: { id: 777, is_bot: false, first_name: "Ada" },
+              message_id: 31,
+              message_thread_id: 101,
+              caption: "Topic one album",
+              date: 1736380800,
+              media_group_id: "album-shared-by-telegram",
+              photo: [{ file_id: "topic1photo" }],
+            },
+            me: { username: "openclaw_bot" },
+            getFile: async () => ({ file_path: "photos/topic1.jpg" }),
+          }),
+          handler({
+            message: {
+              chat: { id: -10042, type: "supergroup" as const, is_forum: true },
+              from: { id: 777, is_bot: false, first_name: "Ada" },
+              message_id: 32,
+              message_thread_id: 202,
+              caption: "Topic two album",
+              date: 1736380801,
+              media_group_id: "album-shared-by-telegram",
+              photo: [{ file_id: "topic2photo" }],
+            },
+            me: { username: "openclaw_bot" },
+            getFile: async () => ({ file_path: "photos/topic2.jpg" }),
+          }),
+        ]);
+
+        await firstReplyStarted;
+        expect(replySpy).toHaveBeenCalledTimes(1);
+        await vi.waitFor(
+          () => {
+            expect(replySpy).toHaveBeenCalledTimes(2);
+          },
+          { timeout: MEDIA_GROUP_WAIT_TIMEOUT_MS, interval: 2 },
+        );
+
+        const firstPayload = replyPayload(replySpy, 0);
+        const secondPayload = replyPayload(replySpy, 1);
+        expect([firstPayload.Body, secondPayload.Body]).toEqual(
+          expect.arrayContaining([
+            expect.stringContaining("Topic one album"),
+            expect.stringContaining("Topic two album"),
+          ]),
+        );
+        expect(firstPayload.MediaPaths).toHaveLength(1);
+        expect(secondPayload.MediaPaths).toHaveLength(1);
+        expect(runtimeError).not.toHaveBeenCalled();
+      } finally {
+        releaseFirstReply?.();
+        fetchSpy.mockRestore();
+        telegramBotDepsForTest.getRuntimeConfig = originalLoadConfig;
+      }
+    },
+    MEDIA_GROUP_TEST_TIMEOUT_MS,
+  );
 });
 
 describe("telegram forwarded bursts", () => {

--- a/extensions/telegram/src/bot.media.stickers-and-fragments.e2e.test.ts
+++ b/extensions/telegram/src/bot.media.stickers-and-fragments.e2e.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { telegramBotDepsForTest } from "./bot.media.e2e-harness.js";
 import {
   TELEGRAM_TEST_TIMINGS,
   cacheStickerSpy,
@@ -202,6 +203,10 @@ describe("telegram text fragments", () => {
   });
 
   const TEXT_FRAGMENT_TEST_TIMEOUT_MS = process.platform === "win32" ? 45_000 : 20_000;
+  const TEXT_FRAGMENT_PARALLEL_WAIT_TIMEOUT_MS = Math.max(
+    2_000,
+    TELEGRAM_TEST_TIMINGS.textFragmentGapMs * 10,
+  );
 
   it(
     "buffers near-limit text and processes sequential parts as one message",
@@ -245,6 +250,88 @@ describe("telegram text fragments", () => {
         expect(payload.RawBody).toContain(part2.slice(0, 32));
       } finally {
         setTimeoutSpy.mockRestore();
+      }
+    },
+    TEXT_FRAGMENT_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "flushes different forum topic fragments in parallel",
+    async () => {
+      const originalLoadConfig = telegramBotDepsForTest.getRuntimeConfig;
+      telegramBotDepsForTest.getRuntimeConfig = (() => ({
+        channels: {
+          telegram: {
+            dmPolicy: "open",
+            allowFrom: ["*"],
+            groupPolicy: "open",
+            groups: { "*": { requireMention: false } },
+          },
+        },
+      })) as typeof telegramBotDepsForTest.getRuntimeConfig;
+
+      const runtimeError = vi.fn();
+      const { handler, replySpy } = await createBotHandlerWithOptions({ runtimeError });
+      let releaseFirstReply: (() => void) | undefined;
+      const firstReplyStarted = new Promise<void>((resolve) => {
+        replySpy.mockImplementationOnce(async (_ctx, opts?: { onReplyStart?: () => unknown }) => {
+          await opts?.onReplyStart?.();
+          resolve();
+          await new Promise<void>((release) => {
+            releaseFirstReply = release;
+          });
+          return undefined;
+        });
+      });
+
+      try {
+        await handler({
+          message: {
+            chat: { id: -10042, type: "supergroup", is_forum: true },
+            from: { id: 777, is_bot: false, first_name: "Ada" },
+            message_id: 20,
+            message_thread_id: 101,
+            date: 1736380800,
+            text: `topic-one ${"A".repeat(4050)}`,
+          },
+          me: { username: "openclaw_bot" },
+          getFile: async () => ({}),
+        });
+
+        await handler({
+          message: {
+            chat: { id: -10042, type: "supergroup", is_forum: true },
+            from: { id: 777, is_bot: false, first_name: "Ada" },
+            message_id: 21,
+            message_thread_id: 202,
+            date: 1736380801,
+            text: `topic-two ${"B".repeat(4050)}`,
+          },
+          me: { username: "openclaw_bot" },
+          getFile: async () => ({}),
+        });
+
+        await firstReplyStarted;
+        expect(replySpy).toHaveBeenCalledTimes(1);
+        await vi.waitFor(
+          () => {
+            expect(replySpy).toHaveBeenCalledTimes(2);
+          },
+          { timeout: TEXT_FRAGMENT_PARALLEL_WAIT_TIMEOUT_MS, interval: 2 },
+        );
+
+        const firstPayload = replySpy.mock.calls.at(0)?.[0] as { RawBody?: string };
+        const secondPayload = replySpy.mock.calls.at(1)?.[0] as { RawBody?: string };
+        expect([firstPayload.RawBody, secondPayload.RawBody]).toEqual(
+          expect.arrayContaining([
+            expect.stringContaining("topic-one"),
+            expect.stringContaining("topic-two"),
+          ]),
+        );
+        expect(runtimeError).not.toHaveBeenCalled();
+      } finally {
+        releaseFirstReply?.();
+        telegramBotDepsForTest.getRuntimeConfig = originalLoadConfig;
       }
     },
     TEXT_FRAGMENT_TEST_TIMEOUT_MS,

--- a/extensions/telegram/src/bot/helpers.test.ts
+++ b/extensions/telegram/src/bot/helpers.test.ts
@@ -68,6 +68,36 @@ describe("resolveTelegramForumFlag", () => {
     expect(getChat).toHaveBeenCalledWith(-100789);
   });
 
+  it("uses supergroup topic-message metadata before getChat lookup", async () => {
+    const getChat = vi.fn(async () => {
+      throw new Error("lookup should not run");
+    });
+    await expect(
+      resolveTelegramForumFlag({
+        chatId: -100987,
+        chatType: "supergroup",
+        isGroup: true,
+        isTopicMessage: true,
+        getChat,
+      }),
+    ).resolves.toBe(true);
+    expect(getChat).not.toHaveBeenCalled();
+  });
+
+  it("does not treat private DM topic metadata as forum metadata", async () => {
+    const getChat = vi.fn(async () => ({ is_forum: true }));
+    await expect(
+      resolveTelegramForumFlag({
+        chatId: 123456,
+        chatType: "private",
+        isGroup: false,
+        isTopicMessage: true,
+        getChat,
+      }),
+    ).resolves.toBe(false);
+    expect(getChat).not.toHaveBeenCalled();
+  });
+
   it("reuses resolved forum metadata for later supergroup updates", async () => {
     const getChat = vi.fn(async () => ({ is_forum: true }));
     const params = {

--- a/extensions/telegram/src/bot/helpers.ts
+++ b/extensions/telegram/src/bot/helpers.ts
@@ -121,18 +121,35 @@ export function extractTelegramForumFlag(value: unknown): boolean | undefined {
   return typeof forum === "boolean" ? forum : undefined;
 }
 
+export function resolveTelegramMessageForumFlagHint(params: {
+  chatType?: Chat["type"];
+  isForum?: boolean;
+  isTopicMessage?: boolean;
+}): boolean | undefined {
+  if (params.chatType === "supergroup" && params.isTopicMessage === true) {
+    return true;
+  }
+  return typeof params.isForum === "boolean" ? params.isForum : undefined;
+}
+
 export async function resolveTelegramForumFlag(params: {
   chatId: string | number;
   chatType?: Chat["type"];
   isGroup: boolean;
   isForum?: boolean;
+  isTopicMessage?: boolean;
   getChat?: TelegramGetChat;
 }): Promise<boolean> {
-  if (typeof params.isForum === "boolean") {
+  const forumHint = resolveTelegramMessageForumFlagHint({
+    chatType: params.chatType,
+    isForum: params.isForum,
+    isTopicMessage: params.isTopicMessage,
+  });
+  if (typeof forumHint === "boolean") {
     if (params.isGroup && params.chatType === "supergroup") {
-      cacheTelegramForumFlag(params.chatId, params.isForum);
+      cacheTelegramForumFlag(params.chatId, forumHint);
     }
-    return params.isForum;
+    return forumHint;
   }
   if (!params.isGroup || params.chatType !== "supergroup" || !params.getChat) {
     return false;

--- a/extensions/telegram/src/sequential-key.ts
+++ b/extensions/telegram/src/sequential-key.ts
@@ -9,7 +9,10 @@ import {
   isAbortRequestText,
   isBtwRequestText,
 } from "openclaw/plugin-sdk/command-primitives-runtime";
-import { resolveTelegramForumThreadId } from "./bot/helpers.js";
+import {
+  resolveTelegramForumThreadId,
+  resolveTelegramMessageForumFlagHint,
+} from "./bot/helpers.js";
 
 const TELEGRAM_READ_ONLY_STATUS_COMMAND_KEYS = new Set([
   "commands",
@@ -137,8 +140,11 @@ export function getTelegramSequentialKey(ctx: TelegramSequentialKeyContext): str
   }
   const isGroup = msg?.chat?.type === "group" || msg?.chat?.type === "supergroup";
   const messageThreadId = msg?.message_thread_id;
-  const isForum =
-    msg?.chat?.is_forum ?? (msg?.chat?.type === "supergroup" && msg?.is_topic_message === true);
+  const isForum = resolveTelegramMessageForumFlagHint({
+    chatType: msg?.chat?.type,
+    isForum: msg?.chat?.is_forum,
+    isTopicMessage: msg?.is_topic_message,
+  });
   const threadId = isGroup
     ? resolveTelegramForumThreadId({ isForum, messageThreadId })
     : messageThreadId;


### PR DESCRIPTION
## Summary
- Fix Telegram forum-topic identity when Bot API messages include `is_topic_message: true` but omit `chat.is_forum`, keeping topic messages in topic-scoped session lanes.
- Replace Telegram text-fragment and media-group global flush chains with per-topic/per-buffer queues so independent topics can flush concurrently.
- Scope media-group buffering by chat + thread + `media_group_id` so albums in different topics cannot share a buffer lane.
- Add a per-group fair outbound queue before the existing grammY throttler so one topic/message lane cannot monopolize Telegram's shared group send pipe while preserving Telegram group rate limits.
- Supersedes #83789 and #83802. #83790 remains separate follow-up/abort behavior work and is not part of this PR.

## Root Cause
Telegram forum topics felt serialized because there were multiple independent bottlenecks in the topic path.

First, topic identity was recovered inconsistently. The early sequential key path could treat `is_topic_message: true` as topic evidence, but later inbound routing paths trusted only `chat.is_forum` or a successful `getChat` lookup. When Telegram omitted `chat.is_forum` and lookup was unavailable, a real forum-topic message could collapse to the base group session.

Second, Telegram text-fragment and media-group buffering each used process-wide promise chains. That preserved order inside a buffer type but serialized unrelated topics. Media groups also keyed only by Telegram's `media_group_id`, so identical album ids from different topics could share one buffer lane.

Third, after internal topic work could run in parallel, Telegram-visible output still shared grammY's group throttler. The installed `@grammyjs/transformer-throttler` groups group sends by `chat_id`; Telegram forum topics share the same `chat_id`, so one topic's progress/edit burst could sit ahead of another topic's outbound update. The new queue fair-shares requests by `message_thread_id` when present, and by `message_id` for preview edits where Telegram omits the thread id, before handing requests to the existing throttler.

## Real behavior proof
Behavior addressed: Telegram forum topics no longer collapse to the base group route, no longer block each other's buffered text/media flushes, and no longer let one topic/message lane monopolize the shared Telegram group outbound pipe.

Real environment tested: local live OpenClaw gateway after applying this patch, rebuilding, and restarting the managed gateway. Live identifiers below are redacted where they identify a real Telegram group, Telegram user, bot token, token provider, or local config path.

Exact steps or command run after this patch:
- `pnpm install --force`
- `pnpm build`
- `openclaw gateway restart`
- `openclaw gateway status --deep`
- `openclaw gateway stability --json --limit 300 --type queue.lane.dequeue`
- `openclaw gateway stability --json --limit 300 --type diagnostic.heartbeat`
- `openclaw gateway stability --json --limit 300 --type message.delivery.started`
- `openclaw gateway stability --json --limit 300 --type message.delivery.completed`
- `openclaw gateway stability --json --limit 300 --type message.processed`
- `journalctl --user -u openclaw-gateway --since '2026-05-18 20:33:27 EDT' --until '2026-05-18 21:22:28 EDT' --no-pager -o cat` filtered for Telegram send, failure, `429`, and `retry_after` counters.

Evidence after fix:
- Gateway restart boundary: `2026-05-18 20:33:27 EDT`.
- Gateway pid after restart: `3951260`.
- `openclaw gateway status --deep`: runtime running and connectivity probe OK.
- Rebuilt `dist` contains `GroupFairQueue`, `resolveForumLaneKey`, and `createTelegramAccountThrottler`.
- Live topic routes observed for `telegram:group:<redacted>:topic:8428` and `telegram:group:<redacted>:topic:5907`.
- Queue snapshot after live traffic: `message.queued=4`, `queue.lane.dequeue=8`, max `waitMs=0`.
- Topic lane sources: `topic:8428` dequeued twice, `topic:5907` dequeued twice, plus their main-lane dispatches.
- Heartbeats after live traffic: max `active=2`, `waiting=0`, `queued=0`.
- Delivery snapshot: `message.delivery.started=3`, `message.delivery.completed=3`, all `outcome=completed`.
- Processed snapshot: `message.processed=3`, all `outcome=completed`.
- Latest Telegram transport counters from restart through `2026-05-18 21:22:28 EDT`: `sendMessage ok=143`, `outbound send ok=38`, Telegram send failures `0`, Telegram `429` / `retry_after` `0`.

Observed result after fix: two real Telegram forum topics entered topic-qualified lanes with zero queue wait, concurrent work was observed by heartbeat, Telegram deliveries completed, and no Telegram flood-control or send-failure signal appeared.

Before proof:
- Applying only the new handler e2e tests to unpatched `origin/main` and running the filtered command failed: `Test Files 2 failed (2); Tests 2 failed | 10 skipped (12)`.
- Both failures reported that the second topic did not start while the first topic was held: `expected "vi.fn()" to be called 2 times, but got 1 times`.
- Source inspection showed the same root-cause shape: topic identity fallback did not consistently use `is_topic_message`, buffer processing used global promise chains, and grammY's upstream group throttler keyed group sends by `chat_id` rather than `message_thread_id`.

## Live Telegram config (sanitized)
- Active Telegram config source: user OpenClaw config, values summarized with all Telegram group IDs, user IDs, bot tokens, token-provider names, and local paths redacted.
- `channels.telegram.enabled`: `true`.
- Bot token source: SecretRef backed by an exec provider; no inline bot token is disclosed here.
- Account shape: single default Telegram account; no `channels.telegram.accounts` entries configured.
- API root: default Telegram Bot API root; no custom `apiRoot` configured.
- `channels.telegram.dmPolicy`: `pairing`.
- `channels.telegram.allowFrom`: one numeric Telegram user ID, no wildcard.
- `channels.telegram.groupPolicy`: `allowlist`.
- `channels.telegram.groupAllowFrom`: one numeric Telegram user ID, no wildcard.
- `channels.telegram.groups`: three explicit Telegram groups, all IDs redacted; one has `requireMention: false`, two have `requireMention: true`, and one group has a group-local allowlist containing two numeric IDs with no wildcard.
- Configured topic overrides: none. The live topics in this proof are discovered from Telegram update metadata (`message_thread_id` / `is_topic_message`) rather than hard-coded in config.
- `channels.telegram.streaming`: `{ mode: "progress", progress: { toolProgress: true, commandText: "status" } }`.
- Legacy `channels.telegram.streamMode`: not configured.
- Native commands: enabled via `commands.native: true`.
- Polling stall watchdog: default `120000ms` because `channels.telegram.pollingStallThresholdMs` is not configured.
- Telegram runner concurrency contract: `extensions/telegram/src/monitor.ts` sets grammY runner sink concurrency from `resolveAgentMaxConcurrent(cfg)`, which reads `agents.defaults.maxConcurrent`.
- Live concurrency config relevant to this PR: `agents.defaults.maxConcurrent=8`, `agents.defaults.subagents.maxConcurrent=16`, no per-agent `maxConcurrent` overrides, and `acp.maxConcurrentSessions=8`.
- Serialization boundary after this patch: grammY still sequences updates by Telegram sequential key, but the key includes forum topic thread IDs; text fragments and media groups queue by per-topic/per-buffer keys; outbound group sends are fair-shared by Telegram forum lane before the existing Telegram-safe throttler.

## Verification
- `git diff --check origin/main...HEAD`
- `node scripts/run-vitest.mjs extensions/telegram/src`
  - `Test Files 117 passed (117)`
  - `Tests 1794 passed (1794)`
- `OPENCLAW_E2E_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts extensions/telegram/src/bot.media.stickers-and-fragments.e2e.test.ts extensions/telegram/src/bot.media.downloads-media-file-path-no-file-download.e2e.test.ts`
  - `Test Files 2 passed (2)`
  - `Tests 12 passed (12)`
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo`
- `codex-review --mode branch`
  - Completed one full loop clean earlier on the combined branch: `codex-review clean: no accepted/actionable findings reported`.

## What was not tested
- Crabbox/TDLib video proof was not run.
- Raw Bot API update payload capture was not collected.
- Callback/native-command/DM-topic live flows were not separately exercised in Telegram after the final restart; focused tests cover those routing semantics.
- Full repository test suite beyond the Telegram unit surface, focused Telegram e2e files, extension type checks, and codex-review.

