### PR TITLE
Guard final delivery session refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ Docs: https://docs.openclaw.ai
 - Discord/subagents: route the initial reply from thread-bound delegated sessions into the bound Discord thread instead of the parent channel. Fixes #83170. (#83172) Thanks @100menotu001.
 - Gateway/sessions: rotate failed agent sessions when their transcript file is missing instead of wedging per-channel lanes. Fixes #83488. (#83553) Thanks @LLagoon3.
 - Agents: refresh final-delivery routing from fresh session state before declaring a no-send failure, keeping recovered runs on the normal durable delivery path. (#83835) Thanks @joshavant.
+- Agents: guard final-delivery fresh session routing against mismatched logical sessions before reusing recovered delivery context. (#83928) Thanks @joshavant.
 - Media: prevent image metadata probing from invoking external decoder delegates on unrecognized image bytes, and stop fallback chaining after real processing errors.
 - Media: install Sharp with the root package and fall back to sips, Windows native imaging, ImageMagick, GraphicsMagick, or ffmpeg for image resizing/conversion when Sharp is unavailable. Fixes #83401. Thanks @scotthuang.
 - Telegram: deliver generated media completions back into forum topics by preserving topic IDs across requester-agent handoff. (#83556) Thanks @fuller-stack-dev.

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -1533,23 +1533,32 @@ async function agentCommandInternal(
               clone: false,
             });
             const freshEntry = freshStore[sessionKey];
-            if (freshEntry) {
-              sessionStore[sessionKey] = freshEntry;
+            if (!freshEntry || freshEntry.sessionId !== sessionId) {
+              return undefined;
             }
+            sessionStore[sessionKey] = freshEntry;
             return freshEntry;
           }
         : undefined;
-    const deliveryResult = await deliverAgentCommandResult({
+    const deliveryParams = {
       cfg,
       deps: resolvedDeps,
       runtime,
       opts,
       outboundSession,
       sessionEntry,
-      resolveFreshSessionEntryForDelivery,
       result,
       payloads,
-    });
+    };
+    const deliveryResult = await deliverAgentCommandResult(
+      resolveFreshSessionEntryForDelivery
+        ? {
+            ...deliveryParams,
+            expectedSessionIdForFreshDelivery: sessionId,
+            resolveFreshSessionEntryForDelivery,
+          }
+        : deliveryParams,
+    );
 
     // Phase 2: Clear pending delivery payload after successful delivery.
     if (

--- a/src/agents/command/delivery.test.ts
+++ b/src/agents/command/delivery.test.ts
@@ -363,7 +363,7 @@ describe("normalizeAgentCommandReplyPayloads", () => {
       opts: {
         message: "go",
         deliver: true,
-        channel: "slack",
+        bestEffortDeliver: true,
         sessionKey: "agent:tester:main",
       } as AgentCommandOpts,
       outboundSession: {
@@ -374,6 +374,7 @@ describe("normalizeAgentCommandReplyPayloads", () => {
         sessionId: "session-1",
         updatedAt: 1,
       },
+      expectedSessionIdForFreshDelivery: "session-1",
       resolveFreshSessionEntryForDelivery,
       payloads: [{ text: "final answer" }],
       result: createResult(),
@@ -392,6 +393,59 @@ describe("normalizeAgentCommandReplyPayloads", () => {
       status: "sent",
       succeeded: true,
       resultCount: 1,
+    });
+  });
+
+  it("does not refresh final delivery routing from a different logical session", async () => {
+    deliverOutboundPayloadsMock.mockResolvedValue([{ channel: "slack", messageId: "msg-1" }]);
+    const runtime = { log: vi.fn(), error: vi.fn() };
+    const resolveFreshSessionEntryForDelivery = vi.fn(async () => ({
+      sessionId: "session-2",
+      updatedAt: 2,
+      deliveryContext: {
+        channel: "slack",
+        to: "#fresh",
+        accountId: "workspace-1",
+      },
+    }));
+
+    const delivered = await deliverAgentCommandResult({
+      cfg: {
+        agents: {
+          list: [{ id: "tester", workspace: "/tmp/agent-workspace" }],
+        },
+      } as OpenClawConfig,
+      deps: {} as CliDeps,
+      runtime: runtime as never,
+      opts: {
+        message: "go",
+        deliver: true,
+        bestEffortDeliver: true,
+        sessionKey: "agent:tester:main",
+      } as AgentCommandOpts,
+      outboundSession: {
+        key: "agent:tester:main",
+        agentId: "tester",
+      } as never,
+      sessionEntry: {
+        sessionId: "session-1",
+        updatedAt: 1,
+      },
+      expectedSessionIdForFreshDelivery: "session-1",
+      resolveFreshSessionEntryForDelivery,
+      payloads: [{ text: "final answer" }],
+      result: createResult(),
+    });
+
+    expect(resolveFreshSessionEntryForDelivery).toHaveBeenCalledTimes(1);
+    expect(deliverOutboundPayloadsMock).not.toHaveBeenCalled();
+    expect(delivered.deliverySucceeded).toBe(false);
+    expectDeliveryStatusFields(delivered, {
+      requested: true,
+      attempted: false,
+      status: "failed",
+      succeeded: false,
+      reason: "channel_resolved_to_internal",
     });
   });
 

--- a/src/agents/command/delivery.ts
+++ b/src/agents/command/delivery.ts
@@ -73,6 +73,42 @@ export type AgentCommandDeliveryResult = {
 
 const NESTED_LOG_PREFIX = "[agent:nested]";
 
+type FreshSessionEntryForDeliveryResolver = () => Promise<SessionEntry | undefined>;
+
+type FreshSessionDeliveryRefreshParams =
+  | {
+      expectedSessionIdForFreshDelivery: string;
+      resolveFreshSessionEntryForDelivery: FreshSessionEntryForDeliveryResolver;
+    }
+  | {
+      expectedSessionIdForFreshDelivery?: string;
+      resolveFreshSessionEntryForDelivery?: undefined;
+    };
+
+type DeliverAgentCommandResultParams = {
+  cfg: OpenClawConfig;
+  deps: CliDeps;
+  runtime: RuntimeEnv;
+  opts: AgentCommandOpts;
+  outboundSession: OutboundSessionContext | undefined;
+  sessionEntry: SessionEntry | undefined;
+  result: RunResult;
+  payloads: RunResult["payloads"];
+} & FreshSessionDeliveryRefreshParams;
+
+function normalizeDeliverySessionId(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function isFreshDeliverySessionMatch(
+  freshSessionEntry: SessionEntry,
+  expectedSessionId: string | undefined,
+): boolean {
+  const normalizedExpected = normalizeDeliverySessionId(expectedSessionId);
+  return Boolean(normalizedExpected && freshSessionEntry.sessionId === normalizedExpected);
+}
+
 function formatNestedLogPrefix(opts: AgentCommandOpts, sessionKey?: string): string {
   const parts = [NESTED_LOG_PREFIX];
   const session = sessionKey ?? opts.sessionKey ?? opts.sessionId;
@@ -331,17 +367,9 @@ export function normalizeAgentCommandReplyPayloads(params: {
   return normalizedPayloads;
 }
 
-export async function deliverAgentCommandResult(params: {
-  cfg: OpenClawConfig;
-  deps: CliDeps;
-  runtime: RuntimeEnv;
-  opts: AgentCommandOpts;
-  outboundSession: OutboundSessionContext | undefined;
-  sessionEntry: SessionEntry | undefined;
-  resolveFreshSessionEntryForDelivery?: () => Promise<SessionEntry | undefined>;
-  result: RunResult;
-  payloads: RunResult["payloads"];
-}): Promise<AgentCommandDeliveryResult> {
+export async function deliverAgentCommandResult(
+  params: DeliverAgentCommandResultParams,
+): Promise<AgentCommandDeliveryResult> {
   const { cfg, deps, runtime, opts, outboundSession, sessionEntry, payloads, result } = params;
   const effectiveSessionKey = outboundSession?.key ?? opts.sessionKey;
   const deliver = opts.deliver === true;
@@ -467,7 +495,13 @@ export async function deliverAgentCommandResult(params: {
   let deliveryRouting = await resolveDeliveryRouting(sessionEntry);
   if (isRetryableFreshSessionRoutingFailure(deliveryRouting)) {
     const freshSessionEntry = await params.resolveFreshSessionEntryForDelivery?.();
-    if (freshSessionEntry && freshSessionEntry !== sessionEntry) {
+    const expectedFreshSessionId =
+      params.expectedSessionIdForFreshDelivery ?? sessionEntry?.sessionId;
+    if (
+      freshSessionEntry &&
+      freshSessionEntry !== sessionEntry &&
+      isFreshDeliverySessionMatch(freshSessionEntry, expectedFreshSessionId)
+    ) {
       const freshRouting = await resolveDeliveryRouting(freshSessionEntry);
       if (!deliveryRoutingFailureReason(freshRouting)) {
         if (!opts.json) {


### PR DESCRIPTION
## Summary
- guard final-delivery fresh session routing so refreshed delivery context is only accepted for the same logical `sessionId`
- add delivery regression coverage for mismatched fresh session entries refusing to send stale final payloads

## Verification
- `node scripts/run-vitest.mjs src/agents/command/delivery.test.ts src/commands/agent.delivery.test.ts`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/review-core.tsbuildinfo`
- `git diff --check`
- `AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --mode local --reviewer claude --fallback-reviewer none`

## Real behavior proof
Behavior addressed: Prevents final-delivery fresh session routing from crossing logical session boundaries while preserving the intended same-session recovered-send path.
Real environment tested: AWS Crabbox direct provider `cbx_9de1ea120140` (`run_58cd2d895bc1`) using Convex-leased `discord` credential, role `ci`.
Exact steps or command run after this patch: Installed Node 24.15.0 and repo dependencies on the AWS Crabbox, then ran `CI=1 OPENCLAW_QA_CREDENTIAL_SOURCE=convex OPENCLAW_PROOF_GIT_HEAD="$REMOTE_HEAD" corepack pnpm exec tsx scripts/dev/issue-83835-discord-final-delivery-refresh-proof.ts --output-dir=.artifacts/qa-e2e/issue-83835-discord-final-delivery-refresh`.
Evidence after fix: Downloaded summary artifact at `.artifacts/qa-e2e/issue-83835-discord-final-delivery-refresh/summary-aws.json`; same-session marker `ISSUE_83835_FINAL_REFRESH_C0EDD6F0` was observed in Discord from the SUT bot, while mismatched-session marker `ISSUE_83835_FINAL_MISMATCH_191C1F1E` was not observed.
Observed result after fix: Same-session fresh route delivered with `status=sent`, `attempted=true`; mismatched fresh route with a different `sessionId` stayed fail-closed with `status=failed`, `attempted=false`, `deliverySucceeded=false`, and no Discord message observed.
What was not tested: The exact original issue #83744 progress/fallback-loss report was not re-reproduced here; this proof covers the #83835 hardening path and the same-session/mismatched-session delivery boundary.
