### PR TITLE
fix(diffs): isolate per-card hydration failures in viewer-client (#83914)

### DIFF
--- a/extensions/diffs/src/viewer-client.ts
+++ b/extensions/diffs/src/viewer-client.ts
@@ -319,16 +319,28 @@ async function hydrateViewer(): Promise<void> {
   syncDocumentTheme();
 
   for (const { host, payload } of cards) {
-    ensureShadowRoot(host);
-    const diff = new FileDiff(createRenderOptions(payload));
-    diff.hydrate({
-      fileContainer: host,
-      prerenderedHTML: payload.prerenderedHTML,
-      ...getHydrateProps(payload),
-    });
-    const controller = { payload, diff };
-    controllers.push(controller);
-    applyState(controller);
+    // Isolate per-card hydration failures so a defect in one card (corrupted
+    // prerenderedHTML, missing shadow root, upstream @pierre/diffs assertion,
+    // etc.) cannot abort the remaining cards on the page. The outer main()
+    // try/catch still owns truly fatal failures like preloadHighlighter
+    // throwing. See #83914.
+    try {
+      ensureShadowRoot(host);
+      const diff = new FileDiff(createRenderOptions(payload));
+      diff.hydrate({
+        fileContainer: host,
+        prerenderedHTML: payload.prerenderedHTML,
+        ...getHydrateProps(payload),
+      });
+      const controller = { payload, diff };
+      controllers.push(controller);
+      applyState(controller);
+    } catch (err) {
+      // Best-effort surface: tag the failed host so callers/tests can detect
+      // partial hydration without losing the other cards.
+      host.dataset.openclawDiffsCardError = "true";
+      console.warn("Failed to hydrate diff card", err);
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #83914.

The hydration loop in `hydrateViewer` (`extensions/diffs/src/viewer-client.ts:321-332`) constructed `new FileDiff(createRenderOptions(payload))` and invoked `diff.hydrate({...})` for each `.oc-diff-card` host in sequence with no per-card try/catch. A single corrupted `prerenderedHTML` payload, missing shadow root, or upstream `@pierre/diffs` assertion threw out of the loop, propagated up to `main()`, was caught as a page-wide failure (`dataset.openclawDiffsError = "true"`), and left every card after the failed one unhydrated. On a page with N diff cards, a defect in card K silently swallowed cards K+1 through N — no per-card error signal, no partial hydration recovery.

## Changes

- `extensions/diffs/src/viewer-client.ts`: wrap the per-card body inside `hydrateViewer` in `try { … } catch (err) { host.dataset.openclawDiffsCardError = "true"; console.warn("Failed to hydrate diff card", err); }`. The catch tags the failing host with an observable dataset marker (so callers and tests can detect partial hydration without losing the rest of the page) and surfaces the underlying error via `console.warn`. The outer `main()` try/catch is unchanged — it still owns truly fatal failures like `preloadHighlighter` throwing.

Diff stat: 1 file, +23 / -10. Behavior change is strictly more permissive: any case that previously hydrated successfully still does so identically; cases that previously threw now isolate the failure to the failing card.

## Real behavior proof

- **Behavior or issue addressed:** Sanitized issue evidence — the loop body at `viewer-client.ts:321-332` constructs `FileDiff` per card and calls `diff.hydrate`. `FileDiff`'s constructor and `hydrate` method both come from `@pierre/diffs` and can throw on malformed input. The per-card scope of the failure was previously not respected.

- **Real environment tested:** Local Node 22.x. Probe at `/tmp/probe_83914.mjs` does both halves of the proof. (a) Parses the patched `viewer-client.ts` and verifies the per-card body is wrapped in `try { … } catch (err) { … }`, that the catch tags the host with `dataset.openclawDiffsCardError`, and that it logs via `console.warn`. (b) Replays the loop semantics in pure JS for four scenarios — buggy shape (card A throws → loop propagates → B and C never hydrate, confirming the #83914 symptom), patched shape (card A throws → A is tagged with the error marker, B and C still hydrate via the controllers list), all-healthy regression (3 cards all hydrate, no failure markers), and middle-card failure (A and C hydrate around B's failure).

- **Exact steps or command run after this patch:** `node /tmp/probe_83914.mjs`

- **Evidence after fix:**

```
PASS: per-card hydration block is wrapped in try { … } catch (err) { … }
PASS: failed host is tagged with openclawDiffsCardError dataset marker for observability
PASS: failure is surfaced via console.warn with the underlying error
PASS: replay (buggy): card A throws → loop aborts → B and C never hydrate (confirms #83914)
PASS: replay (patched): A failure isolated; B and C hydrate; A's host tagged with error marker
PASS: replay (patched, all healthy): all 3 cards hydrate, no failure markers — no regression
PASS: replay (patched, middle card fails): A and C still hydrate around B's failure
```

- **Observed result after fix:** A page with multiple `.oc-diff-card` hosts where one card has corrupted payload now hydrates the remaining cards normally. The failing card carries `data-openclaw-diffs-card-error="true"` for inspection. The page-level `dataset.openclawDiffsReady = "true"` continues to be set because `hydrateViewer` no longer rejects — matching the issue's "Suggested regression test" expectation.

- **What was not tested:** A real DOM environment with `@pierre/diffs` running — the issue notes "no DOM-level unit tests for viewer-client.ts that exercise multi-card hydration failure scenarios" exist in the repo, and standing one up is outside the scope of a per-card isolation fix. The probe replays the exact loop-vs-throw shape at the call site.

## Audit (per CLAUDE rules — all 5 steps)

- **Existing-helper check:** No helper introduced — a single `try/catch` block. The dataset marker `openclawDiffsCardError` follows the same convention as the existing page-level `openclawDiffsError` / `openclawDiffsReady` markers in `main()`. PASS
- **Shared-helper caller check:** `hydrateViewer` is called only from `main()` in the same file. The new error-isolation behavior makes `hydrateViewer` strictly more permissive — any caller that previously saw it resolve still does. PASS
- **Broader-fix rival scan:** `gh pr list --search '83914 in:title,body'` and `gh pr list --search 'hydrateViewer in:title,body'` return no open PRs. Issue timeline shows zero cross-references. PASS
- **Recent-merge audit:** `git log --oneline -5 -- extensions/diffs/src/viewer-client.ts` shows no recent commits touching this file. PASS
- **Prototype-pollution scan:** N/A — pure try/catch with a dataset assignment on a known DOM `HTMLElement`.
