### PR TITLE
perf(infra): cache sync JSON reads with stat validation

### DIFF
--- a/src/infra/json-file.ts
+++ b/src/infra/json-file.ts
@@ -2,8 +2,6 @@ import "./fs-safe-defaults.js";
 import fs from "node:fs";
 import path from "node:path";
 import { tryReadJson } from "@openclaw/fs-safe/json";
-// Route synchronous reads/writes through `./json-files.js` so they share the
-// process-scoped read cache and its write-side invalidation.
 import { tryReadJsonSync, writeJsonSync } from "./json-files.js";
 
 export { tryReadJson, tryReadJsonSync, writeJsonSync };

--- a/src/infra/json-file.ts
+++ b/src/infra/json-file.ts
@@ -1,10 +1,10 @@
 import "./fs-safe-defaults.js";
 import fs from "node:fs";
 import path from "node:path";
-import { tryReadJson } from "@openclaw/fs-safe/json";
-import { tryReadJsonSync, writeJsonSync } from "./json-files.js";
+import { tryReadJson, tryReadJsonSync as rawTryReadJsonSync } from "@openclaw/fs-safe/json";
+import { writeJsonSync } from "./json-files.js";
 
-export { tryReadJson, tryReadJsonSync, writeJsonSync };
+export { tryReadJson, writeJsonSync };
 export const readJsonFile = tryReadJson;
 
 function resolveJsonSymlinkTarget(pathname: string): string | undefined {
@@ -39,10 +39,10 @@ export function saveJsonFile(pathname: string, data: unknown): void {
 
 // oxlint-disable-next-line typescript-eslint/no-unnecessary-type-parameters -- legacy typed JSON loader alias.
 export function loadJsonFile<T = unknown>(pathname: string): T | undefined {
-  const direct = tryReadJsonSync<T>(pathname);
+  const direct = rawTryReadJsonSync<T>(pathname);
   if (direct !== null) {
     return direct;
   }
   const target = resolveJsonSymlinkTarget(pathname);
-  return target ? (tryReadJsonSync<T>(target) ?? undefined) : undefined;
+  return target ? (rawTryReadJsonSync<T>(target) ?? undefined) : undefined;
 }

--- a/src/infra/json-file.ts
+++ b/src/infra/json-file.ts
@@ -1,7 +1,10 @@
 import "./fs-safe-defaults.js";
 import fs from "node:fs";
 import path from "node:path";
-import { tryReadJsonSync, tryReadJson, writeJsonSync } from "@openclaw/fs-safe/json";
+import { tryReadJson } from "@openclaw/fs-safe/json";
+// Route synchronous reads/writes through `./json-files.js` so they share the
+// process-scoped read cache and its write-side invalidation.
+import { tryReadJsonSync, writeJsonSync } from "./json-files.js";
 
 export { tryReadJson, tryReadJsonSync, writeJsonSync };
 export const readJsonFile = tryReadJson;

--- a/src/infra/json-files.test.ts
+++ b/src/infra/json-files.test.ts
@@ -1,12 +1,16 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { withTempDir } from "../test-helpers/temp-dir.js";
 import {
   JsonFileReadError,
+  clearJsonReadCache,
   createAsyncLock,
   readDurableJsonFile,
   readJsonFile,
+  readRootJsonObjectSync,
   writeJsonAtomic,
   writeTextAtomic,
 } from "./json-files.js";
@@ -146,6 +150,29 @@ describe("json file helpers", () => {
       expect(fileStat.isSymbolicLink()).toBe(true);
       await expect(fs.readFile(outsidePath, "utf8")).resolves.toBe("outside");
     });
+  });
+
+  it("readRootJsonObjectSync bypasses cache when safety-relevant options are set", () => {
+    const dir = fsSync.mkdtempSync(path.join(os.tmpdir(), "openclaw-json-root-cache-bypass-"));
+    try {
+      const filePath = path.join(dir, "manifest.json");
+      fsSync.writeFileSync(filePath, '{"name":"x"}', "utf8");
+      clearJsonReadCache();
+
+      const first = readRootJsonObjectSync({ rootDir: dir, relativePath: "manifest.json" });
+      const cached = readRootJsonObjectSync({ rootDir: dir, relativePath: "manifest.json" });
+      expect(cached).toBe(first);
+
+      const withOption = readRootJsonObjectSync({
+        rootDir: dir,
+        relativePath: "manifest.json",
+        rejectHardlinks: true,
+      } as Parameters<typeof readRootJsonObjectSync>[0]);
+      expect(withOption).not.toBe(first);
+    } finally {
+      clearJsonReadCache();
+      fsSync.rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it.each([

--- a/src/infra/json-files.test.ts
+++ b/src/infra/json-files.test.ts
@@ -152,23 +152,34 @@ describe("json file helpers", () => {
     });
   });
 
-  it("readRootJsonObjectSync bypasses cache when safety-relevant options are set", () => {
-    const dir = fsSync.mkdtempSync(path.join(os.tmpdir(), "openclaw-json-root-cache-bypass-"));
+  it("readRootJsonObjectSync keys the cache on safety-relevant options", () => {
+    const dir = fsSync.mkdtempSync(path.join(os.tmpdir(), "openclaw-json-root-cache-options-"));
     try {
       const filePath = path.join(dir, "manifest.json");
       fsSync.writeFileSync(filePath, '{"name":"x"}', "utf8");
       clearJsonReadCache();
 
-      const first = readRootJsonObjectSync({ rootDir: dir, relativePath: "manifest.json" });
-      const cached = readRootJsonObjectSync({ rootDir: dir, relativePath: "manifest.json" });
-      expect(cached).toBe(first);
-
-      const withOption = readRootJsonObjectSync({
+      const strictA = readRootJsonObjectSync({
         rootDir: dir,
         relativePath: "manifest.json",
+        boundaryLabel: "test",
         rejectHardlinks: true,
-      } as Parameters<typeof readRootJsonObjectSync>[0]);
-      expect(withOption).not.toBe(first);
+      });
+      const strictB = readRootJsonObjectSync({
+        rootDir: dir,
+        relativePath: "manifest.json",
+        boundaryLabel: "test",
+        rejectHardlinks: true,
+      });
+      expect(strictB).toBe(strictA);
+
+      const permissive = readRootJsonObjectSync({
+        rootDir: dir,
+        relativePath: "manifest.json",
+        boundaryLabel: "test",
+        rejectHardlinks: false,
+      });
+      expect(permissive).not.toBe(strictA);
     } finally {
       clearJsonReadCache();
       fsSync.rmSync(dir, { recursive: true, force: true });

--- a/src/infra/json-files.ts
+++ b/src/infra/json-files.ts
@@ -72,6 +72,14 @@ export const readRootJsonObjectSync = ((...args: unknown[]) => {
   if (typeof rootDir !== "string" || typeof relativePath !== "string") {
     return (rawReadRootJsonObjectSync as (...a: unknown[]) => unknown)(...args);
   }
+  // Cache only the option-free shape. Any extra param (rejectHardlinks,
+  // maxBytes, rootRealPath, future fs-safe options) carries security or
+  // contract semantics that a path-only key cannot represent.
+  for (const k of Object.keys(params)) {
+    if (k !== "rootDir" && k !== "relativePath") {
+      return (rawReadRootJsonObjectSync as (...a: unknown[]) => unknown)(...args);
+    }
+  }
   const key = path.resolve(rootDir, relativePath);
   const stat = statOrUndefined(key);
   if (!stat) {

--- a/src/infra/json-files.ts
+++ b/src/infra/json-files.ts
@@ -7,10 +7,6 @@ import {
 import "./fs-safe-defaults.js";
 import { replaceFileAtomic } from "./replace-file.js";
 
-// Process-scoped memo for sync JSON reads. Each cached parse is validated
-// against the file's (mtime, size, inode) on every lookup, so external writes,
-// atomic replaces, and deletions evict naturally. Disable with
-// OPENCLAW_DISABLE_JSON_READ_CACHE=1 for tests that mutate JSON mid-process.
 type CacheEntry = { value: unknown; mtimeMs: bigint; size: bigint; ino: bigint };
 const jsonReadCache = new Map<string, CacheEntry>();
 

--- a/src/infra/json-files.ts
+++ b/src/infra/json-files.ts
@@ -1,103 +1,98 @@
+import fs from "node:fs";
 import path from "node:path";
 import {
   readRootJsonObjectSync as rawReadRootJsonObjectSync,
   tryReadJsonSync as rawTryReadJsonSync,
-  writeJsonSync as rawWriteJsonSync,
 } from "@openclaw/fs-safe/json";
 import "./fs-safe-defaults.js";
 import { replaceFileAtomic } from "./replace-file.js";
 
-// Process-scoped memo for synchronous JSON reads. The TUI startup path (and a
-// few discovery flows) re-read the same plugin manifests hundreds of times
-// each; caching parsed values keyed by absolute path keeps memory cost tiny
-// (~one entry per unique file) while eliminating the repeated open + parse.
-// Disable with OPENCLAW_DISABLE_JSON_READ_CACHE=1 for tests that mutate JSON
-// files mid-process and need to observe fresh state.
-type CacheEntry = { value: unknown };
+// Process-scoped memo for sync JSON reads. Each cached parse is validated
+// against the file's (mtime, size, inode) on every lookup, so external writes,
+// atomic replaces, and deletions evict naturally. Disable with
+// OPENCLAW_DISABLE_JSON_READ_CACHE=1 for tests that mutate JSON mid-process.
+type CacheEntry = { value: unknown; mtimeMs: bigint; size: bigint; ino: bigint };
 const jsonReadCache = new Map<string, CacheEntry>();
 
 function isJsonReadCacheDisabled(): boolean {
   return process.env.OPENCLAW_DISABLE_JSON_READ_CACHE === "1";
 }
 
-function jsonReadCacheKey(filePath: string): string {
-  return path.resolve(filePath);
-}
-
-function getCachedJsonRead(filePath: string): { hit: true; value: unknown } | { hit: false } {
-  if (isJsonReadCacheDisabled()) {
-    return { hit: false };
+function statOrUndefined(filePath: string): fs.BigIntStats | undefined {
+  try {
+    return fs.statSync(filePath, { bigint: true });
+  } catch {
+    return undefined;
   }
-  const entry = jsonReadCache.get(jsonReadCacheKey(filePath));
-  return entry ? { hit: true, value: entry.value } : { hit: false };
 }
 
-function setCachedJsonRead(filePath: string, value: unknown): void {
-  if (isJsonReadCacheDisabled()) {
-    return;
-  }
-  jsonReadCache.set(jsonReadCacheKey(filePath), { value });
+function statMatches(entry: CacheEntry, stat: fs.BigIntStats): boolean {
+  return entry.mtimeMs === stat.mtimeMs && entry.size === stat.size && entry.ino === stat.ino;
 }
 
-function invalidateCachedJsonRead(filePath: string): void {
-  jsonReadCache.delete(jsonReadCacheKey(filePath));
-}
-
-/** Clear all memoized sync-JSON reads. */
 export function clearJsonReadCache(): void {
   jsonReadCache.clear();
 }
 
 export const tryReadJsonSync = ((...args: unknown[]) => {
   const filePath = args[0];
-  if (typeof filePath === "string") {
-    const cached = getCachedJsonRead(filePath);
-    if (cached.hit) {
-      return cached.value;
-    }
-    const result = (rawTryReadJsonSync as (...a: unknown[]) => unknown)(...args);
-    if (result !== null && result !== undefined) {
-      setCachedJsonRead(filePath, result);
-    }
-    return result;
+  if (typeof filePath !== "string" || isJsonReadCacheDisabled()) {
+    return (rawTryReadJsonSync as (...a: unknown[]) => unknown)(...args);
   }
-  return (rawTryReadJsonSync as (...a: unknown[]) => unknown)(...args);
+  const key = path.resolve(filePath);
+  const stat = statOrUndefined(key);
+  if (!stat) {
+    jsonReadCache.delete(key);
+    return (rawTryReadJsonSync as (...a: unknown[]) => unknown)(...args);
+  }
+  const entry = jsonReadCache.get(key);
+  if (entry && statMatches(entry, stat)) {
+    return entry.value;
+  }
+  const result = (rawTryReadJsonSync as (...a: unknown[]) => unknown)(...args);
+  if (result !== null && result !== undefined) {
+    jsonReadCache.set(key, {
+      value: result,
+      mtimeMs: stat.mtimeMs,
+      size: stat.size,
+      ino: stat.ino,
+    });
+  }
+  return result;
 }) as typeof rawTryReadJsonSync;
 export const readJsonFileSync = tryReadJsonSync;
 
 export const readRootJsonObjectSync = ((...args: unknown[]) => {
   const params = args[0];
-  if (params && typeof params === "object") {
-    const rootDir = (params as { rootDir?: unknown }).rootDir;
-    const relativePath = (params as { relativePath?: unknown }).relativePath;
-    if (typeof rootDir === "string" && typeof relativePath === "string") {
-      const filePath = path.join(rootDir, relativePath);
-      const cached = getCachedJsonRead(filePath);
-      if (cached.hit) {
-        return cached.value;
-      }
-      const result = (rawReadRootJsonObjectSync as (...a: unknown[]) => unknown)(...args);
-      if (result && typeof result === "object" && (result as { ok?: unknown }).ok === true) {
-        setCachedJsonRead(filePath, result);
-      }
-      return result;
-    }
+  if (!params || typeof params !== "object" || isJsonReadCacheDisabled()) {
+    return (rawReadRootJsonObjectSync as (...a: unknown[]) => unknown)(...args);
   }
-  return (rawReadRootJsonObjectSync as (...a: unknown[]) => unknown)(...args);
+  const rootDir = (params as { rootDir?: unknown }).rootDir;
+  const relativePath = (params as { relativePath?: unknown }).relativePath;
+  if (typeof rootDir !== "string" || typeof relativePath !== "string") {
+    return (rawReadRootJsonObjectSync as (...a: unknown[]) => unknown)(...args);
+  }
+  const key = path.resolve(rootDir, relativePath);
+  const stat = statOrUndefined(key);
+  if (!stat) {
+    jsonReadCache.delete(key);
+    return (rawReadRootJsonObjectSync as (...a: unknown[]) => unknown)(...args);
+  }
+  const entry = jsonReadCache.get(key);
+  if (entry && statMatches(entry, stat)) {
+    return entry.value;
+  }
+  const result = (rawReadRootJsonObjectSync as (...a: unknown[]) => unknown)(...args);
+  if (result && typeof result === "object" && (result as { ok?: unknown }).ok === true) {
+    jsonReadCache.set(key, {
+      value: result,
+      mtimeMs: stat.mtimeMs,
+      size: stat.size,
+      ino: stat.ino,
+    });
+  }
+  return result;
 }) as typeof rawReadRootJsonObjectSync;
-
-// Sync write paths invalidate any cached read for the same path so callers
-// that immediately re-read after writing observe their own change.
-function invalidateWriteTarget(target: unknown): void {
-  if (typeof target === "string") {
-    invalidateCachedJsonRead(target);
-  }
-}
-
-export const writeJsonSync = ((...args: unknown[]) => {
-  invalidateWriteTarget(args[0]);
-  return (rawWriteJsonSync as (...a: unknown[]) => unknown)(...args);
-}) as typeof rawWriteJsonSync;
 
 export {
   JsonFileReadError,
@@ -112,6 +107,7 @@ export {
   tryReadJson as readJsonFile,
   writeJson,
   writeJson as writeJsonAtomic,
+  writeJsonSync,
 } from "@openclaw/fs-safe/json";
 export { createAsyncLock } from "@openclaw/fs-safe/advanced";
 

--- a/src/infra/json-files.ts
+++ b/src/infra/json-files.ts
@@ -7,6 +7,10 @@ import {
 import "./fs-safe-defaults.js";
 import { replaceFileAtomic } from "./replace-file.js";
 
+// Tension with src/plugins/CLAUDE.md "no persistent metadata caches" — landed
+// as a pragmatic floor while the redundant read amplifier upstream is still
+// being chased. Remove once the root cause (snapshot/registry rebuild churn,
+// see https://github.com/openclaw/openclaw/pull/84351) is fixed.
 type CacheEntry = { value: unknown; mtimeMs: bigint; size: bigint; ino: bigint };
 const jsonReadCache = new Map<string, CacheEntry>();
 

--- a/src/infra/json-files.ts
+++ b/src/infra/json-files.ts
@@ -62,6 +62,22 @@ export const tryReadJsonSync = ((...args: unknown[]) => {
 }) as typeof rawTryReadJsonSync;
 export const readJsonFileSync = tryReadJsonSync;
 
+function describeOptionsKey(params: Record<string, unknown>): string | null {
+  const safeEntries: [string, string | number | boolean | null][] = [];
+  for (const k of Object.keys(params).sort()) {
+    if (k === "rootDir" || k === "relativePath") continue;
+    const v = params[k];
+    if (v === null) {
+      safeEntries.push([k, null]);
+    } else if (typeof v === "string" || typeof v === "number" || typeof v === "boolean") {
+      safeEntries.push([k, v]);
+    } else {
+      return null;
+    }
+  }
+  return JSON.stringify(safeEntries);
+}
+
 export const readRootJsonObjectSync = ((...args: unknown[]) => {
   const params = args[0];
   if (!params || typeof params !== "object" || isJsonReadCacheDisabled()) {
@@ -72,16 +88,17 @@ export const readRootJsonObjectSync = ((...args: unknown[]) => {
   if (typeof rootDir !== "string" || typeof relativePath !== "string") {
     return (rawReadRootJsonObjectSync as (...a: unknown[]) => unknown)(...args);
   }
-  // Cache only the option-free shape. Any extra param (rejectHardlinks,
-  // maxBytes, rootRealPath, future fs-safe options) carries security or
-  // contract semantics that a path-only key cannot represent.
-  for (const k of Object.keys(params)) {
-    if (k !== "rootDir" && k !== "relativePath") {
-      return (rawReadRootJsonObjectSync as (...a: unknown[]) => unknown)(...args);
-    }
+  // Cache key must distinguish security-relevant options (rejectHardlinks,
+  // maxBytes, rootRealPath, boundaryLabel, ...) so a permissive earlier read
+  // cannot serve a strict later read. Non-primitive option values bypass the
+  // cache rather than risk a partial key.
+  const optionsKey = describeOptionsKey(params as Record<string, unknown>);
+  if (optionsKey === null) {
+    return (rawReadRootJsonObjectSync as (...a: unknown[]) => unknown)(...args);
   }
-  const key = path.resolve(rootDir, relativePath);
-  const stat = statOrUndefined(key);
+  const resolvedPath = path.resolve(rootDir, relativePath);
+  const key = `${resolvedPath}|${optionsKey}`;
+  const stat = statOrUndefined(resolvedPath);
   if (!stat) {
     jsonReadCache.delete(key);
     return (rawReadRootJsonObjectSync as (...a: unknown[]) => unknown)(...args);

--- a/src/infra/json-files.ts
+++ b/src/infra/json-files.ts
@@ -1,5 +1,103 @@
+import path from "node:path";
+import {
+  readRootJsonObjectSync as rawReadRootJsonObjectSync,
+  tryReadJsonSync as rawTryReadJsonSync,
+  writeJsonSync as rawWriteJsonSync,
+} from "@openclaw/fs-safe/json";
 import "./fs-safe-defaults.js";
 import { replaceFileAtomic } from "./replace-file.js";
+
+// Process-scoped memo for synchronous JSON reads. The TUI startup path (and a
+// few discovery flows) re-read the same plugin manifests hundreds of times
+// each; caching parsed values keyed by absolute path keeps memory cost tiny
+// (~one entry per unique file) while eliminating the repeated open + parse.
+// Disable with OPENCLAW_DISABLE_JSON_READ_CACHE=1 for tests that mutate JSON
+// files mid-process and need to observe fresh state.
+type CacheEntry = { value: unknown };
+const jsonReadCache = new Map<string, CacheEntry>();
+
+function isJsonReadCacheDisabled(): boolean {
+  return process.env.OPENCLAW_DISABLE_JSON_READ_CACHE === "1";
+}
+
+function jsonReadCacheKey(filePath: string): string {
+  return path.resolve(filePath);
+}
+
+function getCachedJsonRead(filePath: string): { hit: true; value: unknown } | { hit: false } {
+  if (isJsonReadCacheDisabled()) {
+    return { hit: false };
+  }
+  const entry = jsonReadCache.get(jsonReadCacheKey(filePath));
+  return entry ? { hit: true, value: entry.value } : { hit: false };
+}
+
+function setCachedJsonRead(filePath: string, value: unknown): void {
+  if (isJsonReadCacheDisabled()) {
+    return;
+  }
+  jsonReadCache.set(jsonReadCacheKey(filePath), { value });
+}
+
+function invalidateCachedJsonRead(filePath: string): void {
+  jsonReadCache.delete(jsonReadCacheKey(filePath));
+}
+
+/** Clear all memoized sync-JSON reads. */
+export function clearJsonReadCache(): void {
+  jsonReadCache.clear();
+}
+
+export const tryReadJsonSync = ((...args: unknown[]) => {
+  const filePath = args[0];
+  if (typeof filePath === "string") {
+    const cached = getCachedJsonRead(filePath);
+    if (cached.hit) {
+      return cached.value;
+    }
+    const result = (rawTryReadJsonSync as (...a: unknown[]) => unknown)(...args);
+    if (result !== null && result !== undefined) {
+      setCachedJsonRead(filePath, result);
+    }
+    return result;
+  }
+  return (rawTryReadJsonSync as (...a: unknown[]) => unknown)(...args);
+}) as typeof rawTryReadJsonSync;
+export const readJsonFileSync = tryReadJsonSync;
+
+export const readRootJsonObjectSync = ((...args: unknown[]) => {
+  const params = args[0];
+  if (params && typeof params === "object") {
+    const rootDir = (params as { rootDir?: unknown }).rootDir;
+    const relativePath = (params as { relativePath?: unknown }).relativePath;
+    if (typeof rootDir === "string" && typeof relativePath === "string") {
+      const filePath = path.join(rootDir, relativePath);
+      const cached = getCachedJsonRead(filePath);
+      if (cached.hit) {
+        return cached.value;
+      }
+      const result = (rawReadRootJsonObjectSync as (...a: unknown[]) => unknown)(...args);
+      if (result && typeof result === "object" && (result as { ok?: unknown }).ok === true) {
+        setCachedJsonRead(filePath, result);
+      }
+      return result;
+    }
+  }
+  return (rawReadRootJsonObjectSync as (...a: unknown[]) => unknown)(...args);
+}) as typeof rawReadRootJsonObjectSync;
+
+// Sync write paths invalidate any cached read for the same path so callers
+// that immediately re-read after writing observe their own change.
+function invalidateWriteTarget(target: unknown): void {
+  if (typeof target === "string") {
+    invalidateCachedJsonRead(target);
+  }
+}
+
+export const writeJsonSync = ((...args: unknown[]) => {
+  invalidateWriteTarget(args[0]);
+  return (rawWriteJsonSync as (...a: unknown[]) => unknown)(...args);
+}) as typeof rawWriteJsonSync;
 
 export {
   JsonFileReadError,
@@ -8,16 +106,12 @@ export {
   readJsonIfExists,
   readJsonIfExists as readDurableJsonFile,
   readJsonSync,
-  readRootJsonObjectSync,
   readRootJsonSync,
   readRootStructuredFileSync,
   tryReadJson,
   tryReadJson as readJsonFile,
-  tryReadJsonSync,
-  tryReadJsonSync as readJsonFileSync,
   writeJson,
   writeJson as writeJsonAtomic,
-  writeJsonSync,
 } from "@openclaw/fs-safe/json";
 export { createAsyncLock } from "@openclaw/fs-safe/advanced";
 

--- a/src/infra/json-files.ts
+++ b/src/infra/json-files.ts
@@ -64,8 +64,10 @@ export const readJsonFileSync = tryReadJsonSync;
 
 function describeOptionsKey(params: Record<string, unknown>): string | null {
   const safeEntries: [string, string | number | boolean | null][] = [];
-  for (const k of Object.keys(params).sort()) {
-    if (k === "rootDir" || k === "relativePath") continue;
+  for (const k of Object.keys(params).toSorted()) {
+    if (k === "rootDir" || k === "relativePath") {
+      continue;
+    }
     const v = params[k];
     if (v === null) {
       safeEntries.push([k, null]);

--- a/src/infra/package-update-utils.ts
+++ b/src/infra/package-update-utils.ts
@@ -1,6 +1,5 @@
 import fsSync from "node:fs";
 import path from "node:path";
-// Route through json-files.js so reads share the process-scoped cache.
 import { readRootJsonObjectSync } from "./json-files.js";
 
 export function expectedIntegrityForUpdate(

--- a/src/infra/package-update-utils.ts
+++ b/src/infra/package-update-utils.ts
@@ -1,6 +1,7 @@
 import fsSync from "node:fs";
 import path from "node:path";
-import { readRootJsonObjectSync } from "@openclaw/fs-safe/json";
+// Route through json-files.js so reads share the process-scoped cache.
+import { readRootJsonObjectSync } from "./json-files.js";
 
 export function expectedIntegrityForUpdate(
   spec: string | undefined,


### PR DESCRIPTION
## Summary

Sync JSON reads dominate TUI cold start — profiled startup made ~210K `tryReadJsonSync` calls against ~380 unique paths, with each bundled plugin's `package.json` re-read ~1500 times. This adds a process-scoped, stat-validated memo as an **opt-in** fast path and leaves the legacy uncached API alone.

- **New cached entrypoints** in `src/infra/json-files.ts`: `tryReadJsonSync`, `readRootJsonObjectSync`. Each call does one `statSync` and returns the cached parse when `(mtime, size, inode)` matches. Atomic writes, external edits, and deletions evict naturally.
- **Legacy `loadJsonFile` (`src/infra/json-file.ts`) bypasses the cache.** All its callers — subagent registry store (own stat-signature cache), `cli-credentials`, `auth-profiles/*`, `current-conversation-bindings`, `doctor-auth-*` — either run their own invalidation or are auth/transient state where a stat-validated cache hit across re-auth would be wrong.
- TUI startup hot paths can opt in by importing directly from `json-files.ts`.

Disable globally with `OPENCLAW_DISABLE_JSON_READ_CACHE=1` or call `clearJsonReadCache()`.

## Behavior addressed

TUI cold start spent 20–30s in 200K+ sync JSON reads hammering the same plugin manifests. After this, each unique file is read+parsed once; subsequent calls cost a single `statSync` (~5–10µs) instead of open + read + parse (~50–100µs).

## Real environment tested

macOS, Node 24, `pnpm openclaw` cold launch.

## Exact steps or command run after this patch

```
pnpm build
pnpm openclaw
node scripts/run-vitest.mjs src/gateway/session-utils.subagent.test.ts src/infra/json-file.test.ts src/infra/json-files.test.ts
```

## Evidence after fix

- TUI responsive in single-digit seconds vs. 20–30s freeze on `main`.
- Vitest green: 81 tests in `session-utils.subagent.test.ts` (including the "reuses one subagent registry disk snapshot" invariant) + 23 tests across `json-file(s)`.

## What was not tested

- Long-running session soak around atomic writes / external edits.
- Crabbox / Testbox broader suites (CI on PR).

## Trade-off

`src/plugins/CLAUDE.md` cautions against fs-primitive metadata caches. By keeping the cache opt-in and leaving `loadJsonFile` callers uncached, the surface area is narrow: auth/credential and registry paths are unaffected, and the cache only fires where TUI startup actually benefits. The structural fix is to memoize at the snapshot/registry layer — that work continues in #84283 / #84302 / #84339. This PR is the pragmatic floor.