### PR TITLE
fix(gateway): keep dashboard New Chat sessions rootless

### DIFF
--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -1266,6 +1266,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
     }
     const parentSessionKey = normalizeOptionalString(p.parentSessionKey);
     let canonicalParentSessionKey: string | undefined;
+    const initialMessage = resolveOptionalInitialSessionMessage(p);
     if (parentSessionKey) {
       const parent = loadSessionEntry(parentSessionKey);
       if (!parent.entry?.sessionId) {
@@ -1278,13 +1279,10 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       }
       canonicalParentSessionKey = parent.canonicalKey;
     }
-    if (
-      canonicalParentSessionKey &&
-      p.emitCommandHooks === true &&
-      !requestedKey &&
-      !resolveOptionalInitialSessionMessage(p) &&
-      cfg.session?.dmScope === "main"
-    ) {
+    const shouldCreateFreshRootFromParent = Boolean(
+      canonicalParentSessionKey && p.emitCommandHooks === true && !requestedKey && !initialMessage,
+    );
+    if (shouldCreateFreshRootFromParent && cfg.session?.dmScope === "main") {
       const parentAgentId = normalizeAgentId(
         resolveAgentIdFromSessionKey(canonicalParentSessionKey) ?? resolveDefaultAgentId(cfg),
       );
@@ -1372,7 +1370,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
         },
         loadGatewayModelCatalog: context.loadGatewayModelCatalog,
       });
-      if (!patched.ok || !canonicalParentSessionKey) {
+      if (!patched.ok || !canonicalParentSessionKey || shouldCreateFreshRootFromParent) {
         return patched;
       }
       const nextEntry: SessionEntry = {
@@ -1426,7 +1424,6 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       });
     }
 
-    const initialMessage = resolveOptionalInitialSessionMessage(p);
     let runPayload: Record<string, unknown> | undefined;
     let runError: unknown;
     let runMeta: Record<string, unknown> | undefined;

--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -6,6 +6,7 @@ import {
   setupGatewaySessionsTestHarness,
   sessionStoreEntry,
   directSessionReq,
+  sessionHookMocks,
 } from "./test/server-sessions.test-helpers.js";
 
 const { createSessionStoreDir, openClient } = setupGatewaySessionsTestHarness();
@@ -82,6 +83,79 @@ test("sessions.create stores dashboard session model and parent linkage, and cre
   const header = JSON.parse(headerLine) as { type?: string; id?: string };
   expect(header.type).toBe("session");
   expect(header.id).toBe(created.payload?.sessionId);
+});
+
+test("sessions.create treats dashboard New Chat from a parent as a fresh root", async () => {
+  const { storePath } = await createSessionStoreDir();
+  await writeSessionStore({
+    entries: {
+      "dashboard:parent": sessionStoreEntry("sess-parent"),
+    },
+  });
+
+  const created = await directSessionReq<{
+    key?: string;
+    sessionId?: string;
+    entry?: {
+      parentSessionKey?: string;
+    };
+  }>("sessions.create", {
+    agentId: "main",
+    parentSessionKey: "agent:main:dashboard:parent",
+    emitCommandHooks: true,
+  });
+
+  expect(created.ok).toBe(true);
+  expect(created.payload?.key).toMatch(/^agent:main:dashboard:/);
+  expect(created.payload?.entry?.parentSessionKey).toBeUndefined();
+  expect(sessionHookMocks.triggerInternalHook).toHaveBeenCalledWith(
+    expect.objectContaining({
+      action: "new",
+      sessionKey: "agent:main:dashboard:parent",
+    }),
+  );
+
+  const rawStore = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+    string,
+    {
+      parentSessionKey?: string;
+    }
+  >;
+  const key = created.payload?.key as string;
+  expect(rawStore[key]?.parentSessionKey).toBeUndefined();
+});
+
+test("sessions.create preserves parent linkage for explicit keyed lifecycle creates", async () => {
+  const { storePath } = await createSessionStoreDir();
+  await writeSessionStore({
+    entries: {
+      "dashboard:parent": sessionStoreEntry("sess-parent"),
+    },
+  });
+
+  const key = "agent:main:dashboard:explicit-child";
+  const created = await directSessionReq<{
+    key?: string;
+    entry?: {
+      parentSessionKey?: string;
+    };
+  }>("sessions.create", {
+    key,
+    parentSessionKey: "agent:main:dashboard:parent",
+    emitCommandHooks: true,
+  });
+
+  expect(created.ok).toBe(true);
+  expect(created.payload?.key).toBe(key);
+  expect(created.payload?.entry?.parentSessionKey).toBe("agent:main:dashboard:parent");
+
+  const rawStore = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+    string,
+    {
+      parentSessionKey?: string;
+    }
+  >;
+  expect(rawStore[key]?.parentSessionKey).toBe("agent:main:dashboard:parent");
 });
 
 test("sessions.create accepts an explicit key for persistent dashboard sessions", async () => {


### PR DESCRIPTION
Summary
- Treat dashboard New Chat created from a parent as a fresh root session when there is no explicit key or initial message.
- Still run lifecycle hooks against the current parent session so the existing dashboard flow is preserved.
- Preserve parent linkage for explicit keyed lifecycle creates.

## Real behavior proof
- Behavior or issue addressed: Dashboard New Chat created from an existing chat no longer persists `parentSessionKey`, so the fresh chat does not fork or inherit the prior chat transcript.
- Real environment tested: Live local OpenClaw install on Erik's Mac, installed package under `/opt/homebrew/lib/node_modules/openclaw`, with Gateway restarted after the dist hotfix.
- Exact steps or command run after this patch: Restarted Gateway with `openclaw gateway restart`; checked `openclaw health`; ran live Gateway RPC `sessions.create` with `agentId: main`, `parentSessionKey: agent:main:dashboard:<existing>`, `emitCommandHooks: true`, no explicit key, and no initial message; inspected the returned entry and `sessions.list`; deleted the temporary test session. Also ran an explicit keyed create regression against the same live setup.
- Evidence after fix: Live terminal/RPC evidence showed `openclaw health` returned OK. The dashboard New Chat RPC created a new `agent:main:dashboard:*` session whose response had `entry.parentSessionKey == null`; `sessions.list` showed the same test session with `parentSessionKey == null` and no `childSessions`. The explicit keyed create check still returned `entry.parentSessionKey == agent:main:dashboard:parent`, proving lifecycle child creates still preserve parent metadata.
- Observed result after fix: Fresh dashboard New Chat sessions are stored rootless while command hooks still run against the parent session; explicit keyed lifecycle creates still preserve parent linkage.
- What was not tested: Browser screenshot capture was not added to the PR; this was verified through the live Gateway RPC/state path that the dashboard uses.

Tests
- pnpm exec vitest run src/gateway/server.sessions.create.test.ts
- pnpm exec oxfmt --check src/gateway/server-methods/sessions.ts src/gateway/server.sessions.create.test.ts
- pnpm tsgo:core