### PR TITLE
[Fix] Reject slow node event sends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ Docs: https://docs.openclaw.ai
 - CLI/gateway: include the running Gateway version in `gateway status` JSON output, preserving existing server metadata while falling back to status RPC data for read probes. Fixes #56222. Thanks @galiniliev.
 - Memory/search: close local embedding providers when active-memory searches time out so pending local model loads and embedding contexts are aborted and released. (#83858) Thanks @brokemac79.
 - CLI/nodes: request pending node surface approval scopes before `openclaw nodes approve` so exec-capable node approval can use admin-scoped Gateway credentials instead of failing with `missing scope: operator.admin`. (#84392) Thanks @joshavant.
+- Gateway: reject slow node event sends before outbound buffers grow unbounded and log the rejected payload diagnostic. (#84387) Thanks @samzong.
 - Agents: include bounded trajectory queued-writer diagnostics in `pi-trajectory-flush` timeout warnings so flush stalls show pending writes, queued bytes, and append state. Fixes #82961. (#82962) Thanks @galiniliev.
 - Agents/subagents: recover stale completion announces by retrying unsupported transcript-wait wakes without transcript waiting and forcing a message-tool handoff when the requester run is already stale. Fixes #83699. (#83700) Thanks @galiniliev.
 - Agents/subagents: constrain wildcard subagent target allowlists to configured agents while preserving explicitly listed compatibility targets. Fixes #84040. (#84357) Thanks @joshavant.

--- a/src/gateway/node-registry.test.ts
+++ b/src/gateway/node-registry.test.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from "node:events";
 import { describe, expect, it, vi } from "vitest";
 import { NodeRegistry, serializeEventPayload } from "./node-registry.js";
+import { MAX_BUFFERED_BYTES } from "./server-constants.js";
 import type { GatewayWsClient } from "./server/ws-types.js";
 
 function makeClient(
@@ -504,6 +505,26 @@ describe("gateway/node-registry", () => {
       '{"type":"event","event":"chat","payload":{"foo":"bar"}}',
       '{"type":"event","event":"heartbeat"}',
     ]);
+  });
+
+  it("rejects raw event sends when the node socket buffer is saturated", () => {
+    const registry = new NodeRegistry();
+    const socket = {
+      bufferedAmount: MAX_BUFFERED_BYTES + 1,
+      send: vi.fn(),
+      close: vi.fn(),
+    };
+    registry.register(
+      makeClient("conn-1", "node-1", [], {
+        socket: socket as unknown as GatewayWsClient["socket"],
+      }),
+      {},
+    );
+    const payload = serializeEventPayload({ foo: "bar" });
+
+    expect(registry.sendEventRaw("node-1", "chat", payload)).toBe(false);
+    expect(socket.send).not.toHaveBeenCalled();
+    expect(socket.close).toHaveBeenCalledWith(1008, "slow consumer");
   });
 
   it("refreshes effective live surface within the declared surface", () => {

--- a/src/gateway/node-registry.test.ts
+++ b/src/gateway/node-registry.test.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from "node:events";
 import { describe, expect, it, vi } from "vitest";
+import { onDiagnosticEvent, resetDiagnosticEventsForTest } from "../infra/diagnostic-events.js";
 import { NodeRegistry, serializeEventPayload } from "./node-registry.js";
 import { MAX_BUFFERED_BYTES } from "./server-constants.js";
 import type { GatewayWsClient } from "./server/ws-types.js";
@@ -508,6 +509,9 @@ describe("gateway/node-registry", () => {
   });
 
   it("rejects raw event sends when the node socket buffer is saturated", () => {
+    resetDiagnosticEventsForTest();
+    const diagnosticEvents: unknown[] = [];
+    const stopDiagnostics = onDiagnosticEvent((event) => diagnosticEvents.push(event));
     const registry = new NodeRegistry();
     const socket = {
       bufferedAmount: MAX_BUFFERED_BYTES + 1,
@@ -522,9 +526,26 @@ describe("gateway/node-registry", () => {
     );
     const payload = serializeEventPayload({ foo: "bar" });
 
-    expect(registry.sendEventRaw("node-1", "chat", payload)).toBe(false);
-    expect(socket.send).not.toHaveBeenCalled();
-    expect(socket.close).toHaveBeenCalledWith(1008, "slow consumer");
+    try {
+      expect(registry.sendEventRaw("node-1", "chat", payload)).toBe(false);
+      expect(socket.send).not.toHaveBeenCalled();
+      expect(socket.close).toHaveBeenCalledWith(1008, "slow consumer");
+      expect(diagnosticEvents).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "payload.large",
+            action: "rejected",
+            surface: "gateway.ws.outbound_buffer",
+            bytes: MAX_BUFFERED_BYTES + 1,
+            limitBytes: MAX_BUFFERED_BYTES,
+            reason: "ws_send_buffer_close",
+          }),
+        ]),
+      );
+    } finally {
+      stopDiagnostics();
+      resetDiagnosticEventsForTest();
+    }
   });
 
   it("refreshes effective live surface within the declared surface", () => {

--- a/src/gateway/node-registry.ts
+++ b/src/gateway/node-registry.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { MAX_BUFFERED_BYTES } from "./server-constants.js";
 import type { GatewayWsClient } from "./server/ws-types.js";
 
 export type NodeSession = {
@@ -72,6 +73,7 @@ type PingableSocket = {
 const SERIALIZED_EVENT_PAYLOAD = Symbol("openclaw.serializedEventPayload");
 const AUTHORIZED_SYSTEM_RUN_EVENT_GRACE_MS = 5 * 60 * 1000;
 const WEBSOCKET_OPEN_READY_STATE = 1;
+const SLOW_CONSUMER_CLOSE_CODE = 1008;
 
 export type SerializedEventPayload = {
   readonly json: string;
@@ -657,6 +659,9 @@ export class NodeRegistry {
   }
 
   private sendEventInternal(node: NodeSession, event: string, payload: unknown): boolean {
+    if (this.rejectSlowNodeSocket(node)) {
+      return false;
+    }
     try {
       node.client.socket.send(
         JSON.stringify({
@@ -683,6 +688,9 @@ export class NodeRegistry {
     ) {
       return false;
     }
+    if (this.rejectSlowNodeSocket(node)) {
+      return false;
+    }
     try {
       const payloadFragment = payloadJSON ? `,"payload":${payloadJSON.json}` : "";
       node.client.socket.send(
@@ -696,5 +704,17 @@ export class NodeRegistry {
 
   private sendEventToSession(node: NodeSession, event: string, payload: unknown): boolean {
     return this.sendEventInternal(node, event, payload);
+  }
+
+  private rejectSlowNodeSocket(node: NodeSession): boolean {
+    if (!(node.client.socket.bufferedAmount > MAX_BUFFERED_BYTES)) {
+      return false;
+    }
+    try {
+      node.client.socket.close(SLOW_CONSUMER_CLOSE_CODE, "slow consumer");
+    } catch {
+      /* ignore */
+    }
+    return true;
   }
 }

--- a/src/gateway/node-registry.ts
+++ b/src/gateway/node-registry.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { logRejectedLargePayload } from "../logging/diagnostic-payload.js";
 import { MAX_BUFFERED_BYTES } from "./server-constants.js";
 import type { GatewayWsClient } from "./server/ws-types.js";
 
@@ -710,6 +711,12 @@ export class NodeRegistry {
     if (!(node.client.socket.bufferedAmount > MAX_BUFFERED_BYTES)) {
       return false;
     }
+    logRejectedLargePayload({
+      surface: "gateway.ws.outbound_buffer",
+      bytes: node.client.socket.bufferedAmount,
+      limitBytes: MAX_BUFFERED_BYTES,
+      reason: "ws_send_buffer_close",
+    });
     try {
       node.client.socket.close(SLOW_CONSUMER_CLOSE_CODE, "slow consumer");
     } catch {


### PR DESCRIPTION
## Summary

- Problem: node outbound fanout accepted event writes even when the node WebSocket send buffer was already beyond the Gateway slow-consumer threshold.
- Solution: gate node event sends on `MAX_BUFFERED_BYTES`, close saturated node sockets with `1008 slow consumer`, and return `false` without writing another frame.
- Changed surface: `NodeRegistry` normal/raw event sends plus a regression test for raw node fanout.
- Scope boundary: no `node.invoke` pending-limit changes, no subscription/runtime fanout rewrite, and no protocol or chat delta changes.

## Motivation / Context

Slow node sockets should not be allowed to accumulate unbounded outbound event frames during fanout. The operator broadcast path already applies the Gateway slow-consumer threshold; node event sends now use the same bounded behavior at the send boundary.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Tests only
- [ ] Chore / CI / build
- [ ] Security

## Scope

- [ ] CLI
- [x] Gateway / orchestration
- [ ] Agent loop / tools
- [ ] Channels / messaging integrations
- [ ] Plugin runtime / SDK
- [ ] UI
- [ ] Docs
- [ ] Tests / infra

## Linked Issue / PR

N/A - no linked issue.

- [x] This PR fixes a bug or regression
- [ ] This PR is follow-up / cleanup
- [ ] This PR is exploratory and should not land as-is

## Real behavior proof

Behavior addressed: a real node WebSocket whose server-side send buffer is already over the Gateway threshold is closed as a slow consumer, and the rejected node event is not written.

Real environment tested: local OpenClaw checkout on macOS, using an actual `ws` `WebSocketServer` plus `WebSocket` client, the Gateway `createGatewayNodeSessionRuntime`, and the patched `NodeRegistry`. The client TCP read side was paused with `_socket.pause()` so the server socket accumulated real WebSocket backpressure instead of using a fake `bufferedAmount`.

Exact steps or command run after this patch: `node --input-type=module --import tsx -` with a one-off proof script that starts a local WebSocket server/client pair, pauses the client TCP reader, registers the server socket as a node through `createGatewayNodeSessionRuntime`, subscribes that node to `agent:main:main`, sends subscribed `chat` frames until `serverSocket.bufferedAmount > MAX_BUFFERED_BYTES`, then calls `NodeRegistry.sendEventRaw(...)` with a final `chat` payload.

Evidence after fix:

```json
{
  "transport": "real ws WebSocketServer + WebSocket client; client TCP read paused",
  "acceptedFramesBeforeThreshold": 13,
  "maxBufferedBytes": 52428800,
  "bufferedAmountBeforeRejectedSend": 54527815,
  "rejectedSendReturned": false,
  "serverSocketReadyStateAfterRejectedSend": 2,
  "sendCallsDeltaOnRejectedSend": 0,
  "bufferedAmountDeltaOnRejectedSend": 17,
  "closeCalledWith": {
    "code": 1008,
    "reason": "slow consumer"
  },
  "clientMessagesObservedBeforeResume": 0,
  "clientSawRejectedFrameBeforeResume": false
}
```

Observed result after fix: the socket crossed the 50 MiB threshold at `54527815` bytes, the rejected `sendEventRaw()` returned `false`, no additional WebSocket `send` call happened for that rejected event, and the actual server socket was moved to `CLOSING` with `close(1008, "slow consumer")`.

What was not tested: a full managed Gateway process with a real paired node app on a remote slow network. This proof uses real local WebSocket transport and the Gateway node-session runtime path, but not the production pairing/client process.

Before evidence: the pre-fix regression returned `true` and wrote one frame with `bufferedAmount = Number.MAX_SAFE_INTEGER`; the added regression failed before the implementation with `expected true to be false`.

## Root Cause

The node event send path in `NodeRegistry` did not consult WebSocket `bufferedAmount` before writing frames, while the operator broadcast path already rejected slow consumers. Subscription fanout preserved one-time payload serialization, but the final node socket send boundary had no slow-consumer guardrail.

Missing detection: there was no node-registry regression covering a saturated node socket.

## Regression Test Plan

- [x] Unit test added or updated
- [ ] Integration / E2E test added or updated
- [ ] Existing test coverage is sufficient
- [ ] Not testable in automation

Target: `src/gateway/node-registry.test.ts`

Scenario covered: a fake node socket with `bufferedAmount = MAX_BUFFERED_BYTES + 1` rejects a raw event send, avoids `socket.send`, and closes the socket with `1008 slow consumer`.

Existing guardrail: the same file still verifies the raw event envelope shape for successful sends.

## User-visible / Behavior Changes

Slow node connections whose outbound WebSocket buffer exceeds the Gateway threshold are closed instead of accepting more node event frames.

## Diagram / Data Flow

Before:

```text
Gateway fanout -> saturated node socket -> additional frame queued
```

After:

```text
Gateway fanout -> NodeRegistry buffer check -> close slow node socket -> no new frame
```

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

N/A - all answers are No.

## Repro + Verification

Environment: local macOS checkout, Node through the repo wrapper for tests, plus a real local `ws` server/client pair for transport proof.

Steps:

1. Run the real WebSocket proof script described in the Real behavior proof section.
2. Run `node scripts/run-vitest.mjs src/gateway/node-registry.test.ts --reporter=verbose`.
3. Run `node scripts/run-vitest.mjs src/gateway/gateway-misc.test.ts --testNamePattern "runtime forwards subscribed node payload json|routes events" --reporter=verbose`.
4. Run `git diff --check`.

Expected: the real saturated node socket rejects the final event without a `send` call and closes with `1008 slow consumer`; focused regression tests pass.

Actual: expected slow-consumer behavior observed in the real WebSocket proof output above; focused test runs passed.

## Evidence

- [x] Failing test / log before fix
- [x] Passing test / log after fix
- [ ] Screenshot / recording
- [ ] CI run
- [x] Manual QA notes

Additional checks run:

- `node scripts/run-vitest.mjs src/gateway/node-registry.test.ts --reporter=verbose` (`Test Files 3 passed (3)`, `Tests 51 passed (51)`)
- `node scripts/run-vitest.mjs src/gateway/gateway-misc.test.ts --testNamePattern "runtime forwards subscribed node payload json|routes events" --reporter=verbose`
- `git diff --check`
- `codex review --uncommitted`
- pre-ship review after commit: no must-fix issues

## Human Verification

Verified scenarios:

- Real local WebSocket backpressure with paused client TCP reads and server-side `bufferedAmount > MAX_BUFFERED_BYTES`.
- Rejected raw node event returned `false`, made zero additional `send` calls, and closed the real server socket with `1008 slow consumer`.
- Red/green regression for saturated raw node event sends.
- Full `src/gateway/node-registry.test.ts` focused suite.
- Subscription fanout target behavior in `src/gateway/gateway-misc.test.ts`.
- `codex-review` clean pass.
- Pre-ship review found no must-fix issues.

Edge cases considered:

- Invalid raw payload still returns `false` before the slow-buffer check matters.
- Missing node still returns `false`.
- Normal raw event envelope behavior is unchanged.
- Saturated node socket is closed instead of accepting another event frame.

Not verified:

- Full managed Gateway with a real paired remote node app under OS/network backpressure.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

N/A - no existing review conversations were addressed while preparing this PR.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

N/A - no migration is required.

## Risks / Mitigations

Risk: slow nodes are disconnected sooner when their outbound WebSocket buffer remains over the Gateway threshold.

Mitigation: this uses the existing Gateway slow-consumer threshold and close policy, and the regression test locks the no-send behavior.
