### PR TITLE
Avoid writing resolved API keys to models config

### DIFF
--- a/src/agents/models-config.applies-config-env-vars.test.ts
+++ b/src/agents/models-config.applies-config-env-vars.test.ts
@@ -246,7 +246,7 @@ describe("models-config", () => {
     ]);
   });
 
-  it("omits resolved plaintext apiKey values from planned models.json contents", async () => {
+  it("replaces resolved plaintext apiKey values with a non-secret marker in planned models.json contents", async () => {
     const plan = await planOpenClawModelsJsonWithDeps(
       {
         cfg: { models: { providers: {} } },
@@ -291,8 +291,69 @@ describe("models-config", () => {
     const parsed = JSON.parse(plan.contents) as {
       providers?: Record<string, { apiKey?: string }>;
     };
-    expect(parsed.providers?.custom?.apiKey).toBeUndefined();
+    // Custom provider's resolved plaintext key is replaced with a non-secret
+    // marker so pi-coding-agent's custom-provider validation (which requires
+    // an apiKey field) still accepts the generated file. The plaintext value
+    // must not appear anywhere in the serialized contents.
+    expect(parsed.providers?.custom?.apiKey).toBe("secretref-managed");
+    expect(plan.contents).not.toContain("sk-resolved-provider-key");
+    // Known env-var marker apiKeys (like "OPENAI_API_KEY") are not secrets
+    // and remain untouched so resolution still works at runtime.
     expect(parsed.providers?.openai?.apiKey).toBe("OPENAI_API_KEY"); // pragma: allowlist secret
+  });
+
+  it("replaces resolved plaintext apiKey values when merging into an existing models.json", async () => {
+    const existing = {
+      providers: {
+        custom: {
+          baseUrl: "https://custom.example/v1",
+          api: "openai-completions",
+          apiKey: "sk-previously-persisted-key", // pragma: allowlist secret
+          models: [],
+        },
+      },
+    };
+    const plan = await planOpenClawModelsJsonWithDeps(
+      {
+        cfg: { models: { mode: "merge", providers: {} } },
+        agentDir: "/tmp/openclaw-models-config-env-vars-test",
+        env: {},
+        existingRaw: `${JSON.stringify(existing, null, 2)}\n`,
+        existingParsed: existing,
+      },
+      {
+        resolveImplicitProviders: async () => ({
+          custom: {
+            baseUrl: "https://custom.example/v1",
+            api: "openai-completions",
+            apiKey: "sk-resolved-provider-key",
+            models: [
+              {
+                id: "custom-model",
+                name: "Custom Model",
+                input: ["text"],
+                reasoning: false,
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 8192,
+                maxTokens: 2048,
+              },
+            ],
+          },
+        }),
+      },
+    );
+
+    expect(plan.action).toBe("write");
+    if (plan.action !== "write") {
+      throw new Error("Expected models.json write plan");
+    }
+
+    const parsed = JSON.parse(plan.contents) as {
+      providers?: Record<string, { apiKey?: string }>;
+    };
+    expect(parsed.providers?.custom?.apiKey).toBe("secretref-managed");
+    expect(plan.contents).not.toContain("sk-resolved-provider-key");
+    expect(plan.contents).not.toContain("sk-previously-persisted-key");
   });
 
   it("uses config env.vars entries for implicit provider discovery without mutating process.env", async () => {

--- a/src/agents/models-config.applies-config-env-vars.test.ts
+++ b/src/agents/models-config.applies-config-env-vars.test.ts
@@ -358,6 +358,158 @@ describe("models-config", () => {
     expect(parsed.providers?.custom?.apiKey).toBe("sk-user-authored-key");
   });
 
+  it("preserves plaintext apiKey values from source config providers", async () => {
+    const plan = await planOpenClawModelsJsonWithDeps(
+      {
+        cfg: {
+          models: {
+            providers: {
+              custom: {
+                baseUrl: "https://custom.example/v1",
+                api: "openai-completions",
+                apiKey: "sk-config-only-key", // pragma: allowlist secret
+                models: [
+                  {
+                    id: "custom-model",
+                    name: "Custom Model",
+                    input: ["text"],
+                    reasoning: false,
+                    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                    contextWindow: 8192,
+                    maxTokens: 2048,
+                  },
+                ],
+              },
+            },
+          },
+        },
+        agentDir: "/tmp/openclaw-models-config-env-vars-test",
+        env: {},
+        existingRaw: "",
+        existingParsed: null,
+      },
+      {
+        resolveImplicitProviders: async () => ({}),
+      },
+    );
+
+    expect(plan.action).toBe("write");
+    if (plan.action !== "write") {
+      throw new Error("Expected models.json write plan");
+    }
+
+    const parsed = JSON.parse(plan.contents) as {
+      providers?: Record<string, { apiKey?: string }>;
+    };
+    expect(parsed.providers?.custom?.apiKey).toBe("sk-config-only-key");
+  });
+
+  it("does not preserve matching existing plaintext apiKey values in replace mode", async () => {
+    const existing = {
+      providers: {
+        custom: {
+          baseUrl: "https://custom.example/v1",
+          api: "openai-completions",
+          apiKey: "sk-previously-generated-key", // pragma: allowlist secret
+          models: [],
+        },
+      },
+    };
+    const plan = await planOpenClawModelsJsonWithDeps(
+      {
+        cfg: { models: { mode: "replace", providers: {} } },
+        agentDir: "/tmp/openclaw-models-config-env-vars-test",
+        env: {},
+        existingRaw: `${JSON.stringify(existing, null, 2)}\n`,
+        existingParsed: existing,
+      },
+      {
+        resolveImplicitProviders: async () => ({
+          custom: {
+            baseUrl: "https://custom.example/v1",
+            api: "openai-completions",
+            apiKey: "sk-previously-generated-key",
+            models: [
+              {
+                id: "custom-model",
+                name: "Custom Model",
+                input: ["text"],
+                reasoning: false,
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 8192,
+                maxTokens: 2048,
+              },
+            ],
+          },
+        }),
+      },
+    );
+
+    expect(plan.action).toBe("write");
+    if (plan.action !== "write") {
+      throw new Error("Expected models.json write plan");
+    }
+
+    const parsed = JSON.parse(plan.contents) as {
+      providers?: Record<string, { apiKey?: string }>;
+    };
+    expect(parsed.providers?.custom?.apiKey).toBe("secretref-managed");
+    expect(plan.contents).not.toContain("sk-previously-generated-key");
+  });
+
+  it("does not preserve matching existing plaintext apiKey values when current resolution regenerated the same key", async () => {
+    const existing = {
+      providers: {
+        custom: {
+          baseUrl: "https://custom.example/v1",
+          api: "openai-completions",
+          apiKey: "sk-regenerated-key", // pragma: allowlist secret
+          models: [],
+        },
+      },
+    };
+    const plan = await planOpenClawModelsJsonWithDeps(
+      {
+        cfg: { models: { mode: "merge", providers: {} } },
+        agentDir: "/tmp/openclaw-models-config-env-vars-test",
+        env: {},
+        existingRaw: `${JSON.stringify(existing, null, 2)}\n`,
+        existingParsed: existing,
+      },
+      {
+        resolveImplicitProviders: async () => ({
+          custom: {
+            baseUrl: "https://custom.example/v1",
+            api: "openai-completions",
+            apiKey: "sk-regenerated-key",
+            models: [
+              {
+                id: "custom-model",
+                name: "Custom Model",
+                input: ["text"],
+                reasoning: false,
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 8192,
+                maxTokens: 2048,
+              },
+            ],
+          },
+        }),
+      },
+    );
+
+    expect(plan.action).toBe("write");
+    if (plan.action !== "write") {
+      throw new Error("Expected models.json write plan");
+    }
+
+    const parsed = JSON.parse(plan.contents) as {
+      providers?: Record<string, { apiKey?: string }>;
+    };
+    expect(parsed.providers?.custom?.apiKey).toBe("secretref-managed");
+    expect(plan.contents).not.toContain("sk-regenerated-key");
+  });
+
   it("replaces plaintext apiKey for a newly added provider in merge mode while preserving an existing provider's user-authored key", async () => {
     const existing = {
       providers: {

--- a/src/agents/models-config.applies-config-env-vars.test.ts
+++ b/src/agents/models-config.applies-config-env-vars.test.ts
@@ -246,6 +246,55 @@ describe("models-config", () => {
     ]);
   });
 
+  it("omits resolved plaintext apiKey values from planned models.json contents", async () => {
+    const plan = await planOpenClawModelsJsonWithDeps(
+      {
+        cfg: { models: { providers: {} } },
+        agentDir: "/tmp/openclaw-models-config-env-vars-test",
+        env: {},
+        existingRaw: "",
+        existingParsed: null,
+      },
+      {
+        resolveImplicitProviders: async () => ({
+          custom: {
+            baseUrl: "https://custom.example/v1",
+            api: "openai-completions",
+            apiKey: "sk-resolved-provider-key",
+            models: [
+              {
+                id: "custom-model",
+                name: "Custom Model",
+                input: ["text"],
+                reasoning: false,
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 8192,
+                maxTokens: 2048,
+              },
+            ],
+          },
+          openai: {
+            baseUrl: "https://api.openai.com/v1",
+            api: "openai-completions",
+            apiKey: "OPENAI_API_KEY", // pragma: allowlist secret
+            models: [],
+          },
+        }),
+      },
+    );
+
+    expect(plan.action).toBe("write");
+    if (plan.action !== "write") {
+      throw new Error("Expected models.json write plan");
+    }
+
+    const parsed = JSON.parse(plan.contents) as {
+      providers?: Record<string, { apiKey?: string }>;
+    };
+    expect(parsed.providers?.custom?.apiKey).toBeUndefined();
+    expect(parsed.providers?.openai?.apiKey).toBe("OPENAI_API_KEY"); // pragma: allowlist secret
+  });
+
   it("uses config env.vars entries for implicit provider discovery without mutating process.env", async () => {
     await withTempEnv(["OPENROUTER_API_KEY", TEST_ENV_VAR], async () => {
       unsetEnv(["OPENROUTER_API_KEY", TEST_ENV_VAR]);

--- a/src/agents/models-config.applies-config-env-vars.test.ts
+++ b/src/agents/models-config.applies-config-env-vars.test.ts
@@ -302,13 +302,16 @@ describe("models-config", () => {
     expect(parsed.providers?.openai?.apiKey).toBe("OPENAI_API_KEY"); // pragma: allowlist secret
   });
 
-  it("replaces resolved plaintext apiKey values when merging into an existing models.json", async () => {
+  it("preserves user-authored existing models.json apiKey values in merge mode", async () => {
+    // Models.json that the user authored by hand. The custom provider's
+    // apiKey is the user's only credential for that provider; the sanitizer
+    // must not replace it with a non-usable marker on subsequent plan/writes.
     const existing = {
       providers: {
         custom: {
           baseUrl: "https://custom.example/v1",
           api: "openai-completions",
-          apiKey: "sk-previously-persisted-key", // pragma: allowlist secret
+          apiKey: "sk-user-authored-key", // pragma: allowlist secret
           models: [],
         },
       },
@@ -326,7 +329,8 @@ describe("models-config", () => {
           custom: {
             baseUrl: "https://custom.example/v1",
             api: "openai-completions",
-            apiKey: "sk-resolved-provider-key",
+            // No apiKey from implicit resolution — mergeWithExistingProviderSecrets
+            // is expected to carry the user's existing key forward.
             models: [
               {
                 id: "custom-model",
@@ -351,9 +355,69 @@ describe("models-config", () => {
     const parsed = JSON.parse(plan.contents) as {
       providers?: Record<string, { apiKey?: string }>;
     };
-    expect(parsed.providers?.custom?.apiKey).toBe("secretref-managed");
-    expect(plan.contents).not.toContain("sk-resolved-provider-key");
-    expect(plan.contents).not.toContain("sk-previously-persisted-key");
+    expect(parsed.providers?.custom?.apiKey).toBe("sk-user-authored-key");
+  });
+
+  it("replaces plaintext apiKey for a newly added provider in merge mode while preserving an existing provider's user-authored key", async () => {
+    const existing = {
+      providers: {
+        kept: {
+          baseUrl: "https://kept.example/v1",
+          api: "openai-completions",
+          apiKey: "sk-user-authored-key", // pragma: allowlist secret
+          models: [],
+        },
+      },
+    };
+    const plan = await planOpenClawModelsJsonWithDeps(
+      {
+        cfg: { models: { mode: "merge", providers: {} } },
+        agentDir: "/tmp/openclaw-models-config-env-vars-test",
+        env: {},
+        existingRaw: `${JSON.stringify(existing, null, 2)}\n`,
+        existingParsed: existing,
+      },
+      {
+        resolveImplicitProviders: async () => ({
+          kept: {
+            baseUrl: "https://kept.example/v1",
+            api: "openai-completions",
+            models: [],
+          },
+          // Newly resolved provider that did not exist in the user's
+          // models.json. Its plaintext apiKey is OpenClaw-resolved, not
+          // user-authored, and must be replaced with a non-secret marker.
+          newprov: {
+            baseUrl: "https://newprov.example/v1",
+            api: "openai-completions",
+            apiKey: "sk-resolved-new-provider-key",
+            models: [
+              {
+                id: "new-model",
+                name: "New Model",
+                input: ["text"],
+                reasoning: false,
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 8192,
+                maxTokens: 2048,
+              },
+            ],
+          },
+        }),
+      },
+    );
+
+    expect(plan.action).toBe("write");
+    if (plan.action !== "write") {
+      throw new Error("Expected models.json write plan");
+    }
+
+    const parsed = JSON.parse(plan.contents) as {
+      providers?: Record<string, { apiKey?: string }>;
+    };
+    expect(parsed.providers?.kept?.apiKey).toBe("sk-user-authored-key");
+    expect(parsed.providers?.newprov?.apiKey).toBe("secretref-managed");
+    expect(plan.contents).not.toContain("sk-resolved-new-provider-key");
   });
 
   it("uses config env.vars entries for implicit provider discovery without mutating process.env", async () => {

--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -6,7 +6,7 @@ import {
   mergeWithExistingProviderSecrets,
   type ExistingProviderConfig,
 } from "./models-config.merge.js";
-import { isNonSecretApiKeyMarker } from "./model-auth-markers.js";
+import { NON_ENV_SECRETREF_MARKER, isNonSecretApiKeyMarker } from "./model-auth-markers.js";
 import {
   applyNativeStreamingUsageCompat,
   enforceSourceManagedProviderSecrets,
@@ -115,9 +115,7 @@ function stripResolvedApiKeysForModelsJson(
   for (const [providerKey, provider] of Object.entries(providers)) {
     const apiKey = provider.apiKey;
     if (typeof apiKey === "string" && apiKey.trim() && !isNonSecretApiKeyMarker(apiKey)) {
-      const providerWithoutApiKey = { ...provider };
-      delete providerWithoutApiKey.apiKey;
-      sanitizedProviders[providerKey] = providerWithoutApiKey;
+      sanitizedProviders[providerKey] = { ...provider, apiKey: NON_ENV_SECRETREF_MARKER };
       changed = true;
       continue;
     }

--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -106,14 +106,48 @@ function resolveProvidersForMode(params: {
   });
 }
 
+function collectExistingUserOwnedApiKeys(existingParsed: unknown): ReadonlyMap<string, string> {
+  const userOwned = new Map<string, string>();
+  if (!isRecord(existingParsed) || !isRecord(existingParsed.providers)) {
+    return userOwned;
+  }
+  for (const [providerKey, entry] of Object.entries(existingParsed.providers)) {
+    if (!isRecord(entry)) {
+      continue;
+    }
+    const apiKey = entry.apiKey;
+    if (typeof apiKey !== "string" || !apiKey.trim()) {
+      continue;
+    }
+    // Existing apiKeys that are already non-secret markers don't need
+    // preservation tracking — leaving them alone falls out naturally from
+    // the marker check below. We only track non-marker (user-authored
+    // plaintext) values, which are the ones the sanitizer must not clobber.
+    if (isNonSecretApiKeyMarker(apiKey)) {
+      continue;
+    }
+    userOwned.set(providerKey, apiKey);
+  }
+  return userOwned;
+}
+
 function stripResolvedApiKeysForModelsJson(
   providers: Record<string, ProviderConfig>,
+  existingUserOwnedApiKeys: ReadonlyMap<string, string>,
 ): Record<string, ProviderConfig> {
   let changed = false;
   const sanitizedProviders: Record<string, ProviderConfig> = {};
 
   for (const [providerKey, provider] of Object.entries(providers)) {
     const apiKey = provider.apiKey;
+    // Preserve user-authored plaintext that already lived in models.json.
+    // mergeWithExistingProviderSecrets intentionally carries these forward,
+    // and replacing them with a non-usable marker would break custom
+    // providers whose only credential lives in the existing models.json.
+    if (typeof apiKey === "string" && existingUserOwnedApiKeys.get(providerKey) === apiKey) {
+      sanitizedProviders[providerKey] = provider;
+      continue;
+    }
     if (typeof apiKey === "string" && apiKey.trim() && !isNonSecretApiKeyMarker(apiKey)) {
       sanitizedProviders[providerKey] = { ...provider, apiKey: NON_ENV_SECRETREF_MARKER };
       changed = true;
@@ -198,8 +232,10 @@ export async function planOpenClawModelsJsonWithDeps(
       sourceSecretDefaults: params.sourceConfigForSecrets?.secrets?.defaults,
       secretRefManagedProviders,
     }) ?? normalizedMergedProviders;
+  const existingUserOwnedApiKeys = collectExistingUserOwnedApiKeys(params.existingParsed);
   const finalProviders = stripResolvedApiKeysForModelsJson(
     applyNativeStreamingUsageCompat(secretEnforcedProviders),
+    existingUserOwnedApiKeys,
   );
   const nextContents = `${JSON.stringify({ providers: finalProviders }, null, 2)}\n`;
 

--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -6,6 +6,7 @@ import {
   mergeWithExistingProviderSecrets,
   type ExistingProviderConfig,
 } from "./models-config.merge.js";
+import { isNonSecretApiKeyMarker } from "./model-auth-markers.js";
 import {
   applyNativeStreamingUsageCompat,
   enforceSourceManagedProviderSecrets,
@@ -105,6 +106,28 @@ function resolveProvidersForMode(params: {
   });
 }
 
+function stripResolvedApiKeysForModelsJson(
+  providers: Record<string, ProviderConfig>,
+): Record<string, ProviderConfig> {
+  let changed = false;
+  const sanitizedProviders: Record<string, ProviderConfig> = {};
+
+  for (const [providerKey, provider] of Object.entries(providers)) {
+    const apiKey = provider.apiKey;
+    if (typeof apiKey === "string" && apiKey.trim() && !isNonSecretApiKeyMarker(apiKey)) {
+      const providerWithoutApiKey = { ...provider };
+      delete providerWithoutApiKey.apiKey;
+      sanitizedProviders[providerKey] = providerWithoutApiKey;
+      changed = true;
+      continue;
+    }
+
+    sanitizedProviders[providerKey] = provider;
+  }
+
+  return changed ? sanitizedProviders : providers;
+}
+
 export async function planOpenClawModelsJsonWithDeps(
   params: {
     cfg: OpenClawConfig;
@@ -177,7 +200,9 @@ export async function planOpenClawModelsJsonWithDeps(
       sourceSecretDefaults: params.sourceConfigForSecrets?.secrets?.defaults,
       secretRefManagedProviders,
     }) ?? normalizedMergedProviders;
-  const finalProviders = applyNativeStreamingUsageCompat(secretEnforcedProviders);
+  const finalProviders = stripResolvedApiKeysForModelsJson(
+    applyNativeStreamingUsageCompat(secretEnforcedProviders),
+  );
   const nextContents = `${JSON.stringify({ providers: finalProviders }, null, 2)}\n`;
 
   if (params.existingRaw === nextContents) {

--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -106,12 +106,14 @@ function resolveProvidersForMode(params: {
   });
 }
 
-function collectExistingUserOwnedApiKeys(existingParsed: unknown): ReadonlyMap<string, string> {
-  const userOwned = new Map<string, string>();
-  if (!isRecord(existingParsed) || !isRecord(existingParsed.providers)) {
-    return userOwned;
+function collectPlaintextApiKeysFromProviders(
+  providers: unknown,
+): ReadonlyMap<string, string> {
+  const plaintextApiKeys = new Map<string, string>();
+  if (!isRecord(providers)) {
+    return plaintextApiKeys;
   }
-  for (const [providerKey, entry] of Object.entries(existingParsed.providers)) {
+  for (const [providerKey, entry] of Object.entries(providers)) {
     if (!isRecord(entry)) {
       continue;
     }
@@ -126,14 +128,44 @@ function collectExistingUserOwnedApiKeys(existingParsed: unknown): ReadonlyMap<s
     if (isNonSecretApiKeyMarker(apiKey)) {
       continue;
     }
-    userOwned.set(providerKey, apiKey);
+    plaintextApiKeys.set(providerKey, apiKey);
   }
-  return userOwned;
+  return plaintextApiKeys;
+}
+
+function collectPreservedApiKeysForModelsJson(params: {
+  mode: NonNullable<ModelsConfig["mode"]>;
+  existingParsed: unknown;
+  sourceProviders: unknown;
+  providersBeforeMerge: Record<string, ProviderConfig>;
+  mergedProviders: Record<string, ProviderConfig>;
+}): ReadonlyMap<string, string> {
+  const preserved = new Map<string, string>(
+    collectPlaintextApiKeysFromProviders(params.sourceProviders),
+  );
+  if (params.mode !== "merge" || !isRecord(params.existingParsed)) {
+    return preserved;
+  }
+  const existingProviders = isRecord(params.existingParsed.providers)
+    ? params.existingParsed.providers
+    : {};
+  const existingPlaintextApiKeys = collectPlaintextApiKeysFromProviders(existingProviders);
+  for (const [providerKey, apiKey] of existingPlaintextApiKeys) {
+    const providerBeforeMerge = params.providersBeforeMerge[providerKey];
+    const beforeMergeApiKey = providerBeforeMerge?.apiKey;
+    if (typeof beforeMergeApiKey === "string" && beforeMergeApiKey.trim()) {
+      continue;
+    }
+    if (params.mergedProviders[providerKey]?.apiKey === apiKey) {
+      preserved.set(providerKey, apiKey);
+    }
+  }
+  return preserved;
 }
 
 function stripResolvedApiKeysForModelsJson(
   providers: Record<string, ProviderConfig>,
-  existingUserOwnedApiKeys: ReadonlyMap<string, string>,
+  preservedPlaintextApiKeys: ReadonlyMap<string, string>,
 ): Record<string, ProviderConfig> {
   let changed = false;
   const sanitizedProviders: Record<string, ProviderConfig> = {};
@@ -144,7 +176,7 @@ function stripResolvedApiKeysForModelsJson(
     // mergeWithExistingProviderSecrets intentionally carries these forward,
     // and replacing them with a non-usable marker would break custom
     // providers whose only credential lives in the existing models.json.
-    if (typeof apiKey === "string" && existingUserOwnedApiKeys.get(providerKey) === apiKey) {
+    if (typeof apiKey === "string" && preservedPlaintextApiKeys.get(providerKey) === apiKey) {
       sanitizedProviders[providerKey] = provider;
       continue;
     }
@@ -232,10 +264,16 @@ export async function planOpenClawModelsJsonWithDeps(
       sourceSecretDefaults: params.sourceConfigForSecrets?.secrets?.defaults,
       secretRefManagedProviders,
     }) ?? normalizedMergedProviders;
-  const existingUserOwnedApiKeys = collectExistingUserOwnedApiKeys(params.existingParsed);
+  const preservedPlaintextApiKeys = collectPreservedApiKeysForModelsJson({
+    mode,
+    existingParsed: params.existingParsed,
+    sourceProviders: params.sourceConfigForSecrets?.models?.providers ?? cfg.models?.providers,
+    providersBeforeMerge: normalizedProviders,
+    mergedProviders,
+  });
   const finalProviders = stripResolvedApiKeysForModelsJson(
     applyNativeStreamingUsageCompat(secretEnforcedProviders),
-    existingUserOwnedApiKeys,
+    preservedPlaintextApiKeys,
   );
   const nextContents = `${JSON.stringify({ providers: finalProviders }, null, 2)}\n`;
 


### PR DESCRIPTION
## Summary

- Omit resolved runtime/provider plaintext `apiKey` values before writing `models.json`.
- Preserve non-secret auth markers such as `OPENAI_API_KEY`.
- Preserve user-owned plaintext credentials only when they come from source config or merge-mode models.json-only compatibility.
- Add regression coverage for source-config plaintext, replace-mode regenerated leaks, merge-mode existing-only credentials, and newly resolved provider keys.

AI-assisted: yes. I reviewed the change and verified the behavior locally.

## Real behavior proof

- **Behavior or issue addressed**: `models.json` planning could serialize a resolved plaintext provider `apiKey`, making that value visible in the agent-readable model config. This patch strips resolved runtime/provider keys at the serialization boundary while preserving marker-based auth and user-owned plaintext credentials that have no alternate runtime auth source.
- **Real environment tested**: Windows 11 PowerShell, Node from the local OpenClaw checkout, branch `fix-models-json-secret-serialization`, commit `53bb3299`.
- **Exact steps or command run after this patch**: Ran a direct runtime probe against `planOpenClawModelsJsonWithDeps` using `node --import tsx --input-type=module`. The probe covered source-config plaintext preservation, replace-mode regenerated plaintext scrubbing, and merge-mode models.json-only credential preservation.
- **Evidence after fix**: Terminal output from the runtime probe:

```json
{
  "configPlaintextPreserved": "sk-config-only-key",
  "replaceModeRegeneratedKey": "secretref-managed",
  "mergeModeExistingOnlyKey": "sk-previously-generated-key"
}
```

- **Observed result after fix**: Source-config plaintext remained usable, a replace-mode regenerated plaintext key was replaced with `secretref-managed`, and a merge-mode models.json-only credential stayed intact for compatibility.
- **What was not tested**: I did not run a live provider request with a real API key. The proof uses a fake key to avoid handling real credentials.

## Test plan

- `node scripts/test-projects.mjs src/agents/models-config.applies-config-env-vars.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/models-config.applies-config-env-vars.test.ts src/agents/models-config.merge.test.ts`
- `pnpm exec oxlint src/agents/models-config.plan.ts src/agents/models-config.applies-config-env-vars.test.ts`
- `git diff --check`

Fixes #11829
