### PR TITLE
fix(cli): reject invalid node run port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/node: reject invalid explicit `node run --port` values instead of silently falling back to the configured or default port. Fixes #83923. Thanks @davinci282828.
 - CLI: reject explicit port numbers above 65535 before they reach Gateway or Node bind paths. Fixes #83900. (#84008) Thanks @hclsys.
 - Codex app-server: preserve plugin tool auth profiles when Codex owns model transport so OpenClaw dynamic tools can resolve their provider credentials. (#83603) Thanks @rubencu.
 - Memory/search: scan the JS-side fallback vector path (used when the sqlite-vec index is unavailable or has a mismatched dimension) in bounded rowid batches and yield to the event loop between batches so large chunk tables can no longer pin the Node.js main thread for multi-second windows. Also keeps the SQL prepared statement rooted in a local so node:sqlite cannot finalize it mid-scan under heap pressure. Fixes #81172. Thanks @dev23xyz-oss.

--- a/src/cli/node-cli/register.test.ts
+++ b/src/cli/node-cli/register.test.ts
@@ -1,8 +1,16 @@
 import { Command } from "commander";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { registerNodeCli } from "./register.js";
 
+type LoadNodeHostConfig = typeof import("../../node-host/config.js").loadNodeHostConfig;
+
 const daemonMocks = vi.hoisted(() => ({
+  defaultRuntime: {
+    error: vi.fn(),
+    exit: vi.fn(),
+  },
+  loadNodeHostConfig: vi.fn<LoadNodeHostConfig>(async () => null),
+  runNodeHost: vi.fn(),
   runNodeDaemonInstall: vi.fn(),
   runNodeDaemonRestart: vi.fn(),
   runNodeDaemonStart: vi.fn(),
@@ -14,11 +22,15 @@ const daemonMocks = vi.hoisted(() => ({
 vi.mock("./daemon.js", () => daemonMocks);
 
 vi.mock("../../node-host/config.js", () => ({
-  loadNodeHostConfig: vi.fn(async () => null),
+  loadNodeHostConfig: daemonMocks.loadNodeHostConfig,
 }));
 
 vi.mock("../../node-host/runner.js", () => ({
-  runNodeHost: vi.fn(),
+  runNodeHost: daemonMocks.runNodeHost,
+}));
+
+vi.mock("../../runtime.js", () => ({
+  defaultRuntime: daemonMocks.defaultRuntime,
 }));
 
 function createProgram(): Command {
@@ -33,11 +45,62 @@ function createProgram(): Command {
 }
 
 describe("registerNodeCli", () => {
+  beforeEach(() => {
+    daemonMocks.defaultRuntime.error.mockClear();
+    daemonMocks.defaultRuntime.exit.mockClear();
+    daemonMocks.loadNodeHostConfig.mockClear();
+    daemonMocks.loadNodeHostConfig.mockResolvedValue(null);
+    daemonMocks.runNodeHost.mockClear();
+    daemonMocks.runNodeDaemonInstall.mockClear();
+    daemonMocks.runNodeDaemonRestart.mockClear();
+    daemonMocks.runNodeDaemonStart.mockClear();
+    daemonMocks.runNodeDaemonStatus.mockClear();
+    daemonMocks.runNodeDaemonStop.mockClear();
+    daemonMocks.runNodeDaemonUninstall.mockClear();
+  });
+
   it("registers node start for the macOS app node service manager", async () => {
     const program = createProgram();
 
     await program.parseAsync(["node", "start", "--json"], { from: "user" });
 
     expect(daemonMocks.runNodeDaemonStart.mock.calls[0]?.[0]?.json).toBe(true);
+  });
+
+  it("rejects an explicit invalid node run port", async () => {
+    const program = createProgram();
+
+    await program.parseAsync(["node", "run", "--port", "abc"], { from: "user" });
+
+    expect(daemonMocks.runNodeHost).not.toHaveBeenCalled();
+    expect(daemonMocks.defaultRuntime.error).toHaveBeenCalledWith(
+      expect.stringContaining("Invalid --port"),
+    );
+    expect(daemonMocks.defaultRuntime.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("uses an explicit valid node run port", async () => {
+    const program = createProgram();
+
+    await program.parseAsync(["node", "run", "--port", "19000"], { from: "user" });
+
+    expect(daemonMocks.runNodeHost).toHaveBeenCalledWith(
+      expect.objectContaining({ gatewayPort: 19000 }),
+    );
+  });
+
+  it("falls back to configured node run port when --port is omitted", async () => {
+    daemonMocks.loadNodeHostConfig.mockResolvedValue({
+      version: 1,
+      nodeId: "node-existing",
+      gateway: { host: "10.0.0.2", port: 19001 },
+    });
+    const program = createProgram();
+
+    await program.parseAsync(["node", "run"], { from: "user" });
+
+    expect(daemonMocks.runNodeHost).toHaveBeenCalledWith(
+      expect.objectContaining({ gatewayHost: "10.0.0.2", gatewayPort: 19001 }),
+    );
   });
 });

--- a/src/cli/node-cli/register.ts
+++ b/src/cli/node-cli/register.ts
@@ -1,10 +1,12 @@
 import type { Command } from "commander";
 import { loadNodeHostConfig } from "../../node-host/config.js";
 import { runNodeHost } from "../../node-host/runner.js";
+import { defaultRuntime } from "../../runtime.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import { formatDocsLink } from "../../terminal/links.js";
 import { theme } from "../../terminal/theme.js";
 import { parsePort } from "../daemon-cli/shared.js";
+import { formatInvalidPortOption } from "../error-format.js";
 import { formatHelpExamples } from "../help-format.js";
 import {
   runNodeDaemonInstall,
@@ -15,9 +17,11 @@ import {
   runNodeDaemonUninstall,
 } from "./daemon.js";
 
-function parsePortWithFallback(value: unknown, fallback: number): number {
-  const parsed = parsePort(value);
-  return parsed ?? fallback;
+function parsePortOption(value: unknown, fallback: number): number | null {
+  if (value === undefined) {
+    return fallback;
+  }
+  return parsePort(value);
 }
 
 export function registerNodeCli(program: Command) {
@@ -54,7 +58,12 @@ export function registerNodeCli(program: Command) {
         normalizeOptionalString(opts.host as string | undefined) ||
         existing?.gateway?.host ||
         "127.0.0.1";
-      const port = parsePortWithFallback(opts.port, existing?.gateway?.port ?? 18789);
+      const port = parsePortOption(opts.port, existing?.gateway?.port ?? 18789);
+      if (port === null) {
+        defaultRuntime.error(formatInvalidPortOption("--port"));
+        defaultRuntime.exit(1);
+        return;
+      }
       await runNodeHost({
         gatewayHost: host,
         gatewayPort: port,


### PR DESCRIPTION
## Summary

- Reject explicit invalid `openclaw node run --port` values instead of falling back to the configured or default port.
- Add focused node CLI registration coverage for invalid, valid, and omitted `--port` values.
- Add the user-visible fix to the changelog.

Fixes #83923.

## Verification

- `git diff --check HEAD~1..HEAD -- CHANGELOG.md src/cli/node-cli/register.ts src/cli/node-cli/register.test.ts`
- Crabbox AWS `cbx_b19076fdaf79`, run `run_26642c3eee98`: regression failed before the source patch, then `node scripts/run-vitest.mjs src/cli/node-cli/register.test.ts -- --reporter=verbose` passed after the patch (`4/4`).
- WSL Ubuntu 24.04 checkout at PR head `c6a8ad803a48e4f19577b3c9ed9942fedfd707f5`: `timeout 10s node scripts/run-node.mjs node run --port abc` exited before starting the node host.

Behavior addressed: `openclaw node run --port abc` now reports `Invalid --port` and exits before starting the node host.
Real environment tested: AWS Crabbox Linux lease `cbx_b19076fdaf79`, run `run_26642c3eee98`; WSL Ubuntu 24.04 checkout at PR head `c6a8ad803a48e4f19577b3c9ed9942fedfd707f5`.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/cli/node-cli/register.test.ts -- --reporter=verbose`; `OPENCLAW_HOME="$(mktemp -d)" timeout 10s node scripts/run-node.mjs node run --port abc`.
Evidence after fix: focused Vitest passed with `4 passed`; scoped `git diff --check` passed; the foreground CLI proof returned `exit_status=1`, stderr `Invalid --port. Use a port number from 1 to 65535, for example 18789.`, and `pgrep -af 'openclaw node run|node-host|src/node-host|run-node.mjs node run'` printed no matching process afterward.
Observed result after fix: invalid explicit `--port` fails fast with the user-facing validation error and does not leave a node host running; valid explicit and omitted ports still dispatch with the expected gateway port in focused registration coverage.
What was not tested: no live gateway connection was attempted, because the invalid explicit port path should exit before connecting.
