### PR TITLE
fix(telegram): allow expandable blockquotes

### DIFF
--- a/extensions/telegram/src/format.test.ts
+++ b/extensions/telegram/src/format.test.ts
@@ -55,6 +55,13 @@ describe("markdownToTelegramHtml", () => {
     ).toBe(input);
   });
 
+  it("preserves Telegram expandable blockquote HTML", () => {
+    const input = "<blockquote expandable>hidden details</blockquote>";
+
+    expect(markdownToTelegramHtml(input)).toBe(input);
+    expect(renderTelegramHtmlText(input, { textMode: "html" })).toBe(input);
+  });
+
   it("does not promote Telegram HTML tags inside code", () => {
     expect(markdownToTelegramHtml("`<b>literal</b>`")).toBe(
       "<code>&lt;b&gt;literal&lt;/b&gt;</code>",
@@ -66,6 +73,9 @@ describe("markdownToTelegramHtml", () => {
 
   it("keeps unsupported Telegram HTML variants escaped", () => {
     expect(markdownToTelegramHtml('<b class="x">bad</b>')).toBe('&lt;b class="x"&gt;bad&lt;/b&gt;');
+    expect(markdownToTelegramHtml('<blockquote cite="x">bad</blockquote>')).toBe(
+      '&lt;blockquote cite="x"&gt;bad&lt;/blockquote&gt;',
+    );
     expect(renderTelegramHtmlText('<b class="x">bad</b>', { textMode: "html" })).toBe(
       '&lt;b class="x"&gt;bad&lt;/b&gt;',
     );

--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -191,13 +191,13 @@ const TELEGRAM_SIMPLE_HTML_TAGS = new Set([
   "code",
   "pre",
   "tg-spoiler",
-  "blockquote",
 ]);
 const TELEGRAM_ATTR_HTML_TAG_PATTERNS = new Map([
   ["a", /^\s+href="[^"]+"\s*$/],
   ["span", /^\s+class="tg-spoiler"\s*$/],
   ["tg-emoji", /^\s+emoji-id="[^"]+"\s*$/],
   ["tg-time", /^\s+datetime="[^"]+"\s*$/],
+  ["blockquote", /^(\s+expandable)?\s*$/],
 ]);
 const TELEGRAM_CODE_LANGUAGE_ATTR_PATTERN = /^\s+class="language-[^"]+"\s*$/;
 let fileReferencePattern: RegExp | undefined;


### PR DESCRIPTION
## Summary

- Problem: `<blockquote expandable>` is stripped in Telegram HTML output. `blockquote` lived in `TELEGRAM_SIMPLE_HTML_TAGS`, which only permits the tag with zero attributes, so the `expandable` attribute failed sanitization.
- Why it matters: Telegram natively supports expandable blockquotes; agents could not emit them through OpenClaw's Telegram HTML output.
- What changed: Move `blockquote` from the simple-tag set to `TELEGRAM_ATTR_HTML_TAG_PATTERNS` with pattern `/^(\s+expandable)?\s*$/`, which accepts both `<blockquote>` and `<blockquote expandable>`, and add formatter regression coverage for the allowed and rejected blockquote attribute cases.
- What did NOT change: All other tags; plain `<blockquote>` and `</blockquote>` still pass, and unsupported blockquote attributes are still escaped.

## Change Type

- [x] Bug fix

## Real behavior proof

- Behavior or issue addressed: Expandable Telegram blockquotes survive OpenClaw's Telegram HTML sanitizer.
- Real environment tested: OpenClaw Telegram channel with an agent reply containing `<blockquote expandable>...</blockquote>`.
- Exact steps or command run after this patch: Sent an OpenClaw Telegram reply containing `<blockquote expandable>...</blockquote>` through the Telegram channel and inspected the rendered Telegram Desktop message.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Mantis Telegram Desktop proof run https://github.com/openclaw/openclaw/actions/runs/26090995992 with artifact https://github.com/openclaw/openclaw/actions/runs/26090995992/artifacts/7081195272 and published screenshots/GIFs in the PR conversation.
- Observed result after fix: Telegram Desktop rendered the message as a collapsible/expandable blockquote instead of a normal blockquote.
- What was not tested: Nested blockquotes.
