### PR TITLE
fix(minimax): stream music generation responses

### DIFF
--- a/extensions/minimax/music-generation-provider.test.ts
+++ b/extensions/minimax/music-generation-provider.test.ts
@@ -28,10 +28,11 @@ beforeAll(async () => {
 installMinimaxProviderHttpMockCleanup();
 
 function mockMusicGenerationResponse(json: Record<string, unknown>): void {
+  const response = new Response(JSON.stringify(json), {
+    headers: { "content-type": "application/json" },
+  });
   postJsonRequestMock.mockResolvedValue({
-    response: {
-      json: async () => json,
-    },
+    response,
     release: vi.fn(async () => {}),
   });
   fetchWithTimeoutMock.mockResolvedValue({
@@ -53,12 +54,22 @@ describe("minimax music generation provider", () => {
     expectExplicitMusicGenerationCapabilities(buildMinimaxMusicGenerationProvider());
   });
 
-  it("creates music and downloads the generated track", async () => {
-    mockMusicGenerationResponse({
-      task_id: "task-123",
-      audio_url: "https://example.com/out.mp3",
-      lyrics: "our city wakes",
-      base_resp: { status_code: 0 },
+  it("streams generated music chunks from MiniMax", async () => {
+    const chunkA = Buffer.from("ID3\x04\x00mp3-a");
+    const chunkB = Buffer.from("mp3-b");
+    postJsonRequestMock.mockResolvedValue({
+      response: new Response(
+        [
+          `data: ${JSON.stringify({ data: { status: 1, audio: chunkA.toString("hex") }, base_resp: { status_code: 0 } })}`,
+          `data: ${JSON.stringify({ data: { status: 1, audio: chunkB.toString("hex") }, base_resp: { status_code: 0 } })}`,
+          `data: ${JSON.stringify({ data: { status: 2, audio: Buffer.concat([chunkA, chunkB]).toString("hex") }, base_resp: { status_code: 0 } })}`,
+          "",
+        ].join("\n\n"),
+        {
+          headers: { "content-type": "text/event-stream" },
+        },
+      ),
+      release: vi.fn(async () => {}),
     });
 
     const provider = buildMinimaxMusicGenerationProvider();
@@ -76,19 +87,74 @@ describe("minimax music generation provider", () => {
     const body = request.body as Record<string, unknown>;
     expect(body.model).toBe("music-2.6");
     expect(body.lyrics).toBe("our city wakes");
-    expect(body.output_format).toBe("url");
+    expect(body.stream).toBe(true);
+    expect(body.output_format).toBe("hex");
     expect(body.audio_setting).toEqual({
       sample_rate: 44100,
       bitrate: 256000,
       format: "mp3",
     });
+    expect(request.timeoutMs).toBe(300000);
     expect(request?.headers).toBeInstanceOf(Headers);
     const headers = request?.headers as Headers | undefined;
     expect(headers?.get("content-type")).toBe("application/json");
     expect(result.tracks).toHaveLength(1);
-    expect(result.lyrics).toEqual(["our city wakes"]);
-    expect(result.metadata?.taskId).toBe("task-123");
-    expect(result.metadata?.audioUrl).toBe("https://example.com/out.mp3");
+    expect(result.tracks[0]?.buffer).toEqual(Buffer.concat([chunkA, chunkB]));
+    expect(result.tracks[0]?.mimeType).toBe("audio/mpeg");
+    expect(result.metadata?.requestedDurationSeconds).toBe(45);
+  });
+
+  it("reports streaming music task failures", async () => {
+    postJsonRequestMock.mockResolvedValue({
+      response: new Response(
+        `data: ${JSON.stringify({
+          base_resp: { status_code: 0 },
+        })}\n\ndata: ${JSON.stringify({
+          base_resp: { status_code: 2013, status_msg: "render rejected" },
+        })}`,
+        {
+          headers: { "content-type": "text/event-stream" },
+        },
+      ),
+      release: vi.fn(async () => {}),
+    });
+
+    const provider = buildMinimaxMusicGenerationProvider();
+
+    await expect(
+      provider.generateMusic({
+        provider: "minimax",
+        model: "music-2.6",
+        prompt: "upbeat dance-pop with female vocals",
+        cfg: {},
+      }),
+    ).rejects.toThrow("MiniMax music generation failed (2013): render rejected");
+  });
+
+  it("keeps terminal streaming audio when no progressive chunks were sent", async () => {
+    const terminalAudio = Buffer.from("terminal-mp3");
+    postJsonRequestMock.mockResolvedValue({
+      response: new Response(
+        `data: ${JSON.stringify({
+          data: { status: 2, audio: terminalAudio.toString("hex") },
+          base_resp: { status_code: 0 },
+        })}`,
+        {
+          headers: { "content-type": "text/event-stream" },
+        },
+      ),
+      release: vi.fn(async () => {}),
+    });
+
+    const provider = buildMinimaxMusicGenerationProvider();
+    const result = await provider.generateMusic({
+      provider: "minimax",
+      model: "music-2.6",
+      prompt: "upbeat dance-pop with female vocals",
+      cfg: {},
+    });
+
+    expect(result.tracks[0]?.buffer).toEqual(terminalAudio);
   });
 
   it("downloads tracks when url output is returned in data.audio", async () => {

--- a/extensions/minimax/music-generation-provider.ts
+++ b/extensions/minimax/music-generation-provider.ts
@@ -8,8 +8,10 @@ import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
 import {
   assertOkOrThrowHttpError,
+  createProviderOperationDeadline,
   fetchProviderDownloadResponse,
   postJsonRequest,
+  resolveProviderOperationTimeoutMs,
   resolveProviderHttpRequestConfig,
 } from "openclaw/plugin-sdk/provider-http";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -17,6 +19,7 @@ import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runti
 const DEFAULT_MINIMAX_MUSIC_BASE_URL = "https://api.minimax.io";
 const DEFAULT_MINIMAX_MUSIC_MODEL = "music-2.6";
 const DEFAULT_TIMEOUT_MS = 120_000;
+const DEFAULT_OPERATION_TIMEOUT_MS = 300_000;
 
 type MinimaxBaseResp = {
   status_code?: number;
@@ -32,6 +35,14 @@ type MinimaxMusicCreateResponse = {
     audio?: string;
     audio_url?: string;
     lyrics?: string;
+  };
+  base_resp?: MinimaxBaseResp;
+};
+
+type MinimaxMusicStreamFrame = {
+  data?: {
+    audio?: string;
+    status?: number | string;
   };
   base_resp?: MinimaxBaseResp;
 };
@@ -106,6 +117,48 @@ async function downloadTrackFromUrl(params: {
   };
 }
 
+async function readStreamingTrack(response: Response): Promise<GeneratedMusicAsset> {
+  const contentType = normalizeOptionalString(response.headers.get("content-type")) ?? "";
+  if (contentType.toLowerCase().startsWith("audio/")) {
+    const ext = extensionForMime(contentType)?.replace(/^\./u, "") || "mp3";
+    return {
+      buffer: Buffer.from(await response.arrayBuffer()),
+      mimeType: contentType,
+      fileName: `track-1.${ext}`,
+    };
+  }
+  const chunks: Buffer[] = [];
+  const text = await response.text();
+  for (const rawLine of text.split(/\r?\n/u)) {
+    const line = rawLine.trim();
+    if (!line.startsWith("data:")) {
+      continue;
+    }
+    const json = line.slice("data:".length).trim();
+    if (!json || json === "[DONE]") {
+      continue;
+    }
+    const frame = JSON.parse(json) as MinimaxMusicStreamFrame;
+    assertMinimaxBaseResp(frame.base_resp, "MiniMax music generation failed");
+    const audio = normalizeOptionalString(frame.data?.audio);
+    if (audio) {
+      if (String(frame.data?.status ?? "") === "2" && chunks.length > 0) {
+        continue;
+      }
+      chunks.push(decodePossibleBinary(audio));
+    }
+  }
+  const buffer = Buffer.concat(chunks);
+  if (buffer.byteLength === 0) {
+    throw new Error("MiniMax music generation response missing audio output");
+  }
+  return {
+    buffer,
+    mimeType: "audio/mpeg",
+    fileName: "track-1.mp3",
+  };
+}
+
 function buildPrompt(req: MusicGenerationRequest): string {
   const parts = [req.prompt.trim()];
   if (typeof req.durationSeconds === "number" && Number.isFinite(req.durationSeconds)) {
@@ -168,6 +221,10 @@ function buildMinimaxMusicProvider(providerId: string): MusicGenerationProvider 
       }
 
       const fetchFn = fetch;
+      const deadline = createProviderOperationDeadline({
+        timeoutMs: req.timeoutMs ?? DEFAULT_OPERATION_TIMEOUT_MS,
+        label: "MiniMax music generation",
+      });
       const { baseUrl, allowPrivateNetwork, headers, dispatcherPolicy } =
         resolveProviderHttpRequestConfig({
           baseUrl: resolveMinimaxMusicBaseUrl(req.cfg, providerId),
@@ -190,7 +247,8 @@ function buildMinimaxMusicProvider(providerId: string): MusicGenerationProvider 
         prompt: buildPrompt(req),
         ...(req.instrumental === true ? { is_instrumental: true } : {}),
         ...(lyrics ? { lyrics } : req.instrumental === true ? {} : { lyrics_optimizer: true }),
-        output_format: "url",
+        stream: true,
+        output_format: "hex",
         audio_setting: {
           sample_rate: 44_100,
           bitrate: 256_000,
@@ -202,7 +260,10 @@ function buildMinimaxMusicProvider(providerId: string): MusicGenerationProvider 
         url: `${baseUrl}/v1/music_generation`,
         headers: jsonHeaders,
         body,
-        timeoutMs: req.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+        timeoutMs: resolveProviderOperationTimeoutMs({
+          deadline,
+          defaultTimeoutMs: DEFAULT_OPERATION_TIMEOUT_MS,
+        }),
         fetchFn,
         pinDns: false,
         allowPrivateNetwork,
@@ -211,22 +272,32 @@ function buildMinimaxMusicProvider(providerId: string): MusicGenerationProvider 
 
       try {
         await assertOkOrThrowHttpError(res, "MiniMax music generation failed");
-        const payload = (await res.json()) as MinimaxMusicCreateResponse;
-        assertMinimaxBaseResp(payload.base_resp, "MiniMax music generation failed");
+        const contentType = normalizeOptionalString(res.headers.get("content-type")) ?? "";
+        const lowerContentType = contentType.toLowerCase();
+        const payload =
+          lowerContentType.includes("text/event-stream") || lowerContentType.startsWith("audio/")
+            ? null
+            : ((await res.clone().json()) as MinimaxMusicCreateResponse);
+        if (payload) {
+          assertMinimaxBaseResp(payload.base_resp, "MiniMax music generation failed");
+        }
 
         const audioCandidate =
-          normalizeOptionalString(payload.audio) ?? normalizeOptionalString(payload.data?.audio);
+          normalizeOptionalString(payload?.audio) ?? normalizeOptionalString(payload?.data?.audio);
         const audioUrl =
-          normalizeOptionalString(payload.audio_url) ||
-          normalizeOptionalString(payload.data?.audio_url) ||
+          normalizeOptionalString(payload?.audio_url) ||
+          normalizeOptionalString(payload?.data?.audio_url) ||
           (isLikelyRemoteUrl(audioCandidate) ? audioCandidate : undefined);
         const inlineAudio = isLikelyRemoteUrl(audioCandidate) ? undefined : audioCandidate;
-        const lyrics = decodePossibleText(payload.lyrics ?? payload.data?.lyrics ?? "");
+        const lyrics = decodePossibleText(payload?.lyrics ?? payload?.data?.lyrics ?? "");
 
         const track = audioUrl
           ? await downloadTrackFromUrl({
               url: audioUrl,
-              timeoutMs: req.timeoutMs,
+              timeoutMs: resolveProviderOperationTimeoutMs({
+                deadline,
+                defaultTimeoutMs: DEFAULT_TIMEOUT_MS,
+              }),
               fetchFn,
             })
           : inlineAudio
@@ -235,7 +306,7 @@ function buildMinimaxMusicProvider(providerId: string): MusicGenerationProvider 
                 mimeType: "audio/mpeg",
                 fileName: "track-1.mp3",
               }
-            : null;
+            : await readStreamingTrack(res);
         if (!track) {
           throw new Error("MiniMax music generation response missing audio output");
         }
@@ -245,8 +316,8 @@ function buildMinimaxMusicProvider(providerId: string): MusicGenerationProvider 
           ...(lyrics ? { lyrics: [lyrics] } : {}),
           model,
           metadata: {
-            ...(normalizeOptionalString(payload.task_id)
-              ? { taskId: normalizeOptionalString(payload.task_id) }
+            ...(normalizeOptionalString(payload?.task_id)
+              ? { taskId: normalizeOptionalString(payload?.task_id) }
               : {}),
             ...(audioUrl ? { audioUrl } : {}),
             instrumental: req.instrumental === true,


### PR DESCRIPTION
## Summary
- Switch MiniMax music generation to request streaming hex output and decode returned SSE/audio frames into an MP3 asset.
- Use the existing music-generation operation deadline for the generation request so streaming or long-running MiniMax responses are not cut off by the 120s per-request fallback.
- Keep existing URL/inline-audio response handling for MiniMax responses that still return JSON.

## Root Cause
MiniMax music generation can take longer than the provider's 120s request fallback. The provider sent one non-streaming generation request and tied the whole operation to that short request timeout, so longer tracks could fail before OpenClaw received usable audio.

Fixes #84506.

## Why This Is Safe
The change is limited to the bundled MiniMax music-generation provider. It keeps the same auth resolution, base URL resolution, SSRF/private-network policy, model selection, mp3-only output contract, and existing JSON response fallback paths. Streaming frames are decoded only from MiniMax's response body, and provider `base_resp` errors continue to fail the request.

Security/runtime controls unchanged: MiniMax credentials still come from the existing provider auth flow, downloads still use the provider download helper, private-network access remains disabled by default, and no prompt-based policy or security behavior was added.

## Real behavior proof
Behavior addressed: MiniMax music generation no longer fails at the old 120s request fallback when generation takes longer than that window.

Real environment tested: Local macOS checkout running this branch, using `MINIMAX_API_KEY` from local `.env` without printing the key.

Exact steps or command run after this patch: A local `node --import tsx` script invoked the patched MiniMax provider with `minimax/music-2.6`, `instrumental=true`, `durationSeconds=130`, `format=mp3`, and `timeoutMs=300000`. A second local `node --import tsx` script invoked the patched OpenClaw `music_generate` tool with `minimax/music-2.6`, `instrumental=true`, `durationSeconds=20`, `format=mp3`, and saved the generated media.

Evidence after fix: Provider proof logs showed `POST https://api.minimax.io/v1/music_generation` returned `200 text/event-stream` after 119819ms and completed after 159219ms with one `audio/mpeg` track of 3130558 bytes. Tool proof logs showed local `music_generate` generated one `minimax/music-2.6` audio attachment and saved one `audio/mpeg` path after a provider request lasting 136518ms plus download.

Observed result after fix: Both live runs completed successfully; the tool run produced a generated audio attachment instead of timing out.

What was not tested: A 240-300 second live MiniMax track was not run to avoid additional provider spend. Telegram/channel delivery was not tested because this PR only changes the MiniMax music provider HTTP flow.

## Verification
- `pnpm exec oxfmt --write --threads=1 extensions/minimax/music-generation-provider.ts extensions/minimax/music-generation-provider.test.ts`
- `pnpm test extensions/minimax/music-generation-provider.test.ts`
- `git diff --check`
- `pnpm check:changed`
- Live MiniMax provider proof with `durationSeconds=130`, redacted logs
- Live patched OpenClaw `music_generate` tool proof with `durationSeconds=20`, redacted logs

## Out of Scope
- Adding a new MiniMax polling endpoint path; a live probe of `GET /v1/query/music_generation` returned `404`, so this PR uses the live-backed streaming contract instead.
- Changing defaults or behavior for non-MiniMax music providers.
- Channel delivery, Telegram posting, or generated media UX changes.

Made with [Cursor](https://cursor.com)