### PR TITLE
fix(acp): preserve final_only text across tool-call boundaries

### DIFF
--- a/src/auto-reply/reply/acp-projector.test.ts
+++ b/src/auto-reply/reply/acp-projector.test.ts
@@ -364,12 +364,19 @@ describe("createAcpReplyProjector", () => {
     expect(deliveries).toStrictEqual([]);
 
     await projector.onEvent({ type: "done" });
-    expect(deliveries).toHaveLength(3);
+    // Tool/status messages are flushed on done, but final text is deferred
+    // to the turn-level flush(true) call so text accumulated before tool
+    // calls is preserved across model invocations within the same turn
+    // (#84486).
+    expect(deliveries).toHaveLength(2);
     expect(deliveries[0]).toEqual({
       kind: "tool",
       text: prefixSystemMessage("available commands updated (7)"),
     });
     expectToolCallSummary(deliveries[1]);
+
+    await projector.flush(true);
+    expect(deliveries).toHaveLength(3);
     expect(deliveries[2]).toEqual({ kind: "final", text: "What now?" });
   });
 
@@ -398,6 +405,157 @@ describe("createAcpReplyProjector", () => {
       text: prefixSystemMessage("available commands updated (7)"),
     });
     expectToolCallSummary(deliveries[1]);
+  });
+
+  it("accumulates text across multiple done events in final_only mode (#84486)", async () => {
+    const { deliveries, projector } = createFinalOnlyStatusToolHarness();
+
+    // First model invocation: text before a tool call
+    await projector.onEvent({
+      type: "text_delta",
+      text: "Step 1: Checking data schema.",
+      tag: "agent_message_chunk",
+    });
+    await projector.onEvent({
+      type: "text_delta",
+      text: " Step 2: Planning the query.",
+      tag: "agent_message_chunk",
+    });
+
+    // First done (toolUse stopReason): tool messages are flushed, but text is
+    // accumulated, not delivered.
+    await projector.onEvent({ type: "done" });
+    expect(deliveries).toHaveLength(0);
+    expect(countMatching(deliveries, (d) => d.kind === "final")).toBe(0);
+
+    // Second model invocation: text after tool result
+    await projector.onEvent({
+      type: "text_delta",
+      text: " Step 3: The results show...",
+      tag: "agent_message_chunk",
+    });
+    await projector.onEvent({ type: "done" });
+    expect(countMatching(deliveries, (d) => d.kind === "final")).toBe(0);
+
+    // Turn completion: flush(true) delivers all accumulated text together
+    await projector.flush(true);
+    const finals = deliveries.filter((d) => d.kind === "final");
+    expect(finals).toHaveLength(1);
+    expect(finals[0]?.text).toContain("Step 1: Checking data schema.");
+    expect(finals[0]?.text).toContain("Step 2: Planning the query.");
+    expect(finals[0]?.text).toContain("Step 3: The results show...");
+  });
+
+  it("enforces maxOutputChars across multiple invocations in final_only mode (#84486)", async () => {
+    const { deliveries, projector } = createFinalOnlyStatusToolHarness();
+    // Override to a very low limit: 5 chars per turn
+    const limitedProjector = createAcpReplyProjector({
+      cfg: createCfg({
+        acp: {
+          enabled: true,
+          stream: {
+            coalesceIdleMs: 0,
+            maxChunkChars: 512,
+            deliveryMode: "final_only",
+            maxOutputChars: 5,
+            tagVisibility: {
+              available_commands_update: true,
+              tool_call: true,
+            },
+          },
+        },
+      }),
+      shouldSendToolSummaries: true,
+      deliver: async (kind, payload) => {
+        deliveries.push({ kind, text: payload.text });
+        return true;
+      },
+    });
+
+    // First invocation: 3 chars accepted, 2 budget remains
+    await limitedProjector.onEvent({
+      type: "text_delta",
+      text: "abc",
+      tag: "agent_message_chunk",
+    });
+
+    // done(toolUse): counter persists in final_only mode
+    await limitedProjector.onEvent({ type: "done" });
+
+    // Second invocation: "de" accepted (fills remaining budget), "fgh..." rejected
+    await limitedProjector.onEvent({
+      type: "text_delta",
+      text: "defghijklm",
+      tag: "agent_message_chunk",
+    });
+    await limitedProjector.onEvent({ type: "done" });
+
+    // Turn completion: deliver accumulated text + truncation notice
+    await limitedProjector.flush(true);
+
+    const finals = deliveries.filter((d) => d.kind === "final");
+    expect(finals).toHaveLength(1);
+    // 5 chars total: abc + de
+    expect(finals[0]?.text).toBe("abcde");
+
+    const truncationNotices = deliveries.filter(
+      (d) => d.kind === "tool" && d.text?.includes("output truncated"),
+    );
+    expect(truncationNotices).toHaveLength(1);
+  });
+
+  it("preserves hidden-boundary separator across done boundaries in final_only mode (#84486)", async () => {
+    // When a hidden tool_call occurs in invocation 1 and visible text follows
+    // in invocation 2, the hidden-boundary separator must still be inserted.
+    const { deliveries, projector } = createProjectorHarness({
+      acp: {
+        enabled: true,
+        stream: {
+          coalesceIdleMs: 0,
+          maxChunkChars: 256,
+          deliveryMode: "final_only",
+          tagVisibility: {
+            tool_call: false, // hidden tool calls
+            tool_call_update: false, // hidden updates
+          },
+        },
+      },
+    });
+
+    // Invocation 1: visible text, then hidden tool call
+    await projector.onEvent({
+      type: "text_delta",
+      text: "Looking up data.",
+      tag: "agent_message_chunk",
+    });
+    await projector.onEvent({
+      type: "tool_call",
+      tag: "tool_call",
+      toolCallId: "call_hidden",
+      status: "in_progress",
+      title: "Hidden lookup",
+      text: "Hidden lookup (in_progress)",
+    });
+    // First done: text deferred, hidden-boundary state must survive
+    await projector.onEvent({ type: "done" });
+
+    // Invocation 2: visible text follows — separator should be inserted
+    await projector.onEvent({
+      type: "text_delta",
+      text: "Results incoming.",
+      tag: "agent_message_chunk",
+    });
+    await projector.onEvent({ type: "done" });
+
+    // Turn completion
+    await projector.flush(true);
+
+    const finals = deliveries.filter((d) => d.kind === "final");
+    expect(finals).toHaveLength(1);
+    // Default hiddenBoundarySeparator in non-live mode is "paragraph" (\n\n).
+    // The separator is inserted between the previous visible text tail and the
+    // next text because pendingHiddenBoundary survived across the done boundary.
+    expect(finals[0]?.text).toBe("Looking up data.\n\nResults incoming.");
   });
 
   it("suppresses usage_update by default and allows deduped usage when tag-visible", async () => {

--- a/src/auto-reply/reply/acp-projector.ts
+++ b/src/auto-reply/reply/acp-projector.ts
@@ -265,15 +265,23 @@ export function createAcpReplyProjector(params: {
     clearLiveIdleTimer();
     blockReplyPipeline.stop();
     blockReplyPipeline = createTurnBlockReplyPipeline();
-    emittedOutputChars = 0;
-    truncationNoticeEmitted = false;
+    if (settings.deliveryMode !== "final_only") {
+      emittedOutputChars = 0;
+      truncationNoticeEmitted = false;
+      lastVisibleOutputTail = undefined;
+      pendingHiddenBoundary = false;
+    }
     lastStatusHash = undefined;
     lastToolHash = undefined;
     lastUsageTuple = undefined;
-    lastVisibleOutputTail = undefined;
-    pendingHiddenBoundary = false;
     liveBufferText = "";
-    finalOnlyOutputText = "";
+    // finalOnlyOutputText deliberately survives resetTurnState so text
+    // produced before tool calls accumulates across model invocations
+    // within a single ACP turn. emittedOutputChars, truncation state,
+    // lastVisibleOutputTail, and pendingHiddenBoundary also persist in
+    // final_only mode so the per-turn output limit, separator insertion,
+    // and hidden-boundary tracking stay scoped to the accumulated turn
+    // (#84486).
     pendingToolDeliveries.length = 0;
     toolLifecycleById.clear();
   };
@@ -287,14 +295,14 @@ export function createAcpReplyProjector(params: {
     }
   };
 
-  const flush = async (force = false): Promise<void> => {
+  const flush = async (force = false, opts?: { skipFinalText?: boolean }): Promise<void> => {
     if (settings.deliveryMode === "live") {
       clearLiveIdleTimer();
       flushLiveBuffer({ force: true });
     }
     await flushBufferedToolDeliveries(force);
     if (settings.deliveryMode === "final_only") {
-      if (force && finalOnlyOutputText.trim().length > 0) {
+      if (force && !opts?.skipFinalText && finalOnlyOutputText.trim().length > 0) {
         const text = finalOnlyOutputText;
         finalOnlyOutputText = "";
         await params.deliver("final", { text });
@@ -498,7 +506,13 @@ export function createAcpReplyProjector(params: {
     }
 
     if (event.type === "done" || event.type === "error") {
-      await flush(true);
+      // In final_only mode, skip final text delivery on intermediate done
+      // events so text accumulated before tool calls is carried forward.
+      // The accumulated text is delivered once at turn completion via the
+      // flush(true) call in tryDispatchAcpReply (#84486).
+      await flush(true, {
+        skipFinalText: settings.deliveryMode === "final_only",
+      });
       resetTurnState();
     }
   };


### PR DESCRIPTION
## Summary

Addresses the ACP `final_only` delivery-mode portion of #84486 — text produced before tool calls was lost because `resetTurnState()` cleared `finalOnlyOutputText` between model invocations within the same ACP turn.

Changes in `final_only` mode (all scoped to `deliveryMode === "final_only"`):
- `finalOnlyOutputText` survives `resetTurnState()` across invocations — pre-tool text is preserved
- `emittedOutputChars` and `truncationNoticeEmitted` survive — `acp.stream.maxOutputChars` is enforced as a per-turn budget
- `lastVisibleOutputTail` and `pendingHiddenBoundary` survive — hidden tool-call boundary separators are correctly inserted across invocation boundaries
- Intermediate `done` events skip final text delivery — accumulated text is delivered once at turn completion via `flush(true)`

## Changes

- `src/auto-reply/reply/acp-projector.ts`: four `final_only` state fields no longer cleared in `resetTurnState()`; `flush()` accepts `skipFinalText` option; `onEvent` passes `skipFinalText: true` for `done`/`error` events in `final_only` mode
- `src/auto-reply/reply/acp-projector.test.ts`: updated existing buffering test; 3 new regression tests covering multi-invocation text accumulation, `maxOutputChars` truncation, and hidden-boundary separator preservation

## Real behavior proof

Behavior addressed: Pre-tool text in final_only delivery mode is discarded when resetTurnState() clears finalOnlyOutputText between model invocations. Output limit counters and hidden-boundary separator state were also incorrectly reset, allowing truncation bypass and separator loss.

Real environment tested: macOS Darwin 25.4.0 (arm64), Node.js v24.14.1, OpenClaw 2026.5.19 (359135f)

Exact steps or command run after this patch:
```
pnpm test src/auto-reply/reply/acp-projector.test.ts \
  src/auto-reply/reply/dispatch-acp.test.ts \
  src/auto-reply/reply/dispatch-acp-delivery.test.ts

pnpm format:check src/auto-reply/reply/acp-projector.ts

pnpm lint src/auto-reply/reply/acp-projector.ts

npx tsx scripts/proof-acp-runtime.ts
```

Evidence after fix (regression/unit tests):
```
 Test Files  3 passed (3)
      Tests  100 passed (100)
 Format: all matched files use the correct format
 Lint:   0 warnings and 0 errors
```

Evidence after fix (real ACP projector runtime — standalone `npx tsx` execution, not a test):
```
================================================================
ACP projector runtime proof — deliveryMode=final_only
================================================================
Projector created. Simulating 2-invocation ACP turn.

[Invocation 1] done(toolUse) — text deferred, skipFinalText=true
  deliveries so far: 0 final
[Invocation 2] done(stop) — text still deferred
  deliveries so far: 0 final
[Turn end] flush(true) — delivering all accumulated text

----------------------------------------------------------------
Result:
----------------------------------------------------------------
  Total deliveries:     2
  Final deliveries:     1
  Contains "Step 1":     true
  Contains "Step 2":     true
  Contains "Step 3":     true
  Contains "Step 4":     true
  Final text preview:   Step 1: Planning. Step 2: Executing query.
                         Step 3: Results: 42 rows. Step 4: Formatting output.
----------------------------------------------------------------
PASS — all 4 steps in one final message, pre-tool text preserved
```

The standalone runtime proof imports the real `createAcpReplyProjector` (not mocked), creates a projector with `deliveryMode=final_only`, feeds it real ACP events across two invocations separated by a tool-call boundary, and captures the deliveries. After `done(toolUse)`, zero final deliveries occurred (text deferred). After `done(stop)`, still zero final deliveries (text deferred). Only on the turn-level `flush(true)` was all accumulated text delivered in one final message containing all 4 steps.

Observed result after fix: 100 regression/unit tests pass across 3 test files. Standalone runtime proof confirms that in final_only mode, pre-tool text survives across the done(toolUse) boundary, intermediate done events skip final delivery, and turn-level flush delivers one complete message. Format and lint clean.

What was not tested: Live Feishu/Telegram channel delivery with real ACP session (requires live credentials and channel setup); the Feishu-specific streaming-card delivery path (separate from ACP dispatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)