### PR TITLE
Gateway: add oc heartbeat agents endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway: add `GET /oc/heartbeat/agents` so LogicOS can read per-agent last-heartbeat timestamps from the in-memory heartbeat runner state.
 - Plugins/hooks: apply a default 30-second timeout to `before_compaction` and `after_compaction` hooks so a hung plugin handler no longer blocks compaction completion. (#84153)
 - Plugins/perf: thread explicit plugin discovery results through `loadBundledCapabilityRuntimeRegistry`, `resolveBundledPluginSources`, and `listChannelCatalogEntries` so callers that already hold a discovery result skip redundant filesystem walks. Thanks @SebTardif.
 - harden update restart script creation [AI]. (#84088) Thanks @pgondhi987.

--- a/src/gateway/oc-heartbeat-agents-http.test.ts
+++ b/src/gateway/oc-heartbeat-agents-http.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from "vitest";
+import { AUTH_NONE, createTestGatewayServer, sendRequest } from "./server-http.test-harness.js";
+
+describe("oc heartbeat agents http", () => {
+  it("returns the heartbeat runner snapshot batch", async () => {
+    const getAgentSnapshots = vi.fn(() => [
+      { agentId: "zeta", lastRunStartedAtMs: undefined },
+      { agentId: "alpha", lastRunStartedAtMs: 1_700_000_000_000 },
+    ]);
+    const server = createTestGatewayServer({
+      resolvedAuth: AUTH_NONE,
+      overrides: {
+        getHeartbeatRunner: () => ({
+          stop: () => {},
+          updateConfig: () => {},
+          getAgentSnapshots,
+        }),
+      },
+    });
+
+    const response = await sendRequest(server, {
+      path: "/oc/heartbeat/agents",
+      method: "GET",
+      remoteAddress: "127.0.0.1",
+    });
+
+    expect(response.res.statusCode).toBe(200);
+    expect(JSON.parse(response.getBody())).toEqual({
+      agents: [
+        { agentId: "alpha", lastSeenAt: "2023-11-14T22:13:20.000Z" },
+        { agentId: "zeta", lastSeenAt: null },
+      ],
+    });
+    expect(getAgentSnapshots).toHaveBeenCalledTimes(1);
+  });
+
+  it("requires GET", async () => {
+    const server = createTestGatewayServer({
+      resolvedAuth: AUTH_NONE,
+      overrides: {
+        getHeartbeatRunner: () => ({
+          stop: () => {},
+          updateConfig: () => {},
+          getAgentSnapshots: () => [],
+        }),
+      },
+    });
+
+    const response = await sendRequest(server, {
+      path: "/oc/heartbeat/agents",
+      method: "POST",
+      remoteAddress: "127.0.0.1",
+    });
+
+    expect(response.res.statusCode).toBe(405);
+  });
+
+  it("rejects remote unauthenticated callers when gateway auth is none", async () => {
+    const server = createTestGatewayServer({
+      resolvedAuth: AUTH_NONE,
+      overrides: {
+        getHeartbeatRunner: () => ({
+          stop: () => {},
+          updateConfig: () => {},
+          getAgentSnapshots: () => [],
+        }),
+      },
+    });
+
+    const response = await sendRequest(server, {
+      path: "/oc/heartbeat/agents",
+      method: "GET",
+      remoteAddress: "203.0.113.10",
+    });
+
+    expect(response.res.statusCode).toBe(401);
+  });
+});

--- a/src/gateway/oc-heartbeat-agents-http.ts
+++ b/src/gateway/oc-heartbeat-agents-http.ts
@@ -1,0 +1,65 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { getRuntimeConfig } from "../config/io.js";
+import type { HeartbeatRunner } from "../infra/heartbeat-runner.js";
+import type { AuthRateLimiter } from "./auth-rate-limit.js";
+import type { ResolvedGatewayAuth } from "./auth.js";
+import { isLocalDirectRequest } from "./auth.js";
+import { sendGatewayAuthFailure, sendJson, sendMethodNotAllowed } from "./http-common.js";
+import { authorizeGatewayHttpRequestOrReply } from "./http-utils.js";
+
+export async function handleOcHeartbeatAgentsHttpRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  opts: {
+    auth: ResolvedGatewayAuth;
+    heartbeatRunner: HeartbeatRunner;
+    trustedProxies?: string[];
+    allowRealIpFallback?: boolean;
+    rateLimiter?: AuthRateLimiter;
+  },
+): Promise<boolean> {
+  const url = new URL(req.url ?? "/", "http://localhost");
+  if (url.pathname !== "/oc/heartbeat/agents") {
+    return false;
+  }
+
+  if (req.method !== "GET") {
+    sendMethodNotAllowed(res, "GET");
+    return true;
+  }
+
+  const cfg = getRuntimeConfig();
+  const trustedProxies = opts.trustedProxies ?? cfg.gateway?.trustedProxies;
+  const allowRealIpFallback = opts.allowRealIpFallback ?? cfg.gateway?.allowRealIpFallback;
+  const isLocal = isLocalDirectRequest(req, trustedProxies, allowRealIpFallback);
+  if (!isLocal) {
+    if (opts.auth.mode === "none") {
+      sendGatewayAuthFailure(res, { ok: false, reason: "unauthorized" });
+      return true;
+    }
+    const requestAuth = await authorizeGatewayHttpRequestOrReply({
+      req,
+      res,
+      auth: opts.auth,
+      trustedProxies,
+      allowRealIpFallback,
+      rateLimiter: opts.rateLimiter,
+    });
+    if (!requestAuth) {
+      return true;
+    }
+  }
+
+  const agents = opts.heartbeatRunner
+    .getAgentSnapshots()
+    .toSorted((a, b) => a.agentId.localeCompare(b.agentId))
+    .map((agent) => ({
+      agentId: agent.agentId,
+      lastSeenAt:
+        agent.lastRunStartedAtMs === undefined
+          ? null
+          : new Date(agent.lastRunStartedAtMs).toISOString(),
+    }));
+  sendJson(res, 200, { agents });
+  return true;
+}

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -80,6 +80,9 @@ let sessionHistoryHttpModulePromise:
   | Promise<typeof import("./sessions-history-http.js")>
   | undefined;
 let sessionKillHttpModulePromise: Promise<typeof import("./session-kill-http.js")> | undefined;
+let ocHeartbeatAgentsHttpModulePromise:
+  | Promise<typeof import("./oc-heartbeat-agents-http.js")>
+  | undefined;
 let toolsInvokeHttpModulePromise: Promise<typeof import("./tools-invoke-http.js")> | undefined;
 let pluginNodeCapabilityAuthModulePromise:
   | Promise<typeof import("./server/plugin-node-capability-auth.js")>
@@ -132,6 +135,11 @@ function getSessionHistoryHttpModule() {
 function getSessionKillHttpModule() {
   sessionKillHttpModulePromise ??= import("./session-kill-http.js");
   return sessionKillHttpModulePromise;
+}
+
+function getOcHeartbeatAgentsHttpModule() {
+  ocHeartbeatAgentsHttpModulePromise ??= import("./oc-heartbeat-agents-http.js");
+  return ocHeartbeatAgentsHttpModulePromise;
 }
 
 function getToolsInvokeHttpModule() {
@@ -490,6 +498,7 @@ export function createGatewayHttpServer(opts: {
   /** Optional rate limiter for auth brute-force protection. */
   rateLimiter?: AuthRateLimiter;
   getReadiness?: ReadinessChecker;
+  getHeartbeatRunner?: () => import("../infra/heartbeat-runner.js").HeartbeatRunner | undefined;
   getRuntimeConfig?: () => OpenClawConfig;
   tlsOptions?: TlsOptions;
 }): HttpServer {
@@ -610,6 +619,23 @@ export function createGatewayHttpServer(opts: {
           run: async () =>
             (await getEmbeddingsHttpModule()).handleOpenAiEmbeddingsHttpRequest(req, res, {
               auth: resolvedAuth,
+              trustedProxies,
+              allowRealIpFallback,
+              rateLimiter,
+            }),
+        });
+      }
+      if (scopedRequestPath === "/oc/heartbeat/agents") {
+        requestStages.push({
+          name: "oc-heartbeat-agents",
+          run: async () =>
+            (await getOcHeartbeatAgentsHttpModule()).handleOcHeartbeatAgentsHttpRequest(req, res, {
+              auth: resolvedAuth,
+              heartbeatRunner: opts.getHeartbeatRunner?.() ?? {
+                stop: () => {},
+                updateConfig: () => {},
+                getAgentSnapshots: () => [],
+              },
               trustedProxies,
               allowRealIpFallback,
               rateLimiter,

--- a/src/gateway/server-runtime-handles.ts
+++ b/src/gateway/server-runtime-handles.ts
@@ -45,6 +45,7 @@ export function createGatewayServerMutableState(): GatewayServerMutableState {
     heartbeatRunner: {
       stop: () => {},
       updateConfig: (_cfg: OpenClawConfig) => {},
+      getAgentSnapshots: () => [],
     } satisfies HeartbeatRunner,
     stopGatewayUpdateCheck: () => {},
     tailscaleCleanup: null as (() => Promise<void>) | null,

--- a/src/gateway/server-runtime-services.test.ts
+++ b/src/gateway/server-runtime-services.test.ts
@@ -4,6 +4,7 @@ const hoisted = vi.hoisted(() => {
   const heartbeatRunner = {
     stop: vi.fn(),
     updateConfig: vi.fn(),
+    getAgentSnapshots: vi.fn(() => []),
   };
   const stopModelPricingRefresh = vi.fn();
   return {

--- a/src/gateway/server-runtime-services.ts
+++ b/src/gateway/server-runtime-services.ts
@@ -30,6 +30,7 @@ function createNoopHeartbeatRunner(): HeartbeatRunner {
   return {
     stop: () => {},
     updateConfig: (_cfg: OpenClawConfig) => {},
+    getAgentSnapshots: () => [],
   };
 }
 

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -2,6 +2,7 @@ import type { IncomingMessage, Server as HttpServer, ServerResponse } from "node
 import type { Duplex } from "node:stream";
 import { WebSocketServer } from "ws";
 import type { CliDeps } from "../cli/deps.types.js";
+import type { HeartbeatRunner } from "../infra/heartbeat-runner.js";
 import type { createSubsystemLogger } from "../logging/subsystem.js";
 import type { PluginRegistry } from "../plugins/registry.js";
 import {
@@ -86,6 +87,7 @@ export async function createGatewayRuntimeState(params: {
   pluginRegistry: PluginRegistry;
   getPluginRouteRegistry?: () => PluginRegistry;
   getGatewayRequestContext?: () => GatewayRequestContext | undefined;
+  getHeartbeatRunner?: () => HeartbeatRunner | undefined;
   pinChannelRegistry?: boolean;
   deps: CliDeps;
   log: { info: (msg: string) => void; warn: (msg: string) => void };
@@ -250,6 +252,7 @@ export async function createGatewayRuntimeState(params: {
         getResolvedAuth: params.getResolvedAuth,
         rateLimiter: params.rateLimiter,
         getReadiness: params.getReadiness,
+        getHeartbeatRunner: params.getHeartbeatRunner,
         tlsOptions: params.gatewayTls?.enabled ? params.gatewayTls.tlsOptions : undefined,
       });
       // Attach upgrade handler BEFORE listening to prevent race condition

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -891,6 +891,7 @@ export async function startGatewayServer(
       pluginRegistry,
       getPluginRouteRegistry: () => pluginRegistry,
       getGatewayRequestContext: () => currentPluginRegistryGatewayContext,
+      getHeartbeatRunner: () => runtimeState?.heartbeatRunner,
       pinChannelRegistry: !minimalTestGateway,
       deps,
       log,

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -291,9 +291,15 @@ function activeHoursConfigMatch(a?: ActiveHoursSchedule, b?: ActiveHoursSchedule
   return a.start === b.start && a.end === b.end && a.timezone === b.timezone;
 }
 
+export type HeartbeatRunnerAgentSnapshot = {
+  agentId: string;
+  lastRunStartedAtMs: number | undefined;
+};
+
 export type HeartbeatRunner = {
   stop: () => void;
   updateConfig: (cfg: OpenClawConfig) => void;
+  getAgentSnapshots: () => readonly HeartbeatRunnerAgentSnapshot[];
 };
 
 function resolveHeartbeatSchedulerSeed(explicitSeed?: string) {
@@ -2506,6 +2512,14 @@ export function startHeartbeatRunner(opts: {
   const disposeWakeHandler = setHeartbeatWakeHandler(wakeHandler);
   updateConfig(state.cfg);
 
+  const getAgentSnapshots = () =>
+    Array.from(state.agents.values())
+      .toSorted((a, b) => a.agentId.localeCompare(b.agentId))
+      .map((agent) => ({
+        agentId: agent.agentId,
+        lastRunStartedAtMs: agent.lastRunStartedAtMs,
+      }));
+
   const cleanup = () => {
     if (state.stopped) {
       return;
@@ -2520,5 +2534,5 @@ export function startHeartbeatRunner(opts: {
 
   opts.abortSignal?.addEventListener("abort", cleanup, { once: true });
 
-  return { stop: cleanup, updateConfig };
+  return { stop: cleanup, updateConfig, getAgentSnapshots };
 }


### PR DESCRIPTION
Summary
- Added `GET /oc/heartbeat/agents`, a read-only gateway endpoint that returns per-agent `lastSeenAt` values from the live in-memory heartbeat runner.
- Exposed a small snapshot helper on the heartbeat runner so the HTTP layer can read the authoritative runtime state without touching session storage or heartbeat logs.
- Kept the route local-first: localhost requests are allowed, and non-local requests still require gateway auth.

Verification
- `pnpm test src/gateway/oc-heartbeat-agents-http.test.ts src/gateway/server-runtime-services.test.ts`
- `pnpm build`
- Live curl against a started gateway: `curl -sS -D - http://127.0.0.1:18999/oc/heartbeat/agents -o -`

Behavior addressed: LogicOS can now cross-check OpenClaw's authoritative per-agent heartbeat state.
Real environment tested: local gateway process on `127.0.0.1:18999`.
Exact steps or command run after this patch: started `openclaw gateway run --port 18999 --bind loopback --verbose` with auth mode none and queried `/oc/heartbeat/agents`.
Evidence after fix: endpoint returned `200 OK` with `{"agents":[{"agentId":"main","lastSeenAt":null}]}`.
Observed result after fix: gateway started cleanly, served the new route, and preserved existing health/plugin startup behavior.
What was not tested: authenticated remote access path and non-local shared-secret auth path.
