### PR TITLE
Doctor: expose session lock findings

### DIFF
--- a/src/agents/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-restart-recovery.test.ts
@@ -73,6 +73,7 @@ function cleanedLockForPath(lockPath: string): SessionLockInspection {
     ageMs: 1_000,
     stale: true,
     staleReasons: ["dead-pid"],
+    removable: true,
     removed: true,
   };
 }

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -36,6 +36,7 @@ export type SessionLockInspection = {
   ageMs: number | null;
   stale: boolean;
   staleReasons: string[];
+  removable: boolean;
   removed: boolean;
 };
 
@@ -858,13 +859,15 @@ export async function cleanStaleLockFiles(params: {
       reclaimLockWithoutStarttime: false,
       readOwnerProcessArgs: ownerProcessArgsReader,
     });
+    const removable = await shouldRemoveLockDuringCleanup(lockPath, inspected, staleMs, nowMs);
     const lockInfo: SessionLockInspection = {
       lockPath,
       ...inspected,
+      removable,
       removed: false,
     };
 
-    if (removeStale && (await shouldRemoveLockDuringCleanup(lockPath, lockInfo, staleMs, nowMs))) {
+    if (removeStale && removable) {
       await fs.rm(lockPath, { force: true });
       lockInfo.removed = true;
       cleaned.push(lockInfo);

--- a/src/commands/doctor-lint.test.ts
+++ b/src/commands/doctor-lint.test.ts
@@ -155,7 +155,7 @@ describe("runDoctorLintCli", () => {
     try {
       const exitCode = await runDoctorLintCli(runtime, {
         json: true,
-        onlyIds: ["core/doctor/session-locks"],
+        onlyIds: ["core/doctor/not-a-check"],
       });
 
       expect(exitCode).toBe(1);
@@ -167,7 +167,7 @@ describe("runDoctorLintCli", () => {
           {
             checkId: "core/doctor/lint-selection",
             severity: "error",
-            path: "core/doctor/session-locks",
+            path: "core/doctor/not-a-check",
           },
         ],
       });

--- a/src/commands/doctor-session-locks.test.ts
+++ b/src/commands/doctor-session-locks.test.ts
@@ -153,15 +153,18 @@ describe("noteSessionLockHealth", () => {
       staleMs: 30_000,
       readOwnerProcessArgs: () => ["node", "/opt/openclaw/openclaw.mjs", "doctor"],
     });
+    if (!lock) {
+      throw new Error("expected stale session lock");
+    }
 
-    expect(sessionLockToHealthFinding(lock!)).toEqual(
+    expect(sessionLockToHealthFinding(lock)).toEqual(
       expect.objectContaining({
         checkId: "core/doctor/session-locks",
         severity: "warning",
         path: lockPath,
       }),
     );
-    expect(sessionLockToRepairEffect(lock!)).toEqual({
+    expect(sessionLockToRepairEffect(lock)).toEqual({
       kind: "state",
       action: "would-remove-stale-session-lock",
       target: lockPath,
@@ -180,11 +183,14 @@ describe("noteSessionLockHealth", () => {
       staleMs: 30_000,
       readOwnerProcessArgs: () => ["node", "/opt/openclaw/openclaw.mjs", "doctor"],
     });
+    if (!lock) {
+      throw new Error("expected stale session lock");
+    }
 
-    expect(lock?.staleReasons).toEqual(["missing-pid", "invalid-createdAt"]);
-    expect(lock?.removable).toBe(false);
-    expect(sessionLockToHealthFinding(lock!).fixHint).toContain("after the cleanup grace period");
-    expect(sessionLockToRepairEffect(lock!)).toEqual({
+    expect(lock.staleReasons).toEqual(["missing-pid", "invalid-createdAt"]);
+    expect(lock.removable).toBe(false);
+    expect(sessionLockToHealthFinding(lock).fixHint).toContain("after the cleanup grace period");
+    expect(sessionLockToRepairEffect(lock)).toEqual({
       kind: "state",
       action: "would-preserve-mtime-gated-stale-session-lock",
       target: malformedLock,
@@ -235,12 +241,15 @@ describe("noteSessionLockHealth", () => {
       staleMs: 30_000,
       readOwnerProcessArgs: () => ["node", "/opt/openclaw/openclaw.mjs", "doctor"],
     });
+    if (!lock) {
+      throw new Error("expected stale session lock");
+    }
 
-    expect(lock?.staleReasons).toEqual(["too-old"]);
-    expect(sessionLockToHealthFinding(lock!).fixHint).toBe(
+    expect(lock.staleReasons).toEqual(["too-old"]);
+    expect(sessionLockToHealthFinding(lock).fixHint).toBe(
       "OpenClaw is preserving this live owned lock; inspect the owning process if it appears stuck.",
     );
-    expect(sessionLockToRepairEffect(lock!)).toEqual({
+    expect(sessionLockToRepairEffect(lock)).toEqual({
       kind: "state",
       action: "would-preserve-report-only-stale-session-lock",
       target: reportOnlyLock,

--- a/src/commands/doctor-session-locks.test.ts
+++ b/src/commands/doctor-session-locks.test.ts
@@ -13,7 +13,12 @@ vi.mock("../../packages/terminal-core/src/note.js", () => ({
   note,
 }));
 
-import { noteSessionLockHealth } from "./doctor-session-locks.js";
+import {
+  detectStaleSessionLocks,
+  noteSessionLockHealth,
+  sessionLockToHealthFinding,
+  sessionLockToRepairEffect,
+} from "./doctor-session-locks.js";
 
 async function expectPathMissing(targetPath: string): Promise<void> {
   try {
@@ -103,6 +108,92 @@ describe("noteSessionLockHealth", () => {
 
     await expectPathMissing(staleLock);
     await expect(fs.access(freshLock)).resolves.toBeUndefined();
+  });
+
+  it("detects stale locks without removing them for structured lint", async () => {
+    const sessionsDir = state.sessionsDir();
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    const staleLock = path.join(sessionsDir, "stale.jsonl.lock");
+    const freshLock = path.join(sessionsDir, "fresh.jsonl.lock");
+
+    await fs.writeFile(
+      staleLock,
+      JSON.stringify({ pid: -1, createdAt: new Date(Date.now() - 120_000).toISOString() }),
+      "utf8",
+    );
+    await fs.writeFile(
+      freshLock,
+      JSON.stringify({ pid: process.pid, createdAt: new Date().toISOString() }),
+      "utf8",
+    );
+
+    const locks = await detectStaleSessionLocks({
+      staleMs: 30_000,
+      readOwnerProcessArgs: () => ["node", "/opt/openclaw/openclaw.mjs", "doctor"],
+    });
+
+    expect(locks).toHaveLength(1);
+    expect(locks[0]?.lockPath).toBe(staleLock);
+    await expect(fs.access(staleLock)).resolves.toBeUndefined();
+    await expect(fs.access(freshLock)).resolves.toBeUndefined();
+  });
+
+  it("maps stale locks to structured findings and dry-run effects", async () => {
+    const sessionsDir = state.sessionsDir();
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const lockPath = path.join(sessionsDir, "stale.jsonl.lock");
+    await fs.writeFile(
+      lockPath,
+      JSON.stringify({ pid: -1, createdAt: new Date(Date.now() - 120_000).toISOString() }),
+      "utf8",
+    );
+
+    const [lock] = await detectStaleSessionLocks({
+      staleMs: 30_000,
+      readOwnerProcessArgs: () => ["node", "/opt/openclaw/openclaw.mjs", "doctor"],
+    });
+
+    expect(sessionLockToHealthFinding(lock!)).toEqual(
+      expect.objectContaining({
+        checkId: "core/doctor/session-locks",
+        severity: "warning",
+        path: lockPath,
+      }),
+    );
+    expect(sessionLockToRepairEffect(lock!)).toEqual({
+      kind: "state",
+      action: "would-remove-stale-session-lock",
+      target: lockPath,
+      dryRunSafe: false,
+    });
+  });
+
+  it("uses the supplied env to choose the structured lint state dir", async () => {
+    const other = await createOpenClawTestState({
+      layout: "state-only",
+      prefix: "openclaw-doctor-locks-other-",
+      applyEnv: false,
+    });
+    try {
+      await fs.mkdir(other.sessionsDir(), { recursive: true });
+      const lockPath = path.join(other.sessionsDir(), "other-stale.jsonl.lock");
+      await fs.writeFile(
+        lockPath,
+        JSON.stringify({ pid: -1, createdAt: new Date(Date.now() - 120_000).toISOString() }),
+        "utf8",
+      );
+
+      const locks = await detectStaleSessionLocks({
+        env: other.env,
+        staleMs: 30_000,
+        readOwnerProcessArgs: () => ["node", "/opt/openclaw/openclaw.mjs", "doctor"],
+      });
+
+      expect(locks.map((lock) => lock.lockPath)).toEqual([lockPath]);
+    } finally {
+      await other.cleanup();
+    }
   });
 
   it("uses configured stale threshold without removing live OpenClaw lock files", async () => {

--- a/src/commands/doctor-session-locks.test.ts
+++ b/src/commands/doctor-session-locks.test.ts
@@ -169,6 +169,30 @@ describe("noteSessionLockHealth", () => {
     });
   });
 
+  it("preserves fresh malformed stale locks in dry-run repair effects", async () => {
+    const sessionsDir = state.sessionsDir();
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    const malformedLock = path.join(sessionsDir, "malformed.jsonl.lock");
+    await fs.writeFile(malformedLock, "{}", "utf8");
+
+    const [lock] = await detectStaleSessionLocks({
+      staleMs: 30_000,
+      readOwnerProcessArgs: () => ["node", "/opt/openclaw/openclaw.mjs", "doctor"],
+    });
+
+    expect(lock?.staleReasons).toEqual(["missing-pid", "invalid-createdAt"]);
+    expect(lock?.removable).toBe(false);
+    expect(sessionLockToHealthFinding(lock!).fixHint).toContain("after the cleanup grace period");
+    expect(sessionLockToRepairEffect(lock!)).toEqual({
+      kind: "state",
+      action: "would-preserve-mtime-gated-stale-session-lock",
+      target: malformedLock,
+      dryRunSafe: false,
+    });
+    await expect(fs.access(malformedLock)).resolves.toBeUndefined();
+  });
+
   it("uses the supplied env to choose the structured lint state dir", async () => {
     const other = await createOpenClawTestState({
       layout: "state-only",

--- a/src/commands/doctor-session-locks.test.ts
+++ b/src/commands/doctor-session-locks.test.ts
@@ -237,6 +237,9 @@ describe("noteSessionLockHealth", () => {
     });
 
     expect(lock?.staleReasons).toEqual(["too-old"]);
+    expect(sessionLockToHealthFinding(lock!).fixHint).toBe(
+      "OpenClaw is preserving this live owned lock; inspect the owning process if it appears stuck.",
+    );
     expect(sessionLockToRepairEffect(lock!)).toEqual({
       kind: "state",
       action: "would-preserve-report-only-stale-session-lock",

--- a/src/commands/doctor-session-locks.test.ts
+++ b/src/commands/doctor-session-locks.test.ts
@@ -196,6 +196,32 @@ describe("noteSessionLockHealth", () => {
     }
   });
 
+  it("preserves report-only live OpenClaw locks in dry-run repair effects", async () => {
+    const sessionsDir = state.sessionsDir();
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    const reportOnlyLock = path.join(sessionsDir, "report-only.jsonl.lock");
+    await fs.writeFile(
+      reportOnlyLock,
+      JSON.stringify({ pid: process.pid, createdAt: new Date(Date.now() - 45_000).toISOString() }),
+      "utf8",
+    );
+
+    const [lock] = await detectStaleSessionLocks({
+      staleMs: 30_000,
+      readOwnerProcessArgs: () => ["node", "/opt/openclaw/openclaw.mjs", "doctor"],
+    });
+
+    expect(lock?.staleReasons).toEqual(["too-old"]);
+    expect(sessionLockToRepairEffect(lock!)).toEqual({
+      kind: "state",
+      action: "would-preserve-report-only-stale-session-lock",
+      target: reportOnlyLock,
+      dryRunSafe: false,
+    });
+    await expect(fs.access(reportOnlyLock)).resolves.toBeUndefined();
+  });
+
   it("uses configured stale threshold without removing live OpenClaw lock files", async () => {
     const sessionsDir = state.sessionsDir();
     await fs.mkdir(sessionsDir, { recursive: true });

--- a/src/commands/doctor-session-locks.ts
+++ b/src/commands/doctor-session-locks.ts
@@ -15,6 +15,13 @@ import { shortenHomePath } from "../utils.js";
 const SESSION_LOCKS_CHECK_ID = "core/doctor/session-locks";
 const REPORT_ONLY_STALE_LOCK_REASONS = new Set(["too-old", "hold-exceeded"]);
 
+function isReportOnlyStaleLock(lock: SessionLockInspection): boolean {
+  return (
+    lock.staleReasons.length > 0 &&
+    lock.staleReasons.every((reason) => REPORT_ONLY_STALE_LOCK_REASONS.has(reason))
+  );
+}
+
 function formatAge(ageMs: number | null): string {
   if (ageMs === null) {
     return "unknown";
@@ -69,7 +76,9 @@ export async function detectStaleSessionLocks(params?: {
 export function sessionLockToHealthFinding(lock: SessionLockInspection): HealthFinding {
   const fixHint = lock.removable
     ? 'Run "openclaw doctor --fix" to remove this stale lock file automatically.'
-    : 'Run "openclaw doctor --fix" after the cleanup grace period if this stale lock remains.';
+    : isReportOnlyStaleLock(lock)
+      ? "OpenClaw is preserving this live owned lock; inspect the owning process if it appears stuck."
+      : 'Run "openclaw doctor --fix" after the cleanup grace period if this stale lock remains.';
   return {
     checkId: SESSION_LOCKS_CHECK_ID,
     severity: "warning",
@@ -82,8 +91,7 @@ export function sessionLockToHealthFinding(lock: SessionLockInspection): HealthF
 export function sessionLockToRepairEffect(lock: SessionLockInspection): HealthRepairEffect {
   const action = lock.removable
     ? "would-remove-stale-session-lock"
-    : lock.staleReasons.length > 0 &&
-        lock.staleReasons.every((reason) => REPORT_ONLY_STALE_LOCK_REASONS.has(reason))
+    : isReportOnlyStaleLock(lock)
       ? "would-preserve-report-only-stale-session-lock"
       : "would-preserve-mtime-gated-stale-session-lock";
   return {

--- a/src/commands/doctor-session-locks.ts
+++ b/src/commands/doctor-session-locks.ts
@@ -67,21 +67,25 @@ export async function detectStaleSessionLocks(params?: {
 }
 
 export function sessionLockToHealthFinding(lock: SessionLockInspection): HealthFinding {
+  const fixHint = lock.removable
+    ? 'Run "openclaw doctor --fix" to remove this stale lock file automatically.'
+    : 'Run "openclaw doctor --fix" after the cleanup grace period if this stale lock remains.';
   return {
     checkId: SESSION_LOCKS_CHECK_ID,
     severity: "warning",
     message: `Stale session lock file: ${shortenHomePath(lock.lockPath)} (${lock.staleReasons.join(", ") || "unknown"})`,
     path: lock.lockPath,
-    fixHint: 'Run "openclaw doctor --fix" to remove stale lock files automatically.',
+    fixHint,
   };
 }
 
 export function sessionLockToRepairEffect(lock: SessionLockInspection): HealthRepairEffect {
-  const action =
-    lock.staleReasons.length > 0 &&
-    lock.staleReasons.every((reason) => REPORT_ONLY_STALE_LOCK_REASONS.has(reason))
+  const action = lock.removable
+    ? "would-remove-stale-session-lock"
+    : lock.staleReasons.length > 0 &&
+        lock.staleReasons.every((reason) => REPORT_ONLY_STALE_LOCK_REASONS.has(reason))
       ? "would-preserve-report-only-stale-session-lock"
-      : "would-remove-stale-session-lock";
+      : "would-preserve-mtime-gated-stale-session-lock";
   return {
     kind: "state",
     action,

--- a/src/commands/doctor-session-locks.ts
+++ b/src/commands/doctor-session-locks.ts
@@ -13,6 +13,7 @@ import type { HealthFinding, HealthRepairEffect } from "../flows/health-checks.j
 import { shortenHomePath } from "../utils.js";
 
 const SESSION_LOCKS_CHECK_ID = "core/doctor/session-locks";
+const REPORT_ONLY_STALE_LOCK_REASONS = new Set(["too-old", "hold-exceeded"]);
 
 function formatAge(ageMs: number | null): string {
   if (ageMs === null) {
@@ -76,9 +77,14 @@ export function sessionLockToHealthFinding(lock: SessionLockInspection): HealthF
 }
 
 export function sessionLockToRepairEffect(lock: SessionLockInspection): HealthRepairEffect {
+  const action =
+    lock.staleReasons.length > 0 &&
+    lock.staleReasons.every((reason) => REPORT_ONLY_STALE_LOCK_REASONS.has(reason))
+      ? "would-preserve-report-only-stale-session-lock"
+      : "would-remove-stale-session-lock";
   return {
     kind: "state",
-    action: "would-remove-stale-session-lock",
+    action,
     target: lock.lockPath,
     dryRunSafe: false,
   };

--- a/src/commands/doctor-session-locks.ts
+++ b/src/commands/doctor-session-locks.ts
@@ -9,7 +9,10 @@ import {
   type SessionWriteLockAcquireTimeoutConfig,
 } from "../agents/session-write-lock.js";
 import { resolveStateDir } from "../config/paths.js";
+import type { HealthFinding, HealthRepairEffect } from "../flows/health-checks.js";
 import { shortenHomePath } from "../utils.js";
+
+const SESSION_LOCKS_CHECK_ID = "core/doctor/session-locks";
 
 function formatAge(ageMs: number | null): string {
   if (ageMs === null) {
@@ -38,6 +41,47 @@ function formatLockLine(lock: SessionLockInspection): string {
     : "stale=no";
   const removedStatus = lock.removed ? " [removed]" : "";
   return `- ${shortenHomePath(lock.lockPath)} ${pidStatus} ${ageStatus} ${staleStatus}${removedStatus}`;
+}
+
+export async function detectStaleSessionLocks(params?: {
+  config?: SessionWriteLockAcquireTimeoutConfig;
+  env?: NodeJS.ProcessEnv;
+  staleMs?: number;
+  readOwnerProcessArgs?: SessionLockOwnerProcessArgsReader;
+}): Promise<readonly SessionLockInspection[]> {
+  const staleMs = params?.staleMs ?? resolveSessionWriteLockStaleMs(params?.config, params?.env);
+  const env = params?.env ?? process.env;
+  const sessionDirs = await resolveAgentSessionDirs(resolveStateDir(env));
+  const staleLocks: SessionLockInspection[] = [];
+  for (const sessionsDir of sessionDirs) {
+    const result = await cleanStaleLockFiles({
+      sessionsDir,
+      staleMs,
+      removeStale: false,
+      readOwnerProcessArgs: params?.readOwnerProcessArgs,
+    });
+    staleLocks.push(...result.locks.filter((lock) => lock.stale));
+  }
+  return staleLocks.toSorted((a, b) => a.lockPath.localeCompare(b.lockPath));
+}
+
+export function sessionLockToHealthFinding(lock: SessionLockInspection): HealthFinding {
+  return {
+    checkId: SESSION_LOCKS_CHECK_ID,
+    severity: "warning",
+    message: `Stale session lock file: ${shortenHomePath(lock.lockPath)} (${lock.staleReasons.join(", ") || "unknown"})`,
+    path: lock.lockPath,
+    fixHint: 'Run "openclaw doctor --fix" to remove stale lock files automatically.',
+  };
+}
+
+export function sessionLockToRepairEffect(lock: SessionLockInspection): HealthRepairEffect {
+  return {
+    kind: "state",
+    action: "would-remove-stale-session-lock",
+    target: lock.lockPath,
+    dryRunSafe: false,
+  };
 }
 
 /** Reports session write locks and removes stale locks when doctor repair is enabled. */

--- a/src/flows/doctor-core-checks.test.ts
+++ b/src/flows/doctor-core-checks.test.ts
@@ -748,4 +748,26 @@ describe("CORE_HEALTH_CHECKS", () => {
       }),
     );
   });
+
+  it("registers stale session locks as a legacy-owned structured check", async () => {
+    const check = getCheck(createCoreHealthChecks(createDeps()), "core/doctor/session-locks");
+
+    expect(check.repair).toBeTypeOf("function");
+    await expect(
+      check.repair?.(
+        {
+          mode: "fix",
+          runtime,
+          cfg: {},
+          cwd: "/tmp/openclaw-test-workspace",
+        },
+        [],
+      ),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        status: "skipped",
+        reason: "legacy doctor session lock contribution owns cleanup",
+      }),
+    );
+  });
 });

--- a/src/flows/doctor-core-checks.test.ts
+++ b/src/flows/doctor-core-checks.test.ts
@@ -752,9 +752,11 @@ describe("CORE_HEALTH_CHECKS", () => {
   it("registers stale session locks as a legacy-owned structured check", async () => {
     const check = getCheck(createCoreHealthChecks(createDeps()), "core/doctor/session-locks");
 
-    expect(check.repair).toBeTypeOf("function");
+    if (typeof check.repair !== "function") {
+      throw new Error("expected session lock check repair");
+    }
     await expect(
-      check.repair?.(
+      check.repair(
         {
           mode: "fix",
           runtime,

--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -14,6 +14,11 @@ import {
   shellCompletionStatusToRepairEffects,
 } from "../commands/doctor-completion.js";
 import {
+  detectStaleSessionLocks,
+  sessionLockToHealthFinding,
+  sessionLockToRepairEffect,
+} from "../commands/doctor-session-locks.js";
+import {
   disableUnavailableSkillsInConfig,
   formatMissingSkillSummary,
 } from "../commands/doctor-skills-core.js";
@@ -42,6 +47,7 @@ const BROWSER_CLAWD_PROFILE_RESIDUE_CHECK_ID = "core/doctor/browser-clawd-profil
 const CODEX_SESSION_ROUTES_CHECK_ID = "core/doctor/codex-session-routes";
 const FINAL_CONFIG_VALIDATION_CHECK_ID = "core/doctor/final-config-validation";
 const GATEWAY_SERVICES_EXTRA_CHECK_ID = "core/doctor/gateway-services/extra";
+const SESSION_LOCKS_CHECK_ID = "core/doctor/session-locks";
 
 type CoreHealthCheckContext = HealthCheckContext & {
   readonly deep?: boolean;
@@ -729,6 +735,32 @@ const gatewayPlatformNotesCheck: HealthCheck = {
   },
 };
 
+const sessionLocksCheck: HealthCheck = {
+  id: SESSION_LOCKS_CHECK_ID,
+  kind: "core",
+  description: "Stale session lock files are represented as structured findings.",
+  source: "doctor",
+  async detect(ctx) {
+    return (await detectStaleSessionLocks({ config: ctx.cfg, env: process.env })).map(
+      sessionLockToHealthFinding,
+    );
+  },
+  async repair(ctx) {
+    const effects = (await detectStaleSessionLocks({ config: ctx.cfg, env: process.env })).map(
+      sessionLockToRepairEffect,
+    );
+    if (ctx.dryRun === true) {
+      return { status: "repaired", changes: [], effects };
+    }
+    return {
+      status: "skipped",
+      reason: "legacy doctor session lock contribution owns cleanup",
+      changes: [],
+      effects,
+    };
+  },
+};
+
 const browserCheck: HealthCheck = {
   id: "core/doctor/browser",
   kind: "core",
@@ -981,6 +1013,7 @@ function createConvertedWorkflowChecks(deps: CoreHealthCheckDeps): readonly Heal
     legacyStateCheck,
     legacyWhatsAppCrontabCheck,
     codexSessionRoutesCheck,
+    sessionLocksCheck,
     shellCompletionCheck,
     uiProtocolFreshnessCheck,
     gatewayServicesExtraCheck,

--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -740,6 +740,7 @@ const sessionLocksCheck: HealthCheck = {
   kind: "core",
   description: "Stale session lock files are represented as structured findings.",
   source: "doctor",
+  defaultEnabled: false,
   async detect(ctx) {
     return (await detectStaleSessionLocks({ config: ctx.cfg, env: process.env })).map(
       sessionLockToHealthFinding,

--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -36,6 +36,7 @@ import { resolveGatewayAuth } from "../gateway/auth.js";
 import { getSkippedExecRefStaticError } from "../secrets/exec-resolution-policy.js";
 import type { SkillStatusEntry } from "../skills/discovery/status.js";
 import { registerHealthCheck } from "./health-check-registry.js";
+import type { SplitHealthCheckInput } from "./health-check-runner-types.js";
 import type {
   HealthCheck,
   HealthCheckContext,
@@ -735,7 +736,7 @@ const gatewayPlatformNotesCheck: HealthCheck = {
   },
 };
 
-const sessionLocksCheck: HealthCheck = {
+const sessionLocksCheck: SplitHealthCheckInput = {
   id: SESSION_LOCKS_CHECK_ID,
   kind: "core",
   description: "Stale session lock files are represented as structured findings.",
@@ -1007,7 +1008,9 @@ function createWorkspaceSuggestionsCheck(deps: CoreHealthCheckDeps): HealthCheck
   };
 }
 
-function createConvertedWorkflowChecks(deps: CoreHealthCheckDeps): readonly HealthCheck[] {
+function createConvertedWorkflowChecks(
+  deps: CoreHealthCheckDeps,
+): readonly SplitHealthCheckInput[] {
   return [
     claudeCliCheck,
     gatewayAuthCheck,
@@ -1049,7 +1052,7 @@ export function resetCoreHealthChecksForTest(): void {
 
 export function createCoreHealthChecks(
   deps: CoreHealthCheckDeps = defaultCoreHealthCheckDeps,
-): readonly HealthCheck[] {
+): readonly SplitHealthCheckInput[] {
   return [
     gatewayConfigCheck,
     ...createConvertedWorkflowChecks(deps),
@@ -1060,4 +1063,4 @@ export function createCoreHealthChecks(
   ];
 }
 
-export const CORE_HEALTH_CHECKS: readonly HealthCheck[] = createCoreHealthChecks();
+export const CORE_HEALTH_CHECKS: readonly SplitHealthCheckInput[] = createCoreHealthChecks();

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -1292,6 +1292,7 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
     createDoctorHealthContribution({
       id: "doctor:session-locks",
       label: "Session locks",
+      healthCheckIds: ["core/doctor/session-locks"],
       run: runSessionLocksHealth,
     }),
     createDoctorHealthContribution({

--- a/src/flows/doctor-lint-flow.test.ts
+++ b/src/flows/doctor-lint-flow.test.ts
@@ -39,6 +39,36 @@ describe("runDoctorLintChecks", () => {
     expect(result.findings.map((finding) => finding.checkId)).toEqual(["a"]);
   });
 
+  it("skips default-disabled checks unless explicitly selected", async () => {
+    const defaultDisabled = {
+      ...check("targeted", async () => [
+        { checkId: "targeted", severity: "warning" as const, message: "warn" },
+      ]),
+      defaultEnabled: false,
+    };
+
+    await expect(
+      runDoctorLintChecks(ctx, {
+        checks: [defaultDisabled],
+      }),
+    ).resolves.toMatchObject({
+      checksRun: 0,
+      checksSkipped: 1,
+      findings: [],
+    });
+
+    await expect(
+      runDoctorLintChecks(ctx, {
+        checks: [defaultDisabled],
+        onlyIds: ["targeted"],
+      }),
+    ).resolves.toMatchObject({
+      checksRun: 1,
+      checksSkipped: 0,
+      findings: [expect.objectContaining({ checkId: "targeted" })],
+    });
+  });
+
   it("supports single-run checks in lint mode", async () => {
     const runnable: RunnableHealthCheck = {
       id: "run-check",

--- a/src/flows/doctor-lint-flow.test.ts
+++ b/src/flows/doctor-lint-flow.test.ts
@@ -40,12 +40,12 @@ describe("runDoctorLintChecks", () => {
   });
 
   it("skips default-disabled checks unless explicitly selected", async () => {
-    const defaultDisabled = {
+    const defaultDisabled = normalizeHealthCheck({
       ...check("targeted", async () => [
         { checkId: "targeted", severity: "warning" as const, message: "warn" },
       ]),
       defaultEnabled: false,
-    };
+    });
 
     await expect(
       runDoctorLintChecks(ctx, {

--- a/src/flows/doctor-lint-flow.ts
+++ b/src/flows/doctor-lint-flow.ts
@@ -37,6 +37,9 @@ export async function runDoctorLintChecks(
     if (only.size > 0 && !only.has(c.id)) {
       return false;
     }
+    if (only.size === 0 && c.defaultEnabled === false) {
+      return false;
+    }
     if (skip.has(c.id)) {
       return false;
     }

--- a/src/flows/doctor-lint-flow.ts
+++ b/src/flows/doctor-lint-flow.ts
@@ -37,7 +37,7 @@ export async function runDoctorLintChecks(
     if (only.size > 0 && !only.has(c.id)) {
       return false;
     }
-    if (only.size === 0 && c.defaultEnabled === false) {
+    if (only.size === 0 && isDefaultDisabled(c)) {
       return false;
     }
     if (skip.has(c.id)) {
@@ -79,6 +79,10 @@ export async function runDoctorLintChecks(
     checksRun: selected.length,
     checksSkipped: all.length - selected.length,
   };
+}
+
+function isDefaultDisabled(check: HealthCheck): boolean {
+  return "defaultEnabled" in check && check.defaultEnabled === false;
 }
 
 // Stable ordering keeps CLI output and tests deterministic across registry order changes.

--- a/src/flows/health-check-adapter.ts
+++ b/src/flows/health-check-adapter.ts
@@ -14,6 +14,7 @@ export function defineSplitHealthCheck(check: HealthCheck): RegisteredHealthChec
     kind: check.kind,
     description: check.description,
     source: check.source,
+    defaultEnabled: check.defaultEnabled,
     sourceContract: "split",
     detect: (ctx, scope) => check.detect(ctx, scope),
     repair:
@@ -73,6 +74,7 @@ export function normalizeHealthCheck(check: HealthCheckInput): RegisteredHealthC
       kind: check.kind,
       description: check.description,
       source: check.source,
+      defaultEnabled: check.defaultEnabled,
       sourceContract: "run",
       async detect(ctx, scope) {
         const result = await check.run({ ...ctx, repair: false }, scope);

--- a/src/flows/health-check-adapter.ts
+++ b/src/flows/health-check-adapter.ts
@@ -3,12 +3,13 @@ import type {
   HealthCheckInput,
   HealthCheckRunResult,
   RegisteredHealthCheck,
+  SplitHealthCheckInput,
 } from "./health-check-runner-types.js";
-import type { HealthCheck, HealthRepairContext } from "./health-checks.js";
+import type { HealthRepairContext } from "./health-checks.js";
 
 // Adapts legacy split detect/repair checks and newer runnable checks to one runner contract.
 /** Wraps a detect/repair health check in the runnable health-check contract. */
-export function defineSplitHealthCheck(check: HealthCheck): RegisteredHealthCheck {
+export function defineSplitHealthCheck(check: SplitHealthCheckInput): RegisteredHealthCheck {
   return {
     id: check.id,
     kind: check.kind,

--- a/src/flows/health-check-runner-types.ts
+++ b/src/flows/health-check-runner-types.ts
@@ -25,18 +25,23 @@ export interface HealthCheckRunResult extends Omit<HealthRepairResult, "changes"
   readonly effects?: readonly HealthRepairEffect[];
 }
 
+/** Internal runner selection metadata. This is intentionally not part of the public SDK type. */
+export interface HealthCheckSelectionOptions {
+  readonly defaultEnabled?: boolean;
+}
+
+export type SplitHealthCheckInput = HealthCheck & HealthCheckSelectionOptions;
+
 /** Health-check implementation that owns its own detect/repair orchestration. */
-export interface RunnableHealthCheck extends Pick<
-  HealthCheck,
-  "id" | "kind" | "description" | "source" | "defaultEnabled"
-> {
+export interface RunnableHealthCheck
+  extends Pick<HealthCheck, "id" | "kind" | "description" | "source">, HealthCheckSelectionOptions {
   run(ctx: HealthCheckRunContext, scope?: HealthCheckScope): Promise<HealthCheckRunResult>;
 }
 
-export type HealthCheckInput = HealthCheck | RunnableHealthCheck;
+export type HealthCheckInput = SplitHealthCheckInput | RunnableHealthCheck;
 
 /** Normalized check contract consumed by lint and repair runners. */
-export interface RegisteredHealthCheck extends HealthCheck {
+export interface RegisteredHealthCheck extends HealthCheck, HealthCheckSelectionOptions {
   readonly sourceContract: "split" | "run";
   run(ctx: HealthCheckRunContext, scope?: HealthCheckScope): Promise<HealthCheckRunResult>;
 }

--- a/src/flows/health-check-runner-types.ts
+++ b/src/flows/health-check-runner-types.ts
@@ -28,7 +28,7 @@ export interface HealthCheckRunResult extends Omit<HealthRepairResult, "changes"
 /** Health-check implementation that owns its own detect/repair orchestration. */
 export interface RunnableHealthCheck extends Pick<
   HealthCheck,
-  "id" | "kind" | "description" | "source"
+  "id" | "kind" | "description" | "source" | "defaultEnabled"
 > {
   run(ctx: HealthCheckRunContext, scope?: HealthCheckScope): Promise<HealthCheckRunResult>;
 }

--- a/src/flows/health-checks.ts
+++ b/src/flows/health-checks.ts
@@ -106,7 +106,6 @@ export interface HealthCheck {
   readonly kind: "core" | "plugin";
   readonly description: string;
   readonly source?: string;
-  readonly defaultEnabled?: boolean;
   detect(ctx: HealthCheckContext, scope?: HealthCheckScope): Promise<readonly HealthFinding[]>;
   repair?(
     ctx: HealthRepairContext,

--- a/src/flows/health-checks.ts
+++ b/src/flows/health-checks.ts
@@ -106,6 +106,7 @@ export interface HealthCheck {
   readonly kind: "core" | "plugin";
   readonly description: string;
   readonly source?: string;
+  readonly defaultEnabled?: boolean;
   detect(ctx: HealthCheckContext, scope?: HealthCheckScope): Promise<readonly HealthFinding[]>;
   repair?(
     ctx: HealthRepairContext,


### PR DESCRIPTION
## Summary

- Exposes stale session write locks as structured doctor health findings.
- Adds dry-run repair effects for stale lock removal while keeping the existing session-lock note/repair function authoritative for real `doctor` / `doctor --fix` cleanup.
- Wires the structured check through the ordered doctor contribution path.
- Keeps `core/doctor/session-locks` default-disabled for broad lint compatibility, but available through explicit `--only core/doctor/session-locks`.
- Keeps the default-selection metadata internal to the doctor runner; `defaultEnabled` is not part of the public `HealthCheck` SDK contract.

This is intentionally the session-lock slice from the doctor repair stack. It does not change session directory discovery, lock ownership detection, or the real mutating cleanup path.

## Stack

Rebased onto current `main` after #84340 merged. Current branch head is signed commit `d0a2fb7b4197af2bdfb0b3469f0bf6ffbdee9c97` (`fix(doctor): keep health check defaults internal`).

## Validation

Current head `d0a2fb7b4197af2bdfb0b3469f0bf6ffbdee9c97`:

- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run src/commands/doctor-session-locks.test.ts src/commands/doctor-lint.test.ts src/flows/doctor-core-checks.test.ts src/flows/doctor-lint-flow.test.ts src/agents/main-session-restart-recovery.test.ts --reporter=dot` - 78 tests passed across 3 shards
- `node_modules/oxlint/bin/oxlint src/agents/main-session-restart-recovery.test.ts src/agents/session-write-lock.ts src/commands/doctor-lint.test.ts src/commands/doctor-session-locks.test.ts src/commands/doctor-session-locks.ts src/flows/doctor-core-checks.test.ts src/flows/doctor-core-checks.ts src/flows/doctor-health-contributions.ts src/flows/doctor-lint-flow.test.ts src/flows/doctor-lint-flow.ts src/flows/health-check-adapter.ts src/flows/health-check-runner-types.ts`
- `node_modules/oxfmt/bin/oxfmt --check src/agents/main-session-restart-recovery.test.ts src/agents/session-write-lock.ts src/commands/doctor-lint.test.ts src/commands/doctor-session-locks.test.ts src/commands/doctor-session-locks.ts src/flows/doctor-core-checks.test.ts src/flows/doctor-core-checks.ts src/flows/doctor-health-contributions.ts src/flows/doctor-lint-flow.test.ts src/flows/doctor-lint-flow.ts src/flows/health-check-adapter.ts src/flows/health-check-runner-types.ts`
- `node node_modules/@typescript/native-preview/bin/tsgo.js -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo --declaration false --singleThreaded --checkers 1`
- `node node_modules/@typescript/native-preview/bin/tsgo.js -p test/tsconfig/tsconfig.test.src.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-src.tsbuildinfo --declaration false --singleThreaded --checkers 1`
- `node scripts/plugin-sdk-surface-report.mjs --check`
- `git diff --check`