### PR TITLE
fix(gateway): show message-tool replies in internal chat UIs

### DIFF
--- a/docs/web/tui.md
+++ b/docs/web/tui.md
@@ -203,7 +203,7 @@ Tips:
 
 ## Connection details
 
-- The TUI registers with the Gateway as `mode: "tui"`.
+- The TUI registers with the Gateway as client id `openclaw-tui` and mode `ui`.
 - Reconnects show a system message; event gaps are surfaced in the log.
 
 ## Options

--- a/docs/web/tui.md
+++ b/docs/web/tui.md
@@ -73,7 +73,7 @@ Notes:
 ## Sending + delivery
 
 - Messages are sent to the Gateway; delivery to providers is off by default.
-- The TUI is an internal source surface like WebChat, not a generic outbound channel. Harnesses that require `tools.message` for visible replies can satisfy the active TUI turn with a targetless `message.send`; explicit provider delivery still uses normal configured channels and never falls back to `lastChannel`.
+- The TUI is an internal chat surface like WebChat, not a generic outbound channel. Harnesses that require `tools.message` for visible replies can satisfy the active TUI turn with a targetless `message.send`; explicit provider delivery still uses normal configured channels and never falls back to `lastChannel`.
 - Turn delivery on:
   - `/deliver on`
   - or the Settings panel

--- a/extensions/codex/src/app-server/dynamic-tools.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.ts
@@ -42,6 +42,8 @@ type CodexDynamicToolHookContext = {
 
 type CodexToolResultHookContext = Omit<CodexDynamicToolHookContext, "config">;
 
+const INTERNAL_SOURCE_REPLY_SINK = "internal-ui";
+
 export type CodexDynamicToolBridge = {
   availableSpecs: CodexDynamicToolSpec[];
   specs: CodexDynamicToolSpec[];
@@ -403,7 +405,7 @@ function collectToolTelemetry(params: {
 function extractInternalSourceReplyPayload(
   details: unknown,
 ): MessagingToolSourceReplyPayload | undefined {
-  if (!isRecord(details) || details.sourceReplySink !== "internal-ui") {
+  if (!isRecord(details) || details.sourceReplySink !== INTERNAL_SOURCE_REPLY_SINK) {
     return undefined;
   }
   const rawPayload = details.sourceReply;

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -458,11 +458,11 @@ describe("message tool secret scoping", () => {
     expect(second?.params?.idempotencyKey).toBe("run-message-tool:message-tool:message_222_1");
   });
 
-  it("surfaces internal UI source replies without reporting a webchat delivery channel", async () => {
+  it("keeps legacy channel while surfacing the internal UI source reply sink", async () => {
     const replyPayload = {
       status: "ok",
       deliveryStatus: "sent",
-      channel: "internal-ui",
+      channel: "webchat",
       target: "current-run",
       sourceReplyDeliveryMode: "message_tool_only",
       sourceReplySink: "internal-ui",
@@ -498,10 +498,9 @@ describe("message tool secret scoping", () => {
       throw new Error("expected text tool result");
     }
 
-    expect(firstBlock.text).not.toContain("webchat");
     const toolOutput = JSON.parse(firstBlock.text) as Record<string, unknown>;
     expect(toolOutput).toMatchObject({
-      channel: "internal-ui",
+      channel: "webchat",
       sourceReplySink: "internal-ui",
       sourceReply: {
         text: "visible reply",

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -536,6 +536,35 @@ describe("message tool secret scoping", () => {
     expect(Array.from(secretResolveCall.targetIds ?? [])).toEqual(["channels.telegram.botToken"]);
   });
 
+  it("keeps an explicit internal current-run context instead of inferring session delivery", async () => {
+    mockSendResult({ channel: "webchat", to: "current-run" });
+
+    const input = await executeSend({
+      action: { message: "hi" },
+      toolOptions: {
+        config: {
+          channels: {
+            imessage: {
+              accountKey: { source: "env", provider: "default", id: "IMESSAGE_ACCOUNT_KEY" },
+            },
+          },
+        } as never,
+        sourceReplyDeliveryMode: "message_tool_only",
+        currentChannelProvider: "webchat",
+        currentChannelId: "current-run",
+        agentSessionKey: "agent:main:imessage:direct:+15551234567",
+      },
+    });
+
+    expect(input?.sourceReplyDeliveryMode).toBe("message_tool_only");
+    expect(input?.toolContext?.currentChannelProvider).toBe("webchat");
+    expect(input?.toolContext?.currentChannelId).toBe("current-run");
+    expect(input?.params).toEqual({ action: "send", message: "hi" });
+
+    const secretResolveCall = latestSecretResolveCall();
+    expect(Array.from(secretResolveCall.targetIds ?? [])).toEqual([]);
+  });
+
   it("preserves direct session keys as explicit user targets when ambient channel drifted to webchat", async () => {
     mockSendResult({ channel: "discord", to: "user:123456789" });
 

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -458,6 +458,57 @@ describe("message tool secret scoping", () => {
     expect(second?.params?.idempotencyKey).toBe("run-message-tool:message-tool:message_222_1");
   });
 
+  it("surfaces internal UI source replies without reporting a webchat delivery channel", async () => {
+    const replyPayload = {
+      status: "ok",
+      deliveryStatus: "sent",
+      channel: "internal-ui",
+      target: "current-run",
+      sourceReplyDeliveryMode: "message_tool_only",
+      sourceReplySink: "internal-ui",
+      sourceReply: {
+        text: "visible reply",
+      },
+      message: "visible reply",
+      dryRun: false,
+    };
+    mocks.runMessageAction.mockResolvedValue({
+      kind: "send",
+      action: "send",
+      channel: "webchat",
+      to: "current-run",
+      handledBy: "internal-source",
+      payload: replyPayload,
+      dryRun: false,
+    } satisfies MessageActionRunResult);
+
+    const tool = createMessageTool({
+      config: {} as never,
+      runMessageAction: mocks.runMessageAction as never,
+      sourceReplyDeliveryMode: "message_tool_only",
+      currentChannelProvider: "webchat",
+      agentSessionKey: "agent:main",
+    });
+    const result = await tool.execute("1", {
+      action: "send",
+      message: "visible reply",
+    });
+    const firstBlock = result.content[0];
+    if (!firstBlock || firstBlock.type !== "text") {
+      throw new Error("expected text tool result");
+    }
+
+    expect(firstBlock.text).not.toContain("webchat");
+    const toolOutput = JSON.parse(firstBlock.text) as Record<string, unknown>;
+    expect(toolOutput).toMatchObject({
+      channel: "internal-ui",
+      sourceReplySink: "internal-ui",
+      sourceReply: {
+        text: "visible reply",
+      },
+    });
+  });
+
   it("uses a non-webchat session key when ambient current channel drifted to webchat", async () => {
     mockSendResult();
 

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -643,6 +643,7 @@ function resolveEffectiveCurrentChannelContext(options?: MessageToolOptions): {
   const sessionDeliveryChannel = normalizeMessageChannel(sessionDelivery?.channel);
   const preferSessionDeliveryContext =
     normalizeMessageChannel(currentChannelProvider) === "webchat" &&
+    !normalizeOptionalString(currentChannelId) &&
     sessionDeliveryChannel !== undefined &&
     sessionDeliveryChannel !== "webchat" &&
     Boolean(sessionDelivery?.to);

--- a/src/agents/tools/sessions-resolution.ts
+++ b/src/agents/tools/sessions-resolution.ts
@@ -1,7 +1,7 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { callGateway } from "../../gateway/call.js";
 import {
-  GATEWAY_CLIENT_IDS,
+  GATEWAY_CURRENT_SESSION_CLIENT_IDS,
   normalizeGatewayClientId,
 } from "../../gateway/protocol/client-info.js";
 import { formatErrorMessage } from "../../infra/errors.js";
@@ -19,15 +19,7 @@ const defaultSessionsResolutionDeps = {
   callGateway,
 };
 
-const CURRENT_SESSION_CLIENT_ALIAS_IDS = new Set<string>([
-  GATEWAY_CLIENT_IDS.TUI,
-  GATEWAY_CLIENT_IDS.CLI,
-  GATEWAY_CLIENT_IDS.WEBCHAT_UI,
-  GATEWAY_CLIENT_IDS.CONTROL_UI,
-  GATEWAY_CLIENT_IDS.MACOS_APP,
-  GATEWAY_CLIENT_IDS.IOS_APP,
-  GATEWAY_CLIENT_IDS.ANDROID_APP,
-]);
+const CURRENT_SESSION_CLIENT_ALIAS_IDS = new Set<string>(GATEWAY_CURRENT_SESSION_CLIENT_IDS);
 
 let sessionsResolutionDeps: {
   callGateway: GatewayCaller;

--- a/src/auto-reply/reply/agent-runner-utils.test.ts
+++ b/src/auto-reply/reply/agent-runner-utils.test.ts
@@ -256,6 +256,28 @@ describe("agent-runner-utils", () => {
     expect(resolved.embeddedContext.messageTo).toBe("268300329");
   });
 
+  it("pins message-tool-only internal UI runs to the current run", () => {
+    const run = makeRun({
+      sessionKey: "agent:main:imessage:direct:+15551234567",
+      sourceReplyDeliveryMode: "message_tool_only",
+    });
+
+    const resolved = buildEmbeddedRunContexts({
+      run,
+      sessionCtx: {
+        Provider: "webchat",
+        Surface: "webchat",
+        OriginatingChannel: "webchat",
+        ExplicitDeliverRoute: false,
+      },
+      hasRepliedRef: undefined,
+      provider: "openai",
+    });
+
+    expect(resolved.embeddedContext.currentChannelProvider).toBe("webchat");
+    expect(resolved.embeddedContext.currentChannelId).toBe("current-run");
+  });
+
   it("uses telegram plugin threading context for native commands", () => {
     hoisted.getChannelPluginMock.mockReturnValue({
       threading: {

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -20,6 +20,7 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "../../shared/string-coerce.js";
+import { INTERNAL_MESSAGE_CHANNEL, normalizeMessageChannel } from "../../utils/message-channel.js";
 import { isReasoningTagProvider } from "../../utils/provider-utils.js";
 import type { TemplateContext } from "../templating.js";
 import {
@@ -195,6 +196,22 @@ function buildEmbeddedContextFromTemplate(params: {
   hasRepliedRef: { value: boolean } | undefined;
 }) {
   const config = params.run.config;
+  const threadingContext = buildThreadingToolContext({
+    sessionCtx: params.sessionCtx,
+    config,
+    hasRepliedRef: params.hasRepliedRef,
+  });
+  const currentSurface =
+    normalizeMessageChannel(params.sessionCtx.Provider) ??
+    normalizeMessageChannel(params.sessionCtx.Surface);
+  const originatingChannel = normalizeMessageChannel(params.sessionCtx.OriginatingChannel);
+  const shouldPinInternalSourceReplyContext =
+    params.run.sourceReplyDeliveryMode === "message_tool_only" &&
+    params.sessionCtx.ExplicitDeliverRoute !== true &&
+    currentSurface === INTERNAL_MESSAGE_CHANNEL &&
+    (!originatingChannel || originatingChannel === INTERNAL_MESSAGE_CHANNEL) &&
+    normalizeMessageChannel(threadingContext.currentChannelProvider) === INTERNAL_MESSAGE_CHANNEL &&
+    !normalizeOptionalString(threadingContext.currentChannelId);
   return {
     sessionId: params.run.sessionId,
     sessionKey: params.run.sessionKey,
@@ -212,11 +229,8 @@ function buildEmbeddedContextFromTemplate(params: {
     messageThreadId: params.sessionCtx.MessageThreadId ?? undefined,
     memberRoleIds: normalizeMemberRoleIds(params.sessionCtx.MemberRoleIds),
     // Provider threading context for tool auto-injection
-    ...buildThreadingToolContext({
-      sessionCtx: params.sessionCtx,
-      config,
-      hasRepliedRef: params.hasRepliedRef,
-    }),
+    ...threadingContext,
+    ...(shouldPinInternalSourceReplyContext ? { currentChannelId: "current-run" } : {}),
   };
 }
 

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -16,6 +16,7 @@ import {
   selectApplicableRuntimeConfig,
   type OpenClawConfig,
 } from "../../config/config.js";
+import { INTERNAL_SOURCE_REPLY_TARGET } from "../../infra/outbound/internal-source-reply.js";
 import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
@@ -232,7 +233,9 @@ function buildEmbeddedContextFromTemplate(params: {
     memberRoleIds: normalizeMemberRoleIds(params.sessionCtx.MemberRoleIds),
     // Provider threading context for tool auto-injection
     ...threadingContext,
-    ...(shouldPinInternalSourceReplyContext ? { currentChannelId: "current-run" } : {}),
+    ...(shouldPinInternalSourceReplyContext
+      ? { currentChannelId: INTERNAL_SOURCE_REPLY_TARGET }
+      : {}),
   };
 }
 

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -205,6 +205,8 @@ function buildEmbeddedContextFromTemplate(params: {
     normalizeMessageChannel(params.sessionCtx.Provider) ??
     normalizeMessageChannel(params.sessionCtx.Surface);
   const originatingChannel = normalizeMessageChannel(params.sessionCtx.OriginatingChannel);
+  // Internal UI source replies must stay on the active run even when the
+  // session key still carries a stale external delivery route.
   const shouldPinInternalSourceReplyContext =
     params.run.sourceReplyDeliveryMode === "message_tool_only" &&
     params.sessionCtx.ExplicitDeliverRoute !== true &&

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -6463,7 +6463,63 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     });
   });
 
-  it("keeps internal source reply metadata on TTS-cloned final payloads", async () => {
+  it("does not prewrite sensitive internal source reply media into transcript mirrors", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "allow",
+    };
+    const dispatcher = createDispatcher();
+    const sensitiveImageUrl =
+      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=";
+    const sourceReply = setReplyPayloadMetadata(
+      {
+        mediaUrl: sensitiveImageUrl,
+        mediaUrls: [sensitiveImageUrl],
+        sensitiveMedia: true,
+      },
+      {
+        deliverDespiteSourceReplySuppression: true,
+        sourceReplyTranscriptMirror: {
+          sessionKey: "agent:main",
+          agentId: "main",
+          mediaUrls: [sensitiveImageUrl],
+          idempotencyKey: "run-sensitive:internal-source-reply:0",
+        },
+      },
+    );
+    const replyResolver = vi.fn(async () => sourceReply satisfies ReplyPayload);
+    transcriptMocks.appendAssistantMessageToSessionTranscript.mockClear();
+
+    const result = await dispatchReplyFromConfig({
+      ctx: buildTestCtx({ Provider: "webchat", Surface: "webchat", SessionKey: "agent:main" }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: {
+        sourceReplyDeliveryMode: "message_tool_only",
+      },
+    });
+
+    const finalPayload = firstFinalReplyPayload(dispatcher);
+    expect(result.queuedFinal).toBe(true);
+    expect(finalPayload?.mediaUrl).toBe(sensitiveImageUrl);
+    expect(getReplyPayloadMetadata(finalPayload ?? {})).toMatchObject({
+      deliverDespiteSourceReplySuppression: true,
+      sourceReplyTranscriptMirror: {
+        sessionKey: "agent:main",
+        agentId: "main",
+        idempotencyKey: "run-sensitive:internal-source-reply:0",
+      },
+    });
+    expect(
+      getReplyPayloadMetadata(finalPayload ?? {})?.sourceReplyTranscriptMirror?.mediaUrls,
+    ).toBeUndefined();
+    expect(transcriptMocks.appendAssistantMessageToSessionTranscript).not.toHaveBeenCalled();
+  });
+
+  it("preserves internal source reply metadata after final TTS synthesis", async () => {
     setNoAbort();
     ttsMocks.state.synthesizeFinalAudio = true;
     sessionStoreMocks.currentEntry = {
@@ -6473,13 +6529,13 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     };
     const dispatcher = createDispatcher();
     const sourceReply = setReplyPayloadMetadata(
-      { text: "message tool reply" },
+      { text: "message tool reply long enough for synthesized audio" },
       {
         deliverDespiteSourceReplySuppression: true,
         sourceReplyTranscriptMirror: {
           sessionKey: "agent:main",
           agentId: "main",
-          text: "message tool reply",
+          text: "message tool reply long enough for synthesized audio",
           idempotencyKey: "run-tts:internal-source-reply:0",
         },
       },
@@ -6496,17 +6552,24 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
       },
     });
 
+    const finalPayload = firstFinalReplyPayload(dispatcher);
     expect(result.queuedFinal).toBe(true);
-    const queuedPayload = (dispatcher.sendFinalReply as ReturnType<typeof vi.fn>).mock
-      .calls[0]?.[0];
-    expect(queuedPayload).toMatchObject({
-      text: "message tool reply",
-      mediaUrl: "https://example.com/tts-synth.opus",
-      audioAsVoice: true,
+    expect(finalPayload).not.toBe(sourceReply);
+    expect(finalPayload?.mediaUrl).toBe("https://example.com/tts-synth.opus");
+    expect(getReplyPayloadMetadata(finalPayload ?? {})).toMatchObject({
+      deliverDespiteSourceReplySuppression: true,
+      sourceReplyTranscriptMirror: {
+        idempotencyKey: "run-tts:internal-source-reply:0",
+      },
     });
-    expect(getReplyPayloadMetadata(queuedPayload)?.sourceReplyTranscriptMirror).toMatchObject({
+    expect(transcriptMocks.appendAssistantMessageToSessionTranscript).toHaveBeenCalledWith({
       sessionKey: "agent:main",
+      agentId: "main",
+      text: "message tool reply long enough for synthesized audio",
+      mediaUrls: undefined,
       idempotencyKey: "run-tts:internal-source-reply:0",
+      updateMode: "inline",
+      config: emptyConfig,
     });
   });
 

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -107,6 +107,7 @@ import {
   getReplyPayloadMetadata,
   isReplyPayloadStatusNotice,
   markReplyPayloadAsTtsSupplement,
+  setReplyPayloadMetadata,
   type ReplyPayload,
 } from "../reply-payload.js";
 import type { FinalizedMsgContext } from "../templating.js";
@@ -696,6 +697,9 @@ async function mirrorInternalSourceReplyToTranscript(params: {
   if (!mirror) {
     return;
   }
+  if (!mirror.text?.trim() && !mirror.mediaUrls?.some((mediaUrl) => mediaUrl.trim())) {
+    return;
+  }
   const result = await appendAssistantMessageToSessionTranscript({
     sessionKey: mirror.sessionKey,
     agentId: mirror.agentId,
@@ -708,6 +712,25 @@ async function mirrorInternalSourceReplyToTranscript(params: {
   if (!result.ok) {
     logVerbose(`dispatch-from-config: internal source reply mirror skipped: ${result.reason}`);
   }
+}
+
+function sanitizeInternalSourceReplyMirrorPayload(payload: ReplyPayload): ReplyPayload {
+  if (payload.sensitiveMedia !== true) {
+    return payload;
+  }
+  const metadata = getReplyPayloadMetadata(payload);
+  const mirror = metadata?.sourceReplyTranscriptMirror;
+  if (!mirror?.mediaUrls?.some((mediaUrl) => mediaUrl.trim())) {
+    return payload;
+  }
+  const sanitizedPayload: ReplyPayload = { ...payload };
+  const sanitizedMirror = { ...mirror };
+  delete sanitizedMirror.mediaUrls;
+  setReplyPayloadMetadata(sanitizedPayload, {
+    ...metadata,
+    sourceReplyTranscriptMirror: sanitizedMirror,
+  });
+  return sanitizedPayload;
 }
 
 function runWithDispatchAbortSignal<T>(
@@ -1658,8 +1681,6 @@ export async function dispatchReplyFromConfig(
         }
       };
       throwIfFinalDeliveryAborted();
-      const sourceReplyTranscriptMirror =
-        getReplyPayloadMetadata(payload)?.sourceReplyTranscriptMirror;
       const hasVisibleFinalContent = hasOutboundReplyContent(payload, { trimText: true });
       if (hasVisibleFinalContent) {
         markInboundDedupeReplayUnsafe();
@@ -1676,8 +1697,12 @@ export async function dispatchReplyFromConfig(
         accountId: replyRoute.accountId,
       });
       throwIfFinalDeliveryAborted();
-      const normalizedPayload = await normalizeReplyMediaPayload(ttsPayload);
+      const normalizedPayload = sanitizeInternalSourceReplyMirrorPayload(
+        await normalizeReplyMediaPayload(ttsPayload),
+      );
       throwIfFinalDeliveryAborted();
+      const sourceReplyTranscriptMirror =
+        getReplyPayloadMetadata(normalizedPayload)?.sourceReplyTranscriptMirror;
       const result = await routeReplyToOriginating(normalizedPayload, {
         abortSignal,
       });

--- a/src/auto-reply/reply/reply-media-paths.test.ts
+++ b/src/auto-reply/reply/reply-media-paths.test.ts
@@ -20,6 +20,7 @@ vi.mock("../../media/read-capability.js", () => ({
   resolveAgentScopedOutboundMediaAccess,
 }));
 
+import { getReplyPayloadMetadata, setReplyPayloadMetadata } from "../reply-payload.js";
 import { createReplyMediaPathNormalizer } from "./reply-media-paths.js";
 
 type NormalizedReply = {
@@ -109,7 +110,7 @@ describe("createReplyMediaPathNormalizer", () => {
     expect(mediaAccess.workspaceDir).toBe("/tmp/agent-workspace");
   });
 
-  it("preserves reply metadata when media normalization clones the payload", async () => {
+  it("preserves reply payload metadata when media paths are normalized", async () => {
     const normalize = createReplyMediaPathNormalizer({
       cfg: {},
       sessionKey: "session-key",
@@ -117,15 +118,16 @@ describe("createReplyMediaPathNormalizer", () => {
     });
     const payload = setReplyPayloadMetadata(
       {
-        text: "Here is the image",
-        mediaUrls: ["./out/photo.png"],
+        text: "Audio visible in the TUI.",
+        mediaUrls: ["./out/audio.mp3"],
       },
       {
+        deliverDespiteSourceReplySuppression: true,
         sourceReplyTranscriptMirror: {
           sessionKey: "main",
-          text: "Here is the image",
-          mediaUrls: ["./out/photo.png"],
-          idempotencyKey: "source-reply:0",
+          agentId: "main",
+          text: "Audio visible in the TUI.",
+          idempotencyKey: "source-reply-idem",
         },
       },
     );
@@ -133,12 +135,12 @@ describe("createReplyMediaPathNormalizer", () => {
     const result = await normalize(payload);
 
     expect(result).not.toBe(payload);
-    expectMedia(result, "/tmp/outbound-media/photo.png", ["/tmp/outbound-media/photo.png"]);
-    expect(getReplyPayloadMetadata(result)?.sourceReplyTranscriptMirror).toEqual({
-      sessionKey: "main",
-      text: "Here is the image",
-      mediaUrls: ["./out/photo.png"],
-      idempotencyKey: "source-reply:0",
+    expectMedia(result, "/tmp/outbound-media/audio.mp3", ["/tmp/outbound-media/audio.mp3"]);
+    expect(getReplyPayloadMetadata(result)).toMatchObject({
+      deliverDespiteSourceReplySuppression: true,
+      sourceReplyTranscriptMirror: {
+        idempotencyKey: "source-reply-idem",
+      },
     });
   });
 

--- a/src/auto-reply/reply/reply-media-paths.test.ts
+++ b/src/auto-reply/reply/reply-media-paths.test.ts
@@ -20,7 +20,6 @@ vi.mock("../../media/read-capability.js", () => ({
   resolveAgentScopedOutboundMediaAccess,
 }));
 
-import { getReplyPayloadMetadata, setReplyPayloadMetadata } from "../reply-payload.js";
 import { createReplyMediaPathNormalizer } from "./reply-media-paths.js";
 
 type NormalizedReply = {

--- a/src/gateway/protocol/client-info.ts
+++ b/src/gateway/protocol/client-info.ts
@@ -28,8 +28,6 @@ export const GATEWAY_CURRENT_SESSION_CLIENT_IDS = [
   GATEWAY_CLIENT_IDS.ANDROID_APP,
 ] as const;
 
-export type GatewayCurrentSessionClientId = (typeof GATEWAY_CURRENT_SESSION_CLIENT_IDS)[number];
-
 export const GATEWAY_INTERNAL_CHAT_SURFACE_CLIENT_IDS = [
   GATEWAY_CLIENT_IDS.WEBCHAT_UI,
   GATEWAY_CLIENT_IDS.CONTROL_UI,
@@ -38,9 +36,6 @@ export const GATEWAY_INTERNAL_CHAT_SURFACE_CLIENT_IDS = [
   GATEWAY_CLIENT_IDS.IOS_APP,
   GATEWAY_CLIENT_IDS.ANDROID_APP,
 ] as const;
-
-export type GatewayInternalChatSurfaceClientId =
-  (typeof GATEWAY_INTERNAL_CHAT_SURFACE_CLIENT_IDS)[number];
 
 // Back-compat naming (internal): these values are IDs, not display names.
 export const GATEWAY_CLIENT_NAMES = GATEWAY_CLIENT_IDS;

--- a/src/gateway/protocol/client-info.ts
+++ b/src/gateway/protocol/client-info.ts
@@ -18,6 +18,30 @@ export const GATEWAY_CLIENT_IDS = {
 
 export type GatewayClientId = (typeof GATEWAY_CLIENT_IDS)[keyof typeof GATEWAY_CLIENT_IDS];
 
+export const GATEWAY_CURRENT_SESSION_CLIENT_IDS = [
+  GATEWAY_CLIENT_IDS.TUI,
+  GATEWAY_CLIENT_IDS.CLI,
+  GATEWAY_CLIENT_IDS.WEBCHAT_UI,
+  GATEWAY_CLIENT_IDS.CONTROL_UI,
+  GATEWAY_CLIENT_IDS.MACOS_APP,
+  GATEWAY_CLIENT_IDS.IOS_APP,
+  GATEWAY_CLIENT_IDS.ANDROID_APP,
+] as const;
+
+export type GatewayCurrentSessionClientId = (typeof GATEWAY_CURRENT_SESSION_CLIENT_IDS)[number];
+
+export const GATEWAY_INTERNAL_CHAT_SURFACE_CLIENT_IDS = [
+  GATEWAY_CLIENT_IDS.WEBCHAT_UI,
+  GATEWAY_CLIENT_IDS.CONTROL_UI,
+  GATEWAY_CLIENT_IDS.TUI,
+  GATEWAY_CLIENT_IDS.MACOS_APP,
+  GATEWAY_CLIENT_IDS.IOS_APP,
+  GATEWAY_CLIENT_IDS.ANDROID_APP,
+] as const;
+
+export type GatewayInternalChatSurfaceClientId =
+  (typeof GATEWAY_INTERNAL_CHAT_SURFACE_CLIENT_IDS)[number];
+
 // Back-compat naming (internal): these values are IDs, not display names.
 export const GATEWAY_CLIENT_NAMES = GATEWAY_CLIENT_IDS;
 export type GatewayClientName = GatewayClientId;

--- a/src/gateway/server-methods/chat-assistant-content.ts
+++ b/src/gateway/server-methods/chat-assistant-content.ts
@@ -1,0 +1,244 @@
+import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
+import { normalizeReplyPayloadsForDelivery } from "../../infra/outbound/payloads.js";
+import { stripInlineDirectiveTagsForDisplay } from "../../utils/directive-tags.js";
+import { stripEnvelopeFromMessage } from "../chat-sanitize.js";
+import { createManagedOutgoingImageBlocks } from "../managed-image-attachments.js";
+import { formatForLog } from "../ws-log.js";
+import { buildWebchatAudioContentBlocksFromReplyPayloads } from "./chat-webchat-media.js";
+
+export type AssistantDisplayContentBlock = Record<string, unknown>;
+
+const MANAGED_OUTGOING_IMAGE_PATH_PREFIX = "/api/chat/media/outgoing/";
+
+export function sanitizeAssistantDisplayText(value?: string | null): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const withoutEnvelope = stripEnvelopeFromMessage(value);
+  const normalized = typeof withoutEnvelope === "string" ? withoutEnvelope : value;
+  const stripped = stripInlineDirectiveTagsForDisplay(normalized).text.trim();
+  return stripped || undefined;
+}
+
+export function extractAssistantDisplayTextFromContent(
+  content?: readonly AssistantDisplayContentBlock[] | null,
+): string | undefined {
+  if (!Array.isArray(content) || content.length === 0) {
+    return undefined;
+  }
+  const parts = content
+    .map((block) => {
+      if (block?.type !== "text" || typeof block.text !== "string") {
+        return "";
+      }
+      return block.text.trim();
+    })
+    .filter(Boolean);
+  return parts.length > 0 ? parts.join("\n\n") : undefined;
+}
+
+export function applyDisplayTextToAssistantContent(
+  content: readonly AssistantDisplayContentBlock[] | undefined,
+  displayText: string | undefined,
+): AssistantDisplayContentBlock[] | undefined {
+  if (!displayText) {
+    return content ? [...content] : undefined;
+  }
+  if (!content || content.length === 0) {
+    return [{ type: "text", text: displayText }];
+  }
+  const next = [...content];
+  const textIndex = next.findIndex(
+    (block) => block?.type === "text" && typeof block.text === "string",
+  );
+  if (textIndex === -1) {
+    return [{ type: "text", text: displayText }, ...next];
+  }
+  next[textIndex] = {
+    ...next[textIndex],
+    text: displayText,
+  };
+  return next;
+}
+
+export async function buildAssistantDisplayContentFromReplyPayloads(params: {
+  sessionKey: string;
+  payloads: ReplyPayload[];
+  managedImageLocalRoots?: Parameters<typeof createManagedOutgoingImageBlocks>[0]["localRoots"];
+  includeSensitiveMedia?: boolean;
+  onLocalAudioAccessDenied?: (message: string) => void;
+  onManagedImagePrepareError?: (message: string) => void;
+}): Promise<AssistantDisplayContentBlock[] | undefined> {
+  const rawTextPayloadCount = params.payloads.filter(
+    (payload) =>
+      payload.isReasoning !== true &&
+      typeof payload.text === "string" &&
+      payload.text.trim().length > 0,
+  ).length;
+  const normalized = normalizeReplyPayloadsForDelivery(params.payloads);
+  if (normalized.length === 0) {
+    return rawTextPayloadCount > 0 ? [{ type: "text", text: "" }] : undefined;
+  }
+
+  const content: AssistantDisplayContentBlock[] = [];
+  let strippedTextPayloadCount = 0;
+  for (const payload of normalized) {
+    const text = sanitizeAssistantDisplayText(payload.text);
+    if (text) {
+      content.push({ type: "text", text });
+    } else if (typeof payload.text === "string" && payload.text.trim().length > 0) {
+      strippedTextPayloadCount += 1;
+    }
+    if (params.includeSensitiveMedia === false && payload.sensitiveMedia === true) {
+      continue;
+    }
+    const audioBlocks = await buildWebchatAudioContentBlocksFromReplyPayloads([payload], {
+      localRoots: Array.isArray(params.managedImageLocalRoots)
+        ? params.managedImageLocalRoots
+        : undefined,
+      onLocalAudioAccessDenied: (err) => {
+        params.onLocalAudioAccessDenied?.(formatForLog(err));
+      },
+    });
+    content.push(...audioBlocks);
+
+    const mediaUrls = Array.from(
+      new Set([
+        ...(Array.isArray(payload.mediaUrls) ? payload.mediaUrls : []),
+        ...(typeof payload.mediaUrl === "string" ? [payload.mediaUrl] : []),
+      ]),
+    );
+    const imageBlocks = await createManagedOutgoingImageBlocks({
+      sessionKey: params.sessionKey,
+      mediaUrls,
+      localRoots: params.managedImageLocalRoots,
+      continueOnPrepareError: true,
+      onPrepareError: (error) => {
+        params.onManagedImagePrepareError?.(error.message);
+      },
+    });
+    if (imageBlocks.length > 0) {
+      content.push(...imageBlocks);
+    }
+  }
+
+  if (content.length > 0) {
+    return content;
+  }
+  return strippedTextPayloadCount > 0 ? [{ type: "text", text: "" }] : undefined;
+}
+
+export function replaceAssistantContentTextBlocks(
+  content: readonly AssistantDisplayContentBlock[] | undefined,
+  transcriptMediaMessage: { content: Array<Record<string, unknown>> } | null,
+): AssistantDisplayContentBlock[] | undefined {
+  const transcriptTextBlocks = (transcriptMediaMessage?.content ?? []).filter(
+    (block): block is AssistantDisplayContentBlock =>
+      Boolean(block) &&
+      typeof block === "object" &&
+      block.type === "text" &&
+      typeof block.text === "string",
+  );
+  if (transcriptTextBlocks.length === 0) {
+    return content ? [...content] : undefined;
+  }
+  if (!content || content.length === 0) {
+    return [...transcriptTextBlocks];
+  }
+  const merged: AssistantDisplayContentBlock[] = [];
+  let transcriptTextIndex = 0;
+  for (const block of content) {
+    if (
+      block?.type === "text" &&
+      typeof block.text === "string" &&
+      transcriptTextIndex < transcriptTextBlocks.length
+    ) {
+      merged.push(transcriptTextBlocks[transcriptTextIndex++]);
+      continue;
+    }
+    merged.push(block);
+  }
+  if (transcriptTextIndex < transcriptTextBlocks.length) {
+    merged.unshift(...transcriptTextBlocks.slice(transcriptTextIndex));
+  }
+  return merged;
+}
+
+function isManagedOutgoingImageUrl(value: unknown): boolean {
+  if (typeof value !== "string" || !value.trim()) {
+    return false;
+  }
+  try {
+    const parsed = new URL(value, "http://localhost");
+    return parsed.pathname.startsWith(MANAGED_OUTGOING_IMAGE_PATH_PREFIX);
+  } catch {
+    return false;
+  }
+}
+
+export function stripManagedOutgoingAssistantContentBlocks(
+  content: readonly AssistantDisplayContentBlock[] | undefined,
+): AssistantDisplayContentBlock[] | undefined {
+  if (!content || content.length === 0) {
+    return undefined;
+  }
+  const filtered = content.filter((block) => {
+    if (block?.type !== "image") {
+      return true;
+    }
+    return !(isManagedOutgoingImageUrl(block.url) || isManagedOutgoingImageUrl(block.openUrl));
+  });
+  return filtered.length > 0 ? filtered : undefined;
+}
+
+export function hasAssistantDisplayMediaContent(
+  content: readonly AssistantDisplayContentBlock[] | undefined,
+): boolean {
+  return Boolean(content?.some((block) => block?.type !== "text"));
+}
+
+export function buildAssistantMediaFallbackText(
+  content: readonly AssistantDisplayContentBlock[] | undefined,
+): string | undefined {
+  if (!hasAssistantDisplayMediaContent(content)) {
+    return undefined;
+  }
+  let hasAudio = false;
+  let hasImage = false;
+  let hasOtherMedia = false;
+  for (const block of content ?? []) {
+    if (block?.type === "text") {
+      continue;
+    }
+    if (block?.type === "image" || block?.type === "input_image") {
+      hasImage = true;
+      continue;
+    }
+    if (block?.type === "attachment") {
+      const attachment =
+        typeof block.attachment === "object" &&
+        block.attachment !== null &&
+        !Array.isArray(block.attachment)
+          ? (block.attachment as Record<string, unknown>)
+          : undefined;
+      if (attachment?.kind === "audio") {
+        hasAudio = true;
+      } else {
+        hasOtherMedia = true;
+      }
+      continue;
+    }
+    if (block?.type === "audio") {
+      hasAudio = true;
+      continue;
+    }
+    hasOtherMedia = true;
+  }
+  if (hasOtherMedia || (hasAudio && hasImage)) {
+    return "Media reply";
+  }
+  if (hasAudio) {
+    return "Audio reply";
+  }
+  return hasImage ? "Image reply" : undefined;
+}

--- a/src/gateway/server-methods/chat-assistant-content.ts
+++ b/src/gateway/server-methods/chat-assistant-content.ts
@@ -191,6 +191,18 @@ export function stripManagedOutgoingAssistantContentBlocks(
   return filtered.length > 0 ? filtered : undefined;
 }
 
+export function hasManagedOutgoingAssistantContent(
+  content: readonly AssistantDisplayContentBlock[] | undefined,
+): boolean {
+  return Boolean(
+    content?.some(
+      (block) =>
+        block?.type === "image" &&
+        (isManagedOutgoingImageUrl(block.url) || isManagedOutgoingImageUrl(block.openUrl)),
+    ),
+  );
+}
+
 export function hasAssistantDisplayMediaContent(
   content: readonly AssistantDisplayContentBlock[] | undefined,
 ): boolean {

--- a/src/gateway/server-methods/chat-internal-source-reply.ts
+++ b/src/gateway/server-methods/chat-internal-source-reply.ts
@@ -2,6 +2,7 @@ import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import { rewriteTranscriptEntriesInSessionFile } from "../../agents/pi-embedded-runner/transcript-rewrite.js";
 import { getReplyPayloadMetadata, type ReplyPayload } from "../../auto-reply/reply-payload.js";
+import { resolveMirroredTranscriptText } from "../../config/sessions/transcript-mirror.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   interactiveReplyToPresentation,
@@ -23,6 +24,8 @@ import {
   buildAssistantMediaFallbackText,
   extractAssistantDisplayTextFromContent,
   hasAssistantDisplayMediaContent,
+  hasManagedOutgoingAssistantContent,
+  replaceAssistantContentTextBlocks,
   sanitizeAssistantDisplayText,
   stripManagedOutgoingAssistantContentBlocks,
   type AssistantDisplayContentBlock,
@@ -205,6 +208,84 @@ function findAssistantTranscriptEntryByIdempotencyKey(
   });
 }
 
+async function findSourceReplyTranscriptMirrorByIdempotencyKey(
+  transcriptPath: string,
+  idempotencyKey: string,
+): Promise<{ messageId: string; message: Record<string, unknown> } | null> {
+  const target = findAssistantTranscriptEntryByIdempotencyKey(
+    await readSessionTranscriptIndex(transcriptPath),
+    idempotencyKey,
+  );
+  const message = target?.record.message as Record<string, unknown> | undefined;
+  if (
+    !target?.id ||
+    !message ||
+    message.provider !== "openclaw" ||
+    message.model !== "delivery-mirror"
+  ) {
+    return null;
+  }
+  return { messageId: target.id, message };
+}
+
+function extractAssistantTranscriptText(message: Record<string, unknown>): string | undefined {
+  const content = message.content;
+  if (!Array.isArray(content)) {
+    return undefined;
+  }
+  const text = content
+    .map((block) =>
+      block &&
+      typeof block === "object" &&
+      (block as { type?: unknown }).type === "text" &&
+      typeof (block as { text?: unknown }).text === "string"
+        ? ((block as { text: string }).text.trim() ?? "")
+        : "",
+    )
+    .filter(Boolean)
+    .join("\n")
+    .trim();
+  return text || undefined;
+}
+
+async function findSourceReplyTranscriptMirrorByMetadata(params: {
+  transcriptPath: string;
+  idempotencyKey: string;
+  metadata: SourceReplyTranscriptMirrorMetadata;
+}): Promise<{ messageId: string; message: Record<string, unknown> } | null> {
+  const byIdempotencyKey = await findSourceReplyTranscriptMirrorByIdempotencyKey(
+    params.transcriptPath,
+    params.idempotencyKey,
+  );
+  if (byIdempotencyKey) {
+    return byIdempotencyKey;
+  }
+  const expectedText = resolveMirroredTranscriptText({
+    text: params.metadata?.text,
+    mediaUrls: params.metadata?.mediaUrls,
+  });
+  if (!expectedText) {
+    return null;
+  }
+  const index = await readSessionTranscriptIndex(params.transcriptPath);
+  const target = index?.entries.toReversed().find((entry) => {
+    const message = entry.record.message as Record<string, unknown> | undefined;
+    return (
+      typeof entry.id === "string" &&
+      entry.id.trim().length > 0 &&
+      message?.role === "assistant" &&
+      message.provider === "openclaw" &&
+      message.model === "delivery-mirror" &&
+      extractAssistantTranscriptText(message) === expectedText
+    );
+  });
+  const message = target?.record.message as Record<string, unknown> | undefined;
+  if (!target?.id || !message) {
+    return null;
+  }
+  return { messageId: target.id, message };
+}
+
 function buildBroadcastContentForManagedImageState(params: {
   content: AssistantDisplayContentBlock[] | undefined;
   displayText: string | undefined;
@@ -272,6 +353,7 @@ export function createInternalSourceReplyProjector(params: {
     transcriptPath: string;
     sourceReplyRunId: string;
     content: AssistantDisplayContentBlock[];
+    allowedRewriteSuffixEntryIds?: readonly string[];
   }): Promise<boolean> => {
     const target = findAssistantTranscriptEntryByIdempotencyKey(
       await readSessionTranscriptIndex(input.transcriptPath),
@@ -286,6 +368,9 @@ export function createInternalSourceReplyProjector(params: {
       sessionKey: params.sessionKey,
       config: params.cfg,
       request: {
+        allowedRewriteSuffixEntryIds: input.allowedRewriteSuffixEntryIds?.length
+          ? [...input.allowedRewriteSuffixEntryIds]
+          : [target.id],
         replacements: [
           {
             entryId: target.id,
@@ -322,6 +407,7 @@ export function createInternalSourceReplyProjector(params: {
     transcriptPath: string;
     sourceReplyRunId: string;
     content: AssistantDisplayContentBlock[];
+    allowedRewriteSuffixEntryIds?: readonly string[];
   }): Promise<boolean> => {
     const target = await waitForAssistantTranscriptEntryByIdempotencyKey(
       input.transcriptPath,
@@ -336,41 +422,246 @@ export function createInternalSourceReplyProjector(params: {
     return await rewriteMirrorContent(input);
   };
 
-  return {
-    async projectIfNeeded(input: { payload: ReplyPayload; agentRunStarted: boolean }) {
-      if (!input.agentRunStarted || !isInternalSourceReplyPayload(input.payload)) {
-        return;
+  const findAllowedSourceReplyMirrorIds = async (input: {
+    transcriptPath: string;
+    payloads: readonly ReplyPayload[];
+  }): Promise<string[]> => {
+    const index = await readSessionTranscriptIndex(input.transcriptPath);
+    const allowedIds = new Set<string>();
+    for (const payload of input.payloads) {
+      const metadata = getReplyPayloadMetadata(payload)?.sourceReplyTranscriptMirror;
+      const idempotencyKey = metadata?.idempotencyKey?.trim();
+      if (!idempotencyKey) {
+        continue;
       }
-      const metadata = getReplyPayloadMetadata(input.payload)?.sourceReplyTranscriptMirror;
-      const [displayPayload] = await normalizeWebchatReplyMediaPathsForDisplay({
-        cfg: params.cfg,
-        sessionKey: params.sessionKey,
-        agentId: params.agentId,
-        accountId: params.accountId,
-        payloads: [input.payload],
+      const target = findAssistantTranscriptEntryByIdempotencyKey(index, idempotencyKey);
+      if (typeof target?.id === "string" && target.id.trim()) {
+        allowedIds.add(target.id);
+      }
+    }
+    return [...allowedIds];
+  };
+
+  const projectExplicitSourceReply = async (input: {
+    payload: ReplyPayload;
+    sourceReplyPayloads: readonly ReplyPayload[];
+  }): Promise<boolean> => {
+    const { payload } = input;
+    if (!isInternalSourceReplyPayload(payload)) {
+      return false;
+    }
+    const metadata = getReplyPayloadMetadata(payload)?.sourceReplyTranscriptMirror;
+    const [displayPayload] = await normalizeWebchatReplyMediaPathsForDisplay({
+      cfg: params.cfg,
+      sessionKey: params.sessionKey,
+      agentId: params.agentId,
+      accountId: params.accountId,
+      payloads: [payload],
+    });
+    if (!displayPayload) {
+      return false;
+    }
+    const { storePath: latestStorePath, entry: latestEntry } = loadSessionEntry(params.sessionKey);
+    const sessionId = latestEntry?.sessionId ?? params.backingSessionId ?? params.clientRunId;
+    const resolvedTranscriptPath = params.resolveTranscriptPath({
+      sessionId,
+      storePath: latestStorePath,
+      sessionFile: latestEntry?.sessionFile ?? params.initialSessionFile,
+      agentId: params.agentId,
+    });
+    const mediaLocalRoots = appendLocalMediaParentRoots(
+      getAgentScopedMediaLocalRoots(params.cfg, params.agentId),
+      resolvedTranscriptPath ? [resolvedTranscriptPath] : undefined,
+    );
+    const assistantContent = await buildAssistantDisplayContentFromReplyPayloads({
+      sessionKey: params.sessionKey,
+      payloads: [displayPayload],
+      managedImageLocalRoots: mediaLocalRoots,
+      includeSensitiveMedia: displayPayload.sensitiveMedia !== true,
+      onLocalAudioAccessDenied: (message) => {
+        params.context.logGateway.warn(
+          `internal chat audio embedding denied local path: ${message}`,
+        );
+      },
+      onManagedImagePrepareError: (message) => {
+        params.context.logGateway.warn(
+          `internal chat image embedding skipped attachment: ${message}`,
+        );
+      },
+    });
+    // Sensitive media may render in the live chat event, but must not be
+    // copied into durable transcript mirrors below.
+    const mediaMessage = await buildInternalChatAssistantMediaMessage([displayPayload], {
+      localRoots: mediaLocalRoots,
+      onLocalAudioAccessDenied: (message) => {
+        params.context.logGateway.warn(
+          `internal chat audio embedding denied local path: ${message}`,
+        );
+      },
+    });
+    const broadcastAssistantContent = hasAssistantDisplayMediaContent(assistantContent)
+      ? assistantContent
+      : hasAssistantDisplayMediaContent(mediaMessage?.content)
+        ? mediaMessage?.content
+        : assistantContent;
+    const transcriptReplyText = params.buildTranscriptReplyText([displayPayload]);
+    const richSourceReplyFallback = buildRichSourceReplyFallbackText(displayPayload);
+    const mediaFallbackText = buildAssistantMediaFallbackText(broadcastAssistantContent);
+    const displayReply = mergeSourceReplyDisplayText(
+      extractAssistantDisplayTextFromContent(assistantContent) ??
+        mediaMessage?.transcriptText ??
+        mediaFallbackText ??
+        transcriptReplyText,
+      richSourceReplyFallback,
+    );
+    if (!displayReply && !broadcastAssistantContent?.length) {
+      return false;
+    }
+    const sourceReplyIndex = projectionCount;
+    projectionCount += 1;
+    // The model run may already have emitted its final event; use a distinct
+    // run id so TUI/WebChat clients do not discard this visible source reply.
+    const sourceReplyRunId =
+      metadata?.idempotencyKey?.trim() ||
+      `${params.clientRunId}:internal-source-reply:${sourceReplyIndex}`;
+    const broadcastContent = applyDisplayTextToAssistantContent(
+      broadcastAssistantContent,
+      displayReply,
+    );
+    const transcriptContentSource =
+      displayPayload.sensitiveMedia === true ? assistantContent : broadcastAssistantContent;
+    const transcriptContent = applyDisplayTextToAssistantContent(
+      transcriptContentSource,
+      displayReply,
+    );
+    const metadataHasDurableMirrorContent = sourceReplyMirrorHasDurableContent(metadata);
+    const needsMirrorUpgrade = sourceReplyContentNeedsMirrorUpgrade({
+      metadata,
+      displayPayload,
+      displayReply,
+      content: transcriptContent,
+      richSourceReplyFallback,
+    });
+    let durableMirrorFound = false;
+    let managedOutgoingImagesAttached = false;
+    const allowedRewriteSuffixEntryIds = resolvedTranscriptPath
+      ? await findAllowedSourceReplyMirrorIds({
+          transcriptPath: resolvedTranscriptPath,
+          payloads: input.sourceReplyPayloads,
+        })
+      : [];
+    if (
+      metadataHasDurableMirrorContent &&
+      needsMirrorUpgrade &&
+      transcriptContent?.length &&
+      resolvedTranscriptPath
+    ) {
+      durableMirrorFound = await rewriteMirrorContent({
+        transcriptPath: resolvedTranscriptPath,
+        sourceReplyRunId,
+        content: transcriptContent,
+        allowedRewriteSuffixEntryIds,
       });
-      if (!displayPayload) {
-        return;
+      if (!durableMirrorFound) {
+        durableMirrorFound = await waitAndRewriteMirrorContent({
+          transcriptPath: resolvedTranscriptPath,
+          sourceReplyRunId,
+          content: transcriptContent,
+          allowedRewriteSuffixEntryIds,
+        });
       }
-      const { storePath: latestStorePath, entry: latestEntry } = loadSessionEntry(
-        params.sessionKey,
-      );
-      const sessionId = latestEntry?.sessionId ?? params.backingSessionId ?? params.clientRunId;
-      const resolvedTranscriptPath = params.resolveTranscriptPath({
+    }
+    if (durableMirrorFound) {
+      managedOutgoingImagesAttached = true;
+    }
+    const broadcastContentForMessage = buildBroadcastContentForManagedImageState({
+      content: broadcastContent,
+      displayText: displayReply,
+      managedOutgoingImagesAttached,
+    });
+    let message: Record<string, unknown> = {
+      role: "assistant",
+      ...(broadcastContentForMessage?.length ? { content: broadcastContentForMessage } : {}),
+      ...(displayReply ? { text: displayReply } : {}),
+      timestamp: Date.now(),
+      stopReason: "stop",
+      usage: { input: 0, output: 0, totalTokens: 0 },
+    };
+    if (displayReply && !metadataHasDurableMirrorContent) {
+      const appended = await params.appendAssistantTranscriptMessage({
+        message: displayReply,
+        ...(transcriptContent?.length ? { content: transcriptContent } : {}),
         sessionId,
         storePath: latestStorePath,
-        sessionFile: latestEntry?.sessionFile ?? params.initialSessionFile,
+        sessionFile: latestEntry?.sessionFile,
         agentId: params.agentId,
+        createIfMissing: true,
+        idempotencyKey: sourceReplyRunId,
+        cfg: params.cfg,
       });
-      const mediaLocalRoots = appendLocalMediaParentRoots(
-        getAgentScopedMediaLocalRoots(params.cfg, params.agentId),
-        resolvedTranscriptPath ? [resolvedTranscriptPath] : undefined,
-      );
-      const assistantContent = await buildAssistantDisplayContentFromReplyPayloads({
+      if (appended.ok && appended.message) {
+        if (appended.messageId && transcriptContent?.length) {
+          await attachManagedOutgoingImagesToMessage({
+            messageId: appended.messageId,
+            blocks: transcriptContent,
+          });
+          managedOutgoingImagesAttached = true;
+        }
+        const appendedBroadcastContent = buildBroadcastContentForManagedImageState({
+          content: broadcastContent,
+          displayText: displayReply,
+          managedOutgoingImagesAttached,
+        });
+        message = appendedBroadcastContent?.length
+          ? { ...appended.message, content: appendedBroadcastContent }
+          : appended.message;
+      } else {
+        params.context.logGateway.warn(
+          `internal chat source reply transcript append failed: ${appended.error ?? "unknown error"}`,
+        );
+      }
+    }
+    params.broadcastFinal({
+      runId: sourceReplyRunId,
+      sessionKey: params.sessionKey,
+      message,
+    });
+    return true;
+  };
+
+  const projectAggregatedSourceReplies = async (
+    sourceReplyPayloads: ReplyPayload[],
+  ): Promise<boolean> => {
+    if (sourceReplyPayloads.length === 0) {
+      return false;
+    }
+    const finalPayloads = await normalizeWebchatReplyMediaPathsForDisplay({
+      cfg: params.cfg,
+      sessionKey: params.sessionKey,
+      agentId: params.agentId,
+      accountId: params.accountId,
+      payloads: sourceReplyPayloads,
+    });
+    const { storePath: latestStorePath, entry: latestEntry } = loadSessionEntry(params.sessionKey);
+    const sessionId = latestEntry?.sessionId ?? params.backingSessionId ?? params.clientRunId;
+    const resolvedTranscriptPath = params.resolveTranscriptPath({
+      sessionId,
+      storePath: latestStorePath,
+      sessionFile: latestEntry?.sessionFile ?? params.initialSessionFile,
+      agentId: params.agentId,
+    });
+    const mediaLocalRoots = appendLocalMediaParentRoots(
+      getAgentScopedMediaLocalRoots(params.cfg, params.agentId),
+      resolvedTranscriptPath ? [resolvedTranscriptPath] : undefined,
+    );
+    const buildReplyAssistantContent = async (
+      payloads: typeof finalPayloads,
+    ): Promise<AssistantDisplayContentBlock[] | undefined> =>
+      await buildAssistantDisplayContentFromReplyPayloads({
         sessionKey: params.sessionKey,
-        payloads: [displayPayload],
+        payloads,
         managedImageLocalRoots: mediaLocalRoots,
-        includeSensitiveMedia: displayPayload.sensitiveMedia !== true,
+        includeSensitiveMedia: false,
         onLocalAudioAccessDenied: (message) => {
           params.context.logGateway.warn(
             `internal chat audio embedding denied local path: ${message}`,
@@ -382,9 +673,8 @@ export function createInternalSourceReplyProjector(params: {
           );
         },
       });
-      // Sensitive media may render in the live chat event, but must not be
-      // copied into durable transcript mirrors below.
-      const mediaMessage = await buildInternalChatAssistantMediaMessage([displayPayload], {
+    const buildReplyMediaMessage = async (payloads: typeof finalPayloads) =>
+      await buildInternalChatAssistantMediaMessage(payloads, {
         localRoots: mediaLocalRoots,
         onLocalAudioAccessDenied: (message) => {
           params.context.logGateway.warn(
@@ -392,125 +682,261 @@ export function createInternalSourceReplyProjector(params: {
           );
         },
       });
-      const broadcastAssistantContent = hasAssistantDisplayMediaContent(assistantContent)
-        ? assistantContent
-        : hasAssistantDisplayMediaContent(mediaMessage?.content)
-          ? mediaMessage?.content
-          : assistantContent;
-      const transcriptReplyText = params.buildTranscriptReplyText([displayPayload]);
-      const richSourceReplyFallback = buildRichSourceReplyFallbackText(displayPayload);
-      const mediaFallbackText = buildAssistantMediaFallbackText(broadcastAssistantContent);
-      const displayReply = mergeSourceReplyDisplayText(
-        extractAssistantDisplayTextFromContent(assistantContent) ??
-          mediaMessage?.transcriptText ??
-          mediaFallbackText ??
-          transcriptReplyText,
-        richSourceReplyFallback,
+    const combinedAssistantContent =
+      sourceReplyPayloads.length === 1
+        ? await buildReplyAssistantContent(finalPayloads)
+        : undefined;
+    const combinedMediaMessage =
+      sourceReplyPayloads.length === 1 ? await buildReplyMediaMessage(finalPayloads) : undefined;
+    type SourceReplyContentState = {
+      broadcastContent: AssistantDisplayContentBlock[];
+      persistedContent: AssistantDisplayContentBlock[];
+      hasManagedOutgoingContent: boolean;
+      backedManagedOutgoingContent: boolean;
+    };
+    const sourceReplyContentStates: SourceReplyContentState[] = [];
+    const sourceReplyBroadcastContent: AssistantDisplayContentBlock[] = [];
+    for (const [replyIndex] of sourceReplyPayloads.entries()) {
+      const finalPayload = finalPayloads[replyIndex];
+      if (!finalPayload) {
+        continue;
+      }
+      const replyAssistantContent =
+        sourceReplyPayloads.length === 1
+          ? combinedAssistantContent
+          : await buildReplyAssistantContent([finalPayload]);
+      const replyMediaMessage =
+        sourceReplyPayloads.length === 1
+          ? combinedMediaMessage
+          : await buildReplyMediaMessage([finalPayload]);
+      const replyBroadcastContent = hasAssistantDisplayMediaContent(replyAssistantContent)
+        ? replyAssistantContent
+        : hasAssistantDisplayMediaContent(replyMediaMessage?.content)
+          ? replyMediaMessage?.content
+          : replyAssistantContent;
+      const persistedContent = replaceAssistantContentTextBlocks(
+        replyAssistantContent,
+        replyMediaMessage ?? null,
       );
-      if (!displayReply && !broadcastAssistantContent?.length) {
+      const state: SourceReplyContentState = {
+        broadcastContent: replyBroadcastContent ? [...replyBroadcastContent] : [],
+        persistedContent: persistedContent ? [...persistedContent] : [],
+        hasManagedOutgoingContent: hasManagedOutgoingAssistantContent(persistedContent),
+        backedManagedOutgoingContent: false,
+      };
+      sourceReplyContentStates[replyIndex] = state;
+      if (state.broadcastContent.length > 0) {
+        sourceReplyBroadcastContent.push(...state.broadcastContent);
+      }
+    }
+
+    const displayReply =
+      extractAssistantDisplayTextFromContent(sourceReplyBroadcastContent) ??
+      params.buildTranscriptReplyText(finalPayloads);
+    if (!sourceReplyBroadcastContent.length && !displayReply) {
+      return false;
+    }
+
+    const sourceReplyPersistenceRequests: Array<{
+      idempotencyKey: string;
+      metadata: SourceReplyTranscriptMirrorMetadata;
+      state: SourceReplyContentState;
+    }> = [];
+    for (const [replyIndex, sourceReplyPayload] of sourceReplyPayloads.entries()) {
+      const state = sourceReplyContentStates[replyIndex];
+      if (!state || !hasAssistantDisplayMediaContent(state.persistedContent)) {
+        continue;
+      }
+      const mirrorMetadata =
+        getReplyPayloadMetadata(sourceReplyPayload)?.sourceReplyTranscriptMirror;
+      const mirrorIdempotencyKey = mirrorMetadata?.idempotencyKey;
+      if (
+        typeof mirrorIdempotencyKey !== "string" ||
+        mirrorIdempotencyKey.trim().length === 0 ||
+        !mirrorMetadata
+      ) {
+        continue;
+      }
+      if (!state.hasManagedOutgoingContent) {
+        state.backedManagedOutgoingContent = true;
+      }
+      sourceReplyPersistenceRequests.push({
+        idempotencyKey: mirrorIdempotencyKey,
+        metadata: mirrorMetadata,
+        state,
+      });
+    }
+
+    const attachSourceReplyManagedImages = async (input: {
+      messageId?: string;
+      request: (typeof sourceReplyPersistenceRequests)[number];
+    }) => {
+      if (!input.request.state.hasManagedOutgoingContent) {
+        input.request.state.backedManagedOutgoingContent = true;
         return;
       }
-      const sourceReplyIndex = projectionCount;
-      projectionCount += 1;
-      // The model run may already have emitted its final event; use a distinct
-      // run id so TUI/WebChat clients do not discard this visible source reply.
-      const sourceReplyRunId =
-        metadata?.idempotencyKey?.trim() ||
-        `${params.clientRunId}:internal-source-reply:${sourceReplyIndex}`;
-      const broadcastContent = applyDisplayTextToAssistantContent(
-        broadcastAssistantContent,
-        displayReply,
-      );
-      const transcriptContentSource =
-        displayPayload.sensitiveMedia === true ? assistantContent : broadcastAssistantContent;
-      const transcriptContent = applyDisplayTextToAssistantContent(
-        transcriptContentSource,
-        displayReply,
-      );
-      const metadataHasDurableMirrorContent = sourceReplyMirrorHasDurableContent(metadata);
-      const needsMirrorUpgrade = sourceReplyContentNeedsMirrorUpgrade({
-        metadata,
-        displayPayload,
-        displayReply,
-        content: transcriptContent,
-        richSourceReplyFallback,
+      if (!input.messageId) {
+        return;
+      }
+      await attachManagedOutgoingImagesToMessage({
+        messageId: input.messageId,
+        blocks: input.request.state.persistedContent,
       });
-      let durableMirrorFound = false;
-      let managedOutgoingImagesAttached = false;
-      if (
-        metadataHasDurableMirrorContent &&
-        needsMirrorUpgrade &&
-        transcriptContent?.length &&
-        resolvedTranscriptPath
-      ) {
-        durableMirrorFound = await rewriteMirrorContent({
+      input.request.state.backedManagedOutgoingContent = true;
+    };
+
+    if (resolvedTranscriptPath && sourceReplyPersistenceRequests.length > 0) {
+      const allowedSourceReplyMirrorIds = new Set<string>();
+      for (const [replyIndex, sourceReplyPayload] of sourceReplyPayloads.entries()) {
+        if (!sourceReplyContentStates[replyIndex]) {
+          continue;
+        }
+        const mirrorMetadata =
+          getReplyPayloadMetadata(sourceReplyPayload)?.sourceReplyTranscriptMirror;
+        const mirrorIdempotencyKey = mirrorMetadata?.idempotencyKey;
+        if (
+          typeof mirrorIdempotencyKey !== "string" ||
+          mirrorIdempotencyKey.trim().length === 0 ||
+          !mirrorMetadata
+        ) {
+          continue;
+        }
+        const target = await findSourceReplyTranscriptMirrorByMetadata({
           transcriptPath: resolvedTranscriptPath,
-          sourceReplyRunId,
-          content: transcriptContent,
+          idempotencyKey: mirrorIdempotencyKey,
+          metadata: mirrorMetadata,
         });
-        if (!durableMirrorFound) {
-          durableMirrorFound = await waitAndRewriteMirrorContent({
-            transcriptPath: resolvedTranscriptPath,
-            sourceReplyRunId,
-            content: transcriptContent,
-          });
+        if (target) {
+          allowedSourceReplyMirrorIds.add(target.messageId);
         }
       }
-      if (durableMirrorFound) {
-        managedOutgoingImagesAttached = true;
-      }
-      const broadcastContentForMessage = buildBroadcastContentForManagedImageState({
-        content: broadcastContent,
-        displayText: displayReply,
-        managedOutgoingImagesAttached,
-      });
-      let message: Record<string, unknown> = {
-        role: "assistant",
-        ...(broadcastContentForMessage?.length ? { content: broadcastContentForMessage } : {}),
-        ...(displayReply ? { text: displayReply } : {}),
-        timestamp: Date.now(),
-        stopReason: "stop",
-        usage: { input: 0, output: 0, totalTokens: 0 },
-      };
-      if (displayReply && !metadataHasDurableMirrorContent) {
-        const appended = await params.appendAssistantTranscriptMessage({
-          message: displayReply,
-          ...(transcriptContent?.length ? { content: transcriptContent } : {}),
-          sessionId,
-          storePath: latestStorePath,
-          sessionFile: latestEntry?.sessionFile,
-          agentId: params.agentId,
-          createIfMissing: true,
-          idempotencyKey: sourceReplyRunId,
-          cfg: params.cfg,
+      const rewriteTargets: Array<{
+        request: (typeof sourceReplyPersistenceRequests)[number];
+        messageId: string;
+        message: Record<string, unknown>;
+      }> = [];
+      for (const request of sourceReplyPersistenceRequests) {
+        const target = await findSourceReplyTranscriptMirrorByMetadata({
+          transcriptPath: resolvedTranscriptPath,
+          idempotencyKey: request.idempotencyKey,
+          metadata: request.metadata,
         });
-        if (appended.ok && appended.message) {
-          if (appended.messageId && transcriptContent?.length) {
-            await attachManagedOutgoingImagesToMessage({
-              messageId: appended.messageId,
-              blocks: transcriptContent,
-            });
-            managedOutgoingImagesAttached = true;
+        if (target) {
+          rewriteTargets.push({ request, ...target });
+        }
+      }
+
+      if (rewriteTargets.length > 0) {
+        const rewriteTargetIds = new Set(rewriteTargets.map((target) => target.messageId));
+        const rewriteIndex = await readSessionTranscriptIndex(resolvedTranscriptPath);
+        const firstRewriteEntryIndex =
+          rewriteIndex?.entries.findIndex(
+            (entry) => typeof entry.id === "string" && rewriteTargetIds.has(entry.id),
+          ) ?? -1;
+        const canRewriteSourceReplyMirrors =
+          firstRewriteEntryIndex >= 0 &&
+          rewriteIndex?.entries
+            .slice(firstRewriteEntryIndex)
+            .every(
+              (entry) => typeof entry.id !== "string" || allowedSourceReplyMirrorIds.has(entry.id),
+            ) === true;
+        if (canRewriteSourceReplyMirrors) {
+          const result = await rewriteTranscriptEntriesInSessionFile({
+            sessionFile: resolvedTranscriptPath,
+            sessionKey: params.sessionKey,
+            config: params.cfg,
+            request: {
+              allowedRewriteSuffixEntryIds: [...allowedSourceReplyMirrorIds],
+              replacements: rewriteTargets.map((target) => ({
+                entryId: target.messageId,
+                message: {
+                  ...(target.message as unknown as AgentMessage),
+                  idempotencyKey: target.request.idempotencyKey,
+                  content: target.request.state.persistedContent,
+                } as unknown as AgentMessage,
+              })),
+            },
+          });
+          if (result.changed) {
+            for (const target of rewriteTargets) {
+              const rewritten = await findSourceReplyTranscriptMirrorByIdempotencyKey(
+                resolvedTranscriptPath,
+                target.request.idempotencyKey,
+              );
+              await attachSourceReplyManagedImages({
+                messageId: rewritten?.messageId,
+                request: target.request,
+              });
+            }
           }
-          const appendedBroadcastContent = buildBroadcastContentForManagedImageState({
-            content: broadcastContent,
-            displayText: displayReply,
-            managedOutgoingImagesAttached,
-          });
-          message = appendedBroadcastContent?.length
-            ? { ...appended.message, content: appendedBroadcastContent }
-            : appended.message;
-        } else {
-          params.context.logGateway.warn(
-            `internal chat source reply transcript append failed: ${appended.error ?? "unknown error"}`,
-          );
         }
       }
-      params.broadcastFinal({
-        runId: sourceReplyRunId,
-        sessionKey: params.sessionKey,
-        message,
-      });
+    }
+
+    const sourceReplyContent = sourceReplyContentStates
+      .flatMap((state) => {
+        if (state.hasManagedOutgoingContent && !state.backedManagedOutgoingContent) {
+          const stripped = stripManagedOutgoingAssistantContentBlocks(state.broadcastContent);
+          return stripped?.length
+            ? stripped
+            : [{ type: "text", text: "Media reply could not be displayed." }];
+        }
+        return state.broadcastContent;
+      })
+      .filter((block): block is AssistantDisplayContentBlock => Boolean(block));
+    const sourceReplyTextFromContent = extractAssistantDisplayTextFromContent(sourceReplyContent);
+    const sourceReplyText =
+      sourceReplyTextFromContent ?? (sourceReplyContent.length === 0 ? displayReply : undefined);
+    const message = {
+      role: "assistant",
+      ...(sourceReplyContent?.length
+        ? { content: sourceReplyContent }
+        : sourceReplyText
+          ? { content: [{ type: "text", text: sourceReplyText }] }
+          : {}),
+      ...(sourceReplyText ? { text: sourceReplyText } : {}),
+      timestamp: Date.now(),
+      stopReason: "stop",
+      usage: { input: 0, output: 0, totalTokens: 0 },
+    };
+    params.broadcastFinal({
+      runId: params.clientRunId,
+      sessionKey: params.sessionKey,
+      message,
+    });
+    return true;
+  };
+
+  return {
+    async projectReplies(input: {
+      deliveredReplies: Array<{ payload: ReplyPayload; kind: "block" | "final" }>;
+      agentRunStarted: boolean;
+    }): Promise<boolean> {
+      if (!input.agentRunStarted) {
+        return false;
+      }
+      const sourceReplyPayloads = input.deliveredReplies
+        .filter((entry) => entry.kind === "final")
+        .map((entry) => entry.payload)
+        .filter(isInternalSourceReplyPayload);
+      if (sourceReplyPayloads.length === 0) {
+        return false;
+      }
+      let broadcasted = false;
+      const aggregatedPayloads: ReplyPayload[] = [];
+      for (const payload of sourceReplyPayloads) {
+        if (getReplyPayloadMetadata(payload)?.deliverDespiteSourceReplySuppression === true) {
+          broadcasted =
+            (await projectExplicitSourceReply({
+              payload,
+              sourceReplyPayloads,
+            })) || broadcasted;
+        } else {
+          aggregatedPayloads.push(payload);
+        }
+      }
+      broadcasted = (await projectAggregatedSourceReplies(aggregatedPayloads)) || broadcasted;
+      return broadcasted;
     },
   };
 }

--- a/src/gateway/server-methods/chat-internal-source-reply.ts
+++ b/src/gateway/server-methods/chat-internal-source-reply.ts
@@ -1,0 +1,514 @@
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
+import { rewriteTranscriptEntriesInSessionFile } from "../../agents/pi-embedded-runner/transcript-rewrite.js";
+import { getReplyPayloadMetadata, type ReplyPayload } from "../../auto-reply/reply-payload.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import {
+  interactiveReplyToPresentation,
+  normalizeInteractiveReply,
+  renderMessagePresentationFallbackText,
+} from "../../interactive/payload.js";
+import {
+  appendLocalMediaParentRoots,
+  getAgentScopedMediaLocalRoots,
+} from "../../media/local-roots.js";
+import { safeJsonStringify } from "../../utils/safe-json.js";
+import { attachManagedOutgoingImagesToMessage } from "../managed-image-attachments.js";
+import { readSessionTranscriptIndex } from "../session-transcript-index.fs.js";
+import { loadSessionEntry } from "../session-utils.js";
+import { formatForLog } from "../ws-log.js";
+import {
+  applyDisplayTextToAssistantContent,
+  buildAssistantDisplayContentFromReplyPayloads,
+  buildAssistantMediaFallbackText,
+  extractAssistantDisplayTextFromContent,
+  hasAssistantDisplayMediaContent,
+  sanitizeAssistantDisplayText,
+  stripManagedOutgoingAssistantContentBlocks,
+  type AssistantDisplayContentBlock,
+} from "./chat-assistant-content.js";
+import { normalizeWebchatReplyMediaPathsForDisplay } from "./chat-reply-media.js";
+import { buildWebchatAssistantMessageFromReplyPayloads } from "./chat-webchat-media.js";
+import type { GatewayRequestContext } from "./types.js";
+
+type SourceReplyTranscriptMirrorMetadata = NonNullable<
+  ReturnType<typeof getReplyPayloadMetadata>
+>["sourceReplyTranscriptMirror"];
+
+type AppendAssistantTranscriptMessage = (params: {
+  message: string;
+  content?: Array<Record<string, unknown>>;
+  sessionId: string;
+  storePath: string | undefined;
+  sessionFile?: string;
+  agentId?: string;
+  createIfMissing?: boolean;
+  idempotencyKey?: string;
+  cfg?: OpenClawConfig;
+}) => Promise<{
+  ok: boolean;
+  messageId?: string;
+  message?: Record<string, unknown>;
+  error?: string;
+}>;
+
+type ResolveTranscriptPath = (params: {
+  sessionId: string;
+  storePath: string | undefined;
+  sessionFile?: string;
+  agentId?: string;
+}) => string | null;
+
+type BroadcastFinal = (params: {
+  runId: string;
+  sessionKey: string;
+  message: Record<string, unknown>;
+}) => void;
+
+const RICH_SOURCE_REPLY_FALLBACK_MAX_CHARS = 8_000;
+const SOURCE_REPLY_MIRROR_RECHECK_DELAYS_MS = [10, 25, 50, 100, 250, 500] as const;
+
+export function isInternalSourceReplyPayload(
+  payload: ReplyPayload | undefined,
+): payload is ReplyPayload {
+  if (!payload || typeof payload !== "object") {
+    return false;
+  }
+  return Boolean(getReplyPayloadMetadata(payload)?.sourceReplyTranscriptMirror);
+}
+
+function truncateRichSourceReplyFallbackText(text: string): string {
+  return text.length <= RICH_SOURCE_REPLY_FALLBACK_MAX_CHARS
+    ? text
+    : `${text.slice(0, RICH_SOURCE_REPLY_FALLBACK_MAX_CHARS)}\n...(truncated)...`;
+}
+
+function buildRichSourceReplyFallbackText(payload: ReplyPayload): string | undefined {
+  const parts: string[] = [];
+  if (payload.presentation) {
+    const text = renderMessagePresentationFallbackText({
+      presentation: payload.presentation,
+    }).trim();
+    if (text) {
+      parts.push(text);
+    }
+  }
+  if (payload.interactive) {
+    const normalizedInteractive = normalizeInteractiveReply(payload.interactive);
+    const interactivePresentation = normalizedInteractive
+      ? interactiveReplyToPresentation(normalizedInteractive)
+      : undefined;
+    const text = interactivePresentation
+      ? renderMessagePresentationFallbackText({
+          presentation: interactivePresentation,
+        }).trim()
+      : undefined;
+    if (text && !parts.includes(text)) {
+      parts.push(text);
+    }
+  }
+  if (
+    payload.channelData &&
+    typeof payload.channelData === "object" &&
+    !Array.isArray(payload.channelData) &&
+    Object.keys(payload.channelData).length > 0
+  ) {
+    const json = safeJsonStringify(payload.channelData);
+    if (json && json !== "{}") {
+      parts.push(`Channel data:\n${json}`);
+    }
+  }
+  const text = parts.join("\n\n").trim();
+  return sanitizeAssistantDisplayText(truncateRichSourceReplyFallbackText(text));
+}
+
+function mergeSourceReplyDisplayText(
+  primaryText: string | undefined,
+  richFallbackText: string | undefined,
+): string | undefined {
+  const primary = sanitizeAssistantDisplayText(primaryText);
+  const rich = sanitizeAssistantDisplayText(richFallbackText);
+  if (!primary) {
+    return rich;
+  }
+  if (!rich || primary.includes(rich)) {
+    return primary;
+  }
+  if (rich.includes(primary)) {
+    return rich;
+  }
+  return `${primary}\n\n${rich}`;
+}
+
+function sourceReplyMirrorHasDurableContent(
+  metadata: SourceReplyTranscriptMirrorMetadata | undefined,
+): boolean {
+  return Boolean(
+    metadata?.text?.trim() || metadata?.mediaUrls?.some((mediaUrl) => mediaUrl.trim()),
+  );
+}
+
+function normalizeSourceReplyMirrorMediaUrls(mediaUrls: readonly string[] | undefined): string[] {
+  return mediaUrls?.map((mediaUrl) => mediaUrl.trim()).filter(Boolean) ?? [];
+}
+
+function sourceReplyMirrorMediaUrlsEqual(
+  left: readonly string[] | undefined,
+  right: readonly string[] | undefined,
+): boolean {
+  const normalizedLeft = normalizeSourceReplyMirrorMediaUrls(left);
+  const normalizedRight = normalizeSourceReplyMirrorMediaUrls(right);
+  if (normalizedLeft.length !== normalizedRight.length) {
+    return false;
+  }
+  return normalizedLeft.every((mediaUrl, index) => mediaUrl === normalizedRight[index]);
+}
+
+function sourceReplyContentNeedsMirrorUpgrade(params: {
+  metadata: SourceReplyTranscriptMirrorMetadata | undefined;
+  displayPayload: ReplyPayload;
+  displayReply?: string;
+  content: readonly AssistantDisplayContentBlock[] | undefined;
+  richSourceReplyFallback?: string;
+}): boolean {
+  if (!params.content?.length) {
+    return false;
+  }
+  if (params.displayPayload.sensitiveMedia === true) {
+    return true;
+  }
+  if (params.richSourceReplyFallback || hasAssistantDisplayMediaContent(params.content)) {
+    return true;
+  }
+  const metadataText = params.metadata?.text?.trim() ?? "";
+  const displayText = params.displayReply?.trim() ?? "";
+  if (metadataText !== displayText) {
+    return true;
+  }
+  return !sourceReplyMirrorMediaUrlsEqual(
+    params.metadata?.mediaUrls,
+    resolveSendableOutboundReplyParts(params.displayPayload).mediaUrls,
+  );
+}
+
+function findAssistantTranscriptEntryByIdempotencyKey(
+  index: Awaited<ReturnType<typeof readSessionTranscriptIndex>>,
+  idempotencyKey: string,
+) {
+  return index?.entries.toReversed().find((entry) => {
+    const message = entry.record.message as Record<string, unknown> | undefined;
+    return (
+      Boolean(entry.id) &&
+      message?.role === "assistant" &&
+      message.idempotencyKey === idempotencyKey
+    );
+  });
+}
+
+function buildBroadcastContentForManagedImageState(params: {
+  content: AssistantDisplayContentBlock[] | undefined;
+  displayText: string | undefined;
+  managedOutgoingImagesAttached: boolean;
+}): AssistantDisplayContentBlock[] | undefined {
+  if (params.managedOutgoingImagesAttached) {
+    return params.content;
+  }
+  const strippedContent = stripManagedOutgoingAssistantContentBlocks(params.content);
+  if (strippedContent?.length) {
+    return strippedContent;
+  }
+  return params.displayText ? [{ type: "text", text: params.displayText }] : undefined;
+}
+
+async function waitForAssistantTranscriptEntryByIdempotencyKey(
+  transcriptPath: string,
+  idempotencyKey: string,
+) {
+  for (const delayMs of SOURCE_REPLY_MIRROR_RECHECK_DELAYS_MS) {
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+    const target = findAssistantTranscriptEntryByIdempotencyKey(
+      await readSessionTranscriptIndex(transcriptPath),
+      idempotencyKey,
+    );
+    if (target) {
+      return target;
+    }
+  }
+  return undefined;
+}
+
+async function buildInternalChatAssistantMediaMessage(
+  payloads: ReplyPayload[],
+  options?: {
+    localRoots?: readonly string[];
+    onLocalAudioAccessDenied?: (message: string) => void;
+  },
+): Promise<{ content: Array<Record<string, unknown>>; transcriptText: string } | null> {
+  return await buildWebchatAssistantMessageFromReplyPayloads(payloads, {
+    localRoots: options?.localRoots,
+    onLocalAudioAccessDenied: (err) => {
+      options?.onLocalAudioAccessDenied?.(formatForLog(err));
+    },
+  });
+}
+
+export function createInternalSourceReplyBroadcaster(params: {
+  cfg: OpenClawConfig;
+  sessionKey: string;
+  agentId: string;
+  accountId?: string;
+  clientRunId: string;
+  backingSessionId?: string | null;
+  initialSessionFile?: string;
+  appendAssistantTranscriptMessage: AppendAssistantTranscriptMessage;
+  buildTranscriptReplyText: (payloads: ReplyPayload[]) => string;
+  broadcastFinal: BroadcastFinal;
+  context: Pick<GatewayRequestContext, "logGateway">;
+  resolveTranscriptPath: ResolveTranscriptPath;
+}) {
+  let broadcastCount = 0;
+
+  const rewriteMirrorContent = async (input: {
+    transcriptPath: string;
+    sourceReplyRunId: string;
+    content: AssistantDisplayContentBlock[];
+  }): Promise<boolean> => {
+    const target = findAssistantTranscriptEntryByIdempotencyKey(
+      await readSessionTranscriptIndex(input.transcriptPath),
+      input.sourceReplyRunId,
+    );
+    const targetMessage = target?.record.message as Record<string, unknown> | undefined;
+    if (!target?.id || !targetMessage) {
+      return false;
+    }
+    const rewritten = await rewriteTranscriptEntriesInSessionFile({
+      sessionFile: input.transcriptPath,
+      sessionKey: params.sessionKey,
+      config: params.cfg,
+      request: {
+        replacements: [
+          {
+            entryId: target.id,
+            message: {
+              ...targetMessage,
+              content: input.content,
+            } as unknown as AgentMessage,
+          },
+        ],
+      },
+    });
+    if (!rewritten.changed && rewritten.reason) {
+      params.context.logGateway.warn(
+        `internal chat source reply transcript rewrite failed: ${rewritten.reason}`,
+      );
+      return false;
+    }
+    const rewrittenTarget = rewritten.changed
+      ? findAssistantTranscriptEntryByIdempotencyKey(
+          await readSessionTranscriptIndex(input.transcriptPath),
+          input.sourceReplyRunId,
+        )
+      : target;
+    if (rewrittenTarget?.id) {
+      await attachManagedOutgoingImagesToMessage({
+        messageId: rewrittenTarget.id,
+        blocks: input.content,
+      });
+    }
+    return true;
+  };
+
+  const waitAndRewriteMirrorContent = async (input: {
+    transcriptPath: string;
+    sourceReplyRunId: string;
+    content: AssistantDisplayContentBlock[];
+  }): Promise<boolean> => {
+    const target = await waitForAssistantTranscriptEntryByIdempotencyKey(
+      input.transcriptPath,
+      input.sourceReplyRunId,
+    );
+    if (!target) {
+      params.context.logGateway.warn(
+        "internal chat source reply transcript rewrite skipped: mirror not found",
+      );
+      return false;
+    }
+    return await rewriteMirrorContent(input);
+  };
+
+  return {
+    async broadcastIfNeeded(input: { payload: ReplyPayload; agentRunStarted: boolean }) {
+      if (!input.agentRunStarted || !isInternalSourceReplyPayload(input.payload)) {
+        return;
+      }
+      const metadata = getReplyPayloadMetadata(input.payload)?.sourceReplyTranscriptMirror;
+      const [displayPayload] = await normalizeWebchatReplyMediaPathsForDisplay({
+        cfg: params.cfg,
+        sessionKey: params.sessionKey,
+        agentId: params.agentId,
+        accountId: params.accountId,
+        payloads: [input.payload],
+      });
+      if (!displayPayload) {
+        return;
+      }
+      const { storePath: latestStorePath, entry: latestEntry } = loadSessionEntry(
+        params.sessionKey,
+      );
+      const sessionId = latestEntry?.sessionId ?? params.backingSessionId ?? params.clientRunId;
+      const resolvedTranscriptPath = params.resolveTranscriptPath({
+        sessionId,
+        storePath: latestStorePath,
+        sessionFile: latestEntry?.sessionFile ?? params.initialSessionFile,
+        agentId: params.agentId,
+      });
+      const mediaLocalRoots = appendLocalMediaParentRoots(
+        getAgentScopedMediaLocalRoots(params.cfg, params.agentId),
+        resolvedTranscriptPath ? [resolvedTranscriptPath] : undefined,
+      );
+      const assistantContent = await buildAssistantDisplayContentFromReplyPayloads({
+        sessionKey: params.sessionKey,
+        payloads: [displayPayload],
+        managedImageLocalRoots: mediaLocalRoots,
+        includeSensitiveMedia: displayPayload.sensitiveMedia !== true,
+        onLocalAudioAccessDenied: (message) => {
+          params.context.logGateway.warn(
+            `internal chat audio embedding denied local path: ${message}`,
+          );
+        },
+        onManagedImagePrepareError: (message) => {
+          params.context.logGateway.warn(
+            `internal chat image embedding skipped attachment: ${message}`,
+          );
+        },
+      });
+      const mediaMessage = await buildInternalChatAssistantMediaMessage([displayPayload], {
+        localRoots: mediaLocalRoots,
+        onLocalAudioAccessDenied: (message) => {
+          params.context.logGateway.warn(
+            `internal chat audio embedding denied local path: ${message}`,
+          );
+        },
+      });
+      const broadcastAssistantContent = hasAssistantDisplayMediaContent(assistantContent)
+        ? assistantContent
+        : hasAssistantDisplayMediaContent(mediaMessage?.content)
+          ? mediaMessage?.content
+          : assistantContent;
+      const transcriptReplyText = params.buildTranscriptReplyText([displayPayload]);
+      const richSourceReplyFallback = buildRichSourceReplyFallbackText(displayPayload);
+      const mediaFallbackText = buildAssistantMediaFallbackText(broadcastAssistantContent);
+      const displayReply = mergeSourceReplyDisplayText(
+        extractAssistantDisplayTextFromContent(assistantContent) ??
+          mediaMessage?.transcriptText ??
+          mediaFallbackText ??
+          transcriptReplyText,
+        richSourceReplyFallback,
+      );
+      if (!displayReply && !broadcastAssistantContent?.length) {
+        return;
+      }
+      const sourceReplyIndex = broadcastCount;
+      broadcastCount += 1;
+      // The model run may already have emitted its final event; use a distinct
+      // run id so TUI/WebChat clients do not discard this visible source reply.
+      const sourceReplyRunId =
+        metadata?.idempotencyKey?.trim() ||
+        `${params.clientRunId}:internal-source-reply:${sourceReplyIndex}`;
+      const broadcastContent = applyDisplayTextToAssistantContent(
+        broadcastAssistantContent,
+        displayReply,
+      );
+      const transcriptContentSource =
+        displayPayload.sensitiveMedia === true ? assistantContent : broadcastAssistantContent;
+      const transcriptContent = applyDisplayTextToAssistantContent(
+        transcriptContentSource,
+        displayReply,
+      );
+      const metadataHasDurableMirrorContent = sourceReplyMirrorHasDurableContent(metadata);
+      const needsMirrorUpgrade = sourceReplyContentNeedsMirrorUpgrade({
+        metadata,
+        displayPayload,
+        displayReply,
+        content: transcriptContent,
+        richSourceReplyFallback,
+      });
+      let durableMirrorFound = false;
+      let managedOutgoingImagesAttached = false;
+      if (
+        metadataHasDurableMirrorContent &&
+        needsMirrorUpgrade &&
+        transcriptContent?.length &&
+        resolvedTranscriptPath
+      ) {
+        durableMirrorFound = await rewriteMirrorContent({
+          transcriptPath: resolvedTranscriptPath,
+          sourceReplyRunId,
+          content: transcriptContent,
+        });
+        if (!durableMirrorFound) {
+          durableMirrorFound = await waitAndRewriteMirrorContent({
+            transcriptPath: resolvedTranscriptPath,
+            sourceReplyRunId,
+            content: transcriptContent,
+          });
+        }
+      }
+      if (durableMirrorFound) {
+        managedOutgoingImagesAttached = true;
+      }
+      const broadcastContentForMessage = buildBroadcastContentForManagedImageState({
+        content: broadcastContent,
+        displayText: displayReply,
+        managedOutgoingImagesAttached,
+      });
+      let message: Record<string, unknown> = {
+        role: "assistant",
+        ...(broadcastContentForMessage?.length ? { content: broadcastContentForMessage } : {}),
+        ...(displayReply ? { text: displayReply } : {}),
+        timestamp: Date.now(),
+        stopReason: "stop",
+        usage: { input: 0, output: 0, totalTokens: 0 },
+      };
+      if (displayReply && !metadataHasDurableMirrorContent) {
+        const appended = await params.appendAssistantTranscriptMessage({
+          message: displayReply,
+          ...(transcriptContent?.length ? { content: transcriptContent } : {}),
+          sessionId,
+          storePath: latestStorePath,
+          sessionFile: latestEntry?.sessionFile,
+          agentId: params.agentId,
+          createIfMissing: true,
+          idempotencyKey: sourceReplyRunId,
+          cfg: params.cfg,
+        });
+        if (appended.ok && appended.message) {
+          if (appended.messageId && transcriptContent?.length) {
+            await attachManagedOutgoingImagesToMessage({
+              messageId: appended.messageId,
+              blocks: transcriptContent,
+            });
+            managedOutgoingImagesAttached = true;
+          }
+          const appendedBroadcastContent = buildBroadcastContentForManagedImageState({
+            content: broadcastContent,
+            displayText: displayReply,
+            managedOutgoingImagesAttached,
+          });
+          message = appendedBroadcastContent?.length
+            ? { ...appended.message, content: appendedBroadcastContent }
+            : appended.message;
+        } else {
+          params.context.logGateway.warn(
+            `internal chat source reply transcript append failed: ${appended.error ?? "unknown error"}`,
+          );
+        }
+      }
+      params.broadcastFinal({
+        runId: sourceReplyRunId,
+        sessionKey: params.sessionKey,
+        message,
+      });
+    },
+  };
+}

--- a/src/gateway/server-methods/chat-internal-source-reply.ts
+++ b/src/gateway/server-methods/chat-internal-source-reply.ts
@@ -382,6 +382,8 @@ export function createInternalSourceReplyBroadcaster(params: {
           );
         },
       });
+      // Sensitive media may render in the live chat event, but must not be
+      // copied into durable transcript mirrors below.
       const mediaMessage = await buildInternalChatAssistantMediaMessage([displayPayload], {
         localRoots: mediaLocalRoots,
         onLocalAudioAccessDenied: (message) => {

--- a/src/gateway/server-methods/chat-internal-source-reply.ts
+++ b/src/gateway/server-methods/chat-internal-source-reply.ts
@@ -252,7 +252,7 @@ async function buildInternalChatAssistantMediaMessage(
   });
 }
 
-export function createInternalSourceReplyBroadcaster(params: {
+export function createInternalSourceReplyProjector(params: {
   cfg: OpenClawConfig;
   sessionKey: string;
   agentId: string;
@@ -266,7 +266,7 @@ export function createInternalSourceReplyBroadcaster(params: {
   context: Pick<GatewayRequestContext, "logGateway">;
   resolveTranscriptPath: ResolveTranscriptPath;
 }) {
-  let broadcastCount = 0;
+  let projectionCount = 0;
 
   const rewriteMirrorContent = async (input: {
     transcriptPath: string;
@@ -337,7 +337,7 @@ export function createInternalSourceReplyBroadcaster(params: {
   };
 
   return {
-    async broadcastIfNeeded(input: { payload: ReplyPayload; agentRunStarted: boolean }) {
+    async projectIfNeeded(input: { payload: ReplyPayload; agentRunStarted: boolean }) {
       if (!input.agentRunStarted || !isInternalSourceReplyPayload(input.payload)) {
         return;
       }
@@ -410,8 +410,8 @@ export function createInternalSourceReplyBroadcaster(params: {
       if (!displayReply && !broadcastAssistantContent?.length) {
         return;
       }
-      const sourceReplyIndex = broadcastCount;
-      broadcastCount += 1;
+      const sourceReplyIndex = projectionCount;
+      projectionCount += 1;
       // The model run may already have emitted its final event; use a distinct
       // run id so TUI/WebChat clients do not discard this visible source reply.
       const sourceReplyRunId =

--- a/src/gateway/server-methods/chat-reply-media.test.ts
+++ b/src/gateway/server-methods/chat-reply-media.test.ts
@@ -2,6 +2,10 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getReplyPayloadMetadata,
+  setReplyPayloadMetadata,
+} from "../../auto-reply/reply-payload.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
 import { createManagedOutgoingImageBlocks } from "../managed-image-attachments.js";
@@ -175,6 +179,29 @@ describe("normalizeWebchatReplyMediaPathsForDisplay", () => {
     await expectPathMissing(path.join(stateDir, "media", "outbound"));
   });
 
+  it("marks staged workspace audio as trusted for WebChat audio embedding", async () => {
+    const stateDir = process.env.OPENCLAW_STATE_DIR ?? "";
+    const agentDir = path.join(stateDir, "agents", "main", "agent");
+    const workspaceDir = path.join(stateDir, "workspace");
+    const audioPath = path.join(workspaceDir, "voice.mp3");
+    await fs.mkdir(path.dirname(audioPath), { recursive: true });
+    await fs.writeFile(audioPath, Buffer.from([0xff, 0xfb, 0x90, 0x00]));
+    const cfg = createConfig({ agentDir, workspaceDir, allowRead: false });
+
+    const [payload] = await normalizeWebchatReplyMediaPathsForDisplay({
+      cfg,
+      sessionKey: "agent:main:webchat:direct:user",
+      agentId: "main",
+      payloads: [{ mediaUrls: [audioPath], audioAsVoice: true }],
+    });
+
+    const normalizedPath = requireString(payload?.mediaUrls?.[0], "normalized audio path");
+    expect(normalizedPath).not.toBe(audioPath);
+    expect(normalizedPath.startsWith(path.join(stateDir, "media"))).toBe(true);
+    expect(payload?.trustedLocalMedia).toBe(true);
+    expect(payload?.audioAsVoice).toBe(true);
+  });
+
   it("does not preserve untrusted local audio paths before display normalization", async () => {
     const stateDir = process.env.OPENCLAW_STATE_DIR ?? "";
     const agentDir = path.join(stateDir, "agents", "main", "agent");
@@ -226,6 +253,42 @@ describe("normalizeWebchatReplyMediaPathsForDisplay", () => {
     });
 
     expect(blocks).toHaveLength(2);
+  });
+
+  it("preserves reply payload metadata while staging mixed display media", async () => {
+    const stateDir = process.env.OPENCLAW_STATE_DIR ?? "";
+    const agentDir = path.join(stateDir, "agents", "main", "agent");
+    const workspaceDir = path.join(stateDir, "workspace");
+    const sourcePath = await createCodexHomeImage({ agentDir });
+    const dataUrl = `data:image/png;base64,${PNG_BYTES.toString("base64")}`;
+    const cfg = createConfig({ agentDir, workspaceDir, allowRead: true });
+    const sourceReplyIdempotencyKey = "source-reply-idem";
+    const originalPayload = setReplyPayloadMetadata(
+      { mediaUrls: [dataUrl, sourcePath] },
+      {
+        deliverDespiteSourceReplySuppression: true,
+        sourceReplyTranscriptMirror: {
+          sessionKey: "main",
+          agentId: "main",
+          idempotencyKey: sourceReplyIdempotencyKey,
+        },
+      },
+    );
+
+    const [payload] = await normalizeWebchatReplyMediaPathsForDisplay({
+      cfg,
+      sessionKey: "agent:main:webchat:direct:user",
+      agentId: "main",
+      payloads: [originalPayload],
+    });
+
+    expect(payload).not.toBe(originalPayload);
+    expect(getReplyPayloadMetadata(payload ?? {})).toMatchObject({
+      deliverDespiteSourceReplySuppression: true,
+      sourceReplyTranscriptMirror: {
+        idempotencyKey: sourceReplyIdempotencyKey,
+      },
+    });
   });
 
   it("does not add a failure warning when a mixed inline image survives", async () => {

--- a/src/gateway/server-methods/chat-reply-media.ts
+++ b/src/gateway/server-methods/chat-reply-media.ts
@@ -1,5 +1,5 @@
 import { resolveAgentWorkspaceDir } from "../../agents/agent-scope.js";
-import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
+import { copyReplyPayloadMetadata, type ReplyPayload } from "../../auto-reply/reply-payload.js";
 import { createReplyMediaPathNormalizer } from "../../auto-reply/reply/reply-media-paths.runtime.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { isPassThroughRemoteMediaSource } from "../../media/media-source-url.js";
@@ -21,6 +21,28 @@ function shouldPreserveDisplayMediaUrl(payload: ReplyPayload, mediaUrl: string):
     return true;
   }
   return payload.trustedLocalMedia === true;
+}
+
+function isTrustedDisplayAudioUrl(mediaUrl: string): boolean {
+  return (
+    isAudioFileName(mediaUrl) &&
+    !isDataUrlMedia(mediaUrl) &&
+    !isPassThroughRemoteMediaSource(mediaUrl)
+  );
+}
+
+function trustStagedDisplayAudio(payload: ReplyPayload): ReplyPayload {
+  if (payload.trustedLocalMedia === true) {
+    return payload;
+  }
+  const mediaUrls = resolveSendableOutboundReplyParts(payload).mediaUrls;
+  if (!mediaUrls.some(isTrustedDisplayAudioUrl)) {
+    return payload;
+  }
+  return copyReplyPayloadMetadata(payload, {
+    ...payload,
+    trustedLocalMedia: true,
+  });
 }
 
 export async function normalizeWebchatReplyMediaPathsForDisplay(params: {
@@ -53,7 +75,7 @@ export async function normalizeWebchatReplyMediaPathsForDisplay(params: {
     }
     const mediaUrls = resolveSendableOutboundReplyParts(payload).mediaUrls;
     if (!mediaUrls.some((mediaUrl) => shouldPreserveDisplayMediaUrl(payload, mediaUrl))) {
-      normalized.push(await normalizeMediaPaths(payload));
+      normalized.push(trustStagedDisplayAudio(await normalizeMediaPaths(payload)));
       continue;
     }
     if (!mediaUrls.some((mediaUrl) => !shouldPreserveDisplayMediaUrl(payload, mediaUrl))) {
@@ -62,6 +84,7 @@ export async function normalizeWebchatReplyMediaPathsForDisplay(params: {
     }
     const mergedMediaUrls: string[] = [];
     let text = payload.text;
+    let hasTrustedStagedAudio = payload.trustedLocalMedia === true;
     for (const mediaUrl of mediaUrls) {
       if (shouldPreserveDisplayMediaUrl(payload, mediaUrl)) {
         mergedMediaUrls.push(mediaUrl);
@@ -76,14 +99,18 @@ export async function normalizeWebchatReplyMediaPathsForDisplay(params: {
       if (normalizedMediaUrls.length === 0) {
         continue;
       }
+      hasTrustedStagedAudio ||= normalizedMediaUrls.some(isTrustedDisplayAudioUrl);
       mergedMediaUrls.push(...normalizedMediaUrls);
     }
-    normalized.push({
-      ...payload,
-      text,
-      mediaUrl: mergedMediaUrls[0],
-      mediaUrls: mergedMediaUrls,
-    });
+    normalized.push(
+      copyReplyPayloadMetadata(payload, {
+        ...payload,
+        text,
+        mediaUrl: mergedMediaUrls[0],
+        mediaUrls: mergedMediaUrls,
+        trustedLocalMedia: hasTrustedStagedAudio || undefined,
+      }),
+    );
   }
   return normalized;
 }

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -1955,6 +1955,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
             presentation: {
               title: "Approval needed",
               blocks: [
+                { type: "text", text: "Status ready." },
                 {
                   type: "buttons",
                   buttons: [{ label: "Retry", value: "retry" }],
@@ -1988,6 +1989,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     expect(text).toContain("Status ready.");
     expect(text).toContain("Approval needed");
     expect(text).toContain("- Retry");
+    expect(text?.match(/Status ready\./g)).toHaveLength(1);
     const index = await readSessionTranscriptIndex(mockState.transcriptPath);
     const persisted = index?.entries.find((entry) => {
       const message = entry.record.message as { idempotencyKey?: unknown } | undefined;
@@ -1999,6 +2001,9 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     expect(persistedContent?.[0]?.text).toContain("Status ready.");
     expect(persistedContent?.[0]?.text).toContain("Approval needed");
     expect(persistedContent?.[0]?.text).toContain("- Retry");
+    expect(
+      (persistedContent?.[0]?.text as string | undefined)?.match(/Status ready\./g),
+    ).toHaveLength(1);
   });
 
   it("broadcasts legacy interactive-only internal source replies from agent runs", async () => {
@@ -2423,6 +2428,65 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     const transcriptMessage = sourceEntries?.[0]?.record.message as Record<string, any> | undefined;
     const transcriptContent = transcriptMessage?.content as Array<Record<string, any>> | undefined;
     expect(transcriptContent?.some((block) => block.type === "image")).toBe(true);
+  });
+
+  it("does not broadcast managed image URLs when the source reply mirror is missing", async () => {
+    createTranscriptFixture("openclaw-chat-send-agent-source-image-missing-mirror-");
+    const sourceReplyIdempotencyKey =
+      "idem-agent-source-image-missing-mirror:internal-source-reply:0";
+    const imagePath = path.join(path.dirname(mockState.transcriptPath), "missing-mirror.png");
+    fs.writeFileSync(
+      imagePath,
+      Buffer.from(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=",
+        "base64",
+      ),
+    );
+    mockState.savedMediaResults = [
+      { path: imagePath, contentType: "image/png" },
+      { path: imagePath, contentType: "image/png" },
+    ];
+    mockState.triggerAgentRunStart = true;
+    mockState.dispatchedReplies = [
+      {
+        kind: "final",
+        payload: setReplyPayloadMetadata(
+          {
+            mediaUrl: imagePath,
+            mediaUrls: [imagePath],
+            trustedLocalMedia: true,
+          },
+          {
+            deliverDespiteSourceReplySuppression: true,
+            sourceReplyTranscriptMirror: {
+              sessionKey: "main",
+              agentId: "main",
+              mediaUrls: [imagePath],
+              idempotencyKey: sourceReplyIdempotencyKey,
+            },
+          },
+        ),
+      },
+    ];
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    const payload = await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-agent-source-image-missing-mirror",
+    });
+
+    expect(payload?.runId).toBe(sourceReplyIdempotencyKey);
+    const liveContent = getMessageContent(payload);
+    expect(liveContent).toEqual([{ type: "text", text: "Image reply" }]);
+    expect(JSON.stringify(payload?.message)).not.toContain("/api/chat/media/outgoing/");
+    const index = await readSessionTranscriptIndex(mockState.transcriptPath);
+    const sourceEntries = index?.entries.filter((entry) => {
+      const message = entry.record.message as { idempotencyKey?: unknown } | undefined;
+      return message?.idempotencyKey === sourceReplyIdempotencyKey;
+    });
+    expect(sourceEntries).toHaveLength(0);
   });
 
   it("upgrades each media-bearing internal source reply mirror in the same agent run", async () => {

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -2335,22 +2335,32 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     expect(JSON.stringify(transcriptContent)).not.toContain(blockedMediaUrl);
   });
 
-  it("waits for the source reply media mirror before upgrading durable chat history", async () => {
-    createTranscriptFixture("openclaw-chat-send-agent-source-media-delayed-mirror-");
-    const sourceReplyIdempotencyKey = "idem-agent-source-media-fallback:internal-source-reply:0";
-    const audioPath = path.join(path.dirname(mockState.transcriptPath), "fallback.mp3");
-    fs.writeFileSync(audioPath, Buffer.from([0xff, 0xfb, 0x90, 0x00]));
+  it("waits for the source reply image mirror before broadcasting managed image URLs", async () => {
+    createTranscriptFixture("openclaw-chat-send-agent-source-image-delayed-mirror-");
+    const sourceReplyIdempotencyKey = "idem-agent-source-image-fallback:internal-source-reply:0";
+    const imagePath = path.join(path.dirname(mockState.transcriptPath), "fallback.png");
+    fs.writeFileSync(
+      imagePath,
+      Buffer.from(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=",
+        "base64",
+      ),
+    );
+    mockState.savedMediaResults = [
+      { path: imagePath, contentType: "image/png" },
+      { path: imagePath, contentType: "image/png" },
+    ];
     let mirrorAppendError: Error | undefined;
     mockState.onAfterAgentRunStart = () => {
       setTimeout(() => {
         void (async () => {
           const mirror = await appendInjectedAssistantMessageToTranscript({
             transcriptPath: mockState.transcriptPath,
-            message: `Fallback audio visible in the TUI.\nMEDIA:${audioPath}\n[[audio_as_voice]]`,
+            message: `Fallback image visible in the TUI.\nMEDIA:${imagePath}`,
             content: [
               {
                 type: "text",
-                text: `Fallback audio visible in the TUI.\nMEDIA:${audioPath}\n[[audio_as_voice]]`,
+                text: `Fallback image visible in the TUI.\nMEDIA:${imagePath}`,
               },
             ],
             idempotencyKey: sourceReplyIdempotencyKey,
@@ -2370,19 +2380,18 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         kind: "final",
         payload: setReplyPayloadMetadata(
           {
-            text: "Fallback audio visible in the TUI.",
-            mediaUrl: audioPath,
-            mediaUrls: [audioPath],
+            text: "Fallback image visible in the TUI.",
+            mediaUrl: imagePath,
+            mediaUrls: [imagePath],
             trustedLocalMedia: true,
-            audioAsVoice: true,
           },
           {
             deliverDespiteSourceReplySuppression: true,
             sourceReplyTranscriptMirror: {
               sessionKey: "main",
               agentId: "main",
-              text: "Fallback audio visible in the TUI.",
-              mediaUrls: [audioPath],
+              text: "Fallback image visible in the TUI.",
+              mediaUrls: [imagePath],
               idempotencyKey: sourceReplyIdempotencyKey,
             },
           },
@@ -2399,29 +2408,26 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     });
 
     expect(payload?.runId).toBe(sourceReplyIdempotencyKey);
-    await waitForAssertion(async () => {
-      if (mirrorAppendError) {
-        throw mirrorAppendError;
-      }
-      const index = await readSessionTranscriptIndex(mockState.transcriptPath);
-      const sourceEntries = index?.entries.filter((entry) => {
-        const message = entry.record.message as { idempotencyKey?: unknown } | undefined;
-        return message?.idempotencyKey === sourceReplyIdempotencyKey;
-      });
-      expect(sourceEntries).toHaveLength(1);
-      const transcriptMessage = sourceEntries?.[0]?.record.message as
-        | Record<string, any>
-        | undefined;
-      const transcriptContent = transcriptMessage?.content as
-        | Array<Record<string, any>>
-        | undefined;
-      expect(transcriptContent?.some((block) => block.type === "attachment")).toBe(true);
-    }, 2_000);
+    if (mirrorAppendError) {
+      throw mirrorAppendError;
+    }
+    const liveContent = getMessageContent(payload);
+    const liveImage = liveContent.find((block) => block.type === "image");
+    expect(liveImage?.url).toContain("/api/chat/media/outgoing/");
+    const index = await readSessionTranscriptIndex(mockState.transcriptPath);
+    const sourceEntries = index?.entries.filter((entry) => {
+      const message = entry.record.message as { idempotencyKey?: unknown } | undefined;
+      return message?.idempotencyKey === sourceReplyIdempotencyKey;
+    });
+    expect(sourceEntries).toHaveLength(1);
+    const transcriptMessage = sourceEntries?.[0]?.record.message as Record<string, any> | undefined;
+    const transcriptContent = transcriptMessage?.content as Array<Record<string, any>> | undefined;
+    expect(transcriptContent?.some((block) => block.type === "image")).toBe(true);
   });
 
   it("upgrades each media-bearing internal source reply mirror in the same agent run", async () => {
     createTranscriptFixture("openclaw-chat-send-agent-source-multi-media-reply-");
-    const sourceReplies = [
+    const sourceReplySpecs = [
       {
         key: "idem-agent-source-multi:internal-source-reply:0",
         text: "First audio visible in the TUI.",
@@ -2432,8 +2438,11 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         text: "Second audio visible in the TUI.",
         file: "second.mp3",
       },
-    ].map((reply) => ({
-      ...reply,
+    ];
+    const sourceReplies = sourceReplySpecs.map((reply) => ({
+      key: reply.key,
+      text: reply.text,
+      file: reply.file,
       audioPath: path.join(path.dirname(mockState.transcriptPath), reply.file),
     }));
     for (const reply of sourceReplies) {
@@ -3323,8 +3332,62 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     });
   });
 
-  it("chat.send does not inherit external routes for webchat clients on channel-scoped sessions", async () => {
-    createTranscriptFixture("openclaw-chat-send-webchat-channel-scoped-no-inherit-");
+  it.each([
+    ["legacy WebChat", GATEWAY_CLIENT_MODES.WEBCHAT, GATEWAY_CLIENT_NAMES.WEBCHAT],
+    ["WebChat UI", GATEWAY_CLIENT_MODES.UI, GATEWAY_CLIENT_NAMES.WEBCHAT_UI],
+    ["Control UI", GATEWAY_CLIENT_MODES.UI, GATEWAY_CLIENT_NAMES.CONTROL_UI],
+    ["TUI", GATEWAY_CLIENT_MODES.UI, GATEWAY_CLIENT_NAMES.TUI],
+    ["macOS app UI", GATEWAY_CLIENT_MODES.UI, GATEWAY_CLIENT_NAMES.MACOS_APP],
+    ["iOS app UI", GATEWAY_CLIENT_MODES.UI, GATEWAY_CLIENT_NAMES.IOS_APP],
+    ["Android app UI", GATEWAY_CLIENT_MODES.UI, GATEWAY_CLIENT_NAMES.ANDROID_APP],
+  ])(
+    "chat.send does not inherit external routes for %s clients on channel-scoped sessions",
+    async (_label, mode, id) => {
+      createTranscriptFixture("openclaw-chat-send-internal-chat-surface-no-inherit-");
+      mockState.finalText = "ok";
+      mockState.sessionEntry = {
+        deliveryContext: {
+          channel: "imessage",
+          to: "+8619800001234",
+          accountId: "default",
+        },
+        lastChannel: "imessage",
+        lastTo: "+8619800001234",
+        lastAccountId: "default",
+      };
+      const respond = vi.fn();
+      const context = createChatContext();
+
+      // Internal chat surfaces inspect the transcript through Gateway chat
+      // events; they must not reuse the external channel route.
+      await runNonStreamingChatSend({
+        context,
+        respond,
+        idempotencyKey: `idem-${id}-channel-scoped-no-inherit`,
+        client: {
+          connect: {
+            client: {
+              mode,
+              id,
+            },
+          },
+        } as unknown,
+        sessionKey: "agent:main:imessage:direct:+8619800001234",
+        deliver: true,
+        expectBroadcast: false,
+      });
+
+      expectDispatchContextFields({
+        OriginatingChannel: "webchat",
+        OriginatingTo: undefined,
+        ExplicitDeliverRoute: false,
+        AccountId: undefined,
+      });
+    },
+  );
+
+  it("chat.send still inherits external routes for native node clients on channel-scoped sessions", async () => {
+    createTranscriptFixture("openclaw-chat-send-native-node-channel-scoped-inherit-");
     mockState.finalText = "ok";
     mockState.sessionEntry = {
       deliveryContext: {
@@ -3339,17 +3402,15 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     const respond = vi.fn();
     const context = createChatContext();
 
-    // Webchat client accessing an iMessage channel-scoped session should NOT
-    // inherit the external delivery route. Fixes #38957.
     await runNonStreamingChatSend({
       context,
       respond,
-      idempotencyKey: "idem-webchat-channel-scoped-no-inherit",
+      idempotencyKey: "idem-native-node-channel-scoped-inherit",
       client: {
         connect: {
           client: {
-            mode: GATEWAY_CLIENT_MODES.WEBCHAT,
-            id: "openclaw-webchat",
+            mode: GATEWAY_CLIENT_MODES.NODE,
+            id: GATEWAY_CLIENT_NAMES.MACOS_APP,
           },
         },
       } as unknown,
@@ -3359,55 +3420,14 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     });
 
     expectDispatchContextFields({
-      OriginatingChannel: "webchat",
-      OriginatingTo: undefined,
-      ExplicitDeliverRoute: false,
-      AccountId: undefined,
+      OriginatingChannel: "imessage",
+      OriginatingTo: "+8619800001234",
+      ExplicitDeliverRoute: true,
+      AccountId: "default",
     });
   });
 
-  it("chat.send does not inherit external routes for TUI clients on channel-scoped sessions", async () => {
-    createTranscriptFixture("openclaw-chat-send-tui-channel-scoped-no-inherit-");
-    mockState.finalText = "ok";
-    mockState.sessionEntry = {
-      deliveryContext: {
-        channel: "imessage",
-        to: "+8619800001234",
-        accountId: "default",
-      },
-      lastChannel: "imessage",
-      lastTo: "+8619800001234",
-      lastAccountId: "default",
-    };
-    const respond = vi.fn();
-    const context = createChatContext();
-
-    await runNonStreamingChatSend({
-      context,
-      respond,
-      idempotencyKey: "idem-tui-channel-scoped-no-inherit",
-      client: {
-        connect: {
-          client: {
-            mode: GATEWAY_CLIENT_MODES.UI,
-            id: GATEWAY_CLIENT_NAMES.TUI,
-          },
-        },
-      } as unknown,
-      sessionKey: "agent:main:imessage:direct:+8619800001234",
-      deliver: true,
-      expectBroadcast: false,
-    });
-
-    expectDispatchContextFields({
-      OriginatingChannel: "webchat",
-      OriginatingTo: undefined,
-      ExplicitDeliverRoute: false,
-      AccountId: undefined,
-    });
-  });
-
-  it("chat.send still inherits external routes for non-source UI clients on channel-scoped sessions", async () => {
+  it("chat.send still inherits external routes for generic UI clients on channel-scoped sessions", async () => {
     createTranscriptFixture("openclaw-chat-send-generic-ui-channel-scoped-inherit-");
     mockState.finalText = "ok";
     mockState.sessionEntry = {

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -4,7 +4,11 @@ import path from "node:path";
 import { CURRENT_SESSION_VERSION } from "@earendil-works/pi-coding-agent";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
-import { setReplyPayloadMetadata } from "../../auto-reply/reply-payload.js";
+import {
+  REPLY_MEDIA_FAILURE_WARNING,
+  setReplyPayloadMetadata,
+  type ReplyPayload,
+} from "../../auto-reply/reply-payload.js";
 import type { MsgContext } from "../../auto-reply/templating.js";
 import { appendSessionTranscriptMessage } from "../../config/sessions/transcript-append.js";
 import { resolveMirroredTranscriptText } from "../../config/sessions/transcript-mirror.js";
@@ -16,6 +20,7 @@ import {
 import { ErrorCodes } from "../protocol/index.js";
 import { CHAT_SEND_SESSION_KEY_MAX_LENGTH } from "../protocol/schema/primitives.js";
 import { readSessionTranscriptIndex } from "../session-transcript-index.fs.js";
+import { appendInjectedAssistantMessageToTranscript } from "./chat-transcript-inject.js";
 import type { GatewayRequestContext } from "./types.js";
 
 const mockState = vi.hoisted(() => ({
@@ -24,34 +29,10 @@ const mockState = vi.hoisted(() => ({
   sessionId: "sess-1",
   mainSessionKey: "main",
   finalText: "[[reply_to_current]]",
-  finalPayload: null as {
-    text?: string;
-    mediaUrl?: string;
-    mediaUrls?: string[];
-    spokenText?: string;
-    audioAsVoice?: boolean;
-    trustedLocalMedia?: boolean;
-    sensitiveMedia?: boolean;
-    replyToId?: string;
-    replyToCurrent?: boolean;
-    isReasoning?: boolean;
-    isError?: boolean;
-  } | null,
+  finalPayload: null as ReplyPayload | null,
   dispatchedReplies: [] as Array<{
     kind: "tool" | "block" | "final";
-    payload: {
-      text?: string;
-      mediaUrl?: string;
-      mediaUrls?: string[];
-      spokenText?: string;
-      ttsSupplement?: { spokenText: string };
-      audioAsVoice?: boolean;
-      trustedLocalMedia?: boolean;
-      replyToId?: string;
-      replyToCurrent?: boolean;
-      isReasoning?: boolean;
-      isError?: boolean;
-    };
+    payload: ReplyPayload;
   }>,
   dispatchError: null as Error | null,
   dispatchErrorAfterAgentRunStart: null as Error | null,
@@ -160,7 +141,6 @@ vi.mock("../../auto-reply/dispatch.js", () => ({
           replyToId?: string;
           replyToCurrent?: boolean;
           isReasoning?: boolean;
-          isError?: boolean;
         }) => boolean;
         sendBlockReply: (payload: {
           text?: string;
@@ -172,7 +152,6 @@ vi.mock("../../auto-reply/dispatch.js", () => ({
           replyToId?: string;
           replyToCurrent?: boolean;
           isReasoning?: boolean;
-          isError?: boolean;
         }) => boolean;
         sendToolResult: (payload: {
           text?: string;
@@ -184,7 +163,6 @@ vi.mock("../../auto-reply/dispatch.js", () => ({
           replyToId?: string;
           replyToCurrent?: boolean;
           isReasoning?: boolean;
-          isError?: boolean;
         }) => boolean;
         markComplete: () => void;
         waitForIdle: () => Promise<void>;
@@ -347,7 +325,11 @@ vi.mock("../../media/store.js", async () => {
 
 const { chatHandlers } = await import("./chat.js");
 
-async function waitForAssertion(assertion: () => void, timeoutMs = 1000, stepMs = 2) {
+async function waitForAssertion(
+  assertion: () => void | Promise<void>,
+  timeoutMs = 1000,
+  stepMs = 2,
+) {
   await vi.waitFor(assertion, { interval: stepMs, timeout: timeoutMs });
 }
 
@@ -1851,6 +1833,682 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     expect(assistantUpdates).toStrictEqual([]);
   });
 
+  it("broadcasts internal source replies from agent runs as live chat finals", async () => {
+    createTranscriptFixture("openclaw-chat-send-agent-source-reply-");
+    mockState.triggerAgentRunStart = true;
+    mockState.dispatchedReplies = [
+      {
+        kind: "final",
+        payload: setReplyPayloadMetadata(
+          {
+            text: "Summary visible in the TUI.",
+          },
+          {
+            deliverDespiteSourceReplySuppression: true,
+            sourceReplyTranscriptMirror: {
+              sessionKey: "main",
+              agentId: "main",
+              text: "Summary visible in the TUI.",
+              idempotencyKey: "idem-agent-source-reply:internal-source-reply:0",
+            },
+          },
+        ),
+      },
+    ];
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    const payload = await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-agent-source-reply",
+    });
+
+    expect(payload?.runId).toBe("idem-agent-source-reply:internal-source-reply:0");
+    expect(payload?.state).toBe("final");
+    expect(getMessage(payload)?.role).toBe("assistant");
+    expect(extractFirstTextBlock(payload)).toBe("Summary visible in the TUI.");
+  });
+
+  it("broadcasts rich-only internal source replies from agent runs as live chat finals", async () => {
+    createTranscriptFixture("openclaw-chat-send-agent-rich-source-reply-");
+    const sourceReplyIdempotencyKey = "idem-agent-rich-source-reply:internal-source-reply:0";
+    mockState.triggerAgentRunStart = true;
+    mockState.dispatchedReplies = [
+      {
+        kind: "final",
+        payload: setReplyPayloadMetadata(
+          {
+            presentation: {
+              title: "Approval needed",
+              blocks: [
+                { type: "text", text: "Choose the next step." },
+                {
+                  type: "buttons",
+                  buttons: [{ label: "Retry", value: "retry" }],
+                },
+              ],
+            },
+            channelData: { kind: "rich-source-reply" },
+          },
+          {
+            deliverDespiteSourceReplySuppression: true,
+            sourceReplyTranscriptMirror: {
+              sessionKey: "main",
+              agentId: "main",
+              idempotencyKey: sourceReplyIdempotencyKey,
+            },
+          },
+        ),
+      },
+    ];
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    const payload = await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-agent-rich-source-reply",
+    });
+
+    const text = extractFirstTextBlock(payload);
+    expect(payload?.runId).toBe(sourceReplyIdempotencyKey);
+    expect(payload?.state).toBe("final");
+    expect(getMessage(payload)?.role).toBe("assistant");
+    expect(text).toContain("Approval needed");
+    expect(text).toContain("Choose the next step.");
+    expect(text).toContain("- Retry");
+    expect(text).toContain("Channel data:");
+    expect(text).toContain('"kind":"rich-source-reply"');
+    const index = await readSessionTranscriptIndex(mockState.transcriptPath);
+    const persisted = index?.entries.find((entry) => {
+      const message = entry.record.message as { idempotencyKey?: unknown } | undefined;
+      return message?.idempotencyKey === sourceReplyIdempotencyKey;
+    });
+    const persistedMessage = persisted?.record.message as Record<string, any> | undefined;
+    const persistedContent = persistedMessage?.content as Array<Record<string, any>> | undefined;
+    expect(persistedContent?.[0]?.text).toContain("Approval needed");
+    expect(persistedContent?.[0]?.text).toContain('"kind":"rich-source-reply"');
+  });
+
+  it("preserves rich controls on mixed text internal source reply mirrors", async () => {
+    createTranscriptFixture("openclaw-chat-send-agent-mixed-rich-source-reply-");
+    const sourceReplyIdempotencyKey = "idem-agent-mixed-rich-source-reply:internal-source-reply:0";
+    const mirror = await appendInjectedAssistantMessageToTranscript({
+      transcriptPath: mockState.transcriptPath,
+      message: "Status ready.",
+      content: [{ type: "text", text: "Status ready." }],
+      idempotencyKey: sourceReplyIdempotencyKey,
+      now: 0,
+    });
+    if (!mirror.ok) {
+      throw new Error(mirror.error ?? "source reply mirror append failed");
+    }
+    const mirrorMessageId = mirror.messageId;
+    mockState.triggerAgentRunStart = true;
+    mockState.dispatchedReplies = [
+      {
+        kind: "final",
+        payload: setReplyPayloadMetadata(
+          {
+            text: "Status ready.",
+            presentation: {
+              title: "Approval needed",
+              blocks: [
+                {
+                  type: "buttons",
+                  buttons: [{ label: "Retry", value: "retry" }],
+                },
+              ],
+            },
+          },
+          {
+            deliverDespiteSourceReplySuppression: true,
+            sourceReplyTranscriptMirror: {
+              sessionKey: "main",
+              agentId: "main",
+              text: "Status ready.",
+              idempotencyKey: sourceReplyIdempotencyKey,
+            },
+          },
+        ),
+      },
+    ];
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    const payload = await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-agent-mixed-rich-source-reply",
+    });
+
+    const text = extractFirstTextBlock(payload);
+    expect(payload?.runId).toBe(sourceReplyIdempotencyKey);
+    expect(text).toContain("Status ready.");
+    expect(text).toContain("Approval needed");
+    expect(text).toContain("- Retry");
+    const index = await readSessionTranscriptIndex(mockState.transcriptPath);
+    const persisted = index?.entries.find((entry) => {
+      const message = entry.record.message as { idempotencyKey?: unknown } | undefined;
+      return message?.idempotencyKey === sourceReplyIdempotencyKey;
+    });
+    const persistedMessage = persisted?.record.message as Record<string, any> | undefined;
+    const persistedContent = persistedMessage?.content as Array<Record<string, any>> | undefined;
+    expect(persisted?.id).not.toBe(mirrorMessageId);
+    expect(persistedContent?.[0]?.text).toContain("Status ready.");
+    expect(persistedContent?.[0]?.text).toContain("Approval needed");
+    expect(persistedContent?.[0]?.text).toContain("- Retry");
+  });
+
+  it("broadcasts legacy interactive-only internal source replies from agent runs", async () => {
+    createTranscriptFixture("openclaw-chat-send-agent-interactive-source-reply-");
+    const sourceReplyIdempotencyKey = "idem-agent-interactive-source-reply:internal-source-reply:0";
+    mockState.triggerAgentRunStart = true;
+    mockState.dispatchedReplies = [
+      {
+        kind: "final",
+        payload: setReplyPayloadMetadata(
+          {
+            interactive: {
+              blocks: [
+                {
+                  type: "buttons",
+                  buttons: [{ label: "Retry", value: "retry" }],
+                },
+                {
+                  type: "select",
+                  placeholder: "Choose lane",
+                  options: [{ label: "Fast", value: "fast" }],
+                },
+              ],
+            },
+          },
+          {
+            deliverDespiteSourceReplySuppression: true,
+            sourceReplyTranscriptMirror: {
+              sessionKey: "main",
+              agentId: "main",
+              idempotencyKey: sourceReplyIdempotencyKey,
+            },
+          },
+        ),
+      },
+    ];
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    const payload = await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-agent-interactive-source-reply",
+    });
+
+    const text = extractFirstTextBlock(payload);
+    expect(payload?.runId).toBe(sourceReplyIdempotencyKey);
+    expect(payload?.state).toBe("final");
+    expect(getMessage(payload)?.role).toBe("assistant");
+    expect(text).toContain("- Retry");
+    expect(text).toContain("Choose lane:");
+    expect(text).toContain("- Fast");
+    const index = await readSessionTranscriptIndex(mockState.transcriptPath);
+    const persisted = index?.entries.find((entry) => {
+      const message = entry.record.message as { idempotencyKey?: unknown } | undefined;
+      return message?.idempotencyKey === sourceReplyIdempotencyKey;
+    });
+    const persistedMessage = persisted?.record.message as Record<string, any> | undefined;
+    const persistedContent = persistedMessage?.content as Array<Record<string, any>> | undefined;
+    expect(persistedContent?.[0]?.text).toContain("- Retry");
+    expect(persistedContent?.[0]?.text).toContain("Choose lane:");
+  });
+
+  it("upgrades media-bearing internal source reply mirrors for durable chat history", async () => {
+    createTranscriptFixture("openclaw-chat-send-agent-source-media-reply-");
+    const sourceReplyIdempotencyKey = "idem-agent-source-media:internal-source-reply:0";
+    const audioPath = path.join(path.dirname(mockState.transcriptPath), "source.mp3");
+    fs.writeFileSync(audioPath, Buffer.from([0xff, 0xfb, 0x90, 0x00]));
+    const mirror = await appendInjectedAssistantMessageToTranscript({
+      transcriptPath: mockState.transcriptPath,
+      message: `Audio visible in the TUI.\nMEDIA:${audioPath}\n[[audio_as_voice]]`,
+      content: [
+        {
+          type: "text",
+          text: `Audio visible in the TUI.\nMEDIA:${audioPath}\n[[audio_as_voice]]`,
+        },
+      ],
+      idempotencyKey: sourceReplyIdempotencyKey,
+      now: 0,
+    });
+    if (!mirror.ok) {
+      throw new Error(mirror.error ?? "source reply mirror append failed");
+    }
+    const mirrorMessageId = mirror.messageId;
+    mockState.triggerAgentRunStart = true;
+    mockState.dispatchedReplies = [
+      {
+        kind: "final",
+        payload: setReplyPayloadMetadata(
+          {
+            text: "Audio visible in the TUI.",
+            mediaUrl: audioPath,
+            mediaUrls: [audioPath],
+            trustedLocalMedia: true,
+            audioAsVoice: true,
+          },
+          {
+            deliverDespiteSourceReplySuppression: true,
+            sourceReplyTranscriptMirror: {
+              sessionKey: "main",
+              agentId: "main",
+              text: "Audio visible in the TUI.",
+              mediaUrls: [audioPath],
+              idempotencyKey: sourceReplyIdempotencyKey,
+            },
+          },
+        ),
+      },
+    ];
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    const payload = await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-agent-source-media",
+    });
+
+    const liveContent = getMessageContent(payload);
+    expect(payload?.runId).toBe(sourceReplyIdempotencyKey);
+    expect(liveContent.some((block) => block.type !== "text")).toBe(true);
+    const index = await readSessionTranscriptIndex(mockState.transcriptPath);
+    const activeMirror = index?.entries.find((entry) => {
+      const message = entry.record.message as { idempotencyKey?: unknown } | undefined;
+      return message?.idempotencyKey === sourceReplyIdempotencyKey;
+    });
+    const transcriptMessage = activeMirror?.record.message as Record<string, any> | undefined;
+    const transcriptContent = transcriptMessage?.content as Array<Record<string, any>> | undefined;
+    expect(activeMirror?.id).not.toBe(mirrorMessageId);
+    expect(transcriptContent?.[0]).toEqual({
+      type: "text",
+      text: "Audio visible in the TUI.",
+    });
+    expect(transcriptContent?.some((block) => block.type === "attachment")).toBe(true);
+  });
+
+  it("uses a synthetic label for image-only internal source reply mirrors", async () => {
+    createTranscriptFixture("openclaw-chat-send-agent-source-image-only-reply-");
+    const sourceReplyIdempotencyKey = "idem-agent-source-image:internal-source-reply:0";
+    const imagePath = path.join(path.dirname(mockState.transcriptPath), "source.png");
+    fs.writeFileSync(
+      imagePath,
+      Buffer.from(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=",
+        "base64",
+      ),
+    );
+    const mirror = await appendInjectedAssistantMessageToTranscript({
+      transcriptPath: mockState.transcriptPath,
+      message: `MEDIA:${imagePath}`,
+      content: [{ type: "text", text: `MEDIA:${imagePath}` }],
+      idempotencyKey: sourceReplyIdempotencyKey,
+      now: 0,
+    });
+    if (!mirror.ok) {
+      throw new Error(mirror.error ?? "source reply mirror append failed");
+    }
+    const mirrorMessageId = mirror.messageId;
+    mockState.savedMediaResults = [
+      { path: imagePath, contentType: "image/png" },
+      { path: imagePath, contentType: "image/png" },
+    ];
+    mockState.triggerAgentRunStart = true;
+    mockState.dispatchedReplies = [
+      {
+        kind: "final",
+        payload: setReplyPayloadMetadata(
+          {
+            mediaUrl: imagePath,
+            mediaUrls: [imagePath],
+          },
+          {
+            deliverDespiteSourceReplySuppression: true,
+            sourceReplyTranscriptMirror: {
+              sessionKey: "main",
+              agentId: "main",
+              mediaUrls: [imagePath],
+              idempotencyKey: sourceReplyIdempotencyKey,
+            },
+          },
+        ),
+      },
+    ];
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    const payload = await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-agent-source-image",
+    });
+
+    const liveContent = getMessageContent(payload);
+    expect(payload?.runId).toBe(sourceReplyIdempotencyKey);
+    expect(liveContent[0]).toEqual({ type: "text", text: "Image reply" });
+    expect(liveContent.some((block) => block.type === "image")).toBe(true);
+    expect(JSON.stringify(payload?.message)).not.toContain("MEDIA:");
+    expect(JSON.stringify(payload?.message)).not.toContain(imagePath);
+    const index = await readSessionTranscriptIndex(mockState.transcriptPath);
+    const activeMirror = index?.entries.find((entry) => {
+      const message = entry.record.message as { idempotencyKey?: unknown } | undefined;
+      return message?.idempotencyKey === sourceReplyIdempotencyKey;
+    });
+    const transcriptMessage = activeMirror?.record.message as Record<string, any> | undefined;
+    const transcriptContent = transcriptMessage?.content as Array<Record<string, any>> | undefined;
+    expect(activeMirror?.id).not.toBe(mirrorMessageId);
+    expect(transcriptContent?.[0]).toEqual({
+      type: "text",
+      text: "Image reply",
+    });
+    expect(transcriptContent?.some((block) => block.type === "image")).toBe(true);
+    expect(JSON.stringify(transcriptContent)).not.toContain("MEDIA:");
+    expect(JSON.stringify(transcriptContent)).not.toContain(imagePath);
+  });
+
+  it("keeps sensitive internal source reply media out of durable mirrors", async () => {
+    createTranscriptFixture("openclaw-chat-send-agent-source-sensitive-media-reply-");
+    const sourceReplyIdempotencyKey = "idem-agent-source-sensitive-media:internal-source-reply:0";
+    const sensitiveImageUrl =
+      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=";
+    mockState.triggerAgentRunStart = true;
+    mockState.dispatchedReplies = [
+      {
+        kind: "final",
+        payload: setReplyPayloadMetadata(
+          {
+            mediaUrl: sensitiveImageUrl,
+            mediaUrls: [sensitiveImageUrl],
+            sensitiveMedia: true,
+          },
+          {
+            deliverDespiteSourceReplySuppression: true,
+            sourceReplyTranscriptMirror: {
+              sessionKey: "main",
+              agentId: "main",
+              idempotencyKey: sourceReplyIdempotencyKey,
+            },
+          },
+        ),
+      },
+    ];
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    const payload = await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-agent-source-sensitive-media",
+    });
+
+    const liveContent = getMessageContent(payload);
+    expect(payload?.runId).toBe(sourceReplyIdempotencyKey);
+    expect(liveContent[0]).toEqual({ type: "text", text: "Image reply" });
+    expect(liveContent.some((block) => block.type === "input_image")).toBe(true);
+    expect(JSON.stringify(payload?.message)).toContain(sensitiveImageUrl);
+    const index = await readSessionTranscriptIndex(mockState.transcriptPath);
+    const activeMirror = index?.entries.find((entry) => {
+      const message = entry.record.message as { idempotencyKey?: unknown } | undefined;
+      return message?.idempotencyKey === sourceReplyIdempotencyKey;
+    });
+    const transcriptMessage = activeMirror?.record.message as Record<string, any> | undefined;
+    const transcriptContent = transcriptMessage?.content as Array<Record<string, any>> | undefined;
+    expect(transcriptContent).toEqual([{ type: "text", text: "Image reply" }]);
+    expect(JSON.stringify(transcriptMessage)).not.toContain("MEDIA:");
+    expect(JSON.stringify(transcriptMessage)).not.toContain(sensitiveImageUrl);
+    expect(fs.readFileSync(mockState.transcriptPath, "utf8")).not.toContain(sensitiveImageUrl);
+  });
+
+  it("upgrades internal source reply mirrors when display media is dropped", async () => {
+    createTranscriptFixture("openclaw-chat-send-agent-source-dropped-media-reply-");
+    const sourceReplyIdempotencyKey = "idem-agent-source-dropped-media:internal-source-reply:0";
+    const blockedMediaUrl = `file://${path.join(path.dirname(mockState.transcriptPath), "blocked.png")}`;
+    const mirror = await appendInjectedAssistantMessageToTranscript({
+      transcriptPath: mockState.transcriptPath,
+      message: `Blocked media visible in the TUI.\nMEDIA:${blockedMediaUrl}`,
+      content: [
+        {
+          type: "text",
+          text: `Blocked media visible in the TUI.\nMEDIA:${blockedMediaUrl}`,
+        },
+      ],
+      idempotencyKey: sourceReplyIdempotencyKey,
+      now: 0,
+    });
+    if (!mirror.ok) {
+      throw new Error(mirror.error ?? "source reply mirror append failed");
+    }
+    const mirrorMessageId = mirror.messageId;
+    mockState.triggerAgentRunStart = true;
+    mockState.dispatchedReplies = [
+      {
+        kind: "final",
+        payload: setReplyPayloadMetadata(
+          {
+            text: "Blocked media visible in the TUI.",
+            mediaUrl: blockedMediaUrl,
+            mediaUrls: [blockedMediaUrl],
+          },
+          {
+            deliverDespiteSourceReplySuppression: true,
+            sourceReplyTranscriptMirror: {
+              sessionKey: "main",
+              agentId: "main",
+              text: "Blocked media visible in the TUI.",
+              mediaUrls: [blockedMediaUrl],
+              idempotencyKey: sourceReplyIdempotencyKey,
+            },
+          },
+        ),
+      },
+    ];
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    const payload = await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-agent-source-dropped-media",
+    });
+
+    const text = extractFirstTextBlock(payload);
+    expect(payload?.runId).toBe(sourceReplyIdempotencyKey);
+    expect(text).toContain(REPLY_MEDIA_FAILURE_WARNING);
+    const index = await readSessionTranscriptIndex(mockState.transcriptPath);
+    const activeMirror = index?.entries.find((entry) => {
+      const message = entry.record.message as { idempotencyKey?: unknown } | undefined;
+      return message?.idempotencyKey === sourceReplyIdempotencyKey;
+    });
+    const transcriptMessage = activeMirror?.record.message as Record<string, any> | undefined;
+    const transcriptContent = transcriptMessage?.content as Array<Record<string, any>> | undefined;
+    expect(activeMirror?.id).not.toBe(mirrorMessageId);
+    expect(transcriptContent?.[0]?.text).toContain(REPLY_MEDIA_FAILURE_WARNING);
+    expect(JSON.stringify(transcriptContent)).not.toContain("MEDIA:");
+    expect(JSON.stringify(transcriptContent)).not.toContain(blockedMediaUrl);
+  });
+
+  it("waits for the source reply media mirror before upgrading durable chat history", async () => {
+    createTranscriptFixture("openclaw-chat-send-agent-source-media-delayed-mirror-");
+    const sourceReplyIdempotencyKey = "idem-agent-source-media-fallback:internal-source-reply:0";
+    const audioPath = path.join(path.dirname(mockState.transcriptPath), "fallback.mp3");
+    fs.writeFileSync(audioPath, Buffer.from([0xff, 0xfb, 0x90, 0x00]));
+    let mirrorAppendError: Error | undefined;
+    mockState.onAfterAgentRunStart = () => {
+      setTimeout(() => {
+        void (async () => {
+          const mirror = await appendInjectedAssistantMessageToTranscript({
+            transcriptPath: mockState.transcriptPath,
+            message: `Fallback audio visible in the TUI.\nMEDIA:${audioPath}\n[[audio_as_voice]]`,
+            content: [
+              {
+                type: "text",
+                text: `Fallback audio visible in the TUI.\nMEDIA:${audioPath}\n[[audio_as_voice]]`,
+              },
+            ],
+            idempotencyKey: sourceReplyIdempotencyKey,
+            now: 0,
+          });
+          if (!mirror.ok) {
+            mirrorAppendError = new Error(mirror.error ?? "source reply mirror append failed");
+          }
+        })().catch((err) => {
+          mirrorAppendError = err instanceof Error ? err : new Error(String(err));
+        });
+      }, 25);
+    };
+    mockState.triggerAgentRunStart = true;
+    mockState.dispatchedReplies = [
+      {
+        kind: "final",
+        payload: setReplyPayloadMetadata(
+          {
+            text: "Fallback audio visible in the TUI.",
+            mediaUrl: audioPath,
+            mediaUrls: [audioPath],
+            trustedLocalMedia: true,
+            audioAsVoice: true,
+          },
+          {
+            deliverDespiteSourceReplySuppression: true,
+            sourceReplyTranscriptMirror: {
+              sessionKey: "main",
+              agentId: "main",
+              text: "Fallback audio visible in the TUI.",
+              mediaUrls: [audioPath],
+              idempotencyKey: sourceReplyIdempotencyKey,
+            },
+          },
+        ),
+      },
+    ];
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    const payload = await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-agent-source-media-fallback",
+    });
+
+    expect(payload?.runId).toBe(sourceReplyIdempotencyKey);
+    await waitForAssertion(async () => {
+      if (mirrorAppendError) {
+        throw mirrorAppendError;
+      }
+      const index = await readSessionTranscriptIndex(mockState.transcriptPath);
+      const sourceEntries = index?.entries.filter((entry) => {
+        const message = entry.record.message as { idempotencyKey?: unknown } | undefined;
+        return message?.idempotencyKey === sourceReplyIdempotencyKey;
+      });
+      expect(sourceEntries).toHaveLength(1);
+      const transcriptMessage = sourceEntries?.[0]?.record.message as
+        | Record<string, any>
+        | undefined;
+      const transcriptContent = transcriptMessage?.content as
+        | Array<Record<string, any>>
+        | undefined;
+      expect(transcriptContent?.some((block) => block.type === "attachment")).toBe(true);
+    }, 2_000);
+  });
+
+  it("upgrades each media-bearing internal source reply mirror in the same agent run", async () => {
+    createTranscriptFixture("openclaw-chat-send-agent-source-multi-media-reply-");
+    const sourceReplies = [
+      {
+        key: "idem-agent-source-multi:internal-source-reply:0",
+        text: "First audio visible in the TUI.",
+        file: "first.mp3",
+      },
+      {
+        key: "idem-agent-source-multi:internal-source-reply:1",
+        text: "Second audio visible in the TUI.",
+        file: "second.mp3",
+      },
+    ].map((reply) => ({
+      ...reply,
+      audioPath: path.join(path.dirname(mockState.transcriptPath), reply.file),
+    }));
+    for (const reply of sourceReplies) {
+      fs.writeFileSync(reply.audioPath, Buffer.from([0xff, 0xfb, 0x90, 0x00]));
+      const mirror = await appendInjectedAssistantMessageToTranscript({
+        transcriptPath: mockState.transcriptPath,
+        message: `${reply.text}\nMEDIA:${reply.audioPath}\n[[audio_as_voice]]`,
+        content: [
+          {
+            type: "text",
+            text: `${reply.text}\nMEDIA:${reply.audioPath}\n[[audio_as_voice]]`,
+          },
+        ],
+        idempotencyKey: reply.key,
+        now: 0,
+      });
+      if (!mirror.ok) {
+        throw new Error(mirror.error ?? "source reply mirror append failed");
+      }
+    }
+    mockState.triggerAgentRunStart = true;
+    mockState.dispatchedReplies = sourceReplies.map((reply) => ({
+      kind: "final" as const,
+      payload: setReplyPayloadMetadata(
+        {
+          text: reply.text,
+          mediaUrl: reply.audioPath,
+          mediaUrls: [reply.audioPath],
+          trustedLocalMedia: true,
+          audioAsVoice: true,
+        },
+        {
+          deliverDespiteSourceReplySuppression: true,
+          sourceReplyTranscriptMirror: {
+            sessionKey: "main",
+            agentId: "main",
+            text: reply.text,
+            mediaUrls: [reply.audioPath],
+            idempotencyKey: reply.key,
+          },
+        },
+      ),
+    }));
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-agent-source-multi",
+      waitFor: "dedupe",
+    });
+
+    const broadcastCalls = (
+      context.broadcast as unknown as ReturnType<typeof vi.fn>
+    ).mock.calls.filter((call) => call[0] === "chat");
+    expect(broadcastCalls).toHaveLength(2);
+    const index = await readSessionTranscriptIndex(mockState.transcriptPath);
+    for (const reply of sourceReplies) {
+      const activeMirror = index?.entries.find((entry) => {
+        const message = entry.record.message as { idempotencyKey?: unknown } | undefined;
+        return message?.idempotencyKey === reply.key;
+      });
+      const transcriptMessage = activeMirror?.record.message as Record<string, any> | undefined;
+      const transcriptContent = transcriptMessage?.content as
+        | Array<Record<string, any>>
+        | undefined;
+      expect(transcriptContent?.[0]).toEqual({
+        type: "text",
+        text: reply.text,
+      });
+      expect(transcriptContent?.some((block) => block.type === "attachment")).toBe(true);
+    }
+  });
+
   it("keeps visible text on non-agent TTS final media because no model transcript exists", async () => {
     const transcriptDir = createTranscriptFixture("openclaw-chat-send-command-tts-final-");
     const audioPath = path.join(transcriptDir, "tts.mp3");
@@ -2708,8 +3366,8 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     });
   });
 
-  it("chat.send still inherits external routes for UI clients on channel-scoped sessions", async () => {
-    createTranscriptFixture("openclaw-chat-send-ui-channel-scoped-inherit-");
+  it("chat.send does not inherit external routes for TUI clients on channel-scoped sessions", async () => {
+    createTranscriptFixture("openclaw-chat-send-tui-channel-scoped-no-inherit-");
     mockState.finalText = "ok";
     mockState.sessionEntry = {
       deliveryContext: {
@@ -2727,12 +3385,53 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     await runNonStreamingChatSend({
       context,
       respond,
-      idempotencyKey: "idem-ui-channel-scoped-inherit",
+      idempotencyKey: "idem-tui-channel-scoped-no-inherit",
       client: {
         connect: {
           client: {
             mode: GATEWAY_CLIENT_MODES.UI,
-            id: "openclaw-tui",
+            id: GATEWAY_CLIENT_NAMES.TUI,
+          },
+        },
+      } as unknown,
+      sessionKey: "agent:main:imessage:direct:+8619800001234",
+      deliver: true,
+      expectBroadcast: false,
+    });
+
+    expectDispatchContextFields({
+      OriginatingChannel: "webchat",
+      OriginatingTo: undefined,
+      ExplicitDeliverRoute: false,
+      AccountId: undefined,
+    });
+  });
+
+  it("chat.send still inherits external routes for non-source UI clients on channel-scoped sessions", async () => {
+    createTranscriptFixture("openclaw-chat-send-generic-ui-channel-scoped-inherit-");
+    mockState.finalText = "ok";
+    mockState.sessionEntry = {
+      deliveryContext: {
+        channel: "imessage",
+        to: "+8619800001234",
+        accountId: "default",
+      },
+      lastChannel: "imessage",
+      lastTo: "+8619800001234",
+      lastAccountId: "default",
+    };
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-generic-ui-channel-scoped-inherit",
+      client: {
+        connect: {
+          client: {
+            mode: GATEWAY_CLIENT_MODES.UI,
+            id: GATEWAY_CLIENT_NAMES.TEST,
           },
         },
       } as unknown,

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -67,7 +67,7 @@ import {
 import {
   INTERNAL_MESSAGE_CHANNEL,
   isGatewayCliClient,
-  isInternalSourceSurfaceClient,
+  isInternalChatSurfaceClient,
   isOperatorUiClient,
   normalizeMessageChannel,
 } from "../../utils/message-channel.js";
@@ -855,7 +855,7 @@ function resolveChatSendOriginatingRoute(params: {
     !isChannelScopedSession &&
     typeof sessionScopeParts[1] === "string" &&
     sessionChannelHint === routeChannelCandidate;
-  const isFromInternalSourceSurfaceClient = isInternalSourceSurfaceClient(params.client);
+  const isFromInternalChatSurfaceClient = isInternalChatSurfaceClient(params.client);
   const isFromGatewayCliClient = isGatewayCliClient(params.client);
   const hasClientMetadata =
     (typeof params.client?.mode === "string" && params.client.mode.trim().length > 0) ||
@@ -868,11 +868,11 @@ function resolveChatSendOriginatingRoute(params: {
     params.hasConnectedClient &&
     (isFromGatewayCliClient || !hasClientMetadata);
 
-  // Internal source surfaces never inherit external delivery routes. Configured-main
+  // Internal chat surfaces never inherit external delivery routes. Configured-main
   // sessions are stricter than channel-scoped sessions: only CLI callers, or
   // legacy callers with no client metadata, may inherit the last external route.
   const canInheritDeliverableRoute = Boolean(
-    !isFromInternalSourceSurfaceClient &&
+    !isFromInternalChatSurfaceClient &&
     sessionChannelHint &&
     sessionChannelHint !== INTERNAL_MESSAGE_CHANNEL &&
     ((!isChannelAgnosticSessionScope && (isChannelScopedSession || hasLegacyChannelPeerShape)) ||
@@ -3138,7 +3138,6 @@ export const chatHandlers: GatewayRequestHandlers = {
           `webchat transcript append failed for media reply: ${appended.error ?? "unknown error"}`,
         );
       };
-      const pendingSourceReplyMirrorUpgradeKeys = new Set<string>();
       const rewriteInternalSourceReplyMirrorContent = async (params: {
         transcriptPath: string;
         sourceReplyRunId: string;
@@ -3170,9 +3169,9 @@ export const chatHandlers: GatewayRequestHandlers = {
         });
         if (!rewritten.changed && rewritten.reason) {
           context.logGateway.warn(
-            `webchat source reply transcript rewrite failed: ${rewritten.reason}`,
+            `internal chat source reply transcript rewrite failed: ${rewritten.reason}`,
           );
-          return true;
+          return false;
         }
         const rewrittenTarget = rewritten.changed
           ? findAssistantTranscriptEntryByIdempotencyKey(
@@ -3188,32 +3187,22 @@ export const chatHandlers: GatewayRequestHandlers = {
         }
         return true;
       };
-      const queueInternalSourceReplyMirrorContentUpgrade = (params: {
+      const waitAndRewriteInternalSourceReplyMirrorContent = async (params: {
         transcriptPath: string;
         sourceReplyRunId: string;
         content: AssistantDisplayContentBlock[];
-      }) => {
-        if (pendingSourceReplyMirrorUpgradeKeys.has(params.sourceReplyRunId)) {
-          return;
+      }): Promise<boolean> => {
+        const target = await waitForAssistantTranscriptEntryByIdempotencyKey(
+          params.transcriptPath,
+          params.sourceReplyRunId,
+        );
+        if (!target) {
+          context.logGateway.warn(
+            "internal chat source reply transcript rewrite skipped: mirror not found",
+          );
+          return false;
         }
-        pendingSourceReplyMirrorUpgradeKeys.add(params.sourceReplyRunId);
-        void (async () => {
-          try {
-            const target = await waitForAssistantTranscriptEntryByIdempotencyKey(
-              params.transcriptPath,
-              params.sourceReplyRunId,
-            );
-            if (!target) {
-              context.logGateway.warn(
-                "webchat source reply transcript rewrite skipped: mirror not found",
-              );
-              return;
-            }
-            await rewriteInternalSourceReplyMirrorContent(params);
-          } finally {
-            pendingSourceReplyMirrorUpgradeKeys.delete(params.sourceReplyRunId);
-          }
-        })();
+        return await rewriteInternalSourceReplyMirrorContent(params);
       };
       let internalSourceReplyBroadcastCount = 0;
       const broadcastInternalSourceReplyIfNeeded = async (payload: ReplyPayload) => {
@@ -3249,16 +3238,16 @@ export const chatHandlers: GatewayRequestHandlers = {
           managedImageLocalRoots: mediaLocalRoots,
           includeSensitiveMedia: displayPayload.sensitiveMedia !== true,
           onLocalAudioAccessDenied: (message) => {
-            context.logGateway.warn(`webchat audio embedding denied local path: ${message}`);
+            context.logGateway.warn(`internal chat audio embedding denied local path: ${message}`);
           },
           onManagedImagePrepareError: (message) => {
-            context.logGateway.warn(`webchat image embedding skipped attachment: ${message}`);
+            context.logGateway.warn(`internal chat image embedding skipped attachment: ${message}`);
           },
         });
         const mediaMessage = await buildWebchatAssistantMediaMessage([displayPayload], {
           localRoots: mediaLocalRoots,
           onLocalAudioAccessDenied: (message) => {
-            context.logGateway.warn(`webchat audio embedding denied local path: ${message}`);
+            context.logGateway.warn(`internal chat audio embedding denied local path: ${message}`);
           },
         });
         const broadcastAssistantContent = hasAssistantDisplayMediaContent(assistantContent)
@@ -3304,15 +3293,8 @@ export const chatHandlers: GatewayRequestHandlers = {
           content: transcriptContent,
           richSourceReplyFallback,
         });
-        let message: Record<string, unknown> = {
-          role: "assistant",
-          ...(broadcastContent?.length ? { content: broadcastContent } : {}),
-          ...(displayReply ? { text: displayReply } : {}),
-          timestamp: Date.now(),
-          stopReason: "stop",
-          usage: { input: 0, output: 0, totalTokens: 0 },
-        };
         let durableMirrorFound = false;
+        let managedOutgoingImagesAttached = false;
         if (
           metadataHasDurableMirrorContent &&
           needsMirrorUpgrade &&
@@ -3325,13 +3307,27 @@ export const chatHandlers: GatewayRequestHandlers = {
             content: transcriptContent,
           });
           if (!durableMirrorFound) {
-            queueInternalSourceReplyMirrorContentUpgrade({
+            durableMirrorFound = await waitAndRewriteInternalSourceReplyMirrorContent({
               transcriptPath: resolvedTranscriptPath,
               sourceReplyRunId,
               content: transcriptContent,
             });
           }
         }
+        if (durableMirrorFound) {
+          managedOutgoingImagesAttached = true;
+        }
+        const broadcastContentForMessage = managedOutgoingImagesAttached
+          ? broadcastContent
+          : (stripManagedOutgoingAssistantContentBlocks(broadcastContent) ?? broadcastContent);
+        let message: Record<string, unknown> = {
+          role: "assistant",
+          ...(broadcastContentForMessage?.length ? { content: broadcastContentForMessage } : {}),
+          ...(displayReply ? { text: displayReply } : {}),
+          timestamp: Date.now(),
+          stopReason: "stop",
+          usage: { input: 0, output: 0, totalTokens: 0 },
+        };
         if (displayReply && !metadataHasDurableMirrorContent) {
           const appended = await appendAssistantTranscriptMessage({
             message: displayReply,
@@ -3350,13 +3346,17 @@ export const chatHandlers: GatewayRequestHandlers = {
                 messageId: appended.messageId,
                 blocks: transcriptContent,
               });
+              managedOutgoingImagesAttached = true;
             }
-            message = broadcastContent?.length
-              ? { ...appended.message, content: broadcastContent }
+            const appendedBroadcastContent = managedOutgoingImagesAttached
+              ? broadcastContent
+              : (stripManagedOutgoingAssistantContentBlocks(broadcastContent) ?? broadcastContent);
+            message = appendedBroadcastContent?.length
+              ? { ...appended.message, content: appendedBroadcastContent }
               : appended.message;
           } else {
             context.logGateway.warn(
-              `webchat source reply transcript append failed: ${appended.error ?? "unknown error"}`,
+              `internal chat source reply transcript append failed: ${appended.error ?? "unknown error"}`,
             );
           }
         }

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -15,14 +15,13 @@ import { resolveProviderIdForAuth } from "../../agents/provider-auth-aliases.js"
 import { ensureSandboxWorkspaceForSession } from "../../agents/sandbox/context.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { dispatchInboundMessage } from "../../auto-reply/dispatch.js";
-import { getReplyPayloadMetadata, type ReplyPayload } from "../../auto-reply/reply-payload.js";
+import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
 import { resolveImageModelOverridePlan } from "../../auto-reply/reply/image-model-override-plan.js";
 import { createReplyDispatcher } from "../../auto-reply/reply/reply-dispatcher.js";
 import { stageSandboxMedia } from "../../auto-reply/reply/stage-sandbox-media.js";
 import type { MsgContext, TemplateContext } from "../../auto-reply/templating.js";
 import { extractCanvasFromText } from "../../chat/canvas-render.js";
 import { resolveSessionFilePath } from "../../config/sessions.js";
-import { resolveMirroredTranscriptText } from "../../config/sessions/transcript-mirror.js";
 import { streamSessionTranscriptLines } from "../../config/sessions/transcript-stream.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
@@ -31,13 +30,7 @@ import {
 } from "../../infra/diagnostics-timeline.js";
 import { formatErrorMessage, formatUncaughtError } from "../../infra/errors.js";
 import { jsonUtf8Bytes } from "../../infra/json-utf8-bytes.js";
-import { normalizeReplyPayloadsForDelivery } from "../../infra/outbound/payloads.js";
 import { getSessionBindingService } from "../../infra/outbound/session-binding-service.js";
-import {
-  interactiveReplyToPresentation,
-  normalizeInteractiveReply,
-  renderMessagePresentationFallbackText,
-} from "../../interactive/payload.js";
 import { logLargePayload } from "../../logging/diagnostic-payload.js";
 import {
   appendLocalMediaParentRoots,
@@ -60,10 +53,7 @@ import { resolveSendPolicy } from "../../sessions/send-policy.js";
 import { parseAgentSessionKey } from "../../sessions/session-key-utils.js";
 import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import { deliveryContextFromSession } from "../../utils/delivery-context.shared.js";
-import {
-  stripInlineDirectiveTagsForDisplay,
-  sanitizeReplyDirectiveId,
-} from "../../utils/directive-tags.js";
+import { sanitizeReplyDirectiveId } from "../../utils/directive-tags.js";
 import {
   INTERNAL_MESSAGE_CHANNEL,
   isGatewayCliClient,
@@ -71,7 +61,6 @@ import {
   isOperatorUiClient,
   normalizeMessageChannel,
 } from "../../utils/message-channel.js";
-import { safeJsonStringify } from "../../utils/safe-json.js";
 import {
   abortChatRunById,
   type ChatAbortControllerEntry,
@@ -94,13 +83,11 @@ import {
   projectRecentChatDisplayMessages,
   resolveEffectiveChatHistoryMaxChars,
 } from "../chat-display-projection.js";
-import { stripEnvelopeFromMessage } from "../chat-sanitize.js";
 import { augmentChatHistoryWithCliSessionImports } from "../cli-session-history.js";
 import { isSuppressedControlReplyText } from "../control-reply-text.js";
 import {
   attachManagedOutgoingImagesToMessage,
   cleanupManagedOutgoingImageRecords,
-  createManagedOutgoingImageBlocks,
 } from "../managed-image-attachments.js";
 import { ADMIN_SCOPE } from "../method-scopes.js";
 import {
@@ -134,15 +121,24 @@ import { formatForLog } from "../ws-log.js";
 import { injectTimestamp, timestampOptsFromConfig } from "./agent-timestamp.js";
 import { setGatewayDedupeEntry } from "./agent-wait-dedupe.js";
 import { normalizeRpcAttachmentsToChatAttachments } from "./attachment-normalize.js";
+import {
+  buildAssistantDisplayContentFromReplyPayloads,
+  extractAssistantDisplayTextFromContent,
+  hasAssistantDisplayMediaContent,
+  replaceAssistantContentTextBlocks,
+  stripManagedOutgoingAssistantContentBlocks,
+  type AssistantDisplayContentBlock,
+} from "./chat-assistant-content.js";
+import {
+  createInternalSourceReplyBroadcaster,
+  isInternalSourceReplyPayload,
+} from "./chat-internal-source-reply.js";
 import { normalizeWebchatReplyMediaPathsForDisplay } from "./chat-reply-media.js";
 import {
   appendInjectedAssistantMessageToTranscript,
   type GatewayInjectedTtsSupplementMarker,
 } from "./chat-transcript-inject.js";
-import {
-  buildWebchatAssistantMessageFromReplyPayloads,
-  buildWebchatAudioContentBlocksFromReplyPayloads,
-} from "./chat-webchat-media.js";
+import { buildWebchatAssistantMessageFromReplyPayloads } from "./chat-webchat-media.js";
 import type {
   GatewayRequestContext,
   GatewayRequestHandlerOptions,
@@ -164,10 +160,6 @@ type AbortedPartialSnapshot = {
   text: string;
   abortOrigin: AbortOrigin;
 };
-
-type SourceReplyTranscriptMirrorMetadata = NonNullable<
-  ReturnType<typeof getReplyPayloadMetadata>
->["sourceReplyTranscriptMirror"];
 
 type ChatAbortRequester = {
   connId?: string;
@@ -193,9 +185,6 @@ type PreRegisteredAgentRun = {
 function normalizeUnknownText(value: unknown): string | undefined {
   return typeof value === "string" ? normalizeOptionalText(value) : undefined;
 }
-
-const RICH_SOURCE_REPLY_FALLBACK_MAX_CHARS = 8_000;
-const SOURCE_REPLY_MIRROR_RECHECK_DELAYS_MS = [10, 25, 50, 100, 250, 500] as const;
 
 /** True when a reply payload carries at least one media reference (mediaUrl or mediaUrls). */
 function isMediaBearingPayload(payload: ReplyPayload): boolean {
@@ -281,7 +270,6 @@ export {
 
 export const CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES = 128 * 1024;
 const CHAT_HISTORY_OVERSIZED_PLACEHOLDER = "[chat.history omitted: message too large]";
-const MANAGED_OUTGOING_IMAGE_PATH_PREFIX = "/api/chat/media/outgoing/";
 let chatHistoryPlaceholderEmitCount = 0;
 const chatHistoryManagedImageCleanupState = new Map<string, Promise<void>>();
 const CHANNEL_AGNOSTIC_SESSION_SCOPES = new Set([
@@ -441,327 +429,6 @@ function hasSensitiveMediaPayload(payloads: ReplyPayload[]): boolean {
   return payloads.some(
     (payload) => payload.sensitiveMedia === true && isMediaBearingPayload(payload),
   );
-}
-
-type AssistantDisplayContentBlock = Record<string, unknown>;
-
-function sanitizeAssistantDisplayText(value?: string | null): string | undefined {
-  if (!value) {
-    return undefined;
-  }
-  const withoutEnvelope = stripEnvelopeFromMessage(value);
-  const normalized = typeof withoutEnvelope === "string" ? withoutEnvelope : value;
-  const stripped = stripInlineDirectiveTagsForDisplay(normalized).text.trim();
-  return stripped || undefined;
-}
-
-function truncateRichSourceReplyFallbackText(text: string): string {
-  return text.length <= RICH_SOURCE_REPLY_FALLBACK_MAX_CHARS
-    ? text
-    : `${text.slice(0, RICH_SOURCE_REPLY_FALLBACK_MAX_CHARS)}\n...(truncated)...`;
-}
-
-function buildRichSourceReplyFallbackText(payload: ReplyPayload): string | undefined {
-  const parts: string[] = [];
-  if (payload.presentation) {
-    const text = renderMessagePresentationFallbackText({
-      presentation: payload.presentation,
-    }).trim();
-    if (text) {
-      parts.push(text);
-    }
-  }
-  if (payload.interactive) {
-    const normalizedInteractive = normalizeInteractiveReply(payload.interactive);
-    const interactivePresentation = normalizedInteractive
-      ? interactiveReplyToPresentation(normalizedInteractive)
-      : undefined;
-    const text = interactivePresentation
-      ? renderMessagePresentationFallbackText({
-          presentation: interactivePresentation,
-        }).trim()
-      : undefined;
-    if (text && !parts.includes(text)) {
-      parts.push(text);
-    }
-  }
-  if (
-    payload.channelData &&
-    typeof payload.channelData === "object" &&
-    !Array.isArray(payload.channelData) &&
-    Object.keys(payload.channelData).length > 0
-  ) {
-    const json = safeJsonStringify(payload.channelData);
-    if (json && json !== "{}") {
-      parts.push(`Channel data:\n${json}`);
-    }
-  }
-  const text = parts.join("\n\n").trim();
-  return sanitizeAssistantDisplayText(truncateRichSourceReplyFallbackText(text));
-}
-
-function extractAssistantDisplayTextFromContent(
-  content?: readonly AssistantDisplayContentBlock[] | null,
-): string | undefined {
-  if (!Array.isArray(content) || content.length === 0) {
-    return undefined;
-  }
-  const parts = content
-    .map((block) => {
-      if (block?.type !== "text" || typeof block.text !== "string") {
-        return "";
-      }
-      return block.text.trim();
-    })
-    .filter(Boolean);
-  return parts.length > 0 ? parts.join("\n\n") : undefined;
-}
-
-function mergeSourceReplyDisplayText(
-  primaryText: string | undefined,
-  richFallbackText: string | undefined,
-): string | undefined {
-  const primary = sanitizeAssistantDisplayText(primaryText);
-  const rich = sanitizeAssistantDisplayText(richFallbackText);
-  if (!primary) {
-    return rich;
-  }
-  if (!rich || primary.includes(rich)) {
-    return primary;
-  }
-  return `${primary}\n\n${rich}`;
-}
-
-function applyDisplayTextToAssistantContent(
-  content: readonly AssistantDisplayContentBlock[] | undefined,
-  displayText: string | undefined,
-): AssistantDisplayContentBlock[] | undefined {
-  if (!displayText) {
-    return content ? [...content] : undefined;
-  }
-  if (!content || content.length === 0) {
-    return [{ type: "text", text: displayText }];
-  }
-  const next = [...content];
-  const textIndex = next.findIndex(
-    (block) => block?.type === "text" && typeof block.text === "string",
-  );
-  if (textIndex === -1) {
-    return [{ type: "text", text: displayText }, ...next];
-  }
-  next[textIndex] = {
-    ...next[textIndex],
-    text: displayText,
-  };
-  return next;
-}
-
-async function buildAssistantDisplayContentFromReplyPayloads(params: {
-  sessionKey: string;
-  payloads: ReplyPayload[];
-  managedImageLocalRoots?: Parameters<typeof createManagedOutgoingImageBlocks>[0]["localRoots"];
-  includeSensitiveMedia?: boolean;
-  onLocalAudioAccessDenied?: (message: string) => void;
-  onManagedImagePrepareError?: (message: string) => void;
-}): Promise<AssistantDisplayContentBlock[] | undefined> {
-  const rawTextPayloadCount = params.payloads.filter(
-    (payload) =>
-      payload.isReasoning !== true &&
-      typeof payload.text === "string" &&
-      payload.text.trim().length > 0,
-  ).length;
-  const normalized = normalizeReplyPayloadsForDelivery(params.payloads);
-  if (normalized.length === 0) {
-    return rawTextPayloadCount > 0 ? [{ type: "text", text: "" }] : undefined;
-  }
-
-  const content: AssistantDisplayContentBlock[] = [];
-  let strippedTextPayloadCount = 0;
-  for (const payload of normalized) {
-    const text = sanitizeAssistantDisplayText(payload.text);
-    if (text) {
-      content.push({ type: "text", text });
-    } else if (typeof payload.text === "string" && payload.text.trim().length > 0) {
-      strippedTextPayloadCount += 1;
-    }
-    if (params.includeSensitiveMedia === false && payload.sensitiveMedia === true) {
-      continue;
-    }
-    const audioBlocks = await buildWebchatAudioContentBlocksFromReplyPayloads([payload], {
-      localRoots: Array.isArray(params.managedImageLocalRoots)
-        ? params.managedImageLocalRoots
-        : undefined,
-      onLocalAudioAccessDenied: (err) => {
-        params.onLocalAudioAccessDenied?.(formatForLog(err));
-      },
-    });
-    content.push(...audioBlocks);
-
-    const mediaUrls = Array.from(
-      new Set([
-        ...(Array.isArray(payload.mediaUrls) ? payload.mediaUrls : []),
-        ...(typeof payload.mediaUrl === "string" ? [payload.mediaUrl] : []),
-      ]),
-    );
-    const imageBlocks = await createManagedOutgoingImageBlocks({
-      sessionKey: params.sessionKey,
-      mediaUrls,
-      localRoots: params.managedImageLocalRoots,
-      continueOnPrepareError: true,
-      onPrepareError: (error) => {
-        params.onManagedImagePrepareError?.(error.message);
-      },
-    });
-    if (imageBlocks.length > 0) {
-      content.push(...imageBlocks);
-    }
-  }
-
-  if (content.length > 0) {
-    return content;
-  }
-  return strippedTextPayloadCount > 0 ? [{ type: "text", text: "" }] : undefined;
-}
-
-function replaceAssistantContentTextBlocks(
-  content: readonly AssistantDisplayContentBlock[] | undefined,
-  transcriptMediaMessage: { content: Array<Record<string, unknown>> } | null,
-): AssistantDisplayContentBlock[] | undefined {
-  const transcriptTextBlocks = (transcriptMediaMessage?.content ?? []).filter(
-    (block): block is AssistantDisplayContentBlock =>
-      Boolean(block) &&
-      typeof block === "object" &&
-      block.type === "text" &&
-      typeof block.text === "string",
-  );
-  if (transcriptTextBlocks.length === 0) {
-    return content ? [...content] : undefined;
-  }
-  if (!content || content.length === 0) {
-    return [...transcriptTextBlocks];
-  }
-  const merged: AssistantDisplayContentBlock[] = [];
-  let transcriptTextIndex = 0;
-  for (const block of content) {
-    if (
-      block?.type === "text" &&
-      typeof block.text === "string" &&
-      transcriptTextIndex < transcriptTextBlocks.length
-    ) {
-      merged.push(transcriptTextBlocks[transcriptTextIndex++]);
-      continue;
-    }
-    merged.push(block);
-  }
-  if (transcriptTextIndex < transcriptTextBlocks.length) {
-    merged.unshift(...transcriptTextBlocks.slice(transcriptTextIndex));
-  }
-  return merged;
-}
-
-function isManagedOutgoingImageUrl(value: unknown): boolean {
-  if (typeof value !== "string" || !value.trim()) {
-    return false;
-  }
-  try {
-    const parsed = new URL(value, "http://localhost");
-    return parsed.pathname.startsWith(MANAGED_OUTGOING_IMAGE_PATH_PREFIX);
-  } catch {
-    return false;
-  }
-}
-
-function stripManagedOutgoingAssistantContentBlocks(
-  content: readonly AssistantDisplayContentBlock[] | undefined,
-): AssistantDisplayContentBlock[] | undefined {
-  if (!content || content.length === 0) {
-    return undefined;
-  }
-  const filtered = content.filter((block) => {
-    if (block?.type !== "image") {
-      return true;
-    }
-    return !(isManagedOutgoingImageUrl(block.url) || isManagedOutgoingImageUrl(block.openUrl));
-  });
-  return filtered.length > 0 ? filtered : undefined;
-}
-
-function extractAssistantDisplayText(
-  content: readonly AssistantDisplayContentBlock[] | undefined,
-): string | undefined {
-  if (!content || content.length === 0) {
-    return undefined;
-  }
-  const text = content
-    .map((block) => (block?.type === "text" && typeof block.text === "string" ? block.text : ""))
-    .filter(Boolean)
-    .join("\n\n")
-    .trim();
-  return text || undefined;
-}
-
-function hasAssistantDisplayMediaContent(
-  content: readonly AssistantDisplayContentBlock[] | undefined,
-): boolean {
-  return Boolean(content?.some((block) => block?.type !== "text"));
-}
-
-function hasManagedOutgoingAssistantContent(
-  content: readonly AssistantDisplayContentBlock[] | undefined,
-): boolean {
-  return Boolean(
-    content?.some(
-      (block) =>
-        block?.type === "image" &&
-        (isManagedOutgoingImageUrl(block.url) || isManagedOutgoingImageUrl(block.openUrl)),
-    ),
-  );
-}
-
-function buildAssistantMediaFallbackText(
-  content: readonly AssistantDisplayContentBlock[] | undefined,
-): string | undefined {
-  if (!hasAssistantDisplayMediaContent(content)) {
-    return undefined;
-  }
-  let hasAudio = false;
-  let hasImage = false;
-  let hasOtherMedia = false;
-  for (const block of content ?? []) {
-    if (block?.type === "text") {
-      continue;
-    }
-    if (block?.type === "image" || block?.type === "input_image") {
-      hasImage = true;
-      continue;
-    }
-    if (block?.type === "attachment") {
-      const attachment =
-        typeof block.attachment === "object" &&
-        block.attachment !== null &&
-        !Array.isArray(block.attachment)
-          ? (block.attachment as Record<string, unknown>)
-          : undefined;
-      if (attachment?.kind === "audio") {
-        hasAudio = true;
-      } else {
-        hasOtherMedia = true;
-      }
-      continue;
-    }
-    if (block?.type === "audio") {
-      hasAudio = true;
-      continue;
-    }
-    hasOtherMedia = true;
-  }
-  if (hasOtherMedia || (hasAudio && hasImage)) {
-    return "Media reply";
-  }
-  if (hasAudio) {
-    return "Audio reply";
-  }
-  return hasImage ? "Image reply" : undefined;
 }
 
 function scheduleChatHistoryManagedImageCleanup(params: {
@@ -1596,103 +1263,6 @@ async function transcriptHasIdempotencyKey(
   }
 }
 
-async function findAssistantTranscriptMessageByIdempotencyKey(
-  transcriptPath: string,
-  idempotencyKey: string,
-): Promise<{ messageId: string; message: Record<string, unknown> } | null> {
-  const trimmedIdempotencyKey = idempotencyKey.trim();
-  if (!trimmedIdempotencyKey) {
-    return null;
-  }
-  const index = await readSessionTranscriptIndex(transcriptPath);
-  const target = index?.entries.toReversed().find((entry) => {
-    const message = entry.record.message as Record<string, unknown> | undefined;
-    return (
-      typeof entry.id === "string" &&
-      entry.id.trim().length > 0 &&
-      message?.role === "assistant" &&
-      message.idempotencyKey === trimmedIdempotencyKey
-    );
-  });
-  const message = target?.record.message as Record<string, unknown> | undefined;
-  if (!target?.id || !message) {
-    return null;
-  }
-  return { messageId: target.id, message };
-}
-
-async function findSourceReplyTranscriptMirrorByIdempotencyKey(
-  transcriptPath: string,
-  idempotencyKey: string,
-): Promise<{ messageId: string; message: Record<string, unknown> } | null> {
-  const found = await findAssistantTranscriptMessageByIdempotencyKey(
-    transcriptPath,
-    idempotencyKey,
-  );
-  if (found?.message.provider !== "openclaw" || found.message.model !== "delivery-mirror") {
-    return null;
-  }
-  return found;
-}
-
-function extractAssistantTranscriptText(message: Record<string, unknown>): string | undefined {
-  const content = message.content;
-  if (!Array.isArray(content)) {
-    return undefined;
-  }
-  const text = content
-    .map((block) =>
-      block &&
-      typeof block === "object" &&
-      (block as { type?: unknown }).type === "text" &&
-      typeof (block as { text?: unknown }).text === "string"
-        ? ((block as { text: string }).text.trim() ?? "")
-        : "",
-    )
-    .filter(Boolean)
-    .join("\n")
-    .trim();
-  return text || undefined;
-}
-
-async function findSourceReplyTranscriptMirrorByMetadata(params: {
-  transcriptPath: string;
-  idempotencyKey: string;
-  metadata: NonNullable<ReturnType<typeof getReplyPayloadMetadata>>["sourceReplyTranscriptMirror"];
-}): Promise<{ messageId: string; message: Record<string, unknown> } | null> {
-  const byIdempotencyKey = await findSourceReplyTranscriptMirrorByIdempotencyKey(
-    params.transcriptPath,
-    params.idempotencyKey,
-  );
-  if (byIdempotencyKey) {
-    return byIdempotencyKey;
-  }
-  const expectedText = resolveMirroredTranscriptText({
-    text: params.metadata?.text,
-    mediaUrls: params.metadata?.mediaUrls,
-  });
-  if (!expectedText) {
-    return null;
-  }
-  const index = await readSessionTranscriptIndex(params.transcriptPath);
-  const target = index?.entries.toReversed().find((entry) => {
-    const message = entry.record.message as Record<string, unknown> | undefined;
-    return (
-      typeof entry.id === "string" &&
-      entry.id.trim().length > 0 &&
-      message?.role === "assistant" &&
-      message.provider === "openclaw" &&
-      message.model === "delivery-mirror" &&
-      extractAssistantTranscriptText(message) === expectedText
-    );
-  });
-  const message = target?.record.message as Record<string, unknown> | undefined;
-  if (!target?.id || !message) {
-    return null;
-  }
-  return { messageId: target.id, message };
-}
-
 async function appendAssistantTranscriptMessage(params: {
   message: string;
   label?: string;
@@ -2200,95 +1770,6 @@ function isBtwReplyPayload(payload: ReplyPayload | undefined): payload is ReplyP
   );
 }
 
-function isInternalSourceReplyPayload(payload: ReplyPayload | undefined): payload is ReplyPayload {
-  if (!payload || typeof payload !== "object") {
-    return false;
-  }
-  return Boolean(getReplyPayloadMetadata(payload)?.sourceReplyTranscriptMirror);
-}
-
-function sourceReplyMirrorHasDurableContent(
-  metadata: SourceReplyTranscriptMirrorMetadata | undefined,
-): boolean {
-  return Boolean(
-    metadata?.text?.trim() || metadata?.mediaUrls?.some((mediaUrl) => mediaUrl.trim()),
-  );
-}
-
-function normalizeSourceReplyMirrorMediaUrls(mediaUrls: readonly string[] | undefined): string[] {
-  return mediaUrls?.map((mediaUrl) => mediaUrl.trim()).filter(Boolean) ?? [];
-}
-
-function sourceReplyMirrorMediaUrlsEqual(
-  left: readonly string[] | undefined,
-  right: readonly string[] | undefined,
-): boolean {
-  const normalizedLeft = normalizeSourceReplyMirrorMediaUrls(left);
-  const normalizedRight = normalizeSourceReplyMirrorMediaUrls(right);
-  if (normalizedLeft.length !== normalizedRight.length) {
-    return false;
-  }
-  return normalizedLeft.every((mediaUrl, index) => mediaUrl === normalizedRight[index]);
-}
-
-function sourceReplyContentNeedsMirrorUpgrade(params: {
-  metadata: SourceReplyTranscriptMirrorMetadata | undefined;
-  displayPayload: ReplyPayload;
-  displayReply?: string;
-  content: readonly AssistantDisplayContentBlock[] | undefined;
-  richSourceReplyFallback?: string;
-}): boolean {
-  if (!params.content?.length) {
-    return false;
-  }
-  if (params.displayPayload.sensitiveMedia === true) {
-    return true;
-  }
-  if (params.richSourceReplyFallback || hasAssistantDisplayMediaContent(params.content)) {
-    return true;
-  }
-  const metadataText = params.metadata?.text?.trim() ?? "";
-  const displayText = params.displayReply?.trim() ?? "";
-  if (metadataText !== displayText) {
-    return true;
-  }
-  return !sourceReplyMirrorMediaUrlsEqual(
-    params.metadata?.mediaUrls,
-    resolveSendableOutboundReplyParts(params.displayPayload).mediaUrls,
-  );
-}
-
-function findAssistantTranscriptEntryByIdempotencyKey(
-  index: Awaited<ReturnType<typeof readSessionTranscriptIndex>>,
-  idempotencyKey: string,
-) {
-  return index?.entries.toReversed().find((entry) => {
-    const message = entry.record.message as Record<string, unknown> | undefined;
-    return (
-      Boolean(entry.id) &&
-      message?.role === "assistant" &&
-      message.idempotencyKey === idempotencyKey
-    );
-  });
-}
-
-async function waitForAssistantTranscriptEntryByIdempotencyKey(
-  transcriptPath: string,
-  idempotencyKey: string,
-) {
-  for (const delayMs of SOURCE_REPLY_MIRROR_RECHECK_DELAYS_MS) {
-    await new Promise((resolve) => setTimeout(resolve, delayMs));
-    const target = findAssistantTranscriptEntryByIdempotencyKey(
-      await readSessionTranscriptIndex(transcriptPath),
-      idempotencyKey,
-    );
-    if (target) {
-      return target;
-    }
-  }
-  return undefined;
-}
-
 function broadcastSideResult(params: {
   context: Pick<GatewayRequestContext, "broadcast" | "nodeSendToSession" | "agentRunSeq">;
   payload: SideResultPayload;
@@ -2323,9 +1804,6 @@ function broadcastChatError(params: {
   params.context.agentRunSeq.delete(params.runId);
 }
 
-function isSourceReplyTranscriptMirrorPayload(payload: ReplyPayload | undefined) {
-  return Boolean(payload && getReplyPayloadMetadata(payload)?.sourceReplyTranscriptMirror);
-}
 
 export const chatHandlers: GatewayRequestHandlers = {
   "chat.history": async ({ params, respond, context }) => {
@@ -3138,235 +2616,27 @@ export const chatHandlers: GatewayRequestHandlers = {
           `webchat transcript append failed for media reply: ${appended.error ?? "unknown error"}`,
         );
       };
-      const rewriteInternalSourceReplyMirrorContent = async (params: {
-        transcriptPath: string;
-        sourceReplyRunId: string;
-        content: AssistantDisplayContentBlock[];
-      }): Promise<boolean> => {
-        const target = findAssistantTranscriptEntryByIdempotencyKey(
-          await readSessionTranscriptIndex(params.transcriptPath),
-          params.sourceReplyRunId,
-        );
-        const targetMessage = target?.record.message as Record<string, unknown> | undefined;
-        if (!target?.id || !targetMessage) {
-          return false;
-        }
-        const rewritten = await rewriteTranscriptEntriesInSessionFile({
-          sessionFile: params.transcriptPath,
-          sessionKey,
-          config: cfg,
-          request: {
-            replacements: [
-              {
-                entryId: target.id,
-                message: {
-                  ...targetMessage,
-                  content: params.content,
-                } as unknown as AgentMessage,
-              },
-            ],
-          },
-        });
-        if (!rewritten.changed && rewritten.reason) {
-          context.logGateway.warn(
-            `internal chat source reply transcript rewrite failed: ${rewritten.reason}`,
-          );
-          return false;
-        }
-        const rewrittenTarget = rewritten.changed
-          ? findAssistantTranscriptEntryByIdempotencyKey(
-              await readSessionTranscriptIndex(params.transcriptPath),
-              params.sourceReplyRunId,
-            )
-          : target;
-        if (rewrittenTarget?.id) {
-          await attachManagedOutgoingImagesToMessage({
-            messageId: rewrittenTarget.id,
-            blocks: params.content,
+      const internalSourceReplyBroadcaster = createInternalSourceReplyBroadcaster({
+        cfg,
+        sessionKey,
+        agentId,
+        accountId,
+        clientRunId,
+        backingSessionId,
+        initialSessionFile: entry?.sessionFile,
+        appendAssistantTranscriptMessage,
+        buildTranscriptReplyText,
+        context,
+        resolveTranscriptPath,
+        broadcastFinal: ({ runId, sessionKey: sourceReplySessionKey, message }) => {
+          broadcastChatFinal({
+            context,
+            runId,
+            sessionKey: sourceReplySessionKey,
+            message,
           });
-        }
-        return true;
-      };
-      const waitAndRewriteInternalSourceReplyMirrorContent = async (params: {
-        transcriptPath: string;
-        sourceReplyRunId: string;
-        content: AssistantDisplayContentBlock[];
-      }): Promise<boolean> => {
-        const target = await waitForAssistantTranscriptEntryByIdempotencyKey(
-          params.transcriptPath,
-          params.sourceReplyRunId,
-        );
-        if (!target) {
-          context.logGateway.warn(
-            "internal chat source reply transcript rewrite skipped: mirror not found",
-          );
-          return false;
-        }
-        return await rewriteInternalSourceReplyMirrorContent(params);
-      };
-      let internalSourceReplyBroadcastCount = 0;
-      const broadcastInternalSourceReplyIfNeeded = async (payload: ReplyPayload) => {
-        if (!agentRunStarted || !isInternalSourceReplyPayload(payload)) {
-          return;
-        }
-        const metadata = getReplyPayloadMetadata(payload)?.sourceReplyTranscriptMirror;
-        const [displayPayload] = await normalizeWebchatReplyMediaPathsForDisplay({
-          cfg,
-          sessionKey,
-          agentId,
-          accountId,
-          payloads: [payload],
-        });
-        if (!displayPayload) {
-          return;
-        }
-        const { storePath: latestStorePath, entry: latestEntry } = loadSessionEntry(sessionKey);
-        const sessionId = latestEntry?.sessionId ?? backingSessionId ?? clientRunId;
-        const resolvedTranscriptPath = resolveTranscriptPath({
-          sessionId,
-          storePath: latestStorePath,
-          sessionFile: latestEntry?.sessionFile ?? entry?.sessionFile,
-          agentId,
-        });
-        const mediaLocalRoots = appendLocalMediaParentRoots(
-          getAgentScopedMediaLocalRoots(cfg, agentId),
-          resolvedTranscriptPath ? [resolvedTranscriptPath] : undefined,
-        );
-        const assistantContent = await buildAssistantDisplayContentFromReplyPayloads({
-          sessionKey,
-          payloads: [displayPayload],
-          managedImageLocalRoots: mediaLocalRoots,
-          includeSensitiveMedia: displayPayload.sensitiveMedia !== true,
-          onLocalAudioAccessDenied: (message) => {
-            context.logGateway.warn(`internal chat audio embedding denied local path: ${message}`);
-          },
-          onManagedImagePrepareError: (message) => {
-            context.logGateway.warn(`internal chat image embedding skipped attachment: ${message}`);
-          },
-        });
-        const mediaMessage = await buildWebchatAssistantMediaMessage([displayPayload], {
-          localRoots: mediaLocalRoots,
-          onLocalAudioAccessDenied: (message) => {
-            context.logGateway.warn(`internal chat audio embedding denied local path: ${message}`);
-          },
-        });
-        const broadcastAssistantContent = hasAssistantDisplayMediaContent(assistantContent)
-          ? assistantContent
-          : hasAssistantDisplayMediaContent(mediaMessage?.content)
-            ? mediaMessage?.content
-            : assistantContent;
-        const transcriptReplyText = buildTranscriptReplyText([displayPayload]);
-        const richSourceReplyFallback = buildRichSourceReplyFallbackText(displayPayload);
-        const mediaFallbackText = buildAssistantMediaFallbackText(broadcastAssistantContent);
-        const displayReply = mergeSourceReplyDisplayText(
-          extractAssistantDisplayTextFromContent(assistantContent) ??
-            mediaMessage?.transcriptText ??
-            mediaFallbackText ??
-            transcriptReplyText,
-          richSourceReplyFallback,
-        );
-        if (!displayReply && !broadcastAssistantContent?.length) {
-          return;
-        }
-        const sourceReplyIndex = internalSourceReplyBroadcastCount;
-        internalSourceReplyBroadcastCount += 1;
-        // The model run may already have emitted its final event; use a distinct
-        // run id so TUI/WebChat clients do not discard this visible source reply.
-        const sourceReplyRunId =
-          metadata?.idempotencyKey?.trim() ||
-          `${clientRunId}:internal-source-reply:${sourceReplyIndex}`;
-        const broadcastContent = applyDisplayTextToAssistantContent(
-          broadcastAssistantContent,
-          displayReply,
-        );
-        const transcriptContentSource =
-          displayPayload.sensitiveMedia === true ? assistantContent : broadcastAssistantContent;
-        const transcriptContent = applyDisplayTextToAssistantContent(
-          transcriptContentSource,
-          displayReply,
-        );
-        const metadataHasDurableMirrorContent = sourceReplyMirrorHasDurableContent(metadata);
-        const needsMirrorUpgrade = sourceReplyContentNeedsMirrorUpgrade({
-          metadata,
-          displayPayload,
-          displayReply,
-          content: transcriptContent,
-          richSourceReplyFallback,
-        });
-        let durableMirrorFound = false;
-        let managedOutgoingImagesAttached = false;
-        if (
-          metadataHasDurableMirrorContent &&
-          needsMirrorUpgrade &&
-          transcriptContent?.length &&
-          resolvedTranscriptPath
-        ) {
-          durableMirrorFound = await rewriteInternalSourceReplyMirrorContent({
-            transcriptPath: resolvedTranscriptPath,
-            sourceReplyRunId,
-            content: transcriptContent,
-          });
-          if (!durableMirrorFound) {
-            durableMirrorFound = await waitAndRewriteInternalSourceReplyMirrorContent({
-              transcriptPath: resolvedTranscriptPath,
-              sourceReplyRunId,
-              content: transcriptContent,
-            });
-          }
-        }
-        if (durableMirrorFound) {
-          managedOutgoingImagesAttached = true;
-        }
-        const broadcastContentForMessage = managedOutgoingImagesAttached
-          ? broadcastContent
-          : (stripManagedOutgoingAssistantContentBlocks(broadcastContent) ?? broadcastContent);
-        let message: Record<string, unknown> = {
-          role: "assistant",
-          ...(broadcastContentForMessage?.length ? { content: broadcastContentForMessage } : {}),
-          ...(displayReply ? { text: displayReply } : {}),
-          timestamp: Date.now(),
-          stopReason: "stop",
-          usage: { input: 0, output: 0, totalTokens: 0 },
-        };
-        if (displayReply && !metadataHasDurableMirrorContent) {
-          const appended = await appendAssistantTranscriptMessage({
-            message: displayReply,
-            ...(transcriptContent?.length ? { content: transcriptContent } : {}),
-            sessionId,
-            storePath: latestStorePath,
-            sessionFile: latestEntry?.sessionFile,
-            agentId,
-            createIfMissing: true,
-            idempotencyKey: sourceReplyRunId,
-            cfg,
-          });
-          if (appended.ok && appended.message) {
-            if (appended.messageId && transcriptContent?.length) {
-              await attachManagedOutgoingImagesToMessage({
-                messageId: appended.messageId,
-                blocks: transcriptContent,
-              });
-              managedOutgoingImagesAttached = true;
-            }
-            const appendedBroadcastContent = managedOutgoingImagesAttached
-              ? broadcastContent
-              : (stripManagedOutgoingAssistantContentBlocks(broadcastContent) ?? broadcastContent);
-            message = appendedBroadcastContent?.length
-              ? { ...appended.message, content: appendedBroadcastContent }
-              : appended.message;
-          } else {
-            context.logGateway.warn(
-              `internal chat source reply transcript append failed: ${appended.error ?? "unknown error"}`,
-            );
-          }
-        }
-        broadcastChatFinal({
-          context,
-          runId: sourceReplyRunId,
-          sessionKey,
-          message,
-        });
-      };
+        },
+      });
       const dispatcher = createReplyDispatcher({
         ...replyPipeline,
         onError: (err) => {
@@ -3378,7 +2648,10 @@ export const chatHandlers: GatewayRequestHandlers = {
             case "final":
               deliveredReplies.push({ payload, kind: info.kind });
               await appendWebchatAgentMediaTranscriptIfNeeded(payload);
-              await broadcastInternalSourceReplyIfNeeded(payload);
+              await internalSourceReplyBroadcaster.broadcastIfNeeded({
+                payload,
+                agentRunStarted,
+              });
               break;
             case "tool":
               // Tool results that carry audio (e.g. the TTS tool) must be promoted
@@ -3464,7 +2737,6 @@ export const chatHandlers: GatewayRequestHandlers = {
                   .map((payload) => payload.text?.trim())
                   .filter((text): text is string => Boolean(text))
                   .join(" | ") || undefined;
-              let broadcastedSourceReplyFinal = false;
               // WebChat persistence has two owners. Agent runs persist model-visible turns
               // through Pi's SessionManager; this dispatcher only owns live delivery payloads.
               // Do not blindly mirror agent-run final payloads into JSONL or chat.history can
@@ -3633,7 +2905,8 @@ export const chatHandlers: GatewayRequestHandlers = {
                         stripManagedOutgoingAssistantContentBlocks(persistedAssistantContent) ??
                         stripManagedOutgoingAssistantContentBlocks(assistantContent);
                       const fallbackText =
-                        extractAssistantDisplayText(fallbackAssistantContent) ?? displayReply;
+                        extractAssistantDisplayTextFromContent(fallbackAssistantContent) ??
+                        displayReply;
                       const now = Date.now();
                       message = {
                         role: "assistant",
@@ -3661,312 +2934,7 @@ export const chatHandlers: GatewayRequestHandlers = {
                     message,
                   });
                 }
-              } else {
-                const sourceReplyPayloads = deliveredReplies
-                  .filter((entry) => entry.kind === "final")
-                  .map((entry) => entry.payload)
-                  .filter(isSourceReplyTranscriptMirrorPayload);
-                if (sourceReplyPayloads.length > 0) {
-                  const finalPayloads = await normalizeWebchatReplyMediaPathsForDisplay({
-                    cfg,
-                    sessionKey,
-                    agentId,
-                    accountId,
-                    payloads: sourceReplyPayloads,
-                  });
-                  const { storePath: latestStorePath, entry: latestEntry } =
-                    loadSessionEntry(sessionKey);
-                  const sessionId = latestEntry?.sessionId ?? backingSessionId ?? clientRunId;
-                  const resolvedTranscriptPath = resolveTranscriptPath({
-                    sessionId,
-                    storePath: latestStorePath,
-                    sessionFile: latestEntry?.sessionFile ?? entry?.sessionFile,
-                    agentId,
-                  });
-                  const mediaLocalRoots = appendLocalMediaParentRoots(
-                    getAgentScopedMediaLocalRoots(cfg, agentId),
-                    resolvedTranscriptPath ? [resolvedTranscriptPath] : undefined,
-                  );
-                  const buildReplyAssistantContent = async (
-                    payloads: typeof finalPayloads,
-                  ): Promise<AssistantDisplayContentBlock[] | undefined> =>
-                    await buildAssistantDisplayContentFromReplyPayloads({
-                      sessionKey,
-                      payloads,
-                      managedImageLocalRoots: mediaLocalRoots,
-                      includeSensitiveMedia: false,
-                      onLocalAudioAccessDenied: (message) => {
-                        context.logGateway.warn(
-                          `webchat audio embedding denied local path: ${message}`,
-                        );
-                      },
-                      onManagedImagePrepareError: (message) => {
-                        context.logGateway.warn(
-                          `webchat image embedding skipped attachment: ${message}`,
-                        );
-                      },
-                    });
-                  const buildReplyMediaMessage = async (payloads: typeof finalPayloads) =>
-                    await buildWebchatAssistantMediaMessage(payloads, {
-                      localRoots: mediaLocalRoots,
-                      onLocalAudioAccessDenied: (message) => {
-                        context.logGateway.warn(
-                          `webchat audio embedding denied local path: ${message}`,
-                        );
-                      },
-                    });
-                  const combinedAssistantContent =
-                    sourceReplyPayloads.length === 1
-                      ? await buildReplyAssistantContent(finalPayloads)
-                      : undefined;
-                  const combinedMediaMessage =
-                    sourceReplyPayloads.length === 1
-                      ? await buildReplyMediaMessage(finalPayloads)
-                      : undefined;
-                  type SourceReplyContentState = {
-                    broadcastContent: AssistantDisplayContentBlock[];
-                    persistedContent: AssistantDisplayContentBlock[];
-                    hasManagedOutgoingContent: boolean;
-                    backedManagedOutgoingContent: boolean;
-                  };
-                  const sourceReplyContentStates: SourceReplyContentState[] = [];
-                  const sourceReplyBroadcastContent: AssistantDisplayContentBlock[] = [];
-                  for (const [replyIndex] of sourceReplyPayloads.entries()) {
-                    const finalPayload = finalPayloads[replyIndex];
-                    if (!finalPayload) {
-                      continue;
-                    }
-                    const replyAssistantContent =
-                      sourceReplyPayloads.length === 1
-                        ? combinedAssistantContent
-                        : await buildReplyAssistantContent([finalPayload]);
-                    const replyMediaMessage =
-                      sourceReplyPayloads.length === 1
-                        ? combinedMediaMessage
-                        : await buildReplyMediaMessage([finalPayload]);
-                    const replyBroadcastContent = hasAssistantDisplayMediaContent(
-                      replyAssistantContent,
-                    )
-                      ? replyAssistantContent
-                      : hasAssistantDisplayMediaContent(replyMediaMessage?.content)
-                        ? replyMediaMessage?.content
-                        : replyAssistantContent;
-                    const persistedContent = replaceAssistantContentTextBlocks(
-                      replyAssistantContent,
-                      replyMediaMessage ?? null,
-                    );
-                    const state: SourceReplyContentState = {
-                      broadcastContent: replyBroadcastContent ? [...replyBroadcastContent] : [],
-                      persistedContent: persistedContent ? [...persistedContent] : [],
-                      hasManagedOutgoingContent:
-                        hasManagedOutgoingAssistantContent(persistedContent),
-                      backedManagedOutgoingContent: false,
-                    };
-                    sourceReplyContentStates[replyIndex] = state;
-                    if (state.broadcastContent.length > 0) {
-                      sourceReplyBroadcastContent.push(...state.broadcastContent);
-                    }
-                  }
-
-                  const displayReply =
-                    extractAssistantDisplayTextFromContent(sourceReplyBroadcastContent) ??
-                    buildTranscriptReplyText(finalPayloads);
-                  if (sourceReplyBroadcastContent.length || displayReply) {
-                    const sourceReplyPersistenceRequests: Array<{
-                      idempotencyKey: string;
-                      metadata: NonNullable<
-                        ReturnType<typeof getReplyPayloadMetadata>
-                      >["sourceReplyTranscriptMirror"];
-                      state: SourceReplyContentState;
-                    }> = [];
-                    for (const [replyIndex, sourceReplyPayload] of sourceReplyPayloads.entries()) {
-                      const state = sourceReplyContentStates[replyIndex];
-                      if (!state || !hasAssistantDisplayMediaContent(state.persistedContent)) {
-                        continue;
-                      }
-                      const mirrorMetadata =
-                        getReplyPayloadMetadata(sourceReplyPayload)?.sourceReplyTranscriptMirror;
-                      const mirrorIdempotencyKey = mirrorMetadata?.idempotencyKey;
-                      if (
-                        typeof mirrorIdempotencyKey !== "string" ||
-                        mirrorIdempotencyKey.trim().length === 0
-                      ) {
-                        continue;
-                      }
-                      if (!state.hasManagedOutgoingContent) {
-                        state.backedManagedOutgoingContent = true;
-                      }
-                      sourceReplyPersistenceRequests.push({
-                        idempotencyKey: mirrorIdempotencyKey,
-                        metadata: mirrorMetadata,
-                        state,
-                      });
-                    }
-
-                    const attachSourceReplyManagedImages = async (params: {
-                      messageId?: string;
-                      request: (typeof sourceReplyPersistenceRequests)[number];
-                    }) => {
-                      if (!params.request.state.hasManagedOutgoingContent) {
-                        params.request.state.backedManagedOutgoingContent = true;
-                        return;
-                      }
-                      if (!params.messageId) {
-                        return;
-                      }
-                      await attachManagedOutgoingImagesToMessage({
-                        messageId: params.messageId,
-                        blocks: params.request.state.persistedContent,
-                      });
-                      params.request.state.backedManagedOutgoingContent = true;
-                    };
-
-                    if (resolvedTranscriptPath && sourceReplyPersistenceRequests.length > 0) {
-                      const allowedSourceReplyMirrorIds = new Set<string>();
-                      for (const [
-                        replyIndex,
-                        sourceReplyPayload,
-                      ] of sourceReplyPayloads.entries()) {
-                        if (!sourceReplyContentStates[replyIndex]) {
-                          continue;
-                        }
-                        const mirrorIdempotencyKey =
-                          getReplyPayloadMetadata(sourceReplyPayload)?.sourceReplyTranscriptMirror
-                            ?.idempotencyKey;
-                        const mirrorMetadata =
-                          getReplyPayloadMetadata(sourceReplyPayload)?.sourceReplyTranscriptMirror;
-                        if (
-                          typeof mirrorIdempotencyKey !== "string" ||
-                          mirrorIdempotencyKey.trim().length === 0 ||
-                          !mirrorMetadata
-                        ) {
-                          continue;
-                        }
-                        const target = await findSourceReplyTranscriptMirrorByMetadata({
-                          transcriptPath: resolvedTranscriptPath,
-                          idempotencyKey: mirrorIdempotencyKey,
-                          metadata: mirrorMetadata,
-                        });
-                        if (target) {
-                          allowedSourceReplyMirrorIds.add(target.messageId);
-                        }
-                      }
-                      const rewriteTargets: Array<{
-                        request: (typeof sourceReplyPersistenceRequests)[number];
-                        messageId: string;
-                        message: Record<string, unknown>;
-                      }> = [];
-                      for (const request of sourceReplyPersistenceRequests) {
-                        const target = await findSourceReplyTranscriptMirrorByMetadata({
-                          transcriptPath: resolvedTranscriptPath,
-                          idempotencyKey: request.idempotencyKey,
-                          metadata: request.metadata,
-                        });
-                        if (target) {
-                          rewriteTargets.push({ request, ...target });
-                        }
-                      }
-
-                      if (rewriteTargets.length > 0) {
-                        const rewriteTargetIds = new Set(
-                          rewriteTargets.map((target) => target.messageId),
-                        );
-                        const rewriteIndex =
-                          await readSessionTranscriptIndex(resolvedTranscriptPath);
-                        const firstRewriteEntryIndex =
-                          rewriteIndex?.entries.findIndex(
-                            (entry) =>
-                              typeof entry.id === "string" && rewriteTargetIds.has(entry.id),
-                          ) ?? -1;
-                        const canRewriteSourceReplyMirrors =
-                          firstRewriteEntryIndex >= 0 &&
-                          rewriteIndex?.entries
-                            .slice(firstRewriteEntryIndex)
-                            .every(
-                              (entry) =>
-                                typeof entry.id !== "string" ||
-                                allowedSourceReplyMirrorIds.has(entry.id),
-                            ) === true;
-                        if (canRewriteSourceReplyMirrors) {
-                          const result = await rewriteTranscriptEntriesInSessionFile({
-                            sessionFile: resolvedTranscriptPath,
-                            sessionKey,
-                            config: cfg,
-                            request: {
-                              allowedRewriteSuffixEntryIds: [...allowedSourceReplyMirrorIds],
-                              replacements: rewriteTargets.map((target) => ({
-                                entryId: target.messageId,
-                                message: {
-                                  ...(target.message as unknown as AgentMessage),
-                                  idempotencyKey: target.request.idempotencyKey,
-                                  content: target.request.state.persistedContent,
-                                } as unknown as AgentMessage,
-                              })),
-                            },
-                          });
-                          if (result.changed) {
-                            for (const target of rewriteTargets) {
-                              const rewritten =
-                                await findSourceReplyTranscriptMirrorByIdempotencyKey(
-                                  resolvedTranscriptPath,
-                                  target.request.idempotencyKey,
-                                );
-                              await attachSourceReplyManagedImages({
-                                messageId: rewritten?.messageId,
-                                request: target.request,
-                              });
-                            }
-                          }
-                        }
-                      }
-                    }
-                    const sourceReplyContent = sourceReplyContentStates
-                      .flatMap((state) => {
-                        if (
-                          state.hasManagedOutgoingContent &&
-                          !state.backedManagedOutgoingContent
-                        ) {
-                          const stripped = stripManagedOutgoingAssistantContentBlocks(
-                            state.broadcastContent,
-                          );
-                          return stripped?.length
-                            ? stripped
-                            : [{ type: "text", text: "Media reply could not be displayed." }];
-                        }
-                        return state.broadcastContent;
-                      })
-                      .filter((block): block is AssistantDisplayContentBlock => Boolean(block));
-                    const sourceReplyTextFromContent =
-                      extractAssistantDisplayTextFromContent(sourceReplyContent);
-                    const sourceReplyText =
-                      sourceReplyTextFromContent ??
-                      (sourceReplyContent.length === 0 ? displayReply : undefined);
-                    const now = Date.now();
-                    const message = {
-                      role: "assistant",
-                      ...(sourceReplyContent?.length
-                        ? { content: sourceReplyContent }
-                        : sourceReplyText
-                          ? { content: [{ type: "text", text: sourceReplyText }] }
-                          : {}),
-                      ...(sourceReplyText ? { text: sourceReplyText } : {}),
-                      timestamp: now,
-                      stopReason: "stop",
-                      usage: { input: 0, output: 0, totalTokens: 0 },
-                    };
-                    broadcastChatFinal({
-                      context,
-                      runId: clientRunId,
-                      sessionKey,
-                      message,
-                    });
-                    broadcastedSourceReplyFinal = true;
-                  }
-                }
-              }
-              const shouldBroadcastAgentError =
-                returnedAgentErrorPayloads.length > 0 && !broadcastedSourceReplyFinal;
-              if (shouldBroadcastAgentError) {
+              } else if (returnedAgentErrorPayloads.length > 0) {
                 if (!hasBeforeAgentRunGate) {
                   await emitUserTranscriptUpdateAfterAgentRun();
                 }
@@ -3980,25 +2948,27 @@ export const chatHandlers: GatewayRequestHandlers = {
                 await emitUserTranscriptUpdateAfterAgentRun();
               }
               if (!context.chatAbortedRuns.has(clientRunId)) {
-                const returnedAgentError = shouldBroadcastAgentError
-                  ? errorShape(
-                      ErrorCodes.UNAVAILABLE,
-                      returnedAgentErrorMessage ?? "agent returned an error payload",
-                    )
-                  : undefined;
+                const returnedAgentError =
+                  returnedAgentErrorPayloads.length > 0
+                    ? errorShape(
+                        ErrorCodes.UNAVAILABLE,
+                        returnedAgentErrorMessage ?? "agent returned an error payload",
+                      )
+                    : undefined;
                 setGatewayDedupeEntry({
                   dedupe: context.dedupe,
                   key: `chat:${clientRunId}`,
                   entry: {
                     ts: Date.now(),
-                    ok: !shouldBroadcastAgentError,
-                    payload: shouldBroadcastAgentError
-                      ? {
-                          runId: clientRunId,
-                          status: "error" as const,
-                          summary: returnedAgentErrorMessage ?? "agent returned an error payload",
-                        }
-                      : { runId: clientRunId, status: "ok" as const },
+                    ok: returnedAgentErrorPayloads.length === 0,
+                    payload:
+                      returnedAgentErrorPayloads.length > 0
+                        ? {
+                            runId: clientRunId,
+                            status: "error" as const,
+                            summary: returnedAgentErrorMessage ?? "agent returned an error payload",
+                          }
+                        : { runId: clientRunId, status: "ok" as const },
                     ...(returnedAgentError ? { error: returnedAgentError } : {}),
                   },
                 });

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -130,7 +130,7 @@ import {
   type AssistantDisplayContentBlock,
 } from "./chat-assistant-content.js";
 import {
-  createInternalSourceReplyBroadcaster,
+  createInternalSourceReplyProjector,
   isInternalSourceReplyPayload,
 } from "./chat-internal-source-reply.js";
 import { normalizeWebchatReplyMediaPathsForDisplay } from "./chat-reply-media.js";
@@ -2616,7 +2616,7 @@ export const chatHandlers: GatewayRequestHandlers = {
           `webchat transcript append failed for media reply: ${appended.error ?? "unknown error"}`,
         );
       };
-      const internalSourceReplyBroadcaster = createInternalSourceReplyBroadcaster({
+      const internalSourceReplyProjector = createInternalSourceReplyProjector({
         cfg,
         sessionKey,
         agentId,
@@ -2648,7 +2648,7 @@ export const chatHandlers: GatewayRequestHandlers = {
             case "final":
               deliveredReplies.push({ payload, kind: info.kind });
               await appendWebchatAgentMediaTranscriptIfNeeded(payload);
-              await internalSourceReplyBroadcaster.broadcastIfNeeded({
+              await internalSourceReplyProjector.projectIfNeeded({
                 payload,
                 agentRunStarted,
               });

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -16,6 +16,7 @@ import { ensureSandboxWorkspaceForSession } from "../../agents/sandbox/context.j
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { dispatchInboundMessage } from "../../auto-reply/dispatch.js";
 import { getReplyPayloadMetadata, type ReplyPayload } from "../../auto-reply/reply-payload.js";
+import { resolveImageModelOverridePlan } from "../../auto-reply/reply/image-model-override-plan.js";
 import { createReplyDispatcher } from "../../auto-reply/reply/reply-dispatcher.js";
 import { stageSandboxMedia } from "../../auto-reply/reply/stage-sandbox-media.js";
 import type { MsgContext, TemplateContext } from "../../auto-reply/templating.js";
@@ -32,6 +33,11 @@ import { formatErrorMessage, formatUncaughtError } from "../../infra/errors.js";
 import { jsonUtf8Bytes } from "../../infra/json-utf8-bytes.js";
 import { normalizeReplyPayloadsForDelivery } from "../../infra/outbound/payloads.js";
 import { getSessionBindingService } from "../../infra/outbound/session-binding-service.js";
+import {
+  interactiveReplyToPresentation,
+  normalizeInteractiveReply,
+  renderMessagePresentationFallbackText,
+} from "../../interactive/payload.js";
 import { logLargePayload } from "../../logging/diagnostic-payload.js";
 import {
   appendLocalMediaParentRoots,
@@ -61,10 +67,11 @@ import {
 import {
   INTERNAL_MESSAGE_CHANNEL,
   isGatewayCliClient,
+  isInternalSourceSurfaceClient,
   isOperatorUiClient,
-  isWebchatClient,
   normalizeMessageChannel,
 } from "../../utils/message-channel.js";
+import { safeJsonStringify } from "../../utils/safe-json.js";
 import {
   abortChatRunById,
   type ChatAbortControllerEntry,
@@ -158,6 +165,10 @@ type AbortedPartialSnapshot = {
   abortOrigin: AbortOrigin;
 };
 
+type SourceReplyTranscriptMirrorMetadata = NonNullable<
+  ReturnType<typeof getReplyPayloadMetadata>
+>["sourceReplyTranscriptMirror"];
+
 type ChatAbortRequester = {
   connId?: string;
   deviceId?: string;
@@ -182,6 +193,9 @@ type PreRegisteredAgentRun = {
 function normalizeUnknownText(value: unknown): string | undefined {
   return typeof value === "string" ? normalizeOptionalText(value) : undefined;
 }
+
+const RICH_SOURCE_REPLY_FALLBACK_MAX_CHARS = 8_000;
+const SOURCE_REPLY_MIRROR_RECHECK_DELAYS_MS = [10, 25, 50, 100, 250, 500] as const;
 
 /** True when a reply payload carries at least one media reference (mediaUrl or mediaUrls). */
 function isMediaBearingPayload(payload: ReplyPayload): boolean {
@@ -441,6 +455,51 @@ function sanitizeAssistantDisplayText(value?: string | null): string | undefined
   return stripped || undefined;
 }
 
+function truncateRichSourceReplyFallbackText(text: string): string {
+  return text.length <= RICH_SOURCE_REPLY_FALLBACK_MAX_CHARS
+    ? text
+    : `${text.slice(0, RICH_SOURCE_REPLY_FALLBACK_MAX_CHARS)}\n...(truncated)...`;
+}
+
+function buildRichSourceReplyFallbackText(payload: ReplyPayload): string | undefined {
+  const parts: string[] = [];
+  if (payload.presentation) {
+    const text = renderMessagePresentationFallbackText({
+      presentation: payload.presentation,
+    }).trim();
+    if (text) {
+      parts.push(text);
+    }
+  }
+  if (payload.interactive) {
+    const normalizedInteractive = normalizeInteractiveReply(payload.interactive);
+    const interactivePresentation = normalizedInteractive
+      ? interactiveReplyToPresentation(normalizedInteractive)
+      : undefined;
+    const text = interactivePresentation
+      ? renderMessagePresentationFallbackText({
+          presentation: interactivePresentation,
+        }).trim()
+      : undefined;
+    if (text && !parts.includes(text)) {
+      parts.push(text);
+    }
+  }
+  if (
+    payload.channelData &&
+    typeof payload.channelData === "object" &&
+    !Array.isArray(payload.channelData) &&
+    Object.keys(payload.channelData).length > 0
+  ) {
+    const json = safeJsonStringify(payload.channelData);
+    if (json && json !== "{}") {
+      parts.push(`Channel data:\n${json}`);
+    }
+  }
+  const text = parts.join("\n\n").trim();
+  return sanitizeAssistantDisplayText(truncateRichSourceReplyFallbackText(text));
+}
+
 function extractAssistantDisplayTextFromContent(
   content?: readonly AssistantDisplayContentBlock[] | null,
 ): string | undefined {
@@ -456,6 +515,45 @@ function extractAssistantDisplayTextFromContent(
     })
     .filter(Boolean);
   return parts.length > 0 ? parts.join("\n\n") : undefined;
+}
+
+function mergeSourceReplyDisplayText(
+  primaryText: string | undefined,
+  richFallbackText: string | undefined,
+): string | undefined {
+  const primary = sanitizeAssistantDisplayText(primaryText);
+  const rich = sanitizeAssistantDisplayText(richFallbackText);
+  if (!primary) {
+    return rich;
+  }
+  if (!rich || primary.includes(rich)) {
+    return primary;
+  }
+  return `${primary}\n\n${rich}`;
+}
+
+function applyDisplayTextToAssistantContent(
+  content: readonly AssistantDisplayContentBlock[] | undefined,
+  displayText: string | undefined,
+): AssistantDisplayContentBlock[] | undefined {
+  if (!displayText) {
+    return content ? [...content] : undefined;
+  }
+  if (!content || content.length === 0) {
+    return [{ type: "text", text: displayText }];
+  }
+  const next = [...content];
+  const textIndex = next.findIndex(
+    (block) => block?.type === "text" && typeof block.text === "string",
+  );
+  if (textIndex === -1) {
+    return [{ type: "text", text: displayText }, ...next];
+  }
+  next[textIndex] = {
+    ...next[textIndex],
+    text: displayText,
+  };
+  return next;
 }
 
 async function buildAssistantDisplayContentFromReplyPayloads(params: {
@@ -620,6 +718,52 @@ function hasManagedOutgoingAssistantContent(
   );
 }
 
+function buildAssistantMediaFallbackText(
+  content: readonly AssistantDisplayContentBlock[] | undefined,
+): string | undefined {
+  if (!hasAssistantDisplayMediaContent(content)) {
+    return undefined;
+  }
+  let hasAudio = false;
+  let hasImage = false;
+  let hasOtherMedia = false;
+  for (const block of content ?? []) {
+    if (block?.type === "text") {
+      continue;
+    }
+    if (block?.type === "image" || block?.type === "input_image") {
+      hasImage = true;
+      continue;
+    }
+    if (block?.type === "attachment") {
+      const attachment =
+        typeof block.attachment === "object" &&
+        block.attachment !== null &&
+        !Array.isArray(block.attachment)
+          ? (block.attachment as Record<string, unknown>)
+          : undefined;
+      if (attachment?.kind === "audio") {
+        hasAudio = true;
+      } else {
+        hasOtherMedia = true;
+      }
+      continue;
+    }
+    if (block?.type === "audio") {
+      hasAudio = true;
+      continue;
+    }
+    hasOtherMedia = true;
+  }
+  if (hasOtherMedia || (hasAudio && hasImage)) {
+    return "Media reply";
+  }
+  if (hasAudio) {
+    return "Audio reply";
+  }
+  return hasImage ? "Image reply" : undefined;
+}
+
 function scheduleChatHistoryManagedImageCleanup(params: {
   sessionKey: string;
   context: Pick<GatewayRequestContext, "logGateway">;
@@ -711,7 +855,7 @@ function resolveChatSendOriginatingRoute(params: {
     !isChannelScopedSession &&
     typeof sessionScopeParts[1] === "string" &&
     sessionChannelHint === routeChannelCandidate;
-  const isFromWebchatClient = isWebchatClient(params.client);
+  const isFromInternalSourceSurfaceClient = isInternalSourceSurfaceClient(params.client);
   const isFromGatewayCliClient = isGatewayCliClient(params.client);
   const hasClientMetadata =
     (typeof params.client?.mode === "string" && params.client.mode.trim().length > 0) ||
@@ -724,11 +868,11 @@ function resolveChatSendOriginatingRoute(params: {
     params.hasConnectedClient &&
     (isFromGatewayCliClient || !hasClientMetadata);
 
-  // Webchat clients never inherit external delivery routes. Configured-main
+  // Internal source surfaces never inherit external delivery routes. Configured-main
   // sessions are stricter than channel-scoped sessions: only CLI callers, or
   // legacy callers with no client metadata, may inherit the last external route.
   const canInheritDeliverableRoute = Boolean(
-    !isFromWebchatClient &&
+    !isFromInternalSourceSurfaceClient &&
     sessionChannelHint &&
     sessionChannelHint !== INTERNAL_MESSAGE_CHANNEL &&
     ((!isChannelAgnosticSessionScope && (isChannelScopedSession || hasLegacyChannelPeerShape)) ||
@@ -2056,6 +2200,95 @@ function isBtwReplyPayload(payload: ReplyPayload | undefined): payload is ReplyP
   );
 }
 
+function isInternalSourceReplyPayload(payload: ReplyPayload | undefined): payload is ReplyPayload {
+  if (!payload || typeof payload !== "object") {
+    return false;
+  }
+  return Boolean(getReplyPayloadMetadata(payload)?.sourceReplyTranscriptMirror);
+}
+
+function sourceReplyMirrorHasDurableContent(
+  metadata: SourceReplyTranscriptMirrorMetadata | undefined,
+): boolean {
+  return Boolean(
+    metadata?.text?.trim() || metadata?.mediaUrls?.some((mediaUrl) => mediaUrl.trim()),
+  );
+}
+
+function normalizeSourceReplyMirrorMediaUrls(mediaUrls: readonly string[] | undefined): string[] {
+  return mediaUrls?.map((mediaUrl) => mediaUrl.trim()).filter(Boolean) ?? [];
+}
+
+function sourceReplyMirrorMediaUrlsEqual(
+  left: readonly string[] | undefined,
+  right: readonly string[] | undefined,
+): boolean {
+  const normalizedLeft = normalizeSourceReplyMirrorMediaUrls(left);
+  const normalizedRight = normalizeSourceReplyMirrorMediaUrls(right);
+  if (normalizedLeft.length !== normalizedRight.length) {
+    return false;
+  }
+  return normalizedLeft.every((mediaUrl, index) => mediaUrl === normalizedRight[index]);
+}
+
+function sourceReplyContentNeedsMirrorUpgrade(params: {
+  metadata: SourceReplyTranscriptMirrorMetadata | undefined;
+  displayPayload: ReplyPayload;
+  displayReply?: string;
+  content: readonly AssistantDisplayContentBlock[] | undefined;
+  richSourceReplyFallback?: string;
+}): boolean {
+  if (!params.content?.length) {
+    return false;
+  }
+  if (params.displayPayload.sensitiveMedia === true) {
+    return true;
+  }
+  if (params.richSourceReplyFallback || hasAssistantDisplayMediaContent(params.content)) {
+    return true;
+  }
+  const metadataText = params.metadata?.text?.trim() ?? "";
+  const displayText = params.displayReply?.trim() ?? "";
+  if (metadataText !== displayText) {
+    return true;
+  }
+  return !sourceReplyMirrorMediaUrlsEqual(
+    params.metadata?.mediaUrls,
+    resolveSendableOutboundReplyParts(params.displayPayload).mediaUrls,
+  );
+}
+
+function findAssistantTranscriptEntryByIdempotencyKey(
+  index: Awaited<ReturnType<typeof readSessionTranscriptIndex>>,
+  idempotencyKey: string,
+) {
+  return index?.entries.toReversed().find((entry) => {
+    const message = entry.record.message as Record<string, unknown> | undefined;
+    return (
+      Boolean(entry.id) &&
+      message?.role === "assistant" &&
+      message.idempotencyKey === idempotencyKey
+    );
+  });
+}
+
+async function waitForAssistantTranscriptEntryByIdempotencyKey(
+  transcriptPath: string,
+  idempotencyKey: string,
+) {
+  for (const delayMs of SOURCE_REPLY_MIRROR_RECHECK_DELAYS_MS) {
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+    const target = findAssistantTranscriptEntryByIdempotencyKey(
+      await readSessionTranscriptIndex(transcriptPath),
+      idempotencyKey,
+    );
+    if (target) {
+      return target;
+    }
+  }
+  return undefined;
+}
+
 function broadcastSideResult(params: {
   context: Pick<GatewayRequestContext, "broadcast" | "nodeSendToSession" | "agentRunSeq">;
   payload: SideResultPayload;
@@ -2808,12 +3041,19 @@ export const chatHandlers: GatewayRequestHandlers = {
         });
       };
       const appendWebchatAgentMediaTranscriptIfNeeded = async (payload: ReplyPayload) => {
-        if (!agentRunStarted || appendedWebchatAgentMedia || !isMediaBearingPayload(payload)) {
+        if (
+          !agentRunStarted ||
+          !isMediaBearingPayload(payload) ||
+          isInternalSourceReplyPayload(payload)
+        ) {
           return;
         }
-        if (isSourceReplyTranscriptMirrorPayload(payload)) {
+        if (appendedWebchatAgentMedia) {
           return;
         }
+        const markMediaHandled = () => {
+          appendedWebchatAgentMedia = true;
+        };
         const ttsSupplementMarker = buildTtsSupplementTranscriptMarker(payload);
         const [transcriptPayload] = await normalizeWebchatReplyMediaPathsForDisplay({
           cfg,
@@ -2891,12 +3131,241 @@ export const chatHandlers: GatewayRequestHandlers = {
               blocks: assistantContent,
             });
           }
-          appendedWebchatAgentMedia = true;
+          markMediaHandled();
           return;
         }
         context.logGateway.warn(
           `webchat transcript append failed for media reply: ${appended.error ?? "unknown error"}`,
         );
+      };
+      const pendingSourceReplyMirrorUpgradeKeys = new Set<string>();
+      const rewriteInternalSourceReplyMirrorContent = async (params: {
+        transcriptPath: string;
+        sourceReplyRunId: string;
+        content: AssistantDisplayContentBlock[];
+      }): Promise<boolean> => {
+        const target = findAssistantTranscriptEntryByIdempotencyKey(
+          await readSessionTranscriptIndex(params.transcriptPath),
+          params.sourceReplyRunId,
+        );
+        const targetMessage = target?.record.message as Record<string, unknown> | undefined;
+        if (!target?.id || !targetMessage) {
+          return false;
+        }
+        const rewritten = await rewriteTranscriptEntriesInSessionFile({
+          sessionFile: params.transcriptPath,
+          sessionKey,
+          config: cfg,
+          request: {
+            replacements: [
+              {
+                entryId: target.id,
+                message: {
+                  ...targetMessage,
+                  content: params.content,
+                } as unknown as AgentMessage,
+              },
+            ],
+          },
+        });
+        if (!rewritten.changed && rewritten.reason) {
+          context.logGateway.warn(
+            `webchat source reply transcript rewrite failed: ${rewritten.reason}`,
+          );
+          return true;
+        }
+        const rewrittenTarget = rewritten.changed
+          ? findAssistantTranscriptEntryByIdempotencyKey(
+              await readSessionTranscriptIndex(params.transcriptPath),
+              params.sourceReplyRunId,
+            )
+          : target;
+        if (rewrittenTarget?.id) {
+          await attachManagedOutgoingImagesToMessage({
+            messageId: rewrittenTarget.id,
+            blocks: params.content,
+          });
+        }
+        return true;
+      };
+      const queueInternalSourceReplyMirrorContentUpgrade = (params: {
+        transcriptPath: string;
+        sourceReplyRunId: string;
+        content: AssistantDisplayContentBlock[];
+      }) => {
+        if (pendingSourceReplyMirrorUpgradeKeys.has(params.sourceReplyRunId)) {
+          return;
+        }
+        pendingSourceReplyMirrorUpgradeKeys.add(params.sourceReplyRunId);
+        void (async () => {
+          try {
+            const target = await waitForAssistantTranscriptEntryByIdempotencyKey(
+              params.transcriptPath,
+              params.sourceReplyRunId,
+            );
+            if (!target) {
+              context.logGateway.warn(
+                "webchat source reply transcript rewrite skipped: mirror not found",
+              );
+              return;
+            }
+            await rewriteInternalSourceReplyMirrorContent(params);
+          } finally {
+            pendingSourceReplyMirrorUpgradeKeys.delete(params.sourceReplyRunId);
+          }
+        })();
+      };
+      let internalSourceReplyBroadcastCount = 0;
+      const broadcastInternalSourceReplyIfNeeded = async (payload: ReplyPayload) => {
+        if (!agentRunStarted || !isInternalSourceReplyPayload(payload)) {
+          return;
+        }
+        const metadata = getReplyPayloadMetadata(payload)?.sourceReplyTranscriptMirror;
+        const [displayPayload] = await normalizeWebchatReplyMediaPathsForDisplay({
+          cfg,
+          sessionKey,
+          agentId,
+          accountId,
+          payloads: [payload],
+        });
+        if (!displayPayload) {
+          return;
+        }
+        const { storePath: latestStorePath, entry: latestEntry } = loadSessionEntry(sessionKey);
+        const sessionId = latestEntry?.sessionId ?? backingSessionId ?? clientRunId;
+        const resolvedTranscriptPath = resolveTranscriptPath({
+          sessionId,
+          storePath: latestStorePath,
+          sessionFile: latestEntry?.sessionFile ?? entry?.sessionFile,
+          agentId,
+        });
+        const mediaLocalRoots = appendLocalMediaParentRoots(
+          getAgentScopedMediaLocalRoots(cfg, agentId),
+          resolvedTranscriptPath ? [resolvedTranscriptPath] : undefined,
+        );
+        const assistantContent = await buildAssistantDisplayContentFromReplyPayloads({
+          sessionKey,
+          payloads: [displayPayload],
+          managedImageLocalRoots: mediaLocalRoots,
+          includeSensitiveMedia: displayPayload.sensitiveMedia !== true,
+          onLocalAudioAccessDenied: (message) => {
+            context.logGateway.warn(`webchat audio embedding denied local path: ${message}`);
+          },
+          onManagedImagePrepareError: (message) => {
+            context.logGateway.warn(`webchat image embedding skipped attachment: ${message}`);
+          },
+        });
+        const mediaMessage = await buildWebchatAssistantMediaMessage([displayPayload], {
+          localRoots: mediaLocalRoots,
+          onLocalAudioAccessDenied: (message) => {
+            context.logGateway.warn(`webchat audio embedding denied local path: ${message}`);
+          },
+        });
+        const broadcastAssistantContent = hasAssistantDisplayMediaContent(assistantContent)
+          ? assistantContent
+          : hasAssistantDisplayMediaContent(mediaMessage?.content)
+            ? mediaMessage?.content
+            : assistantContent;
+        const transcriptReplyText = buildTranscriptReplyText([displayPayload]);
+        const richSourceReplyFallback = buildRichSourceReplyFallbackText(displayPayload);
+        const mediaFallbackText = buildAssistantMediaFallbackText(broadcastAssistantContent);
+        const displayReply = mergeSourceReplyDisplayText(
+          extractAssistantDisplayTextFromContent(assistantContent) ??
+            mediaMessage?.transcriptText ??
+            mediaFallbackText ??
+            transcriptReplyText,
+          richSourceReplyFallback,
+        );
+        if (!displayReply && !broadcastAssistantContent?.length) {
+          return;
+        }
+        const sourceReplyIndex = internalSourceReplyBroadcastCount;
+        internalSourceReplyBroadcastCount += 1;
+        // The model run may already have emitted its final event; use a distinct
+        // run id so TUI/WebChat clients do not discard this visible source reply.
+        const sourceReplyRunId =
+          metadata?.idempotencyKey?.trim() ||
+          `${clientRunId}:internal-source-reply:${sourceReplyIndex}`;
+        const broadcastContent = applyDisplayTextToAssistantContent(
+          broadcastAssistantContent,
+          displayReply,
+        );
+        const transcriptContentSource =
+          displayPayload.sensitiveMedia === true ? assistantContent : broadcastAssistantContent;
+        const transcriptContent = applyDisplayTextToAssistantContent(
+          transcriptContentSource,
+          displayReply,
+        );
+        const metadataHasDurableMirrorContent = sourceReplyMirrorHasDurableContent(metadata);
+        const needsMirrorUpgrade = sourceReplyContentNeedsMirrorUpgrade({
+          metadata,
+          displayPayload,
+          displayReply,
+          content: transcriptContent,
+          richSourceReplyFallback,
+        });
+        let message: Record<string, unknown> = {
+          role: "assistant",
+          ...(broadcastContent?.length ? { content: broadcastContent } : {}),
+          ...(displayReply ? { text: displayReply } : {}),
+          timestamp: Date.now(),
+          stopReason: "stop",
+          usage: { input: 0, output: 0, totalTokens: 0 },
+        };
+        let durableMirrorFound = false;
+        if (
+          metadataHasDurableMirrorContent &&
+          needsMirrorUpgrade &&
+          transcriptContent?.length &&
+          resolvedTranscriptPath
+        ) {
+          durableMirrorFound = await rewriteInternalSourceReplyMirrorContent({
+            transcriptPath: resolvedTranscriptPath,
+            sourceReplyRunId,
+            content: transcriptContent,
+          });
+          if (!durableMirrorFound) {
+            queueInternalSourceReplyMirrorContentUpgrade({
+              transcriptPath: resolvedTranscriptPath,
+              sourceReplyRunId,
+              content: transcriptContent,
+            });
+          }
+        }
+        if (displayReply && !metadataHasDurableMirrorContent) {
+          const appended = await appendAssistantTranscriptMessage({
+            message: displayReply,
+            ...(transcriptContent?.length ? { content: transcriptContent } : {}),
+            sessionId,
+            storePath: latestStorePath,
+            sessionFile: latestEntry?.sessionFile,
+            agentId,
+            createIfMissing: true,
+            idempotencyKey: sourceReplyRunId,
+            cfg,
+          });
+          if (appended.ok && appended.message) {
+            if (appended.messageId && transcriptContent?.length) {
+              await attachManagedOutgoingImagesToMessage({
+                messageId: appended.messageId,
+                blocks: transcriptContent,
+              });
+            }
+            message = broadcastContent?.length
+              ? { ...appended.message, content: broadcastContent }
+              : appended.message;
+          } else {
+            context.logGateway.warn(
+              `webchat source reply transcript append failed: ${appended.error ?? "unknown error"}`,
+            );
+          }
+        }
+        broadcastChatFinal({
+          context,
+          runId: sourceReplyRunId,
+          sessionKey,
+          message,
+        });
       };
       const dispatcher = createReplyDispatcher({
         ...replyPipeline,
@@ -2909,6 +3378,7 @@ export const chatHandlers: GatewayRequestHandlers = {
             case "final":
               deliveredReplies.push({ payload, kind: info.kind });
               await appendWebchatAgentMediaTranscriptIfNeeded(payload);
+              await broadcastInternalSourceReplyIfNeeded(payload);
               break;
             case "tool":
               // Tool results that carry audio (e.g. the TTS tool) must be promoted

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -16,7 +16,6 @@ import { ensureSandboxWorkspaceForSession } from "../../agents/sandbox/context.j
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { dispatchInboundMessage } from "../../auto-reply/dispatch.js";
 import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
-import { resolveImageModelOverridePlan } from "../../auto-reply/reply/image-model-override-plan.js";
 import { createReplyDispatcher } from "../../auto-reply/reply/reply-dispatcher.js";
 import { stageSandboxMedia } from "../../auto-reply/reply/stage-sandbox-media.js";
 import type { MsgContext, TemplateContext } from "../../auto-reply/templating.js";
@@ -1263,6 +1262,31 @@ async function transcriptHasIdempotencyKey(
   }
 }
 
+async function findAssistantTranscriptMessageByIdempotencyKey(
+  transcriptPath: string,
+  idempotencyKey: string,
+): Promise<{ messageId: string; message: Record<string, unknown> } | null> {
+  const trimmedIdempotencyKey = idempotencyKey.trim();
+  if (!trimmedIdempotencyKey) {
+    return null;
+  }
+  const index = await readSessionTranscriptIndex(transcriptPath);
+  const target = index?.entries.toReversed().find((entry) => {
+    const message = entry.record.message as Record<string, unknown> | undefined;
+    return (
+      typeof entry.id === "string" &&
+      entry.id.trim().length > 0 &&
+      message?.role === "assistant" &&
+      message.idempotencyKey === trimmedIdempotencyKey
+    );
+  });
+  const message = target?.record.message as Record<string, unknown> | undefined;
+  if (!target?.id || !message) {
+    return null;
+  }
+  return { messageId: target.id, message };
+}
+
 async function appendAssistantTranscriptMessage(params: {
   message: string;
   label?: string;
@@ -1803,7 +1827,6 @@ function broadcastChatError(params: {
   params.context.nodeSendToSession(params.sessionKey, "chat", payload);
   params.context.agentRunSeq.delete(params.runId);
 }
-
 
 export const chatHandlers: GatewayRequestHandlers = {
   "chat.history": async ({ params, respond, context }) => {
@@ -2648,10 +2671,6 @@ export const chatHandlers: GatewayRequestHandlers = {
             case "final":
               deliveredReplies.push({ payload, kind: info.kind });
               await appendWebchatAgentMediaTranscriptIfNeeded(payload);
-              await internalSourceReplyProjector.projectIfNeeded({
-                payload,
-                agentRunStarted,
-              });
               break;
             case "tool":
               // Tool results that carry audio (e.g. the TTS tool) must be promoted
@@ -2737,6 +2756,12 @@ export const chatHandlers: GatewayRequestHandlers = {
                   .map((payload) => payload.text?.trim())
                   .filter((text): text is string => Boolean(text))
                   .join(" | ") || undefined;
+              const broadcastedSourceReplyFinal = await internalSourceReplyProjector.projectReplies(
+                {
+                  deliveredReplies,
+                  agentRunStarted,
+                },
+              );
               // WebChat persistence has two owners. Agent runs persist model-visible turns
               // through Pi's SessionManager; this dispatcher only owns live delivery payloads.
               // Do not blindly mirror agent-run final payloads into JSONL or chat.history can
@@ -2934,7 +2959,10 @@ export const chatHandlers: GatewayRequestHandlers = {
                     message,
                   });
                 }
-              } else if (returnedAgentErrorPayloads.length > 0) {
+              }
+              const shouldBroadcastAgentError =
+                returnedAgentErrorPayloads.length > 0 && !broadcastedSourceReplyFinal;
+              if (shouldBroadcastAgentError) {
                 if (!hasBeforeAgentRunGate) {
                   await emitUserTranscriptUpdateAfterAgentRun();
                 }
@@ -2944,31 +2972,29 @@ export const chatHandlers: GatewayRequestHandlers = {
                   sessionKey,
                   errorMessage: returnedAgentErrorMessage,
                 });
-              } else if (!hasBeforeAgentRunGate) {
+              } else if (agentRunStarted && !hasBeforeAgentRunGate) {
                 await emitUserTranscriptUpdateAfterAgentRun();
               }
               if (!context.chatAbortedRuns.has(clientRunId)) {
-                const returnedAgentError =
-                  returnedAgentErrorPayloads.length > 0
-                    ? errorShape(
-                        ErrorCodes.UNAVAILABLE,
-                        returnedAgentErrorMessage ?? "agent returned an error payload",
-                      )
-                    : undefined;
+                const returnedAgentError = shouldBroadcastAgentError
+                  ? errorShape(
+                      ErrorCodes.UNAVAILABLE,
+                      returnedAgentErrorMessage ?? "agent returned an error payload",
+                    )
+                  : undefined;
                 setGatewayDedupeEntry({
                   dedupe: context.dedupe,
                   key: `chat:${clientRunId}`,
                   entry: {
                     ts: Date.now(),
-                    ok: returnedAgentErrorPayloads.length === 0,
-                    payload:
-                      returnedAgentErrorPayloads.length > 0
-                        ? {
-                            runId: clientRunId,
-                            status: "error" as const,
-                            summary: returnedAgentErrorMessage ?? "agent returned an error payload",
-                          }
-                        : { runId: clientRunId, status: "ok" as const },
+                    ok: !shouldBroadcastAgentError,
+                    payload: shouldBroadcastAgentError
+                      ? {
+                          runId: clientRunId,
+                          status: "error" as const,
+                          summary: returnedAgentErrorMessage ?? "agent returned an error payload",
+                        }
+                      : { runId: clientRunId, status: "ok" as const },
                     ...(returnedAgentError ? { error: returnedAgentError } : {}),
                   },
                 });

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "node:buffer";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -1137,7 +1138,12 @@ describe("gateway server chat", () => {
         const sourceReplyRunId = "idem-tui-source-reply:internal-source-reply:0";
         const chatEvents: unknown[] = [];
         const collectChatEvents = (data: WebSocket.RawData) => {
-          const obj = JSON.parse(data.toString()) as { event?: unknown; payload?: unknown };
+          const text = Array.isArray(data)
+            ? Buffer.concat(data).toString("utf8")
+            : Buffer.isBuffer(data)
+              ? data.toString("utf8")
+              : Buffer.from(data).toString("utf8");
+          const obj = JSON.parse(text) as { event?: unknown; payload?: unknown };
           if (obj.event === "chat") {
             chatEvents.push(obj.payload);
           }

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { WebSocket } from "ws";
+import { setReplyPayloadMetadata, type ReplyPayload } from "../auto-reply/reply-payload.js";
 import { emitAgentEvent, registerAgentRunContext } from "../infra/agent-events.js";
 import { extractFirstTextBlock } from "../shared/chat-message-content.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
@@ -1114,6 +1115,115 @@ describe("gateway server chat", () => {
       expect(historyRes.ok).toBe(true);
       const historyTexts = collectHistoryTextValues(historyRes.payload?.messages ?? []);
       expect(historyTexts).toEqual(["main thread context"]);
+    });
+  });
+
+  test("delivers message-tool source replies to TUI clients over gateway chat events", async () => {
+    await withMainSessionStore(async () => {
+      let tuiWs: WebSocket | undefined;
+      try {
+        tuiWs = new WebSocket(`ws://127.0.0.1:${port}`);
+        trackConnectChallengeNonce(tuiWs);
+        await new Promise<void>((resolve) => tuiWs?.once("open", resolve));
+        await connectOk(tuiWs, {
+          client: {
+            id: GATEWAY_CLIENT_NAMES.TUI,
+            version: "dev",
+            platform: "test",
+            mode: GATEWAY_CLIENT_MODES.UI,
+          },
+        });
+
+        const sourceReplyRunId = "idem-tui-source-reply:internal-source-reply:0";
+        const chatEvents: unknown[] = [];
+        const collectChatEvents = (data: WebSocket.RawData) => {
+          const obj = JSON.parse(data.toString()) as { event?: unknown; payload?: unknown };
+          if (obj.event === "chat") {
+            chatEvents.push(obj.payload);
+          }
+        };
+        tuiWs.on("message", collectChatEvents);
+        dispatchInboundMessageMock.mockImplementationOnce(async (...args: unknown[]) => {
+          const [params] = args as [
+            {
+              dispatcher: {
+                sendFinalReply: (payload: ReplyPayload) => boolean;
+                markComplete: () => void;
+                waitForIdle: () => Promise<void>;
+                getQueuedCounts: () => { final: number; block: number; tool: number };
+              };
+              replyOptions?: {
+                runId?: string;
+                onAgentRunStart?: (runId: string) => void;
+              };
+            },
+          ];
+          params.replyOptions?.onAgentRunStart?.(
+            params.replyOptions.runId ?? "idem-tui-source-reply",
+          );
+          params.dispatcher.sendFinalReply(
+            setReplyPayloadMetadata(
+              {
+                text: "Summary visible in the TUI.",
+              },
+              {
+                deliverDespiteSourceReplySuppression: true,
+                sourceReplyTranscriptMirror: {
+                  sessionKey: "main",
+                  agentId: "main",
+                  text: "Summary visible in the TUI.",
+                  idempotencyKey: sourceReplyRunId,
+                },
+              },
+            ),
+          );
+          params.dispatcher.markComplete();
+          await params.dispatcher.waitForIdle();
+          return {
+            queuedFinal: true,
+            counts: params.dispatcher.getQueuedCounts(),
+          };
+        });
+
+        const sendRes = await rpcReq(tuiWs, "chat.send", {
+          sessionKey: "main",
+          message: "post a visible source reply",
+          idempotencyKey: "idem-tui-source-reply",
+        });
+        expect(sendRes.ok).toBe(true);
+
+        await vi.waitFor(
+          () => {
+            const sourceFinal = chatEvents.find(
+              (payload) =>
+                typeof payload === "object" &&
+                payload !== null &&
+                (payload as { state?: unknown }).state === "final" &&
+                (payload as { runId?: unknown }).runId === sourceReplyRunId &&
+                extractFirstTextBlock((payload as { message?: unknown }).message) ===
+                  "Summary visible in the TUI.",
+            );
+            if (!sourceFinal) {
+              throw new Error(`missing TUI source reply; seen=${JSON.stringify(chatEvents)}`);
+            }
+          },
+          { timeout: 8000 },
+        );
+        tuiWs.off("message", collectChatEvents);
+        const sourceFinal = chatEvents.find(
+          (payload) =>
+            typeof payload === "object" &&
+            payload !== null &&
+            (payload as { runId?: unknown }).runId === sourceReplyRunId,
+        );
+        expectRecordFields(sourceFinal, {
+          runId: sourceReplyRunId,
+          sessionKey: "agent:main:main",
+          state: "final",
+        });
+      } finally {
+        tuiWs?.close();
+      }
     });
   });
 

--- a/src/infra/outbound/internal-source-reply.ts
+++ b/src/infra/outbound/internal-source-reply.ts
@@ -1,0 +1,9 @@
+export const INTERNAL_SOURCE_REPLY_SINK = "internal-ui" as const;
+export type InternalSourceReplySink = typeof INTERNAL_SOURCE_REPLY_SINK;
+
+export const INTERNAL_SOURCE_REPLY_TARGET = "current-run" as const;
+export type InternalSourceReplyTarget = typeof INTERNAL_SOURCE_REPLY_TARGET;
+
+export function isInternalSourceReplySink(value: unknown): value is InternalSourceReplySink {
+  return value === INTERNAL_SOURCE_REPLY_SINK;
+}

--- a/src/infra/outbound/internal-source-reply.ts
+++ b/src/infra/outbound/internal-source-reply.ts
@@ -1,9 +1,2 @@
 export const INTERNAL_SOURCE_REPLY_SINK = "internal-ui" as const;
-export type InternalSourceReplySink = typeof INTERNAL_SOURCE_REPLY_SINK;
-
 export const INTERNAL_SOURCE_REPLY_TARGET = "current-run" as const;
-export type InternalSourceReplyTarget = typeof INTERNAL_SOURCE_REPLY_TARGET;
-
-export function isInternalSourceReplySink(value: unknown): value is InternalSourceReplySink {
-  return value === INTERNAL_SOURCE_REPLY_SINK;
-}

--- a/src/infra/outbound/message-action-runner.send-validation.test.ts
+++ b/src/infra/outbound/message-action-runner.send-validation.test.ts
@@ -110,6 +110,7 @@ describe("runMessageAction send validation", () => {
       payload: {
         status: "ok",
         deliveryStatus: "sent",
+        channel: "internal-ui",
         sourceReplySink: "internal-ui",
         sourceReply: {
           text: "hello from codex",

--- a/src/infra/outbound/message-action-runner.send-validation.test.ts
+++ b/src/infra/outbound/message-action-runner.send-validation.test.ts
@@ -110,7 +110,7 @@ describe("runMessageAction send validation", () => {
       payload: {
         status: "ok",
         deliveryStatus: "sent",
-        channel: "internal-ui",
+        channel: "webchat",
         sourceReplySink: "internal-ui",
         sourceReply: {
           text: "hello from codex",

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -190,6 +190,21 @@ export function getToolResult(
   return "toolResult" in result ? result.toolResult : undefined;
 }
 
+type InternalSourceReplyToolResultDetails = {
+  status: string;
+  deliveryStatus: string;
+  channel: ChannelId;
+  target: string;
+  sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
+  sourceReplySink?: "internal-ui";
+  sourceReply: ReplyPayload;
+  message?: string;
+  mediaUrl?: string;
+  mediaUrls?: string[];
+  idempotencyKey?: string;
+  dryRun: boolean;
+};
+
 function resolveGatewayActionOptions(gateway?: MessageActionRunnerGateway) {
   const url =
     gateway?.mode === GATEWAY_CLIENT_MODES.BACKEND ||
@@ -718,6 +733,7 @@ async function handleInternalSourceReplySendAction(
         ? resolveSessionAgentId({ sessionKey: input.sessionKey, config: input.cfg })
         : undefined),
   });
+  const idempotencyKey = normalizeOptionalString(params.idempotencyKey);
   const payload = {
     status: "ok",
     deliveryStatus: dryRun ? "dry_run" : "sent",
@@ -729,6 +745,7 @@ async function handleInternalSourceReplySendAction(
     ...(sourceReply.message ? { message: sourceReply.message } : {}),
     ...(sourceReply.mediaUrl ? { mediaUrl: sourceReply.mediaUrl } : {}),
     ...(sourceReply.mediaUrls?.length ? { mediaUrls: sourceReply.mediaUrls } : {}),
+    ...(idempotencyKey ? { idempotencyKey } : {}),
     dryRun,
   };
   return {
@@ -743,31 +760,9 @@ async function handleInternalSourceReplySendAction(
   };
 }
 
-function buildInternalSourceReplyToolResult(payload: {
-  status: string;
-  deliveryStatus: string;
-  channel: ChannelId;
-  target: string;
-  sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
-  sourceReplySink?: "internal-ui";
-  sourceReply: ReplyPayload;
-  message?: string;
-  mediaUrl?: string;
-  mediaUrls?: string[];
-  dryRun: boolean;
-}): AgentToolResult<{
-  status: string;
-  deliveryStatus: string;
-  channel: ChannelId;
-  target: string;
-  sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
-  sourceReplySink?: "internal-ui";
-  sourceReply: ReplyPayload;
-  message?: string;
-  mediaUrl?: string;
-  mediaUrls?: string[];
-  dryRun: boolean;
-}> {
+function buildInternalSourceReplyToolResult(
+  payload: InternalSourceReplyToolResultDetails,
+): AgentToolResult<InternalSourceReplyToolResultDetails> {
   const action = payload.dryRun ? "Prepared" : "Sent";
   const sink = payload.sourceReplySink ? ` via ${payload.sourceReplySink}` : "";
   return {
@@ -790,6 +785,7 @@ function buildInternalSourceReplyToolResult(payload: {
       ...(payload.message ? { message: payload.message } : {}),
       ...(payload.mediaUrl ? { mediaUrl: payload.mediaUrl } : {}),
       ...(payload.mediaUrls?.length ? { mediaUrls: payload.mediaUrls } : {}),
+      ...(payload.idempotencyKey ? { idempotencyKey: payload.idempotencyKey } : {}),
       dryRun: payload.dryRun,
     },
   };

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -98,6 +98,8 @@ export type MessageActionRunnerGateway = {
   mode: GatewayClientMode;
 };
 
+const INTERNAL_SOURCE_REPLY_SINK = "internal-ui" as const;
+
 let messageActionGatewayRuntimePromise: Promise<
   typeof import("./message.gateway.runtime.js")
 > | null = null;
@@ -717,10 +719,10 @@ async function handleInternalSourceReplySendAction(
   const payload = {
     status: "ok",
     deliveryStatus: dryRun ? "dry_run" : "sent",
-    channel: INTERNAL_MESSAGE_CHANNEL,
+    channel: INTERNAL_SOURCE_REPLY_SINK,
     target: "current-run",
     sourceReplyDeliveryMode: input.sourceReplyDeliveryMode,
-    ...(dryRun ? {} : { sourceReplySink: "internal-ui" as const }),
+    ...(dryRun ? {} : { sourceReplySink: INTERNAL_SOURCE_REPLY_SINK }),
     sourceReply: sourceReply.payload,
     ...(sourceReply.message ? { message: sourceReply.message } : {}),
     ...(sourceReply.mediaUrl ? { mediaUrl: sourceReply.mediaUrl } : {}),

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -719,7 +719,7 @@ async function handleInternalSourceReplySendAction(
   const payload = {
     status: "ok",
     deliveryStatus: dryRun ? "dry_run" : "sent",
-    channel: INTERNAL_SOURCE_REPLY_SINK,
+    channel: INTERNAL_MESSAGE_CHANNEL,
     target: "current-run",
     sourceReplyDeliveryMode: input.sourceReplyDeliveryMode,
     ...(dryRun ? {} : { sourceReplySink: INTERNAL_SOURCE_REPLY_SINK }),

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -55,6 +55,10 @@ import {
   resolveMessageChannelSelection,
 } from "./channel-selection.js";
 import type { OutboundSendDeps } from "./deliver.js";
+import {
+  INTERNAL_SOURCE_REPLY_SINK,
+  INTERNAL_SOURCE_REPLY_TARGET,
+} from "./internal-source-reply.js";
 import { normalizeMessageActionInput } from "./message-action-normalization.js";
 import {
   collectActionMediaSourceHints,
@@ -97,8 +101,6 @@ export type MessageActionRunnerGateway = {
   clientDisplayName?: string;
   mode: GatewayClientMode;
 };
-
-const INTERNAL_SOURCE_REPLY_SINK = "internal-ui" as const;
 
 let messageActionGatewayRuntimePromise: Promise<
   typeof import("./message.gateway.runtime.js")
@@ -720,7 +722,7 @@ async function handleInternalSourceReplySendAction(
     status: "ok",
     deliveryStatus: dryRun ? "dry_run" : "sent",
     channel: INTERNAL_MESSAGE_CHANNEL,
-    target: "current-run",
+    target: INTERNAL_SOURCE_REPLY_TARGET,
     sourceReplyDeliveryMode: input.sourceReplyDeliveryMode,
     ...(dryRun ? {} : { sourceReplySink: INTERNAL_SOURCE_REPLY_SINK }),
     sourceReply: sourceReply.payload,
@@ -733,7 +735,7 @@ async function handleInternalSourceReplySendAction(
     kind: "send",
     channel: INTERNAL_MESSAGE_CHANNEL,
     action: "send",
-    to: "current-run",
+    to: INTERNAL_SOURCE_REPLY_TARGET,
     handledBy: "internal-source",
     payload,
     toolResult: buildInternalSourceReplyToolResult(payload),

--- a/src/utils/message-channel.test.ts
+++ b/src/utils/message-channel.test.ts
@@ -3,7 +3,10 @@ import type { ChannelPlugin } from "../channels/plugins/types.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
 import {
+  GATEWAY_CLIENT_MODES,
+  GATEWAY_CLIENT_NAMES,
   INTERNAL_NON_DELIVERY_CHANNELS,
+  isInternalChatSurfaceClient,
   isInternalNonDeliveryChannel,
   isMarkdownCapableMessageChannel,
   resolveGatewayMessageChannel,
@@ -68,6 +71,54 @@ describe("message-channel", () => {
     expect(isInternalNonDeliveryChannel("webchat")).toBe(false);
     expect(isInternalNonDeliveryChannel("")).toBe(false);
     expect(isInternalNonDeliveryChannel("HEARTBEAT")).toBe(false);
+  });
+
+  it("recognises internal chat surface clients", () => {
+    expect(isInternalChatSurfaceClient({ mode: GATEWAY_CLIENT_MODES.WEBCHAT })).toBe(true);
+    expect(
+      isInternalChatSurfaceClient({
+        mode: GATEWAY_CLIENT_MODES.UI,
+        id: GATEWAY_CLIENT_NAMES.WEBCHAT_UI,
+      }),
+    ).toBe(true);
+    expect(isInternalChatSurfaceClient({ id: GATEWAY_CLIENT_NAMES.WEBCHAT_UI })).toBe(true);
+    expect(
+      isInternalChatSurfaceClient({
+        mode: GATEWAY_CLIENT_MODES.UI,
+        id: GATEWAY_CLIENT_NAMES.CONTROL_UI,
+      }),
+    ).toBe(true);
+    expect(
+      isInternalChatSurfaceClient({
+        mode: GATEWAY_CLIENT_MODES.UI,
+        id: GATEWAY_CLIENT_NAMES.TUI,
+      }),
+    ).toBe(true);
+    expect(
+      isInternalChatSurfaceClient({
+        mode: GATEWAY_CLIENT_MODES.UI,
+        id: GATEWAY_CLIENT_NAMES.MACOS_APP,
+      }),
+    ).toBe(true);
+    expect(
+      isInternalChatSurfaceClient({
+        mode: GATEWAY_CLIENT_MODES.NODE,
+        id: GATEWAY_CLIENT_NAMES.MACOS_APP,
+      }),
+    ).toBe(false);
+    expect(isInternalChatSurfaceClient({ id: GATEWAY_CLIENT_NAMES.MACOS_APP })).toBe(false);
+    expect(
+      isInternalChatSurfaceClient({
+        mode: GATEWAY_CLIENT_MODES.NODE,
+        id: GATEWAY_CLIENT_NAMES.TUI,
+      }),
+    ).toBe(true);
+    expect(
+      isInternalChatSurfaceClient({
+        mode: GATEWAY_CLIENT_MODES.UI,
+        id: GATEWAY_CLIENT_NAMES.TEST,
+      }),
+    ).toBe(false);
   });
 
   it("reads markdown capability from channel metadata", () => {

--- a/src/utils/message-channel.ts
+++ b/src/utils/message-channel.ts
@@ -1,6 +1,7 @@
 import { getChatChannelMeta } from "../channels/chat-meta.js";
 import { getRegisteredChannelPluginMeta, normalizeChatChannelId } from "../channels/registry.js";
 import {
+  GATEWAY_INTERNAL_CHAT_SURFACE_CLIENT_IDS,
   GATEWAY_CLIENT_MODES,
   GATEWAY_CLIENT_NAMES,
   type GatewayClientMode,
@@ -33,6 +34,15 @@ import { normalizeMessageChannel } from "./message-channel-normalize.js";
 export { GATEWAY_CLIENT_NAMES, GATEWAY_CLIENT_MODES };
 export type { GatewayClientName, GatewayClientMode };
 export { normalizeGatewayClientName, normalizeGatewayClientMode };
+
+const INTERNAL_CHAT_SURFACE_CLIENT_ID_SET = new Set<string>(
+  GATEWAY_INTERNAL_CHAT_SURFACE_CLIENT_IDS,
+);
+const DUAL_MODE_INTERNAL_CHAT_SURFACE_CLIENT_ID_SET = new Set<string>([
+  GATEWAY_CLIENT_NAMES.MACOS_APP,
+  GATEWAY_CLIENT_NAMES.IOS_APP,
+  GATEWAY_CLIENT_NAMES.ANDROID_APP,
+]);
 
 type GatewayClientInfoLike = {
   mode?: string | null;
@@ -69,8 +79,18 @@ export function isTuiClient(client?: GatewayClientInfoLike | null): boolean {
   return normalizeGatewayClientName(client?.id) === GATEWAY_CLIENT_NAMES.TUI;
 }
 
-export function isInternalSourceSurfaceClient(client?: GatewayClientInfoLike | null): boolean {
-  return isWebchatClient(client) || isTuiClient(client);
+export function isInternalChatSurfaceClient(client?: GatewayClientInfoLike | null): boolean {
+  const mode = normalizeGatewayClientMode(client?.mode);
+  if (mode === GATEWAY_CLIENT_MODES.WEBCHAT) {
+    return true;
+  }
+  const clientId = normalizeGatewayClientName(client?.id);
+  if (!clientId || !INTERNAL_CHAT_SURFACE_CLIENT_ID_SET.has(clientId)) {
+    return false;
+  }
+  return (
+    !DUAL_MODE_INTERNAL_CHAT_SURFACE_CLIENT_ID_SET.has(clientId) || mode === GATEWAY_CLIENT_MODES.UI
+  );
 }
 
 export function isMarkdownCapableMessageChannel(raw?: string | null): boolean {

--- a/src/utils/message-channel.ts
+++ b/src/utils/message-channel.ts
@@ -65,6 +65,14 @@ export function isWebchatClient(client?: GatewayClientInfoLike | null): boolean 
   return normalizeGatewayClientName(client?.id) === GATEWAY_CLIENT_NAMES.WEBCHAT_UI;
 }
 
+export function isTuiClient(client?: GatewayClientInfoLike | null): boolean {
+  return normalizeGatewayClientName(client?.id) === GATEWAY_CLIENT_NAMES.TUI;
+}
+
+export function isInternalSourceSurfaceClient(client?: GatewayClientInfoLike | null): boolean {
+  return isWebchatClient(client) || isTuiClient(client);
+}
+
 export function isMarkdownCapableMessageChannel(raw?: string | null): boolean {
   const channel = normalizeMessageChannel(raw);
   if (!channel) {

--- a/src/utils/message-channel.ts
+++ b/src/utils/message-channel.ts
@@ -75,10 +75,6 @@ export function isWebchatClient(client?: GatewayClientInfoLike | null): boolean 
   return normalizeGatewayClientName(client?.id) === GATEWAY_CLIENT_NAMES.WEBCHAT_UI;
 }
 
-export function isTuiClient(client?: GatewayClientInfoLike | null): boolean {
-  return normalizeGatewayClientName(client?.id) === GATEWAY_CLIENT_NAMES.TUI;
-}
-
 export function isInternalChatSurfaceClient(client?: GatewayClientInfoLike | null): boolean {
   const mode = normalizeGatewayClientMode(client?.mode);
   if (mode === GATEWAY_CLIENT_MODES.WEBCHAT) {


### PR DESCRIPTION
## Summary

Internal OpenClaw chat UIs, including TUI, WebChat, Control UI, and native UI clients, start agent turns through the Gateway `chat.send` path. When an agent answers that turn by calling the `message` tool, the visible reply should render in the same UI run that asked for it.

This PR fixes the path where a message-tool reply for an internal UI turn was not projected back to the active TUI/WebChat run. The exact-head live proof also covers a stale Telegram route because sessions can carry old external delivery metadata, but users do not need to intentionally open a Telegram session in TUI to hit the reported current-run visibility bug. External channels remain separate delivery targets; this only changes how OpenClaw-owned chat surfaces receive replies for their own current run.

## Problem

The reported symptom was that the assistant said it had sent or resent a reply, but the TUI did not show the standalone reply. The underlying bug was in the internal UI current-run projection path: a TUI-originated `chat.send` run could produce a message-tool source reply, but the Gateway did not reliably emit that reply back to the same TUI run as a distinct final chat event. Stale external delivery metadata, such as an older Telegram `lastChannel`, makes the failure mode especially clear and is covered by the live proof, but it is not a required user action or a separate Telegram-session workflow.

## What changed

- Treat TUI, WebChat UI, Control UI, and native UI clients as internal chat surfaces for `chat.send` route resolution, so they do not inherit stale external delivery routes from the session store.
- Add an internal source-reply projection path for message-tool `send` replies. It emits a distinct final chat event for the originating current run and mirrors the same reply into transcript/history so reloads keep showing it.
- Preserve compatibility for existing agents and parsers: the model/tool result `channel` remains `webchat`, while `sourceReplySink: "internal-ui"` marks the internal UI projection path.
- Split source-reply content, media, and transcript mirror handling into focused Gateway helpers so text-only, media-bearing, and rich reply cases share the same projection path.

## Linked Issue/PR

- Related #38957

## Design Boundary

This PR does not create a new public channel, config key, CLI flag, provider policy, or external delivery path. `internal-ui` is an internal sink marker for message-tool source replies on OpenClaw-owned chat surfaces.

Telegram, Slack, Discord, and other external channels remain separate deliverable channels. A Telegram conversation is not made visible in WebChat/TUI by this change; only a run that started from an internal OpenClaw chat UI receives its own current-run source reply through the Gateway chat event/history path.

The compatibility boundary is that `MessageActionRunResult.channel` and the model-facing result payload `channel` stay `webchat`. Code that needs to know where the visible source reply was delivered can read `sourceReplySink: "internal-ui"`.

## Real behavior proof

Behavior addressed: TUI/internal UI turns using message-tool-only visible replies now receive the visible source reply as a distinct final chat event on the originating current run, even when the session store has a stale external delivery route. The Codex message-tool result also preserves internal source-reply details so the gateway can project that visible reply instead of losing it behind the short tool-result summary.

Real environment tested: Local OpenClaw gateway on exact PR head `12f043692b6354e8ec9b89d1ad113b47aec75ebf` (`OpenClaw 2026.5.25 (12f0436)`), fresh isolated OpenClaw home, foreground Gateway on loopback port `44615`, throwaway local token auth, `OPENCLAW_SKIP_CHANNELS=1`, bundled Codex harness `openai-codex/gpt-5.5`, TUI client identity `openclaw-tui` / mode `ui`, and session-store metadata deliberately seeded with stale Telegram delivery route `lastChannel: "telegram"` plus a redacted target before sending the TUI prompt.

Exact steps or command run after this patch:

```bash
PROOF_HOME=<fresh isolated proof home>
PORT=44615

HOME="$PROOF_HOME" \
USERPROFILE="$PROOF_HOME" \
OPENCLAW_HOME="$PROOF_HOME" \
OPENCLAW_LIVE_TEST=1 \
OPENCLAW_LIVE_TEST_QUIET=1 \
OPENCLAW_SKIP_CHANNELS=1 \
OPENCLAW_GATEWAY_PORT="$PORT" \
node scripts/run-node.mjs gateway run \
  --port "$PORT" \
  --bind loopback \
  --auth token \
  --allow-unconfigured \
  --ws-log compact

HOME="$PROOF_HOME" \
USERPROFILE="$PROOF_HOME" \
OPENCLAW_HOME="$PROOF_HOME" \
OPENCLAW_LIVE_TEST=1 \
OPENCLAW_LIVE_TEST_QUIET=1 \
OPENCLAW_SKIP_CHANNELS=1 \
OPENCLAW_GATEWAY_PORT="$PORT" \
node --import tsx --input-type=module <temporary TUI-mode Gateway proof client>

HOME="$PROOF_HOME" \
USERPROFILE="$PROOF_HOME" \
OPENCLAW_HOME="$PROOF_HOME" \
OPENCLAW_LIVE_TEST=1 \
OPENCLAW_LIVE_TEST_QUIET=1 \
OPENCLAW_SKIP_CHANNELS=1 \
OPENCLAW_GATEWAY_PORT="$PORT" \
node scripts/run-node.mjs tui \
  --session "agent:main:tui-terminal-proof-1779703709366" \
  --message "Use the message tool exactly once with action send to send exactly this text to the current run: TUI_TERMINAL_VISIBLE_REPLY_12f043692b_75a2225c. Do not send to Telegram or any external channel. Do not answer with normal assistant text." \
  --deliver \
  --timeout-ms 180000
```

Before both sends, the proof seeded the target session store with a stale Telegram route. The Gateway proof client sent `chat.send` with a TUI-identified client, `deliver: true`, and a prompt requiring `message(action=send)`. The terminal proof launched the real TUI command against the same isolated gateway/proof config.

Evidence after fix: Copied live output from the Gateway proof client on the rebased head:

```json
{
  "proofKind": "gateway-tui-source-reply-live-proof",
  "head": "12f043692b6354e8ec9b89d1ad113b47aec75ebf",
  "sessionKey": "agent:main:tui-live-proof-1779703602476",
  "staleRoute": {
    "channel": "telegram",
    "target": {
      "to": "<redacted-proof-target>"
    }
  },
  "chatSendRunId": "live-tui-source-reply-1779703602477",
  "sourceFinal": {
    "event": "chat",
    "runId": "live-tui-source-reply-1779703602477:message-tool:call_uTy0GOZB92IOqE37oHReGOh9",
    "sessionKey": "agent:main:tui-live-proof-1779703602476",
    "state": "final",
    "text": "TUI_SOURCE_REPLY_FIXED_HEAD_12f043692b_0eb818fd"
  },
  "sourceFinalObserved": true,
  "eventCount": 2,
  "transcriptContainsExpected": true,
  "historyContainsExpectedAssistant": true
}
```

Copied live output from the real terminal TUI proof on the same head:

```json
{
  "proofKind": "terminal-tui-stale-route-source-reply",
  "head": "12f043692b6354e8ec9b89d1ad113b47aec75ebf",
  "sessionKey": "agent:main:tui-terminal-proof-1779703709366",
  "staleRoute": {
    "channel": "telegram",
    "to": "<redacted-proof-target>"
  },
  "expected": "TUI_TERMINAL_VISIBLE_REPLY_12f043692b_75a2225c",
  "terminalOutputObserved": true,
  "exactOutputLineObserved": true,
  "transcriptContainsExpected": true,
  "historyContainsExpectedAssistant": true,
  "sourceReplyObserved": true,
  "visibleToolResultSummary": "Sent visible reply to the current webchat conversation via internal-ui."
}
```

Terminal output excerpt from the real TUI command showed the visible source reply as its own rendered line:

```text
TUI_TERMINAL_VISIBLE_REPLY_12f043692b_75a2225c
```

Observed result after fix: The TUI-originated run received the visible source reply on the internal UI/current-run session despite the stale Telegram route and skipped external channels. No external channel send was needed for the TUI-visible reply, and the compatibility `channel: "webchat"` summary remained intact for existing consumers.

What was not tested: Real Telegram/Slack/Discord delivery was intentionally not exercised; channels were skipped to keep proof isolated and to prove the stale external route was not required for visible TUI replies. The throwaway proof token and temporary proof home were not committed.

Before evidence: Earlier base negative control on exact base commit `5e0850fc548ceab82af7244938b833024e485834` reproduced the failure shape: the model used the `message` tool and the source reply was persisted with `sourceReplySink: "internal-ui"`, but the active TUI returned to idle without rendering the standalone reply. The maintainer-added screenshot below also captures the reported user-visible failure: the assistant said it resent the summary, then acknowledged it had gone to the webchat surface rather than the TUI.

<img width="1354" height="567" alt="image" src="https://github.com/user-attachments/assets/ca3eb07c-293e-46bc-98d0-c4099756d06b" />

## Verification

- `git diff --check origin/main...HEAD`
- `git diff --name-only origin/main...HEAD -- '*.ts' '*.tsx' '*.js' '*.mjs' | xargs node scripts/run-oxlint.mjs` (0 errors)
- `node scripts/run-vitest.mjs src/utils/message-channel.test.ts src/infra/outbound/message-action-runner.send-validation.test.ts src/auto-reply/reply/agent-runner-utils.test.ts src/auto-reply/reply/dispatch-from-config.test.ts src/auto-reply/reply/reply-media-paths.test.ts src/agents/tools/message-tool.test.ts src/gateway/server.chat.gateway-server-chat.test.ts src/gateway/server-methods/chat.directive-tags.test.ts src/gateway/server-methods/chat-reply-media.test.ts extensions/codex/src/app-server/dynamic-tools.test.ts` (13 files, 628 tests passed)
- `codex review --base origin/main` (clean; no actionable findings)
- Exact-head live proof on `12f043692b6354e8ec9b89d1ad113b47aec75ebf`: fresh isolated Gateway + TUI-mode Gateway client + real terminal TUI command, both with stale Telegram route and `OPENCLAW_SKIP_CHANNELS=1`, described above

## Compatibility / Migration

- Backward compatible: yes
- Config/env changes: no
- Public SDK/API changes: no
- External channel behavior changes: no
- Migration needed: no
