### PR TITLE
fix: redact Docker setup gateway token output

### DIFF
--- a/scripts/docker/setup.sh
+++ b/scripts/docker/setup.sh
@@ -108,6 +108,36 @@ read_env_gateway_token() {
   fi
 }
 
+format_gateway_token_fingerprint() {
+  local token="$1"
+  local digest=""
+  local length="${#token}"
+
+  if [[ -z "$token" ]]; then
+    printf '<unset>'
+    return 0
+  fi
+
+  if command -v openssl >/dev/null 2>&1; then
+    digest="$(printf '%s' "$token" | openssl dgst -sha256 -r 2>/dev/null || true)"
+    digest="${digest%% *}"
+  elif command -v shasum >/dev/null 2>&1; then
+    digest="$(printf '%s' "$token" | shasum -a 256 2>/dev/null || true)"
+    digest="${digest%% *}"
+  elif command -v python3 >/dev/null 2>&1; then
+    digest="$(printf '%s' "$token" | python3 -c 'import hashlib, sys; print(hashlib.sha256(sys.stdin.buffer.read()).hexdigest())')"
+  elif command -v node >/dev/null 2>&1; then
+    digest="$(printf '%s' "$token" | node -e 'const crypto = require("node:crypto"); const fs = require("node:fs"); process.stdout.write(crypto.createHash("sha256").update(fs.readFileSync(0)).digest("hex"));')"
+  fi
+
+  if [[ -n "$digest" ]]; then
+    printf 'sha256:%s (%s chars)' "${digest:0:12}" "$length"
+    return 0
+  fi
+
+  printf '[set; %s chars]' "$length"
+}
+
 sync_gateway_config() {
   local allowed_origin_json=""
   local current_allowed_origins=""
@@ -346,6 +376,7 @@ PY
   fi
 fi
 export OPENCLAW_GATEWAY_TOKEN
+MASKED_GATEWAY_TOKEN="$(format_gateway_token_fingerprint "$OPENCLAW_GATEWAY_TOKEN")"
 
 COMPOSE_FILES=("$COMPOSE_FILE")
 COMPOSE_ARGS=()
@@ -572,7 +603,7 @@ else
   else
     echo "Bonjour/mDNS advertising: explicitly enabled (OPENCLAW_DISABLE_BONJOUR=$OPENCLAW_DISABLE_BONJOUR)."
   fi
-  echo "Gateway token: $OPENCLAW_GATEWAY_TOKEN"
+  echo "Gateway token fingerprint: $MASKED_GATEWAY_TOKEN"
   echo "Tailscale exposure: Off (use host-level tailnet/Tailscale setup separately)."
   echo "Install Gateway daemon: No (managed by Docker Compose)"
   echo ""
@@ -711,8 +742,10 @@ echo "Gateway running with host port mapping."
 echo "Access from tailnet devices via the host's tailnet IP."
 echo "Config: $OPENCLAW_CONFIG_DIR"
 echo "Workspace: $OPENCLAW_WORKSPACE_DIR"
-echo "Token: $OPENCLAW_GATEWAY_TOKEN"
+echo "Token fingerprint: $MASKED_GATEWAY_TOKEN"
+echo "Token file: $ENV_FILE"
 echo ""
 echo "Commands:"
 echo "  ${COMPOSE_HINT} logs -f openclaw-gateway"
-echo "  ${COMPOSE_HINT} exec openclaw-gateway node dist/index.js health --token \"$OPENCLAW_GATEWAY_TOKEN\""
+echo "  sed -n 's/^OPENCLAW_GATEWAY_TOKEN=//p' \"$ENV_FILE\""
+echo "  OPENCLAW_GATEWAY_TOKEN=\"\$(sed -n 's/^OPENCLAW_GATEWAY_TOKEN=//p' \"$ENV_FILE\")\" && ${COMPOSE_HINT} exec openclaw-gateway node dist/index.js health --token \"\$OPENCLAW_GATEWAY_TOKEN\""

--- a/test/scripts/test-install-sh-docker.test.ts
+++ b/test/scripts/test-install-sh-docker.test.ts
@@ -1,4 +1,7 @@
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
+import { dirname } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const SCRIPT_PATH = "scripts/test-install-sh-docker.sh";
@@ -10,6 +13,14 @@ const BUN_GLOBAL_ASSERTIONS_PATH = "scripts/e2e/lib/bun-global-install/assertion
 const INSTALL_SMOKE_WORKFLOW_PATH = ".github/workflows/install-smoke.yml";
 const RELEASE_CHECKS_WORKFLOW_PATH = ".github/workflows/openclaw-release-checks.yml";
 const LIVE_E2E_WORKFLOW_PATH = ".github/workflows/openclaw-live-and-e2e-checks-reusable.yml";
+
+function extractShellFunction(script: string, name: string) {
+  const match = script.match(new RegExp(`^${name}\\(\\) \\{[\\s\\S]*?^\\}`, "m"));
+  if (!match) {
+    throw new Error(`Missing shell function: ${name}`);
+  }
+  return match[0];
+}
 
 describe("test-install-sh-docker", () => {
   it("defaults local Apple Silicon smoke runs to native arm64 while keeping CI on amd64", () => {
@@ -118,6 +129,44 @@ describe("test-install-sh-docker", () => {
       'BUILD_ARGS+=(--build-arg "OPENCLAW_IMAGE_PIP_PACKAGES=${OPENCLAW_IMAGE_PIP_PACKAGES}")',
     );
     expect(podmanSetup).not.toContain("OPENCLAW_DOCKER_PIP_PACKAGES");
+  });
+
+  it("redacts the gateway token from Docker setup logs", () => {
+    const script = readFileSync(DOCKER_SETUP_PATH, "utf8");
+    const token = "super-secret-token-123";
+    const fingerprintFunction = extractShellFunction(script, "format_gateway_token_fingerprint");
+    const fingerprint = spawnSync(
+      "/bin/bash",
+      ["-c", `${fingerprintFunction}\nformat_gateway_token_fingerprint "$1"`, "--", token],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: dirname(process.execPath),
+        },
+      },
+    );
+
+    expect(fingerprint.status).toBe(0);
+    expect(fingerprint.stdout.trim()).toBe(
+      `sha256:${createHash("sha256").update(token).digest("hex").slice(0, 12)} (${token.length} chars)`,
+    );
+    expect(fingerprint.stdout).not.toContain(token);
+    expect(script).toContain(
+      'MASKED_GATEWAY_TOKEN="$(format_gateway_token_fingerprint "$OPENCLAW_GATEWAY_TOKEN")"',
+    );
+    expect(script).toContain('echo "Gateway token fingerprint: $MASKED_GATEWAY_TOKEN"');
+    expect(script).toContain('echo "Token fingerprint: $MASKED_GATEWAY_TOKEN"');
+    expect(script).toContain('echo "Token file: $ENV_FILE"');
+    expect(script).toContain("sed -n 's/^OPENCLAW_GATEWAY_TOKEN=//p'");
+    expect(script).toContain(
+      "${COMPOSE_HINT} exec openclaw-gateway node dist/index.js health --token",
+    );
+    expect(script).not.toContain('echo "Gateway token: $OPENCLAW_GATEWAY_TOKEN"');
+    expect(script).not.toContain('echo "Token: $OPENCLAW_GATEWAY_TOKEN"');
+    expect(script).not.toContain(
+      'echo "  ${COMPOSE_HINT} exec openclaw-gateway node dist/index.js health --token "$OPENCLAW_GATEWAY_TOKEN""',
+    );
   });
 
   it("allows repository branch history and release tags for secret-backed Docker release checks", () => {


### PR DESCRIPTION
## Summary

- Stops `scripts/docker/setup.sh` from printing the raw `OPENCLAW_GATEWAY_TOKEN` during Docker setup.
- Replaces the setup summary token output with a short SHA-256 fingerprint and token length.
- Prints the `.env` token file path and an explicit retrieval command for operators who need to run the authenticated health check manually.
- Adds regression coverage in `test/scripts/test-install-sh-docker.test.ts`.

## Motivation

The Docker setup flow treated the gateway token as ordinary operator output. Because setup output can land in CI logs, shell transcripts, or shared bastion logs, printing the raw bearer token could turn logs into reusable gateway credentials.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #84468
- Related #84469
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Docker setup no longer prints the full gateway bearer token to stdout/stderr.
- Real environment tested: Local OpenClaw checkout rebased onto current `upstream/main`.
- Exact steps or command run after this patch: `node scripts/run-oxlint.mjs 'test/scripts/test-install-sh-docker.test.ts' && node scripts/run-vitest.mjs 'test/scripts/test-install-sh-docker.test.ts' && pnpm tsgo`
- Evidence after fix: oxlint reported 0 warnings/errors, the focused Vitest file passed 17 tests, and `pnpm tsgo` completed successfully.
- Observed result after fix: the Docker setup script now prints token fingerprints and token-file retrieval guidance instead of the raw token.
- What was not tested: End-to-end Docker startup on a Docker-capable host.
- Before evidence: The issue body records the previous raw `Gateway token: $OPENCLAW_GATEWAY_TOKEN`, `Token: $OPENCLAW_GATEWAY_TOKEN`, and inline health command token output.

## Root Cause (if applicable)

- Root cause: `scripts/docker/setup.sh` echoed the resolved gateway token directly in setup status output and embedded it in a printed health-check command.
- Missing detection / guardrail: Existing Docker setup tests did not assert that token-related setup output avoids raw token interpolation.
- Contributing context (if known): The script offered convenient copy/paste operator output without distinguishing secrets from non-sensitive setup details.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this: script-level regression coverage for Docker setup output.
- Target test or file: `test/scripts/test-install-sh-docker.test.ts`
- Scenario the test should lock in: the script must use the fingerprint helper, must print fingerprint/token-file guidance, and must not contain the reported raw token echo statements or raw-token health command echo.
- Why this is the smallest reliable guardrail: it checks the exact setup script output paths and executes the shell fingerprint helper without requiring a live Docker daemon.
- Existing test that already covers this (if any): None identified.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- Docker setup output now shows `Gateway token fingerprint:` and `Token fingerprint:` instead of the raw gateway token.
- Docker setup output now includes `Token file: $ENV_FILE` and a command that retrieves the token from `.env` only when the operator explicitly runs it.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): Yes
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: Gateway token handling changed only in setup output. The token remains available from `.env` for authorized local operators, while routine logs no longer disclose the bearer secret.

## Repro + Verification

### Environment

- OS: macOS local checkout
- Runtime/container: Node `v25.9.0`, pnpm `11.1.0`
- Model/provider: N/A for runtime behavior
- Integration/channel (if any): Docker setup script
- Relevant config (redacted): PR branch is based on current `upstream/main`

### Steps

1. Inspect the Docker setup output paths that previously printed the token.
2. Apply this patch.
3. Run `node scripts/run-oxlint.mjs 'test/scripts/test-install-sh-docker.test.ts'`.
4. Run `node scripts/run-vitest.mjs 'test/scripts/test-install-sh-docker.test.ts'`.
5. Run `pnpm tsgo`.

### Expected

- No setup output path prints the raw `OPENCLAW_GATEWAY_TOKEN`.
- The script still gives operators a fingerprint and an explicit local retrieval path.
- Focused lint, focused test, and type checks pass.

### Actual

- `node scripts/run-oxlint.mjs 'test/scripts/test-install-sh-docker.test.ts'`: passed with 0 warnings and 0 errors.
- `node scripts/run-vitest.mjs 'test/scripts/test-install-sh-docker.test.ts'`: passed, 17 tests.
- `pnpm tsgo`: passed.

## Evidence

- Changed files:
  - `scripts/docker/setup.sh`
  - `test/scripts/test-install-sh-docker.test.ts`
- Local diff against `upstream/main`: 2 files, 81 insertions, 3 deletions.
- Focused verification: oxlint, focused Vitest, and `pnpm tsgo` passed.

## Human Verification (required)

- Verified scenarios: token fingerprint helper behavior, presence of fingerprint/token-file setup output, and absence of the reported raw token echo statements.
- Edge cases checked: helper returns `<unset>` for empty token and uses hash-tool fallbacks without printing the raw token.
- What you did **not** verify: live Docker daemon bootstrap.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Operators may need one extra step to copy the token for manual health checks.
  - Mitigation: setup output now prints the token file path and a concrete retrieval command.
- Risk: The fingerprint reveals token length and a short hash prefix.
  - Mitigation: this is sufficient for operator verification without exposing a reusable bearer token.
