### PR TITLE
fix: avoid serializing plaintext model api keys

### DIFF
--- a/src/agents/model-auth-markers.test.ts
+++ b/src/agents/model-auth-markers.test.ts
@@ -24,6 +24,7 @@ function cleanPluginManifestEnv(): Record<(typeof PLUGIN_MANIFEST_ENV_KEYS)[numb
 let listKnownProviderEnvApiKeyNames: typeof import("./model-auth-env-vars.js").listKnownProviderEnvApiKeyNames;
 let GCP_VERTEX_CREDENTIALS_MARKER: typeof import("./model-auth-markers.js").GCP_VERTEX_CREDENTIALS_MARKER;
 let NON_ENV_SECRETREF_MARKER: typeof import("./model-auth-markers.js").NON_ENV_SECRETREF_MARKER;
+let OPENCLAW_MANAGED_AUTH_MARKER: typeof import("./model-auth-markers.js").OPENCLAW_MANAGED_AUTH_MARKER;
 let isKnownEnvApiKeyMarker: typeof import("./model-auth-markers.js").isKnownEnvApiKeyMarker;
 let isNonSecretApiKeyMarker: typeof import("./model-auth-markers.js").isNonSecretApiKeyMarker;
 let listKnownNonSecretApiKeyMarkers: typeof import("./model-auth-markers.js").listKnownNonSecretApiKeyMarkers;
@@ -41,6 +42,7 @@ async function loadMarkerModules() {
   listKnownProviderEnvApiKeyNames = envVarsModule.listKnownProviderEnvApiKeyNames;
   GCP_VERTEX_CREDENTIALS_MARKER = markersModule.GCP_VERTEX_CREDENTIALS_MARKER;
   NON_ENV_SECRETREF_MARKER = markersModule.NON_ENV_SECRETREF_MARKER;
+  OPENCLAW_MANAGED_AUTH_MARKER = markersModule.OPENCLAW_MANAGED_AUTH_MARKER;
   isKnownEnvApiKeyMarker = markersModule.isKnownEnvApiKeyMarker;
   isNonSecretApiKeyMarker = markersModule.isNonSecretApiKeyMarker;
   listKnownNonSecretApiKeyMarkers = markersModule.listKnownNonSecretApiKeyMarkers;
@@ -71,6 +73,7 @@ describe("model auth markers", () => {
     expect(isNonSecretApiKeyMarker("lmstudio-local")).toBe(true);
     expect(isNonSecretApiKeyMarker("codex-app-server")).toBe(true);
     expect(isNonSecretApiKeyMarker(GCP_VERTEX_CREDENTIALS_MARKER)).toBe(true);
+    expect(isNonSecretApiKeyMarker(OPENCLAW_MANAGED_AUTH_MARKER)).toBe(true);
   });
 
   it("reads bundled plugin-owned non-secret markers from manifests", () => {
@@ -79,6 +82,7 @@ describe("model auth markers", () => {
     expect(markers.has("gcp-vertex-credentials")).toBe(true);
     expect(markers.has("lmstudio-local")).toBe(true);
     expect(markers.has("minimax-oauth")).toBe(true);
+    expect(markers.has("openclaw-managed")).toBe(true);
     expect(markers.has("ollama-local")).toBe(true);
   });
 

--- a/src/agents/model-auth-markers.ts
+++ b/src/agents/model-auth-markers.ts
@@ -9,6 +9,7 @@ export const OLLAMA_LOCAL_AUTH_MARKER = "ollama-local";
 /** @deprecated Bundled local-provider marker; do not use from third-party plugins. */
 export const CUSTOM_LOCAL_AUTH_MARKER = "custom-local";
 export const GCP_VERTEX_CREDENTIALS_MARKER = "gcp-vertex-credentials";
+export const OPENCLAW_MANAGED_AUTH_MARKER = "openclaw-managed";
 export const NON_ENV_SECRETREF_MARKER = "secretref-managed"; // pragma: allowlist secret
 export const SECRETREF_ENV_HEADER_MARKER_PREFIX = "secretref-env:"; // pragma: allowlist secret
 
@@ -20,6 +21,7 @@ const AWS_SDK_ENV_MARKERS = new Set([
 const CORE_NON_SECRET_API_KEY_MARKERS = [
   CUSTOM_LOCAL_AUTH_MARKER,
   OLLAMA_LOCAL_AUTH_MARKER,
+  OPENCLAW_MANAGED_AUTH_MARKER,
   NON_ENV_SECRETREF_MARKER,
 ] as const;
 let knownEnvApiKeyMarkersCache: Set<string> | undefined;

--- a/src/agents/models-config.applies-config-env-vars.test.ts
+++ b/src/agents/models-config.applies-config-env-vars.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { createConfigRuntimeEnv } from "../config/env-vars.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
+import { OPENCLAW_MANAGED_AUTH_MARKER } from "./model-auth-markers.js";
 import { unsetEnv, withTempEnv } from "./models-config.e2e-harness.js";
 import {
   planOpenClawModelsJsonWithDeps,
@@ -27,6 +28,21 @@ function createImplicitOpenRouterProvider(): ProviderConfig {
         maxTokens: 8192,
       },
     ],
+  };
+}
+
+function createTestModel(
+  id = "custom-model",
+  name = "Custom",
+): NonNullable<ProviderConfig["models"]>[number] {
+  return {
+    id,
+    name,
+    reasoning: false,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 128000,
+    maxTokens: 16384,
   };
 }
 
@@ -244,6 +260,183 @@ describe("models-config", () => {
     expect(parsed.providers?.google?.models?.map((model) => model.id)).toEqual([
       "gemini-3.1-pro-preview",
     ]);
+  });
+
+  it("serializes a non-secret marker instead of config plaintext provider api keys", async () => {
+    const plan = await planOpenClawModelsJsonWithDeps(
+      {
+        cfg: {
+          models: {
+            providers: {
+              custom: {
+                baseUrl: "https://custom.example/v1",
+                api: "openai-completions",
+                apiKey: "sk-config-plaintext",
+                models: [createTestModel()],
+              },
+            },
+          },
+        },
+        agentDir: "/tmp/openclaw-models-config-env-vars-test",
+        env: {},
+        existingRaw: "",
+        existingParsed: null,
+      },
+      {
+        resolveImplicitProviders: async () => ({}),
+      },
+    );
+
+    expect(plan.action).toBe("write");
+    if (plan.action !== "write") {
+      throw new Error("Expected models.json write plan");
+    }
+    const parsed = JSON.parse(plan.contents) as {
+      providers?: Record<string, { apiKey?: string; baseUrl?: string }>;
+    };
+    expect(parsed.providers?.custom?.baseUrl).toBe("https://custom.example/v1");
+    expect(parsed.providers?.custom?.apiKey).toBe(OPENCLAW_MANAGED_AUTH_MARKER);
+    expect(plan.contents).not.toContain("sk-config-plaintext");
+  });
+
+  it("preserves managed env secret markers while serializing models.json", async () => {
+    const plan = await planOpenClawModelsJsonWithDeps(
+      {
+        cfg: {
+          models: {
+            providers: {
+              custom: {
+                baseUrl: "https://custom.example/v1",
+                api: "openai-completions",
+                apiKey: "${MY_CUSTOM_API_KEY}",
+                models: [createTestModel()],
+              },
+            },
+          },
+        },
+        agentDir: "/tmp/openclaw-models-config-env-vars-test",
+        env: { MY_CUSTOM_API_KEY: "sk-runtime-custom" } as NodeJS.ProcessEnv,
+        existingRaw: "",
+        existingParsed: null,
+      },
+      {
+        resolveImplicitProviders: async () => ({}),
+      },
+    );
+
+    expect(plan.action).toBe("write");
+    if (plan.action !== "write") {
+      throw new Error("Expected models.json write plan");
+    }
+    const parsed = JSON.parse(plan.contents) as {
+      providers?: Record<string, { apiKey?: string }>;
+    };
+    expect(parsed.providers?.custom?.apiKey).toBe("MY_CUSTOM_API_KEY");
+    expect(plan.contents).not.toContain("sk-runtime-custom");
+  });
+
+  it("keeps existing models.json-only plaintext api keys to avoid upgrade auth loss", async () => {
+    const plan = await planOpenClawModelsJsonWithDeps(
+      {
+        cfg: {
+          models: {
+            mode: "merge",
+            providers: {
+              custom: {
+                baseUrl: "https://custom.example/v1",
+                api: "openai-completions",
+                models: [createTestModel()],
+              },
+            },
+          },
+        },
+        agentDir: "/tmp/openclaw-models-config-env-vars-test",
+        env: {},
+        existingRaw: "",
+        existingParsed: {
+          providers: {
+            custom: {
+              baseUrl: "https://old.example/v1",
+              api: "openai-completions",
+              apiKey: "sk-existing-plaintext",
+              models: [createTestModel("old-model", "Old")],
+            },
+          },
+        },
+      },
+      {
+        resolveImplicitProviders: async () => ({}),
+      },
+    );
+
+    expect(plan.action).toBe("write");
+    if (plan.action !== "write") {
+      throw new Error("Expected models.json write plan");
+    }
+    const parsed = JSON.parse(plan.contents) as {
+      providers?: Record<string, { apiKey?: string; baseUrl?: string }>;
+    };
+    expect(parsed.providers?.custom?.baseUrl).toBe("https://old.example/v1");
+    expect(parsed.providers?.custom?.apiKey).toBe("sk-existing-plaintext");
+  });
+
+  it("replaces existing plaintext api keys when source config owns the provider secret", async () => {
+    const plan = await planOpenClawModelsJsonWithDeps(
+      {
+        cfg: {
+          models: {
+            mode: "merge",
+            providers: {
+              custom: {
+                baseUrl: "https://custom.example/v1",
+                api: "openai-completions",
+                apiKey: "sk-config-plaintext",
+                models: [createTestModel()],
+              },
+            },
+          },
+        },
+        sourceConfigForSecrets: {
+          models: {
+            providers: {
+              custom: {
+                baseUrl: "https://custom.example/v1",
+                api: "openai-completions",
+                apiKey: "sk-config-plaintext",
+                models: [createTestModel()],
+              },
+            },
+          },
+        },
+        agentDir: "/tmp/openclaw-models-config-env-vars-test",
+        env: {},
+        existingRaw: "",
+        existingParsed: {
+          providers: {
+            custom: {
+              baseUrl: "https://old.example/v1",
+              api: "openai-completions",
+              apiKey: "sk-existing-plaintext",
+              models: [createTestModel("old-model", "Old")],
+            },
+          },
+        },
+      },
+      {
+        resolveImplicitProviders: async () => ({}),
+      },
+    );
+
+    expect(plan.action).toBe("write");
+    if (plan.action !== "write") {
+      throw new Error("Expected models.json write plan");
+    }
+    const parsed = JSON.parse(plan.contents) as {
+      providers?: Record<string, { apiKey?: string; baseUrl?: string }>;
+    };
+    expect(parsed.providers?.custom?.apiKey).toBe(OPENCLAW_MANAGED_AUTH_MARKER);
+    expect(plan.contents).not.toContain("sk-config-plaintext");
+    expect(plan.contents).not.toContain("sk-existing-plaintext");
   });
 
   it("uses config env.vars entries for implicit provider discovery without mutating process.env", async () => {

--- a/src/agents/models-config.applies-config-env-vars.test.ts
+++ b/src/agents/models-config.applies-config-env-vars.test.ts
@@ -439,6 +439,65 @@ describe("models-config", () => {
     expect(plan.contents).not.toContain("sk-existing-plaintext");
   });
 
+  it("replaces existing plaintext api keys when source provider keys need trimming", async () => {
+    const plan = await planOpenClawModelsJsonWithDeps(
+      {
+        cfg: {
+          models: {
+            mode: "merge",
+            providers: {
+              " custom ": {
+                baseUrl: "https://custom.example/v1",
+                api: "openai-completions",
+                apiKey: "sk-config-plaintext",
+                models: [createTestModel()],
+              },
+            },
+          },
+        },
+        sourceConfigForSecrets: {
+          models: {
+            providers: {
+              " custom ": {
+                baseUrl: "https://custom.example/v1",
+                api: "openai-completions",
+                apiKey: "sk-config-plaintext",
+                models: [createTestModel()],
+              },
+            },
+          },
+        },
+        agentDir: "/tmp/openclaw-models-config-env-vars-test",
+        env: {},
+        existingRaw: "",
+        existingParsed: {
+          providers: {
+            custom: {
+              baseUrl: "https://old.example/v1",
+              api: "openai-completions",
+              apiKey: "sk-existing-plaintext",
+              models: [createTestModel("old-model", "Old")],
+            },
+          },
+        },
+      },
+      {
+        resolveImplicitProviders: async () => ({}),
+      },
+    );
+
+    expect(plan.action).toBe("write");
+    if (plan.action !== "write") {
+      throw new Error("Expected models.json write plan");
+    }
+    const parsed = JSON.parse(plan.contents) as {
+      providers?: Record<string, { apiKey?: string; baseUrl?: string }>;
+    };
+    expect(parsed.providers?.custom?.apiKey).toBe(OPENCLAW_MANAGED_AUTH_MARKER);
+    expect(plan.contents).not.toContain("sk-config-plaintext");
+    expect(plan.contents).not.toContain("sk-existing-plaintext");
+  });
+
   it("uses config env.vars entries for implicit provider discovery without mutating process.env", async () => {
     await withTempEnv(["OPENROUTER_API_KEY", TEST_ENV_VAR], async () => {
       unsetEnv(["OPENROUTER_API_KEY", TEST_ENV_VAR]);

--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -2,6 +2,10 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import { isRecord } from "../utils.js";
 import {
+  isNonSecretApiKeyMarker,
+  OPENCLAW_MANAGED_AUTH_MARKER,
+} from "./model-auth-markers.js";
+import {
   mergeProviders,
   mergeWithExistingProviderSecrets,
   type ExistingProviderConfig,
@@ -105,6 +109,63 @@ function resolveProvidersForMode(params: {
   });
 }
 
+function sanitizeProvidersForModelsJson(params: {
+  providers: Record<string, ProviderConfig>;
+  existingParsed: unknown;
+  secretRefManagedProviders: ReadonlySet<string>;
+  sourceProviders?: Record<string, ProviderConfig>;
+}): Record<string, ProviderConfig> {
+  let mutated = false;
+  const next: Record<string, ProviderConfig> = {};
+  for (const [providerKey, provider] of Object.entries(params.providers)) {
+    const apiKey = typeof provider.apiKey === "string" ? provider.apiKey.trim() : "";
+    const keepApiKey =
+      !apiKey ||
+      isNonSecretApiKeyMarker(apiKey) ||
+      params.secretRefManagedProviders.has(providerKey.trim());
+    if (keepApiKey) {
+      next[providerKey] = provider;
+      continue;
+    }
+    if (
+      shouldKeepExistingModelsJsonApiKey({
+        providerKey,
+        apiKey,
+        existingParsed: params.existingParsed,
+        sourceProviders: params.sourceProviders,
+      })
+    ) {
+      next[providerKey] = provider;
+      continue;
+    }
+    mutated = true;
+    const sanitizedProvider = { ...provider };
+    sanitizedProvider.apiKey = OPENCLAW_MANAGED_AUTH_MARKER;
+    next[providerKey] = sanitizedProvider;
+  }
+  return mutated ? next : params.providers;
+}
+
+function shouldKeepExistingModelsJsonApiKey(params: {
+  providerKey: string;
+  apiKey: string;
+  existingParsed: unknown;
+  sourceProviders?: Record<string, ProviderConfig>;
+}): boolean {
+  if (params.sourceProviders?.[params.providerKey]?.apiKey !== undefined) {
+    return false;
+  }
+  const existing = params.existingParsed;
+  if (!isRecord(existing) || !isRecord(existing.providers)) {
+    return false;
+  }
+  const existingProvider = existing.providers[params.providerKey];
+  if (!isRecord(existingProvider)) {
+    return false;
+  }
+  return existingProvider.apiKey === params.apiKey;
+}
+
 export async function planOpenClawModelsJsonWithDeps(
   params: {
     cfg: OpenClawConfig;
@@ -178,7 +239,13 @@ export async function planOpenClawModelsJsonWithDeps(
       secretRefManagedProviders,
     }) ?? normalizedMergedProviders;
   const finalProviders = applyNativeStreamingUsageCompat(secretEnforcedProviders);
-  const nextContents = `${JSON.stringify({ providers: finalProviders }, null, 2)}\n`;
+  const serializableProviders = sanitizeProvidersForModelsJson({
+    providers: finalProviders,
+    existingParsed: params.existingParsed,
+    secretRefManagedProviders,
+    sourceProviders: params.sourceConfigForSecrets?.models?.providers,
+  });
+  const nextContents = `${JSON.stringify({ providers: serializableProviders }, null, 2)}\n`;
 
   if (params.existingRaw === nextContents) {
     return { action: "noop" };

--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -117,6 +117,7 @@ function sanitizeProvidersForModelsJson(params: {
 }): Record<string, ProviderConfig> {
   let mutated = false;
   const next: Record<string, ProviderConfig> = {};
+  const sourceProvidersByKey = normalizeSourceProviderLookup(params.sourceProviders);
   for (const [providerKey, provider] of Object.entries(params.providers)) {
     const apiKey = typeof provider.apiKey === "string" ? provider.apiKey.trim() : "";
     const keepApiKey =
@@ -132,7 +133,7 @@ function sanitizeProvidersForModelsJson(params: {
         providerKey,
         apiKey,
         existingParsed: params.existingParsed,
-        sourceProviders: params.sourceProviders,
+        sourceProvidersByKey,
       })
     ) {
       next[providerKey] = provider;
@@ -150,9 +151,9 @@ function shouldKeepExistingModelsJsonApiKey(params: {
   providerKey: string;
   apiKey: string;
   existingParsed: unknown;
-  sourceProviders?: Record<string, ProviderConfig>;
+  sourceProvidersByKey: Readonly<Record<string, ProviderConfig>>;
 }): boolean {
-  if (params.sourceProviders?.[params.providerKey]?.apiKey !== undefined) {
+  if (params.sourceProvidersByKey[params.providerKey.trim()]?.apiKey !== undefined) {
     return false;
   }
   const existing = params.existingParsed;
@@ -164,6 +165,23 @@ function shouldKeepExistingModelsJsonApiKey(params: {
     return false;
   }
   return existingProvider.apiKey === params.apiKey;
+}
+
+function normalizeSourceProviderLookup(
+  providers: Record<string, ProviderConfig> | undefined,
+): Record<string, ProviderConfig> {
+  if (!providers) {
+    return {};
+  }
+  const out: Record<string, ProviderConfig> = {};
+  for (const [key, provider] of Object.entries(providers)) {
+    const normalizedKey = key.trim();
+    if (!normalizedKey || !isRecord(provider)) {
+      continue;
+    }
+    out[normalizedKey] = provider;
+  }
+  return out;
 }
 
 export async function planOpenClawModelsJsonWithDeps(

--- a/src/agents/pi-model-discovery.test.ts
+++ b/src/agents/pi-model-discovery.test.ts
@@ -2,16 +2,17 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { OPENCLAW_MANAGED_AUTH_MARKER } from "./model-auth-markers.js";
 import { discoverAuthStorage, discoverModels } from "./pi-model-discovery.js";
 
-function writeModelsJson(agentDir: string, modelId: string): void {
+function writeModelsJson(agentDir: string, modelId: string, apiKey = "sk-test"): void {
   fs.writeFileSync(
     path.join(agentDir, "models.json"),
     JSON.stringify({
       providers: {
         custom: {
           baseUrl: "https://example.test/v1",
-          apiKey: "sk-test",
+          apiKey,
           api: "openai",
           models: [{ id: modelId, name: modelId }],
         },
@@ -34,5 +35,15 @@ describe("discoverModels", () => {
 
     expect(registry.getAll().some((model) => model.id === "new-model")).toBe(true);
     expect(registry.find("custom", "new-model")?.id).toBe("new-model");
+  });
+
+  it("accepts OpenClaw-managed auth markers for custom model entries", () => {
+    const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-pi-models-"));
+    writeModelsJson(agentDir, "custom-model", OPENCLAW_MANAGED_AUTH_MARKER);
+    const authStorage = discoverAuthStorage(agentDir, { skipCredentials: true });
+    const registry = discoverModels(authStorage, agentDir, { normalizeModels: false });
+
+    expect(registry.getError()).toBeUndefined();
+    expect(registry.find("custom", "custom-model")?.id).toBe("custom-model");
   });
 });


### PR DESCRIPTION
## Summary
- Prevent config/source-managed plaintext provider API keys from being serialized into generated models.json contents.
- Preserve the models.json auth/registry contract by writing a non-secret `openclaw-managed` apiKey marker instead of deleting the field.
- Keep existing models.json-only plaintext keys when no source config owns the credential, avoiding upgrade-time loss of the user's only auth source.
- Add regression coverage for plaintext config values, managed env secret markers, existing models.json merges, the new marker, and pi-coding-agent registry acceptance.

Refs #11829.

## Real behavior proof

Behavior or issue addressed: After the fix, a source-configured custom provider with a plaintext API key generates `models.json` without that plaintext key, while still keeping a non-empty `apiKey` marker so pi-coding-agent accepts the custom provider and model.

Real environment tested: Local Windows development checkout, commit `dd10217e`; temporary real OpenClaw agentDir under `C:\Users\Lenovo\AppData\Local\Temp`; actual `planOpenClawModelsJsonWithDeps`, `discoverAuthStorage`, and `discoverModels` were executed via `node --import tsx --input-type=module`. The credential value was a fake redacted proof key, not a real provider secret.

Exact steps or command run after this patch:
1. Created a temporary agentDir.
2. Planned `models.json` for a custom `openai-completions` provider whose source config contained fake plaintext `apiKey: sk-live-proof-redacted`.
3. Wrote the planned contents to the temporary agentDir's `models.json`.
4. Loaded that file through pi-coding-agent registry integration using `discoverAuthStorage` and `discoverModels`.
5. Checked whether the plaintext appeared, what `provider.apiKey` serialized to, whether registry parsing failed, and whether the custom model was available.

Evidence after fix: Copied live terminal output from the command above:
```text
agentDir=C:\Users\Lenovo\AppData\Local\Temp\openclaw-real-proof-WLWDam
plan.action=write
plaintextSerialized=false
provider.apiKey=openclaw-managed
expectedMarker=openclaw-managed
registry.error=none
registry.find=custom-model
registry.available=true
```

Observed result after fix: The plaintext key was not serialized; generated `models.json` used `apiKey: openclaw-managed`; pi-coding-agent reported no registry error; `custom/custom-model` was found and available.

What was not tested: No live external provider request was made with a real API key. The proof validates the changed persistence/registry boundary using actual OpenClaw planner and registry code with a fake proof key; supplemental tests/typechecks cover the code paths in CI-friendly form.

## Verification
- `npm exec --yes pnpm@11.1.0 -- exec vitest run --config test/vitest/vitest.agents.config.ts src/agents/models-config.applies-config-env-vars.test.ts src/agents/models-config.merge.test.ts src/agents/models-config.providers.auth-provenance.test.ts src/agents/model-auth-markers.test.ts src/agents/pi-model-discovery.test.ts`
- `npm exec --yes pnpm@11.1.0 -- tsgo:test`
- `npm exec --yes pnpm@11.1.0 -- tsgo:core`
- `git diff --check`

Result: targeted Vitest run passed 5 files / 43 tests, `tsgo:test` passed, `tsgo:core` passed, and `git diff --check` passed.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? Yes
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

This reduces token persistence for generated config by replacing source-managed plaintext apiKey values with a non-secret marker, while preserving marker-based runtime auth references and the registry contract for custom providers.