### PR TITLE
fix(update): skip main-entry check after missing-extension-entry (#83891)

### DIFF
--- a/src/cli/update-cli/plugin-payload-validation.test.ts
+++ b/src/cli/update-cli/plugin-payload-validation.test.ts
@@ -287,4 +287,33 @@ describe("runPluginPayloadSmokeCheck", () => {
     });
     expect(result.checked).toEqual(["npm"]);
   });
+
+  it("emits exactly one failure when openclaw.extensions is empty AND the declared main file is missing (#83891)", async () => {
+    // Both conditions hold simultaneously: extensions is an empty object
+    // (triggers missing-extension-entry) AND main points to a path that
+    // doesn't exist on disk (would have also triggered missing-main-entry
+    // without the continue; in the empty/invalid branch).
+    const dir = path.join(tmpRoot, "pkg");
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(
+      path.join(dir, "package.json"),
+      JSON.stringify({
+        name: "pkg",
+        main: "dist/index.js",
+        openclaw: { extensions: {} },
+      }),
+      "utf8",
+    );
+    const result = await runPluginPayloadSmokeCheck({
+      records: { pkg: { source: "npm", installPath: dir } },
+      env: {},
+    });
+    const pkgFailures = result.failures.filter((f) => f.pluginId === "pkg");
+    expect(pkgFailures).toHaveLength(1);
+    expect(pkgFailures[0]).toMatchObject({
+      pluginId: "pkg",
+      installPath: dir,
+      reason: "missing-extension-entry",
+    });
+  });
 });

--- a/src/cli/update-cli/plugin-payload-validation.ts
+++ b/src/cli/update-cli/plugin-payload-validation.ts
@@ -112,6 +112,12 @@ export async function runPluginPayloadSmokeCheck(params: {
             : "package.json openclaw.extensions is empty"
         }`,
       });
+      // Skip the trailing main-entry check so a plugin that is *also* missing
+      // its declared main does not emit a second failure entry for the same
+      // pluginId — mirrors the `continue` already used by the
+      // `missing-package-dir` and `invalid-package-json` branches above.
+      // See #83891.
+      continue;
     } else if (extensionResolution.status === "ok") {
       const extensionValidation = await validatePackageExtensionEntriesForInstall({
         packageDir: installPath,


### PR DESCRIPTION
Fixes #83891.

`runPluginPayloadSmokeCheck` (`src/cli/update-cli/plugin-payload-validation.ts:104`) walks each plugin install record and runs a series of validation stages. The `missing-package-dir` and `invalid-package-json` branches `continue` to the next record after their failure push, but the `missing-extension-entry` branch (empty or invalid `openclaw.extensions`) does NOT `continue`. Execution falls through into the trailing main-entry check. If the same plugin ALSO declares a `main` that doesn't exist on disk, a second `missing-main-entry` failure is appended for the same `pluginId`.

Downstream impact: in `runPostCorePluginConvergence` (`src/cli/update-cli/post-core-plugin-convergence.ts:74-77`), every smoke failure becomes a per-plugin warning, so the duplicate entry double-counts in the post-update warnings list and in the `smokeFailures` array consumers iterate. `errored: warnings.length > 0` still fires correctly in the single-failure case, but any caller that uses failure count for severity decisions would over-weight this plugin.

## Changes

- `src/cli/update-cli/plugin-payload-validation.ts`: add `continue;` after the failure push in the `extensionResolution.status === "invalid" || "empty"` branch. The comment above the new statement points at the existing `continue;` in the earlier `missing-package-dir` / `invalid-package-json` branches so the pattern reads as deliberate. The `ok` branch is intentionally unchanged because checking `main` after a valid extension resolution is additive, not duplicate.
- `src/cli/update-cli/plugin-payload-validation.test.ts`: add a regression case under the existing `describe("runPluginPayloadSmokeCheck", …)`. It writes a `package.json` with `openclaw.extensions: {}` (triggers the empty branch) AND `main: "dist/index.js"` (which doesn't exist on disk), then asserts `pkgFailures.length === 1` and that the single failure has `reason: "missing-extension-entry"`. Without the fix this assertion would observe 2 failures.

Diff stat: 2 files, +35 / -0.

## Real behavior proof

- **Behavior or issue addressed:** Sanitized issue evidence — the loop body at `plugin-payload-validation.ts:104-115` is the only branch that pushes a failure and does NOT terminate the iteration. The other branches (`missing-package-dir` at line ~85, `invalid-package-json` at line ~98) already use `continue;` after their failure push.

- **Real environment tested:** Local Node 22.x. Probe at `/tmp/probe_83891.mjs` does both halves of the proof. (a) Parses the patched `plugin-payload-validation.ts` and verifies the `missing-extension-entry` branch now contains both the failure push AND a `continue;` statement, and that the two earlier `continue;` statements are still present. (b) Replays the loop body logic in pure JS for five scenarios — buggy shape (empty extensions + missing main → 2 duplicate failures, confirming the #83891 symptom), patched shape (same fixture → 1 failure), invalid-extension + missing main (also gated, single failure), empty-extensions + main present (extension failure unchanged), ok-extension + missing main (main check still runs — `missing-main-entry` emitted as before; no regression on the ok branch).

- **Exact steps or command run after this patch:** `node /tmp/probe_83891.mjs`

- **Evidence after fix:**

```
PASS: missing-extension-entry branch ends with continue; (mirrors missing-package-dir / invalid-package-json branches)
PASS: earlier branch continue; statements (missing-package-dir / invalid-package-json) still present
PASS: replay (buggy): empty extensions + missing main → 2 failure entries for the same pluginId (confirms #83891)
PASS: replay (patched): same fixture → exactly 1 failure (missing-extension-entry); the duplicate main entry is suppressed
PASS: replay (patched, invalid extension): also gated by continue; — single failure entry
PASS: replay (patched, main present): main-on-disk path unchanged — still 1 extension failure, no false main failure
PASS: replay (patched, ok extension + missing main): main check still runs — single missing-main-entry failure as before

ALL CASES PASS
```

- **Observed result after fix:** A plugin with empty `openclaw.extensions` and a missing `main` file now emits exactly one smoke failure (`missing-extension-entry`) instead of two. The ok-extension path is unchanged — the main check still runs against valid extension resolutions, so legitimate `missing-main-entry` failures still surface.

- **What was not tested:** A live update flow exercising `runPostCorePluginConvergence` end-to-end — that's outside the scope of a single-iteration fall-through fix. The added vitest case exercises the smoke-check boundary directly with a real on-disk fixture.

## Audit (per CLAUDE rules — all 5 steps)

- **Existing-helper check:** No new helper. The fix is a `continue;` statement mirroring the pattern already used in two sibling branches (`missing-package-dir`, `invalid-package-json`) within the same function. PASS
- **Shared-helper caller check:** `runPluginPayloadSmokeCheck` has two callers — `post-core-plugin-convergence.ts` (production) and `plugin-payload-validation.test.ts` (tests). The new behavior strictly reduces the `failures` array size in the dual-failure edge case and is unchanged in every other case. No caller relies on the duplicate-emission behavior. PASS
- **Broader-fix rival scan:** `gh pr list --search '83891 in:title,body'` and `gh pr list --search 'runPluginPayloadSmokeCheck in:title,body'` return no open PRs. Issue timeline shows zero cross-references. PASS
- **Recent-merge audit:** `git log --oneline -5 -- src/cli/update-cli/plugin-payload-validation.ts` shows `e1061a8b46 test(live): tolerate provider drift in release checks` — unrelated. PASS
- **Prototype-pollution scan:** N/A — single `continue;` statement.
