### PR TITLE
fix(diagnostic): avoid aborting queued embedded work

### DIFF
--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -1264,7 +1264,7 @@ describe("stuck session diagnostics threshold", () => {
     expect(recoverStuckSession).not.toHaveBeenCalled();
   });
 
-  it("recovers queued sessions behind terminal embedded progress after the abort threshold", () => {
+  it("does not abort queued sessions behind terminal embedded progress while work remains queued", () => {
     const events: DiagnosticEventPayload[] = [];
     const recoverStuckSession = vi.fn();
     const stuckSessionWarnMs = 30_000;
@@ -1314,11 +1314,7 @@ describe("stuck session diagnostics threshold", () => {
       terminalProgressStale: true,
       lastProgressReason: terminalReason,
     });
-    expectRecoveryCall(
-      recoverStuckSession,
-      { sessionId: "s1", sessionKey: "main", queueDepth: 1, allowActiveAbort: true },
-      ["ageMs", "stateGeneration"],
-    );
+    expect(recoverStuckSession).not.toHaveBeenCalled();
   });
 
   it("starts and stops the stability recorder with the heartbeat lifecycle", () => {

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -478,6 +478,8 @@ function resolveStalledEmbeddedRunAbortMs(stuckSessionWarnMs: number): number {
 
 function isStalledEmbeddedRunRecoveryEligible(params: {
   classification: SessionAttentionClassification | undefined;
+  queueDepth: number;
+  state: SessionStateValue;
   ageMs: number;
   stuckSessionAbortMs: number;
 }): boolean {
@@ -485,6 +487,7 @@ function isStalledEmbeddedRunRecoveryEligible(params: {
     params.classification?.eventType === "session.stalled" &&
     params.classification.classification === "stalled_agent_run" &&
     params.classification.activeWorkKind === "embedded_run" &&
+    !(params.state === "processing" && params.queueDepth > 0) &&
     params.ageMs >= params.stuckSessionAbortMs
   );
 }
@@ -526,6 +529,8 @@ function isStalledModelCallRecoveryEligible(params: {
 function isActiveAbortRecoveryEligible(params: {
   classification: SessionAttentionClassification | undefined;
   activity?: DiagnosticSessionActivitySnapshot;
+  queueDepth: number;
+  state: SessionStateValue;
   ageMs: number;
   stuckSessionAbortMs: number;
 }): boolean {
@@ -848,6 +853,8 @@ export function logSessionAttention(
     isActiveAbortRecoveryEligible({
       classification,
       activity,
+      queueDepth: state.queueDepth,
+      state: params.state,
       ageMs: params.ageMs,
       stuckSessionAbortMs:
         params.abortThresholdMs ?? resolveStalledEmbeddedRunAbortMs(params.thresholdMs),
@@ -1134,6 +1141,8 @@ export function startDiagnosticHeartbeat(
           isActiveAbortRecoveryEligible({
             classification,
             activity,
+            queueDepth: state.queueDepth,
+            state: state.state,
             ageMs: attentionAgeMs,
             stuckSessionAbortMs,
           })


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Diagnostic stuck-session recovery could actively abort an embedded run even when the session was still processing and had queued work remaining behind the active item.
- Solution: Gate the active-abort recovery path so queued embedded work is not aborted while the session is still processing queued items.
- What changed: Added queue-depth and state checks to the recovery eligibility path and updated regression coverage for the queued-work scenario.
- What did NOT change (scope boundary): This PR does not change Telegram delivery behavior, message formatting, model routing, or general stuck-session recovery thresholds outside the queued embedded-work case.

## Motivation

Explain why this change should exist now. Link it to the user pain, failure mode, maintainer need, or product goal. If this is purely mechanical, write `N/A`.

- False-positive abort recovery is costly because it can cancel legitimate queued work and make the system look unstable when it is actually still progressing through backlog.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #84563
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only. Screenshots are encouraged even for CLI, console, text, or log changes; terminal screenshots and copied live output count. Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

- Behavior or issue addressed: Queued embedded work should not be actively aborted by stuck-session recovery while the session is still in `processing` state with queued items remaining.
- Real environment tested: Local OpenClaw contributor environment.
- Exact steps or command run after this patch: Ran `node scripts/run-vitest.mjs run --config test/vitest/vitest.logging.config.ts src/logging/diagnostic.test.ts` and inspected the recovery eligibility path against the live runtime logs that previously showed aggressive abort recovery.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Local targeted test passed for the queued embedded-work scenario; no additional external screenshot attached.
- Observed result after fix: The queued-work regression test passes with the new guard, and the recovery path no longer classifies queued processing as eligible for active abort in that scenario.
- What was not tested: Broader live-system soak testing across unrelated stuck-session recovery paths.
- Before evidence (optional but encouraged): Prior behavior is captured by the replaced regression expectation in `src/logging/diagnostic.test.ts`, which previously expected active abort recovery for the queued scenario.

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: Active-abort recovery only looked at the stalled embedded-run classification and timeout age, not whether the session still had queued work remaining while actively processing.
- Missing detection / guardrail: Recovery eligibility was missing a simple state-plus-queue-depth guard to distinguish backlog from a truly stuck embedded run.
- Contributing context (if known): Diagnostic recovery is intentionally aggressive, so missing queue-awareness creates false positives under queued workloads.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/logging/diagnostic.test.ts`
- Scenario the test should lock in: A session classified as stalled embedded work must not trigger active-abort recovery when it is still in `processing` state and has queued items behind the active run.
- Why this is the smallest reliable guardrail: The decision is pure recovery-eligibility logic, so a focused unit test exercises the exact branch without requiring a live stuck-session harness.
- Existing test that already covers this (if any): The updated queued-session regression test now covers it directly.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

- Queued embedded work is less likely to be canceled by false-positive diagnostic recovery while the session is still processing legitimate backlog.

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

```text
Before:
[processing + queued work] -> [timeout threshold reached] -> [active abort recovery] -> [legitimate queued work canceled]

After:
[processing + queued work] -> [timeout threshold reached] -> [queue-aware guard] -> [no active abort for backlog]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local OpenClaw contributor environment
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): default diagnostic recovery config in local contributor setup

### Steps

1. Create a session snapshot classified as stalled embedded work.
2. Keep the session in `processing` state with `queueDepth > 0`.
3. Evaluate recovery eligibility after the abort threshold.

### Expected

- Active-abort recovery does not fire for the queued-processing case.

### Actual

- Verified by targeted regression test after this patch.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Ran the targeted diagnostic Vitest suite locally and reviewed the recovery logic plus the updated regression expectation.
- Edge cases checked: Processing state with queued work, stalled embedded classification, and threshold-based recovery gating.
- What you did **not** verify: Broader live-system proof across every diagnostic recovery mode.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: If the queue-aware guard is too broad, genuinely stuck embedded runs with backlog could wait longer before recovery.
- Mitigation: The guard is narrowly limited to `processing` sessions with positive queue depth, and existing threshold-based recovery remains unchanged for truly idle or drained stalled runs.

