### PR TITLE
Preserve disabled Discord presentation buttons

### DIFF
--- a/extensions/discord/src/components.builders.ts
+++ b/extensions/discord/src/components.builders.ts
@@ -60,6 +60,7 @@ function createButtonComponent(params: {
     class DynamicLinkButton extends LinkButton {
       label = params.spec.label;
       url = linkUrl;
+      override disabled = params.spec.disabled ?? false;
     }
     return { component: new DynamicLinkButton() };
   }

--- a/extensions/discord/src/components.test.ts
+++ b/extensions/discord/src/components.test.ts
@@ -1,4 +1,4 @@
-import { MessageFlags } from "discord-api-types/v10";
+import { ButtonStyle, MessageFlags } from "discord-api-types/v10";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 let clearDiscordComponentEntries: typeof import("./components-registry.js").clearDiscordComponentEntries;
@@ -58,6 +58,41 @@ describe("discord components", () => {
     );
     expect(result.modals[0]?.callbackData).toBe("codex:modal");
     expect(result.modals[0]?.allowedUsers).toEqual(["discord:user-1"]);
+  });
+
+  it("serializes disabled link buttons", () => {
+    const spec = readDiscordComponentSpec({
+      blocks: [
+        {
+          type: "actions",
+          buttons: [
+            {
+              label: "Open docs",
+              style: "link",
+              url: "https://example.com/docs",
+              disabled: true,
+            },
+          ],
+        },
+      ],
+    });
+    if (!spec) {
+      throw new Error("Expected component spec to be parsed");
+    }
+
+    const result = buildDiscordComponentMessage({ spec });
+    const serialized = result.components[0]?.serialize() as
+      | { components?: Array<{ components?: Array<Record<string, unknown>> }> }
+      | undefined;
+    const button = serialized?.components?.[0]?.components?.[0];
+
+    expect(button).toMatchObject({
+      label: "Open docs",
+      style: ButtonStyle.Link,
+      url: "https://example.com/docs",
+      disabled: true,
+    });
+    expect(result.entries).toHaveLength(0);
   });
 
   it("requires options for modal select fields", () => {

--- a/extensions/discord/src/outbound-adapter.test.ts
+++ b/extensions/discord/src/outbound-adapter.test.ts
@@ -1,3 +1,4 @@
+import { adaptMessagePresentationForChannel } from "openclaw/plugin-sdk/interactive-runtime";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createDiscordOutboundHoisted,
@@ -578,6 +579,47 @@ describe("discordOutbound", () => {
       channel: "discord",
       messageId: "msg-2",
       channelId: "ch-1",
+    });
+  });
+
+  it("preserves disabled presentation buttons through channel adaptation", async () => {
+    const adaptedPresentation = adaptMessagePresentationForChannel({
+      capabilities: discordOutbound.presentationCapabilities,
+      presentation: {
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [{ label: "Already handled", value: "done", disabled: true }],
+          },
+        ],
+      },
+    });
+
+    const payload = await discordOutbound.renderPresentation?.({
+      payload: { text: "Action state" },
+      presentation: adaptedPresentation,
+      ctx: {
+        cfg: {},
+        to: "channel:123456",
+      },
+    } as never);
+
+    if (!payload) {
+      throw new Error("expected Discord presentation payload");
+    }
+
+    const discordData = payload.channelData?.discord as
+      | { presentationComponents?: { blocks?: Array<{ type?: string; buttons?: unknown[] }> } }
+      | undefined;
+    const button = discordData?.presentationComponents?.blocks?.find(
+      (block) => block.type === "actions",
+    )?.buttons?.[0];
+
+    expect(button).toEqual({
+      label: "Already handled",
+      style: "secondary",
+      callbackData: "done",
+      disabled: true,
     });
   });
 

--- a/extensions/discord/src/outbound-adapter.test.ts
+++ b/extensions/discord/src/outbound-adapter.test.ts
@@ -589,7 +589,10 @@ describe("discordOutbound", () => {
         blocks: [
           {
             type: "buttons",
-            buttons: [{ label: "Already handled", value: "done", disabled: true }],
+            buttons: [
+              { label: "Already handled", value: "done", disabled: true },
+              { label: "Open docs", url: "https://example.com/docs", disabled: true },
+            ],
           },
         ],
       },
@@ -611,14 +614,20 @@ describe("discordOutbound", () => {
     const discordData = payload.channelData?.discord as
       | { presentationComponents?: { blocks?: Array<{ type?: string; buttons?: unknown[] }> } }
       | undefined;
-    const button = discordData?.presentationComponents?.blocks?.find(
+    const buttons = discordData?.presentationComponents?.blocks?.find(
       (block) => block.type === "actions",
-    )?.buttons?.[0];
+    )?.buttons;
 
-    expect(button).toEqual({
+    expect(buttons?.[0]).toEqual({
       label: "Already handled",
       style: "secondary",
       callbackData: "done",
+      disabled: true,
+    });
+    expect(buttons?.[1]).toEqual({
+      label: "Open docs",
+      style: "link",
+      url: "https://example.com/docs",
       disabled: true,
     });
   });

--- a/extensions/discord/src/outbound-adapter.ts
+++ b/extensions/discord/src/outbound-adapter.ts
@@ -126,6 +126,7 @@ export const discordOutbound: ChannelOutboundAdapter = {
         maxActionsPerRow: 5,
         maxRows: 5,
         maxLabelLength: 80,
+        supportsDisabled: true,
       },
       selects: {
         maxOptions: 25,

--- a/extensions/discord/src/shared-interactive.test.ts
+++ b/extensions/discord/src/shared-interactive.test.ts
@@ -150,4 +150,31 @@ describe("buildDiscordInteractiveComponents", () => {
       ],
     });
   });
+
+  it("preserves disabled presentation buttons for Discord components", () => {
+    expect(
+      buildDiscordPresentationComponents({
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [{ label: "Already handled", value: "done", disabled: true }],
+          },
+        ],
+      }),
+    ).toEqual({
+      blocks: [
+        {
+          type: "actions",
+          buttons: [
+            {
+              label: "Already handled",
+              style: "secondary",
+              callbackData: "done",
+              disabled: true,
+            },
+          ],
+        },
+      ],
+    });
+  });
 });

--- a/extensions/discord/src/shared-interactive.test.ts
+++ b/extensions/discord/src/shared-interactive.test.ts
@@ -157,7 +157,10 @@ describe("buildDiscordInteractiveComponents", () => {
         blocks: [
           {
             type: "buttons",
-            buttons: [{ label: "Already handled", value: "done", disabled: true }],
+            buttons: [
+              { label: "Already handled", value: "done", disabled: true },
+              { label: "Open docs", url: "https://example.com/docs", disabled: true },
+            ],
           },
         ],
       }),
@@ -170,6 +173,12 @@ describe("buildDiscordInteractiveComponents", () => {
               label: "Already handled",
               style: "secondary",
               callbackData: "done",
+              disabled: true,
+            },
+            {
+              label: "Open docs",
+              style: "link",
+              url: "https://example.com/docs",
               disabled: true,
             },
           ],

--- a/extensions/discord/src/shared-interactive.ts
+++ b/extensions/discord/src/shared-interactive.ts
@@ -60,6 +60,9 @@ export function buildDiscordInteractiveComponents(
                 if (button.url) {
                   spec.url = button.url;
                 }
+                if (button.disabled === true) {
+                  spec.disabled = true;
+                }
                 return spec;
               }),
           });
@@ -153,6 +156,9 @@ function appendDiscordPresentationButtonBlocks(
         }
         if (button.url) {
           component.url = button.url;
+        }
+        if (button.disabled === true) {
+          component.disabled = true;
         }
         return component;
       }),

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -158,6 +158,7 @@ const presentationButtonSchema = Type.Object({
   url: Type.Optional(Type.String()),
   webApp: Type.Optional(Type.Object({ url: Type.String() })),
   web_app: Type.Optional(Type.Object({ url: Type.String() })),
+  disabled: Type.Optional(Type.Boolean()),
   style: Type.Optional(stringEnum(["primary", "secondary", "success", "danger"])),
 });
 


### PR DESCRIPTION
## Summary

Accepts `disabled` on portable presentation buttons, advertises Discord disabled-button support during channel adaptation, and preserves the field in Discord presentation button specs.

## Motivation

Closes #84183.

The runtime type already included `disabled`, and Discord button specs support disabled buttons, but the message tool schema and Discord presentation mapper dropped the field. The channel capabilities also failed to advertise disabled-button support, so outbound adaptation could strip the state before rendering.

## Change Type

- [x] Bug fix

## Scope

- Adds `disabled` to the message tool presentation button schema.
- Copies `disabled: true` into Discord button specs for presentation and legacy interactive button mapping.
- Sets Discord `presentationCapabilities.limits.actions.supportsDisabled` to `true`.
- Adds regression coverage for the adapted outbound path and Discord render output.

## Linked Issue/PR

Closes #84183.

## Real Behavior Proof

Behavior or issue addressed: A portable presentation button with `disabled: true` must survive Discord capability adaptation and render as a disabled Discord component, including URL/link buttons.

Real environment tested: Redacted OpenClaw development checkout on this PR branch, using the Discord outbound adapter and Discord presentation renderer.

Exact steps or command run after this patch: Ran a runtime diagnostic against this branch that read Discord presentation capabilities, adapted a disabled URL presentation button for the Discord target runtime, rendered it into a Discord component spec, and serialized the final link button component.

Evidence after fix: Redacted runtime output:

```json
{
  "supportsDisabled": true,
  "adaptedButton": {
    "label": "Open docs",
    "url": "https://example.com/docs",
    "disabled": true
  },
  "componentSpecButton": {
    "label": "Open docs",
    "style": "link",
    "url": "https://example.com/docs",
    "disabled": true
  },
  "serializedLinkButton": {
    "type": 2,
    "style": 5,
    "label": "Open docs",
    "disabled": true,
    "url": "https://example.com/docs"
  },
  "registeredEntries": 0
}
```

Observed result after fix: Discord advertises disabled-button support, the adapted URL button still has `disabled: true`, the component spec keeps `disabled: true`, and final serialized Discord link-button output includes `disabled: true`.

Not tested: No live Discord provider send was needed for this deterministic capability-adaptation, component-rendering, and final serialization path.

Additional non-link runtime proof from the same branch:

```json
{
  "supportsDisabled": true,
  "adaptedButton": {
    "label": "Already handled",
    "value": "done",
    "disabled": true
  },
  "renderedButton": {
    "label": "Already handled",
    "style": "secondary",
    "callbackData": "done",
    "disabled": true
  }
}
```

## Root Cause

The portable button type and low-level Discord builder already supported disabled buttons, but the schema, adapter capability metadata, and mapping layer did not consistently propagate that field.

## Regression Test Plan

- `node scripts/run-vitest.mjs extensions/discord/src/shared-interactive.test.ts extensions/discord/src/outbound-adapter.test.ts extensions/discord/src/components.test.ts extensions/discord/src/send.components.test.ts`

Result: 4 files passed, 58 tests passed.

## User-visible / Behavior Changes

Callers can send disabled Discord presentation buttons through the message tool without falling back to Discord-specific payloads.

## Diagram

N/A. This is a field propagation and capability-advertisement fix.

## Security Impact

No new secrets or external calls. The change reduces accidental action availability by preserving an explicit disabled state.

## Repro + Verification

Before this change, `disabled: true` could be rejected or dropped before Discord rendering, and disabled URL buttons could survive adaptation but serialize as enabled link buttons. The new regression tests verify that channel adaptation keeps disabled callback and URL buttons, and final Discord link-button serialization emits a disabled component.

## Evidence

- Focused regression command passed.
- Redacted runtime diagnostic above confirms `supportsDisabled` is advertised and `disabled: true` reaches final serialized Discord link-button output.

## Human Verification

No live Discord service is required for this deterministic channel-adaptation and rendering path.

## Compatibility / Migration

Backward compatible. Existing messages render the same unless they set `disabled: true`.

## Risks

Low. Only true values are propagated.
