### PR TITLE
fix(cli): keep nodes json stdout clean

### DIFF
--- a/src/cli/json-output-mode.test.ts
+++ b/src/cli/json-output-mode.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { loggingState } from "../logging/state.js";
+import { hasJsonOutputFlag, withConsoleLogsRoutedToStderrForJson } from "./json-output-mode.js";
+
+describe("json output mode", () => {
+  const originalForceStderr = loggingState.forceConsoleToStderr;
+
+  beforeEach(() => {
+    loggingState.forceConsoleToStderr = false;
+  });
+
+  afterEach(() => {
+    loggingState.forceConsoleToStderr = originalForceStderr;
+  });
+
+  it("detects json output flags before argv terminators", () => {
+    expect(hasJsonOutputFlag(["node", "openclaw", "nodes", "list", "--json"])).toBe(true);
+    expect(hasJsonOutputFlag(["node", "openclaw", "nodes", "list", "--json=true"])).toBe(true);
+    expect(hasJsonOutputFlag(["node", "openclaw", "nodes", "--", "--json"])).toBe(false);
+  });
+
+  it("temporarily routes console logs to stderr while json output is being prepared", async () => {
+    const snapshots: boolean[] = [];
+
+    await withConsoleLogsRoutedToStderrForJson(
+      ["node", "openclaw", "nodes", "list", "--json"],
+      async () => {
+        snapshots.push(loggingState.forceConsoleToStderr);
+      },
+    );
+
+    expect(snapshots).toEqual([true]);
+    expect(loggingState.forceConsoleToStderr).toBe(false);
+  });
+
+  it("leaves existing stderr routing enabled after json output preparation", async () => {
+    loggingState.forceConsoleToStderr = true;
+
+    await withConsoleLogsRoutedToStderrForJson(
+      ["node", "openclaw", "nodes", "list", "--json"],
+      async () => {
+        expect(loggingState.forceConsoleToStderr).toBe(true);
+      },
+    );
+
+    expect(loggingState.forceConsoleToStderr).toBe(true);
+  });
+});

--- a/src/cli/nodes-cli/register.ts
+++ b/src/cli/nodes-cli/register.ts
@@ -12,7 +12,7 @@ import { registerNodesPushCommand } from "./register.push.js";
 import { registerNodesScreenCommands } from "./register.screen.js";
 import { registerNodesStatusCommands } from "./register.status.js";
 
-export async function registerNodesCli(program: Command) {
+export async function registerNodesCli(program: Command, argv: readonly string[] = process.argv) {
   const nodes = program
     .command("nodes")
     .description("Manage gateway-owned nodes (pairing, status, invoke, and media)")
@@ -41,10 +41,12 @@ export async function registerNodesCli(program: Command) {
   registerNodesLocationCommands(nodes);
 
   const { registerPluginCliCommandsFromValidatedConfig } = await import("../../plugins/cli.js");
-  await withConsoleLogsRoutedToStderrForJson(process.argv, () =>
-    registerPluginCliCommandsFromValidatedConfig(program, undefined, undefined, {
-      mode: "lazy",
-      primary: "nodes",
-    }),
+  await withConsoleLogsRoutedToStderrForJson(
+    argv,
+    async () =>
+      await registerPluginCliCommandsFromValidatedConfig(program, undefined, undefined, {
+        mode: "lazy",
+        primary: "nodes",
+      }),
   );
 }

--- a/src/cli/program/register.subclis-core.ts
+++ b/src/cli/program/register.subclis-core.ts
@@ -127,11 +127,15 @@ const entrySpecs: readonly CommandGroupDescriptorSpec<SubCliRegistrar>[] = [
       loadModule: () => import("../exec-policy-cli.js"),
       exportName: "registerExecPolicyCli",
     },
-    {
-      commandNames: ["nodes"],
-      loadModule: () => import("../nodes-cli.js"),
-      exportName: "registerNodesCli",
+  ]),
+  {
+    commandNames: ["nodes"],
+    register: async (program, argv) => {
+      const mod = await import("../nodes-cli.js");
+      await mod.registerNodesCli(program, argv);
     },
+  },
+  ...defineImportedProgramCommandGroupSpecs([
     {
       commandNames: ["devices"],
       loadModule: () => import("../devices-cli.js"),

--- a/src/cli/program/register.subclis.test.ts
+++ b/src/cli/program/register.subclis.test.ts
@@ -172,6 +172,12 @@ describe("registerSubCliCommands", () => {
     await program.parseAsync(["nodes", "list"], { from: "user" });
 
     expect(registerNodesCli).toHaveBeenCalledTimes(1);
+    expect(registerNodesCli).toHaveBeenCalledWith(expect.any(Command), [
+      "node",
+      "openclaw",
+      "nodes",
+      "list",
+    ]);
     expect(nodesAction).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
## Summary
- route plugin-registration console logs to stderr while JSON output is being prepared
- pass the original argv into the lazy `nodes` CLI registrar so `openclaw nodes ... --json` gets the same protection as other lazy plugin commands
- add focused coverage for JSON flag detection and lazy subcommand argv forwarding

## Verification
- `git diff --check origin/main...HEAD`
- `pnpm exec oxfmt --check --threads=1 src/cli/json-output-mode.test.ts src/cli/nodes-cli/register.ts src/cli/program/register.subclis-core.ts src/cli/program/register.subclis.test.ts`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/cli/json-output-mode.test.ts src/cli/program/register.subclis.test.ts --reporter=verbose` (21 tests passed)
- `pnpm deadcode:dependencies`
- `pnpm deadcode:unused-files`
- `pnpm deadcode:report:ci:ts-unused`
- `.agents/skills/autoreview/scripts/autoreview --mode branch` (clean: no accepted/actionable findings)
- Testbox-through-Crabbox `tbx_01ks1q2yrpg4xxytr9sjfeq3xt`: `CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_TEST_PROJECTS_PARALLEL=6 OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 node scripts/run-vitest.mjs src/cli/json-output-mode.test.ts src/cli/program/register.subclis.test.ts src/cli/run-main.exit.test.ts` (99 tests passed)
- WSL maintainer CLI proof: `OPENCLAW_GATEWAY_TOKEN=<redacted> OPENCLAW_SKIP_CHANNELS=1 node scripts/run-node.mjs --dev gateway --reset` then `node scripts/run-node.mjs --dev nodes list --json > nodes-list.stdout.json 2> nodes-list.stderr.txt`; command exit 0 and `JSON.parse(nodes-list.stdout.json)` succeeded (`stdoutBytes=36`, keys `pending`, `paired`).
- Testbox-through-Crabbox `tbx_01ks1qfdc3nxmaw1fdabba4n5x`: `CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_TEST_PROJECTS_PARALLEL=6 OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/cli/program.nodes-basic.e2e.test.ts test/cli-json-stdout.e2e.test.ts` (12 tests passed)

Refs #84293

## Real behavior proof
Behavior addressed: `openclaw nodes list --json` no longer lets lazy plugin registration logs write to stdout before JSON output.
Real environment tested: Blacksmith Testbox through Crabbox plus WSL-native maintainer worktree after rebase onto current `origin/main`.
Exact steps or command run after this patch: `OPENCLAW_GATEWAY_TOKEN=<redacted> OPENCLAW_SKIP_CHANNELS=1 node scripts/run-node.mjs --dev gateway --reset` in a temp `OPENCLAW_HOME`, then `node scripts/run-node.mjs --dev nodes list --json > nodes-list.stdout.json 2> nodes-list.stderr.txt`, followed by `JSON.parse(nodes-list.stdout.json)`; also ran the focused unit/e2e/Testbox/deadcode proof listed above.
Evidence after fix: the real CLI run exited 0; stdout was exactly parseable JSON (`stdoutBytes=36`, top-level object keys `pending`, `paired`); stderr contained gateway connection/pairing diagnostics and gateway/plugin startup logs stayed outside stdout. Local focused CLI tests passed 21 tests; the exact previously failing deadcode unused-file shard passed after rebasing onto current `origin/main`; Testbox `tbx_01ks1q2yrpg4xxytr9sjfeq3xt` passed 99 tests; Testbox `tbx_01ks1qfdc3nxmaw1fdabba4n5x` passed 12 e2e tests.
Observed result after fix: `nodes-list.stdout.json` contained only `{ "pending": [], "paired": [] }` and parsed successfully; the non-JSON gateway message `scope upgrade pending approval` appeared on stderr, not stdout. JSON-mode registration temporarily forces console logs to stderr, restores prior logging state afterward, and `nodes` lazy registration receives argv for `--json` detection.
What was not tested: a live LCM plugin install inside the original reporter's agent container was not exercised; the regression is covered through the CLI registration path and existing nodes/json stdout e2e suites.
