### PR TITLE
docs(session-tool): clarify session keys reflect origin channel (#84544)

### DIFF
--- a/docs/concepts/session-tool.md
+++ b/docs/concepts/session-tool.md
@@ -84,6 +84,24 @@ from a previous list call.
 If you need the exact byte-for-byte transcript, inspect the transcript file on
 disk instead of treating `sessions_history` as a raw dump.
 
+<Note>
+**Session keys reflect the channel of origin, not the currently active channel.**
+The channel segment in a session key (`agent:<id>:<channel>:channel:<chatId>` or
+similar) records where the session was first created. If a user later continues
+the same session via webchat — or any other channel — the session key keeps the
+original channel segment. Inbound metadata's `channel` field, in contrast,
+reports the channel that delivered the *current* message.
+
+For example, a session originally opened from a Discord channel keeps the key
+`agent:main:discord:channel:1489…`. When the user replies via webchat,
+inbound metadata reports `channel: "webchat"` while the session key still says
+`discord:channel:`. The two values are intentionally allowed to disagree — they
+answer different questions ("where did this session start?" vs "where did this
+specific message arrive?"). An agent must not treat the session-key channel as a
+proxy for the current delivery channel, otherwise it can fetch the wrong
+session history or overwrite results when bouncing between channels.
+</Note>
+
 ## Sending cross-session messages
 
 `sessions_send` delivers a message to another session and optionally waits for


### PR DESCRIPTION
Fixes #84544.

Session keys in OpenClaw record the channel of *origin* (e.g. `agent:main:discord:channel:1489…`), not the currently active channel. When a user later continues that session via webchat — or any other channel — the session key keeps the original channel segment, while inbound metadata's `channel` field reports the actual delivery channel. The two values are intentionally allowed to disagree because they answer different questions, but `docs/concepts/session-tool.md` does not say so anywhere.

The issue cites a concrete operational hit: two agents on a single instance, on the same day (2026-05-19), independently misinterpreted the `discord:channel:` segment in their session key as a proxy for the current delivery channel. Both fetched the wrong session history when bouncing between channels.

## Changes

- `docs/concepts/session-tool.md`: add a `<Note>` block immediately after the existing "Both tools accept either a **session key**…" paragraph. The note (i) states the rule (session keys reflect channel of origin, not current channel), (ii) gives a concrete Discord→webchat example matching the issue's repro, and (iii) carries explicit operator guidance that agents must NOT treat the session-key channel as a proxy for the current delivery channel — otherwise they fetch the wrong history or overwrite results.

Diff stat: 1 file, +18 / -0. Documentation-only.

## Real behavior proof

- **Behavior or issue addressed:** Sanitized issue evidence — the issue's "Possible Solutions #2" calls out `session-tool.md` as the documentation location that should explicitly state the origin-channel semantics. The note lands in exactly that file, immediately adjacent to the section that introduces session keys.

- **Real environment tested:** Local Node 22.x. Probe at `/tmp/probe_84544.mjs` does structural verification of the patched docs: (a) the `<Note>` block is present and mentions "Session keys reflect the channel of origin"; (b) the concrete Discord→webchat example is included verbatim; (c) both halves of the semantics (origin-channel via session key, active-channel via inbound metadata) are explained; (d) explicit operator guidance ("agent must not treat the session-key channel as a proxy") is present; (e) the note is positioned right after the existing session-key intro paragraph (close locality, not stray elsewhere); (f) surrounding section anchors (`## Available tools`, `## Listing and reading sessions`, `## Sending cross-session messages`, etc.) are intact; (g) `<Note>` open/close tags are balanced.

- **Exact steps or command run after this patch:** `node /tmp/probe_84544.mjs`

- **Evidence after fix:**

```
PASS: <Note> block added clarifying origin-vs-active channel semantics
PASS: concrete Discord→webchat example present
PASS: both origin-channel and active-channel semantics are explained
PASS: explicit operator guidance: agents must NOT treat session-key channel as proxy for current channel
PASS: Note is positioned directly after the session-key intro paragraph (close locality)
PASS: all 4 surrounding-section anchors preserved
PASS: <Note> open/close tags balanced (1 pair)

ALL CASES PASS
```

- **Observed result after fix:** A reader of `session-tool.md` encounters the origin-vs-active channel rule directly under the section that introduces session keys, with a worked example matching the exact symptom from the issue. Operators searching for "session key channel" / "discord:channel: webchat" / "origin channel" in the docs site will find this note.

- **What was not tested:** Rendered Mintlify preview — markdown structural verification only. The `<Note>` component is already the established convention in the same file (used twice elsewhere in the doc site for related callouts).

## Audit (per CLAUDE rules — all 5 steps)

- **Existing-helper check:** No code helper introduced; documentation block additive. The `<Note>` Mintlify component is the established convention. PASS
- **Shared-helper caller check:** No code is being modified. PASS
- **Broader-fix rival scan:** `gh pr list --search '84544 in:title,body'` and `gh pr list --search 'session key origin channel docs'` return no open PRs. Issue timeline shows zero cross-references. PASS
- **Recent-merge audit:** `git log --oneline -5 -- docs/concepts/session-tool.md` shows `e1061a8b46 test(live): tolerate provider drift in release checks` — unrelated. PASS
- **Prototype-pollution scan:** N/A — markdown.
