### PR TITLE
Fix pending final delivery without send proof

### DIFF
--- a/src/agents/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-restart-recovery.test.ts
@@ -482,7 +482,9 @@ describe("main-session-restart-recovery", () => {
     expect(entry?.pendingFinalDelivery).toBe(true);
     expect(entry?.pendingFinalDeliveryText).toBe(pendingPayload);
     expect(entry?.pendingFinalDeliveryAttemptCount).toBe(1);
-    expect(entry?.pendingFinalDeliveryLastError).toBeNull();
+    expect(entry?.pendingFinalDeliveryLastError).toBe(
+      "pending final resume requested; channel delivery still pending",
+    );
     expect(entry?.pendingFinalDeliveryCreatedAt).toBeLessThanOrEqual(beforeStoreRead);
     expect(entry?.pendingFinalDeliveryLastAttemptAt).toBeLessThanOrEqual(beforeStoreRead);
     expect(entry?.pendingFinalDeliveryLastAttemptAt ?? 0).toBeGreaterThanOrEqual(

--- a/src/agents/main-session-restart-recovery.ts
+++ b/src/agents/main-session-restart-recovery.ts
@@ -310,7 +310,8 @@ async function resumeMainSession(params: {
             entry.pendingFinalDeliveryLastAttemptAt = now;
             entry.pendingFinalDeliveryAttemptCount =
               (entry.pendingFinalDeliveryAttemptCount ?? 0) + 1;
-            entry.pendingFinalDeliveryLastError = null;
+            entry.pendingFinalDeliveryLastError =
+              "pending final resume requested; channel delivery still pending";
             entry.pendingFinalDeliveryText = sanitizedPendingText;
           } else {
             entry.pendingFinalDelivery = undefined;

--- a/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
@@ -229,9 +229,13 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
     });
 
     expect(result.queuedFinal).toBe(false);
-    expect(sessionStoreMocks.updateSessionStoreEntry).not.toHaveBeenCalled();
+    expect(sessionStoreMocks.updateSessionStoreEntry).toHaveBeenCalledOnce();
     expect(sessionStoreMocks.currentEntry?.pendingFinalDelivery).toBe(true);
     expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryText).toBe("durable reply");
     expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryCreatedAt).toBe(1);
+    expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryAttemptCount).toBe(1);
+    expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryLastError).toBe(
+      "final delivery produced no routed or queued send",
+    );
   });
 });

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -570,6 +570,32 @@ async function clearPendingFinalDeliveryAfterSuccess(params: {
   });
 }
 
+async function markPendingFinalDeliveryAfterFailure(params: {
+  storePath?: string;
+  sessionKey?: string;
+  error: string;
+}): Promise<void> {
+  if (!params.storePath || !params.sessionKey) {
+    return;
+  }
+  const now = Date.now();
+  await updateSessionStoreEntry({
+    storePath: params.storePath,
+    sessionKey: params.sessionKey,
+    update: async (entry) => {
+      if (!entry.pendingFinalDelivery && !entry.pendingFinalDeliveryText) {
+        return null;
+      }
+      return {
+        pendingFinalDeliveryLastAttemptAt: now,
+        pendingFinalDeliveryAttemptCount: (entry.pendingFinalDeliveryAttemptCount ?? 0) + 1,
+        pendingFinalDeliveryLastError: params.error,
+        updatedAt: now,
+      };
+    },
+  });
+}
+
 async function mirrorInternalSourceReplyToTranscript(params: {
   metadata: NonNullable<ReturnType<typeof getReplyPayloadMetadata>>["sourceReplyTranscriptMirror"];
   cfg: OpenClawConfig;
@@ -1825,6 +1851,7 @@ export async function dispatchReplyFromConfig(
     let routedFinalCount = 0;
     let attemptedFinalDelivery = false;
     let finalDeliveryFailed = false;
+    let finalDeliveryError: string | undefined;
     const shouldDeliverDespiteSourceReplySuppression = (reply: ReplyPayload) =>
       suppressAutomaticSourceDelivery &&
       ctx.InboundEventKind !== "room_event" &&
@@ -1859,6 +1886,7 @@ export async function dispatchReplyFromConfig(
       routedFinalCount += finalReply.routedFinalCount;
       if (!finalReply.queuedFinal && finalReply.routedFinalCount === 0) {
         finalDeliveryFailed = true;
+        finalDeliveryError = "final delivery produced no routed or queued send";
       }
     }
 
@@ -1866,6 +1894,12 @@ export async function dispatchReplyFromConfig(
       await clearPendingFinalDeliveryAfterSuccess({
         storePath: sessionStoreEntry.storePath,
         sessionKey: sessionStoreEntry.sessionKey ?? sessionKey,
+      });
+    } else if (attemptedFinalDelivery && finalDeliveryFailed) {
+      await markPendingFinalDeliveryAfterFailure({
+        storePath: sessionStoreEntry.storePath,
+        sessionKey: sessionStoreEntry.sessionKey ?? sessionKey,
+        error: finalDeliveryError ?? "final delivery failed",
       });
     }
 

--- a/src/auto-reply/reply/route-reply.test.ts
+++ b/src/auto-reply/reply/route-reply.test.ts
@@ -206,7 +206,7 @@ describe("routeReply", () => {
       ]),
     );
     mocks.deliverOutboundPayloads.mockReset();
-    mocks.deliverOutboundPayloads.mockResolvedValue([]);
+    mocks.deliverOutboundPayloads.mockResolvedValue([{ channel: "slack", messageId: "mock" }]);
   });
 
   afterEach(() => {
@@ -253,6 +253,24 @@ describe("routeReply", () => {
       to: "channel:C123",
     });
     expect(lastDeliveryPayload().text).toBe(`${SILENT_REPLY_TOKEN} -- (why am I here?)`);
+  });
+
+  it("reports a visible reply with no outbound result as failed", async () => {
+    mocks.deliverOutboundPayloads.mockResolvedValueOnce([]);
+
+    const res = await routeReply({
+      payload: { text: "hi" },
+      channel: "telegram",
+      to: "telegram:123",
+      cfg: {} as never,
+    });
+
+    expect(res.ok).toBe(false);
+    expect(res.error).toContain("no visible delivery result");
+    expectLastDeliveryFields({
+      channel: "telegram",
+      to: "telegram:123",
+    });
   });
 
   it("passes policySessionKey through to outbound delivery targets", async () => {

--- a/src/auto-reply/reply/route-reply.test.ts
+++ b/src/auto-reply/reply/route-reply.test.ts
@@ -273,6 +273,32 @@ describe("routeReply", () => {
     });
   });
 
+  it("preserves explicit hook-cancelled delivery suppression", async () => {
+    mocks.deliverOutboundPayloads.mockImplementationOnce(async (params) => {
+      params.onPayloadDeliveryOutcome?.({
+        index: 0,
+        status: "suppressed",
+        reason: "cancelled_by_message_sending_hook",
+        hookEffect: { cancelReason: "review hold" },
+      });
+      return [];
+    });
+
+    const res = await routeReply({
+      payload: { text: "hi" },
+      channel: "telegram",
+      to: "telegram:123",
+      cfg: {} as never,
+    });
+
+    expect(res.ok).toBe(true);
+    expect(mocks.deliverOutboundPayloads).toHaveBeenCalledOnce();
+    expectLastDeliveryFields({
+      channel: "telegram",
+      to: "telegram:123",
+    });
+  });
+
   it("passes policySessionKey through to outbound delivery targets", async () => {
     const cfg = {
       agents: {

--- a/src/auto-reply/reply/route-reply.ts
+++ b/src/auto-reply/reply/route-reply.ts
@@ -238,7 +238,10 @@ export async function routeReply(params: RouteReplyParams): Promise<RouteReplyRe
     if (send.status === "failed" || send.status === "partial_failed") {
       throw send.error;
     }
-    if (send.status === "suppressed") {
+    if (
+      send.status === "suppressed" &&
+      (send.reason === "no_visible_result" || send.reason === "adapter_returned_no_identity")
+    ) {
       return {
         ok: false,
         error: `Failed to route reply to ${channel}: no visible delivery result (${send.reason})`,

--- a/src/auto-reply/reply/route-reply.ts
+++ b/src/auto-reply/reply/route-reply.ts
@@ -238,6 +238,12 @@ export async function routeReply(params: RouteReplyParams): Promise<RouteReplyRe
     if (send.status === "failed" || send.status === "partial_failed") {
       throw send.error;
     }
+    if (send.status === "suppressed") {
+      return {
+        ok: false,
+        error: `Failed to route reply to ${channel}: no visible delivery result (${send.reason})`,
+      };
+    }
     const results = send.status === "sent" ? send.results : [];
 
     const last = results.at(-1);


### PR DESCRIPTION
## Summary
- Treat routed final replies with no visible outbound delivery result as failed instead of successful.
- Preserve pending final delivery state after failed final dispatch and record a non-null retry error.
- Keep restart recovery from marking `deliver: false` pending-final resume requests as clean delivery success.

## Root cause
Final reply state could be persisted before channel delivery, while route-level suppressed/no-result sends were reported as success. Restart recovery also recorded a clean pending-final attempt for a gateway resume request that explicitly used `deliver: false`, leaving `pendingFinalDeliveryLastError` null even though channel delivery had not been proven.

## Linked Issue
Fixes #84238.

## Why This Is Safe
The change only affects runtime accounting after a visible final reply has no routed or queued send proof. Successful deliveries still clear pending-final metadata, and pre-send policy suppression for silent/empty/reasoning replies remains unchanged.

## Security / Runtime Controls
No auth, allowlist, send-policy, prompt, credential, or gateway permission controls changed. The behavior is enforced in runtime delivery accounting, not by prompt text.

## Verification
- `CI=true pnpm test src/auto-reply/reply/route-reply.test.ts src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts src/agents/main-session-restart-recovery.test.ts`
- `git diff --check`
- `CI=true pnpm check:changed`

Behavior addressed: pending final delivery no longer treats a no-result routed send or `deliver: false` resume as clean success.
Real environment tested: local macOS checkout with mocked channel delivery regression coverage.
Exact steps or command run after this patch: `CI=true pnpm test src/auto-reply/reply/route-reply.test.ts src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts src/agents/main-session-restart-recovery.test.ts`
Evidence after fix: route reply returns failure for visible replies with no outbound result; final dispatch preserves pending-final state and writes a non-null last error; restart recovery persists a non-null pending-delivery note.
Observed result after fix: focused tests passed, `git diff --check` passed, and `CI=true pnpm check:changed` passed.
What was not tested: live Telegram DM delivery with real credentials; broader outbox retry-worker design remains unchanged.

## Out Of Scope
- Adding a new pending-final retry worker.
- Reworking the outbound durable queue state machine.
- Live Telegram credentialed E2E validation.


Made with [Cursor](https://cursor.com)