### PR TITLE
fix(agents): respect tool policy for sessions_yield [AI-assisted] (#83981)

### DIFF
--- a/src/agents/openclaw-tools.sessions-yield-policy.test.ts
+++ b/src/agents/openclaw-tools.sessions-yield-policy.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { createOpenClawTools } from "./openclaw-tools.js";
+
+function toolNames(tools: ReturnType<typeof createOpenClawTools>): string[] {
+  return tools.map((tool) => tool.name);
+}
+
+describe("openclaw-tools sessions_yield gating", () => {
+  it("includes sessions_yield by default", () => {
+    const tools = createOpenClawTools({
+      config: {} as OpenClawConfig,
+      disablePluginTools: true,
+      modelProvider: "anthropic",
+      modelId: "claude-sonnet-4-6",
+    });
+    expect(toolNames(tools)).toContain("sessions_yield");
+  });
+
+  it("omits sessions_yield when explicitly denied via tools.deny", () => {
+    const config = { tools: { deny: ["sessions_yield"] } } as OpenClawConfig;
+    const tools = createOpenClawTools({
+      config,
+      disablePluginTools: true,
+      modelProvider: "anthropic",
+      modelId: "claude-sonnet-4-6",
+    });
+    expect(toolNames(tools)).not.toContain("sessions_yield");
+  });
+
+  it("omits sessions_yield when an allowlist is set without it", () => {
+    const config = { tools: { allow: ["message"] } } as OpenClawConfig;
+    const tools = createOpenClawTools({
+      config,
+      disablePluginTools: true,
+      modelProvider: "anthropic",
+      modelId: "claude-sonnet-4-6",
+    });
+    expect(toolNames(tools)).not.toContain("sessions_yield");
+  });
+
+  it("omits sessions_yield when pluginToolDenylist includes it", () => {
+    const tools = createOpenClawTools({
+      config: {} as OpenClawConfig,
+      disablePluginTools: true,
+      pluginToolDenylist: ["sessions_yield"],
+      modelProvider: "anthropic",
+      modelId: "claude-sonnet-4-6",
+    });
+    expect(toolNames(tools)).not.toContain("sessions_yield");
+  });
+});

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -31,6 +31,7 @@ import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
 import type { SpawnedToolContext } from "./spawned-context.js";
 import type { ToolFsPolicy } from "./tool-fs-policy.js";
 import { resolveToolLoopDetectionConfig } from "./tool-loop-detection-config.js";
+import { isToolAllowedByPolicyName } from "./tool-policy-match.js";
 import { createAgentsListTool } from "./tools/agents-list-tool.js";
 import type { AnyAgentTool } from "./tools/common.js";
 import { createCronTool } from "./tools/cron-tool.js";
@@ -364,6 +365,10 @@ export function createOpenClawTools(
       modelProvider: options?.modelProvider,
       modelId: options?.modelId,
     });
+  const includeSessionsYieldTool = isToolAllowedByPolicyName("sessions_yield", {
+    allow: explicitFactoryAllowlist,
+    deny: explicitFactoryDenylist,
+  });
   const tools: AnyAgentTool[] = [
     ...(embedded
       ? []
@@ -449,10 +454,14 @@ export function createOpenClawTools(
           }),
         ]
       : []),
-    createSessionsYieldTool({
-      sessionId: options?.sessionId,
-      onYield: options?.onYield,
-    }),
+    ...(includeSessionsYieldTool
+      ? [
+          createSessionsYieldTool({
+            sessionId: options?.sessionId,
+            onYield: options?.onYield,
+          }),
+        ]
+      : []),
     createSubagentsTool({
       agentSessionKey: options?.agentSessionKey,
     }),


### PR DESCRIPTION
> 🤖 AI-assisted (built with Codex via Hermes orchestration). Test level: lightly tested. Prompt summary available on request.

## Summary
- Problem: `sessions_yield` was always built and registered inside `createOpenClawTools`, regardless of the effective tool policy. Allow/deny filtering only ran later in the pipeline, so agents could still discover and invoke `sessions_yield` even when `tools.deny` listed it or when an explicit `tools.allow` excluded it.
- Why it matters: Agents would intermittently call `sessions_yield` mid-task in restricted-policy contexts, ending the turn unexpectedly and forcing manual resume. Policy expectations were silently violated.
- What changed: Gate `sessions_yield` at construction time using `isToolAllowedByPolicyName` against the same `explicitFactoryAllowlist` / `explicitFactoryDenylist` already used for `message` and `update_plan`. The tool is no longer created (and its `onYield` callback no longer wired) when policy disallows it.
- What did NOT change (scope boundary): No changes to the tool's runtime behavior, to other tools, to filter pipelines downstream, to subagent inheritance, or to plugin tool resolution.

## Change Type (select all)
- [x] Bug fix

## Scope (select all touched areas)
- [x] Agents

## Linked Issue/PR
- Closes #83981
- [x] This PR fixes a bug or regression

## Root Cause
- Root cause: `createSessionsYieldTool` was always present in the `tools` array literal in `src/agents/openclaw-tools.ts`. Allow/deny resolution happened after the tool and its callback were already constructed, so it remained visible in the effective tool catalog and could still be invoked.
- Missing detection / guardrail: No unit test asserted that `sessions_yield` is omitted from `createOpenClawTools` output when `tools.deny` or a narrow `tools.allow` excludes it. Other gated tools (`message`, `update_plan`) had this proof; `sessions_yield` did not.
- Contributing context (if known): `sessions_yield` was added as a default-on tool; the pattern of gating at construction time (mirrored from `message`/`update_plan`) was not extended to it.

## Regression Test Plan
- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/agents/openclaw-tools.sessions-yield-policy.test.ts`
- Scenario the test should lock in: `createOpenClawTools` includes `sessions_yield` by default, but omits it when `tools.deny` contains `sessions_yield`, when a narrow `tools.allow` does not list it, and when `pluginToolDenylist` contains it.
- Why this is the smallest reliable guardrail: It exercises the exact public factory entry point and asserts the resulting tool inventory, which is what agents and the catalog ultimately consume.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes
- When `tools.deny` lists `sessions_yield` (or an explicit `tools.allow` excludes it), the tool is no longer offered to agents and cannot be invoked. Default behavior (no policy) is unchanged: `sessions_yield` remains available.

## Security Impact (required)
- New permissions/capabilities? No
- This change tightens an existing capability gate (policy is now honored for `sessions_yield` as for other gated tools). It can only reduce, not expand, what an agent can do in a given configuration.
