### PR TITLE
fix(discord): preserve streamed replies after tool warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 - Matrix/config: accept `messages.queue.byChannel.matrix` queue overrides and keep queue provider schema/type keys aligned for Matrix, Google Chat, and Mattermost. Thanks @bdjben.
 - CLI: format `openclaw acp client` failures through the shared error formatter so object-shaped errors stay readable instead of printing `[object Object]`. Fixes #83904. (#84080)
 - Providers/Ollama: default unknown-capabilities models to tool-capable so discovered native Ollama models can use tools when `/api/show` omits capabilities. (#84055) Thanks @dutifulbob.
+- Discord: keep finalized streamed replies visible when a later failed-tool warning is delivered instead of letting warning cleanup clear the answer. (#84359) Thanks @joshavant.
 - Installer/Windows: launch `install.ps1` onboarding as an attached child process so fresh native Windows installs do not freeze visibly at `Starting setup...` or corrupt the wizard's terminal rendering.
 - CLI/update: keep restart health checks working across one-version CLI/Gateway protocol skew and use the managed Gateway service Node for all follow-up commands even when the package root is unchanged, so `openclaw update` no longer silently switches the gateway to a different Node binary when multiple Node installations are present. Thanks @amknight.
 - Memory/search: close local embedding providers when active-memory searches time out so pending local model loads and embedding contexts are aborted and released. (#83858) Thanks @brokemac79.

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -2061,6 +2061,37 @@ describe("processDiscordMessage draft streaming", () => {
     expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps finalized previews when later tool warning finals are delivered", async () => {
+    const draftStream = createMockDraftStreamForTest();
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      await params?.dispatcher.sendFinalReply({ text: "delivery survived" });
+      await params?.dispatcher.sendFinalReply({
+        text: "⚠️ 🛠️ `run openclaw definitely-not-a-real-subcommand (agent)` failed",
+        isError: true,
+      } as never);
+      return { queuedFinal: true, counts: { final: 2, tool: 0, block: 0 } };
+    });
+
+    const ctx = await createAutomaticSourceDeliveryContext({
+      discordConfig: { streamMode: "partial", maxLinesPerMessage: 5 },
+    });
+
+    await runProcessDiscordMessage(ctx);
+
+    expectPreviewEditContent("delivery survived");
+    expect(draftStream.clear).not.toHaveBeenCalled();
+    expect(draftStream.messageId()).toBe("preview-1");
+    expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
+    expect(firstMockArg(deliverDiscordReply, "deliverDiscordReply")).toMatchObject({
+      replies: [
+        {
+          text: "⚠️ 🛠️ `run openclaw definitely-not-a-real-subcommand (agent)` failed",
+          isError: true,
+        },
+      ],
+    });
+  });
+
   it("suppresses reasoning payload delivery to Discord", async () => {
     mockDispatchSingleBlockReply({ text: "thinking...", isReasoning: true });
     await processStreamOffDiscordMessage();

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -513,6 +513,7 @@ export async function processDiscordMessage(
   const finalPreviewFlags =
     (discordConfig?.suppressEmbeds ?? true) ? MessageFlags.SuppressEmbeds : undefined;
   let finalReplyStartNotified = false;
+  let nonErrorFinalDeliveryStarted = false;
   const notifyFinalReplyStart = () => {
     if (finalReplyStartNotified) {
       return;
@@ -550,11 +551,16 @@ export async function processDiscordMessage(
             return;
           }
         }
-        if (
+        const followsNonErrorFinalDelivery = payload.isError && nonErrorFinalDeliveryStarted;
+        if (isFinal && !payload.isError) {
+          nonErrorFinalDeliveryStarted = true;
+        }
+        const shouldFinalizeDraftPreview =
           draftStream &&
           isFinal &&
-          (!draftPreview.isProgressMode || draftPreview.hasProgressDraftStarted)
-        ) {
+          (!draftPreview.isProgressMode || draftPreview.hasProgressDraftStarted) &&
+          !followsNonErrorFinalDelivery;
+        if (shouldFinalizeDraftPreview) {
           const reply = resolveSendableOutboundReplyParts(effectivePayload);
           const hasMedia = reply.hasMedia;
           const ttsSupplement = getReplyPayloadTtsSupplement(effectivePayload);


### PR DESCRIPTION
## Summary

- Problem: Discord draft-preview finalization could clear a streamed final answer when a later failed-tool warning arrived as an error final.
- Solution: keep later error finals out of the draft-preview finalizer after a non-error final has started delivery, while still delivering the warning normally.
- What changed: added a bounded Discord delivery state guard and a regression test for final answer plus later tool-warning delivery.
- What did NOT change (scope boundary): standalone error finals still use the existing draft cleanup path; no Discord config or streaming defaults changed.

## Motivation

- Fixes a user-visible Discord streaming failure where the final answer can be replaced by or cleared after a later tool-call failure warning.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #83831
- Related #83844
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

Behavior addressed: Discord streamed final replies should remain visible when a later failed-tool warning is delivered.
Real environment tested: Source checkout on macOS with focused Discord monitor tests; pre-patch AWS Crabbox attempts from current main did not reproduce the exact destructive deletion state.
Exact steps or command run after this patch: node scripts/run-vitest.mjs extensions/discord/src/monitor/message-handler.process.test.ts; pnpm check:changed
Evidence after fix: The new regression test keeps the preview message id after delivering a normal final followed by an isError final, and the full Discord process test file passes.
Observed result after fix: The finalized preview remains intact and the failed-tool warning is delivered through normal Discord reply delivery.
What was not tested: A successful after-patch live AWS Discord deletion reproduction/fix comparison, because current main did not reliably reproduce the destructive live state during investigation.
Before evidence (optional but encouraged): The new regression test failed before the fix because the later error final cleared the already-finalized draft preview.

## Root Cause (if applicable)

- Root cause: Discord final delivery let later error finals re-enter the finalizable draft-preview adapter after a non-error final had already promoted the draft preview into the visible answer.
- Missing detection / guardrail: There was no regression test for multiple final payloads where a normal answer is followed by a failed-tool warning.
- Contributing context (if known): Shared finalizer fallback cleanup is correct for standalone error finals, but not after a successful preview finalization has already made the draft durable.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: extensions/discord/src/monitor/message-handler.process.test.ts
- Scenario the test should lock in: Discord partial streaming finalizes a preview, then a later isError final is delivered without clearing the preview.
- Why this is the smallest reliable guardrail: The failure is in Discord monitor delivery/finalizer coordination and can be reproduced with the existing process test harness.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Discord streamed replies should no longer disappear when a later failed-tool warning is delivered.

## Diagram (if applicable)

```text
Before:
final answer -> preview finalized -> later tool warning -> preview cleanup clears answer

After:
final answer -> preview finalized -> later tool warning delivered normally -> answer remains visible
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any Yes, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS local checkout; AWS Crabbox was used during pre-patch investigation
- Runtime/container: Node/Vitest local test harness
- Model/provider: N/A for regression test
- Integration/channel (if any): Discord
- Relevant config (redacted): Discord streamMode partial in the regression test

### Steps

1. Run the focused Discord process test file.
2. Verify the new regression test finalizes a preview, sends a later isError final, and does not clear the preview.
3. Run changed typecheck/lint/guards.

### Expected

- The final answer preview remains visible and the warning is delivered separately.

### Actual

- The final answer preview remains visible and the warning is delivered separately.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: new regression failed before the fix and passed after; full Discord process test file passed; changed checks passed.
- Edge cases checked: standalone error final behavior remains covered by the adjacent existing test.
- What you did not verify: post-patch live AWS Discord reproduction, because the exact destructive live state was not reliably reproducible on current main.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: accidentally changing standalone error-final draft cleanup.
  - Mitigation: the guard only skips draft-preview finalization for an error final that follows a non-error final delivery start; existing standalone error-final coverage remains intact.
