### PR TITLE
fix(config): dedupe missing official plugin warnings

### DIFF
--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -315,7 +315,7 @@ describe("config plugin validation", () => {
     }
   });
 
-  it("reports catalog install hints for missing configured official external plugins", () => {
+  it("deduplicates catalog install hints for missing configured official external plugins", () => {
     const res = validateConfigObjectWithPlugins(
       {
         agents: { list: [{ id: "pi" }] },
@@ -339,7 +339,7 @@ describe("config plugin validation", () => {
     const message =
       "plugin not installed: brave — install the official external plugin with: openclaw plugins install @openclaw/brave-plugin";
     expectPathMessage(res.warnings, "plugins.entries.brave", message);
-    expectPathMessage(res.warnings, "plugins.allow", message);
+    expect((res.warnings ?? []).filter((warning) => warning.message === message)).toHaveLength(1);
     expect(
       (res.warnings ?? []).some(
         (warning) =>
@@ -403,12 +403,39 @@ describe("config plugin validation", () => {
     const message =
       "plugin not installed: memory-lancedb — install the official external plugin with: openclaw plugins install @openclaw/memory-lancedb";
     expectPathMessage(res.warnings, "plugins.entries.memory-lancedb", message);
-    expectPathMessage(res.warnings, "plugins.allow", message);
+    expect((res.warnings ?? []).filter((warning) => warning.message === message)).toHaveLength(1);
     expect(
       (res.warnings ?? []).some((warning) =>
         warning.message.includes("gateway will run without persistent memory"),
       ),
     ).toBe(false);
+  });
+
+  it("deduplicates yuanbao missing-plugin warnings across entries and allow", () => {
+    const res = validateConfigObjectWithPlugins(
+      {
+        agents: { list: [{ id: "pi" }] },
+        plugins: {
+          entries: { yuanbao: { enabled: true } },
+          allow: ["yuanbao"],
+        },
+      },
+      {
+        env: suiteEnv(),
+        pluginMetadataSnapshot: {
+          manifestRegistry: {
+            plugins: [],
+            diagnostics: [],
+          },
+        },
+      },
+    );
+
+    expect(res.ok).toBe(true);
+    const message =
+      "plugin not installed: yuanbao — install the official external plugin with: openclaw plugins install openclaw-plugin-yuanbao@2.13.1";
+    expectPathMessage(res.warnings, "plugins.entries.yuanbao", message);
+    expect((res.warnings ?? []).filter((warning) => warning.message === message)).toHaveLength(1);
   });
 
   it("keeps official external non-memory plugins fatal in the memory slot", () => {

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -43,8 +43,8 @@ import { materializeRuntimeConfig } from "./materialize.js";
 import { collectConfiguredModelRefs } from "./model-refs.js";
 import type { OpenClawConfig, ConfigValidationIssue } from "./types.js";
 import { coerceSecretRef } from "./types.secrets.js";
-import { OpenClawSchema } from "./zod-schema.js";
 import { isBuiltInModelProviderOverlayId } from "./zod-schema.core.js";
+import { OpenClawSchema } from "./zod-schema.js";
 
 const LEGACY_REMOVED_PLUGIN_IDS = new Set(["google-antigravity-auth", "google-gemini-cli-auth"]);
 const BLOCKED_PLUGIN_CANDIDATE_PREFIX = "blocked plugin candidate:";
@@ -1605,6 +1605,7 @@ function validateConfigObjectWithPluginsBase(
       blockedDiagnosticSourceMatchesPluginId(diagnostic, pluginId),
     );
   };
+  const missingOfficialPluginWarningIds = new Set<string>();
   const pushMissingPluginIssue = (
     path: string,
     pluginId: string,
@@ -1632,6 +1633,13 @@ function validateConfigObjectWithPluginsBase(
       const externalInstallWarning =
         opts.missingMessage ?? formatMissingOfficialExternalPluginWarning(pluginId);
       if (externalInstallWarning) {
+        const normalizedPluginId = normalizePluginId(pluginId);
+        if (!opts.missingMessage && normalizedPluginId) {
+          if (missingOfficialPluginWarningIds.has(normalizedPluginId)) {
+            return;
+          }
+          missingOfficialPluginWarningIds.add(normalizedPluginId);
+        }
         warnings.push({
           path,
           message: externalInstallWarning,


### PR DESCRIPTION
## Summary
- Deduplicate repeated official external plugin install-hint warnings by normalized plugin id.
- Keep the first actionable config path, while preserving generic stale-plugin warnings, removed-plugin warnings, blocked-plugin warnings, and memory-slot-specific wording.
- Add regression coverage for `yuanbao` appearing in both `plugins.entries` and `plugins.allow`.

Fixes #84192.

## Verification
- `node scripts/run-vitest.mjs src/config/config.plugin-validation.test.ts -t "deduplicates|official external memory slot"`
- `node scripts/run-vitest.mjs src/config/plugin-auto-enable.channels.test.ts`
- `node node_modules/@typescript/native-preview/bin/tsgo.js --noEmit --pretty false -p tsconfig.json`
- `git diff --check -- src/config/validation.ts src/config/config.plugin-validation.test.ts`
- `/mnt/c/src/claws-hapi/.agents/skills/autoreview/scripts/autoreview --parallel-tests "node scripts/run-vitest.mjs src/config/config.plugin-validation.test.ts -t \"deduplicates|official external memory slot\" && node scripts/run-vitest.mjs src/config/plugin-auto-enable.channels.test.ts"`

Note: `node scripts/run-vitest.mjs src/config/config.plugin-validation.test.ts` currently fails in this WSL/Node 24 worktree on six fixture-loader cases unrelated to this patch (`does not auto-allow config-loaded overrides...`, plugin config diagnostics, voice-call schema diagnostics, and plugin heartbeat targets). The changed regression subset and adjacent plugin auto-enable file pass.

## Real behavior proof
Behavior addressed: A missing official external plugin referenced in both `plugins.entries.<id>` and `plugins.allow` now emits one install-hint warning instead of duplicate warnings for the same missing plugin id.
Real environment tested: WSL-local OpenClaw source checkout on PR head `2e69db0a`.
Exact steps or command run after this patch: Created a temporary `openclaw.json` containing both `plugins.entries.yuanbao.enabled=true` and `plugins.allow=["yuanbao"]`, then ran `OPENCLAW_HOME=<tmp>/home OPENCLAW_STATE_DIR=<tmp>/state OPENCLAW_CONFIG_PATH=<tmp>/state/openclaw.json node --import tsx src/entry.ts doctor --non-interactive --yes --no-workspace-suggestions`.
Evidence after fix: The real doctor config preflight emitted one missing-plugin install hint for `yuanbao`:

    head: 2e69db0a
    config: plugins.entries.yuanbao + plugins.allow[0]=yuanbao
    yuanbao_install_warning_count: 1
    warning_line: │  - plugins.entries.yuanbao: plugin not installed: yuanbao — install the  │

Observed result after fix: The runtime doctor path reported only the first actionable warning path, `plugins.entries.yuanbao`, for the duplicated `yuanbao` config surfaces. It did not emit a second generic install-hint warning for `plugins.allow`.
What was not tested: A live Windows/Bun startup using the reporter's exact default config path; this proof exercises the same runtime doctor config preflight path that reports config warnings before doctor repairs run.
