### PR TITLE
fix(codex): budget legacy mirrored history projection (#84084)

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -4720,6 +4720,33 @@ describe("runCodexAppServerAttempt", () => {
     expect(inputText).toContain("make the default webpage openclaw");
   });
 
+  it("uses the runtime token budget for legacy mirrored-history projection", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const longContext = `legacy mirrored context start ${"x".repeat(30_000)} LEGACY_CONTEXT_END`;
+    const sessionManager = SessionManager.open(sessionFile);
+    sessionManager.appendMessage(userMessage("previous request", Date.now()));
+    sessionManager.appendMessage(assistantMessage(longContext, Date.now() + 1));
+    const harness = createStartedThreadHarness();
+    const params = createParams(sessionFile, workspaceDir);
+    params.contextTokenBudget = 80_000;
+
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("turn/start");
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await run;
+
+    const turnStart = harness.requests.find((request) => request.method === "turn/start");
+    const inputText =
+      (turnStart?.params as { input?: Array<{ text?: string }> } | undefined)?.input?.[0]?.text ??
+      "";
+
+    expect(inputText.length).toBeGreaterThan(30_000);
+    expect(inputText).toContain("LEGACY_CONTEXT_END");
+    expect(inputText).not.toContain("[truncated ");
+  });
+
   it("passes stable workspace files as Codex developer instructions and keeps MEMORY.md as turn context", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -1126,6 +1126,12 @@ export async function runCodexAppServerAttempt(
       assembledMessages: historyMessages,
       originalHistoryMessages: historyMessages,
       prompt: params.prompt,
+      maxRenderedContextChars: resolveCodexContextEngineProjectionMaxChars({
+        contextTokenBudget: params.contextTokenBudget,
+        reserveTokens: resolveCodexContextEngineProjectionReserveTokens({
+          config: params.config,
+        }),
+      }),
     });
     promptText = projection.promptText;
     prePromptMessageCount = projection.prePromptMessageCount;


### PR DESCRIPTION
Fixes #84084.

## Summary
- Pass the existing context-token-budget-derived projection cap into the legacy mirrored-history Codex startup path.
- Add a regression test proving high-window legacy mirrored history keeps a >30k context marker instead of falling back to the old 24k rendered cap.

## Audits
- A existing-helper audit: reused `resolveCodexContextEngineProjectionMaxChars` and `resolveCodexContextEngineProjectionReserveTokens`; no new projection sizing helper.
- B shared-caller audit: only changes the legacy fallback caller; `projectContextEngineAssemblyForCodex` contract stays unchanged.
- C rival audit: exact open PR searches for `84084`, `legacy mirrored-history`, and `maxRenderedContextChars` returned no issue-specific rival PR.

## Real behavior proof
- Behavior addressed: Legacy mirrored-history Codex startup now sizes projected context from the runtime `contextTokenBudget` instead of using the old 24k rendered-character default.
- Real environment tested: Local OpenClaw checkout on Linux, branch `fix-codex-legacy-mirrored-budget-84084`, commit `bd91823ef2`, Node-based extension app-server path.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts extensions/codex/src/app-server/run-attempt.test.ts`
- Evidence after fix: terminal output from the local run:

```text
RUN  v4.1.6 /home/chenglunhu/code/openclaw

Test Files  1 passed (1)
Tests       183 passed (183)
Start at    18:46:02
Duration    22.07s (transform 2.54s, setup 113ms, import 4.29s, tests 17.59s, environment 0ms)
```

- Observed result after fix: The new legacy mirrored-history startup case preserved a `LEGACY_CONTEXT_END` marker after more than 30k characters of projected context and did not emit `[truncated ...]`; before this patch, that fallback path did not pass `maxRenderedContextChars`, so the same projection used the default 24k cap.
- What was not tested: A live hosted Codex provider turn was not run; this is an app-server startup/projection behavior exercised in the local OpenClaw runtime test harness.

## Validation
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts extensions/codex/src/app-server/run-attempt.test.ts`
