### PR TITLE
fix(codex/command-account): respect explicit auth order over lastGood (#84386)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ Docs: https://docs.openclaw.ai
 - iOS: repair Release archive compilation for the TestFlight build. (#84255) Thanks @ngutman.
 - Agents/compaction: bound plugin-owned CLI transcript compaction with the host safety timeout so a hung context engine can no longer stall post-turn cleanup. (#84083) Thanks @100yenadmin.
 - Control UI/usage: truncate long context skill, tool, and file names in the usage panel while keeping the full name available on hover. (#42197) Thanks @Rain120.
-- Codex: fix `/codex account` showing a stale auth profile as "active now" after `models auth login` + `models auth order set` establishes a new explicit order; the display now respects explicit operator order over `lastGood` heuristics, and anchors to the first explicit-order entry rather than deferring to a lower-ranked profile when all candidates are temporarily unusable. (#84412) Thanks @openperf
+- Codex: respect explicit `models auth order set` and `config.auth.order` precedence over stale `lastGood` in `/codex account`, and show `no working credential` when every explicit-order profile is ineligible instead of marking a lower-ranked profile as active. Fixes #84386. (#84412) Thanks @openperf.
 
 ## 2026.5.19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Codex: fix `/codex account` showing a stale auth profile as "active now" after `models auth login` + `models auth order set` establishes a new explicit order; the display now respects explicit operator order over `lastGood` heuristics, and anchors to the first explicit-order entry rather than deferring to a lower-ranked profile when all candidates are temporarily unusable. (#84412) Thanks @openperf
 - Agents/code mode: spell out the `exec` tool's JavaScript/TypeScript, no Node module, and catalog-bridge constraints in model-visible schema text so agents can use enabled tools without trial-and-error. (#84269) Thanks @Kaspre.
 - Codex: give `image_generate` dynamic-tool calls a 120s default watchdog when no per-call or configured image timeout is set, so image generation no longer falls back to the generic 30s bridge timeout. (#84254) Thanks @moritzmmayerhofer.
 - CLI/message: include a stable top-level `messageId` in `openclaw message --json` output when channel sends return one. (#84191) Thanks @100menotu001.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Codex: fix `/codex account` showing a stale auth profile as "active now" after `models auth login` + `models auth order set` establishes a new explicit order; the display now respects explicit operator order over `lastGood` heuristics, and anchors to the first explicit-order entry rather than deferring to a lower-ranked profile when all candidates are temporarily unusable. (#84412) Thanks @openperf
 - Agents/code mode: spell out the `exec` tool's JavaScript/TypeScript, no Node module, and catalog-bridge constraints in model-visible schema text so agents can use enabled tools without trial-and-error. (#84269) Thanks @Kaspre.
 - Codex: give `image_generate` dynamic-tool calls a 120s default watchdog when no per-call or configured image timeout is set, so image generation no longer falls back to the generic 30s bridge timeout. (#84254) Thanks @moritzmmayerhofer.
 - CLI/message: include a stable top-level `messageId` in `openclaw message --json` output when channel sends return one. (#84191) Thanks @100menotu001.
@@ -49,6 +48,7 @@ Docs: https://docs.openclaw.ai
 - iOS: repair Release archive compilation for the TestFlight build. (#84255) Thanks @ngutman.
 - Agents/compaction: bound plugin-owned CLI transcript compaction with the host safety timeout so a hung context engine can no longer stall post-turn cleanup. (#84083) Thanks @100yenadmin.
 - Control UI/usage: truncate long context skill, tool, and file names in the usage panel while keeping the full name available on hover. (#42197) Thanks @Rain120.
+- Codex: fix `/codex account` showing a stale auth profile as "active now" after `models auth login` + `models auth order set` establishes a new explicit order; the display now respects explicit operator order over `lastGood` heuristics, and anchors to the first explicit-order entry rather than deferring to a lower-ranked profile when all candidates are temporarily unusable. (#84412) Thanks @openperf
 
 ## 2026.5.19
 

--- a/extensions/codex/src/command-account.ts
+++ b/extensions/codex/src/command-account.ts
@@ -62,7 +62,7 @@ export async function readCodexAccountAuthOverview(params: {
     allowKeychainPrompt: false,
     config,
   });
-  const order = resolveDisplayAuthOrder({ config, store });
+  const { order, explicit: explicitOrder } = resolveDisplayAuthOrder({ config, store });
   if (order.length === 0) {
     return undefined;
   }
@@ -71,6 +71,7 @@ export async function readCodexAccountAuthOverview(params: {
   const activeProfileId = resolveActiveProfileId({
     store,
     order,
+    explicitOrder,
     config,
     account: params.account,
     limits: params.limits,
@@ -135,21 +136,45 @@ export async function readCodexAccountAuthOverview(params: {
   };
 }
 
+type DisplayAuthOrder = {
+  readonly order: string[];
+  readonly explicit: boolean;
+};
+
 function resolveDisplayAuthOrder(params: {
   config: AuthProfileOrderConfig;
   store: AuthProfileStore;
-}): string[] {
+}): DisplayAuthOrder {
   const codexOrder =
     resolveOrder(params.store.order, OPENAI_CODEX_PROVIDER_ID) ??
     resolveOrder(params.config?.auth?.order, OPENAI_CODEX_PROVIDER_ID);
   if (codexOrder && codexOrder.length > 0) {
-    return dedupe(codexOrder);
+    return { order: dedupe(codexOrder), explicit: true };
   }
-  return resolveAuthProfileOrder({
+  const order = resolveAuthProfileOrder({
     cfg: params.config,
     store: params.store,
     provider: OPENAI_CODEX_PROVIDER_ID,
   });
+  return { order, explicit: hasExplicitOpenAiAuthOrder(params) };
+}
+
+function hasExplicitOpenAiAuthOrder(params: {
+  config: AuthProfileOrderConfig;
+  store: AuthProfileStore;
+}): boolean {
+  const sources = [params.store.order, params.config?.auth?.order];
+  for (const source of sources) {
+    const codex = resolveOrder(source, OPENAI_CODEX_PROVIDER_ID);
+    if (codex && codex.length > 0) {
+      return true;
+    }
+    const openai = resolveOrder(source, OPENAI_PROVIDER_ID);
+    if (openai && openai.length > 0) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function resolveOrder(
@@ -162,6 +187,7 @@ function resolveOrder(
 function resolveActiveProfileId(params: {
   store: AuthProfileStore;
   order: string[];
+  explicitOrder: boolean;
   config: AuthProfileOrderConfig;
   account: SafeValue<JsonValue | undefined>;
   limits: SafeValue<JsonValue | undefined>;
@@ -174,6 +200,26 @@ function resolveActiveProfileId(params: {
   });
   if (liveProfileId) {
     return liveProfileId;
+  }
+  // Explicit auth order (`models auth order set` or `config.auth.order`) is
+  // authoritative for the status display and overrides `lastGood`/usage
+  // heuristics, matching the core `resolveAuthProfileOrder` precedence so the
+  // display does not silently disagree with the runtime resolver.
+  if (params.explicitOrder) {
+    const firstUsable = params.order.find(
+      (profileId) =>
+        isActiveProfileCandidate(params, profileId) &&
+        resolveAuthProfileEligibility({
+          cfg: params.config,
+          store: params.store,
+          provider: OPENAI_CODEX_PROVIDER_ID,
+          profileId,
+          now: params.now,
+        }).eligible,
+    );
+    if (firstUsable) {
+      return firstUsable;
+    }
   }
   const lastGood = [
     params.store.lastGood?.[OPENAI_PROVIDER_ID],

--- a/extensions/codex/src/command-account.ts
+++ b/extensions/codex/src/command-account.ts
@@ -204,7 +204,10 @@ function resolveActiveProfileId(params: {
   // Explicit auth order (`models auth order set` or `config.auth.order`) is
   // authoritative for the status display and overrides `lastGood`/usage
   // heuristics, matching the core `resolveAuthProfileOrder` precedence so the
-  // display does not silently disagree with the runtime resolver.
+  // display does not silently disagree with the runtime resolver. When no
+  // fully-usable candidate exists, anchor to params.order[0] so the display
+  // stays consistent with operator intent rather than deferring to stale
+  // lastGood/mostRecent heuristics that could show a lower-ranked profile.
   if (params.explicitOrder) {
     const firstUsable = params.order.find(
       (profileId) =>
@@ -217,9 +220,7 @@ function resolveActiveProfileId(params: {
           now: params.now,
         }).eligible,
     );
-    if (firstUsable) {
-      return firstUsable;
-    }
+    return firstUsable ?? params.order[0];
   }
   const lastGood = [
     params.store.lastGood?.[OPENAI_PROVIDER_ID],

--- a/extensions/codex/src/command-account.ts
+++ b/extensions/codex/src/command-account.ts
@@ -205,11 +205,10 @@ function resolveActiveProfileId(params: {
   // authoritative for the status display and overrides `lastGood`/usage
   // heuristics, matching the core `resolveAuthProfileOrder` precedence so the
   // display does not silently disagree with the runtime resolver. When no
-  // fully-usable candidate exists, anchor to params.order[0] so the display
-  // stays consistent with operator intent rather than deferring to stale
-  // lastGood/mostRecent heuristics that could show a lower-ranked profile.
+  // fully-usable candidate exists return undefined — marking an ineligible
+  // profile as active would misrepresent what the runtime resolver can use.
   if (params.explicitOrder) {
-    const firstUsable = params.order.find(
+    return params.order.find(
       (profileId) =>
         isActiveProfileCandidate(params, profileId) &&
         resolveAuthProfileEligibility({
@@ -220,7 +219,6 @@ function resolveActiveProfileId(params: {
           now: params.now,
         }).eligible,
     );
-    return firstUsable ?? params.order[0];
   }
   const lastGood = [
     params.store.lastGood?.[OPENAI_PROVIDER_ID],

--- a/extensions/codex/src/commands.test.ts
+++ b/extensions/codex/src/commands.test.ts
@@ -1392,6 +1392,115 @@ describe("codex command", () => {
     expect(safeCodexControlRequest).toHaveBeenCalledTimes(2);
   });
 
+  it("respects openai-alias explicit order over stale lastGood for API key profiles", async () => {
+    const config = {};
+    const now = Date.now();
+    installAuthProfileStore(
+      {
+        version: 1,
+        profiles: {
+          "openai:fresh-key": {
+            type: "api_key",
+            provider: "openai",
+            key: "sk-fresh-111",
+          },
+          "openai:stale-key": {
+            type: "api_key",
+            provider: "openai",
+            key: "sk-stale-222",
+          },
+        },
+        order: {
+          openai: ["openai:fresh-key", "openai:stale-key"],
+        },
+        lastGood: {
+          openai: "openai:stale-key",
+        },
+      },
+      config,
+    );
+
+    const safeCodexControlRequest = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        value: { account: { type: "unknown" }, requiresOpenaiAuth: false },
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        error: "usage data unavailable",
+      });
+
+    const result = await handleCodexCommand(createContext("account", undefined, { config }), {
+      deps: createDeps({ safeCodexControlRequest }),
+    });
+
+    expect(result.text).toContain("\n  1. fresh-key   API key   — active now");
+    expect(result.text).not.toContain("stale-key   API key   — active now");
+    expect(safeCodexControlRequest).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses first explicit-order profile rather than lastGood when all token credentials are expired", async () => {
+    // Both profiles use type:"token" with expired expiry, so resolveAuthProfileEligibility
+    // returns eligible=false for both and firstUsable is undefined. The fix must return
+    // params.order[0] (fresh) rather than falling through to lastGood (stale).
+    const config = {};
+    const now = Date.now();
+    installAuthProfileStore(
+      {
+        version: 1,
+        profiles: {
+          "openai-codex:fresh@example.com": {
+            type: "token",
+            provider: "openai-codex",
+            token: "fresh-token",
+            expires: now - 1000,
+            email: "fresh@example.com",
+          },
+          "openai-codex:stale@example.com": {
+            type: "token",
+            provider: "openai-codex",
+            token: "stale-token",
+            expires: now - 2000,
+            email: "stale@example.com",
+          },
+        },
+        order: {
+          "openai-codex": ["openai-codex:fresh@example.com", "openai-codex:stale@example.com"],
+        },
+        lastGood: {
+          "openai-codex": "openai-codex:stale@example.com",
+        },
+      },
+      config,
+    );
+
+    const safeCodexControlRequest = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        value: { account: { type: "unknown" }, requiresOpenaiAuth: true },
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        error: "rate limits unavailable",
+      });
+
+    const result = await handleCodexCommand(createContext("account", undefined, { config }), {
+      deps: createDeps({ safeCodexControlRequest }),
+    });
+
+    // With explicit order, order[0] (fresh) must be shown as active even though
+    // all credentials are expired. lastGood (stale) must not override the stated
+    // operator rank.
+    expect(result.text).toContain("\n  1. fresh@example.com   ChatGPT subscription   — active now");
+    expect(result.text).toContain(
+      "\n  2. stale@example.com   ChatGPT subscription   — sign-in expired",
+    );
+    expect(result.text).not.toContain("stale@example.com   ChatGPT subscription   — active now");
+    expect(safeCodexControlRequest).toHaveBeenCalledTimes(2);
+  });
+
   it("escapes successful Codex account fallback summaries before chat display", async () => {
     const unsafe = "<@U123> [trusted](https://evil) @here";
     const safeCodexControlRequest = vi

--- a/extensions/codex/src/commands.test.ts
+++ b/extensions/codex/src/commands.test.ts
@@ -1327,6 +1327,71 @@ describe("codex command", () => {
     );
   });
 
+  it("respects explicit Codex auth order over stale lastGood after OAuth re-login", async () => {
+    const config = {};
+    const now = Date.now();
+    installAuthProfileStore(
+      {
+        version: 1,
+        profiles: {
+          "openai-codex:default": {
+            type: "oauth",
+            provider: "openai-codex",
+            access: "stale-access-token",
+            refresh: "stale-refresh-token",
+            expires: now + 2 * 24 * 60 * 60 * 1000,
+            email: "previous@example.com",
+          },
+          "openai-codex:fresh-email@example.com": {
+            type: "oauth",
+            provider: "openai-codex",
+            access: "fresh-access-token",
+            refresh: "fresh-refresh-token",
+            expires: now + 9 * 24 * 60 * 60 * 1000,
+            email: "fresh-email@example.com",
+          },
+        },
+        order: {
+          "openai-codex": ["openai-codex:fresh-email@example.com", "openai-codex:default"],
+        },
+        lastGood: {
+          "openai-codex": "openai-codex:default",
+        },
+      },
+      config,
+    );
+
+    const safeCodexControlRequest = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        value: { account: { type: "unknown" }, requiresOpenaiAuth: true },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        value: codexRateLimitPayload({
+          primaryUsedPercent: 5,
+          secondaryUsedPercent: 10,
+          primaryResetSeconds: Math.ceil(now / 1000) + 60 * 60,
+          secondaryResetSeconds: Math.ceil(now / 1000) + 6 * 60 * 60,
+        }),
+      });
+
+    const result = await handleCodexCommand(createContext("account", undefined, { config }), {
+      deps: createDeps({ safeCodexControlRequest }),
+    });
+
+    expect(result.text).toContain(
+      "\n  1. fresh-email@example.com   ChatGPT subscription   — active now",
+    );
+    expect(result.text).toContain(
+      "\n  2. previous@example.com   ChatGPT subscription   — available if needed",
+    );
+    expect(result.text).not.toContain("previous@example.com   ChatGPT subscription   — active now");
+    expect(result.text).not.toContain("openai-codex:");
+    expect(safeCodexControlRequest).toHaveBeenCalledTimes(2);
+  });
+
   it("escapes successful Codex account fallback summaries before chat display", async () => {
     const unsafe = "<@U123> [trusted](https://evil) @here";
     const safeCodexControlRequest = vi

--- a/extensions/codex/src/commands.test.ts
+++ b/extensions/codex/src/commands.test.ts
@@ -1440,10 +1440,10 @@ describe("codex command", () => {
     expect(safeCodexControlRequest).toHaveBeenCalledTimes(2);
   });
 
-  it("uses first explicit-order profile rather than lastGood when all token credentials are expired", async () => {
+  it("does not mark any profile active when all explicit-order token credentials are expired", async () => {
     // Both profiles use type:"token" with expired expiry, so resolveAuthProfileEligibility
-    // returns eligible=false for both and firstUsable is undefined. The fix must return
-    // params.order[0] (fresh) rather than falling through to lastGood (stale).
+    // returns eligible=false for both. resolveActiveProfileId must return undefined rather
+    // than marking an ineligible profile as active; the display shows "no working credential".
     const config = {};
     const now = Date.now();
     installAuthProfileStore(
@@ -1477,28 +1477,40 @@ describe("codex command", () => {
 
     const safeCodexControlRequest = vi
       .fn()
+      // call 1: account info for the active/first profile
       .mockResolvedValueOnce({
         ok: true,
         value: { account: { type: "unknown" }, requiresOpenaiAuth: true },
       })
+      // call 2: rate limits for the active profile
       .mockResolvedValueOnce({
         ok: false,
         error: "rate limits unavailable",
+      })
+      // call 3: readSubscriptionUsage — no activeProfileId means the subscription
+      // profile (fresh, type:"token") is fetched separately
+      .mockResolvedValueOnce({
+        ok: false,
+        error: "subscription limits unavailable",
       });
 
     const result = await handleCodexCommand(createContext("account", undefined, { config }), {
       deps: createDeps({ safeCodexControlRequest }),
     });
 
-    // With explicit order, order[0] (fresh) must be shown as active even though
-    // all credentials are expired. lastGood (stale) must not override the stated
-    // operator rank.
-    expect(result.text).toContain("\n  1. fresh@example.com   ChatGPT subscription   — active now");
+    // With all credentials expired, no profile is active — the display shows
+    // "no working credential" and both profiles are labelled "sign-in expired".
+    // lastGood (stale) must not override the stated operator rank, and the
+    // first explicit-order entry must not be falsely marked active when ineligible.
+    expect(result.text).toContain("no working credential");
+    expect(result.text).toContain(
+      "\n  1. fresh@example.com   ChatGPT subscription   — sign-in expired",
+    );
     expect(result.text).toContain(
       "\n  2. stale@example.com   ChatGPT subscription   — sign-in expired",
     );
-    expect(result.text).not.toContain("stale@example.com   ChatGPT subscription   — active now");
-    expect(safeCodexControlRequest).toHaveBeenCalledTimes(2);
+    expect(result.text).not.toContain("active now");
+    expect(safeCodexControlRequest).toHaveBeenCalledTimes(3);
   });
 
   it("escapes successful Codex account fallback summaries before chat display", async () => {


### PR DESCRIPTION
### Summary

- **Problem**: After `models auth login --provider openai-codex` writes a fresh named OAuth profile and `models auth order set` puts that fresh profile first, the Codex `/codex account` display still reports the stale `openai-codex:default` profile as "active now". The status display silently disagrees with what the runtime resolver actually picks, leading operators to believe their re-login did not take effect and to perform unnecessary manual auth-store edits.
- **Root Cause**: The Codex extension's display helper `resolveActiveProfileId` in `extensions/codex/src/command-account.ts` short-circuits to `store.lastGood[openai]` / `store.lastGood[openai-codex]` whenever the `lastGood` profile is still in the order and not in cooldown, ignoring where that profile is ranked. This directly contradicts the core resolver `resolveAuthProfileOrder` (in `src/agents/auth-profiles/order.ts`), which explicitly does not let `lastGood` outrank an explicit operator order ("`lastGood` is NOT prioritized — that would defeat round-robin"). The two paths drift after a re-login: runtime picks the first explicit-order profile (the fresh one), the display picks `lastGood` (the stale one).
- **Fix**: Track whether the resolved order originates from an explicit operator source (`store.order` set via `models auth order set`, or `config.auth.order`). When the order is explicit, `resolveActiveProfileId` returns the first profile in that order that is both not in cooldown (`isActiveProfileCandidate`) and credential-eligible (`resolveAuthProfileEligibility`). The `lastGood`/usage-stat heuristics still apply in the absence of an explicit order, so existing default-order behavior is preserved. This aligns the display path with the runtime resolver's already-correct precedence and contains the change entirely inside the Codex extension, without touching the secops-owned `src/agents/auth-profiles/` surface.
- **What changed**:
  - `extensions/codex/src/command-account.ts`: `resolveDisplayAuthOrder` now returns `{ order, explicit }`; a new `hasExplicitOpenAiAuthOrder` helper inspects both `store.order` and `config.auth.order` (for both `openai-codex` and the `openai` alias key); `resolveActiveProfileId` gains an `explicitOrder` parameter and an explicit-order-first branch placed after the live-account check and before the legacy `lastGood`/`mostRecent`/api-key inference heuristics.
  - `extensions/codex/src/commands.test.ts`: adds a regression test `respects explicit Codex auth order over stale lastGood after OAuth re-login` that reproduces the post-relogin store shape (order = `[fresh, default]`, `lastGood = default`, no live Codex session) and asserts the fresh profile is shown as "active now" and that no isolated subscription-usage probe is sent for the stale profile.
- **What did NOT change (scope boundary)**:
  - No edits to `src/agents/auth-profiles/**` (CODEOWNERS secops surface). The fix relies on the core resolver's existing already-correct policy rather than mutating `lastGood` from a different code path.
  - No new config keys, no migration, no doctor/repair behavior, no public SDK surface change.
  - `resolveAuthProfileOrder` semantics and the runtime auth-profile selection (`extensions/codex/src/app-server/auth-bridge.ts` `resolveCodexAppServerAuthProfileId`) are unchanged.
  - Default-order behavior (no explicit `store.order` / `config.auth.order` entry for `openai-codex` or `openai`) is unchanged: `lastGood`, `mostRecent`, and API-key inference still apply.
  - No changes to provider IDs, profile shapes, eligibility logic, cooldown handling, or label/format strings.

### Reproduction

1. Start with an existing `openai-codex:default` OAuth profile near expiry.
2. Run `openclaw models auth login --provider openai-codex` and complete OAuth; the login writes a new named profile, e.g. `openai-codex:<email>`.
3. Run `openclaw models auth order set --provider openai-codex --agent main openai-codex:<email> openai-codex:default`.
4. Without restarting the Codex app-server, run `openclaw /codex account`.

Before the fix, the auth-order table shows `openai-codex:default` as "active now" and the fresh `openai-codex:<email>` profile as merely "available if needed", even though the runtime resolver already prefers the fresh profile.

After the fix, the fresh `openai-codex:<email>` profile is shown as "active now" and the stale `openai-codex:default` profile is shown as "available if needed", matching the runtime resolver.

### Risk / Mitigation

- **Risk**: Changing the display selection could mask a profile that is currently working but transiently misordered, or hide useful failover signal.
- **Mitigation**: The explicit-order branch is strictly narrower than the prior `lastGood` short-circuit:
  - It only activates when an explicit operator order exists (`store.order` or `config.auth.order`). The default round-robin path still consults `lastGood`/`mostRecent`/api-key inference.
  - Within the explicit-order branch, the candidate must pass both `isActiveProfileCandidate` (not in cooldown / unusable) and `resolveAuthProfileEligibility` (credential present, mode and provider compatible). Ineligible or cooldowned explicit-order entries are skipped and the loop falls through to the legacy heuristics, preserving existing failover behavior. The existing test `does not report a blocked last-good subscription as active` continues to pass, demonstrating the fall-through path is intact.
  - The runtime selection path (`resolveCodexAppServerAuthProfileId` -> `resolveAuthProfileOrder()[0]`) is untouched, so this PR cannot change which profile a real model run uses; it only stops the status command from disagreeing with that selection.
  - Full Codex extension test file (`extensions/codex/src/commands.test.ts`, 89 tests) passes locally, including the four pre-existing order/`lastGood` interaction tests. `src/agents/auth-profiles/{order,profiles,display}.test.ts` and the format / lint / `tsgo:extensions` / `tsgo:extensions:test` gates are clean.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Codex extension (`extensions/codex/`)
- [x] Auth / provider routing (display path only; runtime path unchanged)

### Linked Issue/PR

Fixes #84386
