### PR TITLE
Skip empty sherpa structured transcripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Media/audio: skip empty structured sherpa-onnx transcripts instead of treating the raw JSON payload as spoken text. (#84667) Thanks @TurboTheTurtle.
 - CLI/perf: keep `setup --help`, `onboard --help`, and `configure --help` out of the full wizard runtime while preserving the existing help output. (#84488) Thanks @frankekn.
 
 ## 2026.5.20

--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -771,6 +771,37 @@ describe("applyMediaUnderstanding", () => {
     expectCliRunOptions(options);
   });
 
+  it("skips auto-detected sherpa audio when structured output has empty text", async () => {
+    clearMediaUnderstandingBinaryCacheForTests();
+    const binDir = await createTempMediaDir();
+    const modelDir = await createTempMediaDir();
+    await createMockExecutable(binDir, "sherpa-onnx-offline");
+    await fs.writeFile(path.join(modelDir, "tokens.txt"), "a");
+    await fs.writeFile(path.join(modelDir, "encoder.onnx"), "a");
+    await fs.writeFile(path.join(modelDir, "decoder.onnx"), "a");
+    await fs.writeFile(path.join(modelDir, "joiner.onnx"), "a");
+
+    const emptySherpaJson =
+      '{"lang":"","emotion":"","event":"","text":"","timestamps":[],"durations":[],"tokens":[],"ys_log_probs":[],"words":[]}';
+    const { ctx, cfg } = await setupAudioAutoDetectCase(emptySherpaJson);
+
+    await withMediaAutoDetectEnv(
+      {
+        PATH: binDir,
+        SHERPA_ONNX_MODEL_DIR: modelDir,
+      },
+      async () => {
+        const result = await applyMediaUnderstanding({ ctx, cfg });
+        expect(result.appliedAudio).toBe(false);
+      },
+    );
+
+    expect(ctx.Transcript).toBeUndefined();
+    expect(ctx.Body).toBe("<media:audio>");
+    const [command] = getRunExecCall();
+    expect(command).toBe("sherpa-onnx-offline");
+  });
+
   it("auto-detects whisper-cli when sherpa is unavailable", async () => {
     clearMediaUnderstandingBinaryCacheForTests();
     const binDir = await createTempMediaDir();

--- a/src/media-understanding/runner.cli-audio.test.ts
+++ b/src/media-understanding/runner.cli-audio.test.ts
@@ -81,4 +81,55 @@ describe("media-understanding CLI audio entry", () => {
       maxBuffer: CLI_OUTPUT_MAX_BUFFER,
     });
   });
+
+  it("treats sherpa structured JSON with empty text as empty output", async () => {
+    runExecMock.mockResolvedValueOnce({
+      stdout:
+        '{"lang":"","emotion":"","event":"","text":"","timestamps":[],"durations":[],"tokens":[],"ys_log_probs":[],"words":[]}',
+      stderr: "",
+    });
+
+    await withAudioFixture("openclaw-cli-audio-empty-sherpa", async ({ ctx, cache }) => {
+      const result = await runCliEntry({
+        capability: "audio",
+        entry: {
+          type: "cli",
+          command: "sherpa-onnx-offline",
+          args: ["{{MediaPath}}"],
+        },
+        cfg: { tools: { media: { audio: {} } } } as OpenClawConfig,
+        ctx,
+        attachmentIndex: 0,
+        cache,
+        config: {} as never,
+      });
+
+      expect(result).toBeNull();
+    });
+  });
+
+  it("extracts sherpa text from the final structured output line", async () => {
+    runExecMock.mockResolvedValueOnce({
+      stdout: 'loading model\n{"text":"sherpa transcript","tokens":["sherpa","transcript"]}\n',
+      stderr: "",
+    });
+
+    await withAudioFixture("openclaw-cli-audio-sherpa-json", async ({ ctx, cache }) => {
+      const result = await runCliEntry({
+        capability: "audio",
+        entry: {
+          type: "cli",
+          command: "sherpa-onnx-offline",
+          args: ["{{MediaPath}}"],
+        },
+        cfg: { tools: { media: { audio: {} } } } as OpenClawConfig,
+        ctx,
+        attachmentIndex: 0,
+        cache,
+        config: {} as never,
+      });
+
+      expect(result?.text).toBe("sherpa transcript");
+    });
+  });
 });

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -96,15 +96,16 @@ function trimOutput(text: string, maxChars?: number): string {
   return trimmed.slice(0, maxChars).trim();
 }
 
-function extractSherpaOnnxText(raw: string): string | null {
-  const tryParse = (value: string): string | null => {
+function extractSherpaOnnxText(raw: string): { matched: boolean; text: string } {
+  const noMatch = { matched: false, text: "" };
+  const tryParse = (value: string): { matched: boolean; text: string } => {
     const trimmed = value.trim();
     if (!trimmed) {
-      return null;
+      return noMatch;
     }
     const head = trimmed[0];
     if (head !== "{" && head !== '"') {
-      return null;
+      return noMatch;
     }
     try {
       const parsed = JSON.parse(trimmed) as unknown;
@@ -113,16 +114,16 @@ function extractSherpaOnnxText(raw: string): string | null {
       }
       if (parsed && typeof parsed === "object") {
         const text = (parsed as { text?: unknown }).text;
-        if (typeof text === "string" && text.trim()) {
-          return text.trim();
+        if (typeof text === "string") {
+          return { matched: true, text: text.trim() };
         }
       }
     } catch {}
-    return null;
+    return noMatch;
   };
 
   const direct = tryParse(raw);
-  if (direct) {
+  if (direct.matched) {
     return direct;
   }
 
@@ -132,11 +133,11 @@ function extractSherpaOnnxText(raw: string): string | null {
     .filter(Boolean);
   for (let i = lines.length - 1; i >= 0; i -= 1) {
     const parsed = tryParse(lines[i] ?? "");
-    if (parsed) {
+    if (parsed.matched) {
       return parsed;
     }
   }
-  return null;
+  return noMatch;
 }
 
 function commandBase(command: string): string {
@@ -230,8 +231,8 @@ async function resolveCliOutput(params: {
 
   if (commandId === "sherpa-onnx-offline") {
     const response = extractSherpaOnnxText(params.stdout);
-    if (response) {
-      return response;
+    if (response.matched) {
+      return response.text;
     }
   }
 

--- a/test/scripts/root-package-overrides.test.ts
+++ b/test/scripts/root-package-overrides.test.ts
@@ -22,17 +22,24 @@ function readPnpmWorkspaceConfig(): PnpmWorkspaceConfig {
   return YAML.parse(fs.readFileSync(workspacePath, "utf8")) as PnpmWorkspaceConfig;
 }
 
+function readPackageManifest(packagePath: string): RootPackageManifest {
+  return JSON.parse(fs.readFileSync(packagePath, "utf8")) as RootPackageManifest;
+}
+
 describe("root package override guardrails", () => {
   it("keeps Bedrock runtime ownership in the Amazon provider plugin", () => {
     const manifest = readRootManifest();
     const pnpmWorkspace = readPnpmWorkspaceConfig();
     const packageName = "@aws-sdk/client-bedrock-runtime";
+    const bedrockManifest = readPackageManifest(
+      path.resolve(process.cwd(), "extensions", "amazon-bedrock", "package.json"),
+    );
     const npmOverride = manifest.overrides?.[packageName];
     const pnpmOverride = pnpmWorkspace.overrides?.["@aws-sdk/client-bedrock-runtime"];
 
     expect(manifest.dependencies).not.toHaveProperty(packageName);
     expect(npmOverride).toBeUndefined();
-    expect(pnpmOverride).toBe("3.1048.0");
+    expect(pnpmOverride).toBe(bedrockManifest.dependencies?.[packageName]);
   });
 
   it("pins the node-domexception alias exactly in npm and pnpm overrides", () => {

--- a/test/scripts/root-package-overrides.test.ts
+++ b/test/scripts/root-package-overrides.test.ts
@@ -34,12 +34,14 @@ describe("root package override guardrails", () => {
     const bedrockManifest = readPackageManifest(
       path.resolve(process.cwd(), "extensions", "amazon-bedrock", "package.json"),
     );
+    const bedrockRuntimeDependency = bedrockManifest.dependencies?.[packageName];
     const npmOverride = manifest.overrides?.[packageName];
-    const pnpmOverride = pnpmWorkspace.overrides?.["@aws-sdk/client-bedrock-runtime"];
+    const pnpmOverride = pnpmWorkspace.overrides?.[packageName];
 
+    expect(bedrockRuntimeDependency).toBeDefined();
     expect(manifest.dependencies).not.toHaveProperty(packageName);
     expect(npmOverride).toBeUndefined();
-    expect(pnpmOverride).toBe(bedrockManifest.dependencies?.[packageName]);
+    expect(pnpmOverride).toBe(bedrockRuntimeDependency);
   });
 
   it("pins the node-domexception alias exactly in npm and pnpm overrides", () => {


### PR DESCRIPTION
## Summary

- Treat structured `sherpa-onnx-offline` JSON with an empty `text` field as an empty transcript instead of falling back to raw stdout.
- Preserve normal sherpa JSON extraction for non-empty transcript output, including final-line JSON after startup logs.
- Add direct CLI-runner and auto-detected audio regression coverage.

Closes #84660.

## Real behavior proof

Behavior or issue addressed:
Moonshine/sherpa can emit a structured JSON object where `text` is empty. Before this patch, OpenClaw treated that as unrecognized sherpa output, fell back to the raw JSON string, and could pass that JSON to the LLM as a voice transcript.

Real environment tested:
Local macOS worktree with bundled Node.js `v24.14.0`, repository dependencies, and a fake executable named `sherpa-onnx-offline` invoked through the real CLI media runner.

Exact steps or command run after this patch:
```bash
PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node node_modules/tsx/dist/cli.mjs /private/tmp/openclaw-84660-proof/proof.ts
PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node scripts/run-vitest.mjs src/media-understanding/runner.cli-audio.test.ts src/media-understanding/apply.test.ts
git diff --check upstream/main..HEAD
git log --format='%h %an <%ae> %s' upstream/main..HEAD
```

Evidence after fix:
The standalone runtime proof invokes the real `runCliEntry()` path with a fake `sherpa-onnx-offline` binary. Empty structured JSON no longer returns a transcript, while non-empty structured JSON still extracts normally:
```json
{
  "emptySherpaJsonReturnedTranscript": false,
  "emptySherpaJsonText": null,
  "nonEmptySherpaJsonText": "hello from sherpa",
  "nonEmptySherpaJsonKind": "audio.transcription"
}
```

Targeted tests:
```text
Test Files  2 passed (2)
Tests       52 passed (52)
```

Observed result after fix:
Empty sherpa/moonshine JSON is skipped before it can become `ctx.Transcript` or an `audio.transcription` output, so the serialized Discord voice lane will not enqueue an agent turn for that empty segment. Non-empty sherpa JSON remains accepted.

What was not tested:
I did not run a live Discord voice session or the full repository test suite. The proof uses the real media CLI runner with a fake sherpa executable and targeted media-understanding tests for the affected normalization and auto-detect paths.

## Attribution

If this PR is squashed or reworked, please preserve the commit author attribution for Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>, or include:

Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>
