### PR TITLE
fix(code-mode): sharpen exec tool description so models stop wasting turns rediscovering constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Agents/code mode: sharpen the `exec` tool description so models do not waste turns rediscovering that Node modules are unavailable, that `language` rejects values other than `"javascript"`/`"typescript"`, and that the `tools.search`/`describe`/`call` bridge is the path for shell, file, network, and other I/O. Thanks @Kaspre.
 - Agents/config: allow `agents.list[].experimental.localModelLean` so lean local-model mode can be enabled for one configured agent instead of globally.
 - Providers/xAI: add device-code OAuth login so remote and headless setups can authorize xAI without a localhost browser callback. (#84005) Thanks @fuller-stack-dev.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- Agents/code mode: sharpen the `exec` tool description so models do not waste turns rediscovering that Node modules are unavailable, that `language` rejects values other than `"javascript"`/`"typescript"`, and that the `tools.search`/`describe`/`call` bridge is the path for shell, file, network, and other I/O. Thanks @Kaspre.
 - Agents/config: allow `agents.list[].experimental.localModelLean` so lean local-model mode can be enabled for one configured agent instead of globally.
 - Providers/xAI: add device-code OAuth login so remote and headless setups can authorize xAI without a localhost browser callback. (#84005) Thanks @fuller-stack-dev.
 

--- a/src/agents/code-mode.test.ts
+++ b/src/agents/code-mode.test.ts
@@ -245,6 +245,29 @@ describe("Code Mode", () => {
     expect(language).not.toHaveProperty("oneOf");
   });
 
+  it("describes code-mode runtime constraints in the model-visible exec schema", () => {
+    const { tools } = createCodeModeHarness();
+    const execTool = tools[0];
+    const parameters = execTool.parameters as {
+      properties?: Record<string, Record<string, unknown>>;
+    };
+
+    expect(execTool.description).toContain("Node.js modules");
+    expect(execTool.description).toContain("`require`/`import` are NOT available");
+    expect(execTool.description).toContain("`tools.search(query)`");
+    expect(execTool.description).toContain("enabled catalog tools allowed by policy");
+    expect(execTool.description).toContain("`tools.describe(entry.id)`");
+    expect(execTool.description).toContain("`tools.call(entry.id, args)`");
+    expect(execTool.description).toContain('"javascript" or "typescript"');
+
+    expect(parameters.properties?.code?.description).toContain("`tools` object");
+    expect(parameters.properties?.code?.description).toContain("`ALL_TOOLS`");
+    expect(parameters.properties?.code?.description).toContain("Node built-in modules are not");
+    expect(parameters.properties?.language?.description).toContain(
+      'Must be "javascript" or "typescript"',
+    );
+  });
+
   it("removes legacy Tool Search controls from the visible code mode surface", () => {
     const { config, catalogRef, tools: codeModeTools } = createCodeModeHarness();
     const compacted = applyCodeModeCatalog({

--- a/src/agents/code-mode.ts
+++ b/src/agents/code-mode.ts
@@ -826,7 +826,7 @@ export function createCodeModeTools(ctx: CodeModeToolContext): AnyAgentTool[] {
     name: CODE_MODE_EXEC_TOOL_NAME,
     label: "exec",
     description:
-      "Run JavaScript or TypeScript in OpenClaw code mode. Node.js modules and `require`/`import` are NOT available — for any shell, file, network, or external action, use the catalog bridge from inside your code: `tools.search(query)` to find tools, `tools.describe(name)` for the input schema, then `tools.call(name, args)`. The `language` field accepts only \"javascript\" or \"typescript\"; do not pass \"bash\", \"shell\", or other values.",
+      "Run JavaScript or TypeScript in OpenClaw code mode. Node.js modules and `require`/`import` are NOT available — for any shell, file, network, or external action, use enabled catalog tools allowed by policy from inside your code: `tools.search(query)` to find catalog entries, `tools.describe(entry.id)` for the input schema, then `tools.call(entry.id, args)`. The `language` field accepts only \"javascript\" or \"typescript\"; do not pass \"bash\", \"shell\", or other values.",
     parameters: Type.Object({
       code: Type.String({
         description:

--- a/src/agents/code-mode.ts
+++ b/src/agents/code-mode.ts
@@ -826,11 +826,14 @@ export function createCodeModeTools(ctx: CodeModeToolContext): AnyAgentTool[] {
     name: CODE_MODE_EXEC_TOOL_NAME,
     label: "exec",
     description:
-      "Run JavaScript or TypeScript in OpenClaw code mode. Use ALL_TOOLS and tools.search/describe/call inside the code to discover and call enabled tools.",
+      "Run JavaScript or TypeScript in OpenClaw code mode. Node.js modules and `require`/`import` are NOT available — for any shell, file, network, or external action, use the catalog bridge from inside your code: `tools.search(query)` to find tools, `tools.describe(name)` for the input schema, then `tools.call(name, args)`. The `language` field accepts only \"javascript\" or \"typescript\"; do not pass \"bash\", \"shell\", or other values.",
     parameters: Type.Object({
-      code: Type.String({ description: "JavaScript or TypeScript source to run." }),
+      code: Type.String({
+        description:
+          "JavaScript or TypeScript source to run. The `tools` object (search/describe/call) and `ALL_TOOLS` are available in scope; Node built-in modules are not.",
+      }),
       language: optionalStringEnum(["javascript", "typescript"] as const, {
-        description: "Source language. Defaults to javascript.",
+        description: "Source language. Must be \"javascript\" or \"typescript\". Defaults to javascript.",
       }),
     }),
     execute: async (


### PR DESCRIPTION
## Problem

When OpenClaw code mode is enabled, the `exec` tool's description tells the model to use `tools.search` / `describe` / `call` to call enabled tools but does not state any of the runtime's actual constraints. In observed agent traces, the model burns turns rediscovering them:

- It tries `language: "bash"` because "code mode" reads as "any code"; gets rejected.
- It writes `require('fs')` (or another Node built-in) to do I/O; gets `"code mode module access is disabled."` and loops trying simpler constructs (`let x = 1`, bare expression) to figure out which patterns are allowed.
- It rediscovers, turn by turn, that Node modules are unavailable and that the catalog bridge is the only path to I/O.

## Change and value

Sharpen the description so the model sees the constraints up front:

- Node modules and `require` / `import` are NOT available.
- The `language` field accepts only `"javascript"` or `"typescript"`.
- The catalog bridge is the path for shell, file, network, or external action: `tools.search(query)` finds enabled catalog entries, then code should pass `entry.id` to `tools.describe(entry.id)` and `tools.call(entry.id, args)`.
- Catalog calls still go only through enabled tools allowed by existing policy.

Parameter descriptions also state which symbols are in scope (`tools`, `ALL_TOOLS`) versus what is not (Node built-ins).

No runtime behavior changes — only the tool-card text the model sees.

## Who's affected

All agents with code mode enabled (globally or per-agent), regardless of provider. Most directly: models that don't already know the catalog-bridge contract from training-set examples — typically smaller open-weight models routed through the Pi-embedded-runner.

## Why now

Per-agent code mode shipped in 2026.5.18 (#83473). A controlled re-enable for evaluation surfaced sessions where the agent spent 6+ turns probing the same constraints before stabilizing on the bridge pattern. Description-only fixes are the cheapest path to reduce that floor; the rest of the friction is structural and will need separate work.

## Implementation

`src/agents/code-mode.ts` — `createCodeModeTools`:
- `exec` tool `description` expanded with the three constraints.
- Bridge guidance uses the documented id-based flow: search for entries, then call `describe` / `call` with `entry.id`.
- `code` parameter description states scope explicitly (`tools` and `ALL_TOOLS` in scope; Node built-ins not).
- `language` parameter description states the enum.

`src/agents/code-mode.test.ts`:
- Adds regression coverage that the model-visible `exec` description and parameter descriptions keep those runtime constraints visible.

## Real behavior proof

- **Behavior or issue addressed**: When code mode is enabled, models routed through the Pi-embedded-runner can waste turns rediscovering that `language: "bash"` is rejected, that `require` / `import` is unavailable, and that the `tools.search` / `describe` / `call` bridge is the path to I/O. The current `exec` description does not state any of those constraints; agents must discover them by trial and error at runtime.

- **Real environment tested**: OpenClaw 2026.5.18 stable (commit `50a2481`); agent routed to `ollama-cloud/kimi-k2.6` via the Pi-embedded-runner; `tools.codeMode.enabled: true` (per-agent override per #83473 schema). Same agent, same model, same prompt across before/after for the live delivery proof. Final-head schema readback was run from this PR branch at `e75ca8e7bb34dfc76a6e6dc23397e571353a09e2`. CI-shaped validation was run on the PR merge ref in Crabbox/GCP.

- **Exact steps or command run after this patch**:
  ```bash
  # Live delivery proof — same prompt before and after patching the running dist:
  PROBE='Without calling any tools, recite the description text of the `exec` tool exactly as it appears in your tool definitions. Quote it verbatim and reply with just that text.'

  openclaw agent --local --agent <pi-runtime-codemode-agent> --timeout 120 \
    --model ollama-cloud/kimi-k2.6 --thinking low \
    --session-id "cm-rbp-<phase>-$(date +%s)" \
    -m "$PROBE" --json

  # Final-head schema readback at e75ca8e7bb:
  node --import tsx -e 'import { createCodeModeTools } from "./src/agents/code-mode.ts"; import { createToolSearchCatalogRef } from "./src/agents/tool-search.ts"; const config = { tools: { codeMode: true } }; const [execTool] = createCodeModeTools({ config, runtimeConfig: config, sessionId: "schema-proof", sessionKey: "agent:main:main", runId: "schema-proof", catalogRef: createToolSearchCatalogRef() }); console.log(execTool.description);'

  # Remote merge-ref validation in Crabbox/GCP:
  pnpm install --frozen-lockfile --reporter=append-only
  pnpm build
  pnpm tsgo:core:test
  pnpm check:changed
  ```

- **Evidence after fix**: Live agent dispatches (recitation probe, fresh sessions) at 2026-05-19T20:28Z (before-patch dist) and 2026-05-19T20:42Z (after-patch dist) returned the following final payloads.

  **Before** (`main` dist; agent reads OLD description):
  ```
  Run JavaScript or TypeScript in OpenClaw code mode. Use ALL_TOOLS and tools.search/describe/call inside the code to discover and call enabled tools.
  ```
  No statement that `require` / `import` is blocked. No statement that `language` rejects values other than `javascript` / `typescript`. The model has to discover these by trying them.

  **Live delivery after initial patch** (dist patched to this PR's description block; agent reads NEW description):
  ```
  Run JavaScript or TypeScript in OpenClaw code mode. Node.js modules and `require`/`import` are NOT available — for any shell, file, network, or external action, use the catalog bridge from inside your code: `tools.search(query)` to find tools, `tools.describe(name)` for the input schema, then `tools.call(name, args)`. The `language` field accepts only "javascript" or "typescript"; do not pass "bash", "shell", or other values.
  ```
  The live recitation proved the model receives the model-visible description unchanged.

  **Final head schema readback** (`e75ca8e7bb`; source code path that builds the model-visible tool schema):
  ```
  Run JavaScript or TypeScript in OpenClaw code mode. Node.js modules and `require`/`import` are NOT available — for any shell, file, network, or external action, use enabled catalog tools allowed by policy from inside your code: `tools.search(query)` to find catalog entries, `tools.describe(entry.id)` for the input schema, then `tools.call(entry.id, args)`. The `language` field accepts only "javascript" or "typescript"; do not pass "bash", "shell", or other values.
  ```

  Final-head source assertions also checked the `code` parameter mentions `tools`, `ALL_TOOLS`, and unavailable Node built-ins, and that `language` says it must be `"javascript"` or `"typescript"`.

  **Remote merge-ref validation** (Crabbox/GCP, `us-east1-b`, PR merge ref containing `e75ca8e7bb`): `pnpm install --frozen-lockfile --reporter=append-only`, `pnpm build`, `pnpm tsgo:core:test`, and `pnpm check:changed` all exited 0. `pnpm check:changed` selected the `core` and `coreTests` lanes, typechecked both, linted 8652 files with 217 rules using 1 thread, and reported 0 warnings / 0 errors. Cleanup check found no remaining `crabbox-*` GCP instances.

- **Observed result after fix**: The live recitation proves the generated `exec` description reaches the model as its tool-card text. The final PR head now emits the safer id-based bridge wording from the same `createCodeModeTools` schema path, so agents see the constraints up front without being steered toward ambiguous name-based `describe` / `call` handles.

- **What was not tested**: A multi-trial controlled A/B measuring the rate-of-rediscovery reduction (turns spent attempting `language: "bash"`, `require()`, etc., before stabilizing on the bridge pattern). The proof confirms delivery and final schema text; behavioral impact would need many trials on a model that exhibits the rediscovery loop reliably (an earlier observed instance was a real session that looped 6+ turns on `code mode module access is disabled` after attempting `require('fs')`).