### PR TITLE
fix: strip plaintext model api keys from models json

### DIFF
--- a/src/agents/models-config.applies-config-env-vars.test.ts
+++ b/src/agents/models-config.applies-config-env-vars.test.ts
@@ -276,4 +276,156 @@ describe("models-config", () => {
       expect(process.env[TEST_ENV_VAR]).toBe("from-host");
     });
   });
+
+  it("omits plaintext configured provider apiKeys from generated models.json", async () => {
+    const plan = await planOpenClawModelsJsonWithDeps(
+      {
+        cfg: {
+          models: {
+            providers: {
+              custom: {
+                baseUrl: "https://custom.example/v1",
+                api: "openai-responses",
+                apiKey: "sk-config-plaintext-secret", // pragma: allowlist secret
+                models: [
+                  {
+                    id: "custom-model",
+                    name: "Custom Model",
+                    input: ["text"],
+                    reasoning: false,
+                    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                    contextWindow: 8192,
+                    maxTokens: 2048,
+                  },
+                ],
+              },
+            },
+          },
+        },
+        agentDir: "/tmp/openclaw-models-config-env-vars-test",
+        env: {},
+        existingRaw: "",
+        existingParsed: null,
+      },
+      {
+        resolveImplicitProviders: async () => ({}),
+      },
+    );
+
+    expect(plan.action).toBe("write");
+    if (plan.action !== "write") {
+      throw new Error("Expected models.json write plan");
+    }
+    const parsed = JSON.parse(plan.contents) as {
+      providers?: Record<string, { apiKey?: string; models?: Array<{ id?: string }> }>;
+    };
+    expect(parsed.providers?.custom?.apiKey).toBeUndefined();
+    expect(parsed.providers?.custom?.models?.map((model) => model.id)).toEqual(["custom-model"]);
+    expect(plan.contents).not.toContain("sk-config-plaintext-secret");
+  });
+
+  it("omits plaintext apiKeys merged from existing models.json entries", async () => {
+    const plan = await planOpenClawModelsJsonWithDeps(
+      {
+        cfg: {
+          models: {
+            mode: "merge",
+            providers: {
+              custom: {
+                baseUrl: "https://custom.example/v1",
+                api: "openai-responses",
+                models: [
+                  {
+                    id: "custom-model",
+                    name: "Custom Model",
+                    input: ["text"],
+                    reasoning: false,
+                    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                    contextWindow: 8192,
+                    maxTokens: 2048,
+                  },
+                ],
+              },
+            },
+          },
+        },
+        agentDir: "/tmp/openclaw-models-config-env-vars-test",
+        env: {},
+        existingRaw: "",
+        existingParsed: {
+          providers: {
+            custom: {
+              baseUrl: "https://custom.example/v1",
+              api: "openai-responses",
+              apiKey: "sk-existing-plaintext-secret", // pragma: allowlist secret
+              models: [],
+            },
+          },
+        },
+      },
+      {
+        resolveImplicitProviders: async () => ({}),
+      },
+    );
+
+    expect(plan.action).toBe("write");
+    if (plan.action !== "write") {
+      throw new Error("Expected models.json write plan");
+    }
+    const parsed = JSON.parse(plan.contents) as {
+      providers?: Record<string, { apiKey?: string; baseUrl?: string }>;
+    };
+    expect(parsed.providers?.custom?.apiKey).toBeUndefined();
+    expect(parsed.providers?.custom?.baseUrl).toBe("https://custom.example/v1");
+    expect(plan.contents).not.toContain("sk-existing-plaintext-secret");
+  });
+
+  it("preserves SecretRef-managed provider apiKey markers in generated models.json", async () => {
+    const plan = await planOpenClawModelsJsonWithDeps(
+      {
+        cfg: {
+          models: {
+            providers: {
+              custom: {
+                baseUrl: "https://custom.example/v1",
+                api: "openai-responses",
+                apiKey: {
+                  source: "env",
+                  provider: "default",
+                  id: "CUSTOM_PROVIDER_API_KEY",
+                },
+                models: [
+                  {
+                    id: "custom-model",
+                    name: "Custom Model",
+                    input: ["text"],
+                    reasoning: false,
+                    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                    contextWindow: 8192,
+                    maxTokens: 2048,
+                  },
+                ],
+              },
+            },
+          },
+        },
+        agentDir: "/tmp/openclaw-models-config-env-vars-test",
+        env: {},
+        existingRaw: "",
+        existingParsed: null,
+      },
+      {
+        resolveImplicitProviders: async () => ({}),
+      },
+    );
+
+    expect(plan.action).toBe("write");
+    if (plan.action !== "write") {
+      throw new Error("Expected models.json write plan");
+    }
+    const parsed = JSON.parse(plan.contents) as {
+      providers?: Record<string, { apiKey?: string }>;
+    };
+    expect(parsed.providers?.custom?.apiKey).toBe("CUSTOM_PROVIDER_API_KEY"); // pragma: allowlist secret
+  });
 });

--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import { isRecord } from "../utils.js";
+import { isNonSecretApiKeyMarker } from "./model-auth-markers.js";
 import {
   mergeProviders,
   mergeWithExistingProviderSecrets,
@@ -105,6 +106,30 @@ function resolveProvidersForMode(params: {
   });
 }
 
+function stripPlaintextProviderApiKeysForModelsJson(params: {
+  providers: Record<string, ProviderConfig>;
+  secretRefManagedProviders: ReadonlySet<string>;
+}): Record<string, ProviderConfig> {
+  let nextProviders: Record<string, ProviderConfig> | null = null;
+  for (const [providerKey, provider] of Object.entries(params.providers)) {
+    if (!isRecord(provider) || provider.apiKey === undefined) {
+      continue;
+    }
+    if (
+      typeof provider.apiKey === "string" &&
+      (params.secretRefManagedProviders.has(providerKey.trim()) ||
+        isNonSecretApiKeyMarker(provider.apiKey))
+    ) {
+      continue;
+    }
+
+    const { apiKey: _apiKey, ...providerWithoutPlaintextApiKey } = provider;
+    nextProviders ??= { ...params.providers };
+    nextProviders[providerKey] = providerWithoutPlaintextApiKey;
+  }
+  return nextProviders ?? params.providers;
+}
+
 export async function planOpenClawModelsJsonWithDeps(
   params: {
     cfg: OpenClawConfig;
@@ -177,7 +202,10 @@ export async function planOpenClawModelsJsonWithDeps(
       sourceSecretDefaults: params.sourceConfigForSecrets?.secrets?.defaults,
       secretRefManagedProviders,
     }) ?? normalizedMergedProviders;
-  const finalProviders = applyNativeStreamingUsageCompat(secretEnforcedProviders);
+  const finalProviders = stripPlaintextProviderApiKeysForModelsJson({
+    providers: applyNativeStreamingUsageCompat(secretEnforcedProviders),
+    secretRefManagedProviders,
+  });
   const nextContents = `${JSON.stringify({ providers: finalProviders }, null, 2)}\n`;
 
   if (params.existingRaw === nextContents) {


### PR DESCRIPTION
## Summary
- Strip plaintext provider apiKey values from generated models.json before prompt-visible serialization.
- Preserve SecretRef/env-managed markers and known non-secret auth markers.
- Add regression coverage for configured plaintext keys, existing merge-mode models.json plaintext keys, and SecretRef markers.

Refs #11829

## Verification
- pnpm format:check src/agents/models-config.plan.ts src/agents/models-config.applies-config-env-vars.test.ts
- node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/models-config.plan.ts src/agents/models-config.applies-config-env-vars.test.ts
- node scripts/run-vitest.mjs run src/agents/models-config.applies-config-env-vars.test.ts src/agents/models-config.merge.test.ts --passWithNoTests=false
- pnpm tsgo:core
- pnpm tsgo:core:test

## Real behavior proof
Behavior addressed: Generated models.json no longer persists plaintext provider apiKey values from active config or old merge-mode models.json entries.

Real environment tested: Windows 11/PowerShell, Node v23.11.0, pnpm 11.1.0, local OpenClaw source checkout.

Exact steps or command run after this patch:
- node --import tsx .artifacts/proof-models-json.mts
- pnpm format:check src/agents/models-config.plan.ts src/agents/models-config.applies-config-env-vars.test.ts
- node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/models-config.plan.ts src/agents/models-config.applies-config-env-vars.test.ts
- node scripts/run-vitest.mjs run src/agents/models-config.applies-config-env-vars.test.ts src/agents/models-config.merge.test.ts --passWithNoTests=false
- pnpm tsgo:core
- pnpm tsgo:core:test

Evidence after fix: Terminal output from a local OpenClaw source checkout invoking the patched models.json planner. The command used a fake plaintext provider apiKey value and printed the generated provider JSON after the patch:

```json
{
  "action": "write",
  "providerKeys": [
    "custom"
  ],
  "customHasApiKey": false,
  "planContainsPlaintext": false,
  "modelIds": [
    "proof-model"
  ],
  "writtenModelsJson": {
    "providers": {
      "custom": {
        "baseUrl": "https://example.invalid/v1",
        "api": "openai-responses",
        "models": [
          {
            "id": "proof-model",
            "name": "Proof Model",
            "input": [
              "text"
            ],
            "reasoning": false,
            "cost": {
              "input": 0,
              "output": 0,
              "cacheRead": 0,
              "cacheWrite": 0
            },
            "contextWindow": 8192,
            "maxTokens": 2048
          }
        ]
      }
    }
  }
}
```

Observed result after fix: The command exited 0. The generated provider JSON contains the custom provider and model, but `customHasApiKey` is false and `planContainsPlaintext` is false, confirming the plaintext apiKey was not written into models.json.

What was not tested: Full suite, live gateway/model provider calls, and cross-platform Testbox/Crabbox proof.
