### PR TITLE
docs: add OpenViking context engine guide

### DIFF
--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -8,8 +8,20 @@
     "target": "OpenViking"
   },
   {
-    "source": "OpenViking memory",
-    "target": "OpenViking 记忆"
+    "source": "OpenViking context engine",
+    "target": "OpenViking 上下文引擎"
+  },
+  {
+    "source": "Context engine",
+    "target": "上下文引擎"
+  },
+  {
+    "source": "Compaction",
+    "target": "压缩"
+  },
+  {
+    "source": "Plugin Architecture",
+    "target": "插件架构"
   },
   {
     "source": "iMessage",

--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -4,6 +4,14 @@
     "target": "OpenClaw"
   },
   {
+    "source": "OpenViking",
+    "target": "OpenViking"
+  },
+  {
+    "source": "OpenViking memory",
+    "target": "OpenViking 记忆"
+  },
+  {
     "source": "iMessage",
     "target": "iMessage"
   },

--- a/docs/concepts/context-engine-openviking.md
+++ b/docs/concepts/context-engine-openviking.md
@@ -1,31 +1,32 @@
 ---
-summary: "Remote OpenViking memory, archives, resources, and context assembly through the OpenViking context-engine plugin"
-title: "OpenViking memory"
+summary: "Remote memory, archives, resources, and recall through the OpenViking context-engine plugin"
+title: "OpenViking context engine"
+sidebarTitle: "OpenViking"
 read_when:
-  - You want OpenViking as an optional OpenClaw memory backend
+  - You want OpenViking as an optional OpenClaw context engine
   - You want remote long-term memory, session archives, and resource search
-  - You are choosing between builtin memory, QMD, Honcho, LanceDB, and OpenViking
+  - You are deciding whether OpenViking should replace the legacy context engine
 ---
 
-[OpenViking](https://github.com/volcengine/OpenViking) adds a remote memory and
-context database to OpenClaw. It stores conversation history in an OpenViking
-server, extracts long-term user and agent memories, searches imported resources,
-and feeds relevant context back into OpenClaw before model calls.
+[OpenViking](https://github.com/volcengine/OpenViking) is an OpenClaw
+**context engine** plugin with the id `openviking`. It replaces OpenClaw's
+default context assembly path with a remote OpenViking-backed engine that stores
+conversation history, extracts long-term user and agent memories, searches
+imported resources, and feeds relevant context back into OpenClaw before model
+calls.
 
-OpenViking is installed as an OpenClaw **context engine** plugin with the id
-`openviking`. That is an important distinction:
+That placement is important:
 
 - `plugins.slots.contextEngine = "openviking"` selects OpenViking for context
   assembly, archive-backed compaction, and post-turn capture.
-- `plugins.slots.memory` is still the active memory-tool slot. You can leave
-  `memory-core` enabled for local Markdown memory, or configure another memory
+- `plugins.slots.memory` is still the active memory plugin slot. You can leave
+  `memory-core` enabled for local Markdown memory, or select another memory
   plugin separately.
 - The OpenViking server runs outside OpenClaw. The plugin is a remote HTTP
   client; it does not start or supervise the server.
 
-Use OpenViking when you want OpenClaw memory to live in a remote service,
-support multiple agents or OpenClaw instances, and combine conversation memory
-with searchable resources and skills.
+Use OpenViking when you want remote context assembly, archive-backed
+compaction, and long-term recall across agents or OpenClaw instances.
 
 ## What it provides
 
@@ -273,16 +274,21 @@ openclaw openviking status
 Use `/add-resource`, `/add-skill`, and `/memory-search` from a chat session when
 you want manual imports without asking the model to choose a tool call.
 
-## OpenViking vs other memory backends
+## Relationship to memory backends
 
-| Capability                     | Builtin / QMD                              | Honcho                         | OpenViking                                                            |
-| ------------------------------ | ------------------------------------------ | ------------------------------ | --------------------------------------------------------------------- |
-| Primary storage                | Local Markdown index or local sidecar      | Honcho service                 | OpenViking server                                                     |
-| OpenClaw slot                  | `plugins.slots.memory` or builtin config   | Plugin tools and service       | `plugins.slots.contextEngine`                                         |
-| Session archive and compaction | OpenClaw local summaries                   | Service-backed memory          | OpenViking archive summaries plus active messages                     |
-| Automatic recall               | Builtin/QMD search, optional Active Memory | Honcho tools                   | Context-engine assemble injection                                     |
-| Resource or repo search        | QMD extra paths                            | Not the main focus             | OpenViking resources and skills                                       |
-| Best fit                       | Local-first memory and search              | User modeling and observations | Remote memory, archives, multi-agent context, and RAG-style resources |
+OpenViking is not selected through `plugins.slots.memory`. It can still provide
+long-term memory behavior because a context engine controls the prompt that the
+model actually sees.
+
+| Capability                     | Memory backends                           | OpenViking context engine                            |
+| ------------------------------ | ----------------------------------------- | ---------------------------------------------------- |
+| OpenClaw slot                  | `plugins.slots.memory`                    | `plugins.slots.contextEngine`                        |
+| Primary job                    | Search, store, and expose memory tools    | Assemble context, compact history, and inject recall |
+| Local Markdown memory workflow | Owned by `memory-core`                    | Can run alongside it                                 |
+| Session archive and compaction | OpenClaw summaries or backend-specific    | OpenViking archive summaries plus active messages    |
+| Automatic recall path          | Memory prompt sections and memory tools   | Context-engine `assemble()` injection                |
+| Resource or repo search        | Backend-specific, for example QMD paths   | OpenViking resources and skills                      |
+| Best fit                       | Local-first memory and explicit retrieval | Remote archives, multi-agent context, and RAG        |
 
 OpenViking can run alongside the builtin memory plugin. Keep local Markdown
 memory when you want OpenClaw's `MEMORY.md` and `memory/*.md` workflow, and use
@@ -335,7 +341,7 @@ Set it back to `legacy` if needed.
 
 ## Related
 
-- [Builtin memory engine](/concepts/memory-builtin)
-- [QMD memory engine](/concepts/memory-qmd)
-- [Honcho memory](/concepts/memory-honcho)
-- [Memory LanceDB](/plugins/memory-lancedb)
+- [Context engine](/concepts/context-engine)
+- [Compaction](/concepts/compaction)
+- [Memory overview](/concepts/memory)
+- [Plugin Architecture](/plugins/architecture)

--- a/docs/concepts/context-engine.md
+++ b/docs/concepts/context-engine.md
@@ -301,6 +301,7 @@ The slot is exclusive at run time - only one registered context engine is resolv
 
 - [Compaction](/concepts/compaction) - summarizing long conversations
 - [Context](/concepts/context) - how context is built for agent turns
+- [OpenViking memory](/concepts/memory-openviking) - remote memory through a context-engine plugin
 - [Plugin Architecture](/plugins/architecture) - registering context engine plugins
 - [Plugin manifest](/plugins/manifest) - plugin manifest fields
 - [Plugins](/tools/plugin) - plugin overview

--- a/docs/concepts/context-engine.md
+++ b/docs/concepts/context-engine.md
@@ -116,6 +116,19 @@ When no `plugins.slots.contextEngine` is set (or it's set to `"legacy"`), this e
 
 ## Plugin engines
 
+### OpenViking
+
+OpenViking is a context engine plugin for remote archive-backed context, memory
+recall, and resource search:
+
+<CardGroup cols={1}>
+<Card title="OpenViking context engine" icon="network" href="/concepts/context-engine-openviking">
+Use an OpenViking server for context assembly, archive-backed compaction,
+automatic recall, and searchable resources without taking over
+`plugins.slots.memory`.
+</Card>
+</CardGroup>
+
 A plugin can register a context engine using the plugin API:
 
 ```ts
@@ -301,7 +314,7 @@ The slot is exclusive at run time - only one registered context engine is resolv
 
 - [Compaction](/concepts/compaction) - summarizing long conversations
 - [Context](/concepts/context) - how context is built for agent turns
-- [OpenViking memory](/concepts/memory-openviking) - remote memory through a context-engine plugin
+- [OpenViking context engine](/concepts/context-engine-openviking) - remote archives and recall through a context-engine plugin
 - [Plugin Architecture](/plugins/architecture) - registering context engine plugins
 - [Plugin manifest](/plugins/manifest) - plugin manifest fields
 - [Plugins](/tools/plugin) - plugin overview

--- a/docs/concepts/memory-openviking.md
+++ b/docs/concepts/memory-openviking.md
@@ -1,0 +1,341 @@
+---
+summary: "Remote OpenViking memory, archives, resources, and context assembly through the OpenViking context-engine plugin"
+title: "OpenViking memory"
+read_when:
+  - You want OpenViking as an optional OpenClaw memory backend
+  - You want remote long-term memory, session archives, and resource search
+  - You are choosing between builtin memory, QMD, Honcho, LanceDB, and OpenViking
+---
+
+[OpenViking](https://github.com/volcengine/OpenViking) adds a remote memory and
+context database to OpenClaw. It stores conversation history in an OpenViking
+server, extracts long-term user and agent memories, searches imported resources,
+and feeds relevant context back into OpenClaw before model calls.
+
+OpenViking is installed as an OpenClaw **context engine** plugin with the id
+`openviking`. That is an important distinction:
+
+- `plugins.slots.contextEngine = "openviking"` selects OpenViking for context
+  assembly, archive-backed compaction, and post-turn capture.
+- `plugins.slots.memory` is still the active memory-tool slot. You can leave
+  `memory-core` enabled for local Markdown memory, or configure another memory
+  plugin separately.
+- The OpenViking server runs outside OpenClaw. The plugin is a remote HTTP
+  client; it does not start or supervise the server.
+
+Use OpenViking when you want OpenClaw memory to live in a remote service,
+support multiple agents or OpenClaw instances, and combine conversation memory
+with searchable resources and skills.
+
+## What it provides
+
+- **Remote long-term memory**: OpenViking extracts durable user and agent memory
+  from OpenClaw sessions and stores it under OpenViking namespaces such as
+  `viking://user/...` and `viking://agent/...`.
+- **Automatic recall**: before a model run, the plugin searches OpenViking for
+  relevant memories and injects a bounded `<relevant-memories>` block into the
+  latest user message.
+- **Session archives**: older conversation history is committed into OpenViking
+  archives. OpenClaw receives archive summaries and recent active messages
+  instead of an ever-growing raw transcript.
+- **Archive expansion**: when a summary is not enough, the agent can search or
+  expand archived original messages through OpenViking tools.
+- **Resource and skill search**: the plugin can import files, directories, URLs,
+  Git repositories, and skills into OpenViking, then search them during later
+  turns.
+- **Multi-agent routing**: the plugin derives an OpenViking agent id from the
+  OpenClaw session and optional `agent_prefix`, so different agents can avoid
+  mixing memory.
+
+## Install
+
+### 1. Start OpenViking
+
+Run an OpenViking server that OpenClaw can reach. For a local server:
+
+```bash
+pip install openviking --upgrade --force-reinstall
+openviking-server init
+openviking-server doctor
+openviking-server
+```
+
+The default local HTTP endpoint is `http://127.0.0.1:1933`.
+
+For a server on another machine, bind it to a reachable address:
+
+```bash
+openviking-server --host 0.0.0.0 --port 1933
+```
+
+Then verify the server:
+
+```bash
+curl http://127.0.0.1:1933/health
+```
+
+### 2. Install the OpenClaw plugin
+
+Install the OpenViking plugin from ClawHub:
+
+```bash
+openclaw plugins install clawhub:@openviking/openclaw-plugin
+```
+
+Current OpenClaw versions require the `clawhub:` prefix when you want to force
+ClawHub as the source. The bare command below installs the same package name
+through the normal npm package path instead:
+
+```bash
+openclaw plugins install @openviking/openclaw-plugin
+```
+
+Use the explicit `clawhub:` form when you want OpenClaw-native ClawHub package
+metadata and install provenance.
+
+### 3. Configure the plugin
+
+Run the plugin setup command. For interactive setup:
+
+```bash
+openclaw openviking setup
+```
+
+For non-interactive setup:
+
+```bash
+openclaw openviking setup \
+  --base-url http://127.0.0.1:1933 \
+  --api-key sk-xxx \
+  --json
+```
+
+Setup writes `plugins.entries.openviking.config` and selects the OpenViking
+context engine by setting `plugins.slots.contextEngine` to `openviking`.
+
+If the server is temporarily unreachable but you still want to save config:
+
+```bash
+openclaw openviking setup \
+  --base-url http://127.0.0.1:1933 \
+  --api-key sk-xxx \
+  --allow-offline \
+  --json
+```
+
+If another context engine already owns the slot, setup will not replace it
+unless you pass `--force-slot`.
+
+### 4. Restart and verify
+
+Restart the Gateway so the plugin code and selected context engine are active:
+
+```bash
+openclaw gateway restart
+```
+
+Then verify the integration:
+
+```bash
+openclaw openviking status --json
+```
+
+Look for:
+
+| Field        | Expected value                                 |
+| ------------ | ---------------------------------------------- |
+| `configured` | `true`                                         |
+| `slotActive` | `true`                                         |
+| `health.ok`  | `true` when the OpenViking server is reachable |
+
+You can also inspect the raw OpenClaw config:
+
+```bash
+openclaw config get plugins.entries.openviking.config
+openclaw config get plugins.slots.contextEngine
+```
+
+`plugins.slots.contextEngine` should print `openviking`.
+
+## Configuration
+
+The main config lives under `plugins.entries.openviking.config`:
+
+```json5
+{
+  plugins: {
+    slots: {
+      contextEngine: "openviking",
+    },
+    entries: {
+      openviking: {
+        enabled: true,
+        config: {
+          baseUrl: "http://127.0.0.1:1933",
+          apiKey: "${OPENVIKING_API_KEY}",
+          agent_prefix: "",
+          autoRecall: true,
+          autoCapture: true,
+          recallLimit: 6,
+          recallMaxInjectedChars: 4000,
+          commitTokenThreshold: 20000,
+        },
+      },
+    },
+  },
+}
+```
+
+Common fields:
+
+| Field                     | Default                 | Purpose                                                                                                                           |
+| ------------------------- | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `baseUrl`                 | `http://127.0.0.1:1933` | OpenViking HTTP endpoint. Can also come from `OPENVIKING_BASE_URL` or `OPENVIKING_URL`.                                           |
+| `apiKey`                  | empty                   | Optional OpenViking API key. Can also come from `OPENVIKING_API_KEY`.                                                             |
+| `agent_prefix`            | empty                   | Optional prefix for OpenViking agent ids, useful when several OpenClaw installs share one server.                                 |
+| `accountId` / `userId`    | empty                   | Advanced tenant headers, usually needed only with root keys or trusted server flows.                                              |
+| `autoRecall`              | `true`                  | Search OpenViking before a turn and inject relevant memories.                                                                     |
+| `recallResources`         | `false`                 | Include `viking://resources` in automatic recall and default recall searches.                                                     |
+| `recallLimit`             | `6`                     | Maximum selected memories before budget trimming.                                                                                 |
+| `recallMaxInjectedChars`  | `4000`                  | Total character budget for the injected recall block. Individual memories are skipped rather than truncated when they do not fit. |
+| `autoCapture`             | `true`                  | Append completed turns to OpenViking and trigger extraction when the session crosses the commit threshold.                        |
+| `commitTokenThreshold`    | `20000`                 | Pending-token threshold before `afterTurn` starts an async OpenViking commit.                                                     |
+| `commitKeepRecentCount`   | `10`                    | Number of recent messages the OpenViking server should keep live after an async commit.                                           |
+| `bypassSessionPatterns`   | `[]`                    | Session-key glob patterns that completely bypass OpenViking.                                                                      |
+| `emitStandardDiagnostics` | `false`                 | Emit structured `openviking: diag {...}` logs for assemble and after-turn phases.                                                 |
+| `logFindRequests`         | `false`                 | Log routing details for search and session writes without logging the API key.                                                    |
+
+Namespace fields such as `isolateUserScopeByAgent` and
+`isolateAgentScopeByUser` must match the OpenViking server-side account policy.
+Leave them unset unless your OpenViking deployment explicitly uses isolated
+user/agent namespace variants.
+
+## How it works
+
+OpenViking participates in the OpenClaw context-engine lifecycle.
+
+### Assemble
+
+During prompt assembly, OpenViking handles two jobs:
+
+1. It reads archive and active-session context back from OpenViking and rebuilds
+   the message list that OpenClaw sends to the model.
+2. It searches `viking://user/memories` and `viking://agent/memories`, plus
+   `viking://resources` when `recallResources` is enabled, then injects the
+   selected memories into the latest user message.
+
+The recall path uses a quick availability precheck so a down OpenViking server
+does not stall every model request. Results are deduplicated, thresholded,
+reranked, and trimmed to the configured injection budget.
+
+### After turn
+
+After an agent turn, the plugin appends only the new turn to the OpenViking
+session. It strips OpenViking's own injected recall block before capture and
+preserves useful tool-call and tool-result text for later archive search.
+
+When pending session tokens reach `commitTokenThreshold`, the plugin starts an
+async OpenViking commit with `wait=false`. Archive generation and memory
+extraction continue on the OpenViking server, so the current OpenClaw reply is
+not blocked waiting for extraction.
+
+### Compact and reset
+
+When OpenClaw compacts, the OpenViking engine commits with `wait=true`. It waits
+for the archive and memory extraction result, then returns the latest archive
+overview as the compacted session summary.
+
+Before a session reset, the plugin also commits the current OpenViking session
+when session identity is available.
+
+## Tools and commands
+
+When loaded, the plugin registers OpenViking tools for the agent:
+
+| Tool                | Purpose                                                                                       |
+| ------------------- | --------------------------------------------------------------------------------------------- |
+| `memory_recall`     | Search OpenViking long-term memories.                                                         |
+| `memory_store`      | Store important text by appending a short OpenViking session and committing it.               |
+| `memory_forget`     | Delete a memory by URI, or search and delete one strong match.                                |
+| `ov_archive_search` | Keyword-search archived original messages from the current session.                           |
+| `ov_archive_expand` | Expand one archive back into original messages.                                               |
+| `add_resource`      | Import a file, directory, URL, Git repository, or uploaded archive into OpenViking resources. |
+| `add_skill`         | Import or register an OpenViking skill.                                                       |
+| `memory_search`     | Search OpenViking memories, resources, and skills, especially after imports.                  |
+
+It also registers the `openclaw openviking` CLI namespace:
+
+```bash
+openclaw openviking setup
+openclaw openviking status
+```
+
+Use `/add-resource`, `/add-skill`, and `/memory-search` from a chat session when
+you want manual imports without asking the model to choose a tool call.
+
+## OpenViking vs other memory backends
+
+| Capability                     | Builtin / QMD                              | Honcho                         | OpenViking                                                            |
+| ------------------------------ | ------------------------------------------ | ------------------------------ | --------------------------------------------------------------------- |
+| Primary storage                | Local Markdown index or local sidecar      | Honcho service                 | OpenViking server                                                     |
+| OpenClaw slot                  | `plugins.slots.memory` or builtin config   | Plugin tools and service       | `plugins.slots.contextEngine`                                         |
+| Session archive and compaction | OpenClaw local summaries                   | Service-backed memory          | OpenViking archive summaries plus active messages                     |
+| Automatic recall               | Builtin/QMD search, optional Active Memory | Honcho tools                   | Context-engine assemble injection                                     |
+| Resource or repo search        | QMD extra paths                            | Not the main focus             | OpenViking resources and skills                                       |
+| Best fit                       | Local-first memory and search              | User modeling and observations | Remote memory, archives, multi-agent context, and RAG-style resources |
+
+OpenViking can run alongside the builtin memory plugin. Keep local Markdown
+memory when you want OpenClaw's `MEMORY.md` and `memory/*.md` workflow, and use
+OpenViking for remote archive-backed context and shared knowledge retrieval.
+
+## Troubleshooting
+
+| Symptom                                             | Check                                                                   | Fix                                                                                                    |
+| --------------------------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `slotActive` is `false`                             | `openclaw config get plugins.slots.contextEngine`                       | Run `openclaw openviking setup --force-slot` only if you intend to replace the current context engine. |
+| `health.ok` is `false`                              | `curl <baseUrl>/health` and `openclaw openviking status --json`         | Start or repair the OpenViking server, fix `baseUrl`, or rerun setup with the right API key.           |
+| Setup reports a root key needs tenant context       | Status or setup JSON shows `keyProbe.keyType: "root_key"`               | Rerun setup with `--account-id` and `--user-id`, or use a user API key.                                |
+| The plugin installs but turns do not use OpenViking | `openclaw plugins inspect openviking --runtime --json` and Gateway logs | Restart the live Gateway process that serves your channels.                                            |
+| Recall is empty                                     | `logFindRequests`, OpenViking server logs, and target namespace policy  | Confirm the right `agent_prefix`, user/agent namespace settings, and that memories/resources exist.    |
+| `memory_store` commits but extracts zero memories   | OpenViking server extraction and embedding logs                         | Fix server-side model or embedding credentials, then store or commit again.                            |
+
+For a deeper pipeline check from an OpenViking repository checkout, run:
+
+```bash
+python examples/openclaw-plugin/health_check_tools/ov-healthcheck.py
+```
+
+That check sends a real Gateway conversation and verifies the OpenViking side
+captured, committed, archived, and extracted memory.
+
+## Uninstall
+
+```bash
+openclaw plugins uninstall openviking
+openclaw gateway restart
+```
+
+Recent OpenClaw versions reset `plugins.slots.contextEngine` to `legacy` when
+the selected context-engine plugin is uninstalled. If you are on an older
+OpenClaw build, inspect the slot afterward:
+
+```bash
+openclaw config get plugins.slots.contextEngine
+```
+
+Set it back to `legacy` if needed.
+
+## Further reading
+
+- [OpenViking OpenClaw integration guide](https://docs.openviking.ai/en/agent-integrations/03-openclaw)
+- [OpenViking plugin source](https://github.com/volcengine/OpenViking/tree/main/examples/openclaw-plugin)
+- [Context engine](/concepts/context-engine)
+- [Memory overview](/concepts/memory)
+- [Plugins](/tools/plugin)
+
+## Related
+
+- [Builtin memory engine](/concepts/memory-builtin)
+- [QMD memory engine](/concepts/memory-qmd)
+- [Honcho memory](/concepts/memory-honcho)
+- [Memory LanceDB](/plugins/memory-lancedb)

--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -75,6 +75,10 @@ The agent has two tools for working with memory:
 - **`memory_get`** — reads a specific memory file or line range.
 
 Both tools are provided by the active memory plugin (default: `memory-core`).
+Other plugins can register additional memory-related tools without owning the
+active memory slot. For example, the OpenViking context-engine plugin adds
+OpenViking recall, archive, resource, and skill tools while still leaving
+`plugins.slots.memory` separate.
 
 ## Memory Wiki companion plugin
 
@@ -130,6 +134,10 @@ multi-agent awareness. Plugin install.
 <Card title="LanceDB" icon="layers" href="/plugins/memory-lancedb">
 Bundled LanceDB-backed memory with OpenAI-compatible embeddings, auto-recall,
 auto-capture, and local Ollama embedding support.
+</Card>
+<Card title="OpenViking" icon="network" href="/concepts/memory-openviking">
+Remote memory and context database with archive-backed compaction, automatic
+recall, resource search, and multi-agent routing.
 </Card>
 </CardGroup>
 
@@ -242,6 +250,7 @@ openclaw memory index --force   # Rebuild the index
 - [QMD memory engine](/concepts/memory-qmd): advanced local-first sidecar.
 - [Honcho memory](/concepts/memory-honcho): AI-native cross-session memory.
 - [Memory LanceDB](/plugins/memory-lancedb): LanceDB-backed plugin with OpenAI-compatible embeddings.
+- [OpenViking memory](/concepts/memory-openviking): remote memory, archives, and resource search.
 - [Memory Wiki](/plugins/memory-wiki): compiled knowledge vault and wiki-native tools.
 - [Memory search](/concepts/memory-search): search pipeline, providers, and tuning.
 - [Dreaming](/concepts/dreaming): background promotion from short-term recall to long-term memory.
@@ -255,4 +264,5 @@ openclaw memory index --force   # Rebuild the index
 - [Builtin memory engine](/concepts/memory-builtin)
 - [Honcho memory](/concepts/memory-honcho)
 - [Memory LanceDB](/plugins/memory-lancedb)
+- [OpenViking memory](/concepts/memory-openviking)
 - [Commitments](/concepts/commitments)

--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -76,7 +76,8 @@ The agent has two tools for working with memory:
 
 Both tools are provided by the active memory plugin (default: `memory-core`).
 Other plugins can register additional memory-related tools without owning the
-active memory slot. For example, the OpenViking context-engine plugin adds
+active memory slot. For example, the
+[OpenViking context engine](/concepts/context-engine-openviking) adds
 OpenViking recall, archive, resource, and skill tools while still leaving
 `plugins.slots.memory` separate.
 
@@ -135,11 +136,13 @@ multi-agent awareness. Plugin install.
 Bundled LanceDB-backed memory with OpenAI-compatible embeddings, auto-recall,
 auto-capture, and local Ollama embedding support.
 </Card>
-<Card title="OpenViking" icon="network" href="/concepts/memory-openviking">
-Remote memory and context database with archive-backed compaction, automatic
-recall, resource search, and multi-agent routing.
-</Card>
 </CardGroup>
+
+OpenViking is related, but it is selected through
+`plugins.slots.contextEngine`, not `plugins.slots.memory`. See
+[OpenViking context engine](/concepts/context-engine-openviking) if you want a
+remote OpenViking server to own context assembly, archive-backed compaction, and
+automatic recall while local Markdown memory remains available.
 
 ## Knowledge wiki layer
 
@@ -250,7 +253,7 @@ openclaw memory index --force   # Rebuild the index
 - [QMD memory engine](/concepts/memory-qmd): advanced local-first sidecar.
 - [Honcho memory](/concepts/memory-honcho): AI-native cross-session memory.
 - [Memory LanceDB](/plugins/memory-lancedb): LanceDB-backed plugin with OpenAI-compatible embeddings.
-- [OpenViking memory](/concepts/memory-openviking): remote memory, archives, and resource search.
+- [OpenViking context engine](/concepts/context-engine-openviking): remote archives, recall, and resource search through context assembly.
 - [Memory Wiki](/plugins/memory-wiki): compiled knowledge vault and wiki-native tools.
 - [Memory search](/concepts/memory-search): search pipeline, providers, and tuning.
 - [Dreaming](/concepts/dreaming): background promotion from short-term recall to long-term memory.
@@ -264,5 +267,5 @@ openclaw memory index --force   # Rebuild the index
 - [Builtin memory engine](/concepts/memory-builtin)
 - [Honcho memory](/concepts/memory-honcho)
 - [Memory LanceDB](/plugins/memory-lancedb)
-- [OpenViking memory](/concepts/memory-openviking)
+- [OpenViking context engine](/concepts/context-engine-openviking)
 - [Commitments](/concepts/commitments)

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -165,6 +165,10 @@
       "destination": "/concepts/context-engine"
     },
     {
+      "source": "/concepts/memory-openviking",
+      "destination": "/concepts/context-engine-openviking"
+    },
+    {
       "source": "/cron",
       "destination": "/automation/cron-jobs"
     },
@@ -1128,6 +1132,7 @@
                   "concepts/system-prompt",
                   "concepts/context",
                   "concepts/context-engine",
+                  "concepts/context-engine-openviking",
                   "concepts/agent-workspace",
                   "concepts/soul",
                   "concepts/oauth",
@@ -1152,7 +1157,6 @@
                       "concepts/memory-builtin",
                       "concepts/memory-qmd",
                       "concepts/memory-honcho",
-                      "concepts/memory-openviking",
                       "concepts/memory-search",
                       "concepts/active-memory",
                       "concepts/commitments",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1152,6 +1152,7 @@
                       "concepts/memory-builtin",
                       "concepts/memory-qmd",
                       "concepts/memory-honcho",
+                      "concepts/memory-openviking",
                       "concepts/memory-search",
                       "concepts/active-memory",
                       "concepts/commitments",


### PR DESCRIPTION
## Summary
- Add `docs/concepts/context-engine-openviking.md` covering OpenViking as a remote context-engine plugin, including endpoint setup, plugin install, verification, configuration, lifecycle behavior, tools, and troubleshooting.
- Link the guide from the context-engine docs, keep a memory-overview cross-reference that clarifies `plugins.slots.memory` remains separate, update Mintlify navigation, and add a redirect from the earlier memory-page path.
- Clarify that OpenClaw can connect to a cloud-hosted or team-hosted OpenViking endpoint; self-hosting OpenViking locally is optional and linked to OpenViking's API, public access, and authentication docs.
- Document `openclaw plugins install clawhub:@openviking/openclaw-plugin` as the explicit ClawHub install path and `openclaw plugins install @openviking/openclaw-plugin` as the npm fallback for the published npm package.

## Verification
- `git diff --check`
- `pnpm check:docs`
- `npm view @openviking/openclaw-plugin name version dist-tags description --json`
- `npm search @openviking/openclaw-plugin --json`

## Real behavior proof
Behavior addressed: OpenClaw docs now list OpenViking as an optional context-engine plugin and explain the correct ClawHub install path, npm fallback, endpoint setup, lifecycle behavior, and relationship to memory backends.

Real environment tested: Local OpenClaw docs checkout at `110042d840bbcc8742187a4ad05a4038debb9a79`; reviewed OpenViking `examples/openclaw-plugin` from `volcengine/OpenViking` `origin/main`; checked OpenViking docs for API client-server mode, public/reverse-proxy access, and API-key authentication; queried npm registry for `@openviking/openclaw-plugin`.

Exact steps or command run after this patch: `pnpm check:docs`

Evidence after fix: Docs format, markdownlint, MDX, i18n glossary, and internal link audit all passed; link audit reported `broken_links=0`. npm registry returned `@openviking/openclaw-plugin` version `2026.5.8` with `latest` dist-tag `2026.5.8`.

Observed result after fix: New page appears in `pnpm docs:list` as `concepts/context-engine-openviking.md`; context-engine docs and memory overview link to it, and the old `/concepts/memory-openviking` path redirects to it.

What was not tested: No OpenViking server or OpenClaw runtime install was exercised because this PR is documentation-only.
