### PR TITLE
fix(discord): keep forced voice consult diagnostics private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -238,6 +238,7 @@ Docs: https://docs.openclaw.ai
 - Update/doctor: prune stale local bundled plugin install records that point at old compiled bundled output so current bundled plugin schemas win after upgrade. (#84863) Thanks @fuller-stack-dev.
 - Providers/Ollama: preserve native Ollama tool-call IDs across assistant replay so Gemini over Ollama Cloud can keep its hidden function-call thought-signature handle.
 - Discord: keep session recovery and `/stop` abort ownership on the source dispatch lane while bound ACP turns continue routing to their target session, so stalled pre-run work and late replies are cleared instead of leaking after stop. Fixes #84477. (#85100) Thanks @joshavant.
+- Discord/voice-call: keep forced realtime voice consult diagnostics in debug logs instead of agent prompts, so callers do not hear OpenClaw policy text when the provider misses `openclaw_agent_consult`. (#84411) Thanks @fuller-stack-dev.
 - Codex app-server: mark missing turn completion after observed execution as replay-unsafe and release the session so follow-up turns can run. Fixes #84076. (#85107) Thanks @joshavant.
 - Codex app-server: give visible `message` dynamic tool sends a longer timeout budget so slow channel delivery can return its own result or error instead of hitting the 30-second Codex wrapper. (#85216) Thanks @amknight.
 - Codex app-server: add a dedicated post-tool raw assistant completion idle timeout config so trusted heavy turns can wait longer after tool handoff without weakening final assistant release.

--- a/extensions/discord/src/voice/manager.e2e.test.ts
+++ b/extensions/discord/src/voice/manager.e2e.test.ts
@@ -2139,6 +2139,47 @@ describe("DiscordVoiceManager", () => {
     expectUserMessageIncludes("valid answer");
   });
 
+  it("keeps forced agent-proxy fallback diagnostics out of agent prompts", async () => {
+    agentCommandMock.mockResolvedValueOnce({ payloads: [{ text: "Could you repeat that?" }] });
+    const manager = createManager({
+      groupPolicy: "open",
+      voice: {
+        enabled: true,
+        mode: "agent-proxy",
+        realtime: { provider: "openai" },
+      },
+    });
+
+    await manager.join({ guildId: "g1", channelId: "1001" });
+    const entry = getSessionEntry(manager) as {
+      realtime?: {
+        beginSpeakerTurn: (
+          context: { extraSystemPrompt?: string; senderIsOwner: boolean; speakerLabel: string },
+          userId: string,
+        ) => { close: () => void; sendInputAudio: (audio: Buffer) => void };
+      };
+    };
+    const bridgeParams = lastRealtimeBridgeParams() as
+      | {
+          onTranscript?: (role: "user" | "assistant", text: string, isFinal: boolean) => void;
+        }
+      | undefined;
+
+    const turn = entry.realtime?.beginSpeakerTurn(
+      { extraSystemPrompt: undefined, senderIsOwner: true, speakerLabel: "Owner" },
+      "u-owner",
+    );
+    turn?.sendInputAudio(Buffer.alloc(8));
+    bridgeParams?.onTranscript?.("user", "What?", true);
+
+    await new Promise((resolve) => setTimeout(resolve, 260));
+
+    expect(lastAgentCommandArgs().message).toBe("What?");
+    expect(lastAgentCommandArgs().message).not.toContain("consultPolicy");
+    expect(lastAgentCommandArgs().message).not.toContain("openclaw_agent_consult");
+    expectUserMessageIncludes("Could you repeat that?");
+  });
+
   it("queues forced agent-proxy answers until current realtime playback idles", async () => {
     let resolveFirst: ((value: { payloads: Array<{ text: string }> }) => void) | undefined;
     let resolveSecond: ((value: { payloads: Array<{ text: string }> }) => void) | undefined;

--- a/extensions/discord/src/voice/realtime.ts
+++ b/extensions/discord/src/voice/realtime.ts
@@ -74,6 +74,8 @@ const DISCORD_REALTIME_FORCED_CONSULT_TRAILING_FRAGMENT_WORDS = new Set([
   "to",
   "with",
 ]);
+const DISCORD_REALTIME_FORCED_CONSULT_REASON =
+  "provider_final_transcript_without_openclaw_agent_consult";
 const DISCORD_REALTIME_VERBOSE_OMITTED_EVENTS = new Set([
   "conversation.output_audio.delta",
   "input_audio_buffer.append",
@@ -1083,6 +1085,9 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
     const startedAt = Date.now();
     logger.info(
       `discord voice: realtime forced agent consult starting chars=${question.length} voiceSession=${this.params.entry.voiceSessionKey} supervisorSession=${this.params.entry.route.sessionKey} agent=${this.params.entry.route.agentId} speaker=${context.speakerLabel} owner=${context.senderIsOwner}`,
+    );
+    logger.debug(
+      `discord voice: realtime forced agent consult reason=${DISCORD_REALTIME_FORCED_CONSULT_REASON} consultPolicy=always voiceSession=${this.params.entry.voiceSessionKey} supervisorSession=${this.params.entry.route.sessionKey} agent=${this.params.entry.route.agentId} speaker=${context.speakerLabel}`,
     );
     if (this.hasInterruptibleOutputAudio()) {
       logger.info(

--- a/extensions/discord/src/voice/realtime.ts
+++ b/extensions/discord/src/voice/realtime.ts
@@ -1093,10 +1093,7 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
     try {
       const promise = this.runAgentTurn({
         context,
-        message: [
-          question,
-          "Context: The realtime model produced a final user transcript without calling openclaw_agent_consult. OpenClaw is forcing the consult because consultPolicy is always.",
-        ].join("\n\n"),
+        message: question,
       });
       this.setRecentAgentProxyConsultPromise(pending.recent, promise);
       const text = await promise;

--- a/extensions/voice-call/src/webhook/realtime-handler.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.test.ts
@@ -969,8 +969,6 @@ describe("RealtimeCallHandler path routing", () => {
         const [args, callId, context] = requireFirstMockCall(consult.mock.calls, "consult");
         expect(args).toEqual({
           question: "Create a smoke test file for me.",
-          context:
-            "The realtime provider produced a final user transcript without invoking openclaw_agent_consult, so OpenClaw is forcing the consult because consultPolicy is always.",
         });
         expect(callId).toBe("call-1");
         expect(context).toEqual({});

--- a/extensions/voice-call/src/webhook/realtime-handler.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.test.ts
@@ -970,6 +970,8 @@ describe("RealtimeCallHandler path routing", () => {
         expect(args).toEqual({
           question: "Create a smoke test file for me.",
         });
+        expect(JSON.stringify(args)).not.toContain("consultPolicy");
+        expect(JSON.stringify(args)).not.toContain("openclaw_agent_consult");
         expect(callId).toBe("call-1");
         expect(context).toEqual({});
         await waitForRealtimeTest(() => {

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -1092,8 +1092,6 @@ export class RealtimeCallHandler {
         params.handler(
           {
             question: params.question,
-            context:
-              "The realtime provider produced a final user transcript without invoking openclaw_agent_consult, so OpenClaw is forcing the consult because consultPolicy is always.",
           },
           params.callId,
           {},

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -16,6 +16,7 @@ import {
   type TalkEventInput,
   type TalkSessionController,
 } from "openclaw/plugin-sdk/realtime-voice";
+import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import WebSocket, { WebSocketServer } from "ws";
 import type { VoiceCallRealtimeConfig } from "../config.js";
 import type { CallManager } from "../manager.js";
@@ -45,11 +46,13 @@ const MAX_REALTIME_WS_BUFFERED_BYTES = 1024 * 1024;
 const FORCED_CONSULT_FALLBACK_DELAY_MS = 200;
 const FORCED_CONSULT_NATIVE_DEDUPE_MS = 2_000;
 const FORCED_CONSULT_RESULT_MAX_CHARS = 1800;
+const FORCED_CONSULT_REASON = "provider_final_transcript_without_openclaw_agent_consult";
 const CONSULT_TRANSCRIPT_SETTLE_MS = 350;
 const CONSULT_TRANSCRIPT_SETTLE_MAX_MS = 1_000;
 const MAX_PARTIAL_USER_TRANSCRIPT_CHARS = 1_200;
 const RECENT_FINAL_USER_TRANSCRIPT_TTL_MS = 2_000;
 const BARGE_IN_REQUIRED_LOUD_CHUNKS = 2;
+const logger = createSubsystemLogger("voice-call/realtime");
 
 function normalizePath(pathname: string): string {
   const trimmed = pathname.trim();
@@ -1082,6 +1085,9 @@ export class RealtimeCallHandler {
   }): Promise<void> {
     this.forcedConsultInFlightByCallId.add(params.callId);
     const startedAt = Date.now();
+    logger.debug(
+      `[voice-call] realtime forced agent consult reason=${FORCED_CONSULT_REASON} consultPolicy=always callId=${params.callId} providerCallId=${params.callSid} chars=${params.question.length}`,
+    );
     console.log(
       `[voice-call] realtime forced agent consult starting callId=${params.callId} providerCallId=${params.callSid} chars=${params.question.length}`,
     );


### PR DESCRIPTION
## Summary
- Stop forced Discord realtime consult fallbacks from appending internal consult-policy diagnostics to the agent-facing voice prompt.
- Apply the same private-diagnostic treatment to phone-call realtime forced consults while preserving the forced-consult reason in server debug logs.
- Rebase onto current `upstream/main`, resolve the voice-call test-helper conflict, and keep the Unreleased changelog entry.

## Verification
- Node 24.14.0: `node scripts/run-vitest.mjs --config test/vitest/vitest.e2e.config.ts extensions/discord/src/voice/manager.e2e.test.ts --reporter=verbose`
- Node 24.14.0: `node scripts/run-vitest.mjs --config test/vitest/vitest.extension-voice-call.config.ts extensions/voice-call/src/webhook/realtime-handler.test.ts --reporter=verbose`
- `node_modules/.bin/oxfmt --check CHANGELOG.md extensions/discord/src/voice/manager.e2e.test.ts extensions/discord/src/voice/realtime.ts extensions/voice-call/src/webhook/realtime-handler.test.ts extensions/voice-call/src/webhook/realtime-handler.ts`
- `git diff --check`
- `AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main`

## Real behavior proof
Behavior addressed: Realtime voice forced consult fallback no longer feeds internal consult-policy diagnostics into model-facing prompts that can be spoken back to users.
Real environment tested: Local OpenClaw checkout at PR head `e3057684efed28370958819ccba79241c7c9987f`, running the production voice-call realtime WebSocket handler through an actual local WebSocket session with `consultPolicy=always` and `OPENCLAW_LOG_LEVEL=debug`.
Exact steps or command run after this patch: `NODE_PATH=/Users/jason/workspace/openclaw/node_modules OPENCLAW_LOG_LEVEL=debug ./node_modules/.bin/tsx /tmp/openclaw-pr-84411-real-proof.ts 2>&1 | tee /tmp/openclaw-pr-84411-real-proof.log`
Evidence after fix: Terminal capture from the production runtime path:
```console
[proof] local websocket URL=ws://127.0.0.1:<port>/voice/stream/realtime/e60e6760-4da9-46ac-9624-f762e9cb5062
[proof] telephony websocket connected
[proof] manager event type=call.initiated callId=CA-proof-84411
[voice-call] Realtime call call-proof-84411 initial greeting absent
[proof] manager event type=call.answered callId=call-proof-84411
[voice-call] Realtime bridge starting for call call-proof-84411 (providerCallId=CA-proof-84411, initialGreeting=absent)
[proof] realtime provider bridge created tools=
[proof] realtime bridge connected
[voice-call] realtime input transcript callId=call-proof-84411 providerCallId=CA-proof-84411 final=true chars=32 aggregateChars=32
[proof] manager event type=call.speech callId=call-proof-84411
[voice-call/realtime] [voice-call] realtime forced agent consult reason=provider_final_transcript_without_openclaw_agent_consult consultPolicy=always callId=call-proof-84411 providerCallId=CA-proof-84411 chars=32
[voice-call] realtime forced agent consult starting callId=call-proof-84411 providerCallId=CA-proof-84411 chars=32
[voice-call] realtime forced consult cleared outbound audio callId=call-proof-84411 providerCallId=CA-proof-84411 queuedBytes=0
[proof] consult handler callId=call-proof-84411 context={}
[proof] consult args JSON={"question":"Create a smoke test file for me."}
[voice-call] realtime forced consult cleared outbound audio callId=call-proof-84411 providerCallId=CA-proof-84411 queuedBytes=0
[proof] runtime sendUserMessage="Internal OpenClaw consult result is ready.\nDo not call tools for this internal result.\nSpeak the following answer to the caller now, briefly and naturally:\nI created the smoke test file."
[voice-call] realtime forced agent consult completed callId=call-proof-84411 providerCallId=CA-proof-84411 elapsedMs=3
[proof] args leak markers present=false
[proof] spoken prompt leak markers present=false
[proof] observed forced consult question="Create a smoke test file for me."
[proof] RESULT pass: forced consult diagnostics stayed in debug log only
[proof] manager event type=call.ended callId=call-proof-84411
```
Observed result after fix: The forced-consult debug reason stayed in the `voice-call/realtime` debug log, the agent consult args were exactly `{"question":"Create a smoke test file for me."}`, and both model-facing leak checks reported `false` for `consultPolicy` and `openclaw_agent_consult`.
What was not tested: A live Discord voice room, live carrier phone call, or real OpenAI realtime audio session was not run; this proof exercises the production voice-call realtime WebSocket path locally and the Discord path is covered by the focused regression file.
