### PR TITLE
fix(google-vertex): support production ADC modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Codex: log when implicit app-server `never` approvals are promoted for OpenClaw tool policy, including whether the trigger was a `before_tool_call` hook or trusted tool policy.
+- Google Vertex: support production ADC modes such as Workload Identity Federation, service-account credentials, and metadata-server ADC for the native Vertex transport. (#83971) Thanks @damianFelixPago.
 
 ## 2026.5.25
 

--- a/extensions/google/index.test.ts
+++ b/extensions/google/index.test.ts
@@ -199,6 +199,25 @@ describe("google provider plugin hooks", () => {
     runCase(cliProvider, "google-gemini-cli");
   });
 
+  it("wires Vertex transport before request-time metadata ADC detection", async () => {
+    const { providers } = await registerProviderPlugin({
+      plugin: googleProviderPlugin,
+      id: "google",
+      name: "Google Provider",
+    });
+    const provider = requireRegisteredProvider(providers, "google");
+
+    expect(
+      provider.createStreamFn?.({
+        model: {
+          api: "google-vertex",
+          provider: "google",
+          id: "gemini-2.5-pro",
+        },
+      } as never),
+    ).toEqual(expect.any(Function));
+  });
+
   it("advertises adaptive thinking for Gemini dynamic thinking", async () => {
     const { providers } = await registerProviderPlugin({
       plugin: googleProviderPlugin,

--- a/extensions/google/package.json
+++ b/extensions/google/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "dependencies": {
     "@earendil-works/pi-ai": "0.75.4",
-    "@google/genai": "2.5.0"
+    "@google/genai": "2.5.0",
+    "google-auth-library": "10.6.2"
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*"

--- a/extensions/google/provider-registration.ts
+++ b/extensions/google/provider-registration.ts
@@ -13,7 +13,6 @@ import {
   createGoogleGenerativeAiTransportStreamFn,
   createGoogleVertexTransportStreamFn,
 } from "./transport-stream.js";
-import { hasGoogleVertexAuthorizedUserAdcSync } from "./vertex-adc.js";
 
 export function buildGoogleProvider(): ProviderPlugin {
   return {
@@ -57,7 +56,7 @@ export function buildGoogleProvider(): ProviderPlugin {
       if (model.api === "google-generative-ai") {
         return createGoogleGenerativeAiTransportStreamFn();
       }
-      if (model.api === "google-vertex" && hasGoogleVertexAuthorizedUserAdcSync()) {
+      if (model.api === "google-vertex") {
         return createGoogleVertexTransportStreamFn();
       }
       return undefined;

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -4,14 +4,32 @@ import path from "node:path";
 import type { Model } from "@earendil-works/pi-ai";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { buildGuardedModelFetchMock, guardedFetchMock } = vi.hoisted(() => ({
-  buildGuardedModelFetchMock: vi.fn(),
-  guardedFetchMock: vi.fn(),
-}));
+const {
+  buildGuardedModelFetchMock,
+  guardedFetchMock,
+  googleAuthGetAccessTokenMock,
+  googleAuthMock,
+} = vi.hoisted(() => {
+  const googleAuthGetAccessTokenMock = vi.fn();
+  return {
+    buildGuardedModelFetchMock: vi.fn(),
+    guardedFetchMock: vi.fn(),
+    googleAuthGetAccessTokenMock,
+    googleAuthMock: vi.fn(function GoogleAuthMock() {
+      return {
+        getAccessToken: googleAuthGetAccessTokenMock,
+      };
+    }),
+  };
+});
 
 vi.mock("openclaw/plugin-sdk/provider-transport-runtime", async (importOriginal) => ({
   ...(await importOriginal()),
   buildGuardedModelFetch: buildGuardedModelFetchMock,
+}));
+
+vi.mock("google-auth-library", () => ({
+  GoogleAuth: googleAuthMock,
 }));
 
 let buildGoogleGenerativeAiParams: typeof import("./transport-stream.js").buildGoogleGenerativeAiParams;
@@ -19,6 +37,7 @@ let buildGoogleGemini3FirstResponseRetryParams: typeof import("./transport-strea
 let createGoogleGenerativeAiTransportStreamFn: typeof import("./transport-stream.js").createGoogleGenerativeAiTransportStreamFn;
 let createGoogleVertexTransportStreamFn: typeof import("./transport-stream.js").createGoogleVertexTransportStreamFn;
 let hasGoogleVertexAuthorizedUserAdcSync: typeof import("./vertex-adc.js").hasGoogleVertexAuthorizedUserAdcSync;
+let resolveGoogleVertexAuthorizedUserHeaders: typeof import("./vertex-adc.js").resolveGoogleVertexAuthorizedUserHeaders;
 let resetGoogleVertexAuthorizedUserTokenCacheForTest: typeof import("./vertex-adc.js").resetGoogleVertexAuthorizedUserTokenCacheForTest;
 
 const MODEL_PROVIDER_REQUEST_TRANSPORT_SYMBOL = Symbol.for(
@@ -254,13 +273,18 @@ describe("google transport stream", () => {
       createGoogleGenerativeAiTransportStreamFn,
       createGoogleVertexTransportStreamFn,
     } = await import("./transport-stream.js"));
-    ({ hasGoogleVertexAuthorizedUserAdcSync, resetGoogleVertexAuthorizedUserTokenCacheForTest } =
-      await import("./vertex-adc.js"));
+    ({
+      hasGoogleVertexAuthorizedUserAdcSync,
+      resolveGoogleVertexAuthorizedUserHeaders,
+      resetGoogleVertexAuthorizedUserTokenCacheForTest,
+    } = await import("./vertex-adc.js"));
   });
 
   beforeEach(() => {
     buildGuardedModelFetchMock.mockReset();
     guardedFetchMock.mockReset();
+    googleAuthGetAccessTokenMock.mockReset();
+    googleAuthMock.mockClear();
     buildGuardedModelFetchMock.mockReturnValue(guardedFetchMock);
     resetGoogleVertexAuthorizedUserTokenCacheForTest();
   });
@@ -271,6 +295,7 @@ describe("google transport stream", () => {
 
   afterAll(() => {
     vi.doUnmock("openclaw/plugin-sdk/provider-transport-runtime");
+    vi.doUnmock("google-auth-library");
     vi.resetModules();
   });
 
@@ -693,6 +718,89 @@ describe("google transport stream", () => {
       Authorization: "Bearer oauth-token",
       "Content-Type": "application/json",
     });
+  });
+
+  it("detects supported Vertex ADC sources synchronously", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-google-vertex-adc-detect-"));
+    for (const type of ["authorized_user", "external_account", "service_account"]) {
+      const credentialsPath = path.join(tempDir, `${type}.json`);
+      await writeFile(credentialsPath, JSON.stringify({ type }), "utf8");
+
+      expect(
+        hasGoogleVertexAuthorizedUserAdcSync({
+          GOOGLE_APPLICATION_CREDENTIALS: credentialsPath,
+        }),
+      ).toBe(true);
+    }
+
+    expect(
+      hasGoogleVertexAuthorizedUserAdcSync({
+        HOME: path.join(tempDir, "empty-home"),
+        KUBERNETES_SERVICE_HOST: "10.0.0.1",
+      }),
+    ).toBe(false);
+  });
+
+  it("resolves non-file Vertex ADC through google-auth-library without OAuth refresh fetch", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-google-vertex-authlib-"));
+    vi.stubEnv("GOOGLE_APPLICATION_CREDENTIALS", "");
+    vi.stubEnv("HOME", path.join(tempDir, "home"));
+    vi.stubEnv("APPDATA", "");
+    googleAuthGetAccessTokenMock.mockResolvedValueOnce("ya29.google-auth-token");
+    const tokenFetchMock = vi.fn();
+
+    await expect(resolveGoogleVertexAuthorizedUserHeaders(tokenFetchMock)).resolves.toEqual({
+      Authorization: "Bearer ya29.google-auth-token",
+    });
+
+    expect(googleAuthMock).toHaveBeenCalledWith({
+      scopes: ["https://www.googleapis.com/auth/cloud-platform"],
+    });
+    expect(googleAuthGetAccessTokenMock).toHaveBeenCalledTimes(1);
+    expect(tokenFetchMock).not.toHaveBeenCalled();
+  });
+
+  it("uses google-auth-library bearer auth for Google Vertex credential marker requests", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-google-vertex-authlib-stream-"));
+    vi.stubEnv("GOOGLE_APPLICATION_CREDENTIALS", "");
+    vi.stubEnv("HOME", path.join(tempDir, "home"));
+    vi.stubEnv("APPDATA", "");
+    vi.stubEnv("GOOGLE_CLOUD_PROJECT", "vertex-project");
+    vi.stubEnv("GOOGLE_CLOUD_LOCATION", "us-central1");
+    googleAuthGetAccessTokenMock.mockResolvedValueOnce("ya29.transport-token");
+    const tokenFetchMock = vi.fn();
+    guardedFetchMock.mockResolvedValueOnce(
+      buildSseResponse([
+        {
+          candidates: [{ content: { parts: [{ text: "ok" }] }, finishReason: "STOP" }],
+        },
+      ]),
+    );
+
+    const streamFn = createGoogleVertexTransportStreamFn();
+    const stream = await Promise.resolve(
+      streamFn(
+        buildGoogleVertexModel(),
+        {
+          messages: [{ role: "user", content: "hello", timestamp: 0 }],
+        } as Parameters<typeof streamFn>[1],
+        {
+          apiKey: "gcp-vertex-credentials",
+          fetch: tokenFetchMock,
+        } as Parameters<typeof streamFn>[2],
+      ),
+    );
+    await stream.result();
+
+    expect(tokenFetchMock).not.toHaveBeenCalled();
+    const guardedCall = requireMockCall(guardedFetchMock, 0, "guarded fetch");
+    const guardedInit = requireRequestInit(guardedCall, "guarded fetch");
+    expectHeaders(guardedInit, {
+      Authorization: "Bearer ya29.transport-token",
+      "Content-Type": "application/json",
+      accept: "text/event-stream",
+    });
+    expect(new Headers(guardedInit.headers).has("x-goog-api-key")).toBe(false);
   });
 
   it("refreshes authorized_user ADC before Google Vertex requests", async () => {

--- a/extensions/google/vertex-adc.ts
+++ b/extensions/google/vertex-adc.ts
@@ -17,13 +17,33 @@ type GoogleVertexAuthorizedUserToken = {
   refreshToken: string;
 };
 
+type GoogleVertexAdcToken = {
+  token: string;
+  expiresAtMs: number;
+};
+
 const GCP_VERTEX_CREDENTIALS_MARKER = "gcp-vertex-credentials";
 const GOOGLE_OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token";
+const GOOGLE_VERTEX_OAUTH_SCOPE = "https://www.googleapis.com/auth/cloud-platform";
+// Hold tokens slightly less long than reported expiry (Google's recommendation
+// is a 60s buffer) so we don't ship a request that's already revoked when it
+// leaves the gateway.
+const GOOGLE_VERTEX_TOKEN_EXPIRY_BUFFER_MS = 60_000;
 
 let cachedGoogleVertexAuthorizedUserToken: GoogleVertexAuthorizedUserToken | undefined;
+let cachedGoogleAuthClient:
+  | {
+      promise: Promise<{
+        getAccessToken: () => Promise<string | null | undefined>;
+      }>;
+    }
+  | undefined;
+let cachedGoogleVertexAdcToken: GoogleVertexAdcToken | undefined;
 
 export function resetGoogleVertexAuthorizedUserTokenCacheForTest(): void {
   cachedGoogleVertexAuthorizedUserToken = undefined;
+  cachedGoogleAuthClient = undefined;
+  cachedGoogleVertexAdcToken = undefined;
 }
 
 function normalizeOptionalString(value: unknown): string | undefined {
@@ -85,24 +105,45 @@ async function readGoogleAuthorizedUserCredentials(
   };
 }
 
+function readGoogleAdcCredentialsTypeSync(credentialsPath: string): string | undefined {
+  try {
+    const parsed = JSON.parse(readFileSync(credentialsPath, "utf8")) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return undefined;
+    }
+    const type = (parsed as { type?: unknown }).type;
+    return typeof type === "string" ? type : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Returns true when a file/env Application Default Credentials source usable
+ * for Google Vertex AI is detectable synchronously. We still call the function
+ * `...AuthorizedUserAdcSync` for backwards compatibility with older tests; the
+ * predicate now also covers:
+ *
+ *   1. `authorized_user` credentials file (existing case - `gcloud auth
+ *      application-default login` produces this).
+ *   2. `external_account` credentials file (Workload Identity Federation).
+ *   3. `service_account` credentials file (raw GSA key - rarely used in
+ *      OpenClaw, included for completeness).
+ * Metadata-server ADC is intentionally not detected here: `google-auth-library`
+ * probes the default metadata hosts asynchronously at request time, and the
+ * provider wires the Vertex transport without this sync predicate.
+ */
 export function hasGoogleVertexAuthorizedUserAdcSync(
   env: NodeJS.ProcessEnv = process.env,
 ): boolean {
   const credentialsPath = resolveGoogleApplicationCredentialsPath(env);
-  if (!credentialsPath) {
-    return false;
+  if (credentialsPath) {
+    const type = readGoogleAdcCredentialsTypeSync(credentialsPath);
+    if (type === "authorized_user" || type === "external_account" || type === "service_account") {
+      return true;
+    }
   }
-  try {
-    const parsed = JSON.parse(readFileSync(credentialsPath, "utf8")) as unknown;
-    return (
-      Boolean(parsed) &&
-      typeof parsed === "object" &&
-      !Array.isArray(parsed) &&
-      (parsed as { type?: unknown }).type === "authorized_user"
-    );
-  } catch {
-    return false;
-  }
+  return false;
 }
 
 async function refreshGoogleVertexAuthorizedUserAccessToken(params: {
@@ -123,7 +164,7 @@ async function refreshGoogleVertexAuthorizedUserAccessToken(params: {
   if (
     cached?.credentialsPath === params.credentialsPath &&
     cached.refreshToken === refreshToken &&
-    cached.expiresAtMs - Date.now() > 60_000
+    cached.expiresAtMs - Date.now() > GOOGLE_VERTEX_TOKEN_EXPIRY_BUFFER_MS
   ) {
     return cached.token;
   }
@@ -166,23 +207,83 @@ async function refreshGoogleVertexAuthorizedUserAccessToken(params: {
   return token;
 }
 
+async function resolveGoogleVertexAccessTokenViaGoogleAuth(): Promise<string> {
+  // Lazy-import + cache so we don't pay the google-auth-library load cost on
+  // gateway startup; only when we actually need a non-authorized_user token.
+  if (!cachedGoogleAuthClient) {
+    cachedGoogleAuthClient = {
+      promise: import("google-auth-library").then(({ GoogleAuth }) => {
+        // GoogleAuth handles every ADC variant we care about for GKE:
+        // - external_account (Workload Identity Federation: STS exchange)
+        // - service_account (raw GSA key: JWT-bearer)
+        // - GKE Workload Identity (metadata server when no credentials file)
+        // - Compute Engine / Cloud Run / GAE metadata server fallback
+        // It also caches tokens internally and refreshes before expiry.
+        return new GoogleAuth({
+          scopes: [GOOGLE_VERTEX_OAUTH_SCOPE],
+        });
+      }),
+    };
+  }
+  const auth = await cachedGoogleAuthClient.promise;
+
+  const cached = cachedGoogleVertexAdcToken;
+  if (cached && cached.expiresAtMs - Date.now() > GOOGLE_VERTEX_TOKEN_EXPIRY_BUFFER_MS) {
+    return cached.token;
+  }
+
+  const token = await auth.getAccessToken();
+  const normalized = normalizeOptionalString(token);
+  if (!normalized) {
+    throw new Error(
+      "Google Vertex ADC fallback (google-auth-library) did not return an access token. " +
+        "Verify the GKE Workload Identity binding (KSA \u2192 GSA), `GOOGLE_APPLICATION_CREDENTIALS`, " +
+        "or other ADC source is reachable from this pod.",
+    );
+  }
+  // google-auth-library doesn't expose token expiry on the simple
+  // `getAccessToken()` return type, so we cache for a conservative 5 minutes.
+  // The library itself already refreshes well before its own internal expiry,
+  // so this cache is mainly to avoid hot-loop calls into the auth client.
+  cachedGoogleVertexAdcToken = {
+    token: normalized,
+    expiresAtMs: Date.now() + 5 * 60_000,
+  };
+  return normalized;
+}
+
+/**
+ * Resolve `Authorization: Bearer ...` headers for Google Vertex calls.
+ *
+ * We try the hand-rolled `authorized_user` refresh path first (preserves the
+ * existing fetchImpl test seam and the OpenClaw upstream behaviour); when the
+ * configured ADC source is anything other than `authorized_user` (the common
+ * production cases on GKE: Workload Identity, Workload Identity Federation,
+ * service-account JSON keys), we hand off to `google-auth-library` which
+ * understands all of those natively.
+ *
+ * Note: the function is still named `...AuthorizedUserHeaders` to avoid a
+ * symbol rename across the existing patch surface; the docstring above is
+ * the truth, the name is legacy.
+ */
 export async function resolveGoogleVertexAuthorizedUserHeaders(
   fetchImpl?: typeof fetch,
 ): Promise<Record<string, string>> {
   const credentialsPath = resolveGoogleApplicationCredentialsPath();
-  if (!credentialsPath) {
-    throw new Error(
-      "Google Vertex ADC credentials not found. Set GOOGLE_APPLICATION_CREDENTIALS or run gcloud auth application-default login.",
-    );
+  if (credentialsPath) {
+    const credentials = await readGoogleAuthorizedUserCredentials(credentialsPath);
+    if (credentials) {
+      const token = await refreshGoogleVertexAuthorizedUserAccessToken({
+        credentialsPath,
+        credentials,
+        fetchImpl,
+      });
+      return { Authorization: `Bearer ${token}` };
+    }
   }
-  const credentials = await readGoogleAuthorizedUserCredentials(credentialsPath);
-  if (!credentials) {
-    throw new Error("Google Vertex ADC fallback requires an authorized_user credentials file.");
-  }
-  const token = await refreshGoogleVertexAuthorizedUserAccessToken({
-    credentialsPath,
-    credentials,
-    fetchImpl,
-  });
+  // No file-based authorized_user ADC. Fall back to google-auth-library which
+  // handles GKE Workload Identity (metadata server), Workload Identity
+  // Federation (external_account), and service-account keys.
+  const token = await resolveGoogleVertexAccessTokenViaGoogleAuth();
   return { Authorization: `Bearer ${token}` };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -745,6 +745,9 @@ importers:
       '@google/genai':
         specifier: 2.5.0
         version: 2.5.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
+      google-auth-library:
+        specifier: 10.6.2
+        version: 10.6.2
     devDependencies:
       '@openclaw/plugin-sdk':
         specifier: workspace:*

--- a/src/agents/pi-embedded-runner/model.inline-provider.test.ts
+++ b/src/agents/pi-embedded-runner/model.inline-provider.test.ts
@@ -68,6 +68,24 @@ describe("buildInlineProviderModels", () => {
     ]);
   });
 
+  it("preserves google-vertex api inherited from provider config", () => {
+    const providers: Parameters<typeof buildInlineProviderModels>[0] = {
+      google: {
+        baseUrl: "https://us-central1-aiplatform.googleapis.com/v1",
+        api: "google-vertex",
+        models: [makeModel("gemini-2.5-pro")],
+      },
+    };
+
+    const result = buildInlineProviderModels(providers);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].provider).toBe("google");
+    expect(result[0].baseUrl).toBe("https://us-central1-aiplatform.googleapis.com/v1");
+    expect(result[0].api).toBe("google-vertex");
+    expect(result[0].id).toBe("gemini-2.5-pro");
+  });
+
   it("model-level api takes precedence over provider-level api", () => {
     const providers: Parameters<typeof buildInlineProviderModels>[0] = {
       custom: {

--- a/src/agents/pi-embedded-runner/model.inline-provider.ts
+++ b/src/agents/pi-embedded-runner/model.inline-provider.ts
@@ -40,6 +40,7 @@ export function normalizeResolvedTransportApi(
     case "bedrock-converse-stream":
     case "github-copilot":
     case "google-generative-ai":
+    case "google-vertex":
     case "ollama":
     case "openai-codex-responses":
     case "openai-completions":

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -13,6 +13,7 @@ export const MODEL_APIS = [
   "openai-codex-responses",
   "anthropic-messages",
   "google-generative-ai",
+  "google-vertex",
   "github-copilot",
   "bedrock-converse-stream",
   "ollama",

--- a/src/config/zod-schema.models.test.ts
+++ b/src/config/zod-schema.models.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { ModelsConfigSchema } from "./zod-schema.core.js";
+
+describe("ModelsConfigSchema", () => {
+  it("accepts google-vertex as a model API from MODEL_APIS", () => {
+    const result = ModelsConfigSchema.safeParse({
+      providers: {
+        "google-vertex": {
+          baseUrl: "https://{location}-aiplatform.googleapis.com",
+          api: "google-vertex",
+          apiKey: "gcp-vertex-credentials",
+          models: [
+            {
+              id: "gemini-2.5-pro",
+              name: "Gemini 2.5 Pro",
+              api: "google-vertex",
+            },
+          ],
+        },
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Allow native `api: "google-vertex"` configs through model API validation.
- Preserve inherited provider-level `api: "google-vertex"` during inline model materialization.
- Extend the existing Google Vertex ADC helper beyond `authorized_user` files by falling back to `google-auth-library` for production ADC modes, including GKE Workload Identity / metadata-server ADC, `external_account`, `service_account`, Cloud Run, GAE, and Compute Engine.
- Wire the explicit Vertex transport before request-time ADC probing so default metadata-server ADC is not blocked by a sync env heuristic.

## Why

OpenClaw already has a native Google Vertex transport: `model.api === "google-vertex"` selects the Vertex transport path. The previous ADC preflight and token resolver only accepted `authorized_user` credentials files, which preserved the local `gcloud auth application-default login` case but rejected common production GCP auth shapes before the native Vertex transport could run.

Production GCP deployments commonly rely on metadata server ADC, GKE Workload Identity, Workload Identity Federation (`external_account`), or service account credentials rather than a static Gemini API key or a user ADC file. This patch keeps the existing `authorized_user` refresh behavior intact and adds the standard `google-auth-library` ADC chain for the other supported runtime modes.

## Related upstream work

This PR is scoped as a production ADC completion for the existing native Google Vertex path, not as a new Vertex provider.

- #9729 requested Google Vertex ADC support and was closed as implemented.
- #60860 is a broader Google Vertex provider PR that also touches ADC and endpoint routing.
- #74914 adds `api: "google-vertex"` schema/config support, but is still open. This PR includes the schema allowance and also preserves provider-level inherited `api: "google-vertex"` in `normalizeResolvedTransportApi`, since adding to `MODEL_APIS` alone only covers explicit model-level config.
- #65023 tracks a broader `google-genai` SDK provider direction.

## Real behavior proof

Behavior addressed: Google Vertex requests using the existing native `google-vertex` transport can use production ADC instead of requiring a Gemini/Google API key or a local `authorized_user` ADC file.

Real environment tested: GKE-hosted OpenClaw deployment using metadata-server ADC / Workload Identity with no static `GOOGLE_API_KEY`, no `GEMINI_API_KEY`, and no `GOOGLE_APPLICATION_CREDENTIALS` file on the gateway.

Exact steps or command run after this patch: Configure `models.providers.google.apiKey = "gcp-vertex-credentials"`, provider/model `api = "google-vertex"`, `GOOGLE_CLOUD_PROJECT`, and `GOOGLE_CLOUD_LOCATION=us-central1`; send a normal OpenClaw channel message through `google/gemini-2.5-pro`.

Evidence after fix: GKE metadata server returned HTTP 200 for `/computeMetadata/v1/instance/service-accounts/default/token?scopes=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcloud-platform`, then the gateway sent `POST https://us-central1-aiplatform.googleapis.com/v1/projects/<redacted-project>/locations/us-central1/publishers/google/models/gemini-2.5-pro:streamGenerateContent` with `api=google-vertex` and received HTTP 200 `text/event-stream` in 2291 ms.

Observed result after fix: A user-visible OpenClaw response was returned through the configured channel after the Vertex `streamGenerateContent` request completed with HTTP 200. The path used the `gcp-vertex-credentials` marker and ADC bearer auth, not `x-goog-api-key` or a static service-account JSON file.

What was not tested: Maintainer local ADC live generation could not complete because the local configured GCP project has Vertex AI disabled; the local run did reach the Google Vertex API with ADC bearer auth and failed with a redacted `PERMISSION_DENIED` service-disabled response. Direct AWS Crabbox remote proof was attempted on `cbx_bc3464218fb0`, but the lease lost SSH after sync before the command could run.

## Test plan

- `pnpm install --frozen-lockfile`
  - Result: passed.
- `pnpm test extensions/google/transport-stream.test.ts extensions/google/index.test.ts src/config/zod-schema.models.test.ts src/agents/pi-embedded-runner/model.inline-provider.test.ts -- --reporter=verbose`
  - Result: passed 3 Vitest shards, 75 tests passed.
- `env -u OPENCLAW_TESTBOX -u OPENCLAW_CLOUDFLARE_ACCOUNT_ID -u OPENCLAW_R2_ACCOUNT_ID -u OPENCLAW_R2_S3_ENDPOINT pnpm check:changed`
  - Result: passed.
- `pnpm deps:changes:report -- --base-ref origin/main --markdown /tmp/dependency-changes-83971.md --json /tmp/dependency-changes-83971.json`
  - Result: passed; 2 dependency files changed, 0 resolved packages added/removed/changed.
- Local Vertex ADC smoke via `createGoogleVertexTransportStreamFn()` with `apiKey: "gcp-vertex-credentials"`
  - Result: reached Google Vertex with ADC bearer auth; stopped at cloud project API-disabled `PERMISSION_DENIED`, so not counted as successful generation proof.
- Direct AWS Crabbox remote gate on `cbx_bc3464218fb0`
  - Result: blocked by SSH timeout after sync; infrastructure failure, no patch failure signal.

Made with [Cursor](https://cursor.com)
