### PR TITLE
refactor(terminal): optimize OSC progress label sanitization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Terminal/progress: sanitize OSC progress labels with one precompiled regex pass instead of multiple string scans while preserving the existing OSC terminator cleanup behavior.
+
 ### Fixes
 - iMessage: mark authorized slash-command turns as text-sourced commands so `/status`, `/new`, and `/restart` acknowledgements return to the source conversation. (#82642) thanks @homer-byte.
 

--- a/src/terminal/osc-progress.test.ts
+++ b/src/terminal/osc-progress.test.ts
@@ -10,6 +10,9 @@ describe("OSC progress", () => {
 
   it("writes sanitized OSC 9;4 progress sequences", () => {
     const writes: string[] = [];
+    const esc = String.fromCharCode(0x1b);
+    const bel = String.fromCharCode(0x07);
+    const c1StringTerminator = String.fromCharCode(0x9c);
     const controller = createOscProgressController({
       env: { TERM_PROGRAM: "ghostty" },
       isTty: true,
@@ -17,11 +20,13 @@ describe("OSC progress", () => {
     });
 
     controller.setIndeterminate("Build\u001b]bad\u0007");
+    controller.setIndeterminate(`Build${esc}\\safe${c1StringTerminator}${esc}]bad${bel}]done`);
     controller.setPercent("Build", 42.6);
     controller.clear();
 
     expect(writes).toEqual([
       "\u001b]9;4;3;;Buildbad\u001b\\",
+      "\u001b]9;4;3;;Buildsafebaddone\u001b\\",
       "\u001b]9;4;1;43;Build\u001b\\",
       "\u001b]9;4;0;0;Build\u001b\\",
     ]);

--- a/src/terminal/osc-progress.ts
+++ b/src/terminal/osc-progress.ts
@@ -2,6 +2,14 @@ const OSC_PROGRESS_PREFIX = "\u001b]9;4;";
 const OSC_PROGRESS_ST = "\u001b\\";
 const OSC_PROGRESS_BEL = "\u0007";
 const OSC_PROGRESS_C1_ST = "\u009c";
+const OSC_PROGRESS_ESC = String.fromCharCode(0x1b);
+const REGEXP_SPECIAL_CHARS = /[\\^$.*+?()[\]{}|]/g;
+const OSC_PROGRESS_LABEL_FORBIDDEN_REGEX = new RegExp(
+  [OSC_PROGRESS_ST, OSC_PROGRESS_BEL, OSC_PROGRESS_C1_ST, OSC_PROGRESS_ESC, "]"]
+    .map((part) => part.replace(REGEXP_SPECIAL_CHARS, "\\$&"))
+    .join("|"),
+  "g",
+);
 
 export type OscProgressController = {
   setIndeterminate: (label: string) => void;
@@ -20,14 +28,7 @@ export function supportsOscProgress(env: NodeJS.ProcessEnv, isTty: boolean): boo
 }
 
 function sanitizeOscProgressLabel(label: string): string {
-  return label
-    .replaceAll(OSC_PROGRESS_ST, "")
-    .replaceAll(OSC_PROGRESS_BEL, "")
-    .replaceAll(OSC_PROGRESS_C1_ST, "")
-    .split("\u001b")
-    .join("")
-    .replaceAll("]", "")
-    .trim();
+  return label.replace(OSC_PROGRESS_LABEL_FORBIDDEN_REGEX, "").trim();
 }
 
 function formatOscProgress(state: number, percent: number | null, label: string): string {


### PR DESCRIPTION
### Summary

Replaced the OSC progress label sanitizer's chained string passes with one module-level precompiled regex. The forbidden label tokens are still the same: OSC ST, BEL, C1 ST, bare ESC, and `]`.

### Benchmark

Environment: Node `v22.17.0` on native Windows, run from `C:\Users\user\Downloads\openclaw-pr`.

Method:
- compared the previous chained `replaceAll` / `split().join()` sanitizer against the new regex sanitizer
- verified old and new outputs matched for every benchmark input before timing
- used warmup plus 7 timing rounds per case and reported the median

Results:
- `plain-label` (26 chars): old `576.3 ns/op`, new `88.2 ns/op` -> `6.53x` faster (`-84.7%`)
- `short-osc` (11 chars): old `863.8 ns/op`, new `181.2 ns/op` -> `4.77x` faster (`-79.0%`)
- `mixed-controls` (20 chars): old `1274.2 ns/op`, new `333.5 ns/op` -> `3.82x` faster (`-73.8%`)
- `long-status` (2559 chars): old `23663.9 ns/op`, new `21921.4 ns/op` -> `1.08x` faster (`-7.4%`)

### Tests

- `pnpm install --frozen-lockfile` completed. Note: emitted the existing engine warning because this local machine has Node `v22.17.0` while the repo asks for `>=22.19.0`.
- `pnpm test src/terminal/osc-progress.test.ts` passed: 1 test file, 2 tests.
- `pnpm exec oxfmt --check src/terminal/osc-progress.ts src/terminal/osc-progress.test.ts CHANGELOG.md` passed.
- `git diff --check` passed.

### Real behavior proof

Behavior addressed: OSC progress labels are sanitized before being interpolated into terminal OSC 9;4 progress sequences.

Real environment tested: Native Windows checkout at `C:\Users\user\Downloads\openclaw-pr`, Node `v22.17.0`, pnpm `11.1.0`.

Exact steps or command run after this patch: From the patched checkout, ran a local inline `node` benchmark script that invokes the old sanitizer and new sanitizer on representative OSC progress labels, asserts output equality before timing, then reports median nanoseconds per operation.

Evidence after fix: Terminal output copied from the patched checkout:

```text
$ node <inline osc-progress sanitizer benchmark script>
plain-label     length=  26 old=576.3 ns/op new=88.2 ns/op speedup=6.53x reduction=84.7%
short-osc       length=  11 old=863.8 ns/op new=181.2 ns/op speedup=4.77x reduction=79.0%
mixed-controls  length=  20 old=1274.2 ns/op new=333.5 ns/op speedup=3.82x reduction=73.8%
long-status     length=2559 old=23663.9 ns/op new=21921.4 ns/op speedup=1.08x reduction=7.4%
```

Observed result after fix: The benchmark completed after checking old/new output equality for plain, OSC-containing, mixed-control, and long repeated labels. The new sanitizer preserved the expected sanitized labels, including `Buildsafebaddone` for mixed OSC terminators/control characters, and measured faster across all benchmark cases.

What was not tested: I did not run a live Ghostty/WezTerm terminal session or the full repository test suite.
