### PR TITLE
fix(doctor): preserve legacy agentRuntime when merging codex route config

### DIFF
--- a/src/commands/doctor/shared/codex-route-warnings.ts
+++ b/src/commands/doctor/shared/codex-route-warnings.ts
@@ -1313,7 +1313,7 @@ function rewriteModelsMap(params: {
     const canonicalRecord = asMutableRecord(canonicalEntry);
     params.models[canonicalModel] =
       legacyRecord && canonicalRecord
-        ? { ...legacyRecord, ...canonicalRecord }
+        ? { ...canonicalRecord, ...legacyRecord }
         : (canonicalEntry ?? legacyEntry);
     delete params.models[legacyRef];
   }


### PR DESCRIPTION
## Problem

`openclaw doctor --fix` silently migrates `openai-codex/*` config to `openai/*`, but the merge order causes canonical's agentRuntime to overwrite user-explicit agentRuntime settings.

**Impact**: Users who explicitly configured PI runtime to work around Codex bugs get silently migrated back to Codex, causing 3-4x token inflation.

## Root Cause

`src/commands/doctor/shared/codex-route-warnings.ts:1314` — rewriteModelsMap merges canonical into legacy, but canonical fields (including agentRuntime) take priority over legacy.

## Fix

Flip merge order from `{ ...legacyRecord, ...canonicalRecord }` to `{ ...canonicalRecord, ...legacyRecord }` so user-explicit settings (like PI runtime) take priority over canonical defaults.

## Test

All existing tests pass.

Fixes #84038