### PR TITLE
fix(codex): keep message dynamic tool direct

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.test.ts
@@ -184,11 +184,8 @@ describe("createCodexDynamicToolBridge", () => {
       namespace: CODEX_OPENCLAW_DYNAMIC_TOOL_NAMESPACE,
       deferLoading: true,
     });
-    expectDynamicSpec(message, {
-      name: "message",
-      namespace: CODEX_OPENCLAW_DYNAMIC_TOOL_NAMESPACE,
-      deferLoading: true,
-    });
+    expectDynamicSpec(message, { name: "message" });
+    expectNoNamespace(message);
     expectDynamicSpec(heartbeat, {
       name: HEARTBEAT_RESPONSE_TOOL_NAME,
       namespace: CODEX_OPENCLAW_DYNAMIC_TOOL_NAMESPACE,

--- a/extensions/codex/src/app-server/dynamic-tools.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.ts
@@ -63,9 +63,10 @@ export type CodexDynamicToolBridge = {
 
 export const CODEX_OPENCLAW_DYNAMIC_TOOL_NAMESPACE = "openclaw";
 
-// Keep OpenClaw session spawning searchable in Codex mode so Codex's native
-// spawn_agent remains the primary Codex subagent surface.
-const ALWAYS_DIRECT_DYNAMIC_TOOL_NAMES = new Set(["sessions_yield"]);
+// Keep message direct so source delivery-mode flips do not change a resumed
+// Codex thread's visible-reply tool contract. Keep OpenClaw session spawning
+// searchable so Codex's native spawn_agent remains the primary Codex subagent surface.
+const ALWAYS_DIRECT_DYNAMIC_TOOL_NAMES = new Set(["message", "sessions_yield"]);
 const DEFAULT_CODEX_DYNAMIC_TOOL_RESULT_MAX_CHARS = 16_000;
 
 export function createCodexDynamicToolBridge(params: {

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -8129,6 +8129,79 @@ describe("runCodexAppServerAttempt", () => {
     ]);
   });
 
+  it("resumes Codex threads when source reply mode toggles message-tool-only", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    testing.setOpenClawCodingToolsFactoryForTests(() => [
+      createRuntimeDynamicTool("message"),
+      createRuntimeDynamicTool("web_search"),
+    ]);
+    const harness = createStartedThreadHarness(async (method) => {
+      if (method === "thread/resume") {
+        return threadStartResult();
+      }
+      return undefined;
+    });
+    const createRunParams = (sourceReplyDeliveryMode?: "automatic" | "message_tool_only") => {
+      const params = createParams(sessionFile, workspaceDir);
+      params.disableTools = false;
+      params.runtimePlan = createCodexRuntimePlanFixture();
+      if (sourceReplyDeliveryMode) {
+        params.sourceReplyDeliveryMode = sourceReplyDeliveryMode;
+      }
+      return params;
+    };
+    const completeTurnNumber = async (run: Promise<unknown>, turnStartCount: number) => {
+      await vi.waitFor(
+        () => {
+          expect(
+            harness.requests.filter((request) => request.method === "turn/start"),
+          ).toHaveLength(turnStartCount);
+        },
+        { interval: 1, timeout: 120_000 },
+      );
+      await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+      await run;
+    };
+
+    await completeTurnNumber(
+      runCodexAppServerAttempt(createRunParams("automatic"), {
+        pluginConfig: { appServer: { mode: "yolo" } },
+      }),
+      1,
+    );
+    const firstFingerprint = (await readCodexAppServerBinding(sessionFile))
+      ?.dynamicToolsFingerprint;
+    await completeTurnNumber(
+      runCodexAppServerAttempt(createRunParams("message_tool_only"), {
+        pluginConfig: { appServer: { mode: "yolo" } },
+      }),
+      2,
+    );
+
+    const binding = await readCodexAppServerBinding(sessionFile);
+    const startRequest = harness.requests.find((request) => request.method === "thread/start");
+    const startDynamicTools =
+      (startRequest?.params as { dynamicTools?: Array<Record<string, unknown>> } | undefined)
+        ?.dynamicTools ?? [];
+    const resumeRequest = harness.requests.find((request) => request.method === "thread/resume");
+    const resumeDeveloperInstructions =
+      (resumeRequest?.params as { developerInstructions?: string } | undefined)
+        ?.developerInstructions ?? "";
+    expect(
+      harness.requests
+        .map((request) => request.method)
+        .filter((method) => method === "thread/start" || method === "thread/resume"),
+    ).toEqual(["thread/start", "thread/resume"]);
+    expect(binding?.threadId).toBe("thread-1");
+    expect(binding?.dynamicToolsFingerprint).toBe(firstFingerprint);
+    const message = startDynamicTools.find((tool) => tool.name === "message");
+    expect(message).toBeTruthy();
+    expect(message).not.toHaveProperty("namespace");
+    expect(message).not.toHaveProperty("deferLoading");
+    expect(resumeDeveloperInstructions).toContain("Visible channel replies: use `message`");
+  });
+
   it("keeps plugin app bindings across transient native-tool-disabled turns", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");


### PR DESCRIPTION
## Summary

- Keep the OpenClaw `message` dynamic tool direct for Codex app-server threads in every source-reply mode.
- Preserve deferred loading for other searchable OpenClaw tools, including `web_search`, while keeping `sessions_yield` direct.
- Add a two-turn regression showing an automatic turn followed by `message_tool_only` resumes the existing Codex thread and still carries the visible-reply instruction.

Fixes #84086.

## Real behavior proof

Behavior or issue addressed:
Discord room-event turns can flip `sourceReplyDeliveryMode` to `message_tool_only`; when `message` alternated between deferred and direct dynamic-tool specs, Codex native thread bindings could churn even when the tool count stayed the same.

Real environment tested:
Local OpenClaw checkout on macOS using the real Codex dynamic-tool bridge and fingerprint code with mocked tool implementations.

Exact steps or command run after this patch:
`PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node --import tsx /private/tmp/proof-84086.mjs`

Evidence after fix:
```text
openclaw-codex-message-tool-contract-proof=ok
automatic_message_direct=true
message_tool_only_message_direct=true
fingerprints_equal=true
deferred_tools=web_search
```

Observed result after fix:
The `message` dynamic tool is direct for both ordinary and `message_tool_only` Codex turns, the dynamic-tool fingerprint is stable across those modes, and unrelated tools remain deferred/searchable.

What was not tested:
No live Discord production trajectory was replayed; the proof exercises the real Codex dynamic-tool construction and fingerprint path locally.

## Validation

- `NODE_OPTIONS=--max-old-space-size=8192 OPENCLAW_VITEST_MAX_WORKERS=1 PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node scripts/run-vitest.mjs extensions/codex/src/app-server/dynamic-tools.test.ts -t "keeps turn-yield direct" --pool forks --maxWorkers 1 --vmMemoryLimit 8192MB`
- `NODE_OPTIONS=--max-old-space-size=8192 OPENCLAW_VITEST_MAX_WORKERS=1 PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts -t "resumes Codex threads when source reply mode toggles" --pool forks --maxWorkers 1 --vmMemoryLimit 8192MB`
- `NODE_OPTIONS=--max-old-space-size=8192 OPENCLAW_VITEST_MAX_WORKERS=1 PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node scripts/run-vitest.mjs extensions/codex/src/app-server/dynamic-tools.test.ts extensions/codex/src/app-server/thread-lifecycle.test.ts extensions/codex/src/app-server/run-attempt.test.ts --pool forks --maxWorkers 1 --vmMemoryLimit 8192MB`
- `NODE_OPTIONS=--max-old-space-size=8192 OPENCLAW_VITEST_MAX_WORKERS=1 PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node scripts/run-vitest.mjs src/auto-reply/reply/source-reply-delivery-mode.test.ts src/auto-reply/reply/get-reply-run.media-only.test.ts src/agents/tools/message-tool.test.ts --pool forks --maxWorkers 1 --vmMemoryLimit 8192MB`
- `PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/andy/openclaw-84086/node_modules/.bin:$PATH oxfmt --check extensions/codex/src/app-server/dynamic-tools.ts extensions/codex/src/app-server/dynamic-tools.test.ts extensions/codex/src/app-server/run-attempt.test.ts`
- `PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/andy/openclaw-84086/node_modules/.bin:$PATH oxlint extensions/codex/src/app-server/dynamic-tools.ts extensions/codex/src/app-server/dynamic-tools.test.ts extensions/codex/src/app-server/run-attempt.test.ts`
- `git diff --check`

## Maintainer note

If this PR is squashed or reworked, please preserve author attribution or include:

`Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>`
