### PR TITLE
fix(cli): clear config snapshot cache on rejection (#83855)

### DIFF
--- a/src/cli/program/config-guard.test.ts
+++ b/src/cli/program/config-guard.test.ts
@@ -214,4 +214,36 @@ describe("ensureConfigReady", () => {
     });
     expect(output).toContain("Doctor warnings");
   });
+
+  it("does not pin a rejected config snapshot promise across calls (#83855)", async () => {
+    // Step outside the VITEST guard (config-guard.ts:30) so the cache path
+    // actually runs. The regression: a rejected `readConfigFileSnapshot()`
+    // was permanently cached, so every subsequent CLI invocation in the
+    // same process replayed the original failure.
+    const priorVitest = process.env.VITEST;
+    delete process.env.VITEST;
+    try {
+      resetConfigGuardStateForTests();
+      readConfigFileSnapshotMock.mockReset();
+      const firstError = new Error("ENOENT: openclaw.json");
+      readConfigFileSnapshotMock.mockRejectedValueOnce(firstError);
+      readConfigFileSnapshotMock.mockResolvedValueOnce(makeSnapshot());
+
+      await expect(testApi.getConfigSnapshotForTests()).rejects.toBe(firstError);
+      // Microtask drain so the `.catch` cleanup observes the rejection before
+      // the next call samples `configSnapshotPromise`.
+      await new Promise((resolve) => setImmediate(resolve));
+
+      const second = await testApi.getConfigSnapshotForTests();
+      expect(second).toEqual(makeSnapshot());
+      expect(readConfigFileSnapshotMock).toHaveBeenCalledTimes(2);
+    } finally {
+      if (priorVitest === undefined) {
+        delete process.env.VITEST;
+      } else {
+        process.env.VITEST = priorVitest;
+      }
+      resetConfigGuardStateForTests();
+    }
+  });
 });

--- a/src/cli/program/config-guard.ts
+++ b/src/cli/program/config-guard.ts
@@ -30,7 +30,18 @@ async function getConfigSnapshot() {
   if (process.env.VITEST === "true") {
     return readConfigFileSnapshot();
   }
-  configSnapshotPromise ??= readConfigFileSnapshot();
+  if (!configSnapshotPromise) {
+    // Clear the cached promise on rejection so a transient filesystem error
+    // (e.g. ENOENT during atomic-rename) doesn't pin every subsequent CLI
+    // invocation in this process to the original failure. See #83855.
+    const pending = readConfigFileSnapshot();
+    pending.catch(() => {
+      if (configSnapshotPromise === pending) {
+        configSnapshotPromise = null;
+      }
+    });
+    configSnapshotPromise = pending;
+  }
   return configSnapshotPromise;
 }
 
@@ -139,5 +150,6 @@ export async function ensureConfigReady(params: {
 
 export const testApi = {
   resetConfigGuardStateForTests,
+  getConfigSnapshotForTests: () => getConfigSnapshot(),
 };
 export { testApi as __test__ };


### PR DESCRIPTION
Fixes #83855.

`getConfigSnapshot` (`src/cli/program/config-guard.ts:33`) used `??=` to memoize the in-flight `readConfigFileSnapshot()` promise. If that promise rejected — e.g. a transient ENOENT during a config atomic-rename — the rejected promise stayed pinned in `configSnapshotPromise` for the lifetime of the process, so every subsequent CLI invocation replayed the original failure even after the underlying filesystem state recovered. The VITEST guard one line above bypasses the cache entirely, so no existing test exercised the rejection-caching path.

## Changes

- `src/cli/program/config-guard.ts`: replace the `??=` memoization with an explicit `if (!configSnapshotPromise)` branch that wires a `.catch` cleanup on the pending promise. When the in-flight read rejects, clear `configSnapshotPromise` only if it is still the same pending reference (so a concurrent retry that already replaced the slot is not clobbered). Successful resolutions stay cached unchanged. VITEST bypass preserved. Expose `getConfigSnapshot` via `testApi.getConfigSnapshotForTests` so the regression test can drive the non-VITEST cache path directly.
- `src/cli/program/config-guard.test.ts`: add a regression test that temporarily unsets `process.env.VITEST` (so the cache path actually runs), rejects the first `readConfigFileSnapshot` call, drains microtasks, and asserts the second call invokes the reader again and resolves with a fresh snapshot.

Diff stat: 2 files, +45 / -1.

## Real behavior proof

- **Behavior or issue addressed:** Sanitized issue evidence — the `??=` cache stored the rejected promise once `readConfigFileSnapshot` failed, so every later `ensureConfigReady` invocation in the same Node process kept rejecting with the same error even after the config file came back. The reporter's "Why existing tests miss this" note pins the gap on the VITEST cache bypass.

- **Real environment tested:** Local Node 22.x. Probe at `/tmp/probe_83855.mjs` performs (a) source-level checks on the patched `config-guard.ts` (non-cached branch uses `if (!configSnapshotPromise)`, `.catch` cleanup is gated on `configSnapshotPromise === pending`, VITEST bypass preserved, return shape unchanged), and (b) replays the cache semantics in pure JS across four scenarios — the original buggy `??=` shape (confirms the rejection is pinned and the reader is never re-invoked), the patched shape (first call rejects, second call resolves with a fresh value, reader invoked twice), a race where a concurrent second caller enters before the first settles (both observe the same resolved value, reader called once), and a steady-state cache hit (single reader invocation across three calls).

- **Exact steps or command run after this patch:** `node /tmp/probe_83855.mjs`

- **Evidence after fix:**

```
PASS: non-cached branch uses `if (!configSnapshotPromise)` instead of `??=`
PASS: rejection cleanup gated on 'still latest pending'
PASS: VITEST cache bypass preserved
PASS: return shape unchanged
PASS: replay (buggy): second call replays cached rejection and never re-invokes reader
PASS: replay (patched): first rejects with ENOENT, second resolves with ok, reader invoked twice
PASS: replay (cache-hit): resolved promise is cached across calls (no regression)
PASS: replay (race): concurrent callers share the same in-flight promise — no reader duplication

ALL CASES PASS
```

- **Observed result after fix:** A CLI process that hits a transient `readConfigFileSnapshot` rejection (ENOENT/EBUSY during an atomic-rename window) no longer pins the failure across subsequent commands. The next call after a microtask flush sees `configSnapshotPromise === null` and re-invokes the reader. Concurrent callers still share a single in-flight promise (no reader duplication), and resolved snapshots are cached as before.

- **What was not tested:** A live filesystem race reproduction (atomic-rename collision against a CLI burst). The probe replays both the buggy and patched cache semantics directly against the issue's exact failure path, the regression test exercises the public `testApi.getConfigSnapshotForTests` contract under a non-VITEST environment, and the source-level checks confirm the patched function shape matches the issue's recommended fix.

## Audit (per CLAUDE rules — all 5 steps)

- **Existing-helper check:** Reuses the existing `configSnapshotPromise` module-state pattern, the existing `readConfigFileSnapshot` import, and the existing `resetConfigGuardStateForTests` API. No new helper, no new module-state variable. PASS
- **Shared-helper caller check:** `getConfigSnapshot` has one production caller (`ensureConfigReady` in the same file, line 74). The signature is unchanged; the behavior change is additive — successful resolutions still cache, only the rejected-promise path is allowed to retry. PASS
- **Broader-fix rival scan:** `gh pr list --search '83855 in:title,body'` and `gh pr list --search 'getConfigSnapshot in:title,body'` both return no open PRs. PASS
- **Recent-merge audit:** `git log --oneline -10 -- src/cli/program/config-guard.ts` shows `e1061a8b46 test(live): tolerate provider drift in release checks` — unrelated. PASS
- **Prototype-pollution scan:** N/A — no external-input key copying.
