### PR TITLE
Announce tool plans in chat replies

### DIFF
--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -481,12 +481,93 @@ describe("CodexAppServerEventProjector", () => {
       onBlockReply,
     });
 
-    await projector.announceToolPlanForTool("message");
+    await projector.announceToolPlanForTool({ toolName: "message", args: { action: "send" } });
 
     expect(onBlockReply).not.toHaveBeenCalled();
   });
 
-  it("does not automatically announce when the message tool owns source delivery", async () => {
+  it("does not let ordinary messaging sends suppress later automatic announcements", async () => {
+    const onBlockReply = vi.fn();
+    const projector = await createProjector({
+      ...(await createParams()),
+      onBlockReply,
+    });
+
+    const messageSend = { toolName: "message", args: { action: "send" } };
+    await projector.announceToolPlanForTool(messageSend);
+    await projector.completeToolPlanAnnouncementDeliveryForTool({
+      input: messageSend,
+      delivered: true,
+    });
+    await projector.announceToolPlanForTool("web_search");
+
+    expect(onBlockReply).toHaveBeenCalledWith({
+      text: "I'll run the web search, then answer here.",
+    });
+  });
+
+  it("does not duplicate automatic fallback after confirmed source reply delivery", async () => {
+    const onBlockReply = vi.fn();
+    const projector = await createProjector({
+      ...(await createParams()),
+      sourceReplyDeliveryMode: "message_tool_only",
+      onBlockReply,
+    });
+
+    const messageSend = { toolName: "message", args: { action: "send" } };
+    await projector.announceToolPlanForTool(messageSend);
+    await projector.completeToolPlanAnnouncementDeliveryForTool({
+      input: messageSend,
+      delivered: true,
+    });
+    await projector.announceToolPlanForTool("web_search");
+
+    expect(onBlockReply).not.toHaveBeenCalled();
+  });
+
+  it("uses fallback automatic announcements after unconfirmed messaging sends", async () => {
+    const onBlockReply = vi.fn();
+    const projector = await createProjector({
+      ...(await createParams()),
+      sourceReplyDeliveryMode: "message_tool_only",
+      onBlockReply,
+    });
+
+    const messageSend = { toolName: "message", args: { action: "send" } };
+    await projector.announceToolPlanForTool(messageSend);
+    await projector.announceToolPlanForTool("web_search");
+
+    expect(onBlockReply).not.toHaveBeenCalled();
+    await projector.completeToolPlanAnnouncementDeliveryForTool({
+      input: messageSend,
+      delivered: false,
+    });
+
+    expect(onBlockReply).toHaveBeenCalledWith({
+      text: "I'll run the web search, then answer here.",
+    });
+  });
+
+  it("uses fallback automatic announcements before non-send messaging tool actions", async () => {
+    const onBlockReply = vi.fn();
+    const projector = await createProjector({
+      ...(await createParams()),
+      sourceReplyDeliveryMode: "message_tool_only",
+      onBlockReply,
+    });
+
+    await projector.announceToolPlanForTool({ toolName: "message", args: { action: "read" } });
+
+    expect(onBlockReply).toHaveBeenCalledWith({
+      text: "I'll check the chat state, then answer here.",
+    });
+    expect(projector.buildResult(buildEmptyToolTelemetry()).replayMetadata).toEqual({
+      hadPotentialSideEffects: true,
+      replaySafe: false,
+    });
+  });
+
+  it("keeps plan explanation automatic delivery owned by message tool when source delivery is message-tool-only", async () => {
     const onBlockReply = vi.fn();
     const onAgentEvent = vi.fn();
     const projector = await createProjector({
@@ -502,16 +583,6 @@ describe("CodexAppServerEventProjector", () => {
         plan: [{ step: "query monitoring state", status: "in_progress" }],
       }),
     );
-    await projector.handleNotification(
-      forCurrentTurn("item/started", {
-        item: {
-          type: "webSearch",
-          id: "search-1",
-          query: "monitoring",
-          status: "inProgress",
-        },
-      }),
-    );
 
     expect(onBlockReply).not.toHaveBeenCalled();
     expect(findAgentEvent(onAgentEvent, { stream: "plan" }).data.steps).toEqual([
@@ -523,7 +594,7 @@ describe("CodexAppServerEventProjector", () => {
     });
   });
 
-  it("does not use fallback automatic announcements in message-tool-only turns", async () => {
+  it("uses fallback automatic announcements in message-tool-only turns when Codex skips message first", async () => {
     const onBlockReply = vi.fn();
     const projector = await createProjector({
       ...(await createParams()),
@@ -533,7 +604,13 @@ describe("CodexAppServerEventProjector", () => {
 
     await projector.announceToolPlanForTool("web_search");
 
-    expect(onBlockReply).not.toHaveBeenCalled();
+    expect(onBlockReply).toHaveBeenCalledWith({
+      text: "I'll run the web search, then answer here.",
+    });
+    expect(projector.buildResult(buildEmptyToolTelemetry()).replayMetadata).toEqual({
+      hadPotentialSideEffects: true,
+      replaySafe: false,
+    });
   });
 
   it("projects assistant deltas and usage into embedded attempt results", async () => {

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -16,6 +16,9 @@ import {
 import { createMockPluginRegistry } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  buildCodexPlanAnnouncementText,
+  buildCodexPlanAnnouncementTextFromParts,
+  buildCodexToolPlanAnnouncementText,
   CodexAppServerEventProjector,
   type CodexAppServerEventProjectorOptions,
   type CodexAppServerToolTelemetry,
@@ -262,6 +265,198 @@ function turnCompleted(items: unknown[] = []): ProjectorNotification {
 }
 
 describe("CodexAppServerEventProjector", () => {
+  it("delivers a concise Codex tool plan announcement before native tool progress", async () => {
+    const onBlockReply = vi.fn();
+    const onBlockReplyFlush = vi.fn();
+    const onRunAgentEvent = vi.fn();
+    const projector = await createProjector({
+      ...(await createParams()),
+      onBlockReply,
+      onBlockReplyFlush,
+      onAgentEvent: onRunAgentEvent,
+    });
+    await projector.handleNotification(
+      forCurrentTurn("turn/plan/updated", {
+        plan: [
+          { step: "inspect the Codex app-server tool path", status: "completed" },
+          { step: "make the chat announcement exact", status: "in_progress" },
+          { step: "run focused Codex runtime tests", status: "pending" },
+        ],
+      }),
+    );
+    const postPlanEventIndex = onRunAgentEvent.mock.calls.length;
+
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: {
+          type: "commandExecution",
+          id: "cmd-1",
+          command: "pnpm test",
+          status: "inProgress",
+        },
+      }),
+    );
+
+    expect(onBlockReply).toHaveBeenCalledWith({
+      text:
+        "Plan: inspect the Codex app-server tool path (completed); " +
+        "make the chat announcement exact (in_progress); run focused Codex runtime tests (pending).",
+    });
+    expect(onBlockReply.mock.invocationCallOrder[0]).toBeLessThan(
+      onBlockReplyFlush.mock.invocationCallOrder[0],
+    );
+    expect(onBlockReplyFlush.mock.invocationCallOrder[0]).toBeLessThan(
+      onRunAgentEvent.mock.invocationCallOrder[postPlanEventIndex],
+    );
+
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: {
+          type: "webSearch",
+          id: "search-1",
+          query: "OpenClaw docs",
+          status: "inProgress",
+        },
+      }),
+    );
+
+    expect(onBlockReply).toHaveBeenCalledTimes(1);
+    expect(projector.buildResult(buildEmptyToolTelemetry()).replayMetadata).toEqual({
+      hadPotentialSideEffects: true,
+      replaySafe: false,
+    });
+  });
+
+  it("prefers Codex's chat-ready plan explanation over mechanical plan steps", async () => {
+    const onBlockReply = vi.fn();
+    const onAgentEvent = vi.fn();
+    const projector = await createProjector({
+      ...(await createParams()),
+      onBlockReply,
+      onAgentEvent,
+    });
+    await projector.handleNotification(
+      forCurrentTurn("turn/plan/updated", {
+        explanation:
+          "I'll check your Beszel and Uptime Kuma instances to make sure nothing looks dead or dying.",
+        plan: [
+          { step: "load monitoring credentials", status: "pending" },
+          { step: "query health endpoints", status: "pending" },
+        ],
+      }),
+    );
+
+    expect(onBlockReply).toHaveBeenCalledWith({
+      text: "I'll check your Beszel and Uptime Kuma instances to make sure nothing looks dead or dying.",
+    });
+    expect(onBlockReply.mock.invocationCallOrder[0]).toBeLessThan(
+      onAgentEvent.mock.invocationCallOrder[0],
+    );
+    expect(findAgentEvent(onAgentEvent, { stream: "plan" }).data.steps).toEqual([
+      "load monitoring credentials (pending)",
+      "query health endpoints (pending)",
+    ]);
+
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: {
+          type: "webSearch",
+          id: "search-1",
+          query: "monitoring",
+          status: "inProgress",
+        },
+      }),
+    );
+
+    expect(onBlockReply).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to exact first action when Codex has not emitted a plan", async () => {
+    const onBlockReply = vi.fn();
+    const projector = await createProjector({
+      ...(await createParams()),
+      onBlockReply,
+    });
+
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: {
+          type: "webSearch",
+          id: "search-1",
+          query: "OpenClaw Telegram forum topics",
+          status: "inProgress",
+        },
+      }),
+    );
+
+    expect(onBlockReply).toHaveBeenCalledWith({
+      text: "I'll run the web search, then answer here.",
+    });
+  });
+
+  it("keeps Codex plan announcement copy exact, short, and redacted", () => {
+    const messages = [
+      buildCodexPlanAnnouncementText([
+        "inspect the Codex app-server runtime path",
+        "patch the announcement copy",
+        "run focused tests",
+      ]),
+      buildCodexPlanAnnouncementTextFromParts({
+        explanation:
+          "I'll check your Beszel and Uptime Kuma instances to make sure nothing looks dead or dying.",
+        steps: ["load monitoring credentials", "query health endpoints"],
+      }),
+      buildCodexPlanAnnouncementText([
+        "run OPENAI_API_KEY=sk-proj-plain-secret-value-12345 pnpm test",
+      ]),
+      buildCodexToolPlanAnnouncementText({
+        toolName: "bash",
+        meta: "pnpm test",
+      }),
+      buildCodexToolPlanAnnouncementText({ toolName: "read", meta: "README.md" }),
+      buildCodexToolPlanAnnouncementText({ toolName: "apply_patch", meta: "src/app.ts" }),
+      buildCodexToolPlanAnnouncementText("web_search"),
+      buildCodexToolPlanAnnouncementText("custom_tool"),
+      buildCodexToolPlanAnnouncementText({
+        toolName: "bash",
+        meta: "OPENAI_API_KEY=sk-proj-plain-secret-value-12345 pnpm test",
+      }),
+    ].filter((message): message is string => Boolean(message));
+
+    expect(messages).toContain(
+      "Plan: inspect the Codex app-server runtime path; patch the announcement copy; run focused tests.",
+    );
+    expect(messages).toContain(
+      "I'll check your Beszel and Uptime Kuma instances to make sure nothing looks dead or dying.",
+    );
+    expect(messages).toContain(
+      'I\'ll run the shell command "pnpm test", then report the result here.',
+    );
+    expect(messages).toContain('I\'ll inspect "README.md", then answer here.');
+    expect(messages).toContain('I\'ll edit "src/app.ts", then summarize the change here.');
+    expect(messages).toContain("I'll run the web search, then answer here.");
+
+    for (const message of messages) {
+      const sentenceCount = message.split(/[.!?]+/).filter((part) => part.trim()).length;
+      expect(sentenceCount).toBeLessThanOrEqual(2);
+      expect(message).not.toMatch(/\b(needed|relevant|handle this|continue with the request)\b/u);
+      expect(message).not.toContain("continue with the request");
+      expect(message).not.toContain("sk-proj-plain-secret-value-12345");
+    }
+  });
+
+  it("does not announce before Codex messaging tool sends", async () => {
+    const onBlockReply = vi.fn();
+    const projector = await createProjector({
+      ...(await createParams()),
+      onBlockReply,
+    });
+
+    await projector.announceToolPlanForTool("message");
+
+    expect(onBlockReply).not.toHaveBeenCalled();
+  });
+
   it("projects assistant deltas and usage into embedded attempt results", async () => {
     const { onAssistantMessageStart, onPartialReply, projector } =
       await createProjectorWithAssistantHooks();

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -299,8 +299,8 @@ describe("CodexAppServerEventProjector", () => {
 
     expect(onBlockReply).toHaveBeenCalledWith({
       text:
-        "Plan: inspect the Codex app-server tool path (completed); " +
-        "make the chat announcement exact (in_progress); run focused Codex runtime tests (pending).",
+        "I'll check the relevant state, handle the requested changes, " +
+        "and verify the result, then report back here.",
       isStatusNotice: true,
     });
     expect(onBlockReply.mock.invocationCallOrder[0]).toBeLessThan(
@@ -392,7 +392,7 @@ describe("CodexAppServerEventProjector", () => {
     );
 
     expect(onBlockReply).toHaveBeenCalledWith({
-      text: "I'll run the web search, then answer here.",
+      text: "I'll look up the relevant information, then answer here.",
       isStatusNotice: true,
     });
   });
@@ -422,7 +422,7 @@ describe("CodexAppServerEventProjector", () => {
     );
 
     expect(onBlockReply).toHaveBeenCalledWith({
-      text: "Plan: Inspect code; Run focused tests.",
+      text: "I'll check the relevant state and verify the result, then report back here.",
       isStatusNotice: true,
     });
   });
@@ -457,24 +457,24 @@ describe("CodexAppServerEventProjector", () => {
     ].filter((message): message is string => Boolean(message));
 
     expect(messages).toContain(
-      "Plan: inspect the Codex app-server runtime path; patch the announcement copy; run focused tests.",
+      "I'll check the relevant state, handle the requested changes, and verify the result, then report back here.",
     );
     expect(messages).toContain(
       "I'll check your Beszel and Uptime Kuma instances to make sure nothing looks dead or dying.",
     );
-    expect(messages).toContain(
-      'I\'ll run the shell command "pnpm test", then report the result here.',
-    );
-    expect(messages).toContain('I\'ll inspect "README.md", then answer here.');
-    expect(messages).toContain('I\'ll edit "src/app.ts", then summarize the change here.');
-    expect(messages).toContain("I'll run the web search, then answer here.");
+    expect(messages).toContain("I'll check the relevant local state, then report the result here.");
+    expect(messages).toContain("I'll inspect the relevant context, then answer here.");
+    expect(messages).toContain("I'll make the planned change, then summarize it here.");
+    expect(messages).toContain("I'll look up the relevant information, then answer here.");
 
     for (const message of messages) {
       const sentenceCount = message.split(/[.!?]+/).filter((part) => part.trim()).length;
       expect(sentenceCount).toBeLessThanOrEqual(2);
-      expect(message).not.toMatch(/\b(needed|relevant|handle this|continue with the request)\b/u);
+      expect(message).not.toMatch(/\b(needed|handle this|continue with the request)\b/u);
       expect(message).not.toContain("continue with the request");
       expect(message).not.toContain("sk-proj-plain-secret-value-12345");
+      expect(message).not.toContain("README.md");
+      expect(message).not.toContain("src/app.ts");
     }
   });
 
@@ -506,7 +506,7 @@ describe("CodexAppServerEventProjector", () => {
     await projector.announceToolPlanForTool("web_search");
 
     expect(onBlockReply).toHaveBeenCalledWith({
-      text: "I'll run the web search, then answer here.",
+      text: "I'll look up the relevant information, then answer here.",
       isStatusNotice: true,
     });
   });
@@ -549,7 +549,7 @@ describe("CodexAppServerEventProjector", () => {
     });
 
     expect(onBlockReply).toHaveBeenCalledWith({
-      text: "I'll run the web search, then answer here.",
+      text: "I'll look up the relevant information, then answer here.",
       isStatusNotice: true,
     });
   });
@@ -592,13 +592,37 @@ describe("CodexAppServerEventProjector", () => {
     );
 
     expect(onBlockReply).not.toHaveBeenCalled();
+    expect(onAgentEvent).not.toHaveBeenCalled();
+
+    projector.markToolPlanAnnouncementDelivered();
+
     expect(findAgentEvent(onAgentEvent, { stream: "plan" }).data.steps).toEqual([
       "query monitoring state (in_progress)",
     ]);
     expect(projector.buildResult(buildEmptyToolTelemetry()).replayMetadata).toEqual({
-      hadPotentialSideEffects: false,
-      replaySafe: true,
+      hadPotentialSideEffects: true,
+      replaySafe: false,
     });
+  });
+
+  it("emits message-tool-only plan events immediately when no block reply path exists", async () => {
+    const onAgentEvent = vi.fn();
+    const projector = await createProjector({
+      ...(await createParams()),
+      sourceReplyDeliveryMode: "message_tool_only",
+      onAgentEvent,
+    });
+
+    await projector.handleNotification(
+      forCurrentTurn("turn/plan/updated", {
+        explanation: "I'll check Beszel and Uptime Kuma health now.",
+        plan: [{ step: "query monitoring state", status: "in_progress" }],
+      }),
+    );
+
+    expect(findAgentEvent(onAgentEvent, { stream: "plan" }).data.steps).toEqual([
+      "query monitoring state (in_progress)",
+    ]);
   });
 
   it("uses fallback automatic announcements in message-tool-only turns when Codex skips message first", async () => {
@@ -612,13 +636,50 @@ describe("CodexAppServerEventProjector", () => {
     await projector.announceToolPlanForTool("web_search");
 
     expect(onBlockReply).toHaveBeenCalledWith({
-      text: "I'll run the web search, then answer here.",
+      text: "I'll look up the relevant information, then answer here.",
       isStatusNotice: true,
     });
     expect(projector.buildResult(buildEmptyToolTelemetry()).replayMetadata).toEqual({
       hadPotentialSideEffects: true,
       replaySafe: false,
     });
+  });
+
+  it("delivers the acknowledgement before deferred verbose plan steps in message-tool-only fallback", async () => {
+    const onBlockReply = vi.fn();
+    const onAgentEvent = vi.fn();
+    const projector = await createProjector({
+      ...(await createParams()),
+      sourceReplyDeliveryMode: "message_tool_only",
+      onBlockReply,
+      onAgentEvent,
+    });
+
+    await projector.handleNotification(
+      forCurrentTurn("turn/plan/updated", {
+        explanation: "I'll prepare the Proxmox template and Telegram test setup.",
+        plan: [
+          { step: "check Proxmox template prerequisites", status: "in_progress" },
+          { step: "set up Telegram test credentials", status: "pending" },
+        ],
+      }),
+    );
+
+    expect(onAgentEvent).not.toHaveBeenCalled();
+
+    await projector.announceToolPlanForTool("bash");
+
+    expect(onBlockReply).toHaveBeenCalledWith({
+      text: "I'll prepare the Proxmox template and Telegram test setup.",
+      isStatusNotice: true,
+    });
+    expect(findAgentEvent(onAgentEvent, { stream: "plan" }).data.steps).toEqual([
+      "check Proxmox template prerequisites (in_progress)",
+      "set up Telegram test credentials (pending)",
+    ]);
+    expect(onBlockReply.mock.invocationCallOrder[0]).toBeLessThan(
+      onAgentEvent.mock.invocationCallOrder[0],
+    );
   });
 
   it("projects assistant deltas and usage into embedded attempt results", async () => {

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -394,6 +394,35 @@ describe("CodexAppServerEventProjector", () => {
     });
   });
 
+  it("refreshes streamed step-only plan announcements until the first tool starts", async () => {
+    const onBlockReply = vi.fn();
+    const projector = await createProjector({
+      ...(await createParams()),
+      onBlockReply,
+    });
+
+    await projector.handleNotification(
+      forCurrentTurn("item/plan/delta", { itemId: "plan-1", delta: "Inspect code" }),
+    );
+    await projector.handleNotification(
+      forCurrentTurn("item/plan/delta", { itemId: "plan-1", delta: "\nRun focused tests" }),
+    );
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: {
+          type: "commandExecution",
+          id: "cmd-1",
+          command: "pnpm test",
+          status: "inProgress",
+        },
+      }),
+    );
+
+    expect(onBlockReply).toHaveBeenCalledWith({
+      text: "Plan: Inspect code; Run focused tests.",
+    });
+  });
+
   it("keeps Codex plan announcement copy exact, short, and redacted", () => {
     const messages = [
       buildCodexPlanAnnouncementText([
@@ -453,6 +482,56 @@ describe("CodexAppServerEventProjector", () => {
     });
 
     await projector.announceToolPlanForTool("message");
+
+    expect(onBlockReply).not.toHaveBeenCalled();
+  });
+
+  it("does not automatically announce when the message tool owns source delivery", async () => {
+    const onBlockReply = vi.fn();
+    const onAgentEvent = vi.fn();
+    const projector = await createProjector({
+      ...(await createParams()),
+      sourceReplyDeliveryMode: "message_tool_only",
+      onBlockReply,
+      onAgentEvent,
+    });
+
+    await projector.handleNotification(
+      forCurrentTurn("turn/plan/updated", {
+        explanation: "I'll check Beszel and Uptime Kuma health now.",
+        plan: [{ step: "query monitoring state", status: "in_progress" }],
+      }),
+    );
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: {
+          type: "webSearch",
+          id: "search-1",
+          query: "monitoring",
+          status: "inProgress",
+        },
+      }),
+    );
+
+    expect(onBlockReply).not.toHaveBeenCalled();
+    expect(findAgentEvent(onAgentEvent, { stream: "plan" }).data.steps).toEqual([
+      "query monitoring state (in_progress)",
+    ]);
+    expect(projector.buildResult(buildEmptyToolTelemetry()).replayMetadata).toEqual({
+      hadPotentialSideEffects: false,
+      replaySafe: true,
+    });
+  });
+
+  it("does not use fallback automatic announcements in message-tool-only turns", async () => {
+    const onBlockReply = vi.fn();
+    const projector = await createProjector({
+      ...(await createParams()),
+      sourceReplyDeliveryMode: "message_tool_only",
+      onBlockReply,
+    });
+
+    await projector.announceToolPlanForTool("web_search");
 
     expect(onBlockReply).not.toHaveBeenCalled();
   });

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -301,6 +301,7 @@ describe("CodexAppServerEventProjector", () => {
       text:
         "Plan: inspect the Codex app-server tool path (completed); " +
         "make the chat announcement exact (in_progress); run focused Codex runtime tests (pending).",
+      isStatusNotice: true,
     });
     expect(onBlockReply.mock.invocationCallOrder[0]).toBeLessThan(
       onBlockReplyFlush.mock.invocationCallOrder[0],
@@ -348,6 +349,7 @@ describe("CodexAppServerEventProjector", () => {
 
     expect(onBlockReply).toHaveBeenCalledWith({
       text: "I'll check your Beszel and Uptime Kuma instances to make sure nothing looks dead or dying.",
+      isStatusNotice: true,
     });
     expect(onBlockReply.mock.invocationCallOrder[0]).toBeLessThan(
       onAgentEvent.mock.invocationCallOrder[0],
@@ -391,6 +393,7 @@ describe("CodexAppServerEventProjector", () => {
 
     expect(onBlockReply).toHaveBeenCalledWith({
       text: "I'll run the web search, then answer here.",
+      isStatusNotice: true,
     });
   });
 
@@ -420,6 +423,7 @@ describe("CodexAppServerEventProjector", () => {
 
     expect(onBlockReply).toHaveBeenCalledWith({
       text: "Plan: Inspect code; Run focused tests.",
+      isStatusNotice: true,
     });
   });
 
@@ -503,6 +507,7 @@ describe("CodexAppServerEventProjector", () => {
 
     expect(onBlockReply).toHaveBeenCalledWith({
       text: "I'll run the web search, then answer here.",
+      isStatusNotice: true,
     });
   });
 
@@ -545,6 +550,7 @@ describe("CodexAppServerEventProjector", () => {
 
     expect(onBlockReply).toHaveBeenCalledWith({
       text: "I'll run the web search, then answer here.",
+      isStatusNotice: true,
     });
   });
 
@@ -560,6 +566,7 @@ describe("CodexAppServerEventProjector", () => {
 
     expect(onBlockReply).toHaveBeenCalledWith({
       text: "I'll check the chat state, then answer here.",
+      isStatusNotice: true,
     });
     expect(projector.buildResult(buildEmptyToolTelemetry()).replayMetadata).toEqual({
       hadPotentialSideEffects: true,
@@ -606,6 +613,7 @@ describe("CodexAppServerEventProjector", () => {
 
     expect(onBlockReply).toHaveBeenCalledWith({
       text: "I'll run the web search, then answer here.",
+      isStatusNotice: true,
     });
     expect(projector.buildResult(buildEmptyToolTelemetry()).replayMetadata).toEqual({
       hadPotentialSideEffects: true,

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -8,6 +8,7 @@ import {
   formatToolProgressOutput,
   inferToolMetaFromArgs,
   isMessagingTool,
+  isMessagingToolSendAction,
   normalizeUsage,
   runAgentHarnessAfterCompactionHook,
   runAgentHarnessAfterToolCallHook,
@@ -113,6 +114,7 @@ const TRANSCRIPT_PROGRESS_SUPPRESSED_TOOL_NAMES = new Set([
 export type CodexToolPlanAnnouncementInput = {
   toolName?: string | null;
   meta?: string | null;
+  args?: JsonObject;
 };
 
 export function buildCodexToolPlanAnnouncementText(
@@ -142,6 +144,9 @@ export function buildCodexToolPlanAnnouncementText(
     return meta
       ? `I'll search ${meta}, then answer here.`
       : "I'll run the web search, then answer here.";
+  }
+  if (isCodexMessagingToolName(normalizedToolName)) {
+    return "I'll check the chat state, then answer here.";
   }
   return tool
     ? `I'll run the ${tool} step, then report the result here.`
@@ -192,6 +197,15 @@ function isCodexEditToolName(toolName: string): boolean {
 function isCodexMessagingToolName(toolName: string | undefined): boolean {
   const normalizedToolName = toolName?.trim().toLowerCase();
   return Boolean(normalizedToolName && isMessagingTool(normalizedToolName));
+}
+
+function isCodexSourceReplyMessagingToolSend(details: CodexToolPlanAnnouncementInput): boolean {
+  const normalizedToolName = details.toolName?.trim().toLowerCase();
+  return Boolean(
+    normalizedToolName === "message" &&
+    details.args &&
+    isMessagingToolSendAction(normalizedToolName, details.args),
+  );
 }
 
 function normalizeCodexToolPlanAnnouncementInput(
@@ -274,6 +288,8 @@ export class CodexAppServerEventProjector {
   private latestPlanAnnouncementText: string | undefined;
   private latestPlanAnnouncementFromExplanation = false;
   private toolPlanAnnouncementSent = false;
+  private toolPlanAnnouncementDeliveryPending = false;
+  private deferredToolPlanAnnouncementInput: string | CodexToolPlanAnnouncementInput | undefined;
   private assistantStarted = false;
   private reasoningStarted = false;
   private reasoningEnded = false;
@@ -505,12 +521,33 @@ export class CodexAppServerEventProjector {
     input: string | CodexToolPlanAnnouncementInput | undefined,
   ): Promise<void> {
     const details = normalizeCodexToolPlanAnnouncementInput(input);
+    if (isCodexMessagingToolName(details.toolName ?? undefined)) {
+      if (!details.args) {
+        return;
+      }
+      if (
+        details.toolName &&
+        isMessagingToolSendAction(details.toolName.trim().toLowerCase(), details.args)
+      ) {
+        if (
+          this.params.sourceReplyDeliveryMode === "message_tool_only" &&
+          isCodexSourceReplyMessagingToolSend(details)
+        ) {
+          this.toolPlanAnnouncementDeliveryPending = true;
+        }
+        return;
+      }
+      // Non-send messaging actions, such as reading a channel, still need the
+      // normal pre-tool acknowledgement before work continues.
+    }
+    if (this.toolPlanAnnouncementDeliveryPending) {
+      this.deferredToolPlanAnnouncementInput ??= details;
+      return;
+    }
     if (
       this.toolPlanAnnouncementSent ||
       this.params.silentExpected === true ||
-      this.params.sourceReplyDeliveryMode === "message_tool_only" ||
-      !this.params.onBlockReply ||
-      isCodexMessagingToolName(details.toolName ?? undefined)
+      !this.params.onBlockReply
     ) {
       return;
     }
@@ -525,6 +562,35 @@ export class CodexAppServerEventProjector {
       await this.params.onBlockReplyFlush?.();
     } catch (error) {
       embeddedAgentLog.debug("codex tool plan announcement delivery failed", { error });
+    }
+  }
+
+  markToolPlanAnnouncementDelivered(): void {
+    this.toolPlanAnnouncementDeliveryPending = false;
+    this.deferredToolPlanAnnouncementInput = undefined;
+    this.toolPlanAnnouncementSent = true;
+  }
+
+  async completeToolPlanAnnouncementDeliveryForTool(params: {
+    input: string | CodexToolPlanAnnouncementInput | undefined;
+    delivered: boolean;
+  }): Promise<void> {
+    const details = normalizeCodexToolPlanAnnouncementInput(params.input);
+    if (!isCodexSourceReplyMessagingToolSend(details)) {
+      return;
+    }
+    if (!this.toolPlanAnnouncementDeliveryPending) {
+      return;
+    }
+    if (params.delivered) {
+      this.markToolPlanAnnouncementDelivered();
+      return;
+    }
+    this.toolPlanAnnouncementDeliveryPending = false;
+    const deferredInput = this.deferredToolPlanAnnouncementInput;
+    this.deferredToolPlanAnnouncementInput = undefined;
+    if (deferredInput !== undefined) {
+      await this.announceToolPlanForTool(deferredInput);
     }
   }
 

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -7,6 +7,7 @@ import {
   formatToolAggregate,
   formatToolProgressOutput,
   inferToolMetaFromArgs,
+  isMessagingTool,
   normalizeUsage,
   runAgentHarnessAfterCompactionHook,
   runAgentHarnessAfterToolCallHook,
@@ -21,6 +22,7 @@ import {
   type ToolProgressDetailMode,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { emitTrustedDiagnosticEvent } from "openclaw/plugin-sdk/diagnostic-runtime";
+import { redactToolPayloadText } from "openclaw/plugin-sdk/logging-core";
 import { resolveCodexLocalRuntimeAttribution } from "./local-runtime-attribution.js";
 import { CodexNativeSubagentTaskMirror } from "./native-subagent-task-mirror.js";
 import {
@@ -108,9 +110,119 @@ const TRANSCRIPT_PROGRESS_SUPPRESSED_TOOL_NAMES = new Set([
   "typing",
 ]);
 
+export type CodexToolPlanAnnouncementInput = {
+  toolName?: string | null;
+  meta?: string | null;
+};
+
+export function buildCodexToolPlanAnnouncementText(
+  input: string | CodexToolPlanAnnouncementInput | undefined,
+): string {
+  const details = normalizeCodexToolPlanAnnouncementInput(input);
+  const normalizedToolName = details.toolName?.trim().toLowerCase() ?? "";
+  const meta = formatAnnouncementSnippet(details.meta);
+  const tool = formatAnnouncementSnippet(details.toolName);
+
+  if (isCodexCommandToolName(normalizedToolName)) {
+    return meta
+      ? `I'll run the shell command ${meta}, then report the result here.`
+      : "I'll run the shell command, then report the result here.";
+  }
+  if (isCodexReadToolName(normalizedToolName)) {
+    return meta
+      ? `I'll inspect ${meta}, then answer here.`
+      : "I'll inspect the planned files, then answer here.";
+  }
+  if (isCodexEditToolName(normalizedToolName)) {
+    return meta
+      ? `I'll edit ${meta}, then summarize the change here.`
+      : "I'll edit the planned files, then summarize the changes here.";
+  }
+  if (normalizedToolName.includes("search") || normalizedToolName.includes("browser")) {
+    return meta
+      ? `I'll search ${meta}, then answer here.`
+      : "I'll run the web search, then answer here.";
+  }
+  return tool
+    ? `I'll run the ${tool} step, then report the result here.`
+    : "I'll run the next planned step, then report the result here.";
+}
+
+export function buildCodexPlanAnnouncementText(steps: readonly string[]): string | undefined {
+  return buildCodexPlanAnnouncementTextFromParts({ steps });
+}
+
+export function buildCodexPlanAnnouncementTextFromParts(params: {
+  explanation?: string | null;
+  steps?: readonly string[];
+}): string | undefined {
+  const explanation = truncateAnnouncementText(
+    normalizeAnnouncementText(redactToolPayloadText(params.explanation ?? "")),
+  );
+  if (explanation) {
+    return explanation;
+  }
+  const cleaned = (params.steps ?? [])
+    .map((step) => normalizeAnnouncementText(redactToolPayloadText(step)))
+    .filter((step) => step.length > 0);
+  if (cleaned.length === 0) {
+    return undefined;
+  }
+  const text = `Plan: ${cleaned.slice(0, 4).join("; ")}.`;
+  return truncateAnnouncementText(text);
+}
+
 export function shouldEmitTranscriptToolProgress(toolName: unknown, _args?: unknown): boolean {
   const normalized = typeof toolName === "string" ? toolName.trim().toLowerCase() : "";
   return Boolean(normalized && !TRANSCRIPT_PROGRESS_SUPPRESSED_TOOL_NAMES.has(normalized));
+}
+
+function isCodexCommandToolName(toolName: string): boolean {
+  return toolName === "bash" || toolName === "exec" || toolName === "shell";
+}
+
+function isCodexReadToolName(toolName: string): boolean {
+  return toolName === "read" || toolName === "grep" || toolName === "glob" || toolName === "list";
+}
+
+function isCodexEditToolName(toolName: string): boolean {
+  return toolName === "apply_patch" || toolName === "edit" || toolName === "write";
+}
+
+function isCodexMessagingToolName(toolName: string | undefined): boolean {
+  const normalizedToolName = toolName?.trim().toLowerCase();
+  return Boolean(normalizedToolName && isMessagingTool(normalizedToolName));
+}
+
+function normalizeCodexToolPlanAnnouncementInput(
+  input: string | CodexToolPlanAnnouncementInput | undefined,
+): CodexToolPlanAnnouncementInput {
+  return typeof input === "string" || input === undefined ? { toolName: input } : input;
+}
+
+function formatAnnouncementSnippet(value: string | null | undefined): string | undefined {
+  const normalized = normalizeAnnouncementText(redactToolPayloadText(value ?? ""));
+  if (!normalized) {
+    return undefined;
+  }
+  const maxLength = 96;
+  const truncated =
+    normalized.length > maxLength
+      ? `${normalized.slice(0, maxLength - 3).trimEnd()}...`
+      : normalized;
+  return `"${truncated.replace(/"/gu, "'")}"`;
+}
+
+function normalizeAnnouncementText(value: string | null | undefined): string {
+  return value?.replace(/\s+/gu, " ").trim() ?? "";
+}
+
+function truncateAnnouncementText(text: string): string | undefined {
+  if (!text) {
+    return undefined;
+  }
+  const maxLength = 220;
+  return text.length > maxLength ? `${text.slice(0, maxLength - 3).trimEnd()}...` : text;
 }
 
 type ToolTranscriptCallInput = {
@@ -158,6 +270,9 @@ export class CodexAppServerEventProjector {
   private readonly nativeGeneratedMediaUrls = new Set<string>();
   private readonly diagnosticToolStartedAtByItem = new Map<string, number>();
   private readonly afterToolCallObservedItemIds = new Set<string>();
+  private latestPlanAnnouncementSteps: string[] = [];
+  private latestPlanAnnouncementText: string | undefined;
+  private toolPlanAnnouncementSent = false;
   private assistantStarted = false;
   private reasoningStarted = false;
   private reasoningEnded = false;
@@ -219,10 +334,10 @@ export class CodexAppServerEventProjector {
         await this.handleReasoningDelta(params);
         break;
       case "item/plan/delta":
-        this.handlePlanDelta(params);
+        await this.handlePlanDelta(params);
         break;
       case "turn/plan/updated":
-        this.handleTurnPlanUpdated(params);
+        await this.handleTurnPlanUpdated(params);
         break;
       case "item/started":
         await this.handleItemStarted(params);
@@ -360,8 +475,8 @@ export class CodexAppServerEventProjector {
       cloudCodeAssistFormatError: false,
       attemptUsage: this.tokenUsage,
       replayMetadata: {
-        hadPotentialSideEffects,
-        replaySafe: !hadPotentialSideEffects,
+        hadPotentialSideEffects: hadPotentialSideEffects || this.toolPlanAnnouncementSent,
+        replaySafe: !hadPotentialSideEffects && !this.toolPlanAnnouncementSent,
       },
       itemLifecycle: {
         startedCount: this.activeItemIds.size + this.completedItemIds.size,
@@ -383,6 +498,32 @@ export class CodexAppServerEventProjector {
       name: params.tool,
       arguments: args,
     });
+  }
+
+  async announceToolPlanForTool(
+    input: string | CodexToolPlanAnnouncementInput | undefined,
+  ): Promise<void> {
+    const details = normalizeCodexToolPlanAnnouncementInput(input);
+    if (
+      this.toolPlanAnnouncementSent ||
+      this.params.silentExpected === true ||
+      !this.params.onBlockReply ||
+      isCodexMessagingToolName(details.toolName ?? undefined)
+    ) {
+      return;
+    }
+    this.toolPlanAnnouncementSent = true;
+    try {
+      await this.params.onBlockReply({
+        text:
+          this.latestPlanAnnouncementText ??
+          buildCodexPlanAnnouncementText(this.latestPlanAnnouncementSteps) ??
+          buildCodexToolPlanAnnouncementText(details),
+      });
+      await this.params.onBlockReplyFlush?.();
+    } catch (error) {
+      embeddedAgentLog.debug("codex tool plan announcement delivery failed", { error });
+    }
   }
 
   recordDynamicToolResult(params: {
@@ -451,7 +592,7 @@ export class CodexAppServerEventProjector {
     await this.params.onReasoningStream?.({ text: delta });
   }
 
-  private handlePlanDelta(params: JsonObject): void {
+  private async handlePlanDelta(params: JsonObject): Promise<void> {
     const itemId = readString(params, "itemId") ?? readString(params, "id") ?? "plan";
     const delta = readString(params, "delta") ?? "";
     if (!delta) {
@@ -459,10 +600,10 @@ export class CodexAppServerEventProjector {
     }
     const text = `${this.planTextByItem.get(itemId) ?? ""}${delta}`;
     this.planTextByItem.set(itemId, text);
-    this.emitPlanUpdate({ explanation: undefined, steps: splitPlanText(text) });
+    await this.emitPlanUpdate({ explanation: undefined, steps: splitPlanText(text) });
   }
 
-  private handleTurnPlanUpdated(params: JsonObject): void {
+  private async handleTurnPlanUpdated(params: JsonObject): Promise<void> {
     const plan = Array.isArray(params.plan)
       ? params.plan.flatMap((entry) => {
           if (!isJsonObject(entry)) {
@@ -476,7 +617,7 @@ export class CodexAppServerEventProjector {
           return status ? [`${step} (${status})`] : [step];
         })
       : undefined;
-    this.emitPlanUpdate({
+    await this.emitPlanUpdate({
       explanation: readNullableString(params, "explanation"),
       steps: plan,
     });
@@ -517,6 +658,14 @@ export class CodexAppServerEventProjector {
       });
     }
     this.recordToolMeta(item);
+    if (item && shouldSynthesizeToolProgressForItem(item)) {
+      await this.announceToolPlanForTool(
+        buildCodexToolPlanAnnouncementInputForItem(
+          item,
+          resolveCodexToolProgressDetailMode(this.params.toolProgressDetail),
+        ),
+      );
+    }
     this.emitStandardItemEvent({ phase: "start", item });
     this.emitNormalizedToolItemEvent({ phase: "start", item });
     this.recordNativeToolTranscriptCall(item);
@@ -545,7 +694,7 @@ export class CodexAppServerEventProjector {
     this.recordNativeGeneratedMedia(item);
     if (item?.type === "plan" && typeof item.text === "string" && item.text) {
       this.planTextByItem.set(item.id, item.text);
-      this.emitPlanUpdate({ explanation: undefined, steps: splitPlanText(item.text) });
+      await this.emitPlanUpdate({ explanation: undefined, steps: splitPlanText(item.text) });
     }
     if (item?.type === "contextCompaction" && itemId) {
       this.activeCompactionItemIds.delete(itemId);
@@ -683,7 +832,7 @@ export class CodexAppServerEventProjector {
       this.recordNativeGeneratedMedia(item);
       if (item.type === "plan" && typeof item.text === "string" && item.text) {
         this.planTextByItem.set(item.id, item.text);
-        this.emitPlanUpdate({ explanation: undefined, steps: splitPlanText(item.text) });
+        await this.emitPlanUpdate({ explanation: undefined, steps: splitPlanText(item.text) });
       }
       this.recordToolMeta(item);
       this.emitSnapshotOnlyNativeToolProgress(item);
@@ -830,10 +979,26 @@ export class CodexAppServerEventProjector {
     await this.params.onReasoningEnd?.();
   }
 
-  private emitPlanUpdate(params: { explanation?: string | null; steps?: string[] }): void {
+  private async emitPlanUpdate(params: {
+    explanation?: string | null;
+    steps?: string[];
+  }): Promise<void> {
     if (!params.explanation && (!params.steps || params.steps.length === 0)) {
       return;
     }
+    const steps = params.steps?.map(normalizeAnnouncementText).filter((step) => step.length > 0);
+    if (steps && steps.length > 0) {
+      this.latestPlanAnnouncementSteps = steps;
+    }
+    const explanation = normalizeAnnouncementText(params.explanation);
+    const nextAnnouncementText = buildCodexPlanAnnouncementTextFromParts({
+      explanation: params.explanation,
+      steps,
+    });
+    if (explanation || !this.latestPlanAnnouncementText) {
+      this.latestPlanAnnouncementText = nextAnnouncementText;
+    }
+    await this.announceToolPlanForPlanExplanation(explanation ? nextAnnouncementText : undefined);
     this.emitAgentEvent({
       stream: "plan",
       data: {
@@ -844,6 +1009,24 @@ export class CodexAppServerEventProjector {
         ...(params.steps && params.steps.length > 0 ? { steps: params.steps } : {}),
       },
     });
+  }
+
+  private async announceToolPlanForPlanExplanation(text: string | undefined): Promise<void> {
+    if (
+      !text ||
+      this.toolPlanAnnouncementSent ||
+      this.params.silentExpected === true ||
+      !this.params.onBlockReply
+    ) {
+      return;
+    }
+    this.toolPlanAnnouncementSent = true;
+    try {
+      await this.params.onBlockReply({ text });
+      await this.params.onBlockReplyFlush?.();
+    } catch (error) {
+      embeddedAgentLog.debug("codex tool plan announcement delivery failed", { error });
+    }
   }
 
   private rememberAssistantPhase(item: CodexThreadItem | undefined): void {
@@ -1766,6 +1949,16 @@ function isSideEffectingNativeToolItem(item: CodexThreadItem): boolean {
     itemStatus(item) !== "blocked" &&
     (isMutatingNativeToolItem(item) || item.type === "mcpToolCall")
   );
+}
+
+function buildCodexToolPlanAnnouncementInputForItem(
+  item: CodexThreadItem,
+  detailMode: ToolProgressDetailMode,
+): CodexToolPlanAnnouncementInput {
+  return {
+    toolName: itemName(item),
+    meta: item.type === "webSearch" ? undefined : itemMeta(item, detailMode),
+  };
 }
 
 function shouldSynthesizeToolProgressForItem(item: CodexThreadItem): boolean {

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -558,6 +558,7 @@ export class CodexAppServerEventProjector {
           this.latestPlanAnnouncementText ??
           buildCodexPlanAnnouncementText(this.latestPlanAnnouncementSteps) ??
           buildCodexToolPlanAnnouncementText(details),
+        isStatusNotice: true,
       });
       await this.params.onBlockReplyFlush?.();
     } catch (error) {
@@ -1094,7 +1095,7 @@ export class CodexAppServerEventProjector {
     }
     this.toolPlanAnnouncementSent = true;
     try {
-      await this.params.onBlockReply({ text });
+      await this.params.onBlockReply({ text, isStatusNotice: true });
       await this.params.onBlockReplyFlush?.();
     } catch (error) {
       embeddedAgentLog.debug("codex tool plan announcement delivery failed", { error });

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -272,6 +272,7 @@ export class CodexAppServerEventProjector {
   private readonly afterToolCallObservedItemIds = new Set<string>();
   private latestPlanAnnouncementSteps: string[] = [];
   private latestPlanAnnouncementText: string | undefined;
+  private latestPlanAnnouncementFromExplanation = false;
   private toolPlanAnnouncementSent = false;
   private assistantStarted = false;
   private reasoningStarted = false;
@@ -507,6 +508,7 @@ export class CodexAppServerEventProjector {
     if (
       this.toolPlanAnnouncementSent ||
       this.params.silentExpected === true ||
+      this.params.sourceReplyDeliveryMode === "message_tool_only" ||
       !this.params.onBlockReply ||
       isCodexMessagingToolName(details.toolName ?? undefined)
     ) {
@@ -995,7 +997,10 @@ export class CodexAppServerEventProjector {
       explanation: params.explanation,
       steps,
     });
-    if (explanation || !this.latestPlanAnnouncementText) {
+    if (explanation) {
+      this.latestPlanAnnouncementText = nextAnnouncementText;
+      this.latestPlanAnnouncementFromExplanation = true;
+    } else if (!this.latestPlanAnnouncementFromExplanation && !this.toolPlanAnnouncementSent) {
       this.latestPlanAnnouncementText = nextAnnouncementText;
     }
     await this.announceToolPlanForPlanExplanation(explanation ? nextAnnouncementText : undefined);
@@ -1016,6 +1021,7 @@ export class CodexAppServerEventProjector {
       !text ||
       this.toolPlanAnnouncementSent ||
       this.params.silentExpected === true ||
+      this.params.sourceReplyDeliveryMode === "message_tool_only" ||
       !this.params.onBlockReply
     ) {
       return;

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -122,28 +122,19 @@ export function buildCodexToolPlanAnnouncementText(
 ): string {
   const details = normalizeCodexToolPlanAnnouncementInput(input);
   const normalizedToolName = details.toolName?.trim().toLowerCase() ?? "";
-  const meta = formatAnnouncementSnippet(details.meta);
   const tool = formatAnnouncementSnippet(details.toolName);
 
   if (isCodexCommandToolName(normalizedToolName)) {
-    return meta
-      ? `I'll run the shell command ${meta}, then report the result here.`
-      : "I'll run the shell command, then report the result here.";
+    return "I'll check the relevant local state, then report the result here.";
   }
   if (isCodexReadToolName(normalizedToolName)) {
-    return meta
-      ? `I'll inspect ${meta}, then answer here.`
-      : "I'll inspect the planned files, then answer here.";
+    return "I'll inspect the relevant context, then answer here.";
   }
   if (isCodexEditToolName(normalizedToolName)) {
-    return meta
-      ? `I'll edit ${meta}, then summarize the change here.`
-      : "I'll edit the planned files, then summarize the changes here.";
+    return "I'll make the planned change, then summarize it here.";
   }
   if (normalizedToolName.includes("search") || normalizedToolName.includes("browser")) {
-    return meta
-      ? `I'll search ${meta}, then answer here.`
-      : "I'll run the web search, then answer here.";
+    return "I'll look up the relevant information, then answer here.";
   }
   if (isCodexMessagingToolName(normalizedToolName)) {
     return "I'll check the chat state, then answer here.";
@@ -155,6 +146,46 @@ export function buildCodexToolPlanAnnouncementText(
 
 export function buildCodexPlanAnnouncementText(steps: readonly string[]): string | undefined {
   return buildCodexPlanAnnouncementTextFromParts({ steps });
+}
+
+function joinAnnouncementPhrases(phrases: readonly string[]): string {
+  if (phrases.length <= 1) {
+    return phrases[0] ?? "work through the planned steps";
+  }
+  if (phrases.length === 2) {
+    return `${phrases[0]} and ${phrases[1]}`;
+  }
+  return `${phrases.slice(0, -1).join(", ")}, and ${phrases[phrases.length - 1]}`;
+}
+
+function summarizePlanAnnouncementSteps(steps: readonly string[]): string | undefined {
+  const text = steps.join(" ").toLowerCase();
+  if (!text.trim()) {
+    return undefined;
+  }
+  const phrases: string[] = [];
+  const add = (phrase: string) => {
+    if (!phrases.includes(phrase)) {
+      phrases.push(phrase);
+    }
+  };
+  if (/\b(check|inspect|review|read|load|query|look|audit|search|compare)\b/u.test(text)) {
+    add("check the relevant state");
+  }
+  if (
+    /\b(set ?up|create|configure|install|prepare|patch|edit|update|fix|change|build|make)\b/u.test(
+      text,
+    )
+  ) {
+    add("handle the requested changes");
+  }
+  if (/\b(tests?|verify|validate|smoke|prove|confirm)\b/u.test(text)) {
+    add("verify the result");
+  }
+  if (phrases.length === 0) {
+    add("work through the planned steps");
+  }
+  return `I'll ${joinAnnouncementPhrases(phrases.slice(0, 3))}, then report back here.`;
 }
 
 export function buildCodexPlanAnnouncementTextFromParts(params: {
@@ -173,8 +204,8 @@ export function buildCodexPlanAnnouncementTextFromParts(params: {
   if (cleaned.length === 0) {
     return undefined;
   }
-  const text = `Plan: ${cleaned.slice(0, 4).join("; ")}.`;
-  return truncateAnnouncementText(text);
+  const summary = summarizePlanAnnouncementSteps(cleaned);
+  return summary ? truncateAnnouncementText(summary) : undefined;
 }
 
 export function shouldEmitTranscriptToolProgress(toolName: unknown, _args?: unknown): boolean {
@@ -290,6 +321,9 @@ export class CodexAppServerEventProjector {
   private toolPlanAnnouncementSent = false;
   private toolPlanAnnouncementDeliveryPending = false;
   private deferredToolPlanAnnouncementInput: string | CodexToolPlanAnnouncementInput | undefined;
+  private readonly deferredPlanEvents: Array<
+    Parameters<NonNullable<EmbeddedRunAttemptParams["onAgentEvent"]>>[0]
+  > = [];
   private assistantStarted = false;
   private reasoningStarted = false;
   private reasoningEnded = false;
@@ -563,6 +597,8 @@ export class CodexAppServerEventProjector {
       await this.params.onBlockReplyFlush?.();
     } catch (error) {
       embeddedAgentLog.debug("codex tool plan announcement delivery failed", { error });
+    } finally {
+      this.flushDeferredPlanEvents();
     }
   }
 
@@ -570,6 +606,7 @@ export class CodexAppServerEventProjector {
     this.toolPlanAnnouncementDeliveryPending = false;
     this.deferredToolPlanAnnouncementInput = undefined;
     this.toolPlanAnnouncementSent = true;
+    this.flushDeferredPlanEvents();
   }
 
   async completeToolPlanAnnouncementDeliveryForTool(params: {
@@ -592,7 +629,9 @@ export class CodexAppServerEventProjector {
     this.deferredToolPlanAnnouncementInput = undefined;
     if (deferredInput !== undefined) {
       await this.announceToolPlanForTool(deferredInput);
+      return;
     }
+    this.flushDeferredPlanEvents();
   }
 
   recordDynamicToolResult(params: {
@@ -1071,7 +1110,7 @@ export class CodexAppServerEventProjector {
       this.latestPlanAnnouncementText = nextAnnouncementText;
     }
     await this.announceToolPlanForPlanExplanation(explanation ? nextAnnouncementText : undefined);
-    this.emitAgentEvent({
+    this.emitPlanAgentEvent({
       stream: "plan",
       data: {
         phase: "update",
@@ -1081,6 +1120,34 @@ export class CodexAppServerEventProjector {
         ...(params.steps && params.steps.length > 0 ? { steps: params.steps } : {}),
       },
     });
+  }
+
+  private shouldDeferPlanEventsUntilToolPlanAnnouncement(): boolean {
+    return (
+      this.params.sourceReplyDeliveryMode === "message_tool_only" &&
+      this.params.silentExpected !== true &&
+      Boolean(this.params.onBlockReply) &&
+      !this.toolPlanAnnouncementSent
+    );
+  }
+
+  private emitPlanAgentEvent(
+    event: Parameters<NonNullable<EmbeddedRunAttemptParams["onAgentEvent"]>>[0],
+  ): void {
+    if (this.shouldDeferPlanEventsUntilToolPlanAnnouncement()) {
+      this.deferredPlanEvents.push(event);
+      return;
+    }
+    this.emitAgentEvent(event);
+  }
+
+  private flushDeferredPlanEvents(): void {
+    while (this.deferredPlanEvents.length > 0) {
+      const event = this.deferredPlanEvents.shift();
+      if (event) {
+        this.emitAgentEvent(event);
+      }
+    }
   }
 
   private async announceToolPlanForPlanExplanation(text: string | undefined): Promise<void> {

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -2250,6 +2250,67 @@ describe("runCodexAppServerAttempt", () => {
     expect(activeDiagnosticToolKeys(diagnosticEvents)).toEqual(new Set());
   });
 
+  it("does not treat external message tool sends as source acknowledgement delivery", async () => {
+    const harness = createStartedThreadHarness();
+    const onBlockReply = vi.fn();
+    testing.setOpenClawCodingToolsFactoryForTests(() => [
+      createRuntimeDynamicTool("message"),
+      createRuntimeDynamicTool("lookup"),
+    ]);
+
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+    params.disableTools = false;
+    params.runtimePlan = createCodexRuntimePlanFixture();
+    params.sourceReplyDeliveryMode = "message_tool_only";
+    params.onBlockReply = onBlockReply;
+
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("thread/start");
+
+    await harness.handleServerRequest({
+      id: "request-message-tool",
+      method: "item/tool/call",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        callId: "call-message-1",
+        namespace: null,
+        tool: "message",
+        arguments: {
+          action: "send",
+          text: "sent somewhere else",
+          to: "external-chat",
+        },
+      },
+    });
+
+    expect(onBlockReply).not.toHaveBeenCalled();
+
+    await harness.handleServerRequest({
+      id: "request-lookup-tool",
+      method: "item/tool/call",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        callId: "call-lookup-1",
+        namespace: null,
+        tool: "lookup",
+        arguments: {},
+      },
+    });
+
+    expect(onBlockReply).toHaveBeenCalledWith({
+      text: 'I\'ll run the "lookup" step, then report the result here.',
+      isStatusNotice: true,
+    });
+
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await run;
+  });
+
   it("clears dynamic tool diagnostics after successful app-server tool responses", async () => {
     const harness = createStartedThreadHarness();
     const diagnosticEvents: DiagnosticEventPayload[] = [];

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -2158,6 +2158,7 @@ describe("runCodexAppServerAttempt", () => {
     expect(toolResult.contentItems?.[0]?.text).toMatch(/^Unknown OpenClaw tool: lookup$/u);
     expect(onBlockReply).toHaveBeenCalledWith({
       text: 'I\'ll run the "lookup" step, then report the result here.',
+      isStatusNotice: true,
     });
     expect(onBlockReply.mock.invocationCallOrder[0]).toBeLessThan(
       onExecutionPhase.mock.invocationCallOrder.find(

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -2116,6 +2116,7 @@ describe("runCodexAppServerAttempt", () => {
     const harness = createStartedThreadHarness();
     const onRunAgentEvent = vi.fn();
     const onExecutionPhase = vi.fn();
+    const onBlockReply = vi.fn();
     const globalAgentEvents: AgentEventPayload[] = [];
     const diagnosticEvents: DiagnosticEventPayload[] = [];
     onAgentEvent((event) => globalAgentEvents.push(event));
@@ -2128,6 +2129,7 @@ describe("runCodexAppServerAttempt", () => {
     );
     params.onAgentEvent = onRunAgentEvent;
     params.onExecutionPhase = onExecutionPhase;
+    params.onBlockReply = onBlockReply;
 
     const run = runCodexAppServerAttempt(params);
     await harness.waitForMethod("thread/start");
@@ -2154,6 +2156,14 @@ describe("runCodexAppServerAttempt", () => {
     expect(toolResult.success).toBe(false);
     expect(toolResult.contentItems?.[0]?.type).toBe("inputText");
     expect(toolResult.contentItems?.[0]?.text).toMatch(/^Unknown OpenClaw tool: lookup$/u);
+    expect(onBlockReply).toHaveBeenCalledWith({
+      text: 'I\'ll run the "lookup" step, then report the result here.',
+    });
+    expect(onBlockReply.mock.invocationCallOrder[0]).toBeLessThan(
+      onExecutionPhase.mock.invocationCallOrder.find(
+        (_, index) => onExecutionPhase.mock.calls[index]?.[0]?.phase === "tool_execution_started",
+      ) ?? Number.POSITIVE_INFINITY,
+    );
 
     await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
     await run;

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -2107,9 +2107,11 @@ export async function runCodexAppServerAttempt(
       markCurrentTurnRequestProgress();
       turnCrossedToolHandoff = true;
       const toolProgressDetailMode = resolveCodexToolProgressDetailMode(params.toolProgressDetail);
-      await projector?.announceToolPlanForTool({
+      const toolPlanAnnouncementInput = {
         toolName: call.tool,
-      });
+        ...(isJsonObject(call.arguments) ? { args: call.arguments } : {}),
+      };
+      await projector?.announceToolPlanForTool(toolPlanAnnouncementInput);
       pendingOpenClawDynamicToolCompletionIds.add(call.callId);
       trajectoryRecorder?.recordEvent("tool.call", {
         threadId: call.threadId,
@@ -2171,6 +2173,10 @@ export async function runCodexAppServerAttempt(
         }
       });
       try {
+        const sourceReplyPayloadCountBefore =
+          toolBridge.telemetry.messagingToolSourceReplyPayloads.length;
+        const messagingToolSentTargetCountBefore =
+          toolBridge.telemetry.messagingToolSentTargets.length;
         const response = await handleDynamicToolCallWithTimeout({
           call,
           toolBridge,
@@ -2186,6 +2192,21 @@ export async function runCodexAppServerAttempt(
             });
           },
         });
+        if (
+          toolBridge.telemetry.messagingToolSourceReplyPayloads.length >
+            sourceReplyPayloadCountBefore ||
+          toolBridge.telemetry.messagingToolSentTargets.length > messagingToolSentTargetCountBefore
+        ) {
+          await projector?.completeToolPlanAnnouncementDeliveryForTool({
+            input: toolPlanAnnouncementInput,
+            delivered: true,
+          });
+        } else {
+          await projector?.completeToolPlanAnnouncementDeliveryForTool({
+            input: toolPlanAnnouncementInput,
+            delivered: false,
+          });
+        }
         const protocolResponse = toCodexDynamicToolProtocolResponse(response);
         trajectoryRecorder?.recordEvent("tool.result", {
           threadId: call.threadId,
@@ -2237,6 +2258,10 @@ export async function runCodexAppServerAttempt(
         }
         return protocolResponse as JsonValue;
       } catch (error) {
+        await projector?.completeToolPlanAnnouncementDeliveryForTool({
+          input: toolPlanAnnouncementInput,
+          delivered: false,
+        });
         if (
           !terminalDiagnosticObserved &&
           !hasPendingDynamicToolTerminalDiagnostic({

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -2175,8 +2175,6 @@ export async function runCodexAppServerAttempt(
       try {
         const sourceReplyPayloadCountBefore =
           toolBridge.telemetry.messagingToolSourceReplyPayloads.length;
-        const messagingToolSentTargetCountBefore =
-          toolBridge.telemetry.messagingToolSentTargets.length;
         const response = await handleDynamicToolCallWithTimeout({
           call,
           toolBridge,
@@ -2194,8 +2192,7 @@ export async function runCodexAppServerAttempt(
         });
         if (
           toolBridge.telemetry.messagingToolSourceReplyPayloads.length >
-            sourceReplyPayloadCountBefore ||
-          toolBridge.telemetry.messagingToolSentTargets.length > messagingToolSentTargetCountBefore
+          sourceReplyPayloadCountBefore
         ) {
           await projector?.completeToolPlanAnnouncementDeliveryForTool({
             input: toolPlanAnnouncementInput,

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -2106,6 +2106,10 @@ export async function runCodexAppServerAttempt(
       armCompletionWatchOnResponse = true;
       markCurrentTurnRequestProgress();
       turnCrossedToolHandoff = true;
+      const toolProgressDetailMode = resolveCodexToolProgressDetailMode(params.toolProgressDetail);
+      await projector?.announceToolPlanForTool({
+        toolName: call.tool,
+      });
       pendingOpenClawDynamicToolCompletionIds.add(call.callId);
       trajectoryRecorder?.recordEvent("tool.call", {
         threadId: call.threadId,
@@ -2130,7 +2134,6 @@ export async function runCodexAppServerAttempt(
         sessionId: params.sessionId,
         sessionKey: params.sessionKey,
       });
-      const toolProgressDetailMode = resolveCodexToolProgressDetailMode(params.toolProgressDetail);
       const toolMeta = inferCodexDynamicToolMeta(call, toolProgressDetailMode);
       const toolArgs = sanitizeCodexToolArguments(call.arguments);
       const shouldEmitDynamicToolProgress = shouldEmitTranscriptToolProgress(call.tool, toolArgs);

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -15,8 +15,10 @@ function createAttemptParams(params: {
   authProfileProviders?: Record<string, string>;
   bootstrapContextMode?: "full" | "lightweight";
   bootstrapContextRunKind?: "default" | "heartbeat" | "cron";
+  disableMessageTool?: boolean;
   images?: EmbeddedRunAttemptParams["images"];
   silentExpected?: boolean;
+  sourceReplyDeliveryMode?: EmbeddedRunAttemptParams["sourceReplyDeliveryMode"];
 }): EmbeddedRunAttemptParams {
   const authProfileProviders =
     params.authProfileProviders ??
@@ -33,7 +35,13 @@ function createAttemptParams(params: {
       ? { bootstrapContextRunKind: params.bootstrapContextRunKind }
       : {}),
     ...(params.images ? { images: params.images } : {}),
+    ...(params.disableMessageTool !== undefined
+      ? { disableMessageTool: params.disableMessageTool }
+      : {}),
     ...(params.silentExpected !== undefined ? { silentExpected: params.silentExpected } : {}),
+    ...(params.sourceReplyDeliveryMode
+      ? { sourceReplyDeliveryMode: params.sourceReplyDeliveryMode }
+      : {}),
     authProfileStore: {
       version: 1,
       profiles: Object.fromEntries(
@@ -78,6 +86,19 @@ describe("Codex app-server native code mode config", () => {
     expect(instructions).toContain("SOUL.md");
     expect(instructions).toContain("Beszel and Uptime Kuma");
     expect(instructions).toContain("Do not say generic things");
+  });
+
+  it("routes tool-start acknowledgements through the message tool for message-tool-only turns", () => {
+    const instructions = buildDeveloperInstructions(
+      createAttemptParams({
+        provider: "openai",
+        sourceReplyDeliveryMode: "message_tool_only",
+      }),
+    );
+
+    expect(instructions).toContain("To send a visible message, use the `message` tool.");
+    expect(instructions).toContain("make your first tool call `message`");
+    expect(instructions).toContain("with that exact acknowledgement");
   });
 
   it("omits tool-start acknowledgement instructions for silent turns", () => {

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -16,6 +16,7 @@ function createAttemptParams(params: {
   bootstrapContextMode?: "full" | "lightweight";
   bootstrapContextRunKind?: "default" | "heartbeat" | "cron";
   images?: EmbeddedRunAttemptParams["images"];
+  silentExpected?: boolean;
 }): EmbeddedRunAttemptParams {
   const authProfileProviders =
     params.authProfileProviders ??
@@ -32,6 +33,7 @@ function createAttemptParams(params: {
       ? { bootstrapContextRunKind: params.bootstrapContextRunKind }
       : {}),
     ...(params.images ? { images: params.images } : {}),
+    ...(params.silentExpected !== undefined ? { silentExpected: params.silentExpected } : {}),
     authProfileStore: {
       version: 1,
       profiles: Object.fromEntries(
@@ -66,6 +68,24 @@ describe("Codex app-server native code mode config", () => {
     expect(instructions).toContain(
       "Use OpenClaw `sessions_spawn` only for OpenClaw or ACP delegation.",
     );
+  });
+
+  it("instructs Codex to make tool-start acknowledgements specific and persona-shaped", () => {
+    const instructions = buildDeveloperInstructions(createAttemptParams({ provider: "openai" }));
+
+    expect(instructions).toContain("chat-ready acknowledgement");
+    expect(instructions).toContain("specific to the user's request");
+    expect(instructions).toContain("SOUL.md");
+    expect(instructions).toContain("Beszel and Uptime Kuma");
+    expect(instructions).toContain("Do not say generic things");
+  });
+
+  it("omits tool-start acknowledgement instructions for silent turns", () => {
+    const instructions = buildDeveloperInstructions(
+      createAttemptParams({ provider: "openai", silentExpected: true }),
+    );
+
+    expect(instructions).not.toContain("chat-ready acknowledgement");
   });
 
   it("summarizes deferred dynamic tool names in developer instructions", () => {

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -83,6 +83,10 @@ describe("Codex app-server native code mode config", () => {
 
     expect(instructions).toContain("chat-ready acknowledgement");
     expect(instructions).toContain("specific to the user's request");
+    expect(instructions).toContain("summarizing the overall user-facing work");
+    expect(instructions).toContain("Do not describe implementation mechanics");
+    expect(instructions).toContain("file paths");
+    expect(instructions).toContain("log excerpts");
     expect(instructions).toContain("SOUL.md");
     expect(instructions).toContain("Beszel and Uptime Kuma");
     expect(instructions).toContain("Do not say generic things");

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -853,10 +853,25 @@ export function buildDeveloperInstructions(
     buildDeferredDynamicToolManifest(options.dynamicTools),
     "Use Codex native `spawn_agent` for Codex subagents. Use OpenClaw `sessions_spawn` only for OpenClaw or ACP delegation.",
     buildVisibleReplyInstruction(params, options.dynamicTools),
+    buildToolPlanAnnouncementInstruction(params),
     nativeCommandGuidance,
     params.extraSystemPrompt,
   ];
   return sections.filter((section) => typeof section === "string" && section.trim()).join("\n\n");
+}
+
+function buildToolPlanAnnouncementInstruction(
+  params: EmbeddedRunAttemptParams,
+): string | undefined {
+  if (params.silentExpected === true) {
+    return undefined;
+  }
+  return [
+    "When the chat turn will need tools, make your first plan update include a chat-ready acknowledgement in the plan explanation before the first tool call.",
+    "Write it as the exact short message OpenClaw should send back to the same chat: specific to the user's request, naming the concrete systems/resources involved, and in the voice/style from SOUL.md and the active workspace instructions.",
+    'Keep it to one or two sentences. Do not say generic things like "I\'ll use the necessary tools" or "I\'ll continue with the request."',
+    'Example: if the user asks to check what is unhealthy in Beszel and Uptime Kuma, a good explanation is: "I\'ll check your Beszel and Uptime Kuma instances to make sure nothing looks dead or dying."',
+  ].join(" ");
 }
 
 function buildDeferredDynamicToolManifest(

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -853,7 +853,7 @@ export function buildDeveloperInstructions(
     buildDeferredDynamicToolManifest(options.dynamicTools),
     "Use Codex native `spawn_agent` for Codex subagents. Use OpenClaw `sessions_spawn` only for OpenClaw or ACP delegation.",
     buildVisibleReplyInstruction(params, options.dynamicTools),
-    buildToolPlanAnnouncementInstruction(params),
+    buildToolPlanAnnouncementInstruction(params, options.dynamicTools),
     nativeCommandGuidance,
     params.extraSystemPrompt,
   ];
@@ -862,16 +862,25 @@ export function buildDeveloperInstructions(
 
 function buildToolPlanAnnouncementInstruction(
   params: EmbeddedRunAttemptParams,
+  dynamicTools: readonly CodexDynamicToolSpec[] | undefined,
 ): string | undefined {
   if (params.silentExpected === true) {
     return undefined;
   }
+  const messageToolOnly =
+    params.sourceReplyDeliveryMode === "message_tool_only" &&
+    isMessageToolAvailable(params, dynamicTools);
   return [
     "When the chat turn will need tools, make your first plan update include a chat-ready acknowledgement in the plan explanation before the first tool call.",
     "Write it as the exact short message OpenClaw should send back to the same chat: specific to the user's request, naming the concrete systems/resources involved, and in the voice/style from SOUL.md and the active workspace instructions.",
+    messageToolOnly
+      ? "Because visible replies use the `message` tool in this turn, make your first tool call `message` with that exact acknowledgement, then immediately proceed with the rest of the work."
+      : undefined,
     'Keep it to one or two sentences. Do not say generic things like "I\'ll use the necessary tools" or "I\'ll continue with the request."',
     'Example: if the user asks to check what is unhealthy in Beszel and Uptime Kuma, a good explanation is: "I\'ll check your Beszel and Uptime Kuma instances to make sure nothing looks dead or dying."',
-  ].join(" ");
+  ]
+    .filter((part): part is string => Boolean(part))
+    .join(" ");
 }
 
 function buildDeferredDynamicToolManifest(
@@ -895,13 +904,22 @@ function buildVisibleReplyInstruction(
   params: EmbeddedRunAttemptParams,
   dynamicTools: readonly CodexDynamicToolSpec[] | undefined,
 ): string {
-  const messageToolAvailable = dynamicTools
-    ? dynamicTools.some((tool) => tool.name.trim() === "message")
-    : params.disableMessageTool !== true;
-  if (params.sourceReplyDeliveryMode === "message_tool_only" && messageToolAvailable) {
+  if (
+    params.sourceReplyDeliveryMode === "message_tool_only" &&
+    isMessageToolAvailable(params, dynamicTools)
+  ) {
     return "To send a visible message, use the `message` tool.";
   }
   return "To send a visible reply, use the active Codex delivery path.";
+}
+
+function isMessageToolAvailable(
+  params: EmbeddedRunAttemptParams,
+  dynamicTools: readonly CodexDynamicToolSpec[] | undefined,
+): boolean {
+  return dynamicTools
+    ? dynamicTools.some((tool) => tool.name.trim() === "message")
+    : params.disableMessageTool !== true;
 }
 
 function buildUserInput(

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -872,7 +872,8 @@ function buildToolPlanAnnouncementInstruction(
     isMessageToolAvailable(params, dynamicTools);
   return [
     "When the chat turn will need tools, make your first plan update include a chat-ready acknowledgement in the plan explanation before the first tool call.",
-    "Write it as the exact short message OpenClaw should send back to the same chat: specific to the user's request, naming the concrete systems/resources involved, and in the voice/style from SOUL.md and the active workspace instructions.",
+    "Write it as the exact short message OpenClaw should send back to the same chat: specific to the user's request, summarizing the overall user-facing work you plan to do, naming the concrete systems/resources involved when helpful, and in the voice/style from SOUL.md and the active workspace instructions.",
+    "Do not describe implementation mechanics in the acknowledgement: avoid exact command lines, file paths, log excerpts, private ids, tokens, raw host addresses, or low-level tool names. Save that evidence for the final answer when it is actually useful.",
     messageToolOnly
       ? "Because visible replies use the `message` tool in this turn, make your first tool call `message` with that exact acknowledgement, then immediately proceed with the rest of the work."
       : undefined,

--- a/src/auto-reply/reply-payload.ts
+++ b/src/auto-reply/reply-payload.ts
@@ -51,6 +51,8 @@ export type ReplyPayload = {
   isCompactionNotice?: boolean;
   /** Marks this payload as a model-fallback transition/recovery notice. */
   isFallbackNotice?: boolean;
+  /** Marks this payload as a transient status/progress notice, not final assistant content. */
+  isStatusNotice?: boolean;
   /** Channel-specific payload data (per-channel envelope). */
   channelData?: Record<string, unknown>;
 };
@@ -61,6 +63,12 @@ export type ReplyPayloadTtsSupplement = {
 };
 
 export const REPLY_MEDIA_FAILURE_WARNING = "⚠️ Media failed.";
+
+export function isReplyPayloadStatusNotice(
+  payload: Pick<ReplyPayload, "isCompactionNotice" | "isFallbackNotice" | "isStatusNotice">,
+): boolean {
+  return Boolean(payload.isCompactionNotice || payload.isFallbackNotice || payload.isStatusNotice);
+}
 
 export function appendReplyMediaFailureWarning(text: string | undefined): string {
   if (!text?.trim()) {

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -10,6 +10,7 @@ import {
   appendReplyMediaFailureWarning,
   copyReplyPayloadMetadata,
   getReplyPayloadMetadata,
+  isReplyPayloadStatusNotice,
   setReplyPayloadMetadata,
 } from "../reply-payload.js";
 import type { OriginatingChannelType } from "../templating.js";
@@ -330,7 +331,7 @@ export async function buildReplyPayloads(params: {
   const isDirectlySentBlockPayload = (payload: ReplyPayload) =>
     Boolean(params.directlySentBlockKeys?.has(createBlockReplyContentKey(payload)));
   const preserveUnsentMediaAfterBlockStream = (payload: ReplyPayload): ReplyPayload | null => {
-    if (payload.isError || payload.isFallbackNotice) {
+    if (payload.isError || isReplyPayloadStatusNotice(payload)) {
       return payload;
     }
     const reply = resolveSendableOutboundReplyParts(payload);

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -49,6 +49,7 @@ import {
 } from "../fallback-state.js";
 import { DEFAULT_HEARTBEAT_ACK_MAX_CHARS, stripHeartbeatToken } from "../heartbeat.js";
 import {
+  isReplyPayloadStatusNotice,
   markReplyPayloadForSourceSuppressionDelivery,
   setReplyPayloadMetadata,
 } from "../reply-payload.js";
@@ -922,11 +923,7 @@ function buildInlineRawTracePayload(params: {
 function joinCommitmentAssistantText(payloads: ReplyPayload[]): string {
   return payloads
     .filter(
-      (payload) =>
-        !payload.isError &&
-        !payload.isReasoning &&
-        !payload.isCompactionNotice &&
-        !payload.isFallbackNotice,
+      (payload) => !payload.isError && !payload.isReasoning && !isReplyPayloadStatusNotice(payload),
     )
     .map((payload) => payload.text?.trim())
     .filter((text): text is string => Boolean(text))
@@ -1760,7 +1757,7 @@ export async function runReplyAgent(params: {
     didLogHeartbeatStrip = payloadResult.didLogHeartbeatStrip;
 
     const hasReplyPayloadBeyondFallbackNotice = replyPayloads.some(
-      (payload) => !payload.isFallbackNotice,
+      (payload) => !isReplyPayloadStatusNotice(payload),
     );
     const hasDeliveredBlockStream = Boolean(
       blockReplyPipeline?.didStream() && !blockReplyPipeline.isAborted(),
@@ -1782,7 +1779,7 @@ export async function runReplyAgent(params: {
     const hasReminderCommitment = replyPayloads.some(
       (payload) =>
         !payload.isError &&
-        !payload.isFallbackNotice &&
+        !isReplyPayloadStatusNotice(payload) &&
         typeof payload.text === "string" &&
         hasUnbackedReminderCommitment(payload.text),
     );

--- a/src/auto-reply/reply/block-reply-coalescer.ts
+++ b/src/auto-reply/reply/block-reply-coalescer.ts
@@ -27,6 +27,7 @@ export function createBlockReplyCoalescer(params: {
   let bufferIsReasoning: ReplyPayload["isReasoning"];
   let bufferIsCompactionNotice: ReplyPayload["isCompactionNotice"];
   let bufferIsFallbackNotice: ReplyPayload["isFallbackNotice"];
+  let bufferIsStatusNotice: ReplyPayload["isStatusNotice"];
   let idleTimer: NodeJS.Timeout | undefined;
 
   const clearIdleTimer = () => {
@@ -44,6 +45,7 @@ export function createBlockReplyCoalescer(params: {
     bufferIsReasoning = undefined;
     bufferIsCompactionNotice = undefined;
     bufferIsFallbackNotice = undefined;
+    bufferIsStatusNotice = undefined;
   };
 
   const scheduleIdleFlush = () => {
@@ -76,6 +78,7 @@ export function createBlockReplyCoalescer(params: {
       isReasoning: bufferIsReasoning,
       isCompactionNotice: bufferIsCompactionNotice,
       isFallbackNotice: bufferIsFallbackNotice,
+      isStatusNotice: bufferIsStatusNotice,
     };
     resetBuffer();
     await onFlush(payload);
@@ -109,6 +112,7 @@ export function createBlockReplyCoalescer(params: {
       bufferIsReasoning = payload.isReasoning;
       bufferIsCompactionNotice = payload.isCompactionNotice;
       bufferIsFallbackNotice = payload.isFallbackNotice;
+      bufferIsStatusNotice = payload.isStatusNotice;
       bufferText = text;
       void flush({ force: true });
       return;
@@ -123,7 +127,8 @@ export function createBlockReplyCoalescer(params: {
       bufferText &&
       (bufferIsReasoning !== payload.isReasoning ||
         bufferIsCompactionNotice !== payload.isCompactionNotice ||
-        bufferIsFallbackNotice !== payload.isFallbackNotice);
+        bufferIsFallbackNotice !== payload.isFallbackNotice ||
+        bufferIsStatusNotice !== payload.isStatusNotice);
     if (
       bufferText &&
       (replyToConflict || bufferAudioAsVoice !== payload.audioAsVoice || visibilityConflict)
@@ -137,6 +142,7 @@ export function createBlockReplyCoalescer(params: {
       bufferIsReasoning = payload.isReasoning;
       bufferIsCompactionNotice = payload.isCompactionNotice;
       bufferIsFallbackNotice = payload.isFallbackNotice;
+      bufferIsStatusNotice = payload.isStatusNotice;
     }
 
     const nextText = bufferText ? `${bufferText}${joiner}${text}` : text;
@@ -148,6 +154,7 @@ export function createBlockReplyCoalescer(params: {
         bufferIsReasoning = payload.isReasoning;
         bufferIsCompactionNotice = payload.isCompactionNotice;
         bufferIsFallbackNotice = payload.isFallbackNotice;
+        bufferIsStatusNotice = payload.isStatusNotice;
         if (text.length >= maxChars) {
           void onFlush(payload);
           return;

--- a/src/auto-reply/reply/block-reply-pipeline.test.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.test.ts
@@ -205,6 +205,29 @@ describe("createBlockReplyPipeline dedup with threading", () => {
     expect(pipeline.getSentMediaUrls()).toStrictEqual([]);
   });
 
+  it("does not treat status notices as streamed assistant output", async () => {
+    const sent: Array<{ text?: string; isStatusNotice?: boolean }> = [];
+    const pipeline = createBlockReplyPipeline({
+      onBlockReply: async (payload) => {
+        sent.push({ text: payload.text, isStatusNotice: payload.isStatusNotice });
+      },
+      timeoutMs: 5000,
+    });
+
+    pipeline.enqueue({ text: "I'll check local system time.", isStatusNotice: true });
+    await pipeline.flush({ force: true });
+
+    expect(sent).toEqual([{ text: "I'll check local system time.", isStatusNotice: true }]);
+    expect(pipeline.didStream()).toBe(false);
+    expect(pipeline.hasSentPayload({ text: "Local system time: 11:49 EDT." })).toBe(false);
+
+    pipeline.enqueue({ text: "Local system time: 11:49 EDT." });
+    await pipeline.flush({ force: true });
+
+    expect(pipeline.didStream()).toBe(true);
+    expect(pipeline.hasSentPayload({ text: "Local system time: 11:49 EDT." })).toBe(true);
+  });
+
   it("does not coalesce logical assistant blocks across assistantMessageIndex boundaries", async () => {
     const sent: string[] = [];
     const pipeline = createBlockReplyPipeline({

--- a/src/auto-reply/reply/block-reply-pipeline.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.ts
@@ -3,7 +3,7 @@ import {
   resolveSendableOutboundReplyParts,
 } from "openclaw/plugin-sdk/reply-payload";
 import { logVerbose } from "../../globals.js";
-import { getReplyPayloadMetadata } from "../reply-payload.js";
+import { getReplyPayloadMetadata, isReplyPayloadStatusNotice } from "../reply-payload.js";
 import type { ReplyPayload } from "../types.js";
 import { createBlockReplyCoalescer } from "./block-reply-coalescer.js";
 import type { BlockStreamingCoalescing } from "./block-streaming.js";
@@ -161,15 +161,17 @@ export function createBlockReplyPipeline(params: {
           return;
         }
         sentKeys.add(payloadKey);
-        sentContentKeys.add(contentKey);
         const reply = resolveSendableOutboundReplyParts(payload);
         for (const mediaUrl of reply.mediaUrls) {
           sentMediaUrls.add(mediaUrl);
         }
-        if (!reply.hasMedia && reply.trimmedText) {
-          streamedTextFragments.push(reply.trimmedText);
+        if (!isReplyPayloadStatusNotice(payload)) {
+          sentContentKeys.add(contentKey);
+          if (!reply.hasMedia && reply.trimmedText) {
+            streamedTextFragments.push(reply.trimmedText);
+          }
+          didStream = true;
         }
-        didStream = true;
       })
       .catch((err) => {
         if (err === timeoutError) {

--- a/src/auto-reply/reply/dispatch-acp-delivery.ts
+++ b/src/auto-reply/reply/dispatch-acp-delivery.ts
@@ -11,6 +11,7 @@ import {
 import { createTtsDirectiveTextStreamCleaner } from "../../tts/directives.js";
 import { resolveStatusTtsSnapshot } from "../../tts/status-config.js";
 import { resolveConfiguredTtsMode, shouldCleanTtsDirectiveText } from "../../tts/tts-config.js";
+import { isReplyPayloadStatusNotice } from "../reply-payload.js";
 import type { FinalizedMsgContext } from "../templating.js";
 import type { ReplyPayload } from "../types.js";
 import type { ReplyDispatchKind, ReplyDispatcher } from "./reply-dispatcher.types.js";
@@ -100,7 +101,7 @@ async function maybeApplyAcpTts(params: {
   if (params.skipTts) {
     return params.payload;
   }
-  if (params.payload.isCompactionNotice || params.payload.isFallbackNotice) {
+  if (isReplyPayloadStatusNotice(params.payload)) {
     return params.payload;
   }
   const ttsStatus = resolveStatusTtsSnapshot({
@@ -314,7 +315,7 @@ export function createAcpDispatchDeliveryCoordinator(params: {
     let visiblePayload = payload;
     const rawBlockText = kind === "block" ? normalizeOptionalString(payload.text) : undefined;
     if (rawBlockText) {
-      const isStatusNotice = payload.isCompactionNotice || payload.isFallbackNotice;
+      const isStatusNotice = isReplyPayloadStatusNotice(payload);
       const joinsBufferedTtsDirective =
         state.cleanBlockTtsDirectiveText?.hasBufferedDirectiveText() === true;
       if (!isStatusNotice) {
@@ -340,7 +341,7 @@ export function createAcpDispatchDeliveryCoordinator(params: {
         state.accumulatedVisibleBlockText += visiblePayload.text;
       }
     }
-    const isStatusNotice = payload.isCompactionNotice || payload.isFallbackNotice;
+    const isStatusNotice = isReplyPayloadStatusNotice(payload);
     const rawFinalText =
       kind === "final" && !isStatusNotice ? normalizeOptionalString(payload.text) : undefined;
     if (rawFinalText) {

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1712,7 +1712,7 @@ describe("dispatchReplyFromConfig", () => {
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(notice);
   });
 
-  it("renders plain-text plan updates without generic working statuses when verbose is enabled", async () => {
+  it("renders only plan steps without repeating the explanation when verbose is enabled", async () => {
     setNoAbort();
     const cfg = {
       ...emptyConfig,
@@ -1749,9 +1749,43 @@ describe("dispatchReplyFromConfig", () => {
     await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
 
     expect(firstToolResultPayload(dispatcher)?.text).toBe(
-      "Inspect code, patch it, run tests.\n\n1. Inspect code\n2. Patch code\n3. Run tests",
+      "1. Inspect code\n2. Patch code\n3. Run tests",
     );
     expect(dispatcher.sendToolResult).toHaveBeenCalledTimes(1);
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "done" });
+  });
+
+  it("skips explanation-only plan progress when verbose is enabled", async () => {
+    setNoAbort();
+    const cfg = {
+      ...emptyConfig,
+      agents: {
+        defaults: {
+          verboseDefault: "on",
+        },
+      },
+    } satisfies OpenClawConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      ChatType: "direct",
+    });
+
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+      _cfg?: OpenClawConfig,
+    ) => {
+      await opts?.onPlanUpdate?.({
+        phase: "update",
+        explanation: "Inspect code, patch it, run tests.",
+      });
+      return { text: "done" } satisfies ReplyPayload;
+    };
+
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "done" });
   });
 
@@ -2258,7 +2292,7 @@ describe("dispatchReplyFromConfig", () => {
     });
 
     expect(dispatcher.sendToolResult).toHaveBeenNthCalledWith(1, {
-      text: "Inspect code.\n\n1. Patch code",
+      text: "1. Patch code",
     });
     expect(dispatcher.sendToolResult).toHaveBeenCalledTimes(1);
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "done" });

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1755,6 +1755,106 @@ describe("dispatchReplyFromConfig", () => {
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "done" });
   });
 
+  it("does not resend verbose plan steps when only statuses change", async () => {
+    setNoAbort();
+    const cfg = {
+      ...emptyConfig,
+      agents: {
+        defaults: {
+          verboseDefault: "on",
+        },
+      },
+    } satisfies OpenClawConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      ChatType: "direct",
+    });
+
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+      _cfg?: OpenClawConfig,
+    ) => {
+      await opts?.onPlanUpdate?.({
+        phase: "update",
+        explanation: "Check monitoring health.",
+        steps: [
+          "Check Beszel unhealthy systems (pending)",
+          "Check Uptime Kuma down monitors (pending)",
+        ],
+      });
+      await opts?.onPlanUpdate?.({
+        phase: "update",
+        explanation: "Check monitoring health.",
+        steps: [
+          "Check Beszel unhealthy systems (inProgress)",
+          "Check Uptime Kuma down monitors (pending)",
+        ],
+      });
+      await opts?.onPlanUpdate?.({
+        phase: "update",
+        explanation: "Check monitoring health.",
+        steps: [
+          "Check Beszel unhealthy systems (completed)",
+          "Check Uptime Kuma down monitors (completed)",
+        ],
+      });
+      return { text: "done" } satisfies ReplyPayload;
+    };
+
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    expect(dispatcher.sendToolResult).toHaveBeenCalledOnce();
+    expect(firstToolResultPayload(dispatcher)?.text).toBe(
+      "1. Check Beszel unhealthy systems (pending)\n" +
+        "2. Check Uptime Kuma down monitors (pending)",
+    );
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "done" });
+  });
+
+  it("refreshes verbose plan steps when streamed plan content grows", async () => {
+    setNoAbort();
+    const cfg = {
+      ...emptyConfig,
+      agents: {
+        defaults: {
+          verboseDefault: "on",
+        },
+      },
+    } satisfies OpenClawConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      ChatType: "direct",
+    });
+
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+      _cfg?: OpenClawConfig,
+    ) => {
+      await opts?.onPlanUpdate?.({
+        phase: "update",
+        steps: ["Inspect code"],
+      });
+      await opts?.onPlanUpdate?.({
+        phase: "update",
+        steps: ["Inspect code", "Run focused tests"],
+      });
+      return { text: "done" } satisfies ReplyPayload;
+    };
+
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    expect(dispatcher.sendToolResult).toHaveBeenCalledTimes(2);
+    expect(firstToolResultPayload(dispatcher)?.text).toBe("1. Inspect code");
+    expect((dispatcher.sendToolResult as ReturnType<typeof vi.fn>).mock.calls[1]?.[0]?.text).toBe(
+      "1. Inspect code\n2. Run focused tests",
+    );
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "done" });
+  });
+
   it("skips explanation-only plan progress when verbose is enabled", async () => {
     setNoAbort();
     const cfg = {

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -4719,6 +4719,34 @@ describe("dispatchReplyFromConfig", () => {
     expect(blockReplySentTexts).toContain("The answer is 42");
   });
 
+  it("delivers final replies after status block replies", async () => {
+    setNoAbort();
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({ Provider: "whatsapp" });
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+    ): Promise<ReplyPayload> => {
+      await opts?.onBlockReply?.({
+        text: "I'll check local system time.",
+        isStatusNotice: true,
+      });
+      return { text: "Local system time: 2026-05-20 11:49:47 EDT (-0400)" };
+    };
+
+    await dispatchReplyFromConfig({ ctx, cfg: emptyConfig, dispatcher, replyResolver });
+
+    expect(dispatcher.sendBlockReply).toHaveBeenCalledWith({
+      text: "I'll check local system time.",
+      isStatusNotice: true,
+    });
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "Local system time: 2026-05-20 11:49:47 EDT (-0400)",
+      }),
+    );
+  });
+
   it("strips split TTS directives from streamed block text before delivery", async () => {
     setNoAbort();
     ttsMocks.state.synthesizeFinalAudio = true;

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -4329,6 +4329,110 @@ describe("dispatchReplyFromConfig", () => {
     expect(errorEvent?.error).toBe("Error: dispatch failed");
   });
 
+  it("releases inbound dedupe when dispatch fails after an unsent explanation-only plan update", async () => {
+    setNoAbort();
+    const cfg = {
+      diagnostics: { enabled: true },
+      agents: { defaults: { verboseDefault: "on" } },
+    } as OpenClawConfig;
+    const ctx = buildTestCtx({
+      Provider: "whatsapp",
+      OriginatingChannel: "whatsapp",
+      OriginatingTo: "whatsapp:+15555550127",
+      To: "whatsapp:+15555550127",
+      AccountId: "default",
+      MessageSid: "msg-dup-plan-error",
+      SessionKey: "agent:main:whatsapp:direct:+15555550127",
+      CommandBody: "hello",
+      RawBody: "hello",
+      Body: "hello",
+    });
+    const firstDispatcher = createDispatcher();
+    const replyResolver = vi
+      .fn<
+        (_ctx: MsgContext, _opts?: GetReplyOptions, _cfg?: OpenClawConfig) => Promise<ReplyPayload>
+      >()
+      .mockImplementationOnce(async (_ctx, opts) => {
+        await opts?.onPlanUpdate?.({
+          phase: "update",
+          explanation: "Inspect code, patch it, run tests.",
+        });
+        throw new Error("provider failed after unsent plan");
+      })
+      .mockResolvedValueOnce({ text: "retry succeeds" });
+
+    await expect(
+      dispatchReplyFromConfig({
+        ctx,
+        cfg,
+        dispatcher: firstDispatcher,
+        replyResolver,
+      }),
+    ).rejects.toThrow("provider failed after unsent plan");
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg,
+      dispatcher: createDispatcher(),
+      replyResolver,
+    });
+
+    expect(firstDispatcher.sendToolResult).not.toHaveBeenCalled();
+    expect(replyResolver).toHaveBeenCalledTimes(2);
+  });
+
+  it("poisons inbound dedupe when routed plan progress is sent before dispatch fails", async () => {
+    setNoAbort();
+    mocks.routeReply.mockClear();
+    const cfg = {
+      diagnostics: { enabled: true },
+      agents: { defaults: { verboseDefault: "on" } },
+    } as OpenClawConfig;
+    const ctx = buildTestCtx({
+      Provider: "slack",
+      AccountId: "acc-1",
+      MessageSid: "msg-dup-routed-plan-error",
+      SessionKey: "agent:main:slack:channel:ops-room",
+      OriginatingChannel: "telegram",
+      OriginatingTo: "telegram:999",
+      To: "slack:ops-room",
+      CommandBody: "hello",
+      RawBody: "hello",
+      Body: "hello",
+    });
+    const replyResolver = vi
+      .fn<
+        (_ctx: MsgContext, _opts?: GetReplyOptions, _cfg?: OpenClawConfig) => Promise<ReplyPayload>
+      >()
+      .mockImplementationOnce(async (_ctx, opts) => {
+        await opts?.onPlanUpdate?.({
+          phase: "update",
+          steps: ["check routed destination"],
+        });
+        throw new Error("provider failed after routed plan");
+      })
+      .mockResolvedValueOnce({ text: "retry should not run" });
+
+    await expect(
+      dispatchReplyFromConfig({
+        ctx,
+        cfg,
+        dispatcher: createDispatcher(),
+        replyResolver,
+      }),
+    ).rejects.toThrow("provider failed after routed plan");
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg,
+      dispatcher: createDispatcher(),
+      replyResolver,
+    });
+
+    expect(mocks.routeReply).toHaveBeenCalledTimes(1);
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+  });
+
   it("poisons inbound dedupe when dispatch fails after a block reply", async () => {
     setNoAbort();
     const ctx = buildTestCtx({

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1670,25 +1670,27 @@ export async function dispatchReplyFromConfig(
     const sendPlanUpdate = async (payload: {
       explanation?: string;
       steps?: string[];
-    }): Promise<void> => {
+    }): Promise<boolean> => {
       if (
         shouldSuppressProgressDelivery() ||
         !shouldEmitVerboseProgress() ||
         !shouldSendVerboseProgressMessages
       ) {
-        return;
+        return false;
       }
       const text = formatPlanUpdateText(payload);
       if (!text) {
-        return;
+        return false;
       }
       const replyPayload: ReplyPayload = { text };
       if (shouldRouteToOriginating) {
         await sendPayloadAsync(replyPayload, undefined, false);
-        return;
+        markInboundDedupeReplayUnsafe();
+        return true;
       }
       markInboundDedupeReplayUnsafe();
       dispatcher.sendToolResult(replyPayload);
+      return true;
     };
     const summarizeApprovalLabel = (payload: {
       status?: string;
@@ -1921,8 +1923,11 @@ export async function dispatchReplyFromConfig(
                 return;
               }
               markProgress();
-              markInboundDedupeReplayUnsafe();
-              if (shouldForwardProgressCallback({ forwardWhenSourceDeliverySuppressed: true })) {
+              if (
+                shouldForwardProgressCallback({ forwardWhenSourceDeliverySuppressed: true }) &&
+                onPlanUpdateFromReplyOptions
+              ) {
+                markInboundDedupeReplayUnsafe();
                 await onPlanUpdateFromReplyOptions?.(payload);
               }
               if (isDispatchOperationAborted()) {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1626,6 +1626,7 @@ export async function dispatchReplyFromConfig(
 
     const toolStartStatusesSent = new Set<string>();
     let toolStartStatusCount = 0;
+    let lastSentPlanUpdateKey: string | undefined;
     const normalizeWorkingLabel = (label: string) => {
       const collapsed = label.replace(/\s+/g, " ").trim();
       if (collapsed.length <= 80) {
@@ -1633,10 +1634,21 @@ export async function dispatchReplyFromConfig(
       }
       return `${collapsed.slice(0, 77).trimEnd()}...`;
     };
+    const normalizePlanUpdateSteps = (steps: string[] | undefined) =>
+      (steps ?? []).map((step) => step.replace(/\s+/g, " ").trim()).filter(Boolean);
+    const stripPlanStatusSuffix = (step: string) =>
+      step.replace(
+        /\s+\((?:pending|in_?progress|running|completed|complete|done|failed|error|cancelled|canceled)\)$/i,
+        "",
+      );
+    const buildPlanUpdateKey = (steps: string[] | undefined) => {
+      const normalizedSteps = normalizePlanUpdateSteps(steps);
+      return normalizedSteps.length > 0
+        ? normalizedSteps.map(stripPlanStatusSuffix).join("\n")
+        : undefined;
+    };
     const formatPlanUpdateText = (payload: { steps?: string[] }) => {
-      const steps = (payload.steps ?? [])
-        .map((step) => step.replace(/\s+/g, " ").trim())
-        .filter(Boolean);
+      const steps = normalizePlanUpdateSteps(payload.steps);
       return steps.length > 0
         ? steps.map((step, index) => `${index + 1}. ${step}`).join("\n")
         : undefined;
@@ -1682,6 +1694,11 @@ export async function dispatchReplyFromConfig(
       if (!text) {
         return false;
       }
+      const planUpdateKey = buildPlanUpdateKey(payload.steps);
+      if (planUpdateKey && planUpdateKey === lastSentPlanUpdateKey) {
+        return false;
+      }
+      lastSentPlanUpdateKey = planUpdateKey;
       const replyPayload: ReplyPayload = { text };
       if (shouldRouteToOriginating) {
         await sendPayloadAsync(replyPayload, undefined, false);

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1633,19 +1633,13 @@ export async function dispatchReplyFromConfig(
       }
       return `${collapsed.slice(0, 77).trimEnd()}...`;
     };
-    const formatPlanUpdateText = (payload: { explanation?: string; steps?: string[] }) => {
-      const explanation = payload.explanation?.replace(/\s+/g, " ").trim();
+    const formatPlanUpdateText = (payload: { steps?: string[] }) => {
       const steps = (payload.steps ?? [])
         .map((step) => step.replace(/\s+/g, " ").trim())
         .filter(Boolean);
-      const parts: string[] = [];
-      if (explanation) {
-        parts.push(explanation);
-      }
-      if (steps.length > 0) {
-        parts.push(steps.map((step, index) => `${index + 1}. ${step}`).join("\n"));
-      }
-      return parts.join("\n\n").trim() || "Planning next steps.";
+      return steps.length > 0
+        ? steps.map((step, index) => `${index + 1}. ${step}`).join("\n")
+        : undefined;
     };
     const maybeSendWorkingStatus = async (label: string): Promise<void> => {
       if (shouldSuppressProgressDelivery()) {
@@ -1684,9 +1678,11 @@ export async function dispatchReplyFromConfig(
       ) {
         return;
       }
-      const replyPayload: ReplyPayload = {
-        text: formatPlanUpdateText(payload),
-      };
+      const text = formatPlanUpdateText(payload);
+      if (!text) {
+        return;
+      }
+      const replyPayload: ReplyPayload = { text };
       if (shouldRouteToOriginating) {
         await sendPayloadAsync(replyPayload, undefined, false);
         return;

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -97,6 +97,7 @@ import {
 import type { BlockReplyContext } from "../get-reply-options.types.js";
 import {
   getReplyPayloadMetadata,
+  isReplyPayloadStatusNotice,
   markReplyPayloadAsTtsSupplement,
   type ReplyPayload,
 } from "../reply-payload.js";
@@ -211,7 +212,7 @@ function formatSuppressedReplyPayloadForLog(reply: ReplyPayload): string {
 async function maybeApplyTtsToReplyPayload(
   params: Parameters<Awaited<ReturnType<typeof loadTtsRuntime>>["maybeApplyTtsToPayload"]>[0],
 ) {
-  if (params.payload.isCompactionNotice || params.payload.isFallbackNotice) {
+  if (isReplyPayloadStatusNotice(params.payload)) {
     return params.payload;
   }
   if (
@@ -2025,7 +2026,7 @@ export async function dispatchReplyFromConfig(
                 // Accumulate block text for TTS generation after streaming.
                 // Exclude status notices — they are informational UI signals
                 // and must not be synthesised into the spoken reply.
-                const isStatusNotice = payload.isCompactionNotice || payload.isFallbackNotice;
+                const isStatusNotice = isReplyPayloadStatusNotice(payload);
                 if (payload.text && !isStatusNotice) {
                   const joinsBufferedTtsDirective =
                     cleanBlockTtsDirectiveText?.hasBufferedDirectiveText() === true;

--- a/src/auto-reply/reply/reply-threading.ts
+++ b/src/auto-reply/reply/reply-threading.ts
@@ -4,7 +4,7 @@ import { normalizeAnyChannelId } from "../../channels/registry.js";
 import type { ReplyToMode } from "../../config/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { normalizeOptionalLowercaseString } from "../../shared/string-coerce.js";
-import { copyReplyPayloadMetadata } from "../reply-payload.js";
+import { copyReplyPayloadMetadata, isReplyPayloadStatusNotice } from "../reply-payload.js";
 import type { OriginatingChannelType } from "../templating.js";
 import type { ReplyPayload, ReplyThreadingPolicy } from "../types.js";
 import { isSingleUseReplyToMode } from "./reply-reference.js";
@@ -95,7 +95,7 @@ export function createReplyToModeFilter(
 ) {
   let hasThreaded = false;
   return (payload: ReplyPayload): ReplyPayload => {
-    const isStatusNotice = payload.isCompactionNotice || payload.isFallbackNotice;
+    const isStatusNotice = isReplyPayloadStatusNotice(payload);
     if (!payload.replyToId) {
       return payload;
     }


### PR DESCRIPTION
## Summary

<img width="506" height="405" alt="image" src="https://github.com/user-attachments/assets/75d3b41b-6955-41c0-885f-f3e58c39d479" />

- Adds Codex-runtime guidance so tool-requiring chat turns prepare a specific one- or two-sentence acknowledgement before work begins.
- Sends that acknowledgement before verbose plan progress in automatic source-delivery turns, while keeping verbose/full plan steps as a separate second message.
- Preserves `sourceReplyDeliveryMode: "message_tool_only"` by letting the Codex `message` tool own visible delivery when it actually sends the acknowledgement.
- Adds a guarded fallback for message-tool-only turns where Codex skips the `message` tool and goes straight to another tool, so the chat still gets the pre-tool acknowledgement.
- Suppresses repeated verbose plan-list messages when only step statuses change.

## Root Cause

Before this patch, OpenClaw could only build the pre-tool chat reply from deterministic fallback signals such as tool names or plan step labels. That made the first reply accurate about tool usage, but still too generic for real operator asks because the projector ignored the model's plan explanation and the Codex runtime prompt did not require a chat-ready, request-specific acknowledgement.

The first refinement exposed two additional delivery issues. Verbose chat sessions already rendered `explanation + numbered steps`, while the new acknowledgement path rendered the same explanation again at tool start; that produced duplicated start messages and the ordered user experience was backwards because verbose plan progress could arrive before the acknowledgement. Review also caught that automatic `onBlockReply` delivery must not bypass `message_tool_only`, where the message tool owns visible source delivery.

A later redacted live Telegram group-topic repro showed the remaining failure mode: in a `message_tool_only` turn, Codex called a non-message tool directly without first calling the `message` tool. Because the projector had suppressed automatic delivery for message-tool-only sessions, no pre-tool acknowledgement was emitted even though the turn itself completed. The fix now defers only while a source-reply `message.send` is genuinely pending; confirmed delivery suppresses duplicates, failed or unconfirmed delivery flushes a deferred fallback, and direct non-message tools get the automatic acknowledgement immediately.

## Real behavior proof

Behavior addressed: a tool-requiring chat request now gets one specific acknowledgement first; verbose/full sessions get a separate numbered plan-list message second; status-only plan changes do not resend that list; message-tool-only sessions still get a fallback acknowledgement when Codex skips the message tool.

Real environment tested: local OpenClaw checkout on Linux with this PR applied as an overlay by `oc-update --skip-codex`, using the real OpenClaw build, UI build, daemon reinstall, gateway restart, and post-update health command.

Exact steps or command run after this patch: force-pushed head `01afee79c2864d6e7c596dd0ae99666ce61b5ede`, then ran `oc-update --skip-codex` from the local OpenClaw checkout so the update flow fetched current `origin/main`, applied open PR overlays including #84534, rebuilt, reinstalled the daemon, restarted it, and ran the gateway health command.

Evidence after fix: copied terminal output from the real local update flow after the pushed head:

```text
==> Applying open PR overlays
applied: #84181 Stabilize realtime Talk turns, playback, and consults
applied: #84219 Retry app-server bridge drops safely
applied: #84534 Announce tool plans in chat replies

==> Building core
[build-all] check-cli-bootstrap-imports
CLI bootstrap import guard passed.
[build-all] runtime-postbuild
[build-all] build:plugin-sdk:dts
OK: All 4 required plugin-sdk exports verified.

==> Building UI
vite v8.0.14 building client environment for production...
✓ built in 583ms

==> Reinstalling daemon
Installed systemd service: /home/vac/.config/systemd/user/openclaw-gateway.service
Previous unit backed up to: /home/vac/.config/systemd/user/openclaw-gateway.service.bak

==> Running health check (attempt 3/3)
Discord: configured
Signal: configured
Telegram: configured
Matrix: configured
Agents: main (default), atlas, clawbench-codex
```

Observed result after fix: the local update completed with exit 0 after applying #84534 as an overlay, rebuilding the real OpenClaw runtime/UI, reinstalling the daemon, and getting a live gateway health response. The first two health attempts timed out while the gateway was coming back; the third attempt succeeded but reported unrelated local operator-environment health/audit warnings.

What was not tested: no real Beszel or Uptime Kuma credentials/endpoints were exercised; no private Telegram screenshots, recordings, message links, raw chat identifiers, or raw logs are attached to avoid exposing private identifiers; no additional autoreview pass was run after the final guard change at operator request.

## Verification

- `git diff --check origin/main...HEAD`
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-pr-84534-vitest-cache-4 node scripts/run-vitest.mjs extensions/codex/src/app-server/event-projector.test.ts extensions/codex/src/app-server/run-attempt.test.ts extensions/codex/src/app-server/thread-lifecycle.test.ts src/auto-reply/reply/block-reply-pipeline.test.ts src/auto-reply/reply/dispatch-from-config.test.ts -- --reporter=verbose` — 5 files passed, 464 tests passed
- One autoreview run after the rebase reported actionable findings for routed plan replay safety and no-block-reply plan event deferral; both were fixed before the final focused test command and push.
- `oc-update --skip-codex` — completed after applying PR #84534 as an overlay at head `01afee79c2864d6e7c596dd0ae99666ce61b5ede`; build, UI build, daemon reinstall, restart, and final health-check command completed. Local health/security output still reported unrelated operator-environment warnings.
