### PR TITLE
fix(errors): dedupe identical messages when traversing error .cause chain

### DIFF
--- a/src/infra/errors.test.ts
+++ b/src/infra/errors.test.ts
@@ -88,10 +88,11 @@ describe("error helpers", () => {
     expect(formatted).toBe("error A | error B");
   });
 
-  it("dedupes causes whose message repeats the parent (e.g. FailoverError wrapping)", () => {
-    const inner = new Error('No API key found for provider "openai-codex".');
+  it("dedupes repeated cause messages while preserving deeper distinct causes", () => {
+    const rootCause = new Error("provider auth lookup failed");
+    const inner = new Error('No API key found for provider "openai-codex".', { cause: rootCause });
     const wrapper = new Error(inner.message, { cause: inner });
-    expect(formatErrorMessage(wrapper)).toBe(inner.message);
+    expect(formatErrorMessage(wrapper)).toBe(`${inner.message} | ${rootCause.message}`);
   });
 
   it("redacts sensitive tokens from formatted error messages", () => {

--- a/src/infra/errors.test.ts
+++ b/src/infra/errors.test.ts
@@ -88,6 +88,12 @@ describe("error helpers", () => {
     expect(formatted).toBe("error A | error B");
   });
 
+  it("dedupes causes whose message repeats the parent (e.g. FailoverError wrapping)", () => {
+    const inner = new Error('No API key found for provider "openai-codex".');
+    const wrapper = new Error(inner.message, { cause: inner });
+    expect(formatErrorMessage(wrapper)).toBe(inner.message);
+  });
+
   it("redacts sensitive tokens from formatted error messages", () => {
     const token = "sk-abcdefghijklmnopqrstuv";
     const formatted = formatErrorMessage(new Error(`Authorization: Bearer ${token}`));

--- a/src/infra/errors.ts
+++ b/src/infra/errors.ts
@@ -74,18 +74,20 @@ export function formatErrorMessage(err: unknown): string {
     const seen = new Set<unknown>([err]);
     // Skip causes that repeat a message already emitted (e.g. coerceToFailoverError).
     const seenMessages = new Set<string>([formatted]);
+    const appendCauseMessage = (message: string): void => {
+      if (!message || seenMessages.has(message)) {
+        return;
+      }
+      formatted += ` | ${message}`;
+      seenMessages.add(message);
+    };
     while (cause && !seen.has(cause)) {
       seen.add(cause);
       if (cause instanceof Error) {
-        if (cause.message && !seenMessages.has(cause.message)) {
-          formatted += ` | ${cause.message}`;
-          seenMessages.add(cause.message);
-        }
+        appendCauseMessage(cause.message);
         cause = cause.cause;
       } else if (typeof cause === "string") {
-        if (!seenMessages.has(cause)) {
-          formatted += ` | ${cause}`;
-        }
+        appendCauseMessage(cause);
         break;
       } else {
         break;

--- a/src/infra/errors.ts
+++ b/src/infra/errors.ts
@@ -72,15 +72,20 @@ export function formatErrorMessage(err: unknown): string {
     // Traverse .cause chain to include nested error messages (e.g. grammY HttpError wraps network errors in .cause)
     let cause: unknown = err.cause;
     const seen = new Set<unknown>([err]);
+    // Skip causes that repeat a message already emitted (e.g. coerceToFailoverError).
+    const seenMessages = new Set<string>([formatted]);
     while (cause && !seen.has(cause)) {
       seen.add(cause);
       if (cause instanceof Error) {
-        if (cause.message) {
+        if (cause.message && !seenMessages.has(cause.message)) {
           formatted += ` | ${cause.message}`;
+          seenMessages.add(cause.message);
         }
         cause = cause.cause;
       } else if (typeof cause === "string") {
-        formatted += ` | ${cause}`;
+        if (!seenMessages.has(cause)) {
+          formatted += ` | ${cause}`;
+        }
         break;
       } else {
         break;


### PR DESCRIPTION
See before and after in these 2 messages:

<img width="732" height="383" alt="image" src="https://github.com/user-attachments/assets/cb107b5d-e85b-4c88-adfa-6140bad11b7b" />


## Summary

- `formatErrorMessage` walked `.cause` and appended every level joined by ` | `, so a wrapper that carried the same string as its cause produced doubled output.
- `coerceToFailoverError` (`src/agents/failover-error.ts:524-563`) does exactly that: it builds a `FailoverError` whose `message` is read from the wrapped error and sets `cause: err`. That made auth failures like `No API key found for provider "openai-codex" …` surface in the TUI as the same sentence twice, separated by ` | `, inside the ⚠️ Agent failed before reply line.
- Now the formatter tracks already-emitted messages and skips repeats — leaving genuinely-different cause messages intact (still joined with ` | `).

Behavior addressed: TUI control-UI failure path renders the error message once instead of duplicated. Underlying auth misconfiguration is unchanged.

## Test plan

- [x] `node scripts/run-vitest.mjs src/infra/errors.test.ts` (added a regression case covering the FailoverError-style wrap).