### PR TITLE
[Fix] Avoid registry import in media trust path

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2262,9 +2262,7 @@ export async function runEmbeddedAttempt(
       const trustedLocalMediaToolNames = new Set(coreBuiltinToolNames);
       for (const tool of uncompactedEffectiveTools) {
         const name = (tool.name ?? "").trim();
-        const pluginId = getPluginToolMeta(
-          tool as Parameters<typeof getPluginToolMeta>[0],
-        )?.pluginId;
+        const pluginId = getPluginToolMeta(tool)?.pluginId;
         if (
           name &&
           pluginId &&

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2243,38 +2243,36 @@ export async function runEmbeddedAttempt(
         agentId: sessionAgentId,
       });
       // Exact raw names of every tool registered for this run, including
-      // bundled/plugin tools. Used as the raw-name set for the trusted local
-      // MEDIA: passthrough gate: a normalized alias is not sufficient — the
-      // emitted tool name must match an exact registration of this run.
+      // bundled/plugin tools. Used by diagnostics and TTS suppression paths.
       const builtinToolNames = new Set(
         uncompactedEffectiveTools.flatMap((tool) => {
           const name = (tool.name ?? "").trim();
           return name ? [name] : [];
         }),
       );
-      const trustedBundledPluginToolNames = new Set(
-        uncompactedEffectiveTools.flatMap((tool) => {
-          const name = (tool.name ?? "").trim();
-          const pluginId = getPluginToolMeta(
-            tool as Parameters<typeof getPluginToolMeta>[0],
-          )?.pluginId;
-          if (!name || !pluginId) {
-            return [];
-          }
-          return pluginMetadataSnapshot?.byPluginId.get(pluginId)?.origin === "bundled"
-            ? [name]
-            : [];
-        }),
-      );
       // Admission-time conflict check only against non-plugin core tools, to
       // preserve prior behavior where client tools may coexist with unrelated
       // plugin tool names. MEDIA passthrough is still gated by the raw-name
-      // set above, so a client tool that normalize-collides with a plugin
-      // tool cannot inherit the plugin's local-media trust.
+      // trust set below, so a client tool that normalize-collides with a plugin
+      // tool cannot inherit local-media trust.
       const coreBuiltinToolNames = collectCoreBuiltinToolNames(uncompactedEffectiveTools, {
         isPluginTool: (tool) =>
           Boolean(getPluginToolMeta(tool as Parameters<typeof getPluginToolMeta>[0])),
       });
+      const trustedLocalMediaToolNames = new Set(coreBuiltinToolNames);
+      for (const tool of uncompactedEffectiveTools) {
+        const name = (tool.name ?? "").trim();
+        const pluginId = getPluginToolMeta(
+          tool as Parameters<typeof getPluginToolMeta>[0],
+        )?.pluginId;
+        if (
+          name &&
+          pluginId &&
+          pluginMetadataSnapshot?.byPluginId.get(pluginId)?.origin === "bundled"
+        ) {
+          trustedLocalMediaToolNames.add(name);
+        }
+      }
       const clientToolNameConflicts = findClientToolNameConflicts({
         tools: clientTools ?? [],
         existingToolNames: [...coreBuiltinToolNames, ...PI_RESERVED_TOOL_NAMES],
@@ -3215,8 +3213,7 @@ export async function runEmbeddedAttempt(
           sessionId: params.sessionId,
           agentId: sessionAgentId,
           builtinToolNames,
-          trustedCoreToolNames: coreBuiltinToolNames,
-          trustedBundledPluginToolNames,
+          trustedLocalMediaToolNames,
           internalEvents: params.internalEvents,
         }),
       );

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2155,15 +2155,16 @@ export async function runEmbeddedAttempt(
         cwd: effectiveWorkspace,
       });
 
+      const pluginMetadataSnapshot = getCurrentPluginMetadataSnapshot({
+        config: params.config,
+        env: process.env,
+        workspaceDir: effectiveWorkspace,
+      });
       const settingsManager = createPreparedEmbeddedPiSettingsManager({
         cwd: effectiveWorkspace,
         agentDir,
         cfg: params.config,
-        pluginMetadataSnapshot: getCurrentPluginMetadataSnapshot({
-          config: params.config,
-          env: process.env,
-          workspaceDir: effectiveWorkspace,
-        }),
+        pluginMetadataSnapshot,
         contextTokenBudget: params.contextTokenBudget,
       });
       const piAutoCompactionGuardArgs = {
@@ -2249,6 +2250,20 @@ export async function runEmbeddedAttempt(
         uncompactedEffectiveTools.flatMap((tool) => {
           const name = (tool.name ?? "").trim();
           return name ? [name] : [];
+        }),
+      );
+      const trustedBundledPluginToolNames = new Set(
+        uncompactedEffectiveTools.flatMap((tool) => {
+          const name = (tool.name ?? "").trim();
+          const pluginId = getPluginToolMeta(
+            tool as Parameters<typeof getPluginToolMeta>[0],
+          )?.pluginId;
+          if (!name || !pluginId) {
+            return [];
+          }
+          return pluginMetadataSnapshot?.byPluginId.get(pluginId)?.origin === "bundled"
+            ? [name]
+            : [];
         }),
       );
       // Admission-time conflict check only against non-plugin core tools, to
@@ -3200,6 +3215,8 @@ export async function runEmbeddedAttempt(
           sessionId: params.sessionId,
           agentId: sessionAgentId,
           builtinToolNames,
+          trustedCoreToolNames: coreBuiltinToolNames,
+          trustedBundledPluginToolNames,
           internalEvents: params.internalEvents,
         }),
       );

--- a/src/agents/pi-embedded-subscribe.handlers.tools.media.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.media.test.ts
@@ -11,8 +11,7 @@ function createMockContext(overrides?: {
   onToolResult?: ReturnType<typeof vi.fn>;
   toolResultFormat?: "markdown" | "plain";
   builtinToolNames?: ReadonlySet<string>;
-  trustedCoreToolNames?: ReadonlySet<string>;
-  trustedBundledPluginToolNames?: ReadonlySet<string>;
+  trustedLocalMediaToolNames?: ReadonlySet<string>;
 }): EmbeddedPiSubscribeContext {
   const onToolResult = overrides?.onToolResult ?? vi.fn();
   return {
@@ -44,8 +43,7 @@ function createMockContext(overrides?: {
     },
     log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn() },
     builtinToolNames: overrides?.builtinToolNames,
-    trustedCoreToolNames: overrides?.trustedCoreToolNames,
-    trustedBundledPluginToolNames: overrides?.trustedBundledPluginToolNames,
+    trustedLocalMediaToolNames: overrides?.trustedLocalMediaToolNames,
     shouldEmitToolResult: vi.fn(() => false),
     shouldEmitToolOutput: vi.fn(() => overrides?.shouldEmitToolOutput ?? false),
     emitToolSummary: vi.fn(),
@@ -140,6 +138,7 @@ async function handleCaseVariantBuiltinMedia(mediaPathOrUrl: string) {
     shouldEmitToolOutput: false,
     onToolResult: vi.fn(),
     builtinToolNames: new Set(["web_search"]),
+    trustedLocalMediaToolNames: new Set(["web_search"]),
   });
 
   await handleToolExecutionEnd(ctx, {
@@ -223,6 +222,7 @@ describe("handleToolExecutionEnd media emission", () => {
       shouldEmitToolOutput: false,
       onToolResult,
       builtinToolNames: new Set(["tts"]),
+      trustedLocalMediaToolNames: new Set(["tts"]),
     });
 
     await handleToolExecutionEnd(ctx, {
@@ -271,6 +271,7 @@ describe("handleToolExecutionEnd media emission", () => {
       shouldEmitToolOutput: false,
       onToolResult,
       builtinToolNames: new Set(["browser"]),
+      trustedLocalMediaToolNames: new Set(["browser"]),
     });
 
     await emitMcpMediaToolResult(ctx, "/tmp/secret.png");
@@ -320,6 +321,7 @@ describe("handleToolExecutionEnd media emission", () => {
       onToolResult: vi.fn(),
       toolResultFormat: "plain",
       builtinToolNames: new Set(["tts"]),
+      trustedLocalMediaToolNames: new Set(["tts"]),
     });
 
     await handleToolExecutionEnd(ctx, {
@@ -349,6 +351,7 @@ describe("handleToolExecutionEnd media emission", () => {
       onToolResult: vi.fn(),
       toolResultFormat: "plain",
       builtinToolNames: new Set(["tts"]),
+      trustedLocalMediaToolNames: new Set(["tts"]),
     });
 
     await handleToolExecutionEnd(ctx, {
@@ -378,6 +381,7 @@ describe("handleToolExecutionEnd media emission", () => {
       onToolResult: vi.fn(),
       toolResultFormat: "plain",
       builtinToolNames: new Set(["tts"]),
+      trustedLocalMediaToolNames: new Set(["tts"]),
     });
 
     await handleToolExecutionEnd(ctx, {
@@ -407,6 +411,7 @@ describe("handleToolExecutionEnd media emission", () => {
       onToolResult: vi.fn(),
       toolResultFormat: "plain",
       builtinToolNames: new Set(["web_search"]),
+      trustedLocalMediaToolNames: new Set(["web_search"]),
     });
 
     await handleToolExecutionEnd(ctx, {
@@ -628,11 +633,12 @@ describe("handleToolExecutionEnd media emission", () => {
     expect(ctx.state.pendingToolTrustedLocalMedia).toBe(true);
   });
 
-  it("queues trusted TTS local media when the exact built-in name is absent", async () => {
+  it("queues trusted TTS local media through the local-media trust set", async () => {
     const ctx = createMockContext({
       shouldEmitToolOutput: false,
       onToolResult: vi.fn(),
       builtinToolNames: new Set(["web_search"]),
+      trustedLocalMediaToolNames: new Set(["tts"]),
     });
 
     await handleToolExecutionEnd(ctx, {

--- a/src/agents/pi-embedded-subscribe.handlers.tools.media.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.media.test.ts
@@ -11,6 +11,8 @@ function createMockContext(overrides?: {
   onToolResult?: ReturnType<typeof vi.fn>;
   toolResultFormat?: "markdown" | "plain";
   builtinToolNames?: ReadonlySet<string>;
+  trustedCoreToolNames?: ReadonlySet<string>;
+  trustedBundledPluginToolNames?: ReadonlySet<string>;
 }): EmbeddedPiSubscribeContext {
   const onToolResult = overrides?.onToolResult ?? vi.fn();
   return {
@@ -42,6 +44,8 @@ function createMockContext(overrides?: {
     },
     log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn() },
     builtinToolNames: overrides?.builtinToolNames,
+    trustedCoreToolNames: overrides?.trustedCoreToolNames,
+    trustedBundledPluginToolNames: overrides?.trustedBundledPluginToolNames,
     shouldEmitToolResult: vi.fn(() => false),
     shouldEmitToolOutput: vi.fn(() => overrides?.shouldEmitToolOutput ?? false),
     emitToolSummary: vi.fn(),
@@ -263,7 +267,11 @@ describe("handleToolExecutionEnd media emission", () => {
 
   it("does NOT emit local media for MCP-provenance results", async () => {
     const onToolResult = vi.fn();
-    const ctx = createMockContext({ shouldEmitToolOutput: false, onToolResult });
+    const ctx = createMockContext({
+      shouldEmitToolOutput: false,
+      onToolResult,
+      builtinToolNames: new Set(["browser"]),
+    });
 
     await emitMcpMediaToolResult(ctx, "/tmp/secret.png");
 

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -434,23 +434,14 @@ async function collectEmittedToolOutputMediaUrls(
   toolName: string,
   outputText: string,
   result: unknown,
-  builtinToolNames?: ReadonlySet<string>,
-  trustedBundledPluginToolNames?: ReadonlySet<string>,
-  trustedCoreToolNames?: ReadonlySet<string>,
+  trustedLocalMediaToolNames?: ReadonlySet<string>,
 ): Promise<string[]> {
   const { splitMediaFromOutput } = await loadMediaParse();
   const mediaUrls = splitMediaFromOutput(outputText).mediaUrls ?? [];
   if (mediaUrls.length === 0) {
     return [];
   }
-  return filterToolResultMediaUrls(
-    toolName,
-    mediaUrls,
-    result,
-    builtinToolNames,
-    trustedBundledPluginToolNames,
-    trustedCoreToolNames,
-  );
+  return filterToolResultMediaUrls(toolName, mediaUrls, result, trustedLocalMediaToolNames);
 }
 
 function readExecApprovalPendingDetails(result: unknown): {
@@ -623,9 +614,7 @@ async function emitToolResultOutput(params: {
         rawToolName,
         mediaReply.mediaUrls,
         result,
-        ctx.builtinToolNames,
-        ctx.trustedBundledPluginToolNames,
-        ctx.trustedCoreToolNames,
+        ctx.trustedLocalMediaToolNames,
       )
     : [];
   const shouldEmitOutput =
@@ -644,9 +633,7 @@ async function emitToolResultOutput(params: {
           rawToolName,
           outputText,
           result,
-          ctx.builtinToolNames,
-          ctx.trustedBundledPluginToolNames,
-          ctx.trustedCoreToolNames,
+          ctx.trustedLocalMediaToolNames,
         );
       }
     }

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -434,13 +434,23 @@ async function collectEmittedToolOutputMediaUrls(
   toolName: string,
   outputText: string,
   result: unknown,
+  builtinToolNames?: ReadonlySet<string>,
+  trustedBundledPluginToolNames?: ReadonlySet<string>,
+  trustedCoreToolNames?: ReadonlySet<string>,
 ): Promise<string[]> {
   const { splitMediaFromOutput } = await loadMediaParse();
   const mediaUrls = splitMediaFromOutput(outputText).mediaUrls ?? [];
   if (mediaUrls.length === 0) {
     return [];
   }
-  return filterToolResultMediaUrls(toolName, mediaUrls, result);
+  return filterToolResultMediaUrls(
+    toolName,
+    mediaUrls,
+    result,
+    builtinToolNames,
+    trustedBundledPluginToolNames,
+    trustedCoreToolNames,
+  );
 }
 
 function readExecApprovalPendingDetails(result: unknown): {
@@ -609,7 +619,14 @@ async function emitToolResultOutput(params: {
   const outputText = extractToolResultText(sanitizedResult);
   const mediaReply = isToolError ? undefined : extractToolResultMediaArtifact(result);
   const mediaUrls = mediaReply
-    ? filterToolResultMediaUrls(rawToolName, mediaReply.mediaUrls, result, ctx.builtinToolNames)
+    ? filterToolResultMediaUrls(
+        rawToolName,
+        mediaReply.mediaUrls,
+        result,
+        ctx.builtinToolNames,
+        ctx.trustedBundledPluginToolNames,
+        ctx.trustedCoreToolNames,
+      )
     : [];
   const shouldEmitOutput =
     !shouldSuppressStructuredMediaToolOutput({
@@ -627,6 +644,9 @@ async function emitToolResultOutput(params: {
           rawToolName,
           outputText,
           result,
+          ctx.builtinToolNames,
+          ctx.trustedBundledPluginToolNames,
+          ctx.trustedCoreToolNames,
         );
       }
     }

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -123,6 +123,8 @@ export type EmbeddedPiSubscribeContext = {
   blockChunker: EmbeddedBlockChunker | null;
   hookRunner?: HookRunner;
   builtinToolNames?: ReadonlySet<string>;
+  trustedCoreToolNames?: ReadonlySet<string>;
+  trustedBundledPluginToolNames?: ReadonlySet<string>;
   noteLastAssistant: (msg: AgentMessage) => void;
 
   shouldEmitToolResult: () => boolean;
@@ -231,6 +233,8 @@ export type ToolHandlerContext = {
   log: EmbeddedSubscribeLogger;
   hookRunner?: HookRunner;
   builtinToolNames?: ReadonlySet<string>;
+  trustedCoreToolNames?: ReadonlySet<string>;
+  trustedBundledPluginToolNames?: ReadonlySet<string>;
   flushBlockReplyBuffer: () => void | Promise<void>;
   shouldEmitToolResult: () => boolean;
   shouldEmitToolOutput: () => boolean;

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -123,8 +123,7 @@ export type EmbeddedPiSubscribeContext = {
   blockChunker: EmbeddedBlockChunker | null;
   hookRunner?: HookRunner;
   builtinToolNames?: ReadonlySet<string>;
-  trustedCoreToolNames?: ReadonlySet<string>;
-  trustedBundledPluginToolNames?: ReadonlySet<string>;
+  trustedLocalMediaToolNames?: ReadonlySet<string>;
   noteLastAssistant: (msg: AgentMessage) => void;
 
   shouldEmitToolResult: () => boolean;
@@ -233,8 +232,7 @@ export type ToolHandlerContext = {
   log: EmbeddedSubscribeLogger;
   hookRunner?: HookRunner;
   builtinToolNames?: ReadonlySet<string>;
-  trustedCoreToolNames?: ReadonlySet<string>;
-  trustedBundledPluginToolNames?: ReadonlySet<string>;
+  trustedLocalMediaToolNames?: ReadonlySet<string>;
   flushBlockReplyBuffer: () => void | Promise<void>;
   shouldEmitToolResult: () => boolean;
   shouldEmitToolOutput: () => boolean;

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
@@ -357,6 +357,34 @@ describe("subscribeEmbeddedPiSession", () => {
     expect(payload.mediaUrls).toBeUndefined();
   });
 
+  it("uses builtin tool names as the direct-subscribe local media gate fallback", async () => {
+    const onToolResult = vi.fn();
+    const { emit } = createSubscribedHarness({
+      runId: "run",
+      onToolResult,
+      verboseLevel: "full",
+      toolResultFormat: "plain",
+      builtinToolNames: new Set(["web_search"]),
+    });
+
+    emitToolRun({
+      emit,
+      toolName: "Web_Search",
+      toolCallId: "tool-1",
+      isError: false,
+      result: {
+        content: [{ type: "text", text: "Fetched page\nMEDIA:/tmp/secret.png" }],
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(onToolResult).toHaveBeenCalledTimes(2);
+    });
+    const payload = latestMockCallArg(onToolResult) as { text?: string; mediaUrls?: string[] };
+    expect(payload.text ?? "").toContain("Fetched page");
+    expect(payload.mediaUrls).toBeUndefined();
+  });
+
   it("delivers generated image media once in markdown verbose output", async () => {
     const onToolResult = vi.fn();
     const onBlockReply = vi.fn();

--- a/src/agents/pi-embedded-subscribe.tools.media.test.ts
+++ b/src/agents/pi-embedded-subscribe.tools.media.test.ts
@@ -391,20 +391,18 @@ describe("extractToolResultMediaPaths", () => {
     ).toStrictEqual([]);
   });
 
-  it("keeps local media for exact registered built-in tool names", () => {
+  it("keeps local media for exact trusted built-in tool names", () => {
     expect(
       filterToolResultMediaUrls(
         "web_search",
         ["/tmp/screenshot.png"],
         undefined,
         new Set(["web_search"]),
-        undefined,
-        new Set(["web_search"]),
       ),
     ).toEqual(["/tmp/screenshot.png"]);
   });
 
-  it("keeps trusted TTS local media when the raw built-in name is absent", () => {
+  it("keeps trusted TTS local media through the local-media trust set", () => {
     expect(
       filterToolResultMediaUrls(
         "tts",
@@ -417,18 +415,17 @@ describe("extractToolResultMediaPaths", () => {
             },
           },
         },
-        new Set(["web_search"]),
+        new Set(["tts"]),
       ),
     ).toEqual(["/tmp/reply.opus"]);
   });
 
-  it("keeps local media for plugin tool names registered in this run", () => {
+  it("keeps local media for plugin tool names in the local-media trust set", () => {
     expect(
       filterToolResultMediaUrls(
         "firecrawl_search",
         ["/tmp/search.json"],
         undefined,
-        new Set(["firecrawl_search"]),
         new Set(["firecrawl_search"]),
       ),
     ).toEqual(["/tmp/search.json"]);
@@ -436,26 +433,13 @@ describe("extractToolResultMediaPaths", () => {
 
   it("strips local media for active non-bundled plugin overrides of bundled tool names", () => {
     expect(
-      filterToolResultMediaUrls(
-        "firecrawl_search",
-        ["/etc/passwd"],
-        undefined,
-        new Set(["firecrawl_search"]),
-        new Set(),
-      ),
+      filterToolResultMediaUrls("firecrawl_search", ["/etc/passwd"], undefined, new Set()),
     ).toStrictEqual([]);
   });
 
   it("strips local media for plugin overrides of overlapping core and bundled names", () => {
     expect(
-      filterToolResultMediaUrls(
-        "browser",
-        ["/etc/passwd"],
-        undefined,
-        new Set(["browser"]),
-        new Set(),
-        new Set(),
-      ),
+      filterToolResultMediaUrls("browser", ["/etc/passwd"], undefined, new Set()),
     ).toStrictEqual([]);
   });
 
@@ -466,8 +450,6 @@ describe("extractToolResultMediaPaths", () => {
         ["/tmp/screenshot.png"],
         undefined,
         new Set(["browser"]),
-        new Set(["browser"]),
-        new Set(),
       ),
     ).toEqual(["/tmp/screenshot.png"]);
   });
@@ -483,7 +465,7 @@ describe("extractToolResultMediaPaths", () => {
     ).toStrictEqual([]);
   });
 
-  it("does not trust unvetted plugin tool local MEDIA paths just because they are registered", () => {
+  it("does not trust unvetted plugin tool local MEDIA paths even inside the trust set", () => {
     expect(
       filterToolResultMediaUrls(
         "path_plugin_tool",
@@ -541,27 +523,37 @@ describe("extractToolResultMediaPaths", () => {
 
   it("does not trust external TTS results with trustedLocalMedia", () => {
     expect(
-      filterToolResultMediaUrls("tts", ["/tmp/reply.opus"], {
-        details: {
-          mcpServer: "probe",
-          mcpTool: "tts",
-          media: {
-            mediaUrl: "/tmp/reply.opus",
-            trustedLocalMedia: true,
+      filterToolResultMediaUrls(
+        "tts",
+        ["/tmp/reply.opus"],
+        {
+          details: {
+            mcpServer: "probe",
+            mcpTool: "tts",
+            media: {
+              mediaUrl: "/tmp/reply.opus",
+              trustedLocalMedia: true,
+            },
           },
         },
-      }),
+        new Set(["tts"]),
+      ),
     ).toStrictEqual([]);
   });
 
   it("still allows remote MEDIA urls for MCP-provenance results", () => {
     expect(
-      filterToolResultMediaUrls("browser", ["https://example.com/screenshot.png"], {
-        details: {
-          mcpServer: "probe",
-          mcpTool: "browser",
+      filterToolResultMediaUrls(
+        "browser",
+        ["https://example.com/screenshot.png"],
+        {
+          details: {
+            mcpServer: "probe",
+            mcpTool: "browser",
+          },
         },
-      }),
+        new Set(["browser"]),
+      ),
     ).toEqual(["https://example.com/screenshot.png"]);
   });
 });

--- a/src/agents/pi-embedded-subscribe.tools.media.test.ts
+++ b/src/agents/pi-embedded-subscribe.tools.media.test.ts
@@ -1,3 +1,4 @@
+import { readdirSync, readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import {
   extractToolResultMediaArtifact,
@@ -6,7 +7,43 @@ import {
   isToolResultMediaTrusted,
 } from "./pi-embedded-subscribe.tools.js";
 
+function readBundledManifestToolNames(): string[] {
+  const extensionsDir = new URL("../../extensions/", import.meta.url);
+  return readdirSync(extensionsDir, { withFileTypes: true }).flatMap((entry) => {
+    if (!entry.isDirectory()) {
+      return [];
+    }
+    const manifestUrl = new URL(`${entry.name}/openclaw.plugin.json`, extensionsDir);
+    try {
+      const manifest = JSON.parse(readFileSync(manifestUrl, "utf8")) as {
+        contracts?: { tools?: unknown };
+      };
+      return Array.isArray(manifest.contracts?.tools)
+        ? manifest.contracts.tools.filter((tool): tool is string => typeof tool === "string")
+        : [];
+    } catch {
+      return [];
+    }
+  });
+}
+
 describe("extractToolResultMediaPaths", () => {
+  it("keeps plugin contract registry out of the media trust hot path", () => {
+    const source = readFileSync(
+      new URL("./pi-embedded-subscribe.tools.ts", import.meta.url),
+      "utf8",
+    );
+    expect(source).not.toContain("../plugins/contracts/registry");
+  });
+
+  it("keeps the static bundled plugin media allowlist aligned with manifests", () => {
+    const toolNames = readBundledManifestToolNames();
+    expect(toolNames).toContain("firecrawl_search");
+    for (const toolName of toolNames) {
+      expect(isToolResultMediaTrusted(toolName)).toBe(true);
+    }
+  });
+
   it("returns empty array for null/undefined", () => {
     expect(extractToolResultMediaPaths(null)).toStrictEqual([]);
     expect(extractToolResultMediaPaths(undefined)).toStrictEqual([]);
@@ -340,8 +377,9 @@ describe("extractToolResultMediaPaths", () => {
     expect(isToolResultMediaTrusted("video_generate")).toBe(true);
   });
 
-  it("trusts bundled plugin tool local MEDIA paths", () => {
-    expect(isToolResultMediaTrusted("music_generate")).toBe(true);
+  it("trusts bundled plugin tool names from the static media allowlist", () => {
+    expect(isToolResultMediaTrusted("firecrawl_search")).toBe(true);
+    expect(isToolResultMediaTrusted("firecrawl_search", undefined, new Set())).toBe(false);
   });
 
   it("blocks trusted-media aliases that are not exact registered built-ins", () => {
@@ -358,6 +396,8 @@ describe("extractToolResultMediaPaths", () => {
       filterToolResultMediaUrls(
         "web_search",
         ["/tmp/screenshot.png"],
+        undefined,
+        new Set(["web_search"]),
         undefined,
         new Set(["web_search"]),
       ),
@@ -382,27 +422,74 @@ describe("extractToolResultMediaPaths", () => {
     ).toEqual(["/tmp/reply.opus"]);
   });
 
-  it("keeps local media for bundled plugin tool names registered in this run", () => {
-    // music_generate is a bundled-plugin trusted tool; when the runner
-    // registers it for this run, its raw name must be allowed through the
-    // exact-name gate just like a core built-in.
+  it("keeps local media for plugin tool names registered in this run", () => {
     expect(
       filterToolResultMediaUrls(
-        "music_generate",
-        ["/tmp/song.mp3"],
+        "firecrawl_search",
+        ["/tmp/search.json"],
         undefined,
-        new Set(["music_generate"]),
+        new Set(["firecrawl_search"]),
+        new Set(["firecrawl_search"]),
       ),
-    ).toEqual(["/tmp/song.mp3"]);
+    ).toEqual(["/tmp/search.json"]);
+  });
+
+  it("strips local media for active non-bundled plugin overrides of bundled tool names", () => {
+    expect(
+      filterToolResultMediaUrls(
+        "firecrawl_search",
+        ["/etc/passwd"],
+        undefined,
+        new Set(["firecrawl_search"]),
+        new Set(),
+      ),
+    ).toStrictEqual([]);
+  });
+
+  it("strips local media for plugin overrides of overlapping core and bundled names", () => {
+    expect(
+      filterToolResultMediaUrls(
+        "browser",
+        ["/etc/passwd"],
+        undefined,
+        new Set(["browser"]),
+        new Set(),
+        new Set(),
+      ),
+    ).toStrictEqual([]);
+  });
+
+  it("keeps local media for active bundled plugin tools with overlapping core names", () => {
+    expect(
+      filterToolResultMediaUrls(
+        "browser",
+        ["/tmp/screenshot.png"],
+        undefined,
+        new Set(["browser"]),
+        new Set(["browser"]),
+        new Set(),
+      ),
+    ).toEqual(["/tmp/screenshot.png"]);
   });
 
   it("strips local media for plugin-name collisions when the plugin is not registered", () => {
     expect(
       filterToolResultMediaUrls(
-        "Music_Generate",
+        "Firecrawl_Search",
         ["/etc/passwd"],
         undefined,
-        new Set(["music_generate"]),
+        new Set(["firecrawl_search"]),
+      ),
+    ).toStrictEqual([]);
+  });
+
+  it("does not trust unvetted plugin tool local MEDIA paths just because they are registered", () => {
+    expect(
+      filterToolResultMediaUrls(
+        "path_plugin_tool",
+        ["/etc/passwd"],
+        undefined,
+        new Set(["path_plugin_tool"]),
       ),
     ).toStrictEqual([]);
   });
@@ -438,12 +525,17 @@ describe("extractToolResultMediaPaths", () => {
 
   it("does not trust local MEDIA paths for MCP-provenance results", () => {
     expect(
-      filterToolResultMediaUrls("browser", ["/tmp/screenshot.png"], {
-        details: {
-          mcpServer: "probe",
-          mcpTool: "browser",
+      filterToolResultMediaUrls(
+        "browser",
+        ["/tmp/screenshot.png"],
+        {
+          details: {
+            mcpServer: "probe",
+            mcpTool: "browser",
+          },
         },
-      }),
+        new Set(["browser"]),
+      ),
     ).toStrictEqual([]);
   });
 

--- a/src/agents/pi-embedded-subscribe.tools.ts
+++ b/src/agents/pi-embedded-subscribe.tools.ts
@@ -2,7 +2,6 @@ import { getChannelPlugin, normalizeChannelId } from "../channels/plugins/index.
 import { normalizeTargetForProvider } from "../infra/outbound/target-normalization.js";
 import { redactSensitiveFieldValue, redactToolPayloadText } from "../logging/redact.js";
 import { splitMediaFromOutput } from "../media/parse.js";
-import { pluginRegistrationContractRegistry } from "../plugins/contracts/registry.js";
 import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
@@ -217,7 +216,6 @@ export function extractToolResultText(result: unknown): string | undefined {
 }
 
 // Core tool names that are allowed to emit local MEDIA: paths.
-// Plugin/MCP tools are intentionally excluded to prevent untrusted file reads.
 const TRUSTED_TOOL_RESULT_MEDIA = new Set([
   "agents_list",
   "apply_patch",
@@ -249,9 +247,56 @@ const TRUSTED_TOOL_RESULT_MEDIA = new Set([
   "x_search",
   "write",
 ]);
-const TRUSTED_BUNDLED_PLUGIN_MEDIA_TOOLS = new Set(
-  pluginRegistrationContractRegistry.flatMap((entry) => entry.toolNames),
-);
+// Static bundled-plugin contract tool names. Keep this out of the plugin
+// contract registry hot path.
+const TRUSTED_BUNDLED_PLUGIN_MEDIA_TOOLS = new Set([
+  "browser",
+  "canvas",
+  "code_execution",
+  "diffs",
+  "dir_fetch",
+  "dir_list",
+  "feishu_app_scopes",
+  "feishu_bitable_create_app",
+  "feishu_bitable_create_field",
+  "feishu_bitable_create_record",
+  "feishu_bitable_get_meta",
+  "feishu_bitable_get_record",
+  "feishu_bitable_list_fields",
+  "feishu_bitable_list_records",
+  "feishu_bitable_update_record",
+  "feishu_chat",
+  "feishu_doc",
+  "feishu_drive",
+  "feishu_perm",
+  "feishu_wiki",
+  "file_fetch",
+  "file_write",
+  "firecrawl_scrape",
+  "firecrawl_search",
+  "google_meet",
+  "llm-task",
+  "lobster",
+  "memory_forget",
+  "memory_get",
+  "memory_recall",
+  "memory_search",
+  "memory_store",
+  "qqbot_channel_api",
+  "qqbot_remind",
+  "skill_workshop",
+  "tavily_extract",
+  "tavily_search",
+  "tlon",
+  "voice_call",
+  "wiki_apply",
+  "wiki_get",
+  "wiki_lint",
+  "wiki_search",
+  "wiki_status",
+  "x_search",
+  "zalouser",
+]);
 const HTTP_URL_RE = /^https?:\/\//i;
 
 function readToolResultDetails(result: unknown): Record<string, unknown> | undefined {
@@ -277,20 +322,43 @@ function isExternalToolResult(result: unknown): boolean {
   return typeof details.mcpServer === "string" || typeof details.mcpTool === "string";
 }
 
-export function isToolResultMediaTrusted(toolName?: string, result?: unknown): boolean {
+export function isToolResultMediaTrusted(
+  toolName?: string,
+  result?: unknown,
+  trustedBundledPluginToolNames?: ReadonlySet<string>,
+  trustedCoreToolNames?: ReadonlySet<string>,
+): boolean {
   if (!toolName || isExternalToolResult(result)) {
     return false;
   }
   const normalized = normalizeToolName(toolName);
-  return (
-    TRUSTED_TOOL_RESULT_MEDIA.has(normalized) || TRUSTED_BUNDLED_PLUGIN_MEDIA_TOOLS.has(normalized)
-  );
+  const coreTrusted =
+    TRUSTED_TOOL_RESULT_MEDIA.has(normalized) &&
+    (trustedCoreToolNames === undefined ||
+      isExactRegisteredToolName(toolName, trustedCoreToolNames));
+  const bundledPluginTrusted =
+    TRUSTED_BUNDLED_PLUGIN_MEDIA_TOOLS.has(normalized) &&
+    (trustedBundledPluginToolNames === undefined ||
+      isExactRegisteredToolName(toolName, trustedBundledPluginToolNames));
+  return coreTrusted || bundledPluginTrusted;
 }
 
-function isTrustedOwnedTtsLocalMedia(toolName: string | undefined, result: unknown): boolean {
+function isExactRegisteredToolName(
+  toolName: string | undefined,
+  builtinToolNames?: ReadonlySet<string>,
+): boolean {
+  const registeredName = toolName?.trim();
+  return Boolean(registeredName && builtinToolNames?.has(registeredName));
+}
+
+function isTrustedOwnedTtsLocalMedia(
+  toolName: string | undefined,
+  result: unknown,
+  trustedCoreToolNames?: ReadonlySet<string>,
+): boolean {
   if (
     !toolName ||
-    !isToolResultMediaTrusted(toolName, result) ||
+    !isToolResultMediaTrusted(toolName, result, undefined, trustedCoreToolNames) ||
     normalizeToolName(toolName) !== "tts"
   ) {
     return false;
@@ -307,12 +375,21 @@ export function filterToolResultMediaUrls(
   mediaUrls: string[],
   result?: unknown,
   builtinToolNames?: ReadonlySet<string>,
+  trustedBundledPluginToolNames?: ReadonlySet<string>,
+  trustedCoreToolNames?: ReadonlySet<string>,
 ): string[] {
   if (mediaUrls.length === 0) {
     return mediaUrls;
   }
-  const trustedOwnedTtsLocalMedia = isTrustedOwnedTtsLocalMedia(toolName, result);
-  if (isToolResultMediaTrusted(toolName, result)) {
+  const trustedOwnedTtsLocalMedia = isTrustedOwnedTtsLocalMedia(
+    toolName,
+    result,
+    trustedCoreToolNames,
+  );
+  if (
+    trustedOwnedTtsLocalMedia ||
+    isToolResultMediaTrusted(toolName, result, trustedBundledPluginToolNames, trustedCoreToolNames)
+  ) {
     // When the current run provides its exact registered tool names (core
     // built-ins plus bundled/trusted plugin tools), require the raw emitted
     // tool name to match one of them before allowing local MEDIA: paths.
@@ -323,8 +400,7 @@ export function filterToolResultMediaUrls(
     // survive runs whose exact built-in set omitted the raw tts name.
     if (builtinToolNames !== undefined) {
       if (!trustedOwnedTtsLocalMedia) {
-        const registeredName = toolName?.trim();
-        if (!registeredName || !builtinToolNames.has(registeredName)) {
+        if (!isExactRegisteredToolName(toolName, builtinToolNames)) {
           return mediaUrls.filter((url) => HTTP_URL_RE.test(url.trim()));
         }
       }

--- a/src/agents/pi-embedded-subscribe.tools.ts
+++ b/src/agents/pi-embedded-subscribe.tools.ts
@@ -325,22 +325,21 @@ function isExternalToolResult(result: unknown): boolean {
 export function isToolResultMediaTrusted(
   toolName?: string,
   result?: unknown,
-  trustedBundledPluginToolNames?: ReadonlySet<string>,
-  trustedCoreToolNames?: ReadonlySet<string>,
+  trustedLocalMediaToolNames?: ReadonlySet<string>,
 ): boolean {
   if (!toolName || isExternalToolResult(result)) {
     return false;
   }
   const normalized = normalizeToolName(toolName);
-  const coreTrusted =
-    TRUSTED_TOOL_RESULT_MEDIA.has(normalized) &&
-    (trustedCoreToolNames === undefined ||
-      isExactRegisteredToolName(toolName, trustedCoreToolNames));
-  const bundledPluginTrusted =
-    TRUSTED_BUNDLED_PLUGIN_MEDIA_TOOLS.has(normalized) &&
-    (trustedBundledPluginToolNames === undefined ||
-      isExactRegisteredToolName(toolName, trustedBundledPluginToolNames));
-  return coreTrusted || bundledPluginTrusted;
+  const staticallyTrusted =
+    TRUSTED_TOOL_RESULT_MEDIA.has(normalized) || TRUSTED_BUNDLED_PLUGIN_MEDIA_TOOLS.has(normalized);
+  if (!staticallyTrusted) {
+    return false;
+  }
+  return (
+    trustedLocalMediaToolNames === undefined ||
+    isExactRegisteredToolName(toolName, trustedLocalMediaToolNames)
+  );
 }
 
 function isExactRegisteredToolName(
@@ -354,11 +353,11 @@ function isExactRegisteredToolName(
 function isTrustedOwnedTtsLocalMedia(
   toolName: string | undefined,
   result: unknown,
-  trustedCoreToolNames?: ReadonlySet<string>,
+  trustedLocalMediaToolNames?: ReadonlySet<string>,
 ): boolean {
   if (
     !toolName ||
-    !isToolResultMediaTrusted(toolName, result, undefined, trustedCoreToolNames) ||
+    !isToolResultMediaTrusted(toolName, result, trustedLocalMediaToolNames) ||
     normalizeToolName(toolName) !== "tts"
   ) {
     return false;
@@ -374,9 +373,7 @@ export function filterToolResultMediaUrls(
   toolName: string | undefined,
   mediaUrls: string[],
   result?: unknown,
-  builtinToolNames?: ReadonlySet<string>,
-  trustedBundledPluginToolNames?: ReadonlySet<string>,
-  trustedCoreToolNames?: ReadonlySet<string>,
+  trustedLocalMediaToolNames?: ReadonlySet<string>,
 ): string[] {
   if (mediaUrls.length === 0) {
     return mediaUrls;
@@ -384,27 +381,12 @@ export function filterToolResultMediaUrls(
   const trustedOwnedTtsLocalMedia = isTrustedOwnedTtsLocalMedia(
     toolName,
     result,
-    trustedCoreToolNames,
+    trustedLocalMediaToolNames,
   );
   if (
     trustedOwnedTtsLocalMedia ||
-    isToolResultMediaTrusted(toolName, result, trustedBundledPluginToolNames, trustedCoreToolNames)
+    isToolResultMediaTrusted(toolName, result, trustedLocalMediaToolNames)
   ) {
-    // When the current run provides its exact registered tool names (core
-    // built-ins plus bundled/trusted plugin tools), require the raw emitted
-    // tool name to match one of them before allowing local MEDIA: paths.
-    // This blocks normalized aliases and case-variant collisions such as
-    // "Bash" -> "bash" or "Web_Search" -> "web_search" from inheriting a
-    // registered tool's media trust. TTS-generated local files carry a
-    // separate trusted-media flag from the owned tool result, so they can
-    // survive runs whose exact built-in set omitted the raw tts name.
-    if (builtinToolNames !== undefined) {
-      if (!trustedOwnedTtsLocalMedia) {
-        if (!isExactRegisteredToolName(toolName, builtinToolNames)) {
-          return mediaUrls.filter((url) => HTTP_URL_RE.test(url.trim()));
-        }
-      }
-    }
     return mediaUrls;
   }
   return mediaUrls.filter((url) => HTTP_URL_RE.test(url.trim()));

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -124,6 +124,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
   const canShowReasoning = params.thinkingLevel !== "off";
   const toolResultFormat = params.toolResultFormat ?? "markdown";
   const useMarkdown = toolResultFormat === "markdown";
+  const trustedLocalMediaToolNames = params.trustedLocalMediaToolNames ?? params.builtinToolNames;
   const initialPendingToolMediaUrls = collectPendingMediaFromInternalEvents(params.internalEvents);
   const state: EmbeddedPiSubscribeState = {
     assistantTexts: [],
@@ -548,7 +549,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
       toolName,
       mediaUrls ?? [],
       result,
-      params.trustedLocalMediaToolNames,
+      trustedLocalMediaToolNames,
     );
     if (!cleanedText && filteredMediaUrls.length === 0) {
       return;
@@ -979,7 +980,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     blockChunker,
     hookRunner: params.hookRunner,
     builtinToolNames: params.builtinToolNames,
-    trustedLocalMediaToolNames: params.trustedLocalMediaToolNames,
+    trustedLocalMediaToolNames,
     noteLastAssistant,
     shouldEmitToolResult,
     shouldEmitToolOutput,

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -548,9 +548,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
       toolName,
       mediaUrls ?? [],
       result,
-      params.builtinToolNames,
-      params.trustedBundledPluginToolNames,
-      params.trustedCoreToolNames,
+      params.trustedLocalMediaToolNames,
     );
     if (!cleanedText && filteredMediaUrls.length === 0) {
       return;
@@ -981,8 +979,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     blockChunker,
     hookRunner: params.hookRunner,
     builtinToolNames: params.builtinToolNames,
-    trustedCoreToolNames: params.trustedCoreToolNames,
-    trustedBundledPluginToolNames: params.trustedBundledPluginToolNames,
+    trustedLocalMediaToolNames: params.trustedLocalMediaToolNames,
     noteLastAssistant,
     shouldEmitToolResult,
     shouldEmitToolOutput,

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -549,6 +549,8 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
       mediaUrls ?? [],
       result,
       params.builtinToolNames,
+      params.trustedBundledPluginToolNames,
+      params.trustedCoreToolNames,
     );
     if (!cleanedText && filteredMediaUrls.length === 0) {
       return;
@@ -979,6 +981,8 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     blockChunker,
     hookRunner: params.hookRunner,
     builtinToolNames: params.builtinToolNames,
+    trustedCoreToolNames: params.trustedCoreToolNames,
+    trustedBundledPluginToolNames: params.trustedBundledPluginToolNames,
     noteLastAssistant,
     shouldEmitToolResult,
     shouldEmitToolOutput,

--- a/src/agents/pi-embedded-subscribe.types.ts
+++ b/src/agents/pi-embedded-subscribe.types.ts
@@ -63,10 +63,20 @@ export type SubscribeEmbeddedPiSessionParams = {
   /** Agent identity for hook context — resolved from session config in attempt.ts. */
   agentId?: string;
   /**
-   * Exact raw names of non-plugin OpenClaw tools registered for this run.
+   * Exact raw names of all tools registered for this run.
    * When provided, MEDIA: passthrough requires an exact match instead of only
-   * a normalized-name collision with a trusted built-in.
+   * a normalized-name collision with a trusted tool.
    */
   builtinToolNames?: ReadonlySet<string>;
+  /**
+   * Exact raw names of active core tools that may emit local MEDIA: paths.
+   * Plugin tools with overlapping names are intentionally excluded.
+   */
+  trustedCoreToolNames?: ReadonlySet<string>;
+  /**
+   * Exact raw names of active bundled plugin tools that may emit local MEDIA:
+   * paths. Plugin overrides are intentionally excluded by origin.
+   */
+  trustedBundledPluginToolNames?: ReadonlySet<string>;
   internalEvents?: AgentInternalEvent[];
 };

--- a/src/agents/pi-embedded-subscribe.types.ts
+++ b/src/agents/pi-embedded-subscribe.types.ts
@@ -69,14 +69,10 @@ export type SubscribeEmbeddedPiSessionParams = {
    */
   builtinToolNames?: ReadonlySet<string>;
   /**
-   * Exact raw names of active core tools that may emit local MEDIA: paths.
-   * Plugin tools with overlapping names are intentionally excluded.
+   * Exact raw names of active tools whose origin may emit local MEDIA: paths.
+   * The media helper still applies its static allowed-tool policy on top.
+   * MCP/external tools and non-bundled plugin overrides are intentionally excluded.
    */
-  trustedCoreToolNames?: ReadonlySet<string>;
-  /**
-   * Exact raw names of active bundled plugin tools that may emit local MEDIA:
-   * paths. Plugin overrides are intentionally excluded by origin.
-   */
-  trustedBundledPluginToolNames?: ReadonlySet<string>;
+  trustedLocalMediaToolNames?: ReadonlySet<string>;
   internalEvents?: AgentInternalEvent[];
 };


### PR DESCRIPTION
## Summary

- Problem: agent media trust pulled the plugin contract registry into the embedded subscribe path just to decide whether local `MEDIA:` paths were trusted.
- Solution: replace that hot-path registry import with a static bundled-plugin media allowlist, then gate local media passthrough on the exact active core or bundled plugin tool names for the current run.
- What changed: media filtering now blocks MCP/external provenance, unvetted registered plugin names, and non-bundled overrides of bundled or core tool names while preserving trusted core and active bundled plugin media output.
- What did NOT change (scope boundary): no channel behavior, provider behavior, plugin loading policy, config schema, or public protocol shape changed.

## Motivation

- This addresses the local `startup/import-fanout-investigation` backlog item by removing an avoidable registry/generated-metadata import from the agent subscribe/media trust path while keeping local media trust fail-closed for untrusted tool origins.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- N/A - local startup backlog item only.
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior addressed: The real Gateway media route still saves/generated media, while the agent subscribe trust gate only preserves local `MEDIA:` paths for active trusted core or bundled plugin tool origins and strips MCP/external or untrusted plugin collisions.
- Real environment tested: Local macOS 26.4.1 shell, Node v25.9.0, pnpm 11.1.0. QA suite host runner with a real Gateway child (`dist/index.js gateway run --port 51535 --bind loopback --allow-unconfigured`), `qa-channel` + qa-lab bus, `mock-openai/gpt-5.5` provider; plus a production `subscribeEmbeddedPiSession` event-stream probe. The startup benchmark also used built Gateway processes and probed `/healthz` + `/readyz`.
- Exact steps or command run after this patch:
  - `OPENCLAW_QA_KEEP_TEMP=1 pnpm openclaw qa suite --provider-mode mock-openai --runner host --scenario native-image-generation --output-dir .artifacts/qa-media-trust-refactor-proof`
  - `ls -l /tmp/openclaw/openclaw-qa-suite-RFNTjs/state/media/tool-image-generation/qa-lighthouse---89531b3b-7c57-4953-a338-a2799cd36030.png && file /tmp/openclaw/openclaw-qa-suite-RFNTjs/state/media/tool-image-generation/qa-lighthouse---89531b3b-7c57-4953-a338-a2799cd36030.png && shasum -a 256 /tmp/openclaw/openclaw-qa-suite-RFNTjs/state/media/tool-image-generation/qa-lighthouse---89531b3b-7c57-4953-a338-a2799cd36030.png`
  - `node --import tsx --input-type=module <<'EOF' ... EOF` with an inline script that imports `./src/agents/pi-embedded-subscribe.ts`, feeds `tool_execution_end` + `agent_end` events, passes `trustedLocalMediaToolNames`, and reads `subscription.getPendingToolMediaReply()`.
  - `node --import tsx scripts/bench-gateway-startup.ts --case skipChannels --case fiftyStartupLazyPlugins --runs 2 --warmup 1 --cpu-prof-dir .artifacts/startup-import-fanout/real-proof-cpu --output .artifacts/startup-import-fanout/real-proof.json`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):
  - QA suite report:
    ```text
    # OpenClaw QA Scenario Suite
    - Started: 2026-05-20T03:42:24.382Z
    - Finished: 2026-05-20T03:42:59.138Z
    - Duration ms: 34756
    - Passed: 1
    - Failed: 0

    ### Native image generation
    - Status: pass
    - Steps:
      - [x] enables image_generate and saves a real media artifact
    Protocol note: I reviewed the requested material. Evidence snippet: Background task started for image generation (d66f2a36-6682-4f6f-8b80-931d61d7ca46).
    IMAGE_PATH:/tmp/openclaw/openclaw-qa-suite-RFNTjs/state/media/tool-image-generation/qa-lighthouse---89531b3b-7c57-4953-a338-a2799cd36030.png
    Notes: Runs against qa-channel + qa-lab bus + real gateway child + mock-openai provider.
    ```
  - Preserved media artifact verification:
    ```text
    -rw-r--r--@ 1 x  wheel  68 May 20 11:42 /tmp/openclaw/openclaw-qa-suite-RFNTjs/state/media/tool-image-generation/qa-lighthouse---89531b3b-7c57-4953-a338-a2799cd36030.png
    PNG image data, 1 x 1, 8-bit gray+alpha, non-interlaced
    65deda782bef8ddd50b7e5d3d426fbcfafa4d9ac63bb0e56675b6b46893d51c9
    ```
  - Gateway/session trace showed the built Gateway invocation, `image_generate` tool call, async tool result, and inter-session completion carrying the saved image attachment:
    ```text
    invocation: dist/index.js gateway run --port 51535 --bind loopback --allow-unconfigured
    plugin registry source: active-registry; importedRuntimePluginIds: acpx, memory-core, openai, qa-channel
    toolCall: image_generate filename=qa-lighthouse.png size=1024x1024
    toolResult: status=started taskId=d66f2a36-6682-4f6f-8b80-931d61d7ca46 runId=tool:image_generate:0ee6a0fb-f6db-4758-a68a-17846825130f
    completion attachment: type=image mimeType=image/png path=/tmp/openclaw/openclaw-qa-suite-RFNTjs/state/media/tool-image-generation/qa-lighthouse---89531b3b-7c57-4953-a338-a2799cd36030.png
    ```
  - Production subscribe event-stream probe output:
    ```json
    {
      "trustedCoreExact": ["/tmp/openclaw-proof-core-browser.png"],
      "mcpExactNameLocal": [],
      "pluginOverrideLocal": [],
      "trustedBundledExact": ["/tmp/openclaw-proof-bundled-browser.png"],
      "mcpRemoteStillAllowed": ["https://example.test/proof.png"]
    }
    ```
  - Startup proof still reached readiness: `skipChannels /readyz p50=4635.6ms`; `fiftyStartupLazyPlugins /readyz p50=3895.1ms`; built agent subscribe/embedded chunks had no `plugins/contracts/registry`, `pluginRegistrationContractRegistry`, `registry-Bus`, or `bundled-capability-metadata` matches.
- Observed result after fix: The QA suite drove a real built Gateway child through native image generation and produced a saved PNG media artifact. The production subscribe event stream used the single `trustedLocalMediaToolNames` set, kept exact trusted core and bundled local media, stripped exact-name MCP local media, stripped untrusted plugin override local media, and still allowed remote MCP media URLs.
- What was not tested: Full CI, cross-OS/Testbox, live non-mock provider output, and a real external chat channel were not run.
- Before evidence: N/A - this PR validates the after-patch import and runtime media-trust behavior for the startup investigation path.

## Performance accounting

- This PR does not claim a measured latency win. The proof shows the built Gateway still starts and reaches readiness after removing the registry import from the media trust path, and the built chunks no longer contain the removed registry/generated-metadata imports in the affected agent subscribe/embedded outputs.

## Root Cause (if applicable)

- Root cause: media trust used `pluginRegistrationContractRegistry` to derive bundled plugin tool names, coupling a hot agent subscribe helper to the plugin contract registry and generated bundled capability metadata.
- Missing detection / guardrail: no source/import guard covered this helper, and no manifest-alignment test kept a lightweight allowlist honest.
- Contributing context (if known): local media passthrough has to distinguish trusted core/bundled tool origins from MCP/external tools and plugin name collisions.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/pi-embedded-subscribe.tools.media.test.ts`, `src/agents/pi-embedded-subscribe.handlers.tools.media.test.ts`.
- Scenario the test should lock in: registry-free media trust, static bundled allowlist alignment with manifests, MCP/external local media blocking, unvetted plugin local media blocking, and core/bundled exact-origin passthrough.
- Why this is the smallest reliable guardrail: the behavior is decided by the media trust helper and subscribe handler before any broader Gateway delivery path.
- Existing test that already covers this (if any): N/A.
- If no new test is added, why not: N/A - targeted tests were added/extended.

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

```text
Before:
[tool result MEDIA:] -> [media trust helper] -> [plugin contract registry import] -> [local path decision]

After:
[tool result MEDIA:] -> [media trust helper] -> [single active trustedLocalMediaToolNames set + static allowlist] -> [local path decision]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No.
- Secrets/tokens handling changed? (`Yes/No`): No.
- New/changed network calls? (`Yes/No`): No.
- Command/tool execution surface changed? (`Yes/No`): Yes.
- Data access scope changed? (`Yes/No`): Yes.
- If any `Yes`, explain risk + mitigation: local `MEDIA:` path passthrough is narrowed. The mitigation is exact active-tool origin gating plus explicit MCP/external blocking, with tests for non-bundled overrides and name collisions.

## Repro + Verification

### Environment

- OS: macOS 26.4.1 (25E253)
- Runtime/container: local shell, Node v25.9.0, pnpm 11.1.0
- Model/provider: `mock-openai/gpt-5.5` for QA media proof; N/A for import grep and startup benchmark
- Integration/channel (if any): `qa-channel` + qa-lab bus for QA media proof
- Relevant config (redacted): QA-suite and benchmark-managed temporary Gateway state

### Steps

1. Build the repository with `pnpm build`.
2. Verify affected built chunks do not import the removed registry/generated metadata with `rg "plugins/contracts/registry|pluginRegistrationContractRegistry|registry-Bus|bundled-capability-metadata" dist/attempt.tool-run-context-*.js dist/*subscribe*.js dist/*embedded*.js`.
3. Run the QA suite native image generation proof listed in the Real behavior proof section.
4. Verify the preserved generated media artifact with `ls`, `file`, and `shasum`.
5. Run the production subscribe event-stream media trust probe listed in the Real behavior proof section.
6. Run the startup proof command listed in the Real behavior proof section.

### Expected

- The Gateway reaches `/healthz` and `/readyz` in both benchmark scenarios.
- The affected built chunks do not include the plugin contract registry or bundled capability metadata import.
- The QA suite drives the built Gateway child through native image generation and saves a media artifact.
- Local `MEDIA:` paths are retained only for trusted active core or bundled plugin tool origins.

### Actual

- The Gateway reached `/healthz` and `/readyz` in both scenarios.
- The built chunk import grep returned no matches.
- The QA suite passed `native-image-generation`, produced `qa-lighthouse---89531b3b-7c57-4953-a338-a2799cd36030.png`, and the preserved PNG verified as sha256 `65deda782bef8ddd50b7e5d3d426fbcfafa4d9ac63bb0e56675b6b46893d51c9`.
- The production subscribe event-stream probe returned `{"trustedCoreExact":["/tmp/openclaw-proof-core-browser.png"],"mcpExactNameLocal":[],"pluginOverrideLocal":[],"trustedBundledExact":["/tmp/openclaw-proof-bundled-browser.png"],"mcpRemoteStillAllowed":["https://example.test/proof.png"]}`.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [x] Perf numbers (if relevant)

## Human Verification (required)

What I personally verified:

- Verified scenarios: targeted media trust tests, production subscribe event-stream media trust probe, build, built-chunk import grep, changed-lane discovery, QA suite `native-image-generation` with a real built Gateway child, preserved media artifact verification, and built Gateway startup proof for `skipChannels` and `fiftyStartupLazyPlugins`.
- Edge cases checked: MCP provenance using a trusted name, plugin override of an overlapping core/bundled name, exact active core passthrough, exact active bundled passthrough, remote MCP media passthrough, and manifest alignment for bundled tool names.
- What I did **not** verify: full CI, cross-OS/Testbox, live non-mock provider output, and real external chat channel delivery.

AI-assisted: yes, Codex assisted with implementation and verification; I reviewed the diff and ran the proof commands locally.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

No existing PR review conversations were present for this branch before PR creation.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes.
- Config/env changes? (`Yes/No`): No.
- Migration needed? (`Yes/No`): No.
- If yes, exact upgrade steps: N/A.

## Risks and Mitigations

- Risk: the static bundled tool allowlist could drift from bundled plugin manifests.
  - Mitigation: `src/agents/pi-embedded-subscribe.tools.media.test.ts` reads bundled manifests and asserts the allowlist trusts every declared bundled contract tool name.
- Risk: bundled plugin local media could be too narrow if a run lacks plugin metadata origin information.
  - Mitigation: plugin local media fails closed when exact active bundled origin cannot be proven; core local media remains separately gated by the exact active core tool set.
