### PR TITLE
[Fix] Keep node systemd tokens out of unit files

### DIFF
--- a/src/cli/node-cli/daemon.ts
+++ b/src/cli/node-cli/daemon.ts
@@ -136,7 +136,7 @@ export async function runNodeDaemonInstall(opts: NodeDaemonInstallOptions) {
   const tlsFingerprint =
     normalizeOptionalString(opts.tlsFingerprint) || config?.gateway?.tlsFingerprint;
   const tls = Boolean(opts.tls) || Boolean(tlsFingerprint) || Boolean(config?.gateway?.tls);
-  const { programArguments, workingDirectory, environment, description } =
+  const { programArguments, workingDirectory, environment, environmentValueSources, description } =
     await buildNodeInstallPlan({
       env: process.env,
       host,
@@ -168,6 +168,7 @@ export async function runNodeDaemonInstall(opts: NodeDaemonInstallOptions) {
         programArguments,
         workingDirectory,
         environment,
+        environmentValueSources,
         description,
       });
     },

--- a/src/commands/node-daemon-install-helpers.test.ts
+++ b/src/commands/node-daemon-install-helpers.test.ts
@@ -55,6 +55,9 @@ describe("buildNodeInstallPlan", () => {
     expect(plan.environment).toEqual({
       OPENCLAW_SERVICE_VERSION: "2026.3.22",
     });
+    expect(plan.environmentValueSources).toEqual({
+      OPENCLAW_GATEWAY_TOKEN: "file",
+    });
     expect(mocks.resolvePreferredNodePath).not.toHaveBeenCalled();
     expect(mocks.buildNodeServiceEnvironment).toHaveBeenCalledWith({
       env: {},
@@ -88,6 +91,35 @@ describe("buildNodeInstallPlan", () => {
     expect(mocks.buildNodeServiceEnvironment).toHaveBeenCalledWith({
       env: {},
       extraPathDirs: undefined,
+    });
+  });
+
+  it("marks node gateway tokens as file-backed service env", async () => {
+    mocks.resolveNodeProgramArguments.mockResolvedValue({
+      programArguments: ["node", "node-host"],
+      workingDirectory: "/Users/me",
+    });
+    mocks.resolveSystemNodeInfo.mockResolvedValue({
+      path: "/usr/bin/node",
+      version: "22.0.0",
+      supported: true,
+    });
+    mocks.renderSystemNodeWarning.mockReturnValue(undefined);
+    mocks.buildNodeServiceEnvironment.mockReturnValue({
+      OPENCLAW_GATEWAY_TOKEN: "node-token",
+      OPENCLAW_SERVICE_VERSION: "2026.3.22",
+    });
+
+    const plan = await buildNodeInstallPlan({
+      env: { OPENCLAW_GATEWAY_TOKEN: "node-token" },
+      host: "127.0.0.1",
+      port: 18789,
+      runtime: "node",
+    });
+
+    expect(plan.environment.OPENCLAW_GATEWAY_TOKEN).toBe("node-token");
+    expect(plan.environmentValueSources).toEqual({
+      OPENCLAW_GATEWAY_TOKEN: "file",
     });
   });
 });

--- a/src/commands/node-daemon-install-helpers.ts
+++ b/src/commands/node-daemon-install-helpers.ts
@@ -1,6 +1,7 @@
 import { formatNodeServiceDescription } from "../daemon/constants.js";
 import { resolveNodeProgramArguments } from "../daemon/program-args.js";
 import { buildNodeServiceEnvironment } from "../daemon/service-env.js";
+import type { GatewayServiceEnvironmentValueSource } from "../daemon/service-types.js";
 import {
   emitDaemonInstallRuntimeWarning,
   resolveDaemonInstallRuntimeInputs,
@@ -13,8 +14,18 @@ type NodeInstallPlan = {
   programArguments: string[];
   workingDirectory?: string;
   environment: Record<string, string | undefined>;
+  environmentValueSources?: Record<string, GatewayServiceEnvironmentValueSource | undefined>;
   description?: string;
 };
+
+function buildNodeInstallEnvironmentValueSources(): Record<
+  string,
+  GatewayServiceEnvironmentValueSource | undefined
+> {
+  return {
+    OPENCLAW_GATEWAY_TOKEN: "file",
+  };
+}
 
 export async function buildNodeInstallPlan(params: {
   env: Record<string, string | undefined>;
@@ -65,5 +76,11 @@ export async function buildNodeInstallPlan(params: {
     version: environment.OPENCLAW_SERVICE_VERSION,
   });
 
-  return { programArguments, workingDirectory, environment, description };
+  return {
+    programArguments,
+    workingDirectory,
+    environment,
+    environmentValueSources: buildNodeInstallEnvironmentValueSources(),
+    description,
+  };
 }

--- a/src/daemon/arg-split.ts
+++ b/src/daemon/arg-split.ts
@@ -1,13 +1,21 @@
 type ArgSplitEscapeMode = "none" | "backslash" | "backslash-quote-only";
+type ArgSplitQuoteChar = '"' | "'";
+type ArgSplitQuoteStart = "anywhere" | "item-start";
 
 export function splitArgsPreservingQuotes(
   value: string,
-  options?: { escapeMode?: ArgSplitEscapeMode },
+  options?: {
+    escapeMode?: ArgSplitEscapeMode;
+    quoteChars?: readonly ArgSplitQuoteChar[];
+    quoteStart?: ArgSplitQuoteStart;
+  },
 ): string[] {
   const args: string[] = [];
   let current = "";
-  let inQuotes = false;
+  let quoteChar: ArgSplitQuoteChar | null = null;
   const escapeMode = options?.escapeMode ?? "none";
+  const quoteChars = new Set<ArgSplitQuoteChar>(options?.quoteChars ?? ['"']);
+  const quoteStart = options?.quoteStart ?? "anywhere";
 
   for (let i = 0; i < value.length; i++) {
     const char = value[i];
@@ -28,11 +36,18 @@ export function splitArgsPreservingQuotes(
       i++;
       continue;
     }
-    if (char === '"') {
-      inQuotes = !inQuotes;
-      continue;
+    if (quoteChars.has(char as ArgSplitQuoteChar)) {
+      if (quoteChar === char) {
+        quoteChar = null;
+        continue;
+      }
+      const canOpenQuote = quoteStart === "anywhere" || current.length === 0;
+      if (!quoteChar && canOpenQuote) {
+        quoteChar = char as ArgSplitQuoteChar;
+        continue;
+      }
     }
-    if (!inQuotes && /\s/.test(char)) {
+    if (!quoteChar && /\s/.test(char)) {
       if (current) {
         args.push(current);
         current = "";

--- a/src/daemon/systemd-unit.ts
+++ b/src/daemon/systemd-unit.ts
@@ -137,3 +137,14 @@ export function parseSystemdEnvAssignment(raw: string): { key: string; value: st
   const value = unquoted.slice(eq + 1);
   return { key, value };
 }
+
+export function parseSystemdEnvAssignments(raw: string): Array<{ key: string; value: string }> {
+  return splitArgsPreservingQuotes(raw, { escapeMode: "backslash" }).flatMap((entry) => {
+    const parsed = parseSystemdEnvAssignment(entry);
+    return parsed ? [parsed] : [];
+  });
+}
+
+export function renderSystemdEnvAssignment(key: string, value: string): string {
+  return systemdEscapeArg(`${key}=${value}`);
+}

--- a/src/daemon/systemd-unit.ts
+++ b/src/daemon/systemd-unit.ts
@@ -106,7 +106,8 @@ export function parseSystemdEnvAssignment(raw: string): { key: string; value: st
   }
 
   const unquoted = (() => {
-    if (!(trimmed.startsWith('"') && trimmed.endsWith('"'))) {
+    const quote = trimmed[0];
+    if (!((quote === '"' || quote === "'") && trimmed.endsWith(quote))) {
       return trimmed;
     }
     let out = "";
@@ -139,7 +140,11 @@ export function parseSystemdEnvAssignment(raw: string): { key: string; value: st
 }
 
 export function parseSystemdEnvAssignments(raw: string): Array<{ key: string; value: string }> {
-  return splitArgsPreservingQuotes(raw, { escapeMode: "backslash" }).flatMap((entry) => {
+  return splitArgsPreservingQuotes(raw, {
+    escapeMode: "backslash",
+    quoteChars: ['"', "'"],
+    quoteStart: "item-start",
+  }).flatMap((entry) => {
     const parsed = parseSystemdEnvAssignment(entry);
     return parsed ? [parsed] : [];
   });

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -21,7 +21,7 @@ vi.mock("node:child_process", async () => {
 });
 
 import { splitArgsPreservingQuotes } from "./arg-split.js";
-import { parseSystemdExecStart } from "./systemd-unit.js";
+import { parseSystemdEnvAssignments, parseSystemdExecStart } from "./systemd-unit.js";
 import {
   installSystemdService,
   isNonFatalSystemdInstallProbeError,
@@ -608,6 +608,24 @@ describe("splitArgsPreservingQuotes", () => {
   });
 });
 
+describe("parseSystemdEnvAssignments", () => {
+  it("parses single-quoted whole assignments", () => {
+    expect(
+      parseSystemdEnvAssignments("'OPENCLAW_GATEWAY_TOKEN=single quoted token' FOO=bar"),
+    ).toEqual([
+      { key: "OPENCLAW_GATEWAY_TOKEN", value: "single quoted token" },
+      { key: "FOO", value: "bar" },
+    ]);
+  });
+
+  it("keeps apostrophes inside unquoted assignment values literal", () => {
+    expect(parseSystemdEnvAssignments("FOO=can't OPENCLAW_GATEWAY_TOKEN=token")).toEqual([
+      { key: "FOO", value: "can't" },
+      { key: "OPENCLAW_GATEWAY_TOKEN", value: "token" },
+    ]);
+  });
+});
+
 describe("parseSystemdExecStart", () => {
   it("preserves quoted arguments", () => {
     const execStart = '/usr/bin/openclaw gateway start --name "My Bot"';
@@ -953,6 +971,7 @@ describe("stageSystemdService", () => {
           "ExecStart=/usr/bin/openclaw node run",
           "Environment=FOO=bar OPENCLAW_GATEWAY_TOKEN=inline-token BAZ=qux",
           "Environment=OPENCLAW_GATEWAY_TOKEN=token-only-line",
+          "Environment='OPENCLAW_GATEWAY_TOKEN=single-quoted-token' FROM_SINGLE=kept",
           "Environment=OPENCLAW_GATEWAY_PORT=18789",
         ].join("\n"),
         { encoding: "utf8", mode: 0o600 },
@@ -985,7 +1004,9 @@ describe("stageSystemdService", () => {
       expect(unit).not.toContain("Environment=OPENCLAW_GATEWAY_TOKEN=fresh-token");
       expect(backupUnit).not.toContain("Environment=OPENCLAW_GATEWAY_TOKEN=inline-token");
       expect(backupUnit).not.toContain("Environment=OPENCLAW_GATEWAY_TOKEN=token-only-line");
+      expect(backupUnit).not.toContain("single-quoted-token");
       expect(backupUnit).toContain("Environment=FOO=bar BAZ=qux");
+      expect(backupUnit).toContain("Environment=FROM_SINGLE=kept");
       expect(backupUnit).toContain("Environment=OPENCLAW_GATEWAY_PORT=18789");
       expect(backupStat.mode & 0o777).toBe(0o600);
     });

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -756,6 +756,7 @@ describe("stageSystemdService", () => {
       stateDir: string;
       unitPath: string;
       envFilePath: string;
+      nodeEnvFilePath: string;
     }) => Promise<void>,
   ): Promise<void> {
     const tempHomeRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-systemd-stage-"));
@@ -768,10 +769,11 @@ describe("stageSystemdService", () => {
     };
     const unitPath = resolveSystemdUserUnitPath(env);
     const envFilePath = path.join(stateDir, "gateway.systemd.env");
+    const nodeEnvFilePath = path.join(stateDir, "node.systemd.env");
 
     try {
       await fs.mkdir(stateDir, { recursive: true });
-      await run({ env, stateDir, unitPath, envFilePath });
+      await run({ env, stateDir, unitPath, envFilePath, nodeEnvFilePath });
     } finally {
       await fs.rm(tempHomeRoot, { recursive: true, force: true });
     }
@@ -823,6 +825,169 @@ describe("stageSystemdService", () => {
       expect(unit).not.toContain("Environment=LLM_API_KEY=dotenv-key");
       expect(envFile).toBe("OPENCLAW_GATEWAY_TOKEN=dotenv-token\nLLM_API_KEY=dotenv-key\n");
       expect(envFileStat.mode & 0o777).toBe(0o600);
+    });
+  });
+
+  it("writes node file-backed managed values to the node env file instead of the unit", async () => {
+    await withStageFixture(async ({ env, stateDir, unitPath, envFilePath, nodeEnvFilePath }) => {
+      await fs.rm(stateDir, { recursive: true, force: true });
+
+      mockSystemctlStatusOk();
+
+      await stageSystemdService({
+        env,
+        stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+        programArguments: ["/usr/bin/openclaw", "node", "run"],
+        workingDirectory: "/tmp",
+        environment: {
+          OPENCLAW_GATEWAY_TOKEN: "file-backed-token",
+          OPENCLAW_GATEWAY_PORT: "18789",
+          OPENCLAW_SERVICE_KIND: "node",
+        },
+        environmentValueSources: {
+          OPENCLAW_GATEWAY_TOKEN: "file",
+        },
+      });
+
+      const [unit, envFile, envFileStat] = await Promise.all([
+        fs.readFile(unitPath, "utf8"),
+        fs.readFile(nodeEnvFilePath, "utf8"),
+        fs.stat(nodeEnvFilePath),
+      ]);
+
+      expect(unit).toContain(`EnvironmentFile=-${nodeEnvFilePath}`);
+      expect(unit).toContain("Environment=OPENCLAW_GATEWAY_PORT=18789");
+      expect(unit).not.toContain("Environment=OPENCLAW_GATEWAY_TOKEN=file-backed-token");
+      expect(envFile).toBe("OPENCLAW_GATEWAY_TOKEN=file-backed-token\n");
+      expect(envFileStat.mode & 0o777).toBe(0o600);
+      await expect(fs.access(envFilePath)).rejects.toThrow();
+    });
+  });
+
+  it("migrates operator entries from the legacy gateway env file when writing node env files", async () => {
+    await withStageFixture(async ({ env, unitPath, envFilePath, nodeEnvFilePath }) => {
+      const legacyGatewayEnvFile =
+        ["OPENCLAW_GATEWAY_TOKEN=legacy-node-token", "OPENROUTER_API_KEY=operator-key"].join("\n") +
+        "\n";
+      await fs.writeFile(envFilePath, legacyGatewayEnvFile, {
+        encoding: "utf8",
+        mode: 0o600,
+      });
+
+      mockSystemctlStatusOk();
+
+      await stageSystemdService({
+        env,
+        stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+        programArguments: ["/usr/bin/openclaw", "node", "run"],
+        workingDirectory: "/tmp",
+        environment: {
+          OPENCLAW_GATEWAY_TOKEN: "fresh-file-token",
+          OPENCLAW_GATEWAY_PORT: "18789",
+          OPENCLAW_SERVICE_KIND: "node",
+        },
+        environmentValueSources: {
+          OPENCLAW_GATEWAY_TOKEN: "file",
+        },
+      });
+
+      const [unit, nodeEnvFile, gatewayEnvFile] = await Promise.all([
+        fs.readFile(unitPath, "utf8"),
+        fs.readFile(nodeEnvFilePath, "utf8"),
+        fs.readFile(envFilePath, "utf8"),
+      ]);
+
+      expect(unit).toContain(`EnvironmentFile=-${nodeEnvFilePath}`);
+      expect(unit).not.toContain("OPENCLAW_GATEWAY_TOKEN=fresh-file-token");
+      expect(nodeEnvFile).toBe(
+        "OPENROUTER_API_KEY=operator-key\nOPENCLAW_GATEWAY_TOKEN=fresh-file-token\n",
+      );
+      expect(gatewayEnvFile).toBe(legacyGatewayEnvFile);
+    });
+  });
+
+  it("clears stale node file-backed managed keys without touching the gateway env file", async () => {
+    await withStageFixture(async ({ env, unitPath, envFilePath, nodeEnvFilePath }) => {
+      await fs.writeFile(envFilePath, "OPENCLAW_GATEWAY_TOKEN=stale-token\n", {
+        encoding: "utf8",
+        mode: 0o600,
+      });
+      await fs.writeFile(nodeEnvFilePath, "OPENCLAW_GATEWAY_TOKEN=stale-node-token\n", {
+        encoding: "utf8",
+        mode: 0o600,
+      });
+
+      mockSystemctlStatusOk();
+
+      await stageSystemdService({
+        env,
+        stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+        programArguments: ["/usr/bin/openclaw", "node", "run"],
+        workingDirectory: "/tmp",
+        environment: {
+          OPENCLAW_GATEWAY_PORT: "18789",
+          OPENCLAW_SERVICE_KIND: "node",
+        },
+        environmentValueSources: {
+          OPENCLAW_GATEWAY_TOKEN: "file",
+        },
+      });
+
+      const unit = await fs.readFile(unitPath, "utf8");
+
+      expect(unit).not.toContain("EnvironmentFile=");
+      await expect(fs.access(nodeEnvFilePath)).rejects.toThrow();
+      await expect(fs.readFile(envFilePath, "utf8")).resolves.toBe(
+        "OPENCLAW_GATEWAY_TOKEN=stale-token\n",
+      );
+    });
+  });
+
+  it("sanitizes file-backed managed values out of the backup unit on re-stage", async () => {
+    await withStageFixture(async ({ env, unitPath }) => {
+      await fs.mkdir(path.dirname(unitPath), { recursive: true });
+      await fs.writeFile(
+        unitPath,
+        [
+          "[Service]",
+          "ExecStart=/usr/bin/openclaw node run",
+          "Environment=FOO=bar OPENCLAW_GATEWAY_TOKEN=inline-token BAZ=qux",
+          "Environment=OPENCLAW_GATEWAY_TOKEN=token-only-line",
+          "Environment=OPENCLAW_GATEWAY_PORT=18789",
+        ].join("\n"),
+        { encoding: "utf8", mode: 0o600 },
+      );
+      await fs.chmod(unitPath, 0o600);
+
+      mockSystemctlStatusOk();
+
+      await stageSystemdService({
+        env,
+        stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+        programArguments: ["/usr/bin/openclaw", "node", "run"],
+        workingDirectory: "/tmp",
+        environment: {
+          OPENCLAW_GATEWAY_TOKEN: "fresh-token",
+          OPENCLAW_GATEWAY_PORT: "18789",
+          OPENCLAW_SERVICE_KIND: "node",
+        },
+        environmentValueSources: {
+          OPENCLAW_GATEWAY_TOKEN: "file",
+        },
+      });
+
+      const [unit, backupUnit, backupStat] = await Promise.all([
+        fs.readFile(unitPath, "utf8"),
+        fs.readFile(`${unitPath}.bak`, "utf8"),
+        fs.stat(`${unitPath}.bak`),
+      ]);
+
+      expect(unit).not.toContain("Environment=OPENCLAW_GATEWAY_TOKEN=fresh-token");
+      expect(backupUnit).not.toContain("Environment=OPENCLAW_GATEWAY_TOKEN=inline-token");
+      expect(backupUnit).not.toContain("Environment=OPENCLAW_GATEWAY_TOKEN=token-only-line");
+      expect(backupUnit).toContain("Environment=FOO=bar BAZ=qux");
+      expect(backupUnit).toContain("Environment=OPENCLAW_GATEWAY_PORT=18789");
+      expect(backupStat.mode & 0o777).toBe(0o600);
     });
   });
 
@@ -972,7 +1137,11 @@ describe("stageSystemdService", () => {
 
 describe("systemd service install and uninstall", () => {
   async function withNodeSystemdFixture(
-    run: (context: { env: Record<string, string>; unitPath: string }) => Promise<void>,
+    run: (context: {
+      env: Record<string, string>;
+      unitPath: string;
+      nodeEnvFilePath: string;
+    }) => Promise<void>,
   ): Promise<void> {
     const tempHomeRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-node-systemd-"));
     const home = path.join(tempHomeRoot, "home");
@@ -981,12 +1150,14 @@ describe("systemd service install and uninstall", () => {
       HOME: home,
       OPENCLAW_STATE_DIR: stateDir,
       OPENCLAW_SYSTEMD_UNIT: "openclaw-node",
+      OPENCLAW_SERVICE_KIND: "node",
     };
     const unitPath = resolveSystemdUserUnitPath(env);
+    const nodeEnvFilePath = path.join(stateDir, "node.systemd.env");
 
     try {
       await fs.mkdir(stateDir, { recursive: true });
-      await run({ env, unitPath });
+      await run({ env, unitPath, nodeEnvFilePath });
     } finally {
       await fs.rm(tempHomeRoot, { recursive: true, force: true });
     }
@@ -1213,9 +1384,14 @@ describe("systemd service install and uninstall", () => {
   });
 
   it("disables the OPENCLAW_SYSTEMD_UNIT override during uninstall", async () => {
-    await withNodeSystemdFixture(async ({ env, unitPath }) => {
+    await withNodeSystemdFixture(async ({ env, unitPath, nodeEnvFilePath }) => {
       await fs.mkdir(path.dirname(unitPath), { recursive: true });
       await fs.writeFile(unitPath, "[Unit]\nDescription=OpenClaw Node\n", "utf8");
+      await fs.writeFile(
+        nodeEnvFilePath,
+        "OPENCLAW_GATEWAY_TOKEN=stale-node-token\nOPENROUTER_API_KEY=operator-key\n",
+        { encoding: "utf8", mode: 0o600 },
+      );
 
       execFileMock
         .mockImplementationOnce((_cmd, args, _opts, cb) => {
@@ -1237,7 +1413,47 @@ describe("systemd service install and uninstall", () => {
         accessError = error as NodeJS.ErrnoException;
       }
       expect(accessError?.code).toBe("ENOENT");
+      await expect(fs.readFile(nodeEnvFilePath, "utf8")).resolves.toBe(
+        "OPENROUTER_API_KEY=operator-key\n",
+      );
       expect(requireFirstWrite(write)).toContain("Removed systemd service");
+      expect(execFileMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("preserves node env file values when unit removal fails during uninstall", async () => {
+    await withNodeSystemdFixture(async ({ env, unitPath, nodeEnvFilePath }) => {
+      await fs.mkdir(path.dirname(unitPath), { recursive: true });
+      await fs.writeFile(unitPath, "[Unit]\nDescription=OpenClaw Node\n", "utf8");
+      await fs.writeFile(
+        nodeEnvFilePath,
+        "OPENCLAW_GATEWAY_TOKEN=stale-node-token\nOPENROUTER_API_KEY=operator-key\n",
+        { encoding: "utf8", mode: 0o600 },
+      );
+
+      execFileMock
+        .mockImplementationOnce((_cmd, args, _opts, cb) => {
+          assertUserSystemctlArgs(args, "status");
+          cb(null, "", "");
+        })
+        .mockImplementationOnce((_cmd, args, _opts, cb) => {
+          assertUserSystemctlArgs(args, "disable", "--now", NODE_SERVICE);
+          cb(null, "", "");
+        });
+
+      const unlinkError = new Error("EACCES: permission denied") as NodeJS.ErrnoException;
+      unlinkError.code = "EACCES";
+      vi.spyOn(fs, "unlink").mockRejectedValueOnce(unlinkError);
+
+      const { stdout } = createWritableStreamMock();
+      await expect(uninstallSystemdService({ env, stdout })).rejects.toThrow(
+        "EACCES: permission denied",
+      );
+
+      await expect(fs.readFile(unitPath, "utf8")).resolves.toContain("OpenClaw Node");
+      await expect(fs.readFile(nodeEnvFilePath, "utf8")).resolves.toBe(
+        "OPENCLAW_GATEWAY_TOKEN=stale-node-token\nOPENROUTER_API_KEY=operator-key\n",
+      );
       expect(execFileMock).toHaveBeenCalledTimes(2);
     });
   });

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -21,6 +21,7 @@ import { parseKeyValueOutput } from "./runtime-parse.js";
 import {
   hasEnvironmentFileSource,
   hasInlineEnvironmentSource,
+  isEnvironmentFileOnlySource,
   readManagedServiceEnvKeysFromEnvironment,
 } from "./service-managed-env.js";
 import type { GatewayServiceRuntime } from "./service-runtime.js";
@@ -43,10 +44,13 @@ import {
 import {
   buildSystemdUnit,
   parseSystemdEnvAssignment,
+  parseSystemdEnvAssignments,
   parseSystemdExecStart,
+  renderSystemdEnvAssignment,
 } from "./systemd-unit.js";
 
 const SYSTEMD_GATEWAY_DOTENV_FILENAME = "gateway.systemd.env";
+const SYSTEMD_NODE_DOTENV_FILENAME = "node.systemd.env";
 
 function resolveSystemdUnitPathForName(env: GatewayServiceEnv, name: string): string {
   const home = toPosixPath(resolveHomeDir(env));
@@ -196,6 +200,105 @@ function collectSystemdInlineManagedKeys(params: {
     }
   }
   return keys;
+}
+
+function collectSystemdFileManagedKeys(params: {
+  environmentValueSources?: Record<string, GatewayServiceEnvironmentValueSource | undefined>;
+}): Set<string> {
+  const keys = new Set<string>();
+  for (const [rawKey, source] of Object.entries(params.environmentValueSources ?? {})) {
+    const key = normalizeSystemdEnvironmentKey(rawKey);
+    if (key && isEnvironmentFileOnlySource(source)) {
+      keys.add(key);
+    }
+  }
+  return keys;
+}
+
+function collectSystemdFileBackedEnvironment(params: {
+  environment?: GatewayServiceEnv;
+  fileManagedKeys: ReadonlySet<string>;
+}): Record<string, string> {
+  if (params.fileManagedKeys.size === 0) {
+    return {};
+  }
+  const environment: Record<string, string> = {};
+  for (const [rawKey, rawValue] of Object.entries(params.environment ?? {})) {
+    if (typeof rawValue !== "string" || !rawValue.trim()) {
+      continue;
+    }
+    const key = normalizeSystemdEnvironmentKey(rawKey);
+    if (key && params.fileManagedKeys.has(key)) {
+      environment[rawKey] = rawValue;
+    }
+  }
+  return environment;
+}
+
+function sanitizeSystemdUnitBackupContent(params: {
+  content: string;
+  fileManagedKeys: ReadonlySet<string>;
+}): string {
+  if (params.fileManagedKeys.size === 0) {
+    return params.content;
+  }
+  const sanitizedLines: string[] = [];
+  for (const rawLine of params.content.split("\n")) {
+    const line = rawLine.trim();
+    if (!line.startsWith("Environment=")) {
+      sanitizedLines.push(rawLine);
+      continue;
+    }
+    const assignments = parseSystemdEnvAssignments(line.slice("Environment=".length).trim());
+    if (assignments.length === 0) {
+      sanitizedLines.push(rawLine);
+      continue;
+    }
+    const keptAssignments = assignments.filter(({ key }) => {
+      const normalizedKey = normalizeSystemdEnvironmentKey(key);
+      return !normalizedKey || !params.fileManagedKeys.has(normalizedKey);
+    });
+    if (keptAssignments.length === assignments.length) {
+      sanitizedLines.push(rawLine);
+      continue;
+    }
+    if (keptAssignments.length === 0) {
+      continue;
+    }
+    const leadingWhitespace = rawLine.match(/^\s*/)?.[0] ?? "";
+    sanitizedLines.push(
+      `${leadingWhitespace}Environment=${keptAssignments
+        .map(({ key, value }) => renderSystemdEnvAssignment(key, value))
+        .join(" ")}`,
+    );
+  }
+  return sanitizedLines.join("\n");
+}
+
+function resolveSystemdEnvironmentFilePath(params: {
+  stateDir: string;
+  environment?: GatewayServiceEnv;
+}): string {
+  const serviceKind = params.environment?.OPENCLAW_SERVICE_KIND?.trim();
+  const filename =
+    serviceKind === "node" ? SYSTEMD_NODE_DOTENV_FILENAME : SYSTEMD_GATEWAY_DOTENV_FILENAME;
+  return path.join(params.stateDir, filename);
+}
+
+function resolveLegacyNodeSystemdEnvironmentFilePath(params: {
+  stateDir: string;
+  environment?: GatewayServiceEnv;
+}): string | null {
+  if (params.environment?.OPENCLAW_SERVICE_KIND?.trim() !== "node") {
+    return null;
+  }
+  const legacyPath = path.join(params.stateDir, SYSTEMD_GATEWAY_DOTENV_FILENAME);
+  const currentPath = resolveSystemdEnvironmentFilePath(params);
+  return legacyPath === currentPath ? null : legacyPath;
+}
+
+function isNodeSystemdEnvironment(env: GatewayServiceEnv): boolean {
+  return env.OPENCLAW_SERVICE_KIND?.trim() === "node";
 }
 
 function expandSystemdSpecifier(input: string, env: GatewayServiceEnv): string {
@@ -590,13 +693,23 @@ async function writeSystemdUnit({
 
   const unitPath = resolveSystemdUnitPath(env);
   await fs.mkdir(path.dirname(unitPath), { recursive: true });
+  const fileManagedKeys = collectSystemdFileManagedKeys({
+    environmentValueSources,
+  });
 
   // Preserve user customizations: back up existing unit file before overwriting.
   let backedUp = false;
   try {
-    await fs.access(unitPath);
     const backupPath = `${unitPath}.bak`;
-    await fs.copyFile(unitPath, backupPath);
+    const existingUnit = await fs.readFile(unitPath, "utf8");
+    const existingStat = await fs.stat(unitPath);
+    const backupMode = existingStat.mode & 0o777 || 0o600;
+    const backupUnit = sanitizeSystemdUnitBackupContent({
+      content: existingUnit,
+      fileManagedKeys,
+    });
+    await fs.writeFile(backupPath, backupUnit, { encoding: "utf8", mode: backupMode });
+    await fs.chmod(backupPath, backupMode);
     backedUp = true;
   } catch {
     // File does not exist yet — nothing to back up.
@@ -621,6 +734,12 @@ async function writeSystemdUnit({
     stateDir,
     dotenvVars: stateDirDotEnvVars,
     inlineManagedKeys,
+    fileManagedKeys,
+    fileBackedEnvironment: collectSystemdFileBackedEnvironment({
+      environment,
+      fileManagedKeys,
+    }),
+    environment,
   });
   const environmentSansDotEnvEntries = Object.fromEntries(
     Object.entries(environment ?? {}).filter(([key, value]) => {
@@ -659,8 +778,12 @@ async function writeSystemdGatewayEnvironmentFile(params: {
   /** OpenClaw-managed keys that must not be preserved from an old env file; stale file values
    *  would override fresh inline Environment= entries because EnvironmentFile takes precedence. */
   inlineManagedKeys?: ReadonlySet<string>;
+  /** File-managed keys that should be written from current environment values or removed when absent. */
+  fileManagedKeys?: ReadonlySet<string>;
+  fileBackedEnvironment?: Record<string, string>;
+  environment?: GatewayServiceEnv;
 }): Promise<{ environmentFiles: string[]; environmentKeys: Set<string> }> {
-  const incoming = params.dotenvVars;
+  const incoming = { ...params.dotenvVars, ...params.fileBackedEnvironment };
   for (const [key, value] of Object.entries(incoming)) {
     if (/[\r\n]/.test(value)) {
       throw new Error(
@@ -668,27 +791,45 @@ async function writeSystemdGatewayEnvironmentFile(params: {
       );
     }
   }
-  const envFilePath = path.join(params.stateDir, SYSTEMD_GATEWAY_DOTENV_FILENAME);
+  const envFilePath = resolveSystemdEnvironmentFilePath({
+    stateDir: params.stateDir,
+    environment: params.environment,
+  });
 
-  // Read the existing env file first so we can preserve operator-added secrets
-  // (e.g. provider API keys) across upgrades and re-stages.
+  // Read existing env files first so we can preserve operator-added secrets
+  // (e.g. provider API keys) across upgrades and re-stages. Node units used
+  // to share gateway.systemd.env, so migrate those entries into node.systemd.env.
   // OpenClaw-managed keys (identified by inlineManagedKeys) are excluded: a stale
   // file copy would override the fresh inline Environment= value because systemd's
   // EnvironmentFile takes precedence over inline Environment= directives.
   let existing: Record<string, string> = {};
-  try {
-    existing = await readSystemdEnvironmentFile(envFilePath);
-  } catch {
-    // File does not exist yet — nothing to preserve.
+  const legacyNodeEnvFilePath = resolveLegacyNodeSystemdEnvironmentFilePath({
+    stateDir: params.stateDir,
+    environment: params.environment,
+  });
+  for (const sourceEnvFilePath of [legacyNodeEnvFilePath, envFilePath]) {
+    if (!sourceEnvFilePath) {
+      continue;
+    }
+    try {
+      existing = { ...existing, ...(await readSystemdEnvironmentFile(sourceEnvFilePath)) };
+    } catch {
+      // File does not exist yet — nothing to preserve.
+    }
   }
-  const operatorOnly = params.inlineManagedKeys
-    ? Object.fromEntries(
-        Object.entries(existing).filter(([key]) => {
-          const normalized = normalizeSystemdEnvironmentKey(key);
-          return !normalized || !params.inlineManagedKeys!.has(normalized);
-        }),
-      )
-    : existing;
+  const managedKeysToDrop = new Set([
+    ...(params.inlineManagedKeys ?? []),
+    ...(params.fileManagedKeys ?? []),
+  ]);
+  const operatorOnly =
+    managedKeysToDrop.size > 0
+      ? Object.fromEntries(
+          Object.entries(existing).filter(([key]) => {
+            const normalized = normalizeSystemdEnvironmentKey(key);
+            return !normalized || !managedKeysToDrop.has(normalized);
+          }),
+        )
+      : existing;
   const merged = { ...operatorOnly, ...incoming };
   const environmentKeys = new Set(
     Object.keys(merged).flatMap((key) => {
@@ -699,15 +840,50 @@ async function writeSystemdGatewayEnvironmentFile(params: {
 
   // If the merged result is empty there is nothing to write and no file needed.
   if (Object.keys(merged).length === 0) {
+    await fs.rm(envFilePath, { force: true }).catch(() => undefined);
     return { environmentFiles: [], environmentKeys };
   }
 
   const content = Object.entries(merged)
     .map(([key, value]) => `${key}=${value}`)
     .join("\n");
+  await fs.mkdir(path.dirname(envFilePath), { recursive: true });
   await fs.writeFile(envFilePath, `${content}\n`, { encoding: "utf8", mode: 0o600 });
   await fs.chmod(envFilePath, 0o600);
   return { environmentFiles: [envFilePath], environmentKeys };
+}
+
+async function removeNodeSystemdManagedEnvironmentKeys(env: GatewayServiceEnv): Promise<void> {
+  if (!isNodeSystemdEnvironment(env)) {
+    return;
+  }
+  const stateDir = resolveStateDir(env as NodeJS.ProcessEnv);
+  const envFilePath = resolveSystemdEnvironmentFilePath({
+    stateDir,
+    environment: env,
+  });
+  let existing: Record<string, string> = {};
+  try {
+    existing = await readSystemdEnvironmentFile(envFilePath);
+  } catch {
+    return;
+  }
+  const managedKeys = new Set([normalizeSystemdEnvironmentKey("OPENCLAW_GATEWAY_TOKEN")]);
+  const remaining = Object.fromEntries(
+    Object.entries(existing).filter(([key]) => {
+      const normalized = normalizeSystemdEnvironmentKey(key);
+      return !normalized || !managedKeys.has(normalized);
+    }),
+  );
+  if (Object.keys(remaining).length === 0) {
+    await fs.rm(envFilePath, { force: true });
+    return;
+  }
+  const content = Object.entries(remaining)
+    .map(([key, value]) => `${key}=${value}`)
+    .join("\n");
+  await fs.writeFile(envFilePath, `${content}\n`, { encoding: "utf8", mode: 0o600 });
+  await fs.chmod(envFilePath, 0o600);
 }
 
 export async function stageSystemdService({
@@ -814,10 +990,20 @@ export async function uninstallSystemdService({
   await execSystemctlUser(env, ["disable", "--now", unitName]);
 
   const unitPath = resolveSystemdUnitPath(env);
+  let removed = false;
   try {
     await fs.unlink(unitPath);
+    removed = true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
+    // Unit file was already absent; still clean generated node env state below.
+  }
+  await removeNodeSystemdManagedEnvironmentKeys(env);
+  if (removed) {
     stdout.write(`${formatLine("Removed systemd service", unitPath)}\n`);
-  } catch {
+  } else {
     stdout.write(`Systemd service not found at ${unitPath}\n`);
   }
 }

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -812,7 +812,7 @@ async function writeSystemdGatewayEnvironmentFile(params: {
       continue;
     }
     try {
-      existing = { ...existing, ...(await readSystemdEnvironmentFile(sourceEnvFilePath)) };
+      Object.assign(existing, await readSystemdEnvironmentFile(sourceEnvFilePath));
     } catch {
       // File does not exist yet — nothing to preserve.
     }


### PR DESCRIPTION
## Summary

- Problem: Linux node host systemd installs could place `OPENCLAW_GATEWAY_TOKEN` inline in the generated unit, exposing the token through unit inspection and backups.
- Solution: Treat the node gateway token as an EnvironmentFile-managed value and write it to the owner-only node systemd env file instead of inline `Environment=` directives.
- What changed: node install planning now carries environment value sources into systemd staging; systemd writes node file-backed managed values to `node.systemd.env`, migrates operator entries from the legacy shared env file, and scrubs only OpenClaw-managed token entries on uninstall.
- What did NOT change (scope boundary): gateway service env-file ownership and non-systemd service managers keep their existing behavior.

## Motivation

- Node service credentials should not be serialized into systemd unit files, and existing operator-added env-file entries must survive re-stage/upgrade paths.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #78043
- Related #78044
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

Behavior addressed: `openclaw node install --force` on Linux user systemd keeps the node gateway token out of the generated unit, writes the current token to an owner-only node env file, migrates operator entries from the old shared systemd env file, and leaves only operator entries after uninstall.

Real environment tested: Docker Desktop Linux container running Debian 12 with systemd PID 1 and a real unprivileged user systemd manager (`systemd 252`, `systemctl --user is-system-running=running`, Linux 6.10.14-linuxkit aarch64).

Exact steps or command run after this patch:

```sh
OPENCLAW_GATEWAY_TOKEN=<redacted proof token> pnpm openclaw node install --force --host 127.0.0.1 --port 18789 --json
systemctl --user is-enabled openclaw-node.service
systemctl --user show openclaw-node.service --property=LoadState,ActiveState,SubState --no-page
pnpm openclaw node uninstall --json
```

Evidence after fix:

```text
linux=Linux 6.10.14-linuxkit aarch64
systemd=systemd 252 (252.39-1~deb12u2)
user_manager=running
unit_path=/home/ocproof/.config/systemd/user/openclaw-node.service
envfile_path=/home/ocproof/.openclaw/node.systemd.env
envfile_mode=600
enabled_before_uninstall=enabled
show_before_uninstall=LoadState=loaded;ActiveState=active;SubState=running;
unit_has_inline_gateway_token=no
unit_has_token_value=no
node_envfile_had_gateway_token=yes
node_envfile_preserved_legacy_operator=yes
node_envfile_has_legacy_token=no
legacy_gateway_envfile_preserved_before_uninstall=yes
uninstall_removed_node_unit=yes
node_envfile_exists_after_uninstall=yes
node_envfile_token_after_uninstall=no
node_envfile_preserved_operator_after_uninstall=yes
uninstall_preserved_legacy_gateway_envfile=yes
```

Observed result after fix: The node service was enabled and running under the real user systemd manager. The generated unit referenced `EnvironmentFile=-/home/ocproof/.openclaw/node.systemd.env`, did not contain inline `OPENCLAW_GATEWAY_TOKEN`, and did not contain the redacted proof token value. The node env file was `0600`, preserved a legacy operator key from `gateway.systemd.env`, replaced the legacy token with the current redacted token, and uninstall removed only the managed token while preserving operator env-file entries.

What was not tested: A live gateway connection was not started in the container; the node host stayed running and retried `127.0.0.1:18789`, which is sufficient for credential placement, migration, and user-systemd install/uninstall proof.

Before evidence (optional but encouraged): Regression tests fail on the old behavior for legacy env-file migration and unlink failure cleanup; the new tests pass after this patch.

## Root Cause (if applicable)

- Root cause: node systemd installs reused generic systemd environment rendering without distinguishing inline-managed values from file-managed token values, so the gateway token could be rendered into the unit file.
- Missing detection / guardrail: no regression covered node-specific systemd token placement, legacy env-file migration, or uninstall behavior when the unit file removal fails.
- Contributing context (if known): prior gateway env-file preservation logic was correct for gateway services but did not model the node service's token ownership separately.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/daemon/systemd.test.ts`, `src/commands/node-daemon-install-helpers.test.ts`
- Scenario the test should lock in: node file-backed gateway tokens are written to `node.systemd.env`, are not rendered inline in unit or backup files, preserve/migrate operator env-file entries, and are scrubbed safely during uninstall.
- Why this is the smallest reliable guardrail: these tests exercise the service install plan and systemd renderer directly without needing a full daemon runtime.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Linux node host systemd units no longer inline `OPENCLAW_GATEWAY_TOKEN`; the token is stored in `~/.openclaw/node.systemd.env` with `0600` permissions.

## Diagram (if applicable)

```text
Before:
openclaw node install -> openclaw-node.service -> Environment=OPENCLAW_GATEWAY_TOKEN=...

After:
openclaw node install -> openclaw-node.service -> EnvironmentFile=~/.openclaw/node.systemd.env -> 0600 token file
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) Yes
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: token placement changes from inline unit text to an owner-only env file. The migration preserves operator entries and the real user-systemd proof verifies the unit does not contain the redacted token value.

## Repro + Verification

### Environment

- OS: macOS local checkout for unit tests; Docker Desktop Linux container for real user-systemd proof
- Runtime/container: Node 24.14.0, pnpm 11.1.0, Debian 12 systemd container
- Model/provider: N/A
- Integration/channel (if any): Linux user systemd node host service
- Relevant config (redacted): `OPENCLAW_GATEWAY_TOKEN=<redacted proof token>`

### Steps

1. Seed a legacy `~/.openclaw/gateway.systemd.env` with a redacted old token and an operator key.
2. Run `OPENCLAW_GATEWAY_TOKEN=<redacted proof token> pnpm openclaw node install --force --host 127.0.0.1 --port 18789 --json` under an unprivileged user systemd manager.
3. Inspect the generated unit, node env file mode/content markers, and service state.
4. Run `pnpm openclaw node uninstall --json` and inspect the unit/env-file cleanup markers.

### Expected

- The generated unit does not contain the gateway token inline or by value.
- `node.systemd.env` is `0600`, contains the current token, and preserves legacy operator entries.
- Uninstall removes the unit and removes only the managed token while preserving operator entries.

### Actual

- Matches expected; see copied live proof output above.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted Vitest coverage, formatting, diff whitespace, autoreview, and real Linux user-systemd install/uninstall proof.
- Edge cases checked: legacy shared env-file migration, stale managed token cleanup, unlink failure preserving token state, backup-unit token scrubbing, and uninstall preserving operator entries.
- What you did **not** verify: live gateway connection from the node host to a running gateway.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) Yes
- Migration needed? (`Yes/No`) No manual migration
- If yes, exact upgrade steps: re-running `openclaw node install --force` migrates operator entries from the legacy shared env file into `node.systemd.env` while replacing the managed token value.

## Risks and Mitigations

- Risk: existing operator entries in the old shared env file could be dropped when switching node services to the new env file.
  - Mitigation: migration reads the old shared file first and regression coverage plus runtime proof verify operator entries are preserved.
