### PR TITLE
Preserve managed exec placement for implicit Codex runtime

### DIFF
--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -242,9 +242,35 @@ vi.mock("../logging/subsystem.js", () => ({
 }));
 
 vi.mock("../routing/session-key.js", () => ({
+  classifySessionKeyShape: (key?: string | null) => {
+    const raw = key?.trim() ?? "";
+    if (!raw) {
+      return "missing";
+    }
+    if (raw.startsWith("agent:")) {
+      return raw === "agent:" ? "malformed_agent" : "agent";
+    }
+    return "legacy_or_alias";
+  },
   isSubagentSessionKey: () => false,
+  isUnscopedSessionKeySentinel: (key?: string | null) =>
+    key?.trim().toLowerCase() === "global" || key?.trim().toLowerCase() === "unknown",
   normalizeAgentId: (id: string) => id,
   normalizeMainKey: (key?: string | null) => key?.trim() || "main",
+  resolveAgentIdFromSessionKey: (key?: string | null) => key?.split(":")[1] ?? "main",
+  scopeLegacySessionKeyToAgent: ({
+    agentId,
+    sessionKey,
+  }: {
+    agentId?: string;
+    sessionKey?: string;
+  }) => {
+    const raw = sessionKey?.trim();
+    if (!raw || !agentId || raw.startsWith("agent:")) {
+      return raw;
+    }
+    return `agent:${agentId}:${raw}`;
+  },
 }));
 
 vi.mock("../runtime.js", () => ({

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -988,6 +988,7 @@ async function agentCommandInternal(
       modelId: model,
       agentId: sessionAgentId,
       sessionKey,
+      execHost: sessionEntry?.execHost,
       workspaceDir,
     });
 
@@ -1004,6 +1005,7 @@ async function agentCommandInternal(
           config: cfg,
           agentId: sessionAgentId,
           sessionKey,
+          execHost: entry.execHost,
         });
         const acceptedAuthProviders = listOpenAIAuthProfileProvidersForAgentRuntime({
           provider: providerForAuthProfileValidation,
@@ -1241,6 +1243,7 @@ async function agentCommandInternal(
           agentDir,
           agentId: sessionAgentId,
           sessionKey: sessionKey ?? sessionId,
+          execHost: sessionEntryForAttempt?.execHost,
           prepareAgentHarnessRuntime: async ({ provider, model, agentHarnessRuntimeOverride }) => {
             await ensureSelectedAgentHarnessPlugin({
               config: cfg,
@@ -1248,6 +1251,7 @@ async function agentCommandInternal(
               modelId: model,
               agentId: sessionAgentId,
               sessionKey,
+              execHost: sessionEntryForAttempt?.execHost,
               agentHarnessRuntimeOverride,
               workspaceDir,
             });

--- a/src/agents/agent-runtime-metadata.ts
+++ b/src/agents/agent-runtime-metadata.ts
@@ -22,6 +22,7 @@ export function resolveModelAgentRuntimeMetadata(params: {
   provider?: string;
   model?: string;
   sessionKey?: string;
+  execHost?: string;
   /**
    * True when the loaded session entry has persisted ACP metadata. ACP-shaped
    * keys without this marker can be bridge sessions that use the configured
@@ -46,6 +47,7 @@ export function resolveModelAgentRuntimeMetadata(params: {
     config: params.cfg,
     agentId: params.agentId,
     sessionKey: params.sessionKey,
+    execHost: params.execHost,
   });
   const meta: AgentRuntimeMetadata = {
     id: policy.runtime,

--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -255,6 +255,7 @@ async function resolveRuntimeModel(params: {
         config: params.cfg,
         agentId: params.agentId,
         sessionKey: params.sessionKey,
+        execHost: params.sessionEntry?.execHost,
       }).runtime,
       config: params.cfg,
     }),
@@ -322,6 +323,7 @@ export async function runBtwSideQuestion(
     config: params.cfg,
     agentId: sessionAgentId,
     sessionKey: params.sessionKey,
+    execHost: params.sessionEntry.execHost,
   });
   if (harness.runSideQuestion) {
     const { model, authProfileId, authProfileIdSource } = await resolveRuntimeModel({

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -20,6 +20,7 @@ import { sanitizeForLog } from "../../terminal/ansi.js";
 import { resolveMessageChannel } from "../../utils/message-channel.js";
 import { resolveAuthProfileOrder } from "../auth-profiles/order.js";
 import { ensureAuthProfileStore } from "../auth-profiles/store.js";
+import type { ExecToolDefaults } from "../bash-tools.exec-types.js";
 import { resolveBootstrapWarningSignaturesSeen } from "../bootstrap-budget.js";
 import { runCliAgent } from "../cli-runner.js";
 import { getCliSessionBinding, setCliSessionBinding } from "../cli-session.js";
@@ -82,6 +83,21 @@ const ACP_TRANSCRIPT_USAGE = {
     total: 0,
   },
 } as const;
+
+type AgentExecOverrides = Pick<ExecToolDefaults, "host" | "security" | "ask" | "node">;
+
+function resolveSessionExecOverrides(
+  sessionEntry: SessionEntry | undefined,
+): AgentExecOverrides | undefined {
+  const host = sessionEntry?.execHost as AgentExecOverrides["host"] | undefined;
+  const security = sessionEntry?.execSecurity as AgentExecOverrides["security"] | undefined;
+  const ask = sessionEntry?.execAsk as AgentExecOverrides["ask"] | undefined;
+  const node = sessionEntry?.execNode;
+  if (!host && !security && !ask && !node) {
+    return undefined;
+  }
+  return { host, security, ask, node };
+}
 
 type TranscriptUsage = {
   input?: number;
@@ -404,6 +420,8 @@ export function runAgentAttempt(params: {
   onUserMessagePersisted?: (message: Extract<AgentMessage, { role: "user" }>) => void;
 }) {
   const isRawModelRun = params.opts.modelRun === true || params.opts.promptMode === "none";
+  const execOverrides =
+    params.opts.execOverrides ?? resolveSessionExecOverrides(params.sessionEntry);
   const claudeCliFallbackPrelude =
     !isRawModelRun &&
     params.isFallbackRetry &&
@@ -445,6 +463,7 @@ export function runAgentAttempt(params: {
         config: params.cfg,
         agentId: params.sessionAgentId,
         sessionKey: params.sessionKey ?? params.sessionId,
+        execHost: execOverrides?.host,
       });
   const harnessAuthSelection = resolveHarnessAuthProfileSelection({
     config: params.cfg,
@@ -666,6 +685,7 @@ export function runAgentAttempt(params: {
     fastMode: params.fastMode,
     verboseLevel: params.resolvedVerboseLevel,
     bashElevated: params.opts.bashElevated,
+    execOverrides,
     timeoutMs: params.timeoutMs,
     runId: params.runId,
     lane: params.opts.lane,

--- a/src/agents/command/types.ts
+++ b/src/agents/command/types.ts
@@ -5,7 +5,7 @@ import type { SourceReplyDeliveryMode } from "../../auto-reply/get-reply-options
 import type { ChannelOutboundTargetMode } from "../../channels/plugins/types.public.js";
 import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
 import type { InputProvenance } from "../../sessions/input-provenance.js";
-import type { ExecElevatedDefaults } from "../bash-tools.exec-types.js";
+import type { ExecElevatedDefaults, ExecToolDefaults } from "../bash-tools.exec-types.js";
 import type { AgentStreamParams, ClientToolDefinition } from "./shared-types.js";
 
 /** Image content block for Claude API multimodal messages. */
@@ -83,7 +83,9 @@ export type AgentCommandOpts = {
   runContext?: AgentRunContext;
   /** Internal trusted exec approval follow-up elevated defaults. */
   bashElevated?: ExecElevatedDefaults;
-  /** Trusted sender identity bit for command/channel-action auth; defaults true for local CLI calls. */
+  /** Internal trusted exec defaults resolved from directives or session state. */
+  execOverrides?: Pick<ExecToolDefaults, "host" | "security" | "ask" | "node">;
+  /** Whether this caller is authorized for owner-only tools (defaults true for local CLI calls). */
   senderIsOwner?: boolean;
   /** Whether this caller is authorized to use provider/model per-run overrides. */
   allowModelOverride?: boolean;

--- a/src/agents/harness/policy.ts
+++ b/src/agents/harness/policy.ts
@@ -1,4 +1,6 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resolveAgentConfig } from "../agent-scope-config.js";
+import { resolveSessionAgentIds } from "../agent-scope.js";
 import { resolveModelRuntimePolicy } from "../model-runtime-policy.js";
 import {
   isOpenAICodexProvider,
@@ -14,12 +16,64 @@ export type AgentHarnessPolicy = {
   runtimeSource?: "model" | "provider" | "implicit";
 };
 
+function normalizeExecPlacementHost(
+  value: unknown,
+): "auto" | "gateway" | "node" | "sandbox" | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const normalized = value.trim().toLowerCase();
+  return normalized === "auto" ||
+    normalized === "gateway" ||
+    normalized === "node" ||
+    normalized === "sandbox"
+    ? normalized
+    : undefined;
+}
+
+function resolveConfiguredExecHost(params: {
+  config?: OpenClawConfig;
+  agentId?: string;
+  sessionKey?: string;
+  execHost?: string;
+}): "auto" | "gateway" | "node" | "sandbox" | undefined {
+  const overrideHost = normalizeExecPlacementHost(params.execHost);
+  if (overrideHost) {
+    return overrideHost;
+  }
+  const resolvedAgentId = params.config
+    ? resolveSessionAgentIds({
+        config: params.config,
+        agentId: params.agentId,
+        sessionKey: params.sessionKey,
+      }).sessionAgentId
+    : params.agentId;
+  const agentHost =
+    params.config && resolvedAgentId
+      ? normalizeExecPlacementHost(
+          resolveAgentConfig(params.config, resolvedAgentId)?.tools?.exec?.host,
+        )
+      : undefined;
+  return agentHost ?? normalizeExecPlacementHost(params.config?.tools?.exec?.host);
+}
+
+function shouldUsePiForOpenClawManagedExecPlacement(params: {
+  config?: OpenClawConfig;
+  agentId?: string;
+  sessionKey?: string;
+  execHost?: string;
+}): boolean {
+  const host = resolveConfiguredExecHost(params);
+  return host === "node" || host === "sandbox";
+}
+
 export function resolveAgentHarnessPolicy(params: {
   provider?: string;
   modelId?: string;
   config?: OpenClawConfig;
   agentId?: string;
   sessionKey?: string;
+  execHost?: string;
   env?: NodeJS.ProcessEnv;
 }): AgentHarnessPolicy {
   const configured = resolveModelRuntimePolicy({
@@ -39,12 +93,32 @@ export function resolveAgentHarnessPolicy(params: {
     openAIProviderUsesCodexRuntimeByDefault({ provider: params.provider, config: params.config })
   ) {
     if (runtime === "auto") {
+      if (
+        shouldUsePiForOpenClawManagedExecPlacement({
+          config: params.config,
+          agentId: params.agentId,
+          sessionKey: params.sessionKey,
+          execHost: params.execHost,
+        })
+      ) {
+        return { runtime: "pi", runtimeSource };
+      }
       return { runtime: "codex", runtimeSource };
     }
     return { runtime, runtimeSource };
   }
   if (isOpenAICodexProvider(params.provider)) {
     if (runtime === "auto") {
+      if (
+        shouldUsePiForOpenClawManagedExecPlacement({
+          config: params.config,
+          agentId: params.agentId,
+          sessionKey: params.sessionKey,
+          execHost: params.execHost,
+        })
+      ) {
+        return { runtime: "pi", runtimeSource };
+      }
       return { runtime: "codex", runtimeSource };
     }
     return { runtime, runtimeSource };

--- a/src/agents/harness/runtime-plugin.ts
+++ b/src/agents/harness/runtime-plugin.ts
@@ -94,6 +94,7 @@ export async function ensureSelectedAgentHarnessPlugin(params: {
   config?: OpenClawConfig;
   agentId?: string;
   sessionKey?: string;
+  execHost?: string;
   agentHarnessRuntimeOverride?: string;
   workspaceDir: string;
 }): Promise<void> {
@@ -104,6 +105,7 @@ export async function ensureSelectedAgentHarnessPlugin(params: {
     config: params.config,
     agentId: params.agentId,
     sessionKey: params.sessionKey,
+    execHost: params.execHost,
   });
   const runtime =
     runtimeOverride && runtimeOverride !== "auto" && runtimeOverride !== "default"

--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -289,6 +289,107 @@ describe("runAgentHarnessAttempt", () => {
     expect(piRunAttempt).not.toHaveBeenCalled();
   });
 
+  it("keeps implicit OpenAI model runs on PI when exec host is pinned to node", async () => {
+    registerSuccessfulCodexHarness();
+    const config = {
+      tools: {
+        exec: {
+          host: "node",
+          node: "clawdad",
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    expect(resolveAgentHarnessPolicy({ provider: "openai", modelId: "gpt-5.4", config })).toEqual({
+      runtime: "pi",
+      runtimeSource: "implicit",
+    });
+
+    const result = await runAgentHarnessAttempt({
+      ...createAttemptParams(config),
+      provider: "openai",
+      modelId: "gpt-5.4",
+    });
+
+    expect(result.sessionIdUsed).toBe("pi");
+    expect(piRunAttempt).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps implicit OpenAI model runs on PI for session-level node exec overrides", async () => {
+    registerSuccessfulCodexHarness();
+
+    expect(
+      resolveAgentHarnessPolicy({
+        provider: "openai",
+        modelId: "gpt-5.4",
+        execHost: "node",
+      }),
+    ).toEqual({
+      runtime: "pi",
+      runtimeSource: "implicit",
+    });
+
+    const result = await runAgentHarnessAttempt({
+      ...createAttemptParams(),
+      provider: "openai",
+      modelId: "gpt-5.4",
+      execOverrides: { host: "node" },
+    });
+
+    expect(result.sessionIdUsed).toBe("pi");
+    expect(piRunAttempt).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps implicit OpenAI model runs on PI for sandbox exec placements", async () => {
+    registerSuccessfulCodexHarness();
+
+    expect(
+      resolveAgentHarnessPolicy({
+        provider: "openai",
+        modelId: "gpt-5.4",
+        execHost: "sandbox",
+      }),
+    ).toEqual({
+      runtime: "pi",
+      runtimeSource: "implicit",
+    });
+
+    const result = await runAgentHarnessAttempt({
+      ...createAttemptParams(),
+      provider: "openai",
+      modelId: "gpt-5.4",
+      execOverrides: { host: "sandbox" },
+    });
+
+    expect(result.sessionIdUsed).toBe("pi");
+    expect(piRunAttempt).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps implicit OpenAI Codex provider runs on PI for node exec placements", async () => {
+    registerSuccessfulCodexHarness();
+
+    expect(
+      resolveAgentHarnessPolicy({
+        provider: "openai-codex",
+        modelId: "gpt-5.5",
+        execHost: "node",
+      }),
+    ).toEqual({
+      runtime: "pi",
+      runtimeSource: "implicit",
+    });
+
+    const result = await runAgentHarnessAttempt({
+      ...createAttemptParams(),
+      provider: "openai-codex",
+      modelId: "gpt-5.5",
+      execOverrides: { host: "node" },
+    });
+
+    expect(result.sessionIdUsed).toBe("pi");
+    expect(piRunAttempt).toHaveBeenCalledTimes(1);
+  });
+
   it("falls back to PI when the implicit OpenAI Codex harness is unavailable", async () => {
     expect(resolveAgentHarnessPolicy({ provider: "openai", modelId: "gpt-5.4" })).toEqual({
       runtime: "codex",

--- a/src/agents/harness/selection.ts
+++ b/src/agents/harness/selection.ts
@@ -76,6 +76,7 @@ export function resolveAvailableAgentHarnessPolicy(params: {
   config?: OpenClawConfig;
   agentId?: string;
   sessionKey?: string;
+  execHost?: string;
   env?: NodeJS.ProcessEnv;
 }): AgentHarnessPolicy {
   return applyAgentHarnessAvailabilityPolicy(resolveConfiguredAgentHarnessPolicy(params));
@@ -112,6 +113,7 @@ export function selectAgentHarness(params: {
   config?: OpenClawConfig;
   agentId?: string;
   sessionKey?: string;
+  execHost?: string;
   agentHarnessId?: string;
   agentHarnessRuntimeOverride?: string;
 }): AgentHarness {
@@ -124,6 +126,7 @@ function selectAgentHarnessDecision(params: {
   config?: OpenClawConfig;
   agentId?: string;
   sessionKey?: string;
+  execHost?: string;
   agentHarnessId?: string;
   agentHarnessRuntimeOverride?: string;
 }): AgentHarnessSelectionDecision {
@@ -219,6 +222,7 @@ export async function runAgentHarnessAttempt(
     config: params.config,
     agentId: params.agentId,
     sessionKey: params.sessionKey,
+    execHost: params.execOverrides?.host,
     agentHarnessId: params.agentHarnessId,
     agentHarnessRuntimeOverride: params.agentHarnessRuntimeOverride,
   });
@@ -447,6 +451,7 @@ export async function maybeCompactAgentHarnessSession(
     modelId: params.model,
     config: params.config,
     sessionKey: params.sessionKey,
+    execHost: params.execOverrides?.host,
   });
   if (!harness.compact) {
     if (harness.id !== "pi") {

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -101,6 +101,7 @@ type ModelFallbackRuntimeContext = {
   cfg?: OpenClawConfig;
   agentId?: string;
   sessionKey?: string;
+  execHost?: string;
   resolveAgentHarnessRuntimeOverride?: (provider: string, model: string) => string | undefined;
   prepareAgentHarnessRuntime?: (params: {
     provider: string;
@@ -368,6 +369,7 @@ async function assertModelFallbackCandidateHarnessAvailable(
     config: params.cfg,
     agentId: params.agentId,
     sessionKey: params.sessionKey,
+    execHost: params.execHost,
   });
   const agentRuntime = agentRuntimeOverride ?? harnessPolicy.runtime;
   const agentRuntimeSource = agentRuntimeOverride ? "model" : harnessPolicy.runtimeSource;
@@ -911,6 +913,7 @@ export async function runWithModelFallback<T>(
     sessionId?: string;
     agentId?: string;
     sessionKey?: string;
+    execHost?: string;
     resolveAgentHarnessRuntimeOverride?: (provider: string, model: string) => string | undefined;
     prepareAgentHarnessRuntime?: (params: {
       provider: string;

--- a/src/agents/pi-embedded-runner/compact.queued.ts
+++ b/src/agents/pi-embedded-runner/compact.queued.ts
@@ -107,6 +107,7 @@ export async function compactEmbeddedPiSession(
       config: params.config,
       agentId: agentIds.sessionAgentId,
       sessionKey: params.sessionKey,
+      execHost: params.execOverrides?.host,
     });
     contextTokenBudget = resolveContextWindowInfo({
       cfg: params.config,

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -450,6 +450,7 @@ export async function compactEmbeddedPiSessionDirect(
           modelId: model,
           agentId: fallbackAgentId,
           sessionKey: fallbackSessionKey,
+          execHost: params.execOverrides?.host,
           agentHarnessRuntimeOverride,
           workspaceDir: params.workspaceDir,
         });
@@ -676,6 +677,7 @@ async function compactEmbeddedPiSessionDirectOnce(
       config: params.config,
       agentId: effectiveSkillAgentId,
       sessionKey: params.sessionKey,
+      execHost: params.execOverrides?.host,
     });
     const ctxInfo = resolveContextWindowInfo({
       cfg: params.config,

--- a/src/agents/pi-embedded-runner/compact.types.ts
+++ b/src/agents/pi-embedded-runner/compact.types.ts
@@ -58,6 +58,12 @@ export type CompactEmbeddedPiSessionParams = {
   thinkLevel?: ThinkLevel;
   reasoningLevel?: ReasoningLevel;
   bashElevated?: ExecElevatedDefaults;
+  execOverrides?: {
+    host?: string;
+    security?: string;
+    ask?: string;
+    node?: string;
+  };
   customInstructions?: string;
   tokenBudget?: number;
   force?: boolean;

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -608,6 +608,7 @@ export async function runEmbeddedPiAgent(
         config: params.config,
         agentId: params.agentId,
         sessionKey: params.sessionKey,
+        execHost: params.execOverrides?.host,
         agentHarnessRuntimeOverride: params.agentHarnessRuntimeOverride,
         workspaceDir: resolvedWorkspace,
       });
@@ -617,6 +618,7 @@ export async function runEmbeddedPiAgent(
         config: params.config,
         agentId: params.agentId,
         sessionKey: params.sessionKey,
+        execHost: params.execOverrides?.host,
         agentHarnessId: params.agentHarnessId,
         agentHarnessRuntimeOverride: params.agentHarnessRuntimeOverride,
       });

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1626,6 +1626,7 @@ export async function runAgentTurnWithFallback(params: {
             modelId: model,
             agentId: params.followupRun.run.agentId,
             sessionKey: params.followupRun.run.runtimePolicySessionKey ?? params.sessionKey,
+            execHost: params.followupRun.run.execOverrides?.host,
             agentHarnessRuntimeOverride,
             workspaceDir: params.followupRun.run.workspaceDir,
           });
@@ -1840,6 +1841,7 @@ export async function runAgentTurnWithFallback(params: {
                 config: runtimeConfig,
                 agentId: params.followupRun.run.agentId,
                 sessionKey: params.followupRun.run.runtimePolicySessionKey ?? params.sessionKey,
+                execHost: params.followupRun.run.execOverrides?.host,
               });
           const embeddedRunProvider = resolveOpenAIRuntimeProviderForPi({
             provider,

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -258,6 +258,7 @@ function resolveFollowupContextConfigProvider(params: {
       params.sessionKey ??
       params.followupRun.run.runtimePolicySessionKey ??
       params.followupRun.run.sessionKey,
+    execHost: params.followupRun.run.execOverrides?.host ?? matchingSessionEntry?.execHost,
   });
   return resolveContextConfigProviderForRuntime({
     provider,
@@ -758,6 +759,9 @@ export async function runPreflightCompactionIfNeeded(params: {
     agentHarnessId:
       entry.sessionId === params.followupRun.run.sessionId ? entry.agentHarnessId : undefined,
     thinkLevel: params.followupRun.run.thinkLevel,
+    execOverrides:
+      params.followupRun.run.execOverrides ??
+      (entry.execHost ? { host: entry.execHost } : undefined),
     bashElevated: params.followupRun.run.bashElevated,
     trigger: "budget",
     currentTokenCount: tokenCountForCompaction ?? freshPersistedTokens,
@@ -1077,6 +1081,7 @@ export async function runMemoryFlushIfNeeded(params: {
             params.runtimePolicySessionKey ??
             params.followupRun.run.runtimePolicySessionKey ??
             params.sessionKey,
+          execHost: params.followupRun.run.execOverrides?.host,
           agentHarnessRuntimeOverride,
           workspaceDir: params.followupRun.run.workspaceDir,
         });

--- a/src/auto-reply/reply/agent-runner-run-params.ts
+++ b/src/auto-reply/reply/agent-runner-run-params.ts
@@ -48,6 +48,7 @@ export function resolveModelFallbackOptions(
     agentDir: run.agentDir,
     agentId: run.agentId,
     sessionKey: run.runtimePolicySessionKey ?? run.sessionKey,
+    execHost: run.execOverrides?.host,
     fallbacksOverride,
   };
 }

--- a/src/auto-reply/reply/commands-compact.ts
+++ b/src/auto-reply/reply/commands-compact.ts
@@ -89,6 +89,7 @@ function resolveManualCompactContextTokenBudget(params: {
   model?: string;
   agentId: string;
   sessionKey: string;
+  execHost?: string;
   liveContextTokens?: number;
   persistedContextTokens?: number;
 }): number | undefined {
@@ -111,6 +112,7 @@ function resolveManualCompactContextTokenBudget(params: {
     config: params.cfg,
     agentId: params.agentId,
     sessionKey: params.sessionKey,
+    execHost: params.execHost,
   });
   const contextConfigProvider = resolveContextConfigProviderForRuntime({
     provider,
@@ -223,6 +225,7 @@ export const handleCompactCommand: CommandHandler = async (params) => {
     model: params.model,
     agentId: sessionAgentId,
     sessionKey: params.sessionKey,
+    execHost: targetSessionEntry.execHost,
     liveContextTokens: params.contextTokens,
     persistedContextTokens: targetSessionEntry.contextTokens,
   });
@@ -257,6 +260,7 @@ export const handleCompactCommand: CommandHandler = async (params) => {
     agentHarnessId:
       targetSessionEntry.sessionId === sessionId ? targetSessionEntry.agentHarnessId : undefined,
     thinkLevel: params.resolvedThinkLevel ?? (await params.resolveDefaultThinkingLevel()),
+    execOverrides: targetSessionEntry.execHost ? { host: targetSessionEntry.execHost } : undefined,
     bashElevated: {
       enabled: false,
       allowed: false,

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -41,7 +41,7 @@ const MODELS_ADD_DEPRECATED_TEXT =
   "⚠️ /models add is deprecated. Use /models to browse providers and /model to switch models.";
 
 type ModelsCommandSessionEntry = Partial<
-  Pick<SessionEntry, "authProfileOverride" | "modelProvider" | "model">
+  Pick<SessionEntry, "authProfileOverride" | "modelProvider" | "model" | "execHost">
 >;
 
 export type ModelsProviderData = {
@@ -397,6 +397,7 @@ function resolveProviderLabel(params: {
     config: params.cfg,
     provider: params.provider,
     agentId: params.agentId,
+    execHost: params.sessionEntry?.execHost,
   });
   const acceptedProviderIds = listOpenAIAuthProfileProvidersForAgentRuntime({
     provider: params.provider,

--- a/src/auto-reply/reply/directive-handling.model.ts
+++ b/src/auto-reply/reply/directive-handling.model.ts
@@ -37,7 +37,7 @@ function isMissingAuthLabel(auth: { label: string; source: string }): boolean {
 }
 
 function resolveStatusHarnessRuntime(params: {
-  sessionEntry?: Pick<SessionEntry, "agentHarnessId" | "agentRuntimeOverride">;
+  sessionEntry?: Pick<SessionEntry, "agentHarnessId" | "agentRuntimeOverride" | "execHost">;
   defaultRuntime: string;
 }): string {
   void params.sessionEntry;
@@ -53,7 +53,7 @@ async function resolveStatusAuthLabel(params: {
   activeAgentId: string;
   authMode: ModelAuthDetailMode;
   workspaceDir?: string;
-  sessionEntry?: Pick<SessionEntry, "agentHarnessId" | "agentRuntimeOverride">;
+  sessionEntry?: Pick<SessionEntry, "agentHarnessId" | "agentRuntimeOverride" | "execHost">;
 }): Promise<string> {
   const auth = await resolveAuthLabel(
     params.provider,
@@ -73,6 +73,7 @@ async function resolveStatusAuthLabel(params: {
     modelId: params.modelId,
     config: params.cfg,
     agentId: params.activeAgentId,
+    execHost: params.sessionEntry?.execHost,
   });
   const harnessRuntime = resolveStatusHarnessRuntime({
     sessionEntry: params.sessionEntry,
@@ -319,7 +320,7 @@ export async function maybeHandleModelDirectiveInfo(params: {
   workspaceDir?: string;
   surface?: string;
   sessionEntry?: Pick<SessionEntry, "modelProvider" | "model"> &
-    Partial<Pick<SessionEntry, "agentHarnessId" | "agentRuntimeOverride">>;
+    Partial<Pick<SessionEntry, "agentHarnessId" | "agentRuntimeOverride" | "execHost">>;
 }): Promise<ReplyPayload | undefined> {
   if (!params.directives.hasModelDirective) {
     return undefined;

--- a/src/auto-reply/reply/directive-handling.persist.ts
+++ b/src/auto-reply/reply/directive-handling.persist.ts
@@ -387,6 +387,7 @@ export async function persistInlineDirectives(params: {
           config: cfg,
           agentId: activeAgentId,
           sessionKey,
+          execHost: sessionEntry?.execHost,
         }).runtime,
       }),
       model,

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -545,6 +545,7 @@ const resolveHarnessSourceVisibleRepliesDefault = (params: {
         config: params.cfg,
         agentId: params.sessionAgentId,
         sessionKey: params.sessionKey,
+        execHost: params.entry?.execHost,
         agentHarnessRuntimeOverride,
       });
       return harness.deliveryDefaults?.sourceVisibleReplies;

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -549,6 +549,7 @@ export function createFollowupRunner(params: {
               modelId: model,
               agentId: run.agentId,
               sessionKey: run.runtimePolicySessionKey ?? replySessionKey,
+              execHost: run.execOverrides?.host,
               agentHarnessRuntimeOverride,
               workspaceDir: run.workspaceDir,
             });

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -913,6 +913,7 @@ export async function runPreparedReply(
         config: cfg,
         agentId,
         sessionKey: runtimePolicySessionKey,
+        execHost: execOverrides?.host,
       });
   const resolveAcceptedAuthProfileProviders = () =>
     agentHarnessPolicy

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -332,6 +332,7 @@ export async function createModelSelectionState(params: {
       config: cfg,
       agentId: params.agentId,
       sessionKey,
+      execHost: sessionEntry.execHost,
     });
     const acceptedAuthProviders = listOpenAIAuthProfileProvidersForAgentRuntime({
       provider,

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -1,3 +1,4 @@
+import type { ExecToolDefaults } from "../../agents/bash-tools.exec-types.js";
 import type { BootstrapContextMode } from "../../agents/bootstrap-files.js";
 import { resolveCliRuntimeExecutionProvider } from "../../agents/model-runtime-aliases.js";
 import type { SkillSnapshot } from "../../agents/skills.js";
@@ -37,6 +38,25 @@ import { isLikelyInterimCronMessage } from "./subagent-followup-hints.js";
 
 type AgentTurnPayload = Extract<CronJob["payload"], { kind: "agentTurn" }> | null;
 type CronPromptRunResult = Awaited<ReturnType<typeof runCliAgent>>;
+type CronExecOverrides = Pick<
+  ExecToolDefaults,
+  "host" | "notifyOnExit" | "notifyOnExitEmptySuccess"
+>;
+
+function resolveCronExecOverrides(params: {
+  sessionEntry: MutableCronSession["sessionEntry"];
+  suppressExecNotifyOnExit?: boolean;
+}): CronExecOverrides | undefined {
+  const overrides: CronExecOverrides = {};
+  if (params.sessionEntry.execHost) {
+    overrides.host = params.sessionEntry.execHost as CronExecOverrides["host"];
+  }
+  if (params.suppressExecNotifyOnExit) {
+    overrides.notifyOnExit = false;
+    overrides.notifyOnExitEmptySuccess = false;
+  }
+  return Object.keys(overrides).length > 0 ? overrides : undefined;
+}
 type CronEmbeddedRuntime = typeof import("./run-embedded.runtime.js");
 type CronSubagentRegistryRuntime = typeof import("./run-subagent-registry.runtime.js");
 
@@ -165,6 +185,7 @@ export function createCronPromptExecutor(params: {
           modelId: model,
           agentId: params.agentId,
           sessionKey: params.runSessionKey,
+          execHost: params.cronSession.sessionEntry.execHost,
           agentHarnessRuntimeOverride,
           workspaceDir: params.workspaceDir,
         });
@@ -267,12 +288,10 @@ export function createCronPromptExecutor(params: {
           bootstrapContextMode,
           bootstrapContextRunKind: "cron",
           toolsAllow: params.agentPayload?.toolsAllow,
-          execOverrides: params.suppressExecNotifyOnExit
-            ? {
-                notifyOnExit: false,
-                notifyOnExitEmptySuccess: false,
-              }
-            : undefined,
+          execOverrides: resolveCronExecOverrides({
+            sessionEntry: params.cronSession.sessionEntry,
+            suppressExecNotifyOnExit: params.suppressExecNotifyOnExit,
+          }),
           sourceReplyDeliveryMode,
           runId: params.cronSession.sessionEntry.sessionId,
           requireExplicitMessageTarget: params.sourceDelivery.messageTool.requireExplicitTarget,

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -779,6 +779,7 @@ async function prepareCronRunContext(params: {
               config: cfgWithAgentDefaults,
               agentId,
               sessionKey: agentSessionKey,
+              execHost: cronSession.sessionEntry.execHost,
             }).runtime,
             config: cfgWithAgentDefaults,
           }),

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -1944,6 +1944,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       provider: resolvedDisplayModel.provider,
       model: resolvedDisplayModel.model,
       sessionKey: target.canonicalKey ?? key,
+      execHost: applied.entry?.execHost,
       acpRuntime: applied.entry?.acp != null,
       acpBackend: applied.entry?.acp?.backend,
     });
@@ -2301,6 +2302,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
           agentHarnessId: entry?.sessionId === sessionId ? entry.agentHarnessId : undefined,
           thinkLevel: normalizeThinkLevel(entry?.thinkingLevel),
           reasoningLevel: normalizeReasoningLevel(entry?.reasoningLevel),
+          execOverrides: entry?.execHost ? { host: entry.execHost } : undefined,
           bashElevated: {
             enabled: false,
             allowed: false,

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1836,6 +1836,7 @@ export function buildGatewaySessionRow(params: {
     provider: rowModelProvider,
     model: rowModel,
     sessionKey: key,
+    execHost: entry?.execHost,
     acpRuntime: entry?.acp != null,
     acpBackend: entry?.acp?.backend,
   });

--- a/src/status/status-text.ts
+++ b/src/status/status-text.ts
@@ -146,6 +146,7 @@ async function resolveStatusHarnessId(params: {
       config: params.cfg,
       agentId: params.agentId,
       sessionKey: params.sessionKey,
+      execHost: params.sessionEntry?.execHost,
       agentHarnessId: params.sessionEntry?.agentHarnessId,
     });
     const id = normalizeOptionalLowercaseString(selected.id);


### PR DESCRIPTION
## Summary

Codex runtime currently changes the execution placement contract for OpenAI-backed sessions. When OpenAI implicitly selects the bundled Codex harness, shell/code execution can happen at the Codex/gateway placement instead of the OpenClaw-managed exec placement the session asked for.

This is the same class of problem reported in #83796: Codex runtime/native execution can bypass the OpenClaw placement boundary that PI-backed tools honor. In our node-exec repro, forcing the same OpenAI/Codex model route back through PI makes node exec work again:

```json
"openai-codex/gpt-5.5": {
  "alias": "codex",
  "agentRuntime": {
    "id": "pi"
  }
}
```

That points at Codex runtime placement, not OpenAI auth/model access.

## Changes

- Keep implicit OpenAI -> Codex routing on PI when the effective exec placement is `node` or `sandbox`.
- Apply the same guard to implicit `openai-codex/*` provider routes.
- Preserve explicit runtime pins: if a config explicitly asks for `agentRuntime.id = "codex"`, this PR does not rewrite it.
- Propagate session/config exec placement into harness policy selection across main agent runs, status metadata, plugin loading, compaction, model fallback, BTW side questions, cron isolated runs, and gateway session rows.
- Add regression coverage for:
  - global `tools.exec.host = "node"`
  - per-run/session `execOverrides.host = "node"`
  - per-run/session `execOverrides.host = "sandbox"`
  - implicit `openai-codex/gpt-5.5` with node exec placement

## Risk / Scope

This is intentionally narrower than moving Codex app-server execution into the OpenClaw sandbox or node. It only prevents implicit Codex runtime selection from silently overriding OpenClaw-managed exec placement for node/sandbox sessions. Explicit Codex runtime selection still behaves as an explicit operator choice.


## Real behavior proof

- **Behavior or issue addressed:** Implicit Codex runtime selection no longer overrides OpenClaw-managed exec placement when the effective exec host is `node` or `sandbox`.
- **Real environment tested:** Patched OpenClaw source checkout on the VPS worktree `/root/projects/openclaw-provider-runtime-node-exec-v2`, branch `fix/provider-runtime-node-exec-v2`, using the actual runtime policy resolver from this PR with no test mocks.
- **Exact steps or command run after this patch:** Ran a live Node/tsx command against the patched OpenClaw source to resolve the harness policy for the production-relevant node/sandbox exec placements:
```bash
node --import tsx --input-type=module <<'TS'
import { resolveAgentHarnessPolicy } from './src/agents/harness/policy.ts';

const config = {
  tools: {
    exec: {
      host: 'node',
      node: 'Clawdad',
    },
  },
  models: {
    providers: {
      openai: {},
    },
  },
};

const cases = [
  { label: 'openai/gpt-5.5 with global tools.exec.host=node', provider: 'openai', modelId: 'gpt-5.5', config },
  { label: 'openai-codex/gpt-5.5 with per-run execHost=node', provider: 'openai-codex', modelId: 'gpt-5.5', execHost: 'node' },
  { label: 'openai/gpt-5.5 with per-run execHost=sandbox', provider: 'openai', modelId: 'gpt-5.5', execHost: 'sandbox' },
  { label: 'openai/gpt-5.5 without managed exec placement', provider: 'openai', modelId: 'gpt-5.5' },
];

for (const testCase of cases) {
  const { label, ...params } = testCase;
  console.log(label);
  console.log(JSON.stringify(resolveAgentHarnessPolicy(params), null, 2));
}
TS
```
- **Evidence after fix:** Live console output from the patched branch:
```text
openai/gpt-5.5 with global tools.exec.host=node
{
  "runtime": "pi",
  "runtimeSource": "implicit"
}
openai-codex/gpt-5.5 with per-run execHost=node
{
  "runtime": "pi",
  "runtimeSource": "implicit"
}
openai/gpt-5.5 with per-run execHost=sandbox
{
  "runtime": "pi",
  "runtimeSource": "implicit"
}
openai/gpt-5.5 without managed exec placement
{
  "runtime": "codex",
  "runtimeSource": "implicit"
}
```
- **Observed result after fix:** Node and sandbox exec placements resolve to PI, so OpenClaw-managed exec routing is preserved. A normal OpenAI route without managed exec placement still resolves to Codex, preserving the default Codex behavior outside the affected placement case.
- **What was not tested:** I did not run a live Mac-node command from a full patched Gateway session in this proof; the local proof validates the patched runtime selection path that decides whether the Codex harness can take over before OpenClaw exec tools are built.

## Verification

```bash
node scripts/test-projects.mjs src/agents/harness/selection.test.ts src/agents/harness/runtime-plugin.test.ts src/agents/command/attempt-execution.cli.test.ts src/gateway/session-utils.test.ts
# passed: 2 Vitest shards, 154 tests

node scripts/test-projects.mjs src/agents/model-fallback.test.ts src/agents/btw.test.ts src/agents/agent-command.live-model-switch.test.ts src/auto-reply/reply/commands-models.test.ts src/auto-reply/reply/commands-compact.test.ts src/auto-reply/reply/directive-handling.model.test.ts src/cron/isolated-agent/run.runtime-plugins.test.ts src/cron/isolated-agent/run.session-key.test.ts
# passed: 3 Vitest shards, 212 tests

pnpm tsgo:core:test
# passed

git diff --check
# passed
```

Related: #83796, #83737