### PR TITLE
fix: suppress mutating tool error warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents: honor `messages.suppressToolErrors` for mutating tool failures so configured suppression also hides write/message/apply-patch warning bubbles.
 - Plugins/perf: thread explicit plugin discovery results through `loadBundledCapabilityRuntimeRegistry`, `resolveBundledPluginSources`, and `listChannelCatalogEntries` so callers that already hold a discovery result skip redundant filesystem walks. Thanks @SebTardif.
 - harden update restart script creation [AI]. (#84088) Thanks @pgondhi987.
 - Docker: keep the bundled Codex plugin in official release image keep lists so the default OpenAI agent harness remains available after Docker pruning. Fixes #83613. (#83626) Thanks @YuanHanzhong.

--- a/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
@@ -414,16 +414,14 @@ describe("buildEmbeddedRunPayloads", () => {
     });
   });
 
+  it("suppresses mutating tool errors when messages.suppressToolErrors is enabled", () => {
+    expectNoPayloads({
+      lastToolError: { toolName: "write", error: "connection timeout" },
+      config: { messages: { suppressToolErrors: true } },
+    });
+  });
+
   it.each([
-    {
-      name: "still shows mutating tool errors when messages.suppressToolErrors is enabled",
-      payload: {
-        lastToolError: { toolName: "write", error: "connection timeout" },
-        config: { messages: { suppressToolErrors: true } },
-      },
-      title: "Write",
-      absentDetail: "connection timeout",
-    },
     {
       name: "shows recoverable tool errors for mutating tools",
       payload: {

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -158,6 +158,9 @@ function resolveToolErrorWarningPolicy(params: {
   if (normalizedToolName === "sessions_send") {
     return { showWarning: false, includeDetails };
   }
+  if (params.suppressToolErrors) {
+    return { showWarning: false, includeDetails };
+  }
   const isMutatingToolError =
     params.lastToolError.mutatingAction ?? isLikelyMutatingToolName(params.lastToolError.toolName);
   if (isMutatingToolError) {
@@ -167,9 +170,6 @@ function resolveToolErrorWarningPolicy(params: {
     };
   }
   if (isExecLikeToolName(params.lastToolError.toolName) && !includeDetails) {
-    return { showWarning: false, includeDetails };
-  }
-  if (params.suppressToolErrors) {
     return { showWarning: false, includeDetails };
   }
   return {


### PR DESCRIPTION
## Summary
- Honor `messages.suppressToolErrors` before mutating-tool warning generation.
- Preserve existing `sessions_send`, exec-timeout detail, and explicit `suppressToolErrorWarnings` behavior.
- Add regression coverage for mutating tool errors plus an Unreleased changelog entry.

Existing related PR: https://github.com/openclaw/openclaw/pull/81561 covers the same issue, but its Real behavior proof check is failing because the proof fields do not match the current parser contract. This PR keeps the fix narrow and includes the required proof fields below.

## Verification
- `node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run/payloads.errors.test.ts`
- `node --import tsx -e 'import { buildEmbeddedRunPayloads } from "./src/agents/pi-embedded-runner/run/payloads.ts"; const payloads = buildEmbeddedRunPayloads({ assistantTexts: [], toolMetas: [], lastAssistant: undefined, isCronTrigger: false, sessionKey: "agent:main:telegram:group:-1003998880259:topic:1", inlineToolResultsAllowed: false, verboseLevel: "off", reasoningLevel: "off", toolResultFormat: "plain", lastToolError: { toolName: "write", error: "connection timeout" }, config: { messages: { suppressToolErrors: true } } }); console.log(JSON.stringify({scenario:"mutating write tool error with messages.suppressToolErrors=true", payloadCount: payloads.length, payloadTexts: payloads.map((p) => p.text)}, null, 2));'`
- `git diff --check HEAD~2..HEAD`

## Real behavior proof

Behavior addressed: When `messages.suppressToolErrors=true`, mutating tool failures such as write/message/apply-patch failures should not emit separate user-facing warning bubbles.

Real environment tested: Local OpenClaw source checkout on the Phaedrus VPS, using the Telegram session key shape from the observed failing group chat.

Exact steps or command run after this patch: Ran the payload builder directly with a mutating `write` tool failure, `messages.suppressToolErrors=true`, and a Telegram group session key:

```bash
node --import tsx -e 'import { buildEmbeddedRunPayloads } from "./src/agents/pi-embedded-runner/run/payloads.ts"; const payloads = buildEmbeddedRunPayloads({ assistantTexts: [], toolMetas: [], lastAssistant: undefined, isCronTrigger: false, sessionKey: "agent:main:telegram:group:-1003998880259:topic:1", inlineToolResultsAllowed: false, verboseLevel: "off", reasoningLevel: "off", toolResultFormat: "plain", lastToolError: { toolName: "write", error: "connection timeout" }, config: { messages: { suppressToolErrors: true } } }); console.log(JSON.stringify({scenario:"mutating write tool error with messages.suppressToolErrors=true", payloadCount: payloads.length, payloadTexts: payloads.map((p) => p.text)}, null, 2));'
```

Evidence after fix:

```json
{
  "scenario": "mutating write tool error with messages.suppressToolErrors=true",
  "payloadCount": 0,
  "payloadTexts": []
}
```

Observed result after fix: The mutating tool failure produced zero outbound payloads, so no Telegram warning bubble would be delivered when `messages.suppressToolErrors` is enabled.

What was not tested: I did not deploy this branch into the live root-owned OpenClaw install on Phaedrus; live Telegram validation will happen after this PR is merged/released or otherwise deployed.
