### PR TITLE
Doctor: expose dry-run preview reports

### DIFF
--- a/src/cli/program/register.maintenance.test.ts
+++ b/src/cli/program/register.maintenance.test.ts
@@ -103,6 +103,31 @@ describe("registerMaintenanceCommands doctor action", () => {
     expect(options.repair).toBe(true);
   });
 
+  it("maps --dry-run to a preview repair run", async () => {
+    doctorCommand.mockResolvedValue(undefined);
+
+    await runMaintenanceCli(["doctor", "--dry-run"]);
+
+    expect(doctorCommand).toHaveBeenCalledTimes(1);
+    const [, options] = commandCall(doctorCommand);
+    expect(options.repair).toBe(true);
+    expect(options.dryRun).toBe(true);
+    expect(options.diff).toBe(false);
+  });
+
+  it("maps --diff to dry-run preview with diffs", async () => {
+    doctorCommand.mockResolvedValue(undefined);
+
+    await runMaintenanceCli(["doctor", "--diff", "--json"]);
+
+    expect(doctorCommand).toHaveBeenCalledTimes(1);
+    const [, options] = commandCall(doctorCommand);
+    expect(options.repair).toBe(true);
+    expect(options.dryRun).toBe(true);
+    expect(options.diff).toBe(true);
+    expect(options.json).toBe(true);
+  });
+
   it("runs doctor lint mode without invoking repair doctor", async () => {
     runDoctorLintCli.mockResolvedValue(1);
 

--- a/src/cli/program/register.maintenance.ts
+++ b/src/cli/program/register.maintenance.ts
@@ -19,6 +19,8 @@ export function registerMaintenanceCommands(program: Command) {
     .option("--yes", "Accept defaults without prompting", false)
     .option("--repair", "Apply recommended repairs without prompting", false)
     .option("--fix", "Apply recommended repairs (alias for --repair)", false)
+    .option("--dry-run", "Preview recommended repairs without writing changes", false)
+    .option("--diff", "With --dry-run: include repair diffs in preview output", false)
     .option("--force", "Apply aggressive repairs (overwrites custom service config)", false)
     .option("--non-interactive", "Run without prompts (safe migrations only)", false)
     .option("--generate-gateway-token", "Generate and configure a gateway token", false)
@@ -34,7 +36,11 @@ export function registerMaintenanceCommands(program: Command) {
       "Emit plugin-compat findings only (machine-readable with --json)",
       false,
     )
-    .option("--json", "With --lint or --post-upgrade: emit machine-readable JSON output", false)
+    .option(
+      "--json",
+      "With --lint, --post-upgrade, --dry-run, or --diff: emit machine-readable JSON output",
+      false,
+    )
     .option(
       "--severity-min <level>",
       "With --lint: drop findings below this severity (info|warning|error)",
@@ -80,12 +86,15 @@ export function registerMaintenanceCommands(program: Command) {
         defaultRuntime.exit(2);
         return;
       }
+      const previewOnly = Boolean(opts.dryRun) || Boolean(opts.diff);
       await runCommandWithRuntime(defaultRuntime, async () => {
         const { doctorCommand } = await import("../../commands/doctor.js");
         await doctorCommand(defaultRuntime, {
           workspaceSuggestions: opts.workspaceSuggestions,
           yes: Boolean(opts.yes),
-          repair: Boolean(opts.repair) || Boolean(opts.fix),
+          repair: Boolean(opts.repair) || Boolean(opts.fix) || previewOnly,
+          dryRun: previewOnly,
+          diff: Boolean(opts.diff),
           force: Boolean(opts.force),
           nonInteractive: Boolean(opts.nonInteractive),
           generateGatewayToken: Boolean(opts.generateGatewayToken),
@@ -178,12 +187,17 @@ export function registerMaintenanceCommands(program: Command) {
 function hasLintOnlyDoctorOptions(opts: {
   readonly json?: boolean;
   readonly postUpgrade?: boolean;
+  readonly dryRun?: boolean;
+  readonly diff?: boolean;
   readonly severityMin?: unknown;
   readonly skip?: unknown;
   readonly only?: unknown;
 }): boolean {
   return (
-    (opts.json === true && opts.postUpgrade !== true) ||
+    (opts.json === true &&
+      opts.postUpgrade !== true &&
+      opts.dryRun !== true &&
+      opts.diff !== true) ||
     typeof opts.severityMin === "string" ||
     (Array.isArray(opts.skip) && opts.skip.length > 0) ||
     (Array.isArray(opts.only) && opts.only.length > 0)

--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -8,6 +8,7 @@ import {
   getDoctorConfigInputForTest,
   runDoctorConfigWithInput,
 } from "./doctor-config-flow.test-utils.js";
+import { runDoctorConfigPreflight } from "./doctor-config-preflight.js";
 
 type TerminalNote = (message: string, title?: string) => void;
 
@@ -1509,6 +1510,7 @@ describe("doctor config flow", () => {
     callGatewayMock.mockReset();
     callGatewayMock.mockResolvedValue({});
     runDoctorRepairSequenceMock.mockReset();
+    vi.mocked(runDoctorConfigPreflight).mockClear();
     collectDoctorPreviewNotesParamsMock.mockClear();
     collectImplicitFallbackClobberWarningsMock.mockClear();
     collectImplicitFallbackClobberWarningsMock.mockReturnValue([]);
@@ -1527,6 +1529,63 @@ describe("doctor config flow", () => {
     expect((result.cfg as Record<string, unknown>).gateway).toEqual({
       auth: { mode: "token", token: 123 },
     });
+  });
+
+  it("does not run state or legacy config migrations for dry-run previews", async () => {
+    await runDoctorConfigWithInput({
+      config: {},
+      run: ({ confirm }) =>
+        loadAndMaybeMigrateDoctorConfig({
+          options: { nonInteractive: true, dryRun: true },
+          confirm: async () => confirm(),
+        }),
+    });
+
+    expect(runDoctorConfigPreflight).toHaveBeenCalledWith(
+      expect.objectContaining({
+        migrateState: false,
+        migrateLegacyConfig: false,
+        repairPrefixedConfig: false,
+        recoverCorruptTargetStore: false,
+      }),
+    );
+  });
+
+  it("does not run state or legacy config migrations for diff previews", async () => {
+    await runDoctorConfigWithInput({
+      config: {},
+      run: ({ confirm }) =>
+        loadAndMaybeMigrateDoctorConfig({
+          options: { nonInteractive: true, diff: true },
+          confirm: async () => confirm(),
+        }),
+    });
+
+    expect(runDoctorConfigPreflight).toHaveBeenCalledWith(
+      expect.objectContaining({
+        migrateState: false,
+        migrateLegacyConfig: false,
+        repairPrefixedConfig: false,
+        recoverCorruptTargetStore: false,
+      }),
+    );
+  });
+
+  it("keeps migrations enabled for repair runs", async () => {
+    await runDoctorConfigWithInput({
+      config: {},
+      repair: true,
+      run: loadAndMaybeMigrateDoctorConfig,
+    });
+
+    expect(runDoctorConfigPreflight).toHaveBeenCalledWith(
+      expect.objectContaining({
+        migrateState: true,
+        migrateLegacyConfig: true,
+        repairPrefixedConfig: true,
+        recoverCorruptTargetStore: true,
+      }),
+    );
   });
 
   it("collects plugin blocker previews from the pre-auto-enable config", async () => {

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -11,7 +11,6 @@ import {
   noteOpencodeProviderOverrides,
 } from "./doctor-config-analysis.js";
 import { runDoctorConfigPreflight } from "./doctor-config-preflight.js";
-import { normalizeCompatibilityConfigValues } from "./doctor/shared/legacy-config-core-migrate.js";
 import type { DoctorOptions, DoctorPrompter } from "./doctor-prompter.js";
 import { emitDoctorNotes, sanitizeDoctorNote } from "./doctor/emit-notes.js";
 import { finalizeDoctorConfigFlow } from "./doctor/finalize-config-flow.js";
@@ -24,6 +23,7 @@ import {
   collectMissingDefaultAccountBindingWarnings,
   collectMissingExplicitDefaultAccountWarnings,
 } from "./doctor/shared/default-account-warnings.js";
+import { normalizeCompatibilityConfigValues } from "./doctor/shared/legacy-config-core-migrate.js";
 
 function hasLegacyInternalHookHandlers(raw: unknown): boolean {
   const handlers = (raw as { hooks?: { internal?: { handlers?: unknown } } })?.hooks?.internal
@@ -142,7 +142,10 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
   prompter?: DoctorPrompter;
 }) {
   const shouldRepair = params.options.repair === true || params.options.yes === true;
+  const previewOnly = params.options.dryRun === true || params.options.diff === true;
   const preflight = await runDoctorConfigPreflight({
+    migrateState: !previewOnly,
+    migrateLegacyConfig: !previewOnly,
     repairPrefixedConfig: shouldRepair,
     recoverCorruptTargetStore: shouldRepair,
   });

--- a/src/commands/doctor.types.ts
+++ b/src/commands/doctor.types.ts
@@ -5,6 +5,8 @@ export type DoctorOptions = {
   nonInteractive?: boolean;
   deep?: boolean;
   repair?: boolean;
+  dryRun?: boolean;
+  diff?: boolean;
   force?: boolean;
   generateGatewayToken?: boolean;
   allowExec?: boolean;

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -5,6 +5,8 @@ import type { DoctorPrompter } from "../commands/doctor-prompter.js";
 import { CORE_HEALTH_CHECKS } from "./doctor-core-checks.js";
 import {
   createDoctorHealthContribution,
+  createDoctorRepairPreviewReport,
+  finalizeDoctorRepairPreviewReport,
   resolveDoctorContributionHealthChecks,
   resolveDoctorHealthContributions,
   shouldSkipLegacyUpdateDoctorConfigWrite,
@@ -1093,6 +1095,7 @@ describe("doctor health contributions", () => {
       {
         checks: contribution.healthChecks,
         dryRun: false,
+        diff: false,
       },
     );
     expect(ctx.cfg).toEqual({ updated: true });
@@ -1179,8 +1182,85 @@ describe("doctor health contributions", () => {
       {
         checks: contribution.healthChecks,
         dryRun: true,
+        diff: false,
       },
     );
+  });
+
+  it("records structured repair dry-run output in the preview report", async () => {
+    const contribution = requireDoctorContribution("doctor:structured-health-repairs");
+    const previewReport = createDoctorRepairPreviewReport({ diff: true });
+    mocks.runDoctorHealthRepairs.mockResolvedValue({
+      config: { updated: true },
+      findings: [
+        {
+          checkId: "plugin/example/unrelated",
+          severity: "warning",
+          message: "plugin check can be repaired",
+        },
+      ],
+      remainingFindings: [],
+      changes: ["would update plugin config"],
+      warnings: ["preview warning"],
+      diffs: [
+        {
+          kind: "config",
+          path: "plugins.entries.example.enabled",
+          before: "false",
+          after: "true",
+        },
+      ],
+      effects: [
+        {
+          kind: "config",
+          action: "update",
+          target: "plugins.entries.example.enabled",
+          dryRunSafe: true,
+        },
+      ],
+      checksRun: 1,
+      checksRepaired: 1,
+      checksValidated: 0,
+    });
+    const ctx = {
+      cfg: {},
+      configResult: { cfg: {} },
+      sourceConfigValid: true,
+      prompter: buildDoctorPrompter(false),
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      options: { dryRun: true, diff: true },
+      cfgForPersistence: {},
+      configPath: "/tmp/fake-openclaw.json",
+      env: {},
+      previewReport,
+    } as unknown as Parameters<(typeof contribution)["run"]>[0];
+
+    await contribution.run(ctx);
+
+    expect(mocks.runDoctorHealthRepairs).toHaveBeenCalledWith(expect.any(Object), {
+      checks: [{ id: "plugin/example/unrelated", kind: "plugin" }],
+      dryRun: true,
+      diff: true,
+    });
+    expect(ctx.cfg).toEqual({});
+    expect(finalizeDoctorRepairPreviewReport(previewReport)).toMatchObject({
+      ok: false,
+      checksRun: 1,
+      checksRepaired: 1,
+      changes: ["would update plugin config"],
+      warnings: ["preview warning"],
+      diffs: [
+        expect.objectContaining({
+          path: "plugins.entries.example.enabled",
+        }),
+      ],
+      effects: [
+        expect.objectContaining({
+          action: "update",
+          target: "plugins.entries.example.enabled",
+        }),
+      ],
+    });
   });
 
   it("requires explicit health check ids for multi-check contributions", () => {
@@ -1269,6 +1349,8 @@ describe("doctor health contributions", () => {
 
     expect(mocks.runDoctorHealthRepairs).toHaveBeenCalledWith(expect.any(Object), {
       checks: [{ id: "plugin/example/unrelated", kind: "plugin" }],
+      dryRun: false,
+      diff: false,
     });
   });
 

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -10,9 +10,15 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { buildGatewayConnectionDetails } from "../gateway/call.js";
 import type { UpdatePostInstallDoctorResult } from "../infra/update-doctor-result.js";
 import type { RuntimeEnv } from "../runtime.js";
+import type { DoctorRepairRunResult } from "./doctor-repair-flow.js";
 import { normalizeHealthCheck } from "./health-check-adapter.js";
 import type { HealthCheckInput, RunnableHealthCheck } from "./health-check-runner-types.js";
-import type { HealthCheck, HealthFinding } from "./health-checks.js";
+import type {
+  HealthCheck,
+  HealthFinding,
+  HealthRepairDiff,
+  HealthRepairEffect,
+} from "./health-checks.js";
 import type { FlowContribution } from "./types.js";
 
 type DoctorFlowMode = "local" | "remote";
@@ -44,6 +50,29 @@ export type DoctorHealthFlowContext = {
   gatewayStatus?: import("../commands/status.types.js").StatusSummary;
   gatewayMemoryProbe?: Awaited<ReturnType<typeof probeGatewayMemoryStatus>>;
   postInstallDoctorResult?: UpdatePostInstallDoctorResult;
+  previewReport?: DoctorRepairPreviewReport;
+};
+
+export type DoctorRepairPreviewSkippedItem = {
+  readonly id: string;
+  readonly reason: string;
+};
+
+export type DoctorRepairPreviewReport = {
+  readonly mode: "doctor-repair-preview";
+  readonly dryRun: true;
+  readonly diff: boolean;
+  ok: boolean;
+  checksRun: number;
+  checksRepaired: number;
+  checksValidated: number;
+  findings: HealthFinding[];
+  remainingFindings: HealthFinding[];
+  changes: string[];
+  warnings: string[];
+  effects: HealthRepairEffect[];
+  diffs: HealthRepairDiff[];
+  skipped: DoctorRepairPreviewSkippedItem[];
 };
 
 type DoctorHealthContribution = FlowContribution & {
@@ -81,6 +110,103 @@ const loadModelSelectionModule = async () => await import("../agents/model-selec
 const loadNoteModule = async () => await import("../../packages/terminal-core/src/note.js");
 const loadOnboardHelpersModule = async () => await import("../commands/onboard-helpers.js");
 const loadSecretTypesModule = async () => await import("../config/types.secrets.js");
+
+export function createDoctorRepairPreviewReport(params: {
+  diff?: boolean;
+}): DoctorRepairPreviewReport {
+  return {
+    mode: "doctor-repair-preview",
+    dryRun: true,
+    diff: params.diff === true,
+    ok: true,
+    checksRun: 0,
+    checksRepaired: 0,
+    checksValidated: 0,
+    findings: [],
+    remainingFindings: [],
+    changes: [],
+    warnings: [],
+    effects: [],
+    diffs: [],
+    skipped: [],
+  };
+}
+
+export function finalizeDoctorRepairPreviewReport(
+  report: DoctorRepairPreviewReport,
+): DoctorRepairPreviewReport {
+  report.ok =
+    report.warnings.length === 0 &&
+    report.skipped.length === 0 &&
+    report.findings.every((finding) => finding.severity === "info") &&
+    report.remainingFindings.length === 0;
+  return report;
+}
+
+export function recordDoctorPreviewSkippedContribution(
+  report: DoctorRepairPreviewReport,
+  item: DoctorRepairPreviewSkippedItem,
+): void {
+  report.skipped.push(item);
+}
+
+function appendDoctorRepairPreviewResult(
+  report: DoctorRepairPreviewReport | undefined,
+  result: DoctorRepairRunResult,
+): void {
+  if (!report) {
+    return;
+  }
+  report.checksRun += result.checksRun;
+  report.checksRepaired += result.checksRepaired;
+  report.checksValidated += result.checksValidated;
+  report.findings.push(...result.findings);
+  report.remainingFindings.push(...result.remainingFindings);
+  report.changes.push(...result.changes);
+  report.warnings.push(...result.warnings);
+  report.effects.push(...result.effects);
+  if (report.diff) {
+    report.diffs.push(...result.diffs);
+  }
+}
+
+function renderDoctorRepairPreviewResult(
+  ctx: DoctorHealthFlowContext,
+  result: DoctorRepairRunResult,
+): void {
+  if (ctx.options.json === true) {
+    return;
+  }
+  const lines = [
+    ...result.findings.map(formatDoctorRepairFinding),
+    ...result.changes.map((change) => `change: ${change}`),
+    ...result.effects.map(formatDoctorRepairEffect),
+    ...(ctx.options.diff === true ? result.diffs.map(formatDoctorRepairDiff) : []),
+    ...result.warnings.map((warning) => `warning: ${warning}`),
+  ];
+  if (lines.length > 0) {
+    ctx.runtime.log(lines.join("\n"));
+  }
+}
+
+function formatDoctorRepairFinding(finding: HealthFinding): string {
+  const where = finding.path !== undefined ? ` ${finding.path}` : "";
+  const line = finding.line !== undefined ? `:${finding.line}` : "";
+  return `finding: [${finding.severity}] ${finding.checkId}${where}${line} - ${finding.message}`;
+}
+
+function formatDoctorRepairEffect(effect: HealthRepairEffect): string {
+  const target = effect.target !== undefined ? ` ${effect.target}` : "";
+  const suffix = effect.dryRunSafe === true ? " (dry-run safe)" : "";
+  return `effect: ${effect.kind} ${effect.action}${target}${suffix}`;
+}
+
+function formatDoctorRepairDiff(diff: HealthRepairDiff): string {
+  if (diff.unifiedDiff !== undefined) {
+    return `diff: ${diff.path}\n${diff.unifiedDiff}`;
+  }
+  return `diff: ${diff.path}`;
+}
 
 function isUpdateDoctorRun(env: NodeJS.ProcessEnv | Record<string, string | undefined>): boolean {
   const value = env.OPENCLAW_UPDATE_IN_PROGRESS;
@@ -217,15 +343,24 @@ async function runStructuredDoctorHealthContribution(params: {
       cfg: params.ctx.cfg,
       cwd: workspaceDir,
       configPath: params.ctx.configPath,
-      dryRun: !params.ctx.prompter.shouldRepair,
+      dryRun: params.ctx.options.dryRun === true || !params.ctx.prompter.shouldRepair,
+      diff: params.ctx.options.diff === true,
       allowExecSecretRefs: params.ctx.options.allowExec === true,
     },
     {
       checks: params.checks,
-      dryRun: !params.ctx.prompter.shouldRepair,
+      dryRun: params.ctx.options.dryRun === true || !params.ctx.prompter.shouldRepair,
+      diff: params.ctx.options.diff === true,
     },
   );
-  params.ctx.cfg = result.config;
+  appendDoctorRepairPreviewResult(params.ctx.previewReport, result);
+  if (params.ctx.options.dryRun !== true) {
+    params.ctx.cfg = result.config;
+  }
+  if (params.ctx.options.dryRun === true) {
+    renderDoctorRepairPreviewResult(params.ctx, result);
+    return;
+  }
   renderStructuredHealthFindings(params.ctx, result.findings);
   for (const warning of result.warnings) {
     params.ctx.runtime.error(warning);
@@ -436,7 +571,8 @@ async function runCommandOwnerHealth(ctx: DoctorHealthFlowContext): Promise<void
 }
 
 async function runStructuredHealthRepairs(ctx: DoctorHealthFlowContext): Promise<void> {
-  if (!ctx.prompter.shouldRepair) {
+  const dryRun = ctx.options.dryRun === true;
+  if (!ctx.prompter.shouldRepair && !dryRun) {
     return;
   }
   const { registerBundledHealthChecks } = await import("./bundled-health-checks.js");
@@ -455,14 +591,21 @@ async function runStructuredHealthRepairs(ctx: DoctorHealthFlowContext): Promise
       cfg: ctx.cfg,
       cwd: workspaceDir,
       configPath: ctx.configPath,
+      dryRun,
+      diff: ctx.options.diff === true,
     },
-    { checks },
+    { checks, dryRun, diff: ctx.options.diff === true },
   );
-  ctx.cfg = result.config;
-  if (result.changes.length > 0) {
+  appendDoctorRepairPreviewResult(ctx.previewReport, result);
+  if (!dryRun) {
+    ctx.cfg = result.config;
+  }
+  if (dryRun) {
+    renderDoctorRepairPreviewResult(ctx, result);
+  } else if (result.changes.length > 0) {
     note(result.changes.join("\n"), "Doctor changes");
   }
-  if (result.warnings.length > 0) {
+  if (!dryRun && result.warnings.length > 0) {
     note(result.warnings.join("\n"), "Doctor warnings");
   }
 }
@@ -476,7 +619,8 @@ async function runCoreContributionHealthRepair(
   ctx: DoctorHealthFlowContext,
   checkIds: readonly string[],
 ): Promise<void> {
-  if (!ctx.prompter.shouldRepair || checkIds.length === 0) {
+  const dryRun = ctx.options.dryRun === true;
+  if ((!ctx.prompter.shouldRepair && !dryRun) || checkIds.length === 0) {
     return;
   }
   const { CORE_HEALTH_CHECKS } = await import("./doctor-core-checks.js");
@@ -498,14 +642,21 @@ async function runCoreContributionHealthRepair(
       cfg: ctx.cfg,
       cwd: workspaceDir,
       configPath: ctx.configPath,
+      dryRun,
+      diff: ctx.options.diff === true,
     },
-    { checks },
+    { checks, dryRun, diff: ctx.options.diff === true },
   );
-  ctx.cfg = result.config;
-  if (result.changes.length > 0) {
+  appendDoctorRepairPreviewResult(ctx.previewReport, result);
+  if (!dryRun) {
+    ctx.cfg = result.config;
+  }
+  if (dryRun) {
+    renderDoctorRepairPreviewResult(ctx, result);
+  } else if (result.changes.length > 0) {
     note(result.changes.join("\n"), "Doctor changes");
   }
-  if (result.warnings.length > 0) {
+  if (!dryRun && result.warnings.length > 0) {
     note(result.warnings.join("\n"), "Doctor warnings");
   }
 }

--- a/src/flows/doctor-health.ts
+++ b/src/flows/doctor-health.ts
@@ -2,8 +2,11 @@
 import { intro as clackIntro, outro as clackOutro } from "@clack/prompts";
 import { stylePromptTitle } from "../../packages/terminal-core/src/prompt-style.js";
 import type { DoctorOptions } from "../commands/doctor-prompter.js";
-import type { RuntimeEnv } from "../runtime.js";
-import type { DoctorHealthFlowContext } from "./doctor-health-contributions.js";
+import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
+import type {
+  DoctorHealthFlowContext,
+  DoctorRepairPreviewReport,
+} from "./doctor-health-contributions.js";
 
 // Interactive doctor entrypoint; lazy imports keep normal CLI startup light.
 const intro = (message: string) => clackIntro(stylePromptTitle(message) ?? message);
@@ -20,16 +23,31 @@ function loadConfigModule(): Promise<ConfigModule> {
 /** Runs the full interactive doctor flow against the provided or default runtime. */
 export async function doctorCommand(runtime?: RuntimeEnv, options: DoctorOptions = {}) {
   const effectiveRuntime = runtime ?? (await import("../runtime.js")).defaultRuntime;
-  if (options.repair === true || options.yes === true || options.generateGatewayToken === true) {
+  const previewOnly = options.dryRun === true || options.diff === true;
+  const effectiveOptions: DoctorOptions = previewOnly
+    ? { ...options, repair: false, yes: false, generateGatewayToken: false, dryRun: true }
+    : options;
+  const jsonPreview = previewOnly && effectiveOptions.json === true;
+  const flowRuntime: RuntimeEnv = jsonPreview
+    ? { ...effectiveRuntime, log: () => {}, error: () => {} }
+    : effectiveRuntime;
+  if (
+    !previewOnly &&
+    (effectiveOptions.repair === true ||
+      effectiveOptions.yes === true ||
+      effectiveOptions.generateGatewayToken === true)
+  ) {
     const { assertConfigWriteAllowedInCurrentMode } = await loadConfigModule();
     assertConfigWriteAllowedInCurrentMode();
   }
 
   const { createDoctorPrompter } = await import("../commands/doctor-prompter.js");
   const { printWizardHeader } = await import("../commands/onboard-helpers.js");
-  const prompter = createDoctorPrompter({ runtime: effectiveRuntime, options });
-  printWizardHeader(effectiveRuntime);
-  intro("OpenClaw doctor");
+  const prompter = createDoctorPrompter({ runtime: flowRuntime, options: effectiveOptions });
+  if (!jsonPreview) {
+    printWizardHeader(flowRuntime);
+    intro("OpenClaw doctor");
+  }
 
   const { resolveOpenClawPackageRoot } = await import("../infra/openclaw-root.js");
   const root = await resolveOpenClawPackageRoot({
@@ -40,8 +58,8 @@ export async function doctorCommand(runtime?: RuntimeEnv, options: DoctorOptions
 
   const { maybeOfferUpdateBeforeDoctor } = await import("../commands/doctor-update.js");
   const updateResult = await maybeOfferUpdateBeforeDoctor({
-    runtime: effectiveRuntime,
-    options,
+    runtime: flowRuntime,
+    options: effectiveOptions,
     root,
     confirm: (p) => prompter.confirm(p),
     outro,
@@ -56,31 +74,45 @@ export async function doctorCommand(runtime?: RuntimeEnv, options: DoctorOptions
   const { noteStalePluginRuntimeSymlinks } =
     await import("../commands/doctor/shared/plugin-runtime-symlinks.js");
   const { noteStartupOptimizationHints } = await import("../commands/doctor-platform-notes.js");
-  await maybeRepairUiProtocolFreshness(effectiveRuntime, prompter);
-  noteSourceInstallIssues(root);
-  await noteStalePluginRuntimeSymlinks(root);
-  noteStartupOptimizationHints();
+  await withOptionalSuppressedNotes(jsonPreview, async () => {
+    if (!previewOnly) {
+      await maybeRepairUiProtocolFreshness(flowRuntime, prompter);
+    }
+    noteSourceInstallIssues(root);
+    await noteStalePluginRuntimeSymlinks(root);
+    noteStartupOptimizationHints();
+  });
 
   const { loadAndMaybeMigrateDoctorConfig } = await import("../commands/doctor-config-flow.js");
-  const configResult = await loadAndMaybeMigrateDoctorConfig({
-    options,
-    confirm: (p) => prompter.confirm(p),
-    runtime: effectiveRuntime,
-    prompter,
-  });
+  const configOptions: DoctorOptions = effectiveOptions;
+  const configResult = await withOptionalSuppressedNotes(jsonPreview, () =>
+    loadAndMaybeMigrateDoctorConfig({
+      options: configOptions,
+      confirm: (p) => prompter.confirm(p),
+      runtime: flowRuntime,
+      prompter,
+    }),
+  );
   const { CONFIG_PATH } = await loadConfigModule();
+  const previewReport: DoctorRepairPreviewReport | undefined = previewOnly
+    ? (await import("./doctor-health-contributions.js")).createDoctorRepairPreviewReport({
+        diff: effectiveOptions.diff === true,
+      })
+    : undefined;
   const ctx: DoctorHealthFlowContext = {
-    runtime: effectiveRuntime,
-    options,
+    runtime: flowRuntime,
+    options: effectiveOptions,
     prompter,
     configResult,
     cfg: configResult.cfg,
     cfgForPersistence: structuredClone(configResult.cfg),
     sourceConfigValid: configResult.sourceConfigValid ?? true,
     configPath: configResult.path ?? CONFIG_PATH,
+    previewReport,
   };
-  const { runDoctorHealthContributions } = await import("./doctor-health-contributions.js");
-  await runDoctorHealthContributions(ctx);
+  const { finalizeDoctorRepairPreviewReport, runDoctorHealthContributions } =
+    await import("./doctor-health-contributions.js");
+  await withOptionalSuppressedNotes(jsonPreview, () => runDoctorHealthContributions(ctx));
   if (ctx.postInstallDoctorResult) {
     const {
       UPDATE_POST_INSTALL_DOCTOR_ADVISORY_EXIT_CODE,
@@ -98,5 +130,37 @@ export async function doctorCommand(runtime?: RuntimeEnv, options: DoctorOptions
     }
   }
 
+  if (previewReport) {
+    const finalizedReport = finalizeDoctorRepairPreviewReport(previewReport);
+    if (jsonPreview) {
+      writeRuntimeJson(effectiveRuntime, finalizedReport);
+    } else {
+      effectiveRuntime.log(
+        `Doctor dry-run complete: ${finalizedReport.findings.length} finding(s), ${finalizedReport.changes.length} preview change(s).`,
+      );
+    }
+    return;
+  }
+
   outro("Doctor complete.");
+}
+
+async function withOptionalSuppressedNotes<T>(
+  suppress: boolean,
+  callback: () => Promise<T>,
+): Promise<T> {
+  if (!suppress) {
+    return callback();
+  }
+  const previous = process.env.OPENCLAW_SUPPRESS_NOTES;
+  process.env.OPENCLAW_SUPPRESS_NOTES = "1";
+  try {
+    return await callback();
+  } finally {
+    if (previous === undefined) {
+      delete process.env.OPENCLAW_SUPPRESS_NOTES;
+    } else {
+      process.env.OPENCLAW_SUPPRESS_NOTES = previous;
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Rebuild #84472 narrowly on current `main` to expose Doctor repair previews without carrying the old broad migration stack.

This draft now focuses on the public preview surface for already-structured Doctor repairs:

- `openclaw doctor --dry-run` previews structured repair output without applying config repairs.
- `openclaw doctor --diff` implies dry-run and includes structured repair diffs when checks provide them.
- `openclaw doctor --dry-run --json` / `--diff --json` emits a machine-readable preview report.
- Preview reports include findings, remaining findings, changes, warnings, effects, diffs, skipped entries, and repair counts.
- JSON preview suppresses intermediate human note/log output so the final payload is clean.
- Dry-run/diff config preflight skips state and legacy config migrations; repair mode keeps those migrations enabled.


## Dry-run coverage proposal

This PR should not try to make every Doctor lint family previewable. After the 44/44 structured lint pass, the proposed dry-run bar is selective: dry-run should preview areas where Doctor already has, or should soon have, a concrete mutation path. Pure diagnostics, live service/account probes, optional inventory checks, and advisory findings should remain lint-only unless they gain a real repair owner.

Current checked-in structured repair substrate:

- 44 tracked Doctor rule families have structured lint findings.
- 48 registered lint checks exist because a few families split into multiple checks.
- 13 checks/families currently expose structured repair hooks/effects.
- A useful finished dry-run story is likely 15-18 of 44 families, roughly the 30-40% of Doctor that can truthfully preview file/config/state changes.

High-value dry-run families:

- `core/doctor/session-locks`
- `core/doctor/session-transcripts`
- `core/doctor/session-snapshots`
- `core/doctor/config-audit-scrub`
- `core/doctor/state-integrity`
- `core/doctor/sandbox/registry-files`
- `core/doctor/ui-protocol-freshness`
- `core/doctor/browser-clawd-profile-residue`
- `core/doctor/shell-completion`
- `core/doctor/plugin-registry`
- `core/doctor/configured-plugin-installs`
- `core/doctor/skills-readiness`
- `core/doctor/gateway-services/extra`

Likely follow-up candidates, if the preview can be made truthful and scoped:

- `core/doctor/heartbeat-template`
- `core/doctor/legacy-plugin-manifests`
- `core/doctor/legacy-plugin-dependencies`
- `core/doctor/stale-plugin-runtime-symlinks`
- selected config write previews where the output describes write blockers or exact config-file effects without implying broad lint mutation

Non-goal: dry-run parity for every lint finding. Gateway health/daemon, auth/profile readiness, channel/device/account probes, workspace inventory, disk-space, tool-result-cap, systemd linger, memory search, and other diagnostic/advisory checks can stay lint-only unless a separate PR proves a concrete repair effect.

## Rebuild note

This PR branch was rebuilt from the historical `doctor-dry-run-contribution-guard` branch. The old branch mixed the dry-run preview surface with a broad older doctor migration stack. The replacement is intentionally smaller: CLI wiring, preview report plumbing, JSON output behavior, dry-run preflight guardrails, and focused tests around the existing structured repair runner.

## Validation

Current head `b3563d3f3404c61c7c8409ba6eb5329c254cbbc0`:

- `pnpm build` - passed
- `pnpm exec vitest run src/commands/doctor-config-flow.test.ts -t "does not run state or legacy config migrations for dry-run previews|does not run state or legacy config migrations for diff previews|keeps migrations enabled for repair runs" --reporter=dot --config test/vitest/vitest.commands.config.ts` - 3 passed, 39 skipped
- `pnpm exec vitest run src/commands/doctor-config-flow.test.ts -t "does not run state or legacy config migrations for dry-run previews" --reporter=verbose --config test/vitest/vitest.commands.config.ts` - passed
- `pnpm exec vitest run src/commands/doctor-config-flow.test.ts -t "does not run state or legacy config migrations for diff previews|keeps migrations enabled for repair runs" --reporter=verbose --config test/vitest/vitest.commands.config.ts` - 2 passed, 40 skipped
- `pnpm exec oxlint src/commands/doctor-config-flow.ts src/commands/doctor-config-flow.test.ts` - passed
- `git diff --check` - passed

Not passing locally on current Windows checkout:

- `node scripts/run-vitest.mjs run src/commands/doctor-config-flow.test.ts --reporter=dot` has one pre-existing Windows path assertion failure in `warns when hooks transformsDir points outside the hook transforms root`; expected `/virtual/.openclaw/hooks/transforms`, received a Windows-normalized `\virtual\.openclaw\hooks\transforms`. This PR does not modify that path-formatting code.

## Real behavior proof

Behavior or issue addressed:
`openclaw doctor --dry-run --diff --json --non-interactive` now completes through the built launcher and emits a clean dry-run preview report while dry-run/diff config preflight skips state and legacy config migrations.

Real environment tested:
Windows source checkout at `b3563d3f3404c61c7c8409ba6eb5329c254cbbc0`, Node.js v24.14.0. The CLI was built first with `pnpm build`, then run with isolated `HOME`, `USERPROFILE`, `OPENCLAW_HOME`, and `OPENCLAW_STATE_DIR` under `%TEMP%`.

Exact steps or command run after this patch:
1. `pnpm build`
2. `node openclaw.mjs doctor --dry-run --diff --json --non-interactive`

Evidence after fix:
The command exited `0` in 73.8s from isolated proof root `C:\Users\giodl\AppData\Local\Temp\openclaw-doctor-launcher-proof-f622d14d1b00488899570333a0acab39`.

Stdout:

```json
{
  "mode": "doctor-repair-preview",
  "dryRun": true,
  "diff": true,
  "ok": true,
  "checksRun": 1,
  "checksRepaired": 0,
  "checksValidated": 0,
  "findings": [],
  "remainingFindings": [],
  "changes": [],
  "warnings": [],
  "effects": [],
  "diffs": [],
  "skipped": []
}
```

Observed result after fix:
The built CLI produced only the final JSON preview on stdout and no stderr. The isolated proof root contained runtime cache/state files under the isolated `OPENCLAW_STATE_DIR`, but no `openclaw.json`, `.clobbered*`, or last-known-good config files were created.

What was not tested:
Cross-platform live Doctor repair scenarios were not run for this draft rebuild. The raw source command `node --import tsx src/entry.ts doctor --dry-run --diff --json --non-interactive` still hung before `doctorCommand` startup in this Windows checkout, so the successful real CLI proof uses the built source launcher path (`node openclaw.mjs ...`) after `pnpm build`.

