### PR TITLE
fix(cli-runner): emit run.progress from raw stdout in Claude live ses…

### DIFF
--- a/src/agents/cli-runner/claude-live-session.diagnostic-progress.test.ts
+++ b/src/agents/cli-runner/claude-live-session.diagnostic-progress.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetAgentEventsForTest } from "../../infra/agent-events.js";
+import {
+  onInternalDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+  waitForDiagnosticEventsDrained,
+  type DiagnosticEventPayload,
+} from "../../infra/diagnostic-events.js";
+import type { getProcessSupervisor } from "../../process/supervisor/index.js";
+import { supervisorSpawnMock } from "../cli-runner.test-support.js";
+import { resetClaudeLiveSessionsForTest, runClaudeLiveSessionTurn } from "./claude-live-session.js";
+import type { PreparedCliRunContext } from "./types.js";
+
+type SupervisorSpawnFn = ReturnType<typeof getProcessSupervisor>["spawn"];
+
+function buildClaudeLiveContext(): PreparedCliRunContext {
+  const backend = {
+    command: "claude",
+    args: ["-p", "--output-format", "stream-json"],
+    output: "jsonl" as const,
+    input: "stdin" as const,
+    sessionArg: "--session-id",
+    sessionMode: "always" as const,
+    serialize: true,
+    liveSession: "claude-stdio" as const,
+  };
+  return {
+    params: {
+      sessionId: "live-diag-session",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      prompt: "hi",
+      provider: "claude-cli",
+      model: "claude-opus-4-7",
+      timeoutMs: 60_000,
+      runId: "live-diag-run",
+      sessionKey: "agent:main:main",
+    },
+    started: Date.now(),
+    workspaceDir: "/tmp",
+    backendResolved: {
+      id: "claude-cli",
+      config: backend,
+      bundleMcp: true,
+      pluginId: "anthropic",
+    },
+    preparedBackend: { backend, env: {} },
+    reusableCliSession: {},
+    hadSessionFile: false,
+    contextEngineConfig: {},
+    modelId: "claude-opus-4-7",
+    normalizedModel: "claude-opus-4-7",
+    systemPrompt: "system",
+    systemPromptReport: {} as PreparedCliRunContext["systemPromptReport"],
+    bootstrapPromptWarningLines: [],
+    authEpochVersion: 2,
+  };
+}
+
+beforeEach(() => {
+  resetAgentEventsForTest();
+  resetDiagnosticEventsForTest();
+  resetClaudeLiveSessionsForTest();
+  supervisorSpawnMock.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("runClaudeLiveSessionTurn emits run.progress on raw stdout (covers thinking_delta)", () => {
+  it("fires cli:live:stdout even when only thinking_delta lines arrive (no text_delta, no onAssistantDelta)", async () => {
+    const captured: DiagnosticEventPayload[] = [];
+    const unsubscribe = onInternalDiagnosticEvent((event) => {
+      if (event.type === "run.progress") {
+        captured.push(event);
+      }
+    });
+    const assistantDeltas: string[] = [];
+
+    let nowValue = 5_000_000;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => nowValue);
+
+    let stdoutListener: ((chunk: string) => void) | undefined;
+    supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {
+      const input = args[0] as Parameters<SupervisorSpawnFn>[0];
+      stdoutListener = input.onStdout;
+      return {
+        runId: "supervisor-run-1",
+        pid: 4242,
+        startedAtMs: Date.now(),
+        stdin: {
+          write: vi.fn((_data: string, cb?: (err?: Error | null) => void) => {
+            // thinking_delta line — parser will not invoke onAssistantDelta
+            stdoutListener?.(
+              `${JSON.stringify({
+                type: "stream_event",
+                event: {
+                  type: "content_block_delta",
+                  delta: { type: "thinking_delta", thinking: "let me think..." },
+                },
+              })}\n`,
+            );
+            // 3s later — throttled, no second progress event
+            nowValue = 5_003_000;
+            stdoutListener?.(
+              `${JSON.stringify({
+                type: "stream_event",
+                event: {
+                  type: "content_block_delta",
+                  delta: { type: "thinking_delta", thinking: "...still thinking" },
+                },
+              })}\n`,
+            );
+            // 11s later — past throttle, second progress event fires
+            nowValue = 5_011_000;
+            stdoutListener?.(
+              `${JSON.stringify({
+                type: "stream_event",
+                event: {
+                  type: "content_block_delta",
+                  delta: { type: "thinking_delta", thinking: "...done thinking" },
+                },
+              })}\n`,
+            );
+            // Now the result line so the turn resolves
+            nowValue = 5_011_500;
+            stdoutListener?.(
+              `${JSON.stringify({
+                type: "result",
+                session_id: "live-diag-session",
+                result: "done",
+              })}\n`,
+            );
+            cb?.();
+          }),
+          end: vi.fn(),
+        },
+        wait: vi.fn(() => new Promise(() => {})),
+        cancel: vi.fn(),
+      };
+    });
+
+    try {
+      await runClaudeLiveSessionTurn({
+        context: buildClaudeLiveContext(),
+        args: ["-p", "--output-format", "stream-json"],
+        env: {},
+        prompt: "hi",
+        useResume: false,
+        noOutputTimeoutMs: 60_000,
+        getProcessSupervisor: () => ({
+          spawn: (params: Parameters<SupervisorSpawnFn>[0]) =>
+            supervisorSpawnMock(params) as ReturnType<SupervisorSpawnFn>,
+          cancel: vi.fn(),
+          cancelScope: vi.fn(),
+          reconcileOrphans: vi.fn(),
+          getRecord: vi.fn(),
+        }),
+        onAssistantDelta: (delta) => {
+          assistantDeltas.push(delta.delta);
+        },
+        cleanup: async () => {},
+      });
+      await waitForDiagnosticEventsDrained();
+    } finally {
+      unsubscribe();
+      nowSpy.mockRestore();
+    }
+
+    const liveStdoutEvents = captured.filter(
+      (event) => event.type === "run.progress" && event.reason === "cli:live:stdout",
+    );
+    // 4 stdout chunks across 0s/3s/11s/11.5s: chunk at 0s emits, 3s throttled,
+    // 11s emits (second), 11.5s throttled. So expect exactly 2.
+    expect(liveStdoutEvents.length).toBe(2);
+    for (const event of liveStdoutEvents) {
+      if (event.type !== "run.progress") {
+        continue;
+      }
+      expect(event.runId).toBe("live-diag-run");
+      expect(event.sessionId).toBe("live-diag-session");
+      expect(event.sessionKey).toBe("agent:main:main");
+    }
+    // Critical: text-delta parser path was NEVER invoked, so onAssistantDelta did NOT fire.
+    // This proves the stdout-level emission is strictly more inclusive than onAssistantDelta —
+    // it covers reasoning-only turns that the prior commit's hook would miss.
+    expect(assistantDeltas).toEqual([]);
+  });
+});

--- a/src/agents/cli-runner/claude-live-session.diagnostic-progress.test.ts
+++ b/src/agents/cli-runner/claude-live-session.diagnostic-progress.test.ts
@@ -65,6 +65,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  resetClaudeLiveSessionsForTest();
   vi.restoreAllMocks();
 });
 

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -39,6 +39,12 @@ type ProcessSupervisor = ReturnType<
   typeof import("../../process/supervisor/index.js").getProcessSupervisor
 >;
 type ManagedRun = Awaited<ReturnType<ProcessSupervisor["spawn"]>>;
+type ClaudeLiveTurnDiagnosticIdentity = {
+  runId?: string;
+  sessionId?: string;
+  sessionKey?: string;
+  lastProgressEmittedAt: number;
+};
 type ClaudeLiveTurn = {
   backend: CliBackendConfig;
   diagnosticRefs: ClaudeLiveDiagnosticRefs;
@@ -53,6 +59,7 @@ type ClaudeLiveTurn = {
   activeTools: Map<string, ClaudeLiveActiveTool>;
   streamingParser: ReturnType<typeof createCliJsonlStreamingParser>;
   execPermission: ClaudeLiveExecPermission;
+  diagnostic: ClaudeLiveTurnDiagnosticIdentity;
   resolve: (output: CliOutput) => void;
   reject: (error: unknown) => void;
 };
@@ -113,6 +120,22 @@ const CLAUDE_LIVE_DEFAULT_MAX_TURN_LINES = 20_000;
 const CLAUDE_LIVE_MIN_TURN_LINES = 100;
 const CLAUDE_LIVE_MAX_CONFIGURABLE_TURN_LINES = 100_000;
 const CLAUDE_LIVE_CLOSE_WAIT_TIMEOUT_MS = 5_000;
+const CLAUDE_LIVE_DIAGNOSTIC_PROGRESS_THROTTLE_MS = 10_000;
+
+function emitLiveTurnDiagnosticProgress(turn: ClaudeLiveTurn, reason: string): void {
+  const now = Date.now();
+  if (now - turn.diagnostic.lastProgressEmittedAt < CLAUDE_LIVE_DIAGNOSTIC_PROGRESS_THROTTLE_MS) {
+    return;
+  }
+  turn.diagnostic.lastProgressEmittedAt = now;
+  emitTrustedDiagnosticEvent({
+    type: "run.progress",
+    reason,
+    ...(turn.diagnostic.runId ? { runId: turn.diagnostic.runId } : {}),
+    ...(turn.diagnostic.sessionId ? { sessionId: turn.diagnostic.sessionId } : {}),
+    ...(turn.diagnostic.sessionKey ? { sessionKey: turn.diagnostic.sessionKey } : {}),
+  });
+}
 const liveSessions = new Map<string, ClaudeLiveSession>();
 const liveSessionCreates = new Map<string, Promise<ClaudeLiveSession>>();
 
@@ -945,6 +968,9 @@ function handleClaudeLiveLine(session: ClaudeLiveSession, line: string): void {
 
 function handleClaudeStdout(session: ClaudeLiveSession, chunk: string) {
   resetNoOutputTimer(session);
+  if (session.currentTurn) {
+    emitLiveTurnDiagnosticProgress(session.currentTurn, "cli:live:stdout");
+  }
   session.stdoutBuffer += chunk;
   const maxPendingLineChars =
     session.currentTurn?.outputLimits.maxPendingLineChars ?? CLAUDE_LIVE_DEFAULT_MAX_TURN_RAW_CHARS;
@@ -1154,6 +1180,12 @@ function createTurn(params: {
       onCommentaryText: params.onCommentaryText,
     }),
     execPermission: params.execPermission,
+    diagnostic: {
+      runId: params.context.params.runId,
+      sessionId: params.context.params.sessionId,
+      sessionKey: params.context.params.sessionKey,
+      lastProgressEmittedAt: 0,
+    },
     resolve: params.resolve,
     reject: params.reject,
   };


### PR DESCRIPTION
## Summary

- **Problem:** A prior fix hooked the live-session liveness signal on `onAssistantDelta`, which the parser only invokes for `text_delta` content blocks. Reasoning-only Opus turns that emit just `thinking_delta` lines (no user-visible text) bypass the callback, so the diagnostic watchdog still aborts the run after about six minutes even though the CLI is actively streaming reasoning output.
- **Solution:** Move the live-session liveness signal upstream to `handleClaudeStdout`, which runs on every raw subprocess chunk before any JSONL parsing. The signal now covers every byte the CLI emits — `thinking_delta`, `tool_use`, `content_block_start/stop`, system events — so any progress, including reasoning-only progress, keeps the watchdog informed.
- **What changed:** `src/agents/cli-runner/claude-live-session.ts` (+33 lines) — adds a per-turn diagnostic identity, a throttled `emitLiveTurnDiagnosticProgress()` helper, and a single emit call at the raw-stdout boundary. Adds a new seam coverage file (+190 lines) driving the live session with thinking-only JSONL.
- **What did NOT change:** the watchdog thresholds, the session-recovery flow, the batch (`execute.ts`) `onStdout` path, the parser internals, and every non-claude-cli backend.

## Motivation

Addresses the P1 ClawSweeper finding on the prior PR: the live-progress signal needs to cover non-text stream activity. The real reproduction is a `claude-opus-4-7` turn with extended reasoning where the model emits six or more minutes of `thinking_delta` events before producing any user-visible text — exactly the case the prior fix missed.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration (cli-runner / claude-cli backend)

## Linked Issue/PR

Related to the prior live-progress fix that hooked the text-delta callback (link will be updated once that PR merges). Checked: this PR fixes a bug or regression.

## Real behavior proof

- **Behavior addressed:** the diagnostic stuck-session watchdog aborts long Opus reasoning turns because the prior live-progress hook fires only on `text_delta`. Reasoning-only streams emit `thinking_delta` lines that never reach the prior callback, so `lastProgressAgeMs` grows past `stuckSessionAbortMs` and the lane is killed even while real reasoning is streaming.
- **Real environment tested:** OpenClaw running on WSL2 Ubuntu, claude-cli backend (`@anthropic-ai/claude-code`), `claude-opus-4-7` and `claude-sonnet-4-6` via the live-session mode. The patched build is deployed against the same affected install that was originally hitting the watchdog abort.
- **Before evidence:** prior to this patch the diagnostic watchdog had no progress signal during reasoning-only phases — the prior text-delta hook never fired, so the lane recorded no `lastProgress` for the duration of a thinking burst and the watchdog aborted the run at the configured `stuckSessionAbortMs` (about six minutes) even while the CLI was actively streaming reasoning. Production runtime logs from that period showed `claude live session turn failed: ... error=AbortError` after roughly 360 seconds on Opus reasoning turns with no concurrent text output.
- **Exact steps or command run after this patch:** built OpenClaw from the patched source on the affected install and restarted the local gateway onto the new build, then drove a normal claude-cli session under `claude-opus-4-7` with the live-session mode enabled. Command sequence the gateway is running on:

```
node /home/<user>/Work/OpenClaw/dist/index.js gateway --port 18789
    # then exercise any claude-cli session whose Opus turns include long thinking phases
```

- **Evidence after fix:** copied live terminal output from the patched-build gateway — redacted runtime logs showing the new `cli:live:stdout` progress events firing on every raw CLI chunk and the watchdog seeing the resulting liveness:

```
[diagnostic] long-running session: sessionKey=agent:main:telegram:direct:<n> state=processing age=147s queueDepth=1 lastProgress=cli:live:stdout lastProgressAge=20s recovery=none
[diagnostic] long-running session: sessionKey=agent:main:telegram:direct:<n> state=processing age=122s queueDepth=1 lastProgress=cli:live:stdout lastProgressAge=6s  recovery=none
[diagnostic] long-running session: sessionKey=agent:main:telegram:direct:<n> state=processing age=245s queueDepth=1 lastProgress=cli:live:stdout lastProgressAge=6s  recovery=none
[diagnostic] long-running session: sessionKey=agent:main:main                  state=processing age=302s queueDepth=1 lastProgress=cli:live:stdout lastProgressAge=0s  recovery=none
[agent/cli-backend] claude live session turn: provider=claude-cli model=claude-opus-4-7 durationMs=121524 rawLines=193
[agent/cli-backend] claude live session turn: provider=claude-cli model=claude-opus-4-7 durationMs=114475 rawLines=112
```

The first four lines are the diagnostic system observing the new `cli:live:stdout` reason on long-running lanes, with `lastProgressAge` staying low (0–20 s) while the lane runs past 147–302 s of real work. `recovery=none` confirms the watchdog is no longer escalating to abort on these lanes. The last two lines are normal turn completions at 2 m 1 s and 1 m 54 s — durations that would previously have been at risk of abort if they contained reasoning-only intervals.

- **Observed result after fix:** on the patched-build gateway the diagnostic system records `lastProgress=cli:live:stdout` on every raw CLI chunk and `lastProgressAge` stays small while the lane runs. Long claude-opus-4-7 turns complete normally (durations above two minutes observed on the running gateway), no `AbortError` is emitted on the affected sessions for the duration of the observation window, and `recovery=none` for every long-running classification.
- **What was not tested:** an end-to-end reasoning-only turn of greater than six minutes against the live gateway — the patched build has been running normally with shorter (up to ~2 m) Opus turns, and a six-minute reasoning burst was not deliberately staged for this proof window; the seam test covers the throttle and the strict-coverage assertion that the new emit path fires even when only `thinking_delta` lines arrive.

## Root Cause

`createCliJsonlStreamingParser`'s `onAssistantDelta` callback only fires for `text_delta` content blocks. `thinking_delta`, `tool_use`, `content_block_start/stop`, and system events all pass through the parser but never invoke the delta callback. The prior fix hooked at that text-only boundary, leaving the diagnostic watchdog with no progress signal during reasoning-only phases. Missing guardrail: no regression coverage forced a reasoning-only stream through the live-session path.

## Regression Test Plan

`src/agents/cli-runner/claude-live-session.diagnostic-progress.test.ts` (new file): drives `runClaudeLiveSessionTurn` with a mocked supervisor that feeds JSONL `thinking_delta` lines through the live session's `onStdout`, asserts that `run.progress` with `reason="cli:live:stdout"` fires through the throttle window, and asserts that `onAssistantDelta` is never invoked — proving the stdout-level emission is strictly more inclusive than the prior text-delta hook.

## User-visible / Behavior Changes

None. Internal diagnostic signal only.

## Diagram

```text
Before (prior PR):
  CLI stdout (thinking_delta line) -> handleClaudeStdout
    -> streamingParser.push -> [filtered, no onAssistantDelta]
    -> no progress signal -> watchdog aborts at ~360 s

After (this PR):
  CLI stdout (any line) -> handleClaudeStdout
    -> emitLiveTurnDiagnosticProgress("cli:live:stdout") [throttled 10 s]
    -> streamingParser.push (unchanged)
    -> watchdog sees progress -> no abort
```

## Security Impact

- New permissions: No
- New secrets handling: No
- New network calls: No
- New exec surface: No
- New data access: No (the diagnostic emit uses only the already-available `runId`, `sessionId`, `sessionKey` from `PreparedCliRunContext.params` and a static `reason` literal)

## Repro + Verification

- **Environment:** OpenClaw on WSL2 Linux 6.6, Node 24, gateway local, `claude-opus-4-7` via `claude-cli` (live-session mode).
- **Steps:** rebuild from the patched source, restart the local gateway, drive a normal claude-cli session whose Opus turns include reasoning phases.
- **Expected:** the diagnostic system records `lastProgress=cli:live:stdout` on each raw CLI chunk; long-running sessions are kept alive while the CLI is actively streaming.
- **Actual (before):** the watchdog aborted reasoning-only turns at about 360 s with `AbortError` even while the CLI was emitting `thinking_delta` lines.

## Evidence

- [x] Failing-before-fix scenario locked in by the new seam coverage
- [x] Trace logs / terminal capture (before: production runtime logs showing the prior abort; after: patched-build gateway runtime logs above)

## Human Verification

Verified: the new seam coverage passes against the patched source; the existing cli-runner suite stays clean; the patched-build gateway emits `lastProgress=cli:live:stdout` against real claude-cli sessions and the watchdog stays at `recovery=none` for long-running lanes; durations above two minutes complete normally on Opus. NOT verified: a deliberately-staged reasoning-only turn of more than six minutes against the live gateway (no such turn was deliberately driven during the observation window).

## Review Conversations

- [x] Will resolve bot review threads before merge
- [x] Will respond to maintainer review comments

## Compatibility / Migration

Backward compatible. No config or migration. The new emit uses only existing run/session identifiers and a static `reason` literal.

## Risks and Mitigations

- **Risk:** a subprocess that emits raw stdout while genuinely hung would still keep the diagnostic watchdog from firing.
  **Mitigation:** the supervisor-level `noOutputTimeoutMs` watchdog (separate from the diagnostic watchdog) still kills truly silent processes; the throttle prevents spam from chatty streams.
- **Risk:** once the prior PR merges, the `onAssistantDelta` emission in `execute.ts` becomes redundant for the live-session path (text_delta also passes through `handleClaudeStdout`).
  **Mitigation:** redundant but harmless — the throttle bucket suppresses the duplicate emit. Happy to land a follow-up cleanup once both PRs are in.