### PR TITLE
fix(ollama): default unknown capabilities to tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Providers/Ollama: default unknown-capabilities models to tool-capable so discovered native Ollama models can use tools when `/api/show` omits capabilities. (#84055) Thanks @dutifulbob.
 - Installer/Windows: launch `install.ps1` onboarding as an attached child process so fresh native Windows installs do not freeze visibly at `Starting setup...` or corrupt the wizard's terminal rendering.
 - Memory/search: close local embedding providers when active-memory searches time out so pending local model loads and embedding contexts are aborted and released. (#83858) Thanks @brokemac79.
 - Agents: include bounded trajectory queued-writer diagnostics in `pi-trajectory-flush` timeout warnings so flush stalls show pending writes, queued bytes, and append state. Fixes #82961. (#82962) Thanks @galiniliev.

--- a/extensions/ollama/src/provider-models.test.ts
+++ b/extensions/ollama/src/provider-models.test.ts
@@ -284,6 +284,7 @@ describe("ollama provider models", () => {
 
     const noCapabilities = buildOllamaModelDefinition("unknown-model", 65536);
     expect(noCapabilities.input).toEqual(["text"]);
+    expect(noCapabilities.compat?.supportsTools).toBe(true);
     expect(noCapabilities.compat?.supportsUsageInStreaming).toBe(true);
   });
 

--- a/extensions/ollama/src/provider-models.ts
+++ b/extensions/ollama/src/provider-models.ts
@@ -255,7 +255,7 @@ export function buildOllamaModelDefinition(
       : capabilities.includes("thinking"));
   const compat =
     capabilities === undefined
-      ? { supportsUsageInStreaming: true }
+      ? { supportsTools: true, supportsUsageInStreaming: true }
       : {
           supportsTools: capabilities.includes("tools"),
           supportsUsageInStreaming: true,


### PR DESCRIPTION
## Summary

Ollama models can lose tools when OpenClaw cannot read their capability list.
This change makes that fallback assume native Ollama chat supports tools.
It keeps the fix limited to the one issue reproduced from #81915.

## What Changed

The fallback model definition now marks unknown Ollama capabilities as tool-capable.
Models that explicitly report capabilities still use the reported tools flag.

- Set supportsTools to true when capabilities are unavailable.
- Added a regression assertion for that fallback path.

## Testing

I tested the exact fallback path and the focused Ollama provider model test file.
I also checked formatting and whitespace.

- node --import tsx --eval 'import { buildOllamaModelDefinition } from "./extensions/ollama/src/provider-models.ts"; const m = buildOllamaModelDefinition("qwen2.5:3b"); console.log(JSON.stringify(m.compat)); if (m.compat?.supportsTools !== true) process.exit(1);'
- node scripts/run-vitest.mjs extensions/ollama/src/provider-models.test.ts
- pnpm exec oxfmt --check --threads=1 extensions/ollama/src/provider-models.ts extensions/ollama/src/provider-models.test.ts
- git diff --check

## Real behavior proof

Behavior addressed: OpenClaw omitted supportsTools when Ollama capabilities were unavailable, so an Ollama model could be treated as not tool-capable.
Real environment tested: Local OpenClaw source checkout, Node 22.22.0, pnpm 11.1.0, with a local Ollama-compatible HTTP endpoint that returned /api/tags and /api/show without a capabilities field.
Exact steps or command run after this patch: Ran pnpm openclaw models list --provider ollama --json with OPENCLAW_HOME and OPENCLAW_CONFIG_PATH pointed at the local endpoint, then built the Ollama provider against the same endpoint.
Evidence after fix: Terminal output from the OpenClaw CLI and provider runtime:

```text
OpenClaw CLI command:
$ node scripts/run-node.mjs models list --provider ollama --json
{
  "count": 1,
  "models": [
    {
      "key": "ollama/fallback-tools:latest",
      "name": "fallback-tools:latest",
      "input": "text",
      "contextWindow": 8192,
      "local": true,
      "available": false,
      "tags": [],
      "missing": false
    }
  ]
}

Ollama provider runtime output:
{
  "model": {
    "id": "fallback-tools:latest",
    "input": [
      "text"
    ],
    "contextWindow": 8192,
    "compat": {
      "supportsTools": true,
      "supportsUsageInStreaming": true
    }
  }
}
```

Observed result after fix: The CLI discovered the Ollama model from the endpoint whose /api/show response had no capabilities field, and the provider model still reported compat.supportsTools as true.
What was not tested: No additional behavior beyond the Ollama unknown-capabilities fallback in this PR.

## Risks

The main risk is an Ollama model that truly rejects tools when capabilities cannot be read.
That case can still opt out with compat.supportsTools: false on the model entry.
