### PR TITLE
fix(models): redact plaintext provider api keys

### DIFF
--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import { isRecord } from "../utils.js";
+import { isNonSecretApiKeyMarker, NON_ENV_SECRETREF_MARKER } from "./model-auth-markers.js";
 import {
   mergeProviders,
   mergeWithExistingProviderSecrets,
@@ -105,6 +106,59 @@ function resolveProvidersForMode(params: {
   });
 }
 
+function shouldRedactProviderApiKeyValue(apiKey: unknown): boolean {
+  if (typeof apiKey === "string") {
+    const trimmedApiKey = apiKey.trim();
+    return Boolean(trimmedApiKey) && !isNonSecretApiKeyMarker(trimmedApiKey);
+  }
+  return apiKey !== undefined && apiKey !== null;
+}
+
+function collectPlaintextProviderApiKeyProviderKeys(
+  providers: Record<string, ProviderConfig>,
+): ReadonlySet<string> {
+  const providerKeys = new Set<string>();
+  for (const [providerKey, provider] of Object.entries(providers)) {
+    if (!isRecord(provider) || !("apiKey" in provider)) {
+      continue;
+    }
+    if (shouldRedactProviderApiKeyValue(provider.apiKey)) {
+      providerKeys.add(providerKey);
+    }
+  }
+  return providerKeys;
+}
+
+function redactPlaintextProviderApiKeysForModelsJson(params: {
+  providers: Record<string, ProviderConfig>;
+  redactableProviderKeys: ReadonlySet<string>;
+}): Record<string, ProviderConfig> {
+  const { providers, redactableProviderKeys } = params;
+  let nextProviders: Record<string, ProviderConfig> | null = null;
+
+  for (const [providerKey, provider] of Object.entries(providers)) {
+    if (
+      !redactableProviderKeys.has(providerKey) ||
+      !isRecord(provider) ||
+      !("apiKey" in provider)
+    ) {
+      continue;
+    }
+
+    if (!shouldRedactProviderApiKeyValue(provider.apiKey)) {
+      continue;
+    }
+
+    nextProviders ??= { ...providers };
+    nextProviders[providerKey] = {
+      ...provider,
+      apiKey: NON_ENV_SECRETREF_MARKER,
+    };
+  }
+
+  return nextProviders ?? providers;
+}
+
 export async function planOpenClawModelsJsonWithDeps(
   params: {
     cfg: OpenClawConfig;
@@ -162,6 +216,7 @@ export async function planOpenClawModelsJsonWithDeps(
       sourceSecretDefaults: params.sourceConfigForSecrets?.secrets?.defaults,
       secretRefManagedProviders,
     }) ?? providers;
+  const redactableProviderKeys = collectPlaintextProviderApiKeyProviderKeys(normalizedProviders);
   const mergedProviders = resolveProvidersForMode({
     mode,
     existingParsed: params.existingParsed,
@@ -177,7 +232,10 @@ export async function planOpenClawModelsJsonWithDeps(
       sourceSecretDefaults: params.sourceConfigForSecrets?.secrets?.defaults,
       secretRefManagedProviders,
     }) ?? normalizedMergedProviders;
-  const finalProviders = applyNativeStreamingUsageCompat(secretEnforcedProviders);
+  const finalProviders = redactPlaintextProviderApiKeysForModelsJson({
+    providers: applyNativeStreamingUsageCompat(secretEnforcedProviders),
+    redactableProviderKeys,
+  });
   const nextContents = `${JSON.stringify({ providers: finalProviders }, null, 2)}\n`;
 
   if (params.existingRaw === nextContents) {

--- a/src/agents/models-config.runtime-source-snapshot.test.ts
+++ b/src/agents/models-config.runtime-source-snapshot.test.ts
@@ -184,7 +184,8 @@ async function expectGeneratedProviderApiKey(
 
 async function planGeneratedProviders(params: {
   config: OpenClawConfig;
-  sourceConfigForSecrets: OpenClawConfig;
+  sourceConfigForSecrets?: OpenClawConfig;
+  existingParsed?: unknown;
 }) {
   const plan = await planOpenClawModelsJsonWithDeps(
     {
@@ -193,7 +194,7 @@ async function planGeneratedProviders(params: {
       agentDir: "/tmp/openclaw-models-plan",
       env: {},
       existingRaw: "",
-      existingParsed: null,
+      existingParsed: params.existingParsed ?? null,
     },
     {
       resolveImplicitProviders: async () => ({}),
@@ -219,6 +220,76 @@ function expectOpenAiHeaderMarkers(
 }
 
 describe("models-config runtime source snapshot", () => {
+  it("redacts plaintext provider apiKeys before writing models.json", async () => {
+    const providers = await planGeneratedProviders({
+      config: createOpenAiRuntimeConfigWithHeadersAndApiKey(),
+    });
+
+    expect(providers.openai?.apiKey).toBe(NON_ENV_SECRETREF_MARKER);
+    expect(JSON.stringify(providers)).not.toContain("sk-runtime-resolved");
+  });
+
+  it("preserves existing models.json-only apiKeys so merge mode does not remove the only credential", async () => {
+    const providers = await planGeneratedProviders({
+      config: {
+        models: {
+          mode: "merge",
+          providers: {
+            custom: {
+              baseUrl: "https://config.example/v1",
+              api: "openai-completions",
+              models: [],
+            },
+          },
+        },
+      },
+      existingParsed: {
+        providers: {
+          legacy: {
+            baseUrl: "https://agent.example/v1",
+            apiKey: "sk-stale-existing-key",
+            api: "openai-completions",
+            models: [],
+          },
+        },
+      },
+    });
+
+    expect(providers.legacy?.apiKey).toBe("sk-stale-existing-key"); // pragma: allowlist secret
+  });
+
+  it("redacts plaintext apiKeys from the active config even when merge mode preserves an older key", async () => {
+    const providers = await planGeneratedProviders({
+      config: {
+        models: {
+          mode: "merge",
+          providers: {
+            custom: {
+              baseUrl: "https://config.example/v1",
+              apiKey: "sk-runtime-custom-key", // pragma: allowlist secret
+              api: "openai-completions",
+              models: [],
+            },
+          },
+        },
+      },
+      existingParsed: {
+        providers: {
+          custom: {
+            baseUrl: "https://agent.example/v1",
+            apiKey: "sk-old-existing-key",
+            api: "openai-completions",
+            models: [],
+          },
+        },
+      },
+    });
+
+    expect(providers.custom?.apiKey).toBe(NON_ENV_SECRETREF_MARKER);
+    expect(JSON.stringify(providers)).not.toContain("sk-old-existing-key");
+    expect(JSON.stringify(providers)).not.toContain("sk-runtime-custom-key");
+  });
+
   it("uses runtime source snapshot markers when passed the active runtime config", () => {
     const sourceConfig: OpenClawConfig = {
       models: {


### PR DESCRIPTION
Fixes #11829

## Summary
- Redacts plaintext provider `apiKey` values before serializing generated `models.json` when the key comes from the active runtime/config provider entry.
- Keeps recognized non-secret markers such as `OPENAI_API_KEY` and `secretref-managed` unchanged.
- Preserves existing `models.json`-only provider keys in merge mode so regeneration does not remove the only configured credential before a migration path exists.
- Adds regression coverage for runtime-config secrets, existing-only fallback credentials, and merge mode with an older key.

## Compatibility note
This intentionally stops writing active runtime/config plaintext provider keys into prompt-visible `models.json`, while avoiding the compatibility break where a user had no auth source except an existing agent `models.json` key. A future migration can move those existing-only credentials into auth profiles or another supported secret sink before redaction.

## Real behavior proof
**Behavior or issue addressed:** Active runtime/config provider `apiKey` values should not be persisted into generated `models.json`, but existing `models.json`-only credentials should remain available as the documented auth fallback until a migration exists.

**Real environment tested:** Local OpenClaw checkout on macOS, Node 25.8.0, using the real `ensureOpenClawModelsJson` write path against temporary agent directories.

**Exact steps or command run after this patch:** Ran a local Node/tsx script that called `ensureOpenClawModelsJson` twice: once with a runtime/config plaintext provider key, and once with a pre-existing agent `models.json` key plus no replacement key in config.

**Evidence after fix:** Terminal output from the local OpenClaw write path:

```text
Real behavior proof from local OpenClaw models.json generation
runtime plaintext apiKey serialized as: secretref-managed
runtime plaintext value present in models.json: false
models.json-only apiKey preserved for auth fallback: true
existing-only plaintext value still tied only to existing models.json: true
```

**Observed result after fix:** The generated `models.json` replaced the active runtime/config plaintext key with `secretref-managed` and did not contain the runtime plaintext value. The existing-only key stayed in `models.json`, preserving the auth fallback instead of replacing the only credential source.

**What was not tested:** Live provider network authentication with a real external API key was not exercised; the proof covers the local models.json generation and merge behavior that this patch changes.

## Validation
- `node scripts/test-projects.mjs src/agents/models-config.runtime-source-snapshot.test.ts src/agents/models-config.providers.normalize-keys.test.ts src/agents/models-config.merge.test.ts src/agents/model-auth-markers.test.ts`
- `pnpm tsgo:core`
- `pnpm tsgo:core:test`
- `git diff --check`
