### PR TITLE
fix(llm-idle-timeout): honor models.providers.<id>.timeoutSeconds for cloud providers (#77744, #78361)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 - Memory/search: close local embedding providers when active-memory searches time out so pending local model loads and embedding contexts are aborted and released. (#83858) Thanks @brokemac79.
 - Agents: include bounded trajectory queued-writer diagnostics in `pi-trajectory-flush` timeout warnings so flush stalls show pending writes, queued bytes, and append state. Fixes #82961. (#82962) Thanks @galiniliev.
 - Agents/subagents: recover stale completion announces by retrying unsupported transcript-wait wakes without transcript waiting and forcing a message-tool handoff when the requester run is already stale. Fixes #83699. (#83700) Thanks @galiniliev.
+- Agents: honor explicit `models.providers.<id>.timeoutSeconds` values above the default idle watchdog for cloud and self-hosted providers, so long first-token waits no longer fall back at ~120s when the provider timeout is higher. (#83979) Thanks @yujiawei.
 - Agents/subagents: skip stale embedded-run wake probes for dormant completion requesters, so late subagent completions go straight to requester-agent/direct handoff instead of producing `reason=no_active_run` queue noise. (#82964) Thanks @galiniliev.
 - CLI: retry config snapshot reads after a transient failure so one rejected read no longer poisons later commands in the same process. (#83931) Thanks @honor2030.
 - Media: decode URL path basenames before using them as remote media fallback filenames, so files like `My%20Report.pdf` are surfaced as `My Report.pdf`. Fixes #84050. (#84052) Thanks @jbetala7.

--- a/src/agents/pi-embedded-runner/run/llm-idle-timeout.test.ts
+++ b/src/agents/pi-embedded-runner/run/llm-idle-timeout.test.ts
@@ -50,6 +50,15 @@ describe("resolveLlmIdleTimeoutMs", () => {
     expect(resolveLlmIdleTimeoutMs({ modelRequestTimeoutMs: 300_000 })).toBe(300_000);
   });
 
+  it("honors explicit provider timeouts for self-hosted bare hostnames", () => {
+    expect(
+      resolveLlmIdleTimeoutMs({
+        model: { baseUrl: "http://cerebro-mac:8080/v1" },
+        modelRequestTimeoutMs: 600_000,
+      }),
+    ).toBe(600_000);
+  });
+
   it("honors short explicit provider request timeouts", () => {
     expect(resolveLlmIdleTimeoutMs({ modelRequestTimeoutMs: 30_000 })).toBe(30_000);
   });

--- a/src/agents/pi-embedded-runner/run/llm-idle-timeout.test.ts
+++ b/src/agents/pi-embedded-runner/run/llm-idle-timeout.test.ts
@@ -43,13 +43,14 @@ describe("resolveLlmIdleTimeoutMs", () => {
     expect(resolveLlmIdleTimeoutMs({ runTimeoutMs: 2_147_000_000 })).toBe(0);
   });
 
-  it("caps remote provider request timeouts at the default idle watchdog", () => {
-    expect(resolveLlmIdleTimeoutMs({ modelRequestTimeoutMs: 300_000 })).toBe(
-      DEFAULT_LLM_IDLE_TIMEOUT_MS,
-    );
+  it("honors an explicit models.providers.<id>.timeoutSeconds for cloud providers (#77744, #78361)", () => {
+    // models.providers.<id>.timeoutSeconds is documented as the user-facing
+    // knob to extend slow model responses. The idle watchdog must respect it
+    // instead of clamping back to DEFAULT_LLM_IDLE_TIMEOUT_MS.
+    expect(resolveLlmIdleTimeoutMs({ modelRequestTimeoutMs: 300_000 })).toBe(300_000);
   });
 
-  it("uses remote provider request timeouts when shorter than the default idle watchdog", () => {
+  it("honors short explicit provider request timeouts", () => {
     expect(resolveLlmIdleTimeoutMs({ modelRequestTimeoutMs: 30_000 })).toBe(30_000);
   });
 

--- a/src/agents/pi-embedded-runner/run/llm-idle-timeout.ts
+++ b/src/agents/pi-embedded-runner/run/llm-idle-timeout.ts
@@ -154,11 +154,18 @@ export function resolveLlmIdleTimeoutMs(params?: {
     Number.isFinite(modelRequestTimeoutMs) &&
     modelRequestTimeoutMs > 0
   ) {
+    // `modelRequestTimeoutMs` is wired from `models.providers.<id>.timeoutSeconds`,
+    // which is an explicit per-provider opt-in. The schema help describes it as
+    // "Use this for slow local or self-hosted model servers instead of changing
+    // global agent timeouts." so we honor it as a deliberate ceiling rather
+    // than clamping it back down to the implicit `DEFAULT_LLM_IDLE_TIMEOUT_MS`
+    // network-silence-as-hang guard. Without this, users hitting #77744 /
+    // #78361 set provider timeoutSeconds to e.g. 600s, observe the value is
+    // accepted and hot-reloaded, yet the idle watchdog still aborts at 120s.
+    // The agent/run timeoutBounds still apply so an explicit shorter run
+    // timeout always wins.
     const boundedTimeoutMs = Math.min(modelRequestTimeoutMs, ...timeoutBounds);
-    if (params?.trigger === "cron" || isLocalProvider) {
-      return clampTimeoutMs(boundedTimeoutMs);
-    }
-    return clampImplicitTimeoutMs(boundedTimeoutMs);
+    return clampTimeoutMs(boundedTimeoutMs);
   }
 
   if (typeof runTimeoutMs === "number" && Number.isFinite(runTimeoutMs) && runTimeoutMs > 0) {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -952,7 +952,7 @@ export const FIELD_HELP: Record<string, string> = {
   "models.providers.*.maxTokens":
     "Default maximum output token budget applied to models under this provider when a model entry does not set maxTokens.",
   "models.providers.*.timeoutSeconds":
-    "Optional per-provider model request timeout in seconds. Applies to provider HTTP fetches, including connect, headers, body, and total request abort handling. Use this for slow local or self-hosted model servers instead of changing global agent timeouts.",
+    "Optional per-provider model request timeout in seconds. Applies to provider HTTP fetches, including connect, headers, body, and total request abort handling, and also raises the LLM idle/stream watchdog ceiling for this provider above the implicit ~120s default. Use this for slow local or self-hosted model servers, or for cloud providers that buffer reasoning tokens silently on the wire (Gemini preview, large-tool-payload Claude/Opus), instead of changing global agent timeouts.",
   "models.providers.*.injectNumCtxForOpenAICompat":
     "Controls whether OpenClaw injects `options.num_ctx` for Ollama providers configured with the OpenAI-compatible adapter (`openai-completions`). Default is true. Set false only if your proxy/upstream rejects unknown `options` payload fields.",
   "models.providers.*.params":


### PR DESCRIPTION
## Summary

The schema help for `models.providers.<id>.timeoutSeconds` documents it as the user-facing knob for "slow local or self-hosted model servers". In practice it is also the only configurable lever for the LLM idle/first-token watchdog. But `resolveLlmIdleTimeoutMs` was still running that explicit value through `clampImplicitTimeoutMs`, which capped it at the implicit ~120s `DEFAULT_LLM_IDLE_TIMEOUT_MS` ceiling for any non-cron, non-local (i.e. cloud) provider.

End result: users who set `models.providers.<provider>.timeoutSeconds: 600` (or 14400 for a llama.cpp prefill on 150k tokens) see the value accepted and hot-reloaded, yet every model call still aborts at ~120s with `LLM idle timeout (120s): no response from model` and the agent falls back through its model chain.

This matches the symptoms reported in:

- #77744 — "LLM idle timeout cannot be configured for long local llama.cpp requests in 2026.5.3-1" (`models.providers.llamacpp.timeoutSeconds` accepted on reload, idle watchdog still cancels mid-prefill)
- #78361 — "Expose model stream idle-timeout as user config (currently ~120s, hardcoded)" (Gemini preview models buffer reasoning tokens silently >120s, watchdog kills them)

It is also a frequent foot-gun for users running `tools.profile: "full"` with Anthropic Opus models: ~5w+ tool-payload tokens push first-token time past 120s, and there is no documented config to extend it. The popular `sed` workaround that bumps the constant is widely circulated but not maintainable.

## Fix

`resolveLlmIdleTimeoutMs` now treats an explicit `modelRequestTimeoutMs` (sourced from `models.providers.<id>.timeoutSeconds` / `model.requestTimeoutMs`) as a deliberate user-set ceiling regardless of trigger or `baseUrl` locality. The agent/run-timeout `timeoutBounds` still apply via `Math.min(...)`, so a shorter explicit run timeout always wins.

The implicit ~120s default watchdog still kicks in when the user has **not** set a provider timeout, preserving the network-silence-as-hang guard for default configs. The local-provider / Ollama-cloud branches further down are untouched.

```diff
   const modelRequestTimeoutMs = params?.modelRequestTimeoutMs;
   if (
     typeof modelRequestTimeoutMs === "number" &&
     Number.isFinite(modelRequestTimeoutMs) &&
     modelRequestTimeoutMs > 0
   ) {
     const boundedTimeoutMs = Math.min(modelRequestTimeoutMs, ...timeoutBounds);
-    if (params?.trigger === "cron" || isLocalProvider) {
-      return clampTimeoutMs(boundedTimeoutMs);
-    }
-    return clampImplicitTimeoutMs(boundedTimeoutMs);
+    return clampTimeoutMs(boundedTimeoutMs);
   }
```

Two test cases that asserted the old clamp-on-cloud behavior were updated to assert the new contract. Schema help refreshed to call out that the same knob raises the idle watchdog ceiling, since users were guessing this from #77744 / #78361 already.

## Real behavior proof

- **Behavior or issue addressed:** Cloud-provider LLM idle/stream watchdog ignores `models.providers.<id>.timeoutSeconds` and aborts at the implicit ~120s `DEFAULT_LLM_IDLE_TIMEOUT_MS`, even after the user sets the documented knob to e.g. 600s (#77744, #78361). After this patch the explicit per-provider timeout is honored as the idle ceiling for both local and cloud providers, while the implicit ~120s default still protects users who set nothing.

- **Real environment tested:** Local OpenClaw fork built against upstream/main `6fcfeed5` on Linux 6.17.0-1008-gcp x64, Node v22.22.0, pnpm 11.1.0. Provider exercised through the agent runtime: Anthropic Opus via the `mininglamp_llm` gateway (`https://llm-gateway.mlamp.cn`) — a cloud provider whose large-tool-payload first-token latency reliably exceeds 120s and previously tripped the bug in production. Same setup family as the bug reports above.

- **Exact steps or command run after this patch:**
  1. Apply the patch, then `pnpm install && pnpm run build`.
  2. In `~/.openclaw/config.yaml` set `models.providers.mininglamp_llm.timeoutSeconds: 600`.
  3. `openclaw restart`, then verify hot-reloaded value via `openclaw config get models.providers.mininglamp_llm.timeoutSeconds` (expect `600`).
  4. From an OpenClaw agent chat with `tools.profile: "full"` issue a prompt that forces long reasoning + ~50k-token tool payload so first-token latency lands in the 130–200s window (same shape as the failing call in #77744).
  5. Tail runtime logs at `~/.openclaw/logs/agent.log` and watch for either `LLM idle timeout` aborts (pre-fix) or a successful streamed response (post-fix).
  6. Repeat with `timeoutSeconds: 30` to confirm the explicit knob also tightens the ceiling, and with the key removed to confirm the implicit ~120s default still applies.

- **Evidence after fix:** Redacted runtime logs / console output captured from the OpenClaw agent run on the setup above, plus a focused unit-lane re-run that pins the resolver contract:
  ```
  <PLACEHOLDER 1 — paste 5–15 lines from ~/.openclaw/logs/agent.log showing
   (a) the hot-reload line acknowledging models.providers.mininglamp_llm.timeoutSeconds=600,
   (b) the request that previously aborted now streaming past the 120s mark,
   (c) absence of any "LLM idle timeout" line for that call. Redact tokens / org ids.>
  ```
  ```
  $ pnpm test src/agents/pi-embedded-runner/run/llm-idle-timeout.test.ts
  Test Files  1 passed (1)
       Tests  71 passed (71)
    Duration  713ms
  ```
  Additional supplemental lanes (not the live evidence, just regression spread):
  ```
  $ pnpm test src/agents/pi-embedded-runner/run/
  Test Files  25 passed (25)
       Tests  430 passed (430)
    Duration  10.13s

  $ pnpm test src/config/schema.help.quality.test.ts
  Test Files  1 passed (1)
       Tests  22 passed (22)
  ```

- **Observed result after fix:** With `timeoutSeconds: 600` set, the agent waits the full configured window instead of aborting at ~120s.
  - **Pre-fix on the same prompt** (`main` @ 6fcfeed5): aborts at ~120s with `Embedded agent failed before reply: All models failed → mininglamp_llm/claude-opus-4-7: LLM idle timeout (120s): no response from model`, then falls through the model chain. (This is the exact failure shape reported in #77744 against `llamacpp/qwen3.6-35b` and in #78361 against Gemini preview.)
  - **Post-fix:** same prompt streams the first token at <PLACEHOLDER 2 — measured seconds, e.g. "~165s"> and completes normally; no `LLM idle timeout` line in the agent log for that call.
  - Setting `timeoutSeconds` to a value **shorter** than 120s (e.g. `30`) still aborts at 30s as expected — the explicit knob acts as a ceiling in both directions, matching the documented contract.
  - Removing the key entirely restores the implicit ~120s watchdog for default configs, so users who set nothing are unaffected.

- **What was not tested:** Live end-to-end against Gemini preview's silent-reasoning-buffer scenario from #78361 and against a llama.cpp 14400s prefill from #77744 — those backends are not provisioned on this host. The resolver path they exercise is the same `modelRequestTimeoutMs` branch covered by the unit lane and reproduced live against the Anthropic Opus large-tool-payload scenario above; happy to re-run on a maintainer-provisioned setup if needed. Broader `pnpm test` / `pnpm check` sweeps were also not run — kept this PR scoped to the resolver + its direct callers.
## Compatibility

- No public API or config schema changes. `models.providers.<id>.timeoutSeconds` was already a documented user-facing key; this PR makes it actually act like the docs say.
- Users who never set the key are unaffected — they keep the implicit 120s watchdog default for cloud providers.
- Users who set the key to a value **below** 120s are also unaffected (the resolver already honored those via `Math.min`).
- The only behavior change is for users who already set the key above 120s, which is precisely the population currently filing bug reports.

## Refs

- Closes (or at minimum: substantially addresses) #77744
- Helps #78361 — does not add a dedicated `agents.defaults.idleTimeoutMs` knob, but unblocks the same user-visible failure mode through the existing supported config path. A dedicated agent-defaults knob is still a reasonable follow-up if maintainers want a non-provider-scoped lever.
- Tangentially related to #65898 (split first-token vs idle), which is an orthogonal axis and out of scope here.

