### PR TITLE
fix(plugins): add default timeout for before_compaction/after_compaction hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Plugins/hooks: apply a default 30-second timeout to `before_compaction` and `after_compaction` hooks so a hung plugin handler no longer blocks compaction completion. (#84153)
 - Plugins/perf: thread explicit plugin discovery results through `loadBundledCapabilityRuntimeRegistry`, `resolveBundledPluginSources`, and `listChannelCatalogEntries` so callers that already hold a discovery result skip redundant filesystem walks. Thanks @SebTardif.
 - harden update restart script creation [AI]. (#84088) Thanks @pgondhi987.
 - Docker: keep the bundled Codex plugin in official release image keep lists so the default OpenAI agent harness remains available after Docker pruning. Fixes #83613. (#83626) Thanks @YuanHanzhong.

--- a/src/plugins/hooks.compaction-timeout.test.ts
+++ b/src/plugins/hooks.compaction-timeout.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Test: before_compaction & after_compaction void-hook default timeouts.
+ *
+ * Without a default budget these hooks run fully unbounded. In the codex
+ * agent harness they fire on the serialized notification queue, so a hung
+ * handler freezes every later codex notification — including turn/completed —
+ * and the whole turn hangs. The runner seeds DEFAULT_VOID_HOOK_TIMEOUT_MS_BY_HOOK
+ * with a defensive budget for both hooks; these tests assert a never-settling
+ * handler is bounded by that default rather than hanging.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createHookRunner } from "./hooks.js";
+import { addTestHook, TEST_PLUGIN_AGENT_CTX } from "./hooks.test-helpers.js";
+import { createEmptyPluginRegistry, type PluginRegistry } from "./registry.js";
+import type { PluginHookRegistration } from "./types.js";
+
+// The defensive default applied to before_compaction / after_compaction in
+// DEFAULT_VOID_HOOK_TIMEOUT_MS_BY_HOOK. Kept in sync with hooks.ts.
+const DEFAULT_COMPACTION_HOOK_TIMEOUT_MS = 30_000;
+
+describe("compaction hook default timeouts", () => {
+  let registry: PluginRegistry;
+
+  beforeEach(() => {
+    registry = createEmptyPluginRegistry();
+  });
+
+  it("bounds a never-settling before_compaction handler with the default timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      const handler = vi.fn(() => new Promise<void>(() => {}));
+      addTestHook({
+        registry,
+        pluginId: "plugin-a",
+        hookName: "before_compaction",
+        handler: handler as PluginHookRegistration["handler"],
+      });
+      const logger = {
+        error: vi.fn(),
+        warn: vi.fn(),
+      };
+
+      // No voidHookTimeoutMsByHook override — relies on the built-in default.
+      const runner = createHookRunner(registry, { logger });
+      const run = runner.runBeforeCompaction({ messageCount: 3 }, TEST_PLUGIN_AGENT_CTX);
+
+      await vi.advanceTimersByTimeAsync(DEFAULT_COMPACTION_HOOK_TIMEOUT_MS);
+
+      await expect(run).resolves.toBeUndefined();
+      expect(logger.error).toHaveBeenCalledWith(
+        `[hooks] before_compaction handler from plugin-a failed: timed out after ${DEFAULT_COMPACTION_HOOK_TIMEOUT_MS}ms`,
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("bounds a never-settling after_compaction handler with the default timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      const handler = vi.fn(() => new Promise<void>(() => {}));
+      addTestHook({
+        registry,
+        pluginId: "plugin-a",
+        hookName: "after_compaction",
+        handler: handler as PluginHookRegistration["handler"],
+      });
+      const logger = {
+        error: vi.fn(),
+        warn: vi.fn(),
+      };
+
+      const runner = createHookRunner(registry, { logger });
+      const run = runner.runAfterCompaction(
+        { messageCount: 2, compactedCount: 1 },
+        TEST_PLUGIN_AGENT_CTX,
+      );
+
+      await vi.advanceTimersByTimeAsync(DEFAULT_COMPACTION_HOOK_TIMEOUT_MS);
+
+      await expect(run).resolves.toBeUndefined();
+      expect(logger.error).toHaveBeenCalledWith(
+        `[hooks] after_compaction handler from plugin-a failed: timed out after ${DEFAULT_COMPACTION_HOOK_TIMEOUT_MS}ms`,
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("lets a fast before_compaction handler complete without timing out", async () => {
+    vi.useFakeTimers();
+    try {
+      const handler = vi.fn(
+        async () =>
+          await new Promise<void>((resolve) => {
+            setTimeout(resolve, 20);
+          }),
+      );
+      addTestHook({
+        registry,
+        pluginId: "plugin-a",
+        hookName: "before_compaction",
+        handler: handler as PluginHookRegistration["handler"],
+      });
+      const logger = {
+        error: vi.fn(),
+        warn: vi.fn(),
+      };
+
+      const runner = createHookRunner(registry, { logger });
+      const run = runner.runBeforeCompaction({ messageCount: 3 }, TEST_PLUGIN_AGENT_CTX);
+
+      await vi.advanceTimersByTimeAsync(20);
+
+      await expect(run).resolves.toBeUndefined();
+      expect(logger.error).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -189,6 +189,18 @@ export type HookRunnerOptions = {
 
 const DEFAULT_VOID_HOOK_TIMEOUT_MS_BY_HOOK: Partial<Record<PluginHookName, number>> = {
   agent_end: 30_000,
+  // Defensive default for the compaction lifecycle hooks. Without a budget an
+  // unresponsive handler runs fully unbounded, and in the codex agent harness
+  // these hooks fire on the serialized notification queue
+  // (event-projector handleItemStarted awaits before_compaction / after_compaction
+  // for a contextCompaction item), so a hung handler freezes every later codex
+  // notification — including turn/completed — and the whole turn hangs. These
+  // hooks can legitimately do real work (e.g. a memory flush), so the budget
+  // matches agent_end's 30s rather than the tighter modifying-hook defaults.
+  // The runner is fail-open for void hooks, so a timed-out handler is logged
+  // and compaction proceeds.
+  before_compaction: 30_000,
+  after_compaction: 30_000,
 };
 const DEFAULT_MODIFYING_HOOK_TIMEOUT_MS_BY_HOOK: Partial<Record<PluginHookName, number>> = {
   before_agent_run: 15_000,


### PR DESCRIPTION
## Bug

`DEFAULT_VOID_HOOK_TIMEOUT_MS_BY_HOOK` in `src/plugins/hooks.ts` listed only
`agent_end`. The `before_compaction` and `after_compaction` plugin hooks are
void hooks (`runBeforeCompaction` / `runAfterCompaction` → `runVoidHook(...)`),
and `runVoidHook` applies a timeout *only* when `getVoidHookTimeoutMs` returns
a value. With no table entry and no plugin-supplied `hook.timeoutMs`, both
hooks ran **fully unbounded**.

In the codex agent harness these hooks fire on the *serialized* notification
queue — `extensions/codex/src/app-server/event-projector.ts` `handleItemStarted`
`await`s `runAgentHarnessBeforeCompactionHook` (and the matching
`after_compaction` call site) for a `contextCompaction` item. A slow or hung
compaction hook therefore freezes processing of every later codex notification —
including `turn/completed` — so the whole agent turn hangs.

## Fix

Add `before_compaction` and `after_compaction` entries to
`DEFAULT_VOID_HOOK_TIMEOUT_MS_BY_HOOK`, mirroring the defensive-default pattern
already applied to `agent_end`. The budget is **30s**, matching `agent_end`
(the closest like-for-like precedent — a void lifecycle hook) rather than the
tighter 15s modifying-hook defaults, because compaction hooks can legitimately
do real work such as a memory flush. The runner is fail-open for void hooks,
so a timed-out handler is logged and compaction proceeds without it.

A plugin can still override the default per-registration via `hook.timeoutMs`.

## Related

Related to #84077 — the same compaction-stall investigation. That issue covers
the host's missing safety timeout on plugin-owned `compact()`; this is a
separate, independent mechanism (unbounded void hooks freezing the codex
notification queue), hence "Related" rather than "Fixes".

## Test plan

- [x] `pnpm tsgo:core` and `pnpm tsgo:core:test` — typecheck passes
- [x] `oxlint` on changed files — 0 warnings / 0 errors
- [x] New `src/plugins/hooks.compaction-timeout.test.ts`:
  - a never-settling `before_compaction` handler is bounded by the default timeout (no override) and logged, rather than hanging
  - same for `after_compaction`
  - a fast `before_compaction` handler completes without a false-positive timeout
- [x] `vitest` (plugins project): new tests + `hooks.correlation.test.ts` + `wired-hooks-compaction.test.ts` — 15/15 pass

## Real behavior proof

Behavior addressed: hung plugin `before_compaction` and `after_compaction` handlers no longer stall compaction forever. The hook runner now applies the default fail-open timeout when no per-hook override is configured.

Real environment tested: local OpenClaw checkout `/Volumes/LEXAR/repos/openclaw-fix-compaction-hook-timeout`, branch `fix/compaction-hook-default-timeout`, Node via `node --import tsx`, actual `src/plugins/hooks.ts` plugin hook runner.

Exact steps or command run after the patch: ran a live script that registers a plugin whose `before_compaction` and `after_compaction` hooks never settle, then invokes `runHookTimeout` for both hooks without per-hook timeout overrides.

Evidence after fix:

```json
{
  "branch": "fix/compaction-hook-default-timeout",
  "behavior": "hung before_compaction and after_compaction hooks return via default fail-open timeout",
  "elapsedMs": 30033,
  "eventCount": 2,
  "events": [
    "[hooks] before_compaction handler from live-proof-plugin failed: timed out after 30000ms",
    "[hooks] after_compaction handler from live-proof-plugin failed: timed out after 30000ms"
  ]
}
```

Observed result after fix: both hung hook handlers returned through the default timeout path in about 30 seconds each, emitted fail-open timeout events, and did not block the caller indefinitely.

What was not tested: a real external plugin process wedged in production; the proof uses the in-process hook runner with intentionally never-settling handlers.
