### PR TITLE
Strip apiKey fields from generated models.json

### DIFF
--- a/src/agents/models-config.applies-config-env-vars.test.ts
+++ b/src/agents/models-config.applies-config-env-vars.test.ts
@@ -246,6 +246,51 @@ describe("models-config", () => {
     ]);
   });
 
+  it("strips apiKey fields from the models.json write payload", async () => {
+    const plan = await planOpenClawModelsJsonWithDeps(
+      {
+        cfg: {
+          models: {
+            providers: {
+              custom: {
+                baseUrl: "https://custom.example/v1",
+                api: "openai-completions",
+                apiKey: "sk-config-secret", // pragma: allowlist secret
+                models: [
+                  {
+                    id: "custom-model",
+                    name: "Custom model",
+                    input: ["text"],
+                    apiKey: "sk-model-secret", // pragma: allowlist secret
+                  },
+                ],
+              } as unknown as ProviderConfig,
+            },
+          },
+        },
+        agentDir: "/tmp/openclaw-models-config-env-vars-test",
+        env: {},
+        existingRaw: "",
+        existingParsed: null,
+      },
+      {
+        resolveImplicitProviders: async () => ({}),
+      },
+    );
+
+    expect(plan.action).toBe("write");
+    if (plan.action !== "write") {
+      throw new Error("Expected models.json write plan");
+    }
+    expect(plan.contents).not.toContain("sk-config-secret");
+    expect(plan.contents).not.toContain("sk-model-secret");
+    const parsed = JSON.parse(plan.contents) as {
+      providers?: Record<string, { apiKey?: unknown; models?: Array<{ apiKey?: unknown }> }>;
+    };
+    expect(parsed.providers?.custom?.apiKey).toBeUndefined();
+    expect(parsed.providers?.custom?.models?.[0]?.apiKey).toBeUndefined();
+  });
+
   it("uses config env.vars entries for implicit provider discovery without mutating process.env", async () => {
     await withTempEnv(["OPENROUTER_API_KEY", TEST_ENV_VAR], async () => {
       unsetEnv(["OPENROUTER_API_KEY", TEST_ENV_VAR]);

--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -16,6 +16,13 @@ import {
 } from "./models-config.providers.js";
 
 type ModelsConfig = NonNullable<OpenClawConfig["models"]>;
+type ModelsJsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | ModelsJsonValue[]
+  | { [key: string]: ModelsJsonValue };
 export type ResolveImplicitProvidersForModelsJson = (params: {
   agentDir: string;
   config: OpenClawConfig;
@@ -105,6 +112,24 @@ function resolveProvidersForMode(params: {
   });
 }
 
+function stripApiKeysForModelsJson(value: unknown): ModelsJsonValue {
+  if (Array.isArray(value)) {
+    return value.map((entry) => stripApiKeysForModelsJson(entry));
+  }
+  if (!isRecord(value)) {
+    return value as ModelsJsonValue;
+  }
+
+  const next: Record<string, ModelsJsonValue> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (key === "apiKey") {
+      continue;
+    }
+    next[key] = stripApiKeysForModelsJson(entry);
+  }
+  return next;
+}
+
 export async function planOpenClawModelsJsonWithDeps(
   params: {
     cfg: OpenClawConfig;
@@ -178,7 +203,8 @@ export async function planOpenClawModelsJsonWithDeps(
       secretRefManagedProviders,
     }) ?? normalizedMergedProviders;
   const finalProviders = applyNativeStreamingUsageCompat(secretEnforcedProviders);
-  const nextContents = `${JSON.stringify({ providers: finalProviders }, null, 2)}\n`;
+  const modelsJsonProviders = stripApiKeysForModelsJson(finalProviders);
+  const nextContents = `${JSON.stringify({ providers: modelsJsonProviders }, null, 2)}\n`;
 
   if (params.existingRaw === nextContents) {
     return { action: "noop" };

--- a/src/agents/models-config.runtime-source-snapshot.test.ts
+++ b/src/agents/models-config.runtime-source-snapshot.test.ts
@@ -171,15 +171,12 @@ function withGatewayTokenMode(config: OpenClawConfig): OpenClawConfig {
   };
 }
 
-async function expectGeneratedProviderApiKey(
-  agentDir: string,
-  providerId: string,
-  expected: string,
-) {
+async function expectGeneratedProviderHasNoApiKey(agentDir: string, providerId: string) {
   const parsed = await readGeneratedModelsJson<{
     providers: Record<string, { apiKey?: string }>;
   }>(agentDir);
-  expect(parsed.providers[providerId]?.apiKey).toBe(expected);
+  expect(parsed.providers[providerId]).toBeDefined();
+  expect(parsed.providers[providerId]?.apiKey).toBeUndefined();
 }
 
 async function planGeneratedProviders(params: {
@@ -272,7 +269,7 @@ describe("models-config runtime source snapshot", () => {
       try {
         setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
         await ensureOpenClawModelsJson(clonedRuntimeConfig, agentDir);
-        await expectGeneratedProviderApiKey(agentDir, "openai", "OPENAI_API_KEY"); // pragma: allowlist secret
+        await expectGeneratedProviderHasNoApiKey(agentDir, "openai");
       } finally {
         clearRuntimeConfigSnapshot();
         clearConfigCache();
@@ -325,7 +322,7 @@ describe("models-config runtime source snapshot", () => {
           >;
         }>(agentDir);
         expect(parsed.providers.openai?.baseUrl).toBe("https://api.openai.com/v1");
-        expect(parsed.providers.openai?.apiKey).toBe("OPENAI_API_KEY"); // pragma: allowlist secret
+        expect(parsed.providers.openai?.apiKey).toBeUndefined();
         expect(parsed.providers.openai?.headers?.["X-OpenClaw-Test"]).toBe("one");
 
         // Header changes still rewrite models.json, but merge mode preserves the existing baseUrl.
@@ -337,7 +334,7 @@ describe("models-config runtime source snapshot", () => {
           >;
         }>(agentDir);
         expect(parsed.providers.openai?.baseUrl).toBe("https://api.openai.com/v1");
-        expect(parsed.providers.openai?.apiKey).toBe("OPENAI_API_KEY"); // pragma: allowlist secret
+        expect(parsed.providers.openai?.apiKey).toBeUndefined();
         expect(parsed.providers.openai?.headers?.["X-OpenClaw-Test"]).toBe("two");
       } finally {
         clearRuntimeConfigSnapshot();
@@ -359,7 +356,7 @@ describe("models-config runtime source snapshot", () => {
       config: createOpenAiRuntimeConfigWithHeadersAndApiKey(),
       sourceConfigForSecrets: withGatewayTokenMode(createOpenAiSourceConfigWithHeadersAndApiKey()),
     });
-    expect(providers.openai?.apiKey).toBe("OPENAI_API_KEY"); // pragma: allowlist secret
+    expect(providers.openai?.apiKey).toBeUndefined();
     expectOpenAiHeaderMarkers(providers);
   });
 });

--- a/src/agents/models-config.skips-writing-models-json-no-env-token.test.ts
+++ b/src/agents/models-config.skips-writing-models-json-no-env-token.test.ts
@@ -102,7 +102,6 @@ async function runEnvProviderCase(params: {
   envVar: "MINIMAX_API_KEY" | "SYNTHETIC_API_KEY";
   envValue: string;
   providerKey: "minimax" | "synthetic";
-  expectedApiKeyRef: string;
 }) {
   const previousValue = process.env[params.envVar];
   process.env[params.envVar] = params.envValue;
@@ -113,7 +112,8 @@ async function runEnvProviderCase(params: {
     const raw = await fs.readFile(modelPath, "utf8");
     const parsed = JSON.parse(raw) as { providers: Record<string, ParsedProviderConfig> };
     const provider = parsed.providers[params.providerKey];
-    expect(provider?.apiKey).toBe(params.expectedApiKeyRef);
+    expect(provider).toBeDefined();
+    expect(provider?.apiKey).toBeUndefined();
   } finally {
     if (previousValue === undefined) {
       delete process.env[params.envVar];
@@ -211,7 +211,6 @@ describe("models-config", () => {
         envVar: "MINIMAX_API_KEY",
         envValue: "sk-minimax-test",
         providerKey: "minimax",
-        expectedApiKeyRef: "MINIMAX_API_KEY", // pragma: allowlist secret
       });
     });
   });
@@ -222,7 +221,6 @@ describe("models-config", () => {
         envVar: "SYNTHETIC_API_KEY",
         envValue: "sk-synthetic-test",
         providerKey: "synthetic",
-        expectedApiKeyRef: "SYNTHETIC_API_KEY", // pragma: allowlist secret
       });
     });
   });


### PR DESCRIPTION
## Summary

- Problem: generated `models.json` could persist `apiKey` fields from provider config rows.
- Solution: strip `apiKey` recursively from the final `models.json` write payload.
- What changed: provider/model metadata still writes, but provider-level and nested `apiKey` fields are omitted; tests now assert this contract.
- What did NOT change (scope boundary): runtime auth resolution and provider discovery credential lookup remain outside the generated file.

## Motivation

- Prevent model config auth material from being persisted in a file that agent/runtime readers may inspect.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #11829
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: generated `models.json` no longer includes provider-level or nested `apiKey` fields that could be exposed to agent/runtime readers.
- Real environment tested: local Windows checkout using Node v24.14.0 from the Codex bundled runtime because the system Node v22.15.0 is below the repo requirement.
- Exact steps or command run after this patch: ran the real `ensureOpenClawModelsJson` path against a temporary OpenClaw agent dir with a configured provider containing fake provider-level and model-level `apiKey` values, then read the generated `models.json`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): copied live terminal output:

```text
models_path=C:\Users\CAMILO\Documents\Codex\2026-05-20\you-are-my-autonomous-public-work\openclaw\.artifacts\proof-agent\models.json
provider_present=true
provider_apiKey_present=false
model_apiKey_present=false
secret_string_present=false
model_secret_string_present=false
model_id=proof-model
```

- Observed result after fix: provider rows, base URLs, headers, and model metadata still write normally, while `apiKey` is omitted from `models.json`.
- What was not tested: full repository test suite and live end-to-end agent prompt inspection.
- Before evidence (optional but encouraged): not captured for this generated-file security hardening path; after-fix copied live output above shows the generated file no longer contains provider or model apiKey fields.

## Root Cause (if applicable)

- Root cause: `planOpenClawModelsJsonWithDeps` serialized the fully merged provider config directly, including auth fields that were needed for discovery/runtime setup but not safe to persist in `models.json`.
- Missing detection / guardrail: tests asserted auth markers were persisted instead of asserting generated-file redaction.
- Contributing context (if known): the existing pipeline already normalized several secret references, but final write serialization had no dedicated `apiKey` removal step.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/models-config.applies-config-env-vars.test.ts`, `src/agents/models-config.runtime-source-snapshot.test.ts`, `src/agents/models-config.skips-writing-models-json-no-env-token.test.ts`
- Scenario the test should lock in: generated `models.json` keeps provider/model metadata but omits provider-level and nested `apiKey` fields.
- Why this is the smallest reliable guardrail: it exercises the write-plan output directly and existing generated-file cases that previously expected auth markers.
- Existing test that already covers this (if any): N/A.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Generated `models.json` no longer contains `apiKey` properties.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? Yes, `apiKey` fields are stripped from generated `models.json`.
- New/changed network calls? No

## Verification

- `C:\Users\CAMILO\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe scripts\run-vitest.mjs src/agents/models-config.applies-config-env-vars.test.ts src/agents/models-config.runtime-source-snapshot.test.ts src/agents/models-config.skips-writing-models-json-no-env-token.test.ts --run`
- `node_modules\.bin\oxfmt.CMD --check --threads=1 src/agents/models-config.plan.ts src/agents/models-config.applies-config-env-vars.test.ts src/agents/models-config.runtime-source-snapshot.test.ts src/agents/models-config.skips-writing-models-json-no-env-token.test.ts`
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree C:\Users\CAMILO\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe scripts\run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree C:\Users\CAMILO\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe scripts\run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`
- `git diff --check`