### PR TITLE
fix(cli): honor --no-prefix-cwd in acp

### DIFF
--- a/src/cli/acp-cli.option-collisions.test.ts
+++ b/src/cli/acp-cli.option-collisions.test.ts
@@ -11,6 +11,7 @@ type AcpClientOptions = {
 type AcpGatewayOptions = {
   gatewayPassword?: string;
   gatewayToken?: string;
+  prefixCwd?: boolean;
 };
 
 const mocks = vi.hoisted(() => ({
@@ -87,6 +88,26 @@ describe("acp cli option collisions", () => {
     expect(runAcpClientInteractive).toHaveBeenCalledTimes(1);
     const clientOptions = requireFirstMockArg(runAcpClientInteractive) as { verbose?: boolean };
     expect(clientOptions?.verbose).toBe(true);
+  });
+
+  it("forwards --no-prefix-cwd to the ACP bridge", async () => {
+    await parseAcp(["--no-prefix-cwd"]);
+
+    expect(serveAcpGateway).toHaveBeenCalledTimes(1);
+    const gatewayOptions = requireFirstMockArg(serveAcpGateway) as {
+      prefixCwd?: boolean;
+    };
+    expect(gatewayOptions?.prefixCwd).toBe(false);
+  });
+
+  it("defaults to prefixing the working directory", async () => {
+    await parseAcp([]);
+
+    expect(serveAcpGateway).toHaveBeenCalledTimes(1);
+    const gatewayOptions = requireFirstMockArg(serveAcpGateway) as {
+      prefixCwd?: boolean;
+    };
+    expect(gatewayOptions?.prefixCwd).toBe(true);
   });
 
   it("loads gateway token/password from files", async () => {

--- a/src/cli/acp-cli.ts
+++ b/src/cli/acp-cli.ts
@@ -22,7 +22,7 @@ export function registerAcpCli(program: Command) {
     .option("--session-label <label>", "Default session label to resolve")
     .option("--require-existing", "Fail if the session key/label does not exist", false)
     .option("--reset-session", "Reset the session key before first use", false)
-    .option("--no-prefix-cwd", "Do not prefix prompts with the working directory", false)
+    .option("--no-prefix-cwd", "Do not prefix prompts with the working directory")
     .option("--provenance <mode>", "ACP provenance mode: off, meta, or meta+receipt")
     .option("-v, --verbose", "Verbose logging to stderr", false)
     .addHelpText(
@@ -44,7 +44,7 @@ export function registerAcpCli(program: Command) {
           defaultSessionLabel: opts.sessionLabel as string | undefined,
           requireExistingSession: Boolean(opts.requireExisting),
           resetSession: Boolean(opts.resetSession),
-          prefixCwd: !opts.noPrefixCwd,
+          prefixCwd: opts.prefixCwd !== false,
           provenanceMode,
           verbose: Boolean(opts.verbose),
         });


### PR DESCRIPTION
## Summary

- Let Commander own the negated option default for --no-prefix-cwd.
- Read the positive prefixCwd option that Commander actually populates.
- Add ACP CLI coverage for both the explicit opt-out and the default behavior.

Closes #83901.

## Verification

- node scripts/run-vitest.mjs src/cli/acp-cli.option-collisions.test.ts src/acp/translator.prompt-prefix.test.ts
- Crabbox AWS cbx_1689d0ad78e9, run run_a406418db6fe: regression failed before the source patch, then the focused ACP CLI and translator tests passed after the patch (15/15).

## Real behavior proof

Behavior addressed: openclaw acp --no-prefix-cwd now forwards prefixCwd=false into the ACP bridge so prompts are not prefixed with [Working directory: ...]; the default path still forwards prefixCwd=true.
Real environment tested: Fresh checkout of this PR branch after pnpm install and pnpm build, using a live ACP translator harness from the checkout; maintainer follow-up also verified focused behavior on AWS Crabbox Linux lease cbx_1689d0ad78e9.
Exact steps or command run after this patch: Build the PR checkout, run the ACP translator harness once with the default prefixCwd path and once with the --no-prefix-cwd / prefixCwd=false path, then run node scripts/run-vitest.mjs src/cli/acp-cli.option-collisions.test.ts src/acp/translator.prompt-prefix.test.ts -- --reporter=verbose.
Evidence after fix: The live ACP translator harness printed this after-fix output:

    default prefixCwd=true
    [Working directory: ~/openclaw-test]

    hello
    ---
    with --no-prefix-cwd / prefixCwd=false
    hello

Observed result after fix: The default path still prefixes the working directory, and the --no-prefix-cwd path suppresses that prefix. Focused tests also passed with 15 passed; the same regression test failed before the source patch with prefixCwd received as true.
What was not tested: No long-running interactive ACP server was left running; the live proof used a bounded ACP translator harness and the maintainer proof used focused CLI/translator tests.
