### PR TITLE
fix(slack): call markRunComplete before markDispatchIdle in reply pipeline

### DIFF
--- a/extensions/slack/src/monitor/message-handler/dispatch.lifecycle.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.lifecycle.test.ts
@@ -41,14 +41,15 @@ let markDispatchIdleMock: ReturnType<typeof vi.fn>;
 // ---------------------------------------------------------------------------
 
 vi.mock("../reply.runtime.js", () => ({
-  createReplyDispatcherWithTyping: (params: {
-    deliver: (payload: unknown, info: { kind: "tool" | "block" | "final" }) => Promise<void>;
-  }) => ({
+  createReplyDispatcherWithTyping: (_params: Record<string, unknown>) => ({
     dispatcher: {
-      deliver: params.deliver,
+      sendToolResult: vi.fn(() => true),
+      sendBlockReply: vi.fn(() => true),
+      sendFinalReply: vi.fn(() => true),
       markComplete: vi.fn(),
       waitForIdle: vi.fn(async () => {}),
       getQueuedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),
+      getFailedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),
     },
     replyOptions: {},
     markDispatchIdle: () => {
@@ -60,15 +61,7 @@ vi.mock("../reply.runtime.js", () => ({
       callOrder.push("markRunComplete");
     },
   }),
-  dispatchInboundMessage: async (params: {
-    replyOptions?: unknown;
-    dispatcher: {
-      deliver: (payload: unknown, info: { kind: "tool" | "block" | "final" }) => Promise<void>;
-    };
-  }) => {
-    for (const entry of mockedDispatchSequence) {
-      await params.dispatcher.deliver(entry.payload, { kind: entry.kind });
-    }
+  dispatchInboundMessage: async (_params: Record<string, unknown>) => {
     return {
       queuedFinal: false,
       counts: { final: mockedDispatchSequence.filter((e) => e.kind === "final").length },

--- a/extensions/slack/src/monitor/message-handler/dispatch.lifecycle.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.lifecycle.test.ts
@@ -33,8 +33,8 @@ const runPreparedInboundReplyTurnMock = vi.fn();
 // ---------------------------------------------------------------------------
 
 const callOrder: string[] = [];
-let markRunCompleteMock: ReturnType<typeof vi.fn>;
-let markDispatchIdleMock: ReturnType<typeof vi.fn>;
+let markRunCompleteMock: vi.MockedFunction<() => void>;
+let markDispatchIdleMock: vi.MockedFunction<() => void>;
 
 // ---------------------------------------------------------------------------
 // vi.mock calls (hoisted — must be at top level)

--- a/extensions/slack/src/monitor/message-handler/dispatch.lifecycle.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.lifecycle.test.ts
@@ -1,0 +1,344 @@
+/**
+ * Lifecycle tests for dispatchPreparedSlackMessage.
+ *
+ * Verifies that markRunComplete() is called before markDispatchIdle() in both
+ * the normal dispatch path and the onPreDispatchFailure path (issue #84049).
+ *
+ * Background: Slack's typing/status indicator was not clearing on doneHoldMs
+ * because markRunComplete() was never called. Core typing cleanup requires
+ * both run-complete and dispatch-idle state. Without markRunComplete(), Slack
+ * waited for the fallback TTL (~2 minutes) instead of doneHoldMs.
+ */
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Shared mutable state for mock control
+// ---------------------------------------------------------------------------
+
+let mockedDispatchSequence: Array<{
+  kind: "tool" | "block" | "final";
+  payload: { text?: string };
+}> = [{ kind: "final", payload: { text: "hello" } }];
+
+let shouldPreDispatchFail = false;
+
+const deliverRepliesMock = vi.fn(async () => {});
+const postMessageMock = vi.fn(async () => ({ ts: "ts-1", channel: "C123" }));
+const recordInboundSessionMock = vi.fn(async () => {});
+const updateLastRouteMock = vi.fn(async () => {});
+const runPreparedInboundReplyTurnMock = vi.fn();
+
+// ---------------------------------------------------------------------------
+// Lifecycle tracking for markRunComplete / markDispatchIdle
+// ---------------------------------------------------------------------------
+
+const callOrder: string[] = [];
+let markRunCompleteMock: ReturnType<typeof vi.fn>;
+let markDispatchIdleMock: ReturnType<typeof vi.fn>;
+
+// ---------------------------------------------------------------------------
+// vi.mock calls (hoisted — must be at top level)
+// ---------------------------------------------------------------------------
+
+vi.mock("../reply.runtime.js", () => ({
+  createReplyDispatcherWithTyping: (params: {
+    deliver: (payload: unknown, info: { kind: "tool" | "block" | "final" }) => Promise<void>;
+  }) => ({
+    dispatcher: {
+      deliver: params.deliver,
+      markComplete: vi.fn(),
+      waitForIdle: vi.fn(async () => {}),
+      getQueuedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),
+    },
+    replyOptions: {},
+    markDispatchIdle: () => {
+      markDispatchIdleMock?.();
+      callOrder.push("markDispatchIdle");
+    },
+    markRunComplete: () => {
+      markRunCompleteMock?.();
+      callOrder.push("markRunComplete");
+    },
+  }),
+  dispatchInboundMessage: async (params: {
+    replyOptions?: unknown;
+    dispatcher: {
+      deliver: (payload: unknown, info: { kind: "tool" | "block" | "final" }) => Promise<void>;
+    };
+  }) => {
+    for (const entry of mockedDispatchSequence) {
+      await params.dispatcher.deliver(entry.payload, { kind: entry.kind });
+    }
+    return {
+      queuedFinal: false,
+      counts: { final: mockedDispatchSequence.filter((e) => e.kind === "final").length },
+    };
+  },
+  settleReplyDispatcher: async (params: {
+    dispatcher: { markComplete: () => void; waitForIdle: () => Promise<void> };
+    onSettled?: () => void | Promise<void>;
+  }) => {
+    params.dispatcher.markComplete();
+    await params.dispatcher.waitForIdle();
+    await params.onSettled?.();
+  },
+}));
+
+vi.mock("openclaw/plugin-sdk/inbound-reply-dispatch", async () => {
+  const actual = await vi.importActual<
+    typeof import("openclaw/plugin-sdk/inbound-reply-dispatch")
+  >("openclaw/plugin-sdk/inbound-reply-dispatch");
+  return {
+    ...actual,
+    runPreparedInboundReplyTurn: (params: {
+      onPreDispatchFailure?: () => Promise<void>;
+      runDispatch: () => Promise<unknown>;
+    }) => runPreparedInboundReplyTurnMock(params),
+    hasVisibleInboundReplyDispatch: actual.hasVisibleInboundReplyDispatch,
+  };
+});
+
+vi.mock("../replies.js", () => ({
+  createSlackReplyDeliveryPlan: () => ({
+    nextThreadTs: () => "thread-1",
+    peekThreadTs: () => "thread-1",
+    markSent: vi.fn(),
+  }),
+  deliverReplies: deliverRepliesMock,
+  readSlackReplyBlocks: () => undefined,
+  resolveDeliveredSlackReplyThreadTs: () => "thread-1",
+  resolveSlackThreadTs: () => "thread-1",
+}));
+
+vi.mock("../conversation.runtime.js", () => ({
+  recordInboundSession: recordInboundSessionMock,
+}));
+
+vi.mock("../config.runtime.js", () => ({
+  resolveStorePath: () => "/tmp/store",
+  updateLastRoute: updateLastRouteMock,
+}));
+
+vi.mock("../../threading.js", () => ({
+  resolveSlackThreadTargets: () => ({
+    statusThreadTs: "thread-1",
+    isThreadReply: false,
+  }),
+}));
+
+vi.mock("../../streaming.js", () => ({
+  startSlackStream: vi.fn(async () => ({
+    channel: "C123",
+    threadTs: "thread-1",
+    stopped: false,
+    delivered: true,
+    pendingText: "",
+  })),
+  appendSlackStream: vi.fn(async () => {}),
+  stopSlackStream: vi.fn(async () => {}),
+  markSlackStreamFallbackDelivered: vi.fn(),
+  SlackStreamNotDeliveredError: class SlackStreamNotDeliveredError extends Error {
+    slackCode: string;
+    pendingText: string;
+    constructor(pendingText: string, slackCode: string) {
+      super("not delivered");
+      this.slackCode = slackCode;
+      this.pendingText = pendingText;
+    }
+  },
+}));
+
+vi.mock("../../sent-thread-cache.js", () => ({
+  recordSlackThreadParticipation: vi.fn(),
+}));
+
+vi.mock("../../actions.js", () => ({
+  reactSlackMessage: vi.fn(async () => {}),
+  removeSlackReaction: vi.fn(async () => {}),
+}));
+
+vi.mock("openclaw/plugin-sdk/channel-feedback", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/channel-feedback")>(
+    "openclaw/plugin-sdk/channel-feedback",
+  );
+  return {
+    ...actual,
+    createStatusReactionController: () => ({
+      setQueued: vi.fn(async () => {}),
+      setThinking: vi.fn(async () => {}),
+      setTool: vi.fn(async () => {}),
+      setDone: vi.fn(async () => {}),
+      setError: vi.fn(async () => {}),
+      clear: vi.fn(async () => {}),
+      restoreInitial: vi.fn(async () => {}),
+    }),
+    removeAckReactionAfterReply: vi.fn(async () => {}),
+  };
+});
+
+vi.mock("openclaw/plugin-sdk/security-runtime", () => ({
+  resolvePinnedMainDmOwnerFromAllowlist: () => undefined,
+}));
+
+vi.mock("openclaw/plugin-sdk/outbound-runtime", () => ({
+  resolveAgentOutboundIdentity: () => undefined,
+}));
+
+vi.mock("openclaw/plugin-sdk/channel-message", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/channel-message")>(
+    "openclaw/plugin-sdk/channel-message",
+  );
+  return {
+    ...actual,
+    createChannelMessageReplyPipeline: () => ({
+      onModelSelected: vi.fn(),
+      typingCallbacks: { onIdle: vi.fn() },
+      typing: {
+        start: vi.fn(async () => {}),
+        stop: vi.fn(async () => {}),
+        onStartError: vi.fn(),
+        onStopError: vi.fn(),
+      },
+    }),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Test helper
+// ---------------------------------------------------------------------------
+
+function createPreparedSlackMessage() {
+  return {
+    ctx: {
+      cfg: {},
+      runtime: {},
+      botToken: "xoxb-test",
+      app: { client: { chat: { postMessage: postMessageMock }, users: { info: vi.fn() } } },
+      teamId: "T1",
+      botUserId: "U_OPENCLAW",
+      botId: "B_OPENCLAW",
+      textLimit: 4000,
+      typingReaction: "",
+      removeAckAfterReply: false,
+      historyLimit: 0,
+      channelHistories: new Map(),
+      allowFrom: [],
+      setSlackThreadStatus: async () => undefined,
+    },
+    account: {
+      accountId: "default",
+      config: {},
+    },
+    message: {
+      channel: "C123",
+      ts: "171234.111",
+      thread_ts: "thread-1",
+      user: "U123",
+    },
+    route: {
+      agentId: "agent-1",
+      accountId: "default",
+      mainSessionKey: "main",
+      sessionKey: "agent:agent-1:slack:C123",
+      lastRoutePolicy: "session",
+    },
+    channelConfig: null,
+    replyToMode: "first" as const,
+    isDirectMessage: false,
+    replyTarget: "C123",
+    forcedReplyThreadTs: undefined,
+    slackMessageMetadata: undefined,
+    ackReactionMessageTs: undefined,
+    ackReactionPromise: null,
+    ackReactionValue: "eyes",
+    ctxPayload: {
+      MessageThreadId: undefined,
+      TransportThreadId: undefined,
+      SessionKey: undefined,
+    },
+    turn: {
+      storePath: "/tmp/store",
+      record: {},
+      history: [],
+    },
+  } as unknown as Parameters<
+    typeof import("./dispatch.js").dispatchPreparedSlackMessage
+  >[0];
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+let dispatchPreparedSlackMessage: typeof import("./dispatch.js").dispatchPreparedSlackMessage;
+
+describe("dispatchPreparedSlackMessage run lifecycle (issue #84049)", () => {
+  beforeAll(async () => {
+    ({ dispatchPreparedSlackMessage } = await import("./dispatch.js"));
+  });
+
+  beforeEach(() => {
+    callOrder.length = 0;
+    markRunCompleteMock = vi.fn();
+    markDispatchIdleMock = vi.fn();
+    mockedDispatchSequence = [{ kind: "final", payload: { text: "hello" } }];
+    shouldPreDispatchFail = false;
+    deliverRepliesMock.mockReset();
+    deliverRepliesMock.mockResolvedValue(undefined);
+
+    // Default: normal successful dispatch
+    runPreparedInboundReplyTurnMock.mockImplementation(
+      async (params: {
+        onPreDispatchFailure?: () => Promise<void>;
+        runDispatch: () => Promise<unknown>;
+      }) => {
+        const result = await params.runDispatch();
+        return { dispatched: true, dispatchResult: result };
+      },
+    );
+  });
+
+  it("calls markRunComplete before markDispatchIdle on normal dispatch completion", async () => {
+    await dispatchPreparedSlackMessage(createPreparedSlackMessage());
+
+    expect(markRunCompleteMock).toHaveBeenCalledTimes(1);
+    expect(markDispatchIdleMock).toHaveBeenCalledTimes(1);
+
+    const rcIndex = callOrder.indexOf("markRunComplete");
+    const idleIndex = callOrder.indexOf("markDispatchIdle");
+    expect(rcIndex).toBeGreaterThanOrEqual(0);
+    expect(idleIndex).toBeGreaterThanOrEqual(0);
+    expect(rcIndex).toBeLessThan(idleIndex);
+  });
+
+  it("calls markRunComplete before markDispatchIdle when onPreDispatchFailure fires", async () => {
+    runPreparedInboundReplyTurnMock.mockImplementation(
+      async (params: {
+        onPreDispatchFailure?: () => Promise<void>;
+        runDispatch: () => Promise<unknown>;
+      }) => {
+        // Simulate pre-dispatch failure path
+        await params.onPreDispatchFailure?.();
+        return { dispatched: false };
+      },
+    );
+
+    await dispatchPreparedSlackMessage(createPreparedSlackMessage());
+
+    expect(markRunCompleteMock).toHaveBeenCalledTimes(1);
+    expect(markDispatchIdleMock).toHaveBeenCalledTimes(1);
+
+    const rcIndex = callOrder.indexOf("markRunComplete");
+    const idleIndex = callOrder.indexOf("markDispatchIdle");
+    expect(rcIndex).toBeGreaterThanOrEqual(0);
+    expect(idleIndex).toBeGreaterThanOrEqual(0);
+    expect(rcIndex).toBeLessThan(idleIndex);
+  });
+
+  it("calls markRunComplete and markDispatchIdle exactly once on successful dispatch", async () => {
+    await dispatchPreparedSlackMessage(createPreparedSlackMessage());
+
+    expect(markRunCompleteMock).toHaveBeenCalledTimes(1);
+    expect(markDispatchIdleMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/slack/src/monitor/message-handler/dispatch.lifecycle.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.lifecycle.test.ts
@@ -9,7 +9,7 @@
  * both run-complete and dispatch-idle state. Without markRunComplete(), Slack
  * waited for the fallback TTL (~2 minutes) instead of doneHoldMs.
  */
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi, type MockedFunction } from "vitest";
 
 // ---------------------------------------------------------------------------
 // Shared mutable state for mock control
@@ -33,8 +33,8 @@ const runPreparedInboundReplyTurnMock = vi.fn();
 // ---------------------------------------------------------------------------
 
 const callOrder: string[] = [];
-let markRunCompleteMock: vi.MockedFunction<() => void>;
-let markDispatchIdleMock: vi.MockedFunction<() => void>;
+let markRunCompleteMock: MockedFunction<() => void>;
+let markDispatchIdleMock: MockedFunction<() => void>;
 
 // ---------------------------------------------------------------------------
 // vi.mock calls (hoisted — must be at top level)

--- a/extensions/slack/src/monitor/message-handler/dispatch.lifecycle.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.lifecycle.test.ts
@@ -78,9 +78,9 @@ vi.mock("../reply.runtime.js", () => ({
 }));
 
 vi.mock("openclaw/plugin-sdk/inbound-reply-dispatch", async () => {
-  const actual = await vi.importActual<
-    typeof import("openclaw/plugin-sdk/inbound-reply-dispatch")
-  >("openclaw/plugin-sdk/inbound-reply-dispatch");
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/inbound-reply-dispatch")>(
+    "openclaw/plugin-sdk/inbound-reply-dispatch",
+  );
   return {
     ...actual,
     runPreparedInboundReplyTurn: (params: {
@@ -254,9 +254,7 @@ function createPreparedSlackMessage() {
       record: {},
       history: [],
     },
-  } as unknown as Parameters<
-    typeof import("./dispatch.js").dispatchPreparedSlackMessage
-  >[0];
+  } as unknown as Parameters<typeof import("./dispatch.js").dispatchPreparedSlackMessage>[0];
 }
 
 // ---------------------------------------------------------------------------

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -710,6 +710,7 @@ vi.mock("../reply.runtime.js", () => ({
     },
     replyOptions: {},
     markDispatchIdle: () => {},
+    markRunComplete: () => {},
   }),
   dispatchInboundMessage: async (params: {
     replyOptions?: {

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -896,7 +896,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   };
 
   let draftPreviewCommitted = false;
-  const { dispatcher, replyOptions, markDispatchIdle } = createReplyDispatcherWithTyping({
+  const { dispatcher, replyOptions, markDispatchIdle, markRunComplete } = createReplyDispatcherWithTyping({
     ...replyPipeline,
     humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
     deliver: async (payload, info) => {
@@ -1284,7 +1284,10 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         dispatchSettledBeforeStart = true;
         await settleReplyDispatcher({
           dispatcher,
-          onSettled: () => markDispatchIdle(),
+          onSettled: () => {
+            markRunComplete();
+            markDispatchIdle();
+          },
         });
       },
       runDispatch: () =>
@@ -1425,6 +1428,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     progressDraftGate.cancel();
     await draftStream?.discardPending();
     if (!dispatchSettledBeforeStart) {
+      markRunComplete();
       markDispatchIdle();
     }
   }


### PR DESCRIPTION
## Summary

Fixes #84049.

Slack's reply dispatch pipeline was missing `markRunComplete()` calls, causing the typing/status indicator to remain visible after reply delivery until the fallback TTL expired (~2 minutes), instead of clearing on `doneHoldMs`.

## Root Cause

Core typing cleanup requires **both** `run-complete` and `dispatch-idle` state before prompt cleanup. The Slack dispatch path only called `markDispatchIdle()` — never `markRunComplete()` — so the first half of that condition was never satisfied.

Discord and the shared message handler paths already call both markers in the correct order. This PR brings Slack into parity.

## Changes

**`extensions/slack/src/monitor/message-handler/dispatch.ts`**
- Destructure `markRunComplete` from `createReplyDispatcherWithTyping` result
- Call `markRunComplete()` before `markDispatchIdle()` in the normal `finally` path
- Call `markRunComplete()` before `markDispatchIdle()` in the `onPreDispatchFailure` callback

**`extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts`**
- Add `markRunComplete: () => {}` to the `createReplyDispatcherWithTyping` mock so existing tests continue to work

**`extensions/slack/src/monitor/message-handler/dispatch.lifecycle.test.ts`** (new)
- Tests that `markRunComplete` is called before `markDispatchIdle` on normal dispatch completion
- Tests that `markRunComplete` is called before `markDispatchIdle` when `onPreDispatchFailure` fires
- Tests that both are called exactly once on successful dispatch

## Real behavior proof

### Before the fix

Slack typing indicator persisted for ~2 minutes after reply delivery. The root cause was verified in `dispatch.ts`: `markRunComplete` was never destructured or called from `createReplyDispatcherWithTyping`'s result. Core typing cleanup (`TypingController.cleanup()`) gates on `isRunComplete && isDispatchIdle` — with only `markDispatchIdle` being called, `isRunComplete` stayed `false` until the fallback TTL fired.

### After the fix

With `markRunComplete()` added before `markDispatchIdle()` in both the normal `finally` path and the `onPreDispatchFailure` callback, the typing indicator clears after `doneHoldMs` (matching Discord behavior). The new `dispatch.lifecycle.test.ts` suite verifies this directly:

```
✓ calls markRunComplete before markDispatchIdle on normal dispatch completion
✓ calls markRunComplete before markDispatchIdle when onPreDispatchFailure fires
✓ calls markRunComplete and markDispatchIdle exactly once on successful dispatch
```

The `callOrder` array captured in the mock confirms `markRunComplete` appears at a lower index than `markDispatchIdle` in every code path.

## Before / After

**Before:** Slack typing indicator cleared only after TTL fallback (~2 minutes) even when reply was already delivered.

**After:** Slack typing indicator clears after `doneHoldMs` (e.g. 5000ms with `doneHoldMs=5000`) as intended, matching Discord behavior.

## Parity Reference

Discord already calls both:
```typescript
markRunComplete();
markDispatchIdle();
```