### PR TITLE
Fix node approval scope requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 - Installer/Windows: launch `install.ps1` onboarding as an attached child process so fresh native Windows installs do not freeze visibly at `Starting setup...` or corrupt the wizard's terminal rendering.
 - CLI/update: keep restart health checks working across one-version CLI/Gateway protocol skew and use the managed Gateway service Node for all follow-up commands even when the package root is unchanged, so `openclaw update` no longer silently switches the gateway to a different Node binary when multiple Node installations are present. Thanks @amknight.
 - Memory/search: close local embedding providers when active-memory searches time out so pending local model loads and embedding contexts are aborted and released. (#83858) Thanks @brokemac79.
+- CLI/nodes: request pending node surface approval scopes before `openclaw nodes approve` so exec-capable node approval can use admin-scoped Gateway credentials instead of failing with `missing scope: operator.admin`. (#84392) Thanks @joshavant.
 
 - Agents: include bounded trajectory queued-writer diagnostics in `pi-trajectory-flush` timeout warnings so flush stalls show pending writes, queued bytes, and append state. Fixes #82961. (#82962) Thanks @galiniliev.
 - Agents/subagents: recover stale completion announces by retrying unsupported transcript-wait wakes without transcript waiting and forcing a message-tool handoff when the requester run is already stale. Fixes #83699. (#83700) Thanks @galiniliev.

--- a/src/cli/nodes-cli/register.pairing.ts
+++ b/src/cli/nodes-cli/register.pairing.ts
@@ -1,4 +1,6 @@
 import type { Command } from "commander";
+import type { OperatorScope } from "../../gateway/method-scopes.js";
+import { resolveNodePairApprovalScopes } from "../../infra/node-pairing-authz.js";
 import { defaultRuntime } from "../../runtime.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import { getTerminalTableWidth } from "../../terminal/table.js";
@@ -6,8 +8,60 @@ import { formatCliCommand } from "../command-format.js";
 import { getNodesTheme, runNodesCommand } from "./cli-utils.js";
 import { parsePairingList } from "./format.js";
 import { renderPendingPairingRequestsTable } from "./pairing-render.js";
-import { callGatewayCli, nodesCallOpts, resolveNodeId } from "./rpc.js";
-import type { NodesRpcOpts } from "./types.js";
+import {
+  callGatewayCli,
+  callNodePairApprovalGatewayCli,
+  nodesCallOpts,
+  resolveNodeId,
+} from "./rpc.js";
+import type { NodesRpcOpts, PendingRequest } from "./types.js";
+
+const DEFAULT_NODE_PAIR_APPROVE_SCOPES: OperatorScope[] = ["operator.pairing"];
+const NODE_PAIR_APPROVE_SCOPE_SET = new Set<OperatorScope>([
+  "operator.pairing",
+  "operator.write",
+  "operator.admin",
+]);
+
+function normalizeNodePairApproveScopes(scopes: unknown): OperatorScope[] {
+  const normalized = new Set<OperatorScope>(DEFAULT_NODE_PAIR_APPROVE_SCOPES);
+  if (!Array.isArray(scopes)) {
+    return [...normalized];
+  }
+  for (const scope of scopes) {
+    if (typeof scope !== "string") {
+      continue;
+    }
+    if (!NODE_PAIR_APPROVE_SCOPE_SET.has(scope as OperatorScope)) {
+      continue;
+    }
+    normalized.add(scope as OperatorScope);
+  }
+  return [...normalized];
+}
+
+async function resolveApproveScopesForRequest(
+  opts: NodesRpcOpts,
+  requestId: string,
+): Promise<OperatorScope[]> {
+  try {
+    const result = await callNodePairApprovalGatewayCli(
+      "node.pair.list",
+      opts,
+      {},
+      { scopes: DEFAULT_NODE_PAIR_APPROVE_SCOPES },
+    );
+    const { pending } = parsePairingList(result);
+    const request = pending.find((candidate: PendingRequest) => candidate.requestId === requestId);
+    const scopes = normalizeNodePairApproveScopes(request?.requiredApproveScopes);
+    if (scopes.length > DEFAULT_NODE_PAIR_APPROVE_SCOPES.length) {
+      return scopes;
+    }
+    return resolveNodePairApprovalScopes(request?.commands) as OperatorScope[];
+  } catch {
+    return [...DEFAULT_NODE_PAIR_APPROVE_SCOPES];
+  }
+}
 
 export function registerNodesPairingCommands(nodes: Command) {
   nodesCallOpts(
@@ -49,9 +103,17 @@ export function registerNodesPairingCommands(nodes: Command) {
       .argument("<requestId>", "Pending request id")
       .action(async (requestId: string, opts: NodesRpcOpts) => {
         await runNodesCommand("approve", async () => {
-          const result = await callGatewayCli("node.pair.approve", opts, {
-            requestId,
-          });
+          const scopes = await resolveApproveScopesForRequest(opts, requestId);
+          const result = await callNodePairApprovalGatewayCli(
+            "node.pair.approve",
+            opts,
+            {
+              requestId,
+            },
+            {
+              scopes,
+            },
+          );
           defaultRuntime.writeJson(result);
         });
       }),

--- a/src/cli/nodes-cli/rpc.runtime.ts
+++ b/src/cli/nodes-cli/rpc.runtime.ts
@@ -1,7 +1,10 @@
 import { callGateway } from "../../gateway/call.js";
+import type { OperatorScope } from "../../gateway/method-scopes.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../../gateway/protocol/client-info.js";
 import { withProgress } from "../progress.js";
 import type { NodesRpcOpts } from "./types.js";
+
+const NODE_PAIR_APPROVAL_GATEWAY_METHODS = new Set<string>(["node.pair.list", "node.pair.approve"]);
 
 export async function callGatewayCliRuntime(
   method: string,
@@ -24,6 +27,37 @@ export async function callGatewayCliRuntime(
         timeoutMs: callOpts?.transportTimeoutMs ?? Number(opts.timeout ?? 10_000),
         clientName: GATEWAY_CLIENT_NAMES.CLI,
         mode: GATEWAY_CLIENT_MODES.CLI,
+      }),
+  );
+}
+
+export async function callNodePairApprovalGatewayCliRuntime(
+  method: "node.pair.list" | "node.pair.approve",
+  opts: NodesRpcOpts,
+  params: unknown,
+  callOpts: { scopes: OperatorScope[]; transportTimeoutMs?: number },
+) {
+  if (!NODE_PAIR_APPROVAL_GATEWAY_METHODS.has(method)) {
+    throw new Error(`unsupported node pair approval gateway method: ${method}`);
+  }
+  // Node approval may need the local gateway's backend shared-auth authority
+  // before the CLI device has been granted the node's required operator scopes.
+  return await withProgress(
+    {
+      label: `Nodes ${method}`,
+      indeterminate: true,
+      enabled: opts.json !== true,
+    },
+    async () =>
+      await callGateway({
+        url: opts.url,
+        token: opts.token,
+        method,
+        params,
+        timeoutMs: callOpts.transportTimeoutMs ?? Number(opts.timeout ?? 10_000),
+        clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
+        mode: GATEWAY_CLIENT_MODES.BACKEND,
+        scopes: callOpts.scopes,
       }),
   );
 }

--- a/src/cli/nodes-cli/rpc.ts
+++ b/src/cli/nodes-cli/rpc.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { Command } from "commander";
+import type { OperatorScope } from "../../gateway/method-scopes.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { resolveNodeFromNodeList } from "../../shared/node-resolve.js";
 import { normalizeLowercaseStringOrEmpty } from "../../shared/string-coerce.js";
@@ -31,6 +32,16 @@ export const callGatewayCli = async (
 ) => {
   const runtime = await loadNodesCliRpcRuntime();
   return await runtime.callGatewayCliRuntime(method, opts, params, callOpts);
+};
+
+export const callNodePairApprovalGatewayCli = async (
+  method: "node.pair.list" | "node.pair.approve",
+  opts: NodesRpcOpts,
+  params: unknown,
+  callOpts: { scopes: OperatorScope[]; transportTimeoutMs?: number },
+) => {
+  const runtime = await loadNodesCliRpcRuntime();
+  return await runtime.callNodePairApprovalGatewayCliRuntime(method, opts, params, callOpts);
 };
 
 export function buildNodeInvokeParams(params: {

--- a/src/cli/program.nodes-basic.e2e.test.ts
+++ b/src/cli/program.nodes-basic.e2e.test.ts
@@ -8,8 +8,11 @@ installBaseProgramMocks();
 let registerNodesCli: typeof import("./nodes-cli.js").registerNodesCli;
 
 type GatewayCallRequest = {
+  clientName?: string;
   method?: string;
+  mode?: string;
   params?: unknown;
+  scopes?: unknown;
 };
 
 function formatRuntimeLogCallArg(value: unknown): string {
@@ -434,19 +437,103 @@ describe("cli program (nodes basics)", () => {
 
     expectGatewayRequest("node.list", {});
     expectGatewayRequest("node.describe", { nodeId: "ios-node" });
+    const describeRequest = gatewayRequests().find(
+      (candidate) => candidate.method === "node.describe",
+    );
+    expect(describeRequest?.clientName).toBe("cli");
+    expect(describeRequest?.mode).toBe("cli");
 
     const out = getRuntimeOutput();
     expect(out).toContain("Commands");
     expect(out).toContain("canvas.eval");
   });
 
-  it("runs nodes approve and calls node.pair.approve", async () => {
-    callGateway.mockResolvedValue({
-      requestId: "r1",
-      node: { nodeId: "n1", token: "t1" },
+  it("runs nodes approve with the pending request approval scopes", async () => {
+    callGateway.mockImplementation(async (...args: unknown[]) => {
+      const opts = (args[0] ?? {}) as { method?: string };
+      if (opts.method === "node.pair.list") {
+        return {
+          pending: [
+            {
+              requestId: "r1",
+              nodeId: "n1",
+              ts: Date.now(),
+              requiredApproveScopes: ["operator.pairing", "operator.admin"],
+            },
+          ],
+          paired: [],
+        };
+      }
+      if (opts.method === "node.pair.approve") {
+        return {
+          requestId: "r1",
+          node: { nodeId: "n1", token: "t1" },
+        };
+      }
+      return { ok: true };
     });
+
     await runProgram(["nodes", "approve", "r1"]);
+    expectGatewayRequest("node.pair.list", {});
     expectGatewayRequest("node.pair.approve", { requestId: "r1" });
+    const listRequest = gatewayRequests().find(
+      (candidate) => candidate.method === "node.pair.list",
+    );
+    const approveRequest = gatewayRequests().find(
+      (candidate) => candidate.method === "node.pair.approve",
+    );
+    expect(listRequest?.clientName).toBe("gateway-client");
+    expect(listRequest?.mode).toBe("backend");
+    expect(approveRequest?.scopes).toEqual(["operator.pairing", "operator.admin"]);
+    expect(approveRequest?.clientName).toBe("gateway-client");
+    expect(approveRequest?.mode).toBe("backend");
+  });
+
+  it("falls back to command-derived nodes approve scopes", async () => {
+    callGateway.mockImplementation(async (...args: unknown[]) => {
+      const opts = (args[0] ?? {}) as { method?: string };
+      if (opts.method === "node.pair.list") {
+        return {
+          pending: [
+            {
+              requestId: "r1",
+              nodeId: "n1",
+              ts: Date.now(),
+              commands: ["system.run"],
+            },
+          ],
+          paired: [],
+        };
+      }
+      if (opts.method === "node.pair.approve") {
+        return {
+          requestId: "r1",
+          node: { nodeId: "n1", token: "t1" },
+        };
+      }
+      return { ok: true };
+    });
+
+    await runProgram(["nodes", "approve", "r1"]);
+
+    const approveRequest = gatewayRequests().find(
+      (candidate) => candidate.method === "node.pair.approve",
+    );
+    expect(approveRequest?.scopes).toEqual(["operator.pairing", "operator.admin"]);
+  });
+
+  it("rejects unsupported node approval backend methods at runtime", async () => {
+    const { callNodePairApprovalGatewayCliRuntime } = await import("./nodes-cli/rpc.runtime.js");
+
+    await expect(
+      callNodePairApprovalGatewayCliRuntime(
+        "node.invoke" as never,
+        { json: true },
+        {},
+        { scopes: ["operator.admin"] },
+      ),
+    ).rejects.toThrow("unsupported node pair approval gateway method: node.invoke");
+    expect(callGateway).not.toHaveBeenCalled();
   });
 
   it("runs nodes remove and calls node.pair.remove", async () => {
@@ -500,5 +587,8 @@ describe("cli program (nodes basics)", () => {
       timeoutMs: 15000,
       idempotencyKey: "idem-test",
     });
+    const invokeRequest = gatewayRequests().find((candidate) => candidate.method === "node.invoke");
+    expect(invokeRequest?.clientName).toBe("cli");
+    expect(invokeRequest?.mode).toBe("cli");
   });
 });


### PR DESCRIPTION
## Summary

- Fixes `openclaw nodes approve` for pending node surfaces that require elevated approval scopes, such as `system.run` requiring `operator.admin`.
- Resolves the pending request first, requests the gateway-advertised or command-derived approval scopes, and keeps the privileged backend approval path limited to `node.pair.list` and `node.pair.approve`.
- Adds regression coverage that normal node commands still use CLI identity while the approval helper rejects unsupported backend methods at runtime.

## Verification

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/cli/program.nodes-basic.e2e.test.ts --reporter=verbose`
- `git diff --check`
- `AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --reviewer claude --fallback-reviewer none`
- Live AWS Crabbox proof after the patch: provider `aws`, lease `cbx_33c68aff3b77`, run `run_83a1f4ee38f2`, exit `0`.

## Real behavior proof

Behavior addressed: `openclaw nodes approve <requestId>` failed with `missing scope: operator.admin` for exec-capable pending node surfaces after the 2026.5.18 node surface gate.

Real environment tested: AWS Crabbox from this branch against a live gateway and live node pairing flow.

Exact steps or command run after this patch: provisioned a gateway and node, approved device pairing, confirmed the pending node surface required `["operator.pairing","operator.admin"]`, ran `openclaw nodes approve <requestId>` with the gateway token, and inspected pending/paired node state afterward.

Evidence after fix: AWS Crabbox provider `aws`, lease `cbx_33c68aff3b77`, run `run_83a1f4ee38f2`, exit `0`; output included `requiredApproveScopes=["operator.pairing","operator.admin"]`, `approve_output` success with redacted token, `pending_after=[]`, and paired node commands including `system.run`.

Observed result after fix: the exec-capable pending node surface moved from pending to paired, the CLI device remained pairing-scoped, and node approval completed without manually editing gateway state files.

What was not tested: full cross-platform release CI was not run locally before PR creation; PR CI is expected to cover broader repository gates.

Fixes #84144.
