### PR TITLE
fix(codex): read listed skill files directly

### DIFF
--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -68,6 +68,14 @@ describe("Codex app-server native code mode config", () => {
     );
   });
 
+  it("tells Codex to read listed skill files directly", () => {
+    const instructions = buildDeveloperInstructions(createAttemptParams({ provider: "openai" }));
+
+    expect(instructions).toContain("When loading a listed `SKILL.md`");
+    expect(instructions).toContain("read the exact file path directly");
+    expect(instructions).toContain("Do not search the parent directory");
+  });
+
   it("summarizes deferred dynamic tool names in developer instructions", () => {
     const instructions = buildDeveloperInstructions(createAttemptParams({ provider: "openai" }), {
       dynamicTools: [

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -852,6 +852,7 @@ export function buildDeveloperInstructions(
     "You are a personal agent running inside OpenClaw. OpenClaw has dynamic tools for OpenClaw-owned messaging, cron, sessions, media, gateway, and nodes.",
     buildDeferredDynamicToolManifest(options.dynamicTools),
     "Use Codex native `spawn_agent` for Codex subagents. Use OpenClaw `sessions_spawn` only for OpenClaw or ACP delegation.",
+    "When loading a listed `SKILL.md`, read the exact file path directly. Do not search the parent directory for `SKILL.md`; Codex/OpenClaw state directories may be hidden or gitignored.",
     buildVisibleReplyInstruction(params, options.dynamicTools),
     nativeCommandGuidance,
     params.extraSystemPrompt,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -222,16 +222,16 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 10111
   },
   "openClawDeveloperInstructions": {
-    "chars": 3184,
-    "roughTokens": 796
+    "chars": 3367,
+    "roughTokens": 842
   },
   "totalTextOnly": {
-    "chars": 26362,
-    "roughTokens": 6591
+    "chars": 26545,
+    "roughTokens": 6637
   },
   "totalWithDynamicToolsJson": {
-    "chars": 66805,
-    "roughTokens": 16702
+    "chars": 66988,
+    "roughTokens": 16747
   },
   "userInputText": {
     "chars": 1530,
@@ -421,6 +421,8 @@ You are a personal agent running inside OpenClaw. OpenClaw has dynamic tools for
 Deferred searchable OpenClaw dynamic tools available: agents_list, cron, gateway, nodes, session_status, sessions_history, sessions_list, sessions_send, sessions_spawn, subagents, tts, web_fetch, web_search. Use `tool_search` to load exact callable specs before use.
 
 Use Codex native `spawn_agent` for Codex subagents. Use OpenClaw `sessions_spawn` only for OpenClaw or ACP delegation.
+
+When loading a listed `SKILL.md`, read the exact file path directly. Do not search the parent directory for `SKILL.md`; Codex/OpenClaw state directories may be hidden or gitignored.
 
 To send a visible message, use the `message` tool.
 

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -222,16 +222,16 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 10054
   },
   "openClawDeveloperInstructions": {
-    "chars": 2160,
-    "roughTokens": 540
+    "chars": 2343,
+    "roughTokens": 586
   },
   "totalTextOnly": {
-    "chars": 24838,
-    "roughTokens": 6210
+    "chars": 25021,
+    "roughTokens": 6256
   },
   "totalWithDynamicToolsJson": {
-    "chars": 65056,
-    "roughTokens": 16264
+    "chars": 65239,
+    "roughTokens": 16310
   },
   "userInputText": {
     "chars": 1030,
@@ -421,6 +421,8 @@ You are a personal agent running inside OpenClaw. OpenClaw has dynamic tools for
 Deferred searchable OpenClaw dynamic tools available: agents_list, cron, gateway, nodes, session_status, sessions_history, sessions_list, sessions_send, sessions_spawn, subagents, tts, web_fetch, web_search. Use `tool_search` to load exact callable specs before use.
 
 Use Codex native `spawn_agent` for Codex subagents. Use OpenClaw `sessions_spawn` only for OpenClaw or ACP delegation.
+
+When loading a listed `SKILL.md`, read the exact file path directly. Do not search the parent directory for `SKILL.md`; Codex/OpenClaw state directories may be hidden or gitignored.
 
 To send a visible message, use the `message` tool.
 

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -223,16 +223,16 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 10328
   },
   "openClawDeveloperInstructions": {
-    "chars": 2179,
-    "roughTokens": 545
+    "chars": 2362,
+    "roughTokens": 591
   },
   "totalTextOnly": {
-    "chars": 26707,
-    "roughTokens": 6677
+    "chars": 26890,
+    "roughTokens": 6723
   },
   "totalWithDynamicToolsJson": {
-    "chars": 68020,
-    "roughTokens": 17005
+    "chars": 68203,
+    "roughTokens": 17051
   },
   "userInputText": {
     "chars": 1268,
@@ -422,6 +422,8 @@ You are a personal agent running inside OpenClaw. OpenClaw has dynamic tools for
 Deferred searchable OpenClaw dynamic tools available: agents_list, cron, gateway, heartbeat_respond, nodes, session_status, sessions_history, sessions_list, sessions_send, sessions_spawn, subagents, tts, web_fetch, web_search. Use `tool_search` to load exact callable specs before use.
 
 Use Codex native `spawn_agent` for Codex subagents. Use OpenClaw `sessions_spawn` only for OpenClaw or ACP delegation.
+
+When loading a listed `SKILL.md`, read the exact file path directly. Do not search the parent directory for `SKILL.md`; Codex/OpenClaw state directories may be hidden or gitignored.
 
 To send a visible message, use the `message` tool.
 


### PR DESCRIPTION
Summary:
- Add Codex app-server guidance to read listed `SKILL.md` paths directly instead of searching parent directories.
- Cover the prompt guidance in the Codex app-server thread lifecycle tests.
- Update Codex runtime prompt snapshots for the new developer instruction.
- Rebase onto latest green `origin/main` (`d5cc0d53b7`) to avoid stale-base CI failures.

Verification:
- `pnpm install`
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/thread-lifecycle.test.ts`
- `pnpm prompt:snapshots:check`
- `node scripts/run-bundled-extension-oxlint.mjs`

Real behavior proof:
Behavior addressed: Codex app-server prompts no longer encourage parent-directory skill discovery that can fail under hidden or gitignored OpenClaw/Codex state directories.
Real environment tested: Local macOS Codex worktree, plus prompt snapshot generation/checks for Codex app-server runtime prompts.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/codex/src/app-server/thread-lifecycle.test.ts`; `pnpm prompt:snapshots:check`; `node scripts/run-bundled-extension-oxlint.mjs`
Evidence after fix: The targeted test asserts that developer instructions tell Codex to read listed skill files directly and not search parent directories. Prompt snapshots now include the new instruction in the Codex runtime paths that drifted in CI.
Observed result after fix: The targeted test file passed with 37 tests; prompt snapshots are current; bundled-extension oxlint passed with 0 warnings and 0 errors.
What was not tested: Full test suite and a live Codex app-server Slack turn.
