### PR TITLE
fix(cli): validate --port in node run instead of silently falling back (#83923)

### DIFF
--- a/src/cli/node-cli/register.test.ts
+++ b/src/cli/node-cli/register.test.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { registerNodeCli } from "./register.js";
 
 const daemonMocks = vi.hoisted(() => ({
@@ -13,12 +13,24 @@ const daemonMocks = vi.hoisted(() => ({
 
 vi.mock("./daemon.js", () => daemonMocks);
 
+const loadNodeHostConfigMock = vi.hoisted(() => vi.fn(async () => null));
 vi.mock("../../node-host/config.js", () => ({
-  loadNodeHostConfig: vi.fn(async () => null),
+  loadNodeHostConfig: loadNodeHostConfigMock,
 }));
 
+const runNodeHostMock = vi.hoisted(() => vi.fn());
 vi.mock("../../node-host/runner.js", () => ({
-  runNodeHost: vi.fn(),
+  runNodeHost: runNodeHostMock,
+}));
+
+const runtimeMocks = vi.hoisted(() => ({
+  error: vi.fn(),
+  exit: vi.fn(() => {
+    throw new Error("__exit__");
+  }),
+}));
+vi.mock("../../runtime.js", () => ({
+  defaultRuntime: runtimeMocks,
 }));
 
 function createProgram(): Command {
@@ -33,11 +45,72 @@ function createProgram(): Command {
 }
 
 describe("registerNodeCli", () => {
+  beforeEach(() => {
+    runNodeHostMock.mockReset();
+    runtimeMocks.error.mockReset();
+    runtimeMocks.exit.mockClear();
+    runtimeMocks.exit.mockImplementation(() => {
+      throw new Error("__exit__");
+    });
+    loadNodeHostConfigMock.mockReset();
+    loadNodeHostConfigMock.mockImplementation(async () => null);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("registers node start for the macOS app node service manager", async () => {
     const program = createProgram();
 
     await program.parseAsync(["node", "start", "--json"], { from: "user" });
 
     expect(daemonMocks.runNodeDaemonStart.mock.calls[0]?.[0]?.json).toBe(true);
+  });
+
+  // #83923: `node run --port <bad>` previously silently fell back to the
+  // configured / default port. Now it must surface an invalid-option error
+  // and exit before reaching runNodeHost.
+  it("fails fast on non-numeric --port for node run (#83923)", async () => {
+    const program = createProgram();
+    await expect(
+      program.parseAsync(["node", "run", "--port", "abc"], { from: "user" }),
+    ).rejects.toThrow("__exit__");
+
+    expect(runtimeMocks.error).toHaveBeenCalledTimes(1);
+    expect(String(runtimeMocks.error.mock.calls[0]?.[0])).toMatch(/--port/i);
+    expect(runtimeMocks.exit).toHaveBeenCalledWith(1);
+    expect(runNodeHostMock).not.toHaveBeenCalled();
+  });
+
+  it("fails fast on out-of-range --port for node run (#83923)", async () => {
+    const program = createProgram();
+    await expect(
+      program.parseAsync(["node", "run", "--port", "99999"], { from: "user" }),
+    ).rejects.toThrow("__exit__");
+
+    expect(runtimeMocks.error).toHaveBeenCalledTimes(1);
+    expect(runtimeMocks.exit).toHaveBeenCalledWith(1);
+    expect(runNodeHostMock).not.toHaveBeenCalled();
+  });
+
+  it("passes a valid --port through to runNodeHost (#83923 no-regression)", async () => {
+    const program = createProgram();
+    await program.parseAsync(["node", "run", "--port", "8123"], { from: "user" });
+
+    expect(runtimeMocks.exit).not.toHaveBeenCalled();
+    expect(runNodeHostMock).toHaveBeenCalledTimes(1);
+    expect(runNodeHostMock.mock.calls[0]?.[0]?.gatewayPort).toBe(8123);
+  });
+
+  it("falls back to the configured port when --port is omitted (#83923 no-regression)", async () => {
+    loadNodeHostConfigMock.mockImplementation(async () => ({
+      gateway: { host: "127.0.0.1", port: 19000 },
+    }));
+    const program = createProgram();
+    await program.parseAsync(["node", "run"], { from: "user" });
+
+    expect(runtimeMocks.exit).not.toHaveBeenCalled();
+    expect(runNodeHostMock.mock.calls[0]?.[0]?.gatewayPort).toBe(19000);
   });
 });

--- a/src/cli/node-cli/register.test.ts
+++ b/src/cli/node-cli/register.test.ts
@@ -2,6 +2,15 @@ import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { registerNodeCli } from "./register.js";
 
+type MockNodeHostConfig = {
+  version: 1;
+  nodeId: string;
+  gateway?: {
+    host?: string;
+    port?: number;
+  };
+};
+
 const daemonMocks = vi.hoisted(() => ({
   runNodeDaemonInstall: vi.fn(),
   runNodeDaemonRestart: vi.fn(),
@@ -13,7 +22,9 @@ const daemonMocks = vi.hoisted(() => ({
 
 vi.mock("./daemon.js", () => daemonMocks);
 
-const loadNodeHostConfigMock = vi.hoisted(() => vi.fn(async () => null));
+const loadNodeHostConfigMock = vi.hoisted(() =>
+  vi.fn<() => Promise<MockNodeHostConfig | null>>(async () => null),
+);
 vi.mock("../../node-host/config.js", () => ({
   loadNodeHostConfig: loadNodeHostConfigMock,
 }));
@@ -105,6 +116,8 @@ describe("registerNodeCli", () => {
 
   it("falls back to the configured port when --port is omitted (#83923 no-regression)", async () => {
     loadNodeHostConfigMock.mockImplementation(async () => ({
+      version: 1,
+      nodeId: "node-1",
       gateway: { host: "127.0.0.1", port: 19000 },
     }));
     const program = createProgram();

--- a/src/cli/node-cli/register.ts
+++ b/src/cli/node-cli/register.ts
@@ -1,10 +1,12 @@
 import type { Command } from "commander";
 import { loadNodeHostConfig } from "../../node-host/config.js";
 import { runNodeHost } from "../../node-host/runner.js";
+import { defaultRuntime } from "../../runtime.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import { formatDocsLink } from "../../terminal/links.js";
 import { theme } from "../../terminal/theme.js";
 import { parsePort } from "../daemon-cli/shared.js";
+import { formatInvalidConfigPort, formatInvalidPortOption } from "../error-format.js";
 import { formatHelpExamples } from "../help-format.js";
 import {
   runNodeDaemonInstall,
@@ -15,9 +17,28 @@ import {
   runNodeDaemonUninstall,
 } from "./daemon.js";
 
-function parsePortWithFallback(value: unknown, fallback: number): number {
-  const parsed = parsePort(value);
-  return parsed ?? fallback;
+// Mirrors the install / gateway-run validation paths so an invalid `--port`
+// (non-numeric, zero, negative, or > 65535) fails fast with a clear diagnostic
+// instead of silently falling back to the configured / default port. The
+// previous `parsePortWithFallback(opts.port, fallback)` helper hid the parse
+// failure entirely. See #83923.
+function resolveNodeRunPort(
+  rawPortOption: unknown,
+  configPort: number | undefined,
+): number | null {
+  const portOverride = parsePort(rawPortOption);
+  if (rawPortOption !== undefined && portOverride === null) {
+    defaultRuntime.error(formatInvalidPortOption("--port"));
+    defaultRuntime.exit(1);
+    return null;
+  }
+  const port = portOverride ?? configPort ?? 18789;
+  if (!Number.isFinite(port) || port <= 0 || port > 65_535) {
+    defaultRuntime.error(formatInvalidConfigPort("node.gateway.port"));
+    defaultRuntime.exit(1);
+    return null;
+  }
+  return port;
 }
 
 export function registerNodeCli(program: Command) {
@@ -54,7 +75,10 @@ export function registerNodeCli(program: Command) {
         normalizeOptionalString(opts.host as string | undefined) ||
         existing?.gateway?.host ||
         "127.0.0.1";
-      const port = parsePortWithFallback(opts.port, existing?.gateway?.port ?? 18789);
+      const port = resolveNodeRunPort(opts.port, existing?.gateway?.port);
+      if (port === null) {
+        return;
+      }
       await runNodeHost({
         gatewayHost: host,
         gatewayPort: port,


### PR DESCRIPTION
Fixes #83923.

`node run` used the local `parsePortWithFallback(opts.port, fallback)` helper, which silently returns the configured / default port whenever `parsePort` rejects the input. `openclaw node run --port abc` therefore started the host on 18789 with no warning. Meanwhile `runNodeDaemonInstall` already validates the same input via `parsePort` and `fail(formatInvalidPortOption("--port"))`, and `gateway run` follows the same pattern. The asymmetry between `run` and `install` is exactly the kind of silently-wrong runtime address that is hardest to diagnose — especially when TLS fingerprinting or NAT targets are involved.

## Changes

- `src/cli/node-cli/register.ts`: drop the silent `parsePortWithFallback` helper. Introduce `resolveNodeRunPort(rawPortOption, configPort)` that mirrors the install / gateway-run validation pattern: `parsePort`-then-fail-fast when `--port` is provided but unparseable, and a `(0, 65535]` range check on the resolved port (config-port path) with `formatInvalidConfigPort("node.gateway.port")`.
- `src/cli/node-cli/register.test.ts`: extend the existing test scaffold with mocks for `loadNodeHostConfig`, `runNodeHost`, and `defaultRuntime`. Add 4 regression cases — non-numeric `--port`, out-of-range `--port`, valid `--port` passthrough, and config-fallback no-regression when `--port` is omitted.

Diff stat: 2 files, +104 / -7.

## Real behavior proof

- **Behavior or issue addressed:** Sanitized issue evidence — `openclaw node run --port abc` was returning silently on the fallback port (no diagnostic), while `openclaw node install --port abc` already failed cleanly. Source paths cited in the issue: `register.ts:15-16` (`parsePortWithFallback`), `register.ts:58-68` (the run-command action), `daemon.ts:89-97` (the matching install validation pattern).

- **Real environment tested:** Local Node 22.x. Probe at `/tmp/probe_83923.mjs` (a) parses the patched `register.ts` and verifies the silent helper is gone, the validated helper is present, it reuses `parsePort`, the `--port`-fail branch + `formatInvalidPortOption("--port")`, the `(0, 65535]` range check, and the `formatInvalidConfigPort("node.gateway.port")` use, and (b) replays the new `resolveNodeRunPort` semantics against 7 fixtures: the issue's exact `--port abc` repro (null + --port diagnostic + exit(1)), the out-of-range `--port 99999` repro, valid `--port 8123` passthrough, no-`--port` config-fallback at 19000, no-`--port` no-config default at 18789, invalid config port (-1) surfacing the `node.gateway.port` diagnostic, and the pre-fix buggy shape that silently returns 18789 for `--port abc` (confirms the issue's root cause).

- **Exact steps or command run after this patch:** `node /tmp/probe_83923.mjs`

- **Evidence after fix:**

```
PASS: silent parsePortWithFallback helper removed (no more silent fallback path)
PASS: validated resolveNodeRunPort helper added
PASS: reuses parsePort
PASS: explicit-option-but-unparseable branch fails with --port diagnostic
PASS: uses canonical formatInvalidPortOption for --port
PASS: config-port range check mirrors install path (1..65535)
PASS: config-port-range failure uses canonical node.gateway.port label
PASS: replay: --port abc → null + --port error + exit(1)
PASS: replay: --port 99999 → null + exit(1)
PASS: replay: --port 8123 → 8123 (no exit)
PASS: replay: no --port + configPort=19000 → 19000
PASS: replay: no --port no config → 18789 default
PASS: replay: invalid config port (-1) → null + exit(1) with node.gateway.port diagnostic
PASS: replay (buggy): --port abc silently returns 18789 — confirms #83923 root cause

ALL CASES PASS
```

- **Observed result after fix:** `openclaw node run --port abc` and `openclaw node run --port 99999` now print the same `--port` diagnostic format that `openclaw node install --port abc` already prints, and exit with code 1 before reaching `runNodeHost`. Valid overrides (e.g. `--port 8123`) pass through unchanged, and the config-port fallback path remains intact.

- **What was not tested:** Live `openclaw node run --port abc` smoke against an actual build — that requires `pnpm build`. The vitest regression tests exercise the public `registerNodeCli` contract through Commander, mocking `defaultRuntime` to intercept the error+exit calls, and the source-level probe verifies the predicate end-to-end.

## Audit (per CLAUDE rules — all 5 steps)

- **Existing-helper check:** Reuses the existing `parsePort` import, the existing `formatInvalidPortOption` / `formatInvalidConfigPort` helpers from `../error-format.js`, and the existing `defaultRuntime` runtime (same surface `runNodeDaemonInstall` and `gateway run` use). No new helper. PASS
- **Shared-helper caller check:** The removed `parsePortWithFallback` had exactly one caller (the `node run` action in the same file). New `resolveNodeRunPort` is also called from exactly one site. PASS
- **Broader-fix rival scan:** `gh pr list --search '83923 in:title,body'` returns no open PRs. PASS
- **Recent-merge audit:** `git log --oneline -5 -- src/cli/node-cli/register.ts` shows `e1061a8b46 test(live): tolerate provider drift in release checks` — unrelated. PASS
- **Prototype-pollution scan:** N/A — no external-input key copying.
