### PR TITLE
fix(ios): respect iPadOS in Settings platform display string

### DIFF
--- a/apps/ios/Sources/Device/DeviceInfoHelper.swift
+++ b/apps/ios/Sources/Device/DeviceInfoHelper.swift
@@ -19,10 +19,19 @@ enum DeviceInfoHelper {
         return "\(name) \(v.majorVersion).\(v.minorVersion).\(v.patchVersion)"
     }
 
-    /// Always "iOS X.Y.Z" for UI display (e.g. Settings), matching legacy behavior on iPad.
+    /// e.g. "iOS 18.0.0" or "iPadOS 18.0.0" by interface idiom. Used for UI display (e.g. Settings).
+    @MainActor
     static func platformStringForDisplay() -> String {
         let v = ProcessInfo.processInfo.operatingSystemVersion
-        return "iOS \(v.majorVersion).\(v.minorVersion).\(v.patchVersion)"
+        let name = switch UIDevice.current.userInterfaceIdiom {
+        case .pad:
+            "iPadOS"
+        case .phone:
+            "iOS"
+        default:
+            "iOS"
+        }
+        return "\(name) \(v.majorVersion).\(v.minorVersion).\(v.patchVersion)"
     }
 
     /// Device family for display: "iPad", "iPhone", or "iOS".


### PR DESCRIPTION
## Bug

`DeviceInfoHelper.platformStringForDisplay()` hardcoded `"iOS"` for all devices, including iPads. The sibling `platformString()` in the same file already correctly returns `"iPadOS"` on iPad via `userInterfaceIdiom` check, but `platformStringForDisplay()` was left as legacy behavior (as admitted by its own doc comment: "matching legacy behavior on iPad").

**Expected:** iPad users see `"iPadOS X.Y.Z"` in Settings.

**Actual:** iPad users see `"iOS X.Y.Z"`.

## Fix

- Unify the logic by using the same `UIDevice.current.userInterfaceIdiom` switch already present in `platformString()`
- Add `@MainActor` to match `platformString()` semantics (accessing `UIDevice.current` on main thread)
- Update doc comment to remove the legacy admission

## Real behavior proof

**Behavior or issue addressed:** `platformStringForDisplay()` returns wrong platform name on iPad. `platformString()` in the same file already handles this correctly, making the hardcoded `"iOS"` in `platformStringForDisplay()` a clear omission rather than intentional design.

**Real environment tested:** Code-level review only. No physical iPad or simulator available at this time.

**Exact steps to verify (requesting community help):**

1. Build the iOS app from this branch on an iPad or iPad Simulator
2. Navigate to Settings → About → Platform Version
3. Confirm it displays `"iPadOS X.Y.Z"` instead of `"iOS X.Y.Z"`

**What was not tested:** No runtime verification performed yet. The fix is a straightforward logic unification with the existing `platformString()` method, but actual device/simulator confirmation would be appreciated.