### PR TITLE
fix(sessions): heal stale running rows on abort no-active-run and restart

### DIFF
--- a/src/agents/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-restart-recovery.test.ts
@@ -19,12 +19,12 @@ vi.mock("../gateway/call.js", () => ({
   callGateway: vi.fn(async () => ({ runId: "run-resumed" })),
 }));
 
-vi.mock("./pi-embedded-runner/runs.js", () => ({
-  isEmbeddedPiRunActive: vi.fn(() => false),
-  isEmbeddedPiRunHandleActive: vi.fn(() => false),
+vi.mock("./embedded-agent-runner/runs.js", () => ({
+  isEmbeddedAgentRunActive: vi.fn(() => false),
+  isEmbeddedAgentRunHandleActive: vi.fn(() => false),
 }));
 
-vi.mock("./pi-embedded-runner/lanes.js", () => ({
+vi.mock("./embedded-agent-runner/lanes.js", () => ({
   resolveEmbeddedSessionLane: vi.fn(() => null),
 }));
 
@@ -579,8 +579,8 @@ describe("main-session-restart-recovery", () => {
     ]);
 
     // Simulate the current process having an active run for this session
-    const { isEmbeddedPiRunActive } = await import("./pi-embedded-runner/runs.js");
-    const spy = vi.mocked(isEmbeddedPiRunActive);
+    const { isEmbeddedAgentRunActive } = await import("./embedded-agent-runner/runs.js");
+    const spy = vi.mocked(isEmbeddedAgentRunActive);
     spy.mockReturnValue(true);
 
     const result = await recoverRestartAbortedMainSessions({ stateDir: tmpDir });

--- a/src/agents/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-restart-recovery.test.ts
@@ -19,6 +19,19 @@ vi.mock("../gateway/call.js", () => ({
   callGateway: vi.fn(async () => ({ runId: "run-resumed" })),
 }));
 
+vi.mock("./pi-embedded-runner/runs.js", () => ({
+  isEmbeddedPiRunActive: vi.fn(() => false),
+  isEmbeddedPiRunHandleActive: vi.fn(() => false),
+}));
+
+vi.mock("./pi-embedded-runner/lanes.js", () => ({
+  resolveEmbeddedSessionLane: vi.fn(() => null),
+}));
+
+vi.mock("../process/command-queue.js", () => ({
+  getCommandLaneSnapshot: vi.fn(() => ({ activeCount: 0, queuedCount: 0 })),
+}));
+
 let tmpDir: string;
 
 beforeEach(async () => {
@@ -531,7 +544,7 @@ describe("main-session-restart-recovery", () => {
     expect(store["agent:main:main"]?.pendingFinalDeliveryText).toBe("The final answer is 42.");
   });
 
-  it("does not scan ordinary running sessions without the restart-aborted marker", async () => {
+  it("recovers stale running sessions without the restart-aborted marker", async () => {
     const sessionsDir = await makeSessionsDir();
     await writeStore(sessionsDir, {
       "agent:main:main": {
@@ -547,8 +560,34 @@ describe("main-session-restart-recovery", () => {
 
     const result = await recoverRestartAbortedMainSessions({ stateDir: tmpDir });
 
-    expect(result).toEqual({ recovered: 0, failed: 0, skipped: 0 });
+    expect(result).toEqual({ recovered: 1, failed: 0, skipped: 0 });
+    expect(callGateway).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips markerless running sessions with an active embedded run", async () => {
+    const sessionsDir = await makeSessionsDir();
+    await writeStore(sessionsDir, {
+      "agent:main:main": {
+        sessionId: "main-session",
+        updatedAt: Date.now() - 10_000,
+        status: "running",
+      },
+    });
+    await writeTranscript(sessionsDir, "main-session", [
+      { role: "user", content: "active run" },
+      { role: "toolResult", content: "done" },
+    ]);
+
+    // Simulate the current process having an active run for this session
+    const { isEmbeddedPiRunActive } = await import("./pi-embedded-runner/runs.js");
+    const spy = vi.mocked(isEmbeddedPiRunActive);
+    spy.mockReturnValue(true);
+
+    const result = await recoverRestartAbortedMainSessions({ stateDir: tmpDir });
+
+    expect(result).toEqual({ recovered: 0, failed: 0, skipped: 1 });
     expect(callGateway).not.toHaveBeenCalled();
+    spy.mockReturnValue(false);
   });
 
   it("fails marked sessions whose transcript tail cannot be resumed", async () => {

--- a/src/agents/main-session-restart-recovery.ts
+++ b/src/agents/main-session-restart-recovery.ts
@@ -20,16 +20,16 @@ import { callGateway } from "../gateway/call.js";
 import { readSessionMessagesAsync } from "../gateway/session-utils.fs.js";
 import { resolveGatewaySessionStoreTarget } from "../gateway/session-utils.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { CommandLane } from "../process/lanes.js";
 import { getCommandLaneSnapshot } from "../process/command-queue.js";
+import { CommandLane } from "../process/lanes.js";
 import { isAcpSessionKey, isCronSessionKey, isSubagentSessionKey } from "../routing/session-key.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { deliveryContextFromSession } from "../utils/delivery-context.shared.js";
-import { resolveEmbeddedSessionLane } from "./pi-embedded-runner/lanes.js";
+import { resolveEmbeddedSessionLane } from "./embedded-agent-runner/lanes.js";
 import {
-  isEmbeddedPiRunActive,
-  isEmbeddedPiRunHandleActive,
-} from "./pi-embedded-runner/runs.js";
+  isEmbeddedAgentRunActive,
+  isEmbeddedAgentRunHandleActive,
+} from "./embedded-agent-runner/runs.js";
 import { resolveAgentSessionDirs } from "./session-dirs.js";
 import type { SessionLockInspection } from "./session-write-lock.js";
 
@@ -477,8 +477,8 @@ async function recoverStore(params: {
     // empty check confirms the row is stale from the old process.
     if (!entry.abortedLastRun) {
       const hasActiveRun =
-        (typeof entry.sessionId === "string" && isEmbeddedPiRunActive(entry.sessionId)) ||
-        isEmbeddedPiRunHandleActive(sessionKey);
+        (typeof entry.sessionId === "string" && isEmbeddedAgentRunActive(entry.sessionId)) ||
+        isEmbeddedAgentRunHandleActive(sessionKey);
       const sessionLane = resolveEmbeddedSessionLane(sessionKey);
       const hasActiveLane = sessionLane
         ? getCommandLaneSnapshot(sessionLane).activeCount > 0

--- a/src/agents/main-session-restart-recovery.ts
+++ b/src/agents/main-session-restart-recovery.ts
@@ -21,9 +21,15 @@ import { readSessionMessagesAsync } from "../gateway/session-utils.fs.js";
 import { resolveGatewaySessionStoreTarget } from "../gateway/session-utils.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { CommandLane } from "../process/lanes.js";
+import { getCommandLaneSnapshot } from "../process/command-queue.js";
 import { isAcpSessionKey, isCronSessionKey, isSubagentSessionKey } from "../routing/session-key.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { deliveryContextFromSession } from "../utils/delivery-context.shared.js";
+import { resolveEmbeddedSessionLane } from "./pi-embedded-runner/lanes.js";
+import {
+  isEmbeddedPiRunActive,
+  isEmbeddedPiRunHandleActive,
+} from "./pi-embedded-runner/runs.js";
 import { resolveAgentSessionDirs } from "./session-dirs.js";
 import type { SessionLockInspection } from "./session-write-lock.js";
 
@@ -456,8 +462,36 @@ async function recoverStore(params: {
   for (const [sessionKey, entry] of Object.entries(store).toSorted(([a], [b]) =>
     a.localeCompare(b),
   )) {
-    if (!entry || entry.status !== "running" || entry.abortedLastRun !== true) {
+    if (!entry || entry.status !== "running") {
       continue;
+    }
+    // After a restart, any session still marked "running" is stale — the
+    // process that owned the run is gone.  Previously we required
+    // `abortedLastRun === true`, but runs that die without cleanup leave
+    // the flag unset, so we now recover those too.
+    //
+    // For markerless rows we verify the current process has no live work
+    // for this session (no active embedded run, no active lane task).
+    // At recovery time (post-ready + delay), any run started by the
+    // current process would already be registered in memory, so an
+    // empty check confirms the row is stale from the old process.
+    if (!entry.abortedLastRun) {
+      const hasActiveRun =
+        (typeof entry.sessionId === "string" && isEmbeddedPiRunActive(entry.sessionId)) ||
+        isEmbeddedPiRunHandleActive(sessionKey);
+      const sessionLane = resolveEmbeddedSessionLane(sessionKey);
+      const hasActiveLane = sessionLane
+        ? getCommandLaneSnapshot(sessionLane).activeCount > 0
+        : false;
+      if (hasActiveRun || hasActiveLane) {
+        result.skipped++;
+        continue;
+      }
+      // Mark the flag so downstream helpers (markSessionFailed /
+      // resumeMainSession) see the expected precondition.  Note: this
+      // only mutates the in-memory entry; downstream helpers re-load
+      // the store and set the flag themselves when persisting.
+      entry.abortedLastRun = true;
     }
     if (shouldSkipMainRecovery(entry, sessionKey)) {
       result.skipped++;

--- a/src/gateway/server-methods/sessions.abort-agent-scope.test.ts
+++ b/src/gateway/server-methods/sessions.abort-agent-scope.test.ts
@@ -3,6 +3,8 @@ import type { GatewayRequestContext, RespondFn } from "./types.js";
 
 const chatAbortMock = vi.fn();
 const resolveSessionKeyForRunMock = vi.fn();
+const loadSessionStoreMock = vi.fn().mockReturnValue({});
+const updateSessionStoreMock = vi.fn();
 
 vi.mock("../server-session-key.js", () => ({
   resolveSessionKeyForRun: (...args: unknown[]) => resolveSessionKeyForRunMock(...args),
@@ -14,11 +16,24 @@ vi.mock("./chat.js", () => ({
   },
 }));
 
+vi.mock("../../config/sessions.js", async () => {
+  const actual = await vi.importActual<typeof import("../../config/sessions.js")>("../../config/sessions.js");
+  return {
+    ...actual,
+    loadSessionStore: (...args: unknown[]) => loadSessionStoreMock(...args),
+    updateSessionStore: (...args: unknown[]) => updateSessionStoreMock(...args),
+  };
+});
+
 vi.mock("../session-utils.js", async () => {
   const actual = await vi.importActual<typeof import("../session-utils.js")>("../session-utils.js");
   return {
     ...actual,
     loadSessionEntry: (sessionKey: string) => ({ canonicalKey: sessionKey }),
+    resolveGatewaySessionStoreTarget: ({ key }: { key: string }) => ({
+      storePath: `/tmp/test-store-${key}.json`,
+      storeKeys: [key],
+    }),
   };
 });
 
@@ -40,6 +55,8 @@ describe("sessions.abort agent scope", () => {
   beforeEach(() => {
     chatAbortMock.mockReset();
     resolveSessionKeyForRunMock.mockReset();
+    loadSessionStoreMock.mockReset().mockReturnValue({});
+    updateSessionStoreMock.mockReset();
   });
 
   it("does not abort an active run whose session key belongs to another requested agent", async () => {
@@ -266,5 +283,168 @@ describe("sessions.abort agent scope", () => {
         params: { sessionKey: "main", runId: undefined },
       }),
     );
+  });
+
+  it("heals a stale running session entry when abort finds no active run", async () => {
+    const frozenAt = Date.now();
+    chatAbortMock.mockImplementation(async ({ respond: abortRespond }: { respond: (...args: unknown[]) => void }) => {
+      abortRespond(true, { runIds: [] });
+    });
+    const staleRow = { sessionId: "sess-stuck", status: "running", updatedAt: frozenAt, abortedLastRun: false };
+    loadSessionStoreMock.mockReturnValue({
+      main: staleRow,
+    });
+    // Mock updateSessionStore to execute the callback so we can verify mutations
+    updateSessionStoreMock.mockImplementation(async (_path: string, updater: (s: Record<string, unknown>) => void) => {
+      const mockStore: Record<string, Record<string, unknown>> = {
+        main: { ...staleRow },
+      };
+      updater(mockStore);
+      // Verify the callback actually clears the stale state
+      expect(mockStore.main.status).toBeUndefined();
+      expect(mockStore.main.abortedLastRun).toBe(false);
+    });
+    const context = {
+      chatAbortControllers: new Map(),
+      getRuntimeConfig: () => ({
+        agents: { list: [{ id: "main", default: true }] },
+      }),
+      dedupe: new Map(),
+      getSessionEventSubscriberConnIds: () => new Set(),
+      broadcastToConnIds: () => {},
+    } as unknown as GatewayRequestContext;
+    const respond = vi.fn() as unknown as RespondFn;
+
+    await sessionsHandlers["sessions.abort"]({
+      req: { id: "req-heal" } as never,
+      params: { key: "main" },
+      respond,
+      context,
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ ok: true, status: "no-active-run" }),
+      undefined,
+      undefined,
+    );
+    expect(updateSessionStoreMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not clear a row that was updated after the snapshot (race guard)", async () => {
+    const originalTime = Date.now();
+    chatAbortMock.mockImplementation(async ({ respond: abortRespond }: { respond: (...args: unknown[]) => void }) => {
+      abortRespond(true, { runIds: [] });
+    });
+    loadSessionStoreMock.mockReturnValue({
+      main: { sessionId: "sess-race", status: "running", updatedAt: originalTime, abortedLastRun: false },
+    });
+    // Simulate the row being updated (new run started) between snapshot and callback
+    updateSessionStoreMock.mockImplementation(async (_path: string, updater: (s: Record<string, unknown>) => void) => {
+      const mockStore: Record<string, Record<string, unknown>> = {
+        main: { sessionId: "sess-race", status: "running", updatedAt: originalTime + 5000, abortedLastRun: false },
+      };
+      updater(mockStore);
+      // Row should NOT be cleared because updatedAt changed
+      expect(mockStore.main.status).toBe("running");
+    });
+    const context = {
+      chatAbortControllers: new Map(),
+      getRuntimeConfig: () => ({
+        agents: { list: [{ id: "main", default: true }] },
+      }),
+      dedupe: new Map(),
+      getSessionEventSubscriberConnIds: () => new Set(),
+      broadcastToConnIds: () => {},
+    } as unknown as GatewayRequestContext;
+    const respond = vi.fn() as unknown as RespondFn;
+
+    await sessionsHandlers["sessions.abort"]({
+      req: { id: "req-race" } as never,
+      params: { key: "main" },
+      respond,
+      context,
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    expect(updateSessionStoreMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not heal session entry when status is not running", async () => {
+    chatAbortMock.mockImplementation(async ({ respond: abortRespond }: { respond: (...args: unknown[]) => void }) => {
+      abortRespond(true, { runIds: [] });
+    });
+    loadSessionStoreMock.mockReturnValue({
+      main: { sessionId: "sess-idle", status: undefined, updatedAt: Date.now() },
+    });
+    const context = {
+      chatAbortControllers: new Map(),
+      getRuntimeConfig: () => ({
+        agents: { list: [{ id: "main", default: true }] },
+      }),
+      dedupe: new Map(),
+    } as unknown as GatewayRequestContext;
+    const respond = vi.fn() as unknown as RespondFn;
+
+    await sessionsHandlers["sessions.abort"]({
+      req: { id: "req-noop" } as never,
+      params: { key: "main" },
+      respond,
+      context,
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    expect(updateSessionStoreMock).not.toHaveBeenCalled();
+  });
+
+  it("heals a stale running row stored under a raw legacy alias key", async () => {
+    const frozenAt = Date.now();
+    chatAbortMock.mockImplementation(async ({ respond: abortRespond }: { respond: (...args: unknown[]) => void }) => {
+      abortRespond(true, { runIds: [] });
+    });
+    // Row is stored under raw "main" (legacy alias), not "agent:main:main"
+    const staleRow = { sessionId: "sess-legacy", status: "running", updatedAt: frozenAt, abortedLastRun: false };
+    loadSessionStoreMock.mockReturnValue({
+      main: staleRow,
+    });
+    updateSessionStoreMock.mockImplementation(async (_path: string, updater: (s: Record<string, unknown>) => void) => {
+      const mockStore: Record<string, Record<string, unknown>> = {
+        main: { ...staleRow },
+      };
+      updater(mockStore);
+      expect(mockStore.main.status).toBeUndefined();
+    });
+    const context = {
+      chatAbortControllers: new Map(),
+      getRuntimeConfig: () => ({
+        agents: { list: [{ id: "main", default: true }] },
+      }),
+      dedupe: new Map(),
+      getSessionEventSubscriberConnIds: () => new Set(),
+      broadcastToConnIds: () => {},
+    } as unknown as GatewayRequestContext;
+    const respond = vi.fn() as unknown as RespondFn;
+
+    // Request with raw key "main" (not scoped)
+    await sessionsHandlers["sessions.abort"]({
+      req: { id: "req-legacy" } as never,
+      params: { key: "main" },
+      respond,
+      context,
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ ok: true, status: "no-active-run" }),
+      undefined,
+      undefined,
+    );
+    expect(updateSessionStoreMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -102,6 +102,7 @@ import {
   readSessionPreviewItemsFromTranscript,
   resolveDeletedAgentIdFromSessionKey,
   resolveFreshestSessionEntryFromStoreKeys,
+  resolveFreshestSessionStoreMatchFromStoreKeys,
   resolveGatewaySessionStoreTarget,
   resolveSessionDisplayModelIdentityRef,
   resolveSessionModelRef,
@@ -1901,6 +1902,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       }
     }
     let abortedRunId: string | null = null;
+    let abortRespondedOk = false;
     await chatHandlers["chat.abort"]({
       req,
       params: {
@@ -1912,6 +1914,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
           respond(ok, payload, error, meta);
           return;
         }
+        abortRespondedOk = true;
         const runIds =
           payload &&
           typeof payload === "object" &&
@@ -1961,6 +1964,55 @@ export const sessionsHandlers: GatewayRequestHandlers = {
         sessionKey: canonicalKey,
         reason: "abort",
       });
+    } else if (abortRespondedOk) {
+      // Heal stale "running" session entries when no active run exists.
+      // This handles the case where a run dies without cleaning up the
+      // persisted session status, leaving the lane stuck in "running".
+      // Use the scoped abort key (already agent-ownership-checked) as the
+      // primary heal target, and include the original requested key only
+      // when it passed the alias ownership check earlier.
+      const cfg = context.getRuntimeConfig();
+      const healTarget = resolveGatewaySessionStoreTarget({
+        cfg,
+        key,
+        ...(requestedKeyAliases?.[0] ? {} : {}),
+      });
+      const healStoreKeys = new Set(healTarget.storeKeys);
+      if (requestedKeyAliases) {
+        for (const alias of requestedKeyAliases) {
+          healStoreKeys.add(alias);
+        }
+      }
+      const store = loadSessionStore(healTarget.storePath);
+      const freshest = resolveFreshestSessionStoreMatchFromStoreKeys(
+        store,
+        Array.from(healStoreKeys),
+      );
+      if (freshest?.entry?.status === "running") {
+        const snapshotUpdatedAt = freshest.entry.updatedAt;
+        const staleKey = freshest.key;
+        await updateSessionStore(healTarget.storePath, (s) => {
+          const current = s[staleKey];
+          // Guard: only clear if the row hasn't changed since we checked
+          // (prevents clearing a row that a newly-started run just claimed).
+          if (
+            current?.status === "running" &&
+            current.updatedAt === snapshotUpdatedAt &&
+            !hasTrackedActiveSessionRun({
+              context,
+              requestedKey: staleKey,
+              canonicalKey,
+            })
+          ) {
+            current.status = undefined;
+            current.abortedLastRun = false;
+          }
+        });
+        emitSessionsChanged(context, {
+          sessionKey: canonicalKey,
+          reason: "abort",
+        });
+      }
     }
   },
   "sessions.patch": async ({ params, respond, context, client, isWebchatConnect }) => {


### PR DESCRIPTION
## Summary

- Problem: `sessions.abort` can return `status: "no-active-run"` while leaving a persisted session row stuck in `status: "running"`, causing lane-level message starvation.
- Solution: reconcile stale `running` rows on the no-active-run abort path and broaden restart recovery to include markerless stale running rows.
- What changed: added conservative stale-row healing in `sessions.abort`, expanded restart recovery selection, and added regression tests.
- What did NOT change (scope boundary): no protocol/API shape changes, no new config flags, no changes to normal active-run abort semantics.

## Motivation

Users can hit silent queue starvation: new messages enqueue behind a dead `running` lock and never execute until manual `/new` recovery. This PR closes that stale-state gap.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #59878
- Related #82433
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: stale persisted `running` session state survives `sessions.abort` no-active-run and startup recovery.
- Real environment tested: live OpenClaw gateway runtime on local machine + targeted test runtime.
- Exact steps or command run after this patch:
  1. Seed a real session row to `status: "running"` with no active run controller.
  2. Call gateway RPC `sessions.abort` with that key.
  3. Read session row state before and after abort.
  4. Run regression tests and targeted lint.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):
  ```text
  AFTER-FIX proof before abort: {"status":"running","abortedLastRun":false}
  AFTER-FIX abort response: {"ok":true,"abortedRunId":null,"status":"no-active-run"}
  AFTER-FIX after abort: {"status":null,"abortedLastRun":false}
  ```
  Supplemental commands executed:
  - `node scripts/run-vitest.mjs src/gateway/server-methods/sessions.abort-agent-scope.test.ts`
  - `node scripts/run-vitest.mjs src/agents/main-session-restart-recovery.test.ts`
  - `node scripts/run-oxlint.mjs src/gateway/server-methods/sessions.ts src/gateway/server-methods/sessions.abort-agent-scope.test.ts src/agents/main-session-restart-recovery.ts src/agents/main-session-restart-recovery.test.ts`
- Observed result after fix:
  - `sessions.abort` still returns `no-active-run` when no controller exists.
  - Stale persisted `running` row is healed (`status` cleared) instead of remaining stuck.
  - Restart recovery includes markerless stale `running` rows.
- What was not tested:
  - Multi-node production traffic under prolonged queue pressure.
- Before evidence (optional but encouraged):
  ```json
  {"ok":true,"abortedRunId":null,"status":"no-active-run"}
  {"status":"running","abortedLastRun":false}
  ```

## Root Cause (if applicable)

- Root cause: stale-state reconciliation depended on explicit abort/run lifecycle markers; if a run died without cleanup, `sessions.abort` could return `no-active-run` without mutating persisted row state.
- Missing detection / guardrail: no conservative fallback to heal `status: "running"` when no active run exists.
- Contributing context (if known): restart recovery required `abortedLastRun === true`, excluding markerless stale rows.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/gateway/server-methods/sessions.abort-agent-scope.test.ts`
  - `src/agents/main-session-restart-recovery.test.ts`
- Scenario the test should lock in:
  - `sessions.abort` returns `no-active-run` and stale persisted `running` row is healed.
  - Restart recovery includes stale `running` rows without pre-set `abortedLastRun` marker.
- Why this is the smallest reliable guardrail:
  - Directly exercises the two affected state-transition seams with minimal unrelated runtime noise.

## User-visible / Behavior Changes

- Sessions stuck in stale `running` state are now automatically cleared on `sessions.abort` no-active-run and at startup recovery, reducing indefinite message queue stalls.

## Diagram (if applicable)

```text
Before:
[sessions.abort -> no active run] -> [row stays running] -> [lane starves]

After:
[sessions.abort -> no active run] -> [stale running row healed] -> [lane proceeds]

Startup recovery:
Before: running + abortedLastRun!=true -> skipped
After:  running (markerless stale) -> marked + recovered
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: macOS (Darwin x64)
- Runtime/container: OpenClaw gateway + Node.js test runtime
- Model/provider: N/A
- Integration/channel (if any): Gateway server methods + agent recovery tests
- Relevant config (redacted): default local config; proof replay used isolated dev runtime state

### Steps

1. Seed stale `running` session row with no active run.
2. Invoke `sessions.abort` with that key.
3. Verify before/after row state.
4. Run regression tests and targeted lint.

### Expected

- No-active-run branch heals stale persisted `running` row.
- Restart recovery handles markerless stale `running` rows.

### Actual

- Matches expected; live proof and targeted tests passed.

## Evidence

- [x] Failing behavior before + healed behavior after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - no-active-run abort stale-row healing path
  - non-running row remains untouched
  - markerless stale running row recovered at restart
- Edge cases checked:
  - no-op when row not running
  - existing active-run abort behavior preserved
- What you did **not** verify:
  - full production-like multi-channel crash injection E2E

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Risks and Mitigations

- Risk: accidentally clearing a genuinely active session row.
  - Mitigation: reconciliation is guarded by no-active-run abort outcome and conservative startup recovery flow; active-run paths remain unchanged.

