### PR TITLE
fix(embedded-runner): preserve provider errors on cleanup takeover

### DIFF
--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -274,6 +274,9 @@ export function isNonProviderRuntimeCoordinationError(err: unknown): boolean {
   if (isFailoverError(err)) {
     return false;
   }
+  if (isEmbeddedAttemptSessionTakeover(err)) {
+    return true;
+  }
   return resolveFailoverClassificationFromError(err) === null;
 }
 

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -797,6 +797,38 @@ describe("runWithModelFallback", () => {
     expect(run).toHaveBeenCalledTimes(1);
   });
 
+  it("aborts fallback when a provider prompt error carries cleanup session takeover", async () => {
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-5.4",
+            fallbacks: ["anthropic/claude-sonnet-4-6", "openai/gpt-4.1-mini"],
+          },
+        },
+      },
+    });
+    const cleanupTakeover = new Error(
+      "session file changed while embedded prompt lock was released: /tmp/session.jsonl",
+    );
+    cleanupTakeover.name = "EmbeddedAttemptSessionTakeoverError";
+    const providerFacingError = new Error("provider rejected request: rate limit", {
+      cause: cleanupTakeover,
+    });
+    providerFacingError.name = "EmbeddedAttemptSessionTakeoverError";
+    const run = vi.fn().mockRejectedValue(providerFacingError);
+
+    await expect(
+      runWithModelFallback({
+        cfg,
+        provider: "openai",
+        model: "gpt-5.4",
+        run,
+      }),
+    ).rejects.toBe(providerFacingError);
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
   it("aborts the fallback chain on session write-lock timeout instead of trying every model (#83510)", async () => {
     const cfg = makeCfg({
       agents: {

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -249,6 +249,9 @@ async function runFallbackCandidate<T>(params: {
     if (isCommandLaneTaskTimeoutError(err)) {
       throw err;
     }
+    if (isNonProviderRuntimeCoordinationError(err)) {
+      throw err;
+    }
     // Normalize abort-wrapped rate-limit errors (e.g. Google Vertex RESOURCE_EXHAUSTED)
     // so they become FailoverErrors and continue the fallback loop instead of aborting.
     const normalizedFailover = coerceToFailoverError(err, {

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -998,31 +998,36 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     expectInitialLockReleasedBeforePostTurnWrite(lockEvents);
   });
 
-  it("preserves provider prompt errors when cleanup detects session takeover", async () => {
+  it("preserves provider prompt errors while carrying cleanup session takeover", async () => {
     const providerError = new Error("provider rejected request: HTTP 400");
     let releasingCleanupLock = false;
+    let cleanupTakeover: EmbeddedAttemptSessionTakeoverError | undefined;
     hoisted.flushPendingToolResultsAfterIdleMock.mockImplementation(async () => {
       releasingCleanupLock = true;
     });
     hoisted.acquireSessionWriteLockMock.mockImplementation(async (params) => ({
       release: async () => {
         if (releasingCleanupLock) {
-          throw new EmbeddedAttemptSessionTakeoverError(params.sessionFile);
+          cleanupTakeover = new EmbeddedAttemptSessionTakeoverError(params.sessionFile);
+          throw cleanupTakeover;
         }
       },
     }));
 
-    const result = await createContextEngineAttemptRunner({
+    const error = await createContextEngineAttemptRunner({
       contextEngine: createContextEngineBootstrapAndAssemble(),
       sessionKey,
       tempPaths,
       sessionPrompt: async () => {
         throw providerError;
       },
-    });
+    }).catch((err: unknown) => err);
 
-    expect(result.promptError).toBe(providerError);
-    expect(result.promptErrorSource).toBe("prompt");
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).name).toBe("EmbeddedAttemptSessionTakeoverError");
+    expect((error as Error).message).toBe(providerError.message);
+    expect((error as Error).cause).toBe(cleanupTakeover);
+    expect((error as { promptError?: unknown }).promptError).toBe(providerError);
   });
 
   it("keeps cleanup session takeover fatal when no provider prompt error exists", async () => {

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -19,6 +19,7 @@ import {
   resolvePromptCacheTouchTimestamp,
   runAttemptContextEngineBootstrap,
 } from "./attempt.context-engine-helpers.js";
+import { EmbeddedAttemptSessionTakeoverError } from "./attempt.session-lock.js";
 import {
   cleanupTempPaths,
   createDefaultEmbeddedSession,
@@ -995,6 +996,58 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     expect(result.finalPromptText).toBeUndefined();
     expect(result.promptErrorSource).toBe("hook:before_agent_run");
     expectInitialLockReleasedBeforePostTurnWrite(lockEvents);
+  });
+
+  it("preserves provider prompt errors when cleanup detects session takeover", async () => {
+    const providerError = new Error("provider rejected request: HTTP 400");
+    let releasingCleanupLock = false;
+    hoisted.flushPendingToolResultsAfterIdleMock.mockImplementation(async () => {
+      releasingCleanupLock = true;
+    });
+    hoisted.acquireSessionWriteLockMock.mockImplementation(async (params) => ({
+      release: async () => {
+        if (releasingCleanupLock) {
+          throw new EmbeddedAttemptSessionTakeoverError(params.sessionFile);
+        }
+      },
+    }));
+
+    const result = await createContextEngineAttemptRunner({
+      contextEngine: createContextEngineBootstrapAndAssemble(),
+      sessionKey,
+      tempPaths,
+      sessionPrompt: async () => {
+        throw providerError;
+      },
+    });
+
+    expect(result.promptError).toBe(providerError);
+    expect(result.promptErrorSource).toBe("prompt");
+  });
+
+  it("keeps cleanup session takeover fatal when no provider prompt error exists", async () => {
+    let releasingCleanupLock = false;
+    hoisted.flushPendingToolResultsAfterIdleMock.mockImplementation(async () => {
+      releasingCleanupLock = true;
+    });
+    hoisted.acquireSessionWriteLockMock.mockImplementation(async (params) => ({
+      release: async () => {
+        if (releasingCleanupLock) {
+          throw new EmbeddedAttemptSessionTakeoverError(params.sessionFile);
+        }
+      },
+    }));
+
+    await expect(
+      createContextEngineAttemptRunner({
+        contextEngine: createContextEngineBootstrapAndAssemble(),
+        sessionKey,
+        tempPaths,
+        sessionPrompt: async (session) => {
+          session.messages = [...session.messages, doneMessage];
+        },
+      }),
+    ).rejects.toBeInstanceOf(EmbeddedAttemptSessionTakeoverError);
   });
 
   it("uses assembled context as the default precheck authority", async () => {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1000,6 +1000,18 @@ function shouldPreservePromptErrorAfterCleanupError(params: {
   );
 }
 
+class EmbeddedAttemptPromptErrorWithCleanupTakeoverError extends Error {
+  readonly promptError: unknown;
+  readonly cleanupError: EmbeddedAttemptSessionTakeoverError;
+
+  constructor(params: { promptError: unknown; cleanupError: EmbeddedAttemptSessionTakeoverError }) {
+    super(formatErrorMessage(params.promptError), { cause: params.cleanupError });
+    this.name = "EmbeddedAttemptSessionTakeoverError";
+    this.promptError = params.promptError;
+    this.cleanupError = params.cleanupError;
+  }
+}
+
 function hasVisiblePendingToolMediaReply(
   reply: { mediaUrls?: string[]; audioAsVoice?: boolean } | null | undefined,
 ): boolean {
@@ -4872,6 +4884,12 @@ export async function runEmbeddedAttempt(
             `embedded attempt cleanup detected session takeover after prompt failure; preserving prompt error: ` +
               `runId=${params.runId} sessionId=${params.sessionId} ` +
               `promptError=${formatErrorMessage(promptError)} cleanupError=${formatErrorMessage(cleanupError)}`,
+          );
+          await Promise.reject(
+            new EmbeddedAttemptPromptErrorWithCleanupTakeoverError({
+              promptError,
+              cleanupError: cleanupError as EmbeddedAttemptSessionTakeoverError,
+            }),
           );
         } else {
           await Promise.reject(cleanupError);

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -324,6 +324,7 @@ import {
   shouldInjectHeartbeatPrompt,
 } from "./attempt.prompt-helpers.js";
 import {
+  EmbeddedAttemptSessionTakeoverError,
   createEmbeddedAttemptSessionLockController,
   installPromptSubmissionLockRelease,
   installSessionExternalHookWriteLock,
@@ -987,6 +988,16 @@ function flushSessionManagerFile(sessionManager: ReturnType<typeof guardSessionM
 
 export function shouldRunLlmOutputHooksForAttempt(params: { promptErrorSource: string | null }) {
   return params.promptErrorSource !== "hook:before_agent_run";
+}
+
+function shouldPreservePromptErrorAfterCleanupError(params: {
+  promptError: unknown;
+  cleanupError: unknown;
+}): boolean {
+  return (
+    Boolean(params.promptError) &&
+    params.cleanupError instanceof EmbeddedAttemptSessionTakeoverError
+  );
 }
 
 function hasVisiblePendingToolMediaReply(
@@ -4836,6 +4847,10 @@ export async function runEmbeddedAttempt(
       } catch (err) {
         cleanupError = err;
       }
+      const shouldPreservePromptError = shouldPreservePromptErrorAfterCleanupError({
+        promptError,
+        cleanupError,
+      });
       emitDiagnosticRunCompleted?.(
         cleanupError
           ? "error"
@@ -4846,13 +4861,21 @@ export async function runEmbeddedAttempt(
               : aborted || timedOut || idleTimedOut || timedOutDuringCompaction
                 ? "aborted"
                 : "completed",
-        cleanupError ?? promptError,
+        shouldPreservePromptError ? promptError : (cleanupError ?? promptError),
         beforeAgentRunBlocked
           ? { blockedBy: beforeAgentRunBlockedBy ?? "before_agent_run" }
           : undefined,
       );
       if (cleanupError) {
-        await Promise.reject(cleanupError);
+        if (shouldPreservePromptError) {
+          log.warn(
+            `embedded attempt cleanup detected session takeover after prompt failure; preserving prompt error: ` +
+              `runId=${params.runId} sessionId=${params.sessionId} ` +
+              `promptError=${formatErrorMessage(promptError)} cleanupError=${formatErrorMessage(cleanupError)}`,
+          );
+        } else {
+          await Promise.reject(cleanupError);
+        }
       }
     }
   } finally {


### PR DESCRIPTION
## Summary

- Preserve the original prompt/provider error when embedded-attempt cleanup later reports `EmbeddedAttemptSessionTakeoverError`.
- Keep cleanup-only takeover errors fatal when there is no prior prompt error to report.
- Carry the takeover signal into fallback classification so the user-facing provider message remains visible but model fallback still aborts on local session takeover.
- Add regressions for prompt-error preservation, cleanup-only takeover, and fallback abort behavior.

## Real behavior proof

Behavior addressed: embedded runner cleanup can race with a session takeover after a provider prompt failure; the user-facing failure should remain the provider/prompt error, but fallback must still see the takeover signal and stop instead of dispatching another model attempt into a taken-over session.

Real environment tested: local OpenClaw source checkout in an isolated worktree on this branch, using the patched fallback classifier from the worktree root.

Exact steps or command run after the patch:

```sh
node --import tsx -e '<construct a provider-message wrapper with EmbeddedAttemptSessionTakeoverError identity/cause and pass it to isNonProviderRuntimeCoordinationError>'
node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts src/agents/model-fallback.test.ts
pnpm tsgo:test:src
pnpm check:changed
git diff --check origin/main...HEAD
```

Evidence after fix: terminal output from the one-shot runtime fallback-classifier probe:

```json
{
  "wrapperName": "EmbeddedAttemptSessionTakeoverError",
  "userFacingMessage": "provider rejected request: HTTP 400",
  "causeName": "EmbeddedAttemptSessionTakeoverError",
  "abortsFallback": true
}
```

Observed result after fix: the wrapper preserves the provider-facing message while retaining the takeover identity/cause, and the fallback classifier returns `abortsFallback: true` for that runtime-shaped error.

What was not tested: no live provider outage was forced against a production gateway. The runtime classifier probe exercises the non-mocked fallback boundary; the cleanup race itself is covered by the embedded-runner attempt harness that owns the cleanup/error precedence path.

Supplemental checks:

- Focused Vitest lane passed: 4 files, 218 tests.
- `pnpm tsgo:test:src` passed.
- `pnpm check:changed` passed the core/coreTests lane, lint, typechecks, dependency guards, import-cycle guard, and related changed-file checks.
- `git diff --check origin/main...HEAD` passed.

## Review

Codex review initially flagged that preserving only the provider error could let fallback continue after session takeover. The second commit addresses that by carrying the takeover signal through fallback classification while keeping the provider message user-facing. ClawSweeper re-review now reports patch quality as acceptable; this body update uses the proof-field labels required by the repository gate.

AI-assisted: yes. I understand the change and verified the narrow error-precedence and fallback-abort behavior locally.
