### PR TITLE
fix(codex): add openclaw runtime dependency

### DIFF
--- a/extensions/codex/package.json
+++ b/extensions/codex/package.json
@@ -11,6 +11,7 @@
     "@earendil-works/pi-coding-agent": "0.75.1",
     "@openai/codex": "0.130.0",
     "ajv": "8.20.0",
+    "openclaw": ">=2026.5.19",
     "ws": "8.20.1",
     "zod": "4.4.3"
   },


### PR DESCRIPTION
## Summary

- add the host `openclaw` package as a concrete runtime dependency for `@openclaw/codex`
- keep the change scoped to `extensions/codex/package.json`

## Why

`@openclaw/codex` imports `openclaw/plugin-sdk/...` from its published runtime bundle. When the package is installed by itself, npm installs `@openclaw/codex` without the `openclaw` package, so those bare `openclaw/...` imports fail at runtime.

This matches the live repro in #83964: installing `@openclaw/codex@2026.5.18` alone can throw `ERR_MODULE_NOT_FOUND: Cannot find package 'openclaw'`, while installing `openclaw` beside it makes the same import pass.

## Real behavior proof

- **Behavior or issue addressed**: Standalone installs of `@openclaw/codex` can fail at runtime because the published bundle imports `openclaw/...` but the package does not install `openclaw` as a dependency.
- **Real environment tested**: macOS local shell, Node/npm, installing the real published `@openclaw/codex@2026.5.18` tarball from npm into fresh temporary projects. The after-fix case repacked that same published tarball with only the dependency metadata added, matching this PR's dependency-only change. Current main is versioned `2026.5.19`, which is not published as a stable npm package yet, so the live install proof uses the currently published `2026.5.18` package.
- **Exact steps or command run after this patch**: Installed the published package alone in one fresh temp project, then repacked the same package with `dependencies.openclaw` added and installed that patched tarball alone in a second fresh temp project. In both cases I imported the real bundled `dist/shared-client-DlvmoLBJ.js`.
- **Evidence after fix**:

```text
WORK=/tmp/codex-proof.syMZHr
=== BEFORE: published package alone ===
npm warn deprecated node-domexception@1.0.0: Use your platform's native DOMException instead
BEFORE_OPENCLAW=missing
BEFORE_IMPORT=ERR_MODULE_NOT_FOUND:Cannot find package 'openclaw' imported from /private/tmp/codex-proof.syMZHr/before/node_modules/@openclaw/codex/dist/client-6FkrXfaz.js
=== PATCH PACKAGE METADATA LIKE PR ===
PATCHED_DEP=>=2026.5.18
=== AFTER: patched package alone ===
npm warn deprecated node-domexception@1.0.0: Use your platform's native DOMException instead
AFTER_CODEX_DEP=>=2026.5.18
AFTER_OPENCLAW_VERSION=2026.5.18
AFTER_IMPORT=ok
```

- **Observed result after fix**: With `openclaw` present as a concrete dependency, npm installs `node_modules/openclaw` automatically and the same Codex bundled import succeeds with `AFTER_IMPORT=ok`.
- **What was not tested**: I did not publish a new `@openclaw/codex` package or run a full gateway boot from the unreleased `2026.5.19` package.

## Verification

- checked for existing open PRs mentioning #83964 / Codex dependency before opening this
- parsed `extensions/codex/package.json` and verified `dependencies.openclaw`
- `git diff --check`
- diff is intentionally small: `+1/-0`

Fixes #83964

