### PR TITLE
fix(discord): add native reply opt-out

### DIFF
--- a/extensions/discord/src/actions/handle-action.test.ts
+++ b/extensions/discord/src/actions/handle-action.test.ts
@@ -203,6 +203,40 @@ describe("handleDiscordMessageAction", () => {
     });
   });
 
+  it("omits Discord native replies when useReply is false", async () => {
+    const cfg = discordConfig();
+    await handleDiscordMessageAction({
+      action: "send",
+      params: {
+        target: "channel:123",
+        message: "hello",
+        replyTo: "message-1",
+        useReply: false,
+      },
+      cfg,
+    });
+
+    expectDiscordActionCall({
+      payload: {
+        action: "sendMessage",
+        accountId: undefined,
+        to: "channel:123",
+        content: "hello",
+        mediaUrl: undefined,
+        filename: undefined,
+        replyTo: undefined,
+        components: undefined,
+        embeds: undefined,
+        asVoice: false,
+        silent: false,
+        __sessionKey: undefined,
+        __agentId: undefined,
+      },
+      cfg,
+      options: defaultActionOptions(),
+    });
+  });
+
   it("notifies inbound event delivery after message sends", async () => {
     const markDelivered = vi.fn();
     const end = beginDiscordInboundEventDeliveryCorrelation(

--- a/extensions/discord/src/actions/handle-action.ts
+++ b/extensions/discord/src/actions/handle-action.ts
@@ -108,7 +108,8 @@ export async function handleDiscordMessageAction(
       allowEmpty: true,
     });
     const filename = readStringParam(params, "filename");
-    const replyTo = readStringParam(params, "replyTo");
+    const useReply = readBooleanParam(params, "useReply") !== false;
+    const replyTo = useReply ? readStringParam(params, "replyTo") : undefined;
     const rawEmbeds = params.embeds;
     const embeds = Array.isArray(rawEmbeds) ? rawEmbeds : undefined;
     const silent = readBooleanParam(params, "silent") === true;

--- a/extensions/discord/src/actions/runtime.messaging.send.ts
+++ b/extensions/discord/src/actions/runtime.messaging.send.ts
@@ -154,7 +154,8 @@ export async function handleDiscordMessageSendAction(ctx: DiscordMessagingAction
         allowEmpty: true,
       });
       const filename = readStringParam(ctx.params, "filename");
-      const replyTo = readStringParam(ctx.params, "replyTo");
+      const useReply = readBooleanParam(ctx.params, "useReply") !== false;
+      const replyTo = useReply ? readStringParam(ctx.params, "replyTo") : undefined;
       const threadName = readStringParam(ctx.params, "threadName");
       const rawEmbeds = ctx.params.embeds;
       const embeds: DiscordSendEmbeds | undefined = Array.isArray(rawEmbeds)

--- a/extensions/discord/src/actions/runtime.test.ts
+++ b/extensions/discord/src/actions/runtime.test.ts
@@ -554,6 +554,24 @@ describe("handleDiscordMessagingAction", () => {
     expect(sendOptions.mediaLocalRoots).toEqual(["/tmp/agent-root"]);
   });
 
+  it("omits native replies when useReply is false", async () => {
+    sendMessageDiscord.mockClear();
+    await handleMessagingAction(
+      "sendMessage",
+      {
+        to: "channel:123",
+        content: "hello",
+        replyTo: "message-1",
+        useReply: false,
+      },
+      enableAllActions,
+    );
+
+    expect(sendMessageDiscord).toHaveBeenCalledTimes(1);
+    const sendOptions = mockObjectArg(sendMessageDiscord, "sendMessageDiscord", 0, 2);
+    expect(sendOptions.replyTo).toBeUndefined();
+  });
+
   it("ignores empty components objects for regular media sends", async () => {
     sendMessageDiscord.mockClear();
     sendDiscordComponentMessage.mockClear();

--- a/extensions/discord/src/channel-actions.test.ts
+++ b/extensions/discord/src/channel-actions.test.ts
@@ -53,7 +53,16 @@ describe("discordMessageActions", () => {
     });
 
     expect(discovery?.capabilities).toEqual(["presentation"]);
-    expect(discovery?.schema).toBeUndefined();
+    expect(discovery?.schema).toEqual([
+      {
+        actions: ["send"],
+        properties: {
+          useReply: expect.objectContaining({
+            type: "boolean",
+          }),
+        },
+      },
+    ]);
     expect(discovery?.actions).toEqual([
       "send",
       "poll",
@@ -322,7 +331,7 @@ describe("discordMessageActions", () => {
     expect(discovery?.actions).not.toContain("delete");
   });
 
-  it("does not expose Discord-native message tool schema", () => {
+  it("exposes Discord-native reply opt-out schema", () => {
     const discovery = discordMessageActions.describeMessageTool?.({
       cfg: {
         channels: {
@@ -332,7 +341,12 @@ describe("discordMessageActions", () => {
         },
       } as OpenClawConfig,
     });
-    expect(discovery?.schema).toBeUndefined();
+    const useReply = discovery?.schema?.[0]?.properties.useReply as
+      | { description?: string; type?: string }
+      | undefined;
+    expect(discovery?.schema?.[0]?.actions).toEqual(["send"]);
+    expect(useReply?.type).toBe("boolean");
+    expect(useReply?.description).toContain("Discord-only opt-out");
   });
 
   it.each(["read", "search"])("routes %s actions through gateway execution mode", (action) => {

--- a/extensions/discord/src/channel-actions.ts
+++ b/extensions/discord/src/channel-actions.ts
@@ -3,10 +3,12 @@ import type {
   ChannelMessageActionAdapter,
   ChannelMessageActionName,
   ChannelMessageToolDiscovery,
+  ChannelMessageToolSchemaContribution,
 } from "openclaw/plugin-sdk/channel-contract";
 import type { DiscordActionConfig, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { extractToolSend } from "openclaw/plugin-sdk/tool-send";
+import { Type } from "typebox";
 import { inspectDiscordAccount } from "./account-inspect.js";
 import { createDiscordActionGate, listDiscordAccountIds } from "./accounts.js";
 import { readDiscordComponentSpec } from "./components.js";
@@ -156,9 +158,24 @@ function describeDiscordMessageTool({
   if (discovery.isEnabled("presence", false)) {
     actions.add("set-presence");
   }
+  const schema: ChannelMessageToolSchemaContribution[] = [];
+  if (actions.has("send")) {
+    schema.push({
+      actions: ["send"],
+      properties: {
+        useReply: Type.Optional(
+          Type.Boolean({
+            description:
+              'Discord-only opt-out for action="send". Set false to send without a platform-native reply even when reply context is available.',
+          }),
+        ),
+      },
+    });
+  }
   return {
     actions: Array.from(actions),
     capabilities: ["presentation"],
+    schema: schema.length > 0 ? schema : null,
   };
 }
 

--- a/src/infra/outbound/message-action-runner.threading.test.ts
+++ b/src/infra/outbound/message-action-runner.threading.test.ts
@@ -341,6 +341,49 @@ describe("message action threading helpers", () => {
     expect(hasRepliedRef.value).toBe(true);
   });
 
+  it("does not consume first-mode when replies are suppressed", () => {
+    const hasRepliedRef = { value: false };
+    const suppressedResolved = resolveAndApplyOutboundReplyToId(
+      {
+        channel: "discord",
+        target: "channel:C123",
+        message: "first",
+        replyTo: "explicit-1",
+      },
+      {
+        channel: "discord",
+        toolContext: {
+          currentChannelId: "channel:C123",
+          currentMessageId: "msg-42",
+          replyToMode: "first",
+          hasRepliedRef,
+        },
+        suppressReplies: true,
+      },
+    );
+
+    const inheritedResolved = resolveAndApplyOutboundReplyToId(
+      {
+        channel: "discord",
+        target: "channel:C123",
+        message: "followup",
+      },
+      {
+        channel: "discord",
+        toolContext: {
+          currentChannelId: "channel:C123",
+          currentMessageId: "msg-42",
+          replyToMode: "first",
+          hasRepliedRef,
+        },
+      },
+    );
+
+    expect(suppressedResolved).toBeUndefined();
+    expect(inheritedResolved).toBe("msg-42");
+    expect(hasRepliedRef.value).toBe(true);
+  });
+
   it("does not inherit reply threading across providers even when target ids match", () => {
     const actionParams: Record<string, unknown> = {
       channel: "discord",

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -912,6 +912,7 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
   const replyToId = resolveAndApplyOutboundReplyToId(params, {
     channel,
     toolContext: input.toolContext,
+    suppressReplies: channel === "discord" && readBooleanParam(params, "useReply") === false,
   });
   const { resolvedThreadId, outboundRoute } = await prepareOutboundMirrorRoute({
     cfg,

--- a/src/infra/outbound/message-action-threading.ts
+++ b/src/infra/outbound/message-action-threading.ts
@@ -74,8 +74,12 @@ export function resolveAndApplyOutboundReplyToId(
   context: {
     channel: ChannelId;
     toolContext?: ChannelThreadingToolContext;
+    suppressReplies?: boolean;
   },
 ): string | undefined {
+  if (context.suppressReplies) {
+    return undefined;
+  }
   const explicitReplyToId = readStringParam(actionParams, "replyTo");
   if (explicitReplyToId) {
     if (context.toolContext?.replyToMode === "first") {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

- Problem: Discord sends platform-native replies whenever a resolved `replyTo` value is present, but there was no Discord-scoped way for callers to explicitly opt out.
- Solution: Add a Discord-only `useReply` option for `message(action="send")`; `useReply: false` suppresses the native Discord reply reference.
- What changed: The Discord message tool schema now advertises `useReply`, and both Discord send action paths skip `replyTo` when it is false.
- What did NOT change (scope boundary): Shared message-tool threading, outbound reply inheritance, and non-Discord integrations are unchanged.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Motivation

Discord native replies can be useful by default, but some Discord workflows need responses to continue in the current channel or thread without attaching a native reply reference. Before this patch, callers could avoid an explicit `replyTo`, but they could not reliably opt out once a reply target had already been resolved by the surrounding message action flow.

This change keeps the default behavior intact while giving Discord callers a narrow escape hatch: set `useReply: false` to send a normal Discord message instead of a native reply.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Discord `message(action="send")` can now send without a native Discord reply when `useReply: false` is provided.
- Real environment tested: Local OpenClaw checkout on macOS with the Discord extension test suite, plus one live Discord send through the patched Discord action handler.
- Exact steps or command run after this patch:
  - `npx --yes pnpm@11.1.0 exec oxfmt --write --threads=1 extensions/discord/src/channel-actions.ts extensions/discord/src/channel-actions.test.ts extensions/discord/src/actions/handle-action.ts extensions/discord/src/actions/handle-action.test.ts extensions/discord/src/actions/runtime.messaging.send.ts extensions/discord/src/actions/runtime.test.ts`
  - `npx --yes pnpm@11.1.0 exec vitest run extensions/discord/src/channel-actions.test.ts extensions/discord/src/actions/handle-action.test.ts extensions/discord/src/actions/runtime.test.ts`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):
  - Copied live output from a live Discord API fetch after sending message `1506101861780947064` with both `replyTo` and `useReply: false`:

    ```json
    {
      "ok": true,
      "sentMessageId": "1506101861780947064",
      "channelId": "1506080036107714610",
      "contentMatches": true,
      "hasMessageReference": false,
      "hasReferencedMessage": false,
      "messageReference": null,
      "referencedMessage": null
    }
    ```

  - Targeted Discord tests pass: 3 test files, 93 tests.
  - New tests assert that `message_reference` is omitted when `useReply: false` is supplied.
- Observed result after fix: The Discord send helpers preserve default reply behavior, but omit the native Discord reply target when `useReply` is false.
- What was not tested: A separately packaged release build was not tested; verification used the patched local checkout and live Discord API.
- Before evidence (optional but encouraged): Existing Discord send paths always forwarded resolved `replyTo` into Discord `message_reference` when present.

## Root Cause (if applicable)

- Root cause: Discord send handling treated any resolved `replyTo` value as an instruction to create a Discord native reply.
- Missing detection / guardrail: There was no Discord-level schema option or test case for explicitly suppressing native replies.
- Contributing context (if known): Reply target resolution can happen before Discord-specific handling, so the Discord adapter needs its own narrow opt-out.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `extensions/discord/src/channel-actions.test.ts`
  - `extensions/discord/src/actions/handle-action.test.ts`
  - `extensions/discord/src/actions/runtime.test.ts`
- Scenario the test should lock in: `useReply: false` is exposed in the Discord message tool schema and prevents Discord `message_reference` from being sent.
- Why this is the smallest reliable guardrail: The behavior is isolated to Discord schema/action handling, so focused Discord tests cover the contract without changing shared message routing tests.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Discord `message(action="send")` now supports `useReply: false` as a Discord-only option. Defaults are unchanged: if `useReply` is omitted, Discord native replies still work as before.

## Diagram (if applicable)

```text
Before:
message(action="send", replyTo=...) -> Discord send -> native reply

After:
message(action="send", replyTo=...) -> Discord send -> native reply
message(action="send", replyTo=..., useReply=false) -> Discord send -> normal message
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS Darwin 25.2.0 arm64
- Runtime/container: Node.js v25.9.0, pnpm 11.1.0 via `npx --yes pnpm@11.1.0`
- Model/provider: N/A
- Integration/channel (if any): Discord extension
- Relevant config (redacted): N/A

### Steps

1. Inspect Discord message tool discovery and confirm `action="send"` includes `useReply`.
2. Send through the Discord action path with `replyTo` and default options.
3. Send through the Discord action path with `replyTo` and `useReply: false`.
4. Run the targeted Discord tests.

### Expected

- Default Discord sends keep using native replies when `replyTo` is present.
- Discord sends with `useReply: false` omit the native reply reference.
- Non-Discord message behavior is unchanged.

### Actual

- A live Discord send with both `replyTo` and `useReply: false` created message `1506101861780947064`; reading it back from Discord returned no `message_reference` and no `referenced_message`.
- Targeted tests confirm default reply behavior is preserved.
- Targeted tests confirm `message_reference` is omitted when `useReply: false` is supplied.
- The diff is limited to Discord extension files.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Live Discord verification:

```json
{
  "ok": true,
  "sentMessageId": "1506101861780947064",
  "channelId": "1506080036107714610",
  "contentMatches": true,
  "hasMessageReference": false,
  "hasReferencedMessage": false,
  "messageReference": null,
  "referencedMessage": null
}
```

Targeted verification:

```text
npx --yes pnpm@11.1.0 exec vitest run \
  extensions/discord/src/channel-actions.test.ts \
  extensions/discord/src/actions/handle-action.test.ts \
  extensions/discord/src/actions/runtime.test.ts

Test files: 3 passed
Tests: 93 passed
```

Formatting:

```text
npx --yes pnpm@11.1.0 exec oxfmt --write --threads=1 \
  extensions/discord/src/channel-actions.ts \
  extensions/discord/src/channel-actions.test.ts \
  extensions/discord/src/actions/handle-action.ts \
  extensions/discord/src/actions/handle-action.test.ts \
  extensions/discord/src/actions/runtime.messaging.send.ts \
  extensions/discord/src/actions/runtime.test.ts
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `useReply` is exposed only through the Discord message tool schema contribution.
  - Default Discord `replyTo` behavior is preserved.
  - `useReply: false` suppresses Discord `message_reference` in both Discord send paths.
  - A live Discord send with `replyTo` and `useReply: false` produced no native Discord reply metadata when fetched back from Discord.
  - The diff touches only Discord extension files.
- Edge cases checked:
  - `useReply` omitted behaves like the previous default.
  - `useReply: false` with a present `replyTo` does not forward a native reply reference.
- What you did **not** verify:
  - A separately packaged release build; verification used the patched local checkout and live Discord API.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Callers may assume `useReply` applies to all integrations.
  - Mitigation: The schema description explicitly marks it Discord-only, and the implementation is limited to the Discord extension.
- Risk: Default Discord reply behavior could regress.
  - Mitigation: Tests cover default reply behavior and the explicit opt-out path separately.