### PR TITLE
fix: derive subagent announce source channel from resolved origin

### DIFF
--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -78,6 +78,7 @@ function visibleAgentResponse(runId = "run-main") {
 function expectInputProvenance(
   params: Record<string, unknown> | undefined,
   sourceSessionKey: string,
+  sourceChannel?: string,
 ) {
   const inputProvenance = params?.inputProvenance;
   if (!inputProvenance || typeof inputProvenance !== "object") {
@@ -86,6 +87,9 @@ function expectInputProvenance(
   const provenance = inputProvenance as Record<string, unknown>;
   expect(provenance.kind).toBe("inter_session");
   expect(provenance.sourceSessionKey).toBe(sourceSessionKey);
+  if (sourceChannel !== undefined) {
+    expect(provenance.sourceChannel).toBe(sourceChannel);
+  }
   expect(provenance.sourceTool).toBe("subagent_announce");
 }
 
@@ -760,7 +764,7 @@ describe("subagent announce formatting", () => {
     expect(call?.params?.channel).toBe("discord");
     expect(call?.params?.to).toBe("channel:12345");
     expect(call?.params?.sessionKey).toBe("agent:main:main");
-    expectInputProvenance(call?.params, "agent:main:subagent:test");
+    expectInputProvenance(call?.params, "agent:main:subagent:test", "discord");
     expect(msg).toContain("final answer: 2");
     expect(msg).not.toContain("✅ Subagent");
   });
@@ -1941,6 +1945,38 @@ describe("subagent announce formatting", () => {
       deliver: false,
     });
     expect(getAgentCall().params?.sourceReplyDeliveryMode).toBe("message_tool_only");
+  });
+
+  it("uses requester session route as completion provenance when requester origin is absent", async () => {
+    sessionStore = {
+      "agent:main:main": {
+        sessionId: "requester-session-direct-route-from-session",
+        lastChannel: "whatsapp",
+        lastTo: "+1555",
+        lastAccountId: "acct-wa",
+      },
+    };
+
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:worker",
+      childRunId: "run-completion-session-route",
+      requesterSessionKey: "main",
+      requesterDisplayKey: "main",
+      expectsCompletionMessage: true,
+      ...defaultOutcomeAnnounce,
+    });
+
+    expect(didAnnounce).toBe(true);
+    expect(sendSpy).not.toHaveBeenCalled();
+    expect(agentSpy).toHaveBeenCalledTimes(1);
+    expectAgentCallFields(getAgentCall(), {
+      sessionKey: "agent:main:main",
+      channel: "whatsapp",
+      to: "+1555",
+      accountId: "acct-wa",
+      deliver: true,
+    });
+    expectInputProvenance(getAgentCall().params, "agent:main:subagent:worker", "whatsapp");
   });
 
   it("returns failure for completion-mode when direct delivery fails and steering fallback is unavailable", async () => {

--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -104,6 +104,7 @@ function getAgentCall(index = 0): AgentCallRequest {
 function expectAgentCallFields(
   call: AgentCallRequest,
   expected: {
+    accountId?: string;
     channel?: string;
     deliver?: boolean;
     sessionKey: string;
@@ -118,6 +119,9 @@ function expectAgentCallFields(
   }
   if ("to" in expected) {
     expect(call.params?.to).toBe(expected.to);
+  }
+  if ("accountId" in expected) {
+    expect(call.params?.accountId).toBe(expected.accountId);
   }
 }
 

--- a/src/agents/subagent-announce.test.ts
+++ b/src/agents/subagent-announce.test.ts
@@ -101,6 +101,9 @@ vi.mock("./subagent-announce-delivery.js", () => ({
     };
     directOrigin?: { channel?: string; to?: string; accountId?: string; threadId?: string };
     requesterSessionOrigin?: { provider?: string; channel?: string };
+    sourceSessionKey?: string;
+    sourceChannel?: string;
+    sourceTool?: string;
     bestEffortDeliver?: boolean;
   }) => {
     const store = loadSessionStoreMock("/tmp/sessions.json") as Record<string, unknown>;
@@ -136,6 +139,12 @@ vi.mock("./subagent-announce-delivery.js", () => ({
           effectiveOrigin?.channel !== "webchat" &&
           Boolean(effectiveOrigin?.channel && effectiveOrigin?.to),
         bestEffortDeliver: params.bestEffortDeliver,
+        inputProvenance: {
+          kind: "inter_session",
+          sourceSessionKey: params.sourceSessionKey,
+          sourceChannel: params.sourceChannel,
+          sourceTool: params.sourceTool ?? "subagent_announce",
+        },
         ...(params.requesterIsSubagent
           ? {}
           : {
@@ -440,6 +449,101 @@ describe("subagent announce seam flow", () => {
     expect(agentCall.params?.deliver).toBe(false);
     expect(agentCall.params?.bestEffortDeliver).toBe(true);
     expect(agentCall.params?.accountId).toBe("default");
+  });
+
+  it("uses normalized requester origin channel for completion provenance", async () => {
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:discord",
+      childRunId: "run-discord-direct-announce",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      requesterOrigin: {
+        channel: " Discord ",
+        to: "channel:123",
+        accountId: "default",
+      },
+      task: "deliver completion",
+      timeoutMs: 10,
+      cleanup: "keep",
+      waitForCompletion: false,
+      startedAt: 10,
+      endedAt: 20,
+      outcome: { status: "ok" },
+      roundOneReply: "done",
+      expectsCompletionMessage: true,
+      bestEffortDeliver: true,
+    });
+
+    expect(didAnnounce).toBe(true);
+    expect(agentSpy).toHaveBeenCalledTimes(1);
+    expect(agentSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "agent",
+        params: expect.objectContaining({
+          sessionKey: "agent:main:main",
+          deliver: true,
+          channel: "discord",
+          to: "channel:123",
+          accountId: "default",
+          inputProvenance: expect.objectContaining({
+            kind: "inter_session",
+            sourceSessionKey: "agent:main:subagent:discord",
+            sourceChannel: "discord",
+            sourceTool: "subagent_announce",
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("uses requester session route channel for completion provenance when origin is absent", async () => {
+    loadSessionStoreMock.mockImplementation(() => ({
+      "agent:main:main": {
+        sessionId: "requester-session-route",
+        updatedAt: Date.now(),
+        lastChannel: "whatsapp",
+        lastTo: "+1555",
+        lastAccountId: "acct-wa",
+      },
+    }));
+
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:worker",
+      childRunId: "run-session-route-direct-announce",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "deliver completion",
+      timeoutMs: 10,
+      cleanup: "keep",
+      waitForCompletion: false,
+      startedAt: 10,
+      endedAt: 20,
+      outcome: { status: "ok" },
+      roundOneReply: "done",
+      expectsCompletionMessage: true,
+      bestEffortDeliver: true,
+    });
+
+    expect(didAnnounce).toBe(true);
+    expect(agentSpy).toHaveBeenCalledTimes(1);
+    expect(agentSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "agent",
+        params: expect.objectContaining({
+          sessionKey: "agent:main:main",
+          deliver: true,
+          channel: "whatsapp",
+          to: "+1555",
+          accountId: "acct-wa",
+          inputProvenance: expect.objectContaining({
+            kind: "inter_session",
+            sourceSessionKey: "agent:main:subagent:worker",
+            sourceChannel: "whatsapp",
+            sourceTool: "subagent_announce",
+          }),
+        }),
+      }),
+    );
   });
 
   it("keeps nested subagent completion announces channel-less in session-only mode", async () => {

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -73,6 +73,19 @@ function loadSubagentRegistryRuntime() {
   return subagentRegistryRuntimeLoader.load();
 }
 
+function resolveSubagentAnnounceSourceChannel(params: {
+  completionDirectOrigin?: DeliveryContext;
+  directOrigin?: DeliveryContext;
+  targetRequesterOrigin?: DeliveryContext;
+}): string {
+  return (
+    params.completionDirectOrigin?.channel ??
+    params.directOrigin?.channel ??
+    params.targetRequesterOrigin?.channel ??
+    INTERNAL_MESSAGE_CHANNEL
+  );
+}
+
 export { buildSubagentSystemPrompt } from "./subagent-system-prompt.js";
 export { captureSubagentCompletionReply } from "./subagent-announce-output.js";
 export type { SubagentRunOutcome } from "./subagent-announce-output.js";
@@ -561,7 +574,11 @@ export async function runSubagentAnnounceFlow(params: {
       completionDirectOrigin,
       directOrigin,
       sourceSessionKey: params.childSessionKey,
-      sourceChannel: INTERNAL_MESSAGE_CHANNEL,
+      sourceChannel: resolveSubagentAnnounceSourceChannel({
+        completionDirectOrigin,
+        directOrigin,
+        targetRequesterOrigin,
+      }),
       sourceTool: "subagent_announce",
       targetRequesterSessionKey,
       requesterIsSubagent,


### PR DESCRIPTION
Supersedes/continues the fix from #58874 with the resolved-origin change requested by review.

## Summary

- Derive subagent announce `inputProvenance.sourceChannel` from the resolved origin chain: `completionDirectOrigin -> directOrigin -> targetRequesterOrigin -> INTERNAL_MESSAGE_CHANNEL`.
- Add focused assertions for normalized Discord requester-origin provenance.
- Add requester-session route fallback coverage when requester origin is absent.
- Keep the fix scoped to announce provenance; no channel, credential, dependency, or execution-surface changes.

## Validation

- `corepack pnpm exec oxfmt --check --threads=1 src/agents/subagent-announce.ts src/agents/subagent-announce.test.ts src/agents/subagent-announce.format.e2e.test.ts`
- `corepack pnpm test src/agents/subagent-announce.test.ts` (12/12)
- `corepack pnpm test src/agents/subagent-announce.format.e2e.test.ts` (80/80)
- `corepack pnpm tsgo:test`

## Proof status

Source-level proof is included. Real Telegram/Discord behavior proof is still needed for the external proof gate.