### PR TITLE
[Docs] Document gateway benchmark probes

### DIFF
--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -127,7 +127,9 @@ Inline `--password` can be exposed in local process listings. Prefer `--password
 - Set `OPENCLAW_GATEWAY_STARTUP_TRACE=1` to log phase timings during Gateway startup, including per-phase `eventLoopMax` delay and plugin lookup-table timings for installed-index, manifest registry, startup planning, and owner-map work.
 - Set `OPENCLAW_GATEWAY_RESTART_TRACE=1` to log restart-scoped `restart trace:` lines for restart signal handling, active-work drain, shutdown phases, next start, ready timing, and memory metrics.
 - Set `OPENCLAW_DIAGNOSTICS=timeline` with `OPENCLAW_DIAGNOSTICS_TIMELINE_PATH=<path>` to write a best-effort JSONL startup diagnostics timeline for external QA harnesses. You can also enable the flag with `diagnostics.flags: ["timeline"]` in config; the path is still env-provided. Add `OPENCLAW_DIAGNOSTICS_EVENT_LOOP=1` to include event-loop samples.
-- Run `pnpm test:startup:gateway -- --runs 5 --warmup 1` to benchmark Gateway startup. The benchmark records first process output, `/healthz`, `/readyz`, startup trace timings, event-loop delay, and plugin lookup-table timing details.
+- Run `pnpm build` first, then `pnpm test:startup:gateway -- --runs 5 --warmup 1` to benchmark Gateway startup against the built CLI entry. The benchmark records first process output, `/healthz`, `/readyz`, startup trace timings, event-loop delay, and plugin lookup-table timing details.
+- Run `pnpm build` first, then `pnpm test:restart:gateway -- --case skipChannels --runs 1 --restarts 5` to benchmark in-process Gateway restart against the built CLI entry on macOS or Linux. The restart benchmark uses SIGUSR1, enables both startup and restart traces in the child process, and records next `/healthz`, next `/readyz`, downtime, ready timing, CPU, RSS, and restart trace metrics.
+- Treat `/healthz` as liveness and `/readyz` as usable readiness. Trace lines and benchmark output are for owner attribution; do not treat one trace span or one sample as a complete performance conclusion.
 
 ## Query a running Gateway
 

--- a/docs/reference/test.md
+++ b/docs/reference/test.md
@@ -124,6 +124,93 @@ Checked-in fixture:
 - Refresh with `pnpm test:startup:bench:update`
 - Compare current results against the fixture with `pnpm test:startup:bench:check`
 
+## Gateway startup bench
+
+Script: [`scripts/bench-gateway-startup.ts`](https://github.com/openclaw/openclaw/blob/main/scripts/bench-gateway-startup.ts)
+
+The benchmark defaults to the built CLI entry at `dist/entry.js`; run
+`pnpm build` before using the package-script commands. To measure the source
+runner instead, pass `--entry scripts/run-node.mjs` and keep those results
+separate from built-entry baselines.
+
+Usage:
+
+- `pnpm test:startup:gateway -- --runs 5 --warmup 1`
+- `pnpm test:startup:gateway -- --case default --runs 10 --warmup 1`
+- `pnpm test:startup:gateway -- --case skipChannels --case fiftyPlugins --runs 5`
+- `node --import tsx scripts/bench-gateway-startup.ts --case default --runs 5 --output .artifacts/gateway-startup.json`
+- `node --import tsx scripts/bench-gateway-startup.ts --case default --runs 3 --cpu-prof-dir .artifacts/gateway-startup-cpu`
+
+Case ids:
+
+- `default`: normal Gateway startup.
+- `skipChannels`: Gateway startup with channel startup skipped.
+- `oneInternalHook`: one configured internal hook.
+- `allInternalHooks`: all internal hooks.
+- `fiftyPlugins`: 50 manifest plugins.
+- `fiftyStartupLazyPlugins`: 50 startup-lazy manifest plugins.
+
+Output includes first process output, `/healthz`, `/readyz`, HTTP listen log time,
+Gateway ready log time, CPU time, CPU core ratio, max RSS, heap, startup trace
+metrics, event-loop delay, and plugin lookup-table detail metrics. The script
+enables `OPENCLAW_GATEWAY_STARTUP_TRACE=1` in the child Gateway environment.
+
+Read `/healthz` as liveness: the HTTP server can answer. Read `/readyz` as
+usable readiness: startup plugin sidecars, channels, hooks, and ready-critical
+post-attach work have settled. Ready log time is the Gateway's internal ready
+log timestamp; it is useful for process-side attribution but is not a substitute
+for the external `/readyz` probe.
+
+Use JSON output or `--output` when comparing changes. Use `--cpu-prof-dir` only
+after the trace output points at import, compile, or CPU-bound work that cannot
+be explained from phase timings alone. Do not compare source-runner results with
+built `dist/entry.js` results as the same baseline.
+
+## Gateway restart bench
+
+Script: [`scripts/bench-gateway-restart.ts`](https://github.com/openclaw/openclaw/blob/main/scripts/bench-gateway-restart.ts)
+
+The restart benchmark is supported on macOS and Linux only. It uses SIGUSR1 for
+in-process restarts and fails immediately on Windows.
+
+The benchmark defaults to the built CLI entry at `dist/entry.js`; run
+`pnpm build` before using the package-script commands. To measure the source
+runner instead, pass `--entry scripts/run-node.mjs` and keep those results
+separate from built-entry baselines.
+
+Usage:
+
+- `pnpm test:restart:gateway -- --case skipChannels --runs 1 --restarts 5`
+- `pnpm test:restart:gateway -- --case default --runs 3 --restarts 3 --warmup 1`
+- `pnpm test:restart:gateway -- --case skipChannelsAcpxProbe --case skipChannelsNoAcpxProbe --runs 1 --restarts 5`
+- `node --import tsx scripts/bench-gateway-restart.ts --case fiftyPlugins --runs 1 --restarts 5 --output .artifacts/gateway-restart.json`
+- `node --import tsx scripts/bench-gateway-restart.ts --json`
+
+Case ids:
+
+- `skipChannels`: restart with channels skipped.
+- `skipChannelsAcpxProbe`: restart with channels skipped and ACPX startup probe on.
+- `skipChannelsNoAcpxProbe`: restart with channels skipped and ACPX startup probe off.
+- `default`: normal restart.
+- `fiftyPlugins`: restart with 50 manifest plugins.
+
+Output includes next `/healthz`, next `/readyz`, downtime, restart ready timing,
+CPU, RSS, startup trace metrics for the replacement process, and restart trace
+metrics for signal handling, active-work drain, close phases, next start, ready
+timing, and memory snapshots. The script enables
+`OPENCLAW_GATEWAY_STARTUP_TRACE=1` and `OPENCLAW_GATEWAY_RESTART_TRACE=1` in the
+child Gateway environment.
+
+Use this benchmark when a change touches restart signaling, close handlers,
+startup-after-restart, sidecar shutdown, service handoff, or readiness after
+restart. Start with `skipChannels` when isolating Gateway mechanics from channel
+startup. Use `default` or plugin-heavy cases only after the narrow case explains
+the restart path.
+
+Trace metrics are attribution hints, not verdicts. A restart change should be
+judged from multiple samples, the matching owner span, `/healthz` and `/readyz`
+behavior, and the user-visible restart contract.
+
 ## Onboarding E2E (Docker)
 
 Docker is optional; this is only needed for containerized onboarding smoke tests.

--- a/docs/reference/test.md
+++ b/docs/reference/test.md
@@ -156,10 +156,11 @@ metrics, event-loop delay, and plugin lookup-table detail metrics. The script
 enables `OPENCLAW_GATEWAY_STARTUP_TRACE=1` in the child Gateway environment.
 
 Read `/healthz` as liveness: the HTTP server can answer. Read `/readyz` as
-usable readiness: startup plugin sidecars, channels, hooks, and ready-critical
-post-attach work have settled. Ready log time is the Gateway's internal ready
-log timestamp; it is useful for process-side attribution but is not a substitute
-for the external `/readyz` probe.
+usable readiness: startup plugin sidecars, channels, and ready-critical
+post-attach work have settled. Gateway startup hooks are dispatched
+asynchronously and are not part of the readiness guarantee. Ready log time is the
+Gateway's internal ready log timestamp; it is useful for process-side
+attribution but is not a substitute for the external `/readyz` probe.
 
 Use JSON output or `--output` when comparing changes. Use `--cpu-prof-dir` only
 after the trace output points at import, compile, or CPU-bound work that cannot


### PR DESCRIPTION
## Summary

- Problem: Gateway profiling docs listed benchmark commands without the runtime contract details reviewers need to run them correctly.
- Solution: Document the startup and restart benchmark probes, output shape, case IDs, built-entry prerequisite, and restart platform limit.
- What changed: Updated `docs/cli/gateway.md` and `docs/reference/test.md` only.
- What did NOT change: No benchmark implementation, runtime behavior, config, or test logic changed.

## Change Type (select all)

- [x] Docs

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] UI / DX

## Linked Issue/PR

- Related #
- [ ] This PR fixes a bug or regression

## Motivation

The Gateway benchmark docs should make the benchmark entrypoint, probes, trace fields, and platform limits explicit so performance work does not depend on tribal knowledge.

## Real behavior proof (required for external PRs)

- Behavior addressed: Documentation now states that Gateway benchmark package scripts target the built `dist/entry.js` entry, describes startup/restart probes and metrics, and documents the restart benchmark's macOS/Linux SIGUSR1 requirement.
- Real environment tested: Local source checkout on macOS, Node/pnpm from the repo toolchain.
- Exact steps or command run after this patch: `node --import tsx scripts/bench-gateway-startup.ts --help`; `node --import tsx scripts/bench-gateway-restart.ts --help`; `pnpm changed:lanes --base upstream/main --head HEAD --json`; `git diff --check upstream/main..HEAD`; `pnpm docs:list`; `python3 /Users/x/.agents/skills/codex-review/scripts/run_codex_review.py --commit HEAD`.
- Evidence after fix: Copied terminal output from the local source checkout:

```text
$ node --import tsx scripts/bench-gateway-startup.ts --help
Options:
  --entry <path>       Gateway CLI entry file (default: dist/entry.js)
Case ids:
  default (gateway default)
  skipChannels (gateway, skip channels)
  oneInternalHook (gateway, one configured internal hook)
  allInternalHooks (gateway, all internal hooks)
  fiftyPlugins (gateway, 50 manifest plugins)
  fiftyStartupLazyPlugins (gateway, 50 startup-lazy manifest plugins)

$ node --import tsx scripts/bench-gateway-restart.ts --help
Options:
  --entry <path>           Gateway CLI entry file (default: dist/entry.js)
Case ids:
  skipChannels (gateway restart, skip channels)
  skipChannelsAcpxProbe (gateway restart, skip channels, ACPX startup probe on)
  skipChannelsNoAcpxProbe (gateway restart, skip channels, ACPX startup probe off)
  default (gateway restart, default)
  fiftyPlugins (gateway restart, 50 manifest plugins)

$ pnpm changed:lanes --base upstream/main --head HEAD --json
{
  "paths": ["docs/cli/gateway.md", "docs/reference/test.md"],
  "lanes": { "docs": true, "all": false },
  "docsOnly": true
}

$ python3 /Users/x/.agents/skills/codex-review/scripts/run_codex_review.py --commit HEAD
The commit only adds documentation for existing gateway benchmark scripts, and the documented commands, defaults, platform limitations, and probe semantics align with the current scripts and gateway readiness behavior.
```

- Observed result after fix: The documented benchmark default entry, flags, case IDs, docs-only scope, and readiness/probe semantics match the current scripts and gateway behavior.
- What was not tested: I did not run full benchmark timing samples, because this PR changes documentation only.

## Root Cause (if applicable)

N/A

## Regression Test Plan (if applicable)

N/A

## User-visible / Behavior Changes

Docs only. Users now see the Gateway benchmark prerequisites, supported restart platforms, case IDs, and probe/metric semantics.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Local source checkout
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Open `docs/cli/gateway.md` and `docs/reference/test.md`.
2. Confirm the Gateway benchmark docs list the built-entry prerequisite, startup/restart commands, case IDs, output semantics, and restart platform requirement.
3. Run the docs and changed-lane checks listed above.

### Expected

Docs describe the benchmark contracts without implying the commands work before `pnpm build` or on Windows for restart.

### Actual

The updated docs include the built-entry prerequisite, restart macOS/Linux limit, and matching benchmark flags/case IDs.

## Evidence

- [x] Trace/log snippets

## Human Verification (required)

- Verified scenarios: `git diff --check upstream/main..HEAD`; `pnpm docs:list`; `pnpm changed:lanes --base upstream/main --head HEAD --json`; `codex review --commit HEAD`.
- Edge cases checked: Startup benchmark default entry, restart benchmark default entry, restart platform support, and benchmark help/case IDs.
- What you did **not** verify: Full benchmark timing runs.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

None
