### PR TITLE
Materialize node-host inline interpreter eval before exec approval

### DIFF
--- a/docs/tools/exec-approvals-advanced.md
+++ b/docs/tools/exec-approvals-advanced.md
@@ -172,9 +172,10 @@ Approval-backed interpreter/runtime runs are intentionally conservative:
 Materialized inline-eval scripts contain the requested code. OpenClaw stores them under the state
 directory at `tmp/inline-eval/`, using deterministic content-derived filenames, private `0700`
 directories, and `0600` files. A later request for the same interpreter snapshot and code reuses the
-same path. OpenClaw removes entries older than 24 hours and prunes the oldest entries before the
-cache exceeds 256 files or 16 MiB. Operators should still apply the same local-access and backup
-policy used for other sensitive OpenClaw state.
+same path. While the node host remains running, an hourly sweep removes entries older than 24 hours;
+after a restart, stale entries are pruned before the next inline-eval materialization. OpenClaw also
+prunes the oldest entries before the cache exceeds 256 files or 16 MiB. Operators should still apply
+the same local-access and backup policy used for other sensitive OpenClaw state.
 
 When approvals are required, the exec tool returns immediately with an approval id. Use that id to
 correlate later approved-run system events (`Exec finished`, and `Exec running` when configured).

--- a/docs/tools/exec-approvals-advanced.md
+++ b/docs/tools/exec-approvals-advanced.md
@@ -160,7 +160,8 @@ Approval-backed interpreter/runtime runs are intentionally conservative:
   `node --eval CODE` forms are materialized into a private script before approval. The generated
   POSIX-shell launcher is bound as the concrete file snapshot while the original inline command
   remains visible in the approval preview. The launcher starts the requested interpreter once, so
-  runtime startup hooks preserve their normal eval behavior.
+  runtime startup hooks preserve their normal eval behavior. Shell option variables are removed
+  before the launcher starts so inherited shell configuration cannot suppress or trace the code.
 - Symlinked CPython virtual environments are supported on macOS, where the pinned launcher can
   preserve the venv identity. They fail closed on other POSIX hosts rather than running against the
   base interpreter with different packages or prefixes.

--- a/docs/tools/exec-approvals-advanced.md
+++ b/docs/tools/exec-approvals-advanced.md
@@ -161,6 +161,9 @@ Approval-backed interpreter/runtime runs are intentionally conservative:
   POSIX-shell launcher is bound as the concrete file snapshot while the original inline command
   remains visible in the approval preview. The launcher starts the requested interpreter once, so
   runtime startup hooks preserve their normal eval behavior.
+- Symlinked CPython virtual environments are supported on macOS, where the pinned launcher can
+  preserve the venv identity. They fail closed on other POSIX hosts rather than running against the
+  base interpreter with different packages or prefixes.
 - If OpenClaw cannot identify exactly one concrete local file for an interpreter/runtime command
   (for example package scripts, unsupported eval forms, runtime-specific loader chains, or ambiguous
   multi-file forms), approval-backed execution is denied instead of claiming semantic coverage it

--- a/docs/tools/exec-approvals-advanced.md
+++ b/docs/tools/exec-approvals-advanced.md
@@ -156,12 +156,25 @@ Approval-backed interpreter/runtime runs are intentionally conservative:
   file snapshot.
 - Common package-manager wrapper forms that still resolve to one direct local file (for example
   `pnpm exec`, `pnpm node`, `npm exec`, `npx`) are unwrapped before binding.
+- On non-Windows hosts, exact direct `python -c CODE`, `python3 -c CODE`, `node -e CODE`, and
+  `node --eval CODE` forms are materialized into a private script before approval. The generated
+  POSIX-shell launcher is bound as the concrete file snapshot while the original inline command
+  remains visible in the approval preview. The launcher starts the requested interpreter once, so
+  runtime startup hooks preserve their normal eval behavior.
 - If OpenClaw cannot identify exactly one concrete local file for an interpreter/runtime command
-  (for example package scripts, eval forms, runtime-specific loader chains, or ambiguous multi-file
-  forms), approval-backed execution is denied instead of claiming semantic coverage it does not
-  have.
+  (for example package scripts, unsupported eval forms, runtime-specific loader chains, or ambiguous
+  multi-file forms), approval-backed execution is denied instead of claiming semantic coverage it
+  does not have. Unsupported eval forms include shell-wrapped commands, extra interpreter flags,
+  trailing script arguments, and Node modes whose file execution semantics differ from eval.
 - For those workflows, prefer sandboxing, a separate host boundary, or an explicit trusted
   allowlist/full workflow where the operator accepts the broader runtime semantics.
+
+Materialized inline-eval scripts contain the requested code. OpenClaw stores them under the state
+directory at `tmp/inline-eval/`, using deterministic content-derived filenames, private `0700`
+directories, and `0600` files. A later request for the same interpreter snapshot and code reuses the
+same path. OpenClaw removes entries older than 24 hours and prunes the oldest entries before the
+cache exceeds 256 files or 16 MiB. Operators should still apply the same local-access and backup
+policy used for other sensitive OpenClaw state.
 
 When approvals are required, the exec tool returns immediately with an approval id. Use that id to
 correlate later approved-run system events (`Exec finished`, and `Exec running` when configured).

--- a/package.json
+++ b/package.json
@@ -1587,7 +1587,7 @@
     "crabbox:run": "node scripts/crabbox-wrapper.mjs run",
     "crabbox:stop": "node scripts/crabbox-wrapper.mjs stop",
     "crabbox:warmup": "node scripts/crabbox-wrapper.mjs warmup",
-    "deadcode:dependencies": "pnpm --config.minimum-release-age=0 dlx --package knip@6.8.0 knip --config config/knip.config.ts --production --no-progress --reporter compact --dependencies --no-config-hints",
+    "deadcode:dependencies": "pnpm --config.minimum-release-age=0 dlx knip@6.8.0 --config config/knip.config.ts --production --no-progress --reporter compact --dependencies --no-config-hints",
     "deadcode:exports": "node scripts/check-deadcode-exports.mjs",
     "deadcode:exports:update": "node scripts/check-deadcode-exports.mjs --update",
     "deadcode:knip": "pnpm --config.minimum-release-age=0 dlx --package knip@6.8.0 knip --config config/knip.config.ts --production --no-progress --reporter compact --files --dependencies",

--- a/src/infra/system-run-approval-binding.ts
+++ b/src/infra/system-run-approval-binding.ts
@@ -130,7 +130,7 @@ export function buildSystemRunApprovalBinding(params: {
   };
 }
 
-function argvMatches(expectedArgv: string[], actualArgv: string[]): boolean {
+export function systemRunArgvMatches(expectedArgv: string[], actualArgv: string[]): boolean {
   if (expectedArgv.length === 0 || expectedArgv.length !== actualArgv.length) {
     return false;
   }
@@ -210,7 +210,7 @@ export function matchSystemRunApprovalBinding(params: {
   actual: SystemRunApprovalBinding;
   actualEnvKeys: string[];
 }): SystemRunApprovalMatchResult {
-  if (!argvMatches(params.expected.argv, params.actual.argv)) {
+  if (!systemRunArgvMatches(params.expected.argv, params.actual.argv)) {
     return requestMismatch();
   }
   if (params.expected.cwd !== params.actual.cwd) {

--- a/src/node-host/invoke-system-run-approval-plan.ts
+++ b/src/node-host/invoke-system-run-approval-plan.ts
@@ -1,0 +1,76 @@
+import { normalizeNullableString } from "@openclaw/normalization-core/string-coerce";
+import type { SystemRunApprovalPlan } from "../infra/exec-approvals.js";
+import { isBlockedShellWrapperCommand } from "../infra/exec-wrapper-resolution.js";
+import { formatExecCommand, resolveSystemRunCommandRequest } from "../infra/system-run-command.js";
+import { materializeInlineEvalForApprovalSync } from "./invoke-system-run-inline-eval.js";
+import {
+  hardenApprovedExecutionPaths,
+  resolveMutableFileOperandSnapshotSync,
+} from "./invoke-system-run-plan.js";
+
+export function buildSystemRunApprovalPlan(params: {
+  command?: unknown;
+  rawCommand?: unknown;
+  cwd?: unknown;
+  agentId?: unknown;
+  sessionKey?: unknown;
+}): { ok: true; plan: SystemRunApprovalPlan } | { ok: false; message: string } {
+  const command = resolveSystemRunCommandRequest({
+    command: params.command,
+    rawCommand: params.rawCommand,
+  });
+  if (!command.ok) {
+    return { ok: false, message: command.message };
+  }
+  if (command.argv.length === 0) {
+    return { ok: false, message: "command required" };
+  }
+  if (command.shellPayload === null && isBlockedShellWrapperCommand(command.argv)) {
+    return {
+      ok: false,
+      message: "SYSTEM_RUN_DENIED: approval cannot safely bind this interpreter/runtime command",
+    };
+  }
+  const cwd = normalizeNullableString(params.cwd) ?? undefined;
+  const materializedInlineEval = materializeInlineEvalForApprovalSync(command.argv, cwd);
+  if (!materializedInlineEval.ok) {
+    return { ok: false, message: materializedInlineEval.message };
+  }
+  const approvalArgv = materializedInlineEval.command?.argv ?? command.argv;
+  const hardening = hardenApprovedExecutionPaths({
+    approvedByAsk: true,
+    argv: approvalArgv,
+    shellCommand: command.shellPayload,
+    cwd,
+  });
+  if (!hardening.ok) {
+    return { ok: false, message: hardening.message };
+  }
+  const commandText = formatExecCommand(hardening.argv);
+  const commandPreview =
+    materializedInlineEval.command !== null
+      ? command.commandText
+      : command.previewText?.trim() && command.previewText.trim() !== commandText
+        ? command.previewText.trim()
+        : null;
+  const mutableFileOperand = resolveMutableFileOperandSnapshotSync({
+    argv: hardening.argv,
+    cwd: hardening.cwd,
+    shellCommand: command.shellPayload,
+  });
+  if (!mutableFileOperand.ok) {
+    return { ok: false, message: mutableFileOperand.message };
+  }
+  return {
+    ok: true,
+    plan: {
+      argv: hardening.argv,
+      cwd: hardening.cwd ?? null,
+      commandText,
+      commandPreview,
+      agentId: normalizeNullableString(params.agentId),
+      sessionKey: normalizeNullableString(params.sessionKey),
+      mutableFileOperand: mutableFileOperand.snapshot ?? undefined,
+    },
+  };
+}

--- a/src/node-host/invoke-system-run-inline-eval.ts
+++ b/src/node-host/invoke-system-run-inline-eval.ts
@@ -381,7 +381,15 @@ export function materializeInlineEvalForApprovalSync(
   return {
     ok: true,
     command: {
-      argv: ["/bin/sh", materialized.scriptPath],
+      argv: [
+        "/usr/bin/env",
+        "-u",
+        "SHELLOPTS",
+        "-u",
+        "BASHOPTS",
+        "/bin/sh",
+        materialized.scriptPath,
+      ],
       scriptPath: materialized.scriptPath,
     },
   };

--- a/src/node-host/invoke-system-run-inline-eval.ts
+++ b/src/node-host/invoke-system-run-inline-eval.ts
@@ -23,10 +23,12 @@ type InlineEvalInterpreterSnapshot = {
 const INLINE_EVAL_CACHE_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 const INLINE_EVAL_CACHE_MAX_BYTES = 16 * 1024 * 1024;
 const INLINE_EVAL_CACHE_MAX_FILES = 256;
+const INLINE_EVAL_CACHE_SWEEP_INTERVAL_MS = 60 * 60 * 1000;
 const INLINE_EVAL_TEMP_MAX_AGE_MS = 60 * 60 * 1000;
 const MATERIALIZED_SCRIPT_PATTERN = /^[a-f0-9]{64}\.sh$/;
 const MATERIALIZED_TEMP_PATTERN = /^\.[a-f0-9]{64}\.\d+\.[a-f0-9-]+\.tmp$/;
 const INLINE_EVAL_ARGV_MARKER = "# openclaw-inline-eval-argv-v1:";
+const inlineEvalCacheSweepTimers = new Map<string, NodeJS.Timeout>();
 
 function resolveMaterializableInlineEvalCodeIndex(argv: string[], flag: string): number | null {
   if (argv.length !== 3) {
@@ -39,21 +41,41 @@ function quotePosixShellArg(value: string): string {
   return `'${value.replaceAll("'", `'\\''`)}'`;
 }
 
+function resolvePythonVenvLauncher(interpreter: InlineEvalInterpreterSnapshot): string | undefined {
+  if (interpreter.resolvedPath === interpreter.resolvedRealPath) {
+    return undefined;
+  }
+  const venvRoot = path.dirname(path.dirname(interpreter.resolvedPath));
+  try {
+    return fs.statSync(path.join(venvRoot, "pyvenv.cfg")).isFile()
+      ? interpreter.resolvedPath
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 function renderMaterializedInlineEvalScript(params: {
   normalizedExecutable: string;
   flag: string;
   code: string;
   originalArgv: string[];
   interpreter: InlineEvalInterpreterSnapshot;
+  pythonVenvLauncher?: string;
 }): string | null {
   const argvMarker = `${INLINE_EVAL_ARGV_MARKER}${Buffer.from(JSON.stringify(params.originalArgv)).toString("base64url")}`;
-  if (/^(?:python|python\d+(?:\.\d+)*|pypy|pypy\d*)$/.test(params.normalizedExecutable)) {
+  if (/^(?:python|python\d+(?:\.\d+)*)$/.test(params.normalizedExecutable)) {
+    const venvLines = params.pythonVenvLauncher
+      ? [
+          `__PYVENV_LAUNCHER__=${quotePosixShellArg(params.pythonVenvLauncher)}`,
+          "export __PYVENV_LAUNCHER__",
+        ]
+      : [];
     return [
       "#!/bin/sh",
       argvMarker,
       "set -eu",
-      `__PYVENV_LAUNCHER__=${quotePosixShellArg(params.interpreter.resolvedPath)}`,
-      "export __PYVENV_LAUNCHER__",
+      ...venvLines,
       `exec ${quotePosixShellArg(params.interpreter.resolvedRealPath)} ${quotePosixShellArg(params.flag)} ${quotePosixShellArg(params.code)}`,
       "",
     ].join("\n");
@@ -78,9 +100,10 @@ type CachedInlineEvalScript = {
 
 function pruneInlineEvalCacheSync(params: {
   dir: string;
-  targetPath: string;
+  targetPath?: string;
   incomingBytes: number;
-}): { ok: true } | { ok: false; message: string } {
+  incomingFiles: 0 | 1;
+}): { ok: true; remainingScripts: number } | { ok: false; message: string } {
   if (params.incomingBytes > INLINE_EVAL_CACHE_MAX_BYTES) {
     return { ok: false, message: "SYSTEM_RUN_DENIED: inline-eval script exceeds cache limit" };
   }
@@ -89,7 +112,7 @@ function pruneInlineEvalCacheSync(params: {
   try {
     for (const entry of fs.readdirSync(params.dir, { withFileTypes: true })) {
       const entryPath = path.join(params.dir, entry.name);
-      if (entryPath === params.targetPath) {
+      if (params.targetPath && entryPath === params.targetPath) {
         continue;
       }
       if (MATERIALIZED_TEMP_PATTERN.test(entry.name)) {
@@ -116,7 +139,7 @@ function pruneInlineEvalCacheSync(params: {
     scripts.sort((left, right) => left.mtimeMs - right.mtimeMs);
     let totalBytes = scripts.reduce((sum, script) => sum + script.size, 0);
     while (
-      scripts.length + 1 > INLINE_EVAL_CACHE_MAX_FILES ||
+      scripts.length + params.incomingFiles > INLINE_EVAL_CACHE_MAX_FILES ||
       totalBytes + params.incomingBytes > INLINE_EVAL_CACHE_MAX_BYTES
     ) {
       const oldest = scripts.shift();
@@ -126,10 +149,29 @@ function pruneInlineEvalCacheSync(params: {
       fs.rmSync(oldest.path, { force: true });
       totalBytes -= oldest.size;
     }
-    return { ok: true };
+    return { ok: true, remainingScripts: scripts.length + params.incomingFiles };
   } catch {
     return { ok: false, message: "SYSTEM_RUN_DENIED: unable to prune inline-eval cache" };
   }
+}
+
+function scheduleInlineEvalCacheSweep(inlineEvalDir: string): void {
+  if (inlineEvalCacheSweepTimers.has(inlineEvalDir)) {
+    return;
+  }
+  const timer = setInterval(() => {
+    const result = pruneInlineEvalCacheSync({
+      dir: inlineEvalDir,
+      incomingBytes: 0,
+      incomingFiles: 0,
+    });
+    if (!result.ok || result.remainingScripts === 0) {
+      clearInterval(timer);
+      inlineEvalCacheSweepTimers.delete(inlineEvalDir);
+    }
+  }, INLINE_EVAL_CACHE_SWEEP_INTERVAL_MS);
+  timer.unref();
+  inlineEvalCacheSweepTimers.set(inlineEvalDir, timer);
 }
 
 function ensureUserPrivateDirectory(dir: string): { ok: true } | { ok: false; message: string } {
@@ -158,6 +200,7 @@ function writeMaterializedInlineEvalScriptSync(params: {
   code: string;
   originalArgv: string[];
   interpreter: InlineEvalInterpreterSnapshot;
+  pythonVenvLauncher?: string;
 }): { ok: true; scriptPath: string } | { ok: false; message: string } {
   const scriptBody = renderMaterializedInlineEvalScript(params);
   if (scriptBody === null) {
@@ -184,6 +227,7 @@ function writeMaterializedInlineEvalScriptSync(params: {
         code: params.code,
         originalArgv: params.originalArgv,
         interpreterSnapshot: params.interpreter,
+        pythonVenvLauncher: params.pythonVenvLauncher,
         runtimeWrapper: "posix-shell-eval-v2",
       }),
     )
@@ -194,6 +238,7 @@ function writeMaterializedInlineEvalScriptSync(params: {
     dir: inlineEvalDir,
     targetPath: scriptPath,
     incomingBytes: scriptBytes,
+    incomingFiles: 1,
   });
   if (!pruned.ok) {
     return pruned;
@@ -207,6 +252,7 @@ function writeMaterializedInlineEvalScriptSync(params: {
     fs.chmodSync(tmpScriptPath, 0o600);
     fs.renameSync(tmpScriptPath, scriptPath);
     fs.chmodSync(scriptPath, 0o600);
+    scheduleInlineEvalCacheSweep(inlineEvalDir);
     return { ok: true, scriptPath };
   } catch {
     try {
@@ -283,8 +329,14 @@ export function materializeInlineEvalForApprovalSync(
   if (!hit) {
     return { ok: true, command: null };
   }
+  if (/^pypy\d*$/.test(hit.normalizedExecutable)) {
+    return {
+      ok: false,
+      message: "SYSTEM_RUN_DENIED: approval cannot safely bind this interpreter/runtime command",
+    };
+  }
   const supportedInterpreter =
-    /^(?:python|python\d+(?:\.\d+)*|pypy|pypy\d*)$/.test(hit.normalizedExecutable) ||
+    /^(?:python|python\d+(?:\.\d+)*)$/.test(hit.normalizedExecutable) ||
     hit.normalizedExecutable === "node" ||
     hit.normalizedExecutable === "nodejs";
   if (!supportedInterpreter || (hit.flag !== "-c" && hit.flag !== "-e" && hit.flag !== "--eval")) {
@@ -312,6 +364,9 @@ export function materializeInlineEvalForApprovalSync(
     code,
     originalArgv: argv,
     interpreter,
+    pythonVenvLauncher: hit.normalizedExecutable.startsWith("python")
+      ? resolvePythonVenvLauncher(interpreter)
+      : undefined,
   });
   if (!materialized.ok) {
     return materialized;

--- a/src/node-host/invoke-system-run-inline-eval.ts
+++ b/src/node-host/invoke-system-run-inline-eval.ts
@@ -358,15 +358,22 @@ export function materializeInlineEvalForApprovalSync(
   if (!interpreter) {
     return { ok: false, message: "SYSTEM_RUN_DENIED: unable to resolve inline-eval interpreter" };
   }
+  const pythonVenvLauncher = hit.normalizedExecutable.startsWith("python")
+    ? resolvePythonVenvLauncher(interpreter)
+    : undefined;
+  if (pythonVenvLauncher && process.platform !== "darwin") {
+    return {
+      ok: false,
+      message: "SYSTEM_RUN_DENIED: approval cannot safely bind this interpreter/runtime command",
+    };
+  }
   const materialized = writeMaterializedInlineEvalScriptSync({
     normalizedExecutable: hit.normalizedExecutable,
     flag: hit.flag,
     code,
     originalArgv: argv,
     interpreter,
-    pythonVenvLauncher: hit.normalizedExecutable.startsWith("python")
-      ? resolvePythonVenvLauncher(interpreter)
-      : undefined,
+    pythonVenvLauncher,
   });
   if (!materialized.ok) {
     return materialized;

--- a/src/node-host/invoke-system-run-inline-eval.ts
+++ b/src/node-host/invoke-system-run-inline-eval.ts
@@ -1,0 +1,326 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { normalizeNullableString } from "@openclaw/normalization-core/string-coerce";
+import { resolveStateDir } from "../config/paths.js";
+import {
+  detectInterpreterInlineEvalArgv,
+  type InterpreterInlineEvalHit,
+} from "../infra/command-analysis/inline-eval.js";
+import type { SystemRunApprovalPlan } from "../infra/exec-approvals.js";
+import { resolveCommandResolutionFromArgv } from "../infra/exec-command-resolution.js";
+
+type MaterializedInlineEvalCommand = {
+  argv: string[];
+  scriptPath: string;
+};
+
+type InlineEvalInterpreterSnapshot = {
+  resolvedPath: string;
+  resolvedRealPath: string;
+};
+
+const INLINE_EVAL_CACHE_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+const INLINE_EVAL_CACHE_MAX_BYTES = 16 * 1024 * 1024;
+const INLINE_EVAL_CACHE_MAX_FILES = 256;
+const INLINE_EVAL_TEMP_MAX_AGE_MS = 60 * 60 * 1000;
+const MATERIALIZED_SCRIPT_PATTERN = /^[a-f0-9]{64}\.sh$/;
+const MATERIALIZED_TEMP_PATTERN = /^\.[a-f0-9]{64}\.\d+\.[a-f0-9-]+\.tmp$/;
+const INLINE_EVAL_ARGV_MARKER = "# openclaw-inline-eval-argv-v1:";
+
+function resolveMaterializableInlineEvalCodeIndex(argv: string[], flag: string): number | null {
+  if (argv.length !== 3) {
+    return null;
+  }
+  return normalizeNullableString(argv[1]) === flag ? 2 : null;
+}
+
+function quotePosixShellArg(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+function renderMaterializedInlineEvalScript(params: {
+  normalizedExecutable: string;
+  flag: string;
+  code: string;
+  originalArgv: string[];
+  interpreter: InlineEvalInterpreterSnapshot;
+}): string | null {
+  const argvMarker = `${INLINE_EVAL_ARGV_MARKER}${Buffer.from(JSON.stringify(params.originalArgv)).toString("base64url")}`;
+  if (/^(?:python|python\d+(?:\.\d+)*|pypy|pypy\d*)$/.test(params.normalizedExecutable)) {
+    return [
+      "#!/bin/sh",
+      argvMarker,
+      "set -eu",
+      `__PYVENV_LAUNCHER__=${quotePosixShellArg(params.interpreter.resolvedPath)}`,
+      "export __PYVENV_LAUNCHER__",
+      `exec ${quotePosixShellArg(params.interpreter.resolvedRealPath)} ${quotePosixShellArg(params.flag)} ${quotePosixShellArg(params.code)}`,
+      "",
+    ].join("\n");
+  }
+  if (params.normalizedExecutable === "node" || params.normalizedExecutable === "nodejs") {
+    return [
+      "#!/bin/sh",
+      argvMarker,
+      "set -eu",
+      `exec ${quotePosixShellArg(params.interpreter.resolvedRealPath)} ${quotePosixShellArg(params.flag)} ${quotePosixShellArg(params.code)}`,
+      "",
+    ].join("\n");
+  }
+  return null;
+}
+
+type CachedInlineEvalScript = {
+  path: string;
+  mtimeMs: number;
+  size: number;
+};
+
+function pruneInlineEvalCacheSync(params: {
+  dir: string;
+  targetPath: string;
+  incomingBytes: number;
+}): { ok: true } | { ok: false; message: string } {
+  if (params.incomingBytes > INLINE_EVAL_CACHE_MAX_BYTES) {
+    return { ok: false, message: "SYSTEM_RUN_DENIED: inline-eval script exceeds cache limit" };
+  }
+  const now = Date.now();
+  const scripts: CachedInlineEvalScript[] = [];
+  try {
+    for (const entry of fs.readdirSync(params.dir, { withFileTypes: true })) {
+      const entryPath = path.join(params.dir, entry.name);
+      if (entryPath === params.targetPath) {
+        continue;
+      }
+      if (MATERIALIZED_TEMP_PATTERN.test(entry.name)) {
+        const stat = fs.lstatSync(entryPath);
+        if (now - stat.mtimeMs > INLINE_EVAL_TEMP_MAX_AGE_MS) {
+          fs.rmSync(entryPath, { force: true });
+        }
+        continue;
+      }
+      if (!MATERIALIZED_SCRIPT_PATTERN.test(entry.name)) {
+        continue;
+      }
+      const stat = fs.lstatSync(entryPath);
+      if (!stat.isFile() || stat.isSymbolicLink()) {
+        fs.rmSync(entryPath, { force: true });
+        continue;
+      }
+      if (now - stat.mtimeMs > INLINE_EVAL_CACHE_MAX_AGE_MS) {
+        fs.rmSync(entryPath, { force: true });
+        continue;
+      }
+      scripts.push({ path: entryPath, mtimeMs: stat.mtimeMs, size: stat.size });
+    }
+    scripts.sort((left, right) => left.mtimeMs - right.mtimeMs);
+    let totalBytes = scripts.reduce((sum, script) => sum + script.size, 0);
+    while (
+      scripts.length + 1 > INLINE_EVAL_CACHE_MAX_FILES ||
+      totalBytes + params.incomingBytes > INLINE_EVAL_CACHE_MAX_BYTES
+    ) {
+      const oldest = scripts.shift();
+      if (!oldest) {
+        break;
+      }
+      fs.rmSync(oldest.path, { force: true });
+      totalBytes -= oldest.size;
+    }
+    return { ok: true };
+  } catch {
+    return { ok: false, message: "SYSTEM_RUN_DENIED: unable to prune inline-eval cache" };
+  }
+}
+
+function ensureUserPrivateDirectory(dir: string): { ok: true } | { ok: false; message: string } {
+  try {
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+    const stat = fs.lstatSync(dir);
+    if (!stat.isDirectory() || stat.isSymbolicLink()) {
+      return { ok: false, message: "SYSTEM_RUN_DENIED: inline-eval temp dir is unsafe" };
+    }
+    const uid = typeof process.getuid === "function" ? process.getuid() : undefined;
+    if (uid !== undefined && typeof stat.uid === "number" && stat.uid !== uid) {
+      return { ok: false, message: "SYSTEM_RUN_DENIED: inline-eval temp dir owner mismatch" };
+    }
+    if ((stat.mode & 0o077) !== 0) {
+      fs.chmodSync(dir, 0o700);
+    }
+    return { ok: true };
+  } catch {
+    return { ok: false, message: "SYSTEM_RUN_DENIED: unable to prepare inline-eval temp dir" };
+  }
+}
+
+function writeMaterializedInlineEvalScriptSync(params: {
+  normalizedExecutable: string;
+  flag: string;
+  code: string;
+  originalArgv: string[];
+  interpreter: InlineEvalInterpreterSnapshot;
+}): { ok: true; scriptPath: string } | { ok: false; message: string } {
+  const scriptBody = renderMaterializedInlineEvalScript(params);
+  if (scriptBody === null) {
+    return { ok: false, message: "SYSTEM_RUN_DENIED: unable to materialize inline-eval script" };
+  }
+  const tmpDir = path.join(resolveStateDir(), "tmp");
+  const tmp = ensureUserPrivateDirectory(tmpDir);
+  if (!tmp.ok) {
+    return tmp;
+  }
+  const inlineEvalDir = path.join(tmpDir, "inline-eval");
+  const dir = ensureUserPrivateDirectory(inlineEvalDir);
+  if (!dir.ok) {
+    return dir;
+  }
+
+  const digest = crypto
+    .createHash("sha256")
+    .update(
+      JSON.stringify({
+        version: 1,
+        interpreter: params.normalizedExecutable,
+        flag: params.flag,
+        code: params.code,
+        originalArgv: params.originalArgv,
+        interpreterSnapshot: params.interpreter,
+        runtimeWrapper: "posix-shell-eval-v2",
+      }),
+    )
+    .digest("hex");
+  const scriptPath = path.join(inlineEvalDir, `${digest}.sh`);
+  const scriptBytes = Buffer.byteLength(scriptBody);
+  const pruned = pruneInlineEvalCacheSync({
+    dir: inlineEvalDir,
+    targetPath: scriptPath,
+    incomingBytes: scriptBytes,
+  });
+  if (!pruned.ok) {
+    return pruned;
+  }
+  const tmpScriptPath = path.join(
+    inlineEvalDir,
+    `.${digest}.${process.pid}.${crypto.randomUUID()}.tmp`,
+  );
+  try {
+    fs.writeFileSync(tmpScriptPath, scriptBody, { flag: "wx", mode: 0o600 });
+    fs.chmodSync(tmpScriptPath, 0o600);
+    fs.renameSync(tmpScriptPath, scriptPath);
+    fs.chmodSync(scriptPath, 0o600);
+    return { ok: true, scriptPath };
+  } catch {
+    try {
+      fs.rmSync(tmpScriptPath, { force: true });
+    } catch {
+      // Best effort cleanup only.
+    }
+    return { ok: false, message: "SYSTEM_RUN_DENIED: unable to materialize inline-eval script" };
+  }
+}
+
+function isMaterializedInlineEvalApprovalPlan(
+  plan: SystemRunApprovalPlan | null | undefined,
+): boolean {
+  if (!plan?.commandPreview || !plan.mutableFileOperand) {
+    return false;
+  }
+  const scriptPath = plan.argv[plan.mutableFileOperand.argvIndex];
+  if (!scriptPath) {
+    return false;
+  }
+  let scriptRealPath: string;
+  try {
+    scriptRealPath = fs.realpathSync(scriptPath);
+  } catch {
+    return false;
+  }
+  if (scriptRealPath !== plan.mutableFileOperand.path) {
+    return false;
+  }
+  let inlineEvalDirRealPath: string;
+  try {
+    inlineEvalDirRealPath = fs.realpathSync(path.join(resolveStateDir(), "tmp", "inline-eval"));
+  } catch {
+    return false;
+  }
+  return path.dirname(scriptRealPath) === inlineEvalDirRealPath;
+}
+
+export function detectMaterializedInlineEvalApprovalHit(
+  approvalPlan: SystemRunApprovalPlan | null,
+): InterpreterInlineEvalHit | null {
+  if (!approvalPlan || !isMaterializedInlineEvalApprovalPlan(approvalPlan)) {
+    return null;
+  }
+  const scriptPath = approvalPlan.argv[approvalPlan.mutableFileOperand?.argvIndex ?? -1];
+  if (!scriptPath) {
+    return null;
+  }
+  try {
+    const markerLine = fs.readFileSync(scriptPath, "utf8").split("\n", 3)[1];
+    if (!markerLine?.startsWith(INLINE_EVAL_ARGV_MARKER)) {
+      return null;
+    }
+    const encodedArgv = markerLine.slice(INLINE_EVAL_ARGV_MARKER.length);
+    const decoded = JSON.parse(Buffer.from(encodedArgv, "base64url").toString("utf8")) as unknown;
+    if (!Array.isArray(decoded) || !decoded.every((entry) => typeof entry === "string")) {
+      return null;
+    }
+    return detectInterpreterInlineEvalArgv(decoded);
+  } catch {
+    return null;
+  }
+}
+
+export function materializeInlineEvalForApprovalSync(
+  argv: string[],
+  cwd?: string,
+): { ok: true; command: MaterializedInlineEvalCommand | null } | { ok: false; message: string } {
+  if (process.platform === "win32") {
+    return { ok: true, command: null };
+  }
+  const hit = detectInterpreterInlineEvalArgv(argv);
+  if (!hit) {
+    return { ok: true, command: null };
+  }
+  const supportedInterpreter =
+    /^(?:python|python\d+(?:\.\d+)*|pypy|pypy\d*)$/.test(hit.normalizedExecutable) ||
+    hit.normalizedExecutable === "node" ||
+    hit.normalizedExecutable === "nodejs";
+  if (!supportedInterpreter || (hit.flag !== "-c" && hit.flag !== "-e" && hit.flag !== "--eval")) {
+    return { ok: true, command: null };
+  }
+  const codeIndex = resolveMaterializableInlineEvalCodeIndex(argv, hit.flag);
+  if (codeIndex === null) {
+    return { ok: true, command: null };
+  }
+  const code = argv[codeIndex] ?? "";
+  const resolution = resolveCommandResolutionFromArgv(argv, cwd);
+  const interpreter =
+    resolution?.execution.resolvedPath && resolution.execution.resolvedRealPath
+      ? {
+          resolvedPath: resolution.execution.resolvedPath,
+          resolvedRealPath: resolution.execution.resolvedRealPath,
+        }
+      : undefined;
+  if (!interpreter) {
+    return { ok: false, message: "SYSTEM_RUN_DENIED: unable to resolve inline-eval interpreter" };
+  }
+  const materialized = writeMaterializedInlineEvalScriptSync({
+    normalizedExecutable: hit.normalizedExecutable,
+    flag: hit.flag,
+    code,
+    originalArgv: argv,
+    interpreter,
+  });
+  if (!materialized.ok) {
+    return materialized;
+  }
+  return {
+    ok: true,
+    command: {
+      argv: ["/bin/sh", materialized.scriptPath],
+      scriptPath: materialized.scriptPath,
+    },
+  };
+}

--- a/src/node-host/invoke-system-run-plan.test.ts
+++ b/src/node-host/invoke-system-run-plan.test.ts
@@ -161,6 +161,68 @@ function withFakeRuntimeBins<T>(params: {
   );
 }
 
+function withInlineEvalStateDir<T>(run: (stateDir: string) => T): T {
+  const stateDir = createFixtureDir("openclaw-inline-eval-state-");
+  const oldStateDir = process.env.OPENCLAW_STATE_DIR;
+  process.env.OPENCLAW_STATE_DIR = stateDir;
+  try {
+    return run(stateDir);
+  } finally {
+    if (oldStateDir === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = oldStateDir;
+    }
+  }
+}
+
+function expectMaterializedInlineEvalPlan(params: {
+  command: string[];
+  cwd: string;
+  stateDir: string;
+  code: string;
+  extension: string;
+}) {
+  const prepared = buildSystemRunApprovalPlan({
+    command: params.command,
+    cwd: params.cwd,
+  });
+  expect(prepared.ok).toBe(true);
+  if (!prepared.ok) {
+    throw new Error("unreachable");
+  }
+  expect(prepared.plan.commandPreview).toBe(formatExecCommand(params.command));
+  expect(prepared.plan.argv).toHaveLength(params.command.length - 1);
+  const scriptPath = prepared.plan.argv[prepared.plan.argv.length - 1];
+  expect(path.dirname(scriptPath)).toBe(path.join(params.stateDir, "tmp", "inline-eval"));
+  expect(path.basename(scriptPath)).toMatch(new RegExp(`^[a-f0-9]{64}\\${params.extension}$`));
+  const scriptBody = fs.readFileSync(scriptPath, "utf8");
+  if (params.extension === ".py") {
+    expect(scriptBody).toContain(JSON.stringify(params.code));
+    expect(scriptBody).toContain("__openclaw_inline_eval_interpreter =");
+    expect(scriptBody).toContain("__openclaw_inline_eval_interpreter_realpath =");
+    expect(scriptBody).toContain("inline-eval interpreter changed before execution");
+    expect(scriptBody).toContain("__PYVENV_LAUNCHER__");
+    expect(scriptBody).toContain("__openclaw_inline_eval_os.execve");
+    expect(scriptBody).toContain("__openclaw_inline_eval_interpreter_realpath,");
+    expect(scriptBody).toContain("[__openclaw_inline_eval_interpreter, '-c'");
+  } else {
+    expect(scriptBody).toContain(JSON.stringify(params.code));
+    expect(scriptBody).toContain("process.execve");
+    expect(scriptBody).toContain("process.execPath");
+    expect(scriptBody).toContain("inline-eval exec replacement unavailable");
+  }
+  if (process.platform !== "win32") {
+    expect((fs.statSync(scriptPath).mode & 0o777).toString(8)).toBe("600");
+  }
+  expect(prepared.plan.mutableFileOperand).toEqual({
+    argvIndex: prepared.plan.argv.length - 1,
+    path: fs.realpathSync(scriptPath),
+    sha256: sha256FileSync(scriptPath),
+  });
+  return prepared.plan;
+}
+
 function uniqueRuntimeBinNames(
   cases: ReadonlyArray<Pick<RuntimeFixture, "binName" | "binNames">>,
 ): string[] {
@@ -681,6 +743,129 @@ describe("hardenApprovedExecutionPaths", () => {
       },
     });
   });
+
+  it.runIf(process.platform !== "win32")(
+    "materializes direct python inline eval before approval binding",
+    () => {
+      withFakeRuntimeBins({
+        binNames: ["python3"],
+        run: () => {
+          withInlineEvalStateDir((stateDir) => {
+            const tmp = createFixtureDir("openclaw-python-inline-eval-");
+            const code = "print('hello')\n";
+            const plan = expectMaterializedInlineEvalPlan({
+              command: ["python3", "-c", code],
+              cwd: tmp,
+              stateDir,
+              code,
+              extension: ".py",
+            });
+            expect(plan.argv[0]).toBe(path.join(sharedRuntimeBinDir, "python3"));
+            expect(plan.commandText).toBe(formatExecCommand(plan.argv));
+          });
+        },
+      });
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "materializes absolute python inline eval before approval binding",
+    () => {
+      withInlineEvalStateDir((stateDir) => {
+        const tmp = createFixtureDir("openclaw-absolute-python-inline-eval-");
+        const binDir = path.join(tmp, "venv", "bin");
+        const baseDir = path.join(tmp, "base", "bin");
+        fs.mkdirSync(binDir, { recursive: true });
+        fs.mkdirSync(baseDir, { recursive: true });
+        const pythonPath = path.join(binDir, "python3");
+        const basePythonPath = path.join(baseDir, "python3");
+        writeFakeRuntimeBin(baseDir, "python3");
+        fs.symlinkSync(basePythonPath, pythonPath);
+        const code = "import sys; print(sys.version)\n";
+        const plan = expectMaterializedInlineEvalPlan({
+          command: [pythonPath, "-c", code],
+          cwd: tmp,
+          stateDir,
+          code,
+          extension: ".py",
+        });
+        expect(plan.argv[0]).toBe(fs.realpathSync(basePythonPath));
+      });
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "materializes direct node inline eval before approval binding",
+    () => {
+      withFakeRuntimeBins({
+        binNames: ["node"],
+        run: () => {
+          withInlineEvalStateDir((stateDir) => {
+            const tmp = createFixtureDir("openclaw-node-inline-eval-");
+            const code = "console.log(123)\n";
+            const plan = expectMaterializedInlineEvalPlan({
+              command: ["node", "--eval", code],
+              cwd: tmp,
+              stateDir,
+              code,
+              extension: ".cjs",
+            });
+            expect(plan.argv[0]).toBe(path.join(sharedRuntimeBinDir, "node"));
+          });
+        },
+      });
+    },
+  );
+
+  it.runIf(process.platform !== "win32")("keeps existing real-script behavior unchanged", () => {
+    withFakeRuntimeBins({
+      binNames: ["python3"],
+      run: () => {
+        const tmp = createFixtureDir("openclaw-python-real-script-");
+        const scriptPath = path.join(tmp, "run.py");
+        fs.writeFileSync(scriptPath, "print('real')\n");
+        const prepared = buildSystemRunApprovalPlan({
+          command: ["python3", scriptPath],
+          cwd: tmp,
+        });
+        expect(prepared.ok).toBe(true);
+        if (!prepared.ok) {
+          throw new Error("unreachable");
+        }
+        expect(prepared.plan.argv).toEqual([
+          fs.realpathSync(path.join(sharedRuntimeBinDir, "python3")),
+          scriptPath,
+        ]);
+        expect(prepared.plan.commandPreview).toBeNull();
+        expect(prepared.plan.mutableFileOperand).toEqual({
+          argvIndex: 1,
+          path: fs.realpathSync(scriptPath),
+          sha256: sha256FileSync(scriptPath),
+        });
+      },
+    });
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "continues to fail closed for ambiguous inline eval forms",
+    () => {
+      withFakeRuntimeBins({
+        binNames: ["node", "python3"],
+        run: () => {
+          const tmp = createFixtureDir("openclaw-ambiguous-inline-eval-");
+          expectRuntimeApprovalDenied(["python3", "-B", "-c", "print(1)"], tmp);
+          expectRuntimeApprovalDenied(["python3", "-c", "print(1)", "arg"], tmp);
+          expectRuntimeApprovalDenied(["node", "-p", "1 + 1"], tmp);
+          expectRuntimeApprovalDenied(
+            ["node", "--input-type=module", "--eval", "import 'node:fs'"],
+            tmp,
+          );
+          expectRuntimeApprovalDenied(["node", "--eval", "console.log(process.argv)", "arg"], tmp);
+          expectRuntimeApprovalDenied(["sh", "-lc", 'python3 -c "print(1)"'], tmp);
+        },
+      });
+    },
+  );
 
   it("captures mutable shell script operands in approval plans", () => {
     withScriptOperandPlanFixture(

--- a/src/node-host/invoke-system-run-plan.test.ts
+++ b/src/node-host/invoke-system-run-plan.test.ts
@@ -764,7 +764,7 @@ describe("hardenApprovedExecutionPaths", () => {
     },
   );
 
-  it.runIf(process.platform !== "win32")(
+  it.runIf(process.platform === "darwin")(
     "materializes absolute python inline eval before approval binding",
     () => {
       withInlineEvalStateDir((stateDir) => {
@@ -789,6 +789,25 @@ describe("hardenApprovedExecutionPaths", () => {
           fs.realpathSync(basePythonPath),
         );
         expect(fs.readFileSync(plan.argv[1] ?? "", "utf8")).toContain("__PYVENV_LAUNCHER__");
+      });
+    },
+  );
+
+  it.runIf(process.platform !== "win32" && process.platform !== "darwin")(
+    "fails closed for symlinked Python virtual environments",
+    () => {
+      withInlineEvalStateDir(() => {
+        const tmp = createFixtureDir("openclaw-unsupported-python-venv-inline-eval-");
+        const binDir = path.join(tmp, "venv", "bin");
+        const baseDir = path.join(tmp, "base", "bin");
+        fs.mkdirSync(binDir, { recursive: true });
+        fs.mkdirSync(baseDir, { recursive: true });
+        fs.writeFileSync(path.join(tmp, "venv", "pyvenv.cfg"), "home = ../../base/bin\n");
+        const pythonPath = path.join(binDir, "python3");
+        writeFakeRuntimeBin(baseDir, "python3");
+        fs.symlinkSync(path.join(baseDir, "python3"), pythonPath);
+
+        expectRuntimeApprovalDenied([pythonPath, "-c", "print('safe')"], tmp);
       });
     },
   );

--- a/src/node-host/invoke-system-run-plan.test.ts
+++ b/src/node-host/invoke-system-run-plan.test.ts
@@ -193,8 +193,15 @@ function expectMaterializedInlineEvalPlan(params: {
     throw new Error("unreachable");
   }
   expect(prepared.plan.commandPreview).toBe(formatExecCommand(params.command));
-  expect(prepared.plan.argv).toHaveLength(2);
-  expect(prepared.plan.argv[0]).toBe(fs.realpathSync("/bin/sh"));
+  expect(prepared.plan.argv).toHaveLength(7);
+  expect(prepared.plan.argv.slice(0, 6)).toEqual([
+    fs.realpathSync("/usr/bin/env"),
+    "-u",
+    "SHELLOPTS",
+    "-u",
+    "BASHOPTS",
+    "/bin/sh",
+  ]);
   const scriptPath = prepared.plan.argv[prepared.plan.argv.length - 1];
   if (!scriptPath) {
     throw new Error("expected a materialized inline-eval script path");
@@ -754,7 +761,7 @@ describe("hardenApprovedExecutionPaths", () => {
               stateDir,
               code,
             });
-            expect(fs.readFileSync(plan.argv[1] ?? "", "utf8")).not.toContain(
+            expect(fs.readFileSync(plan.argv.at(-1) ?? "", "utf8")).not.toContain(
               "__PYVENV_LAUNCHER__",
             );
             expect(plan.commandText).toBe(formatExecCommand(plan.argv));
@@ -785,10 +792,10 @@ describe("hardenApprovedExecutionPaths", () => {
           stateDir,
           code,
         });
-        expect(fs.readFileSync(plan.argv[1] ?? "", "utf8")).toContain(
+        expect(fs.readFileSync(plan.argv.at(-1) ?? "", "utf8")).toContain(
           fs.realpathSync(basePythonPath),
         );
-        expect(fs.readFileSync(plan.argv[1] ?? "", "utf8")).toContain("__PYVENV_LAUNCHER__");
+        expect(fs.readFileSync(plan.argv.at(-1) ?? "", "utf8")).toContain("__PYVENV_LAUNCHER__");
       });
     },
   );
@@ -827,7 +834,7 @@ describe("hardenApprovedExecutionPaths", () => {
               stateDir,
               code,
             });
-            expect(fs.readFileSync(plan.argv[1] ?? "", "utf8")).toContain(
+            expect(fs.readFileSync(plan.argv.at(-1) ?? "", "utf8")).toContain(
               fs.realpathSync(path.join(sharedRuntimeBinDir, "node")),
             );
           });
@@ -861,11 +868,17 @@ describe("hardenApprovedExecutionPaths", () => {
         const run = spawnSync(executable, plan.argv.slice(1), {
           cwd: tmp,
           encoding: "utf8",
-          env: { ...process.env, NODE_OPTIONS: `--require=${hookPath}` },
+          env: {
+            ...process.env,
+            BASHOPTS: "extdebug",
+            NODE_OPTIONS: `--require=${hookPath}`,
+            SHELLOPTS: "noexec:xtrace",
+          },
         });
 
         expect(run.status).toBe(0);
         expect(run.stdout).toBe("ok");
+        expect(run.stderr).not.toContain("process.stdout.write");
         expect(fs.readFileSync(counterPath, "utf8")).toBe("started\n");
       });
     },
@@ -911,7 +924,7 @@ describe("hardenApprovedExecutionPaths", () => {
                 stateDir,
                 code: "console.log('expires')",
               });
-              const scriptPath = plan.argv[1];
+              const scriptPath = plan.argv.at(-1);
               if (!scriptPath) {
                 throw new Error("expected a materialized inline-eval script");
               }

--- a/src/node-host/invoke-system-run-plan.test.ts
+++ b/src/node-host/invoke-system-run-plan.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 /** Tests system.run approval plans, cwd snapshots, and mutable script operand binding. */
 import { createHash } from "node:crypto";
 import fs from "node:fs";
@@ -6,8 +7,9 @@ import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { formatExecCommand } from "../infra/system-run-command.js";
 import { withEnv } from "../test-utils/env.js";
+import { buildSystemRunApprovalPlan } from "./invoke-system-run-approval-plan.js";
+import { detectMaterializedInlineEvalApprovalHit } from "./invoke-system-run-inline-eval.js";
 import {
-  buildSystemRunApprovalPlan,
   hardenApprovedExecutionPaths,
   revalidateApprovedMutableFileOperand,
   resolveMutableFileOperandSnapshotSync,
@@ -181,7 +183,6 @@ function expectMaterializedInlineEvalPlan(params: {
   cwd: string;
   stateDir: string;
   code: string;
-  extension: string;
 }) {
   const prepared = buildSystemRunApprovalPlan({
     command: params.command,
@@ -192,25 +193,21 @@ function expectMaterializedInlineEvalPlan(params: {
     throw new Error("unreachable");
   }
   expect(prepared.plan.commandPreview).toBe(formatExecCommand(params.command));
-  expect(prepared.plan.argv).toHaveLength(params.command.length - 1);
+  expect(prepared.plan.argv).toHaveLength(2);
+  expect(prepared.plan.argv[0]).toBe(fs.realpathSync("/bin/sh"));
   const scriptPath = prepared.plan.argv[prepared.plan.argv.length - 1];
+  if (!scriptPath) {
+    throw new Error("expected a materialized inline-eval script path");
+  }
   expect(path.dirname(scriptPath)).toBe(path.join(params.stateDir, "tmp", "inline-eval"));
-  expect(path.basename(scriptPath)).toMatch(new RegExp(`^[a-f0-9]{64}\\${params.extension}$`));
+  expect(path.basename(scriptPath)).toMatch(/^[a-f0-9]{64}\.sh$/);
   const scriptBody = fs.readFileSync(scriptPath, "utf8");
-  if (params.extension === ".py") {
-    expect(scriptBody).toContain(JSON.stringify(params.code));
-    expect(scriptBody).toContain("__openclaw_inline_eval_interpreter =");
-    expect(scriptBody).toContain("__openclaw_inline_eval_interpreter_realpath =");
-    expect(scriptBody).toContain("inline-eval interpreter changed before execution");
+  expect(scriptBody).toContain("#!/bin/sh");
+  expect(scriptBody).toContain("exec ");
+  if (params.command[0]?.toLowerCase().includes("python")) {
     expect(scriptBody).toContain("__PYVENV_LAUNCHER__");
-    expect(scriptBody).toContain("__openclaw_inline_eval_os.execve");
-    expect(scriptBody).toContain("__openclaw_inline_eval_interpreter_realpath,");
-    expect(scriptBody).toContain("[__openclaw_inline_eval_interpreter, '-c'");
   } else {
-    expect(scriptBody).toContain(JSON.stringify(params.code));
-    expect(scriptBody).toContain("process.execve");
-    expect(scriptBody).toContain("process.execPath");
-    expect(scriptBody).toContain("inline-eval exec replacement unavailable");
+    expect(scriptBody).not.toContain("NODE_OPTIONS");
   }
   if (process.platform !== "win32") {
     expect((fs.statSync(scriptPath).mode & 0o777).toString(8)).toBe("600");
@@ -758,9 +755,7 @@ describe("hardenApprovedExecutionPaths", () => {
               cwd: tmp,
               stateDir,
               code,
-              extension: ".py",
             });
-            expect(plan.argv[0]).toBe(path.join(sharedRuntimeBinDir, "python3"));
             expect(plan.commandText).toBe(formatExecCommand(plan.argv));
           });
         },
@@ -787,9 +782,10 @@ describe("hardenApprovedExecutionPaths", () => {
           cwd: tmp,
           stateDir,
           code,
-          extension: ".py",
         });
-        expect(plan.argv[0]).toBe(fs.realpathSync(basePythonPath));
+        expect(fs.readFileSync(plan.argv[1] ?? "", "utf8")).toContain(
+          fs.realpathSync(basePythonPath),
+        );
       });
     },
   );
@@ -808,9 +804,96 @@ describe("hardenApprovedExecutionPaths", () => {
               cwd: tmp,
               stateDir,
               code,
-              extension: ".cjs",
             });
-            expect(plan.argv[0]).toBe(path.join(sharedRuntimeBinDir, "node"));
+            expect(fs.readFileSync(plan.argv[1] ?? "", "utf8")).toContain(
+              fs.realpathSync(path.join(sharedRuntimeBinDir, "node")),
+            );
+          });
+        },
+      });
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "starts Node once when dispatching a materialized inline eval",
+    () => {
+      withInlineEvalStateDir((stateDir) => {
+        const tmp = createFixtureDir("openclaw-node-inline-eval-startup-");
+        const hookPath = path.join(tmp, "startup-hook.cjs");
+        const counterPath = path.join(tmp, "startup-count.txt");
+        fs.writeFileSync(
+          hookPath,
+          `require("node:fs").appendFileSync(${JSON.stringify(counterPath)}, "started\\n");\n`,
+        );
+        const plan = expectMaterializedInlineEvalPlan({
+          command: [process.execPath, "--eval", "process.stdout.write('ok')"],
+          cwd: tmp,
+          stateDir,
+          code: "process.stdout.write('ok')",
+        });
+        const executable = plan.argv[0];
+        if (!executable) {
+          throw new Error("expected a materialized inline-eval launcher");
+        }
+
+        const run = spawnSync(executable, plan.argv.slice(1), {
+          cwd: tmp,
+          encoding: "utf8",
+          env: { ...process.env, NODE_OPTIONS: `--require=${hookPath}` },
+        });
+
+        expect(run.status).toBe(0);
+        expect(run.stdout).toBe("ok");
+        expect(fs.readFileSync(counterPath, "utf8")).toBe("started\n");
+      });
+    },
+  );
+
+  it.runIf(process.platform !== "win32")("prunes expired materialized inline-eval scripts", () => {
+    withFakeRuntimeBins({
+      binNames: ["node"],
+      run: () => {
+        withInlineEvalStateDir((stateDir) => {
+          const inlineEvalDir = path.join(stateDir, "tmp", "inline-eval");
+          fs.mkdirSync(inlineEvalDir, { recursive: true });
+          const expiredPath = path.join(inlineEvalDir, `${"0".repeat(64)}.sh`);
+          fs.writeFileSync(expiredPath, "#!/bin/sh\n");
+          const expiredAt = new Date(Date.now() - 25 * 60 * 60 * 1000);
+          fs.utimesSync(expiredPath, expiredAt, expiredAt);
+
+          expectMaterializedInlineEvalPlan({
+            command: ["node", "--eval", "console.log('fresh')"],
+            cwd: createFixtureDir("openclaw-node-inline-eval-prune-"),
+            stateDir,
+            code: "console.log('fresh')",
+          });
+
+          expect(fs.existsSync(expiredPath)).toBe(false);
+        });
+      },
+    });
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "recovers inline-eval policy metadata when code ends in a backslash",
+    () => {
+      withFakeRuntimeBins({
+        binNames: ["python3"],
+        run: () => {
+          withInlineEvalStateDir((stateDir) => {
+            const code = "print('ok') # \\";
+            const plan = expectMaterializedInlineEvalPlan({
+              command: ["python3", "-c", code],
+              cwd: createFixtureDir("openclaw-python-inline-eval-backslash-"),
+              stateDir,
+              code,
+            });
+
+            expect(detectMaterializedInlineEvalApprovalHit(plan)).toMatchObject({
+              normalizedExecutable: "python3",
+              flag: "-c",
+              argv: ["python3", "-c", code],
+            });
           });
         },
       });

--- a/src/node-host/invoke-system-run-plan.test.ts
+++ b/src/node-host/invoke-system-run-plan.test.ts
@@ -204,9 +204,7 @@ function expectMaterializedInlineEvalPlan(params: {
   const scriptBody = fs.readFileSync(scriptPath, "utf8");
   expect(scriptBody).toContain("#!/bin/sh");
   expect(scriptBody).toContain("exec ");
-  if (params.command[0]?.toLowerCase().includes("python")) {
-    expect(scriptBody).toContain("__PYVENV_LAUNCHER__");
-  } else {
+  if (!params.command[0]?.toLowerCase().includes("python")) {
     expect(scriptBody).not.toContain("NODE_OPTIONS");
   }
   if (process.platform !== "win32") {
@@ -756,6 +754,9 @@ describe("hardenApprovedExecutionPaths", () => {
               stateDir,
               code,
             });
+            expect(fs.readFileSync(plan.argv[1] ?? "", "utf8")).not.toContain(
+              "__PYVENV_LAUNCHER__",
+            );
             expect(plan.commandText).toBe(formatExecCommand(plan.argv));
           });
         },
@@ -774,6 +775,7 @@ describe("hardenApprovedExecutionPaths", () => {
         fs.mkdirSync(baseDir, { recursive: true });
         const pythonPath = path.join(binDir, "python3");
         const basePythonPath = path.join(baseDir, "python3");
+        fs.writeFileSync(path.join(tmp, "venv", "pyvenv.cfg"), "home = ../../base/bin\n");
         writeFakeRuntimeBin(baseDir, "python3");
         fs.symlinkSync(basePythonPath, pythonPath);
         const code = "import sys; print(sys.version)\n";
@@ -786,6 +788,7 @@ describe("hardenApprovedExecutionPaths", () => {
         expect(fs.readFileSync(plan.argv[1] ?? "", "utf8")).toContain(
           fs.realpathSync(basePythonPath),
         );
+        expect(fs.readFileSync(plan.argv[1] ?? "", "utf8")).toContain("__PYVENV_LAUNCHER__");
       });
     },
   );
@@ -875,6 +878,38 @@ describe("hardenApprovedExecutionPaths", () => {
   });
 
   it.runIf(process.platform !== "win32")(
+    "sweeps materialized inline-eval scripts while the host remains active",
+    () => {
+      vi.useFakeTimers();
+      try {
+        withFakeRuntimeBins({
+          binNames: ["node"],
+          run: () => {
+            withInlineEvalStateDir((stateDir) => {
+              const plan = expectMaterializedInlineEvalPlan({
+                command: ["node", "--eval", "console.log('expires')"],
+                cwd: createFixtureDir("openclaw-node-inline-eval-sweep-"),
+                stateDir,
+                code: "console.log('expires')",
+              });
+              const scriptPath = plan.argv[1];
+              if (!scriptPath) {
+                throw new Error("expected a materialized inline-eval script");
+              }
+
+              vi.advanceTimersByTime(25 * 60 * 60 * 1000);
+
+              expect(fs.existsSync(scriptPath)).toBe(false);
+            });
+          },
+        });
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
     "recovers inline-eval policy metadata when code ends in a backslash",
     () => {
       withFakeRuntimeBins({
@@ -933,7 +968,7 @@ describe("hardenApprovedExecutionPaths", () => {
     "continues to fail closed for ambiguous inline eval forms",
     () => {
       withFakeRuntimeBins({
-        binNames: ["node", "python3"],
+        binNames: ["node", "python3", "pypy3"],
         run: () => {
           const tmp = createFixtureDir("openclaw-ambiguous-inline-eval-");
           expectRuntimeApprovalDenied(["python3", "-B", "-c", "print(1)"], tmp);
@@ -944,6 +979,7 @@ describe("hardenApprovedExecutionPaths", () => {
             tmp,
           );
           expectRuntimeApprovalDenied(["node", "--eval", "console.log(process.argv)", "arg"], tmp);
+          expectRuntimeApprovalDenied(["pypy3", "-c", "print(1)"], tmp);
           expectRuntimeApprovalDenied(["sh", "-lc", 'python3 -c "print(1)"'], tmp);
         },
       });

--- a/src/node-host/invoke-system-run-plan.ts
+++ b/src/node-host/invoke-system-run-plan.ts
@@ -7,6 +7,8 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeNullableString,
 } from "@openclaw/normalization-core/string-coerce";
+import { resolveStateDir } from "../config/paths.js";
+import { detectInterpreterInlineEvalArgv } from "../infra/command-analysis/inline-eval.js";
 import type {
   SystemRunApprovalFileOperand,
   SystemRunApprovalPlan,
@@ -157,12 +159,244 @@ const NODE_OPTIONS_WITH_FILE_VALUE = new Set([
 const RUBY_UNSAFE_APPROVAL_FLAGS = new Set(["-I", "-r", "--require"]);
 const PERL_UNSAFE_APPROVAL_FLAGS = new Set(["-I", "-M", "-m"]);
 
+type MaterializedInlineEvalCommand = {
+  argv: string[];
+  scriptPath: string;
+};
+
+type InlineEvalInterpreterSnapshot = {
+  resolvedPath: string;
+  resolvedRealPath: string;
+};
+
 function normalizeOptionFlag(token: string): string {
   return normalizeLowercaseStringOrEmpty(parseInlineOptionToken(token).name);
 }
 
 function readTrimmedArgToken(argv: readonly string[], index: number): string {
   return normalizeNullableString(argv[index]) ?? "";
+}
+
+function resolveInlineEvalScriptExtension(normalizedExecutable: string): string | null {
+  if (/^(?:python|python\d+(?:\.\d+)*|pypy|pypy\d*)$/.test(normalizedExecutable)) {
+    return ".py";
+  }
+  if (normalizedExecutable === "node" || normalizedExecutable === "nodejs") {
+    return ".cjs";
+  }
+  return null;
+}
+
+function resolveMaterializableInlineEvalCodeIndex(argv: string[], flag: string): number | null {
+  if (argv.length !== 3) {
+    return null;
+  }
+  return readTrimmedArgToken(argv, 1) === flag ? 2 : null;
+}
+
+function renderMaterializedInlineEvalScript(params: {
+  normalizedExecutable: string;
+  flag: string;
+  code: string;
+  interpreter?: InlineEvalInterpreterSnapshot;
+}): string | null {
+  if (/^(?:python|python\d+(?:\.\d+)*|pypy|pypy\d*)$/.test(params.normalizedExecutable)) {
+    if (!params.interpreter) {
+      return null;
+    }
+    return [
+      "import os as __openclaw_inline_eval_os",
+      "",
+      `__openclaw_inline_eval_interpreter = ${JSON.stringify(params.interpreter.resolvedPath)}`,
+      `__openclaw_inline_eval_interpreter_realpath = ${JSON.stringify(
+        params.interpreter.resolvedRealPath,
+      )}`,
+      "if (",
+      "    __openclaw_inline_eval_os.path.realpath(__openclaw_inline_eval_interpreter)",
+      "    != __openclaw_inline_eval_interpreter_realpath",
+      "):",
+      "    raise SystemExit('SYSTEM_RUN_DENIED: inline-eval interpreter changed before execution')",
+      `__openclaw_inline_eval_code = ${JSON.stringify(params.code)}`,
+      "__openclaw_inline_eval_env = __openclaw_inline_eval_os.environ.copy()",
+      "__openclaw_inline_eval_env['__PYVENV_LAUNCHER__'] = __openclaw_inline_eval_interpreter",
+      "__openclaw_inline_eval_os.execve(",
+      "    __openclaw_inline_eval_interpreter_realpath,",
+      "    [__openclaw_inline_eval_interpreter, '-c', __openclaw_inline_eval_code],",
+      "    __openclaw_inline_eval_env,",
+      ")",
+      "",
+    ].join("\n");
+  }
+  if (params.normalizedExecutable === "node" || params.normalizedExecutable === "nodejs") {
+    return [
+      `const __openclawInlineEvalFlag = ${JSON.stringify(params.flag)};`,
+      `const __openclawInlineEvalCode = ${JSON.stringify(params.code)};`,
+      'if (typeof process.execve !== "function") {',
+      '  throw new Error("SYSTEM_RUN_DENIED: inline-eval exec replacement unavailable");',
+      "}",
+      "process.execve(",
+      "  process.execPath,",
+      "  [process.execPath, __openclawInlineEvalFlag, __openclawInlineEvalCode],",
+      "  process.env,",
+      ");",
+      "",
+    ].join("\n");
+  }
+  return null;
+}
+
+function ensureUserPrivateDirectory(dir: string): { ok: true } | { ok: false; message: string } {
+  try {
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+    const stat = fs.lstatSync(dir);
+    if (!stat.isDirectory() || stat.isSymbolicLink()) {
+      return { ok: false, message: "SYSTEM_RUN_DENIED: inline-eval temp dir is unsafe" };
+    }
+    const uid = typeof process.getuid === "function" ? process.getuid() : undefined;
+    if (uid !== undefined && typeof stat.uid === "number" && stat.uid !== uid) {
+      return { ok: false, message: "SYSTEM_RUN_DENIED: inline-eval temp dir owner mismatch" };
+    }
+    if ((stat.mode & 0o077) !== 0) {
+      fs.chmodSync(dir, 0o700);
+    }
+    return { ok: true };
+  } catch {
+    return { ok: false, message: "SYSTEM_RUN_DENIED: unable to prepare inline-eval temp dir" };
+  }
+}
+
+function writeMaterializedInlineEvalScriptSync(params: {
+  normalizedExecutable: string;
+  flag: string;
+  code: string;
+  extension: string;
+  interpreter?: InlineEvalInterpreterSnapshot;
+}): { ok: true; scriptPath: string } | { ok: false; message: string } {
+  const scriptBody = renderMaterializedInlineEvalScript({
+    normalizedExecutable: params.normalizedExecutable,
+    flag: params.flag,
+    code: params.code,
+    interpreter: params.interpreter,
+  });
+  if (scriptBody === null) {
+    return { ok: false, message: "SYSTEM_RUN_DENIED: unable to materialize inline-eval script" };
+  }
+  const tmpDir = path.join(resolveStateDir(), "tmp");
+  const tmp = ensureUserPrivateDirectory(tmpDir);
+  if (!tmp.ok) {
+    return tmp;
+  }
+  const inlineEvalDir = path.join(tmpDir, "inline-eval");
+  const dir = ensureUserPrivateDirectory(inlineEvalDir);
+  if (!dir.ok) {
+    return dir;
+  }
+
+  const digest = crypto
+    .createHash("sha256")
+    .update(
+      JSON.stringify({
+        version: 1,
+        interpreter: params.normalizedExecutable,
+        flag: params.flag,
+        extension: params.extension,
+        code: params.code,
+        interpreterSnapshot: params.interpreter,
+        runtimeWrapper: "cwd-eval-v1",
+      }),
+    )
+    .digest("hex");
+  const scriptPath = path.join(inlineEvalDir, `${digest}${params.extension}`);
+  const tmpScriptPath = path.join(
+    inlineEvalDir,
+    `.${digest}.${process.pid}.${crypto.randomUUID()}.tmp`,
+  );
+  try {
+    fs.writeFileSync(tmpScriptPath, scriptBody, { flag: "wx", mode: 0o600 });
+    fs.chmodSync(tmpScriptPath, 0o600);
+    fs.renameSync(tmpScriptPath, scriptPath);
+    fs.chmodSync(scriptPath, 0o600);
+    return { ok: true, scriptPath };
+  } catch {
+    try {
+      fs.rmSync(tmpScriptPath, { force: true });
+    } catch {
+      // Best effort cleanup only.
+    }
+    return { ok: false, message: "SYSTEM_RUN_DENIED: unable to materialize inline-eval script" };
+  }
+}
+
+export function isMaterializedInlineEvalApprovalPlan(
+  plan: SystemRunApprovalPlan | null | undefined,
+): boolean {
+  if (!plan?.commandPreview || !plan.mutableFileOperand) {
+    return false;
+  }
+  const scriptPath = plan.argv[plan.mutableFileOperand.argvIndex];
+  if (!scriptPath) {
+    return false;
+  }
+  let scriptRealPath: string;
+  try {
+    scriptRealPath = fs.realpathSync(scriptPath);
+  } catch {
+    return false;
+  }
+  if (scriptRealPath !== plan.mutableFileOperand.path) {
+    return false;
+  }
+  const normalizedScriptPath = path.normalize(scriptRealPath);
+  const inlineEvalSegment = `${path.sep}tmp${path.sep}inline-eval${path.sep}`;
+  return normalizedScriptPath.includes(inlineEvalSegment);
+}
+
+export function materializeInlineEvalForApprovalSync(
+  argv: string[],
+  cwd?: string,
+): { ok: true; command: MaterializedInlineEvalCommand | null } | { ok: false; message: string } {
+  if (process.platform === "win32") {
+    return { ok: true, command: null };
+  }
+  const hit = detectInterpreterInlineEvalArgv(argv);
+  if (!hit) {
+    return { ok: true, command: null };
+  }
+  const extension = resolveInlineEvalScriptExtension(hit.normalizedExecutable);
+  if (!extension || (hit.flag !== "-c" && hit.flag !== "-e" && hit.flag !== "--eval")) {
+    return { ok: true, command: null };
+  }
+  const codeIndex = resolveMaterializableInlineEvalCodeIndex(argv, hit.flag);
+  if (codeIndex === null) {
+    return { ok: true, command: null };
+  }
+  const code = argv[codeIndex] ?? "";
+  const resolution = resolveCommandResolutionFromArgv(argv, cwd);
+  const interpreter =
+    resolution?.execution.resolvedPath && resolution.execution.resolvedRealPath
+      ? {
+          resolvedPath: resolution.execution.resolvedPath,
+          resolvedRealPath: resolution.execution.resolvedRealPath,
+        }
+      : undefined;
+  const materialized = writeMaterializedInlineEvalScriptSync({
+    normalizedExecutable: hit.normalizedExecutable,
+    flag: hit.flag,
+    code,
+    extension,
+    interpreter,
+  });
+  if (!materialized.ok) {
+    return materialized;
+  }
+  const flagIndex = codeIndex - 1;
+  return {
+    ok: true,
+    command: {
+      argv: [...argv.slice(0, flagIndex), materialized.scriptPath, ...argv.slice(codeIndex + 1)],
+      scriptPath: materialized.scriptPath,
+    },
+  };
 }
 
 const POSIX_SHELL_OPTIONS_WITH_VALUE = new Set([
@@ -1139,9 +1373,17 @@ export function buildSystemRunApprovalPlan(params: {
       message: "SYSTEM_RUN_DENIED: approval cannot safely bind this interpreter/runtime command",
     };
   }
+  const materializedInlineEval = materializeInlineEvalForApprovalSync(
+    command.argv,
+    normalizeNullableString(params.cwd) ?? undefined,
+  );
+  if (!materializedInlineEval.ok) {
+    return { ok: false, message: materializedInlineEval.message };
+  }
+  const approvalArgv = materializedInlineEval.command?.argv ?? command.argv;
   const hardening = hardenApprovedExecutionPaths({
     approvedByAsk: true,
-    argv: command.argv,
+    argv: approvalArgv,
     shellCommand: command.shellPayload,
     cwd: normalizeNullableString(params.cwd) ?? undefined,
   });
@@ -1150,9 +1392,11 @@ export function buildSystemRunApprovalPlan(params: {
   }
   const commandText = formatExecCommand(hardening.argv);
   const commandPreview =
-    command.previewText?.trim() && command.previewText.trim() !== commandText
-      ? command.previewText.trim()
-      : null;
+    materializedInlineEval.command !== null
+      ? command.commandText
+      : command.previewText?.trim() && command.previewText.trim() !== commandText
+        ? command.previewText.trim()
+        : null;
   const mutableFileOperand = resolveMutableFileOperandSnapshotSync({
     argv: hardening.argv,
     cwd: hardening.cwd,

--- a/src/node-host/invoke-system-run-plan.ts
+++ b/src/node-host/invoke-system-run-plan.ts
@@ -7,16 +7,10 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeNullableString,
 } from "@openclaw/normalization-core/string-coerce";
-import { resolveStateDir } from "../config/paths.js";
-import { detectInterpreterInlineEvalArgv } from "../infra/command-analysis/inline-eval.js";
-import type {
-  SystemRunApprovalFileOperand,
-  SystemRunApprovalPlan,
-} from "../infra/exec-approvals.js";
+import type { SystemRunApprovalFileOperand } from "../infra/exec-approvals.js";
 import { resolveCommandResolutionFromArgv } from "../infra/exec-command-resolution.js";
 import { isInterpreterLikeSafeBin } from "../infra/exec-safe-bin-runtime-policy.js";
 import {
-  isBlockedShellWrapperCommand,
   POSIX_SHELL_WRAPPERS,
   normalizeExecutableToken,
   unwrapKnownDispatchWrapperInvocation,
@@ -37,7 +31,6 @@ import {
   POSIX_INLINE_COMMAND_FLAGS,
   resolveInlineCommandMatch,
 } from "../infra/shell-inline-command.js";
-import { formatExecCommand, resolveSystemRunCommandRequest } from "../infra/system-run-command.js";
 import { splitShellArgs } from "../utils/shell-argv.js";
 
 /** File identity snapshot for the approved working directory. */
@@ -159,244 +152,12 @@ const NODE_OPTIONS_WITH_FILE_VALUE = new Set([
 const RUBY_UNSAFE_APPROVAL_FLAGS = new Set(["-I", "-r", "--require"]);
 const PERL_UNSAFE_APPROVAL_FLAGS = new Set(["-I", "-M", "-m"]);
 
-type MaterializedInlineEvalCommand = {
-  argv: string[];
-  scriptPath: string;
-};
-
-type InlineEvalInterpreterSnapshot = {
-  resolvedPath: string;
-  resolvedRealPath: string;
-};
-
 function normalizeOptionFlag(token: string): string {
   return normalizeLowercaseStringOrEmpty(parseInlineOptionToken(token).name);
 }
 
 function readTrimmedArgToken(argv: readonly string[], index: number): string {
   return normalizeNullableString(argv[index]) ?? "";
-}
-
-function resolveInlineEvalScriptExtension(normalizedExecutable: string): string | null {
-  if (/^(?:python|python\d+(?:\.\d+)*|pypy|pypy\d*)$/.test(normalizedExecutable)) {
-    return ".py";
-  }
-  if (normalizedExecutable === "node" || normalizedExecutable === "nodejs") {
-    return ".cjs";
-  }
-  return null;
-}
-
-function resolveMaterializableInlineEvalCodeIndex(argv: string[], flag: string): number | null {
-  if (argv.length !== 3) {
-    return null;
-  }
-  return readTrimmedArgToken(argv, 1) === flag ? 2 : null;
-}
-
-function renderMaterializedInlineEvalScript(params: {
-  normalizedExecutable: string;
-  flag: string;
-  code: string;
-  interpreter?: InlineEvalInterpreterSnapshot;
-}): string | null {
-  if (/^(?:python|python\d+(?:\.\d+)*|pypy|pypy\d*)$/.test(params.normalizedExecutable)) {
-    if (!params.interpreter) {
-      return null;
-    }
-    return [
-      "import os as __openclaw_inline_eval_os",
-      "",
-      `__openclaw_inline_eval_interpreter = ${JSON.stringify(params.interpreter.resolvedPath)}`,
-      `__openclaw_inline_eval_interpreter_realpath = ${JSON.stringify(
-        params.interpreter.resolvedRealPath,
-      )}`,
-      "if (",
-      "    __openclaw_inline_eval_os.path.realpath(__openclaw_inline_eval_interpreter)",
-      "    != __openclaw_inline_eval_interpreter_realpath",
-      "):",
-      "    raise SystemExit('SYSTEM_RUN_DENIED: inline-eval interpreter changed before execution')",
-      `__openclaw_inline_eval_code = ${JSON.stringify(params.code)}`,
-      "__openclaw_inline_eval_env = __openclaw_inline_eval_os.environ.copy()",
-      "__openclaw_inline_eval_env['__PYVENV_LAUNCHER__'] = __openclaw_inline_eval_interpreter",
-      "__openclaw_inline_eval_os.execve(",
-      "    __openclaw_inline_eval_interpreter_realpath,",
-      "    [__openclaw_inline_eval_interpreter, '-c', __openclaw_inline_eval_code],",
-      "    __openclaw_inline_eval_env,",
-      ")",
-      "",
-    ].join("\n");
-  }
-  if (params.normalizedExecutable === "node" || params.normalizedExecutable === "nodejs") {
-    return [
-      `const __openclawInlineEvalFlag = ${JSON.stringify(params.flag)};`,
-      `const __openclawInlineEvalCode = ${JSON.stringify(params.code)};`,
-      'if (typeof process.execve !== "function") {',
-      '  throw new Error("SYSTEM_RUN_DENIED: inline-eval exec replacement unavailable");',
-      "}",
-      "process.execve(",
-      "  process.execPath,",
-      "  [process.execPath, __openclawInlineEvalFlag, __openclawInlineEvalCode],",
-      "  process.env,",
-      ");",
-      "",
-    ].join("\n");
-  }
-  return null;
-}
-
-function ensureUserPrivateDirectory(dir: string): { ok: true } | { ok: false; message: string } {
-  try {
-    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
-    const stat = fs.lstatSync(dir);
-    if (!stat.isDirectory() || stat.isSymbolicLink()) {
-      return { ok: false, message: "SYSTEM_RUN_DENIED: inline-eval temp dir is unsafe" };
-    }
-    const uid = typeof process.getuid === "function" ? process.getuid() : undefined;
-    if (uid !== undefined && typeof stat.uid === "number" && stat.uid !== uid) {
-      return { ok: false, message: "SYSTEM_RUN_DENIED: inline-eval temp dir owner mismatch" };
-    }
-    if ((stat.mode & 0o077) !== 0) {
-      fs.chmodSync(dir, 0o700);
-    }
-    return { ok: true };
-  } catch {
-    return { ok: false, message: "SYSTEM_RUN_DENIED: unable to prepare inline-eval temp dir" };
-  }
-}
-
-function writeMaterializedInlineEvalScriptSync(params: {
-  normalizedExecutable: string;
-  flag: string;
-  code: string;
-  extension: string;
-  interpreter?: InlineEvalInterpreterSnapshot;
-}): { ok: true; scriptPath: string } | { ok: false; message: string } {
-  const scriptBody = renderMaterializedInlineEvalScript({
-    normalizedExecutable: params.normalizedExecutable,
-    flag: params.flag,
-    code: params.code,
-    interpreter: params.interpreter,
-  });
-  if (scriptBody === null) {
-    return { ok: false, message: "SYSTEM_RUN_DENIED: unable to materialize inline-eval script" };
-  }
-  const tmpDir = path.join(resolveStateDir(), "tmp");
-  const tmp = ensureUserPrivateDirectory(tmpDir);
-  if (!tmp.ok) {
-    return tmp;
-  }
-  const inlineEvalDir = path.join(tmpDir, "inline-eval");
-  const dir = ensureUserPrivateDirectory(inlineEvalDir);
-  if (!dir.ok) {
-    return dir;
-  }
-
-  const digest = crypto
-    .createHash("sha256")
-    .update(
-      JSON.stringify({
-        version: 1,
-        interpreter: params.normalizedExecutable,
-        flag: params.flag,
-        extension: params.extension,
-        code: params.code,
-        interpreterSnapshot: params.interpreter,
-        runtimeWrapper: "cwd-eval-v1",
-      }),
-    )
-    .digest("hex");
-  const scriptPath = path.join(inlineEvalDir, `${digest}${params.extension}`);
-  const tmpScriptPath = path.join(
-    inlineEvalDir,
-    `.${digest}.${process.pid}.${crypto.randomUUID()}.tmp`,
-  );
-  try {
-    fs.writeFileSync(tmpScriptPath, scriptBody, { flag: "wx", mode: 0o600 });
-    fs.chmodSync(tmpScriptPath, 0o600);
-    fs.renameSync(tmpScriptPath, scriptPath);
-    fs.chmodSync(scriptPath, 0o600);
-    return { ok: true, scriptPath };
-  } catch {
-    try {
-      fs.rmSync(tmpScriptPath, { force: true });
-    } catch {
-      // Best effort cleanup only.
-    }
-    return { ok: false, message: "SYSTEM_RUN_DENIED: unable to materialize inline-eval script" };
-  }
-}
-
-export function isMaterializedInlineEvalApprovalPlan(
-  plan: SystemRunApprovalPlan | null | undefined,
-): boolean {
-  if (!plan?.commandPreview || !plan.mutableFileOperand) {
-    return false;
-  }
-  const scriptPath = plan.argv[plan.mutableFileOperand.argvIndex];
-  if (!scriptPath) {
-    return false;
-  }
-  let scriptRealPath: string;
-  try {
-    scriptRealPath = fs.realpathSync(scriptPath);
-  } catch {
-    return false;
-  }
-  if (scriptRealPath !== plan.mutableFileOperand.path) {
-    return false;
-  }
-  const normalizedScriptPath = path.normalize(scriptRealPath);
-  const inlineEvalSegment = `${path.sep}tmp${path.sep}inline-eval${path.sep}`;
-  return normalizedScriptPath.includes(inlineEvalSegment);
-}
-
-export function materializeInlineEvalForApprovalSync(
-  argv: string[],
-  cwd?: string,
-): { ok: true; command: MaterializedInlineEvalCommand | null } | { ok: false; message: string } {
-  if (process.platform === "win32") {
-    return { ok: true, command: null };
-  }
-  const hit = detectInterpreterInlineEvalArgv(argv);
-  if (!hit) {
-    return { ok: true, command: null };
-  }
-  const extension = resolveInlineEvalScriptExtension(hit.normalizedExecutable);
-  if (!extension || (hit.flag !== "-c" && hit.flag !== "-e" && hit.flag !== "--eval")) {
-    return { ok: true, command: null };
-  }
-  const codeIndex = resolveMaterializableInlineEvalCodeIndex(argv, hit.flag);
-  if (codeIndex === null) {
-    return { ok: true, command: null };
-  }
-  const code = argv[codeIndex] ?? "";
-  const resolution = resolveCommandResolutionFromArgv(argv, cwd);
-  const interpreter =
-    resolution?.execution.resolvedPath && resolution.execution.resolvedRealPath
-      ? {
-          resolvedPath: resolution.execution.resolvedPath,
-          resolvedRealPath: resolution.execution.resolvedRealPath,
-        }
-      : undefined;
-  const materialized = writeMaterializedInlineEvalScriptSync({
-    normalizedExecutable: hit.normalizedExecutable,
-    flag: hit.flag,
-    code,
-    extension,
-    interpreter,
-  });
-  if (!materialized.ok) {
-    return materialized;
-  }
-  const flagIndex = codeIndex - 1;
-  return {
-    ok: true,
-    command: {
-      argv: [...argv.slice(0, flagIndex), materialized.scriptPath, ...argv.slice(codeIndex + 1)],
-      scriptPath: materialized.scriptPath,
-    },
-  };
 }
 
 const POSIX_SHELL_OPTIONS_WITH_VALUE = new Set([
@@ -1347,74 +1108,5 @@ export function hardenApprovedExecutionPaths(params: {
     argvChanged: true,
     cwd: hardenedCwd,
     approvedCwdSnapshot,
-  };
-}
-
-export function buildSystemRunApprovalPlan(params: {
-  command?: unknown;
-  rawCommand?: unknown;
-  cwd?: unknown;
-  agentId?: unknown;
-  sessionKey?: unknown;
-}): { ok: true; plan: SystemRunApprovalPlan } | { ok: false; message: string } {
-  const command = resolveSystemRunCommandRequest({
-    command: params.command,
-    rawCommand: params.rawCommand,
-  });
-  if (!command.ok) {
-    return { ok: false, message: command.message };
-  }
-  if (command.argv.length === 0) {
-    return { ok: false, message: "command required" };
-  }
-  if (command.shellPayload === null && isBlockedShellWrapperCommand(command.argv)) {
-    return {
-      ok: false,
-      message: "SYSTEM_RUN_DENIED: approval cannot safely bind this interpreter/runtime command",
-    };
-  }
-  const materializedInlineEval = materializeInlineEvalForApprovalSync(
-    command.argv,
-    normalizeNullableString(params.cwd) ?? undefined,
-  );
-  if (!materializedInlineEval.ok) {
-    return { ok: false, message: materializedInlineEval.message };
-  }
-  const approvalArgv = materializedInlineEval.command?.argv ?? command.argv;
-  const hardening = hardenApprovedExecutionPaths({
-    approvedByAsk: true,
-    argv: approvalArgv,
-    shellCommand: command.shellPayload,
-    cwd: normalizeNullableString(params.cwd) ?? undefined,
-  });
-  if (!hardening.ok) {
-    return { ok: false, message: hardening.message };
-  }
-  const commandText = formatExecCommand(hardening.argv);
-  const commandPreview =
-    materializedInlineEval.command !== null
-      ? command.commandText
-      : command.previewText?.trim() && command.previewText.trim() !== commandText
-        ? command.previewText.trim()
-        : null;
-  const mutableFileOperand = resolveMutableFileOperandSnapshotSync({
-    argv: hardening.argv,
-    cwd: hardening.cwd,
-    shellCommand: command.shellPayload,
-  });
-  if (!mutableFileOperand.ok) {
-    return { ok: false, message: mutableFileOperand.message };
-  }
-  return {
-    ok: true,
-    plan: {
-      argv: hardening.argv,
-      cwd: hardening.cwd ?? null,
-      commandText,
-      commandPreview,
-      agentId: normalizeNullableString(params.agentId),
-      sessionKey: normalizeNullableString(params.sessionKey),
-      mutableFileOperand: mutableFileOperand.snapshot ?? undefined,
-    },
   };
 }

--- a/src/node-host/invoke-system-run.test.ts
+++ b/src/node-host/invoke-system-run.test.ts
@@ -1613,6 +1613,205 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     });
   });
 
+  it.runIf(process.platform !== "win32")(
+    "dispatches approved inline eval through the materialized script with a pinned interpreter realpath",
+    async () => {
+      const tmp = createFixtureDir("openclaw-inline-eval-dispatch-");
+      const binDir = path.join(tmp, "venv", "bin");
+      const baseDir = path.join(tmp, "base", "bin");
+      fs.mkdirSync(binDir, { recursive: true });
+      fs.mkdirSync(baseDir, { recursive: true });
+      const basePythonPath = createTempExecutable({ dir: baseDir, name: "python3" });
+      const pythonPath = path.join(binDir, "python3");
+      fs.symlinkSync(basePythonPath, pythonPath);
+
+      const command = [pythonPath, "-c", "import moviepy; print('video stack ok')"];
+      const prepared = buildSystemRunApprovalPlan({
+        command,
+        cwd: tmp,
+      });
+      expect(prepared.ok).toBe(true);
+      if (!prepared.ok) {
+        throw new Error("unreachable");
+      }
+      expect(prepared.plan.argv[0]).toBe(basePythonPath);
+
+      const { runCommand, sendInvokeResult } = await runSystemInvoke({
+        preferMacAppExecHost: false,
+        command,
+        rawCommand: prepared.plan.commandPreview,
+        systemRunPlan: prepared.plan,
+        cwd: prepared.plan.cwd ?? tmp,
+        approved: true,
+        security: "full",
+        ask: "off",
+      });
+
+      expect(runCommand).toHaveBeenCalledTimes(1);
+      const argv = requireFirstRunCommandArgs(runCommand);
+      expect(argv[0]).toBe(basePythonPath);
+      expect(argv[1]).toBe(prepared.plan.argv[1]);
+      expectInvokeOk(sendInvokeResult);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "preserves pinned interpreter realpaths for gateway-forwarded materialized inline eval plans",
+    async () => {
+      const tmp = createFixtureDir("openclaw-inline-eval-forwarded-dispatch-");
+      const binDir = path.join(tmp, "venv", "bin");
+      const baseDir = path.join(tmp, "base", "bin");
+      fs.mkdirSync(binDir, { recursive: true });
+      fs.mkdirSync(baseDir, { recursive: true });
+      const basePythonPath = createTempExecutable({ dir: baseDir, name: "python3" });
+      const pythonPath = path.join(binDir, "python3");
+      fs.symlinkSync(basePythonPath, pythonPath);
+
+      const command = [pythonPath, "-c", "import moviepy; print('video stack ok')"];
+      const prepared = buildSystemRunApprovalPlan({
+        command,
+        cwd: tmp,
+      });
+      expect(prepared.ok).toBe(true);
+      if (!prepared.ok) {
+        throw new Error("unreachable");
+      }
+      expect(prepared.plan.argv[0]).toBe(basePythonPath);
+
+      const { runCommand, sendInvokeResult } = await runSystemInvoke({
+        preferMacAppExecHost: false,
+        command: prepared.plan.argv,
+        rawCommand: prepared.plan.commandText,
+        systemRunPlan: prepared.plan,
+        cwd: prepared.plan.cwd ?? tmp,
+        approved: true,
+        security: "full",
+        ask: "off",
+      });
+
+      expect(runCommand).toHaveBeenCalledTimes(1);
+      const argv = requireFirstRunCommandArgs(runCommand);
+      expect(argv[0]).toBe(basePythonPath);
+      expect(argv[1]).toBe(prepared.plan.argv[1]);
+      expectInvokeOk(sendInvokeResult);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "forwards approved materialized inline eval plans to the mac exec host with matching command text",
+    async () => {
+      const tmp = createFixtureDir("openclaw-inline-eval-mac-host-dispatch-");
+      const pythonPath = createTempExecutable({ dir: tmp, name: "python3" });
+      const command = [pythonPath, "-c", "print('video stack ok')"];
+      const prepared = buildSystemRunApprovalPlan({
+        command,
+        cwd: tmp,
+      });
+      expect(prepared.ok).toBe(true);
+      if (!prepared.ok) {
+        throw new Error("unreachable");
+      }
+
+      const invoke = await runSystemInvoke({
+        preferMacAppExecHost: true,
+        command,
+        rawCommand: prepared.plan.commandPreview,
+        systemRunPlan: prepared.plan,
+        cwd: prepared.plan.cwd ?? tmp,
+        approved: true,
+        security: "full",
+        ask: "off",
+        runViaResponse: createMacExecHostSuccess(),
+      });
+
+      expect(invoke.runCommand).not.toHaveBeenCalled();
+      const macHostCall = requireMacExecHostCall(invoke.runViaMacAppExecHost);
+      expect(macHostCall.request?.command).toEqual(prepared.plan.argv);
+      expect(macHostCall.request?.rawCommand).toBe(prepared.plan.commandText);
+      expectInvokeOk(invoke.sendInvokeResult, { payloadContains: "app-ok" });
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "does not materialize inline eval during non-approved direct execution",
+    async () => {
+      const tmp = createFixtureDir("openclaw-inline-eval-no-approval-");
+      const blockedParent = path.join(tmp, "blocked-parent");
+      fs.writeFileSync(blockedParent, "");
+      const oldStateDir = process.env.OPENCLAW_STATE_DIR;
+      process.env.OPENCLAW_STATE_DIR = path.join(blockedParent, "state");
+      try {
+        const { runCommand, sendInvokeResult } = await runSystemInvoke({
+          preferMacAppExecHost: false,
+          command: [process.execPath, "-e", "console.log('direct ok')"],
+          cwd: tmp,
+          security: "full",
+          ask: "off",
+        });
+
+        expect(runCommand).toHaveBeenCalledTimes(1);
+        expectInvokeOk(sendInvokeResult);
+      } finally {
+        if (oldStateDir === undefined) {
+          delete process.env.OPENCLAW_STATE_DIR;
+        } else {
+          process.env.OPENCLAW_STATE_DIR = oldStateDir;
+        }
+      }
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "does not trust materialized inline eval plan argv before approval",
+    async () => {
+      const tmp = createFixtureDir("openclaw-inline-eval-unapproved-plan-");
+      const binDir = path.join(tmp, "venv", "bin");
+      const baseDir = path.join(tmp, "base", "bin");
+      fs.mkdirSync(binDir, { recursive: true });
+      fs.mkdirSync(baseDir, { recursive: true });
+      const basePythonPath = createTempExecutable({ dir: baseDir, name: "python3" });
+      const pythonPath = path.join(binDir, "python3");
+      fs.symlinkSync(basePythonPath, pythonPath);
+
+      const command = [pythonPath, "-c", "print('strict approval required')"];
+      const prepared = buildSystemRunApprovalPlan({
+        command,
+        cwd: tmp,
+      });
+      expect(prepared.ok).toBe(true);
+      if (!prepared.ok) {
+        throw new Error("unreachable");
+      }
+      setRuntimeConfigSnapshot({
+        tools: {
+          exec: {
+            strictInlineEval: true,
+          },
+        },
+      });
+      try {
+        const { runCommand, sendInvokeResult, sendNodeEvent } = await runSystemInvoke({
+          preferMacAppExecHost: false,
+          command,
+          rawCommand: prepared.plan.commandPreview,
+          systemRunPlan: prepared.plan,
+          cwd: prepared.plan.cwd ?? tmp,
+          approved: false,
+          security: "full",
+          ask: "off",
+        });
+
+        expect(runCommand).not.toHaveBeenCalled();
+        expectExecDeniedEvent(sendNodeEvent);
+        expectInvokeErrorMessage(sendInvokeResult, {
+          message: "python3 -c requires explicit approval in strictInlineEval mode",
+        });
+      } finally {
+        clearRuntimeConfigSnapshot();
+      }
+    },
+  );
+
   it("denies ./sh wrapper spoof in allowlist on-miss mode before execution", async () => {
     const marker = path.join(os.tmpdir(), `openclaw-wrapper-spoof-${process.pid}-${Date.now()}`);
     const runCommand = vi.fn(async () => {
@@ -3159,6 +3358,58 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
       clearRuntimeConfigSnapshot();
     }
   });
+
+  it.runIf(process.platform !== "win32")(
+    "does not persist allow-always approvals for forwarded materialized inline eval plans",
+    async () => {
+      setRuntimeConfigSnapshot({
+        tools: {
+          exec: {
+            strictInlineEval: true,
+          },
+        },
+      });
+      try {
+        await withTempApprovalsHome({
+          approvals: createAllowlistOnMissApprovals(),
+          run: async () => {
+            const tempDir = createFixtureDir("openclaw-inline-eval-forwarded-allow-always-");
+            const executablePath = createTempExecutable({
+              dir: tempDir,
+              name: "python3",
+            });
+            const prepared = buildSystemRunApprovalPlan({
+              command: [executablePath, "-c", "print('hi')"],
+              cwd: tempDir,
+            });
+            expect(prepared.ok).toBe(true);
+            if (!prepared.ok) {
+              throw new Error("unreachable");
+            }
+
+            const { runCommand, sendInvokeResult } = await runSystemInvoke({
+              preferMacAppExecHost: false,
+              command: prepared.plan.argv,
+              rawCommand: prepared.plan.commandText,
+              systemRunPlan: prepared.plan,
+              cwd: prepared.plan.cwd ?? tempDir,
+              security: "allowlist",
+              ask: "on-miss",
+              approvalDecision: "allow-always",
+              approved: true,
+              runCommand: vi.fn(async () => createLocalRunResult("inline-eval-ok")),
+            });
+
+            expect(runCommand).toHaveBeenCalledTimes(1);
+            expectInvokeOk(sendInvokeResult, { payloadContains: "inline-eval-ok" });
+            expect(loadExecApprovals().agents?.main?.allowlist ?? []).toStrictEqual([]);
+          },
+        });
+      } finally {
+        clearRuntimeConfigSnapshot();
+      }
+    },
+  );
 
   it("persists benign awk allow-always approvals in strict inline-eval mode without reopening inline carriers", async () => {
     setRuntimeConfigSnapshot({

--- a/src/node-host/invoke-system-run.test.ts
+++ b/src/node-host/invoke-system-run.test.ts
@@ -30,7 +30,7 @@ import {
 import type { ExecAutoReviewer } from "../infra/exec-auto-review.js";
 import type { ExecHostResponse } from "../infra/exec-host.js";
 import { withEnvAsync } from "../test-utils/env.js";
-import { buildSystemRunApprovalPlan } from "./invoke-system-run-plan.js";
+import { buildSystemRunApprovalPlan } from "./invoke-system-run-approval-plan.js";
 import { handleSystemRunInvoke } from "./invoke-system-run.js";
 import type { HandleSystemRunInvokeOptions } from "./invoke-system-run.js";
 
@@ -1634,49 +1634,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
       if (!prepared.ok) {
         throw new Error("unreachable");
       }
-      expect(prepared.plan.argv[0]).toBe(basePythonPath);
-
-      const { runCommand, sendInvokeResult } = await runSystemInvoke({
-        preferMacAppExecHost: false,
-        command,
-        rawCommand: prepared.plan.commandPreview,
-        systemRunPlan: prepared.plan,
-        cwd: prepared.plan.cwd ?? tmp,
-        approved: true,
-        security: "full",
-        ask: "off",
-      });
-
-      expect(runCommand).toHaveBeenCalledTimes(1);
-      const argv = requireFirstRunCommandArgs(runCommand);
-      expect(argv[0]).toBe(basePythonPath);
-      expect(argv[1]).toBe(prepared.plan.argv[1]);
-      expectInvokeOk(sendInvokeResult);
-    },
-  );
-
-  it.runIf(process.platform !== "win32")(
-    "preserves pinned interpreter realpaths for gateway-forwarded materialized inline eval plans",
-    async () => {
-      const tmp = createFixtureDir("openclaw-inline-eval-forwarded-dispatch-");
-      const binDir = path.join(tmp, "venv", "bin");
-      const baseDir = path.join(tmp, "base", "bin");
-      fs.mkdirSync(binDir, { recursive: true });
-      fs.mkdirSync(baseDir, { recursive: true });
-      const basePythonPath = createTempExecutable({ dir: baseDir, name: "python3" });
-      const pythonPath = path.join(binDir, "python3");
-      fs.symlinkSync(basePythonPath, pythonPath);
-
-      const command = [pythonPath, "-c", "import moviepy; print('video stack ok')"];
-      const prepared = buildSystemRunApprovalPlan({
-        command,
-        cwd: tmp,
-      });
-      expect(prepared.ok).toBe(true);
-      if (!prepared.ok) {
-        throw new Error("unreachable");
-      }
-      expect(prepared.plan.argv[0]).toBe(basePythonPath);
+      expect(prepared.plan.argv[0]).toBe(fs.realpathSync("/bin/sh"));
 
       const { runCommand, sendInvokeResult } = await runSystemInvoke({
         preferMacAppExecHost: false,
@@ -1691,7 +1649,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
 
       expect(runCommand).toHaveBeenCalledTimes(1);
       const argv = requireFirstRunCommandArgs(runCommand);
-      expect(argv[0]).toBe(basePythonPath);
+      expect(argv[0]).toBe(fs.realpathSync("/bin/sh"));
       expect(argv[1]).toBe(prepared.plan.argv[1]);
       expectInvokeOk(sendInvokeResult);
     },
@@ -1714,8 +1672,8 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
 
       const invoke = await runSystemInvoke({
         preferMacAppExecHost: true,
-        command,
-        rawCommand: prepared.plan.commandPreview,
+        command: prepared.plan.argv,
+        rawCommand: prepared.plan.commandText,
         systemRunPlan: prepared.plan,
         cwd: prepared.plan.cwd ?? tmp,
         approved: true,
@@ -1736,10 +1694,9 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     "does not materialize inline eval during non-approved direct execution",
     async () => {
       const tmp = createFixtureDir("openclaw-inline-eval-no-approval-");
-      const blockedParent = path.join(tmp, "blocked-parent");
-      fs.writeFileSync(blockedParent, "");
+      const stateDir = path.join(tmp, "state");
       const oldStateDir = process.env.OPENCLAW_STATE_DIR;
-      process.env.OPENCLAW_STATE_DIR = path.join(blockedParent, "state");
+      process.env.OPENCLAW_STATE_DIR = stateDir;
       try {
         const { runCommand, sendInvokeResult } = await runSystemInvoke({
           preferMacAppExecHost: false,
@@ -1751,6 +1708,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
 
         expect(runCommand).toHaveBeenCalledTimes(1);
         expectInvokeOk(sendInvokeResult);
+        expect(fs.existsSync(path.join(stateDir, "tmp", "inline-eval"))).toBe(false);
       } finally {
         if (oldStateDir === undefined) {
           delete process.env.OPENCLAW_STATE_DIR;
@@ -3325,7 +3283,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     });
   });
 
-  it("rejects unbindable strict inline-eval carriers before delayed approval", async () => {
+  it("materializes supported strict inline-eval carriers before delayed approval", async () => {
     setRuntimeConfigSnapshot({
       tools: {
         exec: {
@@ -3346,11 +3304,12 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
             command: [executablePath, "-c", "print('hi')"],
           });
 
-          expect(prepared).toEqual({
-            ok: false,
-            message:
-              "SYSTEM_RUN_DENIED: approval cannot safely bind this interpreter/runtime command",
-          });
+          expect(prepared.ok).toBe(true);
+          if (!prepared.ok) {
+            throw new Error("unreachable");
+          }
+          expect(prepared.plan.commandPreview).toBe(`${executablePath} -c print('hi')`);
+          expect(prepared.plan.mutableFileOperand?.argvIndex).toBe(1);
           expect(loadExecApprovals().agents?.main?.allowlist ?? []).toStrictEqual([]);
         },
       });

--- a/src/node-host/invoke-system-run.test.ts
+++ b/src/node-host/invoke-system-run.test.ts
@@ -1634,7 +1634,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
       if (!prepared.ok) {
         throw new Error("unreachable");
       }
-      expect(prepared.plan.argv[0]).toBe(fs.realpathSync("/bin/sh"));
+      expect(prepared.plan.argv[0]).toBe(fs.realpathSync("/usr/bin/env"));
 
       const { runCommand, sendInvokeResult } = await runSystemInvoke({
         preferMacAppExecHost: false,
@@ -1649,8 +1649,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
 
       expect(runCommand).toHaveBeenCalledTimes(1);
       const argv = requireFirstRunCommandArgs(runCommand);
-      expect(argv[0]).toBe(fs.realpathSync("/bin/sh"));
-      expect(argv[1]).toBe(prepared.plan.argv[1]);
+      expect(argv).toEqual(prepared.plan.argv);
       expectInvokeOk(sendInvokeResult);
     },
   );
@@ -3309,7 +3308,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
             throw new Error("unreachable");
           }
           expect(prepared.plan.commandPreview).toBe(`${executablePath} -c print('hi')`);
-          expect(prepared.plan.mutableFileOperand?.argvIndex).toBe(1);
+          expect(prepared.plan.mutableFileOperand?.argvIndex).toBe(6);
           expect(loadExecApprovals().agents?.main?.allowlist ?? []).toStrictEqual([]);
         },
       });

--- a/src/node-host/invoke-system-run.ts
+++ b/src/node-host/invoke-system-run.ts
@@ -4,6 +4,7 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   describeInterpreterInlineEval,
+  detectInterpreterInlineEvalArgv,
   type InterpreterInlineEvalHit,
 } from "../infra/command-analysis/inline-eval.js";
 import { detectPolicyInlineEval } from "../infra/command-analysis/policy.js";
@@ -58,6 +59,7 @@ import {
 } from "./invoke-system-run-allowlist.js";
 import {
   hardenApprovedExecutionPaths,
+  isMaterializedInlineEvalApprovalPlan,
   revalidateApprovedCwdSnapshot,
   revalidateApprovedMutableFileOperand,
   resolveMutableFileOperandSnapshotSync,
@@ -115,6 +117,7 @@ type SystemRunParsePhase = {
   needsScreenRecording: boolean;
   approved: boolean;
   suppressNotifyOnExit: boolean;
+  materializedInlineEvalHit: InterpreterInlineEvalHit | null;
 };
 
 type SystemRunPolicyPhase = SystemRunParsePhase & {
@@ -164,6 +167,65 @@ type EffectiveSystemRunExecPolicy = {
   ask: ExecAsk;
   autoReview: boolean;
 };
+
+function parseFormattedExecCommandPreview(commandPreview?: string | null): string[] | null {
+  const text = commandPreview?.trim();
+  if (!text) {
+    return null;
+  }
+  const argv: string[] = [];
+  let index = 0;
+  while (index < text.length) {
+    while (index < text.length && /\s/.test(text[index] ?? "")) {
+      index += 1;
+    }
+    if (index >= text.length) {
+      break;
+    }
+
+    let token = "";
+    if (text[index] === '"') {
+      index += 1;
+      let closed = false;
+      while (index < text.length) {
+        const char = text[index] ?? "";
+        if (char === '"') {
+          index += 1;
+          closed = true;
+          break;
+        }
+        if (char === "\\" && text[index + 1] === '"') {
+          token += '"';
+          index += 2;
+          continue;
+        }
+        token += char;
+        index += 1;
+      }
+      if (!closed || (index < text.length && !/\s/.test(text[index] ?? ""))) {
+        return null;
+      }
+    } else {
+      while (index < text.length && !/\s/.test(text[index] ?? "")) {
+        token += text[index] ?? "";
+        index += 1;
+      }
+    }
+    argv.push(token);
+  }
+  return argv.length > 0 ? argv : null;
+}
+
+function detectMaterializedInlineEvalApprovalHit(
+  approvalPlan: import("../infra/exec-approvals.js").SystemRunApprovalPlan | null,
+): InterpreterInlineEvalHit | null {
+  if (!approvalPlan || !isMaterializedInlineEvalApprovalPlan(approvalPlan)) {
+    return null;
+  }
+  return detectInterpreterInlineEvalArgv(
+    parseFormattedExecCommandPreview(approvalPlan.commandPreview),
+  );
+}
 
 function warnWritableTrustedDirOnce(message: string): void {
   if (safeBinTrustedDirWarningCache.has(message)) {
@@ -517,17 +579,31 @@ async function parseSystemRunPhase(
     overrides: opts.params.env ?? undefined,
     shellWrapper: shellWrapperInvocation,
   });
+  const materializedInlineEvalHit = detectMaterializedInlineEvalApprovalHit(approvalPlan);
+  const planMatchesInlineEval =
+    opts.params.approved === true &&
+    approvalPlan !== null &&
+    isMaterializedInlineEvalApprovalPlan(approvalPlan) &&
+    materializedInlineEvalHit !== null &&
+    (approvalPlan.commandPreview === command.commandText ||
+      approvalPlan.commandText === command.commandText) &&
+    approvalPlan.argv.length > 0;
+  const argv = planMatchesInlineEval ? approvalPlan.argv : command.argv;
+  const effectiveCommandText = planMatchesInlineEval ? approvalPlan.commandText : commandText;
+  const effectiveCommandPreview = planMatchesInlineEval
+    ? (approvalPlan.commandPreview ?? null)
+    : command.previewText;
   return {
-    argv: command.argv,
+    argv,
     shellPayload,
     shellWrapperInvocation,
-    commandText,
-    commandPreview: command.previewText,
+    commandText: effectiveCommandText,
+    commandPreview: effectiveCommandPreview,
     approvalPlan,
     agentId,
     sessionKey,
     runId,
-    execution: { sessionKey, runId, commandText, suppressNotifyOnExit },
+    execution: { sessionKey, runId, commandText: effectiveCommandText, suppressNotifyOnExit },
     approvalDecision,
     approvalSource: approvalSource ?? undefined,
     delayedApprovalPolicySnapshot,
@@ -538,6 +614,7 @@ async function parseSystemRunPhase(
     needsScreenRecording: opts.params.needsScreenRecording === true,
     approved,
     suppressNotifyOnExit,
+    materializedInlineEvalHit: planMatchesInlineEval ? materializedInlineEvalHit : null,
   };
 }
 
@@ -609,7 +686,9 @@ async function evaluateSystemRunPolicyPhase(
   let { analysisOk, allowlistSatisfied } = allowlistEvaluation;
   const strictInlineEval =
     agentExec?.strictInlineEval === true || cfg.tools?.exec?.strictInlineEval === true;
-  const inlineEvalHit = strictInlineEval ? detectPolicyInlineEval(segments) : null;
+  const inlineEvalHit = strictInlineEval
+    ? (parsed.materializedInlineEvalHit ?? detectPolicyInlineEval(segments))
+    : null;
   const isWindows = process.platform === "win32";
   // Detect Windows wrapper transport from the same shell-wrapper view used to
   // derive the inner payload. That keeps `cmd.exe /c` approval-gated even when

--- a/src/node-host/invoke-system-run.ts
+++ b/src/node-host/invoke-system-run.ts
@@ -4,7 +4,6 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   describeInterpreterInlineEval,
-  detectInterpreterInlineEvalArgv,
   type InterpreterInlineEvalHit,
 } from "../infra/command-analysis/inline-eval.js";
 import { detectPolicyInlineEval } from "../infra/command-analysis/policy.js";
@@ -45,7 +44,10 @@ import {
   inspectHostExecEnvOverrides,
   sanitizeSystemRunEnvOverrides,
 } from "../infra/host-env-security.js";
-import { normalizeSystemRunApprovalPlan } from "../infra/system-run-approval-binding.js";
+import {
+  normalizeSystemRunApprovalPlan,
+  systemRunArgvMatches,
+} from "../infra/system-run-approval-binding.js";
 import { formatExecCommand, resolveSystemRunCommandRequest } from "../infra/system-run-command.js";
 import { logWarn } from "../logger.js";
 import { normalizeAgentId } from "../routing/session-key.js";
@@ -57,9 +59,9 @@ import {
   resolvePlannedAllowlistArgv,
   resolveSystemRunExecArgv,
 } from "./invoke-system-run-allowlist.js";
+import { detectMaterializedInlineEvalApprovalHit } from "./invoke-system-run-inline-eval.js";
 import {
   hardenApprovedExecutionPaths,
-  isMaterializedInlineEvalApprovalPlan,
   revalidateApprovedCwdSnapshot,
   revalidateApprovedMutableFileOperand,
   resolveMutableFileOperandSnapshotSync,
@@ -117,7 +119,6 @@ type SystemRunParsePhase = {
   needsScreenRecording: boolean;
   approved: boolean;
   suppressNotifyOnExit: boolean;
-  materializedInlineEvalHit: InterpreterInlineEvalHit | null;
 };
 
 type SystemRunPolicyPhase = SystemRunParsePhase & {
@@ -167,65 +168,6 @@ type EffectiveSystemRunExecPolicy = {
   ask: ExecAsk;
   autoReview: boolean;
 };
-
-function parseFormattedExecCommandPreview(commandPreview?: string | null): string[] | null {
-  const text = commandPreview?.trim();
-  if (!text) {
-    return null;
-  }
-  const argv: string[] = [];
-  let index = 0;
-  while (index < text.length) {
-    while (index < text.length && /\s/.test(text[index] ?? "")) {
-      index += 1;
-    }
-    if (index >= text.length) {
-      break;
-    }
-
-    let token = "";
-    if (text[index] === '"') {
-      index += 1;
-      let closed = false;
-      while (index < text.length) {
-        const char = text[index] ?? "";
-        if (char === '"') {
-          index += 1;
-          closed = true;
-          break;
-        }
-        if (char === "\\" && text[index + 1] === '"') {
-          token += '"';
-          index += 2;
-          continue;
-        }
-        token += char;
-        index += 1;
-      }
-      if (!closed || (index < text.length && !/\s/.test(text[index] ?? ""))) {
-        return null;
-      }
-    } else {
-      while (index < text.length && !/\s/.test(text[index] ?? "")) {
-        token += text[index] ?? "";
-        index += 1;
-      }
-    }
-    argv.push(token);
-  }
-  return argv.length > 0 ? argv : null;
-}
-
-function detectMaterializedInlineEvalApprovalHit(
-  approvalPlan: import("../infra/exec-approvals.js").SystemRunApprovalPlan | null,
-): InterpreterInlineEvalHit | null {
-  if (!approvalPlan || !isMaterializedInlineEvalApprovalPlan(approvalPlan)) {
-    return null;
-  }
-  return detectInterpreterInlineEvalArgv(
-    parseFormattedExecCommandPreview(approvalPlan.commandPreview),
-  );
-}
 
 function warnWritableTrustedDirOnce(message: string): void {
   if (safeBinTrustedDirWarningCache.has(message)) {
@@ -410,15 +352,7 @@ async function sendSystemRunCompleted(
   });
 }
 
-function argvArraysMatch(left: readonly string[] | undefined, right: readonly string[]): boolean {
-  return (
-    left !== undefined &&
-    left.length === right.length &&
-    left.every((entry, index) => entry === right[index])
-  );
-}
-
-export { buildSystemRunApprovalPlan } from "./invoke-system-run-plan.js";
+export { buildSystemRunApprovalPlan } from "./invoke-system-run-approval-plan.js";
 
 async function parseSystemRunPhase(
   opts: HandleSystemRunInvokeOptions,
@@ -494,7 +428,7 @@ async function parseSystemRunPhase(
   if (approvalSource != null || explicitApproval) {
     const planMatchesRequest =
       approvalPlan !== null &&
-      argvArraysMatch(approvalPlan.argv, command.argv) &&
+      systemRunArgvMatches(approvalPlan.argv, command.argv) &&
       approvalPlan.commandText === commandText &&
       normalizeOptionalString(approvalPlan.cwd) === cwd &&
       normalizeOptionalString(approvalPlan.agentId) === agentId &&
@@ -579,31 +513,17 @@ async function parseSystemRunPhase(
     overrides: opts.params.env ?? undefined,
     shellWrapper: shellWrapperInvocation,
   });
-  const materializedInlineEvalHit = detectMaterializedInlineEvalApprovalHit(approvalPlan);
-  const planMatchesInlineEval =
-    opts.params.approved === true &&
-    approvalPlan !== null &&
-    isMaterializedInlineEvalApprovalPlan(approvalPlan) &&
-    materializedInlineEvalHit !== null &&
-    (approvalPlan.commandPreview === command.commandText ||
-      approvalPlan.commandText === command.commandText) &&
-    approvalPlan.argv.length > 0;
-  const argv = planMatchesInlineEval ? approvalPlan.argv : command.argv;
-  const effectiveCommandText = planMatchesInlineEval ? approvalPlan.commandText : commandText;
-  const effectiveCommandPreview = planMatchesInlineEval
-    ? (approvalPlan.commandPreview ?? null)
-    : command.previewText;
   return {
-    argv,
+    argv: command.argv,
     shellPayload,
     shellWrapperInvocation,
-    commandText: effectiveCommandText,
-    commandPreview: effectiveCommandPreview,
+    commandText,
+    commandPreview: command.previewText,
     approvalPlan,
     agentId,
     sessionKey,
     runId,
-    execution: { sessionKey, runId, commandText: effectiveCommandText, suppressNotifyOnExit },
+    execution: { sessionKey, runId, commandText, suppressNotifyOnExit },
     approvalDecision,
     approvalSource: approvalSource ?? undefined,
     delayedApprovalPolicySnapshot,
@@ -614,7 +534,6 @@ async function parseSystemRunPhase(
     needsScreenRecording: opts.params.needsScreenRecording === true,
     approved,
     suppressNotifyOnExit,
-    materializedInlineEvalHit: planMatchesInlineEval ? materializedInlineEvalHit : null,
   };
 }
 
@@ -687,7 +606,8 @@ async function evaluateSystemRunPolicyPhase(
   const strictInlineEval =
     agentExec?.strictInlineEval === true || cfg.tools?.exec?.strictInlineEval === true;
   const inlineEvalHit = strictInlineEval
-    ? (parsed.materializedInlineEvalHit ?? detectPolicyInlineEval(segments))
+    ? (detectMaterializedInlineEvalApprovalHit(parsed.approvalPlan) ??
+      detectPolicyInlineEval(segments))
     : null;
   const isWindows = process.platform === "win32";
   // Detect Windows wrapper transport from the same shell-wrapper view used to
@@ -773,7 +693,8 @@ async function evaluateSystemRunPolicyPhase(
   if (!policy.allowed) {
     const [autoReviewSegment] = segments;
     const directAutoReviewArgvMatchesRequest =
-      parsed.shellPayload !== null || argvArraysMatch(autoReviewSegment?.argv, parsed.argv);
+      parsed.shellPayload !== null ||
+      systemRunArgvMatches(autoReviewSegment?.argv ?? [], parsed.argv);
     const autoReviewArgv =
       segments.length === 1 &&
       directAutoReviewArgvMatchesRequest &&


### PR DESCRIPTION
## Summary

- Materialize exact direct node-host inline-eval forms before system-run approval:
  - `python -c CODE`
  - `python3 -c CODE`
  - `node -e CODE`
  - `node --eval CODE`
- Bind a deterministic POSIX-shell launcher through the existing `mutableFileOperand` realpath + SHA-256 approval checks.
- Keep the original inline command visible in `commandPreview`.
- Preserve strict-inline-eval policy behavior and exact delayed-approval plan matching.
- Fail closed for ambiguous or semantics-changing forms.
- Keep the dead-code dependency CI command compatible with the repository's pinned pnpm by invoking the pinned Knip package directly.

## What Problem This Solves

Current OpenClaw main still denies approval-backed inline interpreter commands because it cannot bind raw inline code to a stable file operand. This PR maps the inline source onto the existing mutable-file approval boundary instead of broadly trusting interpreter execution.

## Security and lifecycle

- Non-Windows only.
- Generated launchers live under `$OPENCLAW_STATE_DIR/tmp/inline-eval`.
- Directories are private `0700`; launcher files are `0600`.
- Filenames are deterministic and content-derived.
- The cache is bounded to 256 files / 16 MiB.
- While the node host is active, an hourly sweep removes files older than 24 hours. After restart, stale entries are pruned before the next materialization.
- `SHELLOPTS` and `BASHOPTS` are removed before `/bin/sh` starts, preventing inherited `noexec`, tracing, or verbose modes from suppressing execution or leaking source.
- Node/Python starts once, so `NODE_OPTIONS` and Python startup hooks are not duplicated.
- Verified symlinked CPython virtual environments are supported on macOS. They fail closed on other POSIX hosts rather than silently running against the base interpreter.
- PyPy fails closed.

Intentionally unsupported:

- Windows materialization.
- Shell-wrapped inline eval.
- Extra interpreter flags.
- Trailing script arguments.
- Node eval modes with different file semantics, such as `--input-type=module --eval`.
- `node -p` and other interpreter/runtime eval forms.

## Evidence

**Behavior addressed:** approval-backed `python -c` / `node -e` requests previously failed because the inline code had no stable file artifact. The current branch materializes a bound launcher, forwards the exact approved argv, and continues to reject unsupported forms.

**Environment:** macOS; final branch head `fce696e4c001ef5d20d93e78488364f5f7e6ac72`.

**Exact verification:**

```sh
node scripts/run-vitest.mjs \
  src/node-host/invoke-system-run-plan.test.ts \
  src/node-host/invoke-system-run.test.ts \
  --reporter=dot
```

The integration-style launcher test starts a real Node child with:

- `NODE_OPTIONS=--require=<startup-hook>`
- `SHELLOPTS=noexec:xtrace`
- `BASHOPTS=extdebug`

**Observed result:** the approved inline payload executes successfully, stdout is exactly `ok`, the Node preload hook runs exactly once, and stderr does not expose the inline source. Tests also cover file binding/revalidation, strict-inline-eval routing, cache expiry, ambiguous-form denial, trailing-backslash metadata recovery, macOS CPython venv handling, and forwarded macOS exec-host plans.

## Validation

- Rebased onto `main` at `bf5fb5b760`; zero base commits missing at push time.
- Focused suite: 103 passed, 1 platform-specific test skipped.
- Exact CI lint and format commands: passed.
- Exact CI test-type commands: passed.
- Exact CI dead-code dependency, unused-file, and export checks: passed.
- Mandatory branch autoreview: clean; no accepted/actionable findings, “patch is correct.”
- `git diff --check`: passed.

Fresh GitHub CI was triggered by the pushed branch update.