### PR TITLE
Add issue contribution intent guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,6 +97,19 @@ Welcome to the lobster tank! 🦞
 4. **Test/CI-only PRs for known `main` failures** → Don't open a PR. The Maintainer team is already tracking those failures, and PRs that only tweak tests or CI to chase them will be closed unless they are required to validate a new fix.
 5. **Questions** → Discord [#help](https://discord.com/channels/1456350064065904867/1459642797895319552) / [#users-helping-users](https://discord.com/channels/1456350064065904867/1459007081603403828)
 
+## When Opening Issues
+
+If you already know whether you plan to work on a fix, please mention that in the issue. This is only a coordination signal, not an assignment or commitment.
+
+Examples:
+
+- I plan to open a PR
+- I may open a PR, but would like maintainer guidance first
+- I can help test or provide details, but probably will not submit a fix
+- I am reporting this for someone else to pick up
+
+Maintainers may still retitle, close, reprioritize, or accept another PR if needed.
+
 ## PR Limits
 
 We cap at **20 open PRs per author**. If you exceed this, the `r: too-many-prs` label is added and your PR is auto-closed. This is a hard limit.


### PR DESCRIPTION
﻿## Summary

Adds a short "When Opening Issues" section to `CONTRIBUTING.md`.

The new guidance asks issue reporters to mention, when they already know, whether they plan to work on a PR themselves, want maintainer guidance first, can help test, or are only reporting the issue for someone else to pick up.

## Why

This is intended as a soft coordination signal, not an assignment or commitment system. It should help avoid duplicate work when someone opens an issue as a tracking note before creating their own PR, while still making clear that maintainers may retitle, close, reprioritize, or accept another PR if needed.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: CONTRIBUTING.md now gives issue reporters a soft way to state whether they already plan to work on a fix, want maintainer guidance, can help test, or are only reporting for someone else to pick up.
- Real environment tested: Local checkout of `openclaw/openclaw` on Windows, branch `docs/issue-contribution-intent`, commit `7d806851bd6a4a4277fe9e1f8429fcd1c577bdfc`.
- Exact steps or command run after this patch: `git diff -- CONTRIBUTING.md` and `pnpm exec oxfmt --check CONTRIBUTING.md`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Copied terminal diff output showing the rendered Markdown source inserted after `How to Contribute`:

```diff
+## When Opening Issues
+
+If you already know whether you plan to work on a fix, please mention that in the issue. This is only a coordination signal, not an assignment or commitment.
+
+Examples:
+
+- I plan to open a PR
+- I may open a PR, but would like maintainer guidance first
+- I can help test or provide details, but probably will not submit a fix
+- I am reporting this for someone else to pick up
+
+Maintainers may still retitle, close, reprioritize, or accept another PR if needed.
+
```

- Observed result after fix: The new section appears between `How to Contribute` and `PR Limits` in `CONTRIBUTING.md`, with no issue-template enforcement or assignment language added.
- What was not tested: I did not change or test GitHub issue templates, because this PR intentionally only updates contributor guidance.

## Validation

- `pnpm exec oxfmt --check CONTRIBUTING.md`
- `git diff --check`
