### PR TITLE
fix(whatsapp): include configured group count in inbound listener startup log

### DIFF
--- a/extensions/whatsapp/src/auto-reply/monitor.startup-log.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor.startup-log.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { formatInboundListenerLog } from "./monitor.js";
+
+describe("formatInboundListenerLog", () => {
+  it("reports DM-only when no groups are configured", () => {
+    expect(formatInboundListenerLog(undefined)).toBe(
+      "Listening for WhatsApp inbound messages (DM only).",
+    );
+    expect(formatInboundListenerLog({})).toBe("Listening for WhatsApp inbound messages (DM only).");
+  });
+
+  it("reports the configured group count with singular noun for one group", () => {
+    expect(formatInboundListenerLog({ "a@g.us": {} })).toBe(
+      "Listening for WhatsApp inbound messages (DM + 1 group).",
+    );
+  });
+
+  it("uses plural noun for multiple configured groups", () => {
+    expect(formatInboundListenerLog({ "a@g.us": {}, "b@g.us": {}, "c@g.us": {} })).toBe(
+      "Listening for WhatsApp inbound messages (DM + 3 groups).",
+    );
+  });
+
+  it("treats the wildcard entry as all groups regardless of other entries", () => {
+    expect(formatInboundListenerLog({ "*": {} })).toBe(
+      "Listening for WhatsApp inbound messages (DM + all groups).",
+    );
+    expect(formatInboundListenerLog({ "*": {}, "a@g.us": {} })).toBe(
+      "Listening for WhatsApp inbound messages (DM + all groups).",
+    );
+  });
+});

--- a/extensions/whatsapp/src/auto-reply/monitor.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor.ts
@@ -180,6 +180,20 @@ async function clearTerminalWebAuthState(params: {
 }
 const DEFAULT_TRANSPORT_TIMEOUT_MS = 5 * 60 * 1000;
 
+export function formatInboundListenerLog(groups: Record<string, unknown> | undefined): string {
+  const keys = groups ? Object.keys(groups) : [];
+  const hasWildcard = keys.includes("*");
+  const explicit = keys.filter((k) => k !== "*").length;
+  if (hasWildcard) {
+    return "Listening for WhatsApp inbound messages (DM + all groups).";
+  }
+  if (explicit === 0) {
+    return "Listening for WhatsApp inbound messages (DM only).";
+  }
+  const noun = explicit === 1 ? "group" : "groups";
+  return `Listening for WhatsApp inbound messages (DM + ${explicit} ${noun}).`;
+}
+
 export async function monitorWebChannel(
   verbose: boolean,
   listenerFactory: typeof attachWebInboxToSocket | undefined = attachWebInboxToSocket,
@@ -541,7 +555,7 @@ export async function monitorWebChannel(
         );
       });
 
-      whatsappLog.info("Listening for personal WhatsApp inbound messages.");
+      whatsappLog.info(formatInboundListenerLog(account.groups));
       if (process.stdout.isTTY || process.stderr.isTTY) {
         whatsappLog.raw("Ctrl+C to stop.");
       }


### PR DESCRIPTION
## Summary

The WhatsApp Web monitor logs `Listening for personal WhatsApp inbound messages.` on every successful connection (`extensions/whatsapp/src/auto-reply/monitor.ts:544` on main). The word "personal" implies DM-only listening, but the monitor in fact routes both DMs and groups when `channels.whatsapp.groups` is populated. Operators reading the log have no way to tell whether their group routing is wired up. Reported in #83779.

This change replaces the static string with a small pure helper, `formatInboundListenerLog`, that renders one of:

- `Listening for WhatsApp inbound messages (DM only).` — when no groups are configured.
- `Listening for WhatsApp inbound messages (DM + N group/groups).` — when N explicit group entries are configured. Singular noun for one.
- `Listening for WhatsApp inbound messages (DM + all groups).` — when the wildcard `*` entry is present (matches all groups regardless of any other entries).

The count is computed from the already-resolved `account.groups` snapshot at the call site — no new core seam, no new plumbing. Helper is colocated and exported only for unit tests.

## Behavior addressed

Misleading WhatsApp startup log that suggests DM-only operation even when group routing is configured.

## Real environment tested

macOS 25.3 (darwin arm64), Node 22.18, pnpm 11.1.0, repo at `f1a55cbd52` rebased onto `origin/main`. Validation was unit-test-only — no live WhatsApp Web bridge available on this machine.

## Exact steps or command run after this patch

```
pnpm install --frozen-lockfile
node scripts/run-vitest.mjs extensions/whatsapp/src/auto-reply/monitor.startup-log.test.ts
pnpm test:extension whatsapp
node scripts/run-oxlint.mjs extensions/whatsapp/src/auto-reply/monitor.ts extensions/whatsapp/src/auto-reply/monitor.startup-log.test.ts
pnpm format:check extensions/whatsapp/src/auto-reply/monitor.ts extensions/whatsapp/src/auto-reply/monitor.startup-log.test.ts
pnpm tsgo:extensions
pnpm tsgo:extensions:test
```

## Evidence after fix

```
monitor.startup-log.test.ts: 4 passed
extensions/whatsapp lane: 73 of 74 test files passed; 1 pre-existing unrelated failure in extensions/whatsapp/src/auth-store.test.ts:113 ("authAgeMs to be greater than or equal to 0") that reproduces on a clean origin/main with my changes stashed, so it is not in scope for this PR per CONTRIBUTING.md.
oxlint: 0 warnings, 0 errors on touched files.
oxfmt: clean.
tsgo:extensions, tsgo:extensions:test: exit 0.
```

## Observed result after fix

The static `Listening for personal WhatsApp inbound messages.` is replaced by an accurate, configuration-driven string. Group-count branches and the wildcard branch all asserted via the colocated unit test. No other behavior changes in the monitor.

## What was not tested

- Live `monitorWebChannel` startup on a real WhatsApp Web bridge — no test account on this machine. The change at the call site is a single string substitution wrapped in a pure function whose output is fully covered by unit tests; the surrounding `whatsappLog.info(...)` plumbing is unchanged.
- Multi-account configurations where `account.groups` resolves from `accounts[<id>].groups` — the helper takes whatever `account.groups` resolves to, and `resolveWhatsAppAccount` already handles the per-account merge upstream; no separate verification.

Closes #83779
