### PR TITLE
fix(cli): preserve equals in root option values [AI-assisted]

### DIFF
--- a/src/cli/root-option-value.test.ts
+++ b/src/cli/root-option-value.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { takeCliRootOptionValue } from "./root-option-value.js";
+
+describe("takeCliRootOptionValue", () => {
+  it("preserves equals signs after the first separator", () => {
+    expect(takeCliRootOptionValue("--token=abc=def", undefined)).toEqual({
+      value: "abc=def",
+      consumedNext: false,
+    });
+    expect(takeCliRootOptionValue("--token=abc==", undefined)).toEqual({
+      value: "abc==",
+      consumedNext: false,
+    });
+  });
+
+  it("treats empty inline values as missing", () => {
+    expect(takeCliRootOptionValue("--token=", "fallback")).toEqual({
+      value: null,
+      consumedNext: false,
+    });
+  });
+
+  it("continues to consume the next token for space-separated values", () => {
+    expect(takeCliRootOptionValue("--token", "abc=def")).toEqual({
+      value: "abc=def",
+      consumedNext: true,
+    });
+  });
+});

--- a/src/cli/root-option-value.ts
+++ b/src/cli/root-option-value.ts
@@ -8,7 +8,7 @@ export function takeCliRootOptionValue(
   consumedNext: boolean;
 } {
   if (raw.includes("=")) {
-    const [, value] = raw.split("=", 2);
+    const value = raw.slice(raw.indexOf("=") + 1);
     const trimmed = (value ?? "").trim();
     return { value: trimmed || null, consumedNext: false };
   }


### PR DESCRIPTION
## Summary

- Problem: root option values passed inline with `=` were truncated after the second `=` character, corrupting tokens, secrets, base64 padding, and URLs with query strings.
- Solution: parse inline values by slicing after the first `=` instead of using `split("=", 2)`.
- What changed: Updated `takeCliRootOptionValue()` and added focused regression coverage for embedded `=` values.
- What did NOT change (scope boundary): No root option names, command routing, profile/container semantics, env loading, or non-inline option parsing changed.

AI-assisted: yes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #83882
- [x] This PR fixes a bug or regression

## Motivation

- Root options can carry token-like or URL-like values. Silently truncating after an embedded `=` can corrupt secrets, base64-padded values, or URLs without any warning.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Inline root option values preserve all characters after the first `=` separator.
- Real environment tested: Local OpenClaw checkout on Linux with Node v22.21.1.
- Exact steps or command run after this patch:
  - `node --import tsx -e 'const { takeCliRootOptionValue } = await import("./src/cli/root-option-value.ts"); for (const raw of ["--token=abc=def", "--token=abc==", "--url=https://example.test/cb?a=b"]) console.log(`${raw} -> ${JSON.stringify(takeCliRootOptionValue(raw, undefined))}`);'`
- Evidence after fix (copied live terminal output):

```text
--token=abc=def -> {"value":"abc=def","consumedNext":false}
--token=abc== -> {"value":"abc==","consumedNext":false}
--url=https://example.test/cb?a=b -> {"value":"https://example.test/cb?a=b","consumedNext":false}
```

- Observed result after fix: Embedded equals signs are preserved for token, base64-padding, and URL-like option values.
- What was not tested: Full repository suite; live command invocation with a real external token.
- Before evidence: Issue #83882 documents the pre-fix `raw.split("=", 2)` behavior where `--token=abc=def` produced only `abc`.

## Root Cause (if applicable)

- Root cause: `raw.split("=", 2)` discarded everything after the second split segment, so only the text between the first and second `=` survived.
- Missing detection / guardrail: There was no direct test for `takeCliRootOptionValue()` with embedded equals signs.
- Contributing context (if known): Inline option parsing only needs to treat the first `=` as the key/value separator; later `=` characters belong to the value.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/cli/root-option-value.test.ts`
- Scenario the test should lock in: `--token=abc=def` and `--token=abc==` preserve embedded equals signs, while `--token=` remains missing and space-separated values still consume the next token.
- Why this is the smallest reliable guardrail: The bug is entirely inside the root-option value helper, so direct helper coverage catches it without invoking the full CLI.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Inline root option values containing `=` are no longer truncated.

## Diagram (if applicable)

```text
Before:
--token=abc=def -> abc

After:
--token=abc=def -> abc=def
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node v22.21.1, local checkout
- Model/provider: N/A
- Integration/channel (if any): CLI root option parsing
- Relevant config (redacted): N/A

### Steps

1. Call `takeCliRootOptionValue("--token=abc=def", undefined)`.
2. Call `takeCliRootOptionValue("--token=abc==", undefined)`.
3. Call `takeCliRootOptionValue("--url=https://example.test/cb?a=b", undefined)`.

### Expected

- All characters after the first `=` are preserved as the value.

### Actual

- All characters after the first `=` are preserved as the value.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Focused validation run:

```text
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.cli.config.ts src/cli/root-option-value.test.ts

Test Files  1 passed (1)
Tests  3 passed (3)
```

Whitespace validation:

```text
git diff --check
```

No output; clean.

## Human Verification (required)

- Verified scenarios: Focused CLI helper unit tests; live `tsx` smoke of token/base64/URL-like inline values; `git diff --check`.
- Edge cases checked: Empty inline value still returns `null`; space-separated value parsing still consumes the next token.
- What you did **not** verify: Full repository suite; live external CLI command carrying a real token.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Changing inline parsing could affect existing root options that contain `=`.
  - Mitigation: This change preserves the documented separator behavior while retaining the existing trim/null handling; direct tests cover both embedded equals and existing empty/space-separated paths.