### PR TITLE
fix(auto-reply): suppress repeated silent tokens

### DIFF
--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -22,6 +22,11 @@ describe("isSilentReplyText", () => {
     expect(isSilentReplyText("  No_RePlY  ")).toBe(true);
   });
 
+  it("returns true for repeated token-only replies", () => {
+    expect(isSilentReplyText("NO_REPLY\n\nNO_REPLY")).toBe(true);
+    expect(isSilentReplyText("  No_RePlY\tNO_REPLY  ")).toBe(true);
+  });
+
   it("returns false for undefined/empty", () => {
     expect(isSilentReplyText(undefined)).toBe(false);
     expect(isSilentReplyText("")).toBe(false);

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -13,7 +13,7 @@ function getSilentExactRegex(token: string): RegExp {
     return cached;
   }
   const escaped = escapeRegExp(token);
-  const regex = new RegExp(`^\\s*${escaped}\\s*$`, "i");
+  const regex = new RegExp(`^\\s*${escaped}(?:\\s+${escaped})*\\s*$`, "i");
   silentExactRegexByToken.set(token, regex);
   return regex;
 }
@@ -36,7 +36,7 @@ export function isSilentReplyText(
   if (!text) {
     return false;
   }
-  // Match only the exact silent token with optional surrounding whitespace.
+  // Match replies that contain only one or more silent tokens with whitespace separators.
   // This prevents substantive replies ending with NO_REPLY from being suppressed (#19537).
   return getSilentExactRegex(token).test(text);
 }


### PR DESCRIPTION
## Summary
- Allow `isSilentReplyText()` to treat repeated silent tokens separated by whitespace as a silent-only reply.
- Add coverage for doubled `NO_REPLY` output while preserving the existing guard against suppressing substantive text.

## Tests
- RED: `node --no-maglev ./node_modules/vitest/vitest.mjs run src/auto-reply/tokens.test.ts` failed before the fix on the new repeated-token assertion.
- GREEN: `node --no-maglev ./node_modules/vitest/vitest.mjs run src/auto-reply/tokens.test.ts` passed after the fix.
- `./node_modules/.bin/oxfmt --check --threads=1 src/auto-reply/tokens.ts src/auto-reply/tokens.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/auto-reply/tokens.ts src/auto-reply/tokens.test.ts`
- `git diff --check`

## Verification
Behavior addressed: repeated `NO_REPLY` token-only assistant replies are now suppressed as silent replies.
Real environment tested: local macOS checkout, Node/Vitest from repository dependencies.
Exact steps or command run after this patch: `node --no-maglev ./node_modules/vitest/vitest.mjs run src/auto-reply/tokens.test.ts`
Evidence after fix: `src/auto-reply/tokens.test.ts` passed with 25 tests.
Observed result after fix: `NO_REPLY\n\nNO_REPLY` and mixed-case repeated token-only replies return `true`; substantive replies ending with `NO_REPLY` still return `false`.
What was not tested: full `pnpm check:changed`; local pnpm dependency status check attempted to reconcile dependencies and timed out fetching optional packages.

Closes #54736
