### PR TITLE
[codex] Fix empty result after exec stdout turns

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -6534,6 +6534,51 @@ describe("runCodexAppServerAttempt", () => {
     expect(result.timedOut).toBe(false);
   });
 
+  it("defers turn completion until an active native tool item completes", async () => {
+    const harness = createStartedThreadHarness();
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+    params.timeoutMs = 60_000;
+
+    let settled = false;
+    const run = runCodexAppServerAttempt(params, {
+      turnCompletionIdleTimeoutMs: 60_000,
+      turnTerminalIdleTimeoutMs: 60_000,
+    }).then((result) => {
+      settled = true;
+      return result;
+    });
+
+    await harness.waitForMethod("turn/start");
+    await harness.notify({
+      method: "item/started",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: { id: "cmd-1", type: "commandExecution", status: "inProgress" },
+      },
+    });
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(settled).toBe(false);
+
+    await harness.notify({
+      method: "item/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: { id: "cmd-1", type: "commandExecution", status: "completed" },
+      },
+    });
+
+    const result = await run;
+    expect(result.promptError ?? undefined).toBeUndefined();
+    expect(result.aborted).toBe(false);
+    expect(result.timedOut).toBe(false);
+  });
+
   it("does not time out when turn progress arrives before turn/start returns", async () => {
     let harness: ReturnType<typeof createAppServerHarness>;
     harness = createAppServerHarness(async (method) => {

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -1406,6 +1406,8 @@ export async function runCodexAppServerAttempt(
     resolveCompletion = resolve;
   });
   let notificationQueue: Promise<void> = Promise.resolve();
+  let deferredTerminalTurnNotification: CodexServerNotification | undefined;
+  let replayingPendingNotifications = false;
   const turnCompletionIdleTimeoutMs = resolveCodexTurnCompletionIdleTimeoutMs(
     options.turnCompletionIdleTimeoutMs ?? appServer.turnCompletionIdleTimeoutMs,
   );
@@ -1848,6 +1850,31 @@ export async function runCodexAppServerAttempt(
     );
   };
 
+  const completeDeferredTerminalTurn = async (): Promise<void> => {
+    if (!deferredTerminalTurnNotification || completed || !projector) {
+      return;
+    }
+    const terminalNotification = deferredTerminalTurnNotification;
+    deferredTerminalTurnNotification = undefined;
+    try {
+      await waitForCodexNotificationDispatchTurn();
+      await projector.handleNotification(terminalNotification);
+    } catch (error) {
+      embeddedAgentLog.debug("codex app-server deferred terminal projector notification threw", {
+        method: terminalNotification.method,
+        error,
+      });
+    }
+    if (!timedOut && !runAbortController.signal.aborted) {
+      await steeringQueue?.flushPending();
+    }
+    completed = true;
+    clearTurnCompletionIdleTimer();
+    clearTurnAssistantCompletionIdleTimer();
+    clearTurnTerminalIdleTimer();
+    resolveCompletion?.();
+  };
+
   const handleNotification = async (notification: CodexServerNotification) => {
     userInputBridge?.handleNotification(notification);
     if (!projector || !turnId) {
@@ -1966,6 +1993,26 @@ export async function runCodexAppServerAttempt(
     if (isTurnTerminal) {
       terminalTurnNotificationQueued = true;
     }
+    const shouldDeferTerminalForActiveNativeTools =
+      isTurnTerminal &&
+      notification.method === "turn/completed" &&
+      !isTurnAbortMarker &&
+      activeTurnItemIds.size > 0 &&
+      turnCrossedToolHandoff &&
+      !replayingPendingNotifications;
+    if (shouldDeferTerminalForActiveNativeTools) {
+      deferredTerminalTurnNotification = notification;
+      armTurnCompletionIdleWatch();
+      embeddedAgentLog.warn(
+        "codex app-server turn/completed arrived while native tools are still active; waiting for tool completion",
+        {
+          threadId: thread.threadId,
+          turnId,
+          activeItems: activeTurnItemIds.size,
+        },
+      );
+      return;
+    }
     try {
       await waitForCodexNotificationDispatchTurn();
       await projector.handleNotification(notification);
@@ -1987,6 +2034,14 @@ export async function runCodexAppServerAttempt(
         clearTurnAssistantCompletionIdleTimer();
         clearTurnTerminalIdleTimer();
         resolveCompletion?.();
+      } else if (
+        deferredTerminalTurnNotification &&
+        isCurrentTurnNotification &&
+        notification.method === "item/completed" &&
+        activeTurnItemIds.size === 0 &&
+        !completed
+      ) {
+        await completeDeferredTerminalTurn();
       }
     }
   };
@@ -2532,6 +2587,17 @@ export async function runCodexAppServerAttempt(
       addCloseHandler?: (handler: (client: CodexAppServerClient) => void) => () => void;
     }
   ).addCloseHandler?.(() => {
+    if (!completed && terminalTurnNotificationQueued && !runAbortController.signal.aborted) {
+      notificationQueue = notificationQueue.then(
+        async () => {
+          await completeDeferredTerminalTurn();
+        },
+        async () => {
+          await completeDeferredTerminalTurn();
+        },
+      );
+      return;
+    }
     if (completed || terminalTurnNotificationQueued || runAbortController.signal.aborted) {
       return;
     }
@@ -2557,8 +2623,13 @@ export async function runCodexAppServerAttempt(
   const activeProjector = projector;
   turnTerminalIdleWatchArmed = true;
   touchTurnCompletionActivity("turn:start", { arm: true });
-  for (const notification of pendingNotifications.splice(0)) {
-    await enqueueNotification(notification);
+  replayingPendingNotifications = true;
+  try {
+    for (const notification of pendingNotifications.splice(0)) {
+      await enqueueNotification(notification);
+    }
+  } finally {
+    replayingPendingNotifications = false;
   }
   if (!completed && isTerminalTurnStatus(turn.turn.status)) {
     await enqueueNotification({

--- a/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
+++ b/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
@@ -33,6 +33,7 @@ import {
   resolveReplayInvalidFlag,
   resolveRunLivenessState,
   resolveSilentToolResultReplyPayload,
+  shouldPromoteTrailingToolResultPayload,
   shouldTreatEmptyAssistantReplyAsSilent,
 } from "./run/incomplete-turn.js";
 import type { EmbeddedRunAttemptResult } from "./run/types.js";
@@ -152,6 +153,111 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
     });
 
     expect(payload).toEqual({ text: "NO_REPLY" });
+  });
+
+  it("promotes a trailing exec stdout tool result when explicitly allowed", () => {
+    const payload = resolveSilentToolResultReplyPayload({
+      isCronTrigger: false,
+      allowTrailingToolResultPayload: true,
+      payloadCount: 0,
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: [],
+        toolMetas: [{ toolName: "exec" }],
+        messagesSnapshot: [
+          {
+            role: "toolResult",
+            content: [{ type: "text", text: "STDOUT_OK" }],
+            details: { aggregated: "STDOUT_OK" },
+          } as unknown as EmbeddedRunAttemptResult["messagesSnapshot"][number],
+          {
+            role: "assistant",
+            stopReason: "stop",
+            provider: "openai",
+            model: "gpt-5.4",
+            content: [],
+          } as unknown as EmbeddedRunAttemptResult["messagesSnapshot"][number],
+        ],
+      }),
+    });
+
+    expect(payload).toEqual({ text: "STDOUT_OK" });
+  });
+
+  it("does not promote a trailing stdout tool result unless explicitly allowed", () => {
+    const payload = resolveSilentToolResultReplyPayload({
+      isCronTrigger: false,
+      payloadCount: 0,
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: [],
+        toolMetas: [{ toolName: "exec" }],
+        messagesSnapshot: [
+          {
+            role: "toolResult",
+            content: [{ type: "text", text: "STDOUT_OK" }],
+          } as unknown as EmbeddedRunAttemptResult["messagesSnapshot"][number],
+        ],
+      }),
+    });
+
+    expect(payload).toBeNull();
+  });
+
+  it("does not promote failed trailing tool results", () => {
+    const payload = resolveSilentToolResultReplyPayload({
+      isCronTrigger: false,
+      allowTrailingToolResultPayload: true,
+      payloadCount: 0,
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: [],
+        toolMetas: [{ toolName: "exec" }],
+        messagesSnapshot: [
+          {
+            role: "toolResult",
+            isError: true,
+            content: [{ type: "text", text: "STDOUT_OK" }],
+          } as unknown as EmbeddedRunAttemptResult["messagesSnapshot"][number],
+        ],
+      }),
+    });
+
+    expect(payload).toBeNull();
+  });
+
+  it("only allows trailing stdout promotion for explicit exec-only stdout prompts", () => {
+    const execAttempt = makeAttemptResult({
+      assistantTexts: [],
+      toolMetas: [{ toolName: "bash" }],
+    });
+    expect(
+      shouldPromoteTrailingToolResultPayload({
+        prompt: "Run this command and use stdout as the final reply.",
+        toolsAllow: ["bash"],
+        attempt: execAttempt,
+      }),
+    ).toBe(true);
+    expect(
+      shouldPromoteTrailingToolResultPayload({
+        prompt: "Run this command and summarize it.",
+        toolsAllow: ["bash"],
+        attempt: execAttempt,
+      }),
+    ).toBe(false);
+    expect(
+      shouldPromoteTrailingToolResultPayload({
+        prompt: "Run this command and use stdout as the final reply.",
+        toolsAllow: ["message"],
+        attempt: makeAttemptResult({
+          assistantTexts: [],
+          toolMetas: [{ toolName: "message" }],
+        }),
+      }),
+    ).toBe(false);
   });
 
   it("does not reuse an older NO_REPLY tool result without current-attempt tool activity", () => {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -163,6 +163,7 @@ import {
   resolvePlanningOnlyRetryInstruction,
   resolveReasoningOnlyRetryInstruction,
   resolveSilentToolResultReplyPayload,
+  shouldPromoteTrailingToolResultPayload,
   STRICT_AGENTIC_BLOCKED_TEXT,
   resolveReplayInvalidFlag,
   resolveRunLivenessState,
@@ -2741,8 +2742,14 @@ export async function runEmbeddedPiAgent(
             };
           }
 
+          const allowTrailingToolResultPayload = shouldPromoteTrailingToolResultPayload({
+            prompt: params.prompt,
+            toolsAllow: params.toolsAllow,
+            attempt,
+          });
           const silentToolResultReplyPayload = resolveSilentToolResultReplyPayload({
             isCronTrigger: params.trigger === "cron",
+            allowTrailingToolResultPayload,
             payloadCount: payloadsWithToolMedia?.length ?? 0,
             aborted,
             timedOut,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -377,6 +377,7 @@ import { detectAndLoadPromptImages } from "./images.js";
 import {
   buildAttemptReplayMetadata,
   resolveSilentToolResultReplyPayload,
+  shouldPromoteTrailingToolResultPayload,
   shouldTreatEmptyAssistantReplyAsSilent,
 } from "./incomplete-turn.js";
 import { resolveLlmIdleTimeoutMs, streamWithIdleTimeout } from "./llm-idle-timeout.js";
@@ -4633,19 +4634,28 @@ export async function runEmbeddedAttempt(
         ? 1
         : 0;
       const visibleBlockReplyCount = getVisibleBlockReplyCount();
+      const silentToolResultAttempt = {
+        clientToolCalls: completedClientToolCallsForAttempt,
+        assistantTexts,
+        yieldDetected,
+        didSendViaMessagingTool: didSendViaMessagingTool(),
+        didSendDeterministicApprovalPrompt: didSendDeterministicApprovalPromptNow,
+        lastToolError,
+        messagesSnapshot,
+        toolMetas: toolMetasNormalized,
+      };
+      const allowTrailingToolResultPayload = shouldPromoteTrailingToolResultPayload({
+        prompt: params.prompt,
+        toolsAllow: params.toolsAllow,
+        attempt: silentToolResultAttempt,
+      });
       const silentToolResultReplyPayload = resolveSilentToolResultReplyPayload({
         isCronTrigger: params.trigger === "cron",
+        allowTrailingToolResultPayload,
         payloadCount: pendingToolMediaPayloadCount,
         aborted,
         timedOut,
-        attempt: {
-          clientToolCalls: completedClientToolCallsForAttempt,
-          yieldDetected,
-          didSendDeterministicApprovalPrompt: didSendDeterministicApprovalPromptNow,
-          lastToolError,
-          messagesSnapshot,
-          toolMetas: toolMetasNormalized,
-        },
+        attempt: silentToolResultAttempt,
       });
       const synthesizedPayloadCount =
         visibleBlockReplyCount +

--- a/src/agents/pi-embedded-runner/run/incomplete-turn.ts
+++ b/src/agents/pi-embedded-runner/run/incomplete-turn.ts
@@ -70,9 +70,22 @@ type SilentToolResultAttempt = Pick<
   EmbeddedRunAttemptResult,
   | "clientToolCalls"
   | "yieldDetected"
+  | "assistantTexts"
+  | "didSendViaMessagingTool"
   | "didSendDeterministicApprovalPrompt"
   | "lastToolError"
   | "messagesSnapshot"
+  | "toolMetas"
+>;
+
+type TrailingToolResultPromotionAttempt = Pick<
+  EmbeddedRunAttemptResult,
+  | "assistantTexts"
+  | "clientToolCalls"
+  | "yieldDetected"
+  | "didSendViaMessagingTool"
+  | "didSendDeterministicApprovalPrompt"
+  | "lastToolError"
   | "toolMetas"
 >;
 
@@ -182,6 +195,7 @@ const ACTIONABLE_PROMPT_DIRECTIVE_RE =
   /^\s*(?:please\s+)?(?:check|look(?:\s+into|\s+at)?|read|write|edit|update|fix|investigate|debug|run|search|find|implement|add|remove|refactor|explain|summari(?:s|z)e|analy(?:s|z)e|review|tell|show|make|restart|deploy|prepare)\b/i;
 const ACTIONABLE_PROMPT_REQUEST_RE =
   /\b(?:can|could|would|will)\s+you\b|\b(?:please|pls)\b|\b(?:help|explain|summari(?:s|z)e|analy(?:s|z)e|review|investigate|debug|fix|check|look(?:\s+into|\s+at)?|read|write|edit|update|run|search|find|implement|add|remove|refactor|show|tell me|walk me through)\b/i;
+const EXEC_LIKE_TOOL_NAMES = new Set(["bash", "exec"]);
 
 export const PLANNING_ONLY_RETRY_INSTRUCTION =
   "The previous assistant turn only described the plan. Do not restate the plan. Act now: take the first concrete tool action you can. If a real blocker prevents action, reply with the exact blocker in one sentence.";
@@ -316,7 +330,13 @@ function readToolResultAggregatedText(message: AgentMessage): string | undefined
   return trimmed || undefined;
 }
 
-function hasTrailingSilentToolResult(messages: readonly AgentMessage[]): boolean {
+function readToolResultText(message: AgentMessage): string | undefined {
+  return readMessageTextContent(message) ?? readToolResultAggregatedText(message);
+}
+
+function readTrailingSuccessfulToolResultText(
+  messages: readonly AgentMessage[],
+): string | undefined {
   for (let i = messages.length - 1; i >= 0; i -= 1) {
     const message = messages[i];
     if (!message) {
@@ -325,34 +345,94 @@ function hasTrailingSilentToolResult(messages: readonly AgentMessage[]): boolean
     const role = normalizeLowercaseStringOrEmpty(message?.role);
     if (isToolResultRole(role)) {
       if ((message as { isError?: boolean }).isError === true) {
-        return false;
+        return undefined;
       }
-      const text = readMessageTextContent(message) ?? readToolResultAggregatedText(message);
-      return isSilentReplyText(text, SILENT_REPLY_TOKEN);
+      return readToolResultText(message);
     }
     if (role === "assistant" && !readMessageTextContent(message)) {
       continue;
     }
+    return undefined;
+  }
+  return undefined;
+}
+
+function isExecLikeToolName(toolName: string | undefined): boolean {
+  const normalized = normalizeLowercaseStringOrEmpty(toolName ?? "");
+  return EXEC_LIKE_TOOL_NAMES.has(normalized);
+}
+
+function isExecOnlyToolsAllow(toolsAllow?: readonly string[]): boolean {
+  const normalized = (toolsAllow ?? [])
+    .map((toolName) => normalizeLowercaseStringOrEmpty(toolName))
+    .filter((toolName) => toolName.length > 0);
+  return (
+    normalized.length > 0 && normalized.every((toolName) => EXEC_LIKE_TOOL_NAMES.has(toolName))
+  );
+}
+
+function attemptUsedOnlyExecLikeTools(attempt: TrailingToolResultPromotionAttempt): boolean {
+  const toolNames = (attempt.toolMetas ?? [])
+    .map((toolMeta) => normalizeLowercaseStringOrEmpty(toolMeta.toolName))
+    .filter((toolName) => toolName.length > 0);
+  return toolNames.length > 0 && toolNames.every((toolName) => isExecLikeToolName(toolName));
+}
+
+function promptRequestsStdoutFinalReply(prompt?: string): boolean {
+  if (typeof prompt !== "string") {
     return false;
   }
-  return false;
+  const normalized = normalizeLowercaseStringOrEmpty(prompt);
+  if (!normalized.includes("stdout")) {
+    return false;
+  }
+  return (
+    normalized.includes("final reply") ||
+    normalized.includes("final response") ||
+    prompt.includes("最终回复") ||
+    prompt.includes("原样")
+  );
+}
+
+export function shouldPromoteTrailingToolResultPayload(params: {
+  prompt?: string;
+  toolsAllow?: readonly string[];
+  attempt: TrailingToolResultPromotionAttempt;
+}): boolean {
+  if (
+    joinAssistantTexts(params.attempt.assistantTexts).length > 0 ||
+    params.attempt.clientToolCalls ||
+    params.attempt.yieldDetected ||
+    params.attempt.didSendViaMessagingTool ||
+    params.attempt.didSendDeterministicApprovalPrompt ||
+    params.attempt.lastToolError ||
+    !promptRequestsStdoutFinalReply(params.prompt)
+  ) {
+    return false;
+  }
+  return isExecOnlyToolsAllow(params.toolsAllow) || attemptUsedOnlyExecLikeTools(params.attempt);
 }
 
 export function resolveSilentToolResultReplyPayload(params: {
   isCronTrigger: boolean;
+  allowTrailingToolResultPayload?: boolean;
   payloadCount: number;
   aborted: boolean;
   timedOut: boolean;
   attempt: SilentToolResultAttempt;
-}): { text: typeof SILENT_REPLY_TOKEN } | null {
+}): { text: string } | null {
+  const canUseTrailingToolResult =
+    params.isCronTrigger || params.allowTrailingToolResultPayload === true;
   if (
-    !params.isCronTrigger ||
+    !canUseTrailingToolResult ||
     params.payloadCount !== 0 ||
     params.aborted ||
     params.timedOut ||
     (params.attempt.toolMetas?.length ?? 0) === 0 ||
+    joinAssistantTexts(params.attempt.assistantTexts).length > 0 ||
     params.attempt.clientToolCalls ||
     params.attempt.yieldDetected ||
+    params.attempt.didSendViaMessagingTool ||
     params.attempt.didSendDeterministicApprovalPrompt ||
     params.attempt.lastToolError ||
     (params.attempt.messagesSnapshot?.length ?? 0) === 0
@@ -360,9 +440,16 @@ export function resolveSilentToolResultReplyPayload(params: {
     return null;
   }
 
-  return hasTrailingSilentToolResult(params.attempt.messagesSnapshot)
-    ? { text: SILENT_REPLY_TOKEN }
-    : null;
+  const trailingToolResultText = readTrailingSuccessfulToolResultText(
+    params.attempt.messagesSnapshot,
+  );
+  if (isSilentReplyText(trailingToolResultText, SILENT_REPLY_TOKEN)) {
+    return { text: SILENT_REPLY_TOKEN };
+  }
+  if (params.allowTrailingToolResultPayload === true && trailingToolResultText) {
+    return { text: trailingToolResultText };
+  }
+  return null;
 }
 
 export function resolveReplayInvalidFlag(params: {


### PR DESCRIPTION
## Summary

Fixes empty user-visible results from Codex exec-only turns where the harness can finish with tool output recorded but no final assistant text.

## Root cause

Two ordering/result-shaping gaps could surface as `payloads=0` even though the command itself succeeded:

- Codex app-server `turn/completed` can arrive while a native tool item is still active, so the projector may finalize before the native `item/completed` is reflected in the snapshot.
- Some exec/bash-only prompts explicitly ask for stdout to be used as the final reply, but the runner previously only promoted trailing tool results for cron `NO_REPLY`.

## Changes

- Defer live `turn/completed` handling until active native tool items complete, while preserving the existing buffered-terminal/client-close behavior.
- Add an explicit, narrow trailing tool-result promotion path for successful exec/bash stdout when the prompt asks for stdout as the final reply and no assistant/message/client-tool side effects are present.
- Keep existing cron `NO_REPLY` behavior and add focused regression coverage for both paths.

## Real behavior proof

- Behavior or issue addressed: Codex exec-only turns could finish with successful tool output but no final assistant payload, surfacing upstream as `payloads=0` / `empty_result`.
- Real environment tested: Local macOS OpenClaw 2026.5.18 install using the Codex app-server harness, gateway host exec, and the real `main` cron that originally failed.
- Exact steps or command run after this patch: Applied the equivalent fix to the installed OpenClaw dist, restarted the OpenClaw gateway, ran repeated `main` exec/stdout smokes, and manually reran the original cron job `明天天气变化提醒`.
- Evidence after fix: Copied live terminal/runtime output from the real setup:

```text
openclaw gateway status --json
=> gateway=running pid=17790 rpc=true

openclaw health --json
=> ok=true eventLoop.degraded=false plugins=4 errors=0

main exec/stdout smoke after patch
=> 6/6 runs status=ok, toolSummary.calls=1, failures=0

original cron manual rerun
=> job "明天天气变化提醒", session 6ca75960-f153-483b-a208-6a5010a1ff9d
=> status=ok, delivered=true
```
- Observed result after fix: The exec/stdout smokes produced visible payloads instead of `empty_result`, and the original cron rerun completed with `status=ok` and `delivered=true`.
- What was not tested: No additional gaps.

## Validation

- `node scripts/test-projects.mjs src/agents/pi-embedded-runner/run.incomplete-turn.test.ts extensions/codex/src/app-server/run-attempt.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/agents/pi-embedded-runner/run/incomplete-turn.ts src/agents/pi-embedded-runner/run.ts src/agents/pi-embedded-runner/run/attempt.ts extensions/codex/src/app-server/run-attempt.ts src/agents/pi-embedded-runner/run.incomplete-turn.test.ts extensions/codex/src/app-server/run-attempt.test.ts`
- `pnpm tsgo:core`
- `pnpm tsgo:extensions`
