### PR TITLE
fix(doctor): migrate invalid thinking formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 
 - Dependencies: update `@openclaw/fs-safe` to `0.2.7` so OpenClaw's default Python-helper-off policy keeps best-effort Node write fallbacks for private stores, secret writes, run logs, and media attachments on Linux/macOS.
 - Browser: honor the configured image sanitization limit for screenshots and labeled snapshots so browser-captured images follow the same resize policy as other image results. (#84595)
+- Doctor: remove unrecognized `models.providers.*.models[*].compat.thinkingFormat` values during `doctor --fix` so stale provider model config can validate after upgrade. Fixes #77803.
 - Status: show the configured default, session-selected model, reason, clear hint, and docs link when a session remains pinned to a model that differs from `agents.defaults.model.primary`.
 - Mac app: keep local packaging signed with a stable app identity for permission testing and fix Control UI production builds under current Vite/Highlight.js exports.
 - macOS app: update the embedded Peekaboo bridge to 3.2.1 so OpenClaw-hosted UI automation works with current Peekaboo CLI capture flows.

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -1136,3 +1136,98 @@ describe("legacy migrate controlUi.allowedOrigins seed (issue #29385)", () => {
     expect(res.changes).toStrictEqual(['Normalized gateway.bind "localhost" → "loopback".']);
   });
 });
+
+describe("legacy model compat migrate", () => {
+  it("removes unrecognized model compat thinkingFormat values", () => {
+    const res = migrateLegacyConfigForTest({
+      models: {
+        providers: {
+          bailian: {
+            models: [
+              {
+                id: "qwen-legacy",
+                name: "Qwen Legacy",
+                compat: {
+                  thinkingFormat: "bailian-legacy",
+                  supportsTools: true,
+                },
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    expect(res.config?.models?.providers?.bailian?.models?.[0]?.compat).toEqual({
+      supportsTools: true,
+    });
+    expect(res.changes).toStrictEqual([
+      'Removed models.providers.bailian.models.0.compat.thinkingFormat (unrecognized value "bailian-legacy"; runtime default applies).',
+    ]);
+  });
+
+  it("preserves recognized model compat thinkingFormat values", () => {
+    const res = migrateLegacyConfigForTest({
+      models: {
+        providers: {
+          bailian: {
+            models: [
+              {
+                id: "qwen3",
+                name: "Qwen3",
+                compat: {
+                  thinkingFormat: "qwen",
+                },
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    expect(res.config).toBeNull();
+    expect(res.changes).toStrictEqual([]);
+  });
+
+  it("selectively removes invalid thinkingFormat values across providers", () => {
+    const res = migrateLegacyConfigForTest({
+      models: {
+        providers: {
+          bailian: {
+            models: [
+              {
+                id: "valid",
+                name: "Valid",
+                compat: { thinkingFormat: "qwen-chat-template" },
+              },
+              {
+                id: "legacy",
+                name: "Legacy",
+                compat: { thinkingFormat: "old-bailian" },
+              },
+            ],
+          },
+          openrouter: {
+            models: [
+              {
+                id: "legacy-router",
+                name: "Legacy Router",
+                compat: { thinkingFormat: "openrouter-v0" },
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    expect(res.config?.models?.providers?.bailian?.models?.[0]?.compat).toEqual({
+      thinkingFormat: "qwen-chat-template",
+    });
+    expect(res.config?.models?.providers?.bailian?.models?.[1]?.compat).toEqual({});
+    expect(res.config?.models?.providers?.openrouter?.models?.[0]?.compat).toEqual({});
+    expect(res.changes).toStrictEqual([
+      'Removed models.providers.bailian.models.1.compat.thinkingFormat (unrecognized value "old-bailian"; runtime default applies).',
+      'Removed models.providers.openrouter.models.0.compat.thinkingFormat (unrecognized value "openrouter-v0"; runtime default applies).',
+    ]);
+  });
+});

--- a/src/commands/doctor/shared/legacy-config-migrate.validation.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.validation.test.ts
@@ -5,6 +5,7 @@ describe("legacy config migrate validation", () => {
   let groupChatRoutingResult: ReturnType<typeof migrateLegacyConfig>;
   let partialValidationResult: ReturnType<typeof migrateLegacyConfig>;
   let agentModelTimeoutResult: ReturnType<typeof migrateLegacyConfig>;
+  let modelThinkingFormatResult: ReturnType<typeof migrateLegacyConfig>;
 
   beforeAll(() => {
     groupChatRoutingResult = migrateLegacyConfig({
@@ -59,6 +60,33 @@ describe("legacy config migrate validation", () => {
             },
           },
         ],
+      },
+    });
+    modelThinkingFormatResult = migrateLegacyConfig({
+      models: {
+        providers: {
+          bailian: {
+            baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+            api: "openai-completions",
+            models: [
+              {
+                id: "qwen-legacy",
+                name: "Qwen Legacy",
+                compat: {
+                  thinkingFormat: "bailian-legacy",
+                  supportsTools: true,
+                },
+              },
+              {
+                id: "qwen-valid",
+                name: "Qwen Valid",
+                compat: {
+                  thinkingFormat: "qwen",
+                },
+              },
+            ],
+          },
+        },
       },
     });
   });
@@ -123,6 +151,21 @@ describe("legacy config migrate validation", () => {
     expect(res.config?.agents?.list?.[0]?.model).toEqual({ primary: "openai/gpt-5.4" });
     expect(res.config?.agents?.list?.[0]?.subagents?.model).toEqual({
       primary: "openai/gpt-5.4-mini",
+    });
+  });
+
+  it("returns valid config after removing invalid model compat thinkingFormat", () => {
+    const res = modelThinkingFormatResult;
+
+    expect(res.partiallyValid).toBeUndefined();
+    expect(res.changes).toStrictEqual([
+      'Removed models.providers.bailian.models.0.compat.thinkingFormat (unrecognized value "bailian-legacy"; runtime default applies).',
+    ]);
+    expect(res.config?.models?.providers?.bailian?.models?.[0]?.compat).toEqual({
+      supportsTools: true,
+    });
+    expect(res.config?.models?.providers?.bailian?.models?.[1]?.compat).toEqual({
+      thinkingFormat: "qwen",
     });
   });
 });

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
@@ -1,0 +1,75 @@
+import {
+  defineLegacyConfigMigration,
+  getRecord,
+  type LegacyConfigMigrationSpec,
+  type LegacyConfigRule,
+} from "../../../config/legacy.shared.js";
+import { isModelThinkingFormat } from "../../../config/types.models.js";
+
+function hasInvalidThinkingFormat(providers: unknown): boolean {
+  const providersRecord = getRecord(providers);
+  if (!providersRecord) {
+    return false;
+  }
+
+  for (const provider of Object.values(providersRecord)) {
+    const models = getRecord(provider)?.models;
+    if (!Array.isArray(models)) {
+      continue;
+    }
+
+    for (const model of models) {
+      const compat = getRecord(getRecord(model)?.compat);
+      const thinkingFormat = compat?.thinkingFormat;
+      if (typeof thinkingFormat === "string" && !isModelThinkingFormat(thinkingFormat)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+const INVALID_THINKING_FORMAT_RULE: LegacyConfigRule = {
+  path: ["models", "providers"],
+  message:
+    'models.providers.<id>.models[*].compat.thinkingFormat has an unrecognized value; run "openclaw doctor --fix" to remove it and restore the runtime default.',
+  match: (value) => hasInvalidThinkingFormat(value),
+};
+
+export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_MODELS: LegacyConfigMigrationSpec[] = [
+  defineLegacyConfigMigration({
+    id: "models.providers.*.models.*.compat.thinkingFormat-invalid",
+    describe: "Remove unrecognized compat.thinkingFormat values from provider model entries",
+    legacyRules: [INVALID_THINKING_FORMAT_RULE],
+    apply: (raw, changes) => {
+      const providers = getRecord(getRecord(raw.models)?.providers);
+      if (!providers) {
+        return;
+      }
+
+      for (const [providerId, provider] of Object.entries(providers)) {
+        const models = getRecord(provider)?.models;
+        if (!Array.isArray(models)) {
+          continue;
+        }
+
+        for (const [index, model] of models.entries()) {
+          const compat = getRecord(getRecord(model)?.compat);
+          if (!compat) {
+            continue;
+          }
+          const thinkingFormat = compat.thinkingFormat;
+          if (typeof thinkingFormat !== "string" || isModelThinkingFormat(thinkingFormat)) {
+            continue;
+          }
+
+          delete compat.thinkingFormat;
+          changes.push(
+            `Removed models.providers.${providerId}.models.${index}.compat.thinkingFormat (unrecognized value ${JSON.stringify(thinkingFormat)}; runtime default applies).`,
+          );
+        }
+      }
+    },
+  }),
+];

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.ts
@@ -3,6 +3,7 @@ import { LEGACY_CONFIG_MIGRATIONS_RUNTIME_AGENTS } from "./legacy-config-migrati
 import { LEGACY_CONFIG_MIGRATIONS_RUNTIME_DIAGNOSTICS } from "./legacy-config-migrations.runtime.diagnostics.js";
 import { LEGACY_CONFIG_MIGRATIONS_RUNTIME_GATEWAY } from "./legacy-config-migrations.runtime.gateway.js";
 import { LEGACY_CONFIG_MIGRATIONS_RUNTIME_MCP } from "./legacy-config-migrations.runtime.mcp.js";
+import { LEGACY_CONFIG_MIGRATIONS_RUNTIME_MODELS } from "./legacy-config-migrations.runtime.models.js";
 import { LEGACY_CONFIG_MIGRATIONS_RUNTIME_PROVIDERS } from "./legacy-config-migrations.runtime.providers.js";
 import { LEGACY_CONFIG_MIGRATIONS_RUNTIME_SESSION } from "./legacy-config-migrations.runtime.session.js";
 import { LEGACY_CONFIG_MIGRATIONS_RUNTIME_TTS } from "./legacy-config-migrations.runtime.tts.js";
@@ -12,6 +13,7 @@ export const LEGACY_CONFIG_MIGRATIONS_RUNTIME: LegacyConfigMigrationSpec[] = [
   ...LEGACY_CONFIG_MIGRATIONS_RUNTIME_DIAGNOSTICS,
   ...LEGACY_CONFIG_MIGRATIONS_RUNTIME_GATEWAY,
   ...LEGACY_CONFIG_MIGRATIONS_RUNTIME_MCP,
+  ...LEGACY_CONFIG_MIGRATIONS_RUNTIME_MODELS,
   ...LEGACY_CONFIG_MIGRATIONS_RUNTIME_PROVIDERS,
   ...LEGACY_CONFIG_MIGRATIONS_RUNTIME_SESSION,
   ...LEGACY_CONFIG_MIGRATIONS_RUNTIME_TTS,

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -50,11 +50,25 @@ type SupportedAnthropicMessagesCompatFields = Pick<
   "supportsEagerToolInputStreaming" | "supportsLongCacheRetention"
 >;
 
-type SupportedThinkingFormat =
+export type SupportedThinkingFormat =
   | NonNullable<OpenAICompletionsCompat["thinkingFormat"]>
   | "deepseek"
   | "openrouter"
   | "together";
+
+export const MODEL_THINKING_FORMATS = [
+  "openai",
+  "openrouter",
+  "deepseek",
+  "together",
+  "qwen",
+  "qwen-chat-template",
+  "zai",
+] as const satisfies readonly SupportedThinkingFormat[];
+
+export function isModelThinkingFormat(value: string): value is SupportedThinkingFormat {
+  return (MODEL_THINKING_FORMATS as readonly string[]).includes(value);
+}
 
 export type ModelCompatConfig = SupportedOpenAICompatFields &
   SupportedOpenAIResponsesCompatFields &

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -9,7 +9,7 @@ import {
 } from "../secrets/ref-contract.js";
 import { normalizeStringEntries } from "../shared/string-normalization.js";
 import type { ModelCompatConfig } from "./types.models.js";
-import { MODEL_APIS } from "./types.models.js";
+import { MODEL_APIS, MODEL_THINKING_FORMATS } from "./types.models.js";
 import type { MediaToolsConfig } from "./types.tools.js";
 import { createAllowDenyChannelRulesSchema } from "./zod-schema.allowdeny.js";
 import { sensitive } from "./zod-schema.sensitive.js";
@@ -202,17 +202,7 @@ const ModelCompatSchema = z
     maxTokensField: z
       .union([z.literal("max_completion_tokens"), z.literal("max_tokens")])
       .optional(),
-    thinkingFormat: z
-      .union([
-        z.literal("openai"),
-        z.literal("openrouter"),
-        z.literal("deepseek"),
-        z.literal("together"),
-        z.literal("qwen"),
-        z.literal("qwen-chat-template"),
-        z.literal("zai"),
-      ])
-      .optional(),
+    thinkingFormat: z.enum(MODEL_THINKING_FORMATS).optional(),
     requiresToolResultName: z.boolean().optional(),
     requiresAssistantAfterToolResult: z.boolean().optional(),
     requiresThinkingAsText: z.boolean().optional(),

--- a/src/model-catalog/normalize.ts
+++ b/src/model-catalog/normalize.ts
@@ -1,4 +1,9 @@
-import { MODEL_APIS, type ModelApi, type ModelCompatConfig } from "../config/types.models.js";
+import {
+  MODEL_APIS,
+  isModelThinkingFormat,
+  type ModelApi,
+  type ModelCompatConfig,
+} from "../config/types.models.js";
 import { isBlockedObjectKey } from "../infra/prototype-keys.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { normalizeTrimmedStringList } from "../shared/string-normalization.js";
@@ -220,15 +225,7 @@ function normalizeModelCatalogCompat(value: unknown): ModelCompatConfig | undefi
   }
 
   const thinkingFormat = normalizeOptionalString(value.thinkingFormat) ?? "";
-  if (
-    thinkingFormat === "openai" ||
-    thinkingFormat === "openrouter" ||
-    thinkingFormat === "deepseek" ||
-    thinkingFormat === "together" ||
-    thinkingFormat === "qwen" ||
-    thinkingFormat === "qwen-chat-template" ||
-    thinkingFormat === "zai"
-  ) {
+  if (isModelThinkingFormat(thinkingFormat)) {
     compat.thinkingFormat = thinkingFormat;
   }
 


### PR DESCRIPTION
## Summary

Fixes #77803.

`openclaw doctor --fix` now removes unrecognized `models.providers.*.models[*].compat.thinkingFormat` values from provider model entries so stale model config can validate after upgrade. The migration is provider-generic: it was reported with Bailian config, but the stored config shape is shared by all configured model providers.

This also centralizes the supported `thinkingFormat` literals in `src/config/types.models.ts` and reuses that contract from:

- config schema validation
- model catalog normalization
- doctor legacy migration detection and repair

## Behavior addressed

`doctor --fix` previously detected the invalid config but had no migration for stale `compat.thinkingFormat` values, so writeback could still fail validation. After this patch, only unrecognized optional `compat.thinkingFormat` values are deleted and the rest of `compat` is preserved.

## Real environment tested

Local WSL source checkout, Node 24, with a temporary `OPENCLAW_CONFIG_PATH` and `OPENCLAW_STATE_DIR`.

## Exact steps or command run after this patch

```bash
tmp=$(mktemp -d /tmp/openclaw-77803-proof.XXXXXX)
cat > "$tmp/openclaw.json" <<'JSON'
{
  "models": {
    "providers": {
      "bailian": {
        "baseUrl": "https://dashscope.aliyuncs.com/compatible-mode/v1",
        "api": "openai-completions",
        "models": [
          {
            "id": "qwen-legacy",
            "name": "Qwen Legacy",
            "compat": {
              "thinkingFormat": "bailian-legacy",
              "supportsTools": true
            }
          },
          {
            "id": "qwen-valid",
            "name": "Qwen Valid",
            "compat": {
              "thinkingFormat": "qwen"
            }
          }
        ]
      }
    }
  }
}
JSON
OPENCLAW_CONFIG_PATH="$tmp/openclaw.json" OPENCLAW_STATE_DIR="$tmp/state" pnpm openclaw doctor --fix
cat "$tmp/openclaw.json"
```

## Evidence after fix

`openclaw doctor --fix` printed:

```text
Legacy config keys detected
- models.providers:
  models.providers.<id>.models[*].compat.thinkingFormat has an unrecognized value; run "openclaw doctor --fix" to remove it and restore the runtime default.

Doctor changes
Removed models.providers.bailian.models.0.compat.thinkingFormat (unrecognized value "bailian-legacy"; runtime default applies).

Updated config: /tmp/openclaw-77803-proof.ozhQe7/openclaw.json
Doctor complete.
```

The repaired config preserved `supportsTools: true`, removed only the invalid `"bailian-legacy"` value, and preserved the valid `"qwen"` value:

```json
{
  "id": "qwen-legacy",
  "name": "Qwen Legacy",
  "compat": {
    "supportsTools": true
  }
}
```

```json
{
  "id": "qwen-valid",
  "name": "Qwen Valid",
  "compat": {
    "thinkingFormat": "qwen"
  }
}
```

## Observed result after fix

The real `doctor --fix` CLI path completed successfully and wrote the migrated config. The invalid `compat.thinkingFormat` no longer blocks validation/writeback, while valid values remain intact.

## What was not tested

I did not reproduce on the reporter's Windows 10 host or with their exact private config, because the issue did not include the literal old Bailian value. The test and CLI proof exercise the same persisted config path with a representative invalid literal.

## Verification

```bash
pnpm install --frozen-lockfile
pnpm exec oxfmt --write --threads=1 src/config/types.models.ts src/config/zod-schema.core.ts src/model-catalog/normalize.ts src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts src/commands/doctor/shared/legacy-config-migrations.runtime.ts src/commands/doctor/shared/legacy-config-migrate.test.ts src/commands/doctor/shared/legacy-config-migrate.validation.test.ts CHANGELOG.md
node scripts/run-vitest.mjs src/commands/doctor/shared/legacy-config-migrate.test.ts src/commands/doctor/shared/legacy-config-migrate.validation.test.ts src/config/config-misc.test.ts src/model-catalog/normalize.test.ts --reporter=dot
node scripts/run-vitest.mjs src/commands/doctor/shared/legacy-config-migrate.test.ts src/commands/doctor/shared/legacy-config-migrate.validation.test.ts --reporter=dot
git diff --check
/mnt/c/src/claws-hapi/.agents/skills/autoreview/scripts/autoreview --mode local
```

Results:

- Focused Vitest: 4 files passed, 140 tests passed.
- Focused migration Vitest rerun: 2 files passed, 56 tests passed.
- Real CLI `doctor --fix` proof passed and wrote the repaired config.
- `git diff --check` passed.
- Autoreview initially found a real type-narrowing issue in model catalog normalization; fixed with a shared `isModelThinkingFormat` type guard. Rerun was clean: no accepted/actionable findings.

Additional typecheck note:

```bash
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.src.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-src-doctor-thinking-format-77803.tsbuildinfo
```

This currently fails on `origin/main`-adjacent status test data, unrelated to this patch:

```text
src/commands/status.summary.redaction.test.ts(70,18): missing configuredModel, selectedModel, modelSelectionReason
src/commands/status.summary.redaction.test.ts(76,22): missing configuredModel, selectedModel, modelSelectionReason
```
