### PR TITLE
fix(install): skip Homebrew when Node is current

### DIFF
--- a/docs/install/installer.md
+++ b/docs/install/installer.md
@@ -68,13 +68,13 @@ Recommended for most interactive installs on macOS/Linux/WSL.
 
 <Steps>
   <Step title="Detect OS">
-    Supports macOS and Linux (including WSL). If macOS is detected, installs Homebrew if missing.
+    Supports macOS and Linux (including WSL). On macOS, Homebrew is installed only when it is needed to install a missing dependency such as Node.js or Git.
   </Step>
   <Step title="Ensure Node.js 24 by default">
     Checks Node version and installs Node 24 if needed (Homebrew on macOS, NodeSource setup scripts on Linux apt/dnf/yum). OpenClaw still supports Node 22 LTS, currently `22.19+`, for compatibility.
   </Step>
   <Step title="Ensure Git">
-    Installs Git if missing.
+    Installs Git if missing. On macOS, this step ensures Homebrew first if Git is missing.
   </Step>
   <Step title="Install OpenClaw">
     - `npm` method (default): global npm install

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2818,12 +2818,10 @@ main() {
 
     ui_stage "Preparing environment"
 
-    # Step 1: Homebrew (macOS only)
-    install_homebrew
-
-    # Step 2: Node.js
+    # Step 1: Node.js. On macOS, Homebrew is only needed when Node.js is missing or outdated.
     load_nvm_for_node_detection
     if ! check_node; then
+        install_homebrew
         install_node
     fi
     activate_supported_node_on_path || true

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1718,6 +1718,7 @@ require_sudo() {
 
 install_git() {
     if [[ "$OS" == "macos" ]]; then
+        install_homebrew
         run_quiet_step "Installing Git" brew install git
     elif [[ "$OS" == "linux" ]]; then
         require_sudo

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -50,9 +50,97 @@ describe("install.sh", () => {
     );
   });
 
+  it("skips Homebrew during macOS preparation when the active Node is already supported", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "openclaw-install-macos-node-"));
+    const events = join(tmp, "events.log");
+
+    let result: ReturnType<typeof runInstallShell> | undefined;
+    let eventsText = "";
+    try {
+      result = runInstallShell(`
+        set -euo pipefail
+        source "${SCRIPT_PATH}"
+        HELP=0
+        DRY_RUN=0
+        INSTALL_METHOD=npm
+        detect_os_or_die() { OS=macos; }
+        bootstrap_gum_temp() { :; }
+        print_installer_banner() { :; }
+        print_gum_status() { :; }
+        detect_openclaw_checkout() { return 1; }
+        show_install_plan() { :; }
+        check_existing_openclaw() { return 1; }
+        ui_stage() { :; }
+        load_nvm_for_node_detection() { printf 'load_nvm_for_node_detection\\n' >> ${JSON.stringify(events)}; }
+        check_node() { printf 'check_node\\n' >> ${JSON.stringify(events)}; return 0; }
+        install_homebrew() { printf 'install_homebrew\\n' >> ${JSON.stringify(events)}; }
+        install_node() { printf 'install_node\\n' >> ${JSON.stringify(events)}; }
+        activate_supported_node_on_path() { :; }
+        ensure_default_node_active_shell() { return 0; }
+        check_git() { return 0; }
+        fix_npm_permissions() { :; }
+        install_openclaw() { printf 'install_openclaw\\n' >> ${JSON.stringify(events)}; exit 0; }
+        main
+      `);
+      eventsText = readFileSync(events, "utf8");
+    } finally {
+      rmSync(tmp, { force: true, recursive: true });
+    }
+
+    expect(result?.status).toBe(0);
+    expect(result?.stdout).not.toContain("Need sudo access on macOS");
+    expect(eventsText).toBe(
+      ["load_nvm_for_node_detection", "check_node", "install_openclaw", ""].join("\n"),
+    );
+  });
+
+  it("installs Homebrew on macOS only when Node is missing or outdated", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "openclaw-install-macos-brew-"));
+    const events = join(tmp, "events.log");
+
+    let result: ReturnType<typeof runInstallShell> | undefined;
+    let eventsText = "";
+    try {
+      result = runInstallShell(`
+        set -euo pipefail
+        source "${SCRIPT_PATH}"
+        HELP=0
+        DRY_RUN=0
+        INSTALL_METHOD=npm
+        detect_os_or_die() { OS=macos; }
+        bootstrap_gum_temp() { :; }
+        print_installer_banner() { :; }
+        print_gum_status() { :; }
+        detect_openclaw_checkout() { return 1; }
+        show_install_plan() { :; }
+        check_existing_openclaw() { return 1; }
+        ui_stage() { :; }
+        load_nvm_for_node_detection() { printf 'load_nvm_for_node_detection\\n' >> ${JSON.stringify(events)}; }
+        check_node() { printf 'check_node\\n' >> ${JSON.stringify(events)}; return 1; }
+        install_homebrew() { printf 'install_homebrew\\n' >> ${JSON.stringify(events)}; }
+        install_node() { printf 'install_node\\n' >> ${JSON.stringify(events)}; exit 0; }
+        main
+      `);
+      eventsText = readFileSync(events, "utf8");
+    } finally {
+      rmSync(tmp, { force: true, recursive: true });
+    }
+
+    expect(result?.status).toBe(0);
+    expect(eventsText).toBe(
+      [
+        "load_nvm_for_node_detection",
+        "check_node",
+        "install_homebrew",
+        "install_node",
+        "",
+      ].join("\n"),
+    );
+  });
+
   it("loads nvm before checking Node.js so stale system Node does not win", () => {
     expect(script).toMatch(
-      /# Step 2: Node\.js\s+load_nvm_for_node_detection\s+if ! check_node; then/,
+      /# Step 1: Node\.js\. On macOS, Homebrew is only needed when Node\.js is missing or outdated\.\s+load_nvm_for_node_detection\s+if ! check_node; then\s+install_homebrew\s+install_node/,
     );
 
     const tmp = mkdtempSync(join(tmpdir(), "openclaw-install-nvm-"));

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -128,11 +128,58 @@ describe("install.sh", () => {
 
     expect(result?.status).toBe(0);
     expect(eventsText).toBe(
+      ["load_nvm_for_node_detection", "check_node", "install_homebrew", "install_node", ""].join(
+        "\n",
+      ),
+    );
+  });
+
+  it("ensures Homebrew before installing missing Git on macOS with supported Node", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "openclaw-install-macos-git-"));
+    const events = join(tmp, "events.log");
+
+    let result: ReturnType<typeof runInstallShell> | undefined;
+    let eventsText = "";
+    try {
+      result = runInstallShell(`
+        set -euo pipefail
+        source "${SCRIPT_PATH}"
+        HELP=0
+        DRY_RUN=0
+        INSTALL_METHOD=npm
+        detect_os_or_die() { OS=macos; }
+        bootstrap_gum_temp() { :; }
+        print_installer_banner() { :; }
+        print_gum_status() { :; }
+        detect_openclaw_checkout() { return 1; }
+        show_install_plan() { :; }
+        check_existing_openclaw() { return 1; }
+        ui_stage() { :; }
+        load_nvm_for_node_detection() { printf 'load_nvm_for_node_detection\\n' >> ${JSON.stringify(events)}; }
+        check_node() { printf 'check_node\\n' >> ${JSON.stringify(events)}; return 0; }
+        activate_supported_node_on_path() { :; }
+        ensure_default_node_active_shell() { return 0; }
+        check_git() { printf 'check_git\\n' >> ${JSON.stringify(events)}; return 1; }
+        install_homebrew() { printf 'install_homebrew\\n' >> ${JSON.stringify(events)}; }
+        run_quiet_step() { printf 'run_quiet_step:%s:%s:%s\\n' "$1" "$2" "$3" >> ${JSON.stringify(events)}; }
+        fix_npm_permissions() { :; }
+        install_openclaw() { printf 'install_openclaw\\n' >> ${JSON.stringify(events)}; exit 0; }
+        main
+      `);
+      eventsText = readFileSync(events, "utf8");
+    } finally {
+      rmSync(tmp, { force: true, recursive: true });
+    }
+
+    expect(result?.status).toBe(0);
+    expect(eventsText).toBe(
       [
         "load_nvm_for_node_detection",
         "check_node",
+        "check_git",
         "install_homebrew",
-        "install_node",
+        "run_quiet_step:Installing Git:brew:install",
+        "install_openclaw",
         "",
       ].join("\n"),
     );


### PR DESCRIPTION
## Summary
- Move macOS Homebrew installation behind the Node.js version check in `scripts/install.sh`.
- Keep Homebrew installation before `install_node` when Node.js is missing or outdated, preserving the existing macOS Node install path.
- Add installer regression tests for both supported-Node and missing/outdated-Node macOS preparation flows.

Fixes #83232

## Real behavior proof

Behavior addressed: On macOS, `scripts/install.sh` called `install_homebrew` during environment preparation before checking whether the active Node.js already satisfied the installer minimum. That forced non-admin users without Homebrew into the Homebrew/admin path even when their existing Node.js was sufficient.

Real environment tested: Local OpenClaw checkout on macOS, Node.js v22.22.0, branch `fix/install-skip-brew-when-node-present-83232`. The targeted test sources the real `scripts/install.sh` with `OPENCLAW_INSTALL_SH_NO_RUN=1`, stubs the side-effectful installer functions, and calls the real `main` flow.

Exact steps or command run after fix:

```console
$ node scripts/run-vitest.mjs test/scripts/install-sh.test.ts
```

Evidence after fix: Terminal output from the targeted test run:

```console
✓ tooling ../scripts/install-sh.test.ts (23 tests) 3345ms
  ✓ loads nvm before checking Node.js so stale system Node does not win 685ms
  ✓ promotes a supported Linux Node binary over stale PATH entries 639ms
  ✓ persists a supported Linux Node path before noninteractive shell guards 620ms
  ✓ reruns spinner-wrapped commands when gum reports ioctl failure 1087ms

Test Files 1 passed (1)
Tests 23 passed (23)
```

Observed result after fix: The new supported-Node macOS regression test records `load_nvm_for_node_detection`, `check_node`, and `install_openclaw` only, proving `install_homebrew` and `install_node` are skipped when `check_node` succeeds. The companion missing/outdated-Node test records `load_nvm_for_node_detection`, `check_node`, `install_homebrew`, and `install_node`, proving the Homebrew-backed Node install path is still used only when Node needs installation or upgrade.

What was not tested: I did not run the real installer against a non-admin macOS account because that would perform machine-level installation actions. The test instead executes the real installer control flow with side-effectful operations stubbed.

## Test plan
- `node scripts/run-vitest.mjs test/scripts/install-sh.test.ts`
- `git diff --check`
