### PR TITLE
fix: strip openai reasoning replay for image turns

### DIFF
--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -7,6 +7,7 @@ import {
 import {
   downgradeOpenAIFunctionCallReasoningPairs,
   downgradeOpenAIReasoningBlocks,
+  downgradeOpenAIReasoningBlocksForImageTurn,
   isMessagingToolDuplicate,
   normalizeTextForComparison,
   sanitizeToolCallId,
@@ -734,6 +735,57 @@ describe("downgradeOpenAIReasoningBlocks", () => {
     expect(downgradeOpenAIReasoningBlocks(input as any, { dropReplayableReasoning: true })).toEqual(
       [{ role: "assistant", content: [{ type: "text", text: "answer" }] }],
     );
+  });
+
+  it("drops replayable reasoning when the latest user turn carries an image", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "thinking",
+            thinking: "internal reasoning",
+            thinkingSignature: JSON.stringify({ id: "rs_123", type: "reasoning" }),
+          },
+          { type: "text", text: "answer" },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "what is this?" },
+          { type: "image", data: "AA==", mimeType: "image/png" },
+        ],
+      },
+    ];
+
+    expect(downgradeOpenAIReasoningBlocksForImageTurn(input as any)).toEqual([
+      { role: "assistant", content: [{ type: "text", text: "answer" }] },
+      input[1],
+    ]);
+  });
+
+  it("keeps replayable reasoning when only older user turns carry images", () => {
+    const input = [
+      {
+        role: "user",
+        content: [{ type: "image", data: "AA==", mimeType: "image/png" }],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "thinking",
+            thinking: "internal reasoning",
+            thinkingSignature: JSON.stringify({ id: "rs_123", type: "reasoning" }),
+          },
+          { type: "text", text: "answer" },
+        ],
+      },
+      { role: "user", content: [{ type: "text", text: "continue" }] },
+    ];
+
+    expect(downgradeOpenAIReasoningBlocksForImageTurn(input as any)).toEqual(input);
   });
 
   it("drops orphaned reasoning blocks without following content", () => {

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -52,6 +52,7 @@ export { isGoogleModelApi, sanitizeGoogleTurnOrdering } from "./pi-embedded-help
 export {
   downgradeOpenAIFunctionCallReasoningPairs,
   downgradeOpenAIReasoningBlocks,
+  downgradeOpenAIReasoningBlocksForImageTurn,
 } from "./pi-embedded-helpers/openai.js";
 export {
   isEmptyAssistantMessageContent,

--- a/src/agents/pi-embedded-helpers/openai.ts
+++ b/src/agents/pi-embedded-helpers/openai.ts
@@ -20,6 +20,27 @@ type DowngradeOpenAIReasoningBlocksOptions = {
   dropReplayableReasoning?: boolean;
 };
 
+function latestUserTurnHasImage(messages: AgentMessage[]): boolean {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (!msg || typeof msg !== "object") {
+      continue;
+    }
+    if ((msg as { role?: unknown }).role !== "user") {
+      continue;
+    }
+    const content = (msg as { content?: unknown }).content;
+    return Array.isArray(content)
+      ? content.some((block) =>
+          Boolean(
+            block && typeof block === "object" && (block as { type?: unknown }).type === "image",
+          ),
+        )
+      : false;
+  }
+  return false;
+}
+
 function parseOpenAIReasoningSignature(value: unknown): OpenAIReasoningSignature | null {
   if (!value) {
     return null;
@@ -280,4 +301,12 @@ export function downgradeOpenAIReasoningBlocks(
   }
 
   return anyChanged ? out : messages;
+}
+
+export function downgradeOpenAIReasoningBlocksForImageTurn(
+  messages: AgentMessage[],
+): AgentMessage[] {
+  return downgradeOpenAIReasoningBlocks(messages, {
+    dropReplayableReasoning: latestUserTurnHasImage(messages),
+  });
 }

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -108,7 +108,7 @@ import {
 import type { EmbeddedContextFile } from "../../pi-embedded-helpers.js";
 import {
   downgradeOpenAIFunctionCallReasoningPairs,
-  downgradeOpenAIReasoningBlocks,
+  downgradeOpenAIReasoningBlocksForImageTurn,
   isCloudCodeAssistFormatError,
   resolveBootstrapMaxChars,
   resolveBootstrapPromptTruncationWarningMode,
@@ -2807,9 +2807,11 @@ export async function runEmbeddedAttempt(
           if (!Array.isArray(messages)) {
             return inner(model, context, options);
           }
-          // Strip orphaned reasoning blocks first, then fix function-call
+          // Strip unsafe reasoning blocks first, then fix function-call
           // pairing — matches the call order in google.ts.
-          const reasoningSanitized = downgradeOpenAIReasoningBlocks(messages as AgentMessage[]);
+          const reasoningSanitized = downgradeOpenAIReasoningBlocksForImageTurn(
+            messages as AgentMessage[],
+          );
           const sanitized = downgradeOpenAIFunctionCallReasoningPairs(reasoningSanitized);
           if (sanitized === messages) {
             return inner(model, context, options);


### PR DESCRIPTION
## Summary
- Problem: Telegram image/file turns routed through OpenAI/Codex Responses can replay prior encrypted `rs_*` reasoning items and hit provider-side encrypted-content verification failures.
- Solution: Strip replayable OpenAI/Codex reasoning blocks when the latest outbound user turn contains image input, then keep the existing Responses function-call replay repair.
- What changed: Added a focused OpenAI replay sanitizer helper and regression coverage for image-current-turn stripping plus a text-only/latest-turn no-op.
- What did NOT change (scope boundary): Telegram media download, Telegram auth/pairing, provider credentials, model security policy, and non-image replay behavior are unchanged.

## Motivation
- Fixes #84406, where Telegram file/image sends could fail with `The encrypted content ... could not be verified` after stale Responses reasoning was replayed.

## Change Type (select all)
- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)
- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #84406
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)
- Behavior or issue addressed: Telegram image/file message reaches the patched OpenClaw runtime, is passed to a vision-capable model, and completes without the encrypted-content rejection reported in #84406.
- Real environment tested: macOS local OpenClaw package install from this branch, isolated state dir `.artifacts/local-telegram-proof/state-19089`, gateway port `19089`, Telegram bot `@openclaw_local_telegram_bot`, model `google/gemini-2.5-flash`, thinking `off`, only Telegram enabled in `channels.status`.
- Exact steps or command run after this patch: packed and installed the patched package into `.artifacts/local-openclaw-install/proof-install`; started the isolated gateway with `OPENCLAW_CONFIG_PATH=.artifacts/local-telegram-proof/openclaw-telegram-proof-19089.json`, `OPENCLAW_STATE_DIR=.artifacts/local-telegram-proof/state-19089`, `OPENCLAW_DEBUG_MODEL_TRANSPORT=1`, `OPENCLAW_DEBUG_MODEL_PAYLOAD=summary`, and `openclaw gateway --port 19089`; approved Telegram pairing for user `6145715142`; sent an image/file DM to the bot.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): redacted runtime log excerpts:
  - `agent model: google/gemini-2.5-flash (thinking=off, fast=off)`
  - `http server listening ... port=19089`
  - `channels.status` showed `channelOrder: ["telegram"]` and no Slack/Discord entries for the proof gateway.
  - `Inbound message telegram:6145715142 -> @openclaw_local_telegram_bot (direct, image/jpeg, 13 chars)`
  - `Image resized to fit limits: 1280x720px 268.7KB -> 221.7KB (-17.5%)`
  - `[model-fetch] start provider=google api=google-generative-ai model=gemini-2.5-flash ... streamGenerateContent`
  - `[model-fetch] response provider=google api=google-generative-ai model=gemini-2.5-flash status=200 elapsedMs=3938 contentType=text/event-stream`
  - `embedded run agent end: runId=54caf240-3606-4ed4-8615-fa5833b26ced isError=false`
  - `message processed: channel=telegram chatId=telegram:6145715142 messageId=50 ... outcome=completed`
  - log search for the successful run found no `LLM request rejected`, `encrypted content`, or `could not be verified` messages.
- Observed result after fix: The Telegram image/file message received a bot response, and the model call completed successfully.
- What was not tested: A live OpenAI/Codex OAuth Telegram image turn was not run; the OpenAI/Codex-specific replay behavior is covered by targeted unit tests. The live Telegram proof used Gemini Flash per local credential availability.
- Before evidence (optional but encouraged): The issue report includes the provider rejection `The encrypted content ... could not be verified` for Telegram file sends on OpenAI/Codex Responses.

## Root Cause (if applicable)
- Root cause: The Responses replay sanitizer preserved paired `rs_*` reasoning items for same-model replay even when a new image/file user turn was being sent. That can resend stale encrypted reasoning in a multimodal request and trigger provider-side verification failures.
- Missing detection / guardrail: Existing coverage checked orphaned reasoning and model-change drops, but not current image-turn replay of otherwise paired reasoning.
- Contributing context (if known): The Telegram media path correctly delivered image input; the unsafe part was provider replay sanitization, not Telegram download.

## Regression Test Plan (if applicable)
- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts`
- Scenario the test should lock in: Drop replayable OpenAI `rs_*` reasoning when the latest user turn carries an image, while preserving reasoning when only older user turns carried images.
- Why this is the smallest reliable guardrail: The replay decision is pure transcript sanitization logic and can be tested without Telegram or live provider credentials.
- Existing test that already covers this (if any): Existing orphan/model-switch reasoning tests covered adjacent cases, not current image turns.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes
Telegram image/file turns routed to OpenAI/Codex Responses should no longer fail because stale encrypted reasoning was replayed with the media turn.

## Diagram (if applicable)
```text
Before:
Telegram image/file -> Responses replay includes stale rs_* reasoning -> provider rejects encrypted content

After:
Telegram image/file -> replay strips rs_* reasoning for image turn -> provider receives media turn without stale encrypted reasoning
```

## Security Impact (required)
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification
### Environment
- OS: macOS local checkout
- Runtime/container: Node 24.8.0; isolated OpenClaw package install from this branch
- Model/provider: `google/gemini-2.5-flash`, thinking `off` for live proof; OpenAI/Codex Responses covered by unit replay tests
- Integration/channel (if any): Telegram DM image/file
- Relevant config (redacted): proof gateway on port `19089`, isolated state dir, Telegram channel only

### Steps
1. Start the isolated patched gateway on port `19089` with Telegram-only config.
2. Approve Telegram pairing for user `6145715142`.
3. Send an image/file DM to `@openclaw_local_telegram_bot`.

### Expected
- Telegram image/file message reaches OpenClaw, model request succeeds, and the bot replies without encrypted-content rejection.

### Actual
- Telegram inbound image was logged, Gemini returned HTTP 200, the embedded run ended with `isError=false`, message processing completed, and the bot replied.

## Evidence
- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)
- Verified scenarios: Focused unit tests for OpenAI replay sanitization; live Telegram image/file DM through an isolated patched gateway.
- Edge cases checked: Latest user turn has image strips replayable reasoning; older image history with latest text-only turn preserves replayable reasoning.
- What you did **not** verify: Live OpenAI/Codex OAuth Telegram media turn.

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations
- Risk: Dropping replayable reasoning for image turns may reduce prompt-cache/reasoning continuity for that one multimodal turn.
  - Mitigation: The behavior is limited to current image turns on OpenAI/Codex Responses, where stale encrypted reasoning is the failure source; text-only same-model replay remains unchanged.

## Verification
- `git diff --check`
- `pnpm test src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts src/agents/pi-embedded-runner.sanitize-session-history.test.ts extensions/codex/src/conversation-turn-input.test.ts`
- `pnpm build`
- `pnpm check:changed`

Made with [Cursor](https://cursor.com)