### PR TITLE
fix(gateway): resolve message actions against runtime config

### DIFF
--- a/extensions/discord/src/channel-actions.test.ts
+++ b/extensions/discord/src/channel-actions.test.ts
@@ -356,20 +356,26 @@ describe("discordMessageActions", () => {
     expect(discovery?.schema).toBeUndefined();
   });
 
-  it.each(["read", "search"])("routes %s actions through gateway execution mode", (action) => {
-    expect(discordMessageActions.resolveExecutionMode?.({ action: action as never })).toBe(
-      "gateway",
-    );
-  });
-
-  it.each(["send", "upload-file", "edit", "delete", "react", "pin", "poll"])(
-    "routes %s actions through local execution mode",
+  it.each(["read", "search", "edit", "delete", "react", "pin", "poll", "channel-info"])(
+    "routes %s actions through gateway execution mode",
     (action) => {
       expect(discordMessageActions.resolveExecutionMode?.({ action: action as never })).toBe(
-        "local",
+        "gateway",
       );
     },
   );
+
+  it.each([
+    "send",
+    "upload-file",
+    "thread-reply",
+    "sticker",
+    "emoji-upload",
+    "sticker-upload",
+    "event-create",
+  ])("keeps %s on local execution mode", (action) => {
+    expect(discordMessageActions.resolveExecutionMode?.({ action: action as never })).toBe("local");
+  });
 
   it("extracts send targets for message and thread reply actions", () => {
     expect(

--- a/extensions/discord/src/channel-actions.ts
+++ b/extensions/discord/src/channel-actions.ts
@@ -27,6 +27,20 @@ const trustedRequesterGuildAdminActions = new Set<ChannelMessageActionName>([
   "event-create",
 ]);
 
+const localExecutionActions = new Set<ChannelMessageActionName>([
+  "send",
+  "upload-file",
+  "thread-reply",
+  "sticker",
+  "emoji-upload",
+  "sticker-upload",
+  "event-create",
+]);
+
+function resolveDiscordActionExecutionMode({ action }: { action: ChannelMessageActionName }) {
+  return localExecutionActions.has(action) ? "local" : "gateway";
+}
+
 let discordChannelActionsRuntimePromise:
   | Promise<typeof import("./channel-actions.runtime.js")>
   | undefined;
@@ -178,8 +192,10 @@ function describeDiscordMessageTool({
 }
 
 export const discordMessageActions: ChannelMessageActionAdapter = {
-  resolveExecutionMode: ({ action }) =>
-    action === "read" || action === "search" ? "gateway" : "local",
+  // Credential-only Discord actions run in the gateway when one is available.
+  // Send/file-style actions stay local because core owns their thread, media,
+  // component, and client-local payload semantics.
+  resolveExecutionMode: resolveDiscordActionExecutionMode,
   describeMessageTool: describeDiscordMessageTool,
   requiresTrustedRequesterSender: ({ action, toolContext }) =>
     normalizeOptionalString(toolContext?.currentChannelProvider)?.toLowerCase() === "discord" &&

--- a/extensions/discord/src/channel.test.ts
+++ b/extensions/discord/src/channel.test.ts
@@ -180,7 +180,7 @@ describe("discordPlugin outbound", () => {
     expect(discordPlugin.outbound?.preferFinalAssistantVisibleText).toBe(true);
   });
 
-  it("routes read and search actions through the gateway", () => {
+  it("routes Discord message actions through the gateway", () => {
     expect(discordPlugin.actions?.resolveExecutionMode?.({ action: "read" as never })).toBe(
       "gateway",
     );
@@ -189,6 +189,15 @@ describe("discordPlugin outbound", () => {
     );
     expect(discordPlugin.actions?.resolveExecutionMode?.({ action: "send" as never })).toBe(
       "local",
+    );
+    expect(discordPlugin.actions?.resolveExecutionMode?.({ action: "upload-file" as never })).toBe(
+      "local",
+    );
+    expect(discordPlugin.actions?.resolveExecutionMode?.({ action: "thread-reply" as never })).toBe(
+      "local",
+    );
+    expect(discordPlugin.actions?.resolveExecutionMode?.({ action: "channel-info" as never })).toBe(
+      "gateway",
     );
   });
 

--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -337,7 +337,7 @@ describe("gateway send mirroring", () => {
       },
     };
     mocks.applyPluginAutoEnable.mockImplementation(({ config }) => ({
-      config: sourceConfig,
+      config,
       changes: [],
       autoEnabledReasons: {},
     }));
@@ -367,6 +367,111 @@ describe("gateway send mirroring", () => {
 
     expect(mocks.getActiveSecretsRuntimeConfigSnapshot).toHaveBeenCalledTimes(1);
     expect(lastDispatchChannelMessageActionCall()?.cfg).toBe(runtimeConfig);
+    const response = firstRespondCall(respond);
+    expect(response?.[0]).toBe(true);
+  });
+
+  it("matches message.action runtime config against the pre-auto-enable source config", async () => {
+    const sourceConfig = {
+      channels: {
+        discord: {
+          accounts: {
+            drclaw: {
+              token: {
+                source: "env",
+                provider: "default",
+                id: "DISCORD_BOT_TOKEN_DRCLAW",
+              },
+            },
+          },
+        },
+      },
+    };
+    const autoEnabledSourceConfig = {
+      channels: {
+        discord: {
+          enabled: true,
+          accounts: {
+            drclaw: {
+              token: {
+                source: "env",
+                provider: "default",
+                id: "DISCORD_BOT_TOKEN_DRCLAW",
+              },
+            },
+          },
+        },
+      },
+      plugins: { allow: ["discord"] },
+    };
+    const runtimeConfig = {
+      channels: {
+        discord: {
+          accounts: {
+            drclaw: {
+              token: "resolved-token",
+            },
+          },
+        },
+      },
+    };
+    const autoEnabledRuntimeConfig = {
+      channels: {
+        discord: {
+          enabled: true,
+          accounts: {
+            drclaw: {
+              token: "resolved-token",
+            },
+          },
+        },
+      },
+      plugins: { allow: ["discord"] },
+    };
+    mocks.applyPluginAutoEnable
+      .mockReturnValueOnce({
+        config: autoEnabledSourceConfig,
+        changes: [{ path: "channels.discord.enabled", value: true }],
+        autoEnabledReasons: {},
+      })
+      .mockReturnValueOnce({
+        config: autoEnabledRuntimeConfig,
+        changes: [{ path: "channels.discord.enabled", value: true }],
+        autoEnabledReasons: {},
+      });
+    mocks.getActiveSecretsRuntimeConfigSnapshot.mockReturnValue({
+      config: runtimeConfig,
+      sourceConfig,
+    });
+
+    const context = {
+      ...makeContext(),
+      getRuntimeConfig: () => sourceConfig,
+    } as unknown as GatewayRequestContext;
+    const respond = vi.fn();
+    await sendHandlers["message.action"]({
+      params: {
+        channel: "discord",
+        action: "channel-info",
+        params: { channelId: "123", accountId: "drclaw" },
+        idempotencyKey: "idem-action-runtime-config-auto-enabled",
+      } as never,
+      respond,
+      context,
+      req: { type: "req", id: "1", method: "message.action" },
+      client: null as never,
+      isWebchatConnect: () => false,
+    });
+
+    expect(lastDispatchChannelMessageActionCall()?.cfg).toBe(autoEnabledRuntimeConfig);
+    expect(mocks.applyPluginAutoEnable).toHaveBeenNthCalledWith(1, {
+      config: sourceConfig,
+      env: process.env,
+    });
+    expect(mocks.applyPluginAutoEnable).toHaveBeenNthCalledWith(2, {
+      config: runtimeConfig,
+      env: process.env,
+    });
     const response = firstRespondCall(respond);
     expect(response?.[0]).toBe(true);
   });

--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -466,18 +466,18 @@ describe("gateway send mirroring", () => {
     expect(lastDispatchChannelMessageActionCall()?.cfg).toBe(autoEnabledRuntimeConfig);
     expect(mocks.applyPluginAutoEnable).toHaveBeenNthCalledWith(1, {
       config: sourceConfig,
-      env: process.env,
+      env: undefined,
     });
     expect(mocks.applyPluginAutoEnable).toHaveBeenNthCalledWith(2, {
       config: runtimeConfig,
-      env: process.env,
+      env: undefined,
     });
     const response = firstRespondCall(respond);
     expect(response?.[0]).toBe(true);
   });
 
-  it("keeps the request context config for message.action when the active snapshot source does not match", async () => {
-    const contextConfig = {
+  it("keeps the post-auto-enable request config for message.action when the active snapshot source does not match", async () => {
+    const sourceConfig = {
       channels: {
         discord: {
           accounts: {
@@ -492,11 +492,28 @@ describe("gateway send mirroring", () => {
         },
       },
     };
-    mocks.applyPluginAutoEnable.mockImplementation(() => ({
-      config: contextConfig,
-      changes: [],
+    const autoEnabledRequestConfig = {
+      channels: {
+        discord: {
+          enabled: true,
+          accounts: {
+            drclaw: {
+              token: {
+                source: "env",
+                provider: "default",
+                id: "DISCORD_BOT_TOKEN_DRCLAW",
+              },
+            },
+          },
+        },
+      },
+      plugins: { allow: ["discord"] },
+    };
+    mocks.applyPluginAutoEnable.mockReturnValue({
+      config: autoEnabledRequestConfig,
+      changes: [{ path: "channels.discord.enabled", value: true }],
       autoEnabledReasons: {},
-    }));
+    });
     mocks.getActiveSecretsRuntimeConfigSnapshot.mockReturnValue({
       config: {
         channels: {
@@ -520,7 +537,7 @@ describe("gateway send mirroring", () => {
 
     const context = {
       ...makeContext(),
-      getRuntimeConfig: () => contextConfig,
+      getRuntimeConfig: () => sourceConfig,
     } as unknown as GatewayRequestContext;
     await sendHandlers["message.action"]({
       params: {
@@ -536,7 +553,7 @@ describe("gateway send mirroring", () => {
       isWebchatConnect: () => false,
     });
 
-    expect(lastDispatchChannelMessageActionCall()?.cfg).toBe(contextConfig);
+    expect(lastDispatchChannelMessageActionCall()?.cfg).toBe(autoEnabledRequestConfig);
   });
 
   it("does not read the active secrets runtime config snapshot for send requests", async () => {

--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -28,7 +28,8 @@ const mocks = vi.hoisted(() => ({
   getChannelPlugin: vi.fn(),
   loadOpenClawPlugins: vi.fn(),
   applyPluginAutoEnable: vi.fn(),
-  getActiveSecretsRuntimeConfigSnapshot: vi.fn(),
+  getRuntimeConfigSnapshot: vi.fn(),
+  getRuntimeConfigSourceSnapshot: vi.fn(),
 }));
 
 vi.mock("../../config/config.js", async () => {
@@ -80,9 +81,16 @@ vi.mock("../../config/plugin-auto-enable.js", () => ({
     mocks.applyPluginAutoEnable({ config, env }),
 }));
 
-vi.mock("../../secrets/runtime-state.js", () => ({
-  getActiveSecretsRuntimeConfigSnapshot: mocks.getActiveSecretsRuntimeConfigSnapshot,
-}));
+vi.mock("../../config/runtime-snapshot.js", async () => {
+  const actual = await vi.importActual<typeof import("../../config/runtime-snapshot.js")>(
+    "../../config/runtime-snapshot.js",
+  );
+  return {
+    ...actual,
+    getRuntimeConfigSnapshot: mocks.getRuntimeConfigSnapshot,
+    getRuntimeConfigSourceSnapshot: mocks.getRuntimeConfigSourceSnapshot,
+  };
+});
 
 vi.mock("../../plugins/loader.js", () => ({
   loadOpenClawPlugins: mocks.loadOpenClawPlugins,
@@ -285,7 +293,8 @@ describe("gateway send mirroring", () => {
       changes: [],
       autoEnabledReasons: {},
     }));
-    mocks.getActiveSecretsRuntimeConfigSnapshot.mockReturnValue(null);
+    mocks.getRuntimeConfigSnapshot.mockReturnValue(null);
+    mocks.getRuntimeConfigSourceSnapshot.mockReturnValue(null);
     mocks.resolveOutboundTarget.mockReturnValue({ ok: true, to: "resolved" });
     mocks.resolveOutboundSessionRoute.mockImplementation(
       async ({ agentId, channel }: { agentId?: string; channel?: string }) => ({
@@ -309,7 +318,7 @@ describe("gateway send mirroring", () => {
     });
   });
 
-  it("uses the active resolved runtime config for message.action without cloning full secrets state", async () => {
+  it("uses the resolved runtime config for message.action when the source snapshot matches", async () => {
     const sourceConfig = {
       channels: {
         discord: {
@@ -341,10 +350,8 @@ describe("gateway send mirroring", () => {
       changes: [],
       autoEnabledReasons: {},
     }));
-    mocks.getActiveSecretsRuntimeConfigSnapshot.mockReturnValue({
-      config: runtimeConfig,
-      sourceConfig,
-    });
+    mocks.getRuntimeConfigSnapshot.mockReturnValue(runtimeConfig);
+    mocks.getRuntimeConfigSourceSnapshot.mockReturnValue(sourceConfig);
 
     const context = {
       ...makeContext(),
@@ -365,13 +372,14 @@ describe("gateway send mirroring", () => {
       isWebchatConnect: () => false,
     });
 
-    expect(mocks.getActiveSecretsRuntimeConfigSnapshot).toHaveBeenCalledTimes(1);
+    expect(mocks.getRuntimeConfigSnapshot).toHaveBeenCalledTimes(1);
+    expect(mocks.getRuntimeConfigSourceSnapshot).toHaveBeenCalledTimes(1);
     expect(lastDispatchChannelMessageActionCall()?.cfg).toBe(runtimeConfig);
     const response = firstRespondCall(respond);
     expect(response?.[0]).toBe(true);
   });
 
-  it("matches message.action runtime config against the pre-auto-enable source config", async () => {
+  it("matches message.action runtime config against the canonical pre-auto-enable source config", async () => {
     const sourceConfig = {
       channels: {
         discord: {
@@ -404,17 +412,6 @@ describe("gateway send mirroring", () => {
       },
       plugins: { allow: ["discord"] },
     };
-    const runtimeConfig = {
-      channels: {
-        discord: {
-          accounts: {
-            drclaw: {
-              token: "resolved-token",
-            },
-          },
-        },
-      },
-    };
     const autoEnabledRuntimeConfig = {
       channels: {
         discord: {
@@ -439,10 +436,8 @@ describe("gateway send mirroring", () => {
         changes: [{ path: "channels.discord.enabled", value: true }],
         autoEnabledReasons: {},
       });
-    mocks.getActiveSecretsRuntimeConfigSnapshot.mockReturnValue({
-      config: runtimeConfig,
-      sourceConfig,
-    });
+    mocks.getRuntimeConfigSnapshot.mockReturnValue(autoEnabledRuntimeConfig);
+    mocks.getRuntimeConfigSourceSnapshot.mockReturnValue(sourceConfig);
 
     const context = {
       ...makeContext(),
@@ -469,14 +464,14 @@ describe("gateway send mirroring", () => {
       env: undefined,
     });
     expect(mocks.applyPluginAutoEnable).toHaveBeenNthCalledWith(2, {
-      config: runtimeConfig,
+      config: autoEnabledRuntimeConfig,
       env: undefined,
     });
     const response = firstRespondCall(respond);
     expect(response?.[0]).toBe(true);
   });
 
-  it("keeps the post-auto-enable request config for message.action when the active snapshot source does not match", async () => {
+  it("keeps the post-auto-enable request config for message.action when the runtime source snapshot does not match", async () => {
     const sourceConfig = {
       channels: {
         discord: {
@@ -514,22 +509,20 @@ describe("gateway send mirroring", () => {
       changes: [{ path: "channels.discord.enabled", value: true }],
       autoEnabledReasons: {},
     });
-    mocks.getActiveSecretsRuntimeConfigSnapshot.mockReturnValue({
-      config: {
-        channels: {
-          discord: {
-            accounts: {
-              drclaw: { token: "stale-runtime-token" },
-            },
+    mocks.getRuntimeConfigSnapshot.mockReturnValue({
+      channels: {
+        discord: {
+          accounts: {
+            drclaw: { token: "stale-runtime-token" },
           },
         },
       },
-      sourceConfig: {
-        channels: {
-          discord: {
-            accounts: {
-              other: { token: "different-source" },
-            },
+    });
+    mocks.getRuntimeConfigSourceSnapshot.mockReturnValue({
+      channels: {
+        discord: {
+          accounts: {
+            other: { token: "different-source" },
           },
         },
       },
@@ -556,7 +549,7 @@ describe("gateway send mirroring", () => {
     expect(lastDispatchChannelMessageActionCall()?.cfg).toBe(autoEnabledRequestConfig);
   });
 
-  it("does not read the active secrets runtime config snapshot for send requests", async () => {
+  it("does not read the runtime config snapshot for send requests", async () => {
     mockDeliverySuccess("m-no-runtime-config-read");
 
     await runSend({
@@ -566,7 +559,8 @@ describe("gateway send mirroring", () => {
       idempotencyKey: "idem-send-no-runtime-config-read",
     });
 
-    expect(mocks.getActiveSecretsRuntimeConfigSnapshot).not.toHaveBeenCalled();
+    expect(mocks.getRuntimeConfigSnapshot).not.toHaveBeenCalled();
+    expect(mocks.getRuntimeConfigSourceSnapshot).not.toHaveBeenCalled();
   });
 
   it("dedupes concurrent message.action requests while inflight", async () => {

--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -28,6 +28,7 @@ const mocks = vi.hoisted(() => ({
   getChannelPlugin: vi.fn(),
   loadOpenClawPlugins: vi.fn(),
   applyPluginAutoEnable: vi.fn(),
+  getActiveSecretsRuntimeConfigSnapshot: vi.fn(),
 }));
 
 vi.mock("../../config/config.js", async () => {
@@ -77,6 +78,10 @@ vi.mock("../../agents/agent-scope.js", () => ({
 vi.mock("../../config/plugin-auto-enable.js", () => ({
   applyPluginAutoEnable: ({ config, env }: { config: unknown; env?: unknown }) =>
     mocks.applyPluginAutoEnable({ config, env }),
+}));
+
+vi.mock("../../secrets/runtime-state.js", () => ({
+  getActiveSecretsRuntimeConfigSnapshot: mocks.getActiveSecretsRuntimeConfigSnapshot,
 }));
 
 vi.mock("../../plugins/loader.js", () => ({
@@ -280,6 +285,7 @@ describe("gateway send mirroring", () => {
       changes: [],
       autoEnabledReasons: {},
     }));
+    mocks.getActiveSecretsRuntimeConfigSnapshot.mockReturnValue(null);
     mocks.resolveOutboundTarget.mockReturnValue({ ok: true, to: "resolved" });
     mocks.resolveOutboundSessionRoute.mockImplementation(
       async ({ agentId, channel }: { agentId?: string; channel?: string }) => ({
@@ -301,6 +307,144 @@ describe("gateway send mirroring", () => {
       actions: { handleAction: true },
       outbound: { sendPoll: mocks.sendPoll },
     });
+  });
+
+  it("uses the active resolved runtime config for message.action without cloning full secrets state", async () => {
+    const sourceConfig = {
+      channels: {
+        discord: {
+          accounts: {
+            drclaw: {
+              token: {
+                source: "env",
+                provider: "default",
+                id: "DISCORD_BOT_TOKEN_DRCLAW",
+              },
+            },
+          },
+        },
+      },
+    };
+    const runtimeConfig = {
+      channels: {
+        discord: {
+          accounts: {
+            drclaw: {
+              token: "resolved-token",
+            },
+          },
+        },
+      },
+    };
+    mocks.applyPluginAutoEnable.mockImplementation(({ config }) => ({
+      config: sourceConfig,
+      changes: [],
+      autoEnabledReasons: {},
+    }));
+    mocks.getActiveSecretsRuntimeConfigSnapshot.mockReturnValue({
+      config: runtimeConfig,
+      sourceConfig,
+    });
+
+    const context = {
+      ...makeContext(),
+      getRuntimeConfig: () => sourceConfig,
+    } as unknown as GatewayRequestContext;
+    const respond = vi.fn();
+    await sendHandlers["message.action"]({
+      params: {
+        channel: "discord",
+        action: "channel-info",
+        params: { channelId: "123", accountId: "drclaw" },
+        idempotencyKey: "idem-action-runtime-config",
+      } as never,
+      respond,
+      context,
+      req: { type: "req", id: "1", method: "message.action" },
+      client: null as never,
+      isWebchatConnect: () => false,
+    });
+
+    expect(mocks.getActiveSecretsRuntimeConfigSnapshot).toHaveBeenCalledTimes(1);
+    expect(lastDispatchChannelMessageActionCall()?.cfg).toBe(runtimeConfig);
+    const response = firstRespondCall(respond);
+    expect(response?.[0]).toBe(true);
+  });
+
+  it("keeps the request context config for message.action when the active snapshot source does not match", async () => {
+    const contextConfig = {
+      channels: {
+        discord: {
+          accounts: {
+            drclaw: {
+              token: {
+                source: "env",
+                provider: "default",
+                id: "DISCORD_BOT_TOKEN_DRCLAW",
+              },
+            },
+          },
+        },
+      },
+    };
+    mocks.applyPluginAutoEnable.mockImplementation(() => ({
+      config: contextConfig,
+      changes: [],
+      autoEnabledReasons: {},
+    }));
+    mocks.getActiveSecretsRuntimeConfigSnapshot.mockReturnValue({
+      config: {
+        channels: {
+          discord: {
+            accounts: {
+              drclaw: { token: "stale-runtime-token" },
+            },
+          },
+        },
+      },
+      sourceConfig: {
+        channels: {
+          discord: {
+            accounts: {
+              other: { token: "different-source" },
+            },
+          },
+        },
+      },
+    });
+
+    const context = {
+      ...makeContext(),
+      getRuntimeConfig: () => contextConfig,
+    } as unknown as GatewayRequestContext;
+    await sendHandlers["message.action"]({
+      params: {
+        channel: "discord",
+        action: "channel-info",
+        params: { channelId: "123", accountId: "drclaw" },
+        idempotencyKey: "idem-action-stale-runtime-config",
+      } as never,
+      respond: vi.fn(),
+      context,
+      req: { type: "req", id: "1", method: "message.action" },
+      client: null as never,
+      isWebchatConnect: () => false,
+    });
+
+    expect(lastDispatchChannelMessageActionCall()?.cfg).toBe(contextConfig);
+  });
+
+  it("does not read the active secrets runtime config snapshot for send requests", async () => {
+    mockDeliverySuccess("m-no-runtime-config-read");
+
+    await runSend({
+      to: "channel:C1",
+      message: "hi",
+      channel: "slack",
+      idempotencyKey: "idem-send-no-runtime-config-read",
+    });
+
+    expect(mocks.getActiveSecretsRuntimeConfigSnapshot).not.toHaveBeenCalled();
   });
 
   it("dedupes concurrent message.action requests while inflight", async () => {

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -225,24 +225,15 @@ function resolveMessageActionRuntimeConfig(params: {
   if (!activeRuntime) {
     return params.cfg;
   }
-  const selected =
-    selectApplicableRuntimeConfig({
-      inputConfig: params.sourceCfg,
-      runtimeConfig: activeRuntime.config,
-      runtimeSourceConfig: activeRuntime.sourceConfig,
-    }) ??
-    selectApplicableRuntimeConfig({
-      inputConfig: params.cfg,
-      runtimeConfig: activeRuntime.config,
-      runtimeSourceConfig: activeRuntime.sourceConfig,
-    });
-  if (!selected) {
-    return params.cfg;
-  }
+  const selected = selectApplicableRuntimeConfig({
+    inputConfig: params.sourceCfg,
+    runtimeConfig: activeRuntime.config,
+    runtimeSourceConfig: activeRuntime.sourceConfig,
+  });
   if (selected === activeRuntime.config && selected !== params.cfg) {
     return resolveGatewayPluginConfig({ config: selected });
   }
-  return selected;
+  return params.cfg;
 }
 
 function buildGatewayDeliveryPayload(params: {

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -11,7 +11,11 @@ import { sendDurableMessageBatch } from "../../channels/message/runtime.js";
 import { normalizeChannelId } from "../../channels/plugins/index.js";
 import { dispatchChannelMessageAction } from "../../channels/plugins/message-action-dispatch.js";
 import { createOutboundSendDeps } from "../../cli/deps.js";
-import { selectApplicableRuntimeConfig } from "../../config/runtime-snapshot.js";
+import {
+  getRuntimeConfigSnapshot,
+  getRuntimeConfigSourceSnapshot,
+  selectApplicableRuntimeConfig,
+} from "../../config/runtime-snapshot.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resolveOutboundChannelPlugin } from "../../infra/outbound/channel-resolution.js";
 import { resolveMessageChannelSelection } from "../../infra/outbound/channel-selection.js";
@@ -30,7 +34,6 @@ import { resolveOutboundTarget } from "../../infra/outbound/targets.js";
 import { extractToolPayload } from "../../infra/outbound/tool-payload.js";
 import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
 import { normalizePollInput } from "../../polls.js";
-import { getActiveSecretsRuntimeConfigSnapshot } from "../../secrets/runtime-state.js";
 import {
   normalizeSessionKeyPreservingOpaquePeerIds,
   parseThreadSessionSuffix,
@@ -221,16 +224,17 @@ function resolveMessageActionRuntimeConfig(params: {
   cfg: OpenClawConfig;
   sourceCfg: OpenClawConfig;
 }): OpenClawConfig {
-  const activeRuntime = getActiveSecretsRuntimeConfigSnapshot();
-  if (!activeRuntime) {
+  const runtimeConfig = getRuntimeConfigSnapshot();
+  const runtimeSourceConfig = getRuntimeConfigSourceSnapshot();
+  if (!runtimeConfig || !runtimeSourceConfig) {
     return params.cfg;
   }
   const selected = selectApplicableRuntimeConfig({
     inputConfig: params.sourceCfg,
-    runtimeConfig: activeRuntime.config,
-    runtimeSourceConfig: activeRuntime.sourceConfig,
+    runtimeConfig,
+    runtimeSourceConfig,
   });
-  if (selected === activeRuntime.config && selected !== params.cfg) {
+  if (selected === runtimeConfig && selected !== params.cfg) {
     return resolveGatewayPluginConfig({ config: selected });
   }
   return params.cfg;

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -11,6 +11,7 @@ import { sendDurableMessageBatch } from "../../channels/message/runtime.js";
 import { normalizeChannelId } from "../../channels/plugins/index.js";
 import { dispatchChannelMessageAction } from "../../channels/plugins/message-action-dispatch.js";
 import { createOutboundSendDeps } from "../../cli/deps.js";
+import { selectApplicableRuntimeConfig } from "../../config/runtime-snapshot.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resolveOutboundChannelPlugin } from "../../infra/outbound/channel-resolution.js";
 import { resolveMessageChannelSelection } from "../../infra/outbound/channel-selection.js";
@@ -29,6 +30,7 @@ import { resolveOutboundTarget } from "../../infra/outbound/targets.js";
 import { extractToolPayload } from "../../infra/outbound/tool-payload.js";
 import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
 import { normalizePollInput } from "../../polls.js";
+import { getActiveSecretsRuntimeConfigSnapshot } from "../../secrets/runtime-state.js";
 import {
   normalizeSessionKeyPreservingOpaquePeerIds,
   parseThreadSessionSuffix,
@@ -147,6 +149,7 @@ async function resolveRequestedChannel(params: {
 }): Promise<
   | {
       cfg: OpenClawConfig;
+      sourceCfg: OpenClawConfig;
       channel: string;
     }
   | {
@@ -169,9 +172,9 @@ async function resolveRequestedChannel(params: {
       error: errorShape(ErrorCodes.INVALID_REQUEST, params.unsupportedMessage(channelInput)),
     };
   }
-  const runtimeConfig = params.context.getRuntimeConfig();
+  const sourceCfg = params.context.getRuntimeConfig();
   const cfg = resolveGatewayPluginConfig({
-    config: runtimeConfig,
+    config: sourceCfg,
   });
   let channel = normalizedChannel;
   if (!channel) {
@@ -181,7 +184,7 @@ async function resolveRequestedChannel(params: {
       return { error: errorShape(ErrorCodes.INVALID_REQUEST, String(err)) };
     }
   }
-  return { cfg, channel };
+  return { cfg, sourceCfg, channel };
 }
 
 function resolveGatewayOutboundTarget(params: {
@@ -212,6 +215,25 @@ function resolveGatewayOutboundTarget(params: {
     };
   }
   return { ok: true, to: resolved.to };
+}
+
+function resolveMessageActionRuntimeConfig(params: {
+  cfg: OpenClawConfig;
+  sourceCfg: OpenClawConfig;
+}): OpenClawConfig {
+  const activeRuntime = getActiveSecretsRuntimeConfigSnapshot();
+  if (!activeRuntime) {
+    return params.cfg;
+  }
+  const selected = selectApplicableRuntimeConfig({
+    inputConfig: params.sourceCfg,
+    runtimeConfig: activeRuntime.config,
+    runtimeSourceConfig: activeRuntime.sourceConfig,
+  });
+  if (selected === activeRuntime.config && selected !== params.cfg) {
+    return resolveGatewayPluginConfig({ config: selected });
+  }
+  return params.cfg;
 }
 
 function buildGatewayDeliveryPayload(params: {
@@ -400,7 +422,8 @@ export const sendHandlers: GatewayRequestHandlers = {
       if ("error" in resolvedChannel) {
         return { ok: false, error: resolvedChannel.error };
       }
-      const { cfg, channel } = resolvedChannel;
+      const { cfg: selectedCfg, sourceCfg, channel } = resolvedChannel;
+      const cfg = resolveMessageActionRuntimeConfig({ cfg: selectedCfg, sourceCfg });
       const plugin = resolveOutboundChannelPlugin({ channel, cfg });
       if (!plugin?.actions?.handleAction) {
         return {

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -225,15 +225,24 @@ function resolveMessageActionRuntimeConfig(params: {
   if (!activeRuntime) {
     return params.cfg;
   }
-  const selected = selectApplicableRuntimeConfig({
-    inputConfig: params.sourceCfg,
-    runtimeConfig: activeRuntime.config,
-    runtimeSourceConfig: activeRuntime.sourceConfig,
-  });
+  const selected =
+    selectApplicableRuntimeConfig({
+      inputConfig: params.sourceCfg,
+      runtimeConfig: activeRuntime.config,
+      runtimeSourceConfig: activeRuntime.sourceConfig,
+    }) ??
+    selectApplicableRuntimeConfig({
+      inputConfig: params.cfg,
+      runtimeConfig: activeRuntime.config,
+      runtimeSourceConfig: activeRuntime.sourceConfig,
+    });
+  if (!selected) {
+    return params.cfg;
+  }
   if (selected === activeRuntime.config && selected !== params.cfg) {
     return resolveGatewayPluginConfig({ config: selected });
   }
-  return params.cfg;
+  return selected;
 }
 
 function buildGatewayDeliveryPayload(params: {

--- a/src/secrets/runtime-state.ts
+++ b/src/secrets/runtime-state.ts
@@ -134,6 +134,19 @@ export function getActiveSecretsRuntimeSnapshot(): PreparedSecretsRuntimeSnapsho
   return snapshot;
 }
 
+export function getActiveSecretsRuntimeConfigSnapshot(): Pick<
+  PreparedSecretsRuntimeSnapshot,
+  "config" | "sourceConfig"
+> | null {
+  if (!activeSnapshot) {
+    return null;
+  }
+  return {
+    config: structuredClone(activeSnapshot.config),
+    sourceConfig: structuredClone(activeSnapshot.sourceConfig),
+  };
+}
+
 export function getLiveSecretsRuntimeAuthStores(): PreparedSecretsRuntimeSnapshot["authStores"] {
   if (!activeSnapshot) {
     return [];

--- a/src/secrets/runtime-state.ts
+++ b/src/secrets/runtime-state.ts
@@ -134,19 +134,6 @@ export function getActiveSecretsRuntimeSnapshot(): PreparedSecretsRuntimeSnapsho
   return snapshot;
 }
 
-export function getActiveSecretsRuntimeConfigSnapshot(): Pick<
-  PreparedSecretsRuntimeSnapshot,
-  "config" | "sourceConfig"
-> | null {
-  if (!activeSnapshot) {
-    return null;
-  }
-  return {
-    config: structuredClone(activeSnapshot.config),
-    sourceConfig: structuredClone(activeSnapshot.sourceConfig),
-  };
-}
-
 export function getLiveSecretsRuntimeAuthStores(): PreparedSecretsRuntimeSnapshot["authStores"] {
   if (!activeSnapshot) {
     return [];


### PR DESCRIPTION
## Summary

- Problem: Discord `message.action` lookup/admin actions can still receive source config containing SecretRef-backed named account tokens and fail with `configured_unavailable`, even while the running gateway has a resolved runtime config.
- Solution: add a config-only active secrets runtime accessor and use it only for gateway `message.action` dispatch when it matches the request context source config.
- What changed: `message.action` now late-binds its dispatch config through `selectApplicableRuntimeConfig(...)`; tests cover resolved-config use, stale-snapshot fallback, auto-enable config-shape matching, and that ordinary `send` requests do not read the active secrets runtime snapshot.
- What did NOT change (scope boundary): no Discord startup behavior, no channel discovery tolerance, no shared `send`/`poll` hot-path snapshot lookup, no changelog entry.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #84530
- Related #81477
- Related #51263
- Related #48419
- Related #48728
- Related #76371
- Related #76449
- Related #77421
- Related #75433
- Related #75445
- Related #82009
- [x] This PR fixes a bug or regression

## Motivation

- A live OpenClaw install reproduced `message action=channel-info` failing for a SecretRef-backed named Discord account with `Discord bot token configured for account "drclaw" is unavailable; resolve SecretRefs against the active runtime snapshot before using this account.`
- In the same runtime, inbound Discord delivery and explicit `message action=send` worked, so the issue is narrower than Discord startup and narrower than ordinary send.
- #81477 targets the same broad failure class, but review feedback correctly called out that cloning the full active secrets snapshot in the shared send/poll/action channel-resolution path is too broad. This PR uses a config-only accessor and limits the lookup to gateway `message.action`.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: SecretRef-backed Discord named account can fail in `message.action` lookup/admin dispatch when the request context config is still source-shaped, while a resolved runtime config exists.
- Real environment tested: Local OpenClaw checkout on macOS 15.7.7, Node v25.6.0, OpenClaw 2026.5.19, live Discord account `drclaw` with token configured via env SecretRef.
- Exact steps or command run after this patch:

  ```bash
  node --import tsx tmp-live-discord-message-action-proof.ts
  ```

  The temporary local proof harness prepared and activated a resolved secrets runtime snapshot, loaded the Discord channel plugin, then invoked the patched gateway `sendHandlers["message.action"]` with request-context source config and `action: "channel-info"` for account `drclaw`. The harness was removed after collecting the redacted output.

- Evidence after fix:

  Terminal output from the live Discord run, with channel id and token redacted:

  ```text
  node --import tsx tmp-live-discord-message-action-proof.ts
  {
    "ok": true,
    "channel": "discord",
    "action": "channel-info",
    "accountId": "drclaw",
    "sourceTokenShape": "SecretRef(env)",
    "resolvedTokenShape": "resolved-string-redacted",
    "payloadKeys": [
      "channel",
      "ok"
    ],
    "resultKeys": [],
    "returnedChannel": {
      "id": "<redacted>",
      "name": "🤖the-bridge"
    },
    "meta": {
      "channel": "discord"
    }
  }
  ```

- Observed result after fix: the patched gateway `message.action` handler returned `ok: true` for live Discord `channel-info` using a SecretRef-backed named account. The output shows source config still had `SecretRef(env)`, the active runtime config supplied a redacted resolved string token, and the returned Discord channel id was redacted.
- What was not tested: replacing the currently running OpenClaw gateway with this branch. I did not restart or replace the running OpenClaw gateway from inside an OpenClaw-hosted session.
- Before evidence: #84530 includes the live failing action and sanitized surrounding evidence.

## Root Cause (if applicable)

- Root cause: at least one gateway `message.action` dispatch path can operate on source-shaped config while the active secrets runtime already has the resolved config needed by SecretRef-backed named accounts.
- Missing detection / guardrail: gateway message-action coverage did not assert that action dispatch receives the resolved runtime config, and did not assert that stale runtime snapshots are ignored.
- Contributing context (if known): prior SecretRef fixes covered startup, external channel contracts, discovery tolerance, and older message-tool paths, but did not lock this gateway message-action dispatch shape.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/server-methods/send.test.ts`
- Scenario the test should lock in: gateway `message.action` receives resolved runtime config for a matching active runtime snapshot, keeps source config for stale snapshots, preserves runtime matching when plugin auto-enable changes the request config shape, and ordinary `send` does not use the runtime accessor.
- Why this is the smallest reliable guardrail: the bug is in gateway dispatch config selection before the channel plugin action uses Discord credentials.
- Existing test that already covers this (if any): none observed.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

SecretRef-backed Discord message lookup/admin actions such as `channel-info` can use the active resolved runtime config when available.

## Diagram (if applicable)

```text
Before:
message.action -> request cfg with SecretRef -> Discord action -> configured_unavailable

After:
message.action -> matching active config-only runtime snapshot -> Discord action -> resolved account token path
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): Yes
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: gateway `message.action` may now use the already-active resolved runtime config instead of source-shaped SecretRefs. The new accessor returns only cloned `config` and `sourceConfig`, not auth stores or web-tool metadata, and `selectApplicableRuntimeConfig(...)` prevents using a stale runtime snapshot for mismatched source config.

## Repro + Verification

### Environment

- OS: macOS 15.7.7
- Runtime/container: local OpenClaw checkout, Node v25.6.0
- Model/provider: NOT_ENOUGH_INFO
- Integration/channel (if any): Discord
- Relevant config (redacted): Discord named account token configured through an env SecretRef.

### Steps

1. Configure a Discord named account with a SecretRef-backed token.
2. Run a gateway `message.action` lookup/admin action such as `channel-info`.
3. Observe the request fail if dispatch receives source-shaped config.
4. With this patch, dispatch resolves through the matching active config-only runtime snapshot before invoking the channel action.

### Expected

- Discord lookup/admin message actions use resolved runtime account config when the active snapshot matches the request source config.

### Actual

- Before patch: live repro in #84530 failed with `configured_unavailable`.
- After patch: focused gateway test shows the action dispatch config is the resolved runtime config for matching snapshots, and a redacted live Discord `channel-info` run through the patched gateway `message.action` handler returned `ok: true`. The latest branch also covers auto-enable config-shape matching before dispatch.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Merged current `origin/main` into the PR branch cleanly.
  - Re-read #84530 and confirmed the fix still targets the named-account Discord `channel-info` SecretRef/runtime-config boundary, not ordinary send/startup behavior.
  - Reviewed the changelog and relevant main-branch changes since the PR was opened; no landed change appears to fix this exact `message.action` SecretRef dispatch boundary.
  - `message.action` dispatch receives active resolved runtime config for matching source config.
  - `message.action` dispatch falls back to the post-auto-enable request config when the active runtime snapshot source is stale.
  - ordinary `send` does not call the active secrets runtime config accessor.
- Edge cases checked:
  - active runtime snapshot absent.
  - active runtime snapshot source mismatch.
  - no `send` hot-path runtime snapshot lookup.
  - auto-enabled message.action config shape still matches the pre-auto-enable source snapshot and dispatches with the auto-enabled resolved runtime config.
- Commands run after the 2026-05-23 follow-up patch:
  - `node scripts/run-vitest.mjs src/gateway/server-methods/send.test.ts` — passed, 108 tests.
  - `pnpm exec oxfmt --check --threads=1 src/gateway/server-methods/send.ts src/gateway/server-methods/send.test.ts` — passed.
  - `pnpm exec oxlint --tsconfig config/tsconfig/oxlint.core.json src/gateway/server-methods/send.ts src/gateway/server-methods/send.test.ts` — passed.
  - `pnpm tsgo:core` — passed.
  - `pnpm tsgo:core:test` — passed.
  - `git diff --check` — passed.
- What you did **not** verify:
  - replacing the currently running gateway with this branch. The live Discord proof used the patched handler in a local process, not a gateway restart.
  - `node scripts/crabbox-wrapper.mjs run --shell -- "pnpm check:changed"`; the crabbox wrapper failed before running repo checks because the crabbox binary failed its basic sanity check.
  - full local `pnpm check:changed`; the local wrapper stayed alive for several minutes after dependency convergence with no child checker process visible, so it was stopped and replaced with the focused commands listed above.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: using a stale active runtime snapshot could route actions through outdated credentials.
  - Mitigation: use `selectApplicableRuntimeConfig(...)` with both active `config` and `sourceConfig`; mismatched source config falls back to the request context config.
- Risk: reintroducing #81477's hot-path performance concern.
  - Mitigation: this PR does not call the accessor from shared channel resolution or ordinary `send`; it adds a config-only accessor and uses it only for gateway `message.action`.

AI-assisted: yes. I used an AI coding agent to implement and verify this change.





