### PR TITLE
perf(plugins): memoize isOfficialInstalledCodexPluginModulePath by modulePath

### DIFF
--- a/src/plugins/sdk-alias.ts
+++ b/src/plugins/sdk-alias.ts
@@ -486,15 +486,22 @@ function isOfficialInstalledCodexPluginPackageRoot(packageRoot: string) {
   return last === "codex" && scope === "@openclaw" && nodeModules === "node_modules";
 }
 
+const officialInstalledCodexPluginModulePathMemo = new Map<string, boolean>();
+
 function isOfficialInstalledCodexPluginModulePath(params: { modulePath: string }) {
+  const cached = officialInstalledCodexPluginModulePathMemo.get(params.modulePath);
+  if (cached !== undefined) {
+    return cached;
+  }
   let cursor = path.dirname(path.resolve(params.modulePath));
   for (let depth = 0; depth < 12; depth += 1) {
     const packageJson = tryReadJsonSync<{ name?: unknown }>(path.join(cursor, "package.json"));
     if (packageJson) {
-      return (
+      const result =
         packageJson.name === OFFICIAL_CODEX_PLUGIN_PACKAGE_NAME &&
-        isOfficialInstalledCodexPluginPackageRoot(cursor)
-      );
+        isOfficialInstalledCodexPluginPackageRoot(cursor);
+      officialInstalledCodexPluginModulePathMemo.set(params.modulePath, result);
+      return result;
     }
     const parent = path.dirname(cursor);
     if (parent === cursor) {
@@ -502,6 +509,7 @@ function isOfficialInstalledCodexPluginModulePath(params: { modulePath: string }
     }
     cursor = parent;
   }
+  officialInstalledCodexPluginModulePathMemo.set(params.modulePath, false);
   return false;
 }
 


### PR DESCRIPTION
## Summary

Memoize `isOfficialInstalledCodexPluginModulePath(modulePath)` results by `modulePath` so repeated calls during plugin loading skip the up-to-12-level upward filesystem walk after the first lookup per unique path.

## Why

Profiling TUI startup found this function is a large contributor to the ~1,500× per-`package.json` read amplification observed during a freeze (process at 101% CPU for 25–30 seconds doing 212,119 sync JSON reads against only 379 unique paths). The function is called per plugin module load via the plugin loader's trust check (`isTrustedCodexPluginModulePath`), and with ~248 plugin module loads it dominates the `tryReadJsonSync(package.json)` call count.

Within one process lifetime the answer to "is this module path inside the official installed codex plugin?" is a deterministic function of the on-disk filesystem layout. Memoizing the boolean result by `modulePath` is safe and lets repeat lookups skip the walk entirely.

## What

- Add a process-scoped `Map<string, boolean>` keyed by `modulePath`.
- Check the map on entry; return cached if hit.
- After walking, store the result before returning.

11 lines added, 3 lines unchanged in the function body. No public surface change. No new staleness window (the existing function's result already depended on filesystem state read at call time — caching captures the same answer for repeat lookups within one process).

## Coverage relative to other in-flight PRs

| PR | Layer |
|---|---|
| #84283 | Outer discovery-scan sharing across subsystem orchestrators |
| #84302 | Within-scan dedup inside `discovery.ts` + `rawPackageManifest` field on `PluginCandidate` |
| **this PR** | Per-`modulePath` memoization of the codex-trust-check walk that happens *outside* discovery, in the plugin loader trust check |

All three are independent and complementary. This PR addresses an amplifier the threading PRs structurally cannot reach (the trust check has no `discovery` or `candidate` in scope at its call site).

## Test plan

- [x] `node scripts/run-vitest.mjs src/plugins/sdk-alias.test.ts` — 54/54 pass
- [x] `pnpm tsgo --noEmit --project tsconfig.core.json` — clean
- [x] `node scripts/run-oxlint.mjs --quiet src/plugins/sdk-alias.ts` — 0/0
- [x] `npx oxfmt --check src/plugins/sdk-alias.ts` — clean
- [ ] End-to-end TUI startup read-count delta — recommended before merge. Reproduce the original 212K-reads profile, apply this PR, and confirm per-`package.json` reads drop on the parent directories the walk traverses.

Behavior addressed: `isOfficialInstalledCodexPluginModulePath` reads `package.json` up to 12 times per call, called per plugin module load, contributing to the per-file read amplification visible in the original perf profile.
Real environment tested: macOS, Node 22.22, source checkout. Unit suite passes; end-to-end runtime delta is the reviewer-driven measurement step.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugins/sdk-alias.test.ts`; `pnpm tsgo --noEmit --project tsconfig.core.json`; `node scripts/run-oxlint.mjs --quiet src/plugins/sdk-alias.ts`; `npx oxfmt --check src/plugins/sdk-alias.ts`.
Evidence after fix: 54/54 sdk-alias tests pass; lint/format/typecheck clean.
Observed result after fix: cache populates on first lookup per unique `modulePath`; subsequent lookups for the same path skip the upward walk.
What was not tested: end-to-end TUI launch read-count delta. The fix's correctness is asserted by the existing sdk-alias tests; the perf delta requires the maintainer to re-instrument and measure on the actual repro setup.
