### PR TITLE
fix(ui): de-duplicate Off option in chat thinking-level picker [AI-assisted]

### DIFF
--- a/ui/src/ui/chat/session-controls.test.ts
+++ b/ui/src/ui/chat/session-controls.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import type { GatewayThinkingLevelOption } from "../types.ts";
+import { buildThinkingOptions } from "./session-controls.ts";
+
+describe("buildThinkingOptions", () => {
+  it("strips an explicit off level so the inherited entry is not duplicated", () => {
+    const levels: GatewayThinkingLevelOption[] = [
+      { id: "off", label: "Off" },
+      { id: "low", label: "Low" },
+      { id: "high", label: "High" },
+    ];
+    const options = buildThinkingOptions(levels, "");
+    expect(options.map((o) => o.value)).toEqual(["low", "high"]);
+  });
+
+  it("strips off entries regardless of casing or surrounding whitespace", () => {
+    const levels: GatewayThinkingLevelOption[] = [
+      { id: " OFF ", label: "Off" },
+      { id: "none", label: "None" },
+      { id: "medium", label: "Medium" },
+    ];
+    const options = buildThinkingOptions(levels, "");
+    expect(options.map((o) => o.value)).toEqual(["medium"]);
+  });
+
+  it("does not include the current override when it normalizes to off", () => {
+    const levels: GatewayThinkingLevelOption[] = [
+      { id: "low", label: "Low" },
+      { id: "high", label: "High" },
+    ];
+    const options = buildThinkingOptions(levels, "off");
+    expect(options.map((o) => o.value)).toEqual(["low", "high"]);
+  });
+
+  it("keeps non-off levels and a non-off current override", () => {
+    const levels: GatewayThinkingLevelOption[] = [
+      { id: "low", label: "Low" },
+      { id: "high", label: "High" },
+    ];
+    const options = buildThinkingOptions(levels, "custom");
+    expect(options.map((o) => o.value)).toEqual(["low", "high", "custom"]);
+  });
+
+  it("returns an empty list when the model only exposes off", () => {
+    const levels: GatewayThinkingLevelOption[] = [{ id: "off", label: "Off" }];
+    const options = buildThinkingOptions(levels, "");
+    expect(options).toEqual([]);
+  });
+});

--- a/ui/src/ui/chat/session-controls.ts
+++ b/ui/src/ui/chat/session-controls.ts
@@ -278,7 +278,7 @@ function resolveThinkingTargetModel(state: AppViewState): {
   };
 }
 
-function buildThinkingOptions(
+export function buildThinkingOptions(
   levels: readonly GatewayThinkingLevelOption[],
   currentOverride: string,
 ): ChatThinkingSelectOption[] {
@@ -287,6 +287,12 @@ function buildThinkingOptions(
 
   const addOption = (value: string, label?: string) => {
     const normalizedValue = normalizeThinkingOptionValue(value);
+    // The inherited/default option (value === "") already represents "Off" when
+    // the effective level is off. Emitting a second explicit "off" entry would
+    // produce a duplicate "Off" row in the picker (issue #84069).
+    if (normalizedValue === "off") {
+      return;
+    }
     pushUniqueTrimmedSelectOption(options, seen, normalizedValue, () =>
       formatThinkingOverrideLabel(normalizedValue, label),
     );
@@ -363,11 +369,16 @@ export function renderChatThinkingSelect(state: AppViewState) {
   const { currentOverride, defaultLabel, options } = resolveChatThinkingSelectState(state);
   const busy =
     state.chatLoading || state.chatSending || Boolean(state.chatRunId) || state.chatStream !== null;
-  const disabled = !state.connected || busy || !state.client;
+  // When the active model has no real thinking levels to choose from, leave the
+  // picker visible but inert so users cannot pick between two indistinguishable
+  // "Off" entries (issue #84069).
+  const hasSelectableOptions = options.length > 0;
+  const disabled = !state.connected || busy || !state.client || !hasSelectableOptions;
   const selectedLabel =
     currentOverride === ""
       ? defaultLabel
-      : (options.find((entry) => entry.value === currentOverride)?.label ?? currentOverride);
+      : (options.find((entry) => entry.value === currentOverride)?.label ??
+        formatThinkingOverrideLabel(currentOverride));
   const onChange = async (e: Event) => {
     const next = (e.target as HTMLSelectElement).value.trim();
     await switchChatThinkingLevel(state, next);


### PR DESCRIPTION
> 🤖 AI-assisted (built with Codex via Hermes orchestration). Test level: lightly tested (new co-located unit tests for the affected helper). Prompt summary available on request.

## Summary
- Problem: The chat thinking-level dropdown shows two indistinguishable "Off" rows for models whose level list includes an explicit `off` entry, and stays interactive even when no real thinking options exist.
- Why it matters: Users can't tell the two "Off" rows apart and may pick the "wrong" one; for non-thinking models the picker invites a meaningless choice.
- What changed: `buildThinkingOptions` now skips any entry whose normalized value is `off` (the inherited `<option value="">` already represents that choice), and `renderChatThinkingSelect` disables the select when no real options remain so it stays visible but inert.
- What did NOT change (scope boundary): No changes to `thinking-labels.ts`, `thinking.ts`, gateway-side level resolution, or the sessions view picker. The inherited-default label logic is untouched.

## Change Type (select all)
- [x] Bug fix

## Scope (select all touched areas)
- [x] UI

## Linked Issue/PR
- Closes #84069
- [x] This PR fixes a bug or regression

## Root Cause
- Root cause: The renderer always emits an `<option value="">` whose label is `defaultLabel` ("Off" when the effective level is off), then concatenates every entry from `buildThinkingOptions`. When the model's level list itself contains `off`, the picker ends up with two "Off" rows: one empty-value, one `value="off"`. Separately, models with no thinking levels still rendered an interactive picker because `disabled` did not consider an empty options list.
- Missing detection / guardrail: No unit test asserted that the inherited default row and the dynamic option list are disjoint, and there was no test covering the empty-options case.
- Contributing context (if known): `buildThinkingOptions` was added to dedupe by lowercase key but it didn't filter the inherited-default sentinel, since the inherited row is emitted by the renderer rather than by `buildThinkingOptions`.

## Regression Test Plan
- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `ui/src/ui/chat/session-controls.test.ts` (new)
- Scenario the test should lock in: `buildThinkingOptions` strips any `off`/`none`/`OFF` entry from the levels list and from the current override, while preserving other levels and non-off overrides.
- Why this is the smallest reliable guardrail: The duplicate-Off bug lives entirely in the option-building helper; locking down its output is sufficient and avoids a heavy lit/DOM test.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes
- Chat thinking-level picker no longer shows two "Off" rows for models that expose an `off` level.
- For models with no real thinking levels, the picker is rendered but disabled (no selectable choices beyond the inherited "Off").

## Security Impact (required)
- New permissions/capabilities? No
- Pure UI-side option filtering and a disabled-state tweak; no auth, network, or persistence changes.
