### PR TITLE
fix(config): include maximum in ceiling validation errors

### DIFF
--- a/src/config/validation.allowed-values.test.ts
+++ b/src/config/validation.allowed-values.test.ts
@@ -81,6 +81,18 @@ describe("config validation allowed-values metadata", () => {
     }
   });
 
+  it("includes maximum values in ceiling rejection messages", () => {
+    const result = validateConfigObjectRaw({
+      session: { agentToAgent: { maxPingPongTurns: 21 } },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      const issue = requireIssue(result.issues, "session.agentToAgent.maxPingPongTurns");
+      expect(issue.message).toBe("Too big: expected number to be <=20 (maximum: 20)");
+    }
+  });
+
   it("surfaces specific sub-issue for invalid_union bindings errors instead of generic 'Invalid input'", () => {
     const result = validateConfigObjectRaw({
       bindings: [

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -543,10 +543,24 @@ export function collectUnsupportedSecretRefPolicyIssues(raw: unknown): ConfigVal
   return collectUnsupportedMutableSecretRefIssues(raw);
 }
 
+function formatZodIssueMessage(record: UnknownIssueRecord | null): string {
+  const message = typeof record?.message === "string" ? record.message : "Invalid input";
+  if (record?.code !== "too_big") {
+    return message;
+  }
+
+  const maximum = record.maximum;
+  if (typeof maximum !== "number" && typeof maximum !== "bigint") {
+    return message;
+  }
+
+  return `${message} (maximum: ${maximum})`;
+}
+
 function mapZodIssueToConfigIssue(issue: unknown): ConfigValidationIssue {
   const record = toIssueRecord(issue);
   const path = formatConfigPath(toConfigPathSegments(record?.path));
-  const message = typeof record?.message === "string" ? record.message : "Invalid input";
+  const message = formatZodIssueMessage(record);
 
   const allowedValuesSummary = summarizeAllowedValues(collectAllowedValuesFromUnknownIssue(issue));
 


### PR DESCRIPTION
## Summary

- Include Zod ceiling metadata in config validation issue messages for `too_big` schema failures.
- Add regression coverage for `session.agentToAgent.maxPingPongTurns` showing the maximum allowed value in the operator-facing error.

## Tests

- `node --no-maglev node_modules/vitest/vitest.mjs run src/config/validation.allowed-values.test.ts -t "includes maximum values"` (RED before implementation)
- `node --no-maglev node_modules/vitest/vitest.mjs run src/config/validation.allowed-values.test.ts`
- `node_modules/.bin/oxfmt --check src/config/validation.ts src/config/validation.allowed-values.test.ts`
- `node scripts/run-oxlint.mjs src/config/validation.ts src/config/validation.allowed-values.test.ts`
- `git diff --check`

## Verification

Behavior addressed: Config schema ceiling rejections now append the concrete maximum value exposed by Zod `too_big` issues.
Real environment tested: Local macOS checkout on branch `fix/config-max-error-message`.
Exact steps or command run after this patch: `node --no-maglev node_modules/vitest/vitest.mjs run src/config/validation.allowed-values.test.ts`; `node_modules/.bin/oxfmt --check src/config/validation.ts src/config/validation.allowed-values.test.ts`; `node scripts/run-oxlint.mjs src/config/validation.ts src/config/validation.allowed-values.test.ts`; `git diff --check`.
Evidence after fix: `src/config/validation.allowed-values.test.ts` passed 8/8 tests; oxfmt and oxlint exited 0; `git diff --check` exited 0.
Observed result after fix: The validation issue for `session.agentToAgent.maxPingPongTurns: 21` is `Too big: expected number to be <=20 (maximum: 20)`.
What was not tested: Full `pnpm check:changed`; local pnpm dependency reconciliation attempted installs and timed out on registry optional package downloads.

Closes #52500
