### PR TITLE
fix(plugins): accept contracts.tools: true as wildcard [AI-assisted]

### DIFF
--- a/src/plugins/manifest-tools-contract.test.ts
+++ b/src/plugins/manifest-tools-contract.test.ts
@@ -1,0 +1,55 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { loadPluginManifest } from "./manifest.js";
+
+describe("manifest contracts.tools normalization (issue #80621)", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "openclaw-manifest-tools-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const writeManifest = (contractsTools: unknown): void => {
+    const manifest = {
+      id: "my-plugin",
+      name: "My Plugin",
+      entry: "./dist/index.js",
+      configSchema: { type: "object", properties: {} },
+      contracts: { tools: contractsTools },
+    };
+    writeFileSync(join(dir, "openclaw.plugin.json"), JSON.stringify(manifest));
+  };
+
+  it("accepts contracts.tools: true as a wildcard ['*']", () => {
+    writeManifest(true);
+    const result = loadPluginManifest(dir, false);
+    if (!result.ok) throw new Error(result.error);
+    expect(result.manifest.contracts?.tools).toEqual(["*"]);
+  });
+
+  it("preserves contracts.tools: string[] as the declared list", () => {
+    writeManifest(["alpha", "beta"]);
+    const result = loadPluginManifest(dir, false);
+    if (!result.ok) throw new Error(result.error);
+    expect(result.manifest.contracts?.tools).toEqual(["alpha", "beta"]);
+  });
+
+  it.each<{ label: string; value: unknown }>([
+    { label: "false", value: false },
+    { label: "null", value: null },
+    { label: "the number 1 (not boolean true)", value: 1 },
+    { label: 'the string "true" (not boolean true)', value: "true" },
+    { label: "an empty array", value: [] },
+  ])("treats $label as an absent contracts.tools", ({ value }) => {
+    writeManifest(value);
+    const result = loadPluginManifest(dir, false);
+    if (!result.ok) throw new Error(result.error);
+    expect(result.manifest.contracts?.tools).toBeUndefined();
+  });
+});

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -815,7 +815,10 @@ function normalizeManifestContracts(value: unknown): PluginManifestContracts | u
   const webSearchProviders = normalizeTrimmedStringList(value.webSearchProviders);
   const migrationProviders = normalizeTrimmedStringList(value.migrationProviders);
   const gatewayMethodDispatch = normalizeTrimmedStringList(value.gatewayMethodDispatch);
-  const tools = normalizeTrimmedStringList(value.tools);
+  // contracts.tools accepts either a list of tool names or the boolean `true`,
+  // which is shorthand for "allow any tool name this plugin registers"
+  // (mapped to a wildcard `*`). See issue #80621.
+  const tools = value.tools === true ? ["*"] : normalizeTrimmedStringList(value.tools);
   const contracts = {
     ...(embeddedExtensionFactories.length > 0 ? { embeddedExtensionFactories } : {}),
     ...(agentToolResultMiddleware.length > 0 ? { agentToolResultMiddleware } : {}),

--- a/src/plugins/tool-contracts.test.ts
+++ b/src/plugins/tool-contracts.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import {
+  findUndeclaredPluginToolNames,
+  normalizePluginToolContractNames,
+} from "./tool-contracts.js";
+
+describe("plugin tool contracts wildcard", () => {
+  it("treats contracts.tools: ['*'] as declaring any tool name (issue #80621)", () => {
+    const declaredNames = normalizePluginToolContractNames({ tools: ["*"] });
+    expect(declaredNames).toEqual(["*"]);
+
+    const undeclared = findUndeclaredPluginToolNames({
+      declaredNames,
+      toolNames: ["arbitrary_tool_name", "another_one"],
+    });
+    expect(undeclared).toEqual([]);
+  });
+
+  it("still rejects unknown names when no wildcard is declared", () => {
+    const declaredNames = normalizePluginToolContractNames({ tools: ["known"] });
+    const undeclared = findUndeclaredPluginToolNames({
+      declaredNames,
+      toolNames: ["known", "unknown"],
+    });
+    expect(undeclared).toEqual(["unknown"]);
+  });
+});

--- a/src/plugins/tool-contracts.ts
+++ b/src/plugins/tool-contracts.ts
@@ -22,5 +22,9 @@ export function findUndeclaredPluginToolNames(params: {
   toolNames: readonly string[];
 }): string[] {
   const declared = new Set(normalizePluginToolNames(params.declaredNames));
+  // `*` is the wildcard shorthand for `contracts.tools: true` and allows any tool name.
+  if (declared.has("*")) {
+    return [];
+  }
   return normalizePluginToolNames(params.toolNames).filter((name) => !declared.has(name));
 }


### PR DESCRIPTION
> 🤖 AI-assisted (built with Hermes orchestration; reviewer = 麻酱, code review = Codex CLI). Test level: fully tested. Prompt summary available on request.

## Summary

- Problem: A plugin manifest that declares `"contracts": { "tools": true }` (the documented shorthand for "allow any tool name this plugin registers") loads with `status: loaded` but every `api.registerTool(...)` call is rejected with `plugin must declare contracts.tools before registering agent tools`. The boolean `true` is silently dropped during manifest normalization.
- Solution: Map `contracts.tools: true` to the wildcard `["*"]` during manifest normalization, and have `findUndeclaredPluginToolNames` short-circuit when `*` is in the declared list.
- What changed: `src/plugins/manifest.ts` (3-line tools normalization), `src/plugins/tool-contracts.ts` (4-line wildcard guard), plus two new test files.
- What did NOT change (scope boundary): No change to `registerTool` callers, no change to the array form (`contracts.tools: ["foo","bar"]`), no change to other contract families (providers, embeddings, channels, etc.), no Feishu / CODEOWNERS-restricted paths touched.

## Motivation

The documentation and tooling treat `contracts.tools: true` as a valid shorthand, but the manifest loader silently drops it. The result is a confusing UX where a plugin claims to be loaded yet no tools are visible and the only signal is a diagnostic that contradicts what the user wrote in `openclaw.plugin.json`. This blocks third-party plugin authors using the shorthand.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #80621
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `api.registerTool()` rejected with `plugin must declare contracts.tools before registering agent tools` even though the plugin's `openclaw.plugin.json` declares `"contracts": { "tools": true }`.
- Real environment tested: Local OpenClaw checkout at `openclaw/openclaw@110042d840` (current `main` at PR time). macOS, Node v22.15.0. Reproduction runs the actual `src/plugins/manifest.ts` `loadPluginManifest()` and the actual `src/plugins/tool-contracts.ts` helpers against a real on-disk plugin manifest — no mocks.
- Exact steps or command run after this patch:
  1. Create a real plugin directory at `/tmp/openclaw-proof-80621/my-plugin/` containing `openclaw.plugin.json` with `{"id":"my-plugin","name":"My Plugin","entry":"./dist/index.js","configSchema":{"type":"object","properties":{}},"contracts":{"tools":true}}`
  2. Run a small driver `repro-80621.mjs` that calls `loadPluginManifest(dir, false)` and `normalizePluginToolContractNames(manifest.contracts)` from the in-repo source.
  3. `node_modules/.bin/tsx repro-80621.mjs` before and after the patch.
- Evidence after fix (redacted terminal capture, OpenClaw source-tree run):

```text
=== BEFORE the fix (current main) ===
=== Plugin manifest loaded ===
id           : my-plugin
contracts raw: undefined
declaredNames: []

❌ registerTool() would now fail with:
   "plugin must declare contracts.tools before registering agent tools"
   (Bug #80621 reproduced — boolean `true` is dropped.)

=== AFTER the fix (this branch) ===
=== Plugin manifest loaded ===
id           : my-plugin
contracts raw: {"tools":["*"]}
declaredNames: ["*"]

✅ contracts.tools accepted as: [ '*' ]
```

- Observed result after fix: `loadPluginManifest()` now returns `manifest.contracts.tools === ["*"]`. `findUndeclaredPluginToolNames` treats `*` as a wildcard, so `registerTool(...)` no longer raises the "plugin must declare contracts.tools" diagnostic, and any tool name the plugin registers is accepted.
- What was not tested: Live end-to-end run of a third-party plugin against a running gateway (the targeted manifest + contracts pipeline is exercised in `loadPluginManifest()` from in-repo source, which is the same code path the runtime uses).
- Before evidence (optional but encouraged): Same `repro-80621.mjs` driver run against `upstream/main` before applying this diff produces the BEFORE block above (registerTool would be rejected). Included inline above.

## Root Cause (if applicable)

- Root cause: `src/plugins/manifest.ts` normalized `value.tools` exclusively through `normalizeTrimmedStringList`, which returns `[]` for any non-array input. The documented shorthand `contracts.tools: true` was therefore quietly coerced to "no tools declared", causing every `registerTool` call to fail the `declaredNames.length === 0` gate.
- Missing detection / guardrail: There was no test that asserted the boolean shorthand makes it through to the normalized contracts.
- Contributing context: The shorthand is mentioned in plugin authoring docs but the manifest loader was originally written assuming array-only input.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/plugins/manifest-tools-contract.test.ts` (new), `src/plugins/tool-contracts.test.ts` (new)
- Scenario the test should lock in:
  - `loadPluginManifest()` against a manifest with `contracts.tools: true` yields `contracts.tools === ["*"]`.
  - `loadPluginManifest()` preserves the array form unchanged.
  - Non-`true` truthy values (`1`, `"true"`, `null`, `false`, `[]`) keep the existing "absent" semantics.
  - `findUndeclaredPluginToolNames` returns `[]` when `*` is in declared, and still rejects unknown names when no wildcard is declared.
- Why this is the smallest reliable guardrail: These cover the normalizer boundary (`tool-contracts.test.ts`) and the manifest loader's on-disk pipeline (`manifest-tools-contract.test.ts`) without pulling in the full plugin loader fixture machinery.
- Existing test that already covers this (if any): N/A (`grep -l "contracts.tools.*true" src/plugins/*.test.ts` returned nothing prior to this PR).
- If no new test is added, why not: N/A — two new test files added (5 cases total: 2 in `tool-contracts.test.ts`, 7 across 3 `it.each` rows + 2 explicit cases in `manifest-tools-contract.test.ts`, 9 tests in all).

## User-visible / Behavior Changes

- Plugins that declare `"contracts": { "tools": true }` in `openclaw.plugin.json` now successfully register tools; previously these calls failed silently with `plugin must declare contracts.tools before registering agent tools`. No change to plugins using the array form.

## Diagram (if applicable)

```text
Before:
manifest { contracts: { tools: true } }
  -> normalizeTrimmedStringList(true)  -> []
  -> contracts.tools omitted from normalized manifest
  -> declaredNames.length === 0 in registerTool gate
  -> ❌ "plugin must declare contracts.tools before registering agent tools"

After:
manifest { contracts: { tools: true } }
  -> branch: tools === true ? ["*"] : normalizeTrimmedStringList(value.tools)
  -> contracts.tools === ["*"] in normalized manifest
  -> findUndeclaredPluginToolNames sees declared.has("*") and short-circuits to []
  -> ✅ registerTool accepts any tool name this plugin registers
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No (the wildcard only affects whether the plugin's *own* declared tools are gated against its *own* `contracts.tools` list — it does not grant the plugin access to any tool outside its own registration scope)
- Data access scope changed? No
- If any Yes, explain risk + mitigation: N/A

The wildcard `*` is internal to the per-plugin contracts gate. A plugin that declares `contracts.tools: true` can register *its own* tools without enumerating them; it gains no access to tools owned by other plugins or core. The behavior matches what the shorthand is documented to mean.

## Repro + Verification

### Environment

- OS: macOS (current repo checkout)
- Runtime/container: Node v22.15.0, pnpm 11.1.0 (vitest 4.1.6 via `node_modules/.bin/vitest`)
- Model/provider: N/A (manifest-loader bug, no model involvement)
- Integration/channel (if any): N/A
- Relevant config (redacted): Plain `openclaw.plugin.json` with `contracts.tools: true`

### Steps

1. `git fetch upstream && git checkout fix/plugin-manifest-contracts-tools-boolean-true`
2. `node_modules/.bin/vitest run src/plugins/manifest-tools-contract.test.ts src/plugins/tool-contracts.test.ts` → `Test Files 2 passed (2) / Tests 9 passed (9)`
3. `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --pretty false --incremental` → no errors for the touched files
4. `pnpm exec oxfmt --check src/plugins/manifest.ts src/plugins/tool-contracts.ts src/plugins/tool-contracts.test.ts src/plugins/manifest-tools-contract.test.ts` → `All matched files use the correct format.`
5. Real-behavior driver `repro-80621.mjs` (described under "Real behavior proof") shows BEFORE → ❌ and AFTER → ✅.
