### PR TITLE
fix(cron): document best-effort edit delivery mode

### DIFF
--- a/src/cli/cron-cli/register.cron-edit.test.ts
+++ b/src/cli/cron-cli/register.cron-edit.test.ts
@@ -1,0 +1,58 @@
+import { Command } from "commander";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const callGatewayFromCli = vi.fn();
+
+vi.mock("../gateway-rpc.js", async () => {
+  const actual = await vi.importActual<typeof import("../gateway-rpc.js")>("../gateway-rpc.js");
+  return {
+    ...actual,
+    callGatewayFromCli: (...args: Parameters<typeof actual.callGatewayFromCli>) =>
+      callGatewayFromCli(...args),
+  };
+});
+
+const { registerCronEditCommand } = await import("./register.cron-edit.js");
+
+function createCronProgram(): Command {
+  const program = new Command();
+  program.exitOverride();
+  registerCronEditCommand(program);
+  return program;
+}
+
+describe("cron edit command", () => {
+  beforeEach(() => {
+    callGatewayFromCli.mockReset();
+    callGatewayFromCli.mockResolvedValue({ ok: true });
+  });
+
+  it("documents that --best-effort-deliver implies announce mode when used alone (#83908)", () => {
+    const editCommand = createCronProgram().commands.find((command) => command.name() === "edit");
+    const help = editCommand?.helpInformation() ?? "";
+
+    expect(help).toContain("--best-effort-deliver");
+    expect(help).toMatch(/also\s+implies --announce when used alone/);
+  });
+
+  it("keeps the documented --best-effort-deliver-only patch behavior (#83908)", async () => {
+    const program = createCronProgram();
+
+    await program.parseAsync(["edit", "job-1", "--best-effort-deliver"], { from: "user" });
+
+    expect(callGatewayFromCli).toHaveBeenCalledWith(
+      "cron.update",
+      expect.objectContaining({ bestEffortDeliver: true }),
+      {
+        id: "job-1",
+        patch: {
+          payload: { kind: "agentTurn" },
+          delivery: {
+            mode: "announce",
+            bestEffort: true,
+          },
+        },
+      },
+    );
+  });
+});

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -109,7 +109,10 @@ export function registerCronEditCommand(cron: Command) {
       )
       .option("--thread-id <id>", "Telegram forum topic thread id")
       .option("--account <id>", "Channel account id for delivery (multi-account setups)")
-      .option("--best-effort-deliver", "Do not fail job if delivery fails")
+      .option(
+        "--best-effort-deliver",
+        "Do not fail job if delivery fails (also implies --announce when used alone)",
+      )
       .option("--no-best-effort-deliver", "Fail job when delivery fails")
       .option("--failure-alert", "Enable failure alerts for this job")
       .option("--no-failure-alert", "Disable failure alerts for this job")


### PR DESCRIPTION
## Summary
- Document that `cron edit --best-effort-deliver` implies announce delivery mode when used without an explicit delivery mode flag.
- Add regression coverage for both the help text and the existing best-effort-only patch shape.

Fixes #83908

## Real behavior proof

Behavior addressed: `openclaw cron edit <id> --best-effort-deliver` has an existing back-compat behavior where the flag alone sets `delivery.mode` to `announce`; the command help should disclose that implication.

Real environment tested: Local OpenClaw checkout on macOS, Node.js v22.22.0, using the real `registerCronEditCommand` Commander registration from `src/cli/cron-cli/register.cron-edit.ts`.

Exact steps or command run after fix: Inspected the real command help generated by Commander for `cron edit`:

```console
$ node --import tsx --input-type=module <<'EOF'
import { Command } from 'commander';
import { registerCronEditCommand } from './src/cli/cron-cli/register.cron-edit.ts';
const program = new Command();
registerCronEditCommand(program);
const edit = program.commands.find((command) => command.name() === 'edit');
const lines = edit.helpInformation().split('\n');
const index = lines.findIndex((entry) => entry.includes('--best-effort-deliver'));
console.log(lines.slice(index, index + 2).map((line) => line.trim()).join(' '));
EOF
```

Evidence after fix: Terminal output from the command above:

```console
--best-effort-deliver                Do not fail job if delivery fails (also implies --announce when used alone)
```

Observed result after fix: The generated `cron edit` help now explicitly states that `--best-effort-deliver` also implies `--announce` when used alone, matching the existing patch behavior. The new regression test also verifies that parsing `edit job-1 --best-effort-deliver` sends a `cron.update` patch with `delivery.mode: "announce"` and `delivery.bestEffort: true`.

What was not tested: I did not run against a live Gateway; the targeted test mocks the Gateway RPC and verifies the real Commander action builds the expected `cron.update` request.

## Test plan
- `node --import tsx --input-type=module ...` (help proof above)
- `node scripts/run-vitest.mjs src/cli/cron-cli/register.cron-edit.test.ts src/cli/cron-cli/register.cron-simple.test.ts`
- `git diff --check`
