### PR TITLE
fix(webchat): preserve refresh-visible history and composer state

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -129,6 +129,7 @@ import {
 } from "../managed-image-attachments.js";
 import { ADMIN_SCOPE } from "../method-scopes.js";
 import { getMaxChatHistoryMessagesBytes, MAX_PAYLOAD_BYTES } from "../server-constants.js";
+import { resolveSessionHistoryTailReadOptions } from "../session-history-state.js";
 import { readSessionTranscriptIndex } from "../session-transcript-index.fs.js";
 import {
   capArrayByJsonBytes,
@@ -2438,16 +2439,21 @@ export const chatHandlers: GatewayRequestHandlers = {
     const defaultLimit = 200;
     const requested = typeof limit === "number" ? limit : defaultLimit;
     const max = Math.min(hardMax, requested);
-    const localReadMax = max > 0 ? max + 1 : 0;
     const maxHistoryBytes = getMaxChatHistoryMessagesBytes();
+    const rawHistoryWindow = resolveSessionHistoryTailReadOptions(max);
+    const localHistoryReadOptions = {
+      maxMessages: rawHistoryWindow.maxMessages + 1,
+      maxLines: rawHistoryWindow.maxLines + 1,
+    };
     const localMessages =
       sessionId && storePath
         ? await readRecentSessionMessagesAsync(sessionId, storePath, entry?.sessionFile, {
-            maxMessages: localReadMax,
+            ...localHistoryReadOptions,
             maxBytes: Math.max(maxHistoryBytes * 2, 1024 * 1024),
           })
         : [];
-    const overreadContextMessage = localMessages.length > max ? localMessages[0] : undefined;
+    const overreadContextMessage =
+      localMessages.length > rawHistoryWindow.maxMessages ? localMessages[0] : undefined;
     const localMessagesWithBoundaryFilter = dropLocalHistoryOverreadContextMessage(
       dropPreSessionStartAnnouncePairs(
         localMessages,

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -1614,6 +1614,43 @@ describe("gateway server chat", () => {
     });
   });
 
+  test("chat.history backfills visible messages when raw tail is mostly silent", async () => {
+    await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
+      const sessionDir = await prepareMainHistoryHarness({ ws, createSessionDir });
+      const silentTail = Array.from({ length: 24 }, (_, index) =>
+        JSON.stringify({
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "NO_REPLY" }],
+            timestamp: Date.now() + index + 2,
+          },
+        }),
+      );
+      await writeMainSessionTranscript(sessionDir, [
+        JSON.stringify({
+          message: {
+            role: "user",
+            content: [{ type: "text", text: "visible question" }],
+            timestamp: Date.now(),
+          },
+        }),
+        JSON.stringify({
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "visible answer" }],
+            timestamp: Date.now() + 1,
+          },
+        }),
+        ...silentTail,
+      ]);
+
+      const messages = await fetchHistoryMessages(ws, { limit: 2, maxChars: 100 });
+      expect(JSON.stringify(messages)).toContain("visible question");
+      expect(JSON.stringify(messages)).toContain("visible answer");
+      expect(JSON.stringify(messages)).not.toContain("NO_REPLY");
+    });
+  });
+
   test("smoke: supports abort and idempotent completion", async () => {
     await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
       const spy = getReplyFromConfig;

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -412,6 +412,60 @@ describe("refreshChat", () => {
     expect(request).toHaveBeenCalledWith("models.list", { view: "configured" });
     expect(requestUpdate).toHaveBeenCalled();
   });
+
+  it("drains a restored queue after refresh proves the selected session is idle", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "chat.history") {
+        return { messages: [] };
+      }
+      if (method === "sessions.list") {
+        return createSessionsResult([row("main", { hasActiveRun: false, status: "done" })]);
+      }
+      return {};
+    });
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      sessionKey: "main",
+      chatQueue: [{ id: "queued-1", text: "after reload", createdAt: 1 }],
+    });
+
+    await refreshChat(host, { scheduleScroll: false });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(request).toHaveBeenCalledWith(
+      "chat.send",
+      expect.objectContaining({
+        sessionKey: "main",
+        message: "after reload",
+      }),
+    );
+    expect(host.chatQueue).toEqual([]);
+  });
+
+  it("keeps a restored queue while the selected session is still active", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "chat.history") {
+        return { messages: [] };
+      }
+      if (method === "sessions.list") {
+        return createSessionsResult([row("main", { hasActiveRun: true, status: "running" })]);
+      }
+      return {};
+    });
+    const restoredQueue = [{ id: "queued-1", text: "after active run", createdAt: 1 }];
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      sessionKey: "main",
+      chatQueue: restoredQueue,
+    });
+
+    await refreshChat(host, { scheduleScroll: false });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(request).not.toHaveBeenCalledWith("chat.send", expect.anything());
+    expect(host.chatQueue).toEqual(restoredQueue);
+    expect(host.chatRunId).toBeNull();
+  });
 });
 
 describe("refreshChatAvatar", () => {

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -149,6 +149,20 @@ function makeHost(overrides?: Partial<ChatHost>): ChatHost {
     chatAvatarReason: null,
     chatSideResult: null,
     chatSideResultTerminalRuns: new Set<string>(),
+    sessionsLoading: false,
+    sessionsResult: null,
+    sessionsResultAgentId: null,
+    sessionsError: null,
+    sessionsFilterActive: "0",
+    sessionsFilterLimit: "50",
+    sessionsIncludeGlobal: true,
+    sessionsIncludeUnknown: true,
+    sessionsShowArchived: false,
+    sessionsExpandedCheckpointKey: null,
+    sessionsCheckpointItemsByKey: {},
+    sessionsCheckpointLoadingKey: null,
+    sessionsCheckpointBusyKey: null,
+    sessionsCheckpointErrorByKey: {},
     chatModelOverrides: {},
     chatModelSwitchPromises: {},
     chatModelsLoading: false,
@@ -465,6 +479,32 @@ describe("refreshChat", () => {
     expect(request).not.toHaveBeenCalledWith("chat.send", expect.anything());
     expect(host.chatQueue).toEqual(restoredQueue);
     expect(host.chatRunId).toBeNull();
+  });
+
+  it("keeps a restored queue when idle proof is stale after sessions refresh fails", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "chat.history") {
+        return { messages: [] };
+      }
+      if (method === "sessions.list") {
+        throw new Error("sessions unavailable");
+      }
+      return {};
+    });
+    const restoredQueue = [{ id: "queued-1", text: "after reload", createdAt: 1 }];
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      sessionKey: "main",
+      chatQueue: restoredQueue,
+      sessionsResult: createSessionsResult([row("main", { hasActiveRun: false, status: "done" })]),
+    });
+
+    await refreshChat(host, { scheduleScroll: false });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(request).not.toHaveBeenCalledWith("chat.send", expect.anything());
+    expect(host.chatQueue).toEqual(restoredQueue);
+    expect(host.sessionsError).toContain("sessions unavailable");
   });
 });
 

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -79,6 +79,7 @@ export type ChatHost = ChatInputHistoryState & {
   chatModelsLoading: boolean;
   chatModelCatalog: ModelCatalogEntry[];
   sessionsResult?: SessionsListResult | null;
+  sessionsError?: string | null;
   sessionsShowArchived?: boolean;
   updateComplete?: Promise<unknown>;
   requestUpdate?: () => void;
@@ -957,8 +958,11 @@ async function flushChatQueue(host: ChatHost) {
   }
 }
 
-function isSelectedSessionKnownIdle(host: ChatHost, sessionKey: string): boolean {
-  const row = host.sessionsResult?.sessions.find((session) =>
+function isSelectedSessionKnownIdle(
+  sessionsResult: SessionsListResult,
+  sessionKey: string,
+): boolean {
+  const row = sessionsResult.sessions.find((session) =>
     areUiSessionKeysEquivalent(session.key, sessionKey),
   );
   return Boolean(row && !isSessionRunActive(row));
@@ -969,15 +973,22 @@ function flushChatQueueAfterIdleSessionReconciliation(
   sessionKey: string,
   historyRefresh: Promise<unknown>,
   sessionsRefresh: Promise<unknown>,
+  previousSessionsResult: SessionsListResult | null | undefined,
 ) {
   if (host.chatQueue.length === 0) {
     return;
   }
-  void Promise.allSettled([historyRefresh, sessionsRefresh]).then(() => {
+  void Promise.allSettled([historyRefresh, sessionsRefresh]).then((results) => {
+    const sessionsRefreshSettled = results[1];
+    const freshSessionsResult = host.sessionsResult;
     if (
+      sessionsRefreshSettled.status !== "fulfilled" ||
       host.chatQueue.length === 0 ||
       !areUiSessionKeysEquivalent(host.sessionKey, sessionKey) ||
-      !isSelectedSessionKnownIdle(host, sessionKey)
+      !freshSessionsResult ||
+      freshSessionsResult === previousSessionsResult ||
+      host.sessionsError ||
+      !isSelectedSessionKnownIdle(freshSessionsResult, sessionKey)
     ) {
       return;
     }
@@ -1361,6 +1372,7 @@ export async function refreshChat(
 ) {
   const refreshedSessionKey = host.sessionKey;
   const requestUpdate = () => host.requestUpdate?.();
+  const previousSessionsResult = host.sessionsResult;
   const historyRefresh = loadChatHistory(host as unknown as ChatState).finally(() => {
     if (opts?.scheduleScroll !== false) {
       scheduleChatScroll(host as unknown as Parameters<typeof scheduleChatScroll>[0]);
@@ -1376,6 +1388,7 @@ export async function refreshChat(
     refreshedSessionKey,
     historyRefresh,
     sessionsRefresh,
+    previousSessionsResult,
   );
   const secondaryRefresh = Promise.allSettled([
     sessionsRefresh,

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -40,7 +40,12 @@ import {
 } from "./controllers/sessions.ts";
 import { GatewayRequestError, type GatewayBrowserClient, type GatewayHelloOk } from "./gateway.ts";
 import { normalizeBasePath } from "./navigation.ts";
-import { DEFAULT_AGENT_ID, normalizeAgentId, parseAgentSessionKey } from "./session-key.ts";
+import {
+  areUiSessionKeysEquivalent,
+  DEFAULT_AGENT_ID,
+  normalizeAgentId,
+  parseAgentSessionKey,
+} from "./session-key.ts";
 import { isSessionRunActive } from "./session-run-state.ts";
 import { normalizeLowercaseStringOrEmpty, normalizeOptionalString } from "./string-coerce.ts";
 import type { ChatModelOverride, ModelCatalogEntry } from "./types.ts";
@@ -952,6 +957,34 @@ async function flushChatQueue(host: ChatHost) {
   }
 }
 
+function isSelectedSessionKnownIdle(host: ChatHost, sessionKey: string): boolean {
+  const row = host.sessionsResult?.sessions.find((session) =>
+    areUiSessionKeysEquivalent(session.key, sessionKey),
+  );
+  return Boolean(row && !isSessionRunActive(row));
+}
+
+function flushChatQueueAfterIdleSessionReconciliation(
+  host: ChatHost,
+  sessionKey: string,
+  historyRefresh: Promise<unknown>,
+  sessionsRefresh: Promise<unknown>,
+) {
+  if (host.chatQueue.length === 0) {
+    return;
+  }
+  void Promise.allSettled([historyRefresh, sessionsRefresh]).then(() => {
+    if (
+      host.chatQueue.length === 0 ||
+      !areUiSessionKeysEquivalent(host.sessionKey, sessionKey) ||
+      !isSelectedSessionKnownIdle(host, sessionKey)
+    ) {
+      return;
+    }
+    void flushChatQueue(host);
+  });
+}
+
 export function removeQueuedMessage(host: ChatHost, id: string) {
   const removed = host.chatQueue.filter((item) => item.id === id);
   host.chatQueue = host.chatQueue.filter((item) => item.id !== id);
@@ -1326,6 +1359,7 @@ export async function refreshChat(
   host: ChatHost,
   opts?: { scheduleScroll?: boolean; awaitHistory?: boolean },
 ) {
+  const refreshedSessionKey = host.sessionKey;
   const requestUpdate = () => host.requestUpdate?.();
   const historyRefresh = loadChatHistory(host as unknown as ChatState).finally(() => {
     if (opts?.scheduleScroll !== false) {
@@ -1333,11 +1367,18 @@ export async function refreshChat(
     }
     requestUpdate();
   });
+  const sessionsRefresh = loadSessions(host as unknown as SessionsState, {
+    ...createChatSessionsLoadOverrides(host),
+    ...scopedAgentListParamsForSession(host, refreshedSessionKey),
+  });
+  flushChatQueueAfterIdleSessionReconciliation(
+    host,
+    refreshedSessionKey,
+    historyRefresh,
+    sessionsRefresh,
+  );
   const secondaryRefresh = Promise.allSettled([
-    loadSessions(host as unknown as SessionsState, {
-      ...createChatSessionsLoadOverrides(host),
-      ...scopedAgentListParamsForSession(host, host.sessionKey),
-    }),
+    sessionsRefresh,
     refreshChatAvatar(host),
     refreshChatModels(host),
     refreshChatCommands(host),

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -31,6 +31,7 @@ import {
   type SessionOperationEventPayload,
 } from "./app-tool-stream.ts";
 import { shouldReloadHistoryForFinalEvent } from "./chat-event-reload.ts";
+import { restoreChatComposerState } from "./chat/composer-persistence.ts";
 import { reconcileChatRunLifecycle } from "./chat/run-lifecycle.ts";
 import { parseChatSideResult, type ChatSideResult } from "./chat/side-result.ts";
 import { formatConnectError } from "./connect-error.ts";
@@ -626,6 +627,9 @@ export function connectGateway(host: GatewayHost, options?: ConnectGatewayOption
       host.lastErrorCode = null;
       host.hello = hello;
       applySnapshot(host, hello);
+      restoreChatComposerState(host as unknown as Parameters<typeof restoreChatComposerState>[0], {
+        preserveCurrent: true,
+      });
       void loadControlUiBootstrapConfig(
         host as unknown as Parameters<typeof loadControlUiBootstrapConfig>[0],
         { applyIdentity: false },

--- a/ui/src/ui/app-lifecycle.node.test.ts
+++ b/ui/src/ui/app-lifecycle.node.test.ts
@@ -1,6 +1,9 @@
 // @vitest-environment node
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { handleDisconnected } from "./app-lifecycle.ts";
+import { createStorageMock } from "../test-helpers/storage.ts";
+import { handleDisconnected, handleUpdated } from "./app-lifecycle.ts";
+import { loadChatComposerSnapshot } from "./chat/composer-persistence.ts";
+import type { ChatQueueItem } from "./ui-types.ts";
 
 function createHost() {
   return {
@@ -15,6 +18,10 @@ function createHost() {
     localMediaPreviewRoots: [],
     chatHasAutoScrolled: false,
     chatManualRefreshInFlight: false,
+    settings: { gatewayUrl: "ws://gateway.test/control" },
+    sessionKey: "main",
+    chatMessage: "",
+    chatQueue: [] as ChatQueueItem[],
     chatLoading: false,
     chatMessages: [],
     chatToolMessages: [],
@@ -70,5 +77,32 @@ describe("handleDisconnected", () => {
     vi.advanceTimersByTime(1_000);
     expect(pendingReload).not.toHaveBeenCalled();
     vi.unstubAllGlobals();
+  });
+});
+
+describe("handleUpdated", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("persists chat draft and queue changes before chat refresh short-circuits", () => {
+    vi.stubGlobal("sessionStorage", createStorageMock());
+    const host = createHost();
+    host.chatManualRefreshInFlight = true;
+    host.chatMessage = "survive refresh";
+    host.chatQueue = [{ id: "queued-1", text: "next prompt", createdAt: 1 }];
+
+    handleUpdated(
+      host as unknown as Parameters<typeof handleUpdated>[0],
+      new Map<PropertyKey, unknown>([
+        ["chatMessage", ""],
+        ["chatQueue", []],
+      ]),
+    );
+
+    expect(loadChatComposerSnapshot(host, "main")).toEqual({
+      draft: "survive refresh",
+      queue: [{ id: "queued-1", text: "next prompt", createdAt: 1 }],
+    });
   });
 });

--- a/ui/src/ui/app-lifecycle.ts
+++ b/ui/src/ui/app-lifecycle.ts
@@ -20,9 +20,11 @@ import {
   syncTabWithLocation,
   syncThemeWithSettings,
 } from "./app-settings.ts";
+import { persistChatComposerState, restoreChatComposerState } from "./chat/composer-persistence.ts";
 import { startControlUiResponsivenessObserver } from "./control-ui-performance.ts";
 import { loadControlUiBootstrapConfig } from "./controllers/control-ui-bootstrap.ts";
 import type { Tab } from "./navigation.ts";
+import type { ChatQueueItem } from "./ui-types.ts";
 
 type LifecycleHost = {
   basePath: string;
@@ -42,6 +44,11 @@ type LifecycleHost = {
   allowExternalEmbedUrls: boolean;
   chatHasAutoScrolled: boolean;
   chatManualRefreshInFlight: boolean;
+  settings?: { gatewayUrl?: string | null };
+  sessionKey: string;
+  chatMessage: string;
+  chatQueue: ChatQueueItem[];
+  pendingGatewayUrl?: string | null;
   realtimeTalkSession?: { stop: () => void } | null;
   realtimeTalkActive?: boolean;
   realtimeTalkStatus?: string;
@@ -74,7 +81,12 @@ export function handleConnected(host: LifecycleHost) {
   const connectGeneration = ++host.connectGeneration;
   host.basePath = inferBasePath();
   applySettingsFromUrl(host as unknown as Parameters<typeof applySettingsFromUrl>[0]);
-  const bootstrapReady = loadControlUiBootstrapConfig(host);
+  if (!host.pendingGatewayUrl) {
+    restoreChatComposerState(host, { preserveCurrent: true });
+  }
+  const bootstrapReady = loadControlUiBootstrapConfig(
+    host as unknown as Parameters<typeof loadControlUiBootstrapConfig>[0],
+  );
   syncTabWithLocation(host as unknown as Parameters<typeof syncTabWithLocation>[0], true);
   syncThemeWithSettings(host as unknown as Parameters<typeof syncThemeWithSettings>[0]);
   window.addEventListener("popstate", host.popStateHandler);
@@ -157,6 +169,9 @@ export function handleDisconnected(host: LifecycleHost) {
 }
 
 export function handleUpdated(host: LifecycleHost, changed: Map<PropertyKey, unknown>) {
+  if (changed.has("chatMessage") || changed.has("chatQueue")) {
+    persistChatComposerState(host);
+  }
   if (host.tab === "chat" && host.chatManualRefreshInFlight) {
     return;
   }

--- a/ui/src/ui/app-lifecycle.ts
+++ b/ui/src/ui/app-lifecycle.ts
@@ -81,9 +81,6 @@ export function handleConnected(host: LifecycleHost) {
   const connectGeneration = ++host.connectGeneration;
   host.basePath = inferBasePath();
   applySettingsFromUrl(host as unknown as Parameters<typeof applySettingsFromUrl>[0]);
-  if (!host.pendingGatewayUrl) {
-    restoreChatComposerState(host, { preserveCurrent: true });
-  }
   const bootstrapReady = loadControlUiBootstrapConfig(
     host as unknown as Parameters<typeof loadControlUiBootstrapConfig>[0],
   );
@@ -93,6 +90,9 @@ export function handleConnected(host: LifecycleHost) {
   void bootstrapReady.finally(() => {
     if (host.connectGeneration !== connectGeneration) {
       return;
+    }
+    if (!host.pendingGatewayUrl) {
+      restoreChatComposerState(host, { preserveCurrent: true });
     }
     connectGateway(host as unknown as Parameters<typeof connectGateway>[0]);
   });

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -9,6 +9,7 @@ import {
 } from "./app-chat.ts";
 import { syncUrlWithSessionKey } from "./app-settings.ts";
 import type { AppViewState } from "./app-view-state.ts";
+import { persistChatComposerState, restoreChatComposerState } from "./chat/composer-persistence.ts";
 import { reconcileChatRunLifecycle } from "./chat/run-lifecycle.ts";
 import {
   renderChatSessionSelect as renderChatSessionSelectBase,
@@ -136,6 +137,7 @@ function restoreChatQueueForSession(state: AppViewState, sessionKey: string): Ch
 function resetChatStateForSessionSwitch(state: AppViewState, sessionKey: string) {
   const host = state as unknown as SessionSwitchHost;
   const previousSessionKey = state.sessionKey;
+  persistChatComposerState(state, previousSessionKey);
   saveChatQueueForSession(state, previousSessionKey);
   state.sessionKey = sessionKey;
   if (previousSessionKey !== sessionKey) {
@@ -161,6 +163,7 @@ function resetChatStateForSessionSwitch(state: AppViewState, sessionKey: string)
   state.realtimeTalkTranscript = null;
   state.resetRealtimeTalkConversation?.();
   state.chatQueue = restoreChatQueueForSession(state, sessionKey);
+  restoreChatComposerState(state);
   host.resetChatInputHistoryNavigation();
   host.chatStreamStartedAt = null;
   reconcileChatRunLifecycle(state as unknown as Parameters<typeof reconcileChatRunLifecycle>[0], {

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -70,6 +70,7 @@ import {
 } from "./app-tool-stream.ts";
 import type { AppViewState } from "./app-view-state.ts";
 import { normalizeAssistantIdentity } from "./assistant-identity.ts";
+import { restoreChatComposerState } from "./chat/composer-persistence.ts";
 import { exportChatMarkdown } from "./chat/export.ts";
 import {
   createRealtimeTalkConversationState,
@@ -1300,12 +1301,14 @@ export class OpenClawApp extends LitElement {
       gatewayUrl: nextGatewayUrl,
       token: nextToken,
     });
+    restoreChatComposerState(this, { preserveCurrent: true });
     this.connect();
   }
 
   handleGatewayUrlCancel() {
     this.pendingGatewayUrl = null;
     this.pendingGatewayToken = null;
+    restoreChatComposerState(this, { preserveCurrent: true });
   }
 
   private async maybeUpgradeSidebarToFullMessage(content: SidebarContent) {

--- a/ui/src/ui/chat/composer-persistence.test.ts
+++ b/ui/src/ui/chat/composer-persistence.test.ts
@@ -189,4 +189,27 @@ describe("chat composer persistence", () => {
       ),
     ).toBeNull();
   });
+
+  it("does not restore steered messages tied to a previous active run", () => {
+    persistChatComposerState(
+      createState({
+        chatQueue: [
+          {
+            id: "steered-1",
+            text: "stale steer",
+            createdAt: 1,
+            kind: "steered",
+            pendingRunId: "run-before-refresh",
+          },
+        ],
+      }),
+    );
+
+    expect(
+      loadChatComposerSnapshot(
+        { settings: { gatewayUrl: "ws://gateway.test/control" } },
+        "agent:lily:main",
+      ),
+    ).toBeNull();
+  });
 });

--- a/ui/src/ui/chat/composer-persistence.test.ts
+++ b/ui/src/ui/chat/composer-persistence.test.ts
@@ -1,0 +1,162 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createStorageMock } from "../../test-helpers/storage.ts";
+import type { ChatQueueItem } from "../ui-types.ts";
+import {
+  loadChatComposerSnapshot,
+  persistChatComposerState,
+  restoreChatComposerState,
+} from "./composer-persistence.ts";
+
+function createState(overrides: Partial<Parameters<typeof persistChatComposerState>[0]> = {}) {
+  return {
+    settings: { gatewayUrl: "ws://gateway.test/control" },
+    sessionKey: "agent:lily:main",
+    chatMessage: "",
+    chatQueue: [],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.stubGlobal("sessionStorage", createStorageMock());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("chat composer persistence", () => {
+  it("restores draft text and queued messages for the same gateway session", () => {
+    const queue: ChatQueueItem[] = [
+      {
+        id: "queued-1",
+        text: "follow up after tools finish",
+        createdAt: 1,
+        attachments: [
+          {
+            id: "att-1",
+            mimeType: "image/png",
+            fileName: "screen.png",
+            dataUrl: "data:image/png;base64,AAA",
+          },
+        ],
+      },
+    ];
+    persistChatComposerState(
+      createState({
+        chatMessage: "unsent draft",
+        chatQueue: queue,
+      }),
+    );
+
+    const restored = createState();
+    expect(restoreChatComposerState(restored)).toBe(true);
+
+    expect(restored.chatMessage).toBe("unsent draft");
+    expect(restored.chatQueue).toEqual(queue);
+  });
+
+  it("scopes persisted composers by gateway and session key", () => {
+    persistChatComposerState(createState({ chatMessage: "main draft" }));
+
+    expect(
+      loadChatComposerSnapshot(
+        { settings: { gatewayUrl: "ws://gateway.test/control" } },
+        "agent:lily:other",
+      ),
+    ).toBeNull();
+    expect(
+      loadChatComposerSnapshot(
+        { settings: { gatewayUrl: "ws://other-gateway.test/control" } },
+        "agent:lily:main",
+      ),
+    ).toBeNull();
+  });
+
+  it("clears the stored session when both draft and queue are empty", () => {
+    persistChatComposerState(createState({ chatMessage: "clear me" }));
+    persistChatComposerState(createState());
+
+    expect(
+      loadChatComposerSnapshot(
+        { settings: { gatewayUrl: "ws://gateway.test/control" } },
+        "agent:lily:main",
+      ),
+    ).toBeNull();
+  });
+
+  it("does not restore queued attachments without payload data", () => {
+    persistChatComposerState(
+      createState({
+        chatQueue: [
+          {
+            id: "queued-1",
+            text: "needs attachment",
+            createdAt: 1,
+            attachments: [{ id: "att-1", mimeType: "image/png", fileName: "screen.png" }],
+          },
+        ],
+      }),
+    );
+
+    expect(
+      loadChatComposerSnapshot(
+        { settings: { gatewayUrl: "ws://gateway.test/control" } },
+        "agent:lily:main",
+      ),
+    ).toBeNull();
+  });
+
+  it("keeps in-memory queue items when the stored snapshot only has a draft", () => {
+    persistChatComposerState(createState({ chatMessage: "stored draft" }));
+    const restored = createState({
+      chatQueue: [{ id: "queued-1", text: "memory queue", createdAt: 1 }],
+    });
+
+    expect(restoreChatComposerState(restored)).toBe(true);
+
+    expect(restored.chatMessage).toBe("stored draft");
+    expect(restored.chatQueue).toEqual([{ id: "queued-1", text: "memory queue", createdAt: 1 }]);
+  });
+
+  it("keeps failed queued messages failed after restore", () => {
+    const failed: ChatQueueItem = {
+      id: "failed-1",
+      text: "manual retry only",
+      createdAt: 1,
+      sendError: "send blocked",
+      sendRunId: "run-failed",
+      sendState: "failed",
+    };
+    persistChatComposerState(createState({ chatQueue: [failed] }));
+
+    const restored = createState();
+    expect(restoreChatComposerState(restored)).toBe(true);
+
+    expect(restored.chatQueue).toEqual([failed]);
+  });
+
+  it("does not restore in-flight sends that may already have reached the gateway", () => {
+    persistChatComposerState(
+      createState({
+        chatQueue: [
+          {
+            id: "sending-1",
+            text: "possibly already sent",
+            createdAt: 1,
+            sendRunId: "run-sending",
+            sendState: "sending",
+          },
+        ],
+      }),
+    );
+
+    expect(
+      loadChatComposerSnapshot(
+        { settings: { gatewayUrl: "ws://gateway.test/control" } },
+        "agent:lily:main",
+      ),
+    ).toBeNull();
+  });
+});

--- a/ui/src/ui/chat/composer-persistence.test.ts
+++ b/ui/src/ui/chat/composer-persistence.test.ts
@@ -74,6 +74,36 @@ describe("chat composer persistence", () => {
     ).toBeNull();
   });
 
+  it("scopes global-session composers by selected agent", () => {
+    const queued: ChatQueueItem = {
+      id: "queued-global",
+      text: "agent-specific prompt",
+      createdAt: 1,
+      sessionKey: "global",
+      agentId: "agent-a",
+    };
+    persistChatComposerState(
+      createState({
+        assistantAgentId: "agent-a",
+        sessionKey: "global",
+        chatMessage: "agent A draft",
+        chatQueue: [queued],
+      }),
+    );
+
+    expect(
+      loadChatComposerSnapshot(
+        { settings: { gatewayUrl: "ws://gateway.test/control" }, assistantAgentId: "agent-b" },
+        "global",
+      ),
+    ).toBeNull();
+
+    const restored = createState({ assistantAgentId: "agent-a", sessionKey: "global" });
+    expect(restoreChatComposerState(restored)).toBe(true);
+    expect(restored.chatMessage).toBe("agent A draft");
+    expect(restored.chatQueue).toEqual([queued]);
+  });
+
   it("clears the stored session when both draft and queue are empty", () => {
     persistChatComposerState(createState({ chatMessage: "clear me" }));
     persistChatComposerState(createState());

--- a/ui/src/ui/chat/composer-persistence.ts
+++ b/ui/src/ui/chat/composer-persistence.ts
@@ -12,12 +12,7 @@ type ChatComposerPersistenceState = {
   assistantAgentId?: string | null;
   agentsList?: { defaultId?: string | null; mainKey?: string | null } | null;
   hello?: {
-    snapshot?: {
-      sessionDefaults?: {
-        defaultAgentId?: string | null;
-        mainKey?: string | null;
-      } | null;
-    } | null;
+    snapshot?: unknown;
   } | null;
   sessionKey: string;
   chatMessage: string;
@@ -46,7 +41,18 @@ function storageKeyForGateway(gatewayUrl: string | null | undefined): string {
 }
 
 function readHelloDefaultAgentId(state: Pick<ChatComposerPersistenceState, "hello">) {
-  return state.hello?.snapshot?.sessionDefaults?.defaultAgentId?.trim() || undefined;
+  const snapshot = state.hello?.snapshot;
+  if (!snapshot || typeof snapshot !== "object") {
+    return undefined;
+  }
+  const defaults = (snapshot as { sessionDefaults?: unknown }).sessionDefaults;
+  if (!defaults || typeof defaults !== "object") {
+    return undefined;
+  }
+  const defaultAgentId = (defaults as { defaultAgentId?: unknown }).defaultAgentId;
+  return typeof defaultAgentId === "string" && defaultAgentId.trim()
+    ? defaultAgentId.trim()
+    : undefined;
 }
 
 function resolveComposerAgentScope(

--- a/ui/src/ui/chat/composer-persistence.ts
+++ b/ui/src/ui/chat/composer-persistence.ts
@@ -1,4 +1,5 @@
 import { getSafeSessionStorage } from "../../local-storage.ts";
+import { DEFAULT_AGENT_ID, normalizeAgentId, parseAgentSessionKey } from "../session-key.ts";
 import type { ChatAttachment, ChatQueueItem } from "../ui-types.ts";
 import { getChatAttachmentDataUrl } from "./attachment-payload-store.ts";
 
@@ -8,6 +9,16 @@ const MAX_STORED_QUEUE_ITEMS = 50;
 
 type ChatComposerPersistenceState = {
   settings?: { gatewayUrl?: string | null };
+  assistantAgentId?: string | null;
+  agentsList?: { defaultId?: string | null; mainKey?: string | null } | null;
+  hello?: {
+    snapshot?: {
+      sessionDefaults?: {
+        defaultAgentId?: string | null;
+        mainKey?: string | null;
+      } | null;
+    } | null;
+  } | null;
   sessionKey: string;
   chatMessage: string;
   chatQueue: ChatQueueItem[];
@@ -32,6 +43,34 @@ type RestoreOptions = {
 function storageKeyForGateway(gatewayUrl: string | null | undefined): string {
   const scope = gatewayUrl?.trim() || "default";
   return `${STORAGE_KEY_PREFIX}${encodeURIComponent(scope).slice(0, 240)}`;
+}
+
+function readHelloDefaultAgentId(state: Pick<ChatComposerPersistenceState, "hello">) {
+  return state.hello?.snapshot?.sessionDefaults?.defaultAgentId?.trim() || undefined;
+}
+
+function resolveComposerAgentScope(
+  state: Pick<ChatComposerPersistenceState, "assistantAgentId" | "agentsList" | "hello">,
+  sessionKey: string,
+): string {
+  const parsed = parseAgentSessionKey(sessionKey);
+  if (parsed) {
+    return normalizeAgentId(parsed.agentId);
+  }
+  const defaultAgentId =
+    state.assistantAgentId?.trim() ||
+    state.agentsList?.defaultId?.trim() ||
+    readHelloDefaultAgentId(state) ||
+    DEFAULT_AGENT_ID;
+  return normalizeAgentId(defaultAgentId);
+}
+
+function storageSessionKeyForState(
+  state: Pick<ChatComposerPersistenceState, "assistantAgentId" | "agentsList" | "hello">,
+  sessionKey: string,
+): string {
+  const agentId = resolveComposerAgentScope(state, sessionKey);
+  return `${sessionKey}\u0000agent:${agentId}`;
 }
 
 function readStore(storage: Storage, key: string): StoredComposerState {
@@ -150,6 +189,8 @@ function serializeQueueItem(item: ChatQueueItem): ChatQueueItem | null {
     ...(item.localCommandArgs ? { localCommandArgs: item.localCommandArgs } : {}),
     ...(item.localCommandName ? { localCommandName: item.localCommandName } : {}),
     ...(item.pendingRunId ? { pendingRunId: item.pendingRunId } : {}),
+    ...(item.sessionKey ? { sessionKey: item.sessionKey } : {}),
+    ...(item.agentId ? { agentId: item.agentId } : {}),
     ...(sendState ? { sendState } : {}),
     ...(item.sendError ? { sendError: item.sendError } : {}),
     ...(item.sendRunId ? { sendRunId: item.sendRunId } : {}),
@@ -215,6 +256,14 @@ function normalizeQueueItem(value: unknown): ChatQueueItem | null {
   if (pendingRunId) {
     item.pendingRunId = pendingRunId;
   }
+  const sessionKey = normalizeOptionalString(entry.sessionKey);
+  if (sessionKey) {
+    item.sessionKey = sessionKey;
+  }
+  const agentId = normalizeOptionalString(entry.agentId);
+  if (agentId) {
+    item.agentId = normalizeAgentId(agentId);
+  }
   return item;
 }
 
@@ -244,7 +293,10 @@ function normalizeStoredSession(value: unknown): StoredComposerSession | null {
 }
 
 export function loadChatComposerSnapshot(
-  state: Pick<ChatComposerPersistenceState, "settings">,
+  state: Pick<
+    ChatComposerPersistenceState,
+    "settings" | "assistantAgentId" | "agentsList" | "hello"
+  >,
   sessionKey: string,
 ): { draft: string; queue: ChatQueueItem[] } | null {
   const storage = getSafeSessionStorage();
@@ -253,7 +305,8 @@ export function loadChatComposerSnapshot(
   }
   try {
     const key = storageKeyForGateway(state.settings?.gatewayUrl);
-    const session = normalizeStoredSession(readStore(storage, key).sessions[sessionKey]);
+    const storeSessionKey = storageSessionKeyForState(state, sessionKey);
+    const session = normalizeStoredSession(readStore(storage, key).sessions[storeSessionKey]);
     if (!session) {
       return null;
     }
@@ -277,15 +330,16 @@ export function persistChatComposerState(
   try {
     const key = storageKeyForGateway(state.settings?.gatewayUrl);
     const store = readStore(storage, key);
+    const storeSessionKey = storageSessionKeyForState(state, sessionKey);
     const draft = state.chatMessage;
     const queue = state.chatQueue
       .slice(0, MAX_STORED_QUEUE_ITEMS)
       .map(serializeQueueItem)
       .filter((item): item is ChatQueueItem => item !== null);
     if (!draft && queue.length === 0) {
-      delete store.sessions[sessionKey];
+      delete store.sessions[storeSessionKey];
     } else {
-      store.sessions[sessionKey] = {
+      store.sessions[storeSessionKey] = {
         ...(draft ? { draft } : {}),
         ...(queue.length > 0 ? { queue } : {}),
         updatedAt: Date.now(),

--- a/ui/src/ui/chat/composer-persistence.ts
+++ b/ui/src/ui/chat/composer-persistence.ts
@@ -165,6 +165,9 @@ function serializeQueueItem(item: ChatQueueItem): ChatQueueItem | null {
   if (!id || (!text.trim() && !item.attachments?.length)) {
     return null;
   }
+  if (item.pendingRunId) {
+    return null;
+  }
   if (item.sendState === "sending") {
     return null;
   }
@@ -188,7 +191,6 @@ function serializeQueueItem(item: ChatQueueItem): ChatQueueItem | null {
     ...(typeof item.refreshSessions === "boolean" ? { refreshSessions: item.refreshSessions } : {}),
     ...(item.localCommandArgs ? { localCommandArgs: item.localCommandArgs } : {}),
     ...(item.localCommandName ? { localCommandName: item.localCommandName } : {}),
-    ...(item.pendingRunId ? { pendingRunId: item.pendingRunId } : {}),
     ...(item.sessionKey ? { sessionKey: item.sessionKey } : {}),
     ...(item.agentId ? { agentId: item.agentId } : {}),
     ...(sendState ? { sendState } : {}),
@@ -251,10 +253,6 @@ function normalizeQueueItem(value: unknown): ChatQueueItem | null {
   const localCommandName = normalizeOptionalString(entry.localCommandName);
   if (localCommandName) {
     item.localCommandName = localCommandName;
-  }
-  const pendingRunId = normalizeOptionalString(entry.pendingRunId);
-  if (pendingRunId) {
-    item.pendingRunId = pendingRunId;
   }
   const sessionKey = normalizeOptionalString(entry.sessionKey);
   if (sessionKey) {

--- a/ui/src/ui/chat/composer-persistence.ts
+++ b/ui/src/ui/chat/composer-persistence.ts
@@ -1,0 +1,316 @@
+import { getSafeSessionStorage } from "../../local-storage.ts";
+import type { ChatAttachment, ChatQueueItem } from "../ui-types.ts";
+import { getChatAttachmentDataUrl } from "./attachment-payload-store.ts";
+
+const STORAGE_KEY_PREFIX = "openclaw.control.chatComposer.v1:";
+const MAX_STORED_SESSIONS = 20;
+const MAX_STORED_QUEUE_ITEMS = 50;
+
+type ChatComposerPersistenceState = {
+  settings?: { gatewayUrl?: string | null };
+  sessionKey: string;
+  chatMessage: string;
+  chatQueue: ChatQueueItem[];
+};
+
+type StoredComposerSession = {
+  draft?: string;
+  queue?: ChatQueueItem[];
+  updatedAt: number;
+};
+
+type StoredComposerState = {
+  version: 1;
+  sessions: Record<string, StoredComposerSession>;
+};
+
+type RestoreOptions = {
+  preserveCurrent?: boolean;
+  sessionKey?: string;
+};
+
+function storageKeyForGateway(gatewayUrl: string | null | undefined): string {
+  const scope = gatewayUrl?.trim() || "default";
+  return `${STORAGE_KEY_PREFIX}${encodeURIComponent(scope).slice(0, 240)}`;
+}
+
+function readStore(storage: Storage, key: string): StoredComposerState {
+  const raw = storage.getItem(key);
+  if (!raw) {
+    return { version: 1, sessions: {} };
+  }
+  try {
+    const parsed = JSON.parse(raw) as Partial<StoredComposerState>;
+    if (
+      !parsed ||
+      parsed.version !== 1 ||
+      !parsed.sessions ||
+      typeof parsed.sessions !== "object"
+    ) {
+      return { version: 1, sessions: {} };
+    }
+    const sessions: Record<string, StoredComposerSession> = {};
+    for (const [sessionKey, value] of Object.entries(parsed.sessions)) {
+      const session = normalizeStoredSession(value);
+      if (session) {
+        sessions[sessionKey] = session;
+      }
+    }
+    return { version: 1, sessions };
+  } catch {
+    return { version: 1, sessions: {} };
+  }
+}
+
+function writeStore(storage: Storage, key: string, store: StoredComposerState): void {
+  const entries = Object.entries(store.sessions)
+    .toSorted((a, b) => b[1].updatedAt - a[1].updatedAt)
+    .slice(0, MAX_STORED_SESSIONS);
+  if (entries.length === 0) {
+    storage.removeItem(key);
+    return;
+  }
+  storage.setItem(key, JSON.stringify({ version: 1, sessions: Object.fromEntries(entries) }));
+}
+
+function normalizeOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function normalizeOptionalBoolean(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function normalizeChatAttachment(value: unknown): ChatAttachment | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  const entry = value as Record<string, unknown>;
+  const id = normalizeOptionalString(entry.id);
+  const mimeType = normalizeOptionalString(entry.mimeType);
+  if (!id || !mimeType) {
+    return null;
+  }
+  const restored: ChatAttachment = { id, mimeType };
+  const fileName = normalizeOptionalString(entry.fileName);
+  if (fileName) {
+    restored.fileName = fileName;
+  }
+  if (typeof entry.sizeBytes === "number" && Number.isFinite(entry.sizeBytes)) {
+    restored.sizeBytes = entry.sizeBytes;
+  }
+  const dataUrl = normalizeOptionalString(entry.dataUrl);
+  if (dataUrl) {
+    restored.dataUrl = dataUrl;
+  }
+  return restored;
+}
+
+function serializeChatAttachment(attachment: ChatAttachment): ChatAttachment | null {
+  const dataUrl = getChatAttachmentDataUrl(attachment);
+  if (!dataUrl) {
+    return null;
+  }
+  return {
+    id: attachment.id,
+    mimeType: attachment.mimeType,
+    ...(attachment.fileName ? { fileName: attachment.fileName } : {}),
+    ...(typeof attachment.sizeBytes === "number" ? { sizeBytes: attachment.sizeBytes } : {}),
+    dataUrl,
+  };
+}
+
+function serializeQueueItem(item: ChatQueueItem): ChatQueueItem | null {
+  const id = normalizeOptionalString(item.id);
+  const text = typeof item.text === "string" ? item.text : "";
+  if (!id || (!text.trim() && !item.attachments?.length)) {
+    return null;
+  }
+  if (item.sendState === "sending") {
+    return null;
+  }
+  const attachments = item.attachments?.map(serializeChatAttachment) ?? [];
+  if (item.attachments?.length && attachments.some((attachment) => attachment === null)) {
+    return null;
+  }
+  const sendState =
+    item.sendState === "failed" || item.sendState === "waiting-reconnect"
+      ? item.sendState
+      : undefined;
+  return {
+    id,
+    text,
+    createdAt:
+      typeof item.createdAt === "number" && Number.isFinite(item.createdAt)
+        ? item.createdAt
+        : Date.now(),
+    ...(item.kind === "queued" || item.kind === "steered" ? { kind: item.kind } : {}),
+    ...(attachments.length ? { attachments: attachments as ChatAttachment[] } : {}),
+    ...(typeof item.refreshSessions === "boolean" ? { refreshSessions: item.refreshSessions } : {}),
+    ...(item.localCommandArgs ? { localCommandArgs: item.localCommandArgs } : {}),
+    ...(item.localCommandName ? { localCommandName: item.localCommandName } : {}),
+    ...(item.pendingRunId ? { pendingRunId: item.pendingRunId } : {}),
+    ...(sendState ? { sendState } : {}),
+    ...(item.sendError ? { sendError: item.sendError } : {}),
+    ...(item.sendRunId ? { sendRunId: item.sendRunId } : {}),
+    ...(typeof item.sendAttempts === "number" && Number.isFinite(item.sendAttempts)
+      ? { sendAttempts: item.sendAttempts }
+      : {}),
+  };
+}
+
+function normalizeQueueItem(value: unknown): ChatQueueItem | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  const entry = value as Record<string, unknown>;
+  const id = normalizeOptionalString(entry.id);
+  const text = typeof entry.text === "string" ? entry.text : "";
+  const createdAt =
+    typeof entry.createdAt === "number" && Number.isFinite(entry.createdAt)
+      ? entry.createdAt
+      : Date.now();
+  if (!id || (!text.trim() && !Array.isArray(entry.attachments))) {
+    return null;
+  }
+  const attachments = Array.isArray(entry.attachments)
+    ? entry.attachments
+        .map(normalizeChatAttachment)
+        .filter((item): item is ChatAttachment => item !== null)
+    : [];
+  const item: ChatQueueItem = { id, text, createdAt };
+  if (entry.kind === "queued" || entry.kind === "steered") {
+    item.kind = entry.kind;
+  }
+  if (attachments.length) {
+    item.attachments = attachments;
+  }
+  const refreshSessions = normalizeOptionalBoolean(entry.refreshSessions);
+  if (refreshSessions !== undefined) {
+    item.refreshSessions = refreshSessions;
+  }
+  if (entry.sendState === "failed" || entry.sendState === "waiting-reconnect") {
+    item.sendState = entry.sendState;
+  }
+  const sendError = normalizeOptionalString(entry.sendError);
+  if (sendError) {
+    item.sendError = sendError;
+  }
+  const sendRunId = normalizeOptionalString(entry.sendRunId);
+  if (sendRunId) {
+    item.sendRunId = sendRunId;
+  }
+  if (typeof entry.sendAttempts === "number" && Number.isFinite(entry.sendAttempts)) {
+    item.sendAttempts = entry.sendAttempts;
+  }
+  const localCommandArgs = normalizeOptionalString(entry.localCommandArgs);
+  if (localCommandArgs) {
+    item.localCommandArgs = localCommandArgs;
+  }
+  const localCommandName = normalizeOptionalString(entry.localCommandName);
+  if (localCommandName) {
+    item.localCommandName = localCommandName;
+  }
+  const pendingRunId = normalizeOptionalString(entry.pendingRunId);
+  if (pendingRunId) {
+    item.pendingRunId = pendingRunId;
+  }
+  return item;
+}
+
+function normalizeStoredSession(value: unknown): StoredComposerSession | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  const entry = value as Record<string, unknown>;
+  const draft = typeof entry.draft === "string" ? entry.draft : undefined;
+  const queue = Array.isArray(entry.queue)
+    ? entry.queue
+        .slice(0, MAX_STORED_QUEUE_ITEMS)
+        .map(normalizeQueueItem)
+        .filter((item): item is ChatQueueItem => item !== null)
+    : undefined;
+  if (!draft && (!queue || queue.length === 0)) {
+    return null;
+  }
+  return {
+    ...(draft ? { draft } : {}),
+    ...(queue && queue.length > 0 ? { queue } : {}),
+    updatedAt:
+      typeof entry.updatedAt === "number" && Number.isFinite(entry.updatedAt)
+        ? entry.updatedAt
+        : Date.now(),
+  };
+}
+
+export function loadChatComposerSnapshot(
+  state: Pick<ChatComposerPersistenceState, "settings">,
+  sessionKey: string,
+): { draft: string; queue: ChatQueueItem[] } | null {
+  const storage = getSafeSessionStorage();
+  if (!storage) {
+    return null;
+  }
+  try {
+    const key = storageKeyForGateway(state.settings?.gatewayUrl);
+    const session = normalizeStoredSession(readStore(storage, key).sessions[sessionKey]);
+    if (!session) {
+      return null;
+    }
+    return {
+      draft: session.draft ?? "",
+      queue: session.queue ?? [],
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function persistChatComposerState(
+  state: ChatComposerPersistenceState,
+  sessionKey: string = state.sessionKey,
+): void {
+  const storage = getSafeSessionStorage();
+  if (!storage || !sessionKey.trim()) {
+    return;
+  }
+  try {
+    const key = storageKeyForGateway(state.settings?.gatewayUrl);
+    const store = readStore(storage, key);
+    const draft = state.chatMessage;
+    const queue = state.chatQueue
+      .slice(0, MAX_STORED_QUEUE_ITEMS)
+      .map(serializeQueueItem)
+      .filter((item): item is ChatQueueItem => item !== null);
+    if (!draft && queue.length === 0) {
+      delete store.sessions[sessionKey];
+    } else {
+      store.sessions[sessionKey] = {
+        ...(draft ? { draft } : {}),
+        ...(queue.length > 0 ? { queue } : {}),
+        updatedAt: Date.now(),
+      };
+    }
+    writeStore(storage, key, store);
+  } catch {
+    // Best-effort only: quota and privacy-mode storage errors should not break chat.
+  }
+}
+
+export function restoreChatComposerState(
+  state: ChatComposerPersistenceState,
+  options: RestoreOptions = {},
+): boolean {
+  const sessionKey = options.sessionKey ?? state.sessionKey;
+  const snapshot = loadChatComposerSnapshot(state, sessionKey);
+  if (!snapshot) {
+    return false;
+  }
+  if (!options.preserveCurrent || !state.chatMessage) {
+    state.chatMessage = snapshot.draft;
+  }
+  if ((!options.preserveCurrent && snapshot.queue.length > 0) || state.chatQueue.length === 0) {
+    state.chatQueue = snapshot.queue;
+  }
+  return true;
+}


### PR DESCRIPTION
## Summary

Refs #83344.

This intentionally does not auto-close #83344 because session preview/title metadata remains out of scope for this PR.

Addresses two refresh-time WebChat state gaps from #83344:

- expands the raw transcript window used by `chat.history` before visible-message projection/pagination, so recent visible conversation can be backfilled even when the latest raw transcript tail is mostly silent/internal traffic
- persists WebChat composer draft text and queued messages per gateway/session in `sessionStorage`, then restores them after refresh/session switching

## Notes

- Uses `sessionStorage` instead of `localStorage` as the safer privacy default: drafts/queued prompts survive refresh in the same tab, but do not persist indefinitely across browser restarts.
- Queued attachments are restored only when their payload data is available. If a queued attachment cannot be serialized safely, the queue item is not persisted rather than being restored without the attachment.
- Session preview/title metadata is intentionally out of scope for this PR.

## Real behavior proof

- Behavior or issue addressed: WebChat refresh keeps visible chat history available after a tool-heavy/raw-tail transcript, and preserves same-tab composer draft plus queued messages for the same gateway/session.
- Real environment tested: Local OpenClaw Control UI from this PR served by Vite at `http://127.0.0.1:5173`, connected in Google Chrome to a local loopback WebSocket gateway at `ws://127.0.0.1:18789`.
- Exact steps or command run after this patch:
  1. Started the patched Control UI with `npm --prefix ui run dev -- --host 127.0.0.1 --port 5173 --force`.
  2. Started a local loopback WebSocket gateway that returns real gateway frames for `connect`, `sessions.list`, `chat.history`, and `chat.send`, and keeps the first `chat.send` run active.
  3. Opened Chrome to `http://127.0.0.1:5173/chat?session=main`.
  4. Verified history showed `visible history before tool-heavy tail` and `visible assistant reply restored after refresh`.
  5. Sent `start long run proof`, then queued `queued proof after refresh` while that run stayed active.
  6. Typed an unsent draft `draft proof after refresh`.
  7. Reloaded the browser tab and waited for the Control UI to reconnect to the same gateway/session.
- Evidence after fix: Copied live output from the browser accessibility tree after reload included:

  ```text
  URL: 127.0.0.1:5173/chat?session=main
  VERSION v proof-local-gateway
  Gateway status: Online
  visible history before tool-heavy tail
  visible assistant reply restored after refresh
  start long run proof
  Queued ( 1 )
  queued proof after refresh
  text entry area Value: draft proof after refresh
  Run status: In progress
  Queue message
  ```

- Observed result after fix: The refreshed WebChat kept the same visible history messages, restored the queued message under `Queued (1)`, and restored the unsent draft in the composer for session `main`. The queued message stayed in the queue rather than being delivered early on reconnect.
- What was not tested: The gateway Vitest target did not run locally because root `node_modules` does not contain `vitest/package.json` after the full pnpm workspace install stalled; session preview/title metadata remains intentionally out of scope for this PR.

## Tests

- Added gateway coverage for `chat.history` backfilling visible messages when the raw tail is mostly `NO_REPLY`.
- Added UI coverage for composer draft/queue restore, gateway/session scoping, clearing, attachment payload handling, and lifecycle persistence.
- Ran `npm --prefix ui test -- src/ui/chat/composer-persistence.test.ts src/ui/app-lifecycle.node.test.ts`:
  - 2 test files passed
  - 8 tests passed
- Ran `git diff --check`.
- Ran a lightweight Node smoke check for `ui/src/ui/chat/composer-persistence.ts`.
- Attempted `OPENCLAW_GATEWAY_PROJECT_SHARDS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/server.chat.gateway-server-chat-b.test.ts`; it failed before running tests because root `node_modules` is missing `vitest/package.json` in this local environment.

Full targeted Vitest was not run locally because dependency installation for the full 128-workspace pnpm repo stalled in this environment.

