### PR TITLE
test(browser): cover action input cli commands

### DIFF
--- a/extensions/browser/src/cli/browser-cli-actions-input/register.element.test.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/register.element.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { getBrowserCliRuntime } from "../browser-cli.test-support.js";
+import {
+  createActionInputProgram,
+  getActionInputCallBrowserRequestMock,
+  getLastActionInputOptions,
+  getLastActionInputRequest,
+  resetActionInputTestState,
+} from "./register.test-helpers.js";
+
+describe("browser action input element commands", () => {
+  beforeEach(() => {
+    resetActionInputTestState();
+  });
+
+  it("sends click bodies with ref, modifiers, target, and profile", async () => {
+    const program = createActionInputProgram();
+
+    await program.parseAsync(
+      [
+        "browser",
+        "--browser-profile",
+        "work",
+        "click",
+        "ref-1",
+        "--target-id",
+        "tab-1",
+        "--double",
+        "--button",
+        "right",
+        "--modifiers",
+        "Shift, Alt,,",
+      ],
+      { from: "user" },
+    );
+
+    expect(getLastActionInputRequest()).toMatchObject({
+      method: "POST",
+      path: "/act",
+      query: { profile: "work" },
+      body: {
+        kind: "click",
+        ref: "ref-1",
+        targetId: "tab-1",
+        doubleClick: true,
+        button: "right",
+        modifiers: ["Shift", "Alt"],
+      },
+    });
+  });
+
+  it.each([
+    { command: "click", argv: ["browser", "click", "   "] },
+    { command: "type", argv: ["browser", "type", "   ", "hello"] },
+    { command: "scrollintoview", argv: ["browser", "scrollintoview", "   "] },
+  ])("rejects blank $command refs before sending a browser action", async ({ argv }) => {
+    const program = createActionInputProgram();
+
+    await program.parseAsync(argv, { from: "user" });
+
+    expect(getActionInputCallBrowserRequestMock()).not.toHaveBeenCalled();
+    expect(String(getBrowserCliRuntime().error.mock.calls.at(-1)?.[0])).toContain(
+      "ref is required",
+    );
+    expect(getBrowserCliRuntime().exit).toHaveBeenLastCalledWith(1);
+  });
+
+  it.each([
+    {
+      name: "click-coords",
+      argv: [
+        "browser",
+        "click-coords",
+        "12",
+        "34",
+        "--target-id",
+        "tab-2",
+        "--double",
+        "--button",
+        "middle",
+        "--delay-ms",
+        "75",
+      ],
+      expectedBody: {
+        kind: "clickCoords",
+        x: 12,
+        y: 34,
+        targetId: "tab-2",
+        doubleClick: true,
+        button: "middle",
+        delayMs: 75,
+      },
+    },
+    {
+      name: "type",
+      argv: ["browser", "type", "ref-2", "hello", "--submit", "--slowly", "--target-id", "tab-3"],
+      expectedBody: {
+        kind: "type",
+        ref: "ref-2",
+        text: "hello",
+        submit: true,
+        slowly: true,
+        targetId: "tab-3",
+      },
+    },
+    {
+      name: "press",
+      argv: ["browser", "press", "Enter", "--target-id", "tab-4"],
+      expectedBody: { kind: "press", key: "Enter", targetId: "tab-4" },
+    },
+    {
+      name: "hover",
+      argv: ["browser", "hover", "ref-3", "--target-id", "tab-5"],
+      expectedBody: { kind: "hover", ref: "ref-3", targetId: "tab-5" },
+    },
+    {
+      name: "drag",
+      argv: ["browser", "drag", "start-ref", "end-ref", "--target-id", "tab-7"],
+      expectedBody: {
+        kind: "drag",
+        startRef: "start-ref",
+        endRef: "end-ref",
+        targetId: "tab-7",
+      },
+    },
+    {
+      name: "select",
+      argv: ["browser", "select", "ref-8", "one", "two", "--target-id", "tab-8"],
+      expectedBody: { kind: "select", ref: "ref-8", values: ["one", "two"], targetId: "tab-8" },
+    },
+  ])("sends $name action bodies", async ({ argv, expectedBody }) => {
+    const program = createActionInputProgram();
+
+    await program.parseAsync(argv, { from: "user" });
+
+    expect(getLastActionInputRequest()).toMatchObject({
+      method: "POST",
+      path: "/act",
+      body: expectedBody,
+    });
+  });
+
+  it("sends scrollintoview timeouts on the action body and outer request", async () => {
+    const program = createActionInputProgram();
+
+    await program.parseAsync(
+      ["browser", "scrollintoview", "ref-4", "--target-id", "tab-6", "--timeout-ms", "1234"],
+      { from: "user" },
+    );
+
+    expect(getLastActionInputRequest()).toMatchObject({
+      method: "POST",
+      path: "/act",
+      body: {
+        kind: "scrollIntoView",
+        ref: "ref-4",
+        targetId: "tab-6",
+        timeoutMs: 1234,
+      },
+    });
+    expect(getLastActionInputOptions()?.timeoutMs).toBe(6234);
+  });
+});

--- a/extensions/browser/src/cli/browser-cli-actions-input/register.files-downloads.test.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/register.files-downloads.test.ts
@@ -1,74 +1,192 @@
-import { Command } from "commander";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import * as browserCliSharedModule from "../browser-cli-shared.js";
-import {
-  createBrowserProgram,
-  getBrowserCliRuntime,
-  getBrowserCliRuntimeCapture,
-} from "../browser-cli.test-support.js";
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { beforeEach, describe, expect, it } from "vitest";
+import { getBrowserCliRuntime } from "../browser-cli.test-support.js";
 import * as cliCoreApiModule from "../core-api.js";
-
-const mocks = vi.hoisted(() => ({
-  callBrowserRequest: vi.fn<
-    (
-      _opts: unknown,
-      req: { path?: string },
-      extra?: { timeoutMs?: number },
-    ) => Promise<Record<string, unknown>>
-  >(async (_opts: unknown, req: { path?: string }) =>
-    req.path === "/wait/download" || req.path === "/download"
-      ? { download: { path: "/tmp/openclaw/downloads/file.txt" } }
-      : { ok: true },
-  ),
-}));
-
-vi.spyOn(browserCliSharedModule, "callBrowserRequest").mockImplementation(mocks.callBrowserRequest);
-const browserCliRuntime = getBrowserCliRuntime();
-vi.spyOn(cliCoreApiModule.defaultRuntime, "log").mockImplementation(browserCliRuntime.log);
-vi.spyOn(cliCoreApiModule.defaultRuntime, "writeJson").mockImplementation(
-  browserCliRuntime.writeJson,
-);
-vi.spyOn(cliCoreApiModule.defaultRuntime, "error").mockImplementation(browserCliRuntime.error);
-vi.spyOn(cliCoreApiModule.defaultRuntime, "exit").mockImplementation(browserCliRuntime.exit);
-
-const { registerBrowserActionInputCommands } = await import("./register.js");
-
-function createActionInputProgram(): Command {
-  const { program, browser, parentOpts } = createBrowserProgram();
-  registerBrowserActionInputCommands(browser, parentOpts);
-  return program;
-}
-
-function getLastRequestOptions(): { timeoutMs?: number } | undefined {
-  return mocks.callBrowserRequest.mock.calls.at(-1)?.[2] as { timeoutMs?: number } | undefined;
-}
+import {
+  createActionInputProgram,
+  getActionInputCallBrowserRequestMock,
+  getLastActionInputOptions,
+  getLastActionInputRequest,
+  resetActionInputTestState,
+} from "./register.test-helpers.js";
 
 describe("browser action input file/download commands", () => {
   beforeEach(() => {
-    mocks.callBrowserRequest.mockClear();
-    getBrowserCliRuntimeCapture().resetRuntimeCapture();
-    getBrowserCliRuntime().exit.mockImplementation(() => {});
+    resetActionInputTestState();
   });
 
-  it("keeps the outer waitfordownload request open for the advertised default wait", async () => {
-    const program = createActionInputProgram();
-
-    await program.parseAsync(["browser", "waitfordownload"], { from: "user" });
-
-    expect(getLastRequestOptions()?.timeoutMs).toBeGreaterThan(120000);
-  });
-
-  it("uses custom download timeouts as the inner wait plus outer slack", async () => {
+  it("sends waitfordownload path, target, and timeout to the download wait endpoint", async () => {
     const program = createActionInputProgram();
 
     await program.parseAsync(
-      ["browser", "download", "ref-1", "file.txt", "--timeout-ms", "25000"],
+      [
+        "browser",
+        "waitfordownload",
+        "downloads/report.pdf",
+        "--target-id",
+        "tab-download",
+        "--timeout-ms",
+        "45000",
+      ],
+      { from: "user" },
+    );
+
+    expect(getLastActionInputRequest()).toMatchObject({
+      method: "POST",
+      path: "/wait/download",
+      body: {
+        path: "downloads/report.pdf",
+        targetId: "tab-download",
+        timeoutMs: 45000,
+      },
+    });
+    expect(getLastActionInputOptions()?.timeoutMs).toBe(50000);
+  });
+
+  it("sends download ref, path, target, and timeout to the download endpoint", async () => {
+    const program = createActionInputProgram();
+
+    await program.parseAsync(
+      [
+        "browser",
+        "download",
+        "ref-1",
+        "file.txt",
+        "--target-id",
+        "tab-click-download",
+        "--timeout-ms",
+        "25000",
+      ],
       {
         from: "user",
       },
     );
 
-    expect(getLastRequestOptions()?.timeoutMs).toBeGreaterThan(25000);
+    expect(getLastActionInputRequest()).toMatchObject({
+      method: "POST",
+      path: "/download",
+      body: {
+        ref: "ref-1",
+        path: "file.txt",
+        targetId: "tab-click-download",
+        timeoutMs: 25000,
+      },
+    });
+    expect(getLastActionInputOptions()?.timeoutMs).toBe(30000);
+  });
+
+  it("sends upload paths and selectors to the file chooser hook", async () => {
+    const program = createActionInputProgram();
+    const uploadPath = path.join(
+      cliCoreApiModule.DEFAULT_UPLOAD_DIR,
+      `vitest-upload-${process.pid}-${randomUUID()}.txt`,
+    );
+    await fs.mkdir(cliCoreApiModule.DEFAULT_UPLOAD_DIR, { recursive: true });
+    await fs.writeFile(uploadPath, "upload body");
+    const canonicalUploadPath = await fs.realpath(uploadPath);
+
+    try {
+      await program.parseAsync(
+        [
+          "browser",
+          "upload",
+          uploadPath,
+          "--ref",
+          "button-ref",
+          "--input-ref",
+          "input-ref",
+          "--element",
+          "input[type=file]",
+          "--target-id",
+          "tab-1",
+          "--timeout-ms",
+          "15000",
+        ],
+        { from: "user" },
+      );
+    } finally {
+      await fs.rm(uploadPath, { force: true });
+    }
+
+    expect(getLastActionInputRequest()).toMatchObject({
+      path: "/hooks/file-chooser",
+      body: {
+        paths: [canonicalUploadPath],
+        ref: "button-ref",
+        inputRef: "input-ref",
+        element: "input[type=file]",
+        targetId: "tab-1",
+        timeoutMs: 15000,
+      },
+    });
+    expect(getLastActionInputOptions()?.timeoutMs).toBe(20000);
+  });
+
+  it("sends dialog actions to the dialog hook", async () => {
+    const program = createActionInputProgram();
+
+    await program.parseAsync(
+      [
+        "browser",
+        "dialog",
+        "--accept",
+        "--prompt",
+        "approved",
+        "--dialog-id",
+        "dialog-1",
+        "--target-id",
+        "tab-dialog",
+        "--timeout-ms",
+        "16000",
+      ],
+      { from: "user" },
+    );
+
+    expect(getLastActionInputRequest()).toMatchObject({
+      method: "POST",
+      path: "/hooks/dialog",
+      body: {
+        accept: true,
+        promptText: "approved",
+        dialogId: "dialog-1",
+        targetId: "tab-dialog",
+        timeoutMs: 16000,
+      },
+    });
+    expect(getLastActionInputOptions()?.timeoutMs).toBe(21000);
+  });
+
+  it("sends dismiss dialog actions to the dialog hook", async () => {
+    const program = createActionInputProgram();
+
+    await program.parseAsync(
+      ["browser", "dialog", "--dismiss", "--dialog-id", "dialog-2", "--target-id", "tab-dialog"],
+      { from: "user" },
+    );
+
+    expect(getLastActionInputRequest()).toMatchObject({
+      method: "POST",
+      path: "/hooks/dialog",
+      body: {
+        accept: false,
+        dialogId: "dialog-2",
+        targetId: "tab-dialog",
+      },
+    });
+    expect(getLastActionInputOptions()?.timeoutMs).toBe(125000);
+  });
+
+  it("rejects missing dialog actions without arming the hook", async () => {
+    const program = createActionInputProgram();
+
+    await program.parseAsync(["browser", "dialog"], { from: "user" });
+
+    const errorCall = getBrowserCliRuntime().error.mock.calls.at(-1);
+    expect(getActionInputCallBrowserRequestMock()).not.toHaveBeenCalled();
+    expect(String(errorCall?.[0])).toContain("Specify --accept or --dismiss");
+    expect(getBrowserCliRuntime().exit).toHaveBeenLastCalledWith(1);
   });
 
   it("rejects conflicting dialog actions without arming the hook", async () => {
@@ -77,8 +195,8 @@ describe("browser action input file/download commands", () => {
     await program.parseAsync(["browser", "dialog", "--accept", "--dismiss"], { from: "user" });
 
     const errorCall = getBrowserCliRuntime().error.mock.calls.at(-1);
-    expect(mocks.callBrowserRequest).not.toHaveBeenCalled();
+    expect(getActionInputCallBrowserRequestMock()).not.toHaveBeenCalled();
     expect(String(errorCall?.[0])).toContain("Specify only one of --accept or --dismiss");
-    expect(getBrowserCliRuntime().exit).toHaveBeenCalledWith(1);
+    expect(getBrowserCliRuntime().exit).toHaveBeenLastCalledWith(1);
   });
 });

--- a/extensions/browser/src/cli/browser-cli-actions-input/register.form-wait-eval.test.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/register.form-wait-eval.test.ts
@@ -1,92 +1,184 @@
-import { Command } from "commander";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import * as browserCliSharedModule from "../browser-cli-shared.js";
+import { beforeEach, describe, expect, it } from "vitest";
+import { getBrowserCliRuntime } from "../browser-cli.test-support.js";
 import {
-  createBrowserProgram,
-  getBrowserCliRuntime,
-  getBrowserCliRuntimeCapture,
-} from "../browser-cli.test-support.js";
-import * as cliCoreApiModule from "../core-api.js";
-
-const mocks = vi.hoisted(() => ({
-  callBrowserRequest: vi.fn<
-    (
-      opts?: unknown,
-      req?: unknown,
-      extra?: { timeoutMs?: number },
-    ) => Promise<Record<string, unknown>>
-  >(async () => ({ result: true })),
-}));
-
-vi.spyOn(browserCliSharedModule, "callBrowserRequest").mockImplementation(mocks.callBrowserRequest);
-const browserCliRuntime = getBrowserCliRuntime();
-vi.spyOn(cliCoreApiModule.defaultRuntime, "log").mockImplementation(browserCliRuntime.log);
-vi.spyOn(cliCoreApiModule.defaultRuntime, "writeJson").mockImplementation(
-  browserCliRuntime.writeJson,
-);
-vi.spyOn(cliCoreApiModule.defaultRuntime, "error").mockImplementation(browserCliRuntime.error);
-vi.spyOn(cliCoreApiModule.defaultRuntime, "exit").mockImplementation(browserCliRuntime.exit);
-
-const { registerBrowserActionInputCommands } = await import("./register.js");
-
-function createActionInputProgram(): Command {
-  const { program, browser, parentOpts } = createBrowserProgram();
-  registerBrowserActionInputCommands(browser, parentOpts);
-  return program;
-}
+  createActionInputProgram,
+  getActionInputCallBrowserRequestMock,
+  getLastActionInputOptions,
+  getLastActionInputRequest,
+  resetActionInputTestState,
+} from "./register.test-helpers.js";
 
 describe("browser action input wait command", () => {
   beforeEach(() => {
-    mocks.callBrowserRequest.mockClear();
-    getBrowserCliRuntimeCapture().resetRuntimeCapture();
+    resetActionInputTestState();
   });
 
-  it("keeps the outer request open longer than a time-based wait", async () => {
+  it("sends time-only waits on the action body and keeps the outer request open", async () => {
     const program = createActionInputProgram();
 
-    await program.parseAsync(["browser", "wait", "--time", "25000"], { from: "user" });
-
-    const options = mocks.callBrowserRequest.mock.calls.at(-1)?.[2] as
-      | { timeoutMs?: number }
-      | undefined;
-    expect(options?.timeoutMs).toBeGreaterThan(25000);
-  });
-
-  it("keeps the outer request open for time delay plus condition timeout", async () => {
-    const program = createActionInputProgram();
-
-    await program.parseAsync(["browser", "wait", "--time", "1000", "--text", "Ready"], {
+    await program.parseAsync(["browser", "wait", "--time", "25000", "--target-id", "tab-time"], {
       from: "user",
     });
 
-    const options = mocks.callBrowserRequest.mock.calls.at(-1)?.[2] as
-      | { timeoutMs?: number }
-      | undefined;
-    expect(options?.timeoutMs).toBeGreaterThan(21000);
+    expect(getLastActionInputRequest()).toMatchObject({
+      method: "POST",
+      path: "/act",
+      body: {
+        kind: "wait",
+        timeMs: 25000,
+        targetId: "tab-time",
+      },
+    });
+    expect(getLastActionInputOptions()?.timeoutMs).toBe(30000);
+  });
+
+  it("sends conditional wait fields and exact timeout slack", async () => {
+    const program = createActionInputProgram();
+
+    await program.parseAsync(
+      [
+        "browser",
+        "--browser-profile",
+        "work",
+        "wait",
+        "main.ready",
+        "--time",
+        "25000",
+        "--text",
+        "Ready",
+        "--url",
+        "**/dash",
+        "--load",
+        "networkidle",
+        "--fn",
+        "() => window.ready === true",
+        "--target-id",
+        "tab-wait",
+        "--timeout-ms",
+        "7000",
+      ],
+      { from: "user" },
+    );
+
+    expect(getLastActionInputRequest()).toMatchObject({
+      method: "POST",
+      path: "/act",
+      query: { profile: "work" },
+      body: {
+        kind: "wait",
+        timeMs: 25000,
+        selector: "main.ready",
+        text: "Ready",
+        url: "**/dash",
+        loadState: "networkidle",
+        fn: "() => window.ready === true",
+        targetId: "tab-wait",
+        timeoutMs: 7000,
+      },
+    });
+    expect(getLastActionInputOptions()?.timeoutMs).toBe(65000);
+  });
+
+  it("sends text-gone wait fields and timeout slack", async () => {
+    const program = createActionInputProgram();
+
+    await program.parseAsync(
+      [
+        "browser",
+        "wait",
+        "--text-gone",
+        "Loading",
+        "--target-id",
+        "tab-gone",
+        "--timeout-ms",
+        "9000",
+      ],
+      { from: "user" },
+    );
+
+    expect(getLastActionInputRequest()).toMatchObject({
+      method: "POST",
+      path: "/act",
+      body: {
+        kind: "wait",
+        textGone: "Loading",
+        targetId: "tab-gone",
+        timeoutMs: 9000,
+      },
+    });
+    expect(getLastActionInputOptions()?.timeoutMs).toBe(14000);
+  });
+});
+
+describe("browser action input fill command", () => {
+  beforeEach(() => {
+    resetActionInputTestState();
+  });
+
+  it("sends fill fields and target id to the browser action endpoint", async () => {
+    const program = createActionInputProgram();
+
+    await program.parseAsync(
+      [
+        "browser",
+        "fill",
+        "--fields",
+        '[{"ref":"email","type":"textbox","value":"hello@example.test"}]',
+        "--target-id",
+        "tab-1",
+      ],
+      { from: "user" },
+    );
+
+    expect(getLastActionInputRequest().body).toMatchObject({
+      kind: "fill",
+      fields: [{ ref: "email", type: "textbox", value: "hello@example.test" }],
+      targetId: "tab-1",
+    });
   });
 });
 
 describe("browser action input evaluate command", () => {
   beforeEach(() => {
-    mocks.callBrowserRequest.mockClear();
-    getBrowserCliRuntimeCapture().resetRuntimeCapture();
+    resetActionInputTestState();
   });
 
-  it("passes timeout-ms through to the evaluate action and outer request", async () => {
+  it("passes fn, ref, target, and timeout through to the evaluate action", async () => {
     const program = createActionInputProgram();
 
     await program.parseAsync(
-      ["browser", "evaluate", "--fn", "() => true", "--timeout-ms", "30000"],
+      [
+        "browser",
+        "evaluate",
+        "--fn",
+        "(el) => el.textContent",
+        "--ref",
+        "ref-1",
+        "--target-id",
+        "tab-2",
+        "--timeout-ms",
+        "30000",
+      ],
       { from: "user" },
     );
 
-    const request = mocks.callBrowserRequest.mock.calls.at(-1)?.[1] as
-      | { body?: { timeoutMs?: number } }
-      | undefined;
-    const options = mocks.callBrowserRequest.mock.calls.at(-1)?.[2] as
-      | { timeoutMs?: number }
-      | undefined;
-    expect(request?.body?.timeoutMs).toBe(30000);
-    expect(options?.timeoutMs).toBeGreaterThan(30000);
+    expect(getLastActionInputRequest().body).toMatchObject({
+      kind: "evaluate",
+      fn: "(el) => el.textContent",
+      ref: "ref-1",
+      targetId: "tab-2",
+      timeoutMs: 30000,
+    });
+    expect(getLastActionInputOptions()?.timeoutMs).toBe(35000);
+  });
+
+  it("rejects evaluate without --fn before sending a browser action", async () => {
+    const program = createActionInputProgram();
+
+    await program.parseAsync(["browser", "evaluate", "--target-id", "tab-2"], { from: "user" });
+
+    expect(getActionInputCallBrowserRequestMock()).not.toHaveBeenCalled();
+    expect(String(getBrowserCliRuntime().error.mock.calls.at(-1)?.[0])).toContain("Missing --fn");
+    expect(getBrowserCliRuntime().exit).toHaveBeenLastCalledWith(1);
   });
 });

--- a/extensions/browser/src/cli/browser-cli-actions-input/register.navigation.test.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/register.navigation.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { getBrowserCliRuntime } from "../browser-cli.test-support.js";
+import {
+  createActionInputProgram,
+  getActionInputResizeMock,
+  getLastActionInputOptions,
+  getLastActionInputRequest,
+  resetActionInputTestState,
+} from "./register.test-helpers.js";
+
+describe("browser action input navigation commands", () => {
+  beforeEach(() => {
+    resetActionInputTestState();
+  });
+
+  it("sends navigate requests with URL, target, profile, and timeout", async () => {
+    const program = createActionInputProgram();
+
+    await program.parseAsync(
+      [
+        "browser",
+        "--browser-profile",
+        "work",
+        "navigate",
+        "https://example.test",
+        "--target-id",
+        "tab-1",
+      ],
+      { from: "user" },
+    );
+
+    expect(getLastActionInputRequest()).toMatchObject({
+      method: "POST",
+      path: "/navigate",
+      query: { profile: "work" },
+      body: {
+        url: "https://example.test",
+        targetId: "tab-1",
+      },
+    });
+    expect(getLastActionInputOptions()?.timeoutMs).toBe(20000);
+    expect(getBrowserCliRuntime().log).toHaveBeenCalledWith(
+      "navigated to https://example.test/after-navigation",
+    );
+  });
+
+  it("passes resize dimensions, target, profile, and timeout to the resize runner", async () => {
+    const program = createActionInputProgram();
+
+    await program.parseAsync(
+      ["browser", "--browser-profile", "work", "resize", "1280", "720", "--target-id", "tab-2"],
+      { from: "user" },
+    );
+
+    expect(getActionInputResizeMock()).toHaveBeenCalledWith({
+      parent: expect.objectContaining({ browserProfile: "work" }),
+      profile: "work",
+      width: 1280,
+      height: 720,
+      targetId: "tab-2",
+      timeoutMs: 20000,
+      successMessage: "resized to 1280x720",
+    });
+  });
+});

--- a/extensions/browser/src/cli/browser-cli-actions-input/register.test-helpers.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/register.test-helpers.ts
@@ -1,0 +1,111 @@
+import type { Command } from "commander";
+import { vi } from "vitest";
+import * as browserCliResizeModule from "../browser-cli-resize.js";
+import * as browserCliSharedModule from "../browser-cli-shared.js";
+import {
+  createBrowserProgram,
+  getBrowserCliRuntime,
+  getBrowserCliRuntimeCapture,
+} from "../browser-cli.test-support.js";
+import * as cliCoreApiModule from "../core-api.js";
+
+export type BrowserActionRequest = {
+  method?: string;
+  path?: string;
+  query?: Record<string, string>;
+  body?: Record<string, unknown>;
+};
+
+export type BrowserActionRuntimeOptions = { timeoutMs?: number };
+
+type BrowserActionCall = [
+  unknown,
+  BrowserActionRequest | undefined,
+  BrowserActionRuntimeOptions | undefined,
+];
+
+const actionInputMocks = vi.hoisted(() => ({
+  callBrowserRequest: vi.fn<
+    (
+      _opts?: unknown,
+      _req?: BrowserActionRequest,
+      _extra?: BrowserActionRuntimeOptions,
+    ) => Promise<Record<string, unknown>>
+  >(async (_opts, req) => ({
+    download: { path: "/tmp/openclaw/downloads/file.txt" },
+    ok: true,
+    result: true,
+    url:
+      req?.path === "/navigate"
+        ? "https://example.test/after-navigation"
+        : "https://example.test/after-action",
+  })),
+  runBrowserResizeWithOutput: vi.fn(async (_params: unknown) => {}),
+}));
+
+vi.spyOn(browserCliSharedModule, "callBrowserRequest").mockImplementation(
+  actionInputMocks.callBrowserRequest,
+);
+vi.spyOn(browserCliResizeModule, "runBrowserResizeWithOutput").mockImplementation(
+  actionInputMocks.runBrowserResizeWithOutput,
+);
+
+const browserCliRuntime = getBrowserCliRuntime();
+vi.spyOn(cliCoreApiModule.defaultRuntime, "log").mockImplementation(browserCliRuntime.log);
+vi.spyOn(cliCoreApiModule.defaultRuntime, "writeJson").mockImplementation(
+  browserCliRuntime.writeJson,
+);
+vi.spyOn(cliCoreApiModule.defaultRuntime, "writeStdout").mockImplementation(
+  browserCliRuntime.writeStdout,
+);
+vi.spyOn(cliCoreApiModule.defaultRuntime, "error").mockImplementation(browserCliRuntime.error);
+vi.spyOn(cliCoreApiModule.defaultRuntime, "exit").mockImplementation(browserCliRuntime.exit);
+
+const { registerBrowserActionInputCommands } = await import("./register.js");
+
+export function createActionInputProgram(): Command {
+  const { program, browser, parentOpts } = createBrowserProgram();
+  registerBrowserActionInputCommands(browser, parentOpts);
+  return program;
+}
+
+export function getActionInputCallBrowserRequestMock() {
+  return actionInputMocks.callBrowserRequest;
+}
+
+export function getActionInputResizeMock() {
+  return actionInputMocks.runBrowserResizeWithOutput;
+}
+
+export function getLastActionInputRequest(): BrowserActionRequest {
+  const call = actionInputMocks.callBrowserRequest.mock.calls.at(-1) as
+    | BrowserActionCall
+    | undefined;
+  if (!call) {
+    throw new Error("expected browser request call");
+  }
+  if (!call[1]) {
+    throw new Error("expected browser request params");
+  }
+  return call[1];
+}
+
+export function getLastActionInputOptions(): BrowserActionRuntimeOptions | undefined {
+  return (
+    actionInputMocks.callBrowserRequest.mock.calls.at(-1) as BrowserActionCall | undefined
+  )?.[2];
+}
+
+export function resetActionInputTestState() {
+  actionInputMocks.callBrowserRequest.mockClear();
+  actionInputMocks.runBrowserResizeWithOutput.mockClear();
+  getBrowserCliRuntimeCapture().resetRuntimeCapture();
+
+  const runtime = getBrowserCliRuntime();
+  runtime.log.mockClear();
+  runtime.error.mockClear();
+  runtime.exit.mockClear();
+  runtime.writeJson.mockClear();
+  runtime.writeStdout.mockClear();
+  runtime.exit.mockImplementation(() => {});
+}

--- a/extensions/browser/src/cli/browser-cli-actions-input/register.test-helpers.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/register.test-helpers.ts
@@ -9,14 +9,11 @@ import {
 } from "../browser-cli.test-support.js";
 import * as cliCoreApiModule from "../core-api.js";
 
-export type BrowserActionRequest = {
-  method?: string;
-  path?: string;
-  query?: Record<string, string>;
-  body?: Record<string, unknown>;
-};
+export type BrowserActionRequest = Parameters<typeof browserCliSharedModule.callBrowserRequest>[1];
 
-export type BrowserActionRuntimeOptions = { timeoutMs?: number };
+export type BrowserActionRuntimeOptions = Parameters<
+  typeof browserCliSharedModule.callBrowserRequest
+>[2];
 
 type BrowserActionCall = [
   unknown,


### PR DESCRIPTION
AI-assisted: yes. I used an AI coding assistant to help prepare the test patch, then reviewed the diff and verified the behavior locally.

## Summary

- Problem: #83877 identified that most browser action-input CLI commands had no CLI-layer test coverage, so request-body wiring and validation could regress silently.
- Solution: add focused registrar tests for element, navigation, form/wait/evaluate, file/download, and dialog action-input commands.
- What changed: added a shared action-input CLI test helper and expanded assertions for `/act`, `/download`, `/wait/download`, `/hooks/dialog`, upload path canonicalization, blank-ref validation, timeout slack, and no-request error paths.
- What did NOT change (scope boundary): no production browser CLI, browser server, gateway, auth, or runtime behavior changed. This is a test-only patch.

## Motivation

#83877 is a source-repro test-gap issue. The affected browser action-input command groups build request bodies at the CLI boundary, but prior tests only covered a few narrow cases. This patch makes the CLI request shape and validation behavior explicit in tests so future production changes in the same files have a real regression net.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #83877
- Related #84208, #84531, #74352, #83660, #81076, #74411 were checked for overlap. This PR is test-only coverage for the CLI action-input surface and does not duplicate their runtime behavior changes.
- [x] This PR fixes a bug or regression

This PR **fixes/closes #83877** by resolving the reported test-gap. It is a test-only fix: the production browser CLI/server behavior is unchanged, and the patch only adds coverage.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed:

#83877 reported a browser action-input CLI test gap. After this patch, the action-input command registration is covered by committed Vitest files, an independent coverage probe confirms the expected command/request-body tokens are present, and a direct source-registrar proof exercises the real `registerBrowserCli` Commander wiring for command help and blank-ref validation.

- Real environment tested:

Local OpenClaw checkout at `/root/repos/openclaw-83877` on Linux 6.17.0-14-generic x86_64, Node v22.22.1. Branch `nex/83877-browser-cli-tests-20260520`, commit `1029ec8d63`, rebased on `upstream/main` `ac69776330`.

- Exact steps or command run after this patch:

```bash
git diff --check upstream/main..HEAD
node scripts/run-vitest.mjs \
  extensions/browser/src/cli/browser-cli-actions-input/register.element.test.ts \
  extensions/browser/src/cli/browser-cli-actions-input/register.navigation.test.ts \
  extensions/browser/src/cli/browser-cli-actions-input/register.form-wait-eval.test.ts \
  extensions/browser/src/cli/browser-cli-actions-input/register.files-downloads.test.ts
python3 /tmp/openclaw-83877-coverage-probe.py
node --import tsx /tmp/openclaw-83877-cli-proof.mjs
```

- Evidence after fix:

Terminal capture from this branch, copied live output:

```
== hygiene after rebase ==
git status: ## nex/83877-browser-cli-tests-20260520...upstream/main [ahead 1]
1029ec8d63 test(browser): cover action input cli commands
count=1
A  extensions/browser/src/cli/browser-cli-actions-input/register.element.test.ts
M  extensions/browser/src/cli/browser-cli-actions-input/register.files-downloads.test.ts
M  extensions/browser/src/cli/browser-cli-actions-input/register.form-wait-eval.test.ts
A  extensions/browser/src/cli/browser-cli-actions-input/register.navigation.test.ts
A  extensions/browser/src/cli/browser-cli-actions-input/register.test-helpers.ts

== diff check ==

== targeted vitest ==
Test Files  4 passed (4)
Tests       26 passed (26)

== coverage probe ==
Coverage probe passed: expected browser action-input command/reviewer-gap/touch-up tokens are present in tests.

== direct registrar proof ==
PASS: click help
  argv: browser click --help
  commanderCode: commander.helpDisplayed
  tokens: Click an element by ref, --target-id, --double
PASS: navigate help
  argv: browser navigate --help
  commanderCode: commander.helpDisplayed
  tokens: Navigate, --target-id
PASS: upload help
  argv: browser upload --help
  commanderCode: commander.helpDisplayed
  tokens: Arm file upload, --input-ref, --timeout-ms
PASS: wait/download/dialog help
  argv: browser dialog --help
  commanderCode: commander.helpDisplayed
  tokens: Arm the next modal dialog, --accept, --dismiss, --dialog-id
PASS: blank click ref validation
  argv: browser click
  runtimeExit: 1
  runtimeErrors: ref is required
```

- Observed result after fix:

The branch is clean and one commit ahead of the current base. The diff contains only the intended five browser action-input test files. Targeted Vitest passes 4 files / 26 tests. The independent probe finds the expected command, request-body, helper, upload, select-ordering, and error-path coverage tokens. The direct registrar proof confirms real Commander registration/help for representative action-input commands and blank `click` ref validation exits with code 1 before a request is sent.

- What was not tested:

I did not run a full installed-plugin `pnpm openclaw browser ...` proof because this local worktree's plugin config does not load the browser root command. The direct registrar proof uses `registerBrowserCli` from source with `OPENCLAW_DISABLE_LAZY_SUBCOMMANDS=1` to exercise the real source registration path. I did not start a browser server or gateway, because this PR does not change runtime browser behavior or network contracts.

- Before evidence (optional but encouraged):

#83877 lists the missing coverage: no existing test file for `register.element.ts` or `register.navigation.ts`, and only partial coverage in the form/files tests. The issue calls out click, click-coords, type, press, hover, scrollintoview, drag, select, navigate, resize, fill, evaluate, and upload as lacking CLI-layer tests.

## Root Cause (if applicable)

- Root cause: the browser action-input CLI registrars had grown command-specific request-body and validation logic without corresponding CLI-layer tests for most commands. This is the root cause of the test-gap, not a production behavior defect.
- Missing detection / guardrail: there was no shared action-input test helper and no test files at all for the element/navigation registrars, so request shape changes could slip through unnoticed.
- Contributing context (if known): `node scripts/run-vitest.mjs` can exit successfully when explicit missing file paths are passed, so coverage-gap verification needs a separate file/token probe rather than relying only on a green targeted test command.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this test gap:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `extensions/browser/src/cli/browser-cli-actions-input/register.element.test.ts`
  - `extensions/browser/src/cli/browser-cli-actions-input/register.navigation.test.ts`
  - `extensions/browser/src/cli/browser-cli-actions-input/register.form-wait-eval.test.ts`
  - `extensions/browser/src/cli/browser-cli-actions-input/register.files-downloads.test.ts`
  - `extensions/browser/src/cli/browser-cli-actions-input/register.test-helpers.ts`
- Scenario the test should lock in: each action-input CLI command should send the expected request path/body, preserve timeout slack where applicable, reject invalid CLI input before sending requests, and keep upload path handling portable across `/tmp` realpath differences.
- Why this is the smallest reliable guardrail: the changed tests instantiate the real CLI registrar/parsers and spy the request boundary, which is exactly where this test gap existed. A full browser server is unnecessary for this test-only request-wiring coverage.
- Existing test that already covers this (if any): prior tests covered only narrow download/dialog/wait/readFields cases, not the broad command surface from #83877.
- If no new test is added, why not: N/A. New and expanded tests are added.

## User-visible / Behavior Changes

None. Test-only patch.

## Diagram (if applicable)

N/A

```text
Before:
CLI action-input command -> mostly untested request body / validation wiring

After:
CLI action-input command -> registrar test -> asserted request path/body, validation, timeout, and no-request error behavior
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux 6.17.0-14-generic x86_64
- Runtime/container: Node v22.22.1, local OpenClaw checkout
- Model/provider: N/A
- Integration/channel (if any): Browser extension CLI tests
- Relevant config (redacted): `OPENCLAW_DISABLE_LAZY_SUBCOMMANDS=1` was used only by the direct source-registrar proof so subcommand help loads the real modules instead of lazy placeholders.

### Steps

1. Rebase the branch on current `upstream/main`.
2. Run `git diff --check upstream/main..HEAD`.
3. Run the four targeted browser action-input Vitest files listed in the real behavior proof section.
4. Run the independent coverage probe and direct source-registrar proof shown above.

### Expected

- Branch is clean and one commit ahead of `upstream/main`.
- Diff contains only browser action-input test files.
- Targeted tests pass.
- Coverage probe finds the requested command/request-body/error-path tokens.
- Source registrar proof shows representative action-input commands are registered and blank refs fail before a request is sent.

### Actual

All expected checks passed for the test-gap coverage change.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: branch hygiene after rebase; diff file list; whitespace check; targeted Vitest for element, navigation, form/wait/evaluate, and files/downloads/dialog; independent probe for expected coverage tokens; direct source-registrar proof for click/navigate/upload/dialog help and blank click-ref validation.
- Edge cases checked: blank refs for click/type/scrollintoview, dialog accept/dismiss conflict and missing action, evaluate missing `--fn`, wait text-gone body, exact timeout slack, upload realpath canonicalization, random upload fixture cleanup without deleting the shared upload directory, and select positional argument ordering.
- What you did **not** verify: full installed-plugin CLI execution through `pnpm openclaw browser`, browser server/gateway runtime behavior, or unrelated adjacent browser behavior PRs.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

N/A for a new PR. No public review conversations exist yet.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: tests could become brittle around platform-specific temp-path resolution.
  - Mitigation: upload assertions use `fs.realpath(uploadPath)` and a random fixture filename instead of assuming `/tmp` string identity or deleting the shared upload directory.
- Risk: source-registrar proof could be confused by lazy subcommand placeholders.
  - Mitigation: the proof uses `OPENCLAW_DISABLE_LAZY_SUBCOMMANDS=1` and waits for dynamic imports before parsing help.
- Risk: adjacent browser behavior PRs may look related.
  - Mitigation: live overlap search checked #84208, #84531, #74352, #83660, #81076, and #74411. This patch only adds tests and does not change their runtime behavior.
