### PR TITLE
fix(cli): validate debug proxy numeric options

### DIFF
--- a/src/cli/proxy-cli.test.ts
+++ b/src/cli/proxy-cli.test.ts
@@ -3,6 +3,17 @@ import { describe, expect, it } from "vitest";
 import { registerProxyCli } from "./proxy-cli.js";
 
 describe("proxy cli", () => {
+  function createProgram() {
+    const program = new Command();
+    program.exitOverride();
+    program.configureOutput({
+      writeErr: () => undefined,
+      writeOut: () => undefined,
+    });
+    registerProxyCli(program);
+    return program;
+  }
+
   it("registers the debug proxy subcommands", () => {
     const program = new Command();
     registerProxyCli(program);
@@ -31,5 +42,18 @@ describe("proxy cli", () => {
       "--apns-authority",
       "--timeout-ms",
     ]);
+  });
+
+  it.each([
+    [["proxy", "sessions", "--limit", "abc"], /--limit must be an integer/],
+    [["proxy", "sessions", "--limit", "0"], /--limit must be a positive integer/],
+    [["proxy", "validate", "--timeout-ms", "1.5"], /--timeout-ms must be an integer/],
+    [["proxy", "validate", "--timeout-ms", "0"], /--timeout-ms must be a positive integer/],
+    [["proxy", "start", "--port", "abc"], /--port must be an integer/],
+    [["proxy", "run", "--port", "65536"], /--port must be between 0 and 65535/],
+  ])("rejects invalid numeric option %s", (args, expected) => {
+    const program = createProgram();
+
+    expect(() => program.parse(["node", "openclaw", ...args])).toThrow(expected);
   });
 });

--- a/src/cli/proxy-cli.ts
+++ b/src/cli/proxy-cli.ts
@@ -1,4 +1,4 @@
-import type { Command } from "commander";
+import { InvalidArgumentError, type Command } from "commander";
 import type { CaptureQueryPreset } from "../proxy-capture/types.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
 
@@ -12,12 +12,32 @@ async function loadProxyCliRuntime(): Promise<ProxyCliRuntime> {
   return await proxyCliRuntimeLoader.load();
 }
 
-function parseOptionalNumber(value: string | undefined): number | undefined {
-  if (!value) {
-    return undefined;
+function parseIntegerOption(value: string | undefined, flag: string): number {
+  const trimmed = value?.trim() ?? "";
+  if (!/^\d+$/u.test(trimmed)) {
+    throw new InvalidArgumentError(`${flag} must be an integer.`);
   }
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : undefined;
+  const parsed = Number(trimmed);
+  if (!Number.isSafeInteger(parsed)) {
+    throw new InvalidArgumentError(`${flag} must be a safe integer.`);
+  }
+  return parsed;
+}
+
+function parsePortOption(value: string | undefined): number {
+  const parsed = parseIntegerOption(value, "--port");
+  if (parsed > 65_535) {
+    throw new InvalidArgumentError("--port must be between 0 and 65535.");
+  }
+  return parsed;
+}
+
+function parsePositiveIntegerOption(value: string | undefined, flag: string): number {
+  const parsed = parseIntegerOption(value, flag);
+  if (parsed <= 0) {
+    throw new InvalidArgumentError(`${flag} must be a positive integer.`);
+  }
+  return parsed;
 }
 
 function collectOption(value: string, previous: string[] | undefined): string[] {
@@ -33,7 +53,7 @@ export function registerProxyCli(program: Command) {
     .command("start")
     .description("Start the local explicit debug proxy")
     .option("--host <host>", "Bind host", "127.0.0.1")
-    .option("--port <port>", "Bind port", parseOptionalNumber)
+    .option("--port <port>", "Bind port", parsePortOption)
     .action(async (opts: { host?: string; port?: number }) => {
       const runtime = await loadProxyCliRuntime();
       await runtime.runDebugProxyStartCommand(opts);
@@ -45,7 +65,7 @@ export function registerProxyCli(program: Command) {
     .allowUnknownOption(true)
     .allowExcessArguments(true)
     .option("--host <host>", "Bind host", "127.0.0.1")
-    .option("--port <port>", "Bind port", parseOptionalNumber)
+    .option("--port <port>", "Bind port", parsePortOption)
     .argument("[cmd...]", "Command to run after --")
     .action(async (cmd: string[], opts: { host?: string; port?: number }) => {
       const runtime = await loadProxyCliRuntime();
@@ -70,7 +90,9 @@ export function registerProxyCli(program: Command) {
     .option("--denied-url <url>", "Destination expected to be blocked by the proxy", collectOption)
     .option("--apns-reachable", "Also verify sandbox APNs HTTP/2 is reachable through the proxy")
     .option("--apns-authority <url>", "APNs authority to probe with --apns-reachable")
-    .option("--timeout-ms <ms>", "Per-request timeout in milliseconds", parseOptionalNumber)
+    .option("--timeout-ms <ms>", "Per-request timeout in milliseconds", (value) =>
+      parsePositiveIntegerOption(value, "--timeout-ms"),
+    )
     .action(
       async (opts: {
         json?: boolean;
@@ -107,7 +129,9 @@ export function registerProxyCli(program: Command) {
   proxy
     .command("sessions")
     .description("List recent capture sessions")
-    .option("--limit <count>", "Maximum sessions to show", parseOptionalNumber)
+    .option("--limit <count>", "Maximum sessions to show", (value) =>
+      parsePositiveIntegerOption(value, "--limit"),
+    )
     .action(async (opts: { limit?: number }) => {
       const runtime = await loadProxyCliRuntime();
       await runtime.runDebugProxySessionsCommand(opts);


### PR DESCRIPTION
## Summary

- Reject invalid debug proxy numeric CLI options before runtime dispatch
- Keep `--port` bounded to an integer 0-65535
- Require positive integers for `proxy validate --timeout-ms` and `proxy sessions --limit`
- Add Commander-level regression coverage for bad proxy numeric values

Fixes #84253

## Real behavior proof

Behavior or issue addressed: `openclaw proxy sessions --limit abc` should fail as an invalid CLI argument instead of reaching the debug proxy SQLite store and surfacing `datatype mismatch`.

Real environment tested: Fresh OpenClaw source checkout rebased onto current `origin/main` on macOS, using the real source CLI entry with isolated debug-proxy DB/blob/cert paths under `/tmp`.

Exact steps or command run after this patch:

```text
env OPENCLAW_DEBUG=1 OPENCLAW_DEBUG_PROXY_DB_PATH=/tmp/openclaw-proxy-proof-rebased-invalid.sqlite OPENCLAW_DEBUG_PROXY_BLOB_DIR=/tmp/openclaw-proxy-proof-rebased-invalid-blobs OPENCLAW_DEBUG_PROXY_CERT_DIR=/tmp/openclaw-proxy-proof-rebased-invalid-certs NO_COLOR=1 pnpm exec tsx src/entry.ts proxy sessions --limit abc
```

Evidence after fix:

```text
OpenClaw could not parse this command: option '--limit <count>' argument 'abc' is invalid. --limit must be an integer.
Try: openclaw proxy sessions --help
```

Observed result after fix: The invalid `--limit abc` value is rejected by the CLI parser before `runDebugProxySessionsCommand()` calls `DebugProxyCaptureStore.listSessions()`, so the SQLite `datatype mismatch` no longer leaks to the user. A valid command still works:

```text
env OPENCLAW_DEBUG=1 OPENCLAW_DEBUG_PROXY_DB_PATH=/tmp/openclaw-proxy-proof-rebased-valid.sqlite OPENCLAW_DEBUG_PROXY_BLOB_DIR=/tmp/openclaw-proxy-proof-rebased-valid-blobs OPENCLAW_DEBUG_PROXY_CERT_DIR=/tmp/openclaw-proxy-proof-rebased-valid-certs NO_COLOR=1 pnpm exec tsx src/entry.ts proxy sessions --limit 1
[]
```

What was not tested: I did not rebuild the packaged `dist/entry.js` launcher in this source worktree; proof used the real TypeScript source CLI entry. I also did not connect through a live debug proxy, because the changed behavior is argument parsing before proxy runtime startup.

## Before-fix evidence

On fresh `origin/main` (`e00cb664ad`), the same actual source CLI path accepted the invalid value far enough to hit SQLite:

```text
env OPENCLAW_DEBUG=1 OPENCLAW_DEBUG_PROXY_DB_PATH=/tmp/openclaw-proxy-proof-2.sqlite OPENCLAW_DEBUG_PROXY_BLOB_DIR=/tmp/openclaw-proxy-proof-2-blobs OPENCLAW_DEBUG_PROXY_CERT_DIR=/tmp/openclaw-proxy-proof-2-certs NO_COLOR=1 pnpm exec tsx src/entry.ts proxy sessions --limit abc
[openclaw] Reason: datatype mismatch
[openclaw] Stack:
[openclaw] Error: datatype mismatch
[openclaw]     at DebugProxyCaptureStore.listSessions (.../src/proxy-capture/store.sqlite.ts:211:8)
[openclaw]     at Module.runDebugProxySessionsCommand (.../src/cli/proxy-cli.runtime.ts:294:81)
```

## Checks

- `pnpm test src/cli/proxy-cli.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/cli/proxy-cli.ts src/cli/proxy-cli.test.ts`
- `git diff --check origin/main...HEAD`
- `git merge-tree --write-tree HEAD origin/main`
- `pnpm check:changed`

## Collision checks

Before filing and again immediately before publishing, I searched open issues and PRs for:

- `datatype mismatch proxy`
- `proxy sessions --limit`
- `debug proxy sessions limit`
- `store.sqlite listSessions`

No open PR covered this debug-proxy CLI option-validation path.
