### PR TITLE
fix(session-lock): allow co-tenant writes during prompt I/O window

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { SessionWriteLockTimeoutError } from "../../session-write-lock-error.js";
+import * as sessionWriteLock from "../../session-write-lock.js";
 import {
   createEmbeddedAttemptSessionLockController,
   EmbeddedAttemptSessionTakeoverError,
@@ -458,5 +459,135 @@ describe("embedded attempt session lock lifecycle", () => {
     await hookPromise;
 
     expect(events).toEqual(["queue-drained", "lock", "hook-start", "hook-end"]);
+  });
+});
+
+describe("co-tenant write epoch fence", () => {
+  it("allows co-tenant writes that go through acquireSessionWriteLock", async () => {
+    const sessionFile = await createTempSessionFile();
+    let epoch = 0;
+    const epochSpy = vi
+      .spyOn(sessionWriteLock, "getSessionWriteEpoch")
+      .mockImplementation(() => epoch);
+    const acquireSessionWriteLock = vi.fn(async () => {
+      epoch += 1;
+      return { release: vi.fn(async () => {}) };
+    });
+
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await controller.releaseForPrompt();
+
+    // Simulate co-tenant acquiring lock and writing
+    epoch += 1;
+    await fs.appendFile(sessionFile, '{"type":"heartbeat"}\n', "utf8");
+
+    const result = await controller.withSessionWriteLock(async () => "ok");
+    expect(result).toBe("ok");
+    expect(controller.hasSessionTakeover()).toBe(false);
+
+    epochSpy.mockRestore();
+  });
+
+  it("detects external writes that bypass the write lock", async () => {
+    const sessionFile = await createTempSessionFile();
+    let epoch = 0;
+    const epochSpy = vi
+      .spyOn(sessionWriteLock, "getSessionWriteEpoch")
+      .mockImplementation(() => epoch);
+    const acquireSessionWriteLock = vi.fn(async () => {
+      epoch += 1;
+      return { release: vi.fn(async () => {}) };
+    });
+
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await controller.releaseForPrompt();
+    await fs.appendFile(sessionFile, '{"type":"takeover"}\n', "utf8");
+
+    await expect(controller.withSessionWriteLock(() => "late")).rejects.toBeInstanceOf(
+      EmbeddedAttemptSessionTakeoverError,
+    );
+    expect(controller.hasSessionTakeover()).toBe(true);
+
+    epochSpy.mockRestore();
+  });
+
+  it("detects external write after accepting a legitimate co-tenant write", async () => {
+    const sessionFile = await createTempSessionFile();
+    let epoch = 0;
+    const epochSpy = vi
+      .spyOn(sessionWriteLock, "getSessionWriteEpoch")
+      .mockImplementation(() => epoch);
+    const acquireSessionWriteLock = vi.fn(async () => {
+      epoch += 1;
+      return { release: vi.fn(async () => {}) };
+    });
+
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await controller.releaseForPrompt();
+
+    // Co-tenant acquires lock and writes — should be accepted
+    epoch += 1;
+    await fs.appendFile(sessionFile, '{"type":"heartbeat"}\n', "utf8");
+
+    const result = await controller.withSessionWriteLock(async () => "ok");
+    expect(result).toBe("ok");
+    expect(controller.hasSessionTakeover()).toBe(false);
+
+    // External write without lock — should be detected
+    await fs.appendFile(sessionFile, '{"type":"takeover"}\n', "utf8");
+
+    await expect(controller.withSessionWriteLock(() => "late")).rejects.toBeInstanceOf(
+      EmbeddedAttemptSessionTakeoverError,
+    );
+    expect(controller.hasSessionTakeover()).toBe(true);
+
+    epochSpy.mockRestore();
+  });
+
+  it("allows multiple co-tenant writes without false takeover", async () => {
+    const sessionFile = await createTempSessionFile();
+    let epoch = 0;
+    const epochSpy = vi
+      .spyOn(sessionWriteLock, "getSessionWriteEpoch")
+      .mockImplementation(() => epoch);
+    const acquireSessionWriteLock = vi.fn(async () => {
+      epoch += 1;
+      return { release: vi.fn(async () => {}) };
+    });
+
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await controller.releaseForPrompt();
+
+    // Simulate 3 co-tenant lock acquisitions with writes
+    epoch += 3;
+    await fs.appendFile(sessionFile, '{"type":"heartbeat1"}\n', "utf8");
+    await fs.appendFile(sessionFile, '{"type":"heartbeat2"}\n', "utf8");
+    await fs.appendFile(sessionFile, '{"type":"cron"}\n', "utf8");
+
+    const result = await controller.withSessionWriteLock(async () => "ok");
+    expect(result).toBe("ok");
+    expect(controller.hasSessionTakeover()).toBe(false);
+
+    const result2 = await controller.withSessionWriteLock(async () => "ok2");
+    expect(result2).toBe("ok2");
+    expect(controller.hasSessionTakeover()).toBe(false);
+
+    epochSpy.mockRestore();
   });
 });

--- a/src/agents/pi-embedded-runner/run/attempt.session-lock.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.session-lock.ts
@@ -293,6 +293,14 @@ export async function createEmbeddedAttemptSessionLockController(params: {
     }
     const currentEpoch = getSessionWriteEpoch(params.lockOptions.sessionFile);
     if (currentEpoch > fenceWriteEpoch + 1) {
+      // Epoch advanced by more than our own reacquire — at least one other
+      // in-process lock holder (heartbeat, cron, channel) wrote during the
+      // prompt I/O window. Accept the change and re-baseline.
+      //
+      // Trade-off: an external lock-bypassing write in the same window would
+      // also be accepted. This is intentional — external bypasses already
+      // violate the lock contract, and rejecting co-tenant writes would
+      // recreate the session-stall regression (#84071).
       fenceFingerprint = current;
       fenceWriteEpoch = currentEpoch;
       return;

--- a/src/agents/pi-embedded-runner/run/attempt.session-lock.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.session-lock.ts
@@ -2,6 +2,7 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import fs from "node:fs/promises";
 import { isSessionWriteLockTimeoutError } from "../../session-write-lock-error.js";
 import type { acquireSessionWriteLock } from "../../session-write-lock.js";
+import { getSessionWriteEpoch } from "../../session-write-lock.js";
 
 type SessionLock = Awaited<ReturnType<typeof acquireSessionWriteLock>>;
 type AcquireSessionWriteLock = typeof acquireSessionWriteLock;
@@ -265,6 +266,7 @@ export async function createEmbeddedAttemptSessionLockController(params: {
   const activeWriteLock = new AsyncLocalStorage<SessionLock>();
   let fenceFingerprint: SessionFileFingerprint | undefined;
   let fenceActive = false;
+  let fenceWriteEpoch = 0;
   let takeoverDetected = false;
 
   async function acquireWriteLock(): Promise<{ lock: SessionLock; owned: boolean }> {
@@ -286,15 +288,23 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       return;
     }
     const current = await readSessionFileFingerprint(params.lockOptions.sessionFile);
-    if (!sameSessionFileFingerprint(fenceFingerprint, current)) {
-      takeoverDetected = true;
-      throw new EmbeddedAttemptSessionTakeoverError(params.lockOptions.sessionFile);
+    if (sameSessionFileFingerprint(fenceFingerprint, current)) {
+      return;
     }
+    const currentEpoch = getSessionWriteEpoch(params.lockOptions.sessionFile);
+    if (currentEpoch > fenceWriteEpoch + 1) {
+      fenceFingerprint = current;
+      fenceWriteEpoch = currentEpoch;
+      return;
+    }
+    takeoverDetected = true;
+    throw new EmbeddedAttemptSessionTakeoverError(params.lockOptions.sessionFile);
   }
 
   async function refreshSessionFileFence(): Promise<void> {
     if (fenceActive && !takeoverDetected) {
       fenceFingerprint = await readSessionFileFingerprint(params.lockOptions.sessionFile);
+      fenceWriteEpoch = getSessionWriteEpoch(params.lockOptions.sessionFile);
     }
   }
 
@@ -308,6 +318,7 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       const lock = heldLock;
       heldLock = undefined;
       fenceFingerprint = await readSessionFileFingerprint(params.lockOptions.sessionFile);
+      fenceWriteEpoch = getSessionWriteEpoch(params.lockOptions.sessionFile);
       fenceActive = true;
       await lock.release();
     },

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -64,7 +64,12 @@ type LockInspectionDetails = Pick<
 >;
 
 const SESSION_LOCKS = createFileLockManager("openclaw.session-write-lock");
+const SESSION_WRITE_EPOCHS = new Map<string, number>();
 let resolveProcessStartTimeForLock = getProcessStartTime;
+
+export function getSessionWriteEpoch(sessionFile: string): number {
+  return SESSION_WRITE_EPOCHS.get(path.resolve(sessionFile)) ?? 0;
+}
 
 function isFileLockError(error: unknown, code: string): boolean {
   return (error as { code?: unknown } | null)?.code === code;
@@ -764,6 +769,8 @@ export async function acquireSessionWriteLock(params: {
           return await shouldReclaimContendedLockFile(lockPath, inspected, staleMs, nowMs);
         },
       });
+      const resolved = path.resolve(sessionFile);
+      SESSION_WRITE_EPOCHS.set(resolved, (SESSION_WRITE_EPOCHS.get(resolved) ?? 0) + 1);
       return { release: lock.release };
     } catch (err) {
       if (isFileLockError(err, "file_lock_stale")) {
@@ -810,5 +817,6 @@ export function resetSessionWriteLockStateForTest(): void {
   stopWatchdogTimer();
   unregisterCleanupHandlers();
   resolveProcessStartTimeForLock = getProcessStartTime;
+  SESSION_WRITE_EPOCHS.clear();
 }
 export { testing as __testing };


### PR DESCRIPTION
## Summary

`EmbeddedAttemptSessionTakeoverError` fires on legitimate co-tenant writes (heartbeat, cron, channel ingress) to shared sessions during the prompt I/O window.

## Root Cause

`attempt.session-lock.ts:284-291`: `releaseForPrompt()` records a file stat fingerprint and releases the lock. Co-tenant writers acquire the same fs-level lock and append to the session file (changing the stat). When the controller reacquires, `assertSessionFileFence()` sees a fingerprint mismatch and sets the sticky `takeoverDetected` flag — even though the write was coordinated through the same lock.

## Fix

Add a process-scoped write epoch counter to `acquireSessionWriteLock()` that increments on each lock acquisition. The controller records the epoch at fence activation. On reacquisition, it checks the epoch delta:

- **delta == 1** (only controller acquired): fingerprint change = external takeover → throw
- **delta > 1** (co-tenants also acquired): fingerprint change = coordinated write → update fence, continue

Cross-process writes don't advance the in-process epoch, so true external takeovers are still detected.

## Tests

4 new tests: co-tenant write accepted, external write detected, mixed co-tenant + external detected, multiple co-tenant writes succeed. All 26 existing session-lock tests pass.

Fixes #84071