### PR TITLE
fix(agents): inherit subagent thinking defaults

### DIFF
--- a/src/agents/openclaw-tools.subagents.sessions-spawn-applies-thinking-default.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn-applies-thinking-default.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveSubagentThinkingOverride } from "./subagent-spawn-thinking.js";
 
-type ThinkingLevel = "high" | "medium" | "low";
+type ThinkingLevel = "high" | "medium" | "low" | "off";
 
 function expectResolvedThinkingPlan(input: {
   expected: ThinkingLevel;
@@ -79,6 +79,32 @@ describe("sessions_spawn thinking defaults", () => {
     expectResolvedThinkingPlan({
       callerThinkingRaw: "medium",
       expected: "high",
+    });
+  });
+
+  it("preserves caller thinking off when inherited", () => {
+    expectResolvedThinkingPlan({
+      cfg: {
+        session: { mainKey: "main", scope: "per-sender" },
+        agents: { defaults: {} },
+      } as OpenClawConfig,
+      callerThinkingRaw: "off",
+      expected: "off",
+    });
+  });
+
+  it("preserves explicit thinking off", () => {
+    expectResolvedThinkingPlan({
+      thinkingOverrideRaw: "off",
+      expected: "off",
+    });
+  });
+
+  it("preserves configured subagent thinking off", () => {
+    expectResolvedThinkingPlan({
+      targetAgentConfig: { subagents: { thinking: "off" } },
+      callerThinkingRaw: "high",
+      expected: "off",
     });
   });
 });

--- a/src/agents/openclaw-tools.subagents.sessions-spawn-applies-thinking-default.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn-applies-thinking-default.test.ts
@@ -8,6 +8,7 @@ function expectResolvedThinkingPlan(input: {
   expected: ThinkingLevel;
   thinkingOverrideRaw?: string;
   callerThinkingRaw?: string;
+  requesterAgentConfig?: unknown;
   targetAgentConfig?: unknown;
   cfg?: OpenClawConfig;
 }) {
@@ -20,6 +21,7 @@ function expectResolvedThinkingPlan(input: {
 
   const plan = resolveSubagentThinkingOverride({
     cfg,
+    requesterAgentConfig: input.requesterAgentConfig,
     targetAgentConfig: input.targetAgentConfig,
     thinkingOverrideRaw: input.thinkingOverrideRaw,
     callerThinkingRaw: input.callerThinkingRaw,
@@ -50,6 +52,15 @@ describe("sessions_spawn thinking defaults", () => {
     expectResolvedThinkingPlan({
       targetAgentConfig: { subagents: { thinking: "medium" } },
       expected: "medium",
+    });
+  });
+
+  it("prefers requester-agent subagent thinking over target-agent subagent thinking", () => {
+    expectResolvedThinkingPlan({
+      requesterAgentConfig: { subagents: { thinking: "low" } },
+      targetAgentConfig: { subagents: { thinking: "medium" } },
+      callerThinkingRaw: "high",
+      expected: "low",
     });
   });
 

--- a/src/agents/openclaw-tools.subagents.sessions-spawn-applies-thinking-default.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn-applies-thinking-default.test.ts
@@ -7,15 +7,22 @@ type ThinkingLevel = "high" | "medium" | "low";
 function expectResolvedThinkingPlan(input: {
   expected: ThinkingLevel;
   thinkingOverrideRaw?: string;
+  callerThinkingRaw?: string;
+  targetAgentConfig?: unknown;
+  cfg?: OpenClawConfig;
 }) {
-  const cfg = {
-    session: { mainKey: "main", scope: "per-sender" },
-    agents: { defaults: { subagents: { thinking: "high" } } },
-  } as OpenClawConfig;
+  const cfg =
+    input.cfg ??
+    ({
+      session: { mainKey: "main", scope: "per-sender" },
+      agents: { defaults: { subagents: { thinking: "high" } } },
+    } as OpenClawConfig);
 
   const plan = resolveSubagentThinkingOverride({
     cfg,
+    targetAgentConfig: input.targetAgentConfig,
     thinkingOverrideRaw: input.thinkingOverrideRaw,
+    callerThinkingRaw: input.callerThinkingRaw,
   });
 
   expect(plan).toEqual({
@@ -36,6 +43,31 @@ describe("sessions_spawn thinking defaults", () => {
     expectResolvedThinkingPlan({
       thinkingOverrideRaw: "low",
       expected: "low",
+    });
+  });
+
+  it("prefers per-agent subagent thinking over global subagent thinking", () => {
+    expectResolvedThinkingPlan({
+      targetAgentConfig: { subagents: { thinking: "medium" } },
+      expected: "medium",
+    });
+  });
+
+  it("inherits caller thinking when no explicit or configured subagent thinking exists", () => {
+    expectResolvedThinkingPlan({
+      cfg: {
+        session: { mainKey: "main", scope: "per-sender" },
+        agents: { defaults: {} },
+      } as OpenClawConfig,
+      callerThinkingRaw: "medium",
+      expected: "medium",
+    });
+  });
+
+  it("prefers global subagent thinking over caller thinking", () => {
+    expectResolvedThinkingPlan({
+      callerThinkingRaw: "medium",
+      expected: "high",
     });
   });
 });

--- a/src/agents/openclaw-tools.subagents.sessions-spawn-applies-thinking-default.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn-applies-thinking-default.test.ts
@@ -6,6 +6,7 @@ type ThinkingLevel = "high" | "medium" | "low" | "off";
 
 function expectResolvedThinkingPlan(input: {
   expected: ThinkingLevel;
+  expectedOverride?: ThinkingLevel | null;
   thinkingOverrideRaw?: string;
   callerThinkingRaw?: string;
   requesterAgentConfig?: unknown;
@@ -29,7 +30,8 @@ function expectResolvedThinkingPlan(input: {
 
   expect(plan).toEqual({
     status: "ok",
-    thinkingOverride: input.expected,
+    thinkingOverride:
+      input.expectedOverride === null ? undefined : (input.expectedOverride ?? input.expected),
     initialSessionPatch: { thinkingLevel: input.expected },
   });
 }
@@ -72,6 +74,7 @@ describe("sessions_spawn thinking defaults", () => {
       } as OpenClawConfig,
       callerThinkingRaw: "medium",
       expected: "medium",
+      expectedOverride: null,
     });
   });
 
@@ -90,6 +93,7 @@ describe("sessions_spawn thinking defaults", () => {
       } as OpenClawConfig,
       callerThinkingRaw: "off",
       expected: "off",
+      expectedOverride: null,
     });
   });
 

--- a/src/agents/subagent-spawn-plan.ts
+++ b/src/agents/subagent-spawn-plan.ts
@@ -42,6 +42,7 @@ export function resolveConfiguredSubagentRunTimeoutSeconds(params: {
 export function resolveSubagentModelAndThinkingPlan(params: {
   cfg: OpenClawConfig;
   targetAgentId: string;
+  requesterAgentConfig?: unknown;
   targetAgentConfig?: unknown;
   modelOverride?: string;
   thinkingOverrideRaw?: string;
@@ -55,6 +56,7 @@ export function resolveSubagentModelAndThinkingPlan(params: {
 
   const thinkingPlan = resolveSubagentThinkingOverride({
     cfg: params.cfg,
+    requesterAgentConfig: params.requesterAgentConfig,
     targetAgentConfig: params.targetAgentConfig,
     thinkingOverrideRaw: params.thinkingOverrideRaw,
     callerThinkingRaw: params.callerThinkingRaw,

--- a/src/agents/subagent-spawn-plan.ts
+++ b/src/agents/subagent-spawn-plan.ts
@@ -45,6 +45,7 @@ export function resolveSubagentModelAndThinkingPlan(params: {
   targetAgentConfig?: unknown;
   modelOverride?: string;
   thinkingOverrideRaw?: string;
+  callerThinkingRaw?: string;
 }) {
   const resolvedModel = resolveSubagentSpawnModelSelection({
     cfg: params.cfg,
@@ -56,6 +57,7 @@ export function resolveSubagentModelAndThinkingPlan(params: {
     cfg: params.cfg,
     targetAgentConfig: params.targetAgentConfig,
     thinkingOverrideRaw: params.thinkingOverrideRaw,
+    callerThinkingRaw: params.callerThinkingRaw,
   });
   if (thinkingPlan.status === "error") {
     const { provider, model } = splitModelRef(resolvedModel);

--- a/src/agents/subagent-spawn-thinking.ts
+++ b/src/agents/subagent-spawn-thinking.ts
@@ -48,7 +48,7 @@ export function resolveSubagentThinkingOverride(params: {
     status: "ok" as const,
     thinkingOverride: normalizedThinking,
     initialSessionPatch: {
-      thinkingLevel: normalizedThinking === "off" ? null : normalizedThinking,
+      thinkingLevel: normalizedThinking,
     },
   };
 }

--- a/src/agents/subagent-spawn-thinking.ts
+++ b/src/agents/subagent-spawn-thinking.ts
@@ -9,16 +9,22 @@ function readString(value: Record<string, unknown>, key: string): string | undef
 
 export function resolveSubagentThinkingOverride(params: {
   cfg: OpenClawConfig;
+  requesterAgentConfig?: unknown;
   targetAgentConfig?: unknown;
   thinkingOverrideRaw?: string;
   callerThinkingRaw?: string;
 }) {
+  const requesterSubagents = asOptionalObjectRecord(
+    asOptionalObjectRecord(params.requesterAgentConfig)?.subagents,
+  );
   const targetSubagents = asOptionalObjectRecord(
     asOptionalObjectRecord(params.targetAgentConfig)?.subagents,
   );
   const defaultSubagents = asOptionalObjectRecord(params.cfg.agents?.defaults?.subagents);
   const resolvedThinkingDefaultRaw =
-    readString(targetSubagents ?? {}, "thinking") ?? readString(defaultSubagents ?? {}, "thinking");
+    readString(requesterSubagents ?? {}, "thinking") ??
+    readString(targetSubagents ?? {}, "thinking") ??
+    readString(defaultSubagents ?? {}, "thinking");
 
   const thinkingCandidateRaw =
     params.thinkingOverrideRaw || resolvedThinkingDefaultRaw || params.callerThinkingRaw;

--- a/src/agents/subagent-spawn-thinking.ts
+++ b/src/agents/subagent-spawn-thinking.ts
@@ -26,9 +26,26 @@ export function resolveSubagentThinkingOverride(params: {
     readString(targetSubagents ?? {}, "thinking") ??
     readString(defaultSubagents ?? {}, "thinking");
 
-  const thinkingCandidateRaw =
-    params.thinkingOverrideRaw || resolvedThinkingDefaultRaw || params.callerThinkingRaw;
-  if (!thinkingCandidateRaw) {
+  const overrideCandidateRaw = params.thinkingOverrideRaw || resolvedThinkingDefaultRaw;
+  if (overrideCandidateRaw) {
+    const normalizedThinking = normalizeThinkLevel(overrideCandidateRaw);
+    if (!normalizedThinking) {
+      return {
+        status: "error" as const,
+        thinkingCandidateRaw: overrideCandidateRaw,
+      };
+    }
+
+    return {
+      status: "ok" as const,
+      thinkingOverride: normalizedThinking,
+      initialSessionPatch: {
+        thinkingLevel: normalizedThinking,
+      },
+    };
+  }
+
+  if (!params.callerThinkingRaw) {
     return {
       status: "ok" as const,
       thinkingOverride: undefined,
@@ -36,17 +53,18 @@ export function resolveSubagentThinkingOverride(params: {
     };
   }
 
-  const normalizedThinking = normalizeThinkLevel(thinkingCandidateRaw);
+  const normalizedThinking = normalizeThinkLevel(params.callerThinkingRaw);
   if (!normalizedThinking) {
     return {
-      status: "error" as const,
-      thinkingCandidateRaw,
+      status: "ok" as const,
+      thinkingOverride: undefined,
+      initialSessionPatch: {},
     };
   }
 
   return {
     status: "ok" as const,
-    thinkingOverride: normalizedThinking,
+    thinkingOverride: undefined,
     initialSessionPatch: {
       thinkingLevel: normalizedThinking,
     },

--- a/src/agents/subagent-spawn-thinking.ts
+++ b/src/agents/subagent-spawn-thinking.ts
@@ -11,6 +11,7 @@ export function resolveSubagentThinkingOverride(params: {
   cfg: OpenClawConfig;
   targetAgentConfig?: unknown;
   thinkingOverrideRaw?: string;
+  callerThinkingRaw?: string;
 }) {
   const targetSubagents = asOptionalObjectRecord(
     asOptionalObjectRecord(params.targetAgentConfig)?.subagents,
@@ -19,7 +20,8 @@ export function resolveSubagentThinkingOverride(params: {
   const resolvedThinkingDefaultRaw =
     readString(targetSubagents ?? {}, "thinking") ?? readString(defaultSubagents ?? {}, "thinking");
 
-  const thinkingCandidateRaw = params.thinkingOverrideRaw || resolvedThinkingDefaultRaw;
+  const thinkingCandidateRaw =
+    params.thinkingOverrideRaw || resolvedThinkingDefaultRaw || params.callerThinkingRaw;
   if (!thinkingCandidateRaw) {
     return {
       status: "ok" as const,

--- a/src/agents/subagent-spawn.runtime.ts
+++ b/src/agents/subagent-spawn.runtime.ts
@@ -3,7 +3,7 @@ export {
   DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH,
 } from "../config/agent-limits.js";
 export { getRuntimeConfig } from "../config/config.js";
-export { mergeSessionEntry, updateSessionStore } from "../config/sessions.js";
+export { loadSessionStore, mergeSessionEntry, updateSessionStore } from "../config/sessions.js";
 export {
   forkSessionFromParent,
   resolveParentForkDecision,

--- a/src/agents/subagent-spawn.test-helpers.ts
+++ b/src/agents/subagent-spawn.test-helpers.ts
@@ -122,6 +122,7 @@ export function expectPersistedRuntimeModel(params: {
 export async function loadSubagentSpawnModuleForTest(params: {
   callGatewayMock: MockFn;
   getRuntimeConfig?: () => Record<string, unknown>;
+  loadSessionStoreMock?: MockFn;
   ensureContextEnginesInitializedMock?: MockFn;
   updateSessionStoreMock?: MockFn;
   forkSessionFromParentMock?: MockFn;
@@ -211,6 +212,7 @@ export async function loadSubagentSpawnModuleForTest(params: {
     getRuntimeConfig: () =>
       params.getRuntimeConfig?.() ??
       createSubagentSpawnTestConfig(params.workspaceDir ?? os.tmpdir()),
+    loadSessionStore: params.loadSessionStoreMock ?? (() => ({})),
     ensureContextEnginesInitialized:
       params.ensureContextEnginesInitializedMock ?? (() => undefined),
     resolveContextEngine: params.resolveContextEngineMock ?? (async () => ({})),

--- a/src/agents/subagent-spawn.test.ts
+++ b/src/agents/subagent-spawn.test.ts
@@ -352,6 +352,106 @@ describe("spawnSubagentDirect seam flow", () => {
     expect(persistedStore?.[childSessionKey]?.thinkingLevel).toBe("high");
   });
 
+  it("inherits requester selected-model thinking when caller session has no stored thinking", async () => {
+    let persistedStore: Record<string, Record<string, unknown>> | undefined;
+    hoisted.configOverride = createConfigOverride({
+      agents: {
+        defaults: {
+          workspace: os.tmpdir(),
+          models: {
+            "openai-codex/gpt-5.4": {
+              params: {
+                thinking: "low",
+              },
+            },
+          },
+        },
+        list: [
+          {
+            id: "main",
+            workspace: "/tmp/workspace-main",
+            thinkingDefault: "high",
+          },
+        ],
+      },
+    });
+    hoisted.loadSessionStoreMock.mockReturnValue({
+      "agent:main:main": {
+        providerOverride: "openai-codex",
+        modelOverride: "gpt-5.4",
+        modelProvider: "anthropic",
+        model: "claude-opus-4-7",
+      },
+    });
+    installSessionStoreCaptureMock(hoisted.updateSessionStoreMock, {
+      onStore: (store) => {
+        persistedStore = store;
+      },
+    });
+
+    const result = await spawnSubagentDirect(
+      {
+        task: "inherit selected model thinking",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    const childSessionKey = result.childSessionKey as string;
+    expect(persistedStore?.[childSessionKey]?.thinkingLevel).toBe("low");
+  });
+
+  it("inherits requester runtime-model thinking when caller session has no stored thinking", async () => {
+    let persistedStore: Record<string, Record<string, unknown>> | undefined;
+    hoisted.configOverride = createConfigOverride({
+      agents: {
+        defaults: {
+          workspace: os.tmpdir(),
+          models: {
+            "openai-codex/gpt-5.4": {
+              params: {
+                thinking: "low",
+              },
+            },
+          },
+        },
+        list: [
+          {
+            id: "main",
+            workspace: "/tmp/workspace-main",
+            thinkingDefault: "high",
+          },
+        ],
+      },
+    });
+    hoisted.loadSessionStoreMock.mockReturnValue({
+      "agent:main:main": {
+        modelProvider: "openai-codex",
+        model: "gpt-5.4",
+      },
+    });
+    installSessionStoreCaptureMock(hoisted.updateSessionStoreMock, {
+      onStore: (store) => {
+        persistedStore = store;
+      },
+    });
+
+    const result = await spawnSubagentDirect(
+      {
+        task: "inherit runtime model thinking",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    const childSessionKey = result.childSessionKey as string;
+    expect(persistedStore?.[childSessionKey]?.thinkingLevel).toBe("low");
+  });
+
   it("inherits global thinkingDefault when caller session and agent have no stored thinking", async () => {
     let persistedStore: Record<string, Record<string, unknown>> | undefined;
     hoisted.configOverride = createConfigOverride({

--- a/src/agents/subagent-spawn.test.ts
+++ b/src/agents/subagent-spawn.test.ts
@@ -288,6 +288,31 @@ describe("spawnSubagentDirect seam flow", () => {
     expect(persistedStore?.[childSessionKey]?.thinkingLevel).toBe("high");
   });
 
+  it("persists inherited requester thinking off", async () => {
+    let persistedStore: Record<string, Record<string, unknown>> | undefined;
+    hoisted.loadSessionStoreMock.mockReturnValue({
+      "agent:main:main": { thinkingLevel: "off" },
+    });
+    installSessionStoreCaptureMock(hoisted.updateSessionStoreMock, {
+      onStore: (store) => {
+        persistedStore = store;
+      },
+    });
+
+    const result = await spawnSubagentDirect(
+      {
+        task: "inherit thinking off",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    const childSessionKey = result.childSessionKey as string;
+    expect(persistedStore?.[childSessionKey]?.thinkingLevel).toBe("off");
+  });
+
   it("applies requester-agent subagent thinking before caller session thinking", async () => {
     let persistedStore: Record<string, Record<string, unknown>> | undefined;
     hoisted.configOverride = createConfigOverride({

--- a/src/agents/subagent-spawn.test.ts
+++ b/src/agents/subagent-spawn.test.ts
@@ -313,6 +313,130 @@ describe("spawnSubagentDirect seam flow", () => {
     expect(persistedStore?.[childSessionKey]?.thinkingLevel).toBe("off");
   });
 
+  it("inherits requester agent thinkingDefault when the caller session has no stored thinking", async () => {
+    let persistedStore: Record<string, Record<string, unknown>> | undefined;
+    hoisted.configOverride = createConfigOverride({
+      agents: {
+        defaults: {
+          workspace: os.tmpdir(),
+        },
+        list: [
+          {
+            id: "main",
+            workspace: "/tmp/workspace-main",
+            thinkingDefault: "high",
+          },
+        ],
+      },
+    });
+    hoisted.loadSessionStoreMock.mockReturnValue({
+      "agent:main:main": {},
+    });
+    installSessionStoreCaptureMock(hoisted.updateSessionStoreMock, {
+      onStore: (store) => {
+        persistedStore = store;
+      },
+    });
+
+    const result = await spawnSubagentDirect(
+      {
+        task: "inherit agent thinking default",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    const childSessionKey = result.childSessionKey as string;
+    expect(persistedStore?.[childSessionKey]?.thinkingLevel).toBe("high");
+  });
+
+  it("inherits global thinkingDefault when caller session and agent have no stored thinking", async () => {
+    let persistedStore: Record<string, Record<string, unknown>> | undefined;
+    hoisted.configOverride = createConfigOverride({
+      agents: {
+        defaults: {
+          workspace: os.tmpdir(),
+          thinkingDefault: "medium",
+        },
+        list: [
+          {
+            id: "main",
+            workspace: "/tmp/workspace-main",
+          },
+        ],
+      },
+    });
+    hoisted.loadSessionStoreMock.mockReturnValue({
+      "agent:main:main": {},
+    });
+    installSessionStoreCaptureMock(hoisted.updateSessionStoreMock, {
+      onStore: (store) => {
+        persistedStore = store;
+      },
+    });
+
+    const result = await spawnSubagentDirect(
+      {
+        task: "inherit global thinking default",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    const childSessionKey = result.childSessionKey as string;
+    expect(persistedStore?.[childSessionKey]?.thinkingLevel).toBe("medium");
+  });
+
+  it("inherits provider/model thinking default when no caller-specific default exists", async () => {
+    let persistedStore: Record<string, Record<string, unknown>> | undefined;
+    hoisted.configOverride = createConfigOverride({
+      agents: {
+        defaults: {
+          workspace: os.tmpdir(),
+          model: "openai-codex/gpt-5.4",
+          models: {
+            "openai-codex/gpt-5.4": {
+              params: {
+                thinking: "low",
+              },
+            },
+          },
+        },
+        list: [
+          {
+            id: "main",
+            workspace: "/tmp/workspace-main",
+          },
+        ],
+      },
+    });
+    hoisted.loadSessionStoreMock.mockReturnValue({
+      "agent:main:main": {},
+    });
+    installSessionStoreCaptureMock(hoisted.updateSessionStoreMock, {
+      onStore: (store) => {
+        persistedStore = store;
+      },
+    });
+
+    const result = await spawnSubagentDirect(
+      {
+        task: "inherit provider model thinking default",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    const childSessionKey = result.childSessionKey as string;
+    expect(persistedStore?.[childSessionKey]?.thinkingLevel).toBe("low");
+  });
+
   it("applies requester-agent subagent thinking before caller session thinking", async () => {
     let persistedStore: Record<string, Record<string, unknown>> | undefined;
     hoisted.configOverride = createConfigOverride({

--- a/src/agents/subagent-spawn.test.ts
+++ b/src/agents/subagent-spawn.test.ts
@@ -288,6 +288,47 @@ describe("spawnSubagentDirect seam flow", () => {
     expect(persistedStore?.[childSessionKey]?.thinkingLevel).toBe("high");
   });
 
+  it("applies requester-agent subagent thinking before caller session thinking", async () => {
+    let persistedStore: Record<string, Record<string, unknown>> | undefined;
+    hoisted.configOverride = createConfigOverride({
+      agents: {
+        defaults: {
+          workspace: os.tmpdir(),
+        },
+        list: [
+          {
+            id: "main",
+            workspace: "/tmp/workspace-main",
+            subagents: {
+              thinking: "medium",
+            },
+          },
+        ],
+      },
+    });
+    hoisted.loadSessionStoreMock.mockReturnValue({
+      "agent:main:main": { thinkingLevel: "high" },
+    });
+    installSessionStoreCaptureMock(hoisted.updateSessionStoreMock, {
+      onStore: (store) => {
+        persistedStore = store;
+      },
+    });
+
+    const result = await spawnSubagentDirect(
+      {
+        task: "requester policy thinking",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    const childSessionKey = result.childSessionKey as string;
+    expect(persistedStore?.[childSessionKey]?.thinkingLevel).toBe("medium");
+  });
+
   it("keeps controller ownership separate from completion ownership", async () => {
     await spawnSubagentDirect(
       {

--- a/src/agents/subagent-spawn.test.ts
+++ b/src/agents/subagent-spawn.test.ts
@@ -352,7 +352,7 @@ describe("spawnSubagentDirect seam flow", () => {
     expect(persistedStore?.[childSessionKey]?.thinkingLevel).toBe("high");
   });
 
-  it("inherits requester selected-model thinking when caller session has no stored thinking", async () => {
+  it("prefers requester agent thinkingDefault over selected-model thinking fallback", async () => {
     let persistedStore: Record<string, Record<string, unknown>> | undefined;
     hoisted.configOverride = createConfigOverride({
       agents: {
@@ -400,10 +400,60 @@ describe("spawnSubagentDirect seam flow", () => {
 
     expect(result.status).toBe("accepted");
     const childSessionKey = result.childSessionKey as string;
+    expect(persistedStore?.[childSessionKey]?.thinkingLevel).toBe("high");
+  });
+
+  it("inherits requester selected-model thinking when caller session has no stored thinking or agent default", async () => {
+    let persistedStore: Record<string, Record<string, unknown>> | undefined;
+    hoisted.configOverride = createConfigOverride({
+      agents: {
+        defaults: {
+          workspace: os.tmpdir(),
+          models: {
+            "openai-codex/gpt-5.4": {
+              params: {
+                thinking: "low",
+              },
+            },
+          },
+        },
+        list: [
+          {
+            id: "main",
+            workspace: "/tmp/workspace-main",
+          },
+        ],
+      },
+    });
+    hoisted.loadSessionStoreMock.mockReturnValue({
+      "agent:main:main": {
+        providerOverride: "openai-codex",
+        modelOverride: "gpt-5.4",
+        modelProvider: "anthropic",
+        model: "claude-opus-4-7",
+      },
+    });
+    installSessionStoreCaptureMock(hoisted.updateSessionStoreMock, {
+      onStore: (store) => {
+        persistedStore = store;
+      },
+    });
+
+    const result = await spawnSubagentDirect(
+      {
+        task: "inherit selected model thinking",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    const childSessionKey = result.childSessionKey as string;
     expect(persistedStore?.[childSessionKey]?.thinkingLevel).toBe("low");
   });
 
-  it("inherits requester runtime-model thinking when caller session has no stored thinking", async () => {
+  it("prefers requester agent thinkingDefault over runtime-model thinking fallback", async () => {
     let persistedStore: Record<string, Record<string, unknown>> | undefined;
     hoisted.configOverride = createConfigOverride({
       agents: {
@@ -422,6 +472,54 @@ describe("spawnSubagentDirect seam flow", () => {
             id: "main",
             workspace: "/tmp/workspace-main",
             thinkingDefault: "high",
+          },
+        ],
+      },
+    });
+    hoisted.loadSessionStoreMock.mockReturnValue({
+      "agent:main:main": {
+        modelProvider: "openai-codex",
+        model: "gpt-5.4",
+      },
+    });
+    installSessionStoreCaptureMock(hoisted.updateSessionStoreMock, {
+      onStore: (store) => {
+        persistedStore = store;
+      },
+    });
+
+    const result = await spawnSubagentDirect(
+      {
+        task: "inherit runtime model thinking",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    const childSessionKey = result.childSessionKey as string;
+    expect(persistedStore?.[childSessionKey]?.thinkingLevel).toBe("high");
+  });
+
+  it("inherits requester runtime-model thinking when caller session has no stored thinking or agent default", async () => {
+    let persistedStore: Record<string, Record<string, unknown>> | undefined;
+    hoisted.configOverride = createConfigOverride({
+      agents: {
+        defaults: {
+          workspace: os.tmpdir(),
+          models: {
+            "openai-codex/gpt-5.4": {
+              params: {
+                thinking: "low",
+              },
+            },
+          },
+        },
+        list: [
+          {
+            id: "main",
+            workspace: "/tmp/workspace-main",
           },
         ],
       },

--- a/src/agents/subagent-spawn.test.ts
+++ b/src/agents/subagent-spawn.test.ts
@@ -10,6 +10,7 @@ import { installAcceptedSubagentGatewayMock } from "./test-helpers/subagent-gate
 
 const hoisted = vi.hoisted(() => ({
   callGatewayMock: vi.fn(),
+  loadSessionStoreMock: vi.fn(),
   updateSessionStoreMock: vi.fn(),
   pruneLegacyStoreKeysMock: vi.fn(),
   registerSubagentRunMock: vi.fn(),
@@ -63,6 +64,7 @@ describe("spawnSubagentDirect seam flow", () => {
     ({ resetSubagentRegistryForTests, spawnSubagentDirect } = await loadSubagentSpawnModuleForTest({
       callGatewayMock: hoisted.callGatewayMock,
       getRuntimeConfig: () => hoisted.configOverride,
+      loadSessionStoreMock: hoisted.loadSessionStoreMock,
       updateSessionStoreMock: hoisted.updateSessionStoreMock,
       pruneLegacyStoreKeysMock: hoisted.pruneLegacyStoreKeysMock,
       registerSubagentRunMock: hoisted.registerSubagentRunMock,
@@ -78,6 +80,7 @@ describe("spawnSubagentDirect seam flow", () => {
   beforeEach(() => {
     resetSubagentRegistryForTests();
     hoisted.callGatewayMock.mockReset();
+    hoisted.loadSessionStoreMock.mockReset();
     hoisted.updateSessionStoreMock.mockReset();
     hoisted.pruneLegacyStoreKeysMock.mockReset();
     hoisted.registerSubagentRunMock.mockReset();
@@ -89,6 +92,7 @@ describe("spawnSubagentDirect seam flow", () => {
     );
     hoisted.configOverride = createConfigOverride();
     installAcceptedSubagentGatewayMock(hoisted.callGatewayMock);
+    hoisted.loadSessionStoreMock.mockReturnValue({});
 
     hoisted.updateSessionStoreMock.mockImplementation(
       async (
@@ -257,6 +261,31 @@ describe("spawnSubagentDirect seam flow", () => {
     const agentParams = requireRecord(agentRequest.params);
     expect(agentParams.sessionKey).toBe(childSessionKey);
     expect(agentParams.cleanupBundleMcpOnRunEnd).toBe(true);
+  });
+
+  it("inherits requester thinking level when no spawn or subagent default is configured", async () => {
+    let persistedStore: Record<string, Record<string, unknown>> | undefined;
+    hoisted.loadSessionStoreMock.mockReturnValue({
+      "agent:main:main": { thinkingLevel: "high" },
+    });
+    installSessionStoreCaptureMock(hoisted.updateSessionStoreMock, {
+      onStore: (store) => {
+        persistedStore = store;
+      },
+    });
+
+    const result = await spawnSubagentDirect(
+      {
+        task: "inherit thinking",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    const childSessionKey = result.childSessionKey as string;
+    expect(persistedStore?.[childSessionKey]?.thinkingLevel).toBe("high");
   });
 
   it("keeps controller ownership separate from completion ownership", async () => {

--- a/src/agents/subagent-spawn.test.ts
+++ b/src/agents/subagent-spawn.test.ts
@@ -352,6 +352,45 @@ describe("spawnSubagentDirect seam flow", () => {
     expect(persistedStore?.[childSessionKey]?.thinkingLevel).toBe("high");
   });
 
+  it("falls back to requester agent thinkingDefault when caller session store cannot be read", async () => {
+    let persistedStore: Record<string, Record<string, unknown>> | undefined;
+    hoisted.configOverride = createConfigOverride({
+      agents: {
+        defaults: {
+          workspace: os.tmpdir(),
+        },
+        list: [
+          {
+            id: "main",
+            workspace: "/tmp/workspace-main",
+            thinkingDefault: "high",
+          },
+        ],
+      },
+    });
+    hoisted.loadSessionStoreMock.mockImplementation(() => {
+      throw new Error("store unavailable");
+    });
+    installSessionStoreCaptureMock(hoisted.updateSessionStoreMock, {
+      onStore: (store) => {
+        persistedStore = store;
+      },
+    });
+
+    const result = await spawnSubagentDirect(
+      {
+        task: "inherit agent thinking default without session store",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    const childSessionKey = result.childSessionKey as string;
+    expect(persistedStore?.[childSessionKey]?.thinkingLevel).toBe("high");
+  });
+
   it("prefers requester agent thinkingDefault over selected-model thinking fallback", async () => {
     let persistedStore: Record<string, Record<string, unknown>> | undefined;
     hoisted.configOverride = createConfigOverride({

--- a/src/agents/subagent-spawn.test.ts
+++ b/src/agents/subagent-spawn.test.ts
@@ -878,6 +878,41 @@ describe("spawnSubagentDirect seam flow", () => {
     expect(params.thinking).toBe("high");
   });
 
+  it("does not forward inherited requester thinking as an explicit agent override", async () => {
+    const calls: Array<{ method?: string; params?: unknown }> = [];
+    hoisted.callGatewayMock.mockImplementation(
+      async (request: { method?: string; params?: unknown }) => {
+        calls.push(request);
+        if (request.method === "agent") {
+          return { runId: "run-inherited-thinking", status: "accepted", acceptedAt: 1000 };
+        }
+        if (request.method?.startsWith("sessions.")) {
+          return { ok: true };
+        }
+        return {};
+      },
+    );
+    hoisted.loadSessionStoreMock.mockReturnValue({
+      "agent:main:main": { thinkingLevel: "xhigh" },
+    });
+    installSessionStoreCaptureMock(hoisted.updateSessionStoreMock);
+
+    const result = await spawnSubagentDirect(
+      {
+        task: "verify inherited thinking is session state",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+        agentChannel: "discord",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    const agentCall = calls.find((call) => call.method === "agent");
+    const params = requireRecord(agentCall?.params);
+    expect(params.thinking).toBeUndefined();
+  });
+
   it("does not duplicate long subagent task text in the initial user message (#72019)", async () => {
     const calls: Array<{ method?: string; params?: unknown }> = [];
     hoisted.callGatewayMock.mockImplementation(

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -40,7 +40,11 @@ import {
   normalizeInheritedToolAllowlist,
   normalizeInheritedToolDenylist,
 } from "./inherited-tool-deny.js";
-import { resolveDefaultModelForAgent } from "./model-selection.js";
+import {
+  normalizeStoredOverrideModel,
+  resolveDefaultModelForAgent,
+  resolvePersistedSelectedModelRef,
+} from "./model-selection.js";
 import { resolveThinkingDefault } from "./model-thinking-default.js";
 import {
   mapToolContextToSpawnedRunMetadata,
@@ -385,16 +389,36 @@ function readRequesterThinkingLevel(params: {
     if (typeof entry?.thinkingLevel === "string" && entry.thinkingLevel.trim()) {
       return entry.thinkingLevel.trim();
     }
+    const defaultModel = resolveDefaultModelForAgent({
+      cfg: params.cfg,
+      agentId: params.requesterAgentId,
+    });
+    if (entry) {
+      const normalizedOverride = normalizeStoredOverrideModel({
+        providerOverride: entry.providerOverride,
+        modelOverride: entry.modelOverride,
+      });
+      const persistedModel = resolvePersistedSelectedModelRef({
+        defaultProvider: defaultModel.provider,
+        runtimeProvider: entry.modelProvider,
+        runtimeModel: entry.model,
+        overrideProvider: normalizedOverride.providerOverride,
+        overrideModel: normalizedOverride.modelOverride,
+      });
+      if (persistedModel) {
+        return resolveThinkingDefault({
+          cfg: params.cfg,
+          provider: persistedModel.provider,
+          model: persistedModel.model,
+        });
+      }
+    }
     const requesterAgentThinking = params.requesterAgentId
       ? resolveAgentConfig(params.cfg, params.requesterAgentId)?.thinkingDefault
       : undefined;
     if (requesterAgentThinking) {
       return requesterAgentThinking;
     }
-    const defaultModel = resolveDefaultModelForAgent({
-      cfg: params.cfg,
-      agentId: params.requesterAgentId,
-    });
     return resolveThinkingDefault({
       cfg: params.cfg,
       provider: defaultModel.provider,

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -40,6 +40,8 @@ import {
   normalizeInheritedToolAllowlist,
   normalizeInheritedToolDenylist,
 } from "./inherited-tool-deny.js";
+import { resolveDefaultModelForAgent } from "./model-selection.js";
+import { resolveThinkingDefault } from "./model-thinking-default.js";
 import {
   mapToolContextToSpawnedRunMetadata,
   normalizeSpawnedRunMetadata,
@@ -371,6 +373,7 @@ function resolveStoreEntryByKeys(
 function readRequesterThinkingLevel(params: {
   cfg: OpenClawConfig;
   requesterInternalKey: string;
+  requesterAgentId?: string;
 }): string | undefined {
   try {
     const target = resolveGatewaySessionStoreTarget({
@@ -379,9 +382,24 @@ function readRequesterThinkingLevel(params: {
     });
     const store = loadSessionStore(target.storePath, { clone: false });
     const entry = resolveStoreEntryByKeys(store, target.storeKeys);
-    return typeof entry?.thinkingLevel === "string" && entry.thinkingLevel.trim()
-      ? entry.thinkingLevel.trim()
+    if (typeof entry?.thinkingLevel === "string" && entry.thinkingLevel.trim()) {
+      return entry.thinkingLevel.trim();
+    }
+    const requesterAgentThinking = params.requesterAgentId
+      ? resolveAgentConfig(params.cfg, params.requesterAgentId)?.thinkingDefault
       : undefined;
+    if (requesterAgentThinking) {
+      return requesterAgentThinking;
+    }
+    const defaultModel = resolveDefaultModelForAgent({
+      cfg: params.cfg,
+      agentId: params.requesterAgentId,
+    });
+    return resolveThinkingDefault({
+      cfg: params.cfg,
+      provider: defaultModel.provider,
+      model: defaultModel.model,
+    });
   } catch {
     return undefined;
   }
@@ -1213,6 +1231,7 @@ export async function spawnSubagentDirect(
   const callerThinkingRaw = readRequesterThinkingLevel({
     cfg,
     requesterInternalKey,
+    requesterAgentId,
   });
   const plan = resolveSubagentModelAndThinkingPlan({
     cfg,

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -81,6 +81,7 @@ import {
   getGlobalHookRunner,
   getSessionBindingService,
   getRuntimeConfig,
+  loadSessionStore,
   mergeSessionEntry,
   mergeDeliveryContext,
   normalizeDeliveryContext,
@@ -365,6 +366,25 @@ function resolveStoreEntryByKeys(
     }
   }
   return undefined;
+}
+
+function readRequesterThinkingLevel(params: {
+  cfg: OpenClawConfig;
+  requesterInternalKey: string;
+}): string | undefined {
+  try {
+    const target = resolveGatewaySessionStoreTarget({
+      cfg: params.cfg,
+      key: params.requesterInternalKey,
+    });
+    const store = loadSessionStore(target.storePath, { clone: false });
+    const entry = resolveStoreEntryByKeys(store, target.storeKeys);
+    return typeof entry?.thinkingLevel === "string" && entry.thinkingLevel.trim()
+      ? entry.thinkingLevel.trim()
+      : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 type PreparedSpawnContext =
@@ -1189,12 +1209,17 @@ export async function spawnSubagentDirect(
   });
   const targetAgentDir = resolveAgentDir(cfg, targetAgentId);
   const targetAgentConfig = resolveAgentConfig(cfg, targetAgentId);
+  const callerThinkingRaw = readRequesterThinkingLevel({
+    cfg,
+    requesterInternalKey,
+  });
   const plan = resolveSubagentModelAndThinkingPlan({
     cfg,
     targetAgentId,
     targetAgentConfig,
     modelOverride,
     thinkingOverrideRaw,
+    callerThinkingRaw,
   });
   if (plan.status === "error") {
     return {

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -379,54 +379,55 @@ function readRequesterThinkingLevel(params: {
   requesterInternalKey: string;
   requesterAgentId?: string;
 }): string | undefined {
+  let entry: SessionEntry | undefined;
   try {
     const target = resolveGatewaySessionStoreTarget({
       cfg: params.cfg,
       key: params.requesterInternalKey,
     });
     const store = loadSessionStore(target.storePath, { clone: false });
-    const entry = resolveStoreEntryByKeys(store, target.storeKeys);
-    if (typeof entry?.thinkingLevel === "string" && entry.thinkingLevel.trim()) {
-      return entry.thinkingLevel.trim();
-    }
-    const requesterAgentThinking = params.requesterAgentId
-      ? resolveAgentConfig(params.cfg, params.requesterAgentId)?.thinkingDefault
-      : undefined;
-    if (requesterAgentThinking) {
-      return requesterAgentThinking;
-    }
-    const defaultModel = resolveDefaultModelForAgent({
-      cfg: params.cfg,
-      agentId: params.requesterAgentId,
-    });
-    if (entry) {
-      const normalizedOverride = normalizeStoredOverrideModel({
-        providerOverride: entry.providerOverride,
-        modelOverride: entry.modelOverride,
-      });
-      const persistedModel = resolvePersistedSelectedModelRef({
-        defaultProvider: defaultModel.provider,
-        runtimeProvider: entry.modelProvider,
-        runtimeModel: entry.model,
-        overrideProvider: normalizedOverride.providerOverride,
-        overrideModel: normalizedOverride.modelOverride,
-      });
-      if (persistedModel) {
-        return resolveThinkingDefault({
-          cfg: params.cfg,
-          provider: persistedModel.provider,
-          model: persistedModel.model,
-        });
-      }
-    }
-    return resolveThinkingDefault({
-      cfg: params.cfg,
-      provider: defaultModel.provider,
-      model: defaultModel.model,
-    });
+    entry = resolveStoreEntryByKeys(store, target.storeKeys);
   } catch {
-    return undefined;
+    entry = undefined;
   }
+  if (typeof entry?.thinkingLevel === "string" && entry.thinkingLevel.trim()) {
+    return entry.thinkingLevel.trim();
+  }
+  const requesterAgentThinking = params.requesterAgentId
+    ? resolveAgentConfig(params.cfg, params.requesterAgentId)?.thinkingDefault
+    : undefined;
+  if (requesterAgentThinking) {
+    return requesterAgentThinking;
+  }
+  const defaultModel = resolveDefaultModelForAgent({
+    cfg: params.cfg,
+    agentId: params.requesterAgentId,
+  });
+  if (entry) {
+    const normalizedOverride = normalizeStoredOverrideModel({
+      providerOverride: entry.providerOverride,
+      modelOverride: entry.modelOverride,
+    });
+    const persistedModel = resolvePersistedSelectedModelRef({
+      defaultProvider: defaultModel.provider,
+      runtimeProvider: entry.modelProvider,
+      runtimeModel: entry.model,
+      overrideProvider: normalizedOverride.providerOverride,
+      overrideModel: normalizedOverride.modelOverride,
+    });
+    if (persistedModel) {
+      return resolveThinkingDefault({
+        cfg: params.cfg,
+        provider: persistedModel.provider,
+        model: persistedModel.model,
+      });
+    }
+  }
+  return resolveThinkingDefault({
+    cfg: params.cfg,
+    provider: defaultModel.provider,
+    model: defaultModel.model,
+  });
 }
 
 type PreparedSpawnContext =

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -389,6 +389,12 @@ function readRequesterThinkingLevel(params: {
     if (typeof entry?.thinkingLevel === "string" && entry.thinkingLevel.trim()) {
       return entry.thinkingLevel.trim();
     }
+    const requesterAgentThinking = params.requesterAgentId
+      ? resolveAgentConfig(params.cfg, params.requesterAgentId)?.thinkingDefault
+      : undefined;
+    if (requesterAgentThinking) {
+      return requesterAgentThinking;
+    }
     const defaultModel = resolveDefaultModelForAgent({
       cfg: params.cfg,
       agentId: params.requesterAgentId,
@@ -412,12 +418,6 @@ function readRequesterThinkingLevel(params: {
           model: persistedModel.model,
         });
       }
-    }
-    const requesterAgentThinking = params.requesterAgentId
-      ? resolveAgentConfig(params.cfg, params.requesterAgentId)?.thinkingDefault
-      : undefined;
-    if (requesterAgentThinking) {
-      return requesterAgentThinking;
     }
     return resolveThinkingDefault({
       cfg: params.cfg,

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -1208,6 +1208,7 @@ export async function spawnSubagentDirect(
     maxSpawnDepth,
   });
   const targetAgentDir = resolveAgentDir(cfg, targetAgentId);
+  const requesterAgentConfig = resolveAgentConfig(cfg, requesterAgentId);
   const targetAgentConfig = resolveAgentConfig(cfg, targetAgentId);
   const callerThinkingRaw = readRequesterThinkingLevel({
     cfg,
@@ -1216,6 +1217,7 @@ export async function spawnSubagentDirect(
   const plan = resolveSubagentModelAndThinkingPlan({
     cfg,
     targetAgentId,
+    requesterAgentConfig,
     targetAgentConfig,
     modelOverride,
     thinkingOverrideRaw,


### PR DESCRIPTION
## Summary

This PR fixes subagent thinking defaults so a child spawned through sessions_spawn(runtime="subagent") can inherit the requester session's persisted thinking level when the spawn request and configured subagent defaults do not specify one.

- Intended outcome: subagents keep the caller's effective thinking behavior instead of silently falling back to a lower/default effort.
- Precedence remains explicit spawn thinking, requester agent subagent default, target agent subagent default, global subagent default, then requester-session fallback.
- Requester-session fallback resolves stored session thinking first, requester agent thinkingDefault second, and persisted selected/runtime/default-model thinking last.
- Existing explicit/configured thinking behavior remains unchanged.
- Out of scope: changing provider selection, model routing, or any live-provider execution semantics beyond the thinking default passed into the subagent session.
- Review focus: the fallback ordering in src/agents/subagent-spawn-thinking.ts, persisted child-session thinkingLevel, and the regression coverage around explicit/configured overrides.

## Linked context

Fixes #55790.

Related review context:
- martingarramon flagged an earlier PR-body fallback-order mismatch; the documented order now matches the implementation and test expectation.
- ClawSweeper previously requested stronger proof that native subagent spawning inherits thinking defaults.

Requested by a maintainer or owner:
- The original issue describes the bug. Follow-up review comments requested documentation/proof clarification, which this body keeps in the current template.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: sessions_spawn(runtime="subagent") preserves requester session thinking as the final fallback when explicit spawn thinking and configured subagent defaults are absent.
- Real environment tested: Local OpenClaw checkout on Linux; Raspberry Pi node pi-claw on aarch64 Linux; running OpenClaw gateway 2026.5.18 for the live native spawn proof.
- Exact steps or command run after this patch:
  - ./node_modules/.bin/vitest run src/agents/subagent-spawn.test.ts --config test/vitest/vitest.agents.config.ts
  - ./node_modules/.bin/vitest run src/agents/openclaw-tools.subagents.sessions-spawn-applies-thinking-default.test.ts --config test/vitest/vitest.unit-fast.config.ts
  - node scripts/test-projects.mjs src/agents/subagent-spawn.test.ts src/agents/openclaw-tools.subagents.sessions-spawn-applies-thinking-default.test.ts on pi-claw
  - Live gateway proof: call native sessions_spawn with runtime="subagent" and no thinking field, then inspect the child session status and trajectory.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):
  ~~~text
  $ git branch --show-current
  fix-subagent-thinking-defaults

  $ ./node_modules/.bin/vitest run src/agents/subagent-spawn.test.ts --config test/vitest/vitest.agents.config.ts
  Test Files  1 passed
  Tests       10 passed

  $ ./node_modules/.bin/vitest run src/agents/openclaw-tools.subagents.sessions-spawn-applies-thinking-default.test.ts --config test/vitest/vitest.unit-fast.config.ts
  Test Files  1 passed
  Tests       5 passed
  ~~~

  ~~~text
  pi-claw branch checkout proof:
  [test] starting test/vitest/vitest.unit-fast.config.ts
  src/agents/openclaw-tools.subagents.sessions-spawn-applies-thinking-default.test.ts
    6 tests passed

  [test] starting test/vitest/vitest.agents.config.ts
  src/agents/subagent-spawn.test.ts
    11 tests passed

  [test] passed 2 Vitest shards in 24.92s
  ~~~

  ~~~text
  Live native sessions_spawn proof:
  Parent session status:
  OpenClaw 2026.5.18
  Model: openai-codex/gpt-5.5
  Session: agent:main:dashboard:c0098499-aab4-4abe-a285-e866e299c320
  Execution: direct . Runtime: OpenAI Codex . Think: medium . Text: low

  sessions_spawn input:
  {
    "runtime": "subagent",
    "mode": "run",
    "taskName": "pr_84007_live_thinking_proof",
    "cleanup": "keep",
    "context": "isolated",
    "task": "Live proof for PR #84007. Reply exactly: PR_84007_CHILD_DONE"
  }

  sessions_spawn result:
  {
    "status": "accepted",
    "childSessionKey": "agent:main:subagent:6ba2b844-766e-40a5-9a9e-808364c22bef",
    "runId": "9592e938-8b19-4309-84cf-46bb60227c85",
    "mode": "run",
    "taskName": "pr_84007_live_thinking_proof",
    "modelApplied": true
  }

  Child session status:
  OpenClaw 2026.5.18
  Model: openai/gpt-5.5
  Session: agent:main:subagent:6ba2b844-766e-40a5-9a9e-808364c22bef
  Tasks: latest succeeded . subagent . Live proof for PR #84007. Reply exactly: PR_84007_CHILD_DONE
  Execution: direct . Runtime: OpenAI Codex . Think: medium . Text: low

  Child trajectory excerpts:
  session.started:
    sessionKey=agent:main:subagent:6ba2b844-766e-40a5-9a9e-808364c22bef
    runId=9592e938-8b19-4309-84cf-46bb60227c85
    provider=openai-codex
    modelId=gpt-5.5
    authProfileId=[REDACTED]

  model.completed:
    assistantTexts=["PR_84007_CHILD_DONE"]
    timedOut=false
    promptError=null
  ~~~
- Observed result after fix: The parent live session ran with Think: medium; the native subagent spawn omitted thinking; the child subagent also ran with Think: medium and completed the assigned task. The branch-checkout tests also verify explicit/configured thinking still takes precedence over inherited requester-session thinking, and the latest focused regression verifies requester agent thinkingDefault wins before selected/runtime model thinking fallback.
- What was not tested: A paid external model-provider call from the local test harness, and private auth profile values/full prompts were not included in public proof.
- Proof limitations or environment constraints: Live gateway proof redacts auth details and captures the native spawn/session behavior rather than exposing provider credentials. The later branch-head refinements are covered by focused regression tests and review comments.
- Before evidence (optional but encouraged): The pre-fix resolver had no requester-session thinking fallback path, so a parent session's persisted thinking level could be dropped unless repeated in spawn input or config.

## Tests and validation

Commands run for this PR:
- ./node_modules/.bin/vitest run src/agents/subagent-spawn.test.ts --config test/vitest/vitest.agents.config.ts
- ./node_modules/.bin/vitest run src/agents/openclaw-tools.subagents.sessions-spawn-applies-thinking-default.test.ts --config test/vitest/vitest.unit-fast.config.ts
- node scripts/test-projects.mjs src/agents/subagent-spawn.test.ts src/agents/openclaw-tools.subagents.sessions-spawn-applies-thinking-default.test.ts
- git diff --check upstream/main...HEAD
- git merge-tree --write-tree origin/fix-subagent-thinking-defaults upstream/main

Regression coverage added or updated:
- src/agents/openclaw-tools.subagents.sessions-spawn-applies-thinking-default.test.ts
- src/agents/subagent-spawn.test.ts
- Supporting spawn-plan/runtime/thinking helper coverage for precedence and persisted child-session thinkingLevel.


Latest validation after the requester thinkingDefault precedence repair and upstream merge:
- node scripts/run-vitest.mjs run --config test/vitest/vitest.full-agentic.config.ts src/agents/subagent-spawn.test.ts src/agents/openclaw-tools.subagents.sessions-spawn-applies-thinking-default.test.ts — passed, 40 tests.
- pnpm -s check:test-types — passed.
- git diff --check upstream/main...HEAD — passed.
- git merge-tree --write-tree HEAD upstream/main — clean.

What failed before this fix, if known:
- The subagent thinking resolver only handled explicit spawn input and configured subagent defaults. It did not receive requester session thinking, so omitted child thinking could lose the caller's persisted thinking level.

If no test was added, why not:
- Not applicable; focused regression coverage was added.

## Risk checklist

Did user-visible behavior change? (Yes/No)
- Yes. Subagents spawned without explicit/configured thinking can now inherit the requester session's thinking level.

Did config, environment, or migration behavior change? (Yes/No)
- No.

Did security, auth, secrets, network, or tool execution behavior change? (Yes/No)
- No.

What is the highest-risk area?
- Compatibility around thinking-precedence order and session-state fallback behavior.

How is that risk mitigated?
- Explicit spawn thinking and configured subagent defaults still take precedence. Tests cover requester-agent defaults, target-agent defaults, global defaults, inherited requester session thinking, and explicit/configured override behavior.

## Current review state

What is the next action?
- ClawSweeper re-review or maintainer review after commit 7e7f11775e. The latest code update aligns requester thinkingDefault before selected/runtime model fallback while preserving the existing explicit/configured subagent precedence.

What is still waiting on author, maintainer, CI, or external proof?
- Fresh ClawSweeper review is pending for the current head after this author-side code repair.

Which bot or reviewer comments were addressed?
- martingarramon's fallback-order documentation mismatch was corrected.
- ClawSweeper proof/validation requests and the requester thinkingDefault precedence finding were addressed with focused tests, Pi proof, live native sessions_spawn proof, and this current-template PR body.
