### PR TITLE
fix(agents): bound plugin-owned context-engine compaction with a safety timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Docs: https://docs.openclaw.ai
 - CLI/TUI: include gateway plugin slash commands in TUI autocomplete, so connected sessions can suggest plugin-owned commands exposed by the running Gateway. (#83640) Thanks @se7en-agent.
 - Gateway/mobile: restore QR setup-code handoff of bounded operator tokens for iOS and Android onboarding while keeping admin and pairing scopes out of bootstrap. (#83684) Thanks @ngutman.
 - iOS: repair Release archive compilation for the TestFlight build. (#84255) Thanks @ngutman.
+- Agents/compaction: bound plugin-owned CLI transcript compaction with the host safety timeout so a hung context engine can no longer stall post-turn cleanup. (#84083) Thanks @100yenadmin.
 
 ## 2026.5.19
 

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-c3d3f4331b8e49a5f54aa4e322a0b03ab057715ed4f50b2b3e20fbbcbaf332db  plugin-sdk-api-baseline.json
-7b925ff856294bc8afc54aea9bf12a038d73821b4df297c60908032e1a4d85d9  plugin-sdk-api-baseline.jsonl
+81675fa8adf4a3a7cc696ba77760e69224dadd15255daab2bdc83dfd8d290fed  plugin-sdk-api-baseline.json
+78d3e47f075a6645b771071aaa27832b25b97c797cdb4777a697614157d944ca  plugin-sdk-api-baseline.jsonl

--- a/extensions/codex/src/app-server/compact.test.ts
+++ b/extensions/codex/src/app-server/compact.test.ts
@@ -683,6 +683,100 @@ describe("maybeCompactCodexAppServerSession", () => {
     expect(compactResult.reason).toBe("below threshold");
     expect(maintain).not.toHaveBeenCalled();
   });
+
+  describe("owning context-engine compaction safety timeout", () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("bounds a hung owning context-engine compact() and reports a clean ok:false", async () => {
+      const sessionFile = await writeTestBinding();
+      const compact = vi.fn<ContextEngine["compact"]>(() => new Promise(() => {}));
+      const contextEngine: ContextEngine = {
+        info: { id: "lossless-claw", name: "Lossless Claw", ownsCompaction: true },
+        assemble: vi.fn() as never,
+        ingest: vi.fn() as never,
+        compact,
+      };
+
+      vi.useFakeTimers();
+      const pendingResult = maybeCompactCodexAppServerSession({
+        sessionId: "session-1",
+        sessionKey: "agent:main:session-1",
+        sessionFile,
+        workspaceDir: tempDir,
+        contextEngine,
+        // 1 s host-resolved compaction timeout.
+        config: { agents: { defaults: { compaction: { timeoutSeconds: 1 } } } },
+      });
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      const result = requireCompactResult(await pendingResult);
+
+      expect(result.ok).toBe(false);
+      expect(result.compacted).toBe(false);
+      expect(result.reason).toContain("timed out");
+      expect(compact).toHaveBeenCalledTimes(1);
+      expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it("threads the caller abort signal into the owning context-engine compact()", async () => {
+      const sessionFile = await writeTestBinding();
+      const controller = new AbortController();
+      const compact = vi.fn<ContextEngine["compact"]>(async () => ({
+        ok: true,
+        compacted: false,
+        reason: "below threshold",
+      }));
+      const contextEngine: ContextEngine = {
+        info: { id: "lossless-claw", name: "Lossless Claw", ownsCompaction: true },
+        assemble: vi.fn() as never,
+        ingest: vi.fn() as never,
+        compact,
+      };
+
+      await maybeCompactCodexAppServerSession({
+        sessionId: "session-1",
+        sessionKey: "agent:main:session-1",
+        sessionFile,
+        workspaceDir: tempDir,
+        contextEngine,
+        abortSignal: controller.signal,
+      });
+
+      expect(compact).toHaveBeenCalledTimes(1);
+      expect(compact.mock.calls[0]?.[0]?.abortSignal).toBe(controller.signal);
+    });
+
+    it("aborts a hung owning context-engine compact() when the caller signal fires", async () => {
+      const sessionFile = await writeTestBinding();
+      const controller = new AbortController();
+      const compact = vi.fn<ContextEngine["compact"]>(() => new Promise(() => {}));
+      const contextEngine: ContextEngine = {
+        info: { id: "lossless-claw", name: "Lossless Claw", ownsCompaction: true },
+        assemble: vi.fn() as never,
+        ingest: vi.fn() as never,
+        compact,
+      };
+
+      const pendingResult = maybeCompactCodexAppServerSession({
+        sessionId: "session-1",
+        sessionKey: "agent:main:session-1",
+        sessionFile,
+        workspaceDir: tempDir,
+        contextEngine,
+        abortSignal: controller.signal,
+      });
+
+      controller.abort(new Error("run aborted"));
+      const result = requireCompactResult(await pendingResult);
+
+      expect(result.ok).toBe(false);
+      expect(result.compacted).toBe(false);
+      expect(result.reason).toContain("run aborted");
+      expect(compact).toHaveBeenCalledTimes(1);
+    });
+  });
 });
 
 function createFakeCodexClient(): {

--- a/extensions/codex/src/app-server/compact.test.ts
+++ b/extensions/codex/src/app-server/compact.test.ts
@@ -461,17 +461,20 @@ describe("maybeCompactCodexAppServerSession", () => {
     expect(details.codexThreadBindingInvalidated).toBe(true);
     expect(await readCodexAppServerBinding(sessionFile)).toBeUndefined();
     expect(compact).toHaveBeenCalledTimes(1);
-    expect(compact).toHaveBeenCalledWith({
-      sessionId: "session-1",
-      sessionKey: "agent:main:session-1",
-      sessionFile,
-      tokenBudget: 777,
-      currentTokenCount: 123,
-      compactionTarget: "threshold",
-      customInstructions: undefined,
-      force: true,
-      runtimeContext: { workspaceDir: tempDir, provider: "codex" },
-    });
+    expect(compact).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: "session-1",
+        sessionKey: "agent:main:session-1",
+        sessionFile,
+        tokenBudget: 777,
+        currentTokenCount: 123,
+        compactionTarget: "threshold",
+        customInstructions: undefined,
+        force: true,
+        runtimeContext: { workspaceDir: tempDir, provider: "codex" },
+        abortSignal: expect.any(AbortSignal),
+      }),
+    );
     expect(maintain).toHaveBeenCalledTimes(1);
     const [maintainCall] = maintain.mock.calls[0] ?? [];
     const maintainParams = maintainCall as
@@ -720,7 +723,7 @@ describe("maybeCompactCodexAppServerSession", () => {
       expect(vi.getTimerCount()).toBe(0);
     });
 
-    it("threads the caller abort signal into the owning context-engine compact()", async () => {
+    it("threads a composed caller abort signal into the owning context-engine compact()", async () => {
       const sessionFile = await writeTestBinding();
       const controller = new AbortController();
       const compact = vi.fn<ContextEngine["compact"]>(async () => ({
@@ -745,7 +748,7 @@ describe("maybeCompactCodexAppServerSession", () => {
       });
 
       expect(compact).toHaveBeenCalledTimes(1);
-      expect(compact.mock.calls[0]?.[0]?.abortSignal).toBe(controller.signal);
+      expect(compact.mock.calls[0]?.[0]?.abortSignal).toBeInstanceOf(AbortSignal);
     });
 
     it("aborts a hung owning context-engine compact() when the caller signal fires", async () => {

--- a/extensions/codex/src/app-server/compact.ts
+++ b/extensions/codex/src/app-server/compact.ts
@@ -1,7 +1,9 @@
 import {
+  compactContextEngineWithSafetyTimeout,
   embeddedAgentLog,
   formatErrorMessage,
   isActiveHarnessContextEngine,
+  resolveCompactionTimeoutMs,
   resolveContextEngineOwnerPluginId,
   runHarnessContextEngineMaintenance,
   type CompactEmbeddedPiSessionParams,
@@ -79,17 +81,27 @@ async function compactOwningContextEngine(
   });
   let result: Awaited<ReturnType<typeof contextEngine.compact>>;
   try {
-    result = await contextEngine.compact({
-      sessionId: params.sessionId,
-      sessionKey: params.sessionKey,
-      sessionFile: params.sessionFile,
-      tokenBudget: params.contextTokenBudget,
-      currentTokenCount: params.currentTokenCount,
-      compactionTarget: params.trigger === "manual" ? "threshold" : "budget",
-      customInstructions: params.customInstructions,
-      force: params.trigger === "manual",
-      runtimeContext: params.contextEngineRuntimeContext,
-    });
+    // Bound the plugin-owned compaction with the same finite safety timeout
+    // that protects native runtime compaction, and thread the caller's abort
+    // signal through, so a slow/hung plugin compact() cannot hang the Codex
+    // compaction lane indefinitely. A timeout/abort (or any thrown error) is
+    // converted to a clean { ok: false } result by the catch below.
+    result = await compactContextEngineWithSafetyTimeout(
+      contextEngine,
+      {
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        sessionFile: params.sessionFile,
+        tokenBudget: params.contextTokenBudget,
+        currentTokenCount: params.currentTokenCount,
+        compactionTarget: params.trigger === "manual" ? "threshold" : "budget",
+        customInstructions: params.customInstructions,
+        force: params.trigger === "manual",
+        runtimeContext: params.contextEngineRuntimeContext,
+      },
+      resolveCompactionTimeoutMs(params.config),
+      params.abortSignal,
+    );
   } catch (error) {
     embeddedAgentLog.warn("context-engine-owned Codex app-server compaction failed", {
       sessionId: params.sessionId,

--- a/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
@@ -842,6 +842,99 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
     expect(savedBinding?.contextEngine?.projection?.epoch).toBe("epoch-after");
   });
 
+  it("bounds a hung owning context-engine compaction during Codex overflow recovery", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    SessionManager.open(sessionFile).appendMessage(
+      assistantMessage("pre-compaction context", Date.now()) as never,
+    );
+    await writeCodexAppServerBinding(sessionFile, {
+      threadId: "thread-old",
+      cwd: workspaceDir,
+      dynamicToolsFingerprint: "[]",
+      contextEngine: {
+        schemaVersion: 1,
+        engineId: "lossless-claw",
+        policyFingerprint:
+          '{"schemaVersion":1,"engineId":"lossless-claw","ownsCompaction":true,"contextTokenBudget":400000,"projectionMaxChars":1000000}',
+        projection: {
+          schemaVersion: 1,
+          mode: "thread_bootstrap",
+          epoch: "epoch-before",
+        },
+      },
+    });
+    // Owning-engine compaction that never settles. Without the safety timeout
+    // the awaited compact() would hang the whole Codex overflow-recovery turn;
+    // with it the call is bounded and forced compaction reports failure so the
+    // run still proceeds on a fresh thread.
+    const compact = vi.fn<ContextEngine["compact"]>(() => new Promise(() => {}));
+    const assemble = vi.fn(
+      async ({ messages, prompt }: Parameters<ContextEngine["assemble"]>[0]) => ({
+        messages: [...messages, userMessage(prompt ?? "", 11)],
+        estimatedTokens: 42,
+        systemPromptAddition: "context-engine system",
+        contextProjection: { mode: "thread_bootstrap" as const, epoch: "epoch-before" },
+      }),
+    );
+    const contextEngine = createContextEngine({ assemble, compact });
+    const harness = createStartedThreadHarness(async (method, requestParams) => {
+      const request = requireRecord(requestParams, `${method} params`);
+      if (method === "thread/resume") {
+        return threadStartResult("thread-old");
+      }
+      if (method === "turn/start" && request.threadId === "thread-old") {
+        throw new Error("Codex ran out of room in the model's context window");
+      }
+      if (method === "thread/start") {
+        return threadStartResult("thread-fresh");
+      }
+      if (method === "turn/start" && request.threadId === "thread-fresh") {
+        return turnStartResult("turn-fresh");
+      }
+      return undefined;
+    });
+    const params = createParams(sessionFile, workspaceDir);
+    params.contextEngine = contextEngine;
+    params.contextTokenBudget = 400_000;
+    // 1 s host-resolved compaction timeout so the hung compact() is bounded
+    // well within the 5 s run timeout used by this harness.
+    params.config = {
+      agents: { defaults: { compaction: { timeoutSeconds: 1 } } },
+    } as EmbeddedRunAttemptParams["config"];
+
+    const run = runCodexAppServerAttempt(params);
+    await vi.waitFor(
+      () =>
+        expect(harness.requests.map((request) => request.method)).toEqual([
+          "thread/resume",
+          "turn/start",
+          "thread/start",
+          "turn/start",
+        ]),
+      { timeout: 4_000 },
+    );
+    await harness.notify({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-fresh",
+        turnId: "turn-fresh",
+        turn: {
+          id: "turn-fresh",
+          status: "completed",
+          items: [{ type: "agentMessage", id: "msg-1", text: "fresh answer" }],
+        },
+      },
+    });
+    const result = await run;
+
+    expect(result.assistantTexts).toContain("fresh answer");
+    expect(compact).toHaveBeenCalledTimes(1);
+    // The run-level abort signal is threaded into the owning-engine compact()
+    // so a cooperating engine can cancel its own in-flight work.
+    expect(compact.mock.calls[0]?.[0]?.abortSignal).toBeInstanceOf(AbortSignal);
+  });
+
   it("keeps current inbound context at the front of the Codex context-engine prompt", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -10,6 +10,7 @@ import {
   buildHarnessContextEngineRuntimeContextFromUsage,
   buildEmbeddedAttemptToolRunContext,
   clearActiveEmbeddedRun,
+  compactContextEngineWithSafetyTimeout,
   embeddedAgentLog,
   emitAgentEvent as emitGlobalAgentEvent,
   finalizeHarnessContextEngineTurn,
@@ -21,6 +22,7 @@ import {
   normalizeAgentRuntimeTools,
   resolveAttemptSpawnWorkspaceDir,
   resolveAgentHarnessBeforePromptBuildResult,
+  resolveCompactionTimeoutMs,
   resolveModelAuthMode,
   resolveContextEngineOwnerPluginId,
   resolveSandboxContext,
@@ -2224,21 +2226,31 @@ export async function runCodexAppServerAttempt(
     try {
       const runtimeContext = buildActiveContextEngineRuntimeContext();
       const overflowTokenCount = params.contextTokenBudget ?? params.contextWindowInfo?.tokens;
-      const compactResult = await activeContextEngine.compact({
-        sessionId: activeSessionId,
-        sessionKey: sandboxSessionKey,
-        sessionFile: activeSessionFile,
-        tokenBudget: params.contextTokenBudget,
-        force: true,
-        ...(overflowTokenCount ? { currentTokenCount: overflowTokenCount } : {}),
-        compactionTarget: "threshold",
-        runtimeContext: overflowTokenCount
-          ? {
-              ...runtimeContext,
-              currentTokenCount: overflowTokenCount,
-            }
-          : runtimeContext,
-      });
+      // Bound the plugin-owned compaction with the same finite safety timeout
+      // that protects native runtime compaction, and thread the run-level
+      // abort signal through, so a slow/hung plugin compact() cannot stall
+      // Codex overflow recovery indefinitely. A timeout/abort surfaces as a
+      // thrown error handled by the catch below.
+      const compactResult = await compactContextEngineWithSafetyTimeout(
+        activeContextEngine,
+        {
+          sessionId: activeSessionId,
+          sessionKey: sandboxSessionKey,
+          sessionFile: activeSessionFile,
+          tokenBudget: params.contextTokenBudget,
+          force: true,
+          ...(overflowTokenCount ? { currentTokenCount: overflowTokenCount } : {}),
+          compactionTarget: "threshold",
+          runtimeContext: overflowTokenCount
+            ? {
+                ...runtimeContext,
+                currentTokenCount: overflowTokenCount,
+              }
+            : runtimeContext,
+        },
+        resolveCompactionTimeoutMs(params.config),
+        runAbortController.signal,
+      );
       embeddedAgentLog.info("codex app-server context-engine forced compaction result", {
         sessionId: activeSessionId,
         sessionKey: sandboxSessionKey,

--- a/src/agents/command/cli-compaction.test.ts
+++ b/src/agents/command/cli-compaction.test.ts
@@ -80,6 +80,8 @@ describe("runCliTurnCompactionLifecycle", () => {
 
   afterEach(async () => {
     resetCliCompactionTestDeps();
+    vi.clearAllTimers();
+    vi.useRealTimers();
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
@@ -228,5 +230,88 @@ describe("runCliTurnCompactionLifecycle", () => {
     });
 
     expect(calls).toEqual(["ensure", "resolve"]);
+  });
+
+  it("bounds a hung CLI context-engine compaction and leaves resume state intact", async () => {
+    const sessionKey = "agent:main:cli";
+    const sessionId = "session-cli-timeout";
+    const sessionFile = path.join(tmpDir, "session-timeout.jsonl");
+    const storePath = path.join(tmpDir, "sessions-timeout.json");
+    await writeSessionFile({ sessionFile, sessionId });
+
+    const sessionEntry: SessionEntry = {
+      sessionId,
+      updatedAt: Date.now(),
+      sessionFile,
+      contextTokens: 1_000,
+      totalTokens: 950,
+      totalTokensFresh: true,
+      cliSessionBindings: {
+        "claude-cli": { sessionId: "claude-session" },
+      },
+      cliSessionIds: {
+        "claude-cli": "claude-session",
+      },
+      claudeCliSessionId: "claude-session",
+    };
+    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+    await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2), "utf-8");
+
+    const compactCalls: Array<Parameters<ContextEngine["compact"]>[0]> = [];
+    const maintenance = vi.fn(async () => ({ changed: false, bytesFreed: 0, rewrittenEntries: 0 }));
+    const recordCliCompactionInStore = vi.fn();
+    setCliCompactionTestDeps({
+      resolveContextEngine: async () => ({
+        ...buildContextEngine({ compactCalls }),
+        async compact(compactParams) {
+          compactCalls.push(compactParams);
+          return await new Promise(() => {});
+        },
+      }),
+      createPreparedEmbeddedPiSettingsManager: async () => ({
+        getCompactionReserveTokens: () => 200,
+        getCompactionKeepRecentTokens: () => 0,
+        applyOverrides: () => {},
+      }),
+      shouldPreemptivelyCompactBeforePrompt: () => ({
+        route: "fits",
+        shouldCompact: false,
+        estimatedPromptTokens: 600,
+        promptBudgetBeforeReserve: 800,
+        overflowTokens: 0,
+        toolResultReducibleChars: 0,
+        effectiveReserveTokens: 200,
+      }),
+      resolveLiveToolResultMaxChars: () => 20_000,
+      runContextEngineMaintenance: maintenance,
+      recordCliCompactionInStore,
+    });
+
+    vi.useFakeTimers();
+    const pending = runCliTurnCompactionLifecycle({
+      cfg: { agents: { defaults: { compaction: { timeoutSeconds: 1 } } } } as OpenClawConfig,
+      sessionId,
+      sessionKey,
+      sessionEntry,
+      sessionStore,
+      storePath,
+      sessionAgentId: "main",
+      workspaceDir: tmpDir,
+      agentDir: tmpDir,
+      provider: "claude-cli",
+      model: "opus",
+    });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    const updatedEntry = await pending;
+    vi.useRealTimers();
+
+    expect(compactCalls).toHaveLength(1);
+    expect(compactCalls[0]?.abortSignal).toBeInstanceOf(AbortSignal);
+    expect(compactCalls[0]?.abortSignal?.aborted).toBe(true);
+    expect(maintenance).not.toHaveBeenCalled();
+    expect(recordCliCompactionInStore).not.toHaveBeenCalled();
+    expect(updatedEntry).toBe(sessionEntry);
+    expect(updatedEntry?.cliSessionBindings?.["claude-cli"]?.sessionId).toBe("claude-session");
   });
 });

--- a/src/agents/command/cli-compaction.ts
+++ b/src/agents/command/cli-compaction.ts
@@ -8,6 +8,10 @@ import { resolveContextEngine as resolveContextEngineImpl } from "../../context-
 import type { ContextEngine } from "../../context-engine/types.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { buildEmbeddedCompactionRuntimeContext } from "../pi-embedded-runner/compaction-runtime-context.js";
+import {
+  compactContextEngineWithSafetyTimeout,
+  resolveCompactionTimeoutMs,
+} from "../pi-embedded-runner/compaction-safety-timeout.js";
 import { runContextEngineMaintenance as runContextEngineMaintenanceImpl } from "../pi-embedded-runner/context-engine-maintenance.js";
 import { shouldPreemptivelyCompactBeforePrompt as shouldPreemptivelyCompactBeforePromptImpl } from "../pi-embedded-runner/run/preemptive-compaction.js";
 import { resolveLiveToolResultMaxChars as resolveLiveToolResultMaxCharsImpl } from "../pi-embedded-runner/tool-result-truncation.js";
@@ -149,16 +153,28 @@ async function compactCliTranscript(params: {
     trigger: "cli_budget",
   };
 
-  const compactResult = await params.contextEngine.compact({
-    sessionId: params.sessionId,
-    sessionKey: params.sessionKey,
-    sessionFile: params.sessionFile,
-    tokenBudget: params.contextTokenBudget,
-    currentTokenCount: params.currentTokenCount,
-    force: true,
-    compactionTarget: "budget",
-    runtimeContext,
-  });
+  let compactResult: Awaited<ReturnType<typeof params.contextEngine.compact>>;
+  try {
+    compactResult = await compactContextEngineWithSafetyTimeout(
+      params.contextEngine,
+      {
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        sessionFile: params.sessionFile,
+        tokenBudget: params.contextTokenBudget,
+        currentTokenCount: params.currentTokenCount,
+        force: true,
+        compactionTarget: "budget",
+        runtimeContext,
+      },
+      resolveCompactionTimeoutMs(params.cfg),
+    );
+  } catch (error) {
+    log.warn(
+      `CLI transcript compaction failed for ${params.provider}/${params.model}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return false;
+  }
 
   if (!compactResult.compacted) {
     log.warn(

--- a/src/agents/pi-embedded-runner.compaction-safety-timeout.test.ts
+++ b/src/agents/pi-embedded-runner.compaction-safety-timeout.test.ts
@@ -206,22 +206,55 @@ describe("compactContextEngineWithSafetyTimeout", () => {
     );
   });
 
-  it("threads the abort signal into the plugin compact() params", async () => {
+  it("threads a signal that follows the run abort signal into the plugin compact() params", async () => {
+    vi.useFakeTimers();
     const controller = new AbortController();
-    const compact = vi.fn<CompactFn>(async () => ({ ok: true, compacted: false }));
+    const reason = new Error("run aborted");
+    let compactAbortSignal: AbortSignal | undefined;
+    const compact = vi.fn<CompactFn>((params) => {
+      compactAbortSignal = params.abortSignal;
+      return new Promise<CompactResult>(() => {});
+    });
 
-    await compactContextEngineWithSafetyTimeout({ compact }, baseParams, 30, controller.signal);
+    const pending = compactContextEngineWithSafetyTimeout(
+      { compact },
+      baseParams,
+      30,
+      controller.signal,
+    );
+    const assertion = expect(pending).rejects.toBe(reason);
 
     expect(compact).toHaveBeenCalledTimes(1);
-    expect(compact.mock.calls[0]?.[0]?.abortSignal).toBe(controller.signal);
+    expect(compactAbortSignal).toBeInstanceOf(AbortSignal);
+    expect(compactAbortSignal?.aborted).toBe(false);
+
+    controller.abort(reason);
+    await assertion;
+    expect(compactAbortSignal?.aborted).toBe(true);
+    expect(compactAbortSignal?.reason).toBe(reason);
+    expect(vi.getTimerCount()).toBe(0);
   });
 
-  it("does not add an abortSignal field when no signal is provided", async () => {
-    const compact = vi.fn<CompactFn>(async () => ({ ok: true, compacted: false }));
+  it("threads the host timeout abort signal into the plugin compact() params", async () => {
+    vi.useFakeTimers();
+    let compactAbortSignal: AbortSignal | undefined;
+    const compact = vi.fn<CompactFn>((params) => {
+      compactAbortSignal = params.abortSignal;
+      return new Promise<CompactResult>(() => {});
+    });
 
-    await compactContextEngineWithSafetyTimeout({ compact }, baseParams, 30);
+    const pending = compactContextEngineWithSafetyTimeout({ compact }, baseParams, 30);
+    const assertion = expect(pending).rejects.toThrow("Compaction timed out");
 
-    expect(compact.mock.calls[0]?.[0]).not.toHaveProperty("abortSignal");
+    expect(compactAbortSignal).toBeInstanceOf(AbortSignal);
+    expect(compactAbortSignal?.aborted).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(30);
+    await assertion;
+    expect(compactAbortSignal?.aborted).toBe(true);
+    expect(compactAbortSignal?.reason).toBeInstanceOf(Error);
+    expect((compactAbortSignal?.reason as Error | undefined)?.message).toBe("Compaction timed out");
+    expect(vi.getTimerCount()).toBe(0);
   });
 
   it("rejects promptly when the run abort signal fires before the timeout", async () => {

--- a/src/agents/pi-embedded-runner.compaction-safety-timeout.test.ts
+++ b/src/agents/pi-embedded-runner.compaction-safety-timeout.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CompactResult, ContextEngine } from "../context-engine/types.js";
 import {
+  compactContextEngineWithSafetyTimeout,
   compactWithSafetyTimeout,
   EMBEDDED_COMPACTION_TIMEOUT_MS,
   resolveCompactionTimeoutMs,
@@ -157,5 +159,98 @@ describe("resolveCompactionTimeoutMs", () => {
         agents: { defaults: { compaction: { timeoutSeconds: Infinity } } },
       }),
     ).toBe(EMBEDDED_COMPACTION_TIMEOUT_MS);
+  });
+});
+
+describe("compactContextEngineWithSafetyTimeout", () => {
+  type CompactFn = ContextEngine["compact"];
+  const baseParams: Parameters<CompactFn>[0] = {
+    sessionId: "session-1",
+    sessionFile: "/tmp/session-1.jsonl",
+    tokenBudget: 100_000,
+    force: true,
+  };
+
+  beforeEach(() => {
+    vi.useRealTimers();
+    vi.clearAllTimers();
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("bounds a hung plugin compact() and rejects with a timeout error", async () => {
+    vi.useFakeTimers();
+    const compact = vi.fn<CompactFn>(() => new Promise<CompactResult>(() => {}));
+
+    const pending = compactContextEngineWithSafetyTimeout({ compact }, baseParams, 30);
+    const assertion = expect(pending).rejects.toThrow("Compaction timed out");
+
+    await vi.advanceTimersByTimeAsync(30);
+    await assertion;
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("returns the plugin compact() result when it settles in time", async () => {
+    const result: CompactResult = {
+      ok: true,
+      compacted: true,
+      result: { tokensBefore: 1000, tokensAfter: 200 },
+    };
+    const compact = vi.fn<CompactFn>(async () => result);
+
+    await expect(compactContextEngineWithSafetyTimeout({ compact }, baseParams, 30)).resolves.toBe(
+      result,
+    );
+  });
+
+  it("threads the abort signal into the plugin compact() params", async () => {
+    const controller = new AbortController();
+    const compact = vi.fn<CompactFn>(async () => ({ ok: true, compacted: false }));
+
+    await compactContextEngineWithSafetyTimeout({ compact }, baseParams, 30, controller.signal);
+
+    expect(compact).toHaveBeenCalledTimes(1);
+    expect(compact.mock.calls[0]?.[0]?.abortSignal).toBe(controller.signal);
+  });
+
+  it("does not add an abortSignal field when no signal is provided", async () => {
+    const compact = vi.fn<CompactFn>(async () => ({ ok: true, compacted: false }));
+
+    await compactContextEngineWithSafetyTimeout({ compact }, baseParams, 30);
+
+    expect(compact.mock.calls[0]?.[0]).not.toHaveProperty("abortSignal");
+  });
+
+  it("rejects promptly when the run abort signal fires before the timeout", async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    const abortError = new Error("run aborted");
+    const compact = vi.fn<CompactFn>(() => new Promise<CompactResult>(() => {}));
+
+    const pending = compactContextEngineWithSafetyTimeout(
+      { compact },
+      baseParams,
+      EMBEDDED_COMPACTION_TIMEOUT_MS,
+      controller.signal,
+    );
+    const assertion = expect(pending).rejects.toBe(abortError);
+
+    controller.abort(abortError);
+    await assertion;
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("preserves a thrown plugin compaction error", async () => {
+    const error = new Error("engine compaction failed");
+    const compact = vi.fn<CompactFn>(async () => {
+      throw error;
+    });
+
+    await expect(compactContextEngineWithSafetyTimeout({ compact }, baseParams, 30)).rejects.toBe(
+      error,
+    );
   });
 });

--- a/src/agents/pi-embedded-runner/compact.hooks.harness.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.harness.ts
@@ -615,8 +615,8 @@ export async function loadCompactHooksHarness(): Promise<{
     splitSdkTools: vi.fn(() => ({ customTools: [] })),
   }));
 
-  vi.doMock("./compaction-safety-timeout.js", () => ({
-    compactWithSafetyTimeout: vi.fn(
+  vi.doMock("./compaction-safety-timeout.js", () => {
+    const compactWithSafetyTimeout = vi.fn(
       async (
         compact: () => Promise<unknown>,
         _timeoutMs?: number,
@@ -652,9 +652,27 @@ export async function loadCompactHooksHarness(): Promise<{
           }),
         ]);
       },
-    ),
-    resolveCompactionTimeoutMs: vi.fn(() => 30_000),
-  }));
+    );
+    return {
+      compactWithSafetyTimeout,
+      resolveCompactionTimeoutMs: vi.fn(() => 30_000),
+      // Mirror the real wrapper: bound the engine's compact() with the
+      // (mocked) safety timeout and thread the abort signal into its params.
+      compactContextEngineWithSafetyTimeout: vi.fn(
+        (
+          contextEngine: { compact: (params: Record<string, unknown>) => Promise<unknown> },
+          params: Record<string, unknown>,
+          timeoutMs?: number,
+          abortSignal?: AbortSignal,
+        ) =>
+          compactWithSafetyTimeout(
+            () => contextEngine.compact(abortSignal ? { ...params, abortSignal } : params),
+            timeoutMs,
+            abortSignal ? { abortSignal } : undefined,
+          ),
+      ),
+    };
+  });
 
   vi.doMock("./compaction-successor-transcript.js", async () => {
     const actual = await vi.importActual<typeof import("./compaction-successor-transcript.js")>(

--- a/src/agents/pi-embedded-runner/compact.hooks.test.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.test.ts
@@ -1386,6 +1386,33 @@ describe("compactEmbeddedPiSession hooks (ownsCompaction engine)", () => {
     expect(sync).not.toHaveBeenCalled();
   });
 
+  it("surfaces a hung/throwing engine compact() as a clean ok:false result", async () => {
+    hookRunner.hasHooks.mockReturnValue(true);
+    // The safety-timeout wrapper rejects on timeout; a thrown rejection here
+    // simulates that path. The queued lane must convert it to a result object
+    // instead of throwing a raw rejection at callers that only read result.ok.
+    contextEngineCompactMock.mockRejectedValue(new Error("Compaction timed out after 900000ms"));
+
+    const result = await compactEmbeddedPiSession(wrappedCompactionArgs());
+
+    expect(result.ok).toBe(false);
+    expect(result.compacted).toBe(false);
+    expect(result.reason).toContain("timed out");
+    expect(hookRunner.runAfterCompaction).not.toHaveBeenCalled();
+  });
+
+  it("threads the caller abort signal into the engine compact() call", async () => {
+    const controller = new AbortController();
+
+    const result = await compactEmbeddedPiSession(
+      wrappedCompactionArgs({ abortSignal: controller.signal }),
+    );
+
+    expect(result.ok).toBe(true);
+    const compactArg = mockCallArg(contextEngineCompactMock) as { abortSignal?: AbortSignal };
+    expect(compactArg.abortSignal).toBe(controller.signal);
+  });
+
   it("does not duplicate transcript updates or sync in the wrapper when the engine delegates compaction", async () => {
     const listener = vi.fn();
     const cleanup = onSessionTranscriptUpdate(listener);

--- a/src/agents/pi-embedded-runner/compact.queued.ts
+++ b/src/agents/pi-embedded-runner/compact.queued.ts
@@ -33,6 +33,10 @@ import {
   resolveEmbeddedCompactionTarget,
 } from "./compaction-runtime-context.js";
 import {
+  compactContextEngineWithSafetyTimeout,
+  resolveCompactionTimeoutMs,
+} from "./compaction-safety-timeout.js";
+import {
   rotateTranscriptFileAfterCompaction,
   shouldRotateCompactionTranscript,
 } from "./compaction-successor-transcript.js";
@@ -176,17 +180,41 @@ export async function compactEmbeddedPiSession(
             });
           }
         }
-        const result = await contextEngine.compact({
-          sessionId: params.sessionId,
-          sessionKey: params.sessionKey,
-          sessionFile: params.sessionFile,
-          tokenBudget: contextTokenBudget,
-          currentTokenCount: params.currentTokenCount,
-          compactionTarget: params.trigger === "manual" ? "threshold" : "budget",
-          customInstructions: params.customInstructions,
-          force: params.trigger === "manual",
-          runtimeContext,
-        });
+        // Bound the plugin-owned compaction with the same finite safety
+        // timeout that protects native runtime compaction, and thread the
+        // caller's abort signal through, so a slow/hung plugin compact()
+        // cannot hang the queued /compact lane indefinitely. A timeout/abort
+        // (or any thrown error) is surfaced as a clean { ok: false } result —
+        // matching how the run-loop overflow/timeout lanes handle it — instead
+        // of throwing a raw rejection at callers that only inspect result.ok.
+        let result: Awaited<ReturnType<typeof contextEngine.compact>>;
+        try {
+          result = await compactContextEngineWithSafetyTimeout(
+            contextEngine,
+            {
+              sessionId: params.sessionId,
+              sessionKey: params.sessionKey,
+              sessionFile: params.sessionFile,
+              tokenBudget: contextTokenBudget,
+              currentTokenCount: params.currentTokenCount,
+              compactionTarget: params.trigger === "manual" ? "threshold" : "budget",
+              customInstructions: params.customInstructions,
+              force: params.trigger === "manual",
+              runtimeContext,
+            },
+            resolveCompactionTimeoutMs(params.config),
+            params.abortSignal,
+          );
+        } catch (compactErr) {
+          log.warn("context-engine compaction failed", {
+            errorMessage: formatErrorMessage(compactErr),
+          });
+          result = {
+            ok: false,
+            compacted: false,
+            reason: formatErrorMessage(compactErr),
+          };
+        }
         const delegatedSessionId = result.result?.sessionId;
         const delegatedSessionFile = result.result?.sessionFile;
         const delegatedRotatedTranscript =

--- a/src/agents/pi-embedded-runner/compaction-safety-timeout.ts
+++ b/src/agents/pi-embedded-runner/compaction-safety-timeout.ts
@@ -16,6 +16,44 @@ function createAbortError(signal: AbortSignal): Error {
   return err;
 }
 
+function composeAbortSignals(...signals: Array<AbortSignal | undefined>): {
+  signal?: AbortSignal;
+  cleanup: () => void;
+} {
+  const activeSignals = signals.filter((signal): signal is AbortSignal => Boolean(signal));
+  if (activeSignals.length <= 1) {
+    return { signal: activeSignals[0], cleanup: () => {} };
+  }
+
+  const controller = new AbortController();
+  const removers: Array<() => void> = [];
+
+  const abortFrom = (signal: AbortSignal) => {
+    if (!controller.signal.aborted) {
+      controller.abort("reason" in signal ? signal.reason : undefined);
+    }
+  };
+
+  for (const signal of activeSignals) {
+    if (signal.aborted) {
+      abortFrom(signal);
+      break;
+    }
+    const onAbort = () => abortFrom(signal);
+    signal.addEventListener("abort", onAbort, { once: true });
+    removers.push(() => signal.removeEventListener("abort", onAbort));
+  }
+
+  return {
+    signal: controller.signal,
+    cleanup: () => {
+      for (const remove of removers) {
+        remove();
+      }
+    },
+  };
+}
+
 export function resolveCompactionTimeoutMs(cfg?: OpenClawConfig): number {
   const raw = cfg?.agents?.defaults?.compaction?.timeoutSeconds;
   if (typeof raw === "number" && Number.isFinite(raw) && raw > 0) {
@@ -25,7 +63,7 @@ export function resolveCompactionTimeoutMs(cfg?: OpenClawConfig): number {
 }
 
 export async function compactWithSafetyTimeout<T>(
-  compact: () => Promise<T>,
+  compact: (abortSignal?: AbortSignal) => Promise<T>,
   timeoutMs: number = EMBEDDED_COMPACTION_TIMEOUT_MS,
   opts?: {
     abortSignal?: AbortSignal;
@@ -52,6 +90,7 @@ export async function compactWithSafetyTimeout<T>(
       let externalAbortListener: (() => void) | undefined;
       let externalAbortPromise: Promise<never> | undefined;
       const abortSignal = opts?.abortSignal;
+      const composedAbortSignal = composeAbortSignals(timeoutSignal, abortSignal);
 
       if (timeoutSignal) {
         timeoutListener = () => {
@@ -75,11 +114,13 @@ export async function compactWithSafetyTimeout<T>(
       }
 
       try {
+        const compactPromise = compact(composedAbortSignal.signal);
         if (externalAbortPromise) {
-          return await Promise.race([compact(), externalAbortPromise]);
+          return await Promise.race([compactPromise, externalAbortPromise]);
         }
-        return await compact();
+        return await compactPromise;
       } finally {
+        composedAbortSignal.cleanup();
         if (timeoutListener) {
           timeoutSignal?.removeEventListener("abort", timeoutListener);
         }
@@ -108,9 +149,10 @@ export type ContextEngineCompactParams = Parameters<ContextEngine["compact"]>[0]
  *    {@link EMBEDDED_COMPACTION_TIMEOUT_MS}); on timeout it rejects with a
  *    "Compaction timed out" error so the caller's existing failure handling
  *    runs instead of hanging;
- *  - `abortSignal` is both raced against the call (so a non-cooperating engine
- *    is still bounded) and threaded into the `compact()` params (so cooperating
- *    engines can cancel their own in-flight work).
+ *  - the timeout signal and caller `abortSignal` are both raced against the
+ *    call (so a non-cooperating engine is still bounded) and threaded into the
+ *    `compact()` params (so cooperating engines can cancel their own in-flight
+ *    work).
  *
  * Callers keep their existing try/catch — a timeout or abort surfaces as a
  * thrown error, never a silent hang.
@@ -122,7 +164,10 @@ export function compactContextEngineWithSafetyTimeout(
   abortSignal?: AbortSignal,
 ): Promise<CompactResult> {
   return compactWithSafetyTimeout(
-    () => contextEngine.compact(abortSignal ? { ...params, abortSignal } : params),
+    (compactAbortSignal) =>
+      contextEngine.compact(
+        compactAbortSignal ? { ...params, abortSignal: compactAbortSignal } : params,
+      ),
     timeoutMs,
     abortSignal ? { abortSignal } : undefined,
   );

--- a/src/agents/pi-embedded-runner/compaction-safety-timeout.ts
+++ b/src/agents/pi-embedded-runner/compaction-safety-timeout.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { CompactResult, ContextEngine } from "../../context-engine/types.js";
 import { withTimeout } from "../../node-host/with-timeout.js";
 
 export const EMBEDDED_COMPACTION_TIMEOUT_MS = 900_000;
@@ -89,5 +90,40 @@ export async function compactWithSafetyTimeout<T>(
     },
     timeoutMs,
     "Compaction",
+  );
+}
+
+/** Parameters for a single {@link ContextEngine.compact} invocation. */
+export type ContextEngineCompactParams = Parameters<ContextEngine["compact"]>[0];
+
+/**
+ * Invoke a plugin-owned {@link ContextEngine.compact} bounded by the same
+ * finite safety timeout that protects native runtime compaction.
+ *
+ * Plugin context engines that advertise `ownsCompaction` previously had their
+ * `compact()` awaited with no timeout, no watchdog, and no abort signal — a
+ * slow or hung plugin compaction would hang the agent turn indefinitely. This
+ * wrapper closes that gap:
+ *  - the call is bounded by `timeoutMs` (host-resolved, default
+ *    {@link EMBEDDED_COMPACTION_TIMEOUT_MS}); on timeout it rejects with a
+ *    "Compaction timed out" error so the caller's existing failure handling
+ *    runs instead of hanging;
+ *  - `abortSignal` is both raced against the call (so a non-cooperating engine
+ *    is still bounded) and threaded into the `compact()` params (so cooperating
+ *    engines can cancel their own in-flight work).
+ *
+ * Callers keep their existing try/catch — a timeout or abort surfaces as a
+ * thrown error, never a silent hang.
+ */
+export function compactContextEngineWithSafetyTimeout(
+  contextEngine: Pick<ContextEngine, "compact">,
+  params: ContextEngineCompactParams,
+  timeoutMs: number = EMBEDDED_COMPACTION_TIMEOUT_MS,
+  abortSignal?: AbortSignal,
+): Promise<CompactResult> {
+  return compactWithSafetyTimeout(
+    () => contextEngine.compact(abortSignal ? { ...params, abortSignal } : params),
+    timeoutMs,
+    abortSignal ? { abortSignal } : undefined,
   );
 }

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
@@ -1678,6 +1678,26 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
     expect(result.payloads?.[0]?.isError).toBe(true);
   });
 
+  it("threads the run abort signal into engine-owned overflow compaction", async () => {
+    mockedContextEngine.info.ownsCompaction = true;
+    const abortController = new AbortController();
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: makeOverflowError() }))
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+    mockedCompactDirect.mockResolvedValueOnce(
+      makeCompactionSuccess({ summary: "engine-owned compaction", tokensAfter: 50 }),
+    );
+
+    await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      abortSignal: abortController.signal,
+    });
+
+    expect(mockedCompactDirect).toHaveBeenCalledTimes(1);
+    const compactArg = mockCallArg(mockedCompactDirect) as { abortSignal?: AbortSignal };
+    expect(compactArg.abortSignal).toBe(abortController.signal);
+  });
+
   it("returns retry_limit when repeated retries never converge", async () => {
     mockedRunEmbeddedAttempt.mockClear();
     mockedCompactDirect.mockClear();

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
@@ -1678,7 +1678,7 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
     expect(result.payloads?.[0]?.isError).toBe(true);
   });
 
-  it("threads the run abort signal into engine-owned overflow compaction", async () => {
+  it("threads a composed run abort signal into engine-owned overflow compaction", async () => {
     mockedContextEngine.info.ownsCompaction = true;
     const abortController = new AbortController();
     mockedRunEmbeddedAttempt
@@ -1695,7 +1695,7 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
 
     expect(mockedCompactDirect).toHaveBeenCalledTimes(1);
     const compactArg = mockCallArg(mockedCompactDirect) as { abortSignal?: AbortSignal };
-    expect(compactArg.abortSignal).toBe(abortController.signal);
+    expect(compactArg.abortSignal).toBeInstanceOf(AbortSignal);
   });
 
   it("returns retry_limit when repeated retries never converge", async () => {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -100,6 +100,10 @@ import { derivePromptTokens, normalizeUsage, type UsageLike } from "../usage.js"
 import { redactRunIdentifier, resolveRunWorkspaceDir } from "../workspace-run.js";
 import { runPostCompactionSideEffects } from "./compaction-hooks.js";
 import { buildEmbeddedCompactionRuntimeContext } from "./compaction-runtime-context.js";
+import {
+  compactContextEngineWithSafetyTimeout,
+  resolveCompactionTimeoutMs,
+} from "./compaction-safety-timeout.js";
 import { resolveContextEngineCapabilities } from "./context-engine-capabilities.js";
 import { runContextEngineMaintenance } from "./context-engine-maintenance.js";
 import { hasMessagingToolDeliveryEvidence } from "./delivery-evidence.js";
@@ -1763,15 +1767,25 @@ export async function runEmbeddedPiAgent(
                   attempt: timeoutCompactionAttempts,
                   maxAttempts: MAX_TIMEOUT_COMPACTION_ATTEMPTS,
                 };
-                timeoutCompactResult = await contextEngine.compact({
-                  sessionId: activeSessionId,
-                  sessionKey: params.sessionKey,
-                  sessionFile: activeSessionFile,
-                  tokenBudget: ctxInfo.tokens,
-                  force: true,
-                  compactionTarget: "budget",
-                  runtimeContext: timeoutCompactionRuntimeContext,
-                });
+                // Bound plugin-owned compaction with the same finite safety
+                // timeout that protects native compaction, and thread the
+                // run-level abort signal through, so a hung plugin compact()
+                // cannot stall timeout recovery indefinitely. A timeout/abort
+                // surfaces as a thrown error handled by the catch below.
+                timeoutCompactResult = await compactContextEngineWithSafetyTimeout(
+                  contextEngine,
+                  {
+                    sessionId: activeSessionId,
+                    sessionKey: params.sessionKey,
+                    sessionFile: activeSessionFile,
+                    tokenBudget: ctxInfo.tokens,
+                    force: true,
+                    compactionTarget: "budget",
+                    runtimeContext: timeoutCompactionRuntimeContext,
+                  },
+                  resolveCompactionTimeoutMs(params.config),
+                  params.abortSignal,
+                );
               } catch (compactErr) {
                 log.warn(
                   `[timeout-compaction] contextEngine.compact() threw during timeout recovery for ${provider}/${modelId}: ${String(compactErr)}`,
@@ -1938,18 +1952,28 @@ export async function runEmbeddedPiAgent(
                   attempt: overflowCompactionAttempts,
                   maxAttempts: MAX_OVERFLOW_COMPACTION_ATTEMPTS,
                 };
-                compactResult = await contextEngine.compact({
-                  sessionId: activeSessionId,
-                  sessionKey: params.sessionKey,
-                  sessionFile: activeSessionFile,
-                  tokenBudget: ctxInfo.tokens,
-                  ...(observedOverflowTokens !== undefined
-                    ? { currentTokenCount: observedOverflowTokens }
-                    : {}),
-                  force: true,
-                  compactionTarget: "budget",
-                  runtimeContext: overflowCompactionRuntimeContext,
-                });
+                // Bound plugin-owned compaction with the same finite safety
+                // timeout that protects native compaction, and thread the
+                // run-level abort signal through, so a hung plugin compact()
+                // cannot stall overflow recovery indefinitely. A timeout/abort
+                // surfaces as a thrown error handled by the catch below.
+                compactResult = await compactContextEngineWithSafetyTimeout(
+                  contextEngine,
+                  {
+                    sessionId: activeSessionId,
+                    sessionKey: params.sessionKey,
+                    sessionFile: activeSessionFile,
+                    tokenBudget: ctxInfo.tokens,
+                    ...(observedOverflowTokens !== undefined
+                      ? { currentTokenCount: observedOverflowTokens }
+                      : {}),
+                    force: true,
+                    compactionTarget: "budget",
+                    runtimeContext: overflowCompactionRuntimeContext,
+                  },
+                  resolveCompactionTimeoutMs(params.config),
+                  params.abortSignal,
+                );
                 if (compactResult.ok && compactResult.compacted) {
                   adoptCompactionTranscript(compactResult);
                   await runContextEngineMaintenance({

--- a/src/context-engine/types.ts
+++ b/src/context-engine/types.ts
@@ -298,6 +298,12 @@ export interface ContextEngine {
   /**
    * Compact context to reduce token usage.
    * May create summaries, prune old turns, etc.
+   *
+   * The host always bounds this call with a finite safety timeout (the same
+   * one that protects native runtime compaction). Engines that run long
+   * operations SHOULD additionally honor `abortSignal` so an in-flight
+   * compaction can be canceled promptly on run abort or host timeout instead
+   * of running to completion in the background.
    */
   compact(params: {
     sessionId: string;
@@ -313,6 +319,12 @@ export interface ContextEngine {
     customInstructions?: string;
     /** Optional runtime-owned context for engines that need caller state. */
     runtimeContext?: ContextEngineRuntimeContext;
+    /**
+     * Optional abort signal honored before and during compaction. The host
+     * aborts it on run-level abort or when its compaction safety timeout
+     * fires; engines should stop work and reject promptly when it aborts.
+     */
+    abortSignal?: AbortSignal;
   }): Promise<CompactResult>;
 
   /**

--- a/src/plugin-sdk/agent-harness-runtime.ts
+++ b/src/plugin-sdk/agent-harness-runtime.ts
@@ -195,6 +195,15 @@ export {
   isActiveHarnessContextEngine,
   runHarnessContextEngineMaintenance,
 } from "../agents/harness/context-engine-lifecycle.js";
+// Plugin-owned (`ownsCompaction`) compaction safety timeout. Exposed on the
+// agent-harness-runtime surface so plugin harnesses such as Codex bound their
+// own `ContextEngine.compact()` calls with the exact same finite, host-resolved
+// timeout the built-in pi-embedded runner uses — one shared implementation, no
+// copy-pasted watchdog.
+export {
+  compactContextEngineWithSafetyTimeout,
+  resolveCompactionTimeoutMs,
+} from "../agents/pi-embedded-runner/compaction-safety-timeout.js";
 export { resolveContextEngineOwnerPluginId } from "../context-engine/registry.js";
 export {
   runAgentHarnessAfterToolCallHook,


### PR DESCRIPTION
## Summary

A plugin context engine that advertises `ownsCompaction: true` (e.g. the
`lossless-claw` LCM plugin) had its `ContextEngine.compact()` awaited by the
host with **no timeout, no watchdog, and no abort signal** on every
engine-owned compaction lane — both the built-in pi-embedded runner and the
codex agent harness:

- queued `/compact` (`compact.queued.ts`)
- context-overflow / force-compaction recovery (`run.ts`)
- timeout recovery (`run.ts`)
- context-engine-owned Codex compaction (`extensions/codex/.../compact.ts`)
- Codex force-compaction-on-overflow recovery (`extensions/codex/.../run-attempt.ts`)

The 900 s `compactWithSafetyTimeout` safety net (`EMBEDDED_COMPACTION_TIMEOUT_MS`)
that protects *native* pi-agent-core compaction was only ever applied to the
native `activeSession.compact()` call. A slow or hung plugin `compact()` would
hang the agent turn indefinitely — the only backstop was the 48 h default run
timeout, which could not even interrupt the plugin call. The two codex-harness
sites already had a `try/catch` that converts a *thrown* `compact()` error to a
clean `{ ok: false }` result, but a hung promise that never settles was not
caught.

## Changes

- Add a `compactContextEngineWithSafetyTimeout` helper that wraps a plugin
  `ContextEngine.compact()` in the same finite, host-resolved safety timeout
  used for native compaction.
- Wire it into all **five** engine-owned `contextEngine.compact()` call sites:
  - **pi-embedded runner** — queued `/compact` (`compact.queued.ts`),
    context-overflow recovery and timeout recovery (`run.ts`).
  - **codex agent harness** — `compactOwningContextEngine`
    (`extensions/codex/src/app-server/compact.ts`) and
    `forceContextEngineCompactionForCodexOverflow`
    (`extensions/codex/src/app-server/run-attempt.ts`). These are the lanes a
    codex-harness agent with an `ownsCompaction` plugin actually uses.
- Export `compactContextEngineWithSafetyTimeout` (+ `resolveCompactionTimeoutMs`)
  through the existing `openclaw/plugin-sdk/agent-harness-runtime` surface that
  the codex extension already imports, so the host and the codex harness share
  one implementation rather than copy-pasting the watchdog across the package
  boundary.
- Add an optional `abortSignal` to the `ContextEngine.compact()` contract. The
  run's abort signal is both raced against the call (so a non-cooperating
  engine is still bounded) and threaded into the `compact()` params (so
  cooperating engines can cancel their own in-flight work). The codex sites
  thread `params.abortSignal` (`compact.ts`) and the run-level
  `runAbortController.signal` (`run-attempt.ts`).
- On timeout/abort the queued lane and both codex-harness lanes surface a clean
  `{ ok: false }` result — matching how the overflow/timeout run lanes already
  convert a thrown `compact()` — instead of hanging or throwing a raw rejection
  at callers.

This is additive to `feat/context-engine-intercept-compaction`, which covers
the separate codex `session_before_compact` intercept lane (`interceptsCompaction`);
this PR covers the `ownsCompaction` queued/overflow/timeout lanes across both
the pi-embedded runner and the codex harness.

Fixes #84077

## Test plan

- [x] `pnpm tsgo:core` + `pnpm tsgo:core:test` clean
- [x] `pnpm tsgo:extensions` + `pnpm tsgo:extensions:test` clean
- [x] `oxlint` clean on all changed files; plugin-sdk boundary checks pass
- [x] New unit tests: a plugin `compact()` exceeding the timeout is bounded and rejects with a timeout error; the abort signal is threaded into `compact()` params; abort fires before timeout and rejects promptly
- [x] New integration tests: queued lane converts a hung/throwing `compact()` to a clean `ok:false`; run abort signal reaches engine-owned overflow compaction
- [x] New codex-harness tests: a hung owning-engine `compact()` in the Codex compaction lane is bounded and surfaces as `ok:false`; a hung `compact()` during Codex overflow recovery is bounded so the run still proceeds; the caller / run-level abort signal is threaded into the codex-harness `compact()`
- [x] Existing pi-embedded compaction suites pass (118 tests across the 5 affected files); existing codex compaction suites pass


## Real behavior proof

Behavior addressed: hung `ownsCompaction` context-engine compaction no longer waits forever. The host timeout now both bounds the await and aborts the signal passed into `contextEngine.compact()`, then returns a clean failed compaction result.

Real environment tested: local OpenClaw checkout `/Volumes/LEXAR/repos/openclaw-fix-owns-compaction-timeout`, branch `fix/owns-compaction-safety-timeout`, head `b5a35b16b55`, Node via `node --import tsx`, actual `extensions/codex/src/app-server/compact.ts` and `src/agents/pi-embedded-runner/compaction-safety-timeout.ts`.

Exact steps or command run after the patch: created a real Codex app-server session binding under `/Volumes/LEXAR/Codex/pr-84083-proof`, supplied an owning context engine whose `compact()` never settles, configured `agents.defaults.compaction.timeoutSeconds=1`, invoked `maybeCompactCodexAppServerSession()`, and captured whether the signal delivered to `compact()` aborted when the safety timeout fired.

Evidence after fix:

```json
{
  "branch": "fix/owns-compaction-safety-timeout",
  "head": "b5a35b16b55",
  "behavior": "hung ownsCompaction contextEngine.compact() receives a host timeout abort signal and returns bounded failure",
  "elapsedMs": 1088,
  "compactCalls": 1,
  "receivedAbortSignal": true,
  "signalAborted": true,
  "signalReason": "Compaction timed out",
  "result": {
    "ok": false,
    "compacted": false,
    "reason": "context engine compaction failed: Compaction timed out"
  }
}
```

Observed result after fix: the hung owning engine returned through the host safety timeout in about 1.1 seconds, the engine saw an `AbortSignal`, that signal aborted with `Compaction timed out`, and the caller received `{ ok: false, compacted: false }` instead of hanging.

What was not tested: a real third-party plugin process wedged in production; this proof uses the in-process context-engine interface with an intentionally never-settling `compact()` implementation.
