### PR TITLE
Include delivery errors in subagent announce give-up logs

### DIFF
--- a/src/agents/subagent-announce.test.ts
+++ b/src/agents/subagent-announce.test.ts
@@ -3,8 +3,14 @@ import type { EmbeddedPiQueueMessageOutcome } from "./pi-embedded-runner/runs.js
 import { createSubagentAnnounceDeliveryRuntimeMock } from "./subagent-announce.test-support.js";
 
 type AgentCallRequest = { method?: string; params?: Record<string, unknown> };
+type AgentCallResponse = { runId?: string; status: string; error?: string };
 
-const agentSpy = vi.fn(async (_req: AgentCallRequest) => ({ runId: "run-main", status: "ok" }));
+const agentSpy = vi.fn(
+  async (_req: AgentCallRequest): Promise<AgentCallResponse> => ({
+    runId: "run-main",
+    status: "ok",
+  }),
+);
 const sessionsDeleteSpy = vi.fn((_req: AgentCallRequest) => undefined);
 const callGatewayMock = vi.fn(async (_request: unknown) => ({}));
 const loadSessionStoreMock = vi.fn((_storePath: string) => ({}));

--- a/src/agents/subagent-announce.test.ts
+++ b/src/agents/subagent-announce.test.ts
@@ -120,7 +120,7 @@ vi.mock("./subagent-announce-delivery.js", () => ({
     const effectiveOrigin =
       params.completionDirectOrigin ?? params.requesterOrigin ?? params.directOrigin;
 
-    await callGatewayMock({
+    const response = (await callGatewayMock({
       method: "agent",
       params: {
         sessionKey: params.targetRequesterSessionKey,
@@ -139,7 +139,11 @@ vi.mock("./subagent-announce-delivery.js", () => ({
               threadId: effectiveOrigin?.threadId,
             }),
       },
-    });
+    })) as { status?: string; error?: string };
+
+    if (response.status === "error") {
+      return { delivered: false, path: "direct", error: response.error ?? "agent delivery failed" };
+    }
 
     return { delivered: true, path: "direct" };
   },
@@ -180,6 +184,7 @@ vi.mock("./subagent-announce-delivery.js", () => ({
 }));
 
 vi.mock("./subagent-announce.registry.runtime.js", () => subagentRegistryRuntimeMock);
+import { defaultRuntime } from "../runtime.js";
 import { applySubagentWaitOutcome } from "./subagent-announce-output.js";
 import { runSubagentAnnounceFlow } from "./subagent-announce.js";
 
@@ -501,5 +506,36 @@ describe("subagent announce seam flow", () => {
     expect(agentCall.params?.channel).toBe("telegram");
     expect(agentCall.params?.accountId).toBe("bot-123");
     expect(agentCall.params?.to).toBe("-1001234567890");
+  });
+
+  it("logs direct completion announce delivery failures through the gateway log path", async () => {
+    const logSpy = vi.spyOn(defaultRuntime, "log").mockImplementation(() => {});
+    agentSpy.mockResolvedValueOnce({ status: "error", error: "Outbound not configured for slack" });
+
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:slack",
+      childRunId: "run-direct-failure-log",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      requesterOrigin: {
+        channel: "slack",
+        to: "C123",
+      },
+      task: "deliver completion",
+      timeoutMs: 10,
+      cleanup: "keep",
+      waitForCompletion: false,
+      startedAt: 10,
+      endedAt: 20,
+      outcome: { status: "ok" },
+      roundOneReply: "done",
+      expectsCompletionMessage: true,
+    });
+
+    expect(didAnnounce).toBe(false);
+    expect(logSpy).toHaveBeenCalledWith(
+      "[warn] Subagent completion direct announce failed for run run-direct-failure-log: Outbound not configured for slack",
+    );
+    logSpy.mockRestore();
   });
 });

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -573,8 +573,8 @@ export async function runSubagentAnnounceFlow(params: {
     params.onDeliveryResult?.(delivery);
     didAnnounce = delivery.delivered;
     if (!delivery.delivered && delivery.path === "direct" && delivery.error) {
-      defaultRuntime.error?.(
-        `Subagent completion direct announce failed for run ${params.childRunId}: ${delivery.error}`,
+      defaultRuntime.log(
+        `[warn] Subagent completion direct announce failed for run ${params.childRunId}: ${delivery.error}`,
       );
     }
   } catch (err) {

--- a/src/agents/subagent-registry-helpers.test.ts
+++ b/src/agents/subagent-registry-helpers.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { reconcileOrphanedRun } from "./subagent-registry-helpers.js";
+import { defaultRuntime } from "../runtime.js";
+import { logAnnounceGiveUp, reconcileOrphanedRun } from "./subagent-registry-helpers.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
 
 function createRunEntry(overrides: Partial<SubagentRunRecord> = {}): SubagentRunRecord {
@@ -50,5 +51,43 @@ describe("reconcileOrphanedRun", () => {
     });
     expect(runs.has(entry.runId)).toBe(false);
     expect(resumedRuns.has(entry.runId)).toBe(false);
+  });
+});
+
+describe("logAnnounceGiveUp", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("includes the last delivery error in retry-limit warnings", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(9_000);
+    const logSpy = vi.spyOn(defaultRuntime, "log").mockImplementation(() => {});
+    const entry = createRunEntry({
+      endedAt: 4_000,
+      announceRetryCount: 3,
+      lastAnnounceDeliveryError: "direct-primary: routed-dispatch-did-not-queue-final",
+    });
+
+    logAnnounceGiveUp(entry, "retry-limit");
+
+    expect(logSpy).toHaveBeenCalledWith(
+      '[warn] Subagent announce give up (retry-limit) run=run-1 child=agent:main:subagent:child requester=agent:main:main retries=3 endedAgo=5s deliveryError="direct-primary: routed-dispatch-did-not-queue-final"',
+    );
+    logSpy.mockRestore();
+  });
+
+  it("normalizes multiline delivery errors onto one gateway log line", () => {
+    const logSpy = vi.spyOn(defaultRuntime, "log").mockImplementation(() => {});
+    const entry = createRunEntry({
+      lastAnnounceDeliveryError: "gateway timeout\nphase: routed dispatch failed",
+    });
+
+    logAnnounceGiveUp(entry, "expiry");
+
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining('deliveryError="gateway timeout phase: routed dispatch failed"'),
+    );
+    logSpy.mockRestore();
   });
 });

--- a/src/agents/subagent-registry-helpers.ts
+++ b/src/agents/subagent-registry-helpers.ts
@@ -65,13 +65,21 @@ export function resolveAnnounceRetryDelayMs(retryCount: number) {
   return Math.min(baseDelay, MAX_ANNOUNCE_RETRY_DELAY_MS);
 }
 
+function formatAnnounceGiveUpLogField(value: string): string {
+  const normalized = value.replace(/\s+/g, " ").trim();
+  return JSON.stringify(normalized.length > 2_000 ? `${normalized.slice(0, 2_000)}…` : normalized);
+}
+
 export function logAnnounceGiveUp(entry: SubagentRunRecord, reason: "retry-limit" | "expiry") {
   const retryCount = entry.announceRetryCount ?? 0;
   const endedAgoMs =
     typeof entry.endedAt === "number" ? Math.max(0, Date.now() - entry.endedAt) : undefined;
   const endedAgoLabel = endedAgoMs != null ? `${Math.round(endedAgoMs / 1000)}s` : "n/a";
+  const deliveryError = entry.lastAnnounceDeliveryError?.trim()
+    ? ` deliveryError=${formatAnnounceGiveUpLogField(entry.lastAnnounceDeliveryError)}`
+    : "";
   defaultRuntime.log(
-    `[warn] Subagent announce give up (${reason}) run=${entry.runId} child=${entry.childSessionKey} requester=${entry.requesterSessionKey} retries=${retryCount} endedAgo=${endedAgoLabel}`,
+    `[warn] Subagent announce give up (${reason}) run=${entry.runId} child=${entry.childSessionKey} requester=${entry.requesterSessionKey} retries=${retryCount} endedAgo=${endedAgoLabel}${deliveryError}`,
   );
 }
 


### PR DESCRIPTION
## Summary

Fixes #84272.

- Include the saved `lastAnnounceDeliveryError` in subagent announce retry-limit / expiry give-up warnings.
- Normalize multiline delivery errors onto one gateway log line so `gateway.log` remains searchable.
- Log direct completion announce delivery failures through the normal gateway log path instead of stderr-only output.

## Root cause

Subagent announce delivery already formatted and persisted the concrete delivery failure on the run entry, but `logAnnounceGiveUp()` only emitted run, child, requester, retry count, and ended age. On macOS managed gateways where stderr can be discarded, the final `gateway.log` warning lost the useful delivery cause.

## Real behavior proof

Behavior or issue addressed:
Subagent announce retry-limit give-up logs now include the underlying delivery error in the normal gateway log output.

Real environment tested:
Local OpenClaw source checkout on macOS using the production `logAnnounceGiveUp()` implementation and `defaultRuntime.log` capture.

Exact steps or command run after this patch:
```text
PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node --import tsx --input-type=module --eval 'import { defaultRuntime } from "./src/runtime.ts"; import { logAnnounceGiveUp } from "./src/agents/subagent-registry-helpers.ts"; const originalLog = defaultRuntime.log; const lines = []; defaultRuntime.log = (line) => lines.push(String(line)); const originalNow = Date.now; Date.now = () => 9000; logAnnounceGiveUp({ runId: "run-proof", childSessionKey: "agent:main:subagent:child", requesterSessionKey: "agent:main:main", requesterDisplayKey: "main", task: "finish", cleanup: "keep", createdAt: 1000, startedAt: 2000, endedAt: 4000, announceRetryCount: 3, lastAnnounceDeliveryError: "direct-primary: routed-dispatch-did-not-queue-final\nsteer-fallback: queue_message_failed" }, "retry-limit"); Date.now = originalNow; defaultRuntime.log = originalLog; console.log(JSON.stringify({ loggedLine: lines[0], hasDeliveryError: lines[0]?.includes("deliveryError="), multilineCollapsed: !lines[0]?.includes("\\n") }, null, 2));'
```

Evidence after fix:
```json
{
  "loggedLine": "[warn] Subagent announce give up (retry-limit) run=run-proof child=agent:main:subagent:child requester=agent:main:main retries=3 endedAgo=5s deliveryError=\"direct-primary: routed-dispatch-did-not-queue-final steer-fallback: queue_message_failed\"",
  "hasDeliveryError": true,
  "multilineCollapsed": true
}
```

Observed result after fix:
The normal gateway log warning includes `deliveryError=...`, preserves the concrete delivery failure, and collapses multiline errors onto one log line.

What was not tested:
No live macOS LaunchAgent was started. The proof exercises the production logging helper directly, and focused tests cover the direct completion announce failure path.

## Validation

- `node scripts/run-vitest.mjs src/agents/subagent-registry-lifecycle.test.ts`
- `node scripts/run-vitest.mjs src/agents/subagent-announce.test.ts src/agents/subagent-announce-dispatch.test.ts`
- `git diff --check`

## Attribution

If maintainers squash or rework this PR, please preserve author attribution or include:

`Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>`
