### PR TITLE
fix(json): retry on transient File changed during read race condition

### DIFF
--- a/src/infra/json-files.test.ts
+++ b/src/infra/json-files.test.ts
@@ -1,4 +1,5 @@
-import fs from "node:fs/promises";
+import fs from "node:fs";
+import fsPromises from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { withTempDir } from "../test-helpers/temp-dir.js";
@@ -6,7 +7,9 @@ import {
   JsonFileReadError,
   createAsyncLock,
   readDurableJsonFile,
+  readJson,
   readJsonFile,
+  tryReadJson,
   writeJsonAtomic,
   writeTextAtomic,
 } from "./json-files.js";
@@ -26,7 +29,7 @@ describe("json file helpers", () => {
       name: "reads valid json",
       setup: async (base: string) => {
         const filePath = path.join(base, "valid.json");
-        await fs.writeFile(filePath, '{"ok":true}', "utf8");
+        await fsPromises.writeFile(filePath, '{"ok":true}', "utf8");
         return filePath;
       },
       expected: { ok: true },
@@ -35,7 +38,7 @@ describe("json file helpers", () => {
       name: "returns null for invalid files",
       setup: async (base: string) => {
         const filePath = path.join(base, "invalid.json");
-        await fs.writeFile(filePath, "{not-json}", "utf8");
+        await fsPromises.writeFile(filePath, "{not-json}", "utf8");
         return filePath;
       },
       expected: null,
@@ -56,8 +59,8 @@ describe("json file helpers", () => {
       const validPath = path.join(base, "valid.json");
       const invalidPath = path.join(base, "invalid.json");
       const missingPath = path.join(base, "missing.json");
-      await fs.writeFile(validPath, '{"ok":true}', "utf8");
-      await fs.writeFile(invalidPath, "{not-json}", "utf8");
+      await fsPromises.writeFile(validPath, '{"ok":true}', "utf8");
+      await fsPromises.writeFile(invalidPath, "{not-json}", "utf8");
 
       await expect(readDurableJsonFile(validPath)).resolves.toEqual({ ok: true });
       await expect(readDurableJsonFile(missingPath)).resolves.toBeNull();
@@ -82,7 +85,7 @@ describe("json file helpers", () => {
         { trailingNewline: true, dirMode: 0o755 },
       );
 
-      await expect(fs.readFile(filePath, "utf8")).resolves.toBe(
+      await expect(fsPromises.readFile(filePath, "utf8")).resolves.toBe(
         '{\n  "ok": true,\n  "nested": {\n    "value": 1\n  }\n}\n',
       );
     });
@@ -95,35 +98,35 @@ describe("json file helpers", () => {
     await withTempDir({ prefix: "openclaw-json-files-" }, async (base) => {
       const filePath = path.join(base, "nested", "note.txt");
       await writeTextAtomic(filePath, input, { trailingNewline: true });
-      await expect(fs.readFile(filePath, "utf8")).resolves.toBe(expected);
+      await expect(fsPromises.readFile(filePath, "utf8")).resolves.toBe(expected);
     });
   });
 
   it("can skip durable fsync work for hot state writes", async () => {
     await withTempDir({ prefix: "openclaw-json-files-" }, async (base) => {
       const filePath = path.join(base, "state.json");
-      const openSpy = vi.spyOn(fs, "open");
+      const openSpy = vi.spyOn(fsPromises, "open");
 
       await writeTextAtomic(filePath, "new", { durable: false });
 
       expect(openSpy).not.toHaveBeenCalled();
-      await expect(fs.readFile(filePath, "utf8")).resolves.toBe("new");
+      await expect(fsPromises.readFile(filePath, "utf8")).resolves.toBe("new");
     });
   });
 
   it("preserves text when Windows rename reports EPERM", async () => {
     await withTempDir({ prefix: "openclaw-json-files-" }, async (base) => {
       const filePath = path.join(base, "state.json");
-      await fs.writeFile(filePath, "old", "utf8");
+      await fsPromises.writeFile(filePath, "old", "utf8");
 
       Object.defineProperty(process, "platform", { value: "win32", configurable: true });
       const renameError = Object.assign(new Error("EPERM"), { code: "EPERM" });
-      const renameSpy = vi.spyOn(fs, "rename").mockRejectedValueOnce(renameError);
+      const renameSpy = vi.spyOn(fsPromises, "rename").mockRejectedValueOnce(renameError);
 
       await writeTextAtomic(filePath, "new");
 
       expect(renameSpy).toHaveBeenCalledOnce();
-      await expect(fs.readFile(filePath, "utf8")).resolves.toBe("new");
+      await expect(fsPromises.readFile(filePath, "utf8")).resolves.toBe("new");
     });
   });
 
@@ -131,20 +134,20 @@ describe("json file helpers", () => {
     await withTempDir({ prefix: "openclaw-json-files-" }, async (base) => {
       const filePath = path.join(base, "state.json");
       const outsidePath = path.join(base, "outside.json");
-      await fs.writeFile(outsidePath, "outside", "utf8");
-      await fs.symlink(outsidePath, filePath);
+      await fsPromises.writeFile(outsidePath, "outside", "utf8");
+      await fsPromises.symlink(outsidePath, filePath);
 
       Object.defineProperty(process, "platform", { value: "win32", configurable: true });
       const renameError = Object.assign(new Error("EPERM"), { code: "EPERM" });
-      vi.spyOn(fs, "rename").mockRejectedValueOnce(renameError);
+      vi.spyOn(fsPromises, "rename").mockRejectedValueOnce(renameError);
 
       await expect(writeTextAtomic(filePath, "new")).rejects.toThrow(
         "Refusing copy fallback through symlink destination",
       );
 
-      const fileStat = await fs.lstat(filePath);
+      const fileStat = await fsPromises.lstat(filePath);
       expect(fileStat.isSymbolicLink()).toBe(true);
-      await expect(fs.readFile(outsidePath, "utf8")).resolves.toBe("outside");
+      await expect(fsPromises.readFile(outsidePath, "utf8")).resolves.toBe("outside");
     });
   });
 
@@ -184,5 +187,79 @@ describe("json file helpers", () => {
     await expect(first).rejects.toThrow(expectedFirstError);
     await expect(second).resolves.toBe("ok");
     expect(events).toEqual(expectedEvents);
+  });
+
+  describe("retry behaviors on 'File changed during read'", () => {
+    /**
+     * Helper: spy on fsPromises.lstat for our target file path.
+     * Returns a real Stats object with a modified ino to trigger
+     * verifyStableReadTarget in @openclaw/fs-safe.
+     * Object.assign + Object.create preserves the Stats prototype.
+     */
+    function setupLstatSpy(targetPath: string, targetCallCount: number): () => number {
+      const origLstat = fsPromises.lstat.bind(fsPromises);
+      let callCount = 0;
+
+      vi.spyOn(fsPromises, "lstat").mockImplementation(async (p, ...args) => {
+        const stat = await origLstat(p as fs.PathLike, ...(args as any));
+        const pathStr = typeof p === "string" ? p : String(p);
+        if (pathStr === targetPath) {
+          callCount++;
+          if (callCount <= targetCallCount) {
+            // Modify ino: for BigInt ino add 100n, for number ino add 100
+            const modifiedIno =
+              typeof stat.ino === "bigint" ? stat.ino + 100n : (stat.ino as number) + 100;
+
+            // Clone stat preserving prototype, override ino
+            return Object.assign(Object.create(Object.getPrototypeOf(stat)), stat, {
+              ino: modifiedIno,
+            });
+          }
+        }
+        return stat;
+      });
+
+      return () => callCount;
+    }
+
+    it("retries on transient File changed during read and succeeds", async () => {
+      await withTempDir({ prefix: "openclaw-json-files-retry-" }, async (base) => {
+        const filePath = path.join(base, "config.json");
+        await fsPromises.writeFile(filePath, '{"ok":true}', "utf8");
+
+        // Only fail lstat once (first call) — retry should succeed on 2nd attempt
+        const getCalls = setupLstatSpy(filePath, 1);
+
+        const result = await readJson<{ ok: boolean }>(filePath);
+        expect(result).toEqual({ ok: true });
+        // Should have at least 2 lstat calls: one failed, one successful
+        expect(getCalls()).toBeGreaterThanOrEqual(2);
+      });
+    });
+
+    it("throws JsonFileReadError after exhausting retries on persistent race", async () => {
+      await withTempDir({ prefix: "openclaw-json-files-exhaust-" }, async (base) => {
+        const filePath = path.join(base, "config.json");
+        await fsPromises.writeFile(filePath, '{"ok":true}', "utf8");
+
+        // Always fail lstat — all 3 retries should exhaust
+        setupLstatSpy(filePath, Infinity);
+
+        await expect(readJson(filePath)).rejects.toThrow(JsonFileReadError);
+      });
+    });
+
+    it("tryReadJson returns null after exhausting retries", async () => {
+      await withTempDir({ prefix: "openclaw-json-files-try-" }, async (base) => {
+        const filePath = path.join(base, "config.json");
+        await fsPromises.writeFile(filePath, '{"ok":true}', "utf8");
+
+        // Always fail lstat — tryReadJson catches and returns null
+        setupLstatSpy(filePath, Infinity);
+
+        const result = await tryReadJson(filePath);
+        expect(result).toBeNull();
+      });
+    });
   });
 });

--- a/src/infra/json-files.test.ts
+++ b/src/infra/json-files.test.ts
@@ -201,14 +201,13 @@ describe("json file helpers", () => {
       let callCount = 0;
 
       vi.spyOn(fsPromises, "lstat").mockImplementation(async (p, ...args) => {
-        const stat = await origLstat(p as fs.PathLike, ...(args as any));
+        const stat = await origLstat(p, ...args);
         const pathStr = typeof p === "string" ? p : String(p);
         if (pathStr === targetPath) {
           callCount++;
           if (callCount <= targetCallCount) {
             // Modify ino: for BigInt ino add 100n, for number ino add 100
-            const modifiedIno =
-              typeof stat.ino === "bigint" ? stat.ino + 100n : (stat.ino as number) + 100;
+            const modifiedIno = typeof stat.ino === "bigint" ? stat.ino + 100n : stat.ino + 100;
 
             // Clone stat preserving prototype, override ino
             return Object.assign(Object.create(Object.getPrototypeOf(stat)), stat, {

--- a/src/infra/json-files.ts
+++ b/src/infra/json-files.ts
@@ -59,15 +59,15 @@ async function withRetryOnFileChanged<T>(fn: () => Promise<T>): Promise<T> {
   }
 }
 
-export async function readJson<T>(filePath: string): Promise<T | null> {
+export async function readJson<T>(filePath: string): Promise<T> {
   try {
-    return await withRetryOnFileChanged(() => readJsonImpl<T>(filePath) as Promise<T | null>);
+    return await withRetryOnFileChanged(() => readJsonImpl<T>(filePath));
   } catch (err) {
     throw err instanceof JsonFileReadError ? err : new JsonFileReadError(filePath, "read", err);
   }
 }
 
-export async function readJsonFileStrict<T>(filePath: string): Promise<T | null> {
+export async function readJsonFileStrict<T>(filePath: string): Promise<T> {
   return readJson<T>(filePath);
 }
 

--- a/src/infra/json-files.ts
+++ b/src/infra/json-files.ts
@@ -1,24 +1,113 @@
 import "./fs-safe-defaults.js";
 import { replaceFileAtomic } from "./replace-file.js";
+import {
+  JsonFileReadError,
+  readJson as readJsonImpl,
+  readJsonIfExists as readJsonIfExistsImpl,
+} from "@openclaw/fs-safe/json";
 
 export {
   JsonFileReadError,
-  readJson,
-  readJson as readJsonFileStrict,
-  readJsonIfExists,
-  readJsonIfExists as readDurableJsonFile,
   readJsonSync,
   readRootJsonObjectSync,
   readRootJsonSync,
   readRootStructuredFileSync,
-  tryReadJson,
-  tryReadJson as readJsonFile,
   tryReadJsonSync,
   tryReadJsonSync as readJsonFileSync,
   writeJson,
   writeJson as writeJsonAtomic,
   writeJsonSync,
 } from "@openclaw/fs-safe/json";
+
+const RETRY_MAX_ATTEMPTS = 3;
+const RETRY_BASE_DELAY_MS = 50;
+
+/**
+ * Recursively walks the error cause chain to detect
+ * "File changed during read" errors wrapped inside
+ * JsonFileReadError by @openclaw/fs-safe.
+ */
+function isFileChangedDuringRead(err: unknown): boolean {
+  let current: unknown = err;
+  while (current) {
+    if (current instanceof Error) {
+      if (
+        typeof current.message === "string" &&
+        current.message.includes("File changed during read")
+      ) {
+        return true;
+      }
+      current = (current as Error & { cause?: unknown }).cause;
+    } else {
+      break;
+    }
+  }
+  return false;
+}
+
+async function withRetryOnFileChanged<T>(fn: () => Promise<T>): Promise<T> {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (isFileChangedDuringRead(err) && attempt < RETRY_MAX_ATTEMPTS - 1) {
+        await new Promise((r) => setTimeout(r, RETRY_BASE_DELAY_MS * Math.pow(2, attempt)));
+        continue;
+      }
+      throw err;
+    }
+  }
+}
+
+export async function readJson<T>(filePath: string): Promise<T | null> {
+  try {
+    return await withRetryOnFileChanged(() => readJsonImpl<T>(filePath) as Promise<T | null>);
+  } catch (err) {
+    throw err instanceof JsonFileReadError ? err : new JsonFileReadError(filePath, "read", err);
+  }
+}
+
+export async function readJsonFileStrict<T>(filePath: string): Promise<T | null> {
+  return readJson<T>(filePath);
+}
+
+export async function readJsonIfExists<T>(filePath: string): Promise<T | null> {
+  try {
+    return await withRetryOnFileChanged(() => readJsonIfExistsImpl<T>(filePath));
+  } catch (err) {
+    if (err instanceof JsonFileReadError) throw err;
+    throw new JsonFileReadError(filePath, "read", err);
+  }
+}
+
+export async function readDurableJsonFile<T>(filePath: string): Promise<T | null> {
+  return readJsonIfExists<T>(filePath);
+}
+
+/**
+ * tryReadJson delegates to readJsonIfExists instead of the internal
+ * tryReadJsonImpl from @openclaw/fs-safe. The fs-safe implementation
+ * swallows all errors internally and returns null, which prevents
+ * the retry wrapper from detecting transient "File changed during read"
+ * race conditions.
+ *
+ * By routing through readJsonIfExists, fs-safe propagates errors on
+ * race conditions, our retry wrapper intercepts and retries them,
+ * and the outer try-catch still handles parse errors / file-not-found
+ * gracefully.
+ */
+export async function tryReadJson<T>(filePath: string): Promise<T | null> {
+  try {
+    return await readJsonIfExists<T>(filePath);
+  } catch {
+    return null;
+  }
+}
+
+export async function readJsonFile<T>(filePath: string): Promise<T | null> {
+  return tryReadJson<T>(filePath);
+}
+
 export { createAsyncLock } from "@openclaw/fs-safe/advanced";
 
 export type WriteTextAtomicOptions = {

--- a/src/infra/json-files.ts
+++ b/src/infra/json-files.ts
@@ -1,10 +1,10 @@
 import "./fs-safe-defaults.js";
-import { replaceFileAtomic } from "./replace-file.js";
 import {
   JsonFileReadError,
   readJson as readJsonImpl,
   readJsonIfExists as readJsonIfExistsImpl,
 } from "@openclaw/fs-safe/json";
+import { replaceFileAtomic } from "./replace-file.js";
 
 export {
   JsonFileReadError,
@@ -51,7 +51,7 @@ async function withRetryOnFileChanged<T>(fn: () => Promise<T>): Promise<T> {
       return await fn();
     } catch (err) {
       if (isFileChangedDuringRead(err) && attempt < RETRY_MAX_ATTEMPTS - 1) {
-        await new Promise((r) => setTimeout(r, RETRY_BASE_DELAY_MS * Math.pow(2, attempt)));
+        await new Promise((r) => setTimeout(r, RETRY_BASE_DELAY_MS * 2 ** attempt));
         continue;
       }
       throw err;
@@ -75,7 +75,9 @@ export async function readJsonIfExists<T>(filePath: string): Promise<T | null> {
   try {
     return await withRetryOnFileChanged(() => readJsonIfExistsImpl<T>(filePath));
   } catch (err) {
-    if (err instanceof JsonFileReadError) throw err;
+    if (err instanceof JsonFileReadError) {
+      throw err;
+    }
     throw new JsonFileReadError(filePath, "read", err);
   }
 }


### PR DESCRIPTION
## Summary

`JsonFileReadError: File changed during read` occurs when `paired.json` is atomically rewritten (temp file + rename) while another component reads it. `verifyStableReadTarget` detects the file changed between stat and open, and throws immediately.

## Fix

Replace the three async JSON read functions in `src/infra/json-files.ts` — `readJson`, `readJsonIfExists`, `tryReadJson` — with bounded retry logic for the transient file-changed race:

### Key design decisions

1. **Cause‑chain walking** — The error from `@openclaw/fs-safe` is `JsonFileReadError` whose message is `"Failed to read JSON file: …"`, while the original `"File changed during read"` error is nested in `err.cause`. The `isFileChangedDuringRead` check recursively follows `err.cause` to detect the true race, unlike the naïve `err.message.includes` approach that would never match.

2. **Bounded retry** — Retry up to 3 attempts with exponential backoff (50 ms → 100 ms). Only retry on `File changed during read` errors — parse errors, ENOENT, and other errors are not retried.

3. **`tryReadJson` re‑routed through `readJsonIfExists`** — The underlying `@openclaw/fs-safe` `tryReadJsonImpl` swallows all errors internally and returns `null`, which prevents the retry wrapper from ever detecting a race. Our `tryReadJson` now delegates to `readJsonIfExists` (which properly propagates errors on race conditions), so the retry wrapper can intercept them. Parse errors and file‑not‑found are still handled gracefully by the outer catch.

4. **Strict reader types preserved** — `readJson<T>` and `readJsonFileStrict<T>` retain `Promise<T>` (not `Promise<T | null>`), maintaining SDK contract compatibility per ClawSweeper's [P2] finding.

## Real behavior proof

- **Behavior or issue addressed:** Gateway startup triggers `JsonFileReadError: Failed to read JSON file: paired.json` when `verifyStableReadTarget` detects the file changed between stat and open (race condition with atomic write). Error propagates as unhandled error in request handler.

- **Real environment tested:** OpenClaw 2026.5.18 (npm install, Oracle VPS, Ubuntu 24.04, Node.js v24.15.0). The paired.json file is rewritten by `openclaw logs --follow` or device pairing operations during gateway startup.

- **Exact steps or command run after this patch:** (1) Backed up the original `dist/json-files-1SmAauRO.js`. (2) Applied the patch with the cause‑chain‑aware retry and `tryReadJson` re‑routing. (3) Verified JS syntax with `node --check`. (4) Ran unit tests — 15/15 passed including new retry-success and retry-exhaustion coverage. (5) The gateway was restarted and has been running without errors for 1.5+ hours.

- **Evidence after fix:**

  **Before (error on every restart with concurrent device operations):**
  ```
  18:43:10+00:00 error [gateway-http] unhandled error in request handler:
    JsonFileReadError: Failed to read JSON file:
      /home/ubuntu/.openclaw/devices/paired.json
    [cause]: Error: File changed during read:
      /home/ubuntu/.openclaw/devices/paired.json
      at verifyStableReadTarget (regular-file-6GdZVPgG.js:152:131)
  ```

  **After (1.5+ hours of runtime — zero JsonFileReadError errors):**
  ```
  # Gateway process (started 2026-05-20 07:53 UTC, 1h28m uptime):
    ubuntu  1338372  node openclaw/dist/index.js gateway --port 18789

  # Dist file confirmed patched:
    $ grep -c 'withRetryOnFileChanged' json-files-1SmAauRO.js
    3

  # Logs — no JsonFileReadError found in any log output
    May 20 08:30:55 node[1338372]: [agent/embedded] incomplete turn detected …
    (normal lifecycle event, not a read error)
  ```

  **Unit tests (15/15 passed, including retry coverage):**
  ```
   ✓ retries on transient File changed during read and succeeds (54ms)
   ✓ throws JsonFileReadError after exhausting retries (159ms)
   ✓ tryReadJson returns null after exhausting retries (164ms)

  Test Files  1 passed (1)
       Tests  15 passed (15)
  ```

- **Observed result after fix:** The `JsonFileReadError: File changed during read` error no longer appears on gateway startup or operation. The cause‑chain‑aware retry mechanism absorbs the transient race condition without propagating to the request handler.

- **What was not tested:** Sync read paths (`readJsonSync`, `tryReadJsonSync`) — less prone to races in practice. Non-Linux platforms (Windows rename semantics differ). Extreme contention (3+ concurrent writes) — retries exhaust after 3 attempts and the original error path activates.

## Related

Fixes #83657