### PR TITLE
[AI-assisted] fix(cron): preserve legacy array stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 - Codex: give `image_generate` dynamic-tool calls a 120s default watchdog when no per-call or configured image timeout is set, so image generation no longer falls back to the generic 30s bridge timeout. (#84254) Thanks @moritzmmayerhofer.
 - Codex: avoid duplicate dynamic tool terminal diagnostics while large diagnostic backlogs drain without blocking tool responses. (#82937) Thanks @galiniliev.
 - CLI/message: include a stable top-level `messageId` in `openclaw message --json` output when channel sends return one. (#84191) Thanks @100menotu001.
+- Cron: preserve legacy top-level array `jobs.json` stores when loading or adding scheduled jobs so old cron jobs are no longer treated as an empty store during upgrade. Fixes #60799. (#84433) Thanks @IWhatsskill.
 - Gateway/agents: use an agent's `identity.name` in Gateway agent summaries when `agents.list[].name` is unset, so configured agent labels remain visible in clients. (#84355; refs #57835) Thanks @luoyanglang.
 - Plugins/hooks: apply a default 30-second timeout to `before_compaction` and `after_compaction` hooks so a hung plugin handler no longer blocks compaction completion. (#84153)
 - Discord: preserve disabled presentation buttons when adapting and rendering Discord message controls. (#84188) Thanks @100menotu001.

--- a/src/commands/doctor-cron.test.ts
+++ b/src/commands/doctor-cron.test.ts
@@ -80,6 +80,11 @@ async function writeCronStore(storePath: string, jobs: Array<Record<string, unkn
   );
 }
 
+async function writeLegacyCronArrayStore(storePath: string, jobs: Array<Record<string, unknown>>) {
+  await fs.mkdir(path.dirname(storePath), { recursive: true });
+  await fs.writeFile(storePath, JSON.stringify(jobs, null, 2), "utf-8");
+}
+
 async function readPersistedJobs(storePath: string): Promise<Array<Record<string, unknown>>> {
   const persisted = JSON.parse(await fs.readFile(storePath, "utf-8")) as {
     jobs: Array<Record<string, unknown>>;
@@ -296,6 +301,29 @@ describe("maybeRepairLegacyCronStore", () => {
     expect(payload.kind).toBe("systemEvent");
     expect(payload.text).toBe("Morning brief");
 
+    expectNoteContaining("Legacy cron job storage detected", "Cron");
+    expectNoteContaining("Cron store normalized", "Doctor changes");
+  });
+
+  it("repairs legacy top-level array cron stores instead of treating them as empty (#60799)", async () => {
+    const storePath = await makeTempStorePath();
+    await writeLegacyCronArrayStore(storePath, [createLegacyCronJob()]);
+
+    await maybeRepairLegacyCronStore({
+      cfg: createCronConfig(storePath),
+      options: {},
+      prompter: makePrompter(true),
+    });
+
+    const persisted = JSON.parse(await fs.readFile(storePath, "utf-8")) as {
+      version?: unknown;
+      jobs?: Array<Record<string, unknown>>;
+    };
+    const job = requirePersistedJob(persisted.jobs ?? [], 0);
+    expect(persisted.version).toBe(1);
+    expect(job.jobId).toBeUndefined();
+    expect(job.id).toBe("legacy-job");
+    expect(job.notify).toBeUndefined();
     expectNoteContaining("Legacy cron job storage detected", "Cron");
     expectNoteContaining("Cron store normalized", "Doctor changes");
   });

--- a/src/cron/service/ops.test.ts
+++ b/src/cron/service/ops.test.ts
@@ -6,7 +6,7 @@ import { findTaskByRunId, resetTaskRegistryForTests } from "../../tasks/task-reg
 import { setupCronServiceSuite, writeCronStoreSnapshot } from "../service.test-harness.js";
 import { loadCronStore } from "../store.js";
 import type { CronJob } from "../types.js";
-import { run, start, stop, update } from "./ops.js";
+import { add, run, start, stop, update } from "./ops.js";
 import { createCronServiceState } from "./state.js";
 import { runMissedJobs } from "./timer.js";
 
@@ -101,6 +101,11 @@ async function writeDueIsolatedJobSnapshot(storePath: string, now: number) {
   });
 }
 
+async function writeLegacyCronArraySnapshot(storePath: string, jobs: CronJob[]) {
+  await fs.mkdir(path.dirname(storePath), { recursive: true });
+  await fs.writeFile(storePath, JSON.stringify(jobs, null, 2), "utf-8");
+}
+
 async function expectDueIsolatedManualRunProgresses(storePath: string, now: number) {
   const state = createOkIsolatedCronState({ storePath, now, summary: "done" });
 
@@ -153,6 +158,59 @@ function createMissedIsolatedJob(now: number): CronJob {
 }
 
 describe("cron service ops seam coverage", () => {
+  it("preserves legacy top-level array jobs when adding a new job (#60799)", async () => {
+    const { storePath } = await makeStorePath();
+    const now = Date.parse("2026-05-20T08:00:00.000Z");
+    const legacyJobs: CronJob[] = [
+      {
+        id: "legacy-alpha",
+        name: "legacy alpha",
+        enabled: true,
+        createdAtMs: now - 120_000,
+        updatedAtMs: now - 120_000,
+        schedule: { kind: "every", everyMs: 3_600_000 },
+        sessionTarget: "main",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "systemEvent", text: "alpha" },
+        state: { nextRunAtMs: now + 3_600_000 },
+      },
+      {
+        id: "legacy-beta",
+        name: "legacy beta",
+        enabled: true,
+        createdAtMs: now - 60_000,
+        updatedAtMs: now - 60_000,
+        schedule: { kind: "every", everyMs: 7_200_000 },
+        sessionTarget: "main",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "systemEvent", text: "beta" },
+        state: { nextRunAtMs: now + 7_200_000 },
+      },
+    ];
+    await writeLegacyCronArraySnapshot(storePath, legacyJobs);
+    const state = createOkIsolatedCronState({ storePath, now });
+
+    const newJob = await add(state, {
+      name: "new after upgrade",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 10_800_000 },
+      sessionTarget: "main",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "systemEvent", text: "new" },
+    });
+    if (state.timer) {
+      clearTimeout(state.timer);
+    }
+
+    const loaded = await loadCronStore(storePath);
+    const raw = JSON.parse(await fs.readFile(storePath, "utf-8")) as {
+      jobs: Array<Record<string, unknown>>;
+    };
+
+    expect(loaded.jobs.map((job) => job.id)).toEqual(["legacy-alpha", "legacy-beta", newJob.id]);
+    expect(raw.jobs.map((job) => job.id)).toEqual(["legacy-alpha", "legacy-beta", newJob.id]);
+  });
+
   it("start marks interrupted running jobs failed, persists, and arms the timer", async () => {
     const { storePath } = await makeStorePath();
     const now = Date.parse("2026-03-23T12:00:00.000Z");

--- a/src/cron/store.test.ts
+++ b/src/cron/store.test.ts
@@ -136,6 +136,66 @@ describe("cron store", () => {
     expect(loaded.jobs[0]?.enabled).toBe(true);
   });
 
+  it("loads legacy top-level array stores instead of treating them as empty", async () => {
+    const store = await makeStorePath();
+    const first = makeStore("legacy-array-1", true).jobs[0];
+    const second = makeStore("legacy-array-2", false).jobs[0];
+    await fs.mkdir(path.dirname(store.storePath), { recursive: true });
+    await fs.writeFile(
+      store.storePath,
+      JSON.stringify([first, "bad-row", null, second], null, 2),
+      "utf-8",
+    );
+
+    const loaded = await loadCronStore(store.storePath);
+
+    expect(loaded.version).toBe(1);
+    expect(loaded.jobs.map((job) => job.id)).toEqual(["legacy-array-1", "legacy-array-2"]);
+    expect(loaded.jobs[0]?.state).toStrictEqual(first.state);
+    expect(loaded.jobs[1]?.enabled).toBe(false);
+  });
+
+  it("loads legacy top-level array stores synchronously", async () => {
+    const store = await makeStorePath();
+    const job = makeStore("legacy-array-sync", true).jobs[0];
+    await fs.mkdir(path.dirname(store.storePath), { recursive: true });
+    await fs.writeFile(store.storePath, JSON.stringify([job], null, 2), "utf-8");
+
+    const loaded = loadCronStoreSync(store.storePath);
+
+    expect(loaded.jobs).toHaveLength(1);
+    expect(loaded.jobs[0]?.id).toBe("legacy-array-sync");
+    expect(loaded.jobs[0]?.state).toStrictEqual(job.state);
+  });
+
+  it("preserves legacy top-level array jobs through a load-add-save round trip", async () => {
+    const store = await makeStorePath();
+    const legacy = makeStore("legacy-array-preserved", true).jobs[0];
+    legacy.state = { nextRunAtMs: legacy.createdAtMs + 60_000 };
+    const added = makeStore("new-job", true).jobs[0];
+    await fs.mkdir(path.dirname(store.storePath), { recursive: true });
+    await fs.writeFile(store.storePath, JSON.stringify([legacy], null, 2), "utf-8");
+
+    const loaded = await loadCronStore(store.storePath);
+    loaded.jobs.push(added);
+    await saveCronStore(store.storePath, loaded);
+
+    const config = JSON.parse(await fs.readFile(store.storePath, "utf-8")) as {
+      version?: unknown;
+      jobs?: Array<Record<string, unknown>>;
+    };
+    const stateFile = JSON.parse(
+      await fs.readFile(store.storePath.replace(/\.json$/, "-state.json"), "utf-8"),
+    ) as { jobs: Record<string, { state?: Record<string, unknown> }> };
+
+    expect(config.version).toBe(1);
+    expect(config.jobs?.map((job) => job.id)).toEqual(["legacy-array-preserved", "new-job"]);
+    expect(config.jobs?.[0]?.state).toStrictEqual({});
+    expect(stateFile.jobs["legacy-array-preserved"]?.state?.nextRunAtMs).toBe(
+      legacy.createdAtMs + 60_000,
+    );
+  });
+
   it("skips non-object persisted jobs instead of hydrating scalar rows", async () => {
     const store = await makeStorePath();
     const valid = makeStore("job-valid", true).jobs[0];

--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -54,6 +54,18 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
+function normalizeCronStoreFile(parsed: unknown): CronStoreFile {
+  const rawJobs = Array.isArray(parsed)
+    ? parsed
+    : isRecord(parsed) && Array.isArray(parsed.jobs)
+      ? parsed.jobs
+      : [];
+  return {
+    version: 1,
+    jobs: rawJobs.filter(isRecord) as never as CronStoreFile["jobs"],
+  };
+}
+
 function stripRuntimeOnlyCronFields(store: CronStoreFile): unknown {
   return {
     version: store.version,
@@ -156,10 +168,7 @@ function loadStateFileSync(statePath: string): CronStateFile | null {
 
 function hasInlineState(jobs: Array<Record<string, unknown> | null | undefined>): boolean {
   return jobs.some(
-    (job) =>
-      job != null &&
-      isRecord(job.state) &&
-      Object.keys(job.state).length > 0,
+    (job) => job != null && isRecord(job.state) && Object.keys(job.state).length > 0,
   );
 }
 
@@ -215,23 +224,13 @@ export async function loadCronStore(storePath: string): Promise<CronStoreFile> {
         cause: err,
       });
     }
-    const parsedRecord =
-      parsed && typeof parsed === "object" && !Array.isArray(parsed)
-        ? (parsed as Record<string, unknown>)
-        : {};
-    const jobs = Array.isArray(parsedRecord.jobs)
-      ? (parsedRecord.jobs.filter(isRecord) as never[])
-      : [];
-    const store = {
-      version: 1 as const,
-      jobs: jobs.filter(Boolean) as never as CronStoreFile["jobs"],
-    };
+    const store = normalizeCronStoreFile(parsed);
+    const jobs = store.jobs as unknown as Array<Record<string, unknown>>;
 
     // Load state file and merge.
     const statePath = resolveStatePath(storePath);
     const stateFile = await loadStateFile(statePath);
-    const hasLegacyInlineState =
-      !stateFile && hasInlineState(jobs as unknown as Array<Record<string, unknown>>);
+    const hasLegacyInlineState = !stateFile && hasInlineState(jobs);
 
     if (stateFile) {
       // State file exists: merge state by job ID. Inline state in jobs.json is ignored.
@@ -285,21 +284,11 @@ export function loadCronStoreSync(storePath: string): CronStoreFile {
         cause: err,
       });
     }
-    const parsedRecord =
-      parsed && typeof parsed === "object" && !Array.isArray(parsed)
-        ? (parsed as Record<string, unknown>)
-        : {};
-    const jobs = Array.isArray(parsedRecord.jobs)
-      ? (parsedRecord.jobs.filter(isRecord) as never[])
-      : [];
-    const store = {
-      version: 1 as const,
-      jobs: jobs.filter(Boolean) as never as CronStoreFile["jobs"],
-    };
+    const store = normalizeCronStoreFile(parsed);
+    const jobs = store.jobs as unknown as Array<Record<string, unknown>>;
 
     const stateFile = loadStateFileSync(resolveStatePath(storePath));
-    const hasLegacyInlineState =
-      !stateFile && hasInlineState(jobs as unknown as Array<Record<string, unknown>>);
+    const hasLegacyInlineState = !stateFile && hasInlineState(jobs);
 
     if (stateFile) {
       for (const job of store.jobs) {

--- a/src/gateway/server.cron.test.ts
+++ b/src/gateway/server.cron.test.ts
@@ -527,6 +527,85 @@ describe("gateway server cron", () => {
     }
   });
 
+  test("cron.add preserves legacy top-level array stores (#60799)", async () => {
+    const { prevSkipCron } = await setupCronTestRun({
+      tempPrefix: "openclaw-gw-cron-legacy-array-",
+      cronEnabled: false,
+    });
+    const storePath = testState.cronStorePath;
+    expect(typeof storePath).toBe("string");
+    const now = Date.parse("2026-05-20T08:00:00.000Z");
+    await fs.writeFile(
+      storePath as string,
+      JSON.stringify(
+        [
+          {
+            id: "gw-legacy-alpha",
+            name: "gateway legacy alpha",
+            enabled: true,
+            createdAtMs: now - 120_000,
+            updatedAtMs: now - 120_000,
+            schedule: { kind: "every", everyMs: 3_600_000 },
+            sessionTarget: "main",
+            wakeMode: "next-heartbeat",
+            payload: { kind: "systemEvent", text: "alpha" },
+            state: { nextRunAtMs: now + 3_600_000 },
+          },
+          {
+            id: "gw-legacy-beta",
+            name: "gateway legacy beta",
+            enabled: true,
+            createdAtMs: now - 60_000,
+            updatedAtMs: now - 60_000,
+            schedule: { kind: "every", everyMs: 7_200_000 },
+            sessionTarget: "main",
+            wakeMode: "next-heartbeat",
+            payload: { kind: "systemEvent", text: "beta" },
+            state: { nextRunAtMs: now + 7_200_000 },
+          },
+        ],
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+    const cronState = await createDirectCronState();
+
+    try {
+      const addRes = await directCronReq(cronState, "cron.add", {
+        name: "gateway new after upgrade",
+        enabled: true,
+        schedule: { kind: "every", everyMs: 10_800_000 },
+        sessionTarget: "main",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "systemEvent", text: "new" },
+      });
+      const newJobId = expectCronJobIdFromResponse(addRes);
+
+      const persisted = JSON.parse(await fs.readFile(storePath as string, "utf-8")) as {
+        version?: unknown;
+        jobs?: Array<Record<string, unknown>>;
+      };
+      expect(persisted.version).toBe(1);
+      expect(persisted.jobs?.map((job) => job.id)).toEqual([
+        "gw-legacy-alpha",
+        "gw-legacy-beta",
+        newJobId,
+      ]);
+
+      const listRes = await directCronReq(cronState, "cron.list", { includeDisabled: true });
+      expect(listRes.ok).toBe(true);
+      const listedJobs = (listRes.payload as { jobs?: Array<Record<string, unknown>> } | null)
+        ?.jobs;
+      expect(listedJobs?.map((job) => job.id)).toEqual(
+        expect.arrayContaining(["gw-legacy-alpha", "gw-legacy-beta", newJobId]),
+      );
+      expect(listedJobs).toHaveLength(3);
+    } finally {
+      await cleanupCronTestRun({ cronState, prevSkipCron });
+    }
+  });
+
   test("handles cron patch merge and validation semantics", { timeout: 45_000 }, async () => {
     const { prevSkipCron } = await setupCronTestRun({
       tempPrefix: "openclaw-gw-cron-patch-",


### PR DESCRIPTION
## Summary

- Problem: legacy cron `jobs.json` files stored as a top-level array are loaded as empty after upgrade, so the first `cron add` can rewrite the file with only the new job.
- Solution: normalize both supported persisted shapes in one cron store loader path: `{ version, jobs }` and legacy `[...]`.
- What changed: async load, sync load, doctor repair, service add, and gateway `cron.add` now preserve legacy array jobs through load/add/save.
- What did NOT change: no cron timeout defaults, auth cooldowns, delivery behavior, storage schema migration, or broad concurrency changes.

## Motivation

This is a P0 data-loss guard for users upgrading from a legacy plain-array cron store. A valid existing cron file should never be interpreted as empty and clobbered by the next write.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #60799
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: legacy top-level array cron stores are preserved when a new cron job is added.
- Real environment tested: isolated Linux testserver checkout on current `origin/main` plus this patch; no real secrets or user cron store used.
- Exact steps or command run after this patch: seeded a temp cron `jobs.json` with two legacy array jobs, called the real cron store load path and cron service `add()`, then read the persisted file.
- Evidence after fix:

```json
{
  "commit": "a54c73687f+6e2ab35417",
  "phase": "after",
  "legacyInputIds": ["legacy-alpha", "legacy-beta"],
  "loadCronStoreJobCount": 2,
  "loadedIds": ["legacy-alpha", "legacy-beta"],
  "persistedShape": "versioned-object",
  "persistedJobCount": 3,
  "persistedIds": ["legacy-alpha", "legacy-beta", "f4c00803-9730-4de8-8f09-674604ac6d7f"],
  "legacyPreservedAfterAdd": true
}
```

- Observed result after fix: both legacy jobs load, the new job is added, and all three jobs persist in the versioned store.
- What was not tested: a real user home cron store and live scheduled job execution were not used; this intentionally used isolated temp state.
- Before evidence:

```json
{
  "commit": "a54c73687f",
  "phase": "before",
  "legacyInputIds": ["legacy-alpha", "legacy-beta"],
  "loadCronStoreJobCount": 0,
  "loadedIds": [],
  "persistedShape": "versioned-object",
  "persistedJobCount": 1,
  "legacyPreservedAfterAdd": false
}
```

## Root Cause (if applicable)

- Root cause: `loadCronStore()` and `loadCronStoreSync()` only read `parsed.jobs` from an object envelope. If `jobs.json` was the older top-level array shape, the loader fell back to an empty job list.
- Missing detection / guardrail: there was no regression coverage for loading a top-level array through async/sync store reads or through the add/save paths.
- Contributing context: doctor repair uses the store loader, so the same normalization gap could make a repair pass treat valid legacy jobs as absent.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/cron/store.test.ts`
  - `src/cron/service/ops.test.ts`
  - `src/commands/doctor-cron.test.ts`
  - `src/gateway/server.cron.test.ts`
- Scenario the test should lock in: legacy top-level array jobs load through async/sync store reads and survive service/gateway `cron.add` plus doctor repair.
- Why this is the smallest reliable guardrail: the bug is in cron store normalization, with service/gateway tests proving the user-facing add path does not clobber data.
- Existing test that already covers this (if any): none for top-level array stores.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

OpenClaw now preserves cron jobs from legacy top-level array `jobs.json` files instead of treating them as empty on load.

## Diagram (if applicable)

```text
Before:
legacy jobs.json array -> load as [] -> cron add -> persisted file contains only new job

After:
legacy jobs.json array -> load legacy jobs -> cron add -> persisted file contains legacy jobs plus new job
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux testserver
- Runtime/container: Node.js v22.22.2, pnpm v11.1.2, isolated temp checkout/state
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): temp cron store path only

### Steps

1. Write a temp `cron/jobs.json` as a top-level array with two valid legacy jobs.
2. Load the store and call the real cron service `add()` path.
3. Read `cron/jobs.json` after save.

### Expected

- Both legacy job IDs and the new job ID are present after add/save.

### Actual

- Before patch: only the new job was present.
- After patch: both legacy jobs plus the new job were present.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - Before/after runtime proof on current `origin/main` and this patch.
  - Focused vitest: `src/cron/store.test.ts`, `src/cron/service/ops.test.ts`, `src/commands/doctor-cron.test.ts`, `src/gateway/server.cron.test.ts` = 4 files / 71 tests passed.
  - Core typecheck passed.
  - Core test typecheck passed.
  - `oxfmt --check` passed for all touched files.
  - Targeted `run-oxlint` passed for all touched files with 0 warnings / 0 errors.
  - `git diff --check` passed.
- Edge cases checked:
  - non-object array rows are ignored
  - sync and async store load both accept the legacy array
  - runtime state still splits into the state sidecar after save
  - doctor repair normalizes a legacy array instead of treating it as empty
  - gateway `cron.add` preserves legacy jobs through the RPC handler path
- What you did **not** verify:
  - full `pnpm check:changed` completion; the testserver OOM-killed `tsgolint` during full core lint, so the touched-file lint/typecheck/test lanes were run directly and passed.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: accepting the legacy array shape could preserve malformed scalar rows.
  - Mitigation: the normalizer keeps the existing object-row filter, so non-object rows are ignored before hydration.
- Risk: async/sync/doctor paths could diverge again later.
  - Mitigation: both loaders now share the same normalizer and have focused regression coverage.
