### PR TITLE
feat(voice-call): add private outbound objectives

### DIFF
--- a/docs/cli/voicecall.md
+++ b/docs/cli/voicecall.md
@@ -17,8 +17,8 @@ When the Gateway is running, operational commands (`call`, `start`, `continue`, 
 ```bash
 openclaw voicecall setup    [--json]
 openclaw voicecall smoke    [-t <phone>] [--message <text>] [--mode <m>] [--yes] [--json]
-openclaw voicecall call     -m <text> [-t <phone>] [--mode <m>]
-openclaw voicecall start    --to <phone> [--message <text>] [--mode <m>]
+openclaw voicecall call     -m <text> [-t <phone>] [--mode <m>] [--objective <text>]
+openclaw voicecall start    --to <phone> [--message <text>] [--mode <m>] [--objective <text>]
 openclaw voicecall continue --call-id <id> --message <text>
 openclaw voicecall speak    --call-id <id> --message <text>
 openclaw voicecall dtmf     --call-id <id> --digits <digits>
@@ -39,7 +39,7 @@ openclaw voicecall expose   [--mode <m>] [--path <p>] [--port <port>] [--serve-p
 | `speak`    | Speak a message without waiting for a response.                 |
 | `dtmf`     | Send DTMF digits to an active call.                             |
 | `end`      | Hang up an active call.                                         |
-| `status`   | Inspect active calls (or one by `--call-id`).                   |
+| `status`   | Inspect active calls, or look up one by `--call-id`.            |
 | `tail`     | Tail `calls.jsonl` (useful during provider tests).              |
 | `latency`  | Summarize turn-latency metrics from `calls.jsonl`.              |
 | `expose`   | Toggle Tailscale serve/funnel for the webhook endpoint.         |
@@ -88,6 +88,7 @@ Initiate an outbound voice call.
 | `-m, --message <text>` | yes      | (none)            | Message to speak when the call connects.                                   |
 | `-t, --to <phone>`     | no       | config `toNumber` | E.164 phone number to call.                                                |
 | `--mode <mode>`        | no       | `conversation`    | Call mode: `notify` (hang up after message) or `conversation` (stay open). |
+| `--objective <text>`   | no       | (none)            | Private per-call objective for realtime task calls; not spoken as opener.  |
 
 ```bash
 openclaw voicecall call --to "+15555550123" --message "Hello"
@@ -98,11 +99,12 @@ openclaw voicecall call -m "Heads up" --mode notify
 
 Alias for `call` with a different default flag shape.
 
-| Flag               | Required | Default        | Description                              |
-| ------------------ | -------- | -------------- | ---------------------------------------- |
-| `--to <phone>`     | yes      | (none)         | Phone number to call.                    |
-| `--message <text>` | no       | (none)         | Message to speak when the call connects. |
-| `--mode <mode>`    | no       | `conversation` | Call mode: `notify` or `conversation`.   |
+| Flag                 | Required | Default        | Description                                                               |
+| -------------------- | -------- | -------------- | ------------------------------------------------------------------------- |
+| `--to <phone>`       | yes      | (none)         | Phone number to call.                                                     |
+| `--message <text>`   | no       | (none)         | Message to speak when the call connects.                                  |
+| `--mode <mode>`      | no       | `conversation` | Call mode: `notify` or `conversation`.                                    |
+| `--objective <text>` | no       | (none)         | Private per-call objective for realtime task calls; not spoken as opener. |
 
 ### `continue`
 
@@ -141,12 +143,12 @@ Hang up an active call.
 
 ### `status`
 
-Inspect active calls.
+Inspect active calls. When `--call-id` is provided, `status` first checks active calls, then searches the 100 most recent persisted call records by OpenClaw call ID or provider call ID.
 
-| Flag             | Default | Description                  |
-| ---------------- | ------- | ---------------------------- |
-| `--call-id <id>` | (none)  | Restrict output to one call. |
-| `--json`         | `false` | Print machine-readable JSON. |
+| Flag             | Default | Description                                  |
+| ---------------- | ------- | -------------------------------------------- |
+| `--call-id <id>` | (none)  | Look up one active or recent completed call. |
+| `--json`         | `false` | Print machine-readable JSON.                 |
 
 ```bash
 openclaw voicecall status

--- a/docs/plugins/voice-call.md
+++ b/docs/plugins/voice-call.md
@@ -726,6 +726,7 @@ Example with a stable public host:
 ```bash
 openclaw voicecall call --to "+15555550123" --message "Hello from OpenClaw"
 openclaw voicecall start --to "+15555550123"   # alias for call
+openclaw voicecall start --to "+15555550123" --message "Hola, buenas tardes" --objective "Book a table for 2 tomorrow at 8pm."
 openclaw voicecall continue --call-id <id> --message "Any questions?"
 openclaw voicecall speak --call-id <id> --message "One moment"
 openclaw voicecall dtmf --call-id <id> --digits "ww123456#"
@@ -750,31 +751,35 @@ for turn latency and listen-wait times.
 
 Tool name: `voice_call`.
 
-| Action          | Args                                       |
-| --------------- | ------------------------------------------ |
-| `initiate_call` | `message`, `to?`, `mode?`, `dtmfSequence?` |
-| `continue_call` | `callId`, `message`                        |
-| `speak_to_user` | `callId`, `message`                        |
-| `send_dtmf`     | `callId`, `digits`                         |
-| `end_call`      | `callId`                                   |
-| `get_status`    | `callId`                                   |
+| Action          | Args                                                     |
+| --------------- | -------------------------------------------------------- |
+| `initiate_call` | `message`, `to?`, `mode?`, `objective?`, `dtmfSequence?` |
+| `continue_call` | `callId`, `message`                                      |
+| `speak_to_user` | `callId`, `message`                                      |
+| `send_dtmf`     | `callId`, `digits`                                       |
+| `end_call`      | `callId`                                                 |
+| `get_status`    | `callId`                                                 |
 
 This repo ships a matching skill doc at `skills/voice-call/SKILL.md`.
 
 ## Gateway RPC
 
-| Method               | Args                                       |
-| -------------------- | ------------------------------------------ |
-| `voicecall.initiate` | `to?`, `message`, `mode?`, `dtmfSequence?` |
-| `voicecall.continue` | `callId`, `message`                        |
-| `voicecall.speak`    | `callId`, `message`                        |
-| `voicecall.dtmf`     | `callId`, `digits`                         |
-| `voicecall.end`      | `callId`                                   |
-| `voicecall.status`   | `callId`                                   |
+| Method               | Args                                                     |
+| -------------------- | -------------------------------------------------------- |
+| `voicecall.initiate` | `to?`, `message`, `mode?`, `objective?`, `dtmfSequence?` |
+| `voicecall.continue` | `callId`, `message`                                      |
+| `voicecall.speak`    | `callId`, `message`                                      |
+| `voicecall.dtmf`     | `callId`, `digits`                                       |
+| `voicecall.end`      | `callId`                                                 |
+| `voicecall.status`   | `callId`                                                 |
 
 `dtmfSequence` is only valid with `mode: "conversation"`. Notify-mode calls
 should use `voicecall.dtmf` after the call exists if they need post-connect
 digits.
+
+`objective` is private call context for realtime task calls. It is not spoken
+as the opener. OpenClaw stores it in internal call metadata for the active call,
+but status/tool/CLI readback redacts it from returned call records.
 
 ## Troubleshooting
 

--- a/extensions/voice-call/README.md
+++ b/extensions/voice-call/README.md
@@ -122,8 +122,10 @@ streaming speech on calls. Override examples and provider caveats live here:
 
 ```bash
 openclaw voicecall call --to "+15555550123" --message "Hello from OpenClaw"
+openclaw voicecall call --to "+15555550123" --message "Hello" --objective "Book a table for 2 tomorrow at 8pm."
 openclaw voicecall continue --call-id <id> --message "Any questions?"
 openclaw voicecall speak --call-id <id> --message "One moment"
+openclaw voicecall dtmf --call-id <id> --digits "ww123456#"
 openclaw voicecall end --call-id <id>
 openclaw voicecall status --json
 openclaw voicecall status --call-id <id>
@@ -137,17 +139,19 @@ Tool name: `voice_call`
 
 Actions:
 
-- `initiate_call` (message, to?, mode?)
+- `initiate_call` (message, to?, mode?, objective?, dtmfSequence?)
 - `continue_call` (callId, message)
 - `speak_to_user` (callId, message)
+- `send_dtmf` (callId, digits)
 - `end_call` (callId)
 - `get_status` (callId)
 
 ## Gateway RPC
 
-- `voicecall.initiate` (to?, message, mode?)
+- `voicecall.initiate` (to?, message, mode?, objective?, dtmfSequence?)
 - `voicecall.continue` (callId, message)
 - `voicecall.speak` (callId, message)
+- `voicecall.dtmf` (callId, digits)
 - `voicecall.end` (callId)
 - `voicecall.status` (callId)
 
@@ -160,6 +164,12 @@ Actions:
 - Voice-call auto-responses enforce a spoken JSON contract (`{"spoken":"..."}`) and filter reasoning/meta output before playback.
 - While a Twilio stream is active, playback does not fall back to TwiML `<Say>`; stream-TTS failures fail the playback request.
 - Outbound conversation calls suppress barge-in only while the initial greeting is actively speaking, then re-enable normal interruption.
+- `objective` is private call context for realtime task calls. It is not
+  spoken as the opener. OpenClaw stores it in internal call metadata for the
+  active call, but status/tool/CLI readback redacts it from returned call
+  records.
+- `dtmfSequence` is only valid for conversation-mode calls; use
+  `voicecall.dtmf` after connect for notify-mode calls.
 - Twilio stream disconnect auto-end uses a short grace window so quick reconnects do not end the call.
 - Realtime provider selection is generic. Configure `streaming.provider` / `realtime.provider` and put provider-owned options under `providers.<id>`.
 - Runtime fallback still accepts the old voice-call keys for now, but migration is a doctor step and the compat shim is scheduled to go away in a future release.

--- a/extensions/voice-call/index.test.ts
+++ b/extensions/voice-call/index.test.ts
@@ -174,6 +174,15 @@ function firstRuntimeConfig(): VoiceCallRuntime["config"] | undefined {
   return options?.config;
 }
 
+function managerMocks() {
+  return runtimeStub.manager as unknown as {
+    getCall: ReturnType<typeof vi.fn>;
+    getCallByProviderCallId: ReturnType<typeof vi.fn>;
+    getActiveCalls: ReturnType<typeof vi.fn>;
+    getCallHistory: ReturnType<typeof vi.fn>;
+  };
+}
+
 function expectWarningIncludes(text: string): void {
   expect(noopLogger.warn.mock.calls.map(([message]) => String(message)).join("\n")).toContain(text);
 }
@@ -488,6 +497,109 @@ describe("voice-call plugin", () => {
     const [ok, payload] = firstRespondCall(respond);
     expect(ok).toBe(true);
     expect(payload?.found).toBe(true);
+  });
+
+  it("redacts private objectives from status readback", async () => {
+    const privateCall = createCallRecord({
+      callId: "private-call",
+      metadata: {
+        initialMessage: "Hola, buenas tardes.",
+        objective: "Book a restaurant table.",
+      },
+    });
+    managerMocks().getCall.mockReturnValue(privateCall);
+    managerMocks().getActiveCalls.mockReturnValue([privateCall]);
+
+    const { methods } = setup({ provider: "mock" });
+    const handler = methods.get("voicecall.status") as
+      | ((ctx: {
+          params: Record<string, unknown>;
+          respond: ReturnType<typeof vi.fn>;
+        }) => Promise<void>)
+      | undefined;
+
+    const singleRespond = vi.fn();
+    await handler?.({ params: { callId: "private-call" }, respond: singleRespond });
+    const singlePayload = firstRespondCall(singleRespond)[1] as {
+      call?: { metadata?: Record<string, unknown> };
+    };
+    expect(singlePayload.call?.metadata).toEqual({ initialMessage: "Hola, buenas tardes." });
+
+    const listRespond = vi.fn();
+    await handler?.({ params: {}, respond: listRespond });
+    const listPayload = firstRespondCall(listRespond)[1] as {
+      calls?: Array<{ metadata?: Record<string, unknown> }>;
+    };
+    expect(listPayload.calls?.[0]?.metadata).toEqual({ initialMessage: "Hola, buenas tardes." });
+  });
+
+  it("returns completed call status from history", async () => {
+    runtimeStub = createRuntimeStub("active-call");
+    const completed = createCallRecord({
+      callId: "completed-call",
+      providerCallId: "provider-completed-call",
+      state: "completed",
+      endedAt: Date.UTC(2026, 4, 2, 9, 5, 0),
+      endReason: "completed",
+      transcript: [{ timestamp: Date.now(), speaker: "bot", text: "Done", isFinal: true }],
+    });
+    managerMocks().getCall.mockReturnValue(undefined);
+    managerMocks().getCallByProviderCallId.mockReturnValue(undefined);
+    managerMocks().getCallHistory.mockResolvedValue([completed]);
+
+    const { methods } = setup({ provider: "mock" });
+    const handler = methods.get("voicecall.status") as
+      | ((ctx: {
+          params: Record<string, unknown>;
+          respond: ReturnType<typeof vi.fn>;
+        }) => Promise<void>)
+      | undefined;
+    const respond = vi.fn();
+    await handler?.({ params: { callId: "completed-call" }, respond });
+
+    expect(firstRespondCall(respond)).toEqual([
+      true,
+      { found: true, call: { ...completed, metadata: undefined } },
+    ]);
+  });
+
+  it("prefers a completed provider history record with call content", async () => {
+    runtimeStub = createRuntimeStub("active-call");
+    const completed = createCallRecord({
+      callId: "completed-call",
+      providerCallId: "provider-completed-call",
+      state: "completed",
+      endedAt: Date.UTC(2026, 4, 2, 9, 5, 0),
+      endReason: "completed",
+      transcript: [{ timestamp: Date.now(), speaker: "bot", text: "Booked", isFinal: true }],
+      metadata: { objective: "Book a restaurant table." },
+    });
+    const emptyLateDuplicate = createCallRecord({
+      callId: "late-duplicate-call",
+      providerCallId: "provider-completed-call",
+      state: "completed",
+      endedAt: Date.UTC(2026, 4, 2, 9, 6, 0),
+      endReason: "completed",
+      transcript: [],
+    });
+    managerMocks().getCall.mockReturnValue(undefined);
+    managerMocks().getCallByProviderCallId.mockReturnValue(undefined);
+    managerMocks().getCallHistory.mockResolvedValue([completed, emptyLateDuplicate]);
+
+    const { methods } = setup({ provider: "mock" });
+    const handler = methods.get("voicecall.status") as
+      | ((ctx: {
+          params: Record<string, unknown>;
+          respond: ReturnType<typeof vi.fn>;
+        }) => Promise<void>)
+      | undefined;
+    const respond = vi.fn();
+    await handler?.({ params: { callId: "provider-completed-call" }, respond });
+
+    expect(firstRespondCall(respond)).toEqual([
+      true,
+      { found: true, call: { ...completed, metadata: undefined } },
+    ]);
   });
 
   it("sends DTMF via voicecall.dtmf", async () => {

--- a/extensions/voice-call/index.ts
+++ b/extensions/voice-call/index.ts
@@ -23,9 +23,32 @@ import {
 } from "./src/config.js";
 import type { CoreConfig } from "./src/core-bridge.js";
 import { createVoiceCallContinueOperationStore } from "./src/gateway-continue-operation.js";
+import { redactCallRecordForRead, redactCallRecordsForRead } from "./src/readback.js";
+import type { CallRecord } from "./src/types.js";
 
 const VOICE_CALL_WRITE_METHOD_SCOPE = { scope: "operator.write" as const };
 const VOICE_CALL_READ_METHOD_SCOPE = { scope: "operator.read" as const };
+
+function hasPostCallContent(call: CallRecord): boolean {
+  return (
+    call.transcript.length > 0 ||
+    typeof call.metadata?.objective === "string" ||
+    typeof call.metadata?.initialMessage === "string"
+  );
+}
+
+function findCallInHistory(history: CallRecord[], callIdOrProviderCallId: string) {
+  const newestFirst = history.toReversed();
+  const exact = newestFirst.find((candidate) => candidate.callId === callIdOrProviderCallId);
+  if (exact) {
+    return exact;
+  }
+
+  const providerMatches = newestFirst.filter(
+    (candidate) => candidate.providerCallId === callIdOrProviderCallId,
+  );
+  return providerMatches.find(hasPostCallContent) ?? providerMatches[0];
+}
 
 const voiceCallConfigSchema = {
   parse(value: unknown): VoiceCallConfig {
@@ -179,6 +202,7 @@ const VoiceCallToolSchema = Type.Union([
     action: Type.Literal("initiate_call"),
     to: Type.Optional(Type.String({ description: "Call target" })),
     message: Type.String({ description: "Intro message" }),
+    objective: Type.Optional(Type.String({ description: "Private per-call objective" })),
     mode: Type.Optional(Type.Union([Type.Literal("notify"), Type.Literal("conversation")])),
     sessionKey: Type.Optional(Type.String({ description: "OpenClaw session key for the call" })),
     requesterSessionKey: Type.Optional(
@@ -214,6 +238,7 @@ const VoiceCallToolSchema = Type.Union([
     to: Type.Optional(Type.String({ description: "Call target" })),
     sid: Type.Optional(Type.String({ description: "Call SID" })),
     message: Type.Optional(Type.String({ description: "Optional intro message" })),
+    objective: Type.Optional(Type.String({ description: "Private per-call objective" })),
     sessionKey: Type.Optional(Type.String({ description: "OpenClaw session key for the call" })),
     requesterSessionKey: Type.Optional(
       Type.String({ description: "OpenClaw session key that initiated the call" }),
@@ -344,9 +369,7 @@ export default definePluginEntry({
 
     const describeHistoricalCall = async (rt: VoiceCallRuntime, callId: string) => {
       const history = await rt.manager.getCallHistory(100);
-      const call = history
-        .toReversed()
-        .find((candidate) => candidate.callId === callId || candidate.providerCallId === callId);
+      const call = findCallInHistory(history, callId);
       if (!call) {
         return undefined;
       }
@@ -357,6 +380,15 @@ export default definePluginEntry({
         endedAt ? `endedAt=${endedAt}` : undefined,
       ].filter(Boolean);
       return `call is not active (${details.join(", ")})`;
+    };
+
+    const resolveCallStatus = async (rt: VoiceCallRuntime, callId: string) => {
+      const active = rt.manager.getCall(callId) || rt.manager.getCallByProviderCallId(callId);
+      if (active) {
+        return active;
+      }
+      const history = await rt.manager.getCallHistory(100);
+      return findCallInHistory(history, callId);
     };
 
     const resolveCallMessageRequest = async (params: GatewayRequestHandlerOptions["params"]) => {
@@ -378,6 +410,7 @@ export default definePluginEntry({
       respond: GatewayRequestHandlerOptions["respond"];
       to: string;
       message?: string;
+      objective?: string;
       mode?: "notify" | "conversation";
       dtmfSequence?: string;
       sessionKey?: string;
@@ -385,6 +418,7 @@ export default definePluginEntry({
     }) => {
       const result = await params.rt.manager.initiateCall(params.to, params.sessionKey, {
         message: params.message,
+        objective: params.objective,
         mode: params.mode,
         dtmfSequence: params.dtmfSequence,
         ...(params.requesterSessionKey ? { requesterSessionKey: params.requesterSessionKey } : {}),
@@ -436,6 +470,7 @@ export default definePluginEntry({
       async ({ params, respond }: GatewayRequestHandlerOptions) => {
         try {
           const message = normalizeOptionalString(params?.message) ?? "";
+          const objective = normalizeOptionalString(params?.objective);
           if (!message) {
             respondError(respond, "message required", ErrorCodes.INVALID_REQUEST);
             return;
@@ -453,6 +488,7 @@ export default definePluginEntry({
             respond,
             to,
             message,
+            objective,
             mode,
             sessionKey: normalizeOptionalString(params?.sessionKey),
             requesterSessionKey: normalizeOptionalString(params?.requesterSessionKey),
@@ -623,15 +659,18 @@ export default definePluginEntry({
             normalizeOptionalString(params?.callId) ?? normalizeOptionalString(params?.sid) ?? "";
           const rt = await ensureRuntime();
           if (!raw) {
-            respond(true, { found: true, calls: rt.manager.getActiveCalls() });
+            respond(true, {
+              found: true,
+              calls: redactCallRecordsForRead(rt.manager.getActiveCalls()),
+            });
             return;
           }
-          const call = rt.manager.getCall(raw) || rt.manager.getCallByProviderCallId(raw);
+          const call = await resolveCallStatus(rt, raw);
           if (!call) {
             respond(true, { found: false });
             return;
           }
-          respond(true, { found: true, call });
+          respond(true, { found: true, call: redactCallRecordForRead(call) });
         } catch (err) {
           sendError(respond, err);
         }
@@ -645,6 +684,7 @@ export default definePluginEntry({
         try {
           const to = normalizeOptionalString(params?.to) ?? "";
           const message = normalizeOptionalString(params?.message) ?? "";
+          const objective = normalizeOptionalString(params?.objective);
           const dtmfSequence = normalizeOptionalString(params?.dtmfSequence);
           const sessionKey = normalizeOptionalString(params?.sessionKey);
           const requesterSessionKey = normalizeOptionalString(params?.requesterSessionKey);
@@ -660,6 +700,7 @@ export default definePluginEntry({
             respond,
             to,
             message: message || undefined,
+            objective,
             mode,
             dtmfSequence,
             sessionKey,
@@ -700,6 +741,7 @@ export default definePluginEntry({
                 }
                 const result = await rt.manager.initiateCall(to, undefined, {
                   message,
+                  objective: normalizeOptionalString(rawParams.objective),
                   dtmfSequence: normalizeOptionalString(rawParams.dtmfSequence),
                   mode:
                     rawParams.mode === "notify" || rawParams.mode === "conversation"
@@ -763,9 +805,10 @@ export default definePluginEntry({
                 if (!callId) {
                   throw new Error("callId required");
                 }
-                const call =
-                  rt.manager.getCall(callId) || rt.manager.getCallByProviderCallId(callId);
-                return json(call ? { found: true, call } : { found: false });
+                const call = await resolveCallStatus(rt, callId);
+                return json(
+                  call ? { found: true, call: redactCallRecordForRead(call) } : { found: false },
+                );
               }
             }
           }
@@ -776,8 +819,10 @@ export default definePluginEntry({
             if (!sid) {
               throw new Error("sid required for status");
             }
-            const call = rt.manager.getCall(sid) || rt.manager.getCallByProviderCallId(sid);
-            return json(call ? { found: true, call } : { found: false });
+            const call = await resolveCallStatus(rt, sid);
+            return json(
+              call ? { found: true, call: redactCallRecordForRead(call) } : { found: false },
+            );
           }
 
           const to = normalizeOptionalString(rawParams.to) ?? rt.config.toNumber;
@@ -790,6 +835,7 @@ export default definePluginEntry({
             {
               dtmfSequence: normalizeOptionalString(rawParams.dtmfSequence),
               message: normalizeOptionalString(rawParams.message),
+              objective: normalizeOptionalString(rawParams.objective),
               ...(normalizeOptionalString(rawParams.requesterSessionKey)
                 ? { requesterSessionKey: normalizeOptionalString(rawParams.requesterSessionKey) }
                 : {}),

--- a/extensions/voice-call/src/cli.ts
+++ b/extensions/voice-call/src/cli.ts
@@ -20,8 +20,14 @@ import {
 import { sleep } from "../api.js";
 import { validateProviderConfig, type VoiceCallConfig } from "./config.js";
 import { getCallHistoryFromStore } from "./manager/store.js";
+import {
+  redactCallRecordForRead,
+  redactCallRecordsForRead,
+  redactVoiceCallJsonLineForRead,
+} from "./readback.js";
 import { setVoiceCallStateRuntime, type VoiceCallStateRuntime } from "./runtime-state.js";
 import type { VoiceCallRuntime } from "./runtime.js";
+import type { CallRecord } from "./types.js";
 import { resolveUserPath } from "./utils.js";
 import { resolveWebhookExposureStatus } from "./webhook-exposure.js";
 import {
@@ -113,6 +119,27 @@ function isGatewayUnavailableForLocalFallback(err: unknown): boolean {
     message.includes("gateway closed (1006") ||
     message.includes("gateway not connected")
   );
+}
+
+function hasPostCallContent(call: CallRecord): boolean {
+  return (
+    call.transcript.length > 0 ||
+    typeof call.metadata?.objective === "string" ||
+    typeof call.metadata?.initialMessage === "string"
+  );
+}
+
+function findCallInHistory(history: CallRecord[], callIdOrProviderCallId: string) {
+  const newestFirst = history.toReversed();
+  const exact = newestFirst.find((candidate) => candidate.callId === callIdOrProviderCallId);
+  if (exact) {
+    return exact;
+  }
+
+  const providerMatches = newestFirst.filter(
+    (candidate) => candidate.providerCallId === callIdOrProviderCallId,
+  );
+  return providerMatches.find(hasPostCallContent) ?? providerMatches[0];
 }
 
 async function callVoiceCallGateway(
@@ -364,10 +391,12 @@ async function initiateCallAndPrintId(params: {
   runtime: VoiceCallRuntime;
   to: string;
   message?: string;
+  objective?: string;
   mode?: string;
 }) {
   const result = await params.runtime.manager.initiateCall(params.to, undefined, {
     message: params.message,
+    objective: params.objective,
     mode: resolveCallMode(params.mode),
   });
   if (!result.success) {
@@ -393,6 +422,7 @@ async function initiateCallViaGatewayOrRuntime(params: {
   method: "voicecall.initiate" | "voicecall.start";
   to?: string;
   message?: string;
+  objective?: string;
   mode?: string;
 }) {
   const mode = resolveCallMode(params.mode);
@@ -401,6 +431,7 @@ async function initiateCallViaGatewayOrRuntime(params: {
     {
       ...(params.to ? { to: params.to } : {}),
       ...(params.message ? { message: params.message } : {}),
+      ...(params.objective ? { objective: params.objective } : {}),
       ...(mode ? { mode } : {}),
     },
     {
@@ -421,6 +452,7 @@ async function initiateCallViaGatewayOrRuntime(params: {
     runtime: rt,
     to,
     message: params.message,
+    objective: params.objective,
     mode: params.mode,
   });
 }
@@ -546,6 +578,7 @@ export function registerVoiceCallCli(params: {
     .command("call")
     .description("Initiate an outbound voice call")
     .requiredOption("-m, --message <text>", "Message to speak when call connects")
+    .option("--objective <text>", "Private per-call objective for realtime task calls")
     .option(
       "-t, --to <phone>",
       "Phone number to call (E.164 format, uses config toNumber if not set)",
@@ -555,37 +588,44 @@ export function registerVoiceCallCli(params: {
       "Call mode: notify (hangup after message) or conversation (stay open)",
       "conversation",
     )
-    .action(async (options: { message: string; to?: string; mode?: string }) => {
-      await initiateCallViaGatewayOrRuntime({
-        ensureRuntime,
-        config,
-        method: "voicecall.initiate",
-        to: options.to,
-        message: options.message,
-        mode: options.mode,
-      });
-    });
+    .action(
+      async (options: { message: string; objective?: string; to?: string; mode?: string }) => {
+        await initiateCallViaGatewayOrRuntime({
+          ensureRuntime,
+          config,
+          method: "voicecall.initiate",
+          to: options.to,
+          message: options.message,
+          objective: options.objective,
+          mode: options.mode,
+        });
+      },
+    );
 
   root
     .command("start")
     .description("Alias for voicecall call")
     .requiredOption("--to <phone>", "Phone number to call")
     .option("--message <text>", "Message to speak when call connects")
+    .option("--objective <text>", "Private per-call objective for realtime task calls")
     .option(
       "--mode <mode>",
       "Call mode: notify (hangup after message) or conversation (stay open)",
       "conversation",
     )
-    .action(async (options: { to: string; message?: string; mode?: string }) => {
-      await initiateCallViaGatewayOrRuntime({
-        ensureRuntime,
-        config,
-        method: "voicecall.start",
-        to: options.to,
-        message: options.message,
-        mode: options.mode,
-      });
-    });
+    .action(
+      async (options: { to: string; message?: string; objective?: string; mode?: string }) => {
+        await initiateCallViaGatewayOrRuntime({
+          ensureRuntime,
+          config,
+          method: "voicecall.start",
+          to: options.to,
+          message: options.message,
+          objective: options.objective,
+          mode: options.mode,
+        });
+      },
+    );
 
   root
     .command("continue")
@@ -733,13 +773,16 @@ export function registerVoiceCallCli(params: {
       }
       const rt = await ensureRuntime();
       if (options.callId) {
-        const call = rt.manager.getCall(options.callId);
-        writeStdoutJson(call ?? { found: false });
+        const call =
+          rt.manager.getCall(options.callId) ??
+          rt.manager.getCallByProviderCallId(options.callId) ??
+          findCallInHistory(await rt.manager.getCallHistory(100), options.callId);
+        writeStdoutJson(call ? redactCallRecordForRead(call) : { found: false });
         return;
       }
       writeStdoutJson({
         found: true,
-        calls: rt.manager.getActiveCalls(),
+        calls: redactCallRecordsForRead(rt.manager.getActiveCalls()),
       });
     });
 
@@ -758,7 +801,7 @@ export function registerVoiceCallCli(params: {
         ensureHistoryStateRuntime();
         const seen = new Set<string>();
         const printCall = (call: unknown): void => {
-          const line = JSON.stringify(call);
+          const line = redactVoiceCallJsonLineForRead(JSON.stringify(call));
           if (!seen.has(line)) {
             seen.add(line);
             writeStdoutLine(line);
@@ -785,7 +828,7 @@ export function registerVoiceCallCli(params: {
         const initial = fs.readFileSync(file, "utf8");
         const lines = initial.split("\n").filter(Boolean);
         for (const line of lines.slice(Math.max(0, lines.length - since))) {
-          writeStdoutLine(line);
+          writeStdoutLine(redactVoiceCallJsonLineForRead(line));
         }
 
         let offset = Buffer.byteLength(initial, "utf8");
@@ -803,7 +846,7 @@ export function registerVoiceCallCli(params: {
                 offset = stat.size;
                 const text = buf.toString("utf8");
                 for (const line of text.split("\n").filter(Boolean)) {
-                  writeStdoutLine(line);
+                  writeStdoutLine(redactVoiceCallJsonLineForRead(line));
                 }
               } finally {
                 fs.closeSync(fd);

--- a/extensions/voice-call/src/manager/events.test.ts
+++ b/extensions/voice-call/src/manager/events.test.ts
@@ -717,6 +717,95 @@ describe("processEvent (functional)", () => {
     expect(Array.from(ctx.processedEventIds)).toEqual(["stable-key-1"]);
   });
 
+  it("records final bot speech in the call transcript", () => {
+    const now = Date.now();
+    const ctx = createContext();
+    ctx.activeCalls.set("call-bot-speech", {
+      callId: "call-bot-speech",
+      providerCallId: "provider-bot-speech",
+      provider: "plivo",
+      direction: "outbound",
+      state: "listening",
+      from: "+15550000000",
+      to: "+15550000001",
+      startedAt: now,
+      transcript: [],
+      processedEventIds: [],
+      metadata: {},
+    });
+    ctx.providerCallIdMap.set("provider-bot-speech", "call-bot-speech");
+
+    processEvent(ctx, {
+      id: "evt-bot-speech",
+      type: "call.speaking",
+      callId: "call-bot-speech",
+      providerCallId: "provider-bot-speech",
+      timestamp: now + 1,
+      text: "I would like to make a reservation.",
+      source: "realtime",
+    });
+
+    const call = ctx.activeCalls.get("call-bot-speech");
+    if (!call) {
+      throw new Error("expected call to remain active");
+    }
+    expect(call.transcript).toEqual([
+      expect.objectContaining({
+        speaker: "bot",
+        text: "I would like to make a reservation.",
+        isFinal: true,
+      }),
+    ]);
+  });
+
+  it("does not duplicate provider TTS speaking events that speak already records", () => {
+    const now = Date.now();
+    const ctx = createContext();
+    ctx.activeCalls.set("call-provider-speech", {
+      callId: "call-provider-speech",
+      providerCallId: "provider-provider-speech",
+      provider: "telnyx",
+      direction: "outbound",
+      state: "listening",
+      from: "+15550000000",
+      to: "+15550000001",
+      startedAt: now,
+      transcript: [
+        {
+          timestamp: now,
+          speaker: "bot",
+          text: "One moment please.",
+          isFinal: true,
+        },
+      ],
+      processedEventIds: [],
+      metadata: {},
+    });
+    ctx.providerCallIdMap.set("provider-provider-speech", "call-provider-speech");
+
+    processEvent(ctx, {
+      id: "evt-provider-speech",
+      type: "call.speaking",
+      callId: "call-provider-speech",
+      providerCallId: "provider-provider-speech",
+      timestamp: now + 1,
+      text: "One moment please.",
+    });
+
+    const call = ctx.activeCalls.get("call-provider-speech");
+    if (!call) {
+      throw new Error("expected call to remain active");
+    }
+    expect(call.state).toBe("speaking");
+    expect(call.transcript).toEqual([
+      expect.objectContaining({
+        speaker: "bot",
+        text: "One moment please.",
+        isFinal: true,
+      }),
+    ]);
+  });
+
   it("keeps retryable call.error events replayable", () => {
     const now = Date.now();
     const ctx = createContext();

--- a/extensions/voice-call/src/manager/events.ts
+++ b/extensions/voice-call/src/manager/events.ts
@@ -281,6 +281,9 @@ export function processEvent(ctx: EventContext, event: NormalizedEvent): void {
       break;
 
     case "call.speaking":
+      if (event.source === "realtime" && event.text.trim()) {
+        addTranscriptEntry(call, "bot", event.text);
+      }
       ensureMaxDurationTimerForLiveCall({
         ctx,
         call,

--- a/extensions/voice-call/src/manager/outbound.test.ts
+++ b/extensions/voice-call/src/manager/outbound.test.ts
@@ -182,6 +182,34 @@ describe("voice-call outbound helpers", () => {
     expect(persistCallRecordMock).toHaveBeenCalledTimes(2);
   });
 
+  it("stores private outbound objectives without changing the initial message", async () => {
+    const initiateProviderCall = vi.fn(async () => ({ providerCallId: "provider-1" }));
+    const ctx = {
+      activeCalls: new Map(),
+      providerCallIdMap: new Map(),
+      provider: { name: "twilio", initiateCall: initiateProviderCall },
+      config: {
+        maxConcurrentCalls: 3,
+        outbound: { defaultMode: "conversation" },
+        fromNumber: "+14155550100",
+      },
+      storePath: "/tmp/voice-call.json",
+      webhookUrl: "https://example.com/webhook",
+    };
+
+    const result = await initiateCall(ctx as never, "+14155550123", "session-1", {
+      message: "Hola, buenas tardes.",
+      objective: "Book a table for two tomorrow at 8pm.",
+    });
+
+    expect(result.success).toBe(true);
+    const metadata = (
+      ctx.activeCalls.get(result.callId) as { metadata?: Record<string, unknown> } | undefined
+    )?.metadata;
+    expect(metadata?.initialMessage).toBe("Hola, buenas tardes.");
+    expect(metadata?.objective).toBe("Book a table for two tomorrow at 8pm.");
+  });
+
   it("assigns per-call session keys to outbound calls when configured", async () => {
     const initiateProviderCall = vi.fn(async () => ({ providerCallId: "provider-1" }));
     const ctx = {

--- a/extensions/voice-call/src/manager/outbound.ts
+++ b/extensions/voice-call/src/manager/outbound.ts
@@ -139,6 +139,7 @@ export async function initiateCall(
   const opts: OutboundCallOptions =
     typeof options === "string" ? { message: options } : (options ?? {});
   const initialMessage = opts.message;
+  const objective = opts.objective?.trim();
   const mode = opts.mode ?? ctx.config.outbound.defaultMode;
   const dtmfSequence = opts.dtmfSequence;
   const requesterSessionKey = opts.requesterSessionKey?.trim();
@@ -196,6 +197,7 @@ export async function initiateCall(
     processedEventIds: [],
     metadata: {
       ...(initialMessage && { initialMessage }),
+      ...(objective ? { objective } : {}),
       mode,
       ...(requesterSessionKey ? { requesterSessionKey } : {}),
     },

--- a/extensions/voice-call/src/readback.ts
+++ b/extensions/voice-call/src/readback.ts
@@ -1,0 +1,30 @@
+import type { CallRecord } from "./types.js";
+
+function redactObjectiveMetadata(metadata: CallRecord["metadata"]): CallRecord["metadata"] {
+  if (!metadata || !Object.hasOwn(metadata, "objective")) {
+    return metadata;
+  }
+  const { objective: _objective, ...rest } = metadata;
+  return Object.keys(rest).length > 0 ? rest : undefined;
+}
+
+export function redactCallRecordForRead(call: CallRecord): CallRecord {
+  const metadata = redactObjectiveMetadata(call.metadata);
+  return metadata === call.metadata ? call : { ...call, metadata };
+}
+
+export function redactCallRecordsForRead(calls: CallRecord[]): CallRecord[] {
+  return calls.map(redactCallRecordForRead);
+}
+
+export function redactVoiceCallJsonLineForRead(line: string): string {
+  try {
+    const parsed = JSON.parse(line) as CallRecord;
+    if (!parsed || typeof parsed !== "object" || !("callId" in parsed)) {
+      return line;
+    }
+    return JSON.stringify(redactCallRecordForRead(parsed));
+  } catch {
+    return line;
+  }
+}

--- a/extensions/voice-call/src/types.ts
+++ b/extensions/voice-call/src/types.ts
@@ -104,6 +104,7 @@ const NormalizedEventSchema = z.discriminatedUnion("type", [
   BaseEventSchema.extend({
     type: z.literal("call.speaking"),
     text: z.string(),
+    source: z.enum(["realtime"]).optional(),
   }),
   BaseEventSchema.extend({
     type: z.literal("call.speech"),
@@ -303,6 +304,8 @@ export type GetCallStatusResult = {
 export type OutboundCallOptions = {
   /** Message to speak when call connects */
   message?: string;
+  /** Private per-call objective for realtime task calls; not spoken as the opener */
+  objective?: string;
   /** Call mode (overrides config default) */
   mode?: CallMode;
   /** DTMF digits to send after the call is connected */

--- a/extensions/voice-call/src/webhook/realtime-handler.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.test.ts
@@ -485,6 +485,83 @@ describe("RealtimeCallHandler path routing", () => {
     }
   });
 
+  it("adds a private objective to realtime instructions without speaking it as the greeting", async () => {
+    let callbacks:
+      | {
+          onReady?: () => void;
+        }
+      | undefined;
+    let bridgeRequest: Parameters<RealtimeVoiceProviderPlugin["createBridge"]>[0] | undefined;
+    const triggerGreeting = vi.fn();
+    const createBridge = vi.fn(
+      (request: Parameters<RealtimeVoiceProviderPlugin["createBridge"]>[0]) => {
+        callbacks = request;
+        bridgeRequest = request;
+        return makeBridge({ triggerGreeting });
+      },
+    );
+    const getCallByProviderCallId = vi.fn(
+      (): CallRecord => ({
+        callId: "call-1",
+        providerCallId: "CA-objective",
+        provider: "twilio",
+        direction: "outbound",
+        state: "ringing",
+        from: "+15550001234",
+        to: "+15550009999",
+        startedAt: Date.now(),
+        transcript: [],
+        processedEventIds: [],
+        metadata: {
+          initialMessage: "Hola, buenas tardes.",
+          objective: "Book a table for two tomorrow at 8pm.",
+        },
+      }),
+    );
+    const handler = makeHandler(
+      { instructions: "Base realtime instructions." },
+      {
+        manager: {
+          getCallByProviderCallId,
+        },
+        realtimeProvider: makeRealtimeProvider(createBridge),
+      },
+    );
+    const server = await startRealtimeServer(handler);
+
+    try {
+      const ws = await connectWs(server.url);
+      try {
+        ws.send(
+          JSON.stringify({
+            event: "start",
+            start: { streamSid: "MZ-objective", callSid: "CA-objective" },
+          }),
+        );
+        await waitForRealtimeTest(() => {
+          expect(createBridge).toHaveBeenCalled();
+        });
+
+        expect(bridgeRequest?.instructions).toContain("Base realtime instructions.");
+        expect(bridgeRequest?.instructions).toContain("Private per-call objective:");
+        expect(bridgeRequest?.instructions).toContain("Book a table for two tomorrow at 8pm.");
+
+        callbacks?.onReady?.();
+
+        expect(triggerGreeting).toHaveBeenCalledTimes(1);
+        const greeting = requireFirstMockCall(triggerGreeting.mock.calls, "greeting")[0];
+        expect(greeting).toContain("Hola, buenas tardes.");
+        expect(greeting).not.toContain("Book a table for two tomorrow at 8pm.");
+      } finally {
+        if (ws.readyState !== WebSocket.CLOSED && ws.readyState !== WebSocket.CLOSING) {
+          ws.close();
+        }
+      }
+    } finally {
+      await server.close();
+    }
+  });
+
   it("speaks through the active outbound realtime bridge by call id", async () => {
     const triggerGreeting = vi.fn();
     const createBridge = vi.fn(() => makeBridge({ triggerGreeting }));

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -76,19 +76,35 @@ function normalizePath(pathname: string): string {
   return prefixed.endsWith("/") ? prefixed.slice(0, -1) : prefixed;
 }
 
-function buildGreetingInstructions(
-  baseInstructions: string | undefined,
-  greeting: string | undefined,
-): string | undefined {
+function buildGreetingInstructions(greeting: string | undefined): string | undefined {
   const trimmedGreeting = greeting?.trim();
   if (!trimmedGreeting) {
     return undefined;
   }
   const intro =
     "Start the call by greeting the caller naturally. Include this greeting in your first spoken reply:";
+  return `${intro} "${trimmedGreeting}"`;
+}
+
+function buildCallInstructions(
+  baseInstructions: string | undefined,
+  objective: string | undefined,
+): string | undefined {
+  const trimmedObjective = objective?.trim();
+  if (!trimmedObjective) {
+    return baseInstructions;
+  }
+  const objectiveInstructions = [
+    "Private per-call objective:",
+    "- Treat the following objective as private call context from the OpenClaw requester.",
+    "- Use it to pursue the task naturally during the realtime conversation.",
+    "- Do not speak this objective verbatim as the opening line.",
+    "- Do not reveal that it came from internal instructions.",
+    trimmedObjective,
+  ].join("\n");
   return baseInstructions
-    ? `${baseInstructions}\n\n${intro} "${trimmedGreeting}"`
-    : `${intro} "${trimmedGreeting}"`;
+    ? `${baseInstructions}\n\n${objectiveInstructions}`
+    : objectiveInstructions;
 }
 
 function readConsultArgText(args: unknown, key: string): string | undefined {
@@ -237,6 +253,7 @@ export type StreamSession = {
 type CallRegistration = {
   callId: string;
   initialGreetingInstructions?: string;
+  callInstructions?: string;
 };
 
 type ActiveRealtimeVoiceBridge = RealtimeVoiceBridgeSession;
@@ -654,7 +671,7 @@ export class RealtimeCallHandler {
       provider: this.realtimeProvider,
       cfg: this.coreConfig,
       providerConfig: this.providerConfig,
-      instructions: this.config.instructions,
+      instructions: registration.callInstructions ?? this.config.instructions,
       tools: this.config.tools,
       initialGreetingInstructions,
       triggerGreetingOnReady: Boolean(initialGreetingInstructions),
@@ -758,6 +775,7 @@ export class RealtimeCallHandler {
           providerCallId: callSid,
           timestamp: Date.now(),
           text,
+          source: "realtime",
         });
       },
       onToolCall: (toolEvent, sessionLocal) => {
@@ -1166,6 +1184,7 @@ export class RealtimeCallHandler {
     }
 
     const initialGreeting = this.extractInitialGreeting(callRecord);
+    const objective = this.extractObjective(callRecord);
     console.log(
       `[voice-call] Realtime call ${callRecord.callId} initial greeting ${initialGreeting ? "queued" : "absent"}`,
     );
@@ -1182,10 +1201,8 @@ export class RealtimeCallHandler {
 
     return {
       callId: callRecord.callId,
-      initialGreetingInstructions: buildGreetingInstructions(
-        this.config.instructions,
-        initialGreeting,
-      ),
+      callInstructions: buildCallInstructions(this.config.instructions, objective),
+      initialGreetingInstructions: buildGreetingInstructions(initialGreeting),
     };
   }
 
@@ -1219,6 +1236,10 @@ export class RealtimeCallHandler {
     return typeof call.metadata?.initialMessage === "string"
       ? call.metadata.initialMessage
       : undefined;
+  }
+
+  private extractObjective(call: CallRecord): string | undefined {
+    return typeof call.metadata?.objective === "string" ? call.metadata.objective : undefined;
   }
 
   private endCallInManager(callSid: string, callId: string, reason: "completed" | "error"): void {

--- a/skills/voice-call/SKILL.md
+++ b/skills/voice-call/SKILL.md
@@ -20,6 +20,7 @@ Use the voice-call plugin to start or inspect calls (Twilio, Telnyx, Plivo, or m
 
 ```bash
 openclaw voicecall call --to "+15555550123" --message "Hello from OpenClaw"
+openclaw voicecall call --to "+15555550123" --message "Hello" --objective "Book a table for 2 tomorrow at 8pm."
 openclaw voicecall status --call-id <id>
 ```
 
@@ -29,9 +30,10 @@ Use `voice_call` for agent-initiated calls.
 
 Actions:
 
-- `initiate_call` (message, to?, mode?)
+- `initiate_call` (message, to?, mode?, objective?, dtmfSequence?)
 - `continue_call` (callId, message)
 - `speak_to_user` (callId, message)
+- `send_dtmf` (callId, digits)
 - `end_call` (callId)
 - `get_status` (callId)
 
@@ -43,3 +45,9 @@ Notes:
 - Telnyx config: `provider: "telnyx"` + `telnyx.apiKey/connectionId` + `fromNumber`.
 - Plivo config: `provider: "plivo"` + `plivo.authId/authToken` + `fromNumber`.
 - Dev fallback: `provider: "mock"` (no network).
+- `objective` is private call context for realtime task calls. It is not
+  spoken as the opener. OpenClaw stores it in internal call metadata for the
+  active call, but status/tool/CLI readback redacts it from returned call
+  records.
+- `dtmfSequence` is only valid for conversation-mode calls; use `send_dtmf`
+  after connect for notify-mode calls.


### PR DESCRIPTION
## Summary

- Problem: realtime outbound Voice Call had only a spoken `message`, so callers had to overload the opening line with the task goal or rely on static config/consults.
- Solution: add an optional private per-call `objective` that is stored on the call record and injected into realtime provider instructions, while `message` remains the natural first spoken line.
- What changed: CLI/tool/RPC paths accept `objective`, realtime calls receive it as private context, completed call status can resolve from history, and final bot speech is persisted into call transcripts.
- What did NOT change (scope boundary): this does not implement the full outbound task-call orchestrator from #59245: no IVR/hold state machine, callback continuity, escalation policy, or recording feature.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #59245
- Related #83806
- [x] This PR fixes a bug or regression

## Motivation

- This is the narrow API slice needed for outbound task calls where the first spoken line should stay natural, but the realtime voice model must still hold a private task objective during the call.
- Without this split, a reservation call can start by reading the task prompt aloud or invert roles after the callee answers, because the only per-call text is the spoken opener.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: realtime outbound call can use a short spoken opener while privately following a reservation objective, and completed calls can be retrieved after hangup with both sides of the transcript.
- Real environment tested: OpenClaw 2026.5.18 installation, Voice Call plugin, Twilio provider, OpenAI realtime voice provider. Phone numbers and public webhook details redacted.
- Exact steps or command run after this patch:

```bash
openclaw voicecall call \
  --mode conversation \
  --message "Здравствуйте" \
  --objective "Call a restaurant on behalf of the requester. Book a table for two tomorrow at 20:00, ask about a birthday dessert/candle, do not pay a deposit during the call, and confirm final details."

openclaw voicecall status --call-id <call-id> --json
```

- Evidence after fix (copied from redacted terminal output):

```json
{
  "state": "completed",
  "endReason": "completed",
  "entries": 23,
  "bot": 12,
  "user": 11
}
```

- Observed result after fix: the call opened with only a short greeting, pursued the private objective, accepted a nearby alternate time only after the requested time was unavailable, refused to pay a deposit directly, and the completed call history returned both `bot` and `user` transcript entries after hangup.
- What was not tested: full autonomous task-call orchestration, IVR/hold handling, callback continuity, user escalation, and audio recording.
- Before evidence (optional but encouraged): before this patch, completed `voicecall.status --call-id <completed-id>` returned `{ "found": false }` after hangup in the local setup, and final bot speech was not persisted into the transcript.

## Root Cause (if applicable)

- Root cause: per-call Voice Call inputs only had a spoken `message`, so there was no source-level slot for hidden task context. Separately, status lookup only checked active calls, and `call.speaking` events did not append final bot speech to the transcript.
- Missing detection / guardrail: there was no test proving that a completed call can be resolved from history, no test for preferring non-empty provider history records, and no test that final bot speech is recorded.
- Contributing context (if known): realtime voice has static `realtime.instructions` and optional agent context, but those are not suitable for dynamic one-off task objectives.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `extensions/voice-call/src/manager/outbound.test.ts`
  - `extensions/voice-call/src/webhook/realtime-handler.test.ts`
  - `extensions/voice-call/index.test.ts`
  - `extensions/voice-call/src/manager/events.test.ts`
- Scenario the test should lock in: objective is stored separately from the initial message, realtime instructions include the objective without making it the greeting, completed call status resolves from history, non-empty provider history records win over late empty duplicates, and final bot speech is recorded.
- Why this is the smallest reliable guardrail: these tests cover the new API contract at the manager, realtime handler, gateway/tool, and event-processing seams without requiring live telephony.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- `openclaw voicecall call` and `openclaw voicecall start` now accept `--objective <text>`.
- The `voice_call` tool and `voicecall.initiate` RPC accept optional `objective`.
- Realtime calls can keep a natural opener while privately following a per-call task objective.
- `voicecall.status` can return completed calls from history instead of only active calls.
- Completed transcripts include final bot speech events.

## Diagram (if applicable)

```text
Before:
message="Book a table..." -> first spoken line leaks task text -> realtime has no private per-call goal

After:
message="Hello" + objective="Book a table..."
  -> first spoken line stays natural
  -> realtime instructions receive private objective
  -> completed status/transcript can be read after hangup
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No new permission scope; yes, an existing call action can now receive private per-call objective text.
- Secrets/tokens handling changed? (`Yes/No`): No.
- New/changed network calls? (`Yes/No`): No.
- Command/tool execution surface changed? (`Yes/No`): Yes, adds an optional CLI/tool/RPC argument.
- Data access scope changed? (`Yes/No`): No.
- If any `Yes`, explain risk + mitigation: the objective is treated as private call context, not spoken as the opener, and is persisted only in the existing call metadata/log path like other call metadata. Call actions still require the existing Voice Call permissions.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local OpenClaw workspace + installed OpenClaw gateway
- Model/provider: OpenAI realtime voice provider
- Integration/channel (if any): Voice Call plugin with Twilio provider
- Relevant config (redacted): realtime voice enabled; provider credentials and phone numbers redacted

### Steps

1. Start an outbound realtime call with a short `--message` and a longer private `--objective`.
2. Complete the call.
3. Run `openclaw voicecall status --call-id <call-id> --json` after hangup.
4. Inspect whether the completed call is returned and whether transcript contains both `bot` and `user` entries.

### Expected

- First spoken turn uses only the natural opener.
- Realtime model follows the private objective during the call.
- Completed status works after hangup.
- Transcript contains both sides.

### Actual

- Matched expected in local live test.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - local plugin runtime build passes: `node scripts/lib/plugin-npm-runtime-build.mjs extensions/voice-call`
  - `git diff --check` passes
  - `corepack pnpm@11.1.0 tsgo:extensions` passes
  - `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --noEmit` passes
  - live outbound call with private objective completes and returns completed status/transcript from history
- Edge cases checked:
  - provider call ID history lookup prefers a completed record with transcript/objective over a late empty duplicate
  - objective is not included in the initial greeting instructions
  - final bot speech is recorded into transcript
- What you did **not** verify:
  - full outbound task-call orchestrator behavior from #59245
  - IVR/hold/callback behavior
  - audio recording

Note: targeted Vitest command was attempted locally and timed out after 120s with repeated `[PLUGIN_TIMINGS]` warnings before assertion output:

```bash
timeout 120s corepack pnpm@11.1.0 vitest run \
  extensions/voice-call/index.test.ts \
  extensions/voice-call/src/manager/outbound.test.ts \
  extensions/voice-call/src/manager/events.test.ts \
  extensions/voice-call/src/webhook/realtime-handler.test.ts \
  --reporter=dot
```

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes.
- Config/env changes? (`Yes/No`): No.
- Migration needed? (`Yes/No`): No.
- If yes, exact upgrade steps: N/A.

## Risks and Mitigations

- Risk: callers may put sensitive text in `objective`, which is persisted in call metadata like other call metadata.
  - Mitigation: this PR does not broaden storage scope; docs describe it as private call context, not a spoken opener. Further retention/redaction policy can be handled separately with broader task-call design.
- Risk: this is a narrow primitive and may be mistaken for the full task-call orchestrator.
  - Mitigation: PR scope explicitly excludes IVR, hold, callback, escalation, authorization policy, and recording.
