### PR TITLE
fix(doctor): preserve non-codex agentRuntime during model ref migration

### DIFF
--- a/src/commands/doctor/shared/codex-route-warnings.test.ts
+++ b/src/commands/doctor/shared/codex-route-warnings.test.ts
@@ -1877,13 +1877,13 @@ describe("collectCodexRouteWarnings", () => {
     expect(result.changes).toStrictEqual([
       [
         "Repaired Codex model routes:",
+        "- agents.defaults.models.openai-codex/gpt-5.5: openai-codex/gpt-5.5 -> openai/gpt-5.5.",
         "- agents.defaults.model.primary: openai-codex/gpt-5.5 -> openai/gpt-5.5.",
         "- agents.defaults.model.fallbacks.0: openai-codex/gpt-5.4 -> openai/gpt-5.4.",
         "- agents.defaults.heartbeat.model: openai-codex/gpt-5.4-mini -> openai/gpt-5.4-mini.",
         "- agents.defaults.subagents.model.primary: openai-codex/gpt-5.5 -> openai/gpt-5.5.",
         "- agents.defaults.subagents.model.fallbacks.0: openai-codex/gpt-5.4 -> openai/gpt-5.4.",
         "- agents.defaults.compaction.memoryFlush.model: openai-codex/gpt-5.4-mini -> openai/gpt-5.4-mini.",
-        "- agents.defaults.models.openai-codex/gpt-5.5: openai-codex/gpt-5.5 -> openai/gpt-5.5.",
         "- agents.list.worker.model: openai-codex/gpt-5.4 -> openai/gpt-5.4.",
         "- channels.modelByChannel.telegram.default: openai-codex/gpt-5.4 -> openai/gpt-5.4.",
         "- hooks.mappings.0.model: openai-codex/gpt-5.4-mini -> openai/gpt-5.4-mini.",
@@ -3367,5 +3367,32 @@ describe("collectCodexRouteWarnings", () => {
 
     expect(result.cfg.agents?.defaults?.model).toBe("openai/gpt-5.5");
     expect(result.cfg.agents?.defaults?.agentRuntime).toBeUndefined();
+  });
+
+  it("preserves intentional PI runtime when migrating openai-codex models map entries", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        agents: {
+          defaults: {
+            model: "openai-codex/gpt-5.4",
+            models: {
+              "openai-codex/gpt-5.4": {
+                agentRuntime: { id: "pi" },
+              },
+            },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.cfg.agents?.defaults?.model).toBe("openai/gpt-5.4");
+    expect(result.cfg.agents?.defaults?.models?.["openai/gpt-5.4"]?.agentRuntime).toEqual({
+      id: "pi",
+    });
+    expect(result.cfg.agents?.defaults?.models?.["openai-codex/gpt-5.4"]).toBeUndefined();
+    expect(result.changes).not.toContainEqual(
+      expect.stringContaining('agentRuntime.id to "codex"'),
+    );
   });
 });

--- a/src/commands/doctor/shared/codex-route-warnings.ts
+++ b/src/commands/doctor/shared/codex-route-warnings.ts
@@ -2158,13 +2158,9 @@ function clearLegacyAgentRuntimePolicy(
     delete container.embeddedHarness;
     changes.push(`Removed ${pathLabel}.embeddedHarness; runtime is now provider/model scoped.`);
   }
-  const runtimeRecord = asMutableRecord(container.agentRuntime);
-  if (runtimeRecord) {
-    const runtimeId = normalizeString(runtimeRecord.id);
-    if (!runtimeId || runtimeId === "codex" || runtimeId === "auto" || runtimeId === "default") {
-      delete container.agentRuntime;
-      changes.push(`Removed ${pathLabel}.agentRuntime; runtime is now provider/model scoped.`);
-    }
+  if (asMutableRecord(container.agentRuntime)) {
+    delete container.agentRuntime;
+    changes.push(`Removed ${pathLabel}.agentRuntime; runtime is now provider/model scoped.`);
   }
 }
 

--- a/src/commands/doctor/shared/codex-route-warnings.ts
+++ b/src/commands/doctor/shared/codex-route-warnings.ts
@@ -1552,6 +1552,15 @@ function rewriteAgentModelRefs(params: {
       });
     }
   };
+  if (params.rewriteModelsMap) {
+    const start = params.hits.length;
+    rewriteModelsMap({
+      hits: params.hits,
+      models: asMutableRecord(agent.models),
+      path: `${params.path}.models`,
+    });
+    preserveCodexRuntimePolicyForNewHits(start);
+  }
   for (const key of AGENT_MODEL_CONFIG_KEYS) {
     const start = params.hits.length;
     if (key === "model") {
@@ -1683,15 +1692,6 @@ function rewriteAgentModelRefs(params: {
     key: "model",
     path: `${params.path}.compaction.memoryFlush.model`,
   });
-  if (params.rewriteModelsMap) {
-    const start = params.hits.length;
-    rewriteModelsMap({
-      hits: params.hits,
-      models: asMutableRecord(agent.models),
-      path: `${params.path}.models`,
-    });
-    preserveCodexRuntimePolicyForNewHits(start);
-  }
 }
 
 function removeUnsupportedCodexCompactionOverrides(params: {
@@ -2158,9 +2158,13 @@ function clearLegacyAgentRuntimePolicy(
     delete container.embeddedHarness;
     changes.push(`Removed ${pathLabel}.embeddedHarness; runtime is now provider/model scoped.`);
   }
-  if (asMutableRecord(container.agentRuntime)) {
-    delete container.agentRuntime;
-    changes.push(`Removed ${pathLabel}.agentRuntime; runtime is now provider/model scoped.`);
+  const runtimeRecord = asMutableRecord(container.agentRuntime);
+  if (runtimeRecord) {
+    const runtimeId = normalizeString(runtimeRecord.id);
+    if (!runtimeId || runtimeId === "codex" || runtimeId === "auto" || runtimeId === "default") {
+      delete container.agentRuntime;
+      changes.push(`Removed ${pathLabel}.agentRuntime; runtime is now provider/model scoped.`);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

`doctor --fix` silently migrates intentional `openai-codex/` config with `agentRuntime: { id: "pi" }` to `openai/` with `agentRuntime: { id: "codex" }`, breaking PI+OAuth runtime and causing 3-4x token inflation.

## Root Cause

In `codex-route-warnings.ts`, `rewriteAgentModelRefs()` processes model config keys (triggering `ensureCodexRuntimePolicy` which writes `codex` runtime) *before* migrating the models map. When the models map is later merged, the generated `codex` entry overwrites the user's `pi` entry.

Additionally, `clearLegacyAgentRuntimePolicy` unconditionally deletes agent-level `agentRuntime` regardless of runtime ID.

## Fix

1. **Reorder**: Move `rewriteModelsMap` before the `AGENT_MODEL_CONFIG_KEYS` loop so legacy entries with explicit runtime pins are merged onto canonical keys first. `ensureCodexRuntimePolicy` then sees the existing `pi` runtime and skips.

2. **Guard**: `clearLegacyAgentRuntimePolicy` now only deletes runtime pins with ID `codex`, `auto`, `default`, or absent. Non-codex runtimes like `pi` are preserved.

## Tests

1 new regression test verifying `openai-codex/gpt-5.4` with `agentRuntime.id: "pi"` migrates correctly. All existing codex-route-warnings tests pass.

Fixes #84038