### PR TITLE
docs(context-engine): add OpenViking as remote context-engine example

### DIFF
--- a/docs/concepts/context-engine.md
+++ b/docs/concepts/context-engine.md
@@ -31,6 +31,12 @@ OpenClaw ships with a built-in `legacy` engine and uses it by default - most use
         openclaw plugins install @martian-engineering/lossless-claw
         ```
       </Tab>
+      <Tab title="From ClawHub">
+        ```bash
+        openclaw plugins install clawhub:@openviking/openclaw-plugin
+        openclaw openviking setup --base-url http://your-server:1933 --json
+        ```
+      </Tab>
       <Tab title="From a local path">
         ```bash
         openclaw plugins install -l ./my-context-engine
@@ -41,7 +47,7 @@ OpenClaw ships with a built-in `legacy` engine and uses it by default - most use
   </Step>
   <Step title="Enable and select the engine">
     ```json5
-    // openclaw.json
+    // openclaw.json — local engine (lossless-claw)
     {
       plugins: {
         slots: {
@@ -51,6 +57,26 @@ OpenClaw ships with a built-in `legacy` engine and uses it by default - most use
           "lossless-claw": {
             enabled: true,
             // Plugin-specific config goes here (see the plugin's docs)
+          },
+        },
+      },
+    }
+    ```
+
+    ```json5
+    // openclaw.json — remote engine (OpenViking)
+    {
+      plugins: {
+        slots: {
+          contextEngine: "openviking",
+        },
+        entries: {
+          "openviking": {
+            enabled: true,
+            config: {
+              baseUrl: "http://your-server:1933",
+              // apiKey: "sk-xxx",  // optional, if the server requires auth
+            },
           },
         },
       },


### PR DESCRIPTION
Add OpenViking as an additional context-engine plugin example alongside lossless-claw in the Quick Start section.

## Changes

- Add a **From ClawHub** install tab showing OpenViking's ClawHub install path
- Add a remote engine config example (OpenViking) alongside the existing local engine example (lossless-claw)

## Why

The current Quick Start only shows one third-party engine (lossless-claw, local SQLite). OpenViking is a remote context-engine plugin that implements the full ContextEngine interface (ingest, assemble, compact, afterTurn) with long-term memory, session archive, and semantic retrieval over a separately deployed server. Adding it gives users a reference for the remote engine pattern.

- ClawHub: @openviking/openclaw-plugin (latest: 2026.5.8)
- GitHub: https://github.com/volcengine/OpenViking (24K+ stars)
- npm: @openviking/openclaw-plugin