### PR TITLE
fix(cli): format acp client errors with formatErrorMessage (#83904)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 - Control UI: treat terminal session status as authoritative over stale active-run flags so completed terminal runs stop showing abort/live UI. (#84057)
 - CLI: preserve embedded equals signs in inline root option values instead of truncating after the second separator. (#83995) Thanks @ThiagoCAltoe.
 - Matrix/config: accept `messages.queue.byChannel.matrix` queue overrides and keep queue provider schema/type keys aligned for Matrix, Google Chat, and Mattermost. Thanks @bdjben.
+- CLI: format `openclaw acp client` failures through the shared error formatter so object-shaped errors stay readable instead of printing `[object Object]`. Fixes #83904. (#84080)
 - Providers/Ollama: default unknown-capabilities models to tool-capable so discovered native Ollama models can use tools when `/api/show` omits capabilities. (#84055) Thanks @dutifulbob.
 - Installer/Windows: launch `install.ps1` onboarding as an attached child process so fresh native Windows installs do not freeze visibly at `Starting setup...` or corrupt the wizard's terminal rendering.
 - Memory/search: close local embedding providers when active-memory searches time out so pending local model loads and embedding contexts are aborted and released. (#83858) Thanks @brokemac79.

--- a/src/cli/acp-cli.option-collisions.test.ts
+++ b/src/cli/acp-cli.option-collisions.test.ts
@@ -166,21 +166,15 @@ describe("acp cli option collisions", () => {
     expectCliError(/Failed to (inspect|read) Gateway token file/);
   });
 
-  // #83904: the `acp client` subcommand used `String(err)` while `acp` itself
-  // already routed through `formatErrorMessage`. Non-Error throws (e.g. plain
-  // objects) surfaced as `[object Object]` instead of a readable diagnostic.
-  // After this fix both subcommands share the same formatter.
   it("formats client errors with formatErrorMessage instead of String(err) (#83904)", async () => {
     runAcpClientInteractive.mockImplementationOnce(async () => {
-      // Plain-object throw: `String({})` → "[object Object]". `formatErrorMessage`
-      // produces something more useful for log triage.
       throw { code: 42, why: "boom" } as unknown as Error;
     });
     const program = createAcpProgram();
     await program.parseAsync(["acp", "client"], { from: "user" });
 
     const errors = defaultRuntime.error.mock.calls.map(([message]) => String(message));
-    expect(errors.some((message) => message.includes("[object Object]"))).toBe(false);
+    expect(errors).toContain('{"code":42,"why":"boom"}');
     expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
   });
 });

--- a/src/cli/acp-cli.option-collisions.test.ts
+++ b/src/cli/acp-cli.option-collisions.test.ts
@@ -165,4 +165,22 @@ describe("acp cli option collisions", () => {
     await parseAcp(["--token-file", "/tmp/openclaw-acp-missing-token.txt"]);
     expectCliError(/Failed to (inspect|read) Gateway token file/);
   });
+
+  // #83904: the `acp client` subcommand used `String(err)` while `acp` itself
+  // already routed through `formatErrorMessage`. Non-Error throws (e.g. plain
+  // objects) surfaced as `[object Object]` instead of a readable diagnostic.
+  // After this fix both subcommands share the same formatter.
+  it("formats client errors with formatErrorMessage instead of String(err) (#83904)", async () => {
+    runAcpClientInteractive.mockImplementationOnce(async () => {
+      // Plain-object throw: `String({})` → "[object Object]". `formatErrorMessage`
+      // produces something more useful for log triage.
+      throw { code: 42, why: "boom" } as unknown as Error;
+    });
+    const program = createAcpProgram();
+    await program.parseAsync(["acp", "client"], { from: "user" });
+
+    const errors = defaultRuntime.error.mock.calls.map(([message]) => String(message));
+    expect(errors.some((message) => message.includes("[object Object]"))).toBe(false);
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+  });
 });

--- a/src/cli/acp-cli.ts
+++ b/src/cli/acp-cli.ts
@@ -73,10 +73,6 @@ export function registerAcpCli(program: Command) {
           verbose: Boolean(opts.verbose || inheritedVerbose),
         });
       } catch (err) {
-        // Match the parent `acp` action a few lines up (line 52): both surfaces
-        // route errors through `formatErrorMessage`, which normalises plain
-        // Error objects and non-Error throws into a readable message instead of
-        // the default `[object Object]` from `String(err)`. See #83904.
         defaultRuntime.error(formatErrorMessage(err));
         defaultRuntime.exit(1);
       }

--- a/src/cli/acp-cli.ts
+++ b/src/cli/acp-cli.ts
@@ -73,7 +73,11 @@ export function registerAcpCli(program: Command) {
           verbose: Boolean(opts.verbose || inheritedVerbose),
         });
       } catch (err) {
-        defaultRuntime.error(String(err));
+        // Match the parent `acp` action a few lines up (line 52): both surfaces
+        // route errors through `formatErrorMessage`, which normalises plain
+        // Error objects and non-Error throws into a readable message instead of
+        // the default `[object Object]` from `String(err)`. See #83904.
+        defaultRuntime.error(formatErrorMessage(err));
         defaultRuntime.exit(1);
       }
     });


### PR DESCRIPTION
Fixes #83904.

The parent `acp` action (`src/cli/acp-cli.ts:52`) already routed errors through `defaultRuntime.error(\`ACP bridge failed: ${formatErrorMessage(err)}\`)`, which normalises both Error objects and non-Error throws (plain-object rejections, bare strings, cause chains) into a readable diagnostic. The sibling `acp client` action at line 76 used `String(err)`, which produces `[object Object]` for plain-object rejections — exactly the class of throw `runAcpClientInteractive` can surface during RPC negotiation. Operators saw `[object Object]` in the terminal and assumed a serialisation bug instead of a connection error.

## Changes

- `src/cli/acp-cli.ts`: replace `defaultRuntime.error(String(err))` in the `acp client` catch block with `defaultRuntime.error(formatErrorMessage(err))`. `formatErrorMessage` is already imported. Add a short comment pointing at the parent action's already-correct shape so a future cleanup pass doesn't accidentally revert this back.
- `src/cli/acp-cli.option-collisions.test.ts`: regression test that mocks `runAcpClientInteractive` to throw a plain object `{ code: 42, why: "boom" }` and asserts no `[object Object]` text appears in `defaultRuntime.error` output, plus the expected `exit(1)`.

Diff stat: 2 files, +23 / -1.

## Real behavior proof

- **Behavior or issue addressed:** Sanitized issue evidence — `acp-cli.ts:52` already used `formatErrorMessage(err)`; `acp-cli.ts:76` used `String(err)`. For plain-object throws, `String({})` returns `[object Object]`, while `formatErrorMessage` returns a JSON-formatted readable diagnostic. The issue's exact repro: throw a non-Error value inside `runAcpClientInteractive` and observe the divergence.

- **Real environment tested:** Local Node 22.x. Probe at `/tmp/probe_83904.mjs` (a) parses the patched `acp-cli.ts` and verifies no remaining `String(err)` paths plus exactly 2 `formatErrorMessage(err)` catch blocks (parent + child action), and (b) replays the formatter difference against 4 throw shapes — plain object (`String` → `[object Object]`, `formatErrorMessage` → readable JSON with `code` and `why` keys), Error (`String` prepends `Error:` prefix, `formatErrorMessage` returns clean message), bare string (both produce the same output), and an explicit root-cause confirmation that `String({})` does in fact produce `[object Object]`.

- **Exact steps or command run after this patch:** `node /tmp/probe_83904.mjs`

- **Evidence after fix:**

```
PASS: no remaining `String(err)` error path
PASS: formatErrorMessage(err) used in 2 catch blocks (consistent across both acp / acp client)
PASS: replay (plain-object throw): String=[object Object]; formatErrorMessage={"code":42,"why":"boom"} (readable diagnostic)
PASS: replay (Error throw): String adds `Error:` prefix; formatErrorMessage produces clean message
PASS: replay (string throw): both formatters produce the same readable output
PASS: confirmed root cause: String({}) → '[object Object]' (this is what users were seeing)

ALL CASES PASS
```

- **Observed result after fix:** Plain-object throws inside `runAcpClientInteractive` now surface as a readable diagnostic (e.g. `{"code":42,"why":"boom"}`) instead of `[object Object]`. Error throws and bare-string throws are unaffected in practice — they were already readable; the change just routes them through the same formatter the parent action uses. The two acp catch surfaces now produce symmetric error output.

- **What was not tested:** Live `openclaw acp client` against a real ACP server that throws a non-Error rejection — that requires a misconfigured ACP server. The vitest regression test exercises the catch block directly via a mocked rejection, and the probe replays the formatter against the same throw shape end-to-end.

## Audit (per CLAUDE rules — all 5 steps)

- **Existing-helper check:** Reuses `formatErrorMessage` (`../infra/errors.js`) which is already imported on line 5 of the same file and used by the parent acp action on line 52. No new helper. PASS
- **Shared-helper caller check:** `formatErrorMessage` is widely used across the codebase for exactly this purpose; the call site here is local to the `acp client` catch block. Single new usage; no other caller affected. PASS
- **Broader-fix rival scan:** `gh pr list --search '83904 in:title,body'` returns no open PRs. PASS
- **Recent-merge audit:** `git log --oneline -5 -- src/cli/acp-cli.ts` shows `e1061a8b46 test(live): tolerate provider drift in release checks` — unrelated. PASS
- **Prototype-pollution scan:** N/A — error formatting only.
