### PR TITLE
perf(cli): lazy-load agents actions for help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - CLI/perf: keep `setup --help`, `onboard --help`, and `configure --help` out of the full wizard runtime while preserving the existing help output. (#84488) Thanks @frankekn.
+- CLI/perf: keep `agents --help` out of agents action/runtime imports so help, completion, and command discovery paths avoid loading the full agents runtime. (#84483) Thanks @frankekn.
 
 ## 2026.5.20
 

--- a/src/cli/help-cold-imports.test.ts
+++ b/src/cli/help-cold-imports.test.ts
@@ -150,6 +150,40 @@ vi.mock("../commands/setup.js", () => {
   return { setupCommand: vi.fn(async () => {}) };
 });
 
+vi.mock("../commands/agent-via-gateway.js", () => {
+  loaded.mark("agent-via-gateway-command");
+  return { agentCliCommand: vi.fn(async () => {}) };
+});
+
+vi.mock("../commands/agents.commands.add.js", () => {
+  loaded.mark("agents-add-command");
+  return { agentsAddCommand: vi.fn(async () => {}) };
+});
+
+vi.mock("../commands/agents.commands.bind.js", () => {
+  loaded.mark("agents-bind-command");
+  return {
+    agentsBindingsCommand: vi.fn(async () => {}),
+    agentsBindCommand: vi.fn(async () => {}),
+    agentsUnbindCommand: vi.fn(async () => {}),
+  };
+});
+
+vi.mock("../commands/agents.commands.delete.js", () => {
+  loaded.mark("agents-delete-command");
+  return { agentsDeleteCommand: vi.fn(async () => {}) };
+});
+
+vi.mock("../commands/agents.commands.identity.js", () => {
+  loaded.mark("agents-identity-command");
+  return { agentsSetIdentityCommand: vi.fn(async () => {}) };
+});
+
+vi.mock("../commands/agents.commands.list.js", () => {
+  loaded.mark("agents-list-command");
+  return { agentsListCommand: vi.fn(async () => {}) };
+});
+
 function makeProgram(): Command {
   const program = new Command();
   program.name("openclaw");
@@ -247,5 +281,20 @@ describe("subcommand help cold imports", () => {
 
     expect(loaded.modules).not.toContain("onboard-command");
     expect(loaded.modules).not.toContain("default-runtime");
+  });
+
+  it("keeps agents help out of agent action modules", async () => {
+    const { registerAgentCommands } = await import("./program/register.agent.js");
+    const program = makeProgram();
+
+    registerAgentCommands(program, { agentChannelOptions: "last|telegram|discord" });
+    await expectHelpExit(program, ["agents", "--help"]);
+
+    expect(loaded.modules).not.toContain("agent-via-gateway-command");
+    expect(loaded.modules).not.toContain("agents-add-command");
+    expect(loaded.modules).not.toContain("agents-bind-command");
+    expect(loaded.modules).not.toContain("agents-delete-command");
+    expect(loaded.modules).not.toContain("agents-identity-command");
+    expect(loaded.modules).not.toContain("agents-list-command");
   });
 });

--- a/src/cli/program/register.agent.test.ts
+++ b/src/cli/program/register.agent.test.ts
@@ -36,10 +36,6 @@ vi.mock("../../commands/agent-via-gateway.js", () => ({
   agentCliCommand: mocks.agentCliCommandMock,
 }));
 
-vi.mock("../../commands/agents.js", () => {
-  throw new Error("register.agent must not import the agents barrel");
-});
-
 vi.mock("../../commands/agents.commands.add.js", () => ({
   agentsAddCommand: mocks.agentsAddCommandMock,
 }));

--- a/src/cli/program/register.agent.test.ts
+++ b/src/cli/program/register.agent.test.ts
@@ -36,17 +36,33 @@ vi.mock("../../commands/agent-via-gateway.js", () => ({
   agentCliCommand: mocks.agentCliCommandMock,
 }));
 
-vi.mock("../../commands/agents.js", () => ({
+vi.mock("../../commands/agents.js", () => {
+  throw new Error("register.agent must not import the agents barrel");
+});
+
+vi.mock("../../commands/agents.commands.add.js", () => ({
   agentsAddCommand: mocks.agentsAddCommandMock,
+}));
+
+vi.mock("../../commands/agents.commands.bind.js", () => ({
   agentsBindingsCommand: mocks.agentsBindingsCommandMock,
   agentsBindCommand: mocks.agentsBindCommandMock,
-  agentsDeleteCommand: mocks.agentsDeleteCommandMock,
-  agentsListCommand: mocks.agentsListCommandMock,
-  agentsSetIdentityCommand: mocks.agentsSetIdentityCommandMock,
   agentsUnbindCommand: mocks.agentsUnbindCommandMock,
 }));
 
-vi.mock("../../globals.js", () => ({
+vi.mock("../../commands/agents.commands.delete.js", () => ({
+  agentsDeleteCommand: mocks.agentsDeleteCommandMock,
+}));
+
+vi.mock("../../commands/agents.commands.identity.js", () => ({
+  agentsSetIdentityCommand: mocks.agentsSetIdentityCommandMock,
+}));
+
+vi.mock("../../commands/agents.commands.list.js", () => ({
+  agentsListCommand: mocks.agentsListCommandMock,
+}));
+
+vi.mock("../../global-state.js", () => ({
   setVerbose: mocks.setVerboseMock,
 }));
 

--- a/src/cli/program/register.agent.ts
+++ b/src/cli/program/register.agent.ts
@@ -1,26 +1,68 @@
 import type { Command } from "commander";
-import { agentCliCommand } from "../../commands/agent-via-gateway.js";
-import {
-  agentsAddCommand,
-  agentsBindingsCommand,
-  agentsBindCommand,
-  agentsDeleteCommand,
-  agentsListCommand,
-  agentsSetIdentityCommand,
-  agentsUnbindCommand,
-} from "../../commands/agents.js";
-import { setVerbose } from "../../globals.js";
 import { defaultRuntime } from "../../runtime.js";
 import { normalizeLowercaseStringOrEmpty } from "../../shared/string-coerce.js";
 import { formatDocsLink } from "../../terminal/links.js";
 import { theme } from "../../terminal/theme.js";
 import { runCommandWithRuntime } from "../cli-utils.js";
 import { hasExplicitOptions } from "../command-options.js";
-import { createDefaultDeps } from "../deps.js";
 import { formatHelpExamples } from "../help-format.js";
 import { collectOption } from "./helpers.js";
 
-export function registerAgentCommands(program: Command, args: { agentChannelOptions: string }) {
+type AgentViaGatewayModule = typeof import("../../commands/agent-via-gateway.js");
+type AgentsAddModule = typeof import("../../commands/agents.commands.add.js");
+type AgentsBindModule = typeof import("../../commands/agents.commands.bind.js");
+type AgentsDeleteModule = typeof import("../../commands/agents.commands.delete.js");
+type AgentsIdentityModule = typeof import("../../commands/agents.commands.identity.js");
+type AgentsListModule = typeof import("../../commands/agents.commands.list.js");
+type CliDepsModule = typeof import("../deps.js");
+type GlobalStateModule = typeof import("../../global-state.js");
+
+async function loadAgentCliCommand(): Promise<AgentViaGatewayModule["agentCliCommand"]> {
+  return (await import("../../commands/agent-via-gateway.js")).agentCliCommand;
+}
+
+async function loadAgentsAddCommand(): Promise<AgentsAddModule["agentsAddCommand"]> {
+  return (await import("../../commands/agents.commands.add.js")).agentsAddCommand;
+}
+
+async function loadAgentsBindCommand(): Promise<AgentsBindModule["agentsBindCommand"]> {
+  return (await import("../../commands/agents.commands.bind.js")).agentsBindCommand;
+}
+
+async function loadAgentsBindingsCommand(): Promise<AgentsBindModule["agentsBindingsCommand"]> {
+  return (await import("../../commands/agents.commands.bind.js")).agentsBindingsCommand;
+}
+
+async function loadAgentsUnbindCommand(): Promise<AgentsBindModule["agentsUnbindCommand"]> {
+  return (await import("../../commands/agents.commands.bind.js")).agentsUnbindCommand;
+}
+
+async function loadAgentsDeleteCommand(): Promise<AgentsDeleteModule["agentsDeleteCommand"]> {
+  return (await import("../../commands/agents.commands.delete.js")).agentsDeleteCommand;
+}
+
+async function loadAgentsSetIdentityCommand(): Promise<
+  AgentsIdentityModule["agentsSetIdentityCommand"]
+> {
+  return (await import("../../commands/agents.commands.identity.js")).agentsSetIdentityCommand;
+}
+
+async function loadAgentsListCommand(): Promise<AgentsListModule["agentsListCommand"]> {
+  return (await import("../../commands/agents.commands.list.js")).agentsListCommand;
+}
+
+async function loadCreateDefaultDeps(): Promise<CliDepsModule["createDefaultDeps"]> {
+  return (await import("../deps.js")).createDefaultDeps;
+}
+
+async function loadSetVerbose(): Promise<GlobalStateModule["setVerbose"]> {
+  return (await import("../../global-state.js")).setVerbose;
+}
+
+export function registerAgentCommands(
+  program: Command,
+  args: { agentChannelOptions: string },
+): void {
   program
     .command("agent")
     .description("Run an agent turn via the Gateway (use --local for embedded)")
@@ -77,13 +119,16 @@ ${formatHelpExamples([
 
 ${theme.muted("Docs:")} ${formatDocsLink("/cli/agent", "docs.openclaw.ai/cli/agent")}`,
     )
-    .action(async (opts) => {
+    .action(async (opts): Promise<void> => {
       const verboseLevel =
         typeof opts.verbose === "string" ? normalizeLowercaseStringOrEmpty(opts.verbose) : "";
-      setVerbose(verboseLevel === "on");
-      // Build default deps (keeps parity with other commands; future-proofing).
-      const deps = createDefaultDeps();
       await runCommandWithRuntime(defaultRuntime, async () => {
+        const setVerbose = await loadSetVerbose();
+        setVerbose(verboseLevel === "on");
+        // Build default deps (keeps parity with other commands; future-proofing).
+        const createDefaultDeps = await loadCreateDefaultDeps();
+        const deps = createDefaultDeps();
+        const agentCliCommand = await loadAgentCliCommand();
         await agentCliCommand(opts, defaultRuntime, deps);
       });
     });
@@ -102,8 +147,9 @@ ${theme.muted("Docs:")} ${formatDocsLink("/cli/agent", "docs.openclaw.ai/cli/age
     .description("List configured agents")
     .option("--json", "Output JSON instead of text", false)
     .option("--bindings", "Include routing bindings", false)
-    .action(async (opts) => {
+    .action(async (opts): Promise<void> => {
       await runCommandWithRuntime(defaultRuntime, async () => {
+        const agentsListCommand = await loadAgentsListCommand();
         await agentsListCommand(
           { json: Boolean(opts.json), bindings: Boolean(opts.bindings) },
           defaultRuntime,
@@ -116,8 +162,9 @@ ${theme.muted("Docs:")} ${formatDocsLink("/cli/agent", "docs.openclaw.ai/cli/age
     .description("List routing bindings")
     .option("--agent <id>", "Filter by agent id")
     .option("--json", "Output JSON instead of text", false)
-    .action(async (opts) => {
+    .action(async (opts): Promise<void> => {
       await runCommandWithRuntime(defaultRuntime, async () => {
+        const agentsBindingsCommand = await loadAgentsBindingsCommand();
         await agentsBindingsCommand(
           {
             agent: opts.agent as string | undefined,
@@ -139,8 +186,9 @@ ${theme.muted("Docs:")} ${formatDocsLink("/cli/agent", "docs.openclaw.ai/cli/age
       [],
     )
     .option("--json", "Output JSON summary", false)
-    .action(async (opts) => {
+    .action(async (opts): Promise<void> => {
       await runCommandWithRuntime(defaultRuntime, async () => {
+        const agentsBindCommand = await loadAgentsBindCommand();
         await agentsBindCommand(
           {
             agent: opts.agent as string | undefined,
@@ -159,8 +207,9 @@ ${theme.muted("Docs:")} ${formatDocsLink("/cli/agent", "docs.openclaw.ai/cli/age
     .option("--bind <channel[:accountId]>", "Binding to remove (repeatable)", collectOption, [])
     .option("--all", "Remove all bindings for this agent", false)
     .option("--json", "Output JSON summary", false)
-    .action(async (opts) => {
+    .action(async (opts): Promise<void> => {
       await runCommandWithRuntime(defaultRuntime, async () => {
+        const agentsUnbindCommand = await loadAgentsUnbindCommand();
         await agentsUnbindCommand(
           {
             agent: opts.agent as string | undefined,
@@ -182,7 +231,7 @@ ${theme.muted("Docs:")} ${formatDocsLink("/cli/agent", "docs.openclaw.ai/cli/age
     .option("--bind <channel[:accountId]>", "Route channel binding (repeatable)", collectOption, [])
     .option("--non-interactive", "Disable prompts; requires --workspace", false)
     .option("--json", "Output JSON summary", false)
-    .action(async (name, opts, command) => {
+    .action(async (name, opts, command): Promise<void> => {
       await runCommandWithRuntime(defaultRuntime, async () => {
         const hasFlags = hasExplicitOptions(command, [
           "workspace",
@@ -191,6 +240,7 @@ ${theme.muted("Docs:")} ${formatDocsLink("/cli/agent", "docs.openclaw.ai/cli/age
           "bind",
           "nonInteractive",
         ]);
+        const agentsAddCommand = await loadAgentsAddCommand();
         await agentsAddCommand(
           {
             name: typeof name === "string" ? name : undefined,
@@ -238,8 +288,9 @@ ${formatHelpExamples([
 ])}
 `,
     )
-    .action(async (opts) => {
+    .action(async (opts): Promise<void> => {
       await runCommandWithRuntime(defaultRuntime, async () => {
+        const agentsSetIdentityCommand = await loadAgentsSetIdentityCommand();
         await agentsSetIdentityCommand(
           {
             agent: opts.agent as string | undefined,
@@ -262,8 +313,9 @@ ${formatHelpExamples([
     .description("Delete an agent and prune workspace/state")
     .option("--force", "Skip confirmation", false)
     .option("--json", "Output JSON summary", false)
-    .action(async (id, opts) => {
+    .action(async (id, opts): Promise<void> => {
       await runCommandWithRuntime(defaultRuntime, async () => {
+        const agentsDeleteCommand = await loadAgentsDeleteCommand();
         await agentsDeleteCommand(
           {
             id: String(id),
@@ -275,8 +327,9 @@ ${formatHelpExamples([
       });
     });
 
-  agents.action(async () => {
+  agents.action(async (): Promise<void> => {
     await runCommandWithRuntime(defaultRuntime, async () => {
+      const agentsListCommand = await loadAgentsListCommand();
       await agentsListCommand({}, defaultRuntime);
     });
   });

--- a/src/cli/program/routed-command-definitions.ts
+++ b/src/cli/program/routed-command-definitions.ts
@@ -20,6 +20,7 @@ import {
 type RouteArgParser<TArgs> = (argv: string[]) => TArgs | null;
 
 type ParsedRouteArgs<TParse extends RouteArgParser<unknown>> = Exclude<ReturnType<TParse>, null>;
+type AgentsListCommandModule = typeof import("../../commands/agents.commands.list.js");
 type ConfigCliModule = typeof import("../config-cli.js");
 type ModelsListCommandModule = typeof import("../../commands/models/list.list-command.js");
 type ModelsStatusCommandModule = typeof import("../../commands/models/list.status-command.js");
@@ -41,6 +42,9 @@ function defineRoutedCommand<TParse extends RouteArgParser<unknown>>(
 }
 
 const configCliLoader = createLazyImportLoader<ConfigCliModule>(() => import("../config-cli.js"));
+const agentsListCommandLoader = createLazyImportLoader<AgentsListCommandModule>(
+  () => import("../../commands/agents.commands.list.js"),
+);
 const modelsListCommandLoader = createLazyImportLoader<ModelsListCommandModule>(
   () => import("../../commands/models/list.list-command.js"),
 );
@@ -50,6 +54,10 @@ const modelsStatusCommandLoader = createLazyImportLoader<ModelsStatusCommandModu
 
 function loadConfigCli(): Promise<ConfigCliModule> {
   return configCliLoader.load();
+}
+
+function loadAgentsListCommand(): Promise<AgentsListCommandModule> {
+  return agentsListCommandLoader.load();
 }
 
 function loadModelsListCommand(): Promise<ModelsListCommandModule> {
@@ -105,7 +113,7 @@ export const routedCommandDefinitions = {
   "agents-list": defineRoutedCommand({
     parseArgs: parseAgentsListRouteArgs,
     runParsedArgs: async (args) => {
-      const { agentsListCommand } = await import("../../commands/agents.js");
+      const { agentsListCommand } = await loadAgentsListCommand();
       await agentsListCommand(args, defaultRuntime);
     },
   }),

--- a/src/cli/program/routes.test.ts
+++ b/src/cli/program/routes.test.ts
@@ -53,10 +53,6 @@ vi.mock("../../commands/channels/status.js", () => ({
   channelsStatusCommand: channelsStatusCommandMock,
 }));
 
-vi.mock("../../commands/agents.js", () => {
-  throw new Error("routed agents list must not import the agents barrel");
-});
-
 vi.mock("../../commands/agents.commands.list.js", () => ({
   agentsListCommand: agentsListCommandMock,
 }));

--- a/src/cli/program/routes.test.ts
+++ b/src/cli/program/routes.test.ts
@@ -53,7 +53,11 @@ vi.mock("../../commands/channels/status.js", () => ({
   channelsStatusCommand: channelsStatusCommandMock,
 }));
 
-vi.mock("../../commands/agents.js", () => ({
+vi.mock("../../commands/agents.js", () => {
+  throw new Error("routed agents list must not import the agents barrel");
+});
+
+vi.mock("../../commands/agents.commands.list.js", () => ({
   agentsListCommand: agentsListCommandMock,
 }));
 

--- a/src/commands/agents.add.test.ts
+++ b/src/commands/agents.add.test.ts
@@ -78,8 +78,7 @@ vi.mock("../wizard/clack-prompter.js", () => ({
 }));
 
 import { WizardCancelledError } from "../wizard/prompts.js";
-import { testing } from "./agents.commands.add.js";
-import { agentsAddCommand } from "./agents.js";
+import { agentsAddCommand, testing } from "./agents.commands.add.js";
 
 const runtime = createTestRuntime();
 

--- a/src/commands/agents.delete.test.ts
+++ b/src/commands/agents.delete.test.ts
@@ -35,7 +35,7 @@ vi.mock("../process/exec.js", () => ({
   runCommandWithTimeout: processMocks.runCommandWithTimeout,
 }));
 
-import { agentsDeleteCommand } from "./agents.js";
+import { agentsDeleteCommand } from "./agents.commands.delete.js";
 
 const runtime = createTestRuntime();
 

--- a/src/commands/agents.identity.test.ts
+++ b/src/commands/agents.identity.test.ts
@@ -22,7 +22,7 @@ vi.mock("../config/config.js", async () => ({
   replaceConfigFile: configMocks.replaceConfigFile,
 }));
 
-import { agentsSetIdentityCommand } from "./agents.js";
+import { agentsSetIdentityCommand } from "./agents.commands.identity.js";
 
 const runtime = createTestRuntime();
 type ConfigWritePayload = {

--- a/src/commands/agents.test.ts
+++ b/src/commands/agents.test.ts
@@ -1,13 +1,8 @@
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
-import {
-  applyAgentBindings,
-  applyAgentConfig,
-  buildAgentSummaries,
-  pruneAgentConfig,
-  removeAgentBindings,
-} from "./agents.js";
+import { applyAgentBindings, removeAgentBindings } from "./agents.bindings.js";
+import { applyAgentConfig, buildAgentSummaries, pruneAgentConfig } from "./agents.config.js";
 
 function requireAgentSummary(
   summaries: ReturnType<typeof buildAgentSummaries>,

--- a/src/commands/agents.ts
+++ b/src/commands/agents.ts
@@ -1,7 +1,0 @@
-export * from "./agents.bindings.js";
-export * from "./agents.commands.bind.js";
-export * from "./agents.commands.add.js";
-export * from "./agents.commands.delete.js";
-export * from "./agents.commands.identity.js";
-export * from "./agents.commands.list.js";
-export * from "./agents.config.js";


### PR DESCRIPTION
## Summary

- Problem: `openclaw agents --help` imported the full agents action barrel and paid heavy startup cost on a help-only path.
- Solution: keep the Commander skeleton static, but lazy-load agent and agents action modules only from their action callbacks.
- What changed: direct lazy imports for agents add/list/bind/unbind/delete/set-identity and agent run; `agents-list` routed command now imports the list module directly; cold-import tests cover `agents --help`.
- What did NOT change (scope boundary): no agents command behavior, docs link, option, routing, or generic subcommand help changes.

## Motivation

- Before this patch, `agents --help` measured at ~1.38s average and ~522MB RSS on the built CLI in this worktree, while root/browser help stayed ~23ms/~46MB.
- The import graph made command discovery/help paths pay for agents action/runtime modules even when no action runs.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #
- [ ] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `openclaw agents --help` cold-start import/runtime cost.
- Real environment tested: local macOS worktree, Node v24.14.0, built `openclaw.mjs` entry.
- Exact steps or command run after this patch: `pnpm build`; `node dist/entry.js agents --help`; `pnpm test:startup:bench -- --case agentsHelp --runs 3 --warmup 1 --json --output .artifacts/perf-agents-help-after.json`.
- Evidence after fix: benchmark after patch averaged 361.2ms, p95 433.4ms, RSS avg 321.7MB.
- Observed result after fix: help output unchanged and startup/RSS materially reduced from before baseline.
- What was not tested: full `pnpm test` suite.
- Before evidence: before benchmark averaged 1382.0ms, p95 1423.1ms, RSS avg 522.4MB.

## Root Cause (if applicable)

- Root cause: `register.agent.ts` statically imported `agent-via-gateway` and the `commands/agents.ts` barrel; the barrel re-exported add/delete/bind/list/config modules, so help registration loaded action/runtime modules.
- Missing detection / guardrail: no cold-import test covered `agents --help`.
- Contributing context: root/browser help have precomputed fast paths; agents help relies on the general registrar path.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/cli/help-cold-imports.test.ts`, `src/cli/program/register.agent.test.ts`.
- Scenario the test should lock in: `agents --help` does not import agent/agents action modules, while action paths still call the same command functions.
- Why this is the smallest reliable guardrail: it tests the registrar import boundary directly without process-level timing noise.
- Existing test that already covers this (if any): none for agents help cold imports.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

`openclaw agents --help` starts faster and uses less memory. Help text and command behavior are unchanged.

## Diagram (if applicable)

```text
Before:
agents --help -> register.agent.ts -> commands/agents.ts barrel -> action modules loaded

After:
agents --help -> register.agent.ts -> help skeleton only
action run  -> callback -> direct import of exactly one action module
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node v24.14.0, local pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. `pnpm build`
2. `node dist/entry.js agents --help > .artifacts/agents-help-after.txt`
3. `diff -u .artifacts/agents-help-before.txt .artifacts/agents-help-after.txt`
4. `pnpm test:startup:bench -- --case agentsHelp --runs 3 --warmup 1 --json --output .artifacts/perf-agents-help-after.json`

### Expected

- Help output unchanged.
- `agents --help` avoids loading heavy agents action modules.
- Startup time/RSS materially drop.

### Actual

- Help output diff was empty.
- `agents --help` benchmark improved from 1382.0ms avg / 522.4MB RSS avg to 361.2ms avg / 321.7MB RSS avg.
- Cold-import tests pass.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [x] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm test src/cli/help-cold-imports.test.ts src/cli/program/register.agent.test.ts src/cli/run-main.exit.test.ts -- --reporter=default`
  - `pnpm build`
  - `diff -u .artifacts/agents-help-before.txt .artifacts/agents-help-after.txt`
  - `pnpm test:startup:bench -- --case agentsHelp --runs 3 --warmup 1 --json --output .artifacts/perf-agents-help-after.json`
  - `pnpm tsgo`
  - `pnpm check:changed`
- Edge cases checked: parent `agents` default action still calls list; lazy-loaded action failures still route through runtime error handling; routed `agents-list` avoids the barrel.
- What you did **not** verify: full test suite and CI.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: lazy imports could accidentally route an action to the wrong module.
  - Mitigation: existing registrar tests now mock direct module paths and verify each action still calls the expected command function.