### PR TITLE
Improve stale Codex auth recovery guidance

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -5271,34 +5271,12 @@ describe("runAgentTurnWithFallback", () => {
   });
 
   it("points stale openai-codex missing-key failures at doctor repair with re-auth fallback", async () => {
-    state.runEmbeddedPiAgentMock.mockRejectedValueOnce(
+    state.runEmbeddedAgentMock.mockRejectedValueOnce(
       new Error('No API key found for provider "openai-codex".'),
     );
 
     const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
-    const result = await runAgentTurnWithFallback({
-      commandBody: "hello",
-      followupRun: createFollowupRun(),
-      sessionCtx: {
-        Provider: "whatsapp",
-        MessageSid: "msg",
-      } as unknown as TemplateContext,
-      opts: {},
-      typingSignals: createMockTypingSignaler(),
-      blockReplyPipeline: null,
-      blockStreamingEnabled: false,
-      resolvedBlockStreamingBreak: "message_end",
-      applyReplyToMode: (payload) => payload,
-      shouldEmitToolResult: () => true,
-      shouldEmitToolOutput: () => false,
-      pendingToolTasks: new Set(),
-      resetSessionAfterCompactionFailure: async () => false,
-      resetSessionAfterRoleOrderingConflict: async () => false,
-      isHeartbeat: false,
-      sessionKey: "main",
-      getActiveSessionEntry: () => undefined,
-      resolvedVerboseLevel: "off",
-    });
+    const result = await runAgentTurnWithFallback(createMinimalRunAgentTurnParams());
 
     expect(result.kind).toBe("final");
     if (result.kind === "final") {

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -5270,6 +5270,44 @@ describe("runAgentTurnWithFallback", () => {
     }
   });
 
+  it("points stale openai-codex missing-key failures at doctor repair with re-auth fallback", async () => {
+    state.runEmbeddedPiAgentMock.mockRejectedValueOnce(
+      new Error('No API key found for provider "openai-codex".'),
+    );
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback({
+      commandBody: "hello",
+      followupRun: createFollowupRun(),
+      sessionCtx: {
+        Provider: "whatsapp",
+        MessageSid: "msg",
+      } as unknown as TemplateContext,
+      opts: {},
+      typingSignals: createMockTypingSignaler(),
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      pendingToolTasks: new Set(),
+      resetSessionAfterCompactionFailure: async () => false,
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      isHeartbeat: false,
+      sessionKey: "main",
+      getActiveSessionEntry: () => undefined,
+      resolvedVerboseLevel: "off",
+    });
+
+    expect(result.kind).toBe("final");
+    if (result.kind === "final") {
+      expect(result.payload.text).toBe(
+        "⚠️ The session is pointing at a stale OpenAI Codex auth route. Run `openclaw doctor --fix` to repair Codex model/session routes, restart the gateway if doctor asks, then try again. If doctor has nothing to repair or the error persists, re-auth with `openclaw models auth login --provider openai-codex` or run `openclaw configure`.",
+      );
+    }
+  });
+
   it("falls back to a generic provider message for unsafe missing-key provider ids", async () => {
     state.runEmbeddedAgentMock.mockRejectedValueOnce(
       new Error('No API key found for provider "openai`\nrm -rf /".'),

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -716,6 +716,9 @@ function buildMissingApiKeyFailureText(message: string): string | null {
   if (provider === "openai" && normalizedMessage.includes("OpenAI Codex OAuth")) {
     return "⚠️ Missing API key for OpenAI on the gateway. Use `openai/gpt-5.5` with the Codex OAuth profile, or set `OPENAI_API_KEY` for direct OpenAI API-key runs.";
   }
+  if (provider === "openai-codex") {
+    return "⚠️ The session is pointing at a stale OpenAI Codex auth route. Run `openclaw doctor --fix` to repair Codex model/session routes, restart the gateway if doctor asks, then try again. If doctor has nothing to repair or the error persists, re-auth with `openclaw models auth login --provider openai-codex` or run `openclaw configure`.";
+  }
   if (SAFE_MISSING_API_KEY_PROVIDERS.has(provider)) {
     return `⚠️ Missing API key for provider "${provider}". Configure the gateway auth for that provider, then try again.`;
   }

--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -1058,6 +1058,79 @@ describe("createModelSelectionState auto-failover overrides", () => {
     expect(state.resetModelOverride).toBe(false);
   });
 
+  it("clears stale auto-created legacy openai-codex route pins when primary is canonical openai", async () => {
+    const sessionEntry = makeEntry({
+      providerOverride: "openai-codex",
+      modelOverride: "gpt-5.5",
+      modelOverrideSource: "auto",
+      modelProvider: "openai-codex",
+      model: "gpt-5.5",
+      contextTokens: 350_000,
+      authProfileOverride: "openai-codex:default",
+      authProfileOverrideSource: "auto",
+    });
+    const sessionStore = { [sessionKey]: sessionEntry };
+
+    const state = await createModelSelectionState({
+      cfg: {} as OpenClawConfig,
+      agentCfg: undefined,
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      defaultProvider: "openai",
+      defaultModel: "gpt-5.5",
+      primaryProvider: "openai",
+      primaryModel: "gpt-5.5",
+      provider: "openai-codex",
+      model: "gpt-5.5",
+      hasModelDirective: false,
+    });
+
+    expect(state.provider).toBe("openai");
+    expect(state.model).toBe("gpt-5.5");
+    expect(state.resetModelOverride).toBe(true);
+    expect(state.resetModelOverrideRef).toBe("openai-codex/gpt-5.5");
+    expect(sessionStore[sessionKey]?.providerOverride).toBeUndefined();
+    expect(sessionStore[sessionKey]?.modelOverride).toBeUndefined();
+    expect(sessionStore[sessionKey]?.modelOverrideSource).toBeUndefined();
+    expect(sessionStore[sessionKey]?.modelProvider).toBeUndefined();
+    expect(sessionStore[sessionKey]?.model).toBeUndefined();
+    expect(sessionStore[sessionKey]?.contextTokens).toBeUndefined();
+    expect(sessionStore[sessionKey]?.authProfileOverride).toBeUndefined();
+    expect(sessionStore[sessionKey]?.authProfileOverrideSource).toBeUndefined();
+  });
+
+  it("keeps explicit user openai-codex route overrides", async () => {
+    const sessionEntry = makeEntry({
+      providerOverride: "openai-codex",
+      modelOverride: "gpt-5.5",
+      modelOverrideSource: "user",
+    });
+    const sessionStore = { [sessionKey]: sessionEntry };
+
+    const state = await createModelSelectionState({
+      cfg: {} as OpenClawConfig,
+      agentCfg: undefined,
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      defaultProvider: "openai",
+      defaultModel: "gpt-5.5",
+      primaryProvider: "openai",
+      primaryModel: "gpt-5.5",
+      provider: "openai",
+      model: "gpt-5.5",
+      hasModelDirective: false,
+    });
+
+    expect(state.provider).toBe("openai-codex");
+    expect(state.model).toBe("gpt-5.5");
+    expect(state.resetModelOverride).toBe(false);
+    expect(sessionStore[sessionKey]?.providerOverride).toBe("openai-codex");
+    expect(sessionStore[sessionKey]?.modelOverride).toBe("gpt-5.5");
+    expect(sessionStore[sessionKey]?.modelOverrideSource).toBe("user");
+  });
+
   it("still clears disallowed auto-failover overrides through allowlist validation", async () => {
     const cfg = {
       agents: {

--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -1100,6 +1100,91 @@ describe("createModelSelectionState auto-failover overrides", () => {
     expect(sessionStore[sessionKey]?.authProfileOverrideSource).toBeUndefined();
   });
 
+  it("preserves usable Codex auth while clearing stale legacy openai-codex route pins", async () => {
+    authProfileStoreMock.store = {
+      version: 1,
+      profiles: {
+        "openai-codex:default": {
+          type: "api_key",
+          provider: "openai-codex",
+          key: "test-key",
+        },
+      },
+    };
+    const sessionEntry = makeEntry({
+      providerOverride: "openai-codex",
+      modelOverride: "gpt-5.5",
+      modelOverrideSource: "auto",
+      authProfileOverride: "openai-codex:default",
+      authProfileOverrideSource: "auto",
+    });
+    const sessionStore = { [sessionKey]: sessionEntry };
+
+    const state = await createModelSelectionState({
+      cfg: {} as OpenClawConfig,
+      agentCfg: undefined,
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      defaultProvider: "openai",
+      defaultModel: "gpt-5.5",
+      primaryProvider: "openai",
+      primaryModel: "gpt-5.5",
+      provider: "openai-codex",
+      model: "gpt-5.5",
+      hasModelDirective: false,
+    });
+
+    expect(state.provider).toBe("openai");
+    expect(state.model).toBe("gpt-5.5");
+    expect(state.resetModelOverride).toBe(true);
+    expect(sessionStore[sessionKey]?.providerOverride).toBeUndefined();
+    expect(sessionStore[sessionKey]?.modelOverride).toBeUndefined();
+    expect(sessionStore[sessionKey]?.authProfileOverride).toBe("openai-codex:default");
+    expect(sessionStore[sessionKey]?.authProfileOverrideSource).toBe("auto");
+  });
+
+  it("keeps auto openai-codex pins when canonical openai uses a custom API route", async () => {
+    const cfg = {
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://proxy.example.test/v1",
+            models: [],
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const sessionEntry = makeEntry({
+      providerOverride: "openai-codex",
+      modelOverride: "gpt-5.5",
+      modelOverrideSource: "auto",
+    });
+    const sessionStore = { [sessionKey]: sessionEntry };
+
+    const state = await createModelSelectionState({
+      cfg,
+      agentCfg: undefined,
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      defaultProvider: "openai",
+      defaultModel: "gpt-5.5",
+      primaryProvider: "openai",
+      primaryModel: "gpt-5.5",
+      provider: "openai-codex",
+      model: "gpt-5.5",
+      hasModelDirective: false,
+    });
+
+    expect(state.provider).toBe("openai-codex");
+    expect(state.model).toBe("gpt-5.5");
+    expect(state.resetModelOverride).toBe(false);
+    expect(sessionStore[sessionKey]?.providerOverride).toBe("openai-codex");
+    expect(sessionStore[sessionKey]?.modelOverride).toBe("gpt-5.5");
+    expect(sessionStore[sessionKey]?.modelOverrideSource).toBe("auto");
+  });
+
   it("keeps explicit user openai-codex route overrides", async () => {
     const sessionEntry = makeEntry({
       providerOverride: "openai-codex",

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -19,7 +19,11 @@ import {
   createModelVisibilityPolicy,
   type ModelVisibilityPolicy,
 } from "../../agents/model-visibility-policy.js";
-import { listOpenAIAuthProfileProvidersForAgentRuntime } from "../../agents/openai-codex-routing.js";
+import {
+  OPENAI_CODEX_PROVIDER_ID,
+  OPENAI_PROVIDER_ID,
+  listOpenAIAuthProfileProvidersForAgentRuntime,
+} from "../../agents/openai-codex-routing.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { applyModelOverrideToSessionEntry } from "../../sessions/model-overrides.js";
@@ -195,6 +199,13 @@ export async function createModelSelectionState(params: {
     primaryProvider: params.primaryProvider,
     primaryModel: params.primaryModel,
   });
+  const staleLegacyOpenAICodexAutoOverride =
+    directStoredModelOverride?.source === "session" &&
+    sessionEntry?.modelOverrideSource === "auto" &&
+    normalizeProviderId(directStoredModelOverride.provider ?? "") === OPENAI_CODEX_PROVIDER_ID &&
+    normalizeProviderId(primaryProvider) === OPENAI_PROVIDER_ID &&
+    normalizeModelRef(OPENAI_PROVIDER_ID, directStoredModelOverride.model).model ===
+      normalizeModelRef(OPENAI_PROVIDER_ID, primaryModel).model;
 
   if (needsModelCatalog) {
     modelCatalog = await (await loadModelCatalogRuntime()).loadModelCatalog({ config: cfg });
@@ -238,11 +249,16 @@ export async function createModelSelectionState(params: {
       directStoredOverride.model,
     );
     const key = modelKey(normalizedOverride.provider, normalizedOverride.model);
-    if (staleHeartbeatAutoFallbackOverride || !visibilityPolicy.allowsKey(key)) {
+    if (
+      staleHeartbeatAutoFallbackOverride ||
+      staleLegacyOpenAICodexAutoOverride ||
+      !visibilityPolicy.allowsKey(key)
+    ) {
       const { updated } = applyModelOverrideToSessionEntry({
         entry: sessionEntry,
         selection: { provider: primaryProvider, model: primaryModel, isDefault: true },
-        preserveAuthProfileOverride: staleHeartbeatAutoFallbackOverride,
+        preserveAuthProfileOverride:
+          staleHeartbeatAutoFallbackOverride || staleLegacyOpenAICodexAutoOverride,
       });
       if (updated) {
         sessionStore[sessionKey] = sessionEntry;
@@ -277,6 +293,23 @@ export async function createModelSelectionState(params: {
       model = primaryModel;
     }
   }
+  if (staleLegacyOpenAICodexAutoOverride) {
+    const normalizedCurrentSelection = normalizeModelRef(provider, model);
+    const currentSelectionKey = modelKey(
+      normalizedCurrentSelection.provider,
+      normalizedCurrentSelection.model,
+    );
+    const normalizedDirectOverride = directStoredOverride
+      ? normalizeModelRef(directStoredOverride.provider, directStoredOverride.model)
+      : null;
+    const directStoredOverrideKey = normalizedDirectOverride
+      ? modelKey(normalizedDirectOverride.provider, normalizedDirectOverride.model)
+      : undefined;
+    if (currentSelectionKey === directStoredOverrideKey) {
+      provider = primaryProvider;
+      model = primaryModel;
+    }
+  }
 
   const storedOverride = resolveStoredModelOverride({
     sessionEntry,
@@ -292,7 +325,8 @@ export async function createModelSelectionState(params: {
   const skipStoredOverride =
     params.skipStoredModelOverride === true ||
     params.hasResolvedHeartbeatModelOverride === true ||
-    (staleHeartbeatAutoFallbackOverride && storedOverride?.source === "session");
+    (staleHeartbeatAutoFallbackOverride && storedOverride?.source === "session") ||
+    (staleLegacyOpenAICodexAutoOverride && storedOverride?.source === "session");
 
   if (storedOverride?.model && !skipStoredOverride) {
     const normalizedStoredOverride = normalizeRuntimeModelRef(

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -199,13 +199,23 @@ export async function createModelSelectionState(params: {
     primaryProvider: params.primaryProvider,
     primaryModel: params.primaryModel,
   });
+  const primaryHarnessPolicy = resolveAgentHarnessPolicy({
+    provider: primaryProvider,
+    modelId: primaryModel,
+    config: cfg,
+    agentId: params.agentId,
+    sessionKey,
+  });
   const staleLegacyOpenAICodexAutoOverride =
     directStoredModelOverride?.source === "session" &&
     sessionEntry?.modelOverrideSource === "auto" &&
     normalizeProviderId(directStoredModelOverride.provider ?? "") === OPENAI_CODEX_PROVIDER_ID &&
     normalizeProviderId(primaryProvider) === OPENAI_PROVIDER_ID &&
-    normalizeModelRef(OPENAI_PROVIDER_ID, directStoredModelOverride.model).model ===
-      normalizeModelRef(OPENAI_PROVIDER_ID, primaryModel).model;
+    primaryHarnessPolicy.runtime === "codex" &&
+    normalizeRuntimeModelRef(OPENAI_PROVIDER_ID, directStoredModelOverride.model).model ===
+      normalizeRuntimeModelRef(OPENAI_PROVIDER_ID, primaryModel).model;
+  const staleDirectStoredOverride =
+    staleHeartbeatAutoFallbackOverride || staleLegacyOpenAICodexAutoOverride;
 
   if (needsModelCatalog) {
     modelCatalog = await (await loadModelCatalogRuntime()).loadModelCatalog({ config: cfg });
@@ -249,16 +259,11 @@ export async function createModelSelectionState(params: {
       directStoredOverride.model,
     );
     const key = modelKey(normalizedOverride.provider, normalizedOverride.model);
-    if (
-      staleHeartbeatAutoFallbackOverride ||
-      staleLegacyOpenAICodexAutoOverride ||
-      !visibilityPolicy.allowsKey(key)
-    ) {
+    if (staleDirectStoredOverride || !visibilityPolicy.allowsKey(key)) {
       const { updated } = applyModelOverrideToSessionEntry({
         entry: sessionEntry,
         selection: { provider: primaryProvider, model: primaryModel, isDefault: true },
-        preserveAuthProfileOverride:
-          staleHeartbeatAutoFallbackOverride || staleLegacyOpenAICodexAutoOverride,
+        preserveAuthProfileOverride: staleDirectStoredOverride,
       });
       if (updated) {
         sessionStore[sessionKey] = sessionEntry;
@@ -276,7 +281,7 @@ export async function createModelSelectionState(params: {
       }
     }
   }
-  if (staleHeartbeatAutoFallbackOverride) {
+  if (staleDirectStoredOverride) {
     const normalizedCurrentSelection = normalizeRuntimeModelRef(provider, model);
     const currentSelectionKey = modelKey(
       normalizedCurrentSelection.provider,
@@ -284,23 +289,6 @@ export async function createModelSelectionState(params: {
     );
     const normalizedDirectOverride = directStoredOverride
       ? normalizeRuntimeModelRef(directStoredOverride.provider, directStoredOverride.model)
-      : null;
-    const directStoredOverrideKey = normalizedDirectOverride
-      ? modelKey(normalizedDirectOverride.provider, normalizedDirectOverride.model)
-      : undefined;
-    if (currentSelectionKey === directStoredOverrideKey) {
-      provider = primaryProvider;
-      model = primaryModel;
-    }
-  }
-  if (staleLegacyOpenAICodexAutoOverride) {
-    const normalizedCurrentSelection = normalizeModelRef(provider, model);
-    const currentSelectionKey = modelKey(
-      normalizedCurrentSelection.provider,
-      normalizedCurrentSelection.model,
-    );
-    const normalizedDirectOverride = directStoredOverride
-      ? normalizeModelRef(directStoredOverride.provider, directStoredOverride.model)
       : null;
     const directStoredOverrideKey = normalizedDirectOverride
       ? modelKey(normalizedDirectOverride.provider, normalizedDirectOverride.model)
@@ -325,8 +313,7 @@ export async function createModelSelectionState(params: {
   const skipStoredOverride =
     params.skipStoredModelOverride === true ||
     params.hasResolvedHeartbeatModelOverride === true ||
-    (staleHeartbeatAutoFallbackOverride && storedOverride?.source === "session") ||
-    (staleLegacyOpenAICodexAutoOverride && storedOverride?.source === "session");
+    (staleDirectStoredOverride && storedOverride?.source === "session");
 
   if (storedOverride?.model && !skipStoredOverride) {
     const normalizedStoredOverride = normalizeRuntimeModelRef(


### PR DESCRIPTION
## Summary

- Clear stale auto-created legacy `openai-codex/gpt-*` session route pins when the configured primary has migrated to canonical `openai/gpt-*`
- Preserve explicit user-selected `openai-codex` overrides while cleaning up stale automatic session state
- Add targeted recovery guidance when an agent run still fails with `No API key found for provider "openai-codex"`
- Keep `openclaw doctor --fix` as the first stale-route repair, with `openclaw models auth login --provider openai-codex` / `openclaw configure` as fallback guidance
- Cover both the stale session-pin prevention and the missing-key recovery text in regression tests

Fixes #83935.

## Real behavior proof

**Behavior or issue addressed:** A live Telegram group session on a real OpenClaw install failed after an update with the stale provider-auth message `Missing API key for provider "openai-codex"`. The working recovery was `openclaw doctor`, not configuring a new API key. This PR now does two things for that path: it prevents stale auto-created `openai-codex/gpt-*` session pins from being reused after migration to `openai/gpt-*`, and it improves the fallback user-facing error if a missing-key failure still gets through.

**Real environment tested:** OpenClaw gateway on Linux/systemd user service, Telegram group session, updated from `2026.5.12` to `2026.5.18`.

**Exact steps or command run after fix:**
1. Updated the live OpenClaw install.
2. Sent a Telegram group message to the existing main session.
3. Observed two failed assistant replies with `Missing API key for provider "openai-codex"`.
4. Ran `openclaw doctor`.
5. Verified the same live install had healthy model auth, active gateway, and responsive dashboard.

**Evidence after fix:**

```
Before repair, live Telegram session reply:
⚠️ Missing API key for provider "openai-codex". Configure the gateway auth for that provider, then try again.

After running doctor:

$ openclaw --version
OpenClaw 2026.5.18 (50a2481)

$ openclaw models list | grep -E '^(openai/gpt-5.5|codex/gpt-5.5)'
openai/gpt-5.5   text        195k  no  yes  default,fallback#1,configured
codex/gpt-5.5    text+image  266k  no  yes

$ systemctl --user is-active openclaw-gateway
active

$ curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:4000/
200
```

**After-patch safe runtime proof from the PR checkout:**

```
$ node --import tsx tmp-proof-stale-codex-message.mjs
⚠️ The session is pointing at a stale OpenAI Codex auth route. Run `openclaw doctor --fix` to repair Codex model/session routes, restart the gateway if doctor asks, then try again. If doctor has nothing to repair or the error persists, re-auth with `openclaw models auth login --provider openai-codex` or run `openclaw configure`.
```

The proof script imports the patched `buildKnownAgentRunFailureReplyPayload` and feeds it the exact real failure signature: `No API key found for provider "openai-codex"`.

**Observed result after fix:** The real setup recovered after doctor, confirming stale `openai-codex` route state should direct users to doctor repair. The source patch additionally clears matching stale automatic session pins before they can keep routing future turns through the legacy provider.

**What was not tested:** I did not install this branch into the live gateway and intentionally re-break the active Telegram session, because doing that would interrupt the working production assistant session again.

## Validation

- `node scripts/run-vitest.mjs src/auto-reply/reply/model-selection.test.ts`
- `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-execution.test.ts -t "points stale openai-codex missing-key failures at doctor repair"`
- `git diff --check`
- GitHub PR checks passed on head `4eaf34e3f5d71679b9d766e249c34a7b27447efa`


