### PR TITLE
Suppress heartbeat fallback after message-tool delivery

### DIFF
--- a/src/auto-reply/heartbeat-reply-payload.ts
+++ b/src/auto-reply/heartbeat-reply-payload.ts
@@ -1,4 +1,5 @@
 import { hasOutboundReplyContent } from "openclaw/plugin-sdk/reply-payload";
+import { getReplyPayloadMetadata } from "./reply-payload.js";
 import type { ReplyPayload } from "./types.js";
 
 export function resolveHeartbeatReplyPayload(
@@ -20,4 +21,16 @@ export function resolveHeartbeatReplyPayload(
     }
   }
   return undefined;
+}
+
+export function hasHeartbeatMessageToolDeliveryEvidence(
+  replyResult: ReplyPayload | ReplyPayload[] | undefined,
+): boolean {
+  if (!replyResult) {
+    return false;
+  }
+  const payloads = Array.isArray(replyResult) ? replyResult : [replyResult];
+  return payloads.some(
+    (payload) => getReplyPayloadMetadata(payload)?.messageToolDelivered === true,
+  );
 }

--- a/src/auto-reply/reply-payload.ts
+++ b/src/auto-reply/reply-payload.ts
@@ -144,6 +144,12 @@ export function buildTtsSupplementMediaPayload(payload: ReplyPayload): ReplyPayl
 export type ReplyPayloadMetadata = {
   assistantMessageIndex?: number;
   /**
+   * The agent completed a visible message-tool delivery during this turn. This
+   * is internal delivery evidence for callers that invoke getReplyFromConfig
+   * directly and must not be serialized into channelData.
+   */
+  messageToolDelivered?: boolean;
+  /**
    * Internal OpenClaw notices generated after a runtime/provider failure are
    * not assistant source replies. Dispatch may deliver them even when normal
    * assistant source replies are message-tool-only; sendPolicy deny still wins.
@@ -188,5 +194,11 @@ export function copyReplyPayloadMetadata<T extends object>(source: object, paylo
 export function markReplyPayloadForSourceSuppressionDelivery<T extends object>(payload: T): T {
   return setReplyPayloadMetadata(payload, {
     deliverDespiteSourceReplySuppression: true,
+  });
+}
+
+export function markReplyPayloadForMessageToolDelivery<T extends object>(payload: T): T {
+  return setReplyPayloadMetadata(payload, {
+    messageToolDelivered: true,
   });
 }

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionEntry } from "../../config/sessions.js";
 import type { TypingMode } from "../../config/types.js";
+import { getReplyPayloadMetadata } from "../reply-payload.js";
 import type { TemplateContext } from "../templating.js";
 import type { GetReplyOptions } from "../types.js";
 import {
@@ -1296,6 +1297,34 @@ describe("runReplyAgent typing (heartbeat)", () => {
     } finally {
       fallbackSpy.mockRestore();
     }
+  });
+
+  it("marks automatic heartbeat replies after generic message-tool delivery", async () => {
+    state.runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "fallback narration that would duplicate the message tool" }],
+      messagingToolSentTexts: ["message tool delivered"],
+      messagingToolSentTargets: [{ tool: "message", provider: "telegram", to: "-100123" }],
+      meta: {},
+    });
+
+    const { run } = createMinimalRun({
+      opts: { isHeartbeat: true },
+      runOverrides: {
+        messageProvider: "telegram",
+      },
+      sessionCtx: {
+        Provider: "telegram",
+        OriginatingChannel: "telegram",
+        OriginatingTo: "-100123",
+        AccountId: "primary",
+      },
+    });
+
+    const res = await run();
+    const payload = Array.isArray(res) ? res[0] : res;
+
+    expect(payload?.text).toBe("fallback narration that would duplicate the message tool");
+    expect(getReplyPayloadMetadata(payload)?.messageToolDelivered).toBe(true);
   });
 
   it("does not treat whitespace-only messaging evidence as fallback delivery", async () => {

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -1323,7 +1323,11 @@ describe("runReplyAgent typing (heartbeat)", () => {
     const res = await run();
     const payload = Array.isArray(res) ? res[0] : res;
 
-    expect(payload?.text).toBe("fallback narration that would duplicate the message tool");
+    if (!payload) {
+      throw new Error("Expected automatic heartbeat reply payload");
+    }
+
+    expect(payload.text).toBe("fallback narration that would duplicate the message tool");
     expect(getReplyPayloadMetadata(payload)?.messageToolDelivered).toBe(true);
   });
 

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -2124,7 +2124,10 @@ export async function runReplyAgent(params: {
     if (isHookBlockedRun) {
       finalPayloads = markBeforeAgentRunBlockedPayloads(finalPayloads);
     }
-    if (opts?.sourceReplyDeliveryMode === "message_tool_only" && successfulMessagingToolDelivery) {
+    if (
+      successfulMessagingToolDelivery &&
+      (opts?.sourceReplyDeliveryMode === "message_tool_only" || isHeartbeat)
+    ) {
       finalPayloads = finalPayloads.map((payload) =>
         markReplyPayloadForMessageToolDelivery(payload),
       );

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -49,6 +49,7 @@ import {
 } from "../fallback-state.js";
 import { DEFAULT_HEARTBEAT_ACK_MAX_CHARS, stripHeartbeatToken } from "../heartbeat.js";
 import {
+  markReplyPayloadForMessageToolDelivery,
   markReplyPayloadForSourceSuppressionDelivery,
   setReplyPayloadMetadata,
 } from "../reply-payload.js";
@@ -179,6 +180,18 @@ function hasSuccessfulSideEffectDelivery(params: {
     hasCommittedMessagingTargetDeliveryEvidence(params.messagingToolSentTargets) ||
     (params.successfulCronAdds ?? 0) > 0 ||
     params.didSendDeterministicApprovalPrompt === true
+  );
+}
+
+function hasSuccessfulMessagingToolDelivery(params: {
+  messagingToolSentTexts?: string[];
+  messagingToolSentMediaUrls?: string[];
+  messagingToolSentTargets?: unknown[];
+}): boolean {
+  return (
+    hasNonEmptyStringArray(params.messagingToolSentTexts) ||
+    hasNonEmptyStringArray(params.messagingToolSentMediaUrls) ||
+    hasCommittedMessagingTargetDeliveryEvidence(params.messagingToolSentTargets)
   );
 }
 
@@ -1635,6 +1648,11 @@ export async function runReplyAgent(params: {
       successfulCronAdds: runResult.successfulCronAdds,
       didSendDeterministicApprovalPrompt: runResult.didSendDeterministicApprovalPrompt,
     });
+    const successfulMessagingToolDelivery = hasSuccessfulMessagingToolDelivery({
+      messagingToolSentTexts: runResult.messagingToolSentTexts,
+      messagingToolSentMediaUrls: runResult.messagingToolSentMediaUrls,
+      messagingToolSentTargets: runResult.messagingToolSentTargets,
+    });
     const returnSilentFallbackFailureIfNeeded = async (): Promise<ReplyPayload | undefined> => {
       const silentFallbackFailurePayload = buildSilentFallbackFailurePayload({
         fallbackTransition,
@@ -2105,6 +2123,11 @@ export async function runReplyAgent(params: {
     }
     if (isHookBlockedRun) {
       finalPayloads = markBeforeAgentRunBlockedPayloads(finalPayloads);
+    }
+    if (opts?.sourceReplyDeliveryMode === "message_tool_only" && successfulMessagingToolDelivery) {
+      finalPayloads = finalPayloads.map((payload) =>
+        markReplyPayloadForMessageToolDelivery(payload),
+      );
     }
 
     // Capture only policy-visible final payloads in session store to support

--- a/src/auto-reply/types.ts
+++ b/src/auto-reply/types.ts
@@ -7,6 +7,7 @@ export type {
 } from "./get-reply-options.types.js";
 export {
   copyReplyPayloadMetadata,
+  markReplyPayloadForMessageToolDelivery,
   markReplyPayloadForSourceSuppressionDelivery,
   setReplyPayloadMetadata,
 } from "./reply-payload.js";

--- a/src/infra/heartbeat-runner.tool-response.test.ts
+++ b/src/infra/heartbeat-runner.tool-response.test.ts
@@ -9,7 +9,10 @@ import {
   GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
   HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT,
 } from "../auto-reply/reply/agent-runner-failure-copy.js";
-import { markReplyPayloadForSourceSuppressionDelivery } from "../auto-reply/types.js";
+import {
+  markReplyPayloadForMessageToolDelivery,
+  markReplyPayloadForSourceSuppressionDelivery,
+} from "../auto-reply/types.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { getLastHeartbeatEvent, resetHeartbeatEventsForTest } from "./heartbeat-events.js";
 import { runHeartbeatOnce, type HeartbeatDeps } from "./heartbeat-runner.js";
@@ -226,6 +229,37 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
     });
 
     expectHeartbeatToolPrompt(result, ["notify=false"]);
+  });
+
+  it("suppresses heartbeat fallback text after message-tool delivery evidence", async () => {
+    await withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const cfg = createConfig({ tmpDir, storePath, visibleReplies: "message_tool" });
+      await seedMainSessionStore(storePath, cfg, {
+        lastChannel: "telegram",
+        lastProvider: "telegram",
+        lastTo: TELEGRAM_GROUP,
+      });
+      replySpy.mockResolvedValue(
+        markReplyPayloadForMessageToolDelivery({
+          text: "Fallback narration that should not be sent after the message tool.",
+        }),
+      );
+      const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1" });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        deps: createDeps({ sendTelegram, getReplyFromConfig: replySpy }),
+      });
+
+      expect(result.status).toBe("ran");
+      expect(replyOptions(replySpy).sourceReplyDeliveryMode).toBe("message_tool_only");
+      expect(sendTelegram).not.toHaveBeenCalled();
+      expect(getLastHeartbeatEvent()).toMatchObject({
+        status: "sent",
+        preview: "Fallback narration that should not be sent after the message tool.",
+        channel: "telegram",
+      });
+    });
   });
 
   it("uses the heartbeat response tool prompt for Codex harness sessions by default", async () => {

--- a/src/infra/heartbeat-runner.tool-response.test.ts
+++ b/src/infra/heartbeat-runner.tool-response.test.ts
@@ -262,6 +262,37 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
     });
   });
 
+  it("suppresses automatic heartbeat fallback text after message-tool delivery evidence", async () => {
+    await withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const cfg = createConfig({ tmpDir, storePath });
+      await seedMainSessionStore(storePath, cfg, {
+        lastChannel: "telegram",
+        lastProvider: "telegram",
+        lastTo: TELEGRAM_GROUP,
+      });
+      replySpy.mockResolvedValue(
+        markReplyPayloadForMessageToolDelivery({
+          text: "Automatic fallback narration that should not be sent.",
+        }),
+      );
+      const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1" });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        deps: createDeps({ sendTelegram, getReplyFromConfig: replySpy }),
+      });
+
+      expect(result.status).toBe("ran");
+      expect(replyOptions(replySpy).sourceReplyDeliveryMode).toBeUndefined();
+      expect(sendTelegram).not.toHaveBeenCalled();
+      expect(getLastHeartbeatEvent()).toMatchObject({
+        status: "sent",
+        preview: "Automatic fallback narration that should not be sent.",
+        channel: "telegram",
+      });
+    });
+  });
+
   it("uses the heartbeat response tool prompt for Codex harness sessions by default", async () => {
     const result = await runPromptScenario({
       session: { agentHarnessId: "codex" },

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -17,7 +17,10 @@ import { resolveModelRefFromString, type ModelRef } from "../agents/model-select
 import { resolveEmbeddedSessionLane } from "../agents/pi-embedded-runner/lanes.js";
 import { formatReasoningMessage } from "../agents/pi-embedded-utils.js";
 import { DEFAULT_HEARTBEAT_FILENAME } from "../agents/workspace.js";
-import { resolveHeartbeatReplyPayload } from "../auto-reply/heartbeat-reply-payload.js";
+import {
+  hasHeartbeatMessageToolDeliveryEvidence,
+  resolveHeartbeatReplyPayload,
+} from "../auto-reply/heartbeat-reply-payload.js";
 import {
   getHeartbeatToolNotificationText,
   resolveHeartbeatToolResponseFromReplyResult,
@@ -1741,6 +1744,8 @@ export async function runHeartbeatOnce(opts: {
     const replyResult = await getReplyFromConfig(ctx, replyOpts, cfg);
     const heartbeatToolResponse = resolveHeartbeatToolResponseFromReplyResult(replyResult);
     const replyPayload = resolveHeartbeatReplyPayload(replyResult);
+    const messageToolDelivered =
+      usesHeartbeatResponseTool && hasHeartbeatMessageToolDeliveryEvidence(replyResult);
     const includeReasoning = heartbeat?.includeReasoning === true;
     const reasoningPayloads = includeReasoning
       ? resolveHeartbeatReasoningPayloads(replyResult).filter((payload) => payload !== replyPayload)
@@ -1770,6 +1775,27 @@ export async function runHeartbeatOnce(opts: {
         cfg,
         ids: dueCommitmentIds,
         status: "dismissed",
+        nowMs: startedAt,
+      });
+      await updateTaskTimestamps();
+      consumeInspectedSystemEvents();
+      return { status: "ran", durationMs: Date.now() - startedAt };
+    }
+
+    if (!heartbeatToolResponse && messageToolDelivered) {
+      emitHeartbeatEvent({
+        status: "sent",
+        reason: opts.reason,
+        preview: replyPayload?.text?.slice(0, 200),
+        durationMs: Date.now() - startedAt,
+        channel: delivery.channel !== "none" ? delivery.channel : undefined,
+        accountId: delivery.accountId,
+        indicatorType: visibility.useIndicator ? resolveIndicatorType("sent") : undefined,
+      });
+      await markCommitmentsStatus({
+        cfg,
+        ids: dueCommitmentIds,
+        status: "sent",
         nowMs: startedAt,
       });
       await updateTaskTimestamps();

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -1744,8 +1744,7 @@ export async function runHeartbeatOnce(opts: {
     const replyResult = await getReplyFromConfig(ctx, replyOpts, cfg);
     const heartbeatToolResponse = resolveHeartbeatToolResponseFromReplyResult(replyResult);
     const replyPayload = resolveHeartbeatReplyPayload(replyResult);
-    const messageToolDelivered =
-      usesHeartbeatResponseTool && hasHeartbeatMessageToolDeliveryEvidence(replyResult);
+    const messageToolDelivered = hasHeartbeatMessageToolDeliveryEvidence(replyResult);
     const includeReasoning = heartbeat?.includeReasoning === true;
     const reasoningPayloads = includeReasoning
       ? resolveHeartbeatReasoningPayloads(replyResult).filter((payload) => payload !== replyPayload)


### PR DESCRIPTION
## Summary

Fixes #84217.

- Carries internal message-tool delivery evidence on reply payload metadata after a real message tool send succeeds in message-tool-only mode.
- Makes the heartbeat runner suppress its fallback text when that delivery evidence is present, instead of sending duplicate narration through the heartbeat channel.
- Adds a heartbeat regression covering the issue shape: message-tool delivery evidence plus stray fallback text.

## Root cause

Heartbeat dispatch only understood the `heartbeat_respond` tool channel data. When non-Codex providers produced a generic `message` tool call and also returned visible fallback text, `runHeartbeatOnce` treated the fallback text as a normal heartbeat reply and sent it to Telegram.

## Real behavior proof

Behavior or issue addressed:
Heartbeat message-tool-only dispatch no longer sends fallback text when a visible generic message tool send has already succeeded.

Real environment tested:
Local OpenClaw source checkout with production `runHeartbeatOnce`, production reply payload metadata helpers, and a real temporary session store on macOS. The proof used an in-memory Telegram sender so the dispatch path could be observed without contacting Telegram.

Exact steps or command run after this patch:
`PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node --import tsx --input-type=module --eval '<script importing runHeartbeatOnce, seeding a temp session store, returning markReplyPayloadForMessageToolDelivery({ text: "fallback narration that would duplicate the message tool" }) from getReplyFromConfig, and recording Telegram send calls>'`

Evidence after fix:
```json
{
  "result": {
    "status": "ran"
  },
  "replyCalls": [
    {
      "sourceReplyDeliveryMode": "message_tool_only",
      "enableHeartbeatTool": true,
      "forceHeartbeatTool": true
    }
  ],
  "telegramSendCallCount": 0,
  "heartbeatEvent": {
    "status": "sent",
    "preview": "fallback narration that would duplicate the message tool",
    "channel": "telegram"
  }
}
```

Observed result after fix:
The heartbeat run still uses message-tool-only mode, records a successful heartbeat event, and does not call the Telegram fallback sender for the duplicate narration.

What was not tested:
No live Telegram API call was made; the proof observes the production heartbeat dispatch decision before network delivery.

## Validation

- `node scripts/run-vitest.mjs src/infra/heartbeat-runner.tool-response.test.ts`
- `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-payloads.test.ts src/auto-reply/reply/dispatch-from-config.test.ts`
- `git diff --check`

## Attribution

If maintainers squash or rework this PR, please preserve author attribution or include:

`Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>`
