### PR TITLE
fix(cli): reject out-of-range port numbers in parsePort (#83900)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI: reject explicit port numbers above 65535 before they reach Gateway or Node bind paths. Fixes #83900. (#84008) Thanks @hclsys.
 - Codex app-server: preserve plugin tool auth profiles when Codex owns model transport so OpenClaw dynamic tools can resolve their provider credentials. (#83603) Thanks @rubencu.
 - Memory/search: scan the JS-side fallback vector path (used when the sqlite-vec index is unavailable or has a mismatched dimension) in bounded rowid batches and yield to the event loop between batches so large chunk tables can no longer pin the Node.js main thread for multi-second windows. Also keeps the SQL prepared statement rooted in a local so node:sqlite cannot finalize it mid-scan under heap pressure. Fixes #81172. Thanks @dev23xyz-oss.
 - Memory Wiki: preserve fs-safe diagnostics when bridge source page writes fail for non-symlink filesystem safety reasons, so directory collisions are reported with the underlying error code. (#83776) Thanks @TurboTheTurtle.

--- a/src/cli/shared/parse-port.test.ts
+++ b/src/cli/shared/parse-port.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { parsePort } from "./parse-port.js";
+
+describe("parsePort (#83900)", () => {
+  it("returns null for nullish inputs", () => {
+    expect(parsePort(undefined)).toBeNull();
+    expect(parsePort(null)).toBeNull();
+  });
+
+  it("returns null for zero and negative values (already enforced)", () => {
+    expect(parsePort(0)).toBeNull();
+    expect(parsePort(-1)).toBeNull();
+    expect(parsePort("0")).toBeNull();
+  });
+
+  it("accepts valid TCP port values", () => {
+    expect(parsePort(1)).toBe(1);
+    expect(parsePort(8080)).toBe(8080);
+    expect(parsePort("3000")).toBe(3000);
+    expect(parsePort(65535)).toBe(65535);
+  });
+
+  it("rejects port numbers above 65535 (regression for #83900)", () => {
+    expect(parsePort(65536)).toBeNull();
+    expect(parsePort(99999)).toBeNull();
+    expect(parsePort("100000")).toBeNull();
+    // Largest 16-bit value is the inclusive boundary.
+    expect(parsePort(65535)).toBe(65535);
+  });
+
+  it("rejects non-integer and non-finite inputs", () => {
+    expect(parsePort(1.5)).toBeNull();
+    expect(parsePort(Number.NaN)).toBeNull();
+    expect(parsePort(Number.POSITIVE_INFINITY)).toBeNull();
+    expect(parsePort("abc")).toBeNull();
+  });
+});

--- a/src/cli/shared/parse-port.ts
+++ b/src/cli/shared/parse-port.ts
@@ -1,8 +1,18 @@
 import { parseStrictPositiveInteger } from "../../infra/parse-finite-number.js";
 
+// TCP/UDP ports are 16-bit, so 65535 is the max. `parseStrictPositiveInteger`
+// only enforces positivity, so values like 99999 were returned as-is and
+// reached gateway-cli / node-cli bind paths; the OS then surfaced the error
+// instead of the CLI rejecting it cleanly at parse time. See #83900.
+const MAX_TCP_PORT = 65_535;
+
 export function parsePort(raw: unknown): number | null {
   if (raw === undefined || raw === null) {
     return null;
   }
-  return parseStrictPositiveInteger(raw) ?? null;
+  const parsed = parseStrictPositiveInteger(raw);
+  if (parsed === undefined || parsed > MAX_TCP_PORT) {
+    return null;
+  }
+  return parsed;
 }


### PR DESCRIPTION
Fixes #83900.

`parsePort` (`src/cli/shared/parse-port.ts`) delegated to `parseStrictPositiveInteger`, which only enforces positivity. Any value above 65535 — the 16-bit TCP/UDP maximum — was returned as-is and reached the gateway-cli / node-cli / daemon-cli bind paths. The OS then surfaced the error at bind/connect time instead of the CLI rejecting it cleanly at parse time. The function's documented contract (`number | null`) implied a valid port, but the implementation didn't enforce the upper bound.

## Changes

- `src/cli/shared/parse-port.ts`: introduce a `MAX_TCP_PORT = 65_535` constant and reject any `parseStrictPositiveInteger` result above it by returning `null` (the same shape callers already handle for zero, negative, NaN, and non-integer inputs).
- `src/cli/shared/parse-port.test.ts`: new file. 5 regression cases covering nullish inputs, zero/negative (already-enforced), the valid range including the inclusive 65535 boundary, the issue's exact `99999` and `100000` repros, and non-integer / non-finite / NaN inputs.

Diff stat: 2 files, +48 / -1.

## Real behavior proof

- **Behavior or issue addressed:** Sanitized issue evidence — `parsePort('99999')` returned `99999`, which then reached `gateway-cli/run.ts:531` (`portOverride = parsePort(opts.port)`) and `node-cli/daemon.ts:82` as a "valid" override. The OS-level bind error surfaces downstream instead of a clean CLI-level rejection.

- **Real environment tested:** Local Node 22.x. Probe at `/tmp/probe_83900.mjs` (a) parses the patched `parse-port.ts` and verifies the `MAX_TCP_PORT` constant + the guard shape (`parsed === undefined || parsed > MAX_TCP_PORT`) + the preserved nullish early-return, and (b) replays both the patched and pre-fix shapes against 11 fixtures: valid 1 / 8080 / 65535, the issue's exact 99999, the boundary 65536, zero, negative, nullish undefined/null, string-form valid `"3000"`, and string-form out-of-range `"100000"`. Confirms patched returns `null` for out-of-range and the buggy shape returned the raw out-of-range integer that would have reached bind/connect.

- **Exact steps or command run after this patch:** `node /tmp/probe_83900.mjs`

- **Evidence after fix:**

```
PASS: MAX_TCP_PORT constant declared (16-bit boundary)
PASS: guard rejects undefined OR values above MAX_TCP_PORT
PASS: nullish-input early-return preserved
PASS: replay: all 11 fixtures (in-range / out-of-range / nullish / string-form) match patched and buggy shapes correctly
PASS: issue repro: buggy(99999)=99999 (would reach bind/connect), patched(99999)=null (clean rejection)

ALL CASES PASS
```

- **Observed result after fix:** `openclaw gateway run --port 99999` (or any other CLI surface that pipes through `parsePort`) now treats out-of-range port input identically to other invalid inputs: `parsePort` returns `null`, and the caller's existing `?? defaultPort` / null-check path applies. No OS-level bind error from invalid 16-bit input.

- **What was not tested:** Live `openclaw gateway run --port 99999` smoke against an actual build — that requires `pnpm build`. The probe replays the predicate end-to-end against the issue's exact fixture, and the vitest regression test exercises the public `parsePort` contract directly.

## Audit (per CLAUDE rules — all 5 steps)

- **Existing-helper check:** Reuses the existing `parseStrictPositiveInteger` import; the new constant `MAX_TCP_PORT` is a single magic-number replacement for a well-known IANA value. No new helper. PASS
- **Shared-helper caller check:** `parsePort` has 4 production callers — `gateway-cli/run.ts:531`, `node-cli/daemon.ts:82`, `node-cli/register.ts:19`, `daemon-cli/install.ts`. All four read the result as `number | null` and apply a default-or-error fallback for `null`. Adding the upper bound strengthens the existing `null` contract; no caller signature change. PASS
- **Broader-fix rival scan:** `gh pr list --search '83900 in:title,body'` and `gh pr list --search 'parsePort in:title,body'` return no open PRs. PASS
- **Recent-merge audit:** `git log --oneline -5 -- src/cli/shared/parse-port.ts` shows `e1061a8b46 test(live): tolerate provider drift in release checks` — unrelated. PASS
- **Prototype-pollution scan:** N/A — single numeric comparison, no external-input key copying.
