### PR TITLE
fix(plugins): refresh discovery during contract retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 
 - Mac app: keep local packaging signed with a stable app identity for permission testing and fix Control UI production builds under current Vite/Highlight.js exports.
 - macOS app: update the embedded Peekaboo bridge to 3.2.1 so OpenClaw-hosted UI automation works with current Peekaboo CLI capture flows.
+- Plugins: refresh discovery between scoped contract runtime retries so newly installed plugins can be found after a transient stale snapshot.
 - Cron: deliver preferred final assistant output for successful scheduled runs when trailing plain tool warnings remain in diagnostics instead of marking the run failed.
 - fix(mattermost): fail closed on missing channel type [AI]. (#84091) Thanks @pgondhi987.
 - Recheck rebuilt system.run argv [AI]. (#84090) Thanks @pgondhi987.

--- a/src/plugins/contracts/registry.retry.test.ts
+++ b/src/plugins/contracts/registry.retry.test.ts
@@ -97,6 +97,77 @@ describe("plugin contract registry scoped retries", () => {
     expect(loadBundledCapabilityRuntimeRegistry).toHaveBeenCalledTimes(2);
   });
 
+  it("refreshes plugin discovery between scoped provider runtime retries", async () => {
+    const staleDiscovery = { candidates: [], diagnostics: [], marker: "before-install" };
+    const freshDiscovery = { candidates: [], diagnostics: [], marker: "after-install" };
+    const discoverOpenClawPlugins = vi
+      .fn()
+      .mockReturnValueOnce(staleDiscovery)
+      .mockReturnValueOnce(freshDiscovery);
+    const loadBundledCapabilityRuntimeRegistry = vi.fn(
+      (params: { discovery?: { marker?: string } }) =>
+        params.discovery === freshDiscovery
+          ? createMockRuntimeRegistry({
+              plugin: {
+                id: "arcee",
+                status: "loaded",
+                providerIds: ["arcee"],
+                webFetchProviderIds: [],
+                webSearchProviderIds: [],
+                migrationProviderIds: [],
+              },
+              providers: [
+                {
+                  pluginId: "arcee",
+                  provider: {
+                    id: "arcee",
+                    label: "Arcee",
+                    docsPath: "/providers/arcee",
+                    auth: [],
+                  } as ProviderPlugin,
+                },
+              ],
+            })
+          : createMockRuntimeRegistry({
+              plugin: {
+                id: "arcee",
+                status: "error",
+                error: "transient discovery miss",
+                providerIds: [],
+                webFetchProviderIds: [],
+                webSearchProviderIds: [],
+                migrationProviderIds: [],
+              },
+              diagnostics: [{ pluginId: "arcee", message: "transient discovery miss" }],
+            }),
+    );
+
+    vi.doMock("../discovery.js", () => ({
+      discoverOpenClawPlugins,
+    }));
+    vi.doMock("../bundled-capability-runtime.js", () => ({
+      loadBundledCapabilityRuntimeRegistry,
+    }));
+    vi.doMock("../provider-contract-public-artifacts.js", () => ({
+      resolveBundledExplicitProviderContractsFromPublicArtifacts: () => null,
+    }));
+
+    const { resolveProviderContractProvidersForPluginIds } = await import("./registry.js");
+
+    expect(
+      resolveProviderContractProvidersForPluginIds(["arcee"]).map((provider) => provider.id),
+    ).toEqual(["arcee"]);
+    expect(discoverOpenClawPlugins).toHaveBeenCalledTimes(2);
+    expect(loadBundledCapabilityRuntimeRegistry).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ discovery: staleDiscovery }),
+    );
+    expect(loadBundledCapabilityRuntimeRegistry).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ discovery: freshDiscovery }),
+    );
+  });
+
   it("retries web search provider loads after a transient plugin-scoped runtime error", async () => {
     const loadBundledCapabilityRuntimeRegistry = vi
       .fn()

--- a/src/plugins/contracts/registry.ts
+++ b/src/plugins/contracts/registry.ts
@@ -256,10 +256,10 @@ function loadScopedCapabilityRuntimeRegistryEntries<T>(params: {
     plugin: BundledCapabilityRuntimeRegistry["plugins"][number],
   ) => readonly string[];
 }): T[] {
-  const discovery = discoverOpenClawPlugins({});
   let lastFailure: Error | undefined;
 
   for (let attempt = 0; attempt < 2; attempt += 1) {
+    const discovery = discoverOpenClawPlugins({});
     const registry = loadBundledCapabilityRuntimeRegistry({
       pluginIds: [params.pluginId],
       pluginSdkResolution: "dist",


### PR DESCRIPTION
Summary
- Refresh plugin discovery inside scoped contract runtime retries instead of reusing the first snapshot across retry attempts.
- Add a regression test that reproduces a transient stale discovery miss and proves the retry sees the fresh snapshot.
- Add a changelog entry for the plugin install/contract retry fix.

Verification
- node node_modules/vitest/vitest.mjs --config test/vitest/vitest.contracts-plugin.config.ts src/plugins/contracts/registry.retry.test.ts
- node node_modules/vitest/vitest.mjs --config test/vitest/vitest.unit-fast.config.ts src/dockerfile.test.ts
- git diff --check
- C:\src\claws-hapi\.agents\skills\autoreview\scripts\autoreview --mode local
- GitHub Actions run 26170233644, targeted Docker E2E lane plugins-offline: passed

Behavior addressed: Scoped plugin contract runtime retries now refresh plugin discovery between attempts, so a plugin installed or made visible after the first stale snapshot can be found by the retry.
Real environment tested: Windows local focused Vitest in a clean OpenClaw main checkout; GitHub Actions reusable Docker E2E workflow using the functional Docker E2E image.
Exact steps or command run after this patch: Ran the focused registry retry test, Dockerfile unit-fast test, git diff whitespace check, autoreview helper, and remote Docker E2E plugins-offline lane on c8a953af9371f0c1e5980283abf554f89f641fea.
Evidence after fix: The new registry retry test fails on unpatched main with expected [] to deeply equal ["arcee"], then passes with this patch; GitHub Actions run https://github.com/openclaw/openclaw/actions/runs/26170233644 passed.
Observed result after fix: src/plugins/contracts/registry.retry.test.ts passed 7/7, src/dockerfile.test.ts passed 18/18, and Docker E2E targeted lane plugins-offline passed.
What was not tested: Full release workflow docker-release.yml was not dispatched because it is environment-gated and pushes release images.

Refs #75451.