### PR TITLE
fix(codex): defer native-hook-relay unregister to avoid cleanup race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Docs: https://docs.openclaw.ai
 
 - WebChat: keep the run-complete indicator in progress until deferred history replay renders the assistant reply, so Done no longer appears before response text. (#85374) Thanks @neeravmakwana.
 - Agents/compaction: skip agent-harness preflight for provider-owned CLI runtime sessions so over-threshold Claude CLI sessions continue through normal compaction instead of failing on a missing harness. Fixes #84857. (#84878) Thanks @zhangguiping-xydt.
+- Codex/app-server: keep successful native hook relays available through a short post-turn grace window so late Codex hook subprocesses can finish policy enforcement without clearing a replacement relay. (#83987) Thanks @Kaspre.
 - Control UI/config: save form-mode edits from the source config snapshot so runtime-only provider defaults like empty `models.providers.<id>.baseUrl` are not written back and rejected. Fixes #85831. Thanks @garyd9.
 - Telegram: normalize legacy durable group retry targets before retry sends, polls, and pins so group retries keep using the real chat id. (#85656) Thanks @luoyanglang.
 - Agents/PDF: route MiniMax PDF fallback policy through plugin metadata so MiniMax uses text extraction instead of VLM image fallback. (#85590, fixes #85575) Thanks @neeravmakwana.

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -176,6 +176,10 @@ export class CodexAppServerEventProjector {
     private readonly options: CodexAppServerEventProjectorOptions = {},
   ) {}
 
+  getCompletedTurnStatus(): CodexTurn["status"] | undefined {
+    return this.completedTurn?.status;
+  }
+
   async handleNotification(notification: CodexServerNotification): Promise<void> {
     const params = isJsonObject(notification.params) ? notification.params : undefined;
     if (!params) {

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -8233,6 +8233,46 @@ describe("runCodexAppServerAttempt", () => {
     expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)).toBeUndefined();
   });
 
+  it("cleans up native hook relay state when Codex completes the turn as interrupted", async () => {
+    const harness = createStartedThreadHarness();
+    const run = runCodexAppServerAttempt(
+      createParams(path.join(tempDir, "session.jsonl"), path.join(tempDir, "workspace")),
+      { nativeHookRelay: { enabled: true }, turnTerminalIdleTimeoutMs: 60_000 },
+    );
+
+    await harness.waitForMethod("turn/start");
+    const startRequest = harness.requests.find((request) => request.method === "thread/start");
+    const relayId = extractRelayIdFromThreadRequest(startRequest?.params);
+    await harness.notify({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        turn: { id: "turn-1", status: "interrupted", items: [] },
+      },
+    });
+
+    const result = await run;
+    expect(result.aborted).toBe(false);
+    expect(result.timedOut).toBe(false);
+    expect(result.promptError).toBeNull();
+    expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)).toBeUndefined();
+    await expect(
+      invokeNativeHookRelay({
+        provider: "codex",
+        relayId,
+        event: "pre_tool_use",
+        rawPayload: {
+          hook_event_name: "PreToolUse",
+          tool_name: "Bash",
+          tool_input: { command: "pnpm test" },
+        },
+      }),
+    ).rejects.toThrow("native hook relay not found");
+    testing.flushPendingCodexNativeHookRelayUnregistersForTests();
+    expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)).toBeUndefined();
+  });
+
   it("keeps upstream cancellation aborted when Codex completes the turn as interrupted", async () => {
     const harness = createStartedThreadHarness();
     const abortController = new AbortController();

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -7142,6 +7142,13 @@ describe("runCodexAppServerAttempt", () => {
     expect(relayId).not.toContain("cu-pr-relay-smoke");
   });
 
+  it("extends native hook relay cleanup grace for configured hook timeouts", () => {
+    expect(testing.resolveCodexNativeHookRelayUnregisterGraceMs(undefined)).toBe(10_000);
+    expect(testing.resolveCodexNativeHookRelayUnregisterGraceMs(5)).toBe(10_000);
+    expect(testing.resolveCodexNativeHookRelayUnregisterGraceMs(9)).toBe(14_000);
+    expect(testing.resolveCodexNativeHookRelayUnregisterGraceMs(60)).toBe(65_000);
+  });
+
   it("sends clearing Codex native hook config when the relay is disabled", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -5,6 +5,7 @@ import { SessionManager } from "@earendil-works/pi-coding-agent";
 import {
   abortAgentHarnessRun,
   embeddedAgentLog,
+  invokeNativeHookRelay,
   nativeHookRelayTesting,
   onAgentEvent,
   queueAgentHarnessMessage,
@@ -860,6 +861,7 @@ describe("runCodexAppServerAttempt", () => {
     await closeCodexSandboxExecServersForTests();
     resetCodexAppServerClientFactoryForTest();
     testing.resetOpenClawCodingToolsFactoryForTests();
+    testing.clearPendingCodexNativeHookRelayUnregistersForTests();
     resetCodexRateLimitCacheForTests();
     nativeHookRelayTesting.clearNativeHookRelaysForTests();
     clearPluginCommands();
@@ -6671,6 +6673,8 @@ describe("runCodexAppServerAttempt", () => {
     expect(preToolUseState?.enabled).toBe(true);
     expect(preToolUseState?.trusted_hash).toMatch(/^sha256:[a-f0-9]{64}$/);
     const relayId = extractRelayIdFromThreadRequest(startRequest?.params);
+    expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)).toBeDefined();
+    testing.flushPendingCodexNativeHookRelayUnregistersForTests();
     expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)).toBeUndefined();
   });
 
@@ -6733,6 +6737,7 @@ describe("runCodexAppServerAttempt", () => {
 
     await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
     await run;
+    testing.flushPendingCodexNativeHookRelayUnregistersForTests();
     expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)).toBeUndefined();
   });
 
@@ -6836,6 +6841,7 @@ describe("runCodexAppServerAttempt", () => {
 
     await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
     await run;
+    testing.flushPendingCodexNativeHookRelayUnregistersForTests();
     expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)).toBeUndefined();
   });
 
@@ -6898,6 +6904,7 @@ describe("runCodexAppServerAttempt", () => {
 
     await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
     await run;
+    testing.flushPendingCodexNativeHookRelayUnregistersForTests();
     expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)).toBeUndefined();
   });
 
@@ -6928,6 +6935,7 @@ describe("runCodexAppServerAttempt", () => {
 
     await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
     await run;
+    testing.flushPendingCodexNativeHookRelayUnregistersForTests();
     expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)).toBeUndefined();
   });
 
@@ -6960,6 +6968,7 @@ describe("runCodexAppServerAttempt", () => {
 
     await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
     await run;
+    testing.flushPendingCodexNativeHookRelayUnregistersForTests();
     expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)).toBeUndefined();
   });
 
@@ -6993,6 +7002,7 @@ describe("runCodexAppServerAttempt", () => {
 
     await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
     await run;
+    testing.flushPendingCodexNativeHookRelayUnregistersForTests();
     expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)).toBeUndefined();
   });
 
@@ -7034,6 +7044,7 @@ describe("runCodexAppServerAttempt", () => {
       await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
       completed = true;
       await run;
+      testing.flushPendingCodexNativeHookRelayUnregistersForTests();
       expect(
         nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId),
       ).toBeUndefined();
@@ -7046,7 +7057,7 @@ describe("runCodexAppServerAttempt", () => {
     }
   });
 
-  it("reuses the Codex native hook relay id across runs for the same session", async () => {
+  it("keeps a replacement Codex native hook relay registered when prior cleanup is pending", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
     const firstHarness = createStartedThreadHarness();
@@ -7065,9 +7076,22 @@ describe("runCodexAppServerAttempt", () => {
       (request) => request.method === "thread/start",
     );
     const firstRelayId = extractRelayIdFromThreadRequest(firstStartRequest?.params);
-    expect(
-      nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(firstRelayId),
-    ).toBeUndefined();
+    expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(firstRelayId)?.runId).toBe(
+      "run-1",
+    );
+    await expect(
+      invokeNativeHookRelay({
+        provider: "codex",
+        relayId: firstRelayId,
+        event: "pre_tool_use",
+        rawPayload: {
+          hook_event_name: "PreToolUse",
+          tool_name: "Bash",
+          tool_use_id: "late-call-1",
+          tool_input: { command: "python3 -c 'print(\"x\")'" },
+        },
+      }),
+    ).resolves.toMatchObject({ exitCode: 0 });
 
     const secondHarness = createResumeHarness();
     const secondParams = createParams(sessionFile, workspaceDir);
@@ -7090,8 +7114,17 @@ describe("runCodexAppServerAttempt", () => {
     expect(resumedRegistration?.runId).toBe("run-2");
     expect(resumedRegistration?.allowedEvents).toEqual(["pre_tool_use"]);
 
+    testing.flushPendingCodexNativeHookRelayUnregistersForTests();
+    expect(
+      nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(firstRelayId)?.runId,
+    ).toBe("run-2");
+
     await secondHarness.completeTurn({ threadId: "thread-existing", turnId: "turn-1" });
     await secondRun;
+    expect(
+      nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(firstRelayId)?.runId,
+    ).toBe("run-2");
+    testing.flushPendingCodexNativeHookRelayUnregistersForTests();
     expect(
       nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(firstRelayId),
     ).toBeUndefined();
@@ -7348,6 +7381,7 @@ describe("runCodexAppServerAttempt", () => {
     const result = await run;
 
     expect(result.aborted).toBe(true);
+    testing.flushPendingCodexNativeHookRelayUnregistersForTests();
     expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)).toBeUndefined();
   });
 

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -7381,6 +7381,19 @@ describe("runCodexAppServerAttempt", () => {
     const result = await run;
 
     expect(result.aborted).toBe(true);
+    expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)).toBeUndefined();
+    await expect(
+      invokeNativeHookRelay({
+        provider: "codex",
+        relayId,
+        event: "pre_tool_use",
+        rawPayload: {
+          hook_event_name: "PreToolUse",
+          tool_name: "Bash",
+          tool_input: { command: "pnpm test" },
+        },
+      }),
+    ).rejects.toThrow("native hook relay not found");
     testing.flushPendingCodexNativeHookRelayUnregistersForTests();
     expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)).toBeUndefined();
   });

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -7115,15 +7115,15 @@ describe("runCodexAppServerAttempt", () => {
     expect(resumedRegistration?.allowedEvents).toEqual(["pre_tool_use"]);
 
     testing.flushPendingCodexNativeHookRelayUnregistersForTests();
-    expect(
-      nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(firstRelayId)?.runId,
-    ).toBe("run-2");
+    expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(firstRelayId)?.runId).toBe(
+      "run-2",
+    );
 
     await secondHarness.completeTurn({ threadId: "thread-existing", turnId: "turn-1" });
     await secondRun;
-    expect(
-      nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(firstRelayId)?.runId,
-    ).toBe("run-2");
+    expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(firstRelayId)?.runId).toBe(
+      "run-2",
+    );
     testing.flushPendingCodexNativeHookRelayUnregistersForTests();
     expect(
       nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(firstRelayId),
@@ -8170,11 +8170,11 @@ describe("runCodexAppServerAttempt", () => {
     expect(result.timedOut).toBe(false);
   });
 
-  it("releases completion when Codex raw-events an interrupted turn marker", async () => {
+  it("releases completion and native hook relay state when Codex raw-events an interrupted turn marker", async () => {
     const harness = createStartedThreadHarness();
     const run = runCodexAppServerAttempt(
       createParams(path.join(tempDir, "session.jsonl"), path.join(tempDir, "workspace")),
-      { turnTerminalIdleTimeoutMs: 60_000 },
+      { nativeHookRelay: { enabled: true }, turnTerminalIdleTimeoutMs: 60_000 },
     );
     let resolved = false;
     void run.then(() => {
@@ -8182,6 +8182,8 @@ describe("runCodexAppServerAttempt", () => {
     });
 
     await harness.waitForMethod("turn/start");
+    const startRequest = harness.requests.find((request) => request.method === "thread/start");
+    const relayId = extractRelayIdFromThreadRequest(startRequest?.params);
     await harness.notify({
       method: "rawResponseItem/completed",
       params: {
@@ -8207,6 +8209,21 @@ describe("runCodexAppServerAttempt", () => {
     expect(result.timedOut).toBe(false);
     expect(result.promptError).toBeNull();
     expect(harness.request.mock.calls.some(([method]) => method === "turn/interrupt")).toBe(false);
+    expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)).toBeUndefined();
+    await expect(
+      invokeNativeHookRelay({
+        provider: "codex",
+        relayId,
+        event: "pre_tool_use",
+        rawPayload: {
+          hook_event_name: "PreToolUse",
+          tool_name: "Bash",
+          tool_input: { command: "pnpm test" },
+        },
+      }),
+    ).rejects.toThrow("native hook relay not found");
+    testing.flushPendingCodexNativeHookRelayUnregistersForTests();
+    expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)).toBeUndefined();
   });
 
   it("keeps upstream cancellation aborted when Codex completes the turn as interrupted", async () => {

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -3284,8 +3284,13 @@ export async function runCodexAppServerAttempt(
       },
       ctx: hookContext,
     });
+    const completedTurnStatus = activeProjector.getCompletedTurnStatus();
     shouldDelayNativeHookRelayUnregister =
-      !timedOut && !runAbortController.signal.aborted && !finalAborted && !finalPromptError;
+      completedTurnStatus === "completed" &&
+      !timedOut &&
+      !runAbortController.signal.aborted &&
+      !finalAborted &&
+      !finalPromptError;
     return {
       ...result,
       timedOut,

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -216,6 +216,7 @@ const CODEX_TURN_TERMINAL_IDLE_TIMEOUT_MS = 30 * 60_000;
 const CODEX_NATIVE_HOOK_RELAY_MIN_TTL_MS = 30 * 60_000;
 const CODEX_NATIVE_HOOK_RELAY_TTL_GRACE_MS = 5 * 60_000;
 const CODEX_NATIVE_HOOK_RELAY_RENEW_INTERVAL_MS = 60_000;
+const CODEX_NATIVE_HOOK_RELAY_UNREGISTER_GRACE_MS = 10_000;
 const CODEX_STEER_ALL_DEBOUNCE_MS = 500;
 const LOG_FIELD_MAX_LENGTH = 160;
 const CODEX_NATIVE_SANDBOX_TOOL_REQUIREMENTS = [
@@ -267,6 +268,46 @@ type CodexWorkspaceBootstrapContext = CodexBootstrapContext & {
 };
 
 let openClawCodingToolsFactoryForTests: OpenClawCodingToolsFactory | undefined;
+
+type PendingCodexNativeHookRelayUnregister = {
+  timeout: ReturnType<typeof setTimeout>;
+  unregister: () => void;
+};
+
+const pendingCodexNativeHookRelayUnregisters = new Set<PendingCodexNativeHookRelayUnregister>();
+
+function scheduleCodexNativeHookRelayUnregister(relay: NativeHookRelayRegistrationHandle): void {
+  let pending: PendingCodexNativeHookRelayUnregister | undefined;
+  const unregister = () => {
+    if (!pending) {
+      return;
+    }
+    const current = pending;
+    pending = undefined;
+    if (!pendingCodexNativeHookRelayUnregisters.delete(current)) {
+      return;
+    }
+    relay.unregister();
+  };
+  const timeout = setTimeout(unregister, CODEX_NATIVE_HOOK_RELAY_UNREGISTER_GRACE_MS);
+  pending = { timeout, unregister };
+  pendingCodexNativeHookRelayUnregisters.add(pending);
+  timeout.unref();
+}
+
+function flushPendingCodexNativeHookRelayUnregistersForTests(): void {
+  for (const pending of [...pendingCodexNativeHookRelayUnregisters]) {
+    clearTimeout(pending.timeout);
+    pending.unregister();
+  }
+}
+
+function clearPendingCodexNativeHookRelayUnregistersForTests(): void {
+  for (const pending of pendingCodexNativeHookRelayUnregisters) {
+    clearTimeout(pending.timeout);
+  }
+  pendingCodexNativeHookRelayUnregisters.clear();
+}
 
 function emitCodexAppServerEvent(
   params: EmbeddedRunAttemptParams,
@@ -3286,19 +3327,11 @@ export async function runCodexAppServerAttempt(
     notificationCleanup();
     requestCleanup();
     closeCleanup?.();
-    // Defer relay unregister so in-flight `nativeHook.invoke` RPCs from
-    // codex's hook subprocess (spawned synchronously during the last
-    // tool dispatch) can still resolve. Without this delay, codex's
-    // subprocess→gateway RPC roundtrip can outlast the run-attempt
-    // teardown — late-arriving invocations then fail with
-    // `errorMessage=native hook relay not found` and the OC
-    // `before_tool_call` chain (firewall, MG, audit) is silently
-    // bypassed for the closing tool call of the run. 10s comfortably
-    // bounds the default 5s `hookTimeoutSec` plus subprocess startup
-    // and WS connect overhead. `unref()` avoids holding the event loop.
+    // Codex hook subprocesses can outlive the app-server turn by a few
+    // seconds. Keep the relay available briefly so late nativeHook.invoke
+    // RPCs can still reach before_tool_call enforcement.
     if (nativeHookRelay) {
-      const relay = nativeHookRelay;
-      setTimeout(() => relay.unregister(), 10_000).unref();
+      scheduleCodexNativeHookRelayUnregister(nativeHookRelay);
     }
     await releaseSandboxExecEnvironment();
     runAbortController.signal.removeEventListener("abort", abortListener);
@@ -5682,5 +5715,7 @@ export const testing = {
   resetOpenClawCodingToolsFactoryForTests(): void {
     openClawCodingToolsFactoryForTests = undefined;
   },
+  flushPendingCodexNativeHookRelayUnregistersForTests,
+  clearPendingCodexNativeHookRelayUnregistersForTests,
 } as const;
 export { testing as __testing };

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -3286,7 +3286,20 @@ export async function runCodexAppServerAttempt(
     notificationCleanup();
     requestCleanup();
     closeCleanup?.();
-    nativeHookRelay?.unregister();
+    // Defer relay unregister so in-flight `nativeHook.invoke` RPCs from
+    // codex's hook subprocess (spawned synchronously during the last
+    // tool dispatch) can still resolve. Without this delay, codex's
+    // subprocess→gateway RPC roundtrip can outlast the run-attempt
+    // teardown — late-arriving invocations then fail with
+    // `errorMessage=native hook relay not found` and the OC
+    // `before_tool_call` chain (firewall, MG, audit) is silently
+    // bypassed for the closing tool call of the run. 10s comfortably
+    // bounds the default 5s `hookTimeoutSec` plus subprocess startup
+    // and WS connect overhead. `unref()` avoids holding the event loop.
+    if (nativeHookRelay) {
+      const relay = nativeHookRelay;
+      setTimeout(() => relay.unregister(), 10_000).unref();
+    }
     await releaseSandboxExecEnvironment();
     runAbortController.signal.removeEventListener("abort", abortListener);
     params.abortSignal?.removeEventListener("abort", abortFromUpstream);

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -217,6 +217,7 @@ const CODEX_NATIVE_HOOK_RELAY_MIN_TTL_MS = 30 * 60_000;
 const CODEX_NATIVE_HOOK_RELAY_TTL_GRACE_MS = 5 * 60_000;
 const CODEX_NATIVE_HOOK_RELAY_RENEW_INTERVAL_MS = 60_000;
 const CODEX_NATIVE_HOOK_RELAY_UNREGISTER_GRACE_MS = 10_000;
+const CODEX_NATIVE_HOOK_RELAY_UNREGISTER_EXTRA_GRACE_MS = 5_000;
 const CODEX_STEER_ALL_DEBOUNCE_MS = 500;
 const LOG_FIELD_MAX_LENGTH = 160;
 const CODEX_NATIVE_SANDBOX_TOOL_REQUIREMENTS = [
@@ -276,7 +277,10 @@ type PendingCodexNativeHookRelayUnregister = {
 
 const pendingCodexNativeHookRelayUnregisters = new Set<PendingCodexNativeHookRelayUnregister>();
 
-function scheduleCodexNativeHookRelayUnregister(relay: NativeHookRelayRegistrationHandle): void {
+function scheduleCodexNativeHookRelayUnregister(params: {
+  relay: NativeHookRelayRegistrationHandle;
+  hookTimeoutSec?: number;
+}): void {
   let pending: PendingCodexNativeHookRelayUnregister | undefined;
   const unregister = () => {
     if (!pending) {
@@ -287,12 +291,26 @@ function scheduleCodexNativeHookRelayUnregister(relay: NativeHookRelayRegistrati
     if (!pendingCodexNativeHookRelayUnregisters.delete(current)) {
       return;
     }
-    relay.unregister();
+    params.relay.unregister();
   };
-  const timeout = setTimeout(unregister, CODEX_NATIVE_HOOK_RELAY_UNREGISTER_GRACE_MS);
+  const timeout = setTimeout(
+    unregister,
+    resolveCodexNativeHookRelayUnregisterGraceMs(params.hookTimeoutSec),
+  );
   pending = { timeout, unregister };
   pendingCodexNativeHookRelayUnregisters.add(pending);
   timeout.unref();
+}
+
+function resolveCodexNativeHookRelayUnregisterGraceMs(hookTimeoutSec: number | undefined): number {
+  const hookTimeoutMs =
+    typeof hookTimeoutSec === "number" && Number.isFinite(hookTimeoutSec) && hookTimeoutSec > 0
+      ? Math.ceil(hookTimeoutSec) * 1000
+      : 0;
+  return Math.max(
+    CODEX_NATIVE_HOOK_RELAY_UNREGISTER_GRACE_MS,
+    hookTimeoutMs + CODEX_NATIVE_HOOK_RELAY_UNREGISTER_EXTRA_GRACE_MS,
+  );
 }
 
 function flushPendingCodexNativeHookRelayUnregistersForTests(): void {
@@ -3339,7 +3357,10 @@ export async function runCodexAppServerAttempt(
         // Codex hook subprocesses can outlive a completed app-server turn by a
         // few seconds. Keep the relay available briefly so late
         // nativeHook.invoke RPCs can still reach before_tool_call enforcement.
-        scheduleCodexNativeHookRelayUnregister(nativeHookRelay);
+        scheduleCodexNativeHookRelayUnregister({
+          relay: nativeHookRelay,
+          hookTimeoutSec: options.nativeHookRelay?.hookTimeoutSec,
+        });
       } else {
         nativeHookRelay.unregister();
       }
@@ -5728,5 +5749,6 @@ export const testing = {
   },
   flushPendingCodexNativeHookRelayUnregistersForTests,
   clearPendingCodexNativeHookRelayUnregistersForTests,
+  resolveCodexNativeHookRelayUnregisterGraceMs,
 } as const;
 export { testing as __testing };

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -1836,6 +1836,7 @@ export async function runCodexAppServerAttempt(
   let turnCompletionIdleTimeoutMessage: string | undefined;
   let clientClosedPromptError: string | undefined;
   let clientClosedAbort = false;
+  let shouldDelayNativeHookRelayUnregister = false;
   let lifecycleStarted = false;
   let lifecycleTerminalEmitted = false;
   let resolveCompletion: (() => void) | undefined;
@@ -3265,6 +3266,8 @@ export async function runCodexAppServerAttempt(
       },
       ctx: hookContext,
     });
+    shouldDelayNativeHookRelayUnregister =
+      !timedOut && !runAbortController.signal.aborted && !finalAborted && !finalPromptError;
     return {
       ...result,
       timedOut,
@@ -3332,7 +3335,7 @@ export async function runCodexAppServerAttempt(
     requestCleanup();
     closeCleanup?.();
     if (nativeHookRelay) {
-      if (!timedOut && !runAbortController.signal.aborted) {
+      if (shouldDelayNativeHookRelayUnregister) {
         // Codex hook subprocesses can outlive a completed app-server turn by a
         // few seconds. Keep the relay available briefly so late
         // nativeHook.invoke RPCs can still reach before_tool_call enforcement.

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -296,7 +296,11 @@ function scheduleCodexNativeHookRelayUnregister(relay: NativeHookRelayRegistrati
 }
 
 function flushPendingCodexNativeHookRelayUnregistersForTests(): void {
-  for (const pending of [...pendingCodexNativeHookRelayUnregisters]) {
+  while (pendingCodexNativeHookRelayUnregisters.size > 0) {
+    const pending = pendingCodexNativeHookRelayUnregisters.values().next().value;
+    if (!pending) {
+      return;
+    }
     clearTimeout(pending.timeout);
     pending.unregister();
   }

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -3331,11 +3331,15 @@ export async function runCodexAppServerAttempt(
     notificationCleanup();
     requestCleanup();
     closeCleanup?.();
-    // Codex hook subprocesses can outlive the app-server turn by a few
-    // seconds. Keep the relay available briefly so late nativeHook.invoke
-    // RPCs can still reach before_tool_call enforcement.
     if (nativeHookRelay) {
-      scheduleCodexNativeHookRelayUnregister(nativeHookRelay);
+      if (!timedOut && !runAbortController.signal.aborted) {
+        // Codex hook subprocesses can outlive a completed app-server turn by a
+        // few seconds. Keep the relay available briefly so late
+        // nativeHook.invoke RPCs can still reach before_tool_call enforcement.
+        scheduleCodexNativeHookRelayUnregister(nativeHookRelay);
+      } else {
+        nativeHookRelay.unregister();
+      }
     }
     await releaseSandboxExecEnvironment();
     runAbortController.signal.removeEventListener("abort", abortListener);

--- a/src/agents/harness/native-hook-relay.test.ts
+++ b/src/agents/harness/native-hook-relay.test.ts
@@ -207,6 +207,18 @@ describe("native hook relay registry", () => {
         allowedEvents: ["post_tool_use"],
       },
     );
+    const secondExpiresAtMs = requireRecord(
+      testing.getNativeHookRelayRegistrationForTests(first.relayId),
+      "replacement native hook relay registration",
+    ).expiresAtMs;
+
+    first.renew(60_000);
+    expect(
+      requireRecord(
+        testing.getNativeHookRelayRegistrationForTests(first.relayId),
+        "replacement native hook relay registration",
+      ).expiresAtMs,
+    ).toBe(secondExpiresAtMs);
 
     first.unregister();
     expectRecordFields(

--- a/src/agents/harness/native-hook-relay.test.ts
+++ b/src/agents/harness/native-hook-relay.test.ts
@@ -783,17 +783,16 @@ describe("native hook relay registry", () => {
   });
 
   it("rejects expired relay ids", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-04-24T12:00:00Z"));
     const relay = registerNativeHookRelay({
       provider: "codex",
       sessionId: "session-1",
       runId: "run-1",
       ttlMs: 1,
     });
-    expect(testing.getNativeHookRelayBridgeRecordForTests(relay.relayId)).toBeDefined();
+    await waitForNativeHookRelayBridgeRecord(relay.relayId);
 
-    vi.setSystemTime(new Date("2026-04-24T12:00:01Z"));
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(relay.expiresAtMs + 1));
 
     await expect(
       invokeNativeHookRelay({

--- a/src/agents/harness/native-hook-relay.test.ts
+++ b/src/agents/harness/native-hook-relay.test.ts
@@ -207,6 +207,21 @@ describe("native hook relay registry", () => {
         allowedEvents: ["post_tool_use"],
       },
     );
+
+    first.unregister();
+    expectRecordFields(
+      requireRecord(
+        testing.getNativeHookRelayRegistrationForTests(first.relayId),
+        "replacement native hook relay registration",
+      ),
+      {
+        runId: "run-2",
+        allowedEvents: ["post_tool_use"],
+      },
+    );
+
+    second.unregister();
+    expect(testing.getNativeHookRelayRegistrationForTests(first.relayId)).toBeUndefined();
   });
 
   it("exposes registered relays through the direct hook bridge", async () => {

--- a/src/agents/harness/native-hook-relay.test.ts
+++ b/src/agents/harness/native-hook-relay.test.ts
@@ -179,7 +179,7 @@ describe("native hook relay registry", () => {
     );
   });
 
-  it("allows callers to replace a relay at a stable id", () => {
+  it("allows callers to replace a relay at a stable id", async () => {
     const first = registerNativeHookRelay({
       provider: "codex",
       relayId: "codex-stable-session",
@@ -231,6 +231,21 @@ describe("native hook relay registry", () => {
         allowedEvents: ["post_tool_use"],
       },
     );
+    await expect(
+      invokeNativeHookRelayBridge({
+        provider: "codex",
+        relayId: second.relayId,
+        event: "post_tool_use",
+        timeoutMs: 2_000,
+        rawPayload: {
+          hook_event_name: "PostToolUse",
+          tool_name: "Bash",
+          tool_use_id: "replacement-call",
+          tool_input: { command: "pnpm test" },
+          tool_response: { output: "ok", exit_code: 0 },
+        },
+      }),
+    ).resolves.toEqual({ stdout: "", stderr: "", exitCode: 0 });
 
     second.unregister();
     expect(testing.getNativeHookRelayRegistrationForTests(first.relayId)).toBeUndefined();
@@ -776,6 +791,7 @@ describe("native hook relay registry", () => {
       runId: "run-1",
       ttlMs: 1,
     });
+    expect(testing.getNativeHookRelayBridgeRecordForTests(relay.relayId)).toBeDefined();
 
     vi.setSystemTime(new Date("2026-04-24T12:00:01Z"));
 
@@ -788,6 +804,9 @@ describe("native hook relay registry", () => {
       }),
     ).rejects.toThrow("expired");
     expect(testing.getNativeHookRelayRegistrationForTests(relay.relayId)).toBeUndefined();
+    expect(testing.getNativeHookRelayBridgeRecordForTests(relay.relayId)).toBeUndefined();
+    relay.unregister();
+    expect(testing.getNativeHookRelayBridgeRecordForTests(relay.relayId)).toBeUndefined();
   });
 
   it("uses the Codex no-op output when no OpenClaw hook decides", async () => {

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -345,12 +345,18 @@ export function registerNativeHookRelay(
         writeNativeHookRelayBridgeRecordForRegistration(current, bridge);
       }
     },
-    unregister: () => unregisterNativeHookRelay(relayId),
+    unregister: () => unregisterNativeHookRelay(relayId, registration),
   };
   return handle;
 }
 
-function unregisterNativeHookRelay(relayId: string): void {
+function unregisterNativeHookRelay(
+  relayId: string,
+  expectedRegistration?: NativeHookRelayRegistration,
+): void {
+  if (expectedRegistration && relays.get(relayId) !== expectedRegistration) {
+    return;
+  }
   unregisterNativeHookRelayBridge(relayId);
   relays.delete(relayId);
   removeNativeHookRelayInvocations(relayId);

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -428,8 +428,7 @@ export async function invokeNativeHookRelay(
     throw new Error("native hook relay not found");
   }
   if (Date.now() > registration.expiresAtMs) {
-    relays.delete(relayId);
-    removeNativeHookRelayInvocations(relayId);
+    unregisterNativeHookRelay(relayId, registration);
     throw new Error("native hook relay expired");
   }
   if (registration.provider !== provider) {
@@ -557,9 +556,7 @@ function removeNativeHookRelayInvocations(relayId: string): void {
 function pruneExpiredNativeHookRelays(now = Date.now()): void {
   for (const [relayId, registration] of relays) {
     if (now > registration.expiresAtMs) {
-      relays.delete(relayId);
-      unregisterNativeHookRelayBridge(relayId);
-      removeNativeHookRelayInvocations(relayId);
+      unregisterNativeHookRelay(relayId, registration);
     }
   }
 }

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -334,7 +334,7 @@ export function registerNativeHookRelay(
       }),
     renew: (ttlMs) => {
       const current = relays.get(relayId);
-      if (!current) {
+      if (current !== registration) {
         return;
       }
       const expiresAtMs = Date.now() + normalizePositiveInteger(ttlMs, DEFAULT_RELAY_TTL_MS);


### PR DESCRIPTION
## Problem

Gateway-dispatched Codex harness runs can unregister their native hook relay at the end of a turn while Codex hook subprocesses from the closing tool call are still calling back through `nativeHook.invoke`. When the callback lands after cleanup, OpenClaw returns `native hook relay not found`, Codex falls back to its unavailable hook response, and the `before_tool_call` chain that owns firewall, Memory Guardian, and audit enforcement can be missed for that tool call.

This is independent of #73950's module-duplication fix. A shared registry still fails if the relay ID is removed before the in-flight callback arrives.

## Change and value

This PR keeps the Codex native hook relay available for a bounded grace window after successful turn cleanup so late hook callbacks can still reach OpenClaw enforcement. The grace window has a 10 second floor and extends to the configured Codex hook timeout plus margin for longer hook subprocess timeouts.

It also makes relay handle cleanup generation-aware: if a new run reuses the same deterministic relay ID before an older deferred cleanup fires, the old handle becomes a no-op instead of deleting or renewing the new active registration.

The grace window is limited to fully successful turns. Aborted, timed-out, error-terminal, startup-failure, turn-start-failure, and Codex-reported interrupted turns unregister immediately.

## Who is affected, and who is not

Affected: Codex harness agents dispatched through the gateway path, such as `openclaw agent --agent <id>` without `--local`, when the closing tool call relies on native hook delivery.

Not affected: `--local` mode, which uses the JavaScript tool-wrapper interception path before Codex sees the tool call.

## Why now

The failure is reproducible on the current 2026.5.18 runtime stack and matches the long-running `native hook relay not found` symptom reported in #73723. ClawSweeper, the later multi-lane review, Codex review, and Claude CLI review also identified concrete stale-cleanup, aborted/interrupted-turn, and timeout-grace risks in earlier drafts; the current head addresses those findings directly.

## Implementation

- Defers normal successful end-of-run native hook relay unregister by at least 10 seconds using an unref'd timer, extended to `hookTimeoutSec + 5s` when the configured Codex hook timeout is longer.
- Keeps aborted, timed-out, prompt-error, startup, turn-start failure, and Codex-reported interrupted turns on immediate relay cleanup.
- Tracks pending deferred unregisters for deterministic test cleanup.
- Changes `NativeHookRelayRegistrationHandle.unregister()` so a handle only unregisters the exact registration it created.
- Changes `NativeHookRelayRegistrationHandle.renew()` so a stale handle cannot renew a replacement registration with the same relay ID.
- Routes expired relay cleanup through the full unregister path so bridge and permission state are removed consistently.
- Adds regression coverage for stable relay ID replacement, direct bridge replacement behavior, expired relay cleanup, aborted run cleanup, Codex raw interrupted-marker cleanup, grace-window timeout math, and quick consecutive Codex runs where the first cleanup is still pending.

## Verification

- Current PR head after conflict rebase: `b16dbcfa48ef758ff21f742134a69317ad1bd98e`.
- Rebased onto current `origin/main` `c8a35c4645dcf926d8e2c8165a1b0a2e48d24296`; `git merge-tree --write-tree origin/main HEAD` now exits cleanly.
- `git diff --check origin/main...HEAD` passed locally after the rebase.
- `./node_modules/.bin/oxfmt --check --threads=1 extensions/codex/src/app-server/run-attempt.ts extensions/codex/src/app-server/run-attempt.test.ts src/agents/harness/native-hook-relay.ts src/agents/harness/native-hook-relay.test.ts` passed locally.
- `timeout 120s ./node_modules/.bin/oxlint --tsconfig config/tsconfig/oxlint.core.json src/agents/harness/native-hook-relay.ts src/agents/harness/native-hook-relay.test.ts` passed locally.
- `timeout 120s ./node_modules/.bin/oxlint --tsconfig config/tsconfig/oxlint.extensions.json extensions/codex/src/app-server/run-attempt.ts extensions/codex/src/app-server/run-attempt.test.ts` passed locally.
- Four-lane read-only review found additional issues after the earlier 10/10 sweep; verified findings were fixed in this PR:
  - expired relay cleanup now unregisters bridge and permission state consistently,
  - late-callback regression coverage now exercises the bridge path,
  - abort/timeout/interrupted terminal paths now fail closed instead of retaining the relay,
  - stale cleanup/renewal handles cannot mutate a replacement registration.
- `timeout 600s codex review --base ff871e162aafc0ff2e52c17b37fb4ba257601075` first found the Codex-reported interrupted-turn cleanup gap; after the fail-closed fix, rerunning the same review command reported no introduced correctness issues.
- Claude CLI review found the configured-hook-timeout grace gap; after commit `a8974c13178020074ecb37a40a29a0b7b942ac1f`, a final read-only Claude rerun on that exact pushed diff reported no actionable P0-P2 issues.
- Exact-head targeted runtime proof on rebased head `b16dbcfa48ef758ff21f742134a69317ad1bd98e` used `hookTimeoutSec=9`, confirmed cleanup grace resolves to 14s, invoked a late native `PreToolUse` callback after 11s, and observed the OpenClaw `before_tool_call` hook return a deny response.
- Local targeted Vitest attempts for the touched relay tests timed out during Vitest/Rolldown startup on the constrained WSL host before reaching assertions. No assertion failure was observed locally. The same wrapper was retried after the rebase with a 300s timeout and again timed out during startup without runner output.
- Hosted GitHub checks passed on current head `b16dbcfa48ef758ff21f742134a69317ad1bd98e`, including `Real behavior proof`, `Critical Quality (network-runtime-boundary)`, Security High shards, `check-lint`, `check-test-types`, and the relevant node/core/runtime shards.

## Real behavior proof

Behavior addressed: Codex native hook relay cleanup could run before late hook callbacks from the closing tool call reached OpenClaw, causing `before_tool_call` enforcement to be skipped. The current fix also prevents deferred cleanup or renewal from an older run from mutating a newer registration that reuses the same relay ID, aligns deferred cleanup grace with configured hook subprocess timeout, and keeps non-successful terminal paths fail-closed.

Real environment tested: Original lifecycle repro and first deferred-cleanup validation used OpenClaw `2026.5.18` stable with the local active patch set and a clean `@openai/codex@0.130.0` binary. Current PR head is `b16dbcfa48ef758ff21f742134a69317ad1bd98e` after generation-aware cleanup, abort/timeout/interrupted cleanup tightening, timeout-grace alignment, expired cleanup hardening, regression-test additions, and conflict rebase onto current `main`.

Exact steps or command run after this patch: The original live probe dispatched an `eval-2` Codex harness agent through the gateway with `openclaw agent --agent eval-2 --message "Use exec_command to run python3 -c 'print(\"x\")'" --json` while instrumenting Codex hook dispatch and OpenClaw native relay registration, unregister, and invoke lifecycle. Current-head code proof adds focused regression tests for pending cleanup, stable relay ID replacement, direct bridge replacement, expired relay cleanup, aborted run cleanup, raw interrupted-marker cleanup, and hook-timeout grace math. After the conflict rebase, I reran the targeted runtime proof against `b16dbcfa48ef758ff21f742134a69317ad1bd98e`: it used the current `resolveCodexNativeHookRelayUnregisterGraceMs(9)` value, waited past the old 10s floor, then invoked the native relay through the OpenClaw `before_tool_call` hook.

Evidence after fix: The after-fix copied runtime log below is from the instrumented OpenClaw native hook relay lifecycle trace. Before the fix, the same trace shape showed `UNREGISTER codex-08fa4130...` followed 1.2 seconds later by `INVOKE codex-08fa4130... found=false`.

```text
21:38:14.471Z UNREGISTER codex-fb6566dce... relays_size_before=0  (pre-register idempotent cleanup)
21:38:14.472Z REGISTER   codex-fb6566dce... relays_size=1
... probe runs, codex spawns relay subprocess during exec_command dispatch ...
21:38:45.684Z INVOKE     codex-fb6566dce... event=pre_tool_use found=TRUE relays_size=1
```

Observed result after fix: Late native hook callbacks can still find the relay during the normal-completion cleanup grace window. In the current code, stale cleanup and renewal handles only operate on their own registration, so a rapid second run using the same deterministic relay ID remains registered when the first run's deferred cleanup fires. Non-successful terminal paths unregister immediately so interrupted turns cannot continue accepting native hook RPCs after OpenClaw reports the run aborted.

Exact-head targeted runtime proof output:

```text
[proof] head=b16dbcfa48ef758ff21f742134a69317ad1bd98e
[proof] hookTimeoutSec=9 cleanupGraceMs=14000
[proof] relayId=fbbc4164-bacd-481c-9a1a-1c26fd34f88a
[proof] registration-after-register=true
[proof] scheduled successful-turn deferred unregister
[proof] registration-after-11s=true
[proof] before_tool_call reached event={"toolName":"exec","params":{"command":"python3 -c 'print(\"x\")'"},"runId":"run-1","toolCallId":"late-proof-call-1"}
[proof] late-invoke-exit=0
[proof] late-invoke-stdout={"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"proof hook blocked late native callback"}}

[proof] before-tool-call-count=1
[proof] registration-after-grace=false
```

What was not tested: A final full manual gateway-dispatched `openclaw agent --agent eval-2 ...` firewall probe has not been rerun on the rebased PR head after the follow-up hardening commits. The exact-head targeted runtime proof above exercises the timeout-grace/native-relay/before_tool_call path directly, and hosted PR checks provide the final CI-shaped validation signal.
