### PR TITLE
fix(auto-reply): require slash command boundary

### DIFF
--- a/src/auto-reply/reply/commands-allowlist.test.ts
+++ b/src/auto-reply/reply/commands-allowlist.test.ts
@@ -322,6 +322,18 @@ function buildAllowlistParams(
 }
 
 describe("handleAllowlistCommand", () => {
+  it("ignores longer command names that only prefix-match /allowlist", async () => {
+    const result = await handleAllowlistCommand(
+      buildAllowlistParams("/allowlist-check list dm", {
+        commands: { text: true },
+        channels: { telegram: { allowFrom: ["123"] } },
+      } as OpenClawConfig),
+      true,
+    );
+
+    expect(result).toBeNull();
+  });
+
   it("lists config and store allowFrom entries", async () => {
     readChannelAllowFromStoreMock.mockResolvedValueOnce(["456"]);
 

--- a/src/auto-reply/reply/commands-allowlist.ts
+++ b/src/auto-reply/reply/commands-allowlist.ts
@@ -20,6 +20,7 @@ import {
   requireCommandFlagEnabled,
   requireGatewayClientScope,
 } from "./command-gates.js";
+import { sliceSlashCommandArgs } from "./commands-slash-parse.js";
 import type { CommandHandler } from "./commands-types.js";
 import { applyAllowlistConfigMutation, AutoReplyConfigMutationError } from "./config-mutations.js";
 import { resolveConfigWriteDeniedText } from "./config-write-authorization.js";
@@ -74,12 +75,10 @@ function resolveAllowlistAccountId(params: {
 }
 
 function parseAllowlistCommand(raw: string): AllowlistCommand | null {
-  const trimmed = raw.trim();
-  const trimmedLower = normalizeOptionalLowercaseString(trimmed) ?? "";
-  if (!trimmedLower.startsWith("/allowlist")) {
+  const rest = sliceSlashCommandArgs(raw, "/allowlist");
+  if (rest === null) {
     return null;
   }
-  const rest = trimmed.slice("/allowlist".length).trim();
   if (!rest) {
     return { action: "list", scope: "dm" };
   }

--- a/src/auto-reply/reply/commands-models.test.ts
+++ b/src/auto-reply/reply/commands-models.test.ts
@@ -314,7 +314,7 @@ describe("handleModelsCommand", () => {
       },
     } as OpenClawConfig);
 
-    expect([...(data.byProvider.get("claude-cli") ?? [])].toSorted()).toEqual([
+    expect(Array.from(data.byProvider.get("claude-cli") ?? []).toSorted()).toEqual([
       "claude-haiku-4-5",
       "claude-opus-4-5",
       "claude-opus-4-6",
@@ -349,7 +349,7 @@ describe("handleModelsCommand", () => {
         },
       },
     } as OpenClawConfig);
-    expect([...(minimaxData.byProvider.get("minimax") ?? [])]).toEqual(["abab-7"]);
+    expect(Array.from(minimaxData.byProvider.get("minimax") ?? [])).toEqual(["abab-7"]);
   });
 
   it("does not synthesize claude-cli models when the catalog has no claude-cli entries", async () => {
@@ -625,8 +625,8 @@ describe("handleModelsCommand", () => {
 
     const data = await buildModelsProviderData(cfg as OpenClawConfig);
 
-    expect([...(data.byProvider.get("openai-codex") ?? [])]).toEqual(["gpt-5.4"]);
-    expect([...(data.byProvider.get("deepseek") ?? [])].toSorted()).toEqual([
+    expect(Array.from(data.byProvider.get("openai-codex") ?? [])).toEqual(["gpt-5.4"]);
+    expect(Array.from(data.byProvider.get("deepseek") ?? []).toSorted()).toEqual([
       "deepseek-v4-flash",
       "deepseek-v4-pro",
     ]);

--- a/src/auto-reply/reply/commands-models.test.ts
+++ b/src/auto-reply/reply/commands-models.test.ts
@@ -188,6 +188,12 @@ function firstAuthCheckerParams() {
 }
 
 describe("handleModelsCommand", () => {
+  it("ignores longer command names that only prefix-match /models", async () => {
+    const result = await handleModelsCommand(buildParams("/models-check openai"), true);
+
+    expect(result).toBeNull();
+  });
+
   it("shows a simple providers menu on text surfaces", async () => {
     const result = await handleModelsCommand(buildParams("/models"), true);
 

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -33,6 +33,7 @@ import {
 import { resolveAgentRuntimeLabel } from "../../status/agent-runtime-label.js";
 import type { ReplyPayload } from "../types.js";
 import { rejectUnauthorizedCommand } from "./command-gates.js";
+import { sliceSlashCommandArgs } from "./commands-slash-parse.js";
 import type { CommandHandler } from "./commands-types.js";
 
 const PAGE_SIZE_DEFAULT = 20;
@@ -475,12 +476,10 @@ export async function resolveModelsCommandReply(params: {
   workspaceDir?: string;
   sessionEntry?: ModelsCommandSessionEntry;
 }): Promise<ReplyPayload | null> {
-  const body = params.commandBodyNormalized.trim();
-  if (!body.startsWith("/models")) {
+  const argText = sliceSlashCommandArgs(params.commandBodyNormalized, "/models");
+  if (argText === null) {
     return null;
   }
-
-  const argText = body.replace(/^\/models\b/i, "").trim();
   const parsed = parseModelsArgs(argText);
 
   const { byProvider, providers, modelNames } = await buildModelsProviderData(
@@ -642,11 +641,12 @@ export const handleModelsCommand: CommandHandler = async (params, allowTextComma
   if (!allowTextCommands) {
     return null;
   }
-  const commandBodyNormalized = params.command.commandBodyNormalized.trim();
-  if (!commandBodyNormalized.startsWith("/models")) {
+  const commandBodyNormalized = params.command.commandBodyNormalized;
+  const argText = sliceSlashCommandArgs(commandBodyNormalized, "/models");
+  if (argText === null) {
     return null;
   }
-  const parsed = parseModelsArgs(commandBodyNormalized.replace(/^\/models\b/i, "").trim());
+  const parsed = parseModelsArgs(argText);
   const unauthorized = rejectUnauthorizedCommand(params, "/models");
   if (unauthorized) {
     return unauthorized;

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -546,7 +546,7 @@ export async function resolveModelsCommandReply(params: {
     };
   }
 
-  const models = [...(byProvider.get(provider) ?? new Set<string>())].toSorted();
+  const models = Array.from(byProvider.get(provider) ?? new Set<string>()).toSorted();
   const total = models.length;
 
   if (total === 0) {

--- a/src/auto-reply/reply/commands-setunset.test.ts
+++ b/src/auto-reply/reply/commands-setunset.test.ts
@@ -87,6 +87,24 @@ describe("parseSlashCommandWithSetUnset", () => {
     expect(result).toBeNull();
   });
 
+  it("does not match longer slash command names that share the same prefix", () => {
+    const result = parseSlashCommandWithSetUnset<ParsedSetUnsetAction>(
+      createSlashParams({ raw: "/config-check show" }),
+    );
+    expect(result).toBeNull();
+  });
+
+  it("accepts colon as a slash command delimiter", () => {
+    const result = parseSlashCommandWithSetUnset<ParsedSetUnsetAction>(
+      createSlashParams({
+        raw: "/config: show",
+        onKnownAction: (action) =>
+          action === "show" ? { action: "unset", path: "dummy" } : undefined,
+      }),
+    );
+    expect(result).toEqual({ action: "unset", path: "dummy" });
+  });
+
   it("prefers set/unset mapping and falls back to known actions", () => {
     const setResult = parseSlashCommandWithSetUnset<ParsedSetUnsetAction>(
       createSlashParams({

--- a/src/auto-reply/reply/commands-slash-parse.ts
+++ b/src/auto-reply/reply/commands-slash-parse.ts
@@ -10,18 +10,25 @@ export type ParsedSlashCommand =
   | { ok: true; action: string; args: string }
   | { ok: false; message: string };
 
-function parseSlashCommandActionArgs(raw: string, slash: string): SlashCommandParseResult {
+export function sliceSlashCommandArgs(raw: string, slash: string): string | null {
   const trimmed = raw.trim();
   const slashLower = normalizeLowercaseStringOrEmpty(slash);
   if (!normalizeLowercaseStringOrEmpty(trimmed).startsWith(slashLower)) {
-    return { kind: "no-match" };
+    return null;
   }
   const charAfterSlash = trimmed.charAt(slash.length);
   if (charAfterSlash && !/[\s:]/.test(charAfterSlash)) {
-    return { kind: "no-match" };
+    return null;
   }
   const restOffset = charAfterSlash === ":" ? slash.length + 1 : slash.length;
-  const rest = trimmed.slice(restOffset).trim();
+  return trimmed.slice(restOffset).trim();
+}
+
+function parseSlashCommandActionArgs(raw: string, slash: string): SlashCommandParseResult {
+  const rest = sliceSlashCommandArgs(raw, slash);
+  if (rest === null) {
+    return { kind: "no-match" };
+  }
   if (!rest) {
     return { kind: "empty" };
   }

--- a/src/auto-reply/reply/commands-slash-parse.ts
+++ b/src/auto-reply/reply/commands-slash-parse.ts
@@ -16,7 +16,12 @@ function parseSlashCommandActionArgs(raw: string, slash: string): SlashCommandPa
   if (!normalizeLowercaseStringOrEmpty(trimmed).startsWith(slashLower)) {
     return { kind: "no-match" };
   }
-  const rest = trimmed.slice(slash.length).trim();
+  const charAfterSlash = trimmed.charAt(slash.length);
+  if (charAfterSlash && !/[\s:]/.test(charAfterSlash)) {
+    return { kind: "no-match" };
+  }
+  const restOffset = charAfterSlash === ":" ? slash.length + 1 : slash.length;
+  const rest = trimmed.slice(restOffset).trim();
   if (!rest) {
     return { kind: "empty" };
   }


### PR DESCRIPTION
## Summary
- require a slash-command token boundary before parsing action args
- keep `/config show` behavior and support `/config: show` as a delimiter form
- add regression coverage so `/config-check show` is not intercepted by `/config`

## Real behavior proof
Behavior addressed: `/config-check show` no longer matches the built-in `/config` parser; `/config show` and `/config: show` still parse as `/config` commands.

Real environment tested: local OpenClaw source checkout on this PR branch, running the real TypeScript parser through Node with `tsx` against `src/auto-reply/reply/commands-setunset.ts`.

Exact steps or command run after the patch:
```bash
node --import tsx --input-type=module - <<'EOF'
import { parseSlashCommandWithSetUnset } from './src/auto-reply/reply/commands-setunset.ts';
const base = {
  slash: '/config',
  invalidMessage: 'Invalid /config syntax.',
  usageMessage: 'Usage: /config show|set|unset',
  onSet: (path, value) => ({ action: 'set', path, value }),
  onUnset: (path) => ({ action: 'unset', path }),
  onError: (message) => ({ action: 'error', message }),
};
const result = {
  longerCommand: parseSlashCommandWithSetUnset({ ...base, raw: '/config-check show', onKnownAction: () => undefined }),
  colonDelimiter: parseSlashCommandWithSetUnset({
    ...base,
    raw: '/config: show',
    onKnownAction: (action) => action === 'show' ? { action: 'show' } : undefined,
  }),
  normalCommand: parseSlashCommandWithSetUnset({
    ...base,
    raw: '/config show',
    onKnownAction: (action) => action === 'show' ? { action: 'show' } : undefined,
  }),
};
console.log(JSON.stringify(result, null, 2));
EOF
```

Evidence after fix:
```json
{
  "longerCommand": null,
  "colonDelimiter": {
    "action": "show"
  },
  "normalCommand": {
    "action": "show"
  }
}
```

Observed result: the actual parser output returns `null` for `/config-check show`, so the `/config` handler does not intercept the longer command name. The same parser still returns `{ "action": "show" }` for `/config show` and `/config: show`.

What was not tested: live channel gateway invocation with an installed `config-check` skill was not run in this environment.

## Supplemental verification
```text
$ node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts src/auto-reply/reply/commands-setunset.test.ts

RUN  v4.1.6 /home/chenglunhu/code/openclaw

Test Files  1 passed (1)
     Tests  11 passed (11)
```

Fixes #84572