### PR TITLE
fix(agents): surface user-visible error when embedded session is stuck or overflows context (#84536)

### DIFF
--- a/src/agents/pi-embedded-runner/run-state.ts
+++ b/src/agents/pi-embedded-runner/run-state.ts
@@ -13,7 +13,7 @@ export type EmbeddedPiQueueHandle = {
   isCompacting: () => boolean;
   supportsTranscriptCommitWait?: boolean;
   cancel?: (reason?: "user_abort" | "restart" | "superseded") => void;
-  abort: () => void;
+  abort: (reason?: unknown) => void;
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
 };
 

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -3157,12 +3157,29 @@ export async function runEmbeddedPiAgent(
             : attempt.yieldDetected
               ? "end_turn"
               : (sessionLastAssistant?.stopReason as string | undefined);
+          // When a stuck-session recovery forcibly aborts the run, synthesize
+          // a user-visible error payload so the user knows to retry instead of
+          // seeing a silent empty response after hours of waiting.
+          // See #84536: preemptive context overflow silently kills embedded sessions.
+          const isStuckRecoveryAbort = aborted && attempt.abortReason === "stuck_recovery";
+          const stuckRecoveryPayload =
+            isStuckRecoveryAbort && !payloadsForTerminalPath?.length
+              ? {
+                  text: "⚠️ Your session was stuck and has been automatically recovered. Please try again.",
+                  isError: true as const,
+                }
+              : undefined;
           const terminalPayloads = emptyAssistantReplyIsSilent
             ? [{ text: SILENT_REPLY_TOKEN }]
-            : payloadsForTerminalPath;
+            : stuckRecoveryPayload
+              ? [stuckRecoveryPayload]
+              : payloadsForTerminalPath;
+          const terminalLivenessState: EmbeddedRunLivenessState = stuckRecoveryPayload
+            ? "blocked"
+            : livenessState;
           attempt.setTerminalLifecycleMeta?.({
             replayInvalid,
-            livenessState,
+            livenessState: terminalLivenessState,
             stopReason,
             yielded: attempt.yieldDetected === true,
           });
@@ -3180,7 +3197,7 @@ export async function runEmbeddedPiAgent(
               finalAssistantVisibleText,
               finalAssistantRawText,
               replayInvalid,
-              livenessState,
+              livenessState: terminalLivenessState,
               agentHarnessResultClassification: attempt.agentHarnessResultClassification,
               ...(attempt.yieldDetected ? { yielded: true } : {}),
               ...(emptyAssistantReplyIsSilent

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -4757,11 +4757,18 @@ export async function runEmbeddedAttempt(
       });
       trajectoryEndRecorded = true;
 
+      const abortReason: string | undefined = aborted
+        ? typeof runAbortController.signal.reason === "string"
+          ? runAbortController.signal.reason
+          : undefined
+        : undefined;
+
       return {
         replayMetadata,
         itemLifecycle: getItemLifecycle(),
         setTerminalLifecycleMeta,
         aborted,
+        abortReason,
         externalAbort,
         timedOut,
         idleTimedOut,

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -70,6 +70,12 @@ export type EmbeddedRunAttemptParams = EmbeddedRunAttemptBase & {
 
 export type EmbeddedRunAttemptResult = {
   aborted: boolean;
+  /**
+   * When the run was aborted externally, the string reason passed to
+   * `handle.abort(reason)` if one was provided (e.g. "stuck_recovery").
+   * Undefined when the abort had no string reason or the run was not aborted.
+   */
+  abortReason?: string;
   /** True when the abort originated from the caller-provided abortSignal. */
   externalAbort: boolean;
   timedOut: boolean;

--- a/src/agents/pi-embedded-runner/runs.ts
+++ b/src/agents/pi-embedded-runner/runs.ts
@@ -508,7 +508,28 @@ export async function abortAndDrainEmbeddedPiRun(params: {
   reason?: string;
 }): Promise<AbortAndDrainEmbeddedPiRunResult> {
   const settleMs = params.settleMs ?? 15_000;
-  const aborted = abortEmbeddedPiRun(params.sessionId);
+  // If a reason is provided (e.g. "stuck_recovery"), abort the handle
+  // directly so the reason flows through to the abort signal. This allows
+  // downstream code (run.ts) to detect why the session was aborted and
+  // synthesize a user-visible error message.
+  let aborted: boolean;
+  if (params.reason) {
+    const handle = ACTIVE_EMBEDDED_RUNS.get(params.sessionId);
+    if (handle) {
+      diag.debug(`aborting run with reason: sessionId=${params.sessionId} reason=${params.reason}`);
+      try {
+        handle.abort(params.reason);
+        aborted = true;
+      } catch (err) {
+        diag.warn(`abort failed: sessionId=${params.sessionId} err=${String(err)}`);
+        aborted = false;
+      }
+    } else {
+      aborted = abortEmbeddedPiRun(params.sessionId);
+    }
+  } else {
+    aborted = abortEmbeddedPiRun(params.sessionId);
+  }
   const drained = aborted ? await waitForEmbeddedPiRunEnd(params.sessionId, settleMs) : false;
   const forceCleared =
     params.forceClear === true && (!aborted || !drained)

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -2423,9 +2423,14 @@ export async function runAgentTurnWithFallback(params: {
   // the error to the user instead of silently returning an empty response.
   // See #26905: Slack DM sessions silently swallowed messages when context
   // overflow errors were returned as embedded error payloads.
+  // NOTE: The `!hasPayloadText` guard was intentionally removed. When run.ts
+  // reaches the terminal overflow path it always includes an error payload;
+  // that `!hasPayloadText` guard made this branch dead code in the common
+  // case and silently allowed overflow errors to bypass this user-visible
+  // notification when the payload was delivered through the "success" path
+  // but the user never saw a useful message (e.g. stuck/aborted sessions).
   const finalEmbeddedError = runResult?.meta?.error;
-  const hasPayloadText = runResult?.payloads?.some((p) => normalizeOptionalString(p.text));
-  if (finalEmbeddedError && !hasPayloadText) {
+  if (finalEmbeddedError) {
     const errorMsg = finalEmbeddedError.message ?? "";
     if (isContextOverflowError(errorMsg)) {
       params.replyOperation?.fail("run_failed", finalEmbeddedError);


### PR DESCRIPTION
Fixes #84536.

## Problem

Preemptive context overflow checks (`shouldPreemptivelyCompactBeforePrompt`) fire during tool loops in embedded agent sessions. The session ends with `embedded_run_agent_end` + error, but **no error message is delivered to the channel**. Sessions remain stuck in "processing" state for hours until manual gateway restart.

## Root Causes

### Bug 1: Dead-code overflow fallback in `agent-runner-execution.ts`

The `!hasPayloadText` guard on the context overflow fallback at the end of `runAgentTurnWithFallback` made the branch unreachable in the common terminal-overflow path. `run.ts` always includes an error payload when it reaches the terminal overflow return, so `hasPayloadText` was always `true` and this fallback never fired.

When the session was genuinely stuck (aborted by stuck-session recovery after hours), the abort result had *empty* payloads and `meta.error` unset — so neither the early check nor this fallback fired, and the user saw nothing.

**Fix:** Remove the `!hasPayloadText` guard. The early check at line ~490 already returns for sessions that can be reset; by the time we reach this fallback, the reset failed or was unavailable, so we should always surface the overflow error.

### Bug 2: Stuck-session recovery produces no user notification

`recoverStuckDiagnosticSession` (triggered after `stuckSessionWarnMs` of a session in processing state) calls `abortAndDrainEmbeddedPiRun` and releases the lane — but the aborted run returns with empty payloads and no error in `meta`, so the user receives no message.

**Fix:** Thread the abort reason (`"stuck_recovery"`) through:
1. `abortAndDrainEmbeddedPiRun` → `handle.abort(reason)` (when reason is provided)
2. `handle.abort(reason)` → `runAbortController.abort(reason)` (abort signal now carries reason)
3. `runAbortController.signal.reason` → `EmbeddedRunAttemptResult.abortReason`
4. `attempt.abortReason === "stuck_recovery"` in `run.ts` → synthesize a user-visible error payload

The synthesized payload delivers: *"⚠️ Your session was stuck and has been automatically recovered. Please try again."*

## Changes

| File | Change |
|------|--------|
| `src/auto-reply/reply/agent-runner-execution.ts` | Remove `!hasPayloadText` dead guard; always surface overflow error |
| `src/agents/pi-embedded-runner/run-state.ts` | `EmbeddedPiQueueHandle.abort: (reason?: unknown) => void` |
| `src/agents/pi-embedded-runner/runs.ts` | Pass `params.reason` to `handle.abort(reason)` in `abortAndDrainEmbeddedPiRun` |
| `src/agents/pi-embedded-runner/run/types.ts` | Add `abortReason?: string` to `EmbeddedRunAttemptResult` |
| `src/agents/pi-embedded-runner/run/attempt.ts` | Read `runAbortController.signal.reason` and expose as `abortReason` |
| `src/agents/pi-embedded-runner/run.ts` | Synthesize "session was stuck" payload when `abortReason === "stuck_recovery"` |

## Design Notes

- No compaction policy or threshold changes
- No new user-facing configuration
- Abort reason threading uses the standard `AbortController.abort(reason)` / `signal.reason` pattern already present in the codebase (see `sessions_yield` abort)
- `stuckRecoveryPayload` is only synthesized when `payloadsForTerminalPath` is empty — normal completions and overflow terminal paths keep their existing payloads
- `livenessState` is set to `"blocked"` for stuck-recovery aborts to match the existing convention for error-terminal paths

## Acceptance criteria

```bash
node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts
node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts
node scripts/run-vitest.mjs src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
```

---

## Fix commit (f4e723e0)

**Root cause fix:** `queueHandle.abort` was wired as `abort: abortRun` where `abortRun(isTimeout = false, reason?)` takes the timeout flag as first arg. Calling `handle.abort("stuck_recovery")` passed `"stuck_recovery"` into the `isTimeout` slot (truthy → `timedOut = true`), leaving `reason = undefined`. The abort signal received `makeTimeoutAbortReason()` instead of `"stuck_recovery"`, so `attempt.abortReason` was never `"stuck_recovery"` and the stuck-recovery payload was never synthesized.

**Fix:** `src/agents/pi-embedded-runner/run/attempt.ts:3314`
```diff
-  abort: abortRun,
+  abort: (reason?: unknown) => abortRun(false, reason),
```

This matches the updated `EmbeddedPiQueueHandle` type (`abort: (reason?: unknown) => void`) and ensures `"stuck_recovery"` flows correctly to `runAbortController.abort(reason)` → `signal.reason` → `abortReason` → `isStuckRecoveryAbort` → user-visible recovery payload. ✓

**Tests added:** `src/agents/pi-embedded-runner/runs.test.ts` — asserts that when `abortAndDrainEmbeddedPiRun({ reason: "stuck_recovery" })` is called, `handle.abort` receives `"stuck_recovery"` as the reason (not isTimeout).

All three acceptance criteria test commands pass.