### PR TITLE
docs(secrets): clarify agent-readable plaintext boundary

### DIFF
--- a/docs/gateway/secrets.md
+++ b/docs/gateway/secrets.md
@@ -14,6 +14,14 @@ OpenClaw supports additive SecretRefs so supported credentials do not need to be
 Plaintext still works. SecretRefs are opt-in per credential.
 </Note>
 
+<Warning>
+Plaintext credentials remain agent-readable if they are stored in files the
+agent can inspect, including `openclaw.json`, `auth-profiles.json`, `.env`, or
+generated `agents/*/agent/models.json` files. SecretRefs reduce that local blast
+radius only after every supported credential has been migrated and
+`openclaw secrets audit --check` reports no plaintext secret residue.
+</Warning>
+
 ## Goals and runtime model
 
 Secrets are resolved into an in-memory runtime snapshot.
@@ -27,6 +35,33 @@ Secrets are resolved into an in-memory runtime snapshot.
 - Outbound delivery paths also read from that active snapshot (for example Discord reply/thread delivery and Telegram action sends); they do not re-resolve SecretRefs on each send.
 
 This keeps secret-provider outages off hot request paths.
+
+## Agent-access boundary
+
+SecretRefs protect credentials from being persisted in supported config and
+generated model surfaces, but they are not a process-isolation boundary. If a
+plaintext credential remains on disk in a path the agent can read, the agent can
+bypass API-level redaction by using file or shell tools to inspect that file.
+
+For production deployments where agent-accessible files are in scope, treat
+SecretRef migration as complete only when all of these are true:
+
+- supported credentials use SecretRefs instead of plaintext values
+- legacy plaintext residue has been scrubbed from `openclaw.json`,
+  `auth-profiles.json`, `.env`, and generated `models.json` files
+- `openclaw secrets audit --check` is clean after the migration
+- any remaining unsupported or rotating credentials are protected by operating
+  system isolation, container isolation, or an external credential proxy
+
+This is why the audit/configure/apply workflow is a security migration gate, not
+just a convenience helper.
+
+<Warning>
+SecretRefs do not make arbitrary readable files safe. Backups, copied configs,
+old generated model catalogs, and unsupported credential classes must be treated
+as production secrets until they are deleted, moved outside the agent trust
+boundary, or protected by a separate isolation layer.
+</Warning>
 
 ## Active-surface filtering
 
@@ -495,9 +530,9 @@ Default operator flow:
     openclaw secrets audit --check
     ```
   </Step>
-  <Step title="Configure SecretRefs">
+  <Step title="Configure and apply SecretRefs">
     ```bash
-    openclaw secrets configure
+    openclaw secrets configure --apply
     ```
   </Step>
   <Step title="Re-audit">
@@ -506,6 +541,13 @@ Default operator flow:
     ```
   </Step>
 </Steps>
+
+Do not treat the migration as complete until the re-audit is clean. If the audit
+still reports plaintext values at rest, the agent-access risk is still present
+even when runtime APIs return redacted values.
+
+If you save a plan instead of applying during `configure`, apply that saved plan
+with `openclaw secrets apply --from <plan-path>` before the re-audit.
 
 <AccordionGroup>
   <Accordion title="secrets audit">


### PR DESCRIPTION
Resolves part of #11829.

## Summary

- Clarifies that SecretRefs do not protect plaintext credentials that remain in agent-readable files.
- Adds an explicit agent-access boundary section to the secrets documentation.
- Makes the migration gate concrete: configure/apply SecretRefs, then re-run `openclaw secrets audit --check` until no plaintext residue remains.
- Calls out backups, copied configs, generated model catalogs, and unsupported credential classes as still requiring OS/container/proxy isolation.

## Why

The issue remains open because SecretRef support is additive and opt-in. Runtime redaction is useful, but it does not stop an agent from reading plaintext credentials directly from files it can inspect. This documentation makes that boundary explicit for operators.

## Real behavior proof

Behavior addressed: The secrets documentation now tells operators that SecretRefs reduce local plaintext exposure only after supported credentials are migrated and `openclaw secrets audit --check` reports no plaintext residue, and it names readable config/model files that still remain inside the agent trust boundary until scrubbed or isolated.

Real environment tested: Local OpenClaw checkout for external PR head `d0f58cc7de08d05b96165810bbcaa58738ef8aee`, rebased on upstream `origin/main` at `a13468320c63573917c185db278f3d4e13389a78`.

Exact steps or command run after this patch: I inspected the patched documentation page in the real checkout with line-numbered search output and ran the whitespace gate:

```bash
git show --stat --oneline HEAD
git diff --check origin/main...HEAD
rg -n "Plaintext credentials remain agent-readable|Agent-access boundary|Configure and apply SecretRefs|Do not treat the migration|openclaw secrets configure --apply|openclaw secrets audit --check" docs/gateway/secrets.md
```

Evidence after fix: Copied terminal output from the local OpenClaw checkout:

```text
d0f58cc7 docs(secrets): clarify agent-readable plaintext boundary
 docs/gateway/secrets.md | 46 ++++++++++++++++++++++++++++++++++++++++++++--
 1 file changed, 44 insertions(+), 2 deletions(-)

18:Plaintext credentials remain agent-readable if they are stored in files the
22:`openclaw secrets audit --check` reports no plaintext secret residue.
39:## Agent-access boundary
52:- `openclaw secrets audit --check` is clean after the migration
530:    openclaw secrets audit --check
533:  <Step title="Configure and apply SecretRefs">
535:    openclaw secrets configure --apply
540:    openclaw secrets audit --check
545:Do not treat the migration as complete until the re-audit is clean. If the audit
```

Observed result after fix: The live documentation source now contains the new warning, the agent-access boundary section, the explicit configure/apply command, and the clean re-audit requirement. `git diff --check origin/main...HEAD` completed with no output, so the docs diff has no whitespace errors.

What was not tested: I did not build or deploy the docs site, because this PR changes only one Markdown documentation source file and the required proof here is the updated documentation content plus whitespace validation.

## Tests

- `git diff --check origin/main...HEAD`
- `git apply --check --reverse earning_goal/bounty_submissions/openclaw-11829-secretref-docs.patch`
