### PR TITLE
fix(channels): suppress late raw tool output

### DIFF
--- a/docs/concepts/messages.md
+++ b/docs/concepts/messages.md
@@ -197,7 +197,7 @@ OpenClaw resolves that behavior by conversation type:
 OpenClaw also uses silent replies for internal runner failures that happen
 before any assistant reply in non-direct chats, so groups/channels do not see
 gateway error boilerplate. Direct chats show compact failure copy by default;
-raw runner details are shown only when `/verbose` is `on` or `full`.
+raw runner details are shown only when `/verbose full` is enabled.
 
 Defaults live under `agents.defaults.silentReply`; `surfaces.<id>.silentReply`
 can override group/internal policy per surface.

--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -266,7 +266,7 @@ User-invocable skills are also exposed as slash commands:
     - `/trace` is narrower than `/verbose`: it only reveals plugin-owned trace/debug lines and keeps normal verbose tool chatter off.
     - `/fast on|off` persists a session override. Use the Sessions UI `inherit` option to clear it and fall back to config defaults.
     - `/fast` is provider-specific: OpenAI/OpenAI Codex map it to `service_tier=priority` on native Responses endpoints, while direct public Anthropic requests, including OAuth-authenticated traffic sent to `api.anthropic.com`, map it to `service_tier=auto` or `standard_only`. See [OpenAI](/providers/openai) and [Anthropic](/providers/anthropic).
-    - Tool failure summaries are still shown when relevant, but detailed failure text is only included when `/verbose` is `on` or `full`.
+    - Tool failure summaries are still shown when relevant, but detailed failure text is only included when `/verbose full` is enabled.
     - `/reasoning`, `/verbose`, and `/trace` are risky in group settings: they may reveal internal reasoning, tool output, or plugin diagnostics you did not intend to expose. Prefer leaving them off, especially in group chats.
 
   </Accordion>

--- a/docs/tools/thinking.md
+++ b/docs/tools/thinking.md
@@ -84,7 +84,7 @@ title: "Thinking levels"
 - Inline directive affects only that message; session/global defaults apply otherwise.
 - Send `/verbose` (or `/verbose:`) with no argument to see the current verbose level.
 - When verbose is on, agents that emit structured tool results (Pi, other JSON agents) send each tool call back as its own metadata-only message, prefixed with `<emoji> <tool-name>: <arg>` when available. These tool summaries are sent as soon as each tool starts (separate bubbles), not as streaming deltas.
-- Tool failure summaries remain visible in normal mode, but raw error detail suffixes are hidden unless verbose is `on` or `full`.
+- Tool failure summaries remain visible in normal mode, but raw error detail suffixes are hidden unless verbose is `full`.
 - When verbose is `full`, tool outputs are also forwarded after completion (separate bubble, truncated to a safe length). If you toggle `/verbose on|full|off` while a run is in-flight, subsequent tool bubbles honor the new setting.
 - `agents.defaults.toolProgressDetail` controls the shape of `/verbose` tool summaries and progress-draft tool lines. Use `"explain"` (default) for compact human labels such as `🛠️ Exec: checking JS syntax`; use `"raw"` when you also want the raw command/detail appended for debugging. Per-agent `agents.list[].toolProgressDetail` overrides the default.
   - `explain`: `🛠️ Exec: check JS syntax for /tmp/app.js`

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -2428,6 +2428,36 @@ describe("CodexAppServerEventProjector", () => {
     });
   });
 
+  it("marks failed completed tool output as error progress", async () => {
+    const onToolResult = vi.fn();
+    const projector = await createProjector({
+      ...(await createParams()),
+      verboseLevel: "full",
+      onToolResult,
+    });
+
+    await projector.handleNotification(
+      turnCompleted([
+        {
+          type: "dynamicToolCall",
+          id: "tool-1",
+          namespace: null,
+          tool: "bash",
+          arguments: { command: "ls /tmp/missing" },
+          status: "failed",
+          contentItems: [{ type: "inputText", text: "No such file or directory" }],
+          success: false,
+          durationMs: 12,
+        },
+      ]),
+    );
+
+    expect(onToolResult).toHaveBeenNthCalledWith(2, {
+      text: "🛠️ `list files in /tmp/missing`\n```txt\nNo such file or directory\n```",
+      isError: true,
+    });
+  });
+
   it("uses a safe markdown fence for verbose tool output", async () => {
     const onToolResult = vi.fn();
     const projector = await createProjector({

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -1153,6 +1153,7 @@ export class CodexAppServerEventProjector {
       itemId,
       text: formatToolOutput(toolName, itemMeta(item, this.toolProgressDetailMode()), output),
       finalOutput: true,
+      isError: isNonSuccessItemStatus(itemStatus(item)),
     });
   }
 
@@ -1160,6 +1161,7 @@ export class CodexAppServerEventProjector {
     itemId: string;
     text: string;
     finalOutput?: boolean;
+    isError?: boolean;
   }): void {
     const text = params.text.trim();
     if (!text) {
@@ -1170,7 +1172,12 @@ export class CodexAppServerEventProjector {
       this.toolResultOutputItemIds.add(params.itemId);
     }
     try {
-      void Promise.resolve(this.params.onToolResult?.({ text })).catch(() => {
+      void Promise.resolve(
+        this.params.onToolResult?.({
+          text,
+          ...(params.isError === true ? { isError: true } : {}),
+        }),
+      ).catch(() => {
         // Tool progress delivery is best-effort and should not affect the turn.
       });
     } catch {
@@ -1331,6 +1338,7 @@ export class CodexAppServerEventProjector {
       itemId: params.id,
       text: formatToolOutput(params.name, undefined, text),
       finalOutput: true,
+      isError: params.isError,
     });
   }
 

--- a/extensions/discord/src/monitor/message-handler.draft-preview.ts
+++ b/extensions/discord/src/monitor/message-handler.draft-preview.ts
@@ -169,6 +169,9 @@ export function createDiscordDraftPreviewController(params: {
       if (!draftStream) {
         return;
       }
+      if (finalReplyDelivered) {
+        return;
+      }
       if (
         options?.toolName !== undefined &&
         !isChannelProgressDraftWorkToolName(options.toolName)
@@ -228,6 +231,9 @@ export function createDiscordDraftPreviewController(params: {
     },
     async pushReasoningProgress(text?: string) {
       if (!draftStream || discordStreamMode !== "progress" || !text) {
+        return;
+      }
+      if (finalReplyDelivered) {
         return;
       }
       reasoningProgressRawText = mergeReasoningProgressText(reasoningProgressRawText, text);

--- a/extensions/discord/src/monitor/message-handler.draft-preview.ts
+++ b/extensions/discord/src/monitor/message-handler.draft-preview.ts
@@ -77,6 +77,7 @@ export function createDiscordDraftPreviewController(params: {
   let draftText = "";
   let hasStreamedMessage = false;
   let finalizedViaPreviewMessage = false;
+  let finalReplyStarted = false;
   let finalReplyDelivered = false;
   const previewToolProgressEnabled =
     Boolean(draftStream) && resolveChannelStreamingPreviewToolProgress(params.discordConfig);
@@ -149,6 +150,9 @@ export function createDiscordDraftPreviewController(params: {
     get finalizedViaPreviewMessage() {
       return finalizedViaPreviewMessage;
     },
+    markFinalReplyStarted() {
+      finalReplyStarted = true;
+    },
     markFinalReplyDelivered() {
       finalReplyDelivered = true;
     },
@@ -169,7 +173,7 @@ export function createDiscordDraftPreviewController(params: {
       if (!draftStream) {
         return;
       }
-      if (finalReplyDelivered) {
+      if (finalReplyStarted || finalReplyDelivered) {
         return;
       }
       if (

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -99,6 +99,7 @@ type DispatchInboundParams = {
   dispatcher: {
     sendBlockReply: (payload: ReplyPayload) => boolean | Promise<boolean>;
     sendFinalReply: (payload: ReplyPayload) => boolean | Promise<boolean>;
+    waitForIdle: () => Promise<void>;
   };
   replyOptions?: {
     onReasoningStream?: (payload?: { text?: string }) => Promise<void> | void;
@@ -1744,6 +1745,38 @@ describe("processDiscordMessage draft streaming", () => {
 
     const updates = draftStream.update.mock.calls.map((call) => call[0]);
     expect(updates).toEqual(["Pinching\n\n🛠️ Exec\n• exec done"]);
+    expectPreviewEditContent("done");
+    expect(deliverDiscordReply).not.toHaveBeenCalled();
+  });
+
+  it("does not update Discord progress drafts after final answer delivery", async () => {
+    const draftStream = createMockDraftStreamForTest();
+
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      await params?.replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+      await params?.replyOptions?.onItemEvent?.({ progressText: "exec running" });
+      await params?.dispatcher.sendFinalReply({ text: "done" });
+      await params?.dispatcher.waitForIdle();
+      await params?.replyOptions?.onCommandOutput?.({
+        phase: "end",
+        title: "Exec",
+        name: "exec",
+        exitCode: 1,
+      });
+      return { queuedFinal: true, counts: { final: 1, tool: 0, block: 0 } };
+    });
+
+    const ctx = await createAutomaticSourceDeliveryContext({
+      discordConfig: {
+        maxLinesPerMessage: 5,
+        streaming: { mode: "progress", progress: { label: "Shelling" } },
+      },
+    });
+
+    await runProcessDiscordMessage(ctx);
+
+    const updates = draftStream.update.mock.calls.map((call) => call[0]);
+    expect(updates).toEqual(["Shelling\n\n🛠️ Exec\n• exec running"]);
     expectPreviewEditContent("done");
     expect(deliverDiscordReply).not.toHaveBeenCalled();
   });

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -1781,6 +1781,38 @@ describe("processDiscordMessage draft streaming", () => {
     expect(deliverDiscordReply).not.toHaveBeenCalled();
   });
 
+  it("does not update Discord progress drafts while final answer delivery is pending", async () => {
+    const draftStream = createMockDraftStreamForTest();
+
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      await params?.replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+      await params?.replyOptions?.onItemEvent?.({ progressText: "exec running" });
+      params?.dispatcher.sendFinalReply({ text: "done" });
+      await params?.replyOptions?.onCommandOutput?.({
+        phase: "end",
+        title: "Exec",
+        name: "exec",
+        exitCode: 1,
+      });
+      await params?.dispatcher.waitForIdle();
+      return { queuedFinal: true, counts: { final: 1, tool: 0, block: 0 } };
+    });
+
+    const ctx = await createAutomaticSourceDeliveryContext({
+      discordConfig: {
+        maxLinesPerMessage: 5,
+        streaming: { mode: "progress", progress: { label: "Shelling" } },
+      },
+    });
+
+    await runProcessDiscordMessage(ctx);
+
+    const updates = draftStream.update.mock.calls.map((call) => call[0]);
+    expect(updates).toEqual(["Shelling\n\n🛠️ Exec\n• exec running"]);
+    expectPreviewEditContent("done");
+    expect(deliverDiscordReply).not.toHaveBeenCalled();
+  });
+
   it("streams Discord tool progress for coding-profile message-tool-only guild replies", async () => {
     const draftStream = createMockDraftStreamForTest();
 

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -518,6 +518,7 @@ export async function processDiscordMessage(
       return;
     }
     finalReplyStartNotified = true;
+    draftPreview.markFinalReplyStarted();
     observer?.onFinalReplyStart?.();
   };
 
@@ -533,6 +534,9 @@ export async function processDiscordMessage(
         if (payload.isReasoning) {
           // Reasoning/thinking payloads should not be delivered to Discord.
           return;
+        }
+        if (isFinal) {
+          draftPreview.markFinalReplyStarted();
         }
         const finalText =
           isFinal && typeof payload.text === "string"

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -722,6 +722,7 @@ export async function processDiscordMessage(
         });
         replyReference.markSent();
         if (isFinal) {
+          draftPreview.markFinalReplyDelivered();
           observer?.onFinalReplyDelivered?.();
         }
       },

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -652,6 +652,35 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(deliverReplies).not.toHaveBeenCalled();
   });
 
+  it("suppresses text-only tool output after media-only final Telegram replies", async () => {
+    deliverInboundReplyWithMessageSendContext.mockResolvedValue({
+      status: "handled_visible",
+      delivery: {
+        messageIds: ["1002"],
+        visibleReplySent: true,
+      },
+    });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ mediaUrl: "file:///tmp/final.png" }, { kind: "final" });
+      await dispatcherOptions.deliver({ text: "late tool output" }, { kind: "tool" });
+      return { queuedFinal: true };
+    });
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "off",
+      telegramDeps: telegramDepsForTest,
+    });
+
+    expect(deliverInboundReplyWithMessageSendContext).toHaveBeenCalledTimes(1);
+    const outbound = expectRecordFields(mockCallArg(deliverInboundReplyWithMessageSendContext), {
+      channel: "telegram",
+      info: { kind: "final" },
+    });
+    expectRecordFields(outbound.payload, { mediaUrl: "file:///tmp/final.png" });
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
   it("skips answer draft stream for same-chat selected quotes", async () => {
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
       await dispatcherOptions.deliver({ text: "Hello", replyToId: "1001" }, { kind: "final" });

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -1702,6 +1702,38 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expectDeliveredReply(0, { text: "Branch is up to date" });
   });
 
+  it("does not restart progress drafts for command output while final answer delivery is pending", async () => {
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+        const finalDelivery = dispatcherOptions.deliver(
+          { text: "Branch is up to date" },
+          { kind: "final" },
+        );
+        await replyOptions?.onCommandOutput?.({
+          phase: "end",
+          title: "Exec",
+          name: "exec",
+          status: "failed",
+          exitCode: 1,
+        });
+        await finalDelivery;
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
+    });
+
+    expect(answerDraftStream.update).toHaveBeenCalledTimes(1);
+    expect(answerDraftStream.update).toHaveBeenCalledWith("Shelling\n\n`🛠️ Exec`");
+    expectDeliveredReply(0, { text: "Branch is up to date" });
+  });
+
   it("uses the transcript final when progress-mode final text is truncated", async () => {
     setupDraftStreams({ answerMessageId: 2001 });
     const fullAnswer =

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -943,6 +943,24 @@ describe("dispatchTelegramMessage draft streaming", () => {
     });
   });
 
+  it("suppresses text-only tool payloads delivered after the final answer", async () => {
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: "Final answer" }, { kind: "final" });
+      await dispatcherOptions.deliver(
+        { text: "failed command output", isError: true },
+        { kind: "tool" },
+      );
+      return { queuedFinal: true };
+    });
+
+    await dispatchWithContext({ context: createContext() });
+
+    expect(answerDraftStream.update).toHaveBeenCalledTimes(1);
+    expect(answerDraftStream.update).toHaveBeenCalledWith("Final answer");
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
   it("mirrors preview-finalized finals into the session transcript", async () => {
     setupDraftStreams({ answerMessageId: 2001 });
     const context = createContext();
@@ -1612,6 +1630,34 @@ describe("dispatchTelegramMessage draft streaming", () => {
         await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
         await dispatcherOptions.deliver({ text: "Branch is up to date" }, { kind: "final" });
         await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
+    });
+
+    expect(answerDraftStream.update).toHaveBeenCalledTimes(1);
+    expect(answerDraftStream.update).toHaveBeenCalledWith("Shelling\n\n`🛠️ Exec`");
+    expectDeliveredReply(0, { text: "Branch is up to date" });
+  });
+
+  it("does not restart progress drafts for command output after final answer delivery", async () => {
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+        await dispatcherOptions.deliver({ text: "Branch is up to date" }, { kind: "final" });
+        await replyOptions?.onCommandOutput?.({
+          phase: "end",
+          title: "Exec",
+          name: "exec",
+          status: "failed",
+          exitCode: 1,
+        });
         return { queuedFinal: true };
       },
     );

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -669,6 +669,9 @@ export const dispatchTelegramMessage = async ({
     if (!answerLane.stream) {
       return false;
     }
+    if (answerLane.finalized) {
+      return false;
+    }
     if (options?.toolName !== undefined && !isChannelProgressDraftWorkToolName(options.toolName)) {
       return false;
     }
@@ -1364,6 +1367,14 @@ export const dispatchTelegramMessage = async ({
                     );
                     const segments = split.segments;
                     const reply = resolveSendableOutboundReplyParts(effectivePayload);
+                    if (
+                      info.kind === "tool" &&
+                      answerLane.finalized &&
+                      !reply.hasMedia &&
+                      !hasExecApprovalPayload(effectivePayload)
+                    ) {
+                      return;
+                    }
 
                     const deliverFinalAnswerText = async (
                       answerPayload: ReplyPayload,

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -662,6 +662,7 @@ export const dispatchTelegramMessage = async ({
       await renderProgressDraft({ flush: true });
     },
   });
+  let finalAnswerDeliveryStarted = false;
   let finalAnswerDelivered = false;
   const pushStreamToolProgress = async (
     line?: string | ChannelProgressDraftLine,
@@ -670,7 +671,7 @@ export const dispatchTelegramMessage = async ({
     if (!answerLane.stream) {
       return false;
     }
-    if (answerLane.finalized || finalAnswerDelivered) {
+    if (answerLane.finalized || finalAnswerDeliveryStarted || finalAnswerDelivered) {
       return false;
     }
     if (options?.toolName !== undefined && !isChannelProgressDraftWorkToolName(options.toolName)) {
@@ -1352,9 +1353,6 @@ export const dispatchTelegramMessage = async ({
                     }
                     const effectivePayload = deduped;
 
-                    if (info.kind === "final") {
-                      await enqueueDraftLaneEvent(async () => {});
-                    }
                     if (
                       shouldSuppressLocalTelegramExecApprovalPrompt({
                         cfg,
@@ -1372,9 +1370,15 @@ export const dispatchTelegramMessage = async ({
                     );
                     const segments = split.segments;
                     const reply = resolveSendableOutboundReplyParts(effectivePayload);
+                    if (info.kind === "final" && (reply.text.length > 0 || reply.hasMedia)) {
+                      finalAnswerDeliveryStarted = true;
+                    }
+                    if (info.kind === "final") {
+                      await enqueueDraftLaneEvent(async () => {});
+                    }
                     if (
                       info.kind === "tool" &&
-                      finalAnswerDelivered &&
+                      (finalAnswerDeliveryStarted || finalAnswerDelivered) &&
                       !reply.hasMedia &&
                       !hasExecApprovalPayload(effectivePayload)
                     ) {

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -662,6 +662,7 @@ export const dispatchTelegramMessage = async ({
       await renderProgressDraft({ flush: true });
     },
   });
+  let finalAnswerDelivered = false;
   const pushStreamToolProgress = async (
     line?: string | ChannelProgressDraftLine,
     options?: { toolName?: string; startImmediately?: boolean },
@@ -669,7 +670,7 @@ export const dispatchTelegramMessage = async ({
     if (!answerLane.stream) {
       return false;
     }
-    if (answerLane.finalized) {
+    if (answerLane.finalized || finalAnswerDelivered) {
       return false;
     }
     if (options?.toolName !== undefined && !isChannelProgressDraftWorkToolName(options.toolName)) {
@@ -1246,8 +1247,12 @@ export const dispatchTelegramMessage = async ({
         resetDraftLaneState(answerLane);
       }
       const delivered = await sendPayload(applyTextToPayload(payload, text), { durable: true });
+      if (!delivered) {
+        return { kind: "skipped" };
+      }
       answerLane.finalized = true;
-      return delivered ? { kind: "sent" } : { kind: "skipped" };
+      finalAnswerDelivered = true;
+      return { kind: "sent" };
     };
     const resolveTranscriptBackedFinalText = async (text: string): Promise<string> =>
       await resolveTranscriptBackedChannelFinalText({
@@ -1369,7 +1374,7 @@ export const dispatchTelegramMessage = async ({
                     const reply = resolveSendableOutboundReplyParts(effectivePayload);
                     if (
                       info.kind === "tool" &&
-                      answerLane.finalized &&
+                      finalAnswerDelivered &&
                       !reply.hasMedia &&
                       !hasExecApprovalPayload(effectivePayload)
                     ) {
@@ -1386,13 +1391,17 @@ export const dispatchTelegramMessage = async ({
                         return deliverProgressModeFinalAnswer(answerPayload, finalText);
                       }
                       await rotateAnswerLaneAfterToolProgress();
-                      return deliverLaneText({
+                      const result = await deliverLaneText({
                         laneName: "answer",
                         text: finalText,
                         payload: answerPayload,
                         infoKind: "final",
                         buttons,
                       });
+                      if (result.kind !== "skipped") {
+                        finalAnswerDelivered = true;
+                      }
+                      return result;
                     };
 
                     const flushBufferedFinalAnswer = async () => {
@@ -1495,6 +1504,9 @@ export const dispatchTelegramMessage = async ({
                           durable: info.kind === "final",
                         });
                       }
+                      if (info.kind === "final" && delivered) {
+                        finalAnswerDelivered = true;
+                      }
                       if (info.kind === "final") {
                         await flushBufferedFinalAnswer();
                       }
@@ -1518,6 +1530,9 @@ export const dispatchTelegramMessage = async ({
                     const delivered = await sendPayload(effectivePayload, {
                       durable: info.kind === "final",
                     });
+                    if (info.kind === "final" && delivered) {
+                      finalAnswerDelivered = true;
+                    }
                     if (info.kind === "final") {
                       await flushBufferedFinalAnswer();
                     }

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -3177,6 +3177,7 @@ export async function runEmbeddedAttempt(
           toolResultFormat: params.toolResultFormat,
           shouldEmitToolResult: params.shouldEmitToolResult,
           shouldEmitToolOutput: params.shouldEmitToolOutput,
+          sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
           onToolResult: params.onToolResult,
           onReasoningStream: params.onReasoningStream,
           onReasoningEnd: params.onReasoningEnd,

--- a/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
@@ -344,7 +344,7 @@ describe("buildEmbeddedRunPayloads", () => {
     });
   });
 
-  it("adds tool error fallback when the assistant only invoked tools and verbose mode is on", () => {
+  it("adds compact tool error fallback when the assistant only invoked tools and verbose mode is on", () => {
     const payloads = buildPayloads({
       lastAssistant: makeAssistant({
         stopReason: "toolUse",
@@ -364,7 +364,7 @@ describe("buildEmbeddedRunPayloads", () => {
 
     expectSingleToolErrorPayload(payloads, {
       title: "Exec",
-      detail: "code 1",
+      absentDetail: "code 1",
     });
   });
 
@@ -582,10 +582,22 @@ describe("buildEmbeddedRunPayloads", () => {
     expectSinglePayloadSummary(payloads, { text: warningText ?? "" });
   });
 
-  it("includes non-recoverable tool error details when verbose mode is on", () => {
+  it("keeps non-recoverable tool errors compact when verbose mode is on", () => {
     const payloads = buildPayloads({
       lastToolError: { toolName: "browser", error: "connection timeout" },
       verboseLevel: "on",
+    });
+
+    expectSingleToolErrorPayload(payloads, {
+      title: "Browser",
+      absentDetail: "connection timeout",
+    });
+  });
+
+  it("includes non-recoverable tool error details when verbose mode is full", () => {
+    const payloads = buildPayloads({
+      lastToolError: { toolName: "browser", error: "connection timeout" },
+      verboseLevel: "full",
     });
 
     expectSingleToolErrorPayload(payloads, {

--- a/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
@@ -544,58 +544,6 @@ describe("buildEmbeddedRunPayloads", () => {
     expectSinglePayloadSummary(payloads, { text });
   });
 
-  it("suppresses exec warnings when assistant output acknowledges a failed exit status", () => {
-    const text = "Done — intentional missing-file check, exit `1`.";
-    const payloads = buildPayloads({
-      assistantTexts: [text],
-      lastAssistant: { stopReason: "end_turn" } as unknown as AssistantMessage,
-      lastToolError: {
-        toolName: "bash",
-        meta: "cat /tmp/openclaw-intentional-failure-demo-final-round",
-        error: "cat: /tmp/openclaw-intentional-failure-demo-final-round: No such file or directory",
-      },
-      verboseLevel: "on",
-    });
-
-    expectSinglePayloadSummary(payloads, { text });
-  });
-
-  it("does not suppress write warnings for unrelated failure text", () => {
-    const text = "The tests failed, so I stopped there.";
-    const payloads = buildPayloads({
-      assistantTexts: [text],
-      lastAssistant: { stopReason: "end_turn" } as unknown as AssistantMessage,
-      lastToolError: {
-        toolName: "write",
-        error: "file missing",
-      },
-      verboseLevel: "on",
-    });
-
-    expect(payloads).toHaveLength(2);
-    expect(payloads[0]?.text).toBe(text);
-    expect(payloads[1]?.isError).toBe(true);
-    expect(payloads[1]?.text).toContain("Write");
-  });
-
-  it("does not suppress exec warnings for unrelated failure text", () => {
-    const text = "The tests failed, so I stopped there.";
-    const payloads = buildPayloads({
-      assistantTexts: [text],
-      lastAssistant: { stopReason: "end_turn" } as unknown as AssistantMessage,
-      lastToolError: {
-        toolName: "bash",
-        error: "command failed",
-      },
-      verboseLevel: "on",
-    });
-
-    expect(payloads).toHaveLength(2);
-    expect(payloads[0]?.text).toBe(text);
-    expect(payloads[1]?.isError).toBe(true);
-    expect(payloads[1]?.text).toContain("Bash");
-  });
-
   it("does not treat session_status read failures as mutating when explicitly flagged", () => {
     const payloads = buildPayloads({
       assistantTexts: ["Status loaded."],

--- a/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
@@ -544,6 +544,58 @@ describe("buildEmbeddedRunPayloads", () => {
     expectSinglePayloadSummary(payloads, { text });
   });
 
+  it("suppresses exec warnings when assistant output acknowledges a failed exit status", () => {
+    const text = "Done — intentional missing-file check, exit `1`.";
+    const payloads = buildPayloads({
+      assistantTexts: [text],
+      lastAssistant: { stopReason: "end_turn" } as unknown as AssistantMessage,
+      lastToolError: {
+        toolName: "bash",
+        meta: "cat /tmp/openclaw-intentional-failure-demo-final-round",
+        error: "cat: /tmp/openclaw-intentional-failure-demo-final-round: No such file or directory",
+      },
+      verboseLevel: "on",
+    });
+
+    expectSinglePayloadSummary(payloads, { text });
+  });
+
+  it("does not suppress write warnings for unrelated failure text", () => {
+    const text = "The tests failed, so I stopped there.";
+    const payloads = buildPayloads({
+      assistantTexts: [text],
+      lastAssistant: { stopReason: "end_turn" } as unknown as AssistantMessage,
+      lastToolError: {
+        toolName: "write",
+        error: "file missing",
+      },
+      verboseLevel: "on",
+    });
+
+    expect(payloads).toHaveLength(2);
+    expect(payloads[0]?.text).toBe(text);
+    expect(payloads[1]?.isError).toBe(true);
+    expect(payloads[1]?.text).toContain("Write");
+  });
+
+  it("does not suppress exec warnings for unrelated failure text", () => {
+    const text = "The tests failed, so I stopped there.";
+    const payloads = buildPayloads({
+      assistantTexts: [text],
+      lastAssistant: { stopReason: "end_turn" } as unknown as AssistantMessage,
+      lastToolError: {
+        toolName: "bash",
+        error: "command failed",
+      },
+      verboseLevel: "on",
+    });
+
+    expect(payloads).toHaveLength(2);
+    expect(payloads[0]?.text).toBe(text);
+    expect(payloads[1]?.isError).toBe(true);
+    expect(payloads[1]?.text).toContain("Bash");
+  });
+
   it("does not treat session_status read failures as mutating when explicitly flagged", () => {
     const payloads = buildPayloads({
       assistantTexts: ["Status loaded."],

--- a/src/agents/pi-embedded-runner/run/payloads.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.test.ts
@@ -430,10 +430,22 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
     });
   });
 
-  it("shows exec tool errors when verbose mode is on", () => {
+  it("keeps exec tool errors compact when verbose mode is on", () => {
     const payloads = buildPayloads({
       lastToolError: { toolName: "exec", error: "command failed" },
       verboseLevel: "on",
+    });
+
+    expectSingleToolErrorPayload(payloads, {
+      title: "Exec",
+      absentDetail: "command failed",
+    });
+  });
+
+  it("shows exec tool error details when verbose mode is full", () => {
+    const payloads = buildPayloads({
+      lastToolError: { toolName: "exec", error: "command failed" },
+      verboseLevel: "full",
     });
 
     expectSingleToolErrorPayload(payloads, {
@@ -456,10 +468,10 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
 
   it.each([
     {
-      name: "includes details for mutating tool failures when verbose is on",
+      name: "keeps mutating tool failures compact when verbose is on",
       verboseLevel: "on" as const,
-      detail: "permission denied",
-      absentDetail: undefined,
+      detail: undefined,
+      absentDetail: "permission denied",
     },
     {
       name: "includes details for mutating tool failures when verbose is full",

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -101,7 +101,7 @@ function hasExplicitMutatingToolFailureAcknowledgement(text: string): boolean {
 }
 
 function isVerboseToolDetailEnabled(level?: VerboseLevel): boolean {
-  return level === "on" || level === "full";
+  return level === "full";
 }
 
 function resolveRawAssistantAnswerText(lastAssistant: AssistantMessage | undefined): string {

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -71,6 +71,8 @@ const MUTATING_FAILURE_ERROR_WHILE_ACTION_PATTERN = new RegExp(
   `\\b(?:hit|encountered|ran into)\\b.{0,60}\\berror\\b.{0,100}\\b(?:while|trying to|when)\\b.{0,100}\\b${MUTATING_FAILURE_ACTION_PATTERN}\\b`,
   "u",
 );
+const EXEC_FAILURE_TERMINAL_STATUS_PATTERN =
+  /\b(?:(?:failed|failure|errored|exited?)\s+(?:with\s+)?(?:exit\s+)?(?:code\s+)?`?[1-9]\d*`?|exit(?:ed)?\s+(?:with\s+)?(?:code\s+)?`?[1-9]\d*`?|non[- ]zero\s+(?:exit\s+)?(?:status|code))(?=$|\W)/u;
 const DID_NOT_FAIL_PATTERN = /\b(?:did not|didn't)\s+fail\b/u;
 const NEGATED_FAILURE_PATTERN = /\b(?:no|not|without)\s+(?:failures?|errors?)\b/u;
 
@@ -79,7 +81,7 @@ function isRecoverableToolError(error: string | undefined): boolean {
   return RECOVERABLE_TOOL_ERROR_KEYWORDS.some((keyword) => errorLower.includes(keyword));
 }
 
-function hasExplicitMutatingToolFailureAcknowledgement(text: string): boolean {
+function hasExplicitMutatingToolFailureAcknowledgement(text: string, toolName?: string): boolean {
   const normalizedText = normalizeTextForComparison(text);
   if (!normalizedText) {
     return false;
@@ -96,7 +98,10 @@ function hasExplicitMutatingToolFailureAcknowledgement(text: string): boolean {
   return (
     MUTATING_FAILURE_ACTION_THEN_FAILURE_PATTERN.test(normalizedText) ||
     MUTATING_FAILURE_FAILURE_THEN_ACTION_PATTERN.test(normalizedText) ||
-    MUTATING_FAILURE_ERROR_WHILE_ACTION_PATTERN.test(normalizedText)
+    MUTATING_FAILURE_ERROR_WHILE_ACTION_PATTERN.test(normalizedText) ||
+    (toolName !== undefined &&
+      isExecLikeToolName(toolName) &&
+      EXEC_FAILURE_TERMINAL_STATUS_PATTERN.test(normalizedText))
   );
 }
 
@@ -464,7 +469,10 @@ export function buildEmbeddedRunPayloads(params: {
       replyToCurrent,
     });
     hasUserFacingAssistantReply = true;
-    if (cleanedText && hasExplicitMutatingToolFailureAcknowledgement(cleanedText)) {
+    if (
+      cleanedText &&
+      hasExplicitMutatingToolFailureAcknowledgement(cleanedText, params.lastToolError?.toolName)
+    ) {
       hasUserFacingFailureAcknowledgement = true;
     }
   }

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -71,8 +71,6 @@ const MUTATING_FAILURE_ERROR_WHILE_ACTION_PATTERN = new RegExp(
   `\\b(?:hit|encountered|ran into)\\b.{0,60}\\berror\\b.{0,100}\\b(?:while|trying to|when)\\b.{0,100}\\b${MUTATING_FAILURE_ACTION_PATTERN}\\b`,
   "u",
 );
-const EXEC_FAILURE_TERMINAL_STATUS_PATTERN =
-  /\b(?:(?:failed|failure|errored|exited?)\s+(?:with\s+)?(?:exit\s+)?(?:code\s+)?`?[1-9]\d*`?|exit(?:ed)?\s+(?:with\s+)?(?:code\s+)?`?[1-9]\d*`?|non[- ]zero\s+(?:exit\s+)?(?:status|code))(?=$|\W)/u;
 const DID_NOT_FAIL_PATTERN = /\b(?:did not|didn't)\s+fail\b/u;
 const NEGATED_FAILURE_PATTERN = /\b(?:no|not|without)\s+(?:failures?|errors?)\b/u;
 
@@ -81,7 +79,7 @@ function isRecoverableToolError(error: string | undefined): boolean {
   return RECOVERABLE_TOOL_ERROR_KEYWORDS.some((keyword) => errorLower.includes(keyword));
 }
 
-function hasExplicitMutatingToolFailureAcknowledgement(text: string, toolName?: string): boolean {
+function hasExplicitMutatingToolFailureAcknowledgement(text: string): boolean {
   const normalizedText = normalizeTextForComparison(text);
   if (!normalizedText) {
     return false;
@@ -98,10 +96,7 @@ function hasExplicitMutatingToolFailureAcknowledgement(text: string, toolName?: 
   return (
     MUTATING_FAILURE_ACTION_THEN_FAILURE_PATTERN.test(normalizedText) ||
     MUTATING_FAILURE_FAILURE_THEN_ACTION_PATTERN.test(normalizedText) ||
-    MUTATING_FAILURE_ERROR_WHILE_ACTION_PATTERN.test(normalizedText) ||
-    (toolName !== undefined &&
-      isExecLikeToolName(toolName) &&
-      EXEC_FAILURE_TERMINAL_STATUS_PATTERN.test(normalizedText))
+    MUTATING_FAILURE_ERROR_WHILE_ACTION_PATTERN.test(normalizedText)
   );
 }
 
@@ -469,10 +464,7 @@ export function buildEmbeddedRunPayloads(params: {
       replyToCurrent,
     });
     hasUserFacingAssistantReply = true;
-    if (
-      cleanedText &&
-      hasExplicitMutatingToolFailureAcknowledgement(cleanedText, params.lastToolError?.toolName)
-    ) {
+    if (cleanedText && hasExplicitMutatingToolFailureAcknowledgement(cleanedText)) {
       hasUserFacingFailureAcknowledgement = true;
     }
   }

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.suppresses-message-end-block-replies-message-tool.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.suppresses-message-end-block-replies-message-tool.test.ts
@@ -1,6 +1,7 @@
 import type { AssistantMessage } from "@earendil-works/pi-ai";
 import { describe, expect, it, vi } from "vitest";
 import {
+  createSubscribedSessionHarness,
   createStubSessionHarness,
   emitAssistantTextDelta,
   emitAssistantTextEnd,
@@ -93,6 +94,34 @@ describe("subscribeEmbeddedPiSession", () => {
 
     expect(subscription.didSendViaMessagingTool()).toBe(true);
     expect(subscription.getMessagingToolSentMediaUrls()).toEqual(["file:///tmp/render.mp4"]);
+  });
+
+  it("suppresses text-only tool summaries after message-tool-only delivery", async () => {
+    const onToolResult = vi.fn();
+    const { emit } = createSubscribedSessionHarness({
+      runId: "run-message-tool-progress",
+      verboseLevel: "on",
+      sourceReplyDeliveryMode: "message_tool_only",
+      onToolResult,
+    });
+
+    await emitMessageToolLifecycle({
+      emit,
+      toolCallId: "tool-message-final",
+      message: "Final answer sent through the message tool.",
+      result: "ok",
+    });
+    onToolResult.mockClear();
+
+    emit({
+      type: "tool_execution_start",
+      toolName: "exec",
+      toolCallId: "tool-exec-late",
+      args: { command: "false" },
+    });
+    await Promise.resolve();
+
+    expect(onToolResult).not.toHaveBeenCalled();
   });
 
   it("does not suppress message_end replies when message tool reports error", async () => {

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -550,6 +550,18 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
       result,
       params.builtinToolNames,
     );
+    if (
+      params.sourceReplyDeliveryMode === "message_tool_only" &&
+      cleanedText &&
+      filteredMediaUrls.length === 0 &&
+      hasCommittedMessagingToolDeliveryEvidence({
+        messagingToolSentTexts,
+        messagingToolSentMediaUrls,
+        messagingToolSentTargets,
+      })
+    ) {
+      return;
+    }
     if (!cleanedText && filteredMediaUrls.length === 0) {
       return;
     }

--- a/src/agents/pi-embedded-subscribe.types.ts
+++ b/src/agents/pi-embedded-subscribe.types.ts
@@ -1,5 +1,8 @@
 import type { AgentSession } from "@earendil-works/pi-coding-agent";
-import type { PartialReplyPayload } from "../auto-reply/get-reply-options.types.js";
+import type {
+  PartialReplyPayload,
+  SourceReplyDeliveryMode,
+} from "../auto-reply/get-reply-options.types.js";
 import type { ReplyPayload } from "../auto-reply/reply-payload.js";
 import type { ReasoningLevel, ThinkLevel, VerboseLevel } from "../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -30,6 +33,7 @@ export type SubscribeEmbeddedPiSessionParams = {
   toolProgressDetail?: ToolProgressDetailMode;
   shouldEmitToolResult?: () => boolean;
   shouldEmitToolOutput?: () => boolean;
+  sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
   onToolResult?: (payload: ReplyPayload) => void | Promise<void>;
   onReasoningStream?: (payload: { text?: string; mediaUrls?: string[] }) => void | Promise<void>;
   /** Called when a thinking/reasoning block ends (</think> tag processed). */

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -2980,6 +2980,77 @@ describe("runAgentTurnWithFallback", () => {
     });
   });
 
+  it("suppresses progress callbacks after message-tool-only delivery completes", async () => {
+    const onItemEvent = vi.fn();
+    const onCommandOutput = vi.fn();
+    state.runEmbeddedPiAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
+      await params.onAgentEvent?.({
+        stream: "item",
+        data: {
+          itemId: "tool-message-1",
+          phase: "end",
+          kind: "tool",
+          title: "message",
+          name: "message",
+          status: "completed",
+        },
+      });
+      await params.onAgentEvent?.({
+        stream: "command_output",
+        data: {
+          itemId: "command:exec-1",
+          phase: "end",
+          title: "command false",
+          toolCallId: "exec-1",
+          name: "exec",
+          output: "failed command output",
+          status: "failed",
+          exitCode: 1,
+        },
+      });
+      return { payloads: [{ text: "NO_REPLY" }], meta: {} };
+    });
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const followupRun = createFollowupRun();
+    followupRun.run.sourceReplyDeliveryMode = "message_tool_only";
+    await runAgentTurnWithFallback({
+      commandBody: "hello",
+      followupRun,
+      sessionCtx: {
+        Provider: "discord",
+        MessageSid: "msg",
+      } as unknown as TemplateContext,
+      opts: {
+        onItemEvent,
+        onCommandOutput,
+      } satisfies GetReplyOptions,
+      typingSignals: createMockTypingSignaler(),
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      pendingToolTasks: new Set(),
+      resetSessionAfterCompactionFailure: async () => false,
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      isHeartbeat: false,
+      sessionKey: "main",
+      getActiveSessionEntry: () => undefined,
+      resolvedVerboseLevel: "on",
+    });
+
+    expect(onItemEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "message",
+        phase: "end",
+        status: "completed",
+      }),
+    );
+    expect(onCommandOutput).not.toHaveBeenCalled();
+  });
+
   it("keeps compaction start notices silent by default", async () => {
     const onBlockReply = vi.fn();
     state.runEmbeddedPiAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -2981,9 +2981,119 @@ describe("runAgentTurnWithFallback", () => {
   });
 
   it("suppresses progress callbacks after message-tool-only delivery completes", async () => {
+    let releaseItemEvent: (() => void) | undefined;
+    const itemEventGate = new Promise<void>((resolve) => {
+      releaseItemEvent = resolve;
+    });
+    let markItemEventStarted: (() => void) | undefined;
+    const itemEventStarted = new Promise<void>((resolve) => {
+      markItemEventStarted = resolve;
+    });
+    const onItemEvent = vi.fn(async () => {
+      markItemEventStarted?.();
+      await itemEventGate;
+    });
+    const onCommandOutput = vi.fn();
+    state.runEmbeddedPiAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
+      await params.onAgentEvent?.({
+        stream: "tool",
+        data: {
+          phase: "start",
+          name: "message",
+          toolCallId: "message-1",
+          args: {
+            action: "send",
+            message: "Visible reply",
+          },
+        },
+      });
+      const itemEventPromise = params.onAgentEvent?.({
+        stream: "item",
+        data: {
+          itemId: "tool-message-1",
+          phase: "end",
+          kind: "tool",
+          title: "message",
+          name: "message",
+          toolCallId: "message-1",
+          status: "completed",
+        },
+      });
+      await itemEventStarted;
+      await params.onAgentEvent?.({
+        stream: "command_output",
+        data: {
+          itemId: "command:exec-1",
+          phase: "end",
+          title: "command false",
+          toolCallId: "exec-1",
+          name: "exec",
+          output: "failed command output",
+          status: "failed",
+          exitCode: 1,
+        },
+      });
+      releaseItemEvent?.();
+      await itemEventPromise;
+      return { payloads: [{ text: "NO_REPLY" }], meta: {} };
+    });
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const followupRun = createFollowupRun();
+    followupRun.run.sourceReplyDeliveryMode = "message_tool_only";
+    await runAgentTurnWithFallback({
+      commandBody: "hello",
+      followupRun,
+      sessionCtx: {
+        Provider: "discord",
+        MessageSid: "msg",
+      } as unknown as TemplateContext,
+      opts: {
+        onItemEvent,
+        onCommandOutput,
+      } satisfies GetReplyOptions,
+      typingSignals: createMockTypingSignaler(),
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      pendingToolTasks: new Set(),
+      resetSessionAfterCompactionFailure: async () => false,
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      isHeartbeat: false,
+      sessionKey: "main",
+      getActiveSessionEntry: () => undefined,
+      resolvedVerboseLevel: "on",
+    });
+
+    expect(onItemEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "message",
+        phase: "end",
+        status: "completed",
+      }),
+    );
+    expect(onCommandOutput).not.toHaveBeenCalled();
+  });
+
+  it("keeps progress callbacks active after message-tool-only reads", async () => {
     const onItemEvent = vi.fn();
     const onCommandOutput = vi.fn();
     state.runEmbeddedPiAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
+      await params.onAgentEvent?.({
+        stream: "tool",
+        data: {
+          phase: "start",
+          name: "message",
+          toolCallId: "message-read-1",
+          args: {
+            action: "read",
+            threadId: "thread-1",
+          },
+        },
+      });
       await params.onAgentEvent?.({
         stream: "item",
         data: {
@@ -2992,6 +3102,7 @@ describe("runAgentTurnWithFallback", () => {
           kind: "tool",
           title: "message",
           name: "message",
+          toolCallId: "message-read-1",
           status: "completed",
         },
       });
@@ -3048,7 +3159,12 @@ describe("runAgentTurnWithFallback", () => {
         status: "completed",
       }),
     );
-    expect(onCommandOutput).not.toHaveBeenCalled();
+    expect(onCommandOutput).toHaveBeenCalledWith(
+      expect.objectContaining({
+        output: "failed command output",
+        status: "failed",
+      }),
+    );
   });
 
   it("keeps compaction start notices silent by default", async () => {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -43,6 +43,7 @@ import {
   isTransientHttpError,
 } from "../../agents/pi-embedded-helpers.js";
 import { sanitizeUserFacingText } from "../../agents/pi-embedded-helpers/sanitize-user-facing-text.js";
+import { isMessagingTool } from "../../agents/pi-embedded-messaging.js";
 import { runEmbeddedPiAgent } from "../../agents/pi-embedded.js";
 import { buildAgentRuntimeOutcomePlan } from "../../agents/runtime-plan/build.js";
 import {
@@ -1523,6 +1524,11 @@ export async function runAgentTurnWithFallback(params: {
             directlySentBlockKeys,
           })
         : undefined;
+      let messageToolOnlyDeliveryCompleted = false;
+      const sourceRepliesAreToolOnly =
+        params.followupRun.run.sourceReplyDeliveryMode === "message_tool_only";
+      const shouldSuppressProgressAfterMessageToolDelivery = () =>
+        sourceRepliesAreToolOnly && messageToolOnlyDeliveryCompleted;
       const onToolResult = params.opts?.onToolResult;
       const outcomePlan = buildAgentRuntimeOutcomePlan();
       const runLane = CommandLane.Main;
@@ -1871,7 +1877,7 @@ export async function runAgentTurnWithFallback(params: {
                   }
                   // Trigger typing when tools start executing.
                   // Must await to ensure typing indicator starts before tool summaries are emitted.
-                  if (evt.stream === "tool") {
+                  if (evt.stream === "tool" && !shouldSuppressProgressAfterMessageToolDelivery()) {
                     const phase = readStringValue(evt.data.phase) ?? "";
                     const name = readStringValue(evt.data.name);
                     if (phase === "start" || phase === "update") {
@@ -1894,14 +1900,26 @@ export async function runAgentTurnWithFallback(params: {
                     evt.stream === "item" &&
                     evt.data.suppressChannelProgress === true &&
                     Boolean(params.opts?.onToolStart);
-                  if (evt.stream === "item" && !suppressItemChannelProgress) {
+                  const itemPhase = evt.stream === "item" ? readStringValue(evt.data.phase) : "";
+                  const itemName = evt.stream === "item" ? readStringValue(evt.data.name) : "";
+                  const itemStatus = evt.stream === "item" ? readStringValue(evt.data.status) : "";
+                  const completedMessageToolDelivery =
+                    sourceRepliesAreToolOnly &&
+                    itemPhase === "end" &&
+                    itemStatus === "completed" &&
+                    isMessagingTool(itemName ?? "");
+                  if (
+                    evt.stream === "item" &&
+                    !suppressItemChannelProgress &&
+                    !shouldSuppressProgressAfterMessageToolDelivery()
+                  ) {
                     await params.opts?.onItemEvent?.({
                       itemId: readStringValue(evt.data.itemId),
                       kind: readStringValue(evt.data.kind),
                       title: readStringValue(evt.data.title),
-                      name: readStringValue(evt.data.name),
-                      phase: readStringValue(evt.data.phase),
-                      status: readStringValue(evt.data.status),
+                      name: itemName,
+                      phase: itemPhase,
+                      status: itemStatus,
                       summary: readStringValue(evt.data.summary),
                       progressText: readStringValue(evt.data.progressText),
                       meta: readStringValue(evt.data.meta),
@@ -1909,7 +1927,10 @@ export async function runAgentTurnWithFallback(params: {
                       approvalSlug: readStringValue(evt.data.approvalSlug),
                     });
                   }
-                  if (evt.stream === "plan") {
+                  if (completedMessageToolDelivery) {
+                    messageToolOnlyDeliveryCompleted = true;
+                  }
+                  if (evt.stream === "plan" && !shouldSuppressProgressAfterMessageToolDelivery()) {
                     await params.opts?.onPlanUpdate?.({
                       phase: readStringValue(evt.data.phase),
                       title: readStringValue(evt.data.title),
@@ -1920,7 +1941,10 @@ export async function runAgentTurnWithFallback(params: {
                       source: readStringValue(evt.data.source),
                     });
                   }
-                  if (evt.stream === "approval") {
+                  if (
+                    evt.stream === "approval" &&
+                    !shouldSuppressProgressAfterMessageToolDelivery()
+                  ) {
                     await params.opts?.onApprovalEvent?.({
                       phase: readStringValue(evt.data.phase),
                       kind: readStringValue(evt.data.kind),
@@ -1937,7 +1961,10 @@ export async function runAgentTurnWithFallback(params: {
                       message: readStringValue(evt.data.message),
                     });
                   }
-                  if (evt.stream === "command_output") {
+                  if (
+                    evt.stream === "command_output" &&
+                    !shouldSuppressProgressAfterMessageToolDelivery()
+                  ) {
                     await params.opts?.onCommandOutput?.({
                       itemId: readStringValue(evt.data.itemId),
                       phase: readStringValue(evt.data.phase),
@@ -1955,7 +1982,7 @@ export async function runAgentTurnWithFallback(params: {
                       cwd: readStringValue(evt.data.cwd),
                     });
                   }
-                  if (evt.stream === "patch") {
+                  if (evt.stream === "patch" && !shouldSuppressProgressAfterMessageToolDelivery()) {
                     await params.opts?.onPatchSummary?.({
                       itemId: readStringValue(evt.data.itemId),
                       phase: readStringValue(evt.data.phase),

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -43,7 +43,7 @@ import {
   isTransientHttpError,
 } from "../../agents/pi-embedded-helpers.js";
 import { sanitizeUserFacingText } from "../../agents/pi-embedded-helpers/sanitize-user-facing-text.js";
-import { isMessagingTool } from "../../agents/pi-embedded-messaging.js";
+import { isMessagingToolSendAction } from "../../agents/pi-embedded-messaging.js";
 import { runEmbeddedPiAgent } from "../../agents/pi-embedded.js";
 import { buildAgentRuntimeOutcomePlan } from "../../agents/runtime-plan/build.js";
 import {
@@ -1525,6 +1525,7 @@ export async function runAgentTurnWithFallback(params: {
           })
         : undefined;
       let messageToolOnlyDeliveryCompleted = false;
+      const messageToolOnlyDeliveryToolCallIds = new Set<string>();
       const sourceRepliesAreToolOnly =
         params.followupRun.run.sourceReplyDeliveryMode === "message_tool_only";
       const shouldSuppressProgressAfterMessageToolDelivery = () =>
@@ -1877,17 +1878,32 @@ export async function runAgentTurnWithFallback(params: {
                   }
                   // Trigger typing when tools start executing.
                   // Must await to ensure typing indicator starts before tool summaries are emitted.
-                  if (evt.stream === "tool" && !shouldSuppressProgressAfterMessageToolDelivery()) {
+                  if (evt.stream === "tool") {
                     const phase = readStringValue(evt.data.phase) ?? "";
                     const name = readStringValue(evt.data.name);
+                    const toolCallId = readStringValue(evt.data.toolCallId) ?? "";
+                    const args =
+                      evt.data.args && typeof evt.data.args === "object"
+                        ? (evt.data.args as Record<string, unknown>)
+                        : undefined;
+                    if (
+                      sourceRepliesAreToolOnly &&
+                      toolCallId &&
+                      name &&
+                      (phase === "start" || phase === "update") &&
+                      args &&
+                      isMessagingToolSendAction(name, args)
+                    ) {
+                      messageToolOnlyDeliveryToolCallIds.add(toolCallId);
+                    }
+                    if (shouldSuppressProgressAfterMessageToolDelivery()) {
+                      return;
+                    }
                     if (phase === "start" || phase === "update") {
                       const toolStartProgressPromise = params.opts?.onToolStart?.({
                         name,
                         phase,
-                        args:
-                          evt.data.args && typeof evt.data.args === "object"
-                            ? (evt.data.args as Record<string, unknown>)
-                            : undefined,
+                        args,
                         detailMode: params.toolProgressDetail,
                       });
                       await Promise.all([
@@ -1903,15 +1919,24 @@ export async function runAgentTurnWithFallback(params: {
                   const itemPhase = evt.stream === "item" ? readStringValue(evt.data.phase) : "";
                   const itemName = evt.stream === "item" ? readStringValue(evt.data.name) : "";
                   const itemStatus = evt.stream === "item" ? readStringValue(evt.data.status) : "";
+                  const itemToolCallId =
+                    evt.stream === "item" ? (readStringValue(evt.data.toolCallId) ?? "") : "";
                   const completedMessageToolDelivery =
                     sourceRepliesAreToolOnly &&
                     itemPhase === "end" &&
                     itemStatus === "completed" &&
-                    isMessagingTool(itemName ?? "");
+                    itemToolCallId.length > 0 &&
+                    messageToolOnlyDeliveryToolCallIds.has(itemToolCallId);
+                  const suppressProgressAfterMessageToolDelivery =
+                    shouldSuppressProgressAfterMessageToolDelivery();
+                  if (completedMessageToolDelivery) {
+                    messageToolOnlyDeliveryToolCallIds.delete(itemToolCallId);
+                    messageToolOnlyDeliveryCompleted = true;
+                  }
                   if (
                     evt.stream === "item" &&
                     !suppressItemChannelProgress &&
-                    !shouldSuppressProgressAfterMessageToolDelivery()
+                    (!suppressProgressAfterMessageToolDelivery || completedMessageToolDelivery)
                   ) {
                     await params.opts?.onItemEvent?.({
                       itemId: readStringValue(evt.data.itemId),
@@ -1926,9 +1951,6 @@ export async function runAgentTurnWithFallback(params: {
                       approvalId: readStringValue(evt.data.approvalId),
                       approvalSlug: readStringValue(evt.data.approvalSlug),
                     });
-                  }
-                  if (completedMessageToolDelivery) {
-                    messageToolOnlyDeliveryCompleted = true;
                   }
                   if (evt.stream === "plan" && !shouldSuppressProgressAfterMessageToolDelivery()) {
                     await params.opts?.onPlanUpdate?.({

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -2063,6 +2063,68 @@ describe("dispatchReplyFromConfig", () => {
     expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
   });
 
+  it("suppresses terminal tool-error fallbacks when regular verbose progress is visible", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "allow",
+      verboseLevel: "on",
+    };
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      ChatType: "direct",
+      SessionKey: "agent:main:telegram:direct:U1",
+    });
+    let receivedOptions: GetReplyOptions | undefined;
+    const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      receivedOptions = opts;
+      return { text: "done" } satisfies ReplyPayload;
+    });
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    expect(receivedOptions?.suppressToolErrorWarnings).toBe(true);
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "done" });
+  });
+
+  it("keeps terminal tool-error fallbacks available in verbose full mode", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "allow",
+      verboseLevel: "full",
+    };
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      ChatType: "direct",
+      SessionKey: "agent:main:telegram:direct:U1",
+    });
+    let receivedOptions: GetReplyOptions | undefined;
+    const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      receivedOptions = opts;
+      return { text: "done" } satisfies ReplyPayload;
+    });
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    expect(receivedOptions?.suppressToolErrorWarnings).toBeUndefined();
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "done" });
+  });
+
   it("delivers text-only tool summaries when verbose overrides preview suppression", async () => {
     setNoAbort();
     sessionStoreMocks.currentEntry = {

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1447,6 +1447,34 @@ describe("dispatchReplyFromConfig", () => {
     expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
   });
 
+  it("suppresses late text-only tool results after final delivery starts", async () => {
+    setNoAbort();
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "discord",
+      ChatType: "channel",
+      IsForum: true,
+      SessionKey: "agent:main:discord:channel:C1",
+    });
+    let lateToolResult: NonNullable<GetReplyOptions["onToolResult"]> | undefined;
+
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+      _cfg?: OpenClawConfig,
+    ) => {
+      lateToolResult = requireToolResultHandler(opts?.onToolResult);
+      return { text: "done" } satisfies ReplyPayload;
+    };
+
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+    await lateToolResult?.({ text: "failed command output", isError: true });
+
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "done" });
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
+  });
+
   it("suppresses group tool summaries but still forwards tool media", async () => {
     setNoAbort();
     const cfg = automaticGroupReplyConfig;
@@ -1871,6 +1899,65 @@ describe("dispatchReplyFromConfig", () => {
 
     expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "done" });
+  });
+
+  it("keeps failed tools compact when preview tool-progress suppression is enabled", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "allow",
+      verboseLevel: "on",
+    };
+    const onCommandOutput = vi.fn();
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "discord",
+      ChatType: "channel",
+      IsForum: true,
+      SessionKey: "agent:main:discord:channel:C1",
+    });
+
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+      _cfg?: OpenClawConfig,
+    ) => {
+      await opts?.onCommandOutput?.({
+        phase: "end",
+        title: "Exec",
+        name: "exec",
+        status: "failed",
+        exitCode: 1,
+      });
+      await opts?.onToolResult?.({ text: "raw failed command output", isError: true });
+      return { text: "done" } satisfies ReplyPayload;
+    };
+
+    const result = await dispatchReplyFromConfig({
+      ctx,
+      cfg,
+      dispatcher,
+      replyResolver,
+      replyOptions: {
+        sourceReplyDeliveryMode: "message_tool_only",
+        suppressDefaultToolProgressMessages: true,
+        allowProgressCallbacksWhenSourceDeliverySuppressed: true,
+        onCommandOutput,
+      },
+    });
+
+    expect(result.sourceReplyDeliveryMode).toBe("message_tool_only");
+    expect(onCommandOutput).toHaveBeenCalledWith({
+      phase: "end",
+      title: "Exec",
+      name: "exec",
+      status: "failed",
+      exitCode: 1,
+    });
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
   });
 
   it("delivers text-only tool summaries when verbose overrides preview suppression", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1960,6 +1960,109 @@ describe("dispatchReplyFromConfig", () => {
     expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
   });
 
+  it("keeps message-tool-only failed tool output compact in normal verbose mode", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "allow",
+      verboseLevel: "on",
+    };
+    const onCommandOutput = vi.fn();
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      ChatType: "direct",
+      SessionKey: "agent:main:telegram:direct:U1",
+    });
+
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+      _cfg?: OpenClawConfig,
+    ) => {
+      await opts?.onCommandOutput?.({
+        phase: "end",
+        title: "Exec",
+        name: "exec",
+        status: "failed",
+        exitCode: 2,
+      });
+      await opts?.onToolResult?.({
+        text: "🛠️ Bash: `ls /tmp/missing`\n```txt\nNo such file or directory\n```",
+        isError: true,
+      });
+      return { text: "done" } satisfies ReplyPayload;
+    };
+
+    const result = await dispatchReplyFromConfig({
+      ctx,
+      cfg,
+      dispatcher,
+      replyResolver,
+      replyOptions: {
+        sourceReplyDeliveryMode: "message_tool_only",
+        allowProgressCallbacksWhenSourceDeliverySuppressed: true,
+        onCommandOutput,
+      },
+    });
+
+    expect(result.sourceReplyDeliveryMode).toBe("message_tool_only");
+    expect(onCommandOutput).toHaveBeenCalledWith({
+      phase: "end",
+      title: "Exec",
+      name: "exec",
+      status: "failed",
+      exitCode: 2,
+    });
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+  });
+
+  it("allows message-tool-only failed tool output in verbose full mode", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "allow",
+      verboseLevel: "full",
+    };
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      ChatType: "direct",
+      SessionKey: "agent:main:telegram:direct:U1",
+    });
+    const failedOutput = {
+      text: "🛠️ Bash: `ls /tmp/missing`\n```txt\nNo such file or directory\n```",
+      isError: true,
+    } satisfies ReplyPayload;
+
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+      _cfg?: OpenClawConfig,
+    ) => {
+      await opts?.onToolResult?.(failedOutput);
+      return { text: "done" } satisfies ReplyPayload;
+    };
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg,
+      dispatcher,
+      replyResolver,
+      replyOptions: {
+        sourceReplyDeliveryMode: "message_tool_only",
+      },
+    });
+
+    expect(dispatcher.sendToolResult).toHaveBeenCalledWith(failedOutput);
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+  });
+
   it("delivers text-only tool summaries when verbose overrides preview suppression", async () => {
     setNoAbort();
     sessionStoreMocks.currentEntry = {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1232,13 +1232,43 @@ export async function dispatchReplyFromConfig(
       !sendPolicyDenied &&
       shouldEmitVerboseProgress() &&
       shouldSendVerboseProgressMessages;
+    let finalReplyDeliveryStarted = false;
+    const hasExecApprovalPayload = (payload: ReplyPayload) => {
+      const execApproval =
+        payload.channelData &&
+        typeof payload.channelData === "object" &&
+        !Array.isArray(payload.channelData)
+          ? payload.channelData.execApproval
+          : undefined;
+      return execApproval && typeof execApproval === "object" && !Array.isArray(execApproval);
+    };
+    const shouldSuppressLateTextOnlyToolProgress = (payload: ReplyPayload) => {
+      if (!finalReplyDeliveryStarted) {
+        return false;
+      }
+      const reply = resolveSendableOutboundReplyParts(payload);
+      return !reply.hasMedia && !hasExecApprovalPayload(payload);
+    };
+    const shouldSuppressMessageToolOnlyTextErrorProgress = (payload: ReplyPayload) => {
+      if (
+        sourceReplyDeliveryMode !== "message_tool_only" ||
+        !suppressDefaultToolProgressMessages ||
+        payload.isError !== true
+      ) {
+        return false;
+      }
+      const reply = resolveSendableOutboundReplyParts(payload);
+      return !reply.hasMedia && !hasExecApprovalPayload(payload);
+    };
     const sendFinalPayload = async (
       payload: ReplyPayload,
     ): Promise<{ queuedFinal: boolean; routedFinalCount: number }> => {
       const sourceReplyTranscriptMirror =
         getReplyPayloadMetadata(payload)?.sourceReplyTranscriptMirror;
-      if (hasOutboundReplyContent(payload, { trimText: true })) {
+      const hasVisibleFinalContent = hasOutboundReplyContent(payload, { trimText: true });
+      if (hasVisibleFinalContent) {
         markInboundDedupeReplayUnsafe();
+        finalReplyDeliveryStarted = true;
       }
       const ttsPayload = await maybeApplyTtsToReplyPayload({
         payload,
@@ -1622,17 +1652,15 @@ export async function dispatchReplyFromConfig(
               if (!deliveryPayload) {
                 return;
               }
+              if (shouldSuppressLateTextOnlyToolProgress(deliveryPayload)) {
+                return;
+              }
+              if (shouldSuppressMessageToolOnlyTextErrorProgress(deliveryPayload)) {
+                return;
+              }
               if (shouldSuppressDefaultToolProgressMessages()) {
                 const hasMedia = resolveSendableOutboundReplyParts(deliveryPayload).hasMedia;
-                const execApproval =
-                  deliveryPayload.channelData &&
-                  typeof deliveryPayload.channelData === "object" &&
-                  !Array.isArray(deliveryPayload.channelData)
-                    ? deliveryPayload.channelData.execApproval
-                    : undefined;
-                const hasExecApproval =
-                  execApproval && typeof execApproval === "object" && !Array.isArray(execApproval);
-                if (!hasMedia && !hasExecApproval && deliveryPayload.isError !== true) {
+                if (!hasMedia && !hasExecApprovalPayload(deliveryPayload)) {
                   return;
                 }
               }

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -324,20 +324,24 @@ const createShouldEmitVerboseProgress = (params: {
   storePath?: string;
   fallbackLevel: string;
 }) => {
-  return () => {
+  const resolveLevel = () => {
     if (params.sessionKey && params.storePath) {
       try {
         const store = loadSessionStore(params.storePath);
         const entry = resolveSessionStoreEntry({ store, sessionKey: params.sessionKey }).existing;
         const currentLevel = normalizeVerboseLevel(entry?.verboseLevel ?? "");
         if (currentLevel) {
-          return currentLevel !== "off";
+          return currentLevel;
         }
       } catch {
         // Ignore transient store read failures and fall back to the current dispatch snapshot.
       }
     }
-    return params.fallbackLevel !== "off";
+    return normalizeVerboseLevel(params.fallbackLevel) ?? "off";
+  };
+  return {
+    shouldEmit: () => resolveLevel() !== "off",
+    shouldEmitFull: () => resolveLevel() === "full",
   };
 };
 
@@ -689,7 +693,7 @@ export async function dispatchReplyFromConfig(
     : initialSessionStoreEntry;
   const sessionAgentId = resolveSessionAgentId({ sessionKey: acpDispatchSessionKey, config: cfg });
   const sessionAgentCfg = resolveAgentConfig(cfg, sessionAgentId);
-  const shouldEmitVerboseProgress = createShouldEmitVerboseProgress({
+  const verboseProgress = createShouldEmitVerboseProgress({
     sessionKey: acpDispatchSessionKey,
     storePath: sessionStoreEntry.storePath,
     fallbackLevel:
@@ -700,6 +704,8 @@ export async function dispatchReplyFromConfig(
           "",
       ) ?? "off",
   });
+  const shouldEmitVerboseProgress = verboseProgress.shouldEmit;
+  const shouldEmitFullVerboseProgress = verboseProgress.shouldEmitFull;
   const replyRoute = resolveEffectiveReplyRoute({ ctx, entry: sessionStoreEntry.entry });
   // Restore route thread context only from the active turn or the thread-scoped session key.
   // Do not read thread ids from the normalised session store here: `origin.threadId` can be
@@ -1252,7 +1258,7 @@ export async function dispatchReplyFromConfig(
     const shouldSuppressMessageToolOnlyTextErrorProgress = (payload: ReplyPayload) => {
       if (
         sourceReplyDeliveryMode !== "message_tool_only" ||
-        !suppressDefaultToolProgressMessages ||
+        shouldEmitFullVerboseProgress() ||
         payload.isError !== true
       ) {
         return false;

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1569,6 +1569,15 @@ export async function dispatchReplyFromConfig(
     const shouldSuppressProgressDelivery = () =>
       sendPolicyDenied ||
       (suppressDelivery && !shouldDeliverVerboseProgressDespiteSourceSuppression());
+    const hasVisibleRegularVerboseToolProgress =
+      shouldEmitVerboseProgress() &&
+      !shouldEmitFullVerboseProgress() &&
+      shouldSendVerboseProgressMessages &&
+      ctx.InboundEventKind !== "room_event" &&
+      !shouldSuppressProgressDelivery();
+    const suppressToolErrorWarnings =
+      params.replyOptions?.suppressToolErrorWarnings ??
+      (hasVisibleRegularVerboseToolProgress ? true : undefined);
     const onToolResultFromReplyOptions = params.replyOptions?.onToolResult;
     const onPlanUpdateFromReplyOptions = params.replyOptions?.onPlanUpdate;
     const onApprovalEventFromReplyOptions = params.replyOptions?.onApprovalEvent;
@@ -1609,6 +1618,7 @@ export async function dispatchReplyFromConfig(
         {
           ...params.replyOptions,
           sourceReplyDeliveryMode,
+          suppressToolErrorWarnings,
           typingPolicy: typing.typingPolicy,
           suppressTyping: typing.suppressTyping,
           onPartialReply: wrapProgressCallback(params.replyOptions?.onPartialReply),


### PR DESCRIPTION
## Summary
- Removes the follow-up regex patch in `src/agents/pi-embedded-runner/run/payloads.ts`; that code path is shared by Codex, but the regex was the wrong fix because the live repro was a terminal fallback warning, not a missing acknowledgement phrase.
- Suppresses terminal `lastToolError` warning payloads for regular verbose turns only when compact progress is actually visible to the channel.
- Keeps verbose `full` behavior intact, so full verbose can still show terminal tool-error detail.
- Keeps the existing Telegram/Discord late-progress guards from this PR: text-only tool output is dropped after final delivery, while media and exec approval payloads remain deliverable.

## Root Cause
Before/RCA proof:
- Live repro after the previous regex patch: the reported private Telegram topic ran through the Codex app-server path on May 19, 2026 at about 15:42 EDT. The trajectory showed a native `bash`/`grep` tool call, a failed `tool.result` (`grep: /tmp/openclaw-intentional-failure-demo-round-five: No such file or directory`), and then a successful assistant final: `Done — intentional \`grep\` failure, missing \`/tmp\` file.`
- Live send proof from the same run: gateway journal showed the final answer followed by another outbound message to the same topic. That extra post-final message was the bad failed-tool dump the user saw.
- Source path proof: `extensions/codex/src/app-server/event-projector.ts` records failed native Codex tool items as `lastToolError`; `src/auto-reply/reply/agent-runner-execution.ts` passes `params.opts?.suppressToolErrorWarnings` into the embedded runner; `src/agents/pi-embedded-runner/run.ts` passes it into `buildEmbeddedRunPayloads`; and `src/agents/pi-embedded-runner/run/payloads.ts` appends a terminal warning when `lastToolError` remains after a user-facing assistant reply.
- Why the prior fix missed: commit `dbe415b907` only broadened acknowledgement text matching for exec-like failures such as `exit 1`. The later live repro acknowledged the failure in natural language but still produced the terminal fallback, proving the right boundary is not another text regex.
- Correct boundary proof: `src/auto-reply/reply/dispatch-from-config.ts` already knows whether the channel will show regular compact verbose progress and whether the user selected `full`. That is the place to tell the runner that terminal tool-error fallback payloads are redundant for regular verbose, while preserving `full`.
- Scope proof: this is not Telegram-specific and not Pi-specific. The affected path is the shared Codex/app-server embedded runner plus channel dispatch options; Telegram and Discord are the visible channel surfaces where late text-only progress can appear as extra chat messages.

## Real behavior proof
Behavior addressed: Failed tool calls still appear as compact regular verbose progress before/finalizing the reply, but the terminal failed-tool warning payload is not appended after the final chat response. Full verbose still keeps terminal error warnings available.

Real environment tested: Tmp worktree branch `fix-channel-late-tool-output` at head `42fccfb3eb550e80cc46951dfc41b36912163ce3`; live gateway checkout updated with PR #84178 overlay on `/home/vac/openclaw`; private Telegram topic/session identifiers are intentionally not copied into the public PR body.

Exact steps or command run after this patch:
- `git revert --no-edit dbe415b907821e97b280018b259068ec6919cd0e`
- `pnpm exec oxfmt --check --threads=1 src/auto-reply/reply/dispatch-from-config.ts src/auto-reply/reply/dispatch-from-config.test.ts`
- `git diff --check`
- `node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.test.ts`
- `node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.test.ts src/auto-reply/reply/agent-runner-execution.test.ts extensions/codex/src/app-server/event-projector.test.ts`
- `git push vacopenclaw fix-channel-late-tool-output`
- `oc-update --skip-codex`
- `systemctl --user status openclaw-gateway --no-pager -l | sed -n '1,80p'`
- `rg -n "suppressToolErrorWarnings" dist | head -20`
- `openclaw health`

Evidence after fix:
- Revert proof: head contains `acc513bdcb Revert "fix(replies): avoid duplicate exec failure warnings"`, so the Pi-named regex patch was removed.
- Formatting: `All matched files use the correct format. Finished in 19ms on 2 files using 1 threads.`
- Whitespace: `git diff --check` produced no output.
- Focused dispatch test: `Test Files 1 passed (1); Tests 132 passed (132); Duration 5.50s`.
- Scoped regression test: `Test Files 3 passed (3); Tests 295 passed (295); Duration 7.40s`.
- Production update: `oc-update --skip-codex` applied `#84178 fix(channels): suppress late raw tool output`, built core/UI, reinstalled the daemon, and health check completed.
- Loaded service proof: `openclaw-gateway.service` is active since `Tue 2026-05-19 15:55:51 EDT`, running `/home/vac/openclaw/dist/index.js gateway --port 18789`.
- Built artifact proof: `dist/dispatch-8nUbnUg_.js` contains `const suppressToolErrorWarnings = params.replyOptions?.suppressToolErrorWarnings ?? (hasVisibleRegularVerboseToolProgress ? true : void 0);` and passes `suppressToolErrorWarnings` into the resolver options.
- Health proof after reload: `Gateway event loop: ok max=648ms p99=22ms util=0.064 cpu=0.121`; Telegram and Discord both configured.
- Existing visual proof: ![Telegram DM after-fix proof](https://raw.githubusercontent.com/VACInc/openclaw/pr-proof-84178/pr-proof/84178/telegram-after-fix-tool-output.jpg)
- Latest private-topic session file timestamp observed after reload check: the latest topic transcript was last modified at `2026-05-19 15:53:21 EDT`, before the corrected live reload at `15:55:51 EDT`; no new post-reload topic turn had occurred at the time of this proof update.
- No codex-review rerun was performed after the maintainer explicitly instructed not to run it again.

Observed result after fix: Regular verbose now tells the shared Codex embedded runner to suppress terminal tool-error warning fallback payloads whenever compact progress is visible, so failed tools stay in the compact progress lane instead of being dumped after the final answer. Verbose `full` is excluded by test and code condition.

What was not tested: A fresh post-reload live Telegram or Discord repro turn was not run by the agent after `oc-update`; the gateway is loaded for maintainer retest. The security audit warnings from `oc-update` are pre-existing local configuration/skill warnings and unrelated to this PR.

## Verification
- `pnpm exec oxfmt --check --threads=1 src/auto-reply/reply/dispatch-from-config.ts src/auto-reply/reply/dispatch-from-config.test.ts`
- `git diff --check`
- `node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.test.ts`
- `node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.test.ts src/auto-reply/reply/agent-runner-execution.test.ts extensions/codex/src/app-server/event-projector.test.ts`
- `oc-update --skip-codex`
- `openclaw health`

## What was not tested
A fresh post-reload live Telegram or Discord repro turn was not run by the agent. The corrected build is running live for maintainer retest.
