### PR TITLE
Fix Codex image generation tool timeout

### DIFF
--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -256,6 +256,8 @@ available timeout in this order:
 
 - A positive per-call `timeoutMs` argument.
 - For `image_generate`, `agents.defaults.imageGenerationModel.timeoutMs`.
+- For `image_generate` without a configured timeout, the 120 second
+  image-generation default.
 - For the media-understanding `image` tool, `tools.media.image.timeoutSeconds`
   converted to milliseconds, or the 60 second media default.
 - The 30 second dynamic-tool default.

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -530,9 +530,10 @@ Supported `appServer` fields:
 OpenClaw-owned dynamic tool calls are bounded independently from
 `appServer.requestTimeoutMs`: Codex `item/tool/call` requests use a 30 second
 OpenClaw watchdog by default. A positive per-call `timeoutMs` argument extends
-or shortens that specific tool budget. The `image_generate` tool also uses
+or shortens that specific tool budget. The `image_generate` tool uses
 `agents.defaults.imageGenerationModel.timeoutMs` when the tool call does not
-provide its own timeout, and the media-understanding `image` tool uses
+provide its own timeout, or a 120 second image-generation default otherwise.
+The media-understanding `image` tool uses
 `tools.media.image.timeoutSeconds` or its 60 second media default. Dynamic tool
 budgets are capped at 600000 ms. On timeout, OpenClaw aborts the tool signal
 where supported and returns a failed dynamic-tool response to Codex so the turn

--- a/docs/tools/image-generation.md
+++ b/docs/tools/image-generation.md
@@ -237,8 +237,9 @@ from each attempt.
     backends. A per-call `timeoutMs` tool parameter overrides the configured
     default. Google, OpenRouter, and xAI hosted image providers use 180 second
     defaults; Azure OpenAI image generation uses 600 seconds. Codex dynamic-tool
-    calls honor the same timeout budget, bounded by OpenClaw's 600000 ms
-    dynamic-tool bridge maximum.
+    calls use a 120 second `image_generate` bridge default and honor the same
+    timeout budget when configured, bounded by OpenClaw's 600000 ms dynamic-tool
+    bridge maximum.
   </Accordion>
   <Accordion title="Inspect at runtime">
     Use `action: "list"` to inspect the currently registered providers,

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -1889,6 +1889,22 @@ describe("runCodexAppServerAttempt", () => {
     ).toBe(180_000);
   });
 
+  it("uses a media-safe default for Codex image generation dynamic tool calls", () => {
+    expect(
+      testing.resolveDynamicToolCallTimeoutMs({
+        call: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          callId: "call-image-generate-default",
+          namespace: null,
+          tool: "image_generate",
+          arguments: { prompt: "cat" },
+        },
+        config: undefined,
+      }),
+    ).toBe(testing.CODEX_DYNAMIC_IMAGE_GENERATION_TOOL_TIMEOUT_MS);
+  });
+
   it("uses the media image timeout for Codex image dynamic tool calls", () => {
     expect(
       testing.resolveDynamicToolCallTimeoutMs({

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -179,6 +179,7 @@ import { filterToolsForVisionInputs } from "./vision-tools.js";
 
 const CODEX_DYNAMIC_TOOL_TIMEOUT_MS = 30_000;
 const CODEX_DYNAMIC_TOOL_MAX_TIMEOUT_MS = 600_000;
+const CODEX_DYNAMIC_IMAGE_GENERATION_TOOL_TIMEOUT_MS = 120_000;
 const CODEX_DYNAMIC_IMAGE_TOOL_TIMEOUT_MS = 60_000;
 const CODEX_APP_SERVER_STARTUP_CONNECTION_CLOSE_MAX_ATTEMPTS = 3;
 const CODEX_APP_SERVER_STARTUP_TIMEOUT_FLOOR_MS = 100;
@@ -2991,9 +2992,12 @@ function readConfiguredDynamicToolTimeoutMs(
   if (toolName === "image_generate") {
     const imageGenerationModel = config?.agents?.defaults?.imageGenerationModel;
     if (!imageGenerationModel || typeof imageGenerationModel !== "object") {
-      return undefined;
+      return CODEX_DYNAMIC_IMAGE_GENERATION_TOOL_TIMEOUT_MS;
     }
-    return readPositiveFiniteTimeoutMs(imageGenerationModel.timeoutMs);
+    return (
+      readPositiveFiniteTimeoutMs(imageGenerationModel.timeoutMs) ??
+      CODEX_DYNAMIC_IMAGE_GENERATION_TOOL_TIMEOUT_MS
+    );
   }
 
   if (toolName === "image") {
@@ -4649,6 +4653,7 @@ function handleApprovalRequest(params: {
 export const testing = {
   CODEX_DYNAMIC_TOOL_TIMEOUT_MS,
   CODEX_DYNAMIC_TOOL_MAX_TIMEOUT_MS,
+  CODEX_DYNAMIC_IMAGE_GENERATION_TOOL_TIMEOUT_MS,
   CODEX_DYNAMIC_IMAGE_TOOL_TIMEOUT_MS,
   CODEX_TURN_COMPLETION_IDLE_TIMEOUT_MS,
   CODEX_TURN_TERMINAL_IDLE_TIMEOUT_MS,


### PR DESCRIPTION
## Summary\n- Add a 120s Codex dynamic-tool default for image_generate calls when no per-call or configured timeout is provided\n- Preserve the existing 30s generic dynamic-tool default and 600s cap\n- Document the image generation timeout behavior in Codex and image generation docs\n\n## Verification\n- COREPACK_HOME=/home/shorty/.cache/corepack corepack pnpm exec vitest run --config tmp-vitest.codex-timeout.config.ts -t "dynamic tool timeouts|image generation dynamic tool"\n- Full run-attempt test file: 182/183 passed; one pre-existing unrelated policy-context test failed (passes session plugin app policy context to elicitation handling)\n

## Real behavior proof

This was reproduced on a real local OpenClaw Gateway using the OpenAI provider configured with `openai/gpt-image-2` as `agents.defaults.imageGenerationModel.primary`.

Before the fix, `image_generate` calls through Codex failed at the dynamic-tool bridge before provider completion:

```text
OpenClaw dynamic tool call timed out after 30000ms while running tool image_generate.
```

After applying the local equivalent of this change, setting the image-generation timeout to 120000 ms, and fully restarting the Gateway process, the same live call succeeded:

```text
Generated 1 image with openai/gpt-image-2.
MEDIA:/home/shorty/.openclaw/media/tool-image-generation/image-1---a17e2b9e-0c86-4d03-9b07-cbd59d20f746.jpg
```

The local provider list also reported OpenAI image generation configured with Codex OAuth/OpenAI auth support and `gpt-image-2` available before the successful run.
