### PR TITLE
Validate wide-area DNS zone domains [AI]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/DNS: validate wide-area discovery domains before deriving zone paths or writing zone files, so invalid `discovery.wideArea.domain` and `dns setup --domain` values fail with a DNS-name diagnostic instead of falling through to unrelated configuration errors. Thanks @mmaps.
 - Agents/BTW: route fallback side-question streams through the embedded stream resolver so Anthropic-compatible MiniMax requests use the same capped transport as normal chat. (#86312) Thanks @neeravmakwana.
 - Telegram: treat `/command@TargetBot` bot-command entities as explicit mentions for the addressed bot so `requireMention` groups no longer drop targeted commands or captions. Fixes #84462. (#86553) Thanks @luoyanglang.
 - CI: bound Docker/Bash E2E tarball npm installs with `OPENCLAW_E2E_NPM_INSTALL_TIMEOUT` so package, onboarding, plugin, and upgrade lanes fail instead of hanging on a stuck npm install.

--- a/src/cli/cli-utils.test.ts
+++ b/src/cli/cli-utils.test.ts
@@ -91,6 +91,25 @@ describe("dns cli", () => {
       log.mockRestore();
     }
   });
+
+  it.each(["foo/bar", "../../x", "evil\nrecords"])(
+    "rejects invalid --domain %j with explicit DNS-name diagnostic",
+    async (domain) => {
+      const log = vi.spyOn(console, "log").mockImplementation(() => {});
+      try {
+        const program = new Command();
+        registerDnsCli(program);
+        await expect(
+          program.parseAsync(["dns", "setup", "--domain", domain], { from: "user" }),
+        ).rejects.toThrow("wide-area discovery domain must be a valid DNS name");
+        const output = log.mock.calls.map((call) => call.join(" ")).join("\\n");
+        expect(output).not.toContain("No wide-area domain configured");
+        expect(output).not.toContain("DNS setup");
+      } finally {
+        log.mockRestore();
+      }
+    },
+  );
 });
 
 describe("parseByteSize", () => {

--- a/src/cli/dns-cli.ts
+++ b/src/cli/dns-cli.ts
@@ -4,7 +4,11 @@ import path from "node:path";
 import type { Command } from "commander";
 import { getRuntimeConfig } from "../config/config.js";
 import { pickPrimaryTailnetIPv4, pickPrimaryTailnetIPv6 } from "../infra/tailnet.js";
-import { getWideAreaZonePath, resolveWideAreaDiscoveryDomain } from "../infra/widearea-dns.js";
+import {
+  getWideAreaZonePath,
+  normalizeWideAreaDomain,
+  resolveWideAreaDiscoveryDomain,
+} from "../infra/widearea-dns.js";
 import { defaultRuntime } from "../runtime.js";
 import { formatDocsLink } from "../terminal/links.js";
 import { getTerminalTableWidth, renderTable } from "../terminal/table.js";
@@ -123,9 +127,13 @@ export function registerDnsCli(program: Command) {
       const cfg = getRuntimeConfig();
       const tailnetIPv4 = pickPrimaryTailnetIPv4();
       const tailnetIPv6 = pickPrimaryTailnetIPv6();
-      const wideAreaDomain = resolveWideAreaDiscoveryDomain({
-        configDomain: (opts.domain as string | undefined) ?? cfg.discovery?.wideArea?.domain,
-      });
+      const explicitDomain = (opts.domain as string | undefined) ?? cfg.discovery?.wideArea?.domain;
+      if (explicitDomain) {
+        // Throw on invalid CLI/config input before resolveWideAreaDiscoveryDomain
+        // silently swallows the validation error and falls back to env.
+        normalizeWideAreaDomain(explicitDomain);
+      }
+      const wideAreaDomain = resolveWideAreaDiscoveryDomain({ configDomain: explicitDomain });
       if (!wideAreaDomain) {
         throw new Error(
           "No wide-area domain configured. Set discovery.wideArea.domain or pass --domain.",

--- a/src/gateway/server-discovery-runtime.test.ts
+++ b/src/gateway/server-discovery-runtime.test.ts
@@ -2,11 +2,13 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { PluginGatewayDiscoveryServiceRegistration } from "../plugins/registry-types.js";
 
 type WriteWideAreaGatewayZone = typeof import("../infra/widearea-dns.js").writeWideAreaGatewayZone;
+type ResolveWideAreaDiscoveryDomain =
+  typeof import("../infra/widearea-dns.js").resolveWideAreaDiscoveryDomain;
 
 const mocks = vi.hoisted(() => ({
   pickPrimaryTailnetIPv4: vi.fn(() => "100.64.0.10"),
   pickPrimaryTailnetIPv6: vi.fn(() => undefined as string | undefined),
-  resolveWideAreaDiscoveryDomain: vi.fn(() => "openclaw.internal."),
+  resolveWideAreaDiscoveryDomain: vi.fn<ResolveWideAreaDiscoveryDomain>(() => "openclaw.internal."),
   writeWideAreaGatewayZone: vi.fn<WriteWideAreaGatewayZone>(async () => ({
     changed: true,
     zonePath: "/tmp/openclaw.internal.db",

--- a/src/gateway/server-discovery-runtime.test.ts
+++ b/src/gateway/server-discovery-runtime.test.ts
@@ -245,6 +245,44 @@ describe("startGatewayDiscovery", () => {
     expect(result.bonjourStop).toBeNull();
   });
 
+  it("logs a warning and skips zone writes when wide-area config is invalid", async () => {
+    process.env.NODE_ENV = "development";
+    delete process.env.VITEST;
+
+    // Drive the gateway through the REAL resolver so an invalid configured
+    // domain flows through normalizeWideAreaDomain → caught → null, exactly
+    // as it does at runtime when an operator boots the gateway with
+    // discovery.wideArea.domain set to a non-DNS string.
+    const widearea = await vi.importActual<typeof import("../infra/widearea-dns.js")>(
+      "../infra/widearea-dns.js",
+    );
+    mocks.resolveWideAreaDiscoveryDomain.mockImplementationOnce(
+      widearea.resolveWideAreaDiscoveryDomain,
+    );
+
+    const logs = makeLogs();
+
+    const result = await startGatewayDiscovery({
+      machineDisplayName: "Lab Mac",
+      port: 18789,
+      gatewayTls: { enabled: false },
+      wideAreaDiscoveryEnabled: true,
+      wideAreaDiscoveryDomain: "foo/bar",
+      tailscaleMode: "serve",
+      mdnsMode: "off",
+      gatewayDiscoveryServices: [],
+      logDiscovery: logs,
+    });
+
+    expect(mocks.writeWideAreaGatewayZone).not.toHaveBeenCalled();
+    expect(logs.warn.mock.calls).toEqual([
+      [
+        "discovery.wideArea.enabled is true, but no domain was configured; set discovery.wideArea.domain to enable unicast DNS-SD",
+      ],
+    ]);
+    expect(result.bonjourStop).toBeNull();
+  });
+
   it("omits the CLI path from wide-area DNS-SD in minimal mode", async () => {
     process.env.NODE_ENV = "development";
     delete process.env.VITEST;

--- a/src/infra/widearea-dns.test.ts
+++ b/src/infra/widearea-dns.test.ts
@@ -88,6 +88,21 @@ describe("wide-area DNS discovery domain helpers", () => {
       },
       expected: null,
     },
+    {
+      name: "returns null for invalid config domains",
+      params: {
+        env: { OPENCLAW_WIDE_AREA_DOMAIN: "env.internal" } as NodeJS.ProcessEnv,
+        configDomain: "foo/bar",
+      },
+      expected: null,
+    },
+    {
+      name: "returns null for invalid env domains",
+      params: {
+        env: { OPENCLAW_WIDE_AREA_DOMAIN: "foo/bar" } as NodeJS.ProcessEnv,
+      },
+      expected: null,
+    },
   ])("$name", ({ params, expected }) => {
     expect(resolveWideAreaDiscoveryDomain(params)).toBe(expected);
   });

--- a/src/infra/widearea-dns.test.ts
+++ b/src/infra/widearea-dns.test.ts
@@ -55,6 +55,15 @@ describe("wide-area DNS discovery domain helpers", () => {
     expect(normalizeWideAreaDomain(value)).toBe(expected);
   });
 
+  it.each(["../../x", "foo/bar", "foo\\bar", "evil\nrecords", "openclaw..internal"])(
+    "rejects invalid domains for %j",
+    (value) => {
+      expect(() => normalizeWideAreaDomain(value)).toThrow(
+        "wide-area discovery domain must be a valid DNS name",
+      );
+    },
+  );
+
   it.each([
     {
       name: "prefers config domain over env",
@@ -83,10 +92,12 @@ describe("wide-area DNS discovery domain helpers", () => {
     expect(resolveWideAreaDiscoveryDomain(params)).toBe(expected);
   });
 
-  it("builds the default zone path from the normalized domain", () => {
-    expect(getWideAreaZonePath("openclaw.internal.")).toBe(
-      path.join(utils.CONFIG_DIR, "dns", "openclaw.internal.db"),
-    );
+  it("builds valid zone paths under the DNS config directory", () => {
+    const dnsDir = path.resolve(utils.CONFIG_DIR, "dns");
+    const zonePath = getWideAreaZonePath("openclaw.internal.");
+
+    expect(zonePath).toBe(path.join(dnsDir, "openclaw.internal.db"));
+    expect(path.relative(dnsDir, zonePath)).toBe("openclaw.internal.db");
   });
 });
 
@@ -153,6 +164,21 @@ describe("wide-area DNS zone writes", () => {
       "wide-area discovery domain is required",
     );
   });
+
+  it.each(["../../x", "foo/bar", "foo\\bar", "evil\nrecords", "openclaw..internal"])(
+    "rejects invalid domain %j before writing",
+    async (domain) => {
+      const ensureDirSpy = vi.spyOn(utils, "ensureDir").mockResolvedValue(undefined);
+      const writeSpy = vi.spyOn(fs, "writeFileSync").mockImplementation(() => undefined);
+
+      await expect(writeWideAreaGatewayZone(makeZoneOpts({ domain }))).rejects.toThrow(
+        "wide-area discovery domain must be a valid DNS name",
+      );
+
+      expect(ensureDirSpy).not.toHaveBeenCalled();
+      expect(writeSpy).not.toHaveBeenCalled();
+    },
+  );
 
   it("skips rewriting unchanged content", async () => {
     vi.spyOn(utils, "ensureDir").mockResolvedValue(undefined);

--- a/src/infra/widearea-dns.ts
+++ b/src/infra/widearea-dns.ts
@@ -4,12 +4,31 @@ import path from "node:path";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { CONFIG_DIR, ensureDir } from "../utils.js";
 
+const DNS_LABEL_RE = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$/;
+const MAX_DNS_NAME_LENGTH = 253;
+const INVALID_DOMAIN_ERROR = "wide-area discovery domain must be a valid DNS name";
+
+function normalizedDomainLabels(raw: string): string[] {
+  const trimmed = raw.trim();
+  const withoutTrailingDot = trimmed.endsWith(".") ? trimmed.slice(0, -1) : trimmed;
+  if (!withoutTrailingDot || withoutTrailingDot.length > MAX_DNS_NAME_LENGTH) {
+    throw new Error(INVALID_DOMAIN_ERROR);
+  }
+
+  const labels = withoutTrailingDot.split(".");
+  if (labels.some((label) => !DNS_LABEL_RE.test(label))) {
+    throw new Error(INVALID_DOMAIN_ERROR);
+  }
+  return labels;
+}
+
 export function normalizeWideAreaDomain(raw?: string | null): string | null {
   const trimmed = raw?.trim();
   if (!trimmed) {
     return null;
   }
-  return trimmed.endsWith(".") ? trimmed : `${trimmed}.`;
+  const labels = normalizedDomainLabels(trimmed);
+  return `${labels.join(".")}.`;
 }
 
 export function resolveWideAreaDiscoveryDomain(params?: {
@@ -22,11 +41,21 @@ export function resolveWideAreaDiscoveryDomain(params?: {
 }
 
 function zoneFilenameForDomain(domain: string): string {
-  return `${domain.replace(/\.$/, "")}.db`;
+  return `${normalizedDomainLabels(domain).join(".")}.db`;
+}
+
+function assertZonePathUnderDnsDir(zonePath: string, dnsDir: string): void {
+  const relativePath = path.relative(dnsDir, zonePath);
+  if (relativePath === "" || relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
+    throw new Error("wide-area discovery zone path must stay under DNS config directory");
+  }
 }
 
 export function getWideAreaZonePath(domain: string): string {
-  return path.join(CONFIG_DIR, "dns", zoneFilenameForDomain(domain));
+  const dnsDir = path.resolve(CONFIG_DIR, "dns");
+  const zonePath = path.resolve(dnsDir, zoneFilenameForDomain(domain));
+  assertZonePathUnderDnsDir(zonePath, dnsDir);
+  return zonePath;
 }
 
 function dnsLabel(raw: string, fallback: string): string {
@@ -175,6 +204,7 @@ export async function writeWideAreaGatewayZone(
   if (!domain) {
     throw new Error("wide-area discovery domain is required");
   }
+  const normalizedOpts = { ...opts, domain };
   const zonePath = getWideAreaZonePath(domain);
   await ensureDir(path.dirname(zonePath));
 
@@ -186,7 +216,7 @@ export async function writeWideAreaGatewayZone(
     }
   })();
 
-  const nextNoSerial = renderWideAreaGatewayZoneText({ ...opts, serial: 0 });
+  const nextNoSerial = renderWideAreaGatewayZoneText({ ...normalizedOpts, serial: 0 });
   const nextHash = extractContentHash(nextNoSerial);
   const existingHash = existing ? extractContentHash(existing) : null;
 
@@ -196,7 +226,7 @@ export async function writeWideAreaGatewayZone(
 
   const existingSerial = existing ? extractSerial(existing) : null;
   const serial = nextSerial(existingSerial, new Date());
-  const next = renderWideAreaGatewayZoneText({ ...opts, serial });
+  const next = renderWideAreaGatewayZoneText({ ...normalizedOpts, serial });
   fs.writeFileSync(zonePath, next, "utf-8");
   return { zonePath, changed: true };
 }

--- a/src/infra/widearea-dns.ts
+++ b/src/infra/widearea-dns.ts
@@ -37,7 +37,11 @@ export function resolveWideAreaDiscoveryDomain(params?: {
 }): string | null {
   const env = params?.env ?? process.env;
   const candidate = params?.configDomain ?? env.OPENCLAW_WIDE_AREA_DOMAIN ?? null;
-  return normalizeWideAreaDomain(candidate);
+  try {
+    return normalizeWideAreaDomain(candidate);
+  } catch {
+    return null;
+  }
 }
 
 function zoneFilenameForDomain(domain: string): string {


### PR DESCRIPTION
## Summary

- Problem: wide-area DNS zone filenames were derived from normalized-but-unvalidated domain strings, and the `dns setup` CLI silently treated invalid `--domain` input as "no domain configured" because the resolver swallowed the validation error.
- Solution: validate configured domains as DNS labels before deriving zone filenames or rendering zone text, and validate explicit CLI/config input in `dns setup` before the resolver's env fallback can mask invalid values.
- What changed: invalid separators, traversal-like segments, control-style embedded newlines, and empty labels are rejected; resolved zone paths are asserted under the DNS config directory; `dns setup` now throws the explicit DNS-name diagnostic instead of the misleading "No wide-area domain configured" message when `--domain` or `discovery.wideArea.domain` is invalid.
- What did NOT change (scope boundary): no CoreDNS install behavior, gateway discovery protocol, defaults, or config key changes; the resolver still returns `null` for the other (background) call sites so wide-area discovery degrades silently outside the user-facing setup command.

This PR was AI-assisted.

## Motivation

- Wide-area DNS setup should only write zone files in the intended DNS config directory, and invalid domain strings should be rejected before they influence filenames or zone origin text.
- A reviewer flagged that the resolver's catch-and-return-null behavior caused `dns setup --domain foo/bar` to print "No wide-area domain configured" rather than an invalid-domain diagnostic. This amendment closes that user-facing gap at the CLI entry without redesigning the resolver contract used by the long-running gateway code paths.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: N/A
- [x] This PR addresses a bug or regression

## Real behavior proof (required for external PRs)

- Behavior addressed: invalid wide-area discovery domains are rejected before zone file path construction, and the `dns setup` CLI surfaces the explicit DNS-name diagnostic instead of the misleading "No wide-area domain configured" message.
- Real environment tested: local OpenClaw checkout on Linux (Node 22.22.2) running `pnpm dev` (TypeScript build + live CLI invoke), plus the repo's Node test wrapper.
- Exact steps or command run after this patch:
  - Live CLI: `pnpm dev dns setup --domain foo/bar` (also `../../x` and `"openclaw..internal"` for invalid forms, and `openclaw.internal` for the happy path).
  - Targeted vitest runs:
    - `node scripts/run-vitest.mjs src/infra/widearea-dns.test.ts`
    - `node scripts/run-vitest.mjs src/cli/cli-utils.test.ts`
    - `node scripts/run-vitest.mjs src/gateway/server-discovery-runtime.test.ts`
- Evidence after fix:

  Live CLI terminal output for `pnpm dev dns setup --domain foo/bar` (Linux, Node 22.22.2):

  ```
  $ node scripts/run-node.mjs dns setup --domain foo/bar
  [openclaw] Could not start the CLI.
  [openclaw] Reason: wide-area discovery domain must be a valid DNS name
  [openclaw] Debug: set OPENCLAW_DEBUG=1 to include the stack trace.
  [openclaw] Try: openclaw doctor
  [openclaw] Help: openclaw --help
  $ echo $?
  1
  ```

  Identical terminal output (same diagnostic, exit code 1) was observed for `--domain ../../x` and `--domain "openclaw..internal"`.

  Live CLI terminal output for the happy path `pnpm dev dns setup --domain openclaw.internal`:

  ```
  $ node scripts/run-node.mjs dns setup --domain openclaw.internal
  DNS setup
  ┌──────────────┬─────────────────────────────────────┐
  │ Key          │ Value                               │
  ├──────────────┼─────────────────────────────────────┤
  │ Domain       │ openclaw.internal.                  │
  │ Zone file    │ ~/.openclaw/dns/openclaw.internal.db│
  │ Tailnet IP   │ —                                   │
  └──────────────┴─────────────────────────────────────┘

  Recommended config ($OPENCLAW_CONFIG_PATH, default ~/.openclaw/openclaw.json):
  { "gateway": { "bind": "auto" },
    "discovery": { "wideArea": { "enabled": true, "domain": "openclaw.internal." } } }

  Tailscale admin (DNS → Nameservers):
  - Add nameserver: <this machine's tailnet IPv4>
  - Restrict to domain (Split DNS): openclaw.internal

  Run with --apply to install CoreDNS and configure it.
  ```

  Targeted vitest runs after the fix:
  - `widearea-dns.test.ts`: `Test Files 1 passed (1)` / `Tests 29 passed (29)`.
  - `cli-utils.test.ts`: `Test Files 1 passed (1)` / `Tests 42 passed (42)`, including the three new `dns setup --domain <invalid>` cases asserting `wide-area discovery domain must be a valid DNS name` and that the table heading "DNS setup" is never logged.
  - `server-discovery-runtime.test.ts`: `Test Files 1 passed (1)` / `Tests 7 passed (7)`, including the new "logs a warning and skips zone writes when wide-area config is invalid" case that drives `startGatewayDiscovery` through the REAL `resolveWideAreaDiscoveryDomain` with `wideAreaDiscoveryDomain: "foo/bar"` and asserts `writeWideAreaGatewayZone` is never called and the operator-facing warning is logged exactly once.
- Observed result after fix: invalid `--domain` input is rejected at the CLI entry with the explicit DNS-name diagnostic and exit code 1 — no DNS setup table is rendered and no zone-file directory is touched. Valid input (`openclaw.internal`) still renders the full setup table and recommended config block. At the gateway startup layer, the real resolver still swallows invalid configured domains to `null` so `startGatewayDiscovery` logs a single operator-facing warning and skips `writeWideAreaGatewayZone` rather than crashing the gateway. Helper-layer invariants (zone path stays under the DNS config directory; invalid labels reject before `ensureDir`/`writeFileSync`) hold.
- What was not tested: live CoreDNS install (`--apply` path, which requires macOS + sudo + Homebrew), full live gateway boot end-to-end against a real Tailnet, and broad changed gates.
- Before evidence (optional but encouraged): before this amendment, `pnpm dev dns setup --domain foo/bar` printed `Error: No wide-area domain configured. Set discovery.wideArea.domain or pass --domain.` — misleading because the user did pass `--domain`. The added live transcript and the three new `cli-utils.test.ts` cases lock that misleading path out.

## Root Cause (if applicable)

- Root cause: `normalizeWideAreaDomain` trimmed the configured value and enforced a trailing dot, but did not validate DNS labels before `getWideAreaZonePath` derived the zone filename. Compounding this, `resolveWideAreaDiscoveryDomain` catches the validation error and returns `null`, so `dns setup` mapped invalid CLI/config input to the "not configured" branch.
- Missing detection / guardrail: there were no colocated tests for path-like domain strings, embedded newline text, or empty labels at the helper layer, and no CLI-layer test for the invalid-`--domain` user path.
- Contributing context (if known): zone path derivation reused the configured domain text directly after only light normalization, and the resolver's silent fallback to env was intentional for background callers but harmful for the user-driven setup command.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target tests / files:
  - `src/infra/widearea-dns.test.ts` — helper-layer rejection of invalid labels, traversal-like input, and embedded newlines, plus zone-path containment under the DNS config directory.
  - `src/cli/cli-utils.test.ts` — CLI-layer `dns setup --domain <invalid>` cases asserting the explicit DNS-name diagnostic and absence of the misleading "No wide-area domain configured" message.
  - `src/gateway/server-discovery-runtime.test.ts` — gateway-startup case driving `startGatewayDiscovery` through the real resolver with `wideAreaDiscoveryDomain: "foo/bar"`; locks in graceful degradation (warning logged, zone writer never called, no throw).
- Scenario the tests should lock in: reject `../../x`, `foo/bar`, `foo\\bar`, `evil\nrecords`, and `openclaw..internal` at the helper layer; reject `foo/bar`, `../../x`, and `evil\nrecords` at the `dns setup` CLI layer; degrade gracefully (warn + skip zone write) at the gateway startup layer when `discovery.wideArea.domain` is invalid; keep valid domains under the DNS config directory.
- Why this is the smallest reliable guardrail: the vulnerable behavior was split between the domain normalization/path derivation helper, the zone writer boundary, the user-facing CLI action, and the gateway startup path — each gets a colocated test.
- Existing test that already covers this (if any): existing tests covered valid normalization, valid zone writing, and the happy-path gateway startup; they did not cover invalid domain input at any layer.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Invalid `discovery.wideArea.domain` values now produce a validation error instead of being used to derive a zone file path.
- `openclaw dns setup --domain <invalid>` (or invalid `discovery.wideArea.domain` in config) now throws `wide-area discovery domain must be a valid DNS name` instead of the misleading `No wide-area domain configured. Set discovery.wideArea.domain or pass --domain.` message.
- Background callers (`server-discovery-runtime`, `gateway-status`, `onboard-remote`, `bonjour-discovery`, `gateway-cli/register`) keep their existing "degrade silently when wide-area is misconfigured" behavior; the resolver contract is unchanged for them.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation: zone file writes are constrained to validated DNS-label filenames under the DNS config directory, narrowing file-write behavior without expanding access. The CLI amendment narrows the user-facing error surface — invalid input no longer reaches the env-fallback path silently.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node test wrapper in the local checkout
- Model/provider: N/A
- Integration/channel (if any): wide-area DNS-SD zone generation, `openclaw dns setup` CLI
- Relevant config (redacted): `discovery.wideArea.domain` values covered by the regression tests; `--domain` flag exercised at the CLI layer

### Steps

1. Exercise invalid wide-area domain strings through `writeWideAreaGatewayZone`.
2. Exercise a valid wide-area domain through `getWideAreaZonePath`.
3. Exercise `dns setup --domain foo/bar` (and other invalid forms) through `registerDnsCli` + `program.parseAsync`.
4. Run `node scripts/run-vitest.mjs src/infra/widearea-dns.test.ts` and `node scripts/run-vitest.mjs src/cli/cli-utils.test.ts`.

### Expected

- Invalid domains reject before directory creation or zone file writes.
- `dns setup` with an invalid `--domain` throws the explicit DNS-name diagnostic before any setup table is printed.
- Valid domains still derive zone paths under the DNS config directory and print the setup table.

### Actual

- `widearea-dns.test.ts`: 29 tests passed.
- `cli-utils.test.ts`: 42 tests passed, including the three new invalid-`--domain` cases.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted wide-area DNS tests via `node scripts/run-vitest.mjs src/infra/widearea-dns.test.ts`, CLI tests via `node scripts/run-vitest.mjs src/cli/cli-utils.test.ts`, gateway-startup tests via `node scripts/run-vitest.mjs src/gateway/server-discovery-runtime.test.ts`, and end-to-end CLI invocation via `pnpm dev dns setup --domain <value>` on Linux with Node 22.22.2.
- Edge cases checked: traversal-like input, forward slash, backslash, embedded newline, empty label, and valid path containment at the helper layer; `--domain foo/bar`, `--domain ../../x`, and `--domain "openclaw..internal"` at the live CLI layer (all produce the explicit DNS-name diagnostic with exit code 1); `wideAreaDiscoveryDomain: "foo/bar"` at gateway startup (real resolver path, warning logged, zone writer untouched, no throw); valid `--domain openclaw.internal` still renders the setup table and recommended config.
- What you did **not** verify: live CoreDNS install (`--apply` path requires macOS + sudo + Homebrew), full live gateway boot end-to-end against a real Tailnet, and broad changed gates.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes for valid DNS-style wide-area domains
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: existing configs with non-DNS wide-area domain strings now fail validation.
  - Mitigation: valid DNS label domains remain accepted, and invalid values fail before writing zone files.
- Risk: existing `dns setup` invocations that relied on the silent "not configured" fallback when passing junk to `--domain` will now see an explicit error.
  - Mitigation: the new error message is actionable and points at the invalid DNS label; the env-fallback path is preserved for the empty/no-explicit-input case.
