### PR TITLE
Scope config preflight note suppression

### DIFF
--- a/src/cli/program/config-guard.test.ts
+++ b/src/cli/program/config-guard.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { note } from "../../terminal/note.js";
 import { formatCliCommand } from "../command-format.js";
 import { ensureConfigReady, testApi } from "./config-guard.js";
 
@@ -39,10 +40,20 @@ function plainErrorCalls(runtime: ReturnType<typeof makeRuntime>): string[] {
 
 async function withCapturedStdout(run: () => Promise<void>): Promise<string> {
   const writes: string[] = [];
-  const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(((chunk: unknown) => {
-    writes.push(String(chunk));
-    return true;
-  }) as typeof process.stdout.write);
+  const writeSpy = vi
+    .spyOn(process.stdout, "write")
+    .mockImplementation(
+      ((
+        chunk: unknown,
+        encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
+        callback?: (error?: Error | null) => void,
+      ) => {
+        writes.push(String(chunk));
+        const done = typeof encodingOrCallback === "function" ? encodingOrCallback : callback;
+        done?.();
+        return true;
+      }) as typeof process.stdout.write,
+    );
   try {
     await run();
     return writes.join("");
@@ -212,9 +223,9 @@ describe("ensureConfigReady", () => {
     expect(loadAndMaybeMigrateDoctorConfigMock).toHaveBeenCalledTimes(1);
   });
 
-  it("prevents preflight stdout noise when suppression is enabled", async () => {
+  it("prevents preflight note noise when suppression is enabled", async () => {
     loadAndMaybeMigrateDoctorConfigMock.mockImplementation(async () => {
-      process.stdout.write("Doctor warnings\n");
+      note("Doctor warnings", "Config warnings");
       return {
         snapshot: makeSnapshot(),
         baseConfig: {},
@@ -226,9 +237,9 @@ describe("ensureConfigReady", () => {
     expect(output).not.toContain("Doctor warnings");
   });
 
-  it("allows preflight stdout noise when suppression is not enabled", async () => {
+  it("allows preflight note noise when suppression is not enabled", async () => {
     loadAndMaybeMigrateDoctorConfigMock.mockImplementation(async () => {
-      process.stdout.write("Doctor warnings\n");
+      note("Doctor warnings", "Config warnings");
       return {
         snapshot: makeSnapshot(),
         baseConfig: {},
@@ -238,5 +249,40 @@ describe("ensureConfigReady", () => {
       await runEnsureConfigReady(["message"], false);
     });
     expect(output).toContain("Doctor warnings");
+  });
+
+  it("does not suppress unrelated concurrent stdout writes while suppressing preflight notes", async () => {
+    let releasePreflight: (() => void) | undefined;
+    let preflightStarted: (() => void) | undefined;
+    const preflightStartedPromise = new Promise<void>((resolve) => {
+      preflightStarted = resolve;
+    });
+    const releasePreflightPromise = new Promise<void>((resolve) => {
+      releasePreflight = resolve;
+    });
+    loadAndMaybeMigrateDoctorConfigMock.mockImplementation(async () => {
+      note("Doctor warnings", "Config warnings");
+      preflightStarted?.();
+      await releasePreflightPromise;
+      return {
+        snapshot: makeSnapshot(),
+        baseConfig: {},
+      };
+    });
+
+    let callbackCalled = false;
+    const output = await withCapturedStdout(async () => {
+      const ready = runEnsureConfigReady(["message"], true);
+      await preflightStartedPromise;
+      process.stdout.write("Concurrent output\n", () => {
+        callbackCalled = true;
+      });
+      releasePreflight?.();
+      await ready;
+    });
+
+    expect(output).toContain("Concurrent output");
+    expect(output).not.toContain("Doctor warnings");
+    expect(callbackCalled).toBe(true);
   });
 });

--- a/src/cli/program/config-guard.ts
+++ b/src/cli/program/config-guard.ts
@@ -1,5 +1,6 @@
 import { readConfigFileSnapshot, setRuntimeConfigSnapshot } from "../../config/config.js";
 import type { RuntimeEnv } from "../../runtime.js";
+import { withSuppressedNotes } from "../../terminal/note.js";
 import { shouldMigrateStateFromPath } from "../argv.js";
 
 const ALLOWED_INVALID_COMMANDS = new Set(["doctor", "logs", "health", "help", "status"]);
@@ -62,20 +63,7 @@ export async function ensureConfigReady(params: {
     if (!params.suppressDoctorStdout) {
       preflightSnapshot = (await runDoctorConfigPreflight()).snapshot;
     } else {
-      const originalStdoutWrite = process.stdout.write.bind(process.stdout);
-      const originalSuppressNotes = process.env.OPENCLAW_SUPPRESS_NOTES;
-      process.stdout.write = (() => true) as unknown as typeof process.stdout.write;
-      process.env.OPENCLAW_SUPPRESS_NOTES = "1";
-      try {
-        preflightSnapshot = (await runDoctorConfigPreflight()).snapshot;
-      } finally {
-        process.stdout.write = originalStdoutWrite;
-        if (originalSuppressNotes === undefined) {
-          delete process.env.OPENCLAW_SUPPRESS_NOTES;
-        } else {
-          process.env.OPENCLAW_SUPPRESS_NOTES = originalSuppressNotes;
-        }
-      }
+      preflightSnapshot = (await withSuppressedNotes(runDoctorConfigPreflight)).snapshot;
     }
   }
 

--- a/src/terminal/note.ts
+++ b/src/terminal/note.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import { note as clackNote } from "@clack/prompts";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { visibleWidth } from "./ansi.js";
@@ -7,6 +8,7 @@ const MIN_NOTE_COLUMNS = 80;
 const URL_PREFIX_RE = /^(https?:\/\/|file:\/\/)/i;
 const WINDOWS_DRIVE_RE = /^[a-zA-Z]:[\\/]/;
 const FILE_LIKE_RE = /^[a-zA-Z0-9._-]+$/;
+const suppressNotesStorage = new AsyncLocalStorage<boolean>();
 
 function isSuppressedByEnv(value: string | undefined): boolean {
   if (!value) {
@@ -197,7 +199,10 @@ function createNoteOutput(columns: number): NodeJS.WriteStream {
 }
 
 export function note(message: unknown, title?: string) {
-  if (isSuppressedByEnv(process.env.OPENCLAW_SUPPRESS_NOTES)) {
+  if (
+    suppressNotesStorage.getStore() === true ||
+    isSuppressedByEnv(process.env.OPENCLAW_SUPPRESS_NOTES)
+  ) {
     return;
   }
   const columns = resolveNoteColumns(process.stdout.columns);
@@ -205,4 +210,8 @@ export function note(message: unknown, title?: string) {
     output: createNoteOutput(columns),
     format: (line) => line,
   });
+}
+
+export function withSuppressedNotes<T>(callback: () => T): T {
+  return suppressNotesStorage.run(true, callback);
 }


### PR DESCRIPTION
## Summary

- Replaces the config guard's global `process.stdout.write` monkey-patch with async-scoped note suppression.
- Keeps `OPENCLAW_SUPPRESS_NOTES` behavior for existing callers while allowing scoped suppression via `withSuppressedNotes`.
- Adds a regression test proving unrelated concurrent stdout writes and callbacks still work while preflight notes are hidden.

Closes #83894.

## Real behavior proof

Behavior or issue addressed:
The `suppressDoctorStdout` path used to replace global `process.stdout.write` across an awaited doctor preflight. That could swallow unrelated concurrent async stdout writes and skip write callbacks while the preflight was pending.

Real environment tested:
Local macOS worktree with bundled Node.js `v24.14.0` and the repository's linked dependencies.

Exact steps or command run after this patch:
```bash
PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node node_modules/tsx/dist/cli.mjs /private/tmp/openclaw-83894-proof/proof.ts
PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node scripts/run-vitest.mjs src/cli/program/config-guard.test.ts src/commands/doctor-config-preflight.test.ts
PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts test/cli-json-stdout.e2e.test.ts
git diff --check upstream/main..HEAD
```

Evidence after fix:
The standalone runtime proof imports the actual patched `note.ts`, enters `withSuppressedNotes` across an `await`, writes unrelated stdout concurrently, and verifies the callback and stdout write still happen:
```json
{
  "doctorNoteVisible": false,
  "concurrentOutputVisible": true,
  "stdoutCallbackCalled": true,
  "stdoutWriteSameInsideSuppressedScope": true,
  "stdoutWriteSameAfterSuppressedAwait": true
}
```

Targeted tests:
```text
Test Files  2 passed (2)
Tests       18 passed (18)
```

JSON stdout e2e:
```text
Test Files  1 passed (1)
Tests       1 passed (1)
```

Observed result after fix:
Doctor preflight note output is suppressed in the guarded path, but unrelated concurrent stdout output remains visible, its callback fires, and `process.stdout.write` remains the same function inside the suppressed async scope before and after an `await`.

What was not tested:
I did not run the full repository test suite. The proof focuses on the stdout suppression bug, the config guard integration tests, and the existing JSON stdout e2e coverage.

## Attribution

If this PR is squashed or reworked, please preserve the commit author attribution for Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>, or include:

Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>
