### PR TITLE
[codex] Add model fallback circuit breaker

### DIFF
--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -94,6 +94,8 @@ export function resolveFailoverStatus(reason: FailoverReason): number | undefine
       return 404;
     case "session_expired":
       return 410; // Gone - session no longer exists
+    case "circuit_open":
+      return 503;
     default:
       return undefined;
   }

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -174,6 +174,7 @@ afterAll(() => {
 });
 
 function resetModelFallbackTestState(): void {
+  __testing.resetModelCircuitStates();
   authRuntimeMock.clear();
   authRuntimeMock.runtime.ensureAuthProfileStore.mockClear();
   authRuntimeMock.runtime.loadAuthProfileStoreForRuntime.mockClear();
@@ -1234,6 +1235,50 @@ describe("runWithModelFallback", () => {
       model: "gpt-4.1-mini",
       firstError: Object.assign(new Error("nope"), { status: 401 }),
     });
+  });
+
+  it("skips a provider/model after repeated failover errors trip its circuit", async () => {
+    const cfg = makeCfg();
+    const run = vi.fn().mockImplementation(async (provider, model) => {
+      if (provider === "openai" && model === "gpt-4.1-mini") {
+        throw Object.assign(new Error("transient provider failure"), { status: 503 });
+      }
+      if (provider === "anthropic" && model === "claude-haiku-3-5") {
+        return "ok";
+      }
+      throw new Error(`unexpected fallback candidate: ${provider}/${model}`);
+    });
+
+    for (let i = 0; i < 5; i += 1) {
+      const result = await runWithModelFallback({
+        cfg,
+        provider: "openai",
+        model: "gpt-4.1-mini",
+        run,
+      });
+
+      expect(result.result).toBe("ok");
+    }
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      run,
+    });
+
+    expect(result.result).toBe("ok");
+    expect(result.attempts[0]).toMatchObject({
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      reason: "circuit_open",
+      status: 503,
+    });
+    expect(run).toHaveBeenCalledTimes(11);
+    expect(requireMockCall(run, 10, "fallback after open circuit")).toEqual([
+      "anthropic",
+      "claude-haiku-3-5",
+    ]);
   });
 
   it("puts configured fallbacks before the configured primary when an override model is requested", () => {

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -55,11 +55,70 @@ import type { FailoverReason } from "./pi-embedded-helpers/types.js";
 import { resolveSessionSuspensionReason, suspendSession } from "./session-suspension.js";
 
 const log = createSubsystemLogger("model-fallback");
+const MODEL_CIRCUIT_FAILURE_THRESHOLD = 5;
+const MODEL_CIRCUIT_WINDOW_MS = 5 * 60 * 1000;
+const MODEL_CIRCUIT_COOLDOWN_MS = 60 * 1000;
+
+type ModelCircuitState = {
+  failures: number[];
+  openUntil: number;
+};
+
+const modelCircuitStates = new Map<string, ModelCircuitState>();
 
 type FailoverAttribution = {
   sessionId?: string;
   lane?: string;
 };
+
+function modelCircuitKey(provider: string, model: string) {
+  return `${provider}\u0000${model}`;
+}
+
+function pruneModelCircuitFailures(state: ModelCircuitState, now: number) {
+  const cutoff = now - MODEL_CIRCUIT_WINDOW_MS;
+  state.failures = state.failures.filter((ts) => ts >= cutoff);
+}
+
+function resolveOpenModelCircuit(params: {
+  provider: string;
+  model: string;
+  now?: number;
+}): { openUntil: number; remainingMs: number } | null {
+  const now = params.now ?? Date.now();
+  const state = modelCircuitStates.get(modelCircuitKey(params.provider, params.model));
+  if (!state) {
+    return null;
+  }
+  pruneModelCircuitFailures(state, now);
+  if (state.openUntil <= now) {
+    state.openUntil = 0;
+    if (state.failures.length === 0) {
+      modelCircuitStates.delete(modelCircuitKey(params.provider, params.model));
+    }
+    return null;
+  }
+  return {
+    openUntil: state.openUntil,
+    remainingMs: state.openUntil - now,
+  };
+}
+
+function recordModelCircuitSuccess(provider: string, model: string) {
+  modelCircuitStates.delete(modelCircuitKey(provider, model));
+}
+
+function recordModelCircuitFailure(provider: string, model: string, now = Date.now()) {
+  const key = modelCircuitKey(provider, model);
+  const state = modelCircuitStates.get(key) ?? { failures: [], openUntil: 0 };
+  pruneModelCircuitFailures(state, now);
+  state.failures.push(now);
+  if (state.failures.length >= MODEL_CIRCUIT_FAILURE_THRESHOLD) {
+    state.openUntil = now + MODEL_CIRCUIT_COOLDOWN_MS;
+  }
+  modelCircuitStates.set(key, state);
+  return state.openUntil > now ? state.openUntil : null;
+}
 
 /**
  * Structured error thrown when all model fallback candidates have been
@@ -626,6 +685,7 @@ export const __testing = {
   resolveImageFallbackCandidates,
   resolveCooldownDecision,
   resolveSessionSuspensionReason,
+  resetModelCircuitStates: () => modelCircuitStates.clear(),
 } as const;
 
 function resolveFallbackCandidates(
@@ -976,6 +1036,40 @@ export async function runWithModelFallback<T>(
 
   for (let i = 0; i < candidates.length; i += 1) {
     const candidate = candidates[i];
+    const openCircuit = resolveOpenModelCircuit(candidate);
+    if (openCircuit) {
+      const error = `Model circuit open for ${candidate.provider}/${candidate.model}; retry in ${Math.ceil(
+        openCircuit.remainingMs / 1000,
+      )}s`;
+      attempts.push({
+        provider: candidate.provider,
+        model: candidate.model,
+        error,
+        reason: "circuit_open",
+        status: 503,
+      });
+      await observeDecision({
+        decision: "skip_candidate",
+        runId: params.runId,
+        sessionId: params.sessionId,
+        lane: params.lane,
+        requestedProvider: params.provider,
+        requestedModel: params.model,
+        candidate,
+        attempt: i + 1,
+        total: candidates.length,
+        reason: "circuit_open",
+        status: 503,
+        error,
+        nextCandidate: candidates[i + 1],
+        isPrimary: i === 0,
+        requestedModelMatched: requestedCandidate
+          ? sameModelCandidate(candidate, requestedCandidate)
+          : false,
+        fallbackConfigured: hasFallbackCandidates,
+      });
+      continue;
+    }
     await assertModelFallbackCandidateHarnessAvailable({
       cfg: params.cfg,
       agentId: params.agentId,
@@ -1169,6 +1263,7 @@ export async function runWithModelFallback<T>(
       attribution: { sessionId: params.sessionId, lane: params.lane },
     });
     if ("success" in attemptRun) {
+      recordModelCircuitSuccess(candidate.provider, candidate.model);
       if (i > 0 || attempts.length > 0 || attemptedDuringCooldown) {
         await observeDecision({
           decision: "candidate_succeeded",
@@ -1272,6 +1367,9 @@ export async function runWithModelFallback<T>(
       const isKnownFailover = isFailoverError(normalized);
       if (!isKnownFailover && i === candidates.length - 1) {
         throw err;
+      }
+      if (isKnownFailover) {
+        recordModelCircuitFailure(candidate.provider, candidate.model);
       }
 
       lastError = isKnownFailover ? normalized : err;

--- a/src/agents/pi-embedded-helpers/types.ts
+++ b/src/agents/pi-embedded-helpers/types.ts
@@ -11,6 +11,7 @@ export type FailoverReason =
   | "timeout"
   | "model_not_found"
   | "session_expired"
+  | "circuit_open"
   | "empty_response"
   | "no_error_details"
   | "unclassified"


### PR DESCRIPTION
## Summary
- add an in-memory per provider/model circuit breaker to model fallback
- skip an open model circuit with `circuit_open` and HTTP 503 so fallback can move to the next candidate
- reset circuit state on candidate success and add focused unit coverage

## Why
Recent FailoverError spikes on a single model accumulated silently and each retry could spend the full timeout budget. A short circuit after repeated failover errors prevents repeatedly burning time/cost on a temporarily unhealthy provider/model while preserving the existing fallback path.

## Validation
- `node scripts/test-projects.mjs src/agents/model-fallback.test.ts` → 62 tests passed
- narrow changed-file tsgo check from prior bounded run: `timeout 90s node scripts/run-tsgo.mjs -p .artifacts/tsconfig.circuit-check.json --noEmit --pretty false` → exited 0
- changed-file formatting check passed after `pnpm exec oxfmt --write src/agents/model-fallback.ts`

## Note
Full `pnpm tsgo:core:test` exceeded the bounded cron budget twice; the narrower changed-file typecheck is clean.


## Real behavior proof
- **Behavior or issue addressed:** Repeated `FailoverError` responses for one provider/model now open a short in-memory circuit and allow fallback to skip that unhealthy candidate with `circuit_open` / HTTP 503 instead of retrying it repeatedly.
- **Real environment tested:** OpenClaw CT 120 (`/home/openclaw/.openclaw/workspace/repos/openclaw-src`) with the local gateway reachable on port 18789; patched upstream source branch `codex/model-fallback-circuit-breaker` at `58d70c03`.
- **Exact steps or command run after this patch:** `openclaw gateway status`, then `node scripts/test-projects.mjs src/agents/model-fallback.test.ts` from the patched OpenClaw source checkout.
- **Evidence after fix:** Terminal output from the real CT 120 OpenClaw environment:

```text
$ openclaw gateway status
Gateway: bind=lan (0.0.0.0), port=18789 (env/config)
Probe target: ws://127.0.0.1:18789
Connectivity probe: ok
Listening: *:18789

$ node scripts/test-projects.mjs src/agents/model-fallback.test.ts
Test Files  1 passed (1)
Tests  62 passed (62)
[test] passed 1 Vitest shard in 6.90s
```

- **Observed result after fix:** The focused model-fallback shard passes on the patched branch, including the after-fix case where five retryable `FailoverError`s open the provider/model circuit and the next fallback attempt skips that candidate as `circuit_open` with status 503 while continuing fallback behavior.
- **What was not tested:** A live paid/provider timeout was not forced against production credentials; full `pnpm tsgo:core:test` still exceeds the bounded cron window, but the narrower changed-file tsgo check and focused behavior shard are green.
