### PR TITLE
fix(outbound): sanitize assistant reasoning before delivery

### DIFF
--- a/src/auto-reply/reply/reply-dispatcher.sanitizer.test.ts
+++ b/src/auto-reply/reply/reply-dispatcher.sanitizer.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest";
+import { createReplyDispatcher } from "./reply-dispatcher.js";
+
+async function drain(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("createReplyDispatcher delivery sanitizer", () => {
+  it("sanitizes assistant block replies before custom delivery", async () => {
+    const deliver = vi.fn(async () => undefined);
+    const dispatcher = createReplyDispatcher({ deliver });
+
+    expect(dispatcher.sendBlockReply({ text: "<think>hidden</think>Visible" })).toBe(true);
+    dispatcher.markComplete();
+    await dispatcher.waitForIdle();
+
+    expect(deliver).toHaveBeenCalledWith({ text: "Visible" }, { kind: "block" });
+  });
+
+  it("drops reasoning-only final replies before custom delivery", async () => {
+    const deliver = vi.fn(async () => undefined);
+    const dispatcher = createReplyDispatcher({ deliver });
+
+    expect(dispatcher.sendFinalReply({ text: "Reasoning:\n_private step_" })).toBe(false);
+    dispatcher.markComplete();
+    await drain();
+
+    expect(deliver).not.toHaveBeenCalled();
+  });
+
+  it("does not sanitize tool result payloads", async () => {
+    const deliver = vi.fn(async () => undefined);
+    const dispatcher = createReplyDispatcher({ deliver });
+
+    expect(dispatcher.sendToolResult({ text: "Reasoning:\nliteral tool output" })).toBe(true);
+    dispatcher.markComplete();
+    await dispatcher.waitForIdle();
+
+    expect(deliver).toHaveBeenCalledWith(
+      { text: "Reasoning:\nliteral tool output" },
+      { kind: "tool" },
+    );
+  });
+});

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -1,6 +1,7 @@
 import type { TypingCallbacks } from "../../channels/typing.js";
 import type { HumanDelayConfig } from "../../config/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { sanitizeAssistantForDelivery } from "../../infra/outbound/assistant-delivery-sanitizer.js";
 import { generateSecureInt } from "../../infra/secure-random.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { SilentReplyConversationType } from "../../shared/silent-reply-policy.js";
@@ -172,6 +173,13 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
       }
       return false;
     }
+    const deliverySanitized =
+      kind === "tool"
+        ? normalized
+        : sanitizeAssistantForDelivery(normalized, { role: "assistant" });
+    if (!deliverySanitized) {
+      return false;
+    }
     queuedCounts[kind] += 1;
     pending += 1;
 
@@ -190,9 +198,9 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
             await sleep(delayMs);
           }
         }
-        let deliverPayload: ReplyPayload | null = normalized;
+        let deliverPayload: ReplyPayload | null = deliverySanitized;
         if (options.beforeDeliver) {
-          deliverPayload = await options.beforeDeliver(normalized, { kind });
+          deliverPayload = await options.beforeDeliver(deliverySanitized, { kind });
           if (!deliverPayload) {
             cancelledCounts[kind] += 1;
             return;

--- a/src/infra/outbound/assistant-delivery-sanitizer.test.ts
+++ b/src/infra/outbound/assistant-delivery-sanitizer.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  sanitizeAssistantForDelivery,
+  sanitizeAssistantTextForDelivery,
+} from "./assistant-delivery-sanitizer.js";
+
+describe("sanitizeAssistantForDelivery", () => {
+  it("strips assistant tagged thinking when thinking is off", () => {
+    expect(sanitizeAssistantTextForDelivery("<think>hidden</think>Visible")).toBe("Visible");
+  });
+
+  it("preserves assistant tagged thinking when thinking is enabled", () => {
+    expect(
+      sanitizeAssistantTextForDelivery("<think>hidden</think>Visible", {
+        thinkingEnabled: true,
+      }),
+    ).toBe("<think>hidden</think>Visible");
+  });
+
+  it("does not sanitize non-assistant literal examples", () => {
+    expect(
+      sanitizeAssistantTextForDelivery("<think>example</think>", {
+        role: "user",
+      }),
+    ).toBe("<think>example</think>");
+  });
+
+  it("drops reasoning-only outbound payloads", () => {
+    expect(sanitizeAssistantForDelivery({ text: "Reasoning:\n_private step_" })).toBeNull();
+    expect(sanitizeAssistantForDelivery({ text: "private step", isReasoning: true })).toBeNull();
+  });
+
+  it("preserves blank text when payload metadata has channel content", () => {
+    expect(sanitizeAssistantForDelivery({ text: " \n\t ", channelData: { mode: "flex" } })).toEqual(
+      {
+        text: " \n\t ",
+        channelData: { mode: "flex" },
+      },
+    );
+  });
+
+  it("preserves final answer content from mixed structured reasoning", () => {
+    expect(
+      sanitizeAssistantForDelivery({
+        text: "Reasoning:\n_private step_\n\nFinal answer:\nVisible answer",
+      }),
+    ).toEqual({ text: "Visible answer" });
+  });
+
+  it("does not alter tagged thinking inside fenced code blocks", () => {
+    expect(
+      sanitizeAssistantTextForDelivery(
+        "```xml\n<think>example</think>\n```\n<think>hidden</think>Visible",
+      ),
+    ).toBe("```xml\n<think>example</think>\n```\nVisible");
+  });
+});

--- a/src/infra/outbound/assistant-delivery-sanitizer.ts
+++ b/src/infra/outbound/assistant-delivery-sanitizer.ts
@@ -1,0 +1,111 @@
+import { copyReplyPayloadMetadata } from "../../auto-reply/reply-payload.js";
+import type { ReplyPayload } from "../../auto-reply/types.js";
+import { hasReplyPayloadContent } from "../../interactive/payload.js";
+
+export type AssistantDeliverySanitizerRole = "assistant" | "user" | "system" | "tool";
+
+export type AssistantDeliverySanitizerOptions = {
+  role?: AssistantDeliverySanitizerRole;
+  /**
+   * When true, visible channel surfaces may keep tagged thinking text. The
+   * default is false because most outbound channels do not have a separate
+   * reasoning lane and must never expose model-private reasoning accidentally.
+   */
+  thinkingEnabled?: boolean;
+  reasoningEnabled?: boolean;
+};
+
+const THINKING_TAG_NAMES = ["think", "thinking", "reasoning", "thought", "thoughts"];
+const THINKING_TAG_PATTERN = new RegExp(
+  `<\\s*(${THINKING_TAG_NAMES.join("|")})\\b[^>]*>[\\s\\S]*?<\\s*/\\s*\\1\\s*>`,
+  "gi",
+);
+const FENCE_PATTERN = /^\s*(```|~~~)/;
+const MIXED_REASONING_FINAL_PATTERN =
+  /^\s*(?:reasoning|thinking|thoughts?)\s*:\s*[\s\S]*?(?:\n\s*(?:final(?:\s+answer)?|answer|response)\s*:\s*)([\s\S]+)$/i;
+const REASONING_ONLY_PATTERN = /^\s*(?:reasoning|thinking|thoughts?)\s*:\s*[\s\S]*$/i;
+
+function canShowThinking(options: AssistantDeliverySanitizerOptions): boolean {
+  return options.thinkingEnabled === true || options.reasoningEnabled === true;
+}
+
+function isAssistantRole(options: AssistantDeliverySanitizerOptions): boolean {
+  return (options.role ?? "assistant") === "assistant";
+}
+
+function stripTaggedThinkingOutsideCodeBlocks(text: string): string {
+  const lines = text.split(/(?<=\n)/);
+  let inFence = false;
+  let changed = false;
+  let outsideBuffer = "";
+  const out: string[] = [];
+  const flushOutside = () => {
+    if (!outsideBuffer) {
+      return;
+    }
+    const stripped = outsideBuffer.replace(THINKING_TAG_PATTERN, "");
+    changed ||= stripped !== outsideBuffer;
+    out.push(stripped);
+    outsideBuffer = "";
+  };
+  for (const line of lines) {
+    if (FENCE_PATTERN.test(line)) {
+      flushOutside();
+      inFence = !inFence;
+      out.push(line);
+      continue;
+    }
+    if (inFence) {
+      out.push(line);
+      continue;
+    }
+    outsideBuffer += line;
+  }
+  flushOutside();
+  return changed ? out.join("") : text;
+}
+
+export function sanitizeAssistantTextForDelivery(
+  text: string,
+  options: AssistantDeliverySanitizerOptions = {},
+): string | null {
+  if (!isAssistantRole(options) || canShowThinking(options)) {
+    return text;
+  }
+  if (!text.trim()) {
+    return text;
+  }
+  let sanitized = stripTaggedThinkingOutsideCodeBlocks(text);
+  const mixedReasoning = MIXED_REASONING_FINAL_PATTERN.exec(sanitized);
+  if (mixedReasoning?.[1]?.trim()) {
+    sanitized = mixedReasoning[1];
+  } else if (REASONING_ONLY_PATTERN.test(sanitized)) {
+    return null;
+  }
+  sanitized = sanitized.replace(/\n{3,}/g, "\n\n").trim();
+  return sanitized ? sanitized : null;
+}
+
+export function sanitizeAssistantForDelivery<T extends ReplyPayload>(
+  payload: T,
+  options: AssistantDeliverySanitizerOptions = {},
+): T | null {
+  if (!isAssistantRole(options)) {
+    return payload;
+  }
+  if (payload.isReasoning === true && !canShowThinking(options)) {
+    return null;
+  }
+  if (typeof payload.text !== "string") {
+    return payload;
+  }
+  const text = sanitizeAssistantTextForDelivery(payload.text, options);
+  if (text === payload.text) {
+    return payload;
+  }
+  if (text === null) {
+    const withoutText = copyReplyPayloadMetadata(payload, { ...payload, text: undefined });
+    return hasReplyPayloadContent(withoutText) ? (withoutText as T) : null;
+  }
+  return copyReplyPayloadMetadata(payload, { ...payload, text }) as T;
+}

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -360,6 +360,42 @@ describe("deliverOutboundPayloads", () => {
     expect(results).toEqual([{ channel: "matrix", messageId: "m1", roomId: "!room:example" }]);
   });
 
+  it("sanitizes assistant thinking tags before channel send", async () => {
+    const sendMatrix = vi.fn().mockResolvedValue({ messageId: "m1", roomId: "!room:example" });
+
+    await deliverMatrixPayload({
+      sendMatrix,
+      payload: { text: "<think>hidden</think>Visible" },
+    });
+
+    expect(sendMatrix).toHaveBeenCalledTimes(1);
+    expect(requireMatrixSendCall(sendMatrix)[1]).toBe("Visible");
+  });
+
+  it("drops reasoning-only assistant payloads before channel send", async () => {
+    const sendMatrix = vi.fn().mockResolvedValue({ messageId: "m1", roomId: "!room:example" });
+
+    const results = await deliverMatrixPayload({
+      sendMatrix,
+      payload: { text: "Reasoning:\n_private step_" },
+    });
+
+    expect(results).toEqual([]);
+    expect(sendMatrix).not.toHaveBeenCalled();
+  });
+
+  it("delivers only the answer for mixed reasoning and final assistant payloads", async () => {
+    const sendMatrix = vi.fn().mockResolvedValue({ messageId: "m1", roomId: "!room:example" });
+
+    await deliverMatrixPayload({
+      sendMatrix,
+      payload: { text: "Reasoning:\n_private step_\n\nFinal answer:\nVisible" },
+    });
+
+    expect(sendMatrix).toHaveBeenCalledTimes(1);
+    expect(requireMatrixSendCall(sendMatrix)[1]).toBe("Visible");
+  });
+
   it("reports unsupported durable final delivery when required capabilities are missing", async () => {
     setActivePluginRegistry(
       createTestRegistry([

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -42,6 +42,7 @@ import { diagnosticErrorCategory } from "../diagnostic-error-metadata.js";
 import { emitDiagnosticEvent, type DiagnosticMessageDeliveryKind } from "../diagnostic-events.js";
 import { formatErrorMessage } from "../errors.js";
 import { throwIfAborted } from "./abort.js";
+import { sanitizeAssistantForDelivery } from "./assistant-delivery-sanitizer.js";
 import { resolveOutboundChannelMessageAdapter } from "./channel-resolution.js";
 import {
   OutboundDeliveryError,
@@ -786,9 +787,12 @@ function normalizePayloadsForChannelDelivery(
     const normalizedPayload = handler.normalizePayload
       ? handler.normalizePayload(sanitizedPayload)
       : sanitizedPayload;
-    const normalized = normalizedPayload
+    const deliverySanitizedPayload = normalizedPayload
+      ? sanitizeAssistantForDelivery(normalizedPayload, { role: "assistant" })
+      : null;
+    const normalized = deliverySanitizedPayload
       ? normalizeEmptyPayloadForDelivery(
-          stripInternalRuntimeScaffoldingFromPayload(normalizedPayload),
+          stripInternalRuntimeScaffoldingFromPayload(deliverySanitizedPayload),
         )
       : null;
     if (normalized) {
@@ -1542,9 +1546,12 @@ async function deliverOutboundPayloadsCore(
       const normalizedEffectivePayload = handler.normalizePayload
         ? handler.normalizePayload(renderedPayload)
         : renderedPayload;
-      const effectivePayload = normalizedEffectivePayload
+      const deliverySanitizedEffectivePayload = normalizedEffectivePayload
+        ? sanitizeAssistantForDelivery(normalizedEffectivePayload, { role: "assistant" })
+        : null;
+      const effectivePayload = deliverySanitizedEffectivePayload
         ? normalizeEmptyPayloadForDelivery(
-            stripInternalRuntimeScaffoldingFromPayload(normalizedEffectivePayload),
+            stripInternalRuntimeScaffoldingFromPayload(deliverySanitizedEffectivePayload),
           )
         : null;
       if (!effectivePayload) {


### PR DESCRIPTION
## Summary
- add an outbound assistant delivery sanitizer that strips private thinking/reasoning tags outside code fences
- drop reasoning-only assistant payloads before channel delivery
- apply the sanitizer at durable outbound delivery and reply-dispatcher boundaries while preserving tool-result payloads
- add regression coverage for sanitizer, durable delivery, and dispatcher paths

## Validation
- `npx oxlint src/infra/outbound/assistant-delivery-sanitizer.ts src/infra/outbound/assistant-delivery-sanitizer.test.ts src/infra/outbound/deliver.ts src/infra/outbound/deliver.test.ts src/auto-reply/reply/reply-dispatcher.ts src/auto-reply/reply/reply-dispatcher.sanitizer.test.ts`
- `npx vitest run src/infra/outbound/assistant-delivery-sanitizer.test.ts src/infra/outbound/deliver.test.ts src/auto-reply/reply/reply-dispatcher.sanitizer.test.ts` — 96 tests passed

Caveat: this is targeted regression coverage; the full repository suite was not run.
