### PR TITLE
fix(agents): strip plaintext model provider keys

### DIFF
--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -345,7 +345,8 @@ Custom providers in `models.providers` are written into `models.json` under the 
     Merge mode precedence for matching provider IDs:
 
     - Non-empty `baseUrl` already present in the agent `models.json` wins.
-    - Non-empty `apiKey` in the agent `models.json` wins only when that provider is not SecretRef-managed in current config/auth-profile context.
+    - Plaintext `apiKey` values already present in the agent `models.json` are not preserved in the prompt-facing catalog. When no current config/auth-profile context already supplies that provider credential, OpenClaw migrates the legacy key into the target agent's local `auth-profiles.json` before writing the stripped `models.json`.
+    - If the legacy `apiKey` migration cannot be durably written, OpenClaw fails closed and leaves the existing `models.json` unchanged instead of writing a stripped catalog that would lose the only credential.
     - SecretRef-managed provider `apiKey` values are refreshed from source markers (`ENV_VAR_NAME` for env refs, `secretref-managed` for file/exec refs) instead of persisting resolved secrets.
     - SecretRef-managed provider header values are refreshed from source markers (`secretref-env:ENV_VAR_NAME` for env refs, `secretref-managed` for file/exec refs).
     - Empty or missing agent `apiKey`/`baseUrl` fall back to config `models.providers`.

--- a/src/agents/auth-profiles.ts
+++ b/src/agents/auth-profiles.ts
@@ -53,6 +53,7 @@ export {
   ensureAuthProfileStore,
   ensureAuthProfileStoreWithoutExternalProfiles,
   hasAnyAuthProfileStoreSource,
+  loadAuthProfileStoreForLocalAgent,
   loadAuthProfileStoreForSecretsRuntime,
   loadAuthProfileStoreWithoutExternalProfiles,
   loadAuthProfileStoreForRuntime,

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -617,6 +617,21 @@ export function loadAuthProfileStoreWithoutExternalProfiles(
   return mergeAuthProfileStores(mainStore, store);
 }
 
+export function loadAuthProfileStoreForLocalAgent(
+  agentDir?: string,
+  loadOptions?: Pick<
+    LoadAuthProfileStoreOptions,
+    "allowKeychainPrompt" | "resolveLegacyOAuthSidecars"
+  >,
+): AuthProfileStore {
+  return loadAuthProfileStoreForAgent(agentDir, {
+    readOnly: true,
+    syncExternalCli: false,
+    allowKeychainPrompt: loadOptions?.allowKeychainPrompt ?? false,
+    resolveLegacyOAuthSidecars: loadOptions?.resolveLegacyOAuthSidecars ?? false,
+  });
+}
+
 export function ensureAuthProfileStore(
   agentDir?: string,
   options?: {

--- a/src/agents/models-config.plan.test.ts
+++ b/src/agents/models-config.plan.test.ts
@@ -132,6 +132,45 @@ describe("models-config plan", () => {
     expect(providers.custom?.apiKey).toBe(NON_ENV_SECRETREF_MARKER);
   });
 
+  it("plans cleanup for catalog-only provider api keys before the empty-provider skip path", async () => {
+    const existingRaw = `${JSON.stringify(
+      {
+        providers: {
+          custom: {
+            baseUrl: "https://custom.example/v1",
+            api: "openai-completions",
+            apiKey: "sk-existing-catalog-only", // pragma: allowlist secret
+            models: [customModelConfig()],
+          },
+        },
+      },
+      null,
+      2,
+    )}\n`;
+
+    const plan = await planOpenClawModelsJsonWithDeps(
+      {
+        cfg: {},
+        sourceConfigForSecrets: {},
+        agentDir: "/tmp/openclaw-models-plan",
+        env: {},
+        existingRaw,
+        existingParsed: JSON.parse(existingRaw) as unknown,
+      },
+      {
+        resolveImplicitProviders: async () => ({}),
+      },
+    );
+
+    expect(plan.action).toBe("write");
+    if (plan.action !== "write") {
+      throw new Error(`expected catalog-only cleanup write, got ${plan.action}`);
+    }
+    expect(plan.contents).not.toContain("sk-existing-catalog-only");
+    const providers = JSON.parse(plan.contents).providers as Record<string, { apiKey?: string }>;
+    expect(providers.custom?.apiKey).toBe(NON_ENV_SECRETREF_MARKER);
+  });
+
   it("keeps custom provider models discoverable after stripping plaintext api keys", async () => {
     const contents = await planGeneratedContents({
       config: {

--- a/src/agents/models-config.plan.test.ts
+++ b/src/agents/models-config.plan.test.ts
@@ -77,7 +77,7 @@ describe("models-config plan", () => {
     expect(providers.openai?.apiKey).toBe("OPENAI_API_KEY"); // pragma: allowlist secret
   });
 
-  it("preserves existing models.json-only provider api keys in merge mode", async () => {
+  it("strips existing models.json-only provider api keys in merge mode", async () => {
     const providers = await planGeneratedProviders({
       config: {
         models: {
@@ -103,6 +103,6 @@ describe("models-config plan", () => {
       },
     });
 
-    expect(providers.custom?.apiKey).toBe("sk-existing-models-json-only"); // pragma: allowlist secret
+    expect(providers.custom?.apiKey).toBeUndefined();
   });
 });

--- a/src/agents/models-config.plan.test.ts
+++ b/src/agents/models-config.plan.test.ts
@@ -1,6 +1,11 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { NON_ENV_SECRETREF_MARKER } from "./model-auth-markers.js";
 import { planOpenClawModelsJsonWithDeps } from "./models-config.plan.js";
+import { discoverAuthStorage, discoverModels } from "./pi-model-discovery.js";
 
 vi.mock("../plugins/manifest-registry.js", () => ({
   loadPluginManifestRegistry: () => ({ plugins: [] }),
@@ -13,11 +18,23 @@ vi.mock("../plugins/provider-runtime.js", () => ({
   resolveProviderSyntheticAuthWithPlugin: () => undefined,
 }));
 
-async function planGeneratedProviders(params: {
+function customModelConfig() {
+  return {
+    id: "custom-model",
+    name: "Custom Model",
+    reasoning: false,
+    input: ["text" as const],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 128_000,
+    maxTokens: 4096,
+  };
+}
+
+async function planGeneratedContents(params: {
   config: OpenClawConfig;
   sourceConfigForSecrets?: OpenClawConfig;
   existingParsed?: unknown;
-}) {
+}): Promise<string> {
   const plan = await planOpenClawModelsJsonWithDeps(
     {
       cfg: params.config,
@@ -35,11 +52,20 @@ async function planGeneratedProviders(params: {
   if (plan.action !== "write") {
     throw new Error(`expected models.json write plan, got ${plan.action}`);
   }
-  return JSON.parse(plan.contents).providers as Record<string, { apiKey?: string }>;
+  return plan.contents;
+}
+
+async function planGeneratedProviders(params: {
+  config: OpenClawConfig;
+  sourceConfigForSecrets?: OpenClawConfig;
+  existingParsed?: unknown;
+}) {
+  const contents = await planGeneratedContents(params);
+  return JSON.parse(contents).providers as Record<string, { apiKey?: string }>;
 }
 
 describe("models-config plan", () => {
-  it("strips plaintext provider api keys from generated models.json", async () => {
+  it("replaces plaintext custom model provider api keys with a pi-compatible marker", async () => {
     const providers = await planGeneratedProviders({
       config: {
         models: {
@@ -48,14 +74,14 @@ describe("models-config plan", () => {
               baseUrl: "https://custom.example/v1",
               api: "openai-completions",
               apiKey: "sk-runtime-custom-key", // pragma: allowlist secret
-              models: [],
+              models: [customModelConfig()],
             },
           },
         },
       },
     });
 
-    expect(providers.custom?.apiKey).toBeUndefined();
+    expect(providers.custom?.apiKey).toBe(NON_ENV_SECRETREF_MARKER);
   });
 
   it("keeps provider api key markers in generated models.json", async () => {
@@ -86,7 +112,7 @@ describe("models-config plan", () => {
             custom: {
               baseUrl: "https://custom.example/v1",
               api: "openai-completions",
-              models: [],
+              models: [customModelConfig()],
             },
           },
         },
@@ -97,12 +123,40 @@ describe("models-config plan", () => {
             baseUrl: "https://custom.example/v1",
             api: "openai-completions",
             apiKey: "sk-existing-models-json-only", // pragma: allowlist secret
-            models: [],
+            models: [customModelConfig()],
           },
         },
       },
     });
 
-    expect(providers.custom?.apiKey).toBeUndefined();
+    expect(providers.custom?.apiKey).toBe(NON_ENV_SECRETREF_MARKER);
+  });
+
+  it("keeps custom provider models discoverable after stripping plaintext api keys", async () => {
+    const contents = await planGeneratedContents({
+      config: {
+        models: {
+          providers: {
+            custom: {
+              baseUrl: "https://custom.example/v1",
+              api: "openai-completions",
+              apiKey: "sk-runtime-custom-key", // pragma: allowlist secret
+              models: [customModelConfig()],
+            },
+          },
+        },
+      },
+    });
+    const parsed = JSON.parse(contents) as { providers: Record<string, { apiKey?: string }> };
+    expect(parsed.providers.custom?.apiKey).toBe(NON_ENV_SECRETREF_MARKER);
+    expect(contents).not.toContain("sk-runtime-custom-key");
+
+    const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-models-plan-"));
+    fs.writeFileSync(path.join(agentDir, "models.json"), contents);
+
+    const authStorage = discoverAuthStorage(agentDir, { skipCredentials: true });
+    const registry = discoverModels(authStorage, agentDir, { normalizeModels: false });
+
+    expect(registry.find("custom", "custom-model")?.id).toBe("custom-model");
   });
 });

--- a/src/agents/models-config.plan.test.ts
+++ b/src/agents/models-config.plan.test.ts
@@ -16,6 +16,7 @@ vi.mock("../plugins/provider-runtime.js", () => ({
 async function planGeneratedProviders(params: {
   config: OpenClawConfig;
   sourceConfigForSecrets?: OpenClawConfig;
+  existingParsed?: unknown;
 }) {
   const plan = await planOpenClawModelsJsonWithDeps(
     {
@@ -24,7 +25,7 @@ async function planGeneratedProviders(params: {
       agentDir: "/tmp/openclaw-models-plan",
       env: {},
       existingRaw: "",
-      existingParsed: null,
+      existingParsed: params.existingParsed ?? null,
     },
     {
       resolveImplicitProviders: async () => ({}),
@@ -74,5 +75,34 @@ describe("models-config plan", () => {
     });
 
     expect(providers.openai?.apiKey).toBe("OPENAI_API_KEY"); // pragma: allowlist secret
+  });
+
+  it("preserves existing models.json-only provider api keys in merge mode", async () => {
+    const providers = await planGeneratedProviders({
+      config: {
+        models: {
+          mode: "merge",
+          providers: {
+            custom: {
+              baseUrl: "https://custom.example/v1",
+              api: "openai-completions",
+              models: [],
+            },
+          },
+        },
+      },
+      existingParsed: {
+        providers: {
+          custom: {
+            baseUrl: "https://custom.example/v1",
+            api: "openai-completions",
+            apiKey: "sk-existing-models-json-only", // pragma: allowlist secret
+            models: [],
+          },
+        },
+      },
+    });
+
+    expect(providers.custom?.apiKey).toBe("sk-existing-models-json-only"); // pragma: allowlist secret
   });
 });

--- a/src/agents/models-config.plan.test.ts
+++ b/src/agents/models-config.plan.test.ts
@@ -14,6 +14,7 @@ vi.mock("../plugins/manifest-registry.js", () => ({
 vi.mock("../plugins/provider-runtime.js", () => ({
   applyProviderNativeStreamingUsageCompatWithPlugin: () => undefined,
   normalizeProviderConfigWithPlugin: () => undefined,
+  resolveExternalAuthProfilesWithPlugins: () => [],
   resolveProviderConfigApiKeyWithPlugin: () => undefined,
   resolveProviderSyntheticAuthWithPlugin: () => undefined,
 }));

--- a/src/agents/models-config.plan.test.ts
+++ b/src/agents/models-config.plan.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { planOpenClawModelsJsonWithDeps } from "./models-config.plan.js";
+
+vi.mock("../plugins/manifest-registry.js", () => ({
+  loadPluginManifestRegistry: () => ({ plugins: [] }),
+}));
+
+vi.mock("../plugins/provider-runtime.js", () => ({
+  applyProviderNativeStreamingUsageCompatWithPlugin: () => undefined,
+  normalizeProviderConfigWithPlugin: () => undefined,
+  resolveProviderConfigApiKeyWithPlugin: () => undefined,
+  resolveProviderSyntheticAuthWithPlugin: () => undefined,
+}));
+
+async function planGeneratedProviders(params: {
+  config: OpenClawConfig;
+  sourceConfigForSecrets?: OpenClawConfig;
+}) {
+  const plan = await planOpenClawModelsJsonWithDeps(
+    {
+      cfg: params.config,
+      sourceConfigForSecrets: params.sourceConfigForSecrets ?? params.config,
+      agentDir: "/tmp/openclaw-models-plan",
+      env: {},
+      existingRaw: "",
+      existingParsed: null,
+    },
+    {
+      resolveImplicitProviders: async () => ({}),
+    },
+  );
+  expect(plan.action).toBe("write");
+  if (plan.action !== "write") {
+    throw new Error(`expected models.json write plan, got ${plan.action}`);
+  }
+  return JSON.parse(plan.contents).providers as Record<string, { apiKey?: string }>;
+}
+
+describe("models-config plan", () => {
+  it("strips plaintext provider api keys from generated models.json", async () => {
+    const providers = await planGeneratedProviders({
+      config: {
+        models: {
+          providers: {
+            custom: {
+              baseUrl: "https://custom.example/v1",
+              api: "openai-completions",
+              apiKey: "sk-runtime-custom-key", // pragma: allowlist secret
+              models: [],
+            },
+          },
+        },
+      },
+    });
+
+    expect(providers.custom?.apiKey).toBeUndefined();
+  });
+
+  it("keeps provider api key markers in generated models.json", async () => {
+    const providers = await planGeneratedProviders({
+      config: {
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://api.openai.com/v1",
+              api: "openai-completions",
+              apiKey: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+              models: [],
+            },
+          },
+        },
+      },
+    });
+
+    expect(providers.openai?.apiKey).toBe("OPENAI_API_KEY"); // pragma: allowlist secret
+  });
+});

--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -111,6 +111,7 @@ function resolveProvidersForMode(params: {
 
 function stripPlaintextProviderApiKeys(
   providers: Record<string, ProviderConfig>,
+  options: { secretRefManagedProviders?: ReadonlySet<string> } = {},
 ): Record<string, ProviderConfig> {
   let mutated = false;
   const nextProviders: Record<string, ProviderConfig> = {};
@@ -119,7 +120,12 @@ function stripPlaintextProviderApiKeys(
       nextProviders[providerKey] = provider;
       continue;
     }
-    if (typeof provider.apiKey === "string" && isNonSecretApiKeyMarker(provider.apiKey)) {
+    const isSecretRefManagedProvider = options.secretRefManagedProviders?.has(providerKey.trim());
+    if (
+      typeof provider.apiKey === "string" &&
+      provider.apiKey.trim() &&
+      (isNonSecretApiKeyMarker(provider.apiKey) || isSecretRefManagedProvider)
+    ) {
       nextProviders[providerKey] = provider;
       continue;
     }
@@ -231,7 +237,9 @@ export async function planOpenClawModelsJsonWithDeps(
       secretRefManagedProviders,
       manifestPlugins,
     }) ?? providers;
-  const promptSafeProviders = stripPlaintextProviderApiKeys(normalizedProviders);
+  const promptSafeProviders = stripPlaintextProviderApiKeys(normalizedProviders, {
+    secretRefManagedProviders,
+  });
   const mergedProviders = resolveProvidersForMode({
     mode,
     existingParsed: params.existingParsed,
@@ -250,7 +258,9 @@ export async function planOpenClawModelsJsonWithDeps(
       secretRefManagedProviders,
     }) ?? normalizedMergedProviders;
   const compatProviders = applyNativeStreamingUsageCompat(secretEnforcedProviders);
-  const finalProviders = stripPlaintextProviderApiKeys(compatProviders);
+  const finalProviders = stripPlaintextProviderApiKeys(compatProviders, {
+    secretRefManagedProviders,
+  });
   const nextContents = `${JSON.stringify({ providers: finalProviders }, null, 2)}\n`;
 
   if (params.existingRaw === nextContents) {

--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -141,6 +141,32 @@ function stripPlaintextProviderApiKeys(
   return mutated ? nextProviders : providers;
 }
 
+function planExistingCatalogOnlyCredentialCleanup(params: {
+  existingRaw: string;
+  existingParsed: unknown;
+}): ModelsJsonPlan | undefined {
+  const existing = params.existingParsed;
+  if (!isRecord(existing) || !isRecord(existing.providers)) {
+    return undefined;
+  }
+
+  const promptSafeProviders = stripPlaintextProviderApiKeys(
+    existing.providers as Record<string, ProviderConfig>,
+  );
+  if (promptSafeProviders === existing.providers) {
+    return undefined;
+  }
+
+  const nextContents = `${JSON.stringify({ providers: promptSafeProviders }, null, 2)}\n`;
+  if (params.existingRaw === nextContents) {
+    return { action: "noop" };
+  }
+  return {
+    action: "write",
+    contents: nextContents,
+  };
+}
+
 export async function planOpenClawModelsJsonWithDeps(
   params: {
     cfg: OpenClawConfig;
@@ -183,7 +209,12 @@ export async function planOpenClawModelsJsonWithDeps(
   );
 
   if (Object.keys(providers).length === 0) {
-    return { action: "skip" };
+    return (
+      planExistingCatalogOnlyCredentialCleanup({
+        existingRaw: params.existingRaw,
+        existingParsed: params.existingParsed,
+      }) ?? { action: "skip" }
+    );
   }
 
   const mode = cfg.models?.mode ?? "merge";

--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -219,6 +219,7 @@ export async function planOpenClawModelsJsonWithDeps(
 
   const mode = cfg.models?.mode ?? "merge";
   const secretRefManagedProviders = new Set<string>();
+  const manifestPlugins = params.pluginMetadataSnapshot?.manifestRegistry.plugins;
   const normalizedProviders =
     normalizeProviders({
       providers,
@@ -228,6 +229,7 @@ export async function planOpenClawModelsJsonWithDeps(
       sourceProviders: params.sourceConfigForSecrets?.models?.providers,
       sourceSecretDefaults: params.sourceConfigForSecrets?.secrets?.defaults,
       secretRefManagedProviders,
+      manifestPlugins,
     }) ?? providers;
   const promptSafeProviders = stripPlaintextProviderApiKeys(normalizedProviders);
   const mergedProviders = resolveProvidersForMode({
@@ -237,7 +239,9 @@ export async function planOpenClawModelsJsonWithDeps(
     secretRefManagedProviders,
   });
   const normalizedMergedProviders =
-    normalizeProviderCatalogModelsForConfig(mergedProviders) ?? mergedProviders;
+    normalizeProviderCatalogModelsForConfig(mergedProviders, {
+      manifestPlugins,
+    }) ?? mergedProviders;
   const secretEnforcedProviders =
     enforceSourceManagedProviderSecrets({
       providers: normalizedMergedProviders,

--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -200,7 +200,8 @@ export async function planOpenClawModelsJsonWithDeps(
       sourceSecretDefaults: params.sourceConfigForSecrets?.secrets?.defaults,
       secretRefManagedProviders,
     }) ?? normalizedMergedProviders;
-  const finalProviders = applyNativeStreamingUsageCompat(secretEnforcedProviders);
+  const compatProviders = applyNativeStreamingUsageCompat(secretEnforcedProviders);
+  const finalProviders = stripPlaintextProviderApiKeys(compatProviders);
   const nextContents = `${JSON.stringify({ providers: finalProviders }, null, 2)}\n`;
 
   if (params.existingRaw === nextContents) {

--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import { isRecord } from "../utils.js";
+import { isNonSecretApiKeyMarker } from "./model-auth-markers.js";
 import {
   mergeProviders,
   mergeWithExistingProviderSecrets,
@@ -105,6 +106,27 @@ function resolveProvidersForMode(params: {
   });
 }
 
+function stripPlaintextProviderApiKeys(
+  providers: Record<string, ProviderConfig>,
+): Record<string, ProviderConfig> {
+  let mutated = false;
+  const nextProviders: Record<string, ProviderConfig> = {};
+  for (const [providerKey, provider] of Object.entries(providers)) {
+    if (!isRecord(provider) || provider.apiKey === undefined) {
+      nextProviders[providerKey] = provider;
+      continue;
+    }
+    if (typeof provider.apiKey === "string" && isNonSecretApiKeyMarker(provider.apiKey)) {
+      nextProviders[providerKey] = provider;
+      continue;
+    }
+    mutated = true;
+    const { apiKey: _apiKey, ...providerWithoutApiKey } = provider as Record<string, unknown>;
+    nextProviders[providerKey] = providerWithoutApiKey as ProviderConfig;
+  }
+  return mutated ? nextProviders : providers;
+}
+
 export async function planOpenClawModelsJsonWithDeps(
   params: {
     cfg: OpenClawConfig;
@@ -177,7 +199,9 @@ export async function planOpenClawModelsJsonWithDeps(
       sourceSecretDefaults: params.sourceConfigForSecrets?.secrets?.defaults,
       secretRefManagedProviders,
     }) ?? normalizedMergedProviders;
-  const finalProviders = applyNativeStreamingUsageCompat(secretEnforcedProviders);
+  const finalProviders = stripPlaintextProviderApiKeys(
+    applyNativeStreamingUsageCompat(secretEnforcedProviders),
+  );
   const nextContents = `${JSON.stringify({ providers: finalProviders }, null, 2)}\n`;
 
   if (params.existingRaw === nextContents) {

--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -184,10 +184,11 @@ export async function planOpenClawModelsJsonWithDeps(
       sourceSecretDefaults: params.sourceConfigForSecrets?.secrets?.defaults,
       secretRefManagedProviders,
     }) ?? providers;
+  const promptSafeProviders = stripPlaintextProviderApiKeys(normalizedProviders);
   const mergedProviders = resolveProvidersForMode({
     mode,
     existingParsed: params.existingParsed,
-    providers: normalizedProviders,
+    providers: promptSafeProviders,
     secretRefManagedProviders,
   });
   const normalizedMergedProviders =
@@ -199,9 +200,7 @@ export async function planOpenClawModelsJsonWithDeps(
       sourceSecretDefaults: params.sourceConfigForSecrets?.secrets?.defaults,
       secretRefManagedProviders,
     }) ?? normalizedMergedProviders;
-  const finalProviders = stripPlaintextProviderApiKeys(
-    applyNativeStreamingUsageCompat(secretEnforcedProviders),
-  );
+  const finalProviders = applyNativeStreamingUsageCompat(secretEnforcedProviders);
   const nextContents = `${JSON.stringify({ providers: finalProviders }, null, 2)}\n`;
 
   if (params.existingRaw === nextContents) {

--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -1,7 +1,8 @@
+import { getProviders } from "@earendil-works/pi-ai";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import { isRecord } from "../utils.js";
-import { isNonSecretApiKeyMarker } from "./model-auth-markers.js";
+import { NON_ENV_SECRETREF_MARKER, isNonSecretApiKeyMarker } from "./model-auth-markers.js";
 import {
   mergeProviders,
   mergeWithExistingProviderSecrets,
@@ -17,6 +18,8 @@ import {
 } from "./models-config.providers.js";
 
 type ModelsConfig = NonNullable<OpenClawConfig["models"]>;
+const PI_BUILT_IN_PROVIDER_IDS = new Set<string>(getProviders());
+
 export type ResolveImplicitProvidersForModelsJson = (params: {
   agentDir: string;
   config: OpenClawConfig;
@@ -121,6 +124,17 @@ function stripPlaintextProviderApiKeys(
       continue;
     }
     mutated = true;
+    if (
+      !PI_BUILT_IN_PROVIDER_IDS.has(providerKey) &&
+      Array.isArray(provider.models) &&
+      provider.models.length > 0
+    ) {
+      nextProviders[providerKey] = {
+        ...provider,
+        apiKey: NON_ENV_SECRETREF_MARKER,
+      } as ProviderConfig;
+      continue;
+    }
     const { apiKey: _apiKey, ...providerWithoutApiKey } = provider as Record<string, unknown>;
     nextProviders[providerKey] = providerWithoutApiKey as ProviderConfig;
   }

--- a/src/agents/models-config.providers.normalize.ts
+++ b/src/agents/models-config.providers.normalize.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
 import { ensureAuthProfileStore } from "./auth-profiles/store.js";
 import { normalizeConfiguredProviderCatalogModelId } from "./model-ref-shared.js";
 import {
@@ -19,6 +20,9 @@ type ModelsConfig = NonNullable<OpenClawConfig["models"]>;
 type ProviderModelConfig = NonNullable<
   NonNullable<ModelsConfig["providers"]>[string]["models"]
 >[number];
+type ProviderModelNormalizationOptions = {
+  manifestPlugins?: readonly Pick<PluginManifestRecord, "modelIdNormalization">[];
+};
 
 function getProviderModelId(model: ProviderModelConfig): string | undefined {
   return typeof model.id === "string" && model.id.trim() ? model.id : undefined;
@@ -45,6 +49,7 @@ function mergeNormalizedProviderModel(
 function normalizeProviderModelsForConfig(
   providerKey: string,
   provider: ProviderConfig,
+  options: ProviderModelNormalizationOptions = {},
 ): { provider: ProviderConfig; mutated: boolean } {
   if (!Array.isArray(provider.models) || provider.models.length === 0) {
     return { provider, mutated: false };
@@ -56,7 +61,9 @@ function normalizeProviderModelsForConfig(
   for (const model of provider.models) {
     const rawId = getProviderModelId(model);
     const normalizedId = rawId
-      ? normalizeConfiguredProviderCatalogModelId(providerKey, rawId)
+      ? normalizeConfiguredProviderCatalogModelId(providerKey, rawId, {
+          manifestPlugins: options.manifestPlugins,
+        })
       : rawId;
     const normalizedModel =
       normalizedId && normalizedId !== rawId ? { ...model, id: normalizedId } : model;
@@ -86,6 +93,7 @@ function normalizeProviderModelsForConfig(
 
 export function normalizeProviderCatalogModelsForConfig(
   providers: ModelsConfig["providers"],
+  options: ProviderModelNormalizationOptions = {},
 ): ModelsConfig["providers"] {
   if (!providers) {
     return providers;
@@ -94,7 +102,7 @@ export function normalizeProviderCatalogModelsForConfig(
   let mutated = false;
   const next: Record<string, ProviderConfig> = {};
   for (const [providerKey, provider] of Object.entries(providers)) {
-    const normalized = normalizeProviderModelsForConfig(providerKey, provider);
+    const normalized = normalizeProviderModelsForConfig(providerKey, provider, options);
     if (normalized.mutated) {
       mutated = true;
     }
@@ -112,6 +120,7 @@ export function normalizeProviders(params: {
   sourceProviders?: ModelsConfig["providers"];
   sourceSecretDefaults?: SecretDefaults;
   secretRefManagedProviders?: Set<string>;
+  manifestPlugins?: ProviderModelNormalizationOptions["manifestPlugins"];
 }): ModelsConfig["providers"] {
   const { providers } = params;
   if (!providers) {
@@ -213,6 +222,9 @@ export function normalizeProviders(params: {
     const providerWithNormalizedModels = normalizeProviderModelsForConfig(
       normalizedKey,
       normalizedProvider,
+      {
+        manifestPlugins: params.manifestPlugins,
+      },
     );
     if (providerWithNormalizedModels.mutated) {
       mutated = true;

--- a/src/agents/models-config.runtime-source-snapshot.test.ts
+++ b/src/agents/models-config.runtime-source-snapshot.test.ts
@@ -25,6 +25,7 @@ vi.mock("../plugins/provider-runtime.js", () => ({
   applyProviderConfigDefaultsWithPlugin: (config: OpenClawConfig) => config,
   applyProviderNativeStreamingUsageCompatWithPlugin: () => undefined,
   normalizeProviderConfigWithPlugin: () => undefined,
+  resolveExternalAuthProfilesWithPlugins: () => [],
   resolveProviderConfigApiKeyWithPlugin: () => undefined,
   resolveProviderSyntheticAuthWithPlugin: () => undefined,
 }));

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -11,13 +11,21 @@ import { privateFileStore } from "../infra/private-file-store.js";
 import { getCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
 import { resolveInstalledManifestRegistryIndexFingerprint } from "../plugins/manifest-registry-installed.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
+import { isRecord } from "../utils.js";
 import {
   resolveAgentWorkspaceDir,
   resolveDefaultAgentDir,
   resolveDefaultAgentId,
 } from "./agent-scope.js";
+import {
+  ensureAuthProfileStore,
+  listProfilesForProvider,
+  upsertAuthProfileWithLock,
+} from "./auth-profiles.js";
+import { isNonSecretApiKeyMarker } from "./model-auth-markers.js";
 import { MODELS_JSON_STATE } from "./models-config-state.js";
 import { planOpenClawModelsJson } from "./models-config.plan.js";
+import { findNormalizedProviderValue, normalizeProviderId } from "./provider-id.js";
 import { stableStringify } from "./stable-stringify.js";
 
 export { resetModelsJsonReadyCacheForTest } from "./models-config-state.js";
@@ -90,6 +98,97 @@ async function readExistingModelsFile(pathname: string): Promise<{
       raw: "",
       parsed: null,
     };
+  }
+}
+
+function resolveProviderCatalog(value: unknown): Record<string, unknown> {
+  if (!isRecord(value) || !isRecord(value.providers)) {
+    return {};
+  }
+  return value.providers;
+}
+
+function resolvePlaintextProviderApiKey(provider: unknown): string | undefined {
+  if (!isRecord(provider) || typeof provider.apiKey !== "string") {
+    return undefined;
+  }
+  const apiKey = provider.apiKey.trim();
+  if (!apiKey || isNonSecretApiKeyMarker(apiKey)) {
+    return undefined;
+  }
+  return apiKey;
+}
+
+function hasConfiguredProviderApiKey(cfg: OpenClawConfig, providerKey: string): boolean {
+  const provider = findNormalizedProviderValue(cfg.models?.providers, providerKey);
+  return isRecord(provider) && provider.apiKey !== undefined;
+}
+
+function resolveMigratedModelsJsonProfileId(providerKey: string): string {
+  const normalized = normalizeProviderId(providerKey)
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return `${normalized || "provider"}:models-json`;
+}
+
+async function migrateExistingModelsJsonOnlyProviderApiKeys(params: {
+  cfg: OpenClawConfig;
+  agentDir: string;
+  existingParsed: unknown;
+  nextContents: string;
+}): Promise<void> {
+  const existingProviders = resolveProviderCatalog(params.existingParsed);
+  if (Object.keys(existingProviders).length === 0) {
+    return;
+  }
+
+  let nextProviders: Record<string, unknown>;
+  try {
+    nextProviders = resolveProviderCatalog(JSON.parse(params.nextContents) as unknown);
+  } catch {
+    return;
+  }
+
+  const candidates = Object.entries(existingProviders).flatMap(
+    ([providerKey, existingProvider]) => {
+      const existingApiKey = resolvePlaintextProviderApiKey(existingProvider);
+      if (!existingApiKey) {
+        return [];
+      }
+      if (hasConfiguredProviderApiKey(params.cfg, providerKey)) {
+        return [];
+      }
+      if (resolvePlaintextProviderApiKey(nextProviders[providerKey])) {
+        return [];
+      }
+      return [{ providerKey, existingApiKey }];
+    },
+  );
+
+  if (candidates.length === 0) {
+    return;
+  }
+
+  const store = ensureAuthProfileStore(params.agentDir, { allowKeychainPrompt: false });
+  for (const { providerKey, existingApiKey } of candidates) {
+    if (listProfilesForProvider(store, providerKey).length > 0) {
+      continue;
+    }
+
+    const profileId = resolveMigratedModelsJsonProfileId(providerKey);
+    const credential = {
+      type: "api_key",
+      provider: providerKey,
+      key: existingApiKey,
+      copyToAgents: false,
+      displayName: "Migrated from models.json",
+    } as const;
+    await upsertAuthProfileWithLock({
+      agentDir: params.agentDir,
+      profileId,
+      credential,
+    });
+    store.profiles[profileId] = credential;
   }
 }
 
@@ -237,6 +336,12 @@ export async function ensureOpenClawModelsJson(
     }
 
     await fs.mkdir(agentDir, { recursive: true, mode: 0o700 });
+    await migrateExistingModelsJsonOnlyProviderApiKeys({
+      cfg,
+      agentDir,
+      existingParsed: existingModelsFile.parsed,
+      nextContents: plan.contents,
+    });
     await writeModelsFileAtomicForModelsJson(targetPath, plan.contents);
     await ensureModelsFileModeForModelsJson(targetPath);
     return { fingerprint, result: { agentDir, wrote: true } };

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -136,6 +136,35 @@ function resolveProviderCatalog(value: unknown): Record<string, unknown> {
   return value.providers;
 }
 
+function stripBlankProviderApiKeysFromModelsJsonContents(contents: string): string {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(contents) as unknown;
+  } catch {
+    return contents;
+  }
+  if (!isRecord(parsed) || !isRecord(parsed.providers)) {
+    return contents;
+  }
+
+  let mutated = false;
+  const nextProviders: Record<string, unknown> = {};
+  for (const [providerKey, provider] of Object.entries(parsed.providers)) {
+    if (isRecord(provider) && typeof provider.apiKey === "string" && !provider.apiKey.trim()) {
+      const { apiKey: _apiKey, ...providerWithoutBlankApiKey } = provider;
+      nextProviders[providerKey] = providerWithoutBlankApiKey;
+      mutated = true;
+      continue;
+    }
+    nextProviders[providerKey] = provider;
+  }
+
+  if (!mutated) {
+    return contents;
+  }
+  return `${JSON.stringify({ ...parsed, providers: nextProviders }, null, 2)}\n`;
+}
+
 function resolveMigratableProviderApiKey(provider: unknown): string | undefined {
   if (!isRecord(provider) || typeof provider.apiKey !== "string") {
     return undefined;
@@ -344,20 +373,19 @@ export async function ensureOpenClawModelsJson(
 ): Promise<{ agentDir: string; wrote: boolean }> {
   const resolved = resolveModelsConfigInput(config);
   const cfg = resolved.config;
+  const explicitAgentDir = agentDirOverride?.trim() || undefined;
   const workspaceDir =
     options.workspaceDir ??
-    (agentDirOverride?.trim()
-      ? undefined
-      : resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg)));
+    (explicitAgentDir ? undefined : resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg)));
   const pluginMetadataSnapshot =
     options.pluginMetadataSnapshot ??
     resolvePluginMetadataSnapshot({
       config: cfg,
       env: createConfigRuntimeEnv(cfg),
       ...(workspaceDir ? { workspaceDir } : {}),
-      allowWorkspaceScopedCurrent: workspaceDir === undefined,
+      allowWorkspaceScopedCurrent: workspaceDir === undefined && explicitAgentDir === undefined,
     });
-  const agentDir = agentDirOverride?.trim() ? agentDirOverride.trim() : resolveDefaultAgentDir(cfg);
+  const agentDir = explicitAgentDir ?? resolveDefaultAgentDir(cfg);
   const targetPath = path.join(agentDir, "models.json");
   const fingerprint = await buildModelsJsonFingerprint({
     config: cfg,
@@ -417,15 +445,21 @@ export async function ensureOpenClawModelsJson(
       return { fingerprint, result: { agentDir, wrote: false } };
     }
 
+    const writeContents = stripBlankProviderApiKeysFromModelsJsonContents(plan.contents);
+    if (writeContents === existingModelsFile.raw) {
+      await ensureModelsFileModeForModelsJson(targetPath);
+      return { fingerprint, result: { agentDir, wrote: false } };
+    }
+
     await fs.mkdir(agentDir, { recursive: true, mode: 0o700 });
     await migrateExistingModelsJsonOnlyProviderApiKeys({
       cfg,
       agentDir,
       env,
       existingParsed: existingModelsFile.parsed,
-      nextContents: plan.contents,
+      nextContents: writeContents,
     });
-    await writeModelsFileAtomicForModelsJson(targetPath, plan.contents);
+    await writeModelsFileAtomicForModelsJson(targetPath, writeContents);
     await ensureModelsFileModeForModelsJson(targetPath);
     return { fingerprint, result: { agentDir, wrote: true } };
   });

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -183,11 +183,16 @@ async function migrateExistingModelsJsonOnlyProviderApiKeys(params: {
       copyToAgents: false,
       displayName: "Migrated from models.json",
     } as const;
-    await upsertAuthProfileWithLock({
+    const updatedStore = await upsertAuthProfileWithLock({
       agentDir: params.agentDir,
       profileId,
       credential,
     });
+    if (updatedStore === null) {
+      throw new Error(
+        `Failed to migrate existing models.json provider apiKey for ${providerKey}; keeping existing models.json unchanged`,
+      );
+    }
     store.profiles[profileId] = credential;
   }
 }

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -7,11 +7,13 @@ import {
   type OpenClawConfig,
 } from "../config/config.js";
 import { createConfigRuntimeEnv } from "../config/env-vars.js";
+import { coerceSecretRef } from "../config/types.secrets.js";
 import { privateFileStore } from "../infra/private-file-store.js";
 import { getCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
 import { resolveInstalledManifestRegistryIndexFingerprint } from "../plugins/manifest-registry-installed.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import { isRecord } from "../utils.js";
+import { normalizeOptionalSecretInput } from "../utils/normalize-secret-input.js";
 import {
   resolveAgentWorkspaceDir,
   resolveDefaultAgentDir,
@@ -121,7 +123,13 @@ function resolvePlaintextProviderApiKey(provider: unknown): string | undefined {
 
 function hasConfiguredProviderApiKey(cfg: OpenClawConfig, providerKey: string): boolean {
   const provider = findNormalizedProviderValue(cfg.models?.providers, providerKey);
-  return isRecord(provider) && provider.apiKey !== undefined;
+  if (!isRecord(provider)) {
+    return false;
+  }
+  return (
+    normalizeOptionalSecretInput(provider.apiKey) !== undefined ||
+    coerceSecretRef(provider.apiKey) !== null
+  );
 }
 
 function resolveMigratedModelsJsonProfileId(providerKey: string): string {

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -13,11 +13,11 @@ import {
   isValidEnvSecretRefId,
 } from "../config/types.secrets.js";
 import { privateFileStore } from "../infra/private-file-store.js";
-import { getCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
 import { resolveInstalledManifestRegistryIndexFingerprint } from "../plugins/manifest-registry-installed.js";
-import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
-import { isRecord } from "../utils.js";
-import { normalizeOptionalSecretInput } from "../utils/normalize-secret-input.js";
+import {
+  resolvePluginMetadataSnapshot,
+  type PluginMetadataSnapshot,
+} from "../plugins/plugin-metadata-snapshot.js";
 import {
   resolveAgentWorkspaceDir,
   resolveDefaultAgentDir,
@@ -109,6 +109,26 @@ async function readExistingModelsFile(pathname: string): Promise<{
   }
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function normalizeOptionalSecretValue(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const collapsed = value.replace(/[\r\n\u2028\u2029]+/g, "");
+  let latin1Only = "";
+  for (const char of collapsed) {
+    const codePoint = char.codePointAt(0);
+    if (typeof codePoint === "number" && codePoint <= 0xff) {
+      latin1Only += char;
+    }
+  }
+  const normalized = latin1Only.trim();
+  return normalized ? normalized : undefined;
+}
+
 function resolveProviderCatalog(value: unknown): Record<string, unknown> {
   if (!isRecord(value) || !isRecord(value.providers)) {
     return {};
@@ -139,7 +159,7 @@ function hasConfiguredProviderApiKey(cfg: OpenClawConfig, providerKey: string): 
     return false;
   }
   return (
-    normalizeOptionalSecretInput(provider.apiKey) !== undefined ||
+    normalizeOptionalSecretValue(provider.apiKey) !== undefined ||
     coerceSecretRef(provider.apiKey) !== null
   );
 }
@@ -165,7 +185,7 @@ function resolveMigratedModelsJsonApiKeyCredential(
   if (
     isKnownEnvApiKeyMarker(existingApiKey) ||
     (isValidEnvSecretRefId(existingApiKey) &&
-      normalizeOptionalSecretInput(env[existingApiKey]) !== undefined)
+      normalizeOptionalSecretValue(env[existingApiKey]) !== undefined)
   ) {
     return {
       ...base,
@@ -331,9 +351,11 @@ export async function ensureOpenClawModelsJson(
       : resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg)));
   const pluginMetadataSnapshot =
     options.pluginMetadataSnapshot ??
-    getCurrentPluginMetadataSnapshot({
+    resolvePluginMetadataSnapshot({
       config: cfg,
+      env: createConfigRuntimeEnv(cfg),
       ...(workspaceDir ? { workspaceDir } : {}),
+      allowWorkspaceScopedCurrent: workspaceDir === undefined,
     });
   const agentDir = agentDirOverride?.trim() ? agentDirOverride.trim() : resolveDefaultAgentDir(cfg);
   const targetPath = path.join(agentDir, "models.json");

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -25,6 +25,7 @@ import {
 } from "./agent-scope.js";
 import {
   ensureAuthProfileStore,
+  loadAuthProfileStoreForLocalAgent,
   listProfilesForProvider,
   type AuthProfileCredential,
   upsertAuthProfileWithLock,
@@ -209,8 +210,12 @@ async function migrateExistingModelsJsonOnlyProviderApiKeys(params: {
   }
 
   const store = ensureAuthProfileStore(params.agentDir, { allowKeychainPrompt: false });
+  const localStore = loadAuthProfileStoreForLocalAgent(params.agentDir, {
+    allowKeychainPrompt: false,
+    resolveLegacyOAuthSidecars: false,
+  });
   for (const { providerKey, existingApiKey } of candidates) {
-    if (listProfilesForProvider(store, providerKey).length > 0) {
+    if (listProfilesForProvider(localStore, providerKey).length > 0) {
       continue;
     }
 
@@ -227,6 +232,7 @@ async function migrateExistingModelsJsonOnlyProviderApiKeys(params: {
       );
     }
     store.profiles[profileId] = credential;
+    localStore.profiles[profileId] = credential;
   }
 }
 

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -30,7 +30,7 @@ import {
   type AuthProfileCredential,
   upsertAuthProfileWithLock,
 } from "./auth-profiles.js";
-import { isNonSecretApiKeyMarker } from "./model-auth-markers.js";
+import { isKnownEnvApiKeyMarker, isNonSecretApiKeyMarker } from "./model-auth-markers.js";
 import { MODELS_JSON_STATE } from "./models-config-state.js";
 import { planOpenClawModelsJson } from "./models-config.plan.js";
 import { findNormalizedProviderValue, normalizeProviderId } from "./provider-id.js";
@@ -116,12 +116,18 @@ function resolveProviderCatalog(value: unknown): Record<string, unknown> {
   return value.providers;
 }
 
-function resolvePlaintextProviderApiKey(provider: unknown): string | undefined {
+function resolveMigratableProviderApiKey(provider: unknown): string | undefined {
   if (!isRecord(provider) || typeof provider.apiKey !== "string") {
     return undefined;
   }
   const apiKey = provider.apiKey.trim();
-  if (!apiKey || isNonSecretApiKeyMarker(apiKey)) {
+  if (!apiKey) {
+    return undefined;
+  }
+  if (isKnownEnvApiKeyMarker(apiKey)) {
+    return apiKey;
+  }
+  if (isNonSecretApiKeyMarker(apiKey, { includeEnvVarName: false })) {
     return undefined;
   }
   return apiKey;
@@ -148,6 +154,7 @@ function resolveMigratedModelsJsonProfileId(providerKey: string): string {
 function resolveMigratedModelsJsonApiKeyCredential(
   providerKey: string,
   existingApiKey: string,
+  env: NodeJS.ProcessEnv,
 ): AuthProfileCredential {
   const base = {
     type: "api_key",
@@ -155,7 +162,11 @@ function resolveMigratedModelsJsonApiKeyCredential(
     copyToAgents: false,
     displayName: "Migrated from models.json",
   } as const;
-  if (isValidEnvSecretRefId(existingApiKey)) {
+  if (
+    isKnownEnvApiKeyMarker(existingApiKey) ||
+    (isValidEnvSecretRefId(existingApiKey) &&
+      normalizeOptionalSecretInput(env[existingApiKey]) !== undefined)
+  ) {
     return {
       ...base,
       keyRef: {
@@ -174,6 +185,7 @@ function resolveMigratedModelsJsonApiKeyCredential(
 async function migrateExistingModelsJsonOnlyProviderApiKeys(params: {
   cfg: OpenClawConfig;
   agentDir: string;
+  env: NodeJS.ProcessEnv;
   existingParsed: unknown;
   nextContents: string;
 }): Promise<void> {
@@ -191,14 +203,14 @@ async function migrateExistingModelsJsonOnlyProviderApiKeys(params: {
 
   const candidates = Object.entries(existingProviders).flatMap(
     ([providerKey, existingProvider]) => {
-      const existingApiKey = resolvePlaintextProviderApiKey(existingProvider);
+      const existingApiKey = resolveMigratableProviderApiKey(existingProvider);
       if (!existingApiKey) {
         return [];
       }
       if (hasConfiguredProviderApiKey(params.cfg, providerKey)) {
         return [];
       }
-      if (resolvePlaintextProviderApiKey(nextProviders[providerKey])) {
+      if (resolveMigratableProviderApiKey(nextProviders[providerKey])) {
         return [];
       }
       return [{ providerKey, existingApiKey }];
@@ -220,7 +232,11 @@ async function migrateExistingModelsJsonOnlyProviderApiKeys(params: {
     }
 
     const profileId = resolveMigratedModelsJsonProfileId(providerKey);
-    const credential = resolveMigratedModelsJsonApiKeyCredential(providerKey, existingApiKey);
+    const credential = resolveMigratedModelsJsonApiKeyCredential(
+      providerKey,
+      existingApiKey,
+      params.env,
+    );
     const updatedStore = await upsertAuthProfileWithLock({
       agentDir: params.agentDir,
       profileId,
@@ -383,6 +399,7 @@ export async function ensureOpenClawModelsJson(
     await migrateExistingModelsJsonOnlyProviderApiKeys({
       cfg,
       agentDir,
+      env,
       existingParsed: existingModelsFile.parsed,
       nextContents: plan.contents,
     });

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -7,7 +7,11 @@ import {
   type OpenClawConfig,
 } from "../config/config.js";
 import { createConfigRuntimeEnv } from "../config/env-vars.js";
-import { coerceSecretRef } from "../config/types.secrets.js";
+import {
+  DEFAULT_SECRET_PROVIDER_ALIAS,
+  coerceSecretRef,
+  isValidEnvSecretRefId,
+} from "../config/types.secrets.js";
 import { privateFileStore } from "../infra/private-file-store.js";
 import { getCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
 import { resolveInstalledManifestRegistryIndexFingerprint } from "../plugins/manifest-registry-installed.js";
@@ -22,6 +26,7 @@ import {
 import {
   ensureAuthProfileStore,
   listProfilesForProvider,
+  type AuthProfileCredential,
   upsertAuthProfileWithLock,
 } from "./auth-profiles.js";
 import { isNonSecretApiKeyMarker } from "./model-auth-markers.js";
@@ -139,6 +144,32 @@ function resolveMigratedModelsJsonProfileId(providerKey: string): string {
   return `${normalized || "provider"}:models-json`;
 }
 
+function resolveMigratedModelsJsonApiKeyCredential(
+  providerKey: string,
+  existingApiKey: string,
+): AuthProfileCredential {
+  const base = {
+    type: "api_key",
+    provider: providerKey,
+    copyToAgents: false,
+    displayName: "Migrated from models.json",
+  } as const;
+  if (isValidEnvSecretRefId(existingApiKey)) {
+    return {
+      ...base,
+      keyRef: {
+        source: "env",
+        provider: DEFAULT_SECRET_PROVIDER_ALIAS,
+        id: existingApiKey,
+      },
+    };
+  }
+  return {
+    ...base,
+    key: existingApiKey,
+  };
+}
+
 async function migrateExistingModelsJsonOnlyProviderApiKeys(params: {
   cfg: OpenClawConfig;
   agentDir: string;
@@ -184,13 +215,7 @@ async function migrateExistingModelsJsonOnlyProviderApiKeys(params: {
     }
 
     const profileId = resolveMigratedModelsJsonProfileId(providerKey);
-    const credential = {
-      type: "api_key",
-      provider: providerKey,
-      key: existingApiKey,
-      copyToAgents: false,
-      displayName: "Migrated from models.json",
-    } as const;
+    const credential = resolveMigratedModelsJsonApiKeyCredential(providerKey, existingApiKey);
     const updatedStore = await upsertAuthProfileWithLock({
       agentDir: params.agentDir,
       profileId,

--- a/src/agents/models-config.write-serialization.test.ts
+++ b/src/agents/models-config.write-serialization.test.ts
@@ -14,12 +14,11 @@ import { readGeneratedModelsJson } from "./models-config.test-utils.js";
 const planOpenClawModelsJsonMock = vi.fn();
 const writePrivateStoreTextWriteMock = vi.fn();
 const upsertAuthProfileWithLockMock = vi.fn();
+type UpsertAuthProfileWithLock = typeof import("./auth-profiles.js").upsertAuthProfileWithLock;
 let actualPrivateFileStore:
   | typeof import("../infra/private-file-store.js").privateFileStore
   | undefined;
-let actualUpsertAuthProfileWithLock:
-  | typeof import("./auth-profiles.js").upsertAuthProfileWithLock
-  | undefined;
+let actualUpsertAuthProfileWithLock: UpsertAuthProfileWithLock | undefined;
 
 installModelsConfigTestHooks();
 
@@ -158,12 +157,14 @@ beforeEach(() => {
       action: "write",
       contents: `${JSON.stringify({ providers: params.cfg?.models?.providers ?? {} }, null, 2)}\n`,
     }));
-  upsertAuthProfileWithLockMock.mockReset().mockImplementation(async (...args) => {
-    if (!actualUpsertAuthProfileWithLock) {
-      throw new Error("auth profile upsert mock not initialized");
-    }
-    return await actualUpsertAuthProfileWithLock(...args);
-  });
+  upsertAuthProfileWithLockMock
+    .mockReset()
+    .mockImplementation(async (...args: Parameters<UpsertAuthProfileWithLock>) => {
+      if (!actualUpsertAuthProfileWithLock) {
+        throw new Error("auth profile upsert mock not initialized");
+      }
+      return await actualUpsertAuthProfileWithLock(...args);
+    });
 });
 
 describe("models-config write serialization", () => {

--- a/src/agents/models-config.write-serialization.test.ts
+++ b/src/agents/models-config.write-serialization.test.ts
@@ -13,8 +13,12 @@ import { readGeneratedModelsJson } from "./models-config.test-utils.js";
 
 const planOpenClawModelsJsonMock = vi.fn();
 const writePrivateStoreTextWriteMock = vi.fn();
+const upsertAuthProfileWithLockMock = vi.fn();
 let actualPrivateFileStore:
   | typeof import("../infra/private-file-store.js").privateFileStore
+  | undefined;
+let actualUpsertAuthProfileWithLock:
+  | typeof import("./auth-profiles.js").upsertAuthProfileWithLock
   | undefined;
 
 installModelsConfigTestHooks();
@@ -119,6 +123,15 @@ beforeAll(async () => {
       },
     };
   });
+  vi.doMock("./auth-profiles.js", async () => {
+    const actual = await vi.importActual<typeof import("./auth-profiles.js")>("./auth-profiles.js");
+    actualUpsertAuthProfileWithLock = actual.upsertAuthProfileWithLock;
+    return {
+      ...actual,
+      upsertAuthProfileWithLock: (...args: Parameters<typeof actual.upsertAuthProfileWithLock>) =>
+        upsertAuthProfileWithLockMock(...args),
+    };
+  });
   ({ ensureOpenClawModelsJson } = await import("./models-config.js"));
   ({ clearCurrentPluginMetadataSnapshot, setCurrentPluginMetadataSnapshot } =
     await import("../plugins/current-plugin-metadata-snapshot.js"));
@@ -145,6 +158,12 @@ beforeEach(() => {
       action: "write",
       contents: `${JSON.stringify({ providers: params.cfg?.models?.providers ?? {} }, null, 2)}\n`,
     }));
+  upsertAuthProfileWithLockMock.mockReset().mockImplementation(async (...args) => {
+    if (!actualUpsertAuthProfileWithLock) {
+      throw new Error("auth profile upsert mock not initialized");
+    }
+    return await actualUpsertAuthProfileWithLock(...args);
+  });
 });
 
 describe("models-config write serialization", () => {
@@ -250,6 +269,57 @@ describe("models-config write serialization", () => {
         key: "sk-existing-models-json-only",
         copyToAgents: false,
       });
+    });
+  });
+
+  it("keeps existing models.json unchanged when api key migration cannot persist", async () => {
+    await withModelsTempHome(async (home) => {
+      const agentDir = path.join(home, "agent");
+      await fs.mkdir(agentDir, { recursive: true });
+      await fs.writeFile(
+        path.join(agentDir, "models.json"),
+        `${JSON.stringify(
+          {
+            providers: {
+              custom: {
+                baseUrl: "https://custom.example/v1",
+                api: "openai-completions",
+                apiKey: "sk-existing-models-json-only", // pragma: allowlist secret
+                models: [],
+              },
+            },
+          },
+          null,
+          2,
+        )}\n`,
+      );
+      upsertAuthProfileWithLockMock.mockResolvedValueOnce(null);
+
+      await expect(
+        ensureOpenClawModelsJson(
+          {
+            models: {
+              mode: "merge",
+              providers: {
+                custom: {
+                  baseUrl: "https://custom.example/v1",
+                  api: "openai-completions",
+                  models: [],
+                },
+              },
+            },
+          },
+          agentDir,
+        ),
+      ).rejects.toThrow(/Failed to migrate existing models\.json provider apiKey for custom/);
+
+      expect(writePrivateStoreTextWriteMock).not.toHaveBeenCalled();
+      const modelsJson = JSON.parse(
+        await fs.readFile(path.join(agentDir, "models.json"), "utf8"),
+      ) as {
+        providers: Record<string, { apiKey?: string }>;
+      };
+      expect(modelsJson.providers.custom?.apiKey).toBe("sk-existing-models-json-only");
     });
   });
 

--- a/src/agents/models-config.write-serialization.test.ts
+++ b/src/agents/models-config.write-serialization.test.ts
@@ -273,6 +273,67 @@ describe("models-config write serialization", () => {
     });
   });
 
+  it("migrates catalog-only provider api keys when cleaning an existing models.json", async () => {
+    await withModelsTempHome(async (home) => {
+      const agentDir = path.join(home, "agent");
+      await fs.mkdir(agentDir, { recursive: true });
+      await fs.writeFile(
+        path.join(agentDir, "models.json"),
+        `${JSON.stringify(
+          {
+            providers: {
+              custom: {
+                baseUrl: "https://custom.example/v1",
+                api: "openai-completions",
+                apiKey: "sk-existing-catalog-only", // pragma: allowlist secret
+                models: [],
+              },
+            },
+          },
+          null,
+          2,
+        )}\n`,
+      );
+      planOpenClawModelsJsonMock.mockImplementation(async () => ({
+        action: "write",
+        contents: `${JSON.stringify(
+          {
+            providers: {
+              custom: {
+                baseUrl: "https://custom.example/v1",
+                api: "openai-completions",
+                models: [],
+              },
+            },
+          },
+          null,
+          2,
+        )}\n`,
+      }));
+
+      await ensureOpenClawModelsJson({}, agentDir);
+
+      const modelsJson = JSON.parse(
+        await fs.readFile(path.join(agentDir, "models.json"), "utf8"),
+      ) as {
+        providers: Record<string, { apiKey?: string }>;
+      };
+      expect(modelsJson.providers.custom?.apiKey).toBeUndefined();
+
+      const authProfiles = JSON.parse(
+        await fs.readFile(path.join(agentDir, "auth-profiles.json"), "utf8"),
+      ) as {
+        profiles: Record<string, unknown>;
+      };
+      expect(authProfiles.profiles["custom:models-json"]).toMatchObject({
+        type: "api_key",
+        provider: "custom",
+        key: "sk-existing-catalog-only",
+        copyToAgents: false,
+      });
+    });
+  });
+
   it("treats blank configured provider api keys as missing during models.json key migration", async () => {
     await withModelsTempHome(async (home) => {
       const agentDir = path.join(home, "agent");

--- a/src/agents/models-config.write-serialization.test.ts
+++ b/src/agents/models-config.write-serialization.test.ts
@@ -272,6 +272,66 @@ describe("models-config write serialization", () => {
     });
   });
 
+  it("treats blank configured provider api keys as missing during models.json key migration", async () => {
+    await withModelsTempHome(async (home) => {
+      const agentDir = path.join(home, "agent");
+      await fs.mkdir(agentDir, { recursive: true });
+      await fs.writeFile(
+        path.join(agentDir, "models.json"),
+        `${JSON.stringify(
+          {
+            providers: {
+              custom: {
+                baseUrl: "https://custom.example/v1",
+                api: "openai-completions",
+                apiKey: "sk-existing-models-json-only", // pragma: allowlist secret
+                models: [],
+              },
+            },
+          },
+          null,
+          2,
+        )}\n`,
+      );
+
+      await ensureOpenClawModelsJson(
+        {
+          models: {
+            mode: "merge",
+            providers: {
+              custom: {
+                baseUrl: "https://custom.example/v1",
+                api: "openai-completions",
+                apiKey: "  ",
+                models: [],
+              },
+            },
+          },
+        },
+        agentDir,
+      );
+
+      const modelsJson = JSON.parse(
+        await fs.readFile(path.join(agentDir, "models.json"), "utf8"),
+      ) as {
+        providers: Record<string, { apiKey?: string }>;
+      };
+      expect(modelsJson.providers.custom?.apiKey).toBeUndefined();
+
+      const authProfiles = JSON.parse(
+        await fs.readFile(path.join(agentDir, "auth-profiles.json"), "utf8"),
+      ) as {
+        profiles: Record<string, unknown>;
+      };
+      expect(authProfiles.profiles["custom:models-json"]).toMatchObject({
+        type: "api_key",
+        provider: "custom",
+        key: "sk-existing-models-json-only",
+        copyToAgents: false,
+      });
+    });
+  });
+
   it("keeps existing models.json unchanged when api key migration cannot persist", async () => {
     await withModelsTempHome(async (home) => {
       const agentDir = path.join(home, "agent");

--- a/src/agents/models-config.write-serialization.test.ts
+++ b/src/agents/models-config.write-serialization.test.ts
@@ -475,7 +475,16 @@ describe("models-config write serialization", () => {
         )}\n`,
       }));
 
-      await ensureOpenClawModelsJson({}, agentDir);
+      await ensureOpenClawModelsJson(
+        {
+          env: {
+            vars: {
+              LITELLM_KEY: "sk-resolved-from-env",
+            },
+          },
+        },
+        agentDir,
+      );
 
       const modelsJson = JSON.parse(
         await fs.readFile(path.join(agentDir, "models.json"), "utf8"),

--- a/src/agents/models-config.write-serialization.test.ts
+++ b/src/agents/models-config.write-serialization.test.ts
@@ -194,6 +194,65 @@ describe("models-config write serialization", () => {
     });
   });
 
+  it("migrates existing models.json-only provider api keys to auth profiles", async () => {
+    await withModelsTempHome(async (home) => {
+      const agentDir = path.join(home, "agent");
+      await fs.mkdir(agentDir, { recursive: true });
+      await fs.writeFile(
+        path.join(agentDir, "models.json"),
+        `${JSON.stringify(
+          {
+            providers: {
+              custom: {
+                baseUrl: "https://custom.example/v1",
+                api: "openai-completions",
+                apiKey: "sk-existing-models-json-only", // pragma: allowlist secret
+                models: [],
+              },
+            },
+          },
+          null,
+          2,
+        )}\n`,
+      );
+
+      await ensureOpenClawModelsJson(
+        {
+          models: {
+            mode: "merge",
+            providers: {
+              custom: {
+                baseUrl: "https://custom.example/v1",
+                api: "openai-completions",
+                models: [],
+              },
+            },
+          },
+        },
+        agentDir,
+      );
+
+      const modelsJson = JSON.parse(
+        await fs.readFile(path.join(agentDir, "models.json"), "utf8"),
+      ) as {
+        providers: Record<string, { apiKey?: string }>;
+      };
+      expect(modelsJson.providers.custom?.apiKey).toBeUndefined();
+
+      const authProfiles = JSON.parse(
+        await fs.readFile(path.join(agentDir, "auth-profiles.json"), "utf8"),
+      ) as {
+        profiles: Record<string, unknown>;
+      };
+      expect(authProfiles.profiles["custom:models-json"]).toMatchObject({
+        type: "api_key",
+        provider: "custom",
+        key: "sk-existing-models-json-only",
+        copyToAgents: false,
+      });
+    });
+  });
+
   it("does not reuse scoped startup discovery cache for a different provider scope", async () => {
     await withModelsTempHome(async (home) => {
       planOpenClawModelsJsonMock.mockImplementation(async () => ({ action: "skip" }));

--- a/src/agents/models-config.write-serialization.test.ts
+++ b/src/agents/models-config.write-serialization.test.ts
@@ -405,7 +405,16 @@ describe("models-config write serialization", () => {
         )}\n`,
       }));
 
-      await ensureOpenClawModelsJson({}, agentDir);
+      await ensureOpenClawModelsJson(
+        {
+          env: {
+            vars: {
+              LITELLM_KEY: "sk-resolved-from-env",
+            },
+          },
+        },
+        agentDir,
+      );
 
       const modelsJson = JSON.parse(
         await fs.readFile(path.join(agentDir, "models.json"), "utf8"),
@@ -428,7 +437,7 @@ describe("models-config write serialization", () => {
     });
   });
 
-  it("migrates env-name catalog-only provider api keys to env-backed auth profiles", async () => {
+  it("migrates env-present catalog-only provider api keys to env-backed auth profiles", async () => {
     await withModelsTempHome(async (home) => {
       const agentDir = path.join(home, "agent");
       await fs.mkdir(agentDir, { recursive: true });
@@ -497,6 +506,66 @@ describe("models-config write serialization", () => {
         source: "profile",
         profileId: "custom:models-json",
       });
+    });
+  });
+
+  it("preserves env-shaped catalog-only provider api keys without an env signal", async () => {
+    await withModelsTempHome(async (home) => {
+      const agentDir = path.join(home, "agent");
+      await fs.mkdir(agentDir, { recursive: true });
+      await fs.writeFile(
+        path.join(agentDir, "models.json"),
+        `${JSON.stringify(
+          {
+            providers: {
+              custom: {
+                baseUrl: "https://custom.example/v1",
+                api: "openai-completions",
+                apiKey: "ALLCAPS_EXAMPLE",
+                models: [],
+              },
+            },
+          },
+          null,
+          2,
+        )}\n`,
+      );
+      planOpenClawModelsJsonMock.mockImplementation(async () => ({
+        action: "write",
+        contents: `${JSON.stringify(
+          {
+            providers: {
+              custom: {
+                baseUrl: "https://custom.example/v1",
+                api: "openai-completions",
+                models: [],
+              },
+            },
+          },
+          null,
+          2,
+        )}\n`,
+      }));
+
+      await ensureOpenClawModelsJson({}, agentDir);
+
+      const modelsJson = JSON.parse(
+        await fs.readFile(path.join(agentDir, "models.json"), "utf8"),
+      ) as {
+        providers: Record<string, { apiKey?: string }>;
+      };
+      expect(modelsJson.providers.custom?.apiKey).toBeUndefined();
+
+      const authProfiles = JSON.parse(
+        await fs.readFile(path.join(agentDir, "auth-profiles.json"), "utf8"),
+      ) as AuthProfileStore;
+      expect(authProfiles.profiles["custom:models-json"]).toMatchObject({
+        type: "api_key",
+        provider: "custom",
+        key: "ALLCAPS_EXAMPLE",
+        copyToAgents: false,
+      });
+      expect(authProfiles.profiles["custom:models-json"]).not.toHaveProperty("keyRef");
     });
   });
 

--- a/src/agents/models-config.write-serialization.test.ts
+++ b/src/agents/models-config.write-serialization.test.ts
@@ -4,6 +4,7 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveInstalledPluginIndexPolicyHash } from "../plugins/installed-plugin-index-policy.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import { resolveDefaultAgentDir } from "./agent-scope.js";
+import type { AuthProfileStore } from "./auth-profiles/types.js";
 import {
   CUSTOM_PROXY_MODELS_CONFIG,
   installModelsConfigTestHooks,
@@ -25,6 +26,7 @@ installModelsConfigTestHooks();
 let ensureOpenClawModelsJson: typeof import("./models-config.js").ensureOpenClawModelsJson;
 let clearCurrentPluginMetadataSnapshot: typeof import("../plugins/current-plugin-metadata-snapshot.js").clearCurrentPluginMetadataSnapshot;
 let setCurrentPluginMetadataSnapshot: typeof import("../plugins/current-plugin-metadata-snapshot.js").setCurrentPluginMetadataSnapshot;
+let createProviderAuthResolver: typeof import("./models-config.providers.secrets.js").createProviderAuthResolver;
 
 function createPluginMetadataSnapshot(workspaceDir: string): PluginMetadataSnapshot {
   const policyHash = resolveInstalledPluginIndexPolicyHash({});
@@ -132,6 +134,7 @@ beforeAll(async () => {
     };
   });
   ({ ensureOpenClawModelsJson } = await import("./models-config.js"));
+  ({ createProviderAuthResolver } = await import("./models-config.providers.secrets.js"));
   ({ clearCurrentPluginMetadataSnapshot, setCurrentPluginMetadataSnapshot } =
     await import("../plugins/current-plugin-metadata-snapshot.js"));
 });
@@ -330,6 +333,78 @@ describe("models-config write serialization", () => {
         provider: "custom",
         key: "sk-existing-catalog-only",
         copyToAgents: false,
+      });
+    });
+  });
+
+  it("migrates env-name catalog-only provider api keys to env-backed auth profiles", async () => {
+    await withModelsTempHome(async (home) => {
+      const agentDir = path.join(home, "agent");
+      await fs.mkdir(agentDir, { recursive: true });
+      await fs.writeFile(
+        path.join(agentDir, "models.json"),
+        `${JSON.stringify(
+          {
+            providers: {
+              custom: {
+                baseUrl: "https://custom.example/v1",
+                api: "openai-completions",
+                apiKey: "LITELLM_KEY",
+                models: [],
+              },
+            },
+          },
+          null,
+          2,
+        )}\n`,
+      );
+      planOpenClawModelsJsonMock.mockImplementation(async () => ({
+        action: "write",
+        contents: `${JSON.stringify(
+          {
+            providers: {
+              custom: {
+                baseUrl: "https://custom.example/v1",
+                api: "openai-completions",
+                models: [],
+              },
+            },
+          },
+          null,
+          2,
+        )}\n`,
+      }));
+
+      await ensureOpenClawModelsJson({}, agentDir);
+
+      const modelsJson = JSON.parse(
+        await fs.readFile(path.join(agentDir, "models.json"), "utf8"),
+      ) as {
+        providers: Record<string, { apiKey?: string }>;
+      };
+      expect(modelsJson.providers.custom?.apiKey).toBeUndefined();
+
+      const authProfiles = JSON.parse(
+        await fs.readFile(path.join(agentDir, "auth-profiles.json"), "utf8"),
+      ) as AuthProfileStore;
+      expect(authProfiles.profiles["custom:models-json"]).toMatchObject({
+        type: "api_key",
+        provider: "custom",
+        keyRef: { source: "env", provider: "default", id: "LITELLM_KEY" },
+        copyToAgents: false,
+      });
+      expect(authProfiles.profiles["custom:models-json"]).not.toHaveProperty("key");
+
+      const auth = createProviderAuthResolver(
+        { LITELLM_KEY: "sk-resolved-from-env" } as NodeJS.ProcessEnv,
+        authProfiles,
+      )("custom");
+      expect(auth).toMatchObject({
+        apiKey: "LITELLM_KEY",
+        discoveryApiKey: "sk-resolved-from-env",
+        mode: "api_key",
+        source: "profile",
+        profileId: "custom:models-json",
       });
     });
   });

--- a/src/agents/models-config.write-serialization.test.ts
+++ b/src/agents/models-config.write-serialization.test.ts
@@ -24,6 +24,7 @@ let actualUpsertAuthProfileWithLock: UpsertAuthProfileWithLock | undefined;
 installModelsConfigTestHooks();
 
 let ensureOpenClawModelsJson: typeof import("./models-config.js").ensureOpenClawModelsJson;
+let ensureAuthProfileStore: typeof import("./auth-profiles.js").ensureAuthProfileStore;
 let clearCurrentPluginMetadataSnapshot: typeof import("../plugins/current-plugin-metadata-snapshot.js").clearCurrentPluginMetadataSnapshot;
 let setCurrentPluginMetadataSnapshot: typeof import("../plugins/current-plugin-metadata-snapshot.js").setCurrentPluginMetadataSnapshot;
 let createProviderAuthResolver: typeof import("./models-config.providers.secrets.js").createProviderAuthResolver;
@@ -134,6 +135,7 @@ beforeAll(async () => {
     };
   });
   ({ ensureOpenClawModelsJson } = await import("./models-config.js"));
+  ({ ensureAuthProfileStore } = await import("./auth-profiles.js"));
   ({ createProviderAuthResolver } = await import("./models-config.providers.secrets.js"));
   ({ clearCurrentPluginMetadataSnapshot, setCurrentPluginMetadataSnapshot } =
     await import("../plugins/current-plugin-metadata-snapshot.js"));
@@ -272,6 +274,95 @@ describe("models-config write serialization", () => {
         provider: "custom",
         key: "sk-existing-models-json-only",
         copyToAgents: false,
+      });
+    });
+  });
+
+  it("migrates local models.json keys when a non-main agent inherits the same profile", async () => {
+    await withModelsTempHome(async (home) => {
+      const mainAgentDir = path.join(home, ".openclaw", "agents", "main", "agent");
+      const agentDir = path.join(home, ".openclaw", "agents", "worker", "agent");
+      process.env.OPENCLAW_AGENT_DIR = mainAgentDir;
+      process.env.PI_CODING_AGENT_DIR = mainAgentDir;
+      await fs.mkdir(mainAgentDir, { recursive: true });
+      await fs.mkdir(agentDir, { recursive: true });
+      await fs.writeFile(
+        path.join(mainAgentDir, "auth-profiles.json"),
+        `${JSON.stringify(
+          {
+            version: 1,
+            profiles: {
+              "custom:models-json": {
+                type: "api_key",
+                provider: "custom",
+                key: "sk-main-inherited-profile", // pragma: allowlist secret
+              },
+            },
+          },
+          null,
+          2,
+        )}\n`,
+      );
+      await fs.writeFile(
+        path.join(agentDir, "models.json"),
+        `${JSON.stringify(
+          {
+            providers: {
+              custom: {
+                baseUrl: "https://custom.example/v1",
+                api: "openai-completions",
+                apiKey: "sk-worker-local-models-json", // pragma: allowlist secret
+                models: [],
+              },
+            },
+          },
+          null,
+          2,
+        )}\n`,
+      );
+
+      await ensureOpenClawModelsJson(
+        {
+          models: {
+            mode: "merge",
+            providers: {
+              custom: {
+                baseUrl: "https://custom.example/v1",
+                api: "openai-completions",
+                models: [],
+              },
+            },
+          },
+        },
+        agentDir,
+      );
+
+      const modelsJson = JSON.parse(
+        await fs.readFile(path.join(agentDir, "models.json"), "utf8"),
+      ) as {
+        providers: Record<string, { apiKey?: string }>;
+      };
+      expect(modelsJson.providers.custom?.apiKey).toBeUndefined();
+
+      const localAuthProfiles = JSON.parse(
+        await fs.readFile(path.join(agentDir, "auth-profiles.json"), "utf8"),
+      ) as AuthProfileStore;
+      expect(localAuthProfiles.profiles["custom:models-json"]).toMatchObject({
+        type: "api_key",
+        provider: "custom",
+        key: "sk-worker-local-models-json",
+        copyToAgents: false,
+      });
+
+      const auth = createProviderAuthResolver(
+        {},
+        ensureAuthProfileStore(agentDir, { allowKeychainPrompt: false }),
+      )("custom");
+      expect(auth).toMatchObject({
+        discoveryApiKey: "sk-worker-local-models-json",
+        mode: "api_key",
+        source: "profile",
+        profileId: "custom:models-json",
       });
     });
   });

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -930,7 +930,7 @@ export const FIELD_HELP: Record<string, string> = {
   models:
     "Model catalog root for provider definitions, merge/replace behavior, and optional Bedrock discovery integration. Keep provider definitions explicit and validated before relying on production failover paths.",
   "models.mode":
-    'Controls provider catalog behavior: "merge" keeps built-ins and overlays your custom providers, while "replace" uses only your configured providers. In "merge", matching provider IDs preserve non-empty agent models.json baseUrl values, while apiKey values are preserved only when the provider is not SecretRef-managed in current config/auth-profile context; SecretRef-managed providers refresh apiKey from current source markers, and matching model contextWindow/maxTokens use the higher value between explicit and implicit entries.',
+    'Controls provider catalog behavior: "merge" keeps built-ins and overlays your custom providers, while "replace" uses only your configured providers. In "merge", matching provider IDs preserve non-empty agent models.json baseUrl values, while plaintext apiKey values in existing agent models.json are stripped from the prompt-facing catalog and migrated to local auth profiles when they are the only available credential; SecretRef-managed providers refresh apiKey from current source markers, durable migration failures fail closed without rewriting models.json, and matching model contextWindow/maxTokens use the higher value between explicit and implicit entries.',
   "models.providers":
     "Provider map keyed by provider ID containing connection/auth settings and concrete model definitions. Use stable provider keys so references from agents and tooling remain portable across environments.",
   "models.pricing":
@@ -940,7 +940,7 @@ export const FIELD_HELP: Record<string, string> = {
   "models.providers.*.baseUrl":
     "Base URL for the provider endpoint used to serve model requests for that provider entry. Use HTTPS endpoints and keep URLs environment-specific through config templating where needed.",
   "models.providers.*.apiKey":
-    "Provider credential used for API-key based authentication when the provider requires direct key auth. Use secret/env substitution and avoid storing real keys in committed config files.",
+    "Provider credential input for API-key based authentication when the provider requires direct key auth. Use secret/env substitution or auth profiles; OpenClaw strips plaintext apiKey values from generated models.json and migrates legacy catalog-only keys into local auth profiles before rewriting that catalog.",
   "models.providers.*.auth":
     'Selects provider auth style: "api-key" for API key auth, "token" for bearer token auth, "oauth" for OAuth credentials, and "aws-sdk" for AWS credential resolution. Match this to your provider requirements.',
   "models.providers.*.api":

--- a/src/plugins/installed-plugin-index-registry.ts
+++ b/src/plugins/installed-plugin-index-registry.ts
@@ -1,5 +1,9 @@
 import { normalizePluginsConfig } from "./config-state.js";
-import { discoverOpenClawPlugins, type PluginCandidate } from "./discovery.js";
+import {
+  discoverOpenClawPlugins,
+  type PluginCandidate,
+  type PluginDiscoveryResult,
+} from "./discovery.js";
 import { loadInstalledPluginIndexInstallRecordsSync } from "./installed-plugin-index-record-reader.js";
 import type { LoadInstalledPluginIndexParams } from "./installed-plugin-index-types.js";
 import { loadPluginManifestRegistry, type PluginManifestRegistry } from "./manifest-registry.js";
@@ -7,6 +11,7 @@ import { loadPluginManifestRegistry, type PluginManifestRegistry } from "./manif
 export function resolveInstalledPluginIndexRegistry(params: LoadInstalledPluginIndexParams): {
   registry: PluginManifestRegistry;
   candidates: readonly PluginCandidate[];
+  discovery?: PluginDiscoveryResult;
 } {
   if (params.candidates) {
     return {
@@ -35,6 +40,7 @@ export function resolveInstalledPluginIndexRegistry(params: LoadInstalledPluginI
     });
   return {
     candidates: discovery.candidates,
+    discovery,
     registry: loadPluginManifestRegistry({
       config: params.config,
       workspaceDir: params.workspaceDir,

--- a/src/plugins/installed-plugin-index.ts
+++ b/src/plugins/installed-plugin-index.ts
@@ -2,6 +2,7 @@ import type { OpenClawConfig } from "../config/types.js";
 import { resolveCompatibilityHostVersion } from "../version.js";
 import { normalizePluginsConfig, resolveEffectivePluginActivationState } from "./config-state.js";
 import { isPluginEnabledByDefaultForPlatform } from "./default-enablement.js";
+import type { PluginDiscoveryResult } from "./discovery.js";
 import { normalizeInstallRecordMap } from "./installed-plugin-index-install-records.js";
 import {
   resolveCompatRegistryVersion,
@@ -42,9 +43,9 @@ export { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-
 
 function buildInstalledPluginIndex(
   params: LoadInstalledPluginIndexParams & { refreshReason?: InstalledPluginIndexRefreshReason },
-): InstalledPluginIndex {
+): { index: InstalledPluginIndex; discovery: PluginDiscoveryResult | undefined } {
   const env = params.env ?? process.env;
-  const { candidates, registry } = resolveInstalledPluginIndexRegistry(params);
+  const { candidates, registry, discovery } = resolveInstalledPluginIndexRegistry(params);
   const registryDiagnostics = registry.diagnostics ?? [];
   const diagnostics = [...registryDiagnostics];
   const generatedAtMs = (params.now?.() ?? new Date()).getTime();
@@ -65,30 +66,39 @@ function buildInstalledPluginIndex(
   });
 
   return {
-    version: INSTALLED_PLUGIN_INDEX_VERSION,
-    warning: INSTALLED_PLUGIN_INDEX_WARNING,
-    hostContractVersion: resolveCompatibilityHostVersion(env),
-    compatRegistryVersion: resolveCompatRegistryVersion(),
-    migrationVersion: INSTALLED_PLUGIN_INDEX_MIGRATION_VERSION,
-    policyHash: resolveInstalledPluginIndexPolicyHash(params.config),
-    generatedAtMs,
-    ...(params.refreshReason ? { refreshReason: params.refreshReason } : {}),
-    installRecords,
-    plugins,
-    diagnostics,
+    index: {
+      version: INSTALLED_PLUGIN_INDEX_VERSION,
+      warning: INSTALLED_PLUGIN_INDEX_WARNING,
+      hostContractVersion: resolveCompatibilityHostVersion(env),
+      compatRegistryVersion: resolveCompatRegistryVersion(),
+      migrationVersion: INSTALLED_PLUGIN_INDEX_MIGRATION_VERSION,
+      policyHash: resolveInstalledPluginIndexPolicyHash(params.config),
+      generatedAtMs,
+      ...(params.refreshReason ? { refreshReason: params.refreshReason } : {}),
+      installRecords,
+      plugins,
+      diagnostics,
+    },
+    discovery,
   };
 }
 
 export function loadInstalledPluginIndex(
   params: LoadInstalledPluginIndexParams = {},
 ): InstalledPluginIndex {
+  return buildInstalledPluginIndex(params).index;
+}
+
+export function loadInstalledPluginIndexWithDiscovery(
+  params: LoadInstalledPluginIndexParams = {},
+): { index: InstalledPluginIndex; discovery: PluginDiscoveryResult | undefined } {
   return buildInstalledPluginIndex(params);
 }
 
 export function refreshInstalledPluginIndex(
   params: RefreshInstalledPluginIndexParams,
 ): InstalledPluginIndex {
-  return buildInstalledPluginIndex({ ...params, refreshReason: params.reason });
+  return buildInstalledPluginIndex({ ...params, refreshReason: params.reason }).index;
 }
 
 export function listInstalledPluginRecords(

--- a/src/plugins/plugin-metadata-snapshot.ts
+++ b/src/plugins/plugin-metadata-snapshot.ts
@@ -681,6 +681,7 @@ function loadPluginMetadataSnapshotImpl(params: LoadPluginMetadataSnapshotParams
         indexPluginCount: index.plugins.length,
         manifestPluginCount: manifestRegistry.plugins.length,
       },
+      discovery: registryResult.discovery,
     },
   };
 }

--- a/src/plugins/plugin-metadata-snapshot.ts
+++ b/src/plugins/plugin-metadata-snapshot.ts
@@ -12,7 +12,6 @@ import { getCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-snap
 import { resolveDefaultPluginNpmDir } from "./install-paths.js";
 import { hashJson } from "./installed-plugin-index-hash.js";
 import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-policy.js";
-import { loadInstalledPluginIndexInstallRecordsSync } from "./installed-plugin-index-record-reader.js";
 import { resolveInstalledPluginIndexStorePath } from "./installed-plugin-index-store-path.js";
 import type { InstalledPluginIndex } from "./installed-plugin-index.js";
 import {
@@ -43,14 +42,14 @@ type PersistedRegistryMemoState = {
   contextHash: string;
   fastHash: string;
   fingerprint: unknown;
-  watchedFilesHash: string;
-  watchedFiles: readonly string[];
 };
 
-let pluginMetadataSnapshotMemo: PluginMetadataSnapshotMemo | undefined;
+const MAX_PLUGIN_METADATA_SNAPSHOT_MEMOS = 8;
+
+let pluginMetadataSnapshotMemos: PluginMetadataSnapshotMemo[] = [];
 
 export function clearLoadPluginMetadataSnapshotMemo(): void {
-  pluginMetadataSnapshotMemo = undefined;
+  pluginMetadataSnapshotMemos = [];
 }
 
 const MEMO_RELEVANT_ENV_KEYS = [
@@ -102,10 +101,6 @@ function readJsonObject(filePath: string): Record<string, unknown> | undefined {
   }
 }
 
-function normalizeString(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim() ? value.trim() : undefined;
-}
-
 function stableMemoValue(value: unknown): unknown {
   if (Array.isArray(value)) {
     return value.map(stableMemoValue);
@@ -118,162 +113,6 @@ function stableMemoValue(value: unknown): unknown {
       .toSorted(([left], [right]) => left.localeCompare(right))
       .map(([key, entry]) => [key, stableMemoValue(entry)]),
   );
-}
-
-function isPathInsideOrEqual(childPath: string, parentPath: string): boolean {
-  const relative = path.relative(parentPath, childPath);
-  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
-}
-
-function tryRealpath(filePath: string): string | null {
-  try {
-    return fs.realpathSync(filePath);
-  } catch {
-    return null;
-  }
-}
-
-function resolvePluginFilePath(
-  pluginDir: string,
-  filePath: string | undefined,
-  options: { allowSymlinkOutsideRoot?: boolean } = {},
-):
-  | { status: "ok"; path: string }
-  | { status: "outside-root"; path: string }
-  | { status: "missing-root"; path: string } {
-  if (!filePath) {
-    return { status: "missing-root", path: "" };
-  }
-  const rootDir = path.resolve(pluginDir);
-  const resolved = path.isAbsolute(filePath)
-    ? path.resolve(filePath)
-    : path.resolve(rootDir, filePath);
-  if (!isPathInsideOrEqual(resolved, rootDir)) {
-    return { status: "outside-root", path: resolved };
-  }
-  const rootRealPath = tryRealpath(rootDir);
-  const targetRealPath = tryRealpath(resolved);
-  if (
-    rootRealPath &&
-    targetRealPath &&
-    !isPathInsideOrEqual(targetRealPath, rootRealPath) &&
-    !options.allowSymlinkOutsideRoot
-  ) {
-    return { status: "outside-root", path: resolved };
-  }
-  return { status: "ok", path: resolved };
-}
-
-function persistedPluginFileFingerprint(
-  rootDir: string | undefined,
-  filePath: string | undefined,
-  options: { allowSymlinkOutsideRoot?: boolean; watchedFiles?: Set<string> } = {},
-): unknown {
-  if (!filePath) {
-    return null;
-  }
-  if (!rootDir) {
-    return [filePath, "missing-root"];
-  }
-  const resolved = resolvePluginFilePath(rootDir, filePath, {
-    allowSymlinkOutsideRoot: options.allowSymlinkOutsideRoot,
-  });
-  if (resolved.status !== "ok") {
-    return [filePath, resolved.status];
-  }
-  options.watchedFiles?.add(resolved.path);
-  return fileFingerprint(resolved.path);
-}
-
-function watchedFileFingerprint(filePath: string | undefined, watchedFiles: Set<string>): unknown {
-  if (!filePath) {
-    return null;
-  }
-  watchedFiles.add(filePath);
-  return fileFingerprint(filePath);
-}
-
-function resolveInstallRecordPath(value: unknown, env: NodeJS.ProcessEnv): string | undefined {
-  const normalized = normalizeString(value);
-  return normalized ? resolveUserPath(normalized, env) : undefined;
-}
-
-function installRecordPathFingerprints(
-  env: NodeJS.ProcessEnv,
-  records: unknown,
-  watchedFiles: Set<string>,
-): readonly unknown[] {
-  if (!isRecord(records)) {
-    return [];
-  }
-  return Object.entries(records)
-    .toSorted(([left], [right]) => left.localeCompare(right))
-    .map(([pluginId, rawRecord]) => {
-      if (!isRecord(rawRecord)) {
-        return [pluginId, rawRecord];
-      }
-      const installPath = normalizeString(rawRecord.installPath);
-      const sourcePath = normalizeString(rawRecord.sourcePath);
-      const resolvedInstallPath = resolveInstallRecordPath(rawRecord.installPath, env);
-      const resolvedSourcePath = resolveInstallRecordPath(rawRecord.sourcePath, env);
-      return [
-        pluginId,
-        installPath,
-        sourcePath,
-        watchedFileFingerprint(
-          resolvedInstallPath ? path.join(resolvedInstallPath, "package.json") : undefined,
-          watchedFiles,
-        ),
-        watchedFileFingerprint(
-          resolvedInstallPath ? path.join(resolvedInstallPath, "openclaw.plugin.json") : undefined,
-          watchedFiles,
-        ),
-        watchedFileFingerprint(resolvedSourcePath, watchedFiles),
-        watchedFileFingerprint(
-          resolvedSourcePath ? path.join(resolvedSourcePath, "package.json") : undefined,
-          watchedFiles,
-        ),
-        watchedFileFingerprint(
-          resolvedSourcePath ? path.join(resolvedSourcePath, "openclaw.plugin.json") : undefined,
-          watchedFiles,
-        ),
-      ];
-    });
-}
-
-function managedNpmDependencyMetadataFingerprints(
-  npmRoot: string,
-  watchedFiles: Set<string>,
-): readonly unknown[] {
-  const rootManifest = readJsonObject(path.join(npmRoot, "package.json"));
-  const dependencies = isRecord(rootManifest?.dependencies) ? rootManifest.dependencies : {};
-  const nodeModulesRoot = path.join(npmRoot, "node_modules");
-  return Object.entries(dependencies)
-    .toSorted(([left], [right]) => left.localeCompare(right))
-    .map(([packageName, rawSpec]) => {
-      const dependencySpec = normalizeString(rawSpec);
-      if (!dependencySpec) {
-        return [packageName, rawSpec];
-      }
-      const packageDir = path.resolve(nodeModulesRoot, packageName);
-      if (!isPathInsideOrEqual(packageDir, path.resolve(nodeModulesRoot))) {
-        return [packageName, dependencySpec, "outside-node-modules"];
-      }
-      return [
-        packageName,
-        dependencySpec,
-        watchedFileFingerprint(path.join(packageDir, "package.json"), watchedFiles),
-        watchedFileFingerprint(path.join(packageDir, "openclaw.plugin.json"), watchedFiles),
-      ];
-    });
-}
-
-function resolveRecordPackageJsonPath(record: Record<string, unknown>): string | undefined {
-  const packageJson = record.packageJson;
-  if (!isRecord(packageJson)) {
-    return undefined;
-  }
-  return normalizeString(packageJson.path);
 }
 
 function pickMemoRelevantEnv(env: NodeJS.ProcessEnv): Record<string, string> {
@@ -379,10 +218,6 @@ function resolvePersistedRegistryMemoContextHash(params: {
   });
 }
 
-function hashWatchedFiles(watchedFiles: readonly string[]): string {
-  return hashJson(watchedFiles.map((filePath) => fileFingerprint(filePath)));
-}
-
 function resolvePersistedRegistryMemoState(params: {
   env: NodeJS.ProcessEnv;
   index?: InstalledPluginIndex;
@@ -400,100 +235,20 @@ function resolvePersistedRegistryMemoState(params: {
       contextHash,
       fastHash,
       fingerprint: fastFingerprint,
-      watchedFiles: [],
-      watchedFilesHash: hashJson([]),
     };
   }
   const indexPath = resolveInstalledPluginIndexStorePath({
     env: params.env,
     ...(params.stateDir ? { stateDir: params.stateDir } : {}),
   });
-  const npmRoot = params.stateDir
-    ? path.join(params.stateDir, "npm")
-    : resolveDefaultPluginNpmDir(params.env);
   const index = params.index ?? readJsonObject(indexPath);
-  const plugins = Array.isArray(index?.plugins) ? index.plugins : [];
-  const diagnostics = Array.isArray(index?.diagnostics) ? index.diagnostics : [];
-  const pluginRootById = new Map<string, string>();
-  const watchedFiles = new Set<string>();
-  for (const rawPlugin of plugins) {
-    if (!isRecord(rawPlugin)) {
-      continue;
-    }
-    const pluginId = normalizeString(rawPlugin.pluginId);
-    const rootDir = normalizeString(rawPlugin.rootDir);
-    if (pluginId && rootDir) {
-      pluginRootById.set(pluginId, rootDir);
-    }
-  }
-  const installRecords =
-    params.index?.installRecords ??
-    loadInstalledPluginIndexInstallRecordsSync({
-      env: params.env,
-      ...(params.stateDir ? { stateDir: params.stateDir } : {}),
-    });
-  const watchedPlugins = plugins.map((rawPlugin) => {
-    if (!isRecord(rawPlugin)) {
-      return rawPlugin;
-    }
-    const rootDir = normalizeString(rawPlugin.rootDir);
-    const manifestPath = normalizeString(rawPlugin.manifestPath);
-    const packageJsonPath = resolveRecordPackageJsonPath(rawPlugin);
-    const source = normalizeString(rawPlugin.source);
-    const setupSource = normalizeString(rawPlugin.setupSource);
-    return [
-      normalizeString(rawPlugin.pluginId),
-      rootDir,
-      rootDir ? fileFingerprint(rootDir) : null,
-      manifestPath,
-      persistedPluginFileFingerprint(rootDir, manifestPath, { watchedFiles }),
-      source,
-      persistedPluginFileFingerprint(rootDir, source, { watchedFiles }),
-      setupSource,
-      persistedPluginFileFingerprint(rootDir, setupSource, { watchedFiles }),
-      packageJsonPath,
-      persistedPluginFileFingerprint(rootDir, packageJsonPath, {
-        allowSymlinkOutsideRoot: true,
-        watchedFiles,
-      }),
-    ];
-  });
-  const watchedDiagnostics = diagnostics.map((rawDiagnostic) => {
-    if (!isRecord(rawDiagnostic)) {
-      return rawDiagnostic;
-    }
-    const pluginId = normalizeString(rawDiagnostic.pluginId);
-    const source = normalizeString(rawDiagnostic.source);
-    return [
-      pluginId,
-      source,
-      persistedPluginFileFingerprint(pluginId ? pluginRootById.get(pluginId) : undefined, source, {
-        watchedFiles,
-      }),
-    ];
-  });
-  const installRecordFiles = installRecordPathFingerprints(
-    params.env,
-    installRecords,
-    watchedFiles,
-  );
-  const managedNpmDependencyFiles = managedNpmDependencyMetadataFingerprints(npmRoot, watchedFiles);
-  const watchedFilesList = [...watchedFiles].toSorted();
   return {
     contextHash,
     fastHash,
     fingerprint: {
       ...fastFingerprint,
       indexHash: hashJson(stableMemoValue(index) ?? null),
-      installRecords: hashJson(stableMemoValue(installRecords)),
-      installRecordFiles,
-      managedNpmDependencyFiles,
-      npmPackageJson: fileFingerprint(path.join(npmRoot, "package.json")),
-      plugins: watchedPlugins,
-      diagnostics: watchedDiagnostics,
     },
-    watchedFiles: watchedFilesList,
-    watchedFilesHash: hashWatchedFiles(watchedFilesList),
   };
 }
 
@@ -503,7 +258,7 @@ function resolvePersistedRegistryMemoStateForLookup(
     preferPersisted?: boolean;
     stateDir?: string;
   },
-  memo: PluginMetadataSnapshotMemo | undefined,
+  memos: readonly PluginMetadataSnapshotMemo[],
 ): PersistedRegistryMemoState {
   const fastFingerprint = resolvePersistedRegistryFastMemoFingerprint(params);
   const fastHash = hashJson(fastFingerprint);
@@ -511,16 +266,51 @@ function resolvePersistedRegistryMemoStateForLookup(
     ...params,
     fastFingerprint,
   });
-  const registryState = memo?.registryState;
-  if (
-    registryState &&
-    registryState.contextHash === contextHash &&
-    registryState.fastHash === fastHash &&
-    hashWatchedFiles(registryState.watchedFiles) === registryState.watchedFilesHash
-  ) {
-    return registryState;
+  for (const memo of memos) {
+    const registryState = memo.registryState;
+    if (
+      registryState &&
+      registryState.contextHash === contextHash &&
+      registryState.fastHash === fastHash
+    ) {
+      // Plugin files are immutable for a running gateway; plugin edits require
+      // an explicit reload/restart, so hot lookups only validate the registry envelope.
+      return registryState;
+    }
   }
   return resolvePersistedRegistryMemoState(params);
+}
+
+function resolveProvidedIndexMemoState(index: InstalledPluginIndex): PersistedRegistryMemoState {
+  const fingerprint = {
+    providedIndex: resolveInstalledManifestRegistryIndexFingerprint(index),
+  };
+  const fingerprintHash = hashJson(fingerprint);
+  return {
+    contextHash: fingerprintHash,
+    fastHash: fingerprintHash,
+    fingerprint,
+  };
+}
+
+function findPluginMetadataSnapshotMemo(key: string): PluginMetadataSnapshotMemo | undefined {
+  const index = pluginMetadataSnapshotMemos.findIndex((memo) => memo.key === key);
+  if (index === -1) {
+    return undefined;
+  }
+  const [memo] = pluginMetadataSnapshotMemos.splice(index, 1);
+  if (!memo) {
+    return undefined;
+  }
+  pluginMetadataSnapshotMemos.unshift(memo);
+  return memo;
+}
+
+function rememberPluginMetadataSnapshotMemo(memo: PluginMetadataSnapshotMemo): void {
+  pluginMetadataSnapshotMemos = [
+    memo,
+    ...pluginMetadataSnapshotMemos.filter((existing) => existing.key !== memo.key),
+  ].slice(0, MAX_PLUGIN_METADATA_SNAPSHOT_MEMOS);
 }
 
 function computePluginMetadataSnapshotMemoKey(params: {
@@ -699,62 +489,27 @@ export function listPluginOriginsFromMetadataSnapshot(
   return new Map(snapshot.plugins.map((record) => [record.id, record.origin]));
 }
 
-export function resolvePluginMetadataSnapshot(
-  params: ResolvePluginMetadataSnapshotParams,
-): PluginMetadataSnapshot {
-  const canUseCurrentSnapshot =
-    params.allowCurrent !== false &&
-    params.stateDir === undefined &&
-    params.preferPersisted !== false;
-  if (canUseCurrentSnapshot) {
-    const current = getCurrentPluginMetadataSnapshot({
-      config: params.config,
-      env: params.env,
-      ...(params.workspaceDir !== undefined ? { workspaceDir: params.workspaceDir } : {}),
-      ...(params.allowWorkspaceScopedCurrent === true
-        ? { allowWorkspaceScopedSnapshot: true }
-        : {}),
-    });
-    if (!current) {
-      return loadPluginMetadataSnapshot(params);
-    }
-    if (!params.index) {
-      return current;
-    }
-    if (
-      isPluginMetadataSnapshotCompatible({
-        snapshot: current,
-        config: params.config,
-        env: params.env,
-        workspaceDir:
-          params.workspaceDir ??
-          (params.allowWorkspaceScopedCurrent === true ? current.workspaceDir : undefined),
-        index: params.index,
-      })
-    ) {
-      return current;
-    }
-  }
-  return loadPluginMetadataSnapshot(params);
-}
-
 // Process-local memoization keeps the hot snapshot work cached while checking
 // the persisted metadata files that the installed-index loader consumes.
 export function loadPluginMetadataSnapshot(
   params: LoadPluginMetadataSnapshotParams,
 ): PluginMetadataSnapshot {
   const activeTimelineSpan = getActiveDiagnosticsTimelineSpan();
-  const memo = pluginMetadataSnapshotMemo;
   const env = params.env ?? process.env;
-  const registryState = resolvePersistedRegistryMemoStateForLookup(
-    {
-      env,
-      ...(params.stateDir ? { stateDir: resolveUserPath(params.stateDir, env) } : {}),
-      ...(params.preferPersisted !== undefined ? { preferPersisted: params.preferPersisted } : {}),
-    },
-    memo,
-  );
+  const registryState = params.index
+    ? resolveProvidedIndexMemoState(params.index)
+    : resolvePersistedRegistryMemoStateForLookup(
+        {
+          env,
+          ...(params.stateDir ? { stateDir: resolveUserPath(params.stateDir, env) } : {}),
+          ...(params.preferPersisted !== undefined
+            ? { preferPersisted: params.preferPersisted }
+            : {}),
+        },
+        pluginMetadataSnapshotMemos,
+      );
   const memoKey = computePluginMetadataSnapshotMemoKey({ params, registryState });
+  const memo = findPluginMetadataSnapshotMemo(memoKey);
   if (memo?.key === memoKey) {
     return measureDiagnosticsTimelineSpanSync(
       "plugins.metadata.scan",
@@ -797,11 +552,11 @@ export function loadPluginMetadataSnapshot(
               : {}),
           })
         : registryState;
-    pluginMetadataSnapshotMemo = {
+    rememberPluginMetadataSnapshotMemo({
       key: computePluginMetadataSnapshotMemoKey({ params, registryState: cachedRegistryState }),
       registryState: cachedRegistryState,
       snapshot: clonePluginMetadataSnapshot(result.snapshot),
-    };
+    });
   }
   return result.snapshot;
 }
@@ -810,18 +565,46 @@ function canMemoizePluginMetadataSnapshotResult(result: {
   registrySource: PluginRegistrySnapshotSource;
   snapshot: PluginMetadataSnapshot;
 }): boolean {
-  if (result.snapshot.index.plugins.length === 0) {
-    return false;
+  return result.registrySource !== "derived" && result.snapshot.index.plugins.length > 0;
+}
+
+export function resolvePluginMetadataSnapshot(
+  params: ResolvePluginMetadataSnapshotParams,
+): PluginMetadataSnapshot {
+  const canUseCurrentSnapshot =
+    params.allowCurrent !== false &&
+    params.stateDir === undefined &&
+    params.preferPersisted !== false;
+  if (canUseCurrentSnapshot) {
+    const current = getCurrentPluginMetadataSnapshot({
+      config: params.config,
+      env: params.env,
+      ...(params.workspaceDir !== undefined ? { workspaceDir: params.workspaceDir } : {}),
+      ...(params.allowWorkspaceScopedCurrent === true
+        ? { allowWorkspaceScopedSnapshot: true }
+        : {}),
+    });
+    if (!current) {
+      return loadPluginMetadataSnapshot(params);
+    }
+    if (!params.index) {
+      return current;
+    }
+    if (
+      isPluginMetadataSnapshotCompatible({
+        snapshot: current,
+        config: params.config,
+        env: params.env,
+        workspaceDir:
+          params.workspaceDir ??
+          (params.allowWorkspaceScopedCurrent === true ? current.workspaceDir : undefined),
+        index: params.index,
+      })
+    ) {
+      return current;
+    }
   }
-  if (result.registrySource !== "derived") {
-    return true;
-  }
-  return (
-    result.snapshot.registryDiagnostics.length > 0 &&
-    result.snapshot.registryDiagnostics.every(
-      (diagnostic) => diagnostic.code === "persisted-registry-stale-policy",
-    )
-  );
+  return loadPluginMetadataSnapshot(params);
 }
 
 function loadPluginMetadataSnapshotImpl(params: LoadPluginMetadataSnapshotParams): {
@@ -873,6 +656,7 @@ function loadPluginMetadataSnapshotImpl(params: LoadPluginMetadataSnapshotParams
     registrySource: registryResult.source,
     snapshot: {
       policyHash: index.policyHash,
+      registrySource: registryResult.source,
       configFingerprint: resolvePluginMetadataControlPlaneFingerprint({
         config: params.config,
         env: params.env,

--- a/src/plugins/plugin-metadata-snapshot.ts
+++ b/src/plugins/plugin-metadata-snapshot.ts
@@ -8,6 +8,7 @@ import {
 } from "../infra/diagnostics-timeline.js";
 import { resolveUserPath } from "../utils.js";
 import { resolveCompatibilityHostVersion } from "../version.js";
+import { getCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-snapshot.js";
 import { resolveDefaultPluginNpmDir } from "./install-paths.js";
 import { hashJson } from "./installed-plugin-index-hash.js";
 import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-policy.js";
@@ -24,6 +25,7 @@ import type {
   LoadPluginMetadataSnapshotParams,
   PluginMetadataSnapshot,
   PluginMetadataSnapshotOwnerMaps,
+  ResolvePluginMetadataSnapshotParams,
 } from "./plugin-metadata-snapshot.types.js";
 import { createPluginRegistryIdNormalizer } from "./plugin-registry-id-normalizer.js";
 import {
@@ -74,6 +76,7 @@ export type {
   PluginMetadataSnapshotMetrics,
   PluginMetadataSnapshotOwnerMaps,
   PluginMetadataSnapshotRegistryDiagnostic,
+  ResolvePluginMetadataSnapshotParams,
 } from "./plugin-metadata-snapshot.types.js";
 
 function fileFingerprint(filePath: string): unknown {
@@ -694,6 +697,45 @@ export function listPluginOriginsFromMetadataSnapshot(
   snapshot: Pick<PluginMetadataSnapshot, "plugins">,
 ): ReadonlyMap<string, PluginManifestRecord["origin"]> {
   return new Map(snapshot.plugins.map((record) => [record.id, record.origin]));
+}
+
+export function resolvePluginMetadataSnapshot(
+  params: ResolvePluginMetadataSnapshotParams,
+): PluginMetadataSnapshot {
+  const canUseCurrentSnapshot =
+    params.allowCurrent !== false &&
+    params.stateDir === undefined &&
+    params.preferPersisted !== false;
+  if (canUseCurrentSnapshot) {
+    const current = getCurrentPluginMetadataSnapshot({
+      config: params.config,
+      env: params.env,
+      ...(params.workspaceDir !== undefined ? { workspaceDir: params.workspaceDir } : {}),
+      ...(params.allowWorkspaceScopedCurrent === true
+        ? { allowWorkspaceScopedSnapshot: true }
+        : {}),
+    });
+    if (!current) {
+      return loadPluginMetadataSnapshot(params);
+    }
+    if (!params.index) {
+      return current;
+    }
+    if (
+      isPluginMetadataSnapshotCompatible({
+        snapshot: current,
+        config: params.config,
+        env: params.env,
+        workspaceDir:
+          params.workspaceDir ??
+          (params.allowWorkspaceScopedCurrent === true ? current.workspaceDir : undefined),
+        index: params.index,
+      })
+    ) {
+      return current;
+    }
+  }
+  return loadPluginMetadataSnapshot(params);
 }
 
 // Process-local memoization keeps the hot snapshot work cached while checking

--- a/src/plugins/plugin-metadata-snapshot.types.ts
+++ b/src/plugins/plugin-metadata-snapshot.types.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { PluginDiscoveryResult } from "./discovery.js";
 import type { InstalledPluginIndex } from "./installed-plugin-index-types.js";
 import type { PluginManifestRecord, PluginManifestRegistry } from "./manifest-registry.js";
 import type { PluginDiagnostic } from "./manifest-types.js";
@@ -48,6 +49,7 @@ export type PluginMetadataSnapshot = {
   normalizePluginId: (pluginId: string) => string;
   owners: PluginMetadataSnapshotOwnerMaps;
   metrics: PluginMetadataSnapshotMetrics;
+  discovery?: PluginDiscoveryResult;
 };
 
 export type PluginMetadataRegistryView = Pick<PluginMetadataSnapshot, "index" | "manifestRegistry">;

--- a/src/plugins/plugin-metadata-snapshot.types.ts
+++ b/src/plugins/plugin-metadata-snapshot.types.ts
@@ -1,7 +1,8 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import type { InstalledPluginIndex } from "./installed-plugin-index.js";
+import type { InstalledPluginIndex } from "./installed-plugin-index-types.js";
 import type { PluginManifestRecord, PluginManifestRegistry } from "./manifest-registry.js";
 import type { PluginDiagnostic } from "./manifest-types.js";
+import type { PluginRegistrySnapshotSource } from "./plugin-registry-snapshot.types.js";
 
 export type PluginMetadataSnapshotOwnerMaps = {
   channels: ReadonlyMap<string, readonly string[]>;
@@ -36,6 +37,7 @@ export type PluginMetadataSnapshotRegistryDiagnostic = {
 export type PluginMetadataSnapshot = {
   policyHash: string;
   configFingerprint?: string;
+  registrySource?: PluginRegistrySnapshotSource;
   workspaceDir?: string;
   index: InstalledPluginIndex;
   registryDiagnostics: readonly PluginMetadataSnapshotRegistryDiagnostic[];

--- a/src/plugins/plugin-metadata-snapshot.types.ts
+++ b/src/plugins/plugin-metadata-snapshot.types.ts
@@ -60,3 +60,8 @@ export type LoadPluginMetadataSnapshotParams = {
   index?: InstalledPluginIndex;
   preferPersisted?: boolean;
 };
+
+export type ResolvePluginMetadataSnapshotParams = LoadPluginMetadataSnapshotParams & {
+  allowCurrent?: boolean;
+  allowWorkspaceScopedCurrent?: boolean;
+};

--- a/src/plugins/plugin-registry-snapshot.ts
+++ b/src/plugins/plugin-registry-snapshot.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { resolveUserPath } from "../utils.js";
 import { resolveBundledPluginsDir } from "./bundled-dir.js";
 import { getCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-snapshot.js";
+import type { PluginDiscoveryResult } from "./discovery.js";
 import { fileSignatureMatches } from "./installed-plugin-index-hash.js";
 import { hasOptionalMissingPluginManifestFile } from "./installed-plugin-index-manifest.js";
 import { loadInstalledPluginIndexInstallRecordsSync } from "./installed-plugin-index-record-reader.js";
@@ -19,18 +20,19 @@ import {
   extractPluginInstallRecordsFromInstalledPluginIndex,
   isInstalledPluginEnabled,
   listInstalledPluginRecords,
-  loadInstalledPluginIndex,
+  loadInstalledPluginIndexWithDiscovery,
   resolveInstalledPluginIndexPolicyHash,
   type InstalledPluginIndex,
   type InstalledPluginIndexRecord,
   type LoadInstalledPluginIndexParams,
   type RefreshInstalledPluginIndexParams,
 } from "./installed-plugin-index.js";
+import type { PluginRegistrySnapshotSource } from "./plugin-registry-snapshot.types.js";
 
 export type PluginRegistrySnapshot = InstalledPluginIndex;
 export type PluginRegistryRecord = InstalledPluginIndexRecord;
 export type PluginRegistryInspection = InstalledPluginIndexStoreInspection;
-export type PluginRegistrySnapshotSource = "provided" | "persisted" | "derived";
+export type { PluginRegistrySnapshotSource } from "./plugin-registry-snapshot.types.js";
 export type PluginRegistrySnapshotDiagnosticCode =
   | "persisted-registry-disabled"
   | "persisted-registry-missing"
@@ -47,6 +49,7 @@ export type PluginRegistrySnapshotResult = {
   snapshot: PluginRegistrySnapshot;
   source: PluginRegistrySnapshotSource;
   diagnostics: readonly PluginRegistrySnapshotDiagnostic[];
+  discovery?: PluginDiscoveryResult;
 };
 
 export const DISABLE_PERSISTED_PLUGIN_REGISTRY_ENV = "OPENCLAW_DISABLE_PERSISTED_PLUGIN_REGISTRY";
@@ -346,11 +349,12 @@ export function loadPluginRegistrySnapshotWithMetadata(
             "Persisted plugin registry is missing recoverable managed npm plugins; using derived plugin index. Run `openclaw plugins registry --refresh` to update the persisted registry.",
         });
       } else {
-        return {
+        const persistedResult: PluginRegistrySnapshotResult = {
           snapshot: persistedIndex,
           source: "persisted",
           diagnostics,
         };
+        return persistedResult;
       }
     } else if (persistedReadsEnabled) {
       diagnostics.push({
@@ -369,15 +373,17 @@ export function loadPluginRegistrySnapshotWithMetadata(
     });
   }
 
+  const derived = loadInstalledPluginIndexWithDiscovery({
+    ...params,
+    installRecords: persistedInstallRecordReadsEnabled
+      ? params.installRecords
+      : (params.installRecords ?? {}),
+  });
   return {
-    snapshot: loadInstalledPluginIndex({
-      ...params,
-      ...(persistedInstallRecordReadsEnabled
-        ? {}
-        : { installRecords: params.installRecords ?? {} }),
-    }),
+    snapshot: derived.index,
     source: "derived",
     diagnostics,
+    discovery: derived.discovery,
   };
 }
 

--- a/src/plugins/plugin-registry-snapshot.types.ts
+++ b/src/plugins/plugin-registry-snapshot.types.ts
@@ -1,0 +1,1 @@
+export type PluginRegistrySnapshotSource = "provided" | "persisted" | "derived";


### PR DESCRIPTION
## Summary
- strip plaintext provider `apiKey` values after merge-mode preservation, source-managed enforcement, and provider compatibility transforms so old `models.json` keys cannot be reintroduced into the final prompt-facing catalog
- clean legacy catalog-only `models.json` plaintext provider keys before the empty-provider `skip` path can preserve them
- migrate existing `models.json`-only plaintext provider keys into the target agent's local `auth-profiles.json` before writing the stripped catalog when there is no configured provider key and no target-local auth profile for that provider
- keep inherited main-agent profiles and runtime/external overlays from suppressing local legacy `models.json` key migration for non-main agents
- migrate known/env-present legacy env-name catalog credentials such as `LITELLM_KEY` to env-backed auth-profile `keyRef`s, while preserving ambiguous env-shaped plaintext strings as inline local auth-profile keys
- preserve non-secret markers such as env SecretRef markers and custom-provider `secretref-managed` compatibility markers
- preserve current-main plugin metadata discovery and manifest-aware model ID normalization while routing providers through the prompt-safe stripping path
- add regression coverage for generated plaintext stripping, merge-mode stripping, catalog-only cleanup, existing-key migration, fail-closed behavior, inherited-profile migration boundaries, env-present keyRef migration, ambiguous env-shaped key preservation, pi model discovery compatibility, metadata discovery threading, and current-head write-path stabilization

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Generated and legacy `models.json` files should not persist plaintext provider `apiKey` values. Cleanup should preserve upgrade auth outside the prompt-facing catalog, including non-main agent local migration boundaries and env-shaped legacy values that must only become `keyRef`s when an env marker or observed env value proves they are env-backed. The rebased branch should also preserve current-main plugin metadata discovery and manifest-aware model normalization.
- Real environment tested: Local OpenClaw source tree matching PR head `4637af01e2f1bf0212758c7450eeb5ca328b8ba7` (`treeMatchesRemoteHead: true`; local commit `3a249e79e3cd0be76920458c507fed56374b6ffb` has the same tree because the remote commit was created through the GitHub Git Database API), macOS, Node.js `v24.1.0`, `/usr/bin/python3` for fs-safe pinned writes. Provider keys in proof output are redacted.
- Exact steps or command run after this patch:

```bash
FS_SAFE_PYTHON_MODE=require FS_SAFE_PYTHON=/usr/bin/python3 REMOTE_HEAD=4637af01e2f1bf0212758c7450eeb5ca328b8ba7 REMOTE_TREE=d14a38d666241655a0efe6dc30ef6b88a89da3bc node --import tsx --input-type=module
```

The inline Node proof script created temporary local agent dirs, called `ensureOpenClawModelsJson`, `planOpenClawModelsJsonWithDeps`, `discoverModels`, `ensureAuthProfileStore`, and `createProviderAuthResolver`, and exercised these real paths: inline custom provider stripping, legacy configured `models.json` key migration, catalog-only cleanup, env-present `keyRef` migration, ambiguous env-shaped plaintext preservation, non-main inherited-profile migration boundary, pi model discovery compatibility, and manifest-aware model normalization after stripping.

- Evidence after fix (copied live output, redacted):

```json
{
  "remoteHead": "4637af01e2f1bf0212758c7450eeb5ca328b8ba7",
  "localCommit": "3a249e79e3cd0be76920458c507fed56374b6ffb",
  "treeMatchesRemoteHead": true,
  "localTree": "d14a38d666241655a0efe6dc30ef6b88a89da3bc",
  "tempRoot": "<tmp>",
  "inlineCustomProvider": {
    "apiKeyMarker": "secretref-managed",
    "hasPlaintextInModelsJson": false,
    "discoverModelsFindsCustomModel": "custom-model"
  },
  "legacyModelsJsonOnlyUpgrade": {
    "apiKeyMarker": "secretref-managed",
    "hasPlaintextInModelsJson": false,
    "migratedProfile": {
      "type": "api_key",
      "provider": "custom",
      "copyToAgents": false,
      "displayName": "Migrated from models.json",
      "key": "<redacted>"
    },
    "discoverModelsFindsLegacyModel": "legacy-model"
  },
  "catalogOnlyLegacyCleanup": {
    "apiKeyMarker": "secretref-managed",
    "hasPlaintextInModelsJson": false,
    "migratedProfile": {
      "type": "api_key",
      "provider": "custom",
      "copyToAgents": false,
      "displayName": "Migrated from models.json",
      "key": "<redacted>"
    },
    "discoverModelsFindsCatalogOnlyModel": "catalog-only-model"
  },
  "envPresentCatalogMigration": {
    "modelsJsonPromptSafe": true,
    "migratedProfile": {
      "type": "api_key",
      "provider": "custom",
      "hasInlineKey": false,
      "keyRef": {
        "source": "env",
        "provider": "default",
        "id": "LITELLM_KEY"
      },
      "copyToAgents": false
    },
    "runtimeAuth": {
      "mode": "api_key",
      "source": "profile",
      "profileId": "custom:models-json",
      "apiKeyMarker": "LITELLM_KEY",
      "resolvedEnvValueSeen": true
    }
  },
  "ambiguousEnvShapedCredential": {
    "modelsJsonPromptSafe": true,
    "migratedProfile": {
      "type": "api_key",
      "provider": "custom",
      "hasInlineKey": true,
      "hasKeyRef": false,
      "copyToAgents": false
    },
    "runtimeAuth": {
      "mode": "api_key",
      "source": "profile",
      "profileId": "custom:models-json",
      "preservedLocalKeySeen": true
    }
  },
  "inheritedProfileBoundary": {
    "modelsJsonPromptSafe": true,
    "localMigratedProfile": {
      "type": "api_key",
      "provider": "custom",
      "copyToAgents": false,
      "displayName": "Migrated from models.json",
      "key": "<redacted>"
    },
    "runtimeAuth": {
      "mode": "api_key",
      "source": "profile",
      "profileId": "custom:models-json",
      "resolvedWorkerKey": true
    }
  },
  "manifestAwareModelNormalization": {
    "planAction": "write",
    "normalizedModelId": "plugin-prefix/bare-model",
    "apiKeyMarker": "secretref-managed"
  }
}
```

- Observed result after fix: the final `models.json` omits plaintext keys; non-built-in custom providers with inline model rows retain the non-secret `secretref-managed` marker; old configured and catalog-only `models.json` credentials migrate into `auth-profiles.json`; env-present legacy catalog values migrate as env-backed `keyRef` credentials and resolve through provider auth; ambiguous env-shaped legacy values with no env signal are preserved as inline local auth-profile keys instead of unresolved env refs; a non-main agent with an inherited same-profile ID still migrates its local legacy catalog key and runtime auth resolves the worker-local key; pi `discoverModels` can still find custom model rows; and manifest-aware model normalization still threads plugin policies through the stripped catalog path.
- What was not tested: I did not test a real paid third-party provider. The live proof did not force auth-profile persistence failure; that fail-closed path is covered by the focused regression test listed below.

## Tests
- `node scripts/run-vitest.mjs src/agents/models-config.write-serialization.test.ts --maxWorkers=1 --reporter=dot`
- `node scripts/run-vitest.mjs src/agents/models-config.plan.test.ts --maxWorkers=1 --reporter=dot`
- `node scripts/run-vitest.mjs src/agents/models-config.runtime-source-snapshot.test.ts --maxWorkers=1 --reporter=dot`
- merge-ref simulation against local `origin/main` with the same three targeted tests after merging the current proof/fix tree
- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false PNPM_CONFIG_OFFLINE=true PNPM_CONFIG_PM_ON_FAIL=ignore pnpm exec tsc --noEmit --pretty false -p tsconfig.core.json`
- `NODE_OPTIONS=--max-old-space-size=8192 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false PNPM_CONFIG_OFFLINE=true PNPM_CONFIG_PM_ON_FAIL=ignore pnpm exec tsc --noEmit --pretty false -p test/tsconfig/tsconfig.core.test.json`
- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false PNPM_CONFIG_OFFLINE=true PNPM_CONFIG_PM_ON_FAIL=ignore pnpm exec oxfmt --check --threads=1 src/agents/models-config.ts src/agents/models-config.plan.ts src/agents/models-config.write-serialization.test.ts src/agents/models-config.plan.test.ts src/agents/models-config.runtime-source-snapshot.test.ts src/agents/models-config.providers.normalize.ts src/plugins/installed-plugin-index-registry.ts src/plugins/installed-plugin-index.ts src/plugins/plugin-metadata-snapshot.ts src/plugins/plugin-registry-snapshot.ts src/plugins/plugin-metadata-snapshot.types.ts src/plugins/plugin-registry-snapshot.types.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/models-config.ts src/agents/models-config.plan.ts src/agents/models-config.write-serialization.test.ts src/agents/models-config.plan.test.ts src/agents/models-config.runtime-source-snapshot.test.ts src/agents/models-config.providers.normalize.ts src/plugins/installed-plugin-index-registry.ts src/plugins/installed-plugin-index.ts src/plugins/plugin-metadata-snapshot.ts src/plugins/plugin-registry-snapshot.ts src/plugins/plugin-metadata-snapshot.types.ts src/plugins/plugin-registry-snapshot.types.ts`
- `pnpm docs:list`
- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false PNPM_CONFIG_OFFLINE=true PNPM_CONFIG_PM_ON_FAIL=ignore pnpm exec oxfmt --check --threads=1 docs/concepts/models.md docs/reference/secretref-credential-surface.md src/config/schema.help.ts`
- `node scripts/run-vitest.mjs src/config/schema.help.quality.test.ts --maxWorkers=1 --reporter=dot`
- `git diff --check`

Refs #11829


