### PR TITLE
fix: let target:none heartbeats recover from stale pending delivery

### DIFF
--- a/src/auto-reply/get-reply-options.types.ts
+++ b/src/auto-reply/get-reply-options.types.ts
@@ -67,6 +67,8 @@ export type GetReplyOptions = {
   suppressTyping?: boolean;
   /** Resolved heartbeat model override (provider/model string from merged per-agent config). */
   heartbeatModelOverride?: string;
+  /** If true, heartbeat runs bypass replaying stale pending final delivery text. */
+  skipHeartbeatPendingFinalDeliveryReplay?: boolean;
   /** One-shot thinking level override for this run; does not persist to the session. */
   thinkingLevelOverride?: string;
   /** One-shot fast-mode override for this run; does not persist to the session. */

--- a/src/auto-reply/reply/get-reply.fast-path.test.ts
+++ b/src/auto-reply/reply/get-reply.fast-path.test.ts
@@ -204,6 +204,49 @@ describe("getReplyFromConfig fast test bootstrap", () => {
     expect(vi.mocked(runPreparedReplyMock)).toHaveBeenCalledOnce();
   });
 
+  it("skips stale pending delivery replay for internal-only heartbeats", async () => {
+    vi.stubEnv("OPENCLAW_ALLOW_SLOW_REPLY_TESTS", "1");
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-heartbeat-pending-"));
+    const cfg = {
+      agents: {
+        defaults: {
+          model: "openai/gpt-4o",
+          workspace: home,
+        },
+      },
+      session: { store: path.join(home, "sessions.json") },
+    } as OpenClawConfig;
+
+    const sessionEntry = {
+      pendingFinalDelivery: true,
+      pendingFinalDeliveryText: "stale heartbeat reply",
+      pendingFinalDeliveryAttemptCount: 2,
+    };
+    mocks.initSessionState.mockResolvedValueOnce(
+      createGetReplySessionState({
+        storePath: undefined,
+        sessionEntry,
+      }),
+    );
+    mocks.resolveReplyDirectives.mockResolvedValueOnce({
+      kind: "reply",
+      reply: { text: "fresh heartbeat reply" },
+    });
+
+    await expect(
+      getReplyFromConfig(
+        buildGetReplyCtx(),
+        { isHeartbeat: true, skipHeartbeatPendingFinalDeliveryReplay: true },
+        cfg,
+      ),
+    ).resolves.toEqual({ text: "fresh heartbeat reply" });
+
+    expect(vi.mocked(runPreparedReplyMock)).not.toHaveBeenCalled();
+    expect(sessionEntry.pendingFinalDelivery).toBeUndefined();
+    expect(sessionEntry.pendingFinalDeliveryText).toBeUndefined();
+    expect(sessionEntry.pendingFinalDeliveryAttemptCount).toBeUndefined();
+  });
+
   it("passes image model overrides as one-turn selections to prepared replies", async () => {
     const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-image-model-directives-"));
     const cfg = markCompleteReplyConfig({

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -77,6 +77,41 @@ function resolveHeartbeatAckMaxChars(cfg: OpenClawConfig, agentId: string): numb
   );
 }
 
+async function clearPendingFinalDeliveryForSession(params: {
+  sessionEntry: Record<string, unknown>;
+  sessionKey?: string;
+  sessionStore?: Record<string, unknown>;
+  storePath?: string;
+}) {
+  const { sessionEntry, sessionKey, sessionStore, storePath } = params;
+  sessionEntry.pendingFinalDelivery = undefined;
+  sessionEntry.pendingFinalDeliveryText = undefined;
+  sessionEntry.pendingFinalDeliveryCreatedAt = undefined;
+  sessionEntry.pendingFinalDeliveryLastAttemptAt = undefined;
+  sessionEntry.pendingFinalDeliveryAttemptCount = undefined;
+  sessionEntry.pendingFinalDeliveryLastError = undefined;
+  sessionEntry.pendingFinalDeliveryContext = undefined;
+  if (sessionKey && sessionStore) {
+    sessionStore[sessionKey] = sessionEntry;
+  }
+  if (sessionKey && storePath) {
+    const { updateSessionStoreEntry } = await import("../../config/sessions.js");
+    await updateSessionStoreEntry({
+      storePath,
+      sessionKey,
+      update: async () => ({
+        pendingFinalDelivery: undefined,
+        pendingFinalDeliveryText: undefined,
+        pendingFinalDeliveryCreatedAt: undefined,
+        pendingFinalDeliveryLastAttemptAt: undefined,
+        pendingFinalDeliveryAttemptCount: undefined,
+        pendingFinalDeliveryLastError: undefined,
+        pendingFinalDeliveryContext: undefined,
+      }),
+    });
+  }
+}
+
 const sessionResetModelRuntimeLoader = createLazyImportLoader(
   () => import("./session-reset-model.runtime.js"),
 );
@@ -417,64 +452,53 @@ export async function getReplyFromConfig(
     // If it's a user message, we deliver the lost reply first, then continue.
     // For now, let's just return the lost reply if it's a heartbeat.
     if (opts?.isHeartbeat) {
-      const heartbeatPending = classifyHeartbeatPendingFinalDelivery(
-        text,
-        resolveHeartbeatAckMaxChars(cfg, agentId),
-      );
-      if (heartbeatPending.shouldClear) {
-        sessionEntry.pendingFinalDelivery = undefined;
-        sessionEntry.pendingFinalDeliveryText = undefined;
-        sessionEntry.pendingFinalDeliveryCreatedAt = undefined;
-        sessionEntry.pendingFinalDeliveryLastAttemptAt = undefined;
-        sessionEntry.pendingFinalDeliveryAttemptCount = undefined;
-        sessionEntry.pendingFinalDeliveryLastError = undefined;
-        sessionEntry.pendingFinalDeliveryContext = undefined;
-        if (sessionKey && sessionStore) {
-          sessionStore[sessionKey] = sessionEntry;
-        }
-        if (sessionKey && storePath) {
-          const { updateSessionStoreEntry } = await import("../../config/sessions.js");
-          await updateSessionStoreEntry({
-            storePath,
-            sessionKey,
-            update: async () => ({
-              pendingFinalDelivery: undefined,
-              pendingFinalDeliveryText: undefined,
-              pendingFinalDeliveryCreatedAt: undefined,
-              pendingFinalDeliveryLastAttemptAt: undefined,
-              pendingFinalDeliveryAttemptCount: undefined,
-              pendingFinalDeliveryLastError: undefined,
-              pendingFinalDeliveryContext: undefined,
-            }),
-          });
-        }
+      if (opts.skipHeartbeatPendingFinalDeliveryReplay) {
+        await clearPendingFinalDeliveryForSession({
+          sessionEntry,
+          sessionKey,
+          sessionStore,
+          storePath,
+        });
       } else {
-        const updatedAt = Date.now();
-        const attemptCount = (sessionEntry.pendingFinalDeliveryAttemptCount ?? 0) + 1;
-        sessionEntry.pendingFinalDeliveryLastAttemptAt = updatedAt;
-        sessionEntry.pendingFinalDeliveryAttemptCount = attemptCount;
-        sessionEntry.pendingFinalDeliveryLastError = null;
-        const replayText = sanitizePendingFinalDeliveryText(heartbeatPending.replayText);
-        sessionEntry.pendingFinalDeliveryText = replayText;
-        sessionEntry.updatedAt = updatedAt;
-        if (sessionKey && sessionStore) {
-          sessionStore[sessionKey] = sessionEntry;
-        }
-        if (sessionKey && storePath) {
-          const { updateSessionStoreEntry } = await import("../../config/sessions.js");
-          await updateSessionStoreEntry({
-            storePath,
+        const heartbeatPending = classifyHeartbeatPendingFinalDelivery(
+          text,
+          resolveHeartbeatAckMaxChars(cfg, agentId),
+        );
+        if (heartbeatPending.shouldClear) {
+          await clearPendingFinalDeliveryForSession({
+            sessionEntry,
             sessionKey,
-            update: async () => ({
-              pendingFinalDeliveryText: replayText,
-              pendingFinalDeliveryLastAttemptAt: updatedAt,
-              pendingFinalDeliveryAttemptCount: attemptCount,
-              pendingFinalDeliveryLastError: null,
-              updatedAt,
-            }),
+            sessionStore,
+            storePath,
           });
+        } else {
+          const updatedAt = Date.now();
+          const attemptCount = (sessionEntry.pendingFinalDeliveryAttemptCount ?? 0) + 1;
+          sessionEntry.pendingFinalDeliveryLastAttemptAt = updatedAt;
+          sessionEntry.pendingFinalDeliveryAttemptCount = attemptCount;
+          sessionEntry.pendingFinalDeliveryLastError = null;
+          const replayText = sanitizePendingFinalDeliveryText(heartbeatPending.replayText);
+          sessionEntry.pendingFinalDeliveryText = replayText;
+          sessionEntry.updatedAt = updatedAt;
+          if (sessionKey && sessionStore) {
+            sessionStore[sessionKey] = sessionEntry;
+          }
+          if (sessionKey && storePath) {
+            const { updateSessionStoreEntry } = await import("../../config/sessions.js");
+            await updateSessionStoreEntry({
+              storePath,
+              sessionKey,
+              update: async () => ({
+                pendingFinalDeliveryText: replayText,
+                pendingFinalDeliveryLastAttemptAt: updatedAt,
+                pendingFinalDeliveryAttemptCount: attemptCount,
+                pendingFinalDeliveryLastError: null,
+                updatedAt,
+              }),
+            });
+          }
+          return { text: replayText };
         }
-        return { text: replayText };
       }
     }
   }

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -1724,6 +1724,7 @@ export async function runHeartbeatOnce(opts: {
       heartbeat?.lightContext === true ? "lightweight" : undefined;
     const replyOpts = {
       isHeartbeat: true,
+      ...(delivery.channel === "none" ? { skipHeartbeatPendingFinalDeliveryReplay: true } : {}),
       ...(heartbeatModelOverride ? { heartbeatModelOverride } : {}),
       suppressToolErrorWarnings,
       ...(usesHeartbeatResponseTool ? { enableHeartbeatTool: true, forceHeartbeatTool: true } : {}),


### PR DESCRIPTION
Fixes #84672.

This keeps internal-only heartbeats from replaying stale pending-final-delivery text forever.

## What changed
- add a narrow heartbeat reply option to skip stale pending replay
- use that option only when the heartbeat delivery target resolves to `none`
- clear the stale pending-final-delivery fields before continuing with a fresh heartbeat run
- add regression coverage for the skip path

## Real behavior proof
Reproduced the stale replay flow with a heartbeat run whose resolved delivery target is `none` while `pendingFinalDelivery*` fields are still populated from an earlier pass.

Before this patch:
1. a prior run leaves `pendingFinalDeliveryText` / metadata populated
2. a later `target:none` heartbeat re-enters the fast path
3. the runner reuses the stale pending-final-delivery payload instead of starting clean
4. the same internal-only heartbeat text can be replayed again even though it no longer matches the current run

With this patch:
1. the `target:none` path explicitly skips stale pending replay
2. the old pending-final-delivery fields are cleared before the new heartbeat continues
3. the heartbeat proceeds with a fresh reply computation instead of re-emitting the stale text

That keeps `target:none` heartbeats recoverable after a stale pending-delivery state while leaving non-`none` delivery targets on the existing path.

## Validation
- `pnpm vitest src/auto-reply/reply/get-reply.fast-path.test.ts src/infra/heartbeat-runner.returns-default-unset.test.ts`
