### PR TITLE
fix(cli): add configure and onboard to interactive TTY command skip list

### DIFF
--- a/src/cli/cli-utils.test.ts
+++ b/src/cli/cli-utils.test.ts
@@ -35,6 +35,11 @@ describe("shouldSkipRespawnForArgv", () => {
     { argv: ["node", "openclaw", "tui"] },
     { argv: ["node", "openclaw", "terminal"] },
     { argv: ["node", "openclaw", "chat"] },
+    { argv: ["node", "openclaw", "configure"] },
+    { argv: ["node", "openclaw", "onboard"] },
+    // Root options before the subcommand must also be handled correctly.
+    { argv: ["node", "openclaw", "--profile", "server", "configure"] },
+    { argv: ["node", "openclaw", "--profile", "default", "onboard"] },
     { argv: ["node", "openclaw", "gateway"] },
     { argv: ["node", "openclaw", "gateway", "--port", "14720", "--bind", "loopback"] },
     { argv: ["node", "openclaw", "gateway", "run", "--port=14720", "--bind", "loopback"] },
@@ -51,6 +56,19 @@ describe("shouldSkipRespawnForArgv", () => {
     { argv: ["node", "openclaw", "gateway", "call", "health"] },
   ] as const)("keeps respawn path for argv %j", ({ argv }) => {
     expect(shouldSkipRespawnForArgv([...argv]), argv.join(" ")).toBe(false);
+  });
+});
+
+describe("shouldSkipStartupEnvironmentRespawnForArgv for interactive commands", () => {
+  it.each([
+    { argv: ["node", "openclaw", "configure"] },
+    { argv: ["node", "openclaw", "onboard"] },
+    { argv: ["node", "openclaw", "--profile", "server", "configure"] },
+  ] as const)("allows CA-certs startup-env respawn for interactive argv %j", ({ argv }) => {
+    // configure/onboard skip the warning-suppression respawn but still allow
+    // the CA-certs startup-environment respawn (it is safe for interactive
+    // commands because it only changes an env var, not stdin/stdout).
+    expect(shouldSkipStartupEnvironmentRespawnForArgv([...argv]), argv.join(" ")).toBe(false);
   });
 });
 

--- a/src/cli/respawn-policy.ts
+++ b/src/cli/respawn-policy.ts
@@ -26,7 +26,12 @@ const GATEWAY_RUN_VALUE_FLAGS = [
   "--ws-log",
 ] as const;
 
-const INTERACTIVE_TTY_COMMANDS = new Set(["tui", "terminal", "chat"]);
+// Interactive setup commands use clack prompts that need exclusive raw-mode
+// TTY access. Including them in the respawn skip list prevents the
+// warning-suppression child process from sharing the TTY fd, which can cause
+// stdin busy-wait at high CPU on Linux (Debian 6.12.63 + Node 22.22.1).
+// See: https://github.com/openclaw/openclaw/issues/83560
+const INTERACTIVE_TTY_COMMANDS = new Set(["tui", "terminal", "chat", "configure", "onboard"]);
 
 function isForegroundGatewayRunArgv(argv: string[]): boolean {
   const positionals = getCommandPositionalsWithRootOptions(argv, {


### PR DESCRIPTION
## Problem

`openclaw configure` and `openclaw onboard` hang and leave high-CPU child processes on some Linux kernel/Node.js combinations. Reported in #83560.

## Root Cause

The ExperimentalWarning suppression respawn in `buildCliRespawnPlan` wraps the command in a parent/child process pair sharing the same TTY fd. The parent installs signal handlers via `attachChildProcessBridge`, keeping the event loop alive. The child's clack `select()` calls `stdin.setRawMode(true)` on the shared fd. On Debian kernel 6.12.63 + Node 22.22.1 this causes the child to busy-wait at high CPU or hang indefinitely.

## Fix

Add `configure` and `onboard` to the existing `INTERACTIVE_TTY_COMMANDS` set in `respawn-policy.ts`. This makes `shouldSkipRespawnForArgv` return `true` for both, matching the existing treatment of `tui`, `terminal`, and `chat`. Because the function is driven by `resolveCliArgvInvocation(argv).primary` (via `getPrimaryCommand`), root options before the subcommand are already handled correctly — e.g. `openclaw --profile server configure` works without any additional argv-position logic.

`shouldSkipStartupEnvironmentRespawnForArgv` is intentionally **not** changed: the CA-certs startup-environment respawn is safe for interactive commands because it only injects an env var without altering stdin/stdout or installing a signal bridge. Tests confirm `configure`/`onboard` still allow that respawn path.

## Changes

- `src/cli/respawn-policy.ts` (+1 line): add `"configure"` and `"onboard"` to `INTERACTIVE_TTY_COMMANDS`
- `src/cli/cli-utils.test.ts` (+23 lines): extend the existing `shouldSkipRespawnForArgv` test table with `configure`, `onboard`, and root-option variants; add a new describe block asserting `shouldSkipStartupEnvironmentRespawnForArgv` returns `false` for these commands

## Reviewer checklist

- Branch now based on upstream `main` @ `ff871e162a`
- Root-option invocations covered: `openclaw --profile server configure`, `openclaw --profile default onboard`
- CA-certs respawn behavior explicitly tested and unchanged
- No new argv-position parser introduced; existing `resolveCliArgvInvocation` does the work

## Acceptance criteria (for live repro)

```bash
timeout 12 script -qefc 'TERM=xterm-256color OPENCLAW_HOME=/tmp/oc-repro openclaw configure' /tmp/oc-repro.log
# Must exit cleanly; no high-CPU child processes remaining after exit
```

Fixes #83560