### PR TITLE
build: suppress rolldown-plugin-dts CommonJS dts warnings from bundled zod locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 Docs: https://docs.openclaw.ai
 
-## Unreleased
-
-### Fixes
-
-- Build: suppress per-locale `rolldown-plugin-dts:fake-js` CommonJS dts warnings emitted while bundling the intentionally-inlined `zod/v4/locales/*.d.cts` files, so `pnpm build` output stays readable after the 0.25.1 plugin bump. Thanks @romneyda.
-
 ## 2026.5.20
 
 ### Changes
@@ -23,6 +17,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - WhatsApp: update Baileys to `7.0.0-rc12`.
+- Build: suppress per-locale `rolldown-plugin-dts:fake-js` CommonJS dts warnings emitted while bundling the intentionally-inlined `zod/v4/locales/*.d.cts` files, so `pnpm build` output stays readable after the 0.25.1 plugin bump. Thanks @romneyda.
 - Approvals: route manual `/approve` decisions through the trusted approval runtime so active exec and plugin approvals no longer look unknown or expired.
 - Mac app: update the About settings copyright year to 2026. (#84385) Thanks @pejmanjohn.
 - Dependencies: update `@openclaw/fs-safe` to `0.2.7` so OpenClaw's default Python-helper-off policy keeps best-effort Node write fallbacks for private stores, secret writes, run logs, and media attachments on Linux/macOS.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Docs: https://docs.openclaw.ai
 
+## Unreleased
+
+### Fixes
+
+- Build: suppress per-locale `rolldown-plugin-dts:fake-js` CommonJS dts warnings emitted while bundling the intentionally-inlined `zod/v4/locales/*.d.cts` files, so `pnpm build` output stays readable after the 0.25.1 plugin bump. Thanks @romneyda.
+
 ## 2026.5.20
 
 ### Changes

--- a/src/infra/tsdown-config.test.ts
+++ b/src/infra/tsdown-config.test.ts
@@ -18,6 +18,7 @@ type TsdownLog = {
   message?: string;
   id?: string;
   importer?: string;
+  plugin?: string;
 };
 
 type TsdownOnLog = (
@@ -264,6 +265,38 @@ describe("tsdown config", () => {
     const log = {
       code: "UNRESOLVED_IMPORT",
       message: "Could not resolve 'missing-dependency' in src/index.ts",
+    };
+
+    configured?.("warn", log, (_level, forwardedLog) => handled.push(forwardedLog));
+
+    expect(handled).toEqual([log]);
+  });
+
+  it("suppresses rolldown-plugin-dts CommonJS dts warnings from bundled zod locales", () => {
+    const configured = unifiedDistGraph()?.inputOptions?.({})?.onLog;
+    const handled: TsdownLog[] = [];
+
+    configured?.(
+      "warn",
+      {
+        code: "PLUGIN_WARNING",
+        plugin: "rolldown-plugin-dts:fake-js",
+        message:
+          "/abs/path/node_modules/zod/v4/locales/ur.d.cts uses CommonJS dts syntax. CommonJS dts modules cannot be reliably bundled by rolldown-plugin-dts. Please mark this module as external in your Rolldown config.",
+      },
+      (_level, log) => handled.push(log),
+    );
+
+    expect(handled).toStrictEqual([]);
+  });
+
+  it("keeps other rolldown-plugin-dts warnings visible", () => {
+    const configured = unifiedDistGraph()?.inputOptions?.({})?.onLog;
+    const handled: TsdownLog[] = [];
+    const log = {
+      code: "PLUGIN_WARNING",
+      plugin: "rolldown-plugin-dts:fake-js",
+      message: "some other dts warning that should not be hidden",
     };
 
     configured?.("warn", log, (_level, forwardedLog) => handled.push(forwardedLog));

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -81,12 +81,21 @@ function buildInputOptions(options: InputOptionsArg): InputOptionsReturn {
     message?: string;
     id?: string;
     importer?: string;
+    plugin?: string;
   }) {
     if (log.code === "PLUGIN_TIMINGS") {
       return true;
     }
     if (log.code === "UNRESOLVED_IMPORT") {
       return normalizedLogHaystack(log).includes("extensions/");
+    }
+    if (
+      log.code === "PLUGIN_WARNING" &&
+      log.plugin === "rolldown-plugin-dts:fake-js" &&
+      typeof log.message === "string" &&
+      log.message.includes("uses CommonJS dts syntax")
+    ) {
+      return true;
     }
     if (log.code !== "EVAL") {
       return false;


### PR DESCRIPTION
## Why not the more invasive fixes

Up front, here's why this PR only filters the warning instead of changing the build:

- **Setting `dts: false` on the tsdown node build** would remove `rolldown-plugin-dts` from the JS bundle pass entirely (`tsdown.config.ts:nodeBuildConfig`). It plausibly works because `build:plugin-sdk:dts` (tsgo) is what actually emits the dts files we ship, but it changes a behavior that's been in place since the tsdown migration. Any downstream step or tooling quietly relying on the tsdown-side dts emission would silently break — and a clean `pnpm build` confirms tsdown is emitting ~2k `*.d.ts` files into `dist/` today, several of which are not the plugin-sdk surface, so the blast radius isn't obviously empty.
- **Externalizing zod for the dts pass only** is what the warning literally suggests, but tsdown's `deps.alwaysBundle` / `deps.neverBundle` / `inputOptions.external` apply uniformly to JS and dts. The JS path needs zod inlined per #78515 (otherwise globally-installed openclaw fails to resolve `zod/*` subpaths). There's no per-pass externalization knob on `rolldown-plugin-dts`, so doing this cleanly would require splitting the build into two graphs.

The warning is purely informational from the bundler's perspective — the dts output is still valid; rolldown-plugin-dts is just hedging on edge cases for `export = ...` style declarations. Filtering it matches the existing `onLog` pattern in this file for `PLUGIN_TIMINGS`, scoped `UNRESOLVED_IMPORT`, and the bottleneck/protobufjs `EVAL` warnings.

## When/why it started

Two upstream changes combined:

1. `0496063264` (2026-05-10) bumped `rolldown-plugin-dts` 0.23.2 → 0.25.0.
2. `94ac563399` (2026-05-20) bumped 0.25.0 → 0.25.1, which is the version that introduced the new `CommonJS dts syntax` warning in `rolldown-plugin-dts:fake-js` (see `isCjsDtsInputSyntax` — fires on `export = ...` and `import x = require(...)`).

Combined with `ea72414e1c` / #78515, which added `zod` and `zod/*` to `shouldAlwaysBundleDependency` so the dts pass walks `src/plugin-sdk/zod.ts` → `zod/v4/classic/external.d.cts` → `../locales/index.cjs` → every per-locale `*.d.cts` (all of which use `export = _default`), every full build now emits one warning per locale file.

## Summary

- Extend `isSuppressedLog` in `tsdown.config.ts` to drop `PLUGIN_WARNING` logs from `rolldown-plugin-dts:fake-js` whose message contains `uses CommonJS dts syntax`. Other warnings from the same plugin still pass through.
- Add `plugin?: string` to the log type and two tests in `src/infra/tsdown-config.test.ts` (one that suppresses the zod-locale message, one that forwards an unrelated warning to the default handler).
- Changelog entry under Unreleased / Fixes.

## Verification

Both runs in a clean Codex worktree on the rebased branch (post `pnpm install --frozen-lockfile`, so `rolldown-plugin-dts@0.25.1` is on disk):

- Behavior addressed: `pnpm build` spam of `(rolldown-plugin-dts:fake-js plugin) /…/zod/v4/locales/*.d.cts uses CommonJS dts syntax. …`
- Real environment tested: local macOS Codex worktree, Node 22.22.0, pnpm 11.1.0
- Exact steps or command run after this patch:
  - `rm -rf dist dist-runtime && OPENCLAW_BUILD_VERBOSE=1 node scripts/tsdown-build.mjs 2>&1 | grep -c "CommonJS dts"` (verbose mode bypasses our `onLog` patch — reproduces upstream warnings)
  - `rm -rf dist dist-runtime && node scripts/tsdown-build.mjs 2>&1 | grep -c "CommonJS dts"` (normal build — filter active)
  - `node scripts/run-vitest.mjs src/infra/tsdown-config.test.ts`
  - `node scripts/run-tsgo.mjs -p tsconfig.core.json --noEmit`
  - `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --noEmit`
  - `node scripts/run-oxlint.mjs tsdown.config.ts src/infra/tsdown-config.test.ts`
- Evidence after fix:
  - Verbose run (bypasses filter): **52** `CommonJS dts` lines emitted, sample `(rolldown-plugin-dts:fake-js plugin) /…/zod/v4/locales/be.d.cts uses CommonJS dts syntax. …`
  - Filtered run: **0** `CommonJS dts` lines; 4931 files in `dist/` — build still succeeds end-to-end
  - Vitest: 15 passed / 15 in `src/infra/tsdown-config.test.ts` (13 existing + 2 new)
  - tsgo core + core-test: exit 0
  - oxlint: 0 warnings / 0 errors
- Observed result after fix: warnings gone from non-verbose `pnpm build`; legitimate other warnings remain reachable through the same `onLog` path.
- What was not tested: full `pnpm build` end-to-end past the `tsdown` step (postbuild, plugin-sdk:dts, etc.) — only the `tsdown` step is touched and only the log path changes; broader CI gates can confirm.

## Test plan

- [x] `node scripts/run-vitest.mjs src/infra/tsdown-config.test.ts` — passes
- [x] Verbose vs filtered tsdown comparison shows 52 → 0
- [x] `tsgo` core + core-test typecheck clean
- [x] `oxlint` clean
- [ ] CI green
