### PR TITLE
Preserve reusable Discord presentation buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 - CLI/message: include a stable top-level `messageId` in `openclaw message --json` output when channel sends return one. (#84191) Thanks @100menotu001.
 - Gateway/agents: use an agent's `identity.name` in Gateway agent summaries when `agents.list[].name` is unset, so configured agent labels remain visible in clients. (#84355; refs #57835) Thanks @luoyanglang.
 - Plugins/hooks: apply a default 30-second timeout to `before_compaction` and `after_compaction` hooks so a hung plugin handler no longer blocks compaction completion. (#84153)
+- Discord: preserve reusable presentation buttons through portable conversion and Discord component registration. (#84187) Thanks @100menotu001.
 - Discord: preserve disabled presentation buttons when adapting and rendering Discord message controls. (#84188) Thanks @100menotu001.
 - Twitch: add a test-only client-manager registry reset helper so non-isolated Twitch tests can clear cached managers between cases. Fixes #83887. (#84244) Thanks @hclsys.
 - Cron: use structured embedded-run denial metadata for isolated scheduled tasks so blocked exec requests fail the job without treating ordinary assistant prose as a denial. (#84067) Thanks @abnershang.

--- a/docs/plugins/message-presentation.md
+++ b/docs/plugins/message-presentation.md
@@ -61,6 +61,7 @@ type MessagePresentationButton = {
   web_app?: { url: string };
   priority?: number;
   disabled?: boolean;
+  reusable?: boolean;
   style?: "primary" | "secondary" | "success" | "danger";
 };
 
@@ -98,6 +99,10 @@ Button semantics:
   order is preserved.
 - `disabled` is optional. Channels must opt in with `supportsDisabled`; otherwise
   core degrades the disabled control to non-interactive fallback text.
+- `reusable` is optional. Channels that support reusable native callbacks may
+  keep the action available after a successful interaction. Use it for
+  repeatable or idempotent actions such as refresh, inspect, or more details;
+  leave it unset for normal one-shot approvals and destructive actions.
 
 Select semantics:
 

--- a/extensions/discord/src/components.builders.ts
+++ b/extensions/discord/src/components.builders.ts
@@ -95,6 +95,7 @@ function createButtonComponent(params: {
       label: params.spec.label,
       callbackData: params.spec.callbackData,
       modalId: params.modalId,
+      reusable: params.spec.reusable,
       allowedUsers: params.spec.allowedUsers,
     },
   };

--- a/extensions/discord/src/components.types.ts
+++ b/extensions/discord/src/components.types.ts
@@ -25,6 +25,8 @@ export type DiscordComponentButtonSpec = {
     animated?: boolean;
   };
   disabled?: boolean;
+  /** Keep this action available after a successful interaction. */
+  reusable?: boolean;
   /** Optional allowlist of users who can interact with this button (ids or names). */
   allowedUsers?: string[];
 };

--- a/extensions/discord/src/shared-interactive.test.ts
+++ b/extensions/discord/src/shared-interactive.test.ts
@@ -186,4 +186,26 @@ describe("buildDiscordInteractiveComponents", () => {
       ],
     });
   });
+
+  it("preserves reusable presentation buttons for Discord action entries", () => {
+    expect(
+      buildDiscordPresentationComponents({
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [{ label: "Refresh", value: "refresh", reusable: true }],
+          },
+        ],
+      }),
+    ).toEqual({
+      blocks: [
+        {
+          type: "actions",
+          buttons: [
+            { label: "Refresh", style: "secondary", callbackData: "refresh", reusable: true },
+          ],
+        },
+      ],
+    });
+  });
 });

--- a/extensions/discord/src/shared-interactive.ts
+++ b/extensions/discord/src/shared-interactive.ts
@@ -63,6 +63,9 @@ export function buildDiscordInteractiveComponents(
                 if (button.disabled === true) {
                   spec.disabled = true;
                 }
+                if (button.reusable === true) {
+                  spec.reusable = true;
+                }
                 return spec;
               }),
           });
@@ -159,6 +162,9 @@ function appendDiscordPresentationButtonBlocks(
         }
         if (button.disabled === true) {
           component.disabled = true;
+        }
+        if (button.reusable === true) {
+          component.reusable = true;
         }
         return component;
       }),

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -159,6 +159,7 @@ const presentationButtonSchema = Type.Object({
   webApp: Type.Optional(Type.Object({ url: Type.String() })),
   web_app: Type.Optional(Type.Object({ url: Type.String() })),
   disabled: Type.Optional(Type.Boolean()),
+  reusable: Type.Optional(Type.Boolean()),
   style: Type.Optional(stringEnum(["primary", "secondary", "success", "danger"])),
 });
 

--- a/src/interactive/payload.test.ts
+++ b/src/interactive/payload.test.ts
@@ -173,7 +173,14 @@ describe("interactive payload helpers", () => {
         { type: "divider" as const },
         {
           type: "buttons" as const,
-          buttons: [{ label: "Approve", value: "approve", style: "success" as const }],
+          buttons: [
+            {
+              label: "Approve",
+              value: "approve",
+              style: "success" as const,
+              reusable: true,
+            },
+          ],
         },
         {
           type: "select" as const,
@@ -189,7 +196,7 @@ describe("interactive payload helpers", () => {
         { type: "text", text: "Canary is ready." },
         {
           type: "buttons",
-          buttons: [{ label: "Approve", value: "approve", style: "success" }],
+          buttons: [{ label: "Approve", value: "approve", style: "success", reusable: true }],
         },
         {
           type: "select",
@@ -202,7 +209,7 @@ describe("interactive payload helpers", () => {
       blocks: [
         {
           type: "buttons",
-          buttons: [{ label: "Approve", value: "approve", style: "success" }],
+          buttons: [{ label: "Approve", value: "approve", style: "success", reusable: true }],
         },
         {
           type: "select",

--- a/src/interactive/payload.ts
+++ b/src/interactive/payload.ts
@@ -33,6 +33,8 @@ export type MessagePresentationButton = {
   priority?: number;
   /** Disable the button when the target channel supports disabled controls. */
   disabled?: boolean;
+  /** Keep this action available after a successful interaction when the target channel supports it. */
+  reusable?: boolean;
   /** Optional visual style hint; unsupported channels ignore or normalize it. */
   style?: InteractiveButtonStyle;
 };
@@ -207,6 +209,7 @@ function normalizeButton(raw: unknown): InteractiveReplyButton | undefined {
     ...(webAppUrl ? { webApp: { url: webAppUrl } } : {}),
     ...(priority !== undefined ? { priority } : {}),
     ...(record.disabled === true ? { disabled: true } : {}),
+    ...(record.reusable === true ? { reusable: true } : {}),
     style: normalizeButtonStyle(record.style),
   };
 }

--- a/src/interactive/payload.ts
+++ b/src/interactive/payload.ts
@@ -369,6 +369,9 @@ export function presentationToInteractiveReply(
           if (button.disabled === true) {
             interactiveButton.disabled = true;
           }
+          if (button.reusable === true) {
+            interactiveButton.reusable = true;
+          }
           return interactiveButton;
         });
       if (buttons.length > 0) {


### PR DESCRIPTION
## Summary

Adds `reusable` to portable presentation buttons, preserves it through Discord presentation mapping, and documents the field for message presentation authors.

## Motivation

Closes #84182.

Presentation buttons can represent repeatable actions such as refresh or more-detail, but the portable schema and Discord mapper dropped the reusable intent before registry entries were created.

## Change Type

- [x] Bug fix
- [x] Documentation

## Scope

- Adds `reusable?: boolean` to the presentation button type and tool schema.
- Carries `reusable: true` from presentation buttons into Discord button specs.
- Preserves per-button reusable state when Discord component entries are built.
- Documents `reusable?: boolean` in `docs/plugins/message-presentation.md`.

## Linked Issue/PR

Closes #84182.

## Real Behavior Proof

Behavior or issue addressed: A portable presentation button with `reusable: true` must keep that flag through Discord mapping and component registry dispatch so repeatable actions are not consumed after the first callback.

Real environment tested: Redacted OpenClaw development checkout on this PR branch, using the Discord extension runtime path that maps presentation payloads into component entries.

Exact steps or command run after this patch: Ran a runtime diagnostic against this branch that created a reusable presentation button, mapped it to a Discord button spec, built component entries, and performed two dispatch-style lookups against the same callback data.

Evidence after fix: Redacted runtime output:

```json
{
  "componentSpecButton": {
    "label": "More detail",
    "style": "secondary",
    "callbackData": "detail",
    "reusable": true
  },
  "entryReusable": true,
  "handlerConsumePolicy": false,
  "firstDispatch": {
    "label": "More detail",
    "callbackData": "detail"
  },
  "secondDispatch": {
    "label": "More detail",
    "callbackData": "detail"
  }
}
```

Observed result after fix: The Discord button spec contains `reusable: true`, the registered entry retains `entryReusable: true`, handler consume policy is `false`, and both lookup attempts return the same button metadata.

Not tested: No live Discord provider send was needed for this field-propagation path; the exercised behavior is the runtime mapping and registry decision that controls whether the callback is consumed.

## Root Cause

Discord component entries supported reusable behavior, but portable presentation buttons had no reusable schema field and the Discord presentation mapper only copied label, style, callback data, and URL.

## Regression Test Plan

- `pnpm exec vitest run extensions/discord/src/shared-interactive.test.ts extensions/discord/src/components.test.ts`

Result: 2 files passed, 15 tests passed.

## User-visible / Behavior Changes

Message senders can now use `presentation.blocks[].buttons[].reusable` for Discord presentation buttons.

## Diagram

N/A. This is a direct schema, adapter, component-entry, and docs propagation fix.

## Security Impact

No new secrets or network calls. The change only preserves an explicit boolean in already-authored message payloads.

## Repro + Verification

Before this change, a presentation button authored with reusable intent could not carry that intent through the message tool schema and Discord presentation mapper. The new test asserts that the generated Discord component spec retains it, and the redacted runtime diagnostic confirms the handler sees it as non-consuming.

## Evidence

- Focused regression command passed.
- Redacted runtime diagnostic above confirms the mapped button remains reusable through component registration and dispatch-style resolution.

## Human Verification

No live Discord service is required for this field-propagation fix; the proof exercises the runtime path that decides whether an interaction callback is consumed.

## Compatibility / Migration

Backward compatible. Existing payloads are unchanged unless they opt into `reusable: true`.

## Risks

Low. The flag is only emitted when explicitly set to true.
