### PR TITLE
fix(slack): forward per-agent identity overlay on heartbeat and runtimeSend (#84297)

### DIFF
--- a/extensions/slack/src/channel.test.ts
+++ b/extensions/slack/src/channel.test.ts
@@ -749,6 +749,26 @@ describe("slackPlugin outbound", () => {
     expect(result).toEqual({ channel: "slack", messageId: "m-text" });
   });
 
+  it("forwards agent identity through the registered text sender", async () => {
+    const sendText = requireSlackSendText();
+
+    await sendText({
+      cfg,
+      to: "C123",
+      text: "heartbeat alert",
+      accountId: "default",
+      identity: { name: "Pulse", emoji: "📟" },
+    });
+
+    expectRecordFields(requireMockCallArg(sendMessageSlackMock, 0, 2), "send options", {
+      identity: {
+        username: "Pulse",
+        iconUrl: undefined,
+        iconEmoji: "📟",
+      },
+    });
+  });
+
   it("forwards partial-send progress through the registered Slack sender", async () => {
     const sendSlack = vi.fn(async (...args: unknown[]) => {
       const options = args[2] as {

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -15,11 +15,7 @@ import {
   resolveOutboundSendDep,
 } from "openclaw/plugin-sdk/channel-outbound";
 import { createPairingPrefixStripper } from "openclaw/plugin-sdk/channel-pairing";
-import {
-  attachChannelToResult,
-  createAttachedChannelResultAdapter,
-  type ChannelOutboundAdapter,
-} from "openclaw/plugin-sdk/channel-send-result";
+import type { ChannelOutboundAdapter } from "openclaw/plugin-sdk/channel-send-result";
 import {
   createChannelDirectoryAdapter,
   createRuntimeDirectoryLiveAdapter,
@@ -263,6 +259,25 @@ async function setSlackHeartbeatThreadStatus(params: {
   }
 }
 
+function withSlackSendOverride(params: {
+  deps?: { [channelId: string]: unknown } | null;
+  send: SlackSendFn;
+  tokenOverride?: string;
+}) {
+  return {
+    ...params.deps,
+    slack: async (
+      to: Parameters<SlackSendFn>[0],
+      text: Parameters<SlackSendFn>[1],
+      opts: Parameters<SlackSendFn>[2],
+    ) =>
+      await params.send(to, text, {
+        ...opts,
+        ...(params.tokenOverride ? { token: params.tokenOverride } : {}),
+      }),
+  };
+}
+
 function resolveSlackRouteTarget(raw: string) {
   const target = parseSlackTarget(raw, { defaultKind: "channel" });
   if (!target) {
@@ -495,76 +510,41 @@ const slackChannelOutbound: ChannelOutboundAdapter = {
       ...ctx,
       replyToId: threadTsValue,
       threadId: null,
-      deps: {
-        ...ctx.deps,
-        slack: async (
-          to: Parameters<SlackSendFn>[0],
-          text: Parameters<SlackSendFn>[1],
-          opts: Parameters<SlackSendFn>[2],
-        ) =>
-          await send(to, text, {
-            ...opts,
-            ...(tokenOverride ? { token: tokenOverride } : {}),
-          }),
-      },
+      deps: withSlackSendOverride({ deps: ctx.deps, send, tokenOverride }),
     });
   },
-  ...createAttachedChannelResultAdapter({
-    channel: "slack",
-    sendText: async ({ to, text, accountId, deps, replyToId, threadId, cfg, onDeliveryResult }) => {
-      const { send, threadTsValue, tokenOverride } = await resolveSlackSendContext({
-        cfg,
-        accountId: accountId ?? undefined,
-        deps,
-        replyToId,
-        threadId,
-      });
-      return await send(to, text, {
-        cfg,
-        threadTs: threadTsValue,
-        accountId: accountId ?? undefined,
-        onDeliveryResult: onDeliveryResult
-          ? async (result) => {
-              await onDeliveryResult(attachChannelToResult("slack", result));
-            }
-          : undefined,
-        ...(tokenOverride ? { token: tokenOverride } : {}),
-      });
-    },
-    sendMedia: async ({
-      to,
-      text,
-      mediaUrl,
-      mediaLocalRoots,
-      accountId,
-      deps,
-      replyToId,
-      threadId,
-      cfg,
-      onDeliveryResult,
-    }) => {
-      const { send, threadTsValue, tokenOverride } = await resolveSlackSendContext({
-        cfg,
-        accountId: accountId ?? undefined,
-        deps,
-        replyToId,
-        threadId,
-      });
-      return await send(to, text, {
-        cfg,
-        mediaUrl,
-        mediaLocalRoots,
-        threadTs: threadTsValue,
-        accountId: accountId ?? undefined,
-        onDeliveryResult: onDeliveryResult
-          ? async (result) => {
-              await onDeliveryResult(attachChannelToResult("slack", result));
-            }
-          : undefined,
-        ...(tokenOverride ? { token: tokenOverride } : {}),
-      });
-    },
-  }),
+  sendText: async (ctx) => {
+    const { send, threadTsValue, tokenOverride } = await resolveSlackSendContext({
+      cfg: ctx.cfg,
+      accountId: ctx.accountId ?? undefined,
+      deps: ctx.deps,
+      replyToId: ctx.replyToId,
+      threadId: ctx.threadId,
+    });
+    const { slackOutbound } = await loadSlackOutboundAdapterModule();
+    return await slackOutbound.sendText!({
+      ...ctx,
+      replyToId: threadTsValue,
+      threadId: null,
+      deps: withSlackSendOverride({ deps: ctx.deps, send, tokenOverride }),
+    });
+  },
+  sendMedia: async (ctx) => {
+    const { send, threadTsValue, tokenOverride } = await resolveSlackSendContext({
+      cfg: ctx.cfg,
+      accountId: ctx.accountId ?? undefined,
+      deps: ctx.deps,
+      replyToId: ctx.replyToId,
+      threadId: ctx.threadId,
+    });
+    const { slackOutbound } = await loadSlackOutboundAdapterModule();
+    return await slackOutbound.sendMedia!({
+      ...ctx,
+      replyToId: threadTsValue,
+      threadId: null,
+      deps: withSlackSendOverride({ deps: ctx.deps, send, tokenOverride }),
+    });
+  },
 };
 
 const slackMessageAdapter = createChannelMessageAdapterFromOutbound({

--- a/extensions/slack/src/outbound-adapter.test.ts
+++ b/extensions/slack/src/outbound-adapter.test.ts
@@ -168,4 +168,28 @@ describe("slackOutbound", () => {
       blocks: [{ type: "divider" }],
     });
   });
+
+  it("preserves raw Unicode agent identity emoji", async () => {
+    sendMessageSlackMock.mockResolvedValueOnce({ messageId: "m-text" });
+
+    await slackOutbound.sendText!({
+      cfg,
+      to: "C123",
+      text: "heartbeat alert",
+      accountId: "default",
+      identity: { name: "Pulse", emoji: "📟" },
+    });
+
+    expect(sendMessageSlackMock).toHaveBeenCalledWith(
+      "C123",
+      "heartbeat alert",
+      expect.objectContaining({
+        identity: {
+          username: "Pulse",
+          iconUrl: undefined,
+          iconEmoji: "📟",
+        },
+      }),
+    );
+  });
 });

--- a/extensions/slack/src/outbound-adapter.ts
+++ b/extensions/slack/src/outbound-adapter.ts
@@ -69,6 +69,8 @@ function resolveSlackSendIdentity(identity?: OutboundIdentity): SlackSendIdentit
   const username = normalizeOptionalString(identity.name);
   const iconUrl = normalizeOptionalString(identity.avatarUrl);
   const rawEmoji = normalizeOptionalString(identity.emoji);
+  // Live Slack accepts Unicode custom icons even though its docs show shortcode form.
+  // send.ts downgrades once per send when a workspace rejects the configured icon.
   const iconEmoji = !iconUrl ? rawEmoji : undefined;
   if (!username && !iconUrl && !iconEmoji) {
     return undefined;

--- a/extensions/slack/src/outbound-adapter.ts
+++ b/extensions/slack/src/outbound-adapter.ts
@@ -69,7 +69,7 @@ function resolveSlackSendIdentity(identity?: OutboundIdentity): SlackSendIdentit
   const username = normalizeOptionalString(identity.name);
   const iconUrl = normalizeOptionalString(identity.avatarUrl);
   const rawEmoji = normalizeOptionalString(identity.emoji);
-  const iconEmoji = !iconUrl && rawEmoji && /^:[^:\s]+:$/.test(rawEmoji) ? rawEmoji : undefined;
+  const iconEmoji = !iconUrl ? rawEmoji : undefined;
   if (!username && !iconUrl && !iconEmoji) {
     return undefined;
   }

--- a/extensions/slack/src/send.identity-fallback.test.ts
+++ b/extensions/slack/src/send.identity-fallback.test.ts
@@ -189,7 +189,7 @@ describe("sendMessageSlack customize-scope fallback", () => {
     );
   });
 
-  it("retries without identity when Slack rejects identity arguments", async () => {
+  it("preserves the username when Slack rejects the custom icon", async () => {
     const client = createSlackSendTestClient();
     vi.mocked(client.chat.postMessage)
       .mockRejectedValueOnce(buildInvalidIdentityError())
@@ -207,6 +207,33 @@ describe("sendMessageSlack customize-scope fallback", () => {
       icon_emoji: "📟",
     });
     expect(readPostMessagePayload(client, 1)).toEqual({
+      channel: "C123",
+      text: "hello",
+      username: "Pulse",
+      unfurl_links: false,
+    });
+    expect(vi.mocked(logVerbose)).toHaveBeenCalledWith(
+      "slack send: custom icon rejected, retrying with username only",
+    );
+  });
+
+  it("drops the full identity only when Slack also rejects the username-only retry", async () => {
+    const client = createSlackSendTestClient();
+    vi.mocked(client.chat.postMessage)
+      .mockRejectedValueOnce(buildInvalidIdentityError())
+      .mockRejectedValueOnce(buildInvalidIdentityError())
+      .mockResolvedValueOnce({ ts: "171234.567" });
+
+    await sendMessageSlack("channel:C123", "hello", {
+      token: "xoxb-test",
+      cfg: SLACK_TEST_CFG,
+      client,
+      identity: { username: "Pulse", iconEmoji: "📟" },
+    });
+
+    expect(readPostMessagePayload(client, 1)).toMatchObject({ username: "Pulse" });
+    expect(readPostMessagePayload(client, 1)).not.toHaveProperty("icon_emoji");
+    expect(readPostMessagePayload(client, 2)).toEqual({
       channel: "C123",
       text: "hello",
       unfurl_links: false,

--- a/extensions/slack/src/send.identity-fallback.test.ts
+++ b/extensions/slack/src/send.identity-fallback.test.ts
@@ -42,6 +42,12 @@ function buildMissingScopeError(overrides?: {
   return err;
 }
 
+function buildInvalidIdentityError(): SlackMissingScopeError {
+  const err = new Error("An API error occurred: invalid_arguments") as SlackMissingScopeError;
+  err.data = { error: "invalid_arguments" };
+  return err;
+}
+
 function readPostMessagePayload(
   client: ReturnType<typeof createSlackSendTestClient>,
   index: number,
@@ -136,7 +142,7 @@ describe("sendMessageSlack customize-scope fallback", () => {
       unfurl_links: false,
     });
     expect(vi.mocked(logVerbose)).toHaveBeenCalledWith(
-      "slack send: missing chat:write.customize, retrying without custom identity",
+      "slack send: custom identity rejected, retrying without custom identity",
     );
     expect(result.messageId).toBe("171234.567");
   });
@@ -160,7 +166,7 @@ describe("sendMessageSlack customize-scope fallback", () => {
     const secondCall = readPostMessagePayload(client, 1);
     expect(secondCall).not.toHaveProperty("icon_emoji");
     expect(vi.mocked(logVerbose)).toHaveBeenCalledWith(
-      "slack send: missing chat:write.customize, retrying without custom identity",
+      "slack send: custom identity rejected, retrying without custom identity",
     );
   });
 
@@ -179,7 +185,34 @@ describe("sendMessageSlack customize-scope fallback", () => {
 
     expect(client.chat.postMessage).toHaveBeenCalledTimes(2);
     expect(vi.mocked(logVerbose)).toHaveBeenCalledWith(
-      "slack send: missing chat:write.customize, retrying without custom identity",
+      "slack send: custom identity rejected, retrying without custom identity",
+    );
+  });
+
+  it("retries without identity when Slack rejects identity arguments", async () => {
+    const client = createSlackSendTestClient();
+    vi.mocked(client.chat.postMessage)
+      .mockRejectedValueOnce(buildInvalidIdentityError())
+      .mockResolvedValueOnce({ ts: "171234.567" });
+
+    await sendMessageSlack("channel:C123", "hello", {
+      token: "xoxb-test",
+      cfg: SLACK_TEST_CFG,
+      client,
+      identity: { username: "Pulse", iconEmoji: "📟" },
+    });
+
+    expect(readPostMessagePayload(client, 0)).toMatchObject({
+      username: "Pulse",
+      icon_emoji: "📟",
+    });
+    expect(readPostMessagePayload(client, 1)).toEqual({
+      channel: "C123",
+      text: "hello",
+      unfurl_links: false,
+    });
+    expect(vi.mocked(logVerbose)).toHaveBeenCalledWith(
+      "slack send: custom identity rejected, retrying without custom identity",
     );
   });
 

--- a/extensions/slack/src/send.identity-fallback.test.ts
+++ b/extensions/slack/src/send.identity-fallback.test.ts
@@ -243,6 +243,30 @@ describe("sendMessageSlack customize-scope fallback", () => {
     );
   });
 
+  it("reuses the downgraded identity for later chunks", async () => {
+    const client = createSlackSendTestClient();
+    vi.mocked(client.chat.postMessage)
+      .mockRejectedValueOnce(buildInvalidIdentityError())
+      .mockResolvedValue({ ts: "171234.567" });
+
+    await sendMessageSlack("channel:C123", "alpha beta", {
+      token: "xoxb-test",
+      cfg: { channels: { slack: { botToken: "xoxb-test", textChunkLimit: 5 } } },
+      client,
+      identity: { username: "Pulse", iconEmoji: "📟" },
+    });
+
+    expect(client.chat.postMessage).toHaveBeenCalledTimes(3);
+    expect(readPostMessagePayload(client, 0)).toMatchObject({
+      username: "Pulse",
+      icon_emoji: "📟",
+    });
+    for (const index of [1, 2]) {
+      expect(readPostMessagePayload(client, index)).toMatchObject({ username: "Pulse" });
+      expect(readPostMessagePayload(client, index)).not.toHaveProperty("icon_emoji");
+    }
+  });
+
   it("rethrows missing_scope errors that reference a different scope", async () => {
     const client = createSlackSendTestClient();
     const err = buildMissingScopeError({ needed: "channels:history" });

--- a/extensions/slack/src/send.ts
+++ b/extensions/slack/src/send.ts
@@ -1,6 +1,6 @@
 // Slack plugin module implements send behavior.
 import type { MessageMetadata } from "@slack/types";
-import type { Block, KnownBlock, WebClient } from "@slack/web-api";
+import type { Block, ChatPostMessageArguments, KnownBlock, WebClient } from "@slack/web-api";
 import {
   createMessageReceiptFromOutboundResults,
   type MessageReceipt,
@@ -376,33 +376,40 @@ async function postSlackMessageBestEffort(params: {
 }) {
   const basePayload = buildSlackPostMessagePayload(params);
   const postChatMessage = params.client.chat.postMessage.bind(params.client.chat);
+  const post = async (payload: ChatPostMessageArguments, identity?: SlackSendIdentity) => ({
+    response: await withSlackDnsRequestRetry("chat.postMessage", () => postChatMessage(payload)),
+    identity,
+  });
   try {
     // Slack Web API types model icon_url and icon_emoji as mutually exclusive.
     // Build payloads in explicit branches so TS and runtime stay aligned.
     const identity = params.identity;
     if (identity?.iconUrl) {
-      return await withSlackDnsRequestRetry("chat.postMessage", () =>
-        postChatMessage({
+      return await post(
+        {
           ...basePayload,
           ...(identity.username ? { username: identity.username } : {}),
           icon_url: identity.iconUrl,
-        }),
+        },
+        identity,
       );
     }
     if (identity?.iconEmoji) {
-      return await withSlackDnsRequestRetry("chat.postMessage", () =>
-        postChatMessage({
+      return await post(
+        {
           ...basePayload,
           ...(identity.username ? { username: identity.username } : {}),
           icon_emoji: identity.iconEmoji,
-        }),
+        },
+        identity,
       );
     }
-    return await withSlackDnsRequestRetry("chat.postMessage", () =>
-      postChatMessage({
+    return await post(
+      {
         ...basePayload,
         ...(identity?.username ? { username: identity.username } : {}),
-      }),
+      },
+      identity,
     );
   } catch (err) {
     if (!hasCustomIdentity(params.identity) || !isSlackCustomIdentityRejectedError(err)) {
@@ -416,8 +423,9 @@ async function postSlackMessageBestEffort(params: {
     ) {
       logVerbose("slack send: custom icon rejected, retrying with username only");
       try {
-        return await withSlackDnsRequestRetry("chat.postMessage", () =>
-          postChatMessage({ ...basePayload, username: identity.username }),
+        return await post(
+          { ...basePayload, username: identity.username },
+          { username: identity.username },
         );
       } catch (retryError) {
         if (!isSlackCustomIdentityRejectedError(retryError)) {
@@ -426,7 +434,7 @@ async function postSlackMessageBestEffort(params: {
       }
     }
     logVerbose("slack send: custom identity rejected, retrying without custom identity");
-    return withSlackDnsRequestRetry("chat.postMessage", () => postChatMessage(basePayload));
+    return post(basePayload);
   }
 }
 
@@ -809,7 +817,7 @@ async function sendMessageSlackQueuedInner(params: {
       trimmedMessage || buildSlackBlocksFallbackText(blocks),
       SLACK_TEXT_LIMIT,
     );
-    const response = await postSlackMessageBestEffort({
+    const { response } = await postSlackMessageBestEffort({
       client,
       channelId,
       text: fallbackText,
@@ -896,17 +904,20 @@ async function sendMessageSlackQueuedInner(params: {
     chunksToPost = resolvedChunks.length ? resolvedChunks : [""];
   }
 
+  let sendIdentity = identity;
   for (const chunk of chunksToPost) {
-    const response = await postSlackMessageBestEffort({
+    const posted = await postSlackMessageBestEffort({
       client,
       channelId,
       text: chunk,
       threadTs: opts.threadTs,
       replyBroadcast: sentMessageIds.length === 0 ? opts.replyBroadcast : undefined,
-      identity,
+      identity: sendIdentity,
       metadata: sentMessageIds.length === 0 ? opts.metadata : undefined,
       unfurl,
     });
+    const response = posted.response;
+    sendIdentity = posted.identity;
     lastMessageId = response.ts ?? lastMessageId;
     deliveredChannelId = resolvePostedMessageChannelId(response, deliveredChannelId);
     canonicalDeliveredThreadTs ??= resolvePostedMessageThreadTs(response);

--- a/extensions/slack/src/send.ts
+++ b/extensions/slack/src/send.ts
@@ -412,10 +412,10 @@ async function postSlackMessageBestEffort(params: {
       identity,
     );
   } catch (err) {
-    if (!hasCustomIdentity(params.identity) || !isSlackCustomIdentityRejectedError(err)) {
+    const identity = params.identity;
+    if (!identity || !hasCustomIdentity(identity) || !isSlackCustomIdentityRejectedError(err)) {
       throw err;
     }
-    const identity = params.identity;
     if (
       !isSlackCustomizeScopeError(err) &&
       identity.username &&

--- a/extensions/slack/src/send.ts
+++ b/extensions/slack/src/send.ts
@@ -354,6 +354,15 @@ function isSlackCustomizeScopeError(err: unknown): boolean {
   return scopes.includes("chat:write.customize");
 }
 
+function isSlackCustomIdentityRejectedError(err: unknown): boolean {
+  if (isSlackCustomizeScopeError(err)) {
+    return true;
+  }
+  const data = getSlackWebApiErrorData(err);
+  const code = normalizeLowercaseStringOrEmpty(normalizeSlackApiString(data?.error));
+  return code === "invalid_arguments" || code === "invalid_arg_name";
+}
+
 async function postSlackMessageBestEffort(params: {
   client: WebClient;
   channelId: string;
@@ -396,10 +405,10 @@ async function postSlackMessageBestEffort(params: {
       }),
     );
   } catch (err) {
-    if (!hasCustomIdentity(params.identity) || !isSlackCustomizeScopeError(err)) {
+    if (!hasCustomIdentity(params.identity) || !isSlackCustomIdentityRejectedError(err)) {
       throw err;
     }
-    logVerbose("slack send: missing chat:write.customize, retrying without custom identity");
+    logVerbose("slack send: custom identity rejected, retrying without custom identity");
     return withSlackDnsRequestRetry("chat.postMessage", () => postChatMessage(basePayload));
   }
 }

--- a/extensions/slack/src/send.ts
+++ b/extensions/slack/src/send.ts
@@ -408,6 +408,23 @@ async function postSlackMessageBestEffort(params: {
     if (!hasCustomIdentity(params.identity) || !isSlackCustomIdentityRejectedError(err)) {
       throw err;
     }
+    const identity = params.identity;
+    if (
+      !isSlackCustomizeScopeError(err) &&
+      identity.username &&
+      (identity.iconUrl || identity.iconEmoji)
+    ) {
+      logVerbose("slack send: custom icon rejected, retrying with username only");
+      try {
+        return await withSlackDnsRequestRetry("chat.postMessage", () =>
+          postChatMessage({ ...basePayload, username: identity.username }),
+        );
+      } catch (retryError) {
+        if (!isSlackCustomIdentityRejectedError(retryError)) {
+          throw retryError;
+        }
+      }
+    }
     logVerbose("slack send: custom identity rejected, retrying without custom identity");
     return withSlackDnsRequestRetry("chat.postMessage", () => postChatMessage(basePayload));
   }

--- a/src/infra/heartbeat-runner.identity.test.ts
+++ b/src/infra/heartbeat-runner.identity.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { runHeartbeatOnce } from "./heartbeat-runner.js";
+import { installHeartbeatRunnerTestRuntime } from "./heartbeat-runner.test-harness.js";
+import { seedMainSessionStore, withTempHeartbeatSandbox } from "./heartbeat-runner.test-utils.js";
+
+installHeartbeatRunnerTestRuntime({ includeSlack: true });
+
+describe("runHeartbeatOnce identity", () => {
+  it.each([
+    { name: "alert", replyText: "needs attention", showOk: false },
+    { name: "heartbeat ok", replyText: "HEARTBEAT_OK", showOk: true },
+  ])("forwards agent identity on $name delivery", async ({ replyText, showOk }) => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: { every: "5m", target: "slack", to: "channel:C123" },
+          },
+          list: [{ id: "main", identity: { name: "Pulse", emoji: "📟" } }],
+        },
+        channels: { slack: { heartbeat: { showOk } } },
+        session: { store: storePath },
+      };
+      await seedMainSessionStore(storePath, cfg, {
+        lastChannel: "slack",
+        lastProvider: "slack",
+        lastTo: "channel:C123",
+      });
+      replySpy.mockResolvedValue({ text: replyText });
+      const sendSlack = vi.fn().mockResolvedValue({ messageId: "m1", channelId: "C123" });
+
+      await runHeartbeatOnce({
+        cfg,
+        deps: {
+          getReplyFromConfig: replySpy,
+          slack: sendSlack,
+          getQueueSize: () => 0,
+          nowMs: () => 0,
+        },
+      });
+
+      expect(sendSlack).toHaveBeenCalledTimes(1);
+      expect(sendSlack.mock.calls[0]?.[2]).toMatchObject({
+        identity: { name: "Pulse", emoji: "📟" },
+      });
+    });
+  });
+});

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -148,6 +148,7 @@ import {
   setHeartbeatWakeHandler,
 } from "./heartbeat-wake.js";
 import type { OutboundSendDeps } from "./outbound/deliver.js";
+import { resolveAgentOutboundIdentity } from "./outbound/identity.js";
 import { buildOutboundSessionContext } from "./outbound/session-context.js";
 import {
   resolveHeartbeatDeliveryTargetWithSessionRoute,
@@ -1857,6 +1858,7 @@ export async function runHeartbeatOnce(opts: {
     sessionKey: runSessionKey,
     policySessionKey: outboundPolicySessionKey,
   });
+  const outboundIdentity = resolveAgentOutboundIdentity(cfg, agentId);
   const canAttemptHeartbeatOk = Boolean(
     !hasDueCommitments && visibility.showOk && delivery.channel !== "none" && delivery.to,
   );
@@ -1911,6 +1913,7 @@ export async function runHeartbeatOnce(opts: {
       threadId: delivery.threadId,
       payloads: [{ text: resolveHeartbeatOkText() }],
       session: outboundSession,
+      identity: outboundIdentity,
       deps: opts.deps,
     });
     if (send.status === "failed" || send.status === "partial_failed") {
@@ -2221,6 +2224,7 @@ export async function runHeartbeatOnce(opts: {
       to: delivery.to,
       accountId: deliveryAccountId,
       session: outboundSession,
+      identity: outboundIdentity,
       threadId: delivery.threadId,
       payloads: [
         ...reasoningPayloads,


### PR DESCRIPTION
## What Problem This Solves

Per-agent Slack identity could be lost on heartbeat/autonomous sends. The heartbeat runner did not pass the resolved identity into durable delivery, and Slack's registered channel sender duplicated canonical outbound logic instead of using the identity-aware adapter.

Fixes #84297.

## Why This Change Was Made

- Resolve the agent identity once in the heartbeat runner and pass it to both the `HEARTBEAT_OK` and normal delivery paths.
- Route Slack's registered text, media, and payload sends through the canonical `slackOutbound` adapter, preserving token overrides, threading, media, callbacks, and result normalization while removing duplicate send logic.
- Preserve configured raw Unicode emoji for Slack custom identity. The reporter's live `chat:write.customize` proof confirms Slack accepts and renders this form.
- If Slack rejects a custom icon, retry with the configured agent name before falling back to the app identity, then reuse that accepted identity for later chunks. Invalid customization cannot lose the message, unnecessarily discard a valid persona, or repeat a failed request for every chunk.

The original branch was rewritten after maintainer review. The unused `RuntimeSendOpts.identity` surface and prohibited changelog edit were removed; contributor credit is preserved in the replacement commit.

## User Impact

Heartbeat-driven Slack messages now use the configured per-agent name and icon when the workspace permits custom identity. Workspaces that reject custom identity still receive the message under the app identity.

## Evidence

- `node scripts/run-vitest.mjs extensions/slack/src/channel.test.ts extensions/slack/src/outbound-adapter.test.ts extensions/slack/src/send.identity-fallback.test.ts src/infra/heartbeat-runner.identity.test.ts` -- 70 tests passed.
- Blacksmith Testbox `tbx_01kwqm5bb530xhebfjasq0fw17` -- core/extension production and test types, lint, database/storage guards, runtime sidecar checks, and import-cycle checks passed. [Actions run](https://github.com/openclaw/openclaw/actions/runs/28721763412)
- Fresh autoreview after the delivery-fallback correction -- no actionable findings.
- Reporter live Slack proof -- `chat:write.customize` accepted and rendered the configured name plus raw Unicode emoji; persisted history showed the custom persona.
- Local configured Slack token does not grant `chat:write.customize`, so no independent customized live post was made. Missing-scope and invalid-argument fallback behavior is covered by focused tests.
