### PR TITLE
fix(slack): suppress reasoning payloads in non-streaming delivery paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 - Memory-core/dreaming: reuse stable narrative subagent session keys per workspace and phase while keeping per-run idempotency and bounded cleanup, so stale `dreaming-narrative-*` sessions do not accumulate. Fixes #68252, #69187, and #70402. (#70464) Thanks @chiyouYCH.
 - Trajectory/support: tolerate partial skill snapshot entries when building support metadata so rejected skill path scans no longer abort trajectory capture. (#71185) Thanks @lukeboyett.
 - Telegram: honor `channels.telegram.pollingStallThresholdMs` in the default isolated polling path, restarting silent workers instead of leaving inbound updates wedged. Fixes #83950. (#84861) Thanks @joshavant.
+- Slack: suppress reasoning payloads before reply delivery and dispatch accounting, so Slack monitor, slash-command, fallback, and direct reply paths do not leak model reasoning. Fixes #84319. (#84322) Thanks @ffluk3 and @joshavant.
 - Agents/Pi: disable the embedded pi-coding-agent runtime auto-retry so OpenClaw's own retry and failover loop does not replay failed tool calls through a nested SDK retry. Fixes #73781. (#74434) Thanks @yelog.
 - CLI/perf: keep `setup --help`, `onboard --help`, and `configure --help` out of the full wizard runtime while preserving the existing help output. (#84488) Thanks @frankekn.
 - CLI/perf: keep `agents --help` out of agents action/runtime imports so help, completion, and command discovery paths avoid loading the full agents runtime. (#84483) Thanks @frankekn.

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -74,29 +74,23 @@ let capturedTyping:
       onStopError?: (err: unknown) => void;
     }
   | undefined;
+type TestReplyDispatchKind = "tool" | "block" | "final";
+type TestReplyPayload = {
+  text?: string;
+  isError?: boolean;
+  isReasoning?: boolean;
+  mediaUrl?: string;
+  mediaUrls?: string[];
+  audioAsVoice?: boolean;
+  spokenText?: string;
+  ttsSupplement?: { spokenText: string; visibleTextAlreadyDelivered?: boolean };
+};
+type TestDispatchCounts = Record<TestReplyDispatchKind, number>;
 let mockedDispatchSequence: Array<{
-  kind: "tool" | "block" | "final";
-  payload: {
-    text?: string;
-    isError?: boolean;
-    isReasoning?: boolean;
-    mediaUrl?: string;
-    mediaUrls?: string[];
-    audioAsVoice?: boolean;
-    spokenText?: string;
-    ttsSupplement?: { spokenText: string; visibleTextAlreadyDelivered?: boolean };
-  };
+  kind: TestReplyDispatchKind;
+  payload: TestReplyPayload;
 }> = [];
-
-function countFinalDispatches(): number {
-  let count = 0;
-  for (const entry of mockedDispatchSequence) {
-    if (entry.kind === "final") {
-      count++;
-    }
-  }
-  return count;
-}
+let mockedQueuedDispatchCounts: TestDispatchCounts = { tool: 0, block: 0, final: 0 };
 
 let mockedProgressEvents: string[] = [];
 let mockedReplyOptionEvents: Array<
@@ -305,6 +299,7 @@ vi.mock("openclaw/plugin-sdk/channel-message", async (importOriginal) => {
   return {
     ...actual,
     createChannelMessageReplyPipeline: (params: {
+      transformReplyPayload?: (payload: TestReplyPayload) => TestReplyPayload | null;
       typing?: {
         start: () => Promise<void>;
         stop?: () => Promise<void>;
@@ -323,6 +318,9 @@ vi.mock("openclaw/plugin-sdk/channel-message", async (importOriginal) => {
                 },
               },
             }
+          : {}),
+        ...(params.transformReplyPayload
+          ? { transformReplyPayload: params.transformReplyPayload }
           : {}),
         onModelSelected: undefined,
       };
@@ -592,6 +590,7 @@ vi.mock("openclaw/plugin-sdk/security-runtime", () => ({
 
 vi.mock("openclaw/plugin-sdk/string-coerce-runtime", () => ({
   normalizeOptionalLowercaseString: (value?: string) => value?.toLowerCase(),
+  normalizeOptionalString: (value?: string) => value,
 }));
 
 vi.mock("../../actions.js", () => ({
@@ -684,10 +683,30 @@ vi.mock("../replies.js", () => ({
 
 vi.mock("../reply.runtime.js", () => ({
   createReplyDispatcherWithTyping: (params: {
-    deliver: (payload: unknown, info: { kind: "tool" | "block" | "final" }) => Promise<void>;
+    transformReplyPayload?: (payload: TestReplyPayload) => TestReplyPayload | null;
+    beforeDeliver?: (
+      payload: TestReplyPayload,
+      info: { kind: TestReplyDispatchKind },
+    ) => Promise<TestReplyPayload | null> | TestReplyPayload | null;
+    deliver: (payload: TestReplyPayload, info: { kind: TestReplyDispatchKind }) => Promise<void>;
   }) => ({
     dispatcher: {
-      deliver: params.deliver,
+      deliver: async (payload: TestReplyPayload, info: { kind: TestReplyDispatchKind }) => {
+        const transformed = params.transformReplyPayload
+          ? params.transformReplyPayload(payload)
+          : payload;
+        if (!transformed) {
+          return;
+        }
+        const deliverPayload = params.beforeDeliver
+          ? await params.beforeDeliver(transformed, info)
+          : transformed;
+        if (!deliverPayload) {
+          return;
+        }
+        mockedQueuedDispatchCounts[info.kind] += 1;
+        await params.deliver(deliverPayload, info);
+      },
     },
     replyOptions: {},
     markDispatchIdle: () => {},
@@ -709,19 +728,7 @@ vi.mock("../reply.runtime.js", () => ({
       onPartialReply?: (payload: { text: string }) => Promise<void> | void;
     };
     dispatcher: {
-      deliver: (
-        payload: {
-          text?: string;
-          isError?: boolean;
-          isReasoning?: boolean;
-          mediaUrl?: string;
-          mediaUrls?: string[];
-          audioAsVoice?: boolean;
-          spokenText?: string;
-          ttsSupplement?: { spokenText: string; visibleTextAlreadyDelivered?: boolean };
-        },
-        info: { kind: "tool" | "block" | "final" },
-      ) => Promise<void>;
+      deliver: (payload: TestReplyPayload, info: { kind: TestReplyDispatchKind }) => Promise<void>;
     };
   }) => {
     capturedReplyOptions = params.replyOptions;
@@ -752,9 +759,7 @@ vi.mock("../reply.runtime.js", () => ({
     }
     return {
       queuedFinal: false,
-      counts: {
-        final: countFinalDispatches(),
-      },
+      counts: { ...mockedQueuedDispatchCounts },
     };
   },
 }));
@@ -797,6 +802,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     mockedReplyThreadTsSequence = undefined;
     mockedSlackReplyBlocks = undefined;
     mockedDispatchSequence = [{ kind: "final", payload: { text: FINAL_REPLY_TEXT } }];
+    mockedQueuedDispatchCounts = { tool: 0, block: 0, final: 0 };
     mockedProgressEvents = [];
     mockedReplyOptionEvents = [];
 
@@ -1425,6 +1431,98 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     });
     expect(appendSlackStreamMock).not.toHaveBeenCalled();
     expect(deliverRepliesMock).not.toHaveBeenCalled();
+  });
+
+  it("suppresses reasoning payloads in the non-streaming delivery path", async () => {
+    mockedNativeStreaming = false;
+    mockedDispatchSequence = [
+      { kind: "block", payload: { text: "Reasoning:\n_hidden_", isReasoning: true } },
+      { kind: "final", payload: { text: FINAL_REPLY_TEXT } },
+    ];
+
+    await dispatchPreparedSlackMessage(createPreparedSlackMessage());
+
+    expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
+    expectDeliverReplyCall(0, FINAL_REPLY_TEXT);
+  });
+
+  it("does not count suppressed reasoning-only payloads as delivered", async () => {
+    mockedNativeStreaming = false;
+    mockedDispatchSequence = [
+      { kind: "final", payload: { text: "Reasoning:\n_hidden_", isReasoning: true } },
+    ];
+
+    await dispatchPreparedSlackMessage(
+      createPreparedSlackMessage({
+        cfg: {
+          messages: {
+            statusReactions: { enabled: true },
+          },
+        },
+        ackReactionMessageTs: "171234.111",
+        ackReactionPromise: Promise.resolve(true),
+      }),
+    );
+
+    expect(deliverRepliesMock).not.toHaveBeenCalled();
+    expect(statusReactionControllerMock.setDone).not.toHaveBeenCalled();
+    expect(statusReactionControllerMock.restoreInitial).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not consume first-reply delivery state for suppressed reasoning payloads", async () => {
+    mockedNativeStreaming = false;
+    mockedReplyThreadTsSequence = [THREAD_TS, undefined];
+    mockedDispatchSequence = [
+      { kind: "block", payload: { text: "hidden", isReasoning: true } },
+      { kind: "final", payload: { text: FINAL_REPLY_TEXT } },
+    ];
+
+    await dispatchPreparedSlackMessage(
+      createPreparedSlackMessage({
+        replyToMode: "first",
+      }),
+    );
+
+    expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
+    expectDeliverReplyCall(0, FINAL_REPLY_TEXT, { replyThreadTs: THREAD_TS });
+  });
+
+  it("suppresses reasoning payloads in non-streaming delivery when mixed with tool payloads", async () => {
+    mockedNativeStreaming = false;
+    mockedDispatchSequence = [
+      { kind: "tool", payload: { text: "tool result" } },
+      { kind: "block", payload: { text: "Let me think about this...", isReasoning: true } },
+      { kind: "block", payload: { text: "I need to consider...", isReasoning: true } },
+      { kind: "final", payload: { text: FINAL_REPLY_TEXT } },
+    ];
+
+    await dispatchPreparedSlackMessage(createPreparedSlackMessage());
+
+    expect(deliverRepliesMock).toHaveBeenCalledTimes(2);
+    expectDeliverReplyCall(0, "tool result");
+    expectDeliverReplyCall(1, FINAL_REPLY_TEXT);
+  });
+
+  it("suppresses reasoning payloads via deliverNormally fallback from streaming errors", async () => {
+    mockedNativeStreaming = true;
+    mockedDispatchSequence = [
+      { kind: "block", payload: { text: "Let me analyze...", isReasoning: true } },
+      { kind: "final", payload: { text: FINAL_REPLY_TEXT } },
+    ];
+    startSlackStreamMock.mockRejectedValueOnce(new Error("stream setup failed"));
+
+    await dispatchPreparedSlackMessage(createPreparedSlackMessage());
+
+    for (const call of deliverRepliesMock.mock.calls) {
+      const params = (call as unknown[])[0] as {
+        replies: Array<{ isReasoning?: boolean }>;
+      };
+      for (const reply of params.replies) {
+        expect(reply.isReasoning).not.toBe(true);
+      }
+    }
+    expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
+    expectDeliverReplyCall(0, FINAL_REPLY_TEXT);
   });
 
   it("keeps same-content tool and final payloads distinct after preview fallback", async () => {

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -488,10 +488,14 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     agentId: route.agentId,
     channel: "slack",
     accountId: route.accountId,
-    transformReplyPayload: (payload) =>
-      isSlackInteractiveRepliesEnabled({ cfg, accountId: route.accountId })
+    transformReplyPayload: (payload) => {
+      if (payload.isReasoning === true) {
+        return null;
+      }
+      return isSlackInteractiveRepliesEnabled({ cfg, accountId: route.accountId })
         ? compileSlackInteractiveReplies(payload)
-        : payload,
+        : payload;
+    },
     typing: {
       start: async () => {
         didSetStatus = true;
@@ -663,6 +667,9 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     kind: ReplyDispatchKind;
     forcedThreadTs?: string;
   }): Promise<void> => {
+    if (params.payload.isReasoning === true) {
+      return;
+    }
     const replyThreadTs = resolveDeliveryThreadTs(params);
     if (
       deliveryTracker.hasDelivered({
@@ -893,6 +900,9 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     ...replyPipeline,
     humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
     deliver: async (payload, info) => {
+      if (payload.isReasoning === true) {
+        return;
+      }
       if (useStreaming) {
         await deliverWithStreaming({ payload, kind: info.kind });
         return;

--- a/extensions/slack/src/monitor/replies.test.ts
+++ b/extensions/slack/src/monitor/replies.test.ts
@@ -329,4 +329,60 @@ describe("deliverSlackSlashReplies chunking", () => {
       response_type: "in_channel",
     });
   });
+
+  it("suppresses reasoning payloads in slash replies", async () => {
+    const respond = vi.fn(async () => undefined);
+
+    await deliverSlackSlashReplies({
+      replies: [{ text: "Let me think...", isReasoning: true }, { text: "final answer" }],
+      respond,
+      ephemeral: false,
+      textLimit: 8000,
+    });
+
+    expect(respond).toHaveBeenCalledTimes(1);
+    expect(respond).toHaveBeenCalledWith({
+      text: "final answer",
+      response_type: "in_channel",
+    });
+  });
+});
+
+describe("deliverReplies reasoning suppression", () => {
+  beforeAll(async () => {
+    ({ deliverReplies } = await import("./replies.js"));
+  });
+
+  beforeEach(() => {
+    sendMock.mockReset();
+  });
+
+  it("suppresses reasoning payloads and delivers only non-reasoning replies", async () => {
+    sendMock.mockResolvedValue(undefined);
+
+    await deliverReplies(
+      baseParams({
+        replies: [{ text: "Reasoning:\n_hidden_", isReasoning: true }, { text: "visible answer" }],
+      }),
+    );
+
+    expect(sendMock).toHaveBeenCalledOnce();
+    const [, text] = requireSendCall();
+    expect(text).toBe("visible answer");
+  });
+
+  it("delivers nothing when all payloads are reasoning", async () => {
+    sendMock.mockResolvedValue(undefined);
+
+    await deliverReplies(
+      baseParams({
+        replies: [
+          { text: "Let me think about this...", isReasoning: true },
+          { text: "I need to consider...", isReasoning: true },
+        ],
+      }),
+    );
+
+    expect(sendMock).not.toHaveBeenCalled();
+  });
 });

--- a/extensions/slack/src/monitor/replies.ts
+++ b/extensions/slack/src/monitor/replies.ts
@@ -47,6 +47,9 @@ export async function deliverReplies(params: {
   metadata?: MessageMetadata;
 }) {
   for (const payload of params.replies) {
+    if (payload.isReasoning === true) {
+      continue;
+    }
     const threadTs = resolveDeliveredSlackReplyThreadTs({
       replyToMode: params.replyToMode,
       payloadReplyToId: payload.replyToId,
@@ -211,6 +214,9 @@ export async function deliverSlackSlashReplies(params: {
   const messages: Array<{ text: string; blocks?: ReturnType<typeof readSlackReplyBlocks> }> = [];
   const chunkLimit = Math.min(params.textLimit, SLACK_TEXT_LIMIT);
   for (const payload of params.replies) {
+    if (payload.isReasoning === true) {
+      continue;
+    }
     const reply = resolveSendableOutboundReplyParts(payload);
     const slackBlocks = readSlackReplyBlocks(payload);
     const text =

--- a/extensions/slack/src/monitor/slash.ts
+++ b/extensions/slack/src/monitor/slash.ts
@@ -27,6 +27,10 @@ import { chunkItems } from "openclaw/plugin-sdk/text-chunking";
 import type { ResolvedSlackAccount } from "../accounts.js";
 import { SLACK_MAX_BLOCKS } from "../blocks-input.js";
 import { formatSlackError } from "../errors.js";
+import {
+  compileSlackInteractiveReplies,
+  isSlackInteractiveRepliesEnabled,
+} from "../interactive-replies.js";
 import { truncateSlackText } from "../truncate.js";
 import { resolveSlackCommandIngress, resolveSlackEffectiveAllowFrom } from "./auth.js";
 import { resolveSlackChannelConfig, type SlackChannelConfigResolved } from "./channel-config.js";
@@ -715,6 +719,14 @@ export async function registerSlackMonitorSlashCommands(params: {
         agentId: route.agentId,
         channel: "slack",
         accountId: route.accountId,
+        transformReplyPayload: (payload) => {
+          if (payload.isReasoning === true) {
+            return null;
+          }
+          return isSlackInteractiveRepliesEnabled({ cfg, accountId: route.accountId })
+            ? compileSlackInteractiveReplies(payload)
+            : payload;
+        },
       });
 
       const deliverSlashPayloads = async (replies: ReplyPayload[]) => {

--- a/src/auto-reply/reply/before-deliver.test.ts
+++ b/src/auto-reply/reply/before-deliver.test.ts
@@ -3,6 +3,31 @@ import type { ReplyPayload } from "../types.js";
 import { createReplyDispatcher } from "./reply-dispatcher.js";
 
 describe("beforeDeliver in reply dispatcher", () => {
+  it("cancels delivery before queueing when transformReplyPayload returns null", async () => {
+    const delivered: string[] = [];
+
+    const dispatcher = createReplyDispatcher({
+      deliver: async (payload) => {
+        delivered.push(payload.text ?? "");
+      },
+      transformReplyPayload: (payload: ReplyPayload) => {
+        if (payload.text?.includes("blocked")) {
+          return null;
+        }
+        return payload;
+      },
+    });
+
+    expect(dispatcher.sendFinalReply({ text: "blocked reply" })).toBe(false);
+    expect(dispatcher.sendFinalReply({ text: "safe reply" })).toBe(true);
+    dispatcher.markComplete();
+    await dispatcher.waitForIdle();
+
+    expect(delivered).toEqual(["safe reply"]);
+    expect(dispatcher.getQueuedCounts()).toEqual({ tool: 0, block: 0, final: 1 });
+    expect(dispatcher.getCancelledCounts?.()).toEqual({ tool: 0, block: 0, final: 0 });
+  });
+
   it("cancels delivery when beforeDeliver returns null", async () => {
     const delivered: string[] = [];
 

--- a/src/auto-reply/reply/normalize-reply.ts
+++ b/src/auto-reply/reply/normalize-reply.ts
@@ -105,7 +105,11 @@ export function normalizeReplyPayload(
 
   let enrichedPayload: ReplyPayload = { ...payload, text };
   if (applyChannelTransforms && opts.transformReplyPayload) {
-    enrichedPayload = opts.transformReplyPayload(enrichedPayload) ?? enrichedPayload;
+    const transformedPayload = opts.transformReplyPayload(enrichedPayload);
+    if (transformedPayload === null) {
+      return null;
+    }
+    enrichedPayload = transformedPayload ?? enrichedPayload;
     text = enrichedPayload.text;
   }
 


### PR DESCRIPTION
## Summary

Fixes #84319.

Slack could surface model reasoning/thinking payloads as visible messages outside the already-guarded native streaming path. This updates Slack reply delivery to suppress `isReasoning` payloads before queue/delivery accounting, adds defense-in-depth guards in direct Slack reply helpers, and fixes the shared reply transform contract so a channel transform returning `null` actually cancels delivery.

## Changes

- Suppresses reasoning payloads in the Slack monitor reply pipeline before dispatch accounting.
- Applies the same transform to Slack slash-command reply pipelines.
- Keeps direct `deliverReplies()` and `deliverSlackSlashReplies()` from sending reasoning payloads.
- Honors `transformReplyPayload(...): null` in shared reply normalization instead of falling back to the original payload.
- Adds regression coverage for non-streaming delivery, streaming fallback, reasoning-only turns, first-reply delivery state, slash replies, direct replies, and pre-queue cancellation.

## Verification

- `node scripts/run-vitest.mjs src/auto-reply/reply/before-deliver.test.ts extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts extensions/slack/src/monitor/replies.test.ts extensions/slack/src/monitor/slash.test.ts`
- `codex review --uncommitted`
- `git diff --check`
- AWS Crabbox live Slack proof: `provider=aws`, `leaseId=cbx_15f21da2e5c2`, `run=run_f413099ecbfd`

Observed result after fix: focused tests passed, autoreview returned no accepted/actionable findings, and the live Slack proof observed the visible final marker while the reasoning marker was absent.

## Real behavior proof

Behavior addressed: Reasoning/thinking payloads marked with `isReasoning` could leak into Slack as visible messages through non-streaming, fallback, slash-command, or direct reply delivery paths.
Real environment tested: AWS Crabbox direct provider running this patch against a real Slack workspace/channel using a Convex-leased `kind=slack` credential.
Exact steps or command run after this patch: `node scripts/crabbox-wrapper.mjs run -provider aws -env-from-profile /private/tmp/convex_pool.env -allow-env OPENCLAW_QA_CONVEX_SITE_URL,OPENCLAW_QA_CONVEX_SECRET_CI -idle-timeout 90m -ttl 180m -timing-json -script-stdin`, with the remote script leasing the Slack credential, calling the patched `deliverReplies()` path with one reasoning marker and one final marker, polling Slack history, and deleting proof messages.
Evidence after fix: Crabbox run `run_f413099ecbfd` on AWS lease `cbx_15f21da2e5c2` printed `credential_source=convex`, `credential_kind=slack`, `final_marker_observed=true`, `reasoning_marker_observed=false`, and `messages_examined=2`.
Observed result after fix: The visible final Slack message was delivered; the reasoning payload was not delivered to Slack; proof messages were cleaned up after observation.
What was not tested: A full live model/provider turn was not rerun after the patch; dispatcher accounting and slash-command behavior are covered by focused regression tests, and the live proof exercises the real Slack delivery API path.
