### PR TITLE
fix(clawhub): preserve URL path prefix in buildUrl

### DIFF
--- a/src/infra/clawhub.test.ts
+++ b/src/infra/clawhub.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { withTempDir } from "../test-helpers/temp-dir.js";
 import {
+  buildUrl,
   downloadClawHubPackageArchive,
   downloadClawHubSkillArchive,
   fetchClawHubPackageArtifact,
@@ -66,6 +67,8 @@ describe("clawhub helpers", () => {
     delete process.env.CLAWHUB_CONFIG_PATH;
     delete process.env.CLAWDHUB_CONFIG_PATH;
     delete process.env.XDG_CONFIG_HOME;
+    delete process.env.OPENCLAW_CLAWHUB_URL;
+    delete process.env.CLAWHUB_URL;
     if (originalHome == null) {
       delete process.env.HOME;
     } else {
@@ -604,5 +607,34 @@ describe("clawhub helpers", () => {
       await archive.cleanup();
       await expectPathMissing(archiveDir);
     }
+  });
+
+  describe("buildUrl", () => {
+    it("preserves path prefix in base URL", () => {
+      const url = buildUrl({
+        baseUrl: "http://host:8080/clawhub",
+        path: "/api/v1/search",
+      });
+      expect(url.pathname).toBe("/clawhub/api/v1/search");
+    });
+
+    it("works with default base URL (no prefix)", () => {
+      const url = buildUrl({
+        baseUrl: "https://clawhub.openclaw.ai",
+        path: "/api/v1/search",
+      });
+      expect(url.pathname).toBe("/api/v1/search");
+    });
+
+    it("appends search params", () => {
+      const url = buildUrl({
+        baseUrl: "http://host:8080/prefix",
+        path: "/api/v1/search",
+        search: { q: "test", limit: "10" },
+      });
+      expect(url.pathname).toBe("/prefix/api/v1/search");
+      expect(url.searchParams.get("q")).toBe("test");
+      expect(url.searchParams.get("limit")).toBe("10");
+    });
   });
 });

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -550,8 +550,8 @@ function normalizeCalVerCorrectionForPluginApi(pluginApiVersion: string): string
   return match?.[1] ?? pluginApiVersion;
 }
 
-function buildUrl(params: Pick<ClawHubRequestParams, "baseUrl" | "path" | "search">): URL {
-  const url = new URL(params.path, `${normalizeBaseUrl(params.baseUrl)}/`);
+export function buildUrl(params: Pick<ClawHubRequestParams, "baseUrl" | "path" | "search">): URL {
+  const url = new URL(`${normalizeBaseUrl(params.baseUrl)}${params.path}`);
   for (const [key, value] of Object.entries(params.search ?? {})) {
     if (!value) {
       continue;


### PR DESCRIPTION
## Summary

When `OPENCLAW_CLAWHUB_URL` contains a path prefix (e.g. `http://host:8080/prefix`), all ClawHub API calls return 404 because `new URL(path, base)` treats a leading-slash path as absolute, silently dropping the base URL's pathname.

## Root Cause

`src/infra/clawhub.ts:554` — the two-argument `new URL("/api/v1/search", "http://host:8080/prefix/")` replaces the entire pathname of the base URL with the absolute path, discarding `/prefix`.

## Fix

Switch to single-argument URL construction: `new URL(\`\${normalizeBaseUrl(base)}\${path}\`)`. This works because `normalizeBaseUrl` already strips trailing slashes and all 14 call sites use `/api/v1/...` literals with leading slashes.

## Tests

3 new tests covering path-prefix preservation, no-prefix compatibility, and search params with prefix. All 43 existing clawhub tests pass.

Fixes #83975