### PR TITLE
fix(agents): log pre-prompt compaction fits decisions

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -389,6 +389,7 @@ import {
 } from "./midturn-precheck.js";
 import {
   PREEMPTIVE_OVERFLOW_ERROR_TEXT,
+  formatPrePromptPrecheckLog,
   shouldPreemptivelyCompactBeforePrompt,
 } from "./preemptive-compaction.js";
 import {
@@ -4010,6 +4011,25 @@ export async function runEmbeddedAttempt(
                   agentId: sessionAgentId,
                 }),
               });
+          if (preemptiveCompaction) {
+            log.debug(
+              formatPrePromptPrecheckLog({
+                result: preemptiveCompaction,
+                provider: params.provider,
+                modelId: params.modelId,
+                messageCount: activeSession.messages.length,
+                contextTokenBudget,
+                reserveTokens,
+                ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+                ...(params.sessionId ? { sessionId: params.sessionId } : {}),
+                ...(contextEnginePromptAuthority === "preassembly_may_overflow" &&
+                unwindowedContextEngineMessagesForPrecheck
+                  ? { unwindowedMessageCount: unwindowedContextEngineMessagesForPrecheck.length }
+                  : {}),
+                ...(params.sessionFile ? { sessionFile: params.sessionFile } : {}),
+              }),
+            );
+          }
           if (preemptiveCompaction?.route === "truncate_tool_results_only") {
             const toolResultMaxChars = resolveLiveToolResultMaxChars({
               contextWindowTokens: contextTokenBudget,

--- a/src/agents/pi-embedded-runner/run/preemptive-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run/preemptive-compaction.test.ts
@@ -5,6 +5,7 @@ import { estimateToolResultReductionPotential } from "../tool-result-truncation.
 
 let PREEMPTIVE_OVERFLOW_ERROR_TEXT: typeof import("./preemptive-compaction.js").PREEMPTIVE_OVERFLOW_ERROR_TEXT;
 let estimatePrePromptTokens: typeof import("./preemptive-compaction.js").estimatePrePromptTokens;
+let formatPrePromptPrecheckLog: typeof import("./preemptive-compaction.js").formatPrePromptPrecheckLog;
 let shouldPreemptivelyCompactBeforePrompt: typeof import("./preemptive-compaction.js").shouldPreemptivelyCompactBeforePrompt;
 
 beforeAll(async () => {
@@ -12,6 +13,7 @@ beforeAll(async () => {
   ({
     PREEMPTIVE_OVERFLOW_ERROR_TEXT,
     estimatePrePromptTokens,
+    formatPrePromptPrecheckLog,
     shouldPreemptivelyCompactBeforePrompt,
   } = await import("./preemptive-compaction.js"));
 });
@@ -91,6 +93,42 @@ describe("preemptive-compaction", () => {
     expect(result.shouldCompact).toBe(false);
     expect(result.route).toBe("fits");
     expect(result.estimatedPromptTokens).toBeLessThan(result.promptBudgetBeforeReserve);
+  });
+
+  it("formats all-route pre-prompt diagnostics for a fits decision", () => {
+    const result = shouldPreemptivelyCompactBeforePrompt({
+      messages: [makeAssistantHistory("short history")],
+      systemPrompt: "sys",
+      prompt: "hello",
+      contextTokenBudget: 10_000,
+      reserveTokens: 1_000,
+    });
+    const line = formatPrePromptPrecheckLog({
+      result,
+      sessionKey: "discord:channel:thread",
+      sessionId: "session-1",
+      provider: "anthropic",
+      modelId: "claude-opus-4-6",
+      messageCount: 1,
+      unwindowedMessageCount: 3,
+      contextTokenBudget: 10_000,
+      reserveTokens: 1_000,
+      sessionFile: "sessions/session-1.json",
+    });
+
+    expect(line).toContain("[context-overflow-precheck] pre-prompt check");
+    expect(line).toContain("sessionKey=discord:channel:thread");
+    expect(line).toContain("provider=anthropic/claude-opus-4-6");
+    expect(line).toContain("route=fits");
+    expect(line).toContain(`estimatedPromptTokens=${result.estimatedPromptTokens}`);
+    expect(line).toContain(`promptBudgetBeforeReserve=${result.promptBudgetBeforeReserve}`);
+    expect(line).toContain("overflowTokens=0");
+    expect(line).toContain(`toolResultReducibleChars=${result.toolResultReducibleChars}`);
+    expect(line).toContain("reserveTokens=1000");
+    expect(line).toContain(`effectiveReserveTokens=${result.effectiveReserveTokens}`);
+    expect(line).toContain("contextTokenBudget=10000");
+    expect(line).toContain("messages=1");
+    expect(line).toContain("unwindowedMessages=3");
   });
 
   it("uses the larger unwindowed message estimate when explicitly provided", () => {

--- a/src/agents/pi-embedded-runner/run/preemptive-compaction.ts
+++ b/src/agents/pi-embedded-runner/run/preemptive-compaction.ts
@@ -16,6 +16,16 @@ const TRUNCATION_ROUTE_BUFFER_TOKENS = 512;
 
 export type { PreemptiveCompactionRoute } from "./preemptive-compaction.types.js";
 
+export type PreemptiveCompactionDecision = {
+  route: PreemptiveCompactionRoute;
+  shouldCompact: boolean;
+  estimatedPromptTokens: number;
+  promptBudgetBeforeReserve: number;
+  overflowTokens: number;
+  toolResultReducibleChars: number;
+  effectiveReserveTokens: number;
+};
+
 export function estimatePrePromptTokens(params: {
   messages: AgentMessage[];
   systemPrompt?: string;
@@ -46,15 +56,7 @@ export function shouldPreemptivelyCompactBeforePrompt(params: {
   contextTokenBudget: number;
   reserveTokens: number;
   toolResultMaxChars?: number;
-}): {
-  route: PreemptiveCompactionRoute;
-  shouldCompact: boolean;
-  estimatedPromptTokens: number;
-  promptBudgetBeforeReserve: number;
-  overflowTokens: number;
-  toolResultReducibleChars: number;
-  effectiveReserveTokens: number;
-} {
+}): PreemptiveCompactionDecision {
   let messagesForPressure = params.messages;
   let estimatedPromptTokens = estimatePrePromptTokens({
     messages: params.messages,
@@ -116,4 +118,35 @@ export function shouldPreemptivelyCompactBeforePrompt(params: {
     toolResultReducibleChars,
     effectiveReserveTokens,
   };
+}
+
+export function formatPrePromptPrecheckLog(params: {
+  result: PreemptiveCompactionDecision;
+  sessionKey?: string;
+  sessionId?: string;
+  provider: string;
+  modelId: string;
+  messageCount: number;
+  unwindowedMessageCount?: number;
+  contextTokenBudget: number;
+  reserveTokens: number;
+  sessionFile?: string;
+}): string {
+  const { result } = params;
+  return (
+    `[context-overflow-precheck] pre-prompt check ` +
+    `sessionKey=${params.sessionKey ?? params.sessionId ?? "unknown"} ` +
+    `provider=${params.provider}/${params.modelId} ` +
+    `route=${result.route} ` +
+    `estimatedPromptTokens=${result.estimatedPromptTokens} ` +
+    `promptBudgetBeforeReserve=${result.promptBudgetBeforeReserve} ` +
+    `overflowTokens=${result.overflowTokens} ` +
+    `toolResultReducibleChars=${result.toolResultReducibleChars} ` +
+    `reserveTokens=${params.reserveTokens} ` +
+    `effectiveReserveTokens=${result.effectiveReserveTokens} ` +
+    `contextTokenBudget=${params.contextTokenBudget} ` +
+    `messages=${params.messageCount} ` +
+    `unwindowedMessages=${params.unwindowedMessageCount ?? params.messageCount} ` +
+    `sessionFile=${params.sessionFile}`
+  );
 }


### PR DESCRIPTION
## Summary

- Problem: the pre-prompt auto-compaction precheck only logged recovery routes, so a normal `route=fits` decision looked the same as the precheck not running.
- Solution: format and emit one debug-level pre-prompt precheck line for every decision route, including `fits`.
- What changed: the log now includes route, estimated prompt tokens, prompt budget before reserve, overflow tokens, reducible tool-result chars, reserve/effective reserve, context budget, message counts, provider/model, and session identity.
- What did NOT change: no compaction thresholds, pruning behavior, cache-ttl policy, model routing, or payload policy changed.

## Motivation

#68609 is an observability gap: the budget decision already exists at the pre-prompt call site, but the normal `fits` path previously fell through silently. This is budget stack PR 1: it makes the decision visible before later PRs persist/report/classify budget state.

## Linked Issue/PR

- Closes #68609
- Related #80594
- Related #9409
- Follow-up stack: #84785, #84800

## Real behavior proof (required for external PRs)

Behavior addressed: pre-prompt compaction precheck decisions now produce a debug-formatted diagnostic line even when the route is `fits`, with the token fields requested in #68609.

Real environment tested: local Windows source worktree on Node `v24.14.0`, rebased on `openclaw/main` at `c0312748c4`.

Exact steps or command run after this patch:

- `node --version`
- `git diff --check openclaw/main...HEAD`
- `node node_modules\vitest\vitest.mjs run src/agents/pi-embedded-runner/run/preemptive-compaction.test.ts --reporter=verbose`
- `node_modules\.bin\oxfmt.CMD --check src/agents/pi-embedded-runner/run/attempt.ts src/agents/pi-embedded-runner/run/preemptive-compaction.ts src/agents/pi-embedded-runner/run/preemptive-compaction.test.ts`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/pr84676.tsbuildinfo`
- `node --import tsx -e "const { shouldPreemptivelyCompactBeforePrompt, formatPrePromptPrecheckLog } = await import('./src/agents/pi-embedded-runner/run/preemptive-compaction.ts'); const result = shouldPreemptivelyCompactBeforePrompt({ messages: [{ role: 'assistant', content: [{ type: 'text', text: 'short history' }], timestamp: 1 }], systemPrompt: 'sys', prompt: 'hello', contextTokenBudget: 10000, reserveTokens: 1000 }); console.log(formatPrePromptPrecheckLog({ result, sessionKey: 'agent:main:main', sessionId: 'redacted-session', provider: 'anthropic', modelId: 'claude-opus-4-6', messageCount: 1, unwindowedMessageCount: 1, contextTokenBudget: 10000, reserveTokens: 1000, sessionFile: 'redacted-session.jsonl' }));"`

Evidence after fix:

```text
node --version
v24.14.0

git diff --check openclaw/main...HEAD
# passed

node node_modules\vitest\vitest.mjs run src/agents/pi-embedded-runner/run/preemptive-compaction.test.ts --reporter=verbose
# passed: Test Files 2 passed (2), Tests 22 passed (22)

node_modules\.bin\oxfmt.CMD --check src/agents/pi-embedded-runner/run/attempt.ts src/agents/pi-embedded-runner/run/preemptive-compaction.ts src/agents/pi-embedded-runner/run/preemptive-compaction.test.ts
# All matched files use the correct format.

node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/pr84676.tsbuildinfo
# passed

[context-overflow-precheck] pre-prompt check sessionKey=agent:main:main provider=anthropic/claude-opus-4-6 route=fits estimatedPromptTokens=8 promptBudgetBeforeReserve=9000 overflowTokens=0 toolResultReducibleChars=0 reserveTokens=1000 effectiveReserveTokens=1000 contextTokenBudget=10000 messages=1 unwindowedMessages=1 sessionFile=redacted-session.jsonl
```

Observed result after fix: `route=fits` now produces the same diagnostic namespace as recovery routes, with the fields needed to distinguish “precheck ran and fits” from “precheck did not run”. The call site invokes the formatter for every non-skipped precheck result before the existing recovery branches.

What was not tested: a long-running live Anthropic Opus/cache-ttl session was not reproduced; this PR intentionally adds diagnostics before changing heuristic or pruning policy. Broad CI is rerunning on the rebased SHA; the previous red shard was `checks-node-core-runtime-infra-state` in unrelated `src/infra/secret-file.test.ts`.

## Root Cause

The pre-prompt call site only logged truncation and compaction branches. A `fits` result continued directly to prompt submission without a diagnostic, unlike the mid-turn precheck path where all routes were already logged.

## Regression Test Plan

- Coverage level: unit/helper test
- Target test: `src/agents/pi-embedded-runner/run/preemptive-compaction.test.ts`
- Scenario: formatting a `fits` pre-prompt precheck diagnostic includes route and budget fields.
- Why this guardrail is scoped: the runner path is expensive; the formatter is production code and the call site now invokes it for every precheck result.

## User-visible / Behavior Changes

Debug logs include an additional `[context-overflow-precheck] pre-prompt check ... route=fits` line when debug logging is enabled. Runtime behavior is unchanged.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Risks and Mitigations

- Risk: extra debug line could be noisy in debug mode.
  - Mitigation: it is debug-level only and reuses the existing context-overflow precheck log namespace.
