### PR TITLE
fix(acp): preserve final-only text across tool calls

### DIFF
--- a/src/auto-reply/reply/acp-projector.test.ts
+++ b/src/auto-reply/reply/acp-projector.test.ts
@@ -373,6 +373,41 @@ describe("createAcpReplyProjector", () => {
     expect(deliveries[2]).toEqual({ kind: "final", text: "What now?" });
   });
 
+  it("keeps final-only text across tool-use done boundaries until terminal done", async () => {
+    const { deliveries, projector } = createFinalOnlyStatusToolHarness();
+
+    await projector.onEvent({
+      type: "text_delta",
+      text: "Step 1: inspect inputs. ",
+      tag: "agent_message_chunk",
+    });
+    await projector.onEvent({
+      type: "tool_call",
+      tag: "tool_call",
+      toolCallId: "call_weather",
+      status: "in_progress",
+      title: "Fetch weather",
+      text: "Fetch weather (in_progress)",
+    });
+    await projector.onEvent({ type: "done", stopReason: "toolUse" });
+
+    expect(deliveries).toStrictEqual([]);
+
+    await projector.onEvent({
+      type: "text_delta",
+      text: "Step 2: summarize result.",
+      tag: "agent_message_chunk",
+    });
+    await projector.onEvent({ type: "done", stopReason: "end_turn" });
+
+    expect(deliveries).toHaveLength(2);
+    expectToolCallSummary(deliveries[0]);
+    expect(deliveries[1]).toEqual({
+      kind: "final",
+      text: "Step 1: inspect inputs. Step 2: summarize result.",
+    });
+  });
+
   it("flushes buffered status/tool output on error in deliveryMode=final_only", async () => {
     const { deliveries, projector } = createFinalOnlyStatusToolHarness();
 

--- a/src/auto-reply/reply/acp-projector.ts
+++ b/src/auto-reply/reply/acp-projector.ts
@@ -63,6 +63,11 @@ function normalizeToolStatus(status: string | undefined): string | undefined {
   return normalized || undefined;
 }
 
+function isToolUseStopReason(stopReason: string | undefined): boolean {
+  const normalized = normalizeOptionalLowercaseString(stopReason)?.replace(/[^a-z0-9]/g, "");
+  return normalized === "tooluse" || normalized === "toolcall" || normalized === "toolcalls";
+}
+
 function resolveHiddenBoundarySeparatorText(mode: AcpHiddenBoundarySeparator): string {
   if (mode === "space") {
     return " ";
@@ -497,7 +502,17 @@ export function createAcpReplyProjector(params: {
       return;
     }
 
-    if (event.type === "done" || event.type === "error") {
+    if (event.type === "done") {
+      if (settings.deliveryMode === "final_only" && isToolUseStopReason(event.stopReason)) {
+        clearLiveIdleTimer();
+        return;
+      }
+      await flush(true);
+      resetTurnState();
+      return;
+    }
+
+    if (event.type === "error") {
       await flush(true);
       resetTurnState();
     }


### PR DESCRIPTION
## Summary
- Keep ACP `final_only` visible text buffered across intermediate tool-use `done` events.
- Flush the accumulated text and buffered tool summaries only when the terminal turn `done` arrives.
- Add a regression test for pre-tool assistant text followed by final assistant text in the same turn.

Related to #84486; does not close it because this PR is scoped to the shared ACP `final_only` projector behavior, not the Feishu streaming-card dispatcher path.

## Real behavior proof

Behavior addressed: ACP `final_only` delivery must preserve assistant text emitted before an intermediate tool-use boundary and deliver it together with the later terminal assistant text.

Real environment tested: Local OpenClaw checkout on macOS, Node.js v22.22.0. Real `createAcpReplyProjector` runtime path invoked with `node --import tsx`; no mocked deliverer behavior beyond capturing the actual projector deliveries array.

Exact steps or command run after the patch:
```console
$ node --import tsx --input-type=module <<'EOF'
import { createAcpReplyProjector } from './src/auto-reply/reply/acp-projector.ts';
const cfg = { acp: { enabled: true, stream: { deliveryMode: 'final_only', coalesceIdleMs: 0, maxChunkChars: 512, tagVisibility: { tool_call: true } } } };
const deliveries = [];
const projector = createAcpReplyProjector({
  cfg,
  shouldSendToolSummaries: true,
  deliver: async (kind, payload) => { deliveries.push({ kind, text: payload.text }); return true; },
});
await projector.onEvent({ type: 'text_delta', text: 'Step 1: inspect inputs. ', tag: 'agent_message_chunk' });
await projector.onEvent({ type: 'tool_call', tag: 'tool_call', toolCallId: 'call_weather', status: 'in_progress', title: 'Fetch weather', text: 'Fetch weather (in_progress)' });
await projector.onEvent({ type: 'done', stopReason: 'toolUse' });
console.log('after toolUse boundary:', JSON.stringify(deliveries));
await projector.onEvent({ type: 'text_delta', text: 'Step 2: summarize result.', tag: 'agent_message_chunk' });
await projector.onEvent({ type: 'done', stopReason: 'end_turn' });
console.log('after terminal boundary:', JSON.stringify(deliveries, null, 2));
EOF
```

Evidence after fix:
```console
after toolUse boundary: []
after terminal boundary: [
  {
    "kind": "tool",
    "text": "🧰 Tool Call: Fetch weather, status=in_progress"
  },
  {
    "kind": "final",
    "text": "Step 1: inspect inputs. Step 2: summarize result."
  }
]
```

Observed result after fix: At the intermediate `toolUse` boundary, no final reply is delivered. At the terminal `end_turn` boundary, the projector emits the buffered tool summary and a single final reply containing both visible text fragments: `Step 1: inspect inputs. Step 2: summarize result.`

What was not tested: A live Feishu or Telegram ACP channel was not connected in this local run; the exercised projector path is the shared ACP delivery component used before channel delivery.

## Test plan
- `node --import tsx --input-type=module` projector reproduction shown above
- `node scripts/run-vitest.mjs src/auto-reply/reply/acp-projector.test.ts`
- `node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-acp.test.ts src/acp/control-plane/manager.test.ts`
- `git diff --check`
