### PR TITLE
fix: handle SIGUSR1 restart on Windows where the signal is unsupported

### DIFF
--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -38,10 +38,6 @@ const renderRestartDiagnostics = vi.fn(() => ["diag: unhealthy runtime"]);
 const resolveGatewayPort = vi.hoisted(() => vi.fn((_cfg?: unknown, _env?: unknown) => 18789));
 const findVerifiedGatewayListenerPidsOnPortSync = vi.fn<(port: number) => number[]>(() => []);
 const signalVerifiedGatewayPidSync = vi.fn<(pid: number, signal: "SIGTERM" | "SIGUSR1") => void>();
-const triggerOpenClawRestart = vi.fn<() => { ok: boolean; method: string; detail?: string; tried?: string[] }>(() => ({
-  ok: true,
-  method: "schtasks",
-}));
 const formatGatewayPidList = vi.fn<(pids: number[]) => string>((pids) => pids.join(", "));
 const probeGateway = vi.fn<
   (opts: {
@@ -95,11 +91,6 @@ vi.mock("../../infra/gateway-processes.js", () => ({
   signalVerifiedGatewayPidSync: (pid: number, signal: "SIGTERM" | "SIGUSR1") =>
     signalVerifiedGatewayPidSync(pid, signal),
   formatGatewayPidList: (pids: number[]) => formatGatewayPidList(pids),
-}));
-
-vi.mock("../../infra/restart.js", () => ({
-  writeGatewayRestartIntentSync: vi.fn(),
-  triggerOpenClawRestart: () => triggerOpenClawRestart(),
 }));
 
 vi.mock("../../gateway/probe.js", () => ({
@@ -544,7 +535,7 @@ describe("runDaemonRestart health checks", () => {
     expect(service.restart).not.toHaveBeenCalled();
   });
 
-  it("uses Windows scheduled task for unmanaged gateway restart", async () => {
+  it("uses SIGTERM for unmanaged gateway restart on Windows", async () => {
     vi.spyOn(process, "platform", "get").mockReturnValue("win32");
     findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([4200]);
     mockUnmanagedRestart({ runPostRestartCheck: true });
@@ -552,8 +543,11 @@ describe("runDaemonRestart health checks", () => {
     await runDaemonRestart({ json: true });
 
     expect(findVerifiedGatewayListenerPidsOnPortSync).toHaveBeenCalledWith(18789);
-    expect(triggerOpenClawRestart).toHaveBeenCalledOnce();
-    expect(signalVerifiedGatewayPidSync).not.toHaveBeenCalled();
+    // SIGUSR1 is unsupported on Windows; SIGTERM is sent instead.
+    // The gateway's SIGTERM handler reads the restart intent file (written
+    // before signaling) and triggers a restart rather than a stop.
+    expect(signalVerifiedGatewayPidSync).toHaveBeenCalledWith(4200, "SIGTERM");
+    expect(signalVerifiedGatewayPidSync).not.toHaveBeenCalledWith(4200, "SIGUSR1");
     expect(probeGateway).toHaveBeenCalledTimes(1);
     expect(waitForGatewayHealthyListener).toHaveBeenCalledTimes(1);
     expect(waitForGatewayHealthyRestart).not.toHaveBeenCalled();

--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -38,6 +38,10 @@ const renderRestartDiagnostics = vi.fn(() => ["diag: unhealthy runtime"]);
 const resolveGatewayPort = vi.hoisted(() => vi.fn((_cfg?: unknown, _env?: unknown) => 18789));
 const findVerifiedGatewayListenerPidsOnPortSync = vi.fn<(port: number) => number[]>(() => []);
 const signalVerifiedGatewayPidSync = vi.fn<(pid: number, signal: "SIGTERM" | "SIGUSR1") => void>();
+const triggerOpenClawRestart = vi.fn<() => { ok: boolean; method: string; detail?: string; tried?: string[] }>(() => ({
+  ok: true,
+  method: "schtasks",
+}));
 const formatGatewayPidList = vi.fn<(pids: number[]) => string>((pids) => pids.join(", "));
 const probeGateway = vi.fn<
   (opts: {
@@ -91,6 +95,11 @@ vi.mock("../../infra/gateway-processes.js", () => ({
   signalVerifiedGatewayPidSync: (pid: number, signal: "SIGTERM" | "SIGUSR1") =>
     signalVerifiedGatewayPidSync(pid, signal),
   formatGatewayPidList: (pids: number[]) => formatGatewayPidList(pids),
+}));
+
+vi.mock("../../infra/restart.js", () => ({
+  writeGatewayRestartIntentSync: vi.fn(),
+  triggerOpenClawRestart: () => triggerOpenClawRestart(),
 }));
 
 vi.mock("../../gateway/probe.js", () => ({
@@ -535,7 +544,7 @@ describe("runDaemonRestart health checks", () => {
     expect(service.restart).not.toHaveBeenCalled();
   });
 
-  it("uses SIGTERM for unmanaged gateway restart on Windows", async () => {
+  it("uses scheduled task restart for unmanaged gateway restart on Windows", async () => {
     vi.spyOn(process, "platform", "get").mockReturnValue("win32");
     findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([4200]);
     mockUnmanagedRestart({ runPostRestartCheck: true });
@@ -543,11 +552,10 @@ describe("runDaemonRestart health checks", () => {
     await runDaemonRestart({ json: true });
 
     expect(findVerifiedGatewayListenerPidsOnPortSync).toHaveBeenCalledWith(18789);
-    // SIGUSR1 is unsupported on Windows; SIGTERM is sent instead.
-    // The gateway's SIGTERM handler reads the restart intent file (written
-    // before signaling) and triggers a restart rather than a stop.
-    expect(signalVerifiedGatewayPidSync).toHaveBeenCalledWith(4200, "SIGTERM");
-    expect(signalVerifiedGatewayPidSync).not.toHaveBeenCalledWith(4200, "SIGUSR1");
+    // On Windows, SIGUSR1 is unsupported for cross-process signaling.
+    // triggerOpenClawRestart() uses the scheduled-task restart handoff.
+    expect(triggerOpenClawRestart).toHaveBeenCalledOnce();
+    expect(signalVerifiedGatewayPidSync).not.toHaveBeenCalled();
     expect(probeGateway).toHaveBeenCalledTimes(1);
     expect(waitForGatewayHealthyListener).toHaveBeenCalledTimes(1);
     expect(waitForGatewayHealthyRestart).not.toHaveBeenCalled();

--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -38,6 +38,10 @@ const renderRestartDiagnostics = vi.fn(() => ["diag: unhealthy runtime"]);
 const resolveGatewayPort = vi.hoisted(() => vi.fn((_cfg?: unknown, _env?: unknown) => 18789));
 const findVerifiedGatewayListenerPidsOnPortSync = vi.fn<(port: number) => number[]>(() => []);
 const signalVerifiedGatewayPidSync = vi.fn<(pid: number, signal: "SIGTERM" | "SIGUSR1") => void>();
+const triggerOpenClawRestart = vi.fn<() => { ok: boolean; method: string; detail?: string; tried?: string[] }>(() => ({
+  ok: true,
+  method: "schtasks",
+}));
 const formatGatewayPidList = vi.fn<(pids: number[]) => string>((pids) => pids.join(", "));
 const probeGateway = vi.fn<
   (opts: {
@@ -91,6 +95,11 @@ vi.mock("../../infra/gateway-processes.js", () => ({
   signalVerifiedGatewayPidSync: (pid: number, signal: "SIGTERM" | "SIGUSR1") =>
     signalVerifiedGatewayPidSync(pid, signal),
   formatGatewayPidList: (pids: number[]) => formatGatewayPidList(pids),
+}));
+
+vi.mock("../../infra/restart.js", () => ({
+  writeGatewayRestartIntentSync: vi.fn(),
+  triggerOpenClawRestart: () => triggerOpenClawRestart(),
 }));
 
 vi.mock("../../gateway/probe.js", () => ({
@@ -520,6 +529,7 @@ describe("runDaemonRestart health checks", () => {
   });
 
   it("signals a single unmanaged gateway process on restart", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("linux");
     findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([4200]);
     mockUnmanagedRestart({ runPostRestartCheck: true });
 
@@ -527,6 +537,23 @@ describe("runDaemonRestart health checks", () => {
 
     expect(findVerifiedGatewayListenerPidsOnPortSync).toHaveBeenCalledWith(18789);
     expect(signalVerifiedGatewayPidSync).toHaveBeenCalledWith(4200, "SIGUSR1");
+    expect(probeGateway).toHaveBeenCalledTimes(1);
+    expect(waitForGatewayHealthyListener).toHaveBeenCalledTimes(1);
+    expect(waitForGatewayHealthyRestart).not.toHaveBeenCalled();
+    expect(terminateStaleGatewayPids).not.toHaveBeenCalled();
+    expect(service.restart).not.toHaveBeenCalled();
+  });
+
+  it("uses Windows scheduled task for unmanaged gateway restart", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([4200]);
+    mockUnmanagedRestart({ runPostRestartCheck: true });
+
+    await runDaemonRestart({ json: true });
+
+    expect(findVerifiedGatewayListenerPidsOnPortSync).toHaveBeenCalledWith(18789);
+    expect(triggerOpenClawRestart).toHaveBeenCalledOnce();
+    expect(signalVerifiedGatewayPidSync).not.toHaveBeenCalled();
     expect(probeGateway).toHaveBeenCalledTimes(1);
     expect(waitForGatewayHealthyListener).toHaveBeenCalledTimes(1);
     expect(waitForGatewayHealthyRestart).not.toHaveBeenCalled();

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -9,7 +9,11 @@ import {
   signalVerifiedGatewayPidSync,
 } from "../../infra/gateway-processes.js";
 import type { SafeGatewayRestartRequestResult } from "../../infra/restart-coordinator.js";
-import { type GatewayRestartIntent, writeGatewayRestartIntentSync } from "../../infra/restart.js";
+import {
+  type GatewayRestartIntent,
+  triggerOpenClawRestart,
+  writeGatewayRestartIntentSync,
+} from "../../infra/restart.js";
 import { defaultRuntime } from "../../runtime.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import { theme } from "../../terminal/theme.js";
@@ -211,13 +215,23 @@ async function restartGatewayWithoutServiceManager(
     reason: "gateway.restart",
     ...(restartIntent ? { intent: restartIntent } : {}),
   });
-  // On Windows, SIGUSR1 is not supported; use SIGTERM instead.
-  // The gateway's SIGTERM handler reads the restart intent file written above
-  // and triggers a draining restart (instead of stopping) when the intent is present.
-  signalVerifiedGatewayPidSync(
-    pids[0],
-    process.platform === "win32" ? "SIGTERM" : "SIGUSR1",
-  );
+  // On Windows, SIGUSR1 is not supported for cross-process signaling.
+  // Node.js unconditionally terminates the target on Windows for SIGTERM too,
+  // so we must use the scheduled-task restart handoff instead.
+  if (process.platform === "win32") {
+    const result = triggerOpenClawRestart();
+    if (!result.ok) {
+      throw new Error(
+        `Gateway restart failed on Windows: ${result.detail ?? "unknown error"}. ` +
+          `Run "openclaw gateway install" to set up the Windows scheduled task.`,
+      );
+    }
+    return {
+      result: "restarted" as const,
+      message: `Gateway restart triggered via ${result.method} on port ${port}: ${pids[0]}.`,
+    };
+  }
+  signalVerifiedGatewayPidSync(pids[0], "SIGUSR1");
   return {
     result: "restarted" as const,
     message: `Gateway restart signal sent to unmanaged process on port ${port}: ${pids[0]}.`,

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -9,7 +9,11 @@ import {
   signalVerifiedGatewayPidSync,
 } from "../../infra/gateway-processes.js";
 import type { SafeGatewayRestartRequestResult } from "../../infra/restart-coordinator.js";
-import { type GatewayRestartIntent, writeGatewayRestartIntentSync } from "../../infra/restart.js";
+import {
+  type GatewayRestartIntent,
+  triggerOpenClawRestart,
+  writeGatewayRestartIntentSync,
+} from "../../infra/restart.js";
 import { defaultRuntime } from "../../runtime.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import { theme } from "../../terminal/theme.js";
@@ -211,6 +215,18 @@ async function restartGatewayWithoutServiceManager(
     reason: "gateway.restart",
     ...(restartIntent ? { intent: restartIntent } : {}),
   });
+  if (process.platform === "win32") {
+    const result = triggerOpenClawRestart();
+    if (!result.ok) {
+      throw new Error(
+        `Gateway restart failed on Windows: ${result.detail ?? "unknown error"}`,
+      );
+    }
+    return {
+      result: "restarted" as const,
+      message: `Gateway restart triggered via ${result.method} on port ${port}: ${pids[0]}.`,
+    };
+  }
   signalVerifiedGatewayPidSync(pids[0], "SIGUSR1");
   return {
     result: "restarted" as const,

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -9,11 +9,7 @@ import {
   signalVerifiedGatewayPidSync,
 } from "../../infra/gateway-processes.js";
 import type { SafeGatewayRestartRequestResult } from "../../infra/restart-coordinator.js";
-import {
-  type GatewayRestartIntent,
-  triggerOpenClawRestart,
-  writeGatewayRestartIntentSync,
-} from "../../infra/restart.js";
+import { type GatewayRestartIntent, writeGatewayRestartIntentSync } from "../../infra/restart.js";
 import { defaultRuntime } from "../../runtime.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import { theme } from "../../terminal/theme.js";
@@ -215,19 +211,13 @@ async function restartGatewayWithoutServiceManager(
     reason: "gateway.restart",
     ...(restartIntent ? { intent: restartIntent } : {}),
   });
-  if (process.platform === "win32") {
-    const result = triggerOpenClawRestart();
-    if (!result.ok) {
-      throw new Error(
-        `Gateway restart failed on Windows: ${result.detail ?? "unknown error"}`,
-      );
-    }
-    return {
-      result: "restarted" as const,
-      message: `Gateway restart triggered via ${result.method} on port ${port}: ${pids[0]}.`,
-    };
-  }
-  signalVerifiedGatewayPidSync(pids[0], "SIGUSR1");
+  // On Windows, SIGUSR1 is not supported; use SIGTERM instead.
+  // The gateway's SIGTERM handler reads the restart intent file written above
+  // and triggers a draining restart (instead of stopping) when the intent is present.
+  signalVerifiedGatewayPidSync(
+    pids[0],
+    process.platform === "win32" ? "SIGTERM" : "SIGUSR1",
+  );
   return {
     result: "restarted" as const,
     message: `Gateway restart signal sent to unmanaged process on port ${port}: ${pids[0]}.`,

--- a/src/infra/gateway-processes.test.ts
+++ b/src/infra/gateway-processes.test.ts
@@ -149,6 +149,21 @@ describe("gateway-processes", () => {
     );
   });
 
+  it("rejects SIGUSR1 on Windows", () => {
+    setPlatform("win32");
+    isGatewayArgvMock.mockReturnValueOnce(true);
+    spawnSyncMock.mockReturnValueOnce({
+      error: null,
+      status: 0,
+      stdout: "node.exe gateway run",
+    });
+    parseCmdScriptCommandLineMock.mockReturnValue(["node.exe", "gateway", "run"]);
+
+    expect(() => signalVerifiedGatewayPidSync(42, "SIGUSR1")).toThrow(
+      /SIGUSR1 is not supported on Windows/,
+    );
+  });
+
   it("dedupes and filters verified gateway listener pids on unix and windows", () => {
     setPlatform("linux");
     findGatewayPidsOnPortSyncMock.mockReturnValue([process.pid, 200, 200, 300, -1]);

--- a/src/infra/gateway-processes.ts
+++ b/src/infra/gateway-processes.ts
@@ -37,6 +37,11 @@ export function signalVerifiedGatewayPidSync(pid: number, signal: "SIGTERM" | "S
   if (!args || !isGatewayArgv(args, { allowGatewayBinary: true })) {
     throw new Error(`refusing to signal non-gateway process pid ${pid}`);
   }
+  if (process.platform === "win32" && signal === "SIGUSR1") {
+    throw new Error(
+      "SIGUSR1 is not supported on Windows; use the Windows scheduled task restart mechanism instead",
+    );
+  }
   process.kill(pid, signal);
 }
 


### PR DESCRIPTION
## Summary

On Windows, `process.kill(pid, "SIGUSR1")` throws `TypeError [ERR_UNKNOWN_SIGNAL]: Unknown signal: SIGUSR1` because SIGUSR1 is a Unix-only signal. This broke `openclaw gateway restart` for unmanaged gateway processes on Windows.

## Changes

### 1. `src/infra/gateway-processes.ts`
Defensive guard: `signalVerifiedGatewayPidSync` throws a clear error when SIGUSR1 is used on win32, instead of crashing with an obscure Node.js `ERR_UNKNOWN_SIGNAL`.

### 2. `src/cli/daemon-cli/lifecycle.ts`
`restartGatewayWithoutServiceManager` now uses `triggerOpenClawRestart()` on win32 (the existing Windows scheduled-task restart handoff) instead of sending SIGUSR1. If the scheduled task is not installed, the error message directs users to run `openclaw gateway install`.

**Why not SIGTERM?** Per ClawSweeper review: Node.js on Windows unconditionally terminates the target process on cross-process SIGTERM, bypassing JS-level handlers. The gateway SIGTERM handler would never run, so the process would just die without restarting. `triggerOpenClawRestart()` uses `schtasks /Run` + a fallback cmd script, which is the established Windows restart path.

## Test plan
- [x] `gateway-processes.test.ts`: new test "rejects SIGUSR1 on Windows"
- [x] `lifecycle.test.ts`: new test "uses scheduled task restart for unmanaged gateway restart on Windows"
- [x] Existing test pinned to linux platform for deterministic behavior
- [x] 27 of 28 tests pass (1 pre-existing failure: test hardcodes Linux 60s timeout, gets Windows 180s — unrelated to this change)

## Real behavior proof

- **Behavior addressed**: `openclaw gateway restart` crashes on Windows with `ERR_UNKNOWN_SIGNAL: Unknown signal: SIGUSR1` for unmanaged gateway processes. The gateway restart handler called `process.kill(pid, "SIGUSR1")` which is not a valid signal on Windows.
- **Real environment tested**: Windows 11 Pro (10.0.28000), OpenClaw 2026.5.18 (patched), Node.js 22.x, git for Windows bash shell
- **Exact steps or command run after the patch**:
  1. `openclaw gateway restart --json` (service restart path)
  2. `openclaw gateway status` (verify gateway healthy post-restart)
  3. `npx vitest run src/infra/gateway-processes.test.ts src/cli/daemon-cli/lifecycle.test.ts`
- **Evidence after fix**:
  Service restart on Windows (gateway managed via Scheduled Task):
  ```
  $ openclaw gateway restart --json
  {
    "action": "restart",
    "ok": true,
    "result": "restarted",
    "service": {
      "label": "Scheduled Task",
      "loaded": true,
      "loadedText": "registered",
      "notLoadedText": "missing"
    }
  }

  $ openclaw gateway status
  Service: Scheduled Task (registered)
  Runtime: running (pid 23880, Verified gateway listener detected on port 18789)
  Connectivity probe: ok
  Capability: admin-capable
  Listening: 127.0.0.1:18789
  CLI version: 2026.5.18
  Gateway version: 2026.5.18
  ```

  Unit test results (28 tests, 27 passed, 1 pre-existing unrelated failure):
  ```
   Test Files  1 failed | 1 passed (2)
        Tests  1 failed | 27 passed (28)
  ```
  - New tests "rejects SIGUSR1 on Windows" and "uses scheduled task restart for unmanaged gateway restart on Windows" both pass
  - The 1 failure is pre-existing: "fails restart when gateway remains unhealthy after the full timeout" hardcodes Linux 60s timeout expectation; on real Windows the platform-aware timeout is 180s
- **Observed result after fix**: Gateway restarts successfully on Windows. The defensive guard in `signalVerifiedGatewayPidSync` now throws a clear error message instead of Node.js's obscure `ERR_UNKNOWN_SIGNAL`. The unmanaged restart path uses `triggerOpenClawRestart()` which spawns the existing Windows schtasks-based restart mechanism, consistent with the in-process restart path.
- **Not tested**: Unmanaged gateway restart path (requires stopping the Windows Scheduled Task service first and running a raw gateway process). This code path is covered by the unit tests with mocked platform="win32" and mocked `triggerOpenClawRestart`.