### PR TITLE
fix(channels): use pinned registry for outbound adapter resolution when channel is pinned

### DIFF
--- a/src/channels/plugins/registry-loader.ts
+++ b/src/channels/plugins/registry-loader.ts
@@ -1,5 +1,5 @@
 import type { PluginChannelRegistration } from "../../plugins/registry-types.js";
-import { getActivePluginChannelRegistry, getActivePluginRegistry } from "../../plugins/runtime.js";
+import { getActivePluginChannelRegistry } from "../../plugins/runtime.js";
 import type { ChannelId } from "./channel-id.types.js";
 
 type ChannelRegistryValueResolver<TValue> = (
@@ -10,24 +10,11 @@ export function createChannelRegistryLoader<TValue>(
   resolveValue: ChannelRegistryValueResolver<TValue>,
 ): (id: ChannelId) => Promise<TValue | undefined> {
   return async (id: ChannelId): Promise<TValue | undefined> => {
-    const resolveFromRegistry = (
-      registry: ReturnType<typeof getActivePluginRegistry>,
-    ): TValue | undefined => {
-      const pluginEntry = registry?.channels.find((entry) => entry.plugin.id === id);
-      return pluginEntry ? resolveValue(pluginEntry) : undefined;
-    };
-
-    const channelRegistry = getActivePluginChannelRegistry();
-    const channelValue = resolveFromRegistry(channelRegistry);
-    if (channelValue !== undefined) {
-      return channelValue;
+    const registry = getActivePluginChannelRegistry();
+    const pluginEntry = registry?.channels.find((entry) => entry.plugin.id === id);
+    if (!pluginEntry) {
+      return undefined;
     }
-
-    const activeRegistry = getActivePluginRegistry();
-    if (activeRegistry && activeRegistry !== channelRegistry) {
-      return resolveFromRegistry(activeRegistry);
-    }
-
-    return undefined;
+    return resolveValue(pluginEntry);
   };
 }

--- a/src/channels/plugins/registry-loader.ts
+++ b/src/channels/plugins/registry-loader.ts
@@ -1,5 +1,5 @@
 import type { PluginChannelRegistration } from "../../plugins/registry-types.js";
-import { getActivePluginChannelRegistry } from "../../plugins/runtime.js";
+import { getActivePluginChannelRegistry, getActivePluginRegistry } from "../../plugins/runtime.js";
 import type { ChannelId } from "./channel-id.types.js";
 
 type ChannelRegistryValueResolver<TValue> = (
@@ -10,11 +10,25 @@ export function createChannelRegistryLoader<TValue>(
   resolveValue: ChannelRegistryValueResolver<TValue>,
 ): (id: ChannelId) => Promise<TValue | undefined> {
   return async (id: ChannelId): Promise<TValue | undefined> => {
-    const registry = getActivePluginChannelRegistry();
-    const pluginEntry = registry?.channels.find((entry) => entry.plugin.id === id);
-    if (!pluginEntry) {
+    const channelRegistry = getActivePluginChannelRegistry();
+    const pinnedEntry = channelRegistry?.channels.find((entry) => entry.plugin.id === id);
+    if (pinnedEntry) {
+      return resolveValue(pinnedEntry);
+    }
+
+    // Pinned registry does not contain this channel. Check the active
+    // registry for dynamically registered channels (e.g. discordVoice,
+    // which is registered at runtime after a voice connection is
+    // established). Do NOT use the active registry when the channel
+    // already exists in the pinned registry — the active registry is
+    // unstable (replaced on every loadOpenClawPlugins call) and may
+    // lack the outbound adapter, causing "Outbound not configured"
+    // errors. See #84568.
+    const activeRegistry = getActivePluginRegistry();
+    if (!activeRegistry || activeRegistry === channelRegistry) {
       return undefined;
     }
-    return resolveValue(pluginEntry);
+    const activeEntry = activeRegistry.channels.find((entry) => entry.plugin.id === id);
+    return activeEntry ? resolveValue(activeEntry) : undefined;
   };
 }

--- a/src/plugins/runtime.channel-pin.test.ts
+++ b/src/plugins/runtime.channel-pin.test.ts
@@ -229,8 +229,13 @@ describe("channel registry pinning", () => {
     expect(adapter).toBe(outboundAdapter);
   });
 
-  it("loadChannelOutboundAdapter falls back to active registry when pinned setup entry cannot send", async () => {
-    const outboundAdapter = { sendText: async () => ({ messageId: "1" }) };
+  it("loadChannelOutboundAdapter does not fall back to active registry when pinned entry has no outbound", async () => {
+    // Regression test for #84568: the unstable active registry was used as a
+    // fallback for outbound resolution. After a post-boot registry replacement
+    // (config-schema load, plugin status query, cron job, health-monitor, etc.)
+    // the active registry may no longer contain the outbound adapter, causing
+    // "Outbound not configured for channel: discord". The pinned registry is
+    // the only safe source for outbound adapter resolution.
     const startup = createEmptyPluginRegistry();
     startup.channels = [
       {
@@ -243,7 +248,11 @@ describe("channel registry pinning", () => {
     replacement.channels = [
       {
         pluginId: "discord",
-        plugin: { id: "discord", meta: {}, outbound: outboundAdapter },
+        plugin: {
+          id: "discord",
+          meta: {},
+          outbound: { sendText: async () => ({ messageId: "1" }) },
+        },
         source: "runtime",
       },
     ] as never;
@@ -252,8 +261,10 @@ describe("channel registry pinning", () => {
     pinActivePluginChannelRegistry(startup);
     setActivePluginRegistry(replacement);
 
+    // Must NOT fall back to the unstable active registry.
+    // The pinned registry entry has no outbound → return undefined.
     const adapter = await loadChannelOutboundAdapter("discord");
-    expect(adapter).toBe(outboundAdapter);
+    expect(adapter).toBeUndefined();
   });
 
   it("keeps pinned channel registry agent-event subscriptions live after active registry replacement", () => {

--- a/src/plugins/runtime.channel-pin.test.ts
+++ b/src/plugins/runtime.channel-pin.test.ts
@@ -229,13 +229,11 @@ describe("channel registry pinning", () => {
     expect(adapter).toBe(outboundAdapter);
   });
 
-  it("loadChannelOutboundAdapter does not fall back to active registry when pinned entry has no outbound", async () => {
-    // Regression test for #84568: the unstable active registry was used as a
-    // fallback for outbound resolution. After a post-boot registry replacement
-    // (config-schema load, plugin status query, cron job, health-monitor, etc.)
-    // the active registry may no longer contain the outbound adapter, causing
-    // "Outbound not configured for channel: discord". The pinned registry is
-    // the only safe source for outbound adapter resolution.
+  it("loadChannelOutboundAdapter does not fall back to active registry when pinned entry exists", async () => {
+    // Regression test for #84568: when the pinned registry has an entry for a
+    // channel (even without an outbound adapter), the active registry must NOT
+    // be consulted. The active registry is unstable and may lack the outbound
+    // adapter after a post-boot registry replacement.
     const startup = createEmptyPluginRegistry();
     startup.channels = [
       {
@@ -261,10 +259,33 @@ describe("channel registry pinning", () => {
     pinActivePluginChannelRegistry(startup);
     setActivePluginRegistry(replacement);
 
-    // Must NOT fall back to the unstable active registry.
-    // The pinned registry entry has no outbound → return undefined.
+    // Pinned has discord (without outbound) → must NOT fall back to active.
     const adapter = await loadChannelOutboundAdapter("discord");
     expect(adapter).toBeUndefined();
+  });
+
+  it("loadChannelOutboundAdapter resolves dynamically registered channels from active registry", async () => {
+    // Channels registered after startup (e.g. discordVoice, registered when a
+    // voice connection is established) do not exist in the pinned registry.
+    // They should be resolved from the active registry.
+    const outboundAdapter = { send: async () => ({ messageId: "1" }) };
+    const startup = createEmptyPluginRegistry();
+    const replacement = createEmptyPluginRegistry();
+    replacement.channels = [
+      {
+        pluginId: "discordVoice",
+        plugin: { id: "discordVoice", meta: {}, outbound: outboundAdapter },
+        source: "runtime",
+      },
+    ] as never;
+
+    setActivePluginRegistry(startup);
+    pinActivePluginChannelRegistry(startup);
+    setActivePluginRegistry(replacement);
+
+    // Pinned has no discordVoice → falls through to active → found.
+    const adapter = await loadChannelOutboundAdapter("discordVoice");
+    expect(adapter).toBe(outboundAdapter);
   });
 
   it("keeps pinned channel registry agent-event subscriptions live after active registry replacement", () => {


### PR DESCRIPTION
## Summary

Fixes #84568

`registry-loader.ts` fell back from the pinned channel registry to `getActivePluginRegistry()` when resolving outbound adapters. The active registry is **unstable** — it gets replaced every time `loadOpenClawPlugins()` runs (config-schema reads, plugin status queries, tool-list loads, cron jobs, health-monitor checks, etc.). After such a replacement the new registry may no longer contain the channel's outbound adapter, causing:

```
Outbound not configured for channel: discord
```

This is a regression introduced by `d7896ed4c9` (`ci: retry release artifact downloads`), which re-introduced the fallback that was previously removed in `bc9c074b2c`. The bug is present in both `2026.5.19-beta.2` and the stable `2026.5.19` release.

## Changes

**`src/channels/plugins/registry-loader.ts`**: Refine the fallback logic:
- If the **pinned registry** has an entry for the requested channel → use **only** the pinned registry. This prevents `#84568` where the unstable active registry lost the outbound adapter after a post-boot registry replacement.
- If the pinned registry has **no entry** for the channel → consult the active registry. This allows dynamically registered channels (e.g. `discordVoice`, registered at runtime when a voice connection is established) to be resolved.

**`src/plugins/runtime.channel-pin.test.ts`**: Replace the old fallback assertion with two tests:
1. Pinned entry exists (even without outbound) → must NOT fall back to active (#84568 regression)
2. Pinned has no entry → falls through to active for dynamic channels

## Local verification

Patched the installed `2026.5.19` stable release (`load-yRKrJeVQ.js`) with this exact change. All five Discord bots receive and reply to messages without `Outbound not configured` errors, and the `github-issue-patrol` cron job delivers to `discordVoice` successfully.

## Tests

```
✓ src/plugins/runtime.channel-pin.test.ts (15/15 passed)
✓ src/channels/plugins/contracts/plugins-core.loader.contract.test.ts (5/5 passed)
✓ src/plugins/loader.test.ts (passed)
✓ src/cli/send-runtime/channel-outbound-send.test.ts (8/8 passed)
✓ pnpm build (success)
```