### PR TITLE
feat(cli): add sessions tail progress view

### DIFF
--- a/docs/cli/sessions.md
+++ b/docs/cli/sessions.md
@@ -47,6 +47,20 @@ Scope selection:
 - `--store <path>`: explicit store path (cannot be combined with `--agent` or `--all-agents`)
 - `--limit <n|all>`: max rows to output (default `100`; `all` restores full output)
 
+Tail human-readable trajectory progress for stored sessions:
+
+```bash
+openclaw sessions tail
+openclaw sessions tail --follow
+openclaw sessions tail --session-key "agent:main:telegram:direct:123" --tail 25
+openclaw sessions --agent work tail --follow
+openclaw sessions --all-agents tail --follow
+```
+
+`openclaw sessions tail` renders recent trajectory JSONL events as compact progress lines. Without `--session-key`, it tails running sessions first, then the latest stored session. `--tail <count>` controls how many existing events print before follow mode; the default is `80`, and `0` starts at the current end. `--follow` keeps watching the selected trajectory files, including relocated files referenced by `<session>.trajectory-path.json`.
+
+The progress view is intentionally conservative: prompt text, tool arguments, and tool result bodies are not printed. Tool calls show the tool name with `{...redacted...}`; tool results show status such as `ok`, `error`, or `done`; model completion lines show provider/model and terminal status.
+
 Export a trajectory bundle for a stored session:
 
 ```bash

--- a/src/cli/program/register.status-health-sessions.test.ts
+++ b/src/cli/program/register.status-health-sessions.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   healthCommand: vi.fn(),
   sessionsCommand: vi.fn(),
   sessionsCleanupCommand: vi.fn(),
+  sessionsTailCommand: vi.fn(),
   exportTrajectoryCommand: vi.fn(),
   commitmentsListCommand: vi.fn(),
   commitmentsDismissCommand: vi.fn(),
@@ -31,6 +32,7 @@ const statusCommand = mocks.statusCommand;
 const healthCommand = mocks.healthCommand;
 const sessionsCommand = mocks.sessionsCommand;
 const sessionsCleanupCommand = mocks.sessionsCleanupCommand;
+const sessionsTailCommand = mocks.sessionsTailCommand;
 const exportTrajectoryCommand = mocks.exportTrajectoryCommand;
 const commitmentsListCommand = mocks.commitmentsListCommand;
 const commitmentsDismissCommand = mocks.commitmentsDismissCommand;
@@ -88,6 +90,10 @@ vi.mock("../../commands/sessions-cleanup.js", () => ({
   sessionsCleanupCommand: mocks.sessionsCleanupCommand,
 }));
 
+vi.mock("../../commands/sessions-tail.js", () => ({
+  sessionsTailCommand: mocks.sessionsTailCommand,
+}));
+
 vi.mock("../../commands/export-trajectory.js", () => ({
   exportTrajectoryCommand: mocks.exportTrajectoryCommand,
 }));
@@ -134,6 +140,7 @@ describe("registerStatusHealthSessionsCommands", () => {
     healthCommand.mockResolvedValue(undefined);
     sessionsCommand.mockResolvedValue(undefined);
     sessionsCleanupCommand.mockResolvedValue(undefined);
+    sessionsTailCommand.mockResolvedValue(undefined);
     exportTrajectoryCommand.mockResolvedValue(undefined);
     commitmentsListCommand.mockResolvedValue(undefined);
     commitmentsDismissCommand.mockResolvedValue(undefined);
@@ -342,6 +349,31 @@ describe("registerStatusHealthSessionsCommands", () => {
 
     expectCommandOptions(sessionsCleanupCommand, {
       allAgents: true,
+    });
+  });
+
+  it("runs sessions tail with forwarded progress options", async () => {
+    await runCli([
+      "sessions",
+      "--store",
+      "/tmp/sessions.json",
+      "--agent",
+      "work",
+      "tail",
+      "--session-key",
+      "agent:main:telegram:direct:owner",
+      "--tail",
+      "5",
+      "--follow",
+    ]);
+
+    expectCommandOptions(sessionsTailCommand, {
+      sessionKey: "agent:main:telegram:direct:owner",
+      store: "/tmp/sessions.json",
+      agent: "work",
+      allAgents: false,
+      follow: true,
+      tail: "5",
     });
   });
 

--- a/src/cli/program/register.status-health-sessions.ts
+++ b/src/cli/program/register.status-health-sessions.ts
@@ -287,6 +287,39 @@ export function registerStatusHealthSessionsCommands(program: Command) {
     });
 
   sessionsCmd
+    .command("tail")
+    .description("Tail human-readable session trajectory progress")
+    .option("--session-key <key>", "Session key to tail (default: active sessions or latest)")
+    .option("--tail <count>", "Number of existing trajectory events to show", "80")
+    .option("--follow", "Continue following for new trajectory events", false)
+    .option("--store <path>", "Path to session store (default: resolved from config)")
+    .option("--agent <id>", "Agent id to inspect (default: configured default agent)")
+    .option("--all-agents", "Aggregate sessions across all configured agents", false)
+    .action(async (opts, command) => {
+      const parentOpts = command.parent?.opts() as
+        | {
+            store?: string;
+            agent?: string;
+            allAgents?: boolean;
+          }
+        | undefined;
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        const { sessionsTailCommand } = await import("../../commands/sessions-tail.js");
+        await sessionsTailCommand(
+          {
+            sessionKey: opts.sessionKey as string | undefined,
+            store: (opts.store as string | undefined) ?? parentOpts?.store,
+            agent: (opts.agent as string | undefined) ?? parentOpts?.agent,
+            allAgents: Boolean(opts.allAgents || parentOpts?.allAgents),
+            follow: Boolean(opts.follow),
+            tail: opts.tail as string | undefined,
+          },
+          defaultRuntime,
+        );
+      });
+    });
+
+  sessionsCmd
     .command("export-trajectory")
     .description("Export a redacted trajectory bundle for a stored session")
     .option("--session-key <key>", "Session key to export")

--- a/src/commands/sessions-tail.test.ts
+++ b/src/commands/sessions-tail.test.ts
@@ -24,7 +24,9 @@ function makeRuntime(): RuntimeEnv {
   };
 }
 
-function makeEvent(params: Partial<TrajectoryEvent> & { type: string; ts: string }): TrajectoryEvent {
+function makeEvent(
+  params: Partial<TrajectoryEvent> & { type: string; ts: string },
+): TrajectoryEvent {
   return {
     traceSchema: "openclaw-trajectory",
     schemaVersion: 1,
@@ -45,9 +47,17 @@ describe("sessionsTailCommand", () => {
   let tmpDir: string;
   let storePath: string;
   let trajectoryPath: string;
+  let previousStateDir: string | undefined;
 
   beforeEach(() => {
+    previousStateDir = process.env.OPENCLAW_STATE_DIR;
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sessions-tail-"));
+    process.env.OPENCLAW_STATE_DIR = path.join(tmpDir, "state");
+    mocks.getRuntimeConfig.mockReturnValue({
+      agents: {
+        list: [{ id: "main" }, { id: "ops" }],
+      },
+    });
     storePath = path.join(tmpDir, "sessions.json");
     trajectoryPath = path.join(tmpDir, "session-one.trajectory.jsonl");
     fs.writeFileSync(
@@ -64,6 +74,11 @@ describe("sessionsTailCommand", () => {
   });
 
   afterEach(() => {
+    if (previousStateDir === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = previousStateDir;
+    }
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
@@ -90,7 +105,10 @@ describe("sessionsTailCommand", () => {
 
     await sessionsTailCommand({ store: storePath, sessionKey }, runtime);
 
-    const output = vi.mocked(runtime.log).mock.calls.map((call) => String(call[0])).join("\n");
+    const output = vi
+      .mocked(runtime.log)
+      .mock.calls.map((call) => String(call[0]))
+      .join("\n");
     expect(output).toContain("12:04:18");
     expect(output).toContain("tool.call");
     expect(output).toContain("bash {...redacted...}");
@@ -119,9 +137,50 @@ describe("sessionsTailCommand", () => {
 
     await sessionsTailCommand({ store: storePath, sessionKey, tail: "2" }, runtime);
 
-    const output = vi.mocked(runtime.log).mock.calls.map((call) => String(call[0])).join("\n");
+    const output = vi
+      .mocked(runtime.log)
+      .mock.calls.map((call) => String(call[0]))
+      .join("\n");
     expect(output).not.toContain("session.started");
     expect(output).toContain("tool.call");
     expect(output).toContain("tool.result");
+  });
+
+  it("resolves the target store from a fully qualified non-default agent session key", async () => {
+    const runtime = makeRuntime();
+    const opsSessionKey = "agent:ops:telegram:direct:owner";
+    const opsSessionsDir = path.join(process.env.OPENCLAW_STATE_DIR!, "agents", "ops", "sessions");
+    fs.mkdirSync(opsSessionsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(opsSessionsDir, "sessions.json"),
+      `${JSON.stringify({
+        [opsSessionKey]: {
+          sessionId: "ops-session",
+          sessionFile: "ops-session.jsonl",
+          updatedAt: 3,
+          status: "done",
+        },
+      })}\n`,
+    );
+    writeJsonl(path.join(opsSessionsDir, "ops-session.trajectory.jsonl"), [
+      makeEvent({
+        sessionId: "ops-session",
+        sessionKey: opsSessionKey,
+        type: "tool.result",
+        ts: "2026-05-18T12:04:21.000Z",
+        data: { name: "bash", success: true },
+      }),
+    ]);
+
+    await sessionsTailCommand({ sessionKey: opsSessionKey }, runtime);
+
+    const output = vi
+      .mocked(runtime.log)
+      .mock.calls.map((call) => String(call[0]))
+      .join("\n");
+    expect(output).toContain("agent:ops:telegram:direct:own…");
+    expect(output).toContain("tool.result");
+    expect(output).toContain("bash ok");
+    expect(output).not.toContain("No sessions found");
   });
 });

--- a/src/commands/sessions-tail.test.ts
+++ b/src/commands/sessions-tail.test.ts
@@ -1,0 +1,127 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { RuntimeEnv } from "../runtime.js";
+import type { TrajectoryEvent } from "../trajectory/types.js";
+import { sessionsTailCommand } from "./sessions-tail.js";
+
+const mocks = vi.hoisted(() => ({
+  getRuntimeConfig: vi.fn(() => ({})),
+}));
+
+vi.mock("../config/config.js", () => ({
+  getRuntimeConfig: mocks.getRuntimeConfig,
+}));
+
+const sessionKey = "agent:main:telegram:direct:owner";
+
+function makeRuntime(): RuntimeEnv {
+  return {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn(),
+  };
+}
+
+function makeEvent(params: Partial<TrajectoryEvent> & { type: string; ts: string }): TrajectoryEvent {
+  return {
+    traceSchema: "openclaw-trajectory",
+    schemaVersion: 1,
+    traceId: "trace-1",
+    source: "runtime",
+    seq: 1,
+    sessionId: "session-one",
+    sessionKey,
+    ...params,
+  };
+}
+
+function writeJsonl(filePath: string, events: TrajectoryEvent[]): void {
+  fs.writeFileSync(filePath, `${events.map((event) => JSON.stringify(event)).join("\n")}\n`);
+}
+
+describe("sessionsTailCommand", () => {
+  let tmpDir: string;
+  let storePath: string;
+  let trajectoryPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sessions-tail-"));
+    storePath = path.join(tmpDir, "sessions.json");
+    trajectoryPath = path.join(tmpDir, "session-one.trajectory.jsonl");
+    fs.writeFileSync(
+      storePath,
+      `${JSON.stringify({
+        [sessionKey]: {
+          sessionId: "session-one",
+          sessionFile: "session-one.jsonl",
+          updatedAt: 2,
+          status: "running",
+        },
+      })}\n`,
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("renders compact redacted progress lines", async () => {
+    const runtime = makeRuntime();
+    writeJsonl(trajectoryPath, [
+      makeEvent({
+        type: "tool.call",
+        ts: "2026-05-18T12:04:18.000Z",
+        data: { name: "bash", arguments: { command: "echo SECRET" } },
+      }),
+      makeEvent({
+        type: "tool.result",
+        ts: "2026-05-18T12:04:21.000Z",
+        data: { name: "bash", success: true, output: "SECRET" },
+      }),
+      makeEvent({
+        type: "model.completed",
+        ts: "2026-05-18T12:04:29.000Z",
+        provider: "openai",
+        modelId: "gpt-5.2",
+      }),
+    ]);
+
+    await sessionsTailCommand({ store: storePath, sessionKey }, runtime);
+
+    const output = vi.mocked(runtime.log).mock.calls.map((call) => String(call[0])).join("\n");
+    expect(output).toContain("12:04:18");
+    expect(output).toContain("tool.call");
+    expect(output).toContain("bash {...redacted...}");
+    expect(output).toContain("tool.result");
+    expect(output).toContain("bash ok");
+    expect(output).toContain("model.completed");
+    expect(output).toContain("openai/gpt-5.2 done");
+    expect(output).not.toContain("SECRET");
+  });
+
+  it("honors the tail count before rendering existing trajectory events", async () => {
+    const runtime = makeRuntime();
+    writeJsonl(trajectoryPath, [
+      makeEvent({ type: "session.started", ts: "2026-05-18T12:04:17.000Z" }),
+      makeEvent({
+        type: "tool.call",
+        ts: "2026-05-18T12:04:18.000Z",
+        data: { name: "bash" },
+      }),
+      makeEvent({
+        type: "tool.result",
+        ts: "2026-05-18T12:04:21.000Z",
+        data: { name: "bash", success: true },
+      }),
+    ]);
+
+    await sessionsTailCommand({ store: storePath, sessionKey, tail: "2" }, runtime);
+
+    const output = vi.mocked(runtime.log).mock.calls.map((call) => String(call[0])).join("\n");
+    expect(output).not.toContain("session.started");
+    expect(output).toContain("tool.call");
+    expect(output).toContain("tool.result");
+  });
+});

--- a/src/commands/sessions-tail.test.ts
+++ b/src/commands/sessions-tail.test.ts
@@ -237,6 +237,47 @@ describe("sessionsTailCommand", () => {
     expect(output).toContain("bash ok");
   });
 
+  it("continues following when a bounded trajectory window is rewritten", async () => {
+    const runtime = makeRuntime();
+    writeJsonl(trajectoryPath, [
+      makeEvent({
+        sourceSeq: 1,
+        type: "session.started",
+        ts: "2026-05-18T12:04:17.000Z",
+      }),
+    ]);
+    const rewrittenEvent = makeEvent({
+      sourceSeq: 2,
+      type: "tool.result",
+      ts: "2026-05-18T12:04:21.000Z",
+      data: { name: "python", success: true },
+    });
+    let rewritten = false;
+    vi.mocked(runtime.log).mockImplementation((message) => {
+      if (!rewritten && String(message).includes("session.started")) {
+        rewritten = true;
+        const nextPath = path.join(tmpDir, "session-one.next.trajectory.jsonl");
+        writeJsonl(nextPath, [rewrittenEvent]);
+        fs.renameSync(nextPath, trajectoryPath);
+      }
+    });
+
+    const run = sessionsTailCommand(
+      { store: storePath, sessionKey, tail: "1", follow: true },
+      runtime,
+    );
+    try {
+      await waitForRuntimeOutput(runtime, "python ok");
+    } finally {
+      process.emit("SIGTERM", "SIGTERM");
+      await run;
+    }
+
+    const output = runtimeOutput(runtime);
+    expect(output).toContain("tool.result");
+    expect(output).toContain("python ok");
+  });
+
   it("resolves the target store from a fully qualified non-default agent session key", async () => {
     const runtime = makeRuntime();
     const opsSessionKey = "agent:ops:telegram:direct:owner";

--- a/src/commands/sessions-tail.test.ts
+++ b/src/commands/sessions-tail.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { RuntimeEnv } from "../runtime.js";
+import { resolveTrajectoryPointerFilePath } from "../trajectory/paths.js";
 import type { TrajectoryEvent } from "../trajectory/types.js";
 import { sessionsTailCommand } from "./sessions-tail.js";
 
@@ -169,6 +170,36 @@ describe("sessionsTailCommand", () => {
     expect(output).not.toContain("session.started");
     expect(output).toContain("tool.call");
     expect(output).toContain("tool.result");
+  });
+
+  it("uses a session trajectory pointer for relocated runtime files", async () => {
+    const runtime = makeRuntime();
+    const relocatedDir = path.join(tmpDir, "relocated-trajectories");
+    const relocatedTrajectoryPath = path.join(relocatedDir, "session-one.jsonl");
+    fs.mkdirSync(relocatedDir, { recursive: true });
+    fs.writeFileSync(
+      resolveTrajectoryPointerFilePath(path.join(tmpDir, "session-one.jsonl")),
+      `${JSON.stringify({
+        traceSchema: "openclaw-trajectory-pointer",
+        schemaVersion: 1,
+        sessionId: "session-one",
+        runtimeFile: relocatedTrajectoryPath,
+      })}\n`,
+    );
+    writeJsonl(relocatedTrajectoryPath, [
+      makeEvent({
+        type: "tool.result",
+        ts: "2026-05-18T12:04:21.000Z",
+        data: { name: "bash", success: true },
+      }),
+    ]);
+
+    await sessionsTailCommand({ store: storePath, sessionKey }, runtime);
+
+    const output = runtimeOutput(runtime);
+    expect(output).toContain("tool.result");
+    expect(output).toContain("bash ok");
+    expect(output).not.toContain("No sessions found");
   });
 
   it("preserves events appended while follow mode starts", async () => {

--- a/src/commands/sessions-tail.test.ts
+++ b/src/commands/sessions-tail.test.ts
@@ -43,6 +43,31 @@ function writeJsonl(filePath: string, events: TrajectoryEvent[]): void {
   fs.writeFileSync(filePath, `${events.map((event) => JSON.stringify(event)).join("\n")}\n`);
 }
 
+function appendJsonl(filePath: string, event: TrajectoryEvent): void {
+  fs.appendFileSync(filePath, `${JSON.stringify(event)}\n`);
+}
+
+function runtimeOutput(runtime: RuntimeEnv): string {
+  return vi
+    .mocked(runtime.log)
+    .mock.calls.map((call) => String(call[0]))
+    .join("\n");
+}
+
+async function waitForRuntimeOutput(
+  runtime: RuntimeEnv,
+  pattern: string,
+  timeoutMs = 3_000,
+): Promise<void> {
+  const startedAt = Date.now();
+  while (!runtimeOutput(runtime).includes(pattern)) {
+    if (Date.now() - startedAt > timeoutMs) {
+      throw new Error(`Timed out waiting for output containing ${pattern}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+}
+
 describe("sessionsTailCommand", () => {
   let tmpDir: string;
   let storePath: string;
@@ -146,6 +171,41 @@ describe("sessionsTailCommand", () => {
     expect(output).toContain("tool.result");
   });
 
+  it("preserves events appended while follow mode starts", async () => {
+    const runtime = makeRuntime();
+    writeJsonl(trajectoryPath, [
+      makeEvent({ type: "session.started", ts: "2026-05-18T12:04:17.000Z" }),
+    ]);
+    const appendedEvent = makeEvent({
+      type: "tool.result",
+      ts: "2026-05-18T12:04:21.000Z",
+      data: { name: "bash", success: true },
+    });
+    let appended = false;
+    vi.mocked(runtime.log).mockImplementation((message) => {
+      if (!appended && String(message).includes("session.started")) {
+        appended = true;
+        appendJsonl(trajectoryPath, appendedEvent);
+      }
+    });
+
+    const run = sessionsTailCommand(
+      { store: storePath, sessionKey, tail: "1", follow: true },
+      runtime,
+    );
+    try {
+      await waitForRuntimeOutput(runtime, "bash ok");
+    } finally {
+      process.emit("SIGTERM", "SIGTERM");
+      await run;
+    }
+
+    const output = runtimeOutput(runtime);
+    expect(output).toContain("session.started");
+    expect(output).toContain("tool.result");
+    expect(output).toContain("bash ok");
+  });
+
   it("resolves the target store from a fully qualified non-default agent session key", async () => {
     const runtime = makeRuntime();
     const opsSessionKey = "agent:ops:telegram:direct:owner";
@@ -174,10 +234,7 @@ describe("sessionsTailCommand", () => {
 
     await sessionsTailCommand({ sessionKey: opsSessionKey }, runtime);
 
-    const output = vi
-      .mocked(runtime.log)
-      .mock.calls.map((call) => String(call[0]))
-      .join("\n");
+    const output = runtimeOutput(runtime);
     expect(output).toContain("agent:ops:telegram:direct:own…");
     expect(output).toContain("tool.result");
     expect(output).toContain("bash ok");

--- a/src/commands/sessions-tail.ts
+++ b/src/commands/sessions-tail.ts
@@ -1,0 +1,367 @@
+import fs from "node:fs";
+import path from "node:path";
+import { getRuntimeConfig } from "../config/config.js";
+import { loadSessionStore } from "../config/sessions.js";
+import { resolveSessionFilePath } from "../config/sessions/paths.js";
+import type { SessionEntry } from "../config/sessions/types.js";
+import { formatErrorMessage } from "../infra/errors.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { resolveTrajectoryFilePath } from "../trajectory/paths.js";
+import type { TrajectoryEvent } from "../trajectory/types.js";
+import { resolveSessionStoreTargetsOrExit } from "./session-store-targets.js";
+import { shortenText } from "./text-format.js";
+
+type SessionsTailOptions = {
+  store?: string;
+  agent?: string;
+  allAgents?: boolean;
+  sessionKey?: string;
+  follow?: boolean;
+  tail?: string | number;
+};
+
+type TailSelection = {
+  agentId: string;
+  key: string;
+  entry: SessionEntry;
+  storePath: string;
+  trajectoryPath: string;
+};
+
+type FollowState = {
+  offset: number;
+  pending: string;
+  selection: TailSelection;
+};
+
+const DEFAULT_TAIL_COUNT = 80;
+const SESSION_KEY_PAD = 30;
+const EVENT_TYPE_PAD = 16;
+const FOLLOW_INTERVAL_MS = 1_000;
+
+function parseTailCount(value: string | number | undefined): number | null {
+  if (value === undefined) {
+    return DEFAULT_TAIL_COUNT;
+  }
+  if (typeof value === "number") {
+    return Number.isInteger(value) && value >= 0 ? value : null;
+  }
+  const trimmed = value.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    return null;
+  }
+  return Number.parseInt(trimmed, 10);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function toOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function isTrajectoryEvent(value: unknown): value is TrajectoryEvent {
+  return (
+    isRecord(value) &&
+    value.traceSchema === "openclaw-trajectory" &&
+    value.schemaVersion === 1 &&
+    typeof value.type === "string" &&
+    typeof value.ts === "string" &&
+    typeof value.sessionId === "string"
+  );
+}
+
+function parseTrajectoryEventLine(line: string): TrajectoryEvent | null {
+  const trimmed = line.trim();
+  if (!trimmed) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    return isTrajectoryEvent(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function formatTimestamp(ts: string): string {
+  const date = new Date(ts);
+  if (Number.isNaN(date.getTime())) {
+    return "--:--:--";
+  }
+  return date.toISOString().slice(11, 19);
+}
+
+function modelLabel(event: TrajectoryEvent): string | undefined {
+  const provider = event.provider?.trim();
+  const model = event.modelId?.trim();
+  if (provider && model) {
+    return `${provider}/${model}`;
+  }
+  return model || provider || undefined;
+}
+
+function toolName(data: Record<string, unknown> | undefined): string {
+  return toOptionalString(data?.name) ?? toOptionalString(data?.toolName) ?? "tool";
+}
+
+function resultStatus(data: Record<string, unknown> | undefined): string {
+  if (data?.success === true) {
+    return "ok";
+  }
+  if (data?.success === false || data?.isError === true) {
+    return "error";
+  }
+  return toOptionalString(data?.status) ?? "done";
+}
+
+function modelCompletionStatus(data: Record<string, unknown> | undefined): string {
+  if (data?.timedOut === true) {
+    return "timeout";
+  }
+  if (data?.aborted === true) {
+    return "aborted";
+  }
+  if (toOptionalString(data?.promptError)) {
+    return "error";
+  }
+  return "done";
+}
+
+function safePreview(event: TrajectoryEvent): string {
+  const data = event.data;
+  switch (event.type) {
+    case "session.started":
+      return "session started";
+    case "context.compiled": {
+      const tools = Array.isArray(data?.tools) ? data.tools.length : undefined;
+      return tools === undefined ? "context compiled" : `context compiled (${tools} tools)`;
+    }
+    case "prompt.submitted":
+      return "prompt submitted";
+    case "prompt.skipped":
+      return `prompt skipped${toOptionalString(data?.reason) ? `: ${data?.reason}` : ""}`;
+    case "tool.call":
+      return `${toolName(data)} {...redacted...}`;
+    case "tool.timeout":
+      return `${toolName(data)} timeout`;
+    case "tool.result":
+      return `${toolName(data)} ${resultStatus(data)}`;
+    case "model.completed": {
+      const model = modelLabel(event);
+      const status = modelCompletionStatus(data);
+      return model ? `${model} ${status}` : status;
+    }
+    case "session.ended":
+      return toOptionalString(data?.status) ?? "ended";
+    case "trace.truncated":
+      return "trajectory truncated";
+    default:
+      return toOptionalString(data?.status) ?? toOptionalString(data?.name) ?? "";
+  }
+}
+
+function formatProgressLine(event: TrajectoryEvent): string {
+  const sessionLabel = shortenText(event.sessionKey ?? event.sessionId, SESSION_KEY_PAD).padEnd(
+    SESSION_KEY_PAD,
+  );
+  const typeLabel = shortenText(event.type, EVENT_TYPE_PAD).padEnd(EVENT_TYPE_PAD);
+  const preview = safePreview(event);
+  return [formatTimestamp(event.ts), typeLabel, sessionLabel, preview].join(" ").trimEnd();
+}
+
+function readTrajectoryLines(filePath: string): string[] {
+  try {
+    const text = fs.readFileSync(filePath, "utf8");
+    return text.split(/\r?\n/u).filter((line) => line.trim().length > 0);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
+}
+
+function renderLines(lines: string[], runtime: RuntimeEnv): void {
+  for (const line of lines) {
+    const event = parseTrajectoryEventLine(line);
+    if (event) {
+      runtime.log(formatProgressLine(event));
+    }
+  }
+}
+
+function isRunningSession(entry: SessionEntry): boolean {
+  return entry.status === "running" || entry.acp?.state === "running";
+}
+
+function compareSelectionsByUpdatedAt(a: TailSelection, b: TailSelection): number {
+  return (b.entry.updatedAt ?? 0) - (a.entry.updatedAt ?? 0);
+}
+
+function buildTailSelection(params: {
+  agentId: string;
+  entry: SessionEntry;
+  key: string;
+  storePath: string;
+}): TailSelection {
+  const sessionsDir = path.dirname(params.storePath);
+  const sessionFile = resolveSessionFilePath(params.entry.sessionId, params.entry, {
+    agentId: params.agentId,
+    sessionsDir,
+  });
+  return {
+    agentId: params.agentId,
+    entry: params.entry,
+    key: params.key,
+    storePath: params.storePath,
+    trajectoryPath: resolveTrajectoryFilePath({
+      sessionFile,
+      sessionId: params.entry.sessionId,
+    }),
+  };
+}
+
+function selectSessionsToTail(selections: TailSelection[], sessionKey?: string): TailSelection[] {
+  const requested = sessionKey?.trim();
+  if (requested) {
+    return selections.filter((selection) => selection.key === requested);
+  }
+
+  const running = selections.filter((selection) => isRunningSession(selection.entry));
+  if (running.length > 0) {
+    return running.toSorted(compareSelectionsByUpdatedAt);
+  }
+
+  const latest = selections.toSorted(compareSelectionsByUpdatedAt)[0];
+  return latest ? [latest] : [];
+}
+
+function statFileSize(filePath: string): number {
+  try {
+    return fs.statSync(filePath).size;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return 0;
+    }
+    throw error;
+  }
+}
+
+function readNewFollowLines(state: FollowState): string[] {
+  let size: number;
+  try {
+    size = fs.statSync(state.selection.trajectoryPath).size;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
+  if (size < state.offset) {
+    state.offset = 0;
+    state.pending = "";
+  }
+  if (size === state.offset) {
+    return [];
+  }
+  const fd = fs.openSync(state.selection.trajectoryPath, "r");
+  try {
+    const buffer = Buffer.alloc(size - state.offset);
+    fs.readSync(fd, buffer, 0, buffer.length, state.offset);
+    state.offset = size;
+    const combined = `${state.pending}${buffer.toString("utf8")}`;
+    const lines = combined.split(/\r?\n/u);
+    state.pending = lines.pop() ?? "";
+    return lines.filter((line) => line.trim().length > 0);
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+async function followSelections(selections: TailSelection[], runtime: RuntimeEnv): Promise<void> {
+  const states = selections.map((selection) => ({
+    offset: statFileSize(selection.trajectoryPath),
+    pending: "",
+    selection,
+  }));
+
+  await new Promise<void>((resolve) => {
+    const interval = setInterval(() => {
+      for (const state of states) {
+        try {
+          renderLines(readNewFollowLines(state), runtime);
+        } catch (error) {
+          runtime.error(
+            `Failed to read trajectory progress for ${state.selection.key}: ${formatErrorMessage(
+              error,
+            )}`,
+          );
+        }
+      }
+    }, FOLLOW_INTERVAL_MS);
+
+    const stop = () => {
+      clearInterval(interval);
+      process.off("SIGINT", stop);
+      process.off("SIGTERM", stop);
+      resolve();
+    };
+    process.once("SIGINT", stop);
+    process.once("SIGTERM", stop);
+  });
+}
+
+export async function sessionsTailCommand(
+  opts: SessionsTailOptions,
+  runtime: RuntimeEnv,
+): Promise<void> {
+  const tailCount = parseTailCount(opts.tail);
+  if (tailCount === null) {
+    runtime.error("--tail must be a non-negative integer, for example --tail 25.");
+    runtime.exit(1);
+    return;
+  }
+
+  const cfg = getRuntimeConfig();
+  const targets = resolveSessionStoreTargetsOrExit({
+    cfg,
+    opts: {
+      store: opts.store,
+      agent: opts.agent,
+      allAgents: opts.allAgents,
+    },
+    runtime,
+  });
+  if (!targets) {
+    return;
+  }
+
+  const selections = targets.flatMap((target) => {
+    const store = loadSessionStore(target.storePath);
+    return Object.entries(store).map(([key, entry]) =>
+      buildTailSelection({
+        agentId: target.agentId,
+        entry,
+        key,
+        storePath: target.storePath,
+      }),
+    );
+  });
+  const selected = selectSessionsToTail(selections, opts.sessionKey);
+  if (selected.length === 0) {
+    const suffix = opts.sessionKey ? ` for ${opts.sessionKey}` : "";
+    runtime.log(`No sessions found${suffix}.`);
+    return;
+  }
+
+  for (const selection of selected) {
+    const lines = readTrajectoryLines(selection.trajectoryPath);
+    renderLines(tailCount > 0 ? lines.slice(-tailCount) : [], runtime);
+  }
+
+  if (opts.follow) {
+    await followSelections(selected, runtime);
+  }
+}

--- a/src/commands/sessions-tail.ts
+++ b/src/commands/sessions-tail.ts
@@ -31,14 +31,29 @@ type TailSelection = {
 };
 
 type FollowState = {
+  cursor: TrajectoryCursor | null;
+  fileState: FollowFileState | null;
   offset: number;
   pending: string;
   selection: TailSelection;
 };
 
 type TrajectorySnapshot = {
-  lines: string[];
+  events: TrajectoryEvent[];
+  fileState: FollowFileState | null;
   offset: number;
+};
+
+type FollowFileState = {
+  dev: number;
+  ino: number;
+  mtimeMs: number;
+  size: number;
+};
+
+type TrajectoryCursor = {
+  seq: number | null;
+  tsMs: number;
 };
 
 const DEFAULT_TAIL_COUNT = 80;
@@ -90,6 +105,69 @@ function parseTrajectoryEventLine(line: string): TrajectoryEvent | null {
   } catch {
     return null;
   }
+}
+
+function parseTrajectoryEventLines(lines: string[]): TrajectoryEvent[] {
+  return lines.flatMap((line) => {
+    const event = parseTrajectoryEventLine(line);
+    return event ? [event] : [];
+  });
+}
+
+function eventSequence(event: TrajectoryEvent): number | null {
+  const seq = event.sourceSeq ?? event.seq;
+  return Number.isFinite(seq) ? seq : null;
+}
+
+function eventTimestampMs(event: TrajectoryEvent): number {
+  const parsed = Date.parse(event.ts);
+  return Number.isFinite(parsed) ? parsed : Number.NEGATIVE_INFINITY;
+}
+
+function eventCursor(event: TrajectoryEvent): TrajectoryCursor {
+  return {
+    seq: eventSequence(event),
+    tsMs: eventTimestampMs(event),
+  };
+}
+
+function compareCursors(left: TrajectoryCursor, right: TrajectoryCursor): number {
+  if (left.seq !== null && right.seq !== null && left.seq !== right.seq) {
+    return left.seq - right.seq;
+  }
+  const byTimestamp = left.tsMs - right.tsMs;
+  if (byTimestamp !== 0) {
+    return byTimestamp;
+  }
+  if (left.seq !== null && right.seq !== null) {
+    return left.seq - right.seq;
+  }
+  return 0;
+}
+
+function maxCursorValue(
+  current: TrajectoryCursor | null,
+  candidate: TrajectoryCursor,
+): TrajectoryCursor {
+  return !current || compareCursors(candidate, current) > 0 ? candidate : current;
+}
+
+function maxCursor(current: TrajectoryCursor | null, event: TrajectoryEvent): TrajectoryCursor {
+  return maxCursorValue(current, eventCursor(event));
+}
+
+function maxCursorFromEvents(events: TrajectoryEvent[]): TrajectoryCursor | null {
+  return events.reduce<TrajectoryCursor | null>((cursor, event) => maxCursor(cursor, event), null);
+}
+
+function eventsAfterCursor(
+  events: TrajectoryEvent[],
+  cursor: TrajectoryCursor | null,
+): TrajectoryEvent[] {
+  if (!cursor) {
+    return events;
+  }
+  return events.filter((event) => compareCursors(eventCursor(event), cursor) > 0);
 }
 
 function formatTimestamp(ts: string): string {
@@ -182,25 +260,51 @@ function formatProgressLine(event: TrajectoryEvent): string {
 
 function readTrajectorySnapshot(filePath: string): TrajectorySnapshot {
   try {
+    const stat = fs.statSync(filePath);
     const text = fs.readFileSync(filePath, "utf8");
     return {
-      lines: text.split(/\r?\n/u).filter((line) => line.trim().length > 0),
+      events: parseTrajectoryEventLines(text.split(/\r?\n/u)),
+      fileState: fileStateFromStat(stat),
       offset: Buffer.byteLength(text, "utf8"),
     };
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      return { lines: [], offset: 0 };
+      return { events: [], fileState: null, offset: 0 };
     }
     throw error;
   }
 }
 
-function renderLines(lines: string[], runtime: RuntimeEnv): void {
-  for (const line of lines) {
-    const event = parseTrajectoryEventLine(line);
-    if (event) {
-      runtime.log(formatProgressLine(event));
+function renderEvents(events: TrajectoryEvent[], runtime: RuntimeEnv): TrajectoryCursor | null {
+  let cursor: TrajectoryCursor | null = null;
+  for (const event of events) {
+    runtime.log(formatProgressLine(event));
+    cursor = maxCursor(cursor, event);
+  }
+  return cursor;
+}
+
+function fileStateFromStat(stat: fs.Stats): FollowFileState {
+  return {
+    dev: stat.dev,
+    ino: stat.ino,
+    mtimeMs: stat.mtimeMs,
+    size: stat.size,
+  };
+}
+
+function sameFileIdentity(left: FollowFileState | null, right: FollowFileState): boolean {
+  return Boolean(left && left.dev === right.dev && left.ino === right.ino);
+}
+
+function readFollowFileState(filePath: string): FollowFileState | null {
+  try {
+    return fileStateFromStat(fs.statSync(filePath));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
     }
+    throw error;
   }
 }
 
@@ -267,53 +371,80 @@ function statFileSize(filePath: string): number {
   }
 }
 
-function readNewFollowLines(state: FollowState): string[] {
-  let size: number;
-  try {
-    size = fs.statSync(state.selection.trajectoryPath).size;
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      return [];
-    }
-    throw error;
-  }
-  if (size < state.offset) {
+function readNewFollowEvents(state: FollowState): TrajectoryEvent[] {
+  const fileState = readFollowFileState(state.selection.trajectoryPath);
+  if (!fileState) {
+    state.fileState = null;
     state.offset = 0;
     state.pending = "";
-  }
-  if (size === state.offset) {
     return [];
   }
+
+  const replaced = !sameFileIdentity(state.fileState, fileState);
+  const truncated = fileState.size < state.offset;
+  const possiblyRewrittenSameSize =
+    fileState.size === state.offset && state.fileState?.mtimeMs !== fileState.mtimeMs;
+
+  if (replaced || truncated || possiblyRewrittenSameSize) {
+    const snapshot = readTrajectorySnapshot(state.selection.trajectoryPath);
+    state.fileState = snapshot.fileState;
+    state.offset = snapshot.offset;
+    state.pending = "";
+    return eventsAfterCursor(snapshot.events, state.cursor);
+  }
+
+  if (fileState.size === state.offset) {
+    state.fileState = fileState;
+    return [];
+  }
+
   const fd = fs.openSync(state.selection.trajectoryPath, "r");
   try {
-    const buffer = Buffer.alloc(size - state.offset);
+    const buffer = Buffer.alloc(fileState.size - state.offset);
     fs.readSync(fd, buffer, 0, buffer.length, state.offset);
-    state.offset = size;
+    state.offset = fileState.size;
+    state.fileState = fileState;
     const combined = `${state.pending}${buffer.toString("utf8")}`;
     const lines = combined.split(/\r?\n/u);
     state.pending = lines.pop() ?? "";
-    return lines.filter((line) => line.trim().length > 0);
+    return parseTrajectoryEventLines(lines);
   } finally {
     fs.closeSync(fd);
+  }
+}
+
+function renderFollowEvents(
+  events: TrajectoryEvent[],
+  state: FollowState,
+  runtime: RuntimeEnv,
+): void {
+  const cursor = renderEvents(events, runtime);
+  if (cursor) {
+    state.cursor = maxCursorValue(state.cursor, cursor);
   }
 }
 
 async function followSelections(
   selections: TailSelection[],
   runtime: RuntimeEnv,
-  initialOffsets: Map<string, number>,
+  initialSnapshots: Map<string, TrajectorySnapshot>,
 ): Promise<void> {
-  const states = selections.map((selection) => ({
-    offset: initialOffsets.get(selection.trajectoryPath) ?? statFileSize(selection.trajectoryPath),
-    pending: "",
-    selection,
-  }));
+  const states = selections.map((selection): FollowState => {
+    const snapshot = initialSnapshots.get(selection.trajectoryPath);
+    return {
+      cursor: snapshot ? maxCursorFromEvents(snapshot.events) : null,
+      fileState: snapshot?.fileState ?? readFollowFileState(selection.trajectoryPath),
+      offset: snapshot?.offset ?? statFileSize(selection.trajectoryPath),
+      pending: "",
+      selection,
+    };
+  });
 
   await new Promise<void>((resolve) => {
     const interval = setInterval(() => {
       for (const state of states) {
         try {
-          renderLines(readNewFollowLines(state), runtime);
+          renderFollowEvents(readNewFollowEvents(state), state, runtime);
         } catch (error) {
           runtime.error(
             `Failed to read trajectory progress for ${state.selection.key}: ${formatErrorMessage(
@@ -388,15 +519,14 @@ export async function sessionsTailCommand(
     return;
   }
 
-  const followOffsets = new Map<string, number>();
+  const followSnapshots = new Map<string, TrajectorySnapshot>();
   for (const selection of selected) {
     const snapshot = readTrajectorySnapshot(selection.trajectoryPath);
-    followOffsets.set(selection.trajectoryPath, snapshot.offset);
-    const lines = snapshot.lines;
-    renderLines(tailCount > 0 ? lines.slice(-tailCount) : [], runtime);
+    followSnapshots.set(selection.trajectoryPath, snapshot);
+    renderEvents(tailCount > 0 ? snapshot.events.slice(-tailCount) : [], runtime);
   }
 
   if (opts.follow) {
-    await followSelections(selected, runtime, followOffsets);
+    await followSelections(selected, runtime, followSnapshots);
   }
 }

--- a/src/commands/sessions-tail.ts
+++ b/src/commands/sessions-tail.ts
@@ -5,6 +5,7 @@ import { loadSessionStore } from "../config/sessions.js";
 import { resolveSessionFilePath } from "../config/sessions/paths.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import { formatErrorMessage } from "../infra/errors.js";
+import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { resolveTrajectoryFilePath } from "../trajectory/paths.js";
 import type { TrajectoryEvent } from "../trajectory/types.js";
@@ -313,6 +314,13 @@ async function followSelections(selections: TailSelection[], runtime: RuntimeEnv
   });
 }
 
+function resolveTailTargetAgent(opts: SessionsTailOptions): string | undefined {
+  if (opts.agent?.trim() || opts.store?.trim() || opts.allAgents === true) {
+    return opts.agent;
+  }
+  return opts.sessionKey?.trim() ? resolveAgentIdFromSessionKey(opts.sessionKey) : undefined;
+}
+
 export async function sessionsTailCommand(
   opts: SessionsTailOptions,
   runtime: RuntimeEnv,
@@ -329,7 +337,7 @@ export async function sessionsTailCommand(
     cfg,
     opts: {
       store: opts.store,
-      agent: opts.agent,
+      agent: resolveTailTargetAgent(opts),
       allAgents: opts.allAgents,
     },
     runtime,

--- a/src/commands/sessions-tail.ts
+++ b/src/commands/sessions-tail.ts
@@ -35,6 +35,11 @@ type FollowState = {
   selection: TailSelection;
 };
 
+type TrajectorySnapshot = {
+  lines: string[];
+  offset: number;
+};
+
 const DEFAULT_TAIL_COUNT = 80;
 const SESSION_KEY_PAD = 30;
 const EVENT_TYPE_PAD = 16;
@@ -172,13 +177,16 @@ function formatProgressLine(event: TrajectoryEvent): string {
   return [formatTimestamp(event.ts), typeLabel, sessionLabel, preview].join(" ").trimEnd();
 }
 
-function readTrajectoryLines(filePath: string): string[] {
+function readTrajectorySnapshot(filePath: string): TrajectorySnapshot {
   try {
     const text = fs.readFileSync(filePath, "utf8");
-    return text.split(/\r?\n/u).filter((line) => line.trim().length > 0);
+    return {
+      lines: text.split(/\r?\n/u).filter((line) => line.trim().length > 0),
+      offset: Buffer.byteLength(text, "utf8"),
+    };
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      return [];
+      return { lines: [], offset: 0 };
     }
     throw error;
   }
@@ -281,9 +289,13 @@ function readNewFollowLines(state: FollowState): string[] {
   }
 }
 
-async function followSelections(selections: TailSelection[], runtime: RuntimeEnv): Promise<void> {
+async function followSelections(
+  selections: TailSelection[],
+  runtime: RuntimeEnv,
+  initialOffsets: Map<string, number>,
+): Promise<void> {
   const states = selections.map((selection) => ({
-    offset: statFileSize(selection.trajectoryPath),
+    offset: initialOffsets.get(selection.trajectoryPath) ?? statFileSize(selection.trajectoryPath),
     pending: "",
     selection,
   }));
@@ -364,12 +376,15 @@ export async function sessionsTailCommand(
     return;
   }
 
+  const followOffsets = new Map<string, number>();
   for (const selection of selected) {
-    const lines = readTrajectoryLines(selection.trajectoryPath);
+    const snapshot = readTrajectorySnapshot(selection.trajectoryPath);
+    followOffsets.set(selection.trajectoryPath, snapshot.offset);
+    const lines = snapshot.lines;
     renderLines(tailCount > 0 ? lines.slice(-tailCount) : [], runtime);
   }
 
   if (opts.follow) {
-    await followSelections(selected, runtime);
+    await followSelections(selected, runtime, followOffsets);
   }
 }

--- a/src/commands/sessions-tail.ts
+++ b/src/commands/sessions-tail.ts
@@ -8,6 +8,7 @@ import { formatErrorMessage } from "../infra/errors.js";
 import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { resolveTrajectoryFilePath } from "../trajectory/paths.js";
+import { resolveTrajectoryRuntimeFile } from "../trajectory/runtime-file.js";
 import type { TrajectoryEvent } from "../trajectory/types.js";
 import { resolveSessionStoreTargetsOrExit } from "./session-store-targets.js";
 import { shortenText } from "./text-format.js";
@@ -211,26 +212,32 @@ function compareSelectionsByUpdatedAt(a: TailSelection, b: TailSelection): numbe
   return (b.entry.updatedAt ?? 0) - (a.entry.updatedAt ?? 0);
 }
 
-function buildTailSelection(params: {
+async function buildTailSelection(params: {
   agentId: string;
   entry: SessionEntry;
   key: string;
   storePath: string;
-}): TailSelection {
+}): Promise<TailSelection> {
   const sessionsDir = path.dirname(params.storePath);
   const sessionFile = resolveSessionFilePath(params.entry.sessionId, params.entry, {
     agentId: params.agentId,
     sessionsDir,
   });
+  const trajectoryPath =
+    (await resolveTrajectoryRuntimeFile({
+      sessionFile,
+      sessionId: params.entry.sessionId,
+    })) ??
+    resolveTrajectoryFilePath({
+      sessionFile,
+      sessionId: params.entry.sessionId,
+    });
   return {
     agentId: params.agentId,
     entry: params.entry,
     key: params.key,
     storePath: params.storePath,
-    trajectoryPath: resolveTrajectoryFilePath({
-      sessionFile,
-      sessionId: params.entry.sessionId,
-    }),
+    trajectoryPath,
   };
 }
 
@@ -360,17 +367,20 @@ export async function sessionsTailCommand(
     return;
   }
 
-  const selections = targets.flatMap((target) => {
+  const selections: TailSelection[] = [];
+  for (const target of targets) {
     const store = loadSessionStore(target.storePath);
-    return Object.entries(store).map(([key, entry]) =>
-      buildTailSelection({
-        agentId: target.agentId,
-        entry,
-        key,
-        storePath: target.storePath,
-      }),
-    );
-  });
+    for (const [key, entry] of Object.entries(store)) {
+      selections.push(
+        await buildTailSelection({
+          agentId: target.agentId,
+          entry,
+          key,
+          storePath: target.storePath,
+        }),
+      );
+    }
+  }
   const selected = selectSessionsToTail(selections, opts.sessionKey);
   if (selected.length === 0) {
     const suffix = opts.sessionKey ? ` for ${opts.sessionKey}` : "";

--- a/src/commands/sessions-tail.ts
+++ b/src/commands/sessions-tail.ts
@@ -146,8 +146,10 @@ function safePreview(event: TrajectoryEvent): string {
     }
     case "prompt.submitted":
       return "prompt submitted";
-    case "prompt.skipped":
-      return `prompt skipped${toOptionalString(data?.reason) ? `: ${data?.reason}` : ""}`;
+    case "prompt.skipped": {
+      const reason = toOptionalString(data?.reason);
+      return `prompt skipped${reason ? `: ${reason}` : ""}`;
+    }
     case "tool.call":
       return `${toolName(data)} {...redacted...}`;
     case "tool.timeout":

--- a/src/trajectory/export.ts
+++ b/src/trajectory/export.ts
@@ -19,12 +19,8 @@ import {
 } from "../logging/diagnostic-support-redaction.js";
 import { isRecord } from "../shared/record-coerce.js";
 import { safeJsonStringify } from "../utils/safe-json.js";
-import {
-  TRAJECTORY_RUNTIME_FILE_MAX_BYTES,
-  resolveTrajectoryFilePath,
-  resolveTrajectoryPointerFilePath,
-  safeTrajectorySessionFileName,
-} from "./paths.js";
+import { TRAJECTORY_RUNTIME_FILE_MAX_BYTES, safeTrajectorySessionFileName } from "./paths.js";
+import { isRegularNonSymlinkFile, resolveTrajectoryRuntimeFile } from "./runtime-file.js";
 import type {
   TrajectoryBundleManifest,
   TrajectoryBundleWarning,
@@ -328,81 +324,6 @@ function summarizeJsonlWarnings(warnings: JsonlParseWarning[]): TrajectoryBundle
     });
   }
   return [...byKey.values()];
-}
-
-async function isRegularNonSymlinkFile(filePath: string): Promise<boolean> {
-  try {
-    const linkStat = await fsp.lstat(filePath);
-    if (linkStat.isSymbolicLink() || !linkStat.isFile()) {
-      return false;
-    }
-    const stat = await fsp.stat(filePath);
-    return stat.isFile() && stat.dev === linkStat.dev && stat.ino === linkStat.ino;
-  } catch {
-    return false;
-  }
-}
-
-async function readRuntimePointerFile(
-  sessionFile: string,
-  sessionId: string,
-): Promise<string | undefined> {
-  const pointerPath = resolveTrajectoryPointerFilePath(sessionFile);
-  if (!(await isRegularNonSymlinkFile(pointerPath))) {
-    return undefined;
-  }
-  try {
-    const parsed = JSON.parse(await fsp.readFile(pointerPath, "utf8")) as unknown;
-    if (!isRecord(parsed)) {
-      return undefined;
-    }
-    if (parsed.sessionId !== sessionId || typeof parsed.runtimeFile !== "string") {
-      return undefined;
-    }
-    const runtimeFile = path.resolve(parsed.runtimeFile);
-    const safeRuntimeFileName = `${safeTrajectorySessionFileName(sessionId)}.jsonl`;
-    const defaultRuntimeFile = path.resolve(
-      resolveTrajectoryFilePath({
-        env: {},
-        sessionFile,
-        sessionId,
-      }),
-    );
-    if (runtimeFile !== defaultRuntimeFile && path.basename(runtimeFile) !== safeRuntimeFileName) {
-      return undefined;
-    }
-    return runtimeFile;
-  } catch {
-    return undefined;
-  }
-}
-
-async function resolveTrajectoryRuntimeFile(params: {
-  runtimeFile?: string;
-  sessionFile: string;
-  sessionId: string;
-}): Promise<string | undefined> {
-  if (params.runtimeFile) {
-    return params.runtimeFile;
-  }
-  const candidates = [
-    await readRuntimePointerFile(params.sessionFile, params.sessionId),
-    resolveTrajectoryFilePath({
-      env: {},
-      sessionFile: params.sessionFile,
-      sessionId: params.sessionId,
-    }),
-    resolveTrajectoryFilePath({
-      sessionFile: params.sessionFile,
-      sessionId: params.sessionId,
-    }),
-  ].filter((candidate): candidate is string => Boolean(candidate));
-  for (const candidate of candidates) {
-    if (await isRegularNonSymlinkFile(candidate)) {
-      return candidate;
-    }
-  }
-  return undefined;
 }
 
 function normalizeTimestamp(value: unknown): string {

--- a/src/trajectory/runtime-file.ts
+++ b/src/trajectory/runtime-file.ts
@@ -1,0 +1,86 @@
+import fsp from "node:fs/promises";
+import path from "node:path";
+import {
+  resolveTrajectoryFilePath,
+  resolveTrajectoryPointerFilePath,
+  safeTrajectorySessionFileName,
+} from "./paths.js";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+export async function isRegularNonSymlinkFile(filePath: string): Promise<boolean> {
+  try {
+    const linkStat = await fsp.lstat(filePath);
+    if (linkStat.isSymbolicLink() || !linkStat.isFile()) {
+      return false;
+    }
+    const stat = await fsp.stat(filePath);
+    return stat.isFile() && stat.dev === linkStat.dev && stat.ino === linkStat.ino;
+  } catch {
+    return false;
+  }
+}
+
+async function readRuntimePointerFile(
+  sessionFile: string,
+  sessionId: string,
+): Promise<string | undefined> {
+  const pointerPath = resolveTrajectoryPointerFilePath(sessionFile);
+  if (!(await isRegularNonSymlinkFile(pointerPath))) {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(await fsp.readFile(pointerPath, "utf8")) as unknown;
+    if (!isRecord(parsed)) {
+      return undefined;
+    }
+    if (parsed.sessionId !== sessionId || typeof parsed.runtimeFile !== "string") {
+      return undefined;
+    }
+    const runtimeFile = path.resolve(parsed.runtimeFile);
+    const safeRuntimeFileName = `${safeTrajectorySessionFileName(sessionId)}.jsonl`;
+    const defaultRuntimeFile = path.resolve(
+      resolveTrajectoryFilePath({
+        env: {},
+        sessionFile,
+        sessionId,
+      }),
+    );
+    if (runtimeFile !== defaultRuntimeFile && path.basename(runtimeFile) !== safeRuntimeFileName) {
+      return undefined;
+    }
+    return runtimeFile;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function resolveTrajectoryRuntimeFile(params: {
+  runtimeFile?: string;
+  sessionFile: string;
+  sessionId: string;
+}): Promise<string | undefined> {
+  if (params.runtimeFile) {
+    return params.runtimeFile;
+  }
+  const candidates = [
+    await readRuntimePointerFile(params.sessionFile, params.sessionId),
+    resolveTrajectoryFilePath({
+      env: {},
+      sessionFile: params.sessionFile,
+      sessionId: params.sessionId,
+    }),
+    resolveTrajectoryFilePath({
+      sessionFile: params.sessionFile,
+      sessionId: params.sessionId,
+    }),
+  ].filter((candidate): candidate is string => Boolean(candidate));
+  for (const candidate of candidates) {
+    if (await isRegularNonSymlinkFile(candidate)) {
+      return candidate;
+    }
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Summary

MVP for #83441.

This adds a human-readable trajectory progress tail under:

```sh
openclaw sessions tail --follow
```

The command renders session trajectory JSONL events into compact operator-facing lines instead of requiring users to find the latest `*.trajectory.jsonl` file and hand-write `jq`.

Follow-ups after ClawSweeper review:

- explicit fully qualified `--session-key` values now resolve the target agent store, so non-default-agent sessions can be tailed without also passing `--agent` or `--all-agents`
- `--follow` carries the initial trajectory read offset forward, so events appended during the initial render-to-follow handoff are not dropped
- `sessions tail` now resolves runtime trajectory files through the same pointer-aware trajectory resolver used by export, so sessions with `OPENCLAW_TRAJECTORY_DIR` relocated runtime files can be tailed from their session-adjacent pointer

## Scope

- Adds `openclaw sessions tail`
- Supports `--session-key`, `--tail`, `--follow`, `--store`, `--agent`, and `--all-agents`
- Selects the requested session, otherwise running sessions, otherwise the latest session
- Renders concise progress lines with timestamp, event type, session key, and safe status/model/tool preview
- Redacts prompt text, tool arguments, and tool results by default
- Resolves the agent store from an explicit fully qualified session key when no store/agent/all-agents override is provided
- Carries the initial trajectory read offset into follow mode so appended events are not dropped between initial tail rendering and polling
- Honors session trajectory pointer files before falling back to the default/current trajectory path

## Maintainer Decision Point

This PR is ready for maintainer review, with one intentional product/API decision point: whether the public command shape should be `openclaw sessions tail` or another surface such as `openclaw logs --source sessions --follow`.

I used `sessions tail` because this renders session trajectory activity rather than gateway/process logs. If maintainers prefer a different command shape, I can adapt this branch.

## Real Behavior Proof

- Behavior or issue addressed: `openclaw sessions tail` should render live human-readable trajectory progress, follow appended trajectory events, redact tool arguments/results, resolve a fully qualified non-default-agent `--session-key` without requiring `--agent`, avoid dropping events appended while follow mode starts, and honor existing relocated trajectory pointer files.
- Real environment tested: local macOS source checkout of this PR branch using Node.js v24.13.1, `node --import tsx src/entry.ts`, and temporary `OPENCLAW_STATE_DIR` directories containing real OpenClaw session-store and `*.trajectory.jsonl` files for a non-default `ops` agent.
- Exact steps or command run after this patch:

  ```sh
  OPENCLAW_STATE_DIR=/tmp/openclaw-sessions-tail-follow-proof-*/state \
    node --import tsx src/entry.ts sessions tail \
      --session-key agent:ops:telegram:direct:redacted-user \
      --tail 1 --follow
  ```

  I also ran the non-follow tail path:

  ```sh
  OPENCLAW_STATE_DIR=/tmp/openclaw-sessions-tail-proof.zBZU2c/state \
    node --import tsx src/entry.ts sessions tail \
      --session-key agent:ops:telegram:direct:redacted-user \
      --tail 4
  ```

- Evidence after fix: copied terminal output from the after-fix source-checkout CLI run. The temporary trajectory fixture included `SECRET_SHOULD_NOT_PRINT` in a tool result body; the rendered output below did not expose it.

  ```text
  $ openclaw sessions tail --session-key agent:ops:telegram:direct:redacted-user --tail 1 --follow
  03:31:01 session.started  agent:ops:telegram:direct:red… session started
  03:31:02 tool.result      agent:ops:telegram:direct:red… bash ok
  ```

  Non-follow copied terminal output:

  ```text
  $ openclaw sessions tail --session-key agent:ops:telegram:direct:redacted-user --tail 4
  03:30:01 session.started  agent:ops:telegram:direct:red… session started
  03:30:02 tool.call        agent:ops:telegram:direct:red… bash {...redacted...}
  03:30:03 tool.result      agent:ops:telegram:direct:red… bash ok
  03:30:04 model.completed  agent:ops:telegram:direct:red… openai/gpt-5.2 done
  ```

- Observed result after fix: the command found the `ops` agent session from the explicit fully qualified session key, printed compact session progress lines, followed an appended trajectory event, rendered tool call/result/model status previews, and kept the secret tool result body out of the output. Focused regression coverage also verifies the follow handoff case and an `OPENCLAW_TRAJECTORY_DIR`-style relocated runtime trajectory pointer.
- What was not tested: full GitHub CI for the latest pushed head is left to the repository workflow. The local run covered focused command tests, trajectory export regression tests, formatting, diff check, full lint, and core/core-test typecheck.
- Before evidence: before the follow-up fixes, source inspection showed `sessions tail` resolved stores before deriving any agent from `--session-key`, follow mode initialized offsets from current file size after initial rendering, and tailing computed only the direct trajectory path without checking the session-adjacent trajectory pointer.

## Verification

- `OPENCLAW_TEST_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.commands.config.ts src/commands/sessions-tail.test.ts` (5 tests passed)
- `OPENCLAW_TEST_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.cli.config.ts src/cli/program/register.status-health-sessions.test.ts` (25 tests passed)
- `OPENCLAW_TEST_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts src/trajectory/export.test.ts` (17 tests passed)
- `./node_modules/.bin/oxfmt --check --threads=1 src/cli/program/register.status-health-sessions.ts src/cli/program/register.status-health-sessions.test.ts src/commands/sessions-tail.ts src/commands/sessions-tail.test.ts src/trajectory/export.ts src/trajectory/runtime-file.ts`
- `OPENCLAW_OXLINT_SKIP_LOCK=1 node scripts/run-oxlint-shards.mjs --threads=8`
- `OPENCLAW_TSGO_HEAVY_CHECK_LOCK_HELD=1 node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
- `OPENCLAW_TSGO_HEAVY_CHECK_LOCK_HELD=1 node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`
- `git diff --check`

## Risk

Low-to-medium. The change is additive CLI surface over existing trajectory/session files. The main open question is naming and redaction policy, not runtime behavior.