### PR TITLE
docs(context-engine): add OpenViking as remote context-engine example

### DIFF
--- a/docs/concepts/context-engine.md
+++ b/docs/concepts/context-engine.md
@@ -1,9 +1,9 @@
 ---
 summary: "Context engine: pluggable context assembly, compaction, and subagent lifecycle"
 read_when:
-  - You want to understand how OpenClaw assembles model context
-  - You are switching between the legacy engine and a plugin engine
-  - You are building a context engine plugin
+ - You want to understand how OpenClaw assembles model context
+ - You are switching between the legacy engine and a plugin engine
+ - You are building a context engine plugin
 title: "Context engine"
 sidebarTitle: "Context engine"
 ---
@@ -14,34 +14,40 @@ OpenClaw ships with a built-in `legacy` engine and uses it by default - most use
 
 ## Quick start
 
-<Steps>
-  <Step title="Check which engine is active">
+ 
+ 
     ```bash
     openclaw doctor
     # or inspect config directly:
     cat ~/.openclaw/openclaw.json | jq '.plugins.slots.contextEngine'
     ```
-  </Step>
-  <Step title="Install a plugin engine">
-    Context engine plugins are installed like any other OpenClaw plugin.
+ 
+ 
+ Context engine plugins are installed like any other OpenClaw plugin.
 
-    <Tabs>
-      <Tab title="From npm">
+ 
+ 
         ```bash
         openclaw plugins install @martian-engineering/lossless-claw
         ```
-      </Tab>
-      <Tab title="From a local path">
+ 
+ 
+        ```bash
+        openclaw plugins install clawhub:@openviking/openclaw-plugin
+        openclaw openviking setup --base-url http://your-server:1933 --json
+        ```
+ 
+ 
         ```bash
         openclaw plugins install -l ./my-context-engine
         ```
-      </Tab>
-    </Tabs>
+ 
+ 
 
-  </Step>
-  <Step title="Enable and select the engine">
+ 
+ 
     ```json5
-    // openclaw.json
+    // openclaw.json 鈥?local engine (lossless-claw)
     {
       plugins: {
         slots: {
@@ -57,32 +63,52 @@ OpenClaw ships with a built-in `legacy` engine and uses it by default - most use
     }
     ```
 
-    Restart the gateway after installing and configuring.
+    ```json5
+    // openclaw.json 鈥?remote engine (OpenViking)
+    {
+      plugins: {
+        slots: {
+          contextEngine: "openviking",
+        },
+        entries: {
+          "openviking": {
+            enabled: true,
+            config: {
+              baseUrl: "http://your-server:1933",
+              // apiKey: "sk-xxx",  // optional, if the server requires auth
+            },
+          },
+        },
+      },
+    }
+    ```
 
-  </Step>
-  <Step title="Switch back to legacy (optional)">
-    Set `contextEngine` to `"legacy"` (or remove the key entirely - `"legacy"` is the default).
-  </Step>
-</Steps>
+ Restart the gateway after installing and configuring.
+
+ 
+ 
+ Set `contextEngine` to `"legacy"` (or remove the key entirely - `"legacy"` is the default).
+ 
+ 
 
 ## How it works
 
 Every time OpenClaw runs a model prompt, the context engine participates at four lifecycle points:
 
-<AccordionGroup>
-  <Accordion title="1. Ingest">
-    Called when a new message is added to the session. The engine can store or index the message in its own data store.
-  </Accordion>
-  <Accordion title="2. Assemble">
-    Called before each model run. The engine returns an ordered set of messages (and an optional `systemPromptAddition`) that fit within the token budget.
-  </Accordion>
-  <Accordion title="3. Compact">
-    Called when the context window is full, or when the user runs `/compact`. The engine summarizes older history to free space.
-  </Accordion>
-  <Accordion title="4. After turn">
-    Called after a run completes. The engine can persist state, trigger background compaction, or update indexes.
-  </Accordion>
-</AccordionGroup>
+ 
+ 
+ Called when a new message is added to the session. The engine can store or index the message in its own data store.
+ 
+ 
+ Called before each model run. The engine returns an ordered set of messages (and an optional `systemPromptAddition`) that fit within the token budget.
+ 
+ 
+ Called when the context window is full, or when the user runs `/compact`. The engine summarizes older history to free space.
+ 
+ 
+ Called after a run completes. The engine can persist state, trigger background compaction, or update indexes.
+ 
+ 
 
 For the bundled non-ACP Codex harness, OpenClaw applies the same lifecycle by projecting assembled context into Codex developer instructions and the current turn prompt. Codex still owns its native thread history and native compactor.
 
@@ -90,12 +116,12 @@ For the bundled non-ACP Codex harness, OpenClaw applies the same lifecycle by pr
 
 OpenClaw calls two optional subagent lifecycle hooks:
 
-<ParamField path="prepareSubagentSpawn" type="method">
-  Prepare shared context state before a child run starts. The hook receives parent/child session keys, `contextMode` (`isolated` or `fork`), available transcript ids/files, and optional TTL. If it returns a rollback handle, OpenClaw calls it when spawn fails after preparation succeeds.
-</ParamField>
-<ParamField path="onSubagentEnded" type="method">
-  Clean up when a subagent session completes or is swept.
-</ParamField>
+ 
+ Prepare shared context state before a child run starts. The hook receives parent/child session keys, `contextMode` (`isolated` or `fork`), available transcript ids/files, and optional TTL. If it returns a rollback handle, OpenClaw calls it when spawn fails after preparation succeeds.
+ 
+ 
+ Clean up when a subagent session completes or is swept.
+ 
 
 ### System prompt addition
 
@@ -106,7 +132,7 @@ The `assemble` method can return a `systemPromptAddition` string. OpenClaw prepe
 The built-in `legacy` engine preserves OpenClaw's original behavior:
 
 - **Ingest**: no-op (the session manager handles message persistence directly).
-- **Assemble**: pass-through (the existing sanitize → validate → limit pipeline in the runtime handles context assembly).
+- **Assemble**: pass-through (the existing sanitize 鈫?validate 鈫?limit pipeline in the runtime handles context assembly).
 - **Compact**: delegates to the built-in summarization compaction, which creates a single summary of older messages and keeps recent messages intact.
 - **After turn**: no-op.
 
@@ -179,35 +205,35 @@ Then enable it in config:
 
 Required members:
 
-| Member             | Kind     | Purpose                                                  |
+| Member | Kind | Purpose |
 | ------------------ | -------- | -------------------------------------------------------- |
-| `info`             | Property | Engine id, name, version, and whether it owns compaction |
-| `ingest(params)`   | Method   | Store a single message                                   |
-| `assemble(params)` | Method   | Build context for a model run (returns `AssembleResult`) |
-| `compact(params)`  | Method   | Summarize/reduce context                                 |
+| `info` | Property | Engine id, name, version, and whether it owns compaction |
+| `ingest(params)` | Method | Store a single message |
+| `assemble(params)` | Method | Build context for a model run (returns `AssembleResult`) |
+| `compact(params)` | Method | Summarize/reduce context |
 
 `assemble` returns an `AssembleResult` with:
 
-<ParamField path="messages" type="Message[]" required>
-  The ordered messages to send to the model.
-</ParamField>
-<ParamField path="estimatedTokens" type="number" required>
-  The engine's estimate of total tokens in the assembled context. OpenClaw uses this for compaction threshold decisions and diagnostic reporting.
-</ParamField>
-<ParamField path="systemPromptAddition" type="string">
-  Prepended to the system prompt.
-</ParamField>
-<ParamField path="promptAuthority" type='"assembled" | "preassembly_may_overflow"'>
-  Controls which token estimate the runner uses for preemptive overflow
-  prechecks. Defaults to `"assembled"`, which means only the assembled
-  prompt's estimate is checked - appropriate for engines that return a
-  windowed, self-contained context. Set to `"preassembly_may_overflow"` only
-  when your assembled view can hide overflow risk in the underlying
-  transcript; the runner then takes the maximum of the assembled estimate
-  and the pre-assembly (unwindowed) session-history estimate when deciding
-  whether to preemptively compact. Either way, the messages you return are
-  still what the model sees - `promptAuthority` only affects the precheck.
-</ParamField>
+ 
+ The ordered messages to send to the model.
+ 
+ 
+ The engine's estimate of total tokens in the assembled context. OpenClaw uses this for compaction threshold decisions and diagnostic reporting.
+ 
+ 
+ Prepended to the system prompt.
+ 
+ 
+ Controls which token estimate the runner uses for preemptive overflow
+ prechecks. Defaults to `"assembled"`, which means only the assembled
+ prompt's estimate is checked - appropriate for engines that return a
+ windowed, self-contained context. Set to `"preassembly_may_overflow"` only
+ when your assembled view can hide overflow risk in the underlying
+ transcript; the runner then takes the maximum of the assembled estimate
+ and the pre-assembly (unwindowed) session-history estimate when deciding
+ whether to preemptively compact. Either way, the messages you return are
+ still what the model sees - `promptAuthority` only affects the precheck.
+ 
 
 `compact` returns a `CompactResult`. When compaction rotates the active
 transcript, `result.sessionId` and `result.sessionFile` identify the successor
@@ -215,42 +241,42 @@ session that the next retry or turn must use.
 
 Optional members:
 
-| Member                         | Kind   | Purpose                                                                                                         |
+| Member | Kind | Purpose |
 | ------------------------------ | ------ | --------------------------------------------------------------------------------------------------------------- |
-| `bootstrap(params)`            | Method | Initialize engine state for a session. Called once when the engine first sees a session (e.g., import history). |
-| `ingestBatch(params)`          | Method | Ingest a completed turn as a batch. Called after a run completes, with all messages from that turn at once.     |
-| `afterTurn(params)`            | Method | Post-run lifecycle work (persist state, trigger background compaction).                                         |
-| `prepareSubagentSpawn(params)` | Method | Set up shared state for a child session before it starts.                                                       |
-| `onSubagentEnded(params)`      | Method | Clean up after a subagent ends.                                                                                 |
-| `dispose()`                    | Method | Release resources. Called during gateway shutdown or plugin reload - not per-session.                           |
+| `bootstrap(params)` | Method | Initialize engine state for a session. Called once when the engine first sees a session (e.g., import history). |
+| `ingestBatch(params)` | Method | Ingest a completed turn as a batch. Called after a run completes, with all messages from that turn at once. |
+| `afterTurn(params)` | Method | Post-run lifecycle work (persist state, trigger background compaction). |
+| `prepareSubagentSpawn(params)` | Method | Set up shared state for a child session before it starts. |
+| `onSubagentEnded(params)` | Method | Clean up after a subagent ends. |
+| `dispose()` | Method | Release resources. Called during gateway shutdown or plugin reload - not per-session. |
 
 ### ownsCompaction
 
 `ownsCompaction` controls whether Pi's built-in in-attempt auto-compaction stays enabled for the run:
 
-<AccordionGroup>
-  <Accordion title="ownsCompaction: true">
-    The engine owns compaction behavior. OpenClaw disables Pi's built-in auto-compaction for that run, and the engine's `compact()` implementation is responsible for `/compact`, overflow recovery compaction, and any proactive compaction it wants to do in `afterTurn()`. OpenClaw may still run the pre-prompt overflow safeguard; when it predicts the full transcript will overflow, the recovery path calls the active engine's `compact()` before submitting another prompt.
-  </Accordion>
-  <Accordion title="ownsCompaction: false or unset">
-    Pi's built-in auto-compaction may still run during prompt execution, but the active engine's `compact()` method is still called for `/compact` and overflow recovery.
-  </Accordion>
-</AccordionGroup>
+ 
+ 
+ The engine owns compaction behavior. OpenClaw disables Pi's built-in auto-compaction for that run, and the engine's `compact()` implementation is responsible for `/compact`, overflow recovery compaction, and any proactive compaction it wants to do in `afterTurn()`. OpenClaw may still run the pre-prompt overflow safeguard; when it predicts the full transcript will overflow, the recovery path calls the active engine's `compact()` before submitting another prompt.
+ 
+ 
+ Pi's built-in auto-compaction may still run during prompt execution, but the active engine's `compact()` method is still called for `/compact` and overflow recovery.
+ 
+ 
 
-<Warning>
+ 
 `ownsCompaction: false` does **not** mean OpenClaw automatically falls back to the legacy engine's compaction path.
-</Warning>
+ 
 
 That means there are two valid plugin patterns:
 
-<Tabs>
-  <Tab title="Owning mode">
-    Implement your own compaction algorithm and set `ownsCompaction: true`.
-  </Tab>
-  <Tab title="Delegating mode">
-    Set `ownsCompaction: false` and have `compact()` call `delegateCompactionToRuntime(...)` from `openclaw/plugin-sdk/core` to use OpenClaw's built-in compaction behavior.
-  </Tab>
-</Tabs>
+ 
+ 
+ Implement your own compaction algorithm and set `ownsCompaction: true`.
+ 
+ 
+ Set `ownsCompaction: false` and have `compact()` call `delegateCompactionToRuntime(...)` from `openclaw/plugin-sdk/core` to use OpenClaw's built-in compaction behavior.
+ 
+ 
 
 A no-op `compact()` is unsafe for an active non-owning engine because it disables the normal `/compact` and overflow-recovery compaction path for that engine slot.
 
@@ -268,27 +294,27 @@ A no-op `compact()` is unsafe for an active non-owning engine because it disable
 }
 ```
 
-<Note>
+ 
 The slot is exclusive at run time - only one registered context engine is resolved for a given run or compaction operation. Other enabled `kind: "context-engine"` plugins can still load and run their registration code; `plugins.slots.contextEngine` only selects which registered engine id OpenClaw resolves when it needs a context engine.
-</Note>
+ 
 
-<Note>
+ 
 **Plugin uninstall:** when you uninstall the plugin currently selected as `plugins.slots.contextEngine`, OpenClaw resets the slot back to the default (`legacy`). The same reset behavior applies to `plugins.slots.memory`. No manual config edit is required.
-</Note>
+ 
 
 ## Relationship to compaction and memory
 
-<AccordionGroup>
-  <Accordion title="Compaction">
-    Compaction is one responsibility of the context engine. The legacy engine delegates to OpenClaw's built-in summarization. Plugin engines can implement any compaction strategy (DAG summaries, vector retrieval, etc.).
-  </Accordion>
-  <Accordion title="Memory plugins">
-    Memory plugins (`plugins.slots.memory`) are separate from context engines. Memory plugins provide search/retrieval; context engines control what the model sees. They can work together - a context engine might use memory plugin data during assembly. Plugin engines that want the active memory prompt path should prefer `buildMemorySystemPromptAddition(...)` from `openclaw/plugin-sdk/core`, which converts the active memory prompt sections into a ready-to-prepend `systemPromptAddition`. If an engine needs lower-level control, it can still pull raw lines from `openclaw/plugin-sdk/memory-host-core` via `buildActiveMemoryPromptSection(...)`.
-  </Accordion>
-  <Accordion title="Session pruning">
-    Trimming old tool results in-memory still runs regardless of which context engine is active.
-  </Accordion>
-</AccordionGroup>
+ 
+ 
+ Compaction is one responsibility of the context engine. The legacy engine delegates to OpenClaw's built-in summarization. Plugin engines can implement any compaction strategy (DAG summaries, vector retrieval, etc.).
+ 
+ 
+ Memory plugins (`plugins.slots.memory`) are separate from context engines. Memory plugins provide search/retrieval; context engines control what the model sees. They can work together - a context engine might use memory plugin data during assembly. Plugin engines that want the active memory prompt path should prefer `buildMemorySystemPromptAddition(...)` from `openclaw/plugin-sdk/core`, which converts the active memory prompt sections into a ready-to-prepend `systemPromptAddition`. If an engine needs lower-level control, it can still pull raw lines from `openclaw/plugin-sdk/memory-host-core` via `buildActiveMemoryPromptSection(...)`.
+ 
+ 
+ Trimming old tool results in-memory still runs regardless of which context engine is active.
+ 
+ 
 
 ## Tips
 


### PR DESCRIPTION
Add OpenViking as an additional context-engine plugin example alongside lossless-claw in the Quick Start section. This adds a ClawHub install path and a remote server configuration example.

## Changes

- Add a **From ClawHub** install tab showing \openclaw plugins install clawhub:@openviking/openclaw-plugin\
- Add a remote engine config example (OpenViking) alongside the existing local engine example (lossless-claw)

## Why

The current Quick Start only shows one third-party engine (lossless-claw, local SQLite). OpenViking is a remote context-engine plugin that implements the full ContextEngine interface (ingest, assemble, compact, afterTurn) with long-term memory, session archive, and semantic retrieval over a separately deployed server. Adding it gives users a reference for the remote engine pattern.

- ClawHub: \@openviking/openclaw-plugin\ (latest: 2026.5.8)
- GitHub: https://github.com/volcengine/OpenViking (24K+ stars)
- npm: \@openviking/openclaw-plugin\

Made with [Cursor](https://cursor.com)