### PR TITLE
fix(cron-cli): bound loadCronJobForShow pagination (#83856)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 - fix(mattermost): fail closed on missing channel type [AI]. (#84091) Thanks @pgondhi987.
 - Recheck rebuilt system.run argv [AI]. (#84090) Thanks @pgondhi987.
+- CLI/cron: bound `openclaw cron show` job lookup pagination so non-advancing or unbounded `cron.list` responses fail instead of hanging the command. Fixes #83856. (#83989)
 - Agents/messages: stop message-tool-only turns after a successful source-channel `message` send while keeping transcript mirrors under the session write lock. (#84289)
 - Agents: filter silent heartbeat response-tool transcript artifacts out of embedded context snapshots so later user turns are not polluted by heartbeat no-op messages. (#83477) Thanks @fuller-stack-dev.
 - Agents/OpenAI: log repeated strict tool-schema downgrade diagnostics once per provider/model/tool signature, reducing duplicate debug noise while preserving `strict=false` fallback behavior. Fixes #82930. (#82933) Thanks @galiniliev.

--- a/src/cli/cron-cli/register.cron-simple.test.ts
+++ b/src/cli/cron-cli/register.cron-simple.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CronJob } from "../../cron/types.js";
+import type { GatewayRpcOpts } from "../gateway-rpc.js";
+
+const callGatewayFromCli = vi.fn();
+
+vi.mock("../gateway-rpc.js", async () => {
+  const actual = await vi.importActual<typeof import("../gateway-rpc.js")>("../gateway-rpc.js");
+  return {
+    ...actual,
+    callGatewayFromCli: (...args: Parameters<typeof actual.callGatewayFromCli>) =>
+      callGatewayFromCli(...args),
+  };
+});
+
+const { loadCronJobForShow } = await import("./register.cron-simple.js");
+
+const opts: GatewayRpcOpts = {} as GatewayRpcOpts;
+
+describe("loadCronJobForShow pagination guard (regression for #83856)", () => {
+  beforeEach(() => {
+    callGatewayFromCli.mockReset();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("throws when nextOffset fails to advance", async () => {
+    callGatewayFromCli.mockResolvedValue({
+      jobs: [],
+      hasMore: true,
+      nextOffset: 0,
+    });
+    await expect(loadCronJobForShow(opts, "missing")).rejects.toThrow(/pagination did not advance/);
+    expect(callGatewayFromCli).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws when pagination exceeds the max page count", async () => {
+    let nextOffset = 0;
+    callGatewayFromCli.mockImplementation(async () => {
+      nextOffset += 1;
+      return { jobs: [], hasMore: true, nextOffset };
+    });
+    await expect(loadCronJobForShow(opts, "missing")).rejects.toThrow(
+      /pagination exceeded maximum pages/,
+    );
+    expect(callGatewayFromCli.mock.calls.length).toBeGreaterThan(1);
+    expect(callGatewayFromCli.mock.calls.length).toBeLessThanOrEqual(50);
+  });
+
+  it("returns the job when found on a later page", async () => {
+    const job: CronJob = { id: "abc", name: "wanted" } as unknown as CronJob;
+    callGatewayFromCli
+      .mockResolvedValueOnce({ jobs: [], hasMore: true, nextOffset: 200 })
+      .mockResolvedValueOnce({ jobs: [job], hasMore: false, nextOffset: null });
+    const result = await loadCronJobForShow(opts, "wanted");
+    expect(result.job?.id).toBe("abc");
+    expect(callGatewayFromCli).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns empty result when pagination terminates without a match", async () => {
+    callGatewayFromCli.mockResolvedValueOnce({
+      jobs: [],
+      hasMore: false,
+      nextOffset: null,
+    });
+    const result = await loadCronJobForShow(opts, "missing");
+    expect(result.job).toBeUndefined();
+  });
+});

--- a/src/cli/cron-cli/register.cron-simple.ts
+++ b/src/cli/cron-cli/register.cron-simple.ts
@@ -15,6 +15,7 @@ import {
 } from "./shared.js";
 
 const CRON_SHOW_PAGE_SIZE = 200;
+const CRON_SHOW_LOOKUP_MAX_PAGES = 50;
 const CRON_RUN_WAIT_TIMEOUT_DEFAULT = "10m";
 const CRON_RUN_WAIT_POLL_INTERVAL_DEFAULT = "2s";
 
@@ -87,32 +88,36 @@ function findCronJobInPage(jobs: CronJob[], idOrName: string): CronJob | undefin
   );
 }
 
-async function loadCronJobForShow(
+export async function loadCronJobForShow(
   opts: GatewayRpcOpts,
   idOrName: string,
 ): Promise<{ job?: CronJob; deliveryPreview?: CronDeliveryPreview }> {
   let offset = 0;
-  for (;;) {
+  for (let page = 0; page < CRON_SHOW_LOOKUP_MAX_PAGES; page += 1) {
     const res = await callGatewayFromCli("cron.list", opts, {
       includeDisabled: true,
       limit: CRON_SHOW_PAGE_SIZE,
       offset,
     });
-    const page = res as {
+    const listed = res as {
       jobs?: CronJob[];
       hasMore?: boolean;
       nextOffset?: number | null;
     };
-    const jobs = page.jobs ?? [];
+    const jobs = listed.jobs ?? [];
     const job = findCronJobInPage(jobs, idOrName);
     if (job) {
       return { job, deliveryPreview: coerceCronDeliveryPreviews(res).get(job.id) };
     }
-    if (!page.hasMore || typeof page.nextOffset !== "number") {
+    if (!listed.hasMore || typeof listed.nextOffset !== "number") {
       return {};
     }
-    offset = page.nextOffset;
+    if (listed.nextOffset <= offset) {
+      throw new Error("cron.list pagination did not advance while looking up cron job");
+    }
+    offset = listed.nextOffset;
   }
+  throw new Error("cron.list pagination exceeded maximum pages while looking up cron job");
 }
 
 function registerCronToggleCommand(params: {


### PR DESCRIPTION
Fixes #83856.

## Summary

`loadCronJobForShow` was paginating with `for (;;)` — no max-pages cap, no check that `nextOffset` actually advances. If the gateway ever returns `hasMore=true` with `nextOffset` stuck at the same value, `openclaw cron show <id-or-name>` would loop forever, reissuing identical `cron.list` RPCs.

The sibling `loadCronJobForEditSchedulePatch` in `register.cron-edit.ts` already has this guard; this PR mirrors that pattern in `register.cron-simple.ts`:

- cap at `CRON_SHOW_LOOKUP_MAX_PAGES = 50` iterations
- assert `nextOffset > offset` between pages, throw if not
- throw if the page cap is exceeded

Also exports `loadCronJobForShow` so the regression test can target it directly (the issue specifically calls out that this feature group has no tests).

AI-assisted (Claude Code).

## Verification

- `node scripts/run-vitest.mjs src/cli/cron-cli` — 25/25 pass, including the four new regression tests
- `node scripts/run-oxlint.mjs src/cli/cron-cli/register.cron-simple.ts src/cli/cron-cli/register.cron-simple.test.ts` — 0 warnings, 0 errors
- `oxfmt --check` on both touched files — clean
- `pnpm tsgo:core` — clean

### Real behavior proof

- **Behavior addressed:** `openclaw cron show <name>` would hang indefinitely if the gateway returned a `cron.list` page with `hasMore=true` and a non-advancing `nextOffset` (e.g. stuck at 0), reissuing the same RPC forever.
- **Real environment tested:** local macOS checkout, rebased on upstream `main` (d60ab485). The real `openclaw` cron CLI command tree (`registerCronSimpleCommands`) was driven through `commander` as a spawned `node` process against a minimal `ws` stub gateway running on `127.0.0.1`. The stub completes the real `connect` / `hello-ok` handshake and returns `{ jobs: [], hasMore: true, nextOffset: 0 }` for every `cron.list` call.
- **Exact steps or command run after this patch:**
  - Spawned the stub: `node .tmp-repro/stub-gateway.mjs` — prints `READY ws://127.0.0.1:<port>`.
  - Spawned the real CLI against it: `node node_modules/.bin/tsx .tmp-repro/cron-show-shim.ts cron show foo --url ws://127.0.0.1:<port> --token stub` (the shim does nothing but call the real `registerCronSimpleCommands`).
- **Evidence after fix:** copied live terminal output, including the full CLI stderr and the stub's per-RPC log. After this PR, the real `cron show` command exits via the new error after a single `cron.list` round-trip:

  ```
  [stub] cron.list #1 (offset=0)

  === CLI result ===
  exit code: 1
  signal: null
  timed out: false
  elapsed: 1330 ms
  --- cli stderr ---
  Error: cron.list pagination did not advance while looking up cron job
  --- stub stderr (RPC log) ---
  [stub] cron.list #1 (offset=0)
  ```

  For comparison, against an unbounded build of the same code path (loop temporarily reverted locally, then restored), the same `node`-spawned CLI hangs and gets SIGKILLed by the 6 s driver timeout after issuing over a thousand identical `cron.list` RPCs all at `offset=0`:

  ```
  [stub] cron.list #1 (offset=0)
  [stub] cron.list #150 (offset=0)
  [stub] cron.list #200 (offset=0)
  ... (continues to #1137+)
  === CLI result ===
  exit code: null
  signal: SIGKILL
  timed out: true
  elapsed: 6003 ms
  --- cli stderr ---
  (empty — process was spinning)
  ```

- **Observed result after fix:** the real `node`-spawned `openclaw cron show foo` CLI process exits with code 1 in ~1.3 s after a single `cron.list` round-trip, emitting `Error: cron.list pagination did not advance while looking up cron job` on stderr. No more hang; one RPC, one error, clean exit.
- **What was not tested:** I did not stand up the full production `openclaw gateway` and force it to actually misbehave at the `cron.listPage` source — the stub gateway above answers the same wire protocol as the real one (real `hello-ok` handshake, real `cron.list` req/res frames), which is what the issue itself recommends.
