### PR TITLE
[codex] fix: omit provider api keys from generated models.json

### DIFF
--- a/src/agents/models-config.applies-config-env-vars.test.ts
+++ b/src/agents/models-config.applies-config-env-vars.test.ts
@@ -246,6 +246,94 @@ describe("models-config", () => {
     ]);
   });
 
+  it("omits provider apiKey fields from serialized models.json plans", async () => {
+    const plan = await planOpenClawModelsJsonWithDeps(
+      {
+        cfg: {
+          models: {
+            mode: "merge",
+            providers: {
+              "custom-proxy": {
+                baseUrl: "https://custom.example/v1",
+                api: "openai-completions",
+                apiKey: "sk-custom-config-secret", // pragma: allowlist secret
+                models: [
+                  {
+                    id: "custom-model",
+                    name: "Custom Model",
+                    input: ["text"],
+                    reasoning: false,
+                    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                    contextWindow: 8192,
+                    maxTokens: 4096,
+                  },
+                ],
+              },
+            },
+          },
+        },
+        agentDir: "/tmp/openclaw-models-config-env-vars-test",
+        env: {},
+        existingRaw: "",
+        existingParsed: {
+          providers: {
+            legacy: {
+              baseUrl: "https://legacy.example/v1",
+              api: "openai-completions",
+              apiKey: "sk-existing-models-json-secret", // pragma: allowlist secret
+              models: [
+                {
+                  id: "legacy-model",
+                  name: "Legacy Model",
+                  input: ["text"],
+                  reasoning: false,
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 8192,
+                  maxTokens: 4096,
+                },
+              ],
+            },
+          },
+        },
+      },
+      {
+        resolveImplicitProviders: async () => ({
+          openai: {
+            baseUrl: "https://api.openai.com/v1",
+            api: "openai-responses",
+            apiKey: "OPENAI_API_KEY", // pragma: allowlist secret
+            models: [
+              {
+                id: "gpt-5.5",
+                name: "GPT-5.5",
+                input: ["text"],
+                reasoning: true,
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 400000,
+                maxTokens: 128000,
+              },
+            ],
+          },
+        }),
+      },
+    );
+
+    expect(plan.action).toBe("write");
+    if (plan.action !== "write") {
+      throw new Error("Expected models.json write plan");
+    }
+    const parsed = JSON.parse(plan.contents) as {
+      providers?: Record<string, { apiKey?: string; baseUrl?: string; models?: unknown[] }>;
+    };
+    expect(plan.contents).not.toContain("apiKey");
+    expect(plan.contents).not.toContain("OPENAI_API_KEY");
+    expect(plan.contents).not.toContain("sk-custom-config-secret");
+    expect(plan.contents).not.toContain("sk-existing-models-json-secret");
+    expect(parsed.providers?.openai?.baseUrl).toBe("https://api.openai.com/v1");
+    expect(parsed.providers?.["custom-proxy"]?.models).toHaveLength(1);
+    expect(parsed.providers?.legacy?.baseUrl).toBe("https://legacy.example/v1");
+  });
+
   it("uses config env.vars entries for implicit provider discovery without mutating process.env", async () => {
     await withTempEnv(["OPENROUTER_API_KEY", TEST_ENV_VAR], async () => {
       unsetEnv(["OPENROUTER_API_KEY", TEST_ENV_VAR]);

--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -105,6 +105,25 @@ function resolveProvidersForMode(params: {
   });
 }
 
+function omitProviderApiKeysForModelsJson(
+  providers: Record<string, ProviderConfig>,
+): Record<string, ProviderConfig> {
+  let sanitized: Record<string, ProviderConfig> | undefined;
+  for (const [key, provider] of Object.entries(providers)) {
+    if (!Object.prototype.hasOwnProperty.call(provider, "apiKey")) {
+      if (sanitized) {
+        sanitized[key] = provider;
+      }
+      continue;
+    }
+    sanitized ??= { ...providers };
+    const nextProvider = { ...provider };
+    delete nextProvider.apiKey;
+    sanitized[key] = nextProvider;
+  }
+  return sanitized ?? providers;
+}
+
 export async function planOpenClawModelsJsonWithDeps(
   params: {
     cfg: OpenClawConfig;
@@ -178,7 +197,8 @@ export async function planOpenClawModelsJsonWithDeps(
       secretRefManagedProviders,
     }) ?? normalizedMergedProviders;
   const finalProviders = applyNativeStreamingUsageCompat(secretEnforcedProviders);
-  const nextContents = `${JSON.stringify({ providers: finalProviders }, null, 2)}\n`;
+  const providersForModelsJson = omitProviderApiKeysForModelsJson(finalProviders);
+  const nextContents = `${JSON.stringify({ providers: providersForModelsJson }, null, 2)}\n`;
 
   if (params.existingRaw === nextContents) {
     return { action: "noop" };

--- a/src/agents/models-config.runtime-source-snapshot.test.ts
+++ b/src/agents/models-config.runtime-source-snapshot.test.ts
@@ -171,15 +171,12 @@ function withGatewayTokenMode(config: OpenClawConfig): OpenClawConfig {
   };
 }
 
-async function expectGeneratedProviderApiKey(
-  agentDir: string,
-  providerId: string,
-  expected: string,
-) {
+async function expectGeneratedProviderOmitsApiKey(agentDir: string, providerId: string) {
   const parsed = await readGeneratedModelsJson<{
     providers: Record<string, { apiKey?: string }>;
   }>(agentDir);
-  expect(parsed.providers[providerId]?.apiKey).toBe(expected);
+  expect(parsed.providers[providerId]).toBeDefined();
+  expect(parsed.providers[providerId]).not.toHaveProperty("apiKey");
 }
 
 async function planGeneratedProviders(params: {
@@ -272,7 +269,7 @@ describe("models-config runtime source snapshot", () => {
       try {
         setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
         await ensureOpenClawModelsJson(clonedRuntimeConfig, agentDir);
-        await expectGeneratedProviderApiKey(agentDir, "openai", "OPENAI_API_KEY"); // pragma: allowlist secret
+        await expectGeneratedProviderOmitsApiKey(agentDir, "openai");
       } finally {
         clearRuntimeConfigSnapshot();
         clearConfigCache();
@@ -325,7 +322,7 @@ describe("models-config runtime source snapshot", () => {
           >;
         }>(agentDir);
         expect(parsed.providers.openai?.baseUrl).toBe("https://api.openai.com/v1");
-        expect(parsed.providers.openai?.apiKey).toBe("OPENAI_API_KEY"); // pragma: allowlist secret
+        expect(parsed.providers.openai).not.toHaveProperty("apiKey");
         expect(parsed.providers.openai?.headers?.["X-OpenClaw-Test"]).toBe("one");
 
         // Header changes still rewrite models.json, but merge mode preserves the existing baseUrl.
@@ -337,7 +334,7 @@ describe("models-config runtime source snapshot", () => {
           >;
         }>(agentDir);
         expect(parsed.providers.openai?.baseUrl).toBe("https://api.openai.com/v1");
-        expect(parsed.providers.openai?.apiKey).toBe("OPENAI_API_KEY"); // pragma: allowlist secret
+        expect(parsed.providers.openai).not.toHaveProperty("apiKey");
         expect(parsed.providers.openai?.headers?.["X-OpenClaw-Test"]).toBe("two");
       } finally {
         clearRuntimeConfigSnapshot();
@@ -354,12 +351,12 @@ describe("models-config runtime source snapshot", () => {
     expectOpenAiHeaderMarkers(providers);
   });
 
-  it("keeps source markers when runtime projection is skipped for incompatible top-level shape", async () => {
+  it("keeps header source markers but omits provider apiKey markers in models.json plans", async () => {
     const providers = await planGeneratedProviders({
       config: createOpenAiRuntimeConfigWithHeadersAndApiKey(),
       sourceConfigForSecrets: withGatewayTokenMode(createOpenAiSourceConfigWithHeadersAndApiKey()),
     });
-    expect(providers.openai?.apiKey).toBe("OPENAI_API_KEY"); // pragma: allowlist secret
+    expect(providers.openai).not.toHaveProperty("apiKey");
     expectOpenAiHeaderMarkers(providers);
   });
 });

--- a/src/agents/models-config.skips-writing-models-json-no-env-token.test.ts
+++ b/src/agents/models-config.skips-writing-models-json-no-env-token.test.ts
@@ -102,7 +102,6 @@ async function runEnvProviderCase(params: {
   envVar: "MINIMAX_API_KEY" | "SYNTHETIC_API_KEY";
   envValue: string;
   providerKey: "minimax" | "synthetic";
-  expectedApiKeyRef: string;
 }) {
   const previousValue = process.env[params.envVar];
   process.env[params.envVar] = params.envValue;
@@ -113,7 +112,9 @@ async function runEnvProviderCase(params: {
     const raw = await fs.readFile(modelPath, "utf8");
     const parsed = JSON.parse(raw) as { providers: Record<string, ParsedProviderConfig> };
     const provider = parsed.providers[params.providerKey];
-    expect(provider?.apiKey).toBe(params.expectedApiKeyRef);
+    expect(provider).toBeDefined();
+    expect(provider).not.toHaveProperty("apiKey");
+    expect(provider?.models?.[0]?.id).toBe("test-model");
   } finally {
     if (previousValue === undefined) {
       delete process.env[params.envVar];
@@ -211,7 +212,6 @@ describe("models-config", () => {
         envVar: "MINIMAX_API_KEY",
         envValue: "sk-minimax-test",
         providerKey: "minimax",
-        expectedApiKeyRef: "MINIMAX_API_KEY", // pragma: allowlist secret
       });
     });
   });
@@ -222,7 +222,6 @@ describe("models-config", () => {
         envVar: "SYNTHETIC_API_KEY",
         envValue: "sk-synthetic-test",
         providerKey: "synthetic",
-        expectedApiKeyRef: "SYNTHETIC_API_KEY", // pragma: allowlist secret
       });
     });
   });


### PR DESCRIPTION
## Summary

Fixes openclaw/openclaw#11829.

This prevents generated `models.json` files from persisting provider-level `apiKey` fields. The sanitization happens at the serialization boundary, after provider discovery/normalization/merge, so provider catalog metadata remains available while credentials stay out of the prompt-visible model catalog.

Covered cases:
- implicit provider env markers, such as `OPENAI_API_KEY`
- literal configured provider keys
- stale provider keys preserved from an existing `models.json` in merge mode

## Root cause

`planOpenClawModelsJsonWithDeps()` built the final provider catalog and serialized it directly. Earlier steps could add `apiKey` values or preserve them from an existing `models.json`, so secrets or secret markers were written back into the agent model catalog.

## Validation

- `corepack pnpm exec oxfmt --check --threads=1 src/agents/models-config.plan.ts src/agents/models-config.applies-config-env-vars.test.ts src/agents/models-config.runtime-source-snapshot.test.ts src/agents/models-config.skips-writing-models-json-no-env-token.test.ts`
- `corepack pnpm check:test-types`
- `node scripts/test-projects.mjs $(rg --files src/agents | rg 'models-config.*\.test\.ts$')`
