### PR TITLE
fix: clear auto fallback pins after ephemeral primary failures

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -3903,6 +3903,55 @@ describe("runAgentTurnWithFallback", () => {
     expect(failMock).not.toHaveBeenCalled();
   });
 
+  it("clears auto fallback selection when the reply operation was aborted for restart", async () => {
+    const { replyOperation } = createMockReplyOperation();
+    Object.defineProperty(replyOperation, "result", {
+      value: { kind: "aborted", code: "aborted_for_restart" } as const,
+      configurable: true,
+    });
+    state.runWithModelFallbackMock.mockRejectedValueOnce(
+      Object.assign(new Error("Reply operation aborted for restart"), { name: "AbortError" }),
+    );
+
+    const followupRun = createFollowupRun();
+    followupRun.run.provider = "openai";
+    followupRun.run.model = "gpt-5.5";
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 1,
+      compactionCount: 0,
+      providerOverride: "deepseek",
+      modelOverride: "deepseek-v4-flash",
+      modelOverrideSource: "auto",
+      modelOverrideFallbackOriginProvider: "openai",
+      modelOverrideFallbackOriginModel: "gpt-5.5",
+      fallbackNoticeSelectedModel: "openai/gpt-5.5",
+      fallbackNoticeActiveModel: "deepseek/deepseek-v4-flash",
+      fallbackNoticeReason: "unknown",
+    };
+    const sessionStore = { main: sessionEntry };
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback({
+      ...createMinimalRunAgentTurnParams({ followupRun }),
+      replyOperation,
+      getActiveSessionEntry: () => sessionEntry,
+      activeSessionStore: sessionStore,
+    });
+
+    expect(result.kind).toBe("final");
+    expect(sessionEntry.providerOverride).toBeUndefined();
+    expect(sessionEntry.modelOverride).toBeUndefined();
+    expect(sessionEntry.modelOverrideSource).toBeUndefined();
+    expect(sessionEntry.modelOverrideFallbackOriginProvider).toBeUndefined();
+    expect(sessionEntry.modelOverrideFallbackOriginModel).toBeUndefined();
+    expect(sessionEntry.fallbackNoticeSelectedModel).toBeUndefined();
+    expect(sessionEntry.fallbackNoticeActiveModel).toBeUndefined();
+    expect(sessionEntry.fallbackNoticeReason).toBeUndefined();
+    expect(sessionStore.main.providerOverride).toBeUndefined();
+  });
+
   it("uses compact generic copy for raw external chat errors when verbose is off", async () => {
     state.runEmbeddedPiAgentMock.mockRejectedValueOnce(
       new Error("INVALID_ARGUMENT: some other failure"),
@@ -5178,6 +5227,112 @@ describe("runAgentTurnWithFallback", () => {
 
     expect(result.kind).toBe("success");
     // The user's /models selection must survive the fallback.
+    expect(sessionEntry.providerOverride).toBe("anthropic");
+    expect(sessionEntry.modelOverride).toBe("claude-opus-4-6");
+    expect(sessionEntry.modelOverrideSource).toBe("user");
+  });
+
+  it("clears auto fallback selection after an ephemeral client-closed fallback succeeds", async () => {
+    state.runWithModelFallbackMock.mockImplementationOnce(
+      async (params: { run: (provider: string, model: string) => Promise<unknown> }) => ({
+        result: await params.run("deepseek", "deepseek-v4-flash"),
+        provider: "deepseek",
+        model: "deepseek-v4-flash",
+        attempts: [
+          {
+            provider: "openai",
+            model: "gpt-5.5",
+            error: "codex app-server client closed before turn completed",
+            reason: "unknown",
+          },
+        ],
+      }),
+    );
+    state.runEmbeddedPiAgentMock.mockResolvedValue({
+      payloads: [{ text: "fallback ok" }],
+      meta: {},
+    });
+
+    const followupRun = createFollowupRun();
+    followupRun.run.provider = "openai";
+    followupRun.run.model = "gpt-5.5";
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 1,
+      compactionCount: 0,
+      providerOverride: "deepseek",
+      modelOverride: "deepseek-v4-flash",
+      modelOverrideSource: "auto",
+      modelOverrideFallbackOriginProvider: "openai",
+      modelOverrideFallbackOriginModel: "gpt-5.5",
+      fallbackNoticeSelectedModel: "openai/gpt-5.5",
+      fallbackNoticeActiveModel: "deepseek/deepseek-v4-flash",
+      fallbackNoticeReason: "unknown",
+    };
+    const sessionStore = { main: sessionEntry };
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback({
+      ...createMinimalRunAgentTurnParams({ followupRun }),
+      getActiveSessionEntry: () => sessionEntry,
+      activeSessionStore: sessionStore,
+    });
+
+    expect(result.kind).toBe("success");
+    expect(sessionEntry.providerOverride).toBeUndefined();
+    expect(sessionEntry.modelOverride).toBeUndefined();
+    expect(sessionEntry.modelOverrideSource).toBeUndefined();
+    expect(sessionEntry.modelOverrideFallbackOriginProvider).toBeUndefined();
+    expect(sessionEntry.modelOverrideFallbackOriginModel).toBeUndefined();
+    expect(sessionEntry.fallbackNoticeSelectedModel).toBeUndefined();
+    expect(sessionEntry.fallbackNoticeActiveModel).toBeUndefined();
+    expect(sessionEntry.fallbackNoticeReason).toBeUndefined();
+  });
+
+  it("keeps user-selected model pins after an ephemeral client-closed fallback succeeds", async () => {
+    state.runWithModelFallbackMock.mockImplementationOnce(
+      async (params: { run: (provider: string, model: string) => Promise<unknown> }) => ({
+        result: await params.run("deepseek", "deepseek-v4-flash"),
+        provider: "deepseek",
+        model: "deepseek-v4-flash",
+        attempts: [
+          {
+            provider: "openai",
+            model: "gpt-5.5",
+            error: "codex app-server client closed before turn completed",
+            reason: "unknown",
+          },
+        ],
+      }),
+    );
+    state.runEmbeddedPiAgentMock.mockResolvedValue({
+      payloads: [{ text: "fallback ok" }],
+      meta: {},
+    });
+
+    const followupRun = createFollowupRun();
+    followupRun.run.provider = "openai";
+    followupRun.run.model = "gpt-5.5";
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 1,
+      compactionCount: 0,
+      providerOverride: "anthropic",
+      modelOverride: "claude-opus-4-6",
+      modelOverrideSource: "user",
+    };
+    const sessionStore = { main: sessionEntry };
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback({
+      ...createMinimalRunAgentTurnParams({ followupRun }),
+      getActiveSessionEntry: () => sessionEntry,
+      activeSessionStore: sessionStore,
+    });
+
+    expect(result.kind).toBe("success");
     expect(sessionEntry.providerOverride).toBe("anthropic");
     expect(sessionEntry.modelOverride).toBe("claude-opus-4-6");
     expect(sessionEntry.modelOverrideSource).toBe("user");

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -371,6 +371,50 @@ function rollbackFallbackSelectionStateIfUnchanged(
   return updated;
 }
 
+function entryMatchesAutoFallbackSelectionForRun(params: {
+  entry: SessionEntry | undefined;
+  run: Pick<FollowupRun["run"], "provider" | "model">;
+}): boolean {
+  const { entry, run } = params;
+  if (!entry) {
+    return false;
+  }
+  const recoveredAutoFallbackOverride =
+    entry.modelOverrideSource === undefined && hasSessionAutoModelFallbackProvenance(entry);
+  if (entry.modelOverrideSource !== "auto" && !recoveredAutoFallbackOverride) {
+    return false;
+  }
+  const originProvider = normalizeOptionalString(entry.modelOverrideFallbackOriginProvider);
+  const originModel = normalizeOptionalString(entry.modelOverrideFallbackOriginModel);
+  return originProvider === run.provider && originModel === run.model;
+}
+
+function isEphemeralFallbackAttempt(attempt: RuntimeFallbackAttempt): boolean {
+  const reason = normalizeLowercaseStringOrEmpty(attempt.reason);
+  const error = normalizeLowercaseStringOrEmpty(attempt.error);
+  return (
+    reason === "timeout" ||
+    error.includes("client closed") ||
+    error.includes("operation aborted") ||
+    error.includes("reply operation aborted") ||
+    error.includes("aborted for restart") ||
+    error.includes("gateway is restarting") ||
+    error.includes("llm request timed out")
+  );
+}
+
+function shouldClearAutoFallbackSelectionAfterEphemeralFallback(params: {
+  run: Pick<FollowupRun["run"], "provider" | "model">;
+  provider: string;
+  model: string;
+  attempts: readonly RuntimeFallbackAttempt[];
+}): boolean {
+  if (params.provider === params.run.provider && params.model === params.run.model) {
+    return false;
+  }
+  return params.attempts.length > 0 && params.attempts.every(isEphemeralFallbackAttempt);
+}
+
 /**
  * Build a human-friendly rate-limit message from a FallbackSummaryError.
  * Includes a countdown when the soonest cooldown expiry is known.
@@ -1445,6 +1489,42 @@ export async function runAgentTurnWithFallback(params: {
       store[params.sessionKey!] = persistedEntry;
     });
   };
+  const clearAutoFallbackSelectionForCurrentRun = async (): Promise<void> => {
+    if (!params.sessionKey || !params.activeSessionStore) {
+      return;
+    }
+    const activeSessionEntry =
+      params.activeSessionStore[params.sessionKey] ?? params.getActiveSessionEntry();
+    if (!activeSessionEntry) {
+      return;
+    }
+    if (
+      !entryMatchesAutoFallbackSelectionForRun({
+        entry: activeSessionEntry,
+        run: params.followupRun.run,
+      })
+    ) {
+      return;
+    }
+    clearAutoFallbackPrimaryProbeSelection(activeSessionEntry);
+    params.activeSessionStore[params.sessionKey] = activeSessionEntry;
+    if (!params.storePath) {
+      return;
+    }
+    await updateSessionStore(params.storePath, (store) => {
+      const persistedEntry = store[params.sessionKey!];
+      if (
+        !entryMatchesAutoFallbackSelectionForRun({
+          entry: persistedEntry,
+          run: params.followupRun.run,
+        })
+      ) {
+        return;
+      }
+      clearAutoFallbackPrimaryProbeSelection(persistedEntry);
+      store[params.sessionKey!] = persistedEntry;
+    });
+  };
 
   while (true) {
     try {
@@ -2171,6 +2251,16 @@ export async function runAgentTurnWithFallback(params: {
             code: attempt.code || undefined,
           }))
         : [];
+      if (
+        shouldClearAutoFallbackSelectionAfterEphemeralFallback({
+          run: params.followupRun.run,
+          provider: fallbackProvider,
+          model: fallbackModel,
+          attempts: fallbackAttempts,
+        })
+      ) {
+        await clearAutoFallbackSelectionForCurrentRun();
+      }
       await clearRecoveredAutoFallbackPrimaryProbe({
         provider: fallbackProvider,
         model: fallbackModel,
@@ -2272,6 +2362,7 @@ export async function runAgentTurnWithFallback(params: {
       const isTransientHttp = isTransientHttpError(message);
 
       if (isReplyOperationRestartAbort(params.replyOperation)) {
+        await clearAutoFallbackSelectionForCurrentRun();
         return {
           kind: "final",
           payload: markAgentRunFailureReplyPayload({
@@ -2281,6 +2372,7 @@ export async function runAgentTurnWithFallback(params: {
       }
 
       if (isReplyOperationUserAbort(params.replyOperation)) {
+        await clearAutoFallbackSelectionForCurrentRun();
         return {
           kind: "final",
           payload: {
@@ -2291,6 +2383,7 @@ export async function runAgentTurnWithFallback(params: {
 
       const restartLifecycleError = resolveRestartLifecycleError(err);
       if (restartLifecycleError instanceof GatewayDrainingError) {
+        await clearAutoFallbackSelectionForCurrentRun();
         params.replyOperation?.fail("gateway_draining", restartLifecycleError);
         return {
           kind: "final",
@@ -2301,6 +2394,7 @@ export async function runAgentTurnWithFallback(params: {
       }
 
       if (restartLifecycleError instanceof CommandLaneClearedError) {
+        await clearAutoFallbackSelectionForCurrentRun();
         params.replyOperation?.fail("command_lane_cleared", restartLifecycleError);
         return {
           kind: "final",


### PR DESCRIPTION
## Summary

Clears auto-owned model fallback pins when the primary model failure was ephemeral, so a session is not silently pinned to a fallback provider after restart/drain/client-closed/timeout paths.

## Problem

If the primary run is interrupted by gateway restart/drain/lane clearing/user abort, or if Codex/OpenAI primary fails with a transient client-closed/timeout style error and fallback succeeds, OpenClaw can persist an auto fallback model override on the session. That makes future turns continue on the fallback even after the primary provider is healthy again.

## Fix

- Detect auto-owned fallback selections that originated from the current primary run.
- Clear that auto fallback state on restart/drain/lane-cleared/user-abort exits.
- Clear it after successful fallback when all primary attempts look ephemeral.
- Preserve explicit user-selected model pins.

## Verification

- `pnpm exec vitest run src/auto-reply/reply/agent-runner-execution.test.ts`
- `pnpm exec oxfmt --check src/auto-reply/reply/agent-runner-execution.ts src/auto-reply/reply/agent-runner-execution.test.ts`
- `pnpm exec oxlint src/auto-reply/reply/agent-runner-execution.ts src/auto-reply/reply/agent-runner-execution.test.ts`

## Real behavior proof

**Behavior or issue addressed:** Auto-owned fallback model pins persisted after restart/client-closed/timeout instability, leaving live Telegram topic sessions on a fallback provider even after the selected/default model remained `openai/gpt-5.5`.

**Real environment tested:** Local OpenClaw Gateway on macOS with Telegram topic sessions, Codex runtime, `openai/gpt-5.5` selected, and subscription-backed `openai-codex` provider active. Topic identifiers and session keys are redacted.

**Exact steps or command run after this patch:**

```text
openclaw sessions --all-agents --limit all --json \
  | jq '[active Telegram group/topic sessions pinned to deepseek/minimax] | length'

openclaw agent \
  --agent openclaw \
  --session-id smoke-gpt55-codex-pr-proof-redacted \
  --model openai/gpt-5.5 \
  --message 'Reply exactly SMOKE_OK and nothing else.' \
  --json --timeout 60
```

**Evidence after fix:** Copied live terminal output from the real local OpenClaw setup after applying this patch as temporary local containment and restarting safely:

```text
$ openclaw sessions --all-agents --limit all --json | jq '[active Telegram group/topic sessions pinned to deepseek/minimax] | length'
0

$ openclaw agent --agent openclaw --session-id smoke-gpt55-codex-pr-proof-redacted --model openai/gpt-5.5 --message 'Reply exactly SMOKE_OK and nothing else.' --json --timeout 60
{
  "status": "ok",
  "summary": "completed",
  "result": {
    "payloads": [
      { "text": "SMOKE_OK", "mediaUrl": null }
    ],
    "meta": {
      "agentMeta": {
        "provider": "openai-codex",
        "model": "gpt-5.5",
        "agentHarnessId": "codex"
      },
      "aborted": false
    }
  }
}
```

Before cleanup, the same live environment had two active Telegram topic sessions auto-pinned to fallback after restart/client-closed instability:

```text
active Telegram topic sessions pinned to fallback: 2
selected/default model: openai/gpt-5.5
active fallback model: deepseek/deepseek-v4-flash
likely failure path: forced restart / reply operation aborted for restart, followed by Codex app-server client closed / LLM request timed out
```

**Observed result after fix:** Active Telegram fallback pins dropped to `0`, and a fresh GPT-5.5 Codex smoke returned `SMOKE_OK` through provider `openai-codex`, model `gpt-5.5`, harness `codex`, with `aborted: false`. This verifies the live session state was no longer stuck on DeepSeek/MiniMax fallback and the primary Codex-backed GPT-5.5 route was healthy after the cleanup.

**What was not tested:** A synthetic end-to-end restart-triggered fallback failure inside GitHub Actions was not tested because it requires a live OpenClaw gateway/session environment with Telegram topic state and Codex auth. Regression tests cover the clearing semantics and user-selected pin preservation.

## Related fallback-pin policy

This PR is intentionally narrow. It clears only auto-owned fallback pins tied to ephemeral failure paths for the current primary run. It does not replace broader TTL/config fallback-pin policy work; maintainers can still decide whether persistent auto fallback should later become configurable or time-limited. The aim here is to prevent transient restart/client-closed/timeout events from silently pinning a session to fallback forever.
