### PR TITLE
fix(whatsapp): clarify inbound group diagnostics

### DIFF
--- a/docs/channels/whatsapp.md
+++ b/docs/channels/whatsapp.md
@@ -634,6 +634,8 @@ Behavior notes:
     - mention gating (`requireMention` + mention patterns)
     - duplicate keys in `openclaw.json` (JSON5): later entries override earlier ones, so keep a single `groupPolicy` per scope
 
+    If `channels.whatsapp.groups` is present, WhatsApp can still observe messages from other groups, but OpenClaw drops them before session routing. Add the group JID to `channels.whatsapp.groups` or add `groups["*"]` to admit all groups while keeping sender authorization under `groupPolicy` and `groupAllowFrom`.
+
   </Accordion>
 
   <Accordion title="Bun runtime warning">

--- a/extensions/whatsapp/src/auto-reply/monitor.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor.ts
@@ -42,6 +42,7 @@ import { whatsappHeartbeatLog, whatsappLog } from "./loggers.js";
 import { buildMentionConfig } from "./mentions.js";
 import { createWebChannelStatusController } from "./monitor-state.js";
 import { createEchoTracker } from "./monitor/echo.js";
+import { formatWhatsAppInboundListeningLog } from "./monitor/listener-log.js";
 import { createWebOnMessageHandler } from "./monitor/on-message.js";
 import type { WebInboundMsg, WebMonitorTuning } from "./types.js";
 import { isLikelyWhatsAppCryptoError } from "./util.js";
@@ -541,7 +542,7 @@ export async function monitorWebChannel(
         );
       });
 
-      whatsappLog.info("Listening for personal WhatsApp inbound messages.");
+      whatsappLog.info(formatWhatsAppInboundListeningLog(account));
       if (process.stdout.isTTY || process.stderr.isTTY) {
         whatsappLog.raw("Ctrl+C to stop.");
       }

--- a/extensions/whatsapp/src/auto-reply/monitor.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor.ts
@@ -22,6 +22,7 @@ import {
   WHATSAPP_WATCHDOG_TIMEOUT_ERROR,
   type ManagedWhatsAppListener,
 } from "../connection-controller.js";
+import { resolveWhatsAppInboundPolicy } from "../inbound-policy.js";
 import { attachWebInboxToSocket, type WhatsAppGroupMetadataCache } from "../inbound/monitor.js";
 import {
   newConnectionId,
@@ -542,7 +543,18 @@ export async function monitorWebChannel(
         );
       });
 
-      whatsappLog.info(formatWhatsAppInboundListeningLog(account));
+      const inboundPolicy = resolveWhatsAppInboundPolicy({
+        cfg,
+        accountId: account.accountId,
+        selfE164: selfE164 ?? null,
+      });
+      whatsappLog.info(
+        formatWhatsAppInboundListeningLog({
+          groups: inboundPolicy.account.groups,
+          groupPolicy: inboundPolicy.groupPolicy,
+          hasGroupAllowFrom: inboundPolicy.groupAllowFrom.length > 0,
+        }),
+      );
       if (process.stdout.isTTY || process.stderr.isTTY) {
         whatsappLog.raw("Ctrl+C to stop.");
       }

--- a/extensions/whatsapp/src/auto-reply/monitor/group-gating.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/group-gating.ts
@@ -115,7 +115,7 @@ export async function applyGroupGating(params: ApplyGroupGatingParams) {
   );
   if (conversationGroupPolicy.allowlistEnabled && !conversationGroupPolicy.allowed) {
     params.logVerbose(
-      `Dropping message from unregistered WhatsApp group ${params.conversationId}. Add the group JID to channels.whatsapp.groups or add "*" to enable routing.`,
+      `Dropping message from unregistered WhatsApp group ${params.conversationId}. Add the group JID to channels.whatsapp.groups, or add "*" there to admit all groups. Sender authorization still applies.`,
     );
     return { shouldProcess: false };
   }

--- a/extensions/whatsapp/src/auto-reply/monitor/group-gating.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/group-gating.ts
@@ -114,7 +114,9 @@ export async function applyGroupGating(params: ApplyGroupGatingParams) {
     params.conversationId,
   );
   if (conversationGroupPolicy.allowlistEnabled && !conversationGroupPolicy.allowed) {
-    params.logVerbose(`Skipping group message ${params.conversationId} (not in allowlist)`);
+    params.logVerbose(
+      `Dropping message from unregistered WhatsApp group ${params.conversationId}. Add the group JID to channels.whatsapp.groups or add "*" to enable routing.`,
+    );
     return { shouldProcess: false };
   }
 

--- a/extensions/whatsapp/src/auto-reply/monitor/listener-log.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/listener-log.ts
@@ -1,9 +1,22 @@
 export function formatWhatsAppInboundListeningLog(account: {
   groups?: Record<string, unknown>;
+  groupPolicy: "open" | "allowlist" | "disabled";
+  hasGroupAllowFrom: boolean;
 }): string {
+  if (account.groupPolicy === "disabled") {
+    return "Listening for WhatsApp inbound messages (DM + groups disabled by groupPolicy).";
+  }
+  if (account.groupPolicy === "allowlist" && !account.hasGroupAllowFrom) {
+    return "Listening for WhatsApp inbound messages (DM + group inbound blocked by empty groupPolicy allowlist).";
+  }
+
   const groups = account.groups ?? {};
   if (Object.keys(groups).length === 0) {
-    return "Listening for WhatsApp inbound messages (DM + all groups; no group allowlist configured).";
+    const suffix =
+      account.groupPolicy === "allowlist"
+        ? "sender allowlist configured"
+        : "no group allowlist configured";
+    return `Listening for WhatsApp inbound messages (DM + all groups; ${suffix}).`;
   }
   if (Object.hasOwn(groups, "*")) {
     return "Listening for WhatsApp inbound messages (DM + all groups; wildcard configured).";

--- a/extensions/whatsapp/src/auto-reply/monitor/listener-log.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/listener-log.ts
@@ -1,0 +1,15 @@
+export function formatWhatsAppInboundListeningLog(account: {
+  groups?: Record<string, unknown>;
+}): string {
+  const groups = account.groups ?? {};
+  if (Object.keys(groups).length === 0) {
+    return "Listening for WhatsApp inbound messages (DM + all groups; no group allowlist configured).";
+  }
+  if (Object.hasOwn(groups, "*")) {
+    return "Listening for WhatsApp inbound messages (DM + all groups; wildcard configured).";
+  }
+
+  const explicitGroupCount = Object.keys(groups).length;
+  const groupLabel = explicitGroupCount === 1 ? "group" : "groups";
+  return `Listening for WhatsApp inbound messages (DM + ${explicitGroupCount} configured ${groupLabel}).`;
+}

--- a/extensions/whatsapp/src/auto-reply/web-auto-reply-monitor.test.ts
+++ b/extensions/whatsapp/src/auto-reply/web-auto-reply-monitor.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { WhatsAppSendResult } from "../inbound/send-result.js";
 import { buildMentionConfig } from "./mentions.js";
 import { applyGroupGating, type GroupHistoryEntry } from "./monitor/group-gating.js";
+import { formatWhatsAppInboundListeningLog } from "./monitor/listener-log.js";
 import { buildInboundLine, formatReplyContext } from "./monitor/message-line.js";
 import type { WebInboundMsg } from "./types.js";
 
@@ -59,6 +60,7 @@ async function runGroupGating(params: {
   const agentId = params.agentId ?? "main";
   const sessionKey = `agent:${agentId}:whatsapp:group:${conversationId}`;
   const baseMentionConfig = buildMentionConfig(params.cfg, undefined);
+  const verboseLogs: string[] = [];
   const result = await applyGroupGating({
     cfg: params.cfg,
     msg: params.msg,
@@ -72,10 +74,10 @@ async function runGroupGating(params: {
     groupHistories,
     groupHistoryLimit: 10,
     groupMemberNames: new Map(),
-    logVerbose: () => {},
+    logVerbose: (message) => verboseLogs.push(message),
     replyLogger: { debug: () => {} },
   });
-  return { result, groupHistories };
+  return { result, groupHistories, verboseLogs };
 }
 
 function createGroupMessage(overrides: Partial<WebInboundMsg> = {}): WebInboundMsg {
@@ -115,6 +117,20 @@ function makeInboundCfg(messagePrefix = "") {
     channels: { whatsapp: { messagePrefix } },
   } as never;
 }
+
+describe("WhatsApp listener diagnostics", () => {
+  it("describes WhatsApp inbound listener scope without implying DM-only routing", () => {
+    expect(formatWhatsAppInboundListeningLog({})).toBe(
+      "Listening for WhatsApp inbound messages (DM + all groups; no group allowlist configured).",
+    );
+    expect(formatWhatsAppInboundListeningLog({ groups: { "123@g.us": {}, "*": {} } })).toBe(
+      "Listening for WhatsApp inbound messages (DM + all groups; wildcard configured).",
+    );
+    expect(formatWhatsAppInboundListeningLog({ groups: { "123@g.us": {}, "456@g.us": {} } })).toBe(
+      "Listening for WhatsApp inbound messages (DM + 2 configured groups).",
+    );
+  });
+});
 
 describe("applyGroupGating", () => {
   it("treats reply-to-bot as implicit mention", async () => {
@@ -583,7 +599,7 @@ describe("applyGroupGating", () => {
       },
     });
 
-    const { result } = await runGroupGating({
+    const { result, verboseLogs } = await runGroupGating({
       cfg,
       msg: createGroupMessage({
         body: "@workbot ping",
@@ -593,6 +609,9 @@ describe("applyGroupGating", () => {
     });
 
     expect(result.shouldProcess).toBe(false);
+    expect(verboseLogs).toContain(
+      'Dropping message from unregistered WhatsApp group 123@g.us. Add the group JID to channels.whatsapp.groups or add "*" to enable routing.',
+    );
   });
 });
 

--- a/extensions/whatsapp/src/auto-reply/web-auto-reply-monitor.test.ts
+++ b/extensions/whatsapp/src/auto-reply/web-auto-reply-monitor.test.ts
@@ -610,7 +610,7 @@ describe("applyGroupGating", () => {
 
     expect(result.shouldProcess).toBe(false);
     expect(verboseLogs).toContain(
-      'Dropping message from unregistered WhatsApp group 123@g.us. Add the group JID to channels.whatsapp.groups or add "*" to enable routing.',
+      'Dropping message from unregistered WhatsApp group 123@g.us. Add the group JID to channels.whatsapp.groups, or add "*" there to admit all groups. Sender authorization still applies.',
     );
   });
 });

--- a/extensions/whatsapp/src/auto-reply/web-auto-reply-monitor.test.ts
+++ b/extensions/whatsapp/src/auto-reply/web-auto-reply-monitor.test.ts
@@ -120,15 +120,50 @@ function makeInboundCfg(messagePrefix = "") {
 
 describe("WhatsApp listener diagnostics", () => {
   it("describes WhatsApp inbound listener scope without implying DM-only routing", () => {
-    expect(formatWhatsAppInboundListeningLog({})).toBe(
+    expect(
+      formatWhatsAppInboundListeningLog({
+        groupPolicy: "open",
+        hasGroupAllowFrom: false,
+      }),
+    ).toBe(
       "Listening for WhatsApp inbound messages (DM + all groups; no group allowlist configured).",
     );
-    expect(formatWhatsAppInboundListeningLog({ groups: { "123@g.us": {}, "*": {} } })).toBe(
-      "Listening for WhatsApp inbound messages (DM + all groups; wildcard configured).",
+    expect(
+      formatWhatsAppInboundListeningLog({
+        groupPolicy: "disabled",
+        hasGroupAllowFrom: true,
+      }),
+    ).toBe("Listening for WhatsApp inbound messages (DM + groups disabled by groupPolicy).");
+    expect(
+      formatWhatsAppInboundListeningLog({
+        groupPolicy: "allowlist",
+        hasGroupAllowFrom: false,
+      }),
+    ).toBe(
+      "Listening for WhatsApp inbound messages (DM + group inbound blocked by empty groupPolicy allowlist).",
     );
-    expect(formatWhatsAppInboundListeningLog({ groups: { "123@g.us": {}, "456@g.us": {} } })).toBe(
-      "Listening for WhatsApp inbound messages (DM + 2 configured groups).",
+    expect(
+      formatWhatsAppInboundListeningLog({
+        groupPolicy: "allowlist",
+        hasGroupAllowFrom: true,
+      }),
+    ).toBe(
+      "Listening for WhatsApp inbound messages (DM + all groups; sender allowlist configured).",
     );
+    expect(
+      formatWhatsAppInboundListeningLog({
+        groups: { "123@g.us": {}, "*": {} },
+        groupPolicy: "allowlist",
+        hasGroupAllowFrom: true,
+      }),
+    ).toBe("Listening for WhatsApp inbound messages (DM + all groups; wildcard configured).");
+    expect(
+      formatWhatsAppInboundListeningLog({
+        groups: { "123@g.us": {}, "456@g.us": {} },
+        groupPolicy: "allowlist",
+        hasGroupAllowFrom: true,
+      }),
+    ).toBe("Listening for WhatsApp inbound messages (DM + 2 configured groups).");
   });
 });
 


### PR DESCRIPTION
## Summary

- Problem: WhatsApp Web startup said it was listening for personal inbound messages even though the monitor observes DM and group traffic, and the group allowlist drop diagnostic did not tell operators how to route observed-but-unregistered groups.
- Solution: Replace the DM-only startup wording with listener-scope diagnostics that distinguish no group allowlist, wildcard group admission, and explicit configured group counts.
- What changed: Unregistered group drops now name `channels.whatsapp.groups`, preserve the current sender-authorization warning, and the WhatsApp docs troubleshooting section calls out the observed-before-routing behavior.
- What did NOT change (scope boundary): Runtime admission policy, `groupPolicy`, `groupAllowFrom`, `allowFrom`, mention gating, and session routing controls are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #83779
- [x] This PR fixes a bug or regression

## Motivation

Operators can see group traffic arriving in the WhatsApp Web monitor while OpenClaw intentionally drops groups that are not admitted by `channels.whatsapp.groups`. The old startup and drop diagnostics made that look like DM-only listening or unexplained message loss.

## Real behavior proof (required for external PRs)

- Behavior addressed: WhatsApp inbound diagnostics now describe DM plus group observation/routing accurately, and unregistered group drops explain the required config without changing runtime policy.
- Real environment tested: macOS local OpenClaw source checkout, Node/Vitest test harness for the WhatsApp Web monitor and config group-policy path.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/whatsapp/src/auto-reply/web-auto-reply-monitor.test.ts src/config/group-policy.test.ts`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

  ```text
  Listening for WhatsApp inbound messages (DM + all groups; no group allowlist configured).
  Listening for WhatsApp inbound messages (DM + all groups; wildcard configured).
  Listening for WhatsApp inbound messages (DM + 2 configured groups).
  Dropping message from unregistered WhatsApp group 123@g.us. Add the group JID to channels.whatsapp.groups, or add "*" there to admit all groups. Sender authorization still applies.
  ```

- Observed result after fix: The focused WhatsApp/config regression run passed with 2 test files and 42 tests, including assertions for the startup diagnostic variants and the unregistered-group drop message.
- What was not tested: A live credentialed WhatsApp session was not run; the change is limited to diagnostics/docs and preserves the existing tested routing policy.
- Before evidence (optional but encouraged):

  ```text
  Listening for personal WhatsApp inbound messages.
  Skipping group message 123@g.us (not in allowlist)
  ```

## Root Cause (if applicable)

- Root cause: The listener startup log was written as if the WhatsApp Web monitor only listened for personal DMs, while later group admission logic can observe group traffic and drop it before session routing.
- Missing detection / guardrail: Existing group-policy tests asserted the drop behavior but did not assert the operator-facing diagnostics.
- Contributing context (if known): `channels.whatsapp.groups` is both the per-group config map and group membership allowlist; `groupAllowFrom` only handles sender authorization inside admitted groups.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/whatsapp/src/auto-reply/web-auto-reply-monitor.test.ts`
- Scenario the test should lock in: Startup diagnostics do not imply DM-only listening, and unregistered group drops explain `channels.whatsapp.groups` while preserving the block.
- Why this is the smallest reliable guardrail: The change is diagnostic-only on top of existing group-gating behavior.
- Existing test that already covers this (if any): `src/config/group-policy.test.ts` covers the group allowlist policy itself.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

WhatsApp logs and docs are clearer for group messages that are observed by the monitor but dropped before routing because the group is not registered in `channels.whatsapp.groups`. No runtime routing, authorization, or security behavior changes.

## Diagram (if applicable)

```text
Before:
WhatsApp Web monitor observes group -> group not in groups allowlist -> vague skip log

After:
WhatsApp Web monitor observes group -> group not in groups allowlist -> drop log names channels.whatsapp.groups and notes sender authorization still applies
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

Security/runtime controls unchanged: `channels.whatsapp.groups` still gates group membership admission; `groupPolicy` and `groupAllowFrom` still gate sender authorization; mention gating still applies after group admission.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/Vitest via repo test wrapper
- Model/provider: N/A
- Integration/channel (if any): WhatsApp
- Relevant config (redacted): tests cover no `groups`, wildcard `groups["*"]`, and explicit group allowlist entries

### Steps

1. Compare previous diagnostics from `origin/main` with the new WhatsApp listener/drop diagnostic strings.
2. Run the focused WhatsApp monitor and group-policy tests.
3. Run docs/list, whitespace, and changed checks.

### Expected

- Startup log describes WhatsApp inbound scope without implying DM-only listening.
- Group allowlist drops identify `channels.whatsapp.groups` and keep sender-authorization expectations explicit.
- Existing group blocking behavior remains unchanged.

### Actual

- Expected diagnostics are asserted in tests.
- Focused tests and changed checks pass.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Verification run:

```text
git diff --check
pnpm docs:list
node scripts/run-vitest.mjs extensions/whatsapp/src/auto-reply/web-auto-reply-monitor.test.ts src/config/group-policy.test.ts
pnpm check:changed
```

## Human Verification (required)

- Verified scenarios: startup log text for no group allowlist, wildcard group admission, explicit group count; unregistered group drop message; current group-policy allowlist behavior.
- Edge cases checked: no `groups`, `groups["*"]`, multiple explicit groups, unregistered group blocked with observable diagnostic.
- What you did **not** verify: live WhatsApp credentials, QR login, or a real phone/device session.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Operators could interpret wildcard admission as bypassing all group controls.
  - Mitigation: The drop diagnostic and docs state that sender authorization still applies through `groupPolicy` and `groupAllowFrom`.

## Out of scope

- Changing WhatsApp group routing or admission behavior.
- Auto-registering observed groups.
- Running a live credentialed WhatsApp E2E lane.

Made with [Cursor](https://cursor.com)