### PR TITLE
fix(message): describe channel parameter as provider name

### DIFF
--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -1454,6 +1454,17 @@ describe("message tool description", () => {
     expect(target?.description).toContain("Telegram chat id/@username");
   });
 
+  it("describes channel as the messaging provider name", () => {
+    const tool = createMessageTool({
+      config: {} as never,
+    });
+    const properties = getToolProperties(tool);
+    const channel = properties.channel as { description?: string } | undefined;
+
+    expect(channel?.description).toContain("Messaging provider name");
+    expect(channel?.description).toContain("not a channel or conversation ID");
+  });
+
   it("hides iMessage group actions for DM targets", () => {
     setActivePluginRegistry(
       createTestRegistry([{ pluginId: "imessage", source: "test", plugin: imessagePlugin }]),

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -139,7 +139,12 @@ function sanitizePresentationTextFields(value: unknown): unknown {
 
 function buildRoutingSchema() {
   return {
-    channel: Type.Optional(Type.String()),
+    channel: Type.Optional(
+      Type.String({
+        description:
+          "Messaging provider name (e.g. slack, discord), not a channel or conversation ID.",
+      }),
+    ),
     target: Type.Optional(channelTargetSchema()),
     targets: Type.Optional(channelTargetsSchema()),
     accountId: Type.Optional(Type.String()),


### PR DESCRIPTION
## Summary

- Clarify the message tool `channel` parameter as a messaging provider name, such as `slack` or `discord`.
- Add coverage that the generated schema describes `channel` as a provider name rather than a conversation/channel ID.

Fixes #10354

## Real behavior proof

Behavior addressed: The `message` tool schema now explains that `channel` is the provider name, not a channel or conversation ID.

Real environment tested: Local OpenClaw checkout on macOS, Node v24.13.1, pnpm v11.1.0.

Exact steps or command run after this patch: Ran this command against the patched local OpenClaw checkout:

```bash
corepack pnpm exec tsx -e "import { createMessageTool } from './src/agents/tools/message-tool.ts'; const tool = createMessageTool(); console.log(JSON.stringify((tool.parameters as any).properties.channel, null, 2));"
```

Evidence after fix: Terminal output from the patched local OpenClaw setup:

```json
{
  "type": "string",
  "description": "Messaging provider name (e.g. slack, discord), not a channel or conversation ID."
}
```

Observed result after fix: The live generated `message` tool schema exposes the new `channel` description and distinguishes provider names from conversation/channel IDs.

What was not tested: Full repository test suite.

## Verification

- `corepack pnpm exec oxfmt --check --threads=1 src/agents/tools/message-tool.ts src/agents/tools/message-tool.test.ts`
- `git diff --check HEAD~1..HEAD`
- `node scripts/run-vitest.mjs src/agents/tools/message-tool.test.ts` (`2 passed`, `118 passed`)
