### PR TITLE
fix: enforce slash command boundaries

### DIFF
--- a/src/auto-reply/reply/commands-allowlist.test.ts
+++ b/src/auto-reply/reply/commands-allowlist.test.ts
@@ -322,6 +322,21 @@ function buildAllowlistParams(
 }
 
 describe("handleAllowlistCommand", () => {
+  it("ignores longer slash command names that share the /allowlist prefix", async () => {
+    const cfg = {
+      commands: { text: true },
+      channels: { telegram: { allowFrom: ["123"] } },
+    } as OpenClawConfig;
+
+    const result = await handleAllowlistCommand(
+      buildAllowlistParams("/allowlist-check list dm", cfg),
+      true,
+    );
+
+    expect(result).toBeNull();
+    expect(readChannelAllowFromStoreMock).not.toHaveBeenCalled();
+  });
+
   it("lists config and store allowFrom entries", async () => {
     readChannelAllowFromStoreMock.mockResolvedValueOnce(["456"]);
 

--- a/src/auto-reply/reply/commands-allowlist.ts
+++ b/src/auto-reply/reply/commands-allowlist.ts
@@ -20,6 +20,7 @@ import {
   requireCommandFlagEnabled,
   requireGatewayClientScope,
 } from "./command-gates.js";
+import { extractSlashCommandRest } from "./commands-slash-parse.js";
 import type { CommandHandler } from "./commands-types.js";
 import { applyAllowlistConfigMutation, AutoReplyConfigMutationError } from "./config-mutations.js";
 import { resolveConfigWriteDeniedText } from "./config-write-authorization.js";
@@ -74,12 +75,10 @@ function resolveAllowlistAccountId(params: {
 }
 
 function parseAllowlistCommand(raw: string): AllowlistCommand | null {
-  const trimmed = raw.trim();
-  const trimmedLower = normalizeOptionalLowercaseString(trimmed) ?? "";
-  if (!trimmedLower.startsWith("/allowlist")) {
+  const rest = extractSlashCommandRest(raw, "/allowlist");
+  if (rest === null) {
     return null;
   }
-  const rest = trimmed.slice("/allowlist".length).trim();
   if (!rest) {
     return { action: "list", scope: "dm" };
   }

--- a/src/auto-reply/reply/commands-compact.test.ts
+++ b/src/auto-reply/reply/commands-compact.test.ts
@@ -110,6 +110,19 @@ describe("handleCompactCommand", () => {
     expect(vi.mocked(compactEmbeddedPiSession)).not.toHaveBeenCalled();
   });
 
+  it("returns null when a longer slash command shares the /compact prefix", async () => {
+    const result = await handleCompactCommand(
+      buildCompactParams("/compact-check now", {
+        commands: { text: true },
+        channels: { whatsapp: { allowFrom: ["*"] } },
+      } as OpenClawConfig),
+      true,
+    );
+
+    expect(result).toBeNull();
+    expect(vi.mocked(compactEmbeddedPiSession)).not.toHaveBeenCalled();
+  });
+
   it("rejects unauthorized /compact commands", async () => {
     const params = buildCompactParams("/compact", {
       commands: { text: true },

--- a/src/auto-reply/reply/commands-compact.ts
+++ b/src/auto-reply/reply/commands-compact.ts
@@ -15,6 +15,7 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "../../shared/string-coerce.js";
+import { extractSlashCommandRest } from "./commands-slash-parse.js";
 import type { CommandHandler } from "./commands-types.js";
 import { stripMentions, stripStructuralPrefixes } from "./mentions.js";
 
@@ -39,14 +40,9 @@ function extractCompactInstructions(params: {
   if (!trimmed) {
     return undefined;
   }
-  const lowered = normalizeLowercaseStringOrEmpty(trimmed);
-  const prefix = lowered.startsWith("/compact") ? "/compact" : null;
-  if (!prefix) {
+  const rest = extractSlashCommandRest(trimmed, "/compact");
+  if (rest === null) {
     return undefined;
-  }
-  let rest = trimmed.slice(prefix.length).trimStart();
-  if (rest.startsWith(":")) {
-    rest = rest.slice(1).trimStart();
   }
   return rest.length ? rest : undefined;
 }
@@ -177,10 +173,7 @@ function resolveManualCompactContextModelId(params: {
 }
 
 export const handleCompactCommand: CommandHandler = async (params) => {
-  const compactRequested =
-    params.command.commandBodyNormalized === "/compact" ||
-    params.command.commandBodyNormalized.startsWith("/compact ");
-  if (!compactRequested) {
+  if (extractSlashCommandRest(params.command.commandBodyNormalized, "/compact") === null) {
     return null;
   }
   if (!params.command.isAuthorizedSender) {

--- a/src/auto-reply/reply/commands-models.test.ts
+++ b/src/auto-reply/reply/commands-models.test.ts
@@ -6,7 +6,11 @@ import {
   createChannelTestPluginBase,
   createTestRegistry,
 } from "../../test-utils/channel-plugins.js";
-import { buildModelsProviderData, handleModelsCommand } from "./commands-models.js";
+import {
+  buildModelsProviderData,
+  handleModelsCommand,
+  resolveModelsCommandReply,
+} from "./commands-models.js";
 import type { HandleCommandsParams } from "./commands-types.js";
 
 const modelCatalogMocks = vi.hoisted(() => ({
@@ -188,6 +192,24 @@ function firstAuthCheckerParams() {
 }
 
 describe("handleModelsCommand", () => {
+  it("ignores longer slash command names that share the /models prefix", async () => {
+    const result = await handleModelsCommand(buildParams("/models-check openai"), true);
+
+    expect(result).toBeNull();
+    expect(modelCatalogMocks.loadModelCatalog).not.toHaveBeenCalled();
+  });
+
+  it("ignores longer slash command names in the shared /models reply resolver", async () => {
+    const result = await resolveModelsCommandReply({
+      cfg: buildParams("/models-check openai").cfg,
+      commandBodyNormalized: "/models-check openai",
+      surface: "discord",
+    });
+
+    expect(result).toBeNull();
+    expect(modelCatalogMocks.loadModelCatalog).not.toHaveBeenCalled();
+  });
+
   it("shows a simple providers menu on text surfaces", async () => {
     const result = await handleModelsCommand(buildParams("/models"), true);
 

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -33,6 +33,7 @@ import {
 import { resolveAgentRuntimeLabel } from "../../status/agent-runtime-label.js";
 import type { ReplyPayload } from "../types.js";
 import { rejectUnauthorizedCommand } from "./command-gates.js";
+import { extractSlashCommandRest } from "./commands-slash-parse.js";
 import type { CommandHandler } from "./commands-types.js";
 
 const PAGE_SIZE_DEFAULT = 20;
@@ -476,11 +477,10 @@ export async function resolveModelsCommandReply(params: {
   sessionEntry?: ModelsCommandSessionEntry;
 }): Promise<ReplyPayload | null> {
   const body = params.commandBodyNormalized.trim();
-  if (!body.startsWith("/models")) {
+  const argText = extractSlashCommandRest(body, "/models");
+  if (argText === null) {
     return null;
   }
-
-  const argText = body.replace(/^\/models\b/i, "").trim();
   const parsed = parseModelsArgs(argText);
 
   const { byProvider, providers, modelNames } = await buildModelsProviderData(
@@ -643,10 +643,11 @@ export const handleModelsCommand: CommandHandler = async (params, allowTextComma
     return null;
   }
   const commandBodyNormalized = params.command.commandBodyNormalized.trim();
-  if (!commandBodyNormalized.startsWith("/models")) {
+  const modelsArgs = extractSlashCommandRest(commandBodyNormalized, "/models");
+  if (modelsArgs === null) {
     return null;
   }
-  const parsed = parseModelsArgs(commandBodyNormalized.replace(/^\/models\b/i, "").trim());
+  const parsed = parseModelsArgs(modelsArgs);
   const unauthorized = rejectUnauthorizedCommand(params, "/models");
   if (unauthorized) {
     return unauthorized;

--- a/src/auto-reply/reply/commands-setunset.test.ts
+++ b/src/auto-reply/reply/commands-setunset.test.ts
@@ -87,6 +87,24 @@ describe("parseSlashCommandWithSetUnset", () => {
     expect(result).toBeNull();
   });
 
+  it("returns null when a longer slash command shares the same prefix", () => {
+    const result = parseSlashCommandWithSetUnset<ParsedSetUnsetAction>(
+      createSlashParams({ raw: "/config-check value" }),
+    );
+    expect(result).toBeNull();
+  });
+
+  it("accepts a colon as a slash command boundary", () => {
+    const result = parseSlashCommandWithSetUnset<ParsedSetUnsetAction>(
+      createSlashParams({
+        raw: "/config: show",
+        onKnownAction: (action) =>
+          action === "show" ? { action: "unset", path: "dummy" } : undefined,
+      }),
+    );
+    expect(result).toEqual({ action: "unset", path: "dummy" });
+  });
+
   it("prefers set/unset mapping and falls back to known actions", () => {
     const setResult = parseSlashCommandWithSetUnset<ParsedSetUnsetAction>(
       createSlashParams({

--- a/src/auto-reply/reply/commands-slash-parse.ts
+++ b/src/auto-reply/reply/commands-slash-parse.ts
@@ -10,13 +10,25 @@ export type ParsedSlashCommand =
   | { ok: true; action: string; args: string }
   | { ok: false; message: string };
 
-function parseSlashCommandActionArgs(raw: string, slash: string): SlashCommandParseResult {
+export function extractSlashCommandRest(raw: string, slash: string): string | null {
   const trimmed = raw.trim();
   const slashLower = normalizeLowercaseStringOrEmpty(slash);
   if (!normalizeLowercaseStringOrEmpty(trimmed).startsWith(slashLower)) {
+    return null;
+  }
+  const nextChar = trimmed.charAt(slash.length);
+  if (nextChar && !/[\s:]/.test(nextChar)) {
+    return null;
+  }
+  const restStart = nextChar === ":" ? slash.length + 1 : slash.length;
+  return trimmed.slice(restStart).trim();
+}
+
+function parseSlashCommandActionArgs(raw: string, slash: string): SlashCommandParseResult {
+  const rest = extractSlashCommandRest(raw, slash);
+  if (rest === null) {
     return { kind: "no-match" };
   }
-  const rest = trimmed.slice(slash.length).trim();
   if (!rest) {
     return { kind: "empty" };
   }


### PR DESCRIPTION
## Summary

- Problem: Built-in slash handlers accepted longer command names that only shared a prefix, such as `/config-check` matching `/config`.
- Solution: Centralize slash-command rest extraction behind a token boundary check.
- What changed: Reused the boundary helper for `/config`-style parsing plus `/models`, `/allowlist`, and `/compact`, with regression tests for the prefix collision cases.
- What did NOT change (scope boundary): No skill command matching, command registry, auth, channel integration, or storage behavior was changed.
- AI-assisted: Yes; implemented with Codex and checked locally with `codex review --base upstream/main`.

## Motivation

- Closes #84572. This prevents built-in command handlers from consuming skill/custom slash commands whose names start with a built-in command prefix.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #84572
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Longer slash command names that share a built-in command prefix no longer match the built-in command parser.
- Real environment tested: Local OpenClaw source checkout on macOS 26.5 arm64 (`Darwin 25.5.0`), Node v25.8.1, pnpm v11.1.0.
- Exact steps or command run after this patch:

```sh
pnpm exec tsx --eval '
import { parseConfigCommand } from "./src/auto-reply/reply/config-commands.ts";
import { extractSlashCommandRest } from "./src/auto-reply/reply/commands-slash-parse.ts";

const results = {
  configCheck: parseConfigCommand("/config-check value"),
  configShow: parseConfigCommand("/config show"),
  modelsCheckRest: extractSlashCommandRest("/models-check openai", "/models"),
  modelsRest: extractSlashCommandRest("/models openai", "/models"),
  allowlistCheckRest: extractSlashCommandRest("/allowlist-check list dm", "/allowlist"),
  allowlistRest: extractSlashCommandRest("/allowlist list dm", "/allowlist"),
  compactCheckRest: extractSlashCommandRest("/compact-check now", "/compact"),
  compactColonRest: extractSlashCommandRest("/compact: focus on decisions", "/compact"),
};

console.log(JSON.stringify(results, null, 2));
'
```

- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```json
{
  "configCheck": null,
  "configShow": {
    "action": "show"
  },
  "modelsCheckRest": null,
  "modelsRest": "openai",
  "allowlistCheckRest": null,
  "allowlistRest": "list dm",
  "compactCheckRest": null,
  "compactColonRest": "focus on decisions"
}
```

- Observed result after fix: `/config-check`, `/models-check`, `/allowlist-check`, and `/compact-check` returned `null`; normal `/config show`, `/models openai`, `/allowlist list dm`, and `/compact: ...` still parse.
- What was not tested: Full live Discord/Telegram channel roundtrip; full repository test suite.
- Before evidence (optional but encouraged): See issue #84572 for the reported before-fix prefix match.

## Root Cause (if applicable)

- Root cause: Shared parsing and several direct built-in handlers used prefix checks without confirming the next character was a command boundary.
- Missing detection / guardrail: Regression coverage did not include longer slash command names that share a built-in prefix.
- Contributing context (if known): The registry advertises exact command aliases, but some handler-level parsing still accepted prefix-only matches.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `commands-setunset.test.ts`, `commands-models.test.ts`, `commands-allowlist.test.ts`, `commands-compact.test.ts`.
- Scenario the test should lock in: Built-in handlers ignore `/config-check`, `/models-check`, `/allowlist-check`, and `/compact-check` while preserving valid built-in command forms.
- Why this is the smallest reliable guardrail: The bug is in parser/handler dispatch, so focused parser and handler tests cover the failure before channel transport is involved.
- Existing test that already covers this (if any): None found for these prefix collision cases.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Built-in slash commands no longer consume longer custom or skill command names that merely share their prefix.

## Diagram (if applicable)

```text
Before:
/user sends /config-check -> /config parser accepts prefix -> built-in config handling

After:
/user sends /config-check -> boundary check rejects /config -> non-built-in command can continue
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): Yes, narrowed built-in slash command matching only.
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: Matching is stricter, not broader; regression tests cover both rejected prefix collisions and accepted valid commands.

## Repro + Verification

### Environment

- OS: macOS 26.5 arm64 (`Darwin 25.5.0`)
- Runtime/container: Node v25.8.1, pnpm v11.1.0
- Model/provider: N/A
- Integration/channel (if any): Local auto-reply slash command parser/handler paths
- Relevant config (redacted): N/A

### Steps

1. Run the focused regression tests.
2. Run the issue-related command tests.
3. Run the live parser proof command shown above.
4. Run formatter and diff checks.

### Expected

- Longer command names sharing a built-in prefix return `null` for the built-in parser/handler.
- Valid built-in slash commands keep parsing normally.

### Actual

- Matches expected behavior in tests and copied live parser output.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Verification commands run:

```sh
node scripts/run-vitest.mjs src/auto-reply/reply/commands-setunset.test.ts src/auto-reply/reply/commands-models.test.ts src/auto-reply/reply/commands-allowlist.test.ts src/auto-reply/reply/commands-compact.test.ts
# 4 files passed, 57 tests passed

node scripts/run-vitest.mjs src/auto-reply/reply/commands-setunset.test.ts src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts src/auto-reply/reply/commands-gating.test.ts src/auto-reply/reply/commands-models.test.ts src/auto-reply/reply/commands-allowlist.test.ts
# 5 files passed, 83 tests passed

pnpm exec oxfmt --check --threads=1 src/auto-reply/reply/commands-slash-parse.ts src/auto-reply/reply/commands-allowlist.ts src/auto-reply/reply/commands-models.ts src/auto-reply/reply/commands-compact.ts src/auto-reply/reply/commands-setunset.test.ts src/auto-reply/reply/commands-models.test.ts src/auto-reply/reply/commands-allowlist.test.ts src/auto-reply/reply/commands-compact.test.ts
# All matched files use the correct format.

git diff --check
# no output

codex review --base upstream/main
# No regression found in the touched command boundary changes.
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Prefix collisions for `/config-check`, `/models-check`, `/allowlist-check`, `/compact-check`; valid `/config`, `/models`, `/allowlist`, `/compact:` command forms.
- Edge cases checked: Whitespace boundary, colon boundary, and end-of-command boundary.
- What you did **not** verify: Full live Discord/Telegram channel roundtrip and full repository test suite.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

No bot review conversations yet.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Tightening slash command matching could reject an untested variant that previously matched by accident.
  - Mitigation: The helper accepts the intended command boundaries: whitespace, colon, or end of command, and tests cover both accepted and rejected forms.
