### PR TITLE
fix(cli): node run validates --port loudly (#83923)

### DIFF
--- a/src/cli/node-cli/register.test.ts
+++ b/src/cli/node-cli/register.test.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { registerNodeCli } from "./register.js";
 
 const daemonMocks = vi.hoisted(() => ({
@@ -11,14 +11,19 @@ const daemonMocks = vi.hoisted(() => ({
   runNodeDaemonUninstall: vi.fn(),
 }));
 
+const nodeHostMocks = vi.hoisted(() => ({
+  loadNodeHostConfig: vi.fn(async () => null as Awaited<unknown>),
+  runNodeHost: vi.fn(async () => {}),
+}));
+
 vi.mock("./daemon.js", () => daemonMocks);
 
 vi.mock("../../node-host/config.js", () => ({
-  loadNodeHostConfig: vi.fn(async () => null),
+  loadNodeHostConfig: nodeHostMocks.loadNodeHostConfig,
 }));
 
 vi.mock("../../node-host/runner.js", () => ({
-  runNodeHost: vi.fn(),
+  runNodeHost: nodeHostMocks.runNodeHost,
 }));
 
 function createProgram(): Command {
@@ -39,5 +44,90 @@ describe("registerNodeCli", () => {
     await program.parseAsync(["node", "start", "--json"], { from: "user" });
 
     expect(daemonMocks.runNodeDaemonStart.mock.calls[0]?.[0]?.json).toBe(true);
+  });
+});
+
+describe("openclaw node run --port validation (#83923)", () => {
+  let originalExit: typeof process.exit;
+  let exitSpy: ReturnType<typeof vi.fn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    nodeHostMocks.runNodeHost.mockClear();
+    nodeHostMocks.loadNodeHostConfig.mockReset();
+    nodeHostMocks.loadNodeHostConfig.mockResolvedValue(null as Awaited<unknown>);
+
+    originalExit = process.exit;
+    // The action calls process.exit(2) on invalid --port; throw inside the mock
+    // so the action stops and the test can observe both the stderr write and
+    // the exit code without actually terminating the test runner.
+    exitSpy = vi.fn((code?: number | string | null) => {
+      throw new Error(`__test_exit__:${String(code)}`);
+    });
+    process.exit = exitSpy as unknown as typeof process.exit;
+    stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    process.exit = originalExit;
+    stderrSpy.mockRestore();
+  });
+
+  it("rejects --port abc with a loud diagnostic and does not start the host", async () => {
+    const program = createProgram();
+
+    await expect(
+      program.parseAsync(["node", "run", "--port", "abc"], { from: "user" }),
+    ).rejects.toThrow(/__test_exit__:2/);
+
+    expect(nodeHostMocks.runNodeHost).not.toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(2);
+    const stderrMessages = stderrSpy.mock.calls.map((call) => String(call[0]));
+    expect(stderrMessages.some((msg) => msg.includes("Invalid --port"))).toBe(true);
+  });
+
+  it("rejects --port 0 (out of range) without starting the host", async () => {
+    const program = createProgram();
+
+    await expect(
+      program.parseAsync(["node", "run", "--port", "0"], { from: "user" }),
+    ).rejects.toThrow(/__test_exit__:2/);
+
+    expect(nodeHostMocks.runNodeHost).not.toHaveBeenCalled();
+  });
+
+  it("rejects --port 70000 (out of range) without starting the host", async () => {
+    const program = createProgram();
+
+    await expect(
+      program.parseAsync(["node", "run", "--port", "70000"], { from: "user" }),
+    ).rejects.toThrow(/__test_exit__:2/);
+
+    expect(nodeHostMocks.runNodeHost).not.toHaveBeenCalled();
+  });
+
+  it("falls back to config / default gateway port when --port is absent", async () => {
+    nodeHostMocks.loadNodeHostConfig.mockResolvedValueOnce({
+      gateway: { port: 22222 },
+    } as Awaited<unknown>);
+    const program = createProgram();
+
+    await program.parseAsync(["node", "run"], { from: "user" });
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(nodeHostMocks.runNodeHost).toHaveBeenCalledTimes(1);
+    expect(nodeHostMocks.runNodeHost.mock.calls[0][0]).toMatchObject({
+      gatewayPort: 22222,
+    });
+  });
+
+  it("uses the parsed --port value when valid", async () => {
+    const program = createProgram();
+
+    await program.parseAsync(["node", "run", "--port", "31337"], { from: "user" });
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(nodeHostMocks.runNodeHost).toHaveBeenCalledTimes(1);
+    expect(nodeHostMocks.runNodeHost.mock.calls[0][0]).toMatchObject({ gatewayPort: 31337 });
   });
 });

--- a/src/cli/node-cli/register.test.ts
+++ b/src/cli/node-cli/register.test.ts
@@ -11,9 +11,18 @@ const daemonMocks = vi.hoisted(() => ({
   runNodeDaemonUninstall: vi.fn(),
 }));
 
+type RunNodeHostStub = (opts: {
+  gatewayHost?: string;
+  gatewayPort?: number;
+  gatewayTls?: boolean;
+  gatewayTlsFingerprint?: string;
+  nodeId?: string;
+  displayName?: string;
+}) => Promise<void>;
+
 const nodeHostMocks = vi.hoisted(() => ({
   loadNodeHostConfig: vi.fn(async () => null as Awaited<unknown>),
-  runNodeHost: vi.fn(async () => {}),
+  runNodeHost: vi.fn<RunNodeHostStub>(async () => {}),
 }));
 
 vi.mock("./daemon.js", () => daemonMocks);
@@ -82,8 +91,8 @@ describe("openclaw node run --port validation (#83923)", () => {
 
     expect(nodeHostMocks.runNodeHost).not.toHaveBeenCalled();
     expect(exitSpy).toHaveBeenCalledWith(2);
-    const stderrMessages = stderrSpy.mock.calls.map((call) => String(call[0]));
-    expect(stderrMessages.some((msg) => msg.includes("Invalid --port"))).toBe(true);
+    const stderrMessages = stderrSpy.mock.calls.map((call: unknown[]) => String(call[0]));
+    expect(stderrMessages.some((msg: string) => msg.includes("Invalid --port"))).toBe(true);
   });
 
   it("rejects --port 0 (out of range) without starting the host", async () => {

--- a/src/cli/node-cli/register.ts
+++ b/src/cli/node-cli/register.ts
@@ -5,6 +5,7 @@ import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import { formatDocsLink } from "../../terminal/links.js";
 import { theme } from "../../terminal/theme.js";
 import { parsePort } from "../daemon-cli/shared.js";
+import { formatInvalidPortOption } from "../error-format.js";
 import { formatHelpExamples } from "../help-format.js";
 import {
   runNodeDaemonInstall,
@@ -15,9 +16,23 @@ import {
   runNodeDaemonUninstall,
 } from "./daemon.js";
 
-function parsePortWithFallback(value: unknown, fallback: number): number {
+/**
+ * Resolve a gateway port from a CLI option, falling back to the config / default
+ * when ``--port`` is absent but rejecting (loud error + exit) when ``--port`` was
+ * passed and the value doesn't parse to a valid port. Previously a silent fallback
+ * meant ``openclaw node run --port abc`` started the host on 18789 with no
+ * diagnostic; ``node install`` already validates the same value via daemon.ts. (#83923)
+ */
+function resolveNodeGatewayPortOrExit(value: unknown, fallback: number): number {
+  if (value === undefined) {
+    return fallback;
+  }
   const parsed = parsePort(value);
-  return parsed ?? fallback;
+  if (parsed === null || parsed > 65_535) {
+    process.stderr.write(`${formatInvalidPortOption("--port")}\n`);
+    process.exit(2);
+  }
+  return parsed;
 }
 
 export function registerNodeCli(program: Command) {
@@ -54,7 +69,7 @@ export function registerNodeCli(program: Command) {
         normalizeOptionalString(opts.host as string | undefined) ||
         existing?.gateway?.host ||
         "127.0.0.1";
-      const port = parsePortWithFallback(opts.port, existing?.gateway?.port ?? 18789);
+      const port = resolveNodeGatewayPortOrExit(opts.port, existing?.gateway?.port ?? 18789);
       await runNodeHost({
         gatewayHost: host,
         gatewayPort: port,


### PR DESCRIPTION
Closes #83923.

## Summary

\`openclaw node run --port abc\` (or \`--port 0\`, \`--port -5\`, \`--port 70000\`) was starting the node host on the silent fallback port (\`existing.gateway.port ?? 18789\`) because \`parsePortWithFallback\` collapsed any invalid input to the fallback with no diagnostic. \`openclaw node install\` already validates the same input via \`runNodeDaemonInstall\` in \`src/cli/node-cli/daemon.ts:98\` and calls \`fail(formatInvalidPortOption("--port"))\`.

Replaces the silent helper with \`resolveNodeGatewayPortOrExit\`:

- \`opts.port === undefined\` → fall back to \`existing.gateway.port ?? 18789\` (unchanged for the no-flag case).
- \`opts.port\` passed but parses to \`null\` (non-numeric or non-positive) OR parses above 65535 → write \`formatInvalidPortOption("--port")\` to stderr and \`process.exit(2)\`.

Aligns \`node run\` with the \`node install\` validation shape so the same CLI surface gives the same diagnostic. Range check is explicit because \`parsePort → parseStrictPositiveInteger\` enforces \`> 0\` but no upper bound; relying on it alone would let \`--port 70000\` through.

## Real behavior proof

Behavior addressed: \`openclaw node run --port abc\` and out-of-range values now emit \`Invalid --port. Set ...\` to stderr and exit with code 2, instead of silently starting the host on the fallback port.

Real environment tested: darwin / arm64 / Node 22.21.1, openclaw source tree at HEAD of branch above.

Exact steps or command run after this patch:

\`\`\`
node scripts/run-vitest.mjs src/cli/node-cli/register.test.ts
./node_modules/.bin/oxlint --type-aware src/cli/node-cli/register.ts src/cli/node-cli/register.test.ts
\`\`\`

Evidence after fix:

\`\`\`
$ node scripts/run-vitest.mjs src/cli/node-cli/register.test.ts
 RUN  v4.1.6 /Users/harshkumarkaithwas/Desktop/openclaw

 ✓ registerNodeCli > registers node start for the macOS app node service manager
 ✓ openclaw node run --port validation (#83923) > rejects --port abc with a loud diagnostic and does not start the host
 ✓ openclaw node run --port validation (#83923) > rejects --port 0 (out of range) without starting the host
 ✓ openclaw node run --port validation (#83923) > rejects --port 70000 (out of range) without starting the host
 ✓ openclaw node run --port validation (#83923) > falls back to config / default gateway port when --port is absent
 ✓ openclaw node run --port validation (#83923) > uses the parsed --port value when valid

 Test Files  1 passed (1)
      Tests  6 passed (6)

$ ./node_modules/.bin/oxlint --type-aware src/cli/node-cli/register.ts src/cli/node-cli/register.test.ts
Found 0 warnings and 0 errors.
\`\`\`

Observed result after fix: \`runNodeHost\` is never invoked for invalid \`--port\` values; the user sees a stderr line matching \`Invalid --port. ...\` and the process exits 2. Valid ports (\`31337\`) still drive \`runNodeHost\` with the parsed value, and the no-flag case still falls back to config / 18789.

What was not tested: a true E2E spawn of the \`openclaw\` binary against a port-bound check — covered transitively by the parallel \`runNodeDaemonInstall\` validation that already lives on main.

## Notes

- Same diagnostic format as \`runNodeDaemonInstall\` (reuses \`formatInvalidPortOption\` from \`src/cli/error-format.ts\`).
- \`parsePortWithFallback\` removed because \`run\` was its only caller; if a future call site needs the silent-fallback shape, name it \`parsePortWithSilentFallback\` so the silent semantics are explicit, as the issue suggested.
- Local lint+format wrappers (\`node scripts/run-oxlint.mjs\`, \`pnpm format\`) hit a pre-existing dts boundary failure on \`@openclaw/proxyline\` (\`ProxylineUndiciOptions\` / \`ifActive\`) unrelated to this PR; ran \`./node_modules/.bin/oxlint --type-aware\` and \`./node_modules/.bin/oxfmt --write\` directly on the touched files.