### PR TITLE
fix(agents): add .catch() to fire-and-forget subagent lifecycle promises

### DIFF
--- a/src/agents/subagent-registry.lifecycle-retry-grace.e2e.test.ts
+++ b/src/agents/subagent-registry.lifecycle-retry-grace.e2e.test.ts
@@ -523,6 +523,57 @@ describe("subagent registry lifecycle error grace", () => {
     expect(run.completion?.capturedAt).toBeTypeOf("number");
   });
 
+  it("completes with timeout status when aborted end event fires after grace window", async () => {
+    registerCompletionRun("run-timeout", "timeout", "timeout test");
+    setAssistantOutput("agent:main:subagent:timeout", "Partial output before timeout");
+
+    // Emit an end event with aborted=true which triggers the timeout grace path
+    emitLifecycleEvent("run-timeout", {
+      phase: "end",
+      aborted: true,
+      endedAt: 3_000,
+    } as LifecycleData & { aborted: boolean });
+    await flushAsync();
+    expect(getAgentCalls()).toHaveLength(0);
+
+    // Advance past the lifecycle timeout retry grace window
+    await vi.advanceTimersByTimeAsync(30_000);
+    await flushAsync();
+
+    await waitForAgentCallCount(1);
+
+    const run = mod
+      .listSubagentRunsForRequester(MAIN_REQUESTER_SESSION_KEY)
+      .find((candidate) => candidate.runId === "run-timeout");
+    expect(run?.outcome?.status).toBe("timeout");
+  });
+
+  it("cancels timeout grace when a successful end event arrives before the grace window expires", async () => {
+    registerCompletionRun("run-timeout-cancel", "timeout-cancel", "timeout cancel test");
+    setAssistantOutput("agent:main:subagent:timeout-cancel", "Final answer after recovery");
+
+    // Emit an aborted end event (starts timeout grace)
+    emitLifecycleEvent("run-timeout-cancel", {
+      phase: "end",
+      aborted: true,
+      endedAt: 4_000,
+    } as LifecycleData & { aborted: boolean });
+    await flushAsync();
+    expect(getAgentCalls()).toHaveLength(0);
+
+    // Before the grace window, the run successfully ends (non-aborted)
+    emitLifecycleEvent("run-timeout-cancel", { phase: "end", endedAt: 4_500 });
+    await flushAsync();
+
+    await waitForAgentCallCount(1);
+    expect(readFirstAnnounceOutcome()?.status).toBe("ok");
+
+    // Advance past the original grace window; no timeout should fire
+    await vi.advanceTimersByTimeAsync(30_000);
+    await flushAsync();
+    expect(getAgentCalls()).toHaveLength(1);
+  });
+
   it("keeps parallel child completion results frozen even when late traffic arrives", async () => {
     // Regression guard: fan-out retries must preserve each child's first frozen result text.
     registerCompletionRun("run-parallel-a", "parallel-a", "parallel a");

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -1044,6 +1044,64 @@ describe("subagent registry seam flow", () => {
     expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
   });
 
+  it("resumes ended cleanup when lifecycle killed completion rejects before cleanup", async () => {
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return { status: "pending" };
+      }
+      return {};
+    });
+    mocks.ensureRuntimePluginsLoaded
+      .mockRejectedValueOnce(new Error("runtime unavailable before cleanup"))
+      .mockRejectedValueOnce(new Error("runtime still unavailable before cleanup"));
+
+    mod.registerSubagentRun({
+      runId: "run-killed-recovery",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "killed recovery test",
+      cleanup: "keep",
+      expectsCompletionMessage: false,
+    });
+
+    const lastOnAgentEventCall = mocks.onAgentEvent.mock.calls[
+      mocks.onAgentEvent.mock.calls.length - 1
+    ] as unknown as
+      | [(evt: { runId: string; stream: string; data: Record<string, unknown> }) => void]
+      | undefined;
+    const lifecycleHandler = lastOnAgentEventCall?.[0];
+    expect(lifecycleHandler).toBeTypeOf("function");
+
+    lifecycleHandler?.({
+      runId: "run-killed-recovery",
+      stream: "lifecycle",
+      data: { phase: "start", startedAt: 100 },
+    });
+
+    lifecycleHandler?.({
+      runId: "run-killed-recovery",
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        startedAt: 100,
+        endedAt: 200,
+        stopReason: "aborted",
+      },
+    });
+
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-killed-recovery");
+      expect(mocks.ensureRuntimePluginsLoaded).toHaveBeenCalledTimes(2);
+      expect(run?.outcome?.status).toBe("error");
+      expect(run?.endedReason).toBe("subagent-killed");
+      expect(run?.cleanupCompletedAt).toBeTypeOf("number");
+    });
+    expect(mocks.runSubagentAnnounceFlow).not.toHaveBeenCalled();
+  });
+
   it("preserves run-mode keep entries past SESSION_RUN_TTL_MS sweep", async () => {
     mod.registerSubagentRun({
       runId: "run-keep-survives-ttl",

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -14,6 +14,7 @@ import type { DeliveryContext } from "../utils/delivery-context.types.js";
 import { removeInternalSessionEffectsTranscript } from "./internal-session-effects.js";
 import { isAbortedAgentStopReason } from "./run-termination.js";
 import type { ensureRuntimePluginsLoaded as ensureRuntimePluginsLoadedFn } from "./runtime-plugins.js";
+import type { SubagentRunOutcome } from "./subagent-announce-output.js";
 import {
   ensureCompletionState,
   ensureDeliveryState,
@@ -337,6 +338,70 @@ function clearAllPendingLifecycleTimeouts() {
   pendingLifecycleTimeoutByRunId.clear();
 }
 
+type CompleteSubagentRunParams = {
+  runId: string;
+  endedAt?: number;
+  outcome: SubagentRunOutcome;
+  reason: SubagentLifecycleEndedReason;
+  sendFarewell?: boolean;
+  accountId?: string;
+  triggerCleanup: boolean;
+};
+
+async function completeSubagentRunWithRecovery(params: CompleteSubagentRunParams, source: string) {
+  try {
+    await completeSubagentRun(params);
+    return;
+  } catch (error) {
+    const current = subagentRuns.get(params.runId);
+    log.warn("failed to complete subagent run; retrying completion", {
+      source,
+      runId: params.runId,
+      childSessionKey: current?.childSessionKey,
+      error,
+    });
+  }
+
+  const current = subagentRuns.get(params.runId);
+  if (
+    !current ||
+    typeof current.endedAt !== "number" ||
+    typeof current.cleanupCompletedAt === "number" ||
+    current.pauseReason === "sessions_yield"
+  ) {
+    return;
+  }
+
+  try {
+    await completeSubagentRun(params);
+    return;
+  } catch (retryError) {
+    log.warn("failed to complete subagent run after retry; retrying ended cleanup", {
+      source,
+      runId: params.runId,
+      childSessionKey: current.childSessionKey,
+      error: retryError,
+    });
+  }
+
+  const latest = subagentRuns.get(params.runId);
+  if (
+    !latest ||
+    typeof latest.endedAt !== "number" ||
+    typeof latest.cleanupCompletedAt === "number" ||
+    latest.pauseReason === "sessions_yield"
+  ) {
+    return;
+  }
+  latest.cleanupHandled = false;
+  resumedRuns.delete(params.runId);
+  resumeSubagentRun(params.runId);
+}
+
+function completeSubagentRunInBackground(params: CompleteSubagentRunParams, source: string) {
+  void completeSubagentRunWithRecovery(params, source);
+}
+
 function schedulePendingLifecycleError(params: { runId: string; endedAt: number; error?: string }) {
   clearPendingLifecycleTimeout(params.runId);
   clearPendingLifecycleError(params.runId);
@@ -353,18 +418,19 @@ function schedulePendingLifecycleError(params: { runId: string; endedAt: number;
     if (entry.endedReason === SUBAGENT_ENDED_REASON_COMPLETE || entry.outcome?.status === "ok") {
       return;
     }
-    void completeSubagentRun({
+    const completionParams = {
       runId: params.runId,
       endedAt: pending.endedAt,
       outcome: {
-        status: "error",
+        status: "error" as const,
         error: pending.error,
       },
       reason: SUBAGENT_ENDED_REASON_ERROR,
       sendFarewell: true,
       accountId: entry.requesterOrigin?.accountId,
       triggerCleanup: true,
-    });
+    };
+    completeSubagentRunInBackground(completionParams, "lifecycle-error-grace");
   }, LIFECYCLE_ERROR_RETRY_GRACE_MS);
   timer.unref?.();
   pendingLifecycleErrorByRunId.set(params.runId, {
@@ -390,17 +456,18 @@ function schedulePendingLifecycleTimeout(params: { runId: string; endedAt: numbe
     if (entry.outcome?.status === "ok") {
       return;
     }
-    void completeSubagentRun({
+    const completionParams = {
       runId: params.runId,
       endedAt: pending.endedAt,
       outcome: {
-        status: "timeout",
+        status: "timeout" as const,
       },
       reason: SUBAGENT_ENDED_REASON_COMPLETE,
       sendFarewell: true,
       accountId: entry.requesterOrigin?.accountId,
       triggerCleanup: true,
-    });
+    };
+    completeSubagentRunInBackground(completionParams, "lifecycle-timeout-grace");
   }, LIFECYCLE_TIMEOUT_RETRY_GRACE_MS);
   timer.unref?.();
   pendingLifecycleTimeoutByRunId.set(params.runId, {
@@ -842,15 +909,18 @@ async function sweepSubagentRuns() {
             notBeforeMs: entry.startedAt ?? entry.createdAt,
           });
           if (completion) {
-            await completeSubagentRun({
-              runId,
-              endedAt: completion.endedAt,
-              outcome: completion.outcome,
-              reason: completion.reason,
-              sendFarewell: true,
-              accountId: entry.requesterOrigin?.accountId,
-              triggerCleanup: true,
-            });
+            await completeSubagentRunWithRecovery(
+              {
+                runId,
+                endedAt: completion.endedAt,
+                outcome: completion.outcome,
+                reason: completion.reason,
+                sendFarewell: true,
+                accountId: entry.requesterOrigin?.accountId,
+                triggerCleanup: true,
+              },
+              "sweeper-session-completion",
+            );
             continue;
           }
 
@@ -859,18 +929,21 @@ async function sweepSubagentRuns() {
             continue;
           }
 
-          await completeSubagentRun({
-            runId,
-            endedAt: now,
-            outcome: {
-              status: "error",
-              error: "subagent run lost active execution context",
+          await completeSubagentRunWithRecovery(
+            {
+              runId,
+              endedAt: now,
+              outcome: {
+                status: "error",
+                error: "subagent run lost active execution context",
+              },
+              reason: SUBAGENT_ENDED_REASON_ERROR,
+              sendFarewell: true,
+              accountId: entry.requesterOrigin?.accountId,
+              triggerCleanup: true,
             },
-            reason: SUBAGENT_ENDED_REASON_ERROR,
-            sendFarewell: true,
-            accountId: entry.requesterOrigin?.accountId,
-            triggerCleanup: true,
-          });
+            "sweeper-lost-context",
+          );
           continue;
         }
       }
@@ -1004,35 +1077,39 @@ function ensureListener() {
       if (isAbortedAgentStopReason(stopReason)) {
         clearPendingLifecycleError(evt.runId);
         clearPendingLifecycleTimeout(evt.runId);
-        await completeSubagentRun({
-          runId: evt.runId,
-          endedAt,
-          outcome: {
-            status: "error",
-            error: "subagent run terminated",
+        await completeSubagentRunWithRecovery(
+          {
+            runId: evt.runId,
+            endedAt,
+            outcome: {
+              status: "error",
+              error: "subagent run terminated",
+            },
+            reason: SUBAGENT_ENDED_REASON_KILLED,
+            sendFarewell: true,
+            accountId: entry.requesterOrigin?.accountId,
+            triggerCleanup: true,
           },
-          reason: SUBAGENT_ENDED_REASON_KILLED,
-          sendFarewell: true,
-          accountId: entry.requesterOrigin?.accountId,
-          triggerCleanup: true,
-        });
+          "lifecycle-killed-event",
+        );
         return;
       }
       if (isBlockedLivenessState(livenessState)) {
         clearPendingLifecycleError(evt.runId);
         clearPendingLifecycleTimeout(evt.runId);
-        await completeSubagentRun({
+        const blockedParams = {
           runId: evt.runId,
           endedAt,
           outcome: {
-            status: "error",
+            status: "error" as const,
             error: formatBlockedLivenessError(error),
           },
           reason: SUBAGENT_ENDED_REASON_ERROR,
           sendFarewell: true,
           accountId: entry.requesterOrigin?.accountId,
           triggerCleanup: true,
-        });
+        };
+        await completeSubagentRunWithRecovery(blockedParams, "lifecycle-blocked-event");
         return;
       }
       if (evt.data?.aborted) {
@@ -1057,16 +1134,19 @@ function ensureListener() {
       }
       clearPendingLifecycleError(evt.runId);
       clearPendingLifecycleTimeout(evt.runId);
-      await completeSubagentRun({
+      const completionParams = {
         runId: evt.runId,
         endedAt,
-        outcome: { status: "ok" },
+        outcome: { status: "ok" as const },
         reason: SUBAGENT_ENDED_REASON_COMPLETE,
         sendFarewell: true,
         accountId: entry.requesterOrigin?.accountId,
         triggerCleanup: true,
-      });
-    })();
+      };
+      await completeSubagentRunWithRecovery(completionParams, "lifecycle-ok-event");
+    })().catch((err) => {
+      log.warn("lifecycle event handler failed", { err, runId: evt.runId });
+    });
   });
 }
 
@@ -1209,18 +1289,21 @@ export async function finalizeInterruptedSubagentRun(params: {
     if (!entry || typeof entry.cleanupCompletedAt === "number") {
       continue;
     }
-    await completeSubagentRun({
-      runId,
-      endedAt,
-      outcome: {
-        status: "error",
-        error: params.error,
+    await completeSubagentRunWithRecovery(
+      {
+        runId,
+        endedAt,
+        outcome: {
+          status: "error",
+          error: params.error,
+        },
+        reason: SUBAGENT_ENDED_REASON_ERROR,
+        sendFarewell: true,
+        accountId: entry.requesterOrigin?.accountId,
+        triggerCleanup: true,
       },
-      reason: SUBAGENT_ENDED_REASON_ERROR,
-      sendFarewell: true,
-      accountId: entry.requesterOrigin?.accountId,
-      triggerCleanup: true,
-    });
+      "explicit-failed-mark",
+    );
     updated += 1;
   }
   return updated;


### PR DESCRIPTION
## Problem

Subagent lifecycle completion can reject after terminal run state is written but before cleanup starts. In that half-ended state the run has `endedAt`/`outcome`, but `cleanupHandled` and `cleanupCompletedAt` are still unset, so parent delivery or final cleanup can be skipped until a later resume path happens to recover it.

## Fix

- Add one central `completeSubagentRunWithRecovery` wrapper that mirrors the existing run-manager recovery contract: complete once, retry once, then route ended-but-not-cleaned runs through `resumeSubagentRun`.
- Use that wrapper for every non-run-manager completion path: pending lifecycle error, pending lifecycle timeout, lifecycle killed, lifecycle blocked, lifecycle ok, sweeper session-completion recovery, sweeper lost-context recovery, and explicit interrupted-run finalization.
- Keep recovery on the existing resume/orphan/announce-cleanup seam instead of adding a parallel orphan source.
- Drop unrelated generated UI i18n baseline churn.

## Verification

- **Behavior addressed**: failed subagent lifecycle completions no longer leave ended runs stuck before cleanup/final delivery; killed, blocked, ok, timeout, sweeper, and explicit failed-mark paths share the same recovery wrapper
- **Real environment tested**: macOS arm64 local test runner; Blacksmith Testbox remote changed check
- **Exact steps or command run after this patch**:
  ```
  node scripts/run-vitest.mjs src/agents/subagent-registry.test.ts src/agents/subagent-registry.lifecycle-retry-grace.e2e.test.ts
  pnpm changed:lanes --json
  pnpm check:changed
  .agents/skills/autoreview/scripts/autoreview --mode local
  ```
- **Evidence after fix**:
  ```
  Test Files  2 passed (2)
       Tests  68 passed (68)
  ```
  `pnpm check:changed` passed via Blacksmith Testbox `tbx_01ksksytyrfxscxs78e8f3eegk`.
  Autoreview reported: `autoreview clean: no accepted/actionable findings reported`.
- **Observed result after fix**: the regression test forces two real `completeSubagentRun` pre-cleanup rejections on the lifecycle killed path and verifies the run still reaches `cleanupCompletedAt`; timeout-grace tests verify aborted lifecycle end events become timeout completions and are canceled by later successful end events
- **What was not tested**: live gateway multi-agent session with a real hook/runtime failure; covered here by focused fault injection plus the remote changed gate
