### PR TITLE
fix(agents): thread errorMessage through finalizeTransportStream

### DIFF
--- a/src/agents/transport-stream-shared.test.ts
+++ b/src/agents/transport-stream-shared.test.ts
@@ -65,6 +65,36 @@ describe("transport stream shared helpers", () => {
     expect(end).toHaveBeenCalledTimes(1);
   });
 
+  it("throws with the original error message when stream failed", () => {
+    const output: { stopReason: string; errorMessage?: string } = {
+      stopReason: "error",
+      errorMessage: "provider request timed out",
+    };
+
+    expect(() =>
+      finalizeTransportStream({ stream: { push: vi.fn(), end: vi.fn() }, output }),
+    ).toThrow("provider request timed out");
+  });
+
+  it("throws with the abort error message when stream was aborted", () => {
+    const output: { stopReason: string; errorMessage?: string } = {
+      stopReason: "aborted",
+      errorMessage: "network connection reset",
+    };
+
+    expect(() =>
+      finalizeTransportStream({ stream: { push: vi.fn(), end: vi.fn() }, output }),
+    ).toThrow("network connection reset");
+  });
+
+  it("falls back to generic message when errorMessage is absent", () => {
+    const output: { stopReason: string; errorMessage?: string } = { stopReason: "error" };
+
+    expect(() =>
+      finalizeTransportStream({ stream: { push: vi.fn(), end: vi.fn() }, output }),
+    ).toThrow("An unknown error occurred");
+  });
+
   it("marks transport stream failures and runs cleanup", () => {
     const push = vi.fn();
     const end = vi.fn();

--- a/src/agents/transport-stream-shared.ts
+++ b/src/agents/transport-stream-shared.ts
@@ -119,7 +119,7 @@ export function finalizeTransportStream(params: {
     throw new Error("Request was aborted");
   }
   if (output.stopReason === "aborted" || output.stopReason === "error") {
-    throw new Error("An unknown error occurred");
+    throw new Error(output.errorMessage ?? "An unknown error occurred");
   }
   stream.push({ type: "done", reason: output.stopReason as never, message: output as never });
   stream.end();


### PR DESCRIPTION
## Summary

`finalizeTransportStream` throws when a stream stops with `stopReason === "error"` or `"aborted"`. The thrown error was hardcoded to `"An unknown error occurred"`, silently discarding `output.errorMessage` — which `failTransportStream` always populates before marking the stream as failed. Every provider transport failure surfaced the same opaque string regardless of the actual cause.

The fix reads `output.errorMessage` at throw-time with a null-coalesce fallback, preserving the `"An unknown error occurred"` string for any path that bypasses `failTransportStream`.

## Real behavior proof

Behavior addressed: `finalizeTransportStream` throws `"An unknown error occurred"` regardless of the actual error, discarding `output.errorMessage` set at `transport-stream-shared.ts:133`.

Real environment tested: local OpenClaw clone on branch `fix/agents-transport-stream-error-message` (2026-05-20).

Exact steps or command run after this patch:
```
npx vitest run src/agents/transport-stream-shared.test.ts --reporter=verbose
```

Evidence after fix:
```
 ✓ |agents-core| transport stream shared helpers > throws with the original error message when stream failed 1ms
 ✓ |agents-core| transport stream shared helpers > throws with the abort error message when stream was aborted 0ms
 ✓ |agents-core| transport stream shared helpers > falls back to generic message when errorMessage is absent 0ms
 ✓ |agents-core| transport stream shared helpers > finalizes successful transport streams 2ms
 ✓ |agents-core| transport stream shared helpers > marks transport stream failures and runs cleanup 1ms
 ✓ |agents-support| transport stream shared helpers > throws with the original error message when stream failed 1ms
 ✓ |agents-support| transport stream shared helpers > throws with the abort error message when stream was aborted 0ms
 ✓ |agents-support| transport stream shared helpers > falls back to generic message when errorMessage is absent 0ms
 ✓ |agents-support| transport stream shared helpers > finalizes successful transport streams 2ms
 ✓ |agents-support| transport stream shared helpers > marks transport stream failures and runs cleanup 1ms

 Test Files  2 passed (2)
      Tests  22 passed (22)
   Duration  2.00s (transform 1.34s, setup 853ms, import 518ms, tests 284ms, environment 0ms)
```

Observed result after fix: `finalizeTransportStream` throws `output.errorMessage` when set; falls back to `"An unknown error occurred"` when `output.errorMessage` is absent.

What was not tested: live provider transport failures requiring a running provider environment.
