### PR TITLE
fix(memory-wiki): bound compile page reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 - fix(mattermost): fail closed on missing channel type [AI]. (#84091) Thanks @pgondhi987.
 - Recheck rebuilt system.run argv [AI]. (#84090) Thanks @pgondhi987.
 - CLI/cron: bound `openclaw cron show` job lookup pagination so non-advancing or unbounded `cron.list` responses fail instead of hanging the command. Fixes #83856. (#83989)
+- Memory Wiki: bound compile-time page summary reads so large FileProvider-backed vaults do not issue an unbounded `fs.readFile` burst. Fixes #68738.
 - Agents/messages: stop message-tool-only turns after a successful source-channel `message` send while keeping transcript mirrors under the session write lock. (#84289)
 - Agents: filter silent heartbeat response-tool transcript artifacts out of embedded context snapshots so later user turns are not polluted by heartbeat no-op messages. (#83477) Thanks @fuller-stack-dev.
 - Agents/OpenAI: log repeated strict tool-schema downgrade diagnostics once per provider/model/tool signature, reducing duplicate debug noise while preserving `strict=false` fallback behavior. Fixes #82930. (#82933) Thanks @galiniliev.

--- a/extensions/memory-wiki/src/compile.test.ts
+++ b/extensions/memory-wiki/src/compile.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { compileMemoryWikiVault } from "./compile.js";
 import { renderWikiMarkdown } from "./markdown.js";
 import { createMemoryWikiTestHarness } from "./test-helpers.js";
@@ -108,6 +108,61 @@ describe("compileMemoryWikiVault", () => {
     await expect(
       fs.readFile(path.join(rootDir, ".openclaw-wiki", "cache", "claims.jsonl"), "utf8"),
     ).resolves.toContain('"text":"Alpha is the canonical source page."');
+  });
+
+  it("bounds concurrent page reads while compiling", async () => {
+    const { rootDir, config } = await createVault({
+      rootDir: nextCaseRoot(),
+      initialize: true,
+    });
+
+    for (let index = 0; index < 24; index += 1) {
+      await fs.writeFile(
+        path.join(rootDir, "sources", `page-${index}.md`),
+        renderWikiMarkdown({
+          frontmatter: {
+            pageType: "source",
+            id: `source.page-${index}`,
+            title: `Page ${index}`,
+          },
+          body: `# Page ${index}\n`,
+        }),
+        "utf8",
+      );
+    }
+
+    const originalReadFile = fs.readFile.bind(fs);
+    let activePageReads = 0;
+    let maxActivePageReads = 0;
+    const readFileSpy = vi
+      .spyOn(fs, "readFile")
+      .mockImplementation(async (...args: Parameters<typeof fs.readFile>) => {
+        const targetPath = args[0];
+        const isTestPageRead =
+          typeof targetPath === "string" &&
+          targetPath.startsWith(path.join(rootDir, "sources", "page-"));
+        if (!isTestPageRead) {
+          return await originalReadFile(...args);
+        }
+
+        activePageReads += 1;
+        maxActivePageReads = Math.max(maxActivePageReads, activePageReads);
+        try {
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          return await originalReadFile(...args);
+        } finally {
+          activePageReads -= 1;
+        }
+      });
+
+    try {
+      await compileMemoryWikiVault(config);
+    } finally {
+      readFileSpy.mockRestore();
+    }
+
+    expect(maxActivePageReads).toBeGreaterThan(0);
+    expect(maxActivePageReads).toBeLessThanOrEqual(16);
   });
 
   it("renders obsidian-friendly links when configured", async () => {

--- a/extensions/memory-wiki/src/compile.ts
+++ b/extensions/memory-wiki/src/compile.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { runTasksWithConcurrency } from "openclaw/plugin-sdk/concurrency-runtime";
 import {
   replaceManagedMarkdownBlock,
   withTrailingNewline,
@@ -47,6 +48,7 @@ const COMPILE_PAGE_GROUPS: Array<{ kind: WikiPageKind; dir: string; heading: str
 ];
 const AGENT_DIGEST_PATH = ".openclaw-wiki/cache/agent-digest.json";
 const CLAIMS_DIGEST_PATH = ".openclaw-wiki/cache/claims.jsonl";
+const READ_PAGE_SUMMARIES_CONCURRENCY = 16;
 const MAX_RELATED_PAGES_PER_SECTION = 12;
 const MAX_SHARED_SOURCE_FANOUT = 24;
 
@@ -352,15 +354,20 @@ async function readPageSummaries(rootDir: string): Promise<WikiPageSummary[]> {
     await Promise.all(COMPILE_PAGE_GROUPS.map((group) => collectMarkdownFiles(rootDir, group.dir)))
   ).flat();
 
-  const pages = await Promise.all(
-    filePaths.map(async (relativePath) => {
+  const readResult = await runTasksWithConcurrency({
+    tasks: filePaths.map((relativePath) => async () => {
       const absolutePath = path.join(rootDir, relativePath);
       const raw = await fs.readFile(absolutePath, "utf8");
       return toWikiPageSummary({ absolutePath, relativePath, raw });
     }),
-  );
+    limit: READ_PAGE_SUMMARIES_CONCURRENCY,
+    errorMode: "stop",
+  });
+  if (readResult.hasError) {
+    throw readResult.firstError;
+  }
 
-  return pages
+  return readResult.results
     .flatMap((page) => (page ? [page] : []))
     .toSorted((left, right) => left.title.localeCompare(right.title));
 }


### PR DESCRIPTION
## Summary
- Bound Memory Wiki page-summary reads during compile with the existing concurrency helper.
- Added a regression test that asserts compile never opens more than 16 page reads at once.
- Added an Unreleased changelog entry.

Fixes #68738.

## Real behavior proof
- **Behavior or issue addressed**: Memory Wiki `wiki compile` now bounds compile-time source page-summary reads so a large FileProvider-backed vault does not launch an unbounded `fs.readFile` burst while compiling.
- **Real environment tested**: Local OpenClaw source checkout on macOS under `/Users/.../Documents/Codex/openclaw-openclaw-https-github-com-openclaw-2`, using an isolated proof vault at `/Users/.../Documents/Codex/openclaw-memory-wiki-proof-20260520-1950/vault`, `memory-wiki` config, native render mode, Obsidian disabled, and 180 real Markdown source pages (`sources/proof-001.md` through `sources/proof-180.md`).
- **Exact steps or command run after this patch**: Ran the source-checkout CLI entrypoint equivalent to `openclaw wiki compile` after applying this patch:

```text
OPENCLAW_CONFIG_PATH=$PROOF_ROOT/openclaw.json \
  OPENCLAW_STATE_DIR=$PROOF_ROOT/state \
  NODE_DISABLE_COMPILE_CACHE=1 \
  node --import tsx src/entry.ts wiki compile
```

- **Evidence after fix**: Copied terminal output from the real source checkout run:

```text
$ OPENCLAW_CONFIG_PATH=$PROOF_ROOT/openclaw.json \
  OPENCLAW_STATE_DIR=$PROOF_ROOT/state \
  NODE_DISABLE_COMPILE_CACHE=1 \
  node --import tsx src/entry.ts wiki compile
Compiled wiki vault at $PROOF_ROOT/vault (189 pages, 0 indexes updated).
real 31.94
user 29.46
sys 1.90
```

- **Observed result after fix**: First JSON compile completed successfully and produced the expected compiled vault counts, then the rerun completed without errors:

```text
pageCounts={"source":180,"report":9,"entity":0,"concept":0,"synthesis":0}
totalPages=189
exit=0
```

- **What was not tested**: I did not run a live Obsidian app integration or a private production vault. The after-fix proof used a local Documents/Codex OpenClaw setup with a synthetic 180-source-page vault, plus the focused automated checks below.

## Testing
- `node scripts/run-vitest.mjs run extensions/memory-wiki/src/compile.test.ts`
- `./node_modules/.bin/oxlint -c .oxlintrc.json --type-aware --tsconfig config/tsconfig/oxlint.extensions.json --report-unused-disable-directives-severity error extensions/memory-wiki/src/compile.ts extensions/memory-wiki/src/compile.test.ts`
- `OPENCLAW_LOCAL_CHECK=0 corepack pnpm run lint:extensions:bundled`
- `corepack pnpm exec oxfmt --check --threads=1 extensions/memory-wiki/src/compile.ts extensions/memory-wiki/src/compile.test.ts CHANGELOG.md`
- `git diff --check origin/main..HEAD`