### PR TITLE
Fix stuck Codex-native subagent tasks after blocked spawn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Docs: https://docs.openclaw.ai
 - Telegram: keep verbose tool progress visible without mirroring non-final progress into active session transcripts, preventing embedded provider replies from aborting mid-run. (#83631) Thanks @kurplunkin.
 - Telegram: log successful outbound text and media deliveries with account, chat, message, operation, thread, reply, silent, and chunk metadata while keeping message bodies out of logs. Fixes #83196. (#83247) Thanks @jrwrest.
 - Cron: link isolated scheduled task runs to their stable cron session so task status and cleanup can follow the backing agent run. (#83606) Thanks @jai.
+- Codex app-server: mark Codex-native subagent task mirrors terminal when blocked or failed spawn-agent calls arrive with stale initializing child state, preventing task registry entries from staying running. Fixes #83852. (#83945) Thanks @joshavant.
 - CLI: enforce the documented Node.js 22.19 runtime floor in the source launcher.
 - Release stability: repair broad-gate regressions in requester-agent completion handoff, QA-Lab mock spawn attribution, Slack monitor test isolation, plugin uninstall peer fixtures, and Node-floor launcher contract coverage.
 - Agents/replies: persist queued follow-up user messages and assistant error stubs only once across model-fallback retries, preventing repeated provider rejections from corrupted same-role session transcripts. Fixes #83404. (#83417) Thanks @yetval.

--- a/extensions/codex/src/app-server/native-subagent-task-mirror.test.ts
+++ b/extensions/codex/src/app-server/native-subagent-task-mirror.test.ts
@@ -273,6 +273,134 @@ describe("CodexNativeSubagentTaskMirror", () => {
     });
   });
 
+  it("finalizes stale collab agent state from the blocked tool call status", () => {
+    const runtime = createRuntime();
+    const mirror = new CodexNativeSubagentTaskMirror(
+      {
+        parentThreadId: "parent-thread",
+        requesterSessionKey: "agent:main:main",
+        now: () => 45_000,
+      },
+      runtime,
+    );
+
+    mirror.handleNotification({
+      method: "item/completed",
+      params: {
+        item: {
+          type: "collabAgentToolCall",
+          tool: "spawnAgent",
+          status: "blocked",
+          senderThreadId: "parent-thread",
+          receiverThreadIds: ["child-thread"],
+          prompt: "read cwd",
+          agentsStates: {
+            "child-thread": {
+              status: "pendingInit",
+              message: "Native hook relay unavailable",
+            },
+          },
+        },
+      },
+    });
+
+    expect(runtime.recordTaskRunProgressByRunId).not.toHaveBeenCalledWith({
+      runId: "codex-thread:child-thread",
+      runtime: "subagent",
+      lastEventAt: 45_000,
+      progressSummary: "Native hook relay unavailable",
+    });
+    expect(runtime.finalizeTaskRunByRunId).toHaveBeenCalledWith({
+      runId: "codex-thread:child-thread",
+      runtime: "subagent",
+      status: "succeeded",
+      endedAt: 45_000,
+      lastEventAt: 45_000,
+      progressSummary: "Native hook relay unavailable",
+      terminalSummary: "Native hook relay unavailable",
+      terminalOutcome: "blocked",
+    });
+  });
+
+  it("does not treat completed tool calls as completed subagents", () => {
+    const runtime = createRuntime();
+    const mirror = new CodexNativeSubagentTaskMirror(
+      {
+        parentThreadId: "parent-thread",
+        requesterSessionKey: "agent:main:main",
+        now: () => 46_000,
+      },
+      runtime,
+    );
+
+    mirror.handleNotification({
+      method: "item/completed",
+      params: {
+        item: {
+          type: "collabAgentToolCall",
+          tool: "spawnAgent",
+          status: "completed",
+          senderThreadId: "parent-thread",
+          receiverThreadIds: ["child-thread"],
+          prompt: "read cwd",
+          agentsStates: {
+            "child-thread": {
+              status: "pendingInit",
+              message: null,
+            },
+          },
+        },
+      },
+    });
+
+    expect(runtime.recordTaskRunProgressByRunId).toHaveBeenCalledWith({
+      runId: "codex-thread:child-thread",
+      runtime: "subagent",
+      lastEventAt: 46_000,
+      progressSummary: "Codex native subagent is initializing.",
+    });
+    expect(runtime.finalizeTaskRunByRunId).not.toHaveBeenCalled();
+  });
+
+  it("does not treat failed non-spawn tool calls as failed subagents", () => {
+    const runtime = createRuntime();
+    const mirror = new CodexNativeSubagentTaskMirror(
+      {
+        parentThreadId: "parent-thread",
+        requesterSessionKey: "agent:main:main",
+        now: () => 47_000,
+      },
+      runtime,
+    );
+
+    mirror.handleNotification({
+      method: "item/completed",
+      params: {
+        item: {
+          type: "collabAgentToolCall",
+          tool: "wait",
+          status: "failed",
+          senderThreadId: "parent-thread",
+          receiverThreadIds: [],
+          agentsStates: {
+            "child-thread": {
+              status: "running",
+              message: "wait timed out",
+            },
+          },
+        },
+      },
+    });
+
+    expect(runtime.recordTaskRunProgressByRunId).toHaveBeenCalledWith({
+      runId: "codex-thread:child-thread",
+      runtime: "subagent",
+      lastEventAt: 47_000,
+      progressSummary: "wait timed out",
+    });
+    expect(runtime.finalizeTaskRunByRunId).not.toHaveBeenCalled();
+  });
+
   it("preserves a completed collab agent message when the thread later goes idle", () => {
     const runtime = createRuntime();
     const mirror = new CodexNativeSubagentTaskMirror(
@@ -319,6 +447,65 @@ describe("CodexNativeSubagentTaskMirror", () => {
       lastEventAt: 50_000,
       progressSummary: "No user task is specified.",
       terminalSummary: "No user task is specified.",
+    });
+  });
+
+  it("lets terminal collab agent state correct an earlier idle thread status", () => {
+    const runtime = createRuntime();
+    const mirror = new CodexNativeSubagentTaskMirror(
+      {
+        parentThreadId: "parent-thread",
+        requesterSessionKey: "agent:main:main",
+        now: () => 55_000,
+      },
+      runtime,
+    );
+
+    mirror.handleNotification({
+      method: "thread/status/changed",
+      params: {
+        threadId: "child-thread",
+        status: { type: "idle" },
+      },
+    });
+    mirror.handleNotification({
+      method: "item/completed",
+      params: {
+        item: {
+          type: "collabAgentToolCall",
+          tool: "spawnAgent",
+          status: "failed",
+          senderThreadId: "parent-thread",
+          receiverThreadIds: ["child-thread"],
+          prompt: "read cwd",
+          agentsStates: {
+            "child-thread": {
+              status: "pendingInit",
+              message: "Native hook relay unavailable",
+            },
+          },
+        },
+      },
+    });
+
+    expect(runtime.finalizeTaskRunByRunId).toHaveBeenNthCalledWith(1, {
+      runId: "codex-thread:child-thread",
+      runtime: "subagent",
+      status: "succeeded",
+      endedAt: 55_000,
+      lastEventAt: 55_000,
+      progressSummary: "Codex native subagent is idle.",
+      terminalSummary: "Codex native subagent finished.",
+    });
+    expect(runtime.finalizeTaskRunByRunId).toHaveBeenNthCalledWith(2, {
+      runId: "codex-thread:child-thread",
+      runtime: "subagent",
+      status: "failed",
+      endedAt: 55_000,
+      lastEventAt: 55_000,
+      error: "Native hook relay unavailable",
+      progressSummary: "Native hook relay unavailable",
+      terminalSummary: "Native hook relay unavailable",
     });
   });
 

--- a/extensions/codex/src/app-server/native-subagent-task-mirror.ts
+++ b/extensions/codex/src/app-server/native-subagent-task-mirror.ts
@@ -192,14 +192,45 @@ export class CodexNativeSubagentTaskMirror {
       return;
     }
     const receiverThreadIds = readStringArray(item.receiverThreadIds);
-    if (normalizeToolName(readString(item, "tool")) === "spawnagent") {
+    const isSpawnAgentTool = normalizeToolName(readString(item, "tool")) === "spawnagent";
+    if (isSpawnAgentTool) {
       for (const receiverThreadId of receiverThreadIds) {
         this.createTaskFromCollabSpawnItem(receiverThreadId, item);
       }
     }
     const agentsStates = readAgentsStates(item.agentsStates);
+    const toolCallStatus = normalizeCollabToolCallStatus(readString(item, "status"));
+    const terminalToolCallThreadIds = new Set<string>();
+    if (isSpawnAgentTool && isBlockedOrFailedCollabToolCallStatus(toolCallStatus)) {
+      for (const threadId of receiverThreadIds) {
+        terminalToolCallThreadIds.add(threadId);
+      }
+      for (const threadId of agentsStates.keys()) {
+        terminalToolCallThreadIds.add(threadId);
+      }
+    }
+    const terminalAgentStateThreadIds = new Set<string>();
     for (const [threadId, state] of agentsStates) {
-      this.applyCollabAgentStatus(threadId, state.status, state.message);
+      const normalizedStatus = normalizeAgentStateStatus(state.status);
+      if (
+        terminalToolCallThreadIds.has(threadId) &&
+        isNonTerminalAgentStateStatus(normalizedStatus)
+      ) {
+        continue;
+      }
+      this.applyCollabAgentStatus(threadId, normalizedStatus, state.message);
+      if (isTerminalAgentStateStatus(normalizedStatus)) {
+        terminalAgentStateThreadIds.add(threadId);
+      }
+    }
+    if (isBlockedOrFailedCollabToolCallStatus(toolCallStatus)) {
+      for (const threadId of terminalToolCallThreadIds) {
+        if (terminalAgentStateThreadIds.has(threadId)) {
+          continue;
+        }
+        const state = agentsStates.get(threadId);
+        this.applyCollabAgentStatus(threadId, toolCallStatus, state?.message);
+      }
     }
   }
 
@@ -246,6 +277,9 @@ export class CodexNativeSubagentTaskMirror {
       return;
     }
     const runId = codexNativeSubagentRunId(threadId);
+    if (this.terminalRunIds.has(runId) && isNonTerminalAgentStateStatus(normalizedStatus)) {
+      return;
+    }
     const eventAt = this.now();
     if (normalizedStatus === "pendingInit" || normalizedStatus === "running") {
       this.runtime.recordTaskRunProgressByRunId({
@@ -270,6 +304,20 @@ export class CodexNativeSubagentTaskMirror {
         lastEventAt: eventAt,
         progressSummary: trimOptional(message) ?? "Codex native subagent completed.",
         terminalSummary: trimOptional(message) ?? "Codex native subagent finished.",
+      });
+      return;
+    }
+    if (normalizedStatus === "blocked") {
+      this.terminalRunIds.add(runId);
+      this.runtime.finalizeTaskRunByRunId({
+        runId,
+        runtime: CODEX_NATIVE_SUBAGENT_RUNTIME,
+        status: "succeeded",
+        endedAt: eventAt,
+        lastEventAt: eventAt,
+        progressSummary: trimOptional(message) ?? "Codex native subagent blocked.",
+        terminalSummary: trimOptional(message) ?? "Codex native subagent blocked.",
+        terminalOutcome: "blocked",
       });
       return;
     }
@@ -381,6 +429,35 @@ function normalizeToolName(value: string | undefined): string | undefined {
   return value?.replace(/[^a-z0-9]/giu, "").toLowerCase();
 }
 
+function normalizeCollabToolCallStatus(value: string | undefined): string | undefined {
+  const key = value?.replace(/[^a-z0-9]/giu, "").toLowerCase();
+  if (key === "completed" || key === "succeeded" || key === "success") {
+    return "completed";
+  }
+  if (key === "failed" || key === "error" || key === "errored") {
+    return "failed";
+  }
+  if (key === "blocked" || key === "declined") {
+    return "blocked";
+  }
+  if (key === "inprogress" || key === "running") {
+    return "running";
+  }
+  return value?.trim();
+}
+
+function isBlockedOrFailedCollabToolCallStatus(value: string | undefined): boolean {
+  return value === "failed" || value === "blocked";
+}
+
+function isNonTerminalAgentStateStatus(value: string | undefined): boolean {
+  return value === "pendingInit" || value === "running";
+}
+
+function isTerminalAgentStateStatus(value: string | undefined): boolean {
+  return value !== undefined && !isNonTerminalAgentStateStatus(value);
+}
+
 function normalizeAgentStateStatus(value: string | undefined): string | undefined {
   const key = value?.replace(/[^a-z0-9]/giu, "").toLowerCase();
   if (!key) {
@@ -400,6 +477,9 @@ function normalizeAgentStateStatus(value: string | undefined): string | undefine
   }
   if (key === "failed" || key === "error" || key === "systemerror") {
     return "failed";
+  }
+  if (key === "blocked" || key === "declined") {
+    return "blocked";
   }
   return value?.trim();
 }


### PR DESCRIPTION
Summary
- Mark Codex-native subagent tasks terminal when a `spawnAgent` collab tool call fails or is blocked while child `agentsStates` is still nonterminal.
- Preserve normal success/running semantics by not treating completed `spawnAgent` tool calls as completed subagents and not treating failed non-spawn collab tools as failed subagents.
- Allow later terminal collab state to correct an earlier thread-level idle success.

Verification
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/native-subagent-task-mirror.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 extensions/codex/src/app-server/native-subagent-task-mirror.ts extensions/codex/src/app-server/native-subagent-task-mirror.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/codex/src/app-server/native-subagent-task-mirror.ts extensions/codex/src/app-server/native-subagent-task-mirror.test.ts`
- `git diff --check`
- `AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --mode local`

Real behavior proof
Behavior addressed: Codex-native subagent task registry entries can remain running when the parent receives a terminal blocked/failed `spawnAgent` result but the child agent state is still stale/nonterminal, such as `pendingInit` with `Native hook relay unavailable`.
Real environment tested: Local OpenClaw source checkout on macOS with focused Codex app-server mirror tests and Codex-native autoreview; no deterministic live blocked native-hook relay path was available.
Exact steps or command run after this patch: Ran the focused Vitest file plus oxfmt, oxlint, git diff whitespace validation, and `$autoreview` against the uncommitted patch before committing.
Evidence after fix: The regression tests cover blocked `spawnAgent` with stale `pendingInit`, completed `spawnAgent` not implying subagent completion, failed non-spawn tool calls not failing subagents, and terminal collab correction after thread idle.
Observed result after fix: The focused test file passed with 11 tests, static checks passed, and `$autoreview` reported no accepted/actionable findings.
What was not tested: A live Discord/Codex run that deterministically forces `Native hook relay unavailable`; the available live submitter follow-up only confirmed normal successful subagents close cleanly.

Fixes #83852
