### PR TITLE
fix(cron): respect recovered tool errors

### DIFF
--- a/src/cron/isolated-agent.helpers.test.ts
+++ b/src/cron/isolated-agent.helpers.test.ts
@@ -62,6 +62,11 @@ describe("resolveCronPayloadOutcome", () => {
     });
 
     expect(result.hasFatalErrorPayload).toBe(false);
+    expect(result.errorPayloadRecovery).toEqual({
+      hadErrorPayload: true,
+      recovered: true,
+      recoveredBy: "laterPayload",
+    });
     expect(result.summary).toBe("Write completed successfully.");
   });
 
@@ -73,6 +78,11 @@ describe("resolveCronPayloadOutcome", () => {
     });
 
     expect(result.hasFatalErrorPayload).toBe(false);
+    expect(result.errorPayloadRecovery).toEqual({
+      hadErrorPayload: true,
+      recovered: true,
+      recoveredBy: "presentationWarning",
+    });
     expect(result.embeddedRunError).toBeUndefined();
     expect(result.pendingPresentationWarningError).toBe("⚠️ ✉️ Message failed");
     expect(result.summary).toBe("Final cron report");
@@ -281,7 +291,7 @@ describe("resolveCronPayloadOutcome", () => {
     expect(result.deliveryPayloadHasStructuredContent).toBe(true);
   });
 
-  it("returns only the last error payload when all payloads are errors", () => {
+  it("uses terminal assistant text when all error payloads were recovered", () => {
     const result = resolveCronPayloadOutcome({
       payloads: [
         { text: "first error", isError: true },
@@ -291,9 +301,31 @@ describe("resolveCronPayloadOutcome", () => {
       preferFinalAssistantVisibleText: true,
     });
 
-    expect(result.outputText).toBe("last error");
-    expect(result.deliveryPayloads).toEqual([{ text: "last error", isError: true }]);
+    expect(result.hasFatalErrorPayload).toBe(false);
+    expect(result.errorPayloadRecovery).toEqual({
+      hadErrorPayload: true,
+      recovered: true,
+      recoveredBy: "terminalAssistantText",
+    });
+    expect(result.outputText).toBe("Recovered final answer");
+    expect(result.deliveryPayloads).toEqual([{ text: "Recovered final answer" }]);
     expect(result.deliveryPayload).toEqual({ text: "last error", isError: true });
+  });
+
+  it("keeps recovered error payloads fatal when final assistant text reports denial", () => {
+    const result = resolveCronPayloadOutcome({
+      payloads: [{ text: "tool error", isError: true }],
+      finalAssistantVisibleText: "I could not run the requested script.",
+      preferFinalAssistantVisibleText: true,
+    });
+
+    expect(result.hasFatalErrorPayload).toBe(true);
+    expect(result.errorPayloadRecovery).toEqual({
+      hadErrorPayload: true,
+      recovered: false,
+    });
+    expect(result.embeddedRunError).toBe("tool error");
+    expect(result.deliveryPayloads).toEqual([{ text: "tool error", isError: true }]);
   });
 
   it("keeps multi-payload direct delivery when finalAssistantVisibleText is not preferred", () => {

--- a/src/cron/isolated-agent/helpers.ts
+++ b/src/cron/isolated-agent/helpers.ts
@@ -18,6 +18,11 @@ export type CronPayloadOutcome = {
   deliveryPayloads: DeliveryPayload[];
   deliveryPayloadHasStructuredContent: boolean;
   hasFatalErrorPayload: boolean;
+  errorPayloadRecovery: {
+    hadErrorPayload: boolean;
+    recovered: boolean;
+    recoveredBy?: "laterPayload" | "terminalAssistantText" | "presentationWarning";
+  };
   embeddedRunError?: string;
   pendingPresentationWarningError?: string;
 };
@@ -274,29 +279,61 @@ export function resolveCronPayloadOutcome(params: {
   const normalizedFinalAssistantVisibleText = normalizeOptionalString(
     params.finalAssistantVisibleText,
   );
+  const failureSignal = normalizeCronFailureSignal(params.failureSignal);
+  const runLevelError = formatCronRunLevelError(params.runLevelError);
+  const hasStructuredDeliveryPayloads = selectedDeliveryPayloads.some((payload) =>
+    payloadHasStructuredDeliveryContent(payload),
+  );
   const hasSuccessfulPayloadAfterLastError =
-    !params.runLevelError &&
+    !runLevelError &&
     lastErrorPayloadIndex >= 0 &&
     params.payloads
       .slice(lastErrorPayloadIndex + 1)
       .some((payload) => payload?.isError !== true && Boolean(payload?.text?.trim()));
   const hasSuccessfulPayloadBeforeLastError =
-    !params.runLevelError &&
+    !runLevelError &&
     lastErrorPayloadIndex > 0 &&
     params.payloads
       .slice(0, lastErrorPayloadIndex)
       .some((payload) => payload?.isError !== true && Boolean(payload?.text?.trim()));
   const hasPendingPresentationWarning =
-    !params.runLevelError &&
-    params.failureSignal?.fatalForCron !== true &&
+    !runLevelError &&
+    failureSignal === undefined &&
     lastErrorPayloadIndex >= 0 &&
     isCronMessagePresentationWarning(lastErrorPayloadText) &&
     (normalizedFinalAssistantVisibleText !== undefined || hasSuccessfulPayloadBeforeLastError);
+  const hasTerminalAssistantRecovery =
+    !runLevelError &&
+    failureSignal === undefined &&
+    params.preferFinalAssistantVisibleText === true &&
+    normalizedFinalAssistantVisibleText !== undefined &&
+    detectCronDenialToken(normalizedFinalAssistantVisibleText) === undefined &&
+    !hasStructuredDeliveryPayloads &&
+    lastErrorPayloadIndex >= 0 &&
+    !hasSuccessfulPayloadAfterLastError &&
+    (!hasSuccessfulPayloadBeforeLastError ||
+      normalizedFinalAssistantVisibleText !== fallbackOutputText);
   const hasFatalStructuredErrorPayload =
-    hasErrorPayload && !hasSuccessfulPayloadAfterLastError && !hasPendingPresentationWarning;
-  const hasStructuredDeliveryPayloads = selectedDeliveryPayloads.some((payload) =>
-    payloadHasStructuredDeliveryContent(payload),
-  );
+    hasErrorPayload &&
+    !hasSuccessfulPayloadAfterLastError &&
+    !hasPendingPresentationWarning &&
+    !hasTerminalAssistantRecovery;
+  const errorPayloadRecoveredBy = hasSuccessfulPayloadAfterLastError
+    ? ("laterPayload" as const)
+    : hasPendingPresentationWarning
+      ? ("presentationWarning" as const)
+      : hasTerminalAssistantRecovery
+        ? ("terminalAssistantText" as const)
+        : undefined;
+  const errorPayloadRecovery = {
+    hadErrorPayload: hasErrorPayload,
+    recovered:
+      hasErrorPayload &&
+      (hasSuccessfulPayloadAfterLastError ||
+        hasPendingPresentationWarning ||
+        hasTerminalAssistantRecovery),
+    ...(errorPayloadRecoveredBy ? { recoveredBy: errorPayloadRecoveredBy } : {}),
+  };
   // Keep structured/media announce payloads intact. Only collapse purely textual
   // cron announce output to the final assistant-visible answer.
   const shouldUseFinalAssistantVisibleText =
@@ -329,8 +366,6 @@ export function resolveCronPayloadOutcome(params: {
       text: payload?.text,
     })),
   ]);
-  const failureSignal = normalizeCronFailureSignal(params.failureSignal);
-  const runLevelError = formatCronRunLevelError(params.runLevelError);
   const hasFatalErrorPayload =
     hasFatalStructuredErrorPayload ||
     failureSignal !== undefined ||
@@ -361,6 +396,7 @@ export function resolveCronPayloadOutcome(params: {
       ? false
       : deliveryPayloadHasStructuredContent,
     hasFatalErrorPayload,
+    errorPayloadRecovery,
     embeddedRunError: structuredErrorText
       ? structuredErrorText
       : failureSignal


### PR DESCRIPTION
## Summary

- Problem: cron isolated runs can mark a recovered task as failed when the final payload list only contains `isError` tool payloads, even though the agent produced terminal assistant-visible output.
- Solution: separate fatal run signals from recoverable tool-error payloads before choosing the cron final status/output.
- What changed: `resolveCronPayloadOutcome` now records `errorPayloadRecovery` and treats later payload output, message-delivery warnings, or terminal assistant-visible text as recovery paths when no typed fatal signal exists.
- What did NOT change (scope boundary): `meta.error`, fatal `failureSignal`, denial markers, structured/media delivery payload handling, and real unrecovered trailing errors remain fatal.

## Motivation

- This closes a known cron false-negative path where a scheduled job can finish useful work but be persisted as `error` because an intermediate tool failure wins over the recovered final assistant result.
- The behavior is already tracked in #74807 and #81514. This PR focuses on the cron outcome classifier instead of only changing summary text selection.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #74807
- Related #81514
- Related #74840
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: recovered cron output should persist as `ok` instead of `error` when the only remaining error evidence is recoverable tool payload text.
- Real environment tested: local OpenClaw checkout on macOS, Node from the repository toolchain, branch `fix/cron-recovered-tool-error` at commit `3cb013e77a`.
- Exact steps or command run after this patch:

```sh
node --import tsx - <<'NODE'
import { resolveCronPayloadOutcome } from './src/cron/isolated-agent/helpers.ts';

const outcome = resolveCronPayloadOutcome({
  payloads: [
    { text: 'redacted tool failure', isError: true },
    { text: 'redacted retry failure', isError: true },
  ],
  finalAssistantVisibleText: 'Recovered final answer from the cron task.',
  preferFinalAssistantVisibleText: true,
});

console.log(JSON.stringify({
  hasFatalErrorPayload: outcome.hasFatalErrorPayload,
  status: outcome.hasFatalErrorPayload ? 'error' : 'ok',
  outputText: outcome.outputText,
  deliveryPayloads: outcome.deliveryPayloads,
  errorPayloadRecovery: outcome.errorPayloadRecovery,
  embeddedRunError: outcome.embeddedRunError ?? null,
}, null, 2));
NODE
```

- Evidence after fix (copied live output):

```json
{
  "hasFatalErrorPayload": false,
  "status": "ok",
  "outputText": "Recovered final answer from the cron task.",
  "deliveryPayloads": [
    {
      "text": "Recovered final answer from the cron task."
    }
  ],
  "errorPayloadRecovery": {
    "hadErrorPayload": true,
    "recovered": true,
    "recoveredBy": "terminalAssistantText"
  },
  "embeddedRunError": null
}
```

- Observed result after fix: the recovered output is selected, `hasFatalErrorPayload` is false, and the final status derived by cron is `ok`.
- What was not tested: a full scheduled daemon run against a live private cron job; the proof uses a redacted local reproduction of the outcome classifier to avoid exposing private task content.
- Before evidence (optional but encouraged): the prior regression test expected the same all-error-payload shape to return only the last error payload even when `finalAssistantVisibleText` was present.

## Root Cause (if applicable)

- Root cause: `resolveCronPayloadOutcome` classified any last `isError` payload as fatal unless a later non-error payload existed, so all-error-payload runs could not be recovered by terminal assistant-visible text.
- Missing detection / guardrail: there was no explicit recovery state distinguishing recoverable tool payload errors from fatal run-level signals.
- Contributing context (if known): cron delivery already receives `finalAssistantVisibleText`, but fatal payload classification ran before that text could act as recovered terminal output.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/cron/isolated-agent.helpers.test.ts`
- Scenario the test should lock in: all payloads are `isError`, final assistant-visible text is present and preferred, no typed fatal signal exists, and cron resolves an `ok` outcome with recovered final text.
- Why this is the smallest reliable guardrail: the bug is in the pure outcome classifier used by cron finalization and interim retry logic.
- Existing test that already covers this (if any): existing tests covered later non-error payload recovery, message-delivery warning recovery, run-level fatal errors, and denial markers; this PR updates the all-error-payload regression case and adds a denial guard.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Cron runs that recover from intermediate tool errors can now be recorded as successful and surface the final assistant result instead of the last recoverable tool error.

## Diagram (if applicable)

```text
Before:
[tool error payloads] -> [final assistant recovered] -> [last error payload wins] -> [cron status: error]

After:
[tool error payloads] -> [final assistant recovered] -> [recovery classified] -> [cron status: ok]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS local checkout
- Runtime/container: repository Node/pnpm toolchain
- Model/provider: N/A for classifier reproduction
- Integration/channel (if any): cron isolated-agent outcome classifier
- Relevant config (redacted): `preferFinalAssistantVisibleText: true`

### Steps

1. Pass redacted all-error payloads plus terminal assistant-visible text into `resolveCronPayloadOutcome`.
2. Verify `hasFatalErrorPayload` resolves false and output/delivery use final assistant text.
3. Run focused cron/helper validation and repository checks.

### Expected

- Recovered terminal assistant-visible text should produce a non-fatal cron outcome when no typed fatal signal exists.

### Actual

- After this patch, the redacted reproduction returns `status: "ok"`, `recoveredBy: "terminalAssistantText"`, and no embedded run error.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Recovered all-error payloads now prefer terminal assistant text and resolve non-fatal.
  - Later successful payload recovery still resolves non-fatal.
  - Message delivery warning recovery still resolves non-fatal.
  - Denial text, run-level errors, and fatal failure signals remain fatal.
- Edge cases checked:
  - Structured/media payloads are not collapsed into final text.
  - Earlier partial output plus a real trailing error remains fatal when final assistant text is only the same partial output.
- What you did **not** verify:
  - Full live private cron daemon run after patch.
  - Full `pnpm test`; focused tests and `pnpm build`/`pnpm check` were run instead.
  - `codex review --base origin/main`; the installed Codex CLI does not expose a `review` subcommand, and a read-only `codex exec` review attempt failed with `401 Unauthorized`.

AI-assisted: yes. I understand the changed classifier path and the added tests.

Validation run locally:

```sh
node scripts/test-projects.mjs src/cron/isolated-agent.helpers.test.ts src/cron/isolated-agent/run.meta-error-status.test.ts src/cron/isolated-agent/run.message-tool-policy.test.ts src/agents/pi-embedded-runner/run/payloads.errors.test.ts
pnpm tsgo:test:src
pnpm check
pnpm build
```

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

No bot review conversations were open when this PR body was updated.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: terminal assistant text could hide a real fatal condition.
  - Mitigation: recovery is blocked when `meta.error`, fatal `failureSignal`, denial markers, structured delivery payloads, or an unrecovered real trailing error should stay fatal.
