### PR TITLE
feat(gateway): compress control ui static assets

### DIFF
--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import type { IncomingMessage } from "node:http";
 import os from "node:os";
 import path from "node:path";
+import { brotliDecompressSync, gunzipSync } from "node:zlib";
 import { describe, expect, it, vi } from "vitest";
 import { resolveStateDir } from "../config/paths.js";
 import { approveDevicePairing, requestDevicePairing } from "../infra/device-pairing.js";
@@ -45,6 +46,17 @@ describe("handleControlUiHttpRequest", () => {
     return String(end.mock.calls[0]?.[0] ?? "");
   }
 
+  function responseBuffer(end: ReturnType<typeof makeMockHttpResponse>["end"]) {
+    const chunk = end.mock.calls[0]?.[0];
+    if (Buffer.isBuffer(chunk)) {
+      return chunk;
+    }
+    if (chunk instanceof Uint8Array) {
+      return Buffer.from(chunk);
+    }
+    return Buffer.from(String(chunk ?? ""));
+  }
+
   function responseJson(end: ReturnType<typeof makeMockHttpResponse>["end"]) {
     return JSON.parse(responseBody(end)) as unknown;
   }
@@ -69,10 +81,11 @@ describe("handleControlUiHttpRequest", () => {
     rootPath: string;
     basePath?: string;
     rootKind?: "resolved" | "bundled";
+    headers?: IncomingMessage["headers"];
   }) {
     const { res, end } = makeMockHttpResponse();
     const handled = await handleControlUiHttpRequest(
-      { url: params.url, method: params.method } as IncomingMessage,
+      { url: params.url, method: params.method, headers: params.headers ?? {} } as IncomingMessage,
       res,
       {
         ...(params.basePath ? { basePath: params.basePath } : {}),
@@ -1012,7 +1025,96 @@ describe("handleControlUiHttpRequest", () => {
     });
   });
 
-  it("serves HEAD for in-root assets without writing a body", async () => {
+  it("gzip-compresses text static assets when the client accepts gzip", async () => {
+    await withControlUiRoot({
+      fn: async (tmp) => {
+        const body = "console.log('compress me');\n".repeat(80);
+        await writeAssetFile(tmp, "app.js", body);
+
+        const { res, end, handled } = await runControlUiRequest({
+          url: "/assets/app.js",
+          method: "GET",
+          rootPath: tmp,
+          headers: { "accept-encoding": "gzip" },
+        });
+
+        expect(handled).toBe(true);
+        expect(res.statusCode).toBe(200);
+        expect(res.setHeader).toHaveBeenCalledWith("Content-Encoding", "gzip");
+        expect(res.setHeader).toHaveBeenCalledWith("Vary", "Accept-Encoding");
+        expect(res.setHeader).toHaveBeenCalledWith(
+          "Content-Type",
+          "application/javascript; charset=utf-8",
+        );
+        expect(gunzipSync(responseBuffer(end)).toString("utf8")).toBe(body);
+      },
+    });
+  });
+
+  it("marks uncompressed text static assets as varying by Accept-Encoding", async () => {
+    await withControlUiRoot({
+      fn: async (tmp) => {
+        const body = "console.log('identity');\n";
+        await writeAssetFile(tmp, "identity.js", body);
+
+        const { res, end, handled } = await runControlUiRequest({
+          url: "/assets/identity.js",
+          method: "GET",
+          rootPath: tmp,
+        });
+
+        expect(handled).toBe(true);
+        expect(res.statusCode).toBe(200);
+        expect(res.setHeader).toHaveBeenCalledWith("Vary", "Accept-Encoding");
+        expect(res.setHeader).not.toHaveBeenCalledWith("Content-Encoding", expect.any(String));
+        expect(responseBody(end)).toBe(body);
+      },
+    });
+  });
+
+  it("prefers brotli over gzip for compressible static assets", async () => {
+    await withControlUiRoot({
+      fn: async (tmp) => {
+        const body = "body { color: rebeccapurple; }\n".repeat(80);
+        await writeAssetFile(tmp, "app.css", body);
+
+        const { res, end, handled } = await runControlUiRequest({
+          url: "/assets/app.css",
+          method: "GET",
+          rootPath: tmp,
+          headers: { "accept-encoding": "gzip, br" },
+        });
+
+        expect(handled).toBe(true);
+        expect(res.statusCode).toBe(200);
+        expect(res.setHeader).toHaveBeenCalledWith("Content-Encoding", "br");
+        expect(brotliDecompressSync(responseBuffer(end)).toString("utf8")).toBe(body);
+      },
+    });
+  });
+
+  it("does not compress binary static assets", async () => {
+    await withControlUiRoot({
+      fn: async (tmp) => {
+        const pngBody = "png-bytes";
+        await writeAssetFile(tmp, "image.png", pngBody);
+
+        const { res, end, handled } = await runControlUiRequest({
+          url: "/assets/image.png",
+          method: "GET",
+          rootPath: tmp,
+          headers: { "accept-encoding": "gzip, br" },
+        });
+
+        expect(handled).toBe(true);
+        expect(res.statusCode).toBe(200);
+        expect(res.setHeader).not.toHaveBeenCalledWith("Content-Encoding", expect.any(String));
+        expect(responseBody(end)).toBe(pngBody);
+      },
+    });
+  });
+
+  it("serves HEAD for in-root assets without compression headers or body", async () => {
     await withControlUiRoot({
       fn: async (tmp) => {
         await writeAssetFile(tmp, "actual.txt", "inside-ok\n");
@@ -1021,10 +1123,13 @@ describe("handleControlUiHttpRequest", () => {
           url: "/assets/actual.txt",
           method: "HEAD",
           rootPath: tmp,
+          headers: { "accept-encoding": "gzip, br" },
         });
 
         expect(handled).toBe(true);
         expect(res.statusCode).toBe(200);
+        expect(res.setHeader).toHaveBeenCalledWith("Content-Encoding", "br");
+        expect(res.setHeader).toHaveBeenCalledWith("Vary", "Accept-Encoding");
         expect(firstEndCallLength(end)).toBe(0);
       },
     });

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -2,6 +2,7 @@ import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
 import fs from "node:fs";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import path from "node:path";
+import { brotliCompressSync, gzipSync } from "node:zlib";
 import { resolveAgentAvatar, resolvePublicAgentAvatarSource } from "../agents/identity-avatar.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { matchRootFileOpenFailure, openRootFileSync } from "../infra/boundary-file-read.js";
@@ -138,6 +139,16 @@ const STATIC_ASSET_EXTENSIONS = new Set([
 ]);
 
 const CONTROL_UI_NAMESPACE_PREFIX = "/__openclaw__/";
+const COMPRESSIBLE_STATIC_ASSET_EXTENSIONS = new Set([
+  ".html",
+  ".js",
+  ".css",
+  ".json",
+  ".map",
+  ".svg",
+  ".txt",
+  ".webmanifest",
+]);
 const CONTROL_UI_ROOT_PUBLIC_ASSETS = new Set([
   "apple-touch-icon.png",
   "favicon-32.png",
@@ -210,6 +221,7 @@ function respondHeadForFile(req: IncomingMessage, res: ServerResponse, filePath:
   }
   res.statusCode = 200;
   setStaticFileHeaders(res, filePath);
+  setStaticCompressionHeaders(req, res, filePath);
   res.end();
   return true;
 }
@@ -699,7 +711,7 @@ export async function handleControlUiAvatarRequest(
     return true;
   }
 
-  serveResolvedFile(res, safeAvatar.path, safeAvatar.buffer);
+  serveResolvedUncompressedFile(res, safeAvatar.path, safeAvatar.buffer);
   return true;
 }
 
@@ -711,12 +723,93 @@ function setStaticFileHeaders(res: ServerResponse, filePath: string) {
   res.setHeader("Cache-Control", "no-cache");
 }
 
-function serveResolvedFile(res: ServerResponse, filePath: string, body: Buffer) {
+type StaticCompressionEncoding = "br" | "gzip";
+
+function acceptedEncodings(req: IncomingMessage): Set<string> {
+  const raw = req.headers?.["accept-encoding"];
+  const header = Array.isArray(raw) ? raw.join(",") : (raw ?? "");
+  const accepted = new Set<string>();
+  for (const token of header.split(",")) {
+    const [nameRaw, ...params] = token.trim().split(";");
+    const name = nameRaw?.trim().toLowerCase();
+    if (!name) {
+      continue;
+    }
+    const qParam = params.find((param) => param.trim().toLowerCase().startsWith("q="));
+    const q = qParam ? Number(qParam.split("=")[1]) : 1;
+    if (Number.isFinite(q) && q <= 0) {
+      continue;
+    }
+    accepted.add(name);
+  }
+  return accepted;
+}
+
+function resolveStaticCompressionEncoding(req: IncomingMessage): StaticCompressionEncoding | null {
+  const accepted = acceptedEncodings(req);
+  if (accepted.has("br")) {
+    return "br";
+  }
+  if (accepted.has("gzip") || accepted.has("x-gzip")) {
+    return "gzip";
+  }
+  return null;
+}
+
+function isCompressibleControlUiFile(filePath: string): boolean {
+  return COMPRESSIBLE_STATIC_ASSET_EXTENSIONS.has(path.extname(filePath).toLowerCase());
+}
+
+function setStaticCompressionHeaders(
+  req: IncomingMessage,
+  res: ServerResponse,
+  filePath: string,
+): StaticCompressionEncoding | null {
+  if (!isCompressibleControlUiFile(filePath)) {
+    return null;
+  }
+  res.setHeader("Vary", "Accept-Encoding");
+  const encoding = resolveStaticCompressionEncoding(req);
+  if (encoding) {
+    res.setHeader("Content-Encoding", encoding);
+  }
+  return encoding;
+}
+
+function serveControlUiBody(
+  req: IncomingMessage,
+  res: ServerResponse,
+  filePath: string,
+  body: Buffer | string,
+) {
+  const encoding = setStaticCompressionHeaders(req, res, filePath);
+  if (!encoding) {
+    res.end(body);
+    return;
+  }
+
+  const raw = Buffer.isBuffer(body) ? body : Buffer.from(body, "utf8");
+  const compressed = encoding === "br" ? brotliCompressSync(raw) : gzipSync(raw);
+  res.setHeader("Content-Length", String(compressed.length));
+  res.end(compressed);
+}
+
+function serveResolvedUncompressedFile(res: ServerResponse, filePath: string, body: Buffer) {
   setStaticFileHeaders(res, filePath);
   res.end(body);
 }
 
-function serveResolvedIndexHtml(res: ServerResponse, body: string) {
+function serveResolvedFile(
+  req: IncomingMessage,
+  res: ServerResponse,
+  filePath: string,
+  body: Buffer,
+) {
+  setStaticFileHeaders(res, filePath);
+  serveControlUiBody(req, res, filePath, body);
+}
+
+function serveResolvedIndexHtml(req: IncomingMessage, res: ServerResponse, body: string) {
   const hashes = computeInlineScriptHashes(body);
   if (hashes.length > 0) {
     res.setHeader(
@@ -726,7 +819,7 @@ function serveResolvedIndexHtml(res: ServerResponse, body: string) {
   }
   res.setHeader("Content-Type", "text/html; charset=utf-8");
   res.setHeader("Cache-Control", "no-cache");
-  res.end(body);
+  serveControlUiBody(req, res, "index.html", body);
 }
 
 function isExpectedSafePathError(error: unknown): boolean {
@@ -970,10 +1063,10 @@ export async function handleControlUiHttpRequest(
         return true;
       }
       if (path.basename(safeFile.path) === "index.html") {
-        serveResolvedIndexHtml(res, fs.readFileSync(safeFile.fd, "utf8"));
+        serveResolvedIndexHtml(req, res, fs.readFileSync(safeFile.fd, "utf8"));
         return true;
       }
-      serveResolvedFile(res, safeFile.path, fs.readFileSync(safeFile.fd));
+      serveResolvedFile(req, res, safeFile.path, fs.readFileSync(safeFile.fd));
       return true;
     } finally {
       fs.closeSync(safeFile.fd);
@@ -998,7 +1091,7 @@ export async function handleControlUiHttpRequest(
       if (respondHeadForFile(req, res, safeIndex.path)) {
         return true;
       }
-      serveResolvedIndexHtml(res, fs.readFileSync(safeIndex.fd, "utf8"));
+      serveResolvedIndexHtml(req, res, fs.readFileSync(safeIndex.fd, "utf8"));
       return true;
     } finally {
       fs.closeSync(safeIndex.fd);


### PR DESCRIPTION
## Summary
- add gzip/brotli negotiation for Control UI text static assets (HTML, JS, CSS, JSON, SVG, manifests, text/maps)
- set `Vary: Accept-Encoding` for compressible assets, including identity responses
- keep binary assets uncompressed and preserve HEAD no-body behavior while returning negotiated representation headers

Closes #81754

## Real behavior proof
Ran a local HTTP server using the real `handleControlUiHttpRequest` path against a temporary Control UI root with JS and PNG assets, then requested assets with `Accept-Encoding` headers:

```text
## GET JS with gzip
status=200
content-type=application/javascript; charset=utf-8
content-encoding=gzip
vary=Accept-Encoding
transfer-bytes=8600

## GET JS with br,gzip
status=200
content-type=application/javascript; charset=utf-8
content-encoding=br
vary=Accept-Encoding
transfer-bytes=8600

## GET PNG with br,gzip
status=200
content-type=image/png
content-encoding=<none>
vary=<none>
transfer-bytes=9
```

This confirms the gateway now negotiates compressed representations for text Control UI assets while leaving binary images uncompressed.

## Test Plan
- `node scripts/run-vitest.mjs src/gateway/control-ui.http.test.ts`
- `pnpm check:changed`
