### PR TITLE
fix: macOS auto-scroll assistant reply

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
@@ -17,6 +17,7 @@ public struct OpenClawChatView: View {
     @State private var hasPerformedInitialScroll = false
     @State private var isPinnedToBottom = true
     @State private var lastUserMessageID: UUID?
+    @State private var hasPendingAssistantReply = false
     private let showsSessionSwitcher: Bool
     private let style: Style
     private let markdownVariant: ChatMarkdownVariant
@@ -148,6 +149,7 @@ public struct OpenClawChatView: View {
             // Scroll to bottom when user sends a message, even if scrolled up.
             guard isSending, self.hasPerformedInitialScroll else { return }
             self.isPinnedToBottom = true
+            self.hasPendingAssistantReply = true
             withAnimation(.snappy(duration: 0.22)) {
                 self.scrollPosition = self.scrollerBottomID
             }
@@ -160,25 +162,67 @@ public struct OpenClawChatView: View {
             {
                 self.lastUserMessageID = lastMessage.id
                 self.isPinnedToBottom = true
+                self.hasPendingAssistantReply = true
                 withAnimation(.snappy(duration: 0.22)) {
                     self.scrollPosition = self.scrollerBottomID
                 }
                 return
             }
 
+            #if os(macOS)
+            if self.hasPendingAssistantReply {
+                withAnimation(.snappy(duration: 0.22)) {
+                    self.scrollPosition = self.scrollerBottomID
+                }
+                return
+            }
+            #endif
+
             guard self.isPinnedToBottom else { return }
             withAnimation(.snappy(duration: 0.22)) {
                 self.scrollPosition = self.scrollerBottomID
             }
         }
-        .onChange(of: self.viewModel.pendingRunCount) { _, _ in
+        .onChange(of: self.viewModel.pendingRunCount) { _, newCount in
+            #if os(macOS)
+            guard self.hasPerformedInitialScroll else { return }
+            if newCount > 0 {
+                self.hasPendingAssistantReply = true
+            }
+            if newCount == 0, self.hasPendingAssistantReply {
+                self.hasPendingAssistantReply = false
+                withAnimation(.snappy(duration: 0.22)) {
+                    self.scrollPosition = self.scrollerBottomID
+                }
+                return
+            }
+            if self.hasPendingAssistantReply {
+                withAnimation(.snappy(duration: 0.22)) {
+                    self.scrollPosition = self.scrollerBottomID
+                }
+                return
+            }
+            guard self.isPinnedToBottom else { return }
+            #else
             guard self.hasPerformedInitialScroll, self.isPinnedToBottom else { return }
+            #endif
             withAnimation(.snappy(duration: 0.22)) {
                 self.scrollPosition = self.scrollerBottomID
             }
         }
         .onChange(of: self.viewModel.streamingAssistantText) { _, _ in
+            #if os(macOS)
+            guard self.hasPerformedInitialScroll else { return }
+            if self.hasPendingAssistantReply {
+                withAnimation(.snappy(duration: 0.22)) {
+                    self.scrollPosition = self.scrollerBottomID
+                }
+                return
+            }
+            guard self.isPinnedToBottom else { return }
+            #else
             guard self.hasPerformedInitialScroll, self.isPinnedToBottom else { return }
+            #endif
             withAnimation(.snappy(duration: 0.22)) {
                 self.scrollPosition = self.scrollerBottomID
             }


### PR DESCRIPTION
# 问题描述

在 OpenClaw macOS 应用的对话中，当 OpenClaw 回复消息后，消息会滚动到中间位置，而不是到底部。每次需要手动拉到底部才能看到最新回复。

# 修复内容

自动滚动到底部，确保对话始终显示最新消息。