### PR TITLE
perf(plugins): scan-scoped package.json cache in discovery

### DIFF
--- a/src/plugins/config-contracts.ts
+++ b/src/plugins/config-contracts.ts
@@ -1,6 +1,6 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isRecord } from "../utils.js";
-import { discoverOpenClawPlugins } from "./discovery.js";
+import { discoverOpenClawPlugins, type PluginDiscoveryResult } from "./discovery.js";
 import { loadPluginManifestRegistry } from "./manifest-registry.js";
 import type { PluginManifestConfigContracts } from "./manifest.js";
 import type { PluginOrigin } from "./plugin-origin.types.js";
@@ -114,6 +114,13 @@ export function resolvePluginConfigContractsById(params: {
   fallbackToBundledMetadataForResolvedBundled?: boolean;
   fallbackBundledPluginIds?: readonly string[];
   pluginIds: readonly string[];
+  /**
+   * Pre-computed discovery result. When supplied, the bundled-fallback path
+   * skips its internal `discoverOpenClawPlugins` call so callers sharing a
+   * discovery snapshot across registry helpers avoid redundant filesystem
+   * walks.
+   */
+  discovery?: PluginDiscoveryResult;
 }): ReadonlyMap<string, PluginConfigContractMetadata> {
   const matches = new Map<string, PluginConfigContractMetadata>();
   const pluginIds = [
@@ -132,10 +139,12 @@ export function resolvePluginConfigContractsById(params: {
     if (bundledContractFallbacks.has(pluginId)) {
       return bundledContractFallbacks.get(pluginId);
     }
-    const discovery = discoverOpenClawPlugins({
-      workspaceDir: params.workspaceDir,
-      env: params.env,
-    });
+    const discovery =
+      params.discovery ??
+      discoverOpenClawPlugins({
+        workspaceDir: params.workspaceDir,
+        env: params.env,
+      });
     const registry = loadPluginManifestRegistry({
       config: params.config,
       workspaceDir: params.workspaceDir,

--- a/src/plugins/config-contracts.ts
+++ b/src/plugins/config-contracts.ts
@@ -114,12 +114,6 @@ export function resolvePluginConfigContractsById(params: {
   fallbackToBundledMetadataForResolvedBundled?: boolean;
   fallbackBundledPluginIds?: readonly string[];
   pluginIds: readonly string[];
-  /**
-   * Pre-computed discovery result. When supplied, the bundled-fallback path
-   * skips its internal `discoverOpenClawPlugins` call so callers sharing a
-   * discovery snapshot across registry helpers avoid redundant filesystem
-   * walks.
-   */
   discovery?: PluginDiscoveryResult;
 }): ReadonlyMap<string, PluginConfigContractMetadata> {
   const matches = new Map<string, PluginConfigContractMetadata>();

--- a/src/plugins/discovery-threading.test.ts
+++ b/src/plugins/discovery-threading.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PluginDiscoveryResult } from "./discovery.js";
+
+const discoverOpenClawPluginsMock = vi.fn();
+
+vi.mock("./discovery.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./discovery.js")>();
+  return {
+    ...actual,
+    discoverOpenClawPlugins: (...args: unknown[]) => discoverOpenClawPluginsMock(...args),
+  };
+});
+
+const { loadPluginManifestRegistry } = await import("./manifest-registry.js");
+const { resolveInstalledPluginIndexRegistry } =
+  await import("./installed-plugin-index-registry.js");
+
+const emptyDiscovery: PluginDiscoveryResult = { candidates: [], diagnostics: [] };
+
+describe("discovery threading", () => {
+  beforeEach(() => {
+    discoverOpenClawPluginsMock.mockReset();
+    discoverOpenClawPluginsMock.mockReturnValue(emptyDiscovery);
+  });
+
+  describe("loadPluginManifestRegistry", () => {
+    it("skips internal discoverOpenClawPlugins when discovery is supplied", () => {
+      loadPluginManifestRegistry({ discovery: emptyDiscovery });
+      expect(discoverOpenClawPluginsMock).not.toHaveBeenCalled();
+    });
+
+    it("calls discoverOpenClawPlugins when neither discovery nor candidates supplied", () => {
+      loadPluginManifestRegistry({});
+      expect(discoverOpenClawPluginsMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("prefers explicit candidates over discovery when both are supplied", () => {
+      loadPluginManifestRegistry({ candidates: [], diagnostics: [], discovery: emptyDiscovery });
+      expect(discoverOpenClawPluginsMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("resolveInstalledPluginIndexRegistry", () => {
+    it("skips internal discoverOpenClawPlugins when discovery is supplied", () => {
+      resolveInstalledPluginIndexRegistry({ discovery: emptyDiscovery, installRecords: {} });
+      expect(discoverOpenClawPluginsMock).not.toHaveBeenCalled();
+    });
+
+    it("calls discoverOpenClawPlugins when neither discovery nor candidates supplied", () => {
+      resolveInstalledPluginIndexRegistry({ installRecords: {} });
+      expect(discoverOpenClawPluginsMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("prefers explicit candidates over discovery when both are supplied", () => {
+      resolveInstalledPluginIndexRegistry({
+        candidates: [],
+        discovery: emptyDiscovery,
+        installRecords: {},
+      });
+      expect(discoverOpenClawPluginsMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -504,11 +504,19 @@ function readCandidatePackageManifest(params: {
   origin: PluginOrigin;
   rejectHardlinks: boolean;
   rootRealPath?: string;
+  packageManifestCache?: Map<string, PackageManifest | null>;
 }): PackageManifest | null {
-  if (params.origin === "bundled") {
-    return readTrustedPackageManifest(params.dir);
+  const cacheKey = params.rootRealPath ?? path.resolve(params.dir);
+  const cached = params.packageManifestCache?.get(cacheKey);
+  if (cached !== undefined) {
+    return cached;
   }
-  return readPackageManifest(params.dir, params.rejectHardlinks, params.rootRealPath);
+  const manifest =
+    params.origin === "bundled"
+      ? readTrustedPackageManifest(params.dir)
+      : readPackageManifest(params.dir, params.rejectHardlinks, params.rootRealPath);
+  params.packageManifestCache?.set(cacheKey, manifest);
+  return manifest;
 }
 
 function deriveIdHint(params: {
@@ -748,6 +756,7 @@ function discoverInDirectory(params: {
   diagnostics: PluginDiagnostic[];
   seen: Set<string>;
   realpathCache: Map<string, string>;
+  packageManifestCache?: Map<string, PackageManifest | null>;
   recurseDirectories?: boolean;
   skipDirectories?: Set<string>;
   visitedDirectories?: Set<string>;
@@ -830,6 +839,7 @@ function discoverInDirectory(params: {
       origin: params.origin,
       rejectHardlinks,
       ...(fullPathRealPath !== undefined ? { rootRealPath: fullPathRealPath } : {}),
+      packageManifestCache: params.packageManifestCache,
     });
     const extensionResolution = resolvePackageExtensionEntries(manifest ?? undefined);
     if (
@@ -1016,6 +1026,7 @@ function discoverFromPath(params: {
   diagnostics: PluginDiagnostic[];
   seen: Set<string>;
   realpathCache: Map<string, string>;
+  packageManifestCache?: Map<string, PackageManifest | null>;
 }) {
   const resolved = resolveUserPath(params.rawPath, params.env);
   if (!fs.existsSync(resolved)) {
@@ -1073,6 +1084,7 @@ function discoverFromPath(params: {
       origin: params.origin,
       rejectHardlinks,
       ...(resolvedRealPath !== undefined ? { rootRealPath: resolvedRealPath } : {}),
+      packageManifestCache: params.packageManifestCache,
     });
     const extensionResolution = resolvePackageExtensionEntries(manifest ?? undefined);
     if (
@@ -1193,6 +1205,7 @@ function discoverFromPath(params: {
       diagnostics: params.diagnostics,
       seen: params.seen,
       realpathCache: params.realpathCache,
+      packageManifestCache: params.packageManifestCache,
       ...(params.requireBuiltRuntimeEntry !== undefined
         ? { requireBuiltRuntimeEntry: params.requireBuiltRuntimeEntry }
         : {}),
@@ -1220,6 +1233,7 @@ export function discoverOpenClawPlugins(params: {
       const result = createDiscoveryResult();
       const seen = new Set<string>();
       const realpathCache = new Map<string, string>();
+      const packageManifestCache = new Map<string, PackageManifest | null>();
       const extra = params.extraPaths ?? [];
       for (const extraPath of extra) {
         if (typeof extraPath !== "string") {
@@ -1251,6 +1265,7 @@ export function discoverOpenClawPlugins(params: {
           diagnostics: result.diagnostics,
           seen,
           realpathCache,
+          packageManifestCache,
         });
       }
       const workspaceMatchesBundledRoot = resolvesToSameDirectory(
@@ -1272,6 +1287,7 @@ export function discoverOpenClawPlugins(params: {
           diagnostics: result.diagnostics,
           seen,
           realpathCache,
+          packageManifestCache,
         });
       }
       return result;
@@ -1284,6 +1300,7 @@ export function discoverOpenClawPlugins(params: {
       const result = createDiscoveryResult();
       const seen = new Set<string>();
       const realpathCache = new Map<string, string>();
+      const packageManifestCache = new Map<string, PackageManifest | null>();
       for (const sourceOverlayDir of listBundledSourceOverlayDirs({
         bundledRoot: roots.stock,
         env,
@@ -1298,6 +1315,7 @@ export function discoverOpenClawPlugins(params: {
           diagnostics: result.diagnostics,
           seen,
           realpathCache,
+          packageManifestCache,
         });
         result.diagnostics.push({
           level: "warn",
@@ -1324,6 +1342,7 @@ export function discoverOpenClawPlugins(params: {
           diagnostics: result.diagnostics,
           seen,
           realpathCache,
+          packageManifestCache,
         });
       }
       const sourceCheckoutExtensionsDir = resolveBundledSourceCheckoutExtensionsDir(roots.stock);
@@ -1342,6 +1361,7 @@ export function discoverOpenClawPlugins(params: {
           diagnostics: result.diagnostics,
           seen,
           realpathCache,
+          packageManifestCache,
           skipDirectories: readChildDirectoryNames(roots.stock),
         });
       }
@@ -1364,6 +1384,7 @@ export function discoverOpenClawPlugins(params: {
           diagnostics: result.diagnostics,
           seen,
           realpathCache,
+          packageManifestCache,
         });
       }
       // Keep auto-discovered global extensions behind bundled plugins.
@@ -1379,6 +1400,7 @@ export function discoverOpenClawPlugins(params: {
         diagnostics: result.diagnostics,
         seen,
         realpathCache,
+        packageManifestCache,
       });
       return result;
     },

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -73,6 +73,7 @@ export type PluginCandidate = {
   packageOptionalDependencies?: PluginDependencySpecMap;
   bundledManifest?: PluginManifest;
   bundledManifestPath?: string;
+  rawPackageManifest?: PackageManifest;
 };
 
 export type PluginDiscoveryResult = {
@@ -665,6 +666,7 @@ function addCandidate(params: {
     packageManifest: getPackageManifestMetadata(manifest ?? undefined),
     packageDependencies: packageDependencies.dependencies,
     packageOptionalDependencies: packageDependencies.optionalDependencies,
+    rawPackageManifest: manifest ?? undefined,
     bundledManifest: params.bundledManifest,
     bundledManifestPath: params.bundledManifestPath,
   });

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -507,7 +507,13 @@ function readCandidatePackageManifest(params: {
   rootRealPath?: string;
   packageManifestCache?: Map<string, PackageManifest | null>;
 }): PackageManifest | null {
-  const cacheKey = params.rootRealPath ?? path.resolve(params.dir);
+  const trustMode =
+    params.origin === "bundled"
+      ? "trusted"
+      : params.rejectHardlinks
+        ? "external-reject"
+        : "external-allow";
+  const cacheKey = `${trustMode}:${params.rootRealPath ?? path.resolve(params.dir)}`;
   const cached = params.packageManifestCache?.get(cacheKey);
   if (cached !== undefined) {
     return cached;

--- a/src/plugins/installed-plugin-index-registry.ts
+++ b/src/plugins/installed-plugin-index-registry.ts
@@ -25,12 +25,14 @@ export function resolveInstalledPluginIndexRegistry(params: LoadInstalledPluginI
   const normalized = normalizePluginsConfig(params.config?.plugins);
   const installRecords =
     params.installRecords ?? loadInstalledPluginIndexInstallRecordsSync({ env: params.env });
-  const discovery = discoverOpenClawPlugins({
-    workspaceDir: params.workspaceDir,
-    extraPaths: normalized.loadPaths,
-    env: params.env,
-    installRecords,
-  });
+  const discovery =
+    params.discovery ??
+    discoverOpenClawPlugins({
+      workspaceDir: params.workspaceDir,
+      extraPaths: normalized.loadPaths,
+      env: params.env,
+      installRecords,
+    });
   return {
     candidates: discovery.candidates,
     registry: loadPluginManifestRegistry({

--- a/src/plugins/installed-plugin-index-types.ts
+++ b/src/plugins/installed-plugin-index-types.ts
@@ -1,7 +1,7 @@
 import type { OpenClawConfig } from "../config/types.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import type { PluginCompatCode } from "./compat/registry.js";
-import type { PluginCandidate } from "./discovery.js";
+import type { PluginCandidate, PluginDiscoveryResult } from "./discovery.js";
 import type { PluginInstallSourceInfo } from "./install-source-info.js";
 import type { InstalledPluginFileSignature } from "./installed-plugin-index-hash.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
@@ -130,6 +130,13 @@ export type LoadInstalledPluginIndexParams = {
   installRecords?: Record<string, PluginInstallRecord>;
   candidates?: PluginCandidate[];
   diagnostics?: PluginDiagnostic[];
+  /**
+   * Pre-computed discovery result. When supplied (and `candidates` is not),
+   * the internal `discoverOpenClawPlugins` call is skipped. Callers sharing a
+   * discovery snapshot across registry helpers in the same flow should supply
+   * this to avoid redundant filesystem walks.
+   */
+  discovery?: PluginDiscoveryResult;
   now?: () => Date;
 };
 

--- a/src/plugins/installed-plugin-index-types.ts
+++ b/src/plugins/installed-plugin-index-types.ts
@@ -130,12 +130,6 @@ export type LoadInstalledPluginIndexParams = {
   installRecords?: Record<string, PluginInstallRecord>;
   candidates?: PluginCandidate[];
   diagnostics?: PluginDiagnostic[];
-  /**
-   * Pre-computed discovery result. When supplied (and `candidates` is not),
-   * the internal `discoverOpenClawPlugins` call is skipped. Callers sharing a
-   * discovery snapshot across registry helpers in the same flow should supply
-   * this to avoid redundant filesystem walks.
-   */
   discovery?: PluginDiscoveryResult;
   now?: () => Date;
 };

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -50,7 +50,11 @@ import {
   type NormalizedPluginsConfig,
 } from "./config-state.js";
 import { isPluginEnabledByDefaultForPlatform } from "./default-enablement.js";
-import { discoverOpenClawPlugins, type PluginCandidate } from "./discovery.js";
+import {
+  discoverOpenClawPlugins,
+  type PluginCandidate,
+  type PluginDiscoveryResult,
+} from "./discovery.js";
 import { shouldRejectHardlinkedPluginFiles } from "./hardlink-policy.js";
 import { getGlobalHookRunner, initializeGlobalHookRunner } from "./hook-runner-global.js";
 import { toSafeImportPath } from "./import-specifier.js";
@@ -198,6 +202,14 @@ export type PluginLoadOptions = {
   loadModules?: boolean;
   throwOnLoadError?: boolean;
   manifestRegistry?: PluginManifestRegistry;
+  /**
+   * Pre-computed plugin discovery result. When supplied, internal calls to
+   * `discoverOpenClawPlugins` are skipped. Callers in the same startup flow
+   * can compute one discovery result and share it across loader entry points
+   * to eliminate redundant filesystem walks. Ignored when `manifestRegistry`
+   * is also provided (the registry already implies a discovery snapshot).
+   */
+  discovery?: PluginDiscoveryResult;
 };
 
 function detailPluginStartupTrace(
@@ -1690,12 +1702,13 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
           candidates: createPluginCandidatesFromManifestRegistry(suppliedManifestRegistry),
           diagnostics: [] as PluginDiagnostic[],
         }
-      : discoverOpenClawPlugins({
+      : (options.discovery ??
+        discoverOpenClawPlugins({
           workspaceDir: options.workspaceDir,
           extraPaths: normalized.loadPaths,
           env,
           installRecords,
-        });
+        }));
     const manifestRegistry =
       suppliedManifestRegistry ??
       loadPluginManifestRegistry({
@@ -2559,12 +2572,14 @@ export async function loadOpenClawPluginCliRegistry(
     activateGlobalSideEffects: false,
   });
 
-  const discovery = discoverOpenClawPlugins({
-    workspaceDir: options.workspaceDir,
-    extraPaths: normalized.loadPaths,
-    env,
-    installRecords,
-  });
+  const discovery =
+    options.discovery ??
+    discoverOpenClawPlugins({
+      workspaceDir: options.workspaceDir,
+      extraPaths: normalized.loadPaths,
+      env,
+      installRecords,
+    });
   const manifestRegistry = loadPluginManifestRegistry({
     config: cfg,
     workspaceDir: options.workspaceDir,

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -202,13 +202,6 @@ export type PluginLoadOptions = {
   loadModules?: boolean;
   throwOnLoadError?: boolean;
   manifestRegistry?: PluginManifestRegistry;
-  /**
-   * Pre-computed plugin discovery result. When supplied, internal calls to
-   * `discoverOpenClawPlugins` are skipped. Callers in the same startup flow
-   * can compute one discovery result and share it across loader entry points
-   * to eliminate redundant filesystem walks. Ignored when `manifestRegistry`
-   * is also provided (the registry already implies a discovery snapshot).
-   */
   discovery?: PluginDiscoveryResult;
 };
 

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -10,7 +10,11 @@ import { resolveUserPath } from "../utils.js";
 import { resolveCompatibilityHostVersion } from "../version.js";
 import { loadBundleManifest } from "./bundle-manifest.js";
 import { normalizePluginsConfigWithResolver } from "./config-policy.js";
-import { discoverOpenClawPlugins, type PluginCandidate } from "./discovery.js";
+import {
+  discoverOpenClawPlugins,
+  type PluginCandidate,
+  type PluginDiscoveryResult,
+} from "./discovery.js";
 import { shouldRejectHardlinkedPluginFiles } from "./hardlink-policy.js";
 import { loadInstalledPluginIndexInstallRecordsSync } from "./installed-plugin-index-record-reader.js";
 import type { PluginManifestCommandAlias } from "./manifest-command-aliases.js";
@@ -916,6 +920,13 @@ export function loadPluginManifestRegistry(
     diagnostics?: PluginDiagnostic[];
     installRecords?: Record<string, PluginInstallRecord>;
     bundledChannelConfigCollector?: BundledChannelConfigCollector;
+    /**
+     * Pre-computed discovery result. When supplied (and `candidates` is not),
+     * the internal `discoverOpenClawPlugins` call is skipped. Callers sharing
+     * a discovery snapshot across multiple registry helpers in the same flow
+     * should supply this to avoid redundant filesystem walks.
+     */
+    discovery?: PluginDiscoveryResult;
   } = {},
 ): PluginManifestRegistry {
   const config = params.config ?? {};
@@ -936,12 +947,13 @@ export function loadPluginManifestRegistry(
         candidates: params.candidates,
         diagnostics: params.diagnostics ?? [],
       }
-    : discoverOpenClawPlugins({
+    : (params.discovery ??
+      discoverOpenClawPlugins({
         workspaceDir: params.workspaceDir,
         extraPaths: normalized.loadPaths,
         env,
         installRecords: getInstallRecords(),
-      });
+      }));
   const diagnostics: PluginDiagnostic[] = [...discovery.diagnostics];
   const candidates: PluginCandidate[] = discovery.candidates;
   const records: PluginManifestRecord[] = [];

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -920,12 +920,6 @@ export function loadPluginManifestRegistry(
     diagnostics?: PluginDiagnostic[];
     installRecords?: Record<string, PluginInstallRecord>;
     bundledChannelConfigCollector?: BundledChannelConfigCollector;
-    /**
-     * Pre-computed discovery result. When supplied (and `candidates` is not),
-     * the internal `discoverOpenClawPlugins` call is skipped. Callers sharing
-     * a discovery snapshot across multiple registry helpers in the same flow
-     * should supply this to avoid redundant filesystem walks.
-     */
     discovery?: PluginDiscoveryResult;
   } = {},
 ): PluginManifestRegistry {


### PR DESCRIPTION
## Summary

Investigates and fixes the inner amplifier — why each plugin's `package.json` was being read ~1,565 times per TUI startup. Stacked on top of #84283.

**Root cause:** `runPluginDiscovery` runs two `tracePluginLifecyclePhase("discovery scan")` blocks (scoped + shared), each invoking multiple overlapping helpers (`discoverFromPath`, `discoverInDirectory`) that all call `readCandidatePackageManifest` per candidate. For bundled plugins reachable through multiple roots (stock root + source-checkout extensions + bundled overlays + installed paths + global root), the same `package.json` gets read once per code path per scan — and the per-helper `seen: Set<string>` dedup operates at the candidate level *after* the manifest read happens. The existing `realpathCache` only memoizes realpath resolution, not the JSON parse.

**Fix:** add a per-scan `Map<string, PackageManifest | null>` threaded through the same chain as `realpathCache`, keyed by `${trustMode}:${rootRealPath}`. Trust mode separates `trusted` (bundled, no hardlink check) from `external-reject` / `external-allow` so the cache can't reuse a trusted parse for a later external-origin read that needs hardlink rejection. Cache lifetime is one scan — created in `runPluginDiscovery` alongside the existing `seen`/`realpathCache`, dies when the scan returns. `discoverOpenClawPlugins` remains stateless externally.

This PR is complementary to #84283:
- #84283: collapses multiple outer scans into one per `ensurePluginRegistryLoaded` invocation.
- This PR: makes each remaining outer scan read each manifest once instead of N times.

## Commits

1. `perf(plugins): scan-scoped package.json cache in discovery` — the cache + threading.
2. `perf(plugins): expose raw parsed package.json on PluginCandidate` — keeps the parsed manifest on the candidate so downstream iterators don't have to re-read.
3. `perf(plugins): make package-manifest cache key trust-aware` — keys the cache by `${trustMode}:${realPath}` so trusted/external/hardlink-rejecting reads don't cross. (Addresses clawsweeper P1.)

## Expected impact

From the original profile (~1,565 reads per extension `package.json`):
- The scan-scoped cache caps within-scan reads at 1 per file per trust mode.
- Combined with #84283, expected post-fix reads per file ≈ **1-2 across one CLI/TUI startup**.
- Estimated reduction: from ~1,565 to ~1-2 per file. **~99% of the inner amplifier eliminated.**

Not measured end-to-end yet — single-launch impact depends on root overlap in the user's environment. If most reads were already from a single root (no overlap), savings are smaller.

## Test plan

- [x] `node scripts/run-vitest.mjs src/plugins/discovery.test.ts` — 67/67 pass
- [x] `pnpm tsgo --noEmit --project tsconfig.core.json` — clean
- [x] `node scripts/run-oxlint.mjs --quiet src/plugins/discovery.ts` — 0/0
- [x] `npx oxfmt --check` — clean
- [ ] End-to-end TUI startup measurement (recommended; pop the audit-branch perf-trace stash, rebuild, launch TUI, count `json.tryReadJsonSync` lines per `extensions/<id>/package.json` path in `/tmp/openclaw-perf.log`).
