### PR TITLE
fix(auto-reply): enforce word boundary in slash command prefix match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -240,6 +240,7 @@ Docs: https://docs.openclaw.ai
 - Discord: preserve disabled presentation buttons when adapting and rendering Discord message controls. (#84188) Thanks @100menotu001.
 - Twitch: add a test-only client-manager registry reset helper so non-isolated Twitch tests can clear cached managers between cases. Fixes #83887. (#84244) Thanks @hclsys.
 - Cron: run main-session scheduled work on a cron-owned wake lane while preserving reply delivery context, so background cron turns no longer block human main-session chat. Fixes #82766. (#82767) Thanks @galiniliev.
+- Auto-reply/slash commands: require a word boundary after the matched prefix in `parseSlashCommandActionArgs` so `/config-check <args>` (or any skill that shares a built-in command prefix) is no longer captured by the shorter built-in handler. Fixes #84572. Thanks @infracore.
 - Cron: use structured embedded-run denial metadata for isolated scheduled tasks so blocked exec requests fail the job without treating ordinary assistant prose as a denial. (#84067) Thanks @abnershang.
 - Cron: keep recovered tool warnings diagnostic for successful scheduled runs so final cron output is delivered instead of being replaced by a post-processing warning. (#84045) Thanks @abnershang.
 - Plugins/perf: thread explicit plugin discovery results through `loadBundledCapabilityRuntimeRegistry`, `resolveBundledPluginSources`, and `listChannelCatalogEntries` so callers that already hold a discovery result skip redundant filesystem walks. Thanks @SebTardif.

--- a/src/auto-reply/reply/commands-slash-parse.test.ts
+++ b/src/auto-reply/reply/commands-slash-parse.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { parseSlashCommandOrNull } from "./commands-slash-parse.js";
+
+describe("parseSlashCommandOrNull", () => {
+  const opts = { invalidMessage: "invalid" };
+
+  it("returns null when the input doesn't start with the slash prefix", () => {
+    expect(parseSlashCommandOrNull("hello world", "/config", opts)).toBeNull();
+  });
+
+  it("parses action + args when the input has a clean word boundary", () => {
+    const result = parseSlashCommandOrNull("/config show enabled", "/config", opts);
+    expect(result).toEqual({ ok: true, action: "show", args: "enabled" });
+  });
+
+  it("returns the default action on an empty body", () => {
+    const result = parseSlashCommandOrNull("/config", "/config", { ...opts, defaultAction: "show" });
+    expect(result).toEqual({ ok: true, action: "show", args: "" });
+  });
+
+  describe("regression: #84572 — prefix match must require a word boundary", () => {
+    // Previously, `/config-check <args>` matched the `/config` handler
+    // via a naive `startsWith` and surfaced as an invalid action, blocking
+    // any skill whose name shared a prefix with a built-in command.
+    it("does not match a longer command name with a hyphen tail (`/config-check`)", () => {
+      expect(parseSlashCommandOrNull("/config-check arg1 arg2", "/config", opts)).toBeNull();
+    });
+
+    it("does not match a longer command name with no whitespace after prefix", () => {
+      expect(parseSlashCommandOrNull("/configfoo", "/config", opts)).toBeNull();
+    });
+
+    it("does not match when prefix sits in the middle of a longer word", () => {
+      // /modelsy should not be captured by /models
+      expect(parseSlashCommandOrNull("/modelsy", "/models", opts)).toBeNull();
+    });
+
+    it("still matches when the boundary is a colon (`/config:json`)", () => {
+      // Some clients allow `cmd:subkey` to pass through to the action parser
+      // when there's no whitespace — the boundary character is still a
+      // separator and not an alpha continuation.
+      const result = parseSlashCommandOrNull("/config:json", "/config", opts);
+      expect(result).not.toBeNull();
+      expect(result?.ok).toBe(true);
+    });
+
+    it("still matches the exact prefix with leading whitespace", () => {
+      const result = parseSlashCommandOrNull("  /config show ", "/config", opts);
+      expect(result).toEqual({ ok: true, action: "show", args: "" });
+    });
+  });
+});

--- a/src/auto-reply/reply/commands-slash-parse.ts
+++ b/src/auto-reply/reply/commands-slash-parse.ts
@@ -16,6 +16,16 @@ function parseSlashCommandActionArgs(raw: string, slash: string): SlashCommandPa
   if (!normalizeLowercaseStringOrEmpty(trimmed).startsWith(slashLower)) {
     return { kind: "no-match" };
   }
+  // Fix #84572: enforce a boundary after the prefix so `/config-check` does
+  // not match the `/config` handler. The character immediately after the
+  // matched prefix must be whitespace, a colon, or end-of-string. Otherwise
+  // the prefix collided with a longer command name (e.g. a skill named
+  // `config-check`) and should be treated as a non-match so the longer
+  // handler — or the skill router — gets a chance to claim it.
+  const charAfter = trimmed.charAt(slash.length);
+  if (charAfter && !/[\s:]/.test(charAfter)) {
+    return { kind: "no-match" };
+  }
   const rest = trimmed.slice(slash.length).trim();
   if (!rest) {
     return { kind: "empty" };


### PR DESCRIPTION
## Summary

Fixes #84572.

`parseSlashCommandActionArgs` used a naive `startsWith` against the configured slash prefix. When a skill name shares a prefix with a built-in command, the longer name was captured by the shorter built-in handler.

Reporter's example: a skill named `config-check` invoked via `/config-check <args>` was captured by the built-in `/config` handler and surfaced as:

> ⚠️  /config is disabled. Set commands.config=true to enable.

Any skill whose name starts with a built-in command prefix (`config-*`, `debug-*`, `models-*`, etc.) was unreachable via slash invocation from any channel.

## Fix

After the prefix match, require that the character immediately after the matched prefix is whitespace, a colon, or end-of-string. Otherwise the prefix collided with a longer command name → return `no-match` so the longer handler — or the skill router — gets a chance to claim it.

```diff
   if (!normalizeLowercaseStringOrEmpty(trimmed).startsWith(slashLower)) {
     return { kind: "no-match" };
   }
+  const charAfter = trimmed.charAt(slash.length);
+  if (charAfter && !/[\s:]/.test(charAfter)) {
+    return { kind: "no-match" };
+  }
   const rest = trimmed.slice(slash.length).trim();
```

This is exactly the suggested fix from the issue body.

## Tests

Adds `src/auto-reply/reply/commands-slash-parse.test.ts` covering:

- `/config-check <args>` returns null for `/config` (the reported case)
- `/configfoo` (no separator) returns null
- `/modelsy` returns null for `/models` (no boundary)
- `/config:json` still matches (colon is a valid boundary)
- `/config show enabled` still parses cleanly (whitespace boundary)
- empty body still returns the default action
- exact-prefix with leading whitespace still parses

## Impact

Closes a regression that affected any skill whose name shares a prefix with a built-in command. Restores reachability for `/config-check`, `/debug-trace`, `/models-list`, etc.