### PR TITLE
fix(ui): avoid local file links as gateway routes

### DIFF
--- a/ui/src/ui/markdown.test.ts
+++ b/ui/src/ui/markdown.test.ts
@@ -182,6 +182,18 @@ describe("toSanitizedMarkdownHtml", () => {
   });
 
   describe("explicit protocol links", () => {
+    it("does not turn local absolute file paths into same-origin Gateway links", () => {
+      const html = toSanitizedMarkdownHtml(
+        "Download [example.docx](/Users/alice/.openclaw/data/output/example.docx)",
+      );
+      expect(html).toBe("<p>Download <a>example.docx</a></p>\n");
+    });
+
+    it("does not turn Windows absolute file paths into clickable links", () => {
+      const html = toSanitizedMarkdownHtml("Open [report.docx](C:\\Users\\alice\\report.docx)");
+      expect(html).toBe("<p>Open <a>report.docx</a></p>\n");
+    });
+
     it("links https:// URLs", () => {
       const html = toSanitizedMarkdownHtml("Visit https://example.com");
       expect(html).toBe(

--- a/ui/src/ui/markdown.ts
+++ b/ui/src/ui/markdown.ts
@@ -85,6 +85,8 @@ const MARKDOWN_CACHE_MAX_CHARS = 50_000;
 const INLINE_DATA_IMAGE_RE = /^data:image\/[a-z0-9.+-]+;base64,/i;
 const markdownCache = new Map<string, string>();
 const TAIL_LINK_BLUR_CLASS = "chat-link-tail-blur";
+const UNIX_ABSOLUTE_FILE_PATH_RE = /^\/(?:Users|home|var|tmp|private|opt|Volumes|mnt|srv)\//;
+const WINDOWS_ABSOLUTE_FILE_PATH_RE = /^[a-z]:[\\/]/i;
 
 // CJK character ranges for URL boundary detection (RFC 3986: CJK is not valid in raw URLs).
 // CJK Unified Ideographs, CJK Symbols/Punctuation, Fullwidth Forms, Hiragana, Katakana,
@@ -114,6 +116,11 @@ function setCachedMarkdown(key: string, value: string) {
   }
 }
 
+function isLocalAbsoluteFileHref(href: string): boolean {
+  const trimmed = href.trim();
+  return UNIX_ABSOLUTE_FILE_PATH_RE.test(trimmed) || WINDOWS_ABSOLUTE_FILE_PATH_RE.test(trimmed);
+}
+
 function installHooks() {
   if (hooksInstalled) {
     return;
@@ -126,6 +133,11 @@ function installHooks() {
     }
     const href = node.getAttribute("href");
     if (!href) {
+      return;
+    }
+
+    if (isLocalAbsoluteFileHref(href)) {
+      node.removeAttribute("href");
       return;
     }
 


### PR DESCRIPTION
## Summary
- Treat local absolute file paths in Control UI markdown links as non-clickable instead of same-origin Gateway routes.
- Preserve normal external links such as `https://docs.openclaw.ai`.
- Add regression coverage for Unix/macOS and Windows-style absolute file path links.

Fixes #84467

## Real behavior proof

Behavior addressed: Control UI Markdown Preview should not turn local absolute artifact paths like `/Users/.../example.docx` into clickable same-origin Gateway links such as `https://127.0.0.1:18789/Users/...`.

Real environment tested: Local OpenClaw checkout on macOS, Node.js v22.22.0. The real `toSanitizedMarkdownHtml` renderer was invoked under a jsdom window whose URL matched a Gateway origin (`https://127.0.0.1:18789/chat?session=test`).

Exact steps or command run after the patch:
```console
$ node --import tsx .hermes/tmp/markdown-proof-84467.mjs
```

The temporary script rendered:
```md
Download [example.docx](/Users/alice/.openclaw/data/output/example.docx) and [docs](https://docs.openclaw.ai).
```

Evidence after fix:
```console
<p>Download <a>example.docx</a> and <a href="https://docs.openclaw.ai" rel="noreferrer noopener" target="_blank">docs</a>.</p>

{"text":"example.docx","hrefAttr":null,"resolvedHref":""}
{"text":"docs","hrefAttr":"https://docs.openclaw.ai","resolvedHref":"https://docs.openclaw.ai/"}
```

Observed result after fix: The local file-path link is rendered without an `href`, so it no longer resolves to a Gateway route. The normal HTTPS link still has its `href`, `rel`, and `target` attributes.

What was not tested: I did not click through a live browser Control UI session; the local run exercised the shared sanitized markdown renderer used by the Control UI preview.

## Test plan
- `node --import tsx .hermes/tmp/markdown-proof-84467.mjs` (temporary local proof script; removed after capture)
- `node scripts/run-vitest.mjs ui/src/ui/markdown.test.ts`
- `git diff --check`
