### PR TITLE
fix(telegram): avoid silent truncation in partial streaming finals

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -1111,6 +1111,55 @@ describe("dispatchTelegramMessage draft streaming", () => {
     });
   });
 
+  it("repairs a preview-finalized Telegram message when the canonical final arrives after stream finalization", async () => {
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    const fullAnswer =
+      "Ja. Hier nochmal sauber Schritt fuer Schritt. Einen API Key kopiert man aus der Google Cloud Console. Danach pruefst du die Projekt- und API-Einstellungen.";
+    const truncatedFinal =
+      "Ja. Hier nochmal sauber Schritt fuer Schritt. Einen API Key kopiert man...";
+    const context = createContext();
+    context.ctxPayload.SessionKey = "agent:default:telegram:direct:123";
+    loadSessionStore.mockReturnValue({
+      "agent:default:telegram:direct:123": { sessionId: "s1" },
+    });
+    readLatestAssistantTextFromSessionTranscript
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce({
+        text: fullAnswer,
+        timestamp: Date.now() + 1_000,
+      });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: truncatedFinal }, { kind: "final" });
+      return { queuedFinal: true };
+    });
+
+    await dispatchWithContext({ context });
+
+    expect(answerDraftStream.update).toHaveBeenCalledWith(truncatedFinal);
+    expect(editMessageTelegram).toHaveBeenCalledWith(
+      expect.anything(),
+      2001,
+      fullAnswer,
+      expect.objectContaining({
+        accountId: "default",
+      }),
+    );
+    expectRecordFields(mockCallArg(emitInternalMessageSentHook), {
+      content: fullAnswer,
+      messageId: 2001,
+    });
+    const transcriptCall = expectRecordFields(mockCallArg(appendSessionTranscriptMessage), {
+      transcriptPath: "/tmp/session.jsonl",
+    });
+    expectRecordFields(transcriptCall.message, {
+      role: "assistant",
+      provider: "openclaw",
+      model: "delivery-mirror",
+      content: [{ type: "text", text: fullAnswer }],
+    });
+  });
+
   it("emits the redacted appended message in transcript updates", async () => {
     setupDraftStreams({ answerMessageId: 2001 });
     const context = createContext();
@@ -1786,6 +1835,29 @@ describe("dispatchTelegramMessage draft streaming", () => {
     );
     expect(followUpTexts.join("")).toContain("one");
     expect(editMessageTelegram).not.toHaveBeenCalled();
+  });
+
+  it("sends a visible fallback when a streamed final follow-up chunk fails", async () => {
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    const longText = "one ".repeat(80);
+    deliverReplies
+      .mockRejectedValueOnce(new Error("telegram send failed"))
+      .mockResolvedValue({ delivered: true });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: longText }, { kind: "final" });
+      return { queuedFinal: true };
+    });
+
+    await dispatchWithContext({ context: createContext(), textLimit: 80 });
+
+    const firstChunk = answerDraftStream.update.mock.calls.at(-1)?.[0] ?? "";
+    expect(firstChunk.length).toBeLessThanOrEqual(80);
+    expect(deliverReplies).toHaveBeenCalledTimes(2);
+    expectDeliveredReply(
+      0,
+      { text: "Something went wrong while processing your request. Please try again." },
+      1,
+    );
   });
 
   it("keeps streamed final text in place when late media arrives", async () => {

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1181,28 +1181,57 @@ export const dispatchTelegramMessage = async ({
       }
       return result.delivered;
     };
-    const emitPreviewFinalizedHook = (result: LaneDeliveryResult) => {
+    const repairPreviewFinalizedText = async (
+      delivery: Extract<LaneDeliveryResult, { kind: "preview-finalized" }>["delivery"],
+    ): Promise<string> => {
+      if (!delivery.content) {
+        return delivery.content;
+      }
+      const repaired = await resolveTranscriptBackedFinalText(delivery.content);
+      if (repaired === delivery.content || isDispatchSuperseded()) {
+        return delivery.content;
+      }
+      try {
+        await (telegramDeps.editMessageTelegram ?? editMessageTelegram)(
+          chatId,
+          delivery.messageId,
+          repaired,
+          {
+            api: bot.api,
+            cfg,
+            accountId: route.accountId,
+            linkPreview: telegramCfg.linkPreview,
+          },
+        );
+        return repaired;
+      } catch (err) {
+        logVerbose(`telegram preview-finalized repair edit failed: ${formatErrorMessage(err)}`);
+        return delivery.content;
+      }
+    };
+    const emitPreviewFinalizedHook = async (result: LaneDeliveryResult) => {
       if (isDispatchSuperseded() || result.kind !== "preview-finalized") {
         return;
       }
+      const deliveredContent = await repairPreviewFinalizedText(result.delivery);
       (telegramDeps.emitInternalMessageSentHook ?? emitInternalMessageSentHook)({
         sessionKeyForInternalHooks: deliveryBaseOptions.sessionKeyForInternalHooks,
         chatId: deliveryBaseOptions.chatId,
         accountId: deliveryBaseOptions.accountId,
-        content: result.delivery.content,
+        content: deliveredContent,
         success: true,
         messageId: result.delivery.messageId,
         isGroup: deliveryBaseOptions.mirrorIsGroup,
         groupId: deliveryBaseOptions.mirrorGroupId,
       });
-      if (deliveryBaseOptions.transcriptMirror && result.delivery.content) {
-        void deliveryBaseOptions
-          .transcriptMirror({ text: result.delivery.content })
-          .catch((err: unknown) => {
-            logVerbose(
-              `telegram preview-finalized transcriptMirror failed: ${formatErrorMessage(err)}`,
-            );
-          });
+      if (deliveryBaseOptions.transcriptMirror && deliveredContent) {
+        try {
+          await deliveryBaseOptions.transcriptMirror({ text: deliveredContent });
+        } catch (err) {
+          logVerbose(
+            `telegram preview-finalized transcriptMirror failed: ${formatErrorMessage(err)}`,
+          );
+        }
       }
     };
     const deliverLaneText = createLaneTextDeliverer({
@@ -1471,7 +1500,7 @@ export const dispatchTelegramMessage = async ({
                               buttons: telegramButtons,
                             });
                       if (info.kind === "final") {
-                        emitPreviewFinalizedHook(result);
+                        await emitPreviewFinalizedHook(result);
                       }
                       blockDelivered = blockDelivered || result.kind !== "skipped";
                       if (segment.lane === "reasoning") {

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1120,13 +1120,14 @@ export const dispatchTelegramMessage = async ({
     };
     const sendPayload = async (
       payload: ReplyPayload,
-      options?: { durable?: boolean; silent?: boolean },
+      options?: { durable?: boolean; silent?: boolean; markDeliveredState?: boolean },
     ) => {
       if (isDispatchSuperseded()) {
         return false;
       }
       const deliverablePayload = applyQuoteReplyTarget(payload);
       const silent = options?.silent ?? (silentErrorReplies && payload.isError === true);
+      const markDeliveredState = options?.markDeliveredState ?? true;
       const durableDelivery = telegramDeps.deliverInboundReplyWithMessageSendContext;
       if (options?.durable && durableDelivery) {
         const durable = await durableDelivery({
@@ -1161,7 +1162,9 @@ export const dispatchTelegramMessage = async ({
           throw durable.error;
         }
         if (durable.status === "handled_visible") {
-          deliveryState.markDelivered();
+          if (markDeliveredState) {
+            deliveryState.markDelivered();
+          }
           return true;
         }
         if (durable.status === "handled_no_send") {
@@ -1176,7 +1179,7 @@ export const dispatchTelegramMessage = async ({
         silent,
         mediaLoader: telegramDeps.loadWebMedia,
       });
-      if (result.delivered) {
+      if (result.delivered && markDeliveredState) {
         deliveryState.markDelivered();
       }
       return result.delivered;

--- a/extensions/telegram/src/lane-delivery-text-deliverer.ts
+++ b/extensions/telegram/src/lane-delivery-text-deliverer.ts
@@ -50,7 +50,7 @@ type CreateLaneTextDelivererParams = {
   splitFinalTextForStream?: (text: string) => readonly string[];
   sendPayload: (
     payload: ReplyPayload,
-    options?: { durable?: boolean; silent?: boolean },
+    options?: { durable?: boolean; silent?: boolean; markDeliveredState?: boolean },
   ) => Promise<boolean>;
   flushDraftLane: (lane: DraftLaneState) => Promise<void>;
   stopDraftLane: (lane: DraftLaneState) => Promise<void>;
@@ -312,7 +312,9 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         if (chunk.trim().length === 0) {
           continue;
         }
-        const delivered = await params.sendPayload(followUpPayload(payload, chunk));
+        const delivered = await params.sendPayload(followUpPayload(payload, chunk), {
+          markDeliveredState: false,
+        });
         if (!delivered) {
           throw new Error("Telegram follow-up chunk was not delivered");
         }
@@ -367,7 +369,9 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         if (chunk.trim().length === 0) {
           continue;
         }
-        const delivered = await params.sendPayload(followUpPayload(payload, chunk));
+        const delivered = await params.sendPayload(followUpPayload(payload, chunk), {
+          markDeliveredState: false,
+        });
         if (!delivered) {
           throw new Error("Telegram follow-up chunk was not delivered");
         }

--- a/extensions/telegram/src/lane-delivery-text-deliverer.ts
+++ b/extensions/telegram/src/lane-delivery-text-deliverer.ts
@@ -348,7 +348,6 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
       return undefined;
     }
 
-    params.markDelivered();
     let buttonsAttached = false;
     if (buttons) {
       try {
@@ -367,9 +366,11 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         }
         await params.sendPayload(followUpPayload(payload, chunk));
       }
+      params.markDelivered();
       return result("preview-finalized", { content: text, messageId, buttonsAttached });
     }
 
+    params.markDelivered();
     return result("preview-updated");
   };
 

--- a/extensions/telegram/src/lane-delivery-text-deliverer.ts
+++ b/extensions/telegram/src/lane-delivery-text-deliverer.ts
@@ -312,7 +312,10 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         if (chunk.trim().length === 0) {
           continue;
         }
-        await params.sendPayload(followUpPayload(payload, chunk));
+        const delivered = await params.sendPayload(followUpPayload(payload, chunk));
+        if (!delivered) {
+          throw new Error("Telegram follow-up chunk was not delivered");
+        }
       }
       lane.finalized = true;
       params.markDelivered();
@@ -364,7 +367,10 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         if (chunk.trim().length === 0) {
           continue;
         }
-        await params.sendPayload(followUpPayload(payload, chunk));
+        const delivered = await params.sendPayload(followUpPayload(payload, chunk));
+        if (!delivered) {
+          throw new Error("Telegram follow-up chunk was not delivered");
+        }
       }
       params.markDelivered();
       return result("preview-finalized", { content: text, messageId, buttonsAttached });

--- a/extensions/telegram/src/lane-delivery.test.ts
+++ b/extensions/telegram/src/lane-delivery.test.ts
@@ -680,6 +680,24 @@ describe("createLaneTextDeliverer", () => {
     expect(harness.markDelivered).not.toHaveBeenCalled();
   });
 
+  it("does not mark streamed finals as delivered when a follow-up chunk is suppressed", async () => {
+    const harness = createHarness({
+      answerMessageId: 999,
+      draftMaxChars: 5,
+      splitFinalTextForStream: () => ["Hello", " world"],
+    });
+    harness.sendPayload.mockResolvedValueOnce(false);
+
+    await expect(deliverFinalAnswer(harness, "Hello world")).rejects.toThrow(
+      "Telegram follow-up chunk was not delivered",
+    );
+
+    expect(harness.answer?.update).toHaveBeenCalledWith("Hello");
+    expect(harness.sendPayload).toHaveBeenCalledTimes(1);
+    expect(harness.sendPayload).toHaveBeenCalledWith({ text: " world" });
+    expect(harness.markDelivered).not.toHaveBeenCalled();
+  });
+
   it("retains the streamed message when stop may have landed without a message id", async () => {
     const answer = createTestDraftStream();
     answer.sendMayHaveLanded.mockReturnValue(true);

--- a/extensions/telegram/src/lane-delivery.test.ts
+++ b/extensions/telegram/src/lane-delivery.test.ts
@@ -351,7 +351,10 @@ describe("createLaneTextDeliverer", () => {
       text: "Hello...",
       buttons,
     });
-    expect(harness.sendPayload).toHaveBeenCalledWith({ text: " world" });
+    expect(harness.sendPayload).toHaveBeenCalledWith(
+      { text: " world" },
+      { markDeliveredState: false },
+    );
     expect(harness.markDelivered).toHaveBeenCalledTimes(1);
   });
 
@@ -658,8 +661,16 @@ describe("createLaneTextDeliverer", () => {
     expect(delivery.messageId).toBe(999);
     expect(harness.answer?.update).toHaveBeenCalledWith("Hello");
     expect(harness.sendPayload).toHaveBeenCalledTimes(2);
-    expect(harness.sendPayload).toHaveBeenNthCalledWith(1, { text: " world" });
-    expect(harness.sendPayload).toHaveBeenNthCalledWith(2, { text: " again" });
+    expect(harness.sendPayload).toHaveBeenNthCalledWith(
+      1,
+      { text: " world" },
+      { markDeliveredState: false },
+    );
+    expect(harness.sendPayload).toHaveBeenNthCalledWith(
+      2,
+      { text: " again" },
+      { markDeliveredState: false },
+    );
   });
 
   it("does not mark streamed finals as delivered when a follow-up chunk send fails", async () => {
@@ -676,7 +687,10 @@ describe("createLaneTextDeliverer", () => {
 
     expect(harness.answer?.update).toHaveBeenCalledWith("Hello");
     expect(harness.sendPayload).toHaveBeenCalledTimes(1);
-    expect(harness.sendPayload).toHaveBeenCalledWith({ text: " world" });
+    expect(harness.sendPayload).toHaveBeenCalledWith(
+      { text: " world" },
+      { markDeliveredState: false },
+    );
     expect(harness.markDelivered).not.toHaveBeenCalled();
   });
 
@@ -694,7 +708,37 @@ describe("createLaneTextDeliverer", () => {
 
     expect(harness.answer?.update).toHaveBeenCalledWith("Hello");
     expect(harness.sendPayload).toHaveBeenCalledTimes(1);
-    expect(harness.sendPayload).toHaveBeenCalledWith({ text: " world" });
+    expect(harness.sendPayload).toHaveBeenCalledWith(
+      { text: " world" },
+      { markDeliveredState: false },
+    );
+    expect(harness.markDelivered).not.toHaveBeenCalled();
+  });
+
+  it("does not mark streamed finals as delivered when a later follow-up chunk is suppressed", async () => {
+    const harness = createHarness({
+      answerMessageId: 999,
+      draftMaxChars: 5,
+      splitFinalTextForStream: () => ["Hello", " world", " again"],
+    });
+    harness.sendPayload.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+
+    await expect(deliverFinalAnswer(harness, "Hello world again")).rejects.toThrow(
+      "Telegram follow-up chunk was not delivered",
+    );
+
+    expect(harness.answer?.update).toHaveBeenCalledWith("Hello");
+    expect(harness.sendPayload).toHaveBeenCalledTimes(2);
+    expect(harness.sendPayload).toHaveBeenNthCalledWith(
+      1,
+      { text: " world" },
+      { markDeliveredState: false },
+    );
+    expect(harness.sendPayload).toHaveBeenNthCalledWith(
+      2,
+      { text: " again" },
+      { markDeliveredState: false },
+    );
     expect(harness.markDelivered).not.toHaveBeenCalled();
   });
 

--- a/extensions/telegram/src/lane-delivery.test.ts
+++ b/extensions/telegram/src/lane-delivery.test.ts
@@ -662,6 +662,24 @@ describe("createLaneTextDeliverer", () => {
     expect(harness.sendPayload).toHaveBeenNthCalledWith(2, { text: " again" });
   });
 
+  it("does not mark streamed finals as delivered when a follow-up chunk send fails", async () => {
+    const harness = createHarness({
+      answerMessageId: 999,
+      draftMaxChars: 5,
+      splitFinalTextForStream: () => ["Hello", " world"],
+    });
+    harness.sendPayload.mockRejectedValueOnce(new Error("telegram send failed"));
+
+    await expect(deliverFinalAnswer(harness, "Hello world")).rejects.toThrow(
+      "telegram send failed",
+    );
+
+    expect(harness.answer?.update).toHaveBeenCalledWith("Hello");
+    expect(harness.sendPayload).toHaveBeenCalledTimes(1);
+    expect(harness.sendPayload).toHaveBeenCalledWith({ text: " world" });
+    expect(harness.markDelivered).not.toHaveBeenCalled();
+  });
+
   it("retains the streamed message when stop may have landed without a message id", async () => {
     const answer = createTestDraftStream();
     answer.sendMayHaveLanded.mockReturnValue(true);


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Telegram partial-stream finals could be marked as delivered before continuation chunks were actually sent, which could suppress visible fallback handling and leave users with a mid-sentence cutoff.
- Solution: Delay Telegram delivered-state marking until continuation chunks succeed, treat suppressed follow-up sends as delivery failures, and repair preview-finalized messages from the transcript-backed final text when needed.
- What changed: Added Telegram delivery-state fixes and regression tests for thrown and false-return follow-up failures, plus preview-finalized transcript-backed repair coverage.
- What did NOT change (scope boundary): This PR does not change diagnostic stuck-session recovery behavior; that work was split into follow-up PR #84666.

## Motivation

Explain why this change should exist now. Link it to the user pain, failure mode, maintainer need, or product goal. If this is purely mechanical, write `N/A`.

- Telegram delivery could fail in a way that looked successful to the gateway, producing silent truncation for real users.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #49889
- Related #84666
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only. Screenshots are encouraged even for CLI, console, text, or log changes; terminal screenshots and copied live output count. Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

- Behavior or issue addressed: Telegram partial-stream final continuation failure should no longer be treated as successfully delivered, and preview-finalized Telegram text should be repairable from transcript-backed final text.
- Real environment tested: Pending maintainer or contributor run against a real Telegram bot/chat setup.
- Exact steps or command run after this patch: Pending real-environment proof run.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Pending.
- Observed result after fix: Pending.
- What was not tested: Real Telegram after-fix behavior has not yet been captured in this contributor environment.
- Before evidence (optional but encouraged): Source-level repro and regression tests cover the failure mode; no attached real Telegram before/after capture yet.

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: Telegram streamed-final follow-up chunks were sent after delivery state could already be marked successful, so a later follow-up failure could leave the system believing the message had been delivered even though the user saw a truncated final.
- Missing detection / guardrail: Follow-up sends that returned false were not treated as delivery failure, and preview-finalized message content was not repaired from the transcript-backed canonical final text.
- Contributing context (if known): N/A

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/telegram/src/lane-delivery.test.ts` and `extensions/telegram/src/bot-message-dispatch.test.ts`.
- Scenario the test should lock in: Follow-up chunk sends that throw or return false must prevent delivered-state success for streamed finals, and preview-finalized messages should repair from transcript-backed final text.
- Why this is the smallest reliable guardrail: These unit tests exercise the exact delivery-state and repair decisions at the seam where the regression occurred without requiring a live Telegram environment.
- Existing test that already covers this (if any): Existing Telegram delivery tests covered adjacent streaming behavior but not the suppressed follow-up failure path.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

- Telegram users should now get visible failure handling instead of silent mid-sentence truncation when streamed final follow-up delivery fails.
- Telegram preview-finalized replies can be repaired to the transcript-backed final text when the finalized preview content is truncated.

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

```text
Before:
[streamed final starts] -> [preview message marked delivered] -> [follow-up chunk fails] -> [fallback suppressed] -> [user sees truncation]

After:
[streamed final starts] -> [follow-up chunks must succeed] -> [mark delivered] -> [result]
                                         \
                                          -> [follow-up failure] -> [treat as delivery failure / fallback path]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local OpenClaw contributor environment
- Model/provider: N/A for unit coverage; real Telegram proof still pending
- Integration/channel (if any): Telegram
- Relevant config (redacted): Telegram bot/channel configuration with partial streaming enabled

### Steps

1. Reproduce a streamed Telegram final that requires follow-up chunks after the preview message.
2. Simulate or trigger a thrown or false-return follow-up send.
3. Verify delivered-state is not marked successful and the fallback/repair path remains available.

### Expected

- Failed follow-up chunks do not leave the system thinking delivery succeeded, and preview-finalized truncated text can be repaired from transcript-backed final text.

### Actual

- Covered by unit tests in this branch; attached real-environment proof is still pending.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Ran targeted Vitest coverage for Telegram delivery tests locally and reviewed the source-level failure mode plus repair path.
- Edge cases checked: Follow-up chunk send returning false, follow-up chunk send throwing, and preview-finalized transcript repair path.
- What you did **not** verify: Real Telegram after-fix behavior proof in a live bot/chat environment.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Real Telegram proof is still missing, so source/test confidence may not match maintainer merge requirements.
- Mitigation: Attach redacted after-fix evidence from a real Telegram run and re-request ClawSweeper review.

