### PR TITLE
feat(cli): suggest closest command for unknown subcommands (#83999)

### DIFF
--- a/src/cli/program/error-output.test.ts
+++ b/src/cli/program/error-output.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { formatCliParseErrorOutput } from "./error-output.js";
+import { formatCliParseErrorOutput, suggestClosestCommand } from "./error-output.js";
 
 describe("formatCliParseErrorOutput", () => {
   it("explains unknown commands with root help and plugin hints", () => {
@@ -10,6 +10,43 @@ describe("formatCliParseErrorOutput", () => {
     expect(output).toBe(
       'OpenClaw does not know the command "wat".\nTry: openclaw --help\nPlugin command? openclaw plugins list\nDocs: https://docs.openclaw.ai/cli\n',
     );
+  });
+
+  it("suggests the closest root command for a typo when knownCommands is provided (#83999)", () => {
+    const output = formatCliParseErrorOutput("error: unknown command 'upate'\n", {
+      argv: ["node", "openclaw", "upate"],
+      knownCommands: ["update", "doctor", "channels", "plugins"],
+    });
+
+    expect(output).toBe(
+      'OpenClaw does not know the command "upate".\nDid you mean this?\n  openclaw update\nTry: openclaw --help\nPlugin command? openclaw plugins list\nDocs: https://docs.openclaw.ai/cli\n',
+    );
+  });
+
+  it("surfaces the explicit alias for `upgrade` -> `update` (#83999)", () => {
+    const output = formatCliParseErrorOutput("error: unknown command 'upgrade'\n", {
+      argv: ["node", "openclaw", "upgrade"],
+      knownCommands: ["update", "doctor"],
+    });
+
+    expect(output).toContain("Did you mean this?\n  openclaw update");
+  });
+
+  it("does not suggest when the typo is far from every known command (#83999)", () => {
+    const output = formatCliParseErrorOutput("error: unknown command 'zzqwerty'\n", {
+      argv: ["node", "openclaw", "zzqwerty"],
+      knownCommands: ["update", "doctor", "channels"],
+    });
+
+    expect(output).not.toContain("Did you mean this?");
+  });
+
+  it("is a no-op when knownCommands is not provided (legacy caller shape)", () => {
+    const output = formatCliParseErrorOutput("error: unknown command 'upate'\n", {
+      argv: ["node", "openclaw", "upate"],
+    });
+
+    expect(output).not.toContain("Did you mean this?");
   });
 
   it("points unknown options at the active command help", () => {
@@ -30,5 +67,36 @@ describe("formatCliParseErrorOutput", () => {
     expect(output).toBe(
       'Missing required argument "name".\nTry: openclaw plugins install --help\n',
     );
+  });
+});
+
+describe("suggestClosestCommand (#83999)", () => {
+  const known = ["update", "doctor", "channels", "plugins", "agents", "status"];
+
+  it("picks the canonical update on `upate`", () => {
+    expect(suggestClosestCommand("upate", known)).toBe("update");
+  });
+
+  it("returns undefined when nothing is close enough", () => {
+    expect(suggestClosestCommand("zzqwerty", known)).toBeUndefined();
+  });
+
+  it("honors the explicit upgrade -> update alias even when edit distance picks another", () => {
+    // `upgrade` distance to `update` is 2 (`gr` -> `t`) — without the alias map
+    // the Levenshtein-only path could ambiguously land on another short root.
+    expect(suggestClosestCommand("upgrade", known)).toBe("update");
+  });
+
+  it("does not invent a command — alias target must be in knownCommands", () => {
+    expect(suggestClosestCommand("upgrade", ["doctor", "channels"])).toBeUndefined();
+  });
+
+  it("returns undefined for empty input", () => {
+    expect(suggestClosestCommand("", known)).toBeUndefined();
+    expect(suggestClosestCommand("   ", known)).toBeUndefined();
+  });
+
+  it("matches case-insensitively against known commands", () => {
+    expect(suggestClosestCommand("DocTr", known)).toBe("doctor");
   });
 });

--- a/src/cli/program/error-output.ts
+++ b/src/cli/program/error-output.ts
@@ -5,7 +5,88 @@ import { formatCliCommand } from "../command-format.js";
 
 type FormatCliParseErrorOptions = {
   argv?: string[];
+  /**
+   * Known root command + sub-CLI root names to consider for the
+   * "Did you mean this?" suggester on unknown commands (#83999). When omitted
+   * the suggester is a no-op, matching legacy callers / tests.
+   */
+  knownCommands?: readonly string[];
 };
+
+/**
+ * Explicit aliases for common terminology that doesn't fall out of edit
+ * distance — e.g. `upgrade` vs `update`. Keep tight; only add entries where
+ * the alias is a widely-shared synonym, not a typo cluster, so the suggestion
+ * always points at a canonical command without surfacing accidental API
+ * surface. See #83999.
+ */
+const COMMAND_ALIASES: Record<string, string> = {
+  upgrade: "update",
+  remove: "uninstall",
+  rm: "uninstall",
+  ls: "list",
+  ping: "doctor",
+};
+
+function levenshtein(a: string, b: string): number {
+  if (a === b) {
+    return 0;
+  }
+  if (a.length === 0) {
+    return b.length;
+  }
+  if (b.length === 0) {
+    return a.length;
+  }
+  // Two-row dynamic-programming Levenshtein — O(min(a, b)) memory, O(a*b) time.
+  // Sufficient for CLI command names; openclaw doesn't ship 1000-character roots.
+  const prev: number[] = Array.from({ length: b.length + 1 }, (_, j) => j);
+  const curr: number[] = Array.from({ length: b.length + 1 }, () => 0);
+  for (let i = 1; i <= a.length; i += 1) {
+    curr[0] = i;
+    for (let j = 1; j <= b.length; j += 1) {
+      const cost = a.charCodeAt(i - 1) === b.charCodeAt(j - 1) ? 0 : 1;
+      curr[j] = Math.min((curr[j - 1] ?? 0) + 1, (prev[j] ?? 0) + 1, (prev[j - 1] ?? 0) + cost);
+    }
+    for (let j = 0; j <= b.length; j += 1) {
+      prev[j] = curr[j] ?? 0;
+    }
+  }
+  return prev[b.length] ?? 0;
+}
+
+export function suggestClosestCommand(
+  unknown: string,
+  known: readonly string[],
+): string | undefined {
+  const input = unknown.trim().toLowerCase();
+  if (!input) {
+    return undefined;
+  }
+  // Explicit alias wins over edit-distance — `openclaw upgrade` should always
+  // suggest `openclaw update`, regardless of how close other commands look.
+  const aliased = COMMAND_ALIASES[input];
+  if (aliased && known.includes(aliased)) {
+    return aliased;
+  }
+  // npm-style threshold: distance must be small relative to input length so we
+  // don't surface a misleading suggestion for genuinely off-vocabulary inputs.
+  const threshold = Math.max(1, Math.floor(input.length * 0.4));
+  let best: { name: string; distance: number } | undefined;
+  for (const name of known) {
+    if (!name) {
+      continue;
+    }
+    const distance = levenshtein(input, name.toLowerCase());
+    if (distance > threshold) {
+      continue;
+    }
+    if (!best || distance < best.distance) {
+      best = { name, distance };
+    }
+  }
+  return best?.name;
+}
 
 function stripCommanderErrorPrefix(raw: string): string {
   return raw
@@ -49,8 +130,13 @@ export function formatCliParseErrorOutput(
   const unknownCommand = message.match(/^unknown command ['"`](.+?)['"`]/i);
   if (unknownCommand) {
     const command = unknownCommand[1] ?? "";
+    const suggestion = options.knownCommands
+      ? suggestClosestCommand(command, options.knownCommands)
+      : undefined;
     return lines(
       theme.error(`OpenClaw does not know the command ${quote(command)}.`),
+      suggestion ? theme.muted("Did you mean this?") : undefined,
+      suggestion ? `  ${theme.command(formatCliCommand(`openclaw ${suggestion}`))}` : undefined,
       formatHelpHint(options.argv, { root: true }),
       `${theme.muted("Plugin command?")} ${theme.command(formatCliCommand("openclaw plugins list"))}`,
       formatDocsHint(),

--- a/src/cli/program/help.ts
+++ b/src/cli/program/help.ts
@@ -105,7 +105,16 @@ export function configureProgramHelp(program: Command, ctx: ProgramContext) {
     writeErr: (str) => {
       process.stderr.write(formatHelpOutput(str));
     },
-    outputError: (str, write) => write(formatCliParseErrorOutput(str, { argv: process.argv })),
+    outputError: (str, write) =>
+      write(
+        formatCliParseErrorOutput(str, {
+          argv: process.argv,
+          // Surface every registered root + sub-CLI root name so the
+          // "Did you mean this?" suggester (#83999) can score the unknown
+          // command against the same catalog `openclaw --help` would list.
+          knownCommands: program.commands.map((cmd) => cmd.name()),
+        }),
+      ),
   });
 
   if (


### PR DESCRIPTION
Closes #83999.

## Summary

\`openclaw upate\` and \`openclaw upgrade\` previously failed with a generic \`OpenClaw does not know the command "upate".\` and left the user to inspect \`openclaw --help\` manually. This change appends npm-style \`Did you mean this?\` suggestions, computed from Levenshtein distance against the registered root commands plus a tight explicit alias map for terminology that doesn't fall out of edit distance (\`upgrade -> update\`, \`remove -> uninstall\`, \`rm -> uninstall\`, \`ls -> list\`, \`ping -> doctor\`).

Output shapes:

\`\`\`
$ openclaw upate
OpenClaw does not know the command "upate".
Did you mean this?
  openclaw update
Try: openclaw --help
Plugin command? openclaw plugins list
Docs: https://docs.openclaw.ai/cli
\`\`\`

\`\`\`
$ openclaw upgrade
OpenClaw does not know the command "upgrade".
Did you mean this?
  openclaw update
...
\`\`\`

\`\`\`
$ openclaw zzqwerty            # no suggestion when nothing is close
OpenClaw does not know the command "zzqwerty".
Try: openclaw --help
...
\`\`\`

## Design

- \`suggestClosestCommand\` is exported from \`src/cli/program/error-output.ts\` and takes \`(unknown, known[])\`. Known commands are passed via the new \`knownCommands\` option on \`formatCliParseErrorOptions\`.
- Explicit aliases win over edit distance — \`upgrade -> update\` is canonical even when other short roots score closer numerically.
- Alias target must exist in \`knownCommands\` so the suggester can't invent a command that this build doesn't actually have.
- npm-style threshold: distance must be \`<= floor(input.length * 0.4)\` (min 1). Keeps \`zzqwerty\` from misleadingly resolving to a 4-character root.
- Two-row Levenshtein, \`O(min(a,b))\` memory, \`O(a*b)\` time. CLI roots are short, so this is fine.
- No auto-correct, no auto-run: just an appended hint, same as the existing plugin hint.
- Wired into the one caller (\`src/cli/program/help.ts:108\`) via \`program.commands.map((cmd) => cmd.name())\`, so the catalog stays in sync with whatever \`openclaw --help\` lists. When \`knownCommands\` is omitted (legacy callers / tests) the suggester is a no-op — behavior is unchanged.

## Real behavior proof

Behavior addressed: unknown root commands now append \`Did you mean this?\` with the closest registered command (or alias target) when the distance is small enough.

Real environment tested: darwin / arm64 / Node 22.21.1, openclaw source tree at HEAD of branch above.

Exact steps or command run after this patch:

\`\`\`
node scripts/run-vitest.mjs src/cli/program/error-output.test.ts
./node_modules/.bin/oxlint --type-aware src/cli/program/error-output.ts src/cli/program/error-output.test.ts src/cli/program/help.ts
\`\`\`

Evidence after fix:

\`\`\`
$ node scripts/run-vitest.mjs src/cli/program/error-output.test.ts
 RUN  v4.1.6 /Users/harshkumarkaithwas/Desktop/openclaw

 Test Files  1 passed (1)
      Tests  13 passed (13)

$ ./node_modules/.bin/oxlint --type-aware src/cli/program/error-output.ts src/cli/program/error-output.test.ts src/cli/program/help.ts
Found 0 warnings and 0 errors.
\`\`\`

Observed result after fix: \`formatCliParseErrorOutput\` now emits \`Did you mean this?\\n  openclaw update\\n\` between the unknown-command error line and the \`Try:\` hint when (a) a typo is within edit-distance threshold OR (b) the input matches an entry in the explicit alias map AND the alias target is registered.

What was not tested: live binary spawn against a built \`openclaw\` CLI — covered transitively by the existing parse-error round-trip and \`run-main.exit.test.ts\` suite, which both call the same Commander \`outputError\` path.

## Coverage

Unit tests in \`src/cli/program/error-output.test.ts\`:

| Case | Asserts |
|---|---|
| typo \`upate\` with full \`knownCommands\` | suggestion \`openclaw update\` |
| explicit alias \`upgrade\` | suggestion \`openclaw update\` even though distance picks differently |
| off-vocabulary \`zzqwerty\` | no \`Did you mean this?\` line |
| legacy caller without \`knownCommands\` | output unchanged |
| \`suggestClosestCommand\` direct: typo / off-vocab / alias / empty / case-insensitive | helper-level coverage |

## Notes

- No public API change; \`knownCommands\` is additive on an existing options bag.
- Local lint+format wrappers (\`node scripts/run-oxlint.mjs\`, \`pnpm format\`) hit a pre-existing dts boundary failure on \`@openclaw/proxyline\` unrelated to this PR; ran \`./node_modules/.bin/oxlint --type-aware\` and \`./node_modules/.bin/oxfmt --write\` directly on the touched files.