### PR TITLE
Doctor: expose UI freshness health findings

### DIFF
--- a/src/agents/bash-tools.exec-foreground-failures.test.ts
+++ b/src/agents/bash-tools.exec-foreground-failures.test.ts
@@ -38,6 +38,7 @@ describe("exec foreground failures", () => {
 
     const result = await tool.execute("call-timeout", {
       command: longDelayCmd,
+      host: "gateway",
     });
 
     expect(result.content[0]?.type).toBe("text");

--- a/src/agents/bash-tools.exec-foreground-failures.test.ts
+++ b/src/agents/bash-tools.exec-foreground-failures.test.ts
@@ -1,14 +1,26 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SpawnInput } from "../process/supervisor/index.js";
 import { captureEnv } from "../test-utils/env.js";
 import { resetProcessRegistryForTests } from "./bash-process-registry.js";
 import { createExecTool } from "./bash-tools.exec.js";
 import { resolveShellFromPath } from "./shell-utils.js";
 
+const supervisorMock = vi.hoisted(() => ({
+  spawn: vi.fn(),
+  cancel: vi.fn(),
+  cancelScope: vi.fn(),
+  reconcileOrphans: vi.fn(),
+  getRecord: vi.fn(),
+}));
+
+vi.mock("../process/supervisor/index.js", () => ({
+  getProcessSupervisor: () => supervisorMock,
+}));
+
 const isWin = process.platform === "win32";
 const defaultShell = isWin
   ? undefined
   : process.env.OPENCLAW_TEST_SHELL || resolveShellFromPath("bash") || process.env.SHELL || "sh";
-const longDelayCmd = isWin ? "Start-Sleep -Seconds 60" : "sleep 60";
 
 describe("exec foreground failures", () => {
   let envSnapshot: ReturnType<typeof captureEnv>;
@@ -19,6 +31,11 @@ describe("exec foreground failures", () => {
     if (!isWin && defaultShell) {
       process.env.SHELL = defaultShell;
     }
+    supervisorMock.spawn.mockReset();
+    supervisorMock.cancel.mockReset();
+    supervisorMock.cancelScope.mockReset();
+    supervisorMock.reconcileOrphans.mockReset();
+    supervisorMock.getRecord.mockReset();
     resetProcessRegistryForTests();
   });
 
@@ -35,12 +52,35 @@ describe("exec foreground failures", () => {
       backgroundMs: 10,
       allowBackground: false,
     });
+    supervisorMock.spawn.mockImplementationOnce(async (input: SpawnInput) => ({
+      runId: input.runId ?? "call-timeout",
+      pid: 1234,
+      startedAtMs: Date.now(),
+      stdin: {
+        write: vi.fn(),
+        end: vi.fn(),
+        destroy: vi.fn(),
+      },
+      wait: vi.fn(async () => ({
+        reason: "overall-timeout" as const,
+        exitCode: null,
+        exitSignal: null,
+        durationMs: input.timeoutMs ?? 50,
+        stdout: "",
+        stderr: "",
+        timedOut: true,
+        noOutputTimedOut: false,
+      })),
+      cancel: vi.fn(),
+    }));
 
     const result = await tool.execute("call-timeout", {
-      command: longDelayCmd,
+      command: "echo never-runs",
       host: "gateway",
     });
 
+    expect(supervisorMock.spawn).toHaveBeenCalledOnce();
+    expect((supervisorMock.spawn.mock.calls[0]?.[0] as SpawnInput | undefined)?.timeoutMs).toBe(50);
     expect(result.content[0]?.type).toBe("text");
     expect((result.content[0] as { text?: string }).text).toMatch(/timed out/i);
     expect((result.content[0] as { text?: string }).text).toMatch(/re-run with a higher timeout/i);

--- a/src/agents/bash-tools.exec-foreground-failures.test.ts
+++ b/src/agents/bash-tools.exec-foreground-failures.test.ts
@@ -8,7 +8,7 @@ const isWin = process.platform === "win32";
 const defaultShell = isWin
   ? undefined
   : process.env.OPENCLAW_TEST_SHELL || resolveShellFromPath("bash") || process.env.SHELL || "sh";
-const longDelayCmd = isWin ? "Start-Sleep -Seconds 5" : "sleep 5";
+const longDelayCmd = isWin ? "Start-Sleep -Seconds 60" : "sleep 60";
 
 describe("exec foreground failures", () => {
   let envSnapshot: ReturnType<typeof captureEnv>;

--- a/src/commands/doctor-ui.test.ts
+++ b/src/commands/doctor-ui.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import {
+  uiProtocolFreshnessIssueToHealthFinding,
+  uiProtocolFreshnessIssueToRepairEffects,
+  type UiProtocolFreshnessIssue,
+} from "./doctor-ui.js";
+
+function issue(overrides: Partial<UiProtocolFreshnessIssue> = {}): UiProtocolFreshnessIssue {
+  return {
+    kind: "missing-assets",
+    root: "/repo/openclaw",
+    uiIndexPath: "/repo/openclaw/dist/control-ui/index.html",
+    canBuild: true,
+    ...overrides,
+  } as UiProtocolFreshnessIssue;
+}
+
+describe("UI protocol freshness health mapping", () => {
+  it("maps missing UI assets to a structured finding and dry-run effect", () => {
+    const current = issue();
+
+    expect(uiProtocolFreshnessIssueToHealthFinding(current)).toEqual(
+      expect.objectContaining({
+        checkId: "core/doctor/ui-protocol-freshness",
+        severity: "warning",
+        path: "/repo/openclaw/dist/control-ui/index.html",
+        fixHint: expect.stringContaining("openclaw doctor --fix"),
+      }),
+    );
+    expect(uiProtocolFreshnessIssueToRepairEffects(current)).toEqual([
+      {
+        kind: "process",
+        action: "would-build-control-ui",
+        target: "/repo/openclaw",
+        dryRunSafe: false,
+      },
+    ]);
+  });
+
+  it("maps stale UI assets to rebuild effects without file diffs", () => {
+    const current = issue({
+      kind: "stale-assets",
+      changesSinceBuild: ["abc123 schema change"],
+    });
+
+    expect(uiProtocolFreshnessIssueToHealthFinding(current).message).toContain(
+      "abc123 schema change",
+    );
+    expect(uiProtocolFreshnessIssueToRepairEffects(current)).toEqual([
+      {
+        kind: "process",
+        action: "would-rebuild-control-ui",
+        target: "/repo/openclaw",
+        dryRunSafe: false,
+      },
+    ]);
+  });
+
+  it("does not report dry-run effects when UI sources are unavailable", () => {
+    expect(uiProtocolFreshnessIssueToRepairEffects(issue({ canBuild: false }))).toEqual([]);
+  });
+});

--- a/src/commands/doctor-ui.test.ts
+++ b/src/commands/doctor-ui.test.ts
@@ -25,8 +25,8 @@ async function createOpenClawRoot(): Promise<string> {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-doctor-ui-"));
   tempRoots.push(root);
   await fs.writeFile(path.join(root, "package.json"), JSON.stringify({ name: "openclaw" }));
-  await fs.mkdir(path.join(root, "src/gateway/protocol"), { recursive: true });
-  await fs.writeFile(path.join(root, "src/gateway/protocol/schema.ts"), "export {};\n");
+  await fs.mkdir(path.join(root, "packages/gateway-protocol/src"), { recursive: true });
+  await fs.writeFile(path.join(root, "packages/gateway-protocol/src/schema.ts"), "export {};\n");
   return root;
 }
 
@@ -89,7 +89,7 @@ describe("UI protocol freshness health mapping", () => {
 
   it("does not report stale assets when git finds no schema changes", async () => {
     const root = await createOpenClawRoot();
-    const schemaPath = path.join(root, "src/gateway/protocol/schema.ts");
+    const schemaPath = path.join(root, "packages/gateway-protocol/src/schema.ts");
     const uiIndexPath = path.join(root, "dist/control-ui/index.html");
     await touch(uiIndexPath, new Date("2026-01-01T00:00:00.000Z"));
     await touch(schemaPath, new Date("2026-01-02T00:00:00.000Z"));
@@ -106,7 +106,7 @@ describe("UI protocol freshness health mapping", () => {
 
   it("reports stale assets when git history is unavailable", async () => {
     const root = await createOpenClawRoot();
-    const schemaPath = path.join(root, "src/gateway/protocol/schema.ts");
+    const schemaPath = path.join(root, "packages/gateway-protocol/src/schema.ts");
     const uiIndexPath = path.join(root, "dist/control-ui/index.html");
     await touch(uiIndexPath, new Date("2026-01-01T00:00:00.000Z"));
     await touch(schemaPath, new Date("2026-01-02T00:00:00.000Z"));

--- a/src/commands/doctor-ui.test.ts
+++ b/src/commands/doctor-ui.test.ts
@@ -1,9 +1,15 @@
-import { describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
 import {
+  detectUiProtocolFreshnessIssues,
   uiProtocolFreshnessIssueToHealthFinding,
   uiProtocolFreshnessIssueToRepairEffects,
   type UiProtocolFreshnessIssue,
 } from "./doctor-ui.js";
+
+const tempRoots: string[] = [];
 
 function issue(overrides: Partial<UiProtocolFreshnessIssue> = {}): UiProtocolFreshnessIssue {
   return {
@@ -15,7 +21,28 @@ function issue(overrides: Partial<UiProtocolFreshnessIssue> = {}): UiProtocolFre
   } as UiProtocolFreshnessIssue;
 }
 
+async function createOpenClawRoot(): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-doctor-ui-"));
+  tempRoots.push(root);
+  await fs.writeFile(path.join(root, "package.json"), JSON.stringify({ name: "openclaw" }));
+  await fs.mkdir(path.join(root, "src/gateway/protocol"), { recursive: true });
+  await fs.writeFile(path.join(root, "src/gateway/protocol/schema.ts"), "export {};\n");
+  return root;
+}
+
+async function touch(filePath: string, date: Date): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, "");
+  await fs.utimes(filePath, date, date);
+}
+
 describe("UI protocol freshness health mapping", () => {
+  afterEach(async () => {
+    await Promise.all(
+      tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })),
+    );
+  });
+
   it("maps missing UI assets to a structured finding and dry-run effect", () => {
     const current = issue();
 
@@ -58,5 +85,30 @@ describe("UI protocol freshness health mapping", () => {
 
   it("does not report dry-run effects when UI sources are unavailable", () => {
     expect(uiProtocolFreshnessIssueToRepairEffects(issue({ canBuild: false }))).toEqual([]);
+  });
+
+  it("reports stale assets even when git history is unavailable", async () => {
+    const root = await createOpenClawRoot();
+    const schemaPath = path.join(root, "src/gateway/protocol/schema.ts");
+    const uiIndexPath = path.join(root, "dist/control-ui/index.html");
+    await touch(uiIndexPath, new Date("2026-01-01T00:00:00.000Z"));
+    await touch(schemaPath, new Date("2026-01-02T00:00:00.000Z"));
+
+    await expect(
+      detectUiProtocolFreshnessIssues({
+        root,
+        async collectChangesSinceBuild() {
+          return [];
+        },
+      }),
+    ).resolves.toEqual([
+      {
+        kind: "stale-assets",
+        root,
+        uiIndexPath,
+        changesSinceBuild: [],
+        canBuild: false,
+      },
+    ]);
   });
 });

--- a/src/commands/doctor-ui.test.ts
+++ b/src/commands/doctor-ui.test.ts
@@ -69,10 +69,10 @@ describe("UI protocol freshness health mapping", () => {
       kind: "stale-assets",
       changesSinceBuild: ["abc123 schema change"],
     });
+    const finding = uiProtocolFreshnessIssueToHealthFinding(current);
 
-    expect(uiProtocolFreshnessIssueToHealthFinding(current).message).toContain(
-      "abc123 schema change",
-    );
+    expect(finding.message).toContain("abc123 schema change");
+    expect(finding.fixHint).toContain("openclaw doctor --fix --force");
     expect(uiProtocolFreshnessIssueToRepairEffects(current)).toEqual([
       {
         kind: "process",

--- a/src/commands/doctor-ui.test.ts
+++ b/src/commands/doctor-ui.test.ts
@@ -87,7 +87,7 @@ describe("UI protocol freshness health mapping", () => {
     expect(uiProtocolFreshnessIssueToRepairEffects(issue({ canBuild: false }))).toEqual([]);
   });
 
-  it("reports stale assets even when git history is unavailable", async () => {
+  it("does not report stale assets when git finds no schema changes", async () => {
     const root = await createOpenClawRoot();
     const schemaPath = path.join(root, "src/gateway/protocol/schema.ts");
     const uiIndexPath = path.join(root, "dist/control-ui/index.html");
@@ -99,6 +99,23 @@ describe("UI protocol freshness health mapping", () => {
         root,
         async collectChangesSinceBuild() {
           return [];
+        },
+      }),
+    ).resolves.toEqual([]);
+  });
+
+  it("reports stale assets when git history is unavailable", async () => {
+    const root = await createOpenClawRoot();
+    const schemaPath = path.join(root, "src/gateway/protocol/schema.ts");
+    const uiIndexPath = path.join(root, "dist/control-ui/index.html");
+    await touch(uiIndexPath, new Date("2026-01-01T00:00:00.000Z"));
+    await touch(schemaPath, new Date("2026-01-02T00:00:00.000Z"));
+
+    await expect(
+      detectUiProtocolFreshnessIssues({
+        root,
+        async collectChangesSinceBuild() {
+          return null;
         },
       }),
     ).resolves.toEqual([

--- a/src/commands/doctor-ui.test.ts
+++ b/src/commands/doctor-ui.test.ts
@@ -104,7 +104,7 @@ describe("UI protocol freshness health mapping", () => {
     ).resolves.toEqual([]);
   });
 
-  it("reports stale assets when git history is unavailable", async () => {
+  it("does not report stale assets when git history is unavailable", async () => {
     const root = await createOpenClawRoot();
     const schemaPath = path.join(root, "packages/gateway-protocol/src/schema.ts");
     const uiIndexPath = path.join(root, "dist/control-ui/index.html");
@@ -118,14 +118,6 @@ describe("UI protocol freshness health mapping", () => {
           return null;
         },
       }),
-    ).resolves.toEqual([
-      {
-        kind: "stale-assets",
-        root,
-        uiIndexPath,
-        changesSinceBuild: [],
-        canBuild: false,
-      },
-    ]);
+    ).resolves.toEqual([]);
   });
 });

--- a/src/commands/doctor-ui.ts
+++ b/src/commands/doctor-ui.ts
@@ -26,14 +26,21 @@ export type UiProtocolFreshnessIssue =
       readonly canBuild: boolean;
     };
 
-export async function detectUiProtocolFreshnessIssues(): Promise<
-  readonly UiProtocolFreshnessIssue[]
-> {
-  const root = await resolveOpenClawPackageRoot({
-    moduleUrl: import.meta.url,
-    argv1: process.argv[1],
-    cwd: process.cwd(),
-  });
+export async function detectUiProtocolFreshnessIssues(
+  opts: {
+    readonly root?: string;
+    readonly argv1?: string;
+    readonly cwd?: string;
+    readonly collectChangesSinceBuild?: (root: string, uiMtime: Date) => Promise<readonly string[]>;
+  } = {},
+): Promise<readonly UiProtocolFreshnessIssue[]> {
+  const root =
+    opts.root ??
+    (await resolveOpenClawPackageRoot({
+      moduleUrl: import.meta.url,
+      argv1: opts.argv1 ?? process.argv[1],
+      cwd: opts.cwd ?? process.cwd(),
+    }));
   if (!root) {
     return [];
   }
@@ -41,7 +48,7 @@ export async function detectUiProtocolFreshnessIssues(): Promise<
   const schemaPath = path.join(root, "packages/gateway-protocol/src/schema.ts");
   const uiHealth = await resolveControlUiDistIndexHealth({
     root,
-    argv1: process.argv[1],
+    argv1: opts.argv1 ?? process.argv[1],
   });
   const uiIndexPath = uiHealth.indexPath ?? resolveControlUiDistIndexPathForRoot(root);
   const uiSourcesPath = path.join(root, "ui/package.json");
@@ -62,33 +69,44 @@ export async function detectUiProtocolFreshnessIssues(): Promise<
     if (schemaStats.mtime <= uiStats.mtime) {
       return [];
     }
-    const gitLog = await runCommandWithTimeout(
-      [
-        "git",
-        "-C",
-        root,
-        "log",
-        `--since=${uiStats.mtime.toISOString()}`,
-        "--format=%h %s",
-        "packages/gateway-protocol/src/schema.ts",
-      ],
-      { timeoutMs: 5000 },
-    ).catch(() => null);
-    if (!gitLog || gitLog.code !== 0 || !gitLog.stdout.trim()) {
-      return [];
-    }
+    const changesSinceBuild = await (
+      opts.collectChangesSinceBuild ?? collectProtocolSchemaChangesSince
+    )(root, uiStats.mtime);
+
     return [
       {
         kind: "stale-assets",
         root,
         uiIndexPath,
-        changesSinceBuild: gitLog.stdout.trim().split("\n"),
+        changesSinceBuild,
         canBuild,
       },
     ];
   } catch {
     return [];
   }
+}
+
+async function collectProtocolSchemaChangesSince(
+  root: string,
+  uiMtime: Date,
+): Promise<readonly string[]> {
+  const gitLog = await runCommandWithTimeout(
+    [
+      "git",
+      "-C",
+      root,
+      "log",
+      `--since=${uiMtime.toISOString()}`,
+      "--format=%h %s",
+      "packages/gateway-protocol/src/schema.ts",
+    ],
+    { timeoutMs: 5000 },
+  ).catch(() => null);
+  if (!gitLog || gitLog.code !== 0 || !gitLog.stdout.trim()) {
+    return [];
+  }
+  return gitLog.stdout.trim().split("\n");
 }
 
 export function uiProtocolFreshnessIssueToHealthFinding(
@@ -125,6 +143,9 @@ export function uiProtocolFreshnessIssueToRepairEffects(
 function formatUiProtocolFreshnessIssue(issue: UiProtocolFreshnessIssue): string {
   if (issue.kind === "missing-assets") {
     return ["- Control UI assets are missing.", "- Run: pnpm ui:build"].join("\n");
+  }
+  if (issue.changesSinceBuild.length === 0) {
+    return "UI assets are older than the protocol schema.";
   }
   return `UI assets are older than the protocol schema.\nFunctional changes since last build:\n${issue.changesSinceBuild
     .map((line) => `- ${line}`)

--- a/src/commands/doctor-ui.ts
+++ b/src/commands/doctor-ui.ts
@@ -75,7 +75,7 @@ export async function detectUiProtocolFreshnessIssues(
     const changesSinceBuild = await (
       opts.collectChangesSinceBuild ?? collectProtocolSchemaChangesSince
     )(root, uiStats.mtime);
-    if (changesSinceBuild !== null && changesSinceBuild.length === 0) {
+    if (changesSinceBuild === null || changesSinceBuild.length === 0) {
       return [];
     }
     return [
@@ -83,7 +83,7 @@ export async function detectUiProtocolFreshnessIssues(
         kind: "stale-assets",
         root,
         uiIndexPath,
-        changesSinceBuild: changesSinceBuild ?? [],
+        changesSinceBuild,
         canBuild,
       },
     ];

--- a/src/commands/doctor-ui.ts
+++ b/src/commands/doctor-ui.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { note } from "../../packages/terminal-core/src/note.js";
+import type { HealthFinding, HealthRepairEffect } from "../flows/health-checks.js";
 import {
   resolveControlUiDistIndexHealth,
   resolveControlUiDistIndexPathForRoot,
@@ -10,18 +11,31 @@ import { runCommandWithTimeout } from "../process/exec.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { DoctorPrompter } from "./doctor-prompter.js";
 
-export async function maybeRepairUiProtocolFreshness(
-  _runtime: RuntimeEnv,
-  prompter: DoctorPrompter,
-) {
+export type UiProtocolFreshnessIssue =
+  | {
+      readonly kind: "missing-assets";
+      readonly root: string;
+      readonly uiIndexPath: string;
+      readonly canBuild: boolean;
+    }
+  | {
+      readonly kind: "stale-assets";
+      readonly root: string;
+      readonly uiIndexPath: string;
+      readonly changesSinceBuild: readonly string[];
+      readonly canBuild: boolean;
+    };
+
+export async function detectUiProtocolFreshnessIssues(): Promise<
+  readonly UiProtocolFreshnessIssue[]
+> {
   const root = await resolveOpenClawPackageRoot({
     moduleUrl: import.meta.url,
     argv1: process.argv[1],
     cwd: process.cwd(),
   });
-
   if (!root) {
-    return;
+    return [];
   }
 
   const schemaPath = path.join(root, "packages/gateway-protocol/src/schema.ts");
@@ -30,35 +44,113 @@ export async function maybeRepairUiProtocolFreshness(
     argv1: process.argv[1],
   });
   const uiIndexPath = uiHealth.indexPath ?? resolveControlUiDistIndexPathForRoot(root);
+  const uiSourcesPath = path.join(root, "ui/package.json");
 
   try {
-    const [schemaStats, uiStats] = await Promise.all([
+    const [schemaStats, uiStats, uiSourcesStats] = await Promise.all([
       fs.stat(schemaPath).catch(() => null),
       fs.stat(uiIndexPath).catch(() => null),
+      fs.stat(uiSourcesPath).catch(() => null),
     ]);
+    if (!schemaStats) {
+      return [];
+    }
+    const canBuild = uiSourcesStats !== null;
+    if (!uiStats) {
+      return [{ kind: "missing-assets", root, uiIndexPath, canBuild }];
+    }
+    if (schemaStats.mtime <= uiStats.mtime) {
+      return [];
+    }
+    const gitLog = await runCommandWithTimeout(
+      [
+        "git",
+        "-C",
+        root,
+        "log",
+        `--since=${uiStats.mtime.toISOString()}`,
+        "--format=%h %s",
+        "packages/gateway-protocol/src/schema.ts",
+      ],
+      { timeoutMs: 5000 },
+    ).catch(() => null);
+    if (!gitLog || gitLog.code !== 0 || !gitLog.stdout.trim()) {
+      return [];
+    }
+    return [
+      {
+        kind: "stale-assets",
+        root,
+        uiIndexPath,
+        changesSinceBuild: gitLog.stdout.trim().split("\n"),
+        canBuild,
+      },
+    ];
+  } catch {
+    return [];
+  }
+}
 
-    if (schemaStats && !uiStats) {
-      note(["- Control UI assets are missing.", "- Run: pnpm ui:build"].join("\n"), "UI");
+export function uiProtocolFreshnessIssueToHealthFinding(
+  issue: UiProtocolFreshnessIssue,
+): HealthFinding {
+  return {
+    checkId: "core/doctor/ui-protocol-freshness",
+    severity: "warning",
+    message: formatUiProtocolFreshnessIssue(issue),
+    path: issue.uiIndexPath,
+    fixHint: issue.canBuild
+      ? "Run `openclaw doctor --fix` to build Control UI assets."
+      : "Install from a source checkout with ui/ sources, then run `pnpm ui:build`.",
+  };
+}
 
-      // In slim/docker environments we may not have the UI source tree. Trying
-      // to build would fail (and spam logs), so skip the interactive repair.
-      const uiSourcesPath = path.join(root, "ui/package.json");
-      const uiSourcesExist = await fs.stat(uiSourcesPath).catch(() => null);
-      if (!uiSourcesExist) {
+export function uiProtocolFreshnessIssueToRepairEffects(
+  issue: UiProtocolFreshnessIssue,
+): readonly HealthRepairEffect[] {
+  if (!issue.canBuild) {
+    return [];
+  }
+  return [
+    {
+      kind: "process",
+      action:
+        issue.kind === "missing-assets" ? "would-build-control-ui" : "would-rebuild-control-ui",
+      target: issue.root,
+      dryRunSafe: false,
+    },
+  ];
+}
+
+function formatUiProtocolFreshnessIssue(issue: UiProtocolFreshnessIssue): string {
+  if (issue.kind === "missing-assets") {
+    return ["- Control UI assets are missing.", "- Run: pnpm ui:build"].join("\n");
+  }
+  return `UI assets are older than the protocol schema.\nFunctional changes since last build:\n${issue.changesSinceBuild
+    .map((line) => `- ${line}`)
+    .join("\n")}`;
+}
+
+export async function maybeRepairUiProtocolFreshness(
+  _runtime: RuntimeEnv,
+  prompter: DoctorPrompter,
+) {
+  for (const issue of await detectUiProtocolFreshnessIssues()) {
+    if (issue.kind === "missing-assets") {
+      note(formatUiProtocolFreshnessIssue(issue), "UI");
+      if (!issue.canBuild) {
         note("Skipping UI build: ui/ sources not present.", "UI");
-        return;
+        continue;
       }
-
       const shouldRepair = await prompter.confirmAutoFix({
         message: "Build Control UI assets now?",
         initialValue: true,
       });
-
       if (shouldRepair) {
         note("Building Control UI assets... (this may take a moment)", "UI");
-        const uiScriptPath = path.join(root, "scripts/ui.js");
+        const uiScriptPath = path.join(issue.root, "scripts/ui.js");
         const buildResult = await runCommandWithTimeout([process.execPath, uiScriptPath, "build"], {
-          cwd: root,
+          cwd: issue.root,
           timeoutMs: 120_000,
           env: { ...process.env, FORCE_COLOR: "1" },
         });
@@ -74,81 +166,37 @@ export async function maybeRepairUiProtocolFreshness(
           note(details, "UI");
         }
       }
-      return;
+      continue;
     }
 
-    if (!schemaStats || !uiStats) {
-      return;
-    }
-
-    if (schemaStats.mtime > uiStats.mtime) {
-      const uiMtimeIso = uiStats.mtime.toISOString();
-      // Find changes since the UI build
-      const gitLog = await runCommandWithTimeout(
-        [
-          "git",
-          "-C",
-          root,
-          "log",
-          `--since=${uiMtimeIso}`,
-          "--format=%h %s",
-          "packages/gateway-protocol/src/schema.ts",
-        ],
-        { timeoutMs: 5000 },
-      ).catch(() => null);
-
-      if (gitLog && gitLog.code === 0 && gitLog.stdout.trim()) {
-        note(
-          `UI assets are older than the protocol schema.\nFunctional changes since last build:\n${gitLog.stdout
-            .trim()
-            .split("\n")
-            .map((l) => `- ${l}`)
-            .join("\n")}`,
-          "UI Freshness",
-        );
-
-        const shouldRepair = await prompter.confirmAggressiveAutoFix({
-          message: "Rebuild UI now? (Detected protocol mismatch requiring update)",
-          initialValue: true,
-        });
-
-        if (shouldRepair) {
-          const uiSourcesPath = path.join(root, "ui/package.json");
-          const uiSourcesExist = await fs.stat(uiSourcesPath).catch(() => null);
-          if (!uiSourcesExist) {
-            note("Skipping UI rebuild: ui/ sources not present.", "UI");
-            return;
-          }
-
-          note("Rebuilding stale UI assets... (this may take a moment)", "UI");
-          // Use scripts/ui.js to build, assuming node is available as we are running in it.
-          // We use the same node executable to run the script.
-          const uiScriptPath = path.join(root, "scripts/ui.js");
-          const buildResult = await runCommandWithTimeout(
-            [process.execPath, uiScriptPath, "build"],
-            {
-              cwd: root,
-              timeoutMs: 120_000,
-              env: { ...process.env, FORCE_COLOR: "1" },
-            },
-          );
-          if (buildResult.code === 0) {
-            note("UI rebuild complete.", "UI");
-          } else {
-            const details = [
-              `UI rebuild failed (exit ${buildResult.code ?? "unknown"}).`,
-              buildResult.stderr.trim() ? buildResult.stderr.trim() : null,
-            ]
-              .filter(Boolean)
-              .join("\n");
-            note(details, "UI");
-          }
-        }
+    note(formatUiProtocolFreshnessIssue(issue), "UI Freshness");
+    const shouldRepair = await prompter.confirmAggressiveAutoFix({
+      message: "Rebuild UI now? (Detected protocol mismatch requiring update)",
+      initialValue: true,
+    });
+    if (shouldRepair) {
+      if (!issue.canBuild) {
+        note("Skipping UI rebuild: ui/ sources not present.", "UI");
+        continue;
+      }
+      note("Rebuilding stale UI assets... (this may take a moment)", "UI");
+      const uiScriptPath = path.join(issue.root, "scripts/ui.js");
+      const buildResult = await runCommandWithTimeout([process.execPath, uiScriptPath, "build"], {
+        cwd: issue.root,
+        timeoutMs: 120_000,
+        env: { ...process.env, FORCE_COLOR: "1" },
+      });
+      if (buildResult.code === 0) {
+        note("UI rebuild complete.", "UI");
+      } else {
+        const details = [
+          `UI rebuild failed (exit ${buildResult.code ?? "unknown"}).`,
+          buildResult.stderr.trim() ? buildResult.stderr.trim() : null,
+        ]
+          .filter(Boolean)
+          .join("\n");
+        note(details, "UI");
       }
     }
-  } catch {
-    // If files don't exist, we can't check.
-    // If git fails, we silently skip.
-    // runtime.debug(`UI freshness check failed: ${String(err)}`);
   }
 }

--- a/src/commands/doctor-ui.ts
+++ b/src/commands/doctor-ui.ts
@@ -31,7 +31,10 @@ export async function detectUiProtocolFreshnessIssues(
     readonly root?: string;
     readonly argv1?: string;
     readonly cwd?: string;
-    readonly collectChangesSinceBuild?: (root: string, uiMtime: Date) => Promise<readonly string[]>;
+    readonly collectChangesSinceBuild?: (
+      root: string,
+      uiMtime: Date,
+    ) => Promise<readonly string[] | null>;
   } = {},
 ): Promise<readonly UiProtocolFreshnessIssue[]> {
   const root =
@@ -72,13 +75,15 @@ export async function detectUiProtocolFreshnessIssues(
     const changesSinceBuild = await (
       opts.collectChangesSinceBuild ?? collectProtocolSchemaChangesSince
     )(root, uiStats.mtime);
-
+    if (changesSinceBuild !== null && changesSinceBuild.length === 0) {
+      return [];
+    }
     return [
       {
         kind: "stale-assets",
         root,
         uiIndexPath,
-        changesSinceBuild,
+        changesSinceBuild: changesSinceBuild ?? [],
         canBuild,
       },
     ];
@@ -90,7 +95,7 @@ export async function detectUiProtocolFreshnessIssues(
 async function collectProtocolSchemaChangesSince(
   root: string,
   uiMtime: Date,
-): Promise<readonly string[]> {
+): Promise<readonly string[] | null> {
   const gitLog = await runCommandWithTimeout(
     [
       "git",
@@ -103,7 +108,10 @@ async function collectProtocolSchemaChangesSince(
     ],
     { timeoutMs: 5000 },
   ).catch(() => null);
-  if (!gitLog || gitLog.code !== 0 || !gitLog.stdout.trim()) {
+  if (!gitLog || gitLog.code !== 0) {
+    return null;
+  }
+  if (!gitLog.stdout.trim()) {
     return [];
   }
   return gitLog.stdout.trim().split("\n");
@@ -191,15 +199,15 @@ export async function maybeRepairUiProtocolFreshness(
     }
 
     note(formatUiProtocolFreshnessIssue(issue), "UI Freshness");
+    if (!issue.canBuild) {
+      note("Skipping UI rebuild: ui/ sources not present.", "UI");
+      continue;
+    }
     const shouldRepair = await prompter.confirmAggressiveAutoFix({
       message: "Rebuild UI now? (Detected protocol mismatch requiring update)",
       initialValue: true,
     });
     if (shouldRepair) {
-      if (!issue.canBuild) {
-        note("Skipping UI rebuild: ui/ sources not present.", "UI");
-        continue;
-      }
       note("Rebuilding stale UI assets... (this may take a moment)", "UI");
       const uiScriptPath = path.join(issue.root, "scripts/ui.js");
       const buildResult = await runCommandWithTimeout([process.execPath, uiScriptPath, "build"], {

--- a/src/commands/doctor-ui.ts
+++ b/src/commands/doctor-ui.ts
@@ -126,7 +126,9 @@ export function uiProtocolFreshnessIssueToHealthFinding(
     message: formatUiProtocolFreshnessIssue(issue),
     path: issue.uiIndexPath,
     fixHint: issue.canBuild
-      ? "Run `openclaw doctor --fix` to build Control UI assets."
+      ? issue.kind === "missing-assets"
+        ? "Run `openclaw doctor --fix` to build Control UI assets."
+        : "Run `openclaw doctor --fix --force` to rebuild Control UI assets, or run `pnpm ui:build`."
       : "Install from a source checkout with ui/ sources, then run `pnpm ui:build`.",
   };
 }

--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -13,6 +13,11 @@ import {
   shellCompletionStatusToRepairEffects,
 } from "../commands/doctor-completion.js";
 import { disableUnavailableSkillsInConfig } from "../commands/doctor-skills-core.js";
+import {
+  detectUiProtocolFreshnessIssues,
+  uiProtocolFreshnessIssueToHealthFinding,
+  uiProtocolFreshnessIssueToRepairEffects,
+} from "../commands/doctor-ui.js";
 import type { ConfigValidationIssue, OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveSecretInputRef, type SecretRef } from "../config/types.secrets.js";
 import { hasAmbiguousGatewayAuthModeConfig } from "../gateway/auth-mode-policy.js";
@@ -832,6 +837,30 @@ const shellCompletionCheck: HealthCheck = {
   },
 };
 
+const uiProtocolFreshnessCheck: HealthCheck = {
+  id: "core/doctor/ui-protocol-freshness",
+  kind: "core",
+  description: "Control UI assets are present and current with the Gateway protocol schema.",
+  source: "doctor",
+  async detect() {
+    return (await detectUiProtocolFreshnessIssues()).map(uiProtocolFreshnessIssueToHealthFinding);
+  },
+  async repair(ctx) {
+    const effects = (await detectUiProtocolFreshnessIssues()).flatMap(
+      uiProtocolFreshnessIssueToRepairEffects,
+    );
+    if (ctx.dryRun === true) {
+      return { status: "repaired", changes: [], effects };
+    }
+    return {
+      status: "skipped",
+      reason: "legacy doctor UI freshness repair owns real mutations",
+      changes: [],
+      effects,
+    };
+  },
+};
+
 function createWorkspaceSuggestionsCheck(deps: CoreHealthCheckDeps): HealthCheck {
   return {
     id: "core/doctor/workspace-suggestions",
@@ -860,6 +889,7 @@ function createConvertedWorkflowChecks(deps: CoreHealthCheckDeps): readonly Heal
     legacyStateCheck,
     legacyWhatsAppCrontabCheck,
     shellCompletionCheck,
+    uiProtocolFreshnessCheck,
     gatewayPlatformNotesCheck,
     createSecurityCheck(deps),
     browserCheck,

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -147,6 +147,7 @@ describe("doctor health contributions", () => {
     mocks.listHealthChecks.mockReset();
     mocks.listHealthChecks.mockReturnValue([
       { id: "core/doctor/shell-completion" },
+      { id: "core/doctor/ui-protocol-freshness" },
       { id: "core/doctor/unrelated" },
     ]);
     mocks.getHealthCheck.mockReset();
@@ -319,7 +320,7 @@ describe("doctor health contributions", () => {
     );
   });
 
-  it("keeps legacy positional shell completion out of the broad structured repair pass", async () => {
+  it("keeps legacy positional repairs out of the broad structured repair pass", async () => {
     const contribution = requireDoctorContribution("doctor:structured-health-repairs");
     const ctx = {
       cfg: {},

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -52,7 +52,10 @@ type DoctorHealthContribution = FlowContribution & {
   run: (ctx: DoctorHealthFlowContext) => Promise<void>;
 };
 
-const LEGACY_POSITIONAL_REPAIR_CHECK_IDS = new Set(["core/doctor/shell-completion"]);
+const LEGACY_POSITIONAL_REPAIR_CHECK_IDS = new Set([
+  "core/doctor/shell-completion",
+  "core/doctor/ui-protocol-freshness",
+]);
 
 const loadAgentDefaultsModule = async () => await import("../agents/defaults.js");
 const loadAgentScopeModule = async () => await import("../agents/agent-scope.js");

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -52,10 +52,7 @@ type DoctorHealthContribution = FlowContribution & {
   run: (ctx: DoctorHealthFlowContext) => Promise<void>;
 };
 
-const LEGACY_POSITIONAL_REPAIR_CHECK_IDS = new Set([
-  "core/doctor/shell-completion",
-  "core/doctor/ui-protocol-freshness",
-]);
+const PRE_HEALTH_POSITIONAL_HEALTH_CHECK_IDS = new Set(["core/doctor/ui-protocol-freshness"]);
 
 const loadAgentDefaultsModule = async () => await import("../agents/defaults.js");
 const loadAgentScopeModule = async () => await import("../agents/agent-scope.js");
@@ -120,6 +117,19 @@ function createDoctorHealthContribution(params: {
     healthCheckIds: params.healthCheckIds ?? [],
     run: params.run,
   };
+}
+
+function resolvePositionalHealthCheckIds(): ReadonlySet<string> {
+  const ids = new Set(PRE_HEALTH_POSITIONAL_HEALTH_CHECK_IDS);
+  for (const contribution of resolveDoctorHealthContributions()) {
+    if (contribution.id === "doctor:structured-health-repairs") {
+      continue;
+    }
+    for (const checkId of contribution.healthCheckIds) {
+      ids.add(checkId);
+    }
+  }
+  return ids;
 }
 
 async function runGatewayConfigHealth(ctx: DoctorHealthFlowContext): Promise<void> {
@@ -317,9 +327,8 @@ async function runStructuredHealthRepairs(ctx: DoctorHealthFlowContext): Promise
   registerCoreHealthChecks();
   const workspaceDir = resolveAgentWorkspaceDir(ctx.cfg, resolveDefaultAgentId(ctx.cfg));
   registerBundledHealthChecks({ cfg: ctx.cfg, cwd: workspaceDir });
-  const checks = listHealthChecks().filter(
-    (check) => !LEGACY_POSITIONAL_REPAIR_CHECK_IDS.has(check.id),
-  );
+  const positionalHealthCheckIds = resolvePositionalHealthCheckIds();
+  const checks = listHealthChecks().filter((check) => !positionalHealthCheckIds.has(check.id));
   const result = await runDoctorHealthRepairs(
     {
       mode: "fix",
@@ -1143,6 +1152,7 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
     createDoctorHealthContribution({
       id: "doctor:shell-completion",
       label: "Shell completion",
+      healthCheckIds: ["core/doctor/shell-completion"],
       run: runShellCompletionHealth,
     }),
     createDoctorHealthContribution({

--- a/src/flows/doctor-health-conversion-plan.ts
+++ b/src/flows/doctor-health-conversion-plan.ts
@@ -54,8 +54,8 @@ export const doctorHealthConversionRules = [
   {
     contributionId: "doctor:structured-health-repairs",
     conversion: "terminal-side-effect",
-    target: ["doctor-health-repair-runner"],
-    rule: "Delete this bridge after converted checks are registered directly; repair orchestration belongs outside the contribution list.",
+    target: ["doctor-health-repair-runner", "core/doctor/ui-protocol-freshness"],
+    rule: "Delete this bridge after converted checks are registered directly; repair orchestration belongs outside the contribution list. UI freshness is registered for lint/dry-run effects while legacy doctor still owns real repair.",
   },
   {
     contributionId: "doctor:legacy-state",


### PR DESCRIPTION
## Summary

- Exposes Control UI protocol freshness as a structured doctor health check for lint and dry-run repair effects.
- Keeps real build/rebuild mutation on the existing `maybeRepairUiProtocolFreshness()` path used by `openclaw doctor --fix`.
- Keeps existing doctor repairs in their positional slots: the pre-health UI freshness step still calls the legacy repair path, and the broad structured runner now excludes positional-owned health checks.
- Hardens the stale detector so a successful empty git history does not create false stale findings, while unavailable git history still reports the mtime mismatch without commit details.
- Skips build/rebuild prompts when the checkout does not contain `ui/` sources.

This PR does not change the public health/plugin SDK contract, does not invent file diffs for generated UI assets, and does not move existing doctor repair order into the broad structured runner.

## Real behavior proof

Behavior or issue addressed:
`openclaw doctor --lint` can report missing/stale Control UI assets, and dry-run repair output can preview the build/rebuild process effect without mutating generated UI files or changing the existing `openclaw doctor --fix` repair ownership.

Real environment tested:
WSL Ubuntu 24.04 durable OpenClaw worktree at `/root/src/openclaw-84290-refresh`, head `403c9bdbdbe9`, source harness using the real doctor health registry and temporary ignored `dist/control-ui/index.html` states. Paths below are redacted.

Exact steps or command run after this patch:
1. `git diff --check`
2. `node_modules/.bin/oxfmt --check --threads=1 src/commands/doctor-ui.ts src/commands/doctor-ui.test.ts src/flows/doctor-core-checks.ts src/flows/doctor-health-contributions.ts src/flows/doctor-health-contributions.test.ts src/flows/doctor-health-conversion-plan.ts`
3. `node_modules/.bin/oxlint --tsconfig config/tsconfig/oxlint.core.json src/commands/doctor-ui.ts src/commands/doctor-ui.test.ts src/flows/doctor-core-checks.ts src/flows/doctor-health-contributions.ts src/flows/doctor-health-contributions.test.ts src/flows/doctor-health-conversion-plan.ts`
4. `node scripts/run-vitest.mjs src/commands/doctor-ui.test.ts src/flows/doctor-health-contributions.test.ts src/commands/doctor-lint.test.ts --reporter=dot --pool=forks --testTimeout=30000 --hookTimeout=30000`
5. `node scripts/run-tsgo.mjs -p tsconfig.core.json --noEmit --incremental false --pretty false`
6. `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --noEmit --incremental false --pretty false`
7. `node --import tsx /tmp/84290-real-proof.mjs`
8. `bash /mnt/c/src/claws-hapi/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

Evidence after fix:
Focused validation passed: oxfmt reported all matched files use the correct format; oxlint reported 0 warnings and 0 errors; Vitest reported 3 focused files and 34 tests passed; core and core-test tsgo exited 0; autoreview reported `autoreview clean: no accepted/actionable findings reported`.

Redacted behavior proof output:

```text
--- missing assets lint JSON ---
exitCode=1
{"ok":false,"checksRun":1,"checksSkipped":55,"findings":[{"checkId":"core/doctor/ui-protocol-freshness","severity":"warning","message":"- Control UI assets are missing.\n- Run: pnpm ui:build","path":"/redacted/openclaw/dist/control-ui/index.html","fixHint":"Run `openclaw doctor --fix` to build Control UI assets."}]}
--- missing assets dry-run repair result ---
{
  "checksRun": 1,
  "checksRepaired": 1,
  "findings": [
    {
      "checkId": "core/doctor/ui-protocol-freshness",
      "severity": "warning",
      "message": "- Control UI assets are missing.\n- Run: pnpm ui:build",
      "path": "/redacted/openclaw/dist/control-ui/index.html",
      "fixHint": "Run `openclaw doctor --fix` to build Control UI assets."
    }
  ],
  "effects": [
    {
      "kind": "process",
      "action": "would-build-control-ui",
      "target": "/redacted/openclaw",
      "dryRunSafe": false
    }
  ],
  "changes": [],
  "warnings": []
}
--- stale assets lint JSON ---
exitCode=1
{"ok":false,"checksRun":1,"checksSkipped":18,"findings":[{"checkId":"core/doctor/ui-protocol-freshness","severity":"warning","message":"UI assets are older than the protocol schema.\nFunctional changes since last build:\n- ef7e652ec4 test(codex): avoid forced-tool allowlist flake","path":"/redacted/openclaw/dist/control-ui/index.html","fixHint":"Run `openclaw doctor --fix` to build Control UI assets."}]}
--- stale assets dry-run repair result ---
{
  "checksRun": 1,
  "checksRepaired": 1,
  "findings": [
    {
      "checkId": "core/doctor/ui-protocol-freshness",
      "severity": "warning",
      "message": "UI assets are older than the protocol schema.\nFunctional changes since last build:\n- ef7e652ec4 test(codex): avoid forced-tool allowlist flake",
      "path": "/redacted/openclaw/dist/control-ui/index.html",
      "fixHint": "Run `openclaw doctor --fix` to build Control UI assets."
    }
  ],
  "effects": [
    {
      "kind": "process",
      "action": "would-rebuild-control-ui",
      "target": "/redacted/openclaw",
      "dryRunSafe": false
    }
  ],
  "changes": [],
  "warnings": []
}
```

Observed result after fix:
The structured health check reports missing Control UI assets and stale assets through lint JSON. Dry-run repair returns preview process effects for build/rebuild without generated file diffs. Real doctor --fix repair remains in the existing pre-health UI freshness slot, while the broad structured runner excludes positional-owned checks. When git can prove there are no schema commits since the UI build, no stale finding is emitted; when git history is unavailable, the mtime mismatch remains reportable without commit details. Slim/source-limited installs do not get prompted to run an impossible UI rebuild.

What was not tested:
No live Control UI rebuild was run because this PR intentionally leaves build/rebuild execution on the existing doctor preflight repair path. No generated UI asset diff is emitted because generated build output is not stable or cheap to preview as a file diff.

## Validation

- `git diff --check`
- `node_modules/.bin/oxfmt --check --threads=1 src/commands/doctor-ui.ts src/commands/doctor-ui.test.ts src/flows/doctor-core-checks.ts src/flows/doctor-health-contributions.ts src/flows/doctor-health-contributions.test.ts src/flows/doctor-health-conversion-plan.ts`
- `node_modules/.bin/oxlint --tsconfig config/tsconfig/oxlint.core.json src/commands/doctor-ui.ts src/commands/doctor-ui.test.ts src/flows/doctor-core-checks.ts src/flows/doctor-health-contributions.ts src/flows/doctor-health-contributions.test.ts src/flows/doctor-health-conversion-plan.ts`
- `node scripts/run-vitest.mjs src/commands/doctor-ui.test.ts src/flows/doctor-health-contributions.test.ts src/commands/doctor-lint.test.ts --reporter=dot --pool=forks --testTimeout=30000 --hookTimeout=30000`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --noEmit --incremental false --pretty false`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --noEmit --incremental false --pretty false`
- `node --import tsx /tmp/84290-real-proof.mjs`
- `bash /mnt/c/src/claws-hapi/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` clean

