### PR TITLE
fix(cli): validate --limit as a positive whole integer in skills search

### DIFF
--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -1,4 +1,4 @@
-import type { Command } from "commander";
+import { InvalidArgumentError, type Command } from "commander";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import {
   installSkillFromClawHub,
@@ -63,7 +63,15 @@ export function registerSkillsCli(program: Command) {
     .command("search")
     .description("Search ClawHub skills")
     .argument("[query...]", "Optional search query")
-    .option("--limit <n>", "Max results", (value) => Number.parseInt(value, 10))
+    .option("--limit <n>", "Max results", (value) => {
+      const parsed = Number.parseInt(value, 10);
+      if (!Number.isInteger(parsed) || String(parsed) !== value.trim() || parsed <= 0) {
+        throw new InvalidArgumentError(
+          `--limit must be a positive whole number (got: ${JSON.stringify(value)})`,
+        );
+      }
+      return parsed;
+    })
     .option("--json", "Output as JSON", false)
     .action(async (queryParts: string[], opts: { limit?: number; json?: boolean }) => {
       try {


### PR DESCRIPTION
## Summary

Fixes #84473 — `openclaw skills search --limit` accepted partially-numeric values like `1abc` (silently coercing to `1`) and non-positive integers like `0` or `-1`, making an unnecessary network request instead of failing fast.

## Change

Replace the bare `Number.parseInt(value, 10)` coercion with a strict validator that throws `InvalidArgumentError` from commander when the value is not a positive whole number. Commander then prints a usage error and exits before any ClawHub request is issued.

**Validation rules enforced:**
- Trimmed string must round-trip through parseInt (rejects `1abc`, `1.5abc`)
- Parsed result must be a finite integer (rejects `5.5`)
- Must be > 0 (rejects `0`, `-1`)

## Real behavior proof

### Before (on main)
```
$ openclaw skills search calendar --limit 1abc
# silently treats limit as 1, returns first result
```

### After (this PR)
```
$ openclaw skills search calendar --limit 1abc
error: option '--limit <n>' argument '1abc' is invalid. --limit must be a positive whole number (got: "1abc")
$ echo $?
1
```

**Accepted values:**
| Input | Result |
|-------|--------|
| `5` | ✅ uses limit 5 |
| `10` | ✅ uses limit 10 |
| `1abc` | ❌ InvalidArgumentError |
| `5.5` | ❌ InvalidArgumentError |
| `0` | ❌ InvalidArgumentError |
| `-1` | ❌ InvalidArgumentError |
| `abc` | ❌ InvalidArgumentError |