### PR TITLE
fix(telegram): recognize bot_command entities as explicit mentions in mention gate

### DIFF
--- a/extensions/telegram/src/bot/body-helpers.ts
+++ b/extensions/telegram/src/bot/body-helpers.ts
@@ -146,12 +146,16 @@ export function hasBotMention(msg: Message, botUsername: string) {
     return true;
   }
   for (const ent of entities) {
-    if (ent.type !== "mention") {
-      continue;
-    }
-    const slice = text.slice(ent.offset, ent.offset + ent.length);
-    if (normalizeLowercaseStringOrEmpty(slice) === mention) {
-      return true;
+    if (ent.type === "mention") {
+      const slice = text.slice(ent.offset, ent.offset + ent.length);
+      if (normalizeLowercaseStringOrEmpty(slice) === mention) {
+        return true;
+      }
+    } else if (ent.type === "bot_command") {
+      const slice = text.slice(ent.offset, ent.offset + ent.length);
+      if (normalizeLowercaseStringOrEmpty(slice).endsWith(mention)) {
+        return true;
+      }
     }
   }
   return false;


### PR DESCRIPTION
## Summary
- Extend `hasBotMention()` to check `bot_command` entities (e.g. `/ping@TargetBot`) in addition to `mention` entities.
- Previously, Telegram group messages with `/command@TargetBot` were dropped by the mention gate as `no-mention` when `requireMention: true`, because the Bot API represents these as `bot_command` entities, not `mention` entities.

## Real behavior proof

**Behavior or issue addressed**: Telegram bot-to-bot `/command@TargetBot` messages are dropped by the mention gate in groups with `requireMention: true`. The Bot API represents these as `bot_command` entities, but the mention gate only checks `mention` entities.

**Real environment tested**: Linux x86_64, Node.js v22.22.0. Pure JavaScript string/entity parsing logic, platform-independent.

**Exact steps or command run after the patch**:
```bash
cd openclaw-84473
node proof_repro_84462.mjs
```
The script tests the mention detection function with 5 scenarios: bot_command targeting our bot, case-insensitive match, normal mention entity, bot_command targeting another bot, and plain text without mention.

**Evidence after fix**:
```
=== Telegram bot_command mention gate fix (#84462) ===
Timestamp : 2026-05-20T13:02:33.846Z
Node.js   : v22.22.0
Platform  : linux x64

--- /ping@mybot (bot_command entity) ---
  BEFORE: no-mention (expect: mentioned)
  AFTER : mentioned → PASS

--- /help@MyBot (case-insensitive) ---
  BEFORE: no-mention (expect: mentioned)
  AFTER : mentioned → PASS

--- @mybot (mention entity) ---
  BEFORE: mentioned (expect: mentioned)
  AFTER : mentioned → PASS

--- /ping@otherbot (not our bot) ---
  BEFORE: no-mention (expect: no-mention)
  AFTER : no-mention → PASS

--- plain text without mention ---
  BEFORE: no-mention (expect: no-mention)
  AFTER : no-mention → PASS

=== Result ===
All scenarios: PASS
```

**Observed result after fix**: Before fix: `/ping@mybot` with a `bot_command` entity returns `no-mention`, causing the message to be silently dropped. After fix: the `bot_command` entity text is checked for `@botUsername` suffix (case-insensitive), so `/ping@mybot` is correctly recognized as an explicit mention. Normal mentions and non-targeting commands are unaffected.

**What was not tested**: Live Telegram Bot API integration with real bot credentials. Forum/topic-specific routing. The second call site in `bot-handlers.runtime.ts:690` (which uses the same `hasBotMention` function, so the fix applies there too).

Fixes #84462