### PR TITLE
fix(telegram): suppress accounts.default warning when defaultAccount is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Docs: https://docs.openclaw.ai
 - Discord: preserve disabled presentation buttons when adapting and rendering Discord message controls. (#84188) Thanks @100menotu001.
 - Twitch: add a test-only client-manager registry reset helper so non-isolated Twitch tests can clear cached managers between cases. Fixes #83887. (#84244) Thanks @hclsys.
 - Cron: run main-session scheduled work on a cron-owned wake lane while preserving reply delivery context, so background cron turns no longer block human main-session chat. Fixes #82766. (#82767) Thanks @galiniliev.
+- Channels/Telegram: suppress the `accounts.default is missing` warning when `channels.telegram.defaultAccount` is configured, so multi-account setups with an alphabetically-first explicit default no longer get false-positive routing nags. Fixes #83948. Thanks @infracore.
 - Cron: use structured embedded-run denial metadata for isolated scheduled tasks so blocked exec requests fail the job without treating ordinary assistant prose as a denial. (#84067) Thanks @abnershang.
 - Cron: keep recovered tool warnings diagnostic for successful scheduled runs so final cron output is delivered instead of being replaced by a post-processing warning. (#84045) Thanks @abnershang.
 - Plugins/perf: thread explicit plugin discovery results through `loadBundledCapabilityRuntimeRegistry`, `resolveBundledPluginSources`, and `listChannelCatalogEntries` so callers that already hold a discovery result skip redundant filesystem walks. Thanks @SebTardif.

--- a/extensions/telegram/src/account-selection.ts
+++ b/extensions/telegram/src/account-selection.ts
@@ -129,15 +129,25 @@ export function resolveDefaultTelegramAccountSelection(cfg: OpenClawConfig): {
     };
   }
   const accountIds = listTelegramAccountIds(cfg);
+  const configuredDefaultAccountId =
+    normalizeOptionalAccountId(cfg.channels?.telegram?.defaultAccount) ?? undefined;
   const resolved = resolveListedDefaultAccountId({
     accountIds,
-    configuredDefaultAccountId:
-      normalizeOptionalAccountId(cfg.channels?.telegram?.defaultAccount) ?? undefined,
+    configuredDefaultAccountId,
   });
   return {
     accountId: resolved,
     accountIds,
+    // Fixes #83948: the previous warning fired any time the resolved account
+    // happened to match `accountIds[0]` (the alphabetical-first fallback),
+    // even when the user had explicitly set `channels.telegram.defaultAccount`
+    // and the configured value just happened to sort first. Suppress the
+    // warning whenever the user has explicitly configured a default account
+    // (the configured value is honored by `resolveListedDefaultAccountId`
+    // above), so we only nag in the true "fell back without explicit
+    // configuration" case.
     shouldWarnMissingDefault:
+      !configuredDefaultAccountId &&
       resolved === accountIds[0] &&
       !accountIds.includes(DEFAULT_ACCOUNT_ID) &&
       accountIds.length > 1,

--- a/extensions/telegram/src/accounts.test.ts
+++ b/extensions/telegram/src/accounts.test.ts
@@ -227,6 +227,30 @@ describe("resolveDefaultTelegramAccountId", () => {
     expectNoMissingDefaultWarning();
   });
 
+  it("does not warn when defaultAccount is set in a multi-account setup (#83948)", () => {
+    // Regression: previously, the warning fired any time the resolved
+    // account happened to equal `accountIds[0]` (alphabetical first),
+    // even when the user had explicitly set `defaultAccount` to that
+    // alphabetically-first value. In the reporter's config below,
+    // `defaultAccount: "charles"` was honored correctly but the warning
+    // still nagged because "charles" sorts before "hermes".
+    const cfg: OpenClawConfig = {
+      channels: {
+        telegram: {
+          defaultAccount: "charles",
+          accounts: {
+            hermes: { botToken: "tok-hermes" },
+            charles: { botToken: "tok-charles" },
+          },
+        },
+      },
+    };
+
+    const result = resolveDefaultTelegramAccountId(cfg);
+    expect(result).toBe("charles");
+    expectNoMissingDefaultWarning();
+  });
+
   it("does not warn when only one non-default account is configured", () => {
     const cfg: OpenClawConfig = {
       channels: {


### PR DESCRIPTION
## Summary

Fixes #83948.

`openclaw status` printed `[telegram] channels.telegram: accounts.default is missing; falling back to "<name>"` on every run when the user had explicitly configured `channels.telegram.defaultAccount`, if the configured value happened to be the alphabetically-first account.

Reporter's config:

```json
{
  "channels": {
    "telegram": {
      "defaultAccount": "charles",
      "accounts": { "hermes": { ... }, "charles": { ... }, ... }
    }
  }
}
```

Routing already worked correctly (the configured `defaultAccount` was honored by `resolveListedDefaultAccountId`), but the warning condition in `resolveDefaultTelegramAccountSelection` compared the resolved account to `accountIds[0]` (the alphabetical-first fallback) without distinguishing between "fell back without configuration" and "configured value happens to sort first."

## Fix

Add `!configuredDefaultAccountId` to the warning condition. The warning now only fires in the true "user did not configure a default and we're guessing from alphabetical order" case.

```diff
+  const configuredDefaultAccountId =
+    normalizeOptionalAccountId(cfg.channels?.telegram?.defaultAccount) ?? undefined;
   const resolved = resolveListedDefaultAccountId({
     accountIds,
-    configuredDefaultAccountId:
-      normalizeOptionalAccountId(cfg.channels?.telegram?.defaultAccount) ?? undefined,
+    configuredDefaultAccountId,
   });
   return {
     accountId: resolved,
     accountIds,
     shouldWarnMissingDefault:
+      !configuredDefaultAccountId &&
       resolved === accountIds[0] &&
       !accountIds.includes(DEFAULT_ACCOUNT_ID) &&
       accountIds.length > 1,
   };
```

## Tests

Adds a regression test mirroring the reporter's exact config (`defaultAccount: "charles"` with `accounts: { hermes, charles }`) — asserts `resolveDefaultTelegramAccountId` returns `"charles"` AND no warning fires. The existing test for `defaultAccount` set with a single account already passed (because `accountIds.length > 1` was false); the new test covers the multi-account case that triggered #83948.

## CHANGELOG

Added entry under `Unreleased > Fixes`.