### PR TITLE
refactor(gateway): remove unused readLastMessagePreviewFromTranscript helper

### DIFF
--- a/src/gateway/session-utils.fs.test.ts
+++ b/src/gateway/session-utils.fs.test.ts
@@ -9,7 +9,6 @@ import { clearSessionTranscriptIndexCache } from "./session-transcript-index.fs.
 import {
   archiveSessionTranscripts,
   readFirstUserMessageFromTranscript,
-  readLastMessagePreviewFromTranscript,
   readLatestSessionUsageFromTranscript,
   readLatestSessionUsageFromTranscriptAsync,
   readLatestRecentSessionUsageFromTranscriptAsync,
@@ -275,176 +274,6 @@ describe("readFirstUserMessageFromTranscript", () => {
   });
 });
 
-describe("readLastMessagePreviewFromTranscript", () => {
-  let tmpDir: string;
-  let storePath: string;
-
-  registerTempSessionStore("openclaw-session-fs-test-", (nextTmpDir, nextStorePath) => {
-    tmpDir = nextTmpDir;
-    storePath = nextStorePath;
-  });
-
-  test("returns null for empty file", () => {
-    const sessionId = "test-last-empty";
-    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
-    fs.writeFileSync(transcriptPath, "", "utf-8");
-
-    const result = readLastMessagePreviewFromTranscript(sessionId, storePath);
-    expect(result).toBeNull();
-  });
-
-  test.each([
-    {
-      sessionId: "test-last-user",
-      lines: [
-        JSON.stringify({ message: { role: "user", content: "First user" } }),
-        JSON.stringify({ message: { role: "assistant", content: "First assistant" } }),
-        JSON.stringify({ message: { role: "user", content: "Last user message" } }),
-      ],
-      expected: "Last user message",
-    },
-    {
-      sessionId: "test-last-assistant",
-      lines: [
-        JSON.stringify({ message: { role: "user", content: "User question" } }),
-        JSON.stringify({ message: { role: "assistant", content: "Final assistant reply" } }),
-      ],
-      expected: "Final assistant reply",
-    },
-  ] as const)(
-    "returns the last user or assistant message from transcript for $sessionId",
-    ({ sessionId, lines, expected }) => {
-      const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
-      fs.writeFileSync(transcriptPath, lines.join("\n"), "utf-8");
-      const result = readLastMessagePreviewFromTranscript(sessionId, storePath);
-      expect(result).toBe(expected);
-    },
-  );
-
-  test("skips system messages to find last user/assistant", () => {
-    const sessionId = "test-last-skip-system";
-    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
-    const lines = [
-      JSON.stringify({ message: { role: "user", content: "Real last" } }),
-      JSON.stringify({ message: { role: "system", content: "System at end" } }),
-    ];
-    fs.writeFileSync(transcriptPath, lines.join("\n"), "utf-8");
-
-    const result = readLastMessagePreviewFromTranscript(sessionId, storePath);
-    expect(result).toBe("Real last");
-  });
-
-  test("returns null when no user/assistant messages exist", () => {
-    const sessionId = "test-last-no-match";
-    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
-    const lines = [
-      JSON.stringify({ type: "session", version: 1, id: sessionId }),
-      JSON.stringify({ message: { role: "system", content: "Only system" } }),
-    ];
-    fs.writeFileSync(transcriptPath, lines.join("\n"), "utf-8");
-
-    const result = readLastMessagePreviewFromTranscript(sessionId, storePath);
-    expect(result).toBeNull();
-  });
-
-  test("handles malformed JSON lines gracefully (last preview)", () => {
-    const sessionId = "test-last-malformed";
-    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
-    const lines = [
-      JSON.stringify({ message: { role: "user", content: "Valid first" } }),
-      "not valid json at end",
-    ];
-    fs.writeFileSync(transcriptPath, lines.join("\n"), "utf-8");
-
-    const result = readLastMessagePreviewFromTranscript(sessionId, storePath);
-    expect(result).toBe("Valid first");
-  });
-
-  test.each([
-    {
-      sessionId: "test-last-array",
-      message: {
-        role: "assistant",
-        content: [{ type: "text", text: "Array content response" }],
-      },
-      expected: "Array content response",
-    },
-    {
-      sessionId: "test-last-output-text",
-      message: {
-        role: "assistant",
-        content: [{ type: "output_text", text: "Output text response" }],
-      },
-      expected: "Output text response",
-    },
-  ] as const)(
-    "handles array/output_text content format for $sessionId",
-    ({ sessionId, message, expected }) => {
-      const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
-      fs.writeFileSync(transcriptPath, JSON.stringify({ message }), "utf-8");
-      const result = readLastMessagePreviewFromTranscript(sessionId, storePath);
-      expect(result, sessionId).toBe(expected);
-    },
-  );
-
-  test("skips empty content to find previous message", () => {
-    const sessionId = "test-last-skip-empty";
-    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
-    const lines = [
-      JSON.stringify({ message: { role: "assistant", content: "Has content" } }),
-      JSON.stringify({ message: { role: "user", content: "" } }),
-    ];
-    fs.writeFileSync(transcriptPath, lines.join("\n"), "utf-8");
-
-    const result = readLastMessagePreviewFromTranscript(sessionId, storePath);
-    expect(result).toBe("Has content");
-  });
-
-  test("reads from end of large file (16KB window)", () => {
-    const sessionId = "test-last-large";
-    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
-    const padding = JSON.stringify({ message: { role: "user", content: "x".repeat(500) } });
-    const lines: string[] = [];
-    for (let i = 0; i < 30; i++) {
-      lines.push(padding);
-    }
-    lines.push(JSON.stringify({ message: { role: "assistant", content: "Last in large file" } }));
-    fs.writeFileSync(transcriptPath, lines.join("\n"), "utf-8");
-
-    const result = readLastMessagePreviewFromTranscript(sessionId, storePath);
-    expect(result).toBe("Last in large file");
-  });
-
-  test("handles valid UTF-8 content", () => {
-    const sessionId = "test-last-utf8";
-    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
-    const validLine = JSON.stringify({
-      message: { role: "user", content: "Valid UTF-8: 你好世界 🌍" },
-    });
-    fs.writeFileSync(transcriptPath, validLine, "utf-8");
-
-    const result = readLastMessagePreviewFromTranscript(sessionId, storePath);
-    expect(result).toBe("Valid UTF-8: 你好世界 🌍");
-  });
-
-  test("strips inline directives from last preview text", () => {
-    const sessionId = "test-last-strip-inline-directives";
-    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
-    const lines = [
-      JSON.stringify({
-        message: {
-          role: "assistant",
-          content: "Hello [[reply_to_current]] world [[audio_as_voice]]",
-        },
-      }),
-    ];
-    fs.writeFileSync(transcriptPath, lines.join("\n"), "utf-8");
-
-    const result = readLastMessagePreviewFromTranscript(sessionId, storePath);
-    expect(result).toBe("Hello  world");
-  });
-});
-
 describe("shared transcript read behaviors", () => {
   let tmpDir: string;
   let storePath: string;
@@ -456,13 +285,11 @@ describe("shared transcript read behaviors", () => {
 
   test("returns null for missing transcript files", () => {
     expect(readFirstUserMessageFromTranscript("missing-session", storePath)).toBeNull();
-    expect(readLastMessagePreviewFromTranscript("missing-session", storePath)).toBeNull();
   });
 
   test("uses sessionFile overrides when provided", () => {
     const sessionId = "test-shared-custom";
     const firstPath = path.join(tmpDir, "custom-first.jsonl");
-    const lastPath = path.join(tmpDir, "custom-last.jsonl");
 
     fs.writeFileSync(
       firstPath,
@@ -472,37 +299,22 @@ describe("shared transcript read behaviors", () => {
       ].join("\n"),
       "utf-8",
     );
-    fs.writeFileSync(
-      lastPath,
-      JSON.stringify({ message: { role: "assistant", content: "Custom file last" } }),
-      "utf-8",
-    );
 
     expect(readFirstUserMessageFromTranscript(sessionId, storePath, firstPath)).toBe(
       "Custom file message",
-    );
-    expect(readLastMessagePreviewFromTranscript(sessionId, storePath, lastPath)).toBe(
-      "Custom file last",
     );
   });
 
   test("trims whitespace in extracted previews", () => {
     const firstSessionId = "test-shared-first-trim";
-    const lastSessionId = "test-shared-last-trim";
 
     fs.writeFileSync(
       path.join(tmpDir, `${firstSessionId}.jsonl`),
       JSON.stringify({ message: { role: "user", content: "  Padded message  " } }),
       "utf-8",
     );
-    fs.writeFileSync(
-      path.join(tmpDir, `${lastSessionId}.jsonl`),
-      JSON.stringify({ message: { role: "assistant", content: "  Padded response  " } }),
-      "utf-8",
-    );
 
     expect(readFirstUserMessageFromTranscript(firstSessionId, storePath)).toBe("Padded message");
-    expect(readLastMessagePreviewFromTranscript(lastSessionId, storePath)).toBe("Padded response");
   });
 });
 

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -1113,27 +1113,6 @@ async function readLastMessagePreviewFromOpenTranscriptAsync(params: {
   return null;
 }
 
-export function readLastMessagePreviewFromTranscript(
-  sessionId: string,
-  storePath: string | undefined,
-  sessionFile?: string,
-  agentId?: string,
-): string | null {
-  const filePath = findExistingTranscriptPath(sessionId, storePath, sessionFile, agentId);
-  if (!filePath) {
-    return null;
-  }
-
-  return withOpenTranscriptFd(filePath, (fd) => {
-    const stat = fs.fstatSync(fd);
-    const size = stat.size;
-    if (size === 0) {
-      return null;
-    }
-    return readLastMessagePreviewFromOpenTranscript({ fd, size });
-  });
-}
-
 type SessionTranscriptUsageSnapshot = {
   modelProvider?: string;
   model?: string;

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -105,7 +105,6 @@ export {
   attachOpenClawTranscriptMeta,
   capArrayByJsonBytes,
   readFirstUserMessageFromTranscript,
-  readLastMessagePreviewFromTranscript,
   readLatestSessionUsageFromTranscriptAsync,
   readLatestRecentSessionUsageFromTranscriptAsync,
   readRecentSessionUsageFromTranscriptAsync,


### PR DESCRIPTION
## Summary

- Problem: The helper function `readLastMessagePreviewFromTranscript` in `src/gateway/session-utils.fs.ts` (re-exported in `src/gateway/session-utils.ts`) was unused throughout the gateway codebase. Other files use the more efficient, cached `readSessionTitleFieldsFromTranscript` (or its async version) to retrieve previews.
- Solution: Removed `readLastMessagePreviewFromTranscript` and its export.
- What changed:
  - Removed the unused `readLastMessagePreviewFromTranscript` implementation in `src/gateway/session-utils.fs.ts`.
  - Removed the re-export of `readLastMessagePreviewFromTranscript` in `src/gateway/session-utils.ts`.
  - Removed tests and references to `readLastMessagePreviewFromTranscript` from `src/gateway/session-utils.fs.test.ts`.
- What did NOT change (scope boundary): Inner helper methods like `readLastMessagePreviewFromOpenTranscript` remain unchanged as they are still utilized by other session-utils helpers.

## Motivation

Explain why this change should exist now. Link it to the user pain, failure mode, maintainer need, or product goal. If this is purely mechanical, write `N/A`.

- Deleting dead code simplifies the codebase, prevents future misuse, and reduces overall maintainer debt.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #
- [ ] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Dead/unused `readLastMessagePreviewFromTranscript` helper function inside session-utils.
- Real environment tested: Local development environment running Node.js 22.22.0 on Windows 10 Pro with pnpm workspaces.
- Exact steps or command run after this patch:
  1. Ran the local gateway unit tests to ensure all other transcript helpers function correctly:
     `pnpm test src/gateway/session-utils.fs.test.ts --run`
  2. Verified that the main OpenClaw CLI builds, boots, and can successfully query session statuses:
     `pnpm openclaw status`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):
  1. Running the live `pnpm openclaw status` command successfully queries the status and outputs without any module or export resolution crashes:
  ```
  $ pnpm openclaw status
  OpenClaw status

  Overview
  +----------------------+-----------------------------------------------------------------------------------------------+
  | Item                 | Value                                                                                         |
  +----------------------+-----------------------------------------------------------------------------------------------+
  | OS                   | windows 10.0.26200 (x64) · node 22.22.0                                                       |
  | Dashboard            | http://127.0.0.1:18789/                                                                       |
  | Tailscale exposure   | off                                                                                           |
  | Channel              | dev (cleanup/unused-read-last-message-preview)                                                |
  | Git                  | cleanup/unused-read-last-message-preview · @ 82c58741                                         |
  | Update               | git cleanup/unused-read-last-message-preview · ↔ origin/cleanup/unused-read-last-message-     |
  |                      | preview · up to date · fetch failed · npm latest 2026.5.18 (local newer) · deps ok            |
  | Gateway              | local · ws://127.0.0.1:18789 (local loopback) · unreachable (connect ECONNREFUSED 127.0.0.     |
  |                      | 1:18789)                                                                                      |
  | Gateway service      | Scheduled Task not installed                                                                  |
  | Node service         | Scheduled Task not installed                                                                  |
  | Agents               | 1 · no bootstrap files · sessions 1 · default main active 5d ago                              |
  | Memory               | enabled (plugin memory-core) · not checked                                                    |
  | Plugin compatibility | none                                                                                          |
  | Probes               | skipped (use --deep)                                                                          |
  | Events               | none                                                                                          |
  | Tasks                | none                                                                                          |
  | Heartbeat            | 30m (main)                                                                                    |
  | Sessions             | 1 active · default gpt-5.5 (200k ctx) · ~\.openclaw\agents\main\sessions\sessions.json        |
  +----------------------+-----------------------------------------------------------------------------------------------+
  ```

  2. Terminal output from the Vitest run showing 72 passing tests:
  ```
  [test] starting test/vitest/vitest.gateway.config.ts

   RUN  v4.1.6 D:/openclaw


   Test Files  1 passed (1)
        Tests  72 passed (72)
     Start at  11:56:22
     Duration  9.75s (transform 971ms, setup 805ms, import 7.16s, tests 1.24s, environment 0ms)

  [test] passed 1 Vitest shard in 26.34s
  ```
- Observed result after fix: The `pnpm openclaw status` command successfully compiled and returned the correct state of the repository under the `cleanup/unused-read-last-message-preview` branch. The test suite completed successfully and verified all 72 remaining test cases pass without references to the deleted helper.
- What was not tested: None.

## Root Cause (if applicable)

- Root cause: N/A
- Missing detection / guardrail: N/A
- Contributing context (if known): N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/gateway/session-utils.fs.test.ts`
- Scenario the test should lock in: Ensure remaining session helpers retrieve previews and summary fields exactly as before.
- Why this is the smallest reliable guardrail: Direct unit testing of the remaining methods.
- Existing test that already covers this (if any): Yes, the remaining 72 tests in `session-utils.fs.test.ts` cover these cases.
- If no new test is added, why not: N/A (We deleted code and tests that were specific to the deleted helper).

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: win32 10.0.26200
- Runtime/container: Node.js 22.19.0
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Run `pnpm test src/gateway/session-utils.fs.test.ts --run`

### Expected

- All remaining unit tests pass with no references to the removed helper.

### Actual

- All 72 tests passed successfully.

## Evidence

Attach at least one:

- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: Ran local Vitest gateway tests on session-utils.fs to verify 100% success on the remaining active code.
- Edge cases checked: Double checked that `readLastMessagePreviewFromTranscript` is not referenced anywhere else in core packages or the plugin-sdk.
- What you did **not** verify: None.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Risks and Mitigations

None.
