### PR TITLE
fix(gateway): register SIGHUP handler for daemon signal hygiene

### DIFF
--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -127,16 +127,16 @@ openclaw gateway restart --force
 
 The Gateway installs handlers for the signals that are part of the OpenClaw lifecycle contract. Use `openclaw gateway restart` for managed-service restarts; it routes to the Gateway restart path and avoids relying on platform-specific hangup behavior.
 
-| Signal    | Foreground Gateway             | Supervised Gateway (`launchd`, `systemd`, `schtasks`) |
-| --------- | ------------------------------ | ----------------------------------------------------- |
-| `SIGTERM` | Graceful shutdown.             | Graceful shutdown.                                    |
-| `SIGINT`  | Graceful shutdown.             | Graceful shutdown.                                    |
-| `SIGUSR1` | Authorized in-process restart. | Authorized in-process restart.                        |
-| `SIGHUP`  | Logged and ignored.            | Logged and ignored.                                   |
+| Signal    | Foreground Gateway             | Supervised Gateway (`launchd`, `systemd`, `schtasks`)                 |
+| --------- | ------------------------------ | --------------------------------------------------------------------- |
+| `SIGTERM` | Graceful shutdown.             | Graceful shutdown.                                                    |
+| `SIGINT`  | Graceful shutdown.             | Graceful shutdown.                                                    |
+| `SIGUSR1` | Authorized in-process restart. | Authorized in-process restart.                                        |
+| `SIGHUP`  | Graceful shutdown.             | Ignored so terminal hangups do not stop a supervisor-managed Gateway. |
 
 `SIGUSR1` restart requires restart commands to be authorized. `commands.restart` is enabled by default; set `commands.restart: false` to block manual restart while gateway tool, config apply, and update restart paths remain allowed.
 
-On non-Windows platforms, the `SIGHUP` handler removes Node.js default hangup termination, so terminal hangup does not stop the Gateway.
+On non-Windows platforms, the foreground `SIGHUP` handler triggers graceful shutdown instead of Node.js default hangup termination.
 On Windows, Node.js may still be terminated after a console close even when a `SIGHUP` listener runs.
 
 <Warning>

--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -127,14 +127,17 @@ openclaw gateway restart --force
 
 The Gateway installs handlers for the signals that are part of the OpenClaw lifecycle contract. Use `openclaw gateway restart` for managed-service restarts; it routes to the Gateway restart path and avoids relying on platform-specific hangup behavior.
 
-| Signal    | Foreground Gateway                                                                                                                                    | Supervised Gateway (`launchd`, `systemd`, `schtasks`)                 |
-| --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| `SIGTERM` | Graceful shutdown.                                                                                                                                    | Graceful shutdown.                                                    |
-| `SIGINT`  | Graceful shutdown.                                                                                                                                    | Graceful shutdown.                                                    |
-| `SIGUSR1` | Authorized in-process restart.                                                                                                                        | Authorized in-process restart.                                        |
-| `SIGHUP`  | No OpenClaw handler; Node.js default behavior applies. On non-Windows platforms this terminates the process, normally as exit `129` (`128 + SIGHUP`). | Ignored so terminal hangups do not stop a supervisor-managed Gateway. |
+| Signal    | Foreground Gateway             | Supervised Gateway (`launchd`, `systemd`, `schtasks`) |
+| --------- | ------------------------------ | ----------------------------------------------------- |
+| `SIGTERM` | Graceful shutdown.             | Graceful shutdown.                                    |
+| `SIGINT`  | Graceful shutdown.             | Graceful shutdown.                                    |
+| `SIGUSR1` | Authorized in-process restart. | Authorized in-process restart.                        |
+| `SIGHUP`  | Logged and ignored.            | Logged and ignored.                                   |
 
 `SIGUSR1` restart requires restart commands to be authorized. `commands.restart` is enabled by default; set `commands.restart: false` to block manual restart while gateway tool, config apply, and update restart paths remain allowed.
+
+On non-Windows platforms, the `SIGHUP` handler removes Node.js default hangup termination, so terminal hangup does not stop the Gateway.
+On Windows, Node.js may still be terminated after a console close even when a `SIGHUP` listener runs.
 
 <Warning>
 Inline `--password` can be exposed in local process listings. Prefer `--password-file`, env, or a SecretRef-backed `gateway.auth.password`.

--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -44,8 +44,8 @@ openclaw gateway run
     - Binding beyond loopback without auth is blocked (safety guardrail).
     - `lan`, `tailnet`, and `custom` currently resolve over IPv4-only BYOH paths.
     - IPv6-only BYOH is not natively supported on this path today. Use an IPv4 sidecar or proxy if the host itself is IPv6-only.
-    - `SIGUSR1` triggers an in-process restart when authorized (`commands.restart` is enabled by default; set `commands.restart: false` to block manual restart, while gateway tool/config apply/update remain allowed).
-    - `SIGINT`/`SIGTERM` handlers stop the gateway process, but they don't restore any custom terminal state. If you wrap the CLI with a TUI or raw-mode input, restore the terminal before exit.
+    - Process signal behavior is documented in [Process Signals](#process-signals).
+    - `SIGINT`/`SIGTERM` handlers stop the gateway process, but they do not restore any custom terminal state. If you wrap the CLI with a TUI or raw-mode input, restore the terminal before exit.
 
   </Accordion>
 </AccordionGroup>
@@ -122,6 +122,19 @@ openclaw gateway restart --force
 `openclaw gateway restart --safe` asks the running Gateway to preflight active OpenClaw work before restarting. If queued operations, reply delivery, embedded runs, or task runs are active, the Gateway reports the blockers, coalesces duplicate safe restart requests, and restarts once the active work drains. Plain `restart` keeps the existing service-manager behavior for compatibility. Use `--force` only when you explicitly want the immediate override path.
 
 `openclaw gateway restart --safe --skip-deferral` runs the same OpenClaw-aware coordinated restart as `--safe`, but bypasses the active-work deferral gate so the Gateway emits the restart immediately even when blockers are reported. Use it as the operator escape hatch when a deferral has been pinned by a stuck task run and `--safe` alone would wait indefinitely. `--skip-deferral` requires `--safe`.
+
+## Process Signals
+
+The Gateway installs handlers for the signals that are part of the OpenClaw lifecycle contract. Use `openclaw gateway restart` for managed-service restarts; it routes to the Gateway restart path and avoids relying on platform-specific hangup behavior.
+
+| Signal    | Foreground Gateway                                                                                                                                    | Supervised Gateway (`launchd`, `systemd`, `schtasks`)                 |
+| --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| `SIGTERM` | Graceful shutdown.                                                                                                                                    | Graceful shutdown.                                                    |
+| `SIGINT`  | Graceful shutdown.                                                                                                                                    | Graceful shutdown.                                                    |
+| `SIGUSR1` | Authorized in-process restart.                                                                                                                        | Authorized in-process restart.                                        |
+| `SIGHUP`  | No OpenClaw handler; Node.js default behavior applies. On non-Windows platforms this terminates the process, normally as exit `129` (`128 + SIGHUP`). | Ignored so terminal hangups do not stop a supervisor-managed Gateway. |
+
+`SIGUSR1` restart requires restart commands to be authorized. `commands.restart` is enabled by default; set `commands.restart: false` to block manual restart while gateway tool, config apply, and update restart paths remain allowed.
 
 <Warning>
 Inline `--password` can be exposed in local process listings. Prefer `--password-file`, env, or a SecretRef-backed `gateway.auth.password`.

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -394,8 +394,9 @@ describe("runGatewayLoop", () => {
     });
   });
 
-  it("ignores SIGHUP unconditionally", async () => {
+  it("ignores SIGHUP when running under a supervisor", async () => {
     vi.clearAllMocks();
+    detectRespawnSupervisor.mockReturnValue("launchd");
 
     await withIsolatedSignals(async ({ captureSignal }) => {
       const { runtime, exited } = await createSignaledLoopHarness();
@@ -406,9 +407,9 @@ describe("runGatewayLoop", () => {
 
       expect(runtime.exit).not.toHaveBeenCalled();
       expect(gatewayLog.info).toHaveBeenCalledWith(
-        "signal SIGHUP received; ignoring terminal hangup",
+        "signal SIGHUP received; ignoring (launchd supervised daemon survives terminal hangup)",
       );
-      expect(detectRespawnSupervisor).not.toHaveBeenCalled();
+      expect(detectRespawnSupervisor).toHaveBeenCalledTimes(1);
 
       const sigterm = captureSignal("SIGTERM");
       sigterm();
@@ -418,24 +419,25 @@ describe("runGatewayLoop", () => {
     });
   });
 
-  it("handles SIGHUP without supervisor detection", async () => {
+  it("gracefully stops on SIGHUP in foreground (no supervisor)", async () => {
     vi.clearAllMocks();
+    detectRespawnSupervisor.mockReturnValue(null);
 
     await withIsolatedSignals(async ({ captureSignal }) => {
-      const { runtime, exited } = await createSignaledLoopHarness();
+      const { close, runtime, exited } = await createSignaledLoopHarness();
       const sighup = captureSignal("SIGHUP");
 
       sighup();
-      await new Promise<void>((resolve) => setImmediate(resolve));
-
-      expect(runtime.exit).not.toHaveBeenCalled();
-      expect(detectRespawnSupervisor).not.toHaveBeenCalled();
-
-      const sigterm = captureSignal("SIGTERM");
-      sigterm();
 
       await expect(exited).resolves.toBe(0);
+      expect(close).toHaveBeenCalledWith({
+        reason: "gateway stopping",
+        restartExpectedMs: null,
+      });
       expect(runtime.exit).toHaveBeenCalledWith(0);
+      expect(gatewayLog.info).toHaveBeenCalledWith("signal SIGHUP received");
+      expect(gatewayLog.info).toHaveBeenCalledWith("received SIGHUP; shutting down");
+      expect(detectRespawnSupervisor).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -183,7 +183,14 @@ vi.mock("../../logging/subsystem.js", () => ({
   createSubsystemLogger: () => gatewayLog,
 }));
 
-const LOOP_SIGNALS = ["SIGTERM", "SIGINT", "SIGUSR1"] as const;
+const detectRespawnSupervisor = vi.fn<() => "launchd" | "systemd" | "schtasks" | null>(() => null);
+
+vi.mock("../../infra/supervisor-markers.js", () => ({
+  detectRespawnSupervisor: (...args: unknown[]) => detectRespawnSupervisor(...(args as [])),
+  SUPERVISOR_HINT_ENV_VARS: [],
+}));
+
+const LOOP_SIGNALS = ["SIGTERM", "SIGINT", "SIGUSR1", "SIGHUP"] as const;
 type LoopSignal = (typeof LOOP_SIGNALS)[number];
 const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
 
@@ -383,6 +390,50 @@ describe("runGatewayLoop", () => {
         reason: "gateway stopping",
         restartExpectedMs: null,
       });
+      expect(runtime.exit).toHaveBeenCalledWith(0);
+    });
+  });
+
+  it("ignores SIGHUP when running under a supervisor", async () => {
+    vi.clearAllMocks();
+    detectRespawnSupervisor.mockReturnValue("launchd");
+
+    await withIsolatedSignals(async ({ captureSignal }) => {
+      const { runtime, exited } = await createSignaledLoopHarness();
+      const sighup = captureSignal("SIGHUP");
+
+      sighup();
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(runtime.exit).not.toHaveBeenCalled();
+
+      const sigterm = captureSignal("SIGTERM");
+      sigterm();
+
+      await expect(exited).resolves.toBe(0);
+      expect(runtime.exit).toHaveBeenCalledWith(0);
+    });
+  });
+
+  it("does not install SIGHUP handler in foreground (no supervisor)", async () => {
+    vi.clearAllMocks();
+    detectRespawnSupervisor.mockReturnValue(null);
+
+    const existingHupListeners = new Set(
+      process.listeners("SIGHUP") as Array<(...args: unknown[]) => void>,
+    );
+
+    await withIsolatedSignals(async ({ captureSignal }) => {
+      const { runtime, exited } = await createSignaledLoopHarness();
+
+      // SIGHUP listener should NOT be registered when no supervisor is detected
+      const sighupListener = addedSignalListener("SIGHUP", existingHupListeners);
+      expect(sighupListener).toBeNull();
+
+      const sigterm = captureSignal("SIGTERM");
+      sigterm();
+
+      await expect(exited).resolves.toBe(0);
       expect(runtime.exit).toHaveBeenCalledWith(0);
     });
   });
@@ -1311,6 +1362,7 @@ describe("runGatewayLoop", () => {
   it("waits briefly before exiting on launchd supervised restart", async () => {
     vi.clearAllMocks();
     peekGatewaySigusr1RestartReason.mockReturnValue(undefined);
+    detectRespawnSupervisor.mockReturnValue("launchd");
     try {
       setPlatform("darwin");
       process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
@@ -1338,6 +1390,7 @@ describe("runGatewayLoop", () => {
       });
     } finally {
       vi.useRealTimers();
+      detectRespawnSupervisor.mockReturnValue(null);
       delete process.env.OPENCLAW_LAUNCHD_LABEL;
       if (originalPlatformDescriptor) {
         Object.defineProperty(process, "platform", originalPlatformDescriptor);
@@ -1348,6 +1401,7 @@ describe("runGatewayLoop", () => {
   it("carries SIGTERM restart intent reason into launchd supervised handoff", async () => {
     vi.clearAllMocks();
     consumeGatewayRestartIntentPayloadSync.mockReturnValueOnce({ reason: "gateway.restart" });
+    detectRespawnSupervisor.mockReturnValue("launchd");
     try {
       setPlatform("darwin");
       process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
@@ -1372,6 +1426,7 @@ describe("runGatewayLoop", () => {
       });
     } finally {
       vi.useRealTimers();
+      detectRespawnSupervisor.mockReturnValue(null);
       delete process.env.OPENCLAW_LAUNCHD_LABEL;
       if (originalPlatformDescriptor) {
         Object.defineProperty(process, "platform", originalPlatformDescriptor);

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -394,9 +394,8 @@ describe("runGatewayLoop", () => {
     });
   });
 
-  it("ignores SIGHUP when running under a supervisor", async () => {
+  it("ignores SIGHUP unconditionally", async () => {
     vi.clearAllMocks();
-    detectRespawnSupervisor.mockReturnValue("launchd");
 
     await withIsolatedSignals(async ({ captureSignal }) => {
       const { runtime, exited } = await createSignaledLoopHarness();
@@ -406,6 +405,10 @@ describe("runGatewayLoop", () => {
       await new Promise<void>((resolve) => setImmediate(resolve));
 
       expect(runtime.exit).not.toHaveBeenCalled();
+      expect(gatewayLog.info).toHaveBeenCalledWith(
+        "signal SIGHUP received; ignoring terminal hangup",
+      );
+      expect(detectRespawnSupervisor).not.toHaveBeenCalled();
 
       const sigterm = captureSignal("SIGTERM");
       sigterm();
@@ -415,20 +418,18 @@ describe("runGatewayLoop", () => {
     });
   });
 
-  it("does not install SIGHUP handler in foreground (no supervisor)", async () => {
+  it("handles SIGHUP without supervisor detection", async () => {
     vi.clearAllMocks();
-    detectRespawnSupervisor.mockReturnValue(null);
-
-    const existingHupListeners = new Set(
-      process.listeners("SIGHUP") as Array<(...args: unknown[]) => void>,
-    );
 
     await withIsolatedSignals(async ({ captureSignal }) => {
       const { runtime, exited } = await createSignaledLoopHarness();
+      const sighup = captureSignal("SIGHUP");
 
-      // SIGHUP listener should NOT be registered when no supervisor is detected
-      const sighupListener = addedSignalListener("SIGHUP", existingHupListeners);
-      expect(sighupListener).toBeNull();
+      sighup();
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(runtime.exit).not.toHaveBeenCalled();
+      expect(detectRespawnSupervisor).not.toHaveBeenCalled();
 
       const sigterm = captureSignal("SIGTERM");
       sigterm();

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -11,7 +11,6 @@ import {
 import type { startGatewayServer } from "../../gateway/server.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { acquireGatewayLock } from "../../infra/gateway-lock.js";
-import { detectRespawnSupervisor } from "../../infra/supervisor-markers.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
@@ -718,7 +717,7 @@ export async function runGatewayLoop(params: {
     gatewayLog.info("signal SIGINT received");
     request("stop", "SIGINT");
   };
-  const supervisor = detectRespawnSupervisor();
+  const supervisor = eagerLifecycleRuntime.detectRespawnSupervisor();
   const onSighup = () => {
     gatewayLog.info(
       `signal SIGHUP received; ignoring (${supervisor} supervised daemon survives terminal hangup)`,

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -11,6 +11,7 @@ import {
 import type { startGatewayServer } from "../../gateway/server.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { acquireGatewayLock } from "../../infra/gateway-lock.js";
+import { detectRespawnSupervisor } from "../../infra/supervisor-markers.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
@@ -137,6 +138,7 @@ export async function runGatewayLoop(params: {
     process.removeListener("SIGTERM", onSigterm);
     process.removeListener("SIGINT", onSigint);
     process.removeListener("SIGUSR1", onSigusr1);
+    process.removeListener("SIGHUP", onSighup);
   };
   const exitProcess = (code: number) => {
     cleanupSignals();
@@ -716,6 +718,12 @@ export async function runGatewayLoop(params: {
     gatewayLog.info("signal SIGINT received");
     request("stop", "SIGINT");
   };
+  const supervisor = detectRespawnSupervisor();
+  const onSighup = () => {
+    gatewayLog.info(
+      `signal SIGHUP received; ignoring (${supervisor} supervised daemon survives terminal hangup)`,
+    );
+  };
   const onSigusr1 = () => {
     gatewayLog.info("signal SIGUSR1 received");
     void (async () => {
@@ -787,6 +795,9 @@ export async function runGatewayLoop(params: {
   process.on("SIGTERM", onSigterm);
   process.on("SIGINT", onSigint);
   process.on("SIGUSR1", onSigusr1);
+  if (supervisor) {
+    process.on("SIGHUP", onSighup);
+  }
 
   try {
     const onIteration = createRestartIterationHook(async () => {

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -717,11 +717,8 @@ export async function runGatewayLoop(params: {
     gatewayLog.info("signal SIGINT received");
     request("stop", "SIGINT");
   };
-  const supervisor = eagerLifecycleRuntime.detectRespawnSupervisor();
   const onSighup = () => {
-    gatewayLog.info(
-      `signal SIGHUP received; ignoring (${supervisor} supervised daemon survives terminal hangup)`,
-    );
+    gatewayLog.info("signal SIGHUP received; ignoring terminal hangup");
   };
   const onSigusr1 = () => {
     gatewayLog.info("signal SIGUSR1 received");
@@ -794,9 +791,7 @@ export async function runGatewayLoop(params: {
   process.on("SIGTERM", onSigterm);
   process.on("SIGINT", onSigint);
   process.on("SIGUSR1", onSigusr1);
-  if (supervisor) {
-    process.on("SIGHUP", onSighup);
-  }
+  process.on("SIGHUP", onSighup);
 
   try {
     const onIteration = createRestartIterationHook(async () => {

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -120,6 +120,7 @@ export async function runGatewayLoop(params: {
   // here pulls the whole re-export graph (lifecycle.runtime.ts is a 36-line
   // re-export hub) into memory, immune to later disk rotation.
   const eagerLifecycleRuntime = await loadGatewayLifecycleRuntimeModule();
+  const supervisor = eagerLifecycleRuntime.detectRespawnSupervisor();
   let lock = await acquireGatewayLock({ port: params.lockPort });
   let server: Awaited<ReturnType<typeof startGatewayServer>> | null = null;
   let shuttingDown = false;
@@ -718,7 +719,14 @@ export async function runGatewayLoop(params: {
     request("stop", "SIGINT");
   };
   const onSighup = () => {
-    gatewayLog.info("signal SIGHUP received; ignoring terminal hangup");
+    if (supervisor) {
+      gatewayLog.info(
+        `signal SIGHUP received; ignoring (${supervisor} supervised daemon survives terminal hangup)`,
+      );
+      return;
+    }
+    gatewayLog.info("signal SIGHUP received");
+    request("stop", "SIGHUP");
   };
   const onSigusr1 = () => {
     gatewayLog.info("signal SIGUSR1 received");


### PR DESCRIPTION
## Summary

Register a **hybrid** SIGHUP handler in the Gateway run-loop that adapts behavior based on execution context:

- **Supervised** (launchd/systemd/schtasks): SIGHUP is logged and **ignored** — the daemon survives terminal hangup.
- **Foreground** (no supervisor detected): SIGHUP triggers **graceful shutdown** — preserving the current operator expectation that terminal hangup stops the Gateway.

This directly addresses ClawSweeper's v3 review feedback that unconditional ignore changes the foreground lifecycle contract. The handler is always registered (preventing exit 129 crashes), but foreground behavior is preserved.

Closes #84249

## Changes

| File | Change |
|------|--------|
| `run-loop.ts` | `detectRespawnSupervisor()` called once at startup; SIGHUP handler branches on result |
| `run-loop.test.ts` | Two SIGHUP test cases: supervised (ignore) + foreground (graceful shutdown) |
| `gateway.md` | Signal table shows mode-dependent SIGHUP behavior + Windows caveat |

## Signal behavior table (v4)

| Signal | Foreground | Supervised |
|--------|-----------|------------|
| `SIGTERM` | Graceful shutdown | Graceful shutdown |
| `SIGINT` | Graceful shutdown | Graceful shutdown |
| `SIGUSR1` | Authorized restart | Authorized restart |
| `SIGHUP` | **Graceful shutdown** | **Ignored** (daemon survives terminal hangup) |

## Why hybrid is correct

1. **Foreground graceful shutdown**: Users who run `openclaw gateway run` in a terminal expect `kill -HUP` (or terminal hangup) to stop the process. The v4 handler respects this by calling `request("stop", "SIGHUP")` — same clean shutdown path as SIGTERM.

2. **Supervised ignore**: Daemons managed by launchd/systemd/schtasks should survive terminal disconnects. SSH session hangup sends SIGHUP to the process group; a supervised daemon should log and ignore it.

3. **No exit 129 crash**: In all modes, the SIGHUP handler is registered, so Node.js never uses its default termination (exit 129).

## HUP compatibility risk: none

No `kill -HUP` workflow exists in the OpenClaw codebase or documentation:
- Docs define only SIGUSR1=restart, SIGINT/SIGTERM=stop
- `openclaw gateway restart` uses SIGUSR1 internally, not SIGHUP
- Foreground behavior matches what operators already expect (process stops on hangup)

## Real behavior proof

- **Behavior or issue addressed**: Gateway crashes with exit 129 on SIGHUP because no signal handler is registered. The fix adds a hybrid handler: foreground → graceful shutdown, supervised → ignore.

- **Real environment tested**: Docker container (`node:22-bookworm`, Node.js v22.22.3, Linux aarch64), OpenClaw checkout at PR head commit `122d26bb`.

- **Failing proof before fix (baseline)**: On upstream/main, Node.js terminates on SIGHUP with exit code 129 — no handler is registered:
```
=== Test 3: Baseline — upstream/main has NO SIGHUP handler ===
[baseline] PID: 215
[baseline] No SIGHUP handler registered (upstream/main behavior)
[baseline] Waiting for signal...
[test] Sending SIGHUP to PID 215 (no handler)...
run-proof-v4.sh: line 83:   215 Hangup
[test] Process exited with code 129 (expected: 129 = SIGHUP default termination)
```

- **Exact steps run after this patch**:

1. Unit tests in Docker:
```bash
docker exec sighup-proof-v4 bash -c \
  "cd /workspace && node scripts/run-vitest.mjs src/cli/gateway-cli/run-loop.test.ts"
```

2. Live signal delivery proof script (`proof-v4-hybrid.js`) — uses the exact same `detectRespawnSupervisor()` logic and `onSighup` handler pattern from `run-loop.ts`:
```bash
docker exec sighup-proof-v4 bash /workspace/run-proof-v4.sh
```

- **Evidence after fix**:

Unit tests (37/37 passing):
```
 ✓ cli src/cli/gateway-cli/run-loop.test.ts (37 tests) 115ms
 Test Files  1 passed (1)
      Tests  37 passed (37)
```

Live signal delivery — **Test 1: Foreground mode** (SIGHUP → graceful shutdown):
```
[proof] PID: 196
[proof] Supervisor detected: none (foreground mode)
[proof] SIGHUP handler registered. Waiting for signals...
[test] Sending SIGHUP to PID 196...
[gateway] signal SIGHUP received
[gateway] received SIGHUP; shutting down
[gateway] graceful close complete, exiting 0
[test] Process exited with code 0 after SIGHUP (expected: 0)
```

Live signal delivery — **Test 2: Supervised mode** (SIGHUP → ignored, survives):
```
[proof] PID: 205
[proof] Supervisor detected: systemd
[proof] SIGHUP handler registered. Waiting for signals...
[test] Sending SIGHUP to PID 205...
[gateway] signal SIGHUP received; ignoring (systemd supervised daemon survives terminal hangup)
[PASS] Process 205 survived SIGHUP (supervised mode)
[test] Sending second SIGHUP...
[gateway] signal SIGHUP received; ignoring (systemd supervised daemon survives terminal hangup)
[PASS] Process 205 survived second SIGHUP
[test] Now sending SIGTERM...
[gateway] signal SIGTERM received
[gateway] received SIGTERM; shutting down
[gateway] graceful close complete, exiting 0
[test] Process exited with code 0 after SIGTERM (expected: 0)
```

Results summary:
```
Test 1 (foreground SIGHUP → graceful shutdown): exit=0 ✅ PASS
Test 2 (supervised SIGHUP → ignored + SIGTERM):  exit=0 ✅ PASS
Test 3 (baseline no handler → killed):           exit=129 ✅ PASS (exit 129)
```

- **Observed result after fix**: 
  - Foreground: SIGHUP triggers clean graceful shutdown (exit 0), preserving the operator lifecycle contract.
  - Supervised: SIGHUP is logged and ignored; process survives multiple SIGHUPs and cleanly exits on SIGTERM (exit 0).
  - Baseline (no handler): Process terminates with exit 129 (Node.js default SIGHUP termination), confirming the fix is necessary.

- **What was not tested**: Live production Gateway binary receiving SIGHUP during actual SSH disconnect. The signal behavior is validated using the exact same `detectRespawnSupervisor()` logic and `onSighup` handler pattern from `run-loop.ts` with real `kill -HUP` signal delivery in Docker. Windows SIGHUP behavior is documented but not tested (Node.js on Windows may still terminate after console close even with a SIGHUP listener).
