### PR TITLE
fix: use fs-safe trash for agents delete

### DIFF
--- a/src/commands/agents.delete.test.ts
+++ b/src/commands/agents.delete.test.ts
@@ -15,6 +15,10 @@ const processMocks = vi.hoisted(() => ({
   runCommandWithTimeout: vi.fn(async () => ({ stdout: "", stderr: "", code: 0 })),
 }));
 
+const fsSafeMocks = vi.hoisted(() => ({
+  movePathToTrash: vi.fn(async (targetPath: string) => `${targetPath}.trashed`),
+}));
+
 const gatewayMocks = vi.hoisted(() => ({
   callGateway: vi.fn(),
   isGatewayTransportError: vi.fn(),
@@ -29,6 +33,10 @@ vi.mock("../config/config.js", async () => ({
 vi.mock("../gateway/call.js", () => ({
   callGateway: gatewayMocks.callGateway,
   isGatewayTransportError: gatewayMocks.isGatewayTransportError,
+}));
+
+vi.mock("../infra/fs-safe.js", () => ({
+  movePathToTrash: fsSafeMocks.movePathToTrash,
 }));
 
 vi.mock("../process/exec.js", () => ({
@@ -84,6 +92,7 @@ describe("agents delete command", () => {
   beforeEach(() => {
     configMocks.readConfigFileSnapshot.mockReset();
     configMocks.replaceConfigFile.mockReset();
+    fsSafeMocks.movePathToTrash.mockClear();
     processMocks.runCommandWithTimeout.mockClear();
     gatewayMocks.callGateway.mockReset();
     gatewayMocks.callGateway.mockRejectedValue(
@@ -282,10 +291,8 @@ describe("agents delete command", () => {
       expect(jsonOutput[0]?.workspaceRetained).toBe(true);
       expect(jsonOutput[0]?.workspaceRetainedReason).toBe("shared");
       expect(jsonOutput[0]?.workspaceSharedWith).toEqual(["main"]);
-      expect(processMocks.runCommandWithTimeout).not.toHaveBeenCalledWith(
-        ["trash", sharedWorkspace],
-        { timeoutMs: 5000 },
-      );
+      const trashedPaths = fsSafeMocks.movePathToTrash.mock.calls.map(([targetPath]) => targetPath);
+      expect(trashedPaths).not.toContain(sharedWorkspace);
     });
   });
 
@@ -319,10 +326,8 @@ describe("agents delete command", () => {
       const output = readJsonLogs()[0];
       expect(output?.workspaceRetained).toBe(true);
       expect(output?.workspaceSharedWith).toEqual(["main"]);
-      expect(processMocks.runCommandWithTimeout).not.toHaveBeenCalledWith(
-        ["trash", childWorkspace],
-        { timeoutMs: 5000 },
-      );
+      const trashedPaths = fsSafeMocks.movePathToTrash.mock.calls.map(([targetPath]) => targetPath);
+      expect(trashedPaths).not.toContain(childWorkspace);
     });
   });
 
@@ -356,10 +361,8 @@ describe("agents delete command", () => {
       const output = readJsonLogs()[0];
       expect(output?.workspaceRetained).toBe(true);
       expect(output?.workspaceSharedWith).toEqual(["main"]);
-      expect(processMocks.runCommandWithTimeout).not.toHaveBeenCalledWith(
-        ["trash", sharedWorkspace],
-        { timeoutMs: 5000 },
-      );
+      const trashedPaths = fsSafeMocks.movePathToTrash.mock.calls.map(([targetPath]) => targetPath);
+      expect(trashedPaths).not.toContain(sharedWorkspace);
     });
   });
 
@@ -396,10 +399,10 @@ describe("agents delete command", () => {
         const output = readJsonLogs()[0];
         expect(output?.workspaceRetained).toBe(true);
         expect(output?.workspaceSharedWith).toEqual(["main"]);
-        expect(processMocks.runCommandWithTimeout).not.toHaveBeenCalledWith(
-          ["trash", aliasWorkspace],
-          { timeoutMs: 5000 },
+        const trashedPaths = fsSafeMocks.movePathToTrash.mock.calls.map(
+          ([targetPath]) => targetPath,
         );
+        expect(trashedPaths).not.toContain(aliasWorkspace);
       });
     },
   );
@@ -432,10 +435,10 @@ describe("agents delete command", () => {
 
       await agentsDeleteCommand({ id: "ops", force: true, json: true }, runtime);
 
-      // trash command should have been called for the workspace
-      expect(processMocks.runCommandWithTimeout).toHaveBeenCalledWith(["trash", opsWorkspace], {
-        timeoutMs: 5000,
+      expect(fsSafeMocks.movePathToTrash).toHaveBeenCalledWith(opsWorkspace, {
+        allowedRoots: [path.dirname(opsWorkspace)],
       });
+      expect(processMocks.runCommandWithTimeout).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/commands/onboard-helpers.test.ts
+++ b/src/commands/onboard-helpers.test.ts
@@ -1,10 +1,12 @@
 import * as fs from "node:fs";
+import fsPromises from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { RuntimeEnv } from "../runtime.js";
 import {
   handleReset,
+  moveToTrash,
   normalizeGatewayTokenInput,
   openUrl,
   probeGatewayReachable,
@@ -14,6 +16,7 @@ import {
 } from "./onboard-helpers.js";
 
 const mocks = vi.hoisted(() => ({
+  movePathToTrash: vi.fn(async (targetPath: string) => `${targetPath}.trashed`),
   runCommandWithTimeout: vi.fn<
     (
       argv: string[],
@@ -28,6 +31,10 @@ const mocks = vi.hoisted(() => ({
   })),
   pickPrimaryTailnetIPv4: vi.fn<() => string | undefined>(() => undefined),
   probeGateway: vi.fn(),
+}));
+
+vi.mock("../infra/fs-safe.js", () => ({
+  movePathToTrash: mocks.movePathToTrash,
 }));
 
 vi.mock("../process/exec.js", () => ({
@@ -86,9 +93,13 @@ describe("handleReset", () => {
 
     const runtime = { log: vi.fn() } as unknown as RuntimeEnv;
 
-    await handleReset("full", workspaceDir, runtime);
+    try {
+      await handleReset("full", workspaceDir, runtime);
+    } finally {
+      fs.rmSync(homeDir, { recursive: true, force: true });
+    }
 
-    const trashedPaths = mocks.runCommandWithTimeout.mock.calls.map(([argv]) => argv[1]);
+    const trashedPaths = mocks.movePathToTrash.mock.calls.map(([targetPath]) => targetPath);
     expect(trashedPaths).toEqual([
       profileConfigPath,
       profileCredentialsDir,
@@ -96,6 +107,78 @@ describe("handleReset", () => {
       workspaceDir,
     ]);
     expect(trashedPaths).not.toContain(defaultCredentialsDir);
+  });
+});
+
+describe("moveToTrash", () => {
+  it("uses fs-safe trash instead of resolving a PATH trash command", async () => {
+    const testRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-trash-helper-"));
+    const targetPath = path.join(testRoot, "target");
+    fs.mkdirSync(targetPath, { recursive: true });
+    const runtime = { log: vi.fn() } as unknown as RuntimeEnv;
+
+    try {
+      await moveToTrash(targetPath, runtime);
+    } finally {
+      fs.rmSync(testRoot, { recursive: true, force: true });
+    }
+
+    expect(mocks.movePathToTrash).toHaveBeenCalledWith(targetPath, {
+      allowedRoots: [path.dirname(targetPath)],
+    });
+    expect(mocks.runCommandWithTimeout).not.toHaveBeenCalled();
+    expect(runtime.log).toHaveBeenCalledWith(`Moved to Trash: ${targetPath}`);
+  });
+
+  it("allows fs-safe trash to move a symlink whose target resolves outside the parent", async () => {
+    const testRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-trash-symlink-"));
+    const targetPath = path.join(testRoot, "target-link");
+    const outsideTarget = path.join(os.tmpdir(), "openclaw-trash-symlink-target");
+    fs.writeFileSync(targetPath, "link placeholder");
+    vi.spyOn(fsPromises, "lstat").mockResolvedValue({
+      isSymbolicLink: () => true,
+    } as fs.Stats);
+    vi.spyOn(fsPromises, "realpath").mockImplementation(async (candidate) =>
+      String(candidate) === path.dirname(targetPath) ? path.dirname(targetPath) : outsideTarget,
+    );
+    const runtime = { log: vi.fn() } as unknown as RuntimeEnv;
+
+    try {
+      await moveToTrash(targetPath, runtime);
+    } finally {
+      fs.rmSync(testRoot, { recursive: true, force: true });
+    }
+
+    expect(mocks.movePathToTrash).toHaveBeenCalledWith(targetPath, {
+      allowedRoots: [path.dirname(targetPath), path.dirname(outsideTarget)],
+    });
+  });
+
+  it("canonicalizes a symlinked parent before calling fs-safe trash", async () => {
+    const testRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-trash-parent-link-"));
+    const lexicalParent = path.join(testRoot, "state-link");
+    const realParent = path.join(testRoot, "state-real");
+    const targetPath = path.join(lexicalParent, "openclaw.json");
+    const sourcePath = path.join(realParent, "openclaw.json");
+    fs.mkdirSync(lexicalParent, { recursive: true });
+    fs.writeFileSync(targetPath, "{}\n");
+    vi.spyOn(fsPromises, "realpath").mockImplementation(async (candidate) =>
+      String(candidate) === lexicalParent ? realParent : String(candidate),
+    );
+    vi.spyOn(fsPromises, "lstat").mockResolvedValue({
+      isSymbolicLink: () => false,
+    } as fs.Stats);
+    const runtime = { log: vi.fn() } as unknown as RuntimeEnv;
+
+    try {
+      await moveToTrash(targetPath, runtime);
+    } finally {
+      fs.rmSync(testRoot, { recursive: true, force: true });
+    }
+
+    expect(mocks.movePathToTrash).toHaveBeenCalledWith(sourcePath, {
+      allowedRoots: [realParent],
+    });
   });
 });
 

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -17,7 +17,7 @@ import {
   resolveBrowserOpenCommand,
 } from "../infra/browser-open.js";
 import { detectBinary } from "../infra/detect-binary.js";
-import { runCommandWithTimeout } from "../process/exec.js";
+import { movePathToTrash } from "../infra/fs-safe.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { stylePromptTitle } from "../terminal/prompt-style.js";
@@ -202,11 +202,34 @@ export async function moveToTrash(pathname: string, runtime: RuntimeEnv): Promis
     return;
   }
   try {
-    await runCommandWithTimeout(["trash", pathname], { timeoutMs: 5000 });
+    const targetPath = path.resolve(pathname);
+    const sourcePath = await resolveMoveToTrashSourcePath(targetPath);
+    await movePathToTrash(sourcePath, {
+      allowedRoots: await resolveMoveToTrashAllowedRoots(sourcePath),
+    });
     runtime.log(`Moved to Trash: ${shortenHomePath(pathname)}`);
   } catch {
     runtime.log(`Failed to move to Trash (manual delete): ${shortenHomePath(pathname)}`);
   }
+}
+
+async function resolveMoveToTrashSourcePath(targetPath: string): Promise<string> {
+  return path.join(await fs.realpath(path.dirname(targetPath)), path.basename(targetPath));
+}
+
+async function resolveMoveToTrashAllowedRoots(targetPath: string): Promise<string[]> {
+  const allowedRoots = [path.dirname(targetPath)];
+  const stat = await fs.lstat(targetPath);
+  if (stat.isSymbolicLink()) {
+    try {
+      // fs-safe resolves valid symlinks before allow-root checks; include the
+      // resolved parent so deleting a configured symlink moves the link itself.
+      allowedRoots.push(path.dirname(await fs.realpath(targetPath)));
+    } catch {
+      // Broken symlinks are handled lexically by fs-safe.
+    }
+  }
+  return [...new Set(allowedRoots)];
 }
 
 export async function handleReset(scope: ResetScope, workspaceDir: string, runtime: RuntimeEnv) {

--- a/src/infra/fs-safe.ts
+++ b/src/infra/fs-safe.ts
@@ -23,6 +23,7 @@ export {
 } from "@openclaw/fs-safe/advanced";
 export { isPathInside } from "@openclaw/fs-safe/path";
 export { pathExists, pathExistsSync } from "@openclaw/fs-safe/advanced";
+export { movePathToTrash, type MovePathToTrashOptions } from "@openclaw/fs-safe/advanced";
 export { readLocalFileFromRoots, resolveLocalPathFromRootsSync } from "@openclaw/fs-safe/advanced";
 export {
   appendRegularFile,


### PR DESCRIPTION
## Summary

- Problem: the offline CLI `agents delete` cleanup path shells out to a PATH-resolved `trash` binary.
- Why it matters: the official Docker runtime image does not include `trash-cli`, so deleting an agent can leave owned workspace/session paths behind after config state says the agent is gone.
- What changed: `moveToTrash()` now reuses OpenClaw's existing filesystem-safe `movePathToTrash()` helper with explicit allowed roots, and focused tests assert the helper route plus shared-workspace retention.
- What did NOT change (scope boundary): this does not add a Docker dependency, does not hard-delete workspaces, does not change JSON output shape, and does not change shared-workspace retention policy.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra
- [x] Core CLI / agents

## Linked Issue/PR

- Closes #83459
- Related #83472
- [x] This PR fixes a bug or regression

## AI assistance

This PR was implemented with Codex assistance. I reviewed the change and understand the affected `agents delete` cleanup path.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `agents delete` no longer depends on a PATH-resolved `trash` binary when moving owned agent paths to trash.
- Real environment tested: Locally built OpenClaw Docker runtime image from this branch. Inside the container, `command -v trash` was absent.
- Exact steps or command run after this patch: Built the repo Docker image, then ran `openclaw agents add bug_test --workspace /tmp/openclaw-workspace --non-interactive --json` followed by `openclaw agents delete bug_test --force --json` inside the container.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

<details>
<summary>Docker proof output</summary>

```text
image: openclaw-83459-agents-delete-trash-helper:20260519T174205Z
timestamp_utc: 20260519T175450Z
container user: uid=1000(node) gid=1000(node) groups=1000(node)
trash binary absent as expected
{
  "agentId": "bug_test",
  "name": "bug_test",
  "workspace": "/tmp/openclaw-workspace",
  "agentDir": "/tmp/openclaw-state/agents/bug_test/agent",
  "bindings": {
    "added": [],
    "updated": [],
    "skipped": [],
    "conflicts": []
  }
}
workspace exists after add: yes
{
  "agentId": "bug_test",
  "workspace": "/tmp/openclaw-workspace",
  "agentDir": "/tmp/openclaw-state/agents/bug_test/agent",
  "sessionsDir": "/tmp/openclaw-state/agents/bug_test/sessions",
  "removedBindings": 0,
  "removedAllow": 0
}
PASS: workspace removed
PASS: workspace moved to trash: /tmp/openclaw-home/.Trash/openclaw-workspace-1779213303448-6JadRW/openclaw-workspace
END: explicit success
PROOF_STATUS=0
sg_status=0
```

</details>

- Observed result after fix: The workspace was removed from `/tmp/openclaw-workspace` and moved under the container user's `~/.Trash` even though no `trash` binary was available.
- What was not tested: Cross-OS desktop Trash integration was not tested; this PR only changes the OpenClaw helper path used by the offline CLI `agents delete` cleanup path.
- Before evidence (optional but encouraged): Source-level proof on current main shows `moveToTrash()` invokes `runCommandWithTimeout(["trash", pathname])`, while the Docker runtime package list does not install `trash-cli`.

## Root Cause (if applicable)

- Root cause: the offline CLI cleanup helper depended on an external `trash` executable instead of the existing in-process fs-safe trash helper.
- Missing detection / guardrail: command tests asserted the old PATH command behavior and did not prove Docker/minimal-Linux cleanup when `trash` was absent.
- Contributing context (if known): the Gateway delete path already used the safer `movePathToTrash()` style, so CLI and Gateway cleanup behavior diverged.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/commands/onboard-helpers.test.ts` and `src/commands/agents.delete.test.ts`.
- Scenario the test should lock in: `moveToTrash()` calls `movePathToTrash()` with explicit allowed roots instead of invoking PATH `trash`, unique workspaces are trashed, and shared workspaces are retained.
- Why this is the smallest reliable guardrail: it covers the changed command helper and the `agents delete` caller without requiring broad Docker E2E for every run.
- Existing test that already covers this (if any): shared workspace retention had existing coverage; this PR updates it to assert the fs-safe helper route.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

`openclaw agents delete` now removes owned cleanup targets in Docker/minimal environments where the external `trash` command is absent. The behavior remains move-to-trash rather than hard-delete.

## Diagram (if applicable)

```text
Before:
openclaw agents delete -> offline cleanup -> PATH trash command missing -> target can remain

After:
openclaw agents delete -> offline cleanup -> fs-safe movePathToTrash -> target moved under ~/.Trash
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: this removes a PATH-resolved external `trash` command from cleanup and reuses the existing fs-safe helper with explicit allowed roots. It does not add a new command execution path.

## Repro + Verification

### Environment

- OS: WSL Ubuntu / local OpenClaw checkout
- Runtime/container: locally built OpenClaw Docker runtime image from this branch
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): isolated temp OpenClaw home/state/config inside the container

### Steps

1. Build the OpenClaw Docker runtime image from this branch.
2. Confirm `command -v trash` is absent inside the container.
3. Run `openclaw agents add bug_test --workspace /tmp/openclaw-workspace --non-interactive --json`.
4. Run `openclaw agents delete bug_test --force --json`.
5. Assert `/tmp/openclaw-workspace` no longer exists and a matching workspace entry exists under `~/.Trash`.

### Expected

- `agents delete` removes the owned workspace from its original path and moves it to Trash-style storage without requiring a `trash` binary.

### Actual

- Docker proof output showed `trash binary absent as expected`, `PASS: workspace removed`, `PASS: workspace moved to trash`, `PROOF_STATUS=0`, and `sg_status=0`.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: focused command tests; changed-lane checks; Codex review; local no-`trash` proof; Docker runtime proof with no `trash` binary.
- Edge cases checked: shared workspace retention, unique workspace cleanup, target symlink outside parent, symlinked parent canonicalization, broken-symlink lexical fallback behavior delegated to fs-safe.
- What you did **not** verify: cross-OS desktop Trash integration and broad full-suite local `pnpm test`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

No bot review conversations exist yet for this PR.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: filesystem cleanup helpers are sensitive to symlink/canonicalization behavior.
  - Mitigation: this PR reuses the existing fs-safe trash helper and adds focused symlink/allowed-root tests for the changed call site.
- Risk: the PR does not address the adjacent orphan parent-directory cleanup suggestion from the issue comments.
  - Mitigation: intentionally kept out of scope so this remains a narrow fix for the Docker missing-`trash` failure path.

## Validation

- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree corepack pnpm test src/commands/onboard-helpers.test.ts src/commands/agents.delete.test.ts`
- `PATH=/tmp/openclaw-corepack-bin:$PATH OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree corepack pnpm check:changed`
- `codex review --base origin/main`
- Local no-`trash` proof with isolated OpenClaw home/state/config
- Docker runtime proof with no `trash` binary available
