### PR TITLE
fix(discord): preserve streamed replies after tool warnings

### DIFF
--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -2061,6 +2061,37 @@ describe("processDiscordMessage draft streaming", () => {
     expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps finalized previews when later tool warning finals are delivered", async () => {
+    const draftStream = createMockDraftStreamForTest();
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      await params?.dispatcher.sendFinalReply({ text: "delivery survived" });
+      await params?.dispatcher.sendFinalReply({
+        text: "⚠️ 🛠️ `run openclaw definitely-not-a-real-subcommand (agent)` failed",
+        isError: true,
+      } as never);
+      return { queuedFinal: true, counts: { final: 2, tool: 0, block: 0 } };
+    });
+
+    const ctx = await createAutomaticSourceDeliveryContext({
+      discordConfig: { streamMode: "partial", maxLinesPerMessage: 5 },
+    });
+
+    await runProcessDiscordMessage(ctx);
+
+    expectPreviewEditContent("delivery survived");
+    expect(draftStream.clear).not.toHaveBeenCalled();
+    expect(draftStream.messageId()).toBe("preview-1");
+    expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
+    expect(firstMockArg(deliverDiscordReply, "deliverDiscordReply")).toMatchObject({
+      replies: [
+        {
+          text: "⚠️ 🛠️ `run openclaw definitely-not-a-real-subcommand (agent)` failed",
+          isError: true,
+        },
+      ],
+    });
+  });
+
   it("suppresses reasoning payload delivery to Discord", async () => {
     mockDispatchSingleBlockReply({ text: "thinking...", isReasoning: true });
     await processStreamOffDiscordMessage();

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -513,6 +513,7 @@ export async function processDiscordMessage(
   const finalPreviewFlags =
     (discordConfig?.suppressEmbeds ?? true) ? MessageFlags.SuppressEmbeds : undefined;
   let finalReplyStartNotified = false;
+  let nonErrorFinalDeliveryStarted = false;
   const notifyFinalReplyStart = () => {
     if (finalReplyStartNotified) {
       return;
@@ -550,11 +551,16 @@ export async function processDiscordMessage(
             return;
           }
         }
-        if (
+        const followsNonErrorFinalDelivery = payload.isError && nonErrorFinalDeliveryStarted;
+        if (isFinal && !payload.isError) {
+          nonErrorFinalDeliveryStarted = true;
+        }
+        const shouldFinalizeDraftPreview =
           draftStream &&
           isFinal &&
-          (!draftPreview.isProgressMode || draftPreview.hasProgressDraftStarted)
-        ) {
+          (!draftPreview.isProgressMode || draftPreview.hasProgressDraftStarted) &&
+          !followsNonErrorFinalDelivery;
+        if (shouldFinalizeDraftPreview) {
           const reply = resolveSendableOutboundReplyParts(effectivePayload);
           const hasMedia = reply.hasMedia;
           const ttsSupplement = getReplyPayloadTtsSupplement(effectivePayload);


### PR DESCRIPTION
## Summary
- Preserve an already-started non-error Discord final reply path when a later `isError` tool-warning final is delivered in the same turn.
- Add regression coverage for Discord partial streaming where `delivery survived` remains in the finalized preview and the warning is sent separately.

## Root cause
Discord partial streaming reused the live draft finalizer for every final payload. When Pi produced a normal assistant final followed by an `isError` tool-warning final, the warning could enter the draft fallback path and call `draftStream.clear()`, deleting the finalized preview message that held the assistant answer.

Fixes #83831.

## Why this is safe
The change is scoped to Discord message delivery for later error final payloads after a non-error final delivery has already started. Standalone error finals still use the existing fallback/cleanup path, and normal preview finalization behavior is unchanged for the first assistant final.

Security/runtime controls are unchanged: this does not alter prompt text, model behavior, tool execution, warning generation, permissions, channel routing, or Discord auth. The preservation decision is enforced in runtime delivery state.

## Real behavior proof
Behavior addressed: Discord partial-stream final answer should remain visible when a later tool-warning final is delivered.

Real environment tested: local Discord message-handler runtime test exercising the same partial-stream delivery lifecycle with mocked Discord transport; live Discord/Pi credentials were not used in this PR.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/discord/src/monitor/message-handler.process.test.ts --testNamePattern "keeps finalized previews when later tool warning finals are delivered"`

Evidence after fix: the targeted test passes with `1 passed | 69 skipped`, and the test asserts the preview edit contains `delivery survived`, `draftStream.clear()` is not called, the draft message id remains `preview-1`, and the warning payload is delivered separately.

Observed result after fix: the finalized preview remains attached while the tool-warning final is sent through normal Discord delivery.

What was not tested: live Discord guild transport with Pi runtime credentials was not run here.

Related before-fix log: with only the production guard removed, the same targeted test fails at `expect(draftStream.clear).not.toHaveBeenCalled()` because `draftStream.clear()` is called once.

## Verification
- `git diff --check`
- `node scripts/run-vitest.mjs extensions/discord/src/monitor/message-handler.process.test.ts`
- `node scripts/run-vitest.mjs extensions/discord/src/monitor/message-handler.process.test.ts src/channels/message/lifecycle.test.ts`
- `pnpm check:changed`

## Out of scope
- Changing Pi tool-warning generation or suppression policy.
- Changing Discord streaming modes, default config, auth, or routing.
- Adding live Discord credentialed E2E coverage in this small fix.

Made with [Cursor](https://cursor.com)