### PR TITLE
Fix WebChat dispatch failure session status

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -154,6 +154,7 @@ import { ADMIN_SCOPE } from "../method-scopes.js";
 import { chatAbortMarkerTimestampMs, type ChatRunTiming } from "../server-chat-state.js";
 import { getMaxChatHistoryMessagesBytes, MAX_PAYLOAD_BYTES } from "../server-constants.js";
 import { resolveSessionHistoryTailReadOptions } from "../session-history-state.js";
+import { persistGatewaySessionLifecycleEvent } from "../session-lifecycle-state.js";
 import { readSessionTranscriptIndex } from "../session-transcript-index.fs.js";
 import {
   capArrayByJsonBytes,
@@ -3746,6 +3747,14 @@ export const chatHandlers: GatewayRequestHandlers = {
       const deliveredReplies: Array<{ payload: ReplyPayload; kind: "block" | "final" }> = [];
       let appendedWebchatAgentMedia = false;
       let agentRunStarted = false;
+      let pendingDispatchLifecycleError:
+        | {
+            endedAt: number;
+            error: string;
+            sessionId: string;
+            startedAt: number;
+          }
+        | undefined;
       const userTurnRecorder: UserTurnTranscriptRecorder = createUserTurnTranscriptRecorder({
         input: baseUserTurnInput,
         resolveInput: () => userTurnInputPromise,
@@ -4957,6 +4966,7 @@ export const chatHandlers: GatewayRequestHandlers = {
           );
         })
         .catch(async (err: unknown) => {
+          const errorMessage = String(err);
           const emitAfterError =
             userTurnRecorder.hasPersisted() || userTurnRecorder.isBlocked()
               ? Promise.resolve()
@@ -4966,7 +4976,19 @@ export const chatHandlers: GatewayRequestHandlers = {
               `webchat user transcript update failed after error: ${formatForLog(transcriptErr)}`,
             );
           });
-          const error = errorShape(ErrorCodes.UNAVAILABLE, String(err));
+          if (
+            !agentRunStarted &&
+            !activeRunAbort.controller.signal.aborted &&
+            !context.chatAbortedRuns.has(clientRunId)
+          ) {
+            pendingDispatchLifecycleError = {
+              endedAt: Date.now(),
+              error: errorMessage,
+              sessionId: activeRunAbort.entry?.sessionId ?? backingSessionId ?? clientRunId,
+              startedAt: activeRunAbort.entry?.startedAtMs ?? now,
+            };
+          }
+          const error = errorShape(ErrorCodes.UNAVAILABLE, errorMessage);
           setGatewayDedupeEntry({
             dedupe: context.dedupe,
             key: `chat:${clientRunId}`,
@@ -4976,7 +4998,7 @@ export const chatHandlers: GatewayRequestHandlers = {
               payload: {
                 runId: clientRunId,
                 status: "error" as const,
-                summary: String(err),
+                summary: errorMessage,
               },
               error,
             },
@@ -4986,14 +5008,57 @@ export const chatHandlers: GatewayRequestHandlers = {
             runId: clientRunId,
             sessionKey,
             agentId,
-            errorMessage: String(err),
+            errorMessage,
           });
         })
-        .finally(() => {
+        .finally(async () => {
           activeRunAbort.cleanup();
           clearAgentRunContext(clientRunId, lifecycleGeneration);
           clearActiveChatSendDedupeRun(context.dedupe, activeChatSendDedupeKey, clientRunId);
           context.removeChatRun(clientRunId, clientRunId, sessionKey);
+          if (!pendingDispatchLifecycleError) {
+            return;
+          }
+          const hasActiveRun = hasTrackedActiveSessionRun({
+            context,
+            requestedKey: rawSessionKey,
+            canonicalKey: sessionKey,
+            ...(sessionKey === "global" && agentId ? { agentId } : {}),
+            defaultAgentId: resolveDefaultAgentId(cfg),
+          });
+          if (hasActiveRun) {
+            return;
+          }
+          const persisted = await persistGatewaySessionLifecycleEvent({
+            sessionKey,
+            ...(sessionKey === "global" && agentId ? { agentId } : {}),
+            event: {
+              runId: clientRunId,
+              sessionId: pendingDispatchLifecycleError.sessionId,
+              lifecycleGeneration,
+              ts: pendingDispatchLifecycleError.endedAt,
+              data: {
+                phase: "error",
+                startedAt: pendingDispatchLifecycleError.startedAt,
+                endedAt: pendingDispatchLifecycleError.endedAt,
+                error: pendingDispatchLifecycleError.error,
+              },
+            },
+          })
+            .then(() => true)
+            .catch((persistErr) => {
+              context.logGateway.warn(
+                `webchat session lifecycle persist failed after error: ${formatForLog(persistErr)}`,
+              );
+              return false;
+            });
+          if (persisted) {
+            emitSessionsChanged(context, {
+              sessionKey,
+              ...(agentId ? { agentId } : {}),
+              reason: "chat.dispatch-error",
+            });
+          }
         });
     } catch (err) {
       activeRunAbort.cleanup({ force: true });

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -5011,7 +5011,7 @@ export const chatHandlers: GatewayRequestHandlers = {
             errorMessage,
           });
         })
-        .finally(async () => {
+        .finally(() => {
           activeRunAbort.cleanup();
           clearAgentRunContext(clientRunId, lifecycleGeneration);
           clearActiveChatSendDedupeRun(context.dedupe, activeChatSendDedupeKey, clientRunId);
@@ -5019,46 +5019,50 @@ export const chatHandlers: GatewayRequestHandlers = {
           if (!pendingDispatchLifecycleError) {
             return;
           }
-          const hasActiveRun = hasTrackedActiveSessionRun({
-            context,
-            requestedKey: rawSessionKey,
-            canonicalKey: sessionKey,
-            ...(sessionKey === "global" && agentId ? { agentId } : {}),
-            defaultAgentId: resolveDefaultAgentId(cfg),
-          });
-          if (hasActiveRun) {
-            return;
-          }
-          const persisted = await persistGatewaySessionLifecycleEvent({
-            sessionKey,
-            ...(sessionKey === "global" && agentId ? { agentId } : {}),
-            event: {
-              runId: clientRunId,
-              sessionId: pendingDispatchLifecycleError.sessionId,
-              lifecycleGeneration,
-              ts: pendingDispatchLifecycleError.endedAt,
-              data: {
-                phase: "error",
-                startedAt: pendingDispatchLifecycleError.startedAt,
-                endedAt: pendingDispatchLifecycleError.endedAt,
-                error: pendingDispatchLifecycleError.error,
-              },
-            },
-          })
-            .then(() => true)
-            .catch((persistErr) => {
+          const persistDispatchLifecycleError = async () => {
+            const dispatchError = pendingDispatchLifecycleError;
+            if (!dispatchError) {
+              return;
+            }
+            const hasActiveRun = hasTrackedActiveSessionRun({
+              context,
+              requestedKey: rawSessionKey,
+              canonicalKey: sessionKey,
+              ...(sessionKey === "global" && agentId ? { agentId } : {}),
+              defaultAgentId: resolveDefaultAgentId(cfg),
+            });
+            if (hasActiveRun) {
+              return;
+            }
+            try {
+              await persistGatewaySessionLifecycleEvent({
+                sessionKey,
+                ...(sessionKey === "global" && agentId ? { agentId } : {}),
+                event: {
+                  runId: clientRunId,
+                  sessionId: dispatchError.sessionId,
+                  lifecycleGeneration,
+                  ts: dispatchError.endedAt,
+                  data: {
+                    phase: "error",
+                    startedAt: dispatchError.startedAt,
+                    endedAt: dispatchError.endedAt,
+                    error: dispatchError.error,
+                  },
+                },
+              });
+              emitSessionsChanged(context, {
+                sessionKey,
+                ...(agentId ? { agentId } : {}),
+                reason: "chat.dispatch-error",
+              });
+            } catch (persistErr: unknown) {
               context.logGateway.warn(
                 `webchat session lifecycle persist failed after error: ${formatForLog(persistErr)}`,
               );
-              return false;
-            });
-          if (persisted) {
-            emitSessionsChanged(context, {
-              sessionKey,
-              ...(agentId ? { agentId } : {}),
-              reason: "chat.dispatch-error",
-            });
-          }
+            }
+          };
+          void persistDispatchLifecycleError();
         });
     } catch (err) {
       activeRunAbort.cleanup({ force: true });

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -692,6 +692,73 @@ describe("gateway server chat", () => {
     });
   });
 
+  test("marks a running webchat session failed when dispatch rejects before a reply", async () => {
+    await withMainSessionStore(async (dir) => {
+      await writeSessionStore({
+        entries: {
+          main: {
+            sessionId: "sess-main",
+            sessionFile: path.join(dir, "sess-main.jsonl"),
+            updatedAt: 1_000,
+            status: "running",
+            startedAt: 900,
+          },
+        },
+      });
+      const subscribeRes = await rpcReq(ws, "sessions.subscribe", {});
+      expect(subscribeRes.ok).toBe(true);
+      dispatchInboundMessageMock.mockRejectedValueOnce(new Error("provider rejected request"));
+
+      const errorPromise = onceMessage(
+        ws,
+        (o) =>
+          o.type === "event" &&
+          o.event === "chat" &&
+          o.payload?.state === "error" &&
+          o.payload?.runId === "idem-dispatch-error-1",
+        8_000,
+      );
+      const sessionChangedPromise = onceMessage(
+        ws,
+        (o) =>
+          o.type === "event" &&
+          o.event === "sessions.changed" &&
+          o.payload?.reason === "chat.dispatch-error" &&
+          o.payload?.sessionKey === "agent:main:main",
+        8_000,
+      );
+      const res = await rpcReq(ws, "chat.send", {
+        sessionKey: "main",
+        message: "run: pwd",
+        idempotencyKey: "idem-dispatch-error-1",
+      });
+      expect(res.ok).toBe(true);
+      await errorPromise;
+      const sessionChanged = await sessionChangedPromise;
+      expectRecordFields(sessionChanged.payload, {
+        sessionId: "sess-main",
+        status: "failed",
+        hasActiveRun: false,
+      });
+
+      const sessionsRes = await rpcReq<{ sessions?: unknown[] }>(ws, "sessions.list", {});
+      expect(sessionsRes.ok).toBe(true);
+      const session = sessionsRes.payload?.sessions?.find(
+        (row): row is Record<string, unknown> =>
+          Boolean(row) &&
+          typeof row === "object" &&
+          (row as { key?: unknown }).key === "agent:main:main",
+      );
+      const actualSession = expectRecordFields(session, {
+        status: "failed",
+        hasActiveRun: false,
+      });
+      expect(typeof actualSession.startedAt).toBe("number");
+      expect(typeof actualSession.endedAt).toBe("number");
+      expect(typeof actualSession.runtimeMs).toBe("number");
+    });
+  });
+
   test("chat.history hides assistant NO_REPLY-only entries", async () => {
     const historyMessages = await loadChatHistoryWithMessages(buildNoReplyHistoryFixture());
     const textValues = collectHistoryTextValues(historyMessages);


### PR DESCRIPTION
## Summary

WebChat dispatch failures before an agent run starts now close the persisted session lifecycle instead of leaving the session stuck as running. The gateway already broadcast a chat error and removed active-run tracking; this PR adds the missing terminal session lifecycle write and `sessions.changed` notification so `sessions.list` and Control UI consumers see `status: "failed"` with `hasActiveRun: false`.

The current net diff is limited to `src/gateway/server-methods/chat.ts` and `src/gateway/server.chat.gateway-server-chat.test.ts`.

## What Changed

- Dispatch rejection handling: `chat.send` now records a pending lifecycle error only when dispatch rejects before `agentRunStarted`, the run was not explicitly aborted, and the run is not in `chatAbortedRuns`.
- Session lifecycle persistence: after active-run cleanup, the gateway persists a terminal lifecycle event with `phase: "error"` when no active run remains for the session.
- Session change notification: after successful lifecycle persistence, the gateway emits `sessions.changed` with reason `chat.dispatch-error` so session subscribers receive the failed terminal state.
- Regression coverage: the WebChat gateway test now rejects `dispatchInboundMessage`, waits for the chat error and `sessions.changed`, and verifies both the event and `sessions.list` report `status: "failed"` and `hasActiveRun: false`.

## Flow

```mermaid
flowchart TD
  A["WebChat chat.send starts"] --> B["dispatchInboundMessage rejects before agent run starts"]
  B --> C["Broadcast chat error"]
  C --> D["Clean active run tracking"]
  D --> E{"Any active run still tracked for session?"}
  E -- "yes" --> F["Leave session lifecycle unchanged"]
  E -- "no" --> G["Persist lifecycle phase: error"]
  G --> H["Emit sessions.changed with failed status"]
```

## Proof

Behavioral proof:

- Before this PR, the pre-agent dispatch rejection path could broadcast a chat error and remove the active run while leaving the persisted session row as `running`.
- After this PR, the same path emits a session-change event like this for subscribed WebChat clients:

```json
{
  "type": "event",
  "event": "sessions.changed",
  "payload": {
    "reason": "chat.dispatch-error",
    "sessionKey": "agent:main:main",
    "sessionId": "sess-main",
    "status": "failed",
    "hasActiveRun": false
  }
}
```

- A follow-up `sessions.list` call returns the same terminal shape for the affected session: `status: "failed"`, `hasActiveRun: false`, and populated `startedAt`, `endedAt`, and `runtimeMs` fields.

## Screenshots

No screenshots are included. This PR changes backend gateway session lifecycle persistence and event payloads, not Control UI layout or visible components; the reviewer-visible behavior is better proven by the `sessions.changed` payload and `sessions.list` state asserted by the regression test. A screenshot would only show unchanged UI consuming the fixed gateway state.

## Verification

Reviewer-checkable behavior:

- `src/gateway/server.chat.gateway-server-chat.test.ts` includes `marks a running webchat session failed when dispatch rejects before a reply`, which simulates the dispatch rejection and asserts the event and list-state behavior above.
- The Mermaid diagram in this PR body was validated with `mmdc` before posting.

Automated checks:

- `pr_net_diff.py --markdown` showed only two net changed files and no branch-only churn.
- `node scripts/run-vitest.mjs src/gateway/server.chat.gateway-server-chat.test.ts -t "marks a running webchat session failed when dispatch rejects before a reply"` passed on head `c702c8b59b7`.
- `node scripts/run-vitest.mjs src/gateway/server.chat.gateway-server-chat.test.ts` passed on head `c702c8b59b7` with 72 tests.
- `pnpm exec oxfmt --check src/gateway/server-methods/chat.ts src/gateway/server.chat.gateway-server-chat.test.ts` passed.
- `node scripts/run-oxlint.mjs src/gateway/server-methods/chat.ts` passed.
- `pnpm tsgo:test:src` passed.
- `git diff --check` passed.
- GitHub CI run `28010707174` passed on head `c702c8b59b7`, including `check-lint`, `check-test-types`, and `checks-node-compact-small-5`.

Not run:

- Slack/Discord channel delivery: this PR does not change channel delivery code; it changes gateway session lifecycle state and WebChat session-event behavior.
