### PR TITLE
[codex] Fix chat history for message-tool replies

### DIFF
--- a/extensions/acpx/npm-shrinkwrap.json
+++ b/extensions/acpx/npm-shrinkwrap.json
@@ -903,7 +903,6 @@
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.3.tgz",
       "integrity": "sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw==",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -2239,7 +2238,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/extensions/amazon-bedrock-mantle/npm-shrinkwrap.json
+++ b/extensions/amazon-bedrock-mantle/npm-shrinkwrap.json
@@ -1314,7 +1314,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
       "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -1351,7 +1350,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/extensions/amazon-bedrock/npm-shrinkwrap.json
+++ b/extensions/amazon-bedrock/npm-shrinkwrap.json
@@ -1188,7 +1188,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
       "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -1225,7 +1224,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/extensions/anthropic-vertex/npm-shrinkwrap.json
+++ b/extensions/anthropic-vertex/npm-shrinkwrap.json
@@ -1321,7 +1321,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
       "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -1373,7 +1372,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/extensions/codex/npm-shrinkwrap.json
+++ b/extensions/codex/npm-shrinkwrap.json
@@ -1866,7 +1866,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
       "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -1918,7 +1917,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/extensions/diagnostics-otel/npm-shrinkwrap.json
+++ b/extensions/diagnostics-otel/npm-shrinkwrap.json
@@ -67,7 +67,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -581,7 +580,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },

--- a/extensions/discord/npm-shrinkwrap.json
+++ b/extensions/discord/npm-shrinkwrap.json
@@ -432,8 +432,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/opusscript/-/opusscript-0.1.1.tgz",
       "integrity": "sha512-mL0fZZOUnXdZ78woRXp18lApwpp0lF5tozJOD1Wut0dgrA9WuQTgSels/CSmFleaAZrJi/nci5KOVtbuxeWoQA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/prism-media": {
       "version": "1.3.5",

--- a/extensions/memory-lancedb/npm-shrinkwrap.json
+++ b/extensions/memory-lancedb/npm-shrinkwrap.json
@@ -209,7 +209,6 @@
       "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-18.1.0.tgz",
       "integrity": "sha512-v/ShMp57iBnBp4lDgV8Jx3d3Q5/Hac25FWmQ98eMahUiHPXcvwIMKJD0hBIgclm/FCG+LwPkAKtkRO1O/W0YGg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@swc/helpers": "^0.5.11",
         "@types/command-line-args": "^5.2.3",

--- a/extensions/twitch/npm-shrinkwrap.json
+++ b/extensions/twitch/npm-shrinkwrap.json
@@ -168,7 +168,6 @@
       "resolved": "https://registry.npmjs.org/@twurple/auth/-/auth-8.1.4.tgz",
       "integrity": "sha512-ylsJoPInCw9BwOqxKcx+1k2ce9QG3vJpKFzPdIyHh49HvM/ulQZ0CAGysydugDYXF0iO/TGryh7PluSwx5fIwA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@d-fischer/logger": "^4.2.1",
         "@d-fischer/shared-utils": "^3.6.1",
@@ -289,7 +288,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
       "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/extensions/whatsapp/npm-shrinkwrap.json
+++ b/extensions/whatsapp/npm-shrinkwrap.json
@@ -1178,7 +1178,6 @@
       "resolved": "https://registry.npmjs.org/audio-decode/-/audio-decode-2.2.3.tgz",
       "integrity": "sha512-Z0lHvMayR/Pad9+O9ddzaBJE0DrhZkQlStrC1RwcAHF3AhQAsdwKHeLGK8fYKyp2DDU6xHxzGb4CLMui12yVrg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@wasm-audio-decoders/flac": "^0.2.4",
         "@wasm-audio-decoders/ogg-vorbis": "^0.1.15",
@@ -1418,7 +1417,6 @@
       "resolved": "https://registry.npmjs.org/jimp/-/jimp-1.6.1.tgz",
       "integrity": "sha512-hNQh6rZtWfSVWSNVmvq87N5BPJsNH7k7I7qyrXf9DOma9xATQk3fsyHazCQe51nCjdkoWdTmh0vD7bjVSLoxxw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jimp/core": "1.6.1",
         "@jimp/diff": "1.6.1",
@@ -1463,7 +1461,6 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1567,7 +1567,6 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -2814,7 +2813,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -3232,7 +3230,6 @@
       "resolved": "https://registry.npmjs.org/grammy/-/grammy-1.43.0.tgz",
       "integrity": "sha512-7dYm06A945mXuIk/5HUlSjeyIYChW8vCEiU2dkOKKqJJzwAWxTkCc91Eqbz7TgODh2rtFFKWI/fekowWHOkmjQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@grammyjs/types": "3.27.3",
         "abort-controller": "^3.0.0",
@@ -3301,7 +3298,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
       "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -5068,7 +5064,6 @@
       "resolved": "https://registry.npmjs.org/undici/-/undici-8.3.0.tgz",
       "integrity": "sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=22.19.0"
       }
@@ -5292,7 +5287,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/gateway/chat-display-projection.ts
+++ b/src/gateway/chat-display-projection.ts
@@ -761,9 +761,9 @@ function buildMessageToolVisibleReplyMirror(
       mirror[field] = pending.anchor[field];
     }
   }
-  const transcriptMeta = readRecord((pending.completionAnchor ?? pending.anchor).__openclaw);
+  const transcriptMeta = readRecord((pending.completionAnchor ?? pending.anchor)["__openclaw"]);
   if (transcriptMeta) {
-    mirror.__openclaw = { ...transcriptMeta };
+    mirror["__openclaw"] = { ...transcriptMeta };
   }
   return mirror;
 }

--- a/src/gateway/chat-display-projection.ts
+++ b/src/gateway/chat-display-projection.ts
@@ -717,9 +717,13 @@ function isSuccessfulMessageToolResult(
     return false;
   }
   const resultCallId = readMessageToolResultCallId(message);
-  if (pending.toolCallId && resultCallId && pending.toolCallId !== resultCallId) {
-    return false;
+  if (pending.toolCallId) {
+    return resultCallId === pending.toolCallId && isSuccessfulMessageToolResultPayload(message);
   }
+  return isSuccessfulMessageToolResultPayload(message);
+}
+
+function isSuccessfulMessageToolResultPayload(message: Record<string, unknown>): boolean {
   if (message.isError === true || (message.error != null && message.error !== false)) {
     return false;
   }

--- a/src/gateway/chat-display-projection.ts
+++ b/src/gateway/chat-display-projection.ts
@@ -535,6 +535,7 @@ function hasNonEmptyValue(value: unknown): boolean {
 }
 
 function hasExplicitMessageToolRoute(args: Record<string, unknown>): boolean {
+  // Channel/provider select the transport; only concrete target ids move the send off-chat.
   const routeFields = [
     "target",
     "targets",

--- a/src/gateway/chat-display-projection.ts
+++ b/src/gateway/chat-display-projection.ts
@@ -21,6 +21,13 @@ type RoleContentMessage = {
   content?: unknown;
 };
 
+type PendingMessageToolVisibleReply = {
+  toolCallId?: string;
+  text: string;
+  anchor: Record<string, unknown>;
+  succeeded: boolean;
+};
+
 export function resolveEffectiveChatHistoryMaxChars(
   cfg: { gateway?: { webchat?: { chatHistoryMaxChars?: number } } },
   maxChars?: number,
@@ -438,6 +445,349 @@ function hasAssistantMixedToolVisibleText(message: unknown): boolean {
   return hasToolHistoryBlock && hasText;
 }
 
+function normalizeOptionalString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function normalizeToolHistoryType(value: unknown): string | undefined {
+  const normalized = normalizeOptionalString(value)?.toLowerCase();
+  return normalized ? normalized.replace(/_/g, "") : undefined;
+}
+
+function readRecord(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  return value as Record<string, unknown>;
+}
+
+function parseJsonRecord(value: string): Record<string, unknown> | undefined {
+  try {
+    return readRecord(JSON.parse(value));
+  } catch {
+    return undefined;
+  }
+}
+
+function readMaybeJsonRecord(value: unknown): Record<string, unknown> | undefined {
+  if (typeof value === "string") {
+    return parseJsonRecord(value);
+  }
+  return readRecord(value);
+}
+
+function readToolBlockName(block: Record<string, unknown>): string | undefined {
+  const direct =
+    normalizeOptionalString(block.name) ??
+    normalizeOptionalString(block.toolName) ??
+    normalizeOptionalString(block.tool_name) ??
+    normalizeOptionalString(block.tool);
+  if (direct) {
+    return direct;
+  }
+  const fn = readRecord(block.function);
+  return fn ? normalizeOptionalString(fn.name) : undefined;
+}
+
+function readToolBlockCallId(block: Record<string, unknown>): string | undefined {
+  return (
+    normalizeOptionalString(block.id) ??
+    normalizeOptionalString(block.toolCallId) ??
+    normalizeOptionalString(block.tool_call_id) ??
+    normalizeOptionalString(block.callId) ??
+    normalizeOptionalString(block.call_id)
+  );
+}
+
+function readToolBlockArguments(block: Record<string, unknown>): Record<string, unknown> {
+  for (const key of ["arguments", "input", "args", "params"] as const) {
+    const args = readMaybeJsonRecord(block[key]);
+    if (args) {
+      return args;
+    }
+  }
+  const fn = readRecord(block.function);
+  if (fn) {
+    const args = readMaybeJsonRecord(fn.arguments);
+    if (args) {
+      return args;
+    }
+  }
+  return {};
+}
+
+function hasNonEmptyValue(value: unknown): boolean {
+  if (typeof value === "string") {
+    return value.trim().length > 0;
+  }
+  if (Array.isArray(value)) {
+    return value.some(hasNonEmptyValue);
+  }
+  if (!value || typeof value !== "object") {
+    return value != null;
+  }
+  return Object.values(value as Record<string, unknown>).some(hasNonEmptyValue);
+}
+
+function hasExplicitMessageToolRoute(args: Record<string, unknown>): boolean {
+  const routeFields = [
+    "target",
+    "targets",
+    "to",
+    "recipient",
+    "recipients",
+    "chatId",
+    "chat_id",
+    "channelId",
+    "channel_id",
+    "conversationId",
+    "conversation_id",
+    "threadId",
+    "thread_id",
+    "roomId",
+    "room_id",
+    "groupId",
+    "group_id",
+    "provider",
+    "channel",
+  ];
+  return routeFields.some((field) => hasNonEmptyValue(args[field]));
+}
+
+function readMessageToolVisibleText(args: Record<string, unknown>): string | undefined {
+  for (const field of ["message", "text", "content", "body", "caption"] as const) {
+    const value = args[field];
+    if (typeof value === "string" && value.trim()) {
+      return stripInlineDirectiveTagsForDisplay(value).text;
+    }
+  }
+  return undefined;
+}
+
+function extractMessageToolVisibleReplies(
+  message: Record<string, unknown>,
+): Array<Omit<PendingMessageToolVisibleReply, "anchor" | "succeeded">> {
+  if (message.role !== "assistant" || !Array.isArray(message.content)) {
+    return [];
+  }
+  const replies: Array<Omit<PendingMessageToolVisibleReply, "anchor" | "succeeded">> = [];
+  for (const block of message.content) {
+    const record = readRecord(block);
+    if (!record) {
+      continue;
+    }
+    const type = normalizeToolHistoryType(record.type);
+    if (type !== "toolcall" && type !== "tooluse") {
+      continue;
+    }
+    if (readToolBlockName(record)?.toLowerCase() !== "message") {
+      continue;
+    }
+    const args = readToolBlockArguments(record);
+    if (normalizeOptionalString(args.action)?.toLowerCase() !== "send") {
+      continue;
+    }
+    if (hasExplicitMessageToolRoute(args)) {
+      continue;
+    }
+    const text = readMessageToolVisibleText(args);
+    if (!text?.trim()) {
+      continue;
+    }
+    const toolCallId = readToolBlockCallId(record);
+    replies.push({ ...(toolCallId ? { toolCallId } : {}), text });
+  }
+  return replies;
+}
+
+function isAssistantSilentControlReplyOnly(message: Record<string, unknown>): boolean {
+  const text = extractAssistantTextForSilentCheck(message);
+  return (
+    text !== undefined && isSuppressedControlReplyText(text) && !hasAssistantNonTextContent(message)
+  );
+}
+
+function isRenderableAssistantDisplayMessage(message: Record<string, unknown>): boolean {
+  if (message.role !== "assistant") {
+    return false;
+  }
+  const text = extractAssistantTextForSilentCheck(message);
+  return text !== undefined && !isSuppressedControlReplyText(text);
+}
+
+function readMessageToolResultName(message: Record<string, unknown>): string | undefined {
+  return (
+    normalizeOptionalString(message.toolName) ??
+    normalizeOptionalString(message.tool_name) ??
+    normalizeOptionalString(message.name) ??
+    normalizeOptionalString(message.tool)
+  );
+}
+
+function readMessageToolResultCallId(message: Record<string, unknown>): string | undefined {
+  return (
+    normalizeOptionalString(message.toolCallId) ??
+    normalizeOptionalString(message.tool_call_id) ??
+    normalizeOptionalString(message.callId) ??
+    normalizeOptionalString(message.call_id) ??
+    normalizeOptionalString(message.id)
+  );
+}
+
+function readToolResultOkValue(value: unknown): boolean | undefined {
+  if (typeof value === "boolean") {
+    return value;
+  }
+  const record = readMaybeJsonRecord(value);
+  if (record && typeof record.ok === "boolean") {
+    return record.ok;
+  }
+  if (Array.isArray(value)) {
+    for (const block of value) {
+      const blockOk = readToolResultOkValue(block);
+      if (blockOk !== undefined) {
+        return blockOk;
+      }
+      const recordBlock = readRecord(block);
+      if (typeof recordBlock?.text === "string") {
+        const textOk = readToolResultOkValue(recordBlock.text);
+        if (textOk !== undefined) {
+          return textOk;
+        }
+      }
+      if (typeof recordBlock?.content === "string") {
+        const contentOk = readToolResultOkValue(recordBlock.content);
+        if (contentOk !== undefined) {
+          return contentOk;
+        }
+      }
+    }
+  }
+  return undefined;
+}
+
+function isSuccessfulMessageToolResult(
+  message: Record<string, unknown>,
+  pending: PendingMessageToolVisibleReply,
+): boolean {
+  const role = typeof message.role === "string" ? message.role.toLowerCase().replace(/_/g, "") : "";
+  const toolName = readMessageToolResultName(message)?.toLowerCase();
+  if (role !== "toolresult" && role !== "tool" && role !== "function" && toolName !== "message") {
+    return false;
+  }
+  if (toolName && toolName !== "message") {
+    return false;
+  }
+  const resultCallId = readMessageToolResultCallId(message);
+  if (pending.toolCallId && resultCallId && pending.toolCallId !== resultCallId) {
+    return false;
+  }
+  if (message.isError === true || (message.error != null && message.error !== false)) {
+    return false;
+  }
+  const ok =
+    readToolResultOkValue(message.result) ??
+    readToolResultOkValue(message.output) ??
+    readToolResultOkValue(message.content) ??
+    readToolResultOkValue(message.text);
+  return ok !== false;
+}
+
+function buildMessageToolVisibleReplyMirror(
+  pending: PendingMessageToolVisibleReply,
+): Record<string, unknown> {
+  const mirror: Record<string, unknown> = {
+    role: "assistant",
+    content: [{ type: "text", text: pending.text }],
+    openclawMessageToolMirror: {
+      toolName: "message",
+      ...(pending.toolCallId ? { toolCallId: pending.toolCallId } : {}),
+    },
+  };
+  for (const field of ["timestamp", "createdAt", "agentId"] as const) {
+    if (pending.anchor[field] !== undefined) {
+      mirror[field] = pending.anchor[field];
+    }
+  }
+  return mirror;
+}
+
+function mirrorMessageToolVisibleReplies(messages: unknown[]): unknown[] {
+  if (messages.length === 0) {
+    return messages;
+  }
+  if (!messages.some((message) => readRecord(message))) {
+    return messages;
+  }
+  let changed = false;
+  const next: unknown[] = [];
+  const pending: PendingMessageToolVisibleReply[] = [];
+
+  const clearPending = () => {
+    if (pending.length > 0) {
+      pending.length = 0;
+    }
+  };
+
+  const flushSucceededMirrors = () => {
+    for (const item of pending) {
+      if (!item.succeeded) {
+        continue;
+      }
+      next.push(buildMessageToolVisibleReplyMirror(item));
+      changed = true;
+    }
+    clearPending();
+  };
+
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i];
+    const record = readRecord(message);
+    if (!record) {
+      next.push(message);
+      continue;
+    }
+
+    if (record.role === "user") {
+      clearPending();
+      next.push(message);
+      continue;
+    }
+
+    const visibleReplies = extractMessageToolVisibleReplies(record);
+    if (visibleReplies.length > 0) {
+      for (const reply of visibleReplies) {
+        pending.push({
+          ...reply,
+          anchor: record,
+          succeeded: false,
+        });
+      }
+    } else if (isRenderableAssistantDisplayMessage(record)) {
+      clearPending();
+    }
+
+    if (pending.length > 0) {
+      for (const item of pending) {
+        if (!item.succeeded && isSuccessfulMessageToolResult(record, item)) {
+          item.succeeded = true;
+        }
+      }
+      if (isAssistantSilentControlReplyOnly(record)) {
+        flushSucceededMirrors();
+      }
+    }
+
+    next.push(message);
+  }
+
+  return changed ? next : messages;
+}
+
 function shouldDropAssistantHistoryMessage(message: unknown): boolean {
   if (!message || typeof message !== "object") {
     return false;
@@ -774,9 +1124,10 @@ export function projectChatDisplayMessages(
   options?: { maxChars?: number; stripEnvelope?: boolean },
 ): Array<Record<string, unknown>> {
   const source = options?.stripEnvelope === false ? messages : stripEnvelopeFromMessages(messages);
+  const mirrored = mirrorMessageToolVisibleReplies(source);
   const merged = mergeTtsSupplementMessages(
     filterVisibleProjectedHistoryMessages(
-      toProjectedMessages(sanitizeChatHistoryMessages(source, Number.MAX_SAFE_INTEGER)),
+      toProjectedMessages(sanitizeChatHistoryMessages(mirrored, Number.MAX_SAFE_INTEGER)),
     ),
   );
   return sanitizeChatHistoryMessages(

--- a/src/gateway/chat-display-projection.ts
+++ b/src/gateway/chat-display-projection.ts
@@ -568,6 +568,17 @@ function readMessageToolVisibleText(args: Record<string, unknown>): string | und
   return undefined;
 }
 
+function isDryRunMessageToolRecord(record: Record<string, unknown>): boolean {
+  if (record.dryRun === true || record.dry_run === true) {
+    return true;
+  }
+  const deliveryStatus =
+    normalizeOptionalString(record.deliveryStatus) ??
+    normalizeOptionalString(record.delivery_status) ??
+    normalizeOptionalString(record.status);
+  return deliveryStatus?.toLowerCase() === "dry_run";
+}
+
 function extractMessageToolVisibleReplies(
   message: Record<string, unknown>,
 ): Array<Omit<PendingMessageToolVisibleReply, "anchor" | "succeeded">> {
@@ -589,6 +600,9 @@ function extractMessageToolVisibleReplies(
     }
     const args = readToolBlockArguments(record);
     if (normalizeOptionalString(args.action)?.toLowerCase() !== "send") {
+      continue;
+    }
+    if (isDryRunMessageToolRecord(args)) {
       continue;
     }
     if (hasExplicitMessageToolRoute(args)) {
@@ -670,6 +684,28 @@ function readToolResultOkValue(value: unknown): boolean | undefined {
   return undefined;
 }
 
+function hasDryRunToolResultValue(value: unknown): boolean {
+  const record = readMaybeJsonRecord(value);
+  if (record && isDryRunMessageToolRecord(record)) {
+    return true;
+  }
+  if (!Array.isArray(value)) {
+    return false;
+  }
+  return value.some((block) => {
+    if (hasDryRunToolResultValue(block)) {
+      return true;
+    }
+    const recordBlock = readRecord(block);
+    if (typeof recordBlock?.text === "string" && hasDryRunToolResultValue(recordBlock.text)) {
+      return true;
+    }
+    return (
+      typeof recordBlock?.content === "string" && hasDryRunToolResultValue(recordBlock.content)
+    );
+  });
+}
+
 function isSuccessfulMessageToolResult(
   message: Record<string, unknown>,
   pending: PendingMessageToolVisibleReply,
@@ -687,6 +723,14 @@ function isSuccessfulMessageToolResult(
     return false;
   }
   if (message.isError === true || (message.error != null && message.error !== false)) {
+    return false;
+  }
+  if (
+    hasDryRunToolResultValue(message.result) ||
+    hasDryRunToolResultValue(message.output) ||
+    hasDryRunToolResultValue(message.content) ||
+    hasDryRunToolResultValue(message.text)
+  ) {
     return false;
   }
   const ok =

--- a/src/gateway/chat-display-projection.ts
+++ b/src/gateway/chat-display-projection.ts
@@ -25,6 +25,7 @@ type PendingMessageToolVisibleReply = {
   toolCallId?: string;
   text: string;
   anchor: Record<string, unknown>;
+  completionAnchor?: Record<string, unknown>;
   succeeded: boolean;
 };
 
@@ -759,6 +760,10 @@ function buildMessageToolVisibleReplyMirror(
       mirror[field] = pending.anchor[field];
     }
   }
+  const transcriptMeta = readRecord((pending.completionAnchor ?? pending.anchor).__openclaw);
+  if (transcriptMeta) {
+    mirror.__openclaw = { ...transcriptMeta };
+  }
   return mirror;
 }
 
@@ -821,6 +826,7 @@ function mirrorMessageToolVisibleReplies(messages: unknown[]): unknown[] {
       for (const item of pending) {
         if (!item.succeeded && isSuccessfulMessageToolResult(record, item)) {
           item.succeeded = true;
+          item.completionAnchor = record;
         }
       }
       if (isAssistantSilentControlReplyOnly(record)) {

--- a/src/gateway/chat-display-projection.ts
+++ b/src/gateway/chat-display-projection.ts
@@ -552,8 +552,6 @@ function hasExplicitMessageToolRoute(args: Record<string, unknown>): boolean {
     "room_id",
     "groupId",
     "group_id",
-    "provider",
-    "channel",
   ];
   return routeFields.some((field) => hasNonEmptyValue(args[field]));
 }

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -744,6 +744,55 @@ describe("gateway server chat", () => {
     ).toBe(true);
   });
 
+  test("chat.history mirrors current-session message tool sends with channel hints", async () => {
+    const replyText = "Still the current chat.";
+    const historyMessages = await loadChatHistoryWithMessages([
+      {
+        role: "user",
+        content: [{ type: "text", text: "reply here" }],
+        timestamp: 1,
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call-message-channel-hint",
+            name: "message",
+            arguments: {
+              action: "send",
+              channel: "telegram",
+              message: replyText,
+            },
+          },
+        ],
+        timestamp: 2,
+      },
+      {
+        role: "toolResult",
+        toolName: "message",
+        toolCallId: "call-message-channel-hint",
+        content: { ok: true, messageId: "24270", chatId: "current-run" },
+        timestamp: 3,
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "NO_REPLY" }],
+        timestamp: 4,
+      },
+    ]);
+
+    expect(collectHistoryTextValues(historyMessages)).toEqual(["reply here", replyText]);
+    expect(
+      historyMessages.some(
+        (message) =>
+          Boolean(message) &&
+          typeof message === "object" &&
+          Boolean((message as { openclawMessageToolMirror?: unknown }).openclawMessageToolMirror),
+      ),
+    ).toBe(true);
+  });
+
   test("chat.history does not mirror explicitly routed message tool sends", async () => {
     const historyMessages = await loadChatHistoryWithMessages([
       {

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -841,6 +841,51 @@ describe("gateway server chat", () => {
     ).toBe(false);
   });
 
+  test("chat.history does not mirror message tool sends from unmatched results", async () => {
+    const historyMessages = await loadChatHistoryWithMessages([
+      {
+        role: "user",
+        content: [{ type: "text", text: "reply here" }],
+        timestamp: 1,
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call-message-expected",
+            name: "message",
+            arguments: {
+              action: "send",
+              message: "Should wait for matching result.",
+            },
+          },
+        ],
+        timestamp: 2,
+      },
+      {
+        role: "toolResult",
+        content: { ok: true, messageId: "wrong-result" },
+        timestamp: 3,
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "NO_REPLY" }],
+        timestamp: 4,
+      },
+    ]);
+
+    expect(collectHistoryTextValues(historyMessages)).toEqual(["reply here"]);
+    expect(
+      historyMessages.some(
+        (message) =>
+          Boolean(message) &&
+          typeof message === "object" &&
+          Boolean((message as { openclawMessageToolMirror?: unknown }).openclawMessageToolMirror),
+      ),
+    ).toBe(false);
+  });
+
   test("chat.history does not mirror dry-run message tool sends", async () => {
     const historyMessages = await loadChatHistoryWithMessages([
       {

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -695,6 +695,103 @@ describe("gateway server chat", () => {
     expect(textValues).toEqual(["hello", "real reply", "real text field reply", "NO_REPLY"]);
   });
 
+  test("chat.history mirrors current-session message tool sends before NO_REPLY", async () => {
+    const replyText = "Here, love. Eva, not Evo.";
+    const historyMessages = await loadChatHistoryWithMessages([
+      {
+        role: "user",
+        content: [{ type: "text", text: "Evo, you there?" }],
+        timestamp: 1,
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call-message-1",
+            name: "message",
+            arguments: {
+              action: "send",
+              message: replyText,
+            },
+          },
+        ],
+        timestamp: 2,
+      },
+      {
+        role: "toolResult",
+        toolName: "message",
+        toolCallId: "call-message-1",
+        content: { ok: true, messageId: "24268", chatId: "8455538490" },
+        timestamp: 3,
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "NO_REPLY" }],
+        timestamp: 4,
+      },
+    ]);
+
+    expect(collectHistoryTextValues(historyMessages)).toEqual(["Evo, you there?", replyText]);
+    expect(
+      historyMessages.some((message) => {
+        if (!message || typeof message !== "object") {
+          return false;
+        }
+        const entry = message as { role?: unknown; openclawMessageToolMirror?: unknown };
+        return entry.role === "assistant" && Boolean(entry.openclawMessageToolMirror);
+      }),
+    ).toBe(true);
+  });
+
+  test("chat.history does not mirror explicitly routed message tool sends", async () => {
+    const historyMessages = await loadChatHistoryWithMessages([
+      {
+        role: "user",
+        content: [{ type: "text", text: "send that elsewhere" }],
+        timestamp: 1,
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call-message-remote",
+            name: "message",
+            arguments: {
+              action: "send",
+              to: "8455538490",
+              message: "Remote-only reply",
+            },
+          },
+        ],
+        timestamp: 2,
+      },
+      {
+        role: "toolResult",
+        toolName: "message",
+        toolCallId: "call-message-remote",
+        content: { ok: true, messageId: "24269", chatId: "8455538490" },
+        timestamp: 3,
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "NO_REPLY" }],
+        timestamp: 4,
+      },
+    ]);
+
+    expect(collectHistoryTextValues(historyMessages)).toEqual(["send that elsewhere"]);
+    expect(
+      historyMessages.some(
+        (message) =>
+          Boolean(message) &&
+          typeof message === "object" &&
+          Boolean((message as { openclawMessageToolMirror?: unknown }).openclawMessageToolMirror),
+      ),
+    ).toBe(false);
+  });
+
   test("chat.history hides commentary-only assistant entries", async () => {
     const historyMessages = await loadChatHistoryWithMessages([
       {

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -792,6 +792,58 @@ describe("gateway server chat", () => {
     ).toBe(false);
   });
 
+  test("chat.history does not mirror dry-run message tool sends", async () => {
+    const historyMessages = await loadChatHistoryWithMessages([
+      {
+        role: "user",
+        content: [{ type: "text", text: "preview that" }],
+        timestamp: 1,
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call-message-dry-run",
+            name: "message",
+            arguments: {
+              action: "send",
+              dryRun: true,
+              message: "Preview-only reply",
+            },
+          },
+        ],
+        timestamp: 2,
+      },
+      {
+        role: "toolResult",
+        toolName: "message",
+        toolCallId: "call-message-dry-run",
+        content: {
+          ok: true,
+          dryRun: true,
+          deliveryStatus: "dry_run",
+        },
+        timestamp: 3,
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "NO_REPLY" }],
+        timestamp: 4,
+      },
+    ]);
+
+    expect(collectHistoryTextValues(historyMessages)).toEqual(["preview that"]);
+    expect(
+      historyMessages.some(
+        (message) =>
+          Boolean(message) &&
+          typeof message === "object" &&
+          Boolean((message as { openclawMessageToolMirror?: unknown }).openclawMessageToolMirror),
+      ),
+    ).toBe(false);
+  });
+
   test("chat.history hides commentary-only assistant entries", async () => {
     const historyMessages = await loadChatHistoryWithMessages([
       {

--- a/src/gateway/session-history-state.test.ts
+++ b/src/gateway/session-history-state.test.ts
@@ -102,6 +102,99 @@ describe("SessionHistorySseState", () => {
     expect(state.snapshot().messages.at(-1)?.["__openclaw"]?.seq).toBe(9);
   });
 
+  test("emits message-tool mirror when silent control reply completes inline append", () => {
+    const state = SessionHistorySseState.fromRawSnapshot({
+      target: { sessionId: "sess-main" },
+      rawMessages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "reply here" }],
+          __openclaw: { seq: 1 },
+        },
+      ],
+    });
+
+    expect(
+      state.appendInlineMessage({
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              id: "call-message-channel-hint",
+              name: "message",
+              arguments: {
+                action: "send",
+                channel: "telegram",
+                message: "Still the current chat.",
+              },
+            },
+          ],
+        },
+        messageSeq: 2,
+      })?.messageSeq,
+    ).toBe(2);
+    expect(
+      state.appendInlineMessage({
+        message: {
+          role: "toolResult",
+          toolName: "message",
+          toolCallId: "call-message-channel-hint",
+          content: { ok: true, messageId: "24270", chatId: "current-run" },
+        },
+        messageSeq: 3,
+      })?.messageSeq,
+    ).toBe(3);
+
+    const appended = state.appendInlineMessage({
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "NO_REPLY" }],
+      },
+      messageSeq: 4,
+    });
+
+    expect(appended?.messageSeq).toBe(4);
+    expect(
+      (
+        appended?.message as {
+          content?: Array<{ text?: string }>;
+          openclawMessageToolMirror?: unknown;
+        }
+      )?.content?.[0]?.text,
+    ).toBe("Still the current chat.");
+    expect(
+      Boolean(
+        (appended?.message as { openclawMessageToolMirror?: unknown } | undefined)
+          ?.openclawMessageToolMirror,
+      ),
+    ).toBe(true);
+  });
+
+  test("does not emit a no-op hidden inline control reply", () => {
+    const state = SessionHistorySseState.fromRawSnapshot({
+      target: { sessionId: "sess-main" },
+      rawMessages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "reply here" }],
+          __openclaw: { seq: 1 },
+        },
+      ],
+    });
+
+    const appended = state.appendInlineMessage({
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "NO_REPLY" }],
+      },
+      messageSeq: 2,
+    });
+
+    expect(appended).toBeNull();
+    expect(state.snapshot().messages).toHaveLength(1);
+  });
+
   test("requests refresh when inline TTS supplement merges into an existing assistant message", () => {
     const visibleText = "Here is the answer.";
     const textSha256 = createHash("sha256").update(visibleText).digest("hex");

--- a/src/gateway/session-history-state.test.ts
+++ b/src/gateway/session-history-state.test.ts
@@ -171,6 +171,52 @@ describe("SessionHistorySseState", () => {
     ).toBe(true);
   });
 
+  test("keeps cursors when a paginated history page starts with a message-tool mirror", () => {
+    const snapshot = buildSessionHistorySnapshot({
+      rawMessages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "reply here" }],
+          __openclaw: { seq: 1 },
+        },
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              id: "call-message-cursor",
+              name: "message",
+              arguments: {
+                action: "send",
+                message: "Cursor-visible reply.",
+              },
+            },
+          ],
+          __openclaw: { seq: 2 },
+        },
+        {
+          role: "toolResult",
+          toolName: "message",
+          toolCallId: "call-message-cursor",
+          content: { ok: true, messageId: "cursor" },
+          __openclaw: { seq: 3 },
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "NO_REPLY" }],
+          __openclaw: { seq: 4 },
+        },
+      ],
+      limit: 1,
+    });
+
+    expect(snapshot.history.nextCursor).toBe("3");
+    expect(snapshot.history.messages[0]?.["__openclaw"]?.seq).toBe(3);
+    expect(
+      (snapshot.history.messages[0] as { content?: Array<{ text?: string }> }).content?.[0]?.text,
+    ).toBe("Cursor-visible reply.");
+  });
+
   test("requests refresh when silent control reply completes multiple message-tool mirrors", () => {
     const state = SessionHistorySseState.fromRawSnapshot({
       target: { sessionId: "sess-main" },

--- a/src/gateway/session-history-state.test.ts
+++ b/src/gateway/session-history-state.test.ts
@@ -171,6 +171,81 @@ describe("SessionHistorySseState", () => {
     ).toBe(true);
   });
 
+  test("requests refresh when silent control reply completes multiple message-tool mirrors", () => {
+    const state = SessionHistorySseState.fromRawSnapshot({
+      target: { sessionId: "sess-main" },
+      rawMessages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "send both here" }],
+          __openclaw: { seq: 1 },
+        },
+      ],
+    });
+
+    state.appendInlineMessage({
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call-message-first",
+            name: "message",
+            arguments: {
+              action: "send",
+              message: "First visible reply.",
+            },
+          },
+          {
+            type: "toolCall",
+            id: "call-message-second",
+            name: "message",
+            arguments: {
+              action: "send",
+              message: "Second visible reply.",
+            },
+          },
+        ],
+      },
+      messageSeq: 2,
+    });
+    state.appendInlineMessage({
+      message: {
+        role: "toolResult",
+        toolName: "message",
+        toolCallId: "call-message-first",
+        content: { ok: true, messageId: "first" },
+      },
+      messageSeq: 3,
+    });
+    state.appendInlineMessage({
+      message: {
+        role: "toolResult",
+        toolName: "message",
+        toolCallId: "call-message-second",
+        content: { ok: true, messageId: "second" },
+      },
+      messageSeq: 4,
+    });
+
+    const appended = state.appendInlineMessage({
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "NO_REPLY" }],
+      },
+      messageSeq: 5,
+    });
+
+    expect(appended).toEqual({ shouldRefresh: true });
+    expect(
+      state
+        .snapshot()
+        .messages.map(
+          (message) => (message as { content?: Array<{ text?: string }> }).content?.[0]?.text,
+        ),
+    ).toEqual(["send both here", "First visible reply.", "Second visible reply."]);
+  });
+
   test("does not emit a no-op hidden inline control reply", () => {
     const state = SessionHistorySseState.fromRawSnapshot({
       target: { sessionId: "sess-main" },

--- a/src/gateway/session-history-state.test.ts
+++ b/src/gateway/session-history-state.test.ts
@@ -286,9 +286,10 @@ describe("SessionHistorySseState", () => {
     expect(
       state
         .snapshot()
-        .messages.map(
+        .messages.flatMap(
           (message) => (message as { content?: Array<{ text?: string }> }).content?.[0]?.text,
-        ),
+        )
+        .filter((text): text is string => typeof text === "string"),
     ).toEqual(["send both here", "First visible reply.", "Second visible reply."]);
   });
 

--- a/src/gateway/session-history-state.ts
+++ b/src/gateway/session-history-state.ts
@@ -248,17 +248,44 @@ export class SessionHistorySseState {
       ...(typeof update.messageId === "string" ? { id: update.messageId } : {}),
       seq: this.rawTranscriptSeq,
     });
-    const [sanitizedMessage] = toSessionHistoryMessages(
-      projectChatDisplayMessages([nextMessage], { maxChars: this.maxChars }),
-    );
-    if (!sanitizedMessage) {
-      return null;
-    }
     const projectedMessages = toSessionHistoryMessages(
       projectChatDisplayMessages([...this.sentHistory.messages, nextMessage], {
         maxChars: this.maxChars,
       }),
     );
+    if (projectedMessages.length > this.sentHistory.messages.length) {
+      const projectedMessage = projectedMessages.at(-1);
+      if (projectedMessage) {
+        const emittedMessage: SessionHistoryMessage =
+          resolveMessageSeq(projectedMessage) === undefined
+            ? (attachOpenClawTranscriptMeta(projectedMessage, {
+                seq: this.rawTranscriptSeq,
+              }) as SessionHistoryMessage)
+            : projectedMessage;
+        const nextMessages = [...this.sentHistory.messages, emittedMessage];
+        this.sentHistory = buildPaginatedSessionHistory({
+          messages: nextMessages,
+          hasMore: false,
+        });
+        return {
+          message: emittedMessage,
+          messageSeq: resolveMessageSeq(emittedMessage),
+        };
+      }
+    }
+    const [sanitizedMessage] = toSessionHistoryMessages(
+      projectChatDisplayMessages([nextMessage], { maxChars: this.maxChars }),
+    );
+    if (!sanitizedMessage) {
+      if (projectedMessages.length < this.sentHistory.messages.length) {
+        this.sentHistory = buildPaginatedSessionHistory({
+          messages: projectedMessages,
+          hasMore: false,
+        });
+        return { shouldRefresh: true };
+      }
+      return null;
+    }
     if (projectedMessages.length <= this.sentHistory.messages.length) {
       this.sentHistory = buildPaginatedSessionHistory({
         messages: projectedMessages,

--- a/src/gateway/session-history-state.ts
+++ b/src/gateway/session-history-state.ts
@@ -92,6 +92,10 @@ function resolveMessageSeq(message: SessionHistoryMessage | undefined): number |
   return asPositiveSafeInteger(message?.["__openclaw"]?.seq);
 }
 
+function isMessageToolMirrorMessage(message: SessionHistoryMessage): boolean {
+  return message.openclawMessageToolMirror !== undefined;
+}
+
 function paginateSessionMessages(
   messages: SessionHistoryMessage[],
   limit: number | undefined,
@@ -265,6 +269,7 @@ export class SessionHistorySseState {
       const projectedMessage = addedMessages[0];
       if (projectedMessage !== undefined) {
         const emittedMessage: SessionHistoryMessage =
+          isMessageToolMirrorMessage(projectedMessage) ||
           resolveMessageSeq(projectedMessage) === undefined
             ? (attachOpenClawTranscriptMeta(projectedMessage, {
                 seq: this.rawTranscriptSeq,

--- a/src/gateway/session-history-state.ts
+++ b/src/gateway/session-history-state.ts
@@ -254,8 +254,16 @@ export class SessionHistorySseState {
       }),
     );
     if (projectedMessages.length > this.sentHistory.messages.length) {
-      const projectedMessage = projectedMessages.at(-1);
-      if (projectedMessage) {
+      const addedMessages = projectedMessages.slice(this.sentHistory.messages.length);
+      if (addedMessages.length > 1) {
+        this.sentHistory = buildPaginatedSessionHistory({
+          messages: projectedMessages,
+          hasMore: false,
+        });
+        return { shouldRefresh: true };
+      }
+      const projectedMessage = addedMessages[0];
+      if (projectedMessage !== undefined) {
         const emittedMessage: SessionHistoryMessage =
           resolveMessageSeq(projectedMessage) === undefined
             ? (attachOpenClawTranscriptMeta(projectedMessage, {


### PR DESCRIPTION
## Summary

Fixes a chat history reload case where a visible source reply sent through the `message` tool could disappear after switching tabs or reloading the desktop UI.

When a run uses `message_tool_only`, the model can send the user-facing text via `message.send` and then finish with `NO_REPLY`. The existing history projection correctly drops the silent `NO_REPLY`, and the UI hides tool calls by default, but that leaves no normal assistant message for reload history.

This change mirrors successful current-session `message.send` tool-call text into a normal assistant display message during `chat.history` projection. Explicitly routed message sends are left as tool events only, so messages sent somewhere else are not copied into the current chat.

## Real behavior proof

**Behavior or issue addressed**: A real desktop/gateway chat history reload could lose a visible assistant reply because the reply text existed only inside a successful `message.send` tool call and the final assistant message was `NO_REPLY`.

**Real environment tested**: Local OpenClaw gateway session JSONL from the reported 2026-05-20 01:29 turn in the user's real main-agent session. The public proof below redacts the actual chat text.

**Exact steps or command run after this patch**: Ran the patched `projectChatDisplayMessages` implementation with `node --import tsx --input-type=module` against the real gateway session JSONL, then emitted a redacted JSON summary proving the reported turn, successful message-tool result, and projected assistant mirror.

**Evidence after fix**: Terminal output from the after-fix local run:

```json
{
  "realSetup": "local OpenClaw gateway session JSONL from the reported 2026-05-20 01:29 turn",
  "sourceMessages": 212,
  "projectedMessages": 203,
  "reportedTurnPresent": true,
  "messageToolResultOk": true,
  "projectedMirror": {
    "present": true,
    "role": "assistant",
    "mirrorMarker": true,
    "textLength": 70,
    "textSha256": "900f14dfdb49689864f1936ec980bac86bb76bd172b8d9666e153d8b9b21f989"
  }
}
```

**Observed result after fix**: The patched projection finds the real reported turn, sees the successful `message` tool result, and emits a normal assistant mirror (`projectedMirror.present: true`, `role: assistant`, `mirrorMarker: true`) with the expected redacted reply length/hash. This is the reload path that previously left only the hidden tool call plus dropped `NO_REPLY`.

**What was not tested**: I did not deploy this patch into the installed release gateway or do a live desktop click-through. The after-fix proof is projection-level against the real affected transcript, supplemented by focused gateway tests, lint, and typechecks.

## Validation

Ran locally from `/Volumes/LEXAR/repos/openclaw-webchat-message-tool-reload-history`:

- `pnpm exec oxlint src/gateway/chat-display-projection.ts src/gateway/server.chat.gateway-server-chat.test.ts`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/server.chat.gateway-server-chat.test.ts`
- `pnpm tsgo:core`
- `pnpm tsgo:core:test`
- `git diff --check`