### PR TITLE
fix(media): decode remote URL fallback filenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 - Agents/subagents: recover stale completion announces by retrying unsupported transcript-wait wakes without transcript waiting and forcing a message-tool handoff when the requester run is already stale. Fixes #83699. (#83700) Thanks @galiniliev.
 - Agents/subagents: skip stale embedded-run wake probes for dormant completion requesters, so late subagent completions go straight to requester-agent/direct handoff instead of producing `reason=no_active_run` queue noise. (#82964) Thanks @galiniliev.
 - CLI: retry config snapshot reads after a transient failure so one rejected read no longer poisons later commands in the same process. (#83931) Thanks @honor2030.
+- Media: decode URL path basenames before using them as remote media fallback filenames, so files like `My%20Report.pdf` are surfaced as `My Report.pdf`. Fixes #84050.
 - WhatsApp: clarify inbound group diagnostics so observed but unregistered groups point to `channels.whatsapp.groups` without changing routing or sender authorization. (#83846) Thanks @neeravmakwana.
 - WhatsApp: drain pending outbound deliveries on a 30s periodic timer in addition to the reconnect handler, so messages enqueued while the provider is already connected no longer wait for the next reconnect to send. (#79083) Thanks @Oviemudiaga.
 - CLI/TUI: include gateway plugin slash commands in TUI autocomplete, so connected sessions can suggest plugin-owned commands exposed by the running Gateway. (#83640) Thanks @se7en-agent.

--- a/src/media/fetch.test.ts
+++ b/src/media/fetch.test.ts
@@ -583,6 +583,69 @@ describe("readRemoteMediaBuffer", () => {
     await expect(fs.readFile(saved.path)).resolves.toStrictEqual(Buffer.from([1, 2, 3, 4]));
   });
 
+  it("decodes URL path basenames when deriving remote media filenames", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(makeStream([new Uint8Array([1, 2, 3])]), {
+          status: 200,
+          headers: { "content-type": "application/pdf" },
+        }),
+    );
+
+    const saved = await saveRemoteMedia({
+      url: "https://example.com/files/My%20Report.pdf",
+      fetchImpl,
+      lookupFn: makeLookupFn(),
+      maxBytes: 8,
+    });
+
+    expect(saved.fileName).toBe("My Report.pdf");
+  });
+
+  it("keeps raw URL path basenames when percent escapes are malformed", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(makeStream([new Uint8Array([1, 2, 3])]), {
+          status: 200,
+          headers: { "content-type": "application/pdf" },
+        }),
+    );
+
+    const saved = await saveRemoteMedia({
+      url: "https://example.com/files/bad%E0%A4%A.pdf",
+      fetchImpl,
+      lookupFn: makeLookupFn(),
+      maxBytes: 8,
+    });
+
+    expect(saved.fileName).toBe("bad%E0%A4%A.pdf");
+  });
+
+  it.each([
+    ["https://example.com/files/reports%2FQ1.pdf", "reports_Q1.pdf"],
+    ["https://example.com/files/reports%5CQ1.pdf", "reports_Q1.pdf"],
+  ])(
+    "keeps decoded URL fallback separators inside the selected basename",
+    async (url, fileName) => {
+      const fetchImpl = vi.fn(
+        async () =>
+          new Response(makeStream([new Uint8Array([1, 2, 3])]), {
+            status: 200,
+            headers: { "content-type": "application/pdf" },
+          }),
+      );
+
+      const saved = await saveRemoteMedia({
+        url,
+        fetchImpl,
+        lookupFn: makeLookupFn(),
+        maxBytes: 8,
+      });
+
+      expect(saved.fileName).toBe(fileName);
+    },
+  );
+
   it("saves bodyless successful responses without unbounded buffering", async () => {
     const saved = await saveResponseMedia(new Response(null, { status: 204 }), {
       sourceUrl: "https://example.com/empty",

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -129,6 +129,18 @@ function parseContentDispositionFileName(header?: string | null): string | undef
   return undefined;
 }
 
+function basenameFromUrlPathname(pathname: string): string {
+  const base = basenameFromAnyPath(pathname);
+  if (!base) {
+    return "";
+  }
+  try {
+    return decodeURIComponent(base).replace(/[\\/]+/g, "_");
+  } catch {
+    return base;
+  }
+}
+
 async function readErrorBodySnippet(
   res: Response,
   opts?: {
@@ -295,7 +307,7 @@ function resolveRemoteFileName(params: {
   let fileNameFromUrl: string | undefined;
   try {
     const parsed = new URL(params.finalUrl);
-    const base = basenameFromAnyPath(parsed.pathname);
+    const base = basenameFromUrlPathname(parsed.pathname);
     fileNameFromUrl = base || undefined;
   } catch {
     // ignore parse errors; leave undefined


### PR DESCRIPTION
## Summary

- Decode valid percent escapes in URL path basenames before using them as remote media fallback filenames.
- Preserve decoded `%2F` and `%5C` segment identity by replacing decoded separators with safe filename underscores.
- Keep malformed percent-escaped basenames as raw text instead of throwing.
- Add focused `saveRemoteMedia` regression coverage and an Unreleased changelog entry.

Fixes #84050.

## Real behavior proof

**Behavior or issue addressed:** Remote media fetched from a URL such as `/files/My%20Report.pdf` should expose `My Report.pdf` as the fallback filename when the response has no `Content-Disposition` filename.

**Real environment tested:** OpenClaw source checkout at `f93dca627a8201e212d6cda867815e657bada005` on macOS with Node.js 24.11.1. The run used an isolated `OPENCLAW_STATE_DIR` and a local HTTP server serving the PDF bytes through the real `saveRemoteMedia` source-runtime path.

**Exact steps or command run after this patch:**

```sh
node --import tsx /private/tmp/openclaw-84052-proof.mjs
```

**Evidence after fix:** Copied console output from the after-fix run:

```json
{
  "setup": "local HTTP server + real saveRemoteMedia source runtime",
  "url": "http://127.0.0.1:63237/files/My%20Report.pdf",
  "fileName": "My Report.pdf",
  "contentType": "application/pdf",
  "size": 21,
  "storedPathBasename": "25319a44-8c4e-4e74-b0fb-b02f6904b821.pdf",
  "storedBytesMatch": true,
  "stateDir": "/var/folders/qg/ftvdj43s1b79kv3g92r9yzsm0000gn/T/openclaw-84052-proof-1ncWQT"
}
```

**Observed result after fix:** The real runtime fetch completed, returned `fileName: "My Report.pdf"` instead of `My%20Report.pdf`, stored the PDF as `application/pdf`, and confirmed `storedBytesMatch: true`.

**What was not tested:** none.

## Tests

- `node scripts/test-projects.mjs src/media/fetch.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/media/fetch.ts src/media/fetch.test.ts`
- `git diff --check origin/main...HEAD`
- `git merge-tree --write-tree HEAD origin/main`
