### PR TITLE
Resolve explicit model aliases before validation

### DIFF
--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -486,6 +486,7 @@ vi.mock("./model-selection.js", () => {
     };
   };
   return {
+    buildModelAliasIndex,
     buildAllowedModelSet,
     createModelVisibilityPolicy: (params: {
       cfg?: unknown;
@@ -649,6 +650,7 @@ vi.mock("./model-selection.js", () => {
       const [provider, ...modelParts] = (primary ?? "anthropic/claude").split("/");
       return { provider, model: modelParts.join("/") || "claude" };
     },
+    resolveModelRefFromString,
     resolveThinkingDefault: (args: unknown) => state.resolveThinkingDefaultMock(args),
   };
 });
@@ -2250,6 +2252,66 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       id: "gpt-5.4",
       compat: { supportedReasoningEfforts: ["low", "medium", "high", "xhigh"] },
     });
+  });
+
+  it("resolves explicit model aliases before thinking validation", async () => {
+    state.runtimeConfigMock = {
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.4" },
+          models: {
+            "openai/*": {},
+            "openai-codex/gpt-5.5": { alias: "code" },
+          },
+        },
+      },
+      models: {
+        providers: {
+          "openai-codex": {
+            models: [
+              {
+                id: "gpt-5.5",
+                name: "GPT 5.5 Codex",
+                reasoning: true,
+                compat: { supportedReasoningEfforts: ["xhigh"] },
+              },
+            ],
+          },
+        },
+      },
+    };
+    state.runWithModelFallbackMock.mockImplementation(async (params: FallbackRunnerParams) => {
+      const result = await params.run(params.provider, params.model);
+      return {
+        result,
+        provider: params.provider,
+        model: params.model,
+        attempts: [],
+      };
+    });
+    state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai-codex", "gpt-5.5"));
+
+    await agentCommand({
+      message: "hello",
+      to: "+1234567890",
+      senderIsOwner: true,
+      model: "code",
+      thinking: "xhigh",
+    });
+
+    const fallbackArgs = requireRecord(
+      mockCallArg(state.runWithModelFallbackMock),
+      "fallback args",
+    );
+    expect(fallbackArgs.provider).toBe("openai-codex");
+    expect(fallbackArgs.model).toBe("gpt-5.5");
+    const thinkingArgs = requireRecord(
+      mockCallArg(state.isThinkingLevelSupportedMock),
+      "thinking args",
+    );
+    expect(thinkingArgs.provider).toBe("openai-codex");
+    expect(thinkingArgs.model).toBe("gpt-5.5");
+    expect(thinkingArgs.level).toBe("xhigh");
   });
 
   it("validates explicit thinking against allowlisted configured model compat when manifest catalog is empty", async () => {

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -485,6 +485,46 @@ vi.mock("./model-selection.js", () => {
       allowAny: false,
     };
   };
+  const buildModelAliasIndex = ({
+    cfg,
+  }: {
+    cfg?: { agents?: { defaults?: { models?: Record<string, { alias?: string }> } } };
+  }) => {
+    const byAlias = new Map<string, { alias: string; ref: { provider: string; model: string } }>();
+    const byKey = new Map<string, string[]>();
+    for (const [ref, entry] of Object.entries(cfg?.agents?.defaults?.models ?? {})) {
+      const alias = entry?.alias?.trim();
+      if (!alias) {
+        continue;
+      }
+      const [provider, ...modelParts] = ref.split("/");
+      const model = modelParts.join("/");
+      byAlias.set(alias.toLowerCase(), { alias, ref: { provider, model } });
+      byKey.set(`${provider}/${model}`, [alias]);
+    }
+    return { byAlias, byKey };
+  };
+  const resolveModelRefFromString = ({
+    raw,
+    defaultProvider,
+    aliasIndex,
+  }: {
+    raw: string;
+    defaultProvider: string;
+    aliasIndex?: ReturnType<typeof buildModelAliasIndex>;
+  }) => {
+    const aliasMatch = aliasIndex?.byAlias.get(raw.trim().toLowerCase());
+    if (aliasMatch) {
+      return { ref: aliasMatch.ref, alias: aliasMatch.alias };
+    }
+    const slash = raw.indexOf("/");
+    return {
+      ref:
+        slash > 0
+          ? { provider: raw.slice(0, slash), model: raw.slice(slash + 1) }
+          : { provider: defaultProvider, model: raw },
+    };
+  };
   return {
     buildModelAliasIndex,
     buildAllowedModelSet,
@@ -581,28 +621,6 @@ vi.mock("./model-selection.js", () => {
       const fallback = allowedCatalog[0];
       return fallback ? { provider: fallback.provider, model: fallback.id } : null;
     },
-    buildModelAliasIndex: ({
-      cfg,
-    }: {
-      cfg?: { agents?: { defaults?: { models?: Record<string, { alias?: string }> } } };
-    }) => {
-      const byAlias = new Map<
-        string,
-        { alias: string; ref: { provider: string; model: string } }
-      >();
-      const byKey = new Map<string, string[]>();
-      for (const [ref, entry] of Object.entries(cfg?.agents?.defaults?.models ?? {})) {
-        const alias = entry?.alias?.trim();
-        if (!alias) {
-          continue;
-        }
-        const [provider, ...modelParts] = ref.split("/");
-        const model = modelParts.join("/");
-        byAlias.set(alias.toLowerCase(), { alias, ref: { provider, model } });
-        byKey.set(`${provider}/${model}`, [alias]);
-      }
-      return { byAlias, byKey };
-    },
     modelKey: (p: string, m: string) => `${p}/${m}`,
     normalizeModelRef: (p: string, m: string) => ({ provider: normalizeProviderId(p), model: m }),
     normalizeProviderId,
@@ -612,29 +630,6 @@ vi.mock("./model-selection.js", () => {
       return slash > 0
         ? { provider: m.slice(0, slash), model: m.slice(slash + 1) }
         : { provider: p, model: m };
-    },
-    resolveModelRefFromString: ({
-      raw,
-      defaultProvider,
-      aliasIndex,
-    }: {
-      raw: string;
-      defaultProvider: string;
-      aliasIndex?: {
-        byAlias: Map<string, { alias: string; ref: { provider: string; model: string } }>;
-      };
-    }) => {
-      const aliasMatch = aliasIndex?.byAlias.get(raw.trim().toLowerCase());
-      if (aliasMatch) {
-        return { ref: aliasMatch.ref, alias: aliasMatch.alias };
-      }
-      const slash = raw.indexOf("/");
-      return {
-        ref:
-          slash > 0
-            ? { provider: raw.slice(0, slash), model: raw.slice(slash + 1) }
-            : { provider: defaultProvider, model: raw },
-      };
     },
     resolveConfiguredModelRef: ({ cfg }: { cfg?: unknown }) => {
       const raw = (cfg as { agents?: { defaults?: { model?: string | { primary?: string } } } })

--- a/src/commands/agent-command.test-mocks.ts
+++ b/src/commands/agent-command.test-mocks.ts
@@ -59,7 +59,7 @@ vi.mock("../agents/model-selection.js", () => {
     agents?: {
       defaults?: {
         model?: string | { primary?: string; fallbacks?: string[] };
-        models?: Record<string, { params?: { thinking?: string } } | undefined>;
+        models?: Record<string, { alias?: string; params?: { thinking?: string } } | undefined>;
         thinkingDefault?: string;
       };
     };
@@ -83,12 +83,52 @@ vi.mock("../agents/model-selection.js", () => {
   };
   const parseModelRef = vi.fn(parseModelRefImpl);
   const normalizeProviderId = (provider: string) => provider.trim().toLowerCase();
+  const resolveModelRefFromString = vi.fn(
+    ({
+      raw,
+      defaultProvider = "openai",
+      aliasIndex,
+    }: {
+      raw: string;
+      defaultProvider?: string;
+      aliasIndex?: { byAlias?: Map<string, { ref: ModelRef; alias?: string }> };
+    }) => {
+      const aliasKey = raw.trim().toLowerCase();
+      const aliasMatch = aliasIndex?.byAlias?.get(aliasKey);
+      if (aliasMatch) {
+        return { ref: aliasMatch.ref, alias: aliasMatch.alias };
+      }
+      const ref = parseModelRef(raw, defaultProvider);
+      return ref ? { ref } : null;
+    },
+  );
   const normalizeModelRef = (provider: string, model: string): ModelRef => ({
     provider: normalizeProviderId(provider),
     model: model.trim(),
   });
   const modelKey = (provider: string, model: string) =>
     `${normalizeProviderId(provider)}/${model.trim().toLowerCase()}`;
+  const buildModelAliasIndex = vi.fn(
+    ({ cfg, defaultProvider = "openai" }: { cfg?: ConfigWithModels; defaultProvider?: string }) => {
+      const byAlias = new Map<string, { alias: string; ref: ModelRef }>();
+      const byKey = new Map<string, string[]>();
+      const modelConfig = cfg?.agents?.defaults?.models ?? {};
+      for (const [rawKey, entry] of Object.entries(modelConfig)) {
+        const alias = entry?.alias?.trim();
+        if (!alias) {
+          continue;
+        }
+        const ref = parseModelRefImpl(rawKey, defaultProvider);
+        if (!ref) {
+          continue;
+        }
+        byAlias.set(alias.toLowerCase(), { alias, ref });
+        const key = modelKey(ref.provider, ref.model);
+        byKey.set(key, [...(byKey.get(key) ?? []), alias]);
+      }
+      return { byAlias, byKey };
+    },
+  );
   const isModelKeyAllowedBySet = (allowedKeys: ReadonlySet<string>, key: string) => {
     if (allowedKeys.has(key)) {
       return true;
@@ -113,6 +153,7 @@ vi.mock("../agents/model-selection.js", () => {
   };
 
   return {
+    buildModelAliasIndex,
     buildAllowedModelSet: vi.fn(({ cfg }: { cfg?: ConfigWithModels; catalog?: CatalogEntry[] }) => {
       const refs = new Set<string>();
       const modelConfig = cfg?.agents?.defaults?.models ?? {};
@@ -182,7 +223,6 @@ vi.mock("../agents/model-selection.js", () => {
       },
     ),
     buildConfiguredModelCatalog: vi.fn(() => []),
-    buildModelAliasIndex: vi.fn(() => new Map()),
     isModelKeyAllowedBySet,
     isCliProvider: vi.fn(() => false),
     modelKey,
@@ -190,18 +230,13 @@ vi.mock("../agents/model-selection.js", () => {
     normalizeProviderId,
     normalizeProviderIdForAuth: normalizeProviderId,
     parseModelRef,
+    resolveModelRefFromString,
     resolveConfiguredModelRef: vi.fn(
       ({ cfg }: { cfg?: ConfigWithModels; defaultProvider?: string; defaultModel?: string }) =>
         resolveDefaultRef(cfg),
     ),
     resolveDefaultModelForAgent: vi.fn(({ cfg }: { cfg?: ConfigWithModels }) =>
       resolveDefaultRef(cfg),
-    ),
-    resolveModelRefFromString: vi.fn(
-      ({ raw, defaultProvider }: { raw: string; defaultProvider?: string }) => {
-        const ref = parseModelRef(raw, defaultProvider ?? "openai");
-        return ref ? { ref, source: "parsed" } : null;
-      },
     ),
     resolveThinkingDefault: vi.fn(
       ({


### PR DESCRIPTION
## Summary

- Resolve bare explicit model overrides through the configured alias index before validation.
- Keep explicit provider+model overrides on the existing normalized path.
- Add a regression for an alias that would otherwise be accepted as a literal model by a provider wildcard.

Closes #83810

## Real behavior proof

Behavior or issue addressed:
Explicit agent runs using a configured model alias like `--model code` were validated as the literal default-provider model `openai/code` before alias resolution. With a provider wildcard such as `openai/*`, that literal parse could pass visibility and make thinking/capability validation target the wrong model.

Real environment tested:
Local OpenClaw checkout on branch `fix/explicit-model-alias-validation-83810`, using the bundled Node runtime at `/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node`.

Exact steps or command run after this patch:
```sh
PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node scripts/run-vitest.mjs src/agents/agent-command.live-model-switch.test.ts
PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node scripts/run-vitest.mjs src/agents/model-selection.test.ts src/agents/model-fallback.test.ts
git diff --check
PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node --import tsx --input-type=module --eval 'import fs from "node:fs"; import { buildModelAliasIndex, modelKey, resolveModelRefFromString } from "./src/agents/model-selection.ts"; const cfg = { agents: { defaults: { model: { primary: "openai/gpt-5.4" }, models: { "openai/*": {}, "openai-codex/gpt-5.5": { alias: "code" } } } } }; const source = fs.readFileSync("src/agents/agent-command.ts", "utf8"); const aliasIndex = buildModelAliasIndex({ cfg, defaultProvider: "openai", manifestPlugins: [] }); const resolved = resolveModelRefFromString({ cfg, raw: "code", defaultProvider: "openai", aliasIndex, manifestPlugins: [] }); const explicitBranchUsesAliasResolver = source.includes("resolveModelRefFromString({") && source.includes("aliasIndex: buildModelAliasIndex({"); const payload = { explicitBranchUsesAliasResolver, rawOverride: "code", defaultProviderBeforeOverride: "openai", providerWildcardConfigured: "openai/*", legacyParseWouldSelect: { provider: "openai", model: "code", key: "openai/code" }, resolvedOverride: resolved?.ref, resolvedAlias: resolved?.alias, validationTargetAfterFix: resolved ? modelKey(resolved.ref.provider, resolved.ref.model) : null }; console.log(JSON.stringify(payload, null, 2)); if (!explicitBranchUsesAliasResolver || payload.validationTargetAfterFix !== "openai-codex/gpt-5.5") process.exit(1);'
```

Evidence after fix:
```json
{
  "explicitBranchUsesAliasResolver": true,
  "rawOverride": "code",
  "defaultProviderBeforeOverride": "openai",
  "providerWildcardConfigured": "openai/*",
  "legacyParseWouldSelect": {
    "provider": "openai",
    "model": "code",
    "key": "openai/code"
  },
  "resolvedOverride": {
    "provider": "openai-codex",
    "model": "gpt-5.5"
  },
  "resolvedAlias": "code",
  "validationTargetAfterFix": "openai-codex/gpt-5.5"
}
```

Observed result after fix:
The explicit run path now resolves the alias before visibility, harness, auth-profile, and thinking validation. The focused regression passes and shows `model: "code"` selects `openai-codex/gpt-5.5` rather than the legacy literal `openai/code`.

What was not tested:
No live model provider request was sent; this patch is limited to local model-selection validation and command routing behavior.

## Checks

- `node scripts/run-vitest.mjs src/agents/agent-command.live-model-switch.test.ts` passed: 40 tests.
- `node scripts/run-vitest.mjs src/agents/model-selection.test.ts src/agents/model-fallback.test.ts` passed: 330 tests.
- `git diff --check` passed.
