### PR TITLE
fix(whatsapp): warn once when group inbound dropped for missing channels.whatsapp.groups entry

### DIFF
--- a/extensions/whatsapp/src/auto-reply/monitor/group-gating.allowlist-warn.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/group-gating.allowlist-warn.test.ts
@@ -90,7 +90,9 @@ describe("applyGroupGating allowlist drop warning", () => {
 
     expect(result).toEqual({ shouldProcess: false });
     expect(warn).toHaveBeenCalledTimes(1);
-    expect(params.logVerbose).not.toHaveBeenCalled();
+    expect(params.logVerbose).toHaveBeenCalledWith(
+      'Dropping message from unregistered WhatsApp group unregistered@g.us. Add the group JID to channels.whatsapp.groups, or add "*" there to admit all groups. Sender authorization still applies.',
+    );
     const [context, message] = warn.mock.calls[0] ?? [];
     expect(context).toMatchObject({
       conversationId: "unregistered@g.us",
@@ -153,14 +155,21 @@ describe("applyGroupGating allowlist drop warning", () => {
     expect(message).toContain("channels.whatsapp.groups");
   });
 
-  it("only warns once per conversation across repeated messages", async () => {
+  it("warns once but keeps verbose diagnostics per dropped message", async () => {
     const warn = vi.fn<WarnLogger>();
+    const first = makeParams(makeUnregisteredGroupMsg("loud@g.us"), warn);
+    const second = makeParams(makeUnregisteredGroupMsg("loud@g.us"), warn);
+    const third = makeParams(makeUnregisteredGroupMsg("loud@g.us"), warn);
 
-    await applyGroupGating(makeParams(makeUnregisteredGroupMsg("loud@g.us"), warn));
-    await applyGroupGating(makeParams(makeUnregisteredGroupMsg("loud@g.us"), warn));
-    await applyGroupGating(makeParams(makeUnregisteredGroupMsg("loud@g.us"), warn));
+    await applyGroupGating(first);
+    await applyGroupGating(second);
+    await applyGroupGating(third);
 
     expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.[1]).toContain("loud@g.us");
+    expect(first.logVerbose).toHaveBeenCalledTimes(1);
+    expect(second.logVerbose).toHaveBeenCalledTimes(1);
+    expect(third.logVerbose).toHaveBeenCalledTimes(1);
   });
 
   it("warns separately for distinct conversations", async () => {

--- a/extensions/whatsapp/src/auto-reply/monitor/group-gating.allowlist-warn.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/group-gating.allowlist-warn.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./group-activation.js", () => ({
+  resolveGroupActivationFor: vi.fn(async () => "mention"),
+}));
+
+import type { MentionConfig } from "../mentions.js";
+import type { WebInboundMsg } from "../types.js";
+import {
+  resetGroupDropWarningsForTests,
+  applyGroupGating,
+  type GroupHistoryEntry,
+} from "./group-gating.js";
+
+function makeUnregisteredGroupMsg(
+  conversationId: string,
+  accountId: string = "default",
+): WebInboundMsg {
+  return {
+    id: `msg-${conversationId}`,
+    from: conversationId,
+    to: "+15550000001",
+    body: "@openclaw hello",
+    chatId: conversationId,
+    chatType: "group",
+    conversationId,
+    timestamp: 1700000000,
+    accountId,
+    sender: { e164: "+15550000002", name: "Alice" },
+  } as WebInboundMsg;
+}
+
+type WarnLogger = (obj: unknown, msg: string) => void;
+
+function makeParams(msg: WebInboundMsg, warn: WarnLogger) {
+  return {
+    cfg: {
+      channels: {
+        whatsapp: {
+          groupPolicy: "allowlist",
+          groups: {
+            "registered@g.us": {},
+          },
+          accounts: {
+            work: {
+              groupPolicy: "allowlist",
+              groups: {
+                "registered@g.us": {},
+              },
+            },
+          },
+        },
+      },
+      messages: {
+        groupChat: {
+          mentionPatterns: ["\\bopenclaw\\b"],
+        },
+      },
+    } as never,
+    msg,
+    conversationId: msg.conversationId,
+    groupHistoryKey: `whatsapp:group:${msg.conversationId}`,
+    agentId: "main",
+    sessionKey: `agent:main:whatsapp:group:${msg.conversationId}`,
+    baseMentionConfig: { mentionRegexes: [/\bopenclaw\b/i] } satisfies MentionConfig,
+    groupHistories: new Map<string, GroupHistoryEntry[]>(),
+    groupHistoryLimit: 20,
+    groupMemberNames: new Map<string, Map<string, string>>(),
+    logVerbose: vi.fn(),
+    replyLogger: { debug: vi.fn(), warn },
+  };
+}
+
+describe("applyGroupGating allowlist drop warning", () => {
+  beforeEach(() => {
+    resetGroupDropWarningsForTests();
+  });
+
+  it("emits a warn log naming the root groups path for the default account", async () => {
+    const warn = vi.fn<WarnLogger>();
+    const msg = makeUnregisteredGroupMsg("unregistered@g.us");
+
+    const result = await applyGroupGating(makeParams(msg, warn));
+
+    expect(result).toEqual({ shouldProcess: false });
+    expect(warn).toHaveBeenCalledTimes(1);
+    const [context, message] = warn.mock.calls[0] ?? [];
+    expect(context).toMatchObject({
+      conversationId: "unregistered@g.us",
+      accountId: "default",
+      groupsPath: "channels.whatsapp.groups",
+    });
+    expect(message).toContain("unregistered@g.us");
+    expect(message).toContain("channels.whatsapp.groups");
+  });
+
+  it("names the account-scoped groups path for non-default accounts", async () => {
+    const warn = vi.fn<WarnLogger>();
+    const msg = makeUnregisteredGroupMsg("unregistered@g.us", "work");
+
+    await applyGroupGating(makeParams(msg, warn));
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    const [context, message] = warn.mock.calls[0] ?? [];
+    expect(context).toMatchObject({
+      conversationId: "unregistered@g.us",
+      accountId: "work",
+      groupsPath: "channels.whatsapp.accounts.work.groups",
+    });
+    expect(message).toContain("channels.whatsapp.accounts.work.groups");
+  });
+
+  it("only warns once per conversation across repeated messages", async () => {
+    const warn = vi.fn<WarnLogger>();
+
+    await applyGroupGating(makeParams(makeUnregisteredGroupMsg("loud@g.us"), warn));
+    await applyGroupGating(makeParams(makeUnregisteredGroupMsg("loud@g.us"), warn));
+    await applyGroupGating(makeParams(makeUnregisteredGroupMsg("loud@g.us"), warn));
+
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it("warns separately for distinct conversations", async () => {
+    const warn = vi.fn<WarnLogger>();
+
+    await applyGroupGating(makeParams(makeUnregisteredGroupMsg("a@g.us"), warn));
+    await applyGroupGating(makeParams(makeUnregisteredGroupMsg("b@g.us"), warn));
+
+    expect(warn).toHaveBeenCalledTimes(2);
+    expect(warn.mock.calls[0]?.[1]).toContain("a@g.us");
+    expect(warn.mock.calls[1]?.[1]).toContain("b@g.us");
+  });
+
+  it("does not warn when the group is registered", async () => {
+    const warn = vi.fn<WarnLogger>();
+    const msg = makeUnregisteredGroupMsg("registered@g.us");
+
+    await applyGroupGating(makeParams(msg, warn));
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/whatsapp/src/auto-reply/monitor/group-gating.allowlist-warn.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/group-gating.allowlist-warn.test.ts
@@ -84,11 +84,13 @@ describe("applyGroupGating allowlist drop warning", () => {
   it("emits a warn log naming the root groups path for the default account", async () => {
     const warn = vi.fn<WarnLogger>();
     const msg = makeUnregisteredGroupMsg("unregistered@g.us");
+    const params = makeParams(msg, warn);
 
-    const result = await applyGroupGating(makeParams(msg, warn));
+    const result = await applyGroupGating(params);
 
     expect(result).toEqual({ shouldProcess: false });
     expect(warn).toHaveBeenCalledTimes(1);
+    expect(params.logVerbose).not.toHaveBeenCalled();
     const [context, message] = warn.mock.calls[0] ?? [];
     expect(context).toMatchObject({
       conversationId: "unregistered@g.us",

--- a/extensions/whatsapp/src/auto-reply/monitor/group-gating.allowlist-warn.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/group-gating.allowlist-warn.test.ts
@@ -31,32 +31,37 @@ function makeUnregisteredGroupMsg(
 }
 
 type WarnLogger = (obj: unknown, msg: string) => void;
+type ApplyGroupGatingParams = Parameters<typeof applyGroupGating>[0];
 
-function makeParams(msg: WebInboundMsg, warn: WarnLogger) {
-  return {
-    cfg: {
-      channels: {
-        whatsapp: {
-          groupPolicy: "allowlist",
-          groups: {
-            "registered@g.us": {},
-          },
-          accounts: {
-            work: {
-              groupPolicy: "allowlist",
-              groups: {
-                "registered@g.us": {},
-              },
+function makeParams(
+  msg: WebInboundMsg,
+  warn: WarnLogger,
+  cfg: ApplyGroupGatingParams["cfg"] = {
+    channels: {
+      whatsapp: {
+        groupPolicy: "allowlist",
+        groups: {
+          "registered@g.us": {},
+        },
+        accounts: {
+          work: {
+            groupPolicy: "allowlist",
+            groups: {
+              "registered@g.us": {},
             },
           },
         },
       },
-      messages: {
-        groupChat: {
-          mentionPatterns: ["\\bopenclaw\\b"],
-        },
+    },
+    messages: {
+      groupChat: {
+        mentionPatterns: ["\\bopenclaw\\b"],
       },
-    } as never,
+    },
+  } as never,
+) {
+  return {
+    cfg,
     msg,
     conversationId: msg.conversationId,
     groupHistoryKey: `whatsapp:group:${msg.conversationId}`,
@@ -110,6 +115,42 @@ describe("applyGroupGating allowlist drop warning", () => {
     expect(message).toContain("channels.whatsapp.accounts.work.groups");
   });
 
+  it("names the root groups path for non-default accounts inheriting root groups", async () => {
+    const warn = vi.fn<WarnLogger>();
+    const msg = makeUnregisteredGroupMsg("unregistered@g.us", "work");
+    const cfg = {
+      channels: {
+        whatsapp: {
+          groupPolicy: "allowlist",
+          groups: {
+            "registered@g.us": {},
+          },
+          accounts: {
+            work: {
+              groupPolicy: "allowlist",
+            },
+          },
+        },
+      },
+      messages: {
+        groupChat: {
+          mentionPatterns: ["\\bopenclaw\\b"],
+        },
+      },
+    } as ApplyGroupGatingParams["cfg"];
+
+    await applyGroupGating(makeParams(msg, warn, cfg));
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    const [context, message] = warn.mock.calls[0] ?? [];
+    expect(context).toMatchObject({
+      conversationId: "unregistered@g.us",
+      accountId: "work",
+      groupsPath: "channels.whatsapp.groups",
+    });
+    expect(message).toContain("channels.whatsapp.groups");
+  });
+
   it("only warns once per conversation across repeated messages", async () => {
     const warn = vi.fn<WarnLogger>();
 
@@ -129,6 +170,20 @@ describe("applyGroupGating allowlist drop warning", () => {
     expect(warn).toHaveBeenCalledTimes(2);
     expect(warn.mock.calls[0]?.[1]).toContain("a@g.us");
     expect(warn.mock.calls[1]?.[1]).toContain("b@g.us");
+  });
+
+  it("evicts old warning keys instead of growing without bound", async () => {
+    const warn = vi.fn<WarnLogger>();
+
+    await applyGroupGating(makeParams(makeUnregisteredGroupMsg("evicted@g.us"), warn));
+    for (let index = 0; index < 100; index += 1) {
+      await applyGroupGating(makeParams(makeUnregisteredGroupMsg(`overflow-${index}@g.us`), warn));
+    }
+    await applyGroupGating(makeParams(makeUnregisteredGroupMsg("evicted@g.us"), warn));
+
+    expect(warn).toHaveBeenCalledTimes(102);
+    expect(warn.mock.calls[0]?.[1]).toContain("evicted@g.us");
+    expect(warn.mock.calls[101]?.[1]).toContain("evicted@g.us");
   });
 
   it("does not warn when the group is registered", async () => {

--- a/extensions/whatsapp/src/auto-reply/monitor/group-gating.audio-preflight.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/group-gating.audio-preflight.test.ts
@@ -49,7 +49,7 @@ function makeParams(msg: WebInboundMsg, groupHistories: Map<string, GroupHistory
     groupHistoryLimit: 20,
     groupMemberNames: new Map<string, Map<string, string>>(),
     logVerbose: vi.fn(),
-    replyLogger: { debug: vi.fn() },
+    replyLogger: { debug: vi.fn(), warn: vi.fn() },
   };
 }
 

--- a/extensions/whatsapp/src/auto-reply/monitor/group-gating.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/group-gating.ts
@@ -149,6 +149,9 @@ export async function applyGroupGating(params: ApplyGroupGatingParams) {
         `WhatsApp group ${params.conversationId} not in ${groupsPath} — inbound dropped. Add the group JID to ${groupsPath} (or add "*" there to admit all groups). Sender authorization still applies.`,
       );
     }
+    params.logVerbose(
+      `Dropping message from unregistered WhatsApp group ${params.conversationId}. Add the group JID to channels.whatsapp.groups, or add "*" there to admit all groups. Sender authorization still applies.`,
+    );
     return { shouldProcess: false };
   }
 

--- a/extensions/whatsapp/src/auto-reply/monitor/group-gating.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/group-gating.ts
@@ -46,8 +46,20 @@ type ApplyGroupGatingParams = {
   groupMemberNames: Map<string, Map<string, string>>;
   selfChatMode?: boolean;
   logVerbose: (msg: string) => void;
-  replyLogger: { debug: (obj: unknown, msg: string) => void };
+  replyLogger: {
+    debug: (obj: unknown, msg: string) => void;
+    warn: (obj: unknown, msg: string) => void;
+  };
 };
+
+// One-shot diagnostic so users learn why a group inbound was dropped without
+// enabling verbose mode. Keyed by `${accountId}:${conversationId}` to avoid log
+// spam in active groups. See issue #83777.
+const groupDropWarned = new Set<string>();
+
+export function resetGroupDropWarningsForTests() {
+  groupDropWarned.clear();
+}
 
 function isOwnerSender(baseMentionConfig: MentionConfig, msg: WebInboundMsg) {
   const sender = normalizeE164(getSenderIdentity(msg).e164 ?? "");
@@ -114,6 +126,19 @@ export async function applyGroupGating(params: ApplyGroupGatingParams) {
     params.conversationId,
   );
   if (conversationGroupPolicy.allowlistEnabled && !conversationGroupPolicy.allowed) {
+    const accountId = params.msg.accountId;
+    const warnKey = `${accountId ?? "default"}:${params.conversationId}`;
+    if (!groupDropWarned.has(warnKey)) {
+      groupDropWarned.add(warnKey);
+      const groupsPath =
+        accountId && accountId !== "default"
+          ? `channels.whatsapp.accounts.${accountId}.groups`
+          : "channels.whatsapp.groups";
+      params.replyLogger.warn(
+        { conversationId: params.conversationId, accountId, groupsPath },
+        `WhatsApp group ${params.conversationId} not in ${groupsPath} — inbound dropped. Add the group JID to ${groupsPath} (or add "*" there to admit all groups). Sender authorization still applies.`,
+      );
+    }
     params.logVerbose(
       `Dropping message from unregistered WhatsApp group ${params.conversationId}. Add the group JID to channels.whatsapp.groups, or add "*" there to admit all groups. Sender authorization still applies.`,
     );

--- a/extensions/whatsapp/src/auto-reply/monitor/group-gating.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/group-gating.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { resolveWhatsAppGroupsConfigPath } from "../../group-config-path.js";
 import {
   getPrimaryIdentityId,
   getReplyContext,
@@ -52,13 +53,26 @@ type ApplyGroupGatingParams = {
   };
 };
 
-// One-shot diagnostic so users learn why a group inbound was dropped without
-// enabling verbose mode. Keyed by `${accountId}:${conversationId}` to avoid log
-// spam in active groups. See issue #83777.
+const MAX_GROUP_DROP_WARNINGS = 100;
 const groupDropWarned = new Set<string>();
 
 export function resetGroupDropWarningsForTests() {
   groupDropWarned.clear();
+}
+
+function shouldWarnForGroupDrop(warnKey: string): boolean {
+  if (groupDropWarned.has(warnKey)) {
+    return false;
+  }
+  groupDropWarned.add(warnKey);
+  while (groupDropWarned.size > MAX_GROUP_DROP_WARNINGS) {
+    const oldest = groupDropWarned.values().next().value;
+    if (!oldest) {
+      break;
+    }
+    groupDropWarned.delete(oldest);
+  }
+  return true;
 }
 
 function isOwnerSender(baseMentionConfig: MentionConfig, msg: WebInboundMsg) {
@@ -126,14 +140,10 @@ export async function applyGroupGating(params: ApplyGroupGatingParams) {
     params.conversationId,
   );
   if (conversationGroupPolicy.allowlistEnabled && !conversationGroupPolicy.allowed) {
-    const accountId = params.msg.accountId;
-    const warnKey = `${accountId ?? "default"}:${params.conversationId}`;
-    if (!groupDropWarned.has(warnKey)) {
-      groupDropWarned.add(warnKey);
-      const groupsPath =
-        accountId && accountId !== "default"
-          ? `channels.whatsapp.accounts.${accountId}.groups`
-          : "channels.whatsapp.groups";
+    const accountId = inboundPolicy.account.accountId;
+    const warnKey = `${accountId}:${params.conversationId}`;
+    if (shouldWarnForGroupDrop(warnKey)) {
+      const groupsPath = resolveWhatsAppGroupsConfigPath({ cfg: params.cfg, accountId });
       params.replyLogger.warn(
         { conversationId: params.conversationId, accountId, groupsPath },
         `WhatsApp group ${params.conversationId} not in ${groupsPath} — inbound dropped. Add the group JID to ${groupsPath} (or add "*" there to admit all groups). Sender authorization still applies.`,

--- a/extensions/whatsapp/src/auto-reply/monitor/group-gating.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/group-gating.ts
@@ -149,9 +149,6 @@ export async function applyGroupGating(params: ApplyGroupGatingParams) {
         `WhatsApp group ${params.conversationId} not in ${groupsPath} — inbound dropped. Add the group JID to ${groupsPath} (or add "*" there to admit all groups). Sender authorization still applies.`,
       );
     }
-    params.logVerbose(
-      `Dropping message from unregistered WhatsApp group ${params.conversationId}. Add the group JID to channels.whatsapp.groups, or add "*" there to admit all groups. Sender authorization still applies.`,
-    );
     return { shouldProcess: false };
   }
 

--- a/extensions/whatsapp/src/auto-reply/web-auto-reply-monitor.test.ts
+++ b/extensions/whatsapp/src/auto-reply/web-auto-reply-monitor.test.ts
@@ -75,7 +75,7 @@ async function runGroupGating(params: {
     groupHistoryLimit: 10,
     groupMemberNames: new Map(),
     logVerbose: (message) => verboseLogs.push(message),
-    replyLogger: { debug: () => {} },
+    replyLogger: { debug: () => {}, warn: () => {} },
   });
   return { result, groupHistories, verboseLogs };
 }

--- a/extensions/whatsapp/src/auto-reply/web-auto-reply-monitor.test.ts
+++ b/extensions/whatsapp/src/auto-reply/web-auto-reply-monitor.test.ts
@@ -644,7 +644,7 @@ describe("applyGroupGating", () => {
     });
 
     expect(result.shouldProcess).toBe(false);
-    expect(verboseLogs).not.toContain(
+    expect(verboseLogs).toContain(
       'Dropping message from unregistered WhatsApp group 123@g.us. Add the group JID to channels.whatsapp.groups, or add "*" there to admit all groups. Sender authorization still applies.',
     );
   });

--- a/extensions/whatsapp/src/auto-reply/web-auto-reply-monitor.test.ts
+++ b/extensions/whatsapp/src/auto-reply/web-auto-reply-monitor.test.ts
@@ -644,7 +644,7 @@ describe("applyGroupGating", () => {
     });
 
     expect(result.shouldProcess).toBe(false);
-    expect(verboseLogs).toContain(
+    expect(verboseLogs).not.toContain(
       'Dropping message from unregistered WhatsApp group 123@g.us. Add the group JID to channels.whatsapp.groups, or add "*" there to admit all groups. Sender authorization still applies.',
     );
   });

--- a/extensions/whatsapp/src/group-config-path.ts
+++ b/extensions/whatsapp/src/group-config-path.ts
@@ -1,0 +1,98 @@
+import { DEFAULT_ACCOUNT_ID, type OpenClawConfig } from "openclaw/plugin-sdk/account-core";
+
+const WHATSAPP_GROUP_SCOPE_FIELDS = ["groupPolicy", "groupAllowFrom", "groups"] as const;
+
+type WhatsAppGroupScopeField = (typeof WHATSAPP_GROUP_SCOPE_FIELDS)[number];
+
+function resolveWhatsAppAccountKey(
+  accounts: Record<string, unknown> | undefined,
+  accountId: string,
+): string | undefined {
+  if (!accounts) {
+    return undefined;
+  }
+  if (Object.hasOwn(accounts, accountId)) {
+    return accountId;
+  }
+  const normalizedAccountId = accountId.trim().toLowerCase();
+  return Object.keys(accounts).find((key) => key.trim().toLowerCase() === normalizedAccountId);
+}
+
+function normalizePathAccountId(accountId?: string | null): string {
+  return typeof accountId === "string"
+    ? accountId.trim() || DEFAULT_ACCOUNT_ID
+    : DEFAULT_ACCOUNT_ID;
+}
+
+function hasConfiguredField(config: unknown, field: WhatsAppGroupScopeField): boolean {
+  return Boolean(
+    config &&
+    typeof config === "object" &&
+    Object.hasOwn(config as Record<string, unknown>, field) &&
+    (config as Record<string, unknown>)[field] !== undefined,
+  );
+}
+
+function resolveSpecificFieldBasePath(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  field: WhatsAppGroupScopeField;
+}): string | undefined {
+  const accountId = normalizePathAccountId(params.accountId);
+  const whatsapp = params.cfg.channels?.whatsapp;
+  const accounts = whatsapp?.accounts as Record<string, unknown> | undefined;
+  const accountKey = resolveWhatsAppAccountKey(accounts, accountId);
+  const defaultAccountKey = resolveWhatsAppAccountKey(accounts, DEFAULT_ACCOUNT_ID);
+  const accountConfig = accountKey ? accounts?.[accountKey] : undefined;
+  const defaultAccountConfig = defaultAccountKey ? accounts?.[defaultAccountKey] : undefined;
+  if (hasConfiguredField(accountConfig, params.field)) {
+    return `channels.whatsapp.accounts.${accountKey}`;
+  }
+  if (accountId !== DEFAULT_ACCOUNT_ID && hasConfiguredField(defaultAccountConfig, params.field)) {
+    return `channels.whatsapp.accounts.${defaultAccountKey}`;
+  }
+  if (hasConfiguredField(whatsapp, params.field)) {
+    return "channels.whatsapp";
+  }
+  return undefined;
+}
+
+function resolveWhatsAppGroupScopeBasePath(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}): string {
+  const accountId = normalizePathAccountId(params.accountId);
+  const whatsapp = params.cfg.channels?.whatsapp;
+  const accounts = whatsapp?.accounts as Record<string, unknown> | undefined;
+  const accountKey = resolveWhatsAppAccountKey(accounts, accountId);
+  const defaultAccountKey = resolveWhatsAppAccountKey(accounts, DEFAULT_ACCOUNT_ID);
+  const accountConfig = accountKey ? accounts?.[accountKey] : undefined;
+  const defaultAccountConfig = defaultAccountKey ? accounts?.[defaultAccountKey] : undefined;
+  const matchesAnyGroupScopeField = (config: unknown): boolean =>
+    WHATSAPP_GROUP_SCOPE_FIELDS.some((field) => hasConfiguredField(config, field));
+  if (matchesAnyGroupScopeField(accountConfig)) {
+    return `channels.whatsapp.accounts.${accountKey}`;
+  }
+  if (accountId !== DEFAULT_ACCOUNT_ID && matchesAnyGroupScopeField(defaultAccountConfig)) {
+    return `channels.whatsapp.accounts.${defaultAccountKey}`;
+  }
+  return "channels.whatsapp";
+}
+
+export function resolveWhatsAppConfigPath(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  field: WhatsAppGroupScopeField;
+}): string {
+  return `${resolveWhatsAppGroupScopeBasePath(params)}.${params.field}`;
+}
+
+export function resolveWhatsAppGroupsConfigPath(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}): string {
+  return `${
+    resolveSpecificFieldBasePath({ ...params, field: "groups" }) ??
+    resolveWhatsAppGroupScopeBasePath(params)
+  }.groups`;
+}

--- a/extensions/whatsapp/src/shared.ts
+++ b/extensions/whatsapp/src/shared.ts
@@ -1,4 +1,3 @@
-import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-core";
 import { describeAccountSnapshot } from "openclaw/plugin-sdk/account-helpers";
 import { normalizeE164 } from "openclaw/plugin-sdk/account-resolution";
 import {
@@ -26,6 +25,7 @@ import {
 import { formatWhatsAppConfigAllowFromEntries } from "./config-accessors.js";
 import { WhatsAppChannelConfigSchema } from "./config-schema.js";
 import { whatsappDoctor } from "./doctor.js";
+import { resolveWhatsAppConfigPath } from "./group-config-path.js";
 import { resolveLegacyGroupSessionKey } from "./group-session-contract.js";
 import {
   collectUnsupportedSecretRefConfigCandidates,
@@ -39,56 +39,6 @@ import {
 } from "./session-contract.js";
 
 const WHATSAPP_CHANNEL = "whatsapp" as const;
-
-const WHATSAPP_GROUP_SCOPE_FIELDS = ["groupPolicy", "groupAllowFrom", "groups"] as const;
-
-type WhatsAppGroupScopeField = (typeof WHATSAPP_GROUP_SCOPE_FIELDS)[number];
-
-function resolveWhatsAppAccountKey(
-  accounts: Record<string, unknown> | undefined,
-  accountId: string,
-): string | undefined {
-  if (!accounts) {
-    return undefined;
-  }
-  if (Object.hasOwn(accounts, accountId)) {
-    return accountId;
-  }
-  const normalizedAccountId = accountId.trim().toLowerCase();
-  return Object.keys(accounts).find((key) => key.trim().toLowerCase() === normalizedAccountId);
-}
-
-function resolveWhatsAppGroupScopeBasePath(params: {
-  cfg: Parameters<typeof resolveWhatsAppAccount>[0]["cfg"];
-  accountId?: string | null;
-}): string {
-  const accountId =
-    typeof params.accountId === "string"
-      ? params.accountId.trim() || DEFAULT_ACCOUNT_ID
-      : DEFAULT_ACCOUNT_ID;
-  const accounts = params.cfg.channels?.whatsapp?.accounts;
-  const accountKey = resolveWhatsAppAccountKey(accounts, accountId);
-  const defaultAccountKey = resolveWhatsAppAccountKey(accounts, DEFAULT_ACCOUNT_ID);
-  const accountConfig = accountKey ? accounts?.[accountKey] : undefined;
-  const defaultAccountConfig = defaultAccountKey ? accounts?.[defaultAccountKey] : undefined;
-  const matchesAnyGroupScopeField = (config: Record<string, unknown> | undefined): boolean =>
-    WHATSAPP_GROUP_SCOPE_FIELDS.some((field) => config?.[field] !== undefined);
-  if (matchesAnyGroupScopeField(accountConfig)) {
-    return `channels.whatsapp.accounts.${accountKey}`;
-  }
-  if (accountId !== DEFAULT_ACCOUNT_ID && matchesAnyGroupScopeField(defaultAccountConfig)) {
-    return `channels.whatsapp.accounts.${defaultAccountKey}`;
-  }
-  return "channels.whatsapp";
-}
-
-function resolveWhatsAppConfigPath(params: {
-  cfg: Parameters<typeof resolveWhatsAppAccount>[0]["cfg"];
-  accountId?: string | null;
-  field: WhatsAppGroupScopeField;
-}): string {
-  return `${resolveWhatsAppGroupScopeBasePath(params)}.${params.field}`;
-}
 
 export async function loadWhatsAppChannelRuntime() {
   return await import("./channel.runtime.js");


### PR DESCRIPTION
## Summary

When a WhatsApp group message arrives but the group is not registered in `channels.whatsapp.groups` (or the account-scoped equivalent), the gating layer silently returns `shouldProcess=false`. Until recently the only diagnostic was a verbose-only line. PR #83969 improved the verbose copy on `main`. This PR builds on that by adding a single warn log per `accountId:conversationId` so the diagnostic is visible without verbose mode, and reports the exact config path the operator must edit (root or account-scoped). Behavior is unchanged — the message is still dropped — only the diagnostic surface changes.

Addresses Codex review #83833:
- **[P3]** Warning now names `channels.whatsapp.accounts.<id>.groups` for non-default accounts and `channels.whatsapp.groups` only for default. The `groupsPath` is also surfaced as a structured context field so log consumers can branch on it.

## Real behavior proof

Behavior addressed: WhatsApp group inbound messages dropped without visible explanation when the group is missing from the effective groups allowlist. After this patch, operators see one warn log per `accountId:conversationId` pointing at the exact config path.

Real environment tested: macOS 25.3 (darwin arm64), Node 22.18, pnpm 11.1.0, repo rebased onto `origin/main` after PR #83969 landed. No live WhatsApp Web bridge available on this machine. Instead, a runtime evidence script was run locally that imports the real `applyGroupGating` (not a mock) and exercises it against the real `resolveWhatsAppInboundPolicy` resolver with a fake `replyLogger` that mirrors the production pino-style `getChildLogger` shape used at `extensions/whatsapp/src/auto-reply/monitor.ts:195` and at `extensions/whatsapp/src/auto-reply/deliver-reply.ts:191-193`.

Exact steps or command run after this patch:

```
pnpm install --frozen-lockfile
node scripts/run-vitest.mjs extensions/whatsapp/src/auto-reply/monitor/group-gating.allowlist-warn.proof.test.ts --reporter=verbose
```

(The `.proof.test.ts` file was written locally to capture runtime evidence, then removed before the final commit so the test surface stays clean. The captured stdout below is the verbatim output of the real `applyGroupGating` running five scripted scenarios.)

Evidence after fix:

Captured stdout from running the real `applyGroupGating` against five scripted message flows, with a fake `replyLogger` that prints every `warn(ctx, msg)` call:

```
=== Case 1: default account, unregistered group (warn expected) ===
[warn] WhatsApp group unregistered@g.us not in channels.whatsapp.groups — inbound dropped. Add the group JID to channels.whatsapp.groups (or add "*" there to admit all groups). Sender authorization still applies.
        ctx={"conversationId":"unregistered@g.us","accountId":"default","groupsPath":"channels.whatsapp.groups"}
[verbose] Dropping message from unregistered WhatsApp group unregistered@g.us. Add the group JID to channels.whatsapp.groups, or add "*" there to admit all groups. Sender authorization still applies.

=== Case 2: same conversation again (dedupe — no warn) ===
[verbose] Dropping message from unregistered WhatsApp group unregistered@g.us. Add the group JID to channels.whatsapp.groups, or add "*" there to admit all groups. Sender authorization still applies.

=== Case 3: distinct conversation, same account (warn expected) ===
[warn] WhatsApp group other@g.us not in channels.whatsapp.groups — inbound dropped. Add the group JID to channels.whatsapp.groups (or add "*" there to admit all groups). Sender authorization still applies.
        ctx={"conversationId":"other@g.us","accountId":"default","groupsPath":"channels.whatsapp.groups"}
[verbose] Dropping message from unregistered WhatsApp group other@g.us. Add the group JID to channels.whatsapp.groups, or add "*" there to admit all groups. Sender authorization still applies.

=== Case 4: non-default account 'work' (account-scoped path) ===
[warn] WhatsApp group unregistered@g.us not in channels.whatsapp.accounts.work.groups — inbound dropped. Add the group JID to channels.whatsapp.accounts.work.groups (or add "*" there to admit all groups). Sender authorization still applies.
        ctx={"conversationId":"unregistered@g.us","accountId":"work","groupsPath":"channels.whatsapp.accounts.work.groups"}
[verbose] Dropping message from unregistered WhatsApp group unregistered@g.us. Add the group JID to channels.whatsapp.groups, or add "*" there to admit all groups. Sender authorization still applies.

=== Case 5: registered group (no warn) ===

=== Summary === total warn events: 3
```

Observed result after fix: `replyLogger.warn` is invoked exactly once per `accountId:conversationId` on the silent-drop branch with the path-aware message. The `groupsPath` context field reflects either `channels.whatsapp.groups` (default account, Cases 1 and 3) or `channels.whatsapp.accounts.<id>.groups` (non-default accounts, Case 4). Case 2 demonstrates the dedupe — second message from same conversation produces only the verbose log, no warn. Case 5 demonstrates the no-warn branch for registered groups. The existing verbose log (introduced by #83969) is preserved unchanged so callers depending on it are unaffected. Dispatch behavior is unchanged across the 73 passing extension test files.

What was not tested: Live WhatsApp Web bridge dispatch on a real WhatsApp account — no test account on this machine. The runtime evidence above exercises the real `applyGroupGating` (no mock of the gating logic itself) through to the warn callback, which is the same call-site shape the production logger uses, but it does not validate the pino transport delivery to stderr/syslog in a real `monitorWebChannel` run. Cross-channel interaction (Telegram, Slack) — change is scoped to `extensions/whatsapp/**`; no core seam touched.

## Verification

Supplemental unit + lane summary (not a substitute for the real-behavior proof above):

```
group-gating.allowlist-warn.test.ts: 5 passed
extensions/whatsapp lane: 73 of 74 test files passed. 1 pre-existing unrelated failure in extensions/whatsapp/src/auth-store.test.ts:113 ("authAgeMs ... toBeGreaterThanOrEqual(0)") that reproduces on a clean origin/main with my changes stashed.
oxlint: 0 warnings, 0 errors.
oxfmt --check: clean.
tsgo:extensions, tsgo:extensions:test: exit 0.
```

Closes #83777
