### PR TITLE
fix(clawhub): preserve base URL path prefix [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,7 @@ Docs: https://docs.openclaw.ai
 - Release stability: repair broad-gate regressions in requester-agent completion handoff, QA-Lab mock spawn attribution, Slack monitor test isolation, plugin uninstall peer fixtures, and Node-floor launcher contract coverage.
 - Agents/replies: persist queued follow-up user messages and assistant error stubs only once across model-fallback retries, preventing repeated provider rejections from corrupted same-role session transcripts. Fixes #83404. (#83417) Thanks @yetval.
 - Telegram: preserve reply-target context for bare mention replies on runtime-only turns so the model sees the replied-to message body. Fixes #83767. (#83953) Thanks @joshavant.
+- ClawHub: preserve configured base URL path prefixes when building API request URLs, so self-hosted ClawHub instances mounted under a subpath keep routing correctly. (#83982) Thanks @ThiagoCAltoe.
 - Slack: persist delivered inbound message IDs and fail closed when same-channel thread replies lose their thread context, preventing delayed duplicate replies and accidental channel-root posts. Fixes #83521. Thanks @shannon0430.
 - Codex app-server: complete OpenClaw dynamic tool diagnostics at the request boundary so successful, failed, timed out, aborted, and blocked tool calls do not leave active tool state behind. Fixes #83474. Thanks @rozmiarD.
 - Gateway/config: keep config writes from failing on unrelated unresolved auth-profile SecretRefs while preserving live auth-profile runtime snapshots.

--- a/src/infra/clawhub.test.ts
+++ b/src/infra/clawhub.test.ts
@@ -59,6 +59,7 @@ describe("clawhub helpers", () => {
   const originalHome = process.env.HOME;
 
   afterEach(() => {
+    delete process.env.OPENCLAW_CLAWHUB_URL;
     delete process.env.OPENCLAW_CLAWHUB_TOKEN;
     delete process.env.CLAWHUB_TOKEN;
     delete process.env.CLAWHUB_AUTH_TOKEN;
@@ -273,6 +274,29 @@ describe("clawhub helpers", () => {
     };
 
     await expect(searchClawHubSkills({ query: "calendar", fetchImpl })).resolves.toStrictEqual([]);
+  });
+
+  it("preserves the configured ClawHub base URL path prefix", async () => {
+    process.env.OPENCLAW_CLAWHUB_URL = "https://internal.example.com/clawhub";
+    let requestedUrl = "";
+
+    await expect(
+      searchClawHubSkills({
+        query: "calendar",
+        fetchImpl: async (input) => {
+          requestedUrl = input instanceof Request ? input.url : String(input);
+          return new Response(JSON.stringify({ results: [] }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        },
+      }),
+    ).resolves.toStrictEqual([]);
+
+    const url = new URL(requestedUrl);
+    expect(url.origin).toBe("https://internal.example.com");
+    expect(url.pathname).toBe("/clawhub/api/v1/search");
+    expect(url.searchParams.get("q")).toBe("calendar");
   });
 
   it("fetches typed package readiness reports", async () => {

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -551,7 +551,10 @@ function normalizeCalVerCorrectionForPluginApi(pluginApiVersion: string): string
 }
 
 function buildUrl(params: Pick<ClawHubRequestParams, "baseUrl" | "path" | "search">): URL {
-  const url = new URL(params.path, `${normalizeBaseUrl(params.baseUrl)}/`);
+  const url = new URL(`${normalizeBaseUrl(params.baseUrl)}/`);
+  const basePath = url.pathname.replace(/\/+$/, "");
+  const requestPath = params.path.startsWith("/") ? params.path : `/${params.path}`;
+  url.pathname = `${basePath}${requestPath}`;
   for (const [key, value] of Object.entries(params.search ?? {})) {
     if (!value) {
       continue;


### PR DESCRIPTION
## Summary

- Problem: ClawHub requests dropped non-root path prefixes from `OPENCLAW_CLAWHUB_URL` / `CLAWHUB_URL`, causing reverse-proxied ClawHub deployments to hit `/api/...` instead of `/prefix/api/...`.
- Solution: Build ClawHub request URLs from the normalized base URL first, then append the request path onto the existing base pathname.
- What changed: Updated `src/infra/clawhub.ts` URL construction and added a focused regression test in `src/infra/clawhub.test.ts`.
- What did NOT change (scope boundary): No endpoint schemas, auth/token handling, downloads, install logic, or default ClawHub URL behavior changed.

AI-assisted: yes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #83975
- [x] This PR fixes a bug or regression

## Motivation

- Reverse-proxied ClawHub deployments under a path prefix cannot be used from OpenClaw because every API request silently drops that prefix and returns 404.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: ClawHub API requests preserve a configured base URL path prefix.
- Real environment tested: Local OpenClaw checkout on Linux with Node v22.21.1 and a local HTTP server standing in for a reverse-proxied ClawHub endpoint under `/clawhub`.
- Exact steps or command run after this patch:
  - `OPENCLAW_CLAWHUB_URL=http://127.0.0.1:18799/clawhub node --import tsx -e 'const { searchClawHubSkills } = await import("./src/infra/clawhub.ts"); const results = await searchClawHubSkills({ query: "calendar" }); console.log(JSON.stringify(results));'`
- Evidence after fix (copied live terminal output from the real OpenClaw checkout):

```text
SERVER GET /clawhub/api/v1/search?q=calendar
[{"slug":"calendar","displayName":"Calendar","version":"1.0.0","summary":"demo"}]
```
- Observed result after fix: The request hit `/clawhub/api/v1/search`, and the search result was returned successfully.
- What was not tested: A live external ClawHub deployment behind nginx; full repository test suite.
- Before evidence: Issue #83975 documents the pre-fix behavior where `new URL("/api/v1/search", "http://host:port/prefix/")` drops `/prefix`.

## Root Cause (if applicable)

- Root cause: `new URL(params.path, base)` treats leading-slash request paths as absolute paths and replaces the base URL pathname.
- Missing detection / guardrail: Existing ClawHub tests covered root-hosted base URLs but not base URLs with non-root path prefixes.
- Contributing context (if known): The ClawHub request paths are intentionally absolute-looking (`/api/v1/...`), which is correct for root-hosted deployments but unsafe when passed directly to URL resolution with a prefixed base.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/infra/clawhub.test.ts`
- Scenario the test should lock in: `OPENCLAW_CLAWHUB_URL=https://internal.example.com/clawhub` plus `searchClawHubSkills({ query: "calendar" })` requests `/clawhub/api/v1/search?q=calendar`.
- Why this is the smallest reliable guardrail: The bug is entirely in ClawHub URL construction, so the helper-level test catches it without requiring network or install flows.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

OpenClaw now supports ClawHub base URLs configured with a non-root path prefix, for example `OPENCLAW_CLAWHUB_URL=http://host:port/clawhub`.

## Diagram (if applicable)

```text
Before:
OPENCLAW_CLAWHUB_URL=http://host/clawhub -> /api/v1/search -> 404

After:
OPENCLAW_CLAWHUB_URL=http://host/clawhub -> /clawhub/api/v1/search -> 200
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node v22.21.1, local checkout
- Model/provider: N/A
- Integration/channel (if any): ClawHub HTTP API helper
- Relevant config (redacted): `OPENCLAW_CLAWHUB_URL=http://127.0.0.1:18799/clawhub`

### Steps

1. Start a local HTTP server that returns 200 only for `/clawhub/api/v1/search`.
2. Set `OPENCLAW_CLAWHUB_URL` to the local server URL with `/clawhub` path prefix.
3. Run `searchClawHubSkills({ query: "calendar" })` through `node --import tsx`.

### Expected

- The request preserves `/clawhub` and returns search results.

### Actual

- The request preserved `/clawhub` and returned search results.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Focused validation run:

```text
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.infra.config.ts src/infra/clawhub.test.ts

Test Files  1 passed (1)
Tests  39 passed | 2 skipped (41)
```

Live local HTTP proof after patch:

```text
SERVER GET /clawhub/api/v1/search?q=calendar
[{"slug":"calendar","displayName":"Calendar","version":"1.0.0","summary":"demo"}]
```

## Human Verification (required)

- Verified scenarios: Focused ClawHub infra tests; local HTTP path-prefix request proof.
- Edge cases checked: Existing ClawHub tests still pass for root-hosted default paths.
- What you did **not** verify: Full test suite, live external ClawHub behind nginx.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: URL path joining could affect existing root-hosted ClawHub requests.
  - Mitigation: Existing ClawHub helper tests still pass, and the new path-prefix test covers the previously missing case.
