### PR TITLE
fix(gateway): suppress duplicate probe warning for same identity (#69135)

### DIFF
--- a/src/commands/gateway-status/output.test.ts
+++ b/src/commands/gateway-status/output.test.ts
@@ -72,7 +72,11 @@ function createProbe(
   };
 }
 
-function createTarget(id: string, probe: GatewayProbeResult): GatewayStatusProbedTarget {
+function createTarget(
+  id: string,
+  probe: GatewayProbeResult,
+  self: GatewayStatusProbedTarget["self"] = null,
+): GatewayStatusProbedTarget {
   return {
     target: {
       id,
@@ -82,7 +86,7 @@ function createTarget(id: string, probe: GatewayProbeResult): GatewayStatusProbe
     },
     probe,
     configSummary: null,
-    self: null,
+    self,
     authDiagnostics: [],
   };
 }
@@ -116,6 +120,73 @@ describe("gateway status output", () => {
         "No gateway answered any probe and Bonjour discovery returned no local gateways. Run `openclaw gateway status --deep --require-rpc` to inspect service state, config paths, listener owners, and logs; include `ss -ltnp` or `lsof -nP -iTCP:<port> -sTCP:LISTEN` for the configured port when filing a report.",
       targetIds: ["localLoopback"],
     });
+  });
+
+  it("does not warn about multiple gateways when reachable probes share self identity", () => {
+    const firstProbe = createProbe("read_only", {
+      ok: true,
+      connectLatencyMs: 20,
+    });
+    const secondProbe = {
+      ...createProbe("read_only", {
+        ok: true,
+        connectLatencyMs: 25,
+      }),
+      url: "ws://gateway-host:18789",
+    };
+
+    const warnings = buildGatewayStatusWarnings({
+      probed: [
+        createTarget("sshTunnel", firstProbe, {
+          host: "Gateway-Host.local",
+          ip: "192.168.1.20",
+          version: "2026.5.18",
+          platform: "linux",
+        }),
+        createTarget("configRemote", secondProbe, {
+          host: "gateway-host.local",
+          ip: "192.168.1.20",
+          version: "2026.5.18",
+          platform: "linux",
+        }),
+      ],
+      sshTarget: "user@gateway-host",
+      sshTunnelStarted: true,
+      sshTunnelError: null,
+      discoveryCount: 0,
+    });
+
+    expect(warnings.some((entry) => entry.code === "multiple_gateways")).toBe(false);
+  });
+
+  it("keeps the multiple gateways warning when reachable probe identity is missing", () => {
+    const warnings = buildGatewayStatusWarnings({
+      probed: [
+        createTarget(
+          "sshTunnel",
+          createProbe("read_only", {
+            ok: true,
+            connectLatencyMs: 20,
+          }),
+        ),
+        createTarget(
+          "configRemote",
+          createProbe("read_only", {
+            ok: true,
+            connectLatencyMs: 25,
+          }),
+        ),
+      ],
+      sshTarget: "user@gateway-host",
+      sshTunnelStarted: true,
+      sshTunnelError: null,
+      discoveryCount: 0,
+    });
+
+    expect(warnings.find((entry) => entry.code === "multiple_gateways")?.targetIds).toStrictEqual([
+      "sshTunnel",
+      "configRemote",
+    ]);
   });
 
   it("derives summary capability from reachable probes only in json output", () => {

--- a/src/commands/gateway-status/output.ts
+++ b/src/commands/gateway-status/output.ts
@@ -21,6 +21,34 @@ export type GatewayStatusWarning = {
 const noReachableGatewayDiagnostic =
   "No gateway answered any probe and Bonjour discovery returned no local gateways. Run `openclaw gateway status --deep --require-rpc` to inspect service state, config paths, listener owners, and logs; include `ss -ltnp` or `lsof -nP -iTCP:<port> -sTCP:LISTEN` for the configured port when filing a report.";
 
+function normalizeGatewayIdentityPart(value: string | undefined): string {
+  return value?.trim().toLowerCase() ?? "";
+}
+
+function readGatewayIdentityKey(entry: GatewayStatusProbedTarget): string | null {
+  const host = normalizeGatewayIdentityPart(entry.self?.host);
+  const ip = normalizeGatewayIdentityPart(entry.self?.ip);
+  if (!host && !ip) {
+    return null;
+  }
+  return `host=${host}|ip=${ip}`;
+}
+
+function hasMultipleReachableGatewayIdentities(reachable: GatewayStatusProbedTarget[]): boolean {
+  if (reachable.length <= 1) {
+    return false;
+  }
+  const identityKeys = new Set<string>();
+  for (const entry of reachable) {
+    const key = readGatewayIdentityKey(entry);
+    if (!key) {
+      return true;
+    }
+    identityKeys.add(key);
+  }
+  return identityKeys.size > 1;
+}
+
 function readModelPricingDegradedDetail(health: unknown): string | null {
   if (!health || typeof health !== "object") {
     return null;
@@ -87,7 +115,7 @@ export function buildGatewayStatusWarnings(params: {
       targetIds: params.probed.map((entry) => entry.target.id),
     });
   }
-  if (reachable.length > 1) {
+  if (hasMultipleReachableGatewayIdentities(reachable)) {
     warnings.push({
       code: "multiple_gateways",
       message:


### PR DESCRIPTION
## Summary
- Suppress the `multiple_gateways` warning when every reachable gateway probe reports the same non-empty self identity.
- Keep the warning for missing identity data or distinct identities, so genuinely ambiguous multi-gateway setups still surface.
- Add regression coverage for same-identity SSH tunnel + configured remote probes and missing-identity fallback.

Fixes #69135.

## Real behavior proof

### behavior
The reported behavior is the gateway-status warning builder treating one logical gateway reached through two transports (`sshTunnel` + configured `remote.url`) as `multiple_gateways`. After this patch, same-identity reachable probes do not emit `multiple_gateways`; missing-identity or distinct-identity probes still do.

### environment
Local OpenClaw checkout on PR branch `fix-gateway-probe-same-identity-69135`, head `dd6cca39769ab659cc3779c7b98adbdaf941c7ba`, running Node with `tsx` against the patched TypeScript source.

### steps
1. Check out this PR branch.
2. Execute the patched `buildGatewayStatusWarnings` function with two reachable targets matching the issue shape: `sshTunnel` at `ws://127.0.0.1:18789` and `configRemote` at `ws://gateway-host:18789`, both reporting the same self identity (`host=gateway-host.local`, `ip=192.168.1.20`).
3. Execute the same path with two reachable targets that do not report self identity.

### evidence
Copied after-fix terminal output from the patched code path:

```console
$ node --import tsx --input-type=module -e '...invoke buildGatewayStatusWarnings with sshTunnel + configRemote same self identity, then with missing identity...'\n{\n  "sameIdentityCodes": [],\n  "missingIdentityCodes": [\n    "multiple_gateways"\n  ]\n}\n```\n\n### observedResult\nThe same-gateway/two-transport case no longer emits the misleading `multiple_gateways` warning. The ambiguous missing-identity case still emits `multiple_gateways`, so the patch does not hide genuinely ambiguous multi-gateway setups.\n\n### notTested\nI did not start a live SSH tunnel to a remote gateway. The proof executes the production warning-builder path directly with the same probed target shape produced by `runGatewayStatusProbePass`; unit coverage also locks the same behavior.\n\n## Validation\n- `node scripts/run-vitest.mjs src/commands/gateway-status/output.test.ts` -> 1 file passed, 6 tests passed\n- `pnpm lint -- src/commands/gateway-status/output.ts src/commands/gateway-status/output.test.ts` -> 0 warnings / 0 errors\n- `git diff --check` -> clean