### PR TITLE
fix(minimax): stop advertising music duration control

### DIFF
--- a/docs/providers/minimax.md
+++ b/docs/providers/minimax.md
@@ -292,7 +292,7 @@ The bundled MiniMax plugin registers music generation through the shared
 - Default music model: `minimax/music-2.6`
 - OAuth music model: `minimax-portal/music-2.6`
 - Also supports `minimax/music-2.5` and `minimax/music-2.0`
-- Prompt controls: `lyrics`, `instrumental`, `durationSeconds`
+- Prompt controls: `lyrics`, `instrumental`
 - Output format: `mp3`
 - Session-backed runs detach through the shared task/status flow, including `action: "status"`
 

--- a/docs/tools/music-generation.md
+++ b/docs/tools/music-generation.md
@@ -274,8 +274,8 @@ explicit `model`, `primary`, and `fallbacks` entries.
   </Accordion>
   <Accordion title="MiniMax">
     Uses the batch `music_generation` endpoint. Supports prompt, optional
-    lyrics, instrumental mode, duration steering, and mp3 output through
-    either `minimax` API-key auth or `minimax-portal` OAuth.
+    lyrics, instrumental mode, and mp3 output through either `minimax`
+    API-key auth or `minimax-portal` OAuth.
   </Accordion>
   <Accordion title="OpenRouter">
     Uses OpenRouter chat completions audio output with streaming enabled. The

--- a/docs/tools/music-generation.md
+++ b/docs/tools/music-generation.md
@@ -94,13 +94,13 @@ Generate an energetic chiptune loop about launching a rocket at sunrise.
 
 ## Supported providers
 
-| Provider   | Default model                | Reference inputs | Supported controls                                        | Auth                                   |
-| ---------- | ---------------------------- | ---------------- | --------------------------------------------------------- | -------------------------------------- |
-| ComfyUI    | `workflow`                   | Up to 1 image    | Workflow-defined music or audio                           | `COMFY_API_KEY`, `COMFY_CLOUD_API_KEY` |
-| fal        | `fal-ai/minimax-music/v2.6`  | None             | `lyrics`, `instrumental`, `durationSeconds`, `format`     | `FAL_KEY` or `FAL_API_KEY`             |
-| Google     | `lyria-3-clip-preview`       | Up to 10 images  | `lyrics`, `instrumental`, `format`                        | `GEMINI_API_KEY`, `GOOGLE_API_KEY`     |
-| MiniMax    | `music-2.6`                  | None             | `lyrics`, `instrumental`, `durationSeconds`, `format=mp3` | `MINIMAX_API_KEY` or MiniMax OAuth     |
-| OpenRouter | `google/lyria-3-pro-preview` | Up to 1 image    | `lyrics`, `instrumental`, `durationSeconds`, `format`     | `OPENROUTER_API_KEY`                   |
+| Provider   | Default model                | Reference inputs | Supported controls                                    | Auth                                   |
+| ---------- | ---------------------------- | ---------------- | ----------------------------------------------------- | -------------------------------------- |
+| ComfyUI    | `workflow`                   | Up to 1 image    | Workflow-defined music or audio                       | `COMFY_API_KEY`, `COMFY_CLOUD_API_KEY` |
+| fal        | `fal-ai/minimax-music/v2.6`  | None             | `lyrics`, `instrumental`, `durationSeconds`, `format` | `FAL_KEY` or `FAL_API_KEY`             |
+| Google     | `lyria-3-clip-preview`       | Up to 10 images  | `lyrics`, `instrumental`, `format`                    | `GEMINI_API_KEY`, `GOOGLE_API_KEY`     |
+| MiniMax    | `music-2.6`                  | None             | `lyrics`, `instrumental`, `format=mp3`                | `MINIMAX_API_KEY` or MiniMax OAuth     |
+| OpenRouter | `google/lyria-3-pro-preview` | Up to 1 image    | `lyrics`, `instrumental`, `durationSeconds`, `format` | `OPENROUTER_API_KEY`                   |
 
 ### Capability matrix
 

--- a/extensions/minimax/music-generation-provider.test.ts
+++ b/extensions/minimax/music-generation-provider.test.ts
@@ -75,6 +75,9 @@ describe("minimax music generation provider", () => {
     expect(request.url).toBe("https://api.minimax.io/v1/music_generation");
     const body = request.body as Record<string, unknown>;
     expect(body.model).toBe("music-2.6");
+    expect(body.prompt).toBe("upbeat dance-pop with female vocals");
+    expect(body.prompt).not.toContain("Target duration");
+    expect(body).not.toHaveProperty("duration");
     expect(body.lyrics).toBe("our city wakes");
     expect(body.output_format).toBe("url");
     expect(body.audio_setting).toEqual({
@@ -89,6 +92,7 @@ describe("minimax music generation provider", () => {
     expect(result.lyrics).toEqual(["our city wakes"]);
     expect(result.metadata?.taskId).toBe("task-123");
     expect(result.metadata?.audioUrl).toBe("https://example.com/out.mp3");
+    expect(result.metadata).not.toHaveProperty("requestedDurationSeconds");
   });
 
   it("downloads tracks when url output is returned in data.audio", async () => {

--- a/extensions/minimax/music-generation-provider.ts
+++ b/extensions/minimax/music-generation-provider.ts
@@ -2,7 +2,6 @@ import { extensionForMime } from "openclaw/plugin-sdk/media-mime";
 import type {
   GeneratedMusicAsset,
   MusicGenerationProvider,
-  MusicGenerationRequest,
 } from "openclaw/plugin-sdk/music-generation";
 import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
@@ -106,14 +105,6 @@ async function downloadTrackFromUrl(params: {
   };
 }
 
-function buildPrompt(req: MusicGenerationRequest): string {
-  const parts = [req.prompt.trim()];
-  if (typeof req.durationSeconds === "number" && Number.isFinite(req.durationSeconds)) {
-    parts.push(`Target duration: about ${Math.max(1, Math.round(req.durationSeconds))} seconds.`);
-  }
-  return parts.join("\n\n");
-}
-
 function resolveMinimaxMusicModel(model: string | undefined): string {
   const trimmed = normalizeOptionalString(model);
   if (!trimmed) {
@@ -138,7 +129,6 @@ function buildMinimaxMusicProvider(providerId: string): MusicGenerationProvider 
         maxTracks: 1,
         supportsLyrics: true,
         supportsInstrumental: true,
-        supportsDuration: true,
         supportsFormat: true,
         supportedFormats: ["mp3"],
       },
@@ -187,7 +177,7 @@ function buildMinimaxMusicProvider(providerId: string): MusicGenerationProvider 
       const lyrics = normalizeOptionalString(req.lyrics);
       const body = {
         model,
-        prompt: buildPrompt(req),
+        prompt: req.prompt.trim(),
         ...(req.instrumental === true ? { is_instrumental: true } : {}),
         ...(lyrics ? { lyrics } : req.instrumental === true ? {} : { lyrics_optimizer: true }),
         output_format: "url",
@@ -251,9 +241,6 @@ function buildMinimaxMusicProvider(providerId: string): MusicGenerationProvider 
             ...(audioUrl ? { audioUrl } : {}),
             instrumental: req.instrumental === true,
             ...(lyrics ? { requestedLyrics: true } : {}),
-            ...(typeof req.durationSeconds === "number"
-              ? { requestedDurationSeconds: req.durationSeconds }
-              : {}),
           },
         };
       } finally {


### PR DESCRIPTION
## Summary

- Stop MiniMax music generation from advertising `durationSeconds` support because the official MiniMax `/v1/music_generation` request contract does not document a duration field.
- Send the MiniMax prompt as authored instead of appending a duration hint that the provider cannot enforce.
- Update MiniMax provider tests and music generation docs so the exposed controls match runtime behavior.

Fixes #84508

## Root Cause

The MiniMax music provider claimed `supportsDuration: true`, but `durationSeconds` was only converted into prompt text. That made the shared `music_generate` capability advertise a runtime control that MiniMax does not actually enforce through a documented structured API field.

## Why This Is Safe

This narrows the advertised MiniMax capability to match the vendor API contract and existing runtime behavior. Callers that request duration through the shared music generation runtime now get the normal unsupported-override handling instead of a misleading MiniMax-specific prompt hint.

Security/runtime controls are unchanged: provider authentication, HTTP request configuration, private-network blocking, response validation, download handling, and mp3-only format validation are untouched.

## Real behavior proof

Behavior addressed: MiniMax music generation no longer advertises durationSeconds support because the official MiniMax `/v1/music_generation` API contract does not document a duration request field.

Real environment tested: Local macOS checkout with `MINIMAX_API_KEY` configured from `.env`, using the patched provider code. Secret values were not printed; the live provider log is redacted.

Exact steps or command run after this patch:

```bash
node --import tsx --input-type=module - <<'NODE'
import { buildMinimaxMusicGenerationProvider } from './extensions/minimax/music-generation-provider.ts';
import { resolveMusicGenerationOverrides } from './src/music-generation/normalization.ts';

const provider = buildMinimaxMusicGenerationProvider();
const generateCaps = provider.capabilities.generate;
const resolved = resolveMusicGenerationOverrides({
  provider,
  model: 'music-2.6',
  durationSeconds: 30,
  format: 'mp3',
});

console.log(JSON.stringify({
  provider: provider.id,
  model: 'music-2.6',
  advertisedControls: {
    supportsLyrics: generateCaps?.supportsLyrics === true,
    supportsInstrumental: generateCaps?.supportsInstrumental === true,
    supportsDuration: generateCaps?.supportsDuration === true,
    supportsFormat: generateCaps?.supportsFormat === true,
    supportedFormats: generateCaps?.supportedFormats ?? [],
  },
  requestedOverrides: { durationSeconds: 30, format: 'mp3' },
  sanitizedRequest: {
    durationSeconds: resolved.durationSeconds ?? null,
    format: resolved.format ?? null,
  },
  ignoredOverrides: resolved.ignoredOverrides,
}, null, 2));
NODE

pnpm test extensions/minimax/music-generation-provider.test.ts
OPENCLAW_LIVE_TEST=1 OPENCLAW_LIVE_TEST_QUIET=0 OPENCLAW_LIVE_MUSIC_GENERATION_PROVIDERS=minimax pnpm test:live -- extensions/music-generation-providers.live.test.ts --reporter=verbose
```

Capability and ignored-override evidence after fix:

```json
{
  "provider": "minimax",
  "model": "music-2.6",
  "advertisedControls": {
    "supportsLyrics": true,
    "supportsInstrumental": true,
    "supportsDuration": false,
    "supportsFormat": true,
    "supportedFormats": [
      "mp3"
    ]
  },
  "requestedOverrides": {
    "durationSeconds": 30,
    "format": "mp3"
  },
  "sanitizedRequest": {
    "durationSeconds": null,
    "format": "mp3"
  },
  "ignoredOverrides": [
    {
      "key": "durationSeconds",
      "value": 30
    }
  ]
}
```

Live MiniMax generation evidence after fix:

```text
$ node scripts/test-live.mjs -- extensions/music-generation-providers.live.test.ts --reporter=verbose

 RUN  v4.1.6 /Users/neeravmakwana/Desktop/github_repos/openclaw_repo_prrefresh

[test:live] still running (40s elapsed, 39s since last output)
[test:live] still running (60s elapsed, 20s since last output)
[live:music-generation] attempted=minimax:generate:music-2.6 (env: MINIMAX_API_KEY [redacted]) skipped=none failures=none shellEnv=none
 ✓ extensions/music-generation-providers.live.test.ts > music generation provider live > covers generate plus declared edit paths with shell/profile auth 60367ms

 Test Files  1 passed (1)
      Tests  1 passed (1)
   Start at  09:17:15
   Duration  68.90s (transform 6.20s, setup 237ms, import 8.17s, tests 60.37s, environment 0ms)
```

Observed result after fix: MiniMax no longer advertises duration support, the shared runtime normalization drops `durationSeconds` and records it as an ignored override, and MiniMax still generates an audio track successfully through the live provider path.

What was not tested: I did not verify MiniMax duration control because the official MiniMax API reference does not expose a documented duration request parameter.

## Verification

- `pnpm docs:list`
- `git diff --check`
- `pnpm test extensions/minimax/music-generation-provider.test.ts`
- `pnpm check:changed`
- `node --import tsx --input-type=module ...` capability/ignored-override proof shown above
- `OPENCLAW_LIVE_TEST=1 OPENCLAW_LIVE_TEST_QUIET=0 OPENCLAW_LIVE_MUSIC_GENERATION_PROVIDERS=minimax pnpm test:live -- extensions/music-generation-providers.live.test.ts --reporter=verbose`

## Out of Scope

- Adding a MiniMax duration request field if MiniMax later documents one.
- Refactoring MiniMax music generation into async task polling.
- Changing other music providers that already have documented duration controls.