### PR TITLE
fix(agents): recover invalid OpenAI Responses reasoning replay

### DIFF
--- a/scripts/proofs/openai-responses-replay-recovery.ts
+++ b/scripts/proofs/openai-responses-replay-recovery.ts
@@ -1,0 +1,275 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import type { Model } from "@earendil-works/pi-ai";
+import { createOpenAIResponsesTransportStreamFn } from "../../src/agents/openai-transport-stream.js";
+import { wrapOpenAIResponsesStreamWithReplayRecovery } from "../../src/agents/pi-embedded-runner/thinking.js";
+
+type RecordedRequest = {
+  method: string;
+  path: string;
+  body: Record<string, unknown>;
+};
+
+const ZERO_USAGE = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  totalTokens: 0,
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+} as const;
+
+function buildModel(baseUrl: string): Model<"openai-responses"> {
+  return {
+    id: "gpt-5.4",
+    name: "gpt-5.4",
+    api: "openai-responses",
+    provider: "openai",
+    baseUrl,
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 128_000,
+    maxTokens: 4096,
+  };
+}
+
+function buildReplayableAssistantMessage(): Extract<AgentMessage, { role: "assistant" }> {
+  return {
+    role: "assistant",
+    api: "openai-responses",
+    provider: "openai",
+    model: "gpt-5.4",
+    usage: ZERO_USAGE,
+    stopReason: "stop",
+    timestamp: Date.now(),
+    content: [
+      {
+        type: "thinking",
+        thinking: "private reasoning",
+        thinkingSignature: JSON.stringify({
+          type: "reasoning",
+          id: "rs_real_transport_proof",
+          summary: [],
+        }),
+      },
+      {
+        type: "text",
+        text: "visible answer",
+        textSignature: JSON.stringify({
+          v: 1,
+          id: "msg_real_transport_proof",
+          phase: "final_answer",
+        }),
+      },
+    ],
+  };
+}
+
+async function readRequestBody(request: http.IncomingMessage): Promise<Record<string, unknown>> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  const text = Buffer.concat(chunks).toString("utf8");
+  return text ? (JSON.parse(text) as Record<string, unknown>) : {};
+}
+
+function writeSse(response: http.ServerResponse, events: unknown[]) {
+  response.writeHead(200, {
+    "content-type": "text/event-stream",
+    "cache-control": "no-cache",
+  });
+  for (const event of events) {
+    response.write(`data: ${JSON.stringify(event)}\n\n`);
+  }
+  response.end("data: [DONE]\n\n");
+}
+
+function writeReasoningReplayError(response: http.ServerResponse) {
+  response.writeHead(400, { "content-type": "application/json" });
+  response.end(
+    JSON.stringify({
+      error: {
+        code: "thinking_signature_invalid",
+        message:
+          "The encrypted content for item rs_real_transport_proof could not be verified. Reason: Encrypted content could not be decrypted or parsed.",
+        type: "invalid_request_error",
+      },
+    }),
+  );
+}
+
+function createProofServer(recordedRequests: RecordedRequest[]) {
+  return http.createServer((request, response) => {
+    void (async () => {
+      try {
+        const body = await readRequestBody(request);
+        recordedRequests.push({
+          method: request.method ?? "",
+          path: request.url ?? "",
+          body,
+        });
+
+        if (recordedRequests.length === 1) {
+          writeReasoningReplayError(response);
+          return;
+        }
+
+        writeSse(response, [
+          { type: "response.created", response: { id: "resp_real_transport_recovered" } },
+          {
+            type: "response.output_item.added",
+            item: {
+              type: "message",
+              id: "msg_real_transport_recovered",
+              role: "assistant",
+              content: [],
+              status: "in_progress",
+            },
+          },
+          { type: "response.output_text.delta", delta: "recovered via real http transport" },
+          {
+            type: "response.output_item.done",
+            item: {
+              type: "message",
+              id: "msg_real_transport_recovered",
+              role: "assistant",
+              status: "completed",
+              content: [{ type: "output_text", text: "recovered via real http transport" }],
+            },
+          },
+          {
+            type: "response.completed",
+            response: {
+              id: "resp_real_transport_recovered",
+              status: "completed",
+              usage: {
+                input_tokens: 2,
+                output_tokens: 5,
+                total_tokens: 7,
+                input_tokens_details: { cached_tokens: 0 },
+              },
+            },
+          },
+        ]);
+      } catch (error) {
+        response.writeHead(500, { "content-type": "application/json" });
+        response.end(JSON.stringify({ error: error instanceof Error ? error.message : error }));
+      }
+    })();
+  });
+}
+
+function listen(server: http.Server): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("Expected TCP address"));
+        return;
+      }
+      resolve(address.port);
+    });
+  });
+}
+
+async function closeServer(server: http.Server) {
+  if (!server.listening) {
+    return;
+  }
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+function inputItems(body: Record<string, unknown>): Record<string, unknown>[] {
+  return Array.isArray(body.input) ? (body.input as Record<string, unknown>[]) : [];
+}
+
+function inputTypes(body: Record<string, unknown>): string[] {
+  return inputItems(body)
+    .map((item) => item.type)
+    .filter((type): type is string => typeof type === "string");
+}
+
+function countInputType(body: Record<string, unknown>, type: string): number {
+  return inputTypes(body).filter((itemType) => itemType === type).length;
+}
+
+async function main() {
+  const recordedRequests: RecordedRequest[] = [];
+  const server = createProofServer(recordedRequests);
+  const port = await listen(server);
+  try {
+    const wrapped = wrapOpenAIResponsesStreamWithReplayRecovery(
+      createOpenAIResponsesTransportStreamFn(),
+      { id: "real-http-transport-proof-session" },
+    );
+    const stream = wrapped(
+      buildModel(`http://127.0.0.1:${port}/v1`),
+      {
+        systemPrompt: "system",
+        messages: [
+          { role: "user", content: "continue", timestamp: Date.now() },
+          buildReplayableAssistantMessage(),
+          { role: "user", content: "continue again", timestamp: Date.now() },
+        ],
+      } as never,
+      { apiKey: "sk-redacted-real-http-proof" } as never,
+    ) as { result: () => Promise<AgentMessage> };
+
+    const result = await stream.result();
+    const first = recordedRequests[0];
+    const second = recordedRequests[1];
+    assert.equal(recordedRequests.length, 2);
+    assert(first);
+    assert(second);
+    assert.equal(first.method, "POST");
+    assert.equal(second.method, "POST");
+    assert.equal(first.path, "/v1/responses");
+    assert.equal(second.path, "/v1/responses");
+    assert(inputTypes(first.body).includes("reasoning"));
+    assert(!inputTypes(second.body).includes("reasoning"));
+    assert(countInputType(second.body, "message") >= 1);
+    assert.equal(result.stopReason, "stop");
+    const firstContent = result.content[0];
+    assert(firstContent && firstContent.type === "text");
+    assert.equal(firstContent.text, "recovered via real http transport");
+
+    console.log("OpenAI Responses replay recovery proof: PASS");
+    console.log("Runtime path: real OpenAI SDK HTTP transport against loopback /v1/responses");
+    console.log(
+      "Mocking: no vi.mock/openai SDK mock; loopback server returns provider-shaped HTTP/SSE",
+    );
+    console.log("Requests observed:", recordedRequests.length);
+    console.log("Request paths:", recordedRequests.map((request) => request.path).join(", "));
+    console.log("First response:", "HTTP 400 thinking_signature_invalid");
+    console.log("First request input types:", inputTypes(first.body).join(", "));
+    console.log("Retry request input types:", inputTypes(second.body).join(", "));
+    console.log(
+      "Retry dropped replayed reasoning:",
+      !inputTypes(second.body).includes("reasoning"),
+    );
+    console.log("Retry preserved replayed message:", countInputType(second.body, "message") >= 1);
+    console.log("Recovered assistant text:", firstContent.text);
+    console.log("Final stopReason:", result.stopReason);
+  } finally {
+    await closeServer(server);
+  }
+}
+
+void main().catch((error) => {
+  console.error("OpenAI Responses replay recovery proof: FAIL");
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -100,6 +100,15 @@ describe("formatAssistantErrorText", () => {
     expect(result).toContain("Session history or replay state is invalid");
     expect(result).toContain("/new");
   });
+  it("returns a recovery hint for invalid OpenAI Responses encrypted reasoning replay", () => {
+    const msg = makeAssistantError(
+      '400 {"error":{"code":"thinking_signature_invalid","message":"The encrypted content for item rs_test could not be verified. Reason: Encrypted content could not be decrypted or parsed.","type":"invalid_request_error"}}',
+    );
+    const result = formatAssistantErrorText(msg);
+    expect(result).toContain("Session history or replay state is invalid");
+    expect(result).toContain("/new");
+    expect(result).not.toContain("provider rejected the request schema");
+  });
   it("handles JSON-wrapped role errors", () => {
     const msg = makeAssistantError('{"error":{"message":"400 Incorrect role information"}}');
     const result = formatAssistantErrorText(msg);

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -329,6 +329,8 @@ const INTERRUPTED_NETWORK_ERROR_RE =
   /\beconnrefused\b|\beconnreset\b|\beconnaborted\b|\benetreset\b|\behostunreach\b|\behostdown\b|\benetunreach\b|\bepipe\b|\bsocket hang up\b|\bconnection refused\b|\bconnection reset\b|\bconnection aborted\b|\bnetwork is unreachable\b|\bhost is unreachable\b|\bfetch failed\b|\bconnection error\b|\bnetwork request failed\b/i;
 const REPLAY_INVALID_RE =
   /\bprevious_response_id\b.*\b(?:invalid|unknown|not found|does not exist|expired|mismatch)\b|\btool_(?:use|call)\.(?:input|arguments)\b.*\b(?:missing|required)\b|\bincorrect role information\b|\broles must alternate\b|\binput item id does not belong to this connection\b/i;
+const OPENAI_RESPONSES_REASONING_REPLAY_INVALID_RE =
+  /\bthinking_signature_invalid\b|\bencrypted content\b.*\b(?:could not be verified|could not be decrypted|could not be parsed)\b/i;
 const SANDBOX_BLOCKED_RE =
   /\bapproval is required\b|\bapproval timed out\b|\bapproval was denied\b|\bblocked by sandbox\b|\bsandbox\b.*\b(?:blocked|denied|forbidden|disabled|not allowed)\b/i;
 const NO_BODY_HTTP_WRAPPER_RE =
@@ -444,7 +446,11 @@ function isDnsTransportErrorMessage(raw: string): boolean {
 }
 
 function isReplayInvalidErrorMessage(raw: string): boolean {
-  return REPLAY_INVALID_RE.test(raw);
+  return REPLAY_INVALID_RE.test(raw) || isOpenAIResponsesReasoningReplayInvalidErrorMessage(raw);
+}
+
+export function isOpenAIResponsesReasoningReplayInvalidErrorMessage(raw: string): boolean {
+  return OPENAI_RESPONSES_REASONING_REPLAY_INVALID_RE.test(raw);
 }
 
 function isSandboxBlockedErrorMessage(raw: string): boolean {

--- a/src/agents/pi-embedded-runner/openai-responses-transport-replay-recovery.test.ts
+++ b/src/agents/pi-embedded-runner/openai-responses-transport-replay-recovery.test.ts
@@ -1,0 +1,160 @@
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import type { Model } from "@earendil-works/pi-ai";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createOpenAIResponsesTransportStreamFn } from "../openai-transport-stream.js";
+import { wrapOpenAIResponsesStreamWithReplayRecovery } from "./thinking.js";
+
+const responsesCreateMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openai", () => {
+  class MockOpenAI {
+    responses = {
+      create: responsesCreateMock,
+    };
+  }
+
+  return {
+    default: MockOpenAI,
+    AzureOpenAI: MockOpenAI,
+  };
+});
+
+const ZERO_USAGE = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  totalTokens: 0,
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+} as const;
+
+function buildModel(): Model<"openai-responses"> {
+  return {
+    id: "gpt-5.4",
+    name: "gpt-5.4",
+    api: "openai-responses",
+    provider: "openai",
+    baseUrl: "https://api.openai.com/v1",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 128_000,
+    maxTokens: 4096,
+  };
+}
+
+function buildReplayableAssistantMessage(): Extract<AgentMessage, { role: "assistant" }> {
+  return {
+    role: "assistant",
+    api: "openai-responses",
+    provider: "openai",
+    model: "gpt-5.4",
+    usage: ZERO_USAGE,
+    stopReason: "stop",
+    timestamp: Date.now(),
+    content: [
+      {
+        type: "thinking",
+        thinking: "private reasoning",
+        thinkingSignature: JSON.stringify({
+          type: "reasoning",
+          id: "rs_test",
+          summary: [],
+        }),
+      },
+      {
+        type: "text",
+        text: "visible answer",
+        textSignature: JSON.stringify({ v: 1, id: "msg_test", phase: "final_answer" }),
+      },
+    ],
+  };
+}
+
+async function* successfulResponsesStream() {
+  yield { type: "response.created", response: { id: "resp_recovered" } };
+  yield { type: "response.output_item.added", item: { type: "message", id: "msg_recovered" } };
+  yield { type: "response.output_text.delta", delta: "recovered" };
+  yield {
+    type: "response.output_item.done",
+    item: {
+      type: "message",
+      id: "msg_recovered",
+      status: "completed",
+      content: [{ type: "output_text", text: "recovered" }],
+    },
+  };
+  yield {
+    type: "response.completed",
+    response: {
+      id: "resp_recovered",
+      status: "completed",
+      usage: {
+        input_tokens: 2,
+        output_tokens: 1,
+        total_tokens: 3,
+        input_tokens_details: { cached_tokens: 0 },
+      },
+    },
+  };
+}
+
+function extractInputTypes(payload: Record<string, unknown> | undefined): string[] {
+  const input = Array.isArray(payload?.input) ? payload.input : [];
+  return input
+    .map((item) =>
+      item && typeof item === "object" ? (item as Record<string, unknown>).type : undefined,
+    )
+    .filter((type): type is string => typeof type === "string");
+}
+
+describe("OpenAI Responses transport replay recovery", () => {
+  beforeEach(() => {
+    responsesCreateMock.mockReset();
+  });
+
+  it("recovers the current transport error-event path by retrying without replayed reasoning", async () => {
+    responsesCreateMock
+      .mockRejectedValueOnce(
+        new Error(
+          '400 {"error":{"code":"thinking_signature_invalid","message":"The encrypted content for item rs_test could not be verified. Reason: Encrypted content could not be decrypted or parsed.","type":"invalid_request_error"}}',
+        ),
+      )
+      .mockResolvedValueOnce(successfulResponsesStream());
+
+    const capturedPayloads: Record<string, unknown>[] = [];
+    const wrapped = wrapOpenAIResponsesStreamWithReplayRecovery(
+      createOpenAIResponsesTransportStreamFn(),
+      { id: "transport-proof-session" },
+    );
+
+    const stream = wrapped(
+      buildModel(),
+      {
+        systemPrompt: "system",
+        messages: [
+          { role: "user", content: "continue", timestamp: Date.now() },
+          buildReplayableAssistantMessage(),
+          { role: "user", content: "continue again", timestamp: Date.now() },
+        ],
+      } as never,
+      {
+        apiKey: "test",
+        onPayload: (payload) => {
+          capturedPayloads.push(payload as Record<string, unknown>);
+        },
+      } as never,
+    ) as { result: () => Promise<AgentMessage> };
+
+    await expect(stream.result()).resolves.toMatchObject({
+      role: "assistant",
+      stopReason: "stop",
+      content: [{ type: "text", text: "recovered" }],
+    });
+
+    expect(responsesCreateMock).toHaveBeenCalledTimes(2);
+    expect(extractInputTypes(capturedPayloads[0])).toContain("reasoning");
+    expect(extractInputTypes(capturedPayloads[1])).not.toContain("reasoning");
+    expect(extractInputTypes(capturedPayloads[1])).toContain("message");
+  });
+});

--- a/src/agents/pi-embedded-runner/openai-responses-transport-replay-recovery.test.ts
+++ b/src/agents/pi-embedded-runner/openai-responses-transport-replay-recovery.test.ts
@@ -140,8 +140,8 @@ describe("OpenAI Responses transport replay recovery", () => {
       } as never,
       {
         apiKey: "test",
-        onPayload: (payload) => {
-          capturedPayloads.push(payload as Record<string, unknown>);
+        onPayload: (payload: Record<string, unknown>) => {
+          capturedPayloads.push(payload);
         },
       } as never,
     ) as { result: () => Promise<AgentMessage> };

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -254,7 +254,11 @@ import {
   resolveEmbeddedAgentStreamFn,
 } from "../stream-resolution.js";
 import { applySystemPromptOverrideToSession } from "../system-prompt.js";
-import { dropReasoningFromHistory, dropThinkingBlocks } from "../thinking.js";
+import {
+  dropReasoningFromHistory,
+  dropThinkingBlocks,
+  wrapOpenAIResponsesStreamWithReplayRecovery,
+} from "../thinking.js";
 import {
   collectAllowedToolNames,
   collectCoreBuiltinToolNames,
@@ -2834,6 +2838,10 @@ export async function runEmbeddedAttempt(
           } as unknown;
           return inner(model, nextContext as typeof context, options);
         };
+        activeSession.agent.streamFn = wrapOpenAIResponsesStreamWithReplayRecovery(
+          activeSession.agent.streamFn,
+          { id: params.sessionId },
+        );
       }
 
       const innerStreamFn = activeSession.agent.streamFn;

--- a/src/agents/pi-embedded-runner/thinking.test.ts
+++ b/src/agents/pi-embedded-runner/thinking.test.ts
@@ -11,6 +11,7 @@ import {
   sanitizeThinkingForRecovery,
   stripInvalidThinkingSignatures,
   wrapAnthropicStreamWithRecovery,
+  wrapOpenAIResponsesStreamWithReplayRecovery,
 } from "./thinking.js";
 
 type AssistantMessage = Extract<AgentMessage, { role: "assistant" }>;
@@ -582,5 +583,171 @@ describe("wrapAnthropicStreamWithRecovery", () => {
 
     await expect(response.result()).resolves.toEqual(finalMessage);
     expect(events).toHaveLength(2);
+  });
+});
+
+describe("wrapOpenAIResponsesStreamWithReplayRecovery", () => {
+  const invalidReasoningError = new Error(
+    '400 {"error":{"code":"thinking_signature_invalid","message":"The encrypted content for item rs_test could not be verified. Reason: Encrypted content could not be decrypted or parsed.","type":"invalid_request_error"}}',
+  );
+
+  it("retries once with replayable reasoning dropped when the request is rejected before streaming", async () => {
+    let callCount = 0;
+    const contexts: Array<{ messages?: AgentMessage[] }> = [];
+    const wrapped = wrapOpenAIResponsesStreamWithReplayRecovery(
+      ((_model, context) => {
+        callCount += 1;
+        contexts.push(context as { messages?: AgentMessage[] });
+        return Promise.reject(invalidReasoningError);
+      }) as Parameters<typeof wrapOpenAIResponsesStreamWithReplayRecovery>[0],
+      { id: "test-session" },
+    );
+
+    await expect(
+      wrapped(
+        {} as never,
+        {
+          messages: castAgentMessages([
+            {
+              role: "assistant",
+              content: [
+                {
+                  type: "thinking",
+                  thinking: "internal",
+                  thinkingSignature: JSON.stringify({ id: "rs_test", type: "reasoning" }),
+                },
+                { type: "text", text: "visible answer" },
+              ],
+            },
+          ]),
+        } as never,
+        {} as never,
+      ),
+    ).rejects.toBe(invalidReasoningError);
+
+    expect(callCount).toBe(2);
+    const retryMessage = contexts[1]?.messages?.[0];
+    if (!retryMessage || retryMessage.role !== "assistant") {
+      throw new Error(
+        "Expected OpenAI Responses recovery retry to start with an assistant message",
+      );
+    }
+    expect(retryMessage.content).toEqual([{ type: "text", text: "visible answer" }]);
+  });
+
+  it("downgrades OpenAI function call ids after dropping paired reasoning", async () => {
+    const contexts: Array<{ messages?: AgentMessage[] }> = [];
+    const wrapped = wrapOpenAIResponsesStreamWithReplayRecovery(
+      ((_model, context) => {
+        contexts.push(context as { messages?: AgentMessage[] });
+        return Promise.reject(invalidReasoningError);
+      }) as Parameters<typeof wrapOpenAIResponsesStreamWithReplayRecovery>[0],
+      { id: "test-session" },
+    );
+
+    await expect(
+      wrapped(
+        {} as never,
+        {
+          messages: castAgentMessages([
+            {
+              role: "assistant",
+              content: [
+                {
+                  type: "thinking",
+                  thinking: "internal",
+                  thinkingSignature: JSON.stringify({ id: "rs_test", type: "reasoning" }),
+                },
+                { type: "toolCall", id: "call_123|fc_123", name: "read", arguments: {} },
+              ],
+            },
+            {
+              role: "toolResult",
+              toolCallId: "call_123|fc_123",
+              toolName: "read",
+              content: [{ type: "text", text: "ok" }],
+            },
+          ]),
+        } as never,
+        {} as never,
+      ),
+    ).rejects.toBe(invalidReasoningError);
+
+    const retryAssistant = contexts[1]?.messages?.[0];
+    const retryToolResult = contexts[1]?.messages?.[1];
+    if (!retryAssistant || retryAssistant.role !== "assistant") {
+      throw new Error("Expected OpenAI Responses recovery retry assistant turn");
+    }
+    if (!retryToolResult || retryToolResult.role !== "toolResult") {
+      throw new Error("Expected OpenAI Responses recovery retry tool result");
+    }
+    expect(retryAssistant.content).toEqual([
+      { type: "toolCall", id: "call_123", name: "read", arguments: {} },
+    ]);
+    expect(retryToolResult.toolCallId).toBe("call_123");
+  });
+
+  it("keeps dropping replayable reasoning on later calls after recovery is activated", async () => {
+    const contexts: Array<{ messages?: AgentMessage[] }> = [];
+    const wrapped = wrapOpenAIResponsesStreamWithReplayRecovery(
+      ((_model, context) => {
+        contexts.push(context as { messages?: AgentMessage[] });
+        if (contexts.length === 1) {
+          return Promise.reject(invalidReasoningError);
+        }
+        return Promise.reject(new Error("done"));
+      }) as Parameters<typeof wrapOpenAIResponsesStreamWithReplayRecovery>[0],
+      { id: "test-session" },
+    );
+    const context = {
+      messages: castAgentMessages([
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "thinking",
+              thinking: "internal",
+              thinkingSignature: JSON.stringify({ id: "rs_test", type: "reasoning" }),
+            },
+            { type: "text", text: "visible answer" },
+          ],
+        },
+      ]),
+    } as never;
+
+    await expect(wrapped({} as never, context, {} as never)).rejects.toThrow("done");
+    await expect(wrapped({} as never, context, {} as never)).rejects.toThrow("done");
+
+    const laterMessage = contexts[2]?.messages?.[0];
+    if (!laterMessage || laterMessage.role !== "assistant") {
+      throw new Error("Expected later OpenAI Responses call to start with an assistant message");
+    }
+    expect(laterMessage.content).toEqual([{ type: "text", text: "visible answer" }]);
+  });
+
+  it("does not retry when the stream fails after yielding a chunk", async () => {
+    let callCount = 0;
+    const wrapped = wrapOpenAIResponsesStreamWithReplayRecovery(
+      (() => {
+        callCount += 1;
+        return (async function* failingStream() {
+          yield "chunk";
+          throw invalidReasoningError;
+        })();
+      }) as unknown as Parameters<typeof wrapOpenAIResponsesStreamWithReplayRecovery>[0],
+      { id: "test-session" },
+    );
+
+    const chunks: unknown[] = [];
+    const response = wrapped({} as never, { messages: [] } as never, {} as never) as {
+      result: () => Promise<unknown>;
+    } & AsyncIterable<unknown>;
+    for await (const chunk of response) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toEqual(["chunk"]);
+    await expect(response.result()).rejects.toBe(invalidReasoningError);
+    expect(callCount).toBe(1);
   });
 });

--- a/src/agents/pi-embedded-runner/thinking.test.ts
+++ b/src/agents/pi-embedded-runner/thinking.test.ts
@@ -590,6 +590,51 @@ describe("wrapOpenAIResponsesStreamWithReplayRecovery", () => {
   const invalidReasoningError = new Error(
     '400 {"error":{"code":"thinking_signature_invalid","message":"The encrypted content for item rs_test could not be verified. Reason: Encrypted content could not be decrypted or parsed.","type":"invalid_request_error"}}',
   );
+  const assistantMessage = (overrides: Partial<AssistantMessage>): AssistantMessage =>
+    castAgentMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "done" }],
+      api: "openai-responses",
+      provider: "openai",
+      model: "gpt-5",
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "stop",
+      timestamp: Date.now(),
+      ...overrides,
+    }) as AssistantMessage;
+  const createTransportErrorStream = () => {
+    const stream = createAssistantMessageEventStream();
+    const errorAssistant = assistantMessage({
+      content: [],
+      stopReason: "error",
+      errorMessage: invalidReasoningError.message,
+    } as Partial<AssistantMessage>);
+    queueMicrotask(() => {
+      stream.push({ type: "error", reason: "error", error: errorAssistant });
+      stream.end();
+    });
+    return stream;
+  };
+  const createDoneStream = () => {
+    const stream = createAssistantMessageEventStream();
+    const doneAssistant = assistantMessage({
+      content: [{ type: "text", text: "recovered" }],
+      stopReason: "stop",
+    });
+    queueMicrotask(() => {
+      stream.push({ type: "start", partial: doneAssistant });
+      stream.push({ type: "done", reason: "stop", message: doneAssistant });
+      stream.end();
+    });
+    return stream;
+  };
 
   it("retries once with replayable reasoning dropped when the request is rejected before streaming", async () => {
     let callCount = 0;
@@ -603,27 +648,27 @@ describe("wrapOpenAIResponsesStreamWithReplayRecovery", () => {
       { id: "test-session" },
     );
 
-    await expect(
-      wrapped(
-        {} as never,
-        {
-          messages: castAgentMessages([
-            {
-              role: "assistant",
-              content: [
-                {
-                  type: "thinking",
-                  thinking: "internal",
-                  thinkingSignature: JSON.stringify({ id: "rs_test", type: "reasoning" }),
-                },
-                { type: "text", text: "visible answer" },
-              ],
-            },
-          ]),
-        } as never,
-        {} as never,
-      ),
-    ).rejects.toBe(invalidReasoningError);
+    const response = wrapped(
+      {} as never,
+      {
+        messages: castAgentMessages([
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "thinking",
+                thinking: "internal",
+                thinkingSignature: JSON.stringify({ id: "rs_test", type: "reasoning" }),
+              },
+              { type: "text", text: "visible answer" },
+            ],
+          },
+        ]),
+      } as never,
+      {} as never,
+    ) as { result: () => Promise<unknown> };
+
+    await expect(response.result()).rejects.toBe(invalidReasoningError);
 
     expect(callCount).toBe(2);
     const retryMessage = contexts[1]?.messages?.[0];
@@ -633,6 +678,64 @@ describe("wrapOpenAIResponsesStreamWithReplayRecovery", () => {
       );
     }
     expect(retryMessage.content).toEqual([{ type: "text", text: "visible answer" }]);
+  });
+
+  it("retries once when the Responses transport emits a pre-start invalid reasoning error event", async () => {
+    let callCount = 0;
+    const wrapped = wrapOpenAIResponsesStreamWithReplayRecovery(
+      (() => {
+        callCount += 1;
+        return callCount === 1 ? createTransportErrorStream() : createDoneStream();
+      }) as Parameters<typeof wrapOpenAIResponsesStreamWithReplayRecovery>[0],
+      { id: "test-session" },
+    );
+
+    const response = wrapped({} as never, { messages: [] } as never, {} as never) as {
+      result: () => Promise<AssistantMessage>;
+    } & AsyncIterable<unknown>;
+    const events: unknown[] = [];
+    for await (const event of response) {
+      events.push(event);
+    }
+
+    await expect(response.result()).resolves.toMatchObject({
+      stopReason: "stop",
+      content: [{ type: "text", text: "recovered" }],
+    });
+    expect(callCount).toBe(2);
+    expect(events).toEqual([
+      expect.objectContaining({ type: "start" }),
+      expect.objectContaining({ type: "done" }),
+    ]);
+  });
+
+  it("retries once when an auth-wrapped Responses stream resolves to a pre-start invalid reasoning error event", async () => {
+    let callCount = 0;
+    const wrapped = wrapOpenAIResponsesStreamWithReplayRecovery(
+      (async () => {
+        callCount += 1;
+        return callCount === 1 ? createTransportErrorStream() : createDoneStream();
+      }) as Parameters<typeof wrapOpenAIResponsesStreamWithReplayRecovery>[0],
+      { id: "test-session" },
+    );
+
+    const response = (await wrapped({} as never, { messages: [] } as never, {} as never)) as {
+      result: () => Promise<AssistantMessage>;
+    } & AsyncIterable<unknown>;
+    const events: unknown[] = [];
+    for await (const event of response) {
+      events.push(event);
+    }
+
+    await expect(response.result()).resolves.toMatchObject({
+      stopReason: "stop",
+      content: [{ type: "text", text: "recovered" }],
+    });
+    expect(callCount).toBe(2);
+    expect(events).toEqual([
+      expect.objectContaining({ type: "start" }),
+      expect.objectContaining({ type: "done" }),
+    ]);
   });
 
   it("downgrades OpenAI function call ids after dropping paired reasoning", async () => {
@@ -645,33 +748,33 @@ describe("wrapOpenAIResponsesStreamWithReplayRecovery", () => {
       { id: "test-session" },
     );
 
-    await expect(
-      wrapped(
-        {} as never,
-        {
-          messages: castAgentMessages([
-            {
-              role: "assistant",
-              content: [
-                {
-                  type: "thinking",
-                  thinking: "internal",
-                  thinkingSignature: JSON.stringify({ id: "rs_test", type: "reasoning" }),
-                },
-                { type: "toolCall", id: "call_123|fc_123", name: "read", arguments: {} },
-              ],
-            },
-            {
-              role: "toolResult",
-              toolCallId: "call_123|fc_123",
-              toolName: "read",
-              content: [{ type: "text", text: "ok" }],
-            },
-          ]),
-        } as never,
-        {} as never,
-      ),
-    ).rejects.toBe(invalidReasoningError);
+    const response = wrapped(
+      {} as never,
+      {
+        messages: castAgentMessages([
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "thinking",
+                thinking: "internal",
+                thinkingSignature: JSON.stringify({ id: "rs_test", type: "reasoning" }),
+              },
+              { type: "toolCall", id: "call_123|fc_123", name: "read", arguments: {} },
+            ],
+          },
+          {
+            role: "toolResult",
+            toolCallId: "call_123|fc_123",
+            toolName: "read",
+            content: [{ type: "text", text: "ok" }],
+          },
+        ]),
+      } as never,
+      {} as never,
+    ) as { result: () => Promise<unknown> };
+
+    await expect(response.result()).rejects.toBe(invalidReasoningError);
 
     const retryAssistant = contexts[1]?.messages?.[0];
     const retryToolResult = contexts[1]?.messages?.[1];
@@ -715,8 +818,14 @@ describe("wrapOpenAIResponsesStreamWithReplayRecovery", () => {
       ]),
     } as never;
 
-    await expect(wrapped({} as never, context, {} as never)).rejects.toThrow("done");
-    await expect(wrapped({} as never, context, {} as never)).rejects.toThrow("done");
+    const firstResponse = wrapped({} as never, context, {} as never) as {
+      result: () => Promise<unknown>;
+    };
+    await expect(firstResponse.result()).rejects.toThrow("done");
+    const secondResponse = wrapped({} as never, context, {} as never) as {
+      result: () => Promise<unknown>;
+    };
+    await expect(secondResponse.result()).rejects.toThrow("done");
 
     const laterMessage = contexts[2]?.messages?.[0];
     if (!laterMessage || laterMessage.role !== "assistant") {

--- a/src/agents/pi-embedded-runner/thinking.ts
+++ b/src/agents/pi-embedded-runner/thinking.ts
@@ -1,12 +1,21 @@
 import type { AgentMessage, StreamFn } from "@earendil-works/pi-agent-core";
 import { createAssistantMessageEventStream } from "@earendil-works/pi-ai";
 import { formatErrorMessage } from "../../infra/errors.js";
+import { isOpenAIResponsesReasoningReplayInvalidErrorMessage } from "../pi-embedded-helpers/errors.js";
+import {
+  downgradeOpenAIFunctionCallReasoningPairs,
+  downgradeOpenAIReasoningBlocks,
+} from "../pi-embedded-helpers/openai.js";
 import { log } from "./logger.js";
 
 type AssistantContentBlock = Extract<AgentMessage, { role: "assistant" }>["content"][number];
 type AssistantMessage = Extract<AgentMessage, { role: "assistant" }>;
 type RecoveryAssessment = "valid" | "incomplete-thinking" | "incomplete-text";
-type RecoverySessionMeta = { id: string; recoveredAnthropicThinking?: boolean };
+type RecoverySessionMeta = {
+  id: string;
+  recoveredAnthropicThinking?: boolean;
+  recoveredOpenAIResponsesReasoning?: boolean;
+};
 
 const THINKING_BLOCK_ERROR_PATTERN = /thinking or redacted_thinking blocks?.* cannot be modified/i;
 export const OMITTED_ASSISTANT_REASONING_TEXT = "[assistant reasoning omitted]";
@@ -465,6 +474,123 @@ export function wrapAnthropicStreamWithRecovery(
         outer.end();
       },
     );
+    outer.result = () => finalResultPromise;
+    return outer as unknown as ReturnType<StreamFn>;
+  };
+}
+
+function dropOpenAIResponsesReplayableReasoning(messages: AgentMessage[]): AgentMessage[] {
+  const reasoningSanitized = downgradeOpenAIReasoningBlocks(messages, {
+    dropReplayableReasoning: true,
+  });
+  return downgradeOpenAIFunctionCallReasoningPairs(reasoningSanitized);
+}
+
+function shouldRecoverOpenAIResponsesReasoningReplayError(
+  error: unknown,
+  sessionMeta: RecoverySessionMeta,
+): boolean {
+  const message = formatErrorMessage(error);
+  if (!isOpenAIResponsesReasoningReplayInvalidErrorMessage(message)) {
+    return false;
+  }
+  if (sessionMeta.recoveredOpenAIResponsesReasoning) {
+    log.warn(
+      `[session-recovery] OpenAI Responses reasoning replay recovery already attempted: sessionId=${sessionMeta.id}`,
+    );
+    return false;
+  }
+  return true;
+}
+
+async function pumpOpenAIResponsesStreamWithReplayRecovery(
+  outer: ReturnType<typeof createAssistantMessageEventStream>,
+  stream: ReturnType<StreamFn>,
+  sessionMeta: RecoverySessionMeta,
+  retry: () => ReturnType<StreamFn>,
+): Promise<AssistantMessage> {
+  let yieldedChunk = false;
+  try {
+    const resolved = stream instanceof Promise ? await stream : stream;
+    for await (const chunk of resolved as AsyncIterable<unknown>) {
+      yieldedChunk = true;
+      outer.push(chunk as Parameters<typeof outer.push>[0]);
+    }
+    const result = await (resolved as { result?: () => Promise<AssistantMessage> }).result?.();
+    return result as AssistantMessage;
+  } catch (error: unknown) {
+    if (!shouldRecoverOpenAIResponsesReasoningReplayError(error, sessionMeta)) {
+      throw error;
+    }
+    if (yieldedChunk) {
+      log.warn(
+        `[session-recovery] OpenAI Responses reasoning replay error occurred after streaming began; skipping retry to avoid duplicate chunks: sessionId=${sessionMeta.id}`,
+      );
+      throw error;
+    }
+    sessionMeta.recoveredOpenAIResponsesReasoning = true;
+    log.warn(
+      `[session-recovery] OpenAI Responses reasoning replay rejected; retrying once without replayable reasoning: sessionId=${sessionMeta.id}`,
+    );
+    const retryStream = retry();
+    const resolvedRetry = retryStream instanceof Promise ? await retryStream : retryStream;
+    for await (const chunk of resolvedRetry as AsyncIterable<unknown>) {
+      outer.push(chunk as Parameters<typeof outer.push>[0]);
+    }
+    const result = await (resolvedRetry as { result?: () => Promise<AssistantMessage> }).result?.();
+    return result as AssistantMessage;
+  }
+}
+
+export function wrapOpenAIResponsesStreamWithReplayRecovery(
+  innerStreamFn: StreamFn,
+  sessionMeta: RecoverySessionMeta,
+): StreamFn {
+  let dropReplayableReasoning = false;
+  return (model, context, options) => {
+    const contextRecord = context as unknown as { messages?: unknown };
+    const originalMessages = Array.isArray(contextRecord.messages)
+      ? (contextRecord.messages as AgentMessage[])
+      : [];
+    const buildContext = (dropReasoning: boolean) => {
+      const cleanedMessages = dropReasoning
+        ? dropOpenAIResponsesReplayableReasoning(originalMessages)
+        : originalMessages;
+      if (cleanedMessages === originalMessages) {
+        return context;
+      }
+      return {
+        ...(context as unknown as Record<string, unknown>),
+        messages: cleanedMessages,
+      } as typeof context;
+    };
+    const retry = () => {
+      dropReplayableReasoning = true;
+      return innerStreamFn(model, buildContext(true), options);
+    };
+
+    const stream = innerStreamFn(model, buildContext(dropReplayableReasoning), options);
+    if (stream instanceof Promise) {
+      return stream.catch((error: unknown) => {
+        if (!shouldRecoverOpenAIResponsesReasoningReplayError(error, sessionMeta)) {
+          throw error;
+        }
+        sessionMeta.recoveredOpenAIResponsesReasoning = true;
+        log.warn(
+          `[session-recovery] OpenAI Responses reasoning replay request rejected; retrying once without replayable reasoning: sessionId=${sessionMeta.id}`,
+        );
+        return retry();
+      }) as ReturnType<StreamFn>;
+    }
+    const outer = createAssistantMessageEventStream();
+    const finalResultPromise = pumpOpenAIResponsesStreamWithReplayRecovery(
+      outer,
+      stream,
+      sessionMeta,
+      retry,
+    ).finally(() => {
+      outer.end();
+    });
     outer.result = () => finalResultPromise;
     return outer as unknown as ReturnType<StreamFn>;
   };

--- a/src/agents/pi-embedded-runner/thinking.ts
+++ b/src/agents/pi-embedded-runner/thinking.ts
@@ -503,42 +503,97 @@ function shouldRecoverOpenAIResponsesReasoningReplayError(
   return true;
 }
 
+function getOpenAIResponsesReasoningReplayInvalidAssistantErrorMessage(
+  message: unknown,
+): string | null {
+  if (!message || typeof message !== "object") {
+    return null;
+  }
+  const record = message as { stopReason?: unknown; errorMessage?: unknown };
+  if (record.stopReason !== "error" || typeof record.errorMessage !== "string") {
+    return null;
+  }
+  return isOpenAIResponsesReasoningReplayInvalidErrorMessage(record.errorMessage)
+    ? record.errorMessage
+    : null;
+}
+
+function getOpenAIResponsesReasoningReplayInvalidEventErrorMessage(event: unknown): string | null {
+  if (!event || typeof event !== "object") {
+    return null;
+  }
+  const record = event as { type?: unknown; error?: unknown };
+  if (record.type !== "error") {
+    return null;
+  }
+  return getOpenAIResponsesReasoningReplayInvalidAssistantErrorMessage(record.error);
+}
+
+async function retryOpenAIResponsesStreamWithoutReplayableReasoning(
+  outer: ReturnType<typeof createAssistantMessageEventStream>,
+  sessionMeta: RecoverySessionMeta,
+  retry: () => ReturnType<StreamFn>,
+): Promise<AssistantMessage> {
+  sessionMeta.recoveredOpenAIResponsesReasoning = true;
+  log.warn(
+    `[session-recovery] OpenAI Responses reasoning replay rejected; retrying once without replayable reasoning: sessionId=${sessionMeta.id}`,
+  );
+  const retryStream = retry();
+  const resolvedRetry = retryStream instanceof Promise ? await retryStream : retryStream;
+  for await (const chunk of resolvedRetry as AsyncIterable<unknown>) {
+    outer.push(chunk as Parameters<typeof outer.push>[0]);
+  }
+  const result = await (resolvedRetry as { result?: () => Promise<AssistantMessage> }).result?.();
+  return result as AssistantMessage;
+}
+
 async function pumpOpenAIResponsesStreamWithReplayRecovery(
   outer: ReturnType<typeof createAssistantMessageEventStream>,
   stream: ReturnType<StreamFn>,
   sessionMeta: RecoverySessionMeta,
   retry: () => ReturnType<StreamFn>,
 ): Promise<AssistantMessage> {
-  let yieldedChunk = false;
+  let forwardedChunk = false;
   try {
     const resolved = stream instanceof Promise ? await stream : stream;
     for await (const chunk of resolved as AsyncIterable<unknown>) {
-      yieldedChunk = true;
+      const replayInvalidError = getOpenAIResponsesReasoningReplayInvalidEventErrorMessage(chunk);
+      if (replayInvalidError && !forwardedChunk) {
+        if (shouldRecoverOpenAIResponsesReasoningReplayError(replayInvalidError, sessionMeta)) {
+          return await retryOpenAIResponsesStreamWithoutReplayableReasoning(
+            outer,
+            sessionMeta,
+            retry,
+          );
+        }
+      }
+      forwardedChunk = true;
       outer.push(chunk as Parameters<typeof outer.push>[0]);
     }
     const result = await (resolved as { result?: () => Promise<AssistantMessage> }).result?.();
+    const replayInvalidResultError =
+      getOpenAIResponsesReasoningReplayInvalidAssistantErrorMessage(result);
+    if (replayInvalidResultError && !forwardedChunk) {
+      if (shouldRecoverOpenAIResponsesReasoningReplayError(replayInvalidResultError, sessionMeta)) {
+        return await retryOpenAIResponsesStreamWithoutReplayableReasoning(
+          outer,
+          sessionMeta,
+          retry,
+        );
+      }
+    }
     return result as AssistantMessage;
   } catch (error: unknown) {
     if (!shouldRecoverOpenAIResponsesReasoningReplayError(error, sessionMeta)) {
       throw error;
     }
-    if (yieldedChunk) {
+    if (forwardedChunk) {
       log.warn(
         `[session-recovery] OpenAI Responses reasoning replay error occurred after streaming began; skipping retry to avoid duplicate chunks: sessionId=${sessionMeta.id}`,
       );
       throw error;
     }
-    sessionMeta.recoveredOpenAIResponsesReasoning = true;
-    log.warn(
-      `[session-recovery] OpenAI Responses reasoning replay rejected; retrying once without replayable reasoning: sessionId=${sessionMeta.id}`,
-    );
-    const retryStream = retry();
-    const resolvedRetry = retryStream instanceof Promise ? await retryStream : retryStream;
-    for await (const chunk of resolvedRetry as AsyncIterable<unknown>) {
-      outer.push(chunk as Parameters<typeof outer.push>[0]);
-    }
-    const result = await (resolvedRetry as { result?: () => Promise<AssistantMessage> }).result?.();
-    return result as AssistantMessage;
+    return await retryOpenAIResponsesStreamWithoutReplayableReasoning(outer, sessionMeta, retry);
   }
 }
 
@@ -570,18 +625,6 @@ export function wrapOpenAIResponsesStreamWithReplayRecovery(
     };
 
     const stream = innerStreamFn(model, buildContext(dropReplayableReasoning), options);
-    if (stream instanceof Promise) {
-      return stream.catch((error: unknown) => {
-        if (!shouldRecoverOpenAIResponsesReasoningReplayError(error, sessionMeta)) {
-          throw error;
-        }
-        sessionMeta.recoveredOpenAIResponsesReasoning = true;
-        log.warn(
-          `[session-recovery] OpenAI Responses reasoning replay request rejected; retrying once without replayable reasoning: sessionId=${sessionMeta.id}`,
-        );
-        return retry();
-      }) as ReturnType<StreamFn>;
-    }
     const outer = createAssistantMessageEventStream();
     const finalResultPromise = pumpOpenAIResponsesStreamWithReplayRecovery(
       outer,


### PR DESCRIPTION
Fixes the OpenAI Responses half of #84002.

This intentionally does not change Slack main/thread session routing. The issue combines two continuation failures; this PR addresses the deterministic Responses replay failure where preserved encrypted reasoning can be rejected with `thinking_signature_invalid`.

## Root cause

OpenAI Responses can reject a replayed encrypted reasoning item when the stored `rs_*` content is no longer verifiable. Current history cleanup only drops replayable OpenAI reasoning when the model snapshot changes or when the reasoning block is orphaned, so a same-provider/same-model continuation can replay the stale encrypted reasoning again.

That error was also classified as a generic schema/format rejection, so terminal failures surfaced as "provider rejected the request schema" instead of a replay-state recovery error.

## What changed

- Classify `thinking_signature_invalid` and encrypted reasoning verification/decryption failures as replay-invalid.
- Wrap OpenAI Responses stream calls with a one-shot recovery path:
  - if the request fails before any streamed chunk, or the current Responses transport emits a pre-start assistant `error` event/result with invalid encrypted reasoning, drop replayable OpenAI reasoning blocks
  - downgrade paired `call|fc` tool call ids after dropping reasoning
  - retry the same model call once
  - keep dropping replayable reasoning for later calls in the same session wrapper after recovery is activated
- Do not retry if any stream chunk was already yielded, to avoid duplicate visible output/events.

## User impact

A Slack or channel continuation that hits stale OpenAI Responses encrypted reasoning should get one clean retry instead of ending the turn with no visible assistant content. If the retry still fails, the user-facing error now points to invalid session/replay state instead of a generic schema rejection.

## Real behavior proof

Behavior or issue addressed: OpenAI Responses continuation recovery for `thinking_signature_invalid` / invalid encrypted reasoning replay.

Real environment tested: Local OpenClaw checkout on this PR branch at original proof head `edc7ccba2a0ab7a3f972362b5ee74753ff0fb302`, then rebased/verified again at current PR head `09f8de688fbfc88e49ac7dd3c27101a0b8a16142`, on macOS with Node `v24.15.0`. The committed proof harness uses the real OpenAI SDK HTTP transport and OpenClaw's current `createOpenAIResponsesTransportStreamFn()` plus `wrapOpenAIResponsesStreamWithReplayRecovery()` against a loopback `/v1/responses` endpoint. It does not mock the OpenAI SDK; the loopback endpoint returns provider-shaped HTTP 400 and SSE responses so reviewers can inspect the request/retry payload transition.

Exact steps or command run after this patch:

```text
node --import tsx scripts/proofs/openai-responses-replay-recovery.ts
```

Evidence after fix:

```text
[openai-transport] [responses] error provider=openai api=openai-responses model=gpt-5.4 name=Error status=400 code=thinking_signature_invalid type=invalid_request_error causeName=undefined causeCode=undefined message=400 The encrypted content for item rs_real_transport_proof could not be verified. Reason: Encrypted content could not be decrypted or parsed.
[agent/embedded] [session-recovery] OpenAI Responses reasoning replay rejected; retrying once without replayable reasoning: sessionId=real-http-transport-proof-session
OpenAI Responses replay recovery proof: PASS
Runtime path: real OpenAI SDK HTTP transport against loopback /v1/responses
Mocking: no vi.mock/openai SDK mock; loopback server returns provider-shaped HTTP/SSE
Requests observed: 2
Request paths: /v1/responses, /v1/responses
First response: HTTP 400 thinking_signature_invalid
First request input types: reasoning, message
Retry request input types: message
Retry dropped replayed reasoning: true
Retry preserved replayed message: true
Recovered assistant text: recovered via real http transport
Final stopReason: stop
```

Observed result after fix: The first real SDK HTTP request contains replayed `reasoning` and receives a provider-shaped `thinking_signature_invalid` 400. The wrapper retries once. The second real SDK HTTP request drops replayed `reasoning`, preserves the replayed visible `message`, consumes the SSE response, and returns assistant text with `stopReason: stop`.

Committed inspectable proof: `scripts/proofs/openai-responses-replay-recovery.ts` is the manual proof harness. `src/agents/pi-embedded-runner/openai-responses-transport-replay-recovery.test.ts` remains the regression test that locks in the mocked-SDK transport error-event path.

What was not tested: Live Slack and live OpenAI Responses were not used. Slack session routing from #84002 is intentionally out of scope for this PR.

## Exact steps or command run after this patch

```text
node --import tsx scripts/proofs/openai-responses-replay-recovery.ts
./node_modules/.bin/oxlint --tsconfig config/tsconfig/oxlint.scripts.json scripts/proofs/openai-responses-replay-recovery.ts
node scripts/run-vitest.mjs src/agents/pi-embedded-runner/openai-responses-transport-replay-recovery.test.ts
node scripts/run-vitest.mjs src/agents/pi-embedded-runner/thinking.test.ts
node scripts/run-vitest.mjs src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
git diff --check
```

Rebase refresh at current PR head `09f8de688fbfc88e49ac7dd3c27101a0b8a16142`:

```text
node --import tsx scripts/proofs/openai-responses-replay-recovery.ts
./node_modules/.bin/oxlint --tsconfig config/tsconfig/oxlint.scripts.json scripts/proofs/openai-responses-replay-recovery.ts
node scripts/run-vitest.mjs src/agents/pi-embedded-runner/openai-responses-transport-replay-recovery.test.ts
node scripts/run-vitest.mjs src/agents/pi-embedded-runner/thinking.test.ts
node scripts/run-vitest.mjs src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
git diff --check
```

## Validation

```text
openai-responses-replay-recovery.ts proof harness: PASS
script oxlint: 0 warnings, 0 errors
openai-responses-transport-replay-recovery.test.ts: 2 test files, 2 tests passed
thinking.test.ts: 33 passed
pi-embedded-helpers.formatassistanterrortext.test.ts: 64 passed
tsgo core: passed
git diff --check: passed
rebase refresh: proof harness PASS, oxlint 0 warnings/0 errors, transport recovery tests 2 passed, thinking tests 33 passed, format assistant error text tests 64 passed, tsgo core passed, git diff --check passed
```
