### PR TITLE
fix(memory-core): skip recall tracking when dreaming.enabled=false (#84436)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Memory/dreaming: skip short-term recall tracking (and the `memory/.dreams/short-term-recall.json` / `memory/.dreams/events.jsonl` writes it produces) on ordinary `memory_search` tool calls and `openclaw memory search` CLI runs when `plugins.entries.memory-core.config.dreaming.enabled` is `false`, so disabling dreaming actually stops dreaming-related artifact churn during normal recall. Fixes #84436.
 - Agents: filter silent heartbeat response-tool transcript artifacts out of embedded context snapshots so later user turns are not polluted by heartbeat no-op messages. (#83477) Thanks @fuller-stack-dev.
 - Agents/OpenAI: log repeated strict tool-schema downgrade diagnostics once per provider/model/tool signature, reducing duplicate debug noise while preserving `strict=false` fallback behavior. Fixes #82930. (#82933) Thanks @galiniliev.
 - Agents/code mode: spell out the `exec` tool's JavaScript/TypeScript, no Node module, and catalog-bridge constraints in model-visible schema text so agents can use enabled tools without trial-and-error. (#84269) Thanks @Kaspre.

--- a/extensions/memory-core/src/cli.runtime.ts
+++ b/extensions/memory-core/src/cli.runtime.ts
@@ -1229,14 +1229,16 @@ export async function runMemorySearch(
         typeof (manager as { status?: () => { workspaceDir?: string } }).status === "function"
           ? manager.status().workspaceDir
           : undefined;
-      void recordShortTermRecalls({
-        workspaceDir,
-        query,
-        results,
-        timezone: dreaming.timezone,
-      }).catch(() => {
-        // Recall tracking is best-effort and must not block normal search results.
-      });
+      if (dreaming.enabled) {
+        void recordShortTermRecalls({
+          workspaceDir,
+          query,
+          results,
+          timezone: dreaming.timezone,
+        }).catch(() => {
+          // Recall tracking is best-effort and must not block normal search results.
+        });
+      }
       if (opts.json) {
         defaultRuntime.writeJson({ results });
         return;

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -1885,6 +1885,13 @@ describe("memory cli", () => {
 
   it("records short-term recall entries from memory search hits", async () => {
     await withTempWorkspace(async (workspaceDir) => {
+      getRuntimeConfig.mockReturnValue({
+        plugins: {
+          entries: {
+            "memory-core": { config: { dreaming: { enabled: true } } },
+          },
+        },
+      });
       const close = vi.fn(async () => {});
       const search = vi.fn(async () => [
         {
@@ -1965,6 +1972,51 @@ describe("memory cli", () => {
         recallDays: ["<today>"],
         conceptTags: ["backup", "backups", "glacier"],
       });
+      expect(close).toHaveBeenCalled();
+    });
+  });
+
+  it("does not write .dreams recall artifacts when dreaming.enabled=false (#84436)", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      getRuntimeConfig.mockReturnValue({
+        plugins: {
+          entries: {
+            "memory-core": { config: { dreaming: { enabled: false } } },
+          },
+        },
+      });
+      const close = vi.fn(async () => {});
+      const search = vi.fn(async () => [
+        {
+          path: "memory/2026-04-03.md",
+          startLine: 1,
+          endLine: 2,
+          score: 0.91,
+          snippet: "Move backups to S3 Glacier.",
+          source: "memory",
+        },
+      ]);
+      mockManager({
+        search,
+        status: () => makeMemoryStatus({ workspaceDir }),
+        close,
+      });
+
+      await runMemoryCli(["search", "glacier", "--json"]);
+
+      // Give any best-effort async recall write a chance to run.
+      await new Promise((resolve) => setImmediate(resolve));
+      await new Promise((resolve) => setImmediate(resolve));
+
+      const recallStorePath = path.join(
+        workspaceDir,
+        "memory",
+        ".dreams",
+        "short-term-recall.json",
+      );
+      const eventsPath = path.join(workspaceDir, "memory", ".dreams", "events.jsonl");
+      await expect(fs.access(recallStorePath)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(fs.access(eventsPath)).rejects.toMatchObject({ code: "ENOENT" });
       expect(close).toHaveBeenCalled();
     });
   });

--- a/extensions/memory-core/src/tools.citations.test.ts
+++ b/extensions/memory-core/src/tools.citations.test.ts
@@ -247,7 +247,16 @@ describe("memory tools", () => {
         },
       ]);
 
-      const tool = createMemorySearchToolOrThrow();
+      const tool = createMemorySearchToolOrThrow({
+        config: {
+          agents: { list: [{ id: "main", default: true }] },
+          plugins: {
+            entries: {
+              "memory-core": { config: { dreaming: { enabled: true } } },
+            },
+          },
+        },
+      });
       await tool.execute("call_recall_persist", { query: "glacier backup" });
 
       const storePath = path.join(workspaceDir, "memory", ".dreams", "short-term-recall.json");

--- a/extensions/memory-core/src/tools.recall-tracking.test.ts
+++ b/extensions/memory-core/src/tools.recall-tracking.test.ts
@@ -72,6 +72,13 @@ describe("memory_search recall tracking", () => {
           citations: "on",
           qmd: { limits: { maxInjectedChars: 100 } },
         },
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: { dreaming: { enabled: true } },
+            },
+          },
+        },
       }),
     );
 
@@ -103,6 +110,13 @@ describe("memory_search recall tracking", () => {
     const tool = createSearchTool(
       asOpenClawConfig({
         agents: { list: [{ id: "main", default: true }] },
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: { dreaming: { enabled: true } },
+            },
+          },
+        },
       }),
     );
     setMemorySearchImpl(async () => [
@@ -164,6 +178,7 @@ describe("memory_search recall tracking", () => {
             "memory-core": {
               config: {
                 dreaming: {
+                  enabled: true,
                   timezone: "Europe/London",
                 },
               },
@@ -178,5 +193,40 @@ describe("memory_search recall tracking", () => {
     expect(recallTrackingMock.recordShortTermRecalls).toHaveBeenCalledTimes(1);
     const [firstCall] = recallTrackingMock.recordShortTermRecalls.mock.calls;
     expect(firstCall?.[0]?.timezone).toBe("Europe/London");
+  });
+
+  it("skips recall tracking entirely when dreaming.enabled is false (#84436)", async () => {
+    setMemorySearchImpl(async () => [
+      {
+        path: "memory/2026-04-03.md",
+        startLine: 1,
+        endLine: 2,
+        score: 0.95,
+        snippet: "Move backups to S3 Glacier.",
+        source: "memory" as const,
+      },
+    ]);
+
+    const tool = createSearchTool(
+      asOpenClawConfig({
+        agents: { list: [{ id: "main", default: true }] },
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: { enabled: false },
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    const result = await tool.execute("call_recall_dreaming_off", { query: "glacier" });
+    const details = result.details as { results: Array<{ path: string }> };
+    expect(details.results).toHaveLength(1);
+    expect(details.results[0]?.path).toBe("memory/2026-04-03.md");
+
+    expect(recallTrackingMock.recordShortTermRecalls).not.toHaveBeenCalled();
   });
 });

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -109,7 +109,14 @@ function queueShortTermRecallTracking(params: {
   rawResults: MemorySearchResult[];
   surfacedResults: MemorySearchResult[];
   timezone?: string;
+  dreamingEnabled: boolean;
 }): void {
+  // Recall tracking only feeds dreaming/promotion (writes memory/.dreams/*).
+  // When dreaming is disabled, callers don't want those artifacts created on
+  // ordinary memory_search runs. Skip the write entirely. See issue #84436.
+  if (!params.dreamingEnabled) {
+    return;
+  }
   const trackingResults = resolveRecallTrackingResults(params.rawResults, params.surfacedResults);
   void recordShortTermRecalls({
     workspaceDir: params.workspaceDir,
@@ -327,16 +334,18 @@ export function createMemorySearchTool(options: {
               ...result,
               corpus: result.source,
             }));
-            const sleepTimezone = resolveMemoryDeepDreamingConfig({
+            const dreamingConfig = resolveMemoryDeepDreamingConfig({
               pluginConfig: resolveMemoryCorePluginConfig(cfg),
               cfg,
-            }).timezone;
+            });
+            const sleepTimezone = dreamingConfig.timezone;
             queueShortTermRecallTracking({
               workspaceDir: status.workspaceDir,
               query,
               rawResults,
               surfacedResults: memoryResults,
               timezone: sleepTimezone,
+              dreamingEnabled: dreamingConfig.enabled,
             });
             provider = status.provider;
             model = status.model;


### PR DESCRIPTION
## Summary

Fixes #84436.

When `plugins.entries.memory-core.config.dreaming.enabled=false`, ordinary `memory_search` tool calls and `openclaw memory search` CLI runs still wrote dreaming-related artifacts (`memory/.dreams/short-term-recall.json` and `memory/.dreams/events.jsonl`), even though users expect that flag to disable all dreaming side effects.

Root cause: `recordShortTermRecalls(...)` is called unconditionally from `extensions/memory-core/src/tools.ts` (in the `memory_search` tool's recall-tracking queue) and `extensions/memory-core/src/cli.runtime.ts` (in `runMemorySearch`). Recall tracking exists only to feed dreaming/promotion, so those writes are only useful when dreaming is on.

## Fix

Gate the recall-tracking call on the resolved top-level `dreaming.enabled` flag at both call sites:

- `tools.ts`: pass the already-resolved `resolveMemoryDeepDreamingConfig({...}).enabled` into `queueShortTermRecallTracking`, which now early-returns when the flag is false. (The deep-dreaming resolver already ANDs the master switch with the deep phase's own enabled flag, which matches the intent — recall tracking only matters when both are on.)
- `cli.runtime.ts`: wrap the `recordShortTermRecalls` call in `if (dreaming.enabled)` where `dreaming` is already being resolved a few lines earlier.

Ordinary `memory_search`, `memory_get`, `corpus=wiki/all`, citations, and session-transcript recall behavior is unchanged — only the dreaming-side-effect writes are suppressed. Gating at the caller means both `short-term-recall.json` and the `events.jsonl` append (which happens inside `recordShortTermRecalls`) are skipped together.

## Tests

- New `tools.recall-tracking.test.ts` case: `memory_search` does not call `recordShortTermRecalls` when `dreaming.enabled=false`.
- New `cli.test.ts` case: `openclaw memory search --json` does not create `memory/.dreams/short-term-recall.json` or `memory/.dreams/events.jsonl` when `dreaming.enabled=false`.
- Updated three existing recall-tracking tests (in `tools.recall-tracking.test.ts`, `tools.citations.test.ts`, `cli.test.ts`) to opt into `dreaming.enabled=true`, since `DEFAULT_MEMORY_DREAMING_ENABLED=false` means the default config now correctly skips the write — those tests are specifically verifying tracking behavior, so they need to be in the on state.

Full `extensions/memory-core` suite: **688 passed / 688**.

## Notes

- I added a single CHANGELOG.md entry under `## Unreleased > ### Fixes`. The `changelog/fragments/` workflow appears to be deprecated (the directory is git-ignored), so I followed the inline-CHANGELOG convention used by most recent fixes.
- I did not touch `dreaming-phases.ts`, `dreaming.ts`, or `short-term-promotion.ts` — those call sites either already gate on the flag or live behind it.
