### PR TITLE
docs(agent-runtimes): clarify model name vs runtime routing for Codex (#84637)

### DIFF
--- a/docs/concepts/agent-runtimes.md
+++ b/docs/concepts/agent-runtimes.md
@@ -58,6 +58,31 @@ the native app-server features available; `openclaw doctor --fix` owns legacy
 `openai/*` for an agent model now means "run this through Codex" unless a
 non-agent OpenAI API surface is being used.
 
+<Warning>
+**A model name that contains the substring `codex` is NOT runtime evidence.**
+Specifically, model IDs such as `openai/gpt-5.3-codex` or `openai/gpt-5.5-codex`
+are *model selections*, not *runtime selections*. They can be valid fallbacks
+for a Pi-routed agent — the model is allowed to run through Pi runtime when its
+`agentRuntime.id` resolves to `pi`. Removing a `gpt-*-codex` model from
+`fallbacks` because its ID contains `codex` is the wrong fix when the goal is
+to stop using Codex *runtime*. The two layers must be evaluated independently:
+
+- **Runtime routing** lives in `agentRuntime.id` (`pi`, `codex`, `claude-cli`, …) on the provider/model entry.
+- **Model selection** lives in the model ref (`openai/gpt-5.5`, `openai/gpt-5.3-codex`, `anthropic/claude-opus-4-7`, …) and in `fallbacks`.
+
+To audit "no Codex _runtime_ in normal sessions" without touching fallback policy:
+
+- inspect resolved `agentRuntime.id` on every provider/model entry and session row — only those that equal `"codex"` are evidence;
+- model IDs whose name contains `codex` are NOT evidence by themselves;
+- stale `systemPromptReport.provider` labels left over from earlier sessions are NOT evidence — they describe the prior route, not the current one.
+
+The shared substring `codex` across provider keys, auth labels, model IDs, the
+embedded harness, the ACP adapter, and the `/codex` chat command is real but
+unavoidable. When in doubt, route every claim through `agentRuntime.id` rather
+than name-matching. See #84637 for an incident where this distinction was
+missed in production.
+</Warning>
+
 The common ChatGPT/Codex subscription setup uses Codex OAuth for auth, but keeps
 the model ref as `openai/*` and selects the `codex` runtime:
 


### PR DESCRIPTION
Fixes #84637 (docs portion, item #4 in the issue's "Requested fix" list).

The issue reports an incident where an agent told to "remove Codex runtime from normal sessions" repeatedly removed `openai/gpt-5.3-codex` from fallbacks instead — three times across one morning — because the model ID contains the substring `codex`. `openai/gpt-5.3-codex` was actually a valid Pi-routed fallback (model-scoped `agentRuntime.id: "pi"`); removing it was the wrong fix.

The issue lists four requested guardrails. **#1-#3 are doctor/status enhancements (separate scope)**; **#4 is documentation**: "Documentation should explicitly say: Codex runtime/harness is not the same thing as `gpt-*-codex` model IDs."

This PR ships item #4. `docs/concepts/agent-runtimes.md` already discusses runtime-vs-provider layering and has a "Codex surfaces" section enumerating four Codex-named concepts (app-server runtime, OAuth profile, ACP adapter, chat command). It does NOT, however, explicitly call out the **model name** with substring `codex` as a fifth confusable surface that is name-only, not runtime evidence. The Warning added here closes that specific gap.

## Changes

- `docs/concepts/agent-runtimes.md`: add a `<Warning>` block immediately after the "Codex surfaces" table that:
  - States the rule: a model name containing `codex` is NOT runtime evidence
  - Cites the exact case from the issue: `openai/gpt-5.3-codex` as a valid Pi-routed fallback
  - Distinguishes runtime routing (`agentRuntime.id`) from model selection (the model ref / fallback list) on separate bulleted lines
  - Provides concrete audit guidance keyed off `agentRuntime.id` (the authoritative field), with model-name and stale-label exclusions
  - References #84637 so future operators searching for the symptom find the rule

Diff stat: 1 file, +25 / -0. Documentation-only; bypasses the real-CLI-invocation proof gate (`docs/...` files only).

## Real behavior proof

- **Behavior or issue addressed:** Sanitized issue evidence — the issue's "Requested fix" section item #4 explicitly names "Documentation should explicitly say: Codex runtime/harness is not the same thing as `gpt-*-codex` model IDs." The Warning lands in `docs/concepts/agent-runtimes.md` (the canonical agent-runtimes concept doc that already enumerates the Codex confusion surfaces) at the section that already handles the topic.

- **Real environment tested:** Local Node 22.x. Probe at `/tmp/probe_84637.mjs` does structural verification: (a) the `<Warning>` is present and starts with the canonical "A model name that contains the substring `codex` is NOT runtime evidence" rule; (b) explicit "*model selections* vs *runtime selections*" framing; (c) concrete `openai/gpt-5.3-codex` example matching the issue's reproduction; (d) all 3 audit-guidance bullets (agentRuntime.id is authoritative, model names not evidence, stale labels not evidence); (e) issue reference `#84637` cited; (f) Warning positioned in the "Codex surfaces" section between the existing table and the "common ChatGPT/Codex subscription setup" paragraph; (g) `<Warning>` open/close tags balanced; (h) surrounding section anchors preserved.

- **Exact steps or command run after this patch:** `node /tmp/probe_84637.mjs`

- **Evidence after fix:**

```
PASS: <Warning> block added clarifying model-name-vs-runtime distinction
PASS: explicit 'model selections' vs 'runtime selections' framing present
PASS: concrete example openai/gpt-5.3-codex is cited (matches issue's exact case)
PASS: all 3 audit-guidance bullets present (agentRuntime.id is authoritative, model names not evidence, stale labels not evidence)
PASS: issue reference #84637 cited
PASS: Warning is positioned in the 'Codex surfaces' section (between table and the common-setup paragraph)
PASS: <Warning> open/close tags balanced (1 pair)
PASS: all 3 surrounding-anchor strings preserved

ALL CASES PASS
```

- **Observed result after fix:** A reader of `docs/concepts/agent-runtimes.md` encounters the model-name-vs-runtime rule directly under the section that already lists Codex confusion surfaces. The Warning gives an explicit `agentRuntime.id`-keyed audit recipe and cites the incident issue. Operators searching the docs site for "Codex runtime" / "gpt-5.3-codex" / "agentRuntime.id" will find the disambiguation rule rather than having to re-derive it.

- **What was not tested:** Rendered Mintlify preview — markdown structural verification only. The `<Warning>` component is already an established convention in this file and across the docs site.

## Audit (per CLAUDE rules — all 5 steps)

- **Existing-helper check:** No code helper introduced; documentation block additive. The `<Warning>` Mintlify component is the established convention used both in this file and in the rest of the docs site. PASS
- **Shared-helper caller check:** No code is being modified. PASS
- **Broader-fix rival scan:** `gh pr list --search '84637 in:title,body'` returns no open PRs. Issue timeline shows zero cross-references. PASS
- **Recent-merge audit:** `git log --oneline -5 -- docs/concepts/agent-runtimes.md` shows `e1061a8b46 test(live): tolerate provider drift in release checks` — unrelated to runtime documentation. PASS
- **Prototype-pollution scan:** N/A — markdown.

## Scope note

The issue lists 4 requested guardrails. This PR ships only #4 (documentation). Items #1 (`openclaw doctor` / `openclaw models status` separation), #2 (warning when removing a Codex-named model), and #3 (`--runtime-policy` audit flag) are doctor/status code changes that need their own scoping and the maintainer-decided ergonomics. Leaving those for separate PRs preserves the narrow-fix discipline; this docs note doesn't preclude or pre-empt their design.
