### PR TITLE
fix(discord): preserve reasoning progress deltas

### DIFF
--- a/extensions/discord/src/monitor/message-handler.draft-preview.ts
+++ b/extensions/discord/src/monitor/message-handler.draft-preview.ts
@@ -1,4 +1,4 @@
-import { EmbeddedBlockChunker } from "openclaw/plugin-sdk/agent-runtime";
+import { EmbeddedBlockChunker, formatReasoningMessage } from "openclaw/plugin-sdk/agent-runtime";
 import {
   createChannelProgressDraftGate,
   type ChannelProgressDraftLine,
@@ -231,7 +231,9 @@ export function createDiscordDraftPreviewController(params: {
         return;
       }
       reasoningProgressRawText = mergeReasoningProgressText(reasoningProgressRawText, text);
-      const normalized = normalizeReasoningProgressLine(reasoningProgressRawText);
+      const normalized = normalizeReasoningProgressLine(
+        formatReasoningMessage(reasoningProgressRawText),
+      );
       if (!normalized) {
         return;
       }

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -2402,6 +2402,38 @@ describe("processDiscordMessage draft streaming", () => {
     expect(updates.join("\n")).not.toContain("_Checking files_Thinking");
   });
 
+  it("appends reasoning deltas before formatting progress text", async () => {
+    const draftStream = createMockDraftStreamForTest();
+
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      await params?.replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+      await params?.replyOptions?.onReasoningStream?.({ text: "Considering" });
+      await params?.replyOptions?.onReasoningStream?.({ text: " plugin" });
+      await params?.replyOptions?.onReasoningStream?.({ text: " installation" });
+      await params?.replyOptions?.onReasoningStream?.({ text: "!" });
+      return createNoQueuedDispatchResult();
+    });
+
+    const ctx = await createAutomaticSourceDeliveryContext({
+      discordConfig: {
+        streaming: {
+          mode: "progress",
+          progress: {
+            label: "Clawing...",
+          },
+        },
+      },
+    });
+
+    await runProcessDiscordMessage(ctx);
+
+    expect(draftStream.update).toHaveBeenCalledWith(
+      "Clawing...\n\n🛠️ Exec\n• _Considering plugin installation!_",
+    );
+    const updates = draftStream.update.mock.calls.map((call) => call[0]);
+    expect(updates.join("\n")).not.toContain("• _!_");
+  });
+
   it("keeps Discord progress lines across assistant boundaries", async () => {
     const draftStream = createMockDraftStreamForTest();
 

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -1,10 +1,6 @@
 import path from "node:path";
 import { MessageFlags } from "discord-api-types/v10";
-import {
-  formatReasoningMessage,
-  resolveAckReaction,
-  resolveHumanDelayConfig,
-} from "openclaw/plugin-sdk/agent-runtime";
+import { resolveAckReaction, resolveHumanDelayConfig } from "openclaw/plugin-sdk/agent-runtime";
 import {
   createStatusReactionController,
   DEFAULT_TIMING,
@@ -824,10 +820,7 @@ export async function processDiscordMessage(
               : undefined,
             onReasoningStream: async (payload) => {
               await statusReactions.setThinking();
-              const formattedText = payload?.text
-                ? formatReasoningMessage(payload.text)
-                : undefined;
-              await draftPreview.pushReasoningProgress(formattedText);
+              await draftPreview.pushReasoningProgress(payload?.text);
             },
             onToolStart: async (payload) => {
               if (isProcessAborted(abortSignal)) {


### PR DESCRIPTION
## Summary

- Keep Discord reasoning progress text raw until draft-preview merging decides whether incoming text is a delta or a snapshot.
- Format the merged reasoning text once for Discord display, preserving the existing italic progress-line rendering.
- Add a regression for fragment-style reasoning deltas so the progress draft no longer collapses to the final token.

Fixes #83983.

## Real behavior proof

Behavior or issue addressed:
Discord progress-mode reasoning deltas were formatted with the `Thinking` display prefix before merge, causing the draft preview to treat every delta as a full snapshot and replace earlier reasoning text.

Real environment tested:
Local OpenClaw checkout on macOS using the real Discord draft-preview controller and a fake Discord REST client that records the outgoing preview message content.

Exact steps or command run after this patch:
`PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node --import tsx /private/tmp/proof-83983.mjs`

Evidence after fix:
```text
openclaw-discord-reasoning-delta-proof=ok
write_count=2
final_preview=Clawing...\n\n• _Considering plugin installation!_
final_delta_only_present=false
```

Observed result after fix:
Four raw reasoning deltas (`Considering`, ` plugin`, ` installation`, `!`) produced one merged Discord progress line, and the final-delta-only preview was absent.

What was not tested:
No live Discord guild was called; the proof uses the real draft-preview code path with a local fake REST client.

## Validation

- `NODE_OPTIONS=--max-old-space-size=8192 OPENCLAW_VITEST_MAX_WORKERS=1 PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node scripts/run-vitest.mjs extensions/discord/src/monitor/message-handler.process.test.ts -t "reasoning" --pool forks --maxWorkers 1 --vmMemoryLimit 8192MB`
- `NODE_OPTIONS=--max-old-space-size=8192 OPENCLAW_VITEST_MAX_WORKERS=1 PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node scripts/run-vitest.mjs extensions/discord/src/monitor/message-handler.process.test.ts extensions/codex/src/app-server/event-projector.test.ts src/agents/pi-embedded-utils.test.ts --pool forks --maxWorkers 1 --vmMemoryLimit 8192MB`
- `PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/andy/openclaw-83983/node_modules/.bin:$PATH oxfmt --check extensions/discord/src/monitor/message-handler.process.ts extensions/discord/src/monitor/message-handler.draft-preview.ts extensions/discord/src/monitor/message-handler.process.test.ts`
- `PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/andy/openclaw-83983/node_modules/.bin:$PATH oxlint extensions/discord/src/monitor/message-handler.process.ts extensions/discord/src/monitor/message-handler.draft-preview.ts extensions/discord/src/monitor/message-handler.process.test.ts`
- `git diff --check`

## Maintainer note

If this PR is squashed or reworked, please preserve author attribution or include:

`Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>`
