### PR TITLE
fix(minimax): pass duration field to music_generation API

### DIFF
--- a/extensions/minimax/music-generation-provider.ts
+++ b/extensions/minimax/music-generation-provider.ts
@@ -190,6 +190,9 @@ function buildMinimaxMusicProvider(providerId: string): MusicGenerationProvider 
         prompt: buildPrompt(req),
         ...(req.instrumental === true ? { is_instrumental: true } : {}),
         ...(lyrics ? { lyrics } : req.instrumental === true ? {} : { lyrics_optimizer: true }),
+        ...(typeof req.durationSeconds === "number" && Number.isFinite(req.durationSeconds)
+          ? { duration: Math.max(1, Math.round(req.durationSeconds)) }
+          : {}),
         output_format: "url",
         audio_setting: {
           sample_rate: 44_100,


### PR DESCRIPTION
## Summary
- Add the `duration` JSON field to the MiniMax `/v1/music_generation` request body when `durationSeconds` is provided.
- Previously, `durationSeconds` was only embedded as a natural-language hint in the prompt text, which the MiniMax API ignores — producing default-length tracks instead of the requested duration.

## Real behavior proof

**Behavior or issue addressed**: MiniMax music_generation provider does not pass `durationSeconds` to the API. It appends a prompt hint like "Target duration: about 30 seconds." which the API ignores, silently producing default-length tracks.

**Real environment tested**: Linux x86_64, Node.js v22.22.0. Pure JavaScript object construction, platform-independent.

**Exact steps or command run after the patch**:
```bash
cd openclaw-84473
node proof_repro_84508.mjs
```
The script builds the API request body with the old and new logic, testing 4 scenarios: with durationSeconds, without, NaN edge case, and float rounding.

**Evidence after fix**:
```
=== MiniMax music_generation durationSeconds fix (#84508) ===
Timestamp : 2026-05-20T12:52:48.657Z
Node.js   : v22.22.0
Platform  : linux x64

--- Scenario 1: request with durationSeconds=30 ---
BEFORE fix: "duration" in body = false
AFTER  fix: "duration" in body = true, value = 30
PASS: true

--- Scenario 2: request without durationSeconds ---
AFTER  fix: "duration" in body = false
PASS: true

--- Scenario 3: durationSeconds=NaN (edge case) ---
AFTER  fix: "duration" in body = false
PASS: true

--- Scenario 4: durationSeconds=45.7 (rounded) ---
AFTER  fix: duration = 46
PASS: true

=== Result ===
With durationSeconds  : PASS
Without durationSeconds: PASS
NaN edge case          : PASS
Float rounding         : PASS
Overall                : PASS
```

**Observed result after fix**: Before fix: the API request body has no `duration` field, so MiniMax returns default-length tracks. After fix: `duration: 30` is included in the body when `durationSeconds=30` is requested. Requests without `durationSeconds` or with NaN are unaffected.

**What was not tested**: Live MiniMax API call with real credentials. The prompt-embedded duration hint is intentionally left in place as a fallback hint.

Fixes #84508