### PR TITLE
fix(update): harden managed handoff cwd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/update: start managed Gateway update handoff helpers from a stable existing directory and tolerate deleted cwd/package roots during macOS LaunchAgent handoff. Fixes #83808. (#83875) Thanks @jason-allen-oneal.
 - Cron: honor `cron.retry.retryOn: ["network"]` for common network error codes such as `EAI_AGAIN`, `EHOSTUNREACH`, and `ENETUNREACH`.
 - Agents/OpenAI: preserve structured provider error code, type, and redacted body metadata on boundary-aware transport failures.
 - CLI/agents: retry transient normal-close Gateway handshakes before falling back to embedded `openclaw agent` execution.

--- a/src/gateway/server-methods/update-managed-service-handoff.test.ts
+++ b/src/gateway/server-methods/update-managed-service-handoff.test.ts
@@ -162,12 +162,14 @@ describe("managed service update handoff", () => {
     expect(args).toHaveLength(2);
     tempDirs.add(path.dirname(args[0] ?? result.logPath));
     const helperParams = JSON.parse(await fs.readFile(args[1] ?? "", "utf-8")) as {
+      cwd?: string;
       metaPath?: string;
       sentinelPath?: string;
     };
     expect(helperParams.metaPath).toMatch(/sentinel-meta\.json$/u);
     expect(helperParams.sentinelPath).toMatch(/restart-sentinel\.json$/u);
-    expect(options.cwd).toBe("/tmp/openclaw");
+    expect(options.cwd).toBe(os.homedir());
+    expect(helperParams.cwd).toBe(os.homedir());
     expect(options.detached).toBe(true);
     expect(options.env.KEEP_ME).toBe("1");
     for (const [key, value] of Object.entries(serviceIdentityEnv)) {

--- a/src/gateway/server-methods/update-managed-service-handoff.ts
+++ b/src/gateway/server-methods/update-managed-service-handoff.ts
@@ -21,6 +21,7 @@ const SERVICE_IDENTITY_ENV_VARS = new Set<string>([
 const HANDOFF_SCRIPT = String.raw`
 const { spawn } = require("node:child_process");
 const fs = require("node:fs");
+const os = require("node:os");
 const path = require("node:path");
 
 const params = JSON.parse(fs.readFileSync(process.argv[2], "utf-8"));
@@ -60,6 +61,23 @@ function cleanupSensitiveFiles() {
       // Best effort only.
     }
   }
+}
+
+function resolveExistingDirectory(candidates) {
+  for (const candidate of candidates) {
+    if (!candidate || typeof candidate !== "string") {
+      continue;
+    }
+    try {
+      const stat = fs.statSync(candidate);
+      if (stat.isDirectory()) {
+        return candidate;
+      }
+    } catch {
+      // Try the next candidate.
+    }
+  }
+  return undefined;
 }
 
 function readJsonFile(filePath) {
@@ -170,8 +188,18 @@ function markUpdateSentinelFailureIfPending(reason) {
   let outputFd;
   try {
     outputFd = fs.openSync(params.logPath, "a", 0o600);
+    const commandCwd =
+      resolveExistingDirectory([
+        params.cwd,
+        os.homedir(),
+        os.tmpdir(),
+        path.parse(process.execPath).root,
+      ]) || params.cwd;
+    if (commandCwd !== params.cwd) {
+      appendLog("managed update command cwd fallback: " + params.cwd + " -> " + commandCwd);
+    }
     const child = spawn(params.commandArgv[0], params.commandArgv.slice(1), {
-      cwd: params.cwd,
+      cwd: commandCwd,
       env: process.env,
       detached: true,
       stdio: ["ignore", outputFd, outputFd],
@@ -273,6 +301,24 @@ export function stripSupervisorHintEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEn
   return next;
 }
 
+async function resolveManagedServiceHandoffCwd(root: string): Promise<string> {
+  const candidates = [os.homedir(), os.tmpdir(), path.dirname(process.execPath), root];
+  for (const candidate of candidates) {
+    if (!candidate.trim()) {
+      continue;
+    }
+    try {
+      const stat = await fs.stat(candidate);
+      if (stat.isDirectory()) {
+        return candidate;
+      }
+    } catch {
+      // Try the next candidate.
+    }
+  }
+  return root;
+}
+
 export async function startManagedServiceUpdateHandoff(params: {
   root: string;
   timeoutMs?: number;
@@ -295,6 +341,7 @@ export async function startManagedServiceUpdateHandoff(params: {
     argv1: params.argv1 ?? process.argv[1],
   });
   const commandLabel = formatManagedServiceUpdateCommand(params.timeoutMs);
+  const handoffCwd = await resolveManagedServiceHandoffCwd(params.root);
   const metaFile: ControlPlaneUpdateSentinelMetaFile = {
     version: 1,
     meta: params.meta,
@@ -302,7 +349,7 @@ export async function startManagedServiceUpdateHandoff(params: {
   const helperParams = {
     parentPid: params.parentPid ?? process.pid,
     parentExitTimeoutMs: Math.max(0, params.restartDelayMs ?? 0) + PARENT_EXIT_GRACE_MS,
-    cwd: params.root,
+    cwd: handoffCwd,
     commandArgv,
     commandLabel,
     handoffId: params.handoffId,
@@ -322,7 +369,7 @@ export async function startManagedServiceUpdateHandoff(params: {
     OPENCLAW_UPDATE_RUN_HANDOFF: "1",
   };
   const child = spawn(params.execPath ?? process.execPath, [scriptPath, paramsPath], {
-    cwd: params.root,
+    cwd: handoffCwd,
     env,
     detached: true,
     stdio: "ignore",

--- a/src/gateway/server-methods/update.test.ts
+++ b/src/gateway/server-methods/update.test.ts
@@ -416,6 +416,31 @@ describe("update.run restart scheduling", () => {
     );
   });
 
+  it("starts managed package handoff when the gateway cwd is unavailable", async () => {
+    detectRespawnSupervisorMock.mockReturnValueOnce("launchd");
+    resolveUpdateInstallSurfaceMock.mockResolvedValueOnce({
+      kind: "global",
+      mode: "npm",
+      root: "/tmp/openclaw-global",
+      packageRoot: "/tmp/openclaw-global",
+    });
+    const cwdSpy = vi.spyOn(process, "cwd").mockImplementation(() => {
+      throw Object.assign(new Error("uv_cwd"), { code: "ENOENT", syscall: "uv_cwd" });
+    });
+    try {
+      await invokeUpdateRun({});
+    } finally {
+      cwdSpy.mockRestore();
+    }
+
+    expect(startManagedServiceUpdateHandoffMock).toHaveBeenCalledTimes(1);
+    expect(startManagedServiceUpdateHandoffMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        root: "/tmp/openclaw",
+      }),
+    );
+  });
+
   it("keeps git/dev updates on the in-process gateway update path", async () => {
     runGatewayUpdateMock.mockResolvedValueOnce({
       status: "ok",

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import os from "node:os";
 import { isRestartEnabled } from "../../config/commands.flags.js";
 import { extractDeliveryInfo } from "../../config/sessions.js";
 import { resolveOpenClawPackageRoot } from "../../infra/openclaw-root.js";
@@ -33,6 +34,14 @@ function formatUpdateRunErrorMessage(err: unknown): string {
     return err.message || err.name;
   }
   return String(err);
+}
+
+function tryResolveProcessCwd(): string | undefined {
+  try {
+    return process.cwd();
+  } catch {
+    return undefined;
+  }
 }
 
 export const updateHandlers: GatewayRequestHandlers = {
@@ -82,12 +91,15 @@ export const updateHandlers: GatewayRequestHandlers = {
     try {
       const config = context.getRuntimeConfig();
       const configChannel = normalizeUpdateChannel(config.update?.channel);
+      const invocationCwd = tryResolveProcessCwd();
       const root =
         (await resolveOpenClawPackageRoot({
           moduleUrl: import.meta.url,
           argv1: process.argv[1],
-          cwd: process.cwd(),
-        })) ?? process.cwd();
+          ...(invocationCwd ? { cwd: invocationCwd } : {}),
+        })) ??
+        invocationCwd ??
+        os.homedir();
       const installSurface = await resolveUpdateInstallSurface({
         timeoutMs,
         cwd: root,

--- a/src/infra/is-main.test.ts
+++ b/src/infra/is-main.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { isMainModule } from "./is-main.js";
 
 describe("isMainModule", () => {
@@ -11,6 +11,23 @@ describe("isMainModule", () => {
         env: {},
       }),
     ).toBe(true);
+  });
+
+  it("falls back to the current file directory when process.cwd is unavailable", () => {
+    const cwdSpy = vi.spyOn(process, "cwd").mockImplementation(() => {
+      throw Object.assign(new Error("uv_cwd"), { code: "ENOENT", syscall: "uv_cwd" });
+    });
+    try {
+      expect(
+        isMainModule({
+          currentFile: "/repo/dist/index.js",
+          argv: ["node", "/repo/dist/index.js"],
+          env: {},
+        }),
+      ).toBe(true);
+    } finally {
+      cwdSpy.mockRestore();
+    }
   });
 
   it("returns true under PM2 when pm_exec_path matches current file", () => {

--- a/src/infra/is-main.ts
+++ b/src/infra/is-main.ts
@@ -25,15 +25,24 @@ function normalizePathCandidate(candidate: string | undefined, cwd: string): str
   }
 }
 
+function resolveDefaultCwd(currentFile: string): string {
+  try {
+    return process.cwd();
+  } catch {
+    return path.dirname(currentFile);
+  }
+}
+
 export function isMainModule({
   currentFile,
   argv = process.argv,
   env = process.env,
-  cwd = process.cwd(),
+  cwd,
   wrapperEntryPairs = [],
 }: IsMainModuleOptions): boolean {
-  const normalizedCurrent = normalizePathCandidate(currentFile, cwd);
-  const normalizedArgv1 = normalizePathCandidate(argv[1], cwd);
+  const resolvedCwd = cwd ?? resolveDefaultCwd(currentFile);
+  const normalizedCurrent = normalizePathCandidate(currentFile, resolvedCwd);
+  const normalizedArgv1 = normalizePathCandidate(argv[1], resolvedCwd);
 
   if (normalizedCurrent && normalizedArgv1 && normalizedCurrent === normalizedArgv1) {
     return true;
@@ -41,7 +50,7 @@ export function isMainModule({
 
   // PM2 runs the script via an internal wrapper; `argv[1]` points at the wrapper.
   // PM2 exposes the actual script path in `pm_exec_path`.
-  const normalizedPmExecPath = normalizePathCandidate(env.pm_exec_path, cwd);
+  const normalizedPmExecPath = normalizePathCandidate(env.pm_exec_path, resolvedCwd);
   if (normalizedCurrent && normalizedPmExecPath && normalizedCurrent === normalizedPmExecPath) {
     return true;
   }

--- a/src/infra/npm-install-env.ts
+++ b/src/infra/npm-install-env.ts
@@ -110,8 +110,16 @@ function readNpmGlobalConfigPath(
 }
 
 function resolveScopedProjectNpmrc(scope: NpmFreshnessConfigScope): string | null {
-  const cwd = scope.npmConfigCwd?.trim() || process.cwd();
-  return cwd ? path.join(cwd, ".npmrc") : null;
+  const scopedCwd = scope.npmConfigCwd?.trim();
+  if (scopedCwd) {
+    return path.join(scopedCwd, ".npmrc");
+  }
+  try {
+    const cwd = process.cwd();
+    return cwd ? path.join(cwd, ".npmrc") : null;
+  } catch {
+    return null;
+  }
 }
 
 function resolveScopedGlobalNpmrc(scope: NpmFreshnessConfigScope): string | null {

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -348,6 +348,30 @@ describe("runGatewayUpdate", () => {
     expect(calls.filter((call) => call.includes("rebase"))).toEqual([]);
   });
 
+  it("uses the supplied update cwd when the process cwd disappeared", async () => {
+    await setupGitCheckout();
+    const cwdSpy = vi.spyOn(process, "cwd").mockImplementation(() => {
+      throw Object.assign(new Error("ENOENT: uv_cwd"), { code: "ENOENT" });
+    });
+    const { runner, calls } = createRunner({
+      ...buildGitWorktreeProbeResponses(),
+      [`git -C ${tempDir} rev-parse --abbrev-ref --symbolic-full-name @{upstream}`]: {
+        code: 1,
+        stderr: "no upstream configured",
+      },
+    });
+
+    try {
+      const result = await runWithRunner(runner);
+
+      expect(result.status).toBe("skipped");
+      expect(result.reason).toBe("no-upstream");
+      expect(calls).toContain(`git -C ${tempDir} rev-parse --show-toplevel`);
+    } finally {
+      cwdSpy.mockRestore();
+    }
+  });
+
   it.each([
     { name: "upstream", options: {} },
     { name: "target ref", options: { devTargetRef: "main" } },

--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -227,7 +227,12 @@ function buildStartDirs(opts: UpdateRunnerOptions): string[] {
       dirs.push(packageRoot);
     }
   }
-  const proc = normalizeDir(process.cwd());
+  let proc: string | null = null;
+  try {
+    proc = normalizeDir(process.cwd());
+  } catch {
+    proc = null;
+  }
   if (proc) {
     dirs.push(proc);
   }


### PR DESCRIPTION
## Summary
- run managed service update helper and updater processes from an existing stable cwd instead of a package root/current cwd that may have disappeared during self-update
- make the early `isMainModule(...)` startup guard tolerate `ENOENT`/`uv_cwd` when the process cwd has disappeared
- add regression coverage for both the handoff cwd and early startup cwd fallback paths

## Verification
- node scripts/run-oxlint.mjs src/gateway/server-methods/update-managed-service-handoff.test.ts src/gateway/server-methods/update-managed-service-handoff.ts src/gateway/server-methods/update.test.ts src/gateway/server-methods/update.ts src/infra/is-main.test.ts src/infra/is-main.ts
- node scripts/run-vitest.mjs src/gateway/server-methods/update-managed-service-handoff.test.ts src/gateway/server-methods/update.test.ts src/infra/is-main.test.ts
- node --import tsx /tmp/openclaw-pr83875-real-smoke-worktree.mjs
- git diff --check

## Not Run
- Live macOS LaunchAgent managed-update smoke; this environment is Linux and cannot exercise launchd.

## Real behavior proof

- Behavior or issue addressed: Managed package update handoff should keep working when the gateway process cwd or package root disappears, and early startup `isMainModule(...)` should not throw when `process.cwd()` raises `ENOENT`/`uv_cwd`.
- Real environment tested: Linux 6.19.14+kali-amd64 isolated worktree at pushed commit `d7314b2295`; Node v22.22.2; pnpm 11.1.0. The smoke removed the live process cwd to trigger `uv_cwd`, then started a real managed update handoff helper with a missing package root and a harmless mock update script.
- Exact steps or command run after this patch:
  1. `node scripts/run-oxlint.mjs src/gateway/server-methods/update-managed-service-handoff.test.ts src/gateway/server-methods/update-managed-service-handoff.ts src/gateway/server-methods/update.test.ts src/gateway/server-methods/update.ts src/infra/is-main.test.ts src/infra/is-main.ts`
  2. `node scripts/run-vitest.mjs src/gateway/server-methods/update-managed-service-handoff.test.ts src/gateway/server-methods/update.test.ts src/infra/is-main.test.ts`
  3. `node --import tsx /tmp/openclaw-pr83875-real-smoke-worktree.mjs`
- Evidence after fix: Terminal stdout from the real smoke command:
  ```json
  {
    "cwdThrows": true,
    "isMainResult": true,
    "missingPackageRootExists": false,
    "handoffStatus": "started",
    "handoffPidType": "number",
    "handoffCommand": "openclaw update --yes --timeout 1",
    "logContainsExitZero": true,
    "commandCwd": "/home/rev",
    "commandCwdExists": true,
    "commandCwdIsMissingPackageRoot": false,
    "logExcerpt": "[2026-05-19T04:07:11.241Z] starting managed update command: openclaw update --yes --timeout 1
managed-command-cwd=/home/rev
managed-command-argv=["update","--yes","--json","--timeout","1"]
[2026-05-19T04:07:11.268Z] managed update command exited code=0 signal=null"
  }
  ```
  Targeted checks also passed: oxlint reported `Found 0 warnings and 0 errors`; vitest reported `Test Files 5 passed (5)` and `Tests 55 passed (55)`.
- Observed result after fix: With the current process cwd removed, `process.cwd()` threw `ENOENT` but `isMainModule(...)` returned true using the current-file directory fallback. The managed handoff started from a missing package root, selected an existing stable cwd (`/home/rev`) instead of the missing root, ran the mock update command there, and the helper log recorded `managed update command exited code=0 signal=null`.
- What was not tested: Did not run a live macOS LaunchAgent, Linux systemd user service, or Windows scheduled task update. The smoke used the same handoff helper path with a harmless mock update command instead of running a real package update.

Fixes openclaw/openclaw#83808

## Current-head proof refresh (2026-05-19)

Pushed commit `0fa523cee2c99aa661ca21472bacaf2529fd138b` closes the remaining cwd-path blocker: `runGatewayUpdate` now tolerates `process.cwd()` throwing `ENOENT: uv_cwd` in both update-runner candidate gathering and npm install environment setup, then proceeds from the supplied update cwd.

Commands run at that head:
- `node scripts/run-oxlint.mjs src/infra/npm-install-env.ts src/infra/update-runner.ts src/infra/update-runner.test.ts src/gateway/server-methods/update-managed-service-handoff.test.ts src/gateway/server-methods/update-managed-service-handoff.ts src/gateway/server-methods/update.test.ts src/gateway/server-methods/update.ts src/infra/is-main.test.ts src/infra/is-main.ts` -> 0 warnings, 0 errors.
- `pnpm exec oxfmt --check --threads=1 src/infra/npm-install-env.ts src/infra/update-runner.ts src/infra/update-runner.test.ts src/gateway/server-methods/update-managed-service-handoff.test.ts src/gateway/server-methods/update-managed-service-handoff.ts src/gateway/server-methods/update.test.ts src/gateway/server-methods/update.ts src/infra/is-main.test.ts src/infra/is-main.ts` -> all matched files use the correct format.
- `node scripts/run-vitest.mjs src/infra/update-runner.test.ts src/gateway/server-methods/update-managed-service-handoff.test.ts src/gateway/server-methods/update.test.ts src/infra/is-main.test.ts` -> 6 test files passed, 99 tests passed.
- `git diff --check` -> passed.

Regression proof detail: the new `runGatewayUpdate` test mocks `process.cwd()` to throw `ENOENT: uv_cwd` and verifies the real update-runner path still probes the supplied `cwd` (`git -C <tempDir> rev-parse --show-toplevel`) and exits cleanly as `skipped/no-upstream` rather than crashing before handoff.

Not run: live macOS LaunchAgent managed-update smoke; this Linux host cannot exercise launchd.

Independent diff review passed with no security concerns or logic errors.
