### PR TITLE
fix(memory-core): guard builtin fallback after qmd failures

### DIFF
--- a/extensions/memory-core/src/memory/search-manager.test.ts
+++ b/extensions/memory-core/src/memory/search-manager.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
 import type { checkQmdBinaryAvailability as checkQmdBinaryAvailabilityFn } from "openclaw/plugin-sdk/memory-core-host-engine-qmd";
+import type { MemoryEmbeddingProbeResult } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 type CheckQmdBinaryAvailability = typeof checkQmdBinaryAvailabilityFn;
@@ -12,6 +13,8 @@ function createManagerStatus(params: {
   provider: string;
   model: string;
   requestedProvider: string;
+  fts?: { enabled: boolean; available: boolean; error?: string };
+  searchMode?: "hybrid" | "fts-only";
   withMemorySourceCounts?: boolean;
 }) {
   const base = {
@@ -24,6 +27,8 @@ function createManagerStatus(params: {
     dirty: false,
     workspaceDir: "/tmp",
     dbPath: "/tmp/index.sqlite",
+    ...(params.fts ? { fts: params.fts } : {}),
+    ...(params.searchMode ? { custom: { searchMode: params.searchMode } } : {}),
   };
   if (!params.withMemorySourceCounts) {
     return base;
@@ -44,6 +49,8 @@ function createManagerMock(params: {
   provider: string;
   model: string;
   requestedProvider: string;
+  fts?: { enabled: boolean; available: boolean; error?: string };
+  searchMode?: "hybrid" | "fts-only";
   searchResults?: Array<{
     path: string;
     startLine: number;
@@ -63,11 +70,15 @@ function createManagerMock(params: {
         provider: params.provider,
         model: params.model,
         requestedProvider: params.requestedProvider,
+        fts: params.fts,
+        searchMode: params.searchMode,
         withMemorySourceCounts: params.withMemorySourceCounts,
       }),
     ),
     sync: vi.fn(async () => {}),
-    probeEmbeddingAvailability: vi.fn(async () => ({ ok: true })),
+    probeEmbeddingAvailability: vi.fn<() => Promise<MemoryEmbeddingProbeResult>>(async () => ({
+      ok: true,
+    })),
     probeVectorAvailability: vi.fn(async () => true),
     close: vi.fn(async () => {}),
   };
@@ -107,7 +118,11 @@ const fallbackManager = vi.hoisted(() => ({
 }));
 
 const fallbackSearch = fallbackManager.search;
-const mockMemoryIndexGet = vi.hoisted(() => vi.fn(async () => fallbackManager));
+const mockMemoryIndexGet = vi.hoisted(() =>
+  vi.fn<(...args: unknown[]) => Promise<typeof fallbackManager | null>>(
+    async () => fallbackManager,
+  ),
+);
 const mockCloseAllMemoryIndexManagers = vi.hoisted(() => vi.fn(async () => {}));
 const mockCloseMemoryIndexManagersForAgent = vi.hoisted(() => vi.fn(async () => {}));
 const checkQmdBinaryAvailability = vi.hoisted(() =>
@@ -349,6 +364,13 @@ describe("getMemorySearchManager caching", () => {
 
   it("falls back immediately when the qmd binary is unavailable", async () => {
     const cfg = createQmdCfg("missing-qmd");
+    const probeManager = createManagerMock({
+      backend: "builtin",
+      provider: "openai",
+      model: "text-embedding-3-small",
+      requestedProvider: "openai",
+    });
+    mockMemoryIndexGet.mockResolvedValueOnce(probeManager).mockResolvedValueOnce(fallbackManager);
     checkQmdBinaryAvailability.mockResolvedValueOnce({
       available: false,
       error: "spawn qmd ENOENT",
@@ -359,8 +381,112 @@ describe("getMemorySearchManager caching", () => {
     const searchResults = await manager.search("hello");
 
     expect(createQmdManagerMock).not.toHaveBeenCalled();
-    expect(mockMemoryIndexGet).toHaveBeenCalled();
+    expect(mockMemoryIndexGet).toHaveBeenCalledTimes(2);
+    expect(mockMemoryIndexGet).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ agentId: "missing-qmd", purpose: "status" }),
+    );
+    expect(mockMemoryIndexGet).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ agentId: "missing-qmd" }),
+    );
     expect(searchResults).toHaveLength(1);
+  });
+
+  it("falls back to builtin FTS-only search when qmd cannot open and embeddings are unavailable", async () => {
+    const agentId = "missing-qmd-fts-only-fallback";
+    const cfg = createQmdCfg(agentId);
+    const unavailableProbe = createManagerMock({
+      backend: "builtin",
+      provider: "none",
+      model: "fts-only",
+      requestedProvider: "auto",
+      fts: { enabled: true, available: true },
+      searchMode: "fts-only",
+    });
+    unavailableProbe.probeEmbeddingAvailability.mockResolvedValueOnce({
+      ok: false,
+      error: "Local embeddings unavailable",
+    });
+    mockMemoryIndexGet
+      .mockResolvedValueOnce(unavailableProbe)
+      .mockResolvedValueOnce(fallbackManager);
+    checkQmdBinaryAvailability.mockResolvedValueOnce({
+      available: false,
+      error: "spawn qmd ENOENT",
+    });
+
+    const result = await getMemorySearchManager({ cfg, agentId });
+    const manager = requireManager(result);
+    const searchResults = await manager.search("hello");
+
+    expect(searchResults).toHaveLength(1);
+    expect(createQmdManagerMock).not.toHaveBeenCalled();
+    expect(unavailableProbe.probeEmbeddingAvailability).toHaveBeenCalledTimes(1);
+    expect(unavailableProbe.status).toHaveBeenCalledTimes(1);
+    expect(unavailableProbe.close).toHaveBeenCalledTimes(1);
+    expect(mockMemoryIndexGet).toHaveBeenCalledTimes(2);
+    expect(mockMemoryIndexGet).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ agentId, purpose: "status" }),
+    );
+    expect(mockMemoryIndexGet).toHaveBeenNthCalledWith(2, expect.objectContaining({ agentId }));
+  });
+
+  it("does not create a full builtin fallback when qmd cannot open and builtin FTS is unavailable", async () => {
+    const agentId = "missing-qmd-no-builtin-search";
+    const cfg = createQmdCfg(agentId);
+    const unavailableProbe = createManagerMock({
+      backend: "builtin",
+      provider: "none",
+      model: "fts-only",
+      requestedProvider: "auto",
+      fts: { enabled: true, available: false, error: "fts unavailable" },
+      searchMode: "fts-only",
+    });
+    unavailableProbe.probeEmbeddingAvailability.mockResolvedValueOnce({
+      ok: false,
+      error: "Local embeddings unavailable",
+    });
+    mockMemoryIndexGet.mockResolvedValueOnce(unavailableProbe);
+    checkQmdBinaryAvailability.mockResolvedValueOnce({
+      available: false,
+      error: "spawn qmd ENOENT",
+    });
+
+    const result = await getMemorySearchManager({ cfg, agentId });
+
+    expect(result.manager).toBeNull();
+    expect(result.error).toBe("Local embeddings unavailable");
+    expect(createQmdManagerMock).not.toHaveBeenCalled();
+    expect(unavailableProbe.probeEmbeddingAvailability).toHaveBeenCalledTimes(1);
+    expect(unavailableProbe.status).toHaveBeenCalledTimes(1);
+    expect(unavailableProbe.close).toHaveBeenCalledTimes(1);
+    expect(mockMemoryIndexGet).toHaveBeenCalledTimes(1);
+    expect(mockMemoryIndexGet).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId, purpose: "status" }),
+    );
+  });
+
+  it("does not create a full builtin fallback when qmd cannot open and builtin probe is unavailable", async () => {
+    const agentId = "missing-qmd-no-fallback-probe";
+    const cfg = createQmdCfg(agentId);
+    mockMemoryIndexGet.mockResolvedValueOnce(null);
+    checkQmdBinaryAvailability.mockResolvedValueOnce({
+      available: false,
+      error: "spawn qmd ENOENT",
+    });
+
+    const result = await getMemorySearchManager({ cfg, agentId });
+
+    expect(result.manager).toBeNull();
+    expect(result.error).toBe("builtin memory search unavailable");
+    expect(createQmdManagerMock).not.toHaveBeenCalled();
+    expect(fallbackSearch).not.toHaveBeenCalled();
+    expect(mockMemoryIndexGet).toHaveBeenCalledTimes(1);
+    expect(mockMemoryIndexGet).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId, purpose: "status" }),
+    );
   });
 
   it("backs off repeated full qmd open failures until the cooldown expires", async () => {
@@ -920,6 +1046,13 @@ describe("getMemorySearchManager caching", () => {
 
   it("falls back to builtin search when qmd fails with sqlite busy", async () => {
     const retryAgentId = "retry-agent-busy";
+    const probeManager = createManagerMock({
+      backend: "builtin",
+      provider: "openai",
+      model: "text-embedding-3-small",
+      requestedProvider: "openai",
+    });
+    mockMemoryIndexGet.mockResolvedValueOnce(probeManager).mockResolvedValueOnce(fallbackManager);
     const { manager: firstManager } = await createFailedQmdSearchHarness({
       agentId: retryAgentId,
       errorMessage: "qmd index busy while reading results: SQLITE_BUSY: database is locked",
@@ -929,6 +1062,16 @@ describe("getMemorySearchManager caching", () => {
     expect(results).toHaveLength(1);
     expect(results[0]?.path).toBe("MEMORY.md");
     expect(fallbackSearch).toHaveBeenCalledTimes(1);
+    expect(probeManager.probeEmbeddingAvailability).toHaveBeenCalledTimes(1);
+    expect(probeManager.close).toHaveBeenCalledTimes(1);
+    expect(mockMemoryIndexGet).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ agentId: retryAgentId, purpose: "status" }),
+    );
+    expect(mockMemoryIndexGet).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ agentId: retryAgentId }),
+    );
   });
 
   it("keeps original qmd error when fallback manager initialization fails", async () => {
@@ -940,6 +1083,95 @@ describe("getMemorySearchManager caching", () => {
     mockMemoryIndexGet.mockRejectedValueOnce(new Error("No API key found for provider openai"));
 
     await expect(firstManager.search("hello")).rejects.toThrow("qmd query failed");
+  });
+
+  it("keeps original qmd error when builtin fallback probe is unavailable", async () => {
+    const retryAgentId = "retry-agent-no-fallback-probe";
+    mockMemoryIndexGet.mockResolvedValueOnce(null);
+    const { manager: firstManager } = await createFailedQmdSearchHarness({
+      agentId: retryAgentId,
+      errorMessage: "qmd query failed",
+    });
+
+    await expect(firstManager.search("hello")).rejects.toThrow("qmd query failed");
+
+    expect(fallbackSearch).not.toHaveBeenCalled();
+    expect(mockMemoryIndexGet).toHaveBeenCalledTimes(1);
+    expect(mockMemoryIndexGet).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: retryAgentId, purpose: "status" }),
+    );
+  });
+
+  it("falls back to builtin FTS-only search when builtin fallback embeddings are unavailable", async () => {
+    const retryAgentId = "retry-agent-fts-only-fallback";
+    const unavailableProbe = createManagerMock({
+      backend: "builtin",
+      provider: "none",
+      model: "fts-only",
+      requestedProvider: "auto",
+      fts: { enabled: true, available: true },
+      searchMode: "fts-only",
+    });
+    unavailableProbe.probeEmbeddingAvailability.mockResolvedValueOnce({
+      ok: false,
+      error: "Local embeddings unavailable",
+    });
+    mockMemoryIndexGet
+      .mockResolvedValueOnce(unavailableProbe)
+      .mockResolvedValueOnce(fallbackManager);
+    const { manager: firstManager } = await createFailedQmdSearchHarness({
+      agentId: retryAgentId,
+      errorMessage: "qmd query failed",
+    });
+
+    const results = await firstManager.search("hello");
+
+    expect(results).toHaveLength(1);
+    expect(unavailableProbe.probeEmbeddingAvailability).toHaveBeenCalledTimes(1);
+    expect(unavailableProbe.status).toHaveBeenCalledTimes(1);
+    expect(unavailableProbe.close).toHaveBeenCalledTimes(1);
+    expect(fallbackSearch).toHaveBeenCalledTimes(1);
+    expect(mockMemoryIndexGet).toHaveBeenCalledTimes(2);
+    expect(mockMemoryIndexGet).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ agentId: retryAgentId, purpose: "status" }),
+    );
+    expect(mockMemoryIndexGet).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ agentId: retryAgentId }),
+    );
+  });
+
+  it("keeps original qmd error when builtin fallback embeddings and FTS are unavailable", async () => {
+    const retryAgentId = "retry-agent-no-builtin-search";
+    const unavailableProbe = createManagerMock({
+      backend: "builtin",
+      provider: "none",
+      model: "fts-only",
+      requestedProvider: "auto",
+      fts: { enabled: true, available: false, error: "fts unavailable" },
+      searchMode: "fts-only",
+    });
+    unavailableProbe.probeEmbeddingAvailability.mockResolvedValueOnce({
+      ok: false,
+      error: "Local embeddings unavailable",
+    });
+    mockMemoryIndexGet.mockResolvedValueOnce(unavailableProbe);
+    const { manager: firstManager } = await createFailedQmdSearchHarness({
+      agentId: retryAgentId,
+      errorMessage: "qmd query failed",
+    });
+
+    await expect(firstManager.search("hello")).rejects.toThrow("qmd query failed");
+
+    expect(unavailableProbe.probeEmbeddingAvailability).toHaveBeenCalledTimes(1);
+    expect(unavailableProbe.status).toHaveBeenCalledTimes(1);
+    expect(unavailableProbe.close).toHaveBeenCalledTimes(1);
+    expect(fallbackSearch).not.toHaveBeenCalled();
+    expect(mockMemoryIndexGet).toHaveBeenCalledTimes(1);
+    expect(mockMemoryIndexGet).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: retryAgentId, purpose: "status" }),
+    );
   });
 
   it("closes cached managers on global teardown", async () => {

--- a/extensions/memory-core/src/memory/search-manager.ts
+++ b/extensions/memory-core/src/memory/search-manager.ts
@@ -12,6 +12,7 @@ import { checkQmdBinaryAvailability } from "openclaw/plugin-sdk/memory-core-host
 import {
   resolveMemoryBackendConfig,
   type MemoryEmbeddingProbeResult,
+  type MemoryProviderStatus,
   type MemorySearchManager,
   type MemorySearchRuntimeDebug,
   type MemorySource,
@@ -108,6 +109,11 @@ export type MemorySearchManagerResult = {
 };
 
 export type MemorySearchManagerPurpose = "default" | "status" | "cli";
+type MemorySearchManagerParams = {
+  cfg: OpenClawConfig;
+  agentId: string;
+  purpose?: MemorySearchManagerPurpose;
+};
 
 function getActiveQmdManagerOpenFailure(
   scopeKey: string,
@@ -145,11 +151,9 @@ function clearQmdManagerOpenFailure(scopeKey: string, identityKey: string): void
   }
 }
 
-export async function getMemorySearchManager(params: {
-  cfg: OpenClawConfig;
-  agentId: string;
-  purpose?: MemorySearchManagerPurpose;
-}): Promise<MemorySearchManagerResult> {
+export async function getMemorySearchManager(
+  params: MemorySearchManagerParams,
+): Promise<MemorySearchManagerResult> {
   const resolved = resolveMemoryBackendConfig(params);
   if (resolved.backend === "qmd" && resolved.qmd) {
     const qmdResolved = resolved.qmd;
@@ -224,8 +228,8 @@ export async function getMemorySearchManager(params: {
         {
           primary,
           fallbackFactory: async () => {
-            const { MemoryIndexManager } = await loadManagerRuntime();
-            return await MemoryIndexManager.get(params);
+            const fallback = await getAvailableBuiltinFallbackMemorySearchManager(params);
+            return fallback.manager;
           },
         },
         () => {
@@ -266,7 +270,7 @@ export async function getMemorySearchManager(params: {
     const recentFailure = getActiveQmdManagerOpenFailure(scopeKey, identityKey);
     if (recentFailure) {
       log.debug?.(`qmd memory unavailable; using builtin during cooldown: ${recentFailure.reason}`);
-      return await getBuiltinMemorySearchManager(params);
+      return await getAvailableBuiltinFallbackMemorySearchManager(params);
     }
 
     const pending = PENDING_QMD_MANAGER_CREATES.get(scopeKey);
@@ -303,17 +307,60 @@ export async function getMemorySearchManager(params: {
     };
     PENDING_QMD_MANAGER_CREATES.set(scopeKey, pendingCreate);
     const manager = await pendingCreate.promise;
-    return manager ? { manager } : await getBuiltinMemorySearchManager(params);
+    return manager ? { manager } : await getAvailableBuiltinFallbackMemorySearchManager(params);
   }
 
   return await getBuiltinMemorySearchManager(params);
 }
 
-async function getBuiltinMemorySearchManager(params: {
-  cfg: OpenClawConfig;
-  agentId: string;
-  purpose?: MemorySearchManagerPurpose;
-}): Promise<MemorySearchManagerResult> {
+async function getAvailableBuiltinFallbackMemorySearchManager(
+  params: MemorySearchManagerParams,
+): Promise<MemorySearchManagerResult> {
+  try {
+    const { MemoryIndexManager } = await loadManagerRuntime();
+    // Probe with a transient manager so an unavailable fallback does not leave
+    // builtin memory watchers running beside the active QMD backend.
+    const probe = await MemoryIndexManager.get({ ...params, purpose: "status" });
+    if (!probe) {
+      const message = "builtin memory search unavailable";
+      log.warn(`memory fallback skipped because ${message}`);
+      return { manager: null, error: message };
+    }
+    try {
+      const availability = await probe.probeEmbeddingAvailability();
+      if (!availability.ok) {
+        const message = availability.error ?? "unknown error";
+        if (!canUseBuiltinFtsOnlyFallback(probe.status())) {
+          log.warn(
+            `memory fallback skipped because builtin embeddings and FTS are unavailable: ${message}`,
+          );
+          return { manager: null, error: message };
+        }
+        log.warn(`memory fallback using builtin FTS-only search: ${message}`);
+      }
+    } finally {
+      await probe.close?.().catch(() => {});
+    }
+    const manager = await MemoryIndexManager.get(params);
+    return { manager };
+  } catch (err) {
+    const message = formatErrorMessage(err);
+    return { manager: null, error: message };
+  }
+}
+
+function canUseBuiltinFtsOnlyFallback(status: MemoryProviderStatus): boolean {
+  return (
+    status.backend === "builtin" &&
+    status.fts?.enabled === true &&
+    status.fts.available === true &&
+    (status.provider === "none" || status.custom?.searchMode === "fts-only")
+  );
+}
+
+async function getBuiltinMemorySearchManager(
+  params: MemorySearchManagerParams,
+): Promise<MemorySearchManagerResult> {
   try {
     const { MemoryIndexManager } = await loadManagerRuntime();
     const manager = await MemoryIndexManager.get(params);


### PR DESCRIPTION
## Summary

- Problem: QMD fallback could create a full builtin memory manager even when builtin memory search was disabled or unusable, leaving unnecessary long-lived builtin resources after QMD failures.
- Solution: probe the builtin fallback with a transient status manager before creating the full builtin manager.
- What changed: QMD open/search failures now only create a full builtin fallback when the transient probe returns a manager and either embeddings are available or builtin FTS-only search is available.
- What did NOT change (scope boundary): QMD search behavior, builtin indexing/search internals, and memory configuration keys are unchanged.

## Motivation

QMD is documented as falling back to the builtin engine when unavailable. The fallback should not create a persistent builtin manager when builtin memory is disabled or has no usable search path, but it should still preserve builtin FTS-only keyword fallback when embeddings are unavailable.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Authentication
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- None
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: QMD failures fall back to builtin memory only when the builtin fallback can actually search, while preserving FTS-only fallback when embeddings are unavailable.
- Real environment tested: Patched source checkout, using the memory subsystem runtime logger while exercising QMD open-failure, QMD search-failure, builtin-unavailable, embeddings-unavailable, and FTS-only fallback paths. The log excerpt below is redacted to remove host, user, absolute path, and unrelated channel fields.
- Exact steps or command run after this patch:
  - `node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo`
  - `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo`
  - `node scripts/run-vitest.mjs extensions/memory-core/src/memory/search-manager.test.ts`
  - `git diff --check origin/main..HEAD`
  - `rg -n "qmd memory failed; switching to builtin index|qmd binary unavailable|memory fallback using builtin FTS-only search|memory fallback skipped because builtin embeddings and FTS are unavailable|memory fallback requested but builtin index is unavailable" <runtime-log>`
- Evidence after fix: Redacted runtime log excerpt from the patched memory subsystem. It shows the patched runtime taking all three intended branches: preserving FTS-only fallback, skipping fallback when both embeddings and FTS are unavailable, and returning a clean unavailable result when the builtin probe returns no manager.

  ```text
  2026-05-20T19:06:28.518+08:00  WARN memory  qmd binary unavailable (qmd); falling back to builtin: spawn qmd ENOENT
  2026-05-20T19:06:28.519+08:00  WARN memory  memory fallback using builtin FTS-only search: Local embeddings unavailable

  2026-05-20T19:06:28.520+08:00  WARN memory  qmd binary unavailable (qmd); falling back to builtin: spawn qmd ENOENT
  2026-05-20T19:06:28.521+08:00  WARN memory  memory fallback skipped because builtin embeddings and FTS are unavailable: Local embeddings unavailable

  2026-05-20T19:06:28.741+08:00  WARN memory  qmd memory failed; switching to builtin index: qmd query failed
  2026-05-20T19:06:28.742+08:00  WARN memory  qmd memory failed; switching to builtin index: qmd index busy while reading results: SQLITE_BUSY: database is locked
  2026-05-20T19:06:28.744+08:00  WARN memory  memory fallback requested but builtin index is unavailable

  2026-05-20T19:06:28.748+08:00  WARN memory  qmd memory failed; switching to builtin index: qmd query failed
  2026-05-20T19:06:28.749+08:00  WARN memory  memory fallback using builtin FTS-only search: Local embeddings unavailable
  2026-05-20T19:06:28.750+08:00  WARN memory  qmd memory failed; switching to builtin index: qmd query failed
  2026-05-20T19:06:28.751+08:00  WARN memory  memory fallback skipped because builtin embeddings and FTS are unavailable: Local embeddings unavailable
  ```

- Observed result after fix: The fallback probe no longer dereferences a missing builtin manager, skips full fallback when builtin search is unavailable, and preserves builtin FTS-only fallback when embeddings are unavailable.
- What was not tested: A full gateway restart/build smoke was not run for this PR.
- Before evidence (optional but encouraged): Existing behavior constructed the builtin fallback directly after QMD failures; existing tests did not cover null builtin probes or FTS-only fallback after QMD failures.

## Root Cause (if applicable)

- Root cause: QMD fallback creation previously treated builtin fallback creation as unconditional after QMD failure.
- Missing detection / guardrail: Tests did not cover `MemoryIndexManager.get(...purpose: "status")` returning null, or embeddings-unavailable status with FTS-only search still available.
- Contributing context (if known): Builtin memory supports FTS-only search when no embedding provider is available, so embedding availability cannot be used as the sole fallback availability signal.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/memory-core/src/memory/search-manager.test.ts`
- Scenario the test should lock in: QMD failures probe builtin fallback first; null probes stay unavailable; embeddings-unavailable with FTS available still falls back; embeddings-unavailable with FTS unavailable stays unavailable.
- Why this is the smallest reliable guardrail: The regression is in fallback-manager selection and can be isolated with mocked QMD and builtin managers.
- Existing test that already covers this (if any): Existing fallback tests covered QMD failures but not null probes or FTS-only fallback availability.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

When QMD is configured and unavailable, builtin fallback is attempted only when the builtin fallback manager is available and has a usable search path. Setups that rely on builtin FTS-only keyword fallback still work when embeddings are unavailable.

## Diagram (if applicable)

```text
Before:
QMD failure -> create full builtin fallback -> search or persistent fallback resources

After:
QMD failure -> transient builtin probe -> full fallback only when builtin search is usable
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Sensitive material handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node-based source checkout
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): `memory.backend = "qmd"` with builtin fallback scenarios covered by focused tests and runtime log output.

### Steps

1. Configure memory with QMD backend.
2. Trigger QMD open and search failures.
3. Verify builtin fallback is probed before full fallback creation.
4. Verify embeddings-unavailable + FTS-available keeps builtin keyword fallback.
5. Verify embeddings-unavailable + FTS-unavailable skips the full builtin fallback.

### Expected

- Missing builtin fallback manager returns a clean unavailable result.
- Builtin FTS-only fallback remains available when embeddings are unavailable and FTS is ready.
- Full builtin fallback is skipped when both embeddings and FTS are unavailable.

### Actual

- Matches expected after this patch; see redacted runtime log excerpt above.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: QMD missing binary fallback, QMD search failure fallback, null builtin probe, embeddings unavailable with FTS available, embeddings unavailable with FTS unavailable.
- Verified runtime log branches: `memory fallback using builtin FTS-only search`, `memory fallback skipped because builtin embeddings and FTS are unavailable`, and `memory fallback requested but builtin index is unavailable`.
- Edge cases checked: QMD open-failure cooldown path and QMD primary search failure path both use the guarded builtin fallback helper.
- What you did **not** verify: Full gateway restart/build smoke.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: The probe could be too strict and skip a usable non-FTS fallback mode.
  - Mitigation: The helper allows fallback when embeddings probe passes, and separately preserves the documented FTS-only path when embeddings are unavailable.

---

This PR was prepared with AI assistance.
