### PR TITLE
fix: omit api keys from generated models json

### DIFF
--- a/src/agents/models-config.applies-config-env-vars.test.ts
+++ b/src/agents/models-config.applies-config-env-vars.test.ts
@@ -276,4 +276,45 @@ describe("models-config", () => {
       expect(process.env[TEST_ENV_VAR]).toBe("from-host");
     });
   });
+
+  it("omits provider apiKey fields from generated models.json contents", async () => {
+    const cfg: OpenClawConfig = {
+      models: {
+        providers: {
+          "custom-proxy": {
+            ...createImplicitOpenRouterProvider(),
+            apiKey: "CUSTOM_PROXY_API_KEY", // pragma: allowlist secret
+          },
+        },
+      },
+    };
+
+    const plan = await planOpenClawModelsJsonWithDeps(
+      {
+        cfg,
+        agentDir: "/tmp/openclaw-models-config-env-vars-test",
+        env: { OPENROUTER_API_KEY: "from-env" }, // pragma: allowlist secret
+        existingRaw: "",
+        existingParsed: null,
+      },
+      {
+        resolveImplicitProviders: async () => ({
+          openrouter: createImplicitOpenRouterProvider(),
+        }),
+      },
+    );
+
+    expect(plan.action).toBe("write");
+    if (plan.action !== "write") {
+      throw new Error("Expected models.json write plan");
+    }
+    const parsed = JSON.parse(plan.contents) as {
+      providers?: Record<string, { apiKey?: unknown; models?: Array<{ id?: string }> }>;
+    };
+
+    expect(parsed.providers?.["custom-proxy"]?.apiKey).toBeUndefined();
+    expect(parsed.providers?.openrouter?.apiKey).toBeUndefined();
+    expect(parsed.providers?.["custom-proxy"]?.models?.[0]?.id).toBe("openrouter/auto");
+    expect(parsed.providers?.openrouter?.models?.[0]?.id).toBe("openrouter/auto");
+  });
 });

--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -105,6 +105,25 @@ function resolveProvidersForMode(params: {
   });
 }
 
+function omitProviderApiKeysForModelsJson(
+  providers: Record<string, ProviderConfig>,
+): Record<string, ProviderConfig> {
+  let mutated = false;
+  const next: Record<string, ProviderConfig> = {};
+
+  for (const [providerId, provider] of Object.entries(providers)) {
+    if ("apiKey" in provider) {
+      const { apiKey: _apiKey, ...providerWithoutApiKey } = provider;
+      next[providerId] = providerWithoutApiKey;
+      mutated = true;
+      continue;
+    }
+    next[providerId] = provider;
+  }
+
+  return mutated ? next : providers;
+}
+
 export async function planOpenClawModelsJsonWithDeps(
   params: {
     cfg: OpenClawConfig;
@@ -178,7 +197,8 @@ export async function planOpenClawModelsJsonWithDeps(
       secretRefManagedProviders,
     }) ?? normalizedMergedProviders;
   const finalProviders = applyNativeStreamingUsageCompat(secretEnforcedProviders);
-  const nextContents = `${JSON.stringify({ providers: finalProviders }, null, 2)}\n`;
+  const modelsJsonProviders = omitProviderApiKeysForModelsJson(finalProviders);
+  const nextContents = `${JSON.stringify({ providers: modelsJsonProviders }, null, 2)}\n`;
 
   if (params.existingRaw === nextContents) {
     return { action: "noop" };

--- a/src/agents/models-config.skips-writing-models-json-no-env-token.test.ts
+++ b/src/agents/models-config.skips-writing-models-json-no-env-token.test.ts
@@ -102,7 +102,6 @@ async function runEnvProviderCase(params: {
   envVar: "MINIMAX_API_KEY" | "SYNTHETIC_API_KEY";
   envValue: string;
   providerKey: "minimax" | "synthetic";
-  expectedApiKeyRef: string;
 }) {
   const previousValue = process.env[params.envVar];
   process.env[params.envVar] = params.envValue;
@@ -113,7 +112,8 @@ async function runEnvProviderCase(params: {
     const raw = await fs.readFile(modelPath, "utf8");
     const parsed = JSON.parse(raw) as { providers: Record<string, ParsedProviderConfig> };
     const provider = parsed.providers[params.providerKey];
-    expect(provider?.apiKey).toBe(params.expectedApiKeyRef);
+    expect(provider).toBeDefined();
+    expect(provider?.apiKey).toBeUndefined();
   } finally {
     if (previousValue === undefined) {
       delete process.env[params.envVar];
@@ -211,7 +211,6 @@ describe("models-config", () => {
         envVar: "MINIMAX_API_KEY",
         envValue: "sk-minimax-test",
         providerKey: "minimax",
-        expectedApiKeyRef: "MINIMAX_API_KEY", // pragma: allowlist secret
       });
     });
   });
@@ -222,7 +221,6 @@ describe("models-config", () => {
         envVar: "SYNTHETIC_API_KEY",
         envValue: "sk-synthetic-test",
         providerKey: "synthetic",
-        expectedApiKeyRef: "SYNTHETIC_API_KEY", // pragma: allowlist secret
       });
     });
   });


### PR DESCRIPTION
# PR: Omit provider apiKey fields from generated models.json

Fixes openclaw/openclaw#11829

## Summary

- Strips provider-level `apiKey` fields at the generated `models.json` serialization boundary.
- Keeps provider and model metadata intact so model catalog generation still works.
- Updates env-gated provider tests to assert providers are written without auth hints.
- Adds a regression test covering both explicit configured providers and implicit discovered providers.

## Validation

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/models-config.applies-config-env-vars.test.ts`
  - initially failed before the production change because `CUSTOM_PROXY_API_KEY` was serialized
  - passes after the fix
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/models-config.applies-config-env-vars.test.ts src/agents/models-config.skips-writing-models-json-no-env-token.test.ts src/agents/models-config.write-serialization.test.ts src/agents/models-config.merge.test.ts src/agents/models-config.file-mode.test.ts`
  - `5 passed`, `34 passed`
- `.\node_modules\.bin\oxfmt.cmd --check src/agents/models-config.plan.ts src/agents/models-config.applies-config-env-vars.test.ts src/agents/models-config.skips-writing-models-json-no-env-token.test.ts`
  - passed
- `.\node_modules\.bin\oxlint.cmd src/agents/models-config.plan.ts src/agents/models-config.applies-config-env-vars.test.ts src/agents/models-config.skips-writing-models-json-no-env-token.test.ts`
  - `0 warnings`, `0 errors`
- `corepack pnpm run tsgo:core:test`
  - passed

## Implementation Notes

This keeps normalization and source-managed secret handling unchanged until the final write plan is ready. The only serialized artifact change is that generated provider entries no longer include `apiKey`, reducing prompt/context exposure from `models.json`.
