### PR TITLE
fix(telegram): recover lone timed-out spool handlers

### DIFF
--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -1900,6 +1900,97 @@ describe("TelegramPollingSession", () => {
     }
   });
 
+  it("fails a timed-out lone spooled handler with no later same-lane update", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const abort = new AbortController();
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-spool-"));
+    const log = vi.fn();
+    const events: string[] = [];
+    const firstBot = {
+      api: {
+        deleteWebhook: vi.fn(async () => true),
+        config: { use: vi.fn() },
+      },
+      init: vi.fn(async () => undefined),
+      handleUpdate: vi.fn(async (update: { update_id?: number }) => {
+        events.push(`first:${update.update_id}`);
+        await waitForTestReplyFenceAbort({
+          key: "test-session:topic-10",
+          laneKey: "telegram:-100:topic:10",
+        });
+      }),
+      stop: vi.fn(async () => undefined),
+    };
+    const secondBot = {
+      api: {
+        deleteWebhook: vi.fn(async () => true),
+        config: { use: vi.fn() },
+      },
+      init: vi.fn(async () => undefined),
+      handleUpdate: vi.fn(async (update: { update_id?: number }) => {
+        events.push(`second:${update.update_id}`);
+      }),
+      stop: vi.fn(async () => undefined),
+    };
+    createTelegramBotMock.mockReturnValueOnce(firstBot).mockReturnValueOnce(secondBot);
+    await writeSpooledTestUpdates(tempDir, [topicUpdate(42, 10, "wedged topic 10 turn")]);
+
+    const stopWorkers: Array<() => void> = [];
+    const createWorker = vi.fn(() => {
+      let stopWorker: (() => void) | undefined;
+      const workerDone = new Promise<void>((resolve) => {
+        stopWorker = resolve;
+      });
+      stopWorkers.push(() => stopWorker?.());
+      return {
+        onMessage: vi.fn(() => () => undefined),
+        stop: vi.fn(async () => {
+          stopWorker?.();
+        }),
+        task: vi.fn(async () => {
+          await workerDone;
+        }),
+      };
+    });
+    const session = createPollingSession({
+      abortSignal: abort.signal,
+      log,
+      isolatedIngress: {
+        enabled: true,
+        spoolDir: tempDir,
+        createWorker,
+        drainIntervalMs: 10,
+        spooledUpdateHandlerTimeoutMs: 100,
+        spooledUpdateHandlerAbortGraceMs: 100,
+      },
+    });
+
+    try {
+      const runPromise = session.runUntilAbort();
+      await vi.waitFor(() => expect(events).toEqual(["first:42"]));
+
+      await vi.advanceTimersByTimeAsync(150);
+      await vi.waitFor(() => expect(createWorker).toHaveBeenCalledTimes(2));
+
+      expect(events).toEqual(["first:42"]);
+      expect(createTelegramBotMock).toHaveBeenCalledTimes(2);
+      expect(firstBot.stop).toHaveBeenCalledTimes(1);
+      expect(await pendingUpdateIds(tempDir, "all")).toEqual([]);
+      expect(await failedUpdateIds(tempDir)).toEqual([42]);
+      expectLogIncludes(log, "spool handler timed out behind update 42");
+
+      abort.abort();
+      stopWorkers.forEach((stopWorker) => stopWorker());
+      await vi.advanceTimersByTimeAsync(20_000);
+      await runPromise;
+    } finally {
+      abort.abort();
+      stopWorkers.forEach((stopWorker) => stopWorker());
+      vi.useRealTimers();
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("keeps a timed-out lane guarded until the old handler stops", async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     const abort = new AbortController();

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -495,6 +495,16 @@ export class TelegramPollingSession {
     return laneKeys;
   }
 
+  #activeSpooledUpdateHandlerKeysForSpool(spoolDir: string): Set<string> {
+    const handlerKeys = new Set<string>();
+    for (const handlerKey of activeSpooledUpdateHandlersByLane.keys()) {
+      if (isSpooledUpdateHandlerKeyForSpool(handlerKey, spoolDir)) {
+        handlerKeys.add(handlerKey);
+      }
+    }
+    return handlerKeys;
+  }
+
   async #drainSpooledUpdates(params: {
     bot: TelegramBot;
     spoolDir: string;
@@ -741,25 +751,32 @@ export class TelegramPollingSession {
       try {
         const drain = await this.#drainSpooledUpdates({ bot, spoolDir });
         consecutiveDrainFailures = 0;
+        const timeoutCandidateHandlerKeys = this.#activeSpooledUpdateHandlerKeysForSpool(spoolDir);
+        for (const handlerKey of drain.blockedByLane) {
+          timeoutCandidateHandlerKeys.add(handlerKey);
+        }
         for (const handlerKey of stalledBacklogKeys) {
           if (
             !activeSpooledUpdateHandlersByLane.has(handlerKey) ||
-            !drain.blockedByLane.has(handlerKey)
+            (!drain.blockedByLane.has(handlerKey) && !timeoutCandidateHandlerKeys.has(handlerKey))
           ) {
             stalledBacklogKeys.delete(handlerKey);
           }
         }
-        for (const handlerKey of drain.blockedByLane) {
+        for (const handlerKey of timeoutCandidateHandlerKeys) {
           const handler = activeSpooledUpdateHandlersByLane.get(handlerKey);
           if (handler?.timedOutAt === undefined) {
             continue;
           }
+          const alreadyStalled = stalledBacklogKeys.has(handlerKey);
           stalledBacklogKeys.add(handlerKey);
-          if (handler.timeoutMessage) {
+          if (!alreadyStalled && handler.timeoutMessage) {
             this.#status.notePollingError(handler.timeoutMessage);
           }
         }
-        const timedOutRecovery = await this.#recoverTimedOutSpooledHandler(drain.blockedByLane);
+        const timedOutRecovery = await this.#recoverTimedOutSpooledHandler(
+          timeoutCandidateHandlerKeys,
+        );
         if (timedOutRecovery?.restart) {
           restartRequested = true;
           void worker.stop();


### PR DESCRIPTION
## Summary

- Include active Telegram isolated-ingress handlers in timeout recovery candidates, even when no later same-lane update is queued.
- Keep timed-out active handlers marked as stalled until they settle or are recovered.
- Add regression coverage for a lone `.json.processing` topic update timing out without backlog.

Fixes #84158.

## Real behavior proof

Behavior or issue addressed:
A lone active Telegram isolated-ingress `.json.processing` claim could be missed by timeout recovery when no later same-lane update existed to populate `blockedByLane`.

Real environment tested:
Local macOS checkout at commit `43c2a0c7b1`, using the real `TelegramPollingSession`, Telegram ingress spool, reply fence, and isolated-ingress drain/recovery code with a local mock Telegram bot runtime and no network calls.

Exact steps or command run after this patch:
`PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node --import tsx /private/tmp/proof-84158.mjs`

Evidence after fix:
Terminal output from the live isolated-ingress spool proof:
```text
openclaw-telegram-lone-spooled-timeout-proof=ok
events=bot0:42
bot_instances=2
pending_update_ids=none
failed_update_ids=42
timeout_log_present=true
```

Observed result after fix:
The single claimed topic update `42` timed out without any later same-lane backlog, was written as a failed tombstone, left no pending updates behind, logged the timeout, and restarted isolated ingress.

What was not tested:
I did not connect to the live Telegram Bot API. The proof avoids external network calls and exercises the local spool/recovery behavior directly.

## Validation

- `NODE_OPTIONS=--max-old-space-size=8192 OPENCLAW_VITEST_MAX_WORKERS=1 PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node scripts/run-vitest.mjs extensions/telegram/src/polling-session.test.ts --pool forks --maxWorkers 1 --vmMemoryLimit 8192MB` - 43 passed
- `PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node_modules/.bin/oxfmt --check --threads=1 extensions/telegram/src/polling-session.ts extensions/telegram/src/polling-session.test.ts`
- `PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node_modules/.bin/oxlint extensions/telegram/src/polling-session.ts extensions/telegram/src/polling-session.test.ts`
- `git diff --check`
- `git log --format='%h %an <%ae> %s' upstream/main..HEAD`:
  `43c2a0c7b1 Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com> fix(telegram): recover lone timed-out spool handlers`
