### PR TITLE
Doctor: expose extra gateway service findings

### DIFF
--- a/src/cli/program/register.maintenance.test.ts
+++ b/src/cli/program/register.maintenance.test.ts
@@ -126,6 +126,7 @@ describe("registerMaintenanceCommands doctor action", () => {
       skipIds: ["a"],
       onlyIds: ["b"],
       allowExec: true,
+      deep: false,
     });
     expect(runtime.exit).toHaveBeenCalledWith(1);
   });

--- a/src/cli/program/register.maintenance.ts
+++ b/src/cli/program/register.maintenance.ts
@@ -63,6 +63,7 @@ export function registerMaintenanceCommands(program: Command) {
               skipIds: Array.isArray(opts.skip) ? opts.skip : [],
               onlyIds: Array.isArray(opts.only) ? opts.only : [],
               allowExec: Boolean(opts.allowExec),
+              deep: Boolean(opts.deep),
             });
             defaultRuntime.exit(exitCode);
           },

--- a/src/commands/doctor-gateway-services.test.ts
+++ b/src/commands/doctor-gateway-services.test.ts
@@ -579,13 +579,14 @@ describe("maybeRepairGatewayServiceConfig", () => {
       installEntrypoint:
         "/Users/test/Library/pnpm/global/5/node_modules/.pnpm/openclaw@2026.3.12/node_modules/openclaw/dist/index.js",
       realpath: async (value: string) => {
-        if (value.includes("/global/5/node_modules/openclaw/")) {
-          return value.replace(
+        const normalized = value.replaceAll("\\", "/").replace(/^[A-Z]:/i, "");
+        if (normalized.includes("/global/5/node_modules/openclaw/")) {
+          return normalized.replace(
             "/global/5/node_modules/openclaw/",
             "/global/5/node_modules/.pnpm/openclaw@2026.3.12/node_modules/openclaw/",
           );
         }
-        return value;
+        return normalized;
       },
     });
 

--- a/src/commands/doctor-gateway-services.test.ts
+++ b/src/commands/doctor-gateway-services.test.ts
@@ -1200,7 +1200,7 @@ describe("maybeScanExtraGatewayServices", () => {
     expect(mocks.findExtraGatewayServices).toHaveBeenCalledWith(process.env, { deep: true });
   });
 
-  it("maps extra gateway services to structured findings", () => {
+  it("maps intentional extra gateway services to informational structured findings", () => {
     expect(
       extraGatewayServiceToHealthFinding({
         platform: "linux",
@@ -1212,9 +1212,28 @@ describe("maybeScanExtraGatewayServices", () => {
     ).toEqual(
       expect.objectContaining({
         checkId: "core/doctor/gateway-services/extra",
-        severity: "warning",
+        severity: "info",
         source: "linux",
         target: "custom-gateway.service",
+      }),
+    );
+  });
+
+  it("keeps legacy gateway services warning-level", () => {
+    expect(
+      extraGatewayServiceToHealthFinding({
+        platform: "linux",
+        label: "openclaw-gateway.service",
+        detail: "legacy unit",
+        scope: "user",
+        legacy: true,
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        checkId: "core/doctor/gateway-services/extra",
+        severity: "warning",
+        source: "linux",
+        target: "openclaw-gateway.service",
       }),
     );
   });

--- a/src/commands/doctor-gateway-services.test.ts
+++ b/src/commands/doctor-gateway-services.test.ts
@@ -110,6 +110,9 @@ vi.mock("./doctor-gateway-auth-token.js", () => ({
 }));
 
 import {
+  detectExtraGatewayServiceIssues,
+  extraGatewayServiceToHealthFinding,
+  extraGatewayServiceToRepairEffects,
   maybeRepairGatewayServiceConfig,
   maybeScanExtraGatewayServices,
 } from "./doctor-gateway-services.js";
@@ -1187,6 +1190,64 @@ describe("maybeScanExtraGatewayServices", () => {
       "system",
     );
     expectNoteContaining("custom-gateway.service", "Other gateway-like services detected");
+  });
+
+  it("threads deep scans through structured extra gateway service detection", async () => {
+    mocks.findExtraGatewayServices.mockResolvedValue([]);
+
+    await detectExtraGatewayServiceIssues({ deep: true });
+
+    expect(mocks.findExtraGatewayServices).toHaveBeenCalledWith(process.env, { deep: true });
+  });
+
+  it("maps extra gateway services to structured findings", () => {
+    expect(
+      extraGatewayServiceToHealthFinding({
+        platform: "linux",
+        label: "custom-gateway.service",
+        detail: "unit: /etc/systemd/system/custom-gateway.service",
+        scope: "system",
+        legacy: false,
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        checkId: "core/doctor/gateway-services/extra",
+        severity: "warning",
+        source: "linux",
+        target: "custom-gateway.service",
+      }),
+    );
+  });
+
+  it("maps legacy gateway services to dry-run cleanup effects", () => {
+    expect(
+      extraGatewayServiceToRepairEffects({
+        platform: "linux",
+        label: "clawdbot-gateway.service",
+        detail: "unit: /home/test/.config/systemd/user/clawdbot-gateway.service",
+        scope: "user",
+        legacy: true,
+      }),
+    ).toEqual([
+      {
+        kind: "service",
+        action: "would-remove-legacy-gateway-service",
+        target: "clawdbot-gateway.service",
+        dryRunSafe: false,
+      },
+    ]);
+  });
+
+  it("does not report cleanup effects for intentional extra gateway services", () => {
+    expect(
+      extraGatewayServiceToRepairEffects({
+        platform: "linux",
+        label: "custom-gateway.service",
+        detail: "unit: /etc/systemd/system/custom-gateway.service",
+        scope: "system",
+        legacy: false,
+      }),
+    ).toEqual([]);
   });
 
   it("removes legacy Linux user systemd services", async () => {

--- a/src/commands/doctor-gateway-services.ts
+++ b/src/commands/doctor-gateway-services.ts
@@ -245,7 +245,7 @@ export async function detectExtraGatewayServiceIssues(
 export function extraGatewayServiceToHealthFinding(service: ExtraGatewayService): HealthFinding {
   return {
     checkId: GATEWAY_SERVICES_EXTRA_CHECK_ID,
-    severity: "warning",
+    severity: service.legacy === true ? "warning" : "info",
     message: `Other gateway-like service detected: ${service.label} (${service.scope}, ${service.detail})`,
     source: service.platform,
     target: service.label,

--- a/src/commands/doctor-gateway-services.ts
+++ b/src/commands/doctor-gateway-services.ts
@@ -33,6 +33,7 @@ import {
   uninstallLegacySystemdUnits,
   type SystemdUnitScope,
 } from "../daemon/systemd.js";
+import type { HealthFinding, HealthRepairEffect } from "../flows/health-checks.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { buildGatewayInstallPlan } from "./daemon-install-helpers.js";
 import { DEFAULT_GATEWAY_DAEMON_RUNTIME, type GatewayDaemonRuntime } from "./daemon-runtime.js";
@@ -51,6 +52,7 @@ const EXECSTART_REPAIR_CODES = new Set<string>([
   SERVICE_AUDIT_CODES.gatewayCommandMissing,
   SERVICE_AUDIT_CODES.gatewayEntrypointMismatch,
 ]);
+const GATEWAY_SERVICES_EXTRA_CHECK_ID = "core/doctor/gateway-services/extra";
 
 function detectGatewayRuntime(programArguments: string[] | undefined): GatewayDaemonRuntime {
   const first = programArguments?.[0];
@@ -229,6 +231,45 @@ async function filterInactiveExtraGatewayServices(
     }
   }
   return activeOrLegacy;
+}
+
+export async function detectExtraGatewayServiceIssues(
+  options: Pick<DoctorOptions, "deep"> = {},
+): Promise<readonly ExtraGatewayService[]> {
+  const detectedExtraServices = await findExtraGatewayServices(process.env, {
+    deep: options.deep,
+  });
+  return await filterInactiveExtraGatewayServices(detectedExtraServices);
+}
+
+export function extraGatewayServiceToHealthFinding(service: ExtraGatewayService): HealthFinding {
+  return {
+    checkId: GATEWAY_SERVICES_EXTRA_CHECK_ID,
+    severity: "warning",
+    message: `Other gateway-like service detected: ${service.label} (${service.scope}, ${service.detail})`,
+    source: service.platform,
+    target: service.label,
+    fixHint:
+      service.legacy === true
+        ? "Run openclaw doctor --fix to remove legacy gateway services."
+        : "Run a single gateway per machine unless this extra gateway is intentional.",
+  };
+}
+
+export function extraGatewayServiceToRepairEffects(
+  service: ExtraGatewayService,
+): readonly HealthRepairEffect[] {
+  if (service.legacy !== true) {
+    return [];
+  }
+  return [
+    {
+      kind: "service",
+      action: "would-remove-legacy-gateway-service",
+      target: service.label,
+      dryRunSafe: false,
+    },
+  ];
 }
 
 async function cleanupLegacyLaunchdService(params: {
@@ -658,10 +699,7 @@ export async function maybeScanExtraGatewayServices(
   runtime: RuntimeEnv,
   prompter: DoctorPrompter,
 ) {
-  const detectedExtraServices = await findExtraGatewayServices(process.env, {
-    deep: options.deep,
-  });
-  const extraServices = await filterInactiveExtraGatewayServices(detectedExtraServices);
+  const extraServices = await detectExtraGatewayServiceIssues(options);
   if (extraServices.length === 0) {
     return;
   }

--- a/src/commands/doctor-lint.test.ts
+++ b/src/commands/doctor-lint.test.ts
@@ -77,18 +77,18 @@ describe("runDoctorLintCli", () => {
     }
   });
 
-  it("passes deep mode to health check context", async () => {
+  it("does not expose deep mode to extension health check context", async () => {
     mocks.readConfigFileSnapshot.mockResolvedValue({
       exists: true,
       valid: true,
       config: {},
       path: "/tmp/openclaw.json",
     });
-    const detect = vi.fn(async () => []);
+    const detect = vi.fn(async (_ctx: unknown) => []);
     registerHealthCheck({
       id: "test/deep-context",
       kind: "plugin",
-      description: "test deep context",
+      description: "test extension context",
       detect,
     });
 
@@ -102,9 +102,9 @@ describe("runDoctorLintCli", () => {
       expect(detect).toHaveBeenCalledWith(
         expect.objectContaining({
           mode: "lint",
-          deep: true,
         }),
       );
+      expect(detect.mock.calls[0]?.[0]).not.toHaveProperty("deep");
     } finally {
       stdout.mockRestore();
     }

--- a/src/commands/doctor-lint.test.ts
+++ b/src/commands/doctor-lint.test.ts
@@ -254,9 +254,49 @@ describe("runDoctorLintCli", () => {
         onlyIds: ["core/doctor/final-config-validation", "plugin/example/lint"],
       });
 
+      expect(exitCode).toBe(0);
+      const payload = JSON.parse(String(stdout.mock.calls.at(-1)?.[0]));
+      expect(payload.ok).toBe(true);
+      expect(payload.checksRun).toBe(2);
+      expect(payload.findings).toEqual([]);
+    } finally {
+      stdout.mockRestore();
+    }
+  });
+
+  it("fails informational findings when severity-min is explicit", async () => {
+    mocks.readConfigFileSnapshot.mockResolvedValue({
+      exists: true,
+      valid: true,
+      config: {},
+      path: "/tmp/openclaw.json",
+    });
+    registerHealthCheck({
+      id: "plugin/example/lint",
+      kind: "plugin",
+      description: "example plugin lint check",
+      async detect() {
+        return [
+          {
+            checkId: "plugin/example/lint",
+            severity: "info",
+            message: "plugin finding",
+          },
+        ];
+      },
+    });
+
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    try {
+      const exitCode = await runDoctorLintCli(runtime, {
+        json: true,
+        severityMin: "info",
+        onlyIds: ["plugin/example/lint"],
+      });
+
       expect(exitCode).toBe(1);
       const payload = JSON.parse(String(stdout.mock.calls.at(-1)?.[0]));
-      expect(payload.checksRun).toBe(2);
+      expect(payload.ok).toBe(false);
       expect(payload.findings).toEqual([
         {
           checkId: "plugin/example/lint",

--- a/src/commands/doctor-lint.test.ts
+++ b/src/commands/doctor-lint.test.ts
@@ -77,6 +77,39 @@ describe("runDoctorLintCli", () => {
     }
   });
 
+  it("passes deep mode to health check context", async () => {
+    mocks.readConfigFileSnapshot.mockResolvedValue({
+      exists: true,
+      valid: true,
+      config: {},
+      path: "/tmp/openclaw.json",
+    });
+    const detect = vi.fn(async () => []);
+    registerHealthCheck({
+      id: "test/deep-context",
+      kind: "plugin",
+      description: "test deep context",
+      detect,
+    });
+
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    try {
+      await runDoctorLintCli(runtime, {
+        deep: true,
+        onlyIds: ["test/deep-context"],
+      });
+
+      expect(detect).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mode: "lint",
+          deep: true,
+        }),
+      );
+    } finally {
+      stdout.mockRestore();
+    }
+  });
+
   it("emits structured JSON for invalid config snapshots", async () => {
     mocks.readConfigFileSnapshot.mockResolvedValue({
       exists: true,

--- a/src/commands/doctor-lint.ts
+++ b/src/commands/doctor-lint.ts
@@ -24,6 +24,7 @@ interface DoctorLintCliOptions {
   readonly skipIds?: readonly string[];
   readonly onlyIds?: readonly string[];
   readonly allowExec?: boolean;
+  readonly deep?: boolean;
 }
 
 function detectMode(opts: DoctorLintCliOptions): "human" | "json" {
@@ -75,6 +76,7 @@ export async function runDoctorLintCli(
     cfg: snapshot.config,
     cwd: resolveAgentWorkspaceDir(snapshot.config, resolveDefaultAgentId(snapshot.config)),
     allowExecSecretRefs: opts.allowExec === true,
+    deep: opts.deep === true,
     ...(snapshot.path !== undefined ? { configPath: snapshot.path } : {}),
   };
   registerBundledHealthChecks({ cfg: snapshot.config, cwd: ctx.cwd });

--- a/src/commands/doctor-lint.ts
+++ b/src/commands/doctor-lint.ts
@@ -45,7 +45,7 @@ export async function runDoctorLintCli(
   opts: DoctorLintCliOptions,
 ): Promise<number> {
   const sevMin =
-    opts.severityMin === undefined ? "info" : parseHealthFindingSeverity(opts.severityMin);
+    opts.severityMin === undefined ? "warning" : parseHealthFindingSeverity(opts.severityMin);
   if (sevMin === null) {
     throw new Error("Invalid --severity-min value. Expected one of: info, warning, error.");
   }

--- a/src/commands/doctor-lint.ts
+++ b/src/commands/doctor-lint.ts
@@ -13,6 +13,7 @@ import { listExtensionHealthChecksForDoctor } from "../flows/health-check-regist
 import {
   healthFindingMeetsSeverity,
   parseHealthFindingSeverity,
+  type HealthCheck,
   type HealthCheckContext,
   type HealthFinding,
 } from "../flows/health-checks.js";
@@ -76,15 +77,15 @@ export async function runDoctorLintCli(
     cfg: snapshot.config,
     cwd: resolveAgentWorkspaceDir(snapshot.config, resolveDefaultAgentId(snapshot.config)),
     allowExecSecretRefs: opts.allowExec === true,
-    deep: opts.deep === true,
     ...(snapshot.path !== undefined ? { configPath: snapshot.path } : {}),
   };
   registerBundledHealthChecks({ cfg: snapshot.config, cwd: ctx.cwd });
   const coreChecks = await resolveDoctorContributionHealthChecks();
   const extensionChecks = listExtensionHealthChecksForDoctor(coreChecks);
+  const coreCtx = { ...ctx, deep: opts.deep === true };
 
   const runOpts: DoctorLintRunOptions = {
-    checks: [...coreChecks, ...extensionChecks],
+    checks: [...coreChecks.map((check) => withCoreLintContext(check, coreCtx)), ...extensionChecks],
     ...(opts.skipIds && opts.skipIds.length > 0 ? { skipIds: opts.skipIds } : {}),
     ...(opts.onlyIds && opts.onlyIds.length > 0 ? { onlyIds: opts.onlyIds } : {}),
   };
@@ -118,6 +119,18 @@ export async function runDoctorLintCli(
   }
 
   return exitCodeFromFindings(result.findings, sevMin);
+}
+
+function withCoreLintContext(
+  check: HealthCheck,
+  ctx: HealthCheckContext & { readonly deep?: boolean },
+): HealthCheck {
+  return {
+    ...check,
+    detect(_ctx, scope) {
+      return check.detect(ctx, scope);
+    },
+  };
 }
 
 function writeJsonResult(result: {

--- a/src/flows/doctor-core-checks.test.ts
+++ b/src/flows/doctor-core-checks.test.ts
@@ -128,7 +128,7 @@ describe("CORE_HEALTH_CHECKS", () => {
     const check = getCheck(createCoreHealthChecks(createDeps()), "core/doctor/hooks-model");
 
     await check.detect({
-      mode: "lint",
+      mode: "lint" as const,
       runtime,
       cfg,
     });
@@ -175,12 +175,14 @@ describe("CORE_HEALTH_CHECKS", () => {
       },
     ]);
 
-    await check.detect({
-      mode: "lint",
+    const ctx = {
+      mode: "lint" as const,
       runtime,
       cfg: {},
       deep: true,
-    });
+    };
+
+    await check.detect(ctx);
 
     expect(mocks.detectExtraGatewayServiceIssues).toHaveBeenCalledWith({ deep: true });
     expect(mocks.extraGatewayServiceToHealthFinding).toHaveBeenCalledWith(
@@ -211,16 +213,15 @@ describe("CORE_HEALTH_CHECKS", () => {
       },
     ]);
 
-    const result = await check.repair?.(
-      {
-        mode: "fix",
-        runtime,
-        cfg: {},
-        deep: true,
-        dryRun: true,
-      },
-      [],
-    );
+    const ctx = {
+      mode: "fix" as const,
+      runtime,
+      cfg: {},
+      deep: true,
+      dryRun: true,
+    };
+
+    const result = await check.repair?.(ctx, []);
 
     expect(mocks.detectExtraGatewayServiceIssues).toHaveBeenCalledWith({ deep: true });
     expect(result?.effects).toContainEqual(

--- a/src/flows/doctor-core-checks.test.ts
+++ b/src/flows/doctor-core-checks.test.ts
@@ -17,10 +17,25 @@ import type { HealthCheck, HealthFinding } from "./health-checks.js";
 
 const mocks = vi.hoisted(() => ({
   loadModelCatalog: vi.fn(async () => []),
+  detectExtraGatewayServiceIssues: vi.fn(async () => []),
+  extraGatewayServiceToHealthFinding: vi.fn(
+    (service: { label: string }): HealthFinding => ({
+      checkId: "core/doctor/gateway-services/extra",
+      severity: "warning",
+      message: service.label,
+    }),
+  ),
+  extraGatewayServiceToRepairEffects: vi.fn(() => []),
 }));
 
 vi.mock("../agents/model-catalog.js", () => ({
   loadModelCatalog: mocks.loadModelCatalog,
+}));
+
+vi.mock("../commands/doctor-gateway-services.js", () => ({
+  detectExtraGatewayServiceIssues: mocks.detectExtraGatewayServiceIssues,
+  extraGatewayServiceToHealthFinding: mocks.extraGatewayServiceToHealthFinding,
+  extraGatewayServiceToRepairEffects: mocks.extraGatewayServiceToRepairEffects,
 }));
 
 const runtime = { log() {}, error() {}, exit() {} };
@@ -128,6 +143,10 @@ describe("CORE_HEALTH_CHECKS", () => {
   beforeEach(() => {
     mocks.loadModelCatalog.mockClear();
     mocks.loadModelCatalog.mockResolvedValue([]);
+    mocks.detectExtraGatewayServiceIssues.mockClear();
+    mocks.detectExtraGatewayServiceIssues.mockResolvedValue([]);
+    mocks.extraGatewayServiceToHealthFinding.mockClear();
+    mocks.extraGatewayServiceToRepairEffects.mockClear();
     tmp = undefined;
   });
 
@@ -143,6 +162,72 @@ describe("CORE_HEALTH_CHECKS", () => {
         check.description.endsWith("represented in the health registry."),
       ),
     ).toBe(false);
+  });
+
+  it("threads deep mode into structured extra gateway service detection", async () => {
+    const check = getCheck(
+      createCoreHealthChecks(createDeps()),
+      "core/doctor/gateway-services/extra",
+    );
+    mocks.detectExtraGatewayServiceIssues.mockResolvedValueOnce([
+      {
+        label: "custom-gateway.service",
+      },
+    ]);
+
+    await check.detect({
+      mode: "lint",
+      runtime,
+      cfg: {},
+      deep: true,
+    });
+
+    expect(mocks.detectExtraGatewayServiceIssues).toHaveBeenCalledWith({ deep: true });
+    expect(mocks.extraGatewayServiceToHealthFinding).toHaveBeenCalledWith(
+      {
+        label: "custom-gateway.service",
+      },
+      0,
+      [{ label: "custom-gateway.service" }],
+    );
+  });
+
+  it("threads deep mode into structured extra gateway service repair previews", async () => {
+    const check = getCheck(
+      createCoreHealthChecks(createDeps()),
+      "core/doctor/gateway-services/extra",
+    );
+    mocks.detectExtraGatewayServiceIssues.mockResolvedValueOnce([
+      {
+        label: "legacy-gateway.service",
+      },
+    ]);
+    mocks.extraGatewayServiceToRepairEffects.mockReturnValueOnce([
+      {
+        kind: "service",
+        action: "would-remove-legacy-gateway-service",
+        target: "legacy-gateway.service",
+        dryRunSafe: false,
+      },
+    ]);
+
+    const result = await check.repair?.(
+      {
+        mode: "fix",
+        runtime,
+        cfg: {},
+        deep: true,
+        dryRun: true,
+      },
+      [],
+    );
+
+    expect(mocks.detectExtraGatewayServiceIssues).toHaveBeenCalledWith({ deep: true });
+    expect(result?.effects).toContainEqual(
+      expect.objectContaining({
+        target: "legacy-gateway.service",
+      }),
+    );
   });
 
   it("converts unavailable skills into repair-capable health findings", async () => {

--- a/src/flows/doctor-core-checks.test.ts
+++ b/src/flows/doctor-core-checks.test.ts
@@ -13,11 +13,11 @@ import {
   type CoreHealthCheckDeps,
 } from "./doctor-core-checks.js";
 import { clearHealthChecksForTest } from "./health-check-registry.js";
-import type { HealthCheck, HealthFinding } from "./health-checks.js";
+import type { HealthCheck, HealthFinding, HealthRepairEffect } from "./health-checks.js";
 
 const mocks = vi.hoisted(() => ({
   loadModelCatalog: vi.fn(async () => []),
-  detectExtraGatewayServiceIssues: vi.fn(async () => []),
+  detectExtraGatewayServiceIssues: vi.fn(async (): Promise<readonly { label: string }[]> => []),
   extraGatewayServiceToHealthFinding: vi.fn(
     (service: { label: string }): HealthFinding => ({
       checkId: "core/doctor/gateway-services/extra",
@@ -25,7 +25,7 @@ const mocks = vi.hoisted(() => ({
       message: service.label,
     }),
   ),
-  extraGatewayServiceToRepairEffects: vi.fn(() => []),
+  extraGatewayServiceToRepairEffects: vi.fn((): readonly HealthRepairEffect[] => []),
 }));
 
 vi.mock("../agents/model-catalog.js", () => ({

--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -659,15 +659,17 @@ const gatewayServicesExtraCheck: HealthCheck = {
   kind: "core",
   description: "Extra gateway-like services are represented as structured findings.",
   source: "doctor",
-  async detect() {
+  async detect(ctx) {
     const { detectExtraGatewayServiceIssues, extraGatewayServiceToHealthFinding } =
       await import("../commands/doctor-gateway-services.js");
-    return (await detectExtraGatewayServiceIssues()).map(extraGatewayServiceToHealthFinding);
+    return (await detectExtraGatewayServiceIssues({ deep: ctx.deep === true })).map(
+      extraGatewayServiceToHealthFinding,
+    );
   },
   async repair(ctx) {
     const { detectExtraGatewayServiceIssues, extraGatewayServiceToRepairEffects } =
       await import("../commands/doctor-gateway-services.js");
-    const effects = (await detectExtraGatewayServiceIssues()).flatMap(
+    const effects = (await detectExtraGatewayServiceIssues({ deep: ctx.deep === true })).flatMap(
       extraGatewayServiceToRepairEffects,
     );
     if (ctx.dryRun === true) {

--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -31,12 +31,25 @@ import { resolveGatewayAuth } from "../gateway/auth.js";
 import { getSkippedExecRefStaticError } from "../secrets/exec-resolution-policy.js";
 import type { SkillStatusEntry } from "../skills/discovery/status.js";
 import { registerHealthCheck } from "./health-check-registry.js";
-import type { HealthCheck, HealthCheckContext, HealthFinding } from "./health-checks.js";
+import type {
+  HealthCheck,
+  HealthCheckContext,
+  HealthFinding,
+  HealthRepairContext,
+} from "./health-checks.js";
 
 const BROWSER_CLAWD_PROFILE_RESIDUE_CHECK_ID = "core/doctor/browser-clawd-profile-residue";
 const CODEX_SESSION_ROUTES_CHECK_ID = "core/doctor/codex-session-routes";
 const FINAL_CONFIG_VALIDATION_CHECK_ID = "core/doctor/final-config-validation";
 const GATEWAY_SERVICES_EXTRA_CHECK_ID = "core/doctor/gateway-services/extra";
+
+type CoreHealthCheckContext = HealthCheckContext & {
+  readonly deep?: boolean;
+};
+
+type CoreHealthRepairContext = HealthRepairContext & {
+  readonly deep?: boolean;
+};
 
 const loadDoctorCoreChecksRuntimeModule = async () =>
   await import("./doctor-core-checks.runtime.js");
@@ -660,18 +673,20 @@ const gatewayServicesExtraCheck: HealthCheck = {
   description: "Extra gateway-like services are represented as structured findings.",
   source: "doctor",
   async detect(ctx) {
+    const coreCtx = ctx as CoreHealthCheckContext;
     const { detectExtraGatewayServiceIssues, extraGatewayServiceToHealthFinding } =
       await import("../commands/doctor-gateway-services.js");
-    return (await detectExtraGatewayServiceIssues({ deep: ctx.deep === true })).map(
+    return (await detectExtraGatewayServiceIssues({ deep: coreCtx.deep === true })).map(
       extraGatewayServiceToHealthFinding,
     );
   },
   async repair(ctx) {
+    const coreCtx = ctx as CoreHealthRepairContext;
     const { detectExtraGatewayServiceIssues, extraGatewayServiceToRepairEffects } =
       await import("../commands/doctor-gateway-services.js");
-    const effects = (await detectExtraGatewayServiceIssues({ deep: ctx.deep === true })).flatMap(
-      extraGatewayServiceToRepairEffects,
-    );
+    const effects = (
+      await detectExtraGatewayServiceIssues({ deep: coreCtx.deep === true })
+    ).flatMap(extraGatewayServiceToRepairEffects);
     if (ctx.dryRun === true) {
       return { status: "repaired", changes: [], effects };
     }

--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -36,6 +36,7 @@ import type { HealthCheck, HealthCheckContext, HealthFinding } from "./health-ch
 const BROWSER_CLAWD_PROFILE_RESIDUE_CHECK_ID = "core/doctor/browser-clawd-profile-residue";
 const CODEX_SESSION_ROUTES_CHECK_ID = "core/doctor/codex-session-routes";
 const FINAL_CONFIG_VALIDATION_CHECK_ID = "core/doctor/final-config-validation";
+const GATEWAY_SERVICES_EXTRA_CHECK_ID = "core/doctor/gateway-services/extra";
 
 const loadDoctorCoreChecksRuntimeModule = async () =>
   await import("./doctor-core-checks.runtime.js");
@@ -653,6 +654,34 @@ const codexSessionRoutesCheck: HealthCheck = {
   },
 };
 
+const gatewayServicesExtraCheck: HealthCheck = {
+  id: GATEWAY_SERVICES_EXTRA_CHECK_ID,
+  kind: "core",
+  description: "Extra gateway-like services are represented as structured findings.",
+  source: "doctor",
+  async detect() {
+    const { detectExtraGatewayServiceIssues, extraGatewayServiceToHealthFinding } =
+      await import("../commands/doctor-gateway-services.js");
+    return (await detectExtraGatewayServiceIssues()).map(extraGatewayServiceToHealthFinding);
+  },
+  async repair(ctx) {
+    const { detectExtraGatewayServiceIssues, extraGatewayServiceToRepairEffects } =
+      await import("../commands/doctor-gateway-services.js");
+    const effects = (await detectExtraGatewayServiceIssues()).flatMap(
+      extraGatewayServiceToRepairEffects,
+    );
+    if (ctx.dryRun === true) {
+      return { status: "repaired", changes: [], effects };
+    }
+    return {
+      status: "skipped",
+      reason: "legacy doctor gateway service contribution owns cleanup",
+      changes: [],
+      effects,
+    };
+  },
+};
+
 const gatewayPlatformNotesCheck: HealthCheck = {
   id: "core/doctor/gateway-services/platform-notes",
   kind: "core",
@@ -926,6 +955,7 @@ function createConvertedWorkflowChecks(deps: CoreHealthCheckDeps): readonly Heal
     codexSessionRoutesCheck,
     shellCompletionCheck,
     uiProtocolFreshnessCheck,
+    gatewayServicesExtraCheck,
     gatewayPlatformNotesCheck,
     createSecurityCheck(deps),
     browserCheck,

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -1012,6 +1012,7 @@ describe("doctor health contributions", () => {
       expect(contributionIds).toContain(coreId);
     }
     expect(contributionIds).toContain("core/doctor/sandbox/registry-files");
+    expect(contributionIds).toContain("core/doctor/gateway-services/extra");
     expect(contributionChecks.map((check) => check.id)).toEqual(contributionIds);
   });
 

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -1351,7 +1351,10 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
     createDoctorHealthContribution({
       id: "doctor:gateway-services",
       label: "Gateway services",
-      healthCheckIds: ["core/doctor/gateway-services/platform-notes"],
+      healthCheckIds: [
+        "core/doctor/gateway-services/extra",
+        "core/doctor/gateway-services/platform-notes",
+      ],
       run: runGatewayServicesHealth,
     }),
     createDoctorHealthContribution({

--- a/src/flows/health-checks.ts
+++ b/src/flows/health-checks.ts
@@ -56,7 +56,6 @@ export interface HealthCheckContext {
   readonly cwd?: string;
   readonly configPath?: string;
   readonly allowExecSecretRefs?: boolean;
-  readonly deep?: boolean;
 }
 
 /** Repair-capable health-check context; fixes may emit diffs or dry-run previews. */

--- a/src/flows/health-checks.ts
+++ b/src/flows/health-checks.ts
@@ -56,6 +56,7 @@ export interface HealthCheckContext {
   readonly cwd?: string;
   readonly configPath?: string;
   readonly allowExecSecretRefs?: boolean;
+  readonly deep?: boolean;
 }
 
 /** Repair-capable health-check context; fixes may emit diffs or dry-run previews. */


### PR DESCRIPTION
## Summary

- Exposes the extra gateway service Doctor checks as structured health findings.
- Adds dry-run repair effects for legacy Gateway cleanup that Doctor already knows how to describe.
- Keeps the existing `doctor:gateway-services` legacy run path authoritative for normal `doctor` / `doctor --fix` mutation.
- Declares the structured checks inline on the existing ordered Doctor contribution, so core Doctor ordering remains contribution-owned.
- Preserves compatibility for intentional non-legacy extra Gateway services by reporting them as informational instead of warning-level lint failures.

This is intentionally the Gateway services slice from the Doctor repair stack. It does not change Gateway startup, provider config, or plugin health behavior.

## Stack

Review order: this is the next Doctor structured-repair PR after #84326. The branch itself is rebased on current `main`; #86627 has landed and supplies the ordered core Doctor contribution model.

Current branch head is signed commit `1818dcab5c5ba0c592b976e45955ac67a3c0d1e5` (`Keep doctor lint deep internal`). The latest commit removes `deep` from the public `HealthCheckContext` SDK contract while keeping `doctor --lint --deep` available to core Doctor checks. The prior rebased-base cleanup for the unused `sessionStore` destructure remains included so prod type/lint CI passes on current main.

## Real behavior proof

Behavior or issue addressed:
Extra or legacy Gateway-like services are visible through structured Doctor health checks, while normal mutating service cleanup remains owned by the existing `doctor:gateway-services` run path. Intentional non-legacy extra Gateway services are non-failing by default; legacy Gateway services remain warning-level and repairable.

Real environment tested:
WSL Ubuntu 24.04, OpenClaw checkout `/root/src/openclaw-84340-proof`, prior PR head `5d57cbeccc55509c3867bb4c964a0094c6869293`, source CLI via `node scripts/run-node.mjs`, source harness via `node --import tsx --input-type=module`, isolated temp `OPENCLAW_STATE_DIR`, temp `OPENCLAW_CONFIG_PATH`, temp `HOME`, and a synthetic legacy user systemd unit. The branch has since been rebased and updated to `8fb226be72dc33af84aa63fb14d4ae4b68adafab`; the latest functional Gateway-services behavior is unchanged.

Exact steps or command run after this patch:

1. Reused the isolated source CLI lint proof for a synthetic legacy `clawdbot-gateway.service` unit.
2. Ran a source harness importing `extraGatewayServiceToHealthFinding`, `extraGatewayServiceToRepairEffects`, and `exitCodeFromFindings`.
3. The harness compared an intentional non-legacy extra Gateway service with a legacy Gateway service under the default lint threshold.
4. Ran focused validation for Gateway-services and Doctor contribution tests.
5. Ran changed-file checks: targeted `oxlint`, targeted `oxfmt --check`, `git diff --check`, and `pnpm tsgo:core`.
6. After the test-only CI follow-up, ran the failed CI coverage locally: `src/cli/program/register.maintenance.test.ts`, `src/flows/doctor-core-checks.test.ts`, `pnpm check:test-types`, and `pnpm tsgo:core`.
7. Removed the unused `sessionStore` destructure exposed by current `upstream/main`, then reran `pnpm tsgo:core` successfully.

Evidence after fix:

```json
{
  "intentional": {
    "severity": "info",
    "fixHint": "Run a single gateway per machine unless this extra gateway is intentional.",
    "defaultLintExit": 0,
    "repairEffects": []
  },
  "legacy": {
    "severity": "warning",
    "fixHint": "Run openclaw doctor --fix to remove legacy gateway services.",
    "defaultLintExit": 1,
    "repairEffects": [
      {
        "kind": "service",
        "action": "would-remove-legacy-gateway-service",
        "target": "openclaw-gateway.service",
        "dryRunSafe": false
      }
    ]
  }
}
```

The earlier real CLI proof still applies to the legacy path: `doctor --lint --json --only core/doctor/gateway-services/extra` reports the synthetic legacy `clawdbot-gateway.service` as a structured warning with the expected check id, Linux source, target service label, and fix hint.

Observed result after fix:
Intentional non-legacy extra Gateway services are visible in structured output without failing default `doctor --lint`. Legacy Gateway services remain warning-level, fail default lint, and expose the dry-run cleanup effect.

What was not tested:
The proof uses synthetic Gateway service fixtures, not a real installed or running Gateway service. I did not run full `doctor --fix` service cleanup in WSL because the mutating cleanup path can invoke systemd/service-management behavior; the PR intentionally keeps that existing legacy run path authoritative.

## ClawSweeper and maintainer status

Latest visible ClawSweeper status:

- Proof: sufficient.
- Status label: ready for maintainer look.
- No concrete contributor-facing blocker remains from the latest durable review.

Maintainer findings to accept before merge:

- Default `doctor --lint` now reports and fails `warning`-and-above findings; `info` findings require `--severity-min info`.
- The structured repair preview intentionally coexists with the legacy Gateway-services mutation path until that rule is deliberately moved fully behind structured health.

Severity finding:

- Keep legacy extra Gateway services at `warning`; they are actionably stale service state with an existing `openclaw doctor --fix` correction path.
- Keep intentional non-legacy extra Gateway services at `info`; they are noteworthy but can be left in place indefinitely when intentional.
- RFC pointer: openclaw/rfcs#1, `rfcs/needs_refactoring/0002-doctor-health-upgrades.md`, records the Doctor warning/info severity bar in the structured health contract.

## Validation

Current head `8fb226be72dc33af84aa63fb14d4ae4b68adafab`:

- `$env:OPENCLAW_VITEST_MAX_WORKERS='1'; node scripts\run-vitest.mjs run src\commands\doctor-gateway-services.test.ts src\commands\doctor-lint.test.ts src\flows\doctor-core-checks.test.ts src\flows\doctor-health-contributions.test.ts src\cli\program\register.maintenance.test.ts --reporter=dot` - 121 tests passed across 3 shards
- `pnpm exec oxlint src\cli\program\register.maintenance.test.ts src\cli\program\register.maintenance.ts src\commands\doctor-gateway-services.test.ts src\commands\doctor-gateway-services.ts src\commands\doctor-lint.test.ts src\commands\doctor-lint.ts src\flows\doctor-core-checks.test.ts src\flows\doctor-core-checks.ts src\flows\doctor-health-contributions.test.ts src\flows\doctor-health-contributions.ts src\flows\health-checks.ts src\config\sessions\session-accessor.ts`
- `pnpm exec oxfmt --check src\cli\program\register.maintenance.test.ts src\cli\program\register.maintenance.ts src\commands\doctor-gateway-services.test.ts src\commands\doctor-gateway-services.ts src\commands\doctor-lint.test.ts src\commands\doctor-lint.ts src\flows\doctor-core-checks.test.ts src\flows\doctor-core-checks.ts src\flows\doctor-health-contributions.test.ts src\flows\doctor-health-contributions.ts src\flows\health-checks.ts src\config\sessions\session-accessor.ts`
- `pnpm tsgo:core`
- `pnpm tsgo:test:src`
- `git diff --check`

Follow-up `1818dcab5c5ba0c592b976e45955ac67a3c0d1e5`:

- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run src/commands/doctor-lint.test.ts src/flows/doctor-core-checks.test.ts src/commands/doctor-gateway-services.test.ts src/flows/doctor-health-contributions.test.ts src/cli/program/register.maintenance.test.ts --reporter=dot` - 121 tests passed across 3 shards
- `node_modules/oxlint/bin/oxlint src/commands/doctor-lint.ts src/commands/doctor-lint.test.ts src/flows/doctor-core-checks.ts src/flows/doctor-core-checks.test.ts src/flows/health-checks.ts`
- `node_modules/oxfmt/bin/oxfmt --check src/commands/doctor-lint.ts src/commands/doctor-lint.test.ts src/flows/doctor-core-checks.ts src/flows/doctor-core-checks.test.ts src/flows/health-checks.ts`
- `node node_modules//native-preview/bin/tsgo.js -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo --declaration false --singleThreaded --checkers 1`
- `node node_modules//native-preview/bin/tsgo.js -p test/tsconfig/tsconfig.test.src.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-src.tsbuildinfo --declaration false --singleThreaded --checkers 1`
- `git diff --check`
