### PR TITLE
fix(browser): drop unused navigation requireRef import

### DIFF
--- a/extensions/browser/src/cli/browser-cli-actions-input/register.navigation.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/register.navigation.ts
@@ -3,7 +3,7 @@ import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runti
 import { runBrowserResizeWithOutput } from "../browser-cli-resize.js";
 import { callBrowserRequest, type BrowserParentOpts } from "../browser-cli-shared.js";
 import { danger, defaultRuntime } from "../core-api.js";
-import { requireRef, resolveBrowserActionContext } from "./shared.js";
+import { resolveBrowserActionContext } from "./shared.js";
 
 export function registerBrowserNavigationCommands(
   browser: Command,
@@ -65,6 +65,4 @@ export function registerBrowserNavigationCommands(
       }
     });
 
-  // Keep `requireRef` reachable; shared utilities are intended for other modules too.
-  void requireRef;
 }


### PR DESCRIPTION
## Summary
- Remove the phantom `requireRef` import from browser navigation command registration.
- Delete the `void requireRef` side-effect expression that existed only to silence unused-import lint.
- Leave `requireRef` exported from `shared.ts` for the modules that actually need it.

Fixes #83878

## Real behavior proof

Behavior addressed: `extensions/browser/src/cli/browser-cli-actions-input/register.navigation.ts` imported `requireRef` only to reference it through `void requireRef`; this kept a dead import alive without any real browser navigation behavior depending on it.

Real environment tested: Local OpenClaw checkout on macOS, Node.js v22.22.0, branch `fix/browser-navigation-drop-requireref-83878`.

Exact steps or command run after fix: Verified the edited source file no longer references `requireRef`, while `shared.ts` still exports `requireRef` for real callers:

```console
$ python3 - <<'PY'
from pathlib import Path
path = Path('extensions/browser/src/cli/browser-cli-actions-input/register.navigation.ts')
text = path.read_text()
print('requireRef occurrences in register.navigation.ts:', text.count('requireRef'))
for i, line in enumerate(text.splitlines(), 1):
    if 'shared.js' in line or 'requireRef' in line:
        print(f'{i}: {line}')
PY
$ python3 - <<'PY'
from pathlib import Path
path = Path('extensions/browser/src/cli/browser-cli-actions-input/shared.ts')
for i, line in enumerate(path.read_text().splitlines(), 1):
    if 'function requireRef' in line:
        print(f'{i}: {line}')
PY
```

Evidence after fix: Terminal output from the command above:

```console
requireRef occurrences in register.navigation.ts: 0
4: import { callBrowserRequest, type BrowserParentOpts } from "../browser-cli-shared.js";
6: import { resolveBrowserActionContext } from "./shared.js";
66: export function requireRef(ref: string | undefined) {
```

Observed result after fix: The browser navigation registration file now imports only the shared helper it actually uses, and the `void requireRef` dead-import workaround is gone. The shared helper remains available from `shared.ts`, so this change only removes the unrelated phantom dependency from `register.navigation.ts`.

What was not tested: I did not run a live browser navigation command because the change is import-graph cleanup only. I also did not complete `pnpm lint:extensions:no-relative-outside-package` because pnpm attempted a dependency install and timed out on registry downloads in this environment.

## Test plan
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/browser/src/cli/browser-cli-actions-input/register.navigation.ts`
- `git diff --check`
