### PR TITLE
fix(feishu): evict client cache when SDK is swapped in tests (#83911)

### DIFF
--- a/extensions/feishu/src/client.test.ts
+++ b/extensions/feishu/src/client.test.ts
@@ -445,3 +445,44 @@ describe("createFeishuWSClient proxy handling", () => {
     expect(options.agent).toEqual({ proxied: true });
   });
 });
+
+describe("setFeishuClientRuntimeForTest cache eviction (#83911)", () => {
+  it("evicts any cached clients so the next createFeishuClient picks up the new SDK", () => {
+    const creds = {
+      appId: "app_cache_evict",
+      appSecret: "secret_cache_evict", // pragma: allowlist secret
+      accountId: "cache-evict",
+    } as const;
+
+    // First client uses the default SDK installed by the outer beforeEach.
+    const firstCall = clientCtorMock.mock.calls.length;
+    createFeishuClient(creds);
+    expect(clientCtorMock.mock.calls.length).toBeGreaterThan(firstCall);
+
+    // Swap the SDK to a freshly tracked Client constructor. Without the new
+    // cache eviction inside setFeishuClientRuntimeForTest, the next
+    // createFeishuClient call would hit the existing cache entry and never
+    // invoke this constructor.
+    const replacementClientCtor = vi.fn(function replacementCtor() {
+      return { replaced: true };
+    });
+    setFeishuClientRuntimeForTest({
+      sdk: {
+        AppType: { SelfBuild: "self" } as never,
+        Domain: {
+          Feishu: "https://open.feishu.cn",
+          Lark: "https://open.larksuite.com",
+        } as never,
+        LoggerLevel: { info: "info" } as never,
+        Client: replacementClientCtor as never,
+        WSClient: wsClientCtorMock as never,
+        EventDispatcher: vi.fn() as never,
+        defaultHttpInstance: mockBaseHttpInstance as never,
+      },
+    });
+
+    expect(replacementClientCtor).toHaveBeenCalledTimes(0);
+    createFeishuClient(creds);
+    expect(replacementClientCtor).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/feishu/src/client.ts
+++ b/extensions/feishu/src/client.ts
@@ -259,4 +259,9 @@ export function setFeishuClientRuntimeForTest(overrides?: {
   feishuClientSdk = overrides?.sdk
     ? { ...defaultFeishuClientSdk, ...overrides.sdk }
     : defaultFeishuClientSdk;
+  // Any clients already cached under an accountId were constructed against the
+  // previous SDK. Without this eviction, the next createFeishuClient call with
+  // matching credentials hits the cache and returns the stale client — so the
+  // SDK swap is silently ignored from the test's perspective. See #83911.
+  clearClientCache();
 }


### PR DESCRIPTION
Fixes #83911.

`setFeishuClientRuntimeForTest` (`extensions/feishu/src/client.ts:256`) swaps `feishuClientSdk` so tests can inject a mock `Lark.Client` (or other SDK piece), but the existing module-level `clientCache` keeps holding clients built against the **previous** SDK. A subsequent `createFeishuClient` call with the same `accountId` and identical credentials hits the cache and returns the stale client — the SDK swap is silently ignored from the test's perspective. Today's tests get away with it only because they mock `./client.js` wholesale; any future test that exercises the real factory across SDK swaps would see stale clients and chase a phantom mock-assertion bug.

## Changes

- `extensions/feishu/src/client.ts`: invoke the already-defined `clearClientCache()` helper at the end of `setFeishuClientRuntimeForTest`, after the SDK swap. No new helper, no production-path change (`setFeishuClientRuntimeForTest` has zero production callers — it's only imported by test scaffolding).
- `extensions/feishu/src/client.test.ts`: regression test that constructs a client with the default SDK, swaps to a freshly tracked replacement `Client` constructor via `setFeishuClientRuntimeForTest`, then constructs another client with the same credentials and asserts the replacement constructor (not the original) is invoked.

Diff stat: 2 files, +46 / -0.

## Real behavior proof

- **Behavior or issue addressed:** Sanitized issue evidence — `clientCache` is the module-level `Map<accountId, { client, config }>` at `client.ts:95-108`, and `clearClientCache` (line 248) is the existing exported helper that handles per-account and full eviction. The new line wires those two together.

- **Real environment tested:** Local Node 22.x. Probe at `/tmp/probe_83911.mjs` (a) parses the patched `client.ts` and verifies `clearClientCache()` is called inside `setFeishuClientRuntimeForTest` and that the eviction follows the SDK swap (correct ordering), and (b) replays the cache + SDK swap semantics in pure JS for three scenarios — pre-fix shape (second `createClient` returns the stale client built against `default-sdk`, confirming the issue's exact symptom), patched shape (second `createClient` builds a fresh client with `mock-sdk` — the eviction works), and the production happy path (same SDK, same creds, cache hit is preserved across consecutive calls — no regression).

- **Exact steps or command run after this patch:** `node /tmp/probe_83911.mjs`

- **Evidence after fix:**

```
PASS: setFeishuClientRuntimeForTest now invokes clearClientCache()
PASS: cache eviction follows SDK swap (correct ordering)
PASS: replay (buggy): second createClient returns the stale client built against default-sdk — confirms #83911 root cause
PASS: replay (patched): second createClient builds a fresh client with mock-sdk — cache eviction works
PASS: replay (production, no runtime swap): cache hit preserved across consecutive calls

ALL CASES PASS
```

- **Observed result after fix:** Tests that swap the Feishu SDK mid-suite via `setFeishuClientRuntimeForTest` now observe the swap on the next `createFeishuClient` call. Production cache-hit behavior (same SDK, same creds → reuse cached client) is unchanged because no production code invokes `setFeishuClientRuntimeForTest`.

- **What was not tested:** Live Lark.Client construction against the Feishu SDK — that requires Feishu credentials and is outside the scope of a cache-eviction fix. The vitest regression case exercises the public `createFeishuClient` + `setFeishuClientRuntimeForTest` boundary with a tracked replacement constructor, and the probe replays both the buggy and patched shapes against the same fixture.

## Audit (per CLAUDE rules — all 5 steps)

- **Existing-helper check:** Reuses the already-exported `clearClientCache()` helper from the same file. No new helper. PASS
- **Shared-helper caller check:** `setFeishuClientRuntimeForTest` is test-only — `grep -r setFeishuClientRuntimeForTest extensions/feishu/src` returns only `client.ts` (the implementation), `client.test.ts` (the import), and `lifecycle.test-support.ts` (a `vi.fn()` mock). No production caller exists; the new line cannot affect production behavior. PASS
- **Broader-fix rival scan:** `gh pr list --search '83911 in:title,body'` and `gh pr list --search 'setFeishuClientRuntimeForTest in:title,body'` return no open PRs. PASS
- **Recent-merge audit:** `git log --oneline -5 -- extensions/feishu/src/client.ts` shows `e1061a8b46 test(live): tolerate provider drift in release checks` — unrelated. PASS
- **Prototype-pollution scan:** N/A — single `Map.clear()` call.
