### PR TITLE
fix(doctor): handle gateway SecretRefs in auth checks

### DIFF
--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -40,6 +40,7 @@ openclaw doctor
 openclaw doctor --lint
 openclaw doctor --lint --json
 openclaw doctor --lint --severity-min warning
+openclaw doctor --lint --allow-exec
 openclaw doctor --deep
 openclaw doctor --fix
 openclaw doctor --fix --non-interactive
@@ -64,6 +65,7 @@ The targeted Discord capabilities probe reports the bot's effective channel perm
 - `--force`: apply aggressive repairs, including overwriting custom service config when needed
 - `--non-interactive`: run without prompts; safe migrations and non-service repairs only
 - `--generate-gateway-token`: generate and configure a gateway token
+- `--allow-exec`: allow doctor to execute configured exec SecretRefs while verifying secrets
 - `--deep`: scan system services for extra gateway installs and report recent Gateway supervisor restart handoffs
 - `--lint`: run modernized health checks in read-only mode and emit diagnostic findings
 - `--json`: with `--lint`, emit JSON findings instead of human output
@@ -84,6 +86,7 @@ are only accepted with `--lint`.
 openclaw doctor --lint
 openclaw doctor --lint --severity-min warning
 openclaw doctor --lint --json
+openclaw doctor --lint --allow-exec
 openclaw doctor --lint --only core/doctor/gateway-config --json
 ```
 
@@ -191,6 +194,7 @@ Notes:
 - Interactive prompts (like keychain/OAuth fixes) only run when stdin is a TTY and `--non-interactive` is **not** set. Headless runs (cron, Telegram, no terminal) will skip prompts.
 - Performance: non-interactive `doctor` runs skip eager plugin loading so headless health checks stay fast. Interactive doctor sessions still load the plugin surfaces needed by the legacy health and repair flow.
 - `--lint` is stricter than `--non-interactive`: it is always read-only, never prompts, and never applies safe migrations. Run `doctor --fix` or `doctor --repair` when you want doctor to make changes.
+- By default, doctor does not execute `exec` SecretRefs while checking secrets. Use `openclaw doctor --allow-exec` or `openclaw doctor --lint --allow-exec` only when you intentionally want doctor to run those configured secret resolvers.
 - `--fix` (alias for `--repair`) writes a backup to `~/.openclaw/openclaw.json.bak` and drops unknown config keys, listing each removal.
 - Modernized health checks can expose a `repair()` path for `doctor --fix`; checks that do not expose one continue through the existing doctor repair flow.
 - `doctor --fix --non-interactive` reports missing or stale gateway service definitions but does not install or rewrite them outside update repair mode. Run `openclaw gateway install` for a missing service, or `openclaw gateway install --force` when you intentionally want to replace the launcher.
@@ -214,7 +218,7 @@ Notes:
 - Doctor warns when skills allowed for the default agent are unavailable in the current runtime environment because bins, env vars, config, or OS requirements are missing. `doctor --fix` can disable those unavailable skills with `skills.entries.<skill>.enabled=false`; install/configure the missing requirement instead when you want to keep the skill active.
 - If sandbox mode is enabled but Docker is unavailable, doctor reports a high-signal warning with remediation (`install Docker` or `openclaw config set agents.defaults.sandbox.mode off`).
 - If legacy sandbox registry files (`~/.openclaw/sandbox/containers.json` or `~/.openclaw/sandbox/browsers.json`) are present, doctor reports them; `openclaw doctor --fix` migrates valid entries into sharded registry directories and quarantines invalid legacy files.
-- If `gateway.auth.token`/`gateway.auth.password` are SecretRef-managed and unavailable in the current command path, doctor reports a read-only warning and does not write plaintext fallback credentials.
+- If `gateway.auth.token`/`gateway.auth.password` are SecretRef-managed and unavailable in the current command path, doctor reports a read-only warning and does not write plaintext fallback credentials. For exec-backed SecretRefs, doctor skips execution unless `--allow-exec` is present.
 - If channel SecretRef inspection fails in a fix path, doctor continues and reports a warning instead of exiting early.
 - After state-directory migrations, doctor warns when enabled default Telegram or Discord accounts depend on env fallback and `TELEGRAM_BOT_TOKEN` or `DISCORD_BOT_TOKEN` is unavailable to the doctor process.
 - Telegram `allowFrom` username auto-resolution (`doctor --fix`) requires a resolvable Telegram token in the current command path. If token inspection is unavailable, doctor reports a warning and skips auto-resolution for that pass.

--- a/src/cli/program/register.maintenance.test.ts
+++ b/src/cli/program/register.maintenance.test.ts
@@ -70,13 +70,14 @@ describe("registerMaintenanceCommands doctor action", () => {
   it("exits with code 0 after successful doctor run", async () => {
     doctorCommand.mockResolvedValue(undefined);
 
-    await runMaintenanceCli(["doctor", "--non-interactive", "--yes"]);
+    await runMaintenanceCli(["doctor", "--non-interactive", "--yes", "--allow-exec"]);
 
     expect(doctorCommand).toHaveBeenCalledTimes(1);
     const [runtimeArg, options] = commandCall(doctorCommand);
     expect(runtimeArg).toBe(runtime);
     expect(options.nonInteractive).toBe(true);
     expect(options.yes).toBe(true);
+    expect(options.allowExec).toBe(true);
     expect(runtime.exit).toHaveBeenCalledWith(0);
   });
 
@@ -114,6 +115,7 @@ describe("registerMaintenanceCommands doctor action", () => {
       "a",
       "--only",
       "b",
+      "--allow-exec",
     ]);
 
     expect(doctorCommand).not.toHaveBeenCalled();
@@ -122,6 +124,7 @@ describe("registerMaintenanceCommands doctor action", () => {
       severityMin: "error",
       skipIds: ["a"],
       onlyIds: ["b"],
+      allowExec: true,
     });
     expect(runtime.exit).toHaveBeenCalledWith(1);
   });

--- a/src/cli/program/register.maintenance.ts
+++ b/src/cli/program/register.maintenance.ts
@@ -20,6 +20,11 @@ export function registerMaintenanceCommands(program: Command) {
     .option("--force", "Apply aggressive repairs (overwrites custom service config)", false)
     .option("--non-interactive", "Run without prompts (safe migrations only)", false)
     .option("--generate-gateway-token", "Generate and configure a gateway token", false)
+    .option(
+      "--allow-exec",
+      "Allow doctor to execute exec SecretRefs while verifying configured secrets",
+      false,
+    )
     .option("--deep", "Scan system services for extra gateway installs", false)
     .option("--lint", "Run read-only health checks and report findings", false)
     .option("--json", "With --lint: emit JSON findings instead of human output", false)
@@ -50,6 +55,7 @@ export function registerMaintenanceCommands(program: Command) {
               severityMin: typeof opts.severityMin === "string" ? opts.severityMin : undefined,
               skipIds: Array.isArray(opts.skip) ? opts.skip : [],
               onlyIds: Array.isArray(opts.only) ? opts.only : [],
+              allowExec: Boolean(opts.allowExec),
             });
             defaultRuntime.exit(exitCode);
           },
@@ -76,6 +82,7 @@ export function registerMaintenanceCommands(program: Command) {
           force: Boolean(opts.force),
           nonInteractive: Boolean(opts.nonInteractive),
           generateGatewayToken: Boolean(opts.generateGatewayToken),
+          allowExec: Boolean(opts.allowExec),
           deep: Boolean(opts.deep),
         });
         defaultRuntime.exit(0);

--- a/src/commands/doctor-gateway-auth-token.test.ts
+++ b/src/commands/doctor-gateway-auth-token.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { withTempHome, writeStateDirDotEnv } from "../config/test-helpers.js";
@@ -9,6 +12,36 @@ import {
 import { resolveGatewayInstallToken } from "./gateway-install-token.js";
 
 const envVar = (...parts: string[]) => parts.join("_");
+
+function createExecGatewayTokenConfig(markerPath: string): OpenClawConfig {
+  return {
+    gateway: {
+      auth: {
+        token: {
+          source: "exec",
+          provider: "execmain",
+          id: "gateway/token",
+        },
+      },
+    },
+    secrets: {
+      providers: {
+        execmain: {
+          source: "exec",
+          command: process.execPath,
+          args: [
+            "-e",
+            [
+              "const fs = require('node:fs');",
+              `fs.writeFileSync(${JSON.stringify(markerPath)}, 'executed');`,
+              "process.stdout.write(JSON.stringify({ protocolVersion: 1, values: { 'gateway/token': 'exec-token' } }));",
+            ].join(""),
+          ],
+        },
+      },
+    },
+  } as OpenClawConfig;
+}
 
 describe("resolveGatewayAuthTokenForService", () => {
   it("returns plaintext gateway.auth.token when configured", async () => {
@@ -72,6 +105,39 @@ describe("resolveGatewayAuthTokenForService", () => {
     );
 
     expect(resolved).toEqual({ token: "resolved-token" });
+  });
+
+  it("skips exec SecretRefs by default for service token checks", async () => {
+    const tmp = await fs.mkdtemp(join(tmpdir(), "openclaw-service-token-exec-ref-"));
+    const markerPath = join(tmp, "exec-ran");
+    try {
+      const resolved = await resolveGatewayAuthTokenForService(
+        createExecGatewayTokenConfig(markerPath),
+        {} as NodeJS.ProcessEnv,
+      );
+
+      expect(resolved).toEqual({});
+      await expect(fs.access(markerPath)).rejects.toThrow();
+    } finally {
+      await fs.rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("executes exec SecretRefs for service token checks when explicitly allowed", async () => {
+    const tmp = await fs.mkdtemp(join(tmpdir(), "openclaw-service-token-exec-ref-"));
+    const markerPath = join(tmp, "exec-ran");
+    try {
+      const resolved = await resolveGatewayAuthTokenForService(
+        createExecGatewayTokenConfig(markerPath),
+        {} as NodeJS.ProcessEnv,
+        { allowExecSecretRefs: true },
+      );
+
+      expect(resolved).toEqual({ token: "exec-token" });
+      await expect(fs.readFile(markerPath, "utf8")).resolves.toBe("executed");
+    } finally {
+      await fs.rm(tmp, { recursive: true, force: true });
+    }
   });
 
   it("falls back to OPENCLAW_GATEWAY_TOKEN when SecretRef is unresolved", async () => {

--- a/src/commands/doctor-gateway-auth-token.test.ts
+++ b/src/commands/doctor-gateway-auth-token.test.ts
@@ -29,6 +29,7 @@ function createExecGatewayTokenConfig(markerPath: string): OpenClawConfig {
         execmain: {
           source: "exec",
           command: process.execPath,
+          allowInsecurePath: true,
           args: [
             "-e",
             [

--- a/src/commands/doctor-gateway-auth-token.ts
+++ b/src/commands/doctor-gateway-auth-token.ts
@@ -1,11 +1,22 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveSecretInputRef } from "../config/types.secrets.js";
 export { shouldRequireGatewayTokenForInstall } from "../gateway/auth-install-policy.js";
 import { resolveGatewayAuthToken } from "../gateway/auth-token-resolution.js";
+import { trimToUndefined } from "../gateway/credentials.js";
 
 export async function resolveGatewayAuthTokenForService(
   cfg: OpenClawConfig,
   env: NodeJS.ProcessEnv,
+  options: { allowExecSecretRefs?: boolean } = {},
 ): Promise<{ token?: string; unavailableReason?: string }> {
+  const tokenRef = resolveSecretInputRef({
+    value: cfg.gateway?.auth?.token,
+    defaults: cfg.secrets?.defaults,
+  }).ref;
+  if (tokenRef?.source === "exec" && options.allowExecSecretRefs !== true) {
+    const envToken = trimToUndefined(env.OPENCLAW_GATEWAY_TOKEN);
+    return envToken ? { token: envToken } : {};
+  }
   const resolved = await resolveGatewayAuthToken({
     cfg,
     env,

--- a/src/commands/doctor-gateway-daemon-flow.test.ts
+++ b/src/commands/doctor-gateway-daemon-flow.test.ts
@@ -333,6 +333,67 @@ describe("maybeRepairGatewayDaemon", () => {
     expect(inspectPortConnections).not.toHaveBeenCalled();
   });
 
+  it("still audits missing service when gateway health was skipped", async () => {
+    setPlatform("linux");
+    service.isLoaded.mockResolvedValueOnce(false);
+    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+
+    await maybeRepairGatewayDaemon({
+      cfg: { gateway: {} },
+      runtime,
+      prompter: createDoctorPrompter({
+        runtime,
+        options: { nonInteractive: true },
+      }),
+      options: { deep: false, nonInteractive: true },
+      gatewayDetailsMessage: "details",
+      healthOk: false,
+      healthSkipped: true,
+    });
+
+    expect(note).toHaveBeenCalledWith("Gateway service not installed.", "Gateway");
+  });
+
+  it("does not audit local services when skipped gateway health is remote", async () => {
+    setPlatform("linux");
+
+    await maybeRepairGatewayDaemon({
+      cfg: { gateway: { mode: "remote" } },
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      prompter: createDoctorPrompter({
+        runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+        options: { nonInteractive: true },
+      }),
+      options: { deep: false, nonInteractive: true },
+      gatewayDetailsMessage: "details",
+      healthOk: false,
+      healthSkipped: true,
+    });
+
+    expect(service.isLoaded).not.toHaveBeenCalled();
+    expect(note).not.toHaveBeenCalledWith("Gateway service not installed.", "Gateway");
+  });
+
+  it("does not start loaded services with unknown runtime when health was skipped", async () => {
+    setPlatform("linux");
+    service.readRuntime.mockResolvedValueOnce({ status: "unknown" });
+
+    await maybeRepairGatewayDaemon({
+      cfg: { gateway: {} },
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      prompter: createDoctorPrompter({
+        runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+        options: { repair: true, nonInteractive: true },
+      }),
+      options: { deep: false, repair: true, nonInteractive: true },
+      gatewayDetailsMessage: "details",
+      healthOk: false,
+      healthSkipped: true,
+    });
+
+    expect(service.restart).not.toHaveBeenCalled();
+  });
+
   it("reports established gateway clients during deep doctor", async () => {
     setPlatform("linux");
     inspectPortConnections.mockResolvedValueOnce({

--- a/src/commands/doctor-gateway-daemon-flow.ts
+++ b/src/commands/doctor-gateway-daemon-flow.ts
@@ -154,12 +154,16 @@ export async function maybeRepairGatewayDaemon(params: {
   options: DoctorOptions;
   gatewayDetailsMessage: string;
   healthOk: boolean;
+  healthSkipped?: boolean;
 }) {
   if (params.healthOk) {
     await maybeReportEstablishedGatewayClients({
       cfg: params.cfg,
       deep: params.options.deep ?? false,
     });
+    return;
+  }
+  if (params.healthSkipped && params.cfg.gateway?.mode === "remote") {
     return;
   }
 
@@ -349,6 +353,9 @@ export async function maybeRepairGatewayDaemon(params: {
   }
 
   if (serviceRuntime?.status !== "running") {
+    if (params.healthSkipped && serviceRuntime?.status !== "stopped") {
+      return;
+    }
     if (serviceRepairExternal) {
       note(EXTERNAL_SERVICE_REPAIR_NOTE, "Gateway");
       return;
@@ -384,6 +391,9 @@ export async function maybeRepairGatewayDaemon(params: {
   }
 
   if (serviceRuntime?.status === "running") {
+    if (params.healthSkipped) {
+      return;
+    }
     if (serviceRepairExternal) {
       note(EXTERNAL_SERVICE_REPAIR_NOTE, "Gateway");
       return;

--- a/src/commands/doctor-gateway-services.test.ts
+++ b/src/commands/doctor-gateway-services.test.ts
@@ -148,8 +148,8 @@ function mockProcessPlatform(platform: NodeJS.Platform) {
   });
 }
 
-async function runRepair(cfg: OpenClawConfig) {
-  await maybeRepairGatewayServiceConfig(cfg, "local", makeDoctorIo(), makeDoctorPrompts());
+async function runRepair(cfg: OpenClawConfig, options: { allowExecSecretRefs?: boolean } = {}) {
+  await maybeRepairGatewayServiceConfig(cfg, "local", makeDoctorIo(), makeDoctorPrompts(), options);
 }
 
 async function runNonInteractiveRepair(params: {
@@ -366,6 +366,37 @@ describe("maybeRepairGatewayServiceConfig", () => {
     expect(mocks.replaceConfigFile).not.toHaveBeenCalled();
     expect(mocks.stage).not.toHaveBeenCalled();
     expect(mocks.install).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes exec SecretRef policy into service token resolution", async () => {
+    setupGatewayTokenRepairScenario();
+
+    const cfg: OpenClawConfig = {
+      gateway: {
+        auth: {
+          mode: "token",
+          token: {
+            source: "exec",
+            provider: "execmain",
+            id: "gateway/token",
+          },
+        },
+      },
+      secrets: {
+        providers: {
+          execmain: {
+            source: "exec",
+            command: process.execPath,
+          },
+        },
+      },
+    };
+
+    await runRepair(cfg, { allowExecSecretRefs: true });
+
+    expect(mocks.resolveGatewayAuthTokenForService).toHaveBeenCalledWith(cfg, process.env, {
+      allowExecSecretRefs: true,
+    });
   });
 
   it("does not duplicate gateway runtime warnings already emitted by the node install plan", async () => {

--- a/src/commands/doctor-gateway-services.ts
+++ b/src/commands/doctor-gateway-services.ts
@@ -354,6 +354,7 @@ export async function maybeRepairGatewayServiceConfig(
   mode: "local" | "remote",
   runtime: RuntimeEnv,
   prompter: DoctorPrompter,
+  options: { allowExecSecretRefs?: boolean } = {},
 ) {
   if (resolveIsNixMode(process.env)) {
     note("Nix mode detected; skip service updates.", "Gateway");
@@ -394,7 +395,9 @@ export async function maybeRepairGatewayServiceConfig(
       defaults: cfg.secrets?.defaults,
     }).ref,
   );
-  const gatewayTokenResolution = await resolveGatewayAuthTokenForService(cfg, process.env);
+  const gatewayTokenResolution = await resolveGatewayAuthTokenForService(cfg, process.env, {
+    allowExecSecretRefs: options.allowExecSecretRefs === true,
+  });
   if (gatewayTokenResolution.unavailableReason) {
     note(
       `Unable to verify gateway service token drift: ${gatewayTokenResolution.unavailableReason}`,

--- a/src/commands/doctor-lint.ts
+++ b/src/commands/doctor-lint.ts
@@ -23,6 +23,7 @@ export interface DoctorLintCliOptions {
   readonly severityMin?: string;
   readonly skipIds?: readonly string[];
   readonly onlyIds?: readonly string[];
+  readonly allowExec?: boolean;
 }
 
 function detectMode(opts: DoctorLintCliOptions): "human" | "json" {
@@ -69,6 +70,7 @@ export async function runDoctorLintCli(
     runtime,
     cfg: snapshot.config,
     cwd: resolveAgentWorkspaceDir(snapshot.config, resolveDefaultAgentId(snapshot.config)),
+    allowExecSecretRefs: opts.allowExec === true,
     ...(snapshot.path !== undefined ? { configPath: snapshot.path } : {}),
   };
   registerBundledHealthChecks({ cfg: snapshot.config, cwd: ctx.cwd });

--- a/src/commands/doctor.types.ts
+++ b/src/commands/doctor.types.ts
@@ -6,4 +6,5 @@ export type DoctorOptions = {
   repair?: boolean;
   force?: boolean;
   generateGatewayToken?: boolean;
+  allowExec?: boolean;
 };

--- a/src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts
+++ b/src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts
@@ -895,6 +895,9 @@ describe("doctor command", () => {
       config: {
         gateway: {
           mode: "remote",
+          auth: {
+            mode: "password",
+          },
           remote: {
             url: "https://gateway.example.test",
             password: {
@@ -946,6 +949,9 @@ describe("doctor command", () => {
       config: {
         gateway: {
           mode: "remote",
+          auth: {
+            mode: "token",
+          },
           remote: {
             url: "https://gateway.example.test",
             token: {

--- a/src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts
+++ b/src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts
@@ -515,6 +515,104 @@ describe("doctor command", () => {
     });
   });
 
+  it("skips token-mode exec token probes even when env password is set", async () => {
+    mockDoctorConfigSnapshot({
+      config: {
+        gateway: {
+          mode: "local",
+          auth: {
+            mode: "token",
+            token: {
+              source: "exec",
+              provider: "default",
+              id: "gateway/token",
+            },
+          },
+        },
+        secrets: {
+          providers: {
+            default: {
+              source: "exec",
+              command: process.execPath,
+            },
+          },
+        },
+      },
+    });
+
+    const previousPassword = process.env.OPENCLAW_GATEWAY_PASSWORD;
+    process.env.OPENCLAW_GATEWAY_PASSWORD = "fallback-password";
+    try {
+      callGateway.mockClear();
+      await doctorCommand(createDoctorRuntime(), {
+        nonInteractive: true,
+        workspaceSuggestions: false,
+      });
+    } finally {
+      if (previousPassword === undefined) {
+        delete process.env.OPENCLAW_GATEWAY_PASSWORD;
+      } else {
+        process.env.OPENCLAW_GATEWAY_PASSWORD = previousPassword;
+      }
+    }
+
+    expect(callGateway).not.toHaveBeenCalled();
+    requireTerminalNote({
+      title: "Gateway",
+      messageIncludes:
+        "Gateway health probes skipped because gateway credentials use an exec SecretRef.",
+    });
+  });
+
+  it("skips password-mode exec password probes even when env token is set", async () => {
+    mockDoctorConfigSnapshot({
+      config: {
+        gateway: {
+          mode: "local",
+          auth: {
+            mode: "password",
+            password: {
+              source: "exec",
+              provider: "default",
+              id: "gateway/password",
+            },
+          },
+        },
+        secrets: {
+          providers: {
+            default: {
+              source: "exec",
+              command: process.execPath,
+            },
+          },
+        },
+      },
+    });
+
+    const previousToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+    process.env.OPENCLAW_GATEWAY_TOKEN = "fallback-token";
+    try {
+      callGateway.mockClear();
+      await doctorCommand(createDoctorRuntime(), {
+        nonInteractive: true,
+        workspaceSuggestions: false,
+      });
+    } finally {
+      if (previousToken === undefined) {
+        delete process.env.OPENCLAW_GATEWAY_TOKEN;
+      } else {
+        process.env.OPENCLAW_GATEWAY_TOKEN = previousToken;
+      }
+    }
+
+    expect(callGateway).not.toHaveBeenCalled();
+    requireTerminalNote({
+      title: "Gateway",
+      messageIncludes:
+        "Gateway health probes skipped because gateway credentials use an exec SecretRef.",
+    });
+  });
+
   it("skips gateway health probes for ambiguous exec SecretRefs", async () => {
     mockDoctorConfigSnapshot({
       config: {

--- a/src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts
+++ b/src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts
@@ -558,6 +558,55 @@ describe("doctor command", () => {
     });
   });
 
+  it("skips remote exec token probes even when env token fallback is set", async () => {
+    mockDoctorConfigSnapshot({
+      config: {
+        gateway: {
+          mode: "remote",
+          remote: {
+            url: "https://gateway.example.test",
+            token: {
+              source: "exec",
+              provider: "default",
+              id: "gateway/remote-token",
+            },
+          },
+        },
+        secrets: {
+          providers: {
+            default: {
+              source: "exec",
+              command: process.execPath,
+            },
+          },
+        },
+      },
+    });
+
+    const previousToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+    process.env.OPENCLAW_GATEWAY_TOKEN = "fallback-token";
+    try {
+      callGateway.mockClear();
+      await doctorCommand(createDoctorRuntime(), {
+        nonInteractive: true,
+        workspaceSuggestions: false,
+      });
+    } finally {
+      if (previousToken === undefined) {
+        delete process.env.OPENCLAW_GATEWAY_TOKEN;
+      } else {
+        process.env.OPENCLAW_GATEWAY_TOKEN = previousToken;
+      }
+    }
+
+    expect(callGateway).not.toHaveBeenCalled();
+    requireTerminalNote({
+      title: "Gateway",
+      messageIncludes:
+        "Gateway health probes skipped because gateway credentials use an exec SecretRef.",
+    });
+  });
+
   it("keeps gateway health probes for non-token auth with exec SecretRefs", async () => {
     mockDoctorConfigSnapshot({
       config: {

--- a/src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts
+++ b/src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts
@@ -386,6 +386,56 @@ describe("doctor command", () => {
     );
   });
 
+  it("does not let OPENCLAW_GATEWAY_TOKEN hide an unresolved SecretRef-managed token", async () => {
+    mockDoctorConfigSnapshot({
+      config: {
+        gateway: {
+          mode: "local",
+          auth: {
+            mode: "token",
+            token: {
+              source: "env",
+              provider: "default",
+              id: "OPENCLAW_MISSING_GATEWAY_REF_TOKEN",
+            },
+          },
+        },
+        secrets: {
+          providers: {
+            default: { source: "env" },
+          },
+        },
+      },
+    });
+
+    const previousFallbackToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+    const previousRefToken = process.env.OPENCLAW_MISSING_GATEWAY_REF_TOKEN;
+    process.env.OPENCLAW_GATEWAY_TOKEN = "fallback-token-1234567890";
+    delete process.env.OPENCLAW_MISSING_GATEWAY_REF_TOKEN;
+    try {
+      await doctorCommand(createDoctorRuntime(), {
+        nonInteractive: true,
+        workspaceSuggestions: false,
+      });
+    } finally {
+      if (previousFallbackToken === undefined) {
+        delete process.env.OPENCLAW_GATEWAY_TOKEN;
+      } else {
+        process.env.OPENCLAW_GATEWAY_TOKEN = previousFallbackToken;
+      }
+      if (previousRefToken === undefined) {
+        delete process.env.OPENCLAW_MISSING_GATEWAY_REF_TOKEN;
+      } else {
+        process.env.OPENCLAW_MISSING_GATEWAY_REF_TOKEN = previousRefToken;
+      }
+    }
+
+    const gatewayAuthNote = requireTerminalNote({ title: "Gateway auth" });
+    expect(String(gatewayAuthNote[0])).toContain(
+      "Gateway token SecretRef could not be resolved: gateway.auth.token SecretRef is unresolved",
+    );
+  });
+
   it("skips gateway auth warning when SecretRef-managed token resolves", async () => {
     mockDoctorConfigSnapshot({
       config: {

--- a/src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts
+++ b/src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts
@@ -385,4 +385,50 @@ describe("doctor command", () => {
       "Doctor will not overwrite gateway.auth.token with a plaintext value.",
     );
   });
+
+  it("skips gateway auth warning when SecretRef-managed token resolves", async () => {
+    mockDoctorConfigSnapshot({
+      config: {
+        gateway: {
+          mode: "local",
+          auth: {
+            mode: "token",
+            token: {
+              source: "env",
+              provider: "default",
+              id: "OPENCLAW_GATEWAY_TOKEN",
+            },
+          },
+        },
+        secrets: {
+          providers: {
+            default: { source: "env" },
+          },
+        },
+      },
+    });
+
+    const previousToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+    process.env.OPENCLAW_GATEWAY_TOKEN = "resolved-token-1234567890";
+    try {
+      await doctorCommand(createDoctorRuntime(), {
+        nonInteractive: true,
+        workspaceSuggestions: false,
+      });
+    } finally {
+      if (previousToken === undefined) {
+        delete process.env.OPENCLAW_GATEWAY_TOKEN;
+      } else {
+        process.env.OPENCLAW_GATEWAY_TOKEN = previousToken;
+      }
+    }
+
+    const warned = terminalNoteMock.mock.calls.some(([message, title]) => {
+      return (
+        title === "Gateway auth" &&
+        String(message).includes("Gateway token is managed via SecretRef")
+      );
+    });
+    expect(warned).toBe(false);
+  });
 });

--- a/src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts
+++ b/src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts
@@ -515,6 +515,49 @@ describe("doctor command", () => {
     });
   });
 
+  it("skips gateway health probes for ambiguous exec SecretRefs", async () => {
+    mockDoctorConfigSnapshot({
+      config: {
+        gateway: {
+          mode: "local",
+          auth: {
+            token: {
+              source: "exec",
+              provider: "default",
+              id: "gateway/token",
+            },
+            password: {
+              source: "exec",
+              provider: "default",
+              id: "gateway/password",
+            },
+          },
+        },
+        secrets: {
+          providers: {
+            default: {
+              source: "exec",
+              command: process.execPath,
+            },
+          },
+        },
+      },
+    });
+
+    callGateway.mockClear();
+    await doctorCommand(createDoctorRuntime(), {
+      nonInteractive: true,
+      workspaceSuggestions: false,
+    });
+
+    expect(callGateway).not.toHaveBeenCalled();
+    requireTerminalNote({
+      title: "Gateway",
+      messageIncludes:
+        "Gateway health probes skipped because gateway credentials use an exec SecretRef.",
+    });
+  });
+
   it("keeps gateway health probes for non-token auth with exec SecretRefs", async () => {
     mockDoctorConfigSnapshot({
       config: {

--- a/src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts
+++ b/src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  callGateway,
   createDoctorRuntime,
   ensureAuthProfileStore,
   mockDoctorConfigSnapshot,
@@ -434,6 +435,45 @@ describe("doctor command", () => {
     expect(String(gatewayAuthNote[0])).toContain(
       "Gateway token SecretRef could not be resolved: gateway.auth.token SecretRef is unresolved",
     );
+  });
+
+  it("skips gateway health probes for exec SecretRefs unless allow-exec is set", async () => {
+    mockDoctorConfigSnapshot({
+      config: {
+        gateway: {
+          mode: "local",
+          auth: {
+            mode: "token",
+            token: {
+              source: "exec",
+              provider: "default",
+              id: "gateway/token",
+            },
+          },
+        },
+        secrets: {
+          providers: {
+            default: {
+              source: "exec",
+              command: process.execPath,
+            },
+          },
+        },
+      },
+    });
+
+    callGateway.mockClear();
+    await doctorCommand(createDoctorRuntime(), {
+      nonInteractive: true,
+      workspaceSuggestions: false,
+    });
+
+    expect(callGateway).not.toHaveBeenCalled();
+    requireTerminalNote({
+      title: "Gateway",
+      messageIncludes:
+        "Gateway health probes skipped because gateway.auth.token uses an exec SecretRef.",
+    });
   });
 
   it("skips gateway auth warning when SecretRef-managed token resolves", async () => {

--- a/src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts
+++ b/src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts
@@ -649,6 +649,51 @@ describe("doctor command", () => {
     expect(skippedGatewayHealth).toBe(false);
   });
 
+  it("keeps local gateway health probes when only dormant remote refs use exec", async () => {
+    mockDoctorConfigSnapshot({
+      config: {
+        gateway: {
+          mode: "local",
+          auth: {
+            mode: "token",
+            token: "configured-token",
+          },
+          remote: {
+            url: "https://gateway.example.test",
+            token: {
+              source: "exec",
+              provider: "default",
+              id: "gateway/remote-token",
+            },
+          },
+        },
+        secrets: {
+          providers: {
+            default: {
+              source: "exec",
+              command: process.execPath,
+            },
+          },
+        },
+      },
+    });
+
+    await doctorCommand(createDoctorRuntime(), {
+      nonInteractive: true,
+      workspaceSuggestions: false,
+    });
+
+    const skippedGatewayHealth = terminalNoteMock.mock.calls.some(([message, title]) => {
+      return (
+        title === "Gateway" &&
+        String(message).includes(
+          "Gateway health probes skipped because gateway credentials use an exec SecretRef.",
+        )
+      );
+    });
+    expect(skippedGatewayHealth).toBe(false);
+  });
+
   it("skips gateway auth warning when SecretRef-managed token resolves", async () => {
     mockDoctorConfigSnapshot({
       config: {

--- a/src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts
+++ b/src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts
@@ -379,7 +379,7 @@ describe("doctor command", () => {
 
     const gatewayAuthNote = requireTerminalNote({ title: "Gateway auth" });
     expect(String(gatewayAuthNote[0])).toContain(
-      "Gateway token is managed via SecretRef and is currently unavailable.",
+      "Gateway token SecretRef could not be resolved: gateway.auth.token SecretRef is unresolved",
     );
     expect(String(gatewayAuthNote[0])).toContain(
       "Doctor will not overwrite gateway.auth.token with a plaintext value.",

--- a/src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts
+++ b/src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts
@@ -476,6 +476,48 @@ describe("doctor command", () => {
     });
   });
 
+  it("keeps gateway health probes for non-token auth with exec SecretRefs", async () => {
+    mockDoctorConfigSnapshot({
+      config: {
+        gateway: {
+          mode: "local",
+          auth: {
+            mode: "password",
+            password: "configured-password",
+            token: {
+              source: "exec",
+              provider: "default",
+              id: "gateway/token",
+            },
+          },
+        },
+        secrets: {
+          providers: {
+            default: {
+              source: "exec",
+              command: process.execPath,
+            },
+          },
+        },
+      },
+    });
+
+    await doctorCommand(createDoctorRuntime(), {
+      nonInteractive: true,
+      workspaceSuggestions: false,
+    });
+
+    const skippedGatewayHealth = terminalNoteMock.mock.calls.some(([message, title]) => {
+      return (
+        title === "Gateway" &&
+        String(message).includes(
+          "Gateway health probes skipped because gateway.auth.token uses an exec SecretRef.",
+        )
+      );
+    });
+    expect(skippedGatewayHealth).toBe(false);
+  });
+
   it("skips gateway auth warning when SecretRef-managed token resolves", async () => {
     mockDoctorConfigSnapshot({
       config: {

--- a/src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts
+++ b/src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts
@@ -741,6 +741,57 @@ describe("doctor command", () => {
     expect(skippedGatewayHealth).toBe(false);
   });
 
+  it("keeps gateway health probes when env password wins over an exec password ref", async () => {
+    mockDoctorConfigSnapshot({
+      config: {
+        gateway: {
+          mode: "local",
+          auth: {
+            mode: "password",
+            password: {
+              source: "exec",
+              provider: "default",
+              id: "gateway/password",
+            },
+          },
+        },
+        secrets: {
+          providers: {
+            default: {
+              source: "exec",
+              command: process.execPath,
+            },
+          },
+        },
+      },
+    });
+
+    const previousPassword = process.env.OPENCLAW_GATEWAY_PASSWORD;
+    process.env.OPENCLAW_GATEWAY_PASSWORD = "fallback-password";
+    try {
+      await doctorCommand(createDoctorRuntime(), {
+        nonInteractive: true,
+        workspaceSuggestions: false,
+      });
+    } finally {
+      if (previousPassword === undefined) {
+        delete process.env.OPENCLAW_GATEWAY_PASSWORD;
+      } else {
+        process.env.OPENCLAW_GATEWAY_PASSWORD = previousPassword;
+      }
+    }
+
+    const skippedGatewayHealth = terminalNoteMock.mock.calls.some(([message, title]) => {
+      return (
+        title === "Gateway" &&
+        String(message).includes(
+          "Gateway health probes skipped because gateway credentials use an exec SecretRef.",
+        )
+      );
+    });
+    expect(skippedGatewayHealth).toBe(false);
+  });
+
   it("keeps local gateway health probes when only dormant remote refs use exec", async () => {
     mockDoctorConfigSnapshot({
       config: {

--- a/src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts
+++ b/src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts
@@ -472,7 +472,46 @@ describe("doctor command", () => {
     requireTerminalNote({
       title: "Gateway",
       messageIncludes:
-        "Gateway health probes skipped because gateway.auth.token uses an exec SecretRef.",
+        "Gateway health probes skipped because gateway credentials use an exec SecretRef.",
+    });
+  });
+
+  it("skips gateway health probes for active exec password SecretRefs", async () => {
+    mockDoctorConfigSnapshot({
+      config: {
+        gateway: {
+          mode: "local",
+          auth: {
+            mode: "password",
+            password: {
+              source: "exec",
+              provider: "default",
+              id: "gateway/password",
+            },
+          },
+        },
+        secrets: {
+          providers: {
+            default: {
+              source: "exec",
+              command: process.execPath,
+            },
+          },
+        },
+      },
+    });
+
+    callGateway.mockClear();
+    await doctorCommand(createDoctorRuntime(), {
+      nonInteractive: true,
+      workspaceSuggestions: false,
+    });
+
+    expect(callGateway).not.toHaveBeenCalled();
+    requireTerminalNote({
+      title: "Gateway",
+      messageIncludes:
+        "Gateway health probes skipped because gateway credentials use an exec SecretRef.",
     });
   });
 
@@ -511,7 +550,7 @@ describe("doctor command", () => {
       return (
         title === "Gateway" &&
         String(message).includes(
-          "Gateway health probes skipped because gateway.auth.token uses an exec SecretRef.",
+          "Gateway health probes skipped because gateway credentials use an exec SecretRef.",
         )
       );
     });

--- a/src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts
+++ b/src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts
@@ -691,6 +691,56 @@ describe("doctor command", () => {
     expect(skippedGatewayHealth).toBe(false);
   });
 
+  it("keeps gateway health probes when env token wins over an exec password ref", async () => {
+    mockDoctorConfigSnapshot({
+      config: {
+        gateway: {
+          mode: "local",
+          auth: {
+            password: {
+              source: "exec",
+              provider: "default",
+              id: "gateway/password",
+            },
+          },
+        },
+        secrets: {
+          providers: {
+            default: {
+              source: "exec",
+              command: process.execPath,
+            },
+          },
+        },
+      },
+    });
+
+    const previousToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+    process.env.OPENCLAW_GATEWAY_TOKEN = "fallback-token";
+    try {
+      await doctorCommand(createDoctorRuntime(), {
+        nonInteractive: true,
+        workspaceSuggestions: false,
+      });
+    } finally {
+      if (previousToken === undefined) {
+        delete process.env.OPENCLAW_GATEWAY_TOKEN;
+      } else {
+        process.env.OPENCLAW_GATEWAY_TOKEN = previousToken;
+      }
+    }
+
+    const skippedGatewayHealth = terminalNoteMock.mock.calls.some(([message, title]) => {
+      return (
+        title === "Gateway" &&
+        String(message).includes(
+          "Gateway health probes skipped because gateway credentials use an exec SecretRef.",
+        )
+      );
+    });
+    expect(skippedGatewayHealth).toBe(false);
+  });
+
   it("keeps local gateway health probes when only dormant remote refs use exec", async () => {
     mockDoctorConfigSnapshot({
       config: {

--- a/src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts
+++ b/src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts
@@ -792,6 +792,108 @@ describe("doctor command", () => {
     expect(skippedGatewayHealth).toBe(false);
   });
 
+  it("keeps remote gateway health probes when env token wins over an exec password ref", async () => {
+    mockDoctorConfigSnapshot({
+      config: {
+        gateway: {
+          mode: "remote",
+          remote: {
+            url: "https://gateway.example.test",
+            password: {
+              source: "exec",
+              provider: "default",
+              id: "gateway/remote-password",
+            },
+          },
+        },
+        secrets: {
+          providers: {
+            default: {
+              source: "exec",
+              command: process.execPath,
+            },
+          },
+        },
+      },
+    });
+
+    const previousToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+    process.env.OPENCLAW_GATEWAY_TOKEN = "fallback-token";
+    try {
+      await doctorCommand(createDoctorRuntime(), {
+        nonInteractive: true,
+        workspaceSuggestions: false,
+      });
+    } finally {
+      if (previousToken === undefined) {
+        delete process.env.OPENCLAW_GATEWAY_TOKEN;
+      } else {
+        process.env.OPENCLAW_GATEWAY_TOKEN = previousToken;
+      }
+    }
+
+    const skippedGatewayHealth = terminalNoteMock.mock.calls.some(([message, title]) => {
+      return (
+        title === "Gateway" &&
+        String(message).includes(
+          "Gateway health probes skipped because gateway credentials use an exec SecretRef.",
+        )
+      );
+    });
+    expect(skippedGatewayHealth).toBe(false);
+  });
+
+  it("keeps remote gateway health probes when env password wins over an exec token ref", async () => {
+    mockDoctorConfigSnapshot({
+      config: {
+        gateway: {
+          mode: "remote",
+          remote: {
+            url: "https://gateway.example.test",
+            token: {
+              source: "exec",
+              provider: "default",
+              id: "gateway/remote-token",
+            },
+          },
+        },
+        secrets: {
+          providers: {
+            default: {
+              source: "exec",
+              command: process.execPath,
+            },
+          },
+        },
+      },
+    });
+
+    const previousPassword = process.env.OPENCLAW_GATEWAY_PASSWORD;
+    process.env.OPENCLAW_GATEWAY_PASSWORD = "fallback-password";
+    try {
+      await doctorCommand(createDoctorRuntime(), {
+        nonInteractive: true,
+        workspaceSuggestions: false,
+      });
+    } finally {
+      if (previousPassword === undefined) {
+        delete process.env.OPENCLAW_GATEWAY_PASSWORD;
+      } else {
+        process.env.OPENCLAW_GATEWAY_PASSWORD = previousPassword;
+      }
+    }
+
+    const skippedGatewayHealth = terminalNoteMock.mock.calls.some(([message, title]) => {
+      return (
+        title === "Gateway" &&
+        String(message).includes(
+          "Gateway health probes skipped because gateway credentials use an exec SecretRef.",
+        )
+      );
+    });
+    expect(skippedGatewayHealth).toBe(false);
+  });
+
   it("keeps local gateway health probes when only dormant remote refs use exec", async () => {
     mockDoctorConfigSnapshot({
       config: {

--- a/src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts
+++ b/src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts
@@ -607,6 +607,48 @@ describe("doctor command", () => {
     });
   });
 
+  it("skips remote probes when local fallback credentials use exec", async () => {
+    mockDoctorConfigSnapshot({
+      config: {
+        gateway: {
+          mode: "remote",
+          auth: {
+            mode: "password",
+            token: {
+              source: "exec",
+              provider: "default",
+              id: "gateway/token",
+            },
+          },
+          remote: {
+            url: "https://gateway.example.test",
+          },
+        },
+        secrets: {
+          providers: {
+            default: {
+              source: "exec",
+              command: process.execPath,
+            },
+          },
+        },
+      },
+    });
+
+    callGateway.mockClear();
+    await doctorCommand(createDoctorRuntime(), {
+      nonInteractive: true,
+      workspaceSuggestions: false,
+    });
+
+    expect(callGateway).not.toHaveBeenCalled();
+    requireTerminalNote({
+      title: "Gateway",
+      messageIncludes:
+        "Gateway health probes skipped because gateway credentials use an exec SecretRef.",
+    });
+  });
+
   it("keeps gateway health probes for non-token auth with exec SecretRefs", async () => {
     mockDoctorConfigSnapshot({
       config: {

--- a/src/flows/doctor-core-checks.test.ts
+++ b/src/flows/doctor-core-checks.test.ts
@@ -352,6 +352,57 @@ describe("registerCoreHealthChecks", () => {
     }
   });
 
+  it("reports unresolved SecretRefs even when OPENCLAW_GATEWAY_TOKEN is set", async () => {
+    const check = CORE_HEALTH_CHECKS.find((entry) => entry.id === "core/doctor/gateway-auth");
+    const previousFallbackToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+    const previousRefToken = process.env.OPENCLAW_MISSING_GATEWAY_REF_TOKEN;
+    process.env.OPENCLAW_GATEWAY_TOKEN = "fallback-token";
+    delete process.env.OPENCLAW_MISSING_GATEWAY_REF_TOKEN;
+    try {
+      const findings = await check?.detect({
+        mode: "lint",
+        runtime: { log() {}, error() {}, exit() {} },
+        cfg: {
+          gateway: {
+            mode: "local",
+            auth: {
+              mode: "token",
+              token: {
+                source: "env",
+                provider: "default",
+                id: "OPENCLAW_MISSING_GATEWAY_REF_TOKEN",
+              },
+            },
+          },
+          secrets: {
+            providers: {
+              default: { source: "env" },
+            },
+          },
+        },
+        cwd: tmp,
+      });
+
+      expect(findings).toContainEqual(
+        expect.objectContaining({
+          checkId: "core/doctor/gateway-auth",
+          message: expect.stringContaining("Gateway token SecretRef could not be resolved:"),
+        }),
+      );
+    } finally {
+      if (previousFallbackToken === undefined) {
+        delete process.env.OPENCLAW_GATEWAY_TOKEN;
+      } else {
+        process.env.OPENCLAW_GATEWAY_TOKEN = previousFallbackToken;
+      }
+      if (previousRefToken === undefined) {
+        delete process.env.OPENCLAW_MISSING_GATEWAY_REF_TOKEN;
+      } else {
+        process.env.OPENCLAW_MISSING_GATEWAY_REF_TOKEN = previousRefToken;
+      }
+    }
+  });
+
   it("does not execute or warn for valid exec SecretRefs during default gateway auth lint checks", async () => {
     tmp = await fs.mkdtemp(join(tmpdir(), "openclaw-health-exec-ref-"));
     const markerPath = join(tmp, "exec-ran");
@@ -454,37 +505,48 @@ describe("registerCoreHealthChecks", () => {
       "utf8",
     );
     const check = CORE_HEALTH_CHECKS.find((entry) => entry.id === "core/doctor/gateway-auth");
+    const previousFallbackToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+    process.env.OPENCLAW_GATEWAY_TOKEN = "fallback-token";
 
-    const findings = await check?.detect({
-      mode: "lint",
-      runtime: { log() {}, error() {}, exit() {} },
-      cfg: {
-        gateway: {
-          mode: "local",
-          auth: {
-            mode: "token",
-            token: {
-              source: "exec",
-              provider: "default",
-              id: "value",
+    let findings: HealthFinding[] | undefined;
+    try {
+      findings = await check?.detect({
+        mode: "lint",
+        runtime: { log() {}, error() {}, exit() {} },
+        cfg: {
+          gateway: {
+            mode: "local",
+            auth: {
+              mode: "token",
+              token: {
+                source: "exec",
+                provider: "default",
+                id: "value",
+              },
+            },
+          },
+          secrets: {
+            providers: {
+              default: {
+                source: "exec",
+                command: process.execPath,
+                args: [resolverPath],
+                jsonOnly: false,
+                allowInsecurePath: true,
+                allowSymlinkCommand: true,
+              },
             },
           },
         },
-        secrets: {
-          providers: {
-            default: {
-              source: "exec",
-              command: process.execPath,
-              args: [resolverPath],
-              jsonOnly: false,
-              allowInsecurePath: true,
-              allowSymlinkCommand: true,
-            },
-          },
-        },
-      },
-      allowExecSecretRefs: true,
-    });
+        allowExecSecretRefs: true,
+      });
+    } finally {
+      if (previousFallbackToken === undefined) {
+        delete process.env.OPENCLAW_GATEWAY_TOKEN;
+      } else {
+        process.env.OPENCLAW_GATEWAY_TOKEN = previousFallbackToken;
+      }
+    }
 
     expect(findings).toContainEqual(
       expect.objectContaining({

--- a/src/flows/doctor-core-checks.test.ts
+++ b/src/flows/doctor-core-checks.test.ts
@@ -301,6 +301,171 @@ describe("registerCoreHealthChecks", () => {
     expect(mocks.loadModelCatalog).toHaveBeenCalledWith({ config: cfg, readOnly: true });
   });
 
+  it("skips gateway auth warning when SecretRef-managed token resolves in lint checks", async () => {
+    const check = CORE_HEALTH_CHECKS.find((entry) => entry.id === "core/doctor/gateway-auth");
+    const previousToken = process.env.OPENCLAW_TEST_GATEWAY_TOKEN;
+    process.env.OPENCLAW_TEST_GATEWAY_TOKEN = "resolved-test-token";
+    try {
+      const findings = await check?.detect({
+        mode: "lint",
+        runtime: { log() {}, error() {}, exit() {} },
+        cfg: {
+          gateway: {
+            mode: "local",
+            auth: {
+              mode: "token",
+              token: {
+                source: "env",
+                provider: "default",
+                id: "OPENCLAW_TEST_GATEWAY_TOKEN",
+              },
+            },
+          },
+          secrets: {
+            providers: {
+              default: { source: "env" },
+            },
+          },
+        },
+        cwd: tmp,
+      });
+
+      expect(findings).toEqual([]);
+    } finally {
+      if (previousToken === undefined) {
+        delete process.env.OPENCLAW_TEST_GATEWAY_TOKEN;
+      } else {
+        process.env.OPENCLAW_TEST_GATEWAY_TOKEN = previousToken;
+      }
+    }
+  });
+
+  it("does not execute or warn for valid exec SecretRefs during default gateway auth lint checks", async () => {
+    tmp = await fs.mkdtemp(join(tmpdir(), "openclaw-health-exec-ref-"));
+    const markerPath = join(tmp, "exec-ran");
+    const check = CORE_HEALTH_CHECKS.find((entry) => entry.id === "core/doctor/gateway-auth");
+
+    const findings = await check?.detect({
+      mode: "lint",
+      runtime: { log() {}, error() {}, exit() {} },
+      cfg: {
+        gateway: {
+          mode: "local",
+          auth: {
+            mode: "token",
+            token: {
+              source: "exec",
+              provider: "default",
+              id: "value",
+            },
+          },
+        },
+        secrets: {
+          providers: {
+            default: {
+              source: "exec",
+              command: "/bin/sh",
+              args: ["-c", `cat >/dev/null; printf executed > ${JSON.stringify(markerPath)}`],
+              jsonOnly: false,
+              allowInsecurePath: true,
+            },
+          },
+        },
+      },
+      cwd: tmp,
+    });
+
+    expect(findings).toEqual([]);
+    await expect(fs.readFile(markerPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("executes exec SecretRefs when gateway auth lint explicitly allows exec checks", async () => {
+    tmp = await fs.mkdtemp(join(tmpdir(), "openclaw-health-exec-ref-"));
+    const markerPath = join(tmp, "exec-ran");
+    const check = CORE_HEALTH_CHECKS.find((entry) => entry.id === "core/doctor/gateway-auth");
+
+    const findings = await check?.detect({
+      mode: "lint",
+      runtime: { log() {}, error() {}, exit() {} },
+      cfg: {
+        gateway: {
+          mode: "local",
+          auth: {
+            mode: "token",
+            token: {
+              source: "exec",
+              provider: "default",
+              id: "value",
+            },
+          },
+        },
+        secrets: {
+          providers: {
+            default: {
+              source: "exec",
+              command: "/bin/sh",
+              args: [
+                "-c",
+                `cat >/dev/null; printf executed > ${JSON.stringify(markerPath)}; printf resolved-token`,
+              ],
+              jsonOnly: false,
+              allowInsecurePath: true,
+            },
+          },
+        },
+      },
+      cwd: tmp,
+      allowExecSecretRefs: true,
+    });
+
+    expect(findings).toEqual([]);
+    await expect(fs.readFile(markerPath, "utf8")).resolves.toBe("executed");
+  });
+
+  it("reports exec SecretRef failures when gateway auth lint explicitly allows exec checks", async () => {
+    const check = CORE_HEALTH_CHECKS.find((entry) => entry.id === "core/doctor/gateway-auth");
+
+    const findings = await check?.detect({
+      mode: "lint",
+      runtime: { log() {}, error() {}, exit() {} },
+      cfg: {
+        gateway: {
+          mode: "local",
+          auth: {
+            mode: "token",
+            token: {
+              source: "exec",
+              provider: "default",
+              id: "value",
+            },
+          },
+        },
+        secrets: {
+          providers: {
+            default: {
+              source: "exec",
+              command: "/bin/sh",
+              args: ["-c", "cat >/dev/null; exit 12"],
+              jsonOnly: false,
+              allowInsecurePath: true,
+            },
+          },
+        },
+      },
+      allowExecSecretRefs: true,
+    });
+
+    expect(findings).toContainEqual(
+      expect.objectContaining({
+        checkId: "core/doctor/gateway-auth",
+        severity: "warning",
+        message: expect.stringContaining("Gateway token SecretRef could not be resolved:"),
+        fixHint:
+          "Run `openclaw doctor --allow-exec` to verify exec SecretRefs during doctor, or `openclaw secrets audit --allow-exec` to audit all exec SecretRefs.",
+      }),
+    );
+  });
+
   it("converts workspace suggestions into info findings", async () => {
     const check = getCheck(
       createCoreHealthChecks(

--- a/src/flows/doctor-core-checks.test.ts
+++ b/src/flows/doctor-core-checks.test.ts
@@ -394,6 +394,19 @@ describe("registerCoreHealthChecks", () => {
   it("executes exec SecretRefs when gateway auth lint explicitly allows exec checks", async () => {
     tmp = await fs.mkdtemp(join(tmpdir(), "openclaw-health-exec-ref-"));
     const markerPath = join(tmp, "exec-ran");
+    const resolverPath = join(tmp, "resolve-token.cjs");
+    await fs.writeFile(
+      resolverPath,
+      [
+        "const fs = require('node:fs');",
+        "process.stdin.resume();",
+        "process.stdin.on('end', () => {",
+        "  fs.writeFileSync(process.argv[2], 'executed');",
+        "  process.stdout.write('resolved-token');",
+        "});",
+      ].join("\n"),
+      "utf8",
+    );
     const check = CORE_HEALTH_CHECKS.find((entry) => entry.id === "core/doctor/gateway-auth");
 
     const findings = await check?.detect({
@@ -415,13 +428,11 @@ describe("registerCoreHealthChecks", () => {
           providers: {
             default: {
               source: "exec",
-              command: "/bin/sh",
-              args: [
-                "-c",
-                `cat >/dev/null; printf executed > ${JSON.stringify(markerPath)}; printf resolved-token`,
-              ],
+              command: process.execPath,
+              args: [resolverPath, markerPath],
               jsonOnly: false,
               allowInsecurePath: true,
+              allowSymlinkCommand: true,
             },
           },
         },
@@ -435,6 +446,13 @@ describe("registerCoreHealthChecks", () => {
   });
 
   it("reports exec SecretRef failures when gateway auth lint explicitly allows exec checks", async () => {
+    tmp = await fs.mkdtemp(join(tmpdir(), "openclaw-health-exec-ref-"));
+    const resolverPath = join(tmp, "fail-token.cjs");
+    await fs.writeFile(
+      resolverPath,
+      ["process.stdin.resume();", "process.stdin.on('end', () => process.exit(12));"].join("\n"),
+      "utf8",
+    );
     const check = CORE_HEALTH_CHECKS.find((entry) => entry.id === "core/doctor/gateway-auth");
 
     const findings = await check?.detect({
@@ -456,10 +474,11 @@ describe("registerCoreHealthChecks", () => {
           providers: {
             default: {
               source: "exec",
-              command: "/bin/sh",
-              args: ["-c", "cat >/dev/null; exit 12"],
+              command: process.execPath,
+              args: [resolverPath],
               jsonOnly: false,
               allowInsecurePath: true,
+              allowSymlinkCommand: true,
             },
           },
         },

--- a/src/flows/doctor-core-checks.test.ts
+++ b/src/flows/doctor-core-checks.test.ts
@@ -1,4 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SkillStatusEntry } from "../agents/skills-status.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
@@ -90,11 +93,20 @@ function getCheck(checks: readonly HealthCheck[], id: string): HealthCheck {
 }
 
 describe("registerCoreHealthChecks", () => {
+  let tmp: string | undefined;
+
   beforeEach(() => {
     clearHealthChecksForTest();
     resetCoreHealthChecksForTest();
     mocks.loadModelCatalog.mockClear();
     mocks.loadModelCatalog.mockResolvedValue([]);
+    tmp = undefined;
+  });
+
+  afterEach(async () => {
+    if (tmp) {
+      await fs.rm(tmp, { force: true, recursive: true });
+    }
   });
 
   it("registers the built-in health checks once", () => {

--- a/src/flows/doctor-core-checks.test.ts
+++ b/src/flows/doctor-core-checks.test.ts
@@ -508,7 +508,7 @@ describe("registerCoreHealthChecks", () => {
     const previousFallbackToken = process.env.OPENCLAW_GATEWAY_TOKEN;
     process.env.OPENCLAW_GATEWAY_TOKEN = "fallback-token";
 
-    let findings: HealthFinding[] | undefined;
+    let findings: readonly HealthFinding[] | undefined;
     try {
       findings = await check?.detect({
         mode: "lint",

--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -191,11 +191,12 @@ const gatewayAuthCheck: HealthCheck = {
       authConfig: ctx.cfg.gateway?.auth,
       tailscaleMode: ctx.cfg.gateway?.tailscale?.mode ?? "off",
     });
+    const hasInlineToken = typeof auth.token === "string" && auth.token.trim() !== "";
     const needsToken =
       auth.mode !== "password" &&
       auth.mode !== "none" &&
       auth.mode !== "trusted-proxy" &&
-      (auth.mode !== "token" || !auth.token);
+      (auth.mode !== "token" || !hasInlineToken || Boolean(gatewayTokenRef));
     if (!needsToken) {
       return [];
     }
@@ -211,9 +212,9 @@ const gatewayAuthCheck: HealthCheck = {
           cfg: ctx.cfg,
           env: process.env,
           unresolvedReasonStyle: "detailed",
-          envFallback: "always",
+          envFallback: "never",
         });
-        if (resolvedToken.token) {
+        if (resolvedToken.source === "secretRef") {
           return [];
         }
         unresolvedRefReason = resolvedToken.unresolvedRefReason;
@@ -223,9 +224,9 @@ const gatewayAuthCheck: HealthCheck = {
         cfg: ctx.cfg,
         env: process.env,
         unresolvedReasonStyle: "detailed",
-        envFallback: "always",
+        envFallback: gatewayTokenRef ? "never" : "always",
       });
-      if (resolvedToken.token) {
+      if (gatewayTokenRef ? resolvedToken.source === "secretRef" : resolvedToken.token) {
         return [];
       }
       unresolvedRefReason = resolvedToken.unresolvedRefReason;

--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -14,9 +14,11 @@ import {
 } from "../commands/doctor-completion.js";
 import { disableUnavailableSkillsInConfig } from "../commands/doctor-skills-core.js";
 import type { ConfigValidationIssue, OpenClawConfig } from "../config/types.openclaw.js";
-import { resolveSecretInputRef } from "../config/types.secrets.js";
+import { resolveSecretInputRef, type SecretRef } from "../config/types.secrets.js";
 import { hasAmbiguousGatewayAuthModeConfig } from "../gateway/auth-mode-policy.js";
+import { resolveGatewayAuthToken } from "../gateway/auth-token-resolution.js";
 import { resolveGatewayAuth } from "../gateway/auth.js";
+import { getSkippedExecRefStaticError } from "../secrets/exec-resolution-policy.js";
 import { registerHealthCheck } from "./health-check-registry.js";
 import type { HealthCheck, HealthCheckContext, HealthFinding } from "./health-checks.js";
 
@@ -147,6 +149,31 @@ function resolveDoctorMode(cfg: OpenClawConfig): "local" | "remote" {
   return cfg.gateway?.mode === "remote" ? "remote" : "local";
 }
 
+export function buildGatewayTokenSecretRefUnavailableMessage(params: {
+  cfg: OpenClawConfig;
+  ref: SecretRef;
+  unresolvedRefReason?: string;
+}): string {
+  if (params.unresolvedRefReason) {
+    return `Gateway token SecretRef could not be resolved: ${params.unresolvedRefReason}`;
+  }
+  if (params.ref.source === "exec") {
+    const staticError = getSkippedExecRefStaticError({ ref: params.ref, config: params.cfg });
+    if (staticError) {
+      return `Gateway token SecretRef could not be verified: ${staticError}`;
+    }
+    return "Gateway token SecretRef uses an exec provider and did not resolve.";
+  }
+  return "Gateway token is managed via SecretRef and is currently unavailable.";
+}
+
+export function buildGatewayTokenSecretRefFixHint(ref: SecretRef): string {
+  if (ref.source === "exec") {
+    return "Run `openclaw doctor --allow-exec` to verify exec SecretRefs during doctor, or `openclaw secrets audit --allow-exec` to audit all exec SecretRefs.";
+  }
+  return "Resolve or rotate the external secret source, then rerun doctor.";
+}
+
 const gatewayAuthCheck: HealthCheck = {
   id: "core/doctor/gateway-auth",
   kind: "core",
@@ -172,14 +199,49 @@ const gatewayAuthCheck: HealthCheck = {
     if (!needsToken) {
       return [];
     }
+    let unresolvedRefReason: string | undefined;
+    if (gatewayTokenRef && gatewayTokenRef.source === "exec") {
+      const staticError = getSkippedExecRefStaticError({ ref: gatewayTokenRef, config: ctx.cfg });
+      if (staticError) {
+        unresolvedRefReason = undefined;
+      } else if (ctx.allowExecSecretRefs !== true) {
+        return [];
+      } else {
+        const resolvedToken = await resolveGatewayAuthToken({
+          cfg: ctx.cfg,
+          env: process.env,
+          unresolvedReasonStyle: "detailed",
+          envFallback: "always",
+        });
+        if (resolvedToken.token) {
+          return [];
+        }
+        unresolvedRefReason = resolvedToken.unresolvedRefReason;
+      }
+    } else {
+      const resolvedToken = await resolveGatewayAuthToken({
+        cfg: ctx.cfg,
+        env: process.env,
+        unresolvedReasonStyle: "detailed",
+        envFallback: "always",
+      });
+      if (resolvedToken.token) {
+        return [];
+      }
+      unresolvedRefReason = resolvedToken.unresolvedRefReason;
+    }
     if (gatewayTokenRef) {
       return [
         {
           checkId: "core/doctor/gateway-auth",
           severity: "warning",
-          message: "Gateway token is managed via SecretRef and is currently unavailable.",
+          message: buildGatewayTokenSecretRefUnavailableMessage({
+            cfg: ctx.cfg,
+            ref: gatewayTokenRef,
+            unresolvedRefReason,
+          }),
           path: "gateway.auth.token",
-          fixHint: "Resolve or rotate the external secret source, then rerun doctor.",
+          fixHint: buildGatewayTokenSecretRefFixHint(gatewayTokenRef),
         },
       ];
     }

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -732,15 +732,11 @@ async function runGatewayHealthChecks(ctx: DoctorHealthFlowContext): Promise<voi
     credentialPlan.localTokenSurfaceActive || ambiguousLocalAuthRefs
       ? credentialPlan.localToken.refPath
       : undefined,
-    (credentialPlan.localPasswordCanWin && !credentialPlan.envPassword) || ambiguousLocalAuthRefs
+    credentialPlan.localPasswordCanWin || ambiguousLocalAuthRefs
       ? credentialPlan.localPassword.refPath
       : undefined,
-    credentialPlan.remoteTokenActive && !credentialPlan.envToken
-      ? credentialPlan.remoteToken.refPath
-      : undefined,
-    credentialPlan.remotePasswordActive && !credentialPlan.envPassword
-      ? credentialPlan.remotePassword.refPath
-      : undefined,
+    credentialPlan.remoteTokenActive ? credentialPlan.remoteToken.refPath : undefined,
+    credentialPlan.remotePasswordActive ? credentialPlan.remotePassword.refPath : undefined,
   ].filter((path): path is NonNullable<typeof path> => Boolean(path));
   const hasActiveExecCredential = activeSecretRefPaths.some((path) => {
     const ref = resolveSecretInputRef({

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -191,11 +191,12 @@ async function runGatewayAuthHealth(ctx: DoctorHealthFlowContext): Promise<void>
   // This aligns with hasExplicitGatewayInstallAuthMode() in auth-install-policy.ts.
   // Previously, only "password" and "token" (with a token present) were excluded,
   // causing doctor --fix to overwrite trusted-proxy/none configs with token mode.
+  const hasInlineToken = typeof auth.token === "string" && auth.token.trim() !== "";
   const needsToken =
     auth.mode !== "password" &&
     auth.mode !== "none" &&
     auth.mode !== "trusted-proxy" &&
-    (auth.mode !== "token" || !auth.token);
+    (auth.mode !== "token" || !hasInlineToken || Boolean(gatewayTokenRef));
   if (!needsToken) {
     return;
   }
@@ -212,9 +213,9 @@ async function runGatewayAuthHealth(ctx: DoctorHealthFlowContext): Promise<void>
         cfg: ctx.cfg,
         env: ctx.env ?? process.env,
         unresolvedReasonStyle: "detailed",
-        envFallback: "always",
+        envFallback: "never",
       });
-      if (resolvedToken.token) {
+      if (resolvedToken.source === "secretRef") {
         return;
       }
       unresolvedRefReason = resolvedToken.unresolvedRefReason;
@@ -224,9 +225,9 @@ async function runGatewayAuthHealth(ctx: DoctorHealthFlowContext): Promise<void>
       cfg: ctx.cfg,
       env: ctx.env ?? process.env,
       unresolvedReasonStyle: "detailed",
-      envFallback: "always",
+      envFallback: gatewayTokenRef ? "never" : "always",
     });
-    if (resolvedToken.token) {
+    if (gatewayTokenRef ? resolvedToken.source === "secretRef" : resolvedToken.token) {
       return;
     }
     unresolvedRefReason = resolvedToken.unresolvedRefReason;

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -818,7 +818,8 @@ async function runGatewayDaemonHealth(ctx: DoctorHealthFlowContext): Promise<voi
     gatewayDetailsMessage: ctx.gatewayDetails?.message ?? "",
     // A skipped exec-backed token probe is unknown, not unhealthy. Do not let
     // doctor --fix restart services only because probing would require exec.
-    healthOk: ctx.gatewayHealthSkipped === true ? true : (ctx.healthOk ?? false),
+    healthOk: ctx.healthOk ?? false,
+    healthSkipped: ctx.gatewayHealthSkipped === true,
   });
 }
 

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -170,7 +170,10 @@ async function runAuthProfileHealth(ctx: DoctorHealthFlowContext): Promise<void>
 
 async function runGatewayAuthHealth(ctx: DoctorHealthFlowContext): Promise<void> {
   const { resolveSecretInputRef } = await import("../config/types.secrets.js");
+  const { buildGatewayTokenSecretRefFixHint, buildGatewayTokenSecretRefUnavailableMessage } =
+    await import("./doctor-core-checks.js");
   const { resolveGatewayAuth } = await import("../gateway/auth.js");
+  const { resolveGatewayAuthToken } = await import("../gateway/auth-token-resolution.js");
   const { note } = await import("../terminal/note.js");
   const { randomToken } = await import("../commands/onboard-helpers.js");
   if (resolveDoctorMode(ctx.cfg) !== "local" || !ctx.sourceConfigValid) {
@@ -196,12 +199,49 @@ async function runGatewayAuthHealth(ctx: DoctorHealthFlowContext): Promise<void>
   if (!needsToken) {
     return;
   }
+  let unresolvedRefReason: string | undefined;
+  if (gatewayTokenRef && gatewayTokenRef.source === "exec") {
+    const { getSkippedExecRefStaticError } = await import("../secrets/exec-resolution-policy.js");
+    const staticError = getSkippedExecRefStaticError({ ref: gatewayTokenRef, config: ctx.cfg });
+    if (staticError) {
+      unresolvedRefReason = undefined;
+    } else if (ctx.options.allowExec !== true) {
+      return;
+    } else {
+      const resolvedToken = await resolveGatewayAuthToken({
+        cfg: ctx.cfg,
+        env: ctx.env ?? process.env,
+        unresolvedReasonStyle: "detailed",
+        envFallback: "always",
+      });
+      if (resolvedToken.token) {
+        return;
+      }
+      unresolvedRefReason = resolvedToken.unresolvedRefReason;
+    }
+  } else {
+    const resolvedToken = await resolveGatewayAuthToken({
+      cfg: ctx.cfg,
+      env: ctx.env ?? process.env,
+      unresolvedReasonStyle: "detailed",
+      envFallback: "always",
+    });
+    if (resolvedToken.token) {
+      return;
+    }
+    unresolvedRefReason = resolvedToken.unresolvedRefReason;
+  }
   if (gatewayTokenRef) {
+    const reason = buildGatewayTokenSecretRefUnavailableMessage({
+      cfg: ctx.cfg,
+      ref: gatewayTokenRef,
+      unresolvedRefReason,
+    });
     note(
       [
-        "Gateway token is managed via SecretRef and is currently unavailable.",
+        reason,
         "Doctor will not overwrite gateway.auth.token with a plaintext value.",
-        "Resolve/rotate the external secret source, then rerun doctor.",
+        buildGatewayTokenSecretRefFixHint(gatewayTokenRef),
       ].join("\n"),
       "Gateway auth",
     );

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -721,6 +721,21 @@ async function runShellCompletionHealth(ctx: DoctorHealthFlowContext): Promise<v
 }
 
 async function runGatewayHealthChecks(ctx: DoctorHealthFlowContext): Promise<void> {
+  const { resolveSecretInputRef } = await import("../config/types.secrets.js");
+  const { note } = await import("../terminal/note.js");
+  const gatewayTokenRef = resolveSecretInputRef({
+    value: ctx.cfg.gateway?.auth?.token,
+    defaults: ctx.cfg.secrets?.defaults,
+  }).ref;
+  if (gatewayTokenRef?.source === "exec" && ctx.options.allowExec !== true) {
+    note(
+      "Gateway health probes skipped because gateway.auth.token uses an exec SecretRef. Run `openclaw doctor --allow-exec` to verify Gateway health with exec SecretRefs.",
+      "Gateway",
+    );
+    ctx.healthOk = false;
+    ctx.gatewayMemoryProbe = { checked: false, ready: false, skipped: true };
+    return;
+  }
   const { checkGatewayHealth, probeGatewayMemoryStatus } =
     await import("../commands/doctor-gateway-health.js");
   const { healthOk, status } = await checkGatewayHealth({

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -723,25 +723,32 @@ async function runShellCompletionHealth(ctx: DoctorHealthFlowContext): Promise<v
 
 async function runGatewayHealthChecks(ctx: DoctorHealthFlowContext): Promise<void> {
   const { resolveSecretInputRef } = await import("../config/types.secrets.js");
+  const { createGatewayCredentialPlan } = await import("../gateway/credential-planner.js");
+  const { readGatewaySecretInputValue } = await import("../gateway/secret-input-paths.js");
   const { note } = await import("../terminal/note.js");
-  const gatewayTokenRef = resolveSecretInputRef({
-    value: ctx.cfg.gateway?.auth?.token,
-    defaults: ctx.cfg.secrets?.defaults,
-  }).ref;
-  const { resolveGatewayAuth } = await import("../gateway/auth.js");
-  const auth = resolveGatewayAuth({
-    authConfig: ctx.cfg.gateway?.auth,
-    tailscaleMode: ctx.cfg.gateway?.tailscale?.mode ?? "off",
+  const credentialPlan = createGatewayCredentialPlan({ config: ctx.cfg, env: process.env });
+  const activeSecretRefPaths = [
+    credentialPlan.localTokenSurfaceActive ? credentialPlan.localToken.refPath : undefined,
+    credentialPlan.localPasswordCanWin && !credentialPlan.envPassword
+      ? credentialPlan.localPassword.refPath
+      : undefined,
+    credentialPlan.remoteTokenActive && !credentialPlan.envToken
+      ? credentialPlan.remoteToken.refPath
+      : undefined,
+    credentialPlan.remotePasswordActive && !credentialPlan.envPassword
+      ? credentialPlan.remotePassword.refPath
+      : undefined,
+  ].filter((path): path is NonNullable<typeof path> => Boolean(path));
+  const hasActiveExecCredential = activeSecretRefPaths.some((path) => {
+    const ref = resolveSecretInputRef({
+      value: readGatewaySecretInputValue(ctx.cfg, path),
+      defaults: ctx.cfg.secrets?.defaults,
+    }).ref;
+    return ref?.source === "exec";
   });
-  const gatewayHealthNeedsToken =
-    auth.mode !== "password" && auth.mode !== "none" && auth.mode !== "trusted-proxy";
-  if (
-    gatewayHealthNeedsToken &&
-    gatewayTokenRef?.source === "exec" &&
-    ctx.options.allowExec !== true
-  ) {
+  if (hasActiveExecCredential && ctx.options.allowExec !== true) {
     note(
-      "Gateway health probes skipped because gateway.auth.token uses an exec SecretRef. Run `openclaw doctor --allow-exec` to verify Gateway health with exec SecretRefs.",
+      "Gateway health probes skipped because gateway credentials use an exec SecretRef. Run `openclaw doctor --allow-exec` to verify Gateway health with exec SecretRefs.",
       "Gateway",
     );
     ctx.gatewayHealthSkipped = true;

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -729,11 +729,18 @@ async function runGatewayHealthChecks(ctx: DoctorHealthFlowContext): Promise<voi
   const credentialPlan = createGatewayCredentialPlan({ config: ctx.cfg, env: process.env });
   const ambiguousLocalAuthRefs = credentialPlan.authMode === undefined;
   const remoteHealthCredentialsActive = credentialPlan.configuredMode === "remote";
+  const remoteLocalTokenFallbackActive = remoteHealthCredentialsActive && !credentialPlan.envToken;
+  const remoteLocalPasswordFallbackActive =
+    remoteHealthCredentialsActive && !credentialPlan.envPassword;
   const activeSecretRefPaths = [
-    credentialPlan.localTokenSurfaceActive || ambiguousLocalAuthRefs
+    credentialPlan.localTokenSurfaceActive ||
+    remoteLocalTokenFallbackActive ||
+    ambiguousLocalAuthRefs
       ? credentialPlan.localToken.refPath
       : undefined,
-    credentialPlan.localPasswordCanWin || ambiguousLocalAuthRefs
+    credentialPlan.localPasswordCanWin ||
+    remoteLocalPasswordFallbackActive ||
+    ambiguousLocalAuthRefs
       ? credentialPlan.localPassword.refPath
       : undefined,
     remoteHealthCredentialsActive && credentialPlan.remoteTokenActive

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -727,11 +727,23 @@ async function runGatewayHealthChecks(ctx: DoctorHealthFlowContext): Promise<voi
   const { readGatewaySecretInputValue } = await import("../gateway/secret-input-paths.js");
   const { note } = await import("../terminal/note.js");
   const credentialPlan = createGatewayCredentialPlan({ config: ctx.cfg, env: process.env });
-  const ambiguousLocalAuthRefs = credentialPlan.authMode === undefined;
+  const ambiguousLocalAuthRefs =
+    credentialPlan.authMode === undefined &&
+    !credentialPlan.envToken &&
+    !credentialPlan.envPassword &&
+    credentialPlan.localToken.hasSecretRef &&
+    credentialPlan.localPassword.hasSecretRef;
   const remoteHealthCredentialsActive = credentialPlan.configuredMode === "remote";
-  const remoteLocalTokenFallbackActive = remoteHealthCredentialsActive && !credentialPlan.envToken;
+  const remoteLocalTokenFallbackActive =
+    remoteHealthCredentialsActive &&
+    !credentialPlan.envToken &&
+    !credentialPlan.remoteToken.configured &&
+    !credentialPlan.remotePassword.configured;
   const remoteLocalPasswordFallbackActive =
-    remoteHealthCredentialsActive && !credentialPlan.envPassword;
+    remoteHealthCredentialsActive &&
+    !credentialPlan.envPassword &&
+    !credentialPlan.remoteToken.configured &&
+    !credentialPlan.remotePassword.configured;
   const activeSecretRefPaths = [
     credentialPlan.localTokenSurfaceActive ||
     remoteLocalTokenFallbackActive ||

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -728,6 +728,7 @@ async function runGatewayHealthChecks(ctx: DoctorHealthFlowContext): Promise<voi
   const { note } = await import("../terminal/note.js");
   const credentialPlan = createGatewayCredentialPlan({ config: ctx.cfg, env: process.env });
   const ambiguousLocalAuthRefs = credentialPlan.authMode === undefined;
+  const remoteHealthCredentialsActive = credentialPlan.configuredMode === "remote";
   const activeSecretRefPaths = [
     credentialPlan.localTokenSurfaceActive || ambiguousLocalAuthRefs
       ? credentialPlan.localToken.refPath
@@ -735,8 +736,12 @@ async function runGatewayHealthChecks(ctx: DoctorHealthFlowContext): Promise<voi
     credentialPlan.localPasswordCanWin || ambiguousLocalAuthRefs
       ? credentialPlan.localPassword.refPath
       : undefined,
-    credentialPlan.remoteTokenActive ? credentialPlan.remoteToken.refPath : undefined,
-    credentialPlan.remotePasswordActive ? credentialPlan.remotePassword.refPath : undefined,
+    remoteHealthCredentialsActive && credentialPlan.remoteTokenActive
+      ? credentialPlan.remoteToken.refPath
+      : undefined,
+    remoteHealthCredentialsActive && credentialPlan.remotePasswordActive
+      ? credentialPlan.remotePassword.refPath
+      : undefined,
   ].filter((path): path is NonNullable<typeof path> => Boolean(path));
   const hasActiveExecCredential = activeSecretRefPaths.some((path) => {
     const ref = resolveSecretInputRef({

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -727,7 +727,18 @@ async function runGatewayHealthChecks(ctx: DoctorHealthFlowContext): Promise<voi
     value: ctx.cfg.gateway?.auth?.token,
     defaults: ctx.cfg.secrets?.defaults,
   }).ref;
-  if (gatewayTokenRef?.source === "exec" && ctx.options.allowExec !== true) {
+  const { resolveGatewayAuth } = await import("../gateway/auth.js");
+  const auth = resolveGatewayAuth({
+    authConfig: ctx.cfg.gateway?.auth,
+    tailscaleMode: ctx.cfg.gateway?.tailscale?.mode ?? "off",
+  });
+  const gatewayHealthNeedsToken =
+    auth.mode !== "password" && auth.mode !== "none" && auth.mode !== "trusted-proxy";
+  if (
+    gatewayHealthNeedsToken &&
+    gatewayTokenRef?.source === "exec" &&
+    ctx.options.allowExec !== true
+  ) {
     note(
       "Gateway health probes skipped because gateway.auth.token uses an exec SecretRef. Run `openclaw doctor --allow-exec` to verify Gateway health with exec SecretRefs.",
       "Gateway",

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -750,7 +750,7 @@ async function runGatewayHealthChecks(ctx: DoctorHealthFlowContext): Promise<voi
     ambiguousLocalAuthRefs
       ? credentialPlan.localToken.refPath
       : undefined,
-    credentialPlan.localPasswordCanWin ||
+    (credentialPlan.localPasswordCanWin && !credentialPlan.envPassword) ||
     remoteLocalPasswordFallbackActive ||
     ambiguousLocalAuthRefs
       ? credentialPlan.localPassword.refPath

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -40,6 +40,7 @@ type DoctorHealthFlowContext = {
   env?: NodeJS.ProcessEnv;
   gatewayDetails?: ReturnType<typeof buildGatewayConnectionDetails>;
   healthOk?: boolean;
+  gatewayHealthSkipped?: boolean;
   gatewayStatus?: import("../commands/status.types.js").StatusSummary;
   gatewayMemoryProbe?: Awaited<ReturnType<typeof probeGatewayMemoryStatus>>;
 };
@@ -743,7 +744,7 @@ async function runGatewayHealthChecks(ctx: DoctorHealthFlowContext): Promise<voi
       "Gateway health probes skipped because gateway.auth.token uses an exec SecretRef. Run `openclaw doctor --allow-exec` to verify Gateway health with exec SecretRefs.",
       "Gateway",
     );
-    ctx.healthOk = false;
+    ctx.gatewayHealthSkipped = true;
     ctx.gatewayMemoryProbe = { checked: false, ready: false, skipped: true };
     return;
   }
@@ -754,6 +755,7 @@ async function runGatewayHealthChecks(ctx: DoctorHealthFlowContext): Promise<voi
     cfg: ctx.cfg,
     timeoutMs: ctx.options.nonInteractive === true ? 3000 : 10_000,
   });
+  ctx.gatewayHealthSkipped = false;
   ctx.healthOk = healthOk;
   ctx.gatewayStatus = status;
   ctx.gatewayMemoryProbe = healthOk
@@ -807,7 +809,9 @@ async function runGatewayDaemonHealth(ctx: DoctorHealthFlowContext): Promise<voi
     prompter: ctx.prompter,
     options: ctx.options,
     gatewayDetailsMessage: ctx.gatewayDetails?.message ?? "",
-    healthOk: ctx.healthOk ?? false,
+    // A skipped exec-backed token probe is unknown, not unhealthy. Do not let
+    // doctor --fix restart services only because probing would require exec.
+    healthOk: ctx.gatewayHealthSkipped === true ? true : (ctx.healthOk ?? false),
   });
 }
 

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -497,6 +497,7 @@ async function runGatewayServicesHealth(ctx: DoctorHealthFlowContext): Promise<v
     resolveDoctorMode(ctx.cfg),
     ctx.runtime,
     ctx.prompter,
+    { allowExecSecretRefs: ctx.options.allowExec === true },
   );
   await noteMacLaunchAgentOverrides();
   await noteMacStaleOpenClawUpdateLaunchdJobs();

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -723,45 +723,22 @@ async function runShellCompletionHealth(ctx: DoctorHealthFlowContext): Promise<v
 
 async function runGatewayHealthChecks(ctx: DoctorHealthFlowContext): Promise<void> {
   const { resolveSecretInputRef } = await import("../config/types.secrets.js");
-  const { createGatewayCredentialPlan } = await import("../gateway/credential-planner.js");
+  const { gatewaySecretInputPathCanWin } = await import("../gateway/credentials-secret-inputs.js");
   const { readGatewaySecretInputValue } = await import("../gateway/secret-input-paths.js");
   const { note } = await import("../terminal/note.js");
-  const credentialPlan = createGatewayCredentialPlan({ config: ctx.cfg, env: process.env });
-  const ambiguousLocalAuthRefs =
-    credentialPlan.authMode === undefined &&
-    !credentialPlan.envToken &&
-    !credentialPlan.envPassword &&
-    credentialPlan.localToken.hasSecretRef &&
-    credentialPlan.localPassword.hasSecretRef;
-  const remoteHealthCredentialsActive = credentialPlan.configuredMode === "remote";
-  const remoteLocalTokenFallbackActive =
-    remoteHealthCredentialsActive &&
-    !credentialPlan.envToken &&
-    !credentialPlan.remoteToken.configured &&
-    !credentialPlan.remotePassword.configured;
-  const remoteLocalPasswordFallbackActive =
-    remoteHealthCredentialsActive &&
-    !credentialPlan.envPassword &&
-    !credentialPlan.remoteToken.configured &&
-    !credentialPlan.remotePassword.configured;
-  const activeSecretRefPaths = [
-    credentialPlan.localTokenSurfaceActive ||
-    remoteLocalTokenFallbackActive ||
-    ambiguousLocalAuthRefs
-      ? credentialPlan.localToken.refPath
-      : undefined,
-    (credentialPlan.localPasswordCanWin && !credentialPlan.envPassword) ||
-    remoteLocalPasswordFallbackActive ||
-    ambiguousLocalAuthRefs
-      ? credentialPlan.localPassword.refPath
-      : undefined,
-    remoteHealthCredentialsActive && credentialPlan.remoteTokenActive
-      ? credentialPlan.remoteToken.refPath
-      : undefined,
-    remoteHealthCredentialsActive && credentialPlan.remotePasswordActive
-      ? credentialPlan.remotePassword.refPath
-      : undefined,
-  ].filter((path): path is NonNullable<typeof path> => Boolean(path));
+  const credentialPaths = [
+    "gateway.auth.token",
+    "gateway.auth.password",
+    "gateway.remote.token",
+    "gateway.remote.password",
+  ] as const;
+  const activeSecretRefPaths = credentialPaths.filter((path) =>
+    gatewaySecretInputPathCanWin({
+      config: ctx.cfg,
+      env: process.env,
+      path,
+    }),
+  );
   const hasActiveExecCredential = activeSecretRefPaths.some((path) => {
     const ref = resolveSecretInputRef({
       value: readGatewaySecretInputValue(ctx.cfg, path),

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -727,9 +727,12 @@ async function runGatewayHealthChecks(ctx: DoctorHealthFlowContext): Promise<voi
   const { readGatewaySecretInputValue } = await import("../gateway/secret-input-paths.js");
   const { note } = await import("../terminal/note.js");
   const credentialPlan = createGatewayCredentialPlan({ config: ctx.cfg, env: process.env });
+  const ambiguousLocalAuthRefs = credentialPlan.authMode === undefined;
   const activeSecretRefPaths = [
-    credentialPlan.localTokenSurfaceActive ? credentialPlan.localToken.refPath : undefined,
-    credentialPlan.localPasswordCanWin && !credentialPlan.envPassword
+    credentialPlan.localTokenSurfaceActive || ambiguousLocalAuthRefs
+      ? credentialPlan.localToken.refPath
+      : undefined,
+    (credentialPlan.localPasswordCanWin && !credentialPlan.envPassword) || ambiguousLocalAuthRefs
       ? credentialPlan.localPassword.refPath
       : undefined,
     credentialPlan.remoteTokenActive && !credentialPlan.envToken

--- a/src/flows/health-checks.ts
+++ b/src/flows/health-checks.ts
@@ -49,6 +49,7 @@ export interface HealthCheckContext {
   readonly cfg: OpenClawConfig;
   readonly cwd?: string;
   readonly configPath?: string;
+  readonly allowExecSecretRefs?: boolean;
 }
 
 export interface HealthRepairContext extends Omit<HealthCheckContext, "mode"> {

--- a/src/gateway/credentials-secret-inputs.ts
+++ b/src/gateway/credentials-secret-inputs.ts
@@ -173,10 +173,13 @@ function canGatewaySecretInputPathWin(params: {
       }),
     );
     const authMode = params.config.gateway?.auth?.mode;
-    const tokenCanWin = resolved.token === sentinel && (authMode === "token" || !resolved.password);
+    const tokenCanWin =
+      resolved.token === sentinel &&
+      ((mode === "local" && authMode === "token") || !resolved.password);
     const passwordCanWin =
       resolved.password === sentinel &&
-      (authMode === "password" || authMode === "trusted-proxy" || !resolved.token);
+      ((mode === "local" && (authMode === "password" || authMode === "trusted-proxy")) ||
+        !resolved.token);
     return tokenCanWin || passwordCanWin;
   } catch {
     return false;

--- a/src/gateway/credentials-secret-inputs.ts
+++ b/src/gateway/credentials-secret-inputs.ts
@@ -172,8 +172,11 @@ function canGatewaySecretInputPathWin(params: {
         options: params.options,
       }),
     );
-    const tokenCanWin = resolved.token === sentinel && !resolved.password;
-    const passwordCanWin = resolved.password === sentinel && !resolved.token;
+    const authMode = params.config.gateway?.auth?.mode;
+    const tokenCanWin = resolved.token === sentinel && (authMode === "token" || !resolved.password);
+    const passwordCanWin =
+      resolved.password === sentinel &&
+      (authMode === "password" || authMode === "trusted-proxy" || !resolved.token);
     return tokenCanWin || passwordCanWin;
   } catch {
     return false;

--- a/src/gateway/credentials-secret-inputs.ts
+++ b/src/gateway/credentials-secret-inputs.ts
@@ -127,7 +127,7 @@ function localAuthModeAllowsGatewaySecretInputPath(params: {
   return true;
 }
 
-function gatewaySecretInputPathCanWin(params: {
+function canGatewaySecretInputPathWin(params: {
   options: NormalizedGatewayCredentialSecretInputOptions;
   env: NodeJS.ProcessEnv;
   config: OpenClawConfig;
@@ -180,6 +180,21 @@ function gatewaySecretInputPathCanWin(params: {
   }
 }
 
+export function gatewaySecretInputPathCanWin(
+  params: GatewayCredentialSecretInputOptions & { path: SupportedGatewaySecretInputPath },
+): boolean {
+  const { path, env = process.env, ...options } = params;
+  return canGatewaySecretInputPathWin({
+    options: {
+      ...options,
+      explicitAuth: resolveExplicitGatewayAuth(options.explicitAuth),
+    },
+    env,
+    config: params.config,
+    path,
+  });
+}
+
 async function resolveConfiguredGatewaySecretInput(params: {
   config: OpenClawConfig;
   path: SupportedGatewaySecretInputPath;
@@ -201,7 +216,7 @@ async function resolvePreferredGatewaySecretInputs(params: {
   let nextConfig = params.config;
   for (const path of ALL_GATEWAY_SECRET_INPUT_PATHS) {
     if (
-      !gatewaySecretInputPathCanWin({
+      !canGatewaySecretInputPathWin({
         options: params.options,
         env: params.env,
         config: nextConfig,

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -315,7 +315,11 @@ async function discardIgnoredResponseBody(res: Response): Promise<void> {
   if (!body) {
     return;
   }
-  await body.cancel().catch(() => undefined);
+  try {
+    await body.cancel();
+  } catch {
+    // Best-effort cleanup after rejecting a response body.
+  }
 }
 
 function resolveRemoteFileName(params: {

--- a/src/media/input-files.ts
+++ b/src/media/input-files.ts
@@ -227,7 +227,11 @@ async function discardIgnoredResponseBody(response: Response): Promise<void> {
   if (!body) {
     return;
   }
-  await body.cancel().catch(() => undefined);
+  try {
+    await body.cancel();
+  } catch {
+    // Best-effort cleanup after rejecting a response body.
+  }
 }
 
 function decodeTextContent(buffer: Buffer, charset: string | undefined): string {


### PR DESCRIPTION
## Summary

- Problem: doctor gateway-auth checks can treat a resolving `gateway.auth.token` SecretRef as unavailable because `resolveGatewayAuth()` does not materialize SecretRef object values.
- Solution: resolve safe gateway token SecretRefs through the existing SecretRef-aware resolver before emitting the gateway-auth warning.
- What changed: both the lint/core health check and interactive doctor health path resolve non-exec SecretRefs before warning, skip valid exec SecretRefs by default without marking doctor unhealthy, and add an explicit `openclaw doctor --allow-exec` verification path.
- What did NOT change (scope boundary): this does not change gateway startup auth, SecretRef provider behavior, service install behavior, token storage, or execute exec SecretRefs without an explicit doctor opt-in.

AI-assisted: prepared with Codex.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #77687
- Related #65201
- Related #77698
- [x] This PR fixes a bug or regression

## Motivation

- SecretRef-backed gateway auth is supported, but doctor and doctor lint were checking the raw auth config through a synchronous resolver that intentionally does not materialize SecretRef values.
- #77698 fixes the same general interactive doctor warning direction. This PR extends the fix shape to `doctor-core-checks.ts` for `openclaw doctor --lint --json`, while preserving the existing no-exec default for diagnostic commands and adding a deliberate doctor exec opt-in.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: false `core/doctor/gateway-auth` warning for a successfully resolving env/file-style SecretRef, plus a clean default path for valid exec-backed SecretRefs that doctor intentionally does not execute by default.
- Real environment tested: macOS, local OpenClaw source checkout used by the CLI and gateway service.
- Exact steps or command run after this patch:
  - `node scripts/run-vitest.mjs run src/flows/doctor-core-checks.test.ts src/commands/doctor-lint.test.ts src/cli/program/register.maintenance.test.ts`
  - `pnpm exec vitest run src/commands/doctor-gateway-auth-token.test.ts`
  - `pnpm build`
  - `openclaw doctor --lint --json` against a temporary config with `gateway.auth.token` as a resolving env SecretRef
  - `openclaw doctor --lint --json` against a temporary config with `gateway.auth.token` as an exec SecretRef
  - `openclaw doctor --lint --json --allow-exec` against the same temporary exec SecretRef config
  - `openclaw doctor --lint --json` against the real local setup with `gateway.auth.token` as an intentional 1Password-backed exec SecretRef
- Evidence after fix:

```shell
node scripts/run-vitest.mjs run src/flows/doctor-core-checks.test.ts src/commands/doctor-lint.test.ts src/cli/program/register.maintenance.test.ts
Test Files  3 passed (3)
Tests       25 passed (25)

pnpm exec vitest run src/commands/doctor-gateway-auth-token.test.ts
Test Files  1 passed (1)
Tests       13 passed (13)

pnpm build
passed
```

Resolving env SecretRef behavior, using a temporary redacted config and filtering for only gateway-auth findings:

```shell
OPENCLAW_CONFIG_PATH="$tmpdir/openclaw.json" \
OPENCLAW_STATE_DIR="$tmpdir/state" \
OPENCLAW_TEST_GATEWAY_TOKEN="resolved-test-token" \
node openclaw.mjs doctor --lint --json | <filter core/doctor/gateway-auth findings>

[]
```

Default exec SecretRef behavior, using a temporary provider that writes a marker only if executed:

```shell
OPENCLAW_CONFIG_PATH="$tmpdir/openclaw.json" \
OPENCLAW_STATE_DIR="$tmpdir/state" \
node openclaw.mjs doctor --lint --json | <filter core/doctor/gateway-auth findings>

[]
marker-not-created-default
```

Explicit exec verification with the same temporary provider:

```shell
OPENCLAW_CONFIG_PATH="$tmpdir/openclaw.json" \
OPENCLAW_STATE_DIR="$tmpdir/state" \
node openclaw.mjs doctor --lint --json --allow-exec | <filter core/doctor/gateway-auth findings>

[]
marker-created-allow-exec
```

Default behavior on the real local setup, filtered to only the gateway-auth finding:

```shell
OPENCLAW_LOCAL_CHECK=1 node openclaw.mjs doctor --lint --json | <filter core/doctor/gateway-auth findings>

[]
```

- Observed result after fix:
  - A resolving env SecretRef no longer emits `core/doctor/gateway-auth`.
  - A valid configured exec SecretRef is not executed by default and no longer reports an unhealthy gateway-auth warning.
  - `openclaw doctor --allow-exec` and `openclaw doctor --lint --allow-exec` explicitly verify exec SecretRefs and still warn if they fail.
- What was not tested: a live unresolved external env/file provider path; existing unresolved coverage remains and this PR preserves the warning path.
- Before evidence (optional but encouraged):

```json
{
  "checkId": "core/doctor/gateway-auth",
  "severity": "warning",
  "message": "Gateway token is managed via SecretRef and is currently unavailable.",
  "path": "gateway.auth.token"
}
```

The real local setup's SecretRef-aware token resolver returned this redacted result before the exec boundary was restored, without printing the token:

```json
{
  "hasToken": true,
  "source": "secretRef",
  "secretRefConfigured": true
}
```

## Root Cause (if applicable)

- Root cause: doctor checked gateway auth through `resolveGatewayAuth()`, which intentionally does not materialize SecretRef object values. For SecretRef-backed token auth, that left `auth.token` unset and made doctor report the configured token as unavailable.
- Missing detection / guardrail: existing doctor coverage asserted the unresolved SecretRef warning branch, but did not cover a resolved SecretRef no-warning case, the default no-exec boundary, or an explicit doctor exec opt-in.
- Contributing context (if known): #77698 identified the same interactive doctor warning path. This PR extends the fix shape to the lint/core health check path and adds no-exec coverage.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts`
  - `src/flows/doctor-core-checks.test.ts`
  - `src/commands/doctor-lint.test.ts`
  - `src/cli/program/register.maintenance.test.ts`
- Scenario the test should lock in:
  - A local token-auth gateway config with `gateway.auth.token` as an env SecretRef should not emit the Gateway auth SecretRef warning when the SecretRef resolves.
  - A local token-auth gateway config with `gateway.auth.token` as a valid exec SecretRef should not execute the exec provider or emit a gateway-auth warning during default lint checks.
  - The same exec SecretRef should execute only when the caller passes the explicit doctor exec opt-in, and failures under that opt-in should warn.
- Why this is the smallest reliable guardrail: it exercises the doctor command and structured health check paths around gateway auth without needing a live external credential provider.
- Existing test that already covers this (if any): `src/commands/doctor-gateway-auth-token.test.ts` already covers token resolver behavior; the new tests cover doctor behavior.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Doctor no longer warns that a resolving non-exec SecretRef-managed gateway token is unavailable.
- If a valid exec SecretRef is configured, default doctor checks do not execute it and do not treat that skipped execution as an unhealthy gateway-auth warning.
- Users can pass `openclaw doctor --allow-exec` or `openclaw doctor --lint --allow-exec` to verify exec-backed gateway tokens deliberately.
- If a non-exec SecretRef does not resolve, doctor still warns and includes the resolver's concrete failure reason when available.
- If an exec SecretRef is statically invalid or fails when `--allow-exec` is used, doctor still warns.

## Diagram (if applicable)

```text
Before:
gateway.auth.token SecretRef -> resolveGatewayAuth() -> no materialized token -> unavailable warning

After:
gateway.auth.token env/file SecretRef -> resolveGatewayAuthToken() -> resolved token -> no warning
gateway.auth.token env/file SecretRef -> resolveGatewayAuthToken() -> unresolved -> warning with reason
gateway.auth.token valid exec SecretRef -> no default execution -> no gateway-auth warning
gateway.auth.token exec SecretRef + --allow-exec -> resolveGatewayAuthToken() -> resolved token -> no warning
gateway.auth.token exec SecretRef + --allow-exec -> resolveGatewayAuthToken() -> unresolved -> warning with reason
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) Yes
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:
  - The change resolves configured non-exec `gateway.auth.token` SecretRefs through the existing gateway token resolver after doctor determines token auth needs a token. It does not print or persist the token.
  - Exec SecretRefs are explicitly not executed during default doctor checks. They are only executed when the caller passes `--allow-exec`, matching the existing explicit-consent pattern used by `openclaw secrets audit --allow-exec`.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local source checkout / Node CLI
- Model/provider: not model-dependent
- Integration/channel (if any): local gateway auth / doctor CLI
- Relevant config (redacted): `gateway.auth.mode: "token"` and `gateway.auth.token` as a SecretRef.

### Steps

1. Configure local gateway token auth with `gateway.auth.token` as a resolving env/file SecretRef.
2. Run `openclaw doctor --lint --json` on current main.
3. Observe `core/doctor/gateway-auth` warning.
4. Apply this patch and rebuild.
5. Run `openclaw doctor --lint --json` again.
6. Configure `gateway.auth.token` as an exec SecretRef and run doctor lint.
7. Re-run doctor lint with `--allow-exec`.

### Expected

- A resolving non-exec SecretRef-backed gateway token should not produce an unavailable-token warning.
- A valid exec SecretRef should not execute during default doctor lint and should not produce an unhealthy gateway-auth warning.
- An exec SecretRef should execute only when `--allow-exec` is present.

### Actual

- After this patch, the env SecretRef test config emits no `core/doctor/gateway-auth` finding.
- The default exec SecretRef test config emits no `core/doctor/gateway-auth` finding and does not create the exec marker.
- The `--allow-exec` test config emits no `core/doctor/gateway-auth` finding and creates the exec marker.
- The real local exec SecretRef setup emits no `core/doctor/gateway-auth` finding by default.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Resolved env SecretRef-backed gateway token no longer emits `core/doctor/gateway-auth`.
  - Valid exec SecretRef-backed gateway token is not executed or warned on during default lint checks.
  - Exec SecretRef-backed gateway token is executed only when doctor lint is run with `--allow-exec`.
  - Existing unresolved SecretRef read-only doctor behavior remains covered.
  - Gateway token resolver tests still pass.
- Edge cases checked:
  - Lint/JSON doctor path and interactive doctor path both apply the same message/fix-hint helper.
- What you did **not** verify:
  - A live unresolved external env/file SecretRef provider failure path.
  - A real 1Password-backed exec provider under `--allow-exec`; the exec opt-in proof used a temporary local provider and did not print or transmit secrets.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: default doctor skips valid exec SecretRef verification.
  - Mitigation: default doctor does not claim the ref resolved; it only avoids treating explicit no-exec consent as an unhealthy auth failure. Users can run `openclaw doctor --allow-exec` when they want doctor to verify exec-backed secrets.
