### PR TITLE
fix(gateway): include openclaw bin in service PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Docs: https://docs.openclaw.ai
 
 - Gateway/LaunchAgent: wait for launchd reload bootout to finish and fall back to kickstart when bootstrap races, so reload handoff does not leave the service deregistered. Fixes #84630. (#84641) Thanks @NianJiuZst.
 - Gateway/LaunchAgent: treat a concurrent launchd bootstrap as a successful restart when the service is already loaded, avoiding false macOS Gateway restart failures. Fixes #84721. (#84722) Thanks @googlerest.
+- Gateway/service: include the active `openclaw` command bin directory in managed service PATH generation and doctor audit expectations for npm-global macOS installs. Fixes #84201. (#84475) Thanks @jbetala7.
 - CLI/update: preserve managed Gateway service environment during package cutovers so macOS LaunchAgent repair/restart reads the pre-update service state instead of caller shell state. (#83026)
 - Agents/providers: honor per-model `api` and `baseUrl` overrides in custom provider auth hooks and transport selection. Fixes #80487. (#80488) Thanks @huveewomg.
 - Gateway/restart: eager-load the lifecycle runtime before in-place upgrade signal handling so package replacement does not deadlock restart imports. (#84890) Thanks @myps6415.

--- a/src/commands/daemon-install-helpers.test.ts
+++ b/src/commands/daemon-install-helpers.test.ts
@@ -149,6 +149,30 @@ describe("buildGatewayInstallPlan", () => {
     expect(serviceEnvRequest?.extraPathDirs).toStrictEqual(["/custom"]);
   });
 
+  it("adds the active openclaw command bin directory to the managed service PATH", async () => {
+    mockNodeGatewayPlanFixture();
+    const originalArgv = process.argv;
+    const openclawBinPath = path.join(isolatedHome, ".npm-global", "bin", "openclaw");
+    process.argv = ["node", openclawBinPath, "gateway", "install"];
+
+    try {
+      await buildGatewayInstallPlan({
+        env: { HOME: isolatedHome },
+        port: 3000,
+        runtime: "node",
+        nodePath: "/opt/homebrew/opt/node/bin/node",
+        platform: "darwin",
+      });
+    } finally {
+      process.argv = originalArgv;
+    }
+
+    expect(mocks.buildServiceEnvironment).toHaveBeenCalledOnce();
+    expect(
+      firstMockArg(mocks.buildServiceEnvironment, "buildServiceEnvironment").extraPathDirs,
+    ).toStrictEqual(["/opt/homebrew/opt/node/bin", path.dirname(openclawBinPath)]);
+  });
+
   it("does not prepend '.' when nodePath is a bare executable name", async () => {
     mockNodeGatewayPlanFixture();
 

--- a/src/commands/daemon-install-helpers.ts
+++ b/src/commands/daemon-install-helpers.ts
@@ -35,7 +35,7 @@ import { discoverConfigSecretTargets } from "../secrets/target-registry.js";
 import {
   emitDaemonInstallRuntimeWarning,
   resolveDaemonInstallRuntimeInputs,
-  resolveDaemonNodeBinDir,
+  resolveDaemonServicePathDirs,
 } from "./daemon-install-plan.shared.js";
 import type { DaemonInstallWarnFn } from "./daemon-install-runtime-warning.js";
 import type { GatewayDaemonRuntime } from "./daemon-runtime.js";
@@ -547,7 +547,11 @@ export async function buildGatewayInstallPlan(params: {
         ? resolveGatewayLaunchAgentLabel(serviceInputEnv.OPENCLAW_PROFILE)
         : undefined,
     platform,
-    extraPathDirs: resolveDaemonNodeBinDir(nodePath),
+    extraPathDirs: resolveDaemonServicePathDirs({
+      nodePath,
+      env: serviceInputEnv,
+      platform,
+    }),
   });
 
   const { environment, environmentValueSources } = await buildGatewayInstallEnvironment({

--- a/src/commands/daemon-install-plan.shared.test.ts
+++ b/src/commands/daemon-install-plan.shared.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   resolveDaemonInstallRuntimeInputs,
   resolveDaemonNodeBinDir,
+  resolveDaemonOpenClawBinDir,
+  resolveDaemonServicePathDirs,
   resolveGatewayDevMode,
 } from "./daemon-install-plan.shared.js";
 
@@ -38,5 +40,70 @@ describe("resolveDaemonNodeBinDir", () => {
 
   it("ignores bare executable names", () => {
     expect(resolveDaemonNodeBinDir("node")).toBeUndefined();
+  });
+});
+
+describe("resolveDaemonOpenClawBinDir", () => {
+  it("uses the active openclaw command directory", () => {
+    expect(
+      resolveDaemonOpenClawBinDir({
+        argv: ["node", "/Users/testuser/.npm-global/bin/openclaw", "gateway", "install"],
+        env: { PATH: "" },
+        platform: "darwin",
+      }),
+    ).toEqual(["/Users/testuser/.npm-global/bin"]);
+  });
+
+  it("finds the PATH shim that resolves to the active package entrypoint", () => {
+    const realpaths = new Map([
+      ["/Users/testuser/.npm-global/bin/openclaw", "/pkg/openclaw/openclaw.mjs"],
+      [
+        "/Users/testuser/.npm-global/lib/node_modules/openclaw/openclaw.mjs",
+        "/pkg/openclaw/openclaw.mjs",
+      ],
+    ]);
+
+    expect(
+      resolveDaemonOpenClawBinDir({
+        argv: [
+          "node",
+          "/Users/testuser/.npm-global/lib/node_modules/openclaw/openclaw.mjs",
+          "gateway",
+          "install",
+        ],
+        env: { PATH: "/Users/testuser/.npm-global/bin:/usr/bin" },
+        platform: "darwin",
+        existsSync: (candidate) => candidate === "/Users/testuser/.npm-global/bin/openclaw",
+        realpathSync: (candidate) => realpaths.get(candidate) ?? candidate,
+      }),
+    ).toEqual(["/Users/testuser/.npm-global/bin"]);
+  });
+
+  it("ignores unrelated openclaw commands elsewhere on PATH", () => {
+    expect(
+      resolveDaemonOpenClawBinDir({
+        argv: ["node", "/opt/openclaw/openclaw.mjs", "gateway", "install"],
+        env: { PATH: "/Users/testuser/.npm-global/bin" },
+        platform: "darwin",
+        existsSync: () => true,
+        realpathSync: (candidate) =>
+          candidate === "/Users/testuser/.npm-global/bin/openclaw"
+            ? "/other/openclaw.mjs"
+            : candidate,
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe("resolveDaemonServicePathDirs", () => {
+  it("combines node and active openclaw command directories", () => {
+    expect(
+      resolveDaemonServicePathDirs({
+        nodePath: "/opt/homebrew/opt/node/bin/node",
+        argv: ["node", "/Users/testuser/.npm-global/bin/openclaw", "gateway", "install"],
+        env: { PATH: "" },
+        platform: "darwin",
+      }),
+    ).toEqual(["/opt/homebrew/opt/node/bin", "/Users/testuser/.npm-global/bin"]);
   });
 });

--- a/src/commands/daemon-install-plan.shared.ts
+++ b/src/commands/daemon-install-plan.shared.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import path from "node:path";
 import { resolvePreferredNodePath } from "../daemon/runtime-paths.js";
 import {
@@ -50,4 +51,100 @@ export function resolveDaemonNodeBinDir(nodePath?: string): string[] | undefined
     return undefined;
   }
   return [path.dirname(trimmed)];
+}
+
+function isOpenClawCommandBasename(basename: string, platform: NodeJS.Platform): boolean {
+  if (basename === "openclaw") {
+    return true;
+  }
+  if (platform === "win32") {
+    return (
+      basename === "openclaw.cmd" || basename === "openclaw.ps1" || basename === "openclaw.exe"
+    );
+  }
+  return false;
+}
+
+function safeRealpathSync(
+  inputPath: string | undefined,
+  realpathSync: (path: string) => string,
+): string | undefined {
+  if (!inputPath) {
+    return undefined;
+  }
+  try {
+    return realpathSync(inputPath);
+  } catch {
+    return undefined;
+  }
+}
+
+function addUniquePathDir(dirs: string[], dir: string | undefined): void {
+  if (!dir || !path.isAbsolute(dir) || dirs.includes(dir)) {
+    return;
+  }
+  dirs.push(dir);
+}
+
+export function resolveDaemonOpenClawBinDir(
+  params: {
+    argv?: string[];
+    env?: Record<string, string | undefined>;
+    platform?: NodeJS.Platform;
+    existsSync?: (path: string) => boolean;
+    realpathSync?: (path: string) => string;
+  } = {},
+): string[] | undefined {
+  const platform = params.platform ?? process.platform;
+  const argv = params.argv ?? process.argv;
+  const env = params.env ?? process.env;
+  const existsSync = params.existsSync ?? fs.existsSync;
+  const realpathSync = params.realpathSync ?? fs.realpathSync.native;
+  const argv1 = argv[1]?.trim();
+  const dirs: string[] = [];
+
+  if (
+    argv1 &&
+    path.isAbsolute(argv1) &&
+    isOpenClawCommandBasename(path.basename(argv1), platform)
+  ) {
+    addUniquePathDir(dirs, path.dirname(argv1));
+  }
+
+  const argvRealpath = path.isAbsolute(argv1 ?? "")
+    ? safeRealpathSync(argv1, realpathSync)
+    : undefined;
+  for (const rawSegment of (env.PATH ?? "").split(path.delimiter)) {
+    const segment = rawSegment.trim();
+    if (!path.isAbsolute(segment)) {
+      continue;
+    }
+    const candidate = path.join(segment, platform === "win32" ? "openclaw.cmd" : "openclaw");
+    if (!existsSync(candidate)) {
+      continue;
+    }
+    const candidateRealpath = safeRealpathSync(candidate, realpathSync);
+    if (argvRealpath && candidateRealpath && candidateRealpath !== argvRealpath) {
+      continue;
+    }
+    addUniquePathDir(dirs, segment);
+  }
+
+  return dirs.length > 0 ? dirs : undefined;
+}
+
+export function resolveDaemonServicePathDirs(params: {
+  nodePath?: string;
+  argv?: string[];
+  env?: Record<string, string | undefined>;
+  platform?: NodeJS.Platform;
+}): string[] | undefined {
+  const dirs: string[] = [];
+  for (const dir of resolveDaemonNodeBinDir(params.nodePath) ?? []) {
+    addUniquePathDir(dirs, dir);
+  }
+  for (const dir of resolveDaemonOpenClawBinDir(params) ?? []) {
+    addUniquePathDir(dirs, dir);
+  }
+  return dirs.length > 0 ? dirs : undefined;
 }

--- a/src/commands/doctor-gateway-services.ts
+++ b/src/commands/doctor-gateway-services.ts
@@ -413,6 +413,7 @@ export async function maybeRepairGatewayServiceConfig(
     command,
     expectedGatewayToken,
     expectedManagedServiceEnvKeys,
+    expectedServicePath: expectedPlan.environment.PATH,
     expectedPort: port,
   });
   const serviceToken = readEmbeddedGatewayToken(command);

--- a/src/daemon/service-audit.test.ts
+++ b/src/daemon/service-audit.test.ts
@@ -212,6 +212,71 @@ describe("auditGatewayServiceConfig", () => {
     expect(issue?.detail).toContain("/opt/pnpm/bin");
   });
 
+  it("accepts an expected active OpenClaw bin even when it looks package-managed", async () => {
+    const expectedServicePath = [
+      "/opt/homebrew/opt/node/bin",
+      "/Users/testuser/Library/pnpm",
+      "/opt/homebrew/bin",
+      "/opt/homebrew/sbin",
+      "/usr/local/bin",
+      "/usr/bin",
+      "/bin",
+      "/usr/sbin",
+      "/sbin",
+    ].join(":");
+
+    const audit = await auditGatewayServiceConfig({
+      env: { HOME: "/Users/testuser" },
+      platform: "darwin",
+      expectedServicePath,
+      command: {
+        programArguments: [
+          "/opt/homebrew/opt/node/bin/node",
+          "/opt/openclaw/dist/index.js",
+          "gateway",
+        ],
+        environment: { PATH: expectedServicePath },
+      },
+    });
+
+    expect(hasIssue(audit, SERVICE_AUDIT_CODES.gatewayPathMissingDirs)).toBe(false);
+    expect(hasIssue(audit, SERVICE_AUDIT_CODES.gatewayPathNonMinimal)).toBe(false);
+  });
+
+  it("still flags unrelated non-minimal PATH entries beside the expected active bin", async () => {
+    const expectedServicePath = [
+      "/opt/homebrew/opt/node/bin",
+      "/Users/testuser/Library/pnpm",
+      "/opt/homebrew/bin",
+      "/opt/homebrew/sbin",
+      "/usr/local/bin",
+      "/usr/bin",
+      "/bin",
+      "/usr/sbin",
+      "/sbin",
+    ].join(":");
+
+    const audit = await auditGatewayServiceConfig({
+      env: { HOME: "/Users/testuser" },
+      platform: "darwin",
+      expectedServicePath,
+      command: {
+        programArguments: [
+          "/opt/homebrew/opt/node/bin/node",
+          "/opt/openclaw/dist/index.js",
+          "gateway",
+        ],
+        environment: { PATH: `${expectedServicePath}:/Users/testuser/.asdf/shims` },
+      },
+    });
+
+    const issue = audit.issues.find(
+      (entry) => entry.code === SERVICE_AUDIT_CODES.gatewayPathNonMinimal,
+    );
+    expect(issue?.detail).not.toContain("/Users/testuser/Library/pnpm");
+    expect(issue?.detail).toContain("/Users/testuser/.asdf/shims");
+  });
+
   it("accepts Linux fnm aliases/default without requiring the legacy current symlink", async () => {
     const env = {
       HOME: "/tmp/openclaw-testuser",

--- a/src/daemon/service-audit.ts
+++ b/src/daemon/service-audit.ts
@@ -408,6 +408,7 @@ function auditGatewayServicePath(
   issues: ServiceConfigIssue[],
   env: Record<string, string | undefined>,
   platform: NodeJS.Platform,
+  expectedServicePath?: string,
 ) {
   if (platform === "win32") {
     return;
@@ -422,11 +423,16 @@ function auditGatewayServicePath(
     return;
   }
 
-  const expected = getMinimalServicePathPartsFromEnv({
-    platform,
-    env,
-    includeMissingUserBinDefaults: false,
-  });
+  const expected = expectedServicePath?.trim()
+    ? expectedServicePath
+        .split(getPathModule(platform).delimiter)
+        .map((entry) => entry.trim())
+        .filter(Boolean)
+    : getMinimalServicePathPartsFromEnv({
+        platform,
+        env,
+        includeMissingUserBinDefaults: false,
+      });
   const parts = servicePath
     .split(getPathModule(platform).delimiter)
     .map((entry) => entry.trim())
@@ -551,6 +557,7 @@ export async function auditGatewayServiceConfig(params: {
   platform?: NodeJS.Platform;
   expectedGatewayToken?: string;
   expectedManagedServiceEnvKeys?: Iterable<string>;
+  expectedServicePath?: string;
   expectedPort?: number;
 }): Promise<ServiceConfigAudit> {
   const issues: ServiceConfigIssue[] = [];
@@ -565,7 +572,7 @@ export async function auditGatewayServiceConfig(params: {
   auditManagedServiceEnvironment(params.command, issues, params.expectedManagedServiceEnvKeys);
   auditProxyServiceEnvironment(params.command, issues);
   auditGatewayToken(params.command, issues, params.expectedGatewayToken);
-  auditGatewayServicePath(params.command, issues, params.env, platform);
+  auditGatewayServicePath(params.command, issues, params.env, platform, params.expectedServicePath);
   await auditGatewayRuntime(params.env, params.command, issues, platform);
 
   if (platform === "linux") {


### PR DESCRIPTION
Fixes #84201

## Summary
- Add the active `openclaw` command bin directory to the explicit managed-service PATH inputs.
- Keep the existing minimal macOS service PATH policy; this does not merge the full ambient shell PATH.
- Preserve the existing Node runtime bin handling and dedupe the combined PATH dirs before service env rendering.
- Pass the install plan's expected service PATH into doctor service audit so doctor accepts the active CLI bin it just generated while still flagging unrelated PATH drift.

## Real behavior proof
**Behavior addressed:** Gateway service env generation for an npm-global OpenClaw install should include the active `openclaw` command's bin directory so gateway-spawned child shells can resolve `openclaw` on PATH.

**Real environment tested:** Local macOS source checkout at PR head `6f90bad09a`, Node v24.11.1, platform parameter set to `darwin` for the service env builder, and an npm-global-style CLI path of `/Users/testuser/.npm-global/bin/openclaw`.

**Exact steps or command run after this patch:**

```sh
node --import tsx -e 'import { buildServiceEnvironment } from "./src/daemon/service-env.ts"; import { resolveDaemonServicePathDirs } from "./src/commands/daemon-install-plan.shared.ts"; const env={HOME:"/Users/testuser",PATH:"/Users/testuser/.npm-global/bin:/usr/bin:/bin"}; const argv=["node","/Users/testuser/.npm-global/bin/openclaw","gateway","install"]; const extraPathDirs=resolveDaemonServicePathDirs({nodePath:"/opt/homebrew/opt/node/bin/node",env,argv,platform:"darwin"}); const serviceEnv=buildServiceEnvironment({env,port:18789,platform:"darwin",launchdLabel:"ai.openclaw.gateway",extraPathDirs}); console.log(JSON.stringify({extraPathDirs,PATH:serviceEnv.PATH},null,2));'
```

**Evidence after fix:** Terminal output from the command above:

```json
{
  "extraPathDirs": [
    "/opt/homebrew/opt/node/bin",
    "/Users/testuser/.npm-global/bin"
  ],
  "PATH": "/opt/homebrew/opt/node/bin:/Users/testuser/.npm-global/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
}
```

**Observed result after fix:** The generated service PATH now contains `/Users/testuser/.npm-global/bin`, the directory containing the active `openclaw` command, immediately after the selected Node runtime bin and before the minimal macOS system dirs. A gateway service env generated from this install shape now gives gateway-spawned child processes a PATH that can resolve `openclaw`.

**What was not tested:** I did not install a real macOS LaunchAgent on this machine or use a private user's npm-global install. The proof exercises the same `resolveDaemonServicePathDirs` plus `buildServiceEnvironment` code path used by `openclaw gateway install`, with the user path redacted to `/Users/testuser`.

## Validation
- `node scripts/run-vitest.mjs src/commands/daemon-install-plan.shared.test.ts src/commands/daemon-install-helpers.test.ts src/daemon/service-env.test.ts src/daemon/service-audit.test.ts` (159 tests passed after the rebase)
- `pnpm exec oxfmt --check --threads=1 src/commands/daemon-install-plan.shared.ts src/commands/daemon-install-plan.shared.test.ts src/commands/daemon-install-helpers.ts src/commands/daemon-install-helpers.test.ts src/commands/doctor-gateway-services.ts src/daemon/service-audit.ts src/daemon/service-audit.test.ts`
- `pnpm check:changed`
- `git diff --check origin/main...HEAD`
- `git merge-tree --write-tree HEAD origin/main`

## Collision checks
- Open PR search: `84201`, `PATH missing`, `gateway install`, `service env`, `npm-global`, `resolveDaemonServicePathDirs`, `extraPathDirs` returned no matching open PRs.
- Closed PR search with the same terms also returned no matching prior fix.
