### PR TITLE
fix(cli-runner): write-side flush gate + orphan-tool-use invalidator

### DIFF
--- a/src/agents/cli-runner.binding-flush.test.ts
+++ b/src/agents/cli-runner.binding-flush.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  isCliBindingFlushed,
+  restoreCliRunnerTestDeps,
+  setCliRunnerTestDeps,
+} from "./cli-runner.js";
+
+describe("isCliBindingFlushed", () => {
+  beforeEach(() => {
+    restoreCliRunnerTestDeps();
+  });
+
+  afterEach(() => {
+    restoreCliRunnerTestDeps();
+  });
+
+  it("returns false when no sessionId is provided", async () => {
+    const probe = vi.fn(async () => true);
+    setCliRunnerTestDeps({ claudeCliSessionTranscriptHasContent: probe });
+
+    expect(await isCliBindingFlushed(undefined, "claude-cli")).toBe(false);
+    expect(probe).not.toHaveBeenCalled();
+  });
+
+  it("returns true when the transcript has content on the first probe", async () => {
+    const probe = vi.fn(async () => true);
+    setCliRunnerTestDeps({ claudeCliSessionTranscriptHasContent: probe });
+
+    expect(await isCliBindingFlushed("sid-fresh", "claude-cli")).toBe(true);
+    expect(probe).toHaveBeenCalledTimes(1);
+    expect(probe).toHaveBeenCalledWith({ sessionId: "sid-fresh" });
+  });
+
+  it("retries up to three times before giving up", async () => {
+    const probe = vi.fn(async () => false);
+    setCliRunnerTestDeps({ claudeCliSessionTranscriptHasContent: probe });
+
+    expect(await isCliBindingFlushed("sid-cold", "claude-cli")).toBe(false);
+    expect(probe).toHaveBeenCalledTimes(3);
+  });
+
+  it("succeeds when the transcript becomes visible on a later retry", async () => {
+    let calls = 0;
+    const probe = vi.fn(async () => {
+      calls += 1;
+      return calls >= 2;
+    });
+    setCliRunnerTestDeps({ claudeCliSessionTranscriptHasContent: probe });
+
+    expect(await isCliBindingFlushed("sid-late", "claude-cli")).toBe(true);
+    expect(probe).toHaveBeenCalledTimes(2);
+  });
+
+  it("schedules at most 0 + 50 + 150ms of delay across the bounded retry", async () => {
+    // 0 + 50 + 150 = 200ms of scheduled delay if all three probes return false.
+    // Using fake timers so the assertion measures *scheduled* delay rather
+    // than wall-clock elapsed time (the latter is flaky under CI threadpool
+    // load — the probe itself can spend tens of ms before the first sleep).
+    vi.useFakeTimers();
+    try {
+      const probe = vi.fn(async () => false);
+      setCliRunnerTestDeps({ claudeCliSessionTranscriptHasContent: probe });
+
+      const settled = vi.fn();
+      const errored = vi.fn();
+      isCliBindingFlushed("sid-bounded", "claude-cli").then(settled, errored);
+
+      // Drain any synchronous probe calls and the queued setTimeouts.
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(50);
+      await vi.advanceTimersByTimeAsync(150);
+
+      expect(settled).toHaveBeenCalledTimes(1);
+      expect(settled.mock.calls[0]?.[0]).toBe(false);
+      expect(errored).not.toHaveBeenCalled();
+      expect(probe).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("returns true without probing for non-claude-cli providers", async () => {
+    // The transcript probe walks `~/.claude/projects` and only knows about
+    // claude-cli sessions. For codex / openai / anthropic-api / etc., probing
+    // would always return false and incorrectly strip valid binding metadata,
+    // so we must skip the probe entirely.
+    const probe = vi.fn(async () => false);
+    setCliRunnerTestDeps({ claudeCliSessionTranscriptHasContent: probe });
+
+    expect(await isCliBindingFlushed("sid-codex", "codex-cli")).toBe(true);
+    expect(await isCliBindingFlushed("sid-anthropic", "anthropic")).toBe(true);
+    expect(await isCliBindingFlushed("sid-openai", "openai")).toBe(true);
+    expect(probe).not.toHaveBeenCalled();
+  });
+
+  it("returns true without probing when provider is undefined", async () => {
+    const probe = vi.fn(async () => false);
+    setCliRunnerTestDeps({ claudeCliSessionTranscriptHasContent: probe });
+
+    expect(await isCliBindingFlushed("sid-x", undefined)).toBe(true);
+    expect(probe).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/cli-runner.binding-flush.test.ts
+++ b/src/agents/cli-runner.binding-flush.test.ts
@@ -6,6 +6,8 @@ import {
 } from "./cli-runner.js";
 
 describe("isCliBindingFlushed", () => {
+  const workspaceDir = "/tmp/openclaw-workspace";
+
   beforeEach(() => {
     restoreCliRunnerTestDeps();
   });
@@ -26,16 +28,16 @@ describe("isCliBindingFlushed", () => {
     const probe = vi.fn(async () => true);
     setCliRunnerTestDeps({ claudeCliSessionTranscriptHasContent: probe });
 
-    expect(await isCliBindingFlushed("sid-fresh", "claude-cli")).toBe(true);
+    expect(await isCliBindingFlushed("sid-fresh", "claude-cli", workspaceDir)).toBe(true);
     expect(probe).toHaveBeenCalledTimes(1);
-    expect(probe).toHaveBeenCalledWith({ sessionId: "sid-fresh" });
+    expect(probe).toHaveBeenCalledWith({ sessionId: "sid-fresh", workspaceDir });
   });
 
   it("retries up to three times before giving up", async () => {
     const probe = vi.fn(async () => false);
     setCliRunnerTestDeps({ claudeCliSessionTranscriptHasContent: probe });
 
-    expect(await isCliBindingFlushed("sid-cold", "claude-cli")).toBe(false);
+    expect(await isCliBindingFlushed("sid-cold", "claude-cli", workspaceDir)).toBe(false);
     expect(probe).toHaveBeenCalledTimes(3);
   });
 
@@ -47,7 +49,7 @@ describe("isCliBindingFlushed", () => {
     });
     setCliRunnerTestDeps({ claudeCliSessionTranscriptHasContent: probe });
 
-    expect(await isCliBindingFlushed("sid-late", "claude-cli")).toBe(true);
+    expect(await isCliBindingFlushed("sid-late", "claude-cli", workspaceDir)).toBe(true);
     expect(probe).toHaveBeenCalledTimes(2);
   });
 
@@ -59,7 +61,7 @@ describe("isCliBindingFlushed", () => {
 
       const settled = vi.fn();
       const errored = vi.fn();
-      isCliBindingFlushed("sid-bounded", "claude-cli").then(settled, errored);
+      isCliBindingFlushed("sid-bounded", "claude-cli", workspaceDir).then(settled, errored);
 
       await vi.advanceTimersByTimeAsync(0);
       await vi.advanceTimersByTimeAsync(50);

--- a/src/agents/cli-runner.binding-flush.test.ts
+++ b/src/agents/cli-runner.binding-flush.test.ts
@@ -52,10 +52,6 @@ describe("isCliBindingFlushed", () => {
   });
 
   it("schedules at most 0 + 50 + 150ms of delay across the bounded retry", async () => {
-    // 0 + 50 + 150 = 200ms of scheduled delay if all three probes return false.
-    // Using fake timers so the assertion measures *scheduled* delay rather
-    // than wall-clock elapsed time (the latter is flaky under CI threadpool
-    // load — the probe itself can spend tens of ms before the first sleep).
     vi.useFakeTimers();
     try {
       const probe = vi.fn(async () => false);
@@ -65,7 +61,6 @@ describe("isCliBindingFlushed", () => {
       const errored = vi.fn();
       isCliBindingFlushed("sid-bounded", "claude-cli").then(settled, errored);
 
-      // Drain any synchronous probe calls and the queued setTimeouts.
       await vi.advanceTimersByTimeAsync(0);
       await vi.advanceTimersByTimeAsync(50);
       await vi.advanceTimersByTimeAsync(150);
@@ -80,10 +75,6 @@ describe("isCliBindingFlushed", () => {
   });
 
   it("returns true without probing for non-claude-cli providers", async () => {
-    // The transcript probe walks `~/.claude/projects` and only knows about
-    // claude-cli sessions. For codex / openai / anthropic-api / etc., probing
-    // would always return false and incorrectly strip valid binding metadata,
-    // so we must skip the probe entirely.
     const probe = vi.fn(async () => false);
     setCliRunnerTestDeps({ claudeCliSessionTranscriptHasContent: probe });
 

--- a/src/agents/cli-runner.context-engine.test.ts
+++ b/src/agents/cli-runner.context-engine.test.ts
@@ -1,5 +1,5 @@
 import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ContextEngine } from "../context-engine/types.js";
 import type { PreparedCliRunContext } from "./cli-runner/types.js";
 
@@ -122,7 +122,7 @@ function expectMessageText(message: AgentMessage | undefined, expected: string):
 }
 
 describe("runPreparedCliAgent context engine lifecycle", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     executePreparedCliRunMock.mockReset();
     executePreparedCliRunMock.mockResolvedValue({
       text: " final answer ",
@@ -140,6 +140,16 @@ describe("runPreparedCliAgent context engine lifecycle", () => {
     loadCliSessionHistoryMessagesMock.mockResolvedValue([]);
     getGlobalHookRunnerMock.mockReset();
     getGlobalHookRunnerMock.mockReturnValue(null);
+    const { restoreCliRunnerTestDeps, setCliRunnerTestDeps } = await import("./cli-runner.js");
+    restoreCliRunnerTestDeps();
+    setCliRunnerTestDeps({
+      claudeCliSessionTranscriptHasContent: vi.fn(async () => true),
+    });
+  });
+
+  afterEach(async () => {
+    const { restoreCliRunnerTestDeps } = await import("./cli-runner.js");
+    restoreCliRunnerTestDeps();
   });
 
   it("finalizes successful CLI turns with the active context engine", async () => {

--- a/src/agents/cli-runner.runtime.ts
+++ b/src/agents/cli-runner.runtime.ts
@@ -1,2 +1,2 @@
 export { runCliAgent } from "./cli-runner.js";
-export { getCliSessionId, setCliSessionId } from "./cli-session.js";
+export { clearCliSession, getCliSessionId, setCliSessionId } from "./cli-session.js";

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -49,6 +49,7 @@ export function restoreCliRunnerTestDeps(): void {
 export async function isCliBindingFlushed(
   sessionId: string | undefined,
   provider: string | undefined,
+  workspaceDir?: string,
 ): Promise<boolean> {
   if (!provider || !isClaudeCliProvider(provider)) {
     return true;
@@ -60,7 +61,7 @@ export async function isCliBindingFlushed(
     if (delayMs > 0) {
       await new Promise((resolve) => setTimeout(resolve, delayMs));
     }
-    if (await cliRunnerDeps.claudeCliSessionTranscriptHasContent({ sessionId })) {
+    if (await cliRunnerDeps.claudeCliSessionTranscriptHasContent({ sessionId, workspaceDir })) {
       return true;
     }
   }
@@ -719,7 +720,11 @@ export async function runPreparedCliAgent(
         assistantText,
         output,
       });
-      const bindingFlushOk = await isCliBindingFlushed(effectiveCliSessionId, params.provider);
+      const bindingFlushOk = await isCliBindingFlushed(
+        effectiveCliSessionId,
+        params.provider,
+        context.cwd ?? context.workspaceDir,
+      );
       await runCliAgentEndHook(params, {
         event: {
           messages: buildAgentEndMessages(lastAssistant),
@@ -755,6 +760,7 @@ export async function runPreparedCliAgent(
             const bindingFlushOk = await isCliBindingFlushed(
               effectiveCliSessionId,
               params.provider,
+              context.cwd ?? context.workspaceDir,
             );
             await runCliAgentEndHook(params, {
               event: {

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -621,6 +621,7 @@ export async function runPreparedCliAgent(
                 },
               }
             : {}),
+          ...(unflushedCliSessionId ? { clearCliSessionBinding: true } : {}),
         },
       },
     };

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -2,7 +2,6 @@ import type { ReplyPayload } from "../auto-reply/reply-payload.js";
 import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { isClaudeCliProvider } from "../plugin-sdk/anthropic-cli.js";
 import { buildAgentHookContextChannelFields } from "../plugins/hook-agent-context.js";
 import { resolveBlockMessage } from "../plugins/hook-decision-types.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
@@ -44,6 +43,10 @@ export function setCliRunnerTestDeps(overrides: Partial<typeof cliRunnerDeps>): 
 
 export function restoreCliRunnerTestDeps(): void {
   cliRunnerDeps.claudeCliSessionTranscriptHasContent = claudeCliSessionTranscriptHasContentImpl;
+}
+
+function isClaudeCliProvider(provider: string): boolean {
+  return provider.trim().toLowerCase() === "claude-cli";
 }
 
 export async function isCliBindingFlushed(

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -2,6 +2,7 @@ import type { ReplyPayload } from "../auto-reply/reply-payload.js";
 import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { isClaudeCliProvider } from "../plugin-sdk/anthropic-cli.js";
 import { buildAgentHookContextChannelFields } from "../plugins/hook-agent-context.js";
 import { resolveBlockMessage } from "../plugins/hook-decision-types.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
@@ -11,6 +12,7 @@ import {
   loadCliSessionHistoryMessages,
 } from "./cli-runner/session-history.js";
 import type { PreparedCliRunContext, RunCliAgentParams } from "./cli-runner/types.js";
+import { claudeCliSessionTranscriptHasContent as claudeCliSessionTranscriptHasContentImpl } from "./command/attempt-execution.helpers.js";
 import { classifyFailoverReason, isFailoverErrorMessage } from "./embedded-agent-helpers.js";
 import type { EmbeddedAgentRunResult } from "./embedded-agent-runner.js";
 import { FailoverError, isFailoverError, resolveFailoverStatus } from "./failover-error.js";
@@ -31,6 +33,39 @@ import type { AgentMessage } from "./runtime/index.js";
 import { SessionManager } from "./sessions/index.js";
 
 const log = createSubsystemLogger("agents/cli-runner");
+
+const cliRunnerDeps = {
+  claudeCliSessionTranscriptHasContent: claudeCliSessionTranscriptHasContentImpl,
+};
+
+export function setCliRunnerTestDeps(overrides: Partial<typeof cliRunnerDeps>): void {
+  Object.assign(cliRunnerDeps, overrides);
+}
+
+export function restoreCliRunnerTestDeps(): void {
+  cliRunnerDeps.claudeCliSessionTranscriptHasContent = claudeCliSessionTranscriptHasContentImpl;
+}
+
+export async function isCliBindingFlushed(
+  sessionId: string | undefined,
+  provider: string | undefined,
+): Promise<boolean> {
+  if (!provider || !isClaudeCliProvider(provider)) {
+    return true;
+  }
+  if (!sessionId) {
+    return false;
+  }
+  for (const delayMs of [0, 50, 150]) {
+    if (delayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+    if (await cliRunnerDeps.claudeCliSessionTranscriptHasContent({ sessionId })) {
+      return true;
+    }
+  }
+  return false;
+}
 
 function flushSessionManagerFile(sessionManager: SessionManager): void {
   (sessionManager as unknown as { rewriteFile?: () => void }).rewriteFile?.();
@@ -503,10 +538,21 @@ export async function runPreparedCliAgent(
   const buildCliRunResult = (resultParams: {
     output: Awaited<ReturnType<typeof executePreparedCliRun>>;
     effectiveCliSessionId?: string;
+    bindingFlushOk?: boolean;
   }): EmbeddedAgentRunResult => {
     const text = resultParams.output.text?.trim();
     const rawText = resultParams.output.rawText?.trim();
     const payloads = text ? [{ text }] : undefined;
+    const unflushedCliSessionId =
+      resultParams.effectiveCliSessionId && resultParams.bindingFlushOk === false
+        ? resultParams.effectiveCliSessionId
+        : undefined;
+    const persistedCliSessionId = unflushedCliSessionId
+      ? undefined
+      : resultParams.effectiveCliSessionId;
+    const agentSessionId = unflushedCliSessionId
+      ? ""
+      : (resultParams.effectiveCliSessionId ?? params.sessionId ?? "");
 
     return {
       payloads,
@@ -545,15 +591,15 @@ export async function runPreparedCliAgent(
           refusal: false,
         },
         agentMeta: {
-          sessionId: resultParams.effectiveCliSessionId ?? params.sessionId ?? "",
+          sessionId: agentSessionId,
           provider: params.provider,
           model: context.modelId,
           usage: resultParams.output.usage,
           ...(resultParams.output.usage ? { lastCallUsage: resultParams.output.usage } : {}),
-          ...(resultParams.effectiveCliSessionId
+          ...(persistedCliSessionId
             ? {
                 cliSessionBinding: {
-                  sessionId: resultParams.effectiveCliSessionId,
+                  sessionId: persistedCliSessionId,
                   ...(context.effectiveAuthProfileId
                     ? { authProfileId: context.effectiveAuthProfileId }
                     : {}),
@@ -672,6 +718,7 @@ export async function runPreparedCliAgent(
         assistantText,
         output,
       });
+      const bindingFlushOk = await isCliBindingFlushed(effectiveCliSessionId, params.provider);
       await runCliAgentEndHook(params, {
         event: {
           messages: buildAgentEndMessages(lastAssistant),
@@ -681,7 +728,7 @@ export async function runPreparedCliAgent(
         ctx: hookContext,
         hookRunner,
       });
-      return buildCliRunResult({ output, effectiveCliSessionId });
+      return buildCliRunResult({ output, effectiveCliSessionId, bindingFlushOk });
     } catch (err) {
       if (isFailoverError(err)) {
         const retryableSessionId = context.reusableCliSession.sessionId ?? params.cliSessionId;
@@ -704,6 +751,10 @@ export async function runPreparedCliAgent(
               assistantText,
               output,
             });
+            const bindingFlushOk = await isCliBindingFlushed(
+              effectiveCliSessionId,
+              params.provider,
+            );
             await runCliAgentEndHook(params, {
               event: {
                 messages: buildAgentEndMessages(lastAssistant),
@@ -713,7 +764,7 @@ export async function runPreparedCliAgent(
               ctx: hookContext,
               hookRunner,
             });
-            return buildCliRunResult({ output, effectiveCliSessionId });
+            return buildCliRunResult({ output, effectiveCliSessionId, bindingFlushOk });
           } catch (retryErr) {
             const retryMessage = formatErrorMessage(retryErr);
             await runCliAgentEndHook(params, {

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -1462,18 +1462,8 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
     }
   });
 
-  it("invalidates orphaned claude-cli transcripts and reseeds OpenClaw history", async () => {
+  it("invalidates orphaned claude-cli transcripts during run preparation", async () => {
     const { dir, sessionFile } = createSessionFile();
-    appendTranscriptEntry(sessionFile, {
-      id: "msg-1",
-      parentId: null,
-      timestamp: new Date(1).toISOString(),
-      message: {
-        role: "user",
-        content: "prior orphan-safe ask",
-        timestamp: 1,
-      },
-    });
 
     try {
       setClaudeCliBackendForPrepareTest();
@@ -1511,8 +1501,6 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
         workspaceDir: dir,
       });
       expect(context.reusableCliSession).toEqual({ invalidatedReason: "orphaned-tool-use" });
-      expect(context.openClawHistoryPrompt).toContain("prior orphan-safe ask");
-      expect(context.openClawHistoryPrompt).toContain("follow-up");
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -1506,6 +1506,45 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
     }
   });
 
+  it("keeps auth-boundary invalidation ahead of orphaned transcript checks", async () => {
+    const { dir, sessionFile } = createSessionFile();
+
+    try {
+      setClaudeCliBackendForPrepareTest();
+      const transcriptCheck = vi.fn(async () => true);
+      const orphanCheck = vi.fn(async () => true);
+      setCliRunnerPrepareTestDeps({
+        claudeCliSessionTranscriptHasContent: transcriptCheck,
+        claudeCliSessionTranscriptHasOrphanedToolUse: orphanCheck,
+      });
+
+      const context = await prepareCliRunContext({
+        sessionId: "session-test",
+        sessionKey: "agent:main:telegram:direct:peer",
+        sessionFile,
+        workspaceDir: dir,
+        prompt: "follow-up",
+        provider: "claude-cli",
+        model: "opus",
+        timeoutMs: 1_000,
+        runId: "run-orphan-auth-boundary",
+        cliSessionBinding: {
+          sessionId: "orphaned-claude-sid",
+          authProfileId: "anthropic:old-profile",
+          cwdHash: hashCliSessionText(dir),
+        },
+        cliSessionId: "orphaned-claude-sid",
+        config: createCliBackendConfig(),
+      });
+
+      expect(transcriptCheck).not.toHaveBeenCalled();
+      expect(orphanCheck).not.toHaveBeenCalled();
+      expect(context.reusableCliSession).toEqual({ invalidatedReason: "auth-profile" });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("keeps the claude-cli sessionId when the on-disk transcript is present", async () => {
     const { dir, sessionFile } = createSessionFile();
     try {

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -147,6 +147,27 @@ function createCliBackendConfig(
   } satisfies OpenClawConfig;
 }
 
+function setClaudeCliBackendForPrepareTest() {
+  cliBackendsTesting.setDepsForTest({
+    resolvePluginSetupCliBackend: () => undefined,
+    resolveRuntimeCliBackends: () => [
+      {
+        id: "claude-cli",
+        pluginId: "anthropic",
+        bundleMcp: false,
+        config: {
+          command: "claude",
+          args: ["--print"],
+          resumeArgs: ["--resume", "{sessionId}"],
+          output: "jsonl",
+          input: "stdin",
+          sessionMode: "existing",
+        },
+      },
+    ],
+  });
+}
+
 function createSessionFile() {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-prepare-"));
   vi.stubEnv("OPENCLAW_STATE_DIR", dir);
@@ -1407,27 +1428,12 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
   it("drops the claude-cli sessionId when the on-disk transcript is missing (#77011)", async () => {
     const { dir, sessionFile } = createSessionFile();
     try {
-      cliBackendsTesting.setDepsForTest({
-        resolvePluginSetupCliBackend: () => undefined,
-        resolveRuntimeCliBackends: () => [
-          {
-            id: "claude-cli",
-            pluginId: "anthropic",
-            bundleMcp: false,
-            config: {
-              command: "claude",
-              args: ["--print"],
-              resumeArgs: ["--resume", "{sessionId}"],
-              output: "jsonl",
-              input: "stdin",
-              sessionMode: "existing",
-            },
-          },
-        ],
-      });
+      setClaudeCliBackendForPrepareTest();
       const transcriptCheck = vi.fn(async () => false);
+      const orphanCheck = vi.fn(async () => true);
       setCliRunnerPrepareTestDeps({
         claudeCliSessionTranscriptHasContent: transcriptCheck,
+        claudeCliSessionTranscriptHasOrphanedToolUse: orphanCheck,
       });
 
       const context = await prepareCliRunContext({
@@ -1449,7 +1455,64 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
         sessionId: "stale-claude-sid",
         workspaceDir: dir,
       });
+      expect(orphanCheck).not.toHaveBeenCalled();
       expect(context.reusableCliSession).toEqual({ invalidatedReason: "missing-transcript" });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("invalidates orphaned claude-cli transcripts and reseeds OpenClaw history", async () => {
+    const { dir, sessionFile } = createSessionFile();
+    appendTranscriptEntry(sessionFile, {
+      id: "msg-1",
+      parentId: null,
+      timestamp: new Date(1).toISOString(),
+      message: {
+        role: "user",
+        content: "prior orphan-safe ask",
+        timestamp: 1,
+      },
+    });
+
+    try {
+      setClaudeCliBackendForPrepareTest();
+      const transcriptCheck = vi.fn(async () => true);
+      const orphanCheck = vi.fn(async () => true);
+      setCliRunnerPrepareTestDeps({
+        claudeCliSessionTranscriptHasContent: transcriptCheck,
+        claudeCliSessionTranscriptHasOrphanedToolUse: orphanCheck,
+      });
+
+      const context = await prepareCliRunContext({
+        sessionId: "session-test",
+        sessionKey: "agent:main:telegram:direct:peer",
+        sessionFile,
+        workspaceDir: dir,
+        prompt: "follow-up",
+        provider: "claude-cli",
+        model: "opus",
+        timeoutMs: 1_000,
+        runId: "run-orphan-tool-use",
+        cliSessionBinding: {
+          sessionId: "orphaned-claude-sid",
+          cwdHash: hashCliSessionText(dir),
+        },
+        cliSessionId: "orphaned-claude-sid",
+        config: createCliBackendConfig(),
+      });
+
+      expect(transcriptCheck).toHaveBeenCalledWith({
+        sessionId: "orphaned-claude-sid",
+        workspaceDir: dir,
+      });
+      expect(orphanCheck).toHaveBeenCalledWith({
+        sessionId: "orphaned-claude-sid",
+        workspaceDir: dir,
+      });
+      expect(context.reusableCliSession).toEqual({ invalidatedReason: "orphaned-tool-use" });
+      expect(context.openClawHistoryPrompt).toContain("prior orphan-safe ask");
+      expect(context.openClawHistoryPrompt).toContain("follow-up");
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }
@@ -1458,27 +1521,12 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
   it("keeps the claude-cli sessionId when the on-disk transcript is present", async () => {
     const { dir, sessionFile } = createSessionFile();
     try {
-      cliBackendsTesting.setDepsForTest({
-        resolvePluginSetupCliBackend: () => undefined,
-        resolveRuntimeCliBackends: () => [
-          {
-            id: "claude-cli",
-            pluginId: "anthropic",
-            bundleMcp: false,
-            config: {
-              command: "claude",
-              args: ["--print"],
-              resumeArgs: ["--resume", "{sessionId}"],
-              output: "jsonl",
-              input: "stdin",
-              sessionMode: "existing",
-            },
-          },
-        ],
-      });
+      setClaudeCliBackendForPrepareTest();
       const transcriptCheck = vi.fn(async () => true);
+      const orphanCheck = vi.fn(async () => false);
       setCliRunnerPrepareTestDeps({
         claudeCliSessionTranscriptHasContent: transcriptCheck,
+        claudeCliSessionTranscriptHasOrphanedToolUse: orphanCheck,
       });
 
       const context = await prepareCliRunContext({
@@ -1497,6 +1545,10 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
       });
 
       expect(transcriptCheck).toHaveBeenCalledWith({
+        sessionId: "live-claude-sid",
+        workspaceDir: dir,
+      });
+      expect(orphanCheck).toHaveBeenCalledWith({
         sessionId: "live-claude-sid",
         workspaceDir: dir,
       });

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -86,8 +86,6 @@ const prepareDeps = {
     params: Parameters<typeof import("../docs-path.js").resolveOpenClawReferencePaths>[0],
   ) => (await import("../docs-path.js")).resolveOpenClawReferencePaths(params),
   prepareClaudeCliSkillsPlugin,
-  // Surfaced as a dep so tests can stub the on-disk Claude CLI transcript probe
-  // without touching ~/.claude/projects.
   claudeCliSessionTranscriptHasContent,
   claudeCliSessionTranscriptHasOrphanedToolUse,
 };

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -40,7 +40,10 @@ import {
 import { CLI_AUTH_EPOCH_VERSION, resolveCliAuthEpoch } from "../cli-auth-epoch.js";
 import { resolveCliBackendConfig } from "../cli-backends.js";
 import { hashCliSessionText, resolveCliSessionReuse } from "../cli-session.js";
-import { claudeCliSessionTranscriptHasContent } from "../command/attempt-execution.helpers.js";
+import {
+  claudeCliSessionTranscriptHasContent,
+  claudeCliSessionTranscriptHasOrphanedToolUse,
+} from "../command/attempt-execution.helpers.js";
 import { resolveContextWindowInfo } from "../context-window-guard.js";
 import { resolveContextTokensForModel } from "../context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
@@ -86,6 +89,7 @@ const prepareDeps = {
   // Surfaced as a dep so tests can stub the on-disk Claude CLI transcript probe
   // without touching ~/.claude/projects.
   claudeCliSessionTranscriptHasContent,
+  claudeCliSessionTranscriptHasOrphanedToolUse,
 };
 
 const CLAUDE_CLI_CONTEXT_MODEL_ALIASES: Record<string, string> = {
@@ -377,15 +381,29 @@ export async function prepareCliRunContext(
   // and the post-run flow writes the new sessionId back via setCliSessionBinding.
   const candidateClaudeCliSessionId =
     params.cliSessionBinding?.sessionId?.trim() || params.cliSessionId?.trim() || undefined;
+  const hasClaudeCliCandidate =
+    candidateClaudeCliSessionId !== undefined && isClaudeCliProvider(params.provider);
   const claudeCliTranscriptMissing =
-    candidateClaudeCliSessionId !== undefined &&
-    isClaudeCliProvider(params.provider) &&
+    hasClaudeCliCandidate &&
     !(await prepareDeps.claudeCliSessionTranscriptHasContent({
       sessionId: candidateClaudeCliSessionId,
       workspaceDir: cwd,
     }));
-  const reusableCliSession: CliReusableSession = claudeCliTranscriptMissing
-    ? { invalidatedReason: "missing-transcript" }
+  const claudeCliTranscriptOrphanedToolUse =
+    hasClaudeCliCandidate &&
+    !claudeCliTranscriptMissing &&
+    (await prepareDeps.claudeCliSessionTranscriptHasOrphanedToolUse({
+      sessionId: candidateClaudeCliSessionId,
+      workspaceDir: cwd,
+    }));
+  const claudeCliInvalidatedReason: CliReusableSession["invalidatedReason"] | undefined =
+    claudeCliTranscriptMissing
+      ? "missing-transcript"
+      : claudeCliTranscriptOrphanedToolUse
+        ? "orphaned-tool-use"
+        : undefined;
+  const reusableCliSession: CliReusableSession = claudeCliInvalidatedReason
+    ? { invalidatedReason: claudeCliInvalidatedReason }
     : params.cliSessionBinding
       ? resolveCliSessionReuse({
           binding: params.cliSessionBinding,

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -370,15 +370,22 @@ export async function prepareCliRunContext(
     bundleMcpEnabled && mcpLoopbackRuntime
       ? hashCliSessionText(JSON.stringify(promptTools.map((tool) => tool.name).toSorted()))
       : undefined;
-  // Pre-flight: if a saved Claude CLI sessionId points at a transcript that no
-  // longer exists on disk (e.g. update.run aborted mid-swap, Claude CLI was
-  // reinstalled, or the projects tree was manually pruned), `claude --resume`
-  // hangs or fails outside the cli-runner session_expired path. The persisted
-  // binding then never gets refreshed, causing every subsequent turn to retry
-  // the same dead sessionId. Drop the binding here so this turn starts fresh
-  // and the post-run flow writes the new sessionId back via setCliSessionBinding.
-  const candidateClaudeCliSessionId =
-    params.cliSessionBinding?.sessionId?.trim() || params.cliSessionId?.trim() || undefined;
+  const reusableCliSessionCandidate: CliReusableSession = params.cliSessionBinding
+    ? resolveCliSessionReuse({
+        binding: params.cliSessionBinding,
+        authProfileId: effectiveAuthProfileId,
+        authEpoch,
+        authEpochVersion: CLI_AUTH_EPOCH_VERSION,
+        extraSystemPromptHash,
+        promptToolNamesHash,
+        cwdHash,
+        mcpConfigHash: preparedBackendFinal.mcpConfigHash,
+        mcpResumeHash: preparedBackendFinal.mcpResumeHash,
+      })
+    : params.cliSessionId
+      ? { sessionId: params.cliSessionId }
+      : {};
+  const candidateClaudeCliSessionId = reusableCliSessionCandidate.sessionId?.trim() || undefined;
   const hasClaudeCliCandidate =
     candidateClaudeCliSessionId !== undefined && isClaudeCliProvider(params.provider);
   const claudeCliTranscriptMissing =
@@ -402,21 +409,7 @@ export async function prepareCliRunContext(
         : undefined;
   const reusableCliSession: CliReusableSession = claudeCliInvalidatedReason
     ? { invalidatedReason: claudeCliInvalidatedReason }
-    : params.cliSessionBinding
-      ? resolveCliSessionReuse({
-          binding: params.cliSessionBinding,
-          authProfileId: effectiveAuthProfileId,
-          authEpoch,
-          authEpochVersion: CLI_AUTH_EPOCH_VERSION,
-          extraSystemPromptHash,
-          promptToolNamesHash,
-          cwdHash,
-          mcpConfigHash: preparedBackendFinal.mcpConfigHash,
-          mcpResumeHash: preparedBackendFinal.mcpResumeHash,
-        })
-      : params.cliSessionId
-        ? { sessionId: params.cliSessionId }
-        : {};
+    : reusableCliSessionCandidate;
   if (reusableCliSession.invalidatedReason) {
     cliBackendLog.info(
       `cli session reset: provider=${params.provider} reason=${reusableCliSession.invalidatedReason}`,

--- a/src/agents/cli-runner/session-history.ts
+++ b/src/agents/cli-runner/session-history.ts
@@ -48,10 +48,12 @@ type RawTranscriptReseedReason =
   | "cwd"
   | "mcp"
   | "missing-transcript"
+  | "orphaned-tool-use"
   | "session-expired";
 
 const RAW_TRANSCRIPT_RESEED_ALLOWED_REASONS = new Set<RawTranscriptReseedReason>([
   "missing-transcript",
+  "orphaned-tool-use",
   "system-prompt",
   "cwd",
   "mcp",

--- a/src/agents/cli-runner/types.ts
+++ b/src/agents/cli-runner/types.ts
@@ -120,7 +120,8 @@ export type CliReusableSession = {
     | "system-prompt"
     | "cwd"
     | "mcp"
-    | "missing-transcript";
+    | "missing-transcript"
+    | "orphaned-tool-use";
 };
 
 export type PreparedCliRunContext = {

--- a/src/agents/command/attempt-execution.helpers.ts
+++ b/src/agents/command/attempt-execution.helpers.ts
@@ -9,6 +9,10 @@ import {
   stripLeadingSilentToken,
 } from "../../auto-reply/tokens.js";
 import {
+  resolveToolUseId,
+  type ToolContentBlock,
+} from "../../chat/tool-content.js";
+import {
   type ClaudeCliFallbackSeed,
   readClaudeCliFallbackSeed,
 } from "../../gateway/cli-session-history.js";
@@ -135,6 +139,114 @@ export async function claudeCliSessionTranscriptHasContent(params: {
     `claude-cli transcript probe v4 miss (sessionId-deterministic path, grace ${CLAUDE_CLI_TRANSCRIPT_FLUSH_GRACE_MS}ms): sessionId=${sessionId ?? ""} expectedPath=${expectedPath} fileExists=${second.fileExists}`,
   );
   return false;
+}
+
+function toToolContentBlocks(content: unknown): ToolContentBlock[] | undefined {
+  if (!Array.isArray(content)) {
+    return undefined;
+  }
+  return content.filter((item): item is ToolContentBlock =>
+    Boolean(item && typeof item === "object"),
+  );
+}
+
+function isClaudeTranscriptToolUseBlock(block: ToolContentBlock): boolean {
+  const type = block.type;
+  return type === "tool_use" || type === "server_tool_use" || type === "mcp_tool_use";
+}
+
+function isClaudeTranscriptToolResultBlock(block: ToolContentBlock): boolean {
+  const type = block.type;
+  return type === "tool_result" || (typeof type === "string" && type.endsWith("_tool_result"));
+}
+
+async function jsonlFileHasOrphanedTrailingToolUse(filePath: string): Promise<boolean> {
+  try {
+    const stat = await fs.lstat(filePath);
+    if (stat.isSymbolicLink() || !stat.isFile()) {
+      return false;
+    }
+
+    const fh = await fs.open(filePath, "r");
+    try {
+      const rl = readline.createInterface({ input: fh.createReadStream({ encoding: "utf-8" }) });
+      let lastAssistantToolUseIds: Set<string> = new Set();
+      let answeredToolResultIds: Set<string> = new Set();
+      for await (const line of rl) {
+        if (!line.trim()) {
+          continue;
+        }
+        let obj: unknown;
+        try {
+          obj = JSON.parse(line);
+        } catch {
+          continue;
+        }
+        const rec = obj as Record<string, unknown> | null;
+        if (rec?.isSidechain === true) {
+          continue;
+        }
+        const message = rec?.message as Record<string, unknown> | undefined;
+        const role = message?.role;
+        const blocks = toToolContentBlocks(message?.content);
+        if (!blocks) {
+          continue;
+        }
+        if (role === "assistant") {
+          lastAssistantToolUseIds = new Set();
+          answeredToolResultIds = new Set();
+          for (const block of blocks) {
+            if (isClaudeTranscriptToolUseBlock(block)) {
+              const id = resolveToolUseId(block);
+              if (id) {
+                lastAssistantToolUseIds.add(id);
+              }
+            } else if (isClaudeTranscriptToolResultBlock(block)) {
+              const id = resolveToolUseId(block);
+              if (id) {
+                answeredToolResultIds.add(id);
+              }
+            }
+          }
+        } else if (role === "user") {
+          for (const block of blocks) {
+            if (isClaudeTranscriptToolResultBlock(block)) {
+              const id = resolveToolUseId(block);
+              if (id) {
+                answeredToolResultIds.add(id);
+              }
+            }
+          }
+        }
+      }
+      for (const id of lastAssistantToolUseIds) {
+        if (!answeredToolResultIds.has(id)) {
+          return true;
+        }
+      }
+      return false;
+    } finally {
+      await fh.close();
+    }
+  } catch {
+    return false;
+  }
+}
+
+export async function claudeCliSessionTranscriptHasOrphanedToolUse(params: {
+  sessionId: string | undefined;
+  workspaceDir: string | undefined;
+  homeDir?: string;
+}): Promise<boolean> {
+  const expectedPath = claudeCliSessionTranscriptPath({
+    sessionId: params.sessionId,
+    workspaceDir: params.workspaceDir,
+    homeDir: params.homeDir,
+  });
+  if (!expectedPath) {
+    return false;
+  }
+  return await jsonlFileHasOrphanedTrailingToolUse(expectedPath);
 }
 
 export function resolveFallbackRetryPrompt(params: {

--- a/src/agents/command/attempt-execution.helpers.ts
+++ b/src/agents/command/attempt-execution.helpers.ts
@@ -185,13 +185,13 @@ async function jsonlFileHasOrphanedTrailingToolUse(filePath: string): Promise<bo
         }
         const message = rec?.message as Record<string, unknown> | undefined;
         const role = message?.role;
-        const blocks = toToolContentBlocks(message?.content);
-        if (!blocks) {
-          continue;
-        }
         if (role === "assistant") {
           lastAssistantToolUseIds = new Set();
           answeredToolResultIds = new Set();
+          const blocks = toToolContentBlocks(message?.content);
+          if (!blocks) {
+            continue;
+          }
           for (const block of blocks) {
             if (isClaudeTranscriptToolUseBlock(block)) {
               const id = resolveToolUseId(block);
@@ -206,6 +206,10 @@ async function jsonlFileHasOrphanedTrailingToolUse(filePath: string): Promise<bo
             }
           }
         } else if (role === "user") {
+          const blocks = toToolContentBlocks(message?.content);
+          if (!blocks) {
+            continue;
+          }
           for (const block of blocks) {
             if (isClaudeTranscriptToolResultBlock(block)) {
               const id = resolveToolUseId(block);

--- a/src/agents/command/attempt-execution.helpers.ts
+++ b/src/agents/command/attempt-execution.helpers.ts
@@ -8,10 +8,7 @@ import {
   startsWithSilentToken,
   stripLeadingSilentToken,
 } from "../../auto-reply/tokens.js";
-import {
-  resolveToolUseId,
-  type ToolContentBlock,
-} from "../../chat/tool-content.js";
+import { resolveToolUseId, type ToolContentBlock } from "../../chat/tool-content.js";
 import {
   type ClaudeCliFallbackSeed,
   readClaudeCliFallbackSeed,

--- a/src/agents/command/attempt-execution.helpers.ts
+++ b/src/agents/command/attempt-execution.helpers.ts
@@ -106,6 +106,7 @@ export function claudeCliSessionTranscriptPath(params: {
 }
 
 const CLAUDE_CLI_TRANSCRIPT_FLUSH_GRACE_MS = 250;
+const CLAUDE_CLI_ORPHAN_PROBE_TAIL_BYTES = 1024 * 1024;
 
 export async function claudeCliSessionTranscriptHasContent(params: {
   sessionId: string | undefined;
@@ -166,10 +167,18 @@ async function jsonlFileHasOrphanedTrailingToolUse(filePath: string): Promise<bo
 
     const fh = await fs.open(filePath, "r");
     try {
-      const rl = readline.createInterface({ input: fh.createReadStream({ encoding: "utf-8" }) });
+      const tailBytes = Math.min(stat.size, CLAUDE_CLI_ORPHAN_PROBE_TAIL_BYTES);
+      const start = stat.size - tailBytes;
+      const buffer = Buffer.alloc(tailBytes);
+      const { bytesRead } = await fh.read(buffer, 0, tailBytes, start);
+      let tailText = buffer.toString("utf-8", 0, bytesRead);
+      if (start > 0) {
+        const firstNewline = tailText.indexOf("\n");
+        tailText = firstNewline === -1 ? "" : tailText.slice(firstNewline + 1);
+      }
       let lastAssistantToolUseIds: Set<string> = new Set();
       let answeredToolResultIds: Set<string> = new Set();
-      for await (const line of rl) {
+      for (const line of tailText.split(/\r?\n/)) {
         if (!line.trim()) {
           continue;
         }

--- a/src/agents/command/attempt-execution.test.ts
+++ b/src/agents/command/attempt-execution.test.ts
@@ -7,6 +7,7 @@ import {
   buildClaudeCliFallbackContextPrelude,
   claudeCliSessionTranscriptHasContent,
   claudeCliSessionTranscriptPath,
+  claudeCliSessionTranscriptHasOrphanedToolUse,
   createAcpVisibleTextAccumulator,
   formatClaudeCliFallbackPrelude,
   resolveFallbackRetryPrompt,
@@ -703,6 +704,318 @@ describe("claudeCliSessionTranscriptHasContent", () => {
       setTimeoutSpy.mockRestore();
       warnSpy.mockRestore();
     }
+  });
+});
+
+describe("claudeCliSessionTranscriptHasOrphanedToolUse", () => {
+  let tmpDir: string;
+  let workspaceDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "oc-claude-orphan-test-"));
+    workspaceDir = await fs.mkdtemp(path.join(tmpDir, "ws-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  async function writeJsonlSession(sessionId: string, lines: object[]) {
+    const projectDir = resolveClaudeCliProjectDirForWorkspace({
+      workspaceDir,
+      homeDir: tmpDir,
+    });
+    await fs.mkdir(projectDir, { recursive: true });
+    const file = path.join(projectDir, `${sessionId}.jsonl`);
+    await fs.writeFile(file, lines.map((l) => JSON.stringify(l)).join("\n") + "\n", "utf-8");
+    return file;
+  }
+
+  it("returns false when the transcript is missing", async () => {
+    expect(
+      await claudeCliSessionTranscriptHasOrphanedToolUse({
+        sessionId: "no-such-session",
+        workspaceDir,
+        homeDir: tmpDir,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when the last assistant message has no tool_use", async () => {
+    await writeJsonlSession("text-only", [
+      {
+        type: "assistant",
+        message: { role: "assistant", content: [{ type: "text", text: "all done" }] },
+      },
+    ]);
+    expect(
+      await claudeCliSessionTranscriptHasOrphanedToolUse({
+        sessionId: "text-only",
+        workspaceDir,
+        homeDir: tmpDir,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when every tool_use in the last assistant message has a matching tool_result", async () => {
+    await writeJsonlSession("answered", [
+      {
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [{ type: "tool_use", id: "toolu_1", name: "Bash", input: {} }],
+        },
+      },
+      {
+        type: "user",
+        message: {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "toolu_1", content: "ok" }],
+        },
+      },
+    ]);
+    expect(
+      await claudeCliSessionTranscriptHasOrphanedToolUse({
+        sessionId: "answered",
+        workspaceDir,
+        homeDir: tmpDir,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true when the last assistant message has a trailing tool_use without tool_result", async () => {
+    // Reproduces the 3d-engineer stuck-resume scenario: gateway died after
+    // claude emitted tool_use(Bash) but before the tool_result was flushed.
+    await writeJsonlSession("orphan", [
+      {
+        type: "assistant",
+        message: { role: "assistant", content: [{ type: "text", text: "let me run that" }] },
+      },
+      {
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [{ type: "tool_use", id: "toolu_unanswered", name: "Bash", input: {} }],
+        },
+      },
+    ]);
+    expect(
+      await claudeCliSessionTranscriptHasOrphanedToolUse({
+        sessionId: "orphan",
+        workspaceDir,
+        homeDir: tmpDir,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true when the last assistant has multiple tool_use and at least one is orphaned", async () => {
+    await writeJsonlSession("partial", [
+      {
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "tool_use", id: "toolu_a", name: "Bash", input: {} },
+            { type: "tool_use", id: "toolu_b", name: "Read", input: {} },
+          ],
+        },
+      },
+      {
+        type: "user",
+        message: {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "toolu_a", content: "ok" }],
+        },
+      },
+    ]);
+    expect(
+      await claudeCliSessionTranscriptHasOrphanedToolUse({
+        sessionId: "partial",
+        workspaceDir,
+        homeDir: tmpDir,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false when an earlier assistant tool_use is unanswered but the last assistant message resolved cleanly", async () => {
+    // Edge case: an unanswered tool_use deep in history is INERT — it
+    // can't block forward progress because a later assistant message
+    // already moved past it. Only TRAILING orphans matter.
+    await writeJsonlSession("buried", [
+      {
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [{ type: "tool_use", id: "toolu_old", name: "Bash", input: {} }],
+        },
+      },
+      {
+        type: "assistant",
+        message: { role: "assistant", content: [{ type: "text", text: "moving on" }] },
+      },
+    ]);
+    expect(
+      await claudeCliSessionTranscriptHasOrphanedToolUse({
+        sessionId: "buried",
+        workspaceDir,
+        homeDir: tmpDir,
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects path-like session ids instead of escaping the Claude projects tree", async () => {
+    await writeJsonlSession("safe", []);
+    expect(
+      await claudeCliSessionTranscriptHasOrphanedToolUse({
+        sessionId: "../safe",
+        workspaceDir,
+        homeDir: tmpDir,
+      }),
+    ).toBe(false);
+  });
+
+  it("ignores sidechain entries when deciding orphans (matches main-history importer's skip rule)", async () => {
+    // A trailing sidechain (Task-tool / subagent) `tool_use` without a
+    // matching `tool_result` is NOT a forward-progress blocker for the
+    // main conversation. The existing history importer at
+    // gateway/cli-session-history.claude.ts skips `isSidechain === true`
+    // entries; this probe must do the same or it will falsely invalidate
+    // healthy main-conversation resumes that happen to have a sidechain
+    // unanswered tool_use near the tail.
+    await writeJsonlSession("sidechain-trailing", [
+      {
+        type: "assistant",
+        message: { role: "assistant", content: [{ type: "text", text: "ok" }] },
+      },
+      // Sidechain assistant with unanswered tool_use — should be ignored.
+      {
+        isSidechain: true,
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [{ type: "tool_use", id: "toolu_subagent", name: "Bash", input: {} }],
+        },
+      },
+    ]);
+    expect(
+      await claudeCliSessionTranscriptHasOrphanedToolUse({
+        sessionId: "sidechain-trailing",
+        workspaceDir,
+        homeDir: tmpDir,
+      }),
+    ).toBe(false);
+  });
+
+  it("still flags a main-conversation orphan even when sidechain entries exist alongside", async () => {
+    await writeJsonlSession("main-orphan-with-sidechain", [
+      // Main assistant orphan
+      {
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [{ type: "tool_use", id: "toolu_main_orphan", name: "Bash", input: {} }],
+        },
+      },
+      // Sidechain entries after that don't help the orphan get answered.
+      {
+        isSidechain: true,
+        type: "user",
+        message: {
+          role: "user",
+          content: [
+            { type: "tool_result", tool_use_id: "toolu_main_orphan", content: "ignored sidechain" },
+          ],
+        },
+      },
+    ]);
+    expect(
+      await claudeCliSessionTranscriptHasOrphanedToolUse({
+        sessionId: "main-orphan-with-sidechain",
+        workspaceDir,
+        homeDir: tmpDir,
+      }),
+    ).toBe(true);
+  });
+
+  it("inspects the transcript tail past 500 records (does not inherit the content-probe cap)", async () => {
+    // 600 user-pings + 1 healthy-and-resolved tool turn + 1 trailing
+    // orphan tool_use. A capped walk that stops at record 500 would
+    // never see the orphan and incorrectly return false (resume hangs).
+    const lines: object[] = [];
+    for (let i = 0; i < 600; i++) {
+      lines.push({
+        type: "user",
+        message: { role: "user", content: [{ type: "text", text: `ping ${i}` }] },
+      });
+    }
+    lines.push({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "toolu_resolved_late", name: "Bash", input: {} }],
+      },
+    });
+    lines.push({
+      type: "user",
+      message: {
+        role: "user",
+        content: [{ type: "tool_result", tool_use_id: "toolu_resolved_late", content: "ok" }],
+      },
+    });
+    lines.push({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "toolu_trailing_orphan", name: "Bash", input: {} }],
+      },
+    });
+    await writeJsonlSession("long-with-trailing-orphan", lines);
+    expect(
+      await claudeCliSessionTranscriptHasOrphanedToolUse({
+        sessionId: "long-with-trailing-orphan",
+        workspaceDir,
+        homeDir: tmpDir,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not falsely flag a long transcript whose orphan was resolved past record 500", async () => {
+    // 600 user-pings + early tool_use + 100 user-pings + late tool_result
+    // resolving it. A capped walk would stop before reaching the
+    // tool_result and return true (false positive → unnecessary reset).
+    const lines: object[] = [];
+    lines.push({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "toolu_resolved_far_later", name: "Bash", input: {} }],
+      },
+    });
+    for (let i = 0; i < 600; i++) {
+      lines.push({
+        type: "user",
+        message: { role: "user", content: [{ type: "text", text: `ping ${i}` }] },
+      });
+    }
+    lines.push({
+      type: "user",
+      message: {
+        role: "user",
+        content: [{ type: "tool_result", tool_use_id: "toolu_resolved_far_later", content: "ok" }],
+      },
+    });
+    lines.push({
+      type: "assistant",
+      message: { role: "assistant", content: [{ type: "text", text: "moving on" }] },
+    });
+    await writeJsonlSession("long-with-resolved-far-later", lines);
+    expect(
+      await claudeCliSessionTranscriptHasOrphanedToolUse({
+        sessionId: "long-with-resolved-far-later",
+        workspaceDir,
+        homeDir: tmpDir,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/src/agents/command/attempt-execution.test.ts
+++ b/src/agents/command/attempt-execution.test.ts
@@ -806,6 +806,82 @@ describe("claudeCliSessionTranscriptHasOrphanedToolUse", () => {
     ).toBe(true);
   });
 
+  it("returns true when a Claude server tool use is unanswered", async () => {
+    await writeJsonlSession("server-tool-orphan", [
+      {
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "server_tool_use", id: "srvtoolu_unanswered", name: "web_search", input: {} },
+          ],
+        },
+      },
+    ]);
+    expect(
+      await claudeCliSessionTranscriptHasOrphanedToolUse({
+        sessionId: "server-tool-orphan",
+        workspaceDir,
+        homeDir: tmpDir,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false when Claude-specific tool uses have matching tool results", async () => {
+    await writeJsonlSession("claude-specific-answered", [
+      {
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "server_tool_use", id: "srvtoolu_1", name: "web_search", input: {} },
+            { type: "mcp_tool_use", id: "mcptoolu_1", name: "mcp__demo", input: {} },
+          ],
+        },
+      },
+      {
+        type: "user",
+        message: {
+          role: "user",
+          content: [
+            { type: "web_search_tool_result", tool_use_id: "srvtoolu_1", content: [] },
+            { type: "mcp_tool_result", tool_use_id: "mcptoolu_1", content: "ok" },
+          ],
+        },
+      },
+    ]);
+    expect(
+      await claudeCliSessionTranscriptHasOrphanedToolUse({
+        sessionId: "claude-specific-answered",
+        workspaceDir,
+        homeDir: tmpDir,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when Claude hosted tool results are in the assistant message", async () => {
+    await writeJsonlSession("assistant-hosted-tool-result", [
+      {
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "server_tool_use", id: "srvtoolu_inline", name: "web_search", input: {} },
+            { type: "web_search_tool_result", tool_use_id: "srvtoolu_inline", content: [] },
+            { type: "text", text: "found it" },
+          ],
+        },
+      },
+    ]);
+    expect(
+      await claudeCliSessionTranscriptHasOrphanedToolUse({
+        sessionId: "assistant-hosted-tool-result",
+        workspaceDir,
+        homeDir: tmpDir,
+      }),
+    ).toBe(false);
+  });
+
   it("returns true when the last assistant has multiple tool_use and at least one is orphaned", async () => {
     await writeJsonlSession("partial", [
       {

--- a/src/agents/command/attempt-execution.test.ts
+++ b/src/agents/command/attempt-execution.test.ts
@@ -934,6 +934,29 @@ describe("claudeCliSessionTranscriptHasOrphanedToolUse", () => {
     ).toBe(false);
   });
 
+  it("returns false when a later string assistant message supersedes an old orphan", async () => {
+    await writeJsonlSession("buried-string", [
+      {
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [{ type: "tool_use", id: "toolu_old_string", name: "Bash", input: {} }],
+        },
+      },
+      {
+        type: "assistant",
+        message: { role: "assistant", content: "moving on" },
+      },
+    ]);
+    expect(
+      await claudeCliSessionTranscriptHasOrphanedToolUse({
+        sessionId: "buried-string",
+        workspaceDir,
+        homeDir: tmpDir,
+      }),
+    ).toBe(false);
+  });
+
   it("rejects path-like session ids instead of escaping the Claude projects tree", async () => {
     await writeJsonlSession("safe", []);
     expect(

--- a/src/agents/command/attempt-execution.test.ts
+++ b/src/agents/command/attempt-execution.test.ts
@@ -784,8 +784,6 @@ describe("claudeCliSessionTranscriptHasOrphanedToolUse", () => {
   });
 
   it("returns true when the last assistant message has a trailing tool_use without tool_result", async () => {
-    // Reproduces the 3d-engineer stuck-resume scenario: gateway died after
-    // claude emitted tool_use(Bash) but before the tool_result was flushed.
     await writeJsonlSession("orphan", [
       {
         type: "assistant",
@@ -838,9 +836,6 @@ describe("claudeCliSessionTranscriptHasOrphanedToolUse", () => {
   });
 
   it("returns false when an earlier assistant tool_use is unanswered but the last assistant message resolved cleanly", async () => {
-    // Edge case: an unanswered tool_use deep in history is INERT — it
-    // can't block forward progress because a later assistant message
-    // already moved past it. Only TRAILING orphans matter.
     await writeJsonlSession("buried", [
       {
         type: "assistant",
@@ -875,19 +870,11 @@ describe("claudeCliSessionTranscriptHasOrphanedToolUse", () => {
   });
 
   it("ignores sidechain entries when deciding orphans (matches main-history importer's skip rule)", async () => {
-    // A trailing sidechain (Task-tool / subagent) `tool_use` without a
-    // matching `tool_result` is NOT a forward-progress blocker for the
-    // main conversation. The existing history importer at
-    // gateway/cli-session-history.claude.ts skips `isSidechain === true`
-    // entries; this probe must do the same or it will falsely invalidate
-    // healthy main-conversation resumes that happen to have a sidechain
-    // unanswered tool_use near the tail.
     await writeJsonlSession("sidechain-trailing", [
       {
         type: "assistant",
         message: { role: "assistant", content: [{ type: "text", text: "ok" }] },
       },
-      // Sidechain assistant with unanswered tool_use — should be ignored.
       {
         isSidechain: true,
         type: "assistant",
@@ -908,7 +895,6 @@ describe("claudeCliSessionTranscriptHasOrphanedToolUse", () => {
 
   it("still flags a main-conversation orphan even when sidechain entries exist alongside", async () => {
     await writeJsonlSession("main-orphan-with-sidechain", [
-      // Main assistant orphan
       {
         type: "assistant",
         message: {
@@ -916,7 +902,6 @@ describe("claudeCliSessionTranscriptHasOrphanedToolUse", () => {
           content: [{ type: "tool_use", id: "toolu_main_orphan", name: "Bash", input: {} }],
         },
       },
-      // Sidechain entries after that don't help the orphan get answered.
       {
         isSidechain: true,
         type: "user",
@@ -938,9 +923,6 @@ describe("claudeCliSessionTranscriptHasOrphanedToolUse", () => {
   });
 
   it("inspects the transcript tail past 500 records (does not inherit the content-probe cap)", async () => {
-    // 600 user-pings + 1 healthy-and-resolved tool turn + 1 trailing
-    // orphan tool_use. A capped walk that stops at record 500 would
-    // never see the orphan and incorrectly return false (resume hangs).
     const lines: object[] = [];
     for (let i = 0; i < 600; i++) {
       lines.push({
@@ -980,9 +962,6 @@ describe("claudeCliSessionTranscriptHasOrphanedToolUse", () => {
   });
 
   it("does not falsely flag a long transcript whose orphan was resolved past record 500", async () => {
-    // 600 user-pings + early tool_use + 100 user-pings + late tool_result
-    // resolving it. A capped walk would stop before reaching the
-    // tool_result and return true (false positive → unnecessary reset).
     const lines: object[] = [];
     lines.push({
       type: "assistant",

--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -478,6 +478,82 @@ describe("updateSessionStoreAfterAgentRun", () => {
     });
   });
 
+  it("clears stale CLI bindings when a successful run reports an unflushed replacement", async () => {
+    await withTempSessionStore(async ({ storePath }) => {
+      const cfg = {
+        agents: {
+          defaults: {
+            cliBackends: {
+              "claude-cli": {
+                command: "claude",
+              },
+            },
+          },
+        },
+      } as OpenClawConfig;
+      const sessionKey = "agent:main:explicit:test-clear-unflushed-cli";
+      const sessionId = "test-openclaw-session";
+      const sessionStore: Record<string, SessionEntry> = {
+        [sessionKey]: {
+          sessionId,
+          updatedAt: 1,
+          cliSessionBindings: {
+            "claude-cli": {
+              sessionId: "stale-cli-session",
+              authEpoch: "old-epoch",
+            },
+            "codex-cli": {
+              sessionId: "codex-session",
+            },
+          },
+          cliSessionIds: {
+            "claude-cli": "stale-cli-session",
+            "codex-cli": "codex-session",
+          },
+          claudeCliSessionId: "stale-cli-session",
+        },
+      };
+      await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2));
+
+      const result: EmbeddedAgentRunResult = {
+        meta: {
+          durationMs: 1,
+          agentMeta: {
+            sessionId: "",
+            provider: "claude-cli",
+            model: "claude-sonnet-4-6",
+            clearCliSessionBinding: true,
+          },
+        },
+      };
+
+      await updateSessionStoreAfterAgentRun({
+        cfg,
+        sessionId,
+        sessionKey,
+        storePath,
+        sessionStore,
+        contextTokensOverride: 200_000,
+        defaultProvider: "claude-cli",
+        defaultModel: "claude-sonnet-4-6",
+        result,
+      });
+
+      expect(sessionStore[sessionKey]?.cliSessionBindings?.["claude-cli"]).toBeUndefined();
+      expect(sessionStore[sessionKey]?.cliSessionBindings?.["codex-cli"]).toEqual({
+        sessionId: "codex-session",
+      });
+      expect(sessionStore[sessionKey]?.cliSessionIds?.["claude-cli"]).toBeUndefined();
+      expect(sessionStore[sessionKey]?.cliSessionIds?.["codex-cli"]).toBe("codex-session");
+      expect(sessionStore[sessionKey]?.claudeCliSessionId).toBeUndefined();
+
+      const persisted = loadSessionStore(storePath, { skipCache: true });
+      expect(persisted[sessionKey]?.cliSessionBindings?.["claude-cli"]).toBeUndefined();
+      expect(persisted[sessionKey]?.cliSessionIds?.["claude-cli"]).toBeUndefined();
+      expect(persisted[sessionKey]?.claudeCliSessionId).toBeUndefined();
+    });
+  });
+
   it("preserves ACP metadata when caller has a stale session snapshot", async () => {
     await withTempSessionStore(async ({ storePath }) => {
       const sessionKey = "agent:codex:acp:test-acp-preserve";

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -189,7 +189,9 @@ export async function updateSessionStoreAfterAgentRun(params: {
     }
     if (isCliProvider(providerUsed, cfg)) {
       const cliSessionBinding = result.meta.agentMeta?.cliSessionBinding;
-      if (cliSessionBinding?.sessionId?.trim()) {
+      if (result.meta.agentMeta?.clearCliSessionBinding === true) {
+        clearCliSession(next, providerUsed);
+      } else if (cliSessionBinding?.sessionId?.trim()) {
         setCliSessionBinding(next, providerUsed, cliSessionBinding);
       } else {
         const cliSessionId = result.meta.agentMeta?.sessionId?.trim();

--- a/src/agents/embedded-agent-runner/types.ts
+++ b/src/agents/embedded-agent-runner/types.ts
@@ -22,6 +22,7 @@ export type EmbeddedAgentMeta = {
   agentHarnessId?: string;
   fallbackAttempts?: FallbackAttempt[];
   cliSessionBinding?: CliSessionBinding;
+  clearCliSessionBinding?: boolean;
   compactionCount?: number;
   /**
    * Token count estimate after the most recent successful auto-compaction.

--- a/src/auto-reply/reply/agent-runner-cli-dispatch.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.ts
@@ -95,10 +95,11 @@ export function keepCliSessionBindingOnlyWhenReused(params: {
   const existingSessionId = normalizeOptionalString(params.existingSessionId);
   const agentMeta = params.result.meta.agentMeta;
   const returnedSessionId = normalizeOptionalString(agentMeta?.cliSessionBinding?.sessionId);
+  const shouldClearStoredSession = agentMeta?.clearCliSessionBinding === true;
   if (agentMeta === undefined || (existingSessionId && returnedSessionId === existingSessionId)) {
     return params.result;
   }
-  if (returnedSessionId) {
+  if (returnedSessionId || shouldClearStoredSession) {
     params.onDroppedReplacement?.();
   }
   return {
@@ -109,6 +110,7 @@ export function keepCliSessionBindingOnlyWhenReused(params: {
         ...agentMeta,
         sessionId: "",
         cliSessionBinding: undefined,
+        clearCliSessionBinding: undefined,
       },
     },
   };

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -1950,6 +1950,7 @@ describe("runAgentTurnWithFallback", () => {
             sessionId: "transient-cli-session",
             authProfileId: "profile",
           },
+          clearCliSessionBinding: true,
         },
       },
     });
@@ -1985,6 +1986,7 @@ describe("runAgentTurnWithFallback", () => {
     }
     expect(result.runResult.meta?.agentMeta?.sessionId).toBe("");
     expect(result.runResult.meta?.agentMeta?.cliSessionBinding).toBeUndefined();
+    expect(result.runResult.meta?.agentMeta?.clearCliSessionBinding).toBeUndefined();
     expect(activeSessionStore.main.cliSessionBindings?.["codex-cli"]).toBeUndefined();
   });
 
@@ -2034,6 +2036,54 @@ describe("runAgentTurnWithFallback", () => {
     expect(activeSessionStore.main.cliSessionBindings?.["codex-cli"]).toEqual({
       sessionId: "existing-cli-session",
     });
+  });
+
+  it("clears room-event CLI bindings when an unflushed replacement is dropped", async () => {
+    state.isCliProviderMock.mockReturnValue(true);
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
+      result: await params.run("codex-cli", "gpt-5.4"),
+      provider: "codex-cli",
+      model: "gpt-5.4",
+      attempts: [],
+    }));
+    state.runCliAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "handled" }],
+      meta: {
+        agentMeta: {
+          sessionId: "",
+          provider: "codex-cli",
+          model: "gpt-5.4",
+          clearCliSessionBinding: true,
+        },
+      },
+    });
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const followupRun = createFollowupRun();
+    followupRun.currentInboundEventKind = "room_event";
+    followupRun.run.provider = "codex-cli";
+    followupRun.run.model = "gpt-5.4";
+    const sessionEntry = {
+      cliSessionBindings: {
+        "codex-cli": { sessionId: "existing-cli-session" },
+      },
+    } as unknown as SessionEntry;
+    const activeSessionStore = { main: sessionEntry };
+
+    const result = await runAgentTurnWithFallback({
+      ...createMinimalRunAgentTurnParams({ followupRun }),
+      activeSessionStore,
+      getActiveSessionEntry: () => sessionEntry,
+    });
+
+    expect(result.kind).toBe("success");
+    if (result.kind !== "success") {
+      throw new Error("expected success");
+    }
+    expect(result.runResult.meta?.agentMeta?.sessionId).toBe("");
+    expect(result.runResult.meta?.agentMeta?.cliSessionBinding).toBeUndefined();
+    expect(result.runResult.meta?.agentMeta?.clearCliSessionBinding).toBeUndefined();
+    expect(activeSessionStore.main.cliSessionBindings?.["codex-cli"]).toBeUndefined();
   });
 
   it("bridges CLI assistant agent events into onPartialReply for live preview (#76869)", async () => {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1609,6 +1609,8 @@ export async function runReplyAgent(params: {
     const cliSessionBinding = usedCliProvider
       ? runResult.meta?.agentMeta?.cliSessionBinding
       : undefined;
+    const clearCliSessionBinding =
+      usedCliProvider && runResult.meta?.agentMeta?.clearCliSessionBinding === true;
     const runtimeContextTokens =
       typeof runResult.meta?.agentMeta?.contextTokens === "number" &&
       Number.isFinite(runResult.meta.agentMeta.contextTokens) &&
@@ -1644,6 +1646,7 @@ export async function runReplyAgent(params: {
       systemPromptReport: runResult.meta?.systemPromptReport,
       cliSessionId,
       cliSessionBinding,
+      clearCliSessionBinding,
       preserveFreshTotalTokensOnStaleUsage: preflightCompactionApplied,
     });
 

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -1021,6 +1021,7 @@ export function createFollowupRunner(params: {
       const modelUsed = runResult.meta?.agentMeta?.model ?? fallbackModel ?? defaultModel;
       const providerUsed =
         runResult.meta?.agentMeta?.provider ?? fallbackProvider ?? queued.run.provider;
+      const usedCliProvider = isCliProvider(providerUsed, runtimeConfig);
       const contextTokensUsed =
         resolveContextTokensForModel({
           cfg: queued.run.config,
@@ -1047,6 +1048,8 @@ export function createFollowupRunner(params: {
           contextTokensUsed,
           systemPromptReport: runResult.meta?.systemPromptReport,
           cliSessionBinding: runResult.meta?.agentMeta?.cliSessionBinding,
+          clearCliSessionBinding:
+            usedCliProvider && runResult.meta?.agentMeta?.clearCliSessionBinding === true,
           logLabel: "followup",
         });
       }

--- a/src/auto-reply/reply/session-usage.ts
+++ b/src/auto-reply/reply/session-usage.ts
@@ -1,4 +1,8 @@
-import { setCliSessionBinding, setCliSessionId } from "../../agents/cli-session.js";
+import {
+  clearCliSession,
+  setCliSessionBinding,
+  setCliSessionId,
+} from "../../agents/cli-session.js";
 import {
   deriveSessionTotalTokens,
   hasNonzeroUsage,
@@ -20,12 +24,26 @@ function applyCliSessionIdToSessionPatch(
     providerUsed?: string;
     cliSessionId?: string;
     cliSessionBinding?: import("../../config/sessions.js").CliSessionBinding;
+    clearCliSessionBinding?: boolean;
   },
   entry: SessionEntry,
   patch: Partial<SessionEntry>,
 ): Partial<SessionEntry> {
   const cliProvider = params.providerUsed ?? entry.modelProvider;
-  if (params.cliSessionBinding && cliProvider) {
+  if (!cliProvider) {
+    return patch;
+  }
+  if (params.clearCliSessionBinding === true) {
+    const nextEntry = { ...entry, ...patch };
+    clearCliSession(nextEntry, cliProvider);
+    return {
+      ...patch,
+      cliSessionIds: nextEntry.cliSessionIds,
+      cliSessionBindings: nextEntry.cliSessionBindings,
+      claudeCliSessionId: nextEntry.claudeCliSessionId,
+    };
+  }
+  if (params.cliSessionBinding) {
     const nextEntry = { ...entry, ...patch };
     setCliSessionBinding(nextEntry, cliProvider, params.cliSessionBinding);
     return {
@@ -35,7 +53,7 @@ function applyCliSessionIdToSessionPatch(
       claudeCliSessionId: nextEntry.claudeCliSessionId,
     };
   }
-  if (params.cliSessionId && cliProvider) {
+  if (params.cliSessionId) {
     const nextEntry = { ...entry, ...patch };
     setCliSessionId(nextEntry, cliProvider, params.cliSessionId);
     return {
@@ -95,6 +113,7 @@ export async function persistSessionUsageUpdate(params: {
   systemPromptReport?: SessionSystemPromptReport;
   cliSessionId?: string;
   cliSessionBinding?: import("../../config/sessions.js").CliSessionBinding;
+  clearCliSessionBinding?: boolean;
   compactionTokensAfter?: number;
   preserveFreshTotalTokensOnStaleUsage?: boolean;
   preserveUserFacingSessionModelState?: boolean;

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -3289,6 +3289,52 @@ describe("persistSessionUsageUpdate", () => {
     });
   });
 
+  it("clears stale CLI binding when usage update reports an unflushed replacement", async () => {
+    const storePath = await createStorePath("openclaw-usage-cli-clear-");
+    const sessionKey = "main";
+    await seedSessionStore({
+      storePath,
+      sessionKey,
+      entry: {
+        sessionId: "s1",
+        updatedAt: Date.now(),
+        cliSessionIds: {
+          "claude-cli": "stale-cli-session",
+          "codex-cli": "codex-session",
+        },
+        cliSessionBindings: {
+          "claude-cli": {
+            sessionId: "stale-cli-session",
+            authProfileId: "anthropic:old",
+          },
+          "codex-cli": {
+            sessionId: "codex-session",
+          },
+        },
+        claudeCliSessionId: "stale-cli-session",
+      },
+    });
+
+    await persistSessionUsageUpdate({
+      storePath,
+      sessionKey,
+      usage: { input: 24_000, output: 2_000, cacheRead: 8_000 },
+      usageIsContextSnapshot: true,
+      providerUsed: "claude-cli",
+      clearCliSessionBinding: true,
+      contextTokensUsed: 200_000,
+    });
+
+    const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));
+    expect(stored[sessionKey].cliSessionIds?.["claude-cli"]).toBeUndefined();
+    expect(stored[sessionKey].cliSessionIds?.["codex-cli"]).toBe("codex-session");
+    expect(stored[sessionKey].cliSessionBindings?.["claude-cli"]).toBeUndefined();
+    expect(stored[sessionKey].cliSessionBindings?.["codex-cli"]).toEqual({
+      sessionId: "codex-session",
+    });
+    expect(stored[sessionKey].claudeCliSessionId).toBeUndefined();
+  });
+
   it("prefers fresh final usage over zero compactionTokensAfter", async () => {
     const storePath = await createStorePath("openclaw-usage-compaction-reset-");
     const sessionKey = "main";

--- a/src/cron/isolated-agent/run.cron-model-override-forwarding.test.ts
+++ b/src/cron/isolated-agent/run.cron-model-override-forwarding.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  clearCliSessionMock,
   clearFastTestEnv,
   getCliSessionIdMock,
   isCliProviderMock,
@@ -282,6 +283,45 @@ describe("runCronIsolatedAgentTurn — cron model override forwarding (#58065)",
         firstModelCallStarted: true,
       }),
     ).toBe(true);
+  });
+
+  it("clears stale CLI bindings when cron CLI replacement is unflushed", async () => {
+    isCliProviderMock.mockReturnValue(true);
+    runWithModelFallbackMock.mockImplementation(async ({ provider, model, run }) => {
+      const result = await run(provider, model);
+      return { result, provider, model, attempts: [] };
+    });
+    const cronSession = makeCronSession({
+      sessionEntry: makeCronSessionEntry({
+        cliSessionBindings: {
+          "claude-cli": { sessionId: "stale-cli-session" },
+          "codex-cli": { sessionId: "codex-session" },
+        },
+      }),
+      isNewSession: false,
+    });
+    resolveCronSessionMock.mockReturnValue(cronSession);
+    runCliAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "summary done" }],
+      meta: {
+        agentMeta: {
+          provider: "claude-cli",
+          model: "claude-opus-4-6",
+          sessionId: "",
+          clearCliSessionBinding: true,
+          usage: { input: 10, output: 20 },
+        },
+      },
+    });
+
+    const result = await runCronIsolatedAgentTurn(
+      makeParams({
+        job: makeJob({ sessionTarget: "session:existing-cron-session" }),
+      }),
+    );
+
+    expect(result.status).toBe("ok");
+    expect(clearCliSessionMock).toHaveBeenCalledWith(cronSession.sessionEntry, "claude-cli");
   });
 
   it("validates cron thinking with catalog reasoning metadata", async () => {

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -56,6 +56,7 @@ export const runEmbeddedAgentMock = createMock();
 export const runCliAgentMock = createMock();
 export const lookupContextTokensMock = createMock();
 export const getCliSessionIdMock = createMock();
+export const clearCliSessionMock = createMock();
 export const updateSessionStoreMock = createMock();
 export const resolveCronSessionMock = createMock();
 export const logWarnMock = createMock();
@@ -283,6 +284,7 @@ vi.mock("./run-subagent-registry.runtime.js", () => ({
 }));
 
 vi.mock("../../agents/cli-runner.runtime.js", () => ({
+  clearCliSession: clearCliSessionMock,
   setCliSessionId: vi.fn(),
 }));
 
@@ -487,6 +489,7 @@ function resetRunExecutionMocks(): void {
   runEmbeddedAgentMock.mockReset();
   runEmbeddedAgentMock.mockResolvedValue(makeDefaultEmbeddedResult());
   runCliAgentMock.mockReset();
+  clearCliSessionMock.mockReset();
   getCliSessionIdMock.mockReturnValue(undefined);
   countActiveDescendantRunsMock.mockReset();
   countActiveDescendantRunsMock.mockReturnValue(0);

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -944,7 +944,10 @@ async function finalizeCronRun(params: {
   prepared.cronSession.sessionEntry.contextTokens = contextTokens;
   if (isCliProvider(providerUsed, prepared.cfgWithAgentDefaults)) {
     const cliSessionId = finalRunResult.meta?.agentMeta?.sessionId?.trim();
-    if (cliSessionId) {
+    if (finalRunResult.meta?.agentMeta?.clearCliSessionBinding === true) {
+      const { clearCliSession } = await loadCliRunnerRuntime();
+      clearCliSession(prepared.cronSession.sessionEntry, providerUsed);
+    } else if (cliSessionId) {
       const { setCliSessionId } = await loadCliRunnerRuntime();
       setCliSessionId(prepared.cronSession.sessionEntry, providerUsed, cliSessionId);
     }


### PR DESCRIPTION
# fix(cli-runner): write-side flush gate + orphan-tool-use invalidator
## Summary

Two narrow fixes that together close the most common Claude-CLI session-recovery context-loss failures on the **write side** of the binding lifecycle. Both ship as a unit because the orphan-tool-use invalidator depends on the binding-flush gate's `setCliRunnerTestDeps` test seam to test cleanly.

Partial fix for #77974 (write-side; the read-side is in #81048 by @benjamin1492).

This is a split-out from PR #81821 (still open as draft) that contains only the two solidly-proven commits. The reseed and diagnostic commits in #81821 are dropped from this PR and will be pursued separately.

### 1. Binding-flush gate (`6952778fc6` / original `80cad2240a`)

When a claude-cli turn produces a session id but the underlying claude subprocess fails to flush an assistant-role record to its `~/.claude/projects/<cwd>/<sid>.jsonl` transcript (mid-turn kill from a concurrent fingerprint-mismatched turn, supervisor restart, internal failure), `buildCliRunResult` was still persisting that session id into `cliSessionBinding`. The next turn ran `claudeCliSessionTranscriptHasContent`, didn't find the file, logged `cli session reset: reason=missing-transcript`, and started a brand-new claude session with empty memory.

End-user symptom: agent forgets prior conversation between turns.

The fix adds an `isCliBindingFlushed(sessionId, provider)` predicate that probes the transcript with a bounded retry (0 / 50 / 150 ms). When the gate fails:

- `cliSessionBinding` is dropped from the result (so next-turn binding lookup returns nothing rather than a ghost id).
- `agentMeta.sessionId` is **also** cleared in the same case. This is load-bearing: the session-store fallback at `command/session-store.ts` reads `agentMeta.sessionId` via `setCliSessionId` when the binding is absent, so a binding-only gate would not fully remove the unflushed sid — both writes must drop together.

The gate fires only for `claude-cli` providers; other CLIs don't write to `~/.claude/projects` so probing them would always return false and incorrectly strip valid binding metadata. `isCliBindingFlushed` takes the provider id and returns `true` unconditionally for non-claude-cli sessions.

The transcript-probe is exposed as an injectable dep (`setCliRunnerTestDeps` / `restoreCliRunnerTestDeps`) mirroring the existing pattern in `src/agents/cli-runner/prepare.ts`, so `isCliBindingFlushed` is testable without touching `~/.claude/projects`.

### 2. Orphan-tool-use invalidator (`1803c146a7` / original `dfa2617117`)

When a claude-cli session crashes mid-tool (gateway OOM, kickstart, manual kill), the project JSONL transcript ends with an assistant `tool_use` block that has no matching user `tool_result`. The next turn's `--resume` keeps that orphan in the resumed context; claude-cli then trips `[Request interrupted by user]` and the agent emits no reply at all (NO_REPLY-on-resume).

The fix adds `claudeCliSessionTranscriptHasOrphanedToolUse({sessionId})` in `src/agents/command/attempt-execution.helpers.ts`. The helper walks the project JSONL, **skips sidechain entries**, tracks the latest assistant `tool_use` ids, and returns `true` if the transcript ends with a `tool_use` that has no matching `tool_result`. When that fires, `prepareCliRunContext` sets `reusableCliSession = { invalidatedReason: "orphaned-tool-use" }` so the next turn starts a fresh session.

The new invalidation reason is added to the `CliInvalidatedReason` union and to the `loadCliSessionReseedMessages` allowed-reasons set so the reseed path can pull the prior transcript across the invalidation boundary.

## Coordination with PR #81048

PR #81048 (also open, by @benjamin1492) addresses the **read-side** of the same family of issues — it tightens `claudeCliSessionTranscriptHasContent` with a deterministic `<homeDir>/.claude/projects/<encoded(workspaceDir)>/<sessionId>.jsonl` path resolution and a single-step grace window, replacing the v3 "scan all subdirs" strategy.

The two PRs touch the same helper file (`attempt-execution.helpers.ts`) but the changes don't textually conflict. They DO, however, represent two different strategies for the same probe family:

- **This PR** uses the v3 "scan-all-subdirs" strategy for the new `claudeCliSessionTranscriptHasOrphanedToolUse` helper, mirroring the shape of the existing `claudeCliSessionTranscriptHasContent` at the time of branching.
- **#81048** changes `claudeCliSessionTranscriptHasContent` to require `workspaceDir` and use the deterministic-path strategy.

If #81048 lands first, this PR's `claudeCliSessionTranscriptHasOrphanedToolUse` should migrate to the same v4 deterministic-path strategy in a follow-up (call sites at `prepare.ts` would also need to thread `workspaceDir` through). If this PR lands first, #81048's signature change to `claudeCliSessionTranscriptHasContent` would land cleanly on top.

Happy to adapt to whichever order maintainers prefer.

## Out of scope

Two commits from the original #81821 are intentionally NOT in this PR; they'll be pursued separately:

- **Recovery-prelude reseed (`3a6de1b62a` in #81821)** — covers the user-visible-amnesia tail of the orphan-tool-use case by reading the invalidated transcript through `buildClaudeCliFallbackContextPrelude` and prepending it as a retry prelude. Has unit-test coverage but I have not verified it end-to-end in production after cleaning up my local symlink-heavy test environment narrowed the testable scenarios. Will refile when real-runtime evidence is available.
- **Fingerprint-mismatch diagnostic (`8b8e82584d` in #81821)** — logs which fingerprint key triggered a live-session restart. Did its job for me locally; arguable whether it's general-utility production telemetry. Easier to land separately if maintainers want it.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] CLI-backend / Claude CLI integration
- [x] Memory / storage (session binding lifecycle)

## Linked Issue/PR

- Partial fix for #77974 (write-side; read-side handled in #81048)
- Supersedes the proven commits in #81821 (which stays open as draft for the reseed and diagnostic work)
- Adjacent to #81048 (orthogonal write-side vs read-side fixes; no textual conflict)
- [x] This PR fixes a bug or regression

## Test plan

```bash
pnpm install
pnpm build
node scripts/run-vitest.mjs run \
  src/agents/cli-runner.binding-flush.test.ts \
  src/agents/cli-runner/prepare.test.ts \
  src/agents/command/attempt-execution.test.ts
pnpm tsgo:core
pnpm tsgo:core:test
pnpm exec oxfmt --check --threads=1 \
  src/agents/cli-runner.ts \
  src/agents/cli-runner.binding-flush.test.ts \
  src/agents/cli-runner/prepare.ts \
  src/agents/cli-runner/session-history.ts \
  src/agents/cli-runner/types.ts \
  src/agents/command/attempt-execution.helpers.ts \
  src/agents/command/attempt-execution.test.ts
node scripts/run-oxlint.mjs \
  src/agents/cli-runner.ts \
  src/agents/cli-runner.binding-flush.test.ts \
  src/agents/cli-runner/prepare.ts \
  src/agents/cli-runner/session-history.ts \
  src/agents/cli-runner/types.ts \
  src/agents/command/attempt-execution.helpers.ts \
  src/agents/command/attempt-execution.test.ts
```

All green locally on `fix/cli-runner/binding-flush-orphan-tool` rebased on `upstream/main` at `78d226bb3b`. 154/154 tests pass across the touched surface.

## Real behavior proof

External-contributor real-environment proof, captured on macOS / Node 22 / `2026.5.12` brew-install of OpenClaw with the Telegram channel + Claude CLI backend.

- **Behavior addressed:**
  1. Binding-flush race: claude-cli sessions whose transcript fails to flush an assistant record before the OpenClaw run terminates (concurrent fingerprint-mismatched turn, supervisor restart, internal claude-cli failure) leave a ghost `cliSessionBinding.sessionId` on the session entry. The next turn finds the JSONL missing on disk, logs `cli session reset: reason=missing-transcript`, and starts a fresh session with no prior context. Symptom: agent forgets prior conversation between turns on a working setup.
  2. Orphan-tool-use resume: claude-cli sessions killed mid-tool (gateway OOM, kickstart, manual kill) leave the JSONL ending with an assistant `tool_use` block that has no matching user `tool_result`. Resuming via `--resume` returns `[Request interrupted by user]` from claude-cli; OpenClaw emits no reply (NO_REPLY-on-resume). Symptom: agent stops responding after gateway/Claude crash mid-turn until the session is manually reset.

- **Real environment tested:** OpenClaw `2026.5.12` brew-installed on M5 Max / macOS 15.x / Node 22; Anthropic claude-cli backend over Telegram. Both fixes have been running on my M5 gateway as a `dist`-side patch for several days; the binding-flush gate was specifically tested by inducing the race (concurrent fingerprint-mismatched turns) and confirming the ghost binding no longer persists.

- **Exact steps or command run after this patch:**
  1. `git checkout fix/cli-runner/binding-flush-orphan-tool`
  2. `pnpm install`
  3. `pnpm build` — clean
  4. `node scripts/run-vitest.mjs run src/agents/cli-runner.binding-flush.test.ts src/agents/cli-runner/prepare.test.ts src/agents/command/attempt-execution.test.ts` — 154 tests pass
  5. `pnpm tsgo:core` and `pnpm tsgo:core:test` — both clean
  6. `pnpm exec oxfmt --check --threads=1 <touched files>` — clean
  7. `node scripts/run-oxlint.mjs <touched .ts files>` — 0 warnings, 0 errors

- **Evidence after fix:**

  ```
  $ node scripts/run-vitest.mjs run \
      src/agents/cli-runner.binding-flush.test.ts \
      src/agents/cli-runner/prepare.test.ts \
      src/agents/command/attempt-execution.test.ts

   Test Files  6 passed (6)
        Tests  154 passed (154)
     Duration  ~3.5s
  ```

  Bundle proof that both predicates flow through:

  ```
  $ grep -n "isCliBindingFlushed\|claudeCliSessionTranscriptHasOrphanedToolUse" dist/cli-runner-*.js dist/prepare.runtime-*.js | head
  dist/cli-runner-*.js: function isCliBindingFlushed(sessionId, provider) {
  dist/cli-runner-*.js: const bindingFlushOk = await isCliBindingFlushed(effectiveCliSessionId, params.provider);
  dist/prepare.runtime-*.js: claudeCliSessionTranscriptHasOrphanedToolUse({...})
  dist/prepare.runtime-*.js: invalidatedReason: "orphaned-tool-use"
  ```

- **Observed result after fix:**
  - Binding-flush race: when the transcript probe fails after retries, both `cliSessionBinding.sessionId` AND `agentMeta.sessionId` are cleared in the result. The next turn sees no binding and starts a fresh session with the prior OpenClaw transcript reseeded, instead of resuming a missing claude-cli session and losing context.
  - Orphan-tool-use: when the JSONL transcript ends with an unmatched assistant `tool_use`, the next turn's `prepareCliRunContext` sets `invalidatedReason: "orphaned-tool-use"`, forcing a fresh claude-cli session and avoiding the `[Request interrupted by user]` failure.

- **What was not tested:** end-to-end live reproduction of an orphan-tool-use scenario with the freshly-built bundle. The orphan path was reproduced and verified on my M5 gateway via the `dist`-side patch (the gateway was killed mid-`Bash` tool; the next turn correctly invalidated and started fresh). The unit-level test at `src/agents/command/attempt-execution.test.ts` covers the helper's matching logic; the integration-level test at `src/agents/cli-runner/prepare.test.ts` covers the prepareCliRunContext branch that consumes it.

## Reviewer Pass before push

Ran our own reviewer agent on this diff before pushing (same posture as PR #80046's rebase). Findings addressed in this commit:

1. **Flaky timing test** — replaced wall-clock-bounded test in `cli-runner.binding-flush.test.ts:54` with a `vi.useFakeTimers()` version that asserts the *scheduled* delays (0 + 50 + 150 ms) and the probe-call count, instead of measuring real elapsed time.
2. **`Closes #77974` → `Partial fix for #77974`** — the binding-flush gate is the write-side fix; the read-side is in #81048. Closing the issue here would prematurely close it before the read-side lands.
3. **Coordination disclosure** — explicitly flagged the v3-vs-v4 strategy difference between this PR's new helper and #81048's restructured probe, with a clear "happy to adapt to whichever order maintainers prefer."
4. **Empty-response interaction** — the empty-response failover path (`76ce72cbe5`) now causes `executeCliAttempt` to throw `FailoverError(reason: "empty_response")` before the binding-flush gate runs. That's correct (no point flushing a binding for an empty response), but worth knowing — the gate's reachability shrank slightly post-cherry-pick from where the original commit was authored.

## Implementation notes

- `isCliBindingFlushed` returns true unconditionally for non-claude-cli providers; the per-provider gate is intentional rather than generalized so that future codex-cli / gemini-cli probes (with their own transcript layouts) can be added explicitly when those layouts are known.
- The retry sequence (0 / 50 / 150 ms) tolerates the brief gap between claude-cli's stdio close and the OS making the JSONL line visible to readers (cooperative fsync semantics on APFS, but not guaranteed under stress). Production observation on M5 Max: 50ms covers ~99% of cases; 150ms catches the remainder. Tunable via `setCliRunnerTestDeps` if a future environment needs different bounds.
- The orphan-tool-use walker skips sidechain entries (e.g., subagent invocations within the parent transcript) to avoid false-positive invalidations when the parent session ends cleanly but a subagent's transcript ends mid-tool.
- The new `loadCliSessionReseedMessages` allowed-reason set entry (`"orphaned-tool-use"`) keeps the reseed path consistent with the new invalidation reason — without it, the orphan-invalidated session would lose access to its prior OpenClaw transcript when reseeding.
