### PR TITLE
fix(cli): gate exported subcli descriptors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 - Cron: deliver preferred final assistant output for successful scheduled runs when trailing plain tool warnings remain in diagnostics instead of marking the run failed.
 - fix(mattermost): fail closed on missing channel type [AI]. (#84091) Thanks @pgondhi987.
 - Recheck rebuilt system.run argv [AI]. (#84090) Thanks @pgondhi987.
+- CLI: keep the private QA subcommand out of exported command descriptors unless `OPENCLAW_ENABLE_PRIVATE_QA_CLI=1`, so root help and subcommand markers match runtime registration. (#84519)
 - CLI/cron: bound `openclaw cron show` job lookup pagination so non-advancing or unbounded `cron.list` responses fail instead of hanging the command. Fixes #83856. (#83989)
 - Agents/messages: stop message-tool-only turns after a successful source-channel `message` send while keeping transcript mirrors under the session write lock. (#84289)
 - Agents: filter silent heartbeat response-tool transcript artifacts out of embedded context snapshots so later user turns are not polluted by heartbeat no-op messages. (#83477) Thanks @fuller-stack-dev.

--- a/src/agents/workspace.load-extra-bootstrap-files.test.ts
+++ b/src/agents/workspace.load-extra-bootstrap-files.test.ts
@@ -43,6 +43,24 @@ describe("loadExtraBootstrapFiles", () => {
     ]);
   });
 
+  it("loads glob patterns with explicit current-directory prefixes", async () => {
+    const workspaceDir = await createWorkspaceDir("glob-current-dir");
+    const packageDir = path.join(workspaceDir, "packages", "core");
+    await fs.mkdir(packageDir, { recursive: true });
+    await fs.writeFile(path.join(packageDir, "AGENTS.md"), "agents", "utf-8");
+
+    const files = await loadExtraBootstrapFiles(workspaceDir, ["./packages/*/AGENTS.md"]);
+
+    expect(files).toStrictEqual([
+      {
+        name: "AGENTS.md",
+        path: path.join(packageDir, "AGENTS.md"),
+        content: "agents",
+        missing: false,
+      },
+    ]);
+  });
+
   it("keeps path-traversal attempts outside workspace excluded", async () => {
     const rootDir = await createWorkspaceDir("root");
     const workspaceDir = path.join(rootDir, "workspace");

--- a/src/agents/workspace.load-extra-bootstrap-files.test.ts
+++ b/src/agents/workspace.load-extra-bootstrap-files.test.ts
@@ -61,6 +61,24 @@ describe("loadExtraBootstrapFiles", () => {
     ]);
   });
 
+  it("loads literal bootstrap paths with square brackets", async () => {
+    const workspaceDir = await createWorkspaceDir("literal-brackets");
+    const packageDir = path.join(workspaceDir, "pkg[1]");
+    await fs.mkdir(packageDir, { recursive: true });
+    await fs.writeFile(path.join(packageDir, "AGENTS.md"), "literal agents", "utf-8");
+
+    const files = await loadExtraBootstrapFiles(workspaceDir, ["pkg[1]/AGENTS.md"]);
+
+    expect(files).toStrictEqual([
+      {
+        name: "AGENTS.md",
+        path: path.join(packageDir, "AGENTS.md"),
+        content: "literal agents",
+        missing: false,
+      },
+    ]);
+  });
+
   it("keeps path-traversal attempts outside workspace excluded", async () => {
     const rootDir = await createWorkspaceDir("root");
     const workspaceDir = path.join(rootDir, "workspace");

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -702,6 +702,95 @@ export function filterBootstrapFilesForSession(
   return files.filter((file) => MINIMAL_BOOTSTRAP_ALLOWLIST.has(file.name));
 }
 
+function hasGlobPattern(pattern: string): boolean {
+  return /[?*[\]{}]/u.test(pattern);
+}
+
+function normalizeWorkspacePatternPath(value: string): string {
+  return value
+    .replaceAll(path.sep, "/")
+    .replaceAll("\\", "/")
+    .replace(/^\.\/+/u, "");
+}
+
+function resolveGlobWalkRoot(pattern: string): string {
+  const normalized = normalizeWorkspacePatternPath(pattern);
+  const globIndex = normalized.search(/[?*[\]{}]/u);
+  if (globIndex === -1) {
+    return normalized;
+  }
+  const slashIndex = normalized.lastIndexOf("/", globIndex);
+  return slashIndex === -1 ? "." : normalized.slice(0, slashIndex) || ".";
+}
+
+async function* walkWorkspaceFiles(
+  workspaceDir: string,
+  initialRelativeDir: string,
+): AsyncGenerator<string> {
+  const stack = [initialRelativeDir === "." ? "" : initialRelativeDir];
+  while (stack.length > 0) {
+    const currentRelativeDir = stack.pop() ?? "";
+    const currentDir = path.resolve(workspaceDir, currentRelativeDir);
+    const relativeToWorkspace = path.relative(workspaceDir, currentDir);
+    if (relativeToWorkspace.startsWith("..") || path.isAbsolute(relativeToWorkspace)) {
+      continue;
+    }
+
+    let entries: syncFs.Dirent[];
+    try {
+      entries = await fs.readdir(currentDir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      const childRelativePath = currentRelativeDir
+        ? path.join(currentRelativeDir, entry.name)
+        : entry.name;
+      if (entry.isDirectory()) {
+        stack.push(childRelativePath);
+        continue;
+      }
+      if (entry.isFile() || entry.isSymbolicLink()) {
+        yield normalizeWorkspacePatternPath(childRelativePath);
+      }
+    }
+  }
+}
+
+async function resolveExtraBootstrapPatternPaths(
+  workspaceDir: string,
+  pattern: string,
+): Promise<string[]> {
+  if (typeof fs.glob === "function") {
+    try {
+      const matches: string[] = [];
+      for await (const match of fs.glob(pattern, { cwd: workspaceDir })) {
+        matches.push(String(match));
+      }
+      return matches;
+    } catch {
+      // Fall through to the local matcher before treating the pattern as literal.
+    }
+  }
+
+  if (typeof path.matchesGlob !== "function") {
+    return [pattern];
+  }
+
+  const normalizedPattern = normalizeWorkspacePatternPath(pattern);
+  const matches: string[] = [];
+  for await (const candidate of walkWorkspaceFiles(
+    workspaceDir,
+    resolveGlobWalkRoot(normalizedPattern),
+  )) {
+    if (path.matchesGlob(candidate, normalizedPattern)) {
+      matches.push(candidate);
+    }
+  }
+  return matches.length > 0 ? matches : [pattern];
+}
+
 export async function loadExtraBootstrapFiles(
   dir: string,
   extraPatterns: string[],
@@ -725,15 +814,10 @@ export async function loadExtraBootstrapFilesWithDiagnostics(
   // Resolve glob patterns into concrete file paths
   const resolvedPaths = new Set<string>();
   for (const pattern of extraPatterns) {
-    if (pattern.includes("*") || pattern.includes("?") || pattern.includes("{")) {
-      try {
-        const matches = fs.glob(pattern, { cwd: resolvedDir });
-        for await (const m of matches) {
-          resolvedPaths.add(m);
-        }
-      } catch {
-        // glob not available or pattern error — fall back to literal
-        resolvedPaths.add(pattern);
+    if (hasGlobPattern(pattern)) {
+      const matches = await resolveExtraBootstrapPatternPaths(resolvedDir, pattern);
+      for (const match of matches) {
+        resolvedPaths.add(match);
       }
     } else {
       resolvedPaths.add(pattern);

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -703,7 +703,8 @@ export function filterBootstrapFilesForSession(
 }
 
 function hasGlobPattern(pattern: string): boolean {
-  return /[?*[\]{}]/u.test(pattern);
+  // Keep square brackets literal here; workspace paths commonly contain them.
+  return /[?*{}]/u.test(pattern);
 }
 
 function normalizeWorkspacePatternPath(value: string): string {
@@ -715,7 +716,7 @@ function normalizeWorkspacePatternPath(value: string): string {
 
 function resolveGlobWalkRoot(pattern: string): string {
   const normalized = normalizeWorkspacePatternPath(pattern);
-  const globIndex = normalized.search(/[?*[\]{}]/u);
+  const globIndex = normalized.search(/[?*{}]/u);
   if (globIndex === -1) {
     return normalized;
   }

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -766,7 +766,7 @@ async function resolveExtraBootstrapPatternPaths(
     try {
       const matches: string[] = [];
       for await (const match of fs.glob(pattern, { cwd: workspaceDir })) {
-        matches.push(String(match));
+        matches.push(match);
       }
       return matches;
     } catch {

--- a/src/cli/program/subcli-descriptors.test.ts
+++ b/src/cli/program/subcli-descriptors.test.ts
@@ -5,6 +5,10 @@ async function importSubCliDescriptors() {
   return import("./subcli-descriptors.js");
 }
 
+function descriptorNames(descriptors: ReadonlyArray<{ name: string }>): string[] {
+  return descriptors.map((descriptor) => descriptor.name);
+}
+
 describe("sub-cli descriptors", () => {
   const originalPrivateQaCli = process.env.OPENCLAW_ENABLE_PRIVATE_QA_CLI;
 
@@ -21,11 +25,10 @@ describe("sub-cli descriptors", () => {
     delete process.env.OPENCLAW_ENABLE_PRIVATE_QA_CLI;
 
     const { SUB_CLI_DESCRIPTORS, getSubCliEntries } = await importSubCliDescriptors();
+    const exportedNames = descriptorNames(SUB_CLI_DESCRIPTORS);
 
-    expect(SUB_CLI_DESCRIPTORS.map((descriptor) => descriptor.name)).toEqual(
-      getSubCliEntries().map((descriptor) => descriptor.name),
-    );
-    expect(SUB_CLI_DESCRIPTORS.map((descriptor) => descriptor.name)).not.toContain("qa");
+    expect(exportedNames).toEqual(descriptorNames(getSubCliEntries()));
+    expect(exportedNames).not.toContain("qa");
   });
 
   it("keeps all sub-cli filter surfaces aligned when private QA is disabled (#83926)", async () => {
@@ -36,8 +39,9 @@ describe("sub-cli descriptors", () => {
       getSubCliCommandsWithSubcommands,
       getSubCliParentDefaultHelpCommands,
     } = await importSubCliDescriptors();
+    const exportedNames = descriptorNames(SUB_CLI_DESCRIPTORS);
 
-    expect(SUB_CLI_DESCRIPTORS.map((descriptor) => descriptor.name)).not.toContain("qa");
+    expect(exportedNames).not.toContain("qa");
     expect(getSubCliCommandsWithSubcommands()).not.toContain("qa");
     expect(getSubCliParentDefaultHelpCommands()).not.toContain("qa");
   });
@@ -51,11 +55,10 @@ describe("sub-cli descriptors", () => {
       getSubCliEntries,
       getSubCliParentDefaultHelpCommands,
     } = await importSubCliDescriptors();
+    const exportedNames = descriptorNames(SUB_CLI_DESCRIPTORS);
 
-    expect(SUB_CLI_DESCRIPTORS.map((descriptor) => descriptor.name)).toEqual(
-      getSubCliEntries().map((descriptor) => descriptor.name),
-    );
-    expect(SUB_CLI_DESCRIPTORS.map((descriptor) => descriptor.name)).toContain("qa");
+    expect(exportedNames).toEqual(descriptorNames(getSubCliEntries()));
+    expect(exportedNames).toContain("qa");
     expect(getSubCliCommandsWithSubcommands()).toContain("qa");
     expect(getSubCliParentDefaultHelpCommands()).not.toContain("qa");
   });

--- a/src/cli/program/subcli-descriptors.test.ts
+++ b/src/cli/program/subcli-descriptors.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+async function importSubCliDescriptors() {
+  vi.resetModules();
+  return import("./subcli-descriptors.js");
+}
+
+describe("sub-cli descriptors", () => {
+  const originalPrivateQaCli = process.env.OPENCLAW_ENABLE_PRIVATE_QA_CLI;
+
+  afterEach(() => {
+    if (originalPrivateQaCli === undefined) {
+      delete process.env.OPENCLAW_ENABLE_PRIVATE_QA_CLI;
+    } else {
+      process.env.OPENCLAW_ENABLE_PRIVATE_QA_CLI = originalPrivateQaCli;
+    }
+    vi.resetModules();
+  });
+
+  it("keeps the exported descriptor list aligned with private QA visibility when disabled (#83927)", async () => {
+    delete process.env.OPENCLAW_ENABLE_PRIVATE_QA_CLI;
+
+    const { SUB_CLI_DESCRIPTORS, getSubCliEntries } = await importSubCliDescriptors();
+
+    expect(SUB_CLI_DESCRIPTORS.map((descriptor) => descriptor.name)).toEqual(
+      getSubCliEntries().map((descriptor) => descriptor.name),
+    );
+    expect(SUB_CLI_DESCRIPTORS.map((descriptor) => descriptor.name)).not.toContain("qa");
+  });
+
+  it("keeps all sub-cli filter surfaces aligned when private QA is disabled (#83926)", async () => {
+    delete process.env.OPENCLAW_ENABLE_PRIVATE_QA_CLI;
+
+    const {
+      SUB_CLI_DESCRIPTORS,
+      getSubCliCommandsWithSubcommands,
+      getSubCliParentDefaultHelpCommands,
+    } = await importSubCliDescriptors();
+
+    expect(SUB_CLI_DESCRIPTORS.map((descriptor) => descriptor.name)).not.toContain("qa");
+    expect(getSubCliCommandsWithSubcommands()).not.toContain("qa");
+    expect(getSubCliParentDefaultHelpCommands()).not.toContain("qa");
+  });
+
+  it("includes qa in the exported descriptor list when private QA is enabled", async () => {
+    process.env.OPENCLAW_ENABLE_PRIVATE_QA_CLI = "1";
+
+    const { SUB_CLI_DESCRIPTORS, getSubCliEntries } = await importSubCliDescriptors();
+
+    expect(SUB_CLI_DESCRIPTORS.map((descriptor) => descriptor.name)).toEqual(
+      getSubCliEntries().map((descriptor) => descriptor.name),
+    );
+    expect(SUB_CLI_DESCRIPTORS.map((descriptor) => descriptor.name)).toContain("qa");
+  });
+});

--- a/src/cli/program/subcli-descriptors.test.ts
+++ b/src/cli/program/subcli-descriptors.test.ts
@@ -45,11 +45,18 @@ describe("sub-cli descriptors", () => {
   it("includes qa in the exported descriptor list when private QA is enabled", async () => {
     process.env.OPENCLAW_ENABLE_PRIVATE_QA_CLI = "1";
 
-    const { SUB_CLI_DESCRIPTORS, getSubCliEntries } = await importSubCliDescriptors();
+    const {
+      SUB_CLI_DESCRIPTORS,
+      getSubCliCommandsWithSubcommands,
+      getSubCliEntries,
+      getSubCliParentDefaultHelpCommands,
+    } = await importSubCliDescriptors();
 
     expect(SUB_CLI_DESCRIPTORS.map((descriptor) => descriptor.name)).toEqual(
       getSubCliEntries().map((descriptor) => descriptor.name),
     );
     expect(SUB_CLI_DESCRIPTORS.map((descriptor) => descriptor.name)).toContain("qa");
+    expect(getSubCliCommandsWithSubcommands()).toContain("qa");
+    expect(getSubCliParentDefaultHelpCommands()).not.toContain("qa");
   });
 });

--- a/src/cli/program/subcli-descriptors.ts
+++ b/src/cli/program/subcli-descriptors.ts
@@ -179,28 +179,42 @@ const subCliCommandCatalog = defineCommandDescriptorCatalog([
   },
 ] as const satisfies ReadonlyArray<SubCliDescriptor>);
 
-export const SUB_CLI_DESCRIPTORS = subCliCommandCatalog.descriptors;
+function filterPrivateQaItems<T>(
+  items: ReadonlyArray<T>,
+  getName: (item: T) => string,
+): ReadonlyArray<T> {
+  if (isPrivateQaCliEnabled()) {
+    return items;
+  }
+  return items.filter((item) => getName(item) !== "qa");
+}
+
+export const SUB_CLI_DESCRIPTORS = filterPrivateQaItems(
+  subCliCommandCatalog.descriptors,
+  (descriptor) => descriptor.name,
+);
 
 export function getSubCliEntries(): ReadonlyArray<SubCliDescriptor> {
-  const descriptors = subCliCommandCatalog.getDescriptors();
-  if (isPrivateQaCliEnabled()) {
-    return descriptors;
-  }
-  return descriptors.filter((descriptor) => descriptor.name !== "qa");
+  return filterPrivateQaItems(
+    subCliCommandCatalog.getDescriptors(),
+    (descriptor) => descriptor.name,
+  );
 }
 
 export function getSubCliCommandsWithSubcommands(): string[] {
-  const commands = subCliCommandCatalog.getCommandsWithSubcommands();
-  if (isPrivateQaCliEnabled()) {
-    return commands;
-  }
-  return commands.filter((command) => command !== "qa");
+  return [
+    ...filterPrivateQaItems(
+      subCliCommandCatalog.getCommandsWithSubcommands(),
+      (command) => command,
+    ),
+  ];
 }
 
 export function getSubCliParentDefaultHelpCommands(): string[] {
-  const commands = subCliCommandCatalog.getParentDefaultHelpCommands();
-  if (isPrivateQaCliEnabled()) {
-    return commands;
-  }
-  return commands.filter((command) => command !== "qa");
+  return [
+    ...filterPrivateQaItems(
+      subCliCommandCatalog.getParentDefaultHelpCommands(),
+      (command) => command,
+    ),
+  ];
 }

--- a/src/infra/net/http-connect-tunnel.test.ts
+++ b/src/infra/net/http-connect-tunnel.test.ts
@@ -330,20 +330,23 @@ describe("openHttpConnectTunnel", () => {
   });
 
   it("rejects and destroys the proxy socket when CONNECT times out", async () => {
+    vi.useFakeTimers();
     const proxySocket = new FakeSocket();
     setNextNetSocket(proxySocket);
     const { openHttpConnectTunnel } = await import("./http-connect-tunnel.js");
 
-    await expect(
-      openHttpConnectTunnel({
-        proxyUrl: new URL("http://proxy.example:8080"),
-        targetHost: "api.push.apple.com",
-        targetPort: 443,
-        timeoutMs: 1,
-      }),
-    ).rejects.toThrow(
+    const tunnel = openHttpConnectTunnel({
+      proxyUrl: new URL("http://proxy.example:8080"),
+      targetHost: "api.push.apple.com",
+      targetPort: 443,
+      timeoutMs: 1,
+    });
+    const rejected = expect(tunnel).rejects.toThrow(
       "Proxy CONNECT failed via http://proxy.example:8080: Proxy CONNECT timed out after 1ms",
     );
+
+    await vi.advanceTimersByTimeAsync(1);
+    await rejected;
     expect(proxySocket.destroyed).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Gate the exported `SUB_CLI_DESCRIPTORS` list through the same private-QA visibility filter used by the sub-CLI helper functions.
- Extract the repeated private-QA filter into one helper shared by descriptor, subcommand, and parent-help surfaces.
- Add regression coverage for disabled/enabled private-QA visibility.

Fixes #83927
Addresses #83926

## Real behavior proof

Behavior addressed: With private QA disabled, the exported `SUB_CLI_DESCRIPTORS` surface should not expose the `qa` command, and it should agree with `getSubCliEntries()`. Related helper surfaces should also hide `qa` from subcommand and parent-help lists.

Real environment tested: Local OpenClaw checkout on macOS, Node.js v22.22.0, using the real `src/cli/program/subcli-descriptors.ts` module.

Exact steps or command run after fix: Ran the real descriptor module twice with private QA disabled and enabled:

```console
$ OPENCLAW_ENABLE_PRIVATE_QA_CLI= node --import tsx --input-type=module <<'EOF'
import { SUB_CLI_DESCRIPTORS, getSubCliEntries, getSubCliCommandsWithSubcommands, getSubCliParentDefaultHelpCommands } from './src/cli/program/subcli-descriptors.ts';
console.log(JSON.stringify({ exportedHasQa: SUB_CLI_DESCRIPTORS.some((d) => d.name === 'qa'), getterHasQa: getSubCliEntries().some((d) => d.name === 'qa'), subcommandsHasQa: getSubCliCommandsWithSubcommands().includes('qa'), parentHelpHasQa: getSubCliParentDefaultHelpCommands().includes('qa'), sameNames: SUB_CLI_DESCRIPTORS.map((d) => d.name).join(',') === getSubCliEntries().map((d) => d.name).join(',') }));
EOF
$ OPENCLAW_ENABLE_PRIVATE_QA_CLI=1 node --import tsx --input-type=module <<'EOF'
import { SUB_CLI_DESCRIPTORS, getSubCliEntries, getSubCliCommandsWithSubcommands } from './src/cli/program/subcli-descriptors.ts';
console.log(JSON.stringify({ exportedHasQa: SUB_CLI_DESCRIPTORS.some((d) => d.name === 'qa'), getterHasQa: getSubCliEntries().some((d) => d.name === 'qa'), subcommandsHasQa: getSubCliCommandsWithSubcommands().includes('qa'), sameNames: SUB_CLI_DESCRIPTORS.map((d) => d.name).join(',') === getSubCliEntries().map((d) => d.name).join(',') }));
EOF
```

Evidence after fix: Terminal output from the commands above:

```console
{"exportedHasQa":false,"getterHasQa":false,"subcommandsHasQa":false,"parentHelpHasQa":false,"sameNames":true}
{"exportedHasQa":true,"getterHasQa":true,"subcommandsHasQa":true,"sameNames":true}
```

Observed result after fix: When private QA is disabled, `SUB_CLI_DESCRIPTORS` no longer exposes `qa` and matches `getSubCliEntries()`. When private QA is enabled, the same exported surface still includes `qa`, preserving the private source-checkout path.

What was not tested: I did not run the full packaged CLI binary; the proof imports the real source module that feeds the CLI descriptor surfaces, and the targeted Vitest coverage exercises the same module behavior.

## Test plan
- `OPENCLAW_ENABLE_PRIVATE_QA_CLI= node --import tsx --input-type=module ...`
- `OPENCLAW_ENABLE_PRIVATE_QA_CLI=1 node --import tsx --input-type=module ...`
- `node scripts/run-vitest.mjs src/cli/program/subcli-descriptors.test.ts src/cli/program/register.subclis.test.ts`
- `git diff --check`
