### PR TITLE
fix(webchat): scope attachment button input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - WebChat: summarize internal message-tool source replies so tool cards no longer duplicate the visible reply body. (#84773) Thanks @jason-allen-oneal.
+- WebChat: scope the visible attachment button to its own composer file input so clicking Upload reliably opens the file picker. (#83952, fixes #47983) Thanks @jason-allen-oneal.
 - Gateway: preserve deferred lifecycle-error cleanup across later non-terminal events so provider timeouts can persist failed session state instead of leaving sessions stuck running. (#85256, fixes #63819) Thanks @samzong.
 - Agents/subagents: report tool-only child progress during timeout summaries instead of showing no visible output.
 - Telegram/ACP: preserve explicit `:topic:` conversation suffixes when inbound ACP targets do not carry a separate thread id.

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -1070,6 +1070,26 @@ describe("chat attachment picker", () => {
     expect(getChatAttachmentDataUrl(attachments[0])).toBe(`data:image/png;base64,${base64}`);
   });
 
+  it("opens the scoped file input from the visible attach button", () => {
+    const container = renderChatView();
+    const input = requireElement(
+      container,
+      ".agent-chat__file-input",
+      "attachment file input",
+    ) as HTMLInputElement;
+    const attachButton = requireElement(
+      container,
+      `[aria-label="${t("chat.composer.attachFile")}"]`,
+      "attach button",
+    ) as HTMLButtonElement;
+    const clickInput = vi.spyOn(input, "click").mockImplementation(() => undefined);
+
+    attachButton.click();
+
+    expect(attachButton.type).toBe("button");
+    expect(clickInput).toHaveBeenCalledTimes(1);
+  });
+
   it("accepts and previews non-video file attachments", async () => {
     const onAttachmentsChange = vi.fn();
     const container = renderChatView({ onAttachmentsChange });

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -427,6 +427,17 @@ function focusComposerFromChrome(event: MouseEvent, connected: boolean) {
     ?.focus({ preventScroll: true });
 }
 
+function clickComposerFileInput(event: MouseEvent) {
+  const target = event.currentTarget;
+  if (!(target instanceof HTMLElement)) {
+    return;
+  }
+  target
+    .closest(".agent-chat__input")
+    ?.querySelector<HTMLInputElement>(".agent-chat__file-input")
+    ?.click();
+}
+
 function restoreHistoryCaret(target: HTMLTextAreaElement, direction: "up" | "down") {
   requestAnimationFrame(() => {
     if (document.activeElement !== target) {
@@ -1562,10 +1573,9 @@ export function renderChat(props: ChatProps) {
         <div class="agent-chat__toolbar">
           <div class="agent-chat__toolbar-left">
             <button
+              type="button"
               class="agent-chat__input-btn"
-              @click=${() => {
-                document.querySelector<HTMLInputElement>(".agent-chat__file-input")?.click();
-              }}
+              @click=${clickComposerFileInput}
               title=${t("chat.composer.attachFile")}
               aria-label=${t("chat.composer.attachFile")}
               ?disabled=${!props.connected}


### PR DESCRIPTION
## Summary
- route the visible WebChat attachment button to the file input inside its own composer instead of using a document-wide query
- mark the toolbar control as type=button so it cannot accidentally submit surrounding forms
- add coverage for the visible button-to-hidden-input activation path

## Verification
- pnpm exec oxfmt --check --threads=1 ui/src/ui/views/chat.ts ui/src/ui/views/chat.test.ts CHANGELOG.md
- node scripts/run-vitest.mjs ui/src/ui/views/chat.test.ts
- pnpm check:changed
- git diff --check

## Not Run
- Live Chrome/Windows native file-picker smoke; this environment is headless/Linux.

## Real behavior proof

- Behavior or issue addressed: WebChat's visible attachment button must trigger the hidden file input in the same `.agent-chat__input` composer, not the first `.agent-chat__file-input` in the document. This covers issue #47983 in `ui/src/ui/views/chat.ts`.
- Real environment tested: Local Linux 6.19.14+kali-amd64 checkout of PR head `b0f962a4b1`; Node v22.22.2; pnpm 11.1.0 via corepack. DOM smoke used Lit + jsdom with the actual `renderChat(...)` implementation from `ui/src/ui/views/chat.ts`.
- Exact steps or command run after this patch:
  1. Created an untracked DOM smoke script under `.artifacts/proof-83952/` that imports `ui/src/ui/views/chat.ts`, renders two WebChat composers, stubs both hidden file inputs' `.click()`, then clicks the second visible attachment button.
  2. `corepack pnpm install --frozen-lockfile`
  3. `node --import tsx .artifacts/proof-83952/webchat-attachment-button-dom-smoke.mjs`
- Evidence after fix: Terminal stdout from the DOM smoke command:
  ```json
  {
    "composerCount": 2,
    "firstAttachButtonType": "button",
    "secondAttachButtonType": "button",
    "firstFileInputInFirstComposer": true,
    "secondFileInputInSecondComposer": true,
    "clickedInputSequence": ["second-file-input"],
    "secondButtonClickedOnlyItsOwnFileInput": true
  }
  ```
- Observed result after fix: Clicking the visible attachment button in the second rendered WebChat composer invoked only that second composer's hidden `.agent-chat__file-input`; the first composer's input was not clicked. The visible attachment buttons rendered as `type="button"`, so the click cannot submit surrounding form chrome.
- What was not tested: Did not interact with the OS-native file picker dialog, because headless DOM/browser automation cannot inspect that dialog directly. Did not run a full gateway/WebChat server or verify the later selected-file upload/send pipeline.

Fixes openclaw/openclaw#47983

## Current-head browser proof refresh (2026-05-19)

Reran a browser-level WebChat upload proof at PR head `b0f962a4b1a0e8983ef82ffddcc798f15ff7d270` using Playwright Chromium `148.0.7778.96` against the actual `renderChat(...)` output bundled from this branch.

Browser proof summary:
```json
{
  "pr": 83952,
  "head": "b0f962a4b1a0e8983ef82ffddcc798f15ff7d270",
  "browser": "148.0.7778.96",
  "fileChooserOpened": true,
  "selectedFile": "openclaw-pr83952-proof-brief.txt",
  "proof": {
    "attachments": [
      {
        "fileName": "openclaw-pr83952-proof-brief.txt",
        "mimeType": "text/plain",
        "sizeBytes": 22,
        "hasDataUrl": true
      }
    ],
    "previewName": "openclaw-pr83952-proof-brief.txt",
    "attachButtonType": "button"
  },
  "consoleErrors": []
}
```

Commands run at current head:
- Browser proof: bundled a small proof page importing `ui/src/ui/views/chat.ts`, opened it in Playwright Chromium, clicked the visible attachment button, observed a real browser `filechooser` event, selected a small non-video text file, and verified `onAttachmentsChange`, Data URL payload registration, and rendered attachment preview name.
- `node scripts/run-vitest.mjs ui/src/ui/views/chat.test.ts` -> 1 test file passed, 39 tests passed.
- `git diff --check` -> passed.

Not run: live Windows Chrome native file-picker smoke; this host is Linux.
