### PR TITLE
fix(cli): use active node for startup bench scripts

### DIFF
--- a/scripts/test-cli-startup-bench-budget.mjs
+++ b/scripts/test-cli-startup-bench-budget.mjs
@@ -105,7 +105,7 @@ function resolveCurrentReportPath() {
     "--output",
     reportPath,
   ];
-  const run = spawnSync("node", args, {
+  const run = spawnSync(process.execPath, args, {
     cwd: process.cwd(),
     stdio: "inherit",
     env: process.env,
@@ -124,6 +124,7 @@ const baseline = readJsonFile(opts.baseline);
 const current = readJsonFile(resolveCurrentReportPath());
 const baselineCases = indexCases(baseline);
 const currentCases = indexCases(current);
+const shouldRequireEveryBaselineCase = opts.preset === "all";
 
 let failed = false;
 
@@ -131,8 +132,10 @@ if (!opts.skipBaseline) {
   for (const [id, baselineCase] of baselineCases) {
     const currentCase = currentCases.get(id);
     if (!currentCase) {
-      console.error(`[test-cli-startup-bench-budget] missing current case ${String(id)}`);
-      failed = true;
+      if (shouldRequireEveryBaselineCase) {
+        console.error(`[test-cli-startup-bench-budget] missing current case ${String(id)}`);
+        failed = true;
+      }
       continue;
     }
 

--- a/scripts/test-update-cli-startup-bench.mjs
+++ b/scripts/test-update-cli-startup-bench.mjs
@@ -64,7 +64,7 @@ const args = [
   opts.out,
 ];
 
-const run = spawnSync("node", args, {
+const run = spawnSync(process.execPath, args, {
   cwd: process.cwd(),
   stdio: "inherit",
   env: process.env,

--- a/test/scripts/cli-startup-bench-spawner.test.ts
+++ b/test/scripts/cli-startup-bench-spawner.test.ts
@@ -1,0 +1,84 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const SCRIPT_PATHS = [
+  "scripts/test-cli-startup-bench-budget.mjs",
+  "scripts/test-update-cli-startup-bench.mjs",
+];
+
+describe("CLI startup benchmark script spawners", () => {
+  it("use the active Node executable for benchmark child processes", () => {
+    for (const scriptPath of SCRIPT_PATHS) {
+      const source = fs.readFileSync(path.resolve(process.cwd(), scriptPath), "utf8");
+
+      expect(source).toContain("spawnSync(process.execPath, args");
+      expect(source).not.toContain('spawnSync("node", args');
+    }
+  });
+
+  it("does not require unrelated fixture cases for a narrowed preset", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-bench-budget-test-"));
+    try {
+      const baselinePath = path.join(tmpDir, "baseline.json");
+      const reportPath = path.join(tmpDir, "current.json");
+      const makeCase = (id: string, name: string) => ({
+        id,
+        name,
+        samples: [],
+        summary: {
+          durationMs: { avg: 10, p50: 10, p95: 10, min: 10, max: 10 },
+          firstOutputMs: null,
+          maxRssMb: null,
+        },
+      });
+
+      fs.writeFileSync(
+        baselinePath,
+        JSON.stringify({
+          primary: { cases: [makeCase("version", "--version"), makeCase("realOnly", "real only")] },
+        }),
+      );
+      fs.writeFileSync(
+        reportPath,
+        JSON.stringify({ primary: { cases: [makeCase("version", "--version")] } }),
+      );
+
+      expect(() =>
+        execFileSync(
+          process.execPath,
+          [
+            "scripts/test-cli-startup-bench-budget.mjs",
+            "--baseline",
+            baselinePath,
+            "--report",
+            reportPath,
+            "--preset",
+            "startup",
+          ],
+          { cwd: process.cwd(), stdio: "pipe" },
+        ),
+      ).not.toThrow();
+
+      expect(() =>
+        execFileSync(
+          process.execPath,
+          [
+            "scripts/test-cli-startup-bench-budget.mjs",
+            "--baseline",
+            baselinePath,
+            "--report",
+            reportPath,
+            "--preset",
+            "all",
+          ],
+          { cwd: process.cwd(), stdio: "pipe" },
+        ),
+      ).toThrow();
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Fixes #83921.

## Summary

- Use `process.execPath` instead of bare `node` when benchmark wrapper scripts spawn `scripts/bench-cli-startup.ts`.
- Allow narrowed benchmark budget runs, such as `--preset startup`, to compare only the cases that were actually generated instead of failing on unrelated fixture cases.
- Add focused coverage for both wrapper spawning and narrowed preset behavior.

## Verification

- `git diff --check`
- Blacksmith Testbox via Crabbox `tbx_01ks1wp6dw5wb18s2v7nfv7e1r`:
  - `pnpm build`
  - `CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 node scripts/run-vitest.mjs test/scripts/cli-startup-bench-spawner.test.ts`
  - `node_bin="$(command -v node)"; PATH=/nonexistent "$node_bin" scripts/test-update-cli-startup-bench.mjs --out /tmp/openclaw-cli-startup-bench-review.json --preset startup --runs 1 --warmup 0 --timeout-ms 10000`
  - `node_bin="$(command -v node)"; PATH=/nonexistent "$node_bin" scripts/test-cli-startup-bench-budget.mjs --preset startup --runs 1 --warmup 0 --timeout-ms 10000 --max-duration-regression-pct 100000 --max-first-output-regression-pct 100000 --max-rss-regression-pct 100000`

## Real behavior proof

Behavior addressed: CLI startup benchmark wrapper scripts no longer depend on a `node` executable being discoverable through `PATH`, and narrowed startup budget checks no longer fail on unrelated real-mode fixture cases.

Real environment tested: Blacksmith Testbox via Crabbox, provider `blacksmith-testbox`, id `tbx_01ks1wp6dw5wb18s2v7nfv7e1r`.

Exact steps or command run after this patch: Built the source tree, ran the focused Vitest file, then ran both benchmark wrapper commands with `PATH=/nonexistent` while invoking the wrappers through the current Node executable.

Evidence after fix: The focused Vitest file passed 2 tests, `test-update-cli-startup-bench.mjs` wrote `/tmp/openclaw-cli-startup-bench-review.json`, and `test-cli-startup-bench-budget.mjs` completed its startup budget comparison successfully.

Observed result after fix: Testbox completed with exit code 0.

What was not tested: Full benchmark presets and full CI were not run for this narrow script fix.
