### PR TITLE
Log Discord component registry error details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 
 - Infra/json: retry transient `File changed during read` races while loading JSON state so config and state reads recover instead of failing the turn. (#84285)
 - Providers/Ollama: resolve configured Ollama Cloud `OLLAMA_API_KEY` markers to the real discovery key so cloud provider entries keep authenticated model catalog access. (#85037)
+- Discord: keep persistent component registry fallback warnings actionable by forwarding structured error and cause metadata through the runtime logger. Fixes #84185. (#84190) Thanks @100menotu001.
 - Gateway/sessions: preserve compatible session auth profile overrides when switching models within the same provider, including provider-auth aliases. Fixes #81837. (#81886) Thanks @TurboTheTurtle.
 - Gateway/status: surface inbound delivery telemetry counters and transport-liveness warnings in `openclaw status --all`. Fixes #49577. (#72724)
 - Docker: prune package-excluded plugin source workspaces and dependency closures so runtime images do not keep packages for plugins that were not opted in.

--- a/extensions/discord/src/components-registry.ts
+++ b/extensions/discord/src/components-registry.ts
@@ -56,7 +56,7 @@ function reportPersistentComponentRegistryError(error: unknown): void {
 
 function formatRegistryError(error: unknown): Record<string, unknown> {
   if (!(error instanceof Error)) {
-    return { error: String(error) };
+    return { error: formatRegistryErrorValue(error) };
   }
   const details: Record<string, unknown> = {
     error: String(error),
@@ -75,9 +75,31 @@ function formatRegistryError(error: unknown): Record<string, unknown> {
       details.errorCauseStack = cause.stack;
     }
   } else if (cause !== undefined) {
-    details.errorCause = String(cause);
+    details.errorCause = formatRegistryErrorValue(cause);
   }
   return details;
+}
+
+function formatRegistryErrorValue(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    typeof value === "bigint" ||
+    typeof value === "symbol"
+  ) {
+    return String(value);
+  }
+  if (value === null) {
+    return "null";
+  }
+  try {
+    return JSON.stringify(value) ?? Object.prototype.toString.call(value);
+  } catch {
+    return Object.prototype.toString.call(value);
+  }
 }
 
 function disablePersistentComponentRegistry(error: unknown): void {

--- a/extensions/discord/src/components-registry.ts
+++ b/extensions/discord/src/components-registry.ts
@@ -48,10 +48,36 @@ function reportPersistentComponentRegistryError(error: unknown): void {
   try {
     getOptionalDiscordRuntime()
       ?.logging.getChildLogger({ plugin: "discord", feature: "component-registry-state" })
-      .warn("Discord persistent component registry state failed", { error: String(error) });
+      .warn("Discord persistent component registry state failed", formatRegistryError(error));
   } catch {
     // Best effort only: persistent state must never break Discord interactions.
   }
+}
+
+function formatRegistryError(error: unknown): Record<string, unknown> {
+  if (!(error instanceof Error)) {
+    return { error: String(error) };
+  }
+  const details: Record<string, unknown> = {
+    error: String(error),
+    errorName: error.name,
+    errorMessage: error.message,
+  };
+  if (error.stack) {
+    details.errorStack = error.stack;
+  }
+  const cause = (error as { cause?: unknown }).cause;
+  if (cause instanceof Error) {
+    details.errorCause = String(cause);
+    details.errorCauseName = cause.name;
+    details.errorCauseMessage = cause.message;
+    if (cause.stack) {
+      details.errorCauseStack = cause.stack;
+    }
+  } else if (cause !== undefined) {
+    details.errorCause = String(cause);
+  }
+  return details;
 }
 
 function disablePersistentComponentRegistry(error: unknown): void {

--- a/extensions/discord/src/components.test.ts
+++ b/extensions/discord/src/components.test.ts
@@ -354,11 +354,14 @@ describe("discord component registry", () => {
 
   it("falls back to the in-memory registry when persistent state cannot open", async () => {
     const warn = vi.fn();
+    const cause = new TypeError("disk busy");
     const { setDiscordRuntime } = await import("./runtime.js");
     setDiscordRuntime({
       state: {
         openKeyedStore: vi.fn(() => {
-          throw new Error("sqlite unavailable");
+          const error = new Error("sqlite unavailable") as Error & { cause?: unknown };
+          error.cause = cause;
+          throw error;
         }),
       },
       logging: { getChildLogger: () => ({ warn }) },
@@ -375,6 +378,16 @@ describe("discord component registry", () => {
     expect(fallbackEntry?.label).toBe("Fallback");
     expect(typeof fallbackEntry?.createdAt).toBe("number");
     expect(typeof fallbackEntry?.expiresAt).toBe("number");
-    expect(warn).toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      "Discord persistent component registry state failed",
+      expect.objectContaining({
+        error: "Error: sqlite unavailable",
+        errorName: "Error",
+        errorMessage: "sqlite unavailable",
+        errorCause: "TypeError: disk busy",
+        errorCauseName: "TypeError",
+        errorCauseMessage: "disk busy",
+      }),
+    );
   });
 });

--- a/src/plugins/runtime/runtime-logging.test.ts
+++ b/src/plugins/runtime/runtime-logging.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const loggingMocks = vi.hoisted(() => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+  return {
+    childLogger,
+    getChildLogger: vi.fn(() => childLogger),
+  };
+});
+
+vi.mock("../../globals.js", () => ({
+  shouldLogVerbose: vi.fn(() => false),
+}));
+
+vi.mock("../../logging.js", () => ({
+  getChildLogger: loggingMocks.getChildLogger,
+}));
+
+let createRuntimeLogging: typeof import("./runtime-logging.js").createRuntimeLogging;
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  loggingMocks.getChildLogger.mockReturnValue(loggingMocks.childLogger);
+  ({ createRuntimeLogging } = await import("./runtime-logging.js"));
+});
+
+describe("createRuntimeLogging", () => {
+  it("forwards structured metadata to child loggers", () => {
+    const logging = createRuntimeLogging();
+    const logger = logging.getChildLogger({ plugin: "discord" }, { level: "warn" });
+    const meta = {
+      errorName: "Error",
+      errorCauseName: "TypeError",
+    };
+
+    logger.debug?.("debug details", meta);
+    logger.info("info details", meta);
+    logger.warn("warn details", meta);
+    logger.error("error details", meta);
+
+    expect(loggingMocks.getChildLogger).toHaveBeenCalledWith(
+      { plugin: "discord" },
+      { level: "warn" },
+    );
+    expect(loggingMocks.childLogger.debug).toHaveBeenCalledWith(meta, "debug details");
+    expect(loggingMocks.childLogger.info).toHaveBeenCalledWith(meta, "info details");
+    expect(loggingMocks.childLogger.warn).toHaveBeenCalledWith(meta, "warn details");
+    expect(loggingMocks.childLogger.error).toHaveBeenCalledWith(meta, "error details");
+  });
+});

--- a/src/plugins/runtime/runtime-logging.ts
+++ b/src/plugins/runtime/runtime-logging.ts
@@ -3,6 +3,18 @@ import { getChildLogger } from "../../logging.js";
 import { normalizeLogLevel } from "../../logging/levels.js";
 import type { PluginRuntime } from "./types.js";
 
+function writeRuntimeLog(
+  log: (...args: unknown[]) => void,
+  message: string,
+  meta?: Record<string, unknown>,
+): void {
+  if (meta && Object.keys(meta).length > 0) {
+    log(meta, message);
+    return;
+  }
+  log(message);
+}
+
 export function createRuntimeLogging(): PluginRuntime["logging"] {
   return {
     shouldLogVerbose,
@@ -11,10 +23,14 @@ export function createRuntimeLogging(): PluginRuntime["logging"] {
         level: opts?.level ? normalizeLogLevel(opts.level) : undefined,
       });
       return {
-        debug: (message) => logger.debug?.(message),
-        info: (message) => logger.info(message),
-        warn: (message) => logger.warn(message),
-        error: (message) => logger.error(message),
+        debug: (message, meta) => {
+          if (logger.debug) {
+            writeRuntimeLog(logger.debug.bind(logger), message, meta);
+          }
+        },
+        info: (message, meta) => writeRuntimeLog(logger.info.bind(logger), message, meta),
+        warn: (message, meta) => writeRuntimeLog(logger.warn.bind(logger), message, meta),
+        error: (message, meta) => writeRuntimeLog(logger.error.bind(logger), message, meta),
       };
     },
   };


### PR DESCRIPTION
## Summary

Logs structured details when the Discord persistent component registry falls back after a state-store failure.

## Motivation

Closes #84185.

The fallback is intentionally recoverable, but the warning previously only logged `String(error)`, which made storage and runtime failures harder to distinguish.

## Change Type

- [x] Bug fix

## Scope

- Formats thrown registry errors into structured warning metadata.
- Includes error name, message, stack, and cause details when available.
- Leaves fallback behavior unchanged.
- Adds coverage for cause metadata in the warning.

## Linked Issue/PR

Closes #84185.

## Real Behavior Proof

Behavior or issue addressed: When the Discord persistent component registry cannot open its keyed store, fallback behavior must still work and the real plugin runtime logger must preserve structured error and cause metadata.

Real environment tested: Redacted OpenClaw development checkout on this PR branch, using the Discord component registry runtime with a deliberately failing keyed-store open path.

Exact steps or command run after this patch: Ran a runtime diagnostic using `createRuntimeLogging()`, injected a store-open failure with an `Error` cause, registered Discord component entries, resolved a fallback entry, and captured the redacted JSON log record emitted through the real runtime logging adapter.

Evidence after fix: Redacted runtime output:

```json
{
  "fallbackEntryAvailable": true,
  "warningMessage": "Discord persistent component registry state failed",
  "structuredMetadata": {
    "errorName": "Error",
    "errorMessage": "redacted registry state open failed",
    "errorCauseName": "TypeError",
    "errorCauseMessage": "redacted state backend unavailable"
  }
}
```

Earlier call-site diagnostic before the runtime adapter fix:

```json
{
  "fallbackEntryAvailable": true,
  "warning": {
    "message": "Discord persistent component registry state failed",
    "errorName": "Error",
    "errorMessage": "redacted registry state open failed",
    "errorCauseName": "TypeError",
    "errorCauseMessage": "redacted state backend unavailable"
  }
}
```

Observed result after fix: Fallback registry resolution remained available, and the warning emitted through the real runtime logging adapter retained `errorName`, `errorMessage`, `errorCauseName`, and `errorCauseMessage` metadata.

Not tested: No live Discord provider send was needed for this persistent-registry fallback logging path.

## Root Cause

The registry warning collapsed the thrown value to a single string, discarding structured `Error` fields and `cause` context.

## Regression Test Plan

- `node scripts/run-vitest.mjs extensions/discord/src/components.test.ts src/plugins/runtime/runtime-logging.test.ts`

Result: 2 files passed, 10 tests passed.

## User-visible / Behavior Changes

No user-facing behavior change. Operators get more actionable warning metadata when persistent component state fails and OpenClaw falls back to in-memory state.

## Diagram

N/A. This is warning metadata only.

## Security Impact

No new secrets, permissions, or external calls. The logged metadata is limited to the caught error details already available in-process.

## Repro + Verification

Before this change, the fallback warning only included `String(error)`, and the production runtime logging adapter dropped metadata arguments. The new regression tests verify name, message, and cause details at the Discord call site and metadata forwarding in the runtime logger adapter; the redacted runtime diagnostic confirms fallback remains available and the real log record carries the structured metadata.

## Evidence

- Focused regression command passed.
- Redacted runtime diagnostic above confirms the fallback entry remains available and the real runtime log record includes structured error and cause metadata.

## Human Verification

No live Discord service is required for this deterministic fallback logging path.

## Compatibility / Migration

Backward compatible. The warning message text is unchanged, and metadata gains additional fields.

## Risks

Low. The formatter is best-effort and is wrapped by the existing logging guard.
