### PR TITLE
Fix managed Gateway updates across CLI and service Node skew

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 - Providers/Ollama: default unknown-capabilities models to tool-capable so discovered native Ollama models can use tools when `/api/show` omits capabilities. (#84055) Thanks @dutifulbob.
 - Installer/Windows: launch `install.ps1` onboarding as an attached child process so fresh native Windows installs do not freeze visibly at `Starting setup...` or corrupt the wizard's terminal rendering.
 - Memory/search: close local embedding providers when active-memory searches time out so pending local model loads and embedding contexts are aborted and released. (#83858) Thanks @brokemac79.
+- CLI/update: validate the managed Gateway service Node before package replacement, so `openclaw update` no longer updates a service that cannot run the target release. Thanks @amknight.
 - Agents: include bounded trajectory queued-writer diagnostics in `pi-trajectory-flush` timeout warnings so flush stalls show pending writes, queued bytes, and append state. Fixes #82961. (#82962) Thanks @galiniliev.
 - Agents/subagents: recover stale completion announces by retrying unsupported transcript-wait wakes without transcript waiting and forcing a message-tool handoff when the requester run is already stale. Fixes #83699. (#83700) Thanks @galiniliev.
 - Agents/subagents: skip stale embedded-run wake probes for dormant completion requesters, so late subagent completions go straight to requester-agent/direct handoff instead of producing `reason=no_active_run` queue noise. (#82964) Thanks @galiniliev.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ Docs: https://docs.openclaw.ai
 
 - Providers/Ollama: default unknown-capabilities models to tool-capable so discovered native Ollama models can use tools when `/api/show` omits capabilities. (#84055) Thanks @dutifulbob.
 - Installer/Windows: launch `install.ps1` onboarding as an attached child process so fresh native Windows installs do not freeze visibly at `Starting setup...` or corrupt the wizard's terminal rendering.
+- CLI/update: keep restart health checks working across one-version CLI/Gateway protocol skew and use the managed Gateway service Node for all follow-up commands even when the package root is unchanged, so `openclaw update` no longer silently switches the gateway to a different Node binary when multiple Node installations are present. Thanks @amknight.
 - Memory/search: close local embedding providers when active-memory searches time out so pending local model loads and embedding contexts are aborted and released. (#83858) Thanks @brokemac79.
-- CLI/update: validate the managed Gateway service Node before package replacement, so `openclaw update` no longer updates a service that cannot run the target release. Thanks @amknight.
+
 - Agents: include bounded trajectory queued-writer diagnostics in `pi-trajectory-flush` timeout warnings so flush stalls show pending writes, queued bytes, and append state. Fixes #82961. (#82962) Thanks @galiniliev.
 - Agents/subagents: recover stale completion announces by retrying unsupported transcript-wait wakes without transcript waiting and forcing a message-tool handoff when the requester run is already stale. Fixes #83699. (#83700) Thanks @galiniliev.
 - Agents/subagents: skip stale embedded-run wake probes for dormant completion requesters, so late subagent completions go straight to requester-agent/direct handoff instead of producing `reason=no_active_run` queue noise. (#82964) Thanks @galiniliev.

--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -67,6 +67,13 @@ from that checkout. The `stable` and `beta` channels use package installs. If th
 gateway is already installed, `openclaw update` refreshes the service metadata
 and restarts it unless you pass `--no-restart`.
 
+For package installs with a managed Gateway service, `openclaw update` targets
+the package root used by that service. If the shell `openclaw` command comes
+from a different install, the updater prints both roots and the managed service
+Node path. The package update uses the package manager that owns the service
+root and checks the managed service Node against the target release engine
+before replacing the package.
+
 ## Alternative: re-run the installer
 
 ```bash

--- a/scripts/e2e/multi-node-update-docker.sh
+++ b/scripts/e2e/multi-node-update-docker.sh
@@ -34,6 +34,7 @@ docker_e2e_package_mount_args "$PACKAGE_TGZ"
 
 echo "=== Running multi-node-update Docker E2E ==="
 
+CONTAINER_EXIT=0
 docker_e2e_run_with_harness \
   -e COREPACK_ENABLE_DOWNLOAD_PROMPT=0 \
   -e CI=true \
@@ -209,6 +210,8 @@ echo "systemctl shim installed."
 # Now install the gateway service using node-A.
 echo "Installing gateway service..."
 mkdir -p "$(dirname "$GATEWAY_UNIT_PATH")"
+# gateway install may exit non-zero because our systemctl shim cannot fully
+# restart, but the unit file gets written before the restart step.
 openclaw gateway install --json >"$ARTIFACTS/gateway-install.json" 2>"$ARTIFACTS/gateway-install.err" || true
 
 echo ""
@@ -222,11 +225,11 @@ if [ -f "$GATEWAY_UNIT_PATH" ]; then
   BAKED_NODE_BEFORE="$(echo "$EXEC_START_BEFORE" | sed "s/^ExecStart=//" | awk "{print \$1}")"
   echo "Baked node path BEFORE update: $BAKED_NODE_BEFORE"
 else
-  echo "WARNING: Gateway unit file was not created at $GATEWAY_UNIT_PATH"
-  ls -la "$(dirname "$GATEWAY_UNIT_PATH")/" 2>/dev/null || true
+  echo "FAIL: Gateway unit file was not created at $GATEWAY_UNIT_PATH"
   echo "gateway install output:"
   cat "$ARTIFACTS/gateway-install.json" 2>/dev/null || true
   cat "$ARTIFACTS/gateway-install.err" 2>/dev/null || true
+  exit 1
 fi
 
 echo ""
@@ -251,13 +254,23 @@ echo "── Step 6: Run openclaw update (this is the bug) ──"
 # `gateway install --force` and bakes the current process.execPath
 # (now node-B) into the service unit. This is where the split happens.
 echo "Running openclaw update --yes --json..."
+UPDATE_EXIT=0
 openclaw update --yes --json \
   --tag /tmp/openclaw-current.tgz \
-  >"$ARTIFACTS/update.json" 2>"$ARTIFACTS/update.err" || true
+  >"$ARTIFACTS/update.json" 2>"$ARTIFACTS/update.err" || UPDATE_EXIT=$?
 
 echo ""
+echo "Update exit code: $UPDATE_EXIT"
 echo "Update stderr (if any):"
 cat "$ARTIFACTS/update.err" 2>/dev/null | tail -10 || true
+
+# The update may fail during restart (systemctl shim limitations) but it must
+# have at least attempted the package install. Check that it ran past early exit.
+if [ "$UPDATE_EXIT" -ne 0 ] && ! grep -q "gateway" "$ARTIFACTS/update.err" 2>/dev/null; then
+  echo "FAIL: openclaw update failed before reaching the package install step"
+  cat "$ARTIFACTS/update.err" 2>/dev/null || true
+  exit 1
+fi
 
 echo ""
 echo "── Step 7: Inspect the service unit AFTER update ──"
@@ -354,7 +367,24 @@ echo "========================================"
 echo "  Reproduction complete."
 echo "  Artifacts saved to /tmp/artifacts/"
 echo "========================================"
-'
+
+# ── Final exit code ──────────────────────────────────────────────────────────
+# Exit non-zero if any BUG was found, making this usable as a CI gate.
+EXIT_CODE=0
+if [ "$BAKED_NODE_AFTER" = "$NODE_B" ] && [ "$BAKED_NODE_BEFORE" != "$NODE_B" ]; then
+  EXIT_CODE=1
+fi
+if [ -f "$NPM_PREFIX_B/lib/node_modules/openclaw/package.json" ]; then
+  EXIT_CODE=1
+fi
+if [ -f "$GATEWAY_UNIT_PATH" ]; then
+  ENTRYPOINT_PATH_CHECK="$(grep "^ExecStart=" "$GATEWAY_UNIT_PATH" | head -1 | sed "s/^ExecStart=//" | awk "{print \$2}")" || true
+  if [ -n "$ENTRYPOINT_PATH_CHECK" ] && [ ! -f "$ENTRYPOINT_PATH_CHECK" ]; then
+    EXIT_CODE=1
+  fi
+fi
+exit $EXIT_CODE
+' || CONTAINER_EXIT=$?
 
 echo ""
 echo "=== Artifacts ==="
@@ -366,3 +396,9 @@ if [ -f "$ARTIFACT_DIR/run.log" ]; then
   echo "=== Key results ==="
   grep -E "^(BUG|FIXED|OK|CHANGED|WARNING)" "$ARTIFACT_DIR/run.log" || echo "(no key results found)"
 fi
+
+if [ "$CONTAINER_EXIT" -ne 0 ]; then
+  echo ""
+  echo "FAIL: Docker container exited with code $CONTAINER_EXIT"
+fi
+exit "$CONTAINER_EXIT"

--- a/scripts/e2e/multi-node-update-docker.sh
+++ b/scripts/e2e/multi-node-update-docker.sh
@@ -1,0 +1,368 @@
+#!/usr/bin/env bash
+# Reproduces the multi-node-install update bug.
+#
+# Sets up two independent Node installations inside a Docker container, installs
+# OpenClaw under node-A, registers the gateway service pointing at node-A, then
+# switches PATH so node-B comes first and runs `openclaw update`. Verifies that:
+#
+# 1. The update targets the wrong install root (node-B npm prefix) or produces
+#    a gateway service definition pointing at node-B while the package lives
+#    under node-A.
+# 2. The gateway fails to start or runs a stale/missing entrypoint.
+#
+# Usage:
+#   ./scripts/e2e/multi-node-update-docker.sh
+#
+# Requires: Docker, a built openclaw-current.tgz (or will build one).
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "$ROOT_DIR/scripts/lib/docker-e2e-image.sh"
+source "$ROOT_DIR/scripts/lib/docker-e2e-package.sh"
+
+IMAGE_NAME="openclaw-multi-node-update-e2e"
+DOCKER_RUN_TIMEOUT="${OPENCLAW_MULTI_NODE_DOCKER_TIMEOUT:-300s}"
+ARTIFACT_DIR="${OPENCLAW_MULTI_NODE_ARTIFACT_DIR:-$ROOT_DIR/.artifacts/multi-node-update}"
+
+mkdir -p "$ARTIFACT_DIR"
+chmod -R a+rwX "$ARTIFACT_DIR" || true
+
+# Build the bare e2e image and prepare the package tarball.
+docker_e2e_build_or_reuse "$IMAGE_NAME" multi-node-update "$ROOT_DIR/scripts/e2e/Dockerfile" "$ROOT_DIR" "bare" "${OPENCLAW_SKIP_DOCKER_BUILD:-0}"
+PACKAGE_TGZ="$(docker_e2e_prepare_package_tgz multi-node-update "${OPENCLAW_CURRENT_PACKAGE_TGZ:-}")"
+docker_e2e_package_mount_args "$PACKAGE_TGZ"
+
+echo "=== Running multi-node-update Docker E2E ==="
+
+docker_e2e_run_with_harness \
+  -e COREPACK_ENABLE_DOWNLOAD_PROMPT=0 \
+  -e CI=true \
+  -e OPENCLAW_NO_ONBOARD=1 \
+  -e OPENCLAW_NO_PROMPT=1 \
+  -e OPENCLAW_SKIP_PROVIDERS=1 \
+  -e OPENCLAW_SKIP_CHANNELS=1 \
+  -e OPENCLAW_DISABLE_BONJOUR=1 \
+  -e OPENAI_API_KEY=sk-multi-node-test \
+  -v "$ARTIFACT_DIR:/tmp/artifacts" \
+  "${DOCKER_E2E_PACKAGE_ARGS[@]}" \
+  --user root \
+  -e HOME=/root \
+  "$IMAGE_NAME" \
+  timeout "$DOCKER_RUN_TIMEOUT" bash -lc '
+set -euo pipefail
+
+ARTIFACTS=/tmp/artifacts
+exec > >(tee "$ARTIFACTS/run.log") 2>&1
+
+echo "========================================"
+echo "  Multi-Node Update Bug Reproduction"
+echo "========================================"
+echo ""
+
+# ── Step 1: Create two separate Node installations ──────────────────────
+echo "── Step 1: Setting up two Node installations ──"
+
+# node-A is the system node that ships with the Docker image (node:24-bookworm-slim).
+NODE_A="$(command -v node)"
+NODE_A_DIR="$(dirname "$NODE_A")"
+NODE_A_VERSION="$("$NODE_A" --version)"
+echo "node-A: $NODE_A ($NODE_A_VERSION)"
+
+# Set up independent npm prefixes.
+NPM_PREFIX_A="/opt/npm-prefix-a"
+NPM_PREFIX_B="/opt/npm-prefix-b"
+mkdir -p "$NPM_PREFIX_A/bin" "$NPM_PREFIX_A/lib" "$NPM_PREFIX_B/bin" "$NPM_PREFIX_B/lib"
+
+# node-B is a second, full Node installation created by copying the entire
+# node prefix. This simulates having two real node installs (e.g. Homebrew +
+# nvm, or system node + volta).
+NODE_B_ROOT="/opt/node-b"
+NODE_A_PREFIX="$(dirname "$NODE_A_DIR")"
+mkdir -p "$NODE_B_ROOT"
+cp -a "$NODE_A_PREFIX/bin" "$NODE_B_ROOT/bin"
+cp -a "$NODE_A_PREFIX/lib" "$NODE_B_ROOT/lib"
+chmod -R +x "$NODE_B_ROOT/bin/"*
+# Configure node-B npm to use its own global prefix (not node-A prefix).
+export npm_config_prefix_orig="${npm_config_prefix:-}"
+"$NODE_B_ROOT/bin/node" "$NODE_B_ROOT/bin/npm" config set prefix "$NPM_PREFIX_B" --global 2>/dev/null || true
+NODE_B="$NODE_B_ROOT/bin/node"
+NODE_B_VERSION="$("$NODE_B" --version)"
+echo "node-B: $NODE_B ($NODE_B_VERSION)"
+
+echo ""
+echo "── Step 2: Install OpenClaw under node-A ──"
+
+# Use node-A to install openclaw with npm prefix A.
+export npm_config_prefix="$NPM_PREFIX_A"
+export NPM_CONFIG_PREFIX="$NPM_PREFIX_A"
+export npm_config_loglevel=error
+export npm_config_fund=false
+export npm_config_audit=false
+export PATH="$NPM_PREFIX_A/bin:$NODE_A_DIR:$PATH"
+
+echo "Installing OpenClaw package under node-A prefix: $NPM_PREFIX_A"
+npm install -g /tmp/openclaw-current.tgz --no-fund --no-audit >"$ARTIFACTS/install-a.log" 2>&1
+echo "Installed. Checking openclaw location..."
+
+OPENCLAW_A="$(command -v openclaw)"
+echo "openclaw binary: $OPENCLAW_A"
+echo "openclaw version: $(openclaw --version 2>/dev/null || echo unknown)"
+
+# Record the package root for node-A install.
+PACKAGE_ROOT_A="$NPM_PREFIX_A/lib/node_modules/openclaw"
+echo "Package root A: $PACKAGE_ROOT_A"
+ls -la "$PACKAGE_ROOT_A/package.json" 2>/dev/null || echo "WARNING: package.json not found at A"
+
+echo ""
+echo "── Step 3: Install the systemd service (gateway) using node-A ──"
+
+# Create a systemctl shim since we are in Docker (no real systemd).
+SHIM_DIR="/usr/local/bin"
+GATEWAY_UNIT_PATH="/root/.config/systemd/user/openclaw-gateway.service"
+SYSTEMCTL_LOG="$ARTIFACTS/systemctl-shim.log"
+GATEWAY_DAEMON_LOG="$ARTIFACTS/gateway-daemon.log"
+GATEWAY_PID_FILE="$ARTIFACTS/gateway.pid"
+: >"$SYSTEMCTL_LOG"
+
+cat >"$SHIM_DIR/systemctl" <<SHIMEOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf "%s %s\n" "\$(date -u +%H:%M:%S)" "\$*" >>"$SYSTEMCTL_LOG"
+
+filtered=()
+for arg in "\$@"; do
+  case "\$arg" in
+    --user|--quiet|--no-page|--now) ;;
+    *) filtered+=("\$arg") ;;
+  esac
+done
+command="\${filtered[0]:-status}"
+
+case "\$command" in
+  daemon-reload)
+    echo "daemon-reload (shim: no-op)"
+    ;;
+  enable)
+    echo "enable (shim: no-op)"
+    ;;
+  restart|start)
+    if [ -s "$GATEWAY_PID_FILE" ]; then
+      old_pid="\$(cat "$GATEWAY_PID_FILE" 2>/dev/null || true)"
+      if kill -0 "\$old_pid" 2>/dev/null; then
+        kill "\$old_pid" 2>/dev/null || true
+        sleep 0.5
+      fi
+    fi
+    unit="$GATEWAY_UNIT_PATH"
+    if [ ! -f "\$unit" ]; then
+      echo "systemctl shim: unit not found: \$unit" >&2
+      exit 1
+    fi
+    exec_start="\$(grep "^ExecStart=" "\$unit" | head -1 | sed "s/^ExecStart=//")"
+    if [ -z "\$exec_start" ]; then
+      echo "systemctl shim: no ExecStart in \$unit" >&2
+      exit 1
+    fi
+    # Source EnvironmentFile if present
+    env_file="\$(grep "^EnvironmentFile=" "\$unit" | head -1 | sed "s/^EnvironmentFile=//" | sed "s/^-//")"
+    if [ -n "\$env_file" ] && [ -f "\$env_file" ]; then
+      set -a; source "\$env_file"; set +a
+    fi
+    # Inline Environment= entries
+    while IFS= read -r env_line; do
+      env_entry="\${env_line#Environment=}"
+      env_entry="\${env_entry#\"}"
+      env_entry="\${env_entry%\"}"
+      export "\$env_entry"
+    done < <(grep "^Environment=" "\$unit" || true)
+    echo "systemctl shim: starting: \$exec_start"
+    eval nohup \$exec_start >>"$GATEWAY_DAEMON_LOG" 2>&1 &
+    echo "\$!" >"$GATEWAY_PID_FILE"
+    echo "systemctl shim: started pid \$(cat "$GATEWAY_PID_FILE")"
+    ;;
+  stop)
+    if [ -s "$GATEWAY_PID_FILE" ]; then
+      pid="\$(cat "$GATEWAY_PID_FILE")"
+      kill "\$pid" 2>/dev/null || true
+      rm -f "$GATEWAY_PID_FILE"
+    fi
+    ;;
+  is-active)
+    if [ -s "$GATEWAY_PID_FILE" ] && kill -0 "\$(cat "$GATEWAY_PID_FILE" 2>/dev/null)" 2>/dev/null; then
+      echo "active"
+    else
+      echo "inactive"
+      exit 3
+    fi
+    ;;
+  show)
+    echo "ActiveState=inactive"
+    ;;
+  *)
+    echo "systemctl shim: ignoring: \$*"
+    ;;
+esac
+SHIMEOF
+chmod +x "$SHIM_DIR/systemctl"
+echo "systemctl shim installed."
+
+# Now install the gateway service using node-A.
+echo "Installing gateway service..."
+mkdir -p "$(dirname "$GATEWAY_UNIT_PATH")"
+openclaw gateway install --json >"$ARTIFACTS/gateway-install.json" 2>"$ARTIFACTS/gateway-install.err" || true
+
+echo ""
+echo "── Step 4: Inspect what node path was baked into the service ──"
+
+if [ -f "$GATEWAY_UNIT_PATH" ]; then
+  echo "Service unit contents:"
+  cat "$GATEWAY_UNIT_PATH" | tee "$ARTIFACTS/unit-before-update.txt"
+  echo ""
+  EXEC_START_BEFORE="$(grep "^ExecStart=" "$GATEWAY_UNIT_PATH" | head -1)"
+  BAKED_NODE_BEFORE="$(echo "$EXEC_START_BEFORE" | sed "s/^ExecStart=//" | awk "{print \$1}")"
+  echo "Baked node path BEFORE update: $BAKED_NODE_BEFORE"
+else
+  echo "WARNING: Gateway unit file was not created at $GATEWAY_UNIT_PATH"
+  ls -la "$(dirname "$GATEWAY_UNIT_PATH")/" 2>/dev/null || true
+  echo "gateway install output:"
+  cat "$ARTIFACTS/gateway-install.json" 2>/dev/null || true
+  cat "$ARTIFACTS/gateway-install.err" 2>/dev/null || true
+fi
+
+echo ""
+echo "── Step 5: Switch PATH so node-B comes first ──"
+
+# Simulate the user scenario: their PATH changes (e.g. they installed
+# a second Node via nvm, brew, etc.) and the new node-B comes first.
+# Crucially, node-B has its own working npm with its own global prefix,
+# but openclaw is NOT installed there.
+export PATH="$NPM_PREFIX_B/bin:$NODE_B_ROOT/bin:$NPM_PREFIX_A/bin:$NODE_A_DIR:$PATH"
+
+# Verify node-B npm works independently.
+echo "node-B npm prefix: $($NODE_B_ROOT/bin/node $NODE_B_ROOT/bin/npm prefix -g 2>/dev/null || echo unknown)"
+echo "which node: $(command -v node)"
+echo "which openclaw: $(command -v openclaw)"
+echo "process.execPath will be: $(node -e "console.log(process.execPath)")"
+
+echo ""
+echo "── Step 6: Run openclaw update (this is the bug) ──"
+
+# Run the update WITH restart so that the update flow re-runs
+# `gateway install --force` and bakes the current process.execPath
+# (now node-B) into the service unit. This is where the split happens.
+echo "Running openclaw update --yes --json..."
+openclaw update --yes --json \
+  --tag /tmp/openclaw-current.tgz \
+  >"$ARTIFACTS/update.json" 2>"$ARTIFACTS/update.err" || true
+
+echo ""
+echo "Update stderr (if any):"
+cat "$ARTIFACTS/update.err" 2>/dev/null | tail -10 || true
+
+echo ""
+echo "── Step 7: Inspect the service unit AFTER update ──"
+
+if [ -f "$GATEWAY_UNIT_PATH" ]; then
+  echo "Service unit contents after update:"
+  cat "$GATEWAY_UNIT_PATH" | tee "$ARTIFACTS/unit-after-update.txt"
+  echo ""
+  EXEC_START_AFTER="$(grep "^ExecStart=" "$GATEWAY_UNIT_PATH" | head -1)"
+  BAKED_NODE_AFTER="$(echo "$EXEC_START_AFTER" | sed "s/^ExecStart=//" | awk "{print \$1}")"
+  echo "Baked node path AFTER update: $BAKED_NODE_AFTER"
+else
+  echo "No unit file after update."
+fi
+
+echo ""
+echo "── Step 8: Verify results ──"
+
+BAKED_NODE_BEFORE="${BAKED_NODE_BEFORE:-unknown}"
+BAKED_NODE_AFTER="${BAKED_NODE_AFTER:-unknown}"
+
+echo "Node A:              $NODE_A"
+echo "Node B:              $NODE_B"
+echo "Baked BEFORE update: $BAKED_NODE_BEFORE"
+echo "Baked AFTER update:  $BAKED_NODE_AFTER"
+echo "Package root A:      $PACKAGE_ROOT_A"
+echo ""
+
+# Check 1: Did the baked node path change from A to B?
+if [ "$BAKED_NODE_AFTER" = "$NODE_B" ] && [ "$BAKED_NODE_BEFORE" != "$NODE_B" ]; then
+  echo "BUG CONFIRMED: Gateway service now points at node-B ($NODE_B)"
+  echo "   but OpenClaw package is still under node-A prefix ($PACKAGE_ROOT_A)."
+  echo "   The gateway will use node-B to run an entrypoint that may reference"
+  echo "   node-A dependencies or may not exist under node-B global prefix."
+elif [ "$BAKED_NODE_AFTER" = "$BAKED_NODE_BEFORE" ]; then
+  echo "FIXED: Gateway service still points at the original node ($BAKED_NODE_AFTER)"
+else
+  echo "CHANGED: Node path changed from $BAKED_NODE_BEFORE to $BAKED_NODE_AFTER"
+fi
+
+# Check 2: Is the OpenClaw package installed under node-B npm prefix?
+if [ -f "$NPM_PREFIX_B/lib/node_modules/openclaw/package.json" ]; then
+  echo "WARNING: OpenClaw was ALSO installed under node-B prefix (split install)"
+else
+  echo "OK: OpenClaw is NOT under node-B prefix (expected: only under node-A)"
+fi
+
+# Check 3: Does the entrypoint in the unit file actually exist?
+if [ -f "$GATEWAY_UNIT_PATH" ]; then
+  EXEC_START_AFTER="$(grep "^ExecStart=" "$GATEWAY_UNIT_PATH" | head -1 | sed "s/^ExecStart=//")"
+  ENTRYPOINT_PATH="$(echo "$EXEC_START_AFTER" | awk "{print \$2}")"
+  if [ -n "$ENTRYPOINT_PATH" ] && [ ! -f "$ENTRYPOINT_PATH" ]; then
+    echo "BUG: Entrypoint in service unit does not exist: $ENTRYPOINT_PATH"
+  elif [ -n "$ENTRYPOINT_PATH" ]; then
+    echo "OK: Entrypoint exists: $ENTRYPOINT_PATH"
+  fi
+fi
+
+# Check 4: Were there any warnings about split install in the update output?
+if [ -f "$ARTIFACTS/update.err" ]; then
+  if grep -qi "Shell OpenClaw root differs" "$ARTIFACTS/update.err" 2>/dev/null; then
+    echo "OK: Update warned about split root"
+  fi
+  if grep -qi "Managed gateway service Node" "$ARTIFACTS/update.err" 2>/dev/null; then
+    echo "OK: Update showed the managed service Node path"
+  fi
+fi
+
+# Check 5: Try to start the gateway and see if it works.
+echo ""
+echo "── Step 9: Try starting the gateway with the post-update unit ──"
+
+if [ -f "$GATEWAY_UNIT_PATH" ]; then
+  systemctl restart 2>&1 || true
+  sleep 3
+  if [ -s "$GATEWAY_PID_FILE" ] && kill -0 "$(cat "$GATEWAY_PID_FILE" 2>/dev/null)" 2>/dev/null; then
+    echo "OK: Gateway started (pid $(cat "$GATEWAY_PID_FILE"))"
+    # Try a health probe.
+    if openclaw gateway status --json >"$ARTIFACTS/status.json" 2>&1; then
+      echo "OK: Gateway status probe succeeded"
+    else
+      echo "WARNING: Gateway status probe failed"
+    fi
+    # Stop it.
+    kill "$(cat "$GATEWAY_PID_FILE")" 2>/dev/null || true
+  else
+    echo "BUG: Gateway failed to start with the post-update unit"
+    cat "$GATEWAY_DAEMON_LOG" 2>/dev/null | tail -20 || true
+  fi
+fi
+
+echo ""
+echo "========================================"
+echo "  Reproduction complete."
+echo "  Artifacts saved to /tmp/artifacts/"
+echo "========================================"
+'
+
+echo ""
+echo "=== Artifacts ==="
+echo "Logs saved to: $ARTIFACT_DIR/"
+ls -la "$ARTIFACT_DIR/" 2>/dev/null || true
+
+if [ -f "$ARTIFACT_DIR/run.log" ]; then
+  echo ""
+  echo "=== Key results ==="
+  grep -E "^(BUG|FIXED|OK|CHANGED|WARNING)" "$ARTIFACT_DIR/run.log" || echo "(no key results found)"
+fi

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -3070,6 +3070,133 @@ describe("update-cli", () => {
     expect(serviceInstallCall?.[0][0]).toBe(serviceNode);
   });
 
+  it("uses the managed service Node when package roots match but node binaries differ", async () => {
+    const root = createCaseDir("openclaw-same-root");
+    // Service is baked with a different node than the current process.execPath.
+    const serviceNode = "/opt/other-node/bin/node";
+    const entrypoint = path.join(root, "dist", "index.js");
+    mockPackageInstallStatus(root);
+    serviceReadCommand.mockResolvedValue({
+      programArguments: [serviceNode, entrypoint, "gateway"],
+    });
+
+    await updateCommand({ dryRun: true });
+
+    const logs = vi
+      .mocked(defaultRuntime.log)
+      .mock.calls.map((call) => String(call[0]))
+      .join("\n");
+    // Should NOT log root redirect messages since the package root is the same.
+    expect(logs).not.toContain("Targeting managed gateway service package root");
+    // Should warn about the node binary mismatch.
+    expect(logs).toContain("differs from the managed gateway service Node");
+    expect(logs).toContain(serviceNode);
+    expect(logs).toContain(
+      "Using the managed service Node for this update so the gateway can start after the upgrade",
+    );
+  });
+
+  it("uses the managed service Node for follow-up commands when roots match but nodes differ", async () => {
+    const servicePrefix = await createTrackedTempDir("openclaw-service-prefix-");
+    const nodeModules = path.join(servicePrefix, "lib", "node_modules");
+    const root = path.join(nodeModules, "openclaw");
+    const serviceNode = path.join(servicePrefix, "bin", "node");
+    const serviceNpm = path.join(servicePrefix, "bin", "npm");
+    const entrypoint = path.join(root, "dist", "index.js");
+    await fs.mkdir(path.dirname(entrypoint), { recursive: true });
+    await fs.mkdir(path.dirname(serviceNode), { recursive: true });
+    await fs.writeFile(serviceNode, "", "utf-8");
+    await fs.writeFile(serviceNpm, "", "utf-8");
+    const serviceNpmReal = await fs.realpath(serviceNpm);
+    await fs.writeFile(
+      path.join(root, "package.json"),
+      JSON.stringify({ name: "openclaw", version: "2026.5.18" }),
+      "utf-8",
+    );
+    await fs.writeFile(entrypoint, "", "utf-8");
+    await writePackageDistInventory(root);
+    // Same package root for both shell and service.
+    mockPackageInstallStatus(root);
+    serviceReadCommand.mockResolvedValue({
+      programArguments: [serviceNode, entrypoint, "gateway"],
+    });
+    serviceLoaded.mockResolvedValue(true);
+    pathExists.mockImplementation(async (candidate: string) => {
+      try {
+        await fs.access(candidate);
+        return true;
+      } catch {
+        return false;
+      }
+    });
+    vi.mocked(runCommandWithTimeout).mockImplementation(async (argv) => {
+      if (Array.isArray(argv) && argv[0] === serviceNode && argv[1] === "--version") {
+        return {
+          stdout: "v24.14.0\n",
+          stderr: "",
+          code: 0,
+          signal: null,
+          killed: false,
+          termination: "exit",
+        };
+      }
+      if (
+        Array.isArray(argv) &&
+        (argv[0] === serviceNpm || argv[0] === serviceNpmReal) &&
+        argv[1] === "root" &&
+        argv[2] === "-g"
+      ) {
+        return {
+          stdout: `${nodeModules}\n`,
+          stderr: "",
+          code: 0,
+          signal: null,
+          killed: false,
+          termination: "exit",
+        };
+      }
+      if (
+        Array.isArray(argv) &&
+        (argv[0] === serviceNpm || argv[0] === serviceNpmReal) &&
+        argv[1] === "i"
+      ) {
+        const stagePrefix = argv.includes("--prefix")
+          ? argv[argv.indexOf("--prefix") + 1]
+          : undefined;
+        const stageRoot = stagePrefix
+          ? path.join(stagePrefix, "lib", "node_modules", "openclaw")
+          : root;
+        const stageEntryPoint = path.join(stageRoot, "dist", "index.js");
+        await fs.mkdir(path.dirname(stageEntryPoint), { recursive: true });
+        await fs.writeFile(
+          path.join(stageRoot, "package.json"),
+          JSON.stringify({ name: "openclaw", version: "2026.5.20" }),
+          "utf-8",
+        );
+        await fs.writeFile(stageEntryPoint, "export {};\n", "utf-8");
+        await writePackageDistInventory(stageRoot);
+      }
+      return {
+        stdout: "",
+        stderr: "",
+        code: 0,
+        signal: null,
+        killed: false,
+        termination: "exit",
+      };
+    });
+
+    await updateCommand({ yes: true });
+
+    // Follow-up commands should use the service Node, not process.execPath.
+    expect(doctorCommandCall()?.[0][0]).toBe(serviceNode);
+    expect(spawnCall()?.[0]).toBe(serviceNode);
+    const serviceInstallCall = commandCalls().find(
+      ([argv]) => argv[2] === "gateway" && argv[3] === "install",
+    );
+    expect(serviceInstallCall?.[0][0]).toBe(serviceNode);
+  });
+
   it("repairs legacy config before persisting a requested update channel", async () => {
     const tempDir = createCaseDir("openclaw-update");
     mockPackageInstallStatus(tempDir);

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -2885,6 +2885,191 @@ describe("update-cli", () => {
     );
   });
 
+  it("warns when a package update targets a managed service root outside the shell root", async () => {
+    const shellRoot = createCaseDir("openclaw-shell-root");
+    const serviceRoot = await createTrackedTempDir("openclaw-service-root-");
+    const serviceNode = path.join(path.dirname(serviceRoot), "bin", "node");
+    await fs.mkdir(path.join(serviceRoot, "dist"), { recursive: true });
+    await fs.writeFile(
+      path.join(serviceRoot, "package.json"),
+      JSON.stringify({ name: "openclaw", version: "2026.5.18" }),
+      "utf-8",
+    );
+    mockPackageInstallStatus(shellRoot);
+    serviceReadCommand.mockResolvedValue({
+      programArguments: [serviceNode, path.join(serviceRoot, "dist", "index.js"), "gateway"],
+    });
+
+    await updateCommand({ dryRun: true });
+
+    const logs = vi
+      .mocked(defaultRuntime.log)
+      .mock.calls.map((call) => String(call[0]))
+      .join("\n");
+    expect(logs).toContain(`Targeting managed gateway service package root: ${serviceRoot}`);
+    expect(logs).toContain(
+      `Shell OpenClaw root differs from the managed gateway service root: ${shellRoot}`,
+    );
+    expect(logs).toContain("make sure `openclaw` on PATH resolves to the managed service root");
+    expect(logs).toContain(`Managed gateway service Node: ${serviceNode}`);
+  });
+
+  it("checks the managed service Node runtime before updating a redirected package root", async () => {
+    const shellRoot = createCaseDir("openclaw-shell-root");
+    const serviceRoot = await createTrackedTempDir("openclaw-service-root-");
+    const serviceNode = path.join(path.dirname(serviceRoot), "bin", "node");
+    await fs.mkdir(path.join(serviceRoot, "dist"), { recursive: true });
+    await fs.mkdir(path.dirname(serviceNode), { recursive: true });
+    await fs.writeFile(serviceNode, "", "utf-8");
+    await fs.writeFile(
+      path.join(serviceRoot, "package.json"),
+      JSON.stringify({ name: "openclaw", version: "2026.5.18" }),
+      "utf-8",
+    );
+    mockPackageInstallStatus(shellRoot);
+    serviceReadCommand.mockResolvedValue({
+      programArguments: [serviceNode, path.join(serviceRoot, "dist", "index.js"), "gateway"],
+    });
+    vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue({
+      target: "latest",
+      version: "2026.5.20",
+      nodeEngine: ">=22.19.0",
+    });
+    vi.mocked(runCommandWithTimeout).mockImplementation(async (argv) => {
+      if (Array.isArray(argv) && argv[0] === serviceNode && argv[1] === "--version") {
+        return {
+          stdout: "v22.18.0\n",
+          stderr: "",
+          code: 0,
+          signal: null,
+          killed: false,
+          termination: "exit",
+        };
+      }
+      return {
+        stdout: "",
+        stderr: "",
+        code: 0,
+        signal: null,
+        killed: false,
+        termination: "exit",
+      };
+    });
+    nodeVersionSatisfiesEngine.mockReturnValue(false);
+
+    await updateCommand({ yes: true });
+
+    expect(nodeVersionSatisfiesEngine).toHaveBeenCalledWith("22.18.0", ">=22.19.0");
+    expect(packageInstallCommandCall()).toBeUndefined();
+    expect(serviceStop).not.toHaveBeenCalled();
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+    const errors = vi.mocked(defaultRuntime.error).mock.calls.map((call) => String(call[0]));
+    expect(errors.join("\n")).toContain(`Node 22.18.0 at ${serviceNode} is too old`);
+    expect(errors.join("\n")).toContain(
+      "Upgrade the Node runtime that owns the managed Gateway service",
+    );
+  });
+
+  it("runs managed service package follow-up commands with the service Node", async () => {
+    const shellRoot = createCaseDir("openclaw-shell-root");
+    const servicePrefix = await createTrackedTempDir("openclaw-service-prefix-");
+    const nodeModules = path.join(servicePrefix, "lib", "node_modules");
+    const serviceRoot = path.join(nodeModules, "openclaw");
+    const serviceNode = path.join(servicePrefix, "bin", "node");
+    const serviceNpm = path.join(servicePrefix, "bin", "npm");
+    const entrypoint = path.join(serviceRoot, "dist", "index.js");
+    await fs.mkdir(path.dirname(entrypoint), { recursive: true });
+    await fs.mkdir(path.dirname(serviceNode), { recursive: true });
+    await fs.writeFile(serviceNode, "", "utf-8");
+    await fs.writeFile(serviceNpm, "", "utf-8");
+    const serviceNpmReal = await fs.realpath(serviceNpm);
+    await fs.writeFile(
+      path.join(serviceRoot, "package.json"),
+      JSON.stringify({ name: "openclaw", version: "2026.5.18" }),
+      "utf-8",
+    );
+    await fs.writeFile(entrypoint, "", "utf-8");
+    await writePackageDistInventory(serviceRoot);
+    mockPackageInstallStatus(shellRoot);
+    serviceReadCommand.mockResolvedValue({
+      programArguments: [serviceNode, entrypoint, "gateway"],
+    });
+    serviceLoaded.mockResolvedValue(true);
+    pathExists.mockImplementation(async (candidate: string) => {
+      try {
+        await fs.access(candidate);
+        return true;
+      } catch {
+        return false;
+      }
+    });
+    vi.mocked(runCommandWithTimeout).mockImplementation(async (argv) => {
+      if (Array.isArray(argv) && argv[0] === serviceNode && argv[1] === "--version") {
+        return {
+          stdout: "v22.22.0\n",
+          stderr: "",
+          code: 0,
+          signal: null,
+          killed: false,
+          termination: "exit",
+        };
+      }
+      if (
+        Array.isArray(argv) &&
+        (argv[0] === serviceNpm || argv[0] === serviceNpmReal) &&
+        argv[1] === "root" &&
+        argv[2] === "-g"
+      ) {
+        return {
+          stdout: `${nodeModules}\n`,
+          stderr: "",
+          code: 0,
+          signal: null,
+          killed: false,
+          termination: "exit",
+        };
+      }
+      if (
+        Array.isArray(argv) &&
+        (argv[0] === serviceNpm || argv[0] === serviceNpmReal) &&
+        argv[1] === "i"
+      ) {
+        const stagePrefix = argv.includes("--prefix")
+          ? argv[argv.indexOf("--prefix") + 1]
+          : undefined;
+        const stageRoot = stagePrefix
+          ? path.join(stagePrefix, "lib", "node_modules", "openclaw")
+          : serviceRoot;
+        const stageEntryPoint = path.join(stageRoot, "dist", "index.js");
+        await fs.mkdir(path.dirname(stageEntryPoint), { recursive: true });
+        await fs.writeFile(
+          path.join(stageRoot, "package.json"),
+          JSON.stringify({ name: "openclaw", version: "2026.5.20" }),
+          "utf-8",
+        );
+        await fs.writeFile(stageEntryPoint, "export {};\n", "utf-8");
+        await writePackageDistInventory(stageRoot);
+      }
+      return {
+        stdout: "",
+        stderr: "",
+        code: 0,
+        signal: null,
+        killed: false,
+        termination: "exit",
+      };
+    });
+
+    await updateCommand({ yes: true });
+
+    expect(doctorCommandCall()?.[0][0]).toBe(serviceNode);
+    expect(spawnCall()?.[0]).toBe(serviceNode);
+    const serviceInstallCall = commandCalls().find(
+      ([argv]) => argv[2] === "gateway" && argv[3] === "install",
+    );
+    expect(serviceInstallCall?.[0][0]).toBe(serviceNode);
+  });
+
   it("repairs legacy config before persisting a requested update channel", async () => {
     const tempDir = createCaseDir("openclaw-update");
     mockPackageInstallStatus(tempDir);

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -3197,6 +3197,110 @@ describe("update-cli", () => {
     expect(serviceInstallCall?.[0][0]).toBe(serviceNode);
   });
 
+  it("pins package install to the service root when nodes differ and no owning npm exists at the prefix", async () => {
+    const servicePrefix = await createTrackedTempDir("openclaw-no-npm-prefix-");
+    const nodeModules = path.join(servicePrefix, "lib", "node_modules");
+    const root = path.join(nodeModules, "openclaw");
+    const serviceNode = path.join(servicePrefix, "bin", "node");
+    const entrypoint = path.join(root, "dist", "index.js");
+    // Create the node binary but intentionally do NOT create <prefix>/bin/npm
+    // so resolvePreferredNpmCommand returns null and the PATH npm is used.
+    await fs.mkdir(path.dirname(entrypoint), { recursive: true });
+    await fs.mkdir(path.dirname(serviceNode), { recursive: true });
+    await fs.writeFile(serviceNode, "", "utf-8");
+    // No npm binary at servicePrefix/bin/npm!
+    await fs.writeFile(
+      path.join(root, "package.json"),
+      JSON.stringify({ name: "openclaw", version: "2026.5.18" }),
+      "utf-8",
+    );
+    await fs.writeFile(entrypoint, "", "utf-8");
+    await writePackageDistInventory(root);
+    mockPackageInstallStatus(root);
+    serviceReadCommand.mockResolvedValue({
+      programArguments: [serviceNode, entrypoint, "gateway"],
+    });
+    serviceLoaded.mockResolvedValue(true);
+    pathExists.mockImplementation(async (candidate: string) => {
+      try {
+        await fs.access(candidate);
+        return true;
+      } catch {
+        return false;
+      }
+    });
+    // The PATH npm returns a DIFFERENT global root (simulates Node-B's npm).
+    const nodeBGlobalRoot = path.join(
+      await createTrackedTempDir("node-b-global-"),
+      "lib",
+      "node_modules",
+    );
+    await fs.mkdir(nodeBGlobalRoot, { recursive: true });
+    vi.mocked(runCommandWithTimeout).mockImplementation(async (argv) => {
+      if (Array.isArray(argv) && argv[0] === serviceNode && argv[1] === "--version") {
+        return {
+          stdout: "v24.14.0\n",
+          stderr: "",
+          code: 0,
+          signal: null,
+          killed: false,
+          termination: "exit",
+        };
+      }
+      if (Array.isArray(argv) && argv[0] === "npm" && argv[1] === "root" && argv[2] === "-g") {
+        // PATH npm returns Node-B's root, NOT the service root.
+        return {
+          stdout: `${nodeBGlobalRoot}\n`,
+          stderr: "",
+          code: 0,
+          signal: null,
+          killed: false,
+          termination: "exit",
+        };
+      }
+      if (Array.isArray(argv) && argv[0] === "npm" && argv[1] === "i") {
+        // Install step: create the expected package structure at the target.
+        const prefixIdx = argv.indexOf("--prefix");
+        const stagePrefix = prefixIdx >= 0 ? argv[prefixIdx + 1] : undefined;
+        const stageRoot = stagePrefix
+          ? path.join(stagePrefix, "lib", "node_modules", "openclaw")
+          : root;
+        const stageEntryPoint = path.join(stageRoot, "dist", "index.js");
+        await fs.mkdir(path.dirname(stageEntryPoint), { recursive: true });
+        await fs.writeFile(
+          path.join(stageRoot, "package.json"),
+          JSON.stringify({ name: "openclaw", version: "2026.5.20" }),
+          "utf-8",
+        );
+        await fs.writeFile(stageEntryPoint, "export {};\n", "utf-8");
+        await writePackageDistInventory(stageRoot);
+      }
+      return {
+        stdout: "",
+        stderr: "",
+        code: 0,
+        signal: null,
+        killed: false,
+        termination: "exit",
+      };
+    });
+
+    await updateCommand({ yes: true });
+
+    // The install command must use --prefix pointing to a location within
+    // the service root's prefix tree, NOT Node-B's global root.
+    const installCall = packageInstallCommandCall();
+    expect(installCall).toBeDefined();
+    const installArgv = installCall![0];
+    const prefixIdx = installArgv.indexOf("--prefix");
+    expect(prefixIdx).toBeGreaterThan(-1);
+    // Staging prefix should be under the service prefix, not Node-B's.
+    expect(installArgv[prefixIdx + 1]).toContain(servicePrefix);
+    expect(installArgv[prefixIdx + 1]).not.toContain(nodeBGlobalRoot);
+    // Follow-up commands use the service node.
+    expect(doctorCommandCall()?.[0][0]).toBe(serviceNode);
+  });
+
   it("repairs legacy config before persisting a requested update channel", async () => {
     const tempDir = createCaseDir("openclaw-update");
     mockPackageInstallStatus(tempDir);

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -1278,6 +1278,31 @@ function resolveManagedServiceNodeRunner(
   return isNodeExecutable(runner) ? runner : undefined;
 }
 
+/**
+ * Resolve the node binary baked into the managed gateway service unit,
+ * independent of any package root redirect. This detects when the user's
+ * current PATH-resolved node differs from the service's baked node even
+ * when the package root is the same.
+ */
+async function resolveManagedServiceNodeRunnerOverride(): Promise<string | undefined> {
+  const command = await resolveGatewayService()
+    .readCommand(process.env)
+    .catch(() => null);
+  const serviceNode = resolveManagedServiceNodeRunner(command);
+  if (!serviceNode) {
+    return undefined;
+  }
+  const currentNode = resolveNodeRunner();
+  const [serviceNodeReal, currentNodeReal] = await Promise.all([
+    tryRealpathOrResolve(serviceNode),
+    tryRealpathOrResolve(currentNode),
+  ]);
+  if (serviceNodeReal === currentNodeReal) {
+    return undefined;
+  }
+  return serviceNode;
+}
+
 async function resolveManagedServicePackageUpdateRoot(params: {
   root: string;
 }): Promise<ManagedServiceRootRedirect | null> {
@@ -2963,11 +2988,16 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
   let packageInstallSpec: string | null = null;
   let packageAlreadyCurrent = false;
   let managedServiceRootRedirect: ManagedServiceRootRedirect | null = null;
+  // Resolved independently of the root redirect so it covers the common case
+  // where the package root is the same but the user's PATH-resolved node
+  // differs from the node baked into the managed gateway service unit.
+  let managedServiceNodeRunner: string | undefined;
 
   if (updateInstallKind === "package") {
     managedServiceRootRedirect = await resolveManagedServicePackageUpdateRoot({ root });
     if (managedServiceRootRedirect) {
       root = managedServiceRootRedirect.root;
+      managedServiceNodeRunner = managedServiceRootRedirect.nodeRunner;
       if (!opts.json) {
         defaultRuntime.log(
           theme.muted(
@@ -2984,11 +3014,27 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
             `After the update, make sure \`${CLI_NAME}\` on PATH resolves to the managed service root or reinstall the gateway service from the shell install you want to use.`,
           ),
         );
-        if (managedServiceRootRedirect.nodeRunner) {
+        if (managedServiceNodeRunner) {
           defaultRuntime.log(
-            theme.muted(`Managed gateway service Node: ${managedServiceRootRedirect.nodeRunner}`),
+            theme.muted(`Managed gateway service Node: ${managedServiceNodeRunner}`),
           );
         }
+      }
+    } else {
+      // Roots match but the node binary may still differ (e.g. user switched
+      // nvm/fnm/brew node after gateway install).
+      managedServiceNodeRunner = await resolveManagedServiceNodeRunnerOverride();
+      if (managedServiceNodeRunner && !opts.json) {
+        defaultRuntime.log(
+          theme.warn(
+            `Current Node (${resolveNodeRunner()}) differs from the managed gateway service Node (${managedServiceNodeRunner}).`,
+          ),
+        );
+        defaultRuntime.log(
+          theme.muted(
+            `Using the managed service Node for this update so the gateway can start after the upgrade.`,
+          ),
+        );
       }
     }
   }
@@ -3140,7 +3186,7 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
     const runtimePreflightError = await resolvePackageRuntimePreflightError({
       tag,
       timeoutMs,
-      nodeRunner: managedServiceRootRedirect?.nodeRunner,
+      nodeRunner: managedServiceNodeRunner,
     });
     if (runtimePreflightError) {
       defaultRuntime.error(runtimePreflightError);
@@ -3209,7 +3255,7 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
             managedServiceEnv: prePackageServiceStop?.serviceEnv,
             invocationCwd,
             honorPackageRoot: managedServiceRootRedirect !== null,
-            nodeRunner: managedServiceRootRedirect?.nodeRunner,
+            nodeRunner: managedServiceNodeRunner,
           })
         : await runGitUpdate({
             root,
@@ -3335,7 +3381,7 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
       opts,
       pluginInstallRecords: preUpdatePluginInstallRecords,
       updateStartedAtMs: startedAt,
-      nodeRunner: managedServiceRootRedirect?.nodeRunner,
+      nodeRunner: managedServiceNodeRunner,
       preUpdateConfig: configSnapshot.valid
         ? {
             sourceConfig: configSnapshot.sourceConfig,
@@ -3461,7 +3507,7 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
     gatewayPort,
     restartScriptPath,
     invocationCwd,
-    nodeRunner: managedServiceRootRedirect?.nodeRunner,
+    nodeRunner: managedServiceNodeRunner,
   });
   if (!restartOk) {
     await markControlPlaneUpdateRestartSentinelFailureBestEffort({

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -33,6 +33,7 @@ import { resolveGatewayInstallEntrypoint } from "../../daemon/gateway-entrypoint
 import { disableCurrentOpenClawUpdateLaunchdJob } from "../../daemon/launchd.js";
 import { resolveGatewayRestartLogPath } from "../../daemon/restart-logs.js";
 import { summarizeGatewayServiceLayout } from "../../daemon/service-layout.js";
+import type { GatewayServiceCommandConfig } from "../../daemon/service-types.js";
 import {
   readGatewayServiceState,
   resolveGatewayService,
@@ -749,6 +750,12 @@ type PrePackageServiceStop = {
   serviceEnv?: NodeJS.ProcessEnv;
 };
 
+type ManagedServiceRootRedirect = {
+  root: string;
+  previousRoot: string;
+  nodeRunner?: string;
+};
+
 function formatGatewayAncestryBlockMessage(pid: number): string {
   return `openclaw update detected it is running inside the gateway process tree.
 Gateway PID ${pid} is an ancestor of this process, so this updater cannot safely stop or restart the gateway that owns it.
@@ -929,6 +936,7 @@ function tryResolveInvocationCwd(): string | undefined {
 async function resolvePackageRuntimePreflightError(params: {
   tag: string;
   timeoutMs?: number;
+  nodeRunner?: string;
 }): Promise<string | null> {
   if (!canResolveRegistryVersionForPackageTarget(params.tag)) {
     return null;
@@ -944,18 +952,43 @@ async function resolvePackageRuntimePreflightError(params: {
   if (status.error) {
     return null;
   }
-  const satisfies = nodeVersionSatisfiesEngine(process.versions.node ?? null, status.nodeEngine);
+  const runtime = await resolvePackageRuntimeForPreflight({
+    nodeRunner: params.nodeRunner,
+    timeoutMs: params.timeoutMs,
+  });
+  const satisfies = nodeVersionSatisfiesEngine(runtime.version, status.nodeEngine);
   if (satisfies !== false) {
     return null;
   }
   const targetLabel = status.version ?? target;
+  const runtimeLabel = runtime.nodeRunner
+    ? `Node ${runtime.version ?? "unknown"} at ${runtime.nodeRunner}`
+    : `Node ${runtime.version ?? "unknown"}`;
   return [
-    `Node ${process.versions.node ?? "unknown"} is too old for openclaw@${targetLabel}.`,
+    `${runtimeLabel} is too old for openclaw@${targetLabel}.`,
     `The requested package requires ${status.nodeEngine}.`,
-    "Upgrade Node to 22.19+ or Node 24, then rerun `openclaw update`.",
+    runtime.nodeRunner
+      ? "Upgrade the Node runtime that owns the managed Gateway service, then rerun `openclaw update`."
+      : "Upgrade Node to 22.19+ or Node 24, then rerun `openclaw update`.",
     "Bare `npm i -g openclaw` can silently install an older compatible release.",
     "After upgrading Node, use `npm i -g openclaw@latest`.",
   ].join("\n");
+}
+
+async function resolvePackageRuntimeForPreflight(params: {
+  nodeRunner?: string;
+  timeoutMs?: number;
+}): Promise<{ version: string | null; nodeRunner?: string }> {
+  const nodeRunner = normalizeOptionalString(params.nodeRunner);
+  if (!nodeRunner) {
+    return { version: process.versions.node ?? null };
+  }
+  const res = await runCommandWithTimeout([nodeRunner, "--version"], {
+    timeoutMs: Math.min(params.timeoutMs ?? 10_000, 10_000),
+  }).catch(() => null);
+  const rawVersion = res?.code === 0 ? res.stdout.trim() : "";
+  const version = rawVersion.replace(/^v/u, "") || null;
+  return { version, nodeRunner };
 }
 
 function resolveServiceRefreshEnv(
@@ -1094,6 +1127,7 @@ async function refreshGatewayServiceEnv(params: {
   jsonMode: boolean;
   invocationCwd?: string;
   env?: NodeJS.ProcessEnv;
+  nodeRunner?: string;
 }): Promise<void> {
   const args = ["gateway", "install", "--force"];
   if (params.jsonMode) {
@@ -1102,11 +1136,14 @@ async function refreshGatewayServiceEnv(params: {
 
   const entrypoint = await resolveGatewayInstallEntrypoint(params.result.root);
   if (entrypoint) {
-    const res = await runCommandWithTimeout([resolveNodeRunner(), entrypoint, ...args], {
-      cwd: params.result.root,
-      env: resolveUpdatedInstallCommandEnv(params.env ?? process.env, params.invocationCwd),
-      timeoutMs: SERVICE_REFRESH_TIMEOUT_MS,
-    });
+    const res = await runCommandWithTimeout(
+      [params.nodeRunner ?? resolveNodeRunner(), entrypoint, ...args],
+      {
+        cwd: params.result.root,
+        env: resolveUpdatedInstallCommandEnv(params.env ?? process.env, params.invocationCwd),
+        timeoutMs: SERVICE_REFRESH_TIMEOUT_MS,
+      },
+    );
     if (res.code === 0) {
       return;
     }
@@ -1129,6 +1166,7 @@ async function runUpdatedInstallGatewayRestart(params: {
   jsonMode: boolean;
   invocationCwd?: string;
   env?: NodeJS.ProcessEnv;
+  nodeRunner?: string;
 }): Promise<boolean> {
   const entrypoint = await resolveGatewayInstallEntrypoint(params.result.root);
   if (!entrypoint) {
@@ -1141,11 +1179,14 @@ async function runUpdatedInstallGatewayRestart(params: {
   if (params.jsonMode) {
     args.push("--json");
   }
-  const res = await runCommandWithTimeout([resolveNodeRunner(), entrypoint, ...args], {
-    cwd: params.result.root,
-    env: resolveUpdatedInstallCommandEnv(params.env ?? process.env, params.invocationCwd),
-    timeoutMs: SERVICE_REFRESH_TIMEOUT_MS,
-  });
+  const res = await runCommandWithTimeout(
+    [params.nodeRunner ?? resolveNodeRunner(), entrypoint, ...args],
+    {
+      cwd: params.result.root,
+      env: resolveUpdatedInstallCommandEnv(params.env ?? process.env, params.invocationCwd),
+      timeoutMs: SERVICE_REFRESH_TIMEOUT_MS,
+    },
+  );
   if (res.code === 0) {
     return true;
   }
@@ -1217,9 +1258,29 @@ async function tryRealpathOrResolve(value: string): Promise<string> {
   }
 }
 
+function isNodeExecutable(value: string | undefined): boolean {
+  const base = normalizeOptionalString(value ? path.basename(value) : undefined)?.toLowerCase();
+  return base === "node" || base === "node.exe";
+}
+
+function resolveManagedServiceNodeRunner(
+  command: GatewayServiceCommandConfig | null,
+): string | undefined {
+  const args = command?.programArguments;
+  if (!args?.length) {
+    return undefined;
+  }
+  const gatewayIndex = args.indexOf("gateway");
+  if (gatewayIndex <= 1) {
+    return undefined;
+  }
+  const runner = args[gatewayIndex - 2];
+  return isNodeExecutable(runner) ? runner : undefined;
+}
+
 async function resolveManagedServicePackageUpdateRoot(params: {
   root: string;
-}): Promise<{ root: string; previousRoot: string } | null> {
+}): Promise<ManagedServiceRootRedirect | null> {
   const command = await resolveGatewayService()
     .readCommand(process.env)
     .catch(() => null);
@@ -1235,7 +1296,12 @@ async function resolveManagedServicePackageUpdateRoot(params: {
   if (currentRootReal === serviceRootReal) {
     return null;
   }
-  return { root: serviceRoot, previousRoot: params.root };
+  const nodeRunner = resolveManagedServiceNodeRunner(command);
+  return {
+    root: serviceRoot,
+    previousRoot: params.root,
+    ...(nodeRunner ? { nodeRunner } : {}),
+  };
 }
 
 async function runPackageInstallUpdate(params: {
@@ -1249,6 +1315,7 @@ async function runPackageInstallUpdate(params: {
   managedServiceEnv?: NodeJS.ProcessEnv;
   invocationCwd?: string;
   honorPackageRoot?: boolean;
+  nodeRunner?: string;
 }): Promise<UpdateRunResult> {
   const manager = await resolveGlobalManager({
     root: params.root,
@@ -1313,7 +1380,13 @@ async function runPackageInstallUpdate(params: {
         await createUpdateConfigSnapshot();
         return await runUpdateStep({
           name: `${CLI_NAME} doctor`,
-          argv: [resolveNodeRunner(), entryPath, "doctor", "--non-interactive", "--fix"],
+          argv: [
+            params.nodeRunner ?? resolveNodeRunner(),
+            entryPath,
+            "doctor",
+            "--non-interactive",
+            "--fix",
+          ],
           cwd: verifiedPackageRoot,
           env: {
             ...resolvePostInstallDoctorEnv({
@@ -1785,6 +1858,7 @@ async function maybeRestartService(params: {
   gatewayPort: number;
   restartScriptPath?: string | null;
   invocationCwd?: string;
+  nodeRunner?: string;
 }): Promise<boolean> {
   const verifyRestartedGateway = async (expectedGatewayVersion: string | undefined) => {
     const restartAfterStaleCleanup = async () => {
@@ -1794,6 +1868,7 @@ async function maybeRestartService(params: {
           jsonMode: Boolean(params.opts.json),
           invocationCwd: params.invocationCwd,
           env: params.serviceEnv,
+          nodeRunner: params.nodeRunner,
         });
         return;
       }
@@ -1907,6 +1982,7 @@ async function maybeRestartService(params: {
             jsonMode: Boolean(params.opts.json),
             invocationCwd: params.invocationCwd,
             env: params.serviceEnv,
+            nodeRunner: params.nodeRunner,
           });
         } catch (err) {
           // Always log the refresh failure so callers can detect it (issue #56772).
@@ -1955,6 +2031,7 @@ async function maybeRestartService(params: {
           jsonMode: Boolean(params.opts.json),
           invocationCwd: params.invocationCwd,
           env: params.serviceEnv,
+          nodeRunner: params.nodeRunner,
         });
       } else if (
         !refreshedGatewayAlreadyHealthy &&
@@ -2548,6 +2625,7 @@ async function continuePostCoreUpdateInFreshProcess(params: {
   pluginInstallRecords: Record<string, PluginInstallRecord>;
   preUpdateConfig?: PreUpdateConfigRestoreInput;
   updateStartedAtMs: number;
+  nodeRunner?: string;
 }): Promise<{ resumed: boolean; pluginUpdate?: PostCorePluginUpdateResult }> {
   const entryPath = await resolveGatewayInstallEntrypoint(params.root);
   if (!entryPath) {
@@ -2576,7 +2654,7 @@ async function continuePostCoreUpdateInFreshProcess(params: {
     await writePostCorePluginInstallRecordsFile(installRecordsPath, params.pluginInstallRecords);
     await writePostCoreSourceConfigFile(sourceConfigPath, params.preUpdateConfig);
     const childStdio = resolvePostCoreUpdateChildStdio();
-    const child = spawn(resolveNodeRunner(), argv, {
+    const child = spawn(params.nodeRunner ?? resolveNodeRunner(), argv, {
       stdio: childStdio,
       env: {
         ...stripGatewayServiceMarkerEnv(disableUpdatedPackageCompileCacheEnv(process.env)),
@@ -2884,7 +2962,7 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
   let fallbackToLatest = false;
   let packageInstallSpec: string | null = null;
   let packageAlreadyCurrent = false;
-  let managedServiceRootRedirect: { root: string; previousRoot: string } | null = null;
+  let managedServiceRootRedirect: ManagedServiceRootRedirect | null = null;
 
   if (updateInstallKind === "package") {
     managedServiceRootRedirect = await resolveManagedServicePackageUpdateRoot({ root });
@@ -2896,6 +2974,21 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
             `Targeting managed gateway service package root: ${managedServiceRootRedirect.root}`,
           ),
         );
+        defaultRuntime.log(
+          theme.warn(
+            `Shell OpenClaw root differs from the managed gateway service root: ${managedServiceRootRedirect.previousRoot}`,
+          ),
+        );
+        defaultRuntime.log(
+          theme.muted(
+            `After the update, make sure \`${CLI_NAME}\` on PATH resolves to the managed service root or reinstall the gateway service from the shell install you want to use.`,
+          ),
+        );
+        if (managedServiceRootRedirect.nodeRunner) {
+          defaultRuntime.log(
+            theme.muted(`Managed gateway service Node: ${managedServiceRootRedirect.nodeRunner}`),
+          );
+        }
       }
     }
   }
@@ -3047,6 +3140,7 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
     const runtimePreflightError = await resolvePackageRuntimePreflightError({
       tag,
       timeoutMs,
+      nodeRunner: managedServiceRootRedirect?.nodeRunner,
     });
     if (runtimePreflightError) {
       defaultRuntime.error(runtimePreflightError);
@@ -3115,6 +3209,7 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
             managedServiceEnv: prePackageServiceStop?.serviceEnv,
             invocationCwd,
             honorPackageRoot: managedServiceRootRedirect !== null,
+            nodeRunner: managedServiceRootRedirect?.nodeRunner,
           })
         : await runGitUpdate({
             root,
@@ -3240,6 +3335,7 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
       opts,
       pluginInstallRecords: preUpdatePluginInstallRecords,
       updateStartedAtMs: startedAt,
+      nodeRunner: managedServiceRootRedirect?.nodeRunner,
       preUpdateConfig: configSnapshot.valid
         ? {
             sourceConfig: configSnapshot.sourceConfig,
@@ -3365,6 +3461,7 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
     gatewayPort,
     restartScriptPath,
     invocationCwd,
+    nodeRunner: managedServiceRootRedirect?.nodeRunner,
   });
   if (!restartOk) {
     await markControlPlaneUpdateRestartSentinelFailureBestEffort({

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -3254,7 +3254,8 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
             jsonMode: Boolean(opts.json),
             managedServiceEnv: prePackageServiceStop?.serviceEnv,
             invocationCwd,
-            honorPackageRoot: managedServiceRootRedirect !== null,
+            honorPackageRoot:
+              managedServiceRootRedirect !== null || managedServiceNodeRunner !== undefined,
             nodeRunner: managedServiceNodeRunner,
           })
         : await runGitUpdate({


### PR DESCRIPTION
## Summary

Fixes `openclaw update` silently switching the gateway to the wrong Node binary when users have multiple Node installations (nvm/fnm/volta/brew).

### The bug

After `gateway install` bakes a specific node path into the service unit, if the user's PATH changes (e.g. switching nvm versions), `openclaw update` would use the new PATH node for all follow-up commands — rewriting the service unit with the wrong binary and breaking the gateway on next restart.

### Fixes (3 commits)

1. **Service node for redirected roots**: When the shell root differs from the service root, extract and use the service's baked node for all follow-up commands. Validate it against the target release's `engines.node` before proceeding.

2. **Service node for same roots**: Independently detect when the current node differs from the service's baked node even when package roots match. Warn the user and use the service's node.

3. **Pin install target**: Set `honorPackageRoot` when the node override is active so the package install stays pinned to the service's global prefix (prevents PATH-visible npm from redirecting the install to a different prefix).

## Verification

- 114 unit tests pass (6 new: redirected root, same-root node mismatch, no-owning-npm pinning, preflight engine check, follow-up command plumbing ×2)
- Docker E2E (`scripts/e2e/multi-node-update-docker.sh`): before fix the baked node switches from node-A to node-B; after fix the unit file is byte-identical
- `oxfmt --check` clean, `git diff --check` clean
