### PR TITLE
[codex] fix gateway chat.abort send race

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -2190,127 +2190,139 @@ export const chatHandlers: GatewayRequestHandlers = {
         return;
       }
     }
+    // Register before awaited attachment/model preparation so an immediate
+    // chat.abort can still find and stop the active run.
+    const activeRunAbort = registerChatAbortController({
+      chatAbortControllers: context.chatAbortControllers,
+      runId: clientRunId,
+      sessionId: backingSessionId ?? clientRunId,
+      sessionKey: rawSessionKey,
+      timeoutMs,
+      now,
+      ownerConnId: normalizeOptionalText(client?.connId),
+      ownerDeviceId: normalizeOptionalText(client?.connect?.device?.id),
+      providerId: resolvedSessionModel.provider,
+      authProviderId: resolvedSessionAuthProvider,
+      kind: "chat-send",
+    });
+    if (!activeRunAbort.registered) {
+      respond(true, { runId: clientRunId, status: "in_flight" as const }, undefined, {
+        cached: true,
+        runId: clientRunId,
+      });
+      return;
+    }
+
     const explicitOriginTargetsPlugin = explicitOriginTargetsPluginBinding(
       explicitOriginResult.value,
     );
     let modelOverride: string | undefined;
     let modelOverrideFallbacks: string[] | undefined;
-    if (normalizedAttachments.length > 0) {
-      try {
-        await measureDiagnosticsTimelineSpan(
-          "gateway.chat_send.prepare_attachments",
-          async () => {
-            const hasImageAttachments = await hasImageChatAttachments(normalizedAttachments);
-            const supportsSessionModelImages = await resolveGatewayModelSupportsImages({
-              loadGatewayModelCatalog: context.loadGatewayModelCatalog,
-              provider: resolvedSessionModel.provider,
-              model: resolvedSessionModel.model,
-            });
-            const explicitOriginSupportsInlineImages =
-              explicitOriginTargetsAcpSession(explicitOriginResult.value) ||
-              explicitOriginTargetsPlugin;
-            const imageModelPlan = await resolveImageModelOverridePlan({
-              cfg,
-              agentId,
-              defaultProvider: resolvedConfiguredDefaultModel.provider,
-              defaultModel: resolvedConfiguredDefaultModel.model,
-              hasImageAttachments,
-              sessionModelSupportsImages:
-                supportsSessionModelImages || explicitOriginSupportsInlineImages,
-              modelSupportsImages: (ref) =>
-                resolveGatewayModelSupportsImages({
-                  loadGatewayModelCatalog: context.loadGatewayModelCatalog,
-                  provider: ref.provider,
-                  model: ref.model,
-                }),
-            });
-            if (imageModelPlan.kind === "inline-image-model") {
-              modelOverride = imageModelPlan.modelOverride;
-              modelOverrideFallbacks = imageModelPlan.modelOverrideFallbacks;
-            }
-            // Bound plugin sessions own the real recipient model, so keep image
-            // attachments even when the parent OpenClaw session model is text-only.
-            const supportsImages =
-              imageModelPlan.kind === "inline-session" ||
-              imageModelPlan.kind === "inline-image-model" ||
-              explicitOriginSupportsInlineImages;
-            const routeImageOffloadsAsMediaPaths = !supportsImages;
-            const parsed = await parseMessageWithAttachments(
-              inboundMessage,
-              normalizedAttachments,
-              {
-                maxBytes: resolveChatAttachmentMaxBytes(cfg),
-                log: context.logGateway,
-                supportsImages,
-                // chat.send routes selected offloadedRefs into ctx.MediaPaths below
-                // so the auto-reply stage pipeline can surface them to the agent.
-                acceptNonImage: true,
-              },
-            );
-            parsedMessage = stripTrailingOffloadedMediaMarkers(
-              parsed.message,
-              routeImageOffloadsAsMediaPaths
-                ? parsed.offloadedRefs.filter((ref) => ref.mimeType.startsWith("image/"))
-                : [],
-            );
-            parsedImages = parsed.images;
-            imageOrder = routeImageOffloadsAsMediaPaths ? [] : parsed.imageOrder;
-            offloadedRefs = parsed.offloadedRefs;
-            ({
-              paths: mediaPathOffloadPaths,
-              types: mediaPathOffloadTypes,
-              workspaceDir: mediaPathOffloadWorkspaceDir,
-            } = await prestageMediaPathOffloads({
-              offloadedRefs,
-              // Text-only image offloads need ctx.MediaPaths so media-understanding
-              // can describe them via agents.defaults.imageModel. Vision-capable
-              // image offloads stay as prompt refs for native image loading.
-              includeImageRefs: routeImageOffloadsAsMediaPaths,
-              cfg,
-              sessionKey,
-              agentId,
-            }));
-          },
-          {
-            phase: "agent-turn",
-            config: cfg,
-            attributes: {
-              attachmentCount: normalizedAttachments.length,
-              hasExplicitOrigin: explicitOriginResult.value !== undefined,
-            },
-          },
-        );
-      } catch (err) {
-        logAttachmentFailure(context.logGateway, "chat.send attachment parse/stage failed", err);
-        respond(
-          false,
-          undefined,
-          errorShape(
-            err instanceof MediaOffloadError ? ErrorCodes.UNAVAILABLE : ErrorCodes.INVALID_REQUEST,
-            String(err),
-          ),
-        );
-        return;
-      }
-    }
-
+    let dispatchScheduled = false;
     try {
-      const activeRunAbort = registerChatAbortController({
-        chatAbortControllers: context.chatAbortControllers,
-        runId: clientRunId,
-        sessionId: backingSessionId ?? clientRunId,
-        sessionKey: rawSessionKey,
-        timeoutMs,
-        now,
-        ownerConnId: normalizeOptionalText(client?.connId),
-        ownerDeviceId: normalizeOptionalText(client?.connect?.device?.id),
-        providerId: resolvedSessionModel.provider,
-        authProviderId: resolvedSessionAuthProvider,
-        kind: "chat-send",
-      });
-      if (!activeRunAbort.registered) {
-        respond(true, { runId: clientRunId, status: "in_flight" as const }, undefined, {
-          cached: true,
+      if (normalizedAttachments.length > 0) {
+        try {
+          await measureDiagnosticsTimelineSpan(
+            "gateway.chat_send.prepare_attachments",
+            async () => {
+              const hasImageAttachments = await hasImageChatAttachments(normalizedAttachments);
+              const supportsSessionModelImages = await resolveGatewayModelSupportsImages({
+                loadGatewayModelCatalog: context.loadGatewayModelCatalog,
+                provider: resolvedSessionModel.provider,
+                model: resolvedSessionModel.model,
+              });
+              const explicitOriginSupportsInlineImages =
+                explicitOriginTargetsAcpSession(explicitOriginResult.value) ||
+                explicitOriginTargetsPlugin;
+              const imageModelPlan = await resolveImageModelOverridePlan({
+                cfg,
+                agentId,
+                defaultProvider: resolvedConfiguredDefaultModel.provider,
+                defaultModel: resolvedConfiguredDefaultModel.model,
+                hasImageAttachments,
+                sessionModelSupportsImages:
+                  supportsSessionModelImages || explicitOriginSupportsInlineImages,
+                modelSupportsImages: (ref) =>
+                  resolveGatewayModelSupportsImages({
+                    loadGatewayModelCatalog: context.loadGatewayModelCatalog,
+                    provider: ref.provider,
+                    model: ref.model,
+                  }),
+              });
+              if (imageModelPlan.kind === "inline-image-model") {
+                modelOverride = imageModelPlan.modelOverride;
+                modelOverrideFallbacks = imageModelPlan.modelOverrideFallbacks;
+              }
+              // Bound plugin sessions own the real recipient model, so keep image
+              // attachments even when the parent OpenClaw session model is text-only.
+              const supportsImages =
+                imageModelPlan.kind === "inline-session" ||
+                imageModelPlan.kind === "inline-image-model" ||
+                explicitOriginSupportsInlineImages;
+              const routeImageOffloadsAsMediaPaths = !supportsImages;
+              const parsed = await parseMessageWithAttachments(
+                inboundMessage,
+                normalizedAttachments,
+                {
+                  maxBytes: resolveChatAttachmentMaxBytes(cfg),
+                  log: context.logGateway,
+                  supportsImages,
+                  // chat.send routes selected offloadedRefs into ctx.MediaPaths below
+                  // so the auto-reply stage pipeline can surface them to the agent.
+                  acceptNonImage: true,
+                },
+              );
+              parsedMessage = stripTrailingOffloadedMediaMarkers(
+                parsed.message,
+                routeImageOffloadsAsMediaPaths
+                  ? parsed.offloadedRefs.filter((ref) => ref.mimeType.startsWith("image/"))
+                  : [],
+              );
+              parsedImages = parsed.images;
+              imageOrder = routeImageOffloadsAsMediaPaths ? [] : parsed.imageOrder;
+              offloadedRefs = parsed.offloadedRefs;
+              ({
+                paths: mediaPathOffloadPaths,
+                types: mediaPathOffloadTypes,
+                workspaceDir: mediaPathOffloadWorkspaceDir,
+              } = await prestageMediaPathOffloads({
+                offloadedRefs,
+                // Text-only image offloads need ctx.MediaPaths so media-understanding
+                // can describe them via agents.defaults.imageModel. Vision-capable
+                // image offloads stay as prompt refs for native image loading.
+                includeImageRefs: routeImageOffloadsAsMediaPaths,
+                cfg,
+                sessionKey,
+                agentId,
+              }));
+            },
+            {
+              phase: "agent-turn",
+              config: cfg,
+              attributes: {
+                attachmentCount: normalizedAttachments.length,
+                hasExplicitOrigin: explicitOriginResult.value !== undefined,
+              },
+            },
+          );
+        } catch (err) {
+          logAttachmentFailure(context.logGateway, "chat.send attachment parse/stage failed", err);
+          respond(
+            false,
+            undefined,
+            errorShape(
+              err instanceof MediaOffloadError
+                ? ErrorCodes.UNAVAILABLE
+                : ErrorCodes.INVALID_REQUEST,
+              String(err),
+            ),
+          );
+          return;
+        }
+      }
+
+      if (activeRunAbort.controller.signal.aborted) {
+        respond(true, { runId: clientRunId, status: "started" as const }, undefined, {
           runId: clientRunId,
         });
         return;
@@ -2945,9 +2957,8 @@ export const chatHandlers: GatewayRequestHandlers = {
           activeRunAbort.cleanup();
           context.removeChatRun(clientRunId, clientRunId, sessionKey);
         });
+      dispatchScheduled = true;
     } catch (err) {
-      context.chatAbortControllers.delete(clientRunId);
-      context.removeChatRun(clientRunId, clientRunId, sessionKey);
       const error = errorShape(ErrorCodes.UNAVAILABLE, String(err));
       const payload = {
         runId: clientRunId,
@@ -2968,6 +2979,11 @@ export const chatHandlers: GatewayRequestHandlers = {
         runId: clientRunId,
         error: formatForLog(err),
       });
+    } finally {
+      if (!dispatchScheduled) {
+        activeRunAbort.cleanup();
+        context.removeChatRun(clientRunId, clientRunId, sessionKey);
+      }
     }
   },
   "chat.inject": async ({ params, respond, context }) => {

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -229,7 +229,7 @@ describe("gateway server chat", () => {
     }
   });
 
-  test("chat.send returns in_flight when duplicate attachment send wins parsing race", async () => {
+  test("chat.send keeps the first attachment run active during preparation", async () => {
     const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
     const dispatchRelease = createDeferred<void>();
     try {
@@ -320,7 +320,7 @@ describe("gateway server chat", () => {
         {
           id: "duplicate",
           ok: true,
-          payload: { runId: "idem-attachment-race", status: "started" },
+          payload: { runId: "idem-attachment-race", status: "in_flight" },
           error: undefined,
         },
       ]);
@@ -339,13 +339,13 @@ describe("gateway server chat", () => {
         {
           id: "duplicate",
           ok: true,
-          payload: { runId: "idem-attachment-race", status: "started" },
+          payload: { runId: "idem-attachment-race", status: "in_flight" },
           error: undefined,
         },
         {
           id: "first",
           ok: true,
-          payload: { runId: "idem-attachment-race", status: "in_flight" },
+          payload: { runId: "idem-attachment-race", status: "started" },
           error: undefined,
         },
       ]);
@@ -357,6 +357,146 @@ describe("gateway server chat", () => {
       }, FAST_WAIT_OPTS);
     } finally {
       dispatchRelease.resolve();
+      dispatchInboundMessageMock.mockReset();
+      testState.sessionStorePath = undefined;
+      clearConfigCache();
+      await fs.rm(sessionDir, { recursive: true, force: true });
+    }
+  });
+
+  test("chat.abort stops an attachment send before attachment preparation finishes", async () => {
+    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+    try {
+      testState.sessionStorePath = path.join(sessionDir, "sessions.json");
+      await writeSessionStore({
+        entries: {
+          main: {
+            sessionId: "sess-main",
+            modelProvider: "test-provider",
+            model: "vision-model",
+            updatedAt: Date.now(),
+          },
+        },
+      });
+
+      const firstCatalog =
+        createDeferred<Awaited<ReturnType<GatewayRequestContext["loadGatewayModelCatalog"]>>>();
+      const sendResponses: Array<{ id: string; ok: boolean; payload?: unknown; error?: unknown }> =
+        [];
+      const abortResponses: Array<{ ok: boolean; payload?: unknown; error?: unknown }> = [];
+      const context = {
+        loadGatewayModelCatalog: vi
+          .fn<GatewayRequestContext["loadGatewayModelCatalog"]>()
+          .mockImplementationOnce(() => firstCatalog.promise)
+          .mockResolvedValue([
+            {
+              id: "vision-model",
+              name: "Vision Model",
+              provider: "test-provider",
+              input: ["text", "image"],
+            },
+          ]),
+        logGateway: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          debug: vi.fn(),
+        },
+        agentRunSeq: new Map<string, number>(),
+        chatAbortControllers: new Map(),
+        chatAbortedRuns: new Map(),
+        chatRunBuffers: new Map(),
+        chatDeltaSentAt: new Map(),
+        chatDeltaLastBroadcastLen: new Map(),
+        chatDeltaLastBroadcastText: new Map(),
+        agentDeltaSentAt: new Map(),
+        bufferedAgentEvents: new Map(),
+        addChatRun: vi.fn(),
+        removeChatRun: vi.fn(),
+        broadcast: vi.fn(),
+        nodeSendToSession: vi.fn(),
+        registerToolEventRecipient: vi.fn(),
+        dedupe: new Map(),
+      } as unknown as GatewayRequestContext;
+      dispatchInboundMessageMock.mockImplementation(async () => undefined);
+
+      const pngB64 =
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=";
+      const runId = "idem-abort-during-attachment-prep";
+      const params = {
+        sessionKey: "main",
+        message: "see image",
+        idempotencyKey: runId,
+        attachments: [
+          {
+            type: "image",
+            mimeType: "image/png",
+            fileName: "dot.png",
+            content: pngB64,
+          },
+        ],
+      };
+      const { chatHandlers } = await import("./server-methods/chat.js");
+
+      const sendPromise = Promise.resolve(
+        chatHandlers["chat.send"]({
+          req: { type: "req", id: "send", method: "chat.send", params },
+          params,
+          client: null,
+          isWebchatConnect: () => false,
+          respond: ((ok, payload, error) => {
+            sendResponses.push({ id: "send", ok, payload, error });
+          }) as RespondFn,
+          context,
+        }),
+      );
+
+      await vi.waitFor(() => {
+        expect(context.loadGatewayModelCatalog).toHaveBeenCalledTimes(1);
+      }, FAST_WAIT_OPTS);
+      expect(context.chatAbortControllers.has(runId)).toBe(true);
+
+      await chatHandlers["chat.abort"]({
+        params: { sessionKey: "main", runId },
+        respond: ((ok, payload, error) => {
+          abortResponses.push({ ok, payload, error });
+        }) as RespondFn,
+        context,
+        req: { type: "req", id: "abort", method: "chat.abort" },
+        client: null,
+        isWebchatConnect: () => false,
+      });
+
+      expect(abortResponses).toEqual([
+        {
+          ok: true,
+          payload: { ok: true, aborted: true, runIds: [runId] },
+          error: undefined,
+        },
+      ]);
+      expect(context.chatAbortControllers.has(runId)).toBe(false);
+
+      firstCatalog.resolve([
+        {
+          id: "vision-model",
+          name: "Vision Model",
+          provider: "test-provider",
+          input: ["text", "image"],
+        },
+      ]);
+      await sendPromise;
+
+      expect(sendResponses).toEqual([
+        {
+          id: "send",
+          ok: true,
+          payload: { runId, status: "started" },
+          error: undefined,
+        },
+      ]);
+      expect(dispatchInboundMessageMock).not.toHaveBeenCalled();
+      expect(context.addChatRun).not.toHaveBeenCalled();
+    } finally {
       dispatchInboundMessageMock.mockReset();
       testState.sessionStorePath = undefined;
       clearConfigCache();


### PR DESCRIPTION
## Summary
- register `chat.send` runs in `chatAbortControllers` before awaited attachment/model preparation so immediate `chat.abort` calls can still find the active run
- short-circuit pre-dispatch sends that were already aborted so they do not enqueue a chat run or reach `dispatchInboundMessage`
- update the attachment parsing race test and add a focused regression that aborts during attachment preparation

## Root Cause
`chat.send` only registered its abort controller after awaited attachment preparation finished, while `chat.abort` returns `aborted: false` immediately when the `runId` is absent. An immediate abort during image/file preparation could therefore miss the in-flight run window.

## Verification
- `node scripts/run-vitest.mjs src/gateway/server.chat.gateway-server-chat-b.test.ts src/gateway/server-methods/chat.abort-authorization.test.ts src/gateway/chat-abort.test.ts`

## Real behavior proof
Behavior addressed: `chat.abort` no longer misses an active `chat.send` run when the abort arrives during attachment preparation.
Real environment tested: Local Gateway Vitest harness on rebased `upstream/main`.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/gateway/server.chat.gateway-server-chat-b.test.ts src/gateway/server-methods/chat.abort-authorization.test.ts src/gateway/chat-abort.test.ts`
Evidence after fix: Added a regression in `src/gateway/server.chat.gateway-server-chat-b.test.ts` that starts `chat.send` with an image attachment, blocks attachment preparation on model-catalog resolution, issues `chat.abort` immediately, and asserts `aborted: true`, active-run cleanup, and no downstream dispatch.
Observed result after fix: The immediate abort succeeds during attachment preparation and the targeted Gateway suite passes on latest `upstream/main`.
What was not tested: No live gateway/manual UI repro, no broad `pnpm check*`, and no Crabbox/Testbox run.

Fixes #84176
