### PR TITLE
feat(gateway): forward frequency_penalty, presence_penalty, and seed via OpenAI-compatible HTTP gateway

### DIFF
--- a/docs/gateway/openai-http-api.md
+++ b/docs/gateway/openai-http-api.md
@@ -219,8 +219,11 @@ Set `stream: true` to receive Server-Sent Events (SSE):
 - `max_tokens`: number; legacy alias accepted for backwards compatibility. Ignored when `max_completion_tokens` is also present.
 - `temperature`: number; best-effort sampling temperature forwarded to the upstream provider via the agent stream-param channel.
 - `top_p`: number; best-effort nucleus sampling forwarded to the upstream provider via the agent stream-param channel.
+- `frequency_penalty`: number; best-effort frequency penalty forwarded to the upstream provider via the agent stream-param channel. Validated range: -2.0 to 2.0. Returns `400 invalid_request_error` for out-of-range values.
+- `presence_penalty`: number; best-effort presence penalty forwarded to the upstream provider via the agent stream-param channel. Validated range: -2.0 to 2.0. Returns `400 invalid_request_error` for out-of-range values.
+- `seed`: number (integer); best-effort seed forwarded to the upstream provider via the agent stream-param channel. Returns `400 invalid_request_error` for non-integer values.
 
-When either token-cap field is set, the value is forwarded to the upstream provider via the agent stream-param channel. The actual wire field name sent to the upstream provider is chosen by the provider transport: `max_completion_tokens` for OpenAI-family endpoints, and `max_tokens` for providers that only accept the legacy name (such as Mistral and Chutes). Sampling fields (`temperature`, `top_p`) follow the same stream-param channel; the ChatGPT-based Codex Responses backend strips them server-side since it uses fixed sampling.
+When either token-cap field is set, the value is forwarded to the upstream provider via the agent stream-param channel. The actual wire field name sent to the upstream provider is chosen by the provider transport: `max_completion_tokens` for OpenAI-family endpoints, and `max_tokens` for providers that only accept the legacy name (such as Mistral and Chutes). Sampling fields (`temperature`, `top_p`, `frequency_penalty`, `presence_penalty`, `seed`) follow the same stream-param channel; the ChatGPT-based Codex Responses backend strips them server-side since it uses fixed sampling.
 
 ### Unsupported variants
 

--- a/src/agents/command/shared-types.ts
+++ b/src/agents/command/shared-types.ts
@@ -6,6 +6,9 @@ export type AgentStreamParams = {
   /** Provider fast-mode override (best-effort). */
   fastMode?: boolean;
   responseFormat?: Record<string, unknown>;
+  frequencyPenalty?: number;
+  presencePenalty?: number;
+  seed?: number;
 };
 
 // Simplified tool definition for client-provided tools (OpenResponses hosted tools)

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -1943,6 +1943,37 @@ describe("openai transport stream", () => {
     expect(params.top_p).toBe(0.9);
   });
 
+  it("forwards penalty params and seed to chat completions request params", () => {
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "gpt-5.4",
+        name: "GPT-5.4",
+        api: "openai-completions",
+        provider: "openai",
+        baseUrl: "https://api.openai.com/v1",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"openai-completions">,
+      {
+        systemPrompt: "system",
+        messages: [{ role: "user", content: "hi", timestamp: 1 }],
+        tools: [],
+      } as never,
+      {
+        frequencyPenalty: -0.5,
+        presencePenalty: 1.25,
+        seed: 12345,
+      },
+    );
+
+    expect(params.frequency_penalty).toBe(-0.5);
+    expect(params.presence_penalty).toBe(1.25);
+    expect(params.seed).toBe(12345);
+  });
+
   it("forwards response_format to chat completions request params", () => {
     const model = {
       id: "gpt-5.4",

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -124,6 +124,9 @@ type BaseStreamOptions = {
   headers?: Record<string, string>;
   openclawCodeModeToolSurface?: boolean;
   responseFormat?: Record<string, unknown>;
+  frequencyPenalty?: number;
+  presencePenalty?: number;
+  seed?: number;
 };
 
 type ModelStreamCooperativeScheduler = {
@@ -3502,6 +3505,15 @@ export function buildOpenAICompletionsParams(
   }
   if (options?.responseFormat !== undefined) {
     params.response_format = options.responseFormat;
+  }
+  if (options?.frequencyPenalty !== undefined) {
+    params.frequency_penalty = options.frequencyPenalty;
+  }
+  if (options?.presencePenalty !== undefined) {
+    params.presence_penalty = options.presencePenalty;
+  }
+  if (options?.seed !== undefined) {
+    params.seed = options.seed;
   }
   if (supportsModelTools(model)) {
     if (context.tools) {

--- a/src/agents/pi-embedded-runner/extra-params.sampling.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.sampling.test.ts
@@ -321,4 +321,95 @@ describe("createStreamFnWithExtraParams sampling overrides", () => {
     expect(first).not.toHaveProperty("responseFormat");
     expect(first.temperature).toBe(0.4);
   });
+
+  it("forwards frequency_penalty, presence_penalty, and seed from override into stream options", () => {
+    const underlying = vi.fn(() => ({
+      push: vi.fn(),
+      result: vi.fn(async () => undefined),
+      [Symbol.asyncIterator]: vi.fn(async function* () {}),
+    })) as unknown as StreamFn;
+    const agent: { streamFn?: StreamFn } = { streamFn: underlying };
+
+    applyExtraParamsToAgent(agent, undefined, "openai", "gpt-5.4", {
+      frequencyPenalty: 0.8,
+      presencePenalty: 0.3,
+      seed: 12345,
+    });
+
+    if (!agent.streamFn) {
+      throw new Error("expected extra params to wrap streamFn");
+    }
+
+    void agent.streamFn(
+      { id: "gpt-5.4", api: "openai-completions", provider: "openai" } as never,
+      { messages: [], tools: [] } as never,
+      undefined,
+    );
+
+    expect(underlying).toHaveBeenCalledTimes(1);
+    const callOptions = (underlying as unknown as { mock: { calls: unknown[][] } }).mock
+      .calls[0]?.[2] as
+      | {
+          frequencyPenalty?: number;
+          presencePenalty?: number;
+          seed?: number;
+        }
+      | undefined;
+    expect(callOptions?.frequencyPenalty).toBe(0.8);
+    expect(callOptions?.presencePenalty).toBe(0.3);
+    expect(callOptions?.seed).toBe(12345);
+  });
+
+  it("prefers camelCase runtime overrides over snake_case config for penalty params", () => {
+    const underlying = vi.fn(() => ({
+      push: vi.fn(),
+      result: vi.fn(async () => undefined),
+      [Symbol.asyncIterator]: vi.fn(async function* () {}),
+    })) as unknown as StreamFn;
+    const agent: { streamFn?: StreamFn } = { streamFn: underlying };
+
+    applyExtraParamsToAgent(
+      agent,
+      {
+        agents: {
+          defaults: {
+            models: {
+              "openai/gpt-5.4": {
+                params: {
+                  frequency_penalty: 0.1,
+                  presence_penalty: 0.1,
+                },
+              },
+            },
+          },
+        },
+      },
+      "openai",
+      "gpt-5.4",
+      {
+        frequencyPenalty: 0.9,
+        presencePenalty: 0.7,
+      },
+    );
+
+    if (!agent.streamFn) {
+      throw new Error("expected extra params to wrap streamFn");
+    }
+
+    void agent.streamFn(
+      { id: "gpt-5.4", api: "openai-completions", provider: "openai" } as never,
+      { messages: [], tools: [] } as never,
+      undefined,
+    );
+
+    const callOptions = (underlying as unknown as { mock: { calls: unknown[][] } }).mock
+      .calls[0]?.[2] as
+      | {
+          frequencyPenalty?: number;
+          presencePenalty?: number;
+        }
+      | undefined;
+    expect(callOptions?.frequencyPenalty).toBe(0.9);
+    expect(callOptions?.presencePenalty).toBe(0.7);
+  });
 });

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -154,6 +154,9 @@ type CacheRetentionStreamOptions = Partial<SimpleStreamOptions> & {
   cachedContent?: string;
   topP?: number;
   responseFormat?: Record<string, unknown>;
+  frequencyPenalty?: number;
+  presencePenalty?: number;
+  seed?: number;
 };
 export type SupportedTransport = AgentRuntimeTransport;
 
@@ -467,6 +470,30 @@ function createStreamFnWithExtraParams(
   if (typeof cachedContent === "string" && cachedContent.trim()) {
     streamParams.cachedContent = cachedContent.trim();
   }
+
+  // Resolve sampling / repetition params and add to streamParams
+  // so transport layers can filter by API type (e.g. openai-responses skips penalty params).
+  // Resolve aliased params: camelCase (runtime/request) checked first so
+  // per-request gateway overrides take priority over configured snake_case values.
+  const resolvedFrequencyPenalty = resolveAliasedParamValueFromKeys(
+    [extraParams],
+    ["frequencyPenalty", "frequency_penalty"],
+  );
+  const resolvedPresencePenalty = resolveAliasedParamValueFromKeys(
+    [extraParams],
+    ["presencePenalty", "presence_penalty"],
+  );
+  const resolvedSeed = extraParams.seed;
+  if (typeof resolvedFrequencyPenalty === "number") {
+    streamParams.frequencyPenalty = resolvedFrequencyPenalty;
+  }
+  if (typeof resolvedPresencePenalty === "number") {
+    streamParams.presencePenalty = resolvedPresencePenalty;
+  }
+  if (typeof resolvedSeed === "number") {
+    streamParams.seed = resolvedSeed;
+  }
+
   const initialCacheRetention = resolveCacheRetention(
     extraParams,
     provider,
@@ -488,9 +515,11 @@ function createStreamFnWithExtraParams(
       typeof callModel.api === "string" ? callModel.api : undefined,
       typeof callModel.id === "string" ? callModel.id : undefined,
     );
-    if (Object.keys(streamParams).length === 0 && !cacheRetention) {
+    const hasStreamParams = Object.keys(streamParams).length > 0 || cacheRetention;
+    if (!hasStreamParams) {
       return underlying(callModel, context, options);
     }
+
     return underlying(callModel, context, {
       ...streamParams,
       ...(cacheRetention ? { cacheRetention } : {}),

--- a/src/gateway/openai-compat-errors.ts
+++ b/src/gateway/openai-compat-errors.ts
@@ -79,6 +79,9 @@ export function resolveOpenAiCompatError(err: unknown): OpenAiCompatError | unde
 export function validateOpenAiSamplingParams(params: {
   temperature?: unknown;
   topP?: unknown;
+  frequencyPenalty?: unknown;
+  presencePenalty?: unknown;
+  seed?: unknown;
 }): string | undefined {
   if (params.temperature != null) {
     if (typeof params.temperature !== "number" || !Number.isFinite(params.temperature)) {
@@ -94,6 +97,30 @@ export function validateOpenAiSamplingParams(params: {
     }
     if (params.topP < 0 || params.topP > 1) {
       return "`top_p` must be between 0 and 1.";
+    }
+  }
+  if (params.frequencyPenalty != null) {
+    if (typeof params.frequencyPenalty !== "number" || !Number.isFinite(params.frequencyPenalty)) {
+      return "`frequency_penalty` must be a finite number.";
+    }
+    if (params.frequencyPenalty < -2 || params.frequencyPenalty > 2) {
+      return "`frequency_penalty` must be between -2.0 and 2.0.";
+    }
+  }
+  if (params.presencePenalty != null) {
+    if (typeof params.presencePenalty !== "number" || !Number.isFinite(params.presencePenalty)) {
+      return "`presence_penalty` must be a finite number.";
+    }
+    if (params.presencePenalty < -2 || params.presencePenalty > 2) {
+      return "`presence_penalty` must be between -2.0 and 2.0.";
+    }
+  }
+  if (params.seed != null) {
+    if (typeof params.seed !== "number" || !Number.isFinite(params.seed)) {
+      return "`seed` must be a finite number.";
+    }
+    if (!Number.isInteger(params.seed)) {
+      return "`seed` must be an integer.";
     }
   }
   return undefined;

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -112,8 +112,11 @@ type FirstAgentCommandOptions = {
   model?: string;
   sessionKey?: string;
   streamParams?: {
+    frequencyPenalty?: number;
     maxTokens?: number;
+    presencePenalty?: number;
     responseFormat?: Record<string, unknown>;
+    seed?: number;
     temperature?: number;
     topP?: number;
   };
@@ -1398,6 +1401,46 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
       const json = (await res.json()) as { error?: { type?: string; message?: string } };
       expect(json.error?.type).toBe("invalid_request_error");
       expect(json.error?.message).toMatch(/top_p/);
+      expect(agentCommand).toHaveBeenCalledTimes(0);
+    }
+  });
+
+  it("forwards inbound penalty and seed params into streamParams", async () => {
+    const port = enabledPort;
+    const mockAgentOnce = (payloads: Array<{ text: string }>) => {
+      agentCommand.mockClear();
+      agentCommand.mockResolvedValueOnce({ payloads } as never);
+    };
+    const getStreamParams = () => firstAgentCommandOptions()?.streamParams;
+
+    {
+      mockAgentOnce([{ text: "hello" }]);
+      const res = await postChatCompletions(port, {
+        model: "openclaw",
+        frequency_penalty: -0.5,
+        presence_penalty: 1.25,
+        seed: 12345,
+        messages: [{ role: "user", content: "hi" }],
+      });
+      expect(res.status).toBe(200);
+      expect(getStreamParams()).toMatchObject({
+        frequencyPenalty: -0.5,
+        presencePenalty: 1.25,
+        seed: 12345,
+      });
+      await res.text();
+    }
+
+    for (const body of [{ frequency_penalty: 3 }, { presence_penalty: -3 }, { seed: 1.5 }]) {
+      agentCommand.mockClear();
+      const res = await postChatCompletions(port, {
+        model: "openclaw",
+        ...body,
+        messages: [{ role: "user", content: "hi" }],
+      });
+      expect(res.status).toBe(400);
+      const json = (await res.json()) as { error?: { type?: string; message?: string } };
+      expect(json.error?.type).toBe("invalid_request_error");
       expect(agentCommand).toHaveBeenCalledTimes(0);
     }
   });

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
-import type { ClientToolDefinition } from "../agents/command/shared-types.js";
+import type { AgentStreamParams, ClientToolDefinition } from "../agents/command/shared-types.js";
 import type { ImageContent } from "../agents/command/types.js";
 import { isClientToolNameConflictError } from "../agents/pi-tool-definition-adapter.js";
 import { STREAM_ERROR_FALLBACK_TEXT } from "../agents/stream-message-shared.js";
@@ -80,6 +80,9 @@ type OpenAiChatCompletionRequest = {
   temperature?: unknown;
   top_p?: unknown;
   response_format?: unknown;
+  frequency_penalty?: unknown;
+  presence_penalty?: unknown;
+  seed?: unknown;
 };
 
 const DEFAULT_OPENAI_CHAT_COMPLETIONS_BODY_BYTES = 20 * 1024 * 1024;
@@ -138,12 +141,7 @@ function buildAgentCommandInput(params: {
   runId: string;
   messageChannel: string;
   abortSignal?: AbortSignal;
-  streamParams?: {
-    maxTokens?: number;
-    temperature?: number;
-    topP?: number;
-    responseFormat?: Record<string, unknown>;
-  };
+  streamParams?: AgentStreamParams;
 }) {
   return {
     message: params.prompt.message,
@@ -849,6 +847,11 @@ export async function handleOpenAiHttpRequest(
         : undefined;
   const temperature = typeof payload.temperature === "number" ? payload.temperature : undefined;
   const topP = typeof payload.top_p === "number" ? payload.top_p : undefined;
+  const frequencyPenalty =
+    typeof payload.frequency_penalty === "number" ? payload.frequency_penalty : undefined;
+  const presencePenalty =
+    typeof payload.presence_penalty === "number" ? payload.presence_penalty : undefined;
+  const seed = typeof payload.seed === "number" ? payload.seed : undefined;
   let responseFormat: Record<string, unknown> | undefined;
   try {
     responseFormat = resolveResponseFormat(payload.response_format);
@@ -864,6 +867,9 @@ export async function handleOpenAiHttpRequest(
   const samplingError = validateOpenAiSamplingParams({
     temperature: payload.temperature,
     topP: payload.top_p,
+    frequencyPenalty: payload.frequency_penalty,
+    presencePenalty: payload.presence_penalty,
+    seed: payload.seed,
   });
   if (samplingError) {
     sendJson(res, 400, {
@@ -875,12 +881,18 @@ export async function handleOpenAiHttpRequest(
     maxTokens !== undefined ||
     temperature !== undefined ||
     topP !== undefined ||
-    responseFormat !== undefined
+    responseFormat !== undefined ||
+    frequencyPenalty !== undefined ||
+    presencePenalty !== undefined ||
+    seed !== undefined
       ? {
           ...(maxTokens !== undefined ? { maxTokens } : {}),
           ...(temperature !== undefined ? { temperature } : {}),
           ...(topP !== undefined ? { topP } : {}),
           ...(responseFormat !== undefined ? { responseFormat } : {}),
+          ...(frequencyPenalty !== undefined ? { frequencyPenalty } : {}),
+          ...(presencePenalty !== undefined ? { presencePenalty } : {}),
+          ...(seed !== undefined ? { seed } : {}),
         }
       : undefined;
 


### PR DESCRIPTION
## Summary

- Forward `frequency_penalty`, `presence_penalty`, and `seed` from inbound `POST /v1/chat/completions` through `streamParams` → runtime stream wrapper → OpenAI transport, so client-supplied sampling parameters reach the upstream provider.
- Extend `AgentStreamParams` with `frequencyPenalty`, `presencePenalty`, and `seed` fields. Forward them through `createStreamFnWithExtraParams` (extra-params layer) and `buildOpenAICompletionsParams` (transport layer) to the provider request payload.
- Add gateway-side validation for the new parameters in `validateOpenAiSamplingParams`: penalty params constrained to `[-2.0, 2.0]`, `seed` must be an integer — matching the existing `temperature`/`top_p` validation contract.
- Resolve aliased param keys with camelCase (runtime/request) priority over snake_case (config) so per-request gateway overrides take precedence over configured model defaults.

## Verification

- `pnpm test src/agents/pi-embedded-runner/extra-params.sampling.test.ts` — 8/8 (existing sampling tests, no regressions)
- `pnpm test src/agents/openai-transport-stream.test.ts` — 168/168 (no regressions)
- `pnpm test src/gateway/openai-http.usage.test.ts src/gateway/openai-http.image-budget.test.ts` — 7/7 (no regressions)
- `pnpm check:changed` — clean (locally)
- `codex review` — "No discrete correctness issues were identified in the provided diff."
- Fork CI (`Lellansin/openclaw`, run [26092092169](https://github.com/Lellansin/openclaw/actions/runs/26092092169)) — 54/54 jobs passed

## Real behavior proof

- Behavior or issue addressed: OpenAI-compatible Gateway HTTP requests now forward client-supplied `frequency_penalty`, `presence_penalty`, and `seed` from `POST /v1/chat/completions` through `streamParams` to the upstream OpenAI-compatible provider. Invalid values are rejected at the gateway boundary with deterministic OpenAI-compatible 400 errors.
- Real environment tested: Local dev gateway on loopback port 18790, built from commit `044a61060a` with `pnpm build`. Runtime Node v24.14.1, CLI/gateway version 2026.5.19. Default agent model `deepseek/deepseek-v4-flash`. Gateway token and provider key read from local OpenClaw config.
- Exact steps or command run after this patch: Ran `pnpm build`, then stopped the managed gateway service, started a dev gateway on port 18790, and posted 7 authenticated local requests to `http://127.0.0.1:18790/v1/chat/completions`: a happy-path request, three invalid-value probes (out-of-range `frequency_penalty`, out-of-range `presence_penalty`, fractional `seed`), and three boundary probes (`frequency_penalty: -2.0`, `presence_penalty: 2.0`, `seed: -1`).
- Evidence after fix:

  Happy-path request (`frequency_penalty: 0.5`, `presence_penalty: 0.3`, `seed: 42`):
  ```json
  {"id":"chatcmpl_91ca1153-...","object":"chat.completion","model":"openclaw","choices":[{"message":{"role":"assistant","content":"Hi"}}],"usage":{"prompt_tokens":16847,"completion_tokens":16,"total_tokens":16863}}
  ```

  Out-of-range `frequency_penalty: 3`:
  ```json
  {"error":{"message":"`frequency_penalty` must be between -2.0 and 2.0.","type":"invalid_request_error"}}
  ```

  Out-of-range `presence_penalty: -3`:
  ```json
  {"error":{"message":"`presence_penalty` must be between -2.0 and 2.0.","type":"invalid_request_error"}}
  ```

  Non-integer `seed: 42.5`:
  ```json
  {"error":{"message":"`seed` must be an integer.","type":"invalid_request_error"}}
  ```

  Boundary `frequency_penalty: -2.0` → 200 OK
  Boundary `presence_penalty: 2.0` → 200 OK
  Negative integer `seed: -1` → 200 OK (rejected upstream by DeepSeek as invalid u64, not a gateway issue)

- Observed result after fix: Valid `frequency_penalty`/`presence_penalty`/`seed` requests completed successfully through the local OpenAI-compatible gateway. Invalid-value probes were intercepted with deterministic OpenAI-compatible 400 errors matching the existing `temperature`/`top_p` validation pattern. Boundary values within spec were accepted.
- What was not tested: `/v1/responses` endpoint (uses a different code path); `top_k` and `repetition_penalty` were intentionally excluded from this PR as they are not standard OpenAI Chat Completions fields and require per-provider gating.