### PR TITLE
Sanitize provider catalog API keys

### DIFF
--- a/src/plugin-sdk/provider-entry.test.ts
+++ b/src/plugin-sdk/provider-entry.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { NON_ENV_SECRETREF_MARKER } from "../agents/model-auth-markers.js";
 import type { ModelDefinitionConfig } from "../config/types.models.js";
 import { capturePluginRegistration } from "../plugins/captured-registration.js";
 import type { ProviderCatalogContext } from "../plugins/types.js";
@@ -111,7 +112,7 @@ describe("defineSingleProviderPluginEntry", () => {
     expect(catalog).toEqual({
       provider: {
         api: "openai-completions",
-        apiKey: "test-key",
+        apiKey: NON_ENV_SECRETREF_MARKER,
         baseUrl: "https://api.demo.test/v1",
         models: [createModel("default", "Default")],
       },
@@ -231,7 +232,7 @@ describe("defineSingleProviderPluginEntry", () => {
     expect(catalog).toEqual({
       provider: {
         api: "openai-completions",
-        apiKey: "test-key",
+        apiKey: NON_ENV_SECRETREF_MARKER,
         baseUrl: "https://override.test/v1",
         models: [createModel("router", "Router")],
       },

--- a/src/plugins/provider-catalog.test.ts
+++ b/src/plugins/provider-catalog.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
+import { resolveUsableCustomProviderApiKey } from "../agents/model-auth.js";
 import { NON_ENV_SECRETREF_MARKER } from "../agents/model-auth-markers.js";
+import { planOpenClawModelsJsonWithDeps } from "../agents/models-config.plan.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type { ModelProviderConfig } from "../config/types.models.js";
 import {
@@ -245,5 +247,61 @@ describe("buildSingleProviderApiKeyCatalog", () => {
       }),
       expected: createPairedCatalogProviders("OPENAI_API_KEY"),
     });
+  });
+
+  it("keeps raw catalog credentials out of generated models.json while source config auth remains usable", async () => {
+    const rawApiKey = "sk-provider-catalog-proof-secret";
+    const catalogResult = await buildSingleProviderApiKeyCatalog({
+      ctx: createCatalogContext({
+        apiKeys: { "test-provider": rawApiKey },
+      }),
+      providerId: "test-provider",
+      buildProvider: () => createProviderConfig(),
+    });
+    if (!catalogResult || !("provider" in catalogResult)) {
+      throw new Error("expected provider catalog result");
+    }
+
+    const plan = await planOpenClawModelsJsonWithDeps(
+      {
+        cfg: {},
+        agentDir: "/tmp/openclaw-provider-catalog-proof",
+        env: {},
+        existingRaw: "",
+        existingParsed: null,
+      },
+      {
+        resolveImplicitProviders: async () => ({
+          "test-provider": catalogResult.provider,
+        }),
+      },
+    );
+
+    expect(plan.action).toBe("write");
+    if (plan.action !== "write") {
+      throw new Error(`expected models.json write plan, got ${plan.action}`);
+    }
+    expect(plan.contents).not.toContain(rawApiKey);
+    const parsed = JSON.parse(plan.contents) as {
+      providers: Record<string, { apiKey?: string }>;
+    };
+    expect(parsed.providers["test-provider"]?.apiKey).toBe(NON_ENV_SECRETREF_MARKER);
+
+    const sourceAuth = resolveUsableCustomProviderApiKey({
+      cfg: {
+        models: {
+          providers: {
+            "test-provider": {
+              ...createProviderConfig(),
+              apiKey: rawApiKey,
+            },
+          },
+        },
+      },
+      provider: "test-provider",
+      env: {},
+    });
+    expect(sourceAuth?.apiKey).toBe(rawApiKey);
+    expect(sourceAuth?.source).toBe("models.json");
   });
 });

--- a/src/plugins/provider-catalog.test.ts
+++ b/src/plugins/provider-catalog.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { NON_ENV_SECRETREF_MARKER } from "../agents/model-auth-markers.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type { ModelProviderConfig } from "../config/types.models.js";
 import {
@@ -154,12 +155,21 @@ describe("buildSingleProviderApiKeyCatalog", () => {
       expected: null,
     },
     {
-      name: "adds api key to the built provider",
+      name: "adds a safe marker for raw api keys",
       ctx: createCatalogContext({
         apiKeys: { "test-provider": "secret-key" },
       }),
       expected: createSingleCatalogProvider({
-        apiKey: "secret-key",
+        apiKey: NON_ENV_SECRETREF_MARKER,
+      }),
+    },
+    {
+      name: "preserves env var api key markers",
+      ctx: createCatalogContext({
+        apiKeys: { "test-provider": "OPENAI_API_KEY" },
+      }),
+      expected: createSingleCatalogProvider({
+        apiKey: "OPENAI_API_KEY",
       }),
     },
     {
@@ -180,7 +190,7 @@ describe("buildSingleProviderApiKeyCatalog", () => {
       allowExplicitBaseUrl: true,
       expected: createSingleCatalogProvider({
         baseUrl: "https://override.example/v1/",
-        apiKey: "secret-key",
+        apiKey: NON_ENV_SECRETREF_MARKER,
       }),
     },
     {
@@ -201,7 +211,7 @@ describe("buildSingleProviderApiKeyCatalog", () => {
       allowExplicitBaseUrl: true,
       expected: createSingleCatalogProvider({
         baseUrl: "https://api.z.ai/custom",
-        apiKey: "secret-key",
+        apiKey: NON_ENV_SECRETREF_MARKER,
       }),
       providerId: "z-ai",
       buildProvider: () => createProviderConfig({ baseUrl: "https://default.example/zai" }),
@@ -224,7 +234,16 @@ describe("buildSingleProviderApiKeyCatalog", () => {
       ctx: createCatalogContext({
         apiKeys: { "test-provider": "secret-key" },
       }),
-      expected: createPairedCatalogProviders("secret-key"),
+      expected: createPairedCatalogProviders(NON_ENV_SECRETREF_MARKER),
+    });
+  });
+
+  it("preserves env markers for each paired provider", async () => {
+    await expectPairedCatalogResult({
+      ctx: createCatalogContext({
+        apiKeys: { "test-provider": "OPENAI_API_KEY" },
+      }),
+      expected: createPairedCatalogProviders("OPENAI_API_KEY"),
     });
   });
 });

--- a/src/plugins/provider-catalog.ts
+++ b/src/plugins/provider-catalog.ts
@@ -1,4 +1,9 @@
 import { normalizeProviderId } from "../agents/provider-id.js";
+import {
+  isKnownEnvApiKeyMarker,
+  isNonSecretApiKeyMarker,
+  NON_ENV_SECRETREF_MARKER,
+} from "../agents/model-auth-markers.js";
 import type { ModelProviderConfig } from "../config/types.js";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -20,6 +25,14 @@ export function findCatalogTemplate(params: {
       ),
     )
     .find((entry) => entry !== undefined);
+}
+
+function sanitizeCatalogApiKeyMarker(apiKey: string): string {
+  const trimmed = apiKey.trim();
+  if (isKnownEnvApiKeyMarker(trimmed) || isNonSecretApiKeyMarker(trimmed)) {
+    return trimmed;
+  }
+  return NON_ENV_SECRETREF_MARKER;
 }
 
 export async function buildSingleProviderApiKeyCatalog(params: {
@@ -46,7 +59,7 @@ export async function buildSingleProviderApiKeyCatalog(params: {
     provider: {
       ...(await params.buildProvider()),
       ...(explicitBaseUrl ? { baseUrl: explicitBaseUrl } : {}),
-      apiKey,
+      apiKey: sanitizeCatalogApiKeyMarker(apiKey),
     },
   };
 }
@@ -66,7 +79,10 @@ export async function buildPairedProviderApiKeyCatalog(params: {
   const providers = await params.buildProviders();
   return {
     providers: Object.fromEntries(
-      Object.entries(providers).map(([id, provider]) => [id, { ...provider, apiKey }]),
+      Object.entries(providers).map(([id, provider]) => [
+        id,
+        { ...provider, apiKey: sanitizeCatalogApiKeyMarker(apiKey) },
+      ]),
     ),
   };
 }


### PR DESCRIPTION
## Summary

Fixes part of #11829 by preventing provider catalog helpers from writing raw API key values into provider configs that can later be serialized into `models.json`.

The provider catalog still uses `resolveProviderApiKey(...)` to decide whether authenticated catalog discovery is available, but now stores only safe persisted markers:

- known environment variable markers such as `OPENAI_API_KEY`
- existing non-secret auth markers
- `secretref-managed` for raw resolved secrets

This keeps runtime authentication separate from model catalog serialization and avoids leaking literal API keys into model-visible config.

## Real behavior proof

- Behavior or issue addressed: Provider catalog helpers no longer persist a raw resolved provider API key into the generated `models.json` provider config, while the original source config auth path still resolves the credential.
- Real environment tested: Windows 11 local OpenClaw checkout on this PR branch, Node v24.14.0, pnpm dependencies installed from the repository lockfile.
- Exact steps or command run after this patch: Ran a local `node --import tsx --input-type=module` terminal command that imports `buildSingleProviderApiKeyCatalog`, threads the result through `planOpenClawModelsJsonWithDeps`, and checks `resolveUsableCustomProviderApiKey` against the original source config.
- Evidence after fix: Terminal output from the after-patch command:

```text
{
  "generatedModelsJsonLiteralSecretPresent": false,
  "generatedModelsJsonApiKey": "secretref-managed",
  "expectedMarker": "secretref-managed",
  "sourceConfigAuthResolved": true,
  "sourceConfigAuthSource": "models.json"
}
```

- Observed result after fix: The generated `models.json` planning output did not contain the literal raw key, persisted `secretref-managed` for the provider `apiKey`, and the source config auth resolver still resolved the original credential successfully.
- What was not tested: No live third-party provider request was sent; this proof exercises the local OpenClaw catalog/planner/auth path without contacting an external model API.

This PR is intentionally a helper-boundary defense for provider catalog helpers that currently copy resolved `apiKey` values into returned provider configs. It can land as a narrow defense-in-depth fix, or maintainers can choose to fold it into a broader planner-level Layer 1 PR if they prefer one canonical boundary.

## Validation

```sh
corepack pnpm exec vitest run src/plugins/provider-catalog.test.ts --reporter dot --pool forks --testTimeout 30000
```

Result after the proof follow-up:

```text
Test Files  1 passed (1)
Tests       10 passed (10)
```