### PR TITLE
fix: constrain wildcard subagent targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 - Memory/search: close local embedding providers when active-memory searches time out so pending local model loads and embedding contexts are aborted and released. (#83858) Thanks @brokemac79.
 - Agents: include bounded trajectory queued-writer diagnostics in `pi-trajectory-flush` timeout warnings so flush stalls show pending writes, queued bytes, and append state. Fixes #82961. (#82962) Thanks @galiniliev.
 - Agents/subagents: recover stale completion announces by retrying unsupported transcript-wait wakes without transcript waiting and forcing a message-tool handoff when the requester run is already stale. Fixes #83699. (#83700) Thanks @galiniliev.
+- Agents/subagents: constrain wildcard subagent target allowlists to configured agents while preserving explicitly listed compatibility targets. Fixes #84040. (#84357) Thanks @joshavant.
 - Agents: honor explicit `models.providers.<id>.timeoutSeconds` values above the default idle watchdog for cloud and self-hosted providers, so long first-token waits no longer fall back at ~120s when the provider timeout is higher. (#83979) Thanks @yujiawei.
 - Agents/subagents: skip stale embedded-run wake probes for dormant completion requesters, so late subagent completions go straight to requester-agent/direct handoff instead of producing `reason=no_active_run` queue noise. (#82964) Thanks @galiniliev.
 - CLI: retry config snapshot reads after a transient failure so one rejected read no longer poisons later commands in the same process. (#83931) Thanks @honor2030.

--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -1092,7 +1092,7 @@ for provider examples and precedence.
 - `runtime`: optional per-agent runtime descriptor. Use `type: "acp"` with `runtime.acp` defaults (`agent`, `backend`, `mode`, `cwd`) when the agent should default to ACP harness sessions.
 - `identity.avatar`: workspace-relative path, `http(s)` URL, or `data:` URI.
 - `identity` derives defaults: `ackReaction` from `emoji`, `mentionPatterns` from `name`/`emoji`.
-- `subagents.allowAgents`: allowlist of agent ids for explicit `sessions_spawn.agentId` targets (`["*"]` = any; default: same agent only). Include the requester id when self-targeted `agentId` calls should be allowed.
+- `subagents.allowAgents`: allowlist of agent ids for explicit `sessions_spawn.agentId` targets (`["*"]` = any configured target; default: same agent only). Include the requester id when self-targeted `agentId` calls should be allowed.
 - Sandbox inheritance guard: if the requester session is sandboxed, `sessions_spawn` rejects targets that would run unsandboxed.
 - `subagents.requireAgentId`: when true, block `sessions_spawn` calls that omit `agentId` (forces explicit profile selection; default: false).
 

--- a/docs/gateway/config-tools.md
+++ b/docs/gateway/config-tools.md
@@ -401,7 +401,7 @@ Experimental built-in tool flags. Default off unless a strict-agentic GPT-5 auto
 ```
 
 - `model`: default model for spawned sub-agents. If omitted, sub-agents inherit the caller's model.
-- `allowAgents`: default allowlist of target agent ids for `sessions_spawn` when the requester agent does not set its own `subagents.allowAgents` (`["*"]` = any; default: same agent only).
+- `allowAgents`: default allowlist of target agent ids for `sessions_spawn` when the requester agent does not set its own `subagents.allowAgents` (`["*"]` = any configured target; default: same agent only).
 - `runTimeoutSeconds`: default timeout (seconds) for `sessions_spawn` when the tool call omits `runTimeoutSeconds`. `0` means no timeout.
 - `announceTimeoutMs`: per-call timeout (milliseconds) for gateway `agent` announce delivery attempts. Default: `120000`. Transient retries can make the total announce wait longer than one configured timeout.
 - Per-subagent tool policy: `tools.subagents.tools.allow` / `tools.subagents.tools.deny`.

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -340,7 +340,7 @@ See [Configuration reference](/gateway/configuration-reference) and
 ### Allowlist
 
 <ParamField path="agents.list[].subagents.allowAgents" type="string[]">
-  List of agent ids that can be targeted via explicit `agentId` (`["*"]` allows any). Default: only the requester agent. If you set a list and still want the requester to spawn itself with `agentId`, include the requester id in the list.
+  List of agent ids that can be targeted via explicit `agentId` (`["*"]` allows any configured target). Default: only the requester agent. If you set a list and still want the requester to spawn itself with `agentId`, include the requester id in the list.
 </ParamField>
 <ParamField path="agents.defaults.subagents.allowAgents" type="string[]">
   Default target-agent allowlist used when the requester agent does not set its own `subagents.allowAgents`.

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -1230,6 +1230,78 @@ describe("spawnAcpDirect", () => {
     expectAcceptedSpawn(result);
   });
 
+  it("allows configured ACP harness ids when subagent allowlist contains wildcard", async () => {
+    replaceSpawnConfig({
+      ...hoisted.state.cfg,
+      acp: {
+        ...hoisted.state.cfg.acp,
+        allowedAgents: ["codex", "writer"],
+      },
+      agents: {
+        ...hoisted.state.cfg.agents,
+        list: [
+          {
+            id: "main",
+            default: true,
+            subagents: {
+              allowAgents: ["*"],
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await spawnAcpDirect(
+      createSpawnRequest({
+        agentId: "writer",
+      }),
+      {
+        ...createRequesterContext(),
+        agentSessionKey: "agent:main:subagent:parent",
+      },
+    );
+
+    expectAcceptedSpawn(result);
+  });
+
+  it("rejects unconfigured ACP harness ids when subagent allowlist contains wildcard", async () => {
+    replaceSpawnConfig({
+      ...hoisted.state.cfg,
+      acp: {
+        ...hoisted.state.cfg.acp,
+        allowedAgents: [],
+      },
+      agents: {
+        ...hoisted.state.cfg.agents,
+        list: [
+          {
+            id: "main",
+            default: true,
+            subagents: {
+              allowAgents: ["*"],
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await spawnAcpDirect(
+      createSpawnRequest({
+        agentId: "writer",
+      }),
+      {
+        ...createRequesterContext(),
+        agentSessionKey: "agent:main:subagent:parent",
+      },
+    );
+
+    const failed = expectFailedSpawn(result, "forbidden");
+    expect(failed.errorCode).toBe("subagent_policy");
+    expect(failed.error).toBe(
+      'agentId "writer" is not in the configured agent registry (allowed: main)',
+    );
+  });
+
   it("rejects ACP spawns to agents outside the subagent allowlist", async () => {
     replaceSpawnConfig({
       ...hoisted.state.cfg,

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -70,7 +70,7 @@ import {
   resolveAcpSpawnStreamLogPath,
   startAcpSpawnParentStreamRelay,
 } from "./acp-spawn-parent-stream.js";
-import { resolveAgentConfig, resolveDefaultAgentId } from "./agent-scope.js";
+import { listAgentIds, resolveAgentConfig, resolveDefaultAgentId } from "./agent-scope.js";
 import {
   findAcpUnsupportedInheritedToolAllow,
   findAcpUnsupportedInheritedToolDeny,
@@ -447,9 +447,39 @@ function resolveTargetAcpAgentId(params: {
 
 function isExplicitlyAllowedAcpAgent(cfg: OpenClawConfig, agentId: string): boolean {
   return (cfg.acp?.allowedAgents ?? []).some((entry) => {
+    if (entry.trim() === "*") {
+      return true;
+    }
     const normalized = normalizeOptionalAgentId(entry);
-    return normalized === "*" || normalized === agentId;
+    return normalized === agentId;
   });
+}
+
+function resolveConfiguredAcpSubagentTargetIds(cfg: OpenClawConfig): string[] {
+  const ids = new Set<string>(listAgentIds(cfg));
+  for (const agent of cfg.agents?.list ?? []) {
+    if (agent.runtime?.type !== "acp") {
+      continue;
+    }
+    const acpAgent = normalizeOptionalAgentId(agent.runtime.acp?.agent);
+    if (acpAgent) {
+      ids.add(acpAgent);
+    }
+  }
+  const defaultAgent = normalizeOptionalAgentId(cfg.acp?.defaultAgent);
+  if (defaultAgent) {
+    ids.add(defaultAgent);
+  }
+  for (const entry of cfg.acp?.allowedAgents ?? []) {
+    if (entry.trim() === "*") {
+      continue;
+    }
+    const id = normalizeOptionalAgentId(entry);
+    if (id) {
+      ids.add(id);
+    }
+  }
+  return Array.from(ids);
 }
 
 function normalizeOptionalAgentId(value: string | undefined | null): string | undefined {
@@ -801,6 +831,7 @@ function resolveAcpSubagentEnvelopeState(params: {
     allowAgents:
       resolveAgentConfig(params.cfg, requesterAgentId)?.subagents?.allowAgents ??
       params.cfg.agents?.defaults?.subagents?.allowAgents,
+    configuredAgentIds: resolveConfiguredAcpSubagentTargetIds(params.cfg),
   });
   if (!targetPolicy.ok) {
     return {

--- a/src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts
@@ -137,14 +137,39 @@ describe("subagent spawn allowlist + sandbox guards", () => {
     expectChildSessionKey(result, /^agent:beta:subagent:/);
   });
 
-  it("allows any agent when allowlist contains *", async () => {
+  it("allows configured agents when allowlist contains *", async () => {
+    setConfig({
+      agents: {
+        list: [{ id: "main", subagents: { allowAgents: ["*"] } }, { id: "beta" }],
+      },
+    });
+    const result = await spawn({ agentId: "beta" });
+    expectStatus(result, "accepted");
+  });
+
+  it("rejects unconfigured agent ids when allowlist contains *", async () => {
     setConfig({
       agents: {
         list: [{ id: "main", subagents: { allowAgents: ["*"] } }],
       },
     });
     const result = await spawn({ agentId: "beta" });
+    expectStatus(result, "forbidden");
+    expect(result.error ?? "").toBe(
+      'agentId "beta" is not in the configured agent registry (allowed: main)',
+    );
+    expect(hoisted.callGatewayMock).not.toHaveBeenCalled();
+  });
+
+  it("allows explicit unconfigured agent ids when allowlist also contains *", async () => {
+    setConfig({
+      agents: {
+        list: [{ id: "main", subagents: { allowAgents: ["*", "beta"] } }],
+      },
+    });
+    const result = await spawn({ agentId: "beta" });
     expectStatus(result, "accepted");
+    expectChildSessionKey(result, /^agent:beta:subagent:/);
   });
 
   it("normalizes allowlisted agent ids", async () => {

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -12,7 +12,7 @@ import type { SubagentLifecycleHookRunner } from "../plugins/hooks.js";
 import { isValidAgentId, normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import type { DeliveryContext } from "../utils/delivery-context.types.js";
-import { resolveAgentDir } from "./agent-scope-config.js";
+import { listAgentIds, resolveAgentDir } from "./agent-scope-config.js";
 import type { BootstrapContextMode } from "./bootstrap-files.js";
 import {
   inheritedToolAllowPatch,
@@ -92,6 +92,10 @@ export type {
 } from "./subagent-spawn.types.js";
 
 export { decodeStrictBase64 };
+
+function resolveConfiguredAgentIds(cfg: OpenClawConfig): string[] {
+  return listAgentIds(cfg);
+}
 
 type SubagentSpawnDeps = {
   callGateway: typeof callGateway;
@@ -839,6 +843,7 @@ export async function spawnSubagentDirect(
     allowAgents:
       resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents ??
       cfg?.agents?.defaults?.subagents?.allowAgents,
+    configuredAgentIds: resolveConfiguredAgentIds(cfg),
   });
   if (!targetPolicy.ok) {
     return {

--- a/src/agents/subagent-target-policy.test.ts
+++ b/src/agents/subagent-target-policy.test.ts
@@ -64,4 +64,59 @@ describe("subagent target policy", () => {
       allowedIds: ["planner"],
     });
   });
+
+  it("limits wildcard allowlists to configured agents plus the requester", () => {
+    expect(
+      resolveSubagentAllowedTargetIds({
+        requesterAgentId: "main",
+        allowAgents: ["*"],
+        configuredAgentIds: ["planner", "checker"],
+      }),
+    ).toEqual({
+      allowAny: true,
+      allowedIds: ["checker", "main", "planner"],
+    });
+  });
+
+  it("rejects wildcard targets outside the configured registry", () => {
+    const result = resolveSubagentTargetPolicy({
+      requesterAgentId: "main",
+      targetAgentId: "bogus",
+      requestedAgentId: "bogus",
+      allowAgents: ["*"],
+      configuredAgentIds: ["main", "planner"],
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("Expected target policy to reject unconfigured wildcard target");
+    }
+    expect(result.allowedText).toBe("main, planner");
+    expect(result.error).toBe(
+      'agentId "bogus" is not in the configured agent registry (allowed: main, planner)',
+    );
+  });
+
+  it("preserves explicit targets when wildcard allowlists are mixed", () => {
+    expect(
+      resolveSubagentAllowedTargetIds({
+        requesterAgentId: "main",
+        allowAgents: ["*", "beta"],
+        configuredAgentIds: ["main", "planner"],
+      }),
+    ).toEqual({
+      allowAny: true,
+      allowedIds: ["beta", "main", "planner"],
+    });
+
+    expect(
+      resolveSubagentTargetPolicy({
+        requesterAgentId: "main",
+        targetAgentId: "beta",
+        requestedAgentId: "beta",
+        allowAgents: ["*", "beta"],
+        configuredAgentIds: ["main", "planner"],
+      }),
+    ).toEqual({ ok: true });
+  });
 });

--- a/src/agents/subagent-target-policy.ts
+++ b/src/agents/subagent-target-policy.ts
@@ -43,6 +43,10 @@ export function resolveSubagentAllowedTargetIds(params: {
     const configuredIds = (params.configuredAgentIds ?? [])
       .map((id) => normalizeAgentId(id))
       .filter(Boolean);
+    configuredIds.push(...policy.allowedIds);
+    if (requesterAgentId) {
+      configuredIds.push(requesterAgentId);
+    }
     return {
       allowAny: true,
       allowedIds: Array.from(new Set(configuredIds)).toSorted((a, b) => a.localeCompare(b)),
@@ -59,6 +63,7 @@ export function resolveSubagentTargetPolicy(params: {
   targetAgentId: string;
   requestedAgentId?: string;
   allowAgents?: readonly string[];
+  configuredAgentIds?: readonly string[];
 }): SubagentTargetPolicyResult {
   const requesterAgentId = normalizeAgentId(params.requesterAgentId);
   const targetAgentId = normalizeAgentId(params.targetAgentId);
@@ -69,11 +74,19 @@ export function resolveSubagentTargetPolicy(params: {
   const allowed = resolveSubagentAllowedTargetIds({
     requesterAgentId,
     allowAgents: params.allowAgents,
+    configuredAgentIds: params.configuredAgentIds,
   });
-  if (allowed.allowAny || allowed.allowedIds.includes(targetAgentId)) {
+  if (allowed.allowedIds.includes(targetAgentId)) {
     return { ok: true };
   }
   const allowedText = allowed.allowedIds.length > 0 ? allowed.allowedIds.join(", ") : "none";
+  if (allowed.allowAny) {
+    return {
+      ok: false,
+      allowedText,
+      error: `agentId "${targetAgentId}" is not in the configured agent registry (allowed: ${allowedText})`,
+    };
+  }
   return {
     ok: false,
     allowedText,

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -434,7 +434,7 @@ export type AgentDefaultsConfig = {
   subagents?: {
     /** Prompt-only guidance for how strongly the main agent should delegate work. Default: "suggest". */
     delegationMode?: SubagentDelegationMode;
-    /** Default allowlist of target agent ids for sessions_spawn. Use "*" to allow any. */
+    /** Default allowlist of target agent ids for sessions_spawn. Use "*" to allow any configured target. */
     allowAgents?: string[];
     /** Max concurrent sub-agent runs (global lane: "subagent"). Default: 1. */
     maxConcurrent?: number;

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -131,7 +131,7 @@ export type AgentConfig = {
   subagents?: {
     /** Prompt-only guidance for how strongly this agent should delegate work. */
     delegationMode?: SubagentDelegationMode;
-    /** Allow spawning sub-agents under other agent ids. Use "*" to allow any. */
+    /** Allow spawning sub-agents under other agent ids. Use "*" to allow any configured target. */
     allowAgents?: string[];
     /** Per-agent default model for spawned sub-agents (string or {primary,fallbacks}). */
     model?: AgentModelConfig;


### PR DESCRIPTION
## Summary

- Problem: `agents.*.subagents.allowAgents: ["*"]` let `sessions_spawn.agentId` target arbitrary unconfigured agent ids, creating ad hoc state roots.
- Solution: Treat wildcard subagent allowlists as “any configured target” while preserving explicit allowlist entries.
- What changed: Native subagent and ACP spawn policy now pass configured target ids into the shared target policy; docs and config comments describe the tightened wildcard behavior.
- What did NOT change: Explicit allowlisted-but-unconfigured target ids still work, including mixed allowlists like `["*", "beta"]`.

## Motivation

- Closes #84040 by making the wildcard match the configured agent registry instead of acting as an open-ended agent-id creation escape.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #84040
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior addressed: `sessions_spawn` with `allowAgents: ["*"]` rejects an unconfigured explicit `agentId` instead of spawning a new arbitrary agent state root.
- Real environment tested: AWS Crabbox direct provider, `provider=aws`, lease `cbx_687b1eaafdfc`, run `run_5a730368b161`, built branch from source, live Gateway, OpenAI `openai/gpt-5.5`.
- Exact steps or command run after this patch: Started Gateway with one configured agent `main`, `main.subagents.allowAgents: ["*"]`, exposed `sessions_spawn`, then ran a live parent agent turn that called `sessions_spawn` once with `agentId: "bogus-84040-b397f15f"`.
- Evidence after fix: Run output reported `ISSUE_84040_FIX_EVIDENCE` with `finalText: "ISSUE_84040_PARENT_REJECTED_b397f15f"`, one `sessions_spawn` tool call, transcript containing both `forbidden` and `configured agent registry`, `rogueAgentDirExists: false`, and `rogueWorkspaceDirExists: false`.
- Observed result after fix: The model saw the forbidden tool result and replied with the rejected sentinel; no rogue agent or workspace directory was created.
- What was not tested: Live Telegram/channel delivery was not involved; this is a Gateway/OpenAI subagent tool-path proof.
- Before evidence: Current-main AWS repro accepted a bogus `agentId` and created `agents/bogus-84040-.../sessions` plus `workspace/bogus-84040-...`.

## Root Cause (if applicable)

- Root cause: The shared subagent target policy treated `allowAgents` containing `"*"` as unconditional allow-any before checking whether the target id existed in the configured registry.
- Missing detection / guardrail: Existing tests covered wildcard acceptance but not wildcard rejection for unconfigured ids.
- Contributing context (if known): Explicit allowlists historically allowed unconfigured ids, so the fix preserves explicit entries while narrowing only wildcard expansion.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [x] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/subagent-target-policy.test.ts`, `src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts`, `src/agents/acp-spawn.test.ts`.
- Scenario the test should lock in: Wildcard allowlists include configured ids plus requester, reject unconfigured ids, and preserve explicit entries in mixed wildcard allowlists.
- Why this is the smallest reliable guardrail: The shared target-policy test proves the pure contract; native and ACP spawn tests prove both callers pass configured target ids correctly.
- Existing test that already covers this (if any): Existing wildcard tests only asserted broad acceptance.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

`subagents.allowAgents: ["*"]` now means any configured target agent, not arbitrary agent ids. Operators who intentionally need an unconfigured target can still list that id explicitly.

## Diagram (if applicable)

```text
Before:
sessions_spawn(agentId=bogus) -> allowAgents ["*"] -> accepted -> bogus agent/workspace state

After:
sessions_spawn(agentId=bogus) -> allowAgents ["*"] -> registry check -> forbidden
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? Yes
- Data access scope changed? Yes
- If any Yes, explain risk + mitigation: The change narrows wildcard delegation to configured agents, reducing accidental or model-driven creation of arbitrary agent state/workspace roots. Explicit allowlist entries preserve intentional compatibility.

## Repro + Verification

### Environment

- OS: Linux on AWS Crabbox
- Runtime/container: Node 24 via repository build on direct AWS Crabbox
- Model/provider: OpenAI `openai/gpt-5.5`
- Integration/channel (if any): Gateway RPC only; no external channel
- Relevant config (redacted): one configured `main` agent with `subagents.allowAgents: ["*"]`; OpenAI API key sourced from environment

### Steps

1. Build OpenClaw from this branch.
2. Start Gateway with one configured `main` agent and `main.subagents.allowAgents: ["*"]`.
3. Run a live parent agent turn that calls `sessions_spawn` once with an unconfigured bogus `agentId`.

### Expected

- The tool call returns `forbidden` with a configured-registry error and no bogus state root is created.

### Actual

- Parent final text was `ISSUE_84040_PARENT_REJECTED_b397f15f`; transcript contained `forbidden` and `configured agent registry`; no rogue agent/workspace directories existed.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: Target-policy pure contract, native `sessions_spawn` allowlist enforcement, ACP envelope allowlist enforcement, live AWS Gateway/OpenAI repro path.
- Edge cases checked: Mixed wildcard-plus-explicit allowlists preserve explicit unconfigured ids; explicit self-target behavior remains denyable; default omitted-agent self-spawn remains allowed.
- What you did **not** verify: Channel-specific delivery flows.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Mostly
- Config/env changes? Yes
- Migration needed? No
- If yes, exact upgrade steps: If an operator intentionally used `["*"]` to target an unconfigured id, add that id explicitly to `allowAgents`.

## Risks and Mitigations

- Risk: Operators relying on wildcard to target ad hoc ids will now see a forbidden result.
  - Mitigation: Explicit allowlist entries still allow those ids, and the error lists configured/allowed targets.
