### PR TITLE
fix(cli): use FLAG_TERMINATOR constant in getCommandPathInternal (#83902)

### DIFF
--- a/src/cli/argv.test.ts
+++ b/src/cli/argv.test.ts
@@ -259,6 +259,24 @@ describe("argv helpers", () => {
     ).toEqual(["update.channel"]);
   });
 
+  // #83902: every argv helper in this module uses the imported FLAG_TERMINATOR
+  // constant as the args-end sentinel; getCommandPathInternal used to compare
+  // against the string literal "--", which would silently diverge from the rest
+  // of the parser if FLAG_TERMINATOR is ever changed. Pin against the live constant.
+  it("stops command-path extraction at the imported FLAG_TERMINATOR constant (#83902)", async () => {
+    const { FLAG_TERMINATOR } = await import("../infra/cli-root-options.js");
+    expect(FLAG_TERMINATOR).toBe("--"); // current value; not the point of this test
+    expect(
+      getCommandPath(["node", "openclaw", "channels", FLAG_TERMINATOR, "add"], 2),
+    ).toEqual(["channels"]);
+    expect(
+      getCommandPathWithRootOptions(
+        ["node", "openclaw", "channels", FLAG_TERMINATOR, "add"],
+        2,
+      ),
+    ).toEqual(["channels"]);
+  });
+
   it("extracts routed config unset positionals with interleaved root options", () => {
     expect(
       getCommandPositionalsWithRootOptions(

--- a/src/cli/argv.ts
+++ b/src/cli/argv.ts
@@ -222,7 +222,12 @@ function getCommandPathInternal(
     if (!arg) {
       continue;
     }
-    if (arg === "--") {
+    // Every other helper in this file (isHelpOrVersionInvocation,
+    // hasRootVersionAlias, isRootInvocationForFlags, getFlagValue, hasFlag)
+    // uses the imported FLAG_TERMINATOR constant. Mirror that here so a future
+    // change to FLAG_TERMINATOR in cli-root-options.ts doesn't silently diverge
+    // command-path resolution from help/version detection. See #83902.
+    if (arg === FLAG_TERMINATOR) {
       break;
     }
     if (opts.skipRootOptions) {


### PR DESCRIPTION
Fixes #83902.

`getCommandPathInternal` (`src/cli/argv.ts:225`) was the sole helper in `argv.ts` comparing `arg === "--"` against the string literal instead of the imported `FLAG_TERMINATOR` constant from `infra/cli-root-options.ts`. Every other helper in the same file (`isHelpOrVersionInvocation`, `hasFlag`, `hasRootVersionAlias`, `isRootInvocationForFlags`, `getFlagValue`, `getCommandPositionals`, etc.) routes its terminator check through `FLAG_TERMINATOR`. Under the current value (`"--"`) the two paths agree, but any future change to the constant would silently desync command-path resolution from help/version detection — subcommand routing would break in a way that's hard to trace.

## Changes

- `src/cli/argv.ts`: replace `if (arg === "--")` in `getCommandPathInternal` with `if (arg === FLAG_TERMINATOR)` (single-line fix as the issue recommended). Add a short comment explaining the consistency requirement.
- `src/cli/argv.test.ts`: regression test that pulls the live `FLAG_TERMINATOR` constant from `infra/cli-root-options.ts` and asserts both `getCommandPath` and `getCommandPathWithRootOptions` stop at it. The test will fail if the constant changes without a corresponding update here.

Diff stat: 2 files, +24 / -1.

## Real behavior proof

- **Behavior or issue addressed:** Sanitized issue evidence — `argv.ts:4` imports `FLAG_TERMINATOR` and uses it in every helper except `getCommandPathInternal` at line 225, which compares against the string literal `"--"`. The issue's reasoning section notes that any future redefinition of `FLAG_TERMINATOR` would silently break command-path resolution while help/version detection continues to track the new value.

- **Real environment tested:** Local Node 22.x. Probe at `/tmp/probe_83902.mjs` (a) parses the patched `argv.ts` and verifies the comparison now uses `FLAG_TERMINATOR`, no remaining `arg === "--"` string-literal in `getCommandPathInternal`, and that `=== FLAG_TERMINATOR` is used 8 times across the file (parser-wide consistency), and (b) replays both the patched and pre-fix shapes against the current `"--"` terminator (both produce `["status"]` — no observable difference under the default config) and a hypothetical `"++"` terminator (patched correctly stops at `"++"` and returns `["status"]`; buggy ignores the redefined constant and returns `["status", "++"]`).

- **Exact steps or command run after this patch:** `node /tmp/probe_83902.mjs`

- **Evidence after fix:**

```
PASS: comparison uses the imported FLAG_TERMINATOR constant
PASS: no remaining `arg === "--"` string-literal comparison
PASS: FLAG_TERMINATOR comparison used 8 times across argv.ts (parser-wide consistency)
PASS: replay (current terminator): patched stops at '--' → ['status']
PASS: replay (current terminator): buggy also stops at '--' → ['status'] — no observable difference under default config
PASS: replay (hypothetical FLAG_TERMINATOR=++): patched correctly stops at '++' → ['status']
PASS: replay (hypothetical FLAG_TERMINATOR=++): buggy ignores the new terminator and treats it as a positional → diverges from patched ['status']

ALL CASES PASS
```

- **Observed result after fix:** Under the current `FLAG_TERMINATOR = "--"` value, behavior is unchanged (the existing `"terminator cuts parsing"` test still passes). Under any hypothetical change to the constant, `getCommandPath` / `getCommandPathWithRootOptions` track the new value in lock-step with the rest of the parser instead of silently using the old literal.

- **What was not tested:** A live build that physically changes `FLAG_TERMINATOR` to a non-`"--"` value — the regression test pins the assertion against the imported constant via `await import("../infra/cli-root-options.js")` so the relationship is enforced at test time, and the source-level probe verifies the comparison shape.

## Audit (per CLAUDE rules — all 5 steps)

- **Existing-helper check:** Reuses the already-imported `FLAG_TERMINATOR` constant. No new helper or import. PASS
- **Shared-helper caller check:** `FLAG_TERMINATOR` has 8 usage sites across `argv.ts` after this patch (was 7); the new one is the same comparison shape as all the others. `getCommandPath` and `getCommandPathWithRootOptions` are exported and called by `command-path.ts` and other CLI plumbing — the behavior change is invisible under the current `"--"` value and matches the existing usage convention across the parser. PASS
- **Broader-fix rival scan:** `gh pr list --search '83902 in:title,body'` and `gh pr list --search 'FLAG_TERMINATOR in:title,body'` return no open PRs. PASS
- **Recent-merge audit:** `git log --oneline -5 -- src/cli/argv.ts` shows `e1061a8b46 test(live): tolerate provider drift in release checks` — unrelated. PASS
- **Prototype-pollution scan:** N/A — string comparison.
