### PR TITLE
perf(plugins): reuse compatible gateway startup registry on dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Gateway/plugins: reuse a compatible Gateway startup plugin registry during dispatch so safe plugin dispatches avoid redundant registry loading. (#84324) Thanks @ai-hpc.
 - Dependencies: refresh provider, plugin, UI, and tooling packages, update `protobufjs` to 8.4.0 to clear the current npm advisory, and carry the Claude ACP completion patch forward to `@agentclientprotocol/claude-agent-acp` 0.36.1.
 - Tests/perf: isolate doctor core health check unit coverage from real skills/workspace discovery so `doctor-core-checks` no longer dominates unit perf while keeping one real skills-readiness smoke. (#84493) Thanks @frankekn.
 

--- a/src/agents/runtime-plugins.registry-reuse.test.ts
+++ b/src/agents/runtime-plugins.registry-reuse.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import type { PluginRegistry } from "../plugins/registry-types.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
+
+const mocks = vi.hoisted(() => ({
+  getCurrentPluginMetadataSnapshot: vi.fn(),
+  loadOpenClawPlugins: vi.fn<typeof import("../plugins/loader.js").loadOpenClawPlugins>(),
+}));
+
+vi.mock("../plugins/current-plugin-metadata-snapshot.js", () => ({
+  getCurrentPluginMetadataSnapshot: mocks.getCurrentPluginMetadataSnapshot,
+}));
+
+vi.mock("../plugins/loader.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../plugins/loader.js")>();
+  return {
+    ...actual,
+    loadOpenClawPlugins: (...args: Parameters<typeof mocks.loadOpenClawPlugins>) =>
+      mocks.loadOpenClawPlugins(...args),
+  };
+});
+
+const [{ ensureRuntimePluginsLoaded }, { clearPluginLoaderCache, testing }] = await Promise.all([
+  import("./runtime-plugins.js"),
+  import("../plugins/loader.js"),
+]);
+
+function createRegistryWithPlugin(pluginId: string): PluginRegistry {
+  const registry = createEmptyPluginRegistry();
+  registry.plugins.push({
+    id: pluginId,
+    status: "loaded",
+  } as never);
+  return registry;
+}
+
+beforeEach(() => {
+  mocks.getCurrentPluginMetadataSnapshot.mockReset();
+  mocks.loadOpenClawPlugins.mockReset();
+});
+
+afterEach(() => {
+  clearPluginLoaderCache();
+  resetPluginRuntimeStateForTest();
+});
+
+describe("ensureRuntimePluginsLoaded registry reuse", () => {
+  it("reuses the compatible gateway startup registry on the dispatch caller path", () => {
+    const config = { plugins: { allow: ["telegram"] } };
+    const activeRegistry = createRegistryWithPlugin("telegram");
+    activeRegistry.coreGatewayMethodNames = ["sessions.get", "sessions.list"];
+    const startupLoadOptions = {
+      config,
+      activationSourceConfig: config,
+      autoEnabledReasons: {},
+      workspaceDir: "/tmp/workspace",
+      onlyPluginIds: ["telegram"],
+      coreGatewayMethodNames: ["sessions.get", "sessions.list"],
+      runtimeOptions: {
+        allowGatewaySubagentBinding: true,
+      },
+      preferBuiltPluginArtifacts: true,
+    };
+    const { cacheKey } = testing.resolvePluginLoadCacheContext(startupLoadOptions);
+    setActivePluginRegistry(activeRegistry, cacheKey, "gateway-bindable", "/tmp/workspace");
+    mocks.getCurrentPluginMetadataSnapshot.mockReturnValue({
+      startup: {
+        pluginIds: ["telegram"],
+      },
+    });
+    mocks.loadOpenClawPlugins.mockImplementation(() => {
+      throw new Error("dispatch should reuse the active gateway startup registry");
+    });
+
+    ensureRuntimePluginsLoaded({
+      config,
+      workspaceDir: "/tmp/workspace",
+    });
+
+    expect(mocks.getCurrentPluginMetadataSnapshot).toHaveBeenCalledWith({
+      config,
+      workspaceDir: "/tmp/workspace",
+    });
+    expect(mocks.loadOpenClawPlugins).not.toHaveBeenCalled();
+  });
+});

--- a/src/plugins/loader.runtime-registry.test.ts
+++ b/src/plugins/loader.runtime-registry.test.ts
@@ -368,6 +368,9 @@ describe("getCompatibleActivePluginRegistry", () => {
         config: startupOptions.config,
         workspaceDir: "/tmp/workspace-a",
         onlyPluginIds: ["acpx", "telegram"],
+        runtimeOptions: {
+          allowGatewaySubagentBinding: true,
+        },
       }),
     ).toBe(registry);
   });
@@ -501,12 +504,15 @@ describe("getCompatibleActivePluginRegistry", () => {
       { id: "telegram" } as (typeof registry.plugins)[number],
     );
     registry.coreGatewayMethodNames = ["sessions.get", "sessions.list"];
-    const startupOptions = {
-      config: {
-        plugins: {
-          allow: ["acpx", "telegram"],
-        },
+    const config = {
+      plugins: {
+        allow: ["acpx", "telegram"],
       },
+    };
+    const startupOptions = {
+      config,
+      activationSourceConfig: config,
+      autoEnabledReasons: {},
       workspaceDir: "/tmp/workspace-a",
       onlyPluginIds: ["acpx", "telegram"],
       coreGatewayMethodNames: ["sessions.get", "sessions.list"],
@@ -519,11 +525,66 @@ describe("getCompatibleActivePluginRegistry", () => {
 
     expect(
       testing.getCompatibleActivePluginRegistry({
-        config: startupOptions.config,
+        config,
         workspaceDir: "/tmp/workspace-a",
         onlyPluginIds: ["acpx", "telegram"],
       }),
     ).toBe(registry);
+  });
+
+  it("reuses a scoped gateway startup registry when dispatch omits built artifact preference", () => {
+    const registry = createEmptyPluginRegistry();
+    registry.plugins.push(
+      { id: "acpx" } as (typeof registry.plugins)[number],
+      { id: "telegram" } as (typeof registry.plugins)[number],
+    );
+    registry.coreGatewayMethodNames = ["sessions.get", "sessions.list"];
+    const config = {
+      plugins: {
+        allow: ["acpx", "telegram"],
+      },
+    };
+    const startupOptions = {
+      config,
+      activationSourceConfig: config,
+      autoEnabledReasons: {},
+      workspaceDir: "/tmp/workspace-a",
+      onlyPluginIds: ["acpx", "telegram"],
+      coreGatewayMethodNames: ["sessions.get", "sessions.list"],
+      runtimeOptions: {
+        allowGatewaySubagentBinding: true,
+      },
+      preferBuiltPluginArtifacts: true,
+    };
+    const { cacheKey } = testing.resolvePluginLoadCacheContext(startupOptions);
+    setActivePluginRegistry(registry, cacheKey, "gateway-bindable");
+
+    expect(
+      testing.getCompatibleActivePluginRegistry({
+        config,
+        workspaceDir: "/tmp/workspace-a",
+        onlyPluginIds: ["acpx", "telegram"],
+        runtimeOptions: {
+          allowGatewaySubagentBinding: true,
+        },
+      }),
+    ).toBe(registry);
+
+    expect(
+      testing.getCompatibleActivePluginRegistry({
+        config: {
+          plugins: {
+            allow: ["acpx", "telegram"],
+            load: { paths: ["/tmp/changed.js"] },
+          },
+        },
+        workspaceDir: "/tmp/workspace-a",
+        onlyPluginIds: ["acpx", "telegram"],
+        runtimeOptions: {
+          allowGatewaySubagentBinding: true,
+        },
+      }),
+    ).toBeUndefined();
   });
 });
 

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -1231,11 +1231,19 @@ function getCompatibleActivePluginRegistry(
       activeCacheKey,
     );
   };
+  const matchesCompatibleActiveRegistry = (candidate: PluginLoadOptions): boolean => {
+    if (matchesActiveCacheKey(candidate)) {
+      return true;
+    }
+    if (
+      scopedPluginLoadOptionsMatchWiderActiveCacheKey(candidate, activeCacheKey, activeRegistry)
+    ) {
+      return true;
+    }
+    return pluginToolDiscoveryOptionsMatchActiveCacheKey(candidate, activeCacheKey);
+  };
 
-  if (matchesActiveCacheKey(options)) {
-    return activeRegistry;
-  }
-  if (scopedPluginLoadOptionsMatchWiderActiveCacheKey(options, activeCacheKey, activeRegistry)) {
+  if (matchesCompatibleActiveRegistry(options)) {
     return activeRegistry;
   }
   if (!loadContext.shouldActivate) {
@@ -1243,50 +1251,47 @@ function getCompatibleActivePluginRegistry(
       ...options,
       activate: true,
     };
-    if (matchesActiveCacheKey(activatingOptions)) {
-      return activeRegistry;
-    }
-    if (
-      scopedPluginLoadOptionsMatchWiderActiveCacheKey(
-        activatingOptions,
-        activeCacheKey,
-        activeRegistry,
-      )
-    ) {
+    if (matchesCompatibleActiveRegistry(activatingOptions)) {
       return activeRegistry;
     }
   }
-  if (pluginToolDiscoveryOptionsMatchActiveCacheKey(options, activeCacheKey)) {
-    return activeRegistry;
+  const activeRuntimeSubagentMode = getActivePluginRuntimeSubagentMode();
+  if (activeRuntimeSubagentMode === "gateway-bindable") {
+    const gatewayStartupOptions: PluginLoadOptions = {
+      ...options,
+      preferBuiltPluginArtifacts: true,
+    };
+    if (matchesCompatibleActiveRegistry(gatewayStartupOptions)) {
+      return activeRegistry;
+    }
+    if (!loadContext.shouldActivate) {
+      const activatingGatewayStartupOptions: PluginLoadOptions = {
+        ...options,
+        activate: true,
+        preferBuiltPluginArtifacts: true,
+      };
+      if (matchesCompatibleActiveRegistry(activatingGatewayStartupOptions)) {
+        return activeRegistry;
+      }
+    }
   }
   if (
     loadContext.runtimeSubagentMode === "default" &&
-    getActivePluginRuntimeSubagentMode() === "gateway-bindable"
+    activeRuntimeSubagentMode === "gateway-bindable"
   ) {
-    const gatewayBindableOptions = {
+    const gatewayBindableOptions: PluginLoadOptions = {
       ...options,
       runtimeOptions: {
         ...options.runtimeOptions,
         allowGatewaySubagentBinding: true,
       },
     };
-    if (matchesActiveCacheKey(gatewayBindableOptions)) {
-      return activeRegistry;
-    }
-    if (
-      scopedPluginLoadOptionsMatchWiderActiveCacheKey(
-        gatewayBindableOptions,
-        activeCacheKey,
-        activeRegistry,
-      )
-    ) {
-      return activeRegistry;
-    }
-    if (pluginToolDiscoveryOptionsMatchActiveCacheKey(gatewayBindableOptions, activeCacheKey)) {
-      return activeRegistry;
-    }
+    const gatewayStartupOptions: PluginLoadOptions = {
+      ...gatewayBindableOptions,
+      preferBuiltPluginArtifacts: true,
+    };
     if (!loadContext.shouldActivate) {
-      const activatingGatewayBindableOptions = {
+      const activatingGatewayBindableOptions: PluginLoadOptions = {
         ...options,
         activate: true,
         runtimeOptions: {
@@ -1294,18 +1299,23 @@ function getCompatibleActivePluginRegistry(
           allowGatewaySubagentBinding: true,
         },
       };
-      if (matchesActiveCacheKey(activatingGatewayBindableOptions)) {
-        return activeRegistry;
-      }
+      const activatingGatewayStartupOptions: PluginLoadOptions = {
+        ...activatingGatewayBindableOptions,
+        preferBuiltPluginArtifacts: true,
+      };
       if (
-        scopedPluginLoadOptionsMatchWiderActiveCacheKey(
-          activatingGatewayBindableOptions,
-          activeCacheKey,
-          activeRegistry,
-        )
+        matchesCompatibleActiveRegistry(gatewayBindableOptions) ||
+        matchesCompatibleActiveRegistry(gatewayStartupOptions) ||
+        matchesCompatibleActiveRegistry(activatingGatewayBindableOptions) ||
+        matchesCompatibleActiveRegistry(activatingGatewayStartupOptions)
       ) {
         return activeRegistry;
       }
+    } else if (
+      matchesCompatibleActiveRegistry(gatewayBindableOptions) ||
+      matchesCompatibleActiveRegistry(gatewayStartupOptions)
+    ) {
+      return activeRegistry;
     }
   }
   return undefined;

--- a/src/plugins/runtime/standalone-runtime-registry-loader.test.ts
+++ b/src/plugins/runtime/standalone-runtime-registry-loader.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearPluginLoaderCache, testing } from "../loader.js";
+import { createEmptyPluginRegistry } from "../registry-empty.js";
+import type { PluginRegistry } from "../registry-types.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../runtime.js";
+
+const loaderMocks = vi.hoisted(() => ({
+  loadOpenClawPlugins: vi.fn<typeof import("../loader.js").loadOpenClawPlugins>(),
+}));
+
+vi.mock("../loader.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../loader.js")>();
+  return {
+    ...actual,
+    loadOpenClawPlugins: (...args: Parameters<typeof loaderMocks.loadOpenClawPlugins>) =>
+      loaderMocks.loadOpenClawPlugins(...args),
+  };
+});
+
+const { ensureStandaloneRuntimePluginRegistryLoaded } =
+  await import("./standalone-runtime-registry-loader.js");
+
+function createRegistryWithPlugin(pluginId: string): PluginRegistry {
+  const registry = createEmptyPluginRegistry();
+  registry.plugins.push({
+    id: pluginId,
+    status: "loaded",
+  } as never);
+  return registry;
+}
+
+beforeEach(() => {
+  loaderMocks.loadOpenClawPlugins.mockReset();
+});
+
+afterEach(() => {
+  clearPluginLoaderCache();
+  resetPluginRuntimeStateForTest();
+});
+
+describe("ensureStandaloneRuntimePluginRegistryLoaded", () => {
+  it("reuses a compatible gateway startup registry for gateway-bindable dispatch load options", () => {
+    const activeRegistry = createRegistryWithPlugin("telegram");
+    activeRegistry.coreGatewayMethodNames = ["sessions.get", "sessions.list"];
+    const config = { plugins: { allow: ["telegram"] } };
+    const startupLoadOptions = {
+      config,
+      activationSourceConfig: config,
+      autoEnabledReasons: {},
+      workspaceDir: "/tmp/ws",
+      onlyPluginIds: ["telegram"],
+      coreGatewayMethodNames: ["sessions.get", "sessions.list"],
+      runtimeOptions: {
+        allowGatewaySubagentBinding: true,
+      },
+      preferBuiltPluginArtifacts: true,
+    };
+    const { cacheKey } = testing.resolvePluginLoadCacheContext(startupLoadOptions);
+    setActivePluginRegistry(activeRegistry, cacheKey, "gateway-bindable", "/tmp/ws");
+
+    const result = ensureStandaloneRuntimePluginRegistryLoaded({
+      loadOptions: {
+        config,
+        onlyPluginIds: ["telegram"],
+        runtimeOptions: {
+          allowGatewaySubagentBinding: true,
+        },
+        workspaceDir: "/tmp/ws",
+      },
+    });
+
+    expect(result).toBe(activeRegistry);
+    expect(loaderMocks.loadOpenClawPlugins).not.toHaveBeenCalled();
+  });
+
+  it("loads a fresh registry when dispatch config is not startup-compatible", () => {
+    const activeRegistry = createRegistryWithPlugin("telegram");
+    activeRegistry.coreGatewayMethodNames = ["sessions.get", "sessions.list"];
+    const config = { plugins: { allow: ["telegram"] } };
+    const startupLoadOptions = {
+      config,
+      activationSourceConfig: config,
+      autoEnabledReasons: {},
+      workspaceDir: "/tmp/ws",
+      onlyPluginIds: ["telegram"],
+      coreGatewayMethodNames: ["sessions.get", "sessions.list"],
+      runtimeOptions: {
+        allowGatewaySubagentBinding: true,
+      },
+      preferBuiltPluginArtifacts: true,
+    };
+    const { cacheKey } = testing.resolvePluginLoadCacheContext(startupLoadOptions);
+    setActivePluginRegistry(activeRegistry, cacheKey, "gateway-bindable", "/tmp/ws");
+    const loadedRegistry = createRegistryWithPlugin("telegram");
+    loaderMocks.loadOpenClawPlugins.mockReturnValue(loadedRegistry);
+
+    const result = ensureStandaloneRuntimePluginRegistryLoaded({
+      loadOptions: {
+        config: {
+          plugins: {
+            allow: ["telegram"],
+            load: { paths: ["/tmp/changed.js"] },
+          },
+        },
+        onlyPluginIds: ["telegram"],
+        runtimeOptions: {
+          allowGatewaySubagentBinding: true,
+        },
+        workspaceDir: "/tmp/ws",
+      },
+    });
+
+    expect(result).toBe(loadedRegistry);
+    expect(loaderMocks.loadOpenClawPlugins).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary

- Reuse a compatible Gateway startup plugin registry during dispatch so the runtime ensure path avoids a redundant plugin load when only startup-only built-artifact preference differs.
- Keep loader compatibility checks for workspace, plugin scope, config, gateway methods, runtime mode, and changed config, so incompatible dispatch options still force a fresh load.
- Add regression coverage for loader compatibility, standalone dispatch reuse, and the `ensureRuntimePluginsLoaded()` caller path that produces this reuse.

This is a dispatch plugin-registry reuse optimization, not a broad agent CLI or Gateway session latency fix.

Fixes #80682
Alternative to #80691.

## Real behavior proof

- Behavior addressed: Dispatch-time standalone runtime ensure should reuse a compatible Gateway startup registry instead of reloading when dispatch already passes gateway-bindable runtime options and only the startup-only built-artifact preference differs.
- Real environment tested: Local OpenClaw source checkout plus release-shaped OCM/Kova package runtimes for `origin/main` and this PR.
- Exact steps or command run after this patch: Kova scenario runs for `gateway-performance`, `agent-gateway-rpc-turn`, and `gateway-session-send-turn` against release-shaped local package runtimes for `origin/main` and this PR, with fresh and many-bundled-plugin states; direct Node dispatch-registry benchmark against the exact `ensureRuntimePluginsLoaded()` dispatch path.
- Evidence after fix:

  ```text
  Terminal output from the Kova/runtime comparison showed gateway, agent, and session end-to-end metrics stayed flat between origin/main and this PR, with pluginLoadFailures=0 across the exercised runs.
  Terminal output from the direct dispatch-registry benchmark showed main median 20.40ms and PR median 3.85ms for the exact dispatch ensure path.
  ```

- Observed result after fix: The package-runtime Kova runs did not show a Gateway, agent CLI, or Gateway session regression, while the direct benchmark isolated the actual improvement to dispatch plugin-registry reuse. Changed config and incompatible load contexts continue to force fresh registry loading through the existing loader compatibility checks.
- What was not tested: Real external Telegram/Discord transport E2E was not rerun for this update; the exercised surface was Gateway startup, dispatch registry reuse, agent gateway turn, and Gateway session send-turn behavior.

## Verification

- `node scripts/run-vitest.mjs src/agents/runtime-plugins.test.ts src/agents/runtime-plugins.registry-reuse.test.ts src/plugins/loader.runtime-registry.test.ts src/plugins/runtime/standalone-runtime-registry-loader.test.ts`
- Testbox `tbx_01ks585wvfbmcbdrax0a4rfer2`: `pnpm check:changed && pnpm test:changed`
- Kova release-shaped runtime comparison for `gateway-performance`, `agent-gateway-rpc-turn`, and `gateway-session-send-turn`
- `git diff --check origin/main...HEAD`
