### PR TITLE
fix(agents): forward turn-source for embedded plugin before_tool_call approvals

### DIFF
--- a/src/agents/pi-tools.before-tool-call.embedded-mode.test.ts
+++ b/src/agents/pi-tools.before-tool-call.embedded-mode.test.ts
@@ -228,6 +228,53 @@ describe("runBeforeToolCallHook — embedded mode approvals", () => {
     }
   });
 
+  it("forwards turn-source so embedded plugin approvals can be delivered back to the originating chat", async () => {
+    // Regression: a `before_tool_call` requireApproval from the embedded
+    // runner used to drop the turn-source, so the gateway had no route to
+    // deliver the approval to the chat (Telegram) and resolved it as
+    // `no-approval-route` (decision: null) — blocking the tool while the
+    // model often hallucinated a fake "/approve" instruction and a success.
+    // Bash exec approvals already carry these fields; plugin approvals must
+    // too. See pi-tools.ts (HookContext turnSource* wiring).
+    setEmbeddedMode(true);
+
+    runBeforeToolCallMock.mockResolvedValue({
+      requireApproval: {
+        pluginId: "pages",
+        title: "Delete site",
+        description: "Permanently delete the site",
+        severity: "critical",
+      },
+    });
+    mockCallGatewayTool.mockResolvedValueOnce({
+      id: "plugin:abc",
+      decision: PluginApprovalResolutions.ALLOW_ONCE,
+    });
+
+    const result = await runBeforeToolCallHook({
+      toolName: "pages_delete",
+      params: { slug: "padel-lead-magnet" },
+      toolCallId: "call-del",
+      ctx: {
+        turnSourceChannel: "telegram",
+        turnSourceTo: "172724380",
+        turnSourceAccountId: "default",
+        turnSourceThreadId: "42",
+      },
+    });
+
+    expect(result.blocked).toBe(false);
+    const approvalCall = requireApprovalRequestCall("plugin approval request");
+    expect(approvalCall.request).toMatchObject({
+      pluginId: "pages",
+      toolName: "pages_delete",
+      turnSourceChannel: "telegram",
+      turnSourceTo: "172724380",
+      turnSourceAccountId: "default",
+      turnSourceThreadId: "42",
+    });
+  });
+
   it("routes trusted policy approval through the same approval gate as before_tool_call hooks", async () => {
     setEmbeddedMode(true);
     const registry = createEmptyPluginRegistry();

--- a/src/agents/pi-tools.before-tool-call.ts
+++ b/src/agents/pi-tools.before-tool-call.ts
@@ -62,6 +62,17 @@ export type HookContext = {
   runId?: string;
   trace?: DiagnosticTraceContext;
   channelId?: string;
+  /**
+   * Turn-source routing so a plugin `before_tool_call` requireApproval can be
+   * delivered back to the originating chat (e.g. Telegram) from the embedded
+   * runner. Without these, `plugin.approval.request` has no delivery route and
+   * resolves `decision: null` ("no approval route") — exec/bash approvals
+   * already carry the same fields. See requestPluginToolApproval below.
+   */
+  turnSourceChannel?: string;
+  turnSourceTo?: string;
+  turnSourceAccountId?: string;
+  turnSourceThreadId?: string | number;
   loopDetection?: ToolLoopDetectionConfig;
   onToolOutcome?: ToolOutcomeObserver;
   sandbox?: {
@@ -196,6 +207,13 @@ async function requestPluginToolApproval(params: {
         toolCallId: params.toolCallId,
         agentId: params.ctx?.agentId,
         sessionKey: params.ctx?.sessionKey,
+        // Turn-source so the gateway can route the approval back to the
+        // originating chat (mirrors bash exec approval delivery). Without
+        // this, embedded-runner plugin approvals have no delivery route.
+        turnSourceChannel: params.ctx?.turnSourceChannel,
+        turnSourceTo: params.ctx?.turnSourceTo,
+        turnSourceAccountId: params.ctx?.turnSourceAccountId,
+        turnSourceThreadId: params.ctx?.turnSourceThreadId,
         timeoutMs: approval.timeoutMs ?? 120_000,
         twoPhase: true,
       },

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -1091,6 +1091,13 @@ export function createOpenClawCodingTools(options?: {
         sessionId: options?.sessionId,
         runId: options?.runId,
         channelId: options?.hookChannelId ?? options?.currentChannelId,
+        // Carry turn-source so plugin before_tool_call requireApproval can be
+        // delivered back to the originating chat (parity with bash exec
+        // approval, see bash-tools.exec.ts turnSource* wiring).
+        turnSourceChannel: options?.messageProvider,
+        turnSourceTo: options?.currentChannelId,
+        turnSourceAccountId: options?.agentAccountId,
+        turnSourceThreadId: options?.currentThreadTs,
         ...(options?.trace ? { trace: options.trace } : {}),
         loopDetection: resolveToolLoopDetectionConfig({ cfg: options?.config, agentId }),
         onToolOutcome: options?.onToolOutcome,


### PR DESCRIPTION
## Summary

A plugin `before_tool_call` hook that returns `requireApproval` is **unusable from the embedded agent runner** when the only delivery path is the originating chat (e.g. a self-hosted Telegram bot with no connected operator approval client and no forwarder).

`requestPluginToolApproval` (`src/agents/pi-tools.before-tool-call.ts`) builds the `plugin.approval.request` payload **without any turn-source fields**, and `HookContext` has no place to carry them. So `hasApprovalTurnSourceRoute()` can never be satisfied, the gateway takes the `!hasApprovalClients && !hasTurnSourceRoute && !delivered` branch in `src/gateway/server-methods/approval-shared.ts`, expires the request as `no-approval-route`, and returns `decision: null`. The tool is then blocked with `Plugin approval unavailable (no approval route)` — and in practice the model frequently papers over the failure by **hallucinating a fake `/approve` instruction and a bogus success message**, so a destructive tool silently never runs while the user is told it did.

Bash/exec approvals already work in chat because `src/agents/bash-tools.exec.ts` forwards `turnSourceChannel/turnSourceTo/turnSourceAccountId/turnSourceThreadId`. The gateway request schema (`src/gateway/protocol/schema/plugin-approvals.ts`) and the Telegram native approval adapter already accept and handle plugin-kind approvals — **only the agent-side propagation was missing**.

## Change

Purely additive, mirrors the existing bash exec wiring:

- add the four optional `turnSource*` fields to `HookContext`
- include them in the `plugin.approval.request` payload
- populate them at the embedded wrap site in `pi-tools.ts` from the run options

The fields are optional and already declared in the gateway request schema, so there is no protocol change.

## Verification

New regression test in `src/agents/pi-tools.before-tool-call.embedded-mode.test.ts` asserts an embedded plugin approval forwards turn-source so it can be delivered back to the originating chat.

Demonstrated red → green on a clean checkout of this branch's base:

- **without the fix** (revert the two source files, keep the test): the new test fails — the `plugin.approval.request` payload omits `turnSourceChannel/turnSourceTo/turnSourceAccountId/turnSourceThreadId`; the 7 pre-existing tests in the file still pass (no regression).
- **with the fix**: all 8 tests pass.

```
pnpm test src/agents/pi-tools.before-tool-call.embedded-mode.test.ts
# Test Files  1 passed (1)
# Tests  8 passed (8)
```

Also reproduced/fixed end-to-end on a self-hosted Telegram deployment: before the change, `pages_delete` gated behind `requireApproval` logged `pages_delete failed: Plugin approval unavailable (no approval route)` and the deletion never happened despite the bot claiming success.
