### PR TITLE
fix(openai): add responses message item types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Docker: keep the bundled Codex plugin in official release image keep lists so the default OpenAI agent harness remains available after Docker pruning. Fixes #83613. (#83626) Thanks @YuanHanzhong.
+- Providers/OpenAI: include explicit Responses message item types for system, developer, and user inputs so Azure AI Foundry project endpoints accept shared Responses payloads. Fixes #84109.
 - CLI/channels: preserve the first line of `openclaw channels logs` output when the rolling tail window starts exactly on a line boundary, mirroring the already-fixed `readLogSlice` behavior in `src/logging/log-tail.ts`.
 - Control UI: treat terminal session status as authoritative over stale active-run flags so completed terminal runs stop showing abort/live UI. (#84057)
 - CLI: preserve embedded equals signs in inline root option values instead of truncating after the second separator. (#83995) Thanks @ThiagoCAltoe.

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -1740,9 +1740,11 @@ describe("openai transport stream", () => {
         tools: [],
       } as never,
       undefined,
-    ) as { input?: Array<{ role?: string }> };
+    ) as { input?: Array<{ content?: unknown; role?: string; type?: string }> };
 
+    expect(params.input?.[0]?.type).toBe("message");
     expect(params.input?.[0]?.role).toBe("system");
+    expect(params.input?.[0]?.content).toEqual([{ type: "input_text", text: "system" }]);
   });
 
   it("omits Responses reasoning params when model compat disables reasoning effort", () => {
@@ -1856,9 +1858,47 @@ describe("openai transport stream", () => {
         tools: [],
       } as never,
       undefined,
-    ) as { input?: Array<{ role?: string }> };
+    ) as { input?: Array<{ content?: unknown; role?: string; type?: string }> };
 
+    expect(params.input?.[0]?.type).toBe("message");
     expect(params.input?.[0]?.role).toBe("developer");
+    expect(params.input?.[0]?.content).toEqual([{ type: "input_text", text: "system" }]);
+  });
+
+  it("adds explicit message item types for Responses user input payloads", () => {
+    const params = buildOpenAIResponsesParams(
+      {
+        id: "gpt-5.4",
+        name: "GPT-5.4",
+        api: "openai-responses",
+        provider: "openai",
+        baseUrl: "https://api.openai.com/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"openai-responses">,
+      {
+        systemPrompt: "system",
+        messages: [{ role: "user", content: "Hello", timestamp: 1 }],
+        tools: [],
+      } as never,
+      undefined,
+    ) as { input?: Array<{ content?: unknown; role?: string; type?: string }> };
+
+    expect(params.input).toEqual([
+      {
+        type: "message",
+        role: "developer",
+        content: [{ type: "input_text", text: "system" }],
+      },
+      {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: "Hello" }],
+      },
+    ]);
   });
 
   it("uses model maxTokens for Responses params when runtime maxTokens is omitted", () => {
@@ -2486,6 +2526,7 @@ describe("openai transport stream", () => {
     expect(params.instructions).toBe("Stable prefix\nDynamic suffix");
     expect(params.input).toEqual([
       {
+        type: "message",
         role: "user",
         content: [{ type: "input_text", text: " " }],
       },
@@ -2857,9 +2898,13 @@ describe("openai transport stream", () => {
         tools: [],
       } as never,
       undefined,
-    ) as { input?: Array<{ content?: string }> };
+    ) as { input?: Array<{ content?: unknown; type?: string }> };
 
-    expect(params.input?.[0]?.content).toBe("Stable prefix\nDynamic suffix");
+    expect(params.input?.[0]).toEqual({
+      type: "message",
+      role: "developer",
+      content: [{ type: "input_text", text: "Stable prefix\nDynamic suffix" }],
+    });
   });
 
   it("defaults responses tool schemas to strict on native OpenAI routes", () => {

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -813,8 +813,14 @@ function convertResponsesMessages(
   const includeSystemPrompt = options?.includeSystemPrompt ?? true;
   if (includeSystemPrompt && context.systemPrompt) {
     messages.push({
+      type: "message",
       role: model.reasoning && options?.supportsDeveloperRole !== false ? "developer" : "system",
-      content: sanitizeTransportPayloadText(stripSystemPromptCacheBoundary(context.systemPrompt)),
+      content: [
+        {
+          type: "input_text",
+          text: sanitizeTransportPayloadText(stripSystemPromptCacheBoundary(context.systemPrompt)),
+        },
+      ],
     });
   }
   let msgIndex = 0;
@@ -822,6 +828,7 @@ function convertResponsesMessages(
     if (msg.role === "user") {
       if (typeof msg.content === "string") {
         messages.push({
+          type: "message",
           role: "user",
           content: [{ type: "input_text", text: sanitizeTransportPayloadText(msg.content) }],
         });
@@ -838,7 +845,7 @@ function convertResponsesMessages(
           ) as ResponseInputMessageContentList
         ).filter((item) => model.input.includes("image") || item.type !== "input_image");
         if (content.length > 0) {
-          messages.push({ role: "user", content });
+          messages.push({ type: "message", role: "user", content });
         }
       }
     } else if (msg.role === "assistant") {
@@ -1667,6 +1674,7 @@ function ensureOpenAICodexResponsesInput(messages: ResponseInput, context: Conte
     );
   }
   messages.push({
+    type: "message",
     role: "user",
     content: [{ type: "input_text", text: OPENAI_CODEX_RESPONSES_EMPTY_INPUT_TEXT }],
   });


### PR DESCRIPTION
Fixes #84109.

## Summary
- add explicit `type: "message"` to system/developer/user Responses input items
- normalize system/developer prompt content to `input_text` content arrays
- keep Codex Responses empty-input fallback on the same explicit message item shape

## Real behavior proof
- Behavior or issue addressed: Azure AI Foundry Responses endpoints reject shared Responses input items when system/developer/user entries omit the explicit `type: "message"` discriminator. This patch makes the exported Responses payload builder emit that stricter message-item shape for system/developer/user inputs.
- Real environment tested: Local OpenClaw checkout on commit `0a54691b3d` after rebasing onto current `main` (`d0f7c8fa28`), Node.js runtime with the repo source loaded through `tsx`, using a Foundry-shaped `openai-responses` model config (`https://example.services.ai.azure.com/api/projects/demo/openai/v1`).
- Exact steps or command run after this patch: `node --import tsx -e ...` was run from the repo root to import `buildOpenAIResponsesParams`, build a Foundry-shaped Responses payload, and print `params.input`.
- Evidence after fix: Console output from the post-patch runtime command showed both input items include `type: "message"` and `input_text` content.

```json
[
  {
    "type": "message",
    "role": "system",
    "content": [
      {
        "type": "input_text",
        "text": "system"
      }
    ]
  },
  {
    "type": "message",
    "role": "user",
    "content": [
      {
        "type": "input_text",
        "text": "Hello"
      }
    ]
  }
]
```

- Observed result after fix: The shared Responses payload builder now emits explicit `type: "message"` entries for the system and user input items and wraps the system prompt as `input_text`, matching the stricter Azure AI Foundry payload shape reported in #84109.
- What was not tested: No live Azure AI Foundry request was sent because no Azure credentials/project endpoint are available in this environment.

## Validation
- `node scripts/run-vitest.mjs src/agents/openai-transport-stream.test.ts -t "Responses"` -> 2 files passed, 50 tests passed, 288 skipped
- `node scripts/run-vitest.mjs src/agents/openai-transport-stream.test.ts src/agents/openai-responses-payload-policy.test.ts extensions/microsoft-foundry/index.test.ts` -> 4 files passed, 374 tests passed
- `pnpm lint -- src/agents/openai-transport-stream.ts src/agents/openai-transport-stream.test.ts CHANGELOG.md` -> 0 warnings, 0 errors
- `git diff --check main...HEAD` -> clean

Note: `NODE_OPTIONS=--max-old-space-size=8192 pnpm exec tsc --noEmit --pretty false` hit Node OOM after ~115s before diagnostics, so no typecheck diagnostics were produced locally.