### PR TITLE
fix(secrets): audit plaintext config backups

### DIFF
--- a/src/secrets/audit.test.ts
+++ b/src/secrets/audit.test.ts
@@ -277,6 +277,35 @@ describe("secrets audit", () => {
     expectFindingCode(report, "REF_UNRESOLVED");
   });
 
+  it("reports plaintext secrets left in adjacent config backups", async () => {
+    const backupPath = `${fixture.configPath}.bak`;
+    await writeJsonFile(backupPath, {
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://api.openai.com/v1",
+            api: "openai-completions",
+            apiKey: "sk-openai-backup-plaintext",
+            models: [{ id: "gpt-5", name: "gpt-5" }],
+          },
+        },
+      },
+    });
+
+    const report = await runSecretsAudit({ env: fixture.env });
+
+    expect(report.filesScanned).toContain(backupPath);
+    expect(
+      hasFinding(
+        report,
+        (entry) =>
+          entry.code === "PLAINTEXT_FOUND" &&
+          entry.file === backupPath &&
+          entry.jsonPath === "models.providers.openai.apiKey",
+      ),
+    ).toBe(true);
+  });
+
   it("skips exec ref resolution during audit unless explicitly allowed", async () => {
     if (process.platform === "win32") {
       return;

--- a/src/secrets/audit.test.ts
+++ b/src/secrets/audit.test.ts
@@ -739,4 +739,50 @@ describe("secrets audit", () => {
       ),
     ).toBe(false);
   });
+
+  it("audits JSON5 config backups for plaintext provider secrets", async () => {
+    const backupPath = `${fixture.configPath}.bak`;
+    await fs.writeFile(
+      backupPath,
+      [
+        "{",
+        "  // Backups are copies of user-authored OpenClaw config and may use JSON5.",
+        "  models: {",
+        "    providers: {",
+        "      openai: {",
+        '        baseUrl: "https://api.openai.com/v1",',
+        '        api: "openai-completions",',
+        '        apiKey: "sk-json5-backup-plaintext",',
+        '        models: [{ id: "gpt-5", name: "gpt-5" }],',
+        "      },",
+        "    },",
+        "  },",
+        "}",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const report = await runSecretsAudit({ env: fixture.env });
+
+    expect(report.filesScanned).toContain(backupPath);
+    expect(
+      hasFinding(
+        report,
+        (entry) =>
+          entry.code === "PLAINTEXT_FOUND" &&
+          entry.file === backupPath &&
+          entry.jsonPath === "models.providers.openai.apiKey",
+      ),
+    ).toBe(true);
+    expect(
+      hasFinding(
+        report,
+        (entry) =>
+          entry.code === "REF_UNRESOLVED" &&
+          entry.file === backupPath &&
+          entry.jsonPath === "<root>",
+      ),
+    ).toBe(false);
+  });
 });

--- a/src/secrets/audit.test.ts
+++ b/src/secrets/audit.test.ts
@@ -785,4 +785,22 @@ describe("secrets audit", () => {
       ),
     ).toBe(false);
   });
+
+  it("ignores unrelated config sidecar files during backup audit", async () => {
+    const sidecarPath = `${fixture.configPath}.sha256`;
+    await fs.writeFile(sidecarPath, "not-json", "utf8");
+
+    const report = await runSecretsAudit({ env: fixture.env });
+
+    expect(report.filesScanned).not.toContain(sidecarPath);
+    expect(
+      hasFinding(
+        report,
+        (entry) =>
+          entry.code === "REF_UNRESOLVED" &&
+          entry.file === sidecarPath &&
+          entry.jsonPath === "<root>",
+      ),
+    ).toBe(false);
+  });
 });

--- a/src/secrets/audit.ts
+++ b/src/secrets/audit.ts
@@ -6,7 +6,7 @@ import {
   isSecretRefHeaderValueMarker,
 } from "../agents/model-auth-markers.js";
 import { normalizeProviderId } from "../agents/model-selection.js";
-import { resolveStateDir, type OpenClawConfig } from "../config/config.js";
+import { parseConfigJson5, resolveStateDir, type OpenClawConfig } from "../config/config.js";
 import { coerceSecretRef } from "../config/types.secrets.js";
 import { resolveSecretInputRef, type SecretRef } from "../config/types.secrets.js";
 import { formatErrorMessage } from "../infra/errors.js";
@@ -267,25 +267,57 @@ function collectConfigBackupSecrets(params: {
 }): void {
   for (const backupPath of listConfigBackupPaths(params.configPath)) {
     params.collector.filesScanned.add(backupPath);
-    const parsedResult = readJsonObjectIfExists(backupPath, {
-      requireRegularFile: true,
-      maxBytes: MAX_AUDIT_MODELS_JSON_BYTES,
-    });
-    if (parsedResult.error) {
+    let raw: string;
+    try {
+      const stats = fs.statSync(backupPath);
+      if (!stats.isFile()) {
+        addFinding(params.collector, {
+          code: "REF_UNRESOLVED",
+          severity: "error",
+          file: backupPath,
+          jsonPath: "<root>",
+          message: `Invalid config backup: Refusing to read non-regular file: ${backupPath}`,
+        });
+        continue;
+      }
+      if (stats.size > MAX_AUDIT_MODELS_JSON_BYTES) {
+        addFinding(params.collector, {
+          code: "REF_UNRESOLVED",
+          severity: "error",
+          file: backupPath,
+          jsonPath: "<root>",
+          message: `Invalid config backup: Refusing to read oversized config (${stats.size} bytes): ${backupPath}`,
+        });
+        continue;
+      }
+      raw = fs.readFileSync(backupPath, "utf8");
+    } catch (err) {
       addFinding(params.collector, {
         code: "REF_UNRESOLVED",
         severity: "error",
         file: backupPath,
         jsonPath: "<root>",
-        message: `Invalid JSON in config backup: ${parsedResult.error}`,
+        message: `Invalid config backup: ${formatErrorMessage(err)}`,
       });
       continue;
     }
-    if (!parsedResult.value) {
+
+    const parsedResult = parseConfigJson5(raw);
+    if (!parsedResult.ok) {
+      addFinding(params.collector, {
+        code: "REF_UNRESOLVED",
+        severity: "error",
+        file: backupPath,
+        jsonPath: "<root>",
+        message: `Invalid JSON5 in config backup: ${parsedResult.error}`,
+      });
+      continue;
+    }
+    if (!isRecord(parsedResult.parsed)) {
       continue;
     }
     collectConfigSecrets({
-      config: parsedResult.value as OpenClawConfig,
+      config: parsedResult.parsed as OpenClawConfig,
       configPath: backupPath,
       collector: params.collector,
     });

--- a/src/secrets/audit.ts
+++ b/src/secrets/audit.ts
@@ -32,6 +32,7 @@ import { isNonEmptyString, isRecord } from "./shared.js";
 import {
   listAgentModelsJsonPaths,
   listAuthProfileStorePaths,
+  listConfigBackupPaths,
   listLegacyAuthJsonPaths,
   parseEnvAssignmentValue,
   readJsonObjectIfExists,
@@ -256,6 +257,37 @@ function collectConfigSecrets(params: {
       jsonPath: target.path,
       message: `${target.path} is stored as plaintext.`,
       provider: target.providerId,
+    });
+  }
+}
+
+function collectConfigBackupSecrets(params: {
+  configPath: string;
+  collector: AuditCollector;
+}): void {
+  for (const backupPath of listConfigBackupPaths(params.configPath)) {
+    params.collector.filesScanned.add(backupPath);
+    const parsedResult = readJsonObjectIfExists(backupPath, {
+      requireRegularFile: true,
+      maxBytes: MAX_AUDIT_MODELS_JSON_BYTES,
+    });
+    if (parsedResult.error) {
+      addFinding(params.collector, {
+        code: "REF_UNRESOLVED",
+        severity: "error",
+        file: backupPath,
+        jsonPath: "<root>",
+        message: `Invalid JSON in config backup: ${parsedResult.error}`,
+      });
+      continue;
+    }
+    if (!parsedResult.value) {
+      continue;
+    }
+    collectConfigSecrets({
+      config: parsedResult.value as OpenClawConfig,
+      configPath: backupPath,
+      collector: params.collector,
     });
   }
 }
@@ -714,6 +746,10 @@ export async function runSecretsAudit(
 
   collectEnvPlaintext({
     envPath,
+    collector,
+  });
+  collectConfigBackupSecrets({
+    configPath,
     collector,
   });
   collectAuthJsonResidue({

--- a/src/secrets/storage-scan.ts
+++ b/src/secrets/storage-scan.ts
@@ -96,12 +96,24 @@ export function listConfigBackupPaths(configPath: string): string[] {
     if (!entry.isFile()) {
       continue;
     }
-    if (entry.name.startsWith(`${configBase}.`) && entry.name !== configBase) {
+    if (isConfigBackupFileName(entry.name, configBase)) {
       paths.add(path.join(configDir, entry.name));
     }
   }
 
   return [...paths];
+}
+
+function isConfigBackupFileName(fileName: string, configBase: string): boolean {
+  if (fileName === `${configBase}.bak` || fileName === `${configBase}.pre-update`) {
+    return true;
+  }
+  const numberedBackupPrefix = `${configBase}.bak.`;
+  if (!fileName.startsWith(numberedBackupPrefix)) {
+    return false;
+  }
+  const suffix = fileName.slice(numberedBackupPrefix.length);
+  return /^\d+$/.test(suffix);
 }
 
 export type ReadJsonObjectOptions = {

--- a/src/secrets/storage-scan.ts
+++ b/src/secrets/storage-scan.ts
@@ -77,6 +77,33 @@ export function listAgentModelsJsonPaths(
   return [...paths];
 }
 
+export function listConfigBackupPaths(configPath: string): string[] {
+  const resolvedConfigPath = resolveUserPath(configPath);
+  const configDir = path.dirname(resolvedConfigPath);
+  const configBase = path.basename(resolvedConfigPath);
+  const paths = new Set<string>();
+
+  const adjacentBackup = `${resolvedConfigPath}.bak`;
+  if (fs.existsSync(adjacentBackup)) {
+    paths.add(adjacentBackup);
+  }
+
+  if (!fs.existsSync(configDir)) {
+    return [...paths];
+  }
+
+  for (const entry of fs.readdirSync(configDir, { withFileTypes: true })) {
+    if (!entry.isFile()) {
+      continue;
+    }
+    if (entry.name.startsWith(`${configBase}.`) && entry.name !== configBase) {
+      paths.add(path.join(configDir, entry.name));
+    }
+  }
+
+  return [...paths];
+}
+
 export type ReadJsonObjectOptions = {
   maxBytes?: number;
   requireRegularFile?: boolean;


### PR DESCRIPTION
## Summary
- scan adjacent OpenClaw config backup files during `openclaw secrets audit`
- report plaintext secrets left in backup config JSON with the backup file path
- add regression coverage for a `.bak` config containing a provider API key

/claim #11829

## Real behavior proof
**Behavior or issue addressed:** `openclaw secrets audit` now scans adjacent config backup files such as `openclaw.json.bak` and reports plaintext provider API keys found there.

**Real environment tested:** Local OpenClaw source checkout on macOS, running the real `pnpm --silent openclaw secrets audit --json` CLI against a temporary config directory outside the unit-test harness.

**Exact steps or command run after this patch:** Created a temporary OpenClaw config directory containing `openclaw.json` plus an adjacent `openclaw.json.bak` with a test provider key, then ran:

```console
HOME=/tmp/openclaw-proof-clean-xTBrff/home OPENCLAW_STATE_DIR=/tmp/openclaw-proof-clean-xTBrff/state OPENCLAW_CONFIG_PATH=/tmp/openclaw-proof-clean-xTBrff/openclaw.json pnpm --silent openclaw secrets audit --json
```

**Evidence after fix:** Terminal output from the real CLI run:

```json
{
  "status": "findings",
  "filesScanned": [
    "/tmp/openclaw-proof-clean-xTBrff/openclaw.json",
    "/tmp/openclaw-proof-clean-xTBrff/openclaw.json.bak"
  ],
  "summary": {
    "plaintextCount": 1,
    "unresolvedRefCount": 0,
    "shadowedRefCount": 0,
    "legacyResidueCount": 0
  },
  "findings": [
    {
      "code": "PLAINTEXT_FOUND",
      "file": "/tmp/openclaw-proof-clean-xTBrff/openclaw.json.bak",
      "jsonPath": "models.providers.openai.apiKey",
      "message": "models.providers.openai.apiKey is stored as plaintext."
    }
  ]
}
```

**Observed result after fix:** The audit includes both `openclaw.json` and `openclaw.json.bak` in `filesScanned`, and reports `PLAINTEXT_FOUND` at `models.providers.openai.apiKey` for the backup file.

**What was not tested:** No additional gaps.

## Verification
- `pnpm test src/secrets/audit.test.ts`
- `git diff --check`
- `pnpm exec oxfmt --check --threads=1 src/secrets/audit.ts src/secrets/storage-scan.ts src/secrets/audit.test.ts`
- `pnpm exec oxlint src/secrets/audit.ts src/secrets/storage-scan.ts src/secrets/audit.test.ts`

Note: `pnpm tsgo:core:test` currently fails in unrelated browser-import tests because `esbuild` cannot be resolved in this local clone.