### PR TITLE
fix(agents): tolerate in-process session writes during prompt release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Docs: https://docs.openclaw.ai
 - Exec: keep configured `tools.exec.pathPrepend` entries ahead of user shell startup PATH changes on POSIX gateway runs. (#81403) Thanks @medns.
 - Gateway/sessions: allow shared-secret bearer callers to read and stream session history without an explicit scope header. (#81815) Thanks @medns.
 - Agents/embedded runner: classify HTML auth provider responses as `auth_html` and return a re-authentication hint instead of the CDN-blocked copy that `upstream_html` returns. Cloudflare Access login pages, nginx basic-auth challenges, and gateway login walls all produce HTML auth bodies that were previously misdiagnosed as transient CDN blocks. (#79900) Thanks @martingarramon.
+- Agents/Pi: tolerate OpenClaw-owned transcript writes while embedded prompts are released for model I/O, keeping long-running Feishu, Slack, Telegram, and cron turns from failing with false session-takeover errors. Fixes #84059. (#84250) Thanks @tianxiaochannel-oss88.
 
 ## 2026.5.20
 

--- a/src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts
@@ -287,6 +287,40 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(controller.hasSessionTakeover()).toBe(false);
   });
 
+  it("allows post-prompt writes after another in-process controller advances the session file under lock", async () => {
+    const sessionFile = await createTempSessionFile();
+    const releases: string[] = [];
+    const acquireSessionWriteLock = vi.fn(async () => ({
+      release: vi.fn(async () => {
+        releases.push("release");
+      }),
+    }));
+    const firstController = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await firstController.releaseForPrompt();
+
+    const secondController = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+    await fs.appendFile(sessionFile, '{"type":"message","id":"same-process"}\n', "utf8");
+    await secondController.releaseForPrompt();
+
+    await expect(
+      firstController.withSessionWriteLock(async () => {
+        await fs.appendFile(sessionFile, '{"type":"message","id":"post-prompt"}\n', "utf8");
+        return "post-write";
+      }),
+    ).resolves.toBe("post-write");
+
+    expect(firstController.hasSessionTakeover()).toBe(false);
+    expect(acquireSessionWriteLock).toHaveBeenCalledTimes(3);
+    expect(releases).toEqual(["release", "release", "release"]);
+  });
+
   it("returns a no-op cleanup lock after prompt lock reacquisition times out", async () => {
     const releases: string[] = [];
     const acquireSessionWriteLock = vi

--- a/src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts
@@ -356,6 +356,42 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(releases).toEqual(["release", "release", "release"]);
   });
 
+  it("rejects external session edits even when another controller appends under lock afterward", async () => {
+    const sessionFile = await createTempSessionFile();
+    const releases: string[] = [];
+    const acquireSessionWriteLock = vi.fn(async () => ({
+      release: vi.fn(async () => {
+        releases.push("release");
+      }),
+    }));
+    const firstController = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await firstController.releaseForPrompt();
+    await fs.appendFile(sessionFile, '{"type":"message","id":"external"}\n', "utf8");
+
+    const secondController = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+    await secondController.withSessionWriteLock(async () => {
+      await fs.appendFile(sessionFile, '{"type":"message","id":"same-process"}\n', "utf8");
+    });
+    await secondController.releaseForPrompt();
+
+    await expect(
+      firstController.withSessionWriteLock(async () => {
+        await fs.appendFile(sessionFile, '{"type":"message","id":"late"}\n', "utf8");
+      }),
+    ).rejects.toBeInstanceOf(EmbeddedAttemptSessionTakeoverError);
+
+    expect(firstController.hasSessionTakeover()).toBe(true);
+    expect(acquireSessionWriteLock).toHaveBeenCalledTimes(3);
+    expect(releases).toEqual(["release", "release", "release"]);
+  });
+
   it("returns a no-op cleanup lock after prompt lock reacquisition times out", async () => {
     const releases: string[] = [];
     const acquireSessionWriteLock = vi

--- a/src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts
@@ -306,7 +306,9 @@ describe("embedded attempt session lock lifecycle", () => {
       acquireSessionWriteLock,
       lockOptions: { ...lockOptions, sessionFile },
     });
-    await fs.appendFile(sessionFile, '{"type":"message","id":"same-process"}\n', "utf8");
+    await secondController.withSessionWriteLock(async () => {
+      await fs.appendFile(sessionFile, '{"type":"message","id":"same-process"}\n', "utf8");
+    });
     await secondController.releaseForPrompt();
 
     await expect(
@@ -317,6 +319,39 @@ describe("embedded attempt session lock lifecycle", () => {
     ).resolves.toBe("post-write");
 
     expect(firstController.hasSessionTakeover()).toBe(false);
+    expect(acquireSessionWriteLock).toHaveBeenCalledTimes(3);
+    expect(releases).toEqual(["release", "release", "release"]);
+  });
+
+  it("rejects external session edits even when another controller releases for prompt afterward", async () => {
+    const sessionFile = await createTempSessionFile();
+    const releases: string[] = [];
+    const acquireSessionWriteLock = vi.fn(async () => ({
+      release: vi.fn(async () => {
+        releases.push("release");
+      }),
+    }));
+    const firstController = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await firstController.releaseForPrompt();
+    await fs.appendFile(sessionFile, '{"type":"message","id":"external"}\n', "utf8");
+
+    const secondController = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+    await secondController.releaseForPrompt();
+
+    await expect(
+      firstController.withSessionWriteLock(async () => {
+        await fs.appendFile(sessionFile, '{"type":"message","id":"late"}\n', "utf8");
+      }),
+    ).rejects.toBeInstanceOf(EmbeddedAttemptSessionTakeoverError);
+
+    expect(firstController.hasSessionTakeover()).toBe(true);
     expect(acquireSessionWriteLock).toHaveBeenCalledTimes(3);
     expect(releases).toEqual(["release", "release", "release"]);
   });

--- a/src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts
@@ -240,6 +240,69 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(release).toHaveBeenCalledTimes(4);
   });
 
+  it("keeps post-provider transcript writes owned after prompt stream returns", async () => {
+    const sessionFile = await createTempSessionFile();
+    const release = vi.fn(async () => {});
+    const acquireSessionWriteLock = vi.fn(async () => ({ release }));
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await controller.releaseForPrompt();
+    await controller.reacquireAfterPrompt();
+    await fs.appendFile(sessionFile, '{"type":"message","id":"provider-error"}\n', "utf8");
+    controller.refreshAfterOwnedSessionWrite();
+
+    const cleanupLock = await controller.acquireForCleanup();
+    await cleanupLock.release();
+
+    expect(controller.hasSessionTakeover()).toBe(false);
+    expect(acquireSessionWriteLock).toHaveBeenCalledTimes(2);
+    expect(release).toHaveBeenCalledTimes(2);
+  });
+
+  it("still rejects external edits before the prompt stream lock is reacquired", async () => {
+    const sessionFile = await createTempSessionFile();
+    const release = vi.fn(async () => {});
+    const acquireSessionWriteLock = vi.fn(async () => ({ release }));
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await controller.releaseForPrompt();
+    await fs.appendFile(sessionFile, '{"type":"message","id":"external"}\n', "utf8");
+
+    await expect(controller.reacquireAfterPrompt()).rejects.toBeInstanceOf(
+      EmbeddedAttemptSessionTakeoverError,
+    );
+    expect(controller.hasSessionTakeover()).toBe(true);
+    expect(acquireSessionWriteLock).toHaveBeenCalledTimes(2);
+    expect(release).toHaveBeenCalledTimes(2);
+  });
+
+  it("still rejects external edits after the prompt stream lock is reacquired", async () => {
+    const sessionFile = await createTempSessionFile();
+    const release = vi.fn(async () => {});
+    const acquireSessionWriteLock = vi.fn(async () => ({ release }));
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await controller.releaseForPrompt();
+    await controller.reacquireAfterPrompt();
+    await fs.appendFile(sessionFile, '{"type":"message","id":"external-after-reacquire"}\n', "utf8");
+
+    const cleanupLock = await controller.acquireForCleanup();
+    await cleanupLock.release();
+
+    expect(controller.hasSessionTakeover()).toBe(true);
+    expect(acquireSessionWriteLock).toHaveBeenCalledTimes(2);
+    expect(release).toHaveBeenCalledTimes(2);
+  });
+
   it("refreshes the prompt fence after an owned transcript mirror append", async () => {
     const sessionFile = await createTempSessionFile();
     const release = vi.fn(async () => {});
@@ -610,16 +673,25 @@ describe("embedded attempt session lock lifecycle", () => {
     const releaseForPrompt = vi.fn(async () => {
       events.push("release");
     });
+    const reacquireAfterPrompt = vi.fn(async () => {
+      events.push("reacquire");
+    });
     const session = { agent: { streamFn } };
 
-    installPromptSubmissionLockRelease({ session, waitForSessionEvents, releaseForPrompt });
+    installPromptSubmissionLockRelease({
+      session,
+      waitForSessionEvents,
+      releaseForPrompt,
+      reacquireAfterPrompt,
+    });
 
     await session.agent.streamFn("model", "context");
 
     expect(waitForSessionEvents).toHaveBeenCalledWith(session);
     expect(releaseForPrompt).toHaveBeenCalledTimes(1);
+    expect(reacquireAfterPrompt).toHaveBeenCalledTimes(1);
     expect(streamFn).toHaveBeenCalledWith("model", "context");
-    expect(events).toEqual(["drain", "release", "stream"]);
+    expect(events).toEqual(["drain", "release", "stream", "reacquire"]);
   });
 
   it("rewraps provider stream submission after the stream function is rebuilt", async () => {
@@ -636,27 +708,48 @@ describe("embedded attempt session lock lifecycle", () => {
     const releaseForPrompt = vi.fn(async () => {
       events.push("release");
     });
+    const reacquireAfterPrompt = vi.fn(async () => {
+      events.push("reacquire");
+    });
     const session = { agent: { streamFn: firstStreamFn } };
 
-    installPromptSubmissionLockRelease({ session, waitForSessionEvents, releaseForPrompt });
-    installPromptSubmissionLockRelease({ session, waitForSessionEvents, releaseForPrompt });
+    installPromptSubmissionLockRelease({
+      session,
+      waitForSessionEvents,
+      releaseForPrompt,
+      reacquireAfterPrompt,
+    });
+    installPromptSubmissionLockRelease({
+      session,
+      waitForSessionEvents,
+      releaseForPrompt,
+      reacquireAfterPrompt,
+    });
     await session.agent.streamFn("first-model");
 
     session.agent.streamFn = secondStreamFn;
-    installPromptSubmissionLockRelease({ session, waitForSessionEvents, releaseForPrompt });
+    installPromptSubmissionLockRelease({
+      session,
+      waitForSessionEvents,
+      releaseForPrompt,
+      reacquireAfterPrompt,
+    });
     await session.agent.streamFn("second-model");
 
     expect(firstStreamFn).toHaveBeenCalledTimes(1);
     expect(secondStreamFn).toHaveBeenCalledTimes(1);
     expect(waitForSessionEvents).toHaveBeenCalledTimes(2);
     expect(releaseForPrompt).toHaveBeenCalledTimes(2);
+    expect(reacquireAfterPrompt).toHaveBeenCalledTimes(2);
     expect(events).toEqual([
       "drain",
       "release",
       "first-stream",
+      "reacquire",
       "drain",
       "release",
       "second-stream",
+      "reacquire",
     ]);
   });
 

--- a/src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   runWithOwnedSessionTranscriptWriteLock,
+  runWithOwnedSessionTranscriptWritePublication,
   withOwnedSessionTranscriptWrites,
 } from "../../../config/sessions/transcript-write-context.js";
 import { SessionWriteLockTimeoutError } from "../../session-write-lock-error.js";
@@ -287,7 +288,95 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(controller.hasSessionTakeover()).toBe(false);
   });
 
-  it("allows post-prompt writes after another controller publishes an owned transcript write", async () => {
+  it("allows post-prompt writes after the prompt context publishes an owned transcript write", async () => {
+    const sessionFile = await createTempSessionFile();
+    const releases: string[] = [];
+    const acquireSessionWriteLock = vi.fn(async () => ({
+      release: vi.fn(async () => {
+        releases.push("release");
+      }),
+    }));
+    const firstController = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await firstController.releaseForPrompt();
+
+    const secondController = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+    const promptActiveSession = async (run: () => Promise<void>): Promise<void> =>
+      await withOwnedSessionTranscriptWrites(
+        {
+          sessionFile,
+          sessionKey: "agent:main:slack:channel:456",
+          withSessionWriteLock: (operation, options) =>
+            secondController.withSessionWriteLock(operation, options),
+        },
+        run,
+      );
+    await promptActiveSession(
+      async () =>
+        await runWithOwnedSessionTranscriptWritePublication(
+          { sessionFile, sessionKey: "agent:main:slack:channel:456" },
+          async () => {
+            await fs.appendFile(sessionFile, '{"type":"message","id":"same-process"}\n', "utf8");
+          },
+        ),
+    );
+    await secondController.releaseForPrompt();
+
+    await expect(
+      firstController.withSessionWriteLock(async () => {
+        await fs.appendFile(sessionFile, '{"type":"message","id":"post-prompt"}\n', "utf8");
+        return "post-write";
+      }),
+    ).resolves.toBe("post-write");
+
+    expect(firstController.hasSessionTakeover()).toBe(false);
+    expect(acquireSessionWriteLock).toHaveBeenCalledTimes(3);
+    expect(releases).toEqual(["release", "release", "release"]);
+  });
+
+  it("rejects external edits interleaved while another controller holds cleanup lock", async () => {
+    const sessionFile = await createTempSessionFile();
+    const releases: string[] = [];
+    const acquireSessionWriteLock = vi.fn(async () => ({
+      release: vi.fn(async () => {
+        releases.push("release");
+      }),
+    }));
+    const firstController = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await firstController.releaseForPrompt();
+
+    const secondController = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+    await secondController.releaseForPrompt();
+    const cleanupLock = await secondController.acquireForCleanup();
+
+    await fs.appendFile(sessionFile, '{"type":"message","id":"external-cleanup"}\n', "utf8");
+    await cleanupLock.release();
+
+    await expect(
+      firstController.withSessionWriteLock(async () => {
+        await fs.appendFile(sessionFile, '{"type":"message","id":"late"}\n', "utf8");
+      }),
+    ).rejects.toBeInstanceOf(EmbeddedAttemptSessionTakeoverError);
+
+    expect(firstController.hasSessionTakeover()).toBe(true);
+    expect(acquireSessionWriteLock).toHaveBeenCalledTimes(4);
+    expect(releases).toEqual(["release", "release", "release", "release"]);
+  });
+
+  it("rejects external edits interleaved inside a broad owned transcript lock", async () => {
     const sessionFile = await createTempSessionFile();
     const releases: string[] = [];
     const acquireSessionWriteLock = vi.fn(async () => ({
@@ -309,15 +398,29 @@ describe("embedded attempt session lock lifecycle", () => {
     await withOwnedSessionTranscriptWrites(
       {
         sessionFile,
-        sessionKey: "agent:main:slack:channel:456",
+        sessionKey: "agent:main:slack:channel:789",
         withSessionWriteLock: (operation, options) =>
           secondController.withSessionWriteLock(operation, options),
       },
       async () =>
         await runWithOwnedSessionTranscriptWriteLock(
-          { sessionFile, sessionKey: "agent:main:slack:channel:456" },
+          { sessionFile, sessionKey: "agent:main:slack:channel:789" },
           async () => {
-            await fs.appendFile(sessionFile, '{"type":"message","id":"same-process"}\n', "utf8");
+            await fs.appendFile(
+              sessionFile,
+              '{"type":"message","id":"external-owned-scope"}\n',
+              "utf8",
+            );
+            await runWithOwnedSessionTranscriptWritePublication(
+              { sessionFile, sessionKey: "agent:main:slack:channel:789" },
+              async () => {
+                await fs.appendFile(
+                  sessionFile,
+                  '{"type":"message","id":"same-process"}\n',
+                  "utf8",
+                );
+              },
+            );
           },
         ),
     );
@@ -325,12 +428,11 @@ describe("embedded attempt session lock lifecycle", () => {
 
     await expect(
       firstController.withSessionWriteLock(async () => {
-        await fs.appendFile(sessionFile, '{"type":"message","id":"post-prompt"}\n', "utf8");
-        return "post-write";
+        await fs.appendFile(sessionFile, '{"type":"message","id":"late"}\n', "utf8");
       }),
-    ).resolves.toBe("post-write");
+    ).rejects.toBeInstanceOf(EmbeddedAttemptSessionTakeoverError);
 
-    expect(firstController.hasSessionTakeover()).toBe(false);
+    expect(firstController.hasSessionTakeover()).toBe(true);
     expect(acquireSessionWriteLock).toHaveBeenCalledTimes(3);
     expect(releases).toEqual(["release", "release", "release"]);
   });

--- a/src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts
@@ -287,7 +287,55 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(controller.hasSessionTakeover()).toBe(false);
   });
 
-  it("allows post-prompt writes after another in-process controller advances the session file under lock", async () => {
+  it("allows post-prompt writes after another controller publishes an owned transcript write", async () => {
+    const sessionFile = await createTempSessionFile();
+    const releases: string[] = [];
+    const acquireSessionWriteLock = vi.fn(async () => ({
+      release: vi.fn(async () => {
+        releases.push("release");
+      }),
+    }));
+    const firstController = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await firstController.releaseForPrompt();
+
+    const secondController = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+    await withOwnedSessionTranscriptWrites(
+      {
+        sessionFile,
+        sessionKey: "agent:main:slack:channel:456",
+        withSessionWriteLock: (operation, options) =>
+          secondController.withSessionWriteLock(operation, options),
+      },
+      async () =>
+        await runWithOwnedSessionTranscriptWriteLock(
+          { sessionFile, sessionKey: "agent:main:slack:channel:456" },
+          async () => {
+            await fs.appendFile(sessionFile, '{"type":"message","id":"same-process"}\n', "utf8");
+          },
+        ),
+    );
+    await secondController.releaseForPrompt();
+
+    await expect(
+      firstController.withSessionWriteLock(async () => {
+        await fs.appendFile(sessionFile, '{"type":"message","id":"post-prompt"}\n', "utf8");
+        return "post-write";
+      }),
+    ).resolves.toBe("post-write");
+
+    expect(firstController.hasSessionTakeover()).toBe(false);
+    expect(acquireSessionWriteLock).toHaveBeenCalledTimes(3);
+    expect(releases).toEqual(["release", "release", "release"]);
+  });
+
+  it("rejects external edits interleaved during a broad same-process locked callback", async () => {
     const sessionFile = await createTempSessionFile();
     const releases: string[] = [];
     const acquireSessionWriteLock = vi.fn(async () => ({
@@ -308,17 +356,17 @@ describe("embedded attempt session lock lifecycle", () => {
     });
     await secondController.withSessionWriteLock(async () => {
       await fs.appendFile(sessionFile, '{"type":"message","id":"same-process"}\n', "utf8");
+      await fs.appendFile(sessionFile, '{"type":"message","id":"external-interleaved"}\n', "utf8");
     });
     await secondController.releaseForPrompt();
 
     await expect(
       firstController.withSessionWriteLock(async () => {
-        await fs.appendFile(sessionFile, '{"type":"message","id":"post-prompt"}\n', "utf8");
-        return "post-write";
+        await fs.appendFile(sessionFile, '{"type":"message","id":"late"}\n', "utf8");
       }),
-    ).resolves.toBe("post-write");
+    ).rejects.toBeInstanceOf(EmbeddedAttemptSessionTakeoverError);
 
-    expect(firstController.hasSessionTakeover()).toBe(false);
+    expect(firstController.hasSessionTakeover()).toBe(true);
     expect(acquireSessionWriteLock).toHaveBeenCalledTimes(3);
     expect(releases).toEqual(["release", "release", "release"]);
   });

--- a/src/agents/pi-embedded-runner/run/attempt.session-lock.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.session-lock.ts
@@ -488,23 +488,6 @@ export async function createEmbeddedAttemptSessionLockController(params: {
 
   const noopLock: SessionLock = { release: async () => {} };
 
-  function wrapOwnedCleanupLock(
-    lock: SessionLock,
-    beforeCleanup: SessionFileFingerprint,
-  ): SessionLock {
-    return {
-      release: async () => {
-        try {
-          if (!takeoverDetected) {
-            await publishOwnedSessionFileWriteIfChanged(beforeCleanup).catch(() => {});
-          }
-        } finally {
-          await lock.release();
-        }
-      },
-    };
-  }
-
   return {
     async releaseForPrompt(): Promise<void> {
       if (!heldLock) {
@@ -537,7 +520,15 @@ export async function createEmbeddedAttemptSessionLockController(params: {
         throw new EmbeddedAttemptSessionTakeoverError(params.lockOptions.sessionFile);
       }
       if (activeWriteLock.getStore()?.active === true) {
-        return await run();
+        if (options?.publishOwnedWrite !== true) {
+          return await run();
+        }
+        const beforeWrite = await readSessionFileFingerprint(params.lockOptions.sessionFile);
+        try {
+          return await run();
+        } finally {
+          await publishOwnedSessionFileFence(beforeWrite);
+        }
       }
       const { lock, owned } = await acquireWriteLock();
       try {
@@ -596,8 +587,7 @@ export async function createEmbeddedAttemptSessionLockController(params: {
         }
         throw err;
       }
-      const beforeCleanup = await readSessionFileFingerprint(params.lockOptions.sessionFile);
-      return wrapOwnedCleanupLock(cleanupLock, beforeCleanup);
+      return cleanupLock;
     },
     hasSessionTakeover(): boolean {
       return takeoverDetected;

--- a/src/agents/pi-embedded-runner/run/attempt.session-lock.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.session-lock.ts
@@ -1,6 +1,7 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import { statSync } from "node:fs";
 import fs from "node:fs/promises";
+import path from "node:path";
 import { isSessionWriteLockTimeoutError } from "../../session-write-lock-error.js";
 import type { acquireSessionWriteLock } from "../../session-write-lock.js";
 
@@ -140,6 +141,34 @@ function sameSessionFileFingerprint(
     left.mtimeNs === right.mtimeNs &&
     left.ctimeNs === right.ctimeNs
   );
+}
+
+type OwnedSessionFileWrite = {
+  generation: number;
+  fingerprint: SessionFileFingerprint;
+};
+
+// Controllers in the same OpenClaw process can legitimately take turns writing
+// the same session file while another attempt is released for model I/O. Track
+// the exact post-write fingerprint so the takeover fence can distinguish those
+// locked in-process writes from unowned external file changes.
+const ownedSessionFileWrites = new Map<string, OwnedSessionFileWrite>();
+let ownedSessionFileWriteGeneration = 0;
+
+function resolveSessionFileFenceKey(sessionFile: string): string {
+  return path.resolve(sessionFile);
+}
+
+function recordOwnedSessionFileWrite(
+  sessionFileKey: string,
+  fingerprint: SessionFileFingerprint,
+): number {
+  ownedSessionFileWriteGeneration += 1;
+  ownedSessionFileWrites.set(sessionFileKey, {
+    generation: ownedSessionFileWriteGeneration,
+    fingerprint,
+  });
+  return ownedSessionFileWriteGeneration;
 }
 
 async function readSessionFileFingerprint(sessionFile: string): Promise<SessionFileFingerprint> {
@@ -334,8 +363,10 @@ export async function createEmbeddedAttemptSessionLockController(params: {
   let heldLock: SessionLock | undefined = await acquireLock();
   const activeWriteLock = new AsyncLocalStorage<ActiveWriteLockState>();
   let fenceFingerprint: SessionFileFingerprint | undefined;
+  let fenceGeneration = 0;
   let fenceActive = false;
   let takeoverDetected = false;
+  const sessionFileFenceKey = resolveSessionFileFenceKey(params.lockOptions.sessionFile);
 
   async function acquireWriteLock(): Promise<{ lock: SessionLock; owned: boolean }> {
     if (heldLock) {
@@ -356,19 +387,60 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       return;
     }
     const current = await readSessionFileFingerprint(params.lockOptions.sessionFile);
-    if (!sameSessionFileFingerprint(fenceFingerprint, current)) {
-      takeoverDetected = true;
-      throw new EmbeddedAttemptSessionTakeoverError(params.lockOptions.sessionFile);
+    if (sameSessionFileFingerprint(fenceFingerprint, current)) {
+      return;
     }
+
+    const ownedWrite = ownedSessionFileWrites.get(sessionFileFenceKey);
+    if (
+      ownedWrite &&
+      ownedWrite.generation > fenceGeneration &&
+      sameSessionFileFingerprint(ownedWrite.fingerprint, current)
+    ) {
+      fenceFingerprint = current;
+      fenceGeneration = ownedWrite.generation;
+      return;
+    }
+
+    takeoverDetected = true;
+    throw new EmbeddedAttemptSessionTakeoverError(params.lockOptions.sessionFile);
+  }
+
+  async function publishOwnedSessionFileWrite(): Promise<{
+    fingerprint: SessionFileFingerprint;
+    generation: number;
+  }> {
+    const fingerprint = await readSessionFileFingerprint(params.lockOptions.sessionFile);
+    const generation = recordOwnedSessionFileWrite(sessionFileFenceKey, fingerprint);
+    return { fingerprint, generation };
   }
 
   async function refreshSessionFileFence(): Promise<void> {
-    if (fenceActive && !takeoverDetected) {
-      fenceFingerprint = await readSessionFileFingerprint(params.lockOptions.sessionFile);
+    if (takeoverDetected) {
+      return;
+    }
+    const { fingerprint, generation } = await publishOwnedSessionFileWrite();
+    if (fenceActive) {
+      fenceFingerprint = fingerprint;
+      fenceGeneration = generation;
     }
   }
 
   const noopLock: SessionLock = { release: async () => {} };
+
+  function wrapOwnedCleanupLock(lock: SessionLock): SessionLock {
+    return {
+      release: async () => {
+        try {
+          if (!takeoverDetected) {
+            await publishOwnedSessionFileWrite().catch(() => {});
+          }
+        } finally {
+          await lock.release();
+        }
+      },
+    };
+  }
 
   return {
     async releaseForPrompt(): Promise<void> {
@@ -377,7 +449,9 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       }
       const lock = heldLock;
       heldLock = undefined;
-      fenceFingerprint = await readSessionFileFingerprint(params.lockOptions.sessionFile);
+      const { fingerprint, generation } = await publishOwnedSessionFileWrite();
+      fenceFingerprint = fingerprint;
+      fenceGeneration = generation;
       fenceActive = true;
       await lock.release();
     },
@@ -446,7 +520,7 @@ export async function createEmbeddedAttemptSessionLockController(params: {
         }
         throw err;
       }
-      return cleanupLock;
+      return wrapOwnedCleanupLock(cleanupLock);
     },
     hasSessionTakeover(): boolean {
       return takeoverDetected;

--- a/src/agents/pi-embedded-runner/run/attempt.session-lock.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.session-lock.ts
@@ -381,6 +381,7 @@ export function installSessionExternalHookWriteLock(params: {
 export type EmbeddedAttemptSessionLockController = {
   releaseForPrompt(): Promise<void>;
   refreshAfterOwnedSessionWrite(): void;
+  reacquireAfterPrompt(): Promise<void>;
   waitForSessionEvents(session: unknown): Promise<void>;
   withSessionWriteLock<T>(
     run: () => Promise<T> | T,
@@ -511,6 +512,20 @@ export async function createEmbeddedAttemptSessionLockController(params: {
         fenceFingerprint = readSessionFileFingerprintSync(params.lockOptions.sessionFile);
       }
     },
+    async reacquireAfterPrompt(): Promise<void> {
+      if (takeoverDetected || heldLock) {
+        return;
+      }
+      const lock = await acquireLock();
+      try {
+        heldLock = lock;
+        await assertSessionFileFence();
+      } catch (err) {
+        heldLock = undefined;
+        await lock.release();
+        throw err;
+      }
+    },
     waitForSessionEvents: waitForSessionEventQueue,
     async withSessionWriteLock<T>(
       run: () => Promise<T> | T,
@@ -599,6 +614,7 @@ export function installPromptSubmissionLockRelease(params: {
   session: unknown;
   waitForSessionEvents: (session: unknown) => Promise<void>;
   releaseForPrompt: () => Promise<void>;
+  reacquireAfterPrompt: () => Promise<void>;
 }): void {
   const agent = (params.session as SessionWithAgentPrompt).agent;
   if (typeof agent?.streamFn !== "function") {
@@ -612,7 +628,11 @@ export function installPromptSubmissionLockRelease(params: {
   const wrappedStreamFn: PromptReleaseStreamFn = async (...args: unknown[]) => {
     await params.waitForSessionEvents(params.session);
     await params.releaseForPrompt();
-    return await originalStreamFn(...args);
+    try {
+      return await originalStreamFn(...args);
+    } finally {
+      await params.reacquireAfterPrompt();
+    }
   };
   wrappedStreamFn["__openclawSessionLockPromptReleaseInstalled"] = true;
   agent.streamFn = wrappedStreamFn;

--- a/src/agents/pi-embedded-runner/run/attempt.session-lock.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.session-lock.ts
@@ -18,6 +18,10 @@ type LockOptions = {
   maxHoldMs: number;
 };
 
+type SessionWriteLockRunOptions = {
+  publishOwnedWrite?: boolean;
+};
+
 type SessionEventProcessor = {
   _processAgentEvent?: (event: unknown) => Promise<void>;
   _extensionRunner?: {
@@ -378,7 +382,10 @@ export type EmbeddedAttemptSessionLockController = {
   releaseForPrompt(): Promise<void>;
   refreshAfterOwnedSessionWrite(): void;
   waitForSessionEvents(session: unknown): Promise<void>;
-  withSessionWriteLock<T>(run: () => Promise<T> | T): Promise<T>;
+  withSessionWriteLock<T>(
+    run: () => Promise<T> | T,
+    options?: SessionWriteLockRunOptions,
+  ): Promise<T>;
   acquireForCleanup(params?: { session?: unknown }): Promise<SessionLock>;
   hasSessionTakeover(): boolean;
 };
@@ -462,6 +469,16 @@ export async function createEmbeddedAttemptSessionLockController(params: {
     if (takeoverDetected) {
       return;
     }
+    const fingerprint = await readSessionFileFingerprint(params.lockOptions.sessionFile);
+    if (!sameSessionFileFingerprint(beforeWrite, fingerprint) && fenceActive) {
+      fenceFingerprint = fingerprint;
+    }
+  }
+
+  async function publishOwnedSessionFileFence(beforeWrite: SessionFileFingerprint): Promise<void> {
+    if (takeoverDetected) {
+      return;
+    }
     const ownedWrite = await publishOwnedSessionFileWriteIfChanged(beforeWrite);
     if (ownedWrite && fenceActive) {
       fenceFingerprint = ownedWrite.fingerprint;
@@ -512,7 +529,10 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       }
     },
     waitForSessionEvents: waitForSessionEventQueue,
-    async withSessionWriteLock<T>(run: () => Promise<T> | T): Promise<T> {
+    async withSessionWriteLock<T>(
+      run: () => Promise<T> | T,
+      options?: SessionWriteLockRunOptions,
+    ): Promise<T> {
       if (takeoverDetected) {
         throw new EmbeddedAttemptSessionTakeoverError(params.lockOptions.sessionFile);
       }
@@ -527,7 +547,11 @@ export async function createEmbeddedAttemptSessionLockController(params: {
           try {
             return await run();
           } finally {
-            await refreshSessionFileFence(beforeWrite);
+            if (options?.publishOwnedWrite === true) {
+              await publishOwnedSessionFileFence(beforeWrite);
+            } else {
+              await refreshSessionFileFence(beforeWrite);
+            }
           }
         };
         if (owned) {

--- a/src/agents/pi-embedded-runner/run/attempt.session-lock.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.session-lock.ts
@@ -150,8 +150,9 @@ type OwnedSessionFileWrite = {
 
 // Controllers in the same OpenClaw process can legitimately take turns writing
 // the same session file while another attempt is released for model I/O. Track
-// the exact post-write fingerprint so the takeover fence can distinguish those
-// locked in-process writes from unowned external file changes.
+// only fingerprints that changed while OpenClaw held the write lock so the
+// takeover fence can distinguish those locked in-process writes from unowned
+// external file changes.
 const ownedSessionFileWrites = new Map<string, OwnedSessionFileWrite>();
 let ownedSessionFileWriteGeneration = 0;
 
@@ -406,34 +407,42 @@ export async function createEmbeddedAttemptSessionLockController(params: {
     throw new EmbeddedAttemptSessionTakeoverError(params.lockOptions.sessionFile);
   }
 
-  async function publishOwnedSessionFileWrite(): Promise<{
+  async function publishOwnedSessionFileWriteIfChanged(
+    beforeWrite: SessionFileFingerprint,
+  ): Promise<{
     fingerprint: SessionFileFingerprint;
     generation: number;
-  }> {
+  } | null> {
     const fingerprint = await readSessionFileFingerprint(params.lockOptions.sessionFile);
+    if (sameSessionFileFingerprint(beforeWrite, fingerprint)) {
+      return null;
+    }
     const generation = recordOwnedSessionFileWrite(sessionFileFenceKey, fingerprint);
     return { fingerprint, generation };
   }
 
-  async function refreshSessionFileFence(): Promise<void> {
+  async function refreshSessionFileFence(beforeWrite: SessionFileFingerprint): Promise<void> {
     if (takeoverDetected) {
       return;
     }
-    const { fingerprint, generation } = await publishOwnedSessionFileWrite();
-    if (fenceActive) {
-      fenceFingerprint = fingerprint;
-      fenceGeneration = generation;
+    const ownedWrite = await publishOwnedSessionFileWriteIfChanged(beforeWrite);
+    if (ownedWrite && fenceActive) {
+      fenceFingerprint = ownedWrite.fingerprint;
+      fenceGeneration = ownedWrite.generation;
     }
   }
 
   const noopLock: SessionLock = { release: async () => {} };
 
-  function wrapOwnedCleanupLock(lock: SessionLock): SessionLock {
+  function wrapOwnedCleanupLock(
+    lock: SessionLock,
+    beforeCleanup: SessionFileFingerprint,
+  ): SessionLock {
     return {
       release: async () => {
         try {
           if (!takeoverDetected) {
-            await publishOwnedSessionFileWrite().catch(() => {});
+            await publishOwnedSessionFileWriteIfChanged(beforeCleanup).catch(() => {});
           }
         } finally {
           await lock.release();
@@ -449,9 +458,13 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       }
       const lock = heldLock;
       heldLock = undefined;
-      const { fingerprint, generation } = await publishOwnedSessionFileWrite();
+      const fingerprint = await readSessionFileFingerprint(params.lockOptions.sessionFile);
+      const ownedWrite = ownedSessionFileWrites.get(sessionFileFenceKey);
       fenceFingerprint = fingerprint;
-      fenceGeneration = generation;
+      fenceGeneration =
+        ownedWrite && sameSessionFileFingerprint(ownedWrite.fingerprint, fingerprint)
+          ? ownedWrite.generation
+          : fenceGeneration;
       fenceActive = true;
       await lock.release();
     },
@@ -471,11 +484,12 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       const { lock, owned } = await acquireWriteLock();
       try {
         await assertSessionFileFence();
+        const beforeWrite = await readSessionFileFingerprint(params.lockOptions.sessionFile);
         const runWithLock = async () => {
           try {
             return await run();
           } finally {
-            await refreshSessionFileFence();
+            await refreshSessionFileFence(beforeWrite);
           }
         };
         if (owned) {
@@ -520,7 +534,8 @@ export async function createEmbeddedAttemptSessionLockController(params: {
         }
         throw err;
       }
-      return wrapOwnedCleanupLock(cleanupLock);
+      const beforeCleanup = await readSessionFileFingerprint(params.lockOptions.sessionFile);
+      return wrapOwnedCleanupLock(cleanupLock, beforeCleanup);
     },
     hasSessionTakeover(): boolean {
       return takeoverDetected;

--- a/src/agents/pi-embedded-runner/run/attempt.session-lock.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.session-lock.ts
@@ -148,12 +148,18 @@ type OwnedSessionFileWrite = {
   fingerprint: SessionFileFingerprint;
 };
 
+type TrustedSessionFileState = {
+  generation: number;
+  fingerprint: SessionFileFingerprint;
+};
+
 // Controllers in the same OpenClaw process can legitimately take turns writing
 // the same session file while another attempt is released for model I/O. Track
 // only fingerprints that changed while OpenClaw held the write lock so the
 // takeover fence can distinguish those locked in-process writes from unowned
 // external file changes.
 const ownedSessionFileWrites = new Map<string, OwnedSessionFileWrite>();
+const trustedSessionFileStates = new Map<string, TrustedSessionFileState>();
 let ownedSessionFileWriteGeneration = 0;
 
 function resolveSessionFileFenceKey(sessionFile: string): string {
@@ -165,11 +171,39 @@ function recordOwnedSessionFileWrite(
   fingerprint: SessionFileFingerprint,
 ): number {
   ownedSessionFileWriteGeneration += 1;
-  ownedSessionFileWrites.set(sessionFileKey, {
+  const state = {
+    generation: ownedSessionFileWriteGeneration,
+    fingerprint,
+  };
+  ownedSessionFileWrites.set(sessionFileKey, state);
+  trustedSessionFileStates.set(sessionFileKey, state);
+  return ownedSessionFileWriteGeneration;
+}
+
+function trustSessionFileState(
+  sessionFileKey: string,
+  fingerprint: SessionFileFingerprint,
+): number | undefined {
+  const trusted = trustedSessionFileStates.get(sessionFileKey);
+  if (trusted) {
+    return sameSessionFileFingerprint(trusted.fingerprint, fingerprint)
+      ? trusted.generation
+      : undefined;
+  }
+  ownedSessionFileWriteGeneration += 1;
+  trustedSessionFileStates.set(sessionFileKey, {
     generation: ownedSessionFileWriteGeneration,
     fingerprint,
   });
   return ownedSessionFileWriteGeneration;
+}
+
+function isTrustedSessionFileState(
+  sessionFileKey: string,
+  fingerprint: SessionFileFingerprint,
+): boolean {
+  const trusted = trustedSessionFileStates.get(sessionFileKey);
+  return !!trusted && sameSessionFileFingerprint(trusted.fingerprint, fingerprint);
 }
 
 async function readSessionFileFingerprint(sessionFile: string): Promise<SessionFileFingerprint> {
@@ -417,6 +451,9 @@ export async function createEmbeddedAttemptSessionLockController(params: {
     if (sameSessionFileFingerprint(beforeWrite, fingerprint)) {
       return null;
     }
+    if (!isTrustedSessionFileState(sessionFileFenceKey, beforeWrite)) {
+      return null;
+    }
     const generation = recordOwnedSessionFileWrite(sessionFileFenceKey, fingerprint);
     return { fingerprint, generation };
   }
@@ -460,11 +497,12 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       heldLock = undefined;
       const fingerprint = await readSessionFileFingerprint(params.lockOptions.sessionFile);
       const ownedWrite = ownedSessionFileWrites.get(sessionFileFenceKey);
+      const trustedGeneration = trustSessionFileState(sessionFileFenceKey, fingerprint);
       fenceFingerprint = fingerprint;
       fenceGeneration =
         ownedWrite && sameSessionFileFingerprint(ownedWrite.fingerprint, fingerprint)
           ? ownedWrite.generation
-          : fenceGeneration;
+          : (trustedGeneration ?? fenceGeneration);
       fenceActive = true;
       await lock.release();
     },

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -3182,8 +3182,10 @@ export async function runEmbeddedAttempt(
       const ownedTranscriptWriteContext = {
         sessionFile: params.sessionFile,
         sessionKey: params.sessionKey,
-        withSessionWriteLock: <T>(operation: () => Promise<T> | T) =>
-          sessionLockController.withSessionWriteLock(operation),
+        withSessionWriteLock: <T>(
+          operation: () => Promise<T> | T,
+          options?: { publishOwnedWrite?: boolean },
+        ) => sessionLockController.withSessionWriteLock(operation, options),
       };
       const promptActiveSession = (
         prompt: string,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -3846,6 +3846,7 @@ export async function runEmbeddedAttempt(
               waitForSessionEvents: (sessionToDrain) =>
                 sessionLockController.waitForSessionEvents(sessionToDrain),
               releaseForPrompt: () => sessionLockController.releaseForPrompt(),
+              reacquireAfterPrompt: () => sessionLockController.reacquireAfterPrompt(),
             });
           }
 

--- a/src/config/sessions/transcript-write-context.ts
+++ b/src/config/sessions/transcript-write-context.ts
@@ -54,9 +54,32 @@ export async function runWithOwnedSessionTranscriptWriteLock<T>(
   },
   run: () => Promise<T> | T,
 ): Promise<T> {
+  return await runWithOwnedSessionTranscriptWriteContext(params, run);
+}
+
+export async function runWithOwnedSessionTranscriptWritePublication<T>(
+  params: {
+    sessionFile?: string;
+    sessionKey?: string;
+  },
+  run: () => Promise<T> | T,
+): Promise<T> {
+  return await runWithOwnedSessionTranscriptWriteContext(params, run, {
+    publishOwnedWrite: true,
+  });
+}
+
+async function runWithOwnedSessionTranscriptWriteContext<T>(
+  params: {
+    sessionFile?: string;
+    sessionKey?: string;
+  },
+  run: () => Promise<T> | T,
+  options?: { publishOwnedWrite?: boolean },
+): Promise<T> {
   const context = ownedTranscriptWriteContext.getStore();
   if (!context || !contextMatches({ context, ...params })) {
     return await run();
   }
-  return await context.withSessionWriteLock(run, { publishOwnedWrite: true });
+  return await context.withSessionWriteLock(run, options);
 }

--- a/src/config/sessions/transcript-write-context.ts
+++ b/src/config/sessions/transcript-write-context.ts
@@ -4,7 +4,10 @@ import path from "node:path";
 type OwnedSessionTranscriptWriteContext = {
   sessionFile?: string;
   sessionKey?: string;
-  withSessionWriteLock: <T>(run: () => Promise<T> | T) => Promise<T>;
+  withSessionWriteLock: <T>(
+    run: () => Promise<T> | T,
+    options?: { publishOwnedWrite?: boolean },
+  ) => Promise<T>;
 };
 
 const ownedTranscriptWriteContext = new AsyncLocalStorage<OwnedSessionTranscriptWriteContext>();
@@ -55,5 +58,5 @@ export async function runWithOwnedSessionTranscriptWriteLock<T>(
   if (!context || !contextMatches({ context, ...params })) {
     return await run();
   }
-  return await context.withSessionWriteLock(run);
+  return await context.withSessionWriteLock(run, { publishOwnedWrite: true });
 }

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -137,7 +137,7 @@ describe("appendAssistantMessageToSessionTranscript", () => {
     );
 
     expect(result.ok).toBe(true);
-    expect(events).toEqual(["lock", "lock"]);
+    expect(events).toEqual(["lock", "lock", "lock"]);
   });
 
   it("keeps matching owned transcript appends locked from bound callbacks", async () => {

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -22,7 +22,10 @@ import {
   streamSessionTranscriptLines,
   streamSessionTranscriptLinesReverse,
 } from "./transcript-stream.js";
-import { runWithOwnedSessionTranscriptWriteLock } from "./transcript-write-context.js";
+import {
+  runWithOwnedSessionTranscriptWriteLock,
+  runWithOwnedSessionTranscriptWritePublication,
+} from "./transcript-write-context.js";
 import type { SessionEntry } from "./types.js";
 
 let piCodingAgentModulePromise: Promise<typeof import("@earendil-works/pi-coding-agent")> | null =
@@ -317,8 +320,6 @@ export async function appendExactAssistantMessageToSessionTranscript(params: {
   return await runWithOwnedSessionTranscriptWriteLock(
     { sessionFile, sessionKey: resolved.normalizedKey },
     async () => {
-      await ensureSessionHeader({ sessionFile, sessionId: entry.sessionId });
-
       const explicitIdempotencyKey =
         params.idempotencyKey ??
         ((params.message as { idempotencyKey?: unknown }).idempotencyKey as string | undefined);
@@ -344,11 +345,18 @@ export async function appendExactAssistantMessageToSessionTranscript(params: {
         ...params.message,
         ...(explicitIdempotencyKey ? { idempotencyKey: explicitIdempotencyKey } : {}),
       } as Parameters<SessionManager["appendMessage"]>[0];
-      const { messageId, message: appendedMessage } = await appendSessionTranscriptMessage({
-        transcriptPath: sessionFile,
-        message,
-        config: params.config,
-      });
+      const { messageId, message: appendedMessage } =
+        await runWithOwnedSessionTranscriptWritePublication(
+          { sessionFile, sessionKey: resolved.normalizedKey },
+          async () => {
+            await ensureSessionHeader({ sessionFile, sessionId: entry.sessionId });
+            return await appendSessionTranscriptMessage({
+              transcriptPath: sessionFile,
+              message,
+              config: params.config,
+            });
+          },
+        );
 
       switch (params.updateMode ?? "inline") {
         case "inline":


### PR DESCRIPTION
## Summary

- Track exact same-process, lock-owned session-file fingerprints across embedded attempt controllers.
- Allow a released prompt attempt to refresh its fence only when the current file fingerprint exactly matches a later explicit OpenClaw-owned transcript write.
- Preserve fail-closed takeover detection for unowned external session-file changes.
- Forward the owned-write publication flag through the production `promptActiveSession` transcript context.
- Split transcript locking from global owned-fingerprint publication, so broad same-process callbacks, cleanup release, and mixed external edits do not publish globally trusted fingerprints.

## Root Cause

The embedded attempt session fence only compared the session file's filesystem fingerprint saved at `releaseForPrompt()` against the fingerprint observed after the prompt lock was reacquired. That correctly rejects unowned external edits, but it also rejects legitimate OpenClaw-managed transcript appends from another same-process controller/attempt that acquired the session write lock while the first attempt was released for model I/O.

The fix keeps the fingerprint fence, but makes it ownership-aware and narrow: OpenClaw records a globally owned post-write fingerprint only for the exact transcript append publication section, routed through `runWithOwnedSessionTranscriptWritePublication()`, and only when the pre-write fingerprint is already trusted by the process. The broader `runWithOwnedSessionTranscriptWriteLock()` now only provides lock serialization. A released attempt accepts the change only when the current file fingerprint exactly equals a newer owned fingerprint. Direct external edits, external edits followed by a broad locked append, external edits interleaved during cleanup, and external edits inside the broader owned transcript lock still fail closed.

Fixes #84059.

## Real behavior proof

- **Behavior or issue addressed**: A prompt-released embedded attempt no longer throws `EmbeddedAttemptSessionTakeoverError` when another controller publishes an explicit owned transcript append for the same session file. External unowned file changes still throw, including an external edit interleaved during a broad same-process locked callback, an external edit interleaved while another controller holds the cleanup lock, and an external edit inside the broader owned transcript lock before the narrow append publication section.
- **Real environment tested**: Local patched OpenClaw checkout at original proof head `7008438d978c75a21e811df4e2dc041d9f9dfe71`, then rebased/verified again through current PR head `da570f3c09b47fce4ee8bd0c92fbb91d1d3d8ea4`, macOS arm64, Node.js `v24.15.0`, real temp session files on the local filesystem, real OpenClaw `acquireSessionWriteLock`.
- **Failing proof before fix**: The new regression test was run before the implementation and failed with the reported error:

```text
AssertionError: promise rejected "EmbeddedAttemptSessionTakeoverError: sess..." instead of resolving

Caused by: EmbeddedAttemptSessionTakeoverError: session file changed while embedded prompt lock was released: .../session.jsonl
```

- **Exact steps or command run after this patch**:

```text
node --import tsx ../proof-embedded-session-lock-in-process.ts
```

- **Evidence after fix**:

```text
OpenClaw proof checkout: /Users/tianxiao/Documents/Codex/2026-05-19/openclaw-message-tool-bug/openclaw-community
In-process locked write result: post-write-committed
In-process takeover detected: false
In-process session line count: 3
External direct write error: EmbeddedAttemptSessionTakeoverError: session file changed while embedded prompt lock was released: /var/folders/wv/szx379kx7r135_kzktxrrs680000gn/T/openclaw-session-lock-proof-Bfobcy/external-session.jsonl
External takeover detected: true
External session line count: 2
External plus locked write error: EmbeddedAttemptSessionTakeoverError: session file changed while embedded prompt lock was released: /var/folders/wv/szx379kx7r135_kzktxrrs680000gn/T/openclaw-session-lock-proof-Bfobcy/external-then-locked-session.jsonl
External plus locked takeover detected: true
External plus locked session line count: 3
```

- **Observed result after fix**: The in-process two-controller proof commits the post-prompt write without setting takeover. Separate external direct and external-plus-locked cases still reject with `EmbeddedAttemptSessionTakeoverError`, proving a locked append does not launder an earlier external edit. The latest unit regressions also prove cleanup-lock release and broad owned transcript lock scopes do not launder external edits into globally owned fingerprints.
- **What was not tested**: I did not run a live Feishu, Slack, WebChat, or Discord channel smoke. The proof uses the embedded session-lock controller directly with real filesystem writes to reproduce the source-level race without sending live channel messages.

## Tests

After rebasing onto current `origin/main` (`5d775122c1`):

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-pi-embedded.config.ts src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts` -> 20 passed
- `node scripts/run-vitest.mjs src/config/sessions/transcript.test.ts src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts` -> 3 files, 62 passed
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo` -> passed
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo` -> passed
- `git diff --check` -> passed

## Security-boundary update

- Added a production-shaped prompt context regression so the `publishOwnedWrite` option is forwarded to `sessionLockController.withSessionWriteLock()`.
- Removed cleanup-lock release fingerprint publication; cleanup no longer marks changed final session-file state as globally owned.
- Split broad owned transcript locking from narrow owned transcript write publication.
- Added regressions for external appends interleaved while another controller holds cleanup lock and inside a broad owned transcript lock.
- Ordinary broad `withSessionWriteLock()` callbacks still refresh their own controller fence, but no longer publish a globally owned fingerprint for other released controllers to accept.
