### PR TITLE
fix(gateway): mark SIGUSR1 token consumed on restartIntent path, reset stale tokens on in-process restart

### DIFF
--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -1090,6 +1090,33 @@ describe("runGatewayLoop", () => {
     });
   });
 
+  it("marks the in-flight token consumed before routing SIGUSR1 with a restart intent", async () => {
+    vi.clearAllMocks();
+    consumeGatewayRestartIntentPayloadSync.mockReturnValueOnce({ reason: "config.patch" });
+
+    await withIsolatedSignals(async ({ captureSignal }) => {
+      const { close, start } = await createSignaledLoopHarness();
+      const sigusr1 = captureSignal("SIGUSR1");
+
+      sigusr1();
+      await waitForLoopCondition(
+        () => close.mock.calls.length > 0,
+        "expected close to be called as part of the restart",
+      );
+      await waitForLoopCondition(
+        () => start.mock.calls.length >= 2,
+        "expected start to be called a second time after restart",
+      );
+
+      expect(markGatewaySigusr1RestartHandled).toHaveBeenCalledTimes(1);
+      expect(markGatewaySigusr1RestartHandled.mock.invocationCallOrder[0]).toBeLessThan(
+        close.mock.invocationCallOrder[0]!,
+      );
+      expect(close).toHaveBeenCalledTimes(1);
+      expect(start).toHaveBeenCalledTimes(2);
+    });
+  });
+
   it("releases the lock before exiting on spawned restart", async () => {
     vi.clearAllMocks();
     peekGatewaySigusr1RestartReason.mockReturnValue(undefined);

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -721,6 +721,10 @@ export async function runGatewayLoop(params: {
       } = await loadGatewayLifecycleRuntimeModule();
       const restartIntent = consumeGatewayRestartIntentPayloadSync();
       if (restartIntent) {
+        // Mark the emitted token consumed before handing off to request().
+        // Without this, the unconsumed token permanently blocks future restart
+        // requests via hasUnconsumedRestartSignal() for the lifetime of the process.
+        markGatewaySigusr1RestartHandled();
         request("restart", "SIGUSR1", restartIntent.reason ?? "gateway.restart", restartIntent);
         return;
       }

--- a/src/infra/infra-runtime.test.ts
+++ b/src/infra/infra-runtime.test.ts
@@ -13,6 +13,7 @@ import {
   isGatewaySigusr1RestartExternallyAllowed,
   markGatewaySigusr1RestartHandled,
   peekGatewaySigusr1RestartReason,
+  resetGatewayRestartStateForInProcessRestart,
   scheduleGatewaySigusr1Restart,
   setGatewaySigusr1RestartPolicy,
   setPreRestartDeferralCheck,
@@ -459,6 +460,21 @@ describe("infra runtime", () => {
         await vi.advanceTimersByTimeAsync(0);
         expect(countSigusr1Emits(emitSpy.mock.calls)).toBe(2);
         expect(peekGatewaySigusr1RestartReason()).toBe("update.run");
+      } finally {
+        process.removeListener("SIGUSR1", handler);
+      }
+    });
+
+    it("aligns stale emit/consume token counters on in-process restart boundary", () => {
+      const handler = () => {};
+      process.on("SIGUSR1", handler);
+      try {
+        emitGatewayRestart();
+        // An unconsumed token permanently coalesces further restart requests.
+        expect(scheduleGatewaySigusr1Restart({ delayMs: 0, reason: "check" }).coalesced).toBe(true);
+        resetGatewayRestartStateForInProcessRestart();
+        // After boundary reset the tokens are aligned; requests go through.
+        expect(scheduleGatewaySigusr1Restart({ delayMs: 0, reason: "post-reset" }).coalesced).toBe(false);
       } finally {
         process.removeListener("SIGUSR1", handler);
       }

--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -78,6 +78,12 @@ function clearActiveDeferralPolls(): void {
 export function resetGatewayRestartStateForInProcessRestart(): void {
   clearActiveDeferralPolls();
   clearPendingScheduledRestart();
+  // Align the token so any stale emission from the previous lifecycle does not
+  // permanently block restart requests in the new one.
+  if (emittedRestartToken !== consumedRestartToken) {
+    consumedRestartToken = emittedRestartToken;
+    emittedRestartReason = undefined;
+  }
 }
 
 export type RestartAuditInfo = {


### PR DESCRIPTION
## Summary

`update.run` from the control UI downloads the new package but the gateway never restarts to pick it up. Every attempt logs `restart coalesced (already in-flight)` and is silently dropped for the lifetime of the process.

### Root cause

Two bugs combine to make the state permanent:

**Bug 1 — `src/cli/gateway-cli/run-loop.ts` (`onSigusr1`):**
When a `restartIntent` file is present, the handler calls `request()` and returns **without calling `markGatewaySigusr1RestartHandled()`**. This leaves `emittedRestartToken > consumedRestartToken`. Every subsequent `scheduleGatewaySigusr1Restart()` call hits the `hasUnconsumedRestartSignal()` guard and is dropped.

**Bug 2 — `src/infra/restart.ts` (`resetGatewayRestartStateForInProcessRestart`):**
This function clears timers and deferral polls but never aligns the token counters. A stale unconsumed token from the previous lifecycle carries forward into the next server iteration after an in-process restart.

### Fix

1. Call `markGatewaySigusr1RestartHandled()` before the `restartIntent` early-return in `onSigusr1` so the token is consumed regardless of which restart path is taken.
2. Align `consumedRestartToken = emittedRestartToken` in `resetGatewayRestartStateForInProcessRestart()` as a safety net so a stale token cannot survive an in-process restart boundary.

### Reproduction

1. Run the gateway as a long-lived systemd user service
2. Let a new version become available and trigger `update.run` (UI or CLI)
3. Observe: npm package updates on disk but gateway PID never changes
4. Every retry logs `restart coalesced (already in-flight)`

### Workaround (until patched)

```bash
systemctl --user restart openclaw-gateway
```

### Real behavior log

**Platform:** systemd user service (`openclaw-gateway.service`), Ubuntu 24.04 LTS / WSL2

Two `update.run` attempts 11 minutes apart. `changedPaths=<n/a>` on the second attempt confirms the npm package updated successfully on attempt 1; only the restart was broken. Gateway process `<pid-a>` never changed between attempts.

```
# Attempt 1 — 15:25:47
<hostname> node[<pid-a>]: [restart] request coalesced (already in-flight) reason=update.run actor=openclaw-control-ui device=<device-id> ip=unknown-ip
<hostname> node[<pid-a>]: [gateway] update.run completed actor=openclaw-control-ui device=<device-id> ip=unknown-ip conn=<conn-uuid> changedPaths=<n/a> restartReason=update.run status=ok
<hostname> node[<pid-a>]: [gateway] update.run restart coalesced actor=openclaw-control-ui device=<device-id> ip=unknown-ip conn=<conn-uuid> delayMs=0

# Attempt 2 — 11 minutes later, same stuck process
<hostname> node[<pid-a>]: [restart] request coalesced (already in-flight) reason=update.run actor=openclaw-control-ui device=<device-id> ip=unknown-ip
<hostname> node[<pid-a>]: [gateway] update.run completed actor=openclaw-control-ui device=<device-id> ip=unknown-ip conn=<conn-uuid> changedPaths=<n/a> restartReason=update.run status=ok
<hostname> node[<pid-a>]: [gateway] update.run restart coalesced actor=openclaw-control-ui device=<device-id> ip=unknown-ip conn=<conn-uuid> delayMs=0

# Workaround: systemctl --user restart openclaw-gateway
<hostname> node[<pid-a>]: [gateway] signal SIGTERM received
<hostname> node[<pid-a>]: [gateway] received SIGTERM; shutting down
<hostname> node[<pid-a>]: [gateway] shutdown error: Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/home/<user>/.npm-global/lib/node_modules/openclaw/dist/hook-runner-global-DIpzvALt.js' imported from /home/<user>/.npm-global/lib/node_modules/openclaw/dist/server.impl-D3CWr7f5.js
# hook-runner-global-DIpzvALt.js is a hashed filename from the new package version. The old process was holding stale module refs because npm swapped the package on disk but the process never restarted.

<hostname> systemd: Stopped openclaw-gateway.service
<hostname> systemd: Started openclaw-gateway.service
<hostname> node[<pid-b>]: [gateway] loading configuration...
<hostname> node[<pid-b>]: [gateway] resolving authentication...
<hostname> node[<pid-b>]: [gateway] starting HTTP server...
<hostname> node[<pid-b>]: [gateway] ready
# New PID, updated binary loaded successfully
```

### Regression tests

Two focused tests cover the two fixes and are included in this PR:

- `src/cli/gateway-cli/run-loop.test.ts`: "marks the in-flight token consumed before routing SIGUSR1 with a restart intent" asserts that `markGatewaySigusr1RestartHandled` is called before `request()` is routed in the `restartIntent` branch. Fails on current main, passes with the fix.
- `src/infra/infra-runtime.test.ts`: "aligns stale emit/consume token counters on in-process restart boundary" asserts that `resetGatewayRestartStateForInProcessRestart()` clears a stale unconsumed token so subsequent restart requests are not coalesced. Fails on current main, passes with the fix.

### Post-patch note

Post-patch behavior is validated by the regression tests added in this PR; both fail against current main and pass with the patch applied. End-to-end log proof of `update.run` succeeding post-patch is omitted because reproducing it requires cutting a new release for the patched gateway to pull from, which is outside contributor scope.