### PR TITLE
fix(nvidia): update Nemotron 3 Super contextWindow to 1M per NVIDIA spec

### DIFF
--- a/extensions/nvidia/openclaw.plugin.json
+++ b/extensions/nvidia/openclaw.plugin.json
@@ -29,7 +29,7 @@
             "id": "nvidia/nemotron-3-super-120b-a12b",
             "name": "NVIDIA Nemotron 3 Super 120B",
             "input": ["text"],
-            "contextWindow": 262144,
+            "contextWindow": 1000000,
             "maxTokens": 8192,
             "cost": {
               "input": 0,


### PR DESCRIPTION
## Summary

Updates `nvidia/nemotron-3-super-120b-a12b` in `extensions/nvidia/openclaw.plugin.json` from a 262144 (256k) `contextWindow` to 1000000 (1M) to match NVIDIA's published spec for the model.

NVIDIA's [Nemotron 3 Super technical blog](https://developer.nvidia.com/blog/introducing-nemotron-3-super-an-open-hybrid-mamba-transformer-moe-for-agentic-reasoning/) states explicitly: *"1M token context window for long-term agent coherence, cross-document reasoning, and multi-step task planning."* This is enabled by the hybrid Mamba-Transformer SSM architecture (Mamba-2 layers provide linear-time complexity over sequence length, making 1M practical rather than theoretical).

The other three models in the same catalog (`moonshotai/kimi-k2.5`, `minimaxai/minimax-m2.5`, `z-ai/glm5`) match upstream specs and are unchanged. Scoped intentionally narrow; happy to file follow-ups for catalog refresh (Kimi K2.6, GLM-5.1, MiniMax M2.7, DeepSeek V4) as separate PRs.

## Verification

The catalog `contextWindow` is the authoritative value at runtime — per-agent `models.json` overrides cannot raise it above what the bundled plugin declares. So a stale value here silently caps real workloads.

Real behavior proof:

Behavior addressed: stale `contextWindow` clamps Nemotron 3 Super at 256k regardless of per-agent overrides; long-context workflows (large codebase analysis, document corpora) that the model was explicitly designed for cannot use the full window.
Real environment tested: macOS 24.6.0, openclaw 2026.5.18 (`50a2481`), Node 25.8.0, NVIDIA NIM (`https://integrate.api.nvidia.com/v1`, free tier API key)
Exact steps or command run after this patch: edited `extensions/nvidia/openclaw.plugin.json` to set `contextWindow: 1000000` for `nvidia/nemotron-3-super-120b-a12b`; re-ran `openclaw models list --json` against the patched installation.
Evidence after fix: with the upstream catalog at 262144, agent-side `models.json` overrides up to `1000000` were silently capped at 200000 in `openclaw models list --json` output. After the patch the catalog value flows through.
Observed result after fix: `openclaw models list --json` reports `contextWindow: 1000000` for `nvidia/nemotron-3-super-120b-a12b`. Other three NVIDIA models unchanged.
What was not tested: did not exercise an actual >256k token completion against the NIM endpoint (would burn free-tier credits); did not run `pnpm test:extension nvidia` (data-only JSON change with no code or schema impact). Both are good follow-ups before merge if desired.
