### PR TITLE
chore: format oxfmt-touched files

### DIFF
--- a/.oxfmtrc.jsonc
+++ b/.oxfmtrc.jsonc
@@ -37,6 +37,7 @@
     "src/gateway/server-methods/CLAUDE.md",
     "src/auto-reply/reply/export-html/",
     "src/canvas-host/a2ui/a2ui.bundle.js",
+    "extensions/diffs/assets/viewer-runtime.js",
     "test/fixtures/agents/prompt-snapshots/codex-model-catalog/*.instructions.md",
     "test/fixtures/agents/prompt-snapshots/happy-path/*.md",
     "vendor/",

--- a/extensions/browser/src/browser/chrome-mcp.test.ts
+++ b/extensions/browser/src/browser/chrome-mcp.test.ts
@@ -338,7 +338,9 @@ describe("chrome MCP page parsing", () => {
 
     expect(message).toContain("Chrome MCP existing-session attach failed");
     expect(message).toContain("~/Library/Application Support/Google/Chrome/Profile 1");
-    expect(message).toContain("attach failed for ~/Library/Application Support/Google/Chrome/Profile 1");
+    expect(message).toContain(
+      "attach failed for ~/Library/Application Support/Google/Chrome/Profile 1",
+    );
     expect(message).not.toContain(homeDir);
     expect(message).not.toContain(userDataDir);
   });

--- a/extensions/canvas/scripts/copy-a2ui.d.mts
+++ b/extensions/canvas/scripts/copy-a2ui.d.mts
@@ -1,4 +1,1 @@
-export declare function copyA2uiAssets(params: {
-  srcDir: string;
-  outDir: string;
-}): Promise<void>;
+export declare function copyA2uiAssets(params: { srcDir: string; outDir: string }): Promise<void>;

--- a/extensions/deepinfra/speech-provider.test.ts
+++ b/extensions/deepinfra/speech-provider.test.ts
@@ -7,18 +7,18 @@ const {
   readProviderBinaryResponseMock,
   resolveProviderHttpRequestConfigMock,
 } = vi.hoisted(() => ({
-    assertOkOrThrowHttpErrorMock: vi.fn(async () => {}),
-    postJsonRequestMock: vi.fn(),
-    readProviderBinaryResponseMock: vi.fn(async (response: Response) => {
-      return new Uint8Array(await response.arrayBuffer());
-    }),
-    resolveProviderHttpRequestConfigMock: vi.fn((params: Record<string, unknown>) => ({
-      baseUrl: params.baseUrl ?? params.defaultBaseUrl ?? "https://api.deepinfra.com/v1/openai",
-      allowPrivateNetwork: false,
-      headers: new Headers(params.defaultHeaders as HeadersInit | undefined),
-      dispatcherPolicy: undefined,
-    })),
-  }));
+  assertOkOrThrowHttpErrorMock: vi.fn(async () => {}),
+  postJsonRequestMock: vi.fn(),
+  readProviderBinaryResponseMock: vi.fn(async (response: Response) => {
+    return new Uint8Array(await response.arrayBuffer());
+  }),
+  resolveProviderHttpRequestConfigMock: vi.fn((params: Record<string, unknown>) => ({
+    baseUrl: params.baseUrl ?? params.defaultBaseUrl ?? "https://api.deepinfra.com/v1/openai",
+    allowPrivateNetwork: false,
+    headers: new Headers(params.defaultHeaders as HeadersInit | undefined),
+    dispatcherPolicy: undefined,
+  })),
+}));
 
 vi.mock("openclaw/plugin-sdk/provider-http", () => ({
   assertOkOrThrowHttpError: assertOkOrThrowHttpErrorMock,

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -202,9 +202,7 @@ function hasGeminiThoughtSignatureTruncationFootprint(value: string): boolean {
   );
 }
 
-function sanitizeGeminiThoughtSignature(
-  thoughtSignature: string | undefined,
-): string | undefined {
+function sanitizeGeminiThoughtSignature(thoughtSignature: string | undefined): string | undefined {
   if (typeof thoughtSignature !== "string") {
     return undefined;
   }
@@ -552,9 +550,7 @@ function convertGoogleMessages(model: GoogleTransportModel, context: Context) {
             : undefined;
           parts.push({
             text: sanitizeTransportPayloadText(block.text),
-            ...(sanitizedTextSignature
-              ? { thoughtSignature: sanitizedTextSignature }
-              : {}),
+            ...(sanitizedTextSignature ? { thoughtSignature: sanitizedTextSignature } : {}),
           });
           continue;
         }

--- a/extensions/kimi-coding/stream.test.ts
+++ b/extensions/kimi-coding/stream.test.ts
@@ -318,7 +318,7 @@ describe("kimi tool-call markup wrapper", () => {
             {
               id: "call_1",
               type: "function",
-              function: { name: "exec", arguments: "{\"command\":\"pwd\"}" },
+              function: { name: "exec", arguments: '{"command":"pwd"}' },
             },
           ],
         },
@@ -359,7 +359,7 @@ describe("kimi tool-call markup wrapper", () => {
             {
               id: "call_1",
               type: "function",
-              function: { name: "exec", arguments: "{\"command\":\"pwd\"}" },
+              function: { name: "exec", arguments: '{"command":"pwd"}' },
             },
           ],
         },
@@ -391,7 +391,7 @@ describe("kimi tool-call markup wrapper", () => {
             {
               id: "call_1",
               type: "function",
-              function: { name: "exec", arguments: "{\"command\":\"pwd\"}" },
+              function: { name: "exec", arguments: '{"command":"pwd"}' },
             },
           ],
         },
@@ -418,7 +418,7 @@ describe("kimi tool-call markup wrapper", () => {
             {
               id: "call_1",
               type: "function",
-              function: { name: "exec", arguments: "{\"command\":\"pwd\"}" },
+              function: { name: "exec", arguments: '{"command":"pwd"}' },
             },
           ],
         },

--- a/extensions/memory-wiki/src/tool.test.ts
+++ b/extensions/memory-wiki/src/tool.test.ts
@@ -2,9 +2,9 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import type { ResolvedMemoryWikiConfig } from "./config.js";
-import { createWikiApplyTool, createWikiLintTool } from "./tool.js";
 import { lintMemoryWikiVault } from "./lint.js";
 import { createMemoryWikiTestHarness } from "./test-helpers.js";
+import { createWikiApplyTool, createWikiLintTool } from "./tool.js";
 
 function asSchemaObject(value: unknown): Record<string, unknown> {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {

--- a/extensions/oc-path/src/oc-path/edit.ts
+++ b/extensions/oc-path/src/oc-path/edit.ts
@@ -26,11 +26,17 @@ export function setMdOcPath(ast: MdAst, path: OcPath, newValue: string): MdEditR
   guardSentinel(newValue, formatOcPath(path));
   if (path.section === "[frontmatter]") {
     const key = path.item ?? path.field;
-    if (key === undefined) {return { ok: false, reason: "unresolved" };}
+    if (key === undefined) {
+      return { ok: false, reason: "unresolved" };
+    }
     const idx = ast.frontmatter.findIndex((e) => e.key === key);
-    if (idx === -1) {return { ok: false, reason: "unresolved" };}
+    if (idx === -1) {
+      return { ok: false, reason: "unresolved" };
+    }
     const existing = ast.frontmatter[idx];
-    if (existing === undefined) {return { ok: false, reason: "unresolved" };}
+    if (existing === undefined) {
+      return { ok: false, reason: "unresolved" };
+    }
     const newEntry: FrontmatterEntry = { ...existing, value: newValue };
     const newFm = ast.frontmatter.slice();
     newFm[idx] = newEntry;
@@ -43,16 +49,26 @@ export function setMdOcPath(ast: MdAst, path: OcPath, newValue: string): MdEditR
 
   const sectionSlug = path.section.toLowerCase();
   const blockIdx = ast.blocks.findIndex((b) => b.slug === sectionSlug);
-  if (blockIdx === -1) {return { ok: false, reason: "unresolved" };}
+  if (blockIdx === -1) {
+    return { ok: false, reason: "unresolved" };
+  }
   const block = ast.blocks[blockIdx];
-  if (block === undefined) {return { ok: false, reason: "unresolved" };}
+  if (block === undefined) {
+    return { ok: false, reason: "unresolved" };
+  }
 
   const itemSlug = path.item.toLowerCase();
   const itemIdx = block.items.findIndex((i) => i.slug === itemSlug);
-  if (itemIdx === -1) {return { ok: false, reason: "unresolved" };}
+  if (itemIdx === -1) {
+    return { ok: false, reason: "unresolved" };
+  }
   const item = block.items[itemIdx];
-  if (item === undefined) {return { ok: false, reason: "unresolved" };}
-  if (item.kv === undefined) {return { ok: false, reason: "no-item-kv" };}
+  if (item === undefined) {
+    return { ok: false, reason: "unresolved" };
+  }
+  if (item.kv === undefined) {
+    return { ok: false, reason: "no-item-kv" };
+  }
   if (item.kv.key.toLowerCase() !== path.field.toLowerCase()) {
     return { ok: false, reason: "unresolved" };
   }
@@ -78,9 +94,15 @@ function rebuildBlockBody(block: AstBlock, newItems: readonly AstItem[]): string
   for (let i = 0; i < newItems.length; i++) {
     const newItem = newItems[i];
     const oldItem = block.items[i];
-    if (newItem === undefined || oldItem === undefined) {continue;}
-    if (newItem.kv === undefined || oldItem.kv === undefined) {continue;}
-    if (newItem.kv.value === oldItem.kv.value) {continue;}
+    if (newItem === undefined || oldItem === undefined) {
+      continue;
+    }
+    if (newItem.kv === undefined || oldItem.kv === undefined) {
+      continue;
+    }
+    if (newItem.kv.value === oldItem.kv.value) {
+      continue;
+    }
     const re = new RegExp(`^(\\s*-\\s*${escapeRegex(oldItem.kv.key)}\\s*:\\s*).*$`, "m");
     body = body.replace(re, `$1${newItem.kv.value}`);
   }
@@ -101,19 +123,29 @@ function finalize(ast: MdAst): MdEditResult {
     parts.push("---");
   }
   if (ast.preamble.length > 0) {
-    if (parts.length > 0) {parts.push("");}
+    if (parts.length > 0) {
+      parts.push("");
+    }
     parts.push(ast.preamble);
   }
   for (const block of ast.blocks) {
-    if (parts.length > 0) {parts.push("");}
+    if (parts.length > 0) {
+      parts.push("");
+    }
     parts.push(`## ${block.heading}`);
-    if (block.bodyText.length > 0) {parts.push(block.bodyText);}
+    if (block.bodyText.length > 0) {
+      parts.push(block.bodyText);
+    }
   }
   return { ok: true, ast: { ...ast, raw: parts.join("\n") } };
 }
 
 function formatFrontmatterValue(value: string): string {
-  if (value.length === 0) {return '""';}
-  if (/[:#&*?|<>=!%@`,[\]{}\r\n]/.test(value)) {return JSON.stringify(value);}
+  if (value.length === 0) {
+    return '""';
+  }
+  if (/[:#&*?|<>=!%@`,[\]{}\r\n]/.test(value)) {
+    return JSON.stringify(value);
+  }
   return value;
 }

--- a/extensions/oc-path/src/oc-path/jsonc/emit.ts
+++ b/extensions/oc-path/src/oc-path/jsonc/emit.ts
@@ -33,7 +33,9 @@ export function emitJsonc(ast: JsoncAst, opts: JsoncEmitOptions = {}): string {
   }
 
   // Render mode loses comments; walks leaves for caller-injected sentinel.
-  if (ast.root === null) {return "";}
+  if (ast.root === null) {
+    return "";
+  }
   return renderValue(ast.root, guardPath, []);
 }
 

--- a/extensions/oc-path/src/oc-path/jsonc/resolve.ts
+++ b/extensions/oc-path/src/oc-path/jsonc/resolve.ts
@@ -26,11 +26,15 @@ export type JsoncOcPathMatch =
     };
 
 export function resolveJsoncOcPath(ast: JsoncAst, path: OcPath): JsoncOcPathMatch | null {
-  if (ast.root === null) {return null;}
+  if (ast.root === null) {
+    return null;
+  }
 
   const segments: string[] = [];
   const collect = (slot: string | undefined): void => {
-    if (slot === undefined) {return;}
+    if (slot === undefined) {
+      return;
+    }
     for (const s of splitRespectingBrackets(slot, ".")) {
       segments.push(isQuotedSeg(s) ? unquoteSeg(s) : s);
     }
@@ -39,32 +43,44 @@ export function resolveJsoncOcPath(ast: JsoncAst, path: OcPath): JsoncOcPathMatc
   collect(path.item);
   collect(path.field);
 
-  if (segments.length === 0) {return { kind: "root", node: ast };}
+  if (segments.length === 0) {
+    return { kind: "root", node: ast };
+  }
 
   let current: JsoncValue = ast.root;
   let lastEntry: JsoncEntry | null = null;
   const walked: string[] = [];
 
   for (let seg of segments) {
-    if (seg.length === 0) {return null;}
+    if (seg.length === 0) {
+      return null;
+    }
     if (isPositionalSeg(seg)) {
       const concrete = positionalForJsonc(current, seg);
-      if (concrete !== null) {seg = concrete;}
+      if (concrete !== null) {
+        seg = concrete;
+      }
     }
     walked.push(seg);
     if (current.kind === "object") {
       const entry = current.entries.find((e) => e.key === seg);
-      if (entry === undefined) {return null;}
+      if (entry === undefined) {
+        return null;
+      }
       lastEntry = entry;
       current = entry.value;
       continue;
     }
     if (current.kind === "array") {
       const idx = Number(seg);
-      if (!Number.isInteger(idx) || idx < 0 || idx >= current.items.length) {return null;}
+      if (!Number.isInteger(idx) || idx < 0 || idx >= current.items.length) {
+        return null;
+      }
       lastEntry = null;
       const item = current.items[idx];
-      if (item === undefined) {return null;}
+      if (item === undefined) {
+        return null;
+      }
       current = item;
       continue;
     }

--- a/extensions/oc-path/src/oc-path/parse.ts
+++ b/extensions/oc-path/src/oc-path/parse.ts
@@ -12,14 +12,7 @@
  */
 
 import MarkdownIt from "markdown-it";
-
-import type {
-  AstBlock,
-  AstItem,
-  Diagnostic,
-  FrontmatterEntry,
-  ParseResult,
-} from "./ast.js";
+import type { AstBlock, AstItem, Diagnostic, FrontmatterEntry, ParseResult } from "./ast.js";
 import { slugify } from "./slug.js";
 
 type Token = ReturnType<MarkdownIt["parse"]>[number];
@@ -153,7 +146,9 @@ function extractItems(tokens: readonly Token[], bodyFileLine: number): AstItem[]
   const items: AstItem[] = [];
   for (let i = 0; i < tokens.length; i++) {
     const t = tokens[i];
-    if (t.type !== "list_item_open" || t.map === null) {continue;}
+    if (t.type !== "list_item_open" || t.map === null) {
+      continue;
+    }
     // First inline at the item's own depth is the item text.
     let nestedDepth = 0;
     let text = "";
@@ -175,9 +170,7 @@ function extractItems(tokens: readonly Token[], bodyFileLine: number): AstItem[]
       text,
       slug: kvMatch ? slugify(kvMatch[1]) : slugify(text),
       line: bodyFileLine + t.map[0],
-      ...(kvMatch !== null
-        ? { kv: { key: kvMatch[1].trim(), value: kvMatch[2].trim() } }
-        : {}),
+      ...(kvMatch !== null ? { kv: { key: kvMatch[1].trim(), value: kvMatch[2].trim() } } : {}),
     });
   }
   return items;

--- a/extensions/oc-path/src/oc-path/resolve.ts
+++ b/extensions/oc-path/src/oc-path/resolve.ts
@@ -35,39 +35,61 @@ export type OcPathMatch =
 export function resolveMdOcPath(ast: MdAst, path: OcPath): OcPathMatch | null {
   if (path.section === "[frontmatter]") {
     const key = path.item ?? path.field;
-    if (key === undefined) {return null;}
+    if (key === undefined) {
+      return null;
+    }
     const entry = ast.frontmatter.find((e) => e.key === key);
-    if (entry === undefined) {return null;}
+    if (entry === undefined) {
+      return null;
+    }
     return { kind: "frontmatter", node: entry };
   }
 
-  if (path.section === undefined) {return { kind: "root", node: ast };}
+  if (path.section === undefined) {
+    return { kind: "root", node: ast };
+  }
 
   const block = ast.blocks.find((b) => b.slug === path.section!.toLowerCase());
-  if (block === undefined) {return null;}
-  if (path.item === undefined) {return { kind: "block", node: block };}
+  if (block === undefined) {
+    return null;
+  }
+  if (path.item === undefined) {
+    return { kind: "block", node: block };
+  }
 
   // Item dispatch: ordinal (#N) > positional ($last) > slug.
   // Ordinal uses document order so duplicate-slug items stay distinct.
   let item: AstItem | undefined;
   if (isOrdinalSeg(path.item)) {
     const n = parseOrdinalSeg(path.item);
-    if (n === null || n < 0 || n >= block.items.length) {return null;}
+    if (n === null || n < 0 || n >= block.items.length) {
+      return null;
+    }
     item = block.items[n];
   } else if (isPositionalSeg(path.item)) {
     const concrete = resolvePositionalSeg(path.item, {
       indexable: true,
       size: block.items.length,
     });
-    if (concrete === null) {return null;}
+    if (concrete === null) {
+      return null;
+    }
     item = block.items[Number(concrete)];
   } else {
     item = block.items.find((i) => i.slug === path.item!.toLowerCase());
   }
-  if (item === undefined) {return null;}
-  if (path.field === undefined) {return { kind: "item", node: item, block };}
+  if (item === undefined) {
+    return null;
+  }
+  if (path.field === undefined) {
+    return { kind: "item", node: item, block };
+  }
 
-  if (item.kv === undefined) {return null;}
-  if (item.kv.key.toLowerCase() !== path.field.toLowerCase()) {return null;}
+  if (item.kv === undefined) {
+    return null;
+  }
+  if (item.kv.key.toLowerCase() !== path.field.toLowerCase()) {
+    return null;
+  }
   return { kind: "item-field", node: item, block, value: item.kv.value };
 }

--- a/extensions/oc-path/src/oc-path/tests/oc-path.test.ts
+++ b/extensions/oc-path/src/oc-path/tests/oc-path.test.ts
@@ -52,10 +52,7 @@ describe("parseOcPath", () => {
   });
 
   it("rejects control chars in ignored query values", () => {
-    expectOcPathError(
-      () => parseOcPath("oc://SOUL.md?ignored=\x00"),
-      "OC_PATH_CONTROL_CHAR",
-    );
+    expectOcPathError(() => parseOcPath("oc://SOUL.md?ignored=\x00"), "OC_PATH_CONTROL_CHAR");
   });
 
   it("rejects missing scheme", () => {

--- a/extensions/oc-path/src/oc-path/tests/scenarios/roundtrip-property.test.ts
+++ b/extensions/oc-path/src/oc-path/tests/scenarios/roundtrip-property.test.ts
@@ -82,7 +82,6 @@ describe("roundtrip-property", () => {
   });
 });
 
-
 function generateCorpus(count: number): string[] {
   const corpus: string[] = [];
   // Deterministic seed so flaky failures don't surface differently each run.

--- a/extensions/oc-path/src/oc-path/tests/scenarios/security-and-limits.test.ts
+++ b/extensions/oc-path/src/oc-path/tests/scenarios/security-and-limits.test.ts
@@ -12,7 +12,6 @@ import {
 import { parseJsonc } from "../../jsonc/parse.js";
 import { parseJsonl } from "../../jsonl/parse.js";
 
-
 describe("encoding edges", () => {
   it("strips leading UTF-8 BOM from path string", () => {
     expect(parseOcPath("﻿oc://X/Y").file).toBe("X");
@@ -36,7 +35,6 @@ describe("encoding edges", () => {
     expect(() => parseOcPath("oc://X.md/items/[k=a\x00b]")).toThrow(OcPathError);
   });
 });
-
 
 describe("file-slot containment", () => {
   it("rejects absolute POSIX file slot", () => {
@@ -72,7 +70,6 @@ describe("file-slot containment", () => {
     expect(() => formatOcPath({ file: "foo/../bar" })).toThrow(/Parent-directory/);
   });
 });
-
 
 describe("path-string and traversal caps", () => {
   it("parseOcPath rejects strings longer than MAX_PATH_LENGTH", () => {
@@ -123,7 +120,6 @@ describe("path-string and traversal caps", () => {
   });
 });
 
-
 describe("sentinel literal at format boundary", () => {
   it("formatOcPath rejects a struct carrying the redaction sentinel", () => {
     expect(() => formatOcPath({ file: "AGENTS.md", section: "__OPENCLAW_REDACTED__" })).toThrow(
@@ -131,7 +127,6 @@ describe("sentinel literal at format boundary", () => {
     );
   });
 });
-
 
 describe("numeric segments dispatch by node kind", () => {
   it("negative numeric key on object resolves as literal key (openclaw#59934)", () => {
@@ -153,7 +148,6 @@ describe("numeric segments dispatch by node kind", () => {
   });
 });
 
-
 describe("setOcPath value coercion is locale-independent and exact-match", () => {
   it("number coercion accepts `1.5`, refuses `1,5`", () => {
     const ast = parseJsonc('{"x":1.0}').ast;
@@ -173,7 +167,6 @@ describe("setOcPath value coercion is locale-independent and exact-match", () =>
     expect(setOcPath(ast, parseOcPath("oc://X/x"), "yes").ok).toBe(false);
   });
 });
-
 
 describe("predicate-value injection is contained", () => {
   it("regex metacharacters in predicate value match literally, not as regex", () => {
@@ -212,7 +205,6 @@ describe("predicate-value injection is contained", () => {
     expect(matches).toHaveLength(1);
   });
 });
-
 
 describe("structural rejection", () => {
   it("rejects mismatched brackets and braces", () => {

--- a/extensions/openrouter/speech-provider.test.ts
+++ b/extensions/openrouter/speech-provider.test.ts
@@ -7,18 +7,18 @@ const {
   readProviderBinaryResponseMock,
   resolveProviderHttpRequestConfigMock,
 } = vi.hoisted(() => ({
-    assertOkOrThrowHttpErrorMock: vi.fn(async () => {}),
-    postJsonRequestMock: vi.fn(),
-    readProviderBinaryResponseMock: vi.fn(async (response: Response) => {
-      return new Uint8Array(await response.arrayBuffer());
-    }),
-    resolveProviderHttpRequestConfigMock: vi.fn((params: Record<string, unknown>) => ({
-      baseUrl: params.baseUrl ?? params.defaultBaseUrl ?? "https://openrouter.ai/api/v1",
-      allowPrivateNetwork: false,
-      headers: new Headers(params.defaultHeaders as HeadersInit | undefined),
-      dispatcherPolicy: undefined,
-    })),
-  }));
+  assertOkOrThrowHttpErrorMock: vi.fn(async () => {}),
+  postJsonRequestMock: vi.fn(),
+  readProviderBinaryResponseMock: vi.fn(async (response: Response) => {
+    return new Uint8Array(await response.arrayBuffer());
+  }),
+  resolveProviderHttpRequestConfigMock: vi.fn((params: Record<string, unknown>) => ({
+    baseUrl: params.baseUrl ?? params.defaultBaseUrl ?? "https://openrouter.ai/api/v1",
+    allowPrivateNetwork: false,
+    headers: new Headers(params.defaultHeaders as HeadersInit | undefined),
+    dispatcherPolicy: undefined,
+  })),
+}));
 
 vi.mock("openclaw/plugin-sdk/provider-http", () => ({
   assertOkOrThrowHttpError: assertOkOrThrowHttpErrorMock,

--- a/extensions/qa-lab/src/tool-coverage-report.test.ts
+++ b/extensions/qa-lab/src/tool-coverage-report.test.ts
@@ -327,9 +327,7 @@ describe("qa tool coverage report", () => {
     });
 
     expect(report.pass).toBe(false);
-    expect(report.failures).toEqual([
-      "web-search missing codex tool call web_search",
-    ]);
+    expect(report.failures).toEqual(["web-search missing codex tool call web_search"]);
   });
 
   it("fails required OpenClaw dynamic tool coverage when the fixture failure mode is preserved", () => {

--- a/extensions/qa-lab/src/tool-coverage-report.ts
+++ b/extensions/qa-lab/src/tool-coverage-report.ts
@@ -208,9 +208,7 @@ function buildRow(params: {
     .find((entry) => entry.required);
   const fallbackMetadata = readScenarioRuntimeToolCoverageMetadata(params.group.scenarios[0]);
   const rowMetadata = metadata ?? fallbackMetadata;
-  const runtimeToolName = params.group.scenarios
-    .map(readScenarioRuntimeToolName)
-    .find(Boolean);
+  const runtimeToolName = params.group.scenarios.map(readScenarioRuntimeToolName).find(Boolean);
   return {
     tool: params.group.tool,
     ...(runtimeToolName ? { runtimeToolName } : {}),

--- a/scripts/lib/bundled-plugin-build-entries.mjs
+++ b/scripts/lib/bundled-plugin-build-entries.mjs
@@ -178,7 +178,8 @@ export function collectBundledPluginBuildEntries(params = {}) {
   for (const candidate of collectBundledPluginCandidates(cwd, extensionsRoot)) {
     const { dirName, pluginDir, relativeFiles, topLevelPublicSurfaceEntries } = candidate;
     const manifestPath = path.join(pluginDir, "openclaw.plugin.json");
-    const hasManifest = relativeFiles?.includes("openclaw.plugin.json") ?? fs.existsSync(manifestPath);
+    const hasManifest =
+      relativeFiles?.includes("openclaw.plugin.json") ?? fs.existsSync(manifestPath);
     const packageJsonPath = path.join(pluginDir, "package.json");
     const packageJson = readBundledPluginPackageJson(packageJsonPath, {
       hasPackageJson: relativeFiles?.includes("package.json"),

--- a/scripts/lib/changed-extensions.mjs
+++ b/scripts/lib/changed-extensions.mjs
@@ -71,7 +71,11 @@ function listChangedPaths(base, head = "HEAD") {
 }
 
 function listAvailableExtensionIdsFromGit() {
-  const packageFiles = runGit(["ls-files", "--", `:(glob)${BUNDLED_PLUGIN_PATH_PREFIX}*/package.json`])
+  const packageFiles = runGit([
+    "ls-files",
+    "--",
+    `:(glob)${BUNDLED_PLUGIN_PATH_PREFIX}*/package.json`,
+  ])
     .split("\n")
     .map((line) => normalizeRelative(line.trim()))
     .filter((line) => line.length > 0);

--- a/scripts/lib/extension-test-plan.mjs
+++ b/scripts/lib/extension-test-plan.mjs
@@ -70,7 +70,9 @@ function isPathInsideRepo(relativePath) {
 }
 
 function isSkippedTrackedTestFile(relativePath) {
-  return relativePath.split("/").some((segment) => segment === "dist" || segment === "node_modules");
+  return relativePath
+    .split("/")
+    .some((segment) => segment === "dist" || segment === "node_modules");
 }
 
 function listTrackedTestFiles(rootPath) {

--- a/scripts/lib/local-build-metadata.d.mts
+++ b/scripts/lib/local-build-metadata.d.mts
@@ -1,7 +1,4 @@
-export {
-  BUILD_STAMP_FILE,
-  RUNTIME_POSTBUILD_STAMP_FILE,
-} from "./local-build-metadata-paths.mjs";
+export { BUILD_STAMP_FILE, RUNTIME_POSTBUILD_STAMP_FILE } from "./local-build-metadata-paths.mjs";
 
 export function resolveGitHead(params?: {
   cwd?: string;

--- a/scripts/test-built-status-message-runtime.mjs
+++ b/scripts/test-built-status-message-runtime.mjs
@@ -8,15 +8,14 @@ import { parsePackageRootArg } from "./lib/package-root-args.mjs";
 const STATUS_MESSAGE_RUNTIME_RE = /^status-message\.runtime(?:-[A-Za-z0-9_-]+)?\.js$/u;
 
 export function findBuiltStatusMessageRuntimePath(distDir) {
-  const candidates = listBuiltStatusMessageRuntimeFiles(distDir)
-    .toSorted((left, right) => {
-      const leftHasHash = left !== "status-message.runtime.js";
-      const rightHasHash = right !== "status-message.runtime.js";
-      if (leftHasHash !== rightHasHash) {
-        return leftHasHash ? -1 : 1;
-      }
-      return left.localeCompare(right);
-    });
+  const candidates = listBuiltStatusMessageRuntimeFiles(distDir).toSorted((left, right) => {
+    const leftHasHash = left !== "status-message.runtime.js";
+    const rightHasHash = right !== "status-message.runtime.js";
+    if (leftHasHash !== rightHasHash) {
+      return leftHasHash ? -1 : 1;
+    }
+    return left.localeCompare(right);
+  });
 
   assert.ok(candidates.length > 0, `missing built status-message runtime bundle under ${distDir}`);
 

--- a/src/agents/pi-embedded-runner/runs.test.ts
+++ b/src/agents/pi-embedded-runner/runs.test.ts
@@ -1,10 +1,10 @@
 import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { diagnosticLogger } from "../../logging/diagnostic.js";
 import {
   testing as replyRunTesting,
   createReplyOperation,
 } from "../../auto-reply/reply/reply-run-registry.js";
+import { diagnosticLogger } from "../../logging/diagnostic.js";
 import {
   testing,
   abortAndDrainEmbeddedPiRun,

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -1425,7 +1425,11 @@ function collectDryRunRefs(params: {
     if (!ref) {
       continue;
     }
-    if (includeAllDiscoveredRefs || targetPaths.has(target.path) || providerAliases.has(ref.provider)) {
+    if (
+      includeAllDiscoveredRefs ||
+      targetPaths.has(target.path) ||
+      providerAliases.has(ref.provider)
+    ) {
       refsByKey.set(secretRefKey(ref), ref);
     }
   }

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -316,16 +316,7 @@ describe("cron cli", () => {
         enqueued: true,
         runId: "manual:job-1:123:0",
         runStatus: status,
-        args: [
-          "cron",
-          "run",
-          "job-1",
-          "--wait",
-          "--wait-timeout",
-          "1s",
-          "--poll-interval",
-          "1ms",
-        ],
+        args: ["cron", "run", "job-1", "--wait", "--wait-timeout", "1s", "--poll-interval", "1ms"],
       });
 
       expect(exitSpy).toHaveBeenCalledWith(expectedExitCode);

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -134,7 +134,10 @@ describe("registerPreActionHooks", () => {
       .command("create")
       .option("--json")
       .action(() => {});
-    program.command("doctor").option("--lint").action(() => {});
+    program
+      .command("doctor")
+      .option("--lint")
+      .action(() => {});
     program.command("completion").action(() => {});
     program.command("secrets").action(() => {});
     program

--- a/src/commands/doctor/shared/allowfrom-fallback-migration.ts
+++ b/src/commands/doctor/shared/allowfrom-fallback-migration.ts
@@ -53,7 +53,9 @@ function readOwnDmAllowFrom(params: { channelName: string; account: ChannelRecor
   );
 }
 
-function findGeneratedChannelConfigSchema(channelName: string): Record<string, unknown> | undefined {
+function findGeneratedChannelConfigSchema(
+  channelName: string,
+): Record<string, unknown> | undefined {
   const normalizedChannelId = normalizeAnyChannelId(channelName);
   return GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA.find(
     (entry) => entry.channelId === channelName || entry.channelId === normalizedChannelId,

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -43,8 +43,8 @@ import { materializeRuntimeConfig } from "./materialize.js";
 import { collectConfiguredModelRefs } from "./model-refs.js";
 import type { OpenClawConfig, ConfigValidationIssue } from "./types.js";
 import { coerceSecretRef } from "./types.secrets.js";
-import { OpenClawSchema } from "./zod-schema.js";
 import { isBuiltInModelProviderOverlayId } from "./zod-schema.core.js";
+import { OpenClawSchema } from "./zod-schema.js";
 
 const LEGACY_REMOVED_PLUGIN_IDS = new Set(["google-antigravity-auth", "google-gemini-cli-auth"]);
 const BLOCKED_PLUGIN_CANDIDATE_PREFIX = "blocked plugin candidate:";

--- a/src/cron/isolated-agent/run.runtime-plugins.test.ts
+++ b/src/cron/isolated-agent/run.runtime-plugins.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { makeIsolatedAgentTurnParams, setupRunCronIsolatedAgentTurnSuite } from "./run.suite-helpers.js";
+import {
+  makeIsolatedAgentTurnParams,
+  setupRunCronIsolatedAgentTurnSuite,
+} from "./run.suite-helpers.js";
 import {
   loadRunCronIsolatedAgentTurn,
   ensureRuntimePluginsLoadedMock,

--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -156,10 +156,7 @@ function loadStateFileSync(statePath: string): CronStateFile | null {
 
 function hasInlineState(jobs: Array<Record<string, unknown> | null | undefined>): boolean {
   return jobs.some(
-    (job) =>
-      job != null &&
-      isRecord(job.state) &&
-      Object.keys(job.state).length > 0,
+    (job) => job != null && isRecord(job.state) && Object.keys(job.state).length > 0,
   );
 }
 

--- a/src/flows/doctor-lint-flow.ts
+++ b/src/flows/doctor-lint-flow.ts
@@ -1,5 +1,5 @@
-import { listHealthChecks } from "./health-check-registry.js";
 import { scrubDoctorErrorMessage } from "./doctor-error-message.js";
+import { listHealthChecks } from "./health-check-registry.js";
 import {
   HEALTH_FINDING_SEVERITY_RANK,
   healthFindingMeetsSeverity,

--- a/src/gateway/server-chat.stream-text-merge.test.ts
+++ b/src/gateway/server-chat.stream-text-merge.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  MAX_LIVE_CHAT_BUFFER_CHARS,
-  resolveMergedAssistantText,
-} from "./live-chat-projector.js";
+import { MAX_LIVE_CHAT_BUFFER_CHARS, resolveMergedAssistantText } from "./live-chat-projector.js";
 
 describe("server chat stream text merge", () => {
   it.each([

--- a/src/plugins/compat/registry.ts
+++ b/src/plugins/compat/registry.ts
@@ -33,11 +33,11 @@ export const PLUGIN_COMPAT_RECORDS = [
     removeAfter: "2026-08-16",
     replacement: "`gateway_stop` hook",
     docsPath: "/plugins/hooks#upcoming-deprecations",
-    surfaces: ["api.on(\"deactivate\", ...)", "plugin typed hook registration"],
+    surfaces: ['api.on("deactivate", ...)', "plugin typed hook registration"],
     diagnostics: ["plugin runtime compatibility warning"],
     tests: ["src/plugins/loader.test.ts"],
     releaseNote:
-      "`api.on(\"deactivate\", ...)` remains wired as a deprecated compatibility alias while plugins migrate to `gateway_stop`.",
+      '`api.on("deactivate", ...)` remains wired as a deprecated compatibility alias while plugins migrate to `gateway_stop`.',
   },
   {
     code: "hook-only-plugin-shape",

--- a/src/tts/directives.test.ts
+++ b/src/tts/directives.test.ts
@@ -116,12 +116,17 @@ describe("parseTtsDirectives provider-aware routing", () => {
   });
 
   it("routes to preferred provider aliases when no provider token is declared", () => {
-    const azure = makeProvider("azure-speech", 20, ({ key, value }) => {
-      if (key === "speed") {
-        return { handled: true, overrides: { speed: Number(value) } };
-      }
-      return undefined;
-    }, { aliases: ["azure"] });
+    const azure = makeProvider(
+      "azure-speech",
+      20,
+      ({ key, value }) => {
+        if (key === "speed") {
+          return { handled: true, overrides: { speed: Number(value) } };
+        }
+        return undefined;
+      },
+      { aliases: ["azure"] },
+    );
 
     const result = parseTtsDirectives("[[tts:speed=1.5]]", fullPolicy, {
       providers: [elevenlabs, azure],

--- a/test/scripts/test-live-codex-harness-docker.test.ts
+++ b/test/scripts/test-live-codex-harness-docker.test.ts
@@ -41,23 +41,17 @@ describe("scripts/test-live-codex-harness-docker.sh", () => {
   it("forwards API-key auth through both OpenAI and Codex env names", () => {
     const script = fs.readFileSync(SCRIPT_PATH, "utf8");
 
-    expect(script).toContain('printf \'OPENAI_API_KEY=%s\\n\' "${OPENAI_API_KEY}"');
-    expect(script).toContain('printf \'CODEX_API_KEY=%s\\n\' "${CODEX_API_KEY:-$OPENAI_API_KEY}"');
-    expect(script.indexOf("OPENAI_API_KEY=%s")).toBeLessThan(
-      script.indexOf("CODEX_API_KEY=%s"),
-    );
+    expect(script).toContain("printf 'OPENAI_API_KEY=%s\\n' \"${OPENAI_API_KEY}\"");
+    expect(script).toContain("printf 'CODEX_API_KEY=%s\\n' \"${CODEX_API_KEY:-$OPENAI_API_KEY}\"");
+    expect(script.indexOf("OPENAI_API_KEY=%s")).toBeLessThan(script.indexOf("CODEX_API_KEY=%s"));
   });
 
   it("keeps API-key runs on the ephemeral Docker home", () => {
     const script = fs.readFileSync(SCRIPT_PATH, "utf8");
 
     expect(script).toContain('DOCKER_USER="$(id -u):$(id -g)"');
-    expect(script).toContain(
-      'if [[ "$CODEX_HARNESS_AUTH_MODE" == "api-key" ]]; then',
-    );
-    expect(script).toContain(
-      'if [[ -z "${DOCKER_HOME_DIR:-}" ]]; then',
-    );
+    expect(script).toContain('if [[ "$CODEX_HARNESS_AUTH_MODE" == "api-key" ]]; then');
+    expect(script).toContain('if [[ -z "${DOCKER_HOME_DIR:-}" ]]; then');
     expect(script).not.toContain('DOCKER_USER="0:0"');
     expect(script).toContain(
       'DOCKER_HOME_DIR="$(mktemp -d "${RUNNER_TEMP:-/tmp}/openclaw-docker-home.XXXXXX")"',
@@ -74,9 +68,7 @@ describe("scripts/test-live-codex-harness-docker.sh", () => {
     expect(script).toContain(
       'chmod 0777 "$DOCKER_HOME_DIR" "$CONFIG_DIR" "$WORKSPACE_DIR" || true',
     );
-    expect(script).toContain(
-      'if [[ "$CODEX_HARNESS_AUTH_MODE" != "api-key" ]]; then',
-    );
+    expect(script).toContain('if [[ "$CODEX_HARNESS_AUTH_MODE" != "api-key" ]]; then');
     expect(script.indexOf('PROFILE_STATUS="api-key-env"')).toBeLessThan(
       script.indexOf("openclaw_live_append_array DOCKER_RUN_ARGS PROFILE_MOUNT"),
     );

--- a/ui/src/ui/navigation.browser.test.ts
+++ b/ui/src/ui/navigation.browser.test.ts
@@ -466,7 +466,9 @@ describe("control UI routing", () => {
 
     expect([...section.classList]).toContain("nav-section--collapsed");
     expect(
-      section.querySelector<HTMLButtonElement>(".nav-section__label")?.getAttribute("aria-expanded"),
+      section
+        .querySelector<HTMLButtonElement>(".nav-section__label")
+        ?.getAttribute("aria-expanded"),
     ).toBe("false");
   });
 


### PR DESCRIPTION
Summary:
- Apply oxfmt formatting to files reported by the formatter
- Add the bundled viewer runtime asset to oxfmt ignores to avoid generated diffs
- Keep extensions/diffs/assets/viewer-runtime.js unchanged

Verification:
- pnpm format:check
- pnpm check:changed
- git diff --check
- Independent review found no security or logic concerns

Note:
- pnpm test:changed still has an unrelated UI jsdom/Node builtin issue on the upstream test lane; not addressed in this formatting PR.

## Real behavior proof
- Behavior or issue addressed: Running the formatter in a real OpenClaw source checkout touched normal source files but also tried to rewrite the bundled viewer runtime asset. This patch keeps the generated runtime asset unchanged and adds it to oxfmt ignores while preserving the formatter output for real source files.
- Real environment tested: Local OpenClaw source checkout on macOS with Node v24.14.0, pnpm 11.1.0, branch chore/oxfmt-generated-asset-ignore at head 929e82af4c.
- Exact steps or command run after this patch:
  1. git diff -- extensions/diffs/assets/viewer-runtime.js
  2. pnpm format:check
  3. pnpm check:changed
  4. git diff --check
- Evidence after fix: Copied terminal output from the local checkout:
  ```text
  $ git diff -- extensions/diffs/assets/viewer-runtime.js
  [no output; generated runtime asset is unchanged]

  $ pnpm format:check
  $ oxfmt --check --threads=1
  Checking formatting...
  All matched files use the correct format.
  Finished in 10081ms on 15989 files using 1 threads.

  $ pnpm check:changed
  [check:changed] duplicate scan target coverage
  [dup:check] target coverage ok
  PASS direct dependency pin guard: checked 430 directly declared dependency specs across 130 tracked package manifests; 0 violations.
  Found 0 warnings and 0 errors.
  runtime-sidecar-loaders: local runtime sidecar loaders look OK.
  Import cycle check: 0 runtime value cycle(s).
  ```
- Observed result after fix: The generated viewer runtime file remains untouched, the formatter accepts the checkout, changed-file checks pass, and the branch contains only formatter output plus the oxfmt ignore entry.
- What was not tested: Full pnpm test:changed was not used as merge proof because the upstream UI jsdom lane still has an unrelated Node builtin classification issue; this PR does not change that lane.
