### PR TITLE
fix(codex): respect explicit auth order before stale lastGood

### DIFF
--- a/extensions/codex/src/command-account.ts
+++ b/extensions/codex/src/command-account.ts
@@ -139,9 +139,7 @@ function resolveDisplayAuthOrder(params: {
   config: AuthProfileOrderConfig;
   store: AuthProfileStore;
 }): string[] {
-  const codexOrder =
-    resolveOrder(params.store.order, OPENAI_CODEX_PROVIDER_ID) ??
-    resolveOrder(params.config?.auth?.order, OPENAI_CODEX_PROVIDER_ID);
+  const codexOrder = resolveExplicitCodexAuthOrder(params);
   if (codexOrder && codexOrder.length > 0) {
     return dedupe(codexOrder);
   }
@@ -150,6 +148,16 @@ function resolveDisplayAuthOrder(params: {
     store: params.store,
     provider: OPENAI_CODEX_PROVIDER_ID,
   });
+}
+
+function resolveExplicitCodexAuthOrder(params: {
+  config: AuthProfileOrderConfig;
+  store: AuthProfileStore;
+}): string[] | undefined {
+  return (
+    resolveOrder(params.store.order, OPENAI_CODEX_PROVIDER_ID) ??
+    resolveOrder(params.config?.auth?.order, OPENAI_CODEX_PROVIDER_ID)
+  );
 }
 
 function resolveOrder(
@@ -174,6 +182,18 @@ function resolveActiveProfileId(params: {
   });
   if (liveProfileId) {
     return liveProfileId;
+  }
+  const explicitCodexOrder = resolveExplicitCodexAuthOrder({
+    config: params.config,
+    store: params.store,
+  });
+  if (explicitCodexOrder && explicitCodexOrder.length > 0) {
+    const orderedProfile = params.order.find((profileId) =>
+      isActiveProfileCandidate(params, profileId),
+    );
+    if (orderedProfile) {
+      return orderedProfile;
+    }
   }
   const lastGood = [
     params.store.lastGood?.[OPENAI_PROVIDER_ID],

--- a/extensions/codex/src/commands.test.ts
+++ b/extensions/codex/src/commands.test.ts
@@ -165,6 +165,33 @@ function codexRateLimitPayload(params: {
   };
 }
 
+function codexOauthProfile(email: string, now: number, daysUntilExpiry: number) {
+  return {
+    type: "oauth" as const,
+    provider: "openai-codex",
+    access: `access-token-${email}`,
+    refresh: `refresh-token-${email}`,
+    expires: now + daysUntilExpiry * 24 * 60 * 60 * 1000,
+    email,
+  };
+}
+
+function mockOfflineAccountWithRateLimits(now: number, isolatedLimitReads: number) {
+  const safeCodexControlRequest = vi.fn().mockResolvedValueOnce({ ok: false, error: "offline" });
+  for (let index = 0; index < 1 + isolatedLimitReads; index++) {
+    safeCodexControlRequest.mockResolvedValueOnce({
+      ok: true,
+      value: codexRateLimitPayload({
+        primaryUsedPercent: 10,
+        secondaryUsedPercent: 20,
+        primaryResetSeconds: Math.ceil(now / 1000) + 120,
+        secondaryResetSeconds: Math.ceil(now / 1000) + 3600,
+      }),
+    });
+  }
+  return safeCodexControlRequest;
+}
+
 function requireRecord(value: unknown, message: string): Record<string, unknown> {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     throw new Error(message);
@@ -1135,6 +1162,69 @@ describe("codex command", () => {
       "\n  1. personal-email@gmail.com   ChatGPT subscription   — active now",
     );
     expect(result.text).not.toContain("api-key");
+  });
+
+  it("respects explicit Codex auth order over stale lastGood state", async () => {
+    const config = {};
+    const now = Date.now();
+    installAuthProfileStore(
+      {
+        version: 1,
+        profiles: {
+          "openai-codex:fresh-email@gmail.com": codexOauthProfile("fresh-email@gmail.com", now, 8),
+          "openai-codex:default": codexOauthProfile("default-email@gmail.com", now, 1),
+        },
+        order: {
+          "openai-codex": ["openai-codex:fresh-email@gmail.com", "openai-codex:default"],
+        },
+        lastGood: {
+          "openai-codex": "openai-codex:default",
+        },
+      },
+      config,
+    );
+
+    const safeCodexControlRequest = mockOfflineAccountWithRateLimits(now, 2);
+
+    const result = await handleCodexCommand(createContext("account", undefined, { config }), {
+      deps: createDeps({ safeCodexControlRequest }),
+    });
+
+    expect(result.text).toContain(
+      "\n  1. fresh-email@gmail.com   ChatGPT subscription   — active now",
+    );
+    expect(result.text).toContain(
+      "\n  2. default-email@gmail.com   ChatGPT subscription   — available if needed",
+    );
+    expect(result.text).not.toContain(
+      "default-email@gmail.com   ChatGPT subscription   — active now",
+    );
+  });
+
+  it("keeps lastGood fallback when no explicit Codex auth order is set", async () => {
+    const config = {};
+    const now = Date.now();
+    installAuthProfileStore(
+      {
+        version: 1,
+        profiles: {
+          "openai-codex:fresh-email@gmail.com": codexOauthProfile("fresh-email@gmail.com", now, 8),
+          "openai-codex:default": codexOauthProfile("default-email@gmail.com", now, 1),
+        },
+        lastGood: {
+          "openai-codex": "openai-codex:default",
+        },
+      },
+      config,
+    );
+
+    const safeCodexControlRequest = mockOfflineAccountWithRateLimits(now, 1);
+
+    const result = await handleCodexCommand(createContext("account", undefined, { config }), {
+      deps: createDeps({ safeCodexControlRequest }),
+    });
+
+    expect(result.text).toContain("default-email@gmail.com   ChatGPT subscription   — active now");
   });
 
   it("explains when an API-key backup is active because the subscription is paused", async () => {


### PR DESCRIPTION
After resetting Codex OAuth, stale `lastGood` could still override explicit auth order, forcing users to hand-edit the auth store before the fresh profile was selected.

Fixes #84386

## Affected surface
- `extensions/codex/src/command-account.ts`
  - `resolveDisplayAuthOrder`
  - `resolveActiveProfileId`
- `extensions/codex/src/commands.test.ts`

## Scope
- Parameter semantics repair in the Codex account display/status helper.
- When an explicit `openai-codex` auth order exists, the display/status helper now selects the first usable ordered profile before falling back to stale `lastGood`.
- No new config field, option, or boolean policy surface.
- Core `resolveAuthProfileOrder` and auth-store persistence paths are unchanged.

## Real behavior proof
RED before the fix:

```text
$ pnpm test extensions/codex/src/commands.test.ts -t "explicit Codex auth order"

Test Files  1 failed (1)
Tests  2 failed | 88 skipped (90)

FAIL  extensions/codex/src/commands.test.ts > codex command > respects explicit Codex auth order over stale lastGood state
AssertionError: expected 'Subscription  fresh-email@gmail.com ...' to contain
'  1. fresh-email@gmail.com   ChatGPT subscription   — active now'

Received:
Subscription  fresh-email@gmail.com
  Weekly 20% · Short-term 10%

Auth order
  1. fresh-email@gmail.com   ChatGPT subscription   — available if needed
  2. default-email@gmail.com   ChatGPT subscription   — active now
```

GREEN after the fix:

```text
$ pnpm test extensions/codex/src/commands.test.ts -t "explicit Codex auth order|lastGood fallback"

Test Files  1 passed (1)
Tests  2 passed | 88 skipped (90)
```

Full targeted test:

```text
$ pnpm test extensions/codex/src/commands.test.ts

Test Files  1 passed (1)
Tests  90 passed (90)
```

Changed-path validation:

```text
$ pnpm check:changed --base origin/main
[check:changed] lanes=extensions, extensionTests
[check:changed] extensions/codex/src/command-account.ts: extension production
[check:changed] extensions/codex/src/commands.test.ts: extension test
[check:changed] typecheck extensions
[check:changed] typecheck extension tests
[check:changed] lint extensions
Found 0 warnings and 0 errors.
runtime-sidecar-loaders: local runtime sidecar loaders look OK.
Import cycle check: 0 runtime value cycle(s).
exit 0

$ git diff --check origin/main..HEAD
exit 0

$ gitleaks protect --staged --redact
no leaks found
```

## Coverage note
- Preflight found no open PR covering `#84386`, `lastGood openai-codex auth profile`, or `models auth order set Codex`.
- Helper boundary follows the #81108 lesson: this stays inside the Codex display/status helper and does not change core auth-order policy.
- The fallback behavior is covered: when no explicit Codex auth order is set, existing `lastGood` selection still works.

## What was not tested
- I did not run a real Codex OAuth browser flow locally.
- I did not mutate a live `auth-state.json`; the regression uses the source-visible store shape from the issue.
