### PR TITLE
[codex] Document Telegram agent response prefixes

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -290,6 +290,51 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
 
 - Telegram is owned by the gateway process.
 - Routing is deterministic: Telegram inbound replies back to Telegram (the model does not pick channels).
+
+### Show which agent answered
+
+For multi-agent Telegram groups, set the Telegram response prefix to `auto` and give each routed
+agent an identity name. Outbound Telegram replies are prefixed by the gateway, so the model does not
+need to remember to write its own label.
+
+```json5
+{
+  agents: {
+    list: [
+      {
+        id: "codex",
+        identity: { name: "Codex" },
+      },
+      {
+        id: "claude",
+        identity: { name: "Claude" },
+      },
+      {
+        id: "gemini",
+        identity: { name: "Gemini" },
+      },
+    ],
+  },
+  channels: {
+    telegram: {
+      responsePrefix: "auto",
+      groups: {
+        "-1001234567890": {
+          topics: {
+            "21": { agentId: "codex" },
+            "1938": { agentId: "claude" },
+          },
+        },
+      },
+    },
+  },
+}
+```
+
+With that config, replies appear as `[Codex] ...`, `[Claude] ...`, etc. Use
+`channels.telegram.responsePrefix: ""` to disable a global prefix for Telegram, or set a literal
+string such as `"[OpenClaw]"` when all agents should share one visible label.
+
 - Inbound messages normalize into the shared channel envelope with reply metadata, media placeholders, and persisted reply-chain context for Telegram replies the gateway has observed.
 - Group sessions are isolated by group ID. Forum topics append `:topic:<threadId>` to keep topics isolated.
 - DM messages can carry `message_thread_id`; OpenClaw preserves the thread ID for replies but keeps DMs on the flat session by default. Configure `channels.telegram.dm.threadReplies: "inbound"`, `channels.telegram.direct.<chatId>.threadReplies: "inbound"`, `requireTopic: true`, or a matching topic config when you intentionally want DM topic session isolation.

--- a/scripts/e2e/lib/upgrade-survivor/assertions.mjs
+++ b/scripts/e2e/lib/upgrade-survivor/assertions.mjs
@@ -207,6 +207,14 @@ function assertConfigSurvived() {
       agents.some((agent) => agent?.id === "ops"),
       "ops agent missing",
     );
+    assert(
+      agents.some((agent) => agent?.id === "main" && agent.identity?.name === "Main"),
+      "main agent identity changed",
+    );
+    assert(
+      agents.some((agent) => agent?.id === "ops" && agent.identity?.name === "Ops"),
+      "ops agent identity changed",
+    );
     if (hasCoverage(coverage)) {
       assert(config.agents?.defaults?.contextTokens === 64000, "default contextTokens changed");
     } else {
@@ -273,6 +281,7 @@ function assertConfigSurvived() {
   if (acceptsIntent(coverage, "telegram-channel")) {
     const telegram = config.channels?.telegram;
     assert(telegram?.enabled === true, "telegram enabled flag changed");
+    assert(telegram?.responsePrefix === "auto", "telegram response prefix changed");
     assert(
       telegram.groups?.["-1001234567890"]?.requireMention === true,
       "telegram group policy changed",

--- a/scripts/e2e/lib/upgrade-survivor/config-recipe/agents.json
+++ b/scripts/e2e/lib/upgrade-survivor/config-recipe/agents.json
@@ -15,7 +15,10 @@
         "primary": "openai/gpt-5.5"
       },
       "thinkingDefault": "low",
-      "skills": ["memory"]
+      "skills": ["memory"],
+      "identity": {
+        "name": "Main"
+      }
     },
     {
       "id": "ops",
@@ -24,7 +27,10 @@
       "model": {
         "primary": "openai/gpt-5.5"
       },
-      "fastModeDefault": true
+      "fastModeDefault": true,
+      "identity": {
+        "name": "Ops"
+      }
     }
   ]
 }

--- a/scripts/e2e/lib/upgrade-survivor/config-recipe/channels-telegram.json
+++ b/scripts/e2e/lib/upgrade-survivor/config-recipe/channels-telegram.json
@@ -18,5 +18,6 @@
         "deny": ["exec"]
       }
     }
-  }
+  },
+  "responsePrefix": "auto"
 }

--- a/scripts/k8s/manifests/configmap.yaml
+++ b/scripts/k8s/manifests/configmap.yaml
@@ -26,6 +26,9 @@ data:
           {
             "id": "default",
             "name": "OpenClaw Assistant",
+            "identity": {
+              "name": "OpenClaw Assistant"
+            },
             "workspace": "~/.openclaw/workspace"
           }
         ]


### PR DESCRIPTION
## Summary

- Document Telegram `responsePrefix: "auto"` for multi-agent groups so replies show labels such as `[Codex]` or `[Claude]`.
- Seed agent `identity.name` and Telegram `responsePrefix` in the upgrade-survivor deployment recipe.
- Preserve the identity/prefix contract in upgrade-survivor assertions and the Kubernetes sample ConfigMap.

## Validation

- `node -e` JSON parse for updated recipe JSON files
- `node --check scripts/e2e/lib/upgrade-survivor/assertions.mjs`
- `git diff --check` for touched files
- `pnpm exec oxfmt --check docs/channels/telegram.md scripts/e2e/lib/upgrade-survivor/config-recipe/agents.json scripts/e2e/lib/upgrade-survivor/config-recipe/channels-telegram.json scripts/e2e/lib/upgrade-survivor/assertions.mjs scripts/k8s/manifests/configmap.yaml`

Note: local direct push to upstream was not permitted for the authenticated account, so the branch was uploaded to fork `ndf14685/openclaw`.
