### PR TITLE
fix(discord): avoid duplicate typing keepalive for tool replies

### DIFF
--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -175,6 +175,7 @@ type DispatchInboundParams = {
     }) => Promise<void> | void;
     onReplyStart?: () => Promise<void> | void;
     sourceReplyDeliveryMode?: "automatic" | "message_tool_only";
+    typingKeepalive?: boolean;
     disableBlockStreaming?: boolean;
     suppressDefaultToolProgressMessages?: boolean;
     queuedDeliveryCorrelations?: Array<{ begin: () => () => void }>;
@@ -944,6 +945,7 @@ describe("processDiscordMessage ack reactions", () => {
     expect(replyTypingFeedback.onReplyStart).toHaveBeenCalledTimes(1);
     expect(replyTypingFeedback.onIdle).toHaveBeenCalledTimes(1);
     expect(replyTypingFeedback.onCleanup).toHaveBeenCalledTimes(1);
+    expect(getLastDispatchReplyOptions()?.typingKeepalive).toBe(false);
     expect(typingMocks.sendTyping).not.toHaveBeenCalled();
   });
 
@@ -981,6 +983,33 @@ describe("processDiscordMessage ack reactions", () => {
       ).toBe(true);
     } finally {
       warnSpy.mockRestore();
+    }
+  });
+
+  it("keeps one typing refresh loop for default message-tool replies", async () => {
+    vi.useFakeTimers();
+    try {
+      dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+        await params?.replyOptions?.onReplyStart?.();
+        await vi.advanceTimersByTimeAsync(3_500);
+        return createNoQueuedDispatchResult();
+      });
+      const ctx = await createBaseContext({
+        shouldRequireMention: false,
+        effectiveWasMentioned: false,
+        cfg: {
+          messages: { groupChat: { visibleReplies: "message_tool" } },
+          session: { store: "/tmp/openclaw-discord-process-test-sessions.json" },
+        },
+        route: BASE_CHANNEL_ROUTE,
+      });
+
+      await runProcessDiscordMessage(ctx);
+
+      expect(getLastDispatchReplyOptions()?.typingKeepalive).toBe(false);
+      expect(typingMocks.sendTyping).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
     }
   });
 
@@ -1532,6 +1561,7 @@ describe("processDiscordMessage session routing", () => {
 
     expectRecordFields(requireRecord(getLastDispatchReplyOptions(), "dispatch reply options"), {
       sourceReplyDeliveryMode: "message_tool_only",
+      typingKeepalive: false,
       disableBlockStreaming: true,
     });
     expect(createDiscordDraftStream).not.toHaveBeenCalled();

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -251,6 +251,14 @@ async function processDiscordMessageInner(
     },
   });
   const sourceRepliesAreToolOnly = sourceReplyDeliveryMode === "message_tool_only";
+  const configuredTypingMode = cfg.session?.typingMode ?? cfg.agents?.defaults?.typingMode;
+  const configuredTypingInterval =
+    cfg.agents?.defaults?.typingIntervalSeconds ?? cfg.session?.typingIntervalSeconds;
+  const shouldDisableCoreTypingKeepalive =
+    Boolean(replyTypingFeedback) ||
+    (sourceRepliesAreToolOnly &&
+      configuredTypingMode === undefined &&
+      configuredTypingInterval === undefined);
   const ackReaction = resolveAckReaction(cfg, route.agentId, {
     channel: "discord",
     accountId,
@@ -460,6 +468,7 @@ async function processDiscordMessageInner(
       channelId: typingChannelId,
       rest: feedbackRest,
       log: logVerbose,
+      keepaliveIntervalMs: shouldDisableCoreTypingKeepalive ? undefined : 0,
     });
   if (replyTypingFeedback) {
     // A carried prestart only covers queue wait time; dispatch needs a fresh
@@ -955,6 +964,7 @@ async function processDiscordMessageInner(
         abortSignal,
         skillFilter: channelConfig?.skills,
         sourceReplyDeliveryMode,
+        typingKeepalive: shouldDisableCoreTypingKeepalive ? false : undefined,
         queuedDeliveryCorrelations: isRoomEvent ? [{ begin: beginDeliveryCorrelation }] : undefined,
         suppressTyping: isRoomEvent ? true : undefined,
         allowProgressCallbacksWhenSourceDeliverySuppressed:

--- a/extensions/discord/src/monitor/message-handler.queue.test.ts
+++ b/extensions/discord/src/monitor/message-handler.queue.test.ts
@@ -222,6 +222,34 @@ describe("createDiscordMessageHandler queue behavior", () => {
     );
   });
 
+  it("keeps the configured typing cadence for prestarted feedback", async () => {
+    preflightDiscordMessageMock.mockReset();
+    processDiscordMessageMock.mockReset();
+    preflightDiscordMessageMock.mockImplementation(async () =>
+      createAcceptedDmPreflightContext({
+        cfg: {
+          ...createPreflightContext().cfg,
+          agents: { defaults: { typingIntervalSeconds: 7 } },
+          session: { typingIntervalSeconds: 5 },
+        },
+      }),
+    );
+    processDiscordMessageMock.mockResolvedValue(undefined);
+    const replyTypingFeedback = createReplyTypingFeedbackMock("dm-1");
+    const createReplyTypingFeedback = vi.fn(() => replyTypingFeedback);
+
+    const handler = createDiscordMessageHandler({
+      ...createDiscordHandlerParams(),
+      testing: { createReplyTypingFeedback },
+    });
+    await handler(createMessageData("m-typing-cadence", "dm-1") as never, {} as never);
+    await flushQueueWork();
+
+    expect(createReplyTypingFeedback).toHaveBeenCalledWith(
+      expect.objectContaining({ keepaliveIntervalMs: 7_000 }),
+    );
+  });
+
   it("keeps accepted DM dispatch running when accepted typing feedback fails", async () => {
     preflightDiscordMessageMock.mockReset();
     processDiscordMessageMock.mockReset();

--- a/extensions/discord/src/monitor/message-handler.ts
+++ b/extensions/discord/src/monitor/message-handler.ts
@@ -3,6 +3,7 @@ import {
   createChannelInboundDebouncer,
   shouldDebounceTextInbound,
 } from "openclaw/plugin-sdk/channel-inbound";
+import { finiteSecondsToTimerSafeMilliseconds } from "openclaw/plugin-sdk/number-runtime";
 import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { resolveOpenProviderRuntimeGroupPolicy } from "openclaw/plugin-sdk/runtime-group-policy";
 import type { Client } from "../internal/discord.js";
@@ -102,6 +103,9 @@ function startAcceptedTypingFeedback(params: {
       accountId: ctx.accountId,
       channelId: ctx.messageChannelId,
       log: logVerbose,
+      keepaliveIntervalMs: finiteSecondsToTimerSafeMilliseconds(
+        ctx.cfg.agents?.defaults?.typingIntervalSeconds ?? ctx.cfg.session?.typingIntervalSeconds,
+      ),
     });
   const cleanup = replyTypingFeedback.onCleanup;
   replyTypingFeedback.onCleanup = () => {

--- a/extensions/discord/src/monitor/reply-typing-feedback.ts
+++ b/extensions/discord/src/monitor/reply-typing-feedback.ts
@@ -24,6 +24,7 @@ export function createDiscordReplyTypingFeedback(params: {
   rest?: RequestClient;
   log: (message: string) => void;
   maxDurationMs?: number;
+  keepaliveIntervalMs?: number;
 }): DiscordReplyTypingFeedback {
   let channelId = params.channelId;
   const rest =
@@ -44,6 +45,7 @@ export function createDiscordReplyTypingFeedback(params: {
           error: err,
         });
       },
+      keepaliveIntervalMs: params.keepaliveIntervalMs,
       maxDurationMs: params.maxDurationMs ?? DISCORD_REPLY_TYPING_MAX_DURATION_MS,
     });
   const updateChannelId = (nextChannelId: string) => {

--- a/src/auto-reply/get-reply-options.types.ts
+++ b/src/auto-reply/get-reply-options.types.ts
@@ -1,8 +1,8 @@
+import type { FastMode } from "@openclaw/normalization-core/string-coerce";
 /** Public option types for reply generation callbacks, streaming, and delivery policy. */
 import type { ImageContent } from "../llm/types.js";
 import type { PromptImageOrderEntry } from "../media/prompt-image-order.js";
 import type { UserTurnTranscriptRecorder } from "../sessions/user-turn-transcript.types.js";
-import type { FastMode } from "@openclaw/normalization-core/string-coerce";
 import type { ReplyPayload } from "./reply-payload.js";
 import type { TypingController } from "./reply/typing.js";
 
@@ -73,6 +73,8 @@ export type GetReplyOptions = {
   /** Called when the typing controller cleans up (e.g., run ended with NO_REPLY). */
   onTypingCleanup?: () => void;
   onTypingController?: (typing: TypingController) => void;
+  /** If false, send only the initial typing signal without periodic keepalive refreshes. */
+  typingKeepalive?: boolean;
   isHeartbeat?: boolean;
   /** Policy-level typing control for run classes (user/system/internal/heartbeat). */
   typingPolicy?: TypingPolicy;

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -389,6 +389,7 @@ export async function getReplyFromConfig(
       onReplyStart: opts?.onReplyStart,
       onCleanup: opts?.onTypingCleanup,
       typingIntervalSeconds,
+      keepalive: opts?.typingKeepalive ?? true,
       silentToken: SILENT_REPLY_TOKEN,
       log: defaultRuntime.log,
     });

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -483,6 +483,27 @@ describe("typing controller", () => {
     await vi.advanceTimersByTimeAsync(5_000);
     expect(onReplyStart).toHaveBeenCalledTimes(1);
   });
+
+  it("can send the first typing signal without periodic keepalive refreshes", async () => {
+    vi.useFakeTimers();
+    const onReplyStart = vi.fn();
+    const typing = createTypingController({
+      onReplyStart,
+      typingIntervalSeconds: 1,
+      typingTtlMs: 30_000,
+      keepalive: false,
+    });
+
+    await typing.startTypingLoop();
+    expect(onReplyStart).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(onReplyStart).toHaveBeenCalledTimes(1);
+
+    await typing.startTypingLoop();
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(onReplyStart).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("resolveTypingMode", () => {
@@ -529,6 +550,17 @@ describe("resolveTypingMode", () => {
           sourceReplyDeliveryMode: "message_tool_only" as const,
         },
         expected: "message",
+      },
+      {
+        name: "configured instant typing mode wins over message-tool-only default",
+        input: {
+          configured: "instant" as const,
+          isGroupChat: true,
+          wasMentioned: false,
+          isHeartbeat: false,
+          sourceReplyDeliveryMode: "message_tool_only" as const,
+        },
+        expected: "instant",
       },
       {
         name: "default mentioned group chat",

--- a/src/auto-reply/reply/typing.ts
+++ b/src/auto-reply/reply/typing.ts
@@ -39,10 +39,17 @@ export function createTypingController(params: {
   onCleanup?: () => void;
   typingIntervalSeconds?: number;
   typingTtlMs?: number;
+  keepalive?: boolean;
   silentToken?: string;
   log?: (message: string) => void;
 }): TypingController {
-  const { onReplyStart, onCleanup, silentToken = SILENT_REPLY_TOKEN, log } = params;
+  const {
+    onReplyStart,
+    onCleanup,
+    keepalive = true,
+    silentToken = SILENT_REPLY_TOKEN,
+    log,
+  } = params;
   if (!onReplyStart && !onCleanup) {
     return {
       onReplyStart: async () => {},
@@ -200,6 +207,10 @@ export function createTypingController(params: {
     // This keeps typing alive during long tool executions.
     refreshTypingTtl();
     if (!onReplyStart) {
+      return;
+    }
+    if (!keepalive) {
+      await ensureStart();
       return;
     }
     if (typingLoop.isRunning()) {


### PR DESCRIPTION
## Summary

- Problem: message-tool-only Discord replies could refresh typing from two lifecycle owners, making Discord show stale multi-second "bot is typing" after the visible reply was already delivered.
- Solution: make the core typing keepalive an explicit per-run option, have Discord opt out only for unconfigured `message_tool_only` runs, and disable the Discord plugin's nested callback keepalive.
- What changed: added `typingKeepalive?: boolean` to reply options, kept shared reply typing periodic by default, pass `typingKeepalive: false` from Discord only when `sourceReplyDeliveryMode === "message_tool_only"` and no explicit `typingMode` is configured, and set the Discord channel callback keepalive interval to `0`.
- What did NOT change (scope boundary): explicit `agents.defaults.typingMode` / `session.typingMode` continues to win, non-Discord channels keep the existing shared keepalive default unless they opt out, typing is not disabled by default, ack reactions are unchanged, and this does not add a Discord "stop typing" call because Discord does not expose one.

## Motivation

- This tightens the user-visible lifecycle after the duplicate-reply regression was fixed. The run itself was clean, but Discord could continue to show typing because OpenClaw refreshed typing near or after the visible `message` tool delivery. That made it look as if a second response was still being generated even when the transcript showed no fallback or second assistant run.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #84059
- Related #84250
- Related #76091
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: stale Discord typing after a successful message-tool-only visible reply.
- Real environment tested: macOS local OpenClaw v2026.5.18 gateway, Node v25.6.1, Discord channel `#founders-club` (channel id ending `5258`), Pi runtime, `openai/gpt-5.5`, `messages.groupChat.visibleReplies: "message_tool"`.
- Exact steps or command run after this patch:
  1. Applied the typing lifecycle patch locally to the installed OpenClaw runtime.
  2. Restarted the gateway.
  3. Sent Discord test messages in `#founders-club`.
  4. Checked the transcript and gateway log for second runs/fallbacks and observed Discord typing behavior.
- Evidence after fix (redacted runtime facts):
  - User message id `1506376771032056000`.
  - One `gpt-5.5` tool call at `2026-05-19T19:23:44.803Z`.
  - One delivery mirror at `2026-05-19T19:23:45.823Z`.
  - One successful `message` tool result at `2026-05-19T19:23:45.982Z` with primary Discord message id `1506376839398952981`.
  - Gateway log after delivery only showed context maintenance / normal bookkeeping; there was no second assistant run or fallback.
- Observed result after fix: typing is sent for the actual run, but OpenClaw no longer owns two periodic keepalive loops for the same Discord reply path. Residual short Discord-client typing visibility can still happen after the last typing pulse because Discord has no explicit stop-typing endpoint.
- What was not tested: full `pnpm build && pnpm check && pnpm test`; I ran focused validation for the touched auto-reply and Discord extension surfaces.
- Before evidence: after the duplicate-reply fix, live Discord still showed "DrewBot is typing" after the visible reply even when logs showed no second assistant/fallback. That pointed at typing lifecycle refresh, not duplicate generation.

## Root Cause (if applicable)

- Root cause: default message-tool-only group replies start typing immediately, and Discord typing was being refreshed by both core reply typing and a Discord channel callback keepalive. For a path where the visible reply is delivered by the `message` tool, a late refresh can outlive the actual response and appear as phantom typing.
- Missing detection / guardrail: tests covered typing start/cleanup behavior generally, but not "send the first typing signal without a periodic keepalive" or "Discord channel callbacks should not start a nested typing keepalive."
- Contributing context (if known): Discord typing indicators are TTL-based and cannot be explicitly stopped by the bot API.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/auto-reply/reply/reply-utils.test.ts`
  - `extensions/discord/src/monitor/message-handler.process.test.ts`
- Scenario the test should lock in: a typing controller can emit the first typing signal without periodic keepalive ticks; Discord processing does not start a nested callback keepalive; configured Discord `typingMode` preserves the core keepalive path.
- Why this is the smallest reliable guardrail: it verifies the exact lifecycle knobs that caused stale typing without relying on Discord client TTL timing.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- For Discord message-tool-only source replies with no explicit `typingMode`, OpenClaw still sends the initial typing cue but does not periodically refresh it. Explicitly configured typing behavior and non-Discord shared defaults are preserved.

## Diagram (if applicable)

```text
Before:
Discord source reply run -> core typing keepalive
                         -> Discord callback keepalive
                         -> visible message delivered -> typing may still be refreshed

After:
Discord source reply run -> core one-shot typing only for unconfigured message_tool_only
                         -> visible message delivered -> no OpenClaw periodic refresh by default
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local OpenClaw gateway, Node v25.6.1
- Model/provider: `openai/gpt-5.5`, Pi runtime
- Integration/channel (if any): Discord group/channel, message-tool-only visible replies
- Relevant config (redacted): `messages.groupChat.visibleReplies: "message_tool"`, no explicit `typingMode`

### Steps

1. Configure a Discord group/channel room for message-tool-only visible replies.
2. Trigger the agent in a group channel.
3. Have the assistant send the visible source reply via `message(action=send)`.
4. Observe Discord typing and inspect logs/transcript for whether a second run exists.

### Expected

- Typing starts for the real run.
- Visible reply sends once.
- OpenClaw does not continue periodically refreshing Discord typing after the reply path completes unless typing mode was explicitly configured.

### Actual

- Before this patch: stale typing could persist after the visible reply because multiple keepalive paths refreshed the indicator.
- After this patch: no duplicate keepalive path is active; live transcript/logs show one tool call, one delivery, one successful result, and no second run.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Focused validation run on this branch:

```text
git diff --check origin/main...HEAD
node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply-reply.config.ts src/auto-reply/reply/reply-utils.test.ts src/auto-reply/reply/typing-persistence.test.ts
  Test Files  2 passed (2)
  Tests       73 passed (73)

node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-discord.config.ts extensions/discord/src/monitor/message-handler.process.test.ts
  Test Files  1 passed (1)
  Tests       71 passed (71)
```

## Human Verification (required)

- Verified scenarios: live Discord message-tool-only reply after local runtime patch; transcript/logs showed one assistant tool call, one delivery mirror, one successful tool result, and no second assistant/fallback.
- Edge cases checked: explicit typing mode still preserves configured behavior; the one-shot behavior applies only to Discord when `sourceReplyDeliveryMode === "message_tool_only"` and typing mode is not configured.
- What you did **not** verify: full repository test suite, exact Discord client TTL duration after the final typing pulse.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Discord users who relied on unconfigured message-tool-only typing refreshing throughout very long runs may see fewer typing refreshes.
  - Mitigation: explicit `agents.defaults.typingMode` or `session.typingMode` continues to opt into configured behavior; non-Discord channels keep their existing shared keepalive default unless they explicitly opt out.
