### PR TITLE
fix(telegram): preserve configured topic lanes

### DIFF
--- a/extensions/telegram/src/bot-core.ts
+++ b/extensions/telegram/src/bot-core.ts
@@ -21,7 +21,7 @@ import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { createNonExitingRuntime, type RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { getOrCreateAccountThrottler } from "./account-throttler.js";
-import { resolveTelegramAccount, type ResolvedTelegramAccount } from "./accounts.js";
+import { resolveTelegramAccount } from "./accounts.js";
 import { normalizeTelegramApiRoot } from "./api-root.js";
 import type { TelegramBotDeps } from "./bot-deps.js";
 import { registerTelegramHandlers } from "./bot-handlers.runtime.js";
@@ -43,39 +43,17 @@ import {
 import { resolveTelegramTransport } from "./fetch.js";
 import { stringifyTelegramRawUpdateForLog } from "./raw-update-log.js";
 import { createTelegramSendChatActionHandler } from "./sendchataction-401-backoff.js";
+import {
+  createTelegramSequentialKeyOptions,
+  resolveTelegramScopedGroupConfig,
+} from "./sequential-key-options.js";
 import { getTelegramSequentialKey } from "./sequential-key.js";
 import { createTelegramThreadBindingManager } from "./thread-bindings.js";
 
 export type { TelegramBotOptions } from "./bot.types.js";
 
 export { getTelegramSequentialKey };
-
-export function resolveTelegramScopedGroupConfig(
-  telegramCfg: ResolvedTelegramAccount["config"],
-  chatId: string | number,
-  messageThreadId?: number,
-) {
-  const groups = telegramCfg.groups;
-  const direct = telegramCfg.direct;
-  const chatIdStr = String(chatId);
-  const isDm = !chatIdStr.startsWith("-");
-
-  if (isDm) {
-    const groupConfig = direct?.[chatIdStr] ?? direct?.["*"];
-    const topicConfig =
-      groupConfig && messageThreadId != null
-        ? groupConfig.topics?.[String(messageThreadId)]
-        : undefined;
-    return { groupConfig, topicConfig };
-  }
-
-  const groupConfig = groups?.[chatIdStr] ?? groups?.["*"];
-  const topicConfig =
-    groupConfig && messageThreadId != null
-      ? groupConfig.topics?.[String(messageThreadId)]
-      : undefined;
-  return { groupConfig, topicConfig };
-}
+export { resolveTelegramScopedGroupConfig } from "./sequential-key-options.js";
 
 type TelegramBotRuntime = {
   Bot: typeof Bot;
@@ -197,6 +175,7 @@ export function createTelegramBotCore(
   });
   const shouldSkipUpdate = (ctx: TelegramUpdateKeyContext) =>
     updateTracker.shouldSkipHandlerDispatch(ctx);
+  const sequentialKeyOptions = createTelegramSequentialKeyOptions(telegramCfg);
 
   bot.use(async (ctx, next) => {
     const begin = updateTracker.beginUpdate(ctx);
@@ -212,7 +191,7 @@ export function createTelegramBotCore(
     }
   });
 
-  bot.use(botRuntime.sequentialize(getTelegramSequentialKey));
+  bot.use(botRuntime.sequentialize((ctx) => getTelegramSequentialKey(ctx, sequentialKeyOptions)));
 
   const rawUpdateLogger = createSubsystemLogger("gateway/channels/telegram/raw-update");
   const MAX_RAW_UPDATE_CHARS = 8000;

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -2638,6 +2638,69 @@ describe("dispatchTelegramMessage draft streaming", () => {
     await Promise.all([firstPromise, sidePromise]);
   });
 
+  it("registers configured forum dispatches on topic reply-fence lanes when flags are omitted", async () => {
+    const historyKey = "telegram:group:-100123:topic:10";
+    const groupHistories = new Map([[historyKey, []]]);
+    let started: (() => void) | undefined;
+    const startGate = new Promise<void>((resolve) => {
+      started = resolve;
+    });
+    let release: (() => void) | undefined;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let abortSignal: AbortSignal | undefined;
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementationOnce(async ({ replyOptions }) => {
+      abortSignal = replyOptions?.abortSignal;
+      started?.();
+      await gate;
+      return {
+        queuedFinal: false,
+        counts: { block: 0, final: 0, tool: 0 },
+      };
+    });
+
+    const promise = dispatchWithContext({
+      context: createContext({
+        ctxPayload: {
+          SessionKey: "agent:main:telegram:group:-100123:topic:10",
+          ChatType: "group",
+          MessageSid: "99",
+          RawBody: "@bot first request",
+          BodyForAgent: "@bot first request",
+          CommandBody: "@bot first request",
+          CommandAuthorized: true,
+        } as unknown as TelegramMessageContext["ctxPayload"],
+        msg: {
+          chat: { id: -100123, type: "supergroup" },
+          message_id: 99,
+          message_thread_id: 10,
+          text: "@bot first request",
+        } as unknown as TelegramMessageContext["msg"],
+        chatId: -100123,
+        isGroup: true,
+        historyKey,
+        historyLimit: 10,
+        groupHistories,
+        threadSpec: { id: 10, scope: "forum" },
+      }),
+      streamMode: "off",
+    });
+    await startGate;
+
+    const { buildTelegramReplyFenceLaneKey, supersedeTelegramReplyFenceLane } =
+      await import("./telegram-reply-fence.js");
+    supersedeTelegramReplyFenceLane(
+      buildTelegramReplyFenceLaneKey({
+        accountId: "default",
+        sequentialKey: "telegram:-100123:topic:10",
+      }),
+    );
+    expect(abortSignal?.aborted).toBe(true);
+    release?.();
+    await promise;
+  });
+
   it("lets authorized /stop abort active non-interrupting side dispatch", async () => {
     const historyKey = "telegram:group:-100123";
     const groupHistories = new Map([[historyKey, []]]);

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -110,7 +110,7 @@ import {
   splitTelegramReasoningText,
 } from "./reasoning-lane-coordinator.js";
 import { editMessageTelegram } from "./send.js";
-import { getTelegramSequentialKey } from "./sequential-key.js";
+import { getTelegramSequentialKey, type TelegramSequentialKeyOptions } from "./sequential-key.js";
 import { cacheSticker, describeStickerImage } from "./sticker-cache.js";
 import {
   beginTelegramReplyFence,
@@ -131,6 +131,7 @@ export { getTelegramReplyFenceSizeForTests, resetTelegramReplyFenceForTests };
 
 const EMPTY_RESPONSE_FALLBACK = "No response generated. Please try again.";
 const silentReplyDispatchLogger = createSubsystemLogger("telegram/silent-reply-dispatch");
+const TELEGRAM_GENERAL_TOPIC_ID = 1;
 
 /** Minimum chars before sending first streaming message (improves push notification UX) */
 const DRAFT_MIN_INITIAL_CHARS = 30;
@@ -452,10 +453,20 @@ export const dispatchTelegramMessage = async ({
     chatId,
     threadSpec,
   });
-  const replyFenceLaneKey = getTelegramSequentialKey({
-    message: msg,
-    ...(context.primaryCtx.me ? { me: context.primaryCtx.me } : {}),
-  });
+  const replyFenceLaneOptions: TelegramSequentialKeyOptions = {
+    isConfiguredForumThread: ({ chatId: laneChatId, messageThreadId }) =>
+      laneChatId === chatId &&
+      threadSpec.scope === "forum" &&
+      (messageThreadId ?? TELEGRAM_GENERAL_TOPIC_ID) ===
+        (threadSpec.id ?? TELEGRAM_GENERAL_TOPIC_ID),
+  };
+  const replyFenceLaneKey = getTelegramSequentialKey(
+    {
+      message: msg,
+      ...(context.primaryCtx.me ? { me: context.primaryCtx.me } : {}),
+    },
+    replyFenceLaneOptions,
+  );
   const scopedReplyFenceLaneKey = buildTelegramReplyFenceLaneKey({
     accountId: route.accountId,
     sequentialKey: replyFenceLaneKey,

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -51,7 +51,6 @@ const {
 const { resolveTelegramFetch } = await import("./fetch.js");
 const {
   createTelegramBotCore: createTelegramBotBase,
-  getTelegramSequentialKey,
   resolveTelegramScopedGroupConfig,
   setTelegramBotRuntimeForTest,
 } = await import("./bot-core.js");
@@ -375,7 +374,7 @@ describe("createTelegramBot", () => {
     createTelegramBot({ token: "tok" });
     expect(sequentializeSpy).toHaveBeenCalledTimes(1);
     expect(middlewareUseSpy).toHaveBeenCalledWith(sequentializeSpy.mock.results[0]?.value);
-    expect(harness.sequentializeKey).toBe(getTelegramSequentialKey);
+    expect(harness.sequentializeKey).toEqual(expect.any(Function));
   });
 
   it("lets /status bypass a busy Telegram topic lane", async () => {
@@ -500,6 +499,137 @@ describe("createTelegramBot", () => {
     releaseFirstTopic();
     await firstPromise;
     expect(events).toEqual(["first:start", "second", "first:end"]);
+  });
+
+  it("uses configured topic lanes when Telegram omits forum flags", async () => {
+    installPerKeySequentializer();
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+          groups: {
+            "-1001234567890": {
+              requireMention: false,
+              topics: {
+                "10": {},
+                "20": {},
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const events: string[] = [];
+    let releaseFirstTopic!: () => void;
+    const firstTopicGate = new Promise<void>((resolve) => {
+      releaseFirstTopic = resolve;
+    });
+
+    createTelegramBot({ token: "tok" });
+    const sequentializer = sequentializeSpy.mock.results[0]?.value as
+      | TelegramMiddleware
+      | undefined;
+    if (!sequentializer) {
+      throw new Error("Expected sequentialize middleware");
+    }
+
+    const topicCtx = (threadId: number, updateId: number) => ({
+      message: {
+        message_id: updateId,
+        date: 0,
+        text: `topic ${threadId}`,
+        message_thread_id: threadId,
+        chat: {
+          id: -1001234567890,
+          type: "supergroup",
+          title: "Forum Group",
+        },
+      },
+      update: { update_id: updateId },
+    });
+
+    const firstPromise = sequentializer(topicCtx(10, 303), async () => {
+      events.push("first:start");
+      await firstTopicGate;
+      events.push("first:end");
+    });
+
+    await flushTelegramTestMicrotasks();
+    expect(events).toEqual(["first:start"]);
+
+    await sequentializer(topicCtx(20, 304), async () => {
+      events.push("second");
+    });
+
+    expect(events).toEqual(["first:start", "second"]);
+
+    releaseFirstTopic();
+    await firstPromise;
+    expect(events).toEqual(["first:start", "second", "first:end"]);
+  });
+
+  it("keeps unconfigured supergroup reply threads serialized on the chat lane", async () => {
+    installPerKeySequentializer();
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+          groups: { "-1001234567890": { requireMention: false } },
+        },
+      },
+    });
+
+    const events: string[] = [];
+    let releaseFirstReply!: () => void;
+    const firstReplyGate = new Promise<void>((resolve) => {
+      releaseFirstReply = resolve;
+    });
+
+    createTelegramBot({ token: "tok" });
+    const sequentializer = sequentializeSpy.mock.results[0]?.value as
+      | TelegramMiddleware
+      | undefined;
+    if (!sequentializer) {
+      throw new Error("Expected sequentialize middleware");
+    }
+
+    const replyCtx = (threadId: number, updateId: number) => ({
+      message: {
+        message_id: updateId,
+        date: 0,
+        text: `reply ${threadId}`,
+        message_thread_id: threadId,
+        chat: {
+          id: -1001234567890,
+          type: "supergroup",
+          title: "Regular Group",
+        },
+      },
+      update: { update_id: updateId },
+    });
+
+    const firstPromise = sequentializer(replyCtx(10, 305), async () => {
+      events.push("first:start");
+      await firstReplyGate;
+      events.push("first:end");
+    });
+
+    await flushTelegramTestMicrotasks();
+    expect(events).toEqual(["first:start"]);
+
+    const secondPromise = sequentializer(replyCtx(20, 306), async () => {
+      events.push("second");
+    });
+
+    await flushTelegramTestMicrotasks();
+    expect(events).toEqual(["first:start"]);
+
+    releaseFirstReply();
+    await Promise.all([firstPromise, secondPromise]);
+    expect(events).toEqual(["first:start", "first:end", "second"]);
   });
 
   it("keeps ordinary Telegram messages serialized within the same topic", async () => {

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -249,6 +249,7 @@ function createPollingSessionWithTransportRestart(params: {
 
 function createPollingSession(params: {
   abortSignal: AbortSignal;
+  config?: ConstructorParameters<typeof TelegramPollingSession>[0]["config"];
   log?: (message: string) => void;
   telegramTransport?: ReturnType<typeof makeTelegramTransport>;
   createTelegramTransport?: () => ReturnType<typeof makeTelegramTransport>;
@@ -259,7 +260,7 @@ function createPollingSession(params: {
 }) {
   return new TelegramPollingSession({
     token: "tok",
-    config: {},
+    config: params.config ?? {},
     accountId: "default",
     runtime: undefined,
     proxyFetch: undefined,
@@ -985,7 +986,7 @@ describe("TelegramPollingSession", () => {
     });
   });
 
-  it("lets isolated ingress drain interleave different Telegram topic lanes", async () => {
+  it("lets isolated ingress drain interleave configured Telegram topic lanes when flags are omitted", async () => {
     const abort = new AbortController();
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-spool-"));
     const events: string[] = [];
@@ -1030,7 +1031,6 @@ describe("TelegramPollingSession", () => {
           message: {
             text,
             message_thread_id: threadId,
-            is_topic_message: true,
             chat: { id: -100, type: "supergroup" },
           },
         },
@@ -1053,6 +1053,20 @@ describe("TelegramPollingSession", () => {
     try {
       const session = createPollingSession({
         abortSignal: abort.signal,
+        config: {
+          channels: {
+            telegram: {
+              groups: {
+                "-100": {
+                  topics: {
+                    "10": {},
+                    "11": {},
+                  },
+                },
+              },
+            },
+          },
+        },
         isolatedIngress: {
           enabled: true,
           spoolDir: tempDir,

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -9,6 +9,7 @@ import {
 } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { mergeTelegramAccountConfig } from "./account-config.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { createTelegramBot } from "./bot.js";
 import { type TelegramTransport } from "./fetch.js";
@@ -17,7 +18,8 @@ import { TelegramPollingLivenessTracker } from "./polling-liveness.js";
 import { createTelegramPollingStatusPublisher } from "./polling-status.js";
 import { TelegramPollingTransportState } from "./polling-transport-state.js";
 import { TELEGRAM_GET_UPDATES_REQUEST_TIMEOUT_MS } from "./request-timeouts.js";
-import { getTelegramSequentialKey } from "./sequential-key.js";
+import { createTelegramSequentialKeyOptions } from "./sequential-key-options.js";
+import { getTelegramSequentialKey, type TelegramSequentialKeyOptions } from "./sequential-key.js";
 import {
   claimTelegramSpooledUpdate,
   deleteTelegramSpooledUpdate,
@@ -222,9 +224,12 @@ export class TelegramPollingSession {
   #stallThresholdMs: number;
   #spooledUpdateHandlerTimeoutMs: number;
   #spooledUpdateHandlerAbortGraceMs: number;
+  #sequentialKeyOptions: TelegramSequentialKeyOptions;
   #deliveryDrainInFlight = false;
 
   constructor(private readonly opts: TelegramPollingSessionOpts) {
+    const telegramCfg = mergeTelegramAccountConfig(opts.config, opts.accountId);
+    this.#sequentialKeyOptions = createTelegramSequentialKeyOptions(telegramCfg);
     this.#transportState = new TelegramPollingTransportState({
       log: opts.log,
       initialTransport: opts.telegramTransport,
@@ -479,10 +484,13 @@ export class TelegramPollingSession {
   }
 
   #spooledUpdateLaneKey(update: TelegramSpooledUpdate): string {
-    return getTelegramSequentialKey({
-      update: update.update as Parameters<typeof getTelegramSequentialKey>[0]["update"],
-      ...(this.opts.botInfo ? { me: this.opts.botInfo } : {}),
-    });
+    return getTelegramSequentialKey(
+      {
+        update: update.update as Parameters<typeof getTelegramSequentialKey>[0]["update"],
+        ...(this.opts.botInfo ? { me: this.opts.botInfo } : {}),
+      },
+      this.#sequentialKeyOptions,
+    );
   }
 
   #activeSpooledUpdateLaneKeysForSpool(spoolDir: string): Set<string> {

--- a/extensions/telegram/src/sequential-key-options.ts
+++ b/extensions/telegram/src/sequential-key-options.ts
@@ -1,0 +1,47 @@
+import type { ResolvedTelegramAccount } from "./accounts.js";
+import type { TelegramSequentialKeyOptions } from "./sequential-key.js";
+
+const TELEGRAM_GENERAL_TOPIC_ID = 1;
+
+export function resolveTelegramScopedGroupConfig(
+  telegramCfg: ResolvedTelegramAccount["config"],
+  chatId: string | number,
+  messageThreadId?: number,
+) {
+  const groups = telegramCfg.groups;
+  const direct = telegramCfg.direct;
+  const chatIdStr = String(chatId);
+  const isDm = !chatIdStr.startsWith("-");
+
+  if (isDm) {
+    const groupConfig = direct?.[chatIdStr] ?? direct?.["*"];
+    const topicConfig =
+      groupConfig && messageThreadId != null
+        ? groupConfig.topics?.[String(messageThreadId)]
+        : undefined;
+    return { groupConfig, topicConfig };
+  }
+
+  const groupConfig = groups?.[chatIdStr] ?? groups?.["*"];
+  const topicConfig =
+    groupConfig && messageThreadId != null
+      ? groupConfig.topics?.[String(messageThreadId)]
+      : undefined;
+  return { groupConfig, topicConfig };
+}
+
+export function createTelegramSequentialKeyOptions(
+  telegramCfg: ResolvedTelegramAccount["config"],
+): TelegramSequentialKeyOptions {
+  return {
+    isConfiguredForumThread: ({ chatId, messageThreadId }) => {
+      const resolvedThreadId = messageThreadId ?? TELEGRAM_GENERAL_TOPIC_ID;
+      const { topicConfig } = resolveTelegramScopedGroupConfig(
+        telegramCfg,
+        chatId,
+        resolvedThreadId,
+      );
+      return Boolean(topicConfig);
+    },
+  };
+}

--- a/extensions/telegram/src/sequential-key.test.ts
+++ b/extensions/telegram/src/sequential-key.test.ts
@@ -1,5 +1,6 @@
 import type { Chat, Message } from "grammy/types";
 import { describe, expect, it } from "vitest";
+import { createTelegramSequentialKeyOptions } from "./sequential-key-options.js";
 import { getTelegramSequentialKey } from "./sequential-key.js";
 
 const mockChat = (chat: Pick<Chat, "id"> & Partial<Pick<Chat, "type" | "is_forum">>): Chat =>
@@ -253,5 +254,56 @@ describe("getTelegramSequentialKey", () => {
     ],
   ])("resolves key %#", (input, expected) => {
     expect(getTelegramSequentialKey(input)).toBe(expected);
+  });
+
+  it("uses configured topic metadata when Telegram omits forum flags", () => {
+    const input = {
+      message: mockMessage({
+        chat: mockChat({ id: 123, type: "supergroup" }),
+        message_thread_id: 9,
+      }),
+    };
+    const options = {
+      isConfiguredForumThread: ({
+        chatId,
+        messageThreadId,
+      }: {
+        chatId: number;
+        messageThreadId?: number;
+      }) => chatId === 123 && messageThreadId === 9,
+    };
+
+    expect(getTelegramSequentialKey(input, options)).toBe("telegram:123:topic:9");
+  });
+
+  it("uses configured General topic metadata when Telegram omits forum flags and thread id", () => {
+    const input = {
+      message: mockMessage({
+        chat: mockChat({ id: -100123, type: "supergroup" }),
+      }),
+    };
+    const options = createTelegramSequentialKeyOptions({
+      groups: {
+        "-100123": {
+          topics: { "1": {} },
+        },
+      },
+    });
+
+    expect(getTelegramSequentialKey(input, options)).toBe("telegram:-100123:topic:1");
+  });
+
+  it("keeps explicit non-forum supergroup replies on the chat lane", () => {
+    const input = {
+      message: mockMessage({
+        chat: mockChat({ id: 123, type: "supergroup", is_forum: false }),
+        message_thread_id: 9,
+      }),
+    };
+    const options = {
+      isConfiguredForumThread: () => true,
+    };
+
+    expect(getTelegramSequentialKey(input, options)).toBe("telegram:123");
   });
 });

--- a/extensions/telegram/src/sequential-key.ts
+++ b/extensions/telegram/src/sequential-key.ts
@@ -41,6 +41,13 @@ type TelegramSequentialKeyContext = {
   };
 };
 
+export type TelegramSequentialKeyOptions = {
+  isConfiguredForumThread?: (params: {
+    chatId: number;
+    messageThreadId: number | undefined;
+  }) => boolean;
+};
+
 export function isTelegramReadOnlyControlLaneText(params: {
   rawText?: string;
   botUsername?: string;
@@ -97,7 +104,37 @@ export function isTelegramControlLaneText(params: {
   return isTelegramReadOnlyControlLaneText(params);
 }
 
-export function getTelegramSequentialKey(ctx: TelegramSequentialKeyContext): string {
+function resolveSequentialKeyForumFlag(
+  msg: Message | undefined,
+  chatId: number | undefined,
+  options: TelegramSequentialKeyOptions | undefined,
+): boolean {
+  const forumHint = resolveTelegramMessageForumFlagHint({
+    chatType: msg?.chat?.type,
+    isForum: msg?.chat?.is_forum,
+    isTopicMessage: msg?.is_topic_message,
+  });
+  if (typeof forumHint === "boolean") {
+    return forumHint;
+  }
+  if (msg?.chat?.type !== "supergroup") {
+    return false;
+  }
+  if (typeof chatId !== "number") {
+    return false;
+  }
+  return (
+    options?.isConfiguredForumThread?.({
+      chatId,
+      messageThreadId: msg?.message_thread_id,
+    }) === true
+  );
+}
+
+export function getTelegramSequentialKey(
+  ctx: TelegramSequentialKeyContext,
+  options?: TelegramSequentialKeyOptions,
+): string {
   const reaction = ctx.update?.message_reaction;
   if (reaction?.chat?.id) {
     return `telegram:${reaction.chat.id}`;
@@ -140,11 +177,7 @@ export function getTelegramSequentialKey(ctx: TelegramSequentialKeyContext): str
   }
   const isGroup = msg?.chat?.type === "group" || msg?.chat?.type === "supergroup";
   const messageThreadId = msg?.message_thread_id;
-  const isForum = resolveTelegramMessageForumFlagHint({
-    chatType: msg?.chat?.type,
-    isForum: msg?.chat?.is_forum,
-    isTopicMessage: msg?.is_topic_message,
-  });
+  const isForum = resolveSequentialKeyForumFlag(msg, chatId, options);
   const threadId = isGroup
     ? resolveTelegramForumThreadId({ isForum, messageThreadId })
     : messageThreadId;


### PR DESCRIPTION
## Summary

Refs #81530.

- Treat configured Telegram forum topics as topic lanes when inbound updates omit `chat.is_forum` and `is_topic_message`.
- Reuse the same configured-topic lane resolution for normal bot sequentialization, isolated ingress spool draining, and reply-fence timeout recovery.
- Keep unconfigured supergroup reply threads serialized on the chat lane so regular group replies do not become accidental topic lanes.

## Verification

- `git diff --check origin/main...HEAD`
- `node scripts/run-vitest.mjs extensions/telegram/src/sequential-key.test.ts extensions/telegram/src/bot.create-telegram-bot.test.ts extensions/telegram/src/polling-session.test.ts extensions/telegram/src/bot-message-dispatch.test.ts`

## Real behavior proof

Behavior addressed: Telegram supergroup forum topic updates that omit Telegram forum flags now use configured topic lanes instead of blocking all configured topics behind the chat lane.

Real environment tested: Local OpenClaw source checkout on macOS, rebased onto current `origin/main`; focused Telegram Vitest coverage only.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/telegram/src/sequential-key.test.ts extensions/telegram/src/bot.create-telegram-bot.test.ts extensions/telegram/src/polling-session.test.ts extensions/telegram/src/bot-message-dispatch.test.ts`

Evidence after fix: 4 test files passed, 253 tests passed; `git diff --check origin/main...HEAD` passed.

Observed result after fix: Configured topic 10 and topic 20 updates without forum flags interleave on separate topic lanes, unconfigured supergroup reply threads remain serialized on the chat lane, isolated ingress drains configured topics independently, and timeout recovery aborts the matching configured topic reply fence.

What was not tested: Live Telegram Bot API delivery with real credentials; this PR does not include a live Telegram credentialed repro.
