### PR TITLE
fix(agents): stop false-positive session-takeover on runner's own transcript appends

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts
@@ -156,7 +156,7 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(events).toEqual(["acquire-1", "release", "events-drained", "acquire-2", "release"]);
   });
 
-  it("rejects post-prompt writes when another owner advances the session file", async () => {
+  it("rejects post-prompt writes when another owner queues a new user turn", async () => {
     const sessionFile = await createTempSessionFile();
     const release = vi.fn(async () => {});
     const acquireSessionWriteLock = vi.fn(async () => ({ release }));
@@ -166,7 +166,11 @@ describe("embedded attempt session lock lifecycle", () => {
     });
 
     await controller.releaseForPrompt();
-    await fs.appendFile(sessionFile, '{"type":"message","id":"takeover"}\n', "utf8");
+    await fs.appendFile(
+      sessionFile,
+      '{"type":"message","id":"takeover","message":{"role":"user","content":"new turn"}}\n',
+      "utf8",
+    );
 
     await expect(controller.withSessionWriteLock(() => "late-write")).rejects.toBeInstanceOf(
       EmbeddedAttemptSessionTakeoverError,
@@ -177,6 +181,297 @@ describe("embedded attempt session lock lifecycle", () => {
     await cleanupLock.release();
 
     expect(release).toHaveBeenCalledTimes(2);
+  });
+
+  it("accepts post-prompt writes when only the runner's own transcript entries appear", async () => {
+    const sessionFile = await createTempSessionFile();
+    const release = vi.fn(async () => {});
+    const acquireSessionWriteLock = vi.fn(async () => ({ release }));
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await controller.releaseForPrompt();
+    // Runner-owned writers (e.g. appendSessionTranscriptMessageLocked via
+    // allowReentrant:true) append assistant replies and persisted tool outputs
+    // during the released-lock window. These must not trip the takeover fence.
+    // Persisted role names follow isAgentMessage in transcript-file-state.ts.
+    await fs.appendFile(
+      sessionFile,
+      '{"type":"message","id":"assistant-1","message":{"role":"assistant","content":"calling tool"}}\n',
+      "utf8",
+    );
+    await fs.appendFile(
+      sessionFile,
+      '{"type":"message","id":"toolresult-1","message":{"role":"toolResult","toolCallId":"call-1","toolName":"exec","isError":false,"content":[{"type":"text","text":"ok"}]}}\n',
+      "utf8",
+    );
+    await fs.appendFile(
+      sessionFile,
+      '{"type":"message","id":"bash-1","message":{"role":"bashExecution","command":"ls","output":"","exitCode":0,"cancelled":false,"truncated":false}}\n',
+      "utf8",
+    );
+
+    await expect(controller.withSessionWriteLock(() => "late-write")).resolves.toBe("late-write");
+    expect(controller.hasSessionTakeover()).toBe(false);
+  });
+
+  it("rejects post-prompt writes when an accepted runner-owned role is malformed", async () => {
+    const sessionFile = await createTempSessionFile();
+    const release = vi.fn(async () => {});
+    const acquireSessionWriteLock = vi.fn(async () => ({ release }));
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await controller.releaseForPrompt();
+    // toolResult requires toolCallId, toolName, isError, and array content
+    // per the persisted message contract. An entry that carries the role
+    // but omits required fields is not a real runner-owned write and must
+    // trip the takeover fence.
+    await fs.appendFile(
+      sessionFile,
+      '{"type":"message","id":"malformed-1","message":{"role":"toolResult","toolCallId":"call-1"}}\n',
+      "utf8",
+    );
+
+    await expect(controller.withSessionWriteLock(() => "late-write")).rejects.toBeInstanceOf(
+      EmbeddedAttemptSessionTakeoverError,
+    );
+    expect(controller.hasSessionTakeover()).toBe(true);
+  });
+
+  it("rejects post-prompt writes when a runner-owned message entry omits id", async () => {
+    const sessionFile = await createTempSessionFile();
+    const release = vi.fn(async () => {});
+    const acquireSessionWriteLock = vi.fn(async () => ({ release }));
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await controller.releaseForPrompt();
+    // Canonical persisted session entries require a non-empty string id. An
+    // appended assistant message that omits the outer entry base is not a
+    // valid runner-owned write and must trip the takeover fence, matching
+    // the behavior current main exhibits via its stat-mismatch path.
+    await fs.appendFile(
+      sessionFile,
+      '{"type":"message","message":{"role":"assistant","content":[{"type":"text","text":"hi"}]}}\n',
+      "utf8",
+    );
+
+    await expect(controller.withSessionWriteLock(() => "late-write")).rejects.toBeInstanceOf(
+      EmbeddedAttemptSessionTakeoverError,
+    );
+    expect(controller.hasSessionTakeover()).toBe(true);
+  });
+
+  it("rejects post-prompt writes when a non-message entry is appended", async () => {
+    const sessionFile = await createTempSessionFile();
+    const release = vi.fn(async () => {});
+    const acquireSessionWriteLock = vi.fn(async () => ({ release }));
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await controller.releaseForPrompt();
+    // Custom/compaction/branch_summary entries are session-state mutations
+    // outside the runner-owned transcript-write path. Appending one during the
+    // released-lock window must trip the takeover fence even though it grew
+    // the file append-only and no user-role entry appeared.
+    await fs.appendFile(
+      sessionFile,
+      '{"type":"custom","id":"custom-1","customType":"branch_marker","data":{}}\n',
+      "utf8",
+    );
+
+    await expect(controller.withSessionWriteLock(() => "late-write")).rejects.toBeInstanceOf(
+      EmbeddedAttemptSessionTakeoverError,
+    );
+    expect(controller.hasSessionTakeover()).toBe(true);
+  });
+
+  it("rejects post-prompt writes when a tail line parses to a non-object value", async () => {
+    const sessionFile = await createTempSessionFile();
+    const release = vi.fn(async () => {});
+    const acquireSessionWriteLock = vi.fn(async () => ({ release }));
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await controller.releaseForPrompt();
+    // A literal JSON null parses cleanly but is not a session entry. The
+    // slow path must fail closed as takeover rather than letting the
+    // canonical validator dereference a non-object.
+    await fs.appendFile(sessionFile, "null\n", "utf8");
+
+    await expect(controller.withSessionWriteLock(() => "late-write")).rejects.toBeInstanceOf(
+      EmbeddedAttemptSessionTakeoverError,
+    );
+    expect(controller.hasSessionTakeover()).toBe(true);
+  });
+
+  it("keeps the fence consistent when a guarded operation throws after assertion", async () => {
+    const sessionFile = await createTempSessionFile();
+    const release = vi.fn(async () => {});
+    const acquireSessionWriteLock = vi.fn(async () => ({ release }));
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    const assistantEntry = (id: string) =>
+      `{"type":"message","id":"${id}","parentId":null,"timestamp":"2026-05-19T00:00:00.000Z","message":{"role":"assistant","content":[{"type":"text","text":"x"}]}}\n`;
+
+    await controller.releaseForPrompt();
+    // First append-then-assert advances the fence over a runner-owned tail.
+    // The guarded operation then throws, which skips refreshSessionFileFence
+    // and used to leave the snapshot describing the new size but holding
+    // the old prefix hash. A second runner-owned append would then false-
+    // positive on prefix-hash mismatch in the next slow path.
+    await fs.appendFile(sessionFile, assistantEntry("a1"), "utf8");
+    await expect(
+      controller.withSessionWriteLock(() => {
+        throw new Error("post-assert");
+      }),
+    ).rejects.toThrow("post-assert");
+    expect(controller.hasSessionTakeover()).toBe(false);
+
+    await fs.appendFile(sessionFile, assistantEntry("a2"), "utf8");
+    await expect(controller.withSessionWriteLock(() => "ok")).resolves.toBe("ok");
+    expect(controller.hasSessionTakeover()).toBe(false);
+  });
+
+  it("refuses to bless a snapshot when the file is rewritten in place during snapshot creation", async () => {
+    const sessionFile = await createTempSessionFile();
+    const release = vi.fn(async () => {});
+    const acquireSessionWriteLock = vi.fn(async () => ({ release }));
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    // Simulate a same-size in-place rewrite landing between snapshot's stat
+    // and its read. Spy on fs.readFile so the very first call (made during
+    // releaseForPrompt's snapshot) atomically rewrites the file with new
+    // content of identical byte length before delegating to the real read.
+    // The post-read re-stat then sees a different mtime/ctime and the
+    // snapshot returns prefixHashHex: null, which makes the next
+    // withSessionWriteLock fail closed even on an otherwise valid append.
+    const originalSize = (await fs.stat(sessionFile)).size;
+    const rewritten = Buffer.alloc(originalSize, 0x78); // same length, different content
+    const readFileSpy = vi.spyOn(fs, "readFile");
+    readFileSpy.mockImplementationOnce(async (target) => {
+      readFileSpy.mockRestore();
+      await fs.writeFile(target as string, rewritten);
+      return fs.readFile(target as string);
+    });
+
+    try {
+      await controller.releaseForPrompt();
+      await fs.appendFile(
+        sessionFile,
+        '{"type":"message","id":"a1","parentId":null,"timestamp":"2026-05-19T00:00:00.000Z","message":{"role":"assistant","content":[{"type":"text","text":"x"}]}}\n',
+        "utf8",
+      );
+
+      await expect(controller.withSessionWriteLock(() => "late-write")).rejects.toBeInstanceOf(
+        EmbeddedAttemptSessionTakeoverError,
+      );
+      expect(controller.hasSessionTakeover()).toBe(true);
+    } finally {
+      readFileSpy.mockRestore();
+    }
+  });
+
+  it("refuses to bless a slow-path verification when the file is rewritten in place during the slow-path read", async () => {
+    const sessionFile = await createTempSessionFile();
+    const release = vi.fn(async () => {});
+    const acquireSessionWriteLock = vi.fn(async () => ({ release }));
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    // Snapshot the fence cleanly first, then inject the race during the
+    // slow path's read. The slow path stats, then reads, then re-stats; the
+    // injected rewrite changes mtime between the two stats and the
+    // verification refuses to bless the post-rewrite content as runner-owned.
+    await controller.releaseForPrompt();
+    await fs.appendFile(
+      sessionFile,
+      '{"type":"message","id":"a1","parentId":null,"timestamp":"2026-05-19T00:00:00.000Z","message":{"role":"assistant","content":[{"type":"text","text":"x"}]}}\n',
+      "utf8",
+    );
+
+    const sizeBeforeRace = (await fs.stat(sessionFile)).size;
+    const rewritten = Buffer.alloc(sizeBeforeRace, 0x79);
+    const readFileSpy = vi.spyOn(fs, "readFile");
+    readFileSpy.mockImplementationOnce(async (target) => {
+      readFileSpy.mockRestore();
+      await fs.writeFile(target as string, rewritten);
+      return fs.readFile(target as string);
+    });
+
+    try {
+      await expect(controller.withSessionWriteLock(() => "late-write")).rejects.toBeInstanceOf(
+        EmbeddedAttemptSessionTakeoverError,
+      );
+      expect(controller.hasSessionTakeover()).toBe(true);
+    } finally {
+      readFileSpy.mockRestore();
+    }
+  });
+
+  it("rejects post-prompt writes when the session file is rewritten in place", async () => {
+    const sessionFile = await createTempSessionFile();
+    const release = vi.fn(async () => {});
+    const acquireSessionWriteLock = vi.fn(async () => ({ release }));
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await controller.releaseForPrompt();
+    // Concurrent compaction or another owner rewriting the transcript in place
+    // would change the file's stat without an append-only growth. The fence
+    // must still trip even though no user-role entry was added.
+    await fs.writeFile(sessionFile, '{"type":"session","compacted":true}\n', "utf8");
+
+    await expect(controller.withSessionWriteLock(() => "late-write")).rejects.toBeInstanceOf(
+      EmbeddedAttemptSessionTakeoverError,
+    );
+    expect(controller.hasSessionTakeover()).toBe(true);
+  });
+
+  it("rejects post-prompt writes when the session file is replaced", async () => {
+    const sessionFile = await createTempSessionFile();
+    const release = vi.fn(async () => {});
+    const acquireSessionWriteLock = vi.fn(async () => ({ release }));
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await controller.releaseForPrompt();
+    // A different owner could atomically replace the session file (unlink +
+    // recreate). dev/ino change must trip the fence regardless of content.
+    await fs.rm(sessionFile);
+    await fs.writeFile(
+      sessionFile,
+      '{"type":"session"}\n{"type":"message","id":"new-owner","message":{"role":"assistant","content":"hello"}}\n',
+      "utf8",
+    );
+
+    await expect(controller.withSessionWriteLock(() => "late-write")).rejects.toBeInstanceOf(
+      EmbeddedAttemptSessionTakeoverError,
+    );
+    expect(controller.hasSessionTakeover()).toBe(true);
   });
 
   it("returns a no-op cleanup lock after prompt lock reacquisition times out", async () => {

--- a/src/agents/pi-embedded-runner/run/attempt.session-lock.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.session-lock.ts
@@ -1,7 +1,9 @@
 import { AsyncLocalStorage } from "node:async_hooks";
+import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import { isSessionWriteLockTimeoutError } from "../../session-write-lock-error.js";
 import type { acquireSessionWriteLock } from "../../session-write-lock.js";
+import { isSessionEntry } from "../transcript-file-state.js";
 
 type SessionLock = Awaited<ReturnType<typeof acquireSessionWriteLock>>;
 type AcquireSessionWriteLock = typeof acquireSessionWriteLock;
@@ -107,6 +109,7 @@ type SessionFileFingerprint =
       size: bigint;
       mtimeNs: bigint;
       ctimeNs: bigint;
+      birthtimeNs: bigint;
     };
 
 function sameSessionFileFingerprint(
@@ -124,7 +127,8 @@ function sameSessionFileFingerprint(
     left.ino === right.ino &&
     left.size === right.size &&
     left.mtimeNs === right.mtimeNs &&
-    left.ctimeNs === right.ctimeNs
+    left.ctimeNs === right.ctimeNs &&
+    left.birthtimeNs === right.birthtimeNs
   );
 }
 
@@ -138,6 +142,7 @@ async function readSessionFileFingerprint(sessionFile: string): Promise<SessionF
       size: stat.size,
       mtimeNs: stat.mtimeNs,
       ctimeNs: stat.ctimeNs,
+      birthtimeNs: stat.birthtimeNs,
     };
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {
@@ -145,6 +150,155 @@ async function readSessionFileFingerprint(sessionFile: string): Promise<SessionF
     }
     throw err;
   }
+}
+
+// The runner's own transcript appends during the released prompt window
+// (appendSessionTranscriptMessageLocked with allowReentrant:true) change the
+// session file's stat without going through refreshSessionFileFence, so any
+// stat mismatch needs a tighter check before being treated as a takeover.
+// We only tolerate a fingerprint mismatch when ALL of these hold:
+//   - same dev/ino (no atomic replacement)
+//   - file grew (size only increases between fence set and assert)
+//   - bytes [0, fenceSize) hash identical to the fenced prefix hash
+//   - bytes [fenceSize, currentSize) contain only message entries whose
+//     role is in the runner-owned persisted set: assistant, toolResult,
+//     or bashExecution. Non-message tail entries (custom, branch_summary,
+//     compaction, session) and any other role are rejected.
+// Anything else — file replacement, shrink, in-place rewrite of earlier
+// bytes, a new user-role entry, or a malformed tail — remains a real takeover.
+
+type FenceSnapshot = {
+  fingerprint: SessionFileFingerprint;
+  prefixHashHex: string | null;
+};
+
+async function snapshotSessionFileFence(sessionFile: string): Promise<FenceSnapshot> {
+  const fingerprint = await readSessionFileFingerprint(sessionFile);
+  if (!fingerprint.exists) {
+    return { fingerprint, prefixHashHex: null };
+  }
+  const buffer = await fs.readFile(sessionFile).catch((err: NodeJS.ErrnoException) => {
+    if (err.code === "ENOENT") {
+      return null;
+    }
+    throw err;
+  });
+  if (!buffer) {
+    return { fingerprint: { exists: false }, prefixHashHex: null };
+  }
+  // Confirm the read buffer matches the pre-read stat; otherwise an in-place
+  // rewrite (same size or otherwise) between the two could leave us hashing
+  // post-rewrite content against a pre-rewrite fingerprint. Re-stat and
+  // compare every fingerprint field, including mtimeNs / ctimeNs, so a
+  // same-size rewrite still fails closed. Returning prefixHashHex: null
+  // forces the next assertSessionFileFence to treat the file as taken over
+  // instead of blessing a mixed-snapshot baseline.
+  const postReadFingerprint = await readSessionFileFingerprint(sessionFile);
+  const fenceOffset = Number(fingerprint.size);
+  if (
+    !Number.isSafeInteger(fenceOffset) ||
+    buffer.byteLength !== fenceOffset ||
+    !sameSessionFileFingerprint(fingerprint, postReadFingerprint)
+  ) {
+    return { fingerprint, prefixHashHex: null };
+  }
+  return {
+    fingerprint,
+    prefixHashHex: createHash("sha256").update(buffer.subarray(0, fenceOffset)).digest("hex"),
+  };
+}
+
+type AppendOnlyVerification = { ok: true; nextSnapshot: FenceSnapshot } | { ok: false };
+
+async function verifyAppendOnlyRunnerOwnedExtension(
+  sessionFile: string,
+  fence: FenceSnapshot,
+): Promise<AppendOnlyVerification> {
+  if (!fence.fingerprint.exists || fence.prefixHashHex === null) {
+    return { ok: false };
+  }
+  const fenceOffset = Number(fence.fingerprint.size);
+  if (!Number.isSafeInteger(fenceOffset) || fenceOffset < 0) {
+    return { ok: false };
+  }
+  const fingerprint = await readSessionFileFingerprint(sessionFile);
+  if (!fingerprint.exists) {
+    return { ok: false };
+  }
+  // dev/ino guard catches replacement onto a new inode; birthtime guard catches
+  // the unlink+recreate-same-inode case (common on tmpfs/ext4 with rapid
+  // recreation), where dev and ino are reused but the inode itself is fresh.
+  if (
+    fingerprint.dev !== fence.fingerprint.dev ||
+    fingerprint.ino !== fence.fingerprint.ino ||
+    fingerprint.birthtimeNs !== fence.fingerprint.birthtimeNs
+  ) {
+    return { ok: false };
+  }
+  if (fingerprint.size <= fence.fingerprint.size) {
+    return { ok: false };
+  }
+  const buffer = await fs.readFile(sessionFile).catch(() => null);
+  const currentOffset = Number(fingerprint.size);
+  if (
+    !buffer ||
+    !Number.isSafeInteger(currentOffset) ||
+    buffer.byteLength !== currentOffset ||
+    buffer.byteLength < fenceOffset
+  ) {
+    // Refuse when a concurrent write between stat and read left the buffer
+    // and fingerprint out of sync; otherwise the snapshot we return would
+    // describe a different file than the next slow path reads.
+    return { ok: false };
+  }
+  // Re-stat after the read so a same-size in-place rewrite during the
+  // stat -> read gap fails closed: the post-read fingerprint will differ
+  // in mtimeNs / ctimeNs from the pre-read one even when byte length and
+  // dev/ino/birthtime are identical.
+  const postReadFingerprint = await readSessionFileFingerprint(sessionFile);
+  if (!sameSessionFileFingerprint(fingerprint, postReadFingerprint)) {
+    return { ok: false };
+  }
+  const prefixHash = createHash("sha256").update(buffer.subarray(0, fenceOffset)).digest("hex");
+  if (prefixHash !== fence.prefixHashHex) {
+    return { ok: false };
+  }
+  const tail = buffer.subarray(fenceOffset).toString("utf8");
+  for (const line of tail.split("\n")) {
+    if (!line) {
+      continue;
+    }
+    let entry: unknown;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      // Malformed tail line (partial write); refuse to bless the change.
+      return { ok: false };
+    }
+    // Delegate the whole-entry contract (record shape, type, id, parentId,
+    // timestamp, message shape) to the canonical isSessionEntry validator,
+    // then narrow to the runner-owned role subset. User and custom roles
+    // remain real takeover signals even when the underlying entry is
+    // well-formed.
+    if (!isSessionEntry(entry) || entry.type !== "message") {
+      return { ok: false };
+    }
+    const role = (entry.message as { role?: unknown }).role;
+    if (role !== "assistant" && role !== "toolResult" && role !== "bashExecution") {
+      return { ok: false };
+    }
+  }
+  // The gate-check prefixHash above covers only the bytes up to the old
+  // fence offset. The next slow path will rehash the file up to the new
+  // fingerprint.size, so the stored snapshot must describe the full
+  // current file. Otherwise a guarded operation that throws between
+  // assertSessionFileFence and refreshSessionFileFence leaves a poisoned
+  // fence (next legitimate runner append false-positives as takeover).
+  const nextPrefixHash = createHash("sha256").update(buffer).digest("hex");
+  return {
+    ok: true,
+    nextSnapshot: { fingerprint, prefixHashHex: nextPrefixHash },
+  };
 }
 
 async function waitForSessionEventQueue(session: unknown): Promise<void> {
@@ -263,7 +417,7 @@ export async function createEmbeddedAttemptSessionLockController(params: {
 
   let heldLock: SessionLock | undefined = await acquireLock();
   const activeWriteLock = new AsyncLocalStorage<SessionLock>();
-  let fenceFingerprint: SessionFileFingerprint | undefined;
+  let fenceSnapshot: FenceSnapshot | undefined;
   let fenceActive = false;
   let takeoverDetected = false;
 
@@ -282,19 +436,27 @@ export async function createEmbeddedAttemptSessionLockController(params: {
   }
 
   async function assertSessionFileFence(): Promise<void> {
-    if (!fenceActive) {
+    if (!fenceActive || !fenceSnapshot) {
       return;
     }
     const current = await readSessionFileFingerprint(params.lockOptions.sessionFile);
-    if (!sameSessionFileFingerprint(fenceFingerprint, current)) {
+    if (sameSessionFileFingerprint(fenceSnapshot.fingerprint, current)) {
+      return;
+    }
+    const verified = await verifyAppendOnlyRunnerOwnedExtension(
+      params.lockOptions.sessionFile,
+      fenceSnapshot,
+    );
+    if (!verified.ok) {
       takeoverDetected = true;
       throw new EmbeddedAttemptSessionTakeoverError(params.lockOptions.sessionFile);
     }
+    fenceSnapshot = verified.nextSnapshot;
   }
 
   async function refreshSessionFileFence(): Promise<void> {
     if (fenceActive && !takeoverDetected) {
-      fenceFingerprint = await readSessionFileFingerprint(params.lockOptions.sessionFile);
+      fenceSnapshot = await snapshotSessionFileFence(params.lockOptions.sessionFile);
     }
   }
 
@@ -307,7 +469,7 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       }
       const lock = heldLock;
       heldLock = undefined;
-      fenceFingerprint = await readSessionFileFingerprint(params.lockOptions.sessionFile);
+      fenceSnapshot = await snapshotSessionFileFence(params.lockOptions.sessionFile);
       fenceActive = true;
       await lock.release();
     },

--- a/src/agents/pi-embedded-runner/transcript-file-state.ts
+++ b/src/agents/pi-embedded-runner/transcript-file-state.ts
@@ -193,22 +193,18 @@ function isAgentMessage(value: unknown): boolean {
   }
 }
 
-function hasSessionEntryBase(entry: FileEntry): boolean {
-  const candidate = entry as {
-    id?: unknown;
-    parentId?: unknown;
-    timestamp?: unknown;
-  };
+function hasSessionEntryBase(entry: Record<string, unknown>): boolean {
   return (
-    isString(candidate.id) &&
-    (candidate.parentId === undefined ||
-      candidate.parentId === null ||
-      isString(candidate.parentId)) &&
-    (candidate.timestamp === undefined || isString(candidate.timestamp))
+    isString(entry.id) &&
+    (entry.parentId === undefined || entry.parentId === null || isString(entry.parentId)) &&
+    (entry.timestamp === undefined || isString(entry.timestamp))
   );
 }
 
-function isSessionEntry(entry: FileEntry): entry is SessionEntry {
+export function isSessionEntry(entry: unknown): entry is SessionEntry {
+  if (!isRecord(entry) || typeof entry.type !== "string") {
+    return false;
+  }
   if (
     entry.type === "session" ||
     !sessionEntryTypes.has(entry.type) ||
@@ -374,7 +370,7 @@ function readableSessionEntries(fileEntries: FileEntry[]): SessionEntry[] {
     if (!isRecord(rawEntry)) {
       continue;
     }
-    const entry = rawEntry as FileEntry;
+    const entry = rawEntry;
     const id = rawEntry.id;
     if (!isSessionEntry(entry)) {
       if (isString(id)) {


### PR DESCRIPTION
## Summary

The embedded attempt session-lock fence uses a `stat()`-based fingerprint (`dev`, `ino`, `size`, `mtimeNs`, `ctimeNs`, `birthtimeNs`) to detect "another lane queued a new user turn against this session" while the runner releases its coarse lock for the LLM prompt window. The fingerprint is a proxy that overfires: every transcript-append the runner itself performs during the released window (`appendSessionTranscriptMessageLocked` writes tool calls, tool results, and assistant replies via `acquireSessionWriteLock(..., allowReentrant: true)`) changes the file's `size`/`mtimeNs`/`ctimeNs` without going through `refreshSessionFileFence`. Long DM turns with tool calls then trip `assertSessionFileFence` and throw `EmbeddedAttemptSessionTakeoverError` after the reply has already been delivered, surfacing a misleading "Agent failed before reply" message on top of a successful turn.

Keep the stat fingerprint as the fast path. On mismatch, only tolerate the runner's append-only assistant/tool transcript shape; treat everything else as a real takeover. The verification requires ALL of:

- **dev/ino match**: no atomic replacement onto a new inode.
- **birthtimeNs matches**: catches the unlink+recreate-same-inode case (common on tmpfs/ext4 with rapid recreation, where dev and ino are reused but the inode itself is fresh).
- **size grew**: file is append-only between fence-set and assert.
- **stat/read consistency**: both `snapshotSessionFileFence` and `verifyAppendOnlyRunnerOwnedExtension` run a post-read `stat` and compare every fingerprint field (size, dev, ino, mtimeNs, ctimeNs, birthtimeNs) against the pre-read fingerprint. Any mismatch fails closed: the snapshot returns `prefixHashHex: null` (forces the next assertion to treat the file as taken over) and the slow path rejects directly. Catches the same-size in-place rewrite race where byte length alone would not detect drift.
- **bytes `[0, fenceSize)` hash identical to the fenced prefix hash**: no in-place rewrite of earlier transcript content.
- **bytes `[fenceSize, currentSize)` are canonical session entries**: every appended line must satisfy `isSessionEntry` from `transcript-file-state.ts` (record shape, type, `id`, `parentId`, `timestamp`, plus the per-type message-shape contract via `isAgentMessage`), with role narrowed to `assistant`, `toolResult`, or `bashExecution`. Non-object parsed values, user-role entries, custom entries, branch_summary entries, and any entry missing the outer base fields remain a real takeover signal.

Anything else (replacement, shrink, in-place rewrite at any size, new user turn, compaction, a malformed appended entry, a non-object tail value, or a stat/read inconsistency window) remains a real takeover. The fence snapshot captures the prefix SHA-256 alongside the fingerprint at `releaseForPrompt` and `refreshSessionFileFence` so the slow path can verify rigorously without keeping a file handle open.

The slow-path tail validation delegates to the canonical `isSessionEntry` whole-entry validator (now `export`-visible from `transcript-file-state.ts`, signature widened to `unknown` with an internal `isRecord` guard so non-record JSON values fail closed). No local mirror of the persisted message contract is maintained: if the upstream `FileEntry`/`SessionEntry` contract changes, the fence's accept-set tracks it automatically.

The `nextSnapshot` returned from a successful slow-path verification hashes the full new buffer (not the pre-fence prefix). Otherwise, when the guarded operation throws between `assertSessionFileFence` and `refreshSessionFileFence`, the stored snapshot would describe the new size but hold the old prefix hash, and the next legitimate runner append would false-positive on prefix-hash mismatch.

### Lock-held invariant

Both `snapshotSessionFileFence` call sites run while the session write lock is held: `releaseForPrompt` (snapshot at L452 before `lock.release()` at L454) and `refreshSessionFileFence` (called inside `withSessionWriteLock`'s `runWithLock` wrapped by `activeWriteLock.run(lock, ...)`). Canonical transcript writers (`appendSessionTranscriptMessageLocked`, `migrateLinearTranscriptToParentLinked`, `ensureTranscriptHeader`) all acquire that same lock. The stat/read consistency guard above is belt-and-suspenders for this invariant: it defends against multi-process scenarios (a second gateway against the same session file), an external editor, or an internal bug that bypasses the lock.

Closes openclaw/openclaw#83436.
Refs openclaw/openclaw#83615 (this PR addresses the EmbeddedAttemptSessionTakeoverError surface; the issue also tracks unrelated kimi-k2.6 schema and DNS-fetch failures).
Refs openclaw/openclaw#84059 (active multi-environment hub for this error: Feishu/Slack/WebChat across macOS APFS, Linux ext4, WSL2, Docker; all are the general internal-write path this PR covers, not the delivery-mirror path addressed by openclaw/openclaw#84437).

## Real behavior proof

**Behavior addressed**: Embedded runner false-positive `EmbeddedAttemptSessionTakeoverError` fires after long Telegram DM turns whose reply was already delivered, surfacing a misleading "Agent failed before reply" message on top of a successful run.

**Real environment tested**: OpenClaw 2026.5.19-beta.1, Linux x86_64, Node 24.13.0. Long-running Telegram DM session against `claude-opus-4-7` (~3.5 min turn with multiple `exec` and `message` tool calls), reproduced reliably before this patch. Production behavior probed via runtime-patched `dist/selection-BpjGe-Y0.js` carrying the same fix semantics, then long DM runs (41s to 122s) exercised through the Telegram channel post-restart.

**Exact steps or command run after this patch**:
```
node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts src/agents/pi-embedded-runner/transcript-file-state.test.ts
CI=true pnpm check:changed --staged=false
openclaw gateway restart
```

**Evidence after fix**:

Pre-patch failure mode, redacted runtime log from gateway (`/tmp/openclaw/openclaw-2026-05-19.log`):
```
03:30:06.971  embedded run agent end: runId=bbd7d487 isError=false
03:30:07.008  embedded run prompt end: runId=bbd7d487 sessionId=<session-id> durationMs=217236
03:30:07.054  lane task error: lane=main durationMs=219867 error="EmbeddedAttemptSessionTakeoverError: session file changed while embedded prompt lock was released: /home/.../agents/main/sessions/<session-id>.jsonl"
03:30:07.071  Embedded agent failed before reply: session file changed while embedded prompt lock was released: /home/.../<session-id>.jsonl
```
Note `isError=false` at `03:30:06.971`: the assistant turn and `message` tool delivery both succeeded, followed 47ms later by the takeover throw, surfacing as a misleading Telegram error on top of a delivered reply.

Post-patch behavior on the same gateway, four long DM runs after gateway restart at 03:46 EDT, every one delivering cleanly with zero takeover errors (redacted runtime log):
```
03:51:18  embedded run prompt end: runId=62395ffd  durationMs=122344  (no takeover)
03:52:39  embedded run prompt end: runId=67e21652  durationMs=41345   (no takeover)
04:05:05  embedded run prompt end: runId=a5994980  durationMs=101810  (no takeover)
04:07:34  embedded run prompt end: runId=a837440b  durationMs=94395   (no takeover)
```
The post-patch window contains only two "Embedded agent failed before reply" entries (at 04:05:06 and 04:07:35), both with cause `LLM request timed out`, unrelated to the takeover path. Zero `SessionTakeoverError` occurrences post-patch.

**Observed result after fix**: Existing acceptance test exercises all three runner-owned roles (`assistant`, `toolResult`, `bashExecution`) with their canonical persisted shapes. Rejection tests cover: another owner queueing a new user turn, a runner-owned role with malformed message contents, a runner-owned message entry missing its outer `id`, a non-message entry (e.g. `custom`/`branch_summary`/`compaction`), a tail line that parses to a non-object value (e.g. literal `null`), in-place rewrite (rejected via prefix hash mismatch), unlink+recreate-same-inode replacement (rejected via `birthtimeNs` mismatch), a same-size in-place rewrite landing during the snapshot's stat-to-read window (rejected via post-read re-stat), and the same race during the slow-path verification's read (rejected via the same guard). A fence-consistency test covers the post-throw path: after a guarded operation throws between assert and refresh, the next valid runner-owned append must not false-positive on prefix-hash mismatch. Targeted Vitest output:
```
Test Files  4 passed (4)
     Tests  82 passed (82)
  Duration  3.86s
```
`check:changed --staged=false` is clean across the full repo lane (lint, typecheck, import-cycles, dependency guards, build artifacts, security/quality lanes).

**What was not tested**: Multi-process write contention on the same `sessionFile` from a different gateway process (no test infrastructure for cross-process locks in this surface). The prefix-hash check is `O(fenceSize)` I/O per fence-set; in production sessions seen so far (~150 KB and below) this is sub-millisecond. Both snapshot producers do one extra `fs.stat` (sub-millisecond on local disk) to enforce the stat/read consistency guard.

## Notes

- Adds three helpers near `readSessionFileFingerprint`: `FenceSnapshot` type, `snapshotSessionFileFence` (used at `releaseForPrompt` and `refreshSessionFileFence`), and `verifyAppendOnlyRunnerOwnedExtension` (used in the slow path of `assertSessionFileFence`). No new module-level dependencies beyond `node:crypto`'s `createHash`.
- Replaces one piece of controller state (`fenceFingerprint: SessionFileFingerprint | undefined`) with `fenceSnapshot: FenceSnapshot | undefined`. No new long-lived resources (no held file handles).
- Exports `isSessionEntry` from `transcript-file-state.ts` so the fence's slow path can delegate the whole-entry contract to the canonical validator. The signature is widened to `unknown` with an internal `isRecord` guard; non-record JSON values fail closed at the canonical boundary instead of needing per-callsite type-shape checks. `isAgentMessage` is not exported (the fence reaches it transitively through `isSessionEntry`).
