### PR TITLE
fix(tts): defer text settlement for final-mode TTS to eliminate churn (#83511)

### DIFF
--- a/docs/plugins/sdk-channel-plugins.md
+++ b/docs/plugins/sdk-channel-plugins.md
@@ -82,6 +82,15 @@ Inbound receivers that defer platform acknowledgements should declare
 ack timing in monitor-local state. Cover every declared policy with
 `verifyChannelMessageReceiveAckPolicyAdapterProofs(...)`.
 
+### TTS voice delivery
+
+Declare native voice-note behavior under `capabilities.tts.voice`. Set
+`synthesisTarget: "voice-note"` when TTS providers should produce a native
+voice-note format. Set `captionedFinalText: true` only when the outbound voice
+operation accepts visible final text and enforces its transport's caption and
+overflow rules. Core then holds final-mode streamed text for that operation and
+falls back to text when the voice payload is proven unsent.
+
 Legacy reply helpers such as `dispatchInboundReplyWithBase` and
 `recordInboundSessionAndDispatchReply` remain available for compatibility
 dispatchers. Do not use them for new channel code; start with the `message`

--- a/docs/tools/tts.md
+++ b/docs/tools/tts.md
@@ -812,6 +812,14 @@ whether voice-style TTS should ask providers for a native `voice-note` target or
 keep normal `audio-file` synthesis, and whether the channel transcodes
 non-native output before sending.
 
+Telegram also advertises captioned final TTS. With `tts.mode: "final"` and
+Auto-TTS set to `always` (or eligible `inbound` mode), streamed text is held
+until synthesis finishes and sent as the voice-note caption. Text beyond
+Telegram's caption limit follows the voice note as a normal text message. If
+synthesis or a proven pre-send delivery step fails, OpenClaw sends the visible
+text instead. `tagged` mode keeps its normal streaming behavior, and text
+inside a `[[tts:text]]` block remains audio-only.
+
 After synthesis, OpenClaw persists batch TTS output in the media store under
 `tool-speech-synthesis`. The reply uses that stable media path instead of a
 provider temporary file, and normal media maintenance prunes expired output.
@@ -856,9 +864,11 @@ When `tts.auto` is enabled, OpenClaw:
 - Summarizes long replies when summaries are enabled, using
   `summaryModel` (or `agents.defaults.model.primary`).
 - Attaches the generated audio to the reply.
-- In `mode: "final"`, still sends audio-only TTS for streamed final replies
-  after the text stream completes; the generated media goes through the same
-  channel media normalization as normal reply attachments.
+- In `mode: "final"`, sends TTS after streamed text completes. Channels without
+  captioned-final support receive an audio-only supplement; Telegram puts text
+  within its caption limit on the voice note and sends overflow as follow-up
+  text. Generated media goes through the same channel media normalization as
+  normal reply attachments.
 
 If the reply exceeds `maxLength`, OpenClaw never skips audio outright:
 

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -2398,6 +2398,34 @@ describe("sendMessageTelegram", () => {
     ]);
   });
 
+  it("sends oversized voice captions as a voice note followed by text", async () => {
+    const chatId = "123";
+    const longText = "A".repeat(1100);
+    botApi.sendVoice.mockResolvedValue({ message_id: 70, chat: { id: chatId } });
+    botApi.sendMessage.mockResolvedValue({ message_id: 71, chat: { id: chatId } });
+    mockLoadedMedia({
+      buffer: Buffer.from("voice"),
+      contentType: "audio/ogg",
+      fileName: "voice.ogg",
+    });
+
+    const result = await sendMessageTelegram(chatId, longText, {
+      cfg: TELEGRAM_TEST_CFG,
+      token: "tok",
+      mediaUrl: "https://example.com/voice.ogg",
+      asVoice: true,
+    });
+
+    expectMediaSendCall(
+      firstMockCall(botApi.sendVoice, "send voice call"),
+      "send voice call",
+      chatId,
+      { caption: undefined },
+    );
+    expect(botApi.sendMessage).toHaveBeenCalledWith(chatId, longText, { parse_mode: "HTML" });
+    expect(result.receipt?.platformMessageIds).toEqual(["70", "71"]);
+  });
+
   it("finalizes media when its separate text renders empty", async () => {
     const storePath = `/tmp/openclaw-telegram-empty-media-follow-up-${process.pid}-${Date.now()}.json`;
     const cursor = createTelegramPromptContextProjectionCursor({

--- a/extensions/telegram/src/shared.ts
+++ b/extensions/telegram/src/shared.ts
@@ -165,6 +165,7 @@ export function createTelegramPluginBase(params: {
       tts: {
         voice: {
           synthesisTarget: "voice-note",
+          captionedFinalText: true,
         },
       },
       polls: true,

--- a/src/auto-reply/reply/before-deliver.test.ts
+++ b/src/auto-reply/reply/before-deliver.test.ts
@@ -4,10 +4,94 @@ import { getReplyPayloadMetadata, setReplyPayloadMetadata } from "../reply-paylo
 import type { ReplyPayload } from "../types.js";
 import {
   appendReplyDispatcherBeforeDeliverCancelled,
+  attachReplyDispatchUndeliveredFallback,
+  captureReplyDispatchDeliveryOutcome,
   createReplyDispatcher,
 } from "./reply-dispatcher.js";
 
 describe("beforeDeliver in reply dispatcher", () => {
+  it("delivers the attached fallback when the primary payload is cancelled", async () => {
+    const delivered: string[] = [];
+    const primary: ReplyPayload = { text: "caption", mediaUrl: "/tmp/voice.ogg" };
+    attachReplyDispatchUndeliveredFallback(primary, { text: "caption" });
+    const outcome = captureReplyDispatchDeliveryOutcome(primary);
+    const dispatcher = createReplyDispatcher({
+      beforeDeliver: (payload) => (payload.mediaUrl ? null : payload),
+      deliver: async (payload) => {
+        delivered.push(payload.text ?? "");
+      },
+    });
+
+    expect(dispatcher.sendFinalReply(primary)).toBe(true);
+    dispatcher.markComplete();
+    await dispatcher.waitForIdle();
+
+    expect(delivered).toEqual(["caption"]);
+    await expect(outcome.promise).resolves.toBe("delivered");
+    expect(dispatcher.getCancelledCounts?.().final).toBe(0);
+  });
+
+  it("delivers the fallback when primary normalization is cancelled", async () => {
+    const delivered: ReplyPayload[] = [];
+    const primary: ReplyPayload = { text: "caption", mediaUrl: "/tmp/voice.ogg" };
+    attachReplyDispatchUndeliveredFallback(primary, { text: "caption" });
+    const dispatcher = createReplyDispatcher({
+      transformReplyPayload: (payload) => (payload.mediaUrl ? null : payload),
+      deliver: async (payload) => {
+        delivered.push(payload);
+      },
+    });
+
+    expect(dispatcher.sendFinalReply(primary)).toBe(true);
+    dispatcher.markComplete();
+    await dispatcher.waitForIdle();
+
+    expect(delivered).toEqual([{ text: "caption" }]);
+  });
+
+  it("delivers the attached fallback after a proven pre-transport failure", async () => {
+    const delivered: string[] = [];
+    const primary: ReplyPayload = { text: "caption", mediaUrl: "/tmp/voice.ogg" };
+    attachReplyDispatchUndeliveredFallback(primary, { text: "caption" });
+    const dispatcher = createReplyDispatcher({
+      deliver: async (payload) => {
+        if (payload.mediaUrl) {
+          throw Object.assign(new Error("connect failed"), {
+            code: "ECONNREFUSED",
+            syscall: "connect",
+          });
+        }
+        delivered.push(payload.text ?? "");
+      },
+    });
+
+    dispatcher.sendFinalReply(primary);
+    dispatcher.markComplete();
+    await dispatcher.waitForIdle();
+
+    expect(delivered).toEqual(["caption"]);
+    expect(dispatcher.getFailedCounts().final).toBe(0);
+  });
+
+  it("does not duplicate text after an ambiguous transport failure", async () => {
+    const delivered: string[] = [];
+    const primary: ReplyPayload = { text: "caption", mediaUrl: "/tmp/voice.ogg" };
+    attachReplyDispatchUndeliveredFallback(primary, { text: "caption" });
+    const dispatcher = createReplyDispatcher({
+      deliver: async (payload) => {
+        delivered.push(payload.text ?? "");
+        throw new Error("send outcome unknown");
+      },
+    });
+
+    dispatcher.sendFinalReply(primary);
+    dispatcher.markComplete();
+    await dispatcher.waitForIdle();
+
+    expect(delivered).toEqual(["caption"]);
+    expect(dispatcher.getFailedCounts().final).toBe(1);
+  });
+
   it("cancels delivery before queueing when transformReplyPayload returns null", async () => {
     const delivered: string[] = [];
 

--- a/src/auto-reply/reply/dispatch-acp-delivery.test.ts
+++ b/src/auto-reply/reply/dispatch-acp-delivery.test.ts
@@ -242,10 +242,10 @@ describe("createAcpDispatchDeliveryCoordinator", () => {
 
     const notice = { text: "Model Fallback: openai/gpt-5.5", isFallbackNotice: true };
     await coordinator.deliver("final", notice);
-    await coordinator.settleVisibleText();
 
     expect(ttsMocks.maybeApplyTtsToPayload).not.toHaveBeenCalled();
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(notice);
+    expect(coordinator.hasDeliveredAnswerFinalToUser()).toBe(false);
   });
 
   it("tracks successful final delivery separately from routed counters", async () => {

--- a/src/auto-reply/reply/dispatch-acp-delivery.ts
+++ b/src/auto-reply/reply/dispatch-acp-delivery.ts
@@ -3,20 +3,34 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
-import { hasOutboundReplyContent } from "openclaw/plugin-sdk/reply-payload";
+import {
+  hasOutboundReplyContent,
+  resolveSendableOutboundReplyParts,
+} from "openclaw/plugin-sdk/reply-payload";
 import type { ChatType } from "../../channels/chat-type.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { TtsAutoMode } from "../../config/types.tts.js";
 import { logVerbose } from "../../globals.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
+import {
+  buildCaptionedFinalTextFallback,
+  cleanDeferredFinalText,
+  isCaptionedFinalTextPayload,
+  mergeDeferredFinalText,
+} from "../../tts/captioned-final.js";
 import { createTtsDirectiveTextStreamCleaner } from "../../tts/directives.js";
 import { resolveStatusTtsSnapshot } from "../../tts/status-config.js";
 import { resolveConfiguredTtsMode, shouldCleanTtsDirectiveText } from "../../tts/tts-config.js";
-import { isReplyPayloadStatusNotice } from "../reply-payload.js";
+import {
+  copyReplyPayloadMetadata,
+  isReplyPayloadStatusNotice,
+  isReplyPayloadTtsSupplement,
+} from "../reply-payload.js";
 import type { FinalizedMsgContext } from "../templating.js";
 import type { ReplyPayload } from "../types.js";
 import {
+  attachReplyDispatchUndeliveredFallback,
   captureReplyDispatchDeliveryOutcome,
   waitForReplyDispatcherIdle,
 } from "./reply-dispatcher.js";
@@ -164,6 +178,8 @@ type AcpDispatchDeliveryState = {
   cleanBlockTtsDirectiveText?: ReturnType<typeof createTtsDirectiveTextStreamCleaner>;
   blockCount: number;
   deliveredFinalReply: boolean;
+  deliveredAnswerFinalToUser: boolean;
+  deliveredFinalTtsMedia: boolean;
   deliveredVisibleText: boolean;
   failedVisibleTextDelivery: boolean;
   queuedDirectVisibleTextDeliveries: number;
@@ -188,6 +204,8 @@ export type AcpDispatchDeliveryCoordinator = {
   resolveAccumulatedDeliveredTranscriptText: () => Promise<string>;
   settleVisibleText: () => Promise<void>;
   hasDeliveredFinalReply: () => boolean;
+  hasDeliveredAnswerFinalToUser: () => boolean;
+  hasDeliveredFinalTtsMedia: () => boolean;
   hasDeliveredVisibleText: () => boolean;
   hasFailedVisibleTextDelivery: () => boolean;
   getRoutedCounts: () => Record<ReplyDispatchKind, number>;
@@ -204,6 +222,7 @@ export function createAcpDispatchDeliveryCoordinator(params: {
   sessionTtsAuto?: TtsAutoMode;
   ttsChannel?: string;
   suppressUserDelivery?: boolean;
+  suppressBlockUserDelivery?: boolean;
   suppressReplyLifecycle?: boolean;
   shouldRouteToOriginating: boolean;
   originatingChannel?: string;
@@ -257,6 +276,8 @@ export function createAcpDispatchDeliveryCoordinator(params: {
       : undefined,
     blockCount: 0,
     deliveredFinalReply: false,
+    deliveredAnswerFinalToUser: false,
+    deliveredFinalTtsMedia: false,
     deliveredVisibleText: false,
     failedVisibleTextDelivery: false,
     queuedDirectVisibleTextDeliveries: 0,
@@ -428,8 +449,27 @@ export function createAcpDispatchDeliveryCoordinator(params: {
     if (params.suppressUserDelivery) {
       return false;
     }
+    if (
+      kind === "block" &&
+      params.suppressBlockUserDelivery &&
+      !isStatusNotice &&
+      !payload.isReasoning &&
+      !payload.isCommentary
+    ) {
+      const hasNonTextContent = Boolean(
+        visiblePayload.mediaUrl ||
+        visiblePayload.mediaUrls?.length ||
+        visiblePayload.presentation ||
+        visiblePayload.interactive ||
+        visiblePayload.channelData,
+      );
+      if (!hasNonTextContent) {
+        return false;
+      }
+      visiblePayload = { ...visiblePayload, text: undefined };
+    }
 
-    const ttsPayload = await maybeApplyAcpTts({
+    const appliedTtsPayload = await maybeApplyAcpTts({
       payload: visiblePayload,
       cfg: params.cfg,
       agentId: params.agentId,
@@ -440,6 +480,24 @@ export function createAcpDispatchDeliveryCoordinator(params: {
       ttsAuto: params.sessionTtsAuto,
       skipTts: meta?.skipTts,
     });
+    const finalVisibleTextSource =
+      kind === "final" && params.suppressBlockUserDelivery && state.cleanBlockTtsDirectiveText
+        ? meta?.skipTts || payload.isError || isReplyPayloadTtsSupplement(payload)
+          ? payload.text
+          : mergeDeferredFinalText(state.accumulatedBlockTtsText, payload.text)
+        : undefined;
+    const ttsPayload =
+      finalVisibleTextSource !== undefined
+        ? copyReplyPayloadMetadata(appliedTtsPayload, {
+            ...appliedTtsPayload,
+            text: cleanDeferredFinalText(finalVisibleTextSource) || undefined,
+          })
+        : appliedTtsPayload;
+    const hasFinalTtsMedia =
+      kind === "final" &&
+      resolveSendableOutboundReplyParts(ttsPayload).hasMedia &&
+      isReplyPayloadTtsSupplement(ttsPayload);
+    const isAnswerBearingFinal = kind === "final" && isCaptionedFinalTextPayload(payload);
 
     if (params.shouldRouteToOriginating && params.originatingChannel && params.originatingTo) {
       const toolCallId = normalizeOptionalString(meta?.toolCallId);
@@ -484,6 +542,14 @@ export function createAcpDispatchDeliveryCoordinator(params: {
         replyKind: kind,
         runId: params.runId,
       });
+      if (!result.delivered && hasFinalTtsMedia && ttsPayload.text?.trim()) {
+        if (!result.suppressed) {
+          logVerbose(
+            `dispatch-acp: route-reply (acp/${kind}) failed: ${result.error ?? "unknown error"}`,
+          );
+        }
+        return await deliver("final", { text: ttsPayload.text }, { skipTts: true });
+      }
       if (!result.delivered && !result.suppressed) {
         if (tracksVisibleText) {
           state.failedVisibleTextDelivery = true;
@@ -521,6 +587,10 @@ export function createAcpDispatchDeliveryCoordinator(params: {
       appendDeliveredTranscriptText(kind, rawBlockText, rawFinalText);
       if (kind === "final") {
         state.deliveredFinalReply = true;
+        if (isAnswerBearingFinal) {
+          state.deliveredAnswerFinalToUser = true;
+          state.deliveredFinalTtsMedia = hasFinalTtsMedia;
+        }
       }
       if (tracksVisibleText) {
         state.deliveredVisibleText = true;
@@ -540,7 +610,15 @@ export function createAcpDispatchDeliveryCoordinator(params: {
       routed: false,
     });
     const transcriptOutcome =
-      rawBlockText || rawFinalText ? captureReplyDispatchDeliveryOutcome(ttsPayload) : undefined;
+      rawBlockText || rawFinalText || hasFinalTtsMedia
+        ? captureReplyDispatchDeliveryOutcome(ttsPayload)
+        : undefined;
+    if (hasFinalTtsMedia && ttsPayload.text?.trim()) {
+      attachReplyDispatchUndeliveredFallback(
+        ttsPayload,
+        buildCaptionedFinalTextFallback(ttsPayload),
+      );
+    }
     const delivered =
       kind === "tool"
         ? params.dispatcher.sendToolResult(ttsPayload)
@@ -560,6 +638,10 @@ export function createAcpDispatchDeliveryCoordinator(params: {
     }
     if (kind === "final" && delivered) {
       state.deliveredFinalReply = true;
+      if (isAnswerBearingFinal) {
+        state.deliveredAnswerFinalToUser = true;
+        state.deliveredFinalTtsMedia = hasFinalTtsMedia;
+      }
     }
     if (delivered && tracksVisibleText) {
       state.queuedDirectVisibleTextDeliveries += 1;
@@ -588,6 +670,8 @@ export function createAcpDispatchDeliveryCoordinator(params: {
     },
     settleVisibleText: settleDirectVisibleText,
     hasDeliveredFinalReply: () => state.deliveredFinalReply,
+    hasDeliveredAnswerFinalToUser: () => state.deliveredAnswerFinalToUser,
+    hasDeliveredFinalTtsMedia: () => state.deliveredFinalTtsMedia,
     hasDeliveredVisibleText: () => state.deliveredVisibleText,
     hasFailedVisibleTextDelivery: () => state.failedVisibleTextDelivery,
     getRoutedCounts: () => ({ ...state.routedCounts }),

--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -56,6 +56,7 @@ const routeMocks = vi.hoisted(() => ({
       _params: unknown,
     ) => Promise<
       | { ok: true; delivered: boolean; messageId?: string }
+      | { ok: true; delivered: false; suppressed: true }
       | { ok: false; delivered: boolean; error: string }
     >
   >(async () => ({ ok: true, delivered: true, messageId: "mock" })),
@@ -95,6 +96,8 @@ const ttsMocks = vi.hoisted(() => ({
   }),
   resolveTtsConfig: vi.fn((_cfg: OpenClawConfig) => ({ mode: "final" })),
 }));
+
+const ttsCapabilityMocks = vi.hoisted(() => ({ captionedFinalText: false }));
 
 const mediaUnderstandingMocks = vi.hoisted(() => ({
   applyMediaUnderstanding: vi.fn<
@@ -175,6 +178,16 @@ vi.mock("../../infra/outbound/message-action-runner.js", () => ({
 vi.mock("./dispatch-acp-tts.runtime.js", () => ({
   maybeApplyTtsToPayload: (params: unknown) => ttsMocks.maybeApplyTtsToPayload(params),
 }));
+
+vi.mock("../../tts/captioned-final.js", async () => {
+  const actual = await vi.importActual<typeof import("../../tts/captioned-final.js")>(
+    "../../tts/captioned-final.js",
+  );
+  return {
+    ...actual,
+    shouldDeferFinalTtsText: () => ttsCapabilityMocks.captionedFinalText,
+  };
+});
 
 vi.mock("../../tts/status-config.js", () => ({
   resolveStatusTtsSnapshot: () => ({
@@ -517,6 +530,7 @@ describe("tryDispatchAcpReply", () => {
     });
     ttsMocks.resolveTtsConfig.mockReset();
     ttsMocks.resolveTtsConfig.mockReturnValue({ mode: "final" });
+    ttsCapabilityMocks.captionedFinalText = false;
     mediaUnderstandingMocks.applyMediaUnderstanding.mockReset();
     mediaUnderstandingMocks.applyMediaUnderstanding.mockResolvedValue(undefined);
     acpAttachmentBuffers.clear();
@@ -2890,6 +2904,150 @@ describe("tryDispatchAcpReply", () => {
     expect(finalPayload.spokenText).toBe("WebChat ACP block reply.");
     expect(finalPayload.trustedLocalMedia).toBe(true);
     expect(result?.queuedFinal).toBe(true);
+  });
+
+  it("delivers Telegram ACP final-mode TTS as one captioned voice reply", async () => {
+    setReadyAcpResolution();
+    ttsCapabilityMocks.captionedFinalText = true;
+    queueTtsReplies({
+      text: "Captioned ACP reply.",
+      mediaUrl: "/tmp/openclaw-media/acp-tts.ogg",
+      audioAsVoice: true,
+      spokenText: "Captioned ACP reply.",
+      ttsSupplement: { spokenText: "Captioned ACP reply." },
+    } as MockTtsReply);
+    mockVisibleTextTurn("Captioned ACP reply.");
+    const { dispatcher } = createDispatcher();
+
+    await runDispatch({
+      bodyForAgent: "reply",
+      dispatcher,
+      ctxOverrides: { Provider: "telegram", Surface: "telegram" },
+    });
+
+    expect(dispatcher.sendBlockReply).not.toHaveBeenCalled();
+    expect(dispatcherCall(dispatcher.sendFinalReply)).toMatchObject({
+      text: "Captioned ACP reply.",
+      mediaUrl: "/tmp/openclaw-media/acp-tts.ogg",
+      audioAsVoice: true,
+    });
+  });
+
+  it("keeps Telegram ACP TTS-only block text out of the voice caption", async () => {
+    setReadyAcpResolution();
+    ttsCapabilityMocks.captionedFinalText = true;
+    queueTtsReplies({
+      mediaUrl: "/tmp/openclaw-media/acp-tts.ogg",
+      audioAsVoice: true,
+    } as MockTtsReply);
+    mockVisibleTextTurn("[[tts:text]]Private speech.[[/tts:text]]");
+    const { dispatcher } = createDispatcher();
+
+    await runDispatch({
+      bodyForAgent: "reply",
+      cfg: createAcpTestConfig({
+        acp: { enabled: true, stream: { deliveryMode: "live" } },
+        tts: { auto: "always" },
+      }),
+      dispatcher,
+      ctxOverrides: { Provider: "telegram", Surface: "telegram" },
+    });
+
+    expect(dispatcherCall(dispatcher.sendFinalReply).text).toBeUndefined();
+  });
+
+  it("keeps cross-block ACP TTS-only text out of the Telegram caption", async () => {
+    setReadyAcpResolution();
+    ttsCapabilityMocks.captionedFinalText = true;
+    queueTtsReplies({
+      mediaUrl: "/tmp/openclaw-media/acp-tts.ogg",
+      audioAsVoice: true,
+    } as MockTtsReply);
+    managerMocks.runTurn.mockImplementationOnce(
+      async ({ onEvent }: { onEvent: (event: unknown) => Promise<void> }) => {
+        await onEvent({
+          type: "text_delta",
+          text: "Visible. [[tts:text]]Private",
+          tag: "agent_message_chunk",
+        });
+        await onEvent({
+          type: "text_delta",
+          text: " speech.[[/tts:text]] Done.",
+          tag: "agent_message_chunk",
+        });
+        await onEvent({ type: "done", status: "completed" });
+      },
+    );
+    const { dispatcher } = createDispatcher();
+
+    await runDispatch({
+      bodyForAgent: "reply",
+      cfg: createAcpTestConfig({
+        acp: { enabled: true, stream: { deliveryMode: "live" } },
+        tts: { auto: "always" },
+      }),
+      dispatcher,
+      ctxOverrides: { Provider: "telegram", Surface: "telegram" },
+    });
+
+    expect(dispatcherCall(dispatcher.sendFinalReply).text).toBe("Visible.  Done.");
+  });
+
+  it("falls back to Telegram ACP text when a routed captioned voice is suppressed", async () => {
+    setReadyAcpResolution();
+    ttsCapabilityMocks.captionedFinalText = true;
+    queueTtsReplies({
+      text: "Visible ACP fallback.",
+      mediaUrl: "/tmp/openclaw-media/acp-tts.ogg",
+      audioAsVoice: true,
+      spokenText: "Visible ACP fallback.",
+      ttsSupplement: { spokenText: "Visible ACP fallback." },
+    } as MockTtsReply);
+    mockRoutedTextTurn("Visible ACP fallback.");
+    routeMocks.routeReply
+      .mockResolvedValueOnce({ ok: true, delivered: false, suppressed: true })
+      .mockResolvedValueOnce({ ok: true, delivered: true, messageId: "fallback" });
+
+    await runDispatch({
+      bodyForAgent: "reply",
+      shouldRouteToOriginating: true,
+      originatingChannel: "telegram",
+      originatingTo: "telegram:thread-1",
+    });
+
+    expect(routeMocks.routeReply).toHaveBeenCalledTimes(2);
+    expect(routePayload(0)).toMatchObject({
+      text: "Visible ACP fallback.",
+      mediaUrl: "/tmp/openclaw-media/acp-tts.ogg",
+    });
+    expect(routePayload(1)).toEqual({ text: "Visible ACP fallback." });
+  });
+
+  it("delivers deferred Telegram ACP text when the runtime is cancelled", async () => {
+    setReadyAcpResolution();
+    ttsCapabilityMocks.captionedFinalText = true;
+    managerMocks.runTurn.mockImplementation(
+      async ({ onEvent }: { onEvent: (event: unknown) => Promise<void> }) => {
+        await onEvent({
+          type: "text_delta",
+          text: "Partial reply before cancellation.",
+          tag: "agent_message_chunk",
+        });
+        await onEvent({ type: "done", status: "cancelled" });
+      },
+    );
+    const { dispatcher } = createDispatcher();
+
+    await runDispatch({
+      bodyForAgent: "reply",
+      dispatcher,
+      ctxOverrides: { Provider: "telegram", Surface: "telegram" },
+    });
+
+    expect(dispatcher.sendBlockReply).not.toHaveBeenCalled();
+    expect(dispatcherCall(dispatcher.sendFinalReply)).toEqual({
+      text: "Partial reply before cancellation.",
+    });
   });
 
   it("falls back to final text when a later telegram ACP block delivery fails", async () => {

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -30,6 +30,7 @@ import {
 import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { classifySessionStateActor } from "../../sessions/session-state-events.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
+import { cleanDeferredFinalText, shouldDeferFinalTtsText } from "../../tts/captioned-final.js";
 import { resolveStatusTtsSnapshot } from "../../tts/status-config.js";
 import { resolveConfiguredTtsMode } from "../../tts/tts-config.js";
 import type { SourceReplyDeliveryMode } from "../get-reply-options.types.js";
@@ -286,17 +287,14 @@ async function finalizeAcpTurnOutput(params: {
   sessionTtsAuto?: TtsAutoMode;
   ttsChannel?: string;
   ttsAccountId?: string;
+  shouldDeferVisibleTextForTts: boolean;
   shouldEmitResolvedIdentityNotice: boolean;
 }): Promise<boolean> {
-  await params.delivery.settleVisibleText();
-  let queuedFinal =
-    params.delivery.hasDeliveredVisibleText() && !params.delivery.hasFailedVisibleTextDelivery();
   const ttsMode = resolveConfiguredTtsMode(params.cfg, {
     agentId: params.agentId,
     channelId: params.ttsChannel,
     accountId: params.ttsAccountId,
   });
-  const accumulatedVisibleBlockText = params.delivery.getAccumulatedVisibleBlockText();
   const accumulatedBlockTtsText = params.delivery.getAccumulatedBlockTtsText();
   const hasAccumulatedBlockText = accumulatedBlockTtsText.trim().length > 0;
   const ttsStatus = resolveStatusTtsSnapshot({
@@ -308,9 +306,27 @@ async function finalizeAcpTurnOutput(params: {
   });
   const canAttemptFinalTts =
     ttsStatus != null && !(ttsStatus.autoMode === "inbound" && !params.inboundAudio);
+  const shouldDeferVisibleTextForTts =
+    params.shouldDeferVisibleTextForTts &&
+    ttsMode === "final" &&
+    hasAccumulatedBlockText &&
+    canAttemptFinalTts;
+  const accumulatedVisibleBlockText = shouldDeferVisibleTextForTts
+    ? cleanDeferredFinalText(accumulatedBlockTtsText)
+    : params.delivery.getAccumulatedVisibleBlockText();
+  if (!shouldDeferVisibleTextForTts) {
+    await params.delivery.settleVisibleText();
+  }
+  let queuedFinal =
+    params.delivery.hasDeliveredVisibleText() && !params.delivery.hasFailedVisibleTextDelivery();
 
-  let finalMediaDelivered = false;
-  if (ttsMode === "final" && hasAccumulatedBlockText && canAttemptFinalTts) {
+  let finalMediaDelivered = params.delivery.hasDeliveredFinalTtsMedia();
+  if (
+    ttsMode === "final" &&
+    hasAccumulatedBlockText &&
+    canAttemptFinalTts &&
+    !finalMediaDelivered
+  ) {
     try {
       const { maybeApplyTtsToPayload } = await loadDispatchAcpTtsRuntime();
       const ttsSyntheticReply = await maybeApplyTtsToPayload({
@@ -324,21 +340,27 @@ async function finalizeAcpTurnOutput(params: {
         accountId: params.ttsAccountId,
       });
       if (ttsSyntheticReply.mediaUrl) {
+        const finalTtsPayload = markReplyPayloadAsTtsSupplement(
+          shouldDeferVisibleTextForTts
+            ? {
+                ...ttsSyntheticReply,
+                text: accumulatedVisibleBlockText || undefined,
+                trustedLocalMedia: true,
+              }
+            : { ...ttsSyntheticReply, text: undefined, trustedLocalMedia: true },
+          accumulatedBlockTtsText,
+          shouldDeferVisibleTextForTts ? undefined : { visibleTextAlreadyDelivered: true },
+        );
+        const delivered = await params.delivery.deliver("final", finalTtsPayload);
+        queuedFinal = queuedFinal || delivered;
+        finalMediaDelivered = params.delivery.hasDeliveredFinalTtsMedia();
+      } else if (shouldDeferVisibleTextForTts && ttsSyntheticReply.text?.trim()) {
         const delivered = await params.delivery.deliver(
           "final",
-          markReplyPayloadAsTtsSupplement(
-            {
-              mediaUrl: ttsSyntheticReply.mediaUrl,
-              audioAsVoice: ttsSyntheticReply.audioAsVoice,
-              spokenText: accumulatedBlockTtsText,
-              trustedLocalMedia: true,
-            },
-            accumulatedBlockTtsText,
-            { visibleTextAlreadyDelivered: true },
-          ),
+          { text: ttsSyntheticReply.text },
+          { skipTts: true },
         );
         queuedFinal = queuedFinal || delivered;
-        finalMediaDelivered = delivered;
       }
     } catch (err) {
       logVerbose(`dispatch-acp: accumulated ACP block TTS failed: ${formatErrorMessage(err)}`);
@@ -351,8 +373,11 @@ async function finalizeAcpTurnOutput(params: {
     ttsMode !== "all" &&
     accumulatedVisibleBlockText.trim().length > 0 &&
     !finalMediaDelivered &&
-    !params.delivery.hasDeliveredFinalReply() &&
-    (!params.delivery.hasDeliveredVisibleText() || params.delivery.hasFailedVisibleTextDelivery());
+    (shouldDeferVisibleTextForTts
+      ? !params.delivery.hasDeliveredAnswerFinalToUser()
+      : !params.delivery.hasDeliveredFinalReply() &&
+        (!params.delivery.hasDeliveredVisibleText() ||
+          params.delivery.hasFailedVisibleTextDelivery()));
   if (shouldDeliverTextFallback) {
     const delivered = await params.delivery.deliver(
       "final",
@@ -449,29 +474,6 @@ export async function tryDispatchAcpReply(params: {
         }
       : undefined;
 
-  let queuedFinal = false;
-  const delivery = createAcpDispatchDeliveryCoordinator({
-    cfg: params.cfg,
-    agentId: acpAgentId,
-    ctx: params.ctx,
-    dispatcher: params.dispatcher,
-    inboundAudio: params.inboundAudio,
-    sessionKey: canonicalSessionKey,
-    sessionTtsAuto: params.sessionTtsAuto,
-    ttsChannel: params.ttsChannel,
-    suppressUserDelivery: params.suppressUserDelivery,
-    suppressReplyLifecycle: params.suppressReplyLifecycle,
-    shouldRouteToOriginating: params.shouldRouteToOriginating,
-    originatingChannel: params.originatingChannel,
-    originatingTo: params.originatingTo,
-    originatingAccountId: params.originatingAccountId,
-    originatingThreadId: params.originatingThreadId,
-    originatingChatType: params.originatingChatType,
-    onReplyStart: params.onReplyStart,
-    abortSignal: params.abortSignal,
-    runId: params.runId,
-  });
-
   const identityPendingBeforeTurn = isSessionIdentityPending(
     resolveSessionIdentityFromMeta(acpResolution.kind === "ready" ? acpResolution.meta : undefined),
   );
@@ -508,6 +510,44 @@ export async function tryDispatchAcpReply(params: {
       : dispatchChannels?.[normalizedDispatchChannel]?.defaultAccount;
   const effectiveDispatchAccountId =
     explicitDispatchAccountId ?? normalizeOptionalString(defaultDispatchAccount);
+  const shouldDeferVisibleTextForTts = shouldDeferFinalTtsText({
+    cfg: params.cfg,
+    ttsAuto: params.sessionTtsAuto,
+    agentId: acpAgentId,
+    channelId: params.ttsChannel,
+    accountId: effectiveDispatchAccountId,
+    inboundAudio: params.inboundAudio,
+  });
+  let queuedFinal = false;
+  const delivery = createAcpDispatchDeliveryCoordinator({
+    cfg: params.cfg,
+    agentId: acpAgentId,
+    ctx: params.ctx,
+    dispatcher: params.dispatcher,
+    inboundAudio: params.inboundAudio,
+    sessionKey: canonicalSessionKey,
+    sessionTtsAuto: params.sessionTtsAuto,
+    ttsChannel: params.ttsChannel,
+    suppressUserDelivery: params.suppressUserDelivery,
+    suppressBlockUserDelivery: shouldDeferVisibleTextForTts,
+    suppressReplyLifecycle: params.suppressReplyLifecycle,
+    shouldRouteToOriginating: params.shouldRouteToOriginating,
+    originatingChannel: params.originatingChannel,
+    originatingTo: params.originatingTo,
+    originatingAccountId: params.originatingAccountId,
+    originatingThreadId: params.originatingThreadId,
+    originatingChatType: params.originatingChatType,
+    onReplyStart: params.onReplyStart,
+    abortSignal: params.abortSignal,
+    runId: params.runId,
+  });
+  const deliverDeferredTextFallback = async (): Promise<boolean> => {
+    if (!shouldDeferVisibleTextForTts || delivery.hasDeliveredAnswerFinalToUser()) {
+      return false;
+    }
+    const text = delivery.getAccumulatedVisibleBlockText();
+    return text.trim() ? await delivery.deliver("final", { text }, { skipTts: true }) : false;
+  };
   const projector = createAcpReplyProjector({
     cfg: params.cfg,
     shouldSendToolSummaries: params.shouldSendToolSummaries,
@@ -773,8 +813,7 @@ export async function tryDispatchAcpReply(params: {
 
     await projector.flush(true);
     if (runtimeTurnWasCancelled || params.abortSignal?.aborted) {
-      // A cancelled runtime can return normally after the projector has already
-      // delivered partial output. Keep the bound transcript aligned with it.
+      queuedFinal = (await deliverDeferredTextFallback()) || queuedFinal;
       await persistTranscript(await delivery.resolveAccumulatedDeliveredTranscriptText());
       queuedFinal = delivery.hasDeliveredFinalReply() || queuedFinal;
       const counts = params.dispatcher.getQueuedCounts();
@@ -794,6 +833,7 @@ export async function tryDispatchAcpReply(params: {
         sessionTtsAuto: params.sessionTtsAuto,
         ttsChannel: params.ttsChannel,
         ttsAccountId: effectiveDispatchAccountId,
+        shouldDeferVisibleTextForTts,
         shouldEmitResolvedIdentityNotice,
       })) || queuedFinal;
 
@@ -815,6 +855,7 @@ export async function tryDispatchAcpReply(params: {
     });
     emitAuditError(acpError);
     await projector.flush(true);
+    queuedFinal = (await deliverDeferredTextFallback()) || queuedFinal;
     await maybeUnbindStaleBoundConversations({
       targetSessionKey: canonicalSessionKey,
       error: acpError,

--- a/src/auto-reply/reply/dispatch-from-config.choose-route.ts
+++ b/src/auto-reply/reply/dispatch-from-config.choose-route.ts
@@ -4,7 +4,16 @@ import {
   resolveSendableOutboundReplyParts,
 } from "openclaw/plugin-sdk/reply-payload";
 import { logVerbose } from "../../globals.js";
+import { formatErrorMessage } from "../../infra/errors.js";
 import { createPluginSubagentRequesterContext } from "../../plugins/runtime/subagent-requester-context.js";
+import {
+  buildCaptionedFinalTextFallback,
+  cleanDeferredFinalText,
+  isCaptionedFinalTextPayload,
+  mergeDeferredFinalText,
+  shouldDeferFinalTtsText,
+} from "../../tts/captioned-final.js";
+import { shouldCleanTtsDirectiveText } from "../../tts/tts-config.js";
 import { registerReplyDispatcherSettledTask } from "../dispatch-dispatcher.js";
 import {
   copyReplyPayloadMetadata,
@@ -28,7 +37,10 @@ import {
   mirrorTranscriptAfterDispatcherSettled,
   transcriptMirrorForDeliveredPayload,
 } from "./dispatch-from-config.transcript.js";
-import type { ReplyDispatchDeliveryOutcome } from "./reply-dispatcher.js";
+import {
+  attachReplyDispatchUndeliveredFallback,
+  type ReplyDispatchDeliveryOutcome,
+} from "./reply-dispatcher.js";
 
 export async function chooseDispatchRoute(state: PrepareDispatchOperationReadyState) {
   const {
@@ -211,22 +223,29 @@ export async function chooseDispatchRoute(state: PrepareDispatchOperationReadySt
     const reply = resolveSendableOutboundReplyParts(payload);
     return !reply.hasMedia && !hasExecApprovalPayload(payload);
   };
+  const captionedFinalTtsContext = {
+    cfg,
+    ttsAuto: sessionTtsAuto,
+    agentId: sessionAgentId,
+    channelId: deliveryChannel,
+    accountId: replyRoute.accountId,
+    inboundAudio: state.inboundAudio,
+  };
+  const deferFinalTtsText = shouldDeferFinalTtsText(captionedFinalTtsContext);
+  const cleanDeferredFinalDirectives = shouldCleanTtsDirectiveText(captionedFinalTtsContext);
   const deliveredBlockContentKeys = new Set<string>();
-  const pendingBlockDeliveryOutcomes = new Map<
-    string,
-    Array<Promise<ReplyDispatchDeliveryOutcome>>
-  >();
+  const blockDeliveryOutcomes = new Map<string, Array<Promise<ReplyDispatchDeliveryOutcome>>>();
   const sendTrackedBlockReply = (payload: ReplyPayload): boolean => {
     const contentKey = createBlockReplyContentKey(payload);
     const delivery = turnLedger.sendQueued("block", payload);
     if (!delivery.queued || !delivery.outcome) {
       return delivery.queued;
     }
-    const outcomes = pendingBlockDeliveryOutcomes.get(contentKey);
+    const outcomes = blockDeliveryOutcomes.get(contentKey);
     if (outcomes) {
       outcomes.push(delivery.outcome);
     } else {
-      pendingBlockDeliveryOutcomes.set(contentKey, [delivery.outcome]);
+      blockDeliveryOutcomes.set(contentKey, [delivery.outcome]);
     }
     return delivery.queued;
   };
@@ -246,11 +265,11 @@ export async function chooseDispatchRoute(state: PrepareDispatchOperationReadySt
     if (deliveredBlockContentKeys.has(contentKey)) {
       return true;
     }
-    const outcomes = pendingBlockDeliveryOutcomes.get(contentKey);
+    const outcomes = blockDeliveryOutcomes.get(contentKey);
     if (!outcomes) {
       return false;
     }
-    pendingBlockDeliveryOutcomes.delete(contentKey);
+    blockDeliveryOutcomes.delete(contentKey);
     const settlement = Promise.all(outcomes).then((settledOutcomes) => ({
       kind: "settled" as const,
       outcomes: settledOutcomes,
@@ -280,14 +299,22 @@ export async function chooseDispatchRoute(state: PrepareDispatchOperationReadySt
   };
   const sendFinalPayload = async (
     payload: ReplyPayload,
-    options: { abortSignal?: AbortSignal; deliveryId?: string } = {},
+    options: {
+      abortSignal?: AbortSignal | false;
+      deliveryId?: string;
+      deferredTtsText?: string;
+      skipTts?: boolean;
+    } = {},
   ): Promise<{
     dedupedAgainstBlock?: boolean;
     queuedFinal: boolean;
     routedFinalCount: number;
     dispatcherOutcome?: Promise<ReplyDispatchDeliveryOutcome>;
   }> => {
-    const abortSignal = options.abortSignal ?? state.getDispatchAbortSignal();
+    const abortSignal =
+      options.abortSignal === false
+        ? undefined
+        : (options.abortSignal ?? state.getDispatchAbortSignal());
     const throwIfFinalDeliveryAborted = () => {
       if (abortSignal?.aborted) {
         throw new DispatchReplyOperationAbortedError();
@@ -318,20 +345,57 @@ export async function chooseDispatchRoute(state: PrepareDispatchOperationReadySt
       markInboundDedupeReplayUnsafe();
       finalReplyDeliveryStarted = true;
     }
-    const ttsPayload =
-      payload.isReasoning === true || payload.isCommentary === true
-        ? payload
-        : await state.maybeApplyTtsWithFinalizationLease({
-            payload,
-            cfg,
-            channel: deliveryChannel,
-            kind: "final",
-            ttsAuto: sessionTtsAuto,
-            agentId: sessionAgentId,
-            accountId: replyRoute.accountId,
-          });
+    const shouldAttachDeferredText = deferFinalTtsText && isCaptionedFinalTextPayload(payload);
+    const deferredRawText = shouldAttachDeferredText
+      ? mergeDeferredFinalText(options.deferredTtsText ?? "", payload.text)
+      : undefined;
+    const ttsInputPayload = shouldAttachDeferredText
+      ? copyReplyPayloadMetadata(payload, {
+          ...payload,
+          text: deferredRawText,
+        })
+      : payload;
+    const deferredVisibleText = shouldAttachDeferredText
+      ? cleanDeferredFinalDirectives
+        ? cleanDeferredFinalText(deferredRawText)
+        : deferredRawText
+      : undefined;
+    let appliedTtsPayload = payload;
+    if (!options.skipTts && payload.isReasoning !== true && payload.isCommentary !== true) {
+      try {
+        appliedTtsPayload = await state.maybeApplyTtsWithFinalizationLease({
+          payload: ttsInputPayload,
+          cfg,
+          channel: deliveryChannel,
+          kind: "final",
+          ttsAuto: sessionTtsAuto,
+          agentId: sessionAgentId,
+          accountId: replyRoute.accountId,
+        });
+      } catch (error) {
+        if (!shouldAttachDeferredText) {
+          throw error;
+        }
+        logVerbose(`dispatch-from-config: final TTS failed: ${formatErrorMessage(error)}`);
+      }
+    }
+    const ttsPayload = shouldAttachDeferredText
+      ? copyReplyPayloadMetadata(appliedTtsPayload, {
+          ...appliedTtsPayload,
+          text: deferredVisibleText || undefined,
+        })
+      : appliedTtsPayload;
     throwIfFinalDeliveryAborted();
-    let normalizedPayload = await state.normalizeReplyMediaPayload(ttsPayload);
+    let normalizedPayload: ReplyPayload;
+    try {
+      normalizedPayload = await state.normalizeReplyMediaPayload(ttsPayload);
+    } catch (error) {
+      if (!shouldAttachDeferredText || !deferredVisibleText) {
+        throw error;
+      }
+      logVerbose(`dispatch-from-config: media normalization failed: ${formatErrorMessage(error)}`);
+      normalizedPayload = buildCaptionedFinalTextFallback(ttsPayload);
+    }
     throwIfFinalDeliveryAborted();
     const deliveredAsBlock = await wasReplyDeliveredAsBlock(payload, abortSignal);
     throwIfFinalDeliveryAborted();
@@ -365,6 +429,27 @@ export async function chooseDispatchRoute(state: PrepareDispatchOperationReadySt
           metadata: sourceReplyTranscriptMirror,
           cfg,
         });
+      }
+      const fallbackText =
+        deferFinalTtsText && normalizedPayload.mediaUrl
+          ? normalizeOptionalString(normalizedPayload.text)
+          : undefined;
+      if (fallbackText && !isRoutedReplyDelivered(result)) {
+        const fallbackResult = await state.routeReplyToOriginating(
+          { text: fallbackText },
+          {
+            abortSignal,
+            kind: "final",
+            ...(hasTranscriptOwner ? { mirror: false } : {}),
+          },
+        );
+        if (fallbackResult && isRoutedReplyDelivered(fallbackResult)) {
+          await mirrorDeliveredReplyToTranscript({
+            metadata: sourceReplyTranscriptMirror,
+            cfg,
+          });
+          return { queuedFinal: true, routedFinalCount: 1 };
+        }
       }
       return {
         queuedFinal: result.ok,
@@ -421,6 +506,12 @@ export async function chooseDispatchRoute(state: PrepareDispatchOperationReadySt
       : undefined;
     if (finalDeliveryCapture) {
       setReplyPayloadMetadata(normalizedPayload, { finalDeliveryCapture });
+    }
+    if (deferFinalTtsText && normalizedPayload.mediaUrl && normalizedPayload.text?.trim()) {
+      attachReplyDispatchUndeliveredFallback(
+        normalizedPayload,
+        buildCaptionedFinalTextFallback(normalizedPayload),
+      );
     }
     const { queued: queuedFinal, outcome: dispatcherOutcome } = turnLedger.sendQueued(
       "final",
@@ -614,6 +705,7 @@ export async function chooseDispatchRoute(state: PrepareDispatchOperationReadySt
     recordRoutedBlockReplyDelivery,
     wasReplyDeliveredAsBlock,
     sendFinalPayload,
+    deferFinalTtsText,
     routeState,
   });
   return { status: "ready" as const, state: nextState };

--- a/src/auto-reply/reply/dispatch-from-config.delivery-and-tts.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.delivery-and-tts.test-utils.ts
@@ -21,6 +21,7 @@ import {
   hookMocks,
   messageAuditMocks,
   mocks,
+  replyMediaPathMocks,
   sessionBindingMocks,
   sessionStoreMocks,
   ttsMocks,
@@ -28,7 +29,9 @@ import {
 import {
   automaticGroupReplyConfig,
   dispatchReplyFromConfig,
+  installCaptionedVoiceTestPlugin,
   setNoAbort,
+  firstFinalReplyPayload,
   firstMockArg,
   dispatchTwiceWithFreshDispatchers,
   messageAuditEvents,
@@ -1773,6 +1776,303 @@ describe("dispatchReplyFromConfig", () => {
     expect(deliveredPayload ? getReplyPayloadMetadata(deliveredPayload) : undefined).toMatchObject({
       assistantMessageIndex: 7,
     });
+  });
+
+  it("delivers final-mode Telegram TTS as one captioned voice reply", async () => {
+    setNoAbort();
+    installCaptionedVoiceTestPlugin("telegram");
+    ttsMocks.state.synthesizeFinalAudio = true;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({ Provider: "telegram", Surface: "telegram" });
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+    ): Promise<ReplyPayload | undefined> => {
+      await opts?.onBlockReply?.({ text: "Hello from block streaming." });
+      return undefined;
+    };
+
+    await dispatchReplyFromConfig({ ctx, cfg: emptyConfig, dispatcher, replyResolver });
+
+    expect(dispatcher.sendBlockReply).not.toHaveBeenCalled();
+    expect(firstFinalReplyPayload(dispatcher)).toMatchObject({
+      text: "Hello from block streaming.",
+      mediaUrl: "https://example.com/tts-synth.opus",
+      audioAsVoice: true,
+    });
+  });
+
+  it("delivers deferred Telegram text when synthesis produces no audio", async () => {
+    setNoAbort();
+    installCaptionedVoiceTestPlugin("telegram");
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({ Provider: "telegram", Surface: "telegram" });
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+    ): Promise<ReplyPayload | undefined> => {
+      await opts?.onBlockReply?.({ text: "Fallback text content." });
+      return undefined;
+    };
+
+    await dispatchReplyFromConfig({ ctx, cfg: emptyConfig, dispatcher, replyResolver });
+
+    expect(dispatcher.sendBlockReply).not.toHaveBeenCalled();
+    expect(firstFinalReplyPayload(dispatcher)).toEqual({ text: "Fallback text content." });
+  });
+
+  it("delivers deferred Telegram text when final synthesis throws", async () => {
+    setNoAbort();
+    installCaptionedVoiceTestPlugin("telegram");
+    ttsMocks.maybeApplyTtsToPayload.mockRejectedValueOnce(new Error("provider unavailable"));
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({ Provider: "telegram", Surface: "telegram" });
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+    ): Promise<ReplyPayload> => {
+      await opts?.onBlockReply?.({ text: "Streamed text." });
+      return { text: "Final text." };
+    };
+
+    await dispatchReplyFromConfig({ ctx, cfg: emptyConfig, dispatcher, replyResolver });
+
+    expect(dispatcher.sendBlockReply).not.toHaveBeenCalled();
+    expect(firstFinalReplyPayload(dispatcher)).toEqual({ text: "Streamed text.\nFinal text." });
+  });
+
+  it("delivers deferred Telegram text when media normalization throws", async () => {
+    setNoAbort();
+    installCaptionedVoiceTestPlugin("telegram");
+    ttsMocks.state.synthesizeFinalAudio = true;
+    replyMediaPathMocks.createReplyMediaPathNormalizer.mockReturnValue(async () => {
+      throw new Error("normalizer unavailable");
+    });
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({ Provider: "telegram", Surface: "telegram" });
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+    ): Promise<ReplyPayload | undefined> => {
+      await opts?.onBlockReply?.({ text: "Streamed text." });
+      return undefined;
+    };
+
+    await dispatchReplyFromConfig({ ctx, cfg: emptyConfig, dispatcher, replyResolver });
+
+    expect(dispatcher.sendBlockReply).not.toHaveBeenCalled();
+    expect(firstFinalReplyPayload(dispatcher)).toEqual({ text: "Streamed text." });
+  });
+
+  it("delivers deferred Telegram text when generation fails after a block", async () => {
+    setNoAbort();
+    installCaptionedVoiceTestPlugin("telegram");
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({ Provider: "telegram", Surface: "telegram" });
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+    ): Promise<ReplyPayload | undefined> => {
+      await opts?.onBlockReply?.({ text: "Partial useful answer." });
+      throw new Error("provider unavailable");
+    };
+
+    await dispatchReplyFromConfig({ ctx, cfg: emptyConfig, dispatcher, replyResolver });
+
+    expect(dispatcher.sendBlockReply).not.toHaveBeenCalled();
+    expect(firstFinalReplyPayload(dispatcher)).toEqual({ text: "Partial useful answer." });
+    expect(
+      vi.mocked(dispatcher.sendFinalReply).mock.calls.map(([payload]) => payload.text),
+    ).toEqual(["Partial useful answer.", expect.stringContaining("Something went wrong")]);
+  });
+
+  it.each([
+    { resolverOutcome: "throws", shouldThrow: true },
+    { resolverOutcome: "returns", shouldThrow: false },
+  ])(
+    "delivers deferred Telegram text when the run aborts and the resolver $resolverOutcome",
+    async ({ shouldThrow }) => {
+      setNoAbort();
+      installCaptionedVoiceTestPlugin("telegram");
+      const abortController = new AbortController();
+      const dispatcher = createDispatcher();
+      const ctx = buildTestCtx({ Provider: "telegram", Surface: "telegram" });
+      const replyResolver = async (
+        _ctx: MsgContext,
+        opts?: GetReplyOptions,
+      ): Promise<ReplyPayload | undefined> => {
+        await opts?.onBlockReply?.({ text: "Partial answer before cancellation." });
+        abortController.abort();
+        if (shouldThrow) {
+          throw new Error("run cancelled");
+        }
+        return undefined;
+      };
+
+      await dispatchReplyFromConfig({
+        ctx,
+        cfg: emptyConfig,
+        dispatcher,
+        replyOptions: { abortSignal: abortController.signal },
+        replyResolver,
+      });
+      dispatcher.markComplete();
+      await dispatcher.waitForIdle();
+
+      expect(dispatcher.sendBlockReply).not.toHaveBeenCalled();
+      expect(firstFinalReplyPayload(dispatcher)).toEqual({
+        text: "Partial answer before cancellation.",
+      });
+    },
+  );
+
+  it("delivers deferred Telegram text after an unrelated final status notice", async () => {
+    setNoAbort();
+    installCaptionedVoiceTestPlugin("telegram");
+    ttsMocks.state.synthesizeFinalAudio = true;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({ Provider: "telegram", Surface: "telegram" });
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+    ): Promise<ReplyPayload> => {
+      await opts?.onBlockReply?.({ text: "Actual answer." });
+      return { text: "Runtime status.", isStatusNotice: true };
+    };
+
+    await dispatchReplyFromConfig({ ctx, cfg: emptyConfig, dispatcher, replyResolver });
+
+    expect(dispatcher.sendBlockReply).not.toHaveBeenCalled();
+    expect(vi.mocked(dispatcher.sendFinalReply).mock.calls).toEqual([
+      [{ text: "Runtime status.", isStatusNotice: true }],
+      [
+        expect.objectContaining({
+          text: "Actual answer.",
+          mediaUrl: "https://example.com/tts-synth.opus",
+        }),
+      ],
+    ]);
+  });
+
+  it("keeps Telegram TTS-only directive text out of the voice caption", async () => {
+    setNoAbort();
+    installCaptionedVoiceTestPlugin("telegram");
+    ttsMocks.maybeApplyTtsToPayload.mockResolvedValueOnce({
+      mediaUrl: "https://example.com/tts-synth.opus",
+      audioAsVoice: true,
+      spokenText: "Private speech text.",
+      trustedLocalMedia: true,
+    });
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({ Provider: "telegram", Surface: "telegram" });
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+    ): Promise<ReplyPayload | undefined> => {
+      await opts?.onBlockReply?.({
+        text: "[[tts:text]]Private speech text.[[/tts:text]]",
+      });
+      return undefined;
+    };
+
+    await dispatchReplyFromConfig({ ctx, cfg: emptyConfig, dispatcher, replyResolver });
+
+    expect(dispatcher.sendBlockReply).not.toHaveBeenCalled();
+    expect(firstFinalReplyPayload(dispatcher)?.text).toBeUndefined();
+  });
+
+  it("keeps streamed TTS-only text out of a later Telegram final caption", async () => {
+    setNoAbort();
+    installCaptionedVoiceTestPlugin("telegram");
+    ttsMocks.state.synthesizeFinalAudio = true;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({ Provider: "telegram", Surface: "telegram" });
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+    ): Promise<ReplyPayload> => {
+      await opts?.onBlockReply?.({
+        text: "Visible block. [[tts:text]]Private speech.[[/tts:text]]",
+      });
+      return { text: "Visible final." };
+    };
+
+    await dispatchReplyFromConfig({ ctx, cfg: emptyConfig, dispatcher, replyResolver });
+
+    expect(firstFinalReplyPayload(dispatcher)).toMatchObject({
+      text: "Visible block.\nVisible final.",
+      mediaUrl: "https://example.com/tts-synth.opus",
+    });
+  });
+
+  it("keeps a cross-boundary TTS-only region out of the Telegram caption", async () => {
+    setNoAbort();
+    installCaptionedVoiceTestPlugin("telegram");
+    ttsMocks.state.synthesizeFinalAudio = true;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({ Provider: "telegram", Surface: "telegram" });
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+    ): Promise<ReplyPayload> => {
+      await opts?.onBlockReply?.({ text: "Visible. [[tts:text]]Private" });
+      return { text: " speech.[[/tts:text]] Done." };
+    };
+
+    await dispatchReplyFromConfig({ ctx, cfg: emptyConfig, dispatcher, replyResolver });
+
+    expect(firstFinalReplyPayload(dispatcher)).toMatchObject({
+      text: "Visible.  Done.",
+      mediaUrl: "https://example.com/tts-synth.opus",
+    });
+  });
+
+  it("keeps distinct streamed and final text in the caption", async () => {
+    setNoAbort();
+    installCaptionedVoiceTestPlugin("telegram");
+    ttsMocks.state.synthesizeFinalAudio = true;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({ Provider: "telegram", Surface: "telegram" });
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+    ): Promise<ReplyPayload> => {
+      await opts?.onBlockReply?.({ text: "First paragraph." });
+      return { text: "Second paragraph." };
+    };
+
+    await dispatchReplyFromConfig({ ctx, cfg: emptyConfig, dispatcher, replyResolver });
+
+    expect(dispatcher.sendBlockReply).not.toHaveBeenCalled();
+    expect(firstFinalReplyPayload(dispatcher)).toMatchObject({
+      text: "First paragraph.\nSecond paragraph.",
+      mediaUrl: "https://example.com/tts-synth.opus",
+    });
+  });
+
+  it("keeps tagged-mode Telegram block text visible", async () => {
+    setNoAbort();
+    installCaptionedVoiceTestPlugin("telegram");
+    ttsMocks.state.statusSnapshot = {
+      autoMode: "tagged",
+      provider: "auto",
+      maxLength: 1500,
+      summarize: true,
+    };
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({ Provider: "telegram", Surface: "telegram" });
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+    ): Promise<ReplyPayload | undefined> => {
+      await opts?.onBlockReply?.({ text: "Plain tagged text." });
+      return undefined;
+    };
+
+    await dispatchReplyFromConfig({ ctx, cfg: emptyConfig, dispatcher, replyResolver });
+
+    expect(dispatcher.sendBlockReply).toHaveBeenCalledWith({ text: "Plain tagged text." });
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/auto-reply/reply/dispatch-from-config.execute.ts
+++ b/src/auto-reply/reply/dispatch-from-config.execute.ts
@@ -5,6 +5,9 @@ import {
 } from "openclaw/plugin-sdk/reply-payload";
 import { isAskUserPromptPending } from "../../agents/tools/ask-user-tool.js";
 import { normalizeAgentPlanSteps } from "../../channels/streaming.js";
+import { logVerbose } from "../../globals.js";
+import { formatErrorMessage } from "../../infra/errors.js";
+import { cleanDeferredFinalText } from "../../tts/captioned-final.js";
 import type { BlockReplyContext } from "../get-reply-options.types.js";
 import {
   copyReplyPayloadMetadata,
@@ -31,6 +34,7 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
     commentaryPayloadsEnabled,
     ctx,
     deliveryChannel,
+    deferFinalTtsText,
     dispatcher,
     failDispatchReplyOperation,
     flushPendingCommentaryProgress,
@@ -54,6 +58,7 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
     resolveToolDeliveryPayload,
     runWithDispatchLifecycleAdmission,
     sendPayloadAsync,
+    sendFinalPayload,
     sessionAgentId,
     sessionTtsAuto,
     shouldForwardProgressCallback,
@@ -68,6 +73,28 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
   let deliberateSilentTerminalReply = false;
   let pendingContinuation = false;
   let didDeliverVisiblePartialReply = false;
+  const flushDeferredFinalText = async () => {
+    if (!deferFinalTtsText || params.replyOptions?.isHeartbeat === true) {
+      return false;
+    }
+    const deferredVisibleText = cleanBlockTtsDirectiveText
+      ? cleanDeferredFinalText(state.progressState.accumulatedBlockTtsText)
+      : state.progressState.accumulatedBlockText;
+    if (!deferredVisibleText.trim()) {
+      return false;
+    }
+    const fallback = await sendFinalPayload(
+      { text: deferredVisibleText },
+      { abortSignal: isDispatchOperationAborted() ? false : undefined, skipTts: true },
+    );
+    if (!fallback.queuedFinal && fallback.routedFinalCount === 0) {
+      return false;
+    }
+    didDeliverVisiblePartialReply = true;
+    state.progressState.accumulatedBlockText = "";
+    state.progressState.accumulatedBlockTtsText = "";
+    return true;
+  };
   const replyResult = await runWithDispatchLifecycleAdmission(
     async () =>
       await runWithDispatchAbortSignal(
@@ -96,13 +123,15 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
                 shouldSuppressToolErrorWarnings: state.shouldSuppressToolErrorWarnings,
                 typingPolicy: typing.typingPolicy,
                 suppressTyping: typing.suppressTyping,
-                onPartialReply: wrapProgressCallback(params.replyOptions?.onPartialReply, {
-                  onVisible: (payload) => {
-                    if (hasOutboundReplyContent(payload, { trimText: true })) {
-                      didDeliverVisiblePartialReply = true;
-                    }
-                  },
-                }),
+                onPartialReply: deferFinalTtsText
+                  ? undefined
+                  : wrapProgressCallback(params.replyOptions?.onPartialReply, {
+                      onVisible: (payload) => {
+                        if (hasOutboundReplyContent(payload, { trimText: true })) {
+                          didDeliverVisiblePartialReply = true;
+                        }
+                      },
+                    }),
                 onReasoningStream: wrapProgressCallback(params.replyOptions?.onReasoningStream),
                 streamReasoningInNonStreamModes:
                   params.replyOptions?.streamReasoningInNonStreamModes,
@@ -427,7 +456,7 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
                       state.progressState.accumulatedBlockTtsText += payload.text;
                       state.progressState.blockCount++;
                     }
-                    const visiblePayload =
+                    let visiblePayload =
                       payload.text &&
                       cleanBlockTtsDirectiveText &&
                       !isStatusNotice &&
@@ -441,6 +470,27 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
                             });
                           })()
                         : payload;
+                    const deferThisBlock =
+                      deferFinalTtsText &&
+                      !isStatusNotice &&
+                      payload.isReasoning !== true &&
+                      payload.isCommentary !== true;
+                    if (deferThisBlock) {
+                      const hasNonTextContent = Boolean(
+                        visiblePayload.mediaUrl ||
+                        visiblePayload.mediaUrls?.length ||
+                        visiblePayload.presentation ||
+                        visiblePayload.interactive ||
+                        visiblePayload.channelData,
+                      );
+                      if (!hasNonTextContent) {
+                        return;
+                      }
+                      visiblePayload = copyReplyPayloadMetadata(visiblePayload, {
+                        ...visiblePayload,
+                        text: undefined,
+                      });
+                    }
                     if (!hasOutboundReplyContent(visiblePayload, { trimText: true })) {
                       return;
                     }
@@ -504,7 +554,14 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
           ),
         trackDispatchLifecycleWork,
       ),
-  ).catch((error: unknown) => {
+  ).catch(async (error: unknown) => {
+    try {
+      await flushDeferredFinalText();
+    } catch (fallbackError) {
+      logVerbose(
+        `dispatch-from-config: deferred final text fallback failed: ${formatErrorMessage(fallbackError)}`,
+      );
+    }
     if (
       params.replyOptions?.isHeartbeat === true ||
       !didDeliverVisiblePartialReply ||
@@ -519,6 +576,15 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
       cfg: replyConfig,
     });
   });
+  if (isDispatchOperationAborted()) {
+    try {
+      await flushDeferredFinalText();
+    } catch (fallbackError) {
+      logVerbose(
+        `dispatch-from-config: deferred final text fallback failed: ${formatErrorMessage(fallbackError)}`,
+      );
+    }
+  }
   const sessionMetadataChanges = takeCommandSessionMetadataChanges(ctx);
   notifySessionMetadataChanges(sessionMetadataChanges);
   const finalDispatchAcquisition = await state.ensureDispatchReplyOperation("dispatch");

--- a/src/auto-reply/reply/dispatch-from-config.finalize.ts
+++ b/src/auto-reply/reply/dispatch-from-config.finalize.ts
@@ -1,10 +1,12 @@
 import { hasOutboundReplyContent } from "openclaw/plugin-sdk/reply-payload";
 import { logVerbose } from "../../globals.js";
 import { formatErrorMessage } from "../../infra/errors.js";
+import { cleanDeferredFinalText } from "../../tts/captioned-final.js";
 import { resolveConfiguredTtsMode } from "../../tts/tts-config.js";
 import { registerReplyDispatcherSettledTask } from "../dispatch-dispatcher.js";
 import {
   getReplyPayloadMetadata,
+  isReplyPayloadStatusNotice,
   markReplyPayloadAsTtsSupplement,
   type ReplyPayload,
 } from "../reply-payload.js";
@@ -28,6 +30,7 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
     cfg,
     chatType,
     ctx,
+    deferFinalTtsText,
     deliveryChannel,
     deliberateSilentTerminalReply,
     dispatcher,
@@ -97,6 +100,7 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
     getReplyPayloadMetadata(reply)?.deliverDespiteSourceReplySuppression === true &&
     (ctx.InboundEventKind !== "room_event" || state.explicitCommandTurnCtx);
   const sentFinalPayloadDedupeKeys = new Set<string>();
+  let deferredTtsTextPending = state.progressState.accumulatedBlockTtsText;
   for (const [replyIndex, reply] of replies.entries()) {
     throwIfDispatchOperationAborted();
     // Durable reasoning is a channel-owned lane; generic channels keep the
@@ -129,7 +133,22 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
       continue;
     }
     sentFinalPayloadDedupeKeys.add(finalPayloadDedupeKey);
-    const finalReply = await state.sendFinalPayload(reply, { deliveryId: String(replyIndex) });
+    const shouldAttachDeferredText =
+      deferFinalTtsText &&
+      reply.isReasoning !== true &&
+      reply.isCommentary !== true &&
+      !isReplyPayloadStatusNotice(reply);
+    const finalReply = await state.sendFinalPayload(reply, {
+      deliveryId: String(replyIndex),
+      ...(shouldAttachDeferredText
+        ? {
+            deferredTtsText: deferredTtsTextPending,
+          }
+        : {}),
+    });
+    if (shouldAttachDeferredText) {
+      deferredTtsTextPending = "";
+    }
     if (finalReply.dedupedAgainstBlock) {
       // The delivering block already settled into the turn ledger.
       continue;
@@ -192,20 +211,18 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
       channelId: deliveryChannel,
       accountId: replyRoute.accountId,
     });
-    // Generate TTS-only reply after block streaming completes (when there's no final reply).
-    // This handles the case where block streaming succeeds and drops final payloads,
-    // but we still want TTS audio to be generated from the accumulated block content.
+    // Final payloads in separate lanes must not strand the deferred answer.
     if (
       ttsMode === "final" &&
-      replies.length === 0 &&
       state.progressState.blockCount > 0 &&
-      state.progressState.accumulatedBlockTtsText.trim()
+      deferredTtsTextPending.trim() &&
+      (replies.length === 0 || deferFinalTtsText)
     ) {
       try {
         await waitForPendingDirectBlockReplyDelivery(getDispatchAbortSignal());
         throwIfDispatchOperationAborted();
         const ttsSyntheticReply = await state.maybeApplyTtsWithFinalizationLease({
-          payload: { text: state.progressState.accumulatedBlockTtsText },
+          payload: { text: deferredTtsTextPending },
           cfg,
           channel: deliveryChannel,
           kind: "final",
@@ -214,42 +231,25 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
           accountId: replyRoute.accountId,
         });
         throwIfDispatchOperationAborted();
-        // Only send if TTS was actually applied (mediaUrl exists)
-        if (ttsSyntheticReply.mediaUrl) {
-          // Send TTS-only payload (no text, just audio) so it doesn't duplicate the block content.
-          // Keep the spoken text only for hooks/archive consumers.
-          const ttsOnlyPayload = markReplyPayloadAsTtsSupplement(
-            {
-              mediaUrl: ttsSyntheticReply.mediaUrl,
-              audioAsVoice: ttsSyntheticReply.audioAsVoice,
-              spokenText: state.progressState.accumulatedBlockTtsText,
-              trustedLocalMedia: true,
-            },
-            state.progressState.accumulatedBlockTtsText,
-            { visibleTextAlreadyDelivered: true },
-          );
-          const normalizedTtsOnlyPayload = await state.normalizeReplyMediaPayload(ttsOnlyPayload);
-          throwIfDispatchOperationAborted();
-          const result = await routeReplyToOriginating(normalizedTtsOnlyPayload, {
-            abortSignal: getDispatchAbortSignal(),
-            kind: "final",
-          });
-          if (result) {
-            queuedFinal = result.ok || queuedFinal;
-            if (isRoutedReplyDelivered(result)) {
-              routedFinalCount += 1;
-            }
-            if (!result.ok) {
-              logVerbose(
-                `dispatch-from-config: route-reply (tts-only) failed: ${result.error ?? "unknown error"}`,
+        if (ttsSyntheticReply.mediaUrl || (deferFinalTtsText && ttsSyntheticReply.text?.trim())) {
+          const ttsOnlyPayload = deferFinalTtsText
+            ? ttsSyntheticReply
+            : markReplyPayloadAsTtsSupplement(
+                {
+                  mediaUrl: ttsSyntheticReply.mediaUrl,
+                  audioAsVoice: ttsSyntheticReply.audioAsVoice,
+                  spokenText: deferredTtsTextPending,
+                  trustedLocalMedia: true,
+                },
+                deferredTtsTextPending,
+                { visibleTextAlreadyDelivered: true },
               );
-            }
-          } else {
-            throwIfDispatchOperationAborted();
-            markInboundDedupeReplayUnsafe();
-            queuedFinal =
-              turnLedger.sendQueued("final", normalizedTtsOnlyPayload).queued || queuedFinal;
-          }
+          const finalReply = await state.sendFinalPayload(ttsOnlyPayload, {
+            abortSignal: getDispatchAbortSignal(),
+            skipTts: true,
+          });
+          queuedFinal = finalReply.queuedFinal || queuedFinal;
+          routedFinalCount += finalReply.routedFinalCount;
         }
       } catch (err) {
         if (isDispatchReplyOperationAbortedError(err)) {
@@ -258,6 +258,15 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
         logVerbose(
           `dispatch-from-config: accumulated block TTS failed: ${formatErrorMessage(err)}`,
         );
+        const deferredVisibleText = cleanDeferredFinalText(deferredTtsTextPending);
+        if (deferFinalTtsText && deferredVisibleText.trim()) {
+          const finalReply = await state.sendFinalPayload(
+            { text: deferredVisibleText },
+            { abortSignal: getDispatchAbortSignal(), skipTts: true },
+          );
+          queuedFinal = finalReply.queuedFinal || queuedFinal;
+          routedFinalCount += finalReply.routedFinalCount;
+        }
       }
     }
   }

--- a/src/auto-reply/reply/dispatch-from-config.shared.test-harness.ts
+++ b/src/auto-reply/reply/dispatch-from-config.shared.test-harness.ts
@@ -1,6 +1,7 @@
 // Shared harness for dispatch-from-config tests and mocked runtimes.
 import { vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { TtsAutoMode } from "../../config/types.tts.js";
 import type { SessionBindingRecord } from "../../infra/outbound/session-binding-service.js";
 import type { StuckSessionRecoveryOutcome } from "../../logging/diagnostic-session-recovery.js";
 import type {
@@ -213,6 +214,17 @@ const ttsMocks = vi.hoisted(() => {
   const state = {
     synthesizeFinalAudio: false,
     synthesizeToolAudio: false,
+    statusSnapshot: {
+      autoMode: "always",
+      provider: "auto",
+      maxLength: 1500,
+      summarize: true,
+    } as {
+      autoMode: TtsAutoMode;
+      provider: string;
+      maxLength: number;
+      summarize: boolean;
+    },
   };
   return {
     state,
@@ -652,12 +664,7 @@ vi.mock("./conversation-binding-input.js", () => ({
     conversationBindingMocks.resolveConversationBindingThreadIdFromMessage,
 }));
 vi.mock("../../tts/status-config.js", () => ({
-  resolveStatusTtsSnapshot: () => ({
-    autoMode: "always",
-    provider: "auto",
-    maxLength: 1500,
-    summarize: true,
-  }),
+  resolveStatusTtsSnapshot: () => ttsMocks.state.statusSnapshot,
 }));
 vi.mock("./dispatch-acp-tts.runtime.js", () => ({
   maybeApplyTtsToPayload: (params: unknown) => ttsMocks.maybeApplyTtsToPayload(params),
@@ -731,6 +738,12 @@ export function resetPluginTtsAndThreadMocks() {
   pluginConversationBindingMocks.shownFallbackNoticeBindingIds.clear();
   ttsMocks.state.synthesizeFinalAudio = false;
   ttsMocks.state.synthesizeToolAudio = false;
+  ttsMocks.state.statusSnapshot = {
+    autoMode: "always",
+    provider: "auto",
+    maxLength: 1500,
+    summarize: true,
+  };
   ttsMocks.maybeApplyTtsToPayload.mockReset().mockImplementation(async (paramsUnknown: unknown) => {
     const params = paramsUnknown as {
       payload: ReplyPayload;

--- a/src/auto-reply/reply/dispatch-from-config.test-harness.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test-harness.ts
@@ -310,6 +310,25 @@ export function installThreadingTestPlugin(params: { defaultAccountId?: string; 
   );
 }
 
+export function installCaptionedVoiceTestPlugin(id: string) {
+  const plugin = createChannelTestPluginBase({
+    id,
+    capabilities: {
+      chatTypes: ["direct"],
+      tts: { voice: { synthesisTarget: "voice-note", captionedFinalText: true } },
+    },
+  });
+  setActivePluginRegistry(
+    createTestRegistry([
+      {
+        pluginId: id,
+        source: "test",
+        plugin,
+      },
+    ]),
+  );
+}
+
 export function requireToolResultHandler(
   handler: GetReplyOptions["onToolResult"] | undefined,
 ): NonNullable<GetReplyOptions["onToolResult"]> {

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -89,6 +89,7 @@ const DEFAULT_BEFORE_DELIVER_TIMEOUT_MS = 15_000;
 const silentReplyLogger = createSubsystemLogger("silent-reply/dispatcher");
 const beforeDeliverCancelledHooks = new WeakMap<ReplyDispatcher, ReplyDispatchCancelHandler[]>();
 const deliveryOutcomeTrackers = new WeakMap<ReplyPayload, ReplyDispatchDeliveryOutcomeTracker>();
+const undeliveredFallbacks = new WeakMap<ReplyPayload, ReplyPayload>();
 
 type ReplyDispatchBeforeDeliverStage = {
   hook: ReplyDispatchBeforeDeliver;
@@ -244,6 +245,14 @@ export function captureReplyDispatchDeliveryOutcome(payload: ReplyPayload): {
   };
   deliveryOutcomeTrackers.set(payload, tracker);
   return { promise: tracker.promise, isTracked: () => tracker.tracked };
+}
+
+/** Attach a text alternative that is delivered only when the primary payload is proven unsent. */
+export function attachReplyDispatchUndeliveredFallback(
+  payload: ReplyPayload,
+  fallback: ReplyPayload,
+): void {
+  undeliveredFallbacks.set(payload, fallback);
 }
 
 function buildReplyDispatchRuntimeInfo(
@@ -434,9 +443,44 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
     }
   };
 
+  const deliverOnce = async (
+    payload: ReplyPayload,
+    info: ReplyDispatchRuntimeInfo,
+  ): Promise<ReplyDispatchDeliveryOutcome> => {
+    let deliverPayload: ReplyPayload | null = payload;
+    let deliveryStarted = false;
+    try {
+      if (beforeDeliver) {
+        try {
+          deliverPayload = await beforeDeliver(payload, info);
+        } catch (error) {
+          await notifyBeforeDeliverCancelled(payload, info);
+          throw error;
+        }
+        if (!deliverPayload) {
+          await notifyBeforeDeliverCancelled(payload, info);
+          return "cancelled";
+        }
+        deliverPayload = copyReplyPayloadMetadata(payload, deliverPayload);
+      }
+      deliveryStarted = true;
+      await options.deliver(deliverPayload, info);
+      return "delivered";
+    } catch (error) {
+      try {
+        await options.onError?.(error, info);
+      } catch {}
+      return deliveryStarted && !isRetryableNoSendFailure(error)
+        ? "failed-deliver"
+        : "failed-before-deliver";
+    }
+  };
+
   const enqueue = (kind: ReplyDispatchKind, payload: ReplyPayload) => {
+    const fallback = undeliveredFallbacks.get(payload);
+    undeliveredFallbacks.delete(payload);
     const originalWasExactSilent = isSilentReplyText(payload.text, SILENT_REPLY_TOKEN);
-    const normalized = normalizeReplyPayloadInternal(payload, {
+    const normalizedPrimary = normalizeReplyPayloadInternal(payload, {
       responsePrefix: options.responsePrefix,
       responsePrefixContext: options.responsePrefixContext,
       responsePrefixContextProvider: options.responsePrefixContextProvider,
@@ -448,6 +492,16 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
           reason,
         }),
     });
+    const normalizedFallback = fallback
+      ? normalizeReplyPayloadInternal(fallback, {
+          responsePrefix: options.responsePrefix,
+          responsePrefixContext: options.responsePrefixContext,
+          responsePrefixContextProvider: options.responsePrefixContextProvider,
+          transformReplyPayload: options.transformReplyPayload,
+          onHeartbeatStrip: options.onHeartbeatStrip,
+        })
+      : null;
+    const normalized = normalizedPrimary ?? normalizedFallback;
     if (!normalized) {
       if (kind === "final" && originalWasExactSilent) {
         silentReplyLogger.debug("exact NO_REPLY final payload was skipped before delivery", {
@@ -458,6 +512,7 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
       }
       return false;
     }
+    const deliveryFallback = normalizedPrimary ? normalizedFallback : null;
     queuedCounts[kind] += 1;
     pending += 1;
     const deliveryOutcomeTracker = deliveryOutcomeTrackers.get(payload);
@@ -470,7 +525,6 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
     if (kind === "block") {
       sentFirstBlock = true;
     }
-    let deliveryStarted = false;
     let deliveryOutcome: ReplyDispatchDeliveryOutcome = "failed-before-deliver";
 
     sendChain = sendChain
@@ -483,38 +537,28 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
           }
         }
         const dispatchInfo = buildReplyDispatchRuntimeInfo(normalized, kind);
-        let deliverPayload: ReplyPayload | null = normalized;
-        if (beforeDeliver) {
-          try {
-            deliverPayload = await beforeDeliver(normalized, dispatchInfo);
-          } catch (err: unknown) {
-            await notifyBeforeDeliverCancelled(normalized, dispatchInfo);
-            throw err;
-          }
-          if (!deliverPayload) {
-            deliveryOutcome = "cancelled";
-            cancelledCounts[kind] += 1;
-            await notifyBeforeDeliverCancelled(normalized, dispatchInfo);
-            return;
-          }
-          deliverPayload = copyReplyPayloadMetadata(normalized, deliverPayload);
+        deliveryOutcome = await deliverOnce(normalized, dispatchInfo);
+        if (
+          deliveryFallback &&
+          (deliveryOutcome === "cancelled" || deliveryOutcome === "failed-before-deliver")
+        ) {
+          deliveryOutcome = await deliverOnce(deliveryFallback, dispatchInfo);
         }
-        deliveryStarted = true;
-        await options.deliver(deliverPayload, dispatchInfo);
-        deliveryOutcome = "delivered";
+        if (deliveryOutcome === "cancelled") {
+          cancelledCounts[kind] += 1;
+        } else if (
+          deliveryOutcome === "failed-before-deliver" ||
+          deliveryOutcome === "failed-deliver"
+        ) {
+          failedCounts[kind] += 1;
+        }
       })
       .catch(async (err: unknown) => {
         failedCounts[kind] += 1;
-        // Error cleanup belongs to this send: idle/finalization must not race it.
-        // Observer failures stay isolated from later queued deliveries.
         try {
           await options.onError?.(err, buildReplyDispatchRuntimeInfo(normalized, kind));
         } catch {}
-        // Observers can attach partial-send evidence; classify only after that proof settles.
-        deliveryOutcome =
-          deliveryStarted && !isRetryableNoSendFailure(err)
-            ? "failed-deliver"
-            : "failed-before-deliver";
+        deliveryOutcome = "failed-before-deliver";
       })
       .finally(() => {
         const dispatchInfo = buildReplyDispatchRuntimeInfo(normalized, kind);

--- a/src/channels/plugins/tts-capabilities.test.ts
+++ b/src/channels/plugins/tts-capabilities.test.ts
@@ -73,7 +73,7 @@ describe("resolveChannelTtsVoiceDelivery", () => {
           pluginId: "telegram",
           plugin: createChannelPlugin("telegram", {
             chatTypes: ["direct"],
-            tts: { voice: { synthesisTarget: "voice-note" } },
+            tts: { voice: { synthesisTarget: "voice-note", captionedFinalText: true } },
           }),
           source: "test",
         },
@@ -104,6 +104,7 @@ describe("resolveChannelTtsVoiceDelivery", () => {
     });
     expect(resolveChannelTtsVoiceDelivery("telegram")).toEqual({
       synthesisTarget: "voice-note",
+      captionedFinalText: true,
     });
     expect(resolveChannelTtsVoiceDelivery("whatsapp")).toEqual({
       synthesisTarget: "voice-note",

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -266,6 +266,8 @@ export type ChannelTtsVoiceDeliveryCapabilities = {
   synthesisTarget: "audio-file" | "voice-note";
   transcodesAudio?: boolean;
   audioFileFormats?: readonly string[];
+  /** Voice notes can carry the final reply text as a visible caption. */
+  captionedFinalText?: boolean;
   /**
    * Optional preferred audio container the channel wants for voice-memo
    * delivery. When set and the host can transcode (e.g. `afconvert` on

--- a/src/tts/captioned-final.test.ts
+++ b/src/tts/captioned-final.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { cleanDeferredFinalText, mergeDeferredFinalText } from "./captioned-final.js";
+
+describe("mergeDeferredFinalText", () => {
+  it("keeps identical and cumulative final text once", () => {
+    expect(mergeDeferredFinalText("hello", "hello")).toBe("hello");
+    expect(mergeDeferredFinalText("hello", "hello world")).toBe("hello world");
+    expect(mergeDeferredFinalText("hello world", "hello")).toBe("hello world");
+  });
+
+  it("keeps distinct streamed and final text", () => {
+    expect(mergeDeferredFinalText("first", "second")).toBe("first\nsecond");
+  });
+});
+
+describe("cleanDeferredFinalText", () => {
+  it("keeps TTS-only text out of the visible final", () => {
+    expect(cleanDeferredFinalText("Visible. [[tts:text]]Private speech.[[/tts:text]] Done.")).toBe(
+      "Visible.  Done.",
+    );
+  });
+});

--- a/src/tts/captioned-final.ts
+++ b/src/tts/captioned-final.ts
@@ -1,0 +1,87 @@
+import {
+  copyReplyPayloadMetadata,
+  isReplyPayloadStatusNotice,
+  type ReplyPayload,
+} from "../auto-reply/reply-payload.js";
+import { resolveChannelTtsVoiceDelivery } from "../channels/plugins/tts-capabilities.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { TtsAutoMode } from "../config/types.tts.js";
+import { createTtsDirectiveTextStreamCleaner } from "./directives.js";
+import { resolveStatusTtsSnapshot } from "./status-config.js";
+import { resolveConfiguredTtsMode } from "./tts-config.js";
+
+export function shouldDeferFinalTtsText(params: {
+  cfg: OpenClawConfig;
+  ttsAuto?: TtsAutoMode;
+  agentId?: string;
+  channelId?: string;
+  accountId?: string;
+  inboundAudio: boolean;
+}): boolean {
+  if (!resolveChannelTtsVoiceDelivery(params.channelId)?.captionedFinalText) {
+    return false;
+  }
+  if (
+    resolveConfiguredTtsMode(params.cfg, {
+      agentId: params.agentId,
+      channelId: params.channelId,
+      accountId: params.accountId,
+    }) !== "final"
+  ) {
+    return false;
+  }
+  const status = resolveStatusTtsSnapshot({
+    cfg: params.cfg,
+    sessionAuto: params.ttsAuto,
+    agentId: params.agentId,
+    channelId: params.channelId,
+    accountId: params.accountId,
+  });
+  return (
+    status != null &&
+    status.autoMode !== "off" &&
+    status.autoMode !== "tagged" &&
+    (status.autoMode !== "inbound" || params.inboundAudio)
+  );
+}
+
+export function mergeDeferredFinalText(streamedText: string, finalText?: string): string {
+  const streamed = streamedText.trim();
+  const final = finalText?.trim() ?? "";
+  if (!streamed) {
+    return final;
+  }
+  if (!final || streamed === final || streamed.startsWith(final)) {
+    return streamed;
+  }
+  if (final.startsWith(streamed)) {
+    return final;
+  }
+  return `${streamed}\n${final}`;
+}
+
+export function isCaptionedFinalTextPayload(payload: ReplyPayload): boolean {
+  return (
+    payload.isReasoning !== true &&
+    payload.isCommentary !== true &&
+    !isReplyPayloadStatusNotice(payload)
+  );
+}
+
+export function cleanDeferredFinalText(text: string | undefined): string {
+  if (!text) {
+    return "";
+  }
+  const cleaner = createTtsDirectiveTextStreamCleaner();
+  return `${cleaner.push(text)}${cleaner.flush()}`.replace(/[ \t]+\n/gu, "\n");
+}
+
+export function buildCaptionedFinalTextFallback(payload: ReplyPayload): ReplyPayload {
+  return copyReplyPayloadMetadata(payload, {
+    text: payload.text,
+    delivery: payload.delivery,
+    replyToId: payload.replyToId,
+    replyToTag: payload.replyToTag,
+    replyToCurrent: payload.replyToCurrent,
+  });
+}


### PR DESCRIPTION
## Summary

- Telegram final-mode TTS now sends one voice note with the answer as its caption instead of showing streamed text first.
- If synthesis or a pre-send delivery step fails, the original visible answer falls back to text. Ambiguous post-send failures do not duplicate it.
- ACP and normal reply dispatch use the same channel capability and delivery outcome rules. Other channels and tagged TTS keep their existing streaming behavior.

Closes #83511.

## What Problem This Solves

Both reply paths committed streamed text before final TTS synthesis. Telegram can carry that same text on the voice note, but core had no channel capability for that contract and no per-send fact proving whether a failed voice payload had reached the user.

This change adds an opt-in `captionedFinalText` channel capability, enabled only by Telegram. Eligible final-mode turns retain answer text until synthesis settles, clean hidden TTS directives once across the complete stream, then send one captioned voice payload. The dispatcher owns an atomic text fallback and uses it only for cancellation or failure before transport starts. Media, status, reasoning, and commentary lanes remain deliverable while answer text is deferred.

Maintainer decision: the generic opt-in capability is approved. It expresses a transport contract; it adds no config or default surface.

`NO_REPLY` remains deliberate silence: exact silent payloads are still filtered before delivery, and no caption fallback is attached when there is no visible answer text.

## Evidence

- Required CI gate: passed on the exact head.
- Focused Vitest: 707 tests passed across caption handling, normal dispatch, ACP dispatch, dispatcher outcomes, and Telegram send behavior.
- Autoreview: clean at P0/P1 after adding cancellation coverage for resolvers that throw and resolvers that return normally.
- Blacksmith Testbox (`openclaw` org): `pnpm check:changed` passed, lease `tbx_01kzajw5vbv1q7pdcg1qx1r15h`, [Actions run](https://github.com/openclaw/openclaw/actions/runs/31069370578).
- Real Telegram-user E2E on the repaired source: one `messageVoiceNote`, caption `OPENCLAW_E2E_OK`, zero preceding text messages, edits, or deletions. Microsoft TTS, final mode, block streaming, ephemeral gateway, mock model.
- Failure E2E: forced synthesis failure produced one visible text reply and no silent turn.
- Tagged-mode regression proof: ordinary tagged replies retain text streaming; audio-only `[[tts:text]]` content never enters the visible caption.

```json
{
  "verdict": "pass",
  "transport": "telegram-real-user",
  "gateway": "ephemeral-repaired-head",
  "provider": "mock-openai",
  "assertions": {
    "finalModeSingleCaptionedVoice": true,
    "precedingTextBubble": false,
    "textEditsOrDeletes": false,
    "synthesisFailureTextFallback": true,
    "noReplyRemainsSilent": true
  }
}
```

## Scope

Production: +575/-149 lines. Tests/support: +633/-8. Docs: +22/-3. The production growth establishes one public capability, one shared caption policy, and authoritative per-send recovery across both dispatch runtimes; the previous parallel post-settlement recovery paths were removed.
