### PR TITLE
fix(line): precheck outbound LINE media size

### DIFF
--- a/extensions/line/src/outbound-media.test.ts
+++ b/extensions/line/src/outbound-media.test.ts
@@ -2,22 +2,58 @@ import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const ssrfMocks = vi.hoisted(() => ({
   resolvePinnedHostnameWithPolicy: vi.fn(),
+  fetchWithSsrFGuard: vi.fn(),
+}));
+
+const runtimeEnvMocks = vi.hoisted(() => ({
+  logVerbose: vi.fn(),
 }));
 
 vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
   resolvePinnedHostnameWithPolicy: ssrfMocks.resolvePinnedHostnameWithPolicy,
+  fetchWithSsrFGuard: ssrfMocks.fetchWithSsrFGuard,
 }));
+
+vi.mock("openclaw/plugin-sdk/runtime-env", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/runtime-env")>(
+    "openclaw/plugin-sdk/runtime-env",
+  );
+  return {
+    ...actual,
+    logVerbose: runtimeEnvMocks.logVerbose,
+  };
+});
 
 afterAll(() => {
   vi.doUnmock("openclaw/plugin-sdk/ssrf-runtime");
+  vi.doUnmock("openclaw/plugin-sdk/runtime-env");
   vi.resetModules();
 });
 
 import {
   detectLineMediaKind,
+  LINE_OUTBOUND_MEDIA_MAX_BYTES,
+  precheckLineOutboundMediaSize,
   resolveLineOutboundMedia,
   validateLineMediaUrl,
 } from "./outbound-media.js";
+
+function buildGuardedHeadResult(params: { status: number; contentLength?: string | null }): {
+  response: Response;
+  finalUrl: string;
+  release: () => Promise<void>;
+} {
+  const headers = new Headers();
+  if (params.contentLength !== undefined && params.contentLength !== null) {
+    headers.set("content-length", params.contentLength);
+  }
+  const response = new Response(null, { status: params.status, headers });
+  return {
+    response,
+    finalUrl: "https://example.com/asset",
+    release: vi.fn(async () => undefined),
+  };
+}
 
 describe("validateLineMediaUrl", () => {
   beforeEach(() => {
@@ -99,6 +135,11 @@ describe("resolveLineOutboundMedia", () => {
       hostname: "example.com",
       addresses: ["93.184.216.34"],
     });
+    ssrfMocks.fetchWithSsrFGuard.mockReset();
+    ssrfMocks.fetchWithSsrFGuard.mockResolvedValue(
+      buildGuardedHeadResult({ status: 200, contentLength: "1024" }),
+    );
+    runtimeEnvMocks.logVerbose.mockReset();
   });
 
   it("respects explicit media kind without remote MIME probing", async () => {
@@ -190,5 +231,199 @@ describe("resolveLineOutboundMedia", () => {
     await expect(resolveLineOutboundMedia("http://example.com/image.jpg")).rejects.toThrow(
       /must use HTTPS/i,
     );
+  });
+
+  it("does not double-probe when previewImageUrl equals the media URL", async () => {
+    const sharedUrl = "https://example.com/asset.jpg";
+    ssrfMocks.fetchWithSsrFGuard.mockReset();
+    ssrfMocks.fetchWithSsrFGuard.mockResolvedValue(
+      buildGuardedHeadResult({ status: 200, contentLength: "1024" }),
+    );
+    await expect(
+      resolveLineOutboundMedia(sharedUrl, { previewImageUrl: sharedUrl }),
+    ).resolves.toEqual({
+      mediaUrl: sharedUrl,
+      mediaKind: "image",
+      previewImageUrl: sharedUrl,
+    });
+    expect(ssrfMocks.fetchWithSsrFGuard).toHaveBeenCalledTimes(1);
+  });
+
+  // T11
+  it("rejects a video URL whose HEAD reports a payload larger than the LINE video cap", async () => {
+    const oversized = LINE_OUTBOUND_MEDIA_MAX_BYTES.video + 1;
+    ssrfMocks.fetchWithSsrFGuard.mockResolvedValueOnce(
+      buildGuardedHeadResult({ status: 200, contentLength: String(oversized) }),
+    );
+    await expect(
+      resolveLineOutboundMedia("https://example.com/big.mp4", {
+        mediaKind: "video",
+        previewImageUrl: "https://example.com/preview.jpg",
+      }),
+    ).rejects.toThrow(/LINE video media must be ≤209715200 bytes/);
+  });
+});
+
+describe("precheckLineOutboundMediaSize", () => {
+  beforeEach(() => {
+    ssrfMocks.fetchWithSsrFGuard.mockReset();
+    runtimeEnvMocks.logVerbose.mockReset();
+  });
+
+  // T1
+  it("resolves when HEAD 200 reports a payload under the image cap", async () => {
+    ssrfMocks.fetchWithSsrFGuard.mockResolvedValueOnce(
+      buildGuardedHeadResult({ status: 200, contentLength: String(1024 * 1024) }),
+    );
+    await expect(
+      precheckLineOutboundMediaSize("https://example.com/image.jpg", "image"),
+    ).resolves.toBeUndefined();
+    expect(runtimeEnvMocks.logVerbose).not.toHaveBeenCalled();
+  });
+
+  // T2
+  it("rejects when HEAD 200 reports a payload over the image cap", async () => {
+    const oversized = 11 * 1024 * 1024;
+    ssrfMocks.fetchWithSsrFGuard.mockResolvedValueOnce(
+      buildGuardedHeadResult({ status: 200, contentLength: String(oversized) }),
+    );
+    await expect(
+      precheckLineOutboundMediaSize("https://example.com/image.jpg", "image"),
+    ).rejects.toThrow(/LINE image media must be ≤10485760 bytes \(got 11534336 bytes/);
+  });
+
+  // T3
+  it("soft-fails when content-length is absent", async () => {
+    ssrfMocks.fetchWithSsrFGuard.mockResolvedValueOnce(
+      buildGuardedHeadResult({ status: 200, contentLength: null }),
+    );
+    await expect(
+      precheckLineOutboundMediaSize("https://example.com/image.jpg", "image"),
+    ).resolves.toBeUndefined();
+    expect(runtimeEnvMocks.logVerbose).toHaveBeenCalledTimes(1);
+    expect(runtimeEnvMocks.logVerbose.mock.calls[0]?.[0]).toMatch(/no content-length/);
+  });
+
+  // T4
+  it("soft-fails when HEAD returns a non-2xx status", async () => {
+    ssrfMocks.fetchWithSsrFGuard.mockResolvedValueOnce(
+      buildGuardedHeadResult({ status: 405, contentLength: null }),
+    );
+    await expect(
+      precheckLineOutboundMediaSize("https://example.com/image.jpg", "image"),
+    ).resolves.toBeUndefined();
+    expect(runtimeEnvMocks.logVerbose).toHaveBeenCalledTimes(1);
+    expect(runtimeEnvMocks.logVerbose.mock.calls[0]?.[0]).toMatch(/status 405/);
+  });
+
+  // T5
+  it("soft-fails when the probe throws", async () => {
+    ssrfMocks.fetchWithSsrFGuard.mockRejectedValueOnce(new Error("ECONNRESET"));
+    await expect(
+      precheckLineOutboundMediaSize("https://example.com/image.jpg", "image"),
+    ).resolves.toBeUndefined();
+    expect(runtimeEnvMocks.logVerbose).toHaveBeenCalledTimes(1);
+    expect(runtimeEnvMocks.logVerbose.mock.calls[0]?.[0]).toMatch(/probe failed/);
+  });
+
+  // T6
+  it("soft-fails when content-length is malformed", async () => {
+    ssrfMocks.fetchWithSsrFGuard.mockResolvedValueOnce(
+      buildGuardedHeadResult({ status: 200, contentLength: "abc" }),
+    );
+    await expect(
+      precheckLineOutboundMediaSize("https://example.com/image.jpg", "image"),
+    ).resolves.toBeUndefined();
+    expect(runtimeEnvMocks.logVerbose).toHaveBeenCalledTimes(1);
+    expect(runtimeEnvMocks.logVerbose.mock.calls[0]?.[0]).toMatch(/malformed content-length/);
+  });
+
+  // T7
+  it("soft-fails when content-length is negative", async () => {
+    ssrfMocks.fetchWithSsrFGuard.mockResolvedValueOnce(
+      buildGuardedHeadResult({ status: 200, contentLength: "-5" }),
+    );
+    await expect(
+      precheckLineOutboundMediaSize("https://example.com/image.jpg", "image"),
+    ).resolves.toBeUndefined();
+    expect(runtimeEnvMocks.logVerbose).toHaveBeenCalledTimes(1);
+    expect(runtimeEnvMocks.logVerbose.mock.calls[0]?.[0]).toMatch(/malformed content-length/);
+  });
+
+  // T8
+  it("resolves when content-length is exactly at the image cap (inclusive)", async () => {
+    ssrfMocks.fetchWithSsrFGuard.mockResolvedValueOnce(
+      buildGuardedHeadResult({
+        status: 200,
+        contentLength: String(LINE_OUTBOUND_MEDIA_MAX_BYTES.image),
+      }),
+    );
+    await expect(
+      precheckLineOutboundMediaSize("https://example.com/image.jpg", "image"),
+    ).resolves.toBeUndefined();
+    expect(runtimeEnvMocks.logVerbose).not.toHaveBeenCalled();
+  });
+
+  // T9
+  it("rejects with the video cap when a 250 MiB video is probed", async () => {
+    const oversized = 250 * 1024 * 1024;
+    ssrfMocks.fetchWithSsrFGuard.mockResolvedValueOnce(
+      buildGuardedHeadResult({ status: 200, contentLength: String(oversized) }),
+    );
+    await expect(
+      precheckLineOutboundMediaSize("https://example.com/video.mp4", "video"),
+    ).rejects.toThrow(/LINE video media must be ≤209715200 bytes \(got 262144000 bytes/);
+  });
+
+  // T10
+  it("resolves for an under-cap audio probe", async () => {
+    ssrfMocks.fetchWithSsrFGuard.mockResolvedValueOnce(
+      buildGuardedHeadResult({ status: 200, contentLength: String(5 * 1024 * 1024) }),
+    );
+    await expect(
+      precheckLineOutboundMediaSize("https://example.com/audio.m4a", "audio"),
+    ).resolves.toBeUndefined();
+    expect(runtimeEnvMocks.logVerbose).not.toHaveBeenCalled();
+  });
+
+  it("issues a HEAD request through fetchWithSsrFGuard with the strict LINE outbound policy", async () => {
+    ssrfMocks.fetchWithSsrFGuard.mockResolvedValueOnce(
+      buildGuardedHeadResult({ status: 200, contentLength: "1024" }),
+    );
+    await precheckLineOutboundMediaSize("https://example.com/image.jpg", "image");
+    expect(ssrfMocks.fetchWithSsrFGuard).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://example.com/image.jpg",
+        init: { method: "HEAD" },
+        requireHttps: true,
+        mode: "strict",
+        timeoutMs: 5000,
+        policy: { allowPrivateNetwork: false },
+      }),
+    );
+  });
+
+  it("redacts the probed URL (no query string) in the rejection message", async () => {
+    const oversized = 11 * 1024 * 1024;
+    ssrfMocks.fetchWithSsrFGuard.mockResolvedValueOnce(
+      buildGuardedHeadResult({ status: 200, contentLength: String(oversized) }),
+    );
+    await expect(
+      precheckLineOutboundMediaSize("https://example.com/image.jpg?sig=secret-token", "image"),
+    ).rejects.toThrow(/from https:\/\/example\.com\/image\.jpg\)/);
+  });
+
+  it("releases the dispatcher after a successful probe", async () => {
+    const release = vi.fn(async () => undefined);
+    ssrfMocks.fetchWithSsrFGuard.mockResolvedValueOnce({
+      response: new Response(null, {
+        status: 200,
+        headers: new Headers({ "content-length": "1024" }),
+      }),
+      finalUrl: "https://example.com/image.jpg",
+      release,
+    });
+    await precheckLineOutboundMediaSize("https://example.com/image.jpg", "image");
+    expect(release).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/line/src/outbound-media.test.ts
+++ b/extensions/line/src/outbound-media.test.ts
@@ -249,6 +249,37 @@ describe("resolveLineOutboundMedia", () => {
     expect(ssrfMocks.fetchWithSsrFGuard).toHaveBeenCalledTimes(1);
   });
 
+  it("rejects when an explicit previewImageUrl exceeds the LINE preview cap (between 1 MiB and 10 MiB)", async () => {
+    const between = 5 * 1024 * 1024; // ≈ 5 MiB — under image cap, over preview cap
+    ssrfMocks.fetchWithSsrFGuard.mockReset();
+    ssrfMocks.fetchWithSsrFGuard
+      .mockResolvedValueOnce(
+        buildGuardedHeadResult({ status: 200, contentLength: "1024" }), // media: under cap
+      )
+      .mockResolvedValueOnce(
+        buildGuardedHeadResult({ status: 200, contentLength: String(between) }), // preview: over preview cap
+      );
+    await expect(
+      resolveLineOutboundMedia("https://example.com/video.mp4", {
+        mediaKind: "video",
+        previewImageUrl: "https://example.com/big-preview.png",
+      }),
+    ).rejects.toThrow(/LINE preview media must be ≤1048576 bytes \(got 5242880 bytes/);
+  });
+
+  it("rejects when previewImageUrl equals mediaUrl and the shared file exceeds the preview cap", async () => {
+    const sharedUrl = "https://example.com/shared.jpg";
+    const between = 5 * 1024 * 1024;
+    ssrfMocks.fetchWithSsrFGuard.mockReset();
+    ssrfMocks.fetchWithSsrFGuard.mockResolvedValueOnce(
+      buildGuardedHeadResult({ status: 200, contentLength: String(between) }),
+    );
+    await expect(
+      resolveLineOutboundMedia(sharedUrl, { previewImageUrl: sharedUrl }),
+    ).rejects.toThrow(/LINE preview media must be ≤1048576 bytes \(got 5242880 bytes/);
+    expect(ssrfMocks.fetchWithSsrFGuard).toHaveBeenCalledTimes(1);
+  });
+
   // T11
   it("rejects a video URL whose HEAD reports a payload larger than the LINE video cap", async () => {
     const oversized = LINE_OUTBOUND_MEDIA_MAX_BYTES.video + 1;
@@ -382,6 +413,29 @@ describe("precheckLineOutboundMediaSize", () => {
     );
     await expect(
       precheckLineOutboundMediaSize("https://example.com/audio.m4a", "audio"),
+    ).resolves.toBeUndefined();
+    expect(runtimeEnvMocks.logVerbose).not.toHaveBeenCalled();
+  });
+
+  it("rejects with the preview cap when kind=preview and content-length is between 1 MiB and 10 MiB", async () => {
+    const between = 5 * 1024 * 1024; // under image cap, over preview cap
+    ssrfMocks.fetchWithSsrFGuard.mockResolvedValueOnce(
+      buildGuardedHeadResult({ status: 200, contentLength: String(between) }),
+    );
+    await expect(
+      precheckLineOutboundMediaSize("https://example.com/preview.png", "preview"),
+    ).rejects.toThrow(/LINE preview media must be ≤1048576 bytes \(got 5242880 bytes/);
+  });
+
+  it("resolves when kind=preview and content-length is exactly at the 1 MiB preview cap (inclusive)", async () => {
+    ssrfMocks.fetchWithSsrFGuard.mockResolvedValueOnce(
+      buildGuardedHeadResult({
+        status: 200,
+        contentLength: String(LINE_OUTBOUND_MEDIA_MAX_BYTES.preview),
+      }),
+    );
+    await expect(
+      precheckLineOutboundMediaSize("https://example.com/preview.png", "preview"),
     ).resolves.toBeUndefined();
     expect(runtimeEnvMocks.logVerbose).not.toHaveBeenCalled();
   });

--- a/extensions/line/src/outbound-media.test.ts
+++ b/extensions/line/src/outbound-media.test.ts
@@ -280,6 +280,25 @@ describe("resolveLineOutboundMedia", () => {
     expect(ssrfMocks.fetchWithSsrFGuard).toHaveBeenCalledTimes(1);
   });
 
+  // Regression: image kind with no explicit previewImageUrl. Downstream
+  // buildLineMediaMessageObject defaults previewImageUrl to the mediaUrl,
+  // so a 5 MiB image URL passes the 10 MiB image cap but later fails on
+  // LINE's 1 MiB preview cap. The resolver must apply the preview cap
+  // locally on the shared URL.
+  it("rejects an image with no explicit previewImageUrl when mediaUrl exceeds the preview cap", async () => {
+    const between = 5 * 1024 * 1024; // under image cap, over preview cap
+    ssrfMocks.fetchWithSsrFGuard.mockReset();
+    ssrfMocks.fetchWithSsrFGuard.mockResolvedValueOnce(
+      buildGuardedHeadResult({ status: 200, contentLength: String(between) }),
+    );
+    await expect(
+      resolveLineOutboundMedia("https://example.com/implicit-preview.jpg", {
+        mediaKind: "image",
+      }),
+    ).rejects.toThrow(/LINE preview media must be ≤1048576 bytes \(got 5242880 bytes/);
+    expect(ssrfMocks.fetchWithSsrFGuard).toHaveBeenCalledTimes(1);
+  });
+
   // T11
   it("rejects a video URL whose HEAD reports a payload larger than the LINE video cap", async () => {
     const oversized = LINE_OUTBOUND_MEDIA_MAX_BYTES.video + 1;

--- a/extensions/line/src/outbound-media.ts
+++ b/extensions/line/src/outbound-media.ts
@@ -1,4 +1,9 @@
-import { resolvePinnedHostnameWithPolicy, type SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
+import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
+import {
+  fetchWithSsrFGuard,
+  resolvePinnedHostnameWithPolicy,
+  type SsrFPolicy,
+} from "openclaw/plugin-sdk/ssrf-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 
 type LineOutboundMediaKind = "image" | "video" | "audio";
@@ -21,6 +26,90 @@ type ResolveLineOutboundMediaOpts = {
 const LINE_OUTBOUND_MEDIA_SSRF_POLICY: SsrFPolicy = {
   allowPrivateNetwork: false,
 };
+
+// Verified against developers.line.biz/en/reference/messaging-api/ on 2026-05-19.
+// Image message: "Max file size: 10MB". Video / audio: "Max file size: 200 MB".
+export const LINE_OUTBOUND_MEDIA_MAX_BYTES: Record<LineOutboundMediaKind, number> = {
+  image: 10 * 1024 * 1024,
+  video: 200 * 1024 * 1024,
+  audio: 200 * 1024 * 1024,
+};
+
+const LINE_OUTBOUND_MEDIA_PRECHECK_TIMEOUT_MS = 5000;
+
+type FetchImpl = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+type PrecheckLineOutboundMediaSizeOpts = {
+  fetchImpl?: FetchImpl;
+};
+
+function redactLineOutboundMediaUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    return `${parsed.protocol}//${parsed.hostname}${parsed.pathname}`;
+  } catch {
+    return "<invalid-url>";
+  }
+}
+
+export async function precheckLineOutboundMediaSize(
+  url: string,
+  kind: LineOutboundMediaKind,
+  opts: PrecheckLineOutboundMediaSizeOpts = {},
+): Promise<void> {
+  const cap = LINE_OUTBOUND_MEDIA_MAX_BYTES[kind];
+  const redacted = redactLineOutboundMediaUrl(url);
+
+  let response: Response;
+  let release: () => Promise<void>;
+  try {
+    const guarded = await fetchWithSsrFGuard({
+      url,
+      init: { method: "HEAD" },
+      requireHttps: true,
+      mode: "strict",
+      policy: LINE_OUTBOUND_MEDIA_SSRF_POLICY,
+      timeoutMs: LINE_OUTBOUND_MEDIA_PRECHECK_TIMEOUT_MS,
+      ...(opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {}),
+    });
+    response = guarded.response;
+    release = guarded.release;
+  } catch {
+    logVerbose(`line: outbound media-size precheck skipped (probe failed): ${redacted}`);
+    return;
+  }
+
+  try {
+    if (response.status !== 200 && response.status !== 206) {
+      logVerbose(
+        `line: outbound media-size precheck skipped (status ${response.status}): ${redacted}`,
+      );
+      return;
+    }
+
+    const lengthHeader = response.headers.get("content-length");
+    if (lengthHeader === null) {
+      logVerbose(`line: outbound media-size precheck skipped (no content-length): ${redacted}`);
+      return;
+    }
+
+    const length = Number(lengthHeader);
+    if (!Number.isFinite(length) || length < 0) {
+      logVerbose(
+        `line: outbound media-size precheck skipped (malformed content-length ${lengthHeader}): ${redacted}`,
+      );
+      return;
+    }
+
+    if (length > cap) {
+      throw new Error(
+        `LINE ${kind} media must be ≤${cap} bytes (got ${length} bytes from ${redacted})`,
+      );
+    }
+  } finally {
+    await release();
+  }
+}
 
 export async function validateLineMediaUrl(url: string): Promise<void> {
   let parsed: URL;
@@ -97,6 +186,10 @@ export async function resolveLineOutboundMedia(
       (opts.trackingId?.trim() ? "video" : undefined) ??
       detectLineMediaKindFromUrl(trimmedUrl) ??
       "image";
+    await precheckLineOutboundMediaSize(trimmedUrl, mediaKind);
+    if (previewImageUrl && previewImageUrl !== trimmedUrl) {
+      await precheckLineOutboundMediaSize(previewImageUrl, "image");
+    }
     return {
       mediaUrl: trimmedUrl,
       mediaKind,

--- a/extensions/line/src/outbound-media.ts
+++ b/extensions/line/src/outbound-media.ts
@@ -196,9 +196,12 @@ export async function resolveLineOutboundMedia(
       (opts.trackingId?.trim() ? "video" : undefined) ??
       detectLineMediaKindFromUrl(trimmedUrl) ??
       "image";
-    if (previewImageUrl && previewImageUrl === trimmedUrl) {
-      // Same URL serves as both originalContentUrl and previewImageUrl;
-      // dedupe to one HEAD probe but evaluate against the stricter preview cap.
+    if (mediaKind === "image" && (!previewImageUrl || previewImageUrl === trimmedUrl)) {
+      // For image kind, buildLineMediaMessageObject defaults
+      // previewImageUrl to mediaUrl when no explicit preview is supplied
+      // (and an explicit same-URL preview is handled identically). The
+      // shared URL must therefore satisfy the stricter preview cap; one
+      // HEAD probe covers both LINE-side validations.
       await precheckLineOutboundMediaSize(trimmedUrl, "preview");
     } else {
       await precheckLineOutboundMediaSize(trimmedUrl, mediaKind);

--- a/extensions/line/src/outbound-media.ts
+++ b/extensions/line/src/outbound-media.ts
@@ -8,6 +8,12 @@ import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coer
 
 type LineOutboundMediaKind = "image" | "video" | "audio";
 
+// "preview" covers previewImageUrl payloads on image/video messages, which
+// LINE caps at 1 MB (smaller than the 10 MB / 200 MB caps that apply to the
+// originalContentUrl). It is not a message-level media kind, so it is kept
+// out of LineOutboundMediaKind / LineOutboundMediaResolved.mediaKind.
+type LineOutboundMediaSizeKind = LineOutboundMediaKind | "preview";
+
 export type LineOutboundMediaResolved = {
   mediaUrl: string;
   mediaKind: LineOutboundMediaKind;
@@ -27,12 +33,16 @@ const LINE_OUTBOUND_MEDIA_SSRF_POLICY: SsrFPolicy = {
   allowPrivateNetwork: false,
 };
 
-// Verified against developers.line.biz/en/reference/messaging-api/ on 2026-05-19.
-// Image message: "Max file size: 10MB". Video / audio: "Max file size: 200 MB".
-export const LINE_OUTBOUND_MEDIA_MAX_BYTES: Record<LineOutboundMediaKind, number> = {
+// Verified against developers.line.biz/en/reference/messaging-api/ on 2026-05-20.
+// Image message originalContentUrl: "Max file size: 10MB".
+// Video / audio message originalContentUrl: "Max file size: 200 MB".
+// previewImageUrl (image / video messages): "Max file size: 1 MB" — strictly
+// smaller than the originalContentUrl cap, so it has to be checked separately.
+export const LINE_OUTBOUND_MEDIA_MAX_BYTES: Record<LineOutboundMediaSizeKind, number> = {
   image: 10 * 1024 * 1024,
   video: 200 * 1024 * 1024,
   audio: 200 * 1024 * 1024,
+  preview: 1 * 1024 * 1024,
 };
 
 const LINE_OUTBOUND_MEDIA_PRECHECK_TIMEOUT_MS = 5000;
@@ -54,7 +64,7 @@ function redactLineOutboundMediaUrl(url: string): string {
 
 export async function precheckLineOutboundMediaSize(
   url: string,
-  kind: LineOutboundMediaKind,
+  kind: LineOutboundMediaSizeKind,
   opts: PrecheckLineOutboundMediaSizeOpts = {},
 ): Promise<void> {
   const cap = LINE_OUTBOUND_MEDIA_MAX_BYTES[kind];
@@ -186,9 +196,15 @@ export async function resolveLineOutboundMedia(
       (opts.trackingId?.trim() ? "video" : undefined) ??
       detectLineMediaKindFromUrl(trimmedUrl) ??
       "image";
-    await precheckLineOutboundMediaSize(trimmedUrl, mediaKind);
-    if (previewImageUrl && previewImageUrl !== trimmedUrl) {
-      await precheckLineOutboundMediaSize(previewImageUrl, "image");
+    if (previewImageUrl && previewImageUrl === trimmedUrl) {
+      // Same URL serves as both originalContentUrl and previewImageUrl;
+      // dedupe to one HEAD probe but evaluate against the stricter preview cap.
+      await precheckLineOutboundMediaSize(trimmedUrl, "preview");
+    } else {
+      await precheckLineOutboundMediaSize(trimmedUrl, mediaKind);
+      if (previewImageUrl) {
+        await precheckLineOutboundMediaSize(previewImageUrl, "preview");
+      }
     }
     return {
       mediaUrl: trimmedUrl,

--- a/extensions/line/src/send.test.ts
+++ b/extensions/line/src/send.test.ts
@@ -12,6 +12,7 @@ const {
   recordChannelActivityMock,
   logVerboseMock,
   resolvePinnedHostnameWithPolicyMock,
+  fetchWithSsrFGuardMock,
 } = vi.hoisted(() => {
   const pushMessageMock = vi.fn();
   const replyMessageMock = vi.fn();
@@ -31,6 +32,7 @@ const {
   const recordChannelActivityMock = vi.fn();
   const logVerboseMock = vi.fn();
   const resolvePinnedHostnameWithPolicyMock = vi.fn();
+  const fetchWithSsrFGuardMock = vi.fn();
   return {
     pushMessageMock,
     replyMessageMock,
@@ -43,6 +45,7 @@ const {
     recordChannelActivityMock,
     logVerboseMock,
     resolvePinnedHostnameWithPolicyMock,
+    fetchWithSsrFGuardMock,
   };
 });
 
@@ -78,6 +81,7 @@ vi.mock("openclaw/plugin-sdk/runtime-env", async () => {
 
 vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
   resolvePinnedHostnameWithPolicy: resolvePinnedHostnameWithPolicyMock,
+  fetchWithSsrFGuard: fetchWithSsrFGuardMock,
 }));
 
 let sendModule: typeof import("./send.js");
@@ -123,6 +127,15 @@ describe("LINE send helpers", () => {
     recordChannelActivityMock.mockReset();
     logVerboseMock.mockReset();
     resolvePinnedHostnameWithPolicyMock.mockReset();
+    fetchWithSsrFGuardMock.mockReset();
+    fetchWithSsrFGuardMock.mockImplementation(async () => ({
+      response: new Response(null, {
+        status: 200,
+        headers: new Headers({ "content-length": "1024" }),
+      }),
+      finalUrl: "https://example.com/asset",
+      release: async () => undefined,
+    }));
 
     MessagingApiClientMock.mockImplementation(function () {
       return {
@@ -449,5 +462,51 @@ describe("LINE send helpers", () => {
       { messages: Array<{ quickReply?: { items: unknown[] } }> },
     ];
     expect(firstCall[0].messages[0].quickReply?.items).toHaveLength(13);
+  });
+
+  it("pushImageMessage does not double-probe when previewImageUrl equals the originalContentUrl", async () => {
+    fetchWithSsrFGuardMock.mockReset();
+    fetchWithSsrFGuardMock.mockImplementation(async () => ({
+      response: new Response(null, {
+        status: 200,
+        headers: new Headers({ "content-length": "2048" }),
+      }),
+      finalUrl: "https://example.com/shared.jpg",
+      release: async () => undefined,
+    }));
+
+    await sendModule.pushImageMessage(
+      "line:user:U200",
+      "https://example.com/shared.jpg",
+      "https://example.com/shared.jpg",
+      { cfg: LINE_TEST_CFG },
+    );
+
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(1);
+    expect(pushMessageMock).toHaveBeenCalledTimes(1);
+  });
+
+  // T12 — sendMessageLine: oversize image URL must reject before client.pushMessage runs.
+  it("does not call LINE pushMessage when an outbound image exceeds the LINE size cap", async () => {
+    fetchWithSsrFGuardMock.mockReset();
+    fetchWithSsrFGuardMock.mockImplementation(async () => ({
+      response: new Response(null, {
+        status: 200,
+        headers: new Headers({ "content-length": String(11 * 1024 * 1024) }),
+      }),
+      finalUrl: "https://example.com/over-cap.png",
+      release: async () => undefined,
+    }));
+
+    await expect(
+      sendModule.sendMessageLine("line:user:U999", "", {
+        cfg: LINE_TEST_CFG,
+        mediaUrl: "https://example.com/over-cap.png",
+        mediaKind: "image",
+      }),
+    ).rejects.toThrow(/LINE image media must be ≤10485760 bytes/);
+
+    expect(pushMessageMock).not.toHaveBeenCalled();
+    expect(replyMessageMock).not.toHaveBeenCalled();
   });
 });

--- a/extensions/line/src/send.test.ts
+++ b/extensions/line/src/send.test.ts
@@ -487,6 +487,9 @@ describe("LINE send helpers", () => {
   });
 
   // T12 — sendMessageLine: oversize image URL must reject before client.pushMessage runs.
+  // Note: with no explicit previewImageUrl, the image branch falls back to
+  // previewImageUrl = mediaUrl. The preview cap (1 MiB) then binds first
+  // because it is strictly stricter than the image cap (10 MiB).
   it("does not call LINE pushMessage when an outbound image exceeds the LINE size cap", async () => {
     fetchWithSsrFGuardMock.mockReset();
     fetchWithSsrFGuardMock.mockImplementation(async () => ({
@@ -504,9 +507,82 @@ describe("LINE send helpers", () => {
         mediaUrl: "https://example.com/over-cap.png",
         mediaKind: "image",
       }),
-    ).rejects.toThrow(/LINE image media must be ≤10485760 bytes/);
+    ).rejects.toThrow(/LINE (image|preview) media must be ≤(10485760|1048576) bytes/);
 
     expect(pushMessageMock).not.toHaveBeenCalled();
     expect(replyMessageMock).not.toHaveBeenCalled();
+  });
+
+  // Preview-cap regression — sendMessageLine image branch must reject when
+  // an explicit previewImageUrl exceeds the LINE 1 MiB preview cap (even if
+  // it is well under the 10 MiB cap that applies to originalContentUrl).
+  it("rejects when previewImageUrl exceeds the LINE 1 MiB preview cap and never calls pushMessage", async () => {
+    const between = 5 * 1024 * 1024;
+    fetchWithSsrFGuardMock.mockReset();
+    fetchWithSsrFGuardMock
+      .mockResolvedValueOnce({
+        response: new Response(null, {
+          status: 200,
+          headers: new Headers({ "content-length": String(1024) }),
+        }),
+        finalUrl: "https://example.com/under-cap.jpg",
+        release: async () => undefined,
+      })
+      .mockResolvedValueOnce({
+        response: new Response(null, {
+          status: 200,
+          headers: new Headers({ "content-length": String(between) }),
+        }),
+        finalUrl: "https://example.com/big-preview.png",
+        release: async () => undefined,
+      });
+
+    await expect(
+      sendModule.sendMessageLine("line:user:U777", "", {
+        cfg: LINE_TEST_CFG,
+        mediaUrl: "https://example.com/under-cap.jpg",
+        mediaKind: "image",
+        previewImageUrl: "https://example.com/big-preview.png",
+      }),
+    ).rejects.toThrow(/LINE preview media must be ≤1048576 bytes \(got 5242880 bytes/);
+
+    expect(pushMessageMock).not.toHaveBeenCalled();
+    expect(replyMessageMock).not.toHaveBeenCalled();
+  });
+
+  // Preview-cap regression — pushImageMessage must reject when an explicit
+  // preview URL exceeds the LINE 1 MiB preview cap, and pushMessage must not
+  // be reached even though the original content URL passes the 10 MiB cap.
+  it("pushImageMessage rejects when the preview URL exceeds the LINE 1 MiB preview cap", async () => {
+    const between = 3 * 1024 * 1024;
+    fetchWithSsrFGuardMock.mockReset();
+    fetchWithSsrFGuardMock
+      .mockResolvedValueOnce({
+        response: new Response(null, {
+          status: 200,
+          headers: new Headers({ "content-length": String(1024) }),
+        }),
+        finalUrl: "https://example.com/original.jpg",
+        release: async () => undefined,
+      })
+      .mockResolvedValueOnce({
+        response: new Response(null, {
+          status: 200,
+          headers: new Headers({ "content-length": String(between) }),
+        }),
+        finalUrl: "https://example.com/big-preview.png",
+        release: async () => undefined,
+      });
+
+    await expect(
+      sendModule.pushImageMessage(
+        "line:user:U777",
+        "https://example.com/original.jpg",
+        "https://example.com/big-preview.png",
+        { cfg: LINE_TEST_CFG },
+      ),
+    ).rejects.toThrow(/LINE preview media must be ≤1048576 bytes \(got 3145728 bytes/);
+
+    expect(pushMessageMock).not.toHaveBeenCalled();
   });
 });

--- a/extensions/line/src/send.test.ts
+++ b/extensions/line/src/send.test.ts
@@ -550,6 +550,36 @@ describe("LINE send helpers", () => {
     expect(replyMessageMock).not.toHaveBeenCalled();
   });
 
+  // Regression: pushImageMessage with no explicit previewImageUrl.
+  // createImageMessage defaults previewImageUrl to originalContentUrl, so a
+  // 3 MiB original URL passes the 10 MiB image cap but later fails on
+  // LINE's 1 MiB preview cap. pushImageMessage must apply the preview cap
+  // locally on the shared URL, with a single HEAD probe (dedupe preserved).
+  it("pushImageMessage rejects when originalContentUrl with no explicit preview exceeds the preview cap", async () => {
+    const between = 3 * 1024 * 1024; // under image cap, over preview cap
+    fetchWithSsrFGuardMock.mockReset();
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response(null, {
+        status: 200,
+        headers: new Headers({ "content-length": String(between) }),
+      }),
+      finalUrl: "https://example.com/implicit-preview.jpg",
+      release: async () => undefined,
+    });
+
+    await expect(
+      sendModule.pushImageMessage(
+        "line:user:U777",
+        "https://example.com/implicit-preview.jpg",
+        undefined,
+        { cfg: LINE_TEST_CFG },
+      ),
+    ).rejects.toThrow(/LINE preview media must be ≤1048576 bytes \(got 3145728 bytes/);
+
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(1);
+    expect(pushMessageMock).not.toHaveBeenCalled();
+  });
+
   // Preview-cap regression — pushImageMessage must reject when an explicit
   // preview URL exceeds the LINE 1 MiB preview cap, and pushMessage must not
   // be reached even though the original content URL passes the 10 MiB cap.

--- a/extensions/line/src/send.ts
+++ b/extensions/line/src/send.ts
@@ -5,7 +5,7 @@ import { requireRuntimeConfig } from "openclaw/plugin-sdk/plugin-config-runtime"
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { resolveLineAccount } from "./accounts.js";
 import { resolveLineChannelAccessToken } from "./channel-access-token.js";
-import { validateLineMediaUrl } from "./outbound-media.js";
+import { precheckLineOutboundMediaSize, validateLineMediaUrl } from "./outbound-media.js";
 import { createLineSendReceipt } from "./send-receipt.js";
 import type { LineSendResult } from "./types.js";
 
@@ -294,11 +294,14 @@ export async function sendMessageLine(
           throw new Error("LINE video messages require previewImageUrl to reference an image URL");
         }
         await validateLineMediaUrl(previewImageUrl);
+        await precheckLineOutboundMediaSize(mediaUrl, "video");
+        await precheckLineOutboundMediaSize(previewImageUrl, "image");
         const trackingId = isLineUserChatId(chatId) ? opts.trackingId : undefined;
         messages.push(createVideoMessage(mediaUrl, previewImageUrl, trackingId));
         break;
       }
       case "audio":
+        await precheckLineOutboundMediaSize(mediaUrl, "audio");
         messages.push(createAudioMessage(mediaUrl, opts.durationMs ?? 60000));
         break;
       case "image":
@@ -307,6 +310,10 @@ export async function sendMessageLine(
         {
           const previewImageUrl = opts.previewImageUrl?.trim() || mediaUrl;
           await validateLineMediaUrl(previewImageUrl);
+          await precheckLineOutboundMediaSize(mediaUrl, "image");
+          if (previewImageUrl !== mediaUrl) {
+            await precheckLineOutboundMediaSize(previewImageUrl, "image");
+          }
           messages.push(createImageMessage(mediaUrl, previewImageUrl));
         }
         break;
@@ -389,6 +396,10 @@ export async function pushImageMessage(
   await validateLineMediaUrl(originalContentUrl);
   if (previewImageUrl) {
     await validateLineMediaUrl(previewImageUrl);
+  }
+  await precheckLineOutboundMediaSize(originalContentUrl, "image");
+  if (previewImageUrl && previewImageUrl !== originalContentUrl) {
+    await precheckLineOutboundMediaSize(previewImageUrl, "image");
   }
   return pushLineMessages(to, [createImageMessage(originalContentUrl, previewImageUrl)], opts, {
     verboseMessage: (chatId) => `line: pushed image to ${chatId}`,

--- a/extensions/line/src/send.ts
+++ b/extensions/line/src/send.ts
@@ -294,8 +294,12 @@ export async function sendMessageLine(
           throw new Error("LINE video messages require previewImageUrl to reference an image URL");
         }
         await validateLineMediaUrl(previewImageUrl);
-        await precheckLineOutboundMediaSize(mediaUrl, "video");
-        await precheckLineOutboundMediaSize(previewImageUrl, "image");
+        if (previewImageUrl === mediaUrl) {
+          await precheckLineOutboundMediaSize(mediaUrl, "preview");
+        } else {
+          await precheckLineOutboundMediaSize(mediaUrl, "video");
+          await precheckLineOutboundMediaSize(previewImageUrl, "preview");
+        }
         const trackingId = isLineUserChatId(chatId) ? opts.trackingId : undefined;
         messages.push(createVideoMessage(mediaUrl, previewImageUrl, trackingId));
         break;
@@ -310,9 +314,11 @@ export async function sendMessageLine(
         {
           const previewImageUrl = opts.previewImageUrl?.trim() || mediaUrl;
           await validateLineMediaUrl(previewImageUrl);
-          await precheckLineOutboundMediaSize(mediaUrl, "image");
-          if (previewImageUrl !== mediaUrl) {
-            await precheckLineOutboundMediaSize(previewImageUrl, "image");
+          if (previewImageUrl === mediaUrl) {
+            await precheckLineOutboundMediaSize(mediaUrl, "preview");
+          } else {
+            await precheckLineOutboundMediaSize(mediaUrl, "image");
+            await precheckLineOutboundMediaSize(previewImageUrl, "preview");
           }
           messages.push(createImageMessage(mediaUrl, previewImageUrl));
         }
@@ -397,9 +403,13 @@ export async function pushImageMessage(
   if (previewImageUrl) {
     await validateLineMediaUrl(previewImageUrl);
   }
-  await precheckLineOutboundMediaSize(originalContentUrl, "image");
-  if (previewImageUrl && previewImageUrl !== originalContentUrl) {
-    await precheckLineOutboundMediaSize(previewImageUrl, "image");
+  if (previewImageUrl && previewImageUrl === originalContentUrl) {
+    await precheckLineOutboundMediaSize(originalContentUrl, "preview");
+  } else {
+    await precheckLineOutboundMediaSize(originalContentUrl, "image");
+    if (previewImageUrl) {
+      await precheckLineOutboundMediaSize(previewImageUrl, "preview");
+    }
   }
   return pushLineMessages(to, [createImageMessage(originalContentUrl, previewImageUrl)], opts, {
     verboseMessage: (chatId) => `line: pushed image to ${chatId}`,

--- a/extensions/line/src/send.ts
+++ b/extensions/line/src/send.ts
@@ -403,13 +403,15 @@ export async function pushImageMessage(
   if (previewImageUrl) {
     await validateLineMediaUrl(previewImageUrl);
   }
-  if (previewImageUrl && previewImageUrl === originalContentUrl) {
+  if (!previewImageUrl || previewImageUrl === originalContentUrl) {
+    // createImageMessage defaults previewImageUrl to originalContentUrl
+    // when no explicit preview is supplied (and an explicit same-URL
+    // preview is handled identically). The shared URL must therefore
+    // satisfy the stricter preview cap.
     await precheckLineOutboundMediaSize(originalContentUrl, "preview");
   } else {
     await precheckLineOutboundMediaSize(originalContentUrl, "image");
-    if (previewImageUrl) {
-      await precheckLineOutboundMediaSize(previewImageUrl, "preview");
-    }
+    await precheckLineOutboundMediaSize(previewImageUrl, "preview");
   }
   return pushLineMessages(to, [createImageMessage(originalContentUrl, previewImageUrl)], opts, {
     verboseMessage: (chatId) => `line: pushed image to ${chatId}`,


### PR DESCRIPTION
## Summary
Outbound LINE media (image / video / audio / preview) currently returns
success from `pushMessage` / `replyMessage` even when the URL body is
larger than the LINE platform cap; LINE rejects the URL asynchronously
after our call returns, so the caller sees no failure but the recipient
never receives the message.

This PR adds a local size precheck on every outbound LINE media call
site. Hosts that don't expose `Content-Length` continue to work
unchanged (soft-fail, pass through).

## Behavior change
- Add `LINE_OUTBOUND_MEDIA_MAX_BYTES` per role (caps documented at the
  [LINE Messaging API reference](https://developers.line.biz/en/reference/messaging-api/#image-message),
  verified 2026-05-20) and `precheckLineOutboundMediaSize` in
  `extensions/line/src/outbound-media.ts`. The helper issues a HEAD via
  the existing `fetchWithSsrFGuard` (5 s, `requireHttps`, `mode:
  "strict"`, `LINE_OUTBOUND_MEDIA_SSRF_POLICY` —
  `allowPrivateNetwork: false`).
- Hard-fail only on HTTP `200` or `206` with `Content-Length > cap`.
  All other statuses (`2xx` without a usable body length, `3xx`, `4xx`,
  `5xx`, network error) take the soft-fail branch and pass through;
  the size contract is only enforceable when the host advertises a
  concrete `Content-Length` alongside a `200/206` response.
- Wire the precheck next to every existing `validateLineMediaUrl` site:
  `resolveLineOutboundMedia`, the video / audio / image branches of
  `sendMessageLine`, and `pushImageMessage`. `previewImageUrl` is
  always checked against the stricter 1 MiB preview cap.
- Implicit-preview image path: in the image branch, both
  `resolveLineOutboundMedia` and `pushImageMessage` default
  `previewImageUrl` to `originalContentUrl`. An image between 1 MiB and
  10 MiB therefore passed the local image cap but was rejected later by
  LINE's preview cap. After this PR the implicit case binds against
  the preview cap first.
- Dedupe: when `previewImageUrl === mediaUrl` (explicit or via the
  implicit fallback), the helper issues a single HEAD probe and
  evaluates it against the stricter preview cap.

## Files
LINE-channel-local; no shared SDK, core, or cross-channel surface is
touched.

```
extensions/line/src/outbound-media.ts       (+114 / -2)   production
extensions/line/src/send.ts                 (+25  / -2)   production
extensions/line/src/outbound-media.test.ts  (+308)        unit tests
extensions/line/src/send.test.ts            (+165)        unit tests
```

Production change is approximately **+139 LOC**; the remaining
**+471 LOC is unit tests** covering cap math (per role, inclusive
boundary), soft-fail branches (probe error, non-2xx, missing /
malformed / negative `Content-Length`), equal-URL dedupe, and the
implicit-preview fallback in both `resolveLineOutboundMedia` and
`pushImageMessage`. The overall diff size therefore reflects test
coverage rather than production surface area, and the production
change is confined to `extensions/line/src/**`.

## Non-Scope
- No changes to `src/media/**` or `src/plugin-sdk/**`. Independent of
  #76566 (MIME helpers — no file overlap).
- No new account-level config knob.
- Format / dimensions / duration validation. Only size is gated.
- The adapter (`extensions/line/src/outbound.ts`, untouched) chains
  `resolveLineOutboundMedia` → `sendMessageLine`. Both layers precheck,
  so the kind-aware adapter path issues two HEAD probes per media URL.
  This matches the existing topology used by `validateLineMediaUrl`
  (same call sites, same duplication), and collapsing it requires
  touching `outbound.ts` which is out of scope for this size-cap PR.
- Quick-reply inline media: the generic quick-reply inline image
  branch in `extensions/line/src/outbound.ts` (the path that pushes an
  image object directly when no LINE-specific media options are
  present) is **intentionally not covered** by this precheck. Scope
  here is restricted to outbound image / video / audio / preview URL
  precheck reachable through `sendMessageLine`, `pushImageMessage`,
  and `resolveLineOutboundMedia`. A follow-up PR can extend the
  precheck to the quick-reply inline branch if maintainers want full
  outbound coverage.

## Verification

| Gate | Result |
|---|---|
| `vitest extensions/line/src/outbound-media.test.ts` | 39 / 39 passed |
| `vitest extensions/line/src/send.test.ts` | 19 / 19 passed |
| `node scripts/test-projects.mjs --changed upstream/main` | exit 0 (typecheck, oxlint, runtime import cycles, all guards) |

## Real behavior proof

Behavior addressed: outbound LINE media (image / video / audio /
preview) URLs whose body exceeds the LINE platform cap previously
returned success from `pushMessage` / `replyMessage` while LINE
rejected the URL asynchronously, so the recipient never received the
message. The new precheck makes this fail locally with a descriptive
error before the LINE API call is issued.

Real environment tested: live LINE Messaging API channel against a
1:1 chat target, using `extensions/line/src/runtime-api.ts` exported
helpers from the rebuilt worktree (`dist/extensions/line/runtime-api.js`).
Media fixtures were hosted on a short-lived Cloudflare quick-tunnel,
which was torn down after the proof window. The fixture host only
served three deterministic byte-length files (small valid, mid
between 1 MiB and 10 MiB, and over 10 MiB).

Exact steps or command run after this patch:
1. Build the worktree (`pnpm build`).
2. Start the fixture host: `python3 -m http.server 18890 --bind 127.0.0.1`.
3. Open the public URL via `cloudflared tunnel --url http://127.0.0.1:18890`.
4. Source `runtime/secrets/.env` to populate `LINE_CHANNEL_ACCESS_TOKEN` / `LINE_CHANNEL_SECRET`.
5. Run a driver that imports `dist/extensions/line/runtime-api.js` and calls `sendMessageLine` / `pushImageMessage` with each of cases A / B / C / D below.

Evidence after fix: cases B, C, D fail locally with the redacted
runtime log output captured below (terminal output from
`node driver.mjs` against the rebuilt worktree's
`dist/extensions/line/runtime-api.js`); `client.pushMessage` is not
invoked in those cases. Case A succeeds end-to-end with the LINE app
receiving the message. The fixture-host access log tail confirms
exactly 1 HEAD per distinct URL, and 0 HEADs on the rejected payload
for soft-fail.

```
$ node driver.mjs B
Error: LINE image media must be ≤10485760 bytes (got 14545753 bytes from <FIXTURE_HOST>/image-overcap.png)

$ node driver.mjs C
Error: LINE preview media must be ≤1048576 bytes (got 1489176 bytes from <FIXTURE_HOST>/mid-preview-overcap.jpg)

$ node driver.mjs D
Error: LINE preview media must be ≤1048576 bytes (got 1489176 bytes from <FIXTURE_HOST>/mid-preview-overcap.jpg)
```

Observed result after fix:
- Case A — `sendMessageLine` image, `previewImageUrl === mediaUrl`, file = 3 116 B → LINE app received the message. Origin log: 1 HEAD (equal-URL dedupe) followed by LINE-side GET.
- Case B — `sendMessageLine` image, `originalContentUrl` 14 545 753 B (> 10 MiB) + valid small preview → local image-cap error; `client.pushMessage` not called. Origin log: 1 HEAD on the over-cap original, no preview HEAD, no LINE-side GET.
- Case C — `sendMessageLine` image, valid small `originalContentUrl` + `previewImageUrl` 1 489 176 B (between 1 MiB and 10 MiB) → local preview-cap error; `client.pushMessage` not called.
- Case D — `sendMessageLine` image, `previewImageUrl === mediaUrl`, shared file 1 489 176 B → local preview-cap error; exactly 1 HEAD for the shared URL (dedupe preserved, stricter cap applied).

What was not tested:
- Live > 200 MB video send (same code path as image; the cap math is locked by `outbound-media.test.ts` with a synthetic `Content-Length: 209715201` HEAD response).
- Live `extensions/line/src/outbound.ts` adapter path; the precheck behavior is identical to the direct `sendMessageLine` path proven above.
- Group / room targets live; the precheck is target-agnostic.
- Live re-capture against the implicit-preview commit; that commit only widens the existing preview-cap call site to the implicit fallback path and is covered by new unit asserts in both `outbound-media.test.ts` and `send.test.ts`.
- `pushImageMessage` (`previewImageUrl === originalContentUrl` shared-file case) live capture is not included in the redacted fenced block above; its preview-cap rejection is covered by unit test `send.test.ts` `pushImageMessage preview-cap rejection`, which asserts the same shape as the live `sendMessageLine` Case D above.
- Quick-reply inline media path (see Non-Scope); this PR does not exercise that branch in either unit or live testing.

<details>
<summary>Appendix: caps, test additions</summary>

Cap values (verified at the LINE Messaging API reference linked above
on 2026-05-20):

| Role | Cap (bytes) |
|---|---|
| image `originalContentUrl` | 10 485 760 (10 MiB) |
| video `originalContentUrl` | 209 715 200 (200 MiB) |
| audio `originalContentUrl` | 209 715 200 (200 MiB) |
| `previewImageUrl` (image / video) | 1 048 576 (1 MiB) |

Test additions:

- Preview-cap commit: 4 asserts in `outbound-media.test.ts` (explicit-preview rejection in `resolveLineOutboundMedia`, equal-URL shared-file rejection, `kind=preview` unit-level rejection, `kind=preview` inclusive boundary); 2 asserts in `send.test.ts` (`sendMessageLine` image branch preview-cap rejection, `pushImageMessage` preview-cap rejection).
- Implicit-preview commit: 1 assert in `outbound-media.test.ts` (implicit `previewImageUrl = mediaUrl` fallback in `resolveLineOutboundMedia`); 1 assert in `send.test.ts` (`pushImageMessage` implicit fallback).

Secrets and the recipient `userId` were redacted in any captured
artifact via driver-side substitution; no credentials are committed.

</details>
