### PR TITLE
fix(doctor): honor per-agent bootstrap profile in size check

### DIFF
--- a/src/commands/doctor-bootstrap-size.test.ts
+++ b/src/commands/doctor-bootstrap-size.test.ts
@@ -62,8 +62,22 @@ describe("noteBootstrapFileSize", () => {
         "Total bootstrap injected chars: 20,000 (13% of max/total 150,000).",
         "Total bootstrap raw chars (before truncation): 25,000.",
         "",
-        "- Tip: tune `agents.defaults.bootstrapMaxChars` for per-file limits.",
+        "- Tip: tune `agents.list[].bootstrapMaxChars` for this agent, or `agents.defaults.bootstrapMaxChars` as fallback, for per-file limits.",
       ].join("\n"),
+    );
+  });
+
+  it("threads the default agent id through bootstrap size resolution", async () => {
+    resolveDefaultAgentId.mockReturnValueOnce("custom-agent");
+    resolveBootstrapContextForRun.mockResolvedValue({
+      bootstrapFiles: [],
+      contextFiles: [],
+    });
+    await noteBootstrapFileSize({} as OpenClawConfig);
+    expect(resolveBootstrapMaxChars).toHaveBeenCalledWith(expect.anything(), "custom-agent");
+    expect(resolveBootstrapTotalMaxChars).toHaveBeenCalledWith(expect.anything(), "custom-agent");
+    expect(resolveBootstrapContextForRun).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: "custom-agent" }),
     );
   });
 

--- a/src/commands/doctor-bootstrap-size.ts
+++ b/src/commands/doctor-bootstrap-size.ts
@@ -37,12 +37,14 @@ function formatCauses(causes: Array<"per-file-limit" | "total-limit">): string {
  * Returns the raw budget analysis for tests and callers that need structured evidence.
  */
 export async function noteBootstrapFileSize(cfg: OpenClawConfig) {
-  const workspaceDir = resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg));
-  const bootstrapMaxChars = resolveBootstrapMaxChars(cfg);
-  const bootstrapTotalMaxChars = resolveBootstrapTotalMaxChars(cfg);
+  const defaultAgentId = resolveDefaultAgentId(cfg);
+  const workspaceDir = resolveAgentWorkspaceDir(cfg, defaultAgentId);
+  const bootstrapMaxChars = resolveBootstrapMaxChars(cfg, defaultAgentId);
+  const bootstrapTotalMaxChars = resolveBootstrapTotalMaxChars(cfg, defaultAgentId);
   const { bootstrapFiles, contextFiles } = await resolveBootstrapContextForRun({
     workspaceDir,
     config: cfg,
+    agentId: defaultAgentId,
   });
   const stats = buildBootstrapInjectionStats({
     bootstrapFiles,
@@ -96,10 +98,14 @@ export async function noteBootstrapFileSize(cfg: OpenClawConfig) {
     lines.push("");
   }
   if (needsPerFileTip) {
-    lines.push("- Tip: tune `agents.defaults.bootstrapMaxChars` for per-file limits.");
+    lines.push(
+      "- Tip: tune `agents.list[].bootstrapMaxChars` for this agent, or `agents.defaults.bootstrapMaxChars` as fallback, for per-file limits.",
+    );
   }
   if (needsTotalTip) {
-    lines.push("- Tip: tune `agents.defaults.bootstrapTotalMaxChars` for total-budget limits.");
+    lines.push(
+      "- Tip: tune `agents.list[].bootstrapTotalMaxChars` for this agent, or `agents.defaults.bootstrapTotalMaxChars` as fallback, for total-budget limits.",
+    );
   }
 
   note(lines.join("\n"), "Bootstrap file size");

--- a/src/flows/doctor-core-checks.test.ts
+++ b/src/flows/doctor-core-checks.test.ts
@@ -878,3 +878,43 @@ describe("CORE_HEALTH_CHECKS", () => {
     );
   });
 });
+
+describe("core/doctor/bootstrap-size", () => {
+  let tmp: string | undefined;
+
+  afterEach(async () => {
+    if (tmp !== undefined) {
+      await fs.rm(tmp, { recursive: true, force: true });
+      tmp = undefined;
+    }
+  });
+
+  it("honors the per-agent bootstrapMaxChars override in health findings", async () => {
+    tmp = await fs.mkdtemp(join(tmpdir(), "openclaw-health-bootstrap-"));
+    // This size fits the global default but exceeds the default agent's effective budget.
+    await fs.writeFile(join(tmp, "AGENTS.md"), "a".repeat(15_000), "utf-8");
+
+    const check = getCheck(CORE_HEALTH_CHECKS, "core/doctor/bootstrap-size");
+    const findings = await check.detect({
+      mode: "lint",
+      runtime,
+      cfg: {
+        agents: {
+          defaults: {
+            workspace: tmp,
+            bootstrapMaxChars: 20_000,
+          },
+          list: [{ id: "custom-agent", default: true, bootstrapMaxChars: 10_000 }],
+        },
+      },
+    });
+
+    expect(findings).toContainEqual(
+      expect.objectContaining({
+        checkId: "core/doctor/bootstrap-size",
+        severity: "warning",
+        message: expect.stringContaining("AGENTS.md"),
+      }),
+    );
+  });
+});

--- a/src/flows/doctor-core-checks.test.ts
+++ b/src/flows/doctor-core-checks.test.ts
@@ -914,6 +914,7 @@ describe("core/doctor/bootstrap-size", () => {
         checkId: "core/doctor/bootstrap-size",
         severity: "warning",
         message: expect.stringContaining("AGENTS.md"),
+        fixHint: expect.stringContaining("agents.list[].bootstrapMaxChars"),
       }),
     );
   });

--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -464,18 +464,20 @@ const bootstrapSizeCheck: HealthCheck = {
     const { resolveBootstrapContextForRun } = await import("../agents/bootstrap-files.js");
     const { resolveBootstrapMaxChars, resolveBootstrapTotalMaxChars } =
       await import("../agents/embedded-agent-helpers.js");
-    const workspaceDir = resolveAgentWorkspaceDir(ctx.cfg, resolveDefaultAgentId(ctx.cfg));
+    const defaultAgentId = resolveDefaultAgentId(ctx.cfg);
+    const workspaceDir = resolveAgentWorkspaceDir(ctx.cfg, defaultAgentId);
     const { bootstrapFiles, contextFiles } = await resolveBootstrapContextForRun({
       workspaceDir,
       config: ctx.cfg,
+      agentId: defaultAgentId,
     });
     const analysis = analyzeBootstrapBudget({
       files: buildBootstrapInjectionStats({
         bootstrapFiles,
         injectedFiles: contextFiles,
       }),
-      bootstrapMaxChars: resolveBootstrapMaxChars(ctx.cfg),
-      bootstrapTotalMaxChars: resolveBootstrapTotalMaxChars(ctx.cfg),
+      bootstrapMaxChars: resolveBootstrapMaxChars(ctx.cfg, defaultAgentId),
+      bootstrapTotalMaxChars: resolveBootstrapTotalMaxChars(ctx.cfg, defaultAgentId),
     });
     const findings: HealthFinding[] = [];
     for (const file of analysis.truncatedFiles) {
@@ -484,7 +486,8 @@ const bootstrapSizeCheck: HealthCheck = {
         severity: "warning",
         message: `${file.name} exceeds bootstrap limits and will be truncated.`,
         path: file.path,
-        fixHint: "Reduce the file size or tune agents.defaults.bootstrapMaxChars/TotalMaxChars.",
+        fixHint:
+          "Reduce the file size or tune `agents.list[].bootstrapMaxChars` for this agent, or `agents.defaults.bootstrapMaxChars` as fallback, for per-file limits.",
       });
     }
     for (const file of analysis.nearLimitFiles) {
@@ -496,7 +499,8 @@ const bootstrapSizeCheck: HealthCheck = {
         severity: "info",
         message: `${file.name} is near the configured bootstrap file limit.`,
         path: file.path,
-        fixHint: "Reduce the file size or tune agents.defaults.bootstrapMaxChars.",
+        fixHint:
+          "Reduce the file size or tune `agents.list[].bootstrapMaxChars` for this agent, or `agents.defaults.bootstrapMaxChars` as fallback, for per-file limits.",
       });
     }
     if (analysis.totalNearLimit) {
@@ -505,7 +509,8 @@ const bootstrapSizeCheck: HealthCheck = {
         severity: analysis.hasTruncation ? "warning" : "info",
         message: "Total bootstrap context is near the configured total limit.",
         path: workspaceDir,
-        fixHint: "Reduce bootstrap file sizes or tune agents.defaults.bootstrapTotalMaxChars.",
+        fixHint:
+          "Reduce bootstrap file sizes or tune `agents.list[].bootstrapTotalMaxChars` for this agent, or `agents.defaults.bootstrapTotalMaxChars` as fallback.",
       });
     }
     return findings;

--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -487,7 +487,7 @@ const bootstrapSizeCheck: HealthCheck = {
         message: `${file.name} exceeds bootstrap limits and will be truncated.`,
         path: file.path,
         fixHint:
-          "Reduce the file size or tune `agents.list[].bootstrapMaxChars` for this agent, or `agents.defaults.bootstrapMaxChars` as fallback, for per-file limits.",
+          "Reduce the file size or tune `agents.list[].bootstrapMaxChars` / `bootstrapTotalMaxChars` for this agent, or the corresponding `agents.defaults.*` fallback.",
       });
     }
     for (const file of analysis.nearLimitFiles) {


### PR DESCRIPTION
> AI-assisted: drafted with Claude Code. Bug discovery, fix, regression test, and behavior-proof reproducer all verified by the author on Windows 11 + Node 24.

## Summary

- Problem: `openclaw doctor` reports bootstrap-file-size warnings against the
  global `agents.defaults.bootstrap*MaxChars` budget even when the active
  default agent has a per-agent override under `agents.list[].bootstrap*MaxChars`,
  so the percentages, near-limit flags, and remediation tips are wrong for
  any setup that uses the per-agent profile feature added in #69966.
- Solution: thread the resolved `defaultAgentId` into the three call sites in
  `noteBootstrapFileSize` so the per-agent override is honored consistently
  with the rest of the runtime (`prepareCliRunContext`, `runEmbeddedAttempt`,
  `compactEmbeddedPiSessionDirectOnce`, and `/context` reporting), and update
  the remediation tip text to point at both the per-agent and defaults knobs.
- What changed: `src/commands/doctor-bootstrap-size.ts` resolves
  `defaultAgentId` once and passes it to `resolveBootstrapMaxChars`,
  `resolveBootstrapTotalMaxChars`, and `resolveBootstrapContextForRun`; the
  two truncation tips now mention `agents.list[].bootstrap*MaxChars` first
  with `agents.defaults.*` as fallback. `src/commands/doctor-bootstrap-size.test.ts`
  gains a regression test that asserts the agent id is threaded through, and
  the existing tip-text assertion is updated.
- What did NOT change (scope boundary): no behavior change for setups that
  rely solely on `agents.defaults.*` (the per-agent resolver falls back to
  defaults). No changes to budget math, warning thresholds, doctor command
  wiring, or other call sites (those were already correct after #69966).
  Doctor still inspects only the default agent's workspace; covering
  non-default agents is out of scope for this fix.

## Motivation

`feat(agents): support per-agent bootstrap profiles` (#69966, commit
`930852af29`) added `bootstrapMaxChars` / `bootstrapTotalMaxChars` /
`contextInjection` overrides under `agents.list[]` and threaded the resolved
session agent id through the embedded runner, CLI runner, compaction path,
and `/context` diagnostics. `noteBootstrapFileSize` in
`src/commands/doctor-bootstrap-size.ts` was missed in that thread-through, so
`openclaw doctor` still resolves only `agents.defaults.bootstrap*MaxChars`.

For users who configure a tighter or looser per-agent override, `openclaw
doctor` either over- or under-warns and the remediation tip points the user
at the wrong knob. The "Real behavior proof" section below shows three
scenarios producing identical wrong output on `origin/main` vs three
correctly differentiated outputs after this patch.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #69966 (introduced per-agent bootstrap profiles; this PR fills in
  the doctor call site missed by that thread-through)
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

Behavior addressed: `openclaw doctor`'s `Bootstrap file size` note reports
percentages and remediation tips against `agents.defaults.bootstrap*MaxChars`
even when the default agent has a per-agent override set, so the reported
percent-of-max and tip wording do not match the budget the runtime actually
uses.

Real environment tested:
- OS: Windows 11 Enterprise 10.0.26200
- Runtime: Node v24.14.1, pnpm 11.1.0 (corepack-pinned at `package.json`)
- Workspace: temp dir with a 25 000-char `AGENTS.md` to force truncation
- Config: default agent `main`, `agents.defaults.bootstrapMaxChars = 20 000`
  (`Total = 100 000`), `agents.list[main].bootstrapMaxChars` set per scenario

Exact steps or command run after this patch:

```text
# Reproducer that imports noteBootstrapFileSize directly and captures stdout
# (the same code path openclaw doctor executes; the doctor command calls
# noteBootstrapFileSize from src/flows/doctor-health-contributions.ts:573).
# Running it against this branch yields the AFTER output below; checking out
# main first yields the BEFORE output (also captured below for comparison).
node --import tsx repro.local.mjs
```

Evidence after fix:

```text
=== A: defaults-only (defaultsMax=20000) ===
◇  Bootstrap file size ─────────────────────────────────────────────────╮
│  Workspace bootstrap files exceed limits and will be truncated:       │
│  - AGENTS.md: 25,000 raw / 19,999 injected (20% truncated; max/file)  │
│  Total bootstrap injected chars: 19,999 (20% of max/total 100,000).   │
│  Total bootstrap raw chars (before truncation): 25,000.               │
│  - Tip: tune `agents.list[].bootstrapMaxChars` for this agent, or     │
│    `agents.defaults.bootstrapMaxChars` as fallback, for per-file      │
│    limits.                                                            │
├───────────────────────────────────────────────────────────────────────╯

=== B: per-agent LARGER (perAgentMax=40000, defaultsMax=20000) ===
(no warning emitted)

=== C: per-agent SMALLER (perAgentMax=10000, defaultsMax=20000) ===
◇  Bootstrap file size ────────────────────────────────────────────────╮
│  Workspace bootstrap files exceed limits and will be truncated:      │
│  - AGENTS.md: 25,000 raw / 9,999 injected (60% truncated; max/file)  │
│  Total bootstrap injected chars: 9,999 (10% of max/total 100,000).   │
│  Total bootstrap raw chars (before truncation): 25,000.              │
│  - Tip: tune `agents.list[].bootstrapMaxChars` for this agent, or    │
│    `agents.defaults.bootstrapMaxChars` as fallback, for per-file     │
│    limits.                                                           │
├──────────────────────────────────────────────────────────────────────╯
```

Before-fix output (origin/main version of `doctor-bootstrap-size.ts`, same
reproducer, same temp workspace) — included for comparison:

```text
=== A: defaults-only (defaultsMax=20000) ===
◇  Bootstrap file size ──────────────────────────────────────────────────╮
│  Workspace bootstrap files exceed limits and will be truncated:        │
│  - AGENTS.md: 25,000 raw / 19,999 injected (20% truncated; max/file)   │
│  Total bootstrap injected chars: 19,999 (20% of max/total 100,000).    │
│  Total bootstrap raw chars (before truncation): 25,000.                │
│  - Tip: tune `agents.defaults.bootstrapMaxChars` for per-file limits.  │
├────────────────────────────────────────────────────────────────────────╯

=== B: per-agent LARGER (perAgentMax=40000, defaultsMax=20000) ===
◇  Bootstrap file size ──────────────────────────────────────────────────╮
│  Workspace bootstrap files exceed limits and will be truncated:        │
│  - AGENTS.md: 25,000 raw / 19,999 injected (20% truncated; max/file)   │
│  Total bootstrap injected chars: 19,999 (20% of max/total 100,000).    │
│  Total bootstrap raw chars (before truncation): 25,000.                │
│  - Tip: tune `agents.defaults.bootstrapMaxChars` for per-file limits.  │
├────────────────────────────────────────────────────────────────────────╯

=== C: per-agent SMALLER (perAgentMax=10000, defaultsMax=20000) ===
◇  Bootstrap file size ──────────────────────────────────────────────────╮
│  Workspace bootstrap files exceed limits and will be truncated:        │
│  - AGENTS.md: 25,000 raw / 19,999 injected (20% truncated; max/file)   │
│  Total bootstrap injected chars: 19,999 (20% of max/total 100,000).    │
│  Total bootstrap raw chars (before truncation): 25,000.                │
│  - Tip: tune `agents.defaults.bootstrapMaxChars` for per-file limits.  │
├────────────────────────────────────────────────────────────────────────╯
```

On `origin/main`, all three scenarios render the SAME warning (20% truncated
against the 20 000-char defaults budget) because the per-agent override is
silently dropped before reaching the resolver. After this patch, scenarios B
and C correctly reflect the per-agent override.

Observed result after fix:
- Scenario A is unchanged (defaults-only setup): same `20% / 20 000` numbers.
- Scenario B (per-agent budget LARGER than defaults) now stays silent — the
  file fits in the 40 000-char per-agent budget.
- Scenario C (per-agent budget SMALLER than defaults) now reports `60%
  truncated at 10 000` instead of `20% at 20 000`, matching the budget the
  runtime actually enforces.
- Both truncation tips now point at the per-agent knob first.

What was not tested:
- Non-default agents (out of scope — doctor still inspects only the default
  agent's workspace; covering additional agents would be a separate change).
- The heartbeat / cron `contextInjection` mode path (already covered by the
  existing `resolveContextInjectionMode` tests in `bootstrap-files.test.ts`).
- Live `openclaw doctor` CLI invocation against a populated state dir — the
  reproducer exercises the same `noteBootstrapFileSize` entry point that
  `src/flows/doctor-health-contributions.ts:573` calls, with the same module
  graph, so the rendered output above is what `openclaw doctor` prints.

## Root Cause

- Root cause: `noteBootstrapFileSize` was authored before #69966 and was
  not updated when that PR turned `resolveBootstrapMaxChars`,
  `resolveBootstrapTotalMaxChars`, and `resolveBootstrapContextForRun` into
  agent-aware resolvers. The other call sites in the embedded runner
  (`runEmbeddedAttempt`), CLI runner (`prepareCliRunContext`), compaction
  (`compactEmbeddedPiSessionDirectOnce`), and `/context` reporting were
  threaded; the doctor warning path was not.
- Missing detection / guardrail: the existing tests mocked the resolver
  functions but did not assert what arguments they were called with, so the
  regression passed silently.
- Contributing context: each resolver defaults `agentId` to `undefined`,
  which collapses cleanly to `agents.defaults.*` — the bug is silent rather
  than a runtime error, which is why it slipped through code review and
  CI on #69966.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/commands/doctor-bootstrap-size.test.ts`
- Scenario the test should lock in: when `resolveDefaultAgentId` returns a
  specific agent id, `noteBootstrapFileSize` passes that same agent id into
  `resolveBootstrapMaxChars`, `resolveBootstrapTotalMaxChars`, and
  `resolveBootstrapContextForRun`.
- Why this is the smallest reliable guardrail: the bug is purely a missed
  argument at the call site. Asserting call arguments catches it without
  needing fixtures for the resolver internals (which are already covered by
  `pi-embedded-helpers.buildbootstrapcontextfiles.test.ts` and
  `bootstrap-files.test.ts`).
- Existing test that already covers this: none — the existing tests asserted
  on the rendered warning string but did not pin the call arguments, so the
  same string was emitted regardless of whether `agentId` was forwarded.
- If no new test is added, why not: N/A — a new test (`threads the default
  agent id through bootstrap size resolution`) is added in this PR.

## User-visible / Behavior Changes

For users who set `agents.list[].bootstrapMaxChars` or
`agents.list[].bootstrapTotalMaxChars` on the default agent:

- `openclaw doctor` percent-of-max numbers in the `Bootstrap file size`
  warning now reflect the per-agent override rather than the global default.
- The two remediation tips now read "Tip: tune
  `agents.list[].bootstrapMaxChars` for this agent, or
  `agents.defaults.bootstrapMaxChars` as fallback, for per-file limits."
  (previously mentioned only the defaults knob).

For users who only use `agents.defaults.*`: no behavior change (the per-agent
resolver falls back to defaults; see Scenario A in the proof section).

## Diagram

N/A — single call-site fix.

## Security Impact

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Windows 11 Enterprise (10.0.26200)
- Runtime: Node v24.14.1, pnpm 11.1.0 (corepack-pinned)
- Model/provider: N/A (doctor command path; no model invocation)
- Integration/channel (if any): N/A
- Relevant config (redacted): default agent `main` with
  `agents.list[main].bootstrapMaxChars` set lower or higher than
  `agents.defaults.bootstrapMaxChars` to surface the discrepancy.

### Steps

1. Configure `agents.list[main].bootstrapMaxChars` differently from
   `agents.defaults.bootstrapMaxChars` in the OpenClaw config.
2. Place a bootstrap file (e.g. `AGENTS.md`) in the default agent's workspace
   sized to land between the two budgets (or above both).
3. Run `openclaw doctor` and inspect the `Bootstrap file size` note.

### Expected

Percent-of-max and tip text reflect `agents.list[main].bootstrap*MaxChars`
when the per-agent override exists, and `agents.defaults.*` otherwise.

### Actual (before this patch)

Percent-of-max and tip text always reflect `agents.defaults.bootstrap*MaxChars`,
silently ignoring the per-agent override (see Scenario B and C in the proof
section above).

## Evidence

- [x] Failing test/log before + passing after (`src/commands/doctor-bootstrap-size.test.ts`)
- [x] Trace/log snippets (rendered `Bootstrap file size` notes above)
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Local validation log:

```text
# format check
$ pnpm format:check src/commands/doctor-bootstrap-size.ts src/commands/doctor-bootstrap-size.test.ts
Checking formatting...
All matched files use the correct format.

# lint
$ pnpm exec oxlint --type-aware src/commands/doctor-bootstrap-size.ts src/commands/doctor-bootstrap-size.test.ts
Found 0 warnings and 0 errors.

# typecheck
$ pnpm tsgo:core
(no errors)

# focused tests
$ node scripts/run-vitest.mjs src/commands/doctor-bootstrap-size.test.ts
 Test Files  1 passed (1)
      Tests  3 passed (3)

# regression test fails on origin/main (without the .ts fix)
$ git checkout main -- src/commands/doctor-bootstrap-size.ts
$ node scripts/run-vitest.mjs src/commands/doctor-bootstrap-size.test.ts
 Test Files  1 failed (1)
      Tests  2 failed | 1 passed (3)
# (asserts on resolveBootstrapMaxChars and resolveBootstrapContextForRun
# argument lists fail because the agent id is dropped before the call.)
```

## Human Verification

- Verified scenarios:
  - Defaults-only configuration: behavior unchanged (Scenario A above).
  - Per-agent budget LARGER than defaults: doctor correctly stays silent
    (Scenario B above; on `main` it falsely warned).
  - Per-agent budget SMALLER than defaults: doctor correctly reports the
    tighter per-agent budget (Scenario C above; on `main` it reported
    against the looser defaults budget).
  - Regression test fails on `origin/main` and passes after the fix.
- Edge cases checked: `resolveDefaultAgentId` returning a non-`"main"` id
  (covered by the new unit test); per-agent override absent / present;
  near-limit vs hard truncation; truncation cause attribution (`per-file-limit`
  vs `total-limit`).
- What I did **not** verify:
  - Non-default agents in a multi-agent config — `noteBootstrapFileSize`
    inspects only the default agent's workspace, so covering other agents
    is a separate change.
  - Live `openclaw doctor` against a fully provisioned state dir — the
    reproducer above exercises the same entry point with the same module
    graph (`src/flows/doctor-health-contributions.ts:573` is the call site
    in the doctor flow), so the rendered output matches what `openclaw
    doctor` would print.

## Review Conversations

- [x] I will reply to or resolve every bot review conversation I address in this PR.
- [x] I will leave unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Risks and Mitigations

- Risk: a third call site of `resolveBootstrapMaxChars`,
  `resolveBootstrapTotalMaxChars`, `resolveBootstrapContextForRun`, or
  `resolveContextInjectionMode` still drops the agent id.
  - Mitigation: a repo-wide grep for those four symbols confirms the doctor
    path (`src/commands/doctor-bootstrap-size.ts`) was the only remaining
    call site without an agent id after #69966. All other call sites in
    `src/agents/cli-runner/prepare.ts`, `src/agents/pi-embedded-runner/run/attempt.ts`,
    `src/agents/pi-embedded-runner/compact.ts`, and
    `src/auto-reply/reply/commands-context-report.ts` were threaded by #69966.
- Risk: tip text wording change breaks a downstream string assertion.
  - Mitigation: the existing assertion in `doctor-bootstrap-size.test.ts` was
    the only string-level assertion on the tip text in this repo (grep on
    "Tip: tune"); it is updated in this PR.
