### PR TITLE
[codex] Guard published dist against deprecated pi runtime imports

### DIFF
--- a/scripts/openclaw-npm-postpublish-verify.ts
+++ b/scripts/openclaw-npm-postpublish-verify.ts
@@ -73,6 +73,12 @@ const OPTIONAL_OR_EXTERNALIZED_RUNTIME_IMPORTS = new Set([
   // Consumers importing them run under their own Vitest dev dependency.
   "vitest",
 ]);
+const DISALLOWED_ROOT_RUNTIME_IMPORT_REWRITES = new Map([
+  ["@mariozechner/pi-agent-core", "@earendil-works/pi-agent-core"],
+  ["@mariozechner/pi-ai", "@earendil-works/pi-ai"],
+  ["@mariozechner/pi-coding-agent", "@earendil-works/pi-coding-agent"],
+  ["@mariozechner/pi-tui", "@earendil-works/pi-tui"],
+]);
 const require = createRequire(import.meta.url);
 const acorn = require("acorn") as typeof import("acorn");
 
@@ -417,6 +423,7 @@ export function collectInstalledRootDependencyManifestErrors(packageRoot: string
     ];
   }
   const missingImporters = new Map<string, Set<string>>();
+  const disallowedImporters = new Map<string, Set<string>>();
   const bundledExtensionRuntimeDependencyOwners =
     collectBundledExtensionRuntimeDependencyOwners(packageRoot);
 
@@ -438,6 +445,12 @@ export function collectInstalledRootDependencyManifestErrors(packageRoot: string
     }
     for (const specifier of parsedSpecifiers.specifiers) {
       const dependencyName = packageNameFromSpecifier(specifier);
+      if (dependencyName && DISALLOWED_ROOT_RUNTIME_IMPORT_REWRITES.has(dependencyName)) {
+        const importers = disallowedImporters.get(dependencyName) ?? new Set<string>();
+        importers.add(relativePath);
+        disallowedImporters.set(dependencyName, importers);
+        continue;
+      }
       if (
         !dependencyName ||
         NODE_BUILTIN_MODULES.has(dependencyName) ||
@@ -457,12 +470,23 @@ export function collectInstalledRootDependencyManifestErrors(packageRoot: string
     }
   }
 
-  return [...missingImporters.entries()]
-    .map(([dependencyName, importers]) => {
+  const deprecatedImportErrors = [...disallowedImporters.entries()].map(
+    ([dependencyName, importers]) => {
+      const importerList = [...importers].toSorted((left, right) => left.localeCompare(right));
+      const replacement = DISALLOWED_ROOT_RUNTIME_IMPORT_REWRITES.get(dependencyName);
+      return `installed package root dist imports deprecated runtime package '${dependencyName}' via: ${importerList.join(", ")}. Rebuild so published artifacts use '${replacement}'.`;
+    },
+  );
+  const missingDependencyErrors = [...missingImporters.entries()].map(
+    ([dependencyName, importers]) => {
       const importerList = [...importers].toSorted((left, right) => left.localeCompare(right));
       return `installed package root is missing declared runtime dependency '${dependencyName}' for dist importers: ${importerList.join(", ")}. Add it to package.json dependencies/optionalDependencies.`;
-    })
-    .toSorted((left, right) => left.localeCompare(right));
+    },
+  );
+
+  return [...deprecatedImportErrors, ...missingDependencyErrors].toSorted((left, right) =>
+    left.localeCompare(right),
+  );
 }
 
 function collectBundledExtensionRuntimeDependencyOwners(

--- a/test/openclaw-npm-postpublish-verify.test.ts
+++ b/test/openclaw-npm-postpublish-verify.test.ts
@@ -301,6 +301,31 @@ describe("collectInstalledRootDependencyManifestErrors", () => {
     }
   });
 
+  it("rejects deprecated pi runtime package scopes even when declared", () => {
+    const packageRoot = makeInstalledPackageRoot();
+
+    try {
+      writePackageFile(packageRoot, "package.json", {
+        version: "2026.4.22",
+        dependencies: {
+          "@mariozechner/pi-ai": "0.74.0",
+        },
+      });
+      mkdirSync(join(packageRoot, "dist"), { recursive: true });
+      writeFileSync(
+        join(packageRoot, "dist", "oauth-runtime.js"),
+        'import { getOAuthApiKey } from "@mariozechner/pi-ai/oauth";\nexport { getOAuthApiKey };\n',
+        "utf8",
+      );
+
+      expect(collectInstalledRootDependencyManifestErrors(packageRoot)).toEqual([
+        "installed package root dist imports deprecated runtime package '@mariozechner/pi-ai' via: oauth-runtime.js. Rebuild so published artifacts use '@earendil-works/pi-ai'.",
+      ]);
+    } finally {
+      rmSync(packageRoot, { recursive: true, force: true });
+    }
+  });
+
   it("accepts optional or externalized runtime imports", () => {
     const packageRoot = makeInstalledPackageRoot();
 


### PR DESCRIPTION
Fixes #84095.

## Summary

- Add a postpublish verification guard that rejects root `dist` artifacts importing deprecated `@mariozechner/pi-*` runtime packages, even when those package names are still declared in `package.json`.
- Add a regression test covering the stale `@mariozechner/pi-ai/oauth` import pattern.
- Catch the packaging failure mode behind #84095 before a broken artifact can ship again.

## Why

Issue #84095 reported that Feishu DM sessions on OpenClaw 2026.5.12 never exposed `feishu_doc`, `feishu_drive`, and related tools, even though the Feishu plugin was enabled and channel tool config was correct.

The failure mode we traced here was stale published root `dist` output still importing deprecated `@mariozechner/pi-*` runtime packages such as `@mariozechner/pi-ai/oauth`. After rebuilding the artifacts so those imports pointed at `@earendil-works/pi-ai/oauth`, the effective Feishu DM tool inventory included the Feishu document tools again. This patch does not change Feishu runtime behavior directly; it hardens the release guard so that a package containing the stale runtime import pattern is rejected before publish.

## Verification

- `pnpm test test/openclaw-npm-postpublish-verify.test.ts`
- `pnpm exec oxfmt --check scripts/openclaw-npm-postpublish-verify.ts test/openclaw-npm-postpublish-verify.test.ts`
- `git diff --check`

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Prevent shipping an OpenClaw package whose root `dist` still imports deprecated `@mariozechner/pi-*` runtime packages. In #84095 this stale packaged runtime import pattern was part of the failure mode that hid Feishu DM tools such as `feishu_doc`.
- Real environment tested: Local macOS source checkout with rebuilt `dist` artifacts and the patched postpublish verifier executed directly via `node --import tsx`.
- Exact steps or command run after this patch:
  1. Created a temporary packaged root with `package.json` declaring `@mariozechner/pi-ai` and `dist/oauth-runtime.js` importing `@mariozechner/pi-ai/oauth`.
  2. Ran `collectInstalledRootDependencyManifestErrors(...)` from `scripts/openclaw-npm-postpublish-verify.ts` through `node --import tsx --input-type=module`.
  3. Ran `rg -n "@mariozechner/pi-ai/oauth|@earendil-works/pi-ai/oauth" dist/oauth-*.js` and `rg -n "@mariozechner/pi-(agent-core|ai|coding-agent|tui)" dist --glob '!dist/extensions/**' || echo 'no deprecated pi root-dist imports found'` against the rebuilt local `dist`.
  4. Ran `pnpm test test/openclaw-npm-postpublish-verify.test.ts`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):
  Terminal output from the patched verifier against a temp packaged root with the stale runtime import:

  ```text
  [
    "installed package root dist imports deprecated runtime package '@mariozechner/pi-ai' via: oauth-runtime.js. Rebuild so published artifacts use '@earendil-works/pi-ai'."
  ]
  ```

  Terminal output from the rebuilt local `dist` scan:

  ```text
  dist import scan:
  dist/oauth-DmXvkUOb.js:21:import { getOAuthApiKey, getOAuthProviders } from "@earendil-works/pi-ai/oauth";

  root dist deprecated scan:
  no deprecated pi root-dist imports found
  ```

  Terminal output from the focused regression test:

  ```text
  [test] passed 1 Vitest shard in 2.39s

   RUN  v4.1.6 /Users/nianjiu/openclaw


   Test Files  1 passed (1)
        Tests  23 passed (23)
  ```
- Observed result after fix: The patched verifier now rejects the stale packaged runtime import pattern with an explicit rebuild error, and the rebuilt root `dist` points at `@earendil-works/pi-ai/oauth` with no deprecated `@mariozechner/pi-*` imports left in root `dist`.
- What was not tested: I did not rerun a live Feishu DM conversation or a published npm install in this PR update; the real proof here is the patched postpublish verifier behavior plus the rebuilt local `dist` artifact state.
