### PR TITLE
fix(memory-wiki): show vault totals in palace summary

### DIFF
--- a/extensions/memory-wiki/src/gateway.test.ts
+++ b/extensions/memory-wiki/src/gateway.test.ts
@@ -356,6 +356,14 @@ describe("memory-wiki gateway methods", () => {
     const { api, registerGatewayMethod } = createPluginApi();
     vi.mocked(listMemoryWikiPalace).mockResolvedValue({
       totalItems: 3,
+      totalPages: 12,
+      pageCounts: {
+        source: 8,
+        entity: 1,
+        concept: 0,
+        synthesis: 2,
+        report: 1,
+      },
       totalClaims: 4,
       totalQuestions: 1,
       totalContradictions: 1,
@@ -400,6 +408,14 @@ describe("memory-wiki gateway methods", () => {
     expect(listMemoryWikiPalace).toHaveBeenCalledWith(config);
     expect(readRespondPayload(respond)).toEqual({
       totalItems: 3,
+      totalPages: 12,
+      pageCounts: {
+        source: 8,
+        entity: 1,
+        concept: 0,
+        synthesis: 2,
+        report: 1,
+      },
       totalClaims: 4,
       totalQuestions: 1,
       totalContradictions: 1,

--- a/extensions/memory-wiki/src/memory-palace.test.ts
+++ b/extensions/memory-wiki/src/memory-palace.test.ts
@@ -16,6 +16,7 @@ describe("listMemoryWikiPalace", () => {
 
     await fs.mkdir(path.join(rootDir, "syntheses"), { recursive: true });
     await fs.mkdir(path.join(rootDir, "entities"), { recursive: true });
+    await fs.mkdir(path.join(rootDir, "sources"), { recursive: true });
     await fs.writeFile(
       path.join(rootDir, "syntheses", "travel-system.md"),
       renderWikiMarkdown({
@@ -54,10 +55,33 @@ describe("listMemoryWikiPalace", () => {
       }),
       "utf8",
     );
+    await fs.writeFile(
+      path.join(rootDir, "sources", "chatgpt-travel.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "source",
+          id: "source.chatgpt.travel",
+          title: "Travel chat export",
+          updatedAt: "2026-04-08T08:00:00.000Z",
+        },
+        body: ["# Travel chat export", "", "Raw source import without extracted claims.", ""].join(
+          "\n",
+        ),
+      }),
+      "utf8",
+    );
 
     const result = await listMemoryWikiPalace(config);
 
     expect(result.totalItems).toBe(2);
+    expect(result.totalPages).toBe(3);
+    expect(result.pageCounts).toMatchObject({
+      source: 1,
+      entity: 1,
+      concept: 0,
+      synthesis: 1,
+      report: 0,
+    });
     expect(result.totalClaims).toBe(3);
     expect(result.totalQuestions).toBe(1);
     expect(result.totalContradictions).toBe(1);

--- a/extensions/memory-wiki/src/memory-palace.ts
+++ b/extensions/memory-wiki/src/memory-palace.ts
@@ -41,6 +41,8 @@ type MemoryWikiPalaceCluster = {
 
 type MemoryWikiPalaceStatus = {
   totalItems: number;
+  totalPages: number;
+  pageCounts: Record<WikiPageKind, number>;
   totalClaims: number;
   totalQuestions: number;
   totalContradictions: number;
@@ -89,6 +91,13 @@ export async function listMemoryWikiPalace(
   config: ResolvedMemoryWikiConfig,
 ): Promise<MemoryWikiPalaceStatus> {
   const pages = await readQueryableWikiPages(config.vault.path);
+  const pageCounts = Object.fromEntries(PALACE_KIND_ORDER.map((kind) => [kind, 0])) as Record<
+    WikiPageKind,
+    number
+  >;
+  for (const page of pages) {
+    pageCounts[page.kind] += 1;
+  }
   const items = pages
     .map((page) => {
       const parsed = parseWikiMarkdown(page.raw);
@@ -140,6 +149,8 @@ export async function listMemoryWikiPalace(
 
   return {
     totalItems: items.length,
+    totalPages: pages.length,
+    pageCounts,
     totalClaims: items.reduce((sum, item) => sum + item.claimCount, 0),
     totalQuestions: items.reduce((sum, item) => sum + item.questionCount, 0),
     totalContradictions: items.reduce((sum, item) => sum + item.contradictionCount, 0),

--- a/ui/src/ui/controllers/dreaming.test.ts
+++ b/ui/src/ui/controllers/dreaming.test.ts
@@ -422,6 +422,14 @@ describe("dreaming controller", () => {
     };
     request.mockResolvedValue({
       totalItems: 2,
+      totalPages: 12,
+      pageCounts: {
+        source: 8,
+        entity: 1,
+        concept: 0,
+        synthesis: 2,
+        report: 1,
+      },
       totalClaims: 3,
       totalQuestions: 1,
       totalContradictions: 1,
@@ -455,6 +463,8 @@ describe("dreaming controller", () => {
 
     expect(request).toHaveBeenCalledWith("wiki.palace", {});
     expect(state.wikiMemoryPalace?.totalItems).toBe(2);
+    expect(state.wikiMemoryPalace?.totalPages).toBe(12);
+    expect(state.wikiMemoryPalace?.pageCounts.synthesis).toBe(2);
     expect(state.wikiMemoryPalace?.totalClaims).toBe(3);
     expect(state.wikiMemoryPalace?.clusters).toHaveLength(1);
     expect(state.wikiMemoryPalace?.clusters[0]?.key).toBe("synthesis");
@@ -494,6 +504,7 @@ describe("dreaming controller", () => {
 
     expect(request).toHaveBeenCalledWith("wiki.palace", {});
     expect(state.wikiMemoryPalace?.totalItems).toBe(1);
+    expect(state.wikiMemoryPalace?.totalPages).toBe(1);
     expect(state.wikiMemoryPalace?.totalClaims).toBe(2);
     expect(state.wikiMemoryPalaceError).toBeNull();
     expect(state.wikiMemoryPalaceLoading).toBe(false);
@@ -509,6 +520,14 @@ describe("dreaming controller", () => {
     };
     state.wikiMemoryPalace = {
       totalItems: 1,
+      totalPages: 1,
+      pageCounts: {
+        source: 0,
+        entity: 0,
+        concept: 0,
+        synthesis: 1,
+        report: 0,
+      },
       totalClaims: 1,
       totalQuestions: 0,
       totalContradictions: 0,
@@ -546,6 +565,14 @@ describe("dreaming controller", () => {
     };
     state.wikiMemoryPalace = {
       totalItems: 1,
+      totalPages: 1,
+      pageCounts: {
+        source: 0,
+        entity: 0,
+        concept: 0,
+        synthesis: 1,
+        report: 0,
+      },
       totalClaims: 1,
       totalQuestions: 0,
       totalContradictions: 0,

--- a/ui/src/ui/controllers/dreaming.test.ts
+++ b/ui/src/ui/controllers/dreaming.test.ts
@@ -478,6 +478,52 @@ describe("dreaming controller", () => {
     expect(state.wikiMemoryPalaceLoading).toBe(false);
   });
 
+  it("derives memory palace page counts from clusters for older payloads", async () => {
+    const { state, request } = createState();
+    state.hello = {
+      type: "hello-ok",
+      protocol: 4,
+      auth: { role: "operator", scopes: [] },
+      features: { methods: ["wiki.palace"] },
+    };
+    request.mockResolvedValue({
+      totalItems: 3,
+      totalClaims: 2,
+      totalQuestions: 1,
+      clusters: [
+        {
+          key: "source",
+          label: "Sources",
+          itemCount: 2,
+          claimCount: 0,
+          questionCount: 0,
+          contradictionCount: 0,
+          items: [],
+        },
+        {
+          key: "synthesis",
+          label: "Syntheses",
+          itemCount: 1,
+          claimCount: 2,
+          questionCount: 1,
+          contradictionCount: 0,
+          items: [],
+        },
+      ],
+    });
+
+    await loadWikiMemoryPalace(state);
+
+    expect(state.wikiMemoryPalace?.pageCounts).toEqual({
+      source: 2,
+      entity: 0,
+      concept: 0,
+      synthesis: 1,
+      report: 0,
+    });
+    expect(state.wikiMemoryPalace?.totalPages).toBe(3);
+  });
+
   it("falls back to config gating for wiki memory palace when methods are not advertised", async () => {
     const { state, request } = createState();
     state.configSnapshot = {

--- a/ui/src/ui/controllers/dreaming.ts
+++ b/ui/src/ui/controllers/dreaming.ts
@@ -151,6 +151,8 @@ export type WikiMemoryPalaceCluster = {
 
 export type WikiMemoryPalace = {
   totalItems: number;
+  totalPages: number;
+  pageCounts: Record<WikiMemoryPalaceItem["kind"], number>;
   totalClaims: number;
   totalQuestions: number;
   totalContradictions: number;
@@ -192,6 +194,8 @@ type WikiImportInsightsPayload = {
 
 type WikiMemoryPalacePayload = {
   totalItems?: unknown;
+  totalPages?: unknown;
+  pageCounts?: unknown;
   totalClaims?: unknown;
   totalQuestions?: unknown;
   totalContradictions?: unknown;
@@ -625,11 +629,24 @@ function normalizeWikiMemoryPalace(raw: unknown): WikiMemoryPalace {
         .map((entry) => normalizeWikiMemoryPalaceCluster(entry))
         .filter((entry): entry is WikiMemoryPalaceCluster => entry !== null)
     : [];
+  const pageCountsRecord = asRecord(record?.pageCounts);
+  const pageCounts = {
+    source: normalizeFiniteInt(pageCountsRecord?.source, 0),
+    entity: normalizeFiniteInt(pageCountsRecord?.entity, 0),
+    concept: normalizeFiniteInt(pageCountsRecord?.concept, 0),
+    synthesis: normalizeFiniteInt(pageCountsRecord?.synthesis, 0),
+    report: normalizeFiniteInt(pageCountsRecord?.report, 0),
+  };
+  const fallbackTotalPages = Object.values(pageCounts).reduce((sum, count) => sum + count, 0);
+  const fallbackTotalItems = clusters.reduce((sum, cluster) => sum + cluster.itemCount, 0);
+  const totalItems = normalizeFiniteInt(record?.totalItems, fallbackTotalItems);
   return {
-    totalItems: normalizeFiniteInt(
-      record?.totalItems,
-      clusters.reduce((sum, cluster) => sum + cluster.itemCount, 0),
+    totalItems,
+    totalPages: normalizeFiniteInt(
+      record?.totalPages,
+      fallbackTotalPages > 0 ? fallbackTotalPages : totalItems,
     ),
+    pageCounts,
     totalClaims: normalizeFiniteInt(
       record?.totalClaims,
       clusters.reduce((sum, cluster) => sum + cluster.claimCount, 0),

--- a/ui/src/ui/controllers/dreaming.ts
+++ b/ui/src/ui/controllers/dreaming.ts
@@ -629,13 +629,23 @@ function normalizeWikiMemoryPalace(raw: unknown): WikiMemoryPalace {
         .map((entry) => normalizeWikiMemoryPalaceCluster(entry))
         .filter((entry): entry is WikiMemoryPalaceCluster => entry !== null)
     : [];
+  const clusterPageCounts = {
+    source: 0,
+    entity: 0,
+    concept: 0,
+    synthesis: 0,
+    report: 0,
+  };
+  for (const cluster of clusters) {
+    clusterPageCounts[cluster.key] += cluster.itemCount;
+  }
   const pageCountsRecord = asRecord(record?.pageCounts);
   const pageCounts = {
-    source: normalizeFiniteInt(pageCountsRecord?.source, 0),
-    entity: normalizeFiniteInt(pageCountsRecord?.entity, 0),
-    concept: normalizeFiniteInt(pageCountsRecord?.concept, 0),
-    synthesis: normalizeFiniteInt(pageCountsRecord?.synthesis, 0),
-    report: normalizeFiniteInt(pageCountsRecord?.report, 0),
+    source: normalizeFiniteInt(pageCountsRecord?.source, clusterPageCounts.source),
+    entity: normalizeFiniteInt(pageCountsRecord?.entity, clusterPageCounts.entity),
+    concept: normalizeFiniteInt(pageCountsRecord?.concept, clusterPageCounts.concept),
+    synthesis: normalizeFiniteInt(pageCountsRecord?.synthesis, clusterPageCounts.synthesis),
+    report: normalizeFiniteInt(pageCountsRecord?.report, clusterPageCounts.report),
   };
   const fallbackTotalPages = Object.values(pageCounts).reduce((sum, count) => sum + count, 0);
   const fallbackTotalItems = clusters.reduce((sum, cluster) => sum + cluster.itemCount, 0);

--- a/ui/src/ui/views/dreaming.test.ts
+++ b/ui/src/ui/views/dreaming.test.ts
@@ -143,6 +143,14 @@ function buildProps(overrides?: Partial<DreamingProps>): DreamingProps {
     wikiMemoryPalaceError: null,
     wikiMemoryPalace: {
       totalItems: 2,
+      totalPages: 12,
+      pageCounts: {
+        source: 8,
+        entity: 1,
+        concept: 0,
+        synthesis: 2,
+        report: 1,
+      },
       totalClaims: 3,
       totalQuestions: 1,
       totalContradictions: 1,
@@ -398,7 +406,10 @@ describe("dreaming view", () => {
     setDreamDiarySubTab("palace");
     const container = renderInto(buildProps());
     expect(compactText(container.querySelector(".dreams-diary__date"))).toBe(
-      "Syntheses · 1 pages · 2 claims · 1 questions · 1 contradictions",
+      "Vault · 12 pages · 3 claim rows · 1 open question",
+    );
+    expect(compactText(container.querySelector(".dreams-diary__para"))).toBe(
+      "Syntheses: 1 page · 2 claim rows · 1 open question · 1 contradiction. Full vault breakdown: 8 sources, 1 entity, 0 concepts, 2 syntheses, 1 report.",
     );
     const insight = container.querySelector(".dreams-diary__insight-card");
     expect(insight?.querySelector(".dreams-diary__insight-title")?.textContent).toBe(

--- a/ui/src/ui/views/dreaming.ts
+++ b/ui/src/ui/views/dreaming.ts
@@ -494,6 +494,21 @@ function formatKindLabel(kind: "entity" | "concept" | "source" | "synthesis" | "
   return kind;
 }
 
+function formatCountLabel(count: number, singular: string, plural = `${singular}s`): string {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+function formatMemoryWikiPageBreakdown(palace: WikiMemoryPalace): string {
+  const { pageCounts } = palace;
+  return [
+    formatCountLabel(pageCounts.source, "source"),
+    formatCountLabel(pageCounts.entity, "entity", "entities"),
+    formatCountLabel(pageCounts.concept, "concept"),
+    formatCountLabel(pageCounts.synthesis, "synthesis", "syntheses"),
+    formatCountLabel(pageCounts.report, "report"),
+  ].join(", ");
+}
+
 function formatImportBadge(item: {
   digestStatus: "available" | "withheld";
   riskLevel: "low" | "medium" | "high" | "unknown";
@@ -1160,16 +1175,19 @@ function renderMemoryPalaceSection(props: DreamingProps) {
     <article class="dreams-diary__entry" key="palace-${cluster.key}">
       <div class="dreams-diary__accent"></div>
       <div class="dreams-diary__date">
-        ${cluster.label} · ${cluster.itemCount} pages
-        ${cluster.claimCount > 0 ? html`· ${cluster.claimCount} claims` : nothing}
-        ${cluster.questionCount > 0 ? html`· ${cluster.questionCount} questions` : nothing}
-        ${cluster.contradictionCount > 0
-          ? html`· ${cluster.contradictionCount} contradictions`
-          : nothing}
+        Vault · ${formatCountLabel(palace?.totalPages ?? palace?.totalItems ?? 0, "page")} ·
+        ${formatCountLabel(palace?.totalClaims ?? 0, "claim row")} ·
+        ${formatCountLabel(palace?.totalQuestions ?? 0, "open question")}
       </div>
       <div class="dreams-diary__prose">
         <p class="dreams-diary__para">
-          Compiled wiki pages currently grouped under ${cluster.label.toLowerCase()}.
+          ${cluster.label}: ${formatCountLabel(cluster.itemCount, "page")} ·
+          ${formatCountLabel(cluster.claimCount, "claim row")} ·
+          ${formatCountLabel(cluster.questionCount, "open question")}
+          ${cluster.contradictionCount > 0
+            ? html`· ${formatCountLabel(cluster.contradictionCount, "contradiction")}`
+            : nothing}.
+          Full vault breakdown: ${palace ? formatMemoryWikiPageBreakdown(palace) : "not available"}.
           ${cluster.updatedAt ? ` Latest update ${formatCompactDateTime(cluster.updatedAt)}.` : ""}
         </p>
       </div>


### PR DESCRIPTION
## Summary

Fixes #84597.

- Add vault-level `totalPages` and `pageCounts` to the memory palace payload.
- Keep `totalItems` as the filtered/visible palace-card count, so existing callers do not lose the palace-specific meaning.
- Render the palace diary headline as a vault summary and move selected section metrics into the body with explicit labels.
- Normalize older payloads in the UI controller by falling back to existing `totalItems` when `totalPages/pageCounts` are absent.

## Real behavior proof

Behavior addressed: the Memory Wiki palace diary no longer presents a selected section count as the top-level summary. It now shows a vault-level page total and claim/open-question totals, then separately labels the selected section's local page/claim/question/contradiction metrics and full vault page breakdown.

Real environment tested: local OpenClaw source checkout on this PR branch, running the actual `listMemoryWikiPalace` implementation against a temporary on-disk Memory Wiki vault containing one synthesis page and one raw source page.

Exact steps or command run after the patch:
```bash
OPENCLAW_FS_SAFE_PYTHON=/usr/bin/python3 FS_SAFE_PYTHON=/usr/bin/python3 OPENCLAW_FS_SAFE_PYTHON_MODE=auto FS_SAFE_PYTHON_MODE=auto node --import tsx --input-type=module /tmp/openclaw-palace-proof.mjs
```

Evidence after fix: copied console output from the patched implementation:
```json
{
  "totalItems": 1,
  "totalPages": 2,
  "pageCounts": {
    "synthesis": 1,
    "entity": 0,
    "concept": 0,
    "source": 1,
    "report": 0
  },
  "headline": "Vault · 2 pages · 2 claim rows · 1 open question",
  "section": "Syntheses: 1 page · 2 claim rows · 1 open question · 1 contradiction"
}
```

Observed result: the actual palace payload now distinguishes `totalItems: 1` visible palace card from `totalPages: 2` full vault pages and includes `pageCounts.source: 1`. The UI summary string built from the same payload is vault-level, while the synthesis metrics remain clearly section-local.

What was not tested: manual browser screenshot verification was not run; the DOM rendering path is covered by the targeted UI view test listed below.

## Supplemental verification

- `OPENCLAW_FS_SAFE_PYTHON=/usr/bin/python3 FS_SAFE_PYTHON=/usr/bin/python3 OPENCLAW_FS_SAFE_PYTHON_MODE=auto FS_SAFE_PYTHON_MODE=auto node scripts/test-projects.mjs extensions/memory-wiki/src/memory-palace.test.ts extensions/memory-wiki/src/gateway.test.ts extensions/memory-wiki/src/status.test.ts ui/src/ui/controllers/dreaming.test.ts ui/src/ui/views/dreaming.test.ts`
- `pnpm exec oxfmt --check extensions/memory-wiki/src/memory-palace.ts extensions/memory-wiki/src/memory-palace.test.ts extensions/memory-wiki/src/gateway.test.ts ui/src/ui/controllers/dreaming.ts ui/src/ui/controllers/dreaming.test.ts ui/src/ui/views/dreaming.ts ui/src/ui/views/dreaming.test.ts`
- `git diff --check`
- `pnpm tsgo:core:test`