### PR TITLE
fix(msteams): mark external system events as non-owner

### DIFF
--- a/extensions/msteams/src/monitor-handler/message-handler.authz.test.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.authz.test.ts
@@ -606,6 +606,98 @@ describe("msteams monitor handler authz", () => {
     expect(runtimeApiMockState.dispatchReplyFromConfigWithSettledDispatcher).not.toHaveBeenCalled();
   });
 
+  it("marks skipped channel message system events as non-owner", async () => {
+    resetThreadMocks();
+    const { deps, enqueueSystemEvent } = createDeps({
+      channels: {
+        msteams: {
+          groupPolicy: "open",
+          requireMention: true,
+        },
+      },
+    } as OpenClawConfig);
+
+    const handler = createMSTeamsMessageHandler(deps);
+    await handler(
+      createMessageActivity({
+        id: "msg-skip-mention",
+        text: "please run the deployment",
+        from: {
+          id: "member-id",
+          aadObjectId: "member-aad",
+          name: "Member",
+        },
+        conversation: {
+          id: "19:channel@thread.tacv2",
+          conversationType: "channel",
+        },
+        channelData: {
+          team: { id: "team123", name: "Team 123" },
+          channel: { name: "General" },
+        },
+      }),
+    );
+
+    expect(runtimeApiMockState.dispatchReplyFromConfigWithSettledDispatcher).not.toHaveBeenCalled();
+    const systemEventCall = enqueueSystemEvent.mock.calls.find(
+      ([text]) => typeof text === "string" && text.includes("please run the deployment"),
+    );
+    if (!systemEventCall) {
+      throw new Error("expected skipped Teams message system event");
+    }
+    expect(systemEventCall[1]).toMatchObject({
+      forceSenderIsOwnerFalse: true,
+      trusted: false,
+    });
+  });
+
+  it("keeps dispatched primary message system events owner-neutral", async () => {
+    resetThreadMocks();
+    const { deps, enqueueSystemEvent } = createDeps({
+      channels: {
+        msteams: {
+          groupPolicy: "open",
+          requireMention: false,
+        },
+      },
+    } as OpenClawConfig);
+
+    const handler = createMSTeamsMessageHandler(deps);
+    await handler(
+      createMessageActivity({
+        id: "msg-active",
+        text: "please check the build",
+        from: {
+          id: "member-id",
+          aadObjectId: "member-aad",
+          name: "Member",
+        },
+        conversation: {
+          id: "19:channel@thread.tacv2",
+          conversationType: "channel",
+        },
+        channelData: {
+          team: { id: "team123", name: "Team 123" },
+          channel: { name: "General" },
+        },
+      }),
+    );
+
+    expect(runtimeApiMockState.dispatchReplyFromConfigWithSettledDispatcher).toHaveBeenCalled();
+    const systemEventCall = enqueueSystemEvent.mock.calls.find(
+      ([text]) => typeof text === "string" && text.includes("please check the build"),
+    );
+    if (!systemEventCall) {
+      throw new Error("expected active Teams message system event");
+    }
+    expect(systemEventCall[1]).not.toMatchObject({
+      forceSenderIsOwnerFalse: true,
+    });
+    expect(systemEventCall[1]).not.toMatchObject({
+      trusted: false,
+    });
+  });
+
   it("authorizes text control commands from static access groups", async () => {
     resetThreadMocks();
     const hasControlCommand = vi.fn(() => true);

--- a/extensions/msteams/src/monitor-handler/message-handler.thread-parent.test.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.thread-parent.test.ts
@@ -38,11 +38,20 @@ vi.mock("../graph-thread.js", () => {
 
 describe("msteams thread parent context injection", () => {
   type MessageHandler = ReturnType<typeof createMSTeamsMessageHandler>;
+  type ParentSystemEventCall = [
+    string,
+    {
+      sessionKey: string;
+      contextKey?: string;
+      forceSenderIsOwnerFalse?: boolean;
+      trusted?: boolean;
+    },
+  ];
 
   function findParentSystemEventCall(
     mock: ReturnType<typeof vi.fn>,
-  ): [string, { sessionKey: string; contextKey?: string }] | undefined {
-    const calls = mock.mock.calls as Array<[string, { sessionKey: string; contextKey?: string }]>;
+  ): ParentSystemEventCall | undefined {
+    const calls = mock.mock.calls as ParentSystemEventCall[];
     return calls.find(([text]) => text.startsWith("Replying to @"));
   }
 
@@ -93,6 +102,10 @@ describe("msteams thread parent context injection", () => {
     expect(parentCall[0]).toBe("Replying to @Alice: Can someone investigate the latency spike?");
     expect(parentCall[1]?.contextKey).toContain("msteams:thread-parent:");
     expect(parentCall[1]?.contextKey).toContain("thread-root-123");
+    expect(parentCall[1]).toMatchObject({
+      forceSenderIsOwnerFalse: true,
+      trusted: false,
+    });
   });
 
   it("caches parent fetches across thread replies in the same session", async () => {

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -498,10 +498,15 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
       ? `Teams DM from ${senderName}`
       : `Teams message in ${conversationType} from ${senderName}`;
 
-    core.system.enqueueSystemEvent(`${inboundLabel}: ${preview}`, {
-      sessionKey: route.sessionKey,
-      contextKey: `msteams:message:${conversationId}:${activity.id ?? "unknown"}`,
-    });
+    const enqueuePrimaryMessageSystemEvent = (opts?: {
+      forceSenderIsOwnerFalse?: boolean;
+      trusted?: boolean;
+    }) =>
+      core.system.enqueueSystemEvent(`${inboundLabel}: ${preview}`, {
+        sessionKey: route.sessionKey,
+        contextKey: `msteams:message:${conversationId}:${activity.id ?? "unknown"}`,
+        ...opts,
+      });
 
     const channelId = conversationId;
     const { teamConfig, channelConfig } = channelGate;
@@ -536,6 +541,10 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
           requireMention,
           mentioned,
         });
+        enqueuePrimaryMessageSystemEvent({
+          forceSenderIsOwnerFalse: true,
+          trusted: false,
+        });
         createChannelHistoryWindow({ historyMap: conversationHistories }).record({
           historyKey: conversationId,
           limit: historyLimit,
@@ -549,6 +558,7 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
         return;
       }
     }
+    enqueuePrimaryMessageSystemEvent();
     let graphConversationId = translateMSTeamsDmConversationIdForGraph({
       isDirectMessage,
       conversationId,
@@ -665,6 +675,8 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
           core.system.enqueueSystemEvent(formatParentContextEvent(parentSummary), {
             sessionKey: route.sessionKey,
             contextKey: `msteams:thread-parent:${conversationId}:${activity.replyToId}`,
+            forceSenderIsOwnerFalse: true,
+            trusted: false,
           });
           markParentContextInjected(route.sessionKey, activity.replyToId);
         }

--- a/extensions/msteams/src/monitor-handler/reaction-handler.test.ts
+++ b/extensions/msteams/src/monitor-handler/reaction-handler.test.ts
@@ -207,6 +207,8 @@ describe("createMSTeamsReactionHandler", () => {
       expect(label).toContain("added");
       expect(meta.sessionKey).toBe("test-session");
       expect(meta.contextKey).toContain("added");
+      expect(meta.forceSenderIsOwnerFalse).toBe(true);
+      expect(meta.trusted).toBe(false);
     });
 
     it("enqueues system event for reactionsRemoved", async () => {

--- a/extensions/msteams/src/monitor-handler/reaction-handler.ts
+++ b/extensions/msteams/src/monitor-handler/reaction-handler.ts
@@ -116,6 +116,8 @@ export function createMSTeamsReactionHandler(deps: MSTeamsMessageHandlerDeps) {
       core.system.enqueueSystemEvent(label, {
         sessionKey: route.sessionKey,
         contextKey: `msteams:reaction:${conversationId}:${targetMessageId}:${senderId}:${reactionType}:${direction}`,
+        forceSenderIsOwnerFalse: true,
+        trusted: false,
       });
     }
   };


### PR DESCRIPTION
## Summary

- Problem: Microsoft Teams message, thread-parent, and reaction system events did not consistently mark Teams-originated context as non-owner when enqueueing session `System:` context.
- Solution: explicitly mark Teams-originated queued/supplemental context as non-owner before it can be drained into a later agent turn, while keeping the active primary message path owner-neutral for same-turn dispatch.
- What changed: mention-skipped Teams message previews, injected thread-parent context, and reaction events now enqueue system events with `forceSenderIsOwnerFalse: true` and `trusted: false`; primary messages that dispatch immediately keep neutral system-event metadata.
- What did NOT change (scope boundary): Teams mention gating, group/channel allowlist behavior, reaction handling, thread-parent fetching, and reply dispatch behavior are unchanged.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes: N/A
- Related: N/A
- [x] This PR fixes a bug or regression

## Motivation

Teams system events can carry external Teams user content into a later agent turn in the same session. If that queued or supplemental context preserves owner trust, external Teams content can influence a turn that is otherwise evaluated with owner-only tool policy. This patch keeps Teams-originated queued context aligned with the non-owner trust boundary without downgrading active same-turn Teams dispatch.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Teams-originated queued/supplemental system context is now explicitly marked non-owner before it can be drained into a later agent turn.
- Real environment tested: local macOS development checkout, branch `msteams-system-event-trust`, using the real MSTeams message handler plus the real OpenClaw system-event queue and formatter.
- Exact steps or command run after this patch:
  - `node --import tsx .artifacts/msteams-system-event-real-behavior-proof.ts`
  - `node --no-maglev ./node_modules/vitest/vitest.mjs run --config test/vitest/vitest.extension-msteams.config.ts extensions/msteams/src/monitor-handler/message-handler.authz.test.ts extensions/msteams/src/monitor-handler/message-handler.thread-parent.test.ts extensions/msteams/src/monitor-handler/reaction-handler.test.ts`
  - `./node_modules/.bin/oxfmt --check extensions/msteams/src/monitor-handler/message-handler.ts extensions/msteams/src/monitor-handler/reaction-handler.ts extensions/msteams/src/monitor-handler/message-handler.authz.test.ts extensions/msteams/src/monitor-handler/message-handler.thread-parent.test.ts extensions/msteams/src/monitor-handler/reaction-handler.test.ts`
- Evidence after fix:

```text
[proof log] info received message {"rawText":"please run the deployment","text":"please run the deployment","attachments":0,"attachmentTypes":[],"from":"member-id","conversation":"19:channel@thread.tacv2"}
[proof log] debug skipping message (mention required) {"teamId":"team123","channelId":"19:channel@thread.tacv2","requireMention":true,"mentioned":false}
[proof] real msteams handler completed
[proof] sessionKey=msteams:channel:19:channel@thread.tacv2
[proof] dispatchAttempts=0
[proof] queuedEvents=1
[proof] queued[0].text=Teams message in channel from Member: please run the deployment
[proof] queued[0].contextKey=msteams:message:19:channel@thread.tacv2:msg-skip-mention-proof
[proof] queued[0].forceSenderIsOwnerFalse=true
[proof] queued[0].trusted=false
[proof] drained.forceSenderIsOwnerFalse=true
[proof] drained.text="System: [2026-05-19 12:18:56 GMT+8] Teams message in channel from Member: please run the deployment"
```

Targeted regression checks also passed:

```text
Test Files  3 passed (3)
Tests       31 passed (31)

Checking formatting...
All matched files use the correct format.
```

- Observed result after fix:
  - A Teams channel message that is skipped by mention gating still enters the session system-event queue.
  - The queued Teams system event is now marked `forceSenderIsOwnerFalse=true` and `trusted=false`.
  - Draining that queued event into the next `System:` block returns `forceSenderIsOwnerFalse=true`, so the later turn can be evaluated as non-owner when external Teams context is present.
  - A primary Teams message that dispatches immediately still enqueues owner-neutral system-event metadata, preserving same-turn owner authorization behavior.
  - No reply dispatch happened for the skipped message (`dispatchAttempts=0`), so mention gating behavior remains unchanged.
- What was not tested: live Microsoft Teams tenant webhook delivery and full Web UI interaction were not exercised. The local proof uses a redacted Bot Framework-style Teams activity against the real Teams handler and real OpenClaw system-event queue/formatter.
- Before evidence (optional but encouraged): before this change, the same Teams enqueue paths did not pass `forceSenderIsOwnerFalse` or `trusted: false`, so drained system-event blocks from those paths did not force owner-trust downgrade.

## Root Cause

- Root cause: the Teams skipped-message, thread-parent, and reaction paths could enqueue external Teams context without carrying the non-owner trust metadata expected by session system events.
- Missing detection / guardrail: existing Teams tests covered dispatch, mention gating, thread-parent context, and reactions, but did not assert the trust metadata on enqueued system events.
- Contributing context: Teams message previews are enqueued before mention gating can skip reply dispatch, so skipped external channel messages can still become session `System:` context for a later turn.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `extensions/msteams/src/monitor-handler/message-handler.authz.test.ts`
  - `extensions/msteams/src/monitor-handler/message-handler.thread-parent.test.ts`
  - `extensions/msteams/src/monitor-handler/reaction-handler.test.ts`
- Scenario the test should lock in:
  - Mention-gated Teams channel messages that do not dispatch still enqueue system context as non-owner.
  - Primary Teams messages that dispatch immediately remain owner-neutral for same-turn dispatch.
  - Teams thread-parent context is marked non-owner.
  - Teams reaction system events are marked non-owner.
- Why this is the smallest reliable guardrail: the affected behavior is local to the Teams system-event enqueue sites and the tests cover each enqueue path directly.
- Existing test that already covers this: none before this PR.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Teams-originated queued/supplemental session system context now forces non-owner trust metadata when it is drained into a later turn. Primary Teams messages that dispatch immediately remain owner-neutral for same-turn authorization. Teams message routing, mention gating, reactions, thread-parent context text, and reply behavior are unchanged.

## Diagram

```text
Before:
Teams skipped/supplemental event -> session System context -> later turn keeps existing owner trust

After:
Teams skipped/supplemental event -> non-owner session System context -> later turn downgrades owner trust
Teams active primary message -> neutral session System context -> same-turn owner trust preserved
```

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? Yes
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: this narrows the command/tool execution surface by ensuring external Teams-originated queued/supplemental context cannot preserve owner trust when it is carried into a later agent turn. Active primary Teams messages keep neutral system-event metadata so same-turn owner-authorized workflows are not downgraded.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local development checkout
- Model/provider: N/A
- Integration/channel (if any): Microsoft Teams extension
- Relevant config (redacted):

```text
channels.msteams.enabled=true
channels.msteams.groupPolicy=open
channels.msteams.requireMention=true
```

### Steps

1. Run the real-behavior proof script against the real Teams handler and OpenClaw system-event queue.
2. Send a redacted Bot Framework-style Teams channel message that does not mention the bot.
3. Verify the handler skips reply dispatch but still queues session system context.
4. Drain the queued system-event block and inspect the owner-trust metadata.
5. Verify an active primary Teams message dispatches with owner-neutral system-event metadata.
6. Run the targeted Teams regression tests and formatting check.

### Expected

- The skipped Teams channel message does not dispatch a reply.
- The queued Teams system event is marked `forceSenderIsOwnerFalse=true` and `trusted=false`.
- The drained `System:` block returns `forceSenderIsOwnerFalse=true`.
- Active primary Teams message system events do not set `forceSenderIsOwnerFalse=true` or `trusted=false`.

### Actual

- Matches expected in the local real-behavior proof and targeted regression tests.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification

- Verified scenarios:
  - Mention-gated Teams channel message is skipped for reply dispatch but queued as non-owner system context.
  - Active primary Teams message dispatches while keeping its message-preview system event owner-neutral.
  - Teams thread-parent context is enqueued as non-owner.
  - Teams reaction system events are enqueued as non-owner.
- Edge cases checked:
  - Mention-gated skipped message path, because this path does not start an immediate reply but still creates session system context.
  - Same-turn primary dispatch path, because it should not force owner downgrade before reply dispatch.
- What you did not verify:
  - Live Microsoft Teams tenant webhook delivery.
  - Full Web UI interaction.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Mostly
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A
- Notes: integrations or automations that relied on skipped/supplemental Teams system events preserving owner trust should now treat those events as external non-owner context.

## Risks and Mitigations

- Risk: a workflow that intentionally expected skipped or supplemental Teams system events to be trusted owner context could see owner-only tools withheld when a later turn includes that external context.
  - Mitigation: the change is limited to skipped message context, thread-parent context, and reaction events; direct same-turn Teams messages and existing Teams routing behavior remain unchanged.
