### PR TITLE
Audit config backups for plaintext secrets

### DIFF
--- a/docs/cli/secrets.md
+++ b/docs/cli/secrets.md
@@ -72,6 +72,7 @@ Scan OpenClaw state for:
 - plaintext secret storage
 - unresolved refs
 - precedence drift (`auth-profiles.json` credentials shadowing `openclaw.json` refs)
+- config backup residues (`openclaw.json.*` and `openclaw.json.bak` plaintext secrets)
 - generated `agents/*/agent/models.json` residues (provider `apiKey` values and sensitive provider headers)
 - legacy residues (legacy auth store entries, OAuth reminders)
 

--- a/src/secrets/audit.test.ts
+++ b/src/secrets/audit.test.ts
@@ -430,6 +430,34 @@ describe("secrets audit", () => {
     expect(report.filesScanned).toContain(fixture.modelsPath);
   });
 
+  it("scans config backups for plaintext provider apiKey values", async () => {
+    const backupPath = `${fixture.configPath}.bak`;
+    await writeJsonFile(backupPath, {
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://api.openai.com/v1",
+            api: "openai-completions",
+            apiKey: "sk-backup-plaintext", // pragma: allowlist secret
+            models: [{ id: "gpt-5", name: "gpt-5" }],
+          },
+        },
+      },
+    });
+
+    const report = await runSecretsAudit({ env: fixture.env });
+    expect(
+      hasFinding(
+        report,
+        (entry) =>
+          entry.code === "PLAINTEXT_FOUND" &&
+          entry.file === backupPath &&
+          entry.jsonPath === "models.providers.openai.apiKey",
+      ),
+    ).toBe(true);
+    expect(report.filesScanned).toContain(backupPath);
+  });
+
   it("scans agent models.json files for plaintext provider header values", async () => {
     await writeModelsProvider({
       headers: {

--- a/src/secrets/audit.ts
+++ b/src/secrets/audit.ts
@@ -6,7 +6,7 @@ import {
   isSecretRefHeaderValueMarker,
 } from "../agents/model-auth-markers.js";
 import { normalizeProviderId } from "../agents/model-selection.js";
-import { resolveStateDir, type OpenClawConfig } from "../config/config.js";
+import { parseConfigJson5, resolveStateDir, type OpenClawConfig } from "../config/config.js";
 import { coerceSecretRef } from "../config/types.secrets.js";
 import { resolveSecretInputRef, type SecretRef } from "../config/types.secrets.js";
 import { formatErrorMessage } from "../infra/errors.js";
@@ -104,6 +104,8 @@ type AuditCollector = {
 };
 
 const REF_RESOLVE_FALLBACK_CONCURRENCY = 8;
+const MAX_AUDIT_CONFIG_BACKUP_BYTES = 5 * 1024 * 1024;
+const MAX_AUDIT_CONFIG_BACKUP_FILES = 50;
 const MAX_AUDIT_MODELS_JSON_BYTES = 5 * 1024 * 1024;
 const ALWAYS_SENSITIVE_MODEL_PROVIDER_HEADER_NAMES = new Set([
   "authorization",
@@ -257,6 +259,99 @@ function collectConfigSecrets(params: {
       message: `${target.path} is stored as plaintext.`,
       provider: target.providerId,
     });
+  }
+}
+
+function listConfigBackupPaths(configPath: string): string[] {
+  const configDir = path.dirname(configPath);
+  const configName = path.basename(configPath);
+  if (!fs.existsSync(configDir)) {
+    return [];
+  }
+  const backupPaths: string[] = [];
+  for (const entry of fs.readdirSync(configDir, { withFileTypes: true })) {
+    if (!entry.isFile()) {
+      continue;
+    }
+    if (entry.name === configName) {
+      continue;
+    }
+    if (entry.name === `${configName}.bak` || entry.name.startsWith(`${configName}.`)) {
+      backupPaths.push(path.join(configDir, entry.name));
+    }
+  }
+  return backupPaths.toSorted().slice(0, MAX_AUDIT_CONFIG_BACKUP_FILES);
+}
+
+function readConfigBackupObject(filePath: string): {
+  value: Record<string, unknown> | null;
+  error?: string;
+} {
+  try {
+    const stats = fs.statSync(filePath);
+    if (!stats.isFile()) {
+      return { value: null, error: `Refusing to read non-regular file: ${filePath}` };
+    }
+    if (stats.size > MAX_AUDIT_CONFIG_BACKUP_BYTES) {
+      return {
+        value: null,
+        error: `Refusing to read oversized config backup (${stats.size} bytes): ${filePath}`,
+      };
+    }
+    const raw = fs.readFileSync(filePath, "utf8");
+    const parsed = parseConfigJson5(raw);
+    if (!parsed.ok) {
+      return { value: null, error: parsed.error };
+    }
+    return isRecord(parsed.parsed) ? { value: parsed.parsed } : { value: null };
+  } catch (err) {
+    return { value: null, error: formatErrorMessage(err) };
+  }
+}
+
+function collectConfigBackupSecrets(params: {
+  configPath: string;
+  collector: AuditCollector;
+}): void {
+  for (const backupPath of listConfigBackupPaths(params.configPath)) {
+    params.collector.filesScanned.add(backupPath);
+    const parsedResult = readConfigBackupObject(backupPath);
+    const parsed = parsedResult.value;
+    if (!parsed) {
+      continue;
+    }
+    const backupConfig = parsed as OpenClawConfig;
+    const defaults = backupConfig.secrets?.defaults;
+    for (const target of discoverConfigSecretTargets(backupConfig)) {
+      if (!target.entry.includeInAudit) {
+        continue;
+      }
+      const { ref } = resolveSecretInputRef({
+        value: target.value,
+        refValue: target.refValue,
+        defaults,
+      });
+      if (ref) {
+        continue;
+      }
+      if (
+        target.entry.id === "models.providers.*.headers.*" &&
+        !isLikelySensitiveModelProviderHeaderName(target.pathSegments.at(-1) ?? "")
+      ) {
+        continue;
+      }
+      if (!hasConfiguredPlaintextSecretValue(target.value, target.entry.expectedResolvedValue)) {
+        continue;
+      }
+      addFinding(params.collector, {
+        code: "PLAINTEXT_FOUND",
+        severity: "warn",
+        file: backupPath,
+        jsonPath: target.path,
+        message: `${target.path} is stored as plaintext in a config backup.`,
+        provider: target.providerId,
+      });
+    }
   }
 }
 
@@ -712,6 +807,10 @@ export async function runSecretsAudit(
     });
   }
 
+  collectConfigBackupSecrets({
+    configPath,
+    collector,
+  });
   collectEnvPlaintext({
     envPath,
     collector,


### PR DESCRIPTION
## Summary
- scan `openclaw.json.*` / `openclaw.json.bak` snapshots during `openclaw secrets audit` for plaintext secret targets
- reuse the config secret target registry so backup findings report the same JSON paths as active config findings
- document the new audit surface and add regression coverage

Refs #11829. 

## Real behavior proof
- **Behavior or issue addressed**: `openclaw secrets audit` now scans `openclaw.json.*` / `openclaw.json.bak` config backups and reports plaintext secret targets that may remain after the active config has moved to SecretRefs.
- **Real environment tested**: Local OpenClaw checkout from this PR branch on macOS using the actual CLI entrypoint, with a temporary `OPENCLAW_STATE_DIR` and `OPENCLAW_CONFIG_PATH`.
- **Exact steps or command run after this patch**:

```bash
PATH="/opt/homebrew/bin:$PATH" \
OPENCLAW_STATE_DIR="$tmp/.openclaw" \
OPENCLAW_CONFIG_PATH="$tmp/.openclaw/openclaw.json" \
OPENAI_API_KEY="env-value-for-proof" \
pnpm exec tsx src/entry.ts secrets audit --json
```

- **Evidence after fix**: Terminal output from the actual CLI run, redacted to only show the relevant finding:

```json
{
  "status": "findings",
  "summary": {
    "plaintextCount": 1,
    "unresolvedRefCount": 0,
    "shadowedRefCount": 0,
    "legacyResidueCount": 0
  },
  "backupFinding": [
    {
      "code": "PLAINTEXT_FOUND",
      "jsonPath": "models.providers.openai.apiKey",
      "message": "models.providers.openai.apiKey is stored as plaintext in a config backup."
    }
  ]
}
```

- **Observed result after fix**: The CLI returned `status: "findings"` and reported the plaintext provider `apiKey` from `openclaw.json.bak`, while the active config used an env-backed SecretRef.
- **What was not tested**: No additional gaps.

## Tests
- `pnpm exec vitest run --config test/vitest/vitest.secrets.config.ts src/secrets/audit.test.ts`
- `pnpm exec oxlint src/secrets/audit.ts src/secrets/audit.test.ts`
- `pnpm exec tsc --noEmit --pretty false --project tsconfig.core.json`
- `git diff --check`
