### PR TITLE
feat(google): route gemini-3.5-flash through forward-compat resolver

### DIFF
--- a/extensions/google/provider-models.test.ts
+++ b/extensions/google/provider-models.test.ts
@@ -460,6 +460,58 @@ describe("resolveGoogleGeminiForwardCompatModel", () => {
     });
   });
 
+  it("resolves gemini 3.5 flash from gemini-3-flash-preview templates", () => {
+    const model = resolveGoogleGeminiForwardCompatModel({
+      providerId: "google",
+      ctx: createContext({
+        provider: "google",
+        modelId: "gemini-3.5-flash",
+        models: [
+          createTemplateModel("google", "gemini-3-flash-preview", {
+            reasoning: true,
+            contextWindow: 1_048_576,
+          }),
+        ],
+      }),
+    });
+
+    expectModelFields(model, {
+      provider: "google",
+      id: "gemini-3.5-flash",
+      api: "google-generative-ai",
+      reasoning: true,
+      contextWindow: 1_048_576,
+    });
+  });
+
+  it("falls back to gemini-2.5-flash when the gemini-3-flash-preview template is missing", () => {
+    const model = resolveGoogleGeminiForwardCompatModel({
+      providerId: "google",
+      ctx: createContext({
+        provider: "google",
+        modelId: "gemini-3.5-flash",
+        models: [
+          createTemplateModel("google", "gemini-2.5-flash", {
+            reasoning: true,
+            contextWindow: 1_048_576,
+          }),
+        ],
+      }),
+    });
+
+    expectModelFields(model, {
+      provider: "google",
+      id: "gemini-3.5-flash",
+      api: "google-generative-ai",
+      reasoning: true,
+      contextWindow: 1_048_576,
+    });
+  });
+
+  it("treats gemini 3.5 flash as a modern google model", () => {
+    expect(isModernGoogleModel("gemini-3.5-flash")).toBe(true);
+  });
+
   it("treats gemini 2.5 ids as modern google models", () => {
     expect(isModernGoogleModel("gemini-2.5-pro")).toBe(true);
     expect(isModernGoogleModel("gemini-2.5-flash-lite")).toBe(true);

--- a/extensions/google/provider-models.ts
+++ b/extensions/google/provider-models.ts
@@ -15,6 +15,7 @@ const GEMINI_3_1_FLASH_LITE_PREFIX = "gemini-3.1-flash-lite";
 const GEMINI_3_1_FLASH_PREFIX = "gemini-3.1-flash";
 const GEMINI_3_FLASH_LITE_PREFIX = "gemini-3-flash-lite";
 const GEMINI_3_FLASH_PREFIX = "gemini-3-flash";
+const GEMINI_3_5_FLASH_PREFIX = "gemini-3.5-flash";
 const GEMINI_PRO_LATEST_ID = "gemini-pro-latest";
 const GEMINI_FLASH_LATEST_ID = "gemini-flash-latest";
 const GEMINI_FLASH_LITE_LATEST_ID = "gemini-flash-lite-latest";
@@ -27,6 +28,10 @@ const GEMINI_3_1_FLASH_LITE_TEMPLATE_IDS = ["gemini-3.1-flash-lite-preview"] as 
 const GEMINI_3_1_FLASH_TEMPLATE_IDS = ["gemini-3-flash-preview", "gemini-2.5-flash"] as const;
 const GEMINI_3_PRO_ANTIGRAVITY_TEMPLATE_IDS = ["gemini-3-pro-low", "gemini-3-pro-high"] as const;
 const GEMINI_3_FLASH_ANTIGRAVITY_TEMPLATE_IDS = ["gemini-3-flash"] as const;
+// Gemini 3.5 Flash went GA at Google I/O 2026. Reuse the closest in-catalog
+// predecessors (gemini-3-flash-preview, gemini-2.5-flash) so the resolver
+// returns a runtime model with sensible metadata while the catalog catches up.
+const GEMINI_3_5_FLASH_TEMPLATE_IDS = ["gemini-3-flash-preview", "gemini-2.5-flash"] as const;
 // Gemma uses the Gemini flash template as a forward-compat approximation
 // until a dedicated Gemma template is registered in the catalog.
 const GEMMA_TEMPLATE_IDS = GEMINI_3_1_FLASH_TEMPLATE_IDS;
@@ -189,6 +194,12 @@ export function resolveGoogleGeminiForwardCompatModel(params: {
     family = {
       googleTemplateIds: GEMINI_3_1_FLASH_TEMPLATE_IDS,
       cliTemplateIds: GEMINI_3_1_FLASH_TEMPLATE_IDS,
+      antigravityTemplateIds: GEMINI_3_FLASH_ANTIGRAVITY_TEMPLATE_IDS,
+    };
+  } else if (lower.startsWith(GEMINI_3_5_FLASH_PREFIX)) {
+    family = {
+      googleTemplateIds: GEMINI_3_5_FLASH_TEMPLATE_IDS,
+      cliTemplateIds: GEMINI_3_5_FLASH_TEMPLATE_IDS,
       antigravityTemplateIds: GEMINI_3_FLASH_ANTIGRAVITY_TEMPLATE_IDS,
     };
   } else if (lower.startsWith(GEMMA_PREFIX)) {


### PR DESCRIPTION
## Summary

Gemini 3.5 Flash went GA at Google I/O 2026 (model id: `gemini-3.5-flash`). The forward-compat resolver in `extensions/google/provider-models.ts` had no branch for the 3.5 family, so:

1. `resolveGoogleGeminiForwardCompatModel(...)` fell through to `return undefined`
2. No runtime model entry was built
3. The downstream call ran with no template metadata, the request went out, and Google returned `404 status code (no body)` from `https://generativelanguage.googleapis.com/v1beta/...`
4. OpenClaw's auto-fallback then routed the request to whatever the configured fallback model was

This patch adds a single new prefix branch that reuses the existing `gemini-3-flash-preview` / `gemini-2.5-flash` templates for metadata, so `gemini-3.5-flash` resolves to a clean runtime model and the API call lands correctly on the GA endpoint.

Only `gemini-3.5-flash` is included. Gemini 3.5 Pro is announced for next month but not yet GA, and there's no Flash Lite in the 3.5 family yet — I deliberately left them out so this PR ships only what's real today.

## Test plan

- [x] `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-providers.config.ts extensions/google/provider-models.test.ts` — all 25 tests pass (22 existing + 3 new)
- [x] End-to-end verification on a real OpenClaw 2026.4.24 install:
  - Without patch: `openclaw infer model run --model google/gemini-3.5-flash --prompt "..."` returns `404 status code (no body)` and falls back to a different provider
  - With patch: same command returns `model: gemini-3.5-flash · provider: google` with the expected response
- [x] Confirmed via direct curl from the same machine that `https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:generateContent` returns 200 with the same AI Studio API key — so the network path and auth are fine and the issue is purely the missing forward-compat branch

## New tests

- `resolves gemini 3.5 flash from gemini-3-flash-preview templates` — happy path
- `falls back to gemini-2.5-flash when the gemini-3-flash-preview template is missing` — template fallback chain
- `treats gemini 3.5 flash as a modern google model` — `isModernGoogleModel` already returns `true` (the `startsWith("gemini-3")` check catches it), explicit assertion keeps it that way

## Reference

- [Gemini 3.5 Flash announcement (Google I/O 2026)](https://ai.google.dev/gemini-api/docs/whats-new-gemini-3.5)
- Model docs: https://ai.google.dev/gemini-api/docs/models/gemini-3.5-flash