### PR TITLE
fix(pi): keep message-tool delivery in session lock

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts
@@ -2,6 +2,10 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  runWithOwnedSessionTranscriptWriteLock,
+  withOwnedSessionTranscriptWrites,
+} from "../../../config/sessions/transcript-write-context.js";
 import { SessionWriteLockTimeoutError } from "../../session-write-lock-error.js";
 import {
   createEmbeddedAttemptSessionLockController,
@@ -177,6 +181,37 @@ describe("embedded attempt session lock lifecycle", () => {
     await cleanupLock.release();
 
     expect(release).toHaveBeenCalledTimes(2);
+  });
+
+  it("refreshes the prompt fence after an owned transcript mirror append", async () => {
+    const sessionFile = await createTempSessionFile();
+    const release = vi.fn(async () => {});
+    const acquireSessionWriteLock = vi.fn(async () => ({ release }));
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await controller.releaseForPrompt();
+    await withOwnedSessionTranscriptWrites(
+      {
+        sessionFile,
+        sessionKey: "agent:main:discord:channel:123",
+        withSessionWriteLock: (operation) => controller.withSessionWriteLock(operation),
+      },
+      async () =>
+        await runWithOwnedSessionTranscriptWriteLock(
+          { sessionFile, sessionKey: "agent:main:discord:channel:123" },
+          async () => {
+            await fs.appendFile(sessionFile, '{"type":"message","id":"delivery-mirror"}\n', "utf8");
+          },
+        ),
+    );
+    await expect(controller.withSessionWriteLock(() => "finalize")).resolves.toBe("finalize");
+
+    expect(controller.hasSessionTakeover()).toBe(false);
+    expect(acquireSessionWriteLock).toHaveBeenCalledTimes(3);
+    expect(release).toHaveBeenCalledTimes(3);
   });
 
   it("returns a no-op cleanup lock after prompt lock reacquisition times out", async () => {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -15,6 +15,7 @@ import {
   runQuotaSuspensionMaintenance,
   updateSessionStoreEntry,
 } from "../../../config/sessions/store.js";
+import { withOwnedSessionTranscriptWrites } from "../../../config/sessions/transcript-write-context.js";
 import { resolveContextEngineOwnerPluginId } from "../../../context-engine/registry.js";
 import type { AssembleResult } from "../../../context-engine/types.js";
 import { emitTrustedDiagnosticEvent } from "../../../infra/diagnostic-events.js";
@@ -380,6 +381,7 @@ import {
 } from "./incomplete-turn.js";
 import { resolveLlmIdleTimeoutMs, streamWithIdleTimeout } from "./llm-idle-timeout.js";
 import { resolveMessageMergeStrategy } from "./message-merge-strategy.js";
+import { installMessageToolOnlyTerminalHook } from "./message-tool-terminal.js";
 import {
   MID_TURN_PRECHECK_ERROR_MESSAGE,
   isMidTurnPrecheckSignal,
@@ -2379,6 +2381,10 @@ export async function runEmbeddedAttempt(
         session: activeSession,
         withSessionWriteLock: (operation) => sessionLockController.withSessionWriteLock(operation),
       });
+      installMessageToolOnlyTerminalHook({
+        agent: activeSession.agent,
+        sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
+      });
       prepStages.mark("agent-session");
       if (isRawModelRun) {
         // Raw model probes should measure exactly the requested prompt against
@@ -3163,7 +3169,15 @@ export async function runEmbeddedAttempt(
         prompt: string,
         options?: Parameters<typeof activeSession.prompt>[1],
       ): Promise<void> =>
-        abortable(trackPromptSettlePromise(activeSession.prompt(prompt, options)));
+        withOwnedSessionTranscriptWrites(
+          {
+            sessionFile: params.sessionFile,
+            sessionKey: params.sessionKey,
+            withSessionWriteLock: (operation) =>
+              sessionLockController.withSessionWriteLock(operation),
+          },
+          async () => abortable(trackPromptSettlePromise(activeSession.prompt(prompt, options))),
+        );
 
       const subscription = subscribeEmbeddedPiSession(
         buildEmbeddedSubscriptionParams({

--- a/src/agents/pi-embedded-runner/run/message-tool-terminal.test.ts
+++ b/src/agents/pi-embedded-runner/run/message-tool-terminal.test.ts
@@ -1,0 +1,312 @@
+import type { Agent, AfterToolCallContext } from "@earendil-works/pi-agent-core";
+import { describe, expect, it, vi } from "vitest";
+import {
+  installMessageToolOnlyTerminalHook,
+  shouldTerminateAfterMessageToolOnlySend,
+} from "./message-tool-terminal.js";
+
+describe("message-tool-only terminal sends", () => {
+  it("marks successful message-tool-only sends as terminal", () => {
+    expect(
+      shouldTerminateAfterMessageToolOnlySend({
+        sourceReplyDeliveryMode: "message_tool_only",
+        context: createAfterToolCallContext({
+          toolName: "message",
+          args: { action: "send", message: "visible reply" },
+        }),
+      }),
+    ).toBe(true);
+    expect(
+      shouldTerminateAfterMessageToolOnlySend({
+        sourceReplyDeliveryMode: "message_tool_only",
+        context: createAfterToolCallContext({
+          toolName: "message",
+          args: { action: "send", message: "visible reply" },
+          result: createDirectSendResult({ messageId: "discord-message-1" }),
+        }),
+      }),
+    ).toBe(true);
+    expect(
+      shouldTerminateAfterMessageToolOnlySend({
+        sourceReplyDeliveryMode: "message_tool_only",
+        context: createAfterToolCallContext({
+          toolName: "message",
+          args: { action: "send", message: "visible reply" },
+          result: createSuppressedSendResult(),
+        }),
+        hookResult: { details: { result: { messageId: "discord-message-2" } } },
+      }),
+    ).toBe(true);
+  });
+
+  it("does not terminate automatic delivery, non-send actions, explicit routes, or failed sends", () => {
+    expect(
+      shouldTerminateAfterMessageToolOnlySend({
+        sourceReplyDeliveryMode: "automatic",
+        context: createAfterToolCallContext({
+          toolName: "message",
+          args: { action: "send", message: "visible reply" },
+        }),
+      }),
+    ).toBe(false);
+    expect(
+      shouldTerminateAfterMessageToolOnlySend({
+        sourceReplyDeliveryMode: "message_tool_only",
+        context: createAfterToolCallContext({
+          toolName: "message",
+          args: { action: "reaction", emoji: "thumbsup" },
+        }),
+      }),
+    ).toBe(false);
+    expect(
+      shouldTerminateAfterMessageToolOnlySend({
+        sourceReplyDeliveryMode: "message_tool_only",
+        context: createAfterToolCallContext({
+          toolName: "message",
+          args: { action: "send", target: "channel:other", message: "cross-channel" },
+        }),
+      }),
+    ).toBe(false);
+    expect(
+      shouldTerminateAfterMessageToolOnlySend({
+        sourceReplyDeliveryMode: "message_tool_only",
+        context: createAfterToolCallContext({
+          toolName: "sessions_send",
+          args: { message: "internal delegation" },
+        }),
+      }),
+    ).toBe(false);
+    expect(
+      shouldTerminateAfterMessageToolOnlySend({
+        sourceReplyDeliveryMode: "message_tool_only",
+        context: createAfterToolCallContext({
+          toolName: "message",
+          args: { action: "send", message: "failed reply" },
+          isError: true,
+        }),
+      }),
+    ).toBe(false);
+  });
+
+  it("does not terminate dry-run or non-delivered sends", () => {
+    expect(
+      shouldTerminateAfterMessageToolOnlySend({
+        sourceReplyDeliveryMode: "message_tool_only",
+        context: createAfterToolCallContext({
+          toolName: "message",
+          args: { action: "send", message: "preview reply", dryRun: true },
+        }),
+      }),
+    ).toBe(false);
+    expect(
+      shouldTerminateAfterMessageToolOnlySend({
+        sourceReplyDeliveryMode: "message_tool_only",
+        context: createAfterToolCallContext({
+          toolName: "message",
+          args: { action: "send", message: "preview reply" },
+          result: {
+            content: [{ type: "text", text: '{"ok":true}' }],
+            details: {
+              payload: {
+                deliveryStatus: "dry_run",
+                dryRun: true,
+              },
+            },
+          },
+        }),
+      }),
+    ).toBe(false);
+    expect(
+      shouldTerminateAfterMessageToolOnlySend({
+        sourceReplyDeliveryMode: "message_tool_only",
+        context: createAfterToolCallContext({
+          toolName: "message",
+          args: { action: "send", message: "preview reply" },
+        }),
+        hookResult: { details: { deliveryStatus: "dry_run" } },
+      }),
+    ).toBe(false);
+    expect(
+      shouldTerminateAfterMessageToolOnlySend({
+        sourceReplyDeliveryMode: "message_tool_only",
+        context: createAfterToolCallContext({
+          toolName: "message",
+          args: { action: "send", message: "preview reply" },
+          result: {
+            content: [{ type: "text", text: '{"deliveryStatus":"dry_run","dryRun":true}' }],
+            details: { ok: true },
+          },
+        }),
+      }),
+    ).toBe(false);
+  });
+
+  it("does not terminate suppressed sends without delivery evidence", () => {
+    expect(
+      shouldTerminateAfterMessageToolOnlySend({
+        sourceReplyDeliveryMode: "message_tool_only",
+        context: createAfterToolCallContext({
+          toolName: "message",
+          args: { action: "send", message: "suppressed reply" },
+          result: createSuppressedSendResult(),
+        }),
+      }),
+    ).toBe(false);
+  });
+
+  it("preserves existing after-tool-call output while adding the terminal hint", async () => {
+    const previousAfterToolCall = vi.fn(async () => ({
+      content: [{ type: "text" as const, text: "rewritten" }],
+      details: { rewritten: true },
+    }));
+    const agent = { afterToolCall: previousAfterToolCall } as unknown as Agent;
+    installMessageToolOnlyTerminalHook({
+      agent,
+      sourceReplyDeliveryMode: "message_tool_only",
+    });
+
+    await expect(
+      agent.afterToolCall?.(
+        createAfterToolCallContext({
+          toolName: "message",
+          args: { action: "send", message: "visible reply" },
+        }),
+      ),
+    ).resolves.toEqual({
+      content: [{ type: "text", text: "rewritten" }],
+      details: { rewritten: true },
+      terminate: true,
+    });
+    expect(previousAfterToolCall).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves existing after-tool-call output alone when the send failed", async () => {
+    const previousAfterToolCall = vi.fn(async () => ({
+      content: [{ type: "text" as const, text: "failed" }],
+      details: { ok: false },
+      isError: true,
+    }));
+    const agent = { afterToolCall: previousAfterToolCall } as unknown as Agent;
+    installMessageToolOnlyTerminalHook({
+      agent,
+      sourceReplyDeliveryMode: "message_tool_only",
+    });
+
+    await expect(
+      agent.afterToolCall?.(
+        createAfterToolCallContext({
+          toolName: "message",
+          args: { action: "send", message: "failed reply" },
+        }),
+      ),
+    ).resolves.toEqual({
+      content: [{ type: "text", text: "failed" }],
+      details: { ok: false },
+      isError: true,
+    });
+    expect(previousAfterToolCall).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not install a wrapper for non-message-tool-only delivery", async () => {
+    const previousAfterToolCall = vi.fn(async () => ({
+      details: { untouched: true },
+    }));
+    const agent = { afterToolCall: previousAfterToolCall } as unknown as Agent;
+    installMessageToolOnlyTerminalHook({
+      agent,
+      sourceReplyDeliveryMode: "automatic",
+    });
+
+    expect(agent.afterToolCall).toBe(previousAfterToolCall);
+  });
+});
+
+function createAfterToolCallContext(params: {
+  toolName: string;
+  args: Record<string, unknown>;
+  isError?: boolean;
+  result?: AfterToolCallContext["result"];
+}): AfterToolCallContext {
+  return {
+    assistantMessage: createToolCallAssistant(params.toolName, params.args),
+    toolCall: {
+      type: "toolCall",
+      id: "call_message",
+      name: params.toolName,
+      arguments: params.args,
+    },
+    args: params.args,
+    result: params.result ?? {
+      content: [
+        {
+          type: "text",
+          text: '{"status":"ok","deliveryStatus":"sent","sourceReplySink":"internal-ui"}',
+        },
+      ],
+      details: {
+        status: "ok",
+        deliveryStatus: "sent",
+        sourceReplySink: "internal-ui",
+        sourceReply: { text: params.args.message },
+      },
+    },
+    isError: params.isError ?? false,
+    context: {
+      systemPrompt: "",
+      messages: [],
+      tools: [],
+    },
+  };
+}
+
+function createDirectSendResult(params: { messageId: string }): AfterToolCallContext["result"] {
+  const payload = {
+    channel: "discord",
+    to: "channel:source",
+    via: "direct",
+    mediaUrl: null,
+    result: {
+      channel: "discord",
+      messageId: params.messageId,
+    },
+  };
+  return {
+    content: [{ type: "text", text: JSON.stringify(payload) }],
+    details: payload,
+  };
+}
+
+function createSuppressedSendResult(): AfterToolCallContext["result"] {
+  const payload = {
+    channel: "discord",
+    to: "channel:source",
+    via: "direct",
+    mediaUrl: null,
+  };
+  return {
+    content: [{ type: "text", text: JSON.stringify(payload) }],
+    details: payload,
+  };
+}
+
+function createToolCallAssistant(
+  toolName: string,
+  args: Record<string, unknown>,
+): AfterToolCallContext["assistantMessage"] {
+  return {
+    role: "assistant",
+    content: [
+      {
+        type: "toolCall",
+        id: "call_message",
+        name: toolName,
+        arguments: args,
+      },
+    ],
+    api: "openai-responses",
+    provider: "openai",
+    model: "gpt-5.5",
+    stopReason: "toolUse",
+    timestamp: 0,
+  };
+}

--- a/src/agents/pi-embedded-runner/run/message-tool-terminal.ts
+++ b/src/agents/pi-embedded-runner/run/message-tool-terminal.ts
@@ -1,0 +1,211 @@
+import type {
+  AfterToolCallContext,
+  AfterToolCallResult,
+  Agent,
+} from "@earendil-works/pi-agent-core";
+import type { SourceReplyDeliveryMode } from "../../../auto-reply/get-reply-options.types.js";
+import { isMessageToolSendActionName } from "../../pi-embedded-messaging.js";
+import { isToolResultError } from "../../pi-embedded-subscribe.tools.js";
+import { normalizeToolName } from "../../tool-policy.js";
+
+const MESSAGE_TOOL_NAME = "message";
+const EXPLICIT_MESSAGE_ROUTE_KEYS = ["channel", "target", "to", "channelId", "provider"];
+const DRY_RUN_DELIVERY_STATUS = "dry_run";
+const SENT_DELIVERY_STATUS = "sent";
+const RESULT_ENVELOPE_KEYS = [
+  "details",
+  "payload",
+  "result",
+  "results",
+  "sendResult",
+  "toolResult",
+];
+
+function argsRecordForToolCall(context: AfterToolCallContext): Record<string, unknown> {
+  if (context.args && typeof context.args === "object" && !Array.isArray(context.args)) {
+    return context.args as Record<string, unknown>;
+  }
+  const fallbackArgs = context.toolCall.arguments;
+  return fallbackArgs && typeof fallbackArgs === "object" && !Array.isArray(fallbackArgs)
+    ? (fallbackArgs as Record<string, unknown>)
+    : {};
+}
+
+function hasStringValue(value: unknown): boolean {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function hasExplicitMessageRoute(args: Record<string, unknown>): boolean {
+  if (EXPLICIT_MESSAGE_ROUTE_KEYS.some((key) => hasStringValue(args[key]))) {
+    return true;
+  }
+  return Array.isArray(args.targets) && args.targets.some((value) => hasStringValue(value));
+}
+
+function normalizeStatus(value: unknown): string | undefined {
+  return typeof value === "string" ? value.trim().toLowerCase() : undefined;
+}
+
+function parseJsonRecord(value: string): Record<string, unknown> | undefined {
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function recordHasDeliveredMessageId(record: Record<string, unknown>): boolean {
+  if (hasStringValue(record.messageId)) {
+    return true;
+  }
+  const receipt = record.receipt;
+  if (!receipt || typeof receipt !== "object" || Array.isArray(receipt)) {
+    return false;
+  }
+  const receiptRecord = receipt as Record<string, unknown>;
+  return (
+    hasStringValue(receiptRecord.primaryPlatformMessageId) ||
+    (Array.isArray(receiptRecord.platformMessageIds) &&
+      receiptRecord.platformMessageIds.some((value) => hasStringValue(value)))
+  );
+}
+
+function deliveryEnvelopeIndicatesDryRun(value: unknown, depth = 0): boolean {
+  if (!value || typeof value !== "object" || depth > 4) {
+    return false;
+  }
+  if (Array.isArray(value)) {
+    return value.some((item) => deliveryEnvelopeIndicatesDryRun(item, depth + 1));
+  }
+
+  const record = value as Record<string, unknown>;
+  if (
+    record.dryRun === true ||
+    normalizeStatus(record.deliveryStatus) === DRY_RUN_DELIVERY_STATUS
+  ) {
+    return true;
+  }
+
+  const content = record.content;
+  if (Array.isArray(content)) {
+    for (const item of content) {
+      if (deliveryEnvelopeIndicatesDryRun(item, depth + 1)) {
+        return true;
+      }
+      if (item && typeof item === "object" && !Array.isArray(item)) {
+        const text = (item as Record<string, unknown>).text;
+        if (typeof text === "string") {
+          const parsed = parseJsonRecord(text);
+          if (parsed && deliveryEnvelopeIndicatesDryRun(parsed, depth + 1)) {
+            return true;
+          }
+        }
+      }
+    }
+  }
+
+  return RESULT_ENVELOPE_KEYS.some((key) =>
+    deliveryEnvelopeIndicatesDryRun(record[key], depth + 1),
+  );
+}
+
+function deliveryEnvelopeIndicatesDelivered(value: unknown, depth = 0): boolean {
+  if (!value || typeof value !== "object" || depth > 4) {
+    return false;
+  }
+  if (Array.isArray(value)) {
+    return value.some((item) => deliveryEnvelopeIndicatesDelivered(item, depth + 1));
+  }
+
+  const record = value as Record<string, unknown>;
+  if (
+    normalizeStatus(record.deliveryStatus) === SENT_DELIVERY_STATUS ||
+    recordHasDeliveredMessageId(record)
+  ) {
+    return true;
+  }
+
+  const content = record.content;
+  if (Array.isArray(content)) {
+    for (const item of content) {
+      if (deliveryEnvelopeIndicatesDelivered(item, depth + 1)) {
+        return true;
+      }
+      if (item && typeof item === "object" && !Array.isArray(item)) {
+        const text = (item as Record<string, unknown>).text;
+        if (typeof text === "string") {
+          const parsed = parseJsonRecord(text);
+          if (parsed && deliveryEnvelopeIndicatesDelivered(parsed, depth + 1)) {
+            return true;
+          }
+        }
+      }
+    }
+  }
+
+  return RESULT_ENVELOPE_KEYS.some((key) =>
+    deliveryEnvelopeIndicatesDelivered(record[key], depth + 1),
+  );
+}
+
+export function shouldTerminateAfterMessageToolOnlySend(params: {
+  sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
+  context: AfterToolCallContext;
+  hookResult?: AfterToolCallResult;
+}): boolean {
+  if (params.sourceReplyDeliveryMode !== "message_tool_only") {
+    return false;
+  }
+  const toolName = normalizeToolName(params.context.toolCall.name);
+  if (toolName !== MESSAGE_TOOL_NAME) {
+    return false;
+  }
+  const args = argsRecordForToolCall(params.context);
+  if (!isMessageToolSendActionName(args.action) || hasExplicitMessageRoute(args)) {
+    return false;
+  }
+  const isError = params.hookResult?.isError ?? params.context.isError;
+  if (isError || isToolResultError(params.context.result)) {
+    return false;
+  }
+  if (
+    args.dryRun === true ||
+    deliveryEnvelopeIndicatesDryRun(params.context.result) ||
+    deliveryEnvelopeIndicatesDryRun(params.hookResult)
+  ) {
+    return false;
+  }
+  if (
+    !deliveryEnvelopeIndicatesDelivered(params.context.result) &&
+    !deliveryEnvelopeIndicatesDelivered(params.hookResult)
+  ) {
+    return false;
+  }
+  return true;
+}
+
+export function installMessageToolOnlyTerminalHook(params: {
+  agent: Agent;
+  sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
+}): void {
+  if (params.sourceReplyDeliveryMode !== "message_tool_only") {
+    return;
+  }
+  const previousAfterToolCall = params.agent.afterToolCall?.bind(params.agent);
+  params.agent.afterToolCall = async (context, signal) => {
+    const hookResult = await previousAfterToolCall?.(context, signal);
+    if (
+      shouldTerminateAfterMessageToolOnlySend({
+        sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
+        context,
+        hookResult,
+      })
+    ) {
+      return { ...hookResult, terminate: true };
+    }
+    return hookResult;
+  };
+}

--- a/src/config/sessions/transcript-write-context.ts
+++ b/src/config/sessions/transcript-write-context.ts
@@ -1,0 +1,52 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import path from "node:path";
+
+type OwnedSessionTranscriptWriteContext = {
+  sessionFile?: string;
+  sessionKey?: string;
+  withSessionWriteLock: <T>(run: () => Promise<T> | T) => Promise<T>;
+};
+
+const ownedTranscriptWriteContext = new AsyncLocalStorage<OwnedSessionTranscriptWriteContext>();
+
+function normalizePathForCompare(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? path.resolve(trimmed) : undefined;
+}
+
+function contextMatches(params: {
+  context: OwnedSessionTranscriptWriteContext;
+  sessionFile?: string;
+  sessionKey?: string;
+}): boolean {
+  const contextSessionFile = normalizePathForCompare(params.context.sessionFile);
+  const sessionFile = normalizePathForCompare(params.sessionFile);
+  if (contextSessionFile && sessionFile) {
+    return contextSessionFile === sessionFile;
+  }
+
+  const contextSessionKey = params.context.sessionKey?.trim();
+  const sessionKey = params.sessionKey?.trim();
+  return Boolean(contextSessionKey && sessionKey && contextSessionKey === sessionKey);
+}
+
+export async function withOwnedSessionTranscriptWrites<T>(
+  context: OwnedSessionTranscriptWriteContext,
+  run: () => Promise<T>,
+): Promise<T> {
+  return await ownedTranscriptWriteContext.run(context, run);
+}
+
+export async function runWithOwnedSessionTranscriptWriteLock<T>(
+  params: {
+    sessionFile?: string;
+    sessionKey?: string;
+  },
+  run: () => Promise<T> | T,
+): Promise<T> {
+  const context = ownedTranscriptWriteContext.getStore();
+  if (!context || !contextMatches({ context, ...params })) {
+    return await run();
+  }
+  return await context.withSessionWriteLock(run);
+}

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -6,6 +6,7 @@ import type { SessionTranscriptUpdate } from "../../sessions/transcript-events.j
 import { resolveSessionTranscriptPathInDir } from "./paths.js";
 import { useTempSessionsFixture } from "./test-helpers.js";
 import { appendSessionTranscriptMessage } from "./transcript-append.js";
+import { withOwnedSessionTranscriptWrites } from "./transcript-write-context.js";
 import {
   appendAssistantMessageToSessionTranscript,
   appendExactAssistantMessageToSessionTranscript,
@@ -108,6 +109,32 @@ describe("appendAssistantMessageToSessionTranscript", () => {
       expect(messageLine.message.content[0].type).toBe("text");
       expect(messageLine.message.content[0].text).toBe("Hello from delivery mirror!");
     }
+  });
+
+  it("runs matching owned transcript appends through the active session write lock", async () => {
+    writeTranscriptStore();
+    const sessionFile = resolveSessionTranscriptPathInDir(sessionId, fixture.sessionsDir());
+    const events: string[] = [];
+
+    const result = await withOwnedSessionTranscriptWrites(
+      {
+        sessionFile,
+        sessionKey,
+        withSessionWriteLock: async (run) => {
+          events.push("lock");
+          return await run();
+        },
+      },
+      async () =>
+        await appendAssistantMessageToSessionTranscript({
+          sessionKey,
+          text: "Hello under lock",
+          storePath: fixture.storePath(),
+        }),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(events).toEqual(["lock"]);
   });
 
   it("appends to legacy lowercase Signal group session entries", async () => {

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -22,6 +22,7 @@ import {
   streamSessionTranscriptLines,
   streamSessionTranscriptLinesReverse,
 } from "./transcript-stream.js";
+import { runWithOwnedSessionTranscriptWriteLock } from "./transcript-write-context.js";
 import type { SessionEntry } from "./types.js";
 
 let piCodingAgentModulePromise: Promise<typeof import("@earendil-works/pi-coding-agent")> | null =
@@ -313,49 +314,60 @@ export async function appendExactAssistantMessageToSessionTranscript(params: {
     };
   }
 
-  await ensureSessionHeader({ sessionFile, sessionId: entry.sessionId });
+  return await runWithOwnedSessionTranscriptWriteLock(
+    { sessionFile, sessionKey: resolved.normalizedKey },
+    async () => {
+      await ensureSessionHeader({ sessionFile, sessionId: entry.sessionId });
 
-  const explicitIdempotencyKey =
-    params.idempotencyKey ??
-    ((params.message as { idempotencyKey?: unknown }).idempotencyKey as string | undefined);
-  const existingMessageId = explicitIdempotencyKey
-    ? await transcriptHasIdempotencyKey(sessionFile, explicitIdempotencyKey)
-    : undefined;
-  if (existingMessageId) {
-    return {
-      ok: true,
-      sessionFile,
-      messageId: existingMessageId === true ? (explicitIdempotencyKey ?? "") : existingMessageId,
-    };
-  }
+      const explicitIdempotencyKey =
+        params.idempotencyKey ??
+        ((params.message as { idempotencyKey?: unknown }).idempotencyKey as string | undefined);
+      const existingMessageId = explicitIdempotencyKey
+        ? await transcriptHasIdempotencyKey(sessionFile, explicitIdempotencyKey)
+        : undefined;
+      if (existingMessageId) {
+        return {
+          ok: true,
+          sessionFile,
+          messageId:
+            existingMessageId === true ? (explicitIdempotencyKey ?? "") : existingMessageId,
+        };
+      }
 
-  const latestEquivalentAssistantId = isRedundantDeliveryMirror(params.message)
-    ? await findLatestEquivalentAssistantMessageId(sessionFile, params.message, params.config)
-    : undefined;
-  if (latestEquivalentAssistantId) {
-    return { ok: true, sessionFile, messageId: latestEquivalentAssistantId };
-  }
-  const message = {
-    ...params.message,
-    ...(explicitIdempotencyKey ? { idempotencyKey: explicitIdempotencyKey } : {}),
-  } as Parameters<SessionManager["appendMessage"]>[0];
-  const { messageId, message: appendedMessage } = await appendSessionTranscriptMessage({
-    transcriptPath: sessionFile,
-    message,
-    config: params.config,
-  });
+      const latestEquivalentAssistantId = isRedundantDeliveryMirror(params.message)
+        ? await findLatestEquivalentAssistantMessageId(sessionFile, params.message, params.config)
+        : undefined;
+      if (latestEquivalentAssistantId) {
+        return { ok: true, sessionFile, messageId: latestEquivalentAssistantId };
+      }
+      const message = {
+        ...params.message,
+        ...(explicitIdempotencyKey ? { idempotencyKey: explicitIdempotencyKey } : {}),
+      } as Parameters<SessionManager["appendMessage"]>[0];
+      const { messageId, message: appendedMessage } = await appendSessionTranscriptMessage({
+        transcriptPath: sessionFile,
+        message,
+        config: params.config,
+      });
 
-  switch (params.updateMode ?? "inline") {
-    case "inline":
-      emitSessionTranscriptUpdate({ sessionFile, sessionKey, message: appendedMessage, messageId });
-      break;
-    case "file-only":
-      emitSessionTranscriptUpdate({ sessionFile, sessionKey });
-      break;
-    case "none":
-      break;
-  }
-  return { ok: true, sessionFile, messageId };
+      switch (params.updateMode ?? "inline") {
+        case "inline":
+          emitSessionTranscriptUpdate({
+            sessionFile,
+            sessionKey,
+            message: appendedMessage,
+            messageId,
+          });
+          break;
+        case "file-only":
+          emitSessionTranscriptUpdate({ sessionFile, sessionKey });
+          break;
+        case "none":
+          break;
+      }
+      return { ok: true, sessionFile, messageId };
+    },
+  );
 }
 
 async function transcriptHasIdempotencyKey(


### PR DESCRIPTION
## Summary

- Problem: message-tool-only Discord replies could be delivered visibly, then the active Pi attempt treated the delivery-mirror transcript append as an external session takeover and aborted the tool result.
- Solution: route owned transcript appends through the active attempt's session write lock and mark only successful, actually delivered, in-channel `message` sends as terminal for `message_tool_only` source delivery.
- What changed: added an AsyncLocalStorage-owned transcript write context, wrapped Pi prompt execution in that context, locked delivery-mirror transcript appends when they match the active session, and added a narrow terminal hook for successful un-routed `message(action=send)` calls.
- What did NOT change (scope boundary): automatic source delivery, explicit cross-channel `message` sends, `sessions_send`, failed tool calls, dry-run or non-delivered sends, reactions, attachments, and non-send message actions are not made terminal.

## Motivation

- This addresses the duplicate Discord reply / fallback failure observed after upgrading to v2026.5.18 in message-tool-only group rooms. The first `gpt-5.5` attempt successfully sent the visible Discord message, but the local transcript mutation was later observed as an external takeover, causing the tool result to be recorded as aborted and the same input to be retried by fallback (`gpt-5.4`), which produced a second visible reply.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #84059
- Related #84250
- Related #84288
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: duplicate Discord replies and model fallback after a successful `message` tool delivery in `messages.groupChat.visibleReplies: "message_tool"` mode.
- Real environment tested: macOS local OpenClaw v2026.5.18 gateway, Node v25.6.1, Discord channel `#founders-club` (channel id ending `5258`), Pi runtime, `openai/gpt-5.5` primary with `openai/gpt-5.4` fallback.
- Exact steps or command run after this patch:
  1. Applied the patch locally to the installed OpenClaw runtime.
  2. Restarted the gateway.
  3. Sent a Discord reply that triggered DrewBot in `#founders-club`.
  4. Checked the session transcript and gateway log for tool delivery, delivery mirror, tool result, and fallback behavior.
- Evidence after fix (redacted runtime log / transcript facts):
  - User message id `1506371869035462806`.
  - One `gpt-5.5` assistant tool call at `2026-05-19T19:04:15.810Z`.
  - One delivery mirror at `2026-05-19T19:04:16.479Z`.
  - Successful `message` tool result at `2026-05-19T19:04:16.640Z` with primary Discord message id `1506371935221715144`.
  - No subsequent model snapshot, fallback attempt, second assistant message, or second visible Discord reply for that input.
  - Redacted runtime log excerpt from the patched local gateway:
    ```text
    2026-05-19T19:04:15.810Z discord #founders-club userMessageId=1506371869035462806 model=openai/gpt-5.5 tool_call=message action=send sourceReplyDeliveryMode=message_tool_only
    2026-05-19T19:04:16.479Z transcript delivery_mirror appended session=agent:main:discord:channel:...5258 delivery=message_tool
    2026-05-19T19:04:16.640Z tool_result name=message status=ok deliveryStatus=sent discordMessageId=1506371935221715144
    2026-05-19T19:04:16.640Z followup_check userMessageId=1506371869035462806 fallbackReplay=false secondAssistantMessage=false secondDiscordReply=false
    ```
- Observed result after fix: the Discord reply was delivered once, the tool result stayed successful, and the fallback chain did not replay the same user message.
- What was not tested: full `pnpm build && pnpm check && pnpm test`; I ran focused validation for the touched runtime surfaces instead.
- Before evidence:
  - Earlier transcript for the same channel showed `gpt-5.5` delivering a visible `message` tool reply, a delivery mirror, then a repaired `toolResult` with text `aborted`.
  - The next model snapshot switched to fallback `gpt-5.4` and replayed the same user message, producing a second visible Discord reply.

## Root Cause (if applicable)

- Root cause: Pi releases the coarse attempt/session lock while the model prompt is running. During a successful `message` tool send, OpenClaw appends a delivery-mirror assistant message to the same session transcript. That append did not run under the active attempt's session lock, so the attempt's post-prompt fence saw the transcript advance and classified its own delivery mirror as an external takeover.
- Missing detection / guardrail: no regression test covered transcript appends made by owned delivery hooks while an embedded prompt was still active, and message-tool-only source replies did not terminate the attempt after a successful visible in-channel send.
- Contributing context (if known): message-tool-only group delivery suppresses automatic final-text posting, so the `message` tool send is the source reply. Retrying the prompt after a false aborted tool result can visibly send the same turn twice.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts`
  - `src/agents/pi-embedded-runner/run/message-tool-terminal.test.ts`
  - `src/config/sessions/transcript.test.ts`
- Scenario the test should lock in: an owned delivery-mirror append during prompt execution refreshes the active prompt fence instead of causing takeover; successful in-channel `message` sends are terminal only for message-tool-only source delivery; dry-run, suppressed, and no-result sends remain non-terminal unless a result envelope includes positive delivery evidence.
- Why this is the smallest reliable guardrail: it exercises the lock ownership, transcript append, and terminal-send predicates directly without needing a live Discord transport in unit tests.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- In message-tool-only source replies, a successful in-channel `message(action=send)` is treated as the visible reply and ends the source turn instead of allowing fallback/finalization to replay the same input.
- Dry-run, suppressed, and no-result `message` tool sends do not end the turn unless the result envelope includes positive delivery evidence, so they cannot suppress the only visible source reply.

## Diagram (if applicable)

```text
Before:
Discord mention -> gpt-5.5 message tool sends -> delivery mirror appends outside prompt lock
  -> prompt fence sees takeover -> tool result repaired as aborted -> fallback retries -> duplicate reply

After:
Discord mention -> gpt-5.5 message tool sends -> delivery mirror appends under owned prompt lock
  -> delivered-evidence message tool terminates message-tool-only source turn -> one visible reply
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local OpenClaw gateway, Node v25.6.1
- Model/provider: `openai/gpt-5.5` primary, `openai/gpt-5.4` fallback, Pi runtime
- Integration/channel (if any): Discord group/channel, message-tool-only visible replies
- Relevant config (redacted): `messages.groupChat.visibleReplies: "message_tool"`

### Steps

1. Configure a Discord group/channel room for message-tool-only visible replies.
2. Trigger the agent with `openai/gpt-5.5` primary and `openai/gpt-5.4` fallback.
3. Have the assistant send the visible source reply via `message(action=send)`.
4. Inspect the session transcript and gateway log for delivery mirror, tool result status, and fallback attempt.

### Expected

- One visible Discord reply.
- Successful `message` tool result.
- No fallback replay for the same input.
- Dry-run, suppressed, and no-result message sends do not terminate the source turn without positive delivery evidence.

### Actual

- Before this patch: a successful visible reply could be followed by an aborted repaired tool result and fallback replay, causing a duplicate reply.
- After this patch: local runtime test produced one visible reply, a successful tool result, and no fallback replay.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Focused validation run on this branch:

```text
git diff --check origin/main...HEAD
node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-pi-embedded.config.ts src/agents/pi-embedded-runner/run/message-tool-terminal.test.ts src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts
  Test Files  2 passed (2)
  Tests       21 passed (21)

node scripts/run-vitest.mjs run src/config/sessions/transcript.test.ts
  Test Files  1 passed (1)
  Tests       22 passed (22)
```

## Human Verification (required)

- Verified scenarios: live Discord message-tool-only source reply delivered once after local runtime patch; transcript recorded successful tool result; fallback replay did not occur.
- Edge cases checked: automatic delivery is not terminal; failed sends are not terminal; dry-run/non-delivered sends are not terminal; suppressed/no-result sends are not terminal; explicit-route sends are not terminal; `sessions_send` is not terminal; owned transcript writes only take over the active session lock when session file/key matches.
- What you did **not** verify: full repository test suite, non-Discord channels, live explicit cross-channel `message` sends.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: treating a `message` tool send as terminal could suppress intended additional source-turn output.
  - Mitigation: terminal behavior is limited to `sourceReplyDeliveryMode === "message_tool_only"`, successful `message` tool send-like actions, no explicit route keys, and positive delivered evidence such as `deliveryStatus: "sent"` or a delivered `messageId`. Cross-channel sends, `sessions_send`, failed sends, dry-run sends, suppressed/no-result sends, reactions, and non-message-tool-only turns continue normally.
