### PR TITLE
[codex] Fix Discord error finals clearing previews

### DIFF
--- a/docs/concepts/streaming.md
+++ b/docs/concepts/streaming.md
@@ -171,7 +171,8 @@ Discord:
 - Uses send + edit preview messages.
 - `block` mode uses draft chunking (`draftChunk`).
 - Preview streaming is skipped when Discord block streaming is explicitly enabled.
-- Final media, error, and explicit-reply payloads cancel pending previews without flushing a new draft, then use normal delivery.
+- Final media and explicit-reply payloads cancel pending previews without flushing a new draft, then use normal delivery.
+- Error finals discard pending preview edits but keep any already-visible preview message, then send the error separately.
 
 Slack:
 

--- a/docs/concepts/streaming.md
+++ b/docs/concepts/streaming.md
@@ -172,7 +172,7 @@ Discord:
 - `block` mode uses draft chunking (`draftChunk`).
 - Preview streaming is skipped when Discord block streaming is explicitly enabled.
 - Final media and explicit-reply payloads cancel pending previews without flushing a new draft, then use normal delivery.
-- Error finals discard pending preview edits but keep any already-visible preview message, then send the error separately.
+- Error finals and finals after an already-delivered same-turn reply discard pending preview edits but keep any already-visible preview message, then use normal delivery.
 
 Slack:
 

--- a/extensions/discord/src/monitor/message-handler.draft-preview.ts
+++ b/extensions/discord/src/monitor/message-handler.draft-preview.ts
@@ -78,6 +78,7 @@ export function createDiscordDraftPreviewController(params: {
   let hasStreamedMessage = false;
   let finalizedViaPreviewMessage = false;
   let finalReplyDelivered = false;
+  let visibleReplyDelivered = false;
   const previewToolProgressEnabled =
     Boolean(draftStream) && resolveChannelStreamingPreviewToolProgress(params.discordConfig);
   const suppressDefaultToolProgressMessages =
@@ -151,6 +152,10 @@ export function createDiscordDraftPreviewController(params: {
     },
     markFinalReplyDelivered() {
       finalReplyDelivered = true;
+      visibleReplyDelivered = true;
+    },
+    markVisibleReplyDelivered() {
+      visibleReplyDelivered = true;
     },
     markPreviewFinalized() {
       finalizedViaPreviewMessage = true;
@@ -376,7 +381,7 @@ export function createDiscordDraftPreviewController(params: {
         if (!finalReplyDelivered) {
           await draftStream?.discardPending();
         }
-        if (!finalReplyDelivered && !finalizedViaPreviewMessage && draftStream?.messageId()) {
+        if (!visibleReplyDelivered && !finalizedViaPreviewMessage && draftStream?.messageId()) {
           await draftStream.clear();
         }
       } catch (err) {

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -2038,9 +2038,10 @@ describe("processDiscordMessage draft streaming", () => {
     });
   });
 
-  it("does not flush draft previews for error finals before normal delivery", async () => {
+  it("retains already-visible draft previews for error finals before normal delivery", async () => {
     const draftStream = createMockDraftStreamForTest();
     dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      await params?.replyOptions?.onPartialReply?.({ text: "partial answer..." });
       await params?.dispatcher.sendFinalReply({
         text: "Something failed",
         isError: true,
@@ -2054,9 +2055,10 @@ describe("processDiscordMessage draft streaming", () => {
 
     await runProcessDiscordMessage(ctx);
 
+    expect(draftStream.update).toHaveBeenCalledWith("partial answer...");
     expect(draftStream.flush).not.toHaveBeenCalled();
     expect(draftStream.discardPending).toHaveBeenCalledTimes(1);
-    expect(draftStream.clear).toHaveBeenCalledTimes(1);
+    expect(draftStream.clear).not.toHaveBeenCalled();
     expect(editMessageDiscord).not.toHaveBeenCalled();
     expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
   });

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -230,14 +230,14 @@ vi.mock("openclaw/plugin-sdk/reply-runtime", () => ({
     onReplyStart?: () => Promise<void> | void;
   }) => {
     const pendingDeliveries: Promise<void>[] = [];
-    const queueDelivery = (payload: unknown, info: { kind: "block" | "final" }) => {
+    const queueDelivery = (payload: unknown, info: { kind: "tool" | "block" | "final" }) => {
       const delivery = Promise.resolve(opts.deliver(payload, info)).catch(() => undefined);
       pendingDeliveries.push(delivery);
       return true;
     };
     return {
       dispatcher: {
-        sendToolResult: vi.fn(() => true),
+        sendToolResult: vi.fn((payload: unknown) => queueDelivery(payload, { kind: "tool" })),
         sendBlockReply: vi.fn((payload: unknown) => queueDelivery(payload, { kind: "block" })),
         sendFinalReply: vi.fn((payload: unknown) => queueDelivery(payload, { kind: "final" })),
         waitForIdle: vi.fn(async () => {
@@ -2061,6 +2061,44 @@ describe("processDiscordMessage draft streaming", () => {
     expect(draftStream.clear).not.toHaveBeenCalled();
     expect(editMessageDiscord).not.toHaveBeenCalled();
     expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
+  });
+
+  it("retains already-visible draft previews when a tool error was delivered before the final", async () => {
+    const draftStream = createMockDraftStreamForTest();
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      await params?.replyOptions?.onPartialReply?.({
+        text: "I don't think the error will show differently if we try again.",
+      });
+      await params?.dispatcher.sendToolResult({
+        text: "Canvas failed",
+        isError: true,
+      } as never);
+      await params?.dispatcher.sendFinalReply({
+        text: 'There - same result. Consistent repro: {"status":"error","tool":"canvas","error":"node required"}',
+      });
+      return { queuedFinal: true, counts: { final: 1, tool: 1, block: 0 } };
+    });
+
+    const ctx = await createAutomaticSourceDeliveryContext({
+      discordConfig: { streamMode: "partial", maxLinesPerMessage: 5 },
+    });
+
+    await runProcessDiscordMessage(ctx);
+
+    expect(draftStream.update).toHaveBeenCalledWith(
+      "I don't think the error will show differently if we try again.",
+    );
+    expect(editMessageDiscord).not.toHaveBeenCalled();
+    expect(draftStream.discardPending).toHaveBeenCalledTimes(1);
+    expect(draftStream.clear).not.toHaveBeenCalled();
+    expect(deliverDiscordReply).toHaveBeenCalledTimes(2);
+    const toolDelivery = requireRecord(
+      firstMockCall(deliverDiscordReply, "tool delivery")[0],
+      "tool delivery",
+    );
+    const finalDelivery = requireRecord(deliverDiscordReply.mock.calls[1]?.[0], "final delivery");
+    expect(toolDelivery.kind).toBe("tool");
+    expect(finalDelivery.kind).toBe("final");
   });
 
   it("suppresses reasoning payload delivery to Discord", async () => {

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -2129,6 +2129,48 @@ describe("processDiscordMessage draft streaming", () => {
     expect(toolDelivery.kind).toBe("tool");
   });
 
+  it("waits for queued tool error delivery before cleaning up draft previews", async () => {
+    const draftStream = createMockDraftStreamForTest();
+    let markToolDeliveryStarted!: () => void;
+    let releaseToolDelivery!: () => void;
+    const toolDeliveryStarted = new Promise<void>((resolve) => {
+      markToolDeliveryStarted = resolve;
+    });
+    const toolDeliveryReleased = new Promise<void>((resolve) => {
+      releaseToolDelivery = resolve;
+    });
+    deliverDiscordReply.mockImplementationOnce(async () => {
+      markToolDeliveryStarted();
+      await toolDeliveryReleased;
+    });
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      await params?.replyOptions?.onPartialReply?.({ text: "partial answer..." });
+      await params?.dispatcher.sendToolResult({
+        text: "Canvas failed",
+        isError: true,
+      } as never);
+      return { queuedFinal: false, counts: { final: 0, tool: 1, block: 0 } };
+    });
+
+    const ctx = await createAutomaticSourceDeliveryContext({
+      discordConfig: { streamMode: "partial", maxLinesPerMessage: 5 },
+    });
+
+    const processing = runProcessDiscordMessage(ctx);
+    await toolDeliveryStarted;
+    await Promise.resolve();
+
+    expect(draftStream.update).toHaveBeenCalledWith("partial answer...");
+    expect(draftStream.clear).not.toHaveBeenCalled();
+
+    releaseToolDelivery();
+    await processing;
+
+    expect(draftStream.discardPending).toHaveBeenCalledTimes(1);
+    expect(draftStream.clear).not.toHaveBeenCalled();
+    expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
+  });
+
   it("suppresses reasoning payload delivery to Discord", async () => {
     mockDispatchSingleBlockReply({ text: "thinking...", isReasoning: true });
     await processStreamOffDiscordMessage();

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -2101,6 +2101,34 @@ describe("processDiscordMessage draft streaming", () => {
     expect(finalDelivery.kind).toBe("final");
   });
 
+  it("retains already-visible draft previews when a tool error is the only delivered reply", async () => {
+    const draftStream = createMockDraftStreamForTest();
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      await params?.replyOptions?.onPartialReply?.({ text: "partial answer..." });
+      await params?.dispatcher.sendToolResult({
+        text: "Canvas failed",
+        isError: true,
+      } as never);
+      return { queuedFinal: false, counts: { final: 0, tool: 1, block: 0 } };
+    });
+
+    const ctx = await createAutomaticSourceDeliveryContext({
+      discordConfig: { streamMode: "partial", maxLinesPerMessage: 5 },
+    });
+
+    await runProcessDiscordMessage(ctx);
+
+    expect(draftStream.update).toHaveBeenCalledWith("partial answer...");
+    expect(draftStream.discardPending).toHaveBeenCalledTimes(1);
+    expect(draftStream.clear).not.toHaveBeenCalled();
+    expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
+    const toolDelivery = requireRecord(
+      firstMockCall(deliverDiscordReply, "tool delivery")[0],
+      "tool delivery",
+    );
+    expect(toolDelivery.kind).toBe("tool");
+  });
+
   it("suppresses reasoning payload delivery to Discord", async () => {
     mockDispatchSingleBlockReply({ text: "thinking...", isReasoning: true });
     await processStreamOffDiscordMessage();

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -644,6 +644,7 @@ export async function processDiscordMessage(
                 });
                 return true;
               },
+              retainDraftOnNormalDelivery: (normalPayload) => normalPayload.isError === true,
               logPreviewEditFailure: (err) => {
                 logVerbose(
                   `discord: preview final edit failed; falling back to standard send (${String(err)})`,

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -580,6 +580,7 @@ export async function processDiscordMessage(
               buildFinalEdit: () => {
                 if (
                   draftPreview.finalizedViaPreviewMessage ||
+                  replyReference.hasReplied() ||
                   (hasMedia && !ttsSupplement) ||
                   typeof previewFinalText !== "string" ||
                   hasExplicitReplyDirective ||
@@ -644,7 +645,8 @@ export async function processDiscordMessage(
                 });
                 return true;
               },
-              retainDraftOnNormalDelivery: (normalPayload) => normalPayload.isError === true,
+              retainDraftOnNormalDelivery: (normalPayload) =>
+                normalPayload.isError === true || replyReference.hasReplied(),
               logPreviewEditFailure: (err) => {
                 logVerbose(
                   `discord: preview final edit failed; falling back to standard send (${String(err)})`,

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -724,6 +724,7 @@ export async function processDiscordMessage(
           kind: info.kind,
         });
         replyReference.markSent();
+        draftPreview.markVisibleReplyDelivered();
         if (isFinal) {
           observer?.onFinalReplyDelivered?.();
         }

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -963,13 +963,20 @@ export async function processDiscordMessage(
     throw err;
   } finally {
     endDiscordInboundEventDeliveryCorrelation();
-    try {
+    if (dispatchSettledBeforeStart) {
       await draftPreview.cleanup();
-    } finally {
-      if (!dispatchSettledBeforeStart) {
-        markRunComplete();
-        markDispatchIdle();
-      }
+    } else {
+      await settleReplyDispatcher({
+        dispatcher,
+        onSettled: async () => {
+          try {
+            await draftPreview.cleanup();
+          } finally {
+            markRunComplete();
+            markDispatchIdle();
+          }
+        },
+      });
     }
     const finalDeliveryFailed = (dispatchResult?.failedCounts?.final ?? 0) > 0;
     if (statusReactionsActive) {

--- a/src/channels/message/lifecycle.test.ts
+++ b/src/channels/message/lifecycle.test.ts
@@ -174,6 +174,32 @@ describe("message lifecycle primitives", () => {
     expect(liveState.canFinalizeInPlace).toBe(false);
   });
 
+  it("can retain live previews after fallback delivery", async () => {
+    const discardPending = vi.fn(async () => undefined);
+    const clear = vi.fn(async () => undefined);
+    const deliverNormally = vi.fn(async () => true);
+
+    const result = await deliverFinalizableLivePreview({
+      kind: "final",
+      payload: { text: "failed", isError: true },
+      draft: {
+        flush: vi.fn(async () => undefined),
+        id: () => "preview-2",
+        discardPending,
+        clear,
+      },
+      buildFinalEdit: () => undefined,
+      editFinal: vi.fn(async () => undefined),
+      deliverNormally,
+      retainDraftOnNormalDelivery: (payload) => payload.isError === true,
+    });
+
+    expect(result.kind).toBe("normal-delivered");
+    expect(discardPending).toHaveBeenCalledTimes(1);
+    expect(deliverNormally).toHaveBeenCalledWith({ text: "failed", isError: true });
+    expect(clear).not.toHaveBeenCalled();
+  });
+
   it("does not complete live preview fallback state when normal delivery throws", async () => {
     const discardPending = vi.fn(async () => undefined);
     const clear = vi.fn(async () => undefined);

--- a/src/channels/message/live.ts
+++ b/src/channels/message/live.ts
@@ -33,6 +33,7 @@ export type FinalizableLivePreviewAdapter<TPayload, TId, TEdit> = {
   ) => Promise<void> | void;
   buildSupplementalPayload?: (payload: TPayload) => TPayload | undefined;
   deliverSupplemental?: (payload: TPayload) => Promise<boolean | void>;
+  retainDraftOnNormalDelivery?: (payload: TPayload) => boolean;
   handlePreviewEditError?: (params: {
     error: unknown;
     id: TId;
@@ -118,6 +119,7 @@ export async function deliverFinalizableLivePreview<TPayload, TId, TEdit>(params
   ) => Promise<void> | void;
   buildSupplementalPayload?: (payload: TPayload) => TPayload | undefined;
   deliverSupplemental?: (payload: TPayload) => Promise<boolean | void>;
+  retainDraftOnNormalDelivery?: (payload: TPayload) => boolean;
   handlePreviewEditError?: (params: {
     error: unknown;
     id: TId;
@@ -191,8 +193,11 @@ export async function deliverFinalizableLivePreview<TPayload, TId, TEdit>(params
     }
   }
 
+  const retainDraftOnNormalDelivery = params.retainDraftOnNormalDelivery?.(params.payload) === true;
   if (params.draft.discardPending) {
     await params.draft.discardPending();
+  } else if (retainDraftOnNormalDelivery) {
+    await params.draft.seal?.();
   } else {
     await params.draft.clear();
   }
@@ -206,7 +211,7 @@ export async function deliverFinalizableLivePreview<TPayload, TId, TEdit>(params
       await params.onNormalDelivered?.();
     }
   } finally {
-    if (delivered) {
+    if (delivered && !retainDraftOnNormalDelivery) {
       await params.draft.clear();
     }
   }
@@ -254,6 +259,9 @@ export async function deliverWithFinalizableLivePreviewAdapter<TPayload, TId, TE
       : {}),
     ...(params.adapter.deliverSupplemental
       ? { deliverSupplemental: params.adapter.deliverSupplemental }
+      : {}),
+    ...(params.adapter.retainDraftOnNormalDelivery
+      ? { retainDraftOnNormalDelivery: params.adapter.retainDraftOnNormalDelivery }
       : {}),
     ...(params.adapter.handlePreviewEditError
       ? { handlePreviewEditError: params.adapter.handlePreviewEditError }


### PR DESCRIPTION
## Summary

Discord preview streaming can leave an already-visible draft/progress preview in Discord while the same agent run later falls back to normal delivery or exits after a visible tool/error reply. The root problem was broader than the first symptom: draft cleanup could run before the queued reply dispatcher had actually delivered pending tool/error output.

This fixes the related paths:

- error finals use normal delivery without clearing already-visible previews
- finals after same-turn tool/error replies do not edit over already-visible previews
- tool/error-only turns track visible delivery separately from final delivery
- Discord message handling now settles queued dispatcher replies before draft cleanup, so cleanup cannot delete the preview while a tool/error reply is still being delivered

## Verification

- `node scripts/run-vitest.mjs extensions/discord/src/monitor/message-handler.process.test.ts src/channels/message/lifecycle.test.ts`
- `git diff --check`

Latest focused result: 2 files passed, 89 tests passed.

`pnpm tsgo:prod` was attempted on the PR branch, but pnpm entered dependency reconciliation and hung in `pnpm install` while retrying optional package downloads. I stopped that stuck spawned process after the focused tests had already passed.

## Real behavior proof

Before-fix proof: A private OpenClaw 2026.5.19-beta.1 Discord gateway screen recording captured this behavior: Dicky posted partial preview text, a canvas tool failure was delivered, then the visible preview was either edited/replaced by a later final or deleted during cleanup when no final was delivered.

Corroborating gateway logs from the repros show canvas tool failures:
- `[tools] canvas failed: node required raw_params={"action":"present","url":"data:text/html,<h1>test</h1>"}`
- `[tools] canvas failed: node required raw_params={"action":"present","url":"data:text/html,<h1>another test for the PR</h1>"}`
- `[tools] canvas failed: node required raw_params={"action":"present","url":"data:text/html,<h1>testing vale's fix</h1>"}`
- `[tools] canvas failed: node required raw_params={"action":"present","url":"data:text/html,<h1>testing vale fix v2</h1>"}`

The final failed repro proved the missing race: the installed runtime already had the visible-reply cleanup markers, but the queued tool delivery had not settled before draft cleanup ran. The new regression test delays tool delivery and asserts cleanup does not clear the preview during that delay.

Runtime hotpatch evidence: The private beta gateway was patched with the compiled equivalent of this PR, including the dispatcher-settle-before-cleanup ordering fix. The installed Discord message-handler chunk was backed up, patched, syntax-checked with `node --check`, and `openclaw-gateway.service` was restarted.

Post-hotpatch health: `openclaw gateway status` reports OpenClaw 2026.5.19-beta.1, runtime running, connectivity probe ok, admin-capable, and listening on the configured loopback gateway port.

What still needs live smoke: Re-running the same Discord canvas repro after the latest hotpatch should show the partial preview preserved while the canvas error remains visible.
