### PR TITLE
fix(feishu): improve quoted message replies and context

### DIFF
--- a/extensions/feishu/src/bot-content.ts
+++ b/extensions/feishu/src/bot-content.ts
@@ -141,6 +141,9 @@ export function parseMessageContent(content: string, messageType: string): strin
     if (messageType === "text") {
       return parsed.text || "";
     }
+    if (messageType === "interactive") {
+      return parseInteractiveMessageContent(parsed);
+    }
     if (["image", "file", "audio", "video", "media", "sticker"].includes(messageType)) {
       if (messageType === "audio") {
         const speechToText =
@@ -175,6 +178,51 @@ export function parseMessageContent(content: string, messageType: string): strin
   } catch {
     return content;
   }
+}
+
+function collectInteractiveText(value: unknown, parts: string[]): void {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectInteractiveText(item, parts);
+    }
+    return;
+  }
+  if (!value || typeof value !== "object") {
+    return;
+  }
+  const record = value as Record<string, unknown>;
+  if (typeof record.title === "string" && record.title.trim()) {
+    parts.push(record.title.trim());
+  }
+  if (typeof record.text === "string" && record.text.trim()) {
+    parts.push(record.text.trim());
+  }
+  if (typeof record.content === "string" && record.content.trim()) {
+    parts.push(record.content.trim());
+  }
+  if (record.text && typeof record.text === "object") {
+    const text = record.text as Record<string, unknown>;
+    if (typeof text.content === "string" && text.content.trim()) {
+      parts.push(text.content.trim());
+    }
+  }
+  for (const key of ["header", "body", "elements", "i18n_elements"] as const) {
+    collectInteractiveText(record[key], parts);
+  }
+}
+
+function parseInteractiveMessageContent(parsed: unknown): string {
+  const parts: string[] = [];
+  collectInteractiveText(parsed, parts);
+  const seen = new Set<string>();
+  const unique = parts.filter((part) => {
+    if (seen.has(part)) {
+      return false;
+    }
+    seen.add(part);
+    return true;
+  });
+  return unique.join("\n").trim() || "[Interactive Card]";
 }
 
 function formatSubMessageContent(content: string, contentType: string): string {

--- a/extensions/feishu/src/bot-content.ts
+++ b/extensions/feishu/src/bot-content.ts
@@ -43,6 +43,8 @@ type GroupSessionScope = "group" | "group_sender" | "group_topic" | "group_topic
 
 type FeishuLogger = (...args: unknown[]) => void;
 
+const FEISHU_CLIENT_UPGRADE_FALLBACK_TEXT = "请升级至最新版本客户端，以查看内容";
+
 type ResolvedFeishuGroupSession = {
   peerId: string;
   parentPeer: { kind: "group"; id: string } | null;
@@ -222,6 +224,9 @@ function parseInteractiveMessageContent(parsed: unknown): string {
     seen.add(part);
     return true;
   });
+  if (unique.some((part) => part.trim() === FEISHU_CLIENT_UPGRADE_FALLBACK_TEXT)) {
+    return "[Interactive Card]";
+  }
   return unique.join("\n").trim() || "[Interactive Card]";
 }
 

--- a/extensions/feishu/src/bot.helpers.test.ts
+++ b/extensions/feishu/src/bot.helpers.test.ts
@@ -90,7 +90,7 @@ describe("parseMessageContent media placeholders", () => {
 });
 
 describe("parseMessageContent interactive cards", () => {
-  it("extracts title and nested legacy text elements from card payloads", () => {
+  it("does not treat Feishu client-upgrade fallback as recovered card content", () => {
     expect(
       parseMessageContent(
         JSON.stringify({
@@ -105,7 +105,7 @@ describe("parseMessageContent interactive cards", () => {
         }),
         "interactive",
       ),
-    ).toBe("saber\n请升级至最新版本客户端，以查看内容");
+    ).toBe("[Interactive Card]");
   });
 });
 

--- a/extensions/feishu/src/bot.helpers.test.ts
+++ b/extensions/feishu/src/bot.helpers.test.ts
@@ -89,6 +89,26 @@ describe("parseMessageContent media placeholders", () => {
   });
 });
 
+describe("parseMessageContent interactive cards", () => {
+  it("extracts title and nested legacy text elements from card payloads", () => {
+    expect(
+      parseMessageContent(
+        JSON.stringify({
+          title: "saber",
+          elements: [
+            [
+              { tag: "img", image_key: "img_v3" },
+              { tag: "text", text: "请升级至最新版本客户端，以查看内容" },
+              { tag: "text", text: "" },
+            ],
+          ],
+        }),
+        "interactive",
+      ),
+    ).toBe("saber\n请升级至最新版本客户端，以查看内容");
+  });
+});
+
 describe("resolveBroadcastAgents", () => {
   it("returns agent list when broadcast config has the peerId", () => {
     const cfg: ClawdbotConfig = { broadcast: { oc_group123: ["susan", "main"] } };

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -163,6 +163,13 @@ function buildDefaultResolveRoute(): ResolvedAgentRoute {
     matchedBy: "default",
   };
 }
+
+function _createUnboundConfiguredRoute(
+  route: NonNullable<ConfiguredBindingRoute>["route"],
+): ConfiguredBindingRoute {
+  return { bindingResolution: null, route };
+}
+
 function createFeishuBotRuntime(overrides: DeepPartial<PluginRuntime> = {}): PluginRuntime {
   return {
     channel: {
@@ -2519,6 +2526,85 @@ describe("handleFeishuMessage command authorization", () => {
     expect(typeof mockCallArg(mockSaveMediaBuffer, 0, 3)).toBe("number");
   });
 
+  it("downloads media from a quoted file message into the agent context", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+    const quotedRawContent = JSON.stringify({
+      file_key: "file_quoted_payload",
+      file_name: "quoted.docx",
+    });
+    mockGetMessageFeishu.mockResolvedValueOnce({
+      messageId: "om_parent_file",
+      chatId: "oc-group",
+      chatType: "group",
+      senderId: "ou-file-sender",
+      senderType: "user",
+      content: "[file message]",
+      rawContent: quotedRawContent,
+      contentType: "file",
+    });
+    mockDownloadMessageResourceFeishu.mockResolvedValueOnce({
+      buffer: Buffer.from("quoted-file"),
+      contentType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      fileName: "quoted.docx",
+    });
+    mockSaveMediaBuffer.mockResolvedValueOnce({
+      id: "quoted.docx",
+      path: "/tmp/quoted.docx",
+      size: Buffer.byteLength("quoted-file"),
+      contentType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    });
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          groupPolicy: "open",
+          requireMention: false,
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-replier",
+        },
+      },
+      message: {
+        message_id: "om_reply_to_file",
+        parent_id: "om_parent_file",
+        chat_id: "oc-group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "please inspect this file" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(mockDownloadMessageResourceFeishu).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageId: "om_parent_file",
+        fileKey: "file_quoted_payload",
+        type: "file",
+      }),
+    );
+    expect(mockSaveMediaBuffer).toHaveBeenCalledWith(
+      expect.any(Buffer),
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      "inbound",
+      expect.any(Number),
+      "quoted.docx",
+    );
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ReplyToBody: "[file message]",
+        MediaPath: "/tmp/quoted.docx",
+        MediaPaths: ["/tmp/quoted.docx"],
+        MediaTypes: ["application/vnd.openxmlformats-officedocument.wordprocessingml.document"],
+      }),
+    );
+  });
+
   it("includes message_id in BodyForAgent on its own line", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
 
@@ -3276,7 +3362,7 @@ describe("handleFeishuMessage command authorization", () => {
     expect(dispatcherOptions.rootId).toBe("om_root_topic");
   });
 
-  it("replies to triggering message in normal group even when root_id is present (#32980)", async () => {
+  it("replies to the triggering message in normal groups even when root_id is present (#32980)", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
 
     const cfg: ClawdbotConfig = {
@@ -3306,12 +3392,13 @@ describe("handleFeishuMessage command authorization", () => {
 
     await dispatchMessage({ cfg, event });
 
-    const dispatcherOptions = mockCallArg<{ replyToMessageId?: string; rootId?: string }>(
-      mockCreateFeishuReplyDispatcher,
-      0,
-      0,
-    );
+    const dispatcherOptions = mockCallArg<{
+      replyToMessageId?: string;
+      rootId?: string;
+      skipReplyToInMessages?: boolean;
+    }>(mockCreateFeishuReplyDispatcher, 0, 0);
     expect(dispatcherOptions.replyToMessageId).toBe("om_quote_reply");
+    expect(dispatcherOptions.skipReplyToInMessages).toBe(false);
     expect(dispatcherOptions.rootId).toBe("om_original_msg");
   });
 
@@ -3351,9 +3438,11 @@ describe("handleFeishuMessage command authorization", () => {
     const dispatcherOptions = mockCallArg<{
       replyToMessageId?: string;
       rootId?: string;
+      skipReplyToInMessages?: boolean;
       replyInThread?: boolean;
     }>(mockCreateFeishuReplyDispatcher, 0, 0);
     expect(dispatcherOptions.replyToMessageId).toBe("om_current_quoted_command");
+    expect(dispatcherOptions.skipReplyToInMessages).toBe(false);
     expect(dispatcherOptions.replyInThread).toBe(false);
     expect(dispatcherOptions.rootId).toBe("om_quoted_root");
   });
@@ -3509,7 +3598,7 @@ describe("handleFeishuMessage command authorization", () => {
     );
   });
 
-  it("does not force thread replies when thread_id exists but thread replies are disabled", async () => {
+  it("does not force thread replies when inbound message contains thread_id but thread replies are disabled", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
 
     const cfg: ClawdbotConfig = {
@@ -3544,8 +3633,10 @@ describe("handleFeishuMessage command authorization", () => {
       replyToMessageId?: string;
       replyInThread?: boolean;
       threadReply?: boolean;
+      skipReplyToInMessages?: boolean;
     }>(mockCreateFeishuReplyDispatcher, 0, 0);
     expect(dispatcherOptions.replyToMessageId).toBe("msg-thread-reply");
+    expect(dispatcherOptions.skipReplyToInMessages).toBe(false);
     expect(dispatcherOptions.replyInThread).toBe(false);
     expect(dispatcherOptions.threadReply).toBe(false);
   });

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -164,12 +164,6 @@ function buildDefaultResolveRoute(): ResolvedAgentRoute {
   };
 }
 
-function _createUnboundConfiguredRoute(
-  route: NonNullable<ConfiguredBindingRoute>["route"],
-): ConfiguredBindingRoute {
-  return { bindingResolution: null, route };
-}
-
 function createFeishuBotRuntime(overrides: DeepPartial<PluginRuntime> = {}): PluginRuntime {
   return {
     channel: {

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -2591,11 +2591,17 @@ describe("handleFeishuMessage command authorization", () => {
     );
     expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
       expect.objectContaining({
-        ReplyToBody: "[file message]",
+        SupplementalContext: expect.objectContaining({
+          quote: expect.objectContaining({
+            body: "[file message]",
+            id: "om_parent_file",
+          }),
+        }),
         MediaPath: "/tmp/quoted.docx",
         MediaPaths: ["/tmp/quoted.docx"],
         MediaTypes: ["application/vnd.openxmlformats-officedocument.wordprocessingml.document"],
       }),
+      undefined,
     );
   });
 

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -864,7 +864,7 @@ describe("handleFeishuMessage ACP routing", () => {
     });
   });
 
-  it("records auto-threaded Feishu group replies with the dispatcher target", async () => {
+  it("does not record a Feishu thread target for normal group replies", async () => {
     const runtime = createFeishuBotRuntime();
     const recordInboundSession = vi.fn(async () => undefined);
     runtime.channel.session.recordInboundSession = recordInboundSession;
@@ -916,8 +916,8 @@ describe("handleFeishuMessage ACP routing", () => {
     }>(recordInboundSession);
     expect(recordParams?.updateLastRoute).toMatchObject({
       to: "chat:oc_group_chat",
-      threadId: "msg-group-auto-thread",
     });
+    expect(recordParams?.updateLastRoute?.threadId).toBeUndefined();
   });
 
   it("passes reasoning preview permission from session state into the dispatcher", async () => {
@@ -3315,6 +3315,49 @@ describe("handleFeishuMessage command authorization", () => {
     expect(dispatcherOptions.rootId).toBe("om_original_msg");
   });
 
+  it("replies to the triggering quoted command message in normal groups", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          groups: {
+            "oc-group": {
+              requireMention: false,
+              groupSessionScope: "group",
+              replyInThread: "disabled",
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-normal-user" } },
+      message: {
+        message_id: "om_current_quoted_command",
+        reply_target_message_id: "om_quoted_message",
+        parent_id: "om_quoted_message",
+        root_id: "om_quoted_root",
+        chat_id: "oc-group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "use this quoted context" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    const dispatcherOptions = mockCallArg<{
+      replyToMessageId?: string;
+      rootId?: string;
+      replyInThread?: boolean;
+    }>(mockCreateFeishuReplyDispatcher, 0, 0);
+    expect(dispatcherOptions.replyToMessageId).toBe("om_current_quoted_command");
+    expect(dispatcherOptions.replyInThread).toBe(false);
+    expect(dispatcherOptions.rootId).toBe("om_quoted_root");
+  });
+
   it("replies to topic root in topic-mode group with root_id", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
 
@@ -3466,7 +3509,7 @@ describe("handleFeishuMessage command authorization", () => {
     );
   });
 
-  it("forces thread replies when inbound message contains thread_id", async () => {
+  it("does not force thread replies when thread_id exists but thread replies are disabled", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
 
     const cfg: ClawdbotConfig = {
@@ -3497,13 +3540,14 @@ describe("handleFeishuMessage command authorization", () => {
 
     await dispatchMessage({ cfg, event });
 
-    const dispatcherOptions = mockCallArg<{ replyInThread?: boolean; threadReply?: boolean }>(
-      mockCreateFeishuReplyDispatcher,
-      0,
-      0,
-    );
-    expect(dispatcherOptions.replyInThread).toBe(true);
-    expect(dispatcherOptions.threadReply).toBe(true);
+    const dispatcherOptions = mockCallArg<{
+      replyToMessageId?: string;
+      replyInThread?: boolean;
+      threadReply?: boolean;
+    }>(mockCreateFeishuReplyDispatcher, 0, 0);
+    expect(dispatcherOptions.replyToMessageId).toBe("msg-thread-reply");
+    expect(dispatcherOptions.replyInThread).toBe(false);
+    expect(dispatcherOptions.threadReply).toBe(false);
   });
 
   it("bootstraps topic thread context only for a new thread session", async () => {

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -977,7 +977,6 @@ export async function handleFeishuMessage(params: {
       return;
     }
 
-    let mediaPayload = buildAgentMediaPayload(mediaList);
     const audioTranscript = await resolveFeishuAudioPreflightTranscript({
       cfg: effectiveCfg,
       mediaList,
@@ -1089,7 +1088,6 @@ export async function handleFeishuMessage(params: {
             });
             if (quotedMediaList.length > 0) {
               mediaList.push(...quotedMediaList);
-              mediaPayload = buildAgentMediaPayload(mediaList);
               log(
                 `feishu[${account.accountId}]: attached ${quotedMediaList.length} quoted media item(s) to agent context`,
               );

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -40,6 +40,7 @@ import {
   resolveFeishuMediaList,
 } from "./bot-content.js";
 import {
+  buildAgentMediaPayload,
   evaluateSupplementalContextVisibility,
   normalizeAgentId,
   resolveChannelContextVisibilityMode,
@@ -976,6 +977,7 @@ export async function handleFeishuMessage(params: {
       return;
     }
 
+    let mediaPayload = buildAgentMediaPayload(mediaList);
     const audioTranscript = await resolveFeishuAudioPreflightTranscript({
       cfg: effectiveCfg,
       mediaList,
@@ -1069,6 +1071,30 @@ export async function handleFeishuMessage(params: {
           log(
             `feishu[${account.accountId}]: fetched quoted message: ${quotedContent?.slice(0, 100)}`,
           );
+          if (
+            quotedMessageInfo.rawContent &&
+            quotedMessageInfo.contentType &&
+            ["image", "file", "audio", "video", "media", "sticker", "post"].includes(
+              quotedMessageInfo.contentType,
+            )
+          ) {
+            const quotedMediaList = await resolveFeishuMediaList({
+              cfg,
+              messageId: ctx.parentId,
+              messageType: quotedMessageInfo.contentType,
+              content: quotedMessageInfo.rawContent,
+              maxBytes: mediaMaxBytes,
+              log,
+              accountId: account.accountId,
+            });
+            if (quotedMediaList.length > 0) {
+              mediaList.push(...quotedMediaList);
+              mediaPayload = buildAgentMediaPayload(mediaList);
+              log(
+                `feishu[${account.accountId}]: attached ${quotedMediaList.length} quoted media item(s) to agent context`,
+              );
+            }
+          }
         } else if (quotedMessageInfo) {
           log(
             `feishu[${account.accountId}]: skipped quoted message from sender ${quotedMessageInfo.senderId ?? "unknown"} (mode=${contextVisibilityMode})`,
@@ -1414,6 +1440,7 @@ export async function handleFeishuMessage(params: {
         : isGroup
           ? normalGroupReplyTargetMessageId
           : defaultReplyTargetMessageId;
+    const skipReplyToInMessages = !isGroup && !directThreadReply;
     const threadReply = isGroup
       ? shouldReplyInFeishuThread
         ? (groupSession?.threadReply ?? false)
@@ -1541,7 +1568,7 @@ export async function handleFeishuMessage(params: {
               chatId: ctx.chatId,
               allowReasoningPreview,
               replyToMessageId: replyTargetMessageId,
-              skipReplyToInMessages: !isGroup && !directThreadReply,
+              skipReplyToInMessages,
               replyInThread: directThreadReply
                 ? true
                 : shouldReplyInFeishuThread
@@ -1721,7 +1748,7 @@ export async function handleFeishuMessage(params: {
           chatId: ctx.chatId,
           allowReasoningPreview,
           replyToMessageId: replyTargetMessageId,
-          skipReplyToInMessages: !isGroup && !directThreadReply,
+          skipReplyToInMessages,
           replyInThread: directThreadReply
             ? true
             : shouldReplyInFeishuThread

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -988,7 +988,8 @@ export async function handleFeishuMessage(params: {
       audioTranscript === undefined
         ? -1
         : mediaList.findIndex((media) => media.contentType?.startsWith("audio/"));
-    const inboundMedia = toInboundMediaFacts(mediaList, {
+    let mediaPayload = buildAgentMediaPayload(mediaList);
+    let inboundMedia = toInboundMediaFacts(mediaList, {
       transcribed: (_media, index) => index === preflightAudioIndex,
     });
     const agentFacingContent = audioTranscript ?? ctx.content;
@@ -1088,6 +1089,10 @@ export async function handleFeishuMessage(params: {
             });
             if (quotedMediaList.length > 0) {
               mediaList.push(...quotedMediaList);
+              mediaPayload = buildAgentMediaPayload(mediaList);
+              inboundMedia = toInboundMediaFacts(mediaList, {
+                transcribed: (_media, index) => index === preflightAudioIndex,
+              });
               log(
                 `feishu[${account.accountId}]: attached ${quotedMediaList.length} quoted media item(s) to agent context`,
               );
@@ -1403,6 +1408,8 @@ export async function handleFeishuMessage(params: {
           RootMessageId: ctx.rootId,
           Transcript: audioTranscript,
           GroupSubject: isGroup ? groupName || ctx.chatId : undefined,
+          ...mediaPayload,
+          ...(preflightAudioIndex >= 0 ? { MediaTranscribedIndexes: [preflightAudioIndex] } : {}),
         },
       });
     };

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -301,6 +301,7 @@ export function parseFeishuMessageEvent(
     chatId: event.message.chat_id,
     messageId: event.message.message_id,
     replyTargetMessageId: event.message.reply_target_message_id?.trim() || undefined,
+    syntheticCardAction: event.message.synthetic_card_action === true,
     suppressReplyTarget: event.message.suppress_reply_target === true,
     senderId: senderUserId || senderOpenId || "",
     // Keep the historical field name, but fall back to user_id when open_id is unavailable
@@ -1387,9 +1388,10 @@ export async function handleFeishuMessage(params: {
     //   root so the bot stays in the same thread.
     // - Groups with explicit replyInThread config: reply to the root so the bot
     //   stays in the thread the user expects.
-    // - Normal groups (auto-detected threadReply from root_id): reply to the
-    //   triggering message itself. Using rootId here would silently push the
-    //   reply into a topic thread invisible in the main chat view (#32980).
+    // - Normal groups: reply to the triggering message itself. Quoted-message
+    //   metadata (reply_target_message_id/root_id/parent_id) is inbound context,
+    //   not the outbound reply anchor; otherwise commands sent with a quote can
+    //   be routed back into the quoted message's thread.
     const isTopicSession =
       isGroup &&
       (groupSession?.groupSessionScope === "group_topic" ||
@@ -1397,17 +1399,28 @@ export async function handleFeishuMessage(params: {
     const configReplyInThread =
       isGroup &&
       (groupConfig?.replyInThread ?? feishuCfg?.replyInThread ?? "disabled") === "enabled";
-    const topicReplyTargetMessageId = ctx.rootId ?? defaultReplyTargetMessageId;
+    const shouldReplyInFeishuThread = isTopicSession || configReplyInThread;
+    const topicReplyTargetMessageId =
+      ctx.rootId ?? ctx.replyTargetMessageId ?? (ctx.suppressReplyTarget ? undefined : ctx.messageId);
+    const normalGroupReplyTargetMessageId = ctx.syntheticCardAction
+      ? ctx.replyTargetMessageId
+      : ctx.suppressReplyTarget
+        ? undefined
+        : ctx.messageId;
     const replyTargetMessageId = directThreadReply
       ? directThreadReplyTargetMessageId
-      : isTopicSession || configReplyInThread
+      : shouldReplyInFeishuThread
         ? topicReplyTargetMessageId
-        : defaultReplyTargetMessageId;
-    const threadReply = isGroup ? (groupSession?.threadReply ?? false) : directThreadReply;
+        : isGroup
+          ? normalGroupReplyTargetMessageId
+          : defaultReplyTargetMessageId;
+    const threadReply = isGroup
+      ? shouldReplyInFeishuThread
+        ? (groupSession?.threadReply ?? false)
+        : false
+      : directThreadReply;
     const lastRouteThreadId =
-      isGroup && (isTopicSession || configReplyInThread || threadReply)
-        ? replyTargetMessageId
-        : undefined;
+      isGroup && shouldReplyInFeishuThread ? replyTargetMessageId : undefined;
     const pinnedMainDmOwner = !isGroup
       ? resolvePinnedMainDmOwnerFromAllowlist({
           dmScope: cfg.session?.dmScope,
@@ -1529,7 +1542,11 @@ export async function handleFeishuMessage(params: {
               allowReasoningPreview,
               replyToMessageId: replyTargetMessageId,
               skipReplyToInMessages: !isGroup && !directThreadReply,
-              replyInThread,
+              replyInThread: directThreadReply
+                ? true
+                : shouldReplyInFeishuThread
+                  ? replyInThread
+                  : false,
               rootId: ctx.rootId,
               threadReply,
               accountId: account.accountId,
@@ -1705,7 +1722,11 @@ export async function handleFeishuMessage(params: {
           allowReasoningPreview,
           replyToMessageId: replyTargetMessageId,
           skipReplyToInMessages: !isGroup && !directThreadReply,
-          replyInThread,
+          replyInThread: directThreadReply
+            ? true
+            : shouldReplyInFeishuThread
+              ? replyInThread
+              : false,
           rootId: ctx.rootId,
           threadReply,
           accountId: account.accountId,

--- a/extensions/feishu/src/card-action.ts
+++ b/extensions/feishu/src/card-action.ts
@@ -147,6 +147,7 @@ function buildSyntheticMessageEvent(
     message: {
       message_id: `card-action-${event.token}`,
       ...(replyTargetMessageId ? { reply_target_message_id: replyTargetMessageId } : {}),
+      synthetic_card_action: true,
       ...(!replyTargetMessageId ? { suppress_reply_target: true } : {}),
       chat_id: event.context.chat_id || event.operator.open_id,
       chat_type: chatType,

--- a/extensions/feishu/src/event-types.ts
+++ b/extensions/feishu/src/event-types.ts
@@ -12,6 +12,8 @@ export type FeishuMessageEvent = {
   message: {
     message_id: string;
     reply_target_message_id?: string;
+    /** Internal marker used by synthetic card-action events. */
+    synthetic_card_action?: boolean;
     suppress_reply_target?: boolean;
     root_id?: string;
     parent_id?: string;

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -688,6 +688,79 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(sendMessageFeishuMock).not.toHaveBeenCalled();
     expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
   });
+  it("skips streaming updates for markdown tables and converts them on close", async () => {
+    const convertMarkdownTables = vi.fn((text: string) => `converted:${text}`);
+    getFeishuRuntimeMock.mockReturnValue({
+      channel: {
+        text: {
+          resolveTextChunkLimit: vi.fn(() => 4000),
+          resolveChunkMode: vi.fn(() => "line"),
+          resolveMarkdownTableMode: vi.fn(() => "code"),
+          convertMarkdownTables,
+          chunkTextWithMode: vi.fn((text) => [text]),
+        },
+        reply: {
+          createReplyDispatcherWithTyping: createReplyDispatcherWithTypingMock,
+          resolveHumanDelayConfig: vi.fn(() => undefined),
+        },
+      },
+    });
+    const table = "| A | B |\n|---|---|\n| 1 | 2 |";
+    const { options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+    });
+
+    await options.deliver({ text: table }, { kind: "final" });
+    await options.onIdle?.();
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(convertMarkdownTables).toHaveBeenCalledWith(table, "code");
+    expect(streamingInstances[0].update).not.toHaveBeenCalled();
+    expect(streamingInstances[0].close).toHaveBeenCalledWith(`converted:${table}`, {
+      note: "Agent: agent",
+    });
+  });
+
+  it("converts markdown tables before non-streaming card fallback", async () => {
+    const convertMarkdownTables = vi.fn((text: string) => `converted:${text}`);
+    getFeishuRuntimeMock.mockReturnValue({
+      channel: {
+        text: {
+          resolveTextChunkLimit: vi.fn(() => 4000),
+          resolveChunkMode: vi.fn(() => "line"),
+          resolveMarkdownTableMode: vi.fn(() => "code"),
+          convertMarkdownTables,
+          chunkTextWithMode: vi.fn((text) => [text]),
+        },
+        reply: {
+          createReplyDispatcherWithTyping: createReplyDispatcherWithTypingMock,
+          resolveHumanDelayConfig: vi.fn(() => undefined),
+        },
+      },
+    });
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config: {
+        renderMode: "auto",
+        streaming: false,
+      },
+    });
+    const table = "| A | B |\n|---|---|\n| 1 | 2 |";
+    const { options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+    });
+
+    await options.deliver({ text: table }, { kind: "final" });
+
+    expect(sendStructuredCardFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({ text: `converted:${table}` }),
+    );
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+  });
+
 
   it("closes streaming with block text when final reply is missing", async () => {
     const { options } = createDispatcherHarness({

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -393,6 +393,24 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   });
 
   it("streams auto mode plain final text when streaming is enabled", async () => {
+  it("keeps typing indicator while omitting reply metadata when skipReplyToInMessages is true", async () => {
+    const { options } = createDispatcherHarness({
+      replyToMessageId: "om_trigger",
+      skipReplyToInMessages: true,
+    });
+
+    await options.onReplyStart?.();
+    await options.deliver({ text: "plain text" }, { kind: "final" });
+
+    expectMockArgFields(addTypingIndicatorMock, "typing indicator params", {
+      messageId: "om_trigger",
+    });
+    expectLastMockArgFields(sendMessageFeishuMock, "send message params", {
+      replyToMessageId: undefined,
+    });
+  });
+
+  it("keeps auto mode plain text on non-streaming send path", async () => {
     const { options } = createDispatcherHarness();
     await options.deliver({ text: "plain text" }, { kind: "final" });
     await options.onIdle?.();

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -393,7 +393,20 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   });
 
   it("streams auto mode plain final text when streaming is enabled", async () => {
+    const { options } = createDispatcherHarness();
+    await options.deliver({ text: "plain text" }, { kind: "final" });
+    await options.onIdle?.();
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(streamingInstances[0].close).toHaveBeenCalledWith("plain text", {
+      note: "Agent: agent",
+    });
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
+  });
+
   it("keeps typing indicator while omitting reply metadata when skipReplyToInMessages is true", async () => {
+    useNonStreamingAutoAccount();
     const { options } = createDispatcherHarness({
       replyToMessageId: "om_trigger",
       skipReplyToInMessages: true,

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -1463,6 +1463,20 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     });
   });
 
+  it("omits reply metadata from streaming cards when skipReplyToInMessages is true", async () => {
+    const { options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+      replyToMessageId: "om_trigger",
+      skipReplyToInMessages: true,
+    });
+    await options.deliver({ text: "```ts\nconst x = 1\n```" }, { kind: "final" });
+
+    expect(streamingInstances).toHaveLength(1);
+    expectStreamingStartOptions(0, {
+      replyToMessageId: undefined,
+    });
+  });
+
   it("uses streaming cards for thread replies and keeps topic metadata", async () => {
     const { options } = createDispatcherHarness({
       runtime: createRuntimeLogger(),

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -268,6 +268,11 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     return `> 💭 **Thinking**\n${lines.join("\n")}`;
   };
 
+  const convertTablesForFeishuCard = (text: string): string =>
+    core.channel.text.convertMarkdownTables(text, tableMode);
+  const hasMarkdownTable = (text: string): boolean =>
+    /\|.+\|[\r\n]+\|[-:| ]+\|/.test(text);
+
   const buildCombinedStreamText = (thinking: string, answer: string): string => {
     const parts: string[] = [];
     if (thinking) {
@@ -290,7 +295,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       if (streamingStartPromise) {
         await streamingStartPromise;
       }
-      if (streaming?.isActive()) {
+      if (streaming?.isActive() && !hasMarkdownTable(combined)) {
         await streaming.update(combined);
       }
     });
@@ -409,7 +414,9 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         statusLine = "";
         const text = buildCombinedStreamText(reasoningText, streamText);
         const finalNote = resolveCardNote(agentId, identity, prefixContext.prefixContext);
-        const contentVisible = await streaming.close(text, { note: finalNote });
+        const contentVisible = await streaming.close(convertTablesForFeishuCard(text), {
+          note: finalNote,
+        });
         // Track the raw streamed text so the duplicate-final check in deliver()
         // can skip the redundant text delivery that arrives after onIdle closes
         // the streaming card.
@@ -461,9 +468,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     infoKind?: string;
     sendChunk: (params: { chunk: string; isFirst: boolean }) => Promise<void>;
   }) => {
-    const chunkSource = paramsLocal.useCard
-      ? paramsLocal.text
-      : core.channel.text.convertMarkdownTables(paramsLocal.text, tableMode);
+    const chunkSource = core.channel.text.convertMarkdownTables(paramsLocal.text, tableMode);
     const chunkText = paramsLocal.useCard
       ? core.channel.text.chunkMarkdownTextWithMode
       : core.channel.text.chunkTextWithMode;

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -268,8 +268,6 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     return `> 💭 **Thinking**\n${lines.join("\n")}`;
   };
 
-  const convertTablesForFeishuCard = (text: string): string =>
-    core.channel.text.convertMarkdownTables(text, tableMode);
   const hasMarkdownTable = (text: string): boolean =>
     /\|.+\|[\r\n]+\|[-:| ]+\|/.test(text);
 

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -262,7 +262,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     if (!thinking) {
       return "";
     }
-    const withoutLabel = thinking.replace(/^(?:Reasoning:|Thinking\.{0,3})\s*/u, "");
+    const withoutLabel = thinking.replace(/^Reasoning:\n/, "");
     const plain = withoutLabel.replace(/^_(.*)_$/gm, "$1");
     const lines = plain.split("\n").map((line) => `> ${line}`);
     return `> 💭 **Thinking**\n${lines.join("\n")}`;

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -268,8 +268,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     return `> 💭 **Thinking**\n${lines.join("\n")}`;
   };
 
-  const hasMarkdownTable = (text: string): boolean =>
-    /\|.+\|[\r\n]+\|[-:| ]+\|/.test(text);
+  const hasMarkdownTable = (text: string): boolean => /\|.+\|[\r\n]+\|[-:| ]+\|/.test(text);
 
   const buildCombinedStreamText = (thinking: string, answer: string): string => {
     const parts: string[] = [];
@@ -357,7 +356,12 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     streamingStartPromise = (async () => {
       const creds =
         account.appId && account.appSecret
-          ? { appId: account.appId, appSecret: account.appSecret, domain: account.domain }
+          ? {
+              appId: account.appId,
+              appSecret: account.appSecret,
+              domain: account.domain,
+              accountId: account.accountId,
+            }
           : null;
       if (!creds) {
         return;
@@ -412,9 +416,12 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         statusLine = "";
         const text = buildCombinedStreamText(reasoningText, streamText);
         const finalNote = resolveCardNote(agentId, identity, prefixContext.prefixContext);
-        const contentVisible = await streaming.close(core.channel.text.convertMarkdownTables(text, tableMode), {
-          note: finalNote,
-        });
+        const contentVisible = await streaming.close(
+          core.channel.text.convertMarkdownTables(text, tableMode),
+          {
+            note: finalNote,
+          },
+        );
         // Track the raw streamed text so the duplicate-final check in deliver()
         // can skip the redundant text delivery that arrives after onIdle closes
         // the streaming card.

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -412,7 +412,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         statusLine = "";
         const text = buildCombinedStreamText(reasoningText, streamText);
         const finalNote = resolveCardNote(agentId, identity, prefixContext.prefixContext);
-        const contentVisible = await streaming.close(convertTablesForFeishuCard(text), {
+        const contentVisible = await streaming.close(core.channel.text.convertMarkdownTables(text, tableMode), {
           note: finalNote,
         });
         // Track the raw streamed text so the duplicate-final check in deliver()
@@ -467,9 +467,10 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     sendChunk: (params: { chunk: string; isFirst: boolean }) => Promise<void>;
   }) => {
     const chunkSource = core.channel.text.convertMarkdownTables(paramsLocal.text, tableMode);
-    const chunkText = paramsLocal.useCard
-      ? core.channel.text.chunkMarkdownTextWithMode
-      : core.channel.text.chunkTextWithMode;
+    const chunkText =
+      paramsLocal.useCard && typeof core.channel.text.chunkMarkdownTextWithMode === "function"
+        ? core.channel.text.chunkMarkdownTextWithMode
+        : core.channel.text.chunkTextWithMode;
     const chunks = resolveTextChunksWithFallback(
       chunkSource,
       chunkText(chunkSource, textChunkLimit, chunkMode),

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -367,7 +367,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         const cardHeader = resolveCardHeader(agentId, identity);
         const cardNote = resolveCardNote(agentId, identity, prefixContext.prefixContext);
         await streaming.start(chatId, resolveReceiveIdType(chatId), {
-          replyToMessageId,
+          replyToMessageId: sendReplyToMessageId,
           replyInThread: effectiveReplyInThread,
           rootId,
           header: cardHeader,

--- a/extensions/feishu/src/send-target.ts
+++ b/extensions/feishu/src/send-target.ts
@@ -8,6 +8,7 @@ type FeishuSendTarget = {
   client: ReturnType<typeof createFeishuClient>;
   receiveId: string;
   receiveIdType: ReturnType<typeof resolveReceiveIdType>;
+  accountId: string;
 };
 
 export function resolveFeishuSendTarget(params: {
@@ -32,5 +33,6 @@ export function resolveFeishuSendTarget(params: {
     client,
     receiveId,
     receiveIdType: resolveReceiveIdType(withoutProviderPrefix),
+    accountId: account.accountId,
   };
 }

--- a/extensions/feishu/src/send.test.ts
+++ b/extensions/feishu/src/send.test.ts
@@ -246,6 +246,9 @@ describe("getMessageFeishu", () => {
       messageId: "om_legacy_card",
     });
 
+    if (!result) {
+      throw new Error("expected interactive card result");
+    }
     expect(result.content).toBe("saber\n请升级至最新版本客户端，以查看内容");
     expect(result.contentType).toBe("interactive");
   });

--- a/extensions/feishu/src/send.test.ts
+++ b/extensions/feishu/src/send.test.ts
@@ -12,18 +12,56 @@ const {
   mockResolveMarkdownTableMode,
   mockResolveFeishuAccount,
   mockRuntimeConvertMarkdownTables,
+  mockRuntimeLoggerWarn,
   mockRuntimeResolveMarkdownTableMode,
-} = vi.hoisted(() => ({
-  mockConvertMarkdownTables: vi.fn((text: string) => text),
-  mockClientGet: vi.fn(),
-  mockClientList: vi.fn(),
-  mockClientPatch: vi.fn(),
-  mockCreateFeishuClient: vi.fn(),
-  mockResolveMarkdownTableMode: vi.fn(() => "preserve"),
-  mockResolveFeishuAccount: vi.fn(),
-  mockRuntimeConvertMarkdownTables: vi.fn((text: string) => text),
-  mockRuntimeResolveMarkdownTableMode: vi.fn(() => "preserve"),
-}));
+  mockRuntimeStores,
+  mockOpenSyncKeyedStore,
+} = vi.hoisted(() => {
+  const stores = new Map<string, Map<string, unknown>>();
+  const openSyncKeyedStore = vi.fn(({ namespace }: { namespace: string }) => {
+    let store = stores.get(namespace);
+    if (!store) {
+      store = new Map<string, unknown>();
+      stores.set(namespace, store);
+    }
+    return {
+      register: (key: string, value: unknown) => {
+        store.set(key, value);
+      },
+      registerIfAbsent: (key: string, value: unknown) => {
+        if (store.has(key)) {
+          return false;
+        }
+        store.set(key, value);
+        return true;
+      },
+      lookup: (key: string) => store.get(key),
+      consume: (key: string) => {
+        const value = store.get(key);
+        store.delete(key);
+        return value;
+      },
+      delete: (key: string) => store.delete(key),
+      entries: () =>
+        Array.from(store.entries()).map(([key, value]) => ({ key, value, createdAt: 0 })),
+      clear: () => store.clear(),
+    };
+  });
+  return {
+    mockConvertMarkdownTables: vi.fn((text: string) => text),
+    mockClientGet: vi.fn(),
+    mockClientList: vi.fn(),
+    mockClientPatch: vi.fn(),
+    mockCreateFeishuClient: vi.fn(),
+    mockResolveMarkdownTableMode: vi.fn(() => "preserve"),
+    mockResolveFeishuAccount: vi.fn(),
+    mockRuntimeConvertMarkdownTables: vi.fn((text: string) => text),
+    mockRuntimeLoggerWarn: vi.fn(),
+    mockRuntimeResolveMarkdownTableMode: vi.fn(() => "preserve"),
+    mockRuntimeStores: stores,
+    mockOpenSyncKeyedStore: openSyncKeyedStore,
+  };
+});
 
 vi.mock("openclaw/plugin-sdk/markdown-table-runtime", () => ({
   resolveMarkdownTableMode: mockResolveMarkdownTableMode,
@@ -54,6 +92,14 @@ vi.mock("./runtime.js", () => ({
         convertMarkdownTables: mockRuntimeConvertMarkdownTables,
       },
     },
+    state: {
+      openSyncKeyedStore: mockOpenSyncKeyedStore,
+    },
+    logging: {
+      getChildLogger: () => ({
+        warn: mockRuntimeLoggerWarn,
+      }),
+    },
   }),
 }));
 
@@ -61,6 +107,9 @@ let buildStructuredCard: typeof import("./send.js").buildStructuredCard;
 let editMessageFeishu: typeof import("./send.js").editMessageFeishu;
 let getMessageFeishu: typeof import("./send.js").getMessageFeishu;
 let listFeishuThreadMessages: typeof import("./send.js").listFeishuThreadMessages;
+let recordFeishuStreamingCardContent: typeof import("./streaming-card-content-index.js").recordFeishuStreamingCardContent;
+let resetFeishuStreamingCardContentMemoryForTests: typeof import("./streaming-card-content-index.js").testingHooks.resetFeishuStreamingCardContentMemoryForTests;
+let resetFeishuStreamingCardContentIndexForTests: typeof import("./streaming-card-content-index.js").testingHooks.resetFeishuStreamingCardContentIndexForTests;
 let resolveFeishuCardTemplate: typeof import("./send.js").resolveFeishuCardTemplate;
 let sendMarkdownCardFeishu: typeof import("./send.js").sendMarkdownCardFeishu;
 let sendMessageFeishu: typeof import("./send.js").sendMessageFeishu;
@@ -78,6 +127,13 @@ describe("getMessageFeishu", () => {
       sendMessageFeishu,
       sendStructuredCardFeishu,
     } = await import("./send.js"));
+    ({
+      recordFeishuStreamingCardContent,
+      testingHooks: {
+        resetFeishuStreamingCardContentIndexForTests,
+        resetFeishuStreamingCardContentMemoryForTests,
+      },
+    } = await import("./streaming-card-content-index.js"));
   });
 
   afterAll(() => {
@@ -95,6 +151,10 @@ describe("getMessageFeishu", () => {
     mockConvertMarkdownTables.mockImplementation((text: string) => text);
     mockRuntimeResolveMarkdownTableMode.mockReturnValue("preserve");
     mockRuntimeConvertMarkdownTables.mockImplementation((text: string) => text);
+    mockRuntimeLoggerWarn.mockReset();
+    mockRuntimeStores.clear();
+    mockOpenSyncKeyedStore.mockClear();
+    resetFeishuStreamingCardContentIndexForTests?.();
     mockResolveFeishuAccount.mockReturnValue({
       accountId: "default",
       configured: true,
@@ -285,7 +345,7 @@ describe("getMessageFeishu", () => {
     });
   });
 
-  it("extracts title and nested legacy text elements from interactive cards", async () => {
+  it("does not treat client-upgrade interactive fallback text as recovered card content", async () => {
     mockClientGet.mockResolvedValueOnce({
       code: 0,
       data: {
@@ -316,11 +376,190 @@ describe("getMessageFeishu", () => {
       messageId: "om_legacy_card",
     });
 
-    if (!result) {
-      throw new Error("expected interactive card result");
-    }
-    expect(result.content).toBe("saber\n请升级至最新版本客户端，以查看内容");
-    expect(result.contentType).toBe("interactive");
+    expect(result?.content).toBe("[Interactive Card]");
+    expect(result?.contentType).toBe("interactive");
+    expect(mockRuntimeLoggerWarn).toHaveBeenCalledWith("feishu streaming card content index miss", {
+      fallbackKind: "client-upgrade",
+      messageId: "om_legacy_card",
+      cardId: undefined,
+      accountId: "default",
+    });
+  });
+
+  it("hydrates card-reference interactive messages from the streaming card content index", async () => {
+    recordFeishuStreamingCardContent({
+      cardId: "card_ref_1",
+      messageId: "om_stream_ref",
+      accountId: "main",
+      chatId: "oc_stream_ref",
+      text: "real final streaming content",
+    });
+    mockResolveFeishuAccount.mockReturnValue({
+      accountId: "main",
+      configured: true,
+    });
+    mockClientGet.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        items: [
+          {
+            message_id: "om_stream_ref",
+            chat_id: "oc_stream_ref",
+            msg_type: "interactive",
+            body: {
+              content: JSON.stringify({ type: "card", data: { card_id: "card_ref_1" } }),
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await getMessageFeishu({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_stream_ref",
+      accountId: "main",
+    });
+
+    expect(result?.content).toBe("real final streaming content");
+  });
+
+  it("hydrates fallback-only interactive card text when the index has better content", async () => {
+    recordFeishuStreamingCardContent({
+      cardId: "card_legacy_1",
+      messageId: "om_legacy_card_indexed",
+      accountId: "default",
+      text: "真实的最终流式内容",
+    });
+    mockClientGet.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        items: [
+          {
+            message_id: "om_legacy_card_indexed",
+            chat_id: "oc_legacy_card",
+            msg_type: "interactive",
+            body: {
+              content: JSON.stringify({
+                title: "saber",
+                elements: [[{ tag: "text", text: "请升级至最新版本客户端，以查看内容" }]],
+              }),
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await getMessageFeishu({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_legacy_card_indexed",
+    });
+
+    expect(result?.content).toBe("真实的最终流式内容");
+  });
+
+  it("hydrates streaming card stubs from persisted plugin state after memory cache reset", async () => {
+    recordFeishuStreamingCardContent({
+      cardId: "card_persisted_ref",
+      messageId: "om_stream_persisted_ref",
+      accountId: "default",
+      chatId: "oc_stream_persisted_ref",
+      text: "persisted streaming content",
+    });
+    resetFeishuStreamingCardContentMemoryForTests?.();
+    mockClientGet.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        items: [
+          {
+            message_id: "om_stream_persisted_ref",
+            chat_id: "oc_stream_persisted_ref",
+            msg_type: "interactive",
+            body: {
+              content: JSON.stringify({
+                type: "card",
+                data: { card_id: "card_persisted_ref" },
+              }),
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await getMessageFeishu({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_stream_persisted_ref",
+    });
+
+    expect(result?.content).toBe("persisted streaming content");
+    expect(mockOpenSyncKeyedStore).toHaveBeenCalledWith({
+      namespace: "streaming-card-content",
+      maxEntries: 20_000,
+      defaultTtlMs: 7 * 24 * 60 * 60 * 1000,
+    });
+  });
+
+  it("keeps the safe interactive fallback when the streaming card content index misses", async () => {
+    mockClientGet.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        items: [
+          {
+            message_id: "om_stream_miss",
+            chat_id: "oc_stream_miss",
+            msg_type: "interactive",
+            body: {
+              content: JSON.stringify({ type: "card", data: { card_id: "card_missing" } }),
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await getMessageFeishu({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_stream_miss",
+    });
+
+    expect(result?.content).toBe("[Interactive Card]");
+    expect(mockRuntimeLoggerWarn).toHaveBeenCalledWith("feishu streaming card content index miss", {
+      fallbackKind: "card-reference",
+      messageId: "om_stream_miss",
+      cardId: "card_missing",
+      accountId: "default",
+    });
+  });
+
+  it("returns the safe fallback when client-upgrade interactive text is not indexed", async () => {
+    mockClientGet.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        items: [
+          {
+            message_id: "om_upgrade_miss",
+            chat_id: "oc_upgrade_miss",
+            msg_type: "interactive",
+            body: {
+              content: JSON.stringify({
+                elements: [[{ tag: "text", text: "请升级至最新版本客户端，以查看内容" }]],
+              }),
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await getMessageFeishu({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_upgrade_miss",
+    });
+
+    expect(result?.content).toBe("[Interactive Card]");
+    expect(mockRuntimeLoggerWarn).toHaveBeenCalledWith("feishu streaming card content index miss", {
+      fallbackKind: "client-upgrade",
+      messageId: "om_upgrade_miss",
+      cardId: undefined,
+      accountId: "default",
+    });
   });
 
   it("falls through empty interactive card element arrays and locale variants", async () => {

--- a/extensions/feishu/src/send.test.ts
+++ b/extensions/feishu/src/send.test.ts
@@ -62,7 +62,9 @@ let editMessageFeishu: typeof import("./send.js").editMessageFeishu;
 let getMessageFeishu: typeof import("./send.js").getMessageFeishu;
 let listFeishuThreadMessages: typeof import("./send.js").listFeishuThreadMessages;
 let resolveFeishuCardTemplate: typeof import("./send.js").resolveFeishuCardTemplate;
+let sendMarkdownCardFeishu: typeof import("./send.js").sendMarkdownCardFeishu;
 let sendMessageFeishu: typeof import("./send.js").sendMessageFeishu;
+let sendStructuredCardFeishu: typeof import("./send.js").sendStructuredCardFeishu;
 
 describe("getMessageFeishu", () => {
   beforeAll(async () => {
@@ -72,7 +74,9 @@ describe("getMessageFeishu", () => {
       getMessageFeishu,
       listFeishuThreadMessages,
       resolveFeishuCardTemplate,
+      sendMarkdownCardFeishu,
       sendMessageFeishu,
+      sendStructuredCardFeishu,
     } = await import("./send.js"));
   });
 
@@ -105,6 +109,72 @@ describe("getMessageFeishu", () => {
         },
       },
     });
+  });
+
+  it("converts markdown tables before sending markdown cards", async () => {
+    const create = vi.fn().mockResolvedValue({ code: 0, data: { message_id: "om_card" } });
+    mockCreateFeishuClient.mockReturnValue({
+      im: {
+        message: {
+          create,
+          get: mockClientGet,
+          list: mockClientList,
+          patch: mockClientPatch,
+        },
+      },
+    });
+    mockResolveMarkdownTableMode.mockReturnValue("code");
+    mockConvertMarkdownTables.mockReturnValue("converted table");
+
+    await sendMarkdownCardFeishu({
+      cfg: {} as ClawdbotConfig,
+      to: "oc_card",
+      text: "| A | B |\n|---|---|\n| 1 | 2 |",
+      accountId: "main",
+    });
+
+    const content = JSON.parse(create.mock.calls[0][0].data.content);
+    expect(mockResolveMarkdownTableMode).toHaveBeenCalledWith({
+      cfg: {},
+      channel: "feishu",
+      accountId: "main",
+    });
+    expect(mockConvertMarkdownTables).toHaveBeenCalledWith(
+      "| A | B |\n|---|---|\n| 1 | 2 |",
+      "code",
+    );
+    expect(content.body.elements[0].content).toBe("converted table");
+  });
+
+  it("converts markdown tables before sending structured cards", async () => {
+    const create = vi.fn().mockResolvedValue({ code: 0, data: { message_id: "om_structured" } });
+    mockCreateFeishuClient.mockReturnValue({
+      im: {
+        message: {
+          create,
+          get: mockClientGet,
+          list: mockClientList,
+          patch: mockClientPatch,
+        },
+      },
+    });
+    mockResolveMarkdownTableMode.mockReturnValue("code");
+    mockConvertMarkdownTables.mockReturnValue("converted table");
+
+    await sendStructuredCardFeishu({
+      cfg: {} as ClawdbotConfig,
+      to: "oc_card",
+      text: "| A | B |\n|---|---|\n| 1 | 2 |",
+      header: { title: "agent" },
+    });
+
+    const content = JSON.parse(create.mock.calls[0][0].data.content);
+    expect(mockConvertMarkdownTables).toHaveBeenCalledWith(
+      "| A | B |\n|---|---|\n| 1 | 2 |",
+      "code",
+    );
+    expect(content.body.elements[0].content).toBe("converted table");
+    expect(content.header.title.content).toBe("agent");
   });
 
   it("sends text without requiring Feishu runtime text helpers", async () => {

--- a/extensions/feishu/src/send.test.ts
+++ b/extensions/feishu/src/send.test.ts
@@ -208,10 +208,46 @@ describe("getMessageFeishu", () => {
       senderOpenId: undefined,
       senderType: undefined,
       content: "hello markdown\nhello div",
+      rawContent: expect.any(String),
       contentType: "interactive",
       createTime: undefined,
       threadId: undefined,
     });
+  });
+
+  it("extracts title and nested legacy text elements from interactive cards", async () => {
+    mockClientGet.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        items: [
+          {
+            message_id: "om_legacy_card",
+            chat_id: "oc_legacy_card",
+            msg_type: "interactive",
+            body: {
+              content: JSON.stringify({
+                title: "saber",
+                elements: [
+                  [
+                    { tag: "img", image_key: "img_v3" },
+                    { tag: "text", text: "请升级至最新版本客户端，以查看内容" },
+                    { tag: "text", text: "" },
+                  ],
+                ],
+              }),
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await getMessageFeishu({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_legacy_card",
+    });
+
+    expect(result.content).toBe("saber\n请升级至最新版本客户端，以查看内容");
+    expect(result.contentType).toBe("interactive");
   });
 
   it("falls through empty interactive card element arrays and locale variants", async () => {
@@ -261,6 +297,7 @@ describe("getMessageFeishu", () => {
       senderOpenId: undefined,
       senderType: undefined,
       content: "hello 2 tasks {{metadata}}",
+      rawContent: expect.any(String),
       contentType: "interactive",
       createTime: undefined,
       threadId: undefined,
@@ -305,6 +342,7 @@ describe("getMessageFeishu", () => {
       senderOpenId: undefined,
       senderType: undefined,
       content: "Card summary\n\n**fallback** body",
+      rawContent: expect.any(String),
       contentType: "interactive",
       createTime: undefined,
       threadId: undefined,
@@ -346,6 +384,7 @@ describe("getMessageFeishu", () => {
       senderOpenId: undefined,
       senderType: undefined,
       content: "Summary\n\npost body",
+      rawContent: expect.any(String),
       contentType: "post",
       createTime: undefined,
       threadId: undefined,
@@ -382,6 +421,7 @@ describe("getMessageFeishu", () => {
       senderOpenId: undefined,
       senderType: undefined,
       content: "[file message]",
+      rawContent: JSON.stringify({ file_key: "file_v3_123" }),
       contentType: "file",
       createTime: undefined,
       threadId: undefined,
@@ -414,6 +454,7 @@ describe("getMessageFeishu", () => {
       senderOpenId: undefined,
       senderType: undefined,
       content: "single payload",
+      rawContent: expect.any(String),
       contentType: "text",
       createTime: undefined,
       threadId: undefined,

--- a/extensions/feishu/src/send.test.ts
+++ b/extensions/feishu/src/send.test.ts
@@ -108,12 +108,15 @@ let editMessageFeishu: typeof import("./send.js").editMessageFeishu;
 let getMessageFeishu: typeof import("./send.js").getMessageFeishu;
 let listFeishuThreadMessages: typeof import("./send.js").listFeishuThreadMessages;
 let recordFeishuStreamingCardContent: typeof import("./streaming-card-content-index.js").recordFeishuStreamingCardContent;
+let recordLegacyFeishuStreamingCardContentForTests: typeof import("./streaming-card-content-index.js").testingHooks.recordLegacyFeishuStreamingCardContentForTests;
 let resetFeishuStreamingCardContentMemoryForTests: typeof import("./streaming-card-content-index.js").testingHooks.resetFeishuStreamingCardContentMemoryForTests;
 let resetFeishuStreamingCardContentIndexForTests: typeof import("./streaming-card-content-index.js").testingHooks.resetFeishuStreamingCardContentIndexForTests;
 let resolveFeishuCardTemplate: typeof import("./send.js").resolveFeishuCardTemplate;
+let sendCardFeishu: typeof import("./send.js").sendCardFeishu;
 let sendMarkdownCardFeishu: typeof import("./send.js").sendMarkdownCardFeishu;
 let sendMessageFeishu: typeof import("./send.js").sendMessageFeishu;
 let sendStructuredCardFeishu: typeof import("./send.js").sendStructuredCardFeishu;
+let updateCardFeishu: typeof import("./send.js").updateCardFeishu;
 
 describe("getMessageFeishu", () => {
   beforeAll(async () => {
@@ -123,13 +126,16 @@ describe("getMessageFeishu", () => {
       getMessageFeishu,
       listFeishuThreadMessages,
       resolveFeishuCardTemplate,
+      sendCardFeishu,
       sendMarkdownCardFeishu,
       sendMessageFeishu,
       sendStructuredCardFeishu,
+      updateCardFeishu,
     } = await import("./send.js"));
     ({
       recordFeishuStreamingCardContent,
       testingHooks: {
+        recordLegacyFeishuStreamingCardContentForTests,
         resetFeishuStreamingCardContentIndexForTests,
         resetFeishuStreamingCardContentMemoryForTests,
       },
@@ -378,7 +384,7 @@ describe("getMessageFeishu", () => {
 
     expect(result?.content).toBe("[Interactive Card]");
     expect(result?.contentType).toBe("interactive");
-    expect(mockRuntimeLoggerWarn).toHaveBeenCalledWith("feishu streaming card content index miss", {
+    expect(mockRuntimeLoggerWarn).toHaveBeenCalledWith("feishu outbound card content index miss", {
       fallbackKind: "client-upgrade",
       messageId: "om_legacy_card",
       cardId: undefined,
@@ -492,10 +498,244 @@ describe("getMessageFeishu", () => {
 
     expect(result?.content).toBe("persisted streaming content");
     expect(mockOpenSyncKeyedStore).toHaveBeenCalledWith({
-      namespace: "streaming-card-content",
+      namespace: "outbound-card-content",
       maxEntries: 20_000,
       defaultTtlMs: 7 * 24 * 60 * 60 * 1000,
     });
+  });
+
+  it("hydrates static structured card fallback from the outbound card content index", async () => {
+    const create = vi
+      .fn()
+      .mockResolvedValue({ code: 0, data: { message_id: "om_structured_index" } });
+    mockCreateFeishuClient.mockReturnValue({
+      im: {
+        message: {
+          create,
+          get: mockClientGet,
+          list: mockClientList,
+          patch: mockClientPatch,
+        },
+      },
+    });
+    mockResolveFeishuAccount.mockReturnValue({ accountId: "main", configured: true });
+
+    await sendStructuredCardFeishu({
+      cfg: {} as ClawdbotConfig,
+      to: "oc_structured_index",
+      text: "structured source text",
+      accountId: "main",
+    });
+    mockResolveFeishuAccount.mockReturnValue({ accountId: "main", configured: true });
+    mockClientGet.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        items: [
+          {
+            message_id: "om_structured_index",
+            chat_id: "oc_structured_index",
+            msg_type: "interactive",
+            body: {
+              content: JSON.stringify({
+                elements: [[{ tag: "text", text: "请升级至最新版本客户端，以查看内容" }]],
+              }),
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await getMessageFeishu({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_structured_index",
+      accountId: "main",
+    });
+
+    expect(result?.content).toBe("structured source text");
+  });
+
+  it("hydrates static markdown card fallback from the outbound card content index", async () => {
+    const create = vi
+      .fn()
+      .mockResolvedValue({ code: 0, data: { message_id: "om_markdown_index" } });
+    mockCreateFeishuClient.mockReturnValue({
+      im: {
+        message: {
+          create,
+          get: mockClientGet,
+          list: mockClientList,
+          patch: mockClientPatch,
+        },
+      },
+    });
+    mockResolveFeishuAccount.mockReturnValue({ accountId: "main", configured: true });
+
+    await sendMarkdownCardFeishu({
+      cfg: {} as ClawdbotConfig,
+      to: "oc_markdown_index",
+      text: "markdown source text",
+      accountId: "main",
+    });
+    mockResolveFeishuAccount.mockReturnValue({ accountId: "main", configured: true });
+    mockClientGet.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        items: [
+          {
+            message_id: "om_markdown_index",
+            chat_id: "oc_markdown_index",
+            msg_type: "interactive",
+            body: {
+              content: JSON.stringify({ type: "card", data: { card_id: "card_markdown" } }),
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await getMessageFeishu({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_markdown_index",
+      accountId: "main",
+    });
+
+    expect(result?.content).toBe("markdown source text");
+  });
+
+  it("indexes direct card sends only when explicit recoverable text is supplied", async () => {
+    const create = vi.fn().mockResolvedValue({ code: 0, data: { message_id: "om_direct_index" } });
+    mockCreateFeishuClient.mockReturnValue({
+      im: {
+        message: {
+          create,
+          get: mockClientGet,
+          list: mockClientList,
+          patch: mockClientPatch,
+        },
+      },
+    });
+    mockResolveFeishuAccount.mockReturnValue({ accountId: "main", configured: true });
+
+    await sendCardFeishu({
+      cfg: {} as ClawdbotConfig,
+      to: "oc_direct_index",
+      card: { schema: "2.0" },
+      accountId: "main",
+      recoverableText: "direct recoverable text",
+    });
+    mockResolveFeishuAccount.mockReturnValue({ accountId: "main", configured: true });
+    mockClientGet.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        items: [
+          {
+            message_id: "om_direct_index",
+            chat_id: "oc_direct_index",
+            msg_type: "interactive",
+            body: {
+              content: JSON.stringify({ type: "card", data: { card_id: "card_direct" } }),
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await getMessageFeishu({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_direct_index",
+      accountId: "main",
+    });
+
+    expect(result?.content).toBe("direct recoverable text");
+  });
+
+  it("does not index placeholder unknown message ids", async () => {
+    const create = vi.fn().mockResolvedValue({ code: 0, data: {} });
+    mockCreateFeishuClient.mockReturnValue({
+      im: {
+        message: {
+          create,
+          get: mockClientGet,
+          list: mockClientList,
+          patch: mockClientPatch,
+        },
+      },
+    });
+
+    await sendCardFeishu({
+      cfg: {} as ClawdbotConfig,
+      to: "oc_unknown_index",
+      card: { schema: "2.0" },
+      recoverableText: "must not persist",
+    });
+
+    expect(mockRuntimeStores.get("outbound-card-content")?.size ?? 0).toBe(0);
+  });
+
+  it("does not hydrate outbound card content across account scopes", async () => {
+    recordFeishuStreamingCardContent({
+      cardId: "card_account_scoped",
+      messageId: "om_account_scoped",
+      accountId: "main",
+      text: "main account content",
+    });
+    mockResolveFeishuAccount.mockReturnValue({ accountId: "other", configured: true });
+    mockClientGet.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        items: [
+          {
+            message_id: "om_account_scoped",
+            chat_id: "oc_account_scoped",
+            msg_type: "interactive",
+            body: {
+              content: JSON.stringify({ type: "card", data: { card_id: "card_account_scoped" } }),
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await getMessageFeishu({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_account_scoped",
+      accountId: "other",
+    });
+
+    expect(result?.content).toBe("[Interactive Card]");
+  });
+
+  it("keeps legacy streaming-card-content records readable", async () => {
+    recordLegacyFeishuStreamingCardContentForTests({
+      cardId: "card_legacy_namespace",
+      messageId: "om_legacy_namespace",
+      accountId: "main",
+      text: "legacy namespace content",
+    });
+    mockResolveFeishuAccount.mockReturnValue({ accountId: "main", configured: true });
+    mockClientGet.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        items: [
+          {
+            message_id: "om_legacy_namespace",
+            chat_id: "oc_legacy_namespace",
+            msg_type: "interactive",
+            body: {
+              content: JSON.stringify({ type: "card", data: { card_id: "card_legacy_namespace" } }),
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await getMessageFeishu({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_legacy_namespace",
+      accountId: "main",
+    });
+
+    expect(result?.content).toBe("legacy namespace content");
   });
 
   it("keeps the safe interactive fallback when the streaming card content index misses", async () => {
@@ -521,7 +761,7 @@ describe("getMessageFeishu", () => {
     });
 
     expect(result?.content).toBe("[Interactive Card]");
-    expect(mockRuntimeLoggerWarn).toHaveBeenCalledWith("feishu streaming card content index miss", {
+    expect(mockRuntimeLoggerWarn).toHaveBeenCalledWith("feishu outbound card content index miss", {
       fallbackKind: "card-reference",
       messageId: "om_stream_miss",
       cardId: "card_missing",
@@ -554,7 +794,7 @@ describe("getMessageFeishu", () => {
     });
 
     expect(result?.content).toBe("[Interactive Card]");
-    expect(mockRuntimeLoggerWarn).toHaveBeenCalledWith("feishu streaming card content index miss", {
+    expect(mockRuntimeLoggerWarn).toHaveBeenCalledWith("feishu outbound card content index miss", {
       fallbackKind: "client-upgrade",
       messageId: "om_upgrade_miss",
       cardId: undefined,
@@ -886,6 +1126,8 @@ describe("getMessageFeishu", () => {
 describe("editMessageFeishu", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockRuntimeStores.clear();
+    resetFeishuStreamingCardContentIndexForTests?.();
     mockResolveFeishuAccount.mockReturnValue({
       accountId: "default",
       configured: true,
@@ -950,6 +1192,97 @@ describe("editMessageFeishu", () => {
       },
     });
     expect(result).toEqual({ messageId: "om_card", contentType: "interactive" });
+  });
+
+  it("invalidates indexed card content when an interactive edit has no recoverable text", async () => {
+    recordFeishuStreamingCardContent({
+      messageId: "om_card_stale",
+      accountId: "default",
+      text: "stale card body",
+    });
+    recordLegacyFeishuStreamingCardContentForTests({
+      messageId: "om_card_stale",
+      accountId: "default",
+      text: "legacy stale card body",
+    });
+    mockClientPatch.mockResolvedValueOnce({ code: 0 });
+
+    await editMessageFeishu({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_card_stale",
+      card: { schema: "2.0" },
+    });
+
+    mockCreateFeishuClient.mockReturnValue({
+      im: {
+        message: {
+          get: mockClientGet,
+        },
+      },
+    });
+    mockClientGet.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        items: [
+          {
+            message_id: "om_card_stale",
+            chat_id: "oc_card_stale",
+            msg_type: "interactive",
+            body: {
+              content: JSON.stringify({ type: "card", data: { card_id: "card_stale" } }),
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await getMessageFeishu({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_card_stale",
+    });
+
+    expect(result?.content).toBe("[Interactive Card]");
+  });
+
+  it("updates indexed card content when a card update supplies recoverable text", async () => {
+    mockClientPatch.mockResolvedValueOnce({ code: 0 });
+
+    await updateCardFeishu({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_card_update",
+      card: { schema: "2.0" },
+      recoverableText: "updated recoverable body",
+    });
+
+    mockCreateFeishuClient.mockReturnValue({
+      im: {
+        message: {
+          get: mockClientGet,
+        },
+      },
+    });
+    mockClientGet.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        items: [
+          {
+            message_id: "om_card_update",
+            chat_id: "oc_card_update",
+            msg_type: "interactive",
+            body: {
+              content: JSON.stringify({ type: "card", data: { card_id: "card_update" } }),
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await getMessageFeishu({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_card_update",
+    });
+
+    expect(result?.content).toBe("updated recoverable body");
   });
 });
 

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -617,6 +617,7 @@ export async function sendMessageFeishu(
   const tableMode = resolveMarkdownTableMode({
     cfg,
     channel: "feishu",
+    accountId,
   });
 
   // Build message content (with @mention support)
@@ -709,6 +710,7 @@ export async function editMessageFeishu(params: {
   const tableMode = resolveMarkdownTableMode({
     cfg,
     channel: "feishu",
+    accountId,
   });
   const messageText = convertMarkdownTables(text!, tableMode);
   const payload = buildFeishuPostMessagePayload({ messageText });
@@ -754,6 +756,19 @@ export async function updateCardFeishu(params: {
  * Cards render markdown properly (code blocks, tables, links, etc.)
  * Uses schema 2.0 format for proper markdown rendering.
  */
+function convertFeishuMarkdownTablesForDelivery(
+  cfg: ClawdbotConfig,
+  text: string,
+  accountId?: string,
+): string {
+  const tableMode = resolveMarkdownTableMode({
+    cfg,
+    channel: "feishu",
+    accountId,
+  });
+  return convertMarkdownTables(text, tableMode);
+}
+
 export function buildMarkdownCard(text: string): Record<string, unknown> {
   return {
     schema: "2.0",
@@ -849,6 +864,7 @@ export async function sendStructuredCardFeishu(params: {
   if (mentions && mentions.length > 0) {
     cardText = buildMentionedCardContent(mentions, text);
   }
+  cardText = convertFeishuMarkdownTablesForDelivery(cfg, cardText, accountId);
   const card = buildStructuredCard(cardText, { header, note });
   return sendCardFeishu({
     cfg,
@@ -891,6 +907,7 @@ export async function sendMarkdownCardFeishu(params: {
   if (mentions && mentions.length > 0) {
     cardText = buildMentionedCardContent(mentions, text);
   }
+  cardText = convertFeishuMarkdownTablesForDelivery(cfg, cardText, accountId);
   const card = buildMarkdownCard(cardText);
   return sendCardFeishu({
     cfg,

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -14,16 +14,19 @@ import { requestFeishuApi } from "./comment-shared.js";
 import type { MentionTarget } from "./mention-target.types.js";
 import { buildMentionedCardContent, buildMentionedMessage } from "./mention.js";
 import { parsePostContent } from "./post.js";
+import { getFeishuRuntime } from "./runtime.js";
 import {
   assertFeishuMessageApiSuccess,
   resolveFeishuReceiptKind,
   toFeishuSendResult,
 } from "./send-result.js";
 import { resolveFeishuSendTarget } from "./send-target.js";
+import { lookupFeishuStreamingCardContent } from "./streaming-card-content-index.js";
 import type { FeishuChatType, FeishuMessageInfo, FeishuSendResult } from "./types.js";
 
 const WITHDRAWN_REPLY_ERROR_CODES = new Set([230011, 231003]);
 const INTERACTIVE_CARD_FALLBACK_TEXT = "[Interactive Card]";
+const FEISHU_CLIENT_UPGRADE_FALLBACK_TEXT = "请升级至最新版本客户端，以查看内容";
 const POST_FALLBACK_TEXT = "[Rich text message]";
 const FEISHU_CARD_TEMPLATES = new Set([
   "blue",
@@ -335,9 +338,43 @@ function readInteractiveTitle(
   return undefined;
 }
 
-function parseInteractiveCardContent(parsed: unknown): string {
+type ParsedInteractiveCardContent = {
+  text: string;
+  fallbackKind?: "card-reference" | "client-upgrade";
+  cardId?: string;
+};
+
+function readStreamingCardReferenceId(parsed: unknown): string | undefined {
+  if (!isRecord(parsed) || parsed.type !== "card" || !isRecord(parsed.data)) {
+    return undefined;
+  }
+  const cardId = parsed.data.card_id;
+  return typeof cardId === "string" && cardId.trim() ? cardId.trim() : undefined;
+}
+
+function resolveFallbackOnlyInteractiveKind(
+  content: string,
+): ParsedInteractiveCardContent["fallbackKind"] | undefined {
+  const lines = content
+    .trim()
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  return lines.includes(FEISHU_CLIENT_UPGRADE_FALLBACK_TEXT) ? "client-upgrade" : undefined;
+}
+
+function parseInteractiveCardContent(parsed: unknown): ParsedInteractiveCardContent {
   if (!isRecord(parsed)) {
-    return INTERACTIVE_CARD_FALLBACK_TEXT;
+    return { text: INTERACTIVE_CARD_FALLBACK_TEXT };
+  }
+
+  const cardId = readStreamingCardReferenceId(parsed);
+  if (cardId) {
+    return {
+      text: INTERACTIVE_CARD_FALLBACK_TEXT,
+      fallbackKind: "card-reference",
+      cardId,
+    };
   }
 
   const variables = readCardTemplateVariables(parsed);
@@ -354,13 +391,74 @@ function parseInteractiveCardContent(parsed: unknown): string {
   }
   const combined = parts.join("\n").trim();
   if (combined) {
-    return combined;
+    return {
+      text: combined,
+      fallbackKind: resolveFallbackOnlyInteractiveKind(combined),
+    };
   }
 
-  return parseInteractivePostFallback(parsed) ?? INTERACTIVE_CARD_FALLBACK_TEXT;
+  const postFallback = parseInteractivePostFallback(parsed);
+  if (postFallback) {
+    return {
+      text: postFallback,
+      fallbackKind: resolveFallbackOnlyInteractiveKind(postFallback),
+    };
+  }
+  return { text: INTERACTIVE_CARD_FALLBACK_TEXT };
 }
 
-function parseFeishuMessageContent(rawContent: string, msgType: string): string {
+function logInteractiveCardHydrationMiss(context: {
+  fallbackKind: NonNullable<ParsedInteractiveCardContent["fallbackKind"]>;
+  messageId?: string;
+  cardId?: string;
+  accountId?: string;
+}): void {
+  try {
+    getFeishuRuntime()
+      .logging.getChildLogger(
+        { channel: "feishu", surface: "streaming-card-content" },
+        { level: "warn" },
+      )
+      .warn("feishu streaming card content index miss", {
+        fallbackKind: context.fallbackKind,
+        messageId: context.messageId,
+        cardId: context.cardId,
+        accountId: context.accountId,
+      });
+  } catch {
+    // Quoted-message parsing must stay best-effort when runtime logging is unavailable.
+  }
+}
+
+function hydrateInteractiveCardContent(
+  parsedContent: ParsedInteractiveCardContent,
+  context: { messageId?: string; accountId?: string },
+): string {
+  if (!parsedContent.fallbackKind) {
+    return parsedContent.text;
+  }
+  const indexed = lookupFeishuStreamingCardContent({
+    cardId: parsedContent.cardId,
+    messageId: context.messageId,
+    accountId: context.accountId,
+  });
+  if (indexed?.text.trim()) {
+    return indexed.text;
+  }
+  logInteractiveCardHydrationMiss({
+    fallbackKind: parsedContent.fallbackKind,
+    messageId: context.messageId,
+    cardId: parsedContent.cardId,
+    accountId: context.accountId,
+  });
+  return INTERACTIVE_CARD_FALLBACK_TEXT;
+}
+
+function parseFeishuMessageContent(
+  rawContent: string,
+  msgType: string,
+  context: { messageId?: string; accountId?: string } = {},
+): string {
   if (!rawContent) {
     return "";
   }
@@ -382,7 +480,7 @@ function parseFeishuMessageContent(rawContent: string, msgType: string): string 
   }
 
   if (msgType === "interactive") {
-    return parseInteractiveCardContent(parsed);
+    return hydrateInteractiveCardContent(parseInteractiveCardContent(parsed), context);
   }
 
   if (typeof parsed === "string") {
@@ -404,12 +502,14 @@ function parseFeishuMessageContent(rawContent: string, msgType: string): string 
 function parseFeishuMessageItem(
   item: FeishuMessageGetItem,
   fallbackMessageId?: string,
+  options: { accountId?: string } = {},
 ): FeishuMessageInfo {
   const msgType = item.msg_type ?? "text";
   const rawContent = item.body?.content ?? "";
+  const messageId = item.message_id ?? fallbackMessageId ?? "";
 
   return {
-    messageId: item.message_id ?? fallbackMessageId ?? "",
+    messageId,
     chatId: item.chat_id ?? "",
     chatType:
       item.chat_type === "group" ||
@@ -421,7 +521,10 @@ function parseFeishuMessageItem(
     senderId: item.sender?.id,
     senderOpenId: item.sender?.id_type === "open_id" ? item.sender?.id : undefined,
     senderType: item.sender?.sender_type,
-    content: parseFeishuMessageContent(rawContent, msgType),
+    content: parseFeishuMessageContent(rawContent, msgType, {
+      messageId,
+      accountId: options.accountId,
+    }),
     rawContent,
     contentType: msgType,
     createTime: parseStrictNonNegativeInteger(item.create_time),
@@ -466,7 +569,7 @@ export async function getMessageFeishu(params: {
       return null;
     }
 
-    return parseFeishuMessageItem(item, messageId);
+    return parseFeishuMessageItem(item, messageId, { accountId: account.accountId });
   } catch {
     return null;
   }
@@ -543,7 +646,7 @@ export async function listFeishuThreadMessages(params: {
       continue;
     }
 
-    const parsed = parseFeishuMessageItem(item);
+    const parsed = parseFeishuMessageItem(item, undefined, { accountId: account.accountId });
 
     results.push({
       messageId: parsed.messageId,

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -250,6 +250,9 @@ function extractInteractiveElementText(
   element: unknown,
   variables: Map<string, string>,
 ): string | undefined {
+  if (Array.isArray(element)) {
+    return extractInteractiveElementsText(element, variables);
+  }
   if (!isRecord(element)) {
     return undefined;
   }
@@ -257,6 +260,12 @@ function extractInteractiveElementText(
   const text = isRecord(element.text) ? element.text : undefined;
 
   if (tag === "div" && typeof text?.content === "string") {
+    return applyCardTemplateVariables(text.content, variables);
+  }
+  if (tag === "text" && typeof element.text === "string") {
+    return applyCardTemplateVariables(element.text, variables);
+  }
+  if (tag === "text" && typeof text?.content === "string") {
     return applyCardTemplateVariables(text.content, variables);
   }
   if ((tag === "markdown" || tag === "lark_md") && typeof element.content === "string") {
@@ -311,17 +320,41 @@ function parseInteractivePostFallback(parsed: unknown): string | undefined {
   return textContent && textContent !== POST_FALLBACK_TEXT ? textContent : undefined;
 }
 
+function readInteractiveTitle(
+  parsed: Record<string, unknown>,
+  variables: Map<string, string>,
+): string | undefined {
+  if (typeof parsed.title === "string" && parsed.title.trim()) {
+    return applyCardTemplateVariables(parsed.title.trim(), variables);
+  }
+  const header = isRecord(parsed.header) ? parsed.header : undefined;
+  const title = isRecord(header?.title) ? header.title : undefined;
+  if (typeof title?.content === "string" && title.content.trim()) {
+    return applyCardTemplateVariables(title.content.trim(), variables);
+  }
+  return undefined;
+}
+
 function parseInteractiveCardContent(parsed: unknown): string {
   if (!isRecord(parsed)) {
     return INTERACTIVE_CARD_FALLBACK_TEXT;
   }
 
   const variables = readCardTemplateVariables(parsed);
+  const parts: string[] = [];
+  const title = readInteractiveTitle(parsed, variables);
+  if (title) {
+    parts.push(title);
+  }
   for (const elements of readInteractiveElementArrays(parsed)) {
     const text = extractInteractiveElementsText(elements, variables);
     if (text) {
-      return text;
+      parts.push(text);
     }
+  }
+  const combined = parts.join("\n").trim();
+  if (combined) {
+    return combined;
   }
 
   return parseInteractivePostFallback(parsed) ?? INTERACTIVE_CARD_FALLBACK_TEXT;
@@ -389,6 +422,7 @@ function parseFeishuMessageItem(
     senderOpenId: item.sender?.id_type === "open_id" ? item.sender?.id : undefined,
     senderType: item.sender?.sender_type,
     content: parseFeishuMessageContent(rawContent, msgType),
+    rawContent,
     contentType: msgType,
     createTime: parseStrictNonNegativeInteger(item.create_time),
     threadId: item.thread_id || undefined,

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -21,7 +21,11 @@ import {
   toFeishuSendResult,
 } from "./send-result.js";
 import { resolveFeishuSendTarget } from "./send-target.js";
-import { lookupFeishuStreamingCardContent } from "./streaming-card-content-index.js";
+import {
+  invalidateFeishuOutboundCardContent,
+  lookupFeishuStreamingCardContent,
+  recordFeishuOutboundCardContent,
+} from "./streaming-card-content-index.js";
 import type { FeishuChatType, FeishuMessageInfo, FeishuSendResult } from "./types.js";
 
 const WITHDRAWN_REPLY_ERROR_CODES = new Set([230011, 231003]);
@@ -416,10 +420,10 @@ function logInteractiveCardHydrationMiss(context: {
   try {
     getFeishuRuntime()
       .logging.getChildLogger(
-        { channel: "feishu", surface: "streaming-card-content" },
+        { channel: "feishu", surface: "outbound-card-content" },
         { level: "warn" },
       )
-      .warn("feishu streaming card content index miss", {
+      .warn("feishu outbound card content index miss", {
         fallbackKind: context.fallbackKind,
         messageId: context.messageId,
         cardId: context.cardId,
@@ -754,16 +758,31 @@ export type SendFeishuCardParams = {
   replyInThread?: boolean;
   allowTopLevelReplyFallback?: boolean;
   accountId?: string;
+  /** Explicit display/source text safe to recover when Feishu later returns only a card shell. */
+  recoverableText?: string;
 };
 
 export async function sendCardFeishu(params: SendFeishuCardParams): Promise<FeishuSendResult> {
-  const { cfg, to, card, replyToMessageId, replyInThread, allowTopLevelReplyFallback, accountId } =
-    params;
-  const { client, receiveId, receiveIdType } = resolveFeishuSendTarget({ cfg, to, accountId });
+  const {
+    cfg,
+    to,
+    card,
+    replyToMessageId,
+    replyInThread,
+    allowTopLevelReplyFallback,
+    accountId,
+    recoverableText,
+  } = params;
+  const {
+    client,
+    receiveId,
+    receiveIdType,
+    accountId: resolvedAccountId,
+  } = resolveFeishuSendTarget({ cfg, to, accountId });
   const content = JSON.stringify(card);
 
   const directParams = { receiveId, receiveIdType, content, msgType: "interactive" };
-  return sendReplyOrFallbackDirect(client, {
+  const result = await sendReplyOrFallbackDirect(client, {
     replyToMessageId,
     replyInThread,
     allowTopLevelReplyFallback,
@@ -773,6 +792,13 @@ export async function sendCardFeishu(params: SendFeishuCardParams): Promise<Feis
     directErrorPrefix: "Feishu card send failed",
     replyErrorPrefix: "Feishu card reply failed",
   });
+  recordFeishuOutboundCardContent({
+    messageId: result.messageId,
+    accountId: resolvedAccountId,
+    chatId: result.chatId,
+    text: recoverableText,
+  });
+  return result;
 }
 
 export async function editMessageFeishu(params: {
@@ -781,8 +807,10 @@ export async function editMessageFeishu(params: {
   text?: string;
   card?: Record<string, unknown>;
   accountId?: string;
+  /** Explicit display/source text safe to recover for edited interactive cards. */
+  recoverableText?: string;
 }): Promise<{ messageId: string; contentType: "post" | "interactive" }> {
-  const { cfg, messageId, text, card, accountId } = params;
+  const { cfg, messageId, text, card, accountId, recoverableText } = params;
   const account = resolveFeishuRuntimeAccount({ cfg, accountId });
   if (!account.configured) {
     throw new Error(`Feishu account "${account.accountId}" not configured`);
@@ -807,6 +835,16 @@ export async function editMessageFeishu(params: {
       throw new Error(`Feishu message edit failed: ${response.msg || `code ${response.code}`}`);
     }
 
+    if (recoverableText?.trim()) {
+      recordFeishuOutboundCardContent({
+        messageId,
+        accountId: account.accountId,
+        text: recoverableText,
+      });
+    } else {
+      invalidateFeishuOutboundCardContent({ messageId, accountId: account.accountId });
+    }
+
     return { messageId, contentType: "interactive" };
   }
 
@@ -826,6 +864,8 @@ export async function editMessageFeishu(params: {
     throw new Error(`Feishu message edit failed: ${response.msg || `code ${response.code}`}`);
   }
 
+  invalidateFeishuOutboundCardContent({ messageId, accountId: account.accountId });
+
   return { messageId, contentType: "post" };
 }
 
@@ -834,8 +874,10 @@ export async function updateCardFeishu(params: {
   messageId: string;
   card: Record<string, unknown>;
   accountId?: string;
+  /** Explicit display/source text safe to recover for updated interactive cards. */
+  recoverableText?: string;
 }): Promise<void> {
-  const { cfg, messageId, card, accountId } = params;
+  const { cfg, messageId, card, accountId, recoverableText } = params;
   const account = resolveFeishuRuntimeAccount({ cfg, accountId });
   if (!account.configured) {
     throw new Error(`Feishu account "${account.accountId}" not configured`);
@@ -851,6 +893,16 @@ export async function updateCardFeishu(params: {
 
   if (response.code !== 0) {
     throw new Error(`Feishu card update failed: ${response.msg || `code ${response.code}`}`);
+  }
+
+  if (recoverableText?.trim()) {
+    recordFeishuOutboundCardContent({
+      messageId,
+      accountId: account.accountId,
+      text: recoverableText,
+    });
+  } else {
+    invalidateFeishuOutboundCardContent({ messageId, accountId: account.accountId });
   }
 }
 
@@ -977,6 +1029,7 @@ export async function sendStructuredCardFeishu(params: {
     replyInThread,
     allowTopLevelReplyFallback,
     accountId,
+    recoverableText: cardText,
   });
 }
 
@@ -1020,5 +1073,6 @@ export async function sendMarkdownCardFeishu(params: {
     replyInThread,
     allowTopLevelReplyFallback,
     accountId,
+    recoverableText: cardText,
   });
 }

--- a/extensions/feishu/src/streaming-card-content-index.ts
+++ b/extensions/feishu/src/streaming-card-content-index.ts
@@ -1,0 +1,207 @@
+// Feishu plugin module persists streaming card text for quoted-message hydration.
+import { createHash } from "node:crypto";
+import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
+import { getFeishuRuntime } from "./runtime.js";
+
+const STREAMING_CARD_CONTENT_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const STORE_MAX_ENTRIES = 20_000;
+const MEMORY_MAX_SIZE = 2_000;
+const STORE_NAMESPACE = "streaming-card-content";
+
+type FeishuStreamingCardContentEntry = {
+  cardId: string;
+  messageId: string;
+  accountId?: string;
+  chatId?: string;
+  text: string;
+  updatedAt: number;
+};
+
+type RecordFeishuStreamingCardContentParams = {
+  cardId?: string | null;
+  messageId?: string | null;
+  accountId?: string | null;
+  chatId?: string | null;
+  text?: string | null;
+  updatedAt?: number;
+  log?: (message: string) => void;
+};
+
+type LookupFeishuStreamingCardContentParams = {
+  cardId?: string | null;
+  messageId?: string | null;
+  accountId?: string | null;
+  log?: (message: string) => void;
+};
+
+const memory = new Map<string, FeishuStreamingCardContentEntry>();
+let cachedStore: PluginStateSyncKeyedStore<FeishuStreamingCardContentEntry> | null = null;
+
+function normalizeId(value: string | null | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function normalizeOptional(value: string | null | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function isFresh(entry: FeishuStreamingCardContentEntry | undefined, now = Date.now()): boolean {
+  return Boolean(
+    entry &&
+    typeof entry.updatedAt === "number" &&
+    Number.isFinite(entry.updatedAt) &&
+    now - entry.updatedAt < STREAMING_CARD_CONTENT_TTL_MS,
+  );
+}
+
+function pruneMemory(now = Date.now()): void {
+  for (const [key, entry] of memory) {
+    if (!isFresh(entry, now)) {
+      memory.delete(key);
+    }
+  }
+  if (memory.size <= MEMORY_MAX_SIZE) {
+    return;
+  }
+  const toRemove = Array.from(memory.entries())
+    .toSorted(([, left], [, right]) => left.updatedAt - right.updatedAt)
+    .slice(0, memory.size - MEMORY_MAX_SIZE);
+  for (const [key] of toRemove) {
+    memory.delete(key);
+  }
+}
+
+function scopedRecordKeys(kind: "card" | "message", id: string, accountId?: string): string[] {
+  const account = normalizeOptional(accountId);
+  return [`${kind}:${account ?? "global"}:${id}`];
+}
+
+function scopedLookupKeys(kind: "card" | "message", id: string, accountId?: string): string[] {
+  const account = normalizeOptional(accountId);
+  return account ? [`${kind}:${account}:${id}`, `${kind}:global:${id}`] : [`${kind}:global:${id}`];
+}
+
+function storeKey(rawKey: string): string {
+  return createHash("sha256").update(rawKey, "utf8").digest("hex").slice(0, 32);
+}
+
+function openStore(): PluginStateSyncKeyedStore<FeishuStreamingCardContentEntry> {
+  if (cachedStore) {
+    return cachedStore;
+  }
+  cachedStore = getFeishuRuntime().state.openSyncKeyedStore<FeishuStreamingCardContentEntry>({
+    namespace: STORE_NAMESPACE,
+    maxEntries: STORE_MAX_ENTRIES,
+    defaultTtlMs: STREAMING_CARD_CONTENT_TTL_MS,
+  });
+  return cachedStore;
+}
+
+function remember(rawKey: string, entry: FeishuStreamingCardContentEntry): void {
+  memory.set(rawKey, entry);
+  pruneMemory(entry.updatedAt);
+}
+
+function readMemory(rawKey: string): FeishuStreamingCardContentEntry | undefined {
+  const entry = memory.get(rawKey);
+  if (isFresh(entry)) {
+    return entry;
+  }
+  memory.delete(rawKey);
+  return undefined;
+}
+
+export function recordFeishuStreamingCardContent(
+  params: RecordFeishuStreamingCardContentParams,
+): boolean {
+  const cardId = normalizeId(params.cardId);
+  const messageId = normalizeId(params.messageId);
+  if (!cardId || !messageId) {
+    return false;
+  }
+  const updatedAt = params.updatedAt ?? Date.now();
+  const entry: FeishuStreamingCardContentEntry = {
+    cardId,
+    messageId,
+    accountId: normalizeOptional(params.accountId),
+    chatId: normalizeOptional(params.chatId),
+    text: typeof params.text === "string" ? params.text : "",
+    updatedAt,
+  };
+  const rawKeys = [
+    ...scopedRecordKeys("message", messageId, entry.accountId),
+    ...scopedRecordKeys("card", cardId, entry.accountId),
+  ];
+
+  for (const rawKey of rawKeys) {
+    remember(rawKey, entry);
+  }
+
+  try {
+    const store = openStore();
+    for (const rawKey of rawKeys) {
+      store.register(storeKey(rawKey), entry, { ttlMs: STREAMING_CARD_CONTENT_TTL_MS });
+    }
+    return true;
+  } catch (error) {
+    params.log?.(`feishu-streaming-card-content: persistent state error: ${String(error)}`);
+    return true;
+  }
+}
+
+function lookupRawKey(
+  rawKey: string,
+  log?: (message: string) => void,
+): FeishuStreamingCardContentEntry | undefined {
+  const memoryEntry = readMemory(rawKey);
+  if (memoryEntry) {
+    return memoryEntry;
+  }
+  try {
+    const entry = openStore().lookup(storeKey(rawKey));
+    if (!entry || !isFresh(entry)) {
+      return undefined;
+    }
+    remember(rawKey, entry);
+    return entry;
+  } catch (error) {
+    log?.(`feishu-streaming-card-content: persistent lookup failed: ${String(error)}`);
+    return undefined;
+  }
+}
+
+export function lookupFeishuStreamingCardContent(
+  params: LookupFeishuStreamingCardContentParams,
+): FeishuStreamingCardContentEntry | undefined {
+  const accountId = normalizeOptional(params.accountId);
+  const messageId = normalizeId(params.messageId);
+  const cardId = normalizeId(params.cardId);
+  const rawKeys: string[] = [];
+  if (messageId) {
+    rawKeys.push(...scopedLookupKeys("message", messageId, accountId));
+  }
+  if (cardId) {
+    rawKeys.push(...scopedLookupKeys("card", cardId, accountId));
+  }
+
+  for (const rawKey of rawKeys) {
+    const entry = lookupRawKey(rawKey, params.log);
+    if (entry?.text.trim()) {
+      return entry;
+    }
+  }
+  return undefined;
+}
+
+export const testingHooks = {
+  resetFeishuStreamingCardContentIndexForTests() {
+    memory.clear();
+    cachedStore?.clear();
+    cachedStore = null;
+  },
+  resetFeishuStreamingCardContentMemoryForTests() {
+    memory.clear();
+  },
+};

--- a/extensions/feishu/src/streaming-card-content-index.ts
+++ b/extensions/feishu/src/streaming-card-content-index.ts
@@ -1,15 +1,16 @@
-// Feishu plugin module persists streaming card text for quoted-message hydration.
+// Feishu plugin module persists outbound card text for quoted-message hydration.
 import { createHash } from "node:crypto";
 import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { getFeishuRuntime } from "./runtime.js";
 
-const STREAMING_CARD_CONTENT_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const OUTBOUND_CARD_CONTENT_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 const STORE_MAX_ENTRIES = 20_000;
 const MEMORY_MAX_SIZE = 2_000;
-const STORE_NAMESPACE = "streaming-card-content";
+const STORE_NAMESPACE = "outbound-card-content";
+const LEGACY_STREAMING_STORE_NAMESPACE = "streaming-card-content";
 
-type FeishuStreamingCardContentEntry = {
-  cardId: string;
+type FeishuOutboundCardContentEntry = {
+  cardId?: string;
   messageId: string;
   accountId?: string;
   chatId?: string;
@@ -17,7 +18,7 @@ type FeishuStreamingCardContentEntry = {
   updatedAt: number;
 };
 
-type RecordFeishuStreamingCardContentParams = {
+type RecordFeishuOutboundCardContentParams = {
   cardId?: string | null;
   messageId?: string | null;
   accountId?: string | null;
@@ -27,19 +28,30 @@ type RecordFeishuStreamingCardContentParams = {
   log?: (message: string) => void;
 };
 
-type LookupFeishuStreamingCardContentParams = {
+type LookupFeishuOutboundCardContentParams = {
   cardId?: string | null;
   messageId?: string | null;
   accountId?: string | null;
   log?: (message: string) => void;
 };
 
-const memory = new Map<string, FeishuStreamingCardContentEntry>();
-let cachedStore: PluginStateSyncKeyedStore<FeishuStreamingCardContentEntry> | null = null;
+type InvalidateFeishuOutboundCardContentParams = {
+  messageId?: string | null;
+  accountId?: string | null;
+  log?: (message: string) => void;
+};
+
+const memory = new Map<string, FeishuOutboundCardContentEntry>();
+const cachedStores = new Map<string, PluginStateSyncKeyedStore<FeishuOutboundCardContentEntry>>();
 
 function normalizeId(value: string | null | undefined): string | undefined {
   const trimmed = value?.trim();
   return trimmed ? trimmed : undefined;
+}
+
+function normalizeMessageId(value: string | null | undefined): string | undefined {
+  const trimmed = normalizeId(value);
+  return trimmed && trimmed !== "unknown" ? trimmed : undefined;
 }
 
 function normalizeOptional(value: string | null | undefined): string | undefined {
@@ -47,12 +59,19 @@ function normalizeOptional(value: string | null | undefined): string | undefined
   return trimmed ? trimmed : undefined;
 }
 
-function isFresh(entry: FeishuStreamingCardContentEntry | undefined, now = Date.now()): boolean {
+function normalizeText(value: string | null | undefined): string | undefined {
+  if (typeof value !== "string" || !value.trim()) {
+    return undefined;
+  }
+  return value;
+}
+
+function isFresh(entry: FeishuOutboundCardContentEntry | undefined, now = Date.now()): boolean {
   return Boolean(
     entry &&
     typeof entry.updatedAt === "number" &&
     Number.isFinite(entry.updatedAt) &&
-    now - entry.updatedAt < STREAMING_CARD_CONTENT_TTL_MS,
+    now - entry.updatedAt < OUTBOUND_CARD_CONTENT_TTL_MS,
   );
 }
 
@@ -80,114 +99,170 @@ function scopedRecordKeys(kind: "card" | "message", id: string, accountId?: stri
 
 function scopedLookupKeys(kind: "card" | "message", id: string, accountId?: string): string[] {
   const account = normalizeOptional(accountId);
-  return account ? [`${kind}:${account}:${id}`, `${kind}:global:${id}`] : [`${kind}:global:${id}`];
+  return [`${kind}:${account ?? "global"}:${id}`];
 }
 
 function storeKey(rawKey: string): string {
   return createHash("sha256").update(rawKey, "utf8").digest("hex").slice(0, 32);
 }
 
-function openStore(): PluginStateSyncKeyedStore<FeishuStreamingCardContentEntry> {
-  if (cachedStore) {
-    return cachedStore;
-  }
-  cachedStore = getFeishuRuntime().state.openSyncKeyedStore<FeishuStreamingCardContentEntry>({
-    namespace: STORE_NAMESPACE,
-    maxEntries: STORE_MAX_ENTRIES,
-    defaultTtlMs: STREAMING_CARD_CONTENT_TTL_MS,
-  });
-  return cachedStore;
+function memoryKey(namespace: string, rawKey: string): string {
+  return `${namespace}:${rawKey}`;
 }
 
-function remember(rawKey: string, entry: FeishuStreamingCardContentEntry): void {
-  memory.set(rawKey, entry);
+function openStore(namespace: string): PluginStateSyncKeyedStore<FeishuOutboundCardContentEntry> {
+  const cached = cachedStores.get(namespace);
+  if (cached) {
+    return cached;
+  }
+  const store = getFeishuRuntime().state.openSyncKeyedStore<FeishuOutboundCardContentEntry>({
+    namespace,
+    maxEntries: STORE_MAX_ENTRIES,
+    defaultTtlMs: OUTBOUND_CARD_CONTENT_TTL_MS,
+  });
+  cachedStores.set(namespace, store);
+  return store;
+}
+
+function remember(namespace: string, rawKey: string, entry: FeishuOutboundCardContentEntry): void {
+  memory.set(memoryKey(namespace, rawKey), entry);
   pruneMemory(entry.updatedAt);
 }
 
-function readMemory(rawKey: string): FeishuStreamingCardContentEntry | undefined {
-  const entry = memory.get(rawKey);
+function readMemory(namespace: string, rawKey: string): FeishuOutboundCardContentEntry | undefined {
+  const key = memoryKey(namespace, rawKey);
+  const entry = memory.get(key);
   if (isFresh(entry)) {
     return entry;
   }
-  memory.delete(rawKey);
+  memory.delete(key);
   return undefined;
 }
 
-export function recordFeishuStreamingCardContent(
-  params: RecordFeishuStreamingCardContentParams,
+function recordFeishuCardContent(
+  namespace: string,
+  params: RecordFeishuOutboundCardContentParams,
 ): boolean {
-  const cardId = normalizeId(params.cardId);
-  const messageId = normalizeId(params.messageId);
-  if (!cardId || !messageId) {
+  const messageId = normalizeMessageId(params.messageId);
+  const text = normalizeText(params.text);
+  if (!messageId || !text) {
     return false;
   }
+  const cardId = normalizeId(params.cardId);
   const updatedAt = params.updatedAt ?? Date.now();
-  const entry: FeishuStreamingCardContentEntry = {
-    cardId,
+  const entry: FeishuOutboundCardContentEntry = {
+    ...(cardId ? { cardId } : {}),
     messageId,
     accountId: normalizeOptional(params.accountId),
     chatId: normalizeOptional(params.chatId),
-    text: typeof params.text === "string" ? params.text : "",
+    text,
     updatedAt,
   };
   const rawKeys = [
     ...scopedRecordKeys("message", messageId, entry.accountId),
-    ...scopedRecordKeys("card", cardId, entry.accountId),
+    ...(cardId ? scopedRecordKeys("card", cardId, entry.accountId) : []),
   ];
 
   for (const rawKey of rawKeys) {
-    remember(rawKey, entry);
+    remember(namespace, rawKey, entry);
   }
 
   try {
-    const store = openStore();
+    const store = openStore(namespace);
     for (const rawKey of rawKeys) {
-      store.register(storeKey(rawKey), entry, { ttlMs: STREAMING_CARD_CONTENT_TTL_MS });
+      store.register(storeKey(rawKey), entry, { ttlMs: OUTBOUND_CARD_CONTENT_TTL_MS });
     }
     return true;
   } catch (error) {
-    params.log?.(`feishu-streaming-card-content: persistent state error: ${String(error)}`);
+    params.log?.(`feishu-outbound-card-content: persistent state error: ${String(error)}`);
     return true;
   }
 }
 
+export function recordFeishuOutboundCardContent(
+  params: RecordFeishuOutboundCardContentParams,
+): boolean {
+  return recordFeishuCardContent(STORE_NAMESPACE, params);
+}
+
+export function recordFeishuStreamingCardContent(
+  params: RecordFeishuOutboundCardContentParams,
+): boolean {
+  if (typeof params.text === "string" && !params.text.trim()) {
+    return invalidateFeishuOutboundCardContent(params);
+  }
+  return recordFeishuOutboundCardContent(params);
+}
+
+function isLookupMatch(params: {
+  entry: FeishuOutboundCardContentEntry;
+  kind: "card" | "message";
+  id: string;
+  accountId?: string;
+}): boolean {
+  const { entry, kind, id, accountId } = params;
+  if (kind === "message" && entry.messageId !== id) {
+    return false;
+  }
+  if (kind === "card" && entry.cardId !== id) {
+    return false;
+  }
+  const entryAccount = normalizeOptional(entry.accountId);
+  return accountId ? entryAccount === accountId : entryAccount === undefined;
+}
+
 function lookupRawKey(
+  namespace: string,
   rawKey: string,
+  match: { kind: "card" | "message"; id: string; accountId?: string },
   log?: (message: string) => void,
-): FeishuStreamingCardContentEntry | undefined {
-  const memoryEntry = readMemory(rawKey);
-  if (memoryEntry) {
+): FeishuOutboundCardContentEntry | undefined {
+  const memoryEntry = readMemory(namespace, rawKey);
+  if (memoryEntry && isLookupMatch({ entry: memoryEntry, ...match })) {
     return memoryEntry;
   }
   try {
-    const entry = openStore().lookup(storeKey(rawKey));
-    if (!entry || !isFresh(entry)) {
+    const entry = openStore(namespace).lookup(storeKey(rawKey));
+    if (!entry || !isFresh(entry) || !isLookupMatch({ entry, ...match })) {
       return undefined;
     }
-    remember(rawKey, entry);
+    remember(namespace, rawKey, entry);
     return entry;
   } catch (error) {
-    log?.(`feishu-streaming-card-content: persistent lookup failed: ${String(error)}`);
+    log?.(`feishu-outbound-card-content: persistent lookup failed: ${String(error)}`);
     return undefined;
   }
 }
 
-export function lookupFeishuStreamingCardContent(
-  params: LookupFeishuStreamingCardContentParams,
-): FeishuStreamingCardContentEntry | undefined {
+function lookupFeishuCardContent(
+  namespace: string,
+  params: LookupFeishuOutboundCardContentParams,
+): FeishuOutboundCardContentEntry | undefined {
   const accountId = normalizeOptional(params.accountId);
-  const messageId = normalizeId(params.messageId);
+  const messageId = normalizeMessageId(params.messageId);
   const cardId = normalizeId(params.cardId);
-  const rawKeys: string[] = [];
+  const rawKeys: Array<{ rawKey: string; kind: "card" | "message"; id: string }> = [];
   if (messageId) {
-    rawKeys.push(...scopedLookupKeys("message", messageId, accountId));
+    rawKeys.push(
+      ...scopedLookupKeys("message", messageId, accountId).map((rawKey) => ({
+        rawKey,
+        kind: "message" as const,
+        id: messageId,
+      })),
+    );
   }
   if (cardId) {
-    rawKeys.push(...scopedLookupKeys("card", cardId, accountId));
+    rawKeys.push(
+      ...scopedLookupKeys("card", cardId, accountId).map((rawKey) => ({
+        rawKey,
+        kind: "card" as const,
+        id: cardId,
+      })),
+    );
   }
 
-  for (const rawKey of rawKeys) {
-    const entry = lookupRawKey(rawKey, params.log);
+  for (const { rawKey, kind, id } of rawKeys) {
+    const entry = lookupRawKey(namespace, rawKey, { kind, id, accountId }, params.log);
     if (entry?.text.trim()) {
       return entry;
     }
@@ -195,13 +270,101 @@ export function lookupFeishuStreamingCardContent(
   return undefined;
 }
 
+export function lookupFeishuOutboundCardContent(
+  params: LookupFeishuOutboundCardContentParams,
+): FeishuOutboundCardContentEntry | undefined {
+  return lookupFeishuCardContent(STORE_NAMESPACE, params);
+}
+
+export function lookupFeishuLegacyStreamingCardContent(
+  params: LookupFeishuOutboundCardContentParams,
+): FeishuOutboundCardContentEntry | undefined {
+  return lookupFeishuCardContent(LEGACY_STREAMING_STORE_NAMESPACE, params);
+}
+
+export function lookupFeishuStreamingCardContent(
+  params: LookupFeishuOutboundCardContentParams,
+): FeishuOutboundCardContentEntry | undefined {
+  return lookupFeishuOutboundCardContent(params) ?? lookupFeishuLegacyStreamingCardContent(params);
+}
+
+function shouldDeleteEntry(
+  entry: FeishuOutboundCardContentEntry,
+  messageId: string,
+  accountId?: string,
+): boolean {
+  if (entry.messageId !== messageId) {
+    return false;
+  }
+  const entryAccount = normalizeOptional(entry.accountId);
+  if (!accountId) {
+    return true;
+  }
+  return entryAccount === accountId || entryAccount === undefined;
+}
+
+function invalidateNamespace(
+  namespace: string,
+  params: { messageId: string; accountId?: string; log?: (message: string) => void },
+): boolean {
+  let deleted = false;
+  const namespacePrefix = `${namespace}:`;
+  for (const [key, entry] of Array.from(memory.entries())) {
+    if (
+      key.startsWith(namespacePrefix) &&
+      shouldDeleteEntry(entry, params.messageId, params.accountId)
+    ) {
+      memory.delete(key);
+      deleted = true;
+    }
+  }
+
+  try {
+    const store = openStore(namespace);
+    for (const { key, value } of store.entries()) {
+      if (shouldDeleteEntry(value, params.messageId, params.accountId)) {
+        deleted = store.delete(key) || deleted;
+      }
+    }
+  } catch (error) {
+    params.log?.(`feishu-outbound-card-content: persistent delete failed: ${String(error)}`);
+  }
+  return deleted;
+}
+
+export function invalidateFeishuOutboundCardContent(
+  params: InvalidateFeishuOutboundCardContentParams,
+): boolean {
+  const messageId = normalizeMessageId(params.messageId);
+  if (!messageId) {
+    return false;
+  }
+  const accountId = normalizeOptional(params.accountId);
+  const deletedCurrent = invalidateNamespace(STORE_NAMESPACE, {
+    messageId,
+    accountId,
+    log: params.log,
+  });
+  const deletedLegacy = invalidateNamespace(LEGACY_STREAMING_STORE_NAMESPACE, {
+    messageId,
+    accountId,
+    log: params.log,
+  });
+  return deletedCurrent || deletedLegacy;
+}
+
 export const testingHooks = {
   resetFeishuStreamingCardContentIndexForTests() {
     memory.clear();
-    cachedStore?.clear();
-    cachedStore = null;
+    for (const store of cachedStores.values()) {
+      store.clear();
+    }
+    cachedStores.clear();
   },
   resetFeishuStreamingCardContentMemoryForTests() {
     memory.clear();
+  },
+  recordLegacyFeishuStreamingCardContentForTests(params: RecordFeishuOutboundCardContentParams) {
+    return recordFeishuCardContent(LEGACY_STREAMING_STORE_NAMESPACE, params);
   },
 };

--- a/extensions/feishu/src/streaming-card.test.ts
+++ b/extensions/feishu/src/streaming-card.test.ts
@@ -1,12 +1,57 @@
 // Feishu tests cover streaming card plugin behavior.
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
+const { fetchWithSsrFGuardMock, mockRuntimeStores, mockOpenSyncKeyedStore } = vi.hoisted(() => {
+  const stores = new Map<string, Map<string, unknown>>();
+  const openSyncKeyedStore = vi.fn(({ namespace }: { namespace: string }) => {
+    let store = stores.get(namespace);
+    if (!store) {
+      store = new Map<string, unknown>();
+      stores.set(namespace, store);
+    }
+    return {
+      register: (key: string, value: unknown) => {
+        store.set(key, value);
+      },
+      registerIfAbsent: (key: string, value: unknown) => {
+        if (store.has(key)) {
+          return false;
+        }
+        store.set(key, value);
+        return true;
+      },
+      lookup: (key: string) => store.get(key),
+      consume: (key: string) => {
+        const value = store.get(key);
+        store.delete(key);
+        return value;
+      },
+      delete: (key: string) => store.delete(key),
+      entries: () =>
+        Array.from(store.entries()).map(([key, value]) => ({ key, value, createdAt: 0 })),
+      clear: () => store.clear(),
+    };
+  });
+  return {
+    fetchWithSsrFGuardMock: vi.fn(),
+    mockRuntimeStores: stores,
+    mockOpenSyncKeyedStore: openSyncKeyedStore,
+  };
+});
 
 vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
   fetchWithSsrFGuard: fetchWithSsrFGuardMock,
 }));
 
+vi.mock("./runtime.js", () => ({
+  getFeishuRuntime: () => ({
+    state: {
+      openSyncKeyedStore: mockOpenSyncKeyedStore,
+    },
+  }),
+}));
+
+import { testingHooks as streamingCardContentIndexTestingHooks } from "./streaming-card-content-index.js";
 import {
   FeishuStreamingSession,
   mergeStreamingText,
@@ -16,6 +61,8 @@ import {
 type StreamingSessionState = {
   cardId: string;
   messageId: string;
+  accountId?: string;
+  chatId?: string;
   sequence: number;
   currentText: string;
   sentText: string;
@@ -42,12 +89,16 @@ function setStreamingSessionInternals(
 describe("FeishuStreamingSession", () => {
   afterAll(() => {
     vi.doUnmock("openclaw/plugin-sdk/ssrf-runtime");
+    vi.doUnmock("./runtime.js");
     vi.resetModules();
   });
 
   beforeEach(() => {
     vi.useRealTimers();
     fetchWithSsrFGuardMock.mockReset();
+    mockRuntimeStores.clear();
+    mockOpenSyncKeyedStore.mockClear();
+    streamingCardContentIndexTestingHooks.resetFeishuStreamingCardContentIndexForTests();
   });
 
   afterEach(() => {
@@ -151,6 +202,106 @@ describe("FeishuStreamingSession", () => {
     } as unknown as ConstructorParameters<typeof FeishuStreamingSession>[0];
     return { authTokens, client };
   }
+
+  function streamingCardContentEntries(): Array<{
+    cardId?: unknown;
+    messageId?: unknown;
+    accountId?: unknown;
+    chatId?: unknown;
+    text?: unknown;
+  }> {
+    return Array.from(mockRuntimeStores.get("streaming-card-content")?.values() ?? []) as Array<{
+      cardId?: unknown;
+      messageId?: unknown;
+      accountId?: unknown;
+      chatId?: unknown;
+      text?: unknown;
+    }>;
+  }
+
+  it("records card identity with empty text when streaming start succeeds", async () => {
+    const { client } = mockStreamingTokenStart(() => ({
+      code: 0,
+      msg: "ok",
+      tenant_access_token: "token-start-index",
+      expire: 7200,
+    }));
+
+    await new FeishuStreamingSession(client, {
+      appId: "app_start_index",
+      appSecret: "secret",
+      accountId: "main",
+    }).start("oc_stream_start", "chat_id");
+
+    expect(streamingCardContentEntries()).toEqual([
+      {
+        cardId: "card-1",
+        messageId: "om_1",
+        accountId: "main",
+        chatId: "oc_stream_start",
+        text: "",
+        updatedAt: expect.any(Number),
+      },
+      {
+        cardId: "card-1",
+        messageId: "om_1",
+        accountId: "main",
+        chatId: "oc_stream_start",
+        text: "",
+        updatedAt: expect.any(Number),
+      },
+    ]);
+  });
+
+  it("records accepted update text and final close text", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(5_000);
+    const updateBodies: string[] = [];
+    const replaceBodies: string[] = [];
+    mockFetches(updateBodies, new Set<number>(), replaceBodies);
+
+    const session = new FeishuStreamingSession({} as never, {
+      appId: "app_update_index",
+      appSecret: "secret",
+    });
+    setStreamingSessionInternals(session, {
+      state: {
+        cardId: "card_update_index",
+        messageId: "om_update_index",
+        accountId: "main",
+        chatId: "oc_update_index",
+        sequence: 1,
+        currentText: "hello",
+        sentText: "hello",
+        hasNote: false,
+      },
+      lastUpdateTime: 3_000,
+    });
+
+    await session.update("hello world");
+    await session.close("final answer");
+
+    expect(updateBodies).toHaveLength(1);
+    expect(replaceBodies).toHaveLength(1);
+    expect(streamingCardContentEntries()).toEqual([
+      {
+        cardId: "card_update_index",
+        messageId: "om_update_index",
+        accountId: "main",
+        chatId: "oc_update_index",
+        text: "final answer",
+        updatedAt: expect.any(Number),
+      },
+      {
+        cardId: "card_update_index",
+        messageId: "om_update_index",
+        accountId: "main",
+        chatId: "oc_update_index",
+        text: "final answer",
+        updatedAt: expect.any(Number),
+      },
+    ]);
+  });
 
   it("flushes throttled pending text after the throttle window", async () => {
     vi.useFakeTimers();

--- a/extensions/feishu/src/streaming-card.test.ts
+++ b/extensions/feishu/src/streaming-card.test.ts
@@ -210,7 +210,7 @@ describe("FeishuStreamingSession", () => {
     chatId?: unknown;
     text?: unknown;
   }> {
-    return Array.from(mockRuntimeStores.get("streaming-card-content")?.values() ?? []) as Array<{
+    return Array.from(mockRuntimeStores.get("outbound-card-content")?.values() ?? []) as Array<{
       cardId?: unknown;
       messageId?: unknown;
       accountId?: unknown;
@@ -219,7 +219,7 @@ describe("FeishuStreamingSession", () => {
     }>;
   }
 
-  it("records card identity with empty text when streaming start succeeds", async () => {
+  it("does not persist empty streaming-start text", async () => {
     const { client } = mockStreamingTokenStart(() => ({
       code: 0,
       msg: "ok",
@@ -233,24 +233,7 @@ describe("FeishuStreamingSession", () => {
       accountId: "main",
     }).start("oc_stream_start", "chat_id");
 
-    expect(streamingCardContentEntries()).toEqual([
-      {
-        cardId: "card-1",
-        messageId: "om_1",
-        accountId: "main",
-        chatId: "oc_stream_start",
-        text: "",
-        updatedAt: expect.any(Number),
-      },
-      {
-        cardId: "card-1",
-        messageId: "om_1",
-        accountId: "main",
-        chatId: "oc_stream_start",
-        text: "",
-        updatedAt: expect.any(Number),
-      },
-    ]);
+    expect(streamingCardContentEntries()).toEqual([]);
   });
 
   it("records accepted update text and final close text", async () => {
@@ -301,6 +284,40 @@ describe("FeishuStreamingSession", () => {
         updatedAt: expect.any(Number),
       },
     ]);
+  });
+
+  it("invalidates indexed streaming content when close clears the card text", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(6_000);
+    const updateBodies: string[] = [];
+    const replaceBodies: string[] = [];
+    mockFetches(updateBodies, new Set<number>(), replaceBodies);
+
+    const session = new FeishuStreamingSession({} as never, {
+      appId: "app_clear_index",
+      appSecret: "secret",
+    });
+    setStreamingSessionInternals(session, {
+      state: {
+        cardId: "card_clear_index",
+        messageId: "om_clear_index",
+        accountId: "main",
+        chatId: "oc_clear_index",
+        sequence: 1,
+        currentText: "preview",
+        sentText: "preview",
+        hasNote: false,
+      },
+      lastUpdateTime: 4_000,
+    });
+
+    await session.update("preview text");
+    expect(streamingCardContentEntries()).toHaveLength(2);
+
+    await session.close("");
+
+    expect(replaceBodies).toHaveLength(1);
+    expect(streamingCardContentEntries()).toEqual([]);
   });
 
   it("flushes throttled pending text after the throttle window", async () => {

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -12,12 +12,15 @@ import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { getFeishuUserAgent } from "./client.js";
 import { requestFeishuApi } from "./comment-shared.js";
 import { resolveFeishuCardTemplate, type CardHeaderConfig } from "./send.js";
+import { recordFeishuStreamingCardContent } from "./streaming-card-content-index.js";
 import type { FeishuDomain } from "./types.js";
 
-type Credentials = { appId: string; appSecret: string; domain?: FeishuDomain };
+type Credentials = { appId: string; appSecret: string; domain?: FeishuDomain; accountId?: string };
 type CardState = {
   cardId: string;
   messageId: string;
+  accountId?: string;
+  chatId?: string;
   sequence: number;
   currentText: string;
   sentText: string;
@@ -342,11 +345,21 @@ export class FeishuStreamingSession {
     this.state = {
       cardId,
       messageId: sendRes.data.message_id,
+      accountId: this.creds.accountId,
+      chatId: receiveIdType === "chat_id" ? receiveId : undefined,
       sequence: 1,
       currentText: "",
       sentText: "",
       hasNote: Boolean(options?.note),
     };
+    recordFeishuStreamingCardContent({
+      cardId,
+      messageId: sendRes.data.message_id,
+      accountId: this.creds.accountId,
+      chatId: receiveIdType === "chat_id" ? receiveId : undefined,
+      text: "",
+      log: this.log,
+    });
     this.log?.(`Started streaming: cardId=${cardId}, messageId=${sendRes.data.message_id}`);
   }
 
@@ -490,6 +503,14 @@ export class FeishuStreamingSession {
       );
       if (sent && this.state) {
         this.state.sentText = mergedText;
+        recordFeishuStreamingCardContent({
+          cardId: this.state.cardId,
+          messageId: this.state.messageId,
+          accountId: this.state.accountId,
+          chatId: this.state.chatId,
+          text: mergedText,
+          log: this.log,
+        });
       }
     });
     await this.queue;
@@ -550,6 +571,14 @@ export class FeishuStreamingSession {
       if (sent) {
         this.state.sentText = text;
         visibleContentSent = Boolean(text.trim());
+        recordFeishuStreamingCardContent({
+          cardId: this.state.cardId,
+          messageId: this.state.messageId,
+          accountId: this.state.accountId,
+          chatId: this.state.chatId,
+          text,
+          log: this.log,
+        });
       }
     }
 
@@ -585,6 +614,14 @@ export class FeishuStreamingSession {
       })
       .catch((e: unknown) => this.log?.(`Close failed: ${String(e)}`));
     const finalState = this.state;
+    recordFeishuStreamingCardContent({
+      cardId: finalState.cardId,
+      messageId: finalState.messageId,
+      accountId: finalState.accountId,
+      chatId: finalState.chatId,
+      text: finalState.sentText,
+      log: this.log,
+    });
     this.state = null;
     this.pendingText = null;
 

--- a/extensions/feishu/src/types.ts
+++ b/extensions/feishu/src/types.ts
@@ -74,6 +74,8 @@ export type FeishuMessageInfo = {
   senderOpenId?: string;
   senderType?: string;
   content: string;
+  /** Raw Feishu body.content JSON, preserved so quoted media messages can be rehydrated. */
+  rawContent?: string;
   contentType: string;
   createTime?: number;
   /** Feishu thread ID (omt_xxx) — present when the message belongs to a topic thread. */

--- a/extensions/feishu/src/types.ts
+++ b/extensions/feishu/src/types.ts
@@ -36,6 +36,8 @@ export type FeishuMessageContext = {
   chatId: string;
   messageId: string;
   replyTargetMessageId?: string;
+  /** True for locally synthesized events created from interactive card actions. */
+  syntheticCardAction?: boolean;
   suppressReplyTarget?: boolean;
   senderId: string;
   senderOpenId: string;


### PR DESCRIPTION
## Summary
- reply to the triggering Feishu group message in normal group mode instead of following quoted-message metadata into a thread
- parse quoted interactive card content so card titles and nested text are available as agent context
- preserve raw quoted media payloads and rehydrate quoted attachments into agent-visible media context
- keep explicit `replyInThread` / topic behavior intact, preserve card-action replies, honor `skipReplyToInMessages` for streaming cards, and keep Feishu reasoning previews from duplicating the SDK `Thinking` label

## Real behavior proof
- **Behavior or issue addressed:** In a real Feishu group, quoted commands should reply to the triggering group message rather than jumping into the quoted message/thread target. Quoted Feishu card/media messages should be available as agent context, and reasoning preview cards should not duplicate the formatted `Thinking` label.
- **Real environment tested:** OpenClaw Feishu extension on a Debian host (`55-debian12-lsw`), systemd user gateway, Feishu group chat, account `default`, Gateway/CLI version `2026.5.18`. The live gateway was running the same Feishu routing/card/media patch set before the small follow-up reasoning-prefix commit; the reasoning-prefix follow-up is covered by the focused dispatcher test below.
- **Exact steps or command run after this patch:**
  1. Built and ran the patched OpenClaw gateway locally.
  2. Sent quoted Feishu group messages in the live `Saber` test group and confirmed replies appeared in the main group conversation, anchored to the triggering message rather than the quoted/thread target.
  3. Read back the live Feishu message through the Feishu channel API and checked the gateway status/logs.
  4. Ran the focused regression tests and extension typecheck on this PR head.
- **Evidence after fix:** Redacted copied live output from the real Feishu setup plus test output:

```text
$ openclaw gateway status
Runtime: running (pid 1303881, state active, sub running, last exit 0, reason 0)
Connectivity probe: ok
Gateway version: 2026.5.18
CLI version: 2026.5.18
Command: .../openclaw-2026.5.18-runtime/dist/index.js gateway --port 18789

Feishu live readback after the patched gateway handled a real group message:
messageId: om_x100b6fe8cdfe18a0c3d8bc7c3c491ab
chatId: oc_0d2155ba8c080ed538911d6fa54000e8
senderType: user
contentType: text
content: 帮我看一下我在 OpenClaw 所有发起的 PR，好像有一个 PR 最近有了一条新的回复，看一下是怎么一回事，并帮我处理一下

Redacted runtime log from the patched Feishu gateway showing quoted-message context retrieval in the live Feishu channel:
2026-05-20T18:50:12+08:00 feishu[default]: fetched quoted message: 改好了，Master。两个点都已修：1. 群聊普通回复不再走飞书 reply / thread；只有显式开启 replyInThread 或 topic 模式时才进话题。2. 引用卡片消息时，会...

$ COREPACK_HOME=/tmp/openclaw-corepack PNPM_HOME=/tmp/openclaw-pnpm pnpm exec vitest run extensions/feishu/src/reply-dispatcher.test.ts extensions/feishu/src/bot.test.ts extensions/feishu/src/send.test.ts
Test Files  3 passed (3)
Tests       144 passed (144)

$ COREPACK_HOME=/tmp/openclaw-corepack PNPM_HOME=/tmp/openclaw-pnpm pnpm tsgo:extensions
Process exited with code 0
```

- **Observed result after fix:** In the live Feishu group, normal quoted messages stayed in the main group reply path instead of being routed into a Feishu thread/topic. The runtime retrieved quoted-message context for the live quoted message. On the PR head, the dispatcher regression test also verifies that the local Feishu reasoning card strips both `Reasoning:` and the SDK `Thinking` label before rendering its own `💭 Thinking` header.
- **What was not tested:** I did not include a public screenshot/video of the private Feishu group because it contains private chat content; the evidence above is a redacted live transcript/log excerpt from the same real setup.

## Testing
- `COREPACK_HOME=/tmp/openclaw-corepack PNPM_HOME=/tmp/openclaw-pnpm pnpm exec vitest run extensions/feishu/src/bot.test.ts extensions/feishu/src/bot.helpers.test.ts extensions/feishu/src/bot.card-action.test.ts extensions/feishu/src/monitor.card-action.lifecycle.test-support.ts extensions/feishu/src/reply-dispatcher.test.ts extensions/feishu/src/send.test.ts`
- `COREPACK_HOME=/tmp/openclaw-corepack PNPM_HOME=/tmp/openclaw-pnpm pnpm exec vitest run extensions/feishu/src/reply-dispatcher.test.ts extensions/feishu/src/bot.test.ts extensions/feishu/src/send.test.ts`
- `COREPACK_HOME=/tmp/openclaw-corepack PNPM_HOME=/tmp/openclaw-pnpm pnpm tsgo:extensions`
- `COREPACK_HOME=/tmp/openclaw-corepack PNPM_HOME=/tmp/openclaw-pnpm pnpm build`

## Additional update: quoted streaming cards
- Persist Feishu streaming-card content in plugin state by message/card id so quoted-message hydration can recover final card text when `im.message.get` returns only a card id stub or client-upgrade fallback.
- Treat `请升级至最新版本客户端，以查看内容` as an unavailable card fallback, not recovered content; index misses now return `[Interactive Card]` and log the message/card/account context.
- Added focused coverage for card-stub hydration, client-upgrade fallback hydration/miss behavior, persisted lookup after memory reset, and streaming start/update/close index writes.

Additional verification on commit `de8b084e34`:
```text
$ git diff --check
# passed

$ node scripts/run-vitest.mjs extensions/feishu/src/send.test.ts extensions/feishu/src/reply-dispatcher.test.ts extensions/feishu/src/streaming-card.test.ts extensions/feishu/src/bot.helpers.test.ts
Test Files  4 passed (4)
Tests       141 passed (141)

$ COREPACK_HOME=/tmp/openclaw-corepack PNPM_HOME=/tmp/openclaw-pnpm pnpm tsgo:extensions
Process exited with code 0

$ COREPACK_HOME=/tmp/openclaw-corepack PNPM_HOME=/tmp/openclaw-pnpm pnpm exec oxfmt --check --threads=1 extensions/feishu/src/bot-content.ts extensions/feishu/src/bot.helpers.test.ts extensions/feishu/src/reply-dispatcher.ts extensions/feishu/src/send.test.ts extensions/feishu/src/send.ts extensions/feishu/src/streaming-card.test.ts extensions/feishu/src/streaming-card.ts extensions/feishu/src/streaming-card-content-index.ts
All matched files use the correct format.
```
