### PR TITLE
fix: sanitize Google thinking payloads for Vertex

### DIFF
--- a/src/plugin-sdk/provider-stream-shared.ts
+++ b/src/plugin-sdk/provider-stream-shared.ts
@@ -935,7 +935,7 @@ export function createGoogleThinkingPayloadWrapper(
   thinkingLevel?: GoogleThinkingInputLevel,
 ): StreamFn {
   return createPayloadPatchStreamWrapper(baseStreamFn, ({ payload, model }) => {
-    if (model.api === "google-generative-ai") {
+    if (isGoogleThinkingPayloadApi(model.api)) {
       sanitizeGoogleThinkingPayload({
         payload,
         modelId: model.id,
@@ -950,6 +950,10 @@ export function createGoogleThinkingStreamWrapper(
   ctx: ProviderWrapStreamFnContext,
 ): NonNullable<ProviderWrapStreamFnContext["streamFn"]> {
   return createGoogleThinkingPayloadWrapper(ctx.streamFn, ctx.thinkingLevel);
+}
+
+function isGoogleThinkingPayloadApi(api: unknown): boolean {
+  return api === "google-generative-ai" || api === "google-vertex" || api === "google-gemini-cli";
 }
 
 export {

--- a/src/plugin-sdk/provider-stream.test.ts
+++ b/src/plugin-sdk/provider-stream.test.ts
@@ -5,6 +5,7 @@ import { createAssistantMessageEventStream } from "../llm/utils/event-stream.js"
 import { VERSION } from "../version.js";
 import {
   composeProviderStreamWrappers as composeProviderStreamWrappersShared,
+  createGoogleThinkingPayloadWrapper,
   createMoonshotThinkingWrapper as createMoonshotThinkingWrapperShared,
   createPlainTextToolCallCompatWrapper as createPlainTextToolCallCompatWrapperShared,
   createToolStreamWrapper as createToolStreamWrapperShared,
@@ -137,6 +138,55 @@ describe("composeProviderStreamWrappers", () => {
 });
 
 describe("buildProviderStreamFamilyHooks", () => {
+  it("sanitizes Google thinking payloads for Vertex and Gemini CLI APIs", async () => {
+    let capturedPayload: Record<string, unknown> | undefined;
+    const baseStreamFn: StreamFn = (model, _context, options) => {
+      const payload = {
+        model: model.id,
+        config: { thinkingConfig: { thinkingBudget: -1 } },
+      } as Record<string, unknown>;
+      options?.onPayload?.(payload as never, model as never);
+      capturedPayload = payload;
+      return {} as never;
+    };
+    const stream = createGoogleThinkingPayloadWrapper(baseStreamFn, "high");
+
+    for (const api of ["google-generative-ai", "google-vertex", "google-gemini-cli"]) {
+      await stream({ api, id: "gemini-3.1-pro-preview" } as never, {} as never, {});
+      const payload = requirePayload(capturedPayload);
+      const config = requireRecord(payload.config, `${api} payload config`);
+      const thinkingConfig = requireRecord(config.thinkingConfig, `${api} thinking config`);
+      expect(thinkingConfig.thinkingLevel).toBe("HIGH");
+      expect(thinkingConfig).not.toHaveProperty("thinkingBudget");
+    }
+  });
+
+  it("does not sanitize non-Google thinking payloads", async () => {
+    let capturedPayload: Record<string, unknown> | undefined;
+    const baseStreamFn: StreamFn = (model, _context, options) => {
+      const payload = {
+        model: model.id,
+        config: { thinkingConfig: { thinkingBudget: -1 } },
+      } as Record<string, unknown>;
+      options?.onPayload?.(payload as never, model as never);
+      capturedPayload = payload;
+      return {} as never;
+    };
+    const stream = createGoogleThinkingPayloadWrapper(baseStreamFn, "high");
+
+    await stream(
+      { api: "openai-completions", id: "gemini-3.1-pro-preview" } as never,
+      {} as never,
+      {},
+    );
+
+    const payload = requirePayload(capturedPayload);
+    const config = requireRecord(payload.config, "non-Google payload config");
+    const thinkingConfig = requireRecord(config.thinkingConfig, "non-Google thinking config");
+    expect(thinkingConfig.thinkingBudget).toBe(-1);
+    expect(thinkingConfig).not.toHaveProperty("thinkingLevel");
+  });
+
   it("covers the stream family matrix", async () => {
     let capturedPayload: Record<string, unknown> | undefined;
     let capturedModelId: string | undefined;


### PR DESCRIPTION
## Summary

- Extends the Google thinking payload sanitizer to `google-vertex` and `google-gemini-cli` APIs in addition to `google-generative-ai`.
- Preserves passthrough behavior for non-Google APIs through the closed Google API allowlist.
- Adds focused SDK stream-wrapper coverage for the new API identifiers.

Refs #38327. This covers the thinking-payload sanitizer path only; any remaining gaxios/native-fetch auth-stack work should stay tracked separately.

## Verification

Current signed head: `2ee3a9a3d5`.
Rebased on `main` at `0d2a9073f536d5da202f7372ed9a665e3b85d77e`.

- `node scripts/run-vitest.mjs src/plugin-sdk/provider-stream.test.ts --reporter=dot` -> 1 shard, 9 tests passed
- `node_modules/oxfmt/bin/oxfmt --check src/plugin-sdk/provider-stream-shared.ts src/plugin-sdk/provider-stream.test.ts` -> passed
- `node_modules/oxlint/bin/oxlint --tsconfig config/tsconfig/oxlint.core.json src/plugin-sdk/provider-stream-shared.ts src/plugin-sdk/provider-stream.test.ts` -> 0 warnings, 0 errors
- `git diff --check origin/main...HEAD && git diff --check` -> passed

## Real behavior proof

Behavior addressed: Google Vertex and Gemini CLI streaming payloads now receive the same thinking-config sanitization as Google Generative AI payloads.

Evidence after fix: focused SDK stream-wrapper regression tests pass for `google-generative-ai`, `google-vertex`, and `google-gemini-cli`, and preserve passthrough behavior for non-Google APIs.

Observed result after fix: invalid thinking budget payloads for all three Google API identifiers are converted to the expected thinking level; non-Google APIs keep the original payload unchanged.

Known proof gap: live Vertex/Gemini CLI provider proof was not run from this maintainer worktree because credentialed provider access is not available here. A provider-owner live run or explicit maintainer proof override is still needed before ClawSweeper can clear the proof gate.

No public config, CLI, plugin API, env var, migration, or plugin contract surface changed.