### PR TITLE
fix(slack): suppress reasoning blocks across all non-streaming delive…

### DIFF
--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -1120,6 +1120,34 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     expect(deliverRepliesMock).not.toHaveBeenCalled();
   });
 
+  it("suppresses reasoning payloads in non-streaming deliver path without calling deliverReplies", async () => {
+    mockedNativeStreaming = false;
+    mockedDispatchSequence = [
+      { kind: "final", payload: { text: "hidden thinking", isReasoning: true } },
+    ];
+
+    await dispatchPreparedSlackMessage(createPreparedSlackMessage());
+
+    expect(deliverRepliesMock).not.toHaveBeenCalled();
+    expect(finalizeSlackPreviewEditMock).not.toHaveBeenCalled();
+  });
+
+  it("delivers only the non-reasoning payload when mixed in non-streaming path", async () => {
+    mockedNativeStreaming = false;
+    mockedDispatchSequence = [
+      { kind: "final", payload: { text: "hidden thinking", isReasoning: true } },
+      { kind: "final", payload: { text: FINAL_REPLY_TEXT } },
+    ];
+    finalizeSlackPreviewEditMock.mockResolvedValueOnce(undefined);
+
+    await dispatchPreparedSlackMessage(createPreparedSlackMessage());
+
+    expect(deliverRepliesMock).not.toHaveBeenCalled();
+    expect(finalizeSlackPreviewEditMock).toHaveBeenCalledTimes(1);
+    const call = finalizeSlackPreviewEditMock.mock.calls[0] as [Record<string, unknown>];
+    expect(call[0].text).toBe(FINAL_REPLY_TEXT);
+  });
+
   it("keeps same-content tool and final payloads distinct after preview fallback", async () => {
     mockedDispatchSequence = [
       { kind: "tool", payload: { text: SAME_TEXT } },

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -604,6 +604,9 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     kind: ReplyDispatchKind;
     forcedThreadTs?: string;
   }): Promise<void> => {
+    if (params.payload.isReasoning === true) {
+      return;
+    }
     const replyThreadTs = resolveDeliveryThreadTs(params);
     if (
       deliveryTracker.hasDelivered({
@@ -834,6 +837,10 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     deliver: async (payload, info) => {
       if (useStreaming) {
         await deliverWithStreaming({ payload, kind: info.kind });
+        return;
+      }
+
+      if (payload.isReasoning === true) {
         return;
       }
 

--- a/extensions/slack/src/monitor/replies.test.ts
+++ b/extensions/slack/src/monitor/replies.test.ts
@@ -284,6 +284,68 @@ describe("createSlackReplyDeliveryPlan", () => {
   });
 });
 
+describe("deliverReplies reasoning suppression", () => {
+  beforeAll(async () => {
+    ({ deliverReplies } = await import("./replies.js"));
+  });
+
+  beforeEach(() => {
+    sendMock.mockReset();
+    sendMock.mockResolvedValue(undefined);
+  });
+
+  it("skips reasoning payloads and does not call sendMessageSlack", async () => {
+    await deliverReplies(baseParams({ replies: [{ text: "Let me think...", isReasoning: true }] }));
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+
+  it("delivers a non-reasoning payload that follows a reasoning payload", async () => {
+    await deliverReplies(
+      baseParams({
+        replies: [
+          { text: "Let me think...", isReasoning: true },
+          { text: "Here is my answer." },
+        ],
+      }),
+    );
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    const [, text] = requireSendCall();
+    expect(text).toBe("Here is my answer.");
+  });
+});
+
+describe("deliverSlackSlashReplies reasoning suppression", () => {
+  it("skips reasoning payloads from slash command responses", async () => {
+    const respond = vi.fn(async () => undefined);
+
+    await deliverSlackSlashReplies({
+      replies: [{ text: "Let me think...", isReasoning: true }],
+      respond,
+      ephemeral: true,
+      textLimit: 4000,
+    });
+
+    expect(respond).not.toHaveBeenCalled();
+  });
+
+  it("delivers only the non-reasoning payload when mixed", async () => {
+    const respond = vi.fn(async () => undefined);
+
+    await deliverSlackSlashReplies({
+      replies: [
+        { text: "Analyzing...", isReasoning: true },
+        { text: "Done." },
+      ],
+      respond,
+      ephemeral: false,
+      textLimit: 4000,
+    });
+
+    expect(respond).toHaveBeenCalledTimes(1);
+    expect(respond).toHaveBeenCalledWith({ text: "Done.", response_type: "in_channel" });
+  });
+});
+
 describe("deliverSlackSlashReplies chunking", () => {
   it("keeps a 4205-character reply in a single slash response by default", async () => {
     const respond = vi.fn(async () => undefined);

--- a/extensions/slack/src/monitor/replies.ts
+++ b/extensions/slack/src/monitor/replies.ts
@@ -45,6 +45,9 @@ export async function deliverReplies(params: {
   identity?: SlackSendIdentity;
 }) {
   for (const payload of params.replies) {
+    if (payload.isReasoning === true) {
+      continue;
+    }
     const threadTs = resolveDeliveredSlackReplyThreadTs({
       replyToMode: params.replyToMode,
       payloadReplyToId: payload.replyToId,
@@ -206,6 +209,9 @@ export async function deliverSlackSlashReplies(params: {
   const messages: Array<{ text: string; blocks?: ReturnType<typeof readSlackReplyBlocks> }> = [];
   const chunkLimit = Math.min(params.textLimit, SLACK_TEXT_LIMIT);
   for (const payload of params.replies) {
+    if (payload.isReasoning === true) {
+      continue;
+    }
     const reply = resolveSendableOutboundReplyParts(payload);
     const slackBlocks = readSlackReplyBlocks(payload);
     const text =


### PR DESCRIPTION
Summary

Problem: Claude Opus 4.6 and 4.7 models with extended thinking enabled send internal reasoning/thinking blocks as visible Slack messages. The only guard that suppressed isReasoning payloads existed exclusively inside deliverWithStreaming, leaving three other delivery paths completely unprotected.
Solution: Added isReasoning === true guards to every delivery function that can independently send a message to Slack — deliverNormally, the non-streaming branch of the deliver() callback, deliverReplies, and deliverSlackSlashReplies.
What changed: Four guard checks added in dispatch.ts and replies.ts. Six new unit tests added in dispatch.preview-fallback.test.ts and replies.test.ts to lock in suppression behavior across all paths.
What did NOT change: No core changes, no SDK contract changes, no config schema changes, no other extensions touched. Scope is strictly the Slack extension delivery pipeline.
Motivation

When a workspace uses Claude Opus 4.6 or 4.7 with extended thinking enabled, the model returns reasoning blocks alongside its final answer. These reasoning blocks are internal — they represent the model thinking out loud and should never be shown to end users.

The Slack extension was only filtering them out in the native streaming path. Any other scenario — streaming turned off in config, streaming falling back after a Slack API error, or a user sending a slash command — bypassed the filter entirely. Users in these scenarios would see raw model reasoning text like "Let me think through this step by step…" appear as a real Slack message, which breaks the user experience and exposes model internals publicly in channels.

This fix closes all three leaking paths so reasoning content is suppressed consistently regardless of how the reply is delivered.

Change Type

 Bug fix
 Security hardening
Scope

 Integrations
Linked Issue/PR

Closes #84319

 This PR fixes a bug or regression
Real behavior proof

Behavior or issue addressed:
Reasoning/thinking content from Claude Opus 4.6/4.7 was appearing as real Slack messages in three scenarios: streaming disabled via config, streaming falling back to normal delivery after a Slack API error, and slash command responses.

Real environment tested:
Local OpenClaw setup, Claude Opus 4.7 via Anthropic API, Slack workspace with Socket Mode, extended thinking enabled with budgetTokens: 5000.

Exact steps run after this patch:

Configured a Slack account with streaming.mode: off and a Claude Opus 4.7 agent
Sent a complex multi-step prompt from a Slack channel
Repeated the same prompt via the /openclaw slash command
Re-enabled streaming and triggered a fallback by sending a media payload that forces normal delivery
Evidence after fix:
All three scenarios produced only the final answer message in Slack. No reasoning preamble or thinking content appeared in any channel, DM, or slash command response.

Observed result after fix:
Slack receives exactly one message per turn — the final answer. Reasoning blocks are silently dropped at every delivery site before they reach the Slack API.

What was not tested:
Amazon Bedrock provider path in a live environment. The isReasoning flag is set by the same provider-agnostic payload contract upstream, so the guards apply identically regardless of provider, but a live Bedrock workspace was not available to confirm end-to-end.

Root Cause

Root cause:
Reasoning suppression was implemented only inside deliverWithStreaming when the native streaming feature was first introduced. The three other functions that independently send messages to Slack — deliverNormally, the non-streaming deliver() callback branch, and deliverSlackSlashReplies — were never updated to apply the same check. Any payload that reached those paths was forwarded to the Slack API unconditionally.

Missing detection / guardrail:
No test covered the non-streaming delivery path with a payload carrying isReasoning: true. The only existing test exercised deliverWithStreaming exclusively, so the three unprotected paths had no coverage.

Contributing context:
Reasoning support was added incrementally. The streaming path was patched first and the non-streaming paths were not updated in the same change, leaving a silent gap.

Regression Test Plan

Coverage level that should have caught this:

 Unit test
 Seam / integration test
Target test or file:

extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
extensions/slack/src/monitor/replies.test.ts
Scenario the test should lock in:
Any payload with isReasoning === true must never reach sendMessageSlack, deliverReplies, finalizeSlackPreviewEdit, or the slash command respond callback — regardless of the streaming configuration active at the time.

Why this is the smallest reliable guardrail:
Tests mock at the exact Slack API call boundaries so they fail immediately if any guard is removed. They do not depend on a live Slack workspace, a real model, or any config combination.

Existing test that already covers this:
dispatch.preview-fallback.test.ts — "suppresses reasoning payloads before Slack native streaming delivery" — covered deliverWithStreaming only. This PR adds equivalent coverage for all three previously unprotected paths.

User-visible / Behavior Changes

Reasoning and thinking content from Claude Opus 4.6/4.7 extended thinking is now suppressed in all Slack delivery scenarios. Before this fix, it appeared as a visible Slack message when streaming was disabled, when streaming fell back after an error, or when using slash commands. After this fix, only the final answer is delivered in all cases. No config changes are required — the fix is applied automatically.

Diagram

Before:


payload (isReasoning=true)
  ├── deliverWithStreaming      → [guard exists] → suppressed ✓
  ├── deliverNormally           → sendMessageSlack → LEAKED ✗
  ├── deliver() non-stream      → editFinal / deliverNormally → LEAKED ✗
  └── deliverSlackSlashReplies  → respond → LEAKED ✗
After:


payload (isReasoning=true)
  ├── deliverWithStreaming      → [guard] → suppressed ✓
  ├── deliverNormally           → [guard] → suppressed ✓
  ├── deliver() non-stream      → [guard] → suppressed ✓
  └── deliverSlackSlashReplies  → [guard] → suppressed ✓
Security Impact

New permissions/capabilities? No
Secrets/tokens handling changed? No
New/changed network calls? No
Command/tool execution surface changed? No
Data access scope changed? No
Repro + Verification

Environment

OS: macOS 15
Runtime/container: Node.js 22.12, OpenClaw local dev
Model/provider: Claude Opus 4.7, Anthropic API
Integration/channel: Slack (Socket Mode)
Relevant config: streaming.mode: off, agent budgetTokens: 5000, extended thinking enabled
Steps

Enable extended thinking on a Claude Opus 4.7 agent with budgetTokens: 5000
Set streaming.mode: off in the Slack account config
Send a multi-step prompt from a Slack channel and observe the messages posted
Repeat the same prompt via /openclaw <prompt> slash command
Re-enable streaming and trigger a fallback by sending a media attachment
Expected:
Only the final answer appears in Slack. No reasoning or thinking text is posted.

Actual (before fix):
Reasoning text such as "Let me think through this carefully…" appeared as a separate Slack message ahead of the real answer when streaming was off or using slash commands.

Evidence:
After applying the guards, all three reproduction steps produce only the final answer message. Reasoning content does not appear in any channel or DM.

Human Verification

What I personally verified, and how:

Traced the payload flow with streaming.mode: off and confirmed reasoning blocks never reached sendMessageSlack — only the final answer landed in Slack

Ran a slash command prompt and verified the respond callback received no reasoning payloads — only the user-visible answer was sent

Forced a streaming fallback by sending a media payload mid-stream and confirmed the fallback delivery path dropped reasoning content correctly

Sent a mixed turn containing a reasoning block followed by a final answer in non-streaming mode and confirmed Slack received exactly one message with only the final answer

Edge cases checked:

Triggered a reasoning-only turn with no final answer block — confirmed no message was sent to Slack and no error was thrown

Verified the original streaming path guard in deliverWithStreaming was not broken by this change — reasoning suppression on the streaming path still works as before

What I did not verify:

Amazon Bedrock provider path in a live environment — the isReasoning flag is set upstream in the same provider-agnostic payload contract so the guards apply regardless of provider, but a live Bedrock workspace was not available to confirm end-to-end

Review Conversations

I replied to or resolved every bot review conversation I addressed in this PR.

I left unresolved only the conversations that still need reviewer or maintainer judgment.

Compatibility / Migration

Backward compatible? Yes
Config/env changes? No
Migration needed? No
Risks and Mitigations

Risk: A future use case may want to optionally surface reasoning content in Slack for debugging or transparency purposes.

Mitigation: The isReasoning flag is set exclusively by the provider-agnostic payload layer to mark content that must not be user-visible. If an opt-in surface is ever needed, it can be introduced as a separate explicit config flag without touching these guards. The guards as written match the documented intent of isReasoning across the entire codebase.
