### PR TITLE
[codex] fix iOS TestFlight release archive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 - WhatsApp: drain pending outbound deliveries on a 30s periodic timer in addition to the reconnect handler, so messages enqueued while the provider is already connected no longer wait for the next reconnect to send. (#79083) Thanks @Oviemudiaga.
 - CLI/TUI: include gateway plugin slash commands in TUI autocomplete, so connected sessions can suggest plugin-owned commands exposed by the running Gateway. (#83640) Thanks @se7en-agent.
 - Gateway/mobile: restore QR setup-code handoff of bounded operator tokens for iOS and Android onboarding while keeping admin and pairing scopes out of bootstrap. (#83684) Thanks @ngutman.
+- iOS: repair Release archive compilation for the TestFlight build. (#84255) Thanks @ngutman.
 
 ## 2026.5.19
 

--- a/apps/ios/Sources/Onboarding/GatewayOnboardingReset.swift
+++ b/apps/ios/Sources/Onboarding/GatewayOnboardingReset.swift
@@ -2,6 +2,7 @@ import Foundation
 import OpenClawKit
 
 enum GatewayOnboardingReset {
+    @MainActor
     static func reset(
         appModel: NodeAppModel,
         instanceId: String,

--- a/apps/ios/Sources/Onboarding/OnboardingWizardView.swift
+++ b/apps/ios/Sources/Onboarding/OnboardingWizardView.swift
@@ -1017,7 +1017,7 @@ struct OnboardingWizardView: View {
 
     private func gatewayProblemPrimaryActionTitle(_ problem: GatewayConnectionProblem) -> String {
         if problem.suggestsOnboardingReset { return "Scan QR again" }
-        problem.canTrustRotatedCertificate ? "Trust certificate" : "Retry connection"
+        return problem.canTrustRotatedCertificate ? "Trust certificate" : "Retry connection"
     }
 
     private func handleGatewayProblemPrimaryAction(_ problem: GatewayConnectionProblem) async {

--- a/apps/ios/Sources/Settings/SettingsTab.swift
+++ b/apps/ios/Sources/Settings/SettingsTab.swift
@@ -1058,7 +1058,7 @@ struct SettingsTab: View {
 
     private func gatewayProblemPrimaryActionTitle(_ problem: GatewayConnectionProblem) -> String {
         if problem.suggestsOnboardingReset { return "Reset onboarding" }
-        problem.canTrustRotatedCertificate ? "Trust certificate" : "Retry connection"
+        return problem.canTrustRotatedCertificate ? "Trust certificate" : "Retry connection"
     }
 
     private func handleGatewayProblemPrimaryAction(_ problem: GatewayConnectionProblem) async {


### PR DESCRIPTION
## Summary

- mark the shared onboarding reset helper as `@MainActor` so it can call the main-actor isolated `NodeAppModel.disconnectGateway()` during Release archives
- add explicit returns in two gateway problem title helpers that failed the iOS Release compiler lane

## Verification

- `pnpm ios:version:check`
- `OPENCLAW_PUSH_RELAY_BASE_URL=https://sincere-civet-851.convex.site/ pnpm ios:beta`

Behavior addressed: iOS Release archive compile failures that blocked TestFlight upload
Real environment tested: local Xcode/Fastlane TestFlight release flow from this branch
Exact steps or command run after this patch: sourced ASC Fastlane metadata from `/Users/guti/projects/openclaw/copy-1/apps/ios/fastlane/.env`, exported `OPENCLAW_PUSH_RELAY_BASE_URL=https://sincere-civet-851.convex.site/`, then ran `pnpm ios:beta`
Evidence after fix: Fastlane archived, exported `apps/ios/build/beta/OpenClaw-2026.5.19.ipa`, and uploaded to App Store Connect
Observed result after fix: `Uploaded iOS beta: version=2026.5.19 short=2026.5.19 build=1`
What was not tested: waiting for App Store Connect/TestFlight processing after upload; the lane used `skip_waiting_for_build_processing`
