### PR TITLE
Fix stale Codex lastGood after explicit auth order relogin

### DIFF
--- a/extensions/codex/src/command-account.ts
+++ b/extensions/codex/src/command-account.ts
@@ -62,7 +62,7 @@ export async function readCodexAccountAuthOverview(params: {
     allowKeychainPrompt: false,
     config,
   });
-  const order = resolveDisplayAuthOrder({ config, store });
+  const { order, explicit: explicitOrder } = resolveDisplayAuthOrder({ config, store });
   if (order.length === 0) {
     return undefined;
   }
@@ -71,6 +71,7 @@ export async function readCodexAccountAuthOverview(params: {
   const activeProfileId = resolveActiveProfileId({
     store,
     order,
+    explicitOrder,
     config,
     account: params.account,
     limits: params.limits,
@@ -135,21 +136,45 @@ export async function readCodexAccountAuthOverview(params: {
   };
 }
 
+type DisplayAuthOrder = {
+  readonly order: string[];
+  readonly explicit: boolean;
+};
+
 function resolveDisplayAuthOrder(params: {
   config: AuthProfileOrderConfig;
   store: AuthProfileStore;
-}): string[] {
+}): DisplayAuthOrder {
   const codexOrder =
     resolveOrder(params.store.order, OPENAI_CODEX_PROVIDER_ID) ??
     resolveOrder(params.config?.auth?.order, OPENAI_CODEX_PROVIDER_ID);
   if (codexOrder && codexOrder.length > 0) {
-    return dedupe(codexOrder);
+    return { order: dedupe(codexOrder), explicit: true };
   }
-  return resolveAuthProfileOrder({
+  const order = resolveAuthProfileOrder({
     cfg: params.config,
     store: params.store,
     provider: OPENAI_CODEX_PROVIDER_ID,
   });
+  return { order, explicit: hasExplicitOpenAiAuthOrder(params) };
+}
+
+function hasExplicitOpenAiAuthOrder(params: {
+  config: AuthProfileOrderConfig;
+  store: AuthProfileStore;
+}): boolean {
+  const sources = [params.store.order, params.config?.auth?.order];
+  for (const source of sources) {
+    const codex = resolveOrder(source, OPENAI_CODEX_PROVIDER_ID);
+    if (codex && codex.length > 0) {
+      return true;
+    }
+    const openai = resolveOrder(source, OPENAI_PROVIDER_ID);
+    if (openai && openai.length > 0) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function resolveOrder(
@@ -162,6 +187,7 @@ function resolveOrder(
 function resolveActiveProfileId(params: {
   store: AuthProfileStore;
   order: string[];
+  explicitOrder: boolean;
   config: AuthProfileOrderConfig;
   account: SafeValue<JsonValue | undefined>;
   limits: SafeValue<JsonValue | undefined>;
@@ -174,6 +200,24 @@ function resolveActiveProfileId(params: {
   });
   if (liveProfileId) {
     return liveProfileId;
+  }
+  // Explicit auth order should win for the status display so it stays aligned
+  // with the runtime resolver after relogin/order changes.
+  if (params.explicitOrder) {
+    const firstUsable = params.order.find(
+      (profileId) =>
+        isActiveProfileCandidate(params, profileId) &&
+        resolveAuthProfileEligibility({
+          cfg: params.config,
+          store: params.store,
+          provider: OPENAI_CODEX_PROVIDER_ID,
+          profileId,
+          now: params.now,
+        }).eligible,
+    );
+    if (firstUsable) {
+      return firstUsable;
+    }
   }
   const lastGood = [
     params.store.lastGood?.[OPENAI_PROVIDER_ID],

--- a/extensions/codex/src/commands.test.ts
+++ b/extensions/codex/src/commands.test.ts
@@ -1346,6 +1346,71 @@ describe("codex command", () => {
     expect(result.text).not.toContain("@here");
   });
 
+  it("respects explicit Codex auth order over stale lastGood after OAuth re-login", async () => {
+    const config = {};
+    const now = Date.now();
+    installAuthProfileStore(
+      {
+        version: 1,
+        profiles: {
+          "openai-codex:default": {
+            type: "oauth",
+            provider: "openai-codex",
+            access: "stale-access-token",
+            refresh: "stale-refresh-token",
+            expires: now + 2 * 24 * 60 * 60 * 1000,
+            email: "previous@example.com",
+          },
+          "openai-codex:fresh-email@example.com": {
+            type: "oauth",
+            provider: "openai-codex",
+            access: "fresh-access-token",
+            refresh: "fresh-refresh-token",
+            expires: now + 9 * 24 * 60 * 60 * 1000,
+            email: "fresh-email@example.com",
+          },
+        },
+        order: {
+          "openai-codex": ["openai-codex:fresh-email@example.com", "openai-codex:default"],
+        },
+        lastGood: {
+          "openai-codex": "openai-codex:default",
+        },
+      },
+      config,
+    );
+
+    const safeCodexControlRequest = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        value: { account: { type: "unknown" }, requiresOpenaiAuth: true },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        value: codexRateLimitPayload({
+          primaryUsedPercent: 5,
+          secondaryUsedPercent: 10,
+          primaryResetSeconds: Math.ceil(now / 1000) + 60 * 60,
+          secondaryResetSeconds: Math.ceil(now / 1000) + 6 * 60 * 60,
+        }),
+      });
+
+    const result = await handleCodexCommand(createContext("account", undefined, { config }), {
+      deps: createDeps({ safeCodexControlRequest }),
+    });
+
+    expect(result.text).toContain(
+      "\n  1. fresh-email@example.com   ChatGPT subscription   — active now",
+    );
+    expect(result.text).toContain(
+      "\n  2. previous@example.com   ChatGPT subscription   — available if needed",
+    );
+    expect(result.text).not.toContain("previous@example.com   ChatGPT subscription   — active now");
+    expect(result.text).not.toContain("openai-codex:");
+    expect(safeCodexControlRequest).toHaveBeenCalledTimes(2);
+  });
+
   it("formats generated Amazon Bedrock account responses", async () => {
     const safeCodexControlRequest = vi
       .fn()


### PR DESCRIPTION
### Summary

- **Problem**: After `models auth login --provider openai-codex` writes a fresh named OAuth profile and `models auth order set` puts that fresh profile first, the Codex `/codex account` display can still report the stale `openai-codex:default` profile as "active now". The status display silently disagrees with what the runtime resolver already prefers, which makes operators think the relogin did not take effect.
- **Root Cause**: The Codex display helper `resolveActiveProfileId` in `extensions/codex/src/command-account.ts` checks `lastGood` before the resolved auth-profile order whenever there is no live account match. That drifts from the core resolver contract in `src/agents/auth-profiles/order.ts`, which already treats explicit operator order as authoritative.
- **Fix**: Track whether the resolved Codex/OpenAI auth order came from an explicit operator source (`store.order` or `config.auth.order`). When the order is explicit, `resolveActiveProfileId` now picks the first profile in that order that is both not in cooldown and credential-eligible. The legacy `lastGood` / usage-stat heuristics still apply when there is no explicit order.
- **What changed**:
  - `extensions/codex/src/command-account.ts`: `resolveDisplayAuthOrder` now returns `{ order, explicit }`; a new `hasExplicitOpenAiAuthOrder` helper detects explicit Codex/OpenAI order; `resolveActiveProfileId` gains an explicit-order-first branch that preserves `resolveAuthProfileEligibility` filtering.
  - `extensions/codex/src/commands.test.ts`: adds `respects explicit Codex auth order over stale lastGood after OAuth re-login`, which reproduces the relogin store shape and asserts the fresh profile is shown as active.
- **What did NOT change**:
  - No edits to `src/agents/auth-profiles/**`.
  - No migration, doctor, config, SDK, or runtime app-server auth-selection changes.
  - No heartbeat/context-engine/session-key work in this PR.

### Verification

- Behavior addressed: stale `lastGood` no longer overrides explicit Codex auth profile order in `/codex account` display.
- Real environment tested: local OpenClaw checkout on macOS; no live OAuth relogin round trip.
- Exact steps or command run after this patch:
  1. `pnpm test extensions/codex/src/commands.test.ts -- --reporter=verbose`
  2. `git diff --check`
- Evidence after fix: 89 tests passed in `extensions/codex/src/commands.test.ts`, including the new relogin regression.
- Observed result after fix: the fresh explicitly ordered profile is shown as `active now`, and the stale default is shown as `available if needed`.
- What was not tested: live Codex OAuth relogin round trip.

### Linked Issue/PR

Fixes #84386
