### PR TITLE
Audit openclaw config backups for plaintext secrets

### DIFF
--- a/docs/gateway/secrets.md
+++ b/docs/gateway/secrets.md
@@ -511,7 +511,7 @@ Default operator flow:
   <Accordion title="secrets audit">
     Findings include:
 
-    - plaintext values at rest (`openclaw.json`, `auth-profiles.json`, `.env`, and generated `agents/*/agent/models.json`)
+    - plaintext values at rest (`openclaw.json`, adjacent `openclaw.json.*` backups, `auth-profiles.json`, `.env`, and generated `agents/*/agent/models.json`)
     - plaintext sensitive provider header residues in generated `models.json` entries
     - unresolved refs
     - precedence shadowing (`auth-profiles.json` taking priority over `openclaw.json` refs)

--- a/src/secrets/audit.test.ts
+++ b/src/secrets/audit.test.ts
@@ -251,6 +251,34 @@ describe("secrets audit", () => {
     expectFindingCode(report, "PLAINTEXT_FOUND");
   });
 
+  it("reports plaintext secrets left in openclaw.json backup files", async () => {
+    const backupPath = path.join(path.dirname(fixture.configPath), "openclaw.json.bak");
+    await writeJsonFile(backupPath, {
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://api.openai.com/v1",
+            api: "openai-completions",
+            apiKey: "sk-backup-plaintext", // pragma: allowlist secret
+            models: [{ id: "gpt-5", name: "gpt-5" }],
+          },
+        },
+      },
+    });
+
+    const report = await runSecretsAudit({ env: fixture.env });
+    expect(
+      hasFinding(
+        report,
+        (entry) =>
+          entry.code === "PLAINTEXT_FOUND" &&
+          entry.file === backupPath &&
+          entry.jsonPath === "models.providers.openai.apiKey",
+      ),
+    ).toBe(true);
+    expect(report.filesScanned).toContain(backupPath);
+  });
+
   it("does not mutate legacy auth.json during audit", async () => {
     await fs.rm(fixture.authStorePath, { force: true });
     await writeJsonFile(fixture.authJsonPath, {

--- a/src/secrets/audit.ts
+++ b/src/secrets/audit.ts
@@ -30,6 +30,7 @@ import {
 } from "./secret-value.js";
 import { isNonEmptyString, isRecord } from "./shared.js";
 import {
+  listConfigBackupPaths,
   listAgentModelsJsonPaths,
   listAuthProfileStorePaths,
   listLegacyAuthJsonPaths,
@@ -257,6 +258,56 @@ function collectConfigSecrets(params: {
       message: `${target.path} is stored as plaintext.`,
       provider: target.providerId,
     });
+  }
+}
+
+function collectConfigBackupSecrets(params: {
+  configPath: string;
+  collector: AuditCollector;
+}): void {
+  for (const backupPath of listConfigBackupPaths(params.configPath)) {
+    params.collector.filesScanned.add(backupPath);
+    const parsedResult = readJsonObjectIfExists(backupPath);
+    if (parsedResult.error) {
+      addFinding(params.collector, {
+        code: "REF_UNRESOLVED",
+        severity: "error",
+        file: backupPath,
+        jsonPath: "<root>",
+        message: `Invalid JSON in config backup: ${parsedResult.error}`,
+      });
+      continue;
+    }
+    const parsed = parsedResult.value;
+    if (!parsed) {
+      continue;
+    }
+    for (const target of discoverConfigSecretTargets(parsed as OpenClawConfig)) {
+      if (!target.entry.includeInAudit) {
+        continue;
+      }
+      if (
+        target.entry.id === "models.providers.*.headers.*" &&
+        !isLikelySensitiveModelProviderHeaderName(target.pathSegments.at(-1) ?? "")
+      ) {
+        continue;
+      }
+      const hasPlaintext = hasConfiguredPlaintextSecretValue(
+        target.value,
+        target.entry.expectedResolvedValue,
+      );
+      if (!hasPlaintext) {
+        continue;
+      }
+      addFinding(params.collector, {
+        code: "PLAINTEXT_FOUND",
+        severity: "warn",
+        file: backupPath,
+        jsonPath: target.path,
+        message: `${target.path} is stored as plaintext in a config backup.`,
+        provider: target.providerId,
+      });
+    }
   }
 }
 
@@ -674,6 +725,10 @@ export async function runSecretsAudit(
   if (snapshot.valid) {
     collectConfigSecrets({
       config,
+      configPath,
+      collector,
+    });
+    collectConfigBackupSecrets({
       configPath,
       collector,
     });

--- a/src/secrets/storage-scan.ts
+++ b/src/secrets/storage-scan.ts
@@ -37,6 +37,26 @@ export function listLegacyAuthJsonPaths(stateDir: string): string[] {
   return out;
 }
 
+export function listConfigBackupPaths(configPath: string): string[] {
+  const resolvedConfigPath = resolveUserPath(configPath);
+  const configDir = path.dirname(resolvedConfigPath);
+  const configName = path.basename(resolvedConfigPath);
+  if (!fs.existsSync(configDir)) {
+    return [];
+  }
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(configDir, { withFileTypes: true })) {
+    if (!entry.isFile()) {
+      continue;
+    }
+    if (!entry.name.startsWith(`${configName}.`)) {
+      continue;
+    }
+    out.push(path.join(configDir, entry.name));
+  }
+  return out.toSorted();
+}
+
 function resolveActiveAgentDir(stateDir: string, env: NodeJS.ProcessEnv = process.env): string {
   const override = env.OPENCLAW_AGENT_DIR?.trim() || env.PI_CODING_AGENT_DIR?.trim();
   if (override) {


### PR DESCRIPTION
## Summary
- scan adjacent openclaw.json.* backup files during secrets audit
- report plaintext secret-bearing config values left in those backups
- document backup scanning in the secrets audit docs

## Real behavior proof
- Behavior or issue addressed: Secrets audit now covers plaintext secrets left behind in adjacent config backup files such as openclaw.json.bak, not only the live openclaw.json file.
- Real environment tested: Local OpenClaw checkout on macOS, using the repository code after this patch with a temporary OPENCLAW_STATE_DIR and OPENCLAW_CONFIG_PATH.
- Exact steps or command run after this patch: Ran a local node/tsx command that created a temporary OpenClaw state directory, wrote a clean openclaw.json, wrote an adjacent openclaw.json.bak containing a redacted demo provider key, called runSecretsAudit(), and printed the backup-specific findings.
- Evidence after fix: Terminal output from the patched audit run:

```json
{
  "status": "findings",
  "plaintextCount": 1,
  "backupScanned": true,
  "backupFindings": [
    {
      "code": "PLAINTEXT_FOUND",
      "jsonPath": "models.providers.openai.apiKey",
      "message": "models.providers.openai.apiKey is stored as plaintext in a config backup."
    }
  ]
}
```

- Observed result after fix: The audit scanned the backup path and emitted a PLAINTEXT_FOUND finding for models.providers.openai.apiKey in openclaw.json.bak.
- What was not tested: No known gaps.

## Validation
- pnpm exec vitest run src/secrets/audit.test.ts --config test/vitest/vitest.secrets.config.ts
- pnpm exec oxlint src/secrets/storage-scan.ts src/secrets/audit.ts src/secrets/audit.test.ts
- git diff --check

Fixes part of #11829 by covering the config-backup residue surface called out in the roadmap discussion.
