### PR TITLE
docs: move native codex plugins into capabilities

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1204,6 +1204,7 @@
                 "group": "Bundled plugin guides",
                 "pages": [
                   "plugins/codex-harness",
+                  "plugins/codex-native-plugins",
                   "plugins/codex-computer-use",
                   "plugins/google-meet",
                   "plugins/webhooks",
@@ -1703,8 +1704,7 @@
                 "group": "Codex harness",
                 "pages": [
                   "plugins/codex-harness-reference",
-                  "plugins/codex-harness-runtime",
-                  "plugins/codex-native-plugins"
+                  "plugins/codex-harness-runtime"
                 ]
               },
               {


### PR DESCRIPTION
## Summary
- move `plugins/codex-native-plugins` from the References tab to the Capabilities tab
- place it in Bundled plugin guides directly under `plugins/codex-harness`

## Verification
- `python - <<"PY"\nimport json\nfrom pathlib import Path\njson.loads(Path("docs/docs.json").read_text())\nprint("docs/docs.json parses")\nPY`
- `git diff --check`
