### PR TITLE
Audit config backups for retained plaintext secrets

### DIFF
--- a/src/secrets/audit.test.ts
+++ b/src/secrets/audit.test.ts
@@ -277,6 +277,37 @@ describe("secrets audit", () => {
     expectFindingCode(report, "REF_UNRESOLVED");
   });
 
+  it("reports plaintext secrets retained by adjacent config backups", async () => {
+    await fs.rm(fixture.authStorePath, { force: true });
+    await fs.writeFile(fixture.envPath, "", "utf8");
+    const backupPath = `${fixture.configPath}.bak`;
+    await writeJsonFile(backupPath, {
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://api.openai.com/v1",
+            api: "openai-completions",
+            apiKey: "sk-config-backup-plaintext", // pragma: allowlist secret
+            models: [{ id: "gpt-5", name: "gpt-5" }],
+          },
+        },
+      },
+    });
+
+    const report = await runSecretsAudit({ env: fixture.env });
+    const finding = report.findings.find(
+      (entry) =>
+        entry.code === "PLAINTEXT_FOUND" &&
+        entry.file === backupPath &&
+        entry.jsonPath === "models.providers.openai.apiKey",
+    );
+
+    expect(finding).toBeDefined();
+    expect(finding?.message).toContain("Config backup contains plaintext");
+    expect(finding?.message).not.toContain("sk-config-backup-plaintext");
+    expect(report.filesScanned).toContain(backupPath);
+  });
+
   it("skips exec ref resolution during audit unless explicitly allowed", async () => {
     if (process.platform === "win32") {
       return;

--- a/src/secrets/audit.ts
+++ b/src/secrets/audit.ts
@@ -32,6 +32,7 @@ import { isNonEmptyString, isRecord } from "./shared.js";
 import {
   listAgentModelsJsonPaths,
   listAuthProfileStorePaths,
+  listConfigBackupPaths,
   listLegacyAuthJsonPaths,
   parseEnvAssignmentValue,
   readJsonObjectIfExists,
@@ -104,6 +105,7 @@ type AuditCollector = {
 };
 
 const REF_RESOLVE_FALLBACK_CONCURRENCY = 8;
+const MAX_AUDIT_CONFIG_BACKUP_BYTES = 5 * 1024 * 1024;
 const MAX_AUDIT_MODELS_JSON_BYTES = 5 * 1024 * 1024;
 const ALWAYS_SENSITIVE_MODEL_PROVIDER_HEADER_NAMES = new Set([
   "authorization",
@@ -257,6 +259,61 @@ function collectConfigSecrets(params: {
       message: `${target.path} is stored as plaintext.`,
       provider: target.providerId,
     });
+  }
+}
+
+function collectConfigBackupSecrets(params: {
+  configPath: string;
+  collector: AuditCollector;
+}): void {
+  for (const backupPath of listConfigBackupPaths(params.configPath)) {
+    params.collector.filesScanned.add(backupPath);
+    const parsedResult = readJsonObjectIfExists(backupPath, {
+      requireRegularFile: true,
+      maxBytes: MAX_AUDIT_CONFIG_BACKUP_BYTES,
+    });
+    if (parsedResult.error || !parsedResult.value) {
+      continue;
+    }
+
+    const backupConfig = parsedResult.value as OpenClawConfig;
+    const defaults = backupConfig.secrets?.defaults;
+    for (const target of discoverConfigSecretTargets(backupConfig)) {
+      if (!target.entry.includeInAudit) {
+        continue;
+      }
+      if (
+        target.entry.id === "models.providers.*.headers.*" &&
+        !isLikelySensitiveModelProviderHeaderName(target.pathSegments.at(-1) ?? "")
+      ) {
+        continue;
+      }
+
+      const { ref } = resolveSecretInputRef({
+        value: target.value,
+        refValue: target.refValue,
+        defaults,
+      });
+      if (ref) {
+        continue;
+      }
+
+      const hasPlaintext = hasConfiguredPlaintextSecretValue(
+        target.value,
+        target.entry.expectedResolvedValue,
+      );
+      if (!hasPlaintext) {
+        continue;
+      }
+      addFinding(params.collector, {
+        code: "PLAINTEXT_FOUND",
+        severity: "warn",
+        file: backupPath,
+        jsonPath: target.path,
+        message: `Config backup contains plaintext at ${target.path}. Remove stale snapshots or rotate the credential if this backup may have left the host.`,
+        provider: target.providerId,
+      });
+    }
   }
 }
 
@@ -714,6 +771,10 @@ export async function runSecretsAudit(
 
   collectEnvPlaintext({
     envPath,
+    collector,
+  });
+  collectConfigBackupSecrets({
+    configPath,
     collector,
   });
   collectAuthJsonResidue({

--- a/src/secrets/storage-scan.ts
+++ b/src/secrets/storage-scan.ts
@@ -37,6 +37,33 @@ export function listLegacyAuthJsonPaths(stateDir: string): string[] {
   return out;
 }
 
+export function listConfigBackupPaths(configPath: string): string[] {
+  const resolvedConfigPath = resolveUserPath(configPath);
+  const configDir = path.dirname(resolvedConfigPath);
+  const configBase = path.basename(resolvedConfigPath);
+  if (!fs.existsSync(configDir)) {
+    return [];
+  }
+
+  const paths: string[] = [];
+  for (const entry of fs.readdirSync(configDir, { withFileTypes: true })) {
+    if (!entry.isFile()) {
+      continue;
+    }
+    const suffix = entry.name.startsWith(configBase) ? entry.name.slice(configBase.length) : "";
+    if (
+      suffix === ".bak" ||
+      suffix.startsWith(".bak.") ||
+      suffix === ".pre-update" ||
+      suffix.startsWith(".rejected.") ||
+      suffix.startsWith(".clobbered.")
+    ) {
+      paths.push(path.join(configDir, entry.name));
+    }
+  }
+  return paths.toSorted();
+}
+
 function resolveActiveAgentDir(stateDir: string, env: NodeJS.ProcessEnv = process.env): string {
   const override = env.OPENCLAW_AGENT_DIR?.trim() || env.PI_CODING_AGENT_DIR?.trim();
   if (override) {


### PR DESCRIPTION
## Summary
- scan adjacent config snapshots such as openclaw.json.bak, numbered backups, pre-update snapshots, rejected snapshots, and clobbered snapshots during secrets audit
- report plaintext secret targets found in those snapshots without echoing secret values
- add regression coverage for plaintext API keys retained in config backups

Refs #11829.

## Real behavior proof
**Behavior or issue addressed**: `openclaw secrets audit` now detects plaintext secrets retained in adjacent `openclaw.json.*` config snapshots, while still resolving the active config SecretRef normally and without echoing the plaintext value.

**Real environment tested**: Local macOS source checkout at `2a3b267e41f71b034627100bcdf47ff54030d267`, Node `v25.2.1`, pnpm `11.1.0`, using the real `pnpm openclaw secrets audit --json` CLI path after the launcher built the stale `dist` output.

**Exact steps or command run after this patch**: Created a temporary OpenClaw state dir with an active `openclaw.json` using `{ source: "env", provider: "default", id: "OPENAI_API_KEY" }`, plus an adjacent `openclaw.json.bak` retaining a sample plaintext provider key. Then ran:
```bash
OPENCLAW_STATE_DIR=.artifacts/secrets-proof-AM4OWZ/state \
OPENCLAW_CONFIG_PATH=.artifacts/secrets-proof-AM4OWZ/state/openclaw.json \
OPENAI_API_KEY=env-proof-value \
pnpm openclaw secrets audit --json
```

**Evidence after fix**: Copied live CLI output excerpt from the command above:
```json
{
  "status": "findings",
  "resolution": {
    "refsChecked": 1,
    "skippedExecRefs": 0,
    "resolvabilityComplete": true
  },
  "filesScanned": [
    ".artifacts/secrets-proof-AM4OWZ/state/openclaw.json",
    ".artifacts/secrets-proof-AM4OWZ/state/openclaw.json.bak"
  ],
  "summary": {
    "plaintextCount": 1,
    "unresolvedRefCount": 0,
    "shadowedRefCount": 0,
    "legacyResidueCount": 0
  },
  "findings": [
    {
      "code": "PLAINTEXT_FOUND",
      "severity": "warn",
      "file": ".artifacts/secrets-proof-AM4OWZ/state/openclaw.json.bak",
      "jsonPath": "models.providers.openai.apiKey",
      "message": "Config backup contains plaintext at models.providers.openai.apiKey. Remove stale snapshots or rotate the credential if this backup may have left the host.",
      "provider": "openai"
    }
  ]
}
```

**Observed result after fix**: The audit scanned both `openclaw.json` and `openclaw.json.bak`, resolved the active env SecretRef (`refsChecked: 1`, `unresolvedRefCount: 0`), and reported exactly one plaintext finding against the backup path/jsonPath. The plaintext key value did not appear in the JSON report.

**What was not tested**: None.

## Tests
- node scripts/test-projects.mjs src/secrets/audit.test.ts
- pnpm exec oxlint src/secrets/audit.ts src/secrets/audit.test.ts src/secrets/storage-scan.ts
- pnpm exec oxfmt --check --threads=1 src/secrets/audit.ts src/secrets/audit.test.ts src/secrets/storage-scan.ts
- pnpm tsgo:core
- pnpm tsgo:core:test