### PR TITLE
fix(telegram): honor defaultAccount in missing default warning

### DIFF
--- a/extensions/telegram/src/account-selection.ts
+++ b/extensions/telegram/src/account-selection.ts
@@ -129,15 +129,17 @@ export function resolveDefaultTelegramAccountSelection(cfg: OpenClawConfig): {
     };
   }
   const accountIds = listTelegramAccountIds(cfg);
+  const configuredDefaultAccountId =
+    normalizeOptionalAccountId(cfg.channels?.telegram?.defaultAccount) ?? undefined;
   const resolved = resolveListedDefaultAccountId({
     accountIds,
-    configuredDefaultAccountId:
-      normalizeOptionalAccountId(cfg.channels?.telegram?.defaultAccount) ?? undefined,
+    configuredDefaultAccountId,
   });
   return {
     accountId: resolved,
     accountIds,
     shouldWarnMissingDefault:
+      configuredDefaultAccountId === undefined &&
       resolved === accountIds[0] &&
       !accountIds.includes(DEFAULT_ACCOUNT_ID) &&
       accountIds.length > 1,

--- a/extensions/telegram/src/accounts.test.ts
+++ b/extensions/telegram/src/accounts.test.ts
@@ -227,6 +227,23 @@ describe("resolveDefaultTelegramAccountId", () => {
     expectNoMissingDefaultWarning();
   });
 
+  it("does not warn when defaultAccount selects one of multiple non-default accounts (#83948)", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        telegram: {
+          defaultAccount: "charles",
+          accounts: {
+            hermes: { botToken: "tok-hermes" },
+            charles: { botToken: "tok-charles" },
+          },
+        },
+      },
+    };
+
+    expect(resolveDefaultTelegramAccountId(cfg)).toBe("charles");
+    expectNoMissingDefaultWarning();
+  });
+
   it("does not warn when only one non-default account is configured", () => {
     const cfg: OpenClawConfig = {
       channels: {


### PR DESCRIPTION
## Summary
- Suppress the Telegram `accounts.default is missing` warning when `channels.telegram.defaultAccount` is explicitly configured.
- Keep the warning for multi-account configs that truly lack both `accounts.default` and `defaultAccount`.
- Add regression coverage for a multi-account non-default `defaultAccount` setup.

Fixes #83948

## Real behavior proof

Behavior addressed: `resolveDefaultTelegramAccountId` should resolve the configured `channels.telegram.defaultAccount` without emitting the noisy `accounts.default is missing` warning when multiple non-default Telegram accounts exist.

Real environment tested: Local OpenClaw checkout on macOS, Node.js v22.22.0, using the real Telegram account resolver from `extensions/telegram/src/accounts.ts`.

Exact steps or command run after fix: Ran this inline Node/tsx command against the real resolver after applying the patch:

```console
$ node --import tsx --input-type=module <<'EOF'
import { resolveDefaultTelegramAccountId, resetMissingDefaultWarnFlag } from './extensions/telegram/src/accounts.ts';
resetMissingDefaultWarnFlag();
const warnings = [];
const originalWarn = console.warn;
console.warn = (...args) => warnings.push(args.join(' '));
const cfg = { channels: { telegram: { defaultAccount: 'charles', accounts: { hermes: { botToken: 'tok-hermes' }, charles: { botToken: 'tok-charles' } } } } };
try {
  console.log(JSON.stringify({ accountId: resolveDefaultTelegramAccountId(cfg), warnings }));
} finally {
  console.warn = originalWarn;
  resetMissingDefaultWarnFlag();
}
EOF
```

Evidence after fix: Terminal output from the command above:

```console
{"accountId":"charles","warnings":[]}
```

Observed result after fix: the resolver still returns `charles`, but no `accounts.default is missing` warning is emitted because `channels.telegram.defaultAccount` already provides the explicit default.

What was not tested: I did not run a full `openclaw status` process against a live multi-account Telegram config; this exercises the shared account-selection path that emits the status/doctor warning.

Before-fix note: before this patch, the same resolver emitted the warning while returning the configured default account:

```console
[telegram] channels.telegram: accounts.default is missing; falling back to "charles". Set channels.telegram.defaultAccount or add channels.telegram.accounts.default to avoid routing surprises in multi-account setups.
charles
```

## Test plan
- `node --import tsx --input-type=module ...` (inline proof above)
- `node scripts/run-vitest.mjs extensions/telegram/src/accounts.test.ts`
- `git diff --check`
