### PR TITLE
fix(twitch): export clearRegistryForTest for cross-test isolation (#83887)

### DIFF
--- a/extensions/twitch/src/client-manager-registry.ts
+++ b/extensions/twitch/src/client-manager-registry.ts
@@ -85,3 +85,20 @@ export async function removeClientManager(accountId: string): Promise<void> {
   registry.delete(accountId);
   entry.logger.info(`Unregistered client manager for account: ${accountId}`);
 }
+
+/**
+ * Test-only: clear the module-level registry of all client manager entries.
+ *
+ * Mirrors the `clearForTest` escape hatch on `TwitchClientManager`. Without
+ * this, the module-level `registry` Map survives across tests when vitest
+ * is run with `--isolate=false` (or any harness that does not tear the
+ * module graph down between cases), and a stale entry from one test will
+ * shadow `getOrCreateClientManager` calls in subsequent tests — silently
+ * handing back another test's mocked logger/manager. See #83887.
+ *
+ * Production code MUST NOT call this. It is safe to call when the registry
+ * is empty (clear() is a no-op on an empty Map).
+ */
+export function clearRegistryForTest(): void {
+  registry.clear();
+}


### PR DESCRIPTION
Fixes #83887.

`extensions/twitch/src/client-manager-registry.ts` holds `const registry = new Map<string, RegistryEntry>()` at module scope. The companion class `TwitchClientManager` (`twitch-client.ts:272`) already exports `clearForTest()` — an explicit acknowledgement that module-level state needs to be reset between tests. The registry has no such escape hatch.

Under vitest `--isolate=false` (or any harness that keeps the module graph hot across cases), a test that calls `getOrCreateClientManager('default', loggerA)` leaves its entry behind. The next test calling `getOrCreateClientManager('default', loggerB)` hits the cache branch (`if (existing) return existing.manager`) and silently receives test A's manager — bound to test A's logger, mocks, and assertion targets. The bug is latent today only because the included tests mock at the `resolveTwitchAccountContext` level and never exercise the registry factory directly. Any test that does will chase a phantom mock-assertion failure.

## Changes

- `extensions/twitch/src/client-manager-registry.ts`: add an exported `clearRegistryForTest(): void { registry.clear(); }`. Mirrors the existing `clearForTest` escape hatch on `TwitchClientManager` (same module convention, same naming). Documented as test-only with a comment explaining the `--isolate=false` failure mode.

Diff stat: 1 file, +17 / -0. No production code is touched and no production caller is added.

## Real behavior proof

- **Behavior or issue addressed:** Sanitized issue evidence — the registry Map is module-scoped and survives across vitest cases unless explicitly cleared. `getOrCreateClientManager` short-circuits on `registry.get(accountId)` without comparing logger identity or any other freshness signal, so a stale entry from a prior test wins. The new helper gives a test's `afterEach` a way to reset the registry without resorting to `vi.resetModules()`.

- **Real environment tested:** Local Node 22.x. Probe at `/tmp/probe_83887.mjs` does both halves of the proof. (a) Parses the patched `client-manager-registry.ts` and verifies `clearRegistryForTest` is exported with the exact body `registry.clear()` and that it is declared AFTER the module-level `registry` definition. (b) Replays the registry's get-or-create semantics in pure JS for four scenarios — buggy shape (no clear between tests → test B receives test A's manager+logger, confirming the #83887 symptom), patched shape with clear-between-tests (test B gets a fresh manager with loggerB), production cache-hit within a single test (same accountId returns cached manager — no regression), and clear-on-empty (safe no-op).

- **Exact steps or command run after this patch:** `node /tmp/probe_83887.mjs`

- **Evidence after fix:**

```
PASS: clearRegistryForTest is exported and calls registry.clear()
PASS: clearRegistryForTest is declared AFTER the module-level registry
PASS: replay (buggy): without registry clear, test B receives test A's manager+logger — confirms #83887 cross-test pollution
PASS: replay (patched): clear between tests → test B gets fresh manager with loggerB
PASS: replay (production cache-hit within a single test): same accountId returns the cached manager — no regression
PASS: replay (patched, empty registry): clear() on empty Map is a safe no-op

ALL CASES PASS
```

- **Observed result after fix:** Any test file exercising `getOrCreateClientManager` can now call `clearRegistryForTest()` in `afterEach` (mirroring the pattern `twitch-client.test.ts:131` already uses for `manager.clearForTest()`). Production behavior is unchanged because production code does not import the new export.

- **What was not tested:** A live vitest `--isolate=false` run inside the repo CI — the harness setup for that is outside the scope of an additive test-helper export. The vitest case shape this enables is identical to the existing `clearForTest` pattern proven elsewhere in the same module.

## Audit (per CLAUDE rules — all 5 steps)

- **Existing-helper check:** Mirrors the already-exported `TwitchClientManager.clearForTest()` (`twitch-client.ts:272-275`) — same module convention. The issue's `_clearRegistryForTest` naming with underscore prefix would have diverged from the live codebase; I used `clearRegistryForTest` to match the sibling. PASS
- **Shared-helper caller check:** `clearRegistryForTest` has zero callers initially — it is a test-only export. Production code (`monitor.ts`, `send.ts`, `plugin.ts`) imports only `getOrCreateClientManager` / `getClientManager` / `removeClientManager`, none of which are affected by adding a new export. PASS
- **Broader-fix rival scan:** `gh pr list --search '83887 in:title,body'` and `gh pr list --search 'clearRegistryForTest in:title,body'` return no open PRs. Issue timeline shows zero cross-references. PASS
- **Recent-merge audit:** `git log --oneline -5 -- extensions/twitch/src/client-manager-registry.ts` shows no recent commits touching this file. PASS
- **Prototype-pollution scan:** N/A — single `Map.clear()` call.
