### PR TITLE
fix(systemd): clear stale ExecStart drop-ins

### DIFF
--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -858,6 +858,86 @@ describe("stageSystemdService", () => {
     });
   });
 
+  it("removes stale OpenClaw ExecStart drop-in overrides on re-stage", async () => {
+    await withStageFixture(async ({ env, unitPath }) => {
+      const dropInDir = `${unitPath}.d`;
+      const overridePath = path.join(dropInDir, "override.conf");
+      await fs.mkdir(dropInDir, { recursive: true });
+      await fs.writeFile(
+        overridePath,
+        [
+          "[Service]",
+          "ExecStart=",
+          "ExecStart=/usr/bin/node /home/test/.local/share/pnpm/global/5/.pnpm/openclaw@2026.5.12/node_modules/openclaw/dist/index.js gateway --port 18789",
+          "TimeoutStartSec=45",
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+
+      mockSystemctlStatusOk();
+
+      await stageSystemdService({
+        env,
+        stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+        programArguments: [
+          "/usr/bin/node",
+          "/home/test/.local/share/pnpm/global/5/.pnpm/openclaw@2026.5.18/node_modules/openclaw/dist/index.js",
+          "gateway",
+          "--port",
+          "18789",
+        ],
+        workingDirectory: "/tmp",
+        environment: {},
+      });
+
+      const [unit, override] = await Promise.all([
+        fs.readFile(unitPath, "utf8"),
+        fs.readFile(overridePath, "utf8"),
+      ]);
+
+      expect(unit).toContain("openclaw@2026.5.18");
+      expect(override).not.toContain("ExecStart=");
+      expect(override).not.toContain("openclaw@2026.5.12");
+      expect(override).toContain("TimeoutStartSec=45");
+    });
+  });
+
+  it("preserves Node-launched non-service OpenClaw ExecStart drop-in overrides", async () => {
+    await withStageFixture(async ({ env, unitPath }) => {
+      const dropInDir = `${unitPath}.d`;
+      const overridePath = path.join(dropInDir, "override.conf");
+      await fs.mkdir(dropInDir, { recursive: true });
+      await fs.writeFile(
+        overridePath,
+        [
+          "[Service]",
+          "ExecStart=",
+          "ExecStart=/usr/bin/node /home/test/openclaw/dist/index.js doctor --fix",
+          "TimeoutStartSec=45",
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+
+      mockSystemctlStatusOk();
+
+      await stageSystemdService({
+        env,
+        stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+        programArguments: ["/usr/bin/openclaw", "gateway", "run"],
+        workingDirectory: "/tmp",
+        environment: {},
+      });
+
+      const override = await fs.readFile(overridePath, "utf8");
+
+      expect(override).toContain("ExecStart=");
+      expect(override).toContain("/usr/bin/node /home/test/openclaw/dist/index.js doctor --fix");
+      expect(override).toContain("TimeoutStartSec=45");
+    });
+  });
+
   it("clears stale inline-managed keys from env file on re-stage (#76860)", async () => {
     await withStageFixture(async ({ env, stateDir, unitPath, envFilePath }) => {
       // Existing env file carries a stale OPENCLAW_GATEWAY_TOKEN that the

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -650,7 +650,98 @@ async function writeSystemdUnit({
     environmentFiles: environmentFileResult.environmentFiles,
   });
   await fs.writeFile(unitPath, unit, "utf8");
+  await reconcileSystemdExecStartDropIns({ unitPath });
   return { unitPath, backedUp };
+}
+
+function isOpenClawServiceExecStart(value: string): boolean {
+  const programArguments = parseSystemdExecStart(value.trim());
+  if (programArguments.length === 0) {
+    return false;
+  }
+  const openClawIndex = programArguments.findIndex(
+    (arg) =>
+      /(^|[/\\])openclaw(\.mjs)?$/.test(arg) ||
+      /[/\\]node_modules[/\\]openclaw[/\\]/.test(arg) ||
+      /[/\\]openclaw[/\\]dist[/\\](index|entry)\.js$/.test(arg) ||
+      /[/\\]openclaw@[^/\\]+[/\\]node_modules[/\\]openclaw[/\\]/.test(arg),
+  );
+  if (openClawIndex < 0) {
+    return false;
+  }
+  const subcommand = programArguments[openClawIndex + 1];
+  return subcommand === "gateway" || subcommand === "node";
+}
+
+function stripOpenClawExecStartOverrideDropIn(content: string): {
+  changed: boolean;
+  text: string;
+} {
+  const lines = content.split("\n");
+  const output: string[] = [];
+  let changed = false;
+  let pendingExecStartReset: string | null = null;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed === "ExecStart=") {
+      if (pendingExecStartReset !== null) {
+        output.push(pendingExecStartReset);
+      }
+      pendingExecStartReset = line;
+      continue;
+    }
+
+    if (trimmed.startsWith("ExecStart=")) {
+      const value = trimmed.slice("ExecStart=".length);
+      if (isOpenClawServiceExecStart(value)) {
+        changed = true;
+        pendingExecStartReset = null;
+        continue;
+      }
+    }
+
+    if (pendingExecStartReset !== null) {
+      output.push(pendingExecStartReset);
+      pendingExecStartReset = null;
+    }
+    output.push(line);
+  }
+
+  if (pendingExecStartReset !== null) {
+    output.push(pendingExecStartReset);
+  }
+
+  return { changed, text: output.join("\n") };
+}
+
+async function reconcileSystemdExecStartDropIns(params: { unitPath: string }): Promise<void> {
+  const dropInDir = `${params.unitPath}.d`;
+  let entries: string[] = [];
+  try {
+    entries = await fs.readdir(dropInDir);
+  } catch {
+    return;
+  }
+
+  await Promise.all(
+    entries
+      .filter((entry) => entry.endsWith(".conf"))
+      .map(async (entry) => {
+        const filePath = path.join(dropInDir, entry);
+        let content = "";
+        try {
+          content = await fs.readFile(filePath, "utf8");
+        } catch {
+          return;
+        }
+        const stripped = stripOpenClawExecStartOverrideDropIn(content);
+        if (!stripped.changed) {
+          return;
+        }
+        await fs.writeFile(filePath, stripped.text, "utf8");
+      }),
+  );
 }
 
 async function writeSystemdGatewayEnvironmentFile(params: {


### PR DESCRIPTION
## Summary

- Problem: `gateway install`, `doctor --repair`, and update restaging rewrite the main systemd unit, but a stale `.service.d/*.conf` drop-in can still override `ExecStart=` and pin the service to an older OpenClaw install.
- Solution: after writing the managed unit, scan same-unit drop-ins and remove only OpenClaw gateway/node `ExecStart=` overrides plus the paired reset line.
- What changed: stale OpenClaw `ExecStart` drop-in overrides are stripped while unrelated drop-in settings, such as timeout overrides, are preserved.
- What did NOT change (scope boundary): this does not remove arbitrary custom non-OpenClaw `ExecStart` overrides, does not change service activation, and does not change env-file handling.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Related #66444
- [x] This PR fixes a bug or regression

## Motivation

- This failure leaves the gateway down after an otherwise successful update. The main unit can look correct, but the merged systemd unit still uses the stale drop-in `ExecStart`, so the service starts an older binary and refuses to read newer config.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: OpenClaw gateway refused to start after update because the config had been written by `2026.5.18`, while systemd still launched `openclaw@2026.5.12` from a drop-in override.
- Real environment tested: Oracle VPS, Linux `6.17.0-1014-oracle` arm64, systemd user service, pnpm global OpenClaw install, gateway on loopback port `18789`.
- Exact steps or command run after this patch: reproduced and fixed the stale drop-in on the live host, then implemented the upstream patch and ran focused tests/checks locally against this branch.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
systemctl --user cat openclaw-gateway.service
before local repair, merged unit had:
/home/mcgheeai/.config/systemd/user/openclaw-gateway.service.d/override.conf
ExecStart=
ExecStart=/home/linuxbrew/.linuxbrew/opt/node/bin/node /home/mcgheeai/.local/share/pnpm/global/5/.pnpm/openclaw@2026.5.12/node_modules/openclaw/dist/index.js gateway --port 18789

systemctl --user status openclaw-gateway.service
Active: active (running)
CGroup:
  /home/linuxbrew/.linuxbrew/opt/node/bin/node /home/mcgheeai/.local/share/pnpm/global/5/.pnpm/openclaw@2026.5.18/node_modules/openclaw/dist/index.js gateway --port 18789

openclaw gateway status --deep
CLI version: 2026.5.18
Gateway version: 2026.5.18
Runtime: running
Connectivity probe: ok
Capability: admin-capable

curl -I -s http://127.0.0.1:18789/
HTTP/1.1 200 OK
```

- Observed result after fix: the stale `override.conf` no longer overrides the main unit, the gateway starts on `2026.5.18`, and the CLI/gateway versions match.
- What was not tested: I did not install this branch as the live production OpenClaw binary on the VPS; the live host was repaired manually first, then this branch was verified with focused unit coverage and repository checks.
- Before evidence (optional but encouraged):

```text
Your OpenClaw config was written by version 2026.5.18, but this command is running 2026.5.12.
Refusing to start the gateway service because this OpenClaw binary (2026.5.12) is older than the config last written by OpenClaw 2026.5.18.
Run the newer openclaw binary on PATH, or reinstall the intended gateway service from the newer install.
```

## Root Cause (if applicable)

- Root cause: the systemd writer reconciled only the main unit file. Existing drop-ins are still part of the effective merged unit, and an `ExecStart=` reset plus stale OpenClaw `ExecStart=` in a drop-in takes precedence over the freshly written main unit.
- Missing detection / guardrail: staging/install tests did not cover an existing `.service.d/override.conf` that pins `ExecStart` to an older OpenClaw install.
- Contributing context (if known): systemd drop-ins are often used locally to adjust timeouts or override generated service behavior; preserving the file while removing only stale OpenClaw `ExecStart` lines avoids dropping unrelated operator settings.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/daemon/systemd.test.ts`
- Scenario the test should lock in: re-staging a systemd unit with an existing `override.conf` containing a stale OpenClaw `ExecStart=` override removes the override and preserves unrelated timeout settings.
- Why this is the smallest reliable guardrail: the bug is local to service file materialization; a filesystem-backed unit test can reproduce the merged-unit hazard without needing a live systemd manager.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

OpenClaw-managed systemd service restaging now removes stale OpenClaw gateway/node `ExecStart` overrides from same-unit drop-ins so the freshly written unit command is not shadowed. Non-OpenClaw drop-in overrides and unrelated drop-in settings remain in place.

## Diagram (if applicable)

```text
Before:
openclaw update -> writes main unit with 2026.5.18 -> stale override.conf still wins -> gateway runs 2026.5.12 -> version guard exits

After:
openclaw update -> writes main unit with 2026.5.18 -> strips stale OpenClaw ExecStart drop-in -> gateway runs 2026.5.18
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation: the service writer now reads and may rewrite `.conf` files under the same user systemd unit drop-in directory. It only removes `ExecStart` lines that parse as OpenClaw gateway/node service commands; unrelated lines are preserved.

## Repro + Verification

### Environment

- OS: Linux `6.17.0-1014-oracle` arm64
- Runtime/container: Node `25.8.1`, pnpm global OpenClaw install
- Model/provider: N/A
- Integration/channel (if any): systemd user gateway service, Telegram channel present but unrelated
- Relevant config (redacted): `~/.config/systemd/user/openclaw-gateway.service.d/override.conf` contained `ExecStart=` and an `openclaw@2026.5.12` gateway command while the main unit and CLI were `2026.5.18`.

### Steps

1. Install/update OpenClaw so the main `openclaw-gateway.service` points at the current pnpm install.
2. Leave a same-unit drop-in with `ExecStart=` and a stale OpenClaw gateway command from an older pnpm install.
3. Start the gateway service.

### Expected

- Service restaging removes the stale OpenClaw drop-in `ExecStart` override, and systemd runs the current command from the main unit.

### Actual

- Before this fix, the stale drop-in remained, systemd ran the older binary, and the gateway refused to start because the config was written by a newer OpenClaw version.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

```text
pnpm test:serial src/daemon/systemd.test.ts src/daemon/systemd-unit.test.ts
[test] passed 2 Vitest shards in 12.14s

pnpm check
[check] typecheck
[check] lint
Found 0 warnings and 0 errors.
Import cycle check: 0 runtime value cycle(s).
```

## Human Verification (required)

- Verified scenarios: local unit test removes stale OpenClaw `ExecStart` from `override.conf`, keeps `TimeoutStartSec=45`, and writes the main unit with the new OpenClaw install path.
- Edge cases checked: focused systemd tests and full `pnpm check` passed.
- What you did **not** verify: live install of this exact branch as the production OpenClaw binary.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: an operator intentionally uses a drop-in `ExecStart` override to pin OpenClaw to a custom OpenClaw gateway/node command.
  - Mitigation: the stripping only runs during OpenClaw service staging/install, when the command is being explicitly regenerated, and only removes overrides that parse as OpenClaw gateway/node commands. Non-OpenClaw overrides are left alone.