### PR TITLE
fix(memory): stop recall tracking when dreaming is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Memory/search: stop recall tracking from writing dreaming side-effect artifacts when `dreaming.enabled=false`, while preserving normal search results. Fixes #84436. (#84444) Thanks @NianJiuZst.
 - fix(config): validate browser sandbox bind sources [AI]. (#84799) Thanks @pgondhi987.
 - doctor: constrain legacy plugin cleanup paths [AI]. (#84801) Thanks @pgondhi987.
 - Update/doctor: prune stale local bundled plugin install records that point at old compiled bundled output so current bundled plugin schemas win after upgrade. (#84863) Thanks @fuller-stack-dev.

--- a/extensions/memory-core/src/cli.runtime.ts
+++ b/extensions/memory-core/src/cli.runtime.ts
@@ -3,7 +3,10 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import type { MemoryEmbeddingProbeResult } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
-import { resolveMemoryRemDreamingConfig } from "openclaw/plugin-sdk/memory-core-host-status";
+import {
+  resolveMemoryDreamingConfig,
+  resolveMemoryRemDreamingConfig,
+} from "openclaw/plugin-sdk/memory-core-host-status";
 import { buildAgentSessionKey } from "openclaw/plugin-sdk/routing";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import {
@@ -1202,8 +1205,13 @@ export async function runMemorySearch(
   const { config: cfg, diagnostics } = await loadMemoryCommandConfig("memory search");
   emitMemorySecretResolveDiagnostics(diagnostics, { json: Boolean(opts.json) });
   const agentId = resolveAgent(cfg, opts.agent);
+  const memoryPluginConfig = resolveMemoryPluginConfig(cfg);
+  const dreamingEnabled = resolveMemoryDreamingConfig({
+    pluginConfig: memoryPluginConfig,
+    cfg,
+  }).enabled;
   const dreaming = resolveShortTermPromotionDreamingConfig({
-    pluginConfig: resolveMemoryPluginConfig(cfg),
+    pluginConfig: memoryPluginConfig,
     cfg,
   });
   await withMemoryManagerForAgent({
@@ -1229,14 +1237,16 @@ export async function runMemorySearch(
         typeof (manager as { status?: () => { workspaceDir?: string } }).status === "function"
           ? manager.status().workspaceDir
           : undefined;
-      void recordShortTermRecalls({
-        workspaceDir,
-        query,
-        results,
-        timezone: dreaming.timezone,
-      }).catch(() => {
-        // Recall tracking is best-effort and must not block normal search results.
-      });
+      if (dreamingEnabled) {
+        void recordShortTermRecalls({
+          workspaceDir,
+          query,
+          results,
+          timezone: dreaming.timezone,
+        }).catch(() => {
+          // Recall tracking is best-effort and must not block normal search results.
+        });
+      }
       if (opts.json) {
         defaultRuntime.writeJson({ results });
         return;

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -1896,6 +1896,19 @@ describe("memory cli", () => {
           source: "memory",
         },
       ]);
+      getRuntimeConfig.mockReturnValue({
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                },
+              },
+            },
+          },
+        },
+      });
       mockManager({
         search,
         status: () => makeMemoryStatus({ workspaceDir }),
@@ -1965,6 +1978,54 @@ describe("memory cli", () => {
         recallDays: ["<today>"],
         conceptTags: ["backup", "backups", "glacier"],
       });
+      expect(close).toHaveBeenCalled();
+    });
+  });
+
+  it("does not record short-term recall entries from memory search when dreaming is disabled", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      const close = vi.fn(async () => {});
+      const search = vi.fn(async () => [
+        {
+          path: "memory/2026-04-03.md",
+          startLine: 1,
+          endLine: 2,
+          score: 0.91,
+          snippet: "Move backups to S3 Glacier.",
+          source: "memory",
+        },
+      ]);
+      getRuntimeConfig.mockReturnValue({
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: false,
+                },
+              },
+            },
+          },
+        },
+      });
+      mockManager({
+        search,
+        status: () => makeMemoryStatus({ workspaceDir }),
+        close,
+      });
+
+      const writeJson = spyRuntimeJson(defaultRuntime);
+      await runMemoryCli(["search", "glacier", "--json"]);
+
+      const payload = firstWrittenJsonArg<{ results: Array<{ path: string }> }>(writeJson);
+      if (!payload) {
+        throw new Error("Expected memory search JSON payload");
+      }
+      expect(payload.results).toHaveLength(1);
+      expect(payload.results[0]?.path).toBe("memory/2026-04-03.md");
+      await expectPathMissing(
+        path.join(workspaceDir, "memory", ".dreams", "short-term-recall.json"),
+      );
       expect(close).toHaveBeenCalled();
     });
   });

--- a/extensions/memory-core/src/tools.citations.test.ts
+++ b/extensions/memory-core/src/tools.citations.test.ts
@@ -247,7 +247,22 @@ describe("memory tools", () => {
         },
       ]);
 
-      const tool = createMemorySearchToolOrThrow();
+      const tool = createMemorySearchToolOrThrow({
+        config: asOpenClawConfig({
+          agents: { list: [{ id: "main", default: true }] },
+          plugins: {
+            entries: {
+              "memory-core": {
+                config: {
+                  dreaming: {
+                    enabled: true,
+                  },
+                },
+              },
+            },
+          },
+        }),
+      });
       await tool.execute("call_recall_persist", { query: "glacier backup" });
 
       const storePath = path.join(workspaceDir, "memory", ".dreams", "short-term-recall.json");

--- a/extensions/memory-core/src/tools.recall-tracking.test.ts
+++ b/extensions/memory-core/src/tools.recall-tracking.test.ts
@@ -67,6 +67,17 @@ describe("memory_search recall tracking", () => {
     const tool = createSearchTool(
       asOpenClawConfig({
         agents: { list: [{ id: "main", default: true }] },
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                },
+              },
+            },
+          },
+        },
         memory: {
           backend: "qmd",
           citations: "on",
@@ -103,6 +114,17 @@ describe("memory_search recall tracking", () => {
     const tool = createSearchTool(
       asOpenClawConfig({
         agents: { list: [{ id: "main", default: true }] },
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                },
+              },
+            },
+          },
+        },
       }),
     );
     setMemorySearchImpl(async () => [
@@ -164,6 +186,7 @@ describe("memory_search recall tracking", () => {
             "memory-core": {
               config: {
                 dreaming: {
+                  enabled: true,
                   timezone: "Europe/London",
                 },
               },
@@ -178,5 +201,41 @@ describe("memory_search recall tracking", () => {
     expect(recallTrackingMock.recordShortTermRecalls).toHaveBeenCalledTimes(1);
     const [firstCall] = recallTrackingMock.recordShortTermRecalls.mock.calls;
     expect(firstCall?.[0]?.timezone).toBe("Europe/London");
+  });
+
+  it("skips recall tracking when dreaming is disabled", async () => {
+    setMemorySearchImpl(async () => [
+      {
+        path: "memory/2026-04-03.md",
+        startLine: 1,
+        endLine: 2,
+        score: 0.95,
+        snippet: "Move backups to S3 Glacier.",
+        source: "memory" as const,
+      },
+    ]);
+
+    const tool = createSearchTool(
+      asOpenClawConfig({
+        agents: { list: [{ id: "main", default: true }] },
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: false,
+                },
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    const result = await tool.execute("call_recall_disabled", { query: "glacier" });
+    const details = result.details as { results: Array<{ path: string }> };
+    expect(details.results).toHaveLength(1);
+    expect(details.results[0]?.path).toBe("memory/2026-04-03.md");
+    expect(recallTrackingMock.recordShortTermRecalls).not.toHaveBeenCalled();
   });
 });

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -14,6 +14,7 @@ import type {
 } from "openclaw/plugin-sdk/memory-core-host-runtime-files";
 import {
   resolveMemoryCorePluginConfig,
+  resolveMemoryDreamingConfig,
   resolveMemoryDeepDreamingConfig,
 } from "openclaw/plugin-sdk/memory-core-host-status";
 import { filterMemorySearchHitsBySessionVisibility } from "./session-search-visibility.js";
@@ -265,6 +266,15 @@ export function createMemorySearchTool(options: {
             mode: citationsMode,
             sessionKey: options.agentSessionKey,
           });
+          const pluginConfig = resolveMemoryCorePluginConfig(cfg);
+          const dreamingEnabled = resolveMemoryDreamingConfig({
+            pluginConfig,
+            cfg,
+          }).enabled;
+          const dreaming = resolveMemoryDeepDreamingConfig({
+            pluginConfig,
+            cfg,
+          });
           const searchStartedAt = Date.now();
           let rawResults: MemorySearchResult[] = [];
           let surfacedMemoryResults: Array<MemorySearchResult & { corpus: MemorySource }> = [];
@@ -327,17 +337,15 @@ export function createMemorySearchTool(options: {
               ...result,
               corpus: result.source,
             }));
-            const sleepTimezone = resolveMemoryDeepDreamingConfig({
-              pluginConfig: resolveMemoryCorePluginConfig(cfg),
-              cfg,
-            }).timezone;
-            queueShortTermRecallTracking({
-              workspaceDir: status.workspaceDir,
-              query,
-              rawResults,
-              surfacedResults: memoryResults,
-              timezone: sleepTimezone,
-            });
+            if (dreamingEnabled) {
+              queueShortTermRecallTracking({
+                workspaceDir: status.workspaceDir,
+                query,
+                rawResults,
+                surfacedResults: memoryResults,
+                timezone: dreaming.timezone,
+              });
+            }
             provider = status.provider;
             model = status.model;
             fallback = status.fallback;


### PR DESCRIPTION
## Summary
- stop normal `memory_search` recall tracking from writing `.dreams` artifacts when `plugins.entries.memory-core.config.dreaming.enabled=false`
- keep ordinary memory search results unchanged while preserving dreaming timezone behavior whenever dreaming is enabled
- add regression coverage for the tool path, CLI path, and positive recall-tracking cases so tests explicitly model dreaming on/off behavior

Closes #84436.

## Verification
- `node scripts/run-vitest.mjs extensions/memory-core/src/tools.recall-tracking.test.ts extensions/memory-core/src/tools.citations.test.ts extensions/memory-core/src/cli.test.ts`
- `pnpm check:changed`

## Real behavior proof
Behavior addressed: ordinary `memory_search` and `openclaw memory search` were still writing `memory/.dreams/short-term-recall.json` and `memory/.dreams/events.jsonl` even when the top-level `dreaming.enabled` master switch was off.
Real environment tested: isolated local OpenClaw source checkout on macOS using a temporary `OPENCLAW_CONFIG_PATH`, `OPENCLAW_STATE_DIR`, and workspace with bundled `memory-core` active and `plugins.entries.memory-core.config.dreaming.enabled=false`.
Exact steps or command run after this patch: create a temp workspace with `memory/2026-05-20.md`, point `OPENCLAW_CONFIG_PATH` and `OPENCLAW_STATE_DIR` at the temp config/state, then run `pnpm openclaw memory search glacier --json`, followed by direct filesystem checks for `memory/.dreams/short-term-recall.json` and `memory/.dreams/events.jsonl`.
Evidence after fix: terminal output from the live run:
```text
$ OPENCLAW_CONFIG_PATH=/tmp/openclaw-proof-YP473f/openclaw.json OPENCLAW_STATE_DIR=/tmp/openclaw-proof-YP473f/state pnpm openclaw memory search glacier --json
[memory] chunks_vec not updated — semantic vector embeddings unavailable — no vector dimensions resolved. Vector recall degraded. Further duplicate warnings suppressed.
{
  "results": [
    {
      "path": "memory/2026-05-20.md",
      "startLine": 1,
      "endLine": 3,
      "score": 0.6466676666656668,
      "snippet": "# Daily Memory\n- Move backups to S3 Glacier after the May retention window.\n",
      "source": "memory"
    }
  ]
}
short-term-recall.json: missing
events.jsonl: missing
```
Observed result after fix: the real CLI search still returned the expected memory hit from `memory/2026-05-20.md`, and the follow-up filesystem checks confirmed that neither `memory/.dreams/short-term-recall.json` nor `memory/.dreams/events.jsonl` was created.
What was not tested: packaged/Testbox/Crabbox proof on Windows; this proof covers a real local OpenClaw CLI run in an isolated source-checkout setup.
