### PR TITLE
fix(imessage): detect and recover anchorless watch payloads before routing

### DIFF
--- a/extensions/imessage/src/monitor.watch-subscribe-retry.test.ts
+++ b/extensions/imessage/src/monitor.watch-subscribe-retry.test.ts
@@ -32,13 +32,15 @@ function createRuntime() {
 }
 
 type MockIMessageRpcClient = IMessageRpcClient & {
-  request: ReturnType<typeof vi.fn<(method: string) => Promise<unknown>>>;
+  request: ReturnType<
+    typeof vi.fn<(method: string, params?: Record<string, unknown>) => Promise<unknown>>
+  >;
   waitForClose: ReturnType<typeof vi.fn<() => Promise<void>>>;
   stop: ReturnType<typeof vi.fn<() => Promise<void>>>;
 };
 
 function createRpcClient(overrides?: {
-  request?: (method: string) => Promise<unknown>;
+  request?: (method: string, params?: Record<string, unknown>) => Promise<unknown>;
   waitForClose?: () => Promise<void>;
 }): MockIMessageRpcClient {
   const client = {
@@ -117,6 +119,118 @@ describe("monitorIMessageProvider watch.subscribe startup retry", () => {
         String(message).includes("imessage: monitor failed"),
       ),
     ).toBe(false);
+  });
+
+  it("repairs anchorless live payloads before debounce classification", async () => {
+    const runtime = createRuntime();
+    let notify: ((msg: { method: string; params?: unknown }) => void) | undefined;
+    let close!: () => void;
+    const closed = new Promise<void>((resolve) => {
+      close = resolve;
+    });
+    const calls: Array<{ method: string; params?: Record<string, unknown> }> = [];
+    const client = createRpcClient({
+      waitForClose: async () => await closed,
+      request: async (method, params) => {
+        calls.push({ method, params });
+        if (method === "watch.subscribe") {
+          return { subscription: 1 };
+        }
+        if (method === "chats.list") {
+          return { chats: [{ id: 101 }, { id: 202 }] };
+        }
+        if (method === "messages.history") {
+          if (params?.chat_id === 101) {
+            return {
+              messages: [
+                {
+                  guid: "GUID-GROUP-A",
+                  chat_id: 101,
+                  chat_guid: "iMessage;+;group-a",
+                  chat_identifier: "group-a",
+                  is_group: true,
+                  participants: ["+15550001111", "+15550002222"],
+                },
+              ],
+            };
+          }
+          if (params?.chat_id === 202) {
+            return {
+              messages: [
+                {
+                  guid: "GUID-GROUP-B",
+                  chat_id: 202,
+                  chat_guid: "iMessage;+;group-b",
+                  chat_identifier: "group-b",
+                  is_group: true,
+                  participants: ["+15550001111", "+15550003333"],
+                },
+              ],
+            };
+          }
+          return { messages: [] };
+        }
+        return {};
+      },
+    });
+
+    createIMessageRpcClientMock.mockImplementation(async (opts) => {
+      notify = opts?.onNotification;
+      return client;
+    });
+
+    const monitorPromise = monitorIMessageProvider({
+      config: {
+        channels: {
+          imessage: {
+            coalesceSameSenderDms: true,
+            groupPolicy: "open",
+            groups: { "*": { requireMention: true } },
+          },
+        },
+        messages: { groupChat: { mentionPatterns: ["@openclaw"] } },
+      } as never,
+      runtime: runtime as never,
+    });
+
+    await vi.waitFor(() => expect(notify).toBeDefined());
+
+    const baseMessage = {
+      chat_id: 0,
+      sender: "+15550001111",
+      is_from_me: false,
+      attachments: null,
+      chat_identifier: "",
+      chat_guid: "",
+      chat_name: "",
+      participants: null,
+      is_group: false,
+    };
+    notify?.({
+      method: "message",
+      params: { message: { ...baseMessage, guid: "GUID-GROUP-A", text: "first group" } },
+    });
+    notify?.({
+      method: "message",
+      params: { message: { ...baseMessage, guid: "GUID-GROUP-B", text: "second group" } },
+    });
+
+    await vi.waitFor(() =>
+      expect(
+        calls.filter((call) => call.method === "messages.history" && call.params?.chat_id === 202),
+      ).toHaveLength(1),
+    );
+
+    expect(calls.filter((call) => call.method === "chats.list")).toHaveLength(2);
+    expect(
+      calls.filter((call) => call.method === "messages.history" && call.params?.chat_id === 101),
+    ).toHaveLength(2);
+    expect(
+      calls.filter((call) => call.method === "messages.history" && call.params?.chat_id === 202),
+    ).toHaveLength(1);
+
+    close();
+    await monitorPromise;
   });
 
   it("still fails after bounded startup retries are exhausted", async () => {

--- a/extensions/imessage/src/monitor/conversation-repair.test.ts
+++ b/extensions/imessage/src/monitor/conversation-repair.test.ts
@@ -1,0 +1,339 @@
+import { describe, expect, it } from "vitest";
+import { isIMessageAnchorless, repairIMessageConversationAnchor } from "./conversation-repair.js";
+import type { IMessagePayload } from "./types.js";
+
+function makeAnchorlessGroupLinkPreview(): IMessagePayload {
+  return {
+    id: 9500,
+    guid: "F0F0F0F0-AAAA-BBBB-CCCC-DDDDDDDDDDDD",
+    chat_id: 0,
+    sender: "+15550001111",
+    is_from_me: false,
+    text: "https://example.com/article",
+    attachments: null,
+    chat_identifier: "",
+    chat_guid: "",
+    chat_name: "",
+    participants: null,
+    is_group: false,
+  };
+}
+
+function makeValidGroupMessage(): IMessagePayload {
+  return {
+    id: 9501,
+    guid: "A1B2C3D4-E5F6-7890-ABCD-EF1234567890",
+    chat_id: 349,
+    sender: "+15550001111",
+    is_from_me: false,
+    text: "hello group",
+    attachments: null,
+    chat_identifier: "chat349",
+    chat_guid: "iMessage;+;chat349",
+    chat_name: "Test Group",
+    participants: ["+15550001111", "+15550002222"],
+    is_group: true,
+  };
+}
+
+function makeValidDm(): IMessagePayload {
+  return {
+    id: 9502,
+    guid: "DM-GUID-0001",
+    chat_id: null,
+    sender: "+15550001111",
+    is_from_me: false,
+    text: "hello dm",
+    attachments: null,
+    chat_identifier: "+15550001111",
+    chat_guid: "iMessage;+;+15550001111",
+    chat_name: null,
+    participants: null,
+    is_group: false,
+  };
+}
+
+describe("isIMessageAnchorless", () => {
+  it("returns true for chat_id=0 with empty chat_guid and chat_identifier", () => {
+    expect(isIMessageAnchorless(makeAnchorlessGroupLinkPreview())).toBe(true);
+  });
+
+  it("returns true for chat_id=null with empty chat_guid and chat_identifier", () => {
+    const msg = makeAnchorlessGroupLinkPreview();
+    msg.chat_id = null;
+    expect(isIMessageAnchorless(msg)).toBe(true);
+  });
+
+  it("returns true for chat_id=-1 with empty chat_guid and chat_identifier", () => {
+    const msg = makeAnchorlessGroupLinkPreview();
+    msg.chat_id = -1;
+    expect(isIMessageAnchorless(msg)).toBe(true);
+  });
+
+  it("returns true for undefined fields", () => {
+    const msg: IMessagePayload = {
+      guid: "test",
+      sender: "+15550001111",
+      text: "hello",
+    };
+    expect(isIMessageAnchorless(msg)).toBe(true);
+  });
+
+  it("returns false for valid group message with positive chat_id", () => {
+    expect(isIMessageAnchorless(makeValidGroupMessage())).toBe(false);
+  });
+
+  it("returns false when chat_guid is non-empty even with chat_id=0", () => {
+    const msg = makeAnchorlessGroupLinkPreview();
+    msg.chat_guid = "iMessage;+;chat349";
+    expect(isIMessageAnchorless(msg)).toBe(false);
+  });
+
+  it("returns false when chat_identifier is non-empty even with chat_id=0", () => {
+    const msg = makeAnchorlessGroupLinkPreview();
+    msg.chat_identifier = "chat349";
+    expect(isIMessageAnchorless(msg)).toBe(false);
+  });
+
+  it("returns false for DM with valid chat_identifier", () => {
+    expect(isIMessageAnchorless(makeValidDm())).toBe(false);
+  });
+});
+
+function mockClient(chats: Array<{ id: number; messages: Record<string, unknown>[] }>) {
+  const calls: { method: string; params?: Record<string, unknown> }[] = [];
+  return {
+    calls,
+    request: async <T = unknown>(method: string, params?: Record<string, unknown>): Promise<T> => {
+      calls.push({ method, params });
+      if (method === "chats.list") {
+        return {
+          chats: chats.map((c) => ({
+            id: c.id,
+            last_message_at: new Date().toISOString(),
+          })),
+        } as T;
+      }
+      if (method === "messages.history") {
+        const chatId = params?.chat_id;
+        const match = chats.find((c) => c.id === chatId);
+        return { messages: match?.messages ?? [] } as T;
+      }
+      throw new Error(`unexpected method: ${method}`);
+    },
+  };
+}
+
+describe("repairIMessageConversationAnchor", () => {
+  it("passes through non-anchorless messages unchanged", async () => {
+    const msg = makeValidGroupMessage();
+    const client = mockClient([]);
+    const result = await repairIMessageConversationAnchor({
+      message: msg,
+      client: client as never,
+    });
+    expect(result).toBe(msg);
+    expect(client.calls).toHaveLength(0);
+  });
+
+  it("recovers group conversation from messages.history by GUID", async () => {
+    const msg = makeAnchorlessGroupLinkPreview();
+    const historyEntry = {
+      id: 9500,
+      guid: msg.guid,
+      chat_id: 349,
+      chat_guid: "iMessage;+;chat349",
+      chat_identifier: "chat349",
+      chat_name: "Test Group",
+      is_group: true,
+      participants: ["+15550001111", "+15550002222"],
+      sender: "+15550001111",
+      text: "https://example.com/article",
+      is_from_me: false,
+    };
+    const client = mockClient([{ id: 349, messages: [historyEntry] }]);
+
+    const result = await repairIMessageConversationAnchor({
+      message: msg,
+      client: client as never,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.chat_id).toBe(349);
+    expect(result!.chat_guid).toBe("iMessage;+;chat349");
+    expect(result!.chat_identifier).toBe("chat349");
+    expect(result!.is_group).toBe(true);
+    expect(result!.chat_name).toBe("Test Group");
+    expect(result!.participants).toEqual(["+15550001111", "+15550002222"]);
+  });
+
+  it("returns null when anchorless and GUID is missing", async () => {
+    const msg = makeAnchorlessGroupLinkPreview();
+    msg.guid = null;
+    const client = mockClient([]);
+    const logs: string[] = [];
+
+    const result = await repairIMessageConversationAnchor({
+      message: msg,
+      client: client as never,
+      runtime: { error: (m) => logs.push(m) },
+    });
+
+    expect(result).toBeNull();
+    expect(logs).toHaveLength(1);
+    expect(logs[0]).toContain("without GUID");
+  });
+
+  it("returns null when GUID is not found in any chat history", async () => {
+    const msg = makeAnchorlessGroupLinkPreview();
+    const client = mockClient([
+      {
+        id: 100,
+        messages: [{ guid: "other-guid-1", chat_id: 100, is_group: true }],
+      },
+      {
+        id: 200,
+        messages: [{ guid: "other-guid-2", chat_id: 200, is_group: false }],
+      },
+    ]);
+    const logs: string[] = [];
+
+    const result = await repairIMessageConversationAnchor({
+      message: msg,
+      client: client as never,
+      runtime: { error: (m) => logs.push(m) },
+    });
+
+    expect(result).toBeNull();
+    expect(logs.some((l) => l.includes("not found"))).toBe(true);
+  });
+
+  it("returns null when chats.list RPC fails", async () => {
+    const msg = makeAnchorlessGroupLinkPreview();
+    const client = {
+      request: async () => {
+        throw new Error("RPC unavailable");
+      },
+    };
+    const logs: string[] = [];
+
+    const result = await repairIMessageConversationAnchor({
+      message: msg,
+      client: client as never,
+      runtime: { error: (m) => logs.push(m) },
+    });
+
+    expect(result).toBeNull();
+    expect(logs.some((l) => l.includes("chats.list error"))).toBe(true);
+  });
+
+  it("continues scanning after a per-chat messages.history failure", async () => {
+    const msg = makeAnchorlessGroupLinkPreview();
+    const targetGuid = msg.guid!;
+    const goodEntry = {
+      id: 9500,
+      guid: targetGuid,
+      chat_id: 349,
+      chat_guid: "iMessage;+;chat349",
+      chat_identifier: "chat349",
+      is_group: true,
+      participants: ["+15550001111"],
+      sender: "+15550001111",
+      text: "test",
+    };
+    let chatsListed = false;
+    let chatId100Queried = false;
+    const client = {
+      request: async <T = unknown>(
+        method: string,
+        params?: Record<string, unknown>,
+      ): Promise<T> => {
+        if (method === "chats.list") {
+          chatsListed = true;
+          return {
+            chats: [
+              { id: 100, last_message_at: new Date().toISOString() },
+              { id: 349, last_message_at: new Date().toISOString() },
+            ],
+          } as T;
+        }
+        if (method === "messages.history") {
+          if (params?.chat_id === 100) {
+            chatId100Queried = true;
+            throw new Error("history unavailable");
+          }
+          if (params?.chat_id === 349) {
+            return { messages: [goodEntry] } as T;
+          }
+        }
+        throw new Error(`unexpected: ${method}`);
+      },
+    };
+
+    const result = await repairIMessageConversationAnchor({
+      message: msg,
+      client: client as never,
+    });
+
+    expect(chatId100Queried).toBe(true);
+    expect(result).not.toBeNull();
+    expect(result!.chat_id).toBe(349);
+    expect(result!.is_group).toBe(true);
+  });
+
+  it("does not overwrite fields with invalid recovered values", async () => {
+    const msg = makeAnchorlessGroupLinkPreview();
+    const entry = {
+      id: 9500,
+      guid: msg.guid,
+      chat_id: 0,
+      chat_guid: "",
+      chat_identifier: "",
+      is_group: "yes",
+      participants: "not-array",
+      sender: "+15550001111",
+    };
+    const client = mockClient([{ id: 1, messages: [entry] }]);
+
+    const result = await repairIMessageConversationAnchor({
+      message: msg,
+      client: client as never,
+    });
+
+    // Recovery found the GUID but recovered no valid fields — still returns
+    // the spread copy with original anchorless values.
+    expect(result).not.toBeNull();
+    expect(result!.chat_id).toBe(0);
+    expect(result!.chat_guid).toBe("");
+    expect(result!.chat_identifier).toBe("");
+    expect(result!.is_group).toBe(false);
+    expect(result!.participants).toBeNull();
+  });
+
+  it("respects chatsLimit parameter", async () => {
+    const msg = makeAnchorlessGroupLinkPreview();
+    let chatsLimitReceived: number | undefined;
+    const client = {
+      request: async <T = unknown>(
+        method: string,
+        params?: Record<string, unknown>,
+      ): Promise<T> => {
+        if (method === "chats.list") {
+          chatsLimitReceived = params?.limit as number;
+          return { chats: [] } as T;
+        }
+        return { messages: [] } as T;
+      },
+    };
+
+    const result = await repairIMessageConversationAnchor({
+      message: msg,
+      client: client as never,
+      chatsLimit: 5,
+    });
+
+    // chatsLimit is passed through to chats.list; empty result means drop.
+    expect(chatsLimitReceived).toBe(5);
+    expect(result).toBeNull();
+  });
+});

--- a/extensions/imessage/src/monitor/conversation-repair.test.ts
+++ b/extensions/imessage/src/monitor/conversation-repair.test.ts
@@ -70,13 +70,13 @@ describe("isIMessageAnchorless", () => {
     expect(isIMessageAnchorless(msg)).toBe(true);
   });
 
-  it("returns true for undefined fields", () => {
+  it("returns false for sender-only direct messages with undefined conversation fields", () => {
     const msg: IMessagePayload = {
       guid: "test",
       sender: "+15550001111",
       text: "hello",
     };
-    expect(isIMessageAnchorless(msg)).toBe(true);
+    expect(isIMessageAnchorless(msg)).toBe(false);
   });
 
   it("returns false for valid group message with positive chat_id", () => {
@@ -127,6 +127,22 @@ function mockClient(chats: Array<{ id: number; messages: Record<string, unknown>
 describe("repairIMessageConversationAnchor", () => {
   it("passes through non-anchorless messages unchanged", async () => {
     const msg = makeValidGroupMessage();
+    const client = mockClient([]);
+    const result = await repairIMessageConversationAnchor({
+      message: msg,
+      client: client as never,
+    });
+    expect(result).toBe(msg);
+    expect(client.calls).toHaveLength(0);
+  });
+
+  it("passes through sender-only direct messages without recovery RPCs", async () => {
+    const msg: IMessagePayload = {
+      guid: "sender-only-dm",
+      sender: "+15550001111",
+      is_from_me: false,
+      text: "hello dm",
+    };
     const client = mockClient([]);
     const result = await repairIMessageConversationAnchor({
       message: msg,

--- a/extensions/imessage/src/monitor/conversation-repair.test.ts
+++ b/extensions/imessage/src/monitor/conversation-repair.test.ts
@@ -281,7 +281,7 @@ describe("repairIMessageConversationAnchor", () => {
     expect(result!.is_group).toBe(true);
   });
 
-  it("does not overwrite fields with invalid recovered values", async () => {
+  it("returns null when recovered fields are all invalid (still anchorless)", async () => {
     const msg = makeAnchorlessGroupLinkPreview();
     const entry = {
       id: 9500,
@@ -294,20 +294,17 @@ describe("repairIMessageConversationAnchor", () => {
       sender: "+15550001111",
     };
     const client = mockClient([{ id: 1, messages: [entry] }]);
+    const logs: string[] = [];
 
     const result = await repairIMessageConversationAnchor({
       message: msg,
       client: client as never,
+      runtime: { error: (m) => logs.push(m) },
     });
 
-    // Recovery found the GUID but recovered no valid fields — still returns
-    // the spread copy with original anchorless values.
-    expect(result).not.toBeNull();
-    expect(result!.chat_id).toBe(0);
-    expect(result!.chat_guid).toBe("");
-    expect(result!.chat_identifier).toBe("");
-    expect(result!.is_group).toBe(false);
-    expect(result!.participants).toBeNull();
+    // GUID found but no valid anchor fields recovered — fail-closed.
+    expect(result).toBeNull();
+    expect(logs.some((l) => l.includes("no valid anchor fields recovered"))).toBe(true);
   });
 
   it("respects chatsLimit parameter", async () => {

--- a/extensions/imessage/src/monitor/conversation-repair.ts
+++ b/extensions/imessage/src/monitor/conversation-repair.ts
@@ -154,6 +154,13 @@ export async function repairIMessageConversationAnchor(
         repaired.participants = entry.participants as string[];
       }
 
+      if (isIMessageAnchorless(repaired)) {
+        runtime?.error?.(
+          `imessage: dropping anchorless message GUID=${guid} (found in history but no valid anchor fields recovered)`,
+        );
+        return null;
+      }
+
       runtime?.log?.(
         `imessage: recovered conversation for GUID=${guid}: chat_id=${repaired.chat_id}, is_group=${repaired.is_group}`,
       );

--- a/extensions/imessage/src/monitor/conversation-repair.ts
+++ b/extensions/imessage/src/monitor/conversation-repair.ts
@@ -1,0 +1,168 @@
+import type { IMessageRpcClient } from "../client.js";
+import type { IMessagePayload } from "./types.js";
+
+/**
+ * An anchorless payload lacks every reliable conversation identifier: no valid
+ * chat_id (positive integer), no non-empty chat_guid, and no non-empty
+ * chat_identifier. When imsg watch.subscribe ships a group link-preview row
+ * with chat_id=0 and empty string fields, the message passes type validation
+ * but cannot be safely routed — it must not fall back to sender-DM routing.
+ */
+export function isIMessageAnchorless(message: IMessagePayload): boolean {
+  const chatId = message.chat_id;
+  const chatGuid = message.chat_guid?.trim();
+  const chatIdentifier = message.chat_identifier?.trim();
+
+  const hasValidChatId = typeof chatId === "number" && chatId > 0 && Number.isFinite(chatId);
+  const hasValidChatGuid = chatGuid !== undefined && chatGuid !== "";
+  const hasValidChatIdentifier = chatIdentifier !== undefined && chatIdentifier !== "";
+
+  return !hasValidChatId && !hasValidChatGuid && !hasValidChatIdentifier;
+}
+
+type ChatsListEntry = {
+  id?: number | null;
+  last_message_at?: string | null;
+};
+
+type MessagesHistoryResult = {
+  messages?: unknown[];
+};
+
+type RuntimeLogger = {
+  log?: (msg: string) => void;
+  error?: (msg: string) => void;
+};
+
+export type RepairIMessageConversationAnchorParams = {
+  message: IMessagePayload;
+  client: IMessageRpcClient;
+  runtime?: RuntimeLogger;
+  /** Override for tests. */
+  chatsLimit?: number;
+  /** Override for tests. */
+  perChatHistoryLimit?: number;
+  /** Override for tests. */
+  rpcTimeoutMs?: number;
+};
+
+const DEFAULT_CHATS_LIMIT = 20;
+const DEFAULT_PER_CHAT_HISTORY_LIMIT = 50;
+const DEFAULT_RPC_TIMEOUT_MS = 5_000;
+
+/**
+ * If the payload is anchorless, attempt to recover the real conversation by
+ * searching recent chats via `chats.list` + `messages.history` for the message
+ * GUID. Returns the repaired payload on success, or `null` to signal a
+ * fail-closed drop. Non-anchorless payloads pass through unchanged.
+ */
+export async function repairIMessageConversationAnchor(
+  params: RepairIMessageConversationAnchorParams,
+): Promise<IMessagePayload | null> {
+  const { message, client, runtime } = params;
+
+  if (!isIMessageAnchorless(message)) {
+    return message;
+  }
+
+  const guid = message.guid?.trim();
+  if (!guid) {
+    runtime?.error?.("imessage: dropping anchorless message without GUID (no recovery possible)");
+    return null;
+  }
+
+  runtime?.log?.(
+    `imessage: anchorless payload detected for GUID=${guid}, attempting conversation recovery`,
+  );
+
+  const chatsLimit = params.chatsLimit ?? DEFAULT_CHATS_LIMIT;
+  const perChatLimit = params.perChatHistoryLimit ?? DEFAULT_PER_CHAT_HISTORY_LIMIT;
+  const timeoutMs = params.rpcTimeoutMs ?? DEFAULT_RPC_TIMEOUT_MS;
+
+  let chatsResult: { chats?: ChatsListEntry[] } | undefined;
+  try {
+    chatsResult = await client.request<{ chats?: ChatsListEntry[] }>(
+      "chats.list",
+      { limit: chatsLimit },
+      { timeoutMs },
+    );
+  } catch (err) {
+    runtime?.error?.(`imessage: conversation recovery failed (chats.list error): ${String(err)}`);
+    return null;
+  }
+
+  const chats = chatsResult?.chats ?? [];
+
+  for (const chat of chats) {
+    const chatId = typeof chat.id === "number" && Number.isFinite(chat.id) ? chat.id : null;
+    if (chatId === null) {
+      continue;
+    }
+
+    let historyResult: MessagesHistoryResult | undefined;
+    try {
+      historyResult = await client.request<MessagesHistoryResult>(
+        "messages.history",
+        {
+          chat_id: chatId,
+          limit: perChatLimit,
+          attachments: false,
+        },
+        { timeoutMs },
+      );
+    } catch {
+      continue;
+    }
+
+    const messages = Array.isArray(historyResult?.messages) ? historyResult.messages : [];
+
+    for (const raw of messages) {
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+        continue;
+      }
+      const entry = raw as Record<string, unknown>;
+      if (entry.guid !== guid) {
+        continue;
+      }
+
+      // Found the message. Extract conversation metadata from the history
+      // entry and overlay onto the original payload.
+      const repaired = { ...message };
+      if (
+        typeof entry.chat_id === "number" &&
+        Number.isFinite(entry.chat_id) &&
+        entry.chat_id > 0
+      ) {
+        repaired.chat_id = entry.chat_id;
+      }
+      if (typeof entry.chat_guid === "string" && entry.chat_guid) {
+        repaired.chat_guid = entry.chat_guid;
+      }
+      if (typeof entry.chat_identifier === "string" && entry.chat_identifier) {
+        repaired.chat_identifier = entry.chat_identifier;
+      }
+      if (typeof entry.is_group === "boolean") {
+        repaired.is_group = entry.is_group;
+      }
+      if (typeof entry.chat_name === "string") {
+        repaired.chat_name = entry.chat_name;
+      }
+      if (
+        Array.isArray(entry.participants) &&
+        entry.participants.every((p) => typeof p === "string")
+      ) {
+        repaired.participants = entry.participants as string[];
+      }
+
+      runtime?.log?.(
+        `imessage: recovered conversation for GUID=${guid}: chat_id=${repaired.chat_id}, is_group=${repaired.is_group}`,
+      );
+      return repaired;
+    }
+  }
+
+  runtime?.error?.(
+    `imessage: dropping anchorless message GUID=${guid} (not found in recent chat history)`,
+  );
+  return null;
+}

--- a/extensions/imessage/src/monitor/conversation-repair.ts
+++ b/extensions/imessage/src/monitor/conversation-repair.ts
@@ -2,22 +2,21 @@ import type { IMessageRpcClient } from "../client.js";
 import type { IMessagePayload } from "./types.js";
 
 /**
- * An anchorless payload lacks every reliable conversation identifier: no valid
- * chat_id (positive integer), no non-empty chat_guid, and no non-empty
- * chat_identifier. When imsg watch.subscribe ships a group link-preview row
- * with chat_id=0 and empty string fields, the message passes type validation
- * but cannot be safely routed — it must not fall back to sender-DM routing.
+ * The malformed watch payload has explicit but unusable conversation fields:
+ * chat_id is non-positive/null and both chat_guid/chat_identifier are empty.
  */
 export function isIMessageAnchorless(message: IMessagePayload): boolean {
   const chatId = message.chat_id;
-  const chatGuid = message.chat_guid?.trim();
-  const chatIdentifier = message.chat_identifier?.trim();
+  const chatGuid = message.chat_guid;
+  const chatIdentifier = message.chat_identifier;
 
-  const hasValidChatId = typeof chatId === "number" && chatId > 0 && Number.isFinite(chatId);
-  const hasValidChatGuid = chatGuid !== undefined && chatGuid !== "";
-  const hasValidChatIdentifier = chatIdentifier !== undefined && chatIdentifier !== "";
+  const hasInvalidExplicitChatId =
+    chatId === null || (typeof chatId === "number" && (!Number.isFinite(chatId) || chatId <= 0));
+  const hasEmptyExplicitChatGuid = typeof chatGuid === "string" && chatGuid.trim() === "";
+  const hasEmptyExplicitChatIdentifier =
+    typeof chatIdentifier === "string" && chatIdentifier.trim() === "";
 
-  return !hasValidChatId && !hasValidChatGuid && !hasValidChatIdentifier;
+  return hasInvalidExplicitChatId && hasEmptyExplicitChatGuid && hasEmptyExplicitChatIdentifier;
 }
 
 type ChatsListEntry = {

--- a/extensions/imessage/src/monitor/conversation-repair.ts
+++ b/extensions/imessage/src/monitor/conversation-repair.ts
@@ -151,7 +151,7 @@ export async function repairIMessageConversationAnchor(
         Array.isArray(entry.participants) &&
         entry.participants.every((p) => typeof p === "string")
       ) {
-        repaired.participants = entry.participants as string[];
+        repaired.participants = entry.participants;
       }
 
       if (isIMessageAnchorless(repaired)) {

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -501,7 +501,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
     });
 
     // Build conversation key for rate limiting (used by both drop and dispatch paths).
-    const chatId = message.chat_id ?? undefined;
+    const chatId = repaired.chat_id ?? undefined;
     const senderForKey = (message.sender ?? "").trim();
     const conversationKey = chatId != null ? `group:${chatId}` : `dm:${senderForKey}`;
     const rateLimitKey = `${accountInfo.accountId}:${conversationKey}`;
@@ -525,7 +525,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       if (decision.reason === "group id not in allowlist") {
         warnGroupAllowlistDropPerChatOnce({
           accountId: accountInfo.accountId,
-          chatId: message.chat_id ?? undefined,
+          chatId: repaired.chat_id ?? undefined,
           log: (msg) => runtime.log?.(warn(msg)),
         });
       }
@@ -611,7 +611,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
     const { ctxPayload, chatTarget } = buildIMessageInboundContext({
       cfg,
       decision,
-      message,
+      message: repaired,
       previousTimestamp,
       remoteHost,
       historyLimit,

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -413,6 +413,14 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
     }
   }
 
+  async function repairMessageConversationAnchor(message: IMessagePayload) {
+    return await repairIMessageConversationAnchor({
+      message,
+      client: getActiveClient(),
+      runtime,
+    });
+  }
+
   async function handleMessageNow(
     message: IMessagePayload,
     options: { advanceCatchupCursor?: boolean } = {},
@@ -465,11 +473,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
     // (e.g. group link-preview with chat_id=0 and empty chat_guid/
     // chat_identifier). Fail-closed: if recovery cannot determine the real
     // conversation, the message is dropped rather than routed to sender DM.
-    const repaired = await repairIMessageConversationAnchor({
-      message,
-      client: getActiveClient(),
-      runtime,
-    });
+    const repaired = await repairMessageConversationAnchor(message);
     if (!repaired) {
       return;
     }
@@ -865,7 +869,11 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       runtime.error?.(`imessage: dropping malformed RPC message payload (keys=${shape})`);
       return;
     }
-    await inboundDebouncer.enqueue({ message });
+    const repaired = await repairMessageConversationAnchor(message);
+    if (!repaired) {
+      return;
+    }
+    await inboundDebouncer.enqueue({ message: repaired });
   };
 
   await waitForTransportReady({

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -54,6 +54,7 @@ import { attachIMessageMonitorAbortHandler } from "./abort-handler.js";
 import { runIMessageCatchup } from "./catchup-bridge.js";
 import { advanceIMessageCatchupCursor, resolveCatchupConfig } from "./catchup.js";
 import { combineIMessagePayloads } from "./coalesce.js";
+import { repairIMessageConversationAnchor } from "./conversation-repair.js";
 import { createIMessageEchoCachingSend, deliverReplies } from "./deliver.js";
 import { createSentMessageCache } from "./echo-cache.js";
 import {
@@ -460,6 +461,19 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
         : "";
     const bodyText = messageText || placeholder;
 
+    // Recover conversation anchor when the watch payload is malformed
+    // (e.g. group link-preview with chat_id=0 and empty chat_guid/
+    // chat_identifier). Fail-closed: if recovery cannot determine the real
+    // conversation, the message is dropped rather than routed to sender DM.
+    const repaired = await repairIMessageConversationAnchor({
+      message,
+      client: getActiveClient(),
+      runtime,
+    });
+    if (!repaired) {
+      return;
+    }
+
     const storeAllowFrom = await readChannelAllowFromStore(
       "imessage",
       process.env,
@@ -468,7 +482,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
     const decision = await resolveIMessageInboundDecision({
       cfg,
       accountId: accountInfo.accountId,
-      message,
+      message: repaired,
       opts,
       messageText,
       bodyText,


### PR DESCRIPTION
## Summary
- Fix iMessage group link-preview watch payloads that lose their conversation anchor (`chat_id=0`, empty `chat_guid` / `chat_identifier`, `is_group=false`) before they can be classified as sender DMs.
- Move anchorless recovery/fail-closed drop ahead of live inbound debounce classification so `coalesceSameSenderDms` cannot merge malformed group payloads under the raw `chat:0` DM bucket.
- Keep the existing recovery path for catchup/direct handling and add monitor-level regression coverage for the live coalescing path.

## Real behavior proof

**Behavior or issue addressed**: iMessage group link-preview watch payloads can arrive without usable conversation anchor fields. Before this fix, live notifications entered the inbound debouncer first, so with `coalesceSameSenderDms=true` multiple anchorless group payloads from the same sender could be merged under `imessage:<account>:dm:chat:0:<sender>` before recovery. The merged turn was then repaired using only the first GUID and could route content from another group under the first recovered group.

**Real environment tested**: macOS 26.4.1, Node.js v24.15.0, OpenClaw v2026.5.19, worktree SHA `e22876fd1bef`, `imsg` 0.9.0 installed at `/opt/homebrew/bin/imsg`.

**Exact steps or command run after this patch**:
```bash
imsg status --json
printf '{"jsonrpc":"2.0","id":1,"method":"chats.list","params":{"limit":3}}\n' | imsg rpc --json

OPENCLAW_GATEWAY_PORT=19046 \
OPENCLAW_GATEWAY_TOKEN=pr-84503-local-token \
OPENCLAW_STATE_DIR=/Users/zhangguiping/daily_pr_work/proofs/openclaw-pr-84503-local-proof/state \
OPENCLAW_CONFIG_PATH=/Users/zhangguiping/daily_pr_work/proofs/openclaw-pr-84503-local-proof/state/openclaw.json \
node scripts/run-node.mjs --dev gateway --bind custom --port 19046

curl --noproxy '*' -sS -I http://127.0.0.1:19046/
curl --noproxy '*' -sS http://127.0.0.1:19046/health

OPENCLAW_GATEWAY_PORT=19046 \
OPENCLAW_GATEWAY_TOKEN=pr-84503-local-token \
OPENCLAW_STATE_DIR=/Users/zhangguiping/daily_pr_work/proofs/openclaw-pr-84503-local-proof/state \
OPENCLAW_CONFIG_PATH=/Users/zhangguiping/daily_pr_work/proofs/openclaw-pr-84503-local-proof/state/openclaw.json \
node scripts/run-node.mjs channels status --probe --channel imessage --json

pnpm exec vitest run \
  extensions/imessage/src/monitor.watch-subscribe-retry.test.ts \
  extensions/imessage/src/monitor/conversation-repair.test.ts \
  extensions/imessage/src/monitor.gating.test.ts \
  extensions/imessage/src/monitor/coalesce.test.ts
```

**Evidence after fix**:
```text
$ imsg status --json
{
  "version": "0.9.0",
  "basic_features": true,
  "sip": "enabled",
  "advanced_features": false,
  "rpc_methods": [
    "chats.list",
    "messages.history",
    "watch.subscribe",
    "watch.unsubscribe",
    "send",
    "send.rich",
    "send.attachment"
  ]
}

$ printf '{"jsonrpc":"2.0","id":1,"method":"chats.list","params":{"limit":3}}\n' | imsg rpc --json
{"result":{"chats":[]},"id":1,"jsonrpc":"2.0"}
```

```text
2026-05-24T18:23:21.205+08:00 [gateway] http server listening (10 plugins: acpx, bonjour, browser, canvas, device-pair, file-transfer, imessage, memory-core, phone-control, talk-voice; 1.7s)
2026-05-24T18:23:21.211+08:00 [gateway] starting channels and sidecars...
2026-05-24T18:23:21.264+08:00 [imessage] [default] starting provider (/opt/homebrew/bin/imsg db=/Users/zhangguiping/Library/Messages/chat.db)
2026-05-24T18:23:21.646+08:00 [gateway] ready
```

```text
$ curl --noproxy '*' -sS -I http://127.0.0.1:19046/
HTTP/1.1 200 OK
Content-Type: text/html; charset=utf-8

$ curl --noproxy '*' -sS http://127.0.0.1:19046/health
{"ok":true,"status":"live"}
```

```text
$ node scripts/run-node.mjs channels status --probe --channel imessage --json
{
  "channels": {
    "imessage": {
      "configured": true,
      "cliPath": "/opt/homebrew/bin/imsg",
      "dbPath": "/Users/zhangguiping/Library/Messages/chat.db",
      "running": true,
      "lastError": null,
      "probe": {
        "ok": true,
        "privateApi": {
          "available": false,
          "rpcMethods": [
            "chats.list",
            "messages.history",
            "watch.subscribe",
            "watch.unsubscribe"
          ]
        }
      }
    }
  },
  "channelAccounts": {
    "imessage": [
      {
        "accountId": "default",
        "enabled": true,
        "configured": true,
        "running": true,
        "lastError": null,
        "probe": {
          "ok": true
        }
      }
    ]
  }
}
```

```text
Test Files  4 passed (4)
Tests       51 passed (51)
Duration    2.82s
```

**Observed result after fix**: The patched PR source starts a real OpenClaw gateway with the real iMessage plugin enabled, not skipped. The gateway starts `/opt/homebrew/bin/imsg` against the local Messages database, reaches `ready`, reports the iMessage account as configured/running with `lastError: null`, and the live channel probe confirms the `watch.subscribe`, `messages.history`, and `chats.list` RPC methods required by the anchorless-payload recovery path. The regression test for the reported live coalescing path still verifies that two anchorless payloads from different groups are repaired before debounce classification, so they no longer share the raw `chat:0` DM bucket.

**Additional live evidence gathered after this patch**:
- A real iMessage group chat exists locally (`chat_id=3`, `is_group=true`), and `imsg messages.history` shows a live URL message in that group:
  - `https://github.com/openclaw/openclaw/pull/84503`
- `imsg watch.subscribe` was started live and returned a real notification for a new group URL message sent with the same account:
  - `subscription=1`
  - `chat_id=3`
  - `is_group=true`
  - `text=https://github.com/openclaw/openclaw/pull/84503`
- That proves the local `Messages.app` + `imsg` + OpenClaw watch pipeline is live end-to-end on a real group conversation, but the notification payload itself was not malformed.

**What was not tested**: No new malformed group link-preview notification arrived from the local Messages account during this run, so the evidence does not include a live incoming private message/GUID. The live proof above verifies the patched OpenClaw runtime, real `imsg` bridge, local Messages DB access, and iMessage watch-capable channel startup; the exact malformed payload branch is covered by the monitor-level regression test using redacted synthetic GUIDs and handles.

Fixes #84470

## Regression Test Plan

- Coverage level: Unit test
- Target test file: `extensions/imessage/src/monitor.watch-subscribe-retry.test.ts`, `extensions/imessage/src/monitor/conversation-repair.test.ts`, `extensions/imessage/src/monitor.gating.test.ts`, `extensions/imessage/src/monitor/coalesce.test.ts`
- Scenario locked in: Anchorless live iMessage payloads are repaired before inbound debounce classification, unrecoverable anchorless payloads fail closed, and existing conversation-repair/gating/coalescing behavior remains covered.
- Why this is the smallest reliable guardrail: The regression drives the same monitor/watch path where live `watch.subscribe` notifications enter OpenClaw, while keeping private iMessage handles and GUIDs out of the repository.

## Root Cause

- Root cause: Live iMessage watch payloads were entering the inbound debouncer before conversation-anchor recovery. When a malformed group payload looked like `chat_id=0`, empty chat identifiers, and `is_group=false`, `coalesceSameSenderDms` could classify it as a sender DM before the GUID-based repair path had a chance to recover the real group.
- Missing detection / guardrail: The live monitor path lacked a pre-debounce guard for anchorless payloads and lacked regression coverage proving anchorless group payloads cannot be coalesced under a raw DM bucket.
