### PR TITLE
fix(browser): honor image sanitization config for screenshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Dependencies: update `@openclaw/fs-safe` to `0.2.7` so OpenClaw's default Python-helper-off policy keeps best-effort Node write fallbacks for private stores, secret writes, run logs, and media attachments on Linux/macOS.
+- Browser: honor the configured image sanitization limit for screenshots and labeled snapshots so browser-captured images follow the same resize policy as other image results. (#84595)
 - Status: show the configured default, session-selected model, reason, clear hint, and docs link when a session remains pinned to a model that differs from `agents.defaults.model.primary`.
 - Mac app: keep local packaging signed with a stable app identity for permission testing and fix Control UI production builds under current Vite/Highlight.js exports.
 - macOS app: update the embedded Peekaboo bridge to 3.2.1 so OpenClaw-hosted UI automation works with current Peekaboo CLI capture flows.

--- a/extensions/browser/src/browser-tool.actions.ts
+++ b/extensions/browser/src/browser-tool.actions.ts
@@ -13,6 +13,7 @@ import {
   readStringValue,
   resolveBrowserConfig,
   resolveProfile,
+  resolveRuntimeImageSanitization,
   wrapExternalContent,
 } from "./browser-tool.runtime.js";
 import { DEFAULT_BROWSER_ACTION_TIMEOUT_MS } from "./browser/constants.js";
@@ -463,6 +464,7 @@ export async function executeSnapshotAction(params: {
         path: snapshot.imagePath,
         extraText: wrappedSnapshot,
         details: safeDetails,
+        imageSanitization: resolveRuntimeImageSanitization(),
       });
     }
     return {

--- a/extensions/browser/src/browser-tool.runtime.ts
+++ b/extensions/browser/src/browser-tool.runtime.ts
@@ -1,4 +1,13 @@
-export { getRuntimeConfig } from "./sdk-config.js";
+import { getRuntimeConfig } from "./sdk-config.js";
+
+export { getRuntimeConfig };
+export function resolveRuntimeImageSanitization(): { maxDimensionPx: number } | undefined {
+  const configured = getRuntimeConfig().agents?.defaults?.imageMaxDimensionPx;
+  if (typeof configured !== "number" || !Number.isFinite(configured)) {
+    return undefined;
+  }
+  return { maxDimensionPx: Math.max(1, Math.floor(configured)) };
+}
 export {
   callGatewayTool,
   imageResultFromFile,

--- a/extensions/browser/src/browser-tool.test.ts
+++ b/extensions/browser/src/browser-tool.test.ts
@@ -123,6 +123,7 @@ const configMocks = vi.hoisted(() => ({
     () => {
       browser: Record<string, unknown>;
       gateway?: { nodes?: { browser?: { node?: string } } };
+      agents?: { defaults?: { imageMaxDimensionPx?: number } };
     }
   >(() => ({ browser: {} })),
 }));
@@ -185,6 +186,12 @@ vi.mock("./browser-tool.runtime.js", () => {
     ...gatewayMocks,
     ...sessionTabRegistryMocks,
     getRuntimeConfig: configMocks.loadConfig,
+    resolveRuntimeImageSanitization: () => {
+      const configured = configMocks.loadConfig().agents?.defaults?.imageMaxDimensionPx;
+      return typeof configured === "number" && Number.isFinite(configured)
+        ? { maxDimensionPx: Math.max(1, Math.floor(configured)) }
+        : undefined;
+    },
     applyBrowserProxyPaths: vi.fn(),
     getBrowserProfileCapabilities: (profile: Record<string, unknown>) => ({
       usesChromeMcp: profile.driver === "existing-session",
@@ -715,6 +722,29 @@ describe("browser tool snapshot maxChars", () => {
     expect(opts.timeoutMs).toBe(12_345);
   });
 
+  it("passes configured image sanitization to screenshot image results", async () => {
+    configMocks.loadConfig.mockReturnValue({
+      browser: {},
+      agents: { defaults: { imageMaxDimensionPx: 2000 } },
+    } as never);
+    toolCommonMocks.imageResultFromFile.mockResolvedValueOnce({
+      content: [{ type: "image", data: "base64", mimeType: "image/png" }],
+      details: { path: "/tmp/test.png" },
+    });
+
+    const tool = createBrowserTool();
+    await tool.execute?.("call-1", {
+      action: "screenshot",
+      target: "host",
+      targetId: "tab-1",
+    });
+
+    const imageParams = lastMockCallArg<{
+      imageSanitization?: { maxDimensionPx?: number };
+    }>(toolCommonMocks.imageResultFromFile, 0);
+    expect(imageParams.imageSanitization).toEqual({ maxDimensionPx: 2000 });
+  });
+
   it("passes screenshot timeoutMs through the node browser proxy", async () => {
     mockSingleBrowserProxyNode();
     gatewayMocks.callGatewayTool.mockResolvedValueOnce({
@@ -1163,6 +1193,10 @@ describe("browser tool snapshot labels", () => {
   registerBrowserToolAfterEachReset();
 
   it("returns image + text when labels are requested", async () => {
+    configMocks.loadConfig.mockReturnValue({
+      browser: {},
+      agents: { defaults: { imageMaxDimensionPx: 2000 } },
+    } as never);
     const tool = createBrowserTool();
     const imageResult = {
       content: [
@@ -1188,12 +1222,14 @@ describe("browser tool snapshot labels", () => {
       labels: true,
     });
 
-    const imageParams = lastMockCallArg<{ path?: string; extraText?: string }>(
-      toolCommonMocks.imageResultFromFile,
-      0,
-    );
+    const imageParams = lastMockCallArg<{
+      path?: string;
+      extraText?: string;
+      imageSanitization?: { maxDimensionPx?: number };
+    }>(toolCommonMocks.imageResultFromFile, 0);
     expect(imageParams.path).toBe("/tmp/snap.png");
     expect(imageParams.extraText).toContain("<<<EXTERNAL_UNTRUSTED_CONTENT");
+    expect(imageParams.imageSanitization).toEqual({ maxDimensionPx: 2000 });
     expect(result).toEqual(imageResult);
     expect(result?.content).toHaveLength(2);
     expect(result?.content?.[0]).toEqual({ type: "text", text: "label text" });

--- a/extensions/browser/src/browser-tool.ts
+++ b/extensions/browser/src/browser-tool.ts
@@ -36,6 +36,7 @@ import {
   readStringParam,
   readStringValue,
   resolveBrowserConfig,
+  resolveRuntimeImageSanitization,
   resolveExistingPathsWithinRoot,
   resolveNodeIdFromList,
   resolveProfile,
@@ -770,6 +771,7 @@ export function createBrowserTool(opts?: {
             label: "browser:screenshot",
             path: result.path,
             details: result,
+            imageSanitization: resolveRuntimeImageSanitization(),
           });
         }
         case "navigate": {

--- a/extensions/openrouter/provider-routing.ts
+++ b/extensions/openrouter/provider-routing.ts
@@ -56,9 +56,9 @@ function mergeOpenRouterProviderRouting(params: {
   const modelRouting = readRecord(params.modelParams?.provider);
   const extraRouting = readRecord(params.extraParams.provider);
   const merged = {
-    ...(providerRouting ?? {}),
-    ...(modelRouting ?? {}),
-    ...(extraRouting ?? {}),
+    ...providerRouting,
+    ...modelRouting,
+    ...extraRouting,
   };
   return Object.keys(merged).length > 0 ? merged : undefined;
 }
@@ -78,8 +78,8 @@ export function resolveOpenRouterExtraParamsForTransport(
   }
   return {
     patch: {
-      ...(providerConfigParams ?? {}),
-      ...(modelParams ?? {}),
+      ...providerConfigParams,
+      ...modelParams,
       ...ctx.extraParams,
       ...(providerRouting ? { provider: providerRouting } : {}),
     },

--- a/src/commands/status.summary.redaction.test.ts
+++ b/src/commands/status.summary.redaction.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { redactSensitiveStatusSummary } from "./status.summary.js";
-import type { StatusSummary } from "./status.types.js";
+import type { SessionStatus, StatusSummary } from "./status.types.js";
 
-function createRecentSessionRow() {
+function createRecentSessionRow(): SessionStatus {
   return {
     key: "main",
     kind: "direct" as const,
@@ -14,6 +14,9 @@ function createRecentSessionRow() {
     remainingTokens: 4,
     percentUsed: 5,
     model: "gpt-5",
+    configuredModel: "gpt-5",
+    selectedModel: "gpt-5",
+    modelSelectionReason: null,
     contextTokens: 200_000,
     flags: ["id:sess-1"],
   };

--- a/src/infra/secret-file.test.ts
+++ b/src/infra/secret-file.test.ts
@@ -111,21 +111,21 @@ describe("readSecretFileSync", () => {
     await expectSecretFileError({ setup, expectedMessage, options });
   });
 
+  it("throws from the try helper for rejected files", async () => {
+    const file = await createSecretPath(async (dir) => {
+      const target = path.join(dir, "target.txt");
+      const link = path.join(dir, "secret-link.txt");
+      await fsPromises.writeFile(target, "top-secret\n", "utf8");
+      await fsPromises.symlink(target, link);
+      return link;
+    });
+
+    expect(() =>
+      tryReadSecretFileSync(file, "Telegram bot token", { rejectSymlink: true }),
+    ).toThrow(`Telegram bot token file at ${file} must not be a symlink.`);
+  });
+
   it.each([
-    {
-      name: "returns undefined from the non-throwing helper for rejected files",
-      pathValue: async () =>
-        createSecretPath(async (dir) => {
-          const target = path.join(dir, "target.txt");
-          const link = path.join(dir, "secret-link.txt");
-          await fsPromises.writeFile(target, "top-secret\n", "utf8");
-          await fsPromises.symlink(target, link);
-          return link;
-        }),
-      label: "Telegram bot token",
-      options: { rejectSymlink: true },
-      expected: undefined,
-    },
     {
       name: "returns undefined from the non-throwing helper for blank file paths",
       pathValue: async () => "   ",


### PR DESCRIPTION
## Summary
- forward `agents.defaults.imageMaxDimensionPx` into browser screenshot tool results
- forward the same image sanitization limits into `snapshot --labels` image results
- add regression coverage for both browser image-returning paths

## Problem
`browser screenshot` normalized images to the browser layer's `<= 2000px` limit first, but then returned them through `imageResultFromFile()` without passing runtime image sanitization config.

That meant the final tool image still fell back to the default `1200px` sanitize limit, even when `agents.defaults.imageMaxDimensionPx` was configured higher. The same omission existed for `browser snapshot --labels`.

## Fix
Thread runtime image sanitization limits into both browser image-returning call sites:
- `browser:screenshot`
- `browser:snapshot` when `labels=true`

This keeps browser tool image behavior aligned with the documented global image sanitization setting and with other OpenClaw image paths that already forward this config.

## Verification
- focused browser extension test suite passed:
  - `extensions/browser/src/browser-tool.test.ts` (`51 passed`)
- direct runtime check with the same input image showed:
  - default config: final browser screenshot output still reduced to `1200x625`
  - `imageMaxDimensionPx = 1920`: final output became `1920x1000`
  - `imageMaxDimensionPx = 2000`: final output stayed at `2000x1042`
  - `imageMaxDimensionPx = 3000`: final output still stayed at `2000x1042`, as expected because browser pre-normalization already caps screenshots at `2000px`

## Real behavior proof
**Behavior or issue addressed**: browser screenshot and `browser snapshot --labels` image results ignored `agents.defaults.imageMaxDimensionPx` on the final tool-image sanitize step, so a browser screenshot could still come out at `1200px` even when the config was set higher.

**Real environment tested**: local OpenClaw checkout on macOS using the real browser screenshot normalization path plus the browser tool image-result path with a local PNG test image as the input.

**Exact steps or command run after this patch**: ran the browser screenshot runtime check against the patched branch, varying `agents.defaults.imageMaxDimensionPx` across default, `1920`, `2000`, and `3000`, then inspected the generated image metadata.

**Evidence after fix**:
```text
live output from runtime image metadata inspection:
normalized browser layer: 2000x1042, 246537 bytes, image/jpeg
default final output:    1200x625,  107491 bytes, image/jpeg
configured 1920:         1920x1000, 214162 bytes, image/jpeg
configured 2000:         2000x1042, 246537 bytes, image/jpeg
configured 3000:         2000x1042, 246537 bytes, image/jpeg
```

**Observed result after fix**: after the patch, browser-originated image results now honor the configured sanitize limit up to the browser layer's own `2000px` ceiling. `1920` produces `1920x1000`, `2000` produces `2000x1042`, and `3000` does not exceed `2000x1042` because browser pre-normalization already caps that path.

**What was not tested**: a full remote provider call was not run; this proof covers the local browser screenshot normalization path and the actual browser tool image packaging and sanitize path.

