### PR TITLE
fix: retry config snapshot after rejection

### DIFF
--- a/src/cli/program/config-guard.test.ts
+++ b/src/cli/program/config-guard.test.ts
@@ -130,6 +130,31 @@ describe("ensureConfigReady", () => {
     );
   });
 
+  it("retries the cached config snapshot after a read rejection", async () => {
+    const originalVitest = process.env.VITEST;
+    process.env.VITEST = "false";
+    const transientError = new Error("temporary config read failure");
+    const recoveredSnapshot = makeSnapshot();
+    readConfigFileSnapshotMock
+      .mockRejectedValueOnce(transientError)
+      .mockResolvedValueOnce(recoveredSnapshot);
+
+    try {
+      await expect(runEnsureConfigReady(["status"])).rejects.toThrow(transientError);
+      await expect(runEnsureConfigReady(["status"])).resolves.toBeDefined();
+      await expect(runEnsureConfigReady(["status"])).resolves.toBeDefined();
+    } finally {
+      if (originalVitest === undefined) {
+        delete process.env.VITEST;
+      } else {
+        process.env.VITEST = originalVitest;
+      }
+    }
+
+    expect(readConfigFileSnapshotMock).toHaveBeenCalledTimes(2);
+    expect(setRuntimeConfigSnapshotMock).toHaveBeenCalledWith(undefined, undefined);
+  });
+
   it("exits for invalid config on non-allowlisted commands", async () => {
     setInvalidSnapshot();
     const runtime = await runEnsureConfigReady(["message"]);

--- a/src/cli/program/config-guard.ts
+++ b/src/cli/program/config-guard.ts
@@ -30,7 +30,15 @@ async function getConfigSnapshot() {
   if (process.env.VITEST === "true") {
     return readConfigFileSnapshot();
   }
-  configSnapshotPromise ??= readConfigFileSnapshot();
+  if (!configSnapshotPromise) {
+    const pendingSnapshot = readConfigFileSnapshot();
+    configSnapshotPromise = pendingSnapshot;
+    pendingSnapshot.catch(() => {
+      if (configSnapshotPromise === pendingSnapshot) {
+        configSnapshotPromise = null;
+      }
+    });
+  }
   return configSnapshotPromise;
 }
 


### PR DESCRIPTION
## Summary

- Problem: `getConfigSnapshot()` cached the first `readConfigFileSnapshot()` promise forever, including rejected promises.
- Solution: clear the cached promise when the in-flight snapshot read rejects, while keeping successful snapshot reuse intact.
- What changed: added a focused regression test for transient read rejection -> retry -> successful cache reuse, and updated the cache path to drop only the rejected in-flight promise.
- What did NOT change (scope boundary): no config schema, CLI command allowlist, or runtime snapshot semantics changed beyond retrying after a failed read.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #83855
- Related #83855
- [x] This PR fixes a bug or regression

## Motivation

- A transient config snapshot read failure should not poison the process for later CLI preflight calls. After the underlying read can succeed again, `ensureConfigReady()` should retry instead of reusing the already-rejected promise.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: transient `readConfigFileSnapshot()` rejection no longer permanently poisons the cached config snapshot promise.
- Real environment tested: local OpenClaw checkout on macOS 26.4.1, Node v24.15.0.
- Exact steps or command run after this patch:
  - `PATH=/opt/homebrew/opt/node@24/bin:/opt/homebrew/bin:$PATH node scripts/test-projects.mjs src/cli/program/config-guard.test.ts`
  - Manual runtime probe with Node's module mock: first config snapshot read rejects, second succeeds, third reuses the recovered cached success.
- Evidence after fix (copied terminal output):

```text
[test] starting test/vitest/vitest.cli.config.ts

 RUN  v4.1.6 /private/tmp/openclaw-83855-config-snapshot

 ✓  cli  src/cli/program/config-guard.test.ts (12 tests) 43ms

 Test Files  1 passed (1)
      Tests  12 passed (12)
   Start at  11:35:06
   Duration  318ms (transform 159ms, setup 151ms, import 38ms, tests 43ms, environment 0ms)

[test] passed 1 Vitest shard in 3.82s
```

Manual runtime probe output:

```text
{"reads":2,"results":["first:transient probe failure","second:recovered","third:cached-success"]}
```

- Observed result after fix: the first rejected snapshot propagates, the next call retries and succeeds, and later calls reuse the successful cached snapshot.
- What was not tested: full packaged binary / long-running production process.
- Before evidence (optional but encouraged): the new regression test fails against the previous `configSnapshotPromise ??= readConfigFileSnapshot()` implementation because the rejected promise stays cached.

## Root Cause (if applicable)

- Root cause: `configSnapshotPromise ??= readConfigFileSnapshot()` memoized the promise object without distinguishing fulfilled and rejected outcomes.
- Missing detection / guardrail: no regression covered the non-Vitest cached path when an initial snapshot read rejects.
- Contributing context (if known): tests usually bypass caching with `process.env.VITEST === "true"`, so this production cache behavior needed an explicit test toggle.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/cli/program/config-guard.test.ts`
- Scenario the test should lock in: first cached snapshot read rejects, a subsequent call retries and succeeds, and a third call reuses the successful cached snapshot.
- Why this is the smallest reliable guardrail: it exercises the `ensureConfigReady()` preflight seam and the production cache branch without broader CLI process setup.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- CLI config preflight can recover from a transient config snapshot read rejection within the same process instead of repeatedly failing with the original rejected promise.

## Diagram (if applicable)

```text
Before:
read rejects -> rejected promise remains cached -> later preflight reuses same rejection

After:
read rejects -> matching cached promise is cleared -> later preflight reads again -> success is cached
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS 26.4.1
- Runtime/container: local checkout, Node v24.15.0
- Model/provider: N/A
- Integration/channel (if any): CLI config guard
- Relevant config (redacted): N/A

### Steps

1. Mock `readConfigFileSnapshot()` to reject once and then resolve.
2. Run `ensureConfigReady(["status"])` once and observe the transient rejection.
3. Run `ensureConfigReady(["status"])` again and observe recovery, then run it a third time to confirm successful cache reuse.

### Expected

- The rejected snapshot promise is not retained after rejection.
- The next config preflight retries the read and can recover.
- Successful reads remain cached.

### Actual

- Matches expected after this patch.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - Focused Vitest file: `src/cli/program/config-guard.test.ts`
  - Manual runtime probe for reject -> retry -> cached success behavior using Node module mocking.
  - Formatting check for touched files via `node_modules/.bin/oxfmt --check src/cli/program/config-guard.ts src/cli/program/config-guard.test.ts`.
- Edge cases checked:
  - The cache is cleared only if the rejected promise is still the current cached promise.
  - A third successful call reuses the recovered cached promise instead of re-reading.
- What you did **not** verify:
  - Full repository test suite.
  - Packaged production binary.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: clearing the cache from an older rejected promise could race with a newer read.
  - Mitigation: the catch handler clears the module-level cache only when it still points at the same rejected promise object.
