### PR TITLE
test(cli): cover parsePort edge cases

### DIFF
--- a/src/cli/shared/parse-port.test.ts
+++ b/src/cli/shared/parse-port.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from "vitest";
 import { parsePort } from "./parse-port.js";
 
-describe("parsePort (#83900)", () => {
+describe("parsePort (#83899, #83900)", () => {
   it("returns null for nullish inputs", () => {
     expect(parsePort(undefined)).toBeNull();
     expect(parsePort(null)).toBeNull();
   });
 
-  it("returns null for zero and negative values (already enforced)", () => {
+  it("returns null for zero and negative values", () => {
     expect(parsePort(0)).toBeNull();
     expect(parsePort(-1)).toBeNull();
     expect(parsePort("0")).toBeNull();
@@ -16,22 +16,26 @@ describe("parsePort (#83900)", () => {
   it("accepts valid TCP port values", () => {
     expect(parsePort(1)).toBe(1);
     expect(parsePort(8080)).toBe(8080);
+    expect(parsePort("8080")).toBe(8080);
     expect(parsePort("3000")).toBe(3000);
-    expect(parsePort(65535)).toBe(65535);
+    expect(parsePort(" 65535 ")).toBe(65_535);
   });
 
-  it("rejects port numbers above 65535 (regression for #83900)", () => {
-    expect(parsePort(65536)).toBeNull();
+  it("rejects port numbers above 65535", () => {
+    expect(parsePort(65_536)).toBeNull();
     expect(parsePort(99999)).toBeNull();
     expect(parsePort("100000")).toBeNull();
+    expect(parsePort(Number.MAX_SAFE_INTEGER + 1)).toBeNull();
     // Largest 16-bit value is the inclusive boundary.
-    expect(parsePort(65535)).toBe(65535);
+    expect(parsePort(65_535)).toBe(65_535);
   });
 
   it("rejects non-integer and non-finite inputs", () => {
     expect(parsePort(1.5)).toBeNull();
+    expect(parsePort("1.5")).toBeNull();
     expect(parsePort(Number.NaN)).toBeNull();
     expect(parsePort(Number.POSITIVE_INFINITY)).toBeNull();
     expect(parsePort("abc")).toBeNull();
+    expect(parsePort("8080ms")).toBeNull();
   });
 });


### PR DESCRIPTION
Fixes #83899.

Summary:
- extend parsePort coverage for numeric strings, whitespace, invalid suffixes, fractional values, and upper-bound rejection
- keep existing #83900 boundary coverage intact

Tests:
- node scripts/run-vitest.mjs src/cli/shared/parse-port.test.ts src/infra/parse-finite-number.test.ts

## Real behavior proof

- **Behavior or issue addressed**: `parsePort` now has direct coverage for real CLI-style port inputs, including numeric strings, whitespace-padded numeric strings, invalid suffixes, fractional strings, and values above the TCP port range.
- **Real environment tested**: Local OpenClaw checkout at `/Users/googlerest/.openclaw/workspace/openclaw-src` on branch `codex/fix-83899-parse-port-tests`, running against the PR head `14213cc8f48546d0cdc18f82b99241f6229840df`.
- **Exact steps or command run after this patch**: Ran `node scripts/run-vitest.mjs src/cli/shared/parse-port.test.ts src/infra/parse-finite-number.test.ts` from the local OpenClaw checkout after applying this patch.
- **Evidence after fix**: Terminal output from the local OpenClaw checkout:

```text
RUN  v4.1.6 /Users/googlerest/.openclaw/workspace/openclaw-src

Test Files  2 passed (2)
     Tests  9 passed (9)
  Start at  18:24:29
  Duration  162ms (transform 36ms, setup 0ms, import 49ms, tests 4ms, environment 0ms)
```

- **Observed result after fix**: The focused parser test run completed successfully in the real checkout, including the added `parsePort` edge cases for `"8080"`, `" 65535 "`, `"1.5"`, `"8080ms"`, and `Number.MAX_SAFE_INTEGER + 1`.
- **What was not tested**: No UI flow was tested because this PR only changes focused parser coverage for the shared CLI port parser.
