### PR TITLE
perf(plugins): extend discovery threading to loader, manifest registry, installed-index, and config contracts

### DIFF
--- a/src/plugins/config-contracts.ts
+++ b/src/plugins/config-contracts.ts
@@ -1,6 +1,6 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isRecord } from "../utils.js";
-import { discoverOpenClawPlugins } from "./discovery.js";
+import { discoverOpenClawPlugins, type PluginDiscoveryResult } from "./discovery.js";
 import { loadPluginManifestRegistry } from "./manifest-registry.js";
 import type { PluginManifestConfigContracts } from "./manifest.js";
 import type { PluginOrigin } from "./plugin-origin.types.js";
@@ -114,6 +114,13 @@ export function resolvePluginConfigContractsById(params: {
   fallbackToBundledMetadataForResolvedBundled?: boolean;
   fallbackBundledPluginIds?: readonly string[];
   pluginIds: readonly string[];
+  /**
+   * Pre-computed discovery result. When supplied, the bundled-fallback path
+   * skips its internal `discoverOpenClawPlugins` call so callers sharing a
+   * discovery snapshot across registry helpers avoid redundant filesystem
+   * walks.
+   */
+  discovery?: PluginDiscoveryResult;
 }): ReadonlyMap<string, PluginConfigContractMetadata> {
   const matches = new Map<string, PluginConfigContractMetadata>();
   const pluginIds = [
@@ -132,10 +139,12 @@ export function resolvePluginConfigContractsById(params: {
     if (bundledContractFallbacks.has(pluginId)) {
       return bundledContractFallbacks.get(pluginId);
     }
-    const discovery = discoverOpenClawPlugins({
-      workspaceDir: params.workspaceDir,
-      env: params.env,
-    });
+    const discovery =
+      params.discovery ??
+      discoverOpenClawPlugins({
+        workspaceDir: params.workspaceDir,
+        env: params.env,
+      });
     const registry = loadPluginManifestRegistry({
       config: params.config,
       workspaceDir: params.workspaceDir,

--- a/src/plugins/discovery-threading.test.ts
+++ b/src/plugins/discovery-threading.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PluginDiscoveryResult } from "./discovery.js";
+
+const discoverOpenClawPluginsMock = vi.fn();
+
+vi.mock("./discovery.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./discovery.js")>();
+  return {
+    ...actual,
+    discoverOpenClawPlugins: (...args: unknown[]) => discoverOpenClawPluginsMock(...args),
+  };
+});
+
+const { loadPluginManifestRegistry } = await import("./manifest-registry.js");
+const { resolveInstalledPluginIndexRegistry } =
+  await import("./installed-plugin-index-registry.js");
+
+const emptyDiscovery: PluginDiscoveryResult = { candidates: [], diagnostics: [] };
+
+describe("discovery threading", () => {
+  beforeEach(() => {
+    discoverOpenClawPluginsMock.mockReset();
+    discoverOpenClawPluginsMock.mockReturnValue(emptyDiscovery);
+  });
+
+  describe("loadPluginManifestRegistry", () => {
+    it("skips internal discoverOpenClawPlugins when discovery is supplied", () => {
+      loadPluginManifestRegistry({ discovery: emptyDiscovery });
+      expect(discoverOpenClawPluginsMock).not.toHaveBeenCalled();
+    });
+
+    it("calls discoverOpenClawPlugins when neither discovery nor candidates supplied", () => {
+      loadPluginManifestRegistry({});
+      expect(discoverOpenClawPluginsMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("prefers explicit candidates over discovery when both are supplied", () => {
+      loadPluginManifestRegistry({ candidates: [], diagnostics: [], discovery: emptyDiscovery });
+      expect(discoverOpenClawPluginsMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("resolveInstalledPluginIndexRegistry", () => {
+    it("skips internal discoverOpenClawPlugins when discovery is supplied", () => {
+      resolveInstalledPluginIndexRegistry({ discovery: emptyDiscovery, installRecords: {} });
+      expect(discoverOpenClawPluginsMock).not.toHaveBeenCalled();
+    });
+
+    it("calls discoverOpenClawPlugins when neither discovery nor candidates supplied", () => {
+      resolveInstalledPluginIndexRegistry({ installRecords: {} });
+      expect(discoverOpenClawPluginsMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("prefers explicit candidates over discovery when both are supplied", () => {
+      resolveInstalledPluginIndexRegistry({
+        candidates: [],
+        discovery: emptyDiscovery,
+        installRecords: {},
+      });
+      expect(discoverOpenClawPluginsMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/plugins/installed-plugin-index-registry.ts
+++ b/src/plugins/installed-plugin-index-registry.ts
@@ -25,12 +25,14 @@ export function resolveInstalledPluginIndexRegistry(params: LoadInstalledPluginI
   const normalized = normalizePluginsConfig(params.config?.plugins);
   const installRecords =
     params.installRecords ?? loadInstalledPluginIndexInstallRecordsSync({ env: params.env });
-  const discovery = discoverOpenClawPlugins({
-    workspaceDir: params.workspaceDir,
-    extraPaths: normalized.loadPaths,
-    env: params.env,
-    installRecords,
-  });
+  const discovery =
+    params.discovery ??
+    discoverOpenClawPlugins({
+      workspaceDir: params.workspaceDir,
+      extraPaths: normalized.loadPaths,
+      env: params.env,
+      installRecords,
+    });
   return {
     candidates: discovery.candidates,
     registry: loadPluginManifestRegistry({

--- a/src/plugins/installed-plugin-index-types.ts
+++ b/src/plugins/installed-plugin-index-types.ts
@@ -1,7 +1,7 @@
 import type { OpenClawConfig } from "../config/types.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import type { PluginCompatCode } from "./compat/registry.js";
-import type { PluginCandidate } from "./discovery.js";
+import type { PluginCandidate, PluginDiscoveryResult } from "./discovery.js";
 import type { PluginInstallSourceInfo } from "./install-source-info.js";
 import type { InstalledPluginFileSignature } from "./installed-plugin-index-hash.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
@@ -130,6 +130,13 @@ export type LoadInstalledPluginIndexParams = {
   installRecords?: Record<string, PluginInstallRecord>;
   candidates?: PluginCandidate[];
   diagnostics?: PluginDiagnostic[];
+  /**
+   * Pre-computed discovery result. When supplied (and `candidates` is not),
+   * the internal `discoverOpenClawPlugins` call is skipped. Callers sharing a
+   * discovery snapshot across registry helpers in the same flow should supply
+   * this to avoid redundant filesystem walks.
+   */
+  discovery?: PluginDiscoveryResult;
   now?: () => Date;
 };
 

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -50,7 +50,11 @@ import {
   type NormalizedPluginsConfig,
 } from "./config-state.js";
 import { isPluginEnabledByDefaultForPlatform } from "./default-enablement.js";
-import { discoverOpenClawPlugins, type PluginCandidate } from "./discovery.js";
+import {
+  discoverOpenClawPlugins,
+  type PluginCandidate,
+  type PluginDiscoveryResult,
+} from "./discovery.js";
 import { shouldRejectHardlinkedPluginFiles } from "./hardlink-policy.js";
 import { getGlobalHookRunner, initializeGlobalHookRunner } from "./hook-runner-global.js";
 import { toSafeImportPath } from "./import-specifier.js";
@@ -198,6 +202,14 @@ export type PluginLoadOptions = {
   loadModules?: boolean;
   throwOnLoadError?: boolean;
   manifestRegistry?: PluginManifestRegistry;
+  /**
+   * Pre-computed plugin discovery result. When supplied, internal calls to
+   * `discoverOpenClawPlugins` are skipped. Callers in the same startup flow
+   * can compute one discovery result and share it across loader entry points
+   * to eliminate redundant filesystem walks. Ignored when `manifestRegistry`
+   * is also provided (the registry already implies a discovery snapshot).
+   */
+  discovery?: PluginDiscoveryResult;
 };
 
 function detailPluginStartupTrace(
@@ -1690,12 +1702,13 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
           candidates: createPluginCandidatesFromManifestRegistry(suppliedManifestRegistry),
           diagnostics: [] as PluginDiagnostic[],
         }
-      : discoverOpenClawPlugins({
+      : (options.discovery ??
+        discoverOpenClawPlugins({
           workspaceDir: options.workspaceDir,
           extraPaths: normalized.loadPaths,
           env,
           installRecords,
-        });
+        }));
     const manifestRegistry =
       suppliedManifestRegistry ??
       loadPluginManifestRegistry({
@@ -2559,12 +2572,14 @@ export async function loadOpenClawPluginCliRegistry(
     activateGlobalSideEffects: false,
   });
 
-  const discovery = discoverOpenClawPlugins({
-    workspaceDir: options.workspaceDir,
-    extraPaths: normalized.loadPaths,
-    env,
-    installRecords,
-  });
+  const discovery =
+    options.discovery ??
+    discoverOpenClawPlugins({
+      workspaceDir: options.workspaceDir,
+      extraPaths: normalized.loadPaths,
+      env,
+      installRecords,
+    });
   const manifestRegistry = loadPluginManifestRegistry({
     config: cfg,
     workspaceDir: options.workspaceDir,

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -10,7 +10,11 @@ import { resolveUserPath } from "../utils.js";
 import { resolveCompatibilityHostVersion } from "../version.js";
 import { loadBundleManifest } from "./bundle-manifest.js";
 import { normalizePluginsConfigWithResolver } from "./config-policy.js";
-import { discoverOpenClawPlugins, type PluginCandidate } from "./discovery.js";
+import {
+  discoverOpenClawPlugins,
+  type PluginCandidate,
+  type PluginDiscoveryResult,
+} from "./discovery.js";
 import { shouldRejectHardlinkedPluginFiles } from "./hardlink-policy.js";
 import { loadInstalledPluginIndexInstallRecordsSync } from "./installed-plugin-index-record-reader.js";
 import type { PluginManifestCommandAlias } from "./manifest-command-aliases.js";
@@ -916,6 +920,13 @@ export function loadPluginManifestRegistry(
     diagnostics?: PluginDiagnostic[];
     installRecords?: Record<string, PluginInstallRecord>;
     bundledChannelConfigCollector?: BundledChannelConfigCollector;
+    /**
+     * Pre-computed discovery result. When supplied (and `candidates` is not),
+     * the internal `discoverOpenClawPlugins` call is skipped. Callers sharing
+     * a discovery snapshot across multiple registry helpers in the same flow
+     * should supply this to avoid redundant filesystem walks.
+     */
+    discovery?: PluginDiscoveryResult;
   } = {},
 ): PluginManifestRegistry {
   const config = params.config ?? {};
@@ -936,12 +947,13 @@ export function loadPluginManifestRegistry(
         candidates: params.candidates,
         diagnostics: params.diagnostics ?? [],
       }
-    : discoverOpenClawPlugins({
+    : (params.discovery ??
+      discoverOpenClawPlugins({
         workspaceDir: params.workspaceDir,
         extraPaths: normalized.loadPaths,
         env,
         installRecords: getInstallRecords(),
-      });
+      }));
   const diagnostics: PluginDiagnostic[] = [...discovery.diagnostics];
   const candidates: PluginCandidate[] = discovery.candidates;
   const records: PluginManifestRecord[] = [];


### PR DESCRIPTION
## Summary

Follow-up to #75451. Extends the function-scoped `discovery?: PluginDiscoveryResult` threading pattern to the remaining four plugin subsystems that still call `discoverOpenClawPlugins` internally during startup, plus tests asserting the wiring.

`discoverOpenClawPlugins` remains stateless. Sharing is function-scoped per `src/plugins/CLAUDE.md` guidance. Every change is additive (a new optional param) and backward compatible — existing callers are unaffected.

## What this PR adds

| File | Change |
|---|---|
| `src/plugins/loader.ts` | Added `discovery?` to `PluginLoadOptions`; both call sites (`loadOpenClawPlugins` and `loadOpenClawPluginCliRegistry`) consult it before doing their own scan. |
| `src/plugins/manifest-registry.ts` | Added `discovery?` to `loadPluginManifestRegistry` params; used when `candidates?` is not supplied. |
| `src/plugins/installed-plugin-index-types.ts` + `installed-plugin-index-registry.ts` | Added `discovery?` to `LoadInstalledPluginIndexParams`; `resolveInstalledPluginIndexRegistry` uses it when `candidates?` is not supplied. |
| `src/plugins/config-contracts.ts` | Added `discovery?` to `resolvePluginConfigContractsById`; threaded into the bundled-fallback closure. |
| `src/plugins/discovery-threading.test.ts` (new) | 6 tests asserting each entry point: (a) skips its internal `discoverOpenClawPlugins` call when `discovery` is supplied, (b) calls it when nothing is supplied, (c) prefers explicit `candidates?` over `discovery?` when both are present. |

#75451 covered `bundled-capability-runtime`, `bundled-sources`, `channel-catalog-registry`, and the `contracts/registry` retry loop. With this PR, all known `discoverOpenClawPlugins` callers in `src/plugins/` accept an optional shared discovery snapshot. Top-level orchestrators can compute one discovery per CLI/TUI/gateway flow and pass it through.

## Context: what we measured before #75451 landed

The freeze that motivated this work is a 25–30s TUI startup with the process at `R+ 101% CPU`, doing **212,119 synchronous JSON reads against only 379 unique paths** per launch — each bundled extension's `package.json` re-read ~1,500 times. CPU profile Bottom-Up was dominated by `lstat` (24%), `open` (13%), `realpathSync` (13% total), with `jiti` source-transform and GC making up the rest. An event-loop heartbeat probe showed the JS event loop blocked for the full freeze duration. The detailed evidence is on #75451: https://github.com/openclaw/openclaw/pull/75451#issuecomment-4491104413

This PR is necessary but not sufficient to close the freeze on its own. It is preparatory plumbing that lets callers actually realize the sharing. A separate follow-up should:

1. Identify the top-level orchestration sites where TUI / CLI / gateway startup invokes multiple of these helpers in sequence.
2. Compute one `PluginDiscoveryResult` there and thread it through each call.
3. Investigate the inside-discovery amplifier (~1,500× per-manifest reads inside one scan) and Node `require()`-driven `package.json` walks during plugin module loading — those are larger costs than the outer scan dedup addressed here.

## Test plan

- [x] `node scripts/run-vitest.mjs src/plugins/discovery-threading.test.ts` — 6/6 pass
- [x] `pnpm tsgo --noEmit --project tsconfig.core.json` — clean
- [x] `node scripts/run-oxlint.mjs --quiet` on touched files — 0 warnings, 0 errors
- [x] `npx oxfmt --check` — clean

Verified the 5 pre-existing failures in `src/plugins/manifest-registry.test.ts` ("suppresses duplicate warnings..." etc.) reproduce on clean main without this PR's changes — unrelated regression.

Behavior addressed: each of the four remaining plugin subsystem helpers in `src/plugins/` independently re-invokes `discoverOpenClawPlugins` during the same startup flow when not explicitly handed a shared discovery snapshot. After #75451 only three helpers + one retry loop had the option to skip the redundant scan; with this PR, all known call sites can.
Real environment tested: macOS, Node 22.22, source checkout. Same setup that produced the 212K-read profile referenced above.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugins/discovery-threading.test.ts`; `pnpm tsgo --noEmit --project tsconfig.core.json`; `node scripts/run-oxlint.mjs --quiet src/plugins/{loader,manifest-registry,installed-plugin-index-registry,installed-plugin-index-types,config-contracts,discovery-threading.test}.ts`; `npx oxfmt --check`.
Evidence after fix: 6 new tests pass; lint/format/typecheck clean.
Observed result after fix: each entry point demonstrably skips its internal discovery call when `discovery` is supplied (asserted by the new test suite via a `vi.mock` spy on `discoverOpenClawPlugins`).
What was not tested: end-to-end TUI startup timing on this PR alone. The sharing is preparatory — orchestrator-level threading that supplies the same discovery to multiple helpers in one flow is a separate follow-up. This PR is the structural prerequisite for that work.
