### PR TITLE
Allow trusted plugin session presentations

### DIFF
--- a/src/plugins/contracts/session-attachments.contract.test.ts
+++ b/src/plugins/contracts/session-attachments.contract.test.ts
@@ -366,7 +366,8 @@ describe("plugin session attachments", () => {
         }),
       ).resolves.toEqual({
         ok: false,
-        error: "session attachments are restricted to bundled plugins",
+        error:
+          'session attachments require bundled origin or contracts.sessionAttachments:["active-session"] with trusted official install or allowConversationAccess=true',
       });
       await expect(
         sendBundledSessionAttachment({
@@ -375,6 +376,83 @@ describe("plugin session attachments", () => {
       ).resolves.toEqual({
         ok: false,
         error: "session has no active delivery route: agent:main:main",
+      });
+      expect(workflowMocks.sendMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  it("allows trusted external plugins that declare the active-session attachment contract", async () => {
+    await withSessionStore(async ({ storePath, filePath }) => {
+      await writeSessionEntry(storePath);
+      mockSuccessfulAttachmentDelivery();
+
+      const result = await sendPluginSessionAttachment({
+        origin: "workspace",
+        trustedOfficialInstall: true,
+        contracts: { sessionAttachments: ["active-session"] },
+        sessionKey: MAIN_SESSION_KEY,
+        files: [{ path: filePath }],
+      });
+
+      expectTelegramAttachmentResult(result, 1);
+      expect(requireFirstSendMessageParams().mediaUrls).toEqual([filePath]);
+    });
+  });
+
+  it("allows operator-approved external active-session presentations without files", async () => {
+    await withSessionStore(async ({ storePath }) => {
+      await writeSessionEntry(storePath);
+      mockSuccessfulAttachmentDelivery();
+
+      const presentation = {
+        title: "Plan Approval",
+        tone: "warning" as const,
+        blocks: [
+          { type: "text" as const, text: "Review the plan." },
+          {
+            type: "buttons" as const,
+            buttons: [
+              { label: "Approve", value: "smarter-claw-plan:a:tok", style: "success" as const },
+            ],
+          },
+        ],
+      };
+      const result = await sendPluginSessionAttachment({
+        origin: "workspace",
+        allowConversationAccess: true,
+        contracts: { sessionAttachments: ["active-session"] },
+        sessionKey: MAIN_SESSION_KEY,
+        text: "Plan approval requested.",
+        presentation,
+      });
+
+      expectTelegramAttachmentResult(result, 0);
+      const sendParams = requireFirstSendMessageParams();
+      expect(sendParams.mediaUrls).toEqual([]);
+      expect(sendParams.payloads).toEqual([
+        {
+          text: "Plan approval requested.",
+          presentation,
+        },
+      ]);
+    });
+  });
+
+  it("rejects external active-session contracts without a trust grant", async () => {
+    await withSessionStore(async ({ storePath, filePath }) => {
+      await writeSessionEntry(storePath);
+
+      await expect(
+        sendPluginSessionAttachment({
+          origin: "workspace",
+          contracts: { sessionAttachments: ["active-session"] },
+          sessionKey: MAIN_SESSION_KEY,
+          files: [{ path: filePath }],
+        }),
+      ).resolves.toEqual({
+        ok: false,
+        error:
+          'session attachments require bundled origin or contracts.sessionAttachments:["active-session"] with trusted official install or allowConversationAccess=true',
       });
       expect(workflowMocks.sendMessage).not.toHaveBeenCalled();
     });

--- a/src/plugins/contracts/session-attachments.contract.test.ts
+++ b/src/plugins/contracts/session-attachments.contract.test.ts
@@ -367,7 +367,7 @@ describe("plugin session attachments", () => {
       ).resolves.toEqual({
         ok: false,
         error:
-          'session attachments require bundled origin or contracts.sessionAttachments:["active-session"] with trusted official install or allowConversationAccess=true',
+          'session attachments require bundled origin or contracts.sessionAttachments:["active-session"] with trusted official install',
       });
       await expect(
         sendBundledSessionAttachment({
@@ -399,7 +399,7 @@ describe("plugin session attachments", () => {
     });
   });
 
-  it("allows operator-approved external active-session presentations without files", async () => {
+  it("allows trusted external active-session presentations without files", async () => {
     await withSessionStore(async ({ storePath }) => {
       await writeSessionEntry(storePath);
       mockSuccessfulAttachmentDelivery();
@@ -419,7 +419,7 @@ describe("plugin session attachments", () => {
       };
       const result = await sendPluginSessionAttachment({
         origin: "workspace",
-        allowConversationAccess: true,
+        trustedOfficialInstall: true,
         contracts: { sessionAttachments: ["active-session"] },
         sessionKey: MAIN_SESSION_KEY,
         text: "Plan approval requested.",
@@ -438,6 +438,27 @@ describe("plugin session attachments", () => {
     });
   });
 
+  it("does not treat generic conversation access as an attachment trust grant", async () => {
+    await withSessionStore(async ({ storePath, filePath }) => {
+      await writeSessionEntry(storePath);
+
+      await expect(
+        sendPluginSessionAttachment({
+          origin: "workspace",
+          allowConversationAccess: true,
+          contracts: { sessionAttachments: ["active-session"] },
+          sessionKey: MAIN_SESSION_KEY,
+          files: [{ path: filePath }],
+        }),
+      ).resolves.toEqual({
+        ok: false,
+        error:
+          'session attachments require bundled origin or contracts.sessionAttachments:["active-session"] with trusted official install',
+      });
+      expect(workflowMocks.sendMessage).not.toHaveBeenCalled();
+    });
+  });
+
   it("rejects external active-session contracts without a trust grant", async () => {
     await withSessionStore(async ({ storePath, filePath }) => {
       await writeSessionEntry(storePath);
@@ -452,7 +473,7 @@ describe("plugin session attachments", () => {
       ).resolves.toEqual({
         ok: false,
         error:
-          'session attachments require bundled origin or contracts.sessionAttachments:["active-session"] with trusted official install or allowConversationAccess=true',
+          'session attachments require bundled origin or contracts.sessionAttachments:["active-session"] with trusted official install',
       });
       expect(workflowMocks.sendMessage).not.toHaveBeenCalled();
     });

--- a/src/plugins/host-hook-attachments.ts
+++ b/src/plugins/host-hook-attachments.ts
@@ -3,6 +3,7 @@ import { lstat } from "node:fs/promises";
 import { resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
 import { resolvePathFromInput } from "../agents/path-policy.js";
 import { resolveWorkspaceRoot } from "../agents/workspace-dir.js";
+import type { ReplyPayload } from "../auto-reply/reply-payload.js";
 import { extractDeliveryInfo } from "../config/sessions/delivery-info.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
@@ -16,9 +17,11 @@ import type {
   PluginSessionAttachmentParams,
   PluginSessionAttachmentResult,
 } from "./host-hooks.js";
+import type { PluginManifestContracts } from "./manifest.js";
 import type { PluginOrigin } from "./plugin-origin.types.js";
 
 const DEFAULT_ATTACHMENT_MAX_BYTES = 25 * 1024 * 1024;
+const ACTIVE_SESSION_ATTACHMENT_CONTRACT = "active-session";
 export const attachmentProbeFs = {
   open: (...args: Parameters<typeof fsPromises.open>) => fsPromises.open(...args),
 };
@@ -128,7 +131,7 @@ export function resolveAttachmentDelivery(params: {
 }
 
 async function validateAttachmentFiles(
-  files: PluginSessionAttachmentParams["files"],
+  files: NonNullable<PluginSessionAttachmentParams["files"]>,
   maxBytes: number,
   options?: {
     forceDocumentMime?: string;
@@ -195,6 +198,24 @@ async function validateAttachmentFiles(
   return paths;
 }
 
+function canSendSessionAttachment(params: {
+  origin?: PluginOrigin;
+  trustedOfficialInstall?: boolean;
+  allowConversationAccess?: boolean;
+  contracts?: Pick<PluginManifestContracts, "sessionAttachments">;
+}): boolean {
+  if (params.origin === "bundled") {
+    return true;
+  }
+  const declaresActiveSessionAttachment = (params.contracts?.sessionAttachments ?? []).includes(
+    ACTIVE_SESSION_ATTACHMENT_CONTRACT,
+  );
+  return (
+    declaresActiveSessionAttachment &&
+    (params.trustedOfficialInstall === true || params.allowConversationAccess === true)
+  );
+}
+
 function resolveAttachmentFilePath(params: {
   filePath: string;
   config?: OpenClawConfig;
@@ -229,17 +250,30 @@ export function resolveSessionAttachmentThreadId(params: {
 }
 
 export async function sendPluginSessionAttachment(
-  params: PluginSessionAttachmentParams & { config?: OpenClawConfig; origin?: PluginOrigin },
+  params: PluginSessionAttachmentParams & {
+    config?: OpenClawConfig;
+    origin?: PluginOrigin;
+    trustedOfficialInstall?: boolean;
+    allowConversationAccess?: boolean;
+    contracts?: Pick<PluginManifestContracts, "sessionAttachments">;
+  },
 ): Promise<PluginSessionAttachmentResult> {
-  if (params.origin !== "bundled") {
-    return { ok: false, error: "session attachments are restricted to bundled plugins" };
+  if (!canSendSessionAttachment(params)) {
+    return {
+      ok: false,
+      error:
+        'session attachments require bundled origin or contracts.sessionAttachments:["active-session"] with trusted official install or allowConversationAccess=true',
+    };
   }
   const sessionKey = normalizeOptionalString(params.sessionKey);
   if (!sessionKey) {
     return { ok: false, error: "sessionKey is required" };
   }
-  if (!Array.isArray(params.files) || params.files.length === 0) {
-    return { ok: false, error: "at least one attachment file is required" };
+  const files = Array.isArray(params.files) ? params.files : [];
+  const rawText = normalizeOptionalString(params.text) ?? "";
+  const hasPresentation = params.presentation !== undefined;
+  if (files.length === 0 && !rawText && !hasPresentation) {
+    return { ok: false, error: "at least one attachment file, text, or presentation is required" };
   }
   const maxBytes =
     typeof params.maxBytes === "number" && Number.isFinite(params.maxBytes)
@@ -271,13 +305,12 @@ export async function sendPluginSessionAttachment(
       error: `attachment delivery setup failed: ${formatErrorMessage(error)}`,
     };
   }
-  const rawText = normalizeOptionalString(params.text) ?? "";
   const resolvedDelivery = resolveAttachmentDelivery({
     channel: deliveryContext.channel,
     captionFormat: params.captionFormat,
     channelHints: params.channelHints,
   });
-  const validated = await validateAttachmentFiles(params.files, maxBytes, {
+  const validated = await validateAttachmentFiles(files, maxBytes, {
     forceDocumentMime: resolvedDelivery.forceDocumentMime,
     config: params.config,
     sessionKey,
@@ -294,14 +327,26 @@ export async function sendPluginSessionAttachment(
   let result: Awaited<ReturnType<SendMessage>>;
   try {
     const sendMessage = await loadSendMessage();
+    const content = resolvedDelivery.escapePlainHtmlCaption ? escapeHtmlText(rawText) : rawText;
+    const payloads: ReplyPayload[] | undefined =
+      hasPresentation || validated.length > 0
+        ? [
+            {
+              ...(content ? { text: content } : {}),
+              ...(validated.length > 0 ? { mediaUrls: validated } : {}),
+              ...(params.presentation ? { presentation: params.presentation } : {}),
+            },
+          ]
+        : undefined;
     result = await sendMessage({
       to: deliveryContext.to,
-      content: resolvedDelivery.escapePlainHtmlCaption ? escapeHtmlText(rawText) : rawText,
+      content,
       channel: deliveryContext.channel,
       accountId: deliveryContext.accountId,
       threadId: resolvedThreadId,
       requesterSessionKey: sessionKey,
       mediaUrls: validated,
+      ...(payloads ? { payloads } : {}),
       forceDocument: resolvedDelivery.forceDocumentMime ? true : params.forceDocument,
       bestEffort: false,
       cfg: params.config,

--- a/src/plugins/host-hook-attachments.ts
+++ b/src/plugins/host-hook-attachments.ts
@@ -201,7 +201,6 @@ async function validateAttachmentFiles(
 function canSendSessionAttachment(params: {
   origin?: PluginOrigin;
   trustedOfficialInstall?: boolean;
-  allowConversationAccess?: boolean;
   contracts?: Pick<PluginManifestContracts, "sessionAttachments">;
 }): boolean {
   if (params.origin === "bundled") {
@@ -210,10 +209,7 @@ function canSendSessionAttachment(params: {
   const declaresActiveSessionAttachment = (params.contracts?.sessionAttachments ?? []).includes(
     ACTIVE_SESSION_ATTACHMENT_CONTRACT,
   );
-  return (
-    declaresActiveSessionAttachment &&
-    (params.trustedOfficialInstall === true || params.allowConversationAccess === true)
-  );
+  return declaresActiveSessionAttachment && params.trustedOfficialInstall === true;
 }
 
 function resolveAttachmentFilePath(params: {
@@ -262,7 +258,7 @@ export async function sendPluginSessionAttachment(
     return {
       ok: false,
       error:
-        'session attachments require bundled origin or contracts.sessionAttachments:["active-session"] with trusted official install or allowConversationAccess=true',
+        'session attachments require bundled origin or contracts.sessionAttachments:["active-session"] with trusted official install',
     };
   }
   const sessionKey = normalizeOptionalString(params.sessionKey);

--- a/src/plugins/host-hooks.ts
+++ b/src/plugins/host-hooks.ts
@@ -1,5 +1,6 @@
 import type { OperatorScope } from "../gateway/operator-scopes.js";
 import type { AgentEventPayload, AgentEventStream } from "../infra/agent-events.js";
+import type { MessagePresentation } from "../interactive/payload.js";
 import type {
   PluginHookAgentContext,
   PluginHookBeforeToolCallEvent,
@@ -237,8 +238,9 @@ export type PluginSessionAttachmentCaptionFormat = "plain" | "html" | "markdown"
 
 export type PluginSessionAttachmentParams = {
   sessionKey: string;
-  files: PluginSessionAttachmentFile[];
+  files?: PluginSessionAttachmentFile[];
   text?: string;
+  presentation?: MessagePresentation;
   threadId?: string | number;
   forceDocument?: boolean;
   maxBytes?: number;

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -1906,6 +1906,27 @@ describe("loadPluginManifestRegistry", () => {
     });
   });
 
+  it("preserves active-session attachment contracts from plugin manifests", () => {
+    const dir = makeTempDir();
+    writeManifest(dir, {
+      id: "workflow-plan-plugin",
+      contracts: {
+        sessionAttachments: ["active-session"],
+      },
+      configSchema: { type: "object" },
+    });
+
+    const registry = loadSingleCandidateRegistry({
+      idHint: "workflow-plan-plugin",
+      rootDir: dir,
+      origin: "workspace",
+    });
+
+    expect(registry.plugins[0]?.contracts).toEqual({
+      sessionAttachments: ["active-session"],
+    });
+  });
+
   it("preserves channel env metadata from plugin manifests", () => {
     const dir = makeTempDir();
     writeManifest(dir, {

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -156,6 +156,7 @@ function resolveManifestPluginSourcePath(params: {
 }
 
 export type PluginManifestContractListKey =
+  | "sessionAttachments"
   | "speechProviders"
   | "externalAuthProviders"
   | "mediaUnderstandingProviders"
@@ -370,6 +371,7 @@ function mergeManifestContracts(
   for (const key of [
     "embeddedExtensionFactories",
     "agentToolResultMiddleware",
+    "sessionAttachments",
     "externalAuthProviders",
     "memoryEmbeddingProviders",
     "speechProviders",

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -397,6 +397,12 @@ export type PluginManifestContracts = {
   embeddedExtensionFactories?: string[];
   agentToolResultMiddleware?: string[];
   /**
+   * Session workflow privileges owned by the plugin. Currently supports
+   * "active-session" to let trusted workflow plugins deliver attachments or
+   * rich presentations to the active session route.
+   */
+  sessionAttachments?: string[];
+  /**
    * Provider ids whose external auth profile hook can contribute runtime-only
    * credentials. Declaring this lets auth-store overlays load only the owning
    * plugin instead of every provider plugin.
@@ -798,6 +804,7 @@ function normalizeManifestContracts(value: unknown): PluginManifestContracts | u
 
   const embeddedExtensionFactories = normalizeTrimmedStringList(value.embeddedExtensionFactories);
   const agentToolResultMiddleware = normalizeTrimmedStringList(value.agentToolResultMiddleware);
+  const sessionAttachments = normalizeTrimmedStringList(value.sessionAttachments);
   const externalAuthProviders = normalizeTrimmedStringList(value.externalAuthProviders);
   const memoryEmbeddingProviders = normalizeTrimmedStringList(value.memoryEmbeddingProviders);
   const speechProviders = normalizeTrimmedStringList(value.speechProviders);
@@ -819,6 +826,7 @@ function normalizeManifestContracts(value: unknown): PluginManifestContracts | u
   const contracts = {
     ...(embeddedExtensionFactories.length > 0 ? { embeddedExtensionFactories } : {}),
     ...(agentToolResultMiddleware.length > 0 ? { agentToolResultMiddleware } : {}),
+    ...(sessionAttachments.length > 0 ? { sessionAttachments } : {}),
     ...(externalAuthProviders.length > 0 ? { externalAuthProviders } : {}),
     ...(memoryEmbeddingProviders.length > 0 ? { memoryEmbeddingProviders } : {}),
     ...(speechProviders.length > 0 ? { speechProviders } : {}),

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -2758,6 +2758,9 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
                     ...attachment,
                     config: runtimeConfig,
                     origin: record.origin,
+                    trustedOfficialInstall: record.trustedOfficialInstall,
+                    allowConversationAccess: params.hookPolicy?.allowConversationAccess,
+                    contracts: record.contracts,
                   });
                 } catch (error) {
                   return {

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -2759,7 +2759,6 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
                     config: runtimeConfig,
                     origin: record.origin,
                     trustedOfficialInstall: record.trustedOfficialInstall,
-                    allowConversationAccess: params.hookPolicy?.allowConversationAccess,
                     contracts: record.contracts,
                   });
                 } catch (error) {


### PR DESCRIPTION
## Why

Workflow plugins can already own tools, session actions, and control surfaces, but the active-session attachment path is currently bundled-only. That leaves trusted workflow plugins with no safe way to deliver a session-scoped Markdown artifact or a rich presentation card to the same channel/thread they are operating in.

This keeps the default restriction intact, but adds a narrow explicit capability for trusted workflow plugins.

## What Changed

- Adds `contracts.sessionAttachments` to plugin manifest contracts.
- Allows `session.workflow.sendSessionAttachment` when either:
  - the plugin is bundled, preserving current behavior, or
  - the plugin declares `contracts.sessionAttachments:["active-session"]` and is a trusted official install.
- Keeps generic conversation access separate from attachment delivery; `allowConversationAccess` alone is not a grant for active-session attachments.
- Lets active-session attachments carry text or a `MessagePresentation` without requiring a file.
- Passes presentations through to the outbound message payload path so channel adapters with button/presentation support can render them.
- Preserves file validation, session-route resolution, delivery routing, max-size checks, and the default deny behavior for untrusted third-party plugins.

## Safety Boundary

Untrusted external plugins remain blocked. A third-party plugin must declare the explicit active-session contract and be trusted by official install metadata. The error remains fail-closed and specific when that trust boundary is missing.

## Real Behavior Proof

- **Behavior or issue addressed**: External workflow plugins can declare an explicit active-session attachment contract, while untrusted third-party plugins remain blocked by default and generic conversation access does not widen the attachment seam.
- **Real environment tested**: Local OpenClaw checkout on macOS at `/Volumes/LEXAR/repos/openclaw-smarter-claw-attachment-sdk`, running the patched host code directly with Node/tsx against the real manifest registry and attachment authorization path.
- **Exact steps or command run after this patch**: Ran this after the patch:

```bash
node --import tsx - <<'EOF'
import fs from 'node:fs';
import os from 'node:os';
import path from 'node:path';
import { loadPluginManifestRegistry } from './src/plugins/manifest-registry.ts';
import { sendPluginSessionAttachment } from './src/plugins/host-hook-attachments.ts';

const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'active-session-contract-'));
fs.writeFileSync(path.join(dir, 'openclaw.plugin.json'), JSON.stringify({
  id: 'workflow-plan-plugin',
  configSchema: { type: 'object' },
  contracts: { sessionAttachments: ['active-session'] },
}));
const registry = loadPluginManifestRegistry({
  candidates: [{
    idHint: 'workflow-plan-plugin',
    rootDir: dir,
    source: path.join(dir, 'index.ts'),
    origin: 'workspace',
  }],
});
console.log('manifest-contracts=', JSON.stringify(registry.plugins[0]?.contracts));
const conversationAccessOnly = await sendPluginSessionAttachment({
  origin: 'workspace',
  allowConversationAccess: true,
  contracts: { sessionAttachments: ['active-session'] },
  sessionKey: 'agent:main:main',
  text: 'Plan approval requested.',
  presentation: { title: 'Plan', blocks: [{ type: 'text', text: 'Review the plan.' }] },
});
console.log('conversation-access-only=', JSON.stringify(conversationAccessOnly));
const trustedShape = await sendPluginSessionAttachment({
  origin: 'workspace',
  trustedOfficialInstall: true,
  contracts: { sessionAttachments: ['active-session'] },
  sessionKey: '',
  text: 'Plan approval requested.',
  presentation: { title: 'Plan', blocks: [{ type: 'text', text: 'Review the plan.' }] },
});
console.log('trusted-shape-result=', JSON.stringify(trustedShape));
EOF
```

- **Evidence after fix**: Terminal output from the patched checkout:

```text
manifest-contracts= {"sessionAttachments":["active-session"]}
conversation-access-only= {"ok":false,"error":"session attachments require bundled origin or contracts.sessionAttachments:[\"active-session\"] with trusted official install"}
trusted-shape-result= {"ok":false,"error":"sessionKey is required"}
```

- **Observed result after fix**: The manifest registry preserved `sessionAttachments:["active-session"]`; a plugin with only generic conversation access was blocked at the attachment trust boundary; a trusted official install advanced past the trust boundary and reached ordinary parameter validation (`sessionKey is required`) without attempting outbound delivery.
- **What was not tested**: Real Telegram delivery was not sent from this OpenClaw PR. The companion Smarter-Claw PR performs plugin-side callback/button wiring; end-to-end Telegram smoke still belongs on an install with this host seam plus a configured bot/channel.

## Validation

Local validation ran from `/Volumes/LEXAR/repos/openclaw-smarter-claw-attachment-sdk`:

- `OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test:contracts:plugins -- src/plugins/contracts/session-attachments.contract.test.ts src/plugins/manifest-registry.test.ts`
  - contract lane ran `session-attachments.contract.test.ts`: 21 tests passed.
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.plugins.config.ts --maxWorkers=1 src/plugins/manifest-registry.test.ts -t "preserves active-session attachment contracts"`
  - 1 focused manifest-registry test passed; 64 skipped by filter.
- `pnpm build:plugin-sdk:strict-smoke`

I intentionally did not run the full local suite; this workstation policy prefers GitHub Actions for heavier OpenClaw validation.
