### PR TITLE
fix(agent-runner): deliver assistant text as fallback when model skips message tool

### DIFF
--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1903,6 +1903,31 @@ export async function runReplyAgent(params: {
       });
     }
 
+    // When sourceReplyDeliveryMode is "message_tool_only" the dispatch layer
+    // silently drops payloads that lack deliverDespiteSourceReplySuppression.
+    // If the model produced visible text but never called the message tool (and
+    // no block-streaming or other side-effect delivery occurred), mark the
+    // payloads for fallback delivery so the user still sees the response.
+    if (
+      opts?.sourceReplyDeliveryMode === "message_tool_only" &&
+      guardedReplyPayloads.length > 0 &&
+      !hasSuccessfulSideEffectDelivery({
+        blockReplyPipeline,
+        directlySentBlockKeys,
+        messagingToolSentTexts: runResult.messagingToolSentTexts,
+        messagingToolSentMediaUrls: runResult.messagingToolSentMediaUrls,
+        messagingToolSentTargets: runResult.messagingToolSentTargets,
+        successfulCronAdds: runResult.successfulCronAdds,
+        didSendDeterministicApprovalPrompt: runResult.didSendDeterministicApprovalPrompt,
+      })
+    ) {
+      for (let i = 0; i < guardedReplyPayloads.length; i++) {
+        guardedReplyPayloads[i] = markReplyPayloadForSourceSuppressionDelivery(
+          guardedReplyPayloads[i],
+        );
+      }
+    }
+
     // Prepend verbose operational notices. Model fallback notices are prepared
     // earlier so they pass through normal reply threading and stream-dedupe.
     let finalPayloads = guardedReplyPayloads;


### PR DESCRIPTION
## Summary

Fixes #84327

When `sourceReplyDeliveryMode` is `"message_tool_only"` (the default for Telegram group/channel chats), model responses were silently dropped if the model generated text without calling the `message` tool. This marks those payloads for fallback delivery so the user always sees the response.

## Problem

The dispatch layer in `dispatch-from-config.ts` suppresses all reply payloads that lack `deliverDespiteSourceReplySuppression` metadata when `suppressDelivery` is true. Payloads from the `message` tool get this flag via `markReplyPayloadForSourceSuppressionDelivery`, but plain assistant text payloads from `buildEmbeddedRunPayloads` never do.

When the model intermittently skips calling the `message` tool (observed after long idle periods when the Anthropic prompt cache goes cold), the response text is generated but silently discarded at the dispatch layer.

## Fix

In `agent-runner.ts`, after the agent run completes: if `sourceReplyDeliveryMode` is `"message_tool_only"`, the model produced text payloads, and no side-effect delivery occurred (no message tool call, no block streaming, no cron adds), mark those payloads with `deliverDespiteSourceReplySuppression` so they bypass the dispatch suppression.

Uses the existing `hasSuccessfulSideEffectDelivery` helper so the fallback only activates when no other delivery path succeeded.

## Real behavior proof

Tested on a live Telegram bot (OpenClaw v2026.5.12, `claude-opus-4-7` via Anthropic API, group chat with queue mode `steer`).

**Before fix** — three consecutive turns with trajectory evidence:

| Time (UTC) | outputTokens | toolMetas | didSend | assistantTexts | messagingToolSentTexts |
|---|---|---|---|---|---|
| 20:16 | 196 | `[]` | `false` | Full relevant response about meal planning | `[]` |
| 20:17 | 96 | `[]` | `false` | \"Hey — did you see the lunch rec?\" | `[]` |
| 20:19 | 56 | `[]` | `false` | Shortened repeat of lunch recommendation | `[]` |

All three responses were silently discarded. User saw nothing.

**After fix** — deployed the fix and restarted gateway:

| Time (UTC) | outputTokens | toolMetas | didSend | assistantTexts | delivered? |
|---|---|---|---|---|---|
| 21:19 | 11 | `[]` | `false` | \"Pong. Here.\" | **Yes** — delivered to Telegram |

Same pattern (model skipped message tool), but the fallback delivery kicked in and the user received the response.

**What was not tested:** Block streaming interaction (block streaming was enabled but the model didn't stream in the broken turns). The fix checks `hasSuccessfulSideEffectDelivery` which covers block streaming, so there should be no double-delivery when block streaming succeeds.

## Verification

```
pnpm test src/auto-reply/reply/agent-runner-payloads.test.ts     # 36 passed
pnpm test src/auto-reply/reply/agent-runner-execution.test.ts    # 72 passed
pnpm test src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts  # 5 passed
pnpm test src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts     # 38 passed
pnpm test src/auto-reply/reply/dispatch-from-config.test.ts      # 107 passed
pnpm test src/auto-reply/reply/source-reply-delivery-mode.test.ts # 17 passed
pnpm build  # clean
```

🤖 AI-assisted: diagnosis and fix authored with Claude Code (Opus 4.6). Human confirmed the fix works via live Telegram testing.