### PR TITLE
[codex] Fix Control UI terminal run status recovery

### DIFF
--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -44,6 +44,7 @@ let handleSendChat: typeof import("./app-chat.ts").handleSendChat;
 let steerQueuedChatMessage: typeof import("./app-chat.ts").steerQueuedChatMessage;
 let navigateChatInputHistory: typeof import("./app-chat.ts").navigateChatInputHistory;
 let handleAbortChat: typeof import("./app-chat.ts").handleAbortChat;
+let hasAbortableSessionRun: typeof import("./app-chat.ts").hasAbortableSessionRun;
 let refreshChat: typeof import("./app-chat.ts").refreshChat;
 let refreshChatAvatar: typeof import("./app-chat.ts").refreshChatAvatar;
 let clearPendingQueueItemsForRun: typeof import("./app-chat.ts").clearPendingQueueItemsForRun;
@@ -55,6 +56,7 @@ async function loadChatHelpers(): Promise<void> {
     steerQueuedChatMessage,
     navigateChatInputHistory,
     handleAbortChat,
+    hasAbortableSessionRun,
     refreshChat,
     refreshChatAvatar,
     clearPendingQueueItemsForRun,
@@ -1571,6 +1573,19 @@ describe("handleAbortChat", () => {
 
     expect(host.pendingAbort).toEqual({ runId: null, sessionKey: "agent:main" });
     expect(host.chatMessage).toBe("");
+  });
+
+  it("ignores stale active-run flags once the current session is terminal", () => {
+    const host = makeHost({
+      chatRunId: null,
+      sessionKey: "agent:main",
+      sessionsResult: createSessionsResult([
+        row("agent:main", { hasActiveRun: true, status: "done" }),
+        row("agent:other", { hasActiveRun: true, status: "running" }),
+      ]),
+    });
+
+    expect(hasAbortableSessionRun(host)).toBe(false);
   });
 
   it("keeps the draft when disconnected without an active run", async () => {

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -35,6 +35,7 @@ import { loadSessions, type SessionsState } from "./controllers/sessions.ts";
 import type { GatewayBrowserClient, GatewayHelloOk } from "./gateway.ts";
 import { normalizeBasePath } from "./navigation.ts";
 import { parseAgentSessionKey } from "./session-key.ts";
+import { isSessionRunActive } from "./session-run-state.ts";
 import { normalizeLowercaseStringOrEmpty } from "./string-coerce.ts";
 import type { ChatModelOverride, ModelCatalogEntry } from "./types.ts";
 import type { SessionsListResult } from "./types.ts";
@@ -108,7 +109,7 @@ export function hasAbortableSessionRun(host: {
   }
   return Boolean(
     host.sessionsResult?.sessions.some(
-      (session) => session.key === host.sessionKey && session.hasActiveRun === true,
+      (session) => session.key === host.sessionKey && isSessionRunActive(session),
     ),
   );
 }

--- a/ui/src/ui/chat/run-lifecycle.ts
+++ b/ui/src/ui/chat/run-lifecycle.ts
@@ -1,4 +1,5 @@
 import { resetToolStream, type CompactionStatus, type FallbackStatus } from "../app-tool-stream.ts";
+import { isSessionRunActive } from "../session-run-state.ts";
 import type { SessionRunStatus, SessionsListResult } from "../types.ts";
 
 export const CHAT_RUN_STATUS_TOAST_DURATION_MS = 5_000;
@@ -202,7 +203,7 @@ export function reconcileChatRunFromCurrentSessionRow(host: RunLifecycleHost): b
   if (!row) {
     return false;
   }
-  if (row.hasActiveRun === true || row.status === "running") {
+  if (isSessionRunActive(row)) {
     return false;
   }
   const terminalStatus = row.status !== undefined;

--- a/ui/src/ui/controllers/sessions.test.ts
+++ b/ui/src/ui/controllers/sessions.test.ts
@@ -367,7 +367,7 @@ describe("loadSessions", () => {
               key: "main",
               kind: "direct",
               updatedAt: 2,
-              hasActiveRun: false,
+              hasActiveRun: true,
               status: "done",
             },
           ],

--- a/ui/src/ui/session-run-state.ts
+++ b/ui/src/ui/session-run-state.ts
@@ -1,0 +1,13 @@
+import type { SessionRunStatus } from "./types.ts";
+
+type SessionRunState = {
+  hasActiveRun?: boolean;
+  status?: SessionRunStatus;
+};
+
+export function isSessionRunActive(state: SessionRunState): boolean {
+  if (state.status) {
+    return state.status === "running";
+  }
+  return state.hasActiveRun === true;
+}

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -559,6 +559,51 @@ describe("chat loading skeleton", () => {
     expect(container.querySelector(".chat-loading-skeleton")).toBeNull();
     expect(container.querySelectorAll(".chat-reading-indicator")).toHaveLength(1);
   });
+
+  it("lets terminal run status win over stale abortable session UI", () => {
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_000);
+    try {
+      const container = renderChatView({
+        canAbort: true,
+        runStatus: {
+          phase: "done",
+          runId: "run-1",
+          sessionKey: "main",
+          occurredAt: 1_000,
+        },
+        sessions: {
+          ts: 0,
+          path: "",
+          count: 1,
+          defaults: { modelProvider: null, model: null, contextTokens: 200_000 },
+          sessions: [
+            {
+              key: "main",
+              kind: "direct",
+              updatedAt: null,
+              hasActiveRun: true,
+              status: "done",
+              totalTokens: 190_000,
+              contextTokens: 200_000,
+            },
+          ],
+        },
+        onCompact: () => undefined,
+      });
+
+      expect(container.querySelector(".agent-chat__run-status--done")?.textContent).toContain(
+        "Done",
+      );
+      expect(container.querySelector(".agent-chat__run-status--in-progress")).toBeNull();
+      expect(container.querySelector(".chat-reading-indicator")).toBeNull();
+      expect(container.querySelector(".chat-send-btn--stop")).toBeNull();
+      expect(container.querySelector<HTMLButtonElement>(".context-notice__action")?.disabled).toBe(
+        false,
+      );
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
 });
 
 describe("chat voice controls", () => {

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -71,6 +71,10 @@ const COMPOSER_CHROME_INTERACTIVE_SELECTOR = [
   "[role='option']",
 ].join(",");
 
+function hasTerminalRunStatus(status: ChatRunUiStatus | null | undefined): boolean {
+  return status?.phase === "done" || status?.phase === "interrupted";
+}
+
 export type ChatProps = {
   sessionKey: string;
   onSessionKeyChange: (next: string) => void;
@@ -979,7 +983,8 @@ export function renderChat(props: ChatProps) {
   const canCompose = props.connected;
   const isBusy = props.sending || props.stream !== null;
   const canAbort = Boolean(props.canAbort && props.onAbort);
-  const composerRunStatus = canAbort ? { phase: "in-progress" as const } : props.runStatus;
+  const showAbortableUi = canAbort && !hasTerminalRunStatus(props.runStatus);
+  const composerRunStatus = showAbortableUi ? { phase: "in-progress" as const } : props.runStatus;
   const compactBusy =
     props.compactionStatus?.phase === "active" || props.compactionStatus?.phase === "retrying";
   const activeSession = props.sessions?.sessions?.find((row) => row.key === props.sessionKey);
@@ -1402,7 +1407,7 @@ export function renderChat(props: ChatProps) {
 
       ${renderChatQueue({
         queue: props.queue,
-        canAbort: props.canAbort,
+        canAbort: showAbortableUi,
         onQueueSteer: props.onQueueSteer,
         onQueueRemove: props.onQueueRemove,
       })}
@@ -1411,7 +1416,7 @@ export function renderChat(props: ChatProps) {
       ${renderCompactionIndicator(props.compactionStatus)}
       ${renderContextNotice(activeSession, props.sessions?.defaults?.contextTokens ?? null, {
         compactBusy,
-        compactDisabled: !props.connected || isBusy || Boolean(props.canAbort),
+        compactDisabled: !props.connected || isBusy || showAbortableUi,
         onCompact: props.onCompact,
       })}
       ${props.showNewMessages
@@ -1533,7 +1538,7 @@ export function renderChat(props: ChatProps) {
           </div>
 
           ${renderChatRunControls({
-            canAbort,
+            canAbort: showAbortableUi,
             connected: props.connected,
             draft: props.draft,
             hasMessages: props.messages.length > 0,

--- a/ui/src/ui/views/sessions.test.ts
+++ b/ui/src/ui/views/sessions.test.ts
@@ -475,6 +475,13 @@ describe("sessions view", () => {
               updatedAt: 10,
               status: "failed",
             },
+            {
+              key: "agent:main:done",
+              kind: "direct",
+              updatedAt: 5,
+              hasActiveRun: true,
+              status: "done",
+            },
           ]),
         ),
       ),
@@ -484,16 +491,23 @@ describe("sessions view", () => {
 
     expect(sessionTableHeaders(container)).toEqual(SESSION_TABLE_HEADERS);
     const badges = Array.from(container.querySelectorAll(".session-status-badge"));
-    expect(badges.map((badge) => badge.textContent?.trim())).toEqual(["Live", "Idle", "Failed"]);
+    expect(badges.map((badge) => badge.textContent?.trim())).toEqual([
+      "Live",
+      "Idle",
+      "Failed",
+      "Done",
+    ]);
     expect(badges.map((badge) => [...badge.classList])).toEqual([
       ["session-status-badge", "session-status-badge--live"],
       ["session-status-badge", "session-status-badge--idle"],
       ["session-status-badge", "session-status-badge--failed"],
+      ["session-status-badge", "session-status-badge--done"],
     ]);
     expect(badges.map((badge) => badge.getAttribute("aria-label"))).toEqual([
       "Status: Live",
       "Status: Idle",
       "Status: Failed",
+      "Status: Done",
     ]);
   });
 

--- a/ui/src/ui/views/sessions.ts
+++ b/ui/src/ui/views/sessions.ts
@@ -4,6 +4,7 @@ import { formatRelativeTimestamp, parseSessionKeyParts } from "../format.ts";
 import { icons } from "../icons.ts";
 import { pathForTab } from "../navigation.ts";
 import { formatSessionTokens } from "../presenter.ts";
+import { isSessionRunActive } from "../session-run-state.ts";
 import { normalizeLowercaseStringOrEmpty, normalizeOptionalString } from "../string-coerce.ts";
 import {
   formatInheritedThinkingLabel,
@@ -196,7 +197,7 @@ function resolveSessionStatusBadge(row: GatewaySessionRow): {
   label: string;
   tone: "live" | "idle" | "done" | "failed" | "muted";
 } {
-  if (row.hasActiveRun === true || row.status === "running") {
+  if (isSessionRunActive(row)) {
     return { label: t("sessionsView.statusLive"), tone: "live" };
   }
   if (row.status) {


### PR DESCRIPTION
## Summary
- stop treating terminal session rows as active runs when `hasActiveRun` lingers after completion
- let terminal chat run status win over stale abortable UI so the Control UI returns to done instead of staying in progress
- add regressions for abort recovery, terminal session refresh, chat rendering, and session badges

Closes #84041.

## Verification
- `node scripts/run-vitest.mjs ui/src/ui/app-chat.test.ts ui/src/ui/controllers/sessions.test.ts ui/src/ui/views/chat.test.ts ui/src/ui/views/sessions.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json ui/src/ui/session-run-state.ts ui/src/ui/app-chat.ts ui/src/ui/chat/run-lifecycle.ts ui/src/ui/views/chat.ts ui/src/ui/views/sessions.ts ui/src/ui/app-chat.test.ts ui/src/ui/controllers/sessions.test.ts ui/src/ui/views/chat.test.ts ui/src/ui/views/sessions.test.ts`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.ui.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-ui-issue-84041.tsbuildinfo`
- `git diff --check -- ui/src/ui/session-run-state.ts ui/src/ui/app-chat.ts ui/src/ui/chat/run-lifecycle.ts ui/src/ui/views/chat.ts ui/src/ui/views/sessions.ts ui/src/ui/app-chat.test.ts ui/src/ui/controllers/sessions.test.ts ui/src/ui/views/chat.test.ts ui/src/ui/views/sessions.test.ts`

## Real behavior proof
Behavior addressed: Control UI now returns to the terminal `Done` state when a session row still carries stale `hasActiveRun: true` after completion, so stale Stop and reading UI do not linger and context compaction becomes available again.

Real environment tested: Local macOS source checkout rendered the current branch Control UI chat surface with current `ui/src/ui/views/chat.ts` code, current Control UI CSS, and a real Chromium page.

Exact steps or command run after this patch: Ran a one-off local `tsx` proof script from the current checkout that rendered the current `renderChat()` output for `status: "done"` plus stale `hasActiveRun: true`, loaded that HTML into Chromium, queried the visible Control UI DOM, and saved a screenshot.

Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Browser console output / terminal capture from the Chromium render:

```text
runStatusLabel=Done
hasDoneStatus=true
hasInProgressStatus=false
stopButtonCount=0
readingIndicatorCount=0
compactDisabled=false
compactLabel=Compact
visibleText="Val Ready to chat Type a message below · / for commands What can you do? Summarize my recent sessions Help me configure a channel Check system health 95% context used 190k / 200k Compact Attach file Start Talk Done New session Export Send"
```

Observed result after fix: The current branch render shows the terminal Done chip, no in-progress chip, no Stop button, no reading indicator, and an enabled Compact action even when the same session row still reports `hasActiveRun: true`.

What was not tested: I did not run the reporter's exact custom local provider setup or capture a full live network/provider round-trip; this proof is a real Chromium render of the current Control UI surface for the stale terminal session state that triggered the bug.
