### PR TITLE
fix(qqbot): deduplicate inbound messages by messageId in per-peer queue

### DIFF
--- a/extensions/qqbot/src/engine/gateway/message-queue.ts
+++ b/extensions/qqbot/src/engine/gateway/message-queue.ts
@@ -191,6 +191,13 @@ export function mergeGroupMessages(batch: QueuedMessage[]): QueuedMessage {
   };
 }
 
+/**
+ * Max number of recent message IDs kept per peer for duplicate detection.
+ * Sized to cover the worst-case burst from a gateway reconnect replay
+ * while staying small enough to not leak memory.
+ */
+const DEFAULT_DEDUP_CACHE_SIZE = 50;
+
 export function createMessageQueue(ctx: MessageQueueContext): MessageQueue {
   const { accountId: _accountId, log } = ctx;
   const globalQueueSize = ctx.globalQueueSize ?? DEFAULT_GLOBAL_QUEUE_SIZE;
@@ -200,6 +207,9 @@ export function createMessageQueue(ctx: MessageQueueContext): MessageQueue {
 
   const userQueues = new Map<string, QueuedMessage[]>();
   const activeUsers = new Set<string>();
+  /** Per-peer recent messageId dedup set — prevents duplicate enqueue
+   *  when the QQ gateway reconnects and replays recent events. */
+  const recentMessageIds = new Map<string, Set<string>>();
   let handleMessageFnRef: ((msg: QueuedMessage) => Promise<void>) | null = null;
   let totalEnqueued = 0;
 
@@ -308,6 +318,34 @@ export function createMessageQueue(ctx: MessageQueueContext): MessageQueue {
 
   const enqueue = (msg: QueuedMessage): void => {
     const peerId = getMessagePeerId(msg);
+
+    // Dedup: skip if we've seen this messageId for this peer recently.
+    // The QQ gateway may replay recent events on reconnect, and without
+    // this guard the same inbound message gets processed multiple times,
+    // producing duplicate outbound replies.
+    if (msg.messageId) {
+      let seen = recentMessageIds.get(peerId);
+      if (!seen) {
+        seen = new Set();
+        recentMessageIds.set(peerId, seen);
+      }
+      if (seen.has(msg.messageId)) {
+        log?.debug?.(
+          `Dropped duplicate message ${msg.messageId} for ${peerId}`,
+          { accountId: ctx.accountId, peerId, messageId: msg.messageId, reason: "recent_id_dedup" },
+        );
+        return;
+      }
+      seen.add(msg.messageId);
+      // Keep the set bounded — oldest entries are dropped when we exceed
+      // the limit. Since duplicates arrive in quick bursts (seconds),
+      // losing old IDs is safe.
+      if (seen.size > DEFAULT_DEDUP_CACHE_SIZE) {
+        // Re-create to shed all old entries in one O(n) sweep.
+        recentMessageIds.set(peerId, new Set([msg.messageId]));
+      }
+    }
+
     const isGroup = isGroupPeer(peerId);
 
     let queue = userQueues.get(peerId);


### PR DESCRIPTION
Fixes #77306

## 问题

QQ Bot 渠道消息重复发送。网关重连时 QQ API 会回放近期事件，同一条消息被多次入队并处理，导致多条重复回复。

## 修复

在 `createMessageQueue().enqueue()` 中增加按 peer 隔离的 `messageId` 去重缓存。同一 peer 的相同 `messageId` 在缓存有效期内再次到达时直接丢弃。

- 每 peer 缓存上限 50 条（`DEFAULT_DEDUP_CACHE_SIZE`），超限时重建集合
- 重复消息打 debug 日志，不影响正常流程
- 仅对含有效 `messageId` 的消息去重，不影响无 ID 的历史消息

## Real behavior proof

### behavior
QQ Bot 消息重复发送：`message_sending` hook 在 WebChat 历史回放时被触发，导致同一条回复反复朝 QQ API 重发。

### environment
OpenClaw with QQ Bot channel, Linux

### steps
1. PR #84011 改动代码审查
2. 确认 `enqueue()` 入口处新增 `recentMessageIds` 去重缓存
3. 重复的 `messageId` 在入队前被拦截，打 debug 日志后 `return`
4. 代码逻辑跟踪：`enqueue()` 第 326-347 行

### evidence
Code review of the fix in `extensions/qqbot/src/engine/gateway/message-queue.ts`:
- 新增 `recentMessageIds: Map<peerId, Set<messageId>>` 每 peer 独立跟踪
- `enqueue()` 入口：`if (seen.has(msg.messageId)) → return` 直接跳过
- 缓存上限 50 条/peer，超限重建集合
- 源码审查确认改动范围仅限此文件，+38 行，不影响其他逻辑

### observedResult
修改后，同一 peer 的相同 `messageId` 第二次到达时被 `seen.has()` 拦截，不会进入队列处理流程。日志输出 `Dropped duplicate message ${messageId} for ${peerId}`。

### notTested
未在实际运行的 QQ Bot 环境下端到端测试（无可用测试账号），但代码逻辑可直接验证：去重发生在队列入口处，不影响下游处理流程。