### PR TITLE
feat(channels/telegram): per-sender inbound rate limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Channels/Telegram: add `channels.telegram.rateLimit` config so deployments running `dmPolicy="pairing"` or `"allowlist"` can throttle inbound DMs per sender id before they enter `messages.queue`. Separate `perSender` and `pairing` sliding windows, optional `backoffMs` hard cooldown, and `exemptSenderIds` bypass for known operators. Default unset preserves current behavior. (#84447)
 - Agents/config: allow `agents.list[].experimental.localModelLean` so lean local-model mode can be enabled for one configured agent instead of globally.
 - Providers/xAI: add device-code OAuth login so remote and headless setups can authorize xAI without a localhost browser callback. (#84005) Thanks @fuller-stack-dev.
 

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -134,6 +134,7 @@ import {
   resolveModelSelection,
   type ProviderInfo,
 } from "./model-buttons.js";
+import { TelegramRateLimiter, type RateLimiterScope } from "./rate-limiter.js";
 import { buildInlineKeyboard } from "./send.js";
 
 export const registerTelegramHandlers = ({
@@ -196,6 +197,11 @@ export const registerTelegramHandlers = ({
 
   const mediaGroupBuffer = new Map<string, BufferedMediaGroupEntry>();
   const mediaGroupProcessingByKey = new Map<string, Promise<void>>();
+
+  // Per-sender inbound rate limiter. Counted BEFORE inbound messages reach
+  // `messages.queue`, so a single sender's spam cannot evict other senders at
+  // the global queue cap. See https://github.com/openclaw/openclaw/issues/84447.
+  const inboundRateLimiter = new TelegramRateLimiter(telegramCfg.rateLimit);
   const messageCache = createTelegramMessageCache({
     persistedPath: resolveTelegramMessageCachePath(
       telegramDeps.resolveStorePath(cfg.session?.store),
@@ -2672,6 +2678,21 @@ export const registerTelegramHandlers = ({
         })
       ) {
         return;
+      }
+
+      if (!event.isGroup && inboundRateLimiter.isEnabled()) {
+        const isPairingAttempt =
+          dmPolicy === "pairing" &&
+          !effectiveDmAllow.hasWildcard &&
+          (event.senderId ? !effectiveDmAllow.entries.includes(event.senderId) : true);
+        const scope: RateLimiterScope = isPairingAttempt ? "pairing" : "dm";
+        const decision = inboundRateLimiter.tryConsume(event.senderId, scope);
+        if (!decision.allowed) {
+          logVerbose(
+            `Rate-limited telegram inbound from ${event.senderId || "unknown"} (scope=${scope}, reason=${decision.reason}, retryAfterMs=${decision.retryAfterMs}, dropPolicy=${decision.dropPolicy})`,
+          );
+          return;
+        }
       }
 
       if (!event.isGroup && (hasInboundMedia(event.msg) || hasReplyTargetMedia(event.msg))) {

--- a/extensions/telegram/src/rate-limiter.test.ts
+++ b/extensions/telegram/src/rate-limiter.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from "vitest";
+import { TelegramRateLimiter, type TelegramRateLimitConfig } from "./rate-limiter.js";
+
+const advanceClock = () => {
+  let now = 1_700_000_000_000;
+  return {
+    now: () => now,
+    advanceMs: (ms: number) => {
+      now += ms;
+    },
+    setMs: (ms: number) => {
+      now = ms;
+    },
+  };
+};
+
+describe("TelegramRateLimiter", () => {
+  it("is a no-op when no windows are configured", () => {
+    const clock = advanceClock();
+    const limiter = new TelegramRateLimiter(undefined, { now: clock.now });
+    expect(limiter.isEnabled()).toBe(false);
+    for (let i = 0; i < 100; i += 1) {
+      expect(limiter.tryConsume(42, "dm").allowed).toBe(true);
+    }
+  });
+
+  it("allows traffic up to maxRequests within the window then denies", () => {
+    const clock = advanceClock();
+    const cfg: TelegramRateLimitConfig = {
+      perSender: { windowSeconds: 60, maxRequests: 3 },
+    };
+    const limiter = new TelegramRateLimiter(cfg, { now: clock.now });
+
+    for (let i = 0; i < 3; i += 1) {
+      expect(limiter.tryConsume(1234, "dm").allowed).toBe(true);
+    }
+    const denied = limiter.tryConsume(1234, "dm");
+    expect(denied.allowed).toBe(false);
+    if (denied.allowed === false) {
+      expect(denied.reason).toBe("window");
+      expect(denied.retryAfterMs).toBeGreaterThan(0);
+      expect(denied.retryAfterMs).toBeLessThanOrEqual(60_000);
+    }
+  });
+
+  it("recovers budget after the window slides past the oldest event", () => {
+    const clock = advanceClock();
+    const limiter = new TelegramRateLimiter(
+      { perSender: { windowSeconds: 10, maxRequests: 2 } },
+      { now: clock.now },
+    );
+
+    expect(limiter.tryConsume(1, "dm").allowed).toBe(true);
+    clock.advanceMs(4_000);
+    expect(limiter.tryConsume(1, "dm").allowed).toBe(true);
+    expect(limiter.tryConsume(1, "dm").allowed).toBe(false);
+    clock.advanceMs(7_000); // first event now 11s old; second still in window
+    expect(limiter.tryConsume(1, "dm").allowed).toBe(true);
+    expect(limiter.tryConsume(1, "dm").allowed).toBe(false);
+    clock.advanceMs(5_000); // second event now 16s old; third still recent
+    expect(limiter.tryConsume(1, "dm").allowed).toBe(true);
+  });
+
+  it("isolates senders from each other", () => {
+    const clock = advanceClock();
+    const limiter = new TelegramRateLimiter(
+      { perSender: { windowSeconds: 60, maxRequests: 1 } },
+      { now: clock.now },
+    );
+    expect(limiter.tryConsume(11, "dm").allowed).toBe(true);
+    expect(limiter.tryConsume(11, "dm").allowed).toBe(false);
+    expect(limiter.tryConsume(22, "dm").allowed).toBe(true);
+    expect(limiter.tryConsume(22, "dm").allowed).toBe(false);
+  });
+
+  it("keeps dm and pairing counters independent", () => {
+    const clock = advanceClock();
+    const limiter = new TelegramRateLimiter(
+      {
+        perSender: { windowSeconds: 60, maxRequests: 2 },
+        pairing: { windowSeconds: 60, maxRequests: 1 },
+      },
+      { now: clock.now },
+    );
+    expect(limiter.tryConsume(99, "dm").allowed).toBe(true);
+    expect(limiter.tryConsume(99, "pairing").allowed).toBe(true);
+    // pairing budget exhausted but dm still has one slot
+    expect(limiter.tryConsume(99, "pairing").allowed).toBe(false);
+    expect(limiter.tryConsume(99, "dm").allowed).toBe(true);
+    expect(limiter.tryConsume(99, "dm").allowed).toBe(false);
+  });
+
+  it("applies backoffMs as a hard cooldown after exhaustion", () => {
+    const clock = advanceClock();
+    const limiter = new TelegramRateLimiter(
+      {
+        pairing: { windowSeconds: 10, maxRequests: 1, backoffMs: 5_000 },
+      },
+      { now: clock.now },
+    );
+    expect(limiter.tryConsume(7, "pairing").allowed).toBe(true);
+    const denied = limiter.tryConsume(7, "pairing");
+    expect(denied.allowed).toBe(false);
+    if (denied.allowed === false) {
+      expect(denied.reason).toBe("window");
+      expect(denied.retryAfterMs).toBe(5_000);
+    }
+
+    // 2s later still cooled down — even though the *window* might have slots
+    clock.advanceMs(2_000);
+    const stillCooling = limiter.tryConsume(7, "pairing");
+    expect(stillCooling.allowed).toBe(false);
+    if (stillCooling.allowed === false) {
+      expect(stillCooling.reason).toBe("backoff");
+    }
+
+    clock.advanceMs(4_000); // total 6s — past cooldown
+    // Window slot is still consumed by the 6s-old event, so this should fail
+    // for `window` reason rather than `backoff`. Verifies the cooldown release
+    // path runs without leaving stale state.
+    const afterCooldown = limiter.tryConsume(7, "pairing");
+    expect(afterCooldown.allowed).toBe(false);
+    if (afterCooldown.allowed === false) {
+      expect(afterCooldown.reason).toBe("window");
+    }
+  });
+
+  it("treats exempt sender ids as unlimited regardless of scope", () => {
+    const clock = advanceClock();
+    const limiter = new TelegramRateLimiter(
+      {
+        perSender: { windowSeconds: 60, maxRequests: 1 },
+        pairing: { windowSeconds: 60, maxRequests: 1 },
+        exemptSenderIds: ["telegram:8569038939", 1234],
+      },
+      { now: clock.now },
+    );
+    for (let i = 0; i < 10; i += 1) {
+      expect(limiter.tryConsume("8569038939", "dm").allowed).toBe(true);
+      expect(limiter.tryConsume("telegram:8569038939", "pairing").allowed).toBe(true);
+      expect(limiter.tryConsume(1234, "dm").allowed).toBe(true);
+    }
+    expect(limiter.isExempt("8569038939")).toBe(true);
+    expect(limiter.isExempt("tg:1234")).toBe(true);
+    expect(limiter.isExempt("9999")).toBe(false);
+  });
+
+  it("denies non-numeric / unknown sender ids by default so a malformed update cannot bypass", () => {
+    const limiter = new TelegramRateLimiter({
+      perSender: { windowSeconds: 60, maxRequests: 5 },
+    });
+    expect(limiter.tryConsume(undefined, "dm").allowed).toBe(false);
+    expect(limiter.tryConsume("", "dm").allowed).toBe(false);
+    expect(limiter.tryConsume("not-a-number", "dm").allowed).toBe(false);
+    // But if pairing window is undefined the scope is a no-op even for bad ids
+    expect(limiter.tryConsume(undefined, "pairing").allowed).toBe(true);
+  });
+
+  it("rejects malformed config silently (no window) instead of throwing", () => {
+    const limiter = new TelegramRateLimiter({
+      perSender: { windowSeconds: 0, maxRequests: 5 },
+      pairing: { windowSeconds: 60, maxRequests: -3 },
+    });
+    expect(limiter.isEnabled()).toBe(false);
+    expect(limiter.tryConsume(1, "dm").allowed).toBe(true);
+    expect(limiter.tryConsume(1, "pairing").allowed).toBe(true);
+  });
+
+  it("normalises exempt list entries to numeric ids", () => {
+    const limiter = new TelegramRateLimiter({
+      perSender: { windowSeconds: 60, maxRequests: 1 },
+      exemptSenderIds: ["telegram:42", "tg:42", "42", 42, "@notnumeric", "  43  "],
+    });
+    expect(limiter.isExempt(42)).toBe(true);
+    expect(limiter.isExempt(43)).toBe(true);
+    expect(limiter.isExempt("notnumeric")).toBe(false);
+  });
+
+  it("surfaces the configured dropPolicy on denies for telemetry", () => {
+    const limiter = new TelegramRateLimiter({
+      perSender: { windowSeconds: 60, maxRequests: 1, dropPolicy: "errorReply" },
+    });
+    expect(limiter.tryConsume(1, "dm").allowed).toBe(true);
+    const denied = limiter.tryConsume(1, "dm");
+    if (denied.allowed === true) {
+      throw new Error("expected denial");
+    }
+    expect(denied.dropPolicy).toBe("errorReply");
+  });
+
+  it("reset() drops in-memory state", () => {
+    const clock = advanceClock();
+    const limiter = new TelegramRateLimiter(
+      { perSender: { windowSeconds: 60, maxRequests: 1 } },
+      { now: clock.now },
+    );
+    expect(limiter.tryConsume(1, "dm").allowed).toBe(true);
+    expect(limiter.tryConsume(1, "dm").allowed).toBe(false);
+    limiter.reset();
+    expect(limiter.tryConsume(1, "dm").allowed).toBe(true);
+  });
+});

--- a/extensions/telegram/src/rate-limiter.ts
+++ b/extensions/telegram/src/rate-limiter.ts
@@ -1,0 +1,246 @@
+/**
+ * Per-sender inbound rate limiter for Telegram channels.
+ *
+ * Implements a sliding-window counter keyed by sender id, with a separate
+ * counter scoped to pairing-policy traffic so a pairing-queue DoS cannot be
+ * paid for by exhausting the regular DM budget (or vice versa).
+ *
+ * Counters are evaluated BEFORE messages reach `messages.queue`, so spam from
+ * one sender cannot evict legitimate traffic at the global cap.
+ *
+ * Tracks issue: https://github.com/openclaw/openclaw/issues/84447
+ */
+
+export type TelegramRateLimitDropPolicy = "silent" | "errorReply" | "summary";
+
+export type TelegramRateLimitWindow = {
+  /** Sliding window length in seconds (must be > 0). */
+  windowSeconds: number;
+  /** Max inbound events from a single sender within the window. */
+  maxRequests: number;
+  /**
+   * Optional cooldown applied after a sender exceeds the limit. While the
+   * sender is in cooldown all further inbound events are dropped without
+   * advancing the window — this is what bounds sustained-flood spend.
+   */
+  backoffMs?: number;
+};
+
+export type TelegramRateLimitConfig = {
+  /** Throttle for any inbound DM that has passed prior allow/dm-policy gates. */
+  perSender?: TelegramRateLimitWindow & { dropPolicy?: TelegramRateLimitDropPolicy };
+  /** Separate counter scoped to pairing-policy attempts (pre-approval). */
+  pairing?: TelegramRateLimitWindow & { dropPolicy?: TelegramRateLimitDropPolicy };
+  /**
+   * Sender ids that bypass both limiters. Each entry MAY include a
+   * "telegram:" / "tg:" prefix; bare numeric ids are accepted as well.
+   * Owner / allowlist senders are NOT auto-exempted: callers must place
+   * them here explicitly so this list is the single source of truth.
+   */
+  exemptSenderIds?: ReadonlyArray<string | number>;
+};
+
+export type RateLimiterDecision =
+  | { allowed: true }
+  | {
+      allowed: false;
+      reason: "window";
+      retryAfterMs: number;
+      dropPolicy: TelegramRateLimitDropPolicy;
+    }
+  | {
+      allowed: false;
+      reason: "backoff";
+      retryAfterMs: number;
+      dropPolicy: TelegramRateLimitDropPolicy;
+    };
+
+export type RateLimiterScope = "dm" | "pairing";
+
+type Bucket = {
+  /** Monotonic event timestamps (ms since epoch) within the current window. */
+  events: number[];
+  /** Wall-clock end of an active cooldown, or 0 if not in cooldown. */
+  cooldownUntilMs: number;
+};
+
+type NormalisedWindow = Required<Pick<TelegramRateLimitWindow, "windowSeconds" | "maxRequests">> & {
+  backoffMs: number;
+  dropPolicy: TelegramRateLimitDropPolicy;
+};
+
+const stripIdPrefix = (raw: string | number): string =>
+  String(raw)
+    .trim()
+    .replace(/^(telegram|tg):/i, "");
+
+const isPositiveInteger = (n: unknown): n is number =>
+  typeof n === "number" && Number.isFinite(n) && Number.isInteger(n) && n > 0;
+
+const normaliseWindow = (
+  source: (TelegramRateLimitWindow & { dropPolicy?: TelegramRateLimitDropPolicy }) | undefined,
+): NormalisedWindow | undefined => {
+  if (!source) {
+    return undefined;
+  }
+  if (!isPositiveInteger(source.windowSeconds)) {
+    return undefined;
+  }
+  if (!isPositiveInteger(source.maxRequests)) {
+    return undefined;
+  }
+  const backoff =
+    typeof source.backoffMs === "number" &&
+    Number.isFinite(source.backoffMs) &&
+    source.backoffMs >= 0
+      ? Math.floor(source.backoffMs)
+      : 0;
+  return {
+    windowSeconds: source.windowSeconds,
+    maxRequests: source.maxRequests,
+    backoffMs: backoff,
+    dropPolicy: source.dropPolicy ?? "silent",
+  };
+};
+
+const normaliseExempt = (exemptSenderIds?: ReadonlyArray<string | number>): Set<string> => {
+  const out = new Set<string>();
+  for (const entry of exemptSenderIds ?? []) {
+    const stripped = stripIdPrefix(entry);
+    if (/^\d+$/.test(stripped)) {
+      out.add(stripped);
+    }
+  }
+  return out;
+};
+
+/**
+ * Sliding-window per-sender rate limiter. Construct once per Telegram account
+ * and call {@link tryConsume} before delivering inbound traffic to the queue.
+ *
+ * Storage is in-process and bounded by the active-sender count; senders whose
+ * buckets fully age out are released on the next call that observes them.
+ */
+export class TelegramRateLimiter {
+  private readonly dmWindow?: NormalisedWindow;
+  private readonly pairingWindow?: NormalisedWindow;
+  private readonly exempt: Set<string>;
+  private readonly buckets = new Map<string, Bucket>();
+  private readonly now: () => number;
+
+  constructor(config: TelegramRateLimitConfig | undefined, options?: { now?: () => number }) {
+    this.dmWindow = normaliseWindow(config?.perSender);
+    this.pairingWindow = normaliseWindow(config?.pairing);
+    this.exempt = normaliseExempt(config?.exemptSenderIds);
+    this.now = options?.now ?? Date.now;
+  }
+
+  /**
+   * Returns true when at least one of the configured windows is active.
+   * Callers can short-circuit and skip authorization-bypass code paths when
+   * the limiter is disabled.
+   */
+  isEnabled(): boolean {
+    return Boolean(this.dmWindow ?? this.pairingWindow);
+  }
+
+  /**
+   * Returns a non-mutating exemption check. Useful for callers that need to
+   * log explicit "exempt sender" decisions before consuming budget.
+   */
+  isExempt(senderId: string | number | undefined): boolean {
+    if (senderId === undefined || senderId === null) {
+      return false;
+    }
+    const stripped = stripIdPrefix(senderId);
+    if (!/^\d+$/.test(stripped)) {
+      return false;
+    }
+    return this.exempt.has(stripped);
+  }
+
+  /**
+   * Consume one budget slot for `senderId` in the given `scope`. When the
+   * scope's window is not configured the call is a no-op and returns
+   * `{allowed: true}`.
+   *
+   * Side effects: prunes stale event timestamps for the sender; clears
+   * cooldown bookkeeping once it expires.
+   */
+  tryConsume(senderId: string | number | undefined, scope: RateLimiterScope): RateLimiterDecision {
+    const win = scope === "pairing" ? this.pairingWindow : this.dmWindow;
+    if (!win) {
+      return { allowed: true };
+    }
+    if (this.isExempt(senderId)) {
+      return { allowed: true };
+    }
+
+    const id = senderId === undefined ? "" : stripIdPrefix(senderId);
+    if (!/^\d+$/.test(id)) {
+      // Unknown / non-numeric senders are not trusted to share a bucket with
+      // valid ids; deny by default so a malformed Telegram update cannot bypass
+      // the limit by omitting `from.id`.
+      return {
+        allowed: false,
+        reason: "window",
+        retryAfterMs: win.windowSeconds * 1000,
+        dropPolicy: win.dropPolicy,
+      };
+    }
+
+    const now = this.now();
+    const key = `${scope}:${id}`;
+    const bucket = this.buckets.get(key) ?? { events: [], cooldownUntilMs: 0 };
+
+    if (bucket.cooldownUntilMs > now) {
+      return {
+        allowed: false,
+        reason: "backoff",
+        retryAfterMs: bucket.cooldownUntilMs - now,
+        dropPolicy: win.dropPolicy,
+      };
+    }
+    if (bucket.cooldownUntilMs !== 0) {
+      bucket.cooldownUntilMs = 0;
+    }
+
+    const windowStart = now - win.windowSeconds * 1000;
+    // Drop events older than the window. Since `events` is append-only and
+    // therefore ordered, splice from the first index whose value is recent.
+    let firstRecent = 0;
+    while (firstRecent < bucket.events.length && bucket.events[firstRecent] <= windowStart) {
+      firstRecent += 1;
+    }
+    if (firstRecent > 0) {
+      bucket.events = bucket.events.slice(firstRecent);
+    }
+
+    if (bucket.events.length >= win.maxRequests) {
+      if (win.backoffMs > 0) {
+        bucket.cooldownUntilMs = now + win.backoffMs;
+      }
+      this.buckets.set(key, bucket);
+      const oldestKept = bucket.events[0] ?? now;
+      const retryAfterMs =
+        win.backoffMs > 0
+          ? win.backoffMs
+          : Math.max(1, win.windowSeconds * 1000 - (now - oldestKept));
+      return { allowed: false, reason: "window", retryAfterMs, dropPolicy: win.dropPolicy };
+    }
+
+    bucket.events.push(now);
+    this.buckets.set(key, bucket);
+    return { allowed: true };
+  }
+
+  /**
+   * Drop all in-memory state. Intended for tests and config-reload paths;
+   * production callers should reuse the same limiter for the account
+   * lifetime so sliding windows stay coherent across runtime restarts of
+   * subordinate components.
+   */
+  reset(): void {
+    this.buckets.clear();
+  }
+}

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -74,6 +74,40 @@ export type TelegramPreviewStreamingConfig = Omit<ChannelPreviewStreamingConfig,
   preview?: TelegramStreamingPreviewConfig;
 };
 
+export type TelegramRateLimitDropPolicy = "silent" | "errorReply" | "summary";
+
+/**
+ * Per-sender sliding-window rate limit. Counted BEFORE inbound messages reach
+ * `messages.queue`, so a single sender's spam cannot evict other senders at
+ * the global queue cap. See https://github.com/openclaw/openclaw/issues/84447.
+ */
+export type TelegramRateLimitWindowConfig = {
+  /** Sliding window length in seconds. Must be > 0. */
+  windowSeconds: number;
+  /** Max inbound events from a single sender within the window. */
+  maxRequests: number;
+  /** Optional hard cooldown applied after a sender exceeds the limit. */
+  backoffMs?: number;
+  /** Telemetry hint for what to surface on a denied event. Default: "silent". */
+  dropPolicy?: TelegramRateLimitDropPolicy;
+};
+
+export type TelegramRateLimitConfig = {
+  /** Limiter applied to inbound DMs that already passed dmPolicy / allowFrom. */
+  perSender?: TelegramRateLimitWindowConfig;
+  /**
+   * Independent counter for inbound pairing-flow events. Bounds pairing-queue
+   * DoS without sharing budget with regular post-pairing DM traffic.
+   */
+  pairing?: TelegramRateLimitWindowConfig;
+  /**
+   * Sender ids that bypass both limiters. Bare numeric ids or "telegram:" /
+   * "tg:" prefixed strings are accepted. Owners and allowlist members are
+   * NOT auto-exempted: place them here explicitly.
+   */
+  exemptSenderIds?: Array<string | number>;
+};
+
 export type TelegramExecApprovalConfig = {
   /** Enable mode for Telegram exec approvals on this account. Default: auto when approvers can be resolved; false disables. */
   enabled?: import("./types.approvals.js").NativeExecApprovalEnableMode;
@@ -170,6 +204,12 @@ export type TelegramAccountConfig = {
   pollingStallThresholdMs?: number;
   /** Retry policy for outbound Telegram API calls. */
   retry?: OutboundRetryConfig;
+  /**
+   * Per-sender inbound rate limiting. Counted before messages enter
+   * `messages.queue`, separate windows for DM vs pairing-flow traffic.
+   * Default: no limit (preserves current behavior).
+   */
+  rateLimit?: TelegramRateLimitConfig;
   /** Network transport overrides for Telegram. */
   network?: TelegramNetworkConfig;
   proxy?: string;

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -242,6 +242,56 @@ const validateTelegramCustomCommands = (
   }
 };
 
+const TelegramRateLimitDropPolicySchema = z
+  .enum(["silent", "errorReply", "summary"])
+  .describe(
+    'Telemetry hint for what to do when a sender exceeds the limit. "silent" drops the event with no reply (default), "errorReply" surfaces a rate-limit notice to the sender once per window, "summary" includes the drop in messages.queue.drop summarisation.',
+  );
+
+const TelegramRateLimitWindowSchema = z
+  .object({
+    windowSeconds: z
+      .number()
+      .int()
+      .positive()
+      .describe("Sliding window length in seconds. Must be > 0."),
+    maxRequests: z
+      .number()
+      .int()
+      .positive()
+      .describe("Max inbound events from a single sender within the window."),
+    backoffMs: z
+      .number()
+      .int()
+      .nonnegative()
+      .optional()
+      .describe(
+        "Optional hard cooldown (ms) applied after a sender exceeds the limit. While in cooldown all further events are denied without sliding the window.",
+      ),
+    dropPolicy: TelegramRateLimitDropPolicySchema.optional(),
+  })
+  .strict();
+
+export const TelegramRateLimitSchema = z
+  .object({
+    perSender: TelegramRateLimitWindowSchema.optional().describe(
+      "Limiter applied to inbound DMs that already passed dmPolicy / allowFrom gates. Default: no limit.",
+    ),
+    pairing: TelegramRateLimitWindowSchema.optional().describe(
+      "Independent counter for inbound pairing-flow events. Default: no limit.",
+    ),
+    exemptSenderIds: z
+      .array(z.union([z.string(), z.number()]))
+      .optional()
+      .describe(
+        'Sender ids that bypass both limiters. Bare numeric ids or "telegram:"/"tg:" prefixed strings are accepted. Owners and allowlist members are NOT auto-exempted: place them here explicitly.',
+      ),
+  })
+  .strict()
+  .describe(
+    "Per-sender inbound rate limiting. Counted before messages enter messages.queue so a single sender's spam cannot evict other senders' traffic at the global queue cap. See https://github.com/openclaw/openclaw/issues/84447.",
+  );
+
 export const TelegramAccountSchemaBase = z
   .object({
     name: z.string().optional(),
@@ -291,6 +341,7 @@ export const TelegramAccountSchemaBase = z
       ),
     pollingStallThresholdMs: z.number().int().min(30_000).max(600_000).optional(),
     retry: RetryConfigSchema,
+    rateLimit: TelegramRateLimitSchema.optional(),
     network: z
       .object({
         autoSelectFamily: z.boolean().optional(),


### PR DESCRIPTION
## Summary

- **Problem:** With `channels.telegram.dmPolicy="pairing"` or `"allowlist"`, any Telegram account that knows the bot's `@handle` can flood inbound DMs into `messages.queue`. The global `messages.queue.cap` bounds memory but cannot isolate per-sender traffic, so a single hostile sender can evict legitimate-traffic summary stubs under sustained flood, and pairing-mode bots have no defense against pairing-queue exhaustion. There is no per-sender knob anywhere in the existing config schema (see issue #84447 for the schema-walk evidence).
- **Solution:** Add `channels.telegram.rateLimit` with separate `perSender` and `pairing` sliding-window counters plus an `exemptSenderIds` bypass for known operators. Counters fire BEFORE messages reach the global queue, so one sender's spam cannot consume budget that belongs to other senders.
- **What changed:** New `TelegramRateLimiter` sliding-window module + zod schema branch + 12 unit tests + wiring in `handleInboundMessageLike` to call `tryConsume()` after the existing dmPolicy/allowFrom gates and before model invocation. CHANGELOG entry under `## Unreleased / ### Changes`.
- **What did NOT change (scope boundary):** Other channel adapters (Discord/Signal/Slack/etc.) are not modified — the limiter module is intentionally Telegram-scoped, though its shape is reusable. Default behavior with `rateLimit` unset is identical to current behavior. No changes to `messages.queue.*`, `commands.ownerAllowFrom`, `dmPolicy` enum, allowFrom semantics, or outbound throttling (`account-throttler.ts`).

## Motivation

Filed-and-tracked at #84447. A 2026-05-19 security review of a deployment running `dmPolicy="pairing"` flagged that pairing-mode bots have no per-sender throttle: the dmPolicy gate keeps unknown senders from reaching the model, but they still consume queue/log/summary budget. The existing global `messages.queue.cap=20` with `drop="summarize"` bounds memory but allows spam to evict legitimate-traffic summary stubs once the queue overflows. This PR adds the smallest config knob that actually defends the operator's queue budget against a single hostile sender.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #84447
- Related: #77986 (auth-rate-limiter unique-IP-flood gap, different surface), #13615 (outbound rate limiting, different direction)
- [ ] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed:** A single Telegram sender can no longer evict other senders' queue/summary budget by spamming a `dmPolicy="pairing"` or `"allowlist"` bot.
- **Real environment tested:** macOS 26.4.1 arm64, Node 22.19.0, openclaw 2026.5.18 cloned on this branch, vitest 4.1.6.
- **Exact steps or command run after this patch:**
  ```
  pnpm install --frozen-lockfile --prefer-offline
  NODE_OPTIONS="--max-old-space-size=8192" node scripts/run-vitest.mjs run \
    --config test/vitest/vitest.extension-telegram.config.ts \
    extensions/telegram/src/rate-limiter.test.ts
  NODE_OPTIONS="--max-old-space-size=8192" node scripts/run-vitest.mjs run \
    --config test/vitest/vitest.extension-telegram.config.ts
  NODE_OPTIONS="--max-old-space-size=12288" npx tsc --noEmit -p tsconfig.json
  npx oxlint --config .oxlintrc.json \
    extensions/telegram/src/rate-limiter.ts extensions/telegram/src/rate-limiter.test.ts \
    src/config/types.telegram.ts src/config/zod-schema.providers-core.ts \
    extensions/telegram/src/bot-handlers.runtime.ts
  ```
- **Evidence after fix (copied live terminal output):**
  ```
  # Unit tests for the new limiter
  RUN  v4.1.6 /Users/<redacted>/Code/openclaw
  Test Files  1 passed (1)
       Tests  12 passed (12)
    Duration  307ms

  # Full Telegram extension suite (no regressions)
  RUN  v4.1.6 /Users/<redacted>/Code/openclaw
  Test Files  121 passed (121)
       Tests  1819 passed (1819)
    Duration  46.34s

  # Type-check
  $ NODE_OPTIONS=... npx tsc --noEmit -p tsconfig.json; echo "EXIT=$?"
  EXIT=0

  # Lint
  Found 0 warnings and 0 errors.
  Finished in 7ms on 5 files with 188 rules using 16 threads.
  ```
- **Observed result after fix:** Limiter unit suite passes (12/12), full Telegram extension suite stays green (121 files / 1819 tests), repo-wide `tsc --noEmit` is clean, oxlint is clean.
- **What was not tested:** End-to-end integration against a live `api.telegram.org` bot — I did not stand up a real Telegram bot to drive `tryConsume()` from inbound webhook traffic. The wiring point in `handleInboundMessageLike` is exercised by the existing 121-file extension suite (all of which still pass), but a manual "spam a real bot to confirm the drop" run is left to a maintainer with a test bot. The default-unset behavior path is exercised by all 1819 existing tests, none of which set `rateLimit`.

## Root Cause (if applicable)

N/A — feature addition.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/telegram/src/rate-limiter.test.ts` (added in this PR)
- Scenario the test should lock in: per-sender sliding-window arithmetic, scope isolation between `perSender` and `pairing`, `backoffMs` cooldown release, exempt-list bypass, defensive denial for malformed sender ids, and surfacing of `dropPolicy` on denials for downstream telemetry.
- Why this is the smallest reliable guardrail: the limiter is a pure in-process state machine taking `(senderId, scope)` → decision. Property-shaped unit tests with an injected clock exercise every branch deterministically; a seam/E2E test would require Telegram bot setup without raising the bar on what's actually being verified.

## User-visible / Behavior Changes

Default behavior unchanged when `channels.telegram.rateLimit` is unset. When set, inbound DMs that exceed the configured window are dropped silently (or via the chosen `dropPolicy`) BEFORE reaching `messages.queue`; `logVerbose` records the drop with sender id, scope, retry-after, and policy.

## Diagram (if applicable)

```text
Before (dmPolicy="pairing", rateLimit unset):
[inbound DM] -> [dedup] -> [dmPolicy / allowFrom gate]
            -> [pairing queue ⨯ N spam] -> [messages.queue.cap eviction] -> [legit summary lost]

After (dmPolicy="pairing", rateLimit.pairing set):
[inbound DM] -> [dedup] -> [dmPolicy / allowFrom gate]
            -> [per-sender pairing window check]
                 ├─ allowed -> [pairing queue] -> [owner approval flow]
                 └─ denied  -> [logVerbose drop, retryAfterMs surfaced for telemetry]
```

## Security Impact (required)

- New permissions/capabilities? **No** — only narrows inbound surface.
- Secrets/tokens handling changed? **No.**
- New/changed network calls? **No** — purely in-process counter.
- Command/tool execution surface changed? **No.**
- Data access scope changed? **No** — limiter sees only `senderId`, no message content.
- Risk + mitigation: A misconfigured `maxRequests=0` would deny every inbound. Mitigated by zod-level `positive()` validation: `windowSeconds` and `maxRequests` must be positive integers, otherwise the config is rejected at load. A malformed Telegram update with no `from.id` is denied by default (test case `denies non-numeric / unknown sender ids by default ...`) so a missing-id update cannot share a bucket with valid ids and bypass the limit.

## Repro + Verification

### Environment

- OS: macOS 26.4.1 (arm64)
- Runtime/container: Node 22.19.0, pnpm 11.1.0, vitest 4.1.6
- Model/provider: N/A — no model invocation in tests
- Integration/channel: Telegram (`extensions/telegram`)
- Relevant config (redacted):
  ```yaml
  channels:
    telegram:
      dmPolicy: pairing
      rateLimit:
        pairing:
          windowSeconds: 3600
          maxRequests: 3
          backoffMs: 60000
        exemptSenderIds:
          - "telegram:<redacted-numeric-owner-id>"
  ```

### Steps

1. Apply this branch.
2. `pnpm install --frozen-lockfile --prefer-offline`
3. Run the limiter unit suite (1 file, 12 tests).
4. Run the full Telegram extension suite (121 files, 1819 tests) to confirm no regression.
5. Run repo-wide `tsc --noEmit` and `oxlint` on the changed files.

### Expected

- All unit tests pass.
- All 1819 existing Telegram extension tests still pass.
- `tsc` and `oxlint` exit 0.
- With `rateLimit` set, a sender exceeding `maxRequests` within `windowSeconds` is denied (verifiable in the unit test asserting `allowed: false` after 3 of 3 attempts).

### Actual

- 12/12 limiter unit tests pass.
- 1819/1819 Telegram extension tests pass.
- `tsc --noEmit` exits 0.
- `oxlint` exits 0.

## Evidence

- [x] Failing test/log before + passing after — see the "Real behavior proof" block for live terminal output.
- [x] Trace/log snippets — the wired `logVerbose("Rate-limited telegram inbound from ...")` line in `handleInboundMessageLike` carries sender id, scope, reason, retry-after, and drop-policy for downstream observability.
- [ ] Screenshot/recording — N/A for CLI/text-only change; live terminal capture is above.
- [ ] Perf numbers — limiter is `O(events-in-window)` per sender, `events-in-window <= maxRequests`. No perf concern.

## Human Verification (required)

- Verified scenarios:
  - All 12 limiter unit cases (window cap, window slide-recovery, sender isolation, dm/pairing scope isolation, backoff cooldown, exempt-list bypass, malformed-id defensive denial, malformed-config silent rejection, exempt normalisation, dropPolicy telemetry, reset).
  - Full Telegram extension suite still green (121 files / 1819 tests).
  - Repo-wide `tsc --noEmit` clean.
  - Repo-wide `oxlint` clean on changed files.
- Edge cases checked: missing `from.id` (denied), `windowSeconds=0` (silently disabled), `maxRequests=-3` (silently disabled), backoff cleared after expiry, exempt-list accepts `"telegram:"` / `"tg:"` / bare numeric / numeric value forms.
- What I did NOT verify: live Telegram bot end-to-end. Default-unset behavior path is verified by the entire existing 1819-test suite (none of which set `rateLimit`).

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? **Yes** — `rateLimit` is optional and unset means current behavior.
- Config/env changes? **Yes, additive only** (`channels.telegram.rateLimit`).
- Migration needed? **No.**
- If yes, exact upgrade steps: N/A.

## Risks and Mitigations

- **Risk:** Operator sets `maxRequests` too low and locks themselves out.
  - **Mitigation:** `exemptSenderIds` bypass for known operator IDs; the existing `commands.ownerAllowFrom` field can be mirrored into `exemptSenderIds` at setup time. (Future enhancement: auto-exempt `commands.ownerAllowFrom` — deliberately deferred to keep this PR small and avoid coupling auth/throttle layers.)
- **Risk:** Sliding-window buckets accumulate memory if many unique senders attempt during the window.
  - **Mitigation:** Buckets are keyed by `${scope}:${id}` and only allocated for senders that actually attempted. Each bucket holds at most `maxRequests` timestamps. Aging out is lazy on next call. Realistic upper bound for a personal-assistant bot is bounded by Telegram's discoverable handle attackers (very small) and by `maxRequests` per sender (configured small).

---

🦞