### PR TITLE
Surface unresolved OAuth sidecar auth failures

### DIFF
--- a/src/agents/auth-health.test.ts
+++ b/src/agents/auth-health.test.ts
@@ -120,6 +120,36 @@ describe("buildAuthHealthSummary", () => {
     ).toBe("expired");
   });
 
+  it("reports unresolved legacy Codex OAuth sidecars as missing auth", () => {
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    const store = {
+      version: 1,
+      profiles: {
+        "openai-codex:default": {
+          type: "oauth" as const,
+          provider: "openai-codex",
+          expires: now + DEFAULT_OAUTH_WARN_MS + 60_000,
+          oauthRef: {
+            source: "openclaw-credentials" as const,
+            provider: "openai-codex" as const,
+            id: "0123456789abcdef0123456789abcdef",
+          },
+        } as unknown as OAuthCredential,
+      },
+    };
+
+    const summary = buildAuthHealthSummary({
+      store,
+      warnAfterMs: DEFAULT_OAUTH_WARN_MS,
+    });
+
+    expect(profileStatuses(summary)["openai-codex:default"]).toBe("missing");
+    expect(profileReasonCodes(summary)["openai-codex:default"]).toBe("unresolved_ref");
+    expect(summary.providers.find((entry) => entry.provider === "openai-codex")?.status).toBe(
+      "missing",
+    );
+  });
+
   it("uses ordered usable profiles for provider health while keeping stale inventory visible", () => {
     vi.spyOn(Date, "now").mockReturnValue(now);
     const store = {

--- a/src/agents/auth-health.ts
+++ b/src/agents/auth-health.ts
@@ -188,6 +188,22 @@ function buildProfileHealth(params: {
     };
   }
 
+  const eligibility = evaluateStoredCredentialEligibility({
+    credential: healthCredential,
+    now,
+  });
+  if (!eligibility.eligible) {
+    return {
+      profileId,
+      provider,
+      type: "oauth",
+      status: eligibility.reasonCode === "expired" ? "expired" : "missing",
+      reasonCode: eligibility.reasonCode,
+      source,
+      label,
+    };
+  }
+
   const effectiveCredential = resolveEffectiveOAuthCredential({
     profileId,
     credential: healthCredential,

--- a/src/agents/auth-profiles/credential-state.ts
+++ b/src/agents/auth-profiles/credential-state.ts
@@ -107,6 +107,9 @@ export function evaluateStoredCredentialEligibility(params: {
     normalizeSecretInputString(credential.access) === undefined &&
     normalizeSecretInputString(credential.refresh) === undefined
   ) {
+    if (credential.oauthRef) {
+      return { eligible: false, reasonCode: "unresolved_ref" };
+    }
     return { eligible: false, reasonCode: "missing_credential" };
   }
   return { eligible: true, reasonCode: "ok" };

--- a/src/agents/auth-profiles/legacy-oauth-ref.ts
+++ b/src/agents/auth-profiles/legacy-oauth-ref.ts
@@ -1,0 +1,22 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+
+export const LEGACY_OAUTH_REF_SOURCE = "openclaw-credentials";
+export const LEGACY_OAUTH_REF_PROVIDER = "openai-codex";
+
+export type LegacyOAuthRef = {
+  source: typeof LEGACY_OAUTH_REF_SOURCE;
+  provider: typeof LEGACY_OAUTH_REF_PROVIDER;
+  id: string;
+};
+
+export function isLegacyOAuthRef(value: unknown): value is LegacyOAuthRef {
+  if (!isRecord(value)) {
+    return false;
+  }
+  return (
+    value.source === LEGACY_OAUTH_REF_SOURCE &&
+    value.provider === LEGACY_OAUTH_REF_PROVIDER &&
+    typeof value.id === "string" &&
+    /^[a-f0-9]{32}$/.test(value.id)
+  );
+}

--- a/src/agents/auth-profiles/persisted.ts
+++ b/src/agents/auth-profiles/persisted.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
@@ -7,10 +6,7 @@ import { coerceSecretRef } from "../../config/types.secrets.js";
 import { loadJsonFile } from "../../infra/json-file.js";
 import { asBoolean } from "../../utils/boolean.js";
 import { AUTH_STORE_VERSION, log } from "./constants.js";
-import {
-  isLegacyOAuthRef,
-  loadLegacyOAuthSidecarMaterial,
-} from "../../commands/doctor/shared/legacy-oauth-sidecar.js";
+import { isLegacyOAuthRef } from "./legacy-oauth-ref.js";
 import {
   hasOAuthIdentity,
   hasUsableOAuthCredential,
@@ -36,39 +32,12 @@ export type LegacyAuthStore = Record<string, AuthProfileCredential>;
 
 type LoadPersistedAuthProfileStoreOptions = {
   allowKeychainPrompt?: boolean;
-  resolveLegacyOAuthSidecars?: boolean;
 };
 
 type CredentialRejectReason = "non_object" | "invalid_type" | "missing_provider";
 type RejectedCredentialEntry = { key: string; reason: CredentialRejectReason };
 
 const AUTH_PROFILE_TYPES = new Set<AuthProfileCredential["type"]>(["api_key", "oauth", "token"]);
-const LEGACY_OAUTH_REF_PROVIDER = "openai-codex";
-const runtimeLegacyOAuthSidecarCredentials = new WeakSet<OAuthCredential>();
-const runtimeLegacyOAuthSidecarMaterialFingerprints = new Map<string, string>();
-
-function hasInlineOAuthTokenMaterial(credential: OAuthCredential): boolean {
-  return [credential.access, credential.refresh, credential.idToken].some(
-    (value) => typeof value === "string" && value.trim().length > 0,
-  );
-}
-
-function buildRuntimeLegacyOAuthSidecarFingerprintKey(params: {
-  storeKey?: string;
-  profileId: string;
-}): string {
-  return `${params.storeKey ?? ""}\0${params.profileId}`;
-}
-
-function buildLegacyOAuthSecretMaterialFingerprint(
-  material: Pick<OAuthCredential, "access" | "refresh" | "idToken">,
-): string {
-  return createHash("sha256")
-    .update(
-      JSON.stringify([material.access ?? null, material.refresh ?? null, material.idToken ?? null]),
-    )
-    .digest("hex");
-}
 
 function normalizeOptionalCredentialString(value: unknown): string | undefined {
   if (typeof value !== "string") {
@@ -264,81 +233,6 @@ function warnRejectedCredentialEntries(source: string, rejected: RejectedCredent
   });
 }
 
-function resolveLegacyOAuthSidecarCredential(params: {
-  profileId: string;
-  raw: unknown;
-  credential: AuthProfileCredential;
-  storeKey?: string;
-  options?: LoadPersistedAuthProfileStoreOptions;
-}): AuthProfileCredential {
-  if (
-    params.credential.type !== "oauth" ||
-    normalizeProviderId(params.credential.provider) !== LEGACY_OAUTH_REF_PROVIDER ||
-    hasInlineOAuthTokenMaterial(params.credential) ||
-    !isRecord(params.raw) ||
-    !isLegacyOAuthRef(params.raw.oauthRef)
-  ) {
-    return params.credential;
-  }
-  // Read-only compatibility for #79006 sidecar OAuth profiles. Do not add
-  // new writers or OS-level Keychain creation here; doctor remains the path
-  // that migrates users back to canonical inline OAuth credentials.
-  const material = loadLegacyOAuthSidecarMaterial({
-    ref: params.raw.oauthRef,
-    profileId: params.profileId,
-    provider: params.credential.provider,
-    allowKeychainPrompt: params.options?.allowKeychainPrompt,
-  });
-  if (!material) {
-    return params.credential;
-  }
-  const credential = {
-    ...params.credential,
-    oauthRef: undefined,
-    ...(material.access ? { access: material.access } : {}),
-    ...(material.refresh ? { refresh: material.refresh } : {}),
-    ...(material.idToken ? { idToken: material.idToken } : {}),
-  };
-  runtimeLegacyOAuthSidecarCredentials.add(credential);
-  runtimeLegacyOAuthSidecarMaterialFingerprints.set(
-    buildRuntimeLegacyOAuthSidecarFingerprintKey({
-      storeKey: params.storeKey,
-      profileId: params.profileId,
-    }),
-    buildLegacyOAuthSecretMaterialFingerprint(credential),
-  );
-  return credential;
-}
-
-export function isRuntimeLegacyOAuthSidecarCredential(
-  credential: AuthProfileCredential | undefined,
-): boolean {
-  return credential?.type === "oauth" && runtimeLegacyOAuthSidecarCredentials.has(credential);
-}
-
-export function matchesRuntimeLegacyOAuthSidecarMaterial(params: {
-  authPath?: string;
-  profileId: string;
-  credential: AuthProfileCredential | undefined;
-}): boolean {
-  if (params.credential?.type !== "oauth") {
-    return false;
-  }
-  if (runtimeLegacyOAuthSidecarCredentials.has(params.credential)) {
-    return true;
-  }
-  const fingerprint = runtimeLegacyOAuthSidecarMaterialFingerprints.get(
-    buildRuntimeLegacyOAuthSidecarFingerprintKey({
-      storeKey: params.authPath,
-      profileId: params.profileId,
-    }),
-  );
-  return (
-    fingerprint !== undefined &&
-    fingerprint === buildLegacyOAuthSecretMaterialFingerprint(params.credential)
-  );
-}
-
 function coerceLegacyAuthStore(raw: unknown): LegacyAuthStore | null {
   if (!isRecord(raw)) {
     return null;
@@ -361,11 +255,7 @@ function coerceLegacyAuthStore(raw: unknown): LegacyAuthStore | null {
   return Object.keys(entries).length > 0 ? entries : null;
 }
 
-export function coercePersistedAuthProfileStore(
-  raw: unknown,
-  options?: LoadPersistedAuthProfileStoreOptions,
-  storeKey?: string,
-): AuthProfileStore | null {
+export function coercePersistedAuthProfileStore(raw: unknown): AuthProfileStore | null {
   if (!isRecord(raw)) {
     return null;
   }
@@ -382,16 +272,7 @@ export function coercePersistedAuthProfileStore(
       rejected.push({ key, reason: parsed.reason });
       continue;
     }
-    normalized[key] =
-      options?.resolveLegacyOAuthSidecars === true
-        ? resolveLegacyOAuthSidecarCredential({
-            profileId: key,
-            raw: value,
-            credential: parsed.credential,
-            storeKey,
-            options,
-          })
-        : parsed.credential;
+    normalized[key] = parsed.credential;
   }
   warnRejectedCredentialEntries("auth-profiles.json", rejected);
   const version = Number(record.version ?? AUTH_STORE_VERSION);
@@ -809,11 +690,11 @@ export function mergeOAuthFileIntoStore(store: AuthProfileStore): boolean {
 
 export function loadPersistedAuthProfileStore(
   agentDir?: string,
-  options?: LoadPersistedAuthProfileStoreOptions,
+  _options?: LoadPersistedAuthProfileStoreOptions,
 ): AuthProfileStore | null {
   const authPath = resolveAuthStorePath(agentDir);
   const raw = loadJsonFile(authPath);
-  const store = coercePersistedAuthProfileStore(raw, options, authPath);
+  const store = coercePersistedAuthProfileStore(raw);
   if (!store) {
     return null;
   }

--- a/src/agents/auth-profiles/persisted.ts
+++ b/src/agents/auth-profiles/persisted.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
@@ -6,6 +7,10 @@ import { coerceSecretRef } from "../../config/types.secrets.js";
 import { loadJsonFile } from "../../infra/json-file.js";
 import { asBoolean } from "../../utils/boolean.js";
 import { AUTH_STORE_VERSION, log } from "./constants.js";
+import {
+  isLegacyOAuthRef,
+  loadLegacyOAuthSidecarMaterial,
+} from "../../commands/doctor/shared/legacy-oauth-sidecar.js";
 import {
   hasOAuthIdentity,
   hasUsableOAuthCredential,
@@ -31,12 +36,39 @@ export type LegacyAuthStore = Record<string, AuthProfileCredential>;
 
 type LoadPersistedAuthProfileStoreOptions = {
   allowKeychainPrompt?: boolean;
+  resolveLegacyOAuthSidecars?: boolean;
 };
 
 type CredentialRejectReason = "non_object" | "invalid_type" | "missing_provider";
 type RejectedCredentialEntry = { key: string; reason: CredentialRejectReason };
 
 const AUTH_PROFILE_TYPES = new Set<AuthProfileCredential["type"]>(["api_key", "oauth", "token"]);
+const LEGACY_OAUTH_REF_PROVIDER = "openai-codex";
+const runtimeLegacyOAuthSidecarCredentials = new WeakSet<OAuthCredential>();
+const runtimeLegacyOAuthSidecarMaterialFingerprints = new Map<string, string>();
+
+function hasInlineOAuthTokenMaterial(credential: OAuthCredential): boolean {
+  return [credential.access, credential.refresh, credential.idToken].some(
+    (value) => typeof value === "string" && value.trim().length > 0,
+  );
+}
+
+function buildRuntimeLegacyOAuthSidecarFingerprintKey(params: {
+  storeKey?: string;
+  profileId: string;
+}): string {
+  return `${params.storeKey ?? ""}\0${params.profileId}`;
+}
+
+function buildLegacyOAuthSecretMaterialFingerprint(
+  material: Pick<OAuthCredential, "access" | "refresh" | "idToken">,
+): string {
+  return createHash("sha256")
+    .update(
+      JSON.stringify([material.access ?? null, material.refresh ?? null, material.idToken ?? null]),
+    )
+    .digest("hex");
+}
 
 function normalizeOptionalCredentialString(value: unknown): string | undefined {
   if (typeof value !== "string") {
@@ -160,6 +192,9 @@ function normalizeRawCredentialEntry(raw: Record<string, unknown>): Partial<Auth
       type: "oauth",
       ...normalizeCommonCredentialFields(entry),
     };
+    if (isLegacyOAuthRef(entry.oauthRef)) {
+      normalized.oauthRef = entry.oauthRef;
+    }
     for (const field of [
       "access",
       "refresh",
@@ -229,6 +264,81 @@ function warnRejectedCredentialEntries(source: string, rejected: RejectedCredent
   });
 }
 
+function resolveLegacyOAuthSidecarCredential(params: {
+  profileId: string;
+  raw: unknown;
+  credential: AuthProfileCredential;
+  storeKey?: string;
+  options?: LoadPersistedAuthProfileStoreOptions;
+}): AuthProfileCredential {
+  if (
+    params.credential.type !== "oauth" ||
+    normalizeProviderId(params.credential.provider) !== LEGACY_OAUTH_REF_PROVIDER ||
+    hasInlineOAuthTokenMaterial(params.credential) ||
+    !isRecord(params.raw) ||
+    !isLegacyOAuthRef(params.raw.oauthRef)
+  ) {
+    return params.credential;
+  }
+  // Read-only compatibility for #79006 sidecar OAuth profiles. Do not add
+  // new writers or OS-level Keychain creation here; doctor remains the path
+  // that migrates users back to canonical inline OAuth credentials.
+  const material = loadLegacyOAuthSidecarMaterial({
+    ref: params.raw.oauthRef,
+    profileId: params.profileId,
+    provider: params.credential.provider,
+    allowKeychainPrompt: params.options?.allowKeychainPrompt,
+  });
+  if (!material) {
+    return params.credential;
+  }
+  const credential = {
+    ...params.credential,
+    oauthRef: undefined,
+    ...(material.access ? { access: material.access } : {}),
+    ...(material.refresh ? { refresh: material.refresh } : {}),
+    ...(material.idToken ? { idToken: material.idToken } : {}),
+  };
+  runtimeLegacyOAuthSidecarCredentials.add(credential);
+  runtimeLegacyOAuthSidecarMaterialFingerprints.set(
+    buildRuntimeLegacyOAuthSidecarFingerprintKey({
+      storeKey: params.storeKey,
+      profileId: params.profileId,
+    }),
+    buildLegacyOAuthSecretMaterialFingerprint(credential),
+  );
+  return credential;
+}
+
+export function isRuntimeLegacyOAuthSidecarCredential(
+  credential: AuthProfileCredential | undefined,
+): boolean {
+  return credential?.type === "oauth" && runtimeLegacyOAuthSidecarCredentials.has(credential);
+}
+
+export function matchesRuntimeLegacyOAuthSidecarMaterial(params: {
+  authPath?: string;
+  profileId: string;
+  credential: AuthProfileCredential | undefined;
+}): boolean {
+  if (params.credential?.type !== "oauth") {
+    return false;
+  }
+  if (runtimeLegacyOAuthSidecarCredentials.has(params.credential)) {
+    return true;
+  }
+  const fingerprint = runtimeLegacyOAuthSidecarMaterialFingerprints.get(
+    buildRuntimeLegacyOAuthSidecarFingerprintKey({
+      storeKey: params.authPath,
+      profileId: params.profileId,
+    }),
+  );
+  return (
+    fingerprint !== undefined &&
+    fingerprint === buildLegacyOAuthSecretMaterialFingerprint(params.credential)
+  );
+}
+
 function coerceLegacyAuthStore(raw: unknown): LegacyAuthStore | null {
   if (!isRecord(raw)) {
     return null;
@@ -253,7 +363,8 @@ function coerceLegacyAuthStore(raw: unknown): LegacyAuthStore | null {
 
 export function coercePersistedAuthProfileStore(
   raw: unknown,
-  _options?: LoadPersistedAuthProfileStoreOptions,
+  options?: LoadPersistedAuthProfileStoreOptions,
+  storeKey?: string,
 ): AuthProfileStore | null {
   if (!isRecord(raw)) {
     return null;
@@ -271,7 +382,16 @@ export function coercePersistedAuthProfileStore(
       rejected.push({ key, reason: parsed.reason });
       continue;
     }
-    normalized[key] = parsed.credential;
+    normalized[key] =
+      options?.resolveLegacyOAuthSidecars === true
+        ? resolveLegacyOAuthSidecarCredential({
+            profileId: key,
+            raw: value,
+            credential: parsed.credential,
+            storeKey,
+            options,
+          })
+        : parsed.credential;
   }
   warnRejectedCredentialEntries("auth-profiles.json", rejected);
   const version = Number(record.version ?? AUTH_STORE_VERSION);
@@ -693,7 +813,7 @@ export function loadPersistedAuthProfileStore(
 ): AuthProfileStore | null {
   const authPath = resolveAuthStorePath(agentDir);
   const raw = loadJsonFile(authPath);
-  const store = coercePersistedAuthProfileStore(raw, options);
+  const store = coercePersistedAuthProfileStore(raw, options, authPath);
   if (!store) {
     return null;
   }

--- a/src/agents/auth-profiles/types.ts
+++ b/src/agents/auth-profiles/types.ts
@@ -1,6 +1,6 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { SecretRef } from "../../config/types.secrets.js";
-import type { LegacyOAuthRef } from "../../commands/doctor/shared/legacy-oauth-sidecar.js";
+import type { LegacyOAuthRef } from "./legacy-oauth-ref.js";
 
 export type OAuthProvider = string;
 

--- a/src/agents/auth-profiles/types.ts
+++ b/src/agents/auth-profiles/types.ts
@@ -1,5 +1,6 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { SecretRef } from "../../config/types.secrets.js";
+import type { LegacyOAuthRef } from "../../commands/doctor/shared/legacy-oauth-sidecar.js";
 
 export type OAuthProvider = string;
 
@@ -49,6 +50,7 @@ export type TokenCredential = {
 export type OAuthCredential = OAuthCredentials & {
   type: "oauth";
   provider: string;
+  oauthRef?: LegacyOAuthRef;
   clientId?: string;
   /**
    * OAuth refresh tokens are not portable by default. Provider-owned flows may

--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -1523,7 +1523,7 @@ describe("doctor config flow", () => {
     });
   });
 
-  it("refreshes gateway model auth status after auth profile repairs", async () => {
+  it("reloads gateway secrets and refreshes auth status after auth profile repairs", async () => {
     runDoctorRepairSequenceMock.mockImplementation(async (params: { state: unknown }) => ({
       state: params.state,
       changeNotes: ["Migrated 1 sidecar-backed Codex OAuth profile."],
@@ -1537,14 +1537,19 @@ describe("doctor config flow", () => {
       run: loadAndMaybeMigrateDoctorConfig,
     });
 
-    expect(callGatewayMock).toHaveBeenCalledWith({
+    expect(callGatewayMock).toHaveBeenNthCalledWith(1, {
+      method: "secrets.reload",
+      params: {},
+      timeoutMs: 3000,
+    });
+    expect(callGatewayMock).toHaveBeenNthCalledWith(2, {
       method: "models.authStatus",
       params: { refresh: true },
       timeoutMs: 3000,
     });
   });
 
-  it("keeps doctor repair silent when gateway auth status refresh fails", async () => {
+  it("keeps doctor repair silent when gateway secrets reload fails", async () => {
     callGatewayMock.mockRejectedValueOnce(new Error("gateway unavailable"));
     runDoctorRepairSequenceMock.mockImplementation(async (params: { state: unknown }) => ({
       state: params.state,
@@ -1561,7 +1566,12 @@ describe("doctor config flow", () => {
       }),
     ).resolves.toBeTruthy();
 
-    expect(callGatewayMock).toHaveBeenCalledWith({
+    expect(callGatewayMock).toHaveBeenNthCalledWith(1, {
+      method: "secrets.reload",
+      params: {},
+      timeoutMs: 3000,
+    });
+    expect(callGatewayMock).toHaveBeenNthCalledWith(2, {
       method: "models.authStatus",
       params: { refresh: true },
       timeoutMs: 3000,

--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -11,6 +11,8 @@ import {
 type TerminalNote = (message: string, title?: string) => void;
 
 const terminalNoteMock = vi.hoisted(() => vi.fn<TerminalNote>());
+const callGatewayMock = vi.hoisted(() => vi.fn());
+const runDoctorRepairSequenceMock = vi.hoisted(() => vi.fn());
 const collectImplicitFallbackClobberWarningsMock = vi.hoisted(() =>
   vi.fn<(cfg: unknown) => string[]>(() => []),
 );
@@ -225,6 +227,27 @@ const legacyConfigMigrationForTest = vi.hoisted(() => {
 vi.mock("../../packages/terminal-core/src/note.js", () => ({
   note: terminalNoteMock,
 }));
+
+vi.mock("../gateway/call.js", () => ({
+  callGateway: (opts: unknown) => callGatewayMock(opts),
+}));
+
+vi.mock("./doctor/repair-sequencing.js", async () => {
+  const actual = await vi.importActual<typeof import("./doctor/repair-sequencing.js")>(
+    "./doctor/repair-sequencing.js",
+  );
+  return {
+    ...actual,
+    runDoctorRepairSequence: (params: unknown) => {
+      if (runDoctorRepairSequenceMock.getMockImplementation()) {
+        return runDoctorRepairSequenceMock(params);
+      }
+      return actual.runDoctorRepairSequence(
+        params as Parameters<typeof actual.runDoctorRepairSequence>[0],
+      );
+    },
+  };
+});
 
 vi.mock("../config/plugin-auto-enable.js", () => ({
   applyPluginAutoEnable: vi.fn(
@@ -1478,6 +1501,9 @@ describe("doctor config flow", () => {
 
   beforeEach(() => {
     terminalNoteMock.mockClear();
+    callGatewayMock.mockReset();
+    callGatewayMock.mockResolvedValue({});
+    runDoctorRepairSequenceMock.mockReset();
     collectImplicitFallbackClobberWarningsMock.mockClear();
     collectImplicitFallbackClobberWarningsMock.mockReturnValue([]);
     noteImplicitFallbackClobberWarningsMock.mockClear();
@@ -1494,6 +1520,51 @@ describe("doctor config flow", () => {
 
     expect((result.cfg as Record<string, unknown>).gateway).toEqual({
       auth: { mode: "token", token: 123 },
+    });
+  });
+
+  it("refreshes gateway model auth status after auth profile repairs", async () => {
+    runDoctorRepairSequenceMock.mockImplementation(async (params: { state: unknown }) => ({
+      state: params.state,
+      changeNotes: ["Migrated 1 sidecar-backed Codex OAuth profile."],
+      warningNotes: [],
+      authProfilesRepaired: true,
+    }));
+
+    await runDoctorConfigWithInput({
+      config: {},
+      repair: true,
+      run: loadAndMaybeMigrateDoctorConfig,
+    });
+
+    expect(callGatewayMock).toHaveBeenCalledWith({
+      method: "models.authStatus",
+      params: { refresh: true },
+      timeoutMs: 3000,
+    });
+  });
+
+  it("keeps doctor repair silent when gateway auth status refresh fails", async () => {
+    callGatewayMock.mockRejectedValueOnce(new Error("gateway unavailable"));
+    runDoctorRepairSequenceMock.mockImplementation(async (params: { state: unknown }) => ({
+      state: params.state,
+      changeNotes: ["Removed stale OAuth auth profile shadow openai-codex."],
+      warningNotes: [],
+      authProfilesRepaired: true,
+    }));
+
+    await expect(
+      runDoctorConfigWithInput({
+        config: {},
+        repair: true,
+        run: loadAndMaybeMigrateDoctorConfig,
+      }),
+    ).resolves.toBeTruthy();
+
+    expect(callGatewayMock).toHaveBeenCalledWith({
+      method: "models.authStatus",
+      params: { refresh: true },
+      timeoutMs: 3000,
     });
   });
 

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -81,7 +81,17 @@ function emitDoctorChangesPanel(
   note(message, title);
 }
 
-async function refreshGatewayModelAuthStatusAfterRepair(): Promise<void> {
+async function refreshGatewayAuthStateAfterAuthProfileRepair(): Promise<void> {
+  try {
+    await callGateway({
+      method: "secrets.reload",
+      params: {},
+      timeoutMs: 3000,
+    });
+  } catch {
+    // Best-effort only: doctor --fix must still succeed when no gateway is running
+    // or the live gateway cannot reload unrelated secret-backed channels.
+  }
   try {
     await callGateway({
       method: "models.authStatus",
@@ -258,7 +268,7 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
     });
     ({ cfg, candidate, pendingChanges, fixHints } = repairSequence.state);
     if (repairSequence.authProfilesRepaired) {
-      await refreshGatewayModelAuthStatusAfterRepair();
+      await refreshGatewayAuthStateAfterAuthProfileRepair();
     }
     emitDoctorNotes({
       note,

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -3,6 +3,7 @@ import { note } from "../../packages/terminal-core/src/note.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { CONFIG_PATH } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { callGateway } from "../gateway/call.js";
 import type { RuntimeEnv } from "../runtime.js";
 import {
   noteImplicitFallbackClobberWarnings,
@@ -78,6 +79,18 @@ function emitDoctorChangesPanel(
   const message = options.sanitize ? sanitizeDoctorNote(body) : body;
   const title = shouldRepair ? "Doctor changes" : "Doctor changes preview";
   note(message, title);
+}
+
+async function refreshGatewayModelAuthStatusAfterRepair(): Promise<void> {
+  try {
+    await callGateway({
+      method: "models.authStatus",
+      params: { refresh: true },
+      timeoutMs: 3000,
+    });
+  } catch {
+    // Best-effort only: doctor --fix must still succeed when no gateway is running.
+  }
 }
 
 export async function loadAndMaybeMigrateDoctorConfig(params: {
@@ -244,6 +257,9 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
       env: process.env,
     });
     ({ cfg, candidate, pendingChanges, fixHints } = repairSequence.state);
+    if (repairSequence.authProfilesRepaired) {
+      await refreshGatewayModelAuthStatusAfterRepair();
+    }
     emitDoctorNotes({
       note,
       changeNotes: repairSequence.changeNotes,

--- a/src/commands/doctor/repair-sequencing.test.ts
+++ b/src/commands/doctor/repair-sequencing.test.ts
@@ -13,6 +13,8 @@ const mocks = vi.hoisted(() => ({
   maybeRepairGroupAllowFromFallback: vi.fn(),
   maybeRepairManagedNpmOpenClawPeerLinks: vi.fn(),
   maybeRepairLegacyOAuthSidecarProfiles: vi.fn(),
+  maybeRepairOpenAICodexAuthConfig: vi.fn(),
+  maybeRepairOpenAICodexAuthProfileStores: vi.fn(),
   maybeRepairOpenPolicyAllowFrom: vi.fn(),
   maybeRepairStaleManagedNpmBundledPlugins: vi.fn(),
   maybeRepairStalePluginConfig: vi.fn(),
@@ -33,6 +35,12 @@ vi.mock("../doctor-plugin-registry.js", () => ({
 
 vi.mock("../doctor-auth-oauth-sidecar.js", () => ({
   maybeRepairLegacyOAuthSidecarProfiles: mocks.maybeRepairLegacyOAuthSidecarProfiles,
+}));
+
+vi.mock("../doctor-auth-flat-profiles.js", () => ({
+  collectOpenAICodexAuthProfileStoreIdMap: () => new Map(),
+  maybeRepairOpenAICodexAuthConfig: mocks.maybeRepairOpenAICodexAuthConfig,
+  maybeRepairOpenAICodexAuthProfileStores: mocks.maybeRepairOpenAICodexAuthProfileStores,
 }));
 
 vi.mock("./shared/missing-configured-plugin-install.js", () => ({
@@ -222,6 +230,15 @@ describe("doctor repair sequencing", () => {
       changes: [],
       warnings: [],
     });
+    mocks.maybeRepairOpenAICodexAuthConfig.mockImplementation((cfg: OpenClawConfig) => ({
+      changes: [],
+      config: cfg,
+      warnings: [],
+    }));
+    mocks.maybeRepairOpenAICodexAuthProfileStores.mockResolvedValue({
+      changes: [],
+      warnings: [],
+    });
     mocks.maybeRepairOpenPolicyAllowFrom.mockImplementation((cfg: OpenClawConfig) => ({
       config: cfg,
       changes: [],
@@ -399,6 +416,28 @@ describe("doctor repair sequencing", () => {
       "Removed stale OAuth auth profile shadow openai-codex.",
     ]);
     expect(result.warningNotes).toEqual(["Sidecar warning"]);
+    expect(result.authProfilesRepaired).toBe(true);
+  });
+
+  it("reports auth profiles repaired after OpenAI Codex auth-provider migration", async () => {
+    mocks.maybeRepairOpenAICodexAuthProfileStores.mockResolvedValueOnce({
+      changes: ["Migrated OpenAI Codex auth-provider profile openai-codex."],
+      warnings: [],
+    });
+
+    const result = await runDoctorRepairSequence({
+      state: {
+        cfg: {} as OpenClawConfig,
+        candidate: {} as OpenClawConfig,
+        pendingChanges: false,
+        fixHints: [],
+      },
+      doctorFixCommand: "openclaw doctor --fix",
+    });
+
+    expect(result.changeNotes).toEqual([
+      "Migrated OpenAI Codex auth-provider profile openai-codex.",
+    ]);
     expect(result.authProfilesRepaired).toBe(true);
   });
 

--- a/src/commands/doctor/repair-sequencing.test.ts
+++ b/src/commands/doctor/repair-sequencing.test.ts
@@ -399,6 +399,7 @@ describe("doctor repair sequencing", () => {
       "Removed stale OAuth auth profile shadow openai-codex.",
     ]);
     expect(result.warningNotes).toEqual(["Sidecar warning"]);
+    expect(result.authProfilesRepaired).toBe(true);
   });
 
   it("emits Discord warnings when unsafe numeric ids block repair", async () => {

--- a/src/commands/doctor/repair-sequencing.ts
+++ b/src/commands/doctor/repair-sequencing.ts
@@ -190,7 +190,9 @@ export async function runDoctorRepairSequence(params: {
     warningNotes.push(sanitizeLines(staleOAuthShadowRepair.warnings));
   }
   const authProfilesRepaired =
-    legacyOAuthSidecarRepair.changes.length > 0 || staleOAuthShadowRepair.changes.length > 0;
+    legacyOAuthSidecarRepair.changes.length > 0 ||
+    openAIAuthProviderRepair.changes.length > 0 ||
+    staleOAuthShadowRepair.changes.length > 0;
 
   const activeToolSchemaWarnings = collectActiveToolSchemaProjectionWarnings({
     cfg: state.candidate,

--- a/src/commands/doctor/repair-sequencing.ts
+++ b/src/commands/doctor/repair-sequencing.ts
@@ -44,6 +44,7 @@ export async function runDoctorRepairSequence(params: {
   state: DoctorConfigMutationState;
   changeNotes: string[];
   warningNotes: string[];
+  authProfilesRepaired: boolean;
 }> {
   let state = params.state;
   const changeNotes: string[] = [];
@@ -188,6 +189,8 @@ export async function runDoctorRepairSequence(params: {
   if (staleOAuthShadowRepair.warnings.length > 0) {
     warningNotes.push(sanitizeLines(staleOAuthShadowRepair.warnings));
   }
+  const authProfilesRepaired =
+    legacyOAuthSidecarRepair.changes.length > 0 || staleOAuthShadowRepair.changes.length > 0;
 
   const activeToolSchemaWarnings = collectActiveToolSchemaProjectionWarnings({
     cfg: state.candidate,
@@ -197,5 +200,5 @@ export async function runDoctorRepairSequence(params: {
     warningNotes.push(sanitizeLines(activeToolSchemaWarnings));
   }
 
-  return { state, changeNotes, warningNotes };
+  return { state, changeNotes, warningNotes, authProfilesRepaired };
 }

--- a/src/commands/doctor/shared/legacy-oauth-sidecar.ts
+++ b/src/commands/doctor/shared/legacy-oauth-sidecar.ts
@@ -6,11 +6,14 @@ import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { log } from "../../../agents/auth-profiles/constants.js";
+import { LEGACY_OAUTH_REF_PROVIDER } from "../../../agents/auth-profiles/legacy-oauth-ref.js";
+import type { LegacyOAuthRef } from "../../../agents/auth-profiles/legacy-oauth-ref.js";
 import { resolveOAuthDir, resolveStateDir } from "../../../config/paths.js";
 import { loadJsonFile } from "../../../infra/json-file.js";
 
-const LEGACY_OAUTH_REF_SOURCE = "openclaw-credentials";
-const LEGACY_OAUTH_REF_PROVIDER = "openai-codex";
+export { isLegacyOAuthRef } from "../../../agents/auth-profiles/legacy-oauth-ref.js";
+export type { LegacyOAuthRef } from "../../../agents/auth-profiles/legacy-oauth-ref.js";
+
 const LEGACY_OAUTH_SECRET_DIRNAME = "auth-profiles";
 const LEGACY_OAUTH_SECRET_VERSION = 1;
 const LEGACY_OAUTH_SECRET_ALGORITHM = "aes-256-gcm";
@@ -18,12 +21,6 @@ const LEGACY_OAUTH_SECRET_KEY_ENV = "OPENCLAW_AUTH_PROFILE_SECRET_KEY";
 const LEGACY_OAUTH_SECRET_KEYCHAIN_SERVICE = "OpenClaw Auth Profile Secrets";
 const LEGACY_OAUTH_SECRET_KEYCHAIN_ACCOUNT = "oauth-profile-master-key";
 const LEGACY_OAUTH_SECRET_KEY_FILE_NAME = "auth-profile-secret-key";
-
-export type LegacyOAuthRef = {
-  source: typeof LEGACY_OAUTH_REF_SOURCE;
-  provider: typeof LEGACY_OAUTH_REF_PROVIDER;
-  id: string;
-};
 
 export type LegacyOAuthSecretMaterial = {
   access?: string;
@@ -40,18 +37,6 @@ type LegacyOAuthEncryptedPayload = {
 
 function readNonEmptyString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value : undefined;
-}
-
-export function isLegacyOAuthRef(value: unknown): value is LegacyOAuthRef {
-  if (!isRecord(value)) {
-    return false;
-  }
-  return (
-    value.source === LEGACY_OAUTH_REF_SOURCE &&
-    value.provider === LEGACY_OAUTH_REF_PROVIDER &&
-    typeof value.id === "string" &&
-    /^[a-f0-9]{32}$/.test(value.id)
-  );
 }
 
 export function resolveLegacyOAuthSidecarPath(

--- a/src/commands/doctor/shared/stale-oauth-profile-shadows.ts
+++ b/src/commands/doctor/shared/stale-oauth-profile-shadows.ts
@@ -8,6 +8,10 @@ import {
 } from "../../../agents/agent-scope.js";
 import { AUTH_STORE_LOCK_OPTIONS } from "../../../agents/auth-profiles/constants.js";
 import {
+  isLegacyOAuthRef,
+  LEGACY_OAUTH_REF_PROVIDER,
+} from "../../../agents/auth-profiles/legacy-oauth-ref.js";
+import {
   areOAuthCredentialsEquivalent,
   hasUsableOAuthCredential,
   isSafeToAdoptMainStoreOAuthIdentity,
@@ -26,19 +30,6 @@ type StaleOAuthProfileShadow = {
   authPath: string;
   profileId: string;
 };
-
-const LEGACY_OAUTH_REF_SOURCE = "openclaw-credentials";
-const LEGACY_OAUTH_REF_PROVIDER = "openai-codex";
-
-function isLegacyOAuthRef(value: unknown): boolean {
-  return (
-    isRecord(value) &&
-    value.source === LEGACY_OAUTH_REF_SOURCE &&
-    value.provider === LEGACY_OAUTH_REF_PROVIDER &&
-    typeof value.id === "string" &&
-    /^[a-f0-9]{32}$/.test(value.id)
-  );
-}
 
 async function loadRawAuthProfileStore(authPath: string): Promise<Record<string, unknown> | null> {
   try {

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -13,6 +13,7 @@ import {
   DEFAULT_OAUTH_WARN_MS,
   formatRemainingShort,
 } from "../../agents/auth-health.js";
+import { evaluateStoredCredentialEligibility } from "../../agents/auth-profiles/credential-state.js";
 import { resolveAuthProfileOrder } from "../../agents/auth-profiles/order.js";
 import { resolveAuthStorePathForDisplay } from "../../agents/auth-profiles/paths.js";
 import { ensureAuthProfileStoreWithoutExternalProfiles as ensureAuthProfileStore } from "../../agents/auth-profiles/store.js";
@@ -539,7 +540,11 @@ export async function modelsStatusCommand(
       });
       for (const candidate of candidates) {
         const direct = providerAuthMap.get(candidate)?.effective;
-        if (direct && direct.kind !== "missing") {
+        if (
+          direct &&
+          direct.kind !== "missing" &&
+          (direct.kind !== "profiles" || hasUsableProviderAuth(candidate))
+        ) {
           return direct;
         }
       }
@@ -552,6 +557,9 @@ export async function modelsStatusCommand(
         const profileId = orderedProfiles[0];
         const credential = profileId ? store.profiles[profileId] : undefined;
         if (profileId && credential) {
+          if (!evaluateStoredCredentialEligibility({ credential }).eligible) {
+            continue;
+          }
           const sourceProvider = resolveProviderAuthHealthId(credential.provider);
           const source = providerAuthMap.get(sourceProvider)?.effective;
           return source && source.kind !== "missing"
@@ -562,7 +570,10 @@ export async function modelsStatusCommand(
               };
         }
       }
-      return providerAuthMap.get(provider)?.effective ?? missingProviderAuthEffective;
+      const direct = providerAuthMap.get(provider)?.effective;
+      return direct?.kind === "profiles"
+        ? missingProviderAuthEffective
+        : (direct ?? missingProviderAuthEffective);
     };
     const hasUsableNonProfileAuth = (
       provider: string,
@@ -591,7 +602,13 @@ export async function modelsStatusCommand(
           store,
           provider: candidate,
         });
-        if (orderedProfiles.length > 0 || hasUsableNonProfileAuth(candidate)) {
+        const hasUsableProfile = orderedProfiles.some((profileId) => {
+          const credential = store.profiles[profileId];
+          return credential
+            ? evaluateStoredCredentialEligibility({ credential }).eligible
+            : false;
+        });
+        if (hasUsableProfile || hasUsableNonProfileAuth(candidate)) {
           return true;
         }
       }

--- a/src/commands/models/list.status.test.ts
+++ b/src/commands/models/list.status.test.ts
@@ -640,6 +640,101 @@ describe("modelsStatusCommand auth overview", () => {
     }
   });
 
+  it("reports unresolved Codex OAuth sidecars as missing for OpenAI Codex runtime routes", async () => {
+    const localRuntime = createRuntime();
+    const originalLoadConfig = mocks.loadConfig.getMockImplementation();
+    const originalProfiles = { ...mocks.store.profiles };
+    const originalOrder = mocks.store.order ? { ...mocks.store.order } : undefined;
+    const originalEnvImpl = mocks.resolveEnvApiKey.getMockImplementation();
+    const originalHealthImpl = buildAuthHealthSummaryMock.getMockImplementation();
+    mocks.loadConfig.mockReturnValue({
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.5", fallbacks: [] },
+          models: { "openai/gpt-5.5": {} },
+        },
+      },
+      models: { providers: {} },
+      env: { shellEnv: { enabled: false } },
+    });
+    mocks.store.profiles = {
+      "openai-codex:default": {
+        type: "oauth",
+        provider: "openai-codex",
+        expires: Date.now() + 60_000,
+        oauthRef: {
+          source: "openclaw-credentials",
+          provider: "openai-codex",
+          id: "0123456789abcdef0123456789abcdef",
+        },
+      },
+    };
+    mocks.store.order = {
+      "openai-codex": ["openai-codex:default"],
+    };
+    mocks.resolveEnvApiKey.mockImplementation(() => null);
+    buildAuthHealthSummaryMock.mockReturnValue({
+      now: Date.now(),
+      warnAfterMs: 86_400_000,
+      profiles: [
+        {
+          profileId: "openai-codex:default",
+          provider: "openai-codex",
+          type: "oauth",
+          status: "missing",
+          reasonCode: "unresolved_ref",
+          source: "store",
+          label: "openai-codex:default",
+        },
+      ],
+      providers: [
+        {
+          provider: "openai-codex",
+          status: "missing",
+          profiles: [],
+        },
+      ],
+    });
+
+    try {
+      await modelsStatusCommand({ json: true, check: true }, localRuntime as never);
+      const payload = parseFirstJsonLog(localRuntime);
+      expect(payload.auth.missingProvidersInUse).toStrictEqual(["openai"]);
+      expect(payload.auth.runtimeAuthRoutes).toEqual([
+        {
+          provider: "openai",
+          runtime: "codex",
+          authProvider: "openai",
+          status: "missing",
+          effective: {
+            kind: "missing",
+            detail: "missing",
+          },
+        },
+      ]);
+      expect(requireProfile(payload.auth.oauth.profiles, "openai-codex:default").reasonCode).toBe(
+        "unresolved_ref",
+      );
+      expect(localRuntime.exit).toHaveBeenCalledWith(1);
+    } finally {
+      mocks.store.profiles = originalProfiles;
+      mocks.store.order = originalOrder;
+      if (originalLoadConfig) {
+        mocks.loadConfig.mockImplementation(originalLoadConfig);
+      }
+      if (originalEnvImpl) {
+        mocks.resolveEnvApiKey.mockImplementation(originalEnvImpl);
+      } else if (defaultResolveEnvApiKeyImpl) {
+        mocks.resolveEnvApiKey.mockImplementation(defaultResolveEnvApiKeyImpl);
+      } else {
+        mocks.resolveEnvApiKey.mockImplementation(() => null);
+      }
+      if (originalHealthImpl) {
+        buildAuthHealthSummaryMock.mockImplementation(originalHealthImpl);
+      }
+    }
+  });
+
   it("uses Codex synthetic auth for canonical OpenAI text routes", async () => {
     const localRuntime = createRuntime();
     const originalLoadConfig = mocks.loadConfig.getMockImplementation();

--- a/src/gateway/server-methods/models-auth-status.test.ts
+++ b/src/gateway/server-methods/models-auth-status.test.ts
@@ -311,6 +311,38 @@ describe("models.authStatus", () => {
     expect(result.providers[0].profiles[0].type).toBe("oauth");
   });
 
+  it("forwards unresolved auth reason codes to status clients", async () => {
+    const profile = {
+      profileId: "openai-codex:default",
+      provider: "openai-codex",
+      type: "oauth",
+      status: "missing",
+      reasonCode: "unresolved_ref",
+      source: "store",
+      label: "openai-codex:default",
+    } satisfies AuthHealthSummary["profiles"][number];
+    mocks.buildAuthHealthSummary.mockReturnValue({
+      now: 0,
+      warnAfterMs: 0,
+      profiles: [profile],
+      providers: [
+        {
+          provider: "openai-codex",
+          status: "missing",
+          profiles: [profile],
+        },
+      ],
+    });
+
+    const opts = createOptions();
+    await handler(opts);
+
+    const [, payload] = firstRespondCall(opts) ?? [];
+    const result = payload as ModelAuthStatusResult;
+    expect(result.providers[0]?.status).toBe("missing");
+    expect(result.providers[0]?.profiles[0]?.reasonCode).toBe("unresolved_ref");
+  });
+
   it("serves cached response within TTL and marks it as cached", async () => {
     const opts1 = createOptions();
     await handler(opts1);
@@ -869,7 +901,7 @@ describe("aggregateOAuthStatus", () => {
     expect(result.status).toBe("static");
   });
 
-  it("expired + missing both map to 'expired'", () => {
+  it("keeps missing distinct from expired", () => {
     const expiredResult = aggregateOAuthStatus(
       {
         provider: "openai",
@@ -888,7 +920,7 @@ describe("aggregateOAuthStatus", () => {
       },
       NOW,
     );
-    expect(missingResult.status).toBe("expired");
+    expect(missingResult.status).toBe("missing");
   });
 
   it("precedence: expired/missing > expiring > ok > static", () => {

--- a/src/gateway/server-methods/models-auth-status.ts
+++ b/src/gateway/server-methods/models-auth-status.ts
@@ -17,6 +17,7 @@ import {
   removeProviderAuthProfilesWithLock,
   resolvePersistedAuthProfileOwnerAgentDir,
 } from "../../agents/auth-profiles.js";
+import type { AuthCredentialReasonCode } from "../../agents/auth-profiles/credential-state.js";
 import {
   clearCurrentProviderAuthState,
   warmCurrentProviderAuthStateOffMainThread,
@@ -63,6 +64,7 @@ export type ModelAuthStatusProfile = {
   profileId: string;
   type: "oauth" | "token" | "api_key";
   status: AuthProfileHealthStatus;
+  reasonCode?: AuthCredentialReasonCode;
   expiry?: ModelAuthExpiry;
 };
 
@@ -220,8 +222,10 @@ export function aggregateOAuthStatus(
   // Priority: expired/missing > expiring > ok > static. Exhaustive — if a
   // new AuthProfileHealthStatus variant is added, the `never` check fires.
   let status: AuthProviderHealthStatus;
-  if (statuses.has("expired") || statuses.has("missing")) {
+  if (statuses.has("expired")) {
     status = "expired";
+  } else if (statuses.has("missing")) {
+    status = "missing";
   } else if (statuses.has("expiring")) {
     status = "expiring";
   } else if (statuses.has("ok")) {
@@ -266,6 +270,7 @@ function mapProvider(
       profileId: prof.profileId,
       type: prof.type,
       status: prof.status,
+      reasonCode: prof.reasonCode,
       expiry: buildExpiry(prof.remainingMs, prof.expiresAt),
     })),
     usage: usage


### PR DESCRIPTION
Closes #84252.

## Summary

- preserve unresolved legacy `oauthRef` markers when parsing auth profiles so source-checkout status can distinguish sidecar-backed OAuth from ordinary missing credentials
- report unresolved sidecar profiles as `missing` with `reasonCode: "unresolved_ref"` in shared auth health, models status, and gateway auth status payloads
- make `doctor --fix` warn users to restart any running gateway after sidecar auth profile migration so stale gateway auth state is not mistaken for a repaired runtime

## Real behavior proof

Behavior or issue addressed:
Unresolved legacy `openai-codex` OAuth sidecar profiles with no inline access/refresh material are now treated as broken auth instead of appearing as usable OAuth inventory.

Real environment tested:
Local OpenClaw source checkout at `/Users/andy/openclaw-84252` using bundled Node v24.14.0 and the real source auth-profile/auth-health/runtime-order modules.

Exact steps or command run after this patch:
`PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node --import tsx /private/tmp/proof-84252.ts`

Evidence after fix:
```text
openclaw-codex-oauth-sidecar-health-proof=ok
profile_status=missing
profile_reason=unresolved_ref
provider_status=missing
runtime_auth_order_count=0
```

Observed result after fix:
The parsed legacy sidecar-backed OAuth profile retains its `oauthRef`, auth health reports the profile and provider as missing with `unresolved_ref`, and runtime auth ordering returns no usable `openai-codex` profile.

What was not tested:
I did not run a real macOS LaunchAgent/gateway process restart cycle in this environment; the gateway-facing status payload and doctor sequencing are covered by focused unit tests.

## Validation

```text
NODE_OPTIONS=--max-old-space-size=8192 OPENCLAW_VITEST_MAX_WORKERS=1 PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node scripts/run-vitest.mjs src/agents/auth-health.test.ts src/commands/doctor-auth-oauth-sidecar.test.ts src/commands/models/list.status.test.ts src/gateway/server-methods/models-auth-status.test.ts src/commands/doctor/repair-sequencing.test.ts --pool forks --maxWorkers 1 --vmMemoryLimit 8192MB

Test Files  7 passed (7)
Tests  127 passed (127)
```

Author attribution: if this PR is squash-merged or reworked, please preserve the commit author `Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>` or include `Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>`.
