### PR TITLE
fix(signal): mark slash text as command source

### DIFF
--- a/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
+++ b/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
@@ -219,6 +219,72 @@ describe("signal createSignalEventHandler inbound context", () => {
     expect(context.UntrustedContext).toBeUndefined();
   });
 
+  it("marks direct slash text as a text command source", async () => {
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        cfg: {
+          messages: { inbound: { debounceMs: 0 } },
+          channels: { signal: { dmPolicy: "allowlist", allowFrom: ["+15550001111"] } },
+        } as any,
+        allowFrom: ["+15550001111"],
+        historyLimit: 0,
+      }),
+    );
+
+    await handler(
+      createSignalReceiveEvent({
+        dataMessage: {
+          message: "/status",
+          attachments: [],
+        },
+      }),
+    );
+
+    const context = requireCapturedContext();
+    expect(context.CommandBody).toBe("/status");
+    expect(context.CommandAuthorized).toBe(true);
+    expect(context.CommandSource).toBe("text");
+    expect(context.CommandTurn).toMatchObject({
+      kind: "text-slash",
+      source: "text",
+      authorized: true,
+      commandName: "status",
+      body: "/status",
+    });
+  });
+
+  it("does not mark ordinary direct text as a command source", async () => {
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        cfg: {
+          messages: { inbound: { debounceMs: 0 } },
+          channels: { signal: { dmPolicy: "allowlist", allowFrom: ["+15550001111"] } },
+        } as any,
+        allowFrom: ["+15550001111"],
+        historyLimit: 0,
+      }),
+    );
+
+    await handler(
+      createSignalReceiveEvent({
+        dataMessage: {
+          message: "status please",
+          attachments: [],
+        },
+      }),
+    );
+
+    const context = requireCapturedContext();
+    expect(context.CommandBody).toBe("status please");
+    expect(context.CommandSource).toBeUndefined();
+    expect(context.CommandTurn).toMatchObject({
+      kind: "normal",
+      source: "message",
+      authorized: false,
+      body: "status please",
+    });
+  });
+
   it("keeps pending group history structured while current text stays command-clean", async () => {
     const groupHistories = new Map([
       [
@@ -477,6 +543,7 @@ describe("signal createSignalEventHandler inbound context", () => {
     );
 
     expect(requireCapturedContext().CommandAuthorized).toBe(true);
+    expect(requireCapturedContext().CommandSource).toBe("text");
   });
 
   it("allows reaction-only group events when groupAllowFrom matches the reaction group id", async () => {

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -221,6 +221,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       MediaTypes: entry.mediaTypes,
       WasMentioned: entry.isGroup ? entry.wasMentioned === true : undefined,
       CommandAuthorized: entry.commandAuthorized,
+      CommandSource: entry.commandBody.trim().startsWith("/") ? "text" : undefined,
       OriginatingChannel: "signal" as const,
       OriginatingTo: signalTo,
     });


### PR DESCRIPTION
## Summary

Signal text messages that start with `/` currently carry `CommandBody` and `CommandAuthorized`, but they do not mark the inbound context as a text command source. After the command-turn normalization changes, that leaves Signal slash messages classified as ordinary message turns instead of explicit text slash command turns.

This matches a live regression observed on `2026.5.18`: normal Signal DMs route to the agent, but direct Signal `/status` and other slash commands are received by `signal-cli` and then produce no visible command response. A local package patch that adds `CommandSource: "text"` for Signal slash text restored `/status` handling.

## Changes

- Set `CommandSource: "text"` for Signal inbound messages whose command body starts with `/`.
- Add focused Signal inbound-context coverage for:
  - direct slash text becoming an authorized text slash command turn
  - ordinary direct text remaining a normal message turn
  - group slash commands preserving text command source metadata

## Related

- Similar channel fix shape: #79556
- Adjacent Signal inbound issue, but not the same failure mode: #75426
- Adjacent Feishu text slash command issue: #79409

## Testing

- `corepack pnpm exec vitest run --config test/vitest/vitest.extension-signal.config.ts extensions/signal/src/monitor/event-handler.inbound-context.test.ts`
- `PATH=/tmp/openclaw-corepack-shims-pr:$PATH pnpm tsgo:test:extensions`
