### PR TITLE
fix(approval): route /approve through approval resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - WhatsApp: update Baileys to `7.0.0-rc12`.
+- Approvals: route manual `/approve` decisions through the trusted approval runtime so active exec and plugin approvals no longer look unknown or expired.
 - Dependencies: update `@openclaw/fs-safe` to `0.2.7` so OpenClaw's default Python-helper-off policy keeps best-effort Node write fallbacks for private stores, secret writes, run logs, and media attachments on Linux/macOS.
 - Infra/secrets: restore the fail-closed contract for `tryReadSecretFileSync` so credential loaders that pass `rejectSymlink: true` (Telegram, LINE, Zalo, IRC, Nextcloud Talk tokens) refuse symlinked credential files instead of silently accepting them, and the infra-state CI shard's secret-file symlink test passes again. Thanks @romneyda.
 - Browser: honor the configured image sanitization limit for screenshots and labeled snapshots so browser-captured images follow the same resize policy as other image results. (#84595)

--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -164,7 +164,7 @@ Current source-of-truth:
   <Accordion title="Skills, allowlists, approvals">
     - `/skill <name> [input]` runs a skill by name.
     - `/allowlist [list|add|remove] ...` manages allowlist entries. Text-only.
-    - `/approve <id> <decision>` resolves exec approval prompts.
+    - `/approve <id> <decision>` resolves exec or plugin approval prompts.
     - `/btw <question>` asks a side question without changing future session context. Alias: `/side`. See [BTW](/tools/btw).
 
   </Accordion>

--- a/src/auto-reply/reply/commands-approve.test.ts
+++ b/src/auto-reply/reply/commands-approve.test.ts
@@ -15,10 +15,10 @@ import {
 import { handleApproveCommand } from "./commands-approve.js";
 import type { HandleCommandsParams } from "./commands-types.js";
 
-const callGatewayMock = vi.hoisted(() => vi.fn());
+const resolveApprovalOverGatewayMock = vi.hoisted(() => vi.fn());
 
-vi.mock("../../gateway/call.js", () => ({
-  callGateway: callGatewayMock,
+vi.mock("../../infra/approval-gateway-resolver.js", () => ({
+  resolveApprovalOverGateway: resolveApprovalOverGatewayMock,
 }));
 
 vi.mock("../../globals.js", () => ({
@@ -32,26 +32,31 @@ function requireRecord(value: unknown, label: string): Record<string, unknown> {
   return value as Record<string, unknown>;
 }
 
-function gatewayRequest(callIndex = 0) {
-  const call = callGatewayMock.mock.calls[callIndex] as unknown[] | undefined;
+function approvalResolverRequest(callIndex = 0) {
+  const call = resolveApprovalOverGatewayMock.mock.calls[callIndex] as unknown[] | undefined;
   if (!call) {
-    throw new Error(`expected gateway call ${callIndex}`);
+    throw new Error(`expected approval resolver call ${callIndex}`);
   }
-  return requireRecord(call[0], `gateway call ${callIndex} request`);
+  return requireRecord(call[0], `approval resolver call ${callIndex} request`);
 }
 
-function expectGatewayResolveCall(params: {
+function expectApprovalResolverCall(params: {
   callIndex?: number;
   method: string;
   id: string;
   decision?: string;
 }) {
-  const request = gatewayRequest(params.callIndex ?? 0);
-  expect(request.method).toBe(params.method);
-  expect(request.params).toEqual({
-    id: params.id,
-    decision: params.decision ?? "allow-once",
-  });
+  const request = approvalResolverRequest(params.callIndex ?? 0);
+  expect(request).toHaveProperty("cfg");
+  expect(request).toHaveProperty("senderId");
+  expect(request.approvalId).toBe(params.id);
+  expect(request.decision).toBe(params.decision ?? "allow-once");
+  if (params.method === "plugin.approval.resolve") {
+    expect(request.resolveMethod).toBe("plugin");
+  } else {
+    expect(request).not.toHaveProperty("resolveMethod");
+  }
+  expect(request.clientDisplayName).toMatch(/^Chat approval \(.+\)$/);
 }
 
 function normalizeDiscordDirectApproverId(value: string | number): string | undefined {
@@ -482,7 +487,7 @@ describe("handleApproveCommand", () => {
   });
 
   it("submits approval", async () => {
-    callGatewayMock.mockResolvedValue({ ok: true });
+    resolveApprovalOverGatewayMock.mockResolvedValue(undefined);
     const result = await handleApproveCommand(
       buildApproveParams(
         "/approve abc allow-once",
@@ -497,11 +502,11 @@ describe("handleApproveCommand", () => {
 
     expect(result?.shouldContinue).toBe(false);
     expect(result?.reply?.text).toContain("Approval allow-once submitted");
-    expectGatewayResolveCall({ method: "exec.approval.resolve", id: "abc" });
+    expectApprovalResolverCall({ method: "exec.approval.resolve", id: "abc" });
   });
 
   it("accepts bare approve text for Slack-style manual approvals", async () => {
-    callGatewayMock.mockResolvedValue({ ok: true });
+    resolveApprovalOverGatewayMock.mockResolvedValue(undefined);
     const result = await handleApproveCommand(
       buildApproveParams(
         "approve abc allow-once",
@@ -520,7 +525,7 @@ describe("handleApproveCommand", () => {
 
     expect(result?.shouldContinue).toBe(false);
     expect(result?.reply?.text).toContain("Approval allow-once submitted");
-    expectGatewayResolveCall({ method: "exec.approval.resolve", id: "abc" });
+    expectApprovalResolverCall({ method: "exec.approval.resolve", id: "abc" });
   });
 
   it("accepts Telegram /approve from configured approvers even when chat access is otherwise blocked", async () => {
@@ -530,12 +535,12 @@ describe("handleApproveCommand", () => {
       SenderId: "123",
     });
     params.command.isAuthorizedSender = false;
-    callGatewayMock.mockResolvedValue({ ok: true });
+    resolveApprovalOverGatewayMock.mockResolvedValue(undefined);
 
     const result = await handleApproveCommand(params, true);
     expect(result?.shouldContinue).toBe(false);
     expect(result?.reply?.text).toContain("Approval allow-once submitted");
-    expectGatewayResolveCall({ method: "exec.approval.resolve", id: "abc12345" });
+    expectApprovalResolverCall({ method: "exec.approval.resolve", id: "abc12345" });
   });
 
   it("honors the configured default account for omitted-account /approve auth", async () => {
@@ -548,7 +553,7 @@ describe("handleApproveCommand", () => {
         },
       ]),
     );
-    callGatewayMock.mockResolvedValue({ ok: true });
+    resolveApprovalOverGatewayMock.mockResolvedValue(undefined);
     const params = buildApproveParams(
       "/approve abc12345 allow-once",
       {
@@ -577,7 +582,7 @@ describe("handleApproveCommand", () => {
     const result = await handleApproveCommand(params, true);
     expect(result?.shouldContinue).toBe(false);
     expect(result?.reply?.text).toContain("Approval allow-once submitted");
-    expectGatewayResolveCall({ method: "exec.approval.resolve", id: "abc12345" });
+    expectApprovalResolverCall({ method: "exec.approval.resolve", id: "abc12345" });
   });
 
   it("accepts Signal /approve from configured approvers even when chat access is otherwise blocked", async () => {
@@ -598,12 +603,12 @@ describe("handleApproveCommand", () => {
       },
     );
     params.command.isAuthorizedSender = false;
-    callGatewayMock.mockResolvedValue({ ok: true });
+    resolveApprovalOverGatewayMock.mockResolvedValue(undefined);
 
     const result = await handleApproveCommand(params, true);
     expect(result?.shouldContinue).toBe(false);
     expect(result?.reply?.text).toContain("Approval allow-once submitted");
-    expectGatewayResolveCall({ method: "exec.approval.resolve", id: "abc12345" });
+    expectApprovalResolverCall({ method: "exec.approval.resolve", id: "abc12345" });
   });
 
   it("does not treat implicit default approval auth as a bypass for unauthorized senders", async () => {
@@ -623,7 +628,7 @@ describe("handleApproveCommand", () => {
     const result = await handleApproveCommand(params, true);
     expect(result?.shouldContinue).toBe(false);
     expect(result?.reply).toBeUndefined();
-    expect(callGatewayMock).not.toHaveBeenCalled();
+    expect(resolveApprovalOverGatewayMock).not.toHaveBeenCalled();
   });
 
   it("does not treat implicit same-chat approval auth as a bypass for unauthorized senders", async () => {
@@ -659,7 +664,7 @@ describe("handleApproveCommand", () => {
     const result = await handleApproveCommand(params, true);
     expect(result?.shouldContinue).toBe(false);
     expect(result?.reply).toBeUndefined();
-    expect(callGatewayMock).not.toHaveBeenCalled();
+    expect(resolveApprovalOverGatewayMock).not.toHaveBeenCalled();
   });
 
   it("does not allow empty helper approvers to bypass unauthorized sender checks", async () => {
@@ -684,11 +689,11 @@ describe("handleApproveCommand", () => {
     const result = await handleApproveCommand(params, true);
     expect(result?.shouldContinue).toBe(false);
     expect(result?.reply).toBeUndefined();
-    expect(callGatewayMock).not.toHaveBeenCalled();
+    expect(resolveApprovalOverGatewayMock).not.toHaveBeenCalled();
   });
 
   it("keeps same-chat /approve available to authorized senders when helper approvers are empty", async () => {
-    callGatewayMock.mockResolvedValue({ ok: true });
+    resolveApprovalOverGatewayMock.mockResolvedValue(undefined);
     const params = buildApproveParams(
       "/approve abc12345 allow-once",
       {
@@ -710,7 +715,7 @@ describe("handleApproveCommand", () => {
     const result = await handleApproveCommand(params, true);
     expect(result?.shouldContinue).toBe(false);
     expect(result?.reply?.text).toContain("Approval allow-once submitted");
-    expectGatewayResolveCall({ method: "exec.approval.resolve", id: "abc12345" });
+    expectApprovalResolverCall({ method: "exec.approval.resolve", id: "abc12345" });
   });
 
   it("accepts Telegram /approve from exec target recipients when native approvals are disabled", async () => {
@@ -738,12 +743,12 @@ describe("handleApproveCommand", () => {
       },
     );
     params.command.isAuthorizedSender = false;
-    callGatewayMock.mockResolvedValue({ ok: true });
+    resolveApprovalOverGatewayMock.mockResolvedValue(undefined);
 
     const result = await handleApproveCommand(params, true);
     expect(result?.shouldContinue).toBe(false);
     expect(result?.reply?.text).toContain("Approval allow-once submitted");
-    expectGatewayResolveCall({ method: "exec.approval.resolve", id: "abc12345" });
+    expectApprovalResolverCall({ method: "exec.approval.resolve", id: "abc12345" });
   });
 
   it("requires configured Discord approvers for exec approvals", async () => {
@@ -753,21 +758,21 @@ describe("handleApproveCommand", () => {
         cfg: createDiscordApproveCfg(null),
         senderId: "123",
         expectedText: "not authorized to approve",
-        expectedGatewayCalls: 0,
+        expectedResolverCalls: 0,
       },
       {
         name: "discord non approver",
         cfg: createDiscordApproveCfg({ enabled: true, approvers: ["999"], target: "channel" }),
         senderId: "123",
         expectedText: "not authorized to approve",
-        expectedGatewayCalls: 0,
+        expectedResolverCalls: 0,
       },
       {
         name: "discord approver with rich client disabled",
         cfg: createDiscordApproveCfg({ enabled: false, approvers: ["123"], target: "channel" }),
         senderId: "123",
         expectedText: "Approval allow-once submitted",
-        expectedGatewayCalls: 1,
+        expectedResolverCalls: 1,
         expectedMethod: "exec.approval.resolve",
       },
       {
@@ -775,13 +780,13 @@ describe("handleApproveCommand", () => {
         cfg: createDiscordApproveCfg({ enabled: true, approvers: ["123"], target: "channel" }),
         senderId: "123",
         expectedText: "Approval allow-once submitted",
-        expectedGatewayCalls: 1,
+        expectedResolverCalls: 1,
         expectedMethod: "exec.approval.resolve",
       },
     ] as const) {
-      callGatewayMock.mockReset();
-      if (testCase.expectedGatewayCalls > 0) {
-        callGatewayMock.mockResolvedValue({ ok: true });
+      resolveApprovalOverGatewayMock.mockReset();
+      if (testCase.expectedResolverCalls > 0) {
+        resolveApprovalOverGatewayMock.mockResolvedValue(undefined);
       }
       const result = await handleApproveCommand(
         buildApproveParams("/approve abc12345 allow-once", testCase.cfg, {
@@ -793,9 +798,11 @@ describe("handleApproveCommand", () => {
       );
       expect(result?.shouldContinue, testCase.name).toBe(false);
       expect(result?.reply?.text, testCase.name).toContain(testCase.expectedText);
-      expect(callGatewayMock, testCase.name).toHaveBeenCalledTimes(testCase.expectedGatewayCalls);
+      expect(resolveApprovalOverGatewayMock, testCase.name).toHaveBeenCalledTimes(
+        testCase.expectedResolverCalls,
+      );
       if ("expectedMethod" in testCase && testCase.expectedMethod) {
-        expectGatewayResolveCall({
+        expectApprovalResolverCall({
           method: testCase.expectedMethod,
           id: "abc12345",
         });
@@ -816,8 +823,8 @@ describe("handleApproveCommand", () => {
         senderId: "123",
       },
     ] as const) {
-      callGatewayMock.mockReset();
-      callGatewayMock.mockResolvedValue({ ok: true });
+      resolveApprovalOverGatewayMock.mockReset();
+      resolveApprovalOverGatewayMock.mockResolvedValue(undefined);
       const result = await handleApproveCommand(
         buildApproveParams("/approve legacy-plugin-123 allow-once", testCase.cfg, {
           Provider: "discord",
@@ -828,13 +835,15 @@ describe("handleApproveCommand", () => {
       );
       expect(result?.shouldContinue, testCase.name).toBe(false);
       expect(result?.reply?.text, testCase.name).toContain("not authorized to approve");
-      expect(callGatewayMock, testCase.name).not.toHaveBeenCalled();
+      expect(resolveApprovalOverGatewayMock, testCase.name).not.toHaveBeenCalled();
     }
   });
 
   it("preserves legacy unprefixed plugin approval fallback on Discord", async () => {
-    callGatewayMock.mockRejectedValueOnce(new Error("unknown or expired approval id"));
-    callGatewayMock.mockResolvedValueOnce({ ok: true });
+    resolveApprovalOverGatewayMock.mockRejectedValueOnce(
+      new Error("unknown or expired approval id"),
+    );
+    resolveApprovalOverGatewayMock.mockResolvedValueOnce(undefined);
     const result = await handleApproveCommand(
       buildApproveParams(
         "/approve legacy-plugin-123 allow-once",
@@ -850,8 +859,8 @@ describe("handleApproveCommand", () => {
 
     expect(result?.shouldContinue).toBe(false);
     expect(result?.reply?.text).toContain("Approval allow-once submitted");
-    expect(callGatewayMock).toHaveBeenCalledTimes(2);
-    expectGatewayResolveCall({
+    expect(resolveApprovalOverGatewayMock).toHaveBeenCalledTimes(2);
+    expectApprovalResolverCall({
       callIndex: 1,
       method: "plugin.approval.resolve",
       id: "legacy-plugin-123",
@@ -879,7 +888,9 @@ describe("handleApproveCommand", () => {
         },
       ]),
     );
-    callGatewayMock.mockRejectedValueOnce(new Error("unknown or expired approval id"));
+    resolveApprovalOverGatewayMock.mockRejectedValueOnce(
+      new Error("unknown or expired approval id"),
+    );
 
     const result = await handleApproveCommand(
       buildApproveParams(
@@ -900,8 +911,8 @@ describe("handleApproveCommand", () => {
     expect(result?.shouldContinue).toBe(false);
     expect(result?.reply?.text).toContain("Failed to submit approval");
     expect(result?.reply?.text).toContain("unknown or expired approval id");
-    expect(callGatewayMock).toHaveBeenCalledTimes(1);
-    expectGatewayResolveCall({ method: "plugin.approval.resolve", id: "abc123" });
+    expect(resolveApprovalOverGatewayMock).toHaveBeenCalledTimes(1);
+    expectApprovalResolverCall({ method: "plugin.approval.resolve", id: "abc123" });
   });
 
   it("requires configured Discord approvers for plugin approvals", async () => {
@@ -911,19 +922,19 @@ describe("handleApproveCommand", () => {
         cfg: createDiscordApproveCfg({ enabled: false, approvers: ["999"], target: "channel" }),
         senderId: "123",
         expectedText: "not authorized to approve plugin requests",
-        expectedGatewayCalls: 0,
+        expectedResolverCalls: 0,
       },
       {
         name: "discord plugin approver",
         cfg: createDiscordApproveCfg({ enabled: false, approvers: ["123"], target: "channel" }),
         senderId: "123",
         expectedText: "Approval allow-once submitted",
-        expectedGatewayCalls: 1,
+        expectedResolverCalls: 1,
       },
     ] as const) {
-      callGatewayMock.mockReset();
-      if (testCase.expectedGatewayCalls > 0) {
-        callGatewayMock.mockResolvedValue({ ok: true });
+      resolveApprovalOverGatewayMock.mockReset();
+      if (testCase.expectedResolverCalls > 0) {
+        resolveApprovalOverGatewayMock.mockResolvedValue(undefined);
       }
       const result = await handleApproveCommand(
         buildApproveParams("/approve plugin:abc123 allow-once", testCase.cfg, {
@@ -935,9 +946,11 @@ describe("handleApproveCommand", () => {
       );
       expect(result?.shouldContinue, testCase.name).toBe(false);
       expect(result?.reply?.text, testCase.name).toContain(testCase.expectedText);
-      expect(callGatewayMock, testCase.name).toHaveBeenCalledTimes(testCase.expectedGatewayCalls);
-      if (testCase.expectedGatewayCalls > 0) {
-        expectGatewayResolveCall({ method: "plugin.approval.resolve", id: "plugin:abc123" });
+      expect(resolveApprovalOverGatewayMock, testCase.name).toHaveBeenCalledTimes(
+        testCase.expectedResolverCalls,
+      );
+      if (testCase.expectedResolverCalls > 0) {
+        expectApprovalResolverCall({ method: "plugin.approval.resolve", id: "plugin:abc123" });
       }
     }
   });
@@ -954,7 +967,7 @@ describe("handleApproveCommand", () => {
           SenderId: "123",
         },
         expectedText: "targets a different Telegram bot",
-        expectGatewayCalls: 0,
+        expectResolverCalls: 0,
       },
       {
         name: "unknown approval id",
@@ -965,9 +978,12 @@ describe("handleApproveCommand", () => {
           Surface: "telegram",
           SenderId: "123",
         },
-        setup: () => callGatewayMock.mockRejectedValue(new Error("unknown or expired approval id")),
+        setup: () =>
+          resolveApprovalOverGatewayMock.mockRejectedValue(
+            new Error("unknown or expired approval id"),
+          ),
         expectedText: "unknown or expired approval id",
-        expectGatewayCalls: 2,
+        expectResolverCalls: 2,
       },
       {
         name: "telegram disabled native delivery reports the channel-disabled message",
@@ -979,7 +995,7 @@ describe("handleApproveCommand", () => {
           SenderId: "123",
         },
         expectedText: "Telegram exec approvals are not enabled",
-        expectGatewayCalls: 0,
+        expectResolverCalls: 0,
       },
       {
         name: "non approver",
@@ -991,10 +1007,10 @@ describe("handleApproveCommand", () => {
           SenderId: "123",
         },
         expectedText: "not authorized to approve",
-        expectGatewayCalls: 0,
+        expectResolverCalls: 0,
       },
     ] as const) {
-      callGatewayMock.mockReset();
+      resolveApprovalOverGatewayMock.mockReset();
       testCase.setup?.();
       const result = await handleApproveCommand(
         buildApproveParams(testCase.commandBody, testCase.cfg, testCase.ctx),
@@ -1002,7 +1018,9 @@ describe("handleApproveCommand", () => {
       );
       expect(result?.shouldContinue, testCase.name).toBe(false);
       expect(result?.reply?.text, testCase.name).toContain(testCase.expectedText);
-      expect(callGatewayMock, testCase.name).toHaveBeenCalledTimes(testCase.expectGatewayCalls);
+      expect(resolveApprovalOverGatewayMock, testCase.name).toHaveBeenCalledTimes(
+        testCase.expectResolverCalls,
+      );
     }
   });
 
@@ -1014,21 +1032,21 @@ describe("handleApproveCommand", () => {
       {
         scopes: ["operator.write"],
         expectedText: "requires operator.approvals",
-        expectedGatewayCalls: 0,
+        expectedResolverCalls: 0,
       },
       {
         scopes: ["operator.approvals"],
         expectedText: "Approval allow-once submitted",
-        expectedGatewayCalls: 1,
+        expectedResolverCalls: 1,
       },
       {
         scopes: ["operator.admin"],
         expectedText: "Approval allow-once submitted",
-        expectedGatewayCalls: 1,
+        expectedResolverCalls: 1,
       },
     ] as const) {
-      callGatewayMock.mockReset();
-      callGatewayMock.mockResolvedValue({ ok: true });
+      resolveApprovalOverGatewayMock.mockReset();
+      resolveApprovalOverGatewayMock.mockResolvedValue(undefined);
       const result = await handleApproveCommand(
         buildApproveParams("/approve abc allow-once", cfg, {
           Provider: "webchat",
@@ -1040,12 +1058,12 @@ describe("handleApproveCommand", () => {
 
       expect(result?.shouldContinue, String(testCase.scopes)).toBe(false);
       expect(result?.reply?.text, String(testCase.scopes)).toContain(testCase.expectedText);
-      expect(callGatewayMock, String(testCase.scopes)).toHaveBeenCalledTimes(
-        testCase.expectedGatewayCalls,
+      expect(resolveApprovalOverGatewayMock, String(testCase.scopes)).toHaveBeenCalledTimes(
+        testCase.expectedResolverCalls,
       );
-      if (testCase.expectedGatewayCalls > 0) {
-        expectGatewayResolveCall({
-          callIndex: callGatewayMock.mock.calls.length - 1,
+      if (testCase.expectedResolverCalls > 0) {
+        expectApprovalResolverCall({
+          callIndex: resolveApprovalOverGatewayMock.mock.calls.length - 1,
           method: "exec.approval.resolve",
           id: "abc",
         });

--- a/src/auto-reply/reply/commands-approve.ts
+++ b/src/auto-reply/reply/commands-approve.ts
@@ -2,10 +2,9 @@ import {
   getChannelPlugin,
   resolveChannelApprovalCapability,
 } from "../../channels/plugins/index.js";
-import { callGateway } from "../../gateway/call.js";
-import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../../gateway/protocol/client-info.js";
 import { logVerbose } from "../../globals.js";
 import { isApprovalNotFoundError } from "../../infra/approval-errors.js";
+import { resolveApprovalOverGateway } from "../../infra/approval-gateway-resolver.js";
 import { resolveApprovalCommandAuthorization } from "../../infra/channel-approval-auth.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { normalizeLowercaseStringOrEmpty } from "../../shared/string-coerce.js";
@@ -191,13 +190,14 @@ export const handleApproveCommand: CommandHandler = async (params, allowTextComm
   }
 
   const resolvedBy = buildResolvedByLabel(params);
-  const callApprovalMethod = async (method: string): Promise<void> => {
-    await callGateway({
-      method,
-      params: { id: parsed.id, decision: parsed.decision },
-      clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
+  const callApprovalMethod = async (method: ApprovalMethod): Promise<void> => {
+    await resolveApprovalOverGateway({
+      cfg: params.cfg,
+      approvalId: parsed.id,
+      decision: parsed.decision,
+      senderId: params.command.senderId,
+      ...(method === "plugin.approval.resolve" ? { resolveMethod: "plugin" as const } : {}),
       clientDisplayName: `Chat approval (${resolvedBy})`,
-      mode: GATEWAY_CLIENT_MODES.BACKEND,
     });
   };
 
@@ -219,14 +219,11 @@ export const handleApproveCommand: CommandHandler = async (params, allowTextComm
     };
   }
 
-  let lastError: unknown = null;
   for (const [index, method] of methods.entries()) {
     try {
       await callApprovalMethod(method);
-      lastError = null;
       break;
     } catch (error) {
-      lastError = error;
       const isLastMethod = index === methods.length - 1;
       if (!isApprovalNotFoundError(error) || isLastMethod) {
         return {
@@ -235,13 +232,6 @@ export const handleApproveCommand: CommandHandler = async (params, allowTextComm
         };
       }
     }
-  }
-
-  if (lastError) {
-    return {
-      shouldContinue: false,
-      reply: { text: `❌ Failed to submit approval: ${formatApprovalSubmitError(lastError)}` },
-    };
   }
 
   return {


### PR DESCRIPTION
## Summary

- Problem: the shared `/approve` command submitted approval decisions through the generic `callGateway` helper. That opened an ordinary transient Gateway request instead of the operator approvals resolver/client path, so approvals that require the trusted approval-runtime client context could be invisible and surface as `unknown or expired`.
- Solution: route `/approve` submissions through `resolveApprovalOverGateway`. That helper connects via the operator approvals Gateway client path and sends approval decisions with the approval-runtime client context used by the exec/plugin approval managers.
- What changed: updated the shared approve command handler to use the approval resolver, preserved exec approval behavior, kept plugin approval routing for `plugin:<id>` approvals, refreshed focused tests around resolver calls and fallback routing, and documented that `/approve` handles exec and plugin approvals.
- What did NOT change (scope boundary): approval authorization policy, approver config shape, native approval delivery, and approval id formats are unchanged.

## Motivation

- Manual `/approve` should behave like native approval actions: it needs to resolve through the trusted approval runtime, not through a one-off generic Gateway call. The failure was observed from Slack with `/approve plugin:<id>`, but the fix is in the shared command path and applies to approval submission generally.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior addressed: manual channel `/approve` should resolve pending exec/plugin approvals through the approval resolver instead of returning `unknown or expired approval id` because the generic Gateway client path cannot see the approval.
- Real environment tested: isolated local OpenClaw Gateway on macOS/Darwin arm64, Node v24.15.0. The proof used a Slack native command context against the real Gateway approval APIs and resolver path; it did not call the Slack network.
- Exact steps or command run after this patch: `node --import tsx --input-type=module <temporary proof harness> | tee /tmp/openclaw-pr-84678-approval-proof.txt`; then `node scripts/run-vitest.mjs src/auto-reply/reply/commands-approve.test.ts`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
proof started gateway_url=ws://127.0.0.1:52702
proof command_context=slack native /approve
proof approval_listener=ready scopes=operator.approvals internal_runtime=true
plugin request accepted status=accepted id=plugin:fe8734e7-2b24-4549-9bc3-6e9a675c0427
plugin command reply=✅ Approval allow-once submitted for plugin:fe8734e7-2b24-4549-9bc3-6e9a675c0427.
plugin waitDecision id=plugin:fe8734e7-2b24-4549-9bc3-6e9a675c0427 decision=allow-once
exec request accepted status=accepted id=proof-exec-3a13b093-ef6e-48cb-a09e-827bd7756e66
exec command reply=✅ Approval allow-once submitted for proof-exec-3a13b093-ef6e-48cb-a09e-827bd7756e66.
exec waitDecision id=proof-exec-3a13b093-ef6e-48cb-a09e-827bd7756e66 decision=allow-once
gateway events=plugin.approval.requested,plugin.approval.resolved,exec.approval.requested,exec.approval.resolved
proof result=pass
```

Focused test output:

```text
node scripts/run-vitest.mjs src/auto-reply/reply/commands-approve.test.ts
Test Files  1 passed (1)
Tests       18 passed (18)
```

- Observed result after fix: `/approve plugin:<id> allow-once` in a channel command context resolved a live pending plugin approval through `plugin.approval.resolve`, and `/approve <exec-id> allow-once` still resolved an exec approval through `exec.approval.resolve`. Gateway events included requested and resolved events for both approval families.
- What was not tested: actual Slack app network slash-command callback delivery from Slack's servers; this proof invokes the Slack command handler locally while using a real Gateway and WebSocket approval clients.
- Before evidence (optional but encouraged): prior manual Slack `/approve plugin:<id> allow-once` returned `Failed to submit approval: unknown or expired approval id`.

## Root Cause (if applicable)

- Root cause: `/approve` bypassed `resolveApprovalOverGateway` and called `callGateway` directly. The generic call did not use the operator approvals client path that supplies the trusted approval-runtime client context required by approval visibility checks.
- Relevant contract: approval resolution filters pending approval records through the connected Gateway client. A trusted approval-runtime client is established by connecting as the Gateway backend approval client with `operator.approvals` scope and the approval runtime token; `resolveApprovalOverGateway` owns that connection path.
- Missing detection / guardrail: tests asserted raw Gateway method calls instead of verifying that `/approve` uses the approval resolver path used by native approval actions.
- Contributing context (if known): exec and plugin approvals both resolve through the shared approval visibility contract; plugin ids additionally need `plugin.approval.resolve` routing.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/reply/commands-approve.test.ts`
- Scenario the test should lock in: `/approve` calls `resolveApprovalOverGateway` instead of `callGateway`, preserves exec approval submission, routes `plugin:<id>` submissions to plugin approval resolution, and still enforces configured approvers across the shared command path.
- Why this is the smallest reliable guardrail: the regression was in shared command routing, before any live channel delivery behavior.
- Existing test that already covers this (if any): existing approve-command tests covered parsing/auth and are updated to assert the resolver path.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Manual `/approve` commands now submit decisions through the same approval resolver path used by trusted approval clients, so pending exec/plugin approvals can be resolved from channel command surfaces as documented.

## Diagram (if applicable)

```text
Before:
/channel /approve <id> -> callGateway -> ordinary transient gateway call -> approval may be hidden -> unknown/expired

After:
/channel /approve <id> -> resolveApprovalOverGateway -> operator approvals client -> approval manager -> resolved
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A.

## Repro + Verification

### Environment

- OS: Darwin 25.2.0 arm64
- Runtime/container: local worktree, Node v24.15.0, pnpm 11.1.0
- Model/provider: N/A
- Integration/channel (if any): shared manual `/approve` command path; verified with a Slack command context and focused command-handler tests
- Relevant config (redacted): channel approval approver config exercised in tests

### Steps

1. Submit `/approve <id> <decision>` from a configured approver.
2. Handler authorizes the sender for that approval family.
3. Handler calls `resolveApprovalOverGateway` to submit the decision through the operator approvals client path.

### Expected

- Pending exec/plugin approval resolves or the actual resolver error is returned.

### Actual

- Focused tests pass and assert approval routing through the resolver.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: real local Gateway proof for channel-context `/approve plugin:<id> allow-once`, real local Gateway proof for exec `/approve <id> allow-once`, focused approve-command test suite with exec approvals, plugin approvals, fallback routing, authorization, and gateway-client scopes.
- Edge cases checked: unauthorized plugin approvers remain rejected in tests; legacy unprefixed fallback still attempts exec then plugin in tests; plugin-only not-found errors surface cleanly in tests.
- What you did **not** verify: actual Slack network callback from the hosted Slack app in this split worktree.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: changing the manual command path could regress exec approval submission.
  - Mitigation: focused tests assert exec approval routing still submits successfully and preserve existing fallback behavior.



