### PR TITLE
docs(channels): document ackReactionScope for Slack & Telegram (DM gotcha)

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -1043,19 +1043,51 @@ When a `message` tool call runs inside a Slack thread and targets the same chann
 
 ## Ack reactions
 
-`ackReaction` sends an acknowledgement emoji while OpenClaw is processing an inbound message.
+`ackReaction` sends an acknowledgement emoji while OpenClaw is processing an inbound message. `ackReactionScope` decides _when_ that emoji is actually sent.
+
+### Emoji (`ackReaction`)
 
 Resolution order:
 
 - `channels.slack.accounts.<accountId>.ackReaction`
 - `channels.slack.ackReaction`
 - `messages.ackReaction`
-- agent identity emoji fallback (`agents.list[].identity.emoji`, else "👀")
+- agent identity emoji fallback (`agents.list[].identity.emoji`, else `"eyes"` / 👀)
 
 Notes:
 
 - Slack expects shortcodes (for example `"eyes"`).
 - Use `""` to disable the reaction for the Slack account or globally.
+
+### Scope (`ackReactionScope`)
+
+Resolution order:
+
+- `channels.slack.accounts.<accountId>.ackReactionScope`
+- `channels.slack.ackReactionScope`
+- `messages.ackReactionScope`
+- default: `"group-mentions"`
+
+Values:
+
+- `"all"`: react in DMs and groups.
+- `"direct"`: react in DMs only.
+- `"group-all"`: react on every group message (no DMs).
+- `"group-mentions"` (default): react in groups, but only when the bot is mentioned (or in group mentionables that opted in). **DMs are excluded.**
+- `"off"` / `"none"`: never react.
+
+<Note>
+The default scope (`"group-mentions"`) does not fire ack reactions in direct messages. If you want to see the configured `ackReaction` (for example `"eyes"`) on inbound Slack DMs, set scope to `"direct"` or `"all"` at the Slack channel level, account level, or under `messages.ackReactionScope`. `messages.ackReactionScope` is read at Slack provider startup, so a gateway restart is needed for the change to take effect.
+</Note>
+
+```json5
+{
+  messages: {
+    ackReaction: "eyes",
+    ackReactionScope: "all", // react in DMs and groups
+  },
+}
+```
 
 ## Text streaming
 

--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -1059,14 +1059,9 @@ Notes:
 - Slack expects shortcodes (for example `"eyes"`).
 - Use `""` to disable the reaction for the Slack account or globally.
 
-### Scope (`ackReactionScope`)
+### Scope (`messages.ackReactionScope`)
 
-Resolution order:
-
-- `channels.slack.accounts.<accountId>.ackReactionScope`
-- `channels.slack.ackReactionScope`
-- `messages.ackReactionScope`
-- default: `"group-mentions"`
+The Slack provider reads scope from `messages.ackReactionScope` (default `"group-mentions"`). There is no Slack-account or Slack-channel-level override today; the value is global to the gateway.
 
 Values:
 
@@ -1077,7 +1072,7 @@ Values:
 - `"off"` / `"none"`: never react.
 
 <Note>
-The default scope (`"group-mentions"`) does not fire ack reactions in direct messages. If you want to see the configured `ackReaction` (for example `"eyes"`) on inbound Slack DMs, set scope to `"direct"` or `"all"` at the Slack channel level, account level, or under `messages.ackReactionScope`. `messages.ackReactionScope` is read at Slack provider startup, so a gateway restart is needed for the change to take effect.
+The default scope (`"group-mentions"`) does not fire ack reactions in direct messages. To see the configured `ackReaction` (for example `"eyes"`) on inbound Slack DMs, set `messages.ackReactionScope` to `"direct"` or `"all"`. `messages.ackReactionScope` is read at Slack provider startup, so a gateway restart is needed for the change to take effect.
 </Note>
 
 ```json5

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -806,17 +806,14 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
     - Telegram expects unicode emoji (for example "👀").
     - Use `""` to disable the reaction for a channel or account.
 
-    **Scope (`ackReactionScope`) resolution order:**
+    **Scope (`messages.ackReactionScope`):**
 
-    - `channels.telegram.accounts.<accountId>.ackReactionScope`
-    - `channels.telegram.ackReactionScope`
-    - `messages.ackReactionScope`
-    - default: `"group-mentions"`
+    The Telegram provider reads scope from `messages.ackReactionScope` (default `"group-mentions"`). There is no Telegram-account or Telegram-channel-level override today.
 
     Values: `"all"` (DMs + groups), `"direct"` (DMs only), `"group-all"` (every group message, no DMs), `"group-mentions"` (groups when the bot is mentioned; **no DMs** — this is the default), `"off"` / `"none"` (disabled).
 
     <Note>
-    The default scope (`"group-mentions"`) does not fire ack reactions in direct messages. To get an ack reaction on inbound Telegram DMs, set the scope to `"direct"` or `"all"`. `messages.ackReactionScope` is read at provider startup, so a gateway restart is needed for the change to take effect.
+    The default scope (`"group-mentions"`) does not fire ack reactions in direct messages. To get an ack reaction on inbound Telegram DMs, set `messages.ackReactionScope` to `"direct"` or `"all"`. The value is read at Telegram provider startup, so a gateway restart is needed for the change to take effect.
     </Note>
 
   </Accordion>

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -792,9 +792,9 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
   </Accordion>
 
   <Accordion title="Ack reactions">
-    `ackReaction` sends an acknowledgement emoji while OpenClaw is processing an inbound message.
+    `ackReaction` sends an acknowledgement emoji while OpenClaw is processing an inbound message. `ackReactionScope` decides *when* that emoji is actually sent.
 
-    Resolution order:
+    **Emoji (`ackReaction`) resolution order:**
 
     - `channels.telegram.accounts.<accountId>.ackReaction`
     - `channels.telegram.ackReaction`
@@ -805,6 +805,19 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
 
     - Telegram expects unicode emoji (for example "👀").
     - Use `""` to disable the reaction for a channel or account.
+
+    **Scope (`ackReactionScope`) resolution order:**
+
+    - `channels.telegram.accounts.<accountId>.ackReactionScope`
+    - `channels.telegram.ackReactionScope`
+    - `messages.ackReactionScope`
+    - default: `"group-mentions"`
+
+    Values: `"all"` (DMs + groups), `"direct"` (DMs only), `"group-all"` (every group message, no DMs), `"group-mentions"` (groups when the bot is mentioned; **no DMs** — this is the default), `"off"` / `"none"` (disabled).
+
+    <Note>
+    The default scope (`"group-mentions"`) does not fire ack reactions in direct messages. To get an ack reaction on inbound Telegram DMs, set the scope to `"direct"` or `"all"`. `messages.ackReactionScope` is read at provider startup, so a gateway restart is needed for the change to take effect.
+    </Note>
 
   </Accordion>
 


### PR DESCRIPTION
## Summary

The Slack and Telegram channel docs cover `ackReaction` (which emoji to send) but don't mention `ackReactionScope` (when to actually send it). Because the default scope is `group-mentions`, setting `ackReaction: "eyes"` on a Slack DM-only deployment looks broken: the bot has the `reactions:write` scope, the config validates, but no reaction ever fires. The actual reason — the scope gate explicitly excludes DMs — only shows up in `src/channels/ack-reactions.ts` and `docs/channels/matrix.md`.

This PR adds that gotcha to the Slack and Telegram channel docs.

## Changes

- **`docs/channels/slack.md`**
  - Split *Ack reactions* into "Emoji (`ackReaction`)" and "Scope (`messages.ackReactionScope`)".
  - Document the full scope enum (`all`, `direct`, `group-all`, `group-mentions`, `off`/`none`).
  - Add a `<Note>` callout flagging that the default does **not** fire in DMs, and that `messages.ackReactionScope` is read at Slack provider startup (gateway restart required).
  - Add a short JSON example using `ackReactionScope: "all"`.
- **`docs/channels/telegram.md`** — same structure inside the existing `<Accordion>`.

Slack and Telegram runtime today reads scope from `messages.ackReactionScope` only (no per-account/per-channel override) — confirmed against `extensions/slack/src/monitor/provider.ts:243` and `extensions/telegram/src/bot-core.ts:262`. The second commit on this PR removed an earlier draft that incorrectly documented per-account override resolution, per reviewer feedback. No behavior changes; docs only.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: A user with `channels.slack.ackReaction: "eyes"` and the `reactions:write` Slack scope sees no reaction on inbound Slack DMs, because `messages.ackReactionScope` defaults to `"group-mentions"` which excludes DMs. The Slack channel docs do not currently mention `ackReactionScope` at all, so users who hit this have no docs path to follow.
- Real environment tested: Live OpenClaw 2026.5.18 gateway, systemd user service `openclaw-gateway` on Linux 6.17 (aws), single Slack workspace, single bot user `drclaw` (`U0AJ2M4UKV5`) with `reactions:write` confirmed via `curl https://slack.com/api/auth.test` response headers (`x-oauth-scopes`). Inbound channel: Slack DM `D0AJBNX1P0B` from a human user.
- Exact steps or command run after this patch:
  1. Confirmed default behavior: with `messages.ackReactionScope` unset (defaulting to `"group-mentions"`) and `channels.slack.ackReaction: "eyes"`, sent multiple inbound DMs over ~40 messages. Zero `:eyes:` reactions appeared on any inbound DM.
  2. Patched config to follow the new docs' recommendation: set `messages.ackReactionScope` to `"all"`.
  3. Observed the gateway config reload via `journalctl --user -u openclaw-gateway` — terminal output below.
  4. Restarted the gateway with `openclaw gateway restart` (the docs' recommended step, since this value is captured at provider startup).
  5. Sent a fresh inbound DM, then queried `curl https://slack.com/api/conversations.history` for the DM channel to inspect reaction state on inbound messages — live output below.
- Evidence after fix (terminal capture, console output, redacted runtime log, copied live output):

Live `journalctl` output showing the config change being detected by the gateway:

```
2026-05-19T16:48:10.384+00:00 [reload] config change detected; evaluating reload (messages.ackReactionScope)
```

Live `curl https://slack.com/api/conversations.history` output, filtered to inbound DM messages from the human user, after the gateway restart (terminal capture):

```
1779211222.646139  Check on the status of that PR and see what the reviews have  :eyes:x1 :hammer_and_wrench:x1 :hourglass_flowing_sand:x1
1779211032.873419  I think that is a good idea, but it is your memory to use, s  :eyes:x1
```

The `:eyes:` reaction is present on both inbound DM messages. `:hammer_and_wrench:` and `:hourglass_flowing_sand:` are the bot's tool-progress and queued-work reactions; the relevant signal here is the `:eyes:` ack reaction now appearing on inbound DMs.

- Observed result after fix: The bot consistently adds `:eyes:` to inbound Slack DM messages after `messages.ackReactionScope` is set to `"all"` and the gateway is restarted. Before the change, with the default `"group-mentions"`, no `:eyes:` reaction appeared on any inbound DM over 40+ messages in the same conversation — the live `conversations.history` output for those messages had no `reactions` field at all. Same `openclaw` gateway, same Slack workspace, same bot, same emoji shortcode — the only delta was the scope value. This validates the DM-default warning and the gateway-restart note added to the docs.
- What was not tested: Telegram DMs were not exercised on a live Telegram deployment in this session; the Telegram docs change mirrors the Slack one based on inspection of `extensions/telegram/src/bot-core.ts:262` (`cfg.messages?.ackReactionScope ?? "group-mentions"`), which is functionally identical to the Slack path. The `"direct"`, `"group-all"`, and `"off"`/`"none"` enum values were not exercised individually; only `"group-mentions"` (the default, before) and `"all"` (the recommended fix, after) were verified end-to-end.
- Before evidence (optional but encouraged): Same gateway, same Slack channel, same bot, same emoji shortcode — 40+ inbound DM messages over the prior conversation, zero `:eyes:` reactions on any of them. Captured via the same `curl https://slack.com/api/conversations.history` query — no `reactions` field on any inbound message in the live output.

## Root Cause (if applicable)

- Root cause: `shouldAckReaction()` in `src/channels/ack-reactions.ts` short-circuits with `false` when `scope === "group-mentions"` (the default) and `isDirect` is true. The Slack channel docs only documented `ackReaction` (which emoji to send) and never the scope gate, so users tracing "why isn't my reaction firing" had no docs path to follow.

## AI-assisted disclosure

Drafted and verified by an automated assistant (Dr. Claw) operating on the user's behalf. Human-run repro was performed end-to-end in the live OpenClaw deployment shown above before the docs were written.

## Test plan

- `pnpm exec node scripts/check-docs-mdx.mjs docs/channels/slack.md docs/channels/telegram.md` → passes.
- `pnpm exec node scripts/format-docs.mjs --check` → clean (full docs corpus, 631 files).
- `pnpm dlx markdownlint-cli2 --config config/markdownlint-cli2.jsonc docs/channels/slack.md docs/channels/telegram.md` → 0 errors.
