### PR TITLE
fix(codex): honor Docker bind write policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@ Docs: https://docs.openclaw.ai
 - Messages/Codex: keep Codex direct/source chats on message-tool visible delivery by default while documenting and testing `messages.visibleReplies: "automatic"` as the old-mode opt-out; channel wildcard model overrides now apply to direct chats before harness delivery defaults.
 - Memory/QMD: keep archived session transcript hits visible after QMD export while preserving normal `.md` session ids that only resemble archive names. (#83518; fixes #83506) Thanks @tanshanshan.
 - Codex app-server: preserve network access for sandboxed Codex code-mode turns when the OpenClaw sandbox allows outbound egress. Fixes #83347. Thanks @YusukeIt0.
+- Codex app-server: honor writable Docker bind mounts for sandboxed workspace-write turns while disabling native Code Mode when container-path aliases or read-only bind shadows cannot be represented safely host-side. Fixes #83737. (#83849) Thanks @joshavant.
 - QA-Lab: keep the OTLP smoke decoder independent of removed OpenTelemetry generated-root internals.
 - Messages: default group/channel visible replies to automatic final delivery again, keeping `message_tool` opt-in for ambient/shared rooms and tool-reliable models.
 - CLI/TUI: force standalone `/exit` runs to terminate after `runTui` returns so onboarding-launched TUI children do not stay alive invisibly. (#83501) Thanks @fuller-stack-dev.

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -744,7 +744,7 @@ describe("runCodexAppServerAttempt", () => {
     );
   });
 
-  it("does not expose sandbox shell tools unless non-Docker sandbox routing is available", async () => {
+  it("keeps Docker sandbox shell tools hidden when native Code Mode can honor sandbox paths", async () => {
     testing.setOpenClawCodingToolsFactoryForTests(() => [
       createRuntimeDynamicTool("exec"),
       createRuntimeDynamicTool("process"),
@@ -765,11 +765,69 @@ describe("runCodexAppServerAttempt", () => {
       effectiveWorkspace: workspaceDir,
       sandboxSessionKey,
       sandbox: { enabled: true, backendId: "docker" } as never,
+      nativeToolSurfaceEnabled: true,
       runAbortController: new AbortController(),
       sessionAgentId: "main",
       pluginConfig: {},
       onYieldDetected: () => undefined,
     });
+
+    expect(dockerTools.map((tool) => tool.name)).toEqual(["message"]);
+  });
+
+  it("exposes Docker sandbox shell tools when native Code Mode cannot honor sandbox paths", async () => {
+    testing.setOpenClawCodingToolsFactoryForTests(() => [
+      createRuntimeDynamicTool("exec"),
+      createRuntimeDynamicTool("process"),
+      createRuntimeDynamicTool("message"),
+    ]);
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(sessionFile, workspaceDir);
+    params.disableTools = false;
+    const sandboxSessionKey = params.sessionKey;
+    if (!sandboxSessionKey) {
+      throw new Error("createParams must provide a sessionKey for Codex dynamic tool tests.");
+    }
+
+    const tools = await testing.buildDynamicTools({
+      params,
+      resolvedWorkspace: workspaceDir,
+      effectiveWorkspace: workspaceDir,
+      sandboxSessionKey,
+      sandbox: {
+        enabled: true,
+        backendId: "docker",
+        docker: { binds: ["/tmp/openclaw-data:/data:rw"] },
+      } as never,
+      nativeToolSurfaceEnabled: false,
+      runAbortController: new AbortController(),
+      sessionAgentId: "main",
+      pluginConfig: {},
+      onYieldDetected: () => undefined,
+    });
+
+    expect(tools.map((tool) => tool.name)).toEqual(["message", "sandbox_exec", "sandbox_process"]);
+    expect(tools.find((tool) => tool.name === "sandbox_exec")?.description).toContain(
+      "Docker container-path bind layout",
+    );
+  });
+
+  it("does not expose sandbox shell tools when sandbox routing is disabled", async () => {
+    testing.setOpenClawCodingToolsFactoryForTests(() => [
+      createRuntimeDynamicTool("exec"),
+      createRuntimeDynamicTool("process"),
+      createRuntimeDynamicTool("message"),
+    ]);
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(sessionFile, workspaceDir);
+    params.disableTools = false;
+    const sandboxSessionKey = params.sessionKey;
+    if (!sandboxSessionKey) {
+      throw new Error("createParams must provide a sessionKey for Codex dynamic tool tests.");
+    }
+
     const disabledSandboxTools = await testing.buildDynamicTools({
       params,
       resolvedWorkspace: workspaceDir,
@@ -782,7 +840,6 @@ describe("runCodexAppServerAttempt", () => {
       onYieldDetected: () => undefined,
     });
 
-    expect(dockerTools.map((tool) => tool.name)).toEqual(["message"]);
     expect(disabledSandboxTools.map((tool) => tool.name)).toEqual(["message"]);
   });
 

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -1199,6 +1199,41 @@ describe("runCodexAppServerAttempt", () => {
     expect(testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
   });
 
+  it("disables Codex native tool surfaces when Docker bind targets need container paths", () => {
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
+    params.disableTools = false;
+
+    expect(
+      testing.shouldEnableCodexAppServerNativeToolSurface(params, {
+        enabled: true,
+        backendId: "docker",
+        docker: { binds: ["/tmp/openclaw-data:/data:rw"] },
+      } as never),
+    ).toBe(false);
+
+    expect(
+      testing.shouldEnableCodexAppServerNativeToolSurface(params, {
+        enabled: true,
+        backendId: "docker",
+        docker: { binds: ["/tmp/openclaw-data:/tmp/openclaw-data:rw"] },
+      } as never),
+    ).toBe(true);
+
+    expect(
+      testing.shouldEnableCodexAppServerNativeToolSurface(params, {
+        enabled: true,
+        backendId: "docker",
+        docker: {
+          binds: [
+            "/tmp/openclaw-data:/tmp/openclaw-data:rw",
+            "/tmp/openclaw-data/secrets:/tmp/openclaw-data/secrets:ro",
+          ],
+        },
+      } as never),
+    ).toBe(false);
+  });
+
   it("forces the message dynamic tool for message-tool-only source replies", () => {
     const workspaceDir = path.join(tempDir, "workspace");
     const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
@@ -8958,13 +8993,19 @@ describe("runCodexAppServerAttempt", () => {
         {
           enabled: true,
           backendId: "docker",
-          docker: { network: "bridge" },
+          docker: {
+            network: "bridge",
+            binds: [
+              "/tmp/openclaw-writable-data:/data:rw",
+              "/tmp/openclaw-readonly-data:/readonly:ro",
+            ],
+          },
         } as never,
         "/tmp/workspace",
       ),
     ).toEqual({
       type: "workspaceWrite",
-      writableRoots: ["/tmp/workspace"],
+      writableRoots: ["/tmp/workspace", path.resolve("/tmp/openclaw-writable-data")],
       networkAccess: true,
       excludeTmpdirEnvVar: false,
       excludeSlashTmp: false,

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -34,6 +34,9 @@ import {
   resolveBootstrapContextForRun,
   setActiveEmbeddedRun,
   supportsModelTools,
+  hasSandboxBindContainerPathAliases,
+  hasSandboxBindReadonlyHostShadows,
+  resolveWritableSandboxBindHostRoots,
   runAgentCleanupStep,
   type AgentMessage,
   type EmbeddedRunAttemptParams,
@@ -452,11 +455,17 @@ function resolveCodexAppServerSandboxPolicyForOpenClawSandbox(
     return undefined;
   }
   const networkAccess = codexNetworkAccessForOpenClawSandbox(sandbox);
+  const writableRoots = new Set([cwd]);
+  if (sandbox.backendId === "docker") {
+    for (const root of resolveWritableSandboxBindHostRoots(sandbox.docker.binds)) {
+      writableRoots.add(root);
+    }
+  }
   // Codex app-server still runs on the Gateway host, so keep Codex's
   // filesystem sandbox while mirroring the OpenClaw sandbox egress policy.
   return {
     type: "workspaceWrite",
-    writableRoots: [cwd],
+    writableRoots: [...writableRoots],
     networkAccess,
     excludeTmpdirEnvVar: false,
     excludeSlashTmp: false,
@@ -891,7 +900,7 @@ export async function runCodexAppServerAttempt(
     disableTools: params.disableTools,
     toolsAllow: params.toolsAllow,
   });
-  const nativeToolSurfaceEnabled = shouldEnableCodexAppServerNativeToolSurface(params);
+  const nativeToolSurfaceEnabled = shouldEnableCodexAppServerNativeToolSurface(params, sandbox);
   for (const diagnostic of bundleMcpThreadConfig.diagnostics) {
     embeddedAgentLog.warn(`bundle-mcp: ${diagnostic.pluginId}: ${diagnostic.message}`);
   }
@@ -3300,15 +3309,33 @@ function includeForcedMessageToolAllow(
   return normalized.has("message") ? toolsAllow : [...toolsAllow, "message"];
 }
 
-function shouldEnableCodexAppServerNativeToolSurface(params: EmbeddedRunAttemptParams): boolean {
+function shouldEnableCodexAppServerNativeToolSurface(
+  params: EmbeddedRunAttemptParams,
+  sandbox?: OpenClawSandboxContext,
+): boolean {
   const toolsAllow = includeForcedMessageToolAllow(params.toolsAllow, params);
   if (toolsAllow === undefined) {
-    return true;
+    return canCodexAppServerNativeToolSurfaceHonorSandbox(sandbox);
   }
   // Codex native code mode exposes its shell/file surface as one app-server
   // capability, so narrow OpenClaw allowlists must fail closed rather than
   // widening `message` or `web_search` into shell access.
-  return hasWildcardCodexToolsAllow(toolsAllow);
+  return (
+    hasWildcardCodexToolsAllow(toolsAllow) &&
+    canCodexAppServerNativeToolSurfaceHonorSandbox(sandbox)
+  );
+}
+
+function canCodexAppServerNativeToolSurfaceHonorSandbox(
+  sandbox: OpenClawSandboxContext | undefined,
+): boolean {
+  if (!sandbox?.enabled || sandbox.backendId !== "docker") {
+    return true;
+  }
+  return (
+    !hasSandboxBindContainerPathAliases(sandbox.docker.binds) &&
+    !hasSandboxBindReadonlyHostShadows(sandbox.docker.binds)
+  );
 }
 
 function disableCodexPluginThreadConfig(pluginConfig?: unknown): CodexPluginConfig {

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -915,6 +915,7 @@ export async function runCodexAppServerAttempt(
     effectiveWorkspace,
     sandboxSessionKey,
     sandbox,
+    nativeToolSurfaceEnabled,
     runAbortController,
     sessionAgentId,
     pluginConfig,
@@ -3155,6 +3156,7 @@ type DynamicToolBuildParams = {
   effectiveWorkspace: string;
   sandboxSessionKey: string;
   sandbox: Awaited<ReturnType<typeof resolveSandboxContext>>;
+  nativeToolSurfaceEnabled?: boolean;
   runAbortController: AbortController;
   sessionAgentId: string;
   pluginConfig: CodexPluginConfig;
@@ -3371,7 +3373,7 @@ function addSandboxShellDynamicToolsIfAvailable(
     ...execTool,
     name: "sandbox_exec",
     description:
-      "Run a shell command through OpenClaw's configured sandbox backend for this session. Use only when the command must execute in the OpenClaw sandbox backend, such as an SSH-backed sandbox. Use Codex's native shell for normal local workspace commands.",
+      "Run a shell command through OpenClaw's configured sandbox backend for this session. Use only when the command must execute in the OpenClaw sandbox backend, such as an SSH-backed sandbox or Docker container-path bind layout that Codex's native shell cannot represent. Use Codex's native shell for normal local workspace commands.",
     execute: async (toolCallId, args, signal, onUpdate) => {
       const result = await execTool.execute(toolCallId, args, signal, onUpdate);
       return {
@@ -3400,7 +3402,7 @@ function addSandboxShellDynamicToolsIfAvailable(
 
 function shouldExposeSandboxExecDynamicTool(input: DynamicToolBuildParams): boolean {
   const backendId = input.sandbox?.enabled ? input.sandbox.backendId.trim().toLowerCase() : "";
-  return Boolean(backendId && backendId !== "docker");
+  return Boolean(backendId && (backendId !== "docker" || input.nativeToolSurfaceEnabled === false));
 }
 
 function isSandboxShellDynamicToolExcluded(config: CodexPluginConfig): boolean {

--- a/src/agents/sandbox/fs-paths.test.ts
+++ b/src/agents/sandbox/fs-paths.test.ts
@@ -3,8 +3,11 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   buildSandboxFsMounts,
+  hasSandboxBindContainerPathAliases,
+  hasSandboxBindReadonlyHostShadows,
   parseSandboxBindMount,
   resolveSandboxFsPathWithMounts,
+  resolveWritableSandboxBindHostRoots,
 } from "./fs-paths.js";
 import { createSandboxTestContext } from "./test-fixtures.js";
 import type { SandboxContext } from "./types.js";
@@ -46,6 +49,50 @@ describe("parseSandboxBindMount", () => {
       containerRoot: "/workspace",
       writable: false,
     });
+  });
+
+  it("returns only unique writable bind host roots", () => {
+    expect(
+      resolveWritableSandboxBindHostRoots([
+        "/tmp/data:/data:rw",
+        "/tmp/read-only:/read-only:ro",
+        "/tmp/default-write:/default-write",
+        "/tmp/data:/data-two:rw",
+        "invalid-bind",
+      ]),
+    ).toEqual([path.resolve("/tmp/data"), path.resolve("/tmp/default-write")]);
+  });
+
+  it("omits writable bind roots that contain read-only host shadows", () => {
+    expect(
+      resolveWritableSandboxBindHostRoots([
+        "/tmp/data:/tmp/data:rw",
+        "/tmp/data/secrets:/tmp/data/secrets:ro",
+        "/tmp/readonly-parent:/tmp/readonly-parent:ro",
+        "/tmp/readonly-parent/work:/tmp/readonly-parent/work:rw",
+      ]),
+    ).toEqual([path.resolve("/tmp/readonly-parent/work")]);
+  });
+
+  it("detects bind mounts whose container path differs from the host path", () => {
+    expect(hasSandboxBindContainerPathAliases(["/tmp/data:/tmp/data:rw"])).toBe(false);
+    expect(hasSandboxBindContainerPathAliases(["/tmp/data:/data:rw"])).toBe(true);
+    expect(hasSandboxBindContainerPathAliases(["invalid-bind"])).toBe(false);
+  });
+
+  it("detects read-only bind shadows inside writable host roots", () => {
+    expect(
+      hasSandboxBindReadonlyHostShadows([
+        "/tmp/data:/tmp/data:rw",
+        "/tmp/data/secrets:/tmp/data/secrets:ro",
+      ]),
+    ).toBe(true);
+    expect(
+      hasSandboxBindReadonlyHostShadows([
+        "/tmp/data:/tmp/data:ro",
+        "/tmp/data/work:/tmp/data/work:rw",
+      ]),
+    ).toBe(false);
   });
 });
 

--- a/src/agents/sandbox/fs-paths.ts
+++ b/src/agents/sandbox/fs-paths.ts
@@ -102,6 +102,56 @@ export function buildSandboxFsMounts(sandbox: SandboxFsBridgeContext): SandboxFs
   return dedupeMounts(mounts);
 }
 
+export function resolveWritableSandboxBindHostRoots(
+  binds: readonly string[] | undefined,
+): string[] {
+  const parsedBinds = parseSandboxBindMounts(binds);
+  const readonlyRoots = parsedBinds.filter((bind) => !bind.writable).map((bind) => bind.hostRoot);
+  const roots: string[] = [];
+  const seen = new Set<string>();
+  for (const parsed of parsedBinds) {
+    if (
+      !parsed.writable ||
+      seen.has(parsed.hostRoot) ||
+      readonlyRoots.some((root) => isHostPathWithinOrEqual(parsed.hostRoot, root))
+    ) {
+      continue;
+    }
+    seen.add(parsed.hostRoot);
+    roots.push(parsed.hostRoot);
+  }
+  return roots;
+}
+
+export function hasSandboxBindContainerPathAliases(binds: readonly string[] | undefined): boolean {
+  for (const parsed of parseSandboxBindMounts(binds)) {
+    if (parsed.hostRoot !== parsed.containerRoot) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function hasSandboxBindReadonlyHostShadows(binds: readonly string[] | undefined): boolean {
+  const parsedBinds = parseSandboxBindMounts(binds);
+  const writableRoots = parsedBinds.filter((bind) => bind.writable).map((bind) => bind.hostRoot);
+  const readonlyRoots = parsedBinds.filter((bind) => !bind.writable).map((bind) => bind.hostRoot);
+  return writableRoots.some((writableRoot) =>
+    readonlyRoots.some((readonlyRoot) => isHostPathWithinOrEqual(writableRoot, readonlyRoot)),
+  );
+}
+
+function parseSandboxBindMounts(binds: readonly string[] | undefined): ParsedBindMount[] {
+  const parsed: ParsedBindMount[] = [];
+  for (const bind of binds ?? []) {
+    const mount = parseSandboxBindMount(bind);
+    if (mount) {
+      parsed.push(mount);
+    }
+  }
+  return parsed;
+}
+
 export function resolveSandboxFsPathWithMounts(params: {
   filePath: string;
   cwd: string;
@@ -261,6 +311,11 @@ function isPathInsideHost(root: string, target: string): boolean {
   );
   const canonicalTarget = path.resolve(canonicalTargetParent, path.basename(resolvedTarget));
   return isPathInside(canonicalRoot, canonicalTarget);
+}
+
+function isHostPathWithinOrEqual(root: string, target: string): boolean {
+  const relative = path.relative(path.resolve(root), path.resolve(target));
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
 }
 
 function toHostSegments(relativePosix: string): string[] {

--- a/src/plugin-sdk/agent-harness-runtime.ts
+++ b/src/plugin-sdk/agent-harness-runtime.ts
@@ -156,6 +156,11 @@ export async function loadCodexBundleMcpThreadConfig(
   return load(params);
 }
 export { resolveSandboxContext } from "../agents/sandbox.js";
+export {
+  hasSandboxBindContainerPathAliases,
+  hasSandboxBindReadonlyHostShadows,
+  resolveWritableSandboxBindHostRoots,
+} from "../agents/sandbox/fs-paths.js";
 export { resolveBootstrapContextForRun } from "../agents/bootstrap-files.js";
 export type { EmbeddedContextFile } from "../agents/pi-embedded-helpers/types.js";
 export { isSubagentSessionKey } from "../routing/session-key.js";


### PR DESCRIPTION
Summary:
- mirror writable Docker bind host roots into Codex app-server workspace-write policy when the bind can be represented safely on the host
- disable Codex native Code Mode for Docker bind aliases such as `host:/data:rw`, and for writable bind roots that contain read-only child bind shadows
- expose OpenClaw `sandbox_exec` / `sandbox_process` as the fallback shell surface when Docker bind paths cannot be represented by Codex host-native Code Mode
- add focused regression coverage for writable bind roots, alias detection, read-only shadow detection, Codex native tool gating, and Docker fallback tool exposure

Fixes #83737

Verification:
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts` (180 tests passed)
- `node scripts/run-vitest.mjs src/agents/sandbox/fs-paths.test.ts extensions/codex/src/app-server/run-attempt.test.ts` (3 files, 204 tests passed before the fallback follow-up)
- `AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --mode local` (clean, no accepted/actionable findings)
- AWS Crabbox `run_4f418fe2f309`, provider `aws`, lease `cbx_1164647677d0`, exit 0

Real behavior proof:
Behavior addressed: Docker sandbox with `workspaceAccess: "ro"` and external writable bind `host:/data:rw` must leave the model with a working sandbox shell/file mutation path when Codex host-native Code Mode is disabled because it cannot represent container-only paths.
Real environment tested: AWS Crabbox direct provider, `run_4f418fe2f309`, lease `cbx_1164647677d0`, Linux target with Node 22, pnpm, Docker 29, built OpenClaw output, and a locally built `openclaw-sandbox:bookworm-slim` image.
Exact steps or command run after this patch: Synced the patched checkout to AWS, installed Node/pnpm/Docker, ran `pnpm install --frozen-lockfile`, `pnpm build`, and `scripts/sandbox-setup.sh`; then created a real Docker sandbox using `workspaceAccess: "ro"`, `${bindRoot}:/data:rw`, and `dangerouslyAllowExternalBindSources: true`, ran `runCodexAppServerAttempt` against a protocol-shaped fake app-server client, inspected the actual `thread/start` payload, invoked the exposed `sandbox_exec` dynamic tool through the app-server `item/tool/call` request handler with `printf patched-from-sandbox >/data/proof.txt && cat /data/proof.txt`, and read the host bind file.
Evidence after fix: Proof output reported `thread/start features.code_mode false`, `thread/start dynamicTools sessions_list,sessions_history,sessions_send,sessions_spawn,sessions_yield,subagents,session_status,sandbox_exec,sandbox_process`, `thread/start environments []`, `sandbox_exec success true`, `sandbox_exec output [{"type":"inputText","text":"patched-from-sandbox"}]`, and `host bind proof patched-from-sandbox`.
Observed result after fix: Codex native Code Mode was disabled for the Docker container-path alias, the OpenClaw sandbox shell fallback remained available, and the fallback wrote `/data/proof.txt` through the Docker bind so the host saw `patched-from-sandbox`.
What was not tested: A real OpenAI-authenticated Codex model turn was not run; the proof used a protocol-shaped fake app-server client so no live credentials were required while still exercising the real OpenClaw app-server setup and dynamic tool call path.
