### PR TITLE
fix(delivery): log failDelivery errors instead of silently swallowing

### DIFF
--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -2582,6 +2582,45 @@ describe("deliverOutboundPayloads", () => {
     );
   });
 
+  it("logs a warning when failDelivery rejects on bestEffort partial failure (#83113)", async () => {
+    queueMocks.failDelivery.mockRejectedValueOnce(new Error("queue storage down"));
+
+    await runBestEffortPartialFailureDelivery();
+
+    expect(queueMocks.failDelivery).toHaveBeenCalledWith(
+      "mock-queue-id",
+      "partial delivery failure (bestEffort)",
+    );
+    const warnCall = requireMockCall(logMocks.warn, "warn");
+    const warnMessage = String(warnCall[0]);
+    expect(warnMessage).toContain("failed to mark queued delivery");
+    expect(warnMessage).toContain("mock-queue-id");
+    expect(warnMessage).toContain("queue storage down");
+  });
+
+  it("logs a warning when failDelivery rejects in the error handler (#83113)", async () => {
+    const sendMatrix = vi.fn().mockRejectedValue(new Error("native send failed"));
+    queueMocks.failDelivery.mockRejectedValueOnce(new Error("db connection lost"));
+
+    await expect(
+      deliverOutboundPayloads({
+        cfg: {},
+        channel: "matrix",
+        to: "!room:example",
+        payloads: [{ text: "hello" }],
+        deps: { matrix: sendMatrix },
+        queuePolicy: "required",
+      }),
+    ).rejects.toThrow("native send failed");
+
+    expect(queueMocks.failDelivery).toHaveBeenCalledWith("mock-queue-id", expect.any(String));
+    const warnCall = requireMockCall(logMocks.warn, "warn");
+    const warnMessage = String(warnCall[0]);
+    expect(warnMessage).toContain("failed to mark queued delivery");
+    expect(warnMessage).toContain("mock-queue-id");
+    expect(warnMessage).toContain("db connection lost");
+  });
+
   it("writes raw payloads to the queue before normalization", async () => {
     const sendMatrix = vi.fn().mockResolvedValue({ messageId: "m-raw", roomId: "!room:example" });
     const rawPayloads: DeliverOutboundPayload[] = [

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -1295,7 +1295,13 @@ async function deliverOutboundPayloadsWithQueueCleanup(
     }
     if (queueId) {
       if (hadPartialFailure) {
-        await failDelivery(queueId, "partial delivery failure (bestEffort)").catch(() => {});
+        await failDelivery(queueId, "partial delivery failure (bestEffort)").catch(
+          (err: unknown) => {
+            log.warn(
+              `failed to mark queued delivery ${queueId} as failed after partial failure; continuing best-effort delivery: ${formatErrorMessage(err)}`,
+            );
+          },
+        );
       } else {
         if (platformSendStarted) {
           await markQueuedPlatformOutcomeUnknown({
@@ -1325,7 +1331,11 @@ async function deliverOutboundPayloadsWithQueueCleanup(
       if (isDeliveryAbortError(err)) {
         await ackDelivery(queueId).catch(() => {});
       } else if (!platformResultsReturned) {
-        await failDelivery(queueId, formatErrorMessage(err)).catch(() => {});
+        await failDelivery(queueId, formatErrorMessage(err)).catch((failErr: unknown) => {
+          log.warn(
+            `failed to mark queued delivery ${queueId} as failed: ${formatErrorMessage(failErr)}`,
+          );
+        });
       }
     }
     throw err;


### PR DESCRIPTION
## Problem

Two `.catch(() => {})` handlers on `failDelivery` calls in `deliverOutboundPayloadsWithQueueCleanup` silently discard errors when marking a queued delivery as failed:

1. **Line 1298** (partial failure path): After a best-effort delivery has partial failures, the catch swallows any error from `failDelivery(queueId, "partial delivery failure")`.
2. **Line 1328** (general failure path): When the delivery throws and the platform hasn't returned results, the catch swallows `failDelivery` errors.

If the delivery queue backend is unavailable (network partition, database lock), these silent swallows mean the queue entry stays in a stale state with no diagnostic trail.

## Fix

Replace both empty `.catch(() => {})` with `.catch((err) => { log.warn(...) })` that logs the queue ID and error message. This follows the existing pattern used by `markQueuedPlatformOutcomeUnknown` (line 1308) and `markQueuedPlatformSendAttemptStarted` in the same function.

Production diff is +11 lines changed across 1 file. No CHANGELOG changes.

## Real behavior proof

Behavior addressed: Two silent `.catch(() => {})` handlers on `failDelivery` calls now log `log.warn()` with the queue ID and error message, providing a diagnostic trail when the delivery queue backend is unavailable during failure marking.

Real environment tested: Linux (Ubuntu 24.04, WSL2), Node.js v22.16.0, OpenClaw built from source (commit 891a6c2) at `/tmp/fix-84449`.

Exact steps or command run after this patch:
```bash
# 1. Build OpenClaw from patched source
cd /tmp/fix-84449
CI=true pnpm install --frozen-lockfile
pnpm build

# 2. Verify log.warn calls are in compiled production code
grep -n "failed to mark queued delivery" dist/deliver-COx0jIM-.js

# 3. Start the patched gateway
timeout 8 node openclaw.mjs gateway

# 4. Run delivery test suite
node scripts/run-vitest.mjs src/infra/outbound/deliver.test.ts
```

Evidence after fix: terminal output copied below.

### Compiled production code verification

All four `log.warn` delivery-failure logging calls are present in the compiled bundle (2 existing + 2 added by this PR):

```console
$ grep -n "failed to mark queued delivery" dist/deliver-COx0jIM-.js
474:log.warn(`failed to mark queued delivery ${params.queueId} as platform-send-attempt-started; ...`);
483:log.warn(`failed to mark queued delivery ${params.queueId} as platform-outcome-unknown; ...`);
877:log.warn(`failed to mark queued delivery ${queueId} as failed after partial failure; continuing best-effort delivery: ${formatErrorMessage(err)}`);
895:log.warn(`failed to mark queued delivery ${queueId} as failed: ${formatErrorMessage(failErr)}`);
```

Lines 877 and 895 are the two new `log.warn` calls added by this PR. Before the fix, both were `catch(() => {})` (empty). Lines 474 and 483 are existing guards that already follow this logging pattern; this PR makes the remaining two consistent.

### Live gateway startup proof

The patched gateway starts, loads the delivery module with the new log.warn handlers, and runs cleanly:

```console
$ timeout 8 node openclaw.mjs gateway
2026-05-21T12:22:06.722-07:00 [gateway] loading configuration…
2026-05-21T12:22:06.818-07:00 [gateway] starting...
2026-05-21T12:22:13.364-07:00 [health-monitor] started (interval: 300s, startup-grace: 60s, channel-connect-grace: 120s)
2026-05-21T12:22:15.751-07:00 [gateway] agent model: openai/gpt-5.5 (thinking=medium, fast=off)
2026-05-21T12:22:15.753-07:00 [gateway] http server listening (8 plugins: acpx, browser, canvas, device-pair, file-transfer, memory-core, phone-control, talk-voice; 8.9s)
2026-05-21T12:22:15.840-07:00 [gateway] signal SIGTERM received
2026-05-21T12:22:15.882-07:00 [gateway] received SIGTERM; shutting down
```

### Vitest delivery test suite (85 tests, supplemental)

```console
$ node scripts/run-vitest.mjs src/infra/outbound/deliver.test.ts
 ✓ |infra| ../../src/infra/outbound/deliver.test.ts (85 tests) 966ms
 Test Files  1 passed (1)
      Tests  85 passed (85)
```

### Fault injection proof: failDelivery catch fires in live gateway delivery

The `failDelivery` catch handler was triggered in a **live running gateway** by injecting `throw new Error("INJECTED: queue storage unavailable")` at the top of the compiled `failDelivery` function, then sending a real delivery via `openclaw message broadcast`.

**Steps:**
1. Inject throw into `failDelivery` in the compiled `dist/delivery-queue-C3SQaKUN.js`.
2. Start the gateway normally.
3. Send a broadcast message to an unconfigured IRC channel: `openclaw message broadcast --channel irc --targets "#nonexistent" --message "test"`.
4. The IRC send fails ("not configured"), triggering `failDelivery` to mark the queue entry as failed.
5. The injected throw makes `failDelivery` reject, and the `.catch()` handler fires.

**Terminal output (fault injection during live delivery):**

```console
$ node openclaw.mjs message broadcast --channel irc --targets "#nonexistent" --message "test delivery failure" --json
[outbound/deliver] failed to mark queued delivery 1fed7a4c-298b-43de-ae94-349e9da98b6f as failed: INJECTED: queue storage unavailable
{
  "action": "broadcast",
  "channel": "irc",
  "payload": {
    "results": [
      {
        "channel": "irc",
        "to": "#nonexistent",
        "ok": false,
        "error": "IRC is not configured for account \"default\" (need host and nick in channels.irc)."
      }
    ]
  }
}
```

**Analysis:**

- `[outbound/deliver] failed to mark queued delivery 1fed7a4c-... as failed: INJECTED: queue storage unavailable`: The **`.catch()` handler fired** with the full queue ID and error message. This is the exact `log.warn` added by this PR.
- The delivery was queued (ID `1fed7a4c-...`), the IRC send failed, `failDelivery` was called to mark the queue entry as failed, and our injected throw made `failDelivery` reject. The catch handler logged the warning and the gateway continued running.
- Before this fix, the same path had `catch(() => {})` -- the `failDelivery` rejection would be silently swallowed with no diagnostic trail.

Observed result after fix: The `.catch()` handler fires during a real gateway delivery when `failDelivery` rejects, logging the queue ID and error message with the `[outbound/deliver]` subsystem prefix. The gateway continues operating normally after the warning. All 85 delivery tests pass.

What was not tested: A real queue storage backend failure (network partition, database lock). The fault injection exercises the exact same compiled code path with a controlled throw at the `failDelivery` function boundary.

