### PR TITLE
memory: add local continuity snapshot helpers

### DIFF
--- a/packages/memory-host-sdk/src/host/continuity.test.ts
+++ b/packages/memory-host-sdk/src/host/continuity.test.ts
@@ -8,6 +8,8 @@ import {
   hasMaterialContinuityChange,
   parseContinuityDocument,
   RECENT_CONTINUITY_LATEST,
+  RECENT_CONTINUITY_SNAPSHOTS_DIR,
+  readRecentContinuitySnapshot,
   renderContinuitySnapshotMarkdown,
 } from "./continuity.js";
 
@@ -18,6 +20,27 @@ async function makeWorkspace(): Promise<string> {
   tempDirs.push(dir);
   await fs.mkdir(path.join(dir, "memory", "recent", "snapshots"), { recursive: true });
   return dir;
+}
+
+async function trySymlink(
+  target: string,
+  linkPath: string,
+  type: "file" | "dir",
+): Promise<boolean> {
+  try {
+    await fs.symlink(
+      target,
+      linkPath,
+      type === "dir" && process.platform === "win32" ? "junction" : type,
+    );
+    return true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "EPERM" || code === "EACCES" || code === "ENOSYS") {
+      return false;
+    }
+    throw err;
+  }
 }
 
 afterEach(async () => {
@@ -227,6 +250,52 @@ describe("hasMaterialContinuityChange", () => {
         conversationSummary: "The updated summary captures new recovery context.",
       }),
     ).toBe(true);
+  });
+});
+
+describe("readRecentContinuitySnapshot", () => {
+  it("rejects symlinked latest.md and falls back to a regular snapshot", async () => {
+    const workspace = await makeWorkspace();
+    const outside = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-continuity-outside-"));
+    tempDirs.push(outside);
+    const outsideLatest = path.join(outside, "latest.md");
+    await fs.writeFile(outsideLatest, "# Outside Snapshot\n", "utf-8");
+
+    const symlinkCreated = await trySymlink(
+      outsideLatest,
+      path.join(workspace, RECENT_CONTINUITY_LATEST),
+      "file",
+    );
+    if (!symlinkCreated) {
+      return;
+    }
+
+    await fs.writeFile(
+      path.join(workspace, RECENT_CONTINUITY_SNAPSHOTS_DIR, "safe.md"),
+      "# Safe Snapshot\n",
+      "utf-8",
+    );
+
+    const snapshot = await readRecentContinuitySnapshot(workspace);
+    expect(snapshot?.path).toBe("memory/recent/snapshots/safe.md");
+    expect(snapshot?.content).toContain("Safe Snapshot");
+    expect(snapshot?.content).not.toContain("Outside Snapshot");
+  });
+
+  it("rejects a symlinked snapshots directory", async () => {
+    const workspace = await makeWorkspace();
+    const outside = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-continuity-outside-"));
+    tempDirs.push(outside);
+    await fs.writeFile(path.join(outside, "leak.md"), "# Outside Snapshot\n", "utf-8");
+
+    const snapshotsDir = path.join(workspace, RECENT_CONTINUITY_SNAPSHOTS_DIR);
+    await fs.rm(snapshotsDir, { recursive: true, force: true });
+    const symlinkCreated = await trySymlink(outside, snapshotsDir, "dir");
+    if (!symlinkCreated) {
+      return;
+    }
+
+    await expect(readRecentContinuitySnapshot(workspace)).resolves.toBeNull();
   });
 });
 

--- a/packages/memory-host-sdk/src/host/continuity.test.ts
+++ b/packages/memory-host-sdk/src/host/continuity.test.ts
@@ -1,0 +1,287 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildContinuityManifest,
+  formatContinuityManifest,
+  hasMaterialContinuityChange,
+  parseContinuityDocument,
+  RECENT_CONTINUITY_LATEST,
+  renderContinuitySnapshotMarkdown,
+} from "./continuity.js";
+
+const tempDirs: string[] = [];
+
+async function makeWorkspace(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-continuity-"));
+  tempDirs.push(dir);
+  await fs.mkdir(path.join(dir, "memory", "recent", "snapshots"), { recursive: true });
+  return dir;
+}
+
+afterEach(async () => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (!dir) {
+      continue;
+    }
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+describe("parseContinuityDocument", () => {
+  it("parses recent snapshot frontmatter and sections", () => {
+    const content = renderContinuitySnapshotMarkdown({
+      status: "active",
+      priority: "high",
+      updatedAt: "2026-04-03T09:00:00.000Z",
+      supersedes: "memory/recent/latest.md",
+      source: "session-memory:command",
+      project: "memory-system",
+      sessionKey: "agent:main:main",
+      validUntil: "2026-04-04T09:00:00.000Z",
+      currentTask: "Implement continuity manifest",
+      currentPhase: "v1 delivery",
+      latestUserRequest: "Absorb Claude memory patterns",
+      blockers: ["Need stable parsing"],
+      nextSteps: ["Wire post-compaction context"],
+      keyArtifacts: ["src/memory/continuity.ts"],
+      conversationSummary: "The user wants a lighter but more resilient memory system.",
+    });
+
+    const parsed = parseContinuityDocument(content);
+    expect(parsed.status).toBe("active");
+    expect(parsed.priority).toBe("high");
+    expect(parsed.project).toBe("memory-system");
+    expect(parsed.currentTask).toBe("Implement continuity manifest");
+    expect(parsed.currentPhase).toBe("v1 delivery");
+    expect(parsed.latestUserRequest).toBe("Absorb Claude memory patterns");
+    expect(parsed.blockers).toEqual(["Need stable parsing"]);
+    expect(parsed.nextSteps).toEqual(["Wire post-compaction context"]);
+    expect(parsed.keyArtifacts).toEqual(["src/memory/continuity.ts"]);
+    expect(parsed.conversationSummary).toBe(
+      "The user wants a lighter but more resilient memory system.",
+    );
+  });
+
+  it("parses legacy markdown field headers", () => {
+    const legacy = `# 当前进度说明
+
+- 项目：系统修复
+- 状态：active
+- 优先级：highest
+- 当前阶段：记忆系统迭代 v1 落地与验证
+- 当前主任务：补近场快照与恢复索引
+- 当前阻塞：还没做第二轮验证
+- 下一步：跑针对性测试
+`;
+
+    const parsed = parseContinuityDocument(legacy);
+    expect(parsed.project).toBe("系统修复");
+    expect(parsed.status).toBe("active");
+    expect(parsed.priority).toBe("highest");
+    expect(parsed.currentPhase).toBe("记忆系统迭代 v1 落地与验证");
+    expect(parsed.currentTask).toBe("补近场快照与恢复索引");
+    expect(parsed.blockers).toEqual(["还没做第二轮验证"]);
+    expect(parsed.nextSteps).toEqual(["跑针对性测试"]);
+  });
+
+  it("parses alternate blockers and singular next step headings", () => {
+    const content = `# Recent Continuity Snapshot
+
+## Current Task
+- Repair continuity parser
+
+## Blockers
+- Parser fallback was not reachable
+
+## Next Step
+- Add regression coverage
+`;
+
+    const parsed = parseContinuityDocument(content);
+    expect(parsed.currentTask).toBe("Repair continuity parser");
+    expect(parsed.blockers).toEqual(["Parser fallback was not reachable"]);
+    expect(parsed.nextSteps).toEqual(["Add regression coverage"]);
+  });
+
+  it("normalizes multiline and heading-shaped snapshot fields before rendering", () => {
+    const content = renderContinuitySnapshotMarkdown({
+      status: "active",
+      priority: "high",
+      updatedAt: "2026-04-03T09:00:00.000Z",
+      source: "session-memory:command",
+      project: "memory-system",
+      sessionKey: "agent:main:main",
+      validUntil: "2026-04-04T09:00:00.000Z",
+      currentTask: `Repair continuity
+## Current Blockers
+- injected blocker`,
+      currentPhase: "v1 delivery",
+      latestUserRequest: `Keep going
+## Next Steps
+- injected next step`,
+      blockers: [
+        `First blocker
+## Next Steps
+- injected`,
+        "Second blocker",
+      ],
+      nextSteps: [
+        `Run tests
+## Key Artifacts
+- injected artifact`,
+      ],
+      keyArtifacts: [
+        `memory/recent/latest.md
+## Current Task
+- injected task`,
+      ],
+    });
+
+    expect(content).toContain("- Repair continuity ## Current Blockers - injected blocker");
+    expect(content).toContain("- Keep going ## Next Steps - injected next step");
+
+    const parsed = parseContinuityDocument(content);
+    expect(parsed.currentTask).toBe("Repair continuity ## Current Blockers - injected blocker");
+    expect(parsed.latestUserRequest).toBe("Keep going ## Next Steps - injected next step");
+    expect(parsed.blockers).toEqual(["First blocker ## Next Steps - injected", "Second blocker"]);
+    expect(parsed.nextSteps).toEqual(["Run tests ## Key Artifacts - injected artifact"]);
+    expect(parsed.keyArtifacts).toEqual([
+      "memory/recent/latest.md ## Current Task - injected task",
+    ]);
+  });
+});
+
+describe("hasMaterialContinuityChange", () => {
+  it("ignores validUntil-only changes", () => {
+    const previous = renderContinuitySnapshotMarkdown({
+      status: "active",
+      priority: "high",
+      updatedAt: "2026-04-03T09:00:00.000Z",
+      source: "session-memory:command",
+      project: "memory-system",
+      sessionKey: "agent:main:main",
+      validUntil: "2026-04-04T09:00:00.000Z",
+      currentTask: "Implement continuity manifest",
+      currentPhase: "v1 delivery",
+      latestUserRequest: "Absorb Claude memory patterns",
+      blockers: [],
+      nextSteps: ["Wire post-compaction context"],
+      keyArtifacts: [],
+    });
+
+    const next = {
+      status: "active",
+      priority: "high",
+      updatedAt: "2026-04-03T10:00:00.000Z",
+      source: "session-memory:command",
+      project: "memory-system",
+      sessionKey: "agent:main:main",
+      validUntil: "2026-04-05T09:00:00.000Z",
+      currentTask: "Implement continuity manifest",
+      currentPhase: "v1 delivery",
+      latestUserRequest: "Absorb Claude memory patterns",
+      blockers: [],
+      nextSteps: ["Wire post-compaction context"],
+      keyArtifacts: [],
+    };
+
+    expect(hasMaterialContinuityChange(previous, next)).toBe(false);
+  });
+
+  it("detects conversation summary changes as material", () => {
+    const previous = renderContinuitySnapshotMarkdown({
+      status: "active",
+      priority: "high",
+      updatedAt: "2026-04-03T09:00:00.000Z",
+      source: "session-memory:command",
+      project: "memory-system",
+      sessionKey: "agent:main:main",
+      validUntil: "2026-04-04T09:00:00.000Z",
+      currentTask: "Implement continuity manifest",
+      currentPhase: "v1 delivery",
+      latestUserRequest: "Absorb Claude memory patterns",
+      blockers: [],
+      nextSteps: ["Wire post-compaction context"],
+      keyArtifacts: [],
+      conversationSummary: "The current summary is still old.",
+    });
+
+    expect(
+      hasMaterialContinuityChange(previous, {
+        status: "active",
+        priority: "high",
+        updatedAt: "2026-04-03T10:00:00.000Z",
+        source: "session-memory:command",
+        project: "memory-system",
+        sessionKey: "agent:main:main",
+        validUntil: "2026-04-05T09:00:00.000Z",
+        currentTask: "Implement continuity manifest",
+        currentPhase: "v1 delivery",
+        latestUserRequest: "Absorb Claude memory patterns",
+        blockers: [],
+        nextSteps: ["Wire post-compaction context"],
+        keyArtifacts: [],
+        conversationSummary: "The updated summary captures new recovery context.",
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("buildContinuityManifest", () => {
+  it("sorts active recent continuity ahead of stale memory", async () => {
+    const workspace = await makeWorkspace();
+    const latestPath = path.join(workspace, RECENT_CONTINUITY_LATEST);
+    await fs.writeFile(
+      latestPath,
+      renderContinuitySnapshotMarkdown({
+        status: "active",
+        priority: "highest",
+        updatedAt: "2026-04-03T09:00:00.000Z",
+        source: "session-memory:command",
+        project: "system-repair",
+        sessionKey: "agent:main:main",
+        validUntil: "2026-04-04T09:00:00.000Z",
+        currentTask: "Ship memory iteration",
+        currentPhase: "verification",
+        latestUserRequest: "Implement the meeting plan",
+        blockers: ["Need to finish tests"],
+        nextSteps: ["Run vitest"],
+        keyArtifacts: ["memory/recent/latest.md"],
+      }),
+      "utf-8",
+    );
+    await fs.writeFile(
+      path.join(workspace, "memory", "active-topics.md"),
+      `# Active Topics
+
+- 状态：active
+- 优先级：high
+- updated_at：2026-04-03 15:00 CST
+- 当前主任务：记忆系统迭代与官方贡献目标
+`,
+      "utf-8",
+    );
+    await fs.writeFile(
+      path.join(workspace, "memory", "2026-03-20.md"),
+      `# Old Daily
+
+- 状态：stale
+- 优先级：low
+- updated_at：2026-03-20 09:00 CST
+- 当前主任务：旧项目
+`,
+      "utf-8",
+    );
+
+    const manifest = await buildContinuityManifest({ workspaceDir: workspace });
+    expect(manifest[0]?.path).toBe("memory/recent/latest.md");
+    expect(manifest[1]?.path).toBe("memory/active-topics.md");
+
+    const formatted = formatContinuityManifest(manifest, 2);
+    expect(formatted).toContain("[active/highest] memory/recent/latest.md");
+    expect(formatted).toContain("[active/high] memory/active-topics.md");
+  });
+});

--- a/packages/memory-host-sdk/src/host/continuity.test.ts
+++ b/packages/memory-host-sdk/src/host/continuity.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   buildContinuityManifest,
   formatContinuityManifest,
@@ -300,6 +300,73 @@ describe("readRecentContinuitySnapshot", () => {
 });
 
 describe("buildContinuityManifest", () => {
+  it("rejects candidates swapped to symlinks after enumeration", async () => {
+    const workspace = await makeWorkspace();
+    const candidate = path.join(workspace, "memory", "candidate.md");
+    await fs.writeFile(
+      candidate,
+      `# Safe Candidate
+
+- 状态：active
+- 优先级：high
+- 当前主任务：Safe manifest content
+`,
+      "utf-8",
+    );
+
+    const outside = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-continuity-outside-"));
+    tempDirs.push(outside);
+    const outsideLeak = path.join(outside, "leak.md");
+    await fs.writeFile(
+      outsideLeak,
+      `# Outside Secret
+
+- 状态：active
+- 优先级：highest
+- 当前主任务：LEAKED OUTSIDE CONTENT
+`,
+      "utf-8",
+    );
+
+    const probeLink = path.join(workspace, "memory", "probe-link.md");
+    const symlinkSupported = await trySymlink(outsideLeak, probeLink, "file");
+    await fs.rm(probeLink, { force: true });
+    if (!symlinkSupported) {
+      return;
+    }
+
+    vi.resetModules();
+    vi.doMock("./internal.js", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("./internal.js")>();
+      return {
+        ...actual,
+        listMemoryFiles: async (...args: Parameters<typeof actual.listMemoryFiles>) => {
+          const files = await actual.listMemoryFiles(...args);
+          if (files.includes(candidate)) {
+            await fs.rm(candidate, { force: true });
+            const swapped = await trySymlink(outsideLeak, candidate, "file");
+            if (!swapped) {
+              throw new Error("Expected symlink swap to succeed after preflight");
+            }
+          }
+          return files;
+        },
+      };
+    });
+
+    try {
+      const { buildContinuityManifest: buildManifestWithRacyList } =
+        await import("./continuity.js");
+      const manifest = await buildManifestWithRacyList({ workspaceDir: workspace });
+
+      expect(manifest).toEqual([]);
+      expect(JSON.stringify(manifest)).not.toContain("LEAKED OUTSIDE CONTENT");
+    } finally {
+      vi.doUnmock("./internal.js");
+      vi.resetModules();
+    }
+  });
+
   it("sorts active recent continuity ahead of stale memory", async () => {
     const workspace = await makeWorkspace();
     const latestPath = path.join(workspace, RECENT_CONTINUITY_LATEST);

--- a/packages/memory-host-sdk/src/host/continuity.ts
+++ b/packages/memory-host-sdk/src/host/continuity.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import YAML from "yaml";
+import { readRegularFile, root, statRegularFile } from "./fs-utils.js";
 import { listMemoryFiles } from "./internal.js";
 
 export const RECENT_CONTINUITY_DIR = "memory/recent";
@@ -563,39 +564,63 @@ export async function readRecentContinuitySnapshot(workspaceDir: string): Promis
   path: string;
   content: string;
 } | null> {
+  const workspaceRoot = await root(workspaceDir);
   const latestPath = path.join(workspaceDir, RECENT_CONTINUITY_LATEST);
   try {
-    const content = await fs.readFile(latestPath, "utf-8");
-    return {
-      path: RECENT_CONTINUITY_LATEST,
-      content,
-    };
-  } catch {}
+    await workspaceRoot.resolve(RECENT_CONTINUITY_LATEST);
+    const stat = await statRegularFile(latestPath);
+    if (!stat.missing) {
+      const content = (await readRegularFile({ filePath: latestPath })).buffer.toString("utf-8");
+      return {
+        path: RECENT_CONTINUITY_LATEST,
+        content,
+      };
+    }
+  } catch {
+    // Fall through to older snapshots; unsafe latest.md candidates are ignored.
+  }
 
   const snapshotsDir = path.join(workspaceDir, RECENT_CONTINUITY_SNAPSHOTS_DIR);
   try {
+    await workspaceRoot.resolve(RECENT_CONTINUITY_SNAPSHOTS_DIR);
+    const snapshotsStat = await fs.lstat(snapshotsDir);
+    if (!snapshotsStat.isDirectory()) {
+      return null;
+    }
     const entries = await fs.readdir(snapshotsDir, { withFileTypes: true });
-    const files = await Promise.all(
-      entries
-        .filter((entry) => entry.isFile() && entry.name.endsWith(".md"))
-        .map(async (entry) => {
-          const absPath = path.join(snapshotsDir, entry.name);
-          const stat = await fs.stat(absPath);
-          return { absPath, mtimeMs: stat.mtimeMs };
-        }),
+    const files = (
+      await Promise.all(
+        entries
+          .filter((entry) => entry.isFile() && entry.name.endsWith(".md"))
+          .map(async (entry) => {
+            const relPath = `${RECENT_CONTINUITY_SNAPSHOTS_DIR}/${entry.name}`;
+            const absPath = path.join(snapshotsDir, entry.name);
+            try {
+              await workspaceRoot.resolve(relPath);
+              const stat = await statRegularFile(absPath);
+              if (stat.missing) {
+                return null;
+              }
+              return { absPath, relPath, mtimeMs: stat.stat.mtimeMs };
+            } catch {
+              return null;
+            }
+          }),
+      )
+    ).filter((entry): entry is { absPath: string; relPath: string; mtimeMs: number } =>
+      Boolean(entry),
     );
     const latest = files.toSorted((a, b) => b.mtimeMs - a.mtimeMs)[0];
     if (!latest) {
       return null;
     }
-    const content = await fs.readFile(latest.absPath, "utf-8");
+    const content = (await readRegularFile({ filePath: latest.absPath })).buffer.toString("utf-8");
     return {
-      path: path.relative(workspaceDir, latest.absPath).replace(/\\/g, "/"),
+      path: latest.relPath,
       content,
     };
-  } catch {
-    return null;
-  }
+  } catch {}
+  return null;
 }
 
 export async function buildContinuityManifest(params: {

--- a/packages/memory-host-sdk/src/host/continuity.ts
+++ b/packages/memory-host-sdk/src/host/continuity.ts
@@ -1,0 +1,709 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import YAML from "yaml";
+import { listMemoryFiles } from "./internal.js";
+
+export const RECENT_CONTINUITY_DIR = "memory/recent";
+export const RECENT_CONTINUITY_LATEST = `${RECENT_CONTINUITY_DIR}/latest.md`;
+export const RECENT_CONTINUITY_SNAPSHOTS_DIR = `${RECENT_CONTINUITY_DIR}/snapshots`;
+
+export type ContinuitySnapshotState = {
+  status: string;
+  priority: string;
+  updatedAt: string;
+  supersedes?: string;
+  source: string;
+  project: string;
+  sessionKey: string;
+  validUntil: string;
+  currentTask: string;
+  currentPhase: string;
+  latestUserRequest: string;
+  blockers: string[];
+  nextSteps: string[];
+  keyArtifacts: string[];
+  conversationSummary?: string;
+};
+
+export type ParsedContinuityDocument = {
+  title?: string;
+  type?: string;
+  status?: string;
+  priority?: string;
+  updatedAt?: string;
+  supersedes?: string;
+  source?: string;
+  project?: string;
+  sessionKey?: string;
+  validUntil?: string;
+  currentTask?: string;
+  currentPhase?: string;
+  latestUserRequest?: string;
+  blockers: string[];
+  nextSteps: string[];
+  keyArtifacts: string[];
+  conversationSummary?: string;
+  summary?: string;
+};
+
+export type ContinuityManifestEntry = {
+  path: string;
+  absPath: string;
+  mtimeMs: number;
+  status?: string;
+  priority?: string;
+  updatedAt?: string;
+  supersedes?: string;
+  type?: string;
+  project?: string;
+  title?: string;
+  summary?: string;
+};
+
+const HEAD_MAX_LINES = 30;
+const HEAD_MAX_BYTES = 12_000;
+const MAX_MANIFEST_FILES = 200;
+
+type ParsedFrontmatter = Record<string, string>;
+
+function coerceFrontmatterValue(value: unknown): string | undefined {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+  if (typeof value === "string") {
+    return value.trim();
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  if (typeof value === "object") {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return undefined;
+    }
+  }
+  return undefined;
+}
+
+function parseFrontmatterBlock(content: string): ParsedFrontmatter {
+  const normalized = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  if (!normalized.startsWith("---\n")) {
+    return {};
+  }
+  const endIndex = normalized.indexOf("\n---", 4);
+  if (endIndex === -1) {
+    return {};
+  }
+  const block = normalized.slice(4, endIndex);
+  try {
+    const parsed = YAML.parse(block, { schema: "core" }) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+    const result: ParsedFrontmatter = {};
+    for (const [rawKey, rawValue] of Object.entries(parsed)) {
+      const key = rawKey.trim();
+      const value = coerceFrontmatterValue(rawValue);
+      if (!key || value === undefined || value.length === 0) {
+        continue;
+      }
+      result[key] = value;
+    }
+    return result;
+  } catch {
+    return {};
+  }
+}
+
+const STATUS_ORDER: Record<string, number> = {
+  active: 0,
+  blocked: 1,
+  pending: 2,
+  stale: 3,
+  superseded: 4,
+  archived: 5,
+  unknown: 6,
+};
+
+const PRIORITY_ORDER: Record<string, number> = {
+  highest: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+  unknown: 4,
+};
+
+const LEGACY_KEY_ALIASES: Record<string, string> = {
+  status: "status",
+  状态: "status",
+  priority: "priority",
+  优先级: "priority",
+  updated_at: "updated_at",
+  updatedat: "updated_at",
+  更新时间: "updated_at",
+  supersedes: "supersedes",
+  覆盖: "supersedes",
+  取代: "supersedes",
+  project: "project",
+  项目: "project",
+  当前项目: "project",
+  topic: "topic",
+  主题: "topic",
+  当前主任务: "current_task",
+  current_task: "current_task",
+  currenttask: "current_task",
+  当前阶段: "current_phase",
+  current_phase: "current_phase",
+  currentphase: "current_phase",
+  当前阻塞: "blockers",
+  blockers: "blockers",
+  下一步: "next_steps",
+  next_steps: "next_steps",
+  nextsteps: "next_steps",
+  关键文件: "key_artifacts",
+  关键产物: "key_artifacts",
+  key_artifacts: "key_artifacts",
+  keyartifacts: "key_artifacts",
+  description: "description",
+  目标: "description",
+  当前重点: "description",
+};
+
+function normalizeWhitespace(value: string | undefined): string {
+  return (value ?? "").replace(/\s+/g, " ").trim();
+}
+
+function normalizeList(values: string[]): string[] {
+  return values.map((value) => normalizeWhitespace(value)).filter(Boolean);
+}
+
+function normalizeSnapshotScalar(value: string | undefined, fallback: string): string {
+  return normalizeWhitespace(value) || fallback;
+}
+
+function normalizeSnapshotList(values: string[]): string[] {
+  const normalized = normalizeList(values);
+  return normalized.length > 0 ? normalized : ["none"];
+}
+
+function canonicalizeStatus(raw: string | undefined): string | undefined {
+  const value = normalizeWhitespace(raw).toLowerCase();
+  if (!value) {
+    return undefined;
+  }
+  switch (value) {
+    case "active":
+    case "doing":
+    case "in_progress":
+    case "in-progress":
+    case "working":
+      return "active";
+    case "blocked":
+      return "blocked";
+    case "pending":
+    case "todo":
+    case "planned":
+      return "pending";
+    case "stale":
+    case "superseded":
+    case "archived":
+      return value;
+    default:
+      return value;
+  }
+}
+
+function canonicalizePriority(raw: string | undefined): string | undefined {
+  const value = normalizeWhitespace(raw).toLowerCase();
+  if (!value) {
+    return undefined;
+  }
+  switch (value) {
+    case "p0":
+    case "highest":
+      return "highest";
+    case "p1":
+    case "high":
+      return "high";
+    case "p2":
+    case "medium":
+      return "medium";
+    case "p3":
+    case "low":
+      return "low";
+    default:
+      return value;
+  }
+}
+
+function parseTimestampMs(raw: string | undefined, fallback: number): number {
+  const value = normalizeWhitespace(raw);
+  if (!value) {
+    return fallback;
+  }
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function compareByContinuityPriority(
+  left: Pick<ContinuityManifestEntry, "status" | "priority" | "updatedAt" | "mtimeMs">,
+  right: Pick<ContinuityManifestEntry, "status" | "priority" | "updatedAt" | "mtimeMs">,
+): number {
+  const leftStatus =
+    STATUS_ORDER[canonicalizeStatus(left.status) ?? "unknown"] ?? STATUS_ORDER.unknown;
+  const rightStatus =
+    STATUS_ORDER[canonicalizeStatus(right.status) ?? "unknown"] ?? STATUS_ORDER.unknown;
+  if (leftStatus !== rightStatus) {
+    return leftStatus - rightStatus;
+  }
+
+  const leftPriority =
+    PRIORITY_ORDER[canonicalizePriority(left.priority) ?? "unknown"] ?? PRIORITY_ORDER.unknown;
+  const rightPriority =
+    PRIORITY_ORDER[canonicalizePriority(right.priority) ?? "unknown"] ?? PRIORITY_ORDER.unknown;
+  if (leftPriority !== rightPriority) {
+    return leftPriority - rightPriority;
+  }
+
+  const leftTime = parseTimestampMs(left.updatedAt, left.mtimeMs);
+  const rightTime = parseTimestampMs(right.updatedAt, right.mtimeMs);
+  return rightTime - leftTime;
+}
+
+function readYamlString(map: Record<string, string>, key: string): string | undefined {
+  const value = normalizeWhitespace(map[key]);
+  return value || undefined;
+}
+
+function canonicalizeLegacyKey(label: string): string | undefined {
+  const normalized = normalizeWhitespace(label).toLowerCase().replace(/\s+/g, "_");
+  return LEGACY_KEY_ALIASES[label] ?? LEGACY_KEY_ALIASES[normalized];
+}
+
+function parseLegacyFieldHeader(content: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  const lines = content.replace(/\r\n/g, "\n").split("\n").slice(0, HEAD_MAX_LINES);
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      continue;
+    }
+
+    const match =
+      trimmed.match(/^-+\s*\*\*([^*]+)\*\*\s*[：:]\s*(.+)$/) ??
+      trimmed.match(/^-+\s*([^：:]+?)\s*[：:]\s*(.+)$/) ??
+      trimmed.match(/^([A-Za-z0-9_\-\u4e00-\u9fff\s]+?)\s*[：:]\s*(.+)$/);
+    if (!match) {
+      continue;
+    }
+
+    const key = canonicalizeLegacyKey(match[1] ?? "");
+    const value = normalizeWhitespace(match[2]);
+    if (!key || !value) {
+      continue;
+    }
+    result[key] = value;
+  }
+
+  return result;
+}
+
+function extractHeading(content: string): string | undefined {
+  const lines = content.replace(/\r\n/g, "\n").split("\n");
+  for (const line of lines) {
+    const match = line.match(/^#\s+(.+?)\s*$/);
+    if (match?.[1]) {
+      return normalizeWhitespace(match[1]);
+    }
+  }
+  return undefined;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function extractSection(content: string, title: string): string | undefined {
+  const pattern = new RegExp(
+    `^##\\s+${escapeRegExp(title)}\\s*$([\\s\\S]*?)(?=^##\\s+|(?![\\s\\S]))`,
+    "gim",
+  );
+  const match = pattern.exec(content);
+  if (!match?.[1]) {
+    return undefined;
+  }
+  return match[1].trim();
+}
+
+function sectionToList(section: string | undefined): string[] {
+  if (!section) {
+    return [];
+  }
+  const lines = section
+    .split(/\r?\n/g)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => line.replace(/^[-*]\s*/, "").trim())
+    .filter(Boolean);
+  const normalized = normalizeList(lines);
+  if (normalized.length === 1 && normalized[0]?.toLowerCase() === "none") {
+    return [];
+  }
+  return normalized;
+}
+
+function firstNonEmptyList(...sections: Array<string | undefined>): string[] {
+  for (const section of sections) {
+    const list = sectionToList(section);
+    if (list.length > 0) {
+      return list;
+    }
+  }
+  return [];
+}
+
+function firstOfList(section: string | undefined): string | undefined {
+  const list = sectionToList(section);
+  return list[0];
+}
+
+function stripFrontmatter(content: string): string {
+  const normalized = content.replace(/\r\n/g, "\n");
+  if (!normalized.startsWith("---\n")) {
+    return normalized;
+  }
+  const endIndex = normalized.indexOf("\n---\n", 4);
+  if (endIndex === -1) {
+    return normalized;
+  }
+  return normalized.slice(endIndex + 5);
+}
+
+function truncateText(value: string | undefined, maxChars: number): string | undefined {
+  const normalized = normalizeWhitespace(value);
+  if (!normalized) {
+    return undefined;
+  }
+  if (normalized.length <= maxChars) {
+    return normalized;
+  }
+  return `${normalized.slice(0, Math.max(0, maxChars - 3))}...`;
+}
+
+async function readHead(absPath: string, maxLines: number, maxBytes: number): Promise<string> {
+  const handle = await fs.open(absPath, "r");
+  try {
+    const buffer = Buffer.alloc(maxBytes);
+    const { bytesRead } = await handle.read(buffer, 0, maxBytes, 0);
+    return buffer
+      .subarray(0, bytesRead)
+      .toString("utf-8")
+      .replace(/\r\n/g, "\n")
+      .split("\n")
+      .slice(0, maxLines)
+      .join("\n");
+  } finally {
+    await handle.close();
+  }
+}
+
+function pickSummary(
+  fields: ParsedContinuityDocument,
+  legacy: Record<string, string>,
+): string | undefined {
+  return (
+    truncateText(fields.currentTask, 180) ??
+    truncateText(fields.currentPhase, 180) ??
+    truncateText(fields.latestUserRequest, 180) ??
+    truncateText(legacy.description, 180) ??
+    truncateText(legacy.topic, 180) ??
+    truncateText(fields.title, 180)
+  );
+}
+
+export function parseContinuityDocument(content: string): ParsedContinuityDocument {
+  const frontmatter = parseFrontmatterBlock(content);
+  const legacy = parseLegacyFieldHeader(stripFrontmatter(content));
+  const heading = extractHeading(stripFrontmatter(content));
+
+  const blockers = firstNonEmptyList(
+    extractSection(content, "Current Blockers"),
+    extractSection(content, "Blockers"),
+  );
+  const nextSteps = firstNonEmptyList(
+    extractSection(content, "Next Steps"),
+    extractSection(content, "Next Step"),
+  );
+  const keyArtifacts = sectionToList(extractSection(content, "Key Artifacts"));
+
+  const parsed: ParsedContinuityDocument = {
+    title: heading ?? readYamlString(frontmatter, "title"),
+    type: readYamlString(frontmatter, "type"),
+    status: canonicalizeStatus(readYamlString(frontmatter, "status") ?? legacy.status),
+    priority: canonicalizePriority(readYamlString(frontmatter, "priority") ?? legacy.priority),
+    updatedAt: readYamlString(frontmatter, "updated_at") ?? legacy.updated_at,
+    supersedes: readYamlString(frontmatter, "supersedes") ?? legacy.supersedes,
+    source: readYamlString(frontmatter, "source"),
+    project: readYamlString(frontmatter, "project") ?? legacy.project,
+    sessionKey: readYamlString(frontmatter, "session_key"),
+    validUntil: readYamlString(frontmatter, "valid_until"),
+    currentTask:
+      firstOfList(extractSection(content, "Current Task")) ??
+      readYamlString(frontmatter, "current_task") ??
+      legacy.current_task,
+    currentPhase:
+      firstOfList(extractSection(content, "Current Phase")) ??
+      readYamlString(frontmatter, "current_phase") ??
+      legacy.current_phase,
+    latestUserRequest:
+      firstOfList(extractSection(content, "Latest User Request")) ??
+      readYamlString(frontmatter, "latest_user_request"),
+    blockers:
+      blockers.length > 0 ? blockers : normalizeList((legacy.blockers ?? "").split(/[；;]+/g)),
+    nextSteps:
+      nextSteps.length > 0 ? nextSteps : normalizeList((legacy.next_steps ?? "").split(/[；;]+/g)),
+    keyArtifacts:
+      keyArtifacts.length > 0
+        ? keyArtifacts
+        : normalizeList((legacy.key_artifacts ?? "").split(/[；;]+/g)),
+    conversationSummary:
+      extractSection(content, "Conversation Summary") ??
+      readYamlString(frontmatter, "conversation_summary"),
+    summary: undefined,
+  };
+
+  parsed.summary = pickSummary(parsed, legacy);
+  return parsed;
+}
+
+export function hasMaterialContinuityChange(
+  previousContent: string | undefined,
+  nextState: ContinuitySnapshotState,
+): boolean {
+  if (!previousContent) {
+    return true;
+  }
+  const previous = parseContinuityDocument(previousContent);
+  const canonicalPrevious = JSON.stringify({
+    status: canonicalizeStatus(previous.status),
+    priority: canonicalizePriority(previous.priority),
+    project: normalizeWhitespace(previous.project),
+    currentTask: normalizeWhitespace(previous.currentTask),
+    currentPhase: normalizeWhitespace(previous.currentPhase),
+    latestUserRequest: normalizeWhitespace(previous.latestUserRequest),
+    blockers: normalizeList(previous.blockers),
+    nextSteps: normalizeList(previous.nextSteps),
+    keyArtifacts: normalizeList(previous.keyArtifacts),
+    conversationSummary: normalizeWhitespace(previous.conversationSummary),
+  });
+  const canonicalNext = JSON.stringify({
+    status: canonicalizeStatus(nextState.status),
+    priority: canonicalizePriority(nextState.priority),
+    project: normalizeWhitespace(nextState.project),
+    currentTask: normalizeWhitespace(nextState.currentTask),
+    currentPhase: normalizeWhitespace(nextState.currentPhase),
+    latestUserRequest: normalizeWhitespace(nextState.latestUserRequest),
+    blockers: normalizeList(nextState.blockers),
+    nextSteps: normalizeList(nextState.nextSteps),
+    keyArtifacts: normalizeList(nextState.keyArtifacts),
+    conversationSummary: normalizeWhitespace(nextState.conversationSummary),
+  });
+  return canonicalPrevious !== canonicalNext;
+}
+
+export function renderContinuitySnapshotMarkdown(state: ContinuitySnapshotState): string {
+  const frontmatter = YAML.stringify({
+    type: "recent_snapshot",
+    status: state.status,
+    priority: state.priority,
+    updated_at: state.updatedAt,
+    supersedes: state.supersedes,
+    source: state.source,
+    project: state.project,
+    session_key: state.sessionKey,
+    valid_until: state.validUntil,
+  }).trimEnd();
+
+  const lines = [
+    "---",
+    frontmatter,
+    "---",
+    "",
+    "# Recent Continuity Snapshot",
+    "",
+    "## Current Task",
+    `- ${normalizeSnapshotScalar(state.currentTask, "unknown")}`,
+    "",
+    "## Current Phase",
+    `- ${normalizeSnapshotScalar(state.currentPhase, "unknown")}`,
+    "",
+    "## Latest User Request",
+    `- ${normalizeSnapshotScalar(state.latestUserRequest, "unknown")}`,
+    "",
+    "## Current Blockers",
+    ...normalizeSnapshotList(state.blockers).map((entry) => `- ${entry}`),
+    "",
+    "## Next Steps",
+    ...normalizeSnapshotList(state.nextSteps).map((entry) => `- ${entry}`),
+    "",
+    "## Key Artifacts",
+    ...normalizeSnapshotList(state.keyArtifacts).map((entry) => `- ${entry}`),
+  ];
+
+  if (normalizeWhitespace(state.conversationSummary)) {
+    lines.push("", "## Conversation Summary", "", normalizeWhitespace(state.conversationSummary));
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+export async function readRecentContinuitySnapshot(workspaceDir: string): Promise<{
+  path: string;
+  content: string;
+} | null> {
+  const latestPath = path.join(workspaceDir, RECENT_CONTINUITY_LATEST);
+  try {
+    const content = await fs.readFile(latestPath, "utf-8");
+    return {
+      path: RECENT_CONTINUITY_LATEST,
+      content,
+    };
+  } catch {}
+
+  const snapshotsDir = path.join(workspaceDir, RECENT_CONTINUITY_SNAPSHOTS_DIR);
+  try {
+    const entries = await fs.readdir(snapshotsDir, { withFileTypes: true });
+    const files = await Promise.all(
+      entries
+        .filter((entry) => entry.isFile() && entry.name.endsWith(".md"))
+        .map(async (entry) => {
+          const absPath = path.join(snapshotsDir, entry.name);
+          const stat = await fs.stat(absPath);
+          return { absPath, mtimeMs: stat.mtimeMs };
+        }),
+    );
+    const latest = files.toSorted((a, b) => b.mtimeMs - a.mtimeMs)[0];
+    if (!latest) {
+      return null;
+    }
+    const content = await fs.readFile(latest.absPath, "utf-8");
+    return {
+      path: path.relative(workspaceDir, latest.absPath).replace(/\\/g, "/"),
+      content,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function buildContinuityManifest(params: {
+  workspaceDir: string;
+  extraPaths?: string[];
+  maxFiles?: number;
+}): Promise<ContinuityManifestEntry[]> {
+  const files = await listMemoryFiles(params.workspaceDir, params.extraPaths);
+  const statEntries = await Promise.all(
+    files.map(async (absPath) => {
+      try {
+        const stat = await fs.stat(absPath);
+        return { absPath, mtimeMs: stat.mtimeMs };
+      } catch {
+        return null;
+      }
+    }),
+  );
+
+  const selected = statEntries
+    .filter((entry): entry is { absPath: string; mtimeMs: number } => Boolean(entry))
+    .toSorted((a, b) => b.mtimeMs - a.mtimeMs)
+    .slice(0, params.maxFiles ?? MAX_MANIFEST_FILES);
+
+  const parsed = await Promise.all(
+    selected.map(async ({ absPath, mtimeMs }) => {
+      try {
+        const head = await readHead(absPath, HEAD_MAX_LINES, HEAD_MAX_BYTES);
+        const doc = parseContinuityDocument(head);
+        return {
+          path: path.relative(params.workspaceDir, absPath).replace(/\\/g, "/"),
+          absPath,
+          mtimeMs,
+          status: doc.status,
+          priority: doc.priority,
+          updatedAt: doc.updatedAt,
+          supersedes: doc.supersedes,
+          type: doc.type,
+          project: doc.project,
+          title: doc.title,
+          summary: doc.summary,
+        } satisfies ContinuityManifestEntry;
+      } catch {
+        return null;
+      }
+    }),
+  );
+
+  const manifestEntries: ContinuityManifestEntry[] = [];
+  for (const entry of parsed) {
+    if (entry) {
+      manifestEntries.push(entry);
+    }
+  }
+  return manifestEntries.toSorted(compareByContinuityPriority);
+}
+
+export function formatContinuityManifest(
+  entries: ContinuityManifestEntry[],
+  maxEntries: number = 5,
+): string {
+  const limited = entries.slice(0, maxEntries);
+  if (limited.length === 0) {
+    return "";
+  }
+  const lines = limited.map((entry) => {
+    const status = canonicalizeStatus(entry.status) ?? "unknown";
+    const priority = canonicalizePriority(entry.priority) ?? "unknown";
+    const stamp = normalizeWhitespace(entry.updatedAt) || new Date(entry.mtimeMs).toISOString();
+    const summary = truncateText(entry.summary ?? entry.title, 180) ?? "no summary";
+    return `- [${status}/${priority}] ${entry.path} (${stamp}): ${summary}`;
+  });
+  return `<continuity-manifest>\n${lines.join("\n")}\n</continuity-manifest>`;
+}
+
+export function formatContinuitySnapshotForPrompt(
+  content: string,
+  maxChars: number = 1200,
+): string {
+  const parsed = parseContinuityDocument(content);
+  const lines: string[] = [];
+  if (parsed.project) {
+    lines.push(`Project: ${parsed.project}`);
+  }
+  if (parsed.currentTask) {
+    lines.push(`Current task: ${parsed.currentTask}`);
+  }
+  if (parsed.currentPhase) {
+    lines.push(`Current phase: ${parsed.currentPhase}`);
+  }
+  if (parsed.latestUserRequest) {
+    lines.push(`Latest user request: ${parsed.latestUserRequest}`);
+  }
+  if (parsed.blockers.length > 0) {
+    lines.push(`Blockers: ${parsed.blockers.join(" | ")}`);
+  }
+  if (parsed.nextSteps.length > 0) {
+    lines.push(`Next steps: ${parsed.nextSteps.join(" | ")}`);
+  }
+  if (parsed.keyArtifacts.length > 0) {
+    lines.push(`Key artifacts: ${parsed.keyArtifacts.join(" | ")}`);
+  }
+  if (parsed.conversationSummary) {
+    lines.push(`Conversation summary: ${normalizeWhitespace(parsed.conversationSummary)}`);
+  }
+  const text = lines.join("\n").trim();
+  if (!text) {
+    return "";
+  }
+  return text.length <= maxChars ? text : `${text.slice(0, Math.max(0, maxChars - 3))}...`;
+}

--- a/packages/memory-host-sdk/src/host/continuity.ts
+++ b/packages/memory-host-sdk/src/host/continuity.ts
@@ -394,20 +394,14 @@ function truncateText(value: string | undefined, maxChars: number): string | und
 }
 
 async function readHead(absPath: string, maxLines: number, maxBytes: number): Promise<string> {
-  const handle = await fs.open(absPath, "r");
-  try {
-    const buffer = Buffer.alloc(maxBytes);
-    const { bytesRead } = await handle.read(buffer, 0, maxBytes, 0);
-    return buffer
-      .subarray(0, bytesRead)
-      .toString("utf-8")
-      .replace(/\r\n/g, "\n")
-      .split("\n")
-      .slice(0, maxLines)
-      .join("\n");
-  } finally {
-    await handle.close();
-  }
+  const { buffer } = await readRegularFile({ filePath: absPath });
+  return buffer
+    .subarray(0, Math.min(buffer.byteLength, maxBytes))
+    .toString("utf-8")
+    .replace(/\r\n/g, "\n")
+    .split("\n")
+    .slice(0, maxLines)
+    .join("\n");
 }
 
 function pickSummary(
@@ -632,8 +626,11 @@ export async function buildContinuityManifest(params: {
   const statEntries = await Promise.all(
     files.map(async (absPath) => {
       try {
-        const stat = await fs.stat(absPath);
-        return { absPath, mtimeMs: stat.mtimeMs };
+        const regularFile = await statRegularFile(absPath);
+        if (regularFile.missing) {
+          return null;
+        }
+        return { absPath, mtimeMs: regularFile.stat.mtimeMs };
       } catch {
         return null;
       }

--- a/packages/memory-host-sdk/src/runtime-files.ts
+++ b/packages/memory-host-sdk/src/runtime-files.ts
@@ -3,6 +3,23 @@
 export { listMemoryFiles, normalizeExtraMemoryPaths } from "./host/internal.js";
 export { readAgentMemoryFile } from "./host/read-file.js";
 export { resolveMemoryBackendConfig } from "./host/backend-config.js";
+export {
+  buildContinuityManifest,
+  formatContinuityManifest,
+  formatContinuitySnapshotForPrompt,
+  hasMaterialContinuityChange,
+  parseContinuityDocument,
+  readRecentContinuitySnapshot,
+  RECENT_CONTINUITY_DIR,
+  RECENT_CONTINUITY_LATEST,
+  RECENT_CONTINUITY_SNAPSHOTS_DIR,
+  renderContinuitySnapshotMarkdown,
+} from "./host/continuity.js";
+export type {
+  ContinuityManifestEntry,
+  ContinuitySnapshotState,
+  ParsedContinuityDocument,
+} from "./host/continuity.js";
 export type {
   MemorySearchManager,
   MemorySearchRuntimeDebug,


### PR DESCRIPTION
## Summary

Adds local-first helpers for reading and rendering recent continuity snapshots under `memory/recent`:

- parse frontmatter-based and legacy markdown continuity notes;
- render a structured recent snapshot document;
- build a small continuity manifest prioritized by status, priority, and recency;
- compare material continuity changes while ignoring TTL-only churn;
- expose the helpers through the focused `@openclaw/memory-host-sdk/runtime-files` surface.

This is intentionally only the local document/manifest layer. It does not add provider-backed extraction, command hooks, compaction hooks, or post-compaction behavior.

## Why

Agents currently have long-term memory files and session transcripts, but there is no small local-first continuity document format for the most recent active task state. This provides a narrow foundation that later integrations can use without mixing runtime hook behavior into this PR.

## Safety / scope

- Local filesystem only.
- No LLM/provider calls.
- No new hook registration.
- No command reply-path changes.
- No compaction/post-compaction behavior changes.

## Real behavior proof

Behavior or issue addressed: The new local continuity helper can render a recent continuity snapshot, parse it back from disk, and build a prioritized continuity manifest that includes both the new `memory/recent/latest.md` file and an existing legacy markdown memory file.

Real environment tested: Local OpenClaw checkout on macOS, running this PR branch with Node/tsx against a temporary workspace under the macOS temp directory. No provider-backed extraction, no LLM call, no command hook, and no compaction hook were used.

Exact steps or command run after this patch: Created a temporary workspace; wrote a rendered continuity snapshot to `memory/recent/latest.md` using `renderContinuitySnapshotMarkdown()`; wrote a legacy-style `memory/active-topics.md`; parsed the snapshot with `parseContinuityDocument()`; built a manifest with `buildContinuityManifest()`; printed it with `formatContinuityManifest()`.

Evidence after fix: Copied live terminal output from the local OpenClaw checkout after running the helper against real files on disk:

```text
real_setup=macOS OpenClaw local workspace tempdir
workspace=/var/folders/pq/fzbnkvys447bgjk0_13b5syr0000gn/T/openclaw-pr84636-proof-0siuQs
parsed.currentTask=Monitor PR #84636 checks
parsed.conversationSummary=PR A is open and local gates passed; CI requires real behavior proof in the PR body.
manifest.length=2
<continuity-manifest>
- [active/highest] memory/recent/latest.md (2026-05-21T01:08:00.000+08:00): Monitor PR #84636 checks
- [active/high] memory/active-topics.md (2026-05-20T17:07:23.235Z): OpenClaw contributor PR A
</continuity-manifest>
```

Observed result after fix: The helper successfully read the real files from the temporary workspace, parsed the rendered snapshot, preserved the `conversationSummary`, and prioritized `memory/recent/latest.md` ahead of the legacy active-topic file in the manifest.

What was not tested: This PR intentionally does not test `/new`, `/reset`, provider-backed extraction, command reply-path behavior, compaction hooks, or post-compaction recovery. Those are intentionally left for follow-up PRs after this local document/manifest layer is reviewed.

## Tests

- `pnpm exec oxfmt --check packages/memory-host-sdk/src/host/continuity.ts packages/memory-host-sdk/src/host/continuity.test.ts packages/memory-host-sdk/src/runtime-files.ts`
- `pnpm exec vitest run --config vitest.config.ts packages/memory-host-sdk/src/host/continuity.test.ts --reporter=dot`
- `pnpm tsgo`
- `pnpm exec oxlint packages/memory-host-sdk/src/host/continuity.ts packages/memory-host-sdk/src/host/continuity.test.ts packages/memory-host-sdk/src/runtime-files.ts`
