### PR TITLE
fix(memory-core): inject temporal context into dream diary prompt [AI-assisted]

### DIFF
--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -123,6 +123,51 @@ describe("buildNarrativePrompt", () => {
     expect(prompt).toContain("snippet-11");
     expect(prompt).not.toContain("snippet-12");
   });
+
+  it("renders without temporal context when none is provided (issue #83830 regression)", () => {
+    const prompt = buildNarrativePrompt({ phase: "light", snippets: ["a"] });
+    expect(prompt).not.toContain("Context:");
+    expect(prompt).not.toContain("Previously written diary entries");
+  });
+
+  it("injects current date, day count, and previous entries when provided", () => {
+    const prompt = buildNarrativePrompt({
+      phase: "light",
+      snippets: ["fragment-a"],
+      currentDate: "May 19, 2026",
+      dayCount: 4,
+      previousEntries: ["Day 1: first meeting in a dim hallway", "Day 2: short walk by the river"],
+    });
+    expect(prompt).toContain("Context:");
+    expect(prompt).toContain("Today is May 19, 2026.");
+    expect(prompt).toContain("This is day 4 of the dream diary.");
+    expect(prompt).toContain(
+      "Previously written diary entries (avoid repeating these openings or phrasing):",
+    );
+    expect(prompt).toContain("Day 1: first meeting in a dim hallway");
+    expect(prompt).toContain("Day 2: short walk by the river");
+    expect(prompt).toContain('Do not open with a "first day"');
+  });
+
+  it("caps previous entries at 5 and skips empty/whitespace entries", () => {
+    const previousEntries = [
+      "entry-0",
+      "   ",
+      "entry-1",
+      "entry-2",
+      "entry-3",
+      "entry-4",
+      "entry-5",
+    ];
+    const prompt = buildNarrativePrompt({
+      phase: "light",
+      snippets: ["fragment"],
+      previousEntries,
+    });
+    expect(prompt).toContain("entry-0");
+    expect(prompt).toContain("entry-4");
+    expect(prompt).not.toContain("entry-5");
+  });
 });
 
 describe("extractNarrativeText", () => {

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import type { Dirent } from "node:fs";
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { createAsyncLock } from "openclaw/plugin-sdk/async-lock-runtime";
@@ -52,6 +53,18 @@ export type NarrativePhaseData = {
   themes?: string[];
   /** Snippets that were promoted to durable memory (deep). */
   promotions?: string[];
+  /**
+   * Temporal context fed to the narrative model so each diary entry knows
+   * which day it is and what was already written.  Without this the prompt
+   * had no way to honor the "vary each entry" instruction and every sweep
+   * regenerated the same "first day" framing (see issue #83830).
+   */
+  /** Current date in human-readable form (e.g. "May 19, 2026"). */
+  currentDate?: string;
+  /** 1-based day number of this diary entry. */
+  dayCount?: number;
+  /** Short snippets (first line / heading) of previously written diary entries, most-recent first. */
+  previousEntries?: string[];
 };
 
 type Logger = {
@@ -258,6 +271,25 @@ function buildNarrativeSessionKey(params: {
 
 export function buildNarrativePrompt(data: NarrativePhaseData): string {
   const lines: string[] = [];
+
+  // Temporal context comes first so the model anchors itself in time before
+  // reading memory fragments.  When recall is dominated by early "first
+  // meeting" snippets, this is the only signal the model has that today is
+  // not actually day 1 (see issue #83830).
+  const hasDate = typeof data.currentDate === "string" && data.currentDate.length > 0;
+  const hasDay =
+    typeof data.dayCount === "number" && Number.isFinite(data.dayCount) && data.dayCount > 0;
+  if (hasDate || hasDay) {
+    lines.push("Context:");
+    if (hasDate) {
+      lines.push(`- Today is ${data.currentDate}.`);
+    }
+    if (hasDay) {
+      lines.push(`- This is day ${data.dayCount} of the dream diary.`);
+    }
+    lines.push("");
+  }
+
   lines.push("Write a dream diary entry from these memory fragments:\n");
 
   for (const snippet of data.snippets.slice(0, 12)) {
@@ -276,6 +308,19 @@ export function buildNarrativePrompt(data: NarrativePhaseData): string {
     for (const promo of data.promotions.slice(0, 5)) {
       lines.push(`- ${promo}`);
     }
+  }
+
+  const prevEntries = data.previousEntries?.filter(
+    (entry) => typeof entry === "string" && entry.trim().length > 0,
+  );
+  if (prevEntries && prevEntries.length > 0) {
+    lines.push("\nPreviously written diary entries (avoid repeating these openings or phrasing):");
+    for (const entry of prevEntries.slice(0, 5)) {
+      lines.push(`- ${entry.trim()}`);
+    }
+    lines.push(
+      '\nDo not open with a "first day" or "waking up for the first time" framing unless this truly is day 1, and do not echo the wording of the previous entries above.',
+    );
   }
 
   return lines.join("\n");
@@ -876,6 +921,64 @@ async function scrubDreamingNarrativeArtifacts(logger: Logger): Promise<void> {
   }
 }
 
+/**
+ * Read existing diary blocks from DREAMS.md and extract short snippets of the
+ * most recent entries plus the next day number.  Best-effort and synchronous
+ * so it can run before the subagent call without adding extra event-loop
+ * ticks that callers (notably runDetachedDreamNarrative) rely on for
+ * test-time ordering.
+ */
+function readDiaryTemporalContextSync(workspaceDir: string): {
+  dayCount: number;
+  previousEntries: string[];
+} {
+  try {
+    let dreamsPath: string | null = null;
+    for (const name of DREAMS_FILENAMES) {
+      const candidate = path.join(workspaceDir, name);
+      try {
+        fsSync.accessSync(candidate);
+        dreamsPath = candidate;
+        break;
+      } catch {
+        // try next filename
+      }
+    }
+    if (!dreamsPath) {
+      return { dayCount: 1, previousEntries: [] };
+    }
+    let existing = "";
+    try {
+      existing = fsSync.readFileSync(dreamsPath, "utf-8");
+    } catch {
+      return { dayCount: 1, previousEntries: [] };
+    }
+    const startIdx = existing.indexOf(DIARY_START_MARKER);
+    const endIdx = existing.indexOf(DIARY_END_MARKER);
+    if (startIdx < 0 || endIdx < 0 || endIdx < startIdx) {
+      return { dayCount: 1, previousEntries: [] };
+    }
+    const inner = existing.slice(startIdx + DIARY_START_MARKER.length, endIdx);
+    const blocks = splitDiaryBlocks(inner);
+    const previousEntries: string[] = [];
+    for (const block of [...blocks].reverse()) {
+      const firstLine = block
+        .split("\n")
+        .map((line) => line.trim())
+        .find((line) => line.length > 0 && !line.startsWith("<!--") && !line.startsWith("#"));
+      if (firstLine) {
+        previousEntries.push(firstLine.slice(0, 200));
+      }
+      if (previousEntries.length >= 5) {
+        break;
+      }
+    }
+    return { dayCount: blocks.length + 1, previousEntries };
+  } catch {
+    return { dayCount: 1, previousEntries: [] };
+  }
+}
+
 export async function generateAndAppendDreamNarrative(params: {
   subagent: SubagentSurface;
   workspaceDir: string;
@@ -896,7 +999,18 @@ export async function generateAndAppendDreamNarrative(params: {
     phase: params.data.phase,
     nowMs,
   });
-  const message = buildNarrativePrompt(params.data);
+  // Enrich phase data with temporal context so the narrative does not repeat
+  // the "first day" framing every sweep (see issue #83830).  Reads DREAMS.md
+  // to count existing entries and surface short snippets of the most recent
+  // ones; falls back gracefully when no diary exists yet.
+  const temporal = readDiaryTemporalContextSync(params.workspaceDir);
+  const enrichedData: NarrativePhaseData = {
+    ...params.data,
+    currentDate: params.data.currentDate ?? formatNarrativeDate(nowMs, params.timezone),
+    dayCount: params.data.dayCount ?? temporal.dayCount,
+    previousEntries: params.data.previousEntries ?? temporal.previousEntries,
+  };
+  const message = buildNarrativePrompt(enrichedData);
   const attempts: Array<{ sessionKey: string; runId: string | null }> = [];
   let successfulSessionKey: string | null = null;
   try {
@@ -912,7 +1026,7 @@ export async function generateAndAppendDreamNarrative(params: {
           subagent: params.subagent,
           sessionKey: attemptSessionKey,
           message,
-          data: params.data,
+          data: enrichedData,
           workspaceDir: params.workspaceDir,
           nowMs,
           timezone: params.timezone,


### PR DESCRIPTION
> 🤖 AI-assisted (built with Codex via Hermes orchestration). Test level: lightly tested. Prompt summary available on request.

## Summary
- Problem: Every dream diary entry written by the dreaming sweep opens with the same "first day" / "初次见面" framing, because the prompt has no temporal context and the short-term recall store keeps surfacing the earliest "first meeting" snippets at the top of the candidate list.
- Why it matters: The diary becomes useless for users running long-lived agents — DREAMS.md fills with near-duplicate Day-1 narratives regardless of how many sweeps have run.
- What changed: `buildNarrativePrompt()` in `extensions/memory-core/src/dreaming-narrative.ts` now optionally takes `currentDate`, `dayCount`, and `previousEntries`. `generateAndAppendDreamNarrative()` populates those fields synchronously from `DREAMS.md` so the model sees today's date, which day this is, recent entry snippets, and an explicit instruction not to repeat their openings unless this truly is day 1.
- What did NOT change (scope boundary): Recall scoring in `short-term-promotion.ts` is untouched (the reporter listed it as one of three contributing factors but it is a separate, larger change). The diary file format, markers, dedupe pipeline, and detached-narrative scheduling are all untouched.

## Change Type (select all)
- [x] Bug fix

## Scope (select all touched areas)
- [x] Extensions

## Linked Issue/PR
- Closes #83830
- [x] This PR fixes a bug or regression

## Root Cause
- Root cause: `buildNarrativePrompt()` fed the model only memory fragments, themes, and promotions. The system prompt says "vary each entry" but the model has no way to know what was written before, what day it is, or which openings to avoid. Combined with the recall store favoring early "first meeting" snippets, every sweep produced another Day-1 narrative.
- Missing detection / guardrail: No unit test asserted that the narrative prompt either includes temporal context or warns the model away from a "first day" framing. The existing tests only verified that snippets/themes/promotions are rendered.
- Contributing context (if known): Recall scoring sorts by `recallCount + lastRecalledAt`, which gives Day-1 memories a persistent feedback loop — out of scope for this PR but worth tracking.

## Regression Test Plan
- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `extensions/memory-core/src/dreaming-narrative.test.ts` (`describe("buildNarrativePrompt")`).
- Scenario the test should lock in: When `currentDate`, `dayCount`, and `previousEntries` are provided, the rendered prompt contains a `Context:` block with the date and day number, lists each previous entry, and includes the explicit "Do not open with a 'first day' …" instruction. Also: legacy callers passing only `phase`/`snippets`/`themes`/`promotions` get the same prompt as before, and previous-entry rendering caps at 5 entries while skipping whitespace-only ones.
- Why this is the smallest reliable guardrail: The fix is purely prompt construction; locking the new lines into the prompt string is the most direct check that a future refactor will not silently drop the temporal context again.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes
- Dream diary entries now reference today's date and day number, and explicitly avoid repeating recent entry openings. Visible only in DREAMS.md content; no API, config, or storage format change.

## Security Impact (required)
- New permissions/capabilities? No
- Pure in-process string construction plus an additional best-effort synchronous read of an existing `DREAMS.md` inside the same workspace directory the dreaming pipeline already reads and writes. No new file paths, network calls, or capabilities are introduced; all I/O errors are swallowed and degrade to the previous prompt shape.
