### PR TITLE
fix(memory): strip invalid thinking signatures for signed-thinking providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - MiniMax: store OAuth token expiry as an absolute millisecond timestamp so OAuth profiles no longer appear expired on every request. (#83480) Thanks @NianJiuZst.
+- Agents/Anthropic: strip missing or blank thinking signatures for signed-thinking providers even when recovery supplies a narrow replay policy without signature preservation. Fixes #84430. (#84448) Thanks @NianJiuZst.
 - Agents/channels: send a visible notice when an aborted main session cannot be resumed after restart, including Telegram group targets. (#85805) Thanks @pfrederiksen.
 - Discord/voice: serialize overlapping voice joins, retry aborted startup readiness within the configured timeout, upgrade meeting-notes-only sessions to realtime when the normal follow join arrives, detach promoted meeting-notes ownership without leaving voice, and include `OpenClaw` in default realtime wake names.
 - Gateway/restart: honor the configured restart drain budget for embedded runs and avoid spending the deferral timeout twice after forced restart timeouts. (#85708) Thanks @Kaspre.

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -1720,6 +1720,75 @@ describe("sanitizeSessionHistory", () => {
     expect((result[2] as Extract<AgentMessage, { role: "toolResult" }>).toolCallId).toBe("call_1");
   });
 
+  it.each([
+    {
+      provider: "anthropic",
+      modelApi: "anthropic-messages",
+      label: "anthropic",
+    },
+    {
+      provider: "amazon-bedrock",
+      modelApi: "bedrock-converse-stream",
+      label: "bedrock",
+    },
+  ])(
+    "preserves signed thinking tool ids for $label when preserveSignatures is false",
+    async ({ provider, modelApi }) => {
+      setNonGoogleModelApi();
+
+      const messages = castAgentMessages([
+        makeUserMessage("retry"),
+        makeAssistantMessage([
+          {
+            type: "thinking",
+            thinking: "internal",
+            thinkingSignature: "sig_1",
+          },
+          { type: "toolCall", id: "call_1", name: "read", arguments: {} },
+        ] as unknown as AssistantMessage["content"]),
+        castAgentMessage({
+          role: "toolResult",
+          toolCallId: "call_1",
+          toolName: "read",
+          content: [{ type: "text", text: "ok" }],
+          isError: false,
+        }),
+      ]);
+
+      const result = await sanitizeAnthropicHistory({
+        provider,
+        modelApi,
+        messages,
+        policy: {
+          sanitizeMode: "full",
+          sanitizeToolCallIds: true,
+          toolCallIdMode: "strict",
+          preserveNativeAnthropicToolUseIds: false,
+          repairToolUseResultPairing: true,
+          preserveSignatures: false,
+          sanitizeThinkingSignatures: false,
+          dropThinkingBlocks: false,
+          applyGoogleTurnOrdering: false,
+          validateGeminiTurns: false,
+          validateAnthropicTurns: true,
+          allowSyntheticToolResults: false,
+        },
+      });
+
+      expect((result[1] as Extract<AgentMessage, { role: "assistant" }>).content).toEqual([
+        {
+          type: "thinking",
+          thinking: "internal",
+          thinkingSignature: "sig_1",
+        },
+        { type: "toolCall", id: "call_1", name: "read", arguments: {} },
+      ]);
+      expect((result[2] as Extract<AgentMessage, { role: "toolResult" }>).toolCallId).toBe(
+        "call_1",
+      );
+    },
+  );
+
   it("keeps earlier mutable ids from colliding with later preserved signed ids", async () => {
     setNonGoogleModelApi();
 

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -2007,4 +2007,181 @@ describe("sanitizeSessionHistory", () => {
     const types = getAssistantContentTypes(result);
     expect(types).toContain("thinking");
   });
+
+  it("strips unsigned thinking blocks for anthropic api even when preserveSignatures is false", async () => {
+    setNonGoogleModelApi();
+
+    const messages = castAgentMessages([
+      makeUserMessage("analyze"),
+      makeAssistantMessage([
+        { type: "thinking", thinking: "no signature" },
+        { type: "thinking", thinking: "empty sig", thinkingSignature: "" },
+        { type: "thinking", thinking: "blank sig", thinkingSignature: "   " },
+        { type: "thinking", thinking: "valid", thinkingSignature: "sig_abc" },
+        { type: "text", text: "result" },
+      ]),
+    ]);
+
+    const result = await sanitizeAnthropicHistory({
+      messages,
+      modelApi: "anthropic-messages",
+      preserveLatestAssistantThinking: false,
+      policy: {
+        sanitizeMode: "full",
+        sanitizeToolCallIds: true,
+        toolCallIdMode: "strict",
+        preserveNativeAnthropicToolUseIds: false,
+        repairToolUseResultPairing: true,
+        preserveSignatures: false,
+        sanitizeThinkingSignatures: false,
+        dropThinkingBlocks: false,
+        applyGoogleTurnOrdering: false,
+        validateGeminiTurns: false,
+        validateAnthropicTurns: true,
+        allowSyntheticToolResults: false,
+      },
+    });
+
+    const assistant = getAssistantMessage(result);
+    const content = assistant.content;
+    const thinkingBlocks = content.filter(
+      (b: { type: string }) => b.type === "thinking" || b.type === "redacted_thinking",
+    );
+    const textBlocks = content.filter((b: { type: string }) => b.type === "text");
+
+    // Only the valid signed thinking block should survive
+    expect(thinkingBlocks).toHaveLength(1);
+    expect((thinkingBlocks[0] as { thinkingSignature?: string }).thinkingSignature).toBe("sig_abc");
+    expect(textBlocks).toHaveLength(1);
+    expect((textBlocks[0] as { text?: string }).text).toBe("result");
+  });
+
+  it("preserves unsigned thinking blocks for kimi coding with anthropic-messages transport", async () => {
+    setNonGoogleModelApi();
+
+    const messages = castAgentMessages([
+      makeUserMessage("analyze"),
+      makeAssistantMessage([
+        { type: "thinking", thinking: "unsigned kimi reasoning" },
+        { type: "text", text: "result" },
+      ]),
+    ]);
+
+    // Kimi uses anthropic-messages transport but does not require signed thinking.
+    // Its provider-level preserveSignatures is false and should stay gated.
+    const result = await sanitizeSessionHistory({
+      messages,
+      modelApi: "anthropic-messages",
+      provider: "kimi",
+      modelId: "kimi-for-coding",
+      sessionManager: makeMockSessionManager(),
+      sessionId: TEST_SESSION_ID,
+      policy: {
+        sanitizeMode: "full",
+        sanitizeToolCallIds: true,
+        toolCallIdMode: "strict",
+        preserveNativeAnthropicToolUseIds: false,
+        repairToolUseResultPairing: true,
+        preserveSignatures: false,
+        sanitizeThinkingSignatures: false,
+        dropThinkingBlocks: false,
+        dropReasoningFromHistory: false,
+        applyGoogleTurnOrdering: false,
+        validateGeminiTurns: false,
+        validateAnthropicTurns: false,
+        allowSyntheticToolResults: false,
+      },
+    });
+
+    const assistant = getAssistantMessage(result);
+    const thinkingBlocks = assistant.content.filter((b: { type: string }) => b.type === "thinking");
+    expect(thinkingBlocks).toHaveLength(1);
+    expect((thinkingBlocks[0] as { thinking?: string }).thinking).toBe("unsigned kimi reasoning");
+  });
+
+  it("preserves unsigned thinking blocks for github copilot claude with anthropic-messages transport", async () => {
+    setNonGoogleModelApi();
+
+    const messages = castAgentMessages([
+      makeUserMessage("analyze"),
+      makeAssistantMessage([
+        { type: "thinking", thinking: "unsigned copilot reasoning" },
+        { type: "text", text: "result" },
+      ]),
+    ]);
+
+    // GitHub Copilot Claude uses anthropic-messages transport but does not
+    // require signed thinking. Its provider-level preserveSignatures is false.
+    const result = await sanitizeSessionHistory({
+      messages,
+      modelApi: "anthropic-messages",
+      provider: "github-copilot",
+      modelId: "claude-opus-4.6",
+      sessionManager: makeMockSessionManager(),
+      sessionId: TEST_SESSION_ID,
+      policy: {
+        sanitizeMode: "full",
+        sanitizeToolCallIds: true,
+        toolCallIdMode: "strict",
+        preserveNativeAnthropicToolUseIds: false,
+        repairToolUseResultPairing: true,
+        preserveSignatures: false,
+        sanitizeThinkingSignatures: false,
+        dropThinkingBlocks: false,
+        dropReasoningFromHistory: false,
+        applyGoogleTurnOrdering: false,
+        validateGeminiTurns: false,
+        validateAnthropicTurns: false,
+        allowSyntheticToolResults: false,
+      },
+    });
+
+    const assistant = getAssistantMessage(result);
+    const thinkingBlocks = assistant.content.filter((b: { type: string }) => b.type === "thinking");
+    expect(thinkingBlocks).toHaveLength(1);
+    expect((thinkingBlocks[0] as { thinking?: string }).thinking).toBe(
+      "unsigned copilot reasoning",
+    );
+  });
+
+  it("strips unsigned thinking for bedrock-converse-stream even when preserveSignatures is false", async () => {
+    setNonGoogleModelApi();
+
+    const messages = castAgentMessages([
+      makeUserMessage("analyze"),
+      makeAssistantMessage([
+        { type: "thinking", thinking: "no sig" },
+        { type: "thinking", thinking: "signed", thinkingSignature: "sig_bedrock" },
+        { type: "text", text: "done" },
+      ]),
+    ]);
+
+    const result = await sanitizeAnthropicHistory({
+      messages,
+      provider: "amazon-bedrock",
+      modelApi: "bedrock-converse-stream",
+      preserveLatestAssistantThinking: false,
+      policy: {
+        sanitizeMode: "full",
+        sanitizeToolCallIds: true,
+        toolCallIdMode: "strict",
+        preserveNativeAnthropicToolUseIds: false,
+        repairToolUseResultPairing: true,
+        preserveSignatures: false,
+        sanitizeThinkingSignatures: false,
+        dropThinkingBlocks: false,
+        applyGoogleTurnOrdering: false,
+        validateGeminiTurns: false,
+        validateAnthropicTurns: true,
+        allowSyntheticToolResults: false,
+      },
+    });
+
+    const assistant = getAssistantMessage(result);
+    const thinkingBlocks = assistant.content.filter((b: { type: string }) => b.type === "thinking");
+    expect(thinkingBlocks).toHaveLength(1);
+    expect((thinkingBlocks[0] as { thinkingSignature?: string }).thinkingSignature).toBe(
+      "sig_bedrock",
+    );
+  });
 });

--- a/src/agents/pi-embedded-runner/replay-history.ts
+++ b/src/agents/pi-embedded-runner/replay-history.ts
@@ -696,10 +696,13 @@ export async function sanitizeSessionHistory(params: {
       model: params.model,
     });
   const withInterSessionMarkers = annotateInterSessionUserMessages(params.messages);
-  const allowProviderOwnedThinkingReplay = shouldAllowProviderOwnedThinkingReplay({
-    modelApi: params.modelApi,
-    policy,
-  });
+  const signedThinkingProvider = providerRequiresSignedThinking(params.provider);
+  const allowProviderOwnedThinkingReplay =
+    shouldAllowProviderOwnedThinkingReplay({
+      modelApi: params.modelApi,
+      policy,
+    }) ||
+    (signedThinkingProvider && !policy.dropThinkingBlocks);
   const isOpenAIResponsesApi =
     params.modelApi === "openai-responses" ||
     params.modelApi === "openai-codex-responses" ||
@@ -734,7 +737,7 @@ export async function sanitizeSessionHistory(params: {
   // signatures once the assistant turn is no longer latest in the outbound
   // request.
   const validatedThinkingSignatures =
-    providerRequiresSignedThinking(params.provider) || policy.preserveSignatures
+    signedThinkingProvider || policy.preserveSignatures
       ? stripInvalidThinkingSignatures(sanitizedImages, {
           preserveLatestAssistant: params.preserveLatestAssistantThinking ?? true,
         })

--- a/src/agents/pi-embedded-runner/replay-history.ts
+++ b/src/agents/pi-embedded-runner/replay-history.ts
@@ -35,6 +35,7 @@ import { STREAM_ERROR_FALLBACK_TEXT } from "../stream-message-shared.js";
 import { sanitizeToolCallIdsForCloudCodeAssist } from "../tool-call-id.js";
 import type { TranscriptPolicy } from "../transcript-policy.js";
 import {
+  providerRequiresSignedThinking,
   resolveTranscriptPolicy,
   shouldAllowProviderOwnedThinkingReplay,
 } from "../transcript-policy.js";
@@ -658,12 +659,6 @@ function isSameModelSnapshot(a: ModelSnapshotEntry, b: ModelSnapshotEntry): bool
   );
 }
 
-const SIGNED_THINKING_PROVIDERS = new Set(["anthropic", "amazon-bedrock", "anthropic-vertex"]);
-
-function providerRequiresSignedThinking(provider?: string | null): boolean {
-  return SIGNED_THINKING_PROVIDERS.has(provider ?? "");
-}
-
 /**
  * Applies the generic replay-history cleanup pipeline before provider-owned
  * replay hooks run.
@@ -697,12 +692,11 @@ export async function sanitizeSessionHistory(params: {
     });
   const withInterSessionMarkers = annotateInterSessionUserMessages(params.messages);
   const signedThinkingProvider = providerRequiresSignedThinking(params.provider);
-  const allowProviderOwnedThinkingReplay =
-    shouldAllowProviderOwnedThinkingReplay({
-      modelApi: params.modelApi,
-      policy,
-    }) ||
-    (signedThinkingProvider && !policy.dropThinkingBlocks);
+  const allowProviderOwnedThinkingReplay = shouldAllowProviderOwnedThinkingReplay({
+    modelApi: params.modelApi,
+    provider: params.provider,
+    policy,
+  });
   const isOpenAIResponsesApi =
     params.modelApi === "openai-responses" ||
     params.modelApi === "openai-codex-responses" ||

--- a/src/agents/pi-embedded-runner/replay-history.ts
+++ b/src/agents/pi-embedded-runner/replay-history.ts
@@ -658,6 +658,12 @@ function isSameModelSnapshot(a: ModelSnapshotEntry, b: ModelSnapshotEntry): bool
   );
 }
 
+const SIGNED_THINKING_PROVIDERS = new Set(["anthropic", "amazon-bedrock", "anthropic-vertex"]);
+
+function providerRequiresSignedThinking(provider?: string | null): boolean {
+  return SIGNED_THINKING_PROVIDERS.has(provider ?? "");
+}
+
 /**
  * Applies the generic replay-history cleanup pipeline before provider-owned
  * replay hooks run.
@@ -723,11 +729,16 @@ export async function sanitizeSessionHistory(params: {
       ...resolveImageSanitizationLimits(params.config),
     },
   );
-  const validatedThinkingSignatures = policy.preserveSignatures
-    ? stripInvalidThinkingSignatures(sanitizedImages, {
-        preserveLatestAssistant: params.preserveLatestAssistantThinking ?? true,
-      })
-    : sanitizedImages;
+  // Some recovery paths supply a narrow policy with preserveSignatures disabled.
+  // Native signed-thinking providers still cannot replay missing/blank
+  // signatures once the assistant turn is no longer latest in the outbound
+  // request.
+  const validatedThinkingSignatures =
+    providerRequiresSignedThinking(params.provider) || policy.preserveSignatures
+      ? stripInvalidThinkingSignatures(sanitizedImages, {
+          preserveLatestAssistant: params.preserveLatestAssistantThinking ?? true,
+        })
+      : sanitizedImages;
   const droppedReasoning = policy.dropReasoningFromHistory
     ? dropReasoningFromHistory(validatedThinkingSignatures)
     : validatedThinkingSignatures;

--- a/src/agents/pi-embedded-runner/run/attempt.tool-call-normalization.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.tool-call-normalization.test.ts
@@ -130,6 +130,46 @@ describe("sanitizeReplayToolCallIdsForStream", () => {
     });
   });
 
+  it("preserves signed-thinking replay ids when requested by provider policy", () => {
+    const rawId = "call_1";
+    const out = sanitizeReplayToolCallIdsForStream({
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "internal", thinkingSignature: "sig_1" },
+            { type: "toolUse", id: rawId, name: "read", input: { path: "." } },
+          ],
+        } as never,
+        {
+          role: "toolResult",
+          toolCallId: rawId,
+          toolUseId: rawId,
+          toolName: "read",
+          content: [{ type: "text", text: "ok" }],
+          isError: false,
+        } as never,
+      ],
+      mode: "strict",
+      preserveReplaySafeThinkingToolCallIds: true,
+      repairToolUseResultPairing: true,
+    });
+
+    expect(out.map((message) => message.role)).toEqual(["assistant", "toolResult"]);
+    expect(requireAssistantMessage(out[0]).content[1]).toMatchObject({
+      type: "toolUse",
+      id: "call_1",
+      name: "read",
+    });
+    expect(toolResultSummary(out[1])).toEqual({
+      role: "toolResult",
+      toolCallId: "call_1",
+      toolUseId: "call_1",
+      toolName: "read",
+      isError: false,
+    });
+  });
+
   it("synthesizes missing tool results after strict id sanitization", () => {
     const rawId = "call_function_av7cbkigmk7x1";
     const out = sanitizeReplayToolCallIdsForStream({

--- a/src/agents/pi-embedded-runner/run/attempt.tool-call-normalization.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.tool-call-normalization.ts
@@ -919,6 +919,7 @@ export function wrapStreamFnSanitizeMalformedToolCalls(
     TranscriptPolicy,
     "validateGeminiTurns" | "validateAnthropicTurns" | "preserveSignatures" | "dropThinkingBlocks"
   >,
+  provider?: string | null,
 ): StreamFn {
   return (model, context, options) => {
     const ctx = context as unknown as { messages?: unknown };
@@ -928,6 +929,7 @@ export function wrapStreamFnSanitizeMalformedToolCalls(
     }
     const allowProviderOwnedThinkingReplay = shouldAllowProviderOwnedThinkingReplay({
       modelApi: (model as { api?: unknown })?.api as string | null | undefined,
+      provider,
       policy: {
         validateAnthropicTurns: transcriptPolicy?.validateAnthropicTurns === true,
         preserveSignatures: transcriptPolicy?.preserveSignatures === true,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2855,6 +2855,7 @@ export async function runEmbeddedAttempt(
             preserveNativeAnthropicToolUseIds: transcriptPolicy.preserveNativeAnthropicToolUseIds,
             preserveReplaySafeThinkingToolCallIds: shouldAllowProviderOwnedThinkingReplay({
               modelApi: (model as { api?: unknown })?.api as string | null | undefined,
+              provider: params.provider,
               policy: transcriptPolicy,
             }),
             repairToolUseResultPairing: transcriptPolicy.repairToolUseResultPairing,
@@ -2911,6 +2912,7 @@ export async function runEmbeddedAttempt(
         activeSession.agent.streamFn,
         allowedToolNames,
         transcriptPolicy,
+        params.provider,
       );
       activeSession.agent.streamFn = wrapStreamFnTrimToolCallNames(
         activeSession.agent.streamFn,

--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -617,6 +617,24 @@ describe("resolveTranscriptPolicy", () => {
     ).toBe(true);
   });
 
+  it.each(["anthropic", "amazon-bedrock"] as const)(
+    "allows provider-owned thinking replay for signed-thinking %s recovery policies",
+    (provider) => {
+      expect(
+        shouldAllowProviderOwnedThinkingReplay({
+          provider,
+          modelApi:
+            provider === "amazon-bedrock" ? "bedrock-converse-stream" : "anthropic-messages",
+          policy: {
+            validateAnthropicTurns: true,
+            preserveSignatures: false,
+            dropThinkingBlocks: false,
+          },
+        }),
+      ).toBe(true);
+    },
+  );
+
   it("does not allow immutable provider-owned thinking replay for github-copilot claude models", () => {
     const policy = resolveTranscriptPolicy({
       provider: "github-copilot",

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -32,17 +32,26 @@ export type TranscriptPolicy = {
   allowSyntheticToolResults: boolean;
 };
 
+const SIGNED_THINKING_PROVIDERS = new Set(["anthropic", "amazon-bedrock", "anthropic-vertex"]);
+
+export function providerRequiresSignedThinking(provider?: string | null): boolean {
+  return SIGNED_THINKING_PROVIDERS.has(normalizeProviderId(provider ?? ""));
+}
+
 export function shouldAllowProviderOwnedThinkingReplay(params: {
   modelApi?: string | null;
+  provider?: string | null;
   policy: Pick<
     TranscriptPolicy,
     "validateAnthropicTurns" | "preserveSignatures" | "dropThinkingBlocks"
   >;
 }): boolean {
+  const hasProviderOwnedSignedThinking =
+    params.policy.preserveSignatures || providerRequiresSignedThinking(params.provider);
   return (
     isAnthropicApi(params.modelApi) &&
     params.policy.validateAnthropicTurns &&
-    params.policy.preserveSignatures &&
+    hasProviderOwnedSignedThinking &&
     !params.policy.dropThinkingBlocks
   );
 }


### PR DESCRIPTION
## Summary

- Fixes #84430 — incomplete thinking blocks (missing signature) persisted to session JSONL cause `Invalid signature in thinking block` on next request
- `stripInvalidThinkingSignatures` was conditionally gated on `policy.preserveSignatures`, allowing unsigned thinking blocks to reach the Anthropic API on recovery paths where `preserveSignatures` is `false`
- Scoped the unconditional sanitizer to the three providers that require signed thinking: `anthropic`, `amazon-bedrock`, and `anthropic-vertex`. Providers using `anthropic-messages` transport without signed-thinking requirements (Kimi Coding, GitHub Copilot Claude) remain gated by `policy.preserveSignatures`

## Changes

- `src/agents/pi-embedded-runner/replay-history.ts`: `stripInvalidThinkingSignatures` now always runs for Anthropic/Bedrock/Vertex providers regardless of `preserveSignatures`; other providers keep the `policy.preserveSignatures` gate
- `src/agents/pi-embedded-runner.sanitize-session-history.test.ts`: 4 new regression tests covering the `preserveSignatures: false` path for Anthropic, Bedrock, Kimi Coding (anthropic-messages transport), and GitHub Copilot Claude (anthropic-messages transport)

## Real behavior proof

Behavior addressed: persisted unsigned Anthropic thinking blocks no longer poison session continuation. The replay sanitizer strips unreplayable thinking blocks before the next provider send, while preserving the replayable text context.

Real environment tested: macOS Darwin 25.4.0 (arm64), Node.js v24.14.1, OpenClaw 2026.5.19 (`7c280d7`), current PR branch, local QA mock Anthropic-compatible provider via `extensions/qa-lab/src/providers/mock-openai/server.ts`

Exact steps or command run after this patch:
```bash
node --import tsx --input-type=module <<'EOF'
import fs from 'node:fs/promises';
import os from 'node:os';
import path from 'node:path';
import { startQaMockOpenAiServer } from './extensions/qa-lab/src/providers/mock-openai/server.ts';
import { runEmbeddedPiAgent } from './src/agents/pi-embedded-runner.ts';
import { SessionManager } from '@earendil-works/pi-coding-agent';

const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'openclaw-pr84448-proof-'));
const agentDir = path.join(tempRoot, 'agent');
const workspaceDir = path.join(tempRoot, 'workspace');
await fs.mkdir(agentDir, { recursive: true });
await fs.mkdir(workspaceDir, { recursive: true });
const server = await startQaMockOpenAiServer({ host: '127.0.0.1', port: 0 });

try {
  const sessionFile = path.join(workspaceDir, 'broken-thinking-session.jsonl');
  const sessionManager = SessionManager.open(sessionFile);
  sessionManager.appendMessage({
    role: 'user',
    content: [{ type: 'text', text: 'Remember the canary BROKEN-SIGNATURE-CANARY.' }],
    timestamp: Date.now() - 10_000,
  });
  sessionManager.appendMessage({
    role: 'assistant',
    content: [
      { type: 'thinking', thinking: 'partial reasoning persisted before signature arrived' },
      { type: 'text', text: 'I remember BROKEN-SIGNATURE-CANARY.' },
    ],
    stopReason: 'stop',
    api: 'anthropic-messages',
    provider: 'anthropic',
    model: 'claude-opus-4-7',
    usage: {
      input: 1,
      output: 1,
      cacheRead: 0,
      cacheWrite: 0,
      totalTokens: 2,
      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
    },
    timestamp: Date.now() - 9_000,
  });

  await runEmbeddedPiAgent({
    sessionId: 'session:test',
    sessionKey: 'agent:test:embedded:pr84448-proof',
    sessionFile,
    workspaceDir,
    config: {
      models: {
        providers: {
          anthropic: {
            api: 'anthropic-messages',
            apiKey: 'sk-test-anthropic',
            baseUrl: `${server.baseUrl}/v1`,
            models: [{
              id: 'claude-opus-4-7',
              name: 'Claude Opus 4.7',
              reasoning: true,
              input: ['text'],
              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
              contextWindow: 200000,
              maxTokens: 8192,
            }],
          },
        },
      },
    },
    prompt: 'Reply with exactly RECOVERY-OK if the remembered canary is BROKEN-SIGNATURE-CANARY.',
    provider: 'anthropic',
    model: 'claude-opus-4-7',
    timeoutMs: 120000,
    agentDir,
    runId: 'pr84448-proof-run',
    enqueue: async (task) => await task(),
    disableTools: true,
  });

  const response = await fetch(`${server.baseUrl}/debug/last-request`);
  console.log(JSON.stringify(await response.json(), null, 2));
} finally {
  await fs.rm(tempRoot, { recursive: true, force: true });
}
EOF

node scripts/run-vitest.mjs src/agents/pi-embedded-runner/thinking.test.ts src/agents/pi-embedded-runner.sanitize-session-history.test.ts src/agents/transcript-policy.test.ts
```

Evidence after fix:
```json
{
  "payloadText": "Protocol note: acknowledged. Continue with the QA scenario plan and report worked, failed, and blocked items.",
  "livenessState": "working",
  "replayInvalid": false,
  "requestModel": "claude-opus-4-7",
  "providerVariant": "anthropic",
  "requestMessageCount": 3,
  "requestContainsBrokenThinkingBlock": false,
  "requestContainsThinkingType": false,
  "requestContainsCanaryText": true,
  "lastRequestPrompt": "Reply with exactly RECOVERY-OK if the remembered canary is BROKEN-SIGNATURE-CANARY."
}
```

Observed result after fix: the continuation succeeded through the real embedded runner path; the next Anthropic-compatible request still contained the remembered canary text, but it did not resend the corrupted thinking block and did not include any `"type":"thinking"` content blocks. `replayInvalid` stayed `false`, so the poisoned session recovered without tripping the invalid-replay guard.

What was not tested: live Anthropic cloud credentials; reproducing the original interrupted SSE capture against the real Anthropic service; write-side prevention of incomplete thinking persistence. This PR proves the replay-side recovery path only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
