### PR TITLE
fix(telegram): fan out message send media urls

### DIFF
--- a/extensions/telegram/src/action-runtime.test.ts
+++ b/extensions/telegram/src/action-runtime.test.ts
@@ -907,6 +907,41 @@ describe("handleTelegramAction", () => {
     ]);
   });
 
+  it("fans out mediaUrls for action sends and captions only the first item", async () => {
+    sendMessageTelegram
+      .mockResolvedValueOnce({ messageId: "img-1", chatId: "123" })
+      .mockResolvedValueOnce({ messageId: "img-2", chatId: "123" });
+
+    const result = await handleTelegramAction(
+      {
+        action: "sendMessage",
+        to: "123456",
+        content: "Rendered images",
+        mediaUrls: ["https://example.com/a.png", "https://example.com/b.png"],
+        presentation: {
+          blocks: [{ type: "buttons", buttons: [{ label: "Open", value: "open" }] }],
+        },
+      },
+      telegramConfig({ capabilities: { inlineButtons: "all" } }),
+    );
+
+    expect(sendMessageTelegram).toHaveBeenCalledTimes(2);
+    const firstCall = mockCall(sendMessageTelegram, 0, "first media send");
+    expect(firstCall[0]).toBe("123456");
+    expect(firstCall[1]).toBe("Rendered images");
+    const firstOptions = requireRecord(firstCall[2], "first media options");
+    expect(firstOptions.mediaUrl).toBe("https://example.com/a.png");
+    expect(firstOptions.buttons).toEqual([[{ text: "Open", callback_data: "open" }]]);
+
+    const secondCall = mockCall(sendMessageTelegram, 1, "second media send");
+    expect(secondCall[0]).toBe("123456");
+    expect(secondCall[1]).toBe("");
+    const secondOptions = requireRecord(secondCall[2], "second media options");
+    expect(secondOptions.mediaUrl).toBe("https://example.com/b.png");
+    expect(secondOptions.buttons).toBeUndefined();
+    expect(resultDetails(result).messageId).toBe("img-2");
+  });
+
   it("pins action sends when delivery pin is requested", async () => {
     await handleTelegramAction(
       {

--- a/extensions/telegram/src/action-runtime.ts
+++ b/extensions/telegram/src/action-runtime.ts
@@ -144,7 +144,7 @@ function resolveTelegramButtonsFromParams(
 
 function readTelegramSendContent(params: {
   args: Record<string, unknown>;
-  mediaUrl?: string;
+  hasMedia: boolean;
   hasButtons: boolean;
   interactive?: unknown;
   presentation?: MessagePresentation;
@@ -165,16 +165,35 @@ function readTelegramSendContent(params: {
     explicitContent ??
     (presentationText?.trim() ? presentationText : undefined) ??
     (interactiveText?.trim() ? interactiveText : undefined);
-  if ((content == null || content.trim().length === 0) && !params.mediaUrl && params.hasButtons) {
+  if ((content == null || content.trim().length === 0) && !params.hasMedia && params.hasButtons) {
     const fallback = presentationText?.trim() ? presentationText : interactiveText;
     if (fallback?.trim()) {
       content = fallback;
     }
   }
-  if (content == null && !params.mediaUrl && !params.hasButtons) {
+  if (content == null && !params.hasMedia && !params.hasButtons) {
     throw new Error("content required.");
   }
   return content ?? "";
+}
+
+function readTelegramSendMediaUrls(params: Record<string, unknown>): string[] {
+  const urls: string[] = [];
+  const seen = new Set<string>();
+  const push = (value?: string | null) => {
+    const trimmed = value?.trim();
+    if (!trimmed || seen.has(trimmed)) {
+      return;
+    }
+    seen.add(trimmed);
+    urls.push(trimmed);
+  };
+  push(readStringParam(params, "mediaUrl"));
+  push(readStringParam(params, "media", { trim: false }));
+  for (const url of readStringArrayParam(params, "mediaUrls") ?? []) {
+    push(url);
+  }
+  return urls;
 }
 
 function normalizeTelegramDeliveryPin(params: Record<string, unknown>) {
@@ -350,16 +369,12 @@ export async function handleTelegramAction(
       throw new Error("Telegram sendMessage is disabled.");
     }
     const to = readStringParam(params, "to", { required: true });
-    const mediaUrl =
-      readStringParam(params, "mediaUrl") ??
-      readStringParam(params, "media", {
-        trim: false,
-      });
+    const mediaUrls = readTelegramSendMediaUrls(params);
     const presentation = normalizeMessagePresentation(params.presentation);
     const buttons = resolveTelegramButtonsFromParams(params, presentation);
     const content = readTelegramSendContent({
       args: params,
-      mediaUrl: mediaUrl ?? undefined,
+      hasMedia: mediaUrls.length > 0,
       hasButtons: Array.isArray(buttons) && buttons.length > 0,
       interactive: params.interactive,
       presentation,
@@ -401,15 +416,14 @@ export async function handleTelegramAction(
         "Telegram bot token missing. Set TELEGRAM_BOT_TOKEN or channels.telegram.botToken.",
       );
     }
-    const result = await telegramActionRuntime.sendMessageTelegram(to, content, {
+    let result: Awaited<ReturnType<typeof telegramActionRuntime.sendMessageTelegram>> | undefined;
+    const baseSendOptions = {
       cfg,
       token,
       accountId: accountId ?? undefined,
-      mediaUrl: mediaUrl || undefined,
       mediaLocalRoots: options?.mediaLocalRoots,
       mediaReadFile: options?.mediaReadFile,
       gatewayClientScopes: options?.gatewayClientScopes,
-      buttons,
       replyToMessageId: replyToMessageId ?? undefined,
       messageThreadId: messageThreadId ?? undefined,
       quoteText: quoteText ?? undefined,
@@ -419,7 +433,24 @@ export async function handleTelegramAction(
         readBooleanParam(params, "forceDocument") ??
         readBooleanParam(params, "asDocument") ??
         false,
-    });
+    };
+    if (mediaUrls.length === 0) {
+      result = await telegramActionRuntime.sendMessageTelegram(to, content, {
+        ...baseSendOptions,
+        buttons,
+      });
+    } else {
+      for (const [index, mediaUrl] of mediaUrls.entries()) {
+        result = await telegramActionRuntime.sendMessageTelegram(to, index === 0 ? content : "", {
+          ...baseSendOptions,
+          mediaUrl,
+          ...(index === 0 ? { buttons } : {}),
+        });
+      }
+    }
+    if (!result) {
+      throw new Error("Telegram sendMessage did not return a result.");
+    }
     notifyVisibleOutboundSuccess(to, messageThreadId);
     await maybePinTelegramActionSend({
       args: params,

--- a/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
+++ b/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
@@ -706,6 +706,75 @@ describe("runMessageAction plugin dispatch", () => {
       );
     });
 
+    it("preserves structured attachment mediaUrls for gateway-executed plugin sends", async () => {
+      const gatewayPlugin = createGatewayActionPlugin({
+        pluginId: "gatewaychat",
+        label: "Gateway Chat",
+        blurb: "Gateway Chat send test plugin.",
+        actions: ["send"],
+        messaging: {
+          targetResolver: {
+            looksLikeId: () => true,
+          },
+        },
+        handleAction: vi.fn(async () => jsonResult({ ok: true, local: true })),
+      });
+      setActivePluginRegistry(
+        createTestRegistry([
+          {
+            pluginId: "gatewaychat",
+            source: "test",
+            plugin: gatewayPlugin,
+          },
+        ]),
+      );
+      mocks.callGatewayLeastPrivilege.mockResolvedValue({
+        ok: true,
+        messageId: "gw-send-media",
+      });
+
+      await runMessageAction({
+        cfg: {
+          channels: {
+            gatewaychat: {
+              enabled: true,
+            },
+          },
+        } as OpenClawConfig,
+        action: "send",
+        params: {
+          channel: "gatewaychat",
+          target: "user-123",
+          message: "rendered images",
+          attachments: [
+            { mediaUrl: "https://example.com/a.png" },
+            { mediaUrl: "https://example.com/b.png" },
+          ],
+        },
+        gateway: {
+          clientName: "cli",
+          mode: "cli",
+        },
+        dryRun: false,
+      });
+
+      const gatewayCall = readMockCallArg(
+        mocks.callGatewayLeastPrivilege,
+        "gateway least privilege call",
+      );
+      const gatewayParams = readRecordField(gatewayCall, "params", "gateway call params");
+      expectRecordFields(
+        readRecordField(gatewayParams, "params", "gateway message params"),
+        {
+          media: "https://example.com/a.png",
+          mediaUrl: "https://example.com/a.png",
+          mediaUrls: ["https://example.com/a.png", "https://example.com/b.png"],
+        },
+        "gateway message params",
+      );
+      expect(mocks.executeSendAction).not.toHaveBeenCalled();
+    });
+
     it("applies TTS before gateway-executed plugin sends", async () => {
       const gatewayPlugin = createGatewayActionPlugin({
         pluginId: "gatewaychat",

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -908,6 +908,7 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
     accountId,
     agentId,
   });
+  applySendPayloadPartsToActionParams(params, sendPayload);
 
   const replyToId = resolveAndApplyOutboundReplyToId(params, {
     channel,


### PR DESCRIPTION
## Summary

- Problem: Telegram `message.send` only consumed a single URL-backed media field, so later items in `mediaUrls` could be dropped.
- Solution: Preserve normalized `mediaUrls` on gateway-dispatched `message.send` actions and fan them out in the Telegram action runtime.
- What changed: The outbound message runner now applies normalized send payload parts back onto gateway action params; Telegram `message.send` now sends each resolved media URL sequentially.
- What did NOT change (scope boundary): This does not implement Telegram `sendMediaGroup`/album semantics and does not hydrate `buffer`/`filename` attachments.

## Motivation

- Multi-image assistant/tool responses can already arrive at the Telegram gateway send path as URL-backed structured media attachments. Dropping every item after the first makes the assistant claim it sent multiple images while the user receives only one.
- This PR keeps the fix narrow: it covers already-resolved media URLs without taking on broader album grouping or binary attachment hydration behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #13620
- Related #41779
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only. Screenshots are encouraged even for CLI, console, text, or log changes; terminal screenshots and copied live output count. Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

- Behavior or issue addressed: URL-backed multi-media Telegram sends should deliver each media item instead of only the first one.
- Real environment tested: Pending real Telegram setup proof from a patched OpenClaw runtime.
- Exact steps or command run after this patch: Pending real Telegram setup proof.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Pending real Telegram setup proof.
- Observed result after fix: Pending real Telegram setup proof.
- What was not tested: Real Telegram bot delivery from a patched OpenClaw runtime has not yet been captured for this PR body; Telegram `sendMediaGroup`/album behavior and binary `buffer`/`filename` hydration are intentionally out of scope.
- Before evidence (optional but encouraged): Existing behavior consumed a singular media field in the Telegram send path; regression coverage added in this PR captures later `mediaUrls` being sent rather than dropped.

## Root Cause (if applicable)

- Root cause: The gateway send path normalized URL-backed structured attachments into send payload parts, but did not preserve the full `mediaUrls` list on the action params consumed by the Telegram plugin action runtime. The Telegram runtime then read only singular media fields.
- Missing detection / guardrail: There was no focused regression test covering gateway-dispatched Telegram `message.send` with multiple URL-backed media attachments.
- Contributing context (if known): Adjacent issues cover broader Telegram albums and binary attachment hydration, which can make the narrower URL-backed fan-out path easy to conflate with larger media-delivery work.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/telegram/src/action-runtime.test.ts`; `src/infra/outbound/message-action-runner.plugin-dispatch.test.ts`.
- Scenario the test should lock in: Gateway-dispatched `message.send` preserves multiple URL-backed media attachments as `mediaUrls`, and Telegram fans them out into sequential sends without duplicating text/buttons on follow-up media.
- Why this is the smallest reliable guardrail: It covers the normalization boundary and the Telegram runtime boundary directly without requiring live Telegram credentials for every test run.
- Existing test that already covers this (if any): None found for this exact gateway-dispatched multi-URL Telegram path.
- If no new test is added, why not: N/A; new tests are included.

## User-visible / Behavior Changes

Telegram users receiving URL-backed multi-media assistant/tool responses should receive each media item as a separate Telegram send instead of only the first item.

## Diagram (if applicable)

```text
Before:
[structured URL attachments] -> [mediaUrls normalized] -> [single media consumed] -> [first image only]

After:
[structured URL attachments] -> [mediaUrls preserved] -> [Telegram sequential sends] -> [all URL media delivered]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS local checkout
- Runtime/container: Node/pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Telegram
- Relevant config (redacted): No secrets or live chat identifiers used in supplemental regression tests

### Steps

1. Run `CI=1 pnpm exec vitest run extensions/telegram/src/action-runtime.test.ts src/infra/outbound/message-action-runner.plugin-dispatch.test.ts --reporter=dot`.
2. Inspect the added Telegram runtime test for multiple `mediaUrls`.
3. Inspect the gateway dispatch test for structured attachments being preserved as `mediaUrl` plus `mediaUrls`.

### Expected

- Multiple URL-backed media attachments are preserved through gateway dispatch.
- Telegram sends each media URL sequentially.
- Text/buttons stay on the first send and are not duplicated on follow-up media sends.

### Actual

- Supplemental regression verification passes locally: 2 test files, 86 tests.
- Real Telegram after-fix evidence is still pending and should be added before the real behavior proof gate can pass.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Supplemental local output:

```text
Test Files  2 passed (2)
Tests       86 passed (86)
Command     CI=1 pnpm exec vitest run extensions/telegram/src/action-runtime.test.ts src/infra/outbound/message-action-runner.plugin-dispatch.test.ts --reporter=dot
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Local regression tests verify gateway media URL preservation and Telegram sequential fan-out for multiple media URLs.
- Edge cases checked: Follow-up media sends do not duplicate text/buttons; the returned message id tracks the last Telegram send result.
- What you did **not** verify: Live Telegram delivery from a patched OpenClaw runtime; Telegram album grouping; binary `buffer`/`filename` hydration.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Multi-media sends now produce multiple Telegram messages instead of silently dropping later media.
  - Mitigation: The behavior is limited to already-resolved URL media; text/buttons are only attached to the first send to avoid repeated captions or actions.
- Risk: This does not satisfy users expecting Telegram album grouping.
  - Mitigation: The PR explicitly keeps `sendMediaGroup`/album behavior out of scope and links the broader related issue.

