### PR TITLE
fix(codex): keep interrupted turns visible-answer eligible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ Docs: https://docs.openclaw.ai
 - Agents/config: keep non-Google provider model refs from being rewritten by Google Gemini preview-id normalization. (#84762) Thanks @zhangguiping-xydt.
 - Installer: require a real controlling terminal before launching onboarding so headless `curl | bash` installs finish cleanly after installing the CLI.
 - Agents/Codex: promote a completed final assistant response when a prompt timeout races Codex app-server completion instead of returning an empty timeout envelope. Refs #84516.
+- Codex app-server: keep interrupted turn statuses from being treated as OpenClaw aborts by themselves, so tool-only turns remain eligible for no-visible-answer recovery. Fixes #84492.
 - Agents: cap heartbeat model bleed context hints by the stored session window when runtime model metadata is unavailable, so overflow recovery advice does not suggest a larger window than the active session actually has.
 - Control UI/Web Push: use `https://openclaw.ai` as the generated default VAPID subject instead of the old localhost mailbox so iOS PWA push setup uses an Apple-acceptable subject when `OPENCLAW_VAPID_SUBJECT` is unset. Fixes #83134. (#83317) Thanks @IWhatsskill.
 - Control UI: distinguish inherited thinking-off settings from explicit Off selections so the thinking selector no longer shows two identical Off rows. (#85223) Thanks @amknight.

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -252,11 +252,15 @@ function rateLimitsUpdated(resetsAt: number): ProjectorNotification {
 }
 
 function turnCompleted(items: unknown[] = []): ProjectorNotification {
+  return turnWithStatus("completed", items);
+}
+
+function turnWithStatus(status: string, items: unknown[] = []): ProjectorNotification {
   return {
     method: "turn/completed",
     params: {
       threadId: THREAD_ID,
-      turn: { id: TURN_ID, status: "completed", items },
+      turn: { id: TURN_ID, status, items },
     },
   } as ProjectorNotification;
 }
@@ -586,6 +590,79 @@ describe("CodexAppServerEventProjector", () => {
 
     expect(result.assistantTexts).toEqual([]);
     expect(result.lastAssistant).toBeUndefined();
+  });
+
+  it("does not treat app-server interrupted status as a user cancellation by itself", async () => {
+    const projector = await createProjector();
+
+    await projector.handleNotification(turnWithStatus("interrupted"));
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+
+    expect(result.aborted).toBe(false);
+    expect(result.externalAbort).toBe(false);
+    expect(result.timedOut).toBe(false);
+    expect(result.promptError).toBeNull();
+    expect(result.assistantTexts).toEqual([]);
+    expect(result.lastAssistant).toBeUndefined();
+  });
+
+  it("keeps sparse successful bash output eligible for the no-visible-answer guard", async () => {
+    const projector = await createProjector();
+
+    await projector.handleNotification(
+      turnWithStatus("interrupted", [
+        {
+          type: "commandExecution",
+          id: "cmd-empty-output",
+          command:
+            "ps -eo pid,ppid,stat,cmd | rg 'venv-roadmap|pytest|run_security_contract_validation|validate_public_install|git push|apply_patch' || true",
+          cwd: "/workspace",
+          processId: null,
+          source: "agent",
+          status: "completed",
+          commandActions: [],
+          aggregatedOutput: "",
+          exitCode: 0,
+          durationMs: 42,
+        },
+      ]),
+    );
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+
+    expect(result.aborted).toBe(false);
+    expect(result.assistantTexts).toEqual([]);
+    expect(result.toolMetas).toEqual([
+      expect.objectContaining({ toolName: "bash", meta: expect.stringContaining("workspace") }),
+    ]);
+  });
+
+  it("keeps explicit cancellation marked aborted for interrupted tool-only turns", async () => {
+    const projector = await createProjector();
+    projector.markAborted();
+
+    await projector.handleNotification(
+      turnWithStatus("interrupted", [
+        {
+          type: "commandExecution",
+          id: "cmd-cancelled",
+          command: "/bin/bash -lc true",
+          cwd: "/workspace",
+          processId: null,
+          source: "agent",
+          status: "completed",
+          commandActions: [],
+          aggregatedOutput: "",
+          exitCode: 0,
+          durationMs: 12,
+        },
+      ]),
+    );
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+    expect(result.aborted).toBe(true);
+    expect(result.assistantTexts).toEqual([]);
   });
 
   it("does not fail a completed reply after a retryable app-server error notification", async () => {

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -313,7 +313,6 @@ export class CodexAppServerEventProjector {
       messagesSnapshot.push(attachCodexMirrorIdentity(lastAssistant, `${turnId}:assistant`));
     }
     const turnFailed = this.completedTurn?.status === "failed";
-    const turnInterrupted = this.completedTurn?.status === "interrupted";
     const promptError =
       this.promptError ??
       (turnFailed ? (this.completedTurn?.error?.message ?? "codex app-server turn failed") : null);
@@ -331,7 +330,7 @@ export class CodexAppServerEventProjector {
       this.sideEffectingToolItemIds.size > 0 ||
       this.sideEffectingDynamicToolCallIds.size > 0;
     return {
-      aborted: this.aborted || turnInterrupted,
+      aborted: this.aborted,
       externalAbort: false,
       timedOut: false,
       idleTimedOut: false,
@@ -660,9 +659,6 @@ export class CodexAppServerEventProjector {
       return;
     }
     this.completedTurn = turn;
-    if (turn.status === "interrupted") {
-      this.aborted = true;
-    }
     if (turn.status === "failed") {
       this.promptError =
         formatCodexUsageLimitErrorMessage({

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -7811,6 +7811,33 @@ describe("runCodexAppServerAttempt", () => {
     expect(harness.request.mock.calls.some(([method]) => method === "turn/interrupt")).toBe(false);
   });
 
+  it("keeps upstream cancellation aborted when Codex completes the turn as interrupted", async () => {
+    const harness = createStartedThreadHarness();
+    const abortController = new AbortController();
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+    params.abortSignal = abortController.signal;
+    const run = runCodexAppServerAttempt(params, { turnTerminalIdleTimeoutMs: 60_000 });
+
+    await harness.waitForMethod("turn/start");
+    abortController.abort("user_cancelled");
+    await harness.notify({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        turn: { id: "turn-1", status: "interrupted" },
+      },
+    });
+
+    const result = await run;
+    expect(result.aborted).toBe(true);
+    expect(result.timedOut).toBe(false);
+    expect(result.promptError).toBeNull();
+  });
+
   it("releases completion when the app-server client closes during an active turn", async () => {
     const harness = createStartedThreadHarness();
     const run = runCodexAppServerAttempt(

--- a/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
+++ b/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
@@ -1235,6 +1235,45 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
     ).toBe(false);
   });
 
+  it("surfaces no-visible-answer recovery for app-server interrupted tool-only output", () => {
+    const interruptedToolOnlyAttempt = makeAttemptResult({
+      assistantTexts: [],
+      toolMetas: [{ toolName: "bash", meta: "workspace" }],
+      messagesSnapshot: [
+        {
+          role: "user",
+          content: "check running processes",
+          timestamp: 1,
+        },
+        {
+          role: "toolResult",
+          content: "",
+          isError: false,
+          details: { aggregated: "" },
+          timestamp: 2,
+        } as unknown as EmbeddedRunAttemptResult["messagesSnapshot"][number],
+      ],
+    });
+
+    const incompleteTurnText = resolveIncompleteTurnPayloadText({
+      payloadCount: interruptedToolOnlyAttempt.assistantTexts.length,
+      aborted: false,
+      timedOut: false,
+      attempt: interruptedToolOnlyAttempt,
+    });
+
+    expect(incompleteTurnText).toContain("couldn't generate a response");
+
+    const explicitCancellationText = resolveIncompleteTurnPayloadText({
+      payloadCount: interruptedToolOnlyAttempt.assistantTexts.length,
+      aborted: true,
+      timedOut: false,
+      attempt: interruptedToolOnlyAttempt,
+    });
+
+    expect(explicitCancellationText).toBeNull();
+  });
+
   it("detects tool-use terminal turn with pre-tool text as incomplete (#76477)", () => {
     // When the last assistant message ended with stopReason=toolUse, pre-tool
     // text alone must not suppress the incomplete-turn guard. The model
@@ -2096,6 +2135,42 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
 
     expect(retryInstruction).toBe(EMPTY_RESPONSE_RETRY_INSTRUCTION);
     expect(DEFAULT_EMPTY_RESPONSE_RETRY_LIMIT).toBe(1);
+  });
+
+  it("surfaces empty Codex app-server replies after successful sparse bash output", () => {
+    const incompleteTurnText = resolveIncompleteTurnPayloadText({
+      payloadCount: 0,
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: [],
+        toolMetas: [{ toolName: "bash", meta: "exit=0" }],
+        messagesSnapshot: [
+          {
+            role: "toolResult",
+            content: [{ type: "text", text: "" }],
+            details: { aggregated: "" },
+          } as unknown as EmbeddedRunAttemptResult["messagesSnapshot"][number],
+          {
+            role: "assistant",
+            stopReason: "stop",
+            provider: "openai-codex",
+            model: "gpt-5.5",
+            content: [{ type: "text", text: "" }],
+          } as unknown as EmbeddedRunAttemptResult["messagesSnapshot"][number],
+        ],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "openai-codex",
+          model: "gpt-5.5",
+          content: [{ type: "text", text: "" }],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    });
+
+    expect(incompleteTurnText).toContain("couldn't generate a response");
+    expect(incompleteTurnText).toContain("verify before retrying");
   });
 
   it("retries generic empty Bedrock Converse turns without visible text", () => {


### PR DESCRIPTION
## Summary

- Problem: Codex app-server `turn.status: "interrupted"` was projected as an OpenClaw abort even when OpenClaw did not explicitly cancel the run.
- Solution: Keep app-server interrupted as terminal app-server state, but do not map it to OpenClaw `aborted` unless OpenClaw explicitly called `markAborted()` or `markTimedOut()`.
- What changed: Added projector and runner regressions for interrupted/tool-only/no-visible-answer Codex turns, including sparse successful bash output.
- What did NOT change (scope boundary): This did not treat every interrupted turn as success, did not synthesize final assistant text, did not disable cancellation, and did not change failed-turn error handling.

## Motivation

- Codex-backed dashboard turns can appear to stop after tool output without delivering the final visible assistant answer.
- The existing incomplete-turn/no-visible-answer guard was bypassed because the app-server `interrupted` terminal status was mapped to `aborted: true`.
- This materially affects UX for Codex-backed OpenClaw usage: the user sees tool-only progress and then needs a continuation turn instead of receiving the answer that the original user-facing turn owed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #84492
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Codex app-server interrupted turn status no longer suppresses no-visible-answer handling for user-facing turns.
- Real environment tested: Local OpenClaw dev checkout rebased on `origin/main` plus Crabbox static SSH Linux VM. Private host/user/workroot values were redacted.
- Exact steps or command run after this patch:

```shell
crabbox run --provider ssh --target linux --static-host <redacted-lab-host> \
  --static-user <redacted-user> --static-port 22 \
  --static-work-root <redacted-workroot> --shell -- \
  'export PATH="$HOME/.local/bin:$PATH"; node --version; pnpm --version;
   pnpm install --frozen-lockfile --ignore-scripts;
   CI=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts \
     extensions/codex/src/app-server/event-projector.test.ts \
     -t "app-server interrupted status|sparse successful bash output";
   CI=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-pi-embedded.config.ts \
     src/agents/pi-embedded-runner/run.incomplete-turn.test.ts \
     -t "sparse bash output"'
```

- Evidence after fix:

```shell
event-projector.test.ts: Test Files 1 passed; Tests 2 passed | 58 skipped
run.incomplete-turn.test.ts: Test Files 1 passed; Tests 1 passed | 95 skipped
run summary sync=2.536s command=32.891s total=35.452s exit=0
lease cleanup stopped=true policy=auto
```

- Observed result after fix: The focused interrupted-turn and sparse-bash regressions passed remotely through Crabbox.
- What was not tested: A full dashboard browser interaction was not run. Full monorepo tests were not run.
- Before evidence:

```shell
FAIL extensions/codex/src/app-server/event-projector.test.ts > CodexAppServerEventProjector > does not treat app-server interrupted status as a user cancellation by itself
AssertionError: expected true to be false
```

## Root Cause (if applicable)

- Root cause: `CodexAppServerEventProjector` converted `turn.status === "interrupted"` into `this.aborted = true` and returned `aborted: this.aborted || turnInterrupted`.
- Missing detection / guardrail: There was no regression covering an app-server interrupted terminal turn with no explicit OpenClaw cancellation and no visible assistant answer.
- Contributing context (if known): The embedded runner intentionally skips incomplete-turn/no-visible-answer handling for true aborts. That made the projector's over-broad status mapping user-visible.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `extensions/codex/src/app-server/event-projector.test.ts`
  - `src/agents/pi-embedded-runner/run.incomplete-turn.test.ts`
- Scenario the test should lock in:
  - App-server `interrupted` does not by itself become OpenClaw `aborted`.
  - Sparse successful bash output plus no visible final assistant text remains eligible for no-visible-answer handling.
  - Replay-unsafe shell activity surfaces a verification warning instead of silently retrying or faking an answer.
- Why this is the smallest reliable guardrail: The bug was a local projection/lifecycle mapping problem plus runner incomplete-turn classification; the focused tests cover both without live model nondeterminism.
- Existing test that already covers this (if any): None found.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

User-facing Codex turns that end with app-server `interrupted` but no explicit OpenClaw cancellation can now reach the existing no-visible-answer guard instead of being classified as aborted.

## Diagram (if applicable)

```text
Before:
Codex turn/completed(status=interrupted) -> projector aborted=true -> incomplete-turn guard skipped -> no final visible answer handling

After:
Codex turn/completed(status=interrupted) -> projector aborted unchanged -> incomplete-turn guard remains active -> retry/error handling stays visible
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux x64 local dev and Linux x64 Crabbox SSH VM
- Runtime/container: Node `v24.15.0` locally and on the VM
- Model/provider: Codex app-server/OpenAI Codex path modeled by focused projector tests
- Integration/channel (if any): OpenClaw Codex app-server harness
- Relevant config (redacted): Crabbox static SSH provider with redacted host/user/workroot

### Steps

1. Rebased the branch on latest official `origin/main`.
2. Ran the focused local test files.
3. Ran the focused regression selections remotely through Crabbox static SSH.

### Expected

- App-server `interrupted` did not automatically become OpenClaw `aborted`.
- Sparse successful bash output did not count as a final visible assistant answer.
- Replay-unsafe tool activity surfaced the existing verification warning path.

### Actual

- Matched expected after this patch.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Local focused tests after rebase:

```shell
CI=1 timeout 240s node scripts/run-vitest.mjs run \
  --config test/vitest/vitest.extensions.config.ts \
  extensions/codex/src/app-server/event-projector.test.ts

Test Files  1 passed (1)
Tests  60 passed (60)
```

```shell
CI=1 timeout 240s node scripts/run-vitest.mjs run \
  --config test/vitest/vitest.agents-pi-embedded.config.ts \
  src/agents/pi-embedded-runner/run.incomplete-turn.test.ts

Test Files  1 passed (1)
Tests  96 passed (96)
```

## Human Verification (required)

- Verified scenarios:
  - Pre-fix focused regression failed on current `main`.
  - Local focused files passed after the patch and after rebase.
  - Crabbox SSH remote proof passed after rebase.
- Edge cases checked:
  - Explicit `markAborted()`/`markTimedOut()` paths remained separate.
  - Failed turns still set `promptError`.
  - Replay-unsafe sparse bash output surfaced a verification warning instead of being silently retried.
- What was not verified:
  - Full dashboard browser UX.
  - Full monorepo test suite.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Some app-server `interrupted` statuses may correspond to genuine app-server-side interruptions.
  - Mitigation: The patch does not mark them successful and does not fake a reply; it only avoids treating them as OpenClaw/user aborts. Explicit OpenClaw abort and timeout paths still set `aborted`/`promptError`.

<!-- exact-interrupted-tool-only-proof-2026-05-20 -->

### Exact interrupted tool-only recovery proof

Added diagnostic regression coverage at commit `2010177bc7` for the exact path ClawSweeper requested:

- Codex app-server terminal projection: `turn/completed status=interrupted`.
- Prior turn item: successful bash `commandExecution` with empty aggregated output and `exitCode=0`.
- No assistant text was projected: `assistantTexts=[]`.
- OpenClaw projection after the patch: `aborted=false`, `timedOut=false`, bash tool metadata preserved.
- The no-visible-answer guard was exercised with a projector-compatible interrupted tool-only attempt and produced recovery text containing `couldn't generate a response`.
- Explicit cancellation counter-proof remained distinct: an explicitly aborted interrupted/tool-only attempt returned `null` from `resolveIncompleteTurnPayloadText(...)`, so user cancellation does not synthesize a fake final answer.

Focused proof commands run locally:

```bash
CI=1 timeout 240s /home/probo/.local/share/pnpm/store/v11/links/@/node/24.15.0/73ce00437ab4f9c458daa7174613927ead616d9a77c35c8b15545d4dc2ac94a0/node_modules/node/bin/node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts extensions/codex/src/app-server/event-projector.test.ts
# Test Files 1 passed (1)
# Tests 61 passed (61)

CI=1 timeout 240s /home/probo/.local/share/pnpm/store/v11/links/@/node/24.15.0/73ce00437ab4f9c458daa7174613927ead616d9a77c35c8b15545d4dc2ac94a0/node_modules/node/bin/node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-pi-embedded.config.ts src/agents/pi-embedded-runner/run.incomplete-turn.test.ts -t "app-server interrupted tool-only output"
# Test Files 1 passed (1)
# Tests 1 passed | 96 skipped (97)

CI=1 timeout 240s /home/probo/.local/share/pnpm/store/v11/links/@/node/24.15.0/73ce00437ab4f9c458daa7174613927ead616d9a77c35c8b15545d4dc2ac94a0/node_modules/node/bin/node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts extensions/codex/src/app-server/run-attempt.test.ts -t "keeps upstream cancellation aborted"
# Test Files 1 passed (1)
# Tests 1 passed | 185 skipped (186)
```

Crabbox SSH proof on the lab VM also passed for the exact diagnostic pair:

```bash
CRABBOX_CONFIG=/home/probo/.config/crabbox/lab-ssh.yaml CRABBOX_SSH_KEY=/home/probo/.ssh/crabbox_lab_ed25519 timeout 1200s /home/probo/.local/bin/crabbox run --provider ssh --target linux --static-host [redacted] --static-user [redacted] --static-port 22 --static-work-root /home/[redacted]/crabbox --shell -- 'export PATH="$HOME/.local/bin:$PATH"; CI=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts extensions/codex/src/app-server/event-projector.test.ts -t "sparse successful bash output|explicit cancellation marked aborted"; CI=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-pi-embedded.config.ts src/agents/pi-embedded-runner/run.incomplete-turn.test.ts -t "app-server interrupted tool-only output"'
# event-projector: Test Files 1 passed (1); Tests 2 passed | 59 skipped (61)
# incomplete-turn: Test Files 1 passed (1); Tests 1 passed | 96 skipped (97)
# lease cleanup stopped=true
```


<!-- exact-runtime-interrupted-tool-only-proof-2026-05-20 -->

### Exact runtime interrupted tool-only recovery proof

After the focused tests, I also ran a runtime diagnostic through the real OpenClaw modules from commit `2010177bc7` rather than a Vitest assertion-only path. The script instantiated `CodexAppServerEventProjector`, fed a redacted Codex app-server `turn/completed` notification with `status="interrupted"`, one successful `commandExecution` item, `aggregatedOutput=""`, and `exitCode=0`, then passed the projected attempt into `resolveIncompleteTurnPayloadText(...)`.

Redacted local runtime output:

```text
[runtime-proof] event=turn/completed status=interrupted item=commandExecution command=bash aggregatedOutputLength=0 exitCode=0
[runtime-proof] projected aborted=false timedOut=false assistantTextCount=0 toolMetas=[{"toolName":"bash","meta":"ps -eo pid,ppid,stat,cmd | rg 'venv-roadmap|pytest|run_security_contract_validation|validate_public_install|git push|ap… (workspace)"}]
[runtime-proof] noVisibleAnswerRecovery="⚠️ Agent couldn't generate a response. Please try again."
[runtime-proof] explicitCancellation projectedAborted=true recovery=null
```

Redacted Crabbox static SSH runtime output from the lab VM:

```text
[runtime-proof] event=turn/completed status=interrupted item=commandExecution command=bash aggregatedOutputLength=0 exitCode=0
[runtime-proof] projected aborted=false timedOut=false assistantTextCount=0 toolMetas=[{"toolName":"bash","meta":"ps -eo pid,ppid,stat,cmd | rg 'venv-roadmap|pytest|run_security_contract_validation|validate_public_install|git push|ap… (workspace)"}]
[runtime-proof] noVisibleAnswerRecovery="⚠️ Agent couldn't generate a response. Please try again."
[runtime-proof] explicitCancellation projectedAborted=true recovery=null
command complete in 25.156s total=27.671s
run summary sync=2.496s command=25.156s total=27.671s sync_skipped=false exit=0
lease cleanup stopped=true policy=auto
```

This is the exact after-fix runtime path requested by ClawSweeper: app-server `interrupted`, tool-only/no-assistant, no explicit OpenClaw abort, no timeout, no synthesized assistant answer, and the existing no-visible-answer recovery text remained reachable. The explicit-cancellation counter-proof stayed distinct: after `markAborted()`, the same interrupted/tool-only shape projected `aborted=true` and produced `recovery=null`.
