### PR TITLE
Emit WhatsApp Web health hook events

### DIFF
--- a/extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
+++ b/extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
@@ -6,7 +6,7 @@ import { escapeRegExp, formatEnvelopeTimestamp } from "openclaw/plugin-sdk/chann
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { setLoggerOverride } from "openclaw/plugin-sdk/runtime-env";
 import { withEnvAsync } from "openclaw/plugin-sdk/test-env";
-import { beforeAll, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { getActiveWebListener } from "./active-listener.js";
 import { WhatsAppAuthUnstableError, resolveWebCredsPath } from "./auth-store.js";
 import { resolveOAuthDir } from "./auth-store.runtime.js";
@@ -42,9 +42,37 @@ const deliveryQueueMocks = vi.hoisted(() => ({
   drainPendingDeliveries: vi.fn(async (_opts: unknown) => undefined),
 }));
 
+const internalHookMocks = vi.hoisted(() => ({
+  createInternalHookEvent: vi.fn(
+    (type: string, action: string, sessionKey: string, context: Record<string, unknown> = {}) => ({
+      type,
+      action,
+      sessionKey,
+      context,
+      timestamp: new Date(),
+      messages: [],
+    }),
+  ),
+  triggerInternalHook: vi.fn(async (_event: unknown) => undefined),
+}));
+
 vi.mock("openclaw/plugin-sdk/delivery-queue-runtime", () => ({
   drainPendingDeliveries: deliveryQueueMocks.drainPendingDeliveries,
 }));
+
+vi.mock("openclaw/plugin-sdk/hook-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/hook-runtime")>(
+    "openclaw/plugin-sdk/hook-runtime",
+  );
+  return {
+    ...actual,
+    createInternalHookEvent: internalHookMocks.createInternalHookEvent,
+    triggerInternalHook: internalHookMocks.triggerInternalHook,
+    fireAndForgetBoundedHook: (task: () => unknown) => {
+      void task();
+    },
+  };
+});
 
 installWebAutoReplyTestHomeHooks();
 
@@ -121,6 +149,21 @@ function mockCallArg(mocked: unknown, callIndex: number, argIndex: number): unkn
   return call[argIndex];
 }
 
+function expectWhatsAppHealthHook(action: string): Record<string, unknown> {
+  const events = internalHookMocks.triggerInternalHook.mock.calls.map((call) => call[0]) as Array<{
+    type?: string;
+    action?: string;
+    context?: Record<string, unknown>;
+  }>;
+  const event = events.find(
+    (candidate) => candidate.type === "whatsapp" && candidate.action === action,
+  );
+  if (!event) {
+    throw new Error(`Expected WhatsApp health hook ${action}`);
+  }
+  return event.context ?? {};
+}
+
 async function expectPathMissing(targetPath: string): Promise<void> {
   try {
     await fs.stat(targetPath);
@@ -137,6 +180,11 @@ describe("web auto-reply connection", () => {
   let monitorWebChannel: typeof import("./auto-reply/monitor.js").monitorWebChannel;
   beforeAll(async () => {
     ({ monitorWebChannel } = await import("./auto-reply/monitor.js"));
+  });
+
+  beforeEach(() => {
+    internalHookMocks.createInternalHookEvent.mockClear();
+    internalHookMocks.triggerInternalHook.mockClear();
   });
 
   it("handles helper envelope timestamps with trimmed timezones (regression)", () => {
@@ -462,6 +510,12 @@ describe("web auto-reply connection", () => {
       expect(finalStatus?.running).toBe(false);
       expect(finalStatus?.connected).toBe(false);
       expect(finalStatus?.healthState).toBe(healthState);
+      expect(expectWhatsAppHealthHook("terminal-disconnect")).toMatchObject({
+        accountId,
+        statusCode: status,
+        healthState,
+        loggedOut: isLoggedOut,
+      });
     },
   );
 
@@ -546,6 +600,18 @@ describe("web auto-reply connection", () => {
         "WhatsApp Web watchdog is recovering a stale connection",
       );
       expect(mockStringMessages(runtime.error).join("\n")).not.toContain("status 499");
+      expect(expectWhatsAppHealthHook("watchdog-timeout")).toMatchObject({
+        accountId: "default",
+        reason: "app-silent",
+        messagesHandled: 1,
+      });
+      expect(expectWhatsAppHealthHook("reconnect-scheduled")).toMatchObject({
+        accountId: "default",
+        statusCode: 499,
+        reconnectAttempts: 1,
+        healthState: "reconnecting",
+        watchdogRecovery: true,
+      });
       expect(
         statuses.filter(
           (status) =>

--- a/extensions/whatsapp/src/auto-reply/monitor.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor.ts
@@ -3,6 +3,11 @@ import { resolveInboundDebounceMs } from "openclaw/plugin-sdk/channel-inbound-de
 import { formatCliCommand } from "openclaw/plugin-sdk/cli-runtime";
 import { hasControlCommand } from "openclaw/plugin-sdk/command-detection";
 import { drainPendingDeliveries } from "openclaw/plugin-sdk/delivery-queue-runtime";
+import {
+  createInternalHookEvent,
+  fireAndForgetBoundedHook,
+  triggerInternalHook,
+} from "openclaw/plugin-sdk/hook-runtime";
 import { DEFAULT_GROUP_HISTORY_LIMIT } from "openclaw/plugin-sdk/reply-history";
 import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
@@ -54,6 +59,25 @@ function isNonRetryableWebCloseStatus(statusCode: unknown): boolean {
   // Baileys 428 = DisconnectReason.connectionClosed, a generic WebSocket close
   // that is often transient and must stay on the reconnect path.
   return statusCode === 440;
+}
+
+const WHATSAPP_HEALTH_HOOK_LIMITS = {
+  maxConcurrency: 4,
+  maxQueue: 64,
+  timeoutMs: 2_000,
+};
+
+function emitWhatsAppHealthHook(
+  action: "watchdog-timeout" | "reconnect-scheduled" | "terminal-disconnect",
+  sessionKey: string,
+  context: Record<string, unknown>,
+): void {
+  fireAndForgetBoundedHook(
+    () => triggerInternalHook(createInternalHookEvent("whatsapp", action, sessionKey, context)),
+    `whatsapp: ${action} internal hook failed`,
+    undefined,
+    WHATSAPP_HEALTH_HOOK_LIMITS,
+  );
 }
 
 type ReplyResolver = typeof import("./reply-resolver.runtime.js").getReplyFromConfig;
@@ -387,6 +411,17 @@ export async function monitorWebChannel(
             const watchdogReason =
               transportSilentMs > transportTimeoutMs ? "transport-inactive" : "app-silent";
             statusController.noteWatchdogStale();
+            emitWhatsAppHealthHook("watchdog-timeout", connectRoute.sessionKey, {
+              accountId: account.accountId,
+              connectionId: snapshot.connectionId,
+              reason: watchdogReason,
+              transportSilentMs,
+              minutesSinceTransportActivity,
+              minutesSinceAppActivity,
+              lastInboundAt: snapshot.lastInboundAt,
+              lastTransportActivityAt: snapshot.lastTransportActivityAt,
+              messagesHandled: snapshot.handledMessages,
+            });
             heartbeatLogger.warn(
               {
                 connectionId: snapshot.connectionId,
@@ -628,6 +663,17 @@ export async function monitorWebChannel(
           reconnectAttempts: decision.reconnectAttempts,
           healthState: decision.healthState,
         });
+        emitWhatsAppHealthHook("terminal-disconnect", connectRoute.sessionKey, {
+          accountId: account.accountId,
+          connectionId: connection.connectionId,
+          status: decision.normalized.statusLabel,
+          statusCode: decision.normalized.statusCode,
+          loggedOut: decision.normalized.isLoggedOut,
+          error: decision.normalized.errorText,
+          reconnectAttempts: decision.reconnectAttempts,
+          maxAttempts: reconnectPolicy.maxAttempts,
+          healthState: decision.healthState,
+        });
 
         if (decision.healthState === "logged-out") {
           await clearTerminalWebAuthState({
@@ -684,6 +730,18 @@ export async function monitorWebChannel(
         statusCode: decision.normalized.statusCode,
         error: decision.normalized.errorText,
         reconnectAttempts: decision.reconnectAttempts,
+        healthState: decision.healthState,
+        watchdogRecovery: isWatchdogRecoveryReconnect,
+      });
+      emitWhatsAppHealthHook("reconnect-scheduled", connectRoute.sessionKey, {
+        accountId: account.accountId,
+        connectionId: connection.connectionId,
+        status: decision.normalized.statusLabel,
+        statusCode: decision.normalized.statusCode,
+        error: decision.normalized.errorText,
+        reconnectAttempts: decision.reconnectAttempts,
+        maxAttempts: reconnectPolicy.maxAttempts,
+        delayMs: decision.delayMs,
         healthState: decision.healthState,
         watchdogRecovery: isWatchdogRecoveryReconnect,
       });


### PR DESCRIPTION
## Summary
- emit internal `whatsapp:*` hook events when WhatsApp Web watchdog/reconnect state changes
- include context for watchdog timeouts, scheduled reconnects, and terminal disconnects
- cover health hook emission in the existing WhatsApp Web connection e2e tests

## Real behavior proof
- **Behavior or issue addressed**: WhatsApp Web provider now emits internal hook events for watchdog timeouts, scheduled reconnects, and terminal disconnects, so a real OpenClaw install can run recovery/notification logic without polling or reset loops.
- **Real environment tested**: Real OpenClaw install on macOS, using the installed `@openclaw/whatsapp` package with the equivalent local dist patch and a managed `whatsapp-health-recovery` hook. The WhatsApp default channel was linked to a real WhatsApp Web session.
- **Exact steps or command run after this patch**:
  ```console
  openclaw hooks list --json | jq '.hooks[] | select(.name=="whatsapp-health-recovery") | {name,status,events}'
  tail -n 5 ~/.openclaw/logs/whatsapp-health-recovery.log
  openclaw channels status --channel whatsapp
  ```
- **Evidence after fix**: Redacted terminal output and runtime log from the real OpenClaw setup:
  ```console
  $ openclaw hooks list --json | jq '.hooks[] | select(.name=="whatsapp-health-recovery") | {name,status,events}'
  {
    "name": "whatsapp-health-recovery",
    "status": null,
    "events": [
      "gateway:startup",
      "whatsapp:watchdog-timeout",
      "whatsapp:reconnect-scheduled",
      "whatsapp:terminal-disconnect"
    ]
  }

  $ tail -n 5 ~/.openclaw/logs/whatsapp-health-recovery.log
  2026-05-19T06:37:38.194Z patch verification completed {"code":0,"stdout":"{\"ok\":true,\"changed\":false,\"changes\":[],\"target\":\"/Users/razvangirgiz/.openclaw/npm/node_modules/@openclaw/whatsapp/dist/monitor-DSBROC8j.js\"}","stderr":""}

  $ openclaw channels status --channel whatsapp
  Checking channel status...
  Gateway reachable.
  - WhatsApp default: enabled, configured, linked, running, connected, dm:pairing, allow:[redacted], health:healthy
  ```
- **Observed result after fix**: The managed hook was available for `gateway:startup`, `whatsapp:watchdog-timeout`, `whatsapp:reconnect-scheduled`, and `whatsapp:terminal-disconnect`, the patch verifier reported `changed:false`, and the real WhatsApp channel remained `linked`, `running`, `connected`, and `health:healthy`.
- **What was not tested**: I did not intentionally log out or conflict the real WhatsApp account after applying the patch; terminal disconnect emission is covered by the e2e test added in this PR.

## Verification
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts`
- `pnpm exec oxlint extensions/whatsapp/src/auto-reply/monitor.ts extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts`