### PR TITLE
fix(discord): stop typing keepalive on message_tool_only delivery (#84276)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Discord/typing: stop the channel typing keepalive in lockstep with delivery when the agent answers via the `message(action=send)` tool under `sourceReplyDeliveryMode === "message_tool_only"`, so the typing bubble no longer lingers for the channel-side TTL (~10s on Discord) after the visible reply has already landed. Fixes #84276.
 - Plugins/perf: thread explicit plugin discovery results through `loadBundledCapabilityRuntimeRegistry`, `resolveBundledPluginSources`, and `listChannelCatalogEntries` so callers that already hold a discovery result skip redundant filesystem walks. Thanks @SebTardif.
 - harden update restart script creation [AI]. (#84088) Thanks @pgondhi987.
 - Docker: keep the bundled Codex plugin in official release image keep lists so the default OpenAI agent harness remains available after Docker pruning. Fixes #83613. (#83626) Thanks @YuanHanzhong.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Discord/typing: stop the channel typing keepalive in lockstep with delivery when the agent answers via the `message(action=send)` tool under `sourceReplyDeliveryMode === "message_tool_only"`, so the typing bubble no longer lingers for the channel-side TTL (~10s on Discord) after the visible reply has already landed. Fixes #84276.
+- Discord/typing: stop the channel typing keepalive in lockstep with delivery when the agent answers via the `message(action=send)` tool under `sourceReplyDeliveryMode === "message_tool_only"`, so the typing bubble no longer lingers for the channel-side TTL (~10s on Discord) after the visible reply has already landed. The signal is only fired for sends that actually target the source conversation, leaves cross-channel/cross-recipient sends untouched, and is wired through both the default Pi runtime path and the Codex app-server dynamic message tool. Fixes #84276.
 - Plugins/perf: thread explicit plugin discovery results through `loadBundledCapabilityRuntimeRegistry`, `resolveBundledPluginSources`, and `listChannelCatalogEntries` so callers that already hold a discovery result skip redundant filesystem walks. Thanks @SebTardif.
 - harden update restart script creation [AI]. (#84088) Thanks @pgondhi987.
 - Docker: keep the bundled Codex plugin in official release image keep lists so the default OpenAI agent harness remains available after Docker pruning. Fixes #83613. (#83626) Thanks @YuanHanzhong.

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -3310,6 +3310,7 @@ async function buildDynamicTools(input: DynamicToolBuildParams) {
     requireExplicitMessageTarget:
       params.requireExplicitMessageTarget ?? isSubagentSessionKey(params.sessionKey),
     sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
+    onSourceReplyDelivered: params.onSourceReplyDelivered,
     disableMessageTool: params.disableMessageTool,
     forceMessageTool: shouldForceMessageTool(params),
     enableHeartbeatTool: params.trigger === "heartbeat",

--- a/extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
+++ b/extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
@@ -1094,6 +1094,7 @@ describe("web auto-reply connection", () => {
       isActive: vi.fn(() => false),
       markRunComplete: vi.fn(),
       markDispatchIdle,
+      markSourceReplyDelivered: vi.fn(),
       cleanup: vi.fn(),
     };
     const reply = vi.fn().mockResolvedValue(createAcceptedWhatsAppSendResult("text", "r1"));

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -122,6 +122,14 @@ export function createOpenClawTools(
     /** Visible source replies must be sent through the message tool when set to message_tool_only. */
     sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
     inboundEventKind?: InboundEventKind;
+    /**
+     * Invoked once the message tool successfully delivers a visible source
+     * reply via `action="send"` while `sourceReplyDeliveryMode === "message_tool_only"`.
+     * Wired to the typing controller so the keepalive can be stopped in lockstep
+     * with delivery instead of waiting for the dispatcher's grace timer
+     * (issue #84276).
+     */
+    onSourceReplyDelivered?: () => void;
     /** If true, omit the message tool from the tool list. */
     disableMessageTool?: boolean;
     /** If true, include the heartbeat response tool for structured heartbeat outcomes. */
@@ -308,6 +316,7 @@ export function createOpenClawTools(
         inboundEventKind: options?.inboundEventKind,
         requesterSenderId: options?.requesterSenderId ?? undefined,
         senderIsOwner: options?.senderIsOwner,
+        onSourceReplyDelivered: options?.onSourceReplyDelivered,
       });
   const heartbeatTool = options?.enableHeartbeatTool ? createHeartbeatResponseTool() : null;
   options?.recordToolPrepStage?.("openclaw-tools:message-tool");

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1433,6 +1433,7 @@ export async function runEmbeddedAttempt(
               params.requireExplicitMessageTarget ?? isSubagentSessionKey(params.sessionKey),
             sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
             inboundEventKind: params.currentInboundEventKind,
+            onSourceReplyDelivered: params.onSourceReplyDelivered,
             disableMessageTool: params.disableMessageTool,
             forceMessageTool: params.forceMessageTool,
             enableHeartbeatTool: params.enableHeartbeatTool,

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -204,6 +204,13 @@ export type RunEmbeddedPiAgentParams = {
   enqueue?: CommandQueueEnqueueFn;
   extraSystemPrompt?: string;
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
+  /**
+   * Notified once the message tool successfully delivers a visible source
+   * reply via `action="send"` while `sourceReplyDeliveryMode === "message_tool_only"`.
+   * Wired from the reply runtime so the typing controller can stop the
+   * channel typing keepalive in lockstep with delivery (issue #84276).
+   */
+  onSourceReplyDelivered?: () => void;
   silentReplyPromptMode?: SilentReplyPromptMode;
   internalEvents?: AgentInternalEvent[];
   inputProvenance?: InputProvenance;

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -440,6 +440,12 @@ export function createOpenClawCodingTools(options?: {
   /** Visible source replies must be sent through the message tool when set to message_tool_only. */
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
   inboundEventKind?: InboundEventKind;
+  /**
+   * Forwarded to the message tool. Invoked once the message tool successfully
+   * delivers a visible source reply via `action="send"` while
+   * `sourceReplyDeliveryMode === "message_tool_only"` (issue #84276).
+   */
+  onSourceReplyDelivered?: () => void;
   /** If true, omit the message tool from the tool list. */
   disableMessageTool?: boolean;
   /** Keep the message tool available even when the selected profile omits it. */
@@ -957,6 +963,7 @@ export function createOpenClawCodingTools(options?: {
           requireExplicitMessageTarget: options?.requireExplicitMessageTarget,
           sourceReplyDeliveryMode: options?.sourceReplyDeliveryMode,
           inboundEventKind: options?.inboundEventKind,
+          onSourceReplyDelivered: options?.onSourceReplyDelivered,
           disableMessageTool: options?.disableMessageTool,
           enableHeartbeatTool,
           disablePluginTools: !includePluginTools,

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -425,6 +425,124 @@ describe("message tool secret scoping", () => {
     expect(input?.toolContext?.currentChannelProvider).toBe("webchat");
   });
 
+  // Issue #84276: Discord typing indicator lingers ~10s after reply delivery in
+  // the message_tool_only source-reply path. The fix wires an
+  // `onSourceReplyDelivered` callback from the message tool back to the typing
+  // controller so the keepalive can be stopped in lockstep with delivery.
+  describe("onSourceReplyDelivered (issue #84276)", () => {
+    function mockNonDryRunSendResult() {
+      mocks.runMessageAction.mockClear();
+      mocks.runMessageAction.mockResolvedValue({
+        kind: "send",
+        action: "send",
+        channel: "discord",
+        to: "user:123",
+        handledBy: "plugin",
+        payload: {},
+        dryRun: false,
+      } satisfies MessageActionRunResult);
+    }
+
+    it("fires onSourceReplyDelivered after a successful non-dry-run send in message_tool_only mode", async () => {
+      mockNonDryRunSendResult();
+      const onSourceReplyDelivered = vi.fn();
+
+      await executeSend({
+        action: { message: "hello" },
+        toolOptions: {
+          sourceReplyDeliveryMode: "message_tool_only",
+          currentChannelProvider: "discord",
+          agentSessionKey: "agent:main:discord:direct:123",
+          onSourceReplyDelivered,
+        },
+      });
+
+      expect(onSourceReplyDelivered).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not fire onSourceReplyDelivered for dry-run sends", async () => {
+      // mockSendResult() defaults to dryRun: true.
+      mockSendResult({ channel: "discord", to: "user:123" });
+      const onSourceReplyDelivered = vi.fn();
+
+      await executeSend({
+        action: { message: "hello" },
+        toolOptions: {
+          sourceReplyDeliveryMode: "message_tool_only",
+          currentChannelProvider: "discord",
+          agentSessionKey: "agent:main:discord:direct:123",
+          onSourceReplyDelivered,
+        },
+      });
+
+      expect(onSourceReplyDelivered).not.toHaveBeenCalled();
+    });
+
+    it("does not fire onSourceReplyDelivered when sourceReplyDeliveryMode is automatic", async () => {
+      mockNonDryRunSendResult();
+      const onSourceReplyDelivered = vi.fn();
+
+      await executeSend({
+        action: { message: "hello" },
+        toolOptions: {
+          sourceReplyDeliveryMode: "automatic",
+          currentChannelProvider: "discord",
+          agentSessionKey: "agent:main:discord:direct:123",
+          onSourceReplyDelivered,
+        },
+      });
+
+      expect(onSourceReplyDelivered).not.toHaveBeenCalled();
+    });
+
+    it("does not fire onSourceReplyDelivered for non-send actions", async () => {
+      mocks.runMessageAction.mockClear();
+      mocks.runMessageAction.mockResolvedValue({
+        kind: "action",
+        action: "react",
+        channel: "discord",
+        handledBy: "plugin",
+        payload: {},
+        dryRun: false,
+      } satisfies MessageActionRunResult);
+      const onSourceReplyDelivered = vi.fn();
+
+      const tool = createMessageTool({
+        config: {} as never,
+        runMessageAction: mocks.runMessageAction as never,
+        sourceReplyDeliveryMode: "message_tool_only",
+        currentChannelProvider: "discord",
+        agentSessionKey: "agent:main:discord:direct:123",
+        onSourceReplyDelivered,
+      });
+      await tool.execute("1", { action: "react", emoji: "👍" });
+
+      expect(onSourceReplyDelivered).not.toHaveBeenCalled();
+    });
+
+    it("survives an onSourceReplyDelivered callback that throws", async () => {
+      mockNonDryRunSendResult();
+      const onSourceReplyDelivered = vi.fn(() => {
+        throw new Error("boom");
+      });
+
+      // Should not throw — callback errors must not fail the tool call.
+      await expect(
+        executeSend({
+          action: { message: "hello" },
+          toolOptions: {
+            sourceReplyDeliveryMode: "message_tool_only",
+            currentChannelProvider: "discord",
+            agentSessionKey: "agent:main:discord:direct:123",
+            onSourceReplyDelivered,
+          },
+        }),
+      ).resolves.toBeDefined();
+
+      expect(onSourceReplyDelivered).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it("uses a non-webchat session key when ambient current channel drifted to webchat", async () => {
     mockSendResult();
 

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -452,6 +452,7 @@ describe("message tool secret scoping", () => {
         toolOptions: {
           sourceReplyDeliveryMode: "message_tool_only",
           currentChannelProvider: "discord",
+          currentChannelId: "user:123",
           agentSessionKey: "agent:main:discord:direct:123",
           onSourceReplyDelivered,
         },
@@ -470,6 +471,7 @@ describe("message tool secret scoping", () => {
         toolOptions: {
           sourceReplyDeliveryMode: "message_tool_only",
           currentChannelProvider: "discord",
+          currentChannelId: "user:123",
           agentSessionKey: "agent:main:discord:direct:123",
           onSourceReplyDelivered,
         },
@@ -487,6 +489,7 @@ describe("message tool secret scoping", () => {
         toolOptions: {
           sourceReplyDeliveryMode: "automatic",
           currentChannelProvider: "discord",
+          currentChannelId: "user:123",
           agentSessionKey: "agent:main:discord:direct:123",
           onSourceReplyDelivered,
         },
@@ -512,6 +515,7 @@ describe("message tool secret scoping", () => {
         runMessageAction: mocks.runMessageAction as never,
         sourceReplyDeliveryMode: "message_tool_only",
         currentChannelProvider: "discord",
+        currentChannelId: "user:123",
         agentSessionKey: "agent:main:discord:direct:123",
         onSourceReplyDelivered,
       });
@@ -533,11 +537,127 @@ describe("message tool secret scoping", () => {
           toolOptions: {
             sourceReplyDeliveryMode: "message_tool_only",
             currentChannelProvider: "discord",
+            currentChannelId: "user:123",
             agentSessionKey: "agent:main:discord:direct:123",
             onSourceReplyDelivered,
           },
         }),
       ).resolves.toBeDefined();
+
+      expect(onSourceReplyDelivered).toHaveBeenCalledTimes(1);
+    });
+
+    // Reviewer P3: don't seal the source channel's typing keepalive when the
+    // agent fires a `message.send` to a different conversation in the same
+    // turn. Only the send that actually targets the source conversation should
+    // trigger the callback.
+    it("does not fire onSourceReplyDelivered when the send targets a different channel", async () => {
+      mocks.runMessageAction.mockClear();
+      mocks.runMessageAction.mockResolvedValue({
+        kind: "send",
+        action: "send",
+        channel: "telegram",
+        to: "user:999",
+        handledBy: "plugin",
+        payload: {},
+        dryRun: false,
+      } satisfies MessageActionRunResult);
+      const onSourceReplyDelivered = vi.fn();
+
+      await executeSend({
+        action: { message: "hello", channel: "telegram", target: "user:999" },
+        toolOptions: {
+          sourceReplyDeliveryMode: "message_tool_only",
+          currentChannelProvider: "discord",
+          currentChannelId: "user:123",
+          agentSessionKey: "agent:main:discord:direct:123",
+          onSourceReplyDelivered,
+        },
+      });
+
+      expect(onSourceReplyDelivered).not.toHaveBeenCalled();
+    });
+
+    it("does not fire onSourceReplyDelivered when the send targets a different recipient on the same channel", async () => {
+      mocks.runMessageAction.mockClear();
+      mocks.runMessageAction.mockResolvedValue({
+        kind: "send",
+        action: "send",
+        channel: "discord",
+        to: "user:999",
+        handledBy: "plugin",
+        payload: {},
+        dryRun: false,
+      } satisfies MessageActionRunResult);
+      const onSourceReplyDelivered = vi.fn();
+
+      await executeSend({
+        action: { message: "hello", target: "user:999" },
+        toolOptions: {
+          sourceReplyDeliveryMode: "message_tool_only",
+          currentChannelProvider: "discord",
+          currentChannelId: "user:123",
+          agentSessionKey: "agent:main:discord:direct:123",
+          onSourceReplyDelivered,
+        },
+      });
+
+      expect(onSourceReplyDelivered).not.toHaveBeenCalled();
+    });
+
+    it("matches the source conversation regardless of the channel-target prefix", async () => {
+      // Resolved target may or may not carry a `user:` prefix depending on the
+      // channel/runner; the comparison must normalize both sides.
+      mocks.runMessageAction.mockClear();
+      mocks.runMessageAction.mockResolvedValue({
+        kind: "send",
+        action: "send",
+        channel: "discord",
+        to: "123",
+        handledBy: "plugin",
+        payload: {},
+        dryRun: false,
+      } satisfies MessageActionRunResult);
+      const onSourceReplyDelivered = vi.fn();
+
+      await executeSend({
+        action: { message: "hello" },
+        toolOptions: {
+          sourceReplyDeliveryMode: "message_tool_only",
+          currentChannelProvider: "discord",
+          currentChannelId: "user:123",
+          agentSessionKey: "agent:main:discord:direct:123",
+          onSourceReplyDelivered,
+        },
+      });
+
+      expect(onSourceReplyDelivered).toHaveBeenCalledTimes(1);
+    });
+
+    it("fires onSourceReplyDelivered for webchat internal-source sends regardless of resolved target string", async () => {
+      mocks.runMessageAction.mockClear();
+      mocks.runMessageAction.mockResolvedValue({
+        kind: "send",
+        action: "send",
+        channel: "webchat",
+        to: "current-run",
+        handledBy: "internal-source",
+        payload: {},
+        dryRun: false,
+      } satisfies MessageActionRunResult);
+      const onSourceReplyDelivered = vi.fn();
+
+      await executeSend({
+        action: { message: "hello" },
+        toolOptions: {
+          sourceReplyDeliveryMode: "message_tool_only",
+          currentChannelProvider: "webchat",
+          // intentionally omit currentChannelId — the internal-source sink
+          // always means "the current run's source conversation".
+          agentSessionKey: "agent:main:webchat:direct:user-1",
+          onSourceReplyDelivered,
+        },
+      });
 
       expect(onSourceReplyDelivered).toHaveBeenCalledTimes(1);
     });

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -54,6 +54,38 @@ function actionNeedsExplicitTarget(action: ChannelMessageActionName): boolean {
   return EXPLICIT_TARGET_ACTIONS.has(action);
 }
 
+// Issue #84276: only treat a `message_tool_only` send as a source-conversation
+// reply when the resolved channel + target actually point at the inbound
+// conversation. Otherwise an agent that sends a side message to a different
+// conversation (e.g. `target=channel:other`) inside the same turn would
+// prematurely seal the source channel's typing keepalive.
+function stripChannelTargetPrefix(value: string): string {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/^(?:user|channel|group|dm):/u, "")
+    .trim();
+}
+
+function sendTargetIsSourceConversation(
+  result: Extract<MessageActionRunResult, { kind: "send" }>,
+  options: Pick<MessageToolOptions, "currentChannelProvider" | "currentChannelId">,
+): boolean {
+  // The webchat internal source-reply sink always targets the current run.
+  if (result.handledBy === "internal-source") {
+    return true;
+  }
+  const sourceChannel = options.currentChannelProvider?.trim().toLowerCase();
+  if (!sourceChannel || String(result.channel).toLowerCase() !== sourceChannel) {
+    return false;
+  }
+  const sourceTarget = options.currentChannelId?.trim();
+  if (!sourceTarget) {
+    return false;
+  }
+  return stripChannelTargetPrefix(result.to) === stripChannelTargetPrefix(sourceTarget);
+}
+
 function stripFormattedReasoningMessage(text: string): string {
   const stripped = stripReasoningTagsFromText(text);
   const lines = stripped.split(/\r?\n/u);
@@ -1073,11 +1105,18 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
       // for the rest of the channel-side TTL after the reply has already
       // landed. Notify the caller (which wires this into the typing
       // controller) so the keepalive can be sealed in lockstep with delivery.
+      // Only fire when the send actually went to the source conversation —
+      // a `message.send` to a different channel/target inside the same turn
+      // must not seal the source channel's typing keepalive.
       if (
         action === "send" &&
         options?.sourceReplyDeliveryMode === "message_tool_only" &&
         result.kind === "send" &&
-        result.dryRun !== true
+        result.dryRun !== true &&
+        sendTargetIsSourceConversation(result, {
+          currentChannelProvider: effectiveCurrentChannel.currentChannelProvider,
+          currentChannelId: effectiveCurrentChannel.currentChannelId,
+        })
       ) {
         try {
           options.onSourceReplyDelivered?.();

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -573,6 +573,13 @@ type MessageToolOptions = {
   inboundEventKind?: InboundEventKind;
   requesterSenderId?: string;
   senderIsOwner?: boolean;
+  /**
+   * Invoked after a successful (non-dry-run) `action="send"` when
+   * `sourceReplyDeliveryMode === "message_tool_only"`. Lets the caller stop
+   * channel typing keepalive immediately so the channel-side typing TTL is not
+   * refreshed after the visible reply has already been delivered (issue #84276).
+   */
+  onSourceReplyDelivered?: () => void;
 };
 
 type MessageToolDiscoveryParams = {
@@ -1057,6 +1064,28 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
         inboundEventKind: options?.inboundEventKind,
         abortSignal: signal,
       });
+
+      // Issue #84276: when the agent delivers a visible reply through the
+      // message tool in `message_tool_only` mode, the source channel's typing
+      // indicator should stop refreshing immediately. Otherwise the keepalive
+      // loop can issue one more `sendTyping` packet between the in-flight tool
+      // call and the dispatcher's finally block, leaving the bubble visible
+      // for the rest of the channel-side TTL after the reply has already
+      // landed. Notify the caller (which wires this into the typing
+      // controller) so the keepalive can be sealed in lockstep with delivery.
+      if (
+        action === "send" &&
+        options?.sourceReplyDeliveryMode === "message_tool_only" &&
+        result.kind === "send" &&
+        result.dryRun !== true
+      ) {
+        try {
+          options.onSourceReplyDelivered?.();
+        } catch {
+          // Typing-indicator cleanup is best-effort; never fail the tool call
+          // because of a downstream signaling error.
+        }
+      }
 
       const toolResult = getToolResult(result);
       if (toolResult) {

--- a/src/auto-reply/dispatch.test.ts
+++ b/src/auto-reply/dispatch.test.ts
@@ -204,6 +204,7 @@ describe("withReplyDispatcher", () => {
       isActive: vi.fn(() => true),
       markRunComplete: vi.fn(),
       markDispatchIdle: vi.fn(),
+      markSourceReplyDelivered: vi.fn(),
       cleanup: vi.fn(),
     };
     hoisted.createReplyDispatcherWithTypingMock.mockReturnValueOnce({

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1079,6 +1079,12 @@ export async function runAgentTurnWithFallback(params: {
   replyOperation?: ReplyOperation;
   opts?: GetReplyOptions;
   typingSignals: TypingSignaler;
+  /**
+   * Forwarded into `runEmbeddedPiAgent` so the message tool can stop the
+   * channel typing keepalive in lockstep with delivery when
+   * `sourceReplyDeliveryMode === "message_tool_only"` (issue #84276).
+   */
+  onSourceReplyDelivered?: () => void;
   blockReplyPipeline: BlockReplyPipeline | null;
   blockStreamingEnabled: boolean;
   blockReplyChunking?: {
@@ -1799,6 +1805,7 @@ export async function runAgentTurnWithFallback(params: {
                 sourceReplyDeliveryMode: params.followupRun.run.sourceReplyDeliveryMode,
                 forceMessageTool:
                   params.followupRun.run.sourceReplyDeliveryMode === "message_tool_only",
+                onSourceReplyDelivered: params.onSourceReplyDelivered,
                 silentReplyPromptMode: params.followupRun.run.silentReplyPromptMode,
                 suppressNextUserMessagePersistence: suppressQueuedUserPersistenceForCandidate,
                 onUserMessagePersisted: () => {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1463,6 +1463,11 @@ export async function runReplyAgent(params: {
         replyOperation,
         opts,
         typingSignals,
+        // Issue #84276: stop the channel typing keepalive immediately when the
+        // message tool delivers a visible reply in `message_tool_only` mode so
+        // Discord/etc. don't keep the typing bubble alive for the remainder of
+        // the channel-side TTL after the reply has already landed.
+        onSourceReplyDelivered: () => typing.markSourceReplyDelivered(),
         blockReplyPipeline,
         blockStreamingEnabled,
         blockReplyChunking,

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -718,6 +718,11 @@ export function createFollowupRunner(params: {
                 silentReplyPromptMode: run.silentReplyPromptMode,
                 sourceReplyDeliveryMode: run.sourceReplyDeliveryMode,
                 forceMessageTool: run.sourceReplyDeliveryMode === "message_tool_only",
+                // Issue #84276: stop channel typing keepalive immediately when
+                // the message tool delivers a visible reply in
+                // `message_tool_only` mode so the channel-side typing TTL is
+                // not refreshed after delivery.
+                onSourceReplyDelivered: () => typing.markSourceReplyDelivered(),
                 suppressNextUserMessagePersistence: suppressQueuedUserPersistenceForCandidate,
                 onUserMessagePersisted: () => {
                   queuedUserMessagePersistedAcrossFallback = true;

--- a/src/auto-reply/reply/get-reply-directives.target-session.test.ts
+++ b/src/auto-reply/reply/get-reply-directives.target-session.test.ts
@@ -28,6 +28,7 @@ function makeTypingController() {
     isActive: () => false,
     markRunComplete: () => {},
     markDispatchIdle: () => {},
+    markSourceReplyDelivered: () => {},
     cleanup: vi.fn(),
   };
 }
@@ -395,6 +396,7 @@ describe("resolveReplyDirectives", () => {
         isActive: () => false,
         markRunComplete: () => {},
         markDispatchIdle: () => {},
+        markSourceReplyDelivered: () => {},
         cleanup: vi.fn(),
       },
       opts: undefined,

--- a/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
@@ -47,6 +47,7 @@ const createTypingController = (): TypingController => ({
   isActive: () => false,
   markRunComplete: () => {},
   markDispatchIdle: () => {},
+  markSourceReplyDelivered: () => {},
   cleanup: vi.fn(),
 });
 

--- a/src/auto-reply/reply/reply.test-helpers.ts
+++ b/src/auto-reply/reply/reply.test-helpers.ts
@@ -7,6 +7,7 @@ export function createMockTypingController() {
     isActive: () => false,
     markRunComplete: () => undefined,
     markDispatchIdle: () => undefined,
+    markSourceReplyDelivered: () => undefined,
     cleanup: () => undefined,
   };
 }

--- a/src/auto-reply/reply/test-helpers.ts
+++ b/src/auto-reply/reply/test-helpers.ts
@@ -13,6 +13,7 @@ export function createMockTypingController(
     isActive: vi.fn(() => false),
     markRunComplete: vi.fn(),
     markDispatchIdle: vi.fn(),
+    markSourceReplyDelivered: vi.fn(),
     cleanup: vi.fn(),
     ...overrides,
   };

--- a/src/auto-reply/reply/typing-persistence.test.ts
+++ b/src/auto-reply/reply/typing-persistence.test.ts
@@ -113,9 +113,77 @@ describe("typing persistence bug fix", () => {
     inert.refreshTypingTtl();
     inert.markRunComplete();
     inert.markDispatchIdle();
+    inert.markSourceReplyDelivered();
     inert.cleanup();
 
     expect(inert.isActive()).toBe(false);
     expect(vi.getTimerCount()).toBe(0);
+  });
+
+  // Issue #84276: in `message_tool_only` source-reply mode the visible reply is
+  // delivered through the message(action=send) tool. Without an explicit signal
+  // the keepalive loop can fire one more `sendTyping` while the tool is in
+  // flight, leaving the channel-side typing TTL refreshed for the full
+  // ~10 seconds after the user sees the reply. `markSourceReplyDelivered()`
+  // must stop the keepalive immediately and seal the controller.
+  describe("markSourceReplyDelivered (issue #84276)", () => {
+    it("stops the keepalive loop immediately on visible source-reply delivery", async () => {
+      await controller.startTypingLoop();
+      expect(onReplyStartSpy).toHaveBeenCalledTimes(1);
+
+      controller.markSourceReplyDelivered();
+
+      expect(onCleanupSpy).toHaveBeenCalledTimes(1);
+
+      // No further keepalive ticks should issue typing pings after delivery.
+      vi.advanceTimersByTime(6000);
+      vi.advanceTimersByTime(6000);
+      vi.advanceTimersByTime(6000);
+      expect(onReplyStartSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("seals the controller so late markRunComplete/markDispatchIdle are no-ops", async () => {
+      await controller.startTypingLoop();
+      controller.markSourceReplyDelivered();
+      expect(onCleanupSpy).toHaveBeenCalledTimes(1);
+
+      controller.markRunComplete();
+      controller.markDispatchIdle();
+      controller.cleanup();
+
+      expect(onCleanupSpy).toHaveBeenCalledTimes(1);
+      expect(controller.isActive()).toBe(false);
+    });
+
+    it("is idempotent across repeated calls", async () => {
+      await controller.startTypingLoop();
+      controller.markSourceReplyDelivered();
+      controller.markSourceReplyDelivered();
+      controller.markSourceReplyDelivered();
+
+      expect(onCleanupSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("clears the dispatch-idle grace timer if markRunComplete fired first", async () => {
+      await controller.startTypingLoop();
+      controller.markRunComplete();
+
+      // The 10 s grace timer is now armed; markSourceReplyDelivered should
+      // clean up immediately without waiting for it.
+      expect(onCleanupSpy).not.toHaveBeenCalled();
+      controller.markSourceReplyDelivered();
+      expect(onCleanupSpy).toHaveBeenCalledTimes(1);
+
+      // Advancing past the original 10s grace must not trigger a second cleanup.
+      vi.advanceTimersByTime(10_000);
+      expect(onCleanupSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("is a no-op when typing was never started", () => {
+      controller.markSourceReplyDelivered();
+      // No keepalive started, so no channel cleanup signal should fire.
+      expect(onCleanupSpy).not.toHaveBeenCalled();
+      expect(onReplyStartSpy).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/auto-reply/reply/typing.ts
+++ b/src/auto-reply/reply/typing.ts
@@ -11,6 +11,16 @@ export type TypingController = {
   isActive: () => boolean;
   markRunComplete: () => void;
   markDispatchIdle: () => void;
+  /**
+   * Signal that a user-visible reply has been delivered through the source channel
+   * (e.g. via a `message(action=send)` tool call in `message_tool_only` mode).
+   *
+   * Stops the keepalive loop immediately and seals the controller so that no
+   * further `sendTyping` packets refresh the channel-side typing TTL after the
+   * reply has already landed. Idempotent: subsequent calls and the existing
+   * markRunComplete/markDispatchIdle finalize flow are no-ops once sealed.
+   */
+  markSourceReplyDelivered: () => void;
   cleanup: () => void;
 };
 
@@ -39,6 +49,7 @@ export function createTypingController(params: {
       isActive: () => false,
       markRunComplete: () => {},
       markDispatchIdle: () => {},
+      markSourceReplyDelivered: () => {},
       cleanup: () => {},
     };
   }
@@ -238,6 +249,27 @@ export function createTypingController(params: {
     maybeStopOnIdle();
   };
 
+  // Issue #84276: in `message_tool_only` source-reply mode the visible reply is
+  // delivered directly through the message(action=send) tool path. Once that
+  // delivery lands the channel will clear its typing indicator on its own when
+  // the actual message arrives, but the keepalive loop may have just refreshed
+  // the typing TTL (Discord ~10s, others similar). Without an explicit signal
+  // the user perceives a lingering typing bubble for the remainder of that TTL
+  // even though the reply is already on screen. Treat a delivered source reply
+  // as a terminal event for typing: stop the keepalive, fire onCleanup, and
+  // seal so late tool/block callbacks (and the dispatcher's grace-timer based
+  // markRunComplete/markDispatchIdle in the finally block) cannot re-engage
+  // typing after the reply is visible.
+  const markSourceReplyDelivered = () => {
+    if (sealed) {
+      return;
+    }
+    log?.("typing: source reply delivered via message tool; stopping keepalive");
+    runComplete = true;
+    dispatchIdle = true;
+    cleanup();
+  };
+
   return {
     onReplyStart: ensureStart,
     startTypingLoop,
@@ -246,6 +278,7 @@ export function createTypingController(params: {
     isActive,
     markRunComplete,
     markDispatchIdle,
+    markSourceReplyDelivered,
     cleanup,
   };
 }


### PR DESCRIPTION
## Summary

- Problem: in `message_tool_only` source-reply mode the Discord typing bubble keeps showing for ~10s after the reply has already landed in the channel.
- Solution: add an explicit "source reply delivered" signal so the typing keepalive is sealed the moment the message tool's `send` resolves, instead of waiting for the dispatcher's idle grace window. The signal only fires for sends that actually target the source conversation.
- What changed: new `TypingController.markSourceReplyDelivered()`; `message(action=send)` fires an optional `onSourceReplyDelivered` callback when `sourceReplyDeliveryMode === "message_tool_only"`, the send is a real (non-dry-run) success, and the resolved channel + target match the source conversation (or it's the webchat internal-source sink). The callback is threaded through both runtime paths: the default Pi runtime (`createOpenClawTools` → `pi-tools` → `runEmbeddedPiAgent`) and the Codex app-server dynamic message tool (`extensions/codex/src/app-server/run-attempt.ts → buildDynamicTools`). Wired in `agent-runner.ts` / `followup-runner.ts` to call `typing.markSourceReplyDelivered()`.
- What did NOT change: the heartbeat typing pipeline is untouched, `DISPATCH_IDLE_GRACE_MS` is left at 10s (shortening it makes the bug worse — see the linked issue), and the `automatic` source-reply path is unaffected. A `message.send` to a different channel/recipient inside the same turn is left alone — only the source-conversation send seals the source typing.

## Motivation

Users perceive the bot as "still typing" for ~10s after a reply has already arrived in DM. It's small but it makes the agent feel laggy or stuck. Issue #84276 traces it to the keepalive loop racing with the dispatcher's finally block; this PR addresses it on the path the issue calls out (Option 2 / Option 3 in the write-up).

-

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #84276
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Discord typing indicator no longer lingers after a `message_tool_only` reply lands, and only the source conversation's typing is sealed when the message tool delivers.
- Real environment tested: I don't have a live Discord workspace from this machine. To exercise the fix end to end without a live channel, I ran the runtime semantics + the new source-conversation guard directly under `node`. Terminal capture below shows the actual stdout from `node verify-typing-fix.mjs` after the patch.
- Exact steps or command run after this patch:
  ```
  node verify-typing-fix.mjs
  ```
  (The script inlines the post-patch `TypingController` lifecycle and the new `sendTargetIsSourceConversation` guard from `src/agents/tools/message-tool.ts`, then drives 8 scenarios against them.)
- Evidence after fix (terminal capture, real stdout):

```text
Verifying TypingController.markSourceReplyDelivered + source-conversation guard (issue #84276)

[1/8] keepalive stops on markSourceReplyDelivered  (replyStart=2, cleanup=1)
[2/8] idempotent across repeat calls           (cleanup=1)
[3/8] late markRunComplete/markDispatchIdle/cleanup are no-ops once sealed
[4/8] dispatch-idle grace timer is cleared when delivery wins the race
[5/8] no-op when typing was never started     (reply=0, cleanup=0)
[6/8] source-conversation send matches even with channel-target prefix
[7/8] sends to other channels or recipients do not seal the source typing
[8/8] webchat internal-source sink always counts as a source-conversation send

All 8 scenarios pass. Discord typing keepalive halts in lockstep with delivery, and only for the source conversation.
```

- Observed result after fix: keepalive halts the moment `message(action=send)` reports a successful non-dry-run send to the source conversation. Subsequent `markRunComplete` / `markDispatchIdle` from the dispatcher's finally block are no-ops, so no further `sendTyping` packets refresh Discord's TTL after the reply has landed. Cross-channel and cross-recipient sends in the same turn do not affect the source-channel typing.
- What was not tested: a live Discord DM run with a real bot token. I do not have a spare bot/token wired up here. If a maintainer or `@openclaw-mantis` can capture the visible bubble disappearance for the redacted live recording the reviewer suggested, that closes the loop.
- Before evidence: the lingering ~10s typing bubble is documented in the original issue write-up (logs + repro steps in #84276).

## Root Cause

- Root cause: `createTypingController` only calls `cleanup()` once both `runComplete` and `dispatchIdle` are true. In `message_tool_only` mode those signals are both fired together from the dispatcher's `finally` block, after the message tool has already returned. The 6s keepalive can issue one more `sendTyping` while the tool is in flight, and Discord's ~10s typing TTL keeps the bubble alive long after we think we cleaned up.
- Missing detection / guardrail: there was no signal between the message tool delivering a visible reply and the typing controller. The controller had no concept of "the visible reply is on screen, stop refreshing the TTL".
- Contributing context: shortening `DISPATCH_IDLE_GRACE_MS` makes things worse — it seals the controller before the legitimate `markDispatchIdle` arrives, but Discord's TTL is independent of our cleanup so the bubble still hangs.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/reply/typing-persistence.test.ts`, `src/agents/tools/message-tool.test.ts`.
- Scenario the test should lock in: when the message tool successfully delivers a visible reply under `sourceReplyDeliveryMode === "message_tool_only"` to the source conversation, the keepalive stops immediately, `onCleanup` fires once, and any late `markRunComplete` / `markDispatchIdle` from the dispatcher's finally block are no-ops. A `message.send` to a different channel/recipient inside the same turn must not seal the source typing.
- Why this is the smallest reliable guardrail: the bug class lives in the typing controller's lifecycle gate plus the hand-off from the message tool. Both sides are now covered with unit tests (5 new lifecycle tests + 9 new message-tool tests covering source/cross/internal-source/dry-run/automatic/non-send/throwing-callback paths) and don't require a live channel to exercise.
- Existing test that already covers this: nothing. There were tests for `markRunComplete` / `markDispatchIdle` separately, but nothing for the `message_tool_only` delivery path.
- If no new test is added: N/A, new tests are added.

## User-visible / Behavior Changes

Discord (and any other channel using `message_tool_only`) clears the typing indicator in lockstep with delivery instead of holding it for the channel-side TTL. No config flag. The path that was broken now matches what users already expect from the `automatic` path. Side messages to other conversations within the same turn are not affected.

## Diagram

```text
Before:
[message tool send] -> [reply delivered]
            keepalive tick at 6s -> sendTyping (refreshes ~10s TTL)
[run finally] -> markRunComplete + markDispatchIdle
            controller cleans up, but Discord still shows typing
            until its TTL expires (~10s after the reply landed)

After:
[message tool send to source convo] -> [reply delivered]
            -> onSourceReplyDelivered()  (guarded: source channel + target match)
            -> typing.markSourceReplyDelivered()
            -> keepalive loop stops, onCleanup fires, controller sealed
            (no further sendTyping refreshes the TTL)

[message tool send to a different conversation in the same turn]
            -> guard returns false, source typing is left alone
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No — if anything we make slightly fewer outbound `sendTyping` calls per turn.
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any Yes, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- Integration/channel: Discord DM, `chat_type=direct`, `sourceReplyDeliveryMode === "message_tool_only"`.
- Relevant config (redacted):

```yaml
agents:
  defaults:
    typingMode: instant
messages:
  visibleReplies: message_tool
```

### Steps

1. Send any prompt to the agent in a Discord DM with `message_tool_only` configured.
2. Watch the typing indicator after the reply text appears.
3. Before this patch: typing bubble persists for ~10s. After: bubble disappears in lockstep with delivery.

### Expected

- Typing bubble clears as soon as the reply message lands in the channel.

### Actual

- With this patch applied, the keepalive loop is stopped via `markSourceReplyDelivered()` the moment the message tool reports a successful non-dry-run send to the source conversation, so no further `sendTyping` packets refresh the TTL.

## Human Verification (required)

- Verified scenarios:
  - `markSourceReplyDelivered()` stops the keepalive immediately and fires `onCleanup` once.
  - Idempotent across repeat calls.
  - Late `markRunComplete` / `markDispatchIdle` / `cleanup` calls are no-ops once sealed.
  - The 10s dispatch-idle grace timer is cleared if delivery wins the race against `markRunComplete`.
  - Calling it before typing has started is a clean no-op.
  - Message-tool callback fires only when `action === "send"`, `sourceReplyDeliveryMode === "message_tool_only"`, the result is a `send`, and `dryRun !== true`. It does not fire for dry runs, `automatic`, or non-send actions.
  - Source-conversation guard: callback fires for default-routed sends, prefix-normalized matches (`user:123` vs `123`), and webchat `handledBy === "internal-source"` sends. It does not fire for cross-channel sends or same-channel sends to a different recipient.
  - A throwing `onSourceReplyDelivered` callback does not fail the tool call.
- Edge cases checked: repeat delivery (idempotent), late tool/block callbacks after delivery (controller sealed so they can't restart typing), heartbeat path (uses a separate typing pipeline so it stays unchanged), cross-conversation `message.send` inside the same turn (source typing untouched).
- What I did not verify: a live Discord bot run end to end. I don't have a spare bot/token on this machine.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes. The new `onSourceReplyDelivered` option and `markSourceReplyDelivered` method are both optional. Callers that don't pass the callback get exactly the previous behavior.
- Config/env changes? No.
- Migration needed? No.
- If yes, exact upgrade steps: N/A.

## Risks and Mitigations

- Risk: the message tool's `onSourceReplyDelivered` callback throws and we swallow the error.
  - Mitigation: the swallow is intentional and narrowly scoped to the callback invocation. Typing cleanup is best-effort and should never fail a successful `send`. The rest of the tool result path is untouched.
- Risk: a heuristically-routed send is misclassified as cross-conversation and we miss the chance to seal typing.
  - Mitigation: the source-conversation guard normalizes the channel-target prefix on both sides before comparing, and the webchat `handledBy === "internal-source"` sink short-circuits to "always source". The fall-through behavior is the same as the original bug (typing lingers for the channel TTL), so a misclassification can only ever degrade to the pre-patch state — it cannot kill typing for a wrong conversation.
- Risk: an agent that calls `message(action=send)` to the source conversation more than once in a single turn won't get a typing indicator for the 2nd/3rd call.
  - Mitigation: in `message_tool_only` mode `disableBlockStreaming` is already `true`, so block streaming wasn't driving typing for those follow-up sends anyway. The trade-off (no typing for follow-up sends to the same conversation inside one turn) is the explicit design in Option 2 of the linked issue write-up, and is preferable to a typing bubble that lingers after the user has already seen the first reply.