### PR TITLE
fix(feishu): eliminate streaming card content duplication

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -244,6 +244,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   let streamingStartPromise: Promise<void> | null = null;
   let streamingClosedForReply = false;
   let streamingCloseErroredForReply = false;
+  let suppressOnPartialReply = false;
   type StreamTextUpdateMode = "snapshot" | "delta";
 
   const formatReasoningPrefix = (thinking: string): string => {
@@ -516,6 +517,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         deliveredFinalTexts.clear();
         streamingClosedForReply = false;
         streamingCloseErroredForReply = false;
+        suppressOnPartialReply = false;
         if (streamingEnabled && renderMode === "card") {
           startStreaming();
         }
@@ -584,6 +586,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
             if (info?.kind === "block") {
               // Some runtimes emit block payloads without onPartial/final callbacks.
               // Mirror block text into streamText so onIdle close still sends content.
+              // Suppress onPartialReply updates to avoid racing with block delivery.
+              suppressOnPartialReply = true;
               queueStreamingUpdate(text, { mode: "delta", dedupeWithLastPartial: true });
             }
             if (info?.kind === "final") {
@@ -675,6 +679,9 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       onPartialReply: streamingEnabled
         ? (payload: ReplyPayload) => {
             if (!payload.text) {
+              return;
+            }
+            if (suppressOnPartialReply) {
               return;
             }
             const cleaned = stripReasoningTagsFromText(payload.text, {

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -429,14 +429,13 @@ export class FeishuStreamingSession {
     if (!this.state || this.closed) {
       return;
     }
-    const mergedInput = mergeStreamingText(this.pendingText ?? this.state.currentText, text);
-    if (!mergedInput || mergedInput === this.state.currentText) {
+    if (!text || text === this.state.currentText) {
       return;
     }
-    this.pendingText = mergedInput;
+    this.pendingText = text;
     this.clearFlushTimer();
 
-    const shouldForceUpdate = shouldPushStreamingUpdate(this.state.currentText, mergedInput);
+    const shouldForceUpdate = shouldPushStreamingUpdate(this.state.currentText, text);
     const now = Date.now();
     if (!shouldForceUpdate && now - this.lastUpdateTime < this.updateThrottleMs) {
       this.schedulePendingFlush();
@@ -448,7 +447,7 @@ export class FeishuStreamingSession {
       if (!this.state || this.closed) {
         return;
       }
-      const nextText = this.pendingText ?? mergedInput;
+      const nextText = this.pendingText ?? text;
       if (!nextText || nextText === this.state.currentText) {
         return;
       }

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -449,21 +449,20 @@ export class FeishuStreamingSession {
         return;
       }
       const nextText = this.pendingText ?? mergedInput;
-      const mergedText = mergeStreamingText(this.state.currentText, nextText);
-      if (!mergedText || mergedText === this.state.currentText) {
+      if (!nextText || nextText === this.state.currentText) {
         return;
       }
-      const appendContent = resolveStreamingCardAppendContent(this.state.sentText, mergedText);
+      const appendContent = resolveStreamingCardAppendContent(this.state.sentText, nextText);
       if (!appendContent) {
         return;
       }
       this.pendingText = null;
-      this.state.currentText = mergedText;
+      this.state.currentText = nextText;
       const sent = await this.updateCardContent(appendContent, (e) =>
         this.log?.(`Update failed: ${String(e)}`),
       );
       if (sent && this.state) {
-        this.state.sentText = mergedText;
+        this.state.sentText = nextText;
       }
     });
     await this.queue;


### PR DESCRIPTION
## Problem

Feishu streaming card messages show duplicated content during streaming — earlier text reappears concatenated with newer text. Content corrects itself only when the stream finishes (via `close()`).

## Root Cause

`FeishuStreamingSession.update(text)` calls:

```javascript
const mergedInput = mergeStreamingText(this.pendingText ?? this.state.currentText, text);
this.pendingText = mergedInput;
```

`text` is `buildCombinedStreamText(reasoningText, streamText)` — the full combined snapshot. When reasoning text changes between consecutive calls, the two combined strings diverge mid-string (e.g. `"> reasoning A\n\nanswer"` vs `"> reasoning B\n\nanswer more"`). Neither is a prefix or suffix of the other, so `mergeStreamingText` falls back to **concatenation**: `previousFull + newFull`. This poisoned value is stored in `pendingText` and sent directly to `updateCardContent`, producing duplicated card content.

The queue callback then reads `this.pendingText` (the poisoned concatenated string) and passes it to `updateCardContent`. `close()` does a fresh final replace with the correct text, which is why duplicates disappear at the end.

## Fix (2 commits)

**Commit 1 — `reply-dispatcher.ts`:** Add `suppressOnPartialReply` flag to prevent `onPartialReply` snapshot updates from racing with block-delta updates in `message_tool_only` mode (group-chat room events, introduced in 5.16).

**Commit 2 — `streaming-card.ts`:** Remove `mergeStreamingText` from `update()`'s entry path entirely. `text` is already the authoritative latest snapshot from `buildCombinedStreamText`. Store it directly in `pendingText` with no merge — the queue reads the latest pending value and calls `updateCardContent` (full PUT replace), so accumulative merging is both redundant and harmful.

```typescript
// Before
const mergedInput = mergeStreamingText(this.pendingText ?? this.state.currentText, text);
if (!mergedInput || mergedInput === this.state.currentText) return;
this.pendingText = mergedInput;

// After
if (!text || text === this.state.currentText) return;
this.pendingText = text;
```

## Testing

Verified locally against `@openclaw/feishu` v2026.5.12 (community plugin) with a group-chat room event trigger using an extended-thinking model. Before the fix: card content repeated on every reasoning token flush. After: clean incremental updates throughout streaming with no duplication.