### PR TITLE
feat(session-fork): raise default cap to 1M, add env override

### DIFF
--- a/src/auto-reply/reply/session-fork.ts
+++ b/src/auto-reply/reply/session-fork.ts
@@ -5,8 +5,23 @@ import { createLazyImportLoader } from "../../shared/lazy-promise.js";
  * Default max parent token count beyond which thread/session parent forking is skipped.
  * This prevents new thread sessions from inheriting near-full parent context.
  * See #26905.
+ *
+ * Bumped from the original 100k default to 1M to match modern frontier-model
+ * context windows. Can be overridden via the OPENCLAW_PARENT_FORK_MAX_TOKENS
+ * environment variable (set to 0 to disable the cap entirely).
  */
-const DEFAULT_PARENT_FORK_MAX_TOKENS = 100_000;
+const DEFAULT_PARENT_FORK_MAX_TOKENS = 1_000_000;
+
+function resolveParentForkMaxTokens(): number {
+  const raw = process.env.OPENCLAW_PARENT_FORK_MAX_TOKENS;
+  if (raw !== undefined && raw !== "") {
+    const parsed = Number(raw);
+    if (Number.isFinite(parsed) && parsed >= 0) {
+      return Math.floor(parsed);
+    }
+  }
+  return DEFAULT_PARENT_FORK_MAX_TOKENS;
+}
 const sessionForkRuntimeLoader = createLazyImportLoader(() => import("./session-fork.runtime.js"));
 
 export type ParentForkDecision =
@@ -41,7 +56,10 @@ export async function resolveParentForkDecision(params: {
   parentEntry: SessionEntry;
   storePath: string;
 }): Promise<ParentForkDecision> {
-  const maxTokens = DEFAULT_PARENT_FORK_MAX_TOKENS;
+  const maxTokens = resolveParentForkMaxTokens();
+  if (maxTokens === 0) {
+    return { status: "fork", maxTokens };
+  }
   const parentTokens = await resolveParentForkTokenCount({
     parentEntry: params.parentEntry,
     storePath: params.storePath,


### PR DESCRIPTION
## Problem

The parent-fork token cap was hardcoded to 100k in #26905 and then made non-configurable in 10b89a3b55 ("refactor: remove parent fork config knob", 2026-05-02). With modern frontier-model context windows commonly at 1M tokens (Claude, GPT-5, Gemini), 100k is now an aggressive lower bound that forces nearly all nontrivial subagent spawns into isolated context — even when the parent session would fit comfortably inside the worker model's actual context window.

Concretely: a coding orchestrator session at ~169k tokens cannot fork its context to a subagent worker, even though the worker model has 9× more room available. The result is fall-through to isolated context, which silently loses task continuity the spawning agent intended to provide.

## Fix

- Raise `DEFAULT_PARENT_FORK_MAX_TOKENS` from 100,000 → 1,000,000 to match current frontier-model context windows.
- Add an `OPENCLAW_PARENT_FORK_MAX_TOKENS` environment variable override.
  - Set to a positive integer to override the default.
  - Set to `0` to disable the cap entirely (existing behavior of `maxTokens <= 0` is preserved).
- Otherwise behavior is unchanged: parents over the cap still fall back to isolated context with the existing skip message.

## Why env var, not full config restore

The original config knob (`session.parentForkMaxTokens`) touched 18+ files including schema generation. This PR is the minimal change that solves the practical problem (subagents getting forced to isolated context too aggressively) while restoring tunability for operators who need it. A fuller schema-based restore can follow if desired.

## Testing

No new tests added; existing logic paths are preserved. The env var is a thin opt-in override around the existing `maxTokens` resolution.

Co-authored-by: Jun <flashosophy@github>