### PR TITLE
[codex] isolate heartbeat context-engine session keys

### DIFF
--- a/extensions/codex/src/app-server/compact.test.ts
+++ b/extensions/codex/src/app-server/compact.test.ts
@@ -516,6 +516,60 @@ describe("maybeCompactCodexAppServerSession", () => {
     );
   });
 
+  it("prefers contextEngineSessionKey for owning Codex context-engine compaction", async () => {
+    const sessionFile = await writeTestBinding();
+    const compact = vi.fn(async () => ({
+      ok: true,
+      compacted: true,
+      result: {
+        summary: "engine summary",
+        firstKeptEntryId: "entry-1",
+        tokensBefore: 55,
+      },
+    }));
+    const maintain = vi.fn(async () => ({
+      changed: false,
+      bytesFreed: 0,
+      rewrittenEntries: 0,
+    }));
+    const contextEngine: ContextEngine = {
+      info: { id: "lossless-claw", name: "Lossless Claw", ownsCompaction: true },
+      assemble: vi.fn() as never,
+      ingest: vi.fn() as never,
+      compact,
+      maintain,
+    };
+
+    await maybeCompactCodexAppServerSession({
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1",
+      contextEngineSessionKey: "agent:main:session-1:heartbeat-run:codex",
+      sessionFile,
+      workspaceDir: tempDir,
+      contextEngine,
+      contextTokenBudget: 777,
+      contextEngineRuntimeContext: { workspaceDir: tempDir, provider: "codex" },
+      currentTokenCount: 123,
+      trigger: "manual",
+    });
+
+    expect(compact).toHaveBeenCalledWith({
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1:heartbeat-run:codex",
+      sessionFile,
+      tokenBudget: 777,
+      currentTokenCount: 123,
+      compactionTarget: "threshold",
+      customInstructions: undefined,
+      force: true,
+      runtimeContext: { workspaceDir: tempDir, provider: "codex" },
+    });
+    const [maintainCall] = maintain.mock.calls[0] ?? [];
+    expect((maintainCall as { sessionKey?: string } | undefined)?.sessionKey).toBe(
+      "agent:main:session-1:heartbeat-run:codex",
+    );
+  });
+
   it("adopts successor transcript handles after owning context-engine compaction", async () => {
     const sessionFile = await writeTestBinding();
     const successorFile = path.join(tempDir, "session.compacted.jsonl");

--- a/extensions/codex/src/app-server/compact.test.ts
+++ b/extensions/codex/src/app-server/compact.test.ts
@@ -476,7 +476,7 @@ describe("maybeCompactCodexAppServerSession", () => {
       }),
     );
     expect(maintain).toHaveBeenCalledTimes(1);
-    const [maintainCall] = maintain.mock.calls[0] ?? [];
+    const maintainCall = maintain.mock.calls[0]?.[0];
     const maintainParams = maintainCall as
       | {
           sessionId?: string;
@@ -553,18 +553,20 @@ describe("maybeCompactCodexAppServerSession", () => {
       trigger: "manual",
     });
 
-    expect(compact).toHaveBeenCalledWith({
-      sessionId: "session-1",
-      sessionKey: "agent:main:session-1:heartbeat-run:codex",
-      sessionFile,
-      tokenBudget: 777,
-      currentTokenCount: 123,
-      compactionTarget: "threshold",
-      customInstructions: undefined,
-      force: true,
-      runtimeContext: { workspaceDir: tempDir, provider: "codex" },
-    });
-    const [maintainCall] = maintain.mock.calls[0] ?? [];
+    expect(compact).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: "session-1",
+        sessionKey: "agent:main:session-1:heartbeat-run:codex",
+        sessionFile,
+        tokenBudget: 777,
+        currentTokenCount: 123,
+        compactionTarget: "threshold",
+        customInstructions: undefined,
+        force: true,
+        runtimeContext: { workspaceDir: tempDir, provider: "codex" },
+      }),
+    );
+    const maintainCall = maintain.mock.calls[0]?.[0];
     expect((maintainCall as { sessionKey?: string } | undefined)?.sessionKey).toBe(
       "agent:main:session-1:heartbeat-run:codex",
     );
@@ -620,7 +622,7 @@ describe("maybeCompactCodexAppServerSession", () => {
     expect(await readCodexAppServerBinding(sessionFile)).toBeUndefined();
     expect(await readCodexAppServerBinding(successorFile)).toBeUndefined();
     expect(maintain).toHaveBeenCalledTimes(1);
-    const [maintainCall] = maintain.mock.calls[0] ?? [];
+    const maintainCall = maintain.mock.calls[0]?.[0];
     const maintainParams = maintainCall as
       | {
           sessionId?: string;

--- a/extensions/codex/src/app-server/compact.test.ts
+++ b/extensions/codex/src/app-server/compact.test.ts
@@ -527,7 +527,7 @@ describe("maybeCompactCodexAppServerSession", () => {
         tokensBefore: 55,
       },
     }));
-    const maintain = vi.fn(async () => ({
+    const maintain = vi.fn(async (_params: unknown) => ({
       changed: false,
       bytesFreed: 0,
       rewrittenEntries: 0,

--- a/extensions/codex/src/app-server/compact.ts
+++ b/extensions/codex/src/app-server/compact.ts
@@ -31,6 +31,13 @@ type CodexNativeCompactionWaiter = {
 const DEFAULT_CODEX_COMPACTION_WAIT_TIMEOUT_MS = 5 * 60 * 1000;
 const warnedIgnoredCompactionOverrides = new Set<string>();
 
+function resolveContextEngineSessionKey(params: {
+  sessionKey?: string;
+  contextEngineSessionKey?: string;
+}): string | undefined {
+  return params.contextEngineSessionKey?.trim() || params.sessionKey?.trim() || undefined;
+}
+
 export async function maybeCompactCodexAppServerSession(
   params: CompactEmbeddedPiSessionParams,
   options: { pluginConfig?: unknown; clientFactory?: CodexAppServerClientFactory } = {},
@@ -48,7 +55,7 @@ export async function maybeCompactCodexAppServerSession(
       await runHarnessContextEngineMaintenance({
         contextEngine: activeContextEngine,
         sessionId: params.sessionId,
-        sessionKey: params.sessionKey,
+        sessionKey: resolveContextEngineSessionKey(params),
         sessionFile: params.sessionFile,
         reason: "compaction",
         runtimeContext: params.contextEngineRuntimeContext,
@@ -90,7 +97,7 @@ async function compactOwningContextEngine(
       contextEngine,
       {
         sessionId: params.sessionId,
-        sessionKey: params.sessionKey,
+        sessionKey: resolveContextEngineSessionKey(params),
         sessionFile: params.sessionFile,
         tokenBudget: params.contextTokenBudget,
         currentTokenCount: params.currentTokenCount,
@@ -123,7 +130,7 @@ async function compactOwningContextEngine(
       await runHarnessContextEngineMaintenance({
         contextEngine,
         sessionId: compactedSessionId,
-        sessionKey: params.sessionKey,
+        sessionKey: resolveContextEngineSessionKey(params),
         sessionFile: compactedSessionFile,
         reason: "compaction",
         runtimeContext: params.contextEngineRuntimeContext,

--- a/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
@@ -348,6 +348,34 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
     expect(openSpy).not.toHaveBeenCalled();
   });
 
+  it("prefers contextEngineSessionKey for Codex bootstrap and assemble", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    SessionManager.open(sessionFile).appendMessage(
+      assistantMessage("existing context", Date.now()) as never,
+    );
+    const contextEngine = createContextEngine();
+    const harness = createStartedThreadHarness();
+    const params = createParams(sessionFile, workspaceDir);
+    params.contextEngine = contextEngine;
+    params.contextEngineSessionKey = "agent:main:session-1:heartbeat-run:codex";
+
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("turn/start");
+    await harness.completeTurn();
+    await run;
+
+    const bootstrapParams = requireFirstCallArg(contextEngine.bootstrap, "bootstrap") as Parameters<
+      NonNullable<ContextEngine["bootstrap"]>
+    >[0];
+    expect(bootstrapParams.sessionKey).toBe("agent:main:session-1:heartbeat-run:codex");
+
+    const assembleParams = requireFirstCallArg(contextEngine.assemble, "assemble") as Parameters<
+      ContextEngine["assemble"]
+    >[0];
+    expect(assembleParams.sessionKey).toBe("agent:main:session-1:heartbeat-run:codex");
+  });
+
   it("uses the runtime token budget for large Codex context-engine projections", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
@@ -784,6 +812,7 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
     const params = createParams(sessionFile, workspaceDir);
     params.contextEngine = contextEngine;
     params.contextTokenBudget = 400_000;
+    params.contextEngineSessionKey = "agent:main:session-1:heartbeat-run:codex";
 
     const run = runCodexAppServerAttempt(params);
     await vi.waitFor(() =>
@@ -812,7 +841,7 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
     expect(compact).toHaveBeenCalledWith(
       expect.objectContaining({
         sessionId: "session-1",
-        sessionKey: "agent:main:session-1",
+        sessionKey: "agent:main:session-1:heartbeat-run:codex",
         sessionFile,
         tokenBudget: 400_000,
         currentTokenCount: 400_000,
@@ -995,6 +1024,35 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
     expect(afterTurnCall.messages.some((message) => message.role === "user")).toBe(true);
     expect(afterTurnCall.messages.some((message) => message.role === "assistant")).toBe(true);
     expect(maintain).toHaveBeenCalledTimes(1);
+  });
+
+  it("prefers contextEngineSessionKey for Codex afterTurn and maintenance", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const afterTurn = vi.fn(
+      async (_params: Parameters<NonNullable<ContextEngine["afterTurn"]>>[0]) => undefined,
+    );
+    const maintain = vi.fn(async () => ({ changed: false, bytesFreed: 0, rewrittenEntries: 0 }));
+    const contextEngine = createContextEngine({ afterTurn, maintain, bootstrap: undefined });
+    const harness = createStartedThreadHarness();
+    const params = createParams(sessionFile, workspaceDir);
+    params.contextEngine = contextEngine;
+    params.contextTokenBudget = 111;
+    params.contextEngineSessionKey = "agent:main:session-1:heartbeat-run:codex";
+
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("turn/start");
+    await harness.completeTurn();
+    await run;
+
+    const afterTurnCall = requireFirstCallArg(afterTurn, "afterTurn") as Parameters<
+      NonNullable<ContextEngine["afterTurn"]>
+    >[0];
+    expect(afterTurnCall.sessionKey).toBe("agent:main:session-1:heartbeat-run:codex");
+    const maintainCall = requireFirstCallArg(maintain, "maintain") as Parameters<
+      NonNullable<ContextEngine["maintain"]>
+    >[0];
+    expect(maintainCall.sessionKey).toBe("agent:main:session-1:heartbeat-run:codex");
   });
 
   it("reloads mirrored history after bootstrap mutates the session transcript", async () => {

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -804,6 +804,7 @@ export async function runCodexAppServerAttempt(
   await fs.mkdir(resolvedWorkspace, { recursive: true });
   const sandboxSessionKey =
     params.sandboxSessionKey?.trim() || params.sessionKey?.trim() || params.sessionId;
+  const contextEngineSessionKey = params.contextEngineSessionKey?.trim() || sandboxSessionKey;
   const sandbox = await resolveSandboxContext({
     config: params.config,
     sessionKey: sandboxSessionKey,
@@ -997,6 +998,7 @@ export async function runCodexAppServerAttempt(
       contextEngine: activeContextEngine,
       sessionId: activeSessionId,
       sessionKey: sandboxSessionKey,
+      contextEngineSessionKey,
       sessionFile: activeSessionFile,
       runtimeContext: buildActiveContextEngineRuntimeContext(),
       runMaintenance: runHarnessContextEngineMaintenance,
@@ -1044,6 +1046,7 @@ export async function runCodexAppServerAttempt(
       contextEngine: activeContextEngine,
       sessionId: activeSessionId,
       sessionKey: sandboxSessionKey,
+      contextEngineSessionKey,
       messages: historyMessages,
       tokenBudget: params.contextTokenBudget,
       availableTools: new Set(toolBridge.specs.map((tool) => tool.name).filter(isNonEmptyString)),
@@ -2250,7 +2253,7 @@ export async function runCodexAppServerAttempt(
         activeContextEngine,
         {
           sessionId: activeSessionId,
-          sessionKey: sandboxSessionKey,
+          sessionKey: contextEngineSessionKey,
           sessionFile: activeSessionFile,
           tokenBudget: params.contextTokenBudget,
           force: true,
@@ -2284,7 +2287,7 @@ export async function runCodexAppServerAttempt(
       await runHarnessContextEngineMaintenance({
         contextEngine: activeContextEngine,
         sessionId: activeSessionId,
-        sessionKey: sandboxSessionKey,
+        sessionKey: contextEngineSessionKey,
         sessionFile: activeSessionFile,
         reason: "compaction",
         runtimeContext: maintenanceRuntimeContext,
@@ -2693,6 +2696,7 @@ export async function runCodexAppServerAttempt(
         yieldAborted: Boolean(result.yieldDetected),
         sessionIdUsed: activeSessionId,
         sessionKey: sandboxSessionKey,
+        contextEngineSessionKey,
         sessionFile: activeSessionFile,
         messagesSnapshot: finalMessages,
         prePromptMessageCount,

--- a/src/agents/harness/context-engine-lifecycle.ts
+++ b/src/agents/harness/context-engine-lifecycle.ts
@@ -19,6 +19,7 @@ export async function bootstrapHarnessContextEngine(params: {
   contextEngine?: HarnessContextEngine;
   sessionId: string;
   sessionKey?: string;
+  contextEngineSessionKey?: string;
   sessionFile: string;
   sessionManager?: unknown;
   runtimeContext?: ContextEngineRuntimeContext;
@@ -36,14 +37,14 @@ export async function bootstrapHarnessContextEngine(params: {
     if (typeof params.contextEngine?.bootstrap === "function") {
       await params.contextEngine.bootstrap({
         sessionId: params.sessionId,
-        sessionKey: params.sessionKey,
+        sessionKey: params.contextEngineSessionKey ?? params.sessionKey,
         sessionFile: params.sessionFile,
       });
     }
     await (params.runMaintenance ?? runHarnessContextEngineMaintenance)({
       contextEngine: params.contextEngine,
       sessionId: params.sessionId,
-      sessionKey: params.sessionKey,
+      sessionKey: params.contextEngineSessionKey ?? params.sessionKey,
       sessionFile: params.sessionFile,
       reason: "bootstrap",
       sessionManager: params.sessionManager,
@@ -62,6 +63,7 @@ export async function assembleHarnessContextEngine(params: {
   contextEngine?: HarnessContextEngine;
   sessionId: string;
   sessionKey?: string;
+  contextEngineSessionKey?: string;
   messages: AgentMessage[];
   tokenBudget?: number;
   availableTools?: Set<string>;
@@ -75,7 +77,7 @@ export async function assembleHarnessContextEngine(params: {
   const messages = stripRuntimeContextCustomMessages(params.messages);
   return await params.contextEngine.assemble({
     sessionId: params.sessionId,
-    sessionKey: params.sessionKey,
+    sessionKey: params.contextEngineSessionKey ?? params.sessionKey,
     messages,
     tokenBudget: params.tokenBudget,
     ...(params.availableTools ? { availableTools: params.availableTools } : {}),
@@ -95,6 +97,7 @@ export async function finalizeHarnessContextEngineTurn(params: {
   yieldAborted: boolean;
   sessionIdUsed: string;
   sessionKey?: string;
+  contextEngineSessionKey?: string;
   sessionFile: string;
   messagesSnapshot: AgentMessage[];
   prePromptMessageCount: number;
@@ -119,7 +122,7 @@ export async function finalizeHarnessContextEngineTurn(params: {
     try {
       await params.contextEngine.afterTurn({
         sessionId: params.sessionIdUsed,
-        sessionKey: params.sessionKey,
+        sessionKey: params.contextEngineSessionKey ?? params.sessionKey,
         sessionFile: params.sessionFile,
         messages: conversationSnapshot.messages,
         prePromptMessageCount: conversationSnapshot.prePromptMessageCount,
@@ -139,7 +142,7 @@ export async function finalizeHarnessContextEngineTurn(params: {
         try {
           await params.contextEngine.ingestBatch({
             sessionId: params.sessionIdUsed,
-            sessionKey: params.sessionKey,
+            sessionKey: params.contextEngineSessionKey ?? params.sessionKey,
             messages: newMessages,
           });
         } catch (ingestErr) {
@@ -151,7 +154,7 @@ export async function finalizeHarnessContextEngineTurn(params: {
           try {
             await params.contextEngine.ingest?.({
               sessionId: params.sessionIdUsed,
-              sessionKey: params.sessionKey,
+              sessionKey: params.contextEngineSessionKey ?? params.sessionKey,
               message: msg,
             });
           } catch (ingestErr) {
@@ -172,7 +175,7 @@ export async function finalizeHarnessContextEngineTurn(params: {
     await (params.runMaintenance ?? runHarnessContextEngineMaintenance)({
       contextEngine: params.contextEngine,
       sessionId: params.sessionIdUsed,
-      sessionKey: params.sessionKey,
+      sessionKey: params.contextEngineSessionKey ?? params.sessionKey,
       sessionFile: params.sessionFile,
       reason: "turn",
       sessionManager: params.sessionManager,

--- a/src/agents/pi-embedded-runner/compact.queued.ts
+++ b/src/agents/pi-embedded-runner/compact.queued.ts
@@ -193,7 +193,7 @@ export async function compactEmbeddedPiSession(
             contextEngine,
             {
               sessionId: params.sessionId,
-              sessionKey: params.sessionKey,
+              sessionKey: params.contextEngineSessionKey ?? params.sessionKey,
               sessionFile: params.sessionFile,
               tokenBudget: contextTokenBudget,
               currentTokenCount: params.currentTokenCount,
@@ -276,7 +276,7 @@ export async function compactEmbeddedPiSession(
           await runContextEngineMaintenance({
             contextEngine,
             sessionId: postCompactionSessionId,
-            sessionKey: params.sessionKey,
+            sessionKey: params.contextEngineSessionKey ?? params.sessionKey,
             sessionFile: postCompactionSessionFile,
             reason: "compaction",
             runtimeContext,
@@ -385,7 +385,7 @@ function buildCompactionContextEngineRuntimeContext(params: {
     }),
     ...resolveContextEngineCapabilities({
       config: params.params.config,
-      sessionKey: params.params.sessionKey,
+      sessionKey: params.params.contextEngineSessionKey ?? params.params.sessionKey,
       agentId: sessionAgentId,
       contextEnginePluginId: params.contextEnginePluginId,
       purpose: "context-engine.compaction",

--- a/src/agents/pi-embedded-runner/compact.types.ts
+++ b/src/agents/pi-embedded-runner/compact.types.ts
@@ -11,6 +11,8 @@ export type CompactEmbeddedPiSessionParams = {
   sessionId: string;
   runId?: string;
   sessionKey?: string;
+  /** Optional context-engine-only identity. Defaults to sessionKey. */
+  contextEngineSessionKey?: string;
   /** Session key used only for runtime policy/sandbox resolution. Defaults to sessionKey. */
   sandboxSessionKey?: string;
   messageChannel?: string;

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
@@ -51,6 +51,7 @@ function makeForwardingCase(internalEvents: AgentInternalEvent[]) {
       ownerOnlyToolAllowlist: ["cron"],
       bootstrapContextMode: "lightweight",
       bootstrapContextRunKind: "cron",
+      contextEngineSessionKey: "agent:main:test-key:heartbeat-run:test-session",
       disableMessageTool: true,
       forceMessageTool: true,
       requireExplicitMessageTarget: true,
@@ -61,6 +62,7 @@ function makeForwardingCase(internalEvents: AgentInternalEvent[]) {
       ownerOnlyToolAllowlist: ["cron"],
       bootstrapContextMode: "lightweight",
       bootstrapContextRunKind: "cron",
+      contextEngineSessionKey: "agent:main:test-key:heartbeat-run:test-session",
       disableMessageTool: true,
       forceMessageTool: true,
       requireExplicitMessageTarget: true,
@@ -1621,6 +1623,40 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
     expectRecordFields(maintenanceParams.runtimeContext, {
       trigger: "overflow",
       authProfileId: "test-profile",
+    });
+  });
+
+  it("uses contextEngineSessionKey for overflow compaction and maintenance", async () => {
+    const contextEngineSessionKey = "agent:main:test-key:heartbeat-run:test-session";
+    mockedContextEngine.info.ownsCompaction = true;
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: makeOverflowError() }))
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+    mockedCompactDirect.mockResolvedValueOnce({
+      ok: true,
+      compacted: true,
+      result: {
+        summary: "engine-owned compaction",
+        tokensAfter: 50,
+      },
+    });
+
+    await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      contextEngineSessionKey,
+    });
+
+    expectMockCallFields(mockedCompactDirect, {
+      sessionId: "test-session",
+      sessionKey: contextEngineSessionKey,
+      sessionFile: "/tmp/session.json",
+    });
+    expectMockCallFields(mockedRunContextEngineMaintenance, {
+      contextEngine: mockedContextEngine,
+      sessionId: "test-session",
+      sessionKey: contextEngineSessionKey,
+      sessionFile: "/tmp/session.json",
+      reason: "compaction",
     });
   });
 

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1179,6 +1179,7 @@ export async function runEmbeddedPiAgent(
         workspaceDir: resolvedWorkspace,
       });
       const contextEnginePluginId = resolveContextEngineOwnerPluginId(contextEngine);
+      const contextEngineSessionKey = params.contextEngineSessionKey?.trim() || resolvedSessionKey;
       startupStages.mark("context-engine");
       notifyExecutionPhase("context_engine", { provider, model: modelId });
       try {
@@ -1415,6 +1416,7 @@ export async function runEmbeddedPiAgent(
             config: params.config,
             allowGatewaySubagentBinding: params.allowGatewaySubagentBinding,
             contextEngine,
+            contextEngineSessionKey,
             contextTokenBudget: ctxInfo.tokens,
             contextWindowInfo: ctxInfo,
             skillsSnapshot: params.skillsSnapshot,
@@ -1754,7 +1756,7 @@ export async function runEmbeddedPiAgent(
                   }),
                   ...resolveContextEngineCapabilities({
                     config: params.config,
-                    sessionKey: params.sessionKey,
+                    sessionKey: contextEngineSessionKey,
                     agentId: sessionAgentId,
                     contextEnginePluginId,
                     purpose: "context-engine.timeout-compaction",
@@ -1776,7 +1778,7 @@ export async function runEmbeddedPiAgent(
                   contextEngine,
                   {
                     sessionId: activeSessionId,
-                    sessionKey: params.sessionKey,
+                    sessionKey: contextEngineSessionKey,
                     sessionFile: activeSessionFile,
                     tokenBudget: ctxInfo.tokens,
                     force: true,
@@ -1936,7 +1938,7 @@ export async function runEmbeddedPiAgent(
                   }),
                   ...resolveContextEngineCapabilities({
                     config: params.config,
-                    sessionKey: params.sessionKey,
+                    sessionKey: contextEngineSessionKey,
                     agentId: sessionAgentId,
                     contextEnginePluginId,
                     purpose: "context-engine.overflow-compaction",
@@ -1961,7 +1963,7 @@ export async function runEmbeddedPiAgent(
                   contextEngine,
                   {
                     sessionId: activeSessionId,
-                    sessionKey: params.sessionKey,
+                    sessionKey: contextEngineSessionKey,
                     sessionFile: activeSessionFile,
                     tokenBudget: ctxInfo.tokens,
                     ...(observedOverflowTokens !== undefined
@@ -1979,7 +1981,7 @@ export async function runEmbeddedPiAgent(
                   await runContextEngineMaintenance({
                     contextEngine,
                     sessionId: activeSessionId,
-                    sessionKey: params.sessionKey,
+                    sessionKey: contextEngineSessionKey,
                     sessionFile: activeSessionFile,
                     reason: "compaction",
                     runtimeContext: overflowCompactionRuntimeContext,

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -1203,6 +1203,31 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     expectCalledWithSessionKey(afterTurn, sessionKey);
   });
 
+  it("prefers contextEngineSessionKey over sessionKey for lifecycle hooks", async () => {
+    const contextEngineSessionKey = `${sessionKey}:heartbeat-run:test-session`;
+    const { bootstrap, assemble } = createContextEngineBootstrapAndAssemble();
+    const afterTurn = vi.fn(async (_params: { sessionKey?: string }) => {});
+    const contextEngine = createTestContextEngine({
+      bootstrap,
+      assemble,
+      afterTurn,
+    });
+
+    await runBootstrap(sessionKey, contextEngine, { contextEngineSessionKey });
+    await runAssemble(sessionKey, contextEngine, { contextEngineSessionKey });
+    await finalizeTurn(sessionKey, contextEngine, { contextEngineSessionKey });
+
+    expectCalledWithSessionKey(bootstrap, contextEngineSessionKey);
+    expectCalledWithSessionKey(assemble, contextEngineSessionKey);
+    expectCalledWithSessionKey(afterTurn, contextEngineSessionKey);
+    expect(
+      hoisted.runContextEngineMaintenanceMock.mock.calls.every(
+        ([params]) =>
+          requireRecord(params, "maintenance params").sessionKey === contextEngineSessionKey,
+      ),
+    ).toBe(true);
+  });
+
   it("resolves bootstrap context before acquiring the session write lock", async () => {
     const events: string[] = [];
     hoisted.resolveBootstrapContextForRunMock.mockImplementation(async () => {
@@ -1301,6 +1326,28 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     expectCalledWithSessionKey(ingestBatch, sessionKey);
   });
 
+  it("prefers contextEngineSessionKey for ingestBatch fallback and maintenance", async () => {
+    const contextEngineSessionKey = `${sessionKey}:heartbeat-run:test-session`;
+    const { bootstrap, assemble } = createContextEngineBootstrapAndAssemble();
+    const ingestBatch = vi.fn(
+      async (_params: { sessionKey?: string; messages: AgentMessage[] }) => ({ ingestedCount: 1 }),
+    );
+
+    await finalizeTurn(sessionKey, createTestContextEngine({ bootstrap, assemble, ingestBatch }), {
+      contextEngineSessionKey,
+      messagesSnapshot: [seedMessage, doneMessage],
+      prePromptMessageCount: 1,
+    });
+
+    expectCalledWithSessionKey(ingestBatch, contextEngineSessionKey);
+    expect(
+      hoisted.runContextEngineMaintenanceMock.mock.calls.every(
+        ([params]) =>
+          requireRecord(params, "maintenance params").sessionKey === contextEngineSessionKey,
+      ),
+    ).toBe(true);
+  });
+
   it("forwards sessionKey to per-message ingest when ingestBatch is absent", async () => {
     const { bootstrap, assemble } = createContextEngineBootstrapAndAssemble();
     const ingest = vi.fn(async (_params: { sessionKey?: string; message: AgentMessage }) => ({
@@ -1317,6 +1364,27 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
       message: doneMessage,
       sessionId: embeddedSessionId,
       sessionKey,
+    });
+  });
+
+  it("prefers contextEngineSessionKey for per-message ingest fallback", async () => {
+    const contextEngineSessionKey = `${sessionKey}:heartbeat-run:test-session`;
+    const { bootstrap, assemble } = createContextEngineBootstrapAndAssemble();
+    const ingest = vi.fn(async (_params: { sessionKey?: string; message: AgentMessage }) => ({
+      ingested: true,
+    }));
+
+    await finalizeTurn(sessionKey, createTestContextEngine({ bootstrap, assemble, ingest }), {
+      contextEngineSessionKey,
+      messagesSnapshot: [seedMessage, doneMessage],
+      prePromptMessageCount: 1,
+    });
+
+    expect(ingest).toHaveBeenCalledTimes(1);
+    expect(ingest).toHaveBeenCalledWith({
+      message: doneMessage,
+      sessionId: embeddedSessionId,
+      sessionKey: contextEngineSessionKey,
     });
   });
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1057,6 +1057,13 @@ export function resolveAttemptToolPolicyMessageProvider(params: {
   return params.messageProvider ?? params.messageChannel;
 }
 
+function resolveContextEngineSessionKey(params: {
+  sessionKey?: string;
+  contextEngineSessionKey?: string;
+}): string | undefined {
+  return params.contextEngineSessionKey?.trim() || params.sessionKey?.trim() || undefined;
+}
+
 function collectAttemptExplicitToolAllowlistSources(params: {
   config?: EmbeddedRunAttemptParams["config"];
   sessionKey?: string;
@@ -2122,6 +2129,7 @@ export async function runEmbeddedAttempt(
         contextEngine: activeContextEngine,
         sessionId: params.sessionId,
         sessionKey: params.sessionKey,
+        contextEngineSessionKey: resolveContextEngineSessionKey(params),
         sessionFile: params.sessionFile,
         sessionManager,
         runtimeContext: buildAfterTurnRuntimeContext({
@@ -2479,6 +2487,7 @@ export async function runEmbeddedAttempt(
           contextEngine: activeContextEngine,
           sessionId: params.sessionId,
           sessionKey: params.sessionKey,
+          contextEngineSessionKey: resolveContextEngineSessionKey(params),
           sessionFile: params.sessionFile,
           tokenBudget: params.contextTokenBudget,
           modelId: params.modelId,
@@ -3068,6 +3077,7 @@ export async function runEmbeddedAttempt(
               contextEngine: activeContextEngine,
               sessionId: params.sessionId,
               sessionKey: params.sessionKey,
+              contextEngineSessionKey: resolveContextEngineSessionKey(params),
               messages: activeSession.messages,
               tokenBudget: params.contextTokenBudget,
               availableTools: new Set(effectiveTools.map((tool) => tool.name)),
@@ -4335,6 +4345,7 @@ export async function runEmbeddedAttempt(
             yieldAborted,
             sessionIdUsed,
             sessionKey: params.sessionKey,
+            contextEngineSessionKey: resolveContextEngineSessionKey(params),
             sessionFile: params.sessionFile,
             messagesSnapshot,
             prePromptMessageCount: contextEngineAfterTurnCheckpoint ?? prePromptMessageCount,

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -38,6 +38,8 @@ export type CurrentInboundPromptContext = {
 export type RunEmbeddedPiAgentParams = {
   sessionId: string;
   sessionKey?: string;
+  /** Optional context-engine-only identity. Defaults to sessionKey. */
+  contextEngineSessionKey?: string;
   /** Session-like key for sandbox and tool-policy resolution. Defaults to sessionKey. */
   sandboxSessionKey?: string;
   agentId?: string;

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -36,6 +36,8 @@ export type EmbeddedRunAttemptParams = EmbeddedRunAttemptBase & {
   initialReplayState?: EmbeddedRunReplayState;
   /** Pluggable context engine for ingest/assemble/compact lifecycle. */
   contextEngine?: ContextEngine;
+  /** Context-engine-only session identity. Defaults to sessionKey. */
+  contextEngineSessionKey?: string;
   /** Resolved model context window in tokens for assemble/compact budgeting. */
   contextTokenBudget?: number;
   /** Source metadata for the resolved model context budget. */

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
@@ -485,12 +485,14 @@ describe("installContextEngineLoopHook", () => {
       prePromptMessageCount: number;
     }) => Record<string, unknown> | undefined,
     onAfterTurnCheckpoint?: (messageCount: number) => void,
+    contextEngineSessionKey?: string,
   ): () => void {
     return installContextEngineLoopHook({
       agent,
       contextEngine: engine,
       sessionId,
       sessionKey,
+      ...(contextEngineSessionKey ? { contextEngineSessionKey } : {}),
       sessionFile,
       tokenBudget,
       modelId,
@@ -544,6 +546,19 @@ describe("installContextEngineLoopHook", () => {
     expect(afterTurnParams?.prePromptMessageCount).toBe(1);
     expect(afterTurnParams?.messages).toBe(messages);
     expect(engine.assemble).toHaveBeenCalledTimes(1);
+  });
+
+  it("prefers contextEngineSessionKey for loop-hook afterTurn and assemble calls", async () => {
+    const agent = makeGuardableAgent();
+    const engine = makeMockEngine();
+    const contextEngineSessionKey = `${sessionKey}:heartbeat-run:test-session`;
+    installHook(agent, engine, 1, undefined, undefined, contextEngineSessionKey);
+
+    const messages = [makeUser("first"), makeToolResult("call_1", "result")];
+    await callTransform(agent, messages);
+
+    expect(recordMockArg(engine.afterTurn).sessionKey).toBe(contextEngineSessionKey);
+    expect(recordMockArg(engine.assemble).sessionKey).toBe(contextEngineSessionKey);
   });
 
   it("passes runtimeContext through loop-hook afterTurn calls", async () => {
@@ -839,6 +854,26 @@ describe("installContextEngineLoopHook", () => {
     expect(ingestParams?.sessionKey).toBe(sessionKey);
     expect(ingestParams?.message).toBe(toolResult);
     expect(engine.assemble).toHaveBeenCalledTimes(1);
+  });
+
+  it("prefers contextEngineSessionKey for ingestBatch and per-message loop-hook fallbacks", async () => {
+    const contextEngineSessionKey = `${sessionKey}:heartbeat-run:test-session`;
+
+    const batchAgent = makeGuardableAgent();
+    const batchEngine = makeMockEngine({ omitAfterTurn: true });
+    installHook(batchAgent, batchEngine, 1, undefined, undefined, contextEngineSessionKey);
+    await callTransform(batchAgent, [makeUser("first"), makeToolResult("call_1", "r1")]);
+    expect(recordMockArg(batchEngine.ingestBatch ?? vi.fn()).sessionKey).toBe(
+      contextEngineSessionKey,
+    );
+    expect(recordMockArg(batchEngine.assemble).sessionKey).toBe(contextEngineSessionKey);
+
+    const singleAgent = makeGuardableAgent();
+    const singleEngine = makeMockEngine({ omitAfterTurn: true, omitIngestBatch: true });
+    installHook(singleAgent, singleEngine, 1, undefined, undefined, contextEngineSessionKey);
+    await callTransform(singleAgent, [makeUser("first"), makeToolResult("call_2", "r2")]);
+    expect(recordMockArg(singleEngine.ingest).sessionKey).toBe(contextEngineSessionKey);
+    expect(recordMockArg(singleEngine.assemble).sessionKey).toBe(contextEngineSessionKey);
   });
 
   it("falls through to source messages when engine.afterTurn throws", async () => {

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.ts
@@ -236,6 +236,7 @@ export function installContextEngineLoopHook(params: {
   contextEngine: ContextEngine;
   sessionId: string;
   sessionKey?: string;
+  contextEngineSessionKey?: string;
   sessionFile: string;
   tokenBudget?: number;
   modelId: string;
@@ -247,6 +248,7 @@ export function installContextEngineLoopHook(params: {
   }) => ContextEngineRuntimeContext | undefined;
 }): () => void {
   const { contextEngine, sessionId, sessionKey, sessionFile, tokenBudget, modelId } = params;
+  const contextEngineSessionKey = params.contextEngineSessionKey?.trim() || sessionKey;
   const mutableAgent = params.agent as GuardableAgentRecord;
   const originalTransformContext = mutableAgent.transformContext;
   let lastSeenLength: number | null = null;
@@ -294,7 +296,7 @@ export function installContextEngineLoopHook(params: {
       if (typeof contextEngine.afterTurn === "function") {
         await contextEngine.afterTurn({
           sessionId,
-          sessionKey,
+          sessionKey: contextEngineSessionKey,
           sessionFile,
           messages: sourceMessages,
           prePromptMessageCount,
@@ -310,14 +312,14 @@ export function installContextEngineLoopHook(params: {
           if (typeof contextEngine.ingestBatch === "function") {
             await contextEngine.ingestBatch({
               sessionId,
-              sessionKey,
+              sessionKey: contextEngineSessionKey,
               messages: newMessages,
             });
           } else {
             for (const message of newMessages) {
               await contextEngine.ingest({
                 sessionId,
-                sessionKey,
+                sessionKey: contextEngineSessionKey,
                 message,
               });
             }
@@ -329,7 +331,7 @@ export function installContextEngineLoopHook(params: {
       lastSourceMessages = sourceMessages;
       const assembled = await contextEngine.assemble({
         sessionId,
-        sessionKey,
+        sessionKey: contextEngineSessionKey,
         messages: sourceMessages,
         tokenBudget,
         model: modelId,

--- a/src/auto-reply/get-reply-options.types.ts
+++ b/src/auto-reply/get-reply-options.types.ts
@@ -73,6 +73,12 @@ export type GetReplyOptions = {
   fastModeOverride?: boolean;
   /** Controls bootstrap workspace context injection (default: full). */
   bootstrapContextMode?: "full" | "lightweight";
+  /**
+   * Optional session identity forwarded only to context-engine lifecycle hooks.
+   * This lets callers preserve a stable routing/session key while isolating
+   * context-engine state for runs that must not replay prior context.
+   */
+  contextEngineSessionKey?: string;
   /** If true, suppress tool error warning payloads for this run. */
   suppressToolErrorWarnings?: boolean;
   /** If true, run the model without OpenClaw tools for this turn. */

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -799,6 +799,27 @@ describe("runAgentTurnWithFallback", () => {
     });
   });
 
+  it("forwards contextEngineSessionKey into embedded runs", async () => {
+    state.runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "ok" }],
+      meta: {},
+    });
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback(
+      createMinimalRunAgentTurnParams({
+        opts: {
+          contextEngineSessionKey: "agent:main:main:heartbeat-run:test-session",
+        } satisfies GetReplyOptions,
+      }),
+    );
+
+    expect(result.kind).toBe("success");
+    expectMockCallArgFields(state.runEmbeddedPiAgentMock, 0, "embedded run", {
+      contextEngineSessionKey: "agent:main:main:heartbeat-run:test-session",
+    });
+  });
+
   it("keeps the primary origin when an auto pin is cleared before fallback persists", async () => {
     const probe = {
       provider: "anthropic",

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1830,6 +1830,7 @@ export async function runAgentTurnWithFallback(params: {
                 enableHeartbeatTool: params.opts?.enableHeartbeatTool,
                 forceHeartbeatTool: params.opts?.forceHeartbeatTool,
                 bootstrapContextMode: params.opts?.bootstrapContextMode,
+                contextEngineSessionKey: params.opts?.contextEngineSessionKey,
                 bootstrapContextRunKind: params.opts?.isHeartbeat ? "heartbeat" : "default",
                 images: currentTurnImages.images,
                 imageOrder: currentTurnImages.imageOrder,

--- a/src/infra/heartbeat-runner.isolated-key-stability.test.ts
+++ b/src/infra/heartbeat-runner.isolated-key-stability.test.ts
@@ -28,8 +28,19 @@ type HeartbeatReplyContext = {
   SessionKey?: string;
 };
 
+type HeartbeatReplyOptions = {
+  contextEngineSessionKey?: string;
+};
+
 function replyCall(replySpy: { mock: { calls: unknown[][] } }, index = 0): HeartbeatReplyContext {
   return (replySpy.mock.calls[index]?.at(0) ?? {}) as HeartbeatReplyContext;
+}
+
+function replyOptsCall(
+  replySpy: { mock: { calls: unknown[][] } },
+  index = 0,
+): HeartbeatReplyOptions {
+  return (replySpy.mock.calls[index]?.at(1) ?? {}) as HeartbeatReplyOptions;
 }
 
 describe("runHeartbeatOnce – isolated session key stability (#59493)", () => {
@@ -162,6 +173,59 @@ describe("runHeartbeatOnce – isolated session key stability (#59493)", () => {
       });
 
       expect(ctx?.SessionKey).toBe(`${baseSessionKey}:heartbeat`);
+    });
+  });
+
+  it("keeps the routing SessionKey stable while issuing a fresh context-engine key per isolated tick", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
+      const cfg = makeIsolatedHeartbeatConfig(tmpDir, storePath);
+      const baseSessionKey = resolveMainSessionKey(cfg);
+      await seedSessionStore(storePath, baseSessionKey, {
+        lastChannel: "whatsapp",
+        lastProvider: "whatsapp",
+        lastTo: "+1555",
+      });
+
+      const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
+      replySpy.mockResolvedValue({ text: "HEARTBEAT_OK" });
+
+      await runHeartbeatOnce({
+        cfg,
+        sessionKey: baseSessionKey,
+        deps: {
+          getQueueSize: () => 0,
+          nowMs: () => 1,
+        },
+      });
+
+      await runHeartbeatOnce({
+        cfg,
+        sessionKey: baseSessionKey,
+        deps: {
+          getQueueSize: () => 0,
+          nowMs: () => 2,
+        },
+      });
+
+      expect(replySpy).toHaveBeenCalledTimes(2);
+      const firstCtx = replyCall(replySpy);
+      const secondCtx = replyCall(replySpy, 1);
+      const firstOpts = replyOptsCall(replySpy);
+      const secondOpts = replyOptsCall(replySpy, 1);
+
+      expect(firstCtx.SessionKey).toBe(`${baseSessionKey}:heartbeat`);
+      expect(secondCtx.SessionKey).toBe(`${baseSessionKey}:heartbeat`);
+      expect(firstOpts.contextEngineSessionKey).toBeDefined();
+      expect(secondOpts.contextEngineSessionKey).toBeDefined();
+      expect(firstOpts.contextEngineSessionKey).toMatch(
+        new RegExp(`^${baseSessionKey}:heartbeat-run:`),
+      );
+      expect(secondOpts.contextEngineSessionKey).toMatch(
+        new RegExp(`^${baseSessionKey}:heartbeat-run:`),
+      );
+      expect(firstOpts.contextEngineSessionKey).not.toBe(`${baseSessionKey}:heartbeat`);
+      expect(secondOpts.contextEngineSessionKey).not.toBe(`${baseSessionKey}:heartbeat`);
+      expect(firstOpts.contextEngineSessionKey).not.toBe(secondOpts.contextEngineSessionKey);
     });
   });
 

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -693,6 +693,13 @@ function resolveStaleHeartbeatIsolatedSessionKey(params: {
   return undefined;
 }
 
+function buildIsolatedHeartbeatContextEngineSessionKey(params: {
+  isolatedBaseSessionKey: string;
+  sessionId: string;
+}) {
+  return `${params.isolatedBaseSessionKey}:heartbeat-run:${params.sessionId}`;
+}
+
 function resolveHeartbeatReasoningPayloads(
   replyResult: ReplyPayload | ReplyPayload[] | undefined,
 ): ReplyPayload[] {
@@ -1496,6 +1503,7 @@ export async function runHeartbeatOnce(opts: {
   }
 
   let runSessionKey = sessionKey;
+  let contextEngineSessionKey: string | undefined;
   if (useIsolatedSession) {
     const configuredSession = resolveHeartbeatSession(cfg, agentId, heartbeat);
     // Collapse only the repeated `:heartbeat` suffixes introduced by wake-triggered
@@ -1534,6 +1542,10 @@ export async function runHeartbeatOnce(opts: {
         ...cronSession.sessionEntry,
         heartbeatIsolatedBaseSessionKey: isolatedBaseSessionKey,
       };
+      contextEngineSessionKey = buildIsolatedHeartbeatContextEngineSessionKey({
+        isolatedBaseSessionKey,
+        sessionId: cronSession.sessionEntry.sessionId,
+      });
       referencedSessionIds = new Set(
         Object.values(store)
           .map((sessionEntry) => sessionEntry?.sessionId)
@@ -1734,6 +1746,7 @@ export async function runHeartbeatOnce(opts: {
       // Heartbeat timeout is a per-run override so user turns keep the global default.
       timeoutOverrideSeconds,
       bootstrapContextMode,
+      ...(contextEngineSessionKey ? { contextEngineSessionKey } : {}),
       onModelSelected: replyPrefix.onModelSelected,
     };
     const getReplyFromConfig =


### PR DESCRIPTION
## Summary

- Problem: isolated heartbeat runs kept a stable `:heartbeat` routing key everywhere, so context-engine lifecycle hooks could still associate later ticks with prior heartbeat state.
- Solution: preserve the stable routing `SessionKey`, but forward a fresh per-tick `contextEngineSessionKey` only through context-engine bootstrap, assemble, ingest, and compaction paths.
- What changed: heartbeat isolated runs now mint `:heartbeat-run:<sessionId>` keys for context-engine state, and the embedded runner/auto-reply flow threads that override through lifecycle and recovery paths with regression coverage.
- What did NOT change (scope boundary): normal session routing, wake re-entry convergence on the stable `:heartbeat` key, and non-heartbeat runs still default to the existing `sessionKey` behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #84218
- Related #84218
- [x] This PR fixes a bug or regression

## Motivation

- Isolated heartbeat is already documented as starting from fresh context, so replaying accumulated heartbeat context into later ticks can grow prompts until the heartbeat loop compacts and restarts instead of doing scheduled work.

## Real behavior proof (required for external PRs)

Behavior addressed: `isolatedSession=true` heartbeat runs should keep the stable delivery `SessionKey` while using a fresh context-engine-only session identity on each isolated tick.
Real environment tested: Local OpenClaw source checkout in a Codex worktree, using a temporary workspace and session store, with the production `runHeartbeatOnce()` path invoked twice under `isolatedSession=true` and `heartbeat.target=none` to avoid outbound delivery.
Exact steps or command run after this patch:
```bash
node --import tsx --input-type=module <<'EOF'
import fs from 'node:fs/promises';
import os from 'node:os';
import path from 'node:path';
import { runHeartbeatOnce } from './src/infra/heartbeat-runner.ts';
import { resolveMainSessionKey } from './src/config/sessions.ts';

const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'openclaw-hb-proof-'));
const storePath = path.join(tmpDir, 'sessions.json');
await fs.writeFile(path.join(tmpDir, 'HEARTBEAT.md'), '- Check status\n', 'utf8');
const cfg = {
  agents: { defaults: { workspace: tmpDir, heartbeat: { every: '5m', target: 'none', isolatedSession: true } } },
  session: { store: storePath },
};
const sessionKey = resolveMainSessionKey(cfg);
await fs.writeFile(storePath, JSON.stringify({
  [sessionKey]: { sessionId: 'seed-session', updatedAt: Date.now(), lastChannel: 'none', lastProvider: 'heartbeat', lastTo: 'self' }
}), 'utf8');
const observed = [];
const getReplyFromConfig = async (ctx, opts) => {
  observed.push({ SessionKey: ctx.SessionKey, contextEngineSessionKey: opts.contextEngineSessionKey });
  return { text: 'HEARTBEAT_OK' };
};
for (const nowMs of [1, 2]) {
  await runHeartbeatOnce({ cfg, sessionKey, deps: { nowMs: () => nowMs, getQueueSize: () => 0, getReplyFromConfig } });
}
console.log(JSON.stringify(observed, null, 2));
await fs.rm(tmpDir, { recursive: true, force: true });
EOF
```
Evidence after fix (console output):
```text
[sessions/store] pruned stale session entries
[sessions/store] pruned stale session entries
[
  {
    "SessionKey": "agent:main:main:heartbeat",
    "contextEngineSessionKey": "agent:main:main:heartbeat-run:a5bcc111-0825-4313-bc6e-f2c0ab3809bd"
  },
  {
    "SessionKey": "agent:main:main:heartbeat",
    "contextEngineSessionKey": "agent:main:main:heartbeat-run:ad2bf62e-2a5e-4437-836b-19e54b72f069"
  }
]
```
Observed result after fix: Both isolated runs used the stable routing key `agent:main:main:heartbeat`, while the context-engine-only key changed between runs, proving the heartbeat tick kept stable delivery routing without reusing the prior tick's context-engine identity.
What was not tested: Live gateway/channel delivery, end-to-end overflow looping against a real provider, and non-PI harnesses.

## Root Cause (if applicable)

- Root cause: `runHeartbeatOnce()` created a fresh isolated session id, but still passed the stable `<base>:heartbeat` key into the auto-reply and embedded-runner context-engine lifecycle, so any context engine keyed by `sessionKey` could replay earlier heartbeat state.
- Missing detection / guardrail: isolated-heartbeat tests only covered stable `:heartbeat` key convergence and did not assert a separate fresh identity for context-engine lifecycle/compaction paths.
- Contributing context (if known): the same stable key was reused across bootstrap, assemble, `afterTurn`, ingest, and compaction maintenance paths.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/infra/heartbeat-runner.isolated-key-stability.test.ts`
  - `src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts`
  - `src/agents/pi-embedded-runner/tool-result-context-guard.test.ts`
  - `src/agents/pi-embedded-runner/run.overflow-compaction.test.ts`
  - `src/auto-reply/reply/agent-runner-execution.test.ts`
- Scenario the test should lock in: isolated heartbeat ticks keep the stable routing key for delivery, but all context-engine-owned lifecycle and compaction calls use a fresh per-run identity.
- Why this is the smallest reliable guardrail: the bug is in the seam between heartbeat session setup and embedded context-engine lifecycle forwarding, so seam tests can prove the identity split without needing a full live heartbeat deployment.
- Existing test that already covers this (if any): the pre-existing isolated heartbeat stability test covered stable `:heartbeat` routing convergence only.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- Heartbeat runs with `isolatedSession=true` now honor the documented fresh-session contract for context-engine state while keeping the existing stable heartbeat routing key.

## Diagram (if applicable)

N/A.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local source checkout via `node scripts/run-vitest.mjs`
- Model/provider: N/A
- Integration/channel (if any): none
- Relevant config (redacted): heartbeat isolated-session config covered by targeted tests

### Steps

1. Run isolated heartbeat regression coverage.
2. Run embedded context-engine forwarding and overflow-compaction coverage.
3. Confirm the new context-engine-only key stays fresh per isolated tick while the outward routing key remains stable.

### Expected

- Isolated heartbeat delivery still routes through `<base>:heartbeat`, but context-engine lifecycle/compaction paths do not reuse prior heartbeat state.

### Actual

- The targeted tests pass with distinct `contextEngineSessionKey` values across isolated ticks and stable outbound routing keys.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: inspected the heartbeat runner, embedded runner lifecycle forwarding, compaction paths, loop-hook forwarding, and targeted regression tests for the new session-key split.
- Edge cases checked: isolated heartbeat wake re-entry still converges on the stable `:heartbeat` routing key; non-heartbeat paths still default to the existing `sessionKey` contract.
- What you did **not** verify: a live gateway/channel heartbeat repro on current main.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.


