### PR TITLE
fix(cli): reject partially numeric --limit values in search commands

### DIFF
--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -1,4 +1,4 @@
-import type { Command } from "commander";
+import { InvalidArgumentError, type Command } from "commander";
 import { formatDocsLink } from "../terminal/links.js";
 import { theme } from "../terminal/theme.js";
 import type { PluginInspectOptions } from "./plugins-inspect-command.js";
@@ -75,7 +75,13 @@ export function registerPluginsCli(program: Command) {
     .command("search")
     .description("Search ClawHub plugin packages")
     .argument("[query...]", "Search query")
-    .option("--limit <n>", "Max results", (value) => Number.parseInt(value, 10))
+    .option("--limit <n>", "Max results", (value) => {
+      const n = Number(value);
+      if (!Number.isFinite(n) || n !== Math.trunc(n) || n < 1 || value.trim() !== String(n)) {
+        throw new InvalidArgumentError("--limit must be a positive integer");
+      }
+      return n;
+    })
     .option("--json", "Print JSON", false)
     .action(async (queryParts: string[], opts: PluginSearchOptions) => {
       const { runPluginsSearchCommand } = await import("./plugins-search-command.js");

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -1,4 +1,4 @@
-import type { Command } from "commander";
+import { InvalidArgumentError, type Command } from "commander";
 import {
   resolveAgentIdByWorkspacePath,
   resolveAgentWorkspaceDir,
@@ -120,7 +120,13 @@ export function registerSkillsCli(program: Command) {
     .command("search")
     .description("Search ClawHub skills")
     .argument("[query...]", "Optional search query")
-    .option("--limit <n>", "Max results", (value) => Number.parseInt(value, 10))
+    .option("--limit <n>", "Max results", (value) => {
+      const n = Number(value);
+      if (!Number.isFinite(n) || n !== Math.trunc(n) || n < 1 || value.trim() !== String(n)) {
+        throw new InvalidArgumentError("--limit must be a positive integer");
+      }
+      return n;
+    })
     .option("--json", "Output as JSON", false)
     .action(async (queryParts: string[], opts: { limit?: number; json?: boolean }) => {
       try {


### PR DESCRIPTION
## Summary
- Replace `Number.parseInt` with strict `Number()` + validation for `--limit` option in `plugins search` and `skills search` CLI commands.
- Rejects partially numeric values like `1abc`, decimals like `5.5`, and non-positive values like `0` or `-1` that were previously silently accepted.

## Real behavior proof

**Behavior or issue addressed**: `openclaw plugins search` and `openclaw skills search` parse `--limit` with `Number.parseInt`, so partially numeric values like `1abc` are accepted as `1` instead of being rejected.

**Real environment tested**: Linux x86_64, Node.js v22.22.0. Pure JavaScript parsing logic, platform-independent.

**Exact steps or command run after the patch**:
```bash
cd openclaw-84473
node proof_repro.mjs
```
The script tests 6 inputs (`1abc`, `5.5`, `0`, `-1`, `10`, `1`) against the old parseInt parser and the new strict parser to verify rejection/acceptance behavior.

**Evidence after fix**:
```
=== CLI search --limit strict parsing fix (#84473) ===
Timestamp : 2026-05-20T10:06:04.223Z
Node.js   : v22.22.0
Platform  : linux x64

--- Test: various --limit values ---

Input: "1abc"
  BEFORE (parseInt): accepted as 1
  AFTER  (strict):   rejected: --limit must be a positive integer
  Expected: REJECT → PASS

Input: "5.5"
  BEFORE (parseInt): accepted as 5
  AFTER  (strict):   rejected: --limit must be a positive integer
  Expected: REJECT → PASS

Input: "0"
  BEFORE (parseInt): accepted as 0
  AFTER  (strict):   rejected: --limit must be a positive integer
  Expected: REJECT → PASS

Input: "-1"
  BEFORE (parseInt): accepted as -1
  AFTER  (strict):   rejected: --limit must be a positive integer
  Expected: REJECT → PASS

Input: "10"
  BEFORE (parseInt): accepted as 10
  AFTER  (strict):   accepted as 10
  Expected: ACCEPT → PASS

Input: "1"
  BEFORE (parseInt): accepted as 1
  AFTER  (strict):   accepted as 1
  Expected: ACCEPT → PASS

=== Result ===
All cases: PASS
```

**Observed result after fix**: Before fix: `Number.parseInt("1abc", 10)` returns `1`, silently accepting invalid input. After fix: strict `Number()` + validation rejects `"1abc"`, `"5.5"`, `"0"`, `"-1"` with error "--limit must be a positive integer". Valid integers `"10"` and `"1"` still accepted normally.

**What was not tested**: Live CLI invocation with `pnpm openclaw plugins search`. Other CLI commands that use `Number.parseInt` for different options (those are out of scope for this issue).

Fixes #84473