### PR TITLE
[Fix] Preflight runtime SecretRefs before config writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Discord/voice: keep realtime playback running when meeting notes attaches to an existing voice session or a realtime consult starts, and route realtime user transcripts into meeting notes.
+- Config/secrets: preflight active runtime SecretRefs before root and include config writes persist, and roll back unchanged file/env state when post-write refresh fails. Fixes #46531. (#84454) Thanks @samzong.
 - WebChat: keep the run-complete indicator in progress until deferred history replay renders the assistant reply, so Done no longer appears before response text. (#85374) Thanks @neeravmakwana.
 - Agents/compaction: skip agent-harness preflight for provider-owned CLI runtime sessions so over-threshold Claude CLI sessions continue through normal compaction instead of failing on a missing harness. Fixes #84857. (#84878) Thanks @zhangguiping-xydt.
 - Control UI/config: save form-mode edits from the source config snapshot so runtime-only provider defaults like empty `models.providers.<id>.baseUrl` are not written back and rejected. Fixes #85831. Thanks @garyd9.

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-0516394dbae9a5a497ad1c8eb568a10b88db9026be537e6b5671a198c71ea459  plugin-sdk-api-baseline.json
-635c4205b8ce8d84f67fe7183536d5c0a65eeec087eae75245e7e936cebca9c3  plugin-sdk-api-baseline.jsonl
+8882e41620deeed05be9526981c32a034444abc232903b946c48d416f46f06c3  plugin-sdk-api-baseline.json
+40b22ddad62692447717a2b4f0ecdbd9f6209fa86eaf4e66f85d37c48e26d394  plugin-sdk-api-baseline.jsonl

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -92,6 +92,7 @@ import {
   getRuntimeConfigSourceSnapshot as getRuntimeConfigSourceSnapshotState,
   loadPinnedRuntimeConfig,
   notifyRuntimeConfigWriteListeners,
+  preflightRuntimeSnapshotWrite,
   registerRuntimeConfigWriteListener,
   resetConfigRuntimeState as resetConfigRuntimeStateState,
   resolveRuntimeConfigCacheKey,
@@ -135,6 +136,7 @@ type ShippedPluginInstallConfigWriteMigration =
   | {
       migrated: true;
       filePath: string;
+      writtenHash: string;
       previousFile:
         | {
             existed: false;
@@ -184,6 +186,10 @@ type ConfigHealthState = {
 
 export type ParseConfigJson5Result = { ok: true; parsed: unknown } | { ok: false; error: string };
 export type ConfigWriteResult = { persistedHash: string; persistedConfig: OpenClawConfig };
+const configWritePostCommitRollback = Symbol("configWritePostCommitRollback");
+type InternalConfigWriteResult = ConfigWriteResult & {
+  [configWritePostCommitRollback]?: () => void;
+};
 export type ConfigWriteOptions = {
   /**
    * Read-time env snapshot used to validate `${VAR}` restoration decisions.
@@ -261,6 +267,11 @@ export type ConfigWriteOptions = {
    * readable by the parent process after a candidate doctor repair.
    */
   lastTouchedVersionOverride?: string;
+  /**
+   * Internal hook used by the exported runtime-aware writer after validation
+   * has produced the exact source config that will be committed.
+   */
+  preCommitRuntimePreflight?: (sourceConfig: OpenClawConfig) => Promise<unknown>;
 };
 
 export type ReadConfigFileSnapshotForWriteResult = {
@@ -325,6 +336,46 @@ export function resolveConfigSnapshotHash(snapshot: {
     return null;
   }
   return hashConfigRaw(snapshot.raw);
+}
+
+async function rollbackConfigFileWriteIfUnchanged(params: {
+  configPath: string;
+  previousSnapshot: ConfigFileSnapshot;
+  committedHash: string;
+}): Promise<boolean> {
+  let currentRaw: string | null = null;
+  try {
+    currentRaw = await fs.promises.readFile(params.configPath, "utf-8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code !== "ENOENT") {
+      throw error;
+    }
+  }
+  if (hashConfigRaw(currentRaw) !== params.committedHash) {
+    return false;
+  }
+  if (params.previousSnapshot.exists && typeof params.previousSnapshot.raw === "string") {
+    await replaceFileAtomic({
+      filePath: params.configPath,
+      content: params.previousSnapshot.raw,
+      dirMode: 0o700,
+      mode: 0o600,
+      tempPrefix: path.basename(params.configPath),
+      copyFallbackOnPermissionError: true,
+    });
+    return true;
+  }
+  if (params.previousSnapshot.exists) {
+    return false;
+  }
+  try {
+    await fs.promises.unlink(params.configPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code !== "ENOENT") {
+      throw error;
+    }
+  }
+  return true;
 }
 
 function coerceConfig(value: unknown): OpenClawConfig {
@@ -1190,6 +1241,29 @@ function resolveConfigForRead(
   };
 }
 
+function snapshotEnv(env: NodeJS.ProcessEnv): Record<string, string | undefined> {
+  return { ...env };
+}
+
+function restoreEnvChangesIfUnchanged(params: {
+  env: NodeJS.ProcessEnv;
+  before: Record<string, string | undefined>;
+  after: Record<string, string | undefined>;
+}): void {
+  const keys = new Set([...Object.keys(params.before), ...Object.keys(params.after)]);
+  for (const key of keys) {
+    if (params.before[key] === params.after[key] || params.env[key] !== params.after[key]) {
+      continue;
+    }
+    const previous = params.before[key];
+    if (previous === undefined) {
+      delete params.env[key];
+    } else {
+      params.env[key] = previous;
+    }
+  }
+}
+
 type ReadConfigFileSnapshotInternalResult = {
   snapshot: ConfigFileSnapshot;
   envSnapshotForRestore?: Record<string, string | undefined>;
@@ -1444,6 +1518,21 @@ export function createConfigIO(
     };
   }
 
+  function resolveRuntimePreflightSourceConfig(candidate: OpenClawConfig): OpenClawConfig {
+    const env = { ...deps.env } as NodeJS.ProcessEnv;
+    const resolvedIncludes = resolveConfigIncludesForRead(candidate, configPath, {
+      ...deps,
+      env,
+    });
+    const readResolution = resolveConfigForRead(resolvedIncludes, env);
+    return coerceConfig(
+      migrateAndStripShippedPluginInstallConfigRecords(readResolution.resolvedConfigRaw, {
+        persist: false,
+        rootConfigRaw: candidate,
+      }).config,
+    );
+  }
+
   function ensureShippedPluginInstallConfigRecordsMigratedForWrite(
     snapshot: ConfigFileSnapshot,
   ): ShippedPluginInstallConfigWriteMigration {
@@ -1475,7 +1564,7 @@ export function createConfigIO(
         } as const)
       : ({ existed: false } as const);
     try {
-      writePersistedInstalledPluginIndexInstallRecordsSync(
+      const writtenPath = writePersistedInstalledPluginIndexInstallRecordsSync(
         {
           ...installRecords,
           ...existingRecords,
@@ -1486,9 +1575,13 @@ export function createConfigIO(
           stateDir,
         },
       );
+      const writtenRaw = deps.fs.existsSync(writtenPath)
+        ? deps.fs.readFileSync(writtenPath, "utf-8")
+        : null;
       return {
         migrated: true,
-        filePath,
+        filePath: writtenPath,
+        writtenHash: hashConfigRaw(writtenRaw),
         previousFile,
       };
     } catch (err) {
@@ -1503,16 +1596,22 @@ export function createConfigIO(
 
   function rollbackShippedPluginInstallConfigWriteMigration(
     migration: ShippedPluginInstallConfigWriteMigration,
-  ): void {
+  ): boolean {
     if (!migration.migrated) {
-      return;
+      return false;
+    }
+    const currentRaw = deps.fs.existsSync(migration.filePath)
+      ? deps.fs.readFileSync(migration.filePath, "utf-8")
+      : null;
+    if (hashConfigRaw(currentRaw) !== migration.writtenHash) {
+      return false;
     }
     if (migration.previousFile.existed) {
       deps.fs.writeFileSync(migration.filePath, migration.previousFile.raw, {
         encoding: "utf-8",
         mode: 0o600,
       });
-      return;
+      return true;
     }
     try {
       deps.fs.unlinkSync(migration.filePath);
@@ -1521,6 +1620,7 @@ export function createConfigIO(
         throw err;
       }
     }
+    return true;
   }
 
   function loadConfig(): OpenClawConfig {
@@ -2025,7 +2125,7 @@ export function createConfigIO(
   async function writeConfigFile(
     cfg: OpenClawConfig,
     options: ConfigWriteOptions = {},
-  ): Promise<{ persistedHash: string; persistedConfig: OpenClawConfig }> {
+  ): Promise<InternalConfigWriteResult> {
     assertConfigWriteAllowedInCurrentMode({ configPath, env: deps.env });
     clearConfigCache();
     const unsetPaths = resolveManagedUnsetPathsForWrite(options.unsetPaths);
@@ -2267,6 +2367,22 @@ export function createConfigIO(
       throw err;
     }
 
+    const preCommitRuntimePreflight =
+      options.preCommitRuntimePreflight ??
+      (async (sourceConfig: OpenClawConfig) => {
+        await preflightRuntimeSnapshotWrite({
+          nextSourceConfig: sourceConfig,
+          refreshOptions: options.runtimeRefresh,
+          formatRefreshError: (error) => formatErrorMessage(error),
+          createRefreshError: (detail, cause) =>
+            new ConfigRuntimeRefreshError(
+              `Config write blocked before committing ${configPath}: active SecretRef resolution failed: ${detail}`,
+              { cause },
+            ),
+        });
+      });
+    await preCommitRuntimePreflight(resolveRuntimePreflightSourceConfig(stampedOutputConfig));
+
     const pluginInstallConfigMigration =
       ensureShippedPluginInstallConfigRecordsMigratedForWrite(snapshot);
     let configCommitted = false;
@@ -2293,7 +2409,17 @@ export function createConfigIO(
         undefined,
         await deps.fs.promises.stat(configPath).catch(() => null),
       );
-      return { persistedHash: nextHash, persistedConfig: stampedOutputConfig };
+      return {
+        persistedHash: nextHash,
+        persistedConfig: stampedOutputConfig,
+        ...(pluginInstallConfigMigration.migrated
+          ? {
+              [configWritePostCommitRollback]: () => {
+                rollbackShippedPluginInstallConfigWriteMigration(pluginInstallConfigMigration);
+              },
+            }
+          : {}),
+      };
     } catch (err) {
       if (!configCommitted) {
         rollbackShippedPluginInstallConfigWriteMigration(pluginInstallConfigMigration);
@@ -2486,8 +2612,10 @@ export async function writeConfigFile(
     const runtimePatch = createMergePatch(runtimeConfigSnapshot!, cfg);
     nextCfg = coerceConfig(applyMergePatch(runtimeConfigSourceSnapshot!, runtimePatch));
   }
+  const baseSnapshot = options.baseSnapshot ?? (await io.readConfigFileSnapshot());
+  let runtimePreflightResult: unknown;
   const writeResult = await io.writeConfigFile(nextCfg, {
-    baseSnapshot: options.baseSnapshot,
+    baseSnapshot,
     envSnapshotForRestore: resolveWriteEnvSnapshotForPath({
       actualConfigPath: io.configPath,
       expectedConfigPath: options.expectedConfigPath,
@@ -2506,6 +2634,18 @@ export async function writeConfigFile(
     skipPluginValidation: options.skipPluginValidation,
     preservedLegacyRootKeys: options.preservedLegacyRootKeys,
     lastTouchedVersionOverride: options.lastTouchedVersionOverride,
+    preCommitRuntimePreflight: async (sourceConfig) => {
+      runtimePreflightResult = await preflightRuntimeSnapshotWrite({
+        nextSourceConfig: sourceConfig,
+        refreshOptions: options.runtimeRefresh,
+        formatRefreshError: (error) => formatErrorMessage(error),
+        createRefreshError: (detail, cause) =>
+          new ConfigRuntimeRefreshError(
+            `Config write blocked before committing ${io.configPath}: active SecretRef resolution failed: ${detail}`,
+            { cause },
+          ),
+      });
+    },
   });
   if (
     options.skipRuntimeSnapshotRefresh &&
@@ -2527,6 +2667,8 @@ export async function writeConfigFile(
   // triggering a `plugins`-scoped restart of the gateway for changes that
   // never touched any plugin entry.
   let canonicalSourceConfig: OpenClawConfig = nextCfg;
+  const envBeforeCanonicalRead = snapshotEnv(process.env);
+  let envAfterCanonicalRead = envBeforeCanonicalRead;
   try {
     const freshSnapshot = await io.readConfigFileSnapshot();
     if (freshSnapshot.exists && freshSnapshot.valid) {
@@ -2535,6 +2677,8 @@ export async function writeConfigFile(
   } catch {
     // Best-effort; fall back to nextCfg so a transient read failure does not
     // block the write notification.
+  } finally {
+    envAfterCanonicalRead = snapshotEnv(process.env);
   }
   const notifyCommittedWrite = () => {
     const currentRuntimeConfig = getRuntimeConfigSnapshotState();
@@ -2553,19 +2697,44 @@ export async function writeConfigFile(
   };
   // Keep the last-known-good runtime snapshot active until the specialized refresh path
   // succeeds, so concurrent readers do not observe unresolved SecretRefs mid-refresh.
-  await finalizeRuntimeSnapshotWrite({
-    nextSourceConfig: canonicalSourceConfig,
-    refreshOptions: options.runtimeRefresh,
-    hadRuntimeSnapshot,
-    hadBothSnapshots,
-    loadFreshConfig: () => io.loadConfig(),
-    notifyCommittedWrite,
-    formatRefreshError: (error) => formatErrorMessage(error),
-    createRefreshError: (detail, cause) =>
-      new ConfigRuntimeRefreshError(
-        `Config was written to ${io.configPath}, but runtime snapshot refresh failed: ${detail}`,
-        { cause },
-      ),
-  });
+  try {
+    await finalizeRuntimeSnapshotWrite({
+      nextSourceConfig: canonicalSourceConfig,
+      refreshOptions: options.runtimeRefresh,
+      hadRuntimeSnapshot,
+      hadBothSnapshots,
+      loadFreshConfig: () => io.loadConfig(),
+      notifyCommittedWrite,
+      formatRefreshError: (error) => formatErrorMessage(error),
+      preflightResult: runtimePreflightResult,
+      createRefreshError: (detail, cause) =>
+        new ConfigRuntimeRefreshError(
+          `Config was written to ${io.configPath}, but runtime snapshot refresh failed: ${detail}`,
+          { cause },
+        ),
+    });
+  } catch (error) {
+    try {
+      const rolledBackConfig = await rollbackConfigFileWriteIfUnchanged({
+        configPath: io.configPath,
+        previousSnapshot: baseSnapshot,
+        committedHash: writeResult.persistedHash,
+      });
+      if (rolledBackConfig) {
+        restoreEnvChangesIfUnchanged({
+          env: process.env,
+          before: envBeforeCanonicalRead,
+          after: envAfterCanonicalRead,
+        });
+        writeResult[configWritePostCommitRollback]?.();
+      }
+    } catch (rollbackError) {
+      throw new ConfigRuntimeRefreshError(
+        `${formatErrorMessage(error)} Rollback failed: ${formatErrorMessage(rollbackError)}`,
+        { cause: error },
+      );
+    }
+    throw error;
+  }
   return { ...writeResult, persistedConfig: canonicalSourceConfig };
 }

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -1245,7 +1245,7 @@ function snapshotEnv(env: NodeJS.ProcessEnv): Record<string, string | undefined>
   return { ...env };
 }
 
-function restoreEnvChangesIfUnchanged(params: {
+export function restoreEnvChangesIfUnchanged(params: {
   env: NodeJS.ProcessEnv;
   before: Record<string, string | undefined>;
   after: Record<string, string | undefined>;
@@ -2431,6 +2431,7 @@ export function createConfigIO(
 
   return {
     configPath,
+    env: deps.env,
     loadConfig,
     readBestEffortConfig,
     readSourceConfigBestEffort,

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { readPersistedInstalledPluginIndex } from "../plugins/installed-plugin-index-store.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
+import { clearLoadPluginMetadataSnapshotMemo } from "../plugins/plugin-metadata-snapshot.js";
 import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
 import { CONFIG_CLOBBER_SNAPSHOT_LIMIT } from "./io.clobber-snapshot.js";
 import {
@@ -12,6 +13,7 @@ import {
   registerConfigWriteListener,
   resetConfigRuntimeState,
   setRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshotRefreshHandler,
   writeConfigFile,
 } from "./io.js";
 import type { ConfigFileSnapshot, OpenClawConfig } from "./types.openclaw.js";
@@ -86,6 +88,7 @@ describe("config io write", () => {
 
   afterEach(() => {
     resetConfigRuntimeState();
+    clearLoadPluginMetadataSnapshotMemo();
     mockMaintainConfigBackups.mockReset();
     mockMaintainConfigBackups.mockResolvedValue(undefined);
   });
@@ -464,6 +467,10 @@ describe("config io write", () => {
   });
 
   it("keeps shipped plugin install config records when index migration fails", async () => {
+    mockLoadPluginManifestRegistry.mockReturnValue({
+      diagnostics: [],
+      plugins: [],
+    } satisfies PluginManifestRegistry);
     await withSuiteHome(async (home) => {
       const configPath = path.join(home, ".openclaw", "openclaw.json");
       const unwritableStatePath = path.join(home, ".openclaw");
@@ -907,6 +914,56 @@ describe("config io write", () => {
           )}.`,
         ],
       ]);
+    });
+  });
+
+  it("does not preflight runtime secrets before rejecting blocked root writes", async () => {
+    await withSuiteHome(async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      const original = {
+        meta: { lastTouchedVersion: "2026.4.30" },
+        gateway: { mode: "local", port: 18789 },
+      } satisfies ConfigFileSnapshot["config"];
+      const originalRaw = `${JSON.stringify(original, null, 2)}\n`;
+      await fs.writeFile(configPath, originalRaw, "utf-8");
+      const io = createConfigIO({
+        configPath,
+        env: { VITEST: "true" } as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: silentLogger,
+      });
+      const baseSnapshot = {
+        path: configPath,
+        exists: true,
+        raw: originalRaw,
+        parsed: original,
+        sourceConfig: original,
+        resolved: original,
+        valid: true,
+        runtimeConfig: original,
+        config: original,
+        issues: [],
+        warnings: [],
+        legacyIssues: [],
+      } satisfies ConfigFileSnapshot;
+      let preflightCalls = 0;
+
+      await expectConfigWriteRejected(
+        io.writeConfigFile(
+          { update: { channel: "beta" } },
+          {
+            baseSnapshot,
+            preCommitRuntimePreflight: async () => {
+              preflightCalls += 1;
+              throw new Error("should not preflight rejected writes");
+            },
+          },
+        ),
+      );
+
+      expect(preflightCalls).toBe(0);
+      await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(originalRaw);
     });
   });
 
@@ -1417,6 +1474,309 @@ describe("config io write", () => {
           delete process.env.OPENCLAW_CONFIG_PATH;
         } else {
           process.env.OPENCLAW_CONFIG_PATH = previousConfigPath;
+        }
+      }
+    });
+  });
+
+  it("rolls back the root config when post-write runtime refresh fails", async () => {
+    await withSuiteHome(async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      const previousConfigPath = process.env.OPENCLAW_CONFIG_PATH;
+      process.env.OPENCLAW_CONFIG_PATH = configPath;
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      const initialConfig = { gateway: { mode: "local", port: 18789 } } satisfies OpenClawConfig;
+      const initialRaw = `${JSON.stringify(initialConfig, null, 2)}\n`;
+      await fs.writeFile(configPath, initialRaw, "utf-8");
+
+      try {
+        setRuntimeConfigSnapshotRefreshHandler({
+          refresh: () => {
+            throw new Error("synthetic refresh failure");
+          },
+        });
+
+        await expect(writeConfigFile({ gateway: { mode: "local", port: 19001 } })).rejects.toThrow(
+          /runtime snapshot refresh failed: synthetic refresh failure/,
+        );
+
+        await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(initialRaw);
+      } finally {
+        setRuntimeConfigSnapshotRefreshHandler(null);
+        if (previousConfigPath === undefined) {
+          delete process.env.OPENCLAW_CONFIG_PATH;
+        } else {
+          process.env.OPENCLAW_CONFIG_PATH = previousConfigPath;
+        }
+      }
+    });
+  });
+
+  it("does not delete an existing root config when rollback has no previous raw payload", async () => {
+    await withSuiteHome(async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      const previousConfigPath = process.env.OPENCLAW_CONFIG_PATH;
+      process.env.OPENCLAW_CONFIG_PATH = configPath;
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      const initialConfig = { gateway: { mode: "local", port: 18789 } } satisfies OpenClawConfig;
+      await fs.writeFile(configPath, `${JSON.stringify(initialConfig, null, 2)}\n`, "utf-8");
+      const baseSnapshot = {
+        path: configPath,
+        exists: true,
+        raw: null,
+        parsed: initialConfig,
+        sourceConfig: initialConfig,
+        resolved: initialConfig,
+        valid: true,
+        runtimeConfig: initialConfig,
+        config: initialConfig,
+        issues: [],
+        warnings: [],
+        legacyIssues: [],
+      } satisfies ConfigFileSnapshot;
+
+      try {
+        setRuntimeConfigSnapshotRefreshHandler({
+          refresh: () => {
+            throw new Error("synthetic refresh failure");
+          },
+        });
+
+        await expect(
+          writeConfigFile(
+            { gateway: { mode: "local", port: 19001 } },
+            {
+              baseSnapshot,
+            },
+          ),
+        ).rejects.toThrow(/runtime snapshot refresh failed: synthetic refresh failure/);
+
+        const persisted = JSON.parse(await fs.readFile(configPath, "utf-8")) as OpenClawConfig;
+        expect(persisted.gateway).toEqual({ mode: "local", port: 19001 });
+      } finally {
+        setRuntimeConfigSnapshotRefreshHandler(null);
+        if (previousConfigPath === undefined) {
+          delete process.env.OPENCLAW_CONFIG_PATH;
+        } else {
+          process.env.OPENCLAW_CONFIG_PATH = previousConfigPath;
+        }
+      }
+    });
+  });
+
+  it("does not overwrite concurrent root config edits during failed refresh rollback", async () => {
+    await withSuiteHome(async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      const previousConfigPath = process.env.OPENCLAW_CONFIG_PATH;
+      process.env.OPENCLAW_CONFIG_PATH = configPath;
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.writeFile(
+        configPath,
+        `${JSON.stringify({ gateway: { mode: "local", port: 18789 } }, null, 2)}\n`,
+        "utf-8",
+      );
+      const concurrentRaw = `${JSON.stringify(
+        { gateway: { mode: "local", port: 19191 } },
+        null,
+        2,
+      )}\n`;
+
+      try {
+        setRuntimeConfigSnapshotRefreshHandler({
+          refresh: async () => {
+            await fs.writeFile(configPath, concurrentRaw, "utf-8");
+            throw new Error("synthetic refresh failure");
+          },
+        });
+
+        await expect(writeConfigFile({ gateway: { mode: "local", port: 19001 } })).rejects.toThrow(
+          /runtime snapshot refresh failed: synthetic refresh failure/,
+        );
+
+        await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(concurrentRaw);
+      } finally {
+        setRuntimeConfigSnapshotRefreshHandler(null);
+        if (previousConfigPath === undefined) {
+          delete process.env.OPENCLAW_CONFIG_PATH;
+        } else {
+          process.env.OPENCLAW_CONFIG_PATH = previousConfigPath;
+        }
+      }
+    });
+  });
+
+  it("rolls back plugin install index migration when runtime refresh fails", async () => {
+    await withSuiteHome(async (home) => {
+      const stateDir = path.join(home, ".openclaw");
+      const configPath = path.join(stateDir, "openclaw.json");
+      const pluginDir = path.join(stateDir, "plugins", "demo");
+      const previousConfigPath = process.env.OPENCLAW_CONFIG_PATH;
+      const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      const initialConfig = {
+        plugins: {
+          entries: { demo: { enabled: true } },
+          installs: {
+            demo: {
+              source: "npm",
+              spec: "demo@1.0.0",
+              installPath: pluginDir,
+            },
+          },
+        },
+      } satisfies OpenClawConfig;
+      const initialRaw = `${JSON.stringify(initialConfig, null, 2)}\n`;
+      await fs.writeFile(configPath, initialRaw, "utf-8");
+      process.env.OPENCLAW_CONFIG_PATH = configPath;
+      process.env.OPENCLAW_STATE_DIR = stateDir;
+
+      try {
+        setRuntimeConfigSnapshotRefreshHandler({
+          refresh: () => {
+            throw new Error("synthetic refresh failure");
+          },
+        });
+
+        await expect(
+          writeConfigFile({ plugins: { entries: { demo: { enabled: true } } } }),
+        ).rejects.toThrow(/runtime snapshot refresh failed: synthetic refresh failure/);
+
+        await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(initialRaw);
+        await expect(readPersistedInstalledPluginIndex({ stateDir })).resolves.toBeNull();
+      } finally {
+        setRuntimeConfigSnapshotRefreshHandler(null);
+        if (previousConfigPath === undefined) {
+          delete process.env.OPENCLAW_CONFIG_PATH;
+        } else {
+          process.env.OPENCLAW_CONFIG_PATH = previousConfigPath;
+        }
+        if (previousStateDir === undefined) {
+          delete process.env.OPENCLAW_STATE_DIR;
+        } else {
+          process.env.OPENCLAW_STATE_DIR = previousStateDir;
+        }
+      }
+    });
+  });
+
+  it("blocks runtime preflight failures before committing root writes", async () => {
+    await withSuiteHome(async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      const previousConfigPath = process.env.OPENCLAW_CONFIG_PATH;
+      const initialRaw = `${JSON.stringify({ gateway: { mode: "local" } }, null, 2)}\n`;
+      let observedSource: OpenClawConfig | undefined;
+
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.writeFile(configPath, initialRaw, "utf-8");
+      process.env.OPENCLAW_CONFIG_PATH = configPath;
+
+      try {
+        setRuntimeConfigSnapshotRefreshHandler({
+          preflight: async ({ sourceConfig }) => {
+            observedSource = sourceConfig;
+            throw new Error("missing included secret");
+          },
+          refresh: () => true,
+        });
+
+        await expect(
+          writeConfigFile({
+            gateway: { mode: "local", port: 19001 },
+            logging: { level: "debug" },
+          }),
+        ).rejects.toThrow(/active SecretRef resolution failed: missing included secret/);
+
+        expect(observedSource?.gateway?.port).toBe(19001);
+        await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(initialRaw);
+      } finally {
+        setRuntimeConfigSnapshotRefreshHandler(null);
+        if (previousConfigPath === undefined) {
+          delete process.env.OPENCLAW_CONFIG_PATH;
+        } else {
+          process.env.OPENCLAW_CONFIG_PATH = previousConfigPath;
+        }
+      }
+    });
+  });
+
+  it("blocks runtime preflight failures before direct config IO commits root writes", async () => {
+    await withSuiteHome(async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      const initialRaw = `${JSON.stringify({ gateway: { mode: "local" } }, null, 2)}\n`;
+      const env = {
+        ...process.env,
+        OPENCLAW_CONFIG_PATH: configPath,
+      } as NodeJS.ProcessEnv;
+      let observedSource: OpenClawConfig | undefined;
+
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.writeFile(configPath, initialRaw, "utf-8");
+
+      try {
+        setRuntimeConfigSnapshotRefreshHandler({
+          preflight: async ({ sourceConfig }) => {
+            observedSource = sourceConfig;
+            throw new Error("missing direct IO secret");
+          },
+          refresh: () => true,
+        });
+
+        await expect(
+          createConfigIO({ env, logger: silentLogger }).writeConfigFile({
+            gateway: { mode: "local", port: 19001 },
+          }),
+        ).rejects.toThrow(/active SecretRef resolution failed: missing direct IO secret/);
+
+        expect(observedSource?.gateway?.port).toBe(19001);
+        await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(initialRaw);
+      } finally {
+        setRuntimeConfigSnapshotRefreshHandler(null);
+      }
+    });
+  });
+
+  it("restores config env vars when post-write runtime refresh rollback succeeds", async () => {
+    await withSuiteHome(async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      const previousConfigPath = process.env.OPENCLAW_CONFIG_PATH;
+      const envKey = "OPENCLAW_TEST_RUNTIME_ROLLBACK_ENV";
+      const previousEnvValue = process.env[envKey];
+      const initialConfig = { gateway: { mode: "local", port: 18789 } } satisfies OpenClawConfig;
+      const initialRaw = `${JSON.stringify(initialConfig, null, 2)}\n`;
+
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.writeFile(configPath, initialRaw, "utf-8");
+      process.env.OPENCLAW_CONFIG_PATH = configPath;
+      delete process.env[envKey];
+
+      try {
+        setRuntimeConfigSnapshotRefreshHandler({
+          refresh: () => {
+            expect(process.env[envKey]).toBe("written-env-value");
+            throw new Error("synthetic refresh failure");
+          },
+        });
+
+        await expect(
+          writeConfigFile({
+            gateway: { mode: "local", port: 19001 },
+            env: { vars: { [envKey]: "written-env-value" } },
+          }),
+        ).rejects.toThrow(/runtime snapshot refresh failed: synthetic refresh failure/);
+
+        await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(initialRaw);
+        expect(process.env[envKey]).toBeUndefined();
+      } finally {
+        setRuntimeConfigSnapshotRefreshHandler(null);
+        if (previousConfigPath === undefined) {
+          delete process.env.OPENCLAW_CONFIG_PATH;
+        } else {
+          process.env.OPENCLAW_CONFIG_PATH = previousConfigPath;
+        }
+        if (previousEnvValue === undefined) {
+          delete process.env[envKey];
+        } else {
+          process.env[envKey] = previousEnvValue;
         }
       }
     });

--- a/src/config/mutate.test.ts
+++ b/src/config/mutate.test.ts
@@ -2,13 +2,18 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
+import type { ConfigWriteOptions } from "./io.js";
 import {
   ConfigMutationConflictError,
   mutateConfigFile,
   replaceConfigFile,
   transformConfigFileWithRetry,
 } from "./mutate.js";
-import { registerRuntimeConfigWriteListener, resetConfigRuntimeState } from "./runtime-snapshot.js";
+import {
+  registerRuntimeConfigWriteListener,
+  resetConfigRuntimeState,
+  setRuntimeConfigSnapshotRefreshHandler,
+} from "./runtime-snapshot.js";
 import type { ConfigFileSnapshot, OpenClawConfig } from "./types.js";
 
 type MockValidationIssue = { path: string; message: string };
@@ -181,7 +186,12 @@ describe("config mutate helpers", () => {
           list: [{ id: "other-agent" }, { id: "work" }],
         },
       },
-      { baseSnapshot: fresh, expectedConfigPath: fresh.path, afterWrite: { mode: "auto" } },
+      {
+        baseSnapshot: fresh,
+        expectedConfigPath: fresh.path,
+        afterWrite: { mode: "auto" },
+        preCommitRuntimePreflight: expect.any(Function),
+      },
     );
   });
 
@@ -607,6 +617,175 @@ describe("config mutate helpers", () => {
     expect(persistedPlugins.entries?.["strict-plugin"]).toEqual({ enabled: true });
   });
 
+  it("preflights single-file top-level include writes before persisting", async () => {
+    const home = await suiteRootTracker.make("include-runtime-preflight");
+    const configPath = path.join(home, ".openclaw", "openclaw.json");
+    const pluginsPath = path.join(home, ".openclaw", "config", "plugins.json5");
+    await fs.mkdir(path.dirname(pluginsPath), { recursive: true });
+    await fs.writeFile(
+      configPath,
+      `${JSON.stringify({ plugins: { $include: "./config/plugins.json5" } }, null, 2)}\n`,
+      "utf-8",
+    );
+    const initialPluginsRaw = `${JSON.stringify({ entries: {} }, null, 2)}\n`;
+    await fs.writeFile(pluginsPath, initialPluginsRaw, "utf-8");
+    const snapshot = createSnapshot({
+      hash: "hash-include-preflight",
+      path: configPath,
+      parsed: { plugins: { $include: "./config/plugins.json5" } },
+      sourceConfig: { plugins: { entries: {} } },
+    });
+
+    try {
+      setRuntimeConfigSnapshotRefreshHandler({
+        preflight: () => {
+          throw new Error("missing include secret");
+        },
+        refresh: () => true,
+      });
+
+      await expect(
+        replaceConfigFile({
+          baseHash: snapshot.hash,
+          snapshot,
+          writeOptions: { expectedConfigPath: snapshot.path },
+          nextConfig: {
+            plugins: {
+              entries: {
+                demo: { enabled: true },
+              },
+            },
+          },
+        }),
+      ).rejects.toThrow(/active SecretRef resolution failed: missing include secret/);
+
+      await expect(fs.readFile(pluginsPath, "utf-8")).resolves.toBe(initialPluginsRaw);
+    } finally {
+      setRuntimeConfigSnapshotRefreshHandler(null);
+    }
+  });
+
+  it("rolls back single-file top-level include writes when runtime refresh fails", async () => {
+    const home = await suiteRootTracker.make("include-runtime-refresh-rollback");
+    const configPath = path.join(home, ".openclaw", "openclaw.json");
+    const pluginsPath = path.join(home, ".openclaw", "config", "plugins.json5");
+    await fs.mkdir(path.dirname(pluginsPath), { recursive: true });
+    await fs.writeFile(
+      configPath,
+      `${JSON.stringify({ plugins: { $include: "./config/plugins.json5" } }, null, 2)}\n`,
+      "utf-8",
+    );
+    const initialPluginsRaw = `${JSON.stringify({ entries: {} }, null, 2)}\n`;
+    await fs.writeFile(pluginsPath, initialPluginsRaw, "utf-8");
+    const snapshot = createSnapshot({
+      hash: "hash-include-refresh-rollback",
+      path: configPath,
+      parsed: { plugins: { $include: "./config/plugins.json5" } },
+      sourceConfig: { plugins: { entries: {} } },
+    });
+    const nextConfig = {
+      plugins: {
+        entries: {
+          demo: { enabled: true },
+        },
+      },
+    };
+    ioMocks.readConfigFileSnapshotForWrite.mockResolvedValue({
+      snapshot: createSnapshot({
+        hash: "hash-include-refresh-written",
+        path: configPath,
+        parsed: { plugins: { $include: "./config/plugins.json5" } },
+        sourceConfig: nextConfig,
+      }),
+      writeOptions: { expectedConfigPath: configPath },
+    });
+
+    try {
+      setRuntimeConfigSnapshotRefreshHandler({
+        preflight: () => true,
+        refresh: () => {
+          throw new Error("lost include secret");
+        },
+      });
+
+      await expect(
+        replaceConfigFile({
+          baseHash: snapshot.hash,
+          snapshot,
+          writeOptions: { expectedConfigPath: snapshot.path },
+          nextConfig,
+        }),
+      ).rejects.toThrow(/runtime snapshot refresh failed: lost include secret/);
+
+      await expect(fs.readFile(pluginsPath, "utf-8")).resolves.toBe(initialPluginsRaw);
+    } finally {
+      setRuntimeConfigSnapshotRefreshHandler(null);
+    }
+  });
+
+  it("does not overwrite concurrent include edits during failed refresh rollback", async () => {
+    const home = await suiteRootTracker.make("include-runtime-refresh-concurrent");
+    const configPath = path.join(home, ".openclaw", "openclaw.json");
+    const pluginsPath = path.join(home, ".openclaw", "config", "plugins.json5");
+    await fs.mkdir(path.dirname(pluginsPath), { recursive: true });
+    await fs.writeFile(
+      configPath,
+      `${JSON.stringify({ plugins: { $include: "./config/plugins.json5" } }, null, 2)}\n`,
+      "utf-8",
+    );
+    await fs.writeFile(pluginsPath, `${JSON.stringify({ entries: {} }, null, 2)}\n`, "utf-8");
+    const concurrentPluginsRaw = `${JSON.stringify(
+      { entries: { concurrent: { enabled: true } } },
+      null,
+      2,
+    )}\n`;
+    const snapshot = createSnapshot({
+      hash: "hash-include-refresh-concurrent",
+      path: configPath,
+      parsed: { plugins: { $include: "./config/plugins.json5" } },
+      sourceConfig: { plugins: { entries: {} } },
+    });
+    const nextConfig = {
+      plugins: {
+        entries: {
+          demo: { enabled: true },
+        },
+      },
+    };
+    ioMocks.readConfigFileSnapshotForWrite.mockResolvedValue({
+      snapshot: createSnapshot({
+        hash: "hash-include-refresh-concurrent-written",
+        path: configPath,
+        parsed: { plugins: { $include: "./config/plugins.json5" } },
+        sourceConfig: nextConfig,
+      }),
+      writeOptions: { expectedConfigPath: configPath },
+    });
+
+    try {
+      setRuntimeConfigSnapshotRefreshHandler({
+        preflight: () => true,
+        refresh: async () => {
+          await fs.writeFile(pluginsPath, concurrentPluginsRaw, "utf-8");
+          throw new Error("lost include secret");
+        },
+      });
+
+      await expect(
+        replaceConfigFile({
+          baseHash: snapshot.hash,
+          snapshot,
+          writeOptions: { expectedConfigPath: snapshot.path },
+          nextConfig,
+        }),
+      ).rejects.toThrow(/runtime snapshot refresh failed: lost include secret/);
+
+      await expect(fs.readFile(pluginsPath, "utf-8")).resolves.toBe(concurrentPluginsRaw);
+    } finally {
+      setRuntimeConfigSnapshotRefreshHandler(null);
+    }
+  });
+
   it("rejects invalid base config before skipped-plugin include writes", async () => {
     const home = await suiteRootTracker.make("include-skip-invalid-base");
     const configPath = path.join(home, ".openclaw", "openclaw.json");
@@ -697,5 +876,63 @@ describe("config mutate helpers", () => {
         afterWrite: { mode: "auto" },
       },
     );
+  });
+
+  it("preflights injected root writers before persisting", async () => {
+    const home = await suiteRootTracker.make("injected-root-runtime-preflight");
+    const configPath = path.join(home, ".openclaw", "openclaw.json");
+    await fs.mkdir(path.dirname(configPath), { recursive: true });
+    const initialConfig = { gateway: { mode: "local" } } satisfies OpenClawConfig;
+    const initialRaw = `${JSON.stringify(initialConfig, null, 2)}\n`;
+    await fs.writeFile(configPath, initialRaw, "utf-8");
+    const snapshot = createSnapshot({
+      hash: "hash-injected-root",
+      path: configPath,
+      sourceConfig: initialConfig,
+    });
+    const nextConfig = {
+      gateway: {
+        mode: "local",
+        auth: {
+          mode: "token",
+          token: { source: "exec", provider: "execmain", id: "gateway/token" },
+        },
+      },
+    } as OpenClawConfig;
+    const injectedWrite = vi.fn(async (config: OpenClawConfig, options?: ConfigWriteOptions) => {
+      await options?.preCommitRuntimePreflight?.(config);
+      await fs.writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, "utf-8");
+      return { persistedHash: "hash-written", persistedConfig: config };
+    });
+
+    try {
+      setRuntimeConfigSnapshotRefreshHandler({
+        preflight: () => {
+          throw new Error("missing root secret");
+        },
+        refresh: () => true,
+      });
+
+      await expect(
+        replaceConfigFile({
+          snapshot,
+          baseHash: snapshot.hash,
+          writeOptions: { expectedConfigPath: snapshot.path },
+          nextConfig,
+          io: {
+            readConfigFileSnapshotForWrite: vi.fn(),
+            writeConfigFile: injectedWrite,
+          },
+        }),
+      ).rejects.toThrow(/active SecretRef resolution failed: missing root secret/);
+
+      expect(injectedWrite).toHaveBeenCalledTimes(1);
+      expect(injectedWrite.mock.calls[0]?.[1]?.preCommitRuntimePreflight).toEqual(
+        expect.any(Function),
+      );
+      await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(initialRaw);
+    } finally {
+      setRuntimeConfigSnapshotRefreshHandler(null);
+    }
   });
 });

--- a/src/config/mutate.test.ts
+++ b/src/config/mutate.test.ts
@@ -36,7 +36,10 @@ const validationMocks = vi.hoisted(() => ({
   ),
 }));
 
-vi.mock("./io.js", () => ioMocks);
+vi.mock("./io.js", async () => ({
+  ...(await vi.importActual<typeof import("./io.js")>("./io.js")),
+  ...ioMocks,
+}));
 vi.mock("./validation.js", () => validationMocks);
 
 function createSnapshot(params: {
@@ -669,6 +672,8 @@ describe("config mutate helpers", () => {
     const home = await suiteRootTracker.make("include-runtime-refresh-rollback");
     const configPath = path.join(home, ".openclaw", "openclaw.json");
     const pluginsPath = path.join(home, ".openclaw", "config", "plugins.json5");
+    const env = {} as NodeJS.ProcessEnv;
+    const envKey = "OPENCLAW_TEST_INCLUDE_ROLLBACK_ENV";
     await fs.mkdir(path.dirname(pluginsPath), { recursive: true });
     await fs.writeFile(
       configPath,
@@ -690,17 +695,21 @@ describe("config mutate helpers", () => {
         },
       },
     };
-    ioMocks.readConfigFileSnapshotForWrite.mockResolvedValue({
-      snapshot: createSnapshot({
-        hash: "hash-include-refresh-written",
-        path: configPath,
-        parsed: { plugins: { $include: "./config/plugins.json5" } },
-        sourceConfig: nextConfig,
-      }),
-      writeOptions: { expectedConfigPath: configPath },
+    ioMocks.readConfigFileSnapshotForWrite.mockImplementation(async () => {
+      env[envKey] = "written-env-value";
+      return {
+        snapshot: createSnapshot({
+          hash: "hash-include-refresh-written",
+          path: configPath,
+          parsed: { plugins: { $include: "./config/plugins.json5" } },
+          sourceConfig: nextConfig,
+        }),
+        writeOptions: { expectedConfigPath: configPath },
+      };
     });
 
     try {
+      delete env[envKey];
       setRuntimeConfigSnapshotRefreshHandler({
         preflight: () => true,
         refresh: () => {
@@ -712,14 +721,17 @@ describe("config mutate helpers", () => {
         replaceConfigFile({
           baseHash: snapshot.hash,
           snapshot,
+          io: { ...ioMocks, env },
           writeOptions: { expectedConfigPath: snapshot.path },
           nextConfig,
         }),
       ).rejects.toThrow(/runtime snapshot refresh failed: lost include secret/);
 
       await expect(fs.readFile(pluginsPath, "utf-8")).resolves.toBe(initialPluginsRaw);
+      expect(env[envKey]).toBeUndefined();
     } finally {
       setRuntimeConfigSnapshotRefreshHandler(null);
+      delete env[envKey];
     }
   });
 

--- a/src/config/mutate.ts
+++ b/src/config/mutate.ts
@@ -13,6 +13,7 @@ import { INCLUDE_KEY } from "./includes.js";
 import { createInvalidConfigError, formatInvalidConfigDetails } from "./io.invalid-config.js";
 import {
   readConfigFileSnapshotForWrite,
+  restoreEnvChangesIfUnchanged,
   resolveConfigSnapshotHash,
   writeConfigFile,
   type ConfigWriteOptions,
@@ -75,6 +76,7 @@ export type ConfigReplaceResult = {
 };
 
 export type ConfigMutationIO = {
+  env?: NodeJS.ProcessEnv;
   readConfigFileSnapshotForWrite: typeof readConfigFileSnapshotForWrite;
   writeConfigFile: (
     cfg: OpenClawConfig,
@@ -360,6 +362,9 @@ async function tryWriteSingleTopLevelIncludeMutation(params: {
   const committedIncludeRaw = formatJsonFileValue(nextConfigRecord[key]);
   const committedIncludeHash = hashFileRaw(committedIncludeRaw);
   await writeJsonFileAtomic(includePath, nextConfigRecord[key]);
+  const writeEnv = params.io?.env ?? process.env;
+  const envBeforePostWriteRead = { ...writeEnv };
+  let envAfterPostWriteRead = envBeforePostWriteRead;
   try {
     if (
       params.writeOptions?.skipRuntimeSnapshotRefresh &&
@@ -369,9 +374,14 @@ async function tryWriteSingleTopLevelIncludeMutation(params: {
       return { persistedHash: null, persistedConfig: nextConfig };
     }
 
-    const refreshed = await (
-      params.io?.readConfigFileSnapshotForWrite ?? readConfigFileSnapshotForWrite
-    )(params.writeOptions?.skipPluginValidation ? { skipPluginValidation: true } : undefined);
+    let refreshed: Awaited<ReturnType<typeof readConfigFileSnapshotForWrite>>;
+    try {
+      refreshed = await (
+        params.io?.readConfigFileSnapshotForWrite ?? readConfigFileSnapshotForWrite
+      )(params.writeOptions?.skipPluginValidation ? { skipPluginValidation: true } : undefined);
+    } finally {
+      envAfterPostWriteRead = { ...writeEnv };
+    }
     const refreshedSnapshot = refreshed.snapshot;
     const persistedHash = resolveConfigSnapshotHash(refreshedSnapshot);
     if (!refreshedSnapshot.valid) {
@@ -419,11 +429,18 @@ async function tryWriteSingleTopLevelIncludeMutation(params: {
     return { persistedHash, persistedConfig: refreshedSnapshot.sourceConfig };
   } catch (error) {
     try {
-      await rollbackJsonFileWriteIfUnchanged({
+      const rolledBack = await rollbackJsonFileWriteIfUnchanged({
         filePath: includePath,
         previousRaw: previousIncludeRaw,
         committedHash: committedIncludeHash,
       });
+      if (rolledBack) {
+        restoreEnvChangesIfUnchanged({
+          env: writeEnv,
+          before: envBeforePostWriteRead,
+          after: envAfterPostWriteRead,
+        });
+      }
     } catch (rollbackError) {
       throw new Error(
         `${formatErrorMessage(error)} Rollback failed: ${formatErrorMessage(rollbackError)}`,

--- a/src/config/mutate.ts
+++ b/src/config/mutate.ts
@@ -1,4 +1,5 @@
 import { AsyncLocalStorage } from "node:async_hooks";
+import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { isDeepStrictEqual } from "node:util";
@@ -27,6 +28,7 @@ import {
   getRuntimeConfigSnapshotRefreshHandler,
   getRuntimeConfigSourceSnapshot,
   notifyRuntimeConfigWriteListeners,
+  preflightRuntimeSnapshotWrite,
   resolveConfigWriteAfterWrite,
   resolveConfigWriteFollowUp,
   type ConfigWriteAfterWrite,
@@ -235,10 +237,65 @@ function getSingleTopLevelIncludeTarget(params: {
   return resolved;
 }
 
+function formatJsonFileValue(value: unknown): string {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+function hashFileRaw(raw: string | null): string {
+  const hash = crypto.createHash("sha256");
+  if (raw === null) {
+    hash.update("missing");
+  } else {
+    hash.update("present\0");
+    hash.update(raw, "utf-8");
+  }
+  return hash.digest("hex");
+}
+
+async function readFileRawIfExists(filePath: string): Promise<string | null> {
+  try {
+    return await fs.readFile(filePath, "utf-8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  }
+}
+
+async function rollbackJsonFileWriteIfUnchanged(params: {
+  filePath: string;
+  previousRaw: string | null;
+  committedHash: string;
+}): Promise<boolean> {
+  const currentRaw = await readFileRawIfExists(params.filePath);
+  if (hashFileRaw(currentRaw) !== params.committedHash) {
+    return false;
+  }
+  if (params.previousRaw !== null) {
+    await replaceFileAtomic({
+      filePath: params.filePath,
+      content: params.previousRaw,
+      dirMode: 0o700,
+      mode: 0o600,
+      tempPrefix: path.basename(params.filePath),
+    });
+    return true;
+  }
+  try {
+    await fs.unlink(params.filePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code !== "ENOENT") {
+      throw error;
+    }
+  }
+  return true;
+}
+
 async function writeJsonFileAtomic(filePath: string, value: unknown): Promise<void> {
   await replaceFileAtomic({
     filePath,
-    content: `${JSON.stringify(value, null, 2)}\n`,
+    content: formatJsonFileValue(value),
     dirMode: 0o700,
     mode: 0o600,
     tempPrefix: path.basename(filePath),
@@ -289,62 +346,92 @@ async function tryWriteSingleTopLevelIncludeMutation(params: {
   const runtimeConfigSourceSnapshot = getRuntimeConfigSourceSnapshot();
   const hadRuntimeSnapshot = Boolean(runtimeConfigSnapshot);
   const hadBothSnapshots = Boolean(runtimeConfigSnapshot && runtimeConfigSourceSnapshot);
-  await writeJsonFileAtomic(includePath, nextConfigRecord[key]);
-  if (
-    params.writeOptions?.skipRuntimeSnapshotRefresh &&
-    !hadRuntimeSnapshot &&
-    !getRuntimeConfigSnapshotRefreshHandler()
-  ) {
-    return { persistedHash: null, persistedConfig: nextConfig };
-  }
-
-  const refreshed = await (
-    params.io?.readConfigFileSnapshotForWrite ?? readConfigFileSnapshotForWrite
-  )(params.writeOptions?.skipPluginValidation ? { skipPluginValidation: true } : undefined);
-  const refreshedSnapshot = refreshed.snapshot;
-  const persistedHash = resolveConfigSnapshotHash(refreshedSnapshot);
-  if (!refreshedSnapshot.valid) {
-    throw createInvalidConfigError(
-      params.snapshot.path,
-      formatInvalidConfigDetails(refreshedSnapshot.issues),
-    );
-  }
-  if (!persistedHash) {
-    throw new Error(
-      `Config was written to ${params.snapshot.path}, but no persisted hash was available.`,
-    );
-  }
-
-  const notifyCommittedWrite = () => {
-    const currentRuntimeConfig = getRuntimeConfigSnapshot();
-    if (!currentRuntimeConfig) {
-      return;
-    }
-    notifyRuntimeConfigWriteListeners(
-      createRuntimeConfigWriteNotification({
-        configPath: params.snapshot.path,
-        sourceConfig: refreshedSnapshot.sourceConfig,
-        runtimeConfig: currentRuntimeConfig,
-        persistedHash,
-        afterWrite: params.afterWrite ?? params.writeOptions?.afterWrite,
-      }),
-    );
-  };
-  await finalizeRuntimeSnapshotWrite({
-    nextSourceConfig: refreshedSnapshot.sourceConfig,
+  const runtimePreflightResult = await preflightRuntimeSnapshotWrite({
+    nextSourceConfig: nextConfig,
     refreshOptions: params.writeOptions?.runtimeRefresh,
-    hadRuntimeSnapshot,
-    hadBothSnapshots,
-    loadFreshConfig: () => refreshedSnapshot.runtimeConfig,
-    notifyCommittedWrite,
     formatRefreshError: (error) => formatErrorMessage(error),
     createRefreshError: (detail, cause) =>
       new Error(
-        `Config was written to ${params.snapshot.path}, but runtime snapshot refresh failed: ${detail}`,
+        `Config write blocked before committing ${includePath}: active SecretRef resolution failed: ${detail}`,
         { cause },
       ),
   });
-  return { persistedHash, persistedConfig: refreshedSnapshot.sourceConfig };
+  const previousIncludeRaw = await readFileRawIfExists(includePath);
+  const committedIncludeRaw = formatJsonFileValue(nextConfigRecord[key]);
+  const committedIncludeHash = hashFileRaw(committedIncludeRaw);
+  await writeJsonFileAtomic(includePath, nextConfigRecord[key]);
+  try {
+    if (
+      params.writeOptions?.skipRuntimeSnapshotRefresh &&
+      !hadRuntimeSnapshot &&
+      !getRuntimeConfigSnapshotRefreshHandler()
+    ) {
+      return { persistedHash: null, persistedConfig: nextConfig };
+    }
+
+    const refreshed = await (
+      params.io?.readConfigFileSnapshotForWrite ?? readConfigFileSnapshotForWrite
+    )(params.writeOptions?.skipPluginValidation ? { skipPluginValidation: true } : undefined);
+    const refreshedSnapshot = refreshed.snapshot;
+    const persistedHash = resolveConfigSnapshotHash(refreshedSnapshot);
+    if (!refreshedSnapshot.valid) {
+      throw createInvalidConfigError(
+        params.snapshot.path,
+        formatInvalidConfigDetails(refreshedSnapshot.issues),
+      );
+    }
+    if (!persistedHash) {
+      throw new Error(
+        `Config was written to ${params.snapshot.path}, but no persisted hash was available.`,
+      );
+    }
+
+    const notifyCommittedWrite = () => {
+      const currentRuntimeConfig = getRuntimeConfigSnapshot();
+      if (!currentRuntimeConfig) {
+        return;
+      }
+      notifyRuntimeConfigWriteListeners(
+        createRuntimeConfigWriteNotification({
+          configPath: params.snapshot.path,
+          sourceConfig: refreshedSnapshot.sourceConfig,
+          runtimeConfig: currentRuntimeConfig,
+          persistedHash,
+          afterWrite: params.afterWrite ?? params.writeOptions?.afterWrite,
+        }),
+      );
+    };
+    await finalizeRuntimeSnapshotWrite({
+      nextSourceConfig: refreshedSnapshot.sourceConfig,
+      refreshOptions: params.writeOptions?.runtimeRefresh,
+      hadRuntimeSnapshot,
+      hadBothSnapshots,
+      loadFreshConfig: () => refreshedSnapshot.runtimeConfig,
+      notifyCommittedWrite,
+      preflightResult: runtimePreflightResult,
+      formatRefreshError: (error) => formatErrorMessage(error),
+      createRefreshError: (detail, cause) =>
+        new Error(
+          `Config was written to ${params.snapshot.path}, but runtime snapshot refresh failed: ${detail}`,
+          { cause },
+        ),
+    });
+    return { persistedHash, persistedConfig: refreshedSnapshot.sourceConfig };
+  } catch (error) {
+    try {
+      await rollbackJsonFileWriteIfUnchanged({
+        filePath: includePath,
+        previousRaw: previousIncludeRaw,
+        committedHash: committedIncludeHash,
+      });
+    } catch (rollbackError) {
+      throw new Error(
+        `${formatErrorMessage(error)} Rollback failed: ${formatErrorMessage(rollbackError)}`,
+        { cause: rollbackError },
+      );
+    }
+    throw error;
+  }
 }
 
 function resolveConfigWriteResult(
@@ -404,13 +491,35 @@ async function replaceConfigFileUnlocked(params: {
     io: params.io,
   });
   if (!writeResult) {
+    const fallbackWriteOptions: ConfigWriteOptions = {
+      baseSnapshot: snapshot,
+      ...writeOptions,
+      ...params.writeOptions,
+      afterWrite,
+    };
+    const ioPreCommitRuntimePreflight = params.io
+      ? fallbackWriteOptions.preCommitRuntimePreflight
+      : undefined;
+    if (params.io) {
+      fallbackWriteOptions.preCommitRuntimePreflight = async (sourceConfig) => {
+        await ioPreCommitRuntimePreflight?.(sourceConfig);
+        await preflightRuntimeSnapshotWrite({
+          nextSourceConfig: sourceConfig,
+          refreshOptions: fallbackWriteOptions.runtimeRefresh,
+          formatRefreshError: (error) => formatErrorMessage(error),
+          createRefreshError: (detail, cause) =>
+            new Error(
+              `Config write blocked before committing ${snapshot.path}: active SecretRef resolution failed: ${detail}`,
+              { cause },
+            ),
+        });
+      };
+    }
     writeResult = resolveConfigWriteResult(
-      await (params.io?.writeConfigFile ?? writeConfigFile)(params.nextConfig, {
-        baseSnapshot: snapshot,
-        ...writeOptions,
-        ...params.writeOptions,
-        afterWrite,
-      }),
+      await (params.io?.writeConfigFile ?? writeConfigFile)(
+        params.nextConfig,
+        fallbackWriteOptions,
+      ),
       params.nextConfig,
     );
   }

--- a/src/config/runtime-snapshot.ts
+++ b/src/config/runtime-snapshot.ts
@@ -7,7 +7,9 @@ export type RuntimeConfigSnapshotRefreshOptions = {
 
 export type RuntimeConfigSnapshotRefreshParams = RuntimeConfigSnapshotRefreshOptions & {
   sourceConfig: OpenClawConfig;
+  preflightResult?: unknown;
 };
+type MaybePromise<T> = T | Promise<T>;
 
 export type ConfigWriteAfterWrite =
   | { mode: "auto" }
@@ -61,6 +63,7 @@ export function resolveConfigWriteFollowUp(
 }
 
 export type RuntimeConfigSnapshotRefreshHandler = {
+  preflight?: (params: RuntimeConfigSnapshotRefreshParams) => MaybePromise<unknown>;
   refresh: (params: RuntimeConfigSnapshotRefreshParams) => boolean | Promise<boolean>;
   clearOnRefreshFailure?: () => void;
 };
@@ -267,6 +270,26 @@ export function loadPinnedRuntimeConfig(loadFresh: () => OpenClawConfig): OpenCl
   return getRuntimeConfigSnapshot() ?? config;
 }
 
+export async function preflightRuntimeSnapshotWrite(params: {
+  nextSourceConfig: OpenClawConfig;
+  refreshOptions?: RuntimeConfigSnapshotRefreshOptions;
+  createRefreshError: (detail: string, cause: unknown) => Error;
+  formatRefreshError: (error: unknown) => string;
+}): Promise<unknown> {
+  const refreshHandler = getRuntimeConfigSnapshotRefreshHandler();
+  if (!refreshHandler?.preflight) {
+    return undefined;
+  }
+  try {
+    return await refreshHandler.preflight({
+      sourceConfig: params.nextSourceConfig,
+      ...params.refreshOptions,
+    });
+  } catch (error) {
+    throw params.createRefreshError(params.formatRefreshError(error), error);
+  }
+}
+
 export async function finalizeRuntimeSnapshotWrite(params: {
   nextSourceConfig: OpenClawConfig;
   refreshOptions?: RuntimeConfigSnapshotRefreshOptions;
@@ -276,6 +299,7 @@ export async function finalizeRuntimeSnapshotWrite(params: {
   notifyCommittedWrite: () => void;
   createRefreshError: (detail: string, cause: unknown) => Error;
   formatRefreshError: (error: unknown) => string;
+  preflightResult?: unknown;
 }): Promise<void> {
   const refreshHandler = getRuntimeConfigSnapshotRefreshHandler();
   if (refreshHandler) {
@@ -283,6 +307,7 @@ export async function finalizeRuntimeSnapshotWrite(params: {
       const refreshed = await refreshHandler.refresh({
         sourceConfig: params.nextSourceConfig,
         ...params.refreshOptions,
+        preflightResult: params.preflightResult,
       });
       if (refreshed) {
         params.notifyCommittedWrite();

--- a/src/gateway/server-startup-config.ts
+++ b/src/gateway/server-startup-config.ts
@@ -264,19 +264,29 @@ export function createRuntimeSecretsActivator(params: {
             config: pruneSkippedStartupSecretSurfaces(config),
           });
           if (fastPath) {
+            const coercePreflightSnapshot = (
+              value: unknown,
+              sourceConfig: OpenClawConfig,
+            ): PreparedRuntimeSecretsSnapshot | null => {
+              if (!value || typeof value !== "object") {
+                return null;
+              }
+              const candidate = value as PreparedRuntimeSecretsSnapshot;
+              return isDeepStrictEqual(candidate.sourceConfig, sourceConfig) ? candidate : null;
+            };
             return await finishPreparedSnapshot(fastPath.snapshot, activationParams, {
               activateRuntimeSecretsSnapshot: (snapshot) =>
                 activateSecretsRuntimeSnapshotState({
                   snapshot,
                   refreshContext: fastPath.refreshContext,
                   refreshHandler: {
-                    refresh: async ({ sourceConfig, includeAuthStoreRefs }) => {
+                    preflight: async ({ sourceConfig, includeAuthStoreRefs }) => {
                       const secretsRuntime = await loadSecretsRuntime();
                       const activeSnapshot = getActiveSecretsRuntimeSnapshot();
-                      const oneShotSkipAuthStoreRefs =
-                        includeAuthStoreRefs === false &&
-                        fastPath.refreshContext.includeAuthStoreRefs;
-                      const refreshed = await secretsRuntime.prepareSecretsRuntimeSnapshot({
+                      if (!activeSnapshot) {
+                        return false;
+                      }
+                      return await secretsRuntime.prepareSecretsRuntimeSnapshot({
                         config: sourceConfig,
                         env: fastPath.refreshContext.env,
                         agentDirs: resolveRefreshAgentDirs(sourceConfig, fastPath.refreshContext),
@@ -287,6 +297,27 @@ export function createRuntimeSecretsActivator(params: {
                           ? {}
                           : { loadAuthStore: fastPath.refreshContext.loadAuthStore }),
                       });
+                    },
+                    refresh: async ({ sourceConfig, includeAuthStoreRefs, preflightResult }) => {
+                      const secretsRuntime = await loadSecretsRuntime();
+                      const activeSnapshot = getActiveSecretsRuntimeSnapshot();
+                      const oneShotSkipAuthStoreRefs =
+                        includeAuthStoreRefs === false &&
+                        fastPath.refreshContext.includeAuthStoreRefs;
+                      const refreshed =
+                        coercePreflightSnapshot(preflightResult, sourceConfig) ??
+                        (await secretsRuntime.prepareSecretsRuntimeSnapshot({
+                          config: sourceConfig,
+                          env: fastPath.refreshContext.env,
+                          agentDirs: resolveRefreshAgentDirs(sourceConfig, fastPath.refreshContext),
+                          includeAuthStoreRefs:
+                            includeAuthStoreRefs ?? fastPath.refreshContext.includeAuthStoreRefs,
+                          loadablePluginOrigins: fastPath.refreshContext.loadablePluginOrigins,
+                          ...(fastPath.usesAuthStoreFallback ||
+                          !fastPath.refreshContext.loadAuthStore
+                            ? {}
+                            : { loadAuthStore: fastPath.refreshContext.loadAuthStore }),
+                        }));
                       if (oneShotSkipAuthStoreRefs && activeSnapshot) {
                         refreshed.authStores = getLiveSecretsRuntimeAuthStores();
                         setPreparedSecretsRuntimeSnapshotRefreshContext(

--- a/src/secrets/runtime-request-secret-refs.test.ts
+++ b/src/secrets/runtime-request-secret-refs.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { setRuntimeAuthProfileStoreSnapshot } from "../agents/auth-profiles/runtime-snapshots.js";
 import { getRuntimeConfigSnapshotRefreshHandler } from "../config/runtime-snapshot.js";
@@ -9,6 +12,21 @@ import {
 } from "./runtime.test-support.ts";
 
 const { prepareSecretsRuntimeSnapshot } = setupSecretsRuntimeSnapshotTestHooks();
+
+async function writeSecureFile(filePath: string, content: string, mode = 0o600): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  const tempPath = `${filePath}.tmp-${process.pid}-${Date.now()}-${Math.random()
+    .toString(16)
+    .slice(2)}`;
+  try {
+    await fs.writeFile(tempPath, content, "utf8");
+    await fs.chmod(tempPath, mode);
+    await fs.rename(tempPath, filePath);
+  } catch (err) {
+    await fs.rm(tempPath, { force: true }).catch(() => {});
+    throw err;
+  }
+}
 
 describe("secrets runtime snapshot request secret refs", () => {
   it("can skip auth-profile SecretRef resolution when includeAuthStoreRefs is false", async () => {
@@ -102,6 +120,71 @@ describe("secrets runtime snapshot request secret refs", () => {
     ] as { token?: string } | undefined;
     expect(profile?.token).toBe("sk-live");
   });
+
+  it.skipIf(process.platform === "win32")(
+    "reuses preflighted exec SecretRef snapshots during active runtime refresh",
+    async () => {
+      const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-runtime-exec-preflight-"));
+      try {
+        const execLogPath = path.join(root, "exec-calls.log");
+        const execScriptPath = path.join(root, "resolver.sh");
+        await writeSecureFile(
+          execScriptPath,
+          [
+            "#!/bin/sh",
+            `printf 'x\\n' >> ${JSON.stringify(execLogPath)}`,
+            "cat >/dev/null",
+            'printf \'{"protocolVersion":1,"values":{"gateway/token":"exec-gateway-token"}}\'',
+          ].join("\n"),
+          0o700,
+        );
+
+        const config = asConfig({
+          secrets: {
+            providers: {
+              execmain: {
+                source: "exec",
+                command: execScriptPath,
+                jsonOnly: true,
+                timeoutMs: 20_000,
+                noOutputTimeoutMs: 10_000,
+              },
+            },
+          },
+          gateway: {
+            auth: {
+              mode: "token",
+              token: { source: "exec", provider: "execmain", id: "gateway/token" },
+            },
+          },
+        });
+        const snapshot = await prepareSecretsRuntimeSnapshot({
+          config,
+          agentDirs: [path.join(root, "agent")],
+          loadAuthStore: () => ({ version: 1, profiles: {} }),
+        });
+        activateSecretsRuntimeSnapshot(snapshot);
+        await fs.writeFile(execLogPath, "", "utf8");
+
+        const refreshHandler = getRuntimeConfigSnapshotRefreshHandler();
+        if (!refreshHandler?.preflight) {
+          throw new Error("Expected active runtime refresh preflight handler");
+        }
+        const preflightResult = await refreshHandler.preflight({ sourceConfig: config });
+        await expect(
+          refreshHandler.refresh({ sourceConfig: config, preflightResult }),
+        ).resolves.toBe(true);
+
+        const execCalls = (await fs.readFile(execLogPath, "utf8")).split("\n").filter(Boolean);
+        expect(execCalls).toHaveLength(1);
+        expect(getActiveSecretsRuntimeSnapshot()?.config.gateway?.auth?.token).toBe(
+          "exec-gateway-token",
+        );
+      } finally {
+        await fs.rm(root, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("resolves model provider request secret refs for headers, auth, and tls material", async () => {
     const config = asConfig({

--- a/src/secrets/runtime.gateway-auth.integration.test.ts
+++ b/src/secrets/runtime.gateway-auth.integration.test.ts
@@ -65,7 +65,7 @@ describe("secrets runtime snapshot gateway-auth integration", () => {
   });
 
   it(
-    "keeps last-known-good runtime snapshot active when reload introduces unresolved active gateway auth refs",
+    "rejects unresolved active gateway auth refs before persisting them",
     async () => {
       await withTempHome("openclaw-secrets-runtime-gateway-auth-reload-lkg-", async (home) => {
         const initialTokenRef = {
@@ -78,6 +78,23 @@ describe("secrets runtime snapshot gateway-auth integration", () => {
           provider: "default",
           id: "MISSING_GATEWAY_AUTH_TOKEN",
         } as const;
+        await fs.mkdir(path.join(home, ".openclaw"), { recursive: true });
+        await fs.writeFile(
+          path.join(home, ".openclaw", "openclaw.json"),
+          `${JSON.stringify(
+            {
+              gateway: {
+                auth: {
+                  mode: "token",
+                  token: initialTokenRef,
+                },
+              },
+            },
+            null,
+            2,
+          )}\n`,
+          "utf8",
+        );
 
         const prepared = await prepareSecretsRuntimeSnapshot({
           config: asConfig({
@@ -109,7 +126,7 @@ describe("secrets runtime snapshot gateway-auth integration", () => {
               },
             },
           }),
-        ).rejects.toThrow(/runtime snapshot refresh failed: .*MISSING_GATEWAY_AUTH_TOKEN/i);
+        ).rejects.toThrow(/active SecretRef resolution failed: .*MISSING_GATEWAY_AUTH_TOKEN/i);
 
         const activeAfterFailure = getActiveSecretsRuntimeSnapshot();
         if (activeAfterFailure === null) {
@@ -121,7 +138,7 @@ describe("secrets runtime snapshot gateway-auth integration", () => {
         const persistedConfig = JSON.parse(
           await fs.readFile(path.join(home, ".openclaw", "openclaw.json"), "utf8"),
         ) as OpenClawConfig;
-        expect(persistedConfig.gateway?.auth?.token).toEqual(missingTokenRef);
+        expect(persistedConfig.gateway?.auth?.token).toEqual(initialTokenRef);
       });
     },
     SECRETS_RUNTIME_INTEGRATION_TIMEOUT_MS,

--- a/src/secrets/runtime.ts
+++ b/src/secrets/runtime.ts
@@ -1,3 +1,4 @@
+import { isDeepStrictEqual } from "node:util";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope-config.js";
 import {
   clearRuntimeAuthProfileStoreSnapshots,
@@ -217,19 +218,27 @@ export function activateSecretsRuntimeSnapshot(snapshot: PreparedSecretsRuntimeS
       loadAuthStore: loadAuthProfileStoreForSecretsRuntime,
       loadablePluginOrigins: new Map<string, PluginOrigin>(),
     } satisfies SecretsRuntimeRefreshContext);
+  const coercePreflightSnapshot = (
+    value: unknown,
+    sourceConfig: OpenClawConfig,
+  ): PreparedSecretsRuntimeSnapshot | null => {
+    if (!value || typeof value !== "object") {
+      return null;
+    }
+    const candidate = value as PreparedSecretsRuntimeSnapshot;
+    return isDeepStrictEqual(candidate.sourceConfig, sourceConfig) ? candidate : null;
+  };
   activateSecretsRuntimeSnapshotState({
     snapshot,
     refreshContext,
     refreshHandler: {
-      refresh: async ({ sourceConfig, includeAuthStoreRefs }) => {
+      preflight: async ({ sourceConfig, includeAuthStoreRefs }) => {
         const activeRefreshContext = getActiveSecretsRuntimeRefreshContext();
         const activeSnapshot = getActiveSecretsRuntimeSnapshotState();
         if (!activeSnapshot || !activeRefreshContext) {
           return false;
         }
-        const oneShotSkipAuthStoreRefs =
-          includeAuthStoreRefs === false && activeRefreshContext.includeAuthStoreRefs;
-        const refreshed = await prepareSecretsRuntimeSnapshot({
+        return await prepareSecretsRuntimeSnapshot({
           config: sourceConfig,
           env: activeRefreshContext.env,
           agentDirs: resolveRefreshAgentDirs(sourceConfig, activeRefreshContext),
@@ -239,6 +248,27 @@ export function activateSecretsRuntimeSnapshot(snapshot: PreparedSecretsRuntimeS
             ? { loadAuthStore: activeRefreshContext.loadAuthStore }
             : {}),
         });
+      },
+      refresh: async ({ sourceConfig, includeAuthStoreRefs, preflightResult }) => {
+        const activeRefreshContext = getActiveSecretsRuntimeRefreshContext();
+        const activeSnapshot = getActiveSecretsRuntimeSnapshotState();
+        if (!activeSnapshot || !activeRefreshContext) {
+          return false;
+        }
+        const oneShotSkipAuthStoreRefs =
+          includeAuthStoreRefs === false && activeRefreshContext.includeAuthStoreRefs;
+        const refreshed =
+          coercePreflightSnapshot(preflightResult, sourceConfig) ??
+          (await prepareSecretsRuntimeSnapshot({
+            config: sourceConfig,
+            env: activeRefreshContext.env,
+            agentDirs: resolveRefreshAgentDirs(sourceConfig, activeRefreshContext),
+            includeAuthStoreRefs: includeAuthStoreRefs ?? activeRefreshContext.includeAuthStoreRefs,
+            loadablePluginOrigins: activeRefreshContext.loadablePluginOrigins,
+            ...(activeRefreshContext.loadAuthStore
+              ? { loadAuthStore: activeRefreshContext.loadAuthStore }
+              : {}),
+          }));
         if (oneShotSkipAuthStoreRefs) {
           refreshed.authStores = getLiveSecretsRuntimeAuthStores();
           setPreparedSecretsRuntimeSnapshotRefreshContext(refreshed, activeRefreshContext);


### PR DESCRIPTION
## Summary

- Problem: bottom/CLI config mutation paths could persist config that the active daemon runtime could not prepare, especially unresolved active SecretRefs, leaving the next runtime refresh or startup to fail after the bad config was already on disk.
- Solution: preflight the exact source config against the active runtime refresh handler before committing root or single-file include writes, then pass the preflighted result into refresh so SecretRefs are not resolved twice.
- Rollback hardening: if a post-commit runtime refresh still fails, roll back unchanged root/include writes and restore env mutations that were injected by the post-write read when they are still unchanged.
- Scope boundary: no config schema change, no SecretRef syntax change, no plugin validation policy change, and no external provider credential behavior change beyond failing before persistence.

## Motivation

Config writes should not leave daemon-unpreparable SecretRefs on disk. If the active runtime already knows a write cannot resolve required SecretRefs, the write should fail before commit; if refresh fails after commit, rollback should restore both file bytes and config-injected env state.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #46531
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior addressed: active runtime SecretRef failures are blocked before root and include config writes persist, and refresh-failure rollback restores root/include files plus env mutations.
- Real environment tested: local OpenClaw source checkout on macOS in this branch, using real temporary `openclaw.json`, included `models.json5`, included `env.json5`, production `prepareSecretsRuntimeSnapshot()`, `activateSecretsRuntimeSnapshot()`, `writeConfigFile()`, `createConfigIO()`, and `replaceConfigFile()`.
- Exact steps or command run after this patch: `node --import tsx --input-type=module` with an inline script that executed four real write scenarios: active gateway-auth SecretRef root write, active model-provider request SecretRef include write, root refresh-failure rollback with `env.vars`, and include refresh-failure rollback with included `env.vars`.
- Evidence after fix: terminal output copied from the command:

```json
{
  "allPassed": true,
  "results": {
    "rootSecretRefPreflightBlocked": true,
    "rootSecretRefNamesMissingEnv": true,
    "rootFileUnchangedAfterSecretRefPreflight": true,
    "rootRuntimeSnapshotPreserved": true,
    "rootSourceRefPreserved": true,
    "includeSecretRefPreflightBlocked": true,
    "includeSecretRefNamesMissingEnv": true,
    "includeFileUnchangedAfterSecretRefPreflight": true,
    "rootRefreshFailureSurfaced": true,
    "rootRefreshSawWrittenEnv": true,
    "rootRefreshRollbackRestoredFile": true,
    "rootRefreshRollbackRestoredEnv": true,
    "includeRefreshFailureSurfaced": true,
    "includeRefreshSawWrittenEnv": true,
    "includeRefreshRollbackRestoredFile": true,
    "includeRefreshRollbackRestoredEnv": true
  }
}
```

- Observed result after fix: unresolved active SecretRefs failed with `active SecretRef resolution failed` before file bytes changed; active runtime config/source snapshots stayed on the previous good values; synthetic refresh failures surfaced as runtime refresh errors; root and included files returned to original bytes; config-injected env vars were removed after successful rollback.
- What was not tested: full managed gateway restart, live external provider credentials, and OS package install/update flows.
- Before evidence: PR review found the previous proof only exercised a narrow temp include rollback case and did not prove the broader SecretRef preflight behavior or the root/include rollback surface.

## Root Cause

- Root cause: runtime snapshot refresh was treated as post-write follow-up for bottom/CLI config mutations, so daemon-unpreparable active SecretRefs could be written before refresh failed.
- Secondary gap: root writes had env restoration around rollback, but single-file include writes did not restore env mutations from the post-write read.
- Missing detection / guardrail: tests covered gateway startup preflight and include file rollback separately, but not the bottom/CLI writer proving active runtime SecretRefs before persistence.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target tests or files:
  - `src/config/io.write-config.test.ts`
  - `src/config/mutate.test.ts`
  - `src/secrets/runtime.gateway-auth.integration.test.ts`
  - `src/secrets/runtime-request-secret-refs.test.ts`
- Scenario the tests lock in: root and single-file include config writes call active runtime preflight before committing, preserve the previous runtime snapshot/source on failure, reuse preflighted runtime SecretRef snapshots during refresh, and roll back file/env state on refresh failure.
- Why this is the smallest reliable guardrail: the regression lives at the config writer/runtime refresh boundary, so the tests exercise that boundary directly without requiring a full gateway restart.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Config writes that would leave the active daemon unable to resolve required SecretRefs now fail before persistence. Refresh failures after persistence roll back unchanged root/include writes and restore config-injected env mutations when safe.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) Yes
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: unresolved active SecretRefs are blocked before disk writes, preflighted SecretRef snapshots are reused for refresh, and rollback removes stale env-injected secret values when they are still unchanged.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node.js checkout through repo scripts
- Model/provider: N/A
- Integration/channel (if any): active secrets runtime and config writer/runtime refresh boundary
- Relevant config (redacted): temporary configs with gateway auth SecretRef, model provider request SecretRef, root `env.vars`, top-level `models` include, and top-level `env` include

### Steps

1. Activate a production secrets runtime snapshot with a resolvable gateway auth SecretRef, then attempt a root config write that changes it to a missing env SecretRef.
2. Activate a production secrets runtime snapshot with a resolvable model provider request SecretRef loaded from an included `models.json5`, then attempt an include mutation that changes it to a missing env SecretRef.
3. Force a root post-commit runtime refresh failure after a config write with `env.vars`.
4. Force an include post-commit runtime refresh failure after an included `env.vars` write.
5. Assert file bytes, runtime snapshot/source, surfaced errors, and env state after each failure.

### Expected

- Active SecretRef failures are rejected before persistence.
- The previous runtime snapshot/source remains active after failed preflight.
- Refresh failures roll back unchanged root/include writes.
- Env mutations injected by the failed post-write read are restored when unchanged.

### Actual

- All four behavior scenarios passed with every assertion in the JSON proof output set to `true`.

## Verification

- `git merge-tree HEAD upstream/main | rg -n "CONFLICT|Auto-merging|docs/.generated|<<<<<<<|>>>>>>>|======="`: passed, no output.
- `node scripts/run-vitest.mjs src/secrets/runtime.gateway-auth.integration.test.ts src/secrets/runtime-request-secret-refs.test.ts src/config/runtime-snapshot.test.ts src/config/io.write-config.test.ts src/config/mutate.test.ts src/gateway/server-methods/config.test.ts src/gateway/server-methods/config.shared-auth.test.ts`: passed, 9 files / 102 tests.
- `node --import tsx --input-type=module` real behavior proof script: passed, JSON output above.
- `pnpm changed:lanes --base upstream/main --head HEAD --json`: core + coreTests + docs only.
- `pnpm plugin-sdk:api:check`: passed.
- `pnpm tsgo:core`: passed.
- `pnpm tsgo:test:src`: passed.
- `pnpm format:check src/config/io.ts src/config/io.write-config.test.ts src/config/mutate.ts src/config/mutate.test.ts src/config/runtime-snapshot.ts src/gateway/server-startup-config.ts src/secrets/runtime.ts src/secrets/runtime-request-secret-refs.test.ts src/secrets/runtime.gateway-auth.integration.test.ts`: passed.
- `node scripts/run-oxlint.mjs src/config/io.ts src/config/io.write-config.test.ts src/config/mutate.ts src/config/mutate.test.ts src/config/runtime-snapshot.ts src/gateway/server-startup-config.ts src/secrets/runtime.ts src/secrets/runtime-request-secret-refs.test.ts src/secrets/runtime.gateway-auth.integration.test.ts --quiet`: passed, 0 warnings / 0 errors.
- `pnpm build`: passed.
- `git diff --check upstream/main...HEAD`: passed.

## Performance accounting

N/A. This PR changes failure ordering and rollback correctness, not a latency or throughput path.

## AI-assisted disclosure

AI-assisted. I verified the behavior with source-backed tests and the real runtime proof above.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) Yes
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: no user action required; failed writes now fail earlier or roll back more completely.

## Risks and Mitigations

- Risk: env restoration could overwrite a concurrent env update.
  - Mitigation: restoration only touches keys whose current value still matches the value captured immediately after the post-write read.
- Risk: preflight could resolve expensive SecretRefs twice.
  - Mitigation: refresh receives and reuses the preflighted runtime snapshot when it matches the source config.
