### PR TITLE
fix(msteams,voice-call): large-file resumable upload + hang up rejected inbound calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- MSTeams: support files >4 MiB via Graph resumable upload sessions (createUploadSession + chunked PUT). Small files keep the simple `:/content` path.
 - Docs: add direct BotFather link and verification reminder in Telegram setup. (#4064) Thanks @shatner.
 - Docs: add Mintlify language navigation for zh-Hans. (#6416) Thanks @joshp123.
 - Telegram: use shared pairing store. (#6127) Thanks @obviyus.
@@ -13,6 +14,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Voice-call: hang up rejected inbound calls instead of leaving them ringing/connected when the caller is outside the allowlist.
 - Docs: run oxfmt to fix format checks. (#6513) Thanks @app/clawdinator.
 - Auto-reply: avoid referencing workspace files in /new greeting prompt. (#5706) Thanks @bravostation.
 - Process: resolve Windows `spawn()` failures for npm-family CLIs by appending `.cmd` when needed. (#5815) Thanks @thejhinvirtuoso.

--- a/docs/specs/2026-05-16-agent-skills-interop/plan.md
+++ b/docs/specs/2026-05-16-agent-skills-interop/plan.md
@@ -1,0 +1,22 @@
+# Plan — Agent Skills format interop
+
+## Approach
+
+Add a small loader layer that parses SKILL.md frontmatter in either the canonical Anthropic shape or the current openclaw shape, normalizes into one internal representation, and feeds existing discovery. Add CLI import/export commands that translate to/from the Anthropic file layout. Keep `metadata.openclaw` as the home for install hints; document the conventions in `docs/tools/skills.md`.
+
+## Steps
+
+1. Define an internal `SkillManifest` TypeBox schema in `src/plugins/skill-manifest.ts` that holds the normalized fields (`name`, `description`, `metadata.openclaw.*`, optional `allowed_tools`).
+2. Parse the SKILL.md frontmatter into `SkillManifest` accepting both shapes. Reject ambiguous mixes with a typed error.
+3. Update `src/plugins/discovery.ts` to use the new manifest type; keep behavior for installed-bin checks identical.
+4. Feed `allowed_tools` (when present) into `src/agents/tool-policy.ts` so the skill ships with its own tool allowlist.
+5. Add `openclaw skills import <path|url>` — fetch + extract + validate; refuses bundles with executable scripts unless `--allow-scripts` is passed.
+6. Add `openclaw skills export <name>` — emit a tarball matching the canonical file layout for use in Claude.ai / Claude Code / Agent SDK.
+7. `openclaw doctor` — surface old-shape skills with a migration hint (no auto-rewrite).
+8. Docs: extend `docs/tools/skills.md` with the canonical shape, the `metadata.openclaw` extension, and a migration recipe.
+
+## Dependencies / order
+
+- Steps 1–2 (schema + parser) block everything else.
+- Step 4 (allowed-tools wiring) depends on 3.
+- Steps 5–6 (import/export) can land in parallel with each other after 1–3.

--- a/docs/specs/2026-05-16-agent-skills-interop/requirements.md
+++ b/docs/specs/2026-05-16-agent-skills-interop/requirements.md
@@ -1,0 +1,33 @@
+# Requirements — Agent Skills format interop
+
+## Outcome
+
+The 50+ skills under `skills/*` are loadable as Anthropic Agent Skills (the SKILL.md format used by Claude.ai, Claude Code, and the Claude Agent SDK) without losing openclaw-specific install metadata. Operators can also load external Agent Skills packages (Anthropic-hosted or third-party) into the openclaw runtime through the same skills mechanism that already exists.
+
+## Users affected
+
+- Skill authors — current SKILL.md frontmatter shape differs slightly from Anthropic's spec.
+- Operators who use Claude.ai or Claude Code alongside openclaw and want to share skills.
+- Skills runtime — `src/plugins/discovery.ts`, `src/plugins/`, `clawhub` registry, `openclaw configure --section skills`.
+
+## In scope
+
+- Adopt Anthropic's Agent Skills SKILL.md spec as the canonical shape: `name`, `description`, optional `metadata`. Keep openclaw-specific install hints under a namespaced key (`metadata.openclaw`) so the spec stays compliant.
+- Bidirectional loader: read both old and new shapes; new writes use the canonical shape.
+- Optional `allowed_tools` field reading — when present, skill discovery feeds the existing tool-policy `allow` list.
+- Import path: `openclaw skills import <path-or-url>` loads an Anthropic-shape skill bundle into the operator's workspace skills directory.
+- Export path: `openclaw skills export <name>` emits a tarball matching the Anthropic Agent Skills file layout.
+- Doctor migration: detect old-shape skills and suggest migration (do not auto-rewrite — risk of breaking custom metadata).
+
+## Out of scope
+
+- Replacing or removing the `clawhub` registry — interop is additive.
+- Hosting an alternative skills registry.
+- Skills that depend on Claude.ai-specific runtime APIs we don't have (those skip discovery with a clear log).
+- Auto-migration of existing skills' frontmatter — manual migration via doctor hint.
+
+## Decisions
+
+- Keep `metadata.openclaw` as a namespaced extension. Reason: complies with Anthropic's spec while preserving install metadata (`requires.bins`, `install` arrays).
+- New skills authored in canonical shape; old ones still load. Reason: avoid churn while maintaining interop.
+- Allowed-tools fed into the existing policy machinery rather than a parallel system. Reason: single source of truth for tool gating.

--- a/docs/specs/2026-05-16-agent-skills-interop/validation.md
+++ b/docs/specs/2026-05-16-agent-skills-interop/validation.md
@@ -1,0 +1,39 @@
+# Validation — Agent Skills format interop
+
+## Automated tests
+
+- `src/plugins/skill-manifest.test.ts` — parse canonical + legacy frontmatter; reject ambiguous mixes.
+- `src/plugins/discovery.test.ts` — both shapes discovered identically.
+- `src/plugins/skills-import.test.ts` — import accepts an Anthropic-shape tarball; rejects unauthorized executable scripts.
+- `src/plugins/skills-export.test.ts` — export round-trips through import without manifest loss.
+- `src/agents/tool-policy-skills.test.ts` — `allowed_tools` on a skill restricts the agent's tool surface during that skill's execution.
+- E2E: `scripts/e2e/skills-interop-docker.sh` — import a canonical-shape skill; run a session that triggers it; assert the agent uses only the allowed tools.
+
+## Smoke checks
+
+- `openclaw skills import <fixture-tarball>` succeeds and the skill appears in `openclaw skills list`.
+- `openclaw skills export github` produces a tarball; `tar -tf` shows SKILL.md at the root.
+- `openclaw doctor` lists any skills still on the legacy shape.
+
+## Manual criteria
+
+- The exported tarball loads cleanly into Claude Code (`/skills add ./openclaw-github.tar.gz`).
+- Migration hint copy in doctor output is actionable.
+
+## AI eval plan
+
+- Success criteria: on a 10-prompt skill-routing eval, the agent picks the right skill ≥ 90% of the time after import; ≤ 5% misfire on prompts that should not trigger a skill.
+- Eval dataset: `tests/evals/skills-routing/` — operator prompts × expected skill selection.
+- Regression set: 5 cases — explicit skill mention, implicit match, ambiguous, no-match, denied-by-allowed-tools.
+- Cadence: per-PR on fixtures; nightly on the live-models matrix.
+
+## Risks & rollback
+
+- **Risks:**
+  - Misparsed frontmatter silently drops a skill on startup. *Detect via* explicit parser tests + a startup log line per discovered skill (count + names).
+  - Malicious imported skill ships scripts. *Mitigate* by requiring `--allow-scripts` and printing the script paths before extraction.
+- **Rollback:** revert the PR; the legacy shape still loads via the same parser.
+
+## Open questions
+
+- Do we publish the canonical openclaw skills (canvas, clawhub, peekaboo, etc.) into Anthropic's Agent Skills registry by default, or operator-opt-in? Defer to a follow-up.

--- a/docs/specs/2026-05-16-anthropic-managed-memory-tool/plan.md
+++ b/docs/specs/2026-05-16-anthropic-managed-memory-tool/plan.md
@@ -1,0 +1,22 @@
+# Plan — Anthropic managed memory tool
+
+## Approach
+
+The Pi SDK already lets us inject Anthropic-specific extra params (see `src/agents/pi-embedded-runner/extra-params.ts` which already handles hardcoded `cache_control`). Add a `memory` tool entry to that extra-params layer when the resolved model is in the Opus 4.7+ family, then implement a local handler that fulfills the tool's commands against `~/.openclaw/agents/<agentId>/memories/` with a strict path-resolver. Surface the new tool to operators as part of the existing memory section in `openclaw configure`.
+
+## Steps
+
+1. Detect capability: extend `src/agents/model-catalog.ts` with a `supportsManagedMemoryTool` flag derived from model id (Opus 4.7+ on Anthropic; pass-through if a provider exposes a compatible primitive).
+2. Implement `src/agents/tools/managed-memory-tool.ts` — handler for `view`, `create`, `str_replace`, `insert`, `delete`, `rename`. Use `node:fs/promises`; resolve every path through a helper that rejects anything outside the per-agent root.
+3. Add `src/agents/pi-embedded-runner/managed-memory.ts` — emit the Anthropic `memory` tool definition in extra-params when the capability flag is true and `memory.managed.enabled !== false`.
+4. Add config keys: `memory.managed.enabled` (default `auto` — on when capability is present), `memory.managed.root` (override the default per-agent path). Hook into `src/config/`.
+5. Audit log: every memory command writes a JSONL entry to `~/.openclaw/agents/<agentId>/memories/.audit.jsonl` so transcript replay can show what the model wrote.
+6. Surface in the existing memory configure wizard step (`src/commands/configure.wizard.ts`) — describe the difference between custom search and managed scratchpad.
+7. Tool-policy: add `managed_memory` to the allow/deny machinery in `src/agents/tool-policy.ts` so operators can disable per-agent.
+8. Docs: extend `docs/concepts/memory.md` (or new sibling) explaining the two-layer model.
+
+## Dependencies / order
+
+- Step 1 blocks step 3.
+- Steps 2 and 3 must land together (tool handler + extra-params injection).
+- Steps 5–8 can land after the core ships.

--- a/docs/specs/2026-05-16-anthropic-managed-memory-tool/requirements.md
+++ b/docs/specs/2026-05-16-anthropic-managed-memory-tool/requirements.md
@@ -1,0 +1,33 @@
+# Requirements — Anthropic managed memory tool
+
+## Outcome
+
+When an agent runs on Claude Opus 4.7 (or any model that advertises the managed memory tool), it can read and write a per-agent `/memories/*` scratchpad using Anthropic's built-in memory tool primitive — alongside, not replacing, the existing custom `memory_search` / `memory_get` tools that index `MEMORY.md` and `memory/*.md` via BM25 + embeddings.
+
+## Users affected
+
+- Operators who run long-horizon agentic loops (multi-hour coding/agentic sessions) and want the model to keep state across turns.
+- The agent runtime — `src/agents/pi-embedded-runner/` and `src/agents/tools/memory-tool.ts`.
+- Storage layer: `~/.openclaw/agents/<agentId>/memories/` per-agent scratchpad root.
+
+## In scope
+
+- Wire Anthropic's `memory` tool primitive into the Pi-embedded runner extra-params when the active model + provider supports it.
+- Map memory commands (`view`, `create`, `str_replace`, `insert`, `delete`, `rename`) to file operations under `~/.openclaw/agents/<agentId>/memories/` with path-traversal guards (must resolve under the per-agent root).
+- Coexist with existing custom memory tools: `memory_search` (semantic recall over MEMORY.md + memory/*.md) and `memory_get` (path-scoped read).
+- Per-session toggle (`memory.managed.enabled`) and per-agent root override (`memory.managed.root`).
+- Surface memory operations in session transcripts so the operator can audit what the model wrote.
+
+## Out of scope
+
+- Rewriting the existing memory_search/get tools (they remain for cross-session structured recall).
+- Cross-agent shared memory.
+- Cloud-hosted memory (Anthropic's Managed Agents agent memory beta — that runs server-side at Anthropic; we stay client-side).
+- Migrating the legacy MEMORY.md format to /memories/.
+
+## Decisions
+
+- Client-side managed memory only, not Managed Agents memory. Reason: openclaw is a single-operator local-first product; data stays on the operator's host.
+- Per-agent root, not per-session. Reason: the operator's mental model is "this agent learned X" — `agentId` is the right cardinality.
+- Co-exist with current memory tools rather than replace. Reason: `memory_search` indexes operator-curated MEMORY.md; the managed tool is a model-managed scratchpad. They serve different purposes.
+- Path-traversal guard is hard-fail, not sanitize. Reason: never silently relocate model-written files; surface a tool error instead.

--- a/docs/specs/2026-05-16-anthropic-managed-memory-tool/validation.md
+++ b/docs/specs/2026-05-16-anthropic-managed-memory-tool/validation.md
@@ -1,0 +1,40 @@
+# Validation — Anthropic managed memory tool
+
+## Automated tests
+
+- `src/agents/tools/managed-memory-tool.test.ts` — every command (`view`, `create`, `str_replace`, `insert`, `delete`, `rename`) round-trips against a tmp root.
+- `src/agents/tools/managed-memory-tool.path-traversal.test.ts` — paths with `..`, absolute paths, and symlink escapes all reject with a typed error.
+- `src/agents/pi-embedded-runner/managed-memory.test.ts` — extra-params payload contains the `memory` tool only when the capability flag is true.
+- `src/agents/model-catalog.test.ts` — `supportsManagedMemoryTool` true for Opus 4.7 ids, false for Sonnet 4.6 / Haiku 4.5.
+- Live test (gated on `OPENCLAW_LIVE_TEST=1`): run a multi-turn session on Opus 4.7 that asks the model to remember a fact, ends the session, starts a new one, and asks for recall — assert the scratchpad file exists with the expected content.
+
+## Smoke checks
+
+- `openclaw agent --message "remember that my preferred timezone is America/Lima"` on an Opus 4.7 session → file appears under `~/.openclaw/agents/<agentId>/memories/`.
+- Restart the agent, ask "what's my timezone?" → reply includes Lima without re-prompting.
+- `cat ~/.openclaw/agents/<agentId>/memories/.audit.jsonl` shows the write event.
+
+## Manual criteria
+
+- Audit JSONL is readable and useful for a human auditing what the model has written.
+- Operator can purge the scratchpad easily (`rm -rf ~/.openclaw/agents/<agentId>/memories/`); the agent recovers without crashing.
+
+## AI eval plan
+
+- Success criteria: on a 20-prompt recall set ("remember X" → new session → "what's X?"), recall accuracy ≥ 95% with the managed tool enabled; ≤ 5% file-write churn for prompts that should NOT trigger memory (e.g. ephemeral chitchat).
+- Eval dataset: `tests/evals/managed-memory-recall.jsonl` — paired remember/recall prompts + a control set of no-op prompts.
+- Regression set: 5 prompts covering create, str_replace, delete, rename, and view-of-deleted-path-after-restart.
+- Cadence: run on every PR touching `src/agents/tools/managed-memory-tool.ts` or `pi-embedded-runner/`. Nightly on the live-models matrix.
+
+## Risks & rollback
+
+- **Risks:**
+  - Model writes secrets to memory files (API keys it saw during a session). *Detect via* a secret-scanner hook on memory writes (reuse `.secrets.baseline`).
+  - Path-traversal regression hands the model the operator's home dir. *Detect via* the dedicated traversal test; defense in depth from `node:fs/promises` realpath check.
+  - Audit log grows unbounded over long sessions. *Mitigate* with a daily rotation (handled by the existing logging subsystem).
+- **Rollback:** set `memory.managed.enabled=false` in config; the tool stops being advertised to the model. PR revert is safe — the file root is additive.
+
+## Open questions
+
+- Default for `memory.managed.enabled`: `auto` (capability-based) or `off` (opt-in)? Lean `auto` but confirm before merging.
+- Should the audit JSONL be queryable via `memory_search`? (Probably yes — adds reflection signal.)

--- a/docs/specs/2026-05-16-apple-foundation-models-on-device/plan.md
+++ b/docs/specs/2026-05-16-apple-foundation-models-on-device/plan.md
@@ -1,0 +1,24 @@
+# Plan — Apple Foundation Models on-device bridge
+
+## Approach
+
+Add a `OpenClawLocalLLM` Swift module in `apps/shared/OpenClawKit/Sources/` that exposes a small API (`classifyIntent`, `polishDictation`, `summarize(short:)`) over Apple's Foundation Models framework. The apps call this module on the device-side hot paths (Voice Wake transcript polish, chat input classification) before deciding to invoke the Gateway. Capability detection (`AppleIntelligence.isAvailable`) gates everything; on unsupported devices the module is a no-op stub.
+
+## Steps
+
+1. Add `apps/shared/OpenClawKit/Sources/OpenClawKit/LocalLLM/Capability.swift` — `AppleIntelligenceCapability` check and graceful fallback object.
+2. Add `LocalLLM/IntentClassifier.swift` — prompt template + `Intent` enum decoding via `@Generable`/structured output (Foundation Models framework feature).
+3. Add `LocalLLM/DictationPolish.swift` — punctuation/capitalization pass; preserves entities like phone numbers/email.
+4. Add `LocalLLM/ShortSummary.swift` — opt-in summary; bounded by max input tokens.
+5. Wire `IntentClassifier` into `apps/macos/Sources/.../ChatInputCoordinator.swift` and equivalents in iOS so chat commands are detected before the Gateway round-trip.
+6. Wire `DictationPolish` after Voice Wake's final transcript and before invoking the Gateway agent.
+7. Settings UI: "Use on-device intelligence" toggle (on by default when capable) in macOS preferences + iOS settings screen.
+8. Telemetry (local-only): count of on-device hits + savings estimate visible in the macOS debug panel; nothing leaves the device.
+9. Docs: `docs/platforms/macos.md` + `docs/platforms/ios.md` note the capability + toggle.
+
+## Dependencies / order
+
+- Step 1 (capability) blocks everything else.
+- Steps 2–4 (the three local pipelines) can ship in parallel.
+- Steps 5–6 (wiring) depend on 2–4.
+- Steps 7–9 (settings + docs) land last.

--- a/docs/specs/2026-05-16-apple-foundation-models-on-device/requirements.md
+++ b/docs/specs/2026-05-16-apple-foundation-models-on-device/requirements.md
@@ -1,0 +1,34 @@
+# Requirements — Apple Foundation Models on-device bridge
+
+## Outcome
+
+On iOS 26 / macOS Tahoe 26 / Apple Intelligence-capable devices, the openclaw apps use Apple's on-device ~3B foundation model for cheap local inference: intent classification ("is this a chat command or a question?"), wake-phrase candidate filtering, post-Whisper dictation polish, and short summaries — keeping these out of the Anthropic + OpenAI bills and off the network entirely. The Gateway and core text-agent path remain unchanged.
+
+## Users affected
+
+- iOS / macOS app users on Apple Intelligence-capable hardware.
+- The Talk Mode / Voice Wake stack — pre-agent polish.
+- The chat UI — local "did you mean" suggestions, message classification.
+- App code: `apps/macos/Sources/`, `apps/ios/Sources/`, `apps/shared/OpenClawKit/Sources/`.
+
+## In scope
+
+- New `OpenClawLocalLLM` module in `apps/shared/OpenClawKit/Sources/` wrapping Apple's Foundation Models framework (Swift, iOS 18+ / macOS 15+ — Apple Intelligence required).
+- Intent classifier: short prompts in / typed `Intent` enum out (`chatCommand`, `question`, `dictationFragment`, `noise`).
+- Dictation polish: post-Whisper STT pass that fixes punctuation/capitalization locally before submitting to the agent.
+- Local summarization for very short transcripts (≤ N tokens) when an operator opts in.
+- Hard fallback to "do nothing locally, send everything to the Gateway" on unsupported devices.
+
+## Out of scope
+
+- Replacing or supplementing the Gateway's text-agent path — Apple's 3B model is not the assistant brain.
+- Android equivalent (Gemini Nano / on-device Gemini) — separate spec; the Android app currently uses Apple cloud / Gateway path.
+- Cross-vendor inference abstraction — keep this Apple-specific to ship cleanly.
+- Storing prompts/responses from the on-device model in transcripts — local-only, ephemeral.
+
+## Decisions
+
+- Use Apple's Foundation Models framework directly, not via a wrapper library. Reason: framework is GA on iOS 26 / macOS Tahoe 26 and stable; wrappers add lag.
+- Intent classifier output is an enum, not free-text. Reason: easier to test, easier to wire into the existing voice/chat dispatch.
+- Local results never claim to be from the assistant — UI labels them as "device" or hides them entirely. Reason: prevents operator confusion about which model produced an answer.
+- Opt-out, not opt-in, on capable devices. Reason: cost + privacy win is high; risk of degrading UX is low if the fallback is clean.

--- a/docs/specs/2026-05-16-apple-foundation-models-on-device/validation.md
+++ b/docs/specs/2026-05-16-apple-foundation-models-on-device/validation.md
@@ -1,0 +1,39 @@
+# Validation — Apple Foundation Models on-device bridge
+
+## Automated tests
+
+- `OpenClawKitTests/LocalLLM/IntentClassifierTests.swift` — fixture inputs map to expected `Intent` cases; ≥ 90% on the bundled fixture set.
+- `OpenClawKitTests/LocalLLM/DictationPolishTests.swift` — punctuation/capitalization fixes for 20 sample transcripts; named entities preserved.
+- `OpenClawKitTests/LocalLLM/CapabilityTests.swift` — no-op stub returns sentinel values on unsupported simulators.
+- macOS UI test: chat input "/" triggers local classifier before Gateway call.
+- iOS UI test: Voice Wake transcript passes through `DictationPolish` before being submitted.
+
+## Smoke checks
+
+- On an Apple-Intelligence-capable Mac, toggle "Use on-device intelligence" off and on; behavior changes accordingly without restart.
+- Run the apps offline (Wi-Fi off) and confirm intent classification still works while Gateway calls fail gracefully.
+
+## Manual criteria
+
+- Dictation polish reads as a clear improvement on a sample of 10 real Voice Wake transcripts (subjective — must not introduce hallucinations).
+- Intent classifier doesn't misclassify a normal question as a `/command` (the most user-visible failure mode).
+
+## AI eval plan
+
+- Success criteria: intent classifier precision ≥ 0.95 and recall ≥ 0.90 for `chatCommand` class on a 100-input fixture; dictation polish WER reduction ≥ 30% vs. raw Whisper output on a 20-sample set.
+- Eval dataset: `apps/shared/OpenClawKit/Sources/OpenClawKit/LocalLLM/Tests/Fixtures/`.
+- Regression set: 8 inputs — `/status`, `/new`, "what's the weather", dictation with email + phone, dictation with proper nouns, ambiguous "summary please", noise/silence.
+- Cadence: per-PR on the Apple test target; manual quarterly review on real recorded Voice Wake transcripts.
+
+## Risks & rollback
+
+- **Risks:**
+  - Apple's framework changes the prompt API between OS versions. *Detect via* the CI Apple matrix (build against iOS 26 and the next-major beta).
+  - On-device model hallucinates entities during dictation polish. *Mitigate* by clamping the polish prompt to "preserve named entities verbatim".
+  - "Device intelligence" toggle ends up causing surprising offline gaps. *Mitigate* by defaulting to off when battery low / thermal pressure high.
+- **Rollback:** flip the global "Use on-device intelligence" toggle off; the apps revert to Gateway-only behavior. App-level rollback if needed: ship a build that hides the toggle.
+
+## Open questions
+
+- Should we share the dictation polish output back to the Gateway alongside the raw transcript so the agent has both? Probably yes — costs nothing extra.
+- Do we add a Liquid Glass-style indicator in macOS's status bar when an on-device call replaced a Gateway call? Defer to design.

--- a/docs/specs/2026-05-16-computer-use-loop/plan.md
+++ b/docs/specs/2026-05-16-computer-use-loop/plan.md
@@ -1,0 +1,24 @@
+# Plan — Computer-use loop with high-res vision
+
+## Approach
+
+Layer a `computer_use` aggregate tool over the existing browser, canvas, and screen.record primitives. Inputs are screenshots taken at native resolution (capped at Opus 4.7's 2576px ceiling) and the model emits coordinate-based actions that the aggregator translates into `browser.click(x,y)` / `browser.type(text)` / `node.invoke({system: "click",...})`. Capability gating in `src/agents/model-catalog.ts` keeps this off for models that don't support computer-use. The whole loop runs inside the existing Pi-embedded runtime so tool-policy, session state, and audit log are uniform with the rest of the agent.
+
+## Steps
+
+1. Add `src/media/image-ops.ts` resolution mode: when the active model supports hi-res input, skip the current downscale step and only enforce the 2576px ceiling.
+2. Add `src/agents/tools/computer-use.ts` — Anthropic computer-use tool schema (`screenshot`, `left_click`, `right_click`, `mouse_move`, `type`, `key`, `scroll`, `wait`). Dispatch into the underlying tools.
+3. Wire DPR + coordinate normalization in `src/browser/` and `src/canvas-host/` so the model's coord system maps to physical click coords correctly.
+4. Add capability flag `supportsComputerUse` in `src/agents/model-catalog.ts`; advertise the tool only when true and operator opts in via `computerUse.enabled`.
+5. Allowlist + denylist gates: `src/agents/tool-policy.ts` enforces `computerUse.allowedHosts` + `computerUse.allowedNodes`; navigation outside the list returns a typed tool error to the model.
+6. Audit log: every action persists a JSONL row + a hashed screenshot path under `~/.openclaw/agents/<agentId>/computer-use/<sessionKey>/`. Reuse the existing logging redaction so typed passwords (heuristic: tool param marked `secret=true`) are not stored.
+7. Wall-clock guard: per-action `30s` default, whole-loop default `10min`, both configurable; on hit emit a typed timeout that the model can read and recover from.
+8. CLI: `openclaw computer-use replay <session>` to step through an audited trace; `openclaw computer-use status` to show active loops.
+9. Docs: `docs/tools/computer-use.mdx` with the host-allowlist pattern and screenshot retention notes.
+
+## Dependencies / order
+
+- Step 1 (hi-res image pipeline) blocks step 2.
+- Step 4 (capability flag) blocks step 2 surfacing.
+- Steps 5–7 (policy + audit + timeouts) must all land before turning the feature on by default for any operator.
+- Step 8 (replay) and 9 (docs) follow.

--- a/docs/specs/2026-05-16-computer-use-loop/requirements.md
+++ b/docs/specs/2026-05-16-computer-use-loop/requirements.md
@@ -1,0 +1,36 @@
+# Requirements — Computer-use loop with high-res vision
+
+## Outcome
+
+OpenClaw can run an Anthropic computer-use loop on Claude Opus 4.7: the agent inspects browser/canvas/device screenshots at the model's new max resolution (2576px / 3.75MP), reasons about pixels, and performs `click`/`type`/`key`/`scroll` actions back through the existing browser + canvas + screen.record tool surface. Long-horizon agentic tasks ("book me a flight", "fill this form", "summarize what's on my screen") work end-to-end without a human in the inner loop.
+
+## Users affected
+
+- Operators driving long-running agentic tasks via chat or voice.
+- The browser tool — `src/browser/` (CDP-driven Chrome).
+- The canvas tool — `src/canvas-host/` (A2UI host).
+- The node tools — `src/node-host/` (screen.record, camera, system.run/notify on macOS).
+- The agent runtime — model selection, vision payload assembly, tool dispatch.
+
+## In scope
+
+- New `src/agents/tools/computer-use.ts` aggregating the existing browser/canvas/screen.record/click/keyboard primitives behind Anthropic's computer-use tool schema (model emits coordinate-based actions).
+- Vision pipeline upgrade: pass screenshots at up to 2576px on the longest edge (was previously downscaled). Adapt `src/media/image-ops.ts` to preserve resolution when the active model is Opus 4.7+.
+- Action coordinate system normalized to logical screen pixels with a one-place DPR map for Retina/4K capture.
+- Hard timeouts per action + per loop; whole-loop wall-clock budget configurable.
+- Allowlist by `computerUse.allowedHosts` for the browser surface and `computerUse.allowedNodes` for device targets.
+- Audit log of every action (URL, screenshot hash, click coords, typed text) under `~/.openclaw/agents/<agentId>/computer-use/<sessionKey>/`.
+
+## Out of scope
+
+- Replacing the existing browser/canvas tools — computer-use is a *layer* on top, not a rewrite.
+- Mobile (iOS/Android) computer-use via screen capture — punt to a follow-up; the camera and screen.record primitives are reused via `node.invoke` but app-driving on mobile is much harder.
+- Background headless agents running computer-use without operator presence — explicitly require an active session window.
+- Anthropic Managed Agents-side compute (server-side) — stay client-side.
+
+## Decisions
+
+- Coordinate space: logical screen pixels at capture-time DPR, snap to physical via the canvas/browser tool layer. Reason: matches Anthropic's documented expectation and avoids drift across multi-monitor / Retina setups.
+- Per-action wall clock 30s default. Reason: prevents the model from hanging on a stuck page.
+- Allowlist enforced at the *navigation* moment, not after the screenshot. Reason: avoids leaking pixels from an out-of-scope page.
+- Audit log retention = 7 days by default. Reason: enough for debugging without unbounded disk growth.

--- a/docs/specs/2026-05-16-computer-use-loop/validation.md
+++ b/docs/specs/2026-05-16-computer-use-loop/validation.md
@@ -1,0 +1,43 @@
+# Validation — Computer-use loop with high-res vision
+
+## Automated tests
+
+- `src/media/image-ops.test.ts` — hi-res capture preserves resolution when `supportsHiResVision=true`; downscale otherwise; 2576px ceiling honored.
+- `src/agents/tools/computer-use.test.ts` — every action type round-trips into the right underlying tool with correct coords.
+- `src/browser/dpr-coords.test.ts` — Retina + 4K + 100% DPR all map coords consistently.
+- `src/agents/tool-policy.test.ts` — host-allowlist deny returns a typed error rather than navigating.
+- `src/agents/computer-use-audit.test.ts` — JSONL rows + hashed screenshot files exist after a fixture run; secret params are redacted.
+- E2E: `scripts/e2e/computer-use-docker.sh` — headless Chromium runs a fixture form-fill task end-to-end with a mocked Opus 4.7 emitting scripted actions.
+
+## Smoke checks
+
+- `openclaw agent --message "open example.com and screenshot the hero image" --computer-use on` succeeds; audit log shows the screenshot.
+- Attempt a navigation outside the host allowlist; the model receives a tool error and stops.
+- `openclaw computer-use replay <session>` walks through the trace step by step.
+
+## Manual criteria
+
+- Click coords land where a human would click on Retina + non-Retina monitors.
+- Action timeouts feel right — the agent gives up on a stuck page in ≤ 30s rather than spinning.
+- Audit screenshots are diagnostic — small enough to inspect quickly, big enough to see what the model saw.
+
+## AI eval plan
+
+- Success criteria: on a 15-task computer-use suite (form fills, click targets, scroll-to-element, screenshot-and-summarize), ≥ 70% completion in ≤ 10 actions per task and zero out-of-allowlist navigations.
+- Eval dataset: `tests/evals/computer-use/` — fixture pages + expected outcomes; small enough to run on every PR.
+- Regression set: 4 tasks — single click, type-and-submit, scroll-and-read, navigate-to-forbidden-host (must refuse).
+- Cadence: per-PR on fixtures; nightly on the live-models matrix using a sandbox Chrome user data dir.
+
+## Risks & rollback
+
+- **Risks:**
+  - Hi-res screenshots blow up token usage. *Detect via* per-session token budget alerts and the new `/usage` surface from `2026-05-16-prompt-caching-and-1m-context`.
+  - Coord drift across multi-monitor configurations. *Detect via* the DPR test matrix; reproduce with `xrandr`-style fixtures.
+  - The model gets stuck in a loop clicking the same coord. *Mitigate* by per-action wall clock + a same-coord-loop detector that returns a typed error after N retries.
+  - Audit screenshots leak sensitive content (passwords filled into pages). *Mitigate* by the secret-param redaction + a default 7-day retention.
+- **Rollback:** set `computerUse.enabled=false` to remove the tool from the model's allowlist. PR revert is safe — the underlying browser/canvas tools work without computer-use enabled.
+
+## Open questions
+
+- Default action timeout — 30s vs. 60s? 30s is tighter but safer.
+- Should we offer a "training mode" that captures operator clicks as a starting point for future tasks? Defer to a follow-up spec.

--- a/docs/specs/2026-05-16-mcp-host/plan.md
+++ b/docs/specs/2026-05-16-mcp-host/plan.md
@@ -1,0 +1,26 @@
+# Plan — MCP host (client + server)
+
+## Approach
+
+Introduce a new `src/mcp/` module with two halves: a **client** (`src/mcp/client/`) that connects to remote MCP servers and registers their tools/resources/prompts into the agent tool registry, and a **server** (`src/mcp/server/`) that exposes openclaw's existing tool catalog over Streamable HTTP. Both use the same TypeBox schema layer as the rest of the codebase, the same fail-closed Gateway auth, and the same tool-policy gate (`src/agents/tool-policy.ts`). Configuration lives under `mcp.servers.<name>` (client side) and `mcp.expose` (server side). Elicitation is plumbed into the wizard RPC so URL-mode flows reuse the existing browser-open + form-render path.
+
+## Steps
+
+1. Add `src/mcp/protocol/` with TypeBox schemas for the November-2025 message types (initialize, tools/*, resources/*, prompts/*, sampling/*, roots/*, elicitation/*). Validate against `@sinclair/typebox`.
+2. Build `src/mcp/transport/` with Streamable HTTP (request/response + server-pushed events over a single HTTP connection) and STDIO transports. No SSE.
+3. Implement `src/mcp/client/` — connection lifecycle, capability negotiation, tool/resource/prompt enumeration, sampling callback bridging to the agent's LLM, roots enumeration from `config.mcp.roots`.
+4. Implement `src/mcp/auth/` — OAuth 2.1 Resource Server flow with PKCE, Resource Indicators (RFC 8707), CIMD client metadata published at `/.well-known/openclaw-mcp-client.json`. Token storage under `~/.openclaw/credentials/mcp/<server>.json` with the same secret-file ACL audit as web creds.
+5. Implement `src/mcp/server/` — expose the agent tool catalog plus a curated `resources` set (config snapshot, channel allowlists, session log paths). Bind under the Gateway's `/mcp` route. Reuse `gateway.auth` for token/password.
+6. Add `src/mcp/elicitation/` — translate MCP elicitation requests into wizard steps (URL → browser open; form → JSON-Schema render via existing wizard engine).
+7. Wire MCP tools into `src/agents/tool-policy.ts` so policy names like `mcp:<server>.<tool>` flow through allow/deny + group:web style rules.
+8. CLI: add `openclaw mcp list|add|remove|call|auth|whoami` and an `mcp` section to `openclaw configure`. Web UI: add a sessions/agent → MCP servers panel.
+9. Deprecate the `skills/mcporter` SKILL.md call paths once `openclaw mcp call` is on par; leave the binary install metadata for backwards compat.
+10. Doctor checks: warn on un-auth'd remote MCP servers; warn when openclaw-as-server is exposed without a token; warn on SSE-only legacy servers.
+
+## Dependencies / order
+
+- Steps 1–2 block everything else.
+- Step 3 (client) and step 5 (server) are independent and can ship in parallel once 1–2 are merged.
+- Step 4 (auth) blocks step 3 for any production-grade external server, but can be stubbed for STDIO-only local testing.
+- Step 8 (CLI/UI) depends on 3 and 5.
+- Step 9 only after `openclaw mcp call` reaches parity with `mcporter call`.

--- a/docs/specs/2026-05-16-mcp-host/requirements.md
+++ b/docs/specs/2026-05-16-mcp-host/requirements.md
@@ -1,0 +1,35 @@
+# Requirements — MCP host (client + server)
+
+## Outcome
+
+OpenClaw natively speaks Model Context Protocol: the Gateway can connect to remote MCP servers (Streamable HTTP transport, OAuth 2.1) and surface their tools/resources/prompts to agents, AND the Gateway can expose its own tools/resources/prompts as an MCP server consumable by Claude.ai, Claude Code, Claude Agent SDK, OpenAI Realtime, and any other MCP client. The ad-hoc `skills/mcporter` CLI wrapper is no longer needed for first-class use.
+
+## Users affected
+
+- Operator configuring tool surface (`openclaw configure --section mcp` or `mcp.servers.*` config keys).
+- Plugin authors wrapping external services as MCP servers instead of openclaw plugins.
+- External agents (Claude.ai, ChatGPT Realtime, Claude Code) connecting back into a running Gateway.
+- Tool surfaces: CLI (`openclaw mcp list`, `openclaw mcp call`), Web UI MCP panel, agent runtime tool registry.
+
+## In scope
+
+- MCP client speaking the November-2025 spec (Streamable HTTP transport replacing SSE; STDIO retained for local servers).
+- All five primitives: tools, resources, prompts, sampling, roots.
+- OAuth 2.1 Resource Server auth with RFC 8707 resource indicators; Client ID Metadata Documents (CIMD) preferred over Dynamic Client Registration.
+- Elicitation handling in both URL mode (open browser for OAuth/credentials/payment) and form mode (gateway renders a structured form via the wizard).
+- MCP server exposure of the openclaw tool catalog (browser, canvas, cron, sessions_*, channel send, skills) over Streamable HTTP, gated by the existing fail-closed Gateway auth.
+- Surface MCP tools through the same allow/deny policy used for built-in tools (`tool-policy.ts`).
+
+## Out of scope
+
+- Replacing the existing in-process tool API for built-in tools — MCP is an additional integration layer, not a rewrite.
+- Hosting a public MCP server registry (we may publish into the public registry but do not run one).
+- Migrating the 50+ `skills/*` directories to MCP servers — covered separately by `2026-05-16-agent-skills-interop`.
+- Cross-tenant auth (openclaw stays single-operator; OAuth scopes are per-operator).
+
+## Decisions
+
+- Streamable HTTP transport for remote servers; STDIO only for local user-installed servers. Reason: SSE is deprecated in the 2025-11 spec.
+- CIMD over DCR. Reason: spec-recommended since 2025-11 and avoids a per-client DB on the authorization server.
+- Expose openclaw-as-server under the existing Gateway WS host on a sibling HTTP route (`/mcp`), not a new port. Reason: reuses Tailscale Serve/Funnel + token/password auth that already gates the Gateway.
+- Reuse existing `openclaw doctor` for misconfiguration surfacing. Reason: consistent operator UX.

--- a/docs/specs/2026-05-16-mcp-host/validation.md
+++ b/docs/specs/2026-05-16-mcp-host/validation.md
@@ -1,0 +1,45 @@
+# Validation — MCP host (client + server)
+
+## Automated tests
+
+- `src/mcp/protocol/*.test.ts` — schema round-trips for every November-2025 message type.
+- `src/mcp/transport/streamable-http.test.ts` — request/response, server push, reconnect/resume, 401 → reauth path.
+- `src/mcp/client/connection.test.ts` — initialize, capability negotiation, tool enumeration, sampling callback.
+- `src/mcp/auth/oauth.test.ts` — PKCE, Resource Indicators, CIMD metadata publish, token refresh.
+- `src/mcp/server/route.test.ts` — Gateway `/mcp` route enforces fail-closed auth; rejects without token/password; honors `tool-policy` deny lists.
+- `src/mcp/elicitation/wizard-bridge.test.ts` — URL-mode opens browser via the existing helper; form-mode renders via wizard JSON-Schema engine.
+- `scripts/e2e/mcp-host-docker.sh` — Docker E2E: bring up a reference MCP server fixture, connect openclaw client, call a tool, verify result.
+- `scripts/e2e/mcp-server-docker.sh` — Docker E2E: connect Claude Code / a stub MCP client to openclaw-as-server, list tools, call browser+session tool, verify auth gate.
+
+## Smoke checks
+
+- `openclaw mcp add demo --url https://mcp.example/ --auth oauth` → completes OAuth → `openclaw mcp list` shows server.
+- `openclaw mcp call demo.echo text=hi` returns `hi`.
+- `curl -H "Authorization: Bearer $TOKEN" $GATEWAY/mcp/initialize` returns server capabilities.
+- `openclaw doctor` flags an MCP server that is configured without auth.
+
+## Manual criteria
+
+- The Web UI MCP panel lists the same servers/tools as `openclaw mcp list`.
+- Elicitation prompts during onboarding feel native (same palette + spinner as `src/cli/progress.ts`).
+- Errors from upstream MCP servers surface user-readable messages, not raw RPC dumps.
+
+## AI eval plan
+
+- Success criteria: when an MCP tool is available, the agent picks it for an in-scope request ≥ 90% of the time over a 30-prompt eval set covering 3 demo servers (github, filesystem, fetch); zero attempts to call a deny-listed MCP tool over 100 sampled traces.
+- Eval dataset: `tests/evals/mcp-tool-routing.jsonl` — operator prompts + expected MCP tool selection (build it once on first ship, store in repo).
+- Regression set: 6 prompts spanning resource fetch, tool call with auth, elicitation prompt mid-loop, sampling callback, denied tool, malformed server response.
+- Cadence: run on every PR that touches `src/mcp/**` and nightly against the live-models matrix.
+
+## Risks & rollback
+
+- **Risks:**
+  - Streamable HTTP server-push semantics interact badly with reverse-proxy idle timeouts. *Detect via* `gateway-network` E2E and the new `mcp-host-docker` script.
+  - OAuth 2.1 CIMD adoption is uneven across MCP servers; some still want DCR. *Mitigate* by supporting DCR as a fallback flag, log to doctor.
+  - Server-mode exposure widens the Gateway attack surface. *Detect via* doctor warnings + the existing trusted-proxy detection that treats non-local Host headers as remote.
+- **Rollback:** revert the PR; the `mcp.servers` config block is additive (existing tools keep working). For server-mode, set `mcp.expose=false` to unbind `/mcp` without redeploying.
+
+## Open questions
+
+- Do we ship a curated resources surface in v1, or start tools-only and add resources in a follow-up? (Decide before Step 5.)
+- Should the openclaw-as-server registration land in the public MCP registry by default, or opt-in via config? (Decide before Step 5 ships.)

--- a/docs/specs/2026-05-16-openai-realtime-talk-mode/plan.md
+++ b/docs/specs/2026-05-16-openai-realtime-talk-mode/plan.md
@@ -1,0 +1,25 @@
+# Plan — OpenAI Realtime API for Talk Mode + Voice Wake
+
+## Approach
+
+Add a Realtime adapter layer to the agent runtime that owns a long-lived OpenAI Realtime session per active Talk Mode session, bridges audio in/out, and re-uses the existing tool registry. On the device side, the macOS/iOS/Android apps stream microphone audio over WebRTC to the Gateway, which forwards (after auth) to OpenAI Realtime. The current TTS/STT pipeline becomes a fallback for environments where Realtime keys aren't configured. The `VoiceWakeForwarder` PATH/command pattern (`openclaw-mac agent --message "${text}" --thinking low`) stays compatible because the wake path still emits a final transcript via `gpt-realtime-whisper` before invoking the agent.
+
+## Steps
+
+1. Add `src/agents/realtime/session.ts` — OpenAI Realtime client built on `ws` + `undici` per-account proxy dispatcher; capability negotiation; tool registration mapping `tool-policy` allowlist into `tools` field on session config.
+2. Add `src/agents/realtime/audio-bridge.ts` — pcm16 ↔ Opus / WebM transcoding; sample-rate handling for Apple ↔ Android ↔ server side.
+3. Extend the Gateway WS protocol (`src/gateway/`) with a `realtime.open|input|output|close` message family. Generate Swift bindings via `pnpm protocol:gen:swift` (then `pnpm protocol:check`).
+4. `apps/macos`, `apps/ios`, `apps/android` — point Talk Mode and Voice Wake at the new Gateway methods. Reuse existing Canvas / camera capture; pipe captured frames as image input to the Realtime session.
+5. Voice Wake STT path: replace the current transcription helper with a single Realtime-Whisper call that streams a final transcript, then invokes the text agent as today. Keep the launchd PATH fix from `AGENTS.md`.
+6. Tool dispatch: wire long-running tool calls into the Realtime `function_call` event flow such that the model keeps talking while a browser/canvas call runs (Realtime now tolerates long function calls).
+7. MCP tools (from `2026-05-16-mcp-host`) surface to Realtime via the session config — same allowlist, no separate registration.
+8. Config: `voice.realtime.enabled`, `voice.realtime.model` (default `gpt-realtime-2`), `voice.realtime.reasoningEffort` (default `low`), `voice.realtime.whisperModel` (default `gpt-realtime-whisper`). Onboarding wizard asks for `OPENAI_REALTIME_API_KEY` (separate from existing OpenAI key — allows different quota).
+9. Fallback: if Realtime config is absent, route Talk Mode through the current TTS+text+STT pipeline unchanged.
+
+## Dependencies / order
+
+- Steps 1–2 block everything else.
+- Step 3 (protocol) blocks step 4 (apps).
+- Step 6 (long tool calls) depends on step 1.
+- Step 7 (MCP) depends on `2026-05-16-mcp-host` shipping the client side.
+- Step 9 (fallback) is a guard; can land first to avoid breaking existing users.

--- a/docs/specs/2026-05-16-openai-realtime-talk-mode/requirements.md
+++ b/docs/specs/2026-05-16-openai-realtime-talk-mode/requirements.md
@@ -1,0 +1,34 @@
+# Requirements — OpenAI Realtime API for Talk Mode + Voice Wake
+
+## Outcome
+
+Talk Mode (continuous conversation) and Voice Wake (push-to-talk / wake-word transcription) on the macOS/iOS/Android apps run on OpenAI's GA Realtime API: `gpt-realtime-2` for the conversational loop and `gpt-realtime-whisper` for streaming speech-to-text, replacing the current TTS+STT round-trip stack. Long-running tool calls (browser, canvas, channel send) don't interrupt the voice loop.
+
+## Users affected
+
+- Operators using Voice Wake / Talk Mode on Apple/Android devices.
+- The agent runtime — currently routes voice through transcription → text agent → TTS in three steps.
+- The `extensions/voice-call` plugin (separate Twilio path — coordinated, not replaced here).
+- Talk Mode UI in `apps/macos`, `apps/ios`, `apps/android`.
+
+## In scope
+
+- New `src/agents/realtime/` runtime that holds a WebRTC/WebSocket Realtime session, streams audio in, streams audio + transcripts out, and dispatches tool calls through the same `tool-policy` + `sessions_*` machinery as the text loop.
+- `gpt-realtime-2` for the conversational model; configurable reasoning effort (minimal / low / medium / high / very-high) — default `low` to match the existing Voice Wake forwarder.
+- `gpt-realtime-whisper` for streaming STT in Voice Wake (push-to-talk capture → final transcript before the text agent runs).
+- Image input through the Realtime API (camera snap / canvas screenshot piped inline).
+- MCP server tools surfaced to Realtime via the Realtime API's MCP server support.
+- Fallback to the current pipeline when `OPENAI_REALTIME_API_KEY` is absent.
+
+## Out of scope
+
+- SIP phone-call answering (covered by `2026-05-16-sip-phone-channel`).
+- Realtime translation channel (the `gpt-realtime-translate` integration is a follow-up; tracked separately).
+- Anthropic voice (no GA realtime voice from Anthropic as of May 2026).
+- Removing the existing `node-edge-tts` / ElevenLabs paths — they stay as cheap fallbacks for text-only TTS in non-Talk contexts.
+
+## Decisions
+
+- WebSocket transport for the macOS/Linux Gateway → OpenAI Realtime hop; WebRTC for the iOS/Android nodes → Gateway hop. Reason: WebRTC handles client-side jitter; the server→OpenAI side benefits from the simpler WS transport.
+- Default reasoning effort `low`. Reason: matches today's `openclaw-mac agent --thinking low` convention so existing operators don't get unexpected latency.
+- Keep streaming OFF for external messaging channels. Reason: existing rule (no partials to WhatsApp/Telegram/etc.). Voice surfaces are internal so streaming is fine.

--- a/docs/specs/2026-05-16-openai-realtime-talk-mode/validation.md
+++ b/docs/specs/2026-05-16-openai-realtime-talk-mode/validation.md
@@ -1,0 +1,45 @@
+# Validation — OpenAI Realtime API for Talk Mode + Voice Wake
+
+## Automated tests
+
+- `src/agents/realtime/session.test.ts` — connection lifecycle, capability negotiation, tool registration, reasoning-effort config plumb-through.
+- `src/agents/realtime/audio-bridge.test.ts` — pcm16↔Opus round-trip, sample-rate conversion, silence/EOS handling.
+- `src/gateway/realtime-rpc.test.ts` — new WS methods accept/reject per fail-closed auth; protocol schema validates.
+- `pnpm protocol:check` — confirms `dist/protocol.schema.json` + Swift bindings stay in sync.
+- Apps unit tests (XCTest + JUnit) — Talk Mode state machine + Voice Wake forwarder.
+- `vitest.live.config.ts` matrix entry for Realtime: gated on `OPENAI_REALTIME_LIVE=1`, exercises a 30-second conversation with one tool call.
+
+## Smoke checks
+
+- `openclaw configure --section voice` shows the new Realtime section with the masked key.
+- macOS: hold-to-talk via the menu bar; speak "what time is it?"; expect spoken reply.
+- macOS: Talk Mode toggle; ask the agent to "search the web for X" → tool call fires, audio reply resumes without dropping the channel.
+- Voice Wake (mobile): say the wake word; the final transcript appears in the chat surface and the agent answers via Realtime audio.
+- Fallback test: remove `OPENAI_REALTIME_API_KEY`; Talk Mode degrades to the previous TTS/STT path without errors.
+
+## Manual criteria
+
+- Latency from end-of-speech to first audio output ≤ 800ms on a wired Mac in good network conditions (subjective on mobile cellular).
+- Echo/duplex is acceptable — the device doesn't pick up its own output as new input.
+- Reasoning-effort `low` doesn't add perceived sluggishness vs. the old pipeline.
+
+## AI eval plan
+
+- Success criteria: on a 25-prompt voice-eval set spanning Q&A, multi-turn, tool calls, and image inputs, transcript WER ≤ 5% (vs. a reference transcript) and tool-call accuracy ≥ 90%.
+- Eval dataset: `tests/evals/realtime-voice/` — short WAV clips + expected transcripts + expected tool selections.
+- Regression set: 6 cases — "hello", "remember Y", "search X", "look at this image" (with camera snap), "stop", barge-in mid-reply.
+- Cadence: live matrix on every PR that touches `src/agents/realtime/` or the apps' Talk Mode views; nightly on the live-models matrix.
+
+## Risks & rollback
+
+- **Risks:**
+  - WebRTC NAT traversal fails on some networks. *Detect via* a TURN fallback config + the `gateway-network` E2E.
+  - Realtime usage bills against a different OpenAI quota than text — operators get surprise costs. *Mitigate* by surfacing per-session token + audio-second usage in `/usage`.
+  - Audio sync drift on long sessions. *Detect via* timed echo test in the live matrix.
+  - Long-running tool calls block the loop on older Realtime versions. *Mitigate* by gating on the GA model id; doctor warns when set to a pre-GA id.
+- **Rollback:** set `voice.realtime.enabled=false` to revert to the old pipeline. PR revert is safe because step 9 (fallback) preserves existing behavior.
+
+## Open questions
+
+- Should the camera-snap image input fire automatically on every Talk Mode turn, or only when the operator opts in per session? Lean opt-in for privacy.
+- How do we expose audio-second usage in the existing `/usage` chat command? (Decide before Step 8 ships.)

--- a/docs/specs/2026-05-16-prompt-caching-and-1m-context/plan.md
+++ b/docs/specs/2026-05-16-prompt-caching-and-1m-context/plan.md
@@ -1,0 +1,22 @@
+# Plan — 1-hour prompt caching + flat-rate 1M context
+
+## Approach
+
+Extend `src/agents/pi-embedded-runner/extra-params.ts` (which already injects `cache_control` markers) so the markers are TTL-aware and the breakpoints are placed by a small policy module that knows the session's stable prefix shape (system prompt, MEMORY preamble, skill manifests). Add `context.window` plumbing into the same request-builder so the 1M flat-rate context can be enabled per session. Cache + window state surface through `/usage` and `/status`.
+
+## Steps
+
+1. Add `src/agents/pi-embedded-runner/cache-markers.ts` — given the request payload, identify the stable prefix segments and emit `cache_control: { type: "ephemeral", ttl: "5m" | "1h" }` markers at the right boundaries.
+2. Extend extra-params to honor the per-session `cache.ttl` setting; existing hardcoded 5m markers become the auto default.
+3. Add `context.window="1M"` plumb-through in `src/agents/model-catalog.ts` capability flags + the request builder; reject when the model can't.
+4. Per-session config + `sessions.patch` extension (alongside the `taskBudget` patch from the budgets spec): `cache.ttl`, `context.window`.
+5. `/usage` extension — track cache-write, cache-read, cached-input token columns; show hit-rate %. Underlying counters come from the Anthropic usage object.
+6. `openclaw doctor` — warn on `cache.ttl=1h` set against a non-cache-capable model; warn on `context.window=1M` against non-1M models.
+7. CLI: `openclaw sessions set <key> --cache-ttl 1h --context-window 1M`.
+8. Docs: extend `docs/concepts/models.md` with caching + 1M context notes.
+
+## Dependencies / order
+
+- Step 1 (markers) blocks step 2.
+- Step 3 (1M plumb-through) is independent; can ship first.
+- Step 5 (`/usage`) depends on 1–3 to have data to show.

--- a/docs/specs/2026-05-16-prompt-caching-and-1m-context/requirements.md
+++ b/docs/specs/2026-05-16-prompt-caching-and-1m-context/requirements.md
@@ -1,0 +1,32 @@
+# Requirements — 1-hour prompt caching + flat-rate 1M context
+
+## Outcome
+
+Operators can enable per-session 1-hour prompt caching (cache writes at 2× base, reads at 0.1× — Anthropic May 2026 pricing) and opt into the flat-rate 1M context window on Opus 4.7 and Sonnet 4.6 without per-message ceremony. The Gateway auto-routes high-reuse system prompts + skill bundles + memory directories through `cache_control` and reports cache hit rate per session in `/usage`.
+
+## Users affected
+
+- Operators running long, repeat-prompt-shaped sessions (interactive chats with stable system context, agents with large bundled skills).
+- The agent runtime — `src/agents/pi-embedded-runner/extra-params.ts` already understands `cache_control` (hardcoded 5-minute markers); we extend to 1h.
+- Cost reporting — `/usage` chat command, `src/agents/usage-tracking`.
+
+## In scope
+
+- Per-session `cache.ttl = "5m" | "1h" | "off"` (default `5m` to preserve current behavior).
+- Auto-mark cache breakpoints for: system prompt, MEMORY.md preamble, bundled-skill manifests, large attachments. Operator can override the auto markers.
+- Per-session `context.window = "default" | "1M"` for capable models. Auto-rejects on non-capable models with a clear error.
+- `/usage` shows `cached_input`, `cache_write`, `cache_read` token columns + hit-rate %.
+- Doctor warning when `cache.ttl=1h` is used with a model that doesn't support it.
+
+## Out of scope
+
+- Cross-session cache sharing (Anthropic doesn't expose it; we don't fake it).
+- Pre-warming caches at startup.
+- Custom cache TTLs beyond the two Anthropic offers (5m / 1h).
+- Provider-specific caching for non-Anthropic providers (each has its own model + may not have caching).
+
+## Decisions
+
+- Default TTL `5m`, not `1h`. Reason: 1h write is 2× base — easy to overspend if the session doesn't reuse enough.
+- Auto-mark the system prompt + skill bundle by default; don't auto-mark user messages. Reason: the system prompt is stable across turns; user messages aren't.
+- 1M context is opt-in per session, not per agent. Reason: avoid accidental enable on short sessions where the flat rate is still wasted token allocation.

--- a/docs/specs/2026-05-16-prompt-caching-and-1m-context/validation.md
+++ b/docs/specs/2026-05-16-prompt-caching-and-1m-context/validation.md
@@ -1,0 +1,40 @@
+# Validation — 1-hour prompt caching + flat-rate 1M context
+
+## Automated tests
+
+- `src/agents/pi-embedded-runner/cache-markers.test.ts` — markers placed at expected segment boundaries; TTL honored.
+- `src/agents/pi-embedded-runner/extra-params.test.ts` — `ttl: "1h"` emitted when configured; `5m` by default; absent when `off`.
+- `src/agents/model-catalog.test.ts` — `supportsCaching` + `supportsMillionContext` true/false for known models.
+- `src/agents/usage-tracking.test.ts` — cache-write/read/hit-rate counters correctly aggregated.
+- E2E: `scripts/e2e/cache-budget-docker.sh` — fixture long-session that should hit ≥ 80% cache-read on turn 5+ against a stub provider.
+- Live: gated `OPENCLAW_LIVE_TEST=1` — three-turn conversation reports a real hit rate above 0 on a cache-capable model.
+
+## Smoke checks
+
+- `openclaw sessions set <key> --cache-ttl 1h` then `/usage` after two turns shows non-zero `cache_read`.
+- `openclaw sessions set <key> --context-window 1M` on Opus 4.7 succeeds; on a non-capable model errors clearly.
+- `openclaw doctor` flags an incompatible combo.
+
+## Manual criteria
+
+- `/usage` columns are readable; hit-rate % is easy to spot.
+- Operator can tell whether their session is benefiting from caching at a glance.
+
+## AI eval plan
+
+- Success criteria: on a 10-session fixture of repeat-shaped chats, average `cache_read` ratio ≥ 60% with default 5m markers, ≥ 85% with 1h markers when sessions span >5min.
+- Eval dataset: `tests/evals/cache-replay/` — recorded session shapes (system prompt + skill bundle + user turn pattern).
+- Regression set: 3 sessions — short (1 turn), medium (5 turns over 4min), long (10 turns over 30min).
+- Cadence: per-PR on fixtures; nightly on the live-models matrix to validate Anthropic returns the cache counters we expect.
+
+## Risks & rollback
+
+- **Risks:**
+  - Operator enables `1h` on a short session and overpays for the cache write. *Mitigate* with `/usage` visibility and a doctor hint.
+  - 1M context surcharge surprise on a model that *advertises* 1M but Anthropic adds a flat fee later. *Detect via* the usage tracker; surface the per-call cost.
+  - Marker placement breaks deterministic prefix on a future Pi SDK upgrade. *Detect via* the marker placement test.
+- **Rollback:** set `cache.ttl=off` and `context.window=default` per session. PR revert is safe.
+
+## Open questions
+
+- Should the cache markers preserve through a `/compact` operation, or be rebuilt? Probably rebuilt, since the prefix changes.

--- a/docs/specs/2026-05-16-sip-phone-channel/plan.md
+++ b/docs/specs/2026-05-16-sip-phone-channel/plan.md
@@ -1,0 +1,24 @@
+# Plan — SIP phone channel
+
+## Approach
+
+Add `src/phone/` as a new built-in channel that registers a SIP trunk against OpenAI Realtime's SIP endpoint and surfaces inbound calls to the Gateway as `phone:<E.164>` session keys. The channel reuses the existing `src/agents/realtime/` runtime (from `2026-05-16-openai-realtime-talk-mode`) so the Realtime session, tool dispatch, and transcript persistence are shared. Allowlist + pairing flows go through `src/channels/` + `src/pairing/` exactly like Telegram/Discord/Slack today.
+
+## Steps
+
+1. Add `src/phone/sip-bridge.ts` — registers the operator's SIP credentials with OpenAI's Realtime SIP endpoint; emits `phone.callRing` / `phone.callAccepted` / `phone.callEnded` events into the Gateway event bus.
+2. Add `src/phone/session.ts` — when a call rings, derive `sessionKey="phone:<E.164>"`, check allowlist, run pairing flow for unknown callers (TTS the pairing code, capture DTMF or spoken approval code back), then hand off to the Realtime runtime.
+3. Add `src/phone/pairing.ts` — DTMF + voice approval flow; reuses `src/pairing/pairing-store.ts` so approvals carry to other channels.
+4. Add `src/phone/transcripts.ts` — persist call audio + transcript under `~/.openclaw/agents/<agentId>/sessions/phone-<timestamp>.jsonl` and (optional) `.opus`. Honor the recording opt-in flag.
+5. Channel registration: add `phone` to `src/channels/channel-config.ts` so allowlists, command gating, and conversation labels work consistently.
+6. Routing: extend `src/routing/resolve-route.ts` to map `phone:<E.164>` to the right agent under the operator's `routing` config.
+7. CLI: `openclaw phone status`, `openclaw phone pairing approve <code>`, `openclaw phone test --to <number>` (dry-run, no actual call).
+8. Doctor: warn on missing SIP creds; warn when allowlist is empty AND `dmPolicy="open"`; warn when the SIP trunk's domain doesn't match its TLS cert.
+9. Docs: `docs/channels/phone.mdx` + a deployment guide for at least one SIP provider as an example (no preference, but a worked example helps adoption).
+
+## Dependencies / order
+
+- Whole feature depends on `2026-05-16-openai-realtime-talk-mode` shipping `src/agents/realtime/`.
+- Steps 1–2 (SIP bridge + session) block everything.
+- Step 3 (pairing) blocks first-call usability.
+- Steps 7–9 land after the core path works end-to-end.

--- a/docs/specs/2026-05-16-sip-phone-channel/requirements.md
+++ b/docs/specs/2026-05-16-sip-phone-channel/requirements.md
@@ -1,0 +1,35 @@
+# Requirements — SIP phone channel
+
+## Outcome
+
+A new `phone` channel lets the openclaw assistant answer real phone calls via OpenAI Realtime API's GA SIP integration: inbound calls hit a SIP trunk, the Realtime API answers with `gpt-realtime-2`, the conversation is treated as a normal session (with tool calls, session keys, allowlists, channel routing) and ends with a transcript filed under `~/.openclaw/agents/<agentId>/sessions/`. The existing `extensions/voice-call` Twilio path coexists for outbound and SMS but is no longer the primary way to handle inbound voice.
+
+## Users affected
+
+- Operators who want a phone number their AI assistant can answer (personal hotline, "call my assistant").
+- Channel routing — `src/channels/`, `src/routing/` — must learn about a `phone` channel kind.
+- Pairing / DM allowlist — phone numbers feed into the same allowlist model as Telegram/WhatsApp/etc.
+- `openclaw doctor` — surfaces SIP credential and number health.
+
+## In scope
+
+- New built-in channel `src/phone/` with SIP signaling proxy or, more practically, an OpenAI Realtime SIP endpoint configuration that registers the operator's SIP trunk credentials.
+- Inbound: caller-ID → session key derivation; default `dmPolicy="pairing"` like other channels; pairing message played via TTS for unknown callers.
+- Outbound: not in scope here (operator-initiated calling stays on `extensions/voice-call`).
+- Per-session conversation routed through the same agent runtime as text channels (full tool-call support, transcripts saved, `/status` `/new` chat commands available via DTMF or by the agent reading them).
+- Recording: opt-in per session (`phone.recording=on|off`), with consent prompt at call start when on.
+- Number provisioning: docs only — operator brings their own SIP trunk (e.g., Twilio Programmable SIP, Telnyx, etc.).
+
+## Out of scope
+
+- Cold outbound dialing (a separate spec; the assistant placing a call on the operator's behalf needs a different consent + cost model).
+- Replacing or removing `extensions/voice-call` — it remains for Twilio-specific SMS + ngrok-tunneled webhooks.
+- SMS via SIP (some carriers bundle it; keep it on the existing Twilio path).
+- IVR menus and complex call trees — keep the call surface as natural conversation only.
+
+## Decisions
+
+- Use OpenAI Realtime SIP integration rather than a custom SIP stack. Reason: it's GA, handles RTP/STUN/TURN, and ties to the same Realtime session shape used by Talk Mode.
+- Reuse `dmPolicy="pairing"` semantics with phone numbers normalized to E.164. Reason: matches the inbound DM trust posture across all channels.
+- Recording opt-in, not opt-out. Reason: legal exposure is asymmetric and consent rules vary by jurisdiction.
+- Default reasoning effort `low` like Talk Mode. Reason: latency budget on a phone call is tight (~700ms human tolerance for response gaps).

--- a/docs/specs/2026-05-16-sip-phone-channel/validation.md
+++ b/docs/specs/2026-05-16-sip-phone-channel/validation.md
@@ -1,0 +1,44 @@
+# Validation — SIP phone channel
+
+## Automated tests
+
+- `src/phone/sip-bridge.test.ts` — registration handshake, reconnect on disconnect, event emission for ring/accept/end.
+- `src/phone/session.test.ts` — session key derivation, allowlist gate, pairing fallthrough for unknown callers.
+- `src/phone/pairing.test.ts` — DTMF approval flow; voice approval transcribed to a code; pairing-store integration with cross-channel approval.
+- `src/phone/transcripts.test.ts` — JSONL persistence, optional audio recording, consent-prompt sequencing.
+- `src/channels/phone-routing.test.ts` — `phone:` session keys route to the configured agent.
+- Live test (gated on `OPENCLAW_PHONE_LIVE_TEST=1`): place a real call against a sandbox SIP trunk and assert ring → answer → tool call → hangup.
+
+## Smoke checks
+
+- `openclaw phone status` shows trunk registration + last-call timestamp.
+- From an allowlisted number, call the trunk; greeting plays; ask the agent to "search for the weather in Lima"; reply lands within ~1.5s.
+- From an unknown number, call the trunk; pairing code is read aloud; `openclaw pairing approve phone <code>` succeeds; subsequent calls bypass pairing.
+- `openclaw doctor` flags an open `dmPolicy` on `phone` with an empty allowlist.
+
+## Manual criteria
+
+- Greeting voice sounds natural, not robotic; reasoning-effort `low` doesn't introduce conversational gaps the caller notices.
+- Recording consent prompt is the first sentence on the call when recording is on.
+- Hangup detection is reliable — sessions don't dangle (verifiable via `~/.openclaw/agents/<agentId>/sessions/phone-*.jsonl` having a clean end event).
+
+## AI eval plan
+
+- Success criteria: 90% tool-call accuracy on a 20-prompt phone-eval set (voice WAVs + expected tool selection + expected final reply intent); ≤ 1s 95p time-to-first-audio after end-of-utterance.
+- Eval dataset: `tests/evals/phone-call-eval/` — voice samples + expected outcomes.
+- Regression set: pairing flow (unknown caller), allowlist accept, allowlist reject, mid-call tool call, hangup-during-tool-call.
+- Cadence: nightly on the phone live matrix when `OPENCLAW_PHONE_LIVE_TEST=1` is set; per-PR on the offline fixtures.
+
+## Risks & rollback
+
+- **Risks:**
+  - SIP/RTP traversal varies by trunk provider. *Detect via* a documented test matrix in `docs/channels/phone.mdx`.
+  - Caller-ID spoofing — bad actor calls in claiming to be an allowlisted number. *Mitigate* by requiring STIR/SHAKEN verification on the trunk and falling back to pairing when verification is absent.
+  - Long calls rack up Realtime audio costs invisibly. *Mitigate* by surfacing audio-second cost in `/usage` and an optional per-call cap (`phone.maxDurationSec`).
+  - Recording without consent — legal risk. *Mitigate* by hard-defaulting `phone.recording=off` and gating recording start on a consent prompt heard by the caller.
+- **Rollback:** unregister the SIP trunk; revert the PR; the new `phone` channel is additive.
+
+## Open questions
+
+- Which SIP provider do we showcase in docs? Suggested: pick the cheapest provider with documented OpenAI Realtime compatibility before merge.
+- Should we charge a per-call PIN check on top of allowlist? Probably no for v1 (it doubles the friction).

--- a/docs/specs/2026-05-16-task-budgets/plan.md
+++ b/docs/specs/2026-05-16-task-budgets/plan.md
@@ -1,0 +1,24 @@
+# Plan — Task budgets
+
+## Approach
+
+Store `taskBudget` on the session record alongside the existing `thinkingLevel`, `verboseLevel`, `model`, `sendPolicy`, `groupActivation` keys patched via `sessions.patch`. Plumb it into Pi-embedded extra-params so the Anthropic task-budget primitive is emitted on every model turn (the model sees the countdown and adapts). Compaction safeguard reads the remaining budget and tightens. Chat commands `/budget` + updated `/status` + `/usage` give the operator live visibility.
+
+## Steps
+
+1. Extend `src/sessions/` session schema with optional `taskBudget: { tokens?: number, wallClockMs?: number, compactionPolicy?: "tight"|"normal" }`.
+2. Extend `sessions.patch` WS method (and the corresponding Swift/Web UI bindings) to accept `taskBudget` updates; regenerate via `pnpm protocol:check`.
+3. Track `spent` and `startedAt` per turn in `src/agents/pi-embedded-runner/` so `remaining = tokens - spent` is available before each model call.
+4. Inject Anthropic task-budget params into `pi-embedded-runner/extra-params.ts` when the model supports it and budget is set.
+5. Wire a soft wall-clock guard: `setTimeout` that calls `agent.stop()` with a typed end-of-loop event.
+6. Compaction safeguard (`src/agents/`) reads `remaining` and chooses a shorter compaction summary when remaining < threshold.
+7. Chat commands: add `/budget <tokens>` and `/budget reset` to the auto-reply registry (`src/auto-reply/commands-registry.ts`); extend `/status` + `/usage` output to include `budget=` + `remaining=` rows.
+8. CLI: `openclaw sessions set <sessionKey> --budget-tokens 50000 --budget-wallclock 600000`.
+9. Docs: extend `docs/concepts/session.md` + add a "task budgets" subsection.
+
+## Dependencies / order
+
+- Steps 1–2 (schema + RPC) block everything else.
+- Step 3 (accounting) blocks 4 and 6.
+- Step 5 (wall clock) is independent.
+- Steps 7–9 land after the core path works.

--- a/docs/specs/2026-05-16-task-budgets/requirements.md
+++ b/docs/specs/2026-05-16-task-budgets/requirements.md
@@ -1,0 +1,34 @@
+# Requirements — Task budgets
+
+## Outcome
+
+Long-running agent sessions can be given a token budget for an entire agentic loop; the model receives a running countdown and uses it to prioritize work, surface progress, and stop gracefully when the budget is exhausted. Operators see budget + spent in `/usage` and `/status`, and compaction triggers honor the remaining budget (so we don't compact away context the model still needs for the budget it was given).
+
+## Users affected
+
+- Operators starting a long agentic task (e.g., "fix the failing test suite", "summarize this 500-page PDF").
+- Pi-embedded agent runtime — `src/agents/pi-embedded-runner/`.
+- Session model — `src/sessions/`, particularly `sessions.patch` (per-session settings) and the compaction safeguard.
+- Chat commands — `/status`, `/usage`, `/compact` need to expose budget state.
+
+## In scope
+
+- Per-session `taskBudget` setting (`tokens`, `wallClockMs`, `compactionPolicy`) configurable via `sessions.patch` and a new `/budget <n>` chat command.
+- Inject Anthropic's task-budget primitive into the request extra-params when on Opus 4.7+ via `src/agents/pi-embedded-runner/extra-params.ts`.
+- Budget countdown visible in `/status` and in the existing `/usage` footer when enabled.
+- Compaction safeguard reads `remainingBudget` and prefers a smaller summary when the budget is tight.
+- Auto-stop on budget exhaustion with a typed end-of-loop result the operator sees as a final reply.
+
+## Out of scope
+
+- Cost-based budgets in dollars — keep it tokens + wall-clock for v1 (cost can be derived).
+- Cross-session budget pooling.
+- Budget enforcement for non-Anthropic providers (the primitive is Anthropic-specific in May 2026; for other providers we maintain a soft local guard but the model doesn't see the countdown).
+- Auto-extend on budget hit — operator-initiated only.
+
+## Decisions
+
+- Token budget is the primary unit. Reason: it's what the Anthropic primitive expects and what compaction reasons about.
+- `wallClockMs` is an additional soft cap that ends the loop without involving the model. Reason: protects against runaway tool-call loops that don't burn many tokens.
+- Default budget = unset (current behavior unchanged). Reason: avoid surprising current operators.
+- Surface `remainingBudget` in `/status` even when budget is unset — show "no budget" rather than hide the row.

--- a/docs/specs/2026-05-16-task-budgets/validation.md
+++ b/docs/specs/2026-05-16-task-budgets/validation.md
@@ -1,0 +1,40 @@
+# Validation — Task budgets
+
+## Automated tests
+
+- `src/sessions/task-budget.test.ts` — schema validation, `sessions.patch` round-trip, default off.
+- `src/agents/pi-embedded-runner/task-budget-accounting.test.ts` — `spent` increments correctly; `remaining` available pre-call.
+- `src/agents/pi-embedded-runner/extra-params-budget.test.ts` — Anthropic task-budget params emitted only on capable models.
+- `src/agents/compaction-budget.test.ts` — tight compaction chosen when `remaining < threshold`.
+- `src/auto-reply/commands-registry-budget.test.ts` — `/budget` chat command updates the session.
+- E2E: `scripts/e2e/task-budget-docker.sh` — fixture session with a small budget runs to budget exhaustion and emits the typed end event.
+
+## Smoke checks
+
+- `openclaw sessions set <key> --budget-tokens 5000 --budget-wallclock 60000` then run a long task; `/status` shows `budget=5000 remaining=...`; loop ends on exhaustion with a final reply.
+- `/budget reset` clears the budget mid-session.
+- Wall-clock budget alone (no token budget) triggers a clean stop after the configured ms.
+
+## Manual criteria
+
+- `/status` budget row is readable and aligned with the existing table rendering (`src/terminal/table.ts`).
+- End-of-budget final reply explains *why* the loop ended ("budget exhausted: spent 5000/5000 tokens"), not a cryptic error.
+
+## AI eval plan
+
+- Success criteria: with a 5000-token budget on a multi-tool task, the model finishes within budget ≥ 85% of the time and surfaces a "stopping early" reply when it can't, on a 12-task fixture set.
+- Eval dataset: `tests/evals/task-budget/` — task prompts × budget sizes.
+- Regression set: 3 budgets (tight 2k / nominal 20k / generous 200k) × 4 tasks (single tool, multi tool, no tool, compaction needed).
+- Cadence: per-PR on fixtures; nightly on the live-models matrix to validate Anthropic's countdown is being read.
+
+## Risks & rollback
+
+- **Risks:**
+  - Model misreads the countdown and stops early on simple tasks. *Detect via* the eval set; mitigate by keeping default off.
+  - Compaction tightens too aggressively and drops needed context. *Detect via* the existing "summarize dropped messages" safeguard from 2026.1.x.
+  - Soft wall-clock fires during a tool call and leaves a tool result orphaned. *Mitigate* by deferring stop to the next agent loop iteration.
+- **Rollback:** unset `taskBudget` per session, or revert the PR. Both safe.
+
+## Open questions
+
+- Should `/budget` show a percentage in `/status` (e.g., "30% remaining") or only absolute? Probably both.

--- a/docs/specs/2026-05-16-telegram-bot-to-bot/plan.md
+++ b/docs/specs/2026-05-16-telegram-bot-to-bot/plan.md
@@ -1,0 +1,23 @@
+# Plan — Telegram bot-to-bot routing (Bot API 9.5)
+
+## Approach
+
+Extend the Telegram update handler in `src/telegram/` to surface `from.is_bot=true` separately from human senders, route them through a new bot-aware policy layer that consults the BotFather whitelist (when available) and the local allowlist, and persist approvals via the shared pairing store. Outbound sends to bots get a symmetric policy gate. Ad-hoc @-mention queries land as one-shot agent calls with a stateless session key.
+
+## Steps
+
+1. Update inbound message normalization (`src/telegram/`) to flag bot senders and surface `senderBotId` to the routing layer.
+2. Extend `src/channels/channel-config.ts` allowlist schema with `bots.allowFrom`, `bots.denyFrom`, `bots.dmPolicy` (mirroring the existing human-side keys).
+3. Route handler: derive `sessionKey="telegram:<accountId>:bot:<peerBotId>"` for ongoing bot↔bot threads; `sessionKey="telegram:<accountId>:adhoc:<msgId>"` for unsolicited mentions in chats openclaw isn't a member of.
+4. Approval flow: unknown bot sender → reply with a pairing code (same UX as human DM pairing) → `openclaw pairing approve telegram-bot <code>` adds the bot to the allowlist.
+5. Outbound: extend the Telegram send path to consult the same allowlist before sending; refuse with a typed error if the target is a bot not in the list.
+6. BotFather granular whitelist: if Manager Bot credentials are configured, periodically fetch the per-bot whitelist and merge with local state (local entries take precedence on conflict).
+7. CLI: `openclaw telegram bots list|approve|deny`.
+8. Doctor: warn on `bots.dmPolicy="open"` with empty allowlist; warn when no Manager Bot credential is configured AND bot-to-bot is enabled (operator might miss granular whitelist updates).
+9. Docs: `docs/channels/telegram.mdx` updates explaining the bot-to-bot model.
+
+## Dependencies / order
+
+- Step 1 (inbound flag) blocks 3–5.
+- Step 2 (config) blocks 3–5.
+- Steps 6–9 land after the core path works.

--- a/docs/specs/2026-05-16-telegram-bot-to-bot/requirements.md
+++ b/docs/specs/2026-05-16-telegram-bot-to-bot/requirements.md
@@ -1,0 +1,33 @@
+# Requirements — Telegram bot-to-bot routing (Bot API 9.5)
+
+## Outcome
+
+OpenClaw's Telegram channel handles the Bot API 9.5 bot-to-bot conversations: it can both receive messages from other bots and send messages to other bots, enabling multi-agent workflows that span distinct Telegram bot identities (e.g., a research bot owned by openclaw talks to a deploy bot owned by an external service). Granular per-bot whitelist (BotFather-set) and AI bot @-mentions outside group membership are also respected.
+
+## Users affected
+
+- Operators wiring multi-agent automations across multiple Telegram bots.
+- Telegram channel — `src/telegram/`.
+- Channel routing — `src/routing/resolve-route.ts`, allowlist machinery in `src/channels/`.
+- `openclaw doctor` and `openclaw configure --section telegram`.
+
+## In scope
+
+- Detect Bot API 9.5 sender shape — flag inbound updates whose `from.is_bot=true`.
+- Per-sender policy: `telegram.bots.<senderBotId>` accept/refuse/promptToApprove.
+- Honor the new BotFather granular whitelist exposed via the Manager Bots API (per-bot, not just per-account).
+- Outbound: allow sending to other bots when policy permits; reject sends to bots not in the allowlist.
+- Session-key shape: `telegram:<accountId>:bot:<peerBotId>` so bot-to-bot conversations are isolated from human-to-bot ones.
+- Handle the "AI bot mentioned in any chat without joining" pattern — when openclaw is @-mentioned in a chat it isn't a member of, the message is processed as an ad-hoc query with no persistent session (governed by allowlist).
+
+## Out of scope
+
+- Building outbound bot orchestration logic — agents drive the conversations through existing tools; we only ensure the channel pipe is open.
+- Cross-account bot federation (single Telegram account, multiple bots — that already works).
+- Hosting Manager Bots ourselves; we read whitelist from the Telegram API but don't create/manage bots automatically.
+
+## Decisions
+
+- Default policy for unknown bot senders: `promptToApprove` (same posture as DM pairing). Reason: trust posture stays fail-closed; bot identity can be spoofed via display-name games.
+- Ad-hoc @-mention queries don't persist a session by default. Reason: avoids accidental session sprawl when openclaw is mentioned in unfamiliar chats.
+- Reuse `src/pairing/pairing-store.ts` for bot-id approvals. Reason: one allowlist source.

--- a/docs/specs/2026-05-16-telegram-bot-to-bot/validation.md
+++ b/docs/specs/2026-05-16-telegram-bot-to-bot/validation.md
@@ -1,0 +1,42 @@
+# Validation — Telegram bot-to-bot routing (Bot API 9.5)
+
+## Automated tests
+
+- `src/telegram/bot-sender.test.ts` — `from.is_bot=true` correctly tagged on inbound.
+- `src/channels/bot-allowlist.test.ts` — config schema parse + allow/deny precedence.
+- `src/routing/telegram-bot-session-key.test.ts` — session keys derived as specified for bot↔bot and ad-hoc.
+- `src/telegram/outbound-bot-policy.test.ts` — sends to disallowed bots fail with the typed error.
+- `src/pairing/telegram-bot-approval.test.ts` — pairing-store integration.
+- E2E: fixture in `scripts/e2e/telegram-bot-docker.sh` exercising the bot-to-bot path against a mocked Telegram server.
+- Live test (gated `OPENCLAW_LIVE_TEST=1`) — two real bots ping each other through a sandbox group; first contact triggers pairing, post-approval messages flow.
+
+## Smoke checks
+
+- An unknown bot DMs the openclaw bot; openclaw replies with a pairing code; `openclaw pairing approve telegram-bot <code>` accepts; subsequent messages flow.
+- Outbound send to a non-allowlisted bot returns a clear error.
+- `openclaw telegram bots list` shows current approvals.
+- `openclaw doctor` warns on misconfiguration.
+
+## Manual criteria
+
+- Pairing message wording for bot senders is distinct from the human DM pairing message (so the receiving operator doesn't get confused).
+- Ad-hoc @-mention replies feel responsive and clearly stateless (don't accidentally remember the chat next time).
+
+## AI eval plan
+
+- Success criteria: in a 10-prompt fixture mixing human DMs and bot-sourced messages, routing assigns the correct session-key shape 100% of the time; deny-listed bot sends never go through.
+- Eval dataset: `tests/evals/telegram-bot-routing.jsonl` — labeled update fixtures.
+- Regression set: 5 fixtures — known bot DM, unknown bot DM, group @-mention by bot, group @-mention by human, outbound to denied bot.
+- Cadence: per-PR on fixtures; nightly on the live Telegram matrix.
+
+## Risks & rollback
+
+- **Risks:**
+  - Bot impersonation: a bot with a similar display name tries to slip past the allowlist. *Mitigate* by allowlist matching on `senderBotId` (the immutable numeric id), never on display name.
+  - Loops: two bots chatter forever. *Mitigate* by reusing the existing per-channel rate limiter + a per-bot turn budget.
+  - Manager Bot whitelist sync races. *Mitigate* by treating local state as canonical on conflict; doctor logs the drift.
+- **Rollback:** set `telegram.bots.dmPolicy="closed"` to block all bot senders; PR revert is safe — the existing human path is unchanged.
+
+## Open questions
+
+- Default behavior for unsolicited @-mentions in random chats: silent (don't reply) or "I haven't been authorized in this chat"? Lean silent to reduce spam surface; confirm before merge.

--- a/docs/specs/ai-quality.md
+++ b/docs/specs/ai-quality.md
@@ -1,0 +1,70 @@
+# AI quality
+
+## AI surface area
+
+OpenClaw is LLM-driven end to end. Every inbound message on any channel is routed to an isolated agent session, which runs an LLM tool-call loop and emits a reply.
+
+- **Agent runtime** — `src/agents/` on top of `@mariozechner/pi-agent-core` / `pi-coding-agent` / `pi-ai`. One agent per `agentId`; sessions persist under `~/.openclaw/agents/<agentId>/sessions/*.jsonl`.
+- **Model providers wired in `src/providers/` + Pi SDK** — Anthropic (OAuth Pro/Max + API key), OpenAI, AWS Bedrock, Google (Gemini / Vertex / Antigravity), Moonshot/Kimi, MiniMax, Qwen, OpenRouter, GitHub Copilot, Venice, Perplexity, Brave, Ollama, Vercel AI Gateway. Auth-profile rotation + failover live in `src/agents/` (see `docs/concepts/model-failover`).
+- **Tool surface** — bash/exec, browser (CDP via Playwright), canvas/A2UI, cron + wakeups, sessions_* coordination tools, channel send actions, node device tools (`node.invoke` → camera, screen.record, system.run/notify, location.get), 50+ bundled skills under `skills/*` (GitHub, Notion, Slack, Obsidian, weather, image gen, whisper, etc.).
+- **Memory / retrieval** — `src/memory/` plus `extensions/memory-core` and `extensions/memory-lancedb`. Embeddings via `sqlite-vec` (default) or LanceDB; hybrid (BM25 + embeddings) retrieval; provider-pluggable embedding models.
+- **Media understanding** — `src/media-understanding/` calls vision models (OpenAI / Google / Groq) for image/video; `src/link-understanding/` extracts page content + OG metadata via `@mozilla/readability`.
+- **Voice** — Voice Wake + Talk Mode (macOS/iOS/Android) transcribe local audio and forward as `openclaw-mac agent --message "${text}" --thinking low`; outbound TTS via `node-edge-tts`, ElevenLabs, OpenAI, or Apple/Google providers.
+- **Auto-reply** — `src/auto-reply/` handles short replies (greetings, /new prompts, command gating, broadcast groups, partial-reply chunking).
+
+## Success criteria
+
+Treat these as the operating bar rather than published SLOs — there is no public eval dashboard:
+
+- Inbound on every supported channel reaches an agent reply (or a typed error) without crashing the Gateway. The Gateway already filters transient network errors and only exits on fatal errors (CHANGELOG 2026.1.25, #2980).
+- Model failover skips cooldowned providers (#2143) and falls through the configured auth-profile chain without surfacing provider noise to the user.
+- Context compaction stays inside the configured cap (#6187) and summarizes dropped messages during safeguard pruning (#2509).
+- External chat surfaces (WhatsApp/Telegram/Slack/Discord/...) receive **only final replies**, not streaming partials.
+- Live model tests pass (`pnpm test:live` and `pnpm test:docker:live-models`).
+
+Explicit measurable targets (precision/recall/coverage) are not currently published. Define them before relying on this file as a production gate.
+
+## Evaluation approach
+
+- **Unit + integration:** Vitest with 70% coverage thresholds across lines/branches/functions/statements (`pnpm test`, `pnpm test:coverage`).
+- **Live-model regression:** `OPENCLAW_LIVE_TEST=1 pnpm test:live` (OpenClaw-only) or `LIVE=1` (includes provider live tests). Docker-pinned runs: `pnpm test:docker:live-models` and `pnpm test:docker:live-gateway`.
+- **End-to-end onboarding + plugins + QR + doctor-switch:** Docker E2E suites under `scripts/e2e/*` (`pnpm test:docker:onboard`, `pnpm test:docker:plugins`, `pnpm test:docker:qr`, `pnpm test:docker:doctor-switch`, `pnpm test:docker:gateway-network`).
+- **Model benchmarking:** ad-hoc via `scripts/bench-model.ts`; reproductions via `scripts/repro/*`; Claude usage debugging via `scripts/debug-claude-usage.ts`.
+- **Formal conformance:** the `formal-conformance.yml` workflow runs on PRs and validates against the external `clawdbot-formal-models` repo.
+- **Full gate before landing a PR:** `pnpm lint && pnpm build && pnpm test` (per `AGENTS.md` landing-mode rules).
+
+## Known failure modes
+
+- **Prompt injection from inbound DMs.** Treat every inbound DM as untrusted input. Mitigations: DM `pairing` default policy, per-channel allowlists, external hook content wrapped by default (#1827), `openclaw doctor` flagging risky DM configurations.
+- **Provider outages / rate limits.** Mitigated by auth-profile rotation and failover that skips cooldowned providers (#2143). Transient network errors (fetch failures, timeouts, DNS) no longer crash the Gateway (#2980).
+- **Context overflow.** Compaction respects configured context window (#6187) and summarizes dropped messages (#2509).
+- **Oversized images / unsupported media.** Retries on oversized image errors are suppressed; size limits surfaced (#2871). Text-attachment MIME misclassification covered (#3628).
+- **Multi-account / multi-agent confusion.** Per-account DM session scope (#3095); precompiled session-key regexes (#1697); requesterOrigin preferred over stale session entries (#4957); AccountId included in Telegram native command context (#2942).
+- **Tool-loop drift.** `sessions_*` tools coordinate work between sessions instead of letting agents jump chat surfaces; `/compact`, `/new`, `/reset` chat commands give the operator manual control.
+- **Streaming bleed-through to chat apps.** Hard rule: only final replies on external surfaces; streaming/tool events on internal UIs only.
+
+## Safety & privacy
+
+- **Gateway auth fail-closed.** Mode `"none"` removed (2026.1.25). Token or password required; Tailscale Serve identity allowed.
+- **Loopback enforcement.** `gateway.bind=loopback` when Tailscale Serve/Funnel is on. Funnel requires `gateway.auth.mode="password"`.
+- **DM allowlist + pairing.** Default `dmPolicy="pairing"`; opening DMs to the public requires `dmPolicy="open"` + `"*"` in `allowFrom`.
+- **Trusted-proxy detection.** Loopback + non-local Host connections are treated as remote unless trusted proxy headers are present.
+- **External content wrapping.** Hook content from external sources is wrapped by default (#1827, per-hook opt-out).
+- **URL fetch hardening.** DNS pinning mitigates rebinding on outbound URL fetches.
+- **mDNS minimal.** Discovery defaults to minimal mode to reduce information disclosure (#1882).
+- **Voice-call webhook signing.** Twilio webhook signature verification enforced for ngrok URLs; free-tier ngrok bypass disabled by default.
+- **Secrets handling.** Web provider credentials under `~/.openclaw/credentials/`; Pi session logs under `~/.openclaw/sessions/`. Never commit real phone numbers, videos, tokens, or live config — `AGENTS.md` mandates fake placeholders in docs/tests/examples.
+- **`.secrets.baseline`** + `detect-secrets` pre-commit hook (`.pre-commit-config.yaml`) gates accidental secret commits.
+- **Lobster shell-injection fix (GHSA-4mhr-g7xj-cg8j)** in 2026.1.31 (#5335). Continue to audit any tool that takes operator-supplied paths or argv.
+
+## Regression checks
+
+The small set that must keep working after every prompt or model change:
+
+- `pnpm test` (unit + integration, 70% coverage gate).
+- `pnpm protocol:check` — TypeBox schema + Swift `GatewayModels.swift` stay in sync.
+- `pnpm test:docker:live-models` — Docker-pinned multi-provider sanity.
+- `pnpm test:docker:onboard` — end-to-end onboarding wizard.
+- `pnpm test:docker:plugins` — plugin install/discovery.
+- Channel smoke: send a DM through each enabled channel and confirm a final reply lands (no streaming bleed-through, no empty replies, correct session key per `outbound-session-mirroring` invariants).
+- `openclaw doctor` — clean output on a fresh and on an upgraded install.

--- a/docs/specs/mission.md
+++ b/docs/specs/mission.md
@@ -1,0 +1,22 @@
+# Mission
+
+## What this is
+
+OpenClaw is a single-user personal AI assistant you run on your own devices. A local Gateway acts as the control plane: it accepts inbound messages from the chat apps you already use (WhatsApp, Telegram, Slack, Discord, Google Chat, Signal, iMessage, BlueBubbles, Microsoft Teams, Matrix, Zalo, Zalo Personal, WebChat), routes them to isolated agent sessions, executes tools (browser, canvas, cron, skills, device nodes), and sends replies back through the same channel. Companion apps (macOS menu bar, iOS, Android) add Voice Wake, Talk Mode, and a live agent-driven Canvas surface. The Gateway is the plumbing; the product is the assistant that reaches you wherever you already chat.
+
+## Who it serves
+
+The operator who wants their *own* AI assistant — running on their own host, paired to their own accounts, gated by their own allowlist — and who is comfortable installing a CLI, configuring channels, and bringing their own model credentials (Anthropic Pro/Max recommended; OpenAI, Bedrock, Gemini, OpenRouter, MiniMax, Kimi/Moonshot, Qwen, Copilot, Ollama, etc. all supported).
+
+## What it is NOT
+
+- **Not a multi-tenant SaaS chatbot.** One Gateway, one operator. There is no team plan, no shared workspace, no centralized hosted backend.
+- **Not a customer-support / helpdesk bot.** Inbound DMs are treated as untrusted; the default DM policy is `pairing`, not open.
+- **Not a foundation model.** OpenClaw orchestrates third-party model providers; it does not train or host models.
+- **Not the Gateway alone.** The Gateway is the control plane, not the product. Channels, voice, canvas, skills, and apps are the product surface.
+- **Not a chat UI product.** WebChat exists for control; the assistant is meant to live inside the chat apps the operator already uses.
+- **Not stream-friendly to external surfaces.** Streaming/partial replies stay on internal UIs; external messaging surfaces (WhatsApp/Telegram/etc.) receive final replies only.
+
+## Success signal
+
+The operator keeps the Gateway daemon running and uses the assistant from their phone — on their existing chat apps — instead of opening a separate chat UI.

--- a/docs/specs/roadmap.md
+++ b/docs/specs/roadmap.md
@@ -1,0 +1,30 @@
+# Roadmap
+
+Inferred from `docs/refactor/`, `docs/experiments/`, and recent `CHANGELOG.md` entries (current released version: **2026.1.31**). When in doubt, the design docs under `docs/refactor/` are the source of truth — this file is a pointer.
+
+## Now
+
+- **Plugin SDK + runtime refactor** — every messaging connector becomes a plugin (bundled or external) against one stable API; no plugin imports from `src/**` directly. See `docs/refactor/plugin-sdk.md`.
+- **Outbound session mirroring (#1520)** — outbound sends mirror into the *target* channel session key, create session entries on outbound, and align thread/topic scoping with inbound. Core + plugin channel routing already updated; covering bundled extensions and tests. See `docs/refactor/outbound-session-mirroring.md`.
+- **Channel + provider polish** — ongoing reliability work across Telegram (shared pairing store, draft streaming partials), Discord (PluralKit proxied senders, directory resolution), Slack, BlueBubbles attachment debounce, MiniMax/Kimi/OpenRouter auth + attribution headers, Moonshot endpoint clarifications. See recent CHANGELOG entries 2026.1.29–2026.1.31.
+
+## Next
+
+- **Clawnet** — unify the node ↔ gateway ↔ operator-client protocol: one transport, scoped roles (operator/agent/device/admin), unified pairing + approvals, TLS pinning, stable IDs with cute slugs. See `docs/refactor/clawnet.md`.
+- **Exec host routing + headless runner** — `exec.host` + `exec.security` to route execution across sandbox / gateway / node with per-agent policy, ask modes, allowlists, and a headless runner service with optional UI IPC. Defaults stay safe (no cross-host exec without explicit opt-in). See `docs/refactor/exec-host.md`.
+- **Strict config validation** — reject unknown config keys (root + nested), reject plugins without a schema, remove legacy auto-migration on load (migrations only via `doctor`), auto-run doctor dry-run on startup. See `docs/refactor/strict-config.md`.
+- **Onboarding + config protocol** — shared wizard surface across CLI, macOS app, and Web UI via Gateway RPC (`wizard.start`/`next`/`cancel`/`status`, `config.schema`). See `docs/experiments/onboarding-config-protocol.md`.
+- **Targeted hardening plans** — cron-add hardening, group-policy hardening, OpenResponses gateway. See `docs/experiments/plans/`.
+
+## Later
+
+- **Model config proposal** — see `docs/experiments/proposals/model-config.md`.
+- **Memory research direction** — vector + hybrid retrieval evolution; see `docs/experiments/research/memory.md` and `extensions/memory-core` / `extensions/memory-lancedb`.
+- **Formal-conformance expansion** — the `formal-conformance.yml` workflow validates against the `clawdbot-formal-models` repo on PRs; more surface area can be brought under it.
+
+## Parked
+
+- **Multi-tenant / SaaS hosting** — out of scope; OpenClaw is a single-operator product (see `mission.md`). Hosted-backend ideas are deferred to keep the trust boundary at the operator's own host.
+- **Open inbound DMs by default** — explicitly rejected. Gateway auth `"none"` was removed in 2026.1.25 and DM `pairing` is the default; `dmPolicy="open"` requires an explicit opt-in plus `"*"` in `allowFrom`.
+- **Streaming partials on external chat surfaces (WhatsApp/Telegram/etc.)** — parked for UX + safety reasons; only final replies go out.
+- **Carbon dependency upgrades** — frozen by policy (`@buape/carbon@0.14.0`); revisit only if forced by an upstream break.

--- a/docs/specs/tech-stack.md
+++ b/docs/specs/tech-stack.md
@@ -1,0 +1,49 @@
+# Tech stack
+
+## Runtime & language
+
+- **Core CLI + Gateway:** TypeScript (ESM, strict), targets **Node ≥22.12**. Bun is supported and preferred for running TS directly in dev (`bun <file.ts>` / `bunx`). Node is the production runtime for `dist/`.
+- **Package manager:** `pnpm@10.23.0` (corepack). `pnpm-workspace.yaml` covers `.`, `ui/`, `packages/*` (clawdbot, moltbot compat shims), and `extensions/*` (channel + auth plugins).
+- **macOS / iOS apps:** Swift + SwiftUI on a shared `OpenClawKit` library (iOS 18+, macOS 15+). Use the `Observation` framework (`@Observable`, `@Bindable`) — not `ObservableObject`/`@StateObject`.
+- **Android app:** Kotlin + Jetpack Compose, `compileSdk 36`, `minSdk 31`. Gradle build; pulls OpenClawKit assets at build time.
+- **Web UI:** Lit + `@lit-labs/signals` (served from the Gateway under `/__openclaw__/`).
+- **TUI:** `@mariozechner/pi-tui` (terminal chat client).
+
+## Key libraries
+
+- **Agent runtime:** `@mariozechner/pi-agent-core`, `@mariozechner/pi-ai`, `@mariozechner/pi-coding-agent`, `@mariozechner/pi-tui` — the LLM + tool-call loop, model registry, and TUI live here.
+- **Model providers:** Anthropic (OAuth Pro/Max + API key), OpenAI, AWS Bedrock (`@aws-sdk/client-bedrock`), GitHub Copilot, Google (Gemini / Vertex / Antigravity), Moonshot/Kimi, MiniMax, Qwen, OpenRouter, Ollama (`ollama` dev dep), Venice, Perplexity, Brave, Vercel AI Gateway.
+- **Channels:** `grammy` + `@grammyjs/runner` + `@grammyjs/transformer-throttler` (Telegram), `@buape/carbon@0.14.0` + `discord-api-types` (Discord — **frozen**, do not bump), `@slack/bolt` + `@slack/web-api` (Slack), `@whiskeysockets/baileys@7.0.0-rc.9` (WhatsApp web), `@line/bot-sdk` (LINE), `signal-cli` daemon (Signal). Extensions add Matrix (`@vector-im/matrix-bot-sdk`), Microsoft Teams, BlueBubbles, Zalo, Zalo Personal, Mattermost, Nextcloud Talk, Nostr, Tlon, Twitch, Google Chat, and a Twilio-backed Voice Call surface.
+- **Transport & HTTP:** `ws` (Gateway WebSocket control plane), `express@5`, `undici` (with per-account proxy support).
+- **Browser tool:** `playwright-core@1.58.1` driving an openclaw-managed Chrome/Chromium via CDP.
+- **Canvas / A2UI:** in-house host under `src/canvas-host/` bundled via `scripts/bundle-a2ui.sh`; `.bundle.hash` is generated, commit separately.
+- **Schemas & validation:** `@sinclair/typebox@0.34.47` (overridden), `ajv`, `zod@4`, `json5`, `yaml`.
+- **Media:** `sharp`, `pdfjs-dist`, `@mozilla/readability`, `linkedom`, `file-type`, `jszip`, `tar@7.5.7` (pinned override).
+- **CLI ergonomics:** `commander`, `@clack/prompts`, `osc-progress`, `chalk`, `cli-highlight`, `qrcode-terminal`; shared CLI palette in `src/terminal/palette.ts`.
+- **Voice / TTS:** `node-edge-tts`, ElevenLabs (via apps), optional Apple/Google providers; Voice Wake forwards via `openclaw-mac agent --message "${text}" --thinking low`.
+- **Storage / memory:** `sqlite-vec@0.1.7-alpha.2` for embeddings; `proper-lockfile` for session lock files; vector providers exposed via `extensions/memory-core` + `extensions/memory-lancedb`.
+- **Process / IPC:** `@lydell/node-pty` (PTY), `@homebridge/ciao` (Bonjour discovery), `croner` (cron + wakeups), `chokidar` (file watching), `jiti` (runtime TS for plugin SDK resolution).
+- **Logging:** `tslog`; macOS unified-log queries via `scripts/clawlog.sh`.
+
+## Conventions
+
+- **Lint + format:** `oxlint --type-aware` and `oxfmt` (`pnpm lint`, `pnpm format`, `pnpm format:fix`). SwiftFormat + SwiftLint for Apple code.
+- **Tests:** Vitest with V8 coverage gates at **70%** (lines/branches/functions/statements). Colocated `*.test.ts`; E2E in `*.e2e.test.ts` (`vitest.e2e.config.ts`); live-model tests gated by `OPENCLAW_LIVE_TEST=1` / `CLAWDBOT_LIVE_TEST=1` (`vitest.live.config.ts`); Docker E2E suites in `scripts/e2e/*` (onboard, plugins, gateway-network, QR, doctor-switch). Cap workers at 16.
+- **File layout:** dependency-injection via `createDefaultDeps` (no DI framework — functional composition). Keep files under ~500 LOC where practical; ~700 is a soft ceiling. Extract helpers instead of "V2" copies. Channel-specific code lives under `src/<channel>/`; shared routing under `src/channels/` + `src/routing/`.
+- **Plugins:** every messaging connector aims to be a plugin (bundled in `extensions/*` or external). Plugin runtime deps live in the extension's own `package.json` — never in root. Use `openclaw` in `devDependencies`/`peerDependencies`, never `workspace:*` under `dependencies` (npm install breaks). The runtime resolves `openclaw/plugin-sdk` via a jiti alias.
+- **Naming:** `OpenClaw` (product/UI/docs headings); `openclaw` (CLI command, npm package, paths, config keys). Branding migrations from legacy `clawdbot`/`bot.molt` are handled by `openclaw doctor`.
+- **Docs (Mintlify):** root-relative internal links with no `.md`/`.mdx` extension (`[Config](/configuration)`). Avoid em dashes and apostrophes in headings — they break Mintlify anchors. README on GitHub keeps absolute `https://docs.openclaw.ai/...` URLs.
+- **Commits:** use `scripts/committer "<msg>" <file...>` for scoped staging; concise action-oriented messages (`CLI: add verbose flag to send`). PRs land via rebase (clean history) or squash (messy). Always add the contributor as co-author and update `bun scripts/update-clawtributors.ts` for new contributors.
+- **Schema guardrails:** in tool input schemas, avoid `Type.Union`/`anyOf`/`oneOf`/`allOf` and the raw `format` property. Use `stringEnum`/`Type.Optional(...)`. Keep top-level tool schema as `type: "object"` with `properties`.
+
+## Non-negotiables
+
+- **Gateway auth is fail-closed.** Mode `"none"` was removed in 2026.1.25; token or password is required (Tailscale Serve identity is allowed). `gateway.bind=loopback` is enforced whenever Tailscale Serve/Funnel is enabled. Funnel additionally requires `gateway.auth.mode="password"`.
+- **Inbound DMs are untrusted.** Default DM policy is `pairing` on Telegram/WhatsApp/Signal/iMessage/Microsoft Teams/Discord/Google Chat/Slack. Public DM access requires explicit `dmPolicy="open"` + `"*"` in `allowFrom`. `openclaw doctor` surfaces misconfigurations.
+- **No streaming/partial replies to external messaging surfaces.** WhatsApp/Telegram/Slack/Discord/etc. receive *final* replies only; streaming/tool events stay on internal UIs and the control channel.
+- **Don't edit `node_modules`** (global, Homebrew, npm, git installs — anywhere). Updates overwrite. Notes belong in `tools.md` or `AGENTS.md`.
+- **Frozen / pinned dependencies:** `@buape/carbon` (never update), `tar@7.5.7` (npm + pnpm override), and any package listed in `pnpm.patchedDependencies` must use an exact version (no `^`/`~`). Patching deps (pnpm patches, overrides, vendored) requires explicit operator approval.
+- **Multi-agent safety:** do not `git stash`, change worktrees, or switch branches unless explicitly asked. Assume parallel agent sessions; scope commits to your own changes.
+- **Releases:** never bump version numbers or run `npm publish` without explicit operator consent. Read `docs/reference/RELEASING.md` and `docs/platforms/mac/release.md` first. npm publishes go through the 1Password skill inside a fresh tmux session with an OTP from `op://Private/Npmjs`.
+- **macOS-only constraints:** rebuild the macOS app on the Mac itself (never over SSH). Start/stop the Gateway via the app, not ad-hoc tmux. Use `launchctl print gui/$UID | grep openclaw` to verify — there is no fixed LaunchAgent label.
+- **Security defaults:** mDNS minimal discovery by default; URL fetches DNS-pin to mitigate rebinding; external hook content is wrapped by default (per-hook opt-out); Tailscale Serve auth validates identity via local `tailscaled` before trusting headers.

--- a/extensions/msteams/src/graph-upload.test.ts
+++ b/extensions/msteams/src/graph-upload.test.ts
@@ -1,0 +1,307 @@
+import { describe, expect, it, vi } from "vitest";
+import type { MSTeamsAccessTokenProvider } from "./attachments/types.js";
+import { uploadToOneDrive, uploadToSharePoint } from "./graph-upload.js";
+
+const TOKEN = "fake-bearer-token";
+
+function makeTokenProvider(): MSTeamsAccessTokenProvider {
+  return {
+    getAccessToken: vi.fn(async () => TOKEN),
+  } as unknown as MSTeamsAccessTokenProvider;
+}
+
+function jsonResponse(status: number, body: unknown, init: { statusText?: string } = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    statusText: init.statusText ?? "",
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function emptyResponse(status: number, statusText = ""): Response {
+  return new Response(null, { status, statusText });
+}
+
+describe("uploadToOneDrive — simple PUT path (<= 4 MiB)", () => {
+  it("PUTs a 1 MiB buffer in a single request and returns the driveItem", async () => {
+    const buffer = Buffer.alloc(1 * 1024 * 1024, 7);
+    const fetchFn = vi.fn().mockResolvedValueOnce(
+      jsonResponse(201, {
+        id: "small-id",
+        webUrl: "https://contoso/small",
+        name: "small.bin",
+      }),
+    );
+
+    const result = await uploadToOneDrive({
+      buffer,
+      filename: "small.bin",
+      tokenProvider: makeTokenProvider(),
+      fetchFn,
+    });
+
+    expect(result).toEqual({
+      id: "small-id",
+      webUrl: "https://contoso/small",
+      name: "small.bin",
+    });
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchFn.mock.calls[0];
+    expect(url).toBe(
+      "https://graph.microsoft.com/v1.0/me/drive/root:/OpenClawShared/small.bin:/content",
+    );
+    expect(init.method).toBe("PUT");
+    expect(init.headers.Authorization).toBe(`Bearer ${TOKEN}`);
+  });
+
+  it("throws a labeled error when the simple PUT returns non-2xx", async () => {
+    const fetchFn = vi.fn().mockResolvedValueOnce(
+      new Response("nope", { status: 503, statusText: "Service Unavailable" }),
+    );
+
+    await expect(
+      uploadToOneDrive({
+        buffer: Buffer.alloc(1024),
+        filename: "x.bin",
+        tokenProvider: makeTokenProvider(),
+        fetchFn,
+      }),
+    ).rejects.toThrow(/OneDrive upload failed: 503/);
+  });
+
+  it("throws when the simple PUT response is missing id/webUrl/name", async () => {
+    const fetchFn = vi.fn().mockResolvedValueOnce(jsonResponse(201, { id: "only-id" }));
+    await expect(
+      uploadToOneDrive({
+        buffer: Buffer.alloc(1024),
+        filename: "x.bin",
+        tokenProvider: makeTokenProvider(),
+        fetchFn,
+      }),
+    ).rejects.toThrow(/OneDrive response missing required fields/);
+  });
+});
+
+describe("uploadToOneDrive — resumable upload session (> 4 MiB)", () => {
+  it("creates an upload session and PUTs the file in three Content-Range chunks", async () => {
+    // 5 MiB file with a 2 MiB chunk size → 3 chunks (2 + 2 + 1).
+    const total = 5 * 1024 * 1024;
+    const chunkSize = 2 * 1024 * 1024;
+    const buffer = Buffer.alloc(total, 1);
+
+    const uploadUrl = "https://contoso.sharepoint.com/uploadSession/abc-123";
+    const finalItem = {
+      id: "large-id",
+      webUrl: "https://contoso/large",
+      name: "big.bin",
+    };
+
+    const fetchFn = vi
+      .fn()
+      // createUploadSession
+      .mockResolvedValueOnce(jsonResponse(200, { uploadUrl }))
+      // chunk 1
+      .mockResolvedValueOnce(jsonResponse(202, { nextExpectedRanges: [`${chunkSize}-`] }))
+      // chunk 2
+      .mockResolvedValueOnce(jsonResponse(202, { nextExpectedRanges: [`${chunkSize * 2}-`] }))
+      // chunk 3 — final
+      .mockResolvedValueOnce(jsonResponse(201, finalItem));
+
+    const result = await uploadToOneDrive({
+      buffer,
+      filename: "big.bin",
+      tokenProvider: makeTokenProvider(),
+      fetchFn,
+      chunkSize,
+    });
+
+    expect(result).toEqual(finalItem);
+    expect(fetchFn).toHaveBeenCalledTimes(4);
+
+    const [sessionUrl, sessionInit] = fetchFn.mock.calls[0];
+    expect(sessionUrl).toBe(
+      "https://graph.microsoft.com/v1.0/me/drive/root:/OpenClawShared/big.bin:/createUploadSession",
+    );
+    expect(sessionInit.method).toBe("POST");
+    expect(sessionInit.headers.Authorization).toBe(`Bearer ${TOKEN}`);
+    expect(JSON.parse(sessionInit.body as string)).toEqual({
+      item: { "@microsoft.graph.conflictBehavior": "rename", name: "big.bin" },
+    });
+
+    const ranges = fetchFn.mock.calls.slice(1).map((call) => {
+      const init = call[1] as RequestInit;
+      const headers = init.headers as Record<string, string>;
+      return {
+        url: call[0],
+        method: init.method,
+        range: headers["Content-Range"],
+        length: headers["Content-Length"],
+      };
+    });
+
+    expect(ranges).toEqual([
+      {
+        url: uploadUrl,
+        method: "PUT",
+        range: `bytes 0-${chunkSize - 1}/${total}`,
+        length: String(chunkSize),
+      },
+      {
+        url: uploadUrl,
+        method: "PUT",
+        range: `bytes ${chunkSize}-${chunkSize * 2 - 1}/${total}`,
+        length: String(chunkSize),
+      },
+      {
+        url: uploadUrl,
+        method: "PUT",
+        range: `bytes ${chunkSize * 2}-${total - 1}/${total}`,
+        length: String(total - chunkSize * 2),
+      },
+    ]);
+  });
+
+  it("cancels the session with DELETE when a chunk PUT fails", async () => {
+    const total = 5 * 1024 * 1024;
+    const chunkSize = 2 * 1024 * 1024;
+    const buffer = Buffer.alloc(total, 2);
+    const uploadUrl = "https://contoso.sharepoint.com/uploadSession/abandon";
+
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(200, { uploadUrl }))
+      // chunk 1 fails
+      .mockResolvedValueOnce(new Response("boom", { status: 500, statusText: "Server Error" }))
+      // cancel
+      .mockResolvedValueOnce(emptyResponse(204));
+
+    await expect(
+      uploadToOneDrive({
+        buffer,
+        filename: "doomed.bin",
+        tokenProvider: makeTokenProvider(),
+        fetchFn,
+        chunkSize,
+      }),
+    ).rejects.toThrow(/OneDrive chunk upload failed at bytes 0-/);
+
+    expect(fetchFn).toHaveBeenCalledTimes(3);
+    const [cancelUrl, cancelInit] = fetchFn.mock.calls[2];
+    expect(cancelUrl).toBe(uploadUrl);
+    expect(cancelInit.method).toBe("DELETE");
+  });
+
+  it("propagates errors but still attempts session cancellation on fetch rejection", async () => {
+    const total = 5 * 1024 * 1024;
+    const chunkSize = 2 * 1024 * 1024;
+    const buffer = Buffer.alloc(total, 3);
+    const uploadUrl = "https://contoso.sharepoint.com/uploadSession/network-fail";
+
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(200, { uploadUrl }))
+      .mockRejectedValueOnce(new Error("ECONNRESET"))
+      .mockResolvedValueOnce(emptyResponse(204));
+
+    await expect(
+      uploadToOneDrive({
+        buffer,
+        filename: "doomed.bin",
+        tokenProvider: makeTokenProvider(),
+        fetchFn,
+        chunkSize,
+      }),
+    ).rejects.toThrow(/ECONNRESET/);
+    expect(fetchFn.mock.calls[2][1].method).toBe("DELETE");
+  });
+
+  it("throws a labeled error if createUploadSession returns non-2xx", async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("denied", { status: 403, statusText: "Forbidden" }));
+
+    await expect(
+      uploadToOneDrive({
+        buffer: Buffer.alloc(5 * 1024 * 1024, 4),
+        filename: "x.bin",
+        tokenProvider: makeTokenProvider(),
+        fetchFn,
+        chunkSize: 2 * 1024 * 1024,
+      }),
+    ).rejects.toThrow(/OneDrive createUploadSession failed: 403/);
+  });
+
+  it("throws if createUploadSession response lacks uploadUrl", async () => {
+    const fetchFn = vi.fn().mockResolvedValueOnce(jsonResponse(200, {}));
+    await expect(
+      uploadToOneDrive({
+        buffer: Buffer.alloc(5 * 1024 * 1024, 5),
+        filename: "x.bin",
+        tokenProvider: makeTokenProvider(),
+        fetchFn,
+        chunkSize: 2 * 1024 * 1024,
+      }),
+    ).rejects.toThrow(/createUploadSession response missing uploadUrl/);
+  });
+});
+
+describe("uploadToSharePoint", () => {
+  it("uses the simple :/content endpoint under the site for small buffers", async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse(201, { id: "sp-id", webUrl: "https://sp/small", name: "s.bin" }),
+      );
+
+    const result = await uploadToSharePoint({
+      buffer: Buffer.alloc(1024, 6),
+      filename: "s.bin",
+      tokenProvider: makeTokenProvider(),
+      fetchFn,
+      siteId: "tenant.sharepoint.com,site,web",
+    });
+
+    expect(result).toEqual({ id: "sp-id", webUrl: "https://sp/small", name: "s.bin" });
+    const [url, init] = fetchFn.mock.calls[0];
+    expect(url).toBe(
+      "https://graph.microsoft.com/v1.0/sites/tenant.sharepoint.com,site,web/drive/root:/OpenClawShared/s.bin:/content",
+    );
+    expect(init.method).toBe("PUT");
+  });
+
+  it("upgrades to the upload-session protocol for large buffers under the site root", async () => {
+    const total = 5 * 1024 * 1024;
+    const chunkSize = 2 * 1024 * 1024;
+    const buffer = Buffer.alloc(total, 9);
+    const uploadUrl = "https://contoso.sharepoint.com/uploadSession/sp-large";
+
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(200, { uploadUrl }))
+      .mockResolvedValueOnce(jsonResponse(202, {}))
+      .mockResolvedValueOnce(jsonResponse(202, {}))
+      .mockResolvedValueOnce(
+        jsonResponse(201, { id: "sp-big", webUrl: "https://sp/big", name: "big.bin" }),
+      );
+
+    const result = await uploadToSharePoint({
+      buffer,
+      filename: "big.bin",
+      tokenProvider: makeTokenProvider(),
+      fetchFn,
+      siteId: "tenant,site,web",
+      chunkSize,
+    });
+
+    expect(result).toEqual({ id: "sp-big", webUrl: "https://sp/big", name: "big.bin" });
+    expect(fetchFn.mock.calls[0][0]).toBe(
+      "https://graph.microsoft.com/v1.0/sites/tenant,site,web/drive/root:/OpenClawShared/big.bin:/createUploadSession",
+    );
+    // Three PUT chunks against the issued upload URL.
+    expect(fetchFn.mock.calls.slice(1).map((c) => c[0])).toEqual([
+      uploadUrl,
+      uploadUrl,
+      uploadUrl,
+    ]);
+  });
+});

--- a/extensions/msteams/src/graph-upload.ts
+++ b/extensions/msteams/src/graph-upload.ts
@@ -7,6 +7,12 @@
  * - Uploading files to SharePoint (group/channel scope)
  * - Creating sharing links (organization-wide or per-user)
  * - Getting chat members for per-user sharing
+ *
+ * Files <= LARGE_FILE_THRESHOLD use the simple `:/content` PUT endpoint.
+ * Larger files use the Graph resumable upload session protocol:
+ *   1. POST createUploadSession -> uploadUrl
+ *   2. PUT each chunk to uploadUrl with Content-Range; 202 advances, 200/201 returns the driveItem
+ *   3. On error mid-upload, DELETE uploadUrl is sent best-effort as cleanup.
  */
 
 import type { MSTeamsAccessTokenProvider } from "./attachments/types.js";
@@ -15,16 +21,193 @@ const GRAPH_ROOT = "https://graph.microsoft.com/v1.0";
 const GRAPH_BETA = "https://graph.microsoft.com/beta";
 const GRAPH_SCOPE = "https://graph.microsoft.com";
 
+// Simple PUT upload is documented to support up to 4 MiB; above that we MUST use upload sessions.
+const LARGE_FILE_THRESHOLD = 4 * 1024 * 1024;
+// Graph requires chunk sizes that are multiples of 320 KiB. 16 * 320 KiB ≈ 5 MiB is the common default.
+const GRAPH_CHUNK_UNIT = 320 * 1024;
+const DEFAULT_CHUNK_SIZE = 16 * GRAPH_CHUNK_UNIT;
+
 export interface OneDriveUploadResult {
   id: string;
   webUrl: string;
   name: string;
 }
 
+interface DriveItemResponse {
+  id?: string;
+  webUrl?: string;
+  name?: string;
+}
+
+function assertDriveItem(data: DriveItemResponse, label: string): OneDriveUploadResult {
+  if (!data.id || !data.webUrl || !data.name) {
+    throw new Error(`${label} response missing required fields`);
+  }
+  return { id: data.id, webUrl: data.webUrl, name: data.name };
+}
+
+/**
+ * Create a resumable upload session for a path that lives under either /me/drive or /sites/{id}/drive.
+ * Returns the uploadUrl the caller PUTs chunks to.
+ */
+async function createUploadSession(params: {
+  sessionUrl: string;
+  filename: string;
+  tokenProvider: MSTeamsAccessTokenProvider;
+  fetchFn: typeof fetch;
+  label: string;
+}): Promise<{ uploadUrl: string }> {
+  const token = await params.tokenProvider.getAccessToken(GRAPH_SCOPE);
+  const res = await params.fetchFn(params.sessionUrl, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      item: {
+        "@microsoft.graph.conflictBehavior": "rename",
+        name: params.filename,
+      },
+    }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(
+      `${params.label} createUploadSession failed: ${res.status} ${res.statusText} - ${body}`,
+    );
+  }
+
+  const data = (await res.json()) as { uploadUrl?: string };
+  if (!data.uploadUrl) {
+    throw new Error(`${params.label} createUploadSession response missing uploadUrl`);
+  }
+  return { uploadUrl: data.uploadUrl };
+}
+
+/**
+ * PUT the buffer to an active upload session URL in chunked ranges.
+ * The final chunk's response (200/201) carries the completed driveItem.
+ * If any chunk PUT fails, DELETE uploadUrl is sent best-effort as cleanup.
+ */
+async function putChunks(params: {
+  uploadUrl: string;
+  buffer: Buffer;
+  chunkSize: number;
+  fetchFn: typeof fetch;
+  label: string;
+}): Promise<OneDriveUploadResult> {
+  const total = params.buffer.length;
+  let offset = 0;
+  let final: DriveItemResponse | null = null;
+
+  while (offset < total) {
+    const end = Math.min(offset + params.chunkSize, total);
+    const chunk = params.buffer.subarray(offset, end);
+
+    let res: Response;
+    try {
+      res = await params.fetchFn(params.uploadUrl, {
+        method: "PUT",
+        headers: {
+          "Content-Length": String(chunk.length),
+          "Content-Range": `bytes ${offset}-${end - 1}/${total}`,
+        },
+        body: new Uint8Array(chunk),
+      });
+    } catch (err) {
+      await cancelUploadSession(params.uploadUrl, params.fetchFn);
+      throw err;
+    }
+
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      await cancelUploadSession(params.uploadUrl, params.fetchFn);
+      throw new Error(
+        `${params.label} chunk upload failed at bytes ${offset}-${end - 1}/${total}: ${res.status} ${res.statusText} - ${body}`,
+      );
+    }
+
+    if (res.status === 200 || res.status === 201) {
+      final = (await res.json()) as DriveItemResponse;
+      break;
+    }
+    // 202: chunk accepted, continue. We trust our own slicing and ignore nextExpectedRanges.
+    offset = end;
+  }
+
+  if (!final) {
+    throw new Error(
+      `${params.label} upload session ended without a final driveItem response (${total} bytes)`,
+    );
+  }
+  return assertDriveItem(final, params.label);
+}
+
+async function cancelUploadSession(uploadUrl: string, fetchFn: typeof fetch): Promise<void> {
+  try {
+    await fetchFn(uploadUrl, { method: "DELETE" });
+  } catch {
+    // Best-effort cleanup; the session expires server-side regardless.
+  }
+}
+
+/**
+ * Internal: route the buffer to either the simple `:/content` PUT path or the resumable session path.
+ */
+async function uploadBuffer(params: {
+  buffer: Buffer;
+  filename: string;
+  contentType?: string;
+  tokenProvider: MSTeamsAccessTokenProvider;
+  fetchFn: typeof fetch;
+  simpleUrl: string;
+  sessionUrl: string;
+  label: string;
+  chunkSize: number;
+}): Promise<OneDriveUploadResult> {
+  if (params.buffer.length <= LARGE_FILE_THRESHOLD) {
+    const token = await params.tokenProvider.getAccessToken(GRAPH_SCOPE);
+    const res = await params.fetchFn(params.simpleUrl, {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": params.contentType ?? "application/octet-stream",
+      },
+      body: new Uint8Array(params.buffer),
+    });
+
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      throw new Error(`${params.label} upload failed: ${res.status} ${res.statusText} - ${body}`);
+    }
+    return assertDriveItem((await res.json()) as DriveItemResponse, params.label);
+  }
+
+  const { uploadUrl } = await createUploadSession({
+    sessionUrl: params.sessionUrl,
+    filename: params.filename,
+    tokenProvider: params.tokenProvider,
+    fetchFn: params.fetchFn,
+    label: params.label,
+  });
+
+  return putChunks({
+    uploadUrl,
+    buffer: params.buffer,
+    chunkSize: params.chunkSize,
+    fetchFn: params.fetchFn,
+    label: params.label,
+  });
+}
+
 /**
  * Upload a file to the user's OneDrive root folder.
- * For larger files, this uses the simple upload endpoint (up to 4MB).
- * TODO: For files >4MB, implement resumable upload session.
+ * Switches to the resumable upload-session protocol for files larger than 4 MiB.
+ *
+ * @param params.chunkSize - Optional override for the chunk size used in session uploads.
+ *   Must be a multiple of 320 KiB per Graph's contract. Defaults to ~5 MiB.
  */
 export async function uploadToOneDrive(params: {
   buffer: Buffer;
@@ -32,42 +215,22 @@ export async function uploadToOneDrive(params: {
   contentType?: string;
   tokenProvider: MSTeamsAccessTokenProvider;
   fetchFn?: typeof fetch;
+  chunkSize?: number;
 }): Promise<OneDriveUploadResult> {
   const fetchFn = params.fetchFn ?? fetch;
-  const token = await params.tokenProvider.getAccessToken(GRAPH_SCOPE);
-
-  // Use "OpenClawShared" folder to organize bot-uploaded files
   const uploadPath = `/OpenClawShared/${encodeURIComponent(params.filename)}`;
 
-  const res = await fetchFn(`${GRAPH_ROOT}/me/drive/root:${uploadPath}:/content`, {
-    method: "PUT",
-    headers: {
-      Authorization: `Bearer ${token}`,
-      "Content-Type": params.contentType ?? "application/octet-stream",
-    },
-    body: new Uint8Array(params.buffer),
+  return uploadBuffer({
+    buffer: params.buffer,
+    filename: params.filename,
+    contentType: params.contentType,
+    tokenProvider: params.tokenProvider,
+    fetchFn,
+    simpleUrl: `${GRAPH_ROOT}/me/drive/root:${uploadPath}:/content`,
+    sessionUrl: `${GRAPH_ROOT}/me/drive/root:${uploadPath}:/createUploadSession`,
+    label: "OneDrive",
+    chunkSize: params.chunkSize ?? DEFAULT_CHUNK_SIZE,
   });
-
-  if (!res.ok) {
-    const body = await res.text().catch(() => "");
-    throw new Error(`OneDrive upload failed: ${res.status} ${res.statusText} - ${body}`);
-  }
-
-  const data = (await res.json()) as {
-    id?: string;
-    webUrl?: string;
-    name?: string;
-  };
-
-  if (!data.id || !data.webUrl || !data.name) {
-    throw new Error("OneDrive upload response missing required fields");
-  }
-
-  return {
-    id: data.id,
-    webUrl: data.webUrl,
-    name: data.name,
-  };
 }
 
 export interface OneDriveSharingLink {
@@ -165,8 +328,11 @@ export async function uploadAndShareOneDrive(params: {
 /**
  * Upload a file to a SharePoint site.
  * This is used for group chats and channels where /me/drive doesn't work for bots.
+ * Switches to the resumable upload-session protocol for files larger than 4 MiB.
  *
  * @param params.siteId - SharePoint site ID (e.g., "contoso.sharepoint.com,guid1,guid2")
+ * @param params.chunkSize - Optional override for the chunk size used in session uploads.
+ *   Must be a multiple of 320 KiB per Graph's contract. Defaults to ~5 MiB.
  */
 export async function uploadToSharePoint(params: {
   buffer: Buffer;
@@ -175,45 +341,23 @@ export async function uploadToSharePoint(params: {
   tokenProvider: MSTeamsAccessTokenProvider;
   siteId: string;
   fetchFn?: typeof fetch;
+  chunkSize?: number;
 }): Promise<OneDriveUploadResult> {
   const fetchFn = params.fetchFn ?? fetch;
-  const token = await params.tokenProvider.getAccessToken(GRAPH_SCOPE);
-
-  // Use "OpenClawShared" folder to organize bot-uploaded files
   const uploadPath = `/OpenClawShared/${encodeURIComponent(params.filename)}`;
+  const siteBase = `${GRAPH_ROOT}/sites/${params.siteId}/drive/root:${uploadPath}`;
 
-  const res = await fetchFn(
-    `${GRAPH_ROOT}/sites/${params.siteId}/drive/root:${uploadPath}:/content`,
-    {
-      method: "PUT",
-      headers: {
-        Authorization: `Bearer ${token}`,
-        "Content-Type": params.contentType ?? "application/octet-stream",
-      },
-      body: new Uint8Array(params.buffer),
-    },
-  );
-
-  if (!res.ok) {
-    const body = await res.text().catch(() => "");
-    throw new Error(`SharePoint upload failed: ${res.status} ${res.statusText} - ${body}`);
-  }
-
-  const data = (await res.json()) as {
-    id?: string;
-    webUrl?: string;
-    name?: string;
-  };
-
-  if (!data.id || !data.webUrl || !data.name) {
-    throw new Error("SharePoint upload response missing required fields");
-  }
-
-  return {
-    id: data.id,
-    webUrl: data.webUrl,
-    name: data.name,
-  };
+  return uploadBuffer({
+    buffer: params.buffer,
+    filename: params.filename,
+    contentType: params.contentType,
+    tokenProvider: params.tokenProvider,
+    fetchFn,
+    simpleUrl: `${siteBase}:/content`,
+    sessionUrl: `${siteBase}:/createUploadSession`,
+    label: "SharePoint",
+    chunkSize: params.chunkSize ?? DEFAULT_CHUNK_SIZE,
+  });
 }
 
 export interface ChatMember {

--- a/extensions/voice-call/src/manager.test.ts
+++ b/extensions/voice-call/src/manager.test.ts
@@ -19,6 +19,7 @@ import { CallManager } from "./manager.js";
 class FakeProvider implements VoiceCallProvider {
   readonly name = "plivo" as const;
   readonly playTtsCalls: PlayTtsInput[] = [];
+  readonly hangupCalls: HangupCallInput[] = [];
 
   verifyWebhook(_ctx: WebhookContext): WebhookVerificationResult {
     return { ok: true };
@@ -29,7 +30,9 @@ class FakeProvider implements VoiceCallProvider {
   async initiateCall(_input: InitiateCallInput): Promise<InitiateCallResult> {
     return { providerCallId: "request-uuid", status: "initiated" };
   }
-  async hangupCall(_input: HangupCallInput): Promise<void> {}
+  async hangupCall(input: HangupCallInput): Promise<void> {
+    this.hangupCalls.push(input);
+  }
   async playTts(input: PlayTtsInput): Promise<void> {
     this.playTtsCalls.push(input);
   }
@@ -69,6 +72,71 @@ describe("CallManager", () => {
     expect(manager.getCall(callId)?.providerCallId).toBe("call-uuid");
     expect(manager.getCallByProviderCallId("call-uuid")?.callId).toBe(callId);
     expect(manager.getCallByProviderCallId("request-uuid")).toBeUndefined();
+  });
+
+  it("hangs up rejected inbound calls instead of leaving them ringing", async () => {
+    const config = VoiceCallConfigSchema.parse({
+      enabled: true,
+      provider: "plivo",
+      fromNumber: "+15550000000",
+      inboundPolicy: "allowlist",
+      allowFrom: ["+15555550000"],
+    });
+
+    const storePath = path.join(os.tmpdir(), `openclaw-voice-call-reject-${Date.now()}`);
+    const provider = new FakeProvider();
+    const manager = new CallManager(config, storePath);
+    manager.initialize(provider, "https://example.com/voice/webhook");
+
+    manager.processEvent({
+      id: "evt-reject-1",
+      type: "call.ringing",
+      callId: "ignored",
+      providerCallId: "prov-rejected-123",
+      direction: "inbound",
+      from: "+15558675309",
+      to: "+15550000000",
+      timestamp: Date.now(),
+    });
+
+    // hangupCall is fire-and-forget; let the microtask queue drain.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(provider.hangupCalls).toHaveLength(1);
+    expect(provider.hangupCalls[0]?.providerCallId).toBe("prov-rejected-123");
+    expect(provider.hangupCalls[0]?.reason).toBe("hangup-bot");
+    expect(manager.getCallByProviderCallId("prov-rejected-123")).toBeUndefined();
+  });
+
+  it("accepts inbound calls in the allowlist and does NOT call hangupCall", async () => {
+    const config = VoiceCallConfigSchema.parse({
+      enabled: true,
+      provider: "plivo",
+      fromNumber: "+15550000000",
+      inboundPolicy: "allowlist",
+      allowFrom: ["+15558675309"],
+    });
+
+    const storePath = path.join(os.tmpdir(), `openclaw-voice-call-accept-${Date.now()}`);
+    const provider = new FakeProvider();
+    const manager = new CallManager(config, storePath);
+    manager.initialize(provider, "https://example.com/voice/webhook");
+
+    manager.processEvent({
+      id: "evt-accept-1",
+      type: "call.ringing",
+      callId: "ignored",
+      providerCallId: "prov-accepted-456",
+      direction: "inbound",
+      from: "+15558675309",
+      to: "+15550000000",
+      timestamp: Date.now(),
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(provider.hangupCalls).toHaveLength(0);
+    expect(manager.getCallByProviderCallId("prov-accepted-456")).toBeDefined();
   });
 
   it("speaks initial message on answered for notify mode (non-Twilio)", async () => {

--- a/extensions/voice-call/src/manager.ts
+++ b/extensions/voice-call/src/manager.ts
@@ -551,7 +551,23 @@ export class CallManager {
     if (!call && event.direction === "inbound" && event.providerCallId) {
       // Check if we should accept this inbound call
       if (!this.shouldAcceptInbound(event.from)) {
-        // TODO: Could hang up the call here
+        // Hang up the rejected call so the caller isn't left ringing/connected.
+        // processEvent is sync; fire-and-forget with a logged failure path.
+        const providerCallId = event.providerCallId;
+        if (this.provider) {
+          void this.provider
+            .hangupCall({
+              callId: crypto.randomUUID(),
+              providerCallId,
+              reason: "hangup-bot",
+            })
+            .catch((err) => {
+              console.warn(
+                `[voice-call] Failed to hang up rejected inbound call ${providerCallId}:`,
+                err,
+              );
+            });
+        }
         return;
       }
 

--- a/extensions/voice-call/src/manager/events.ts
+++ b/extensions/voice-call/src/manager/events.ts
@@ -92,7 +92,23 @@ export function processEvent(ctx: CallManagerContext, event: NormalizedEvent): v
 
   if (!call && event.direction === "inbound" && event.providerCallId) {
     if (!shouldAcceptInbound(ctx.config, event.from)) {
-      // TODO: Could hang up the call here.
+      // Hang up the rejected call so the caller isn't left ringing/connected.
+      // processEvent is sync; fire-and-forget with a logged failure path.
+      const providerCallId = event.providerCallId;
+      if (ctx.provider) {
+        void ctx.provider
+          .hangupCall({
+            callId: crypto.randomUUID(),
+            providerCallId,
+            reason: "hangup-bot",
+          })
+          .catch((err) => {
+            console.warn(
+              `[voice-call] Failed to hang up rejected inbound call ${providerCallId}:`,
+              err,
+            );
+          });
+      }
       return;
     }
 


### PR DESCRIPTION
## Summary

Closes two long-standing TODOs:

1. **MSTeams: support files > 4 MiB.** The simple `:/content` PUT is hard-limited by Graph to 4 MiB. Files above that threshold now route through the resumable upload session protocol — `createUploadSession` returns an `uploadUrl`, the buffer is sliced into chunks (default ~5 MiB, configurable via `chunkSize`), each chunk is `PUT` with a `Content-Range` header, and the final chunk's 200/201 response carries the completed `driveItem`. On mid-upload failure, a best-effort `DELETE uploadUrl` cancels the session. Small files keep the existing single-request path. Both `uploadToOneDrive` and `uploadToSharePoint` go through the same internal helper, so they stay in sync.

2. **Voice-call: hang up rejected inbound calls.** When an inbound call arrives from a number outside the configured allowlist, `processEvent` previously just `return`ed — leaving the provider holding the call (Twilio: continues ringing/connected). Now we call `provider.hangupCall(...)` with the `providerCallId` we already have on the event. Fire-and-forget with a logged failure path because `processEvent` is synchronous. Same fix applied to both `manager.ts:554` and the modular `manager/events.ts:96` so it lands regardless of which path is active.

No public API breakage — `uploadToOneDrive`/`uploadToSharePoint` add an optional `chunkSize` parameter (defaults preserved).

## Tests

10 new tests in `extensions/msteams/src/graph-upload.test.ts` cover:
- 1 MiB simple-upload happy path + `Authorization` header
- Simple PUT non-2xx error → labeled error message
- Simple PUT response missing fields → labeled error
- 5 MiB / 2 MiB chunks → 3 chunks with correct `Content-Range` (`bytes 0-…`, `bytes 2097152-…`, `bytes 4194304-…/5242880`) and final driveItem assertion
- Mid-upload PUT failure → labeled error AND `DELETE uploadUrl` cleanup
- Mid-upload fetch rejection → propagates AND `DELETE uploadUrl` cleanup
- `createUploadSession` non-2xx → labeled error
- `createUploadSession` missing `uploadUrl` → labeled error
- SharePoint simple path uses `/sites/{siteId}/.../content`
- SharePoint large path uses `/sites/{siteId}/.../createUploadSession` and chunks against the issued URL

2 new tests in `extensions/voice-call/src/manager.test.ts` assert:
- Rejected inbound call → `provider.hangupCall` invoked with the right `providerCallId` + `reason: "hangup-bot"`, no call record created
- Accepted inbound call → `provider.hangupCall` NOT invoked, call record created

`FakeProvider` is extended with a `hangupCalls: HangupCallInput[]` recorder.

## Verification

```bash
# Targeted (clean machine, no env noise):
npx vitest run --config vitest.extensions.config.ts \
  extensions/msteams/src/graph-upload.test.ts \
  extensions/voice-call/src/manager.test.ts
# Test Files  2 passed (2)
#      Tests  14 passed (14)

pnpm lint    # my files clean (35 pre-existing errors in matrix/whatsapp/nostr/etc. runtime.ts — unrelated)
pnpm build   # tsc --noEmit false + canvas:a2ui:bundle + post-build copies — clean
```

## Test plan

- [ ] CI green on the branch.
- [ ] Manual: send a 6 MB file in a Teams chat with a configured bot — confirm the file lands and the share link works.
- [ ] Manual: configure `inboundPolicy: allowlist` and call from a number outside the allowlist — confirm Twilio shows the call as `completed` immediately rather than left hanging.