### PR TITLE
fix(codex): stabilize heartbeat dynamic tool schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -272,6 +272,7 @@ Docs: https://docs.openclaw.ai
 - Codex: respect explicit `models auth order set` and `config.auth.order` precedence over stale `lastGood` in `/codex account`, and show `no working credential` when every explicit-order profile is ineligible instead of marking a lower-ranked profile as active. Fixes #84386. (#84412) Thanks @openperf.
 - Agents: honor `messages.suppressToolErrors` for mutating tool failures so configured chat surfaces do not receive separate warning payloads. (#81561) Thanks @moeedahmed.
 - Agents/fallback: surface billing guidance for mixed rate-limit plus billing fallback exhaustion instead of generic failure copy. Fixes #79396. (#79489) Thanks @aayushprsingh.
+- Codex: keep heartbeat response tool schemas durable without exposing dynamic tools disabled by turn policy, so heartbeat wakeups can reuse threads while scoped tool allowlists stay enforced. (#84681) Thanks @jalehman.
 
 ## 2026.5.19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,6 +173,7 @@ Docs: https://docs.openclaw.ai
 - CLI/perf: keep `secrets --help` and `nodes --help` on the precomputed help path so parent help avoids loading action-heavy command runtime modules. (#84818) Thanks @frankekn.
 - CLI/perf: serve `doctor`, `gateway`, `models`, and `plugins` parent help from startup metadata so common subcommand help avoids full CLI program construction. (#84786) Thanks @frankekn.
 - Codex/Lossless: keep context-engine history on the canonical run session when Telegram DMs use per-peer runtime policy keys. Fixes #84936. (#84954) Thanks @neeravmakwana.
+- Codex: keep heartbeat response tool schemas durable without exposing dynamic tools disabled by turn policy, so heartbeat wakeups can reuse threads while scoped tool allowlists stay enforced. (#84681) Thanks @jalehman.
 - Auth/OAuth: skip the refresh adapter when a stored OAuth credential has no refresh token so agent turns fail fast on missing-key instead of waiting on the 120s refresh timeout. Thanks @romneyda.
 - Auth/Codex: load legacy OAuth sidecar credentials in the embedded runner's secrets-runtime auth loaders so Telegram replies, cron-triggered turns, and other isolated sub-agent lanes can reach the existing #83312 refresh-and-rewrite migration instead of failing with `No API key found for provider "openai-codex"` until the user runs `openclaw doctor`. Thanks @Totalsolutionsync and @romneyda.
 - Codex/failover: classify `deactivated_workspace` as a permanent auth failure so configured fallback models can advance when a Codex workspace is deactivated. (#55893) Thanks @litang9.
@@ -272,7 +273,6 @@ Docs: https://docs.openclaw.ai
 - Codex: respect explicit `models auth order set` and `config.auth.order` precedence over stale `lastGood` in `/codex account`, and show `no working credential` when every explicit-order profile is ineligible instead of marking a lower-ranked profile as active. Fixes #84386. (#84412) Thanks @openperf.
 - Agents: honor `messages.suppressToolErrors` for mutating tool failures so configured chat surfaces do not receive separate warning payloads. (#81561) Thanks @moeedahmed.
 - Agents/fallback: surface billing guidance for mixed rate-limit plus billing fallback exhaustion instead of generic failure copy. Fixes #79396. (#79489) Thanks @aayushprsingh.
-- Codex: keep heartbeat response tool schemas durable without exposing dynamic tools disabled by turn policy, so heartbeat wakeups can reuse threads while scoped tool allowlists stay enforced. (#84681) Thanks @jalehman.
 
 ## 2026.5.19
 

--- a/extensions/codex/src/app-server/dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.test.ts
@@ -219,6 +219,44 @@ describe("createCodexDynamicToolBridge", () => {
     expectNoNamespace(bridge.specs[0]);
   });
 
+  it("can register a durable tool schema while denying execution for the current turn", async () => {
+    const heartbeatExecute = vi.fn(async () => textToolResult("heartbeat recorded"));
+    const bridge = createCodexDynamicToolBridge({
+      tools: [createTool({ name: "message" })],
+      registeredTools: [
+        createTool({ name: "message" }),
+        createTool({ name: HEARTBEAT_RESPONSE_TOOL_NAME, execute: heartbeatExecute }),
+      ],
+      signal: new AbortController().signal,
+    });
+
+    expect(bridge.availableSpecs.map((tool) => tool.name)).toEqual(["message"]);
+    expect(bridge.specs.map((tool) => tool.name)).toEqual([
+      "message",
+      HEARTBEAT_RESPONSE_TOOL_NAME,
+    ]);
+
+    const result = await bridge.handleToolCall({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      callId: "call-1",
+      namespace: null,
+      tool: HEARTBEAT_RESPONSE_TOOL_NAME,
+      arguments: {},
+    });
+
+    expect(result).toEqual({
+      success: false,
+      contentItems: [
+        {
+          type: "inputText",
+          text: `OpenClaw tool is not available for this turn: ${HEARTBEAT_RESPONSE_TOOL_NAME}`,
+        },
+      ],
+    });
+    expect(heartbeatExecute).not.toHaveBeenCalled();
+  });
+
   it("can expose all dynamic tools directly for compatibility", () => {
     const bridge = createCodexDynamicToolBridge({
       tools: [createTool({ name: "web_search" }), createTool({ name: "message" })],

--- a/extensions/codex/src/app-server/dynamic-tools.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.ts
@@ -43,6 +43,7 @@ type CodexDynamicToolHookContext = {
 type CodexToolResultHookContext = Omit<CodexDynamicToolHookContext, "config">;
 
 export type CodexDynamicToolBridge = {
+  availableSpecs: CodexDynamicToolSpec[];
   specs: CodexDynamicToolSpec[];
   handleToolCall: (
     params: CodexDynamicToolCallParams,
@@ -70,6 +71,7 @@ const DEFAULT_CODEX_DYNAMIC_TOOL_RESULT_MAX_CHARS = 16_000;
 
 export function createCodexDynamicToolBridge(params: {
   tools: AnyAgentTool[];
+  registeredTools?: AnyAgentTool[];
   signal: AbortSignal;
   hookContext?: CodexDynamicToolHookContext;
   loading?: CodexDynamicToolsLoading;
@@ -85,6 +87,8 @@ export function createCodexDynamicToolBridge(params: {
     return wrapToolWithBeforeToolCallHook(tool, params.hookContext, { emitDiagnostics: false });
   });
   const toolMap = new Map(tools.map((tool) => [tool.name, tool]));
+  const registeredTools = params.registeredTools ?? tools;
+  const registeredToolNames = new Set(registeredTools.map((tool) => tool.name));
   const telemetry: CodexDynamicToolBridge["telemetry"] = {
     didSendViaMessagingTool: false,
     messagingToolSentTexts: [],
@@ -106,7 +110,14 @@ export function createCodexDynamicToolBridge(params: {
   ]);
 
   return {
-    specs: tools.map((tool) =>
+    availableSpecs: tools.map((tool) =>
+      createCodexDynamicToolSpec({
+        tool,
+        loading: params.loading ?? "searchable",
+        directToolNames,
+      }),
+    ),
+    specs: registeredTools.map((tool) =>
       createCodexDynamicToolSpec({
         tool,
         loading: params.loading ?? "searchable",
@@ -117,6 +128,17 @@ export function createCodexDynamicToolBridge(params: {
     handleToolCall: async (call, options) => {
       const tool = toolMap.get(call.tool);
       if (!tool) {
+        if (registeredToolNames.has(call.tool)) {
+          return {
+            contentItems: [
+              {
+                type: "inputText",
+                text: `OpenClaw tool is not available for this turn: ${call.tool}`,
+              },
+            ],
+            success: false,
+          };
+        }
         return {
           contentItems: [{ type: "inputText", text: `Unknown OpenClaw tool: ${call.tool}` }],
           success: false,

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -2388,6 +2388,9 @@ describe("runCodexAppServerAttempt", () => {
       if (trigger) {
         params.trigger = trigger;
       }
+      if (trigger === "heartbeat") {
+        params.sourceReplyDeliveryMode = "message_tool_only";
+      }
       return params;
     };
 

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -2331,6 +2331,81 @@ describe("runCodexAppServerAttempt", () => {
     expect(startConfig?.["features.code_mode_only"]).toBe(true);
   });
 
+  it("registers heartbeat response durably without advertising it on normal turns", async () => {
+    testing.setOpenClawCodingToolsFactoryForTests((options) => [
+      createRuntimeDynamicTool("message"),
+      ...(options?.enableHeartbeatTool === true
+        ? [createRuntimeDynamicTool("heartbeat_respond")]
+        : []),
+    ]);
+    const harness = createStartedThreadHarness(async (method) => {
+      if (method === "thread/resume") {
+        return threadStartResult("thread-1");
+      }
+      return undefined;
+    });
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const createRunParams = (trigger?: EmbeddedRunAttemptParams["trigger"]) => {
+      const params = createParams(sessionFile, workspaceDir);
+      params.disableTools = false;
+      params.runtimePlan = createCodexRuntimePlanFixture();
+      if (trigger) {
+        params.trigger = trigger;
+      }
+      return params;
+    };
+
+    const normalRun = runCodexAppServerAttempt(createRunParams(), {
+      pluginConfig: { appServer: { mode: "yolo" } },
+    });
+    await harness.waitForMethod("turn/start", 120_000);
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await normalRun;
+
+    const startRequest = harness.requests.find((entry) => entry.method === "thread/start");
+    const startParams = startRequest?.params as
+      | { dynamicTools?: Array<{ name?: string }>; developerInstructions?: string }
+      | undefined;
+    const registeredToolNames = startParams?.dynamicTools?.map((tool) => tool.name) ?? [];
+
+    expect(registeredToolNames).toContain("message");
+    expect(registeredToolNames).toContain("heartbeat_respond");
+    expect(startParams?.developerInstructions).toContain(
+      "Deferred searchable OpenClaw dynamic tools available: message.",
+    );
+    expect(startParams?.developerInstructions).not.toContain(
+      "Deferred searchable OpenClaw dynamic tools available: heartbeat_respond",
+    );
+
+    const heartbeatRun = runCodexAppServerAttempt(createRunParams("heartbeat"), {
+      pluginConfig: { appServer: { mode: "yolo" } },
+    });
+    await vi.waitFor(
+      () => {
+        expect(harness.requests.filter((entry) => entry.method === "turn/start")).toHaveLength(2);
+      },
+      { interval: 1, timeout: 120_000 },
+    );
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await heartbeatRun;
+
+    const nextNormalRun = runCodexAppServerAttempt(createRunParams(), {
+      pluginConfig: { appServer: { mode: "yolo" } },
+    });
+    await vi.waitFor(
+      () => {
+        expect(harness.requests.filter((entry) => entry.method === "turn/start")).toHaveLength(3);
+      },
+      { interval: 1, timeout: 120_000 },
+    );
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await nextNormalRun;
+
+    expect(harness.requests.filter((entry) => entry.method === "thread/start")).toHaveLength(1);
+    expect(harness.requests.filter((entry) => entry.method === "thread/resume")).toHaveLength(2);
+  });
+
   it("disables Codex native tool surfaces when runtime toolsAllow is empty", async () => {
     testing.setOpenClawCodingToolsFactoryForTests(() => [
       createRuntimeDynamicTool("message"),

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -2406,6 +2406,71 @@ describe("runCodexAppServerAttempt", () => {
     expect(harness.requests.filter((entry) => entry.method === "thread/resume")).toHaveLength(2);
   });
 
+  it("keeps the persistent dynamic schema stable across heartbeat-only turns", async () => {
+    testing.setOpenClawCodingToolsFactoryForTests((options) => [
+      createRuntimeDynamicTool("message"),
+      createRuntimeDynamicTool("web_search"),
+      ...(options?.enableHeartbeatTool === true
+        ? [createRuntimeDynamicTool("heartbeat_respond")]
+        : []),
+    ]);
+    const harness = createStartedThreadHarness(async (method) => {
+      if (method === "thread/resume") {
+        return threadStartResult("thread-1");
+      }
+      return undefined;
+    });
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const createRunParams = (trigger?: EmbeddedRunAttemptParams["trigger"]) => {
+      const params = createParams(sessionFile, workspaceDir);
+      params.disableTools = false;
+      params.runtimePlan = createCodexRuntimePlanFixture();
+      if (trigger) {
+        params.trigger = trigger;
+        params.toolsAllow = ["heartbeat_respond"];
+      }
+      return params;
+    };
+
+    const normalRun = runCodexAppServerAttempt(createRunParams(), {
+      pluginConfig: { appServer: { mode: "yolo" } },
+    });
+    await harness.waitForMethod("turn/start", 120_000);
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await normalRun;
+
+    const heartbeatRun = runCodexAppServerAttempt(createRunParams("heartbeat"), {
+      pluginConfig: { appServer: { mode: "yolo" } },
+    });
+    await vi.waitFor(
+      () => {
+        expect(harness.requests.filter((entry) => entry.method === "turn/start")).toHaveLength(2);
+      },
+      { interval: 1, timeout: 120_000 },
+    );
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await heartbeatRun;
+
+    const nextNormalRun = runCodexAppServerAttempt(createRunParams(), {
+      pluginConfig: { appServer: { mode: "yolo" } },
+    });
+    await vi.waitFor(
+      () => {
+        expect(harness.requests.filter((entry) => entry.method === "turn/start")).toHaveLength(3);
+      },
+      { interval: 1, timeout: 120_000 },
+    );
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await nextNormalRun;
+
+    expect(
+      harness.requests
+        .map((entry) => entry.method)
+        .filter((method) => method === "thread/start" || method === "thread/resume"),
+    ).toEqual(["thread/start", "thread/start", "thread/resume"]);
+  });
+
   it("disables Codex native tool surfaces when runtime toolsAllow is empty", async () => {
     testing.setOpenClawCodingToolsFactoryForTests(() => [
       createRuntimeDynamicTool("message"),

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -2251,9 +2251,12 @@ describe("runCodexAppServerAttempt", () => {
   });
 
   it("keeps forced message dynamic tool when toolsAllow is empty", async () => {
-    testing.setOpenClawCodingToolsFactoryForTests(() => [
+    testing.setOpenClawCodingToolsFactoryForTests((options) => [
       createRuntimeDynamicTool("message"),
       createRuntimeDynamicTool("music_generate"),
+      ...(options?.forceHeartbeatTool === true
+        ? [createRuntimeDynamicTool("heartbeat_respond")]
+        : []),
     ]);
     const harness = createStartedThreadHarness();
     const params = createParams(
@@ -2264,6 +2267,38 @@ describe("runCodexAppServerAttempt", () => {
     params.runtimePlan = createCodexRuntimePlanFixture();
     params.sourceReplyDeliveryMode = "message_tool_only";
     params.toolsAllow = [];
+
+    const run = runCodexAppServerAttempt(params, {
+      pluginConfig: { appServer: { mode: "yolo" } },
+    });
+    await harness.waitForMethod("turn/start", 120_000);
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await run;
+
+    const startRequest = harness.requests.find((entry) => entry.method === "thread/start");
+    const dynamicToolNames =
+      (
+        startRequest?.params as { dynamicTools?: Array<{ name?: string }> } | undefined
+      )?.dynamicTools?.map((tool) => tool.name) ?? [];
+
+    expect(dynamicToolNames).toEqual(["message"]);
+  });
+
+  it("keeps forced heartbeat registration inside narrow toolsAllow policy", async () => {
+    testing.setOpenClawCodingToolsFactoryForTests((options) => [
+      createRuntimeDynamicTool("message"),
+      ...(options?.forceHeartbeatTool === true
+        ? [createRuntimeDynamicTool("heartbeat_respond")]
+        : []),
+    ]);
+    const harness = createStartedThreadHarness();
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+    params.disableTools = false;
+    params.runtimePlan = createCodexRuntimePlanFixture();
+    params.toolsAllow = ["message"];
 
     const run = runCodexAppServerAttempt(params, {
       pluginConfig: { appServer: { mode: "yolo" } },

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -2435,7 +2435,7 @@ describe("runCodexAppServerAttempt", () => {
               : tools,
           logDiagnostics: () => undefined,
         },
-      } as NonNullable<EmbeddedRunAttemptParams["runtimePlan"]>;
+      } as unknown as NonNullable<EmbeddedRunAttemptParams["runtimePlan"]>;
       if (trigger) {
         params.trigger = trigger;
       }

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -2425,10 +2425,19 @@ describe("runCodexAppServerAttempt", () => {
     const createRunParams = (trigger?: EmbeddedRunAttemptParams["trigger"]) => {
       const params = createParams(sessionFile, workspaceDir);
       params.disableTools = false;
-      params.runtimePlan = createCodexRuntimePlanFixture();
+      const runtimePlan = createCodexRuntimePlanFixture();
+      params.runtimePlan = {
+        ...runtimePlan,
+        tools: {
+          normalize: (tools: Array<{ name: string }>) =>
+            trigger === "heartbeat"
+              ? tools.filter((tool) => tool.name === "heartbeat_respond")
+              : tools,
+          logDiagnostics: () => undefined,
+        },
+      } as NonNullable<EmbeddedRunAttemptParams["runtimePlan"]>;
       if (trigger) {
         params.trigger = trigger;
-        params.toolsAllow = ["heartbeat_respond"];
       }
       return params;
     };
@@ -2468,7 +2477,7 @@ describe("runCodexAppServerAttempt", () => {
       harness.requests
         .map((entry) => entry.method)
         .filter((method) => method === "thread/start" || method === "thread/resume"),
-    ).toEqual(["thread/start", "thread/start", "thread/resume"]);
+    ).toEqual(["thread/start", "thread/resume", "thread/resume"]);
   });
 
   it("disables Codex native tool surfaces when runtime toolsAllow is empty", async () => {

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -1004,6 +1004,7 @@ export async function runCodexAppServerAttempt(
     sessionAgentId,
     pluginConfig,
     forceHeartbeatTool: true,
+    ignoreToolsAllow: true,
     onYieldDetected: () => {
       yieldDetected = true;
     },
@@ -3583,6 +3584,7 @@ type DynamicToolBuildParams = {
   sessionAgentId: string;
   pluginConfig: CodexPluginConfig;
   forceHeartbeatTool?: boolean;
+  ignoreToolsAllow?: boolean;
   onYieldDetected: () => void;
 };
 
@@ -3706,7 +3708,9 @@ async function buildDynamicTools(input: DynamicToolBuildParams) {
     modelHasVision,
     hasInboundImages: (params.images?.length ?? 0) > 0,
   });
-  const toolsAllow = includeForcedCodexDynamicToolAllow(params.toolsAllow, params, input);
+  const toolsAllow = input.ignoreToolsAllow
+    ? undefined
+    : includeForcedCodexDynamicToolAllow(params.toolsAllow, params, input);
   const filteredTools = filterCodexDynamicToolsForAllowlist(visionFilteredTools, toolsAllow);
   return normalizeAgentRuntimeTools({
     runtimePlan: params.runtimePlan,

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -1005,6 +1005,7 @@ export async function runCodexAppServerAttempt(
     pluginConfig,
     forceHeartbeatTool: true,
     ignoreToolsAllow: true,
+    ignoreRuntimePlan: true,
     onYieldDetected: () => {
       yieldDetected = true;
     },
@@ -3585,6 +3586,7 @@ type DynamicToolBuildParams = {
   pluginConfig: CodexPluginConfig;
   forceHeartbeatTool?: boolean;
   ignoreToolsAllow?: boolean;
+  ignoreRuntimePlan?: boolean;
   onYieldDetected: () => void;
 };
 
@@ -3713,7 +3715,7 @@ async function buildDynamicTools(input: DynamicToolBuildParams) {
     : includeForcedCodexDynamicToolAllow(params.toolsAllow, params, input);
   const filteredTools = filterCodexDynamicToolsForAllowlist(visionFilteredTools, toolsAllow);
   return normalizeAgentRuntimeTools({
-    runtimePlan: params.runtimePlan,
+    runtimePlan: input.ignoreRuntimePlan ? undefined : params.runtimePlan,
     tools: filteredTools,
     provider: params.provider,
     config: params.config,

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -20,7 +20,6 @@ import {
   hasBeforeToolCallPolicy,
   isActiveHarnessContextEngine,
   isSubagentSessionKey,
-  HEARTBEAT_RESPONSE_TOOL_NAME,
   loadCodexBundleMcpThreadConfig,
   normalizeAgentRuntimeTools,
   resolveAttemptSpawnWorkspaceDir,
@@ -3708,7 +3707,7 @@ async function buildDynamicTools(input: DynamicToolBuildParams) {
     modelHasVision,
     hasInboundImages: (params.images?.length ?? 0) > 0,
   });
-  const toolsAllow = includeForcedCodexDynamicToolAllow(params.toolsAllow, params, input);
+  const toolsAllow = includeForcedCodexDynamicToolAllow(params.toolsAllow, params);
   const filteredTools = filterCodexDynamicToolsForAllowlist(visionFilteredTools, toolsAllow);
   return normalizeAgentRuntimeTools({
     runtimePlan: input.ignoreRuntimePlan ? undefined : params.runtimePlan,
@@ -3726,15 +3725,11 @@ async function buildDynamicTools(input: DynamicToolBuildParams) {
 function includeForcedCodexDynamicToolAllow(
   toolsAllow: string[] | undefined,
   params: EmbeddedRunAttemptParams,
-  input: { forceHeartbeatTool?: boolean },
 ): string[] | undefined {
   if (toolsAllow === undefined || hasWildcardCodexToolsAllow(toolsAllow)) {
     return toolsAllow;
   }
-  const forcedToolNames = [
-    ...(shouldForceMessageTool(params) ? ["message"] : []),
-    ...(input.forceHeartbeatTool === true ? [HEARTBEAT_RESPONSE_TOOL_NAME] : []),
-  ];
+  const forcedToolNames = shouldForceMessageTool(params) ? ["message"] : [];
   if (forcedToolNames.length === 0) {
     return toolsAllow;
   }
@@ -3759,9 +3754,7 @@ function shouldEnableCodexAppServerNativeToolSurface(
   if (isEffectiveExecHostNode(params, options.agentId)) {
     return false;
   }
-  const toolsAllow = includeForcedCodexDynamicToolAllow(params.toolsAllow, params, {
-    forceHeartbeatTool: false,
-  });
+  const toolsAllow = includeForcedCodexDynamicToolAllow(params.toolsAllow, params);
   if (toolsAllow === undefined) {
     return canCodexAppServerNativeToolSurfaceHonorSandbox(sandbox, options);
   }

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -1004,7 +1004,6 @@ export async function runCodexAppServerAttempt(
     sessionAgentId,
     pluginConfig,
     forceHeartbeatTool: true,
-    ignoreToolsAllow: true,
     ignoreRuntimePlan: true,
     onYieldDetected: () => {
       yieldDetected = true;
@@ -3585,7 +3584,6 @@ type DynamicToolBuildParams = {
   sessionAgentId: string;
   pluginConfig: CodexPluginConfig;
   forceHeartbeatTool?: boolean;
-  ignoreToolsAllow?: boolean;
   ignoreRuntimePlan?: boolean;
   onYieldDetected: () => void;
 };
@@ -3710,9 +3708,7 @@ async function buildDynamicTools(input: DynamicToolBuildParams) {
     modelHasVision,
     hasInboundImages: (params.images?.length ?? 0) > 0,
   });
-  const toolsAllow = input.ignoreToolsAllow
-    ? undefined
-    : includeForcedCodexDynamicToolAllow(params.toolsAllow, params, input);
+  const toolsAllow = includeForcedCodexDynamicToolAllow(params.toolsAllow, params, input);
   const filteredTools = filterCodexDynamicToolsForAllowlist(visionFilteredTools, toolsAllow);
   return normalizeAgentRuntimeTools({
     runtimePlan: input.ignoreRuntimePlan ? undefined : params.runtimePlan,

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -20,6 +20,7 @@ import {
   hasBeforeToolCallPolicy,
   isActiveHarnessContextEngine,
   isSubagentSessionKey,
+  HEARTBEAT_RESPONSE_TOOL_NAME,
   loadCodexBundleMcpThreadConfig,
   normalizeAgentRuntimeTools,
   resolveAttemptSpawnWorkspaceDir,
@@ -992,8 +993,24 @@ export async function runCodexAppServerAttempt(
       yieldDetected = true;
     },
   });
+  const registeredTools = await buildDynamicTools({
+    params,
+    resolvedWorkspace,
+    effectiveWorkspace,
+    sandboxSessionKey,
+    sandbox,
+    nativeToolSurfaceEnabled,
+    runAbortController,
+    sessionAgentId,
+    pluginConfig,
+    forceHeartbeatTool: true,
+    onYieldDetected: () => {
+      yieldDetected = true;
+    },
+  });
   const toolBridge = createCodexDynamicToolBridge({
     tools,
+    registeredTools,
     signal: runAbortController.signal,
     loading: resolveCodexDynamicToolsLoading(pluginConfig),
     directToolNames: shouldForceMessageTool(params) ? ["message"] : [],
@@ -1068,7 +1085,7 @@ export async function runCodexAppServerAttempt(
   });
   const baseDeveloperInstructions = joinPresentSections(
     buildDeveloperInstructions(params, {
-      dynamicTools: toolBridge.specs,
+      dynamicTools: toolBridge.availableSpecs,
     }),
     workspaceBootstrapContext.developerInstructions,
   );
@@ -1099,7 +1116,9 @@ export async function runCodexAppServerAttempt(
       sessionKey: contextSessionKey,
       messages: historyMessages,
       tokenBudget: params.contextTokenBudget,
-      availableTools: new Set(toolBridge.specs.map((tool) => tool.name).filter(isNonEmptyString)),
+      availableTools: new Set(
+        toolBridge.availableSpecs.map((tool) => tool.name).filter(isNonEmptyString),
+      ),
       citationsMode: params.config?.memory?.citations,
       modelId: params.modelId,
       prompt: params.prompt,
@@ -1205,14 +1224,14 @@ export async function runCodexAppServerAttempt(
     developerInstructions: promptBuild.developerInstructions,
     workspaceBootstrapContext,
     skillsPrompt: openClawPromptContext ? (params.skillsSnapshot?.prompt ?? "") : "",
-    tools: toolBridge.specs,
+    tools: toolBridge.availableSpecs,
   });
   const trajectoryRecorder = createCodexTrajectoryRecorder({
     attempt: params,
     cwd: effectiveWorkspace,
     developerInstructions: promptBuild.developerInstructions,
     prompt: codexTurnPromptText,
-    tools: toolBridge.specs,
+    tools: toolBridge.availableSpecs,
   });
   let client: CodexAppServerClient;
   let thread: CodexAppServerThreadLifecycleBinding;
@@ -1539,7 +1558,7 @@ export async function runCodexAppServerAttempt(
     cwd: effectiveWorkspace,
     developerInstructions: promptBuild.developerInstructions,
     prompt: codexTurnPromptText,
-    tools: toolBridge.specs,
+    tools: toolBridge.availableSpecs,
   });
 
   let projector: CodexAppServerEventProjector | undefined;
@@ -3563,6 +3582,7 @@ type DynamicToolBuildParams = {
   runAbortController: AbortController;
   sessionAgentId: string;
   pluginConfig: CodexPluginConfig;
+  forceHeartbeatTool?: boolean;
   onYieldDetected: () => void;
 };
 
@@ -3660,8 +3680,8 @@ async function buildDynamicTools(input: DynamicToolBuildParams) {
     sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
     disableMessageTool: params.disableMessageTool,
     forceMessageTool: shouldForceMessageTool(params),
-    enableHeartbeatTool: params.trigger === "heartbeat",
-    forceHeartbeatTool: params.trigger === "heartbeat",
+    enableHeartbeatTool: params.trigger === "heartbeat" || input.forceHeartbeatTool === true,
+    forceHeartbeatTool: params.trigger === "heartbeat" || input.forceHeartbeatTool === true,
     onYield: (message) => {
       input.onYieldDetected();
       emitCodexAppServerEvent(params, {
@@ -3686,7 +3706,7 @@ async function buildDynamicTools(input: DynamicToolBuildParams) {
     modelHasVision,
     hasInboundImages: (params.images?.length ?? 0) > 0,
   });
-  const toolsAllow = includeForcedMessageToolAllow(params.toolsAllow, params);
+  const toolsAllow = includeForcedCodexDynamicToolAllow(params.toolsAllow, params, input);
   const filteredTools = filterCodexDynamicToolsForAllowlist(visionFilteredTools, toolsAllow);
   return normalizeAgentRuntimeTools({
     runtimePlan: params.runtimePlan,
@@ -3701,22 +3721,29 @@ async function buildDynamicTools(input: DynamicToolBuildParams) {
   });
 }
 
-function includeForcedMessageToolAllow(
+function includeForcedCodexDynamicToolAllow(
   toolsAllow: string[] | undefined,
   params: EmbeddedRunAttemptParams,
+  input: { forceHeartbeatTool?: boolean },
 ): string[] | undefined {
-  if (
-    !shouldForceMessageTool(params) ||
-    toolsAllow === undefined ||
-    hasWildcardCodexToolsAllow(toolsAllow)
-  ) {
+  if (toolsAllow === undefined || hasWildcardCodexToolsAllow(toolsAllow)) {
+    return toolsAllow;
+  }
+  const forcedToolNames = [
+    ...(shouldForceMessageTool(params) ? ["message"] : []),
+    ...(input.forceHeartbeatTool === true ? [HEARTBEAT_RESPONSE_TOOL_NAME] : []),
+  ];
+  if (forcedToolNames.length === 0) {
     return toolsAllow;
   }
   if (toolsAllow.length === 0) {
-    return ["message"];
+    return forcedToolNames;
   }
   const normalized = new Set(toolsAllow.map((name) => normalizeCodexDynamicToolName(name)));
-  return normalized.has("message") ? toolsAllow : [...toolsAllow, "message"];
+  const missingToolNames = forcedToolNames.filter(
+    (toolName) => !normalized.has(normalizeCodexDynamicToolName(toolName)),
+  );
+  return missingToolNames.length === 0 ? toolsAllow : [...toolsAllow, ...missingToolNames];
 }
 
 function shouldEnableCodexAppServerNativeToolSurface(
@@ -3730,7 +3757,9 @@ function shouldEnableCodexAppServerNativeToolSurface(
   if (isEffectiveExecHostNode(params, options.agentId)) {
     return false;
   }
-  const toolsAllow = includeForcedMessageToolAllow(params.toolsAllow, params);
+  const toolsAllow = includeForcedCodexDynamicToolAllow(params.toolsAllow, params, {
+    forceHeartbeatTool: false,
+  });
   if (toolsAllow === undefined) {
     return canCodexAppServerNativeToolSurfaceHonorSandbox(sandbox, options);
   }

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -5,6 +5,7 @@ import {
   buildTurnStartParams,
   buildThreadResumeParams,
   buildThreadStartParams,
+  codexDynamicToolsFingerprint,
   resolveReasoningEffort,
 } from "./thread-lifecycle.js";
 
@@ -112,6 +113,35 @@ describe("Codex app-server native code mode config", () => {
     });
 
     expect(instructions).not.toContain("Deferred searchable OpenClaw dynamic tools available");
+  });
+
+  it("keeps durable dynamic tool fingerprints independent from presentation mode", () => {
+    const inputSchema = {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        text: { type: "string" },
+      },
+      required: ["text"],
+    };
+    const directFingerprint = codexDynamicToolsFingerprint([
+      {
+        name: "message",
+        description: "Send a visible message",
+        inputSchema,
+      },
+    ]);
+    const searchableFingerprint = codexDynamicToolsFingerprint([
+      {
+        name: "message",
+        description: "Load and send a visible message",
+        inputSchema,
+        namespace: "openclaw",
+        deferLoading: true,
+      },
+    ]);
+
+    expect(searchableFingerprint).toBe(directFingerprint);
   });
 
   it("keeps OpenClaw skill catalogs out of developer instructions", () => {

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -840,7 +840,9 @@ function fingerprintDynamicToolSpec(tool: JsonValue): JsonValue {
   for (const [key, child] of Object.entries(tool).toSorted(([left], [right]) =>
     left.localeCompare(right),
   )) {
-    if (key === "description") {
+    // Tool-search presentation can change per turn without changing the
+    // durable app-server execution contract for an existing thread.
+    if (key === "description" || key === "deferLoading" || key === "namespace") {
       continue;
     }
     stable[key] = stabilizeJsonValue(child);


### PR DESCRIPTION
## Context for maintainers

OpenClaw has a long-lived session, such as `agent:main:telegram:group:-1003774691294:topic:1`, and the Codex app-server has its own long-lived thread. OpenClaw stores a binding that says "this OpenClaw session should resume this Codex thread with this dynamic tool schema." A rotation means OpenClaw stops using the old Codex thread for that session and starts a new one; it does not switch back to the old thread later.

Before this PR, the same dynamic tool list was used both for the tools callable on the current turn and for the durable schema used to decide whether an existing Codex thread could be resumed. That broke normal -> heartbeat -> normal flows because those turns intentionally expose different callable tools. Normal turns should not be able to call `heartbeat_respond`, while heartbeat turns should. Some tools can also move between direct presentation and deferred/searchable presentation without changing their actual execution contract.

The bad pre-PR sequence was:

```text
normal turn
  uses Codex thread A
  fingerprint = normal tools

heartbeat turn
  fingerprint changes
  OpenClaw starts Codex thread B

next normal turn
  fingerprint changes back
  OpenClaw starts Codex thread C
```

It did not return from thread B back to thread A. The binding is only one active pointer, so every mismatch created another new Codex thread and lost continuity with the previous one.

This PR separates the two concepts. The prompt-facing tool surface remains turn-scoped, so normal turns still do not advertise or execute `heartbeat_respond`. The durable Codex registration is broad enough to include heartbeat support, so heartbeat turns can run without forcing a new Codex thread. The durable fingerprint also ignores presentation-only fields such as `namespace` and `deferLoading`, so a direct tool and a deferred/searchable tool with the same name and input schema do not look like different thread contracts.

## Summary

- Register a durable Codex dynamic tool schema set separately from the tools actually callable on the current turn.
- Keep `heartbeat_respond` in the thread schema so normal -> heartbeat -> normal turns reuse the same Codex thread, while normal turns still deny heartbeat tool execution explicitly.
- Normalize durable dynamic-tool fingerprints around execution contracts, not per-turn presentation mode, so direct tools and deferred/searchable tools with the same schema do not force thread rotation.
- Keep prompt-facing tool manifests, system prompt reports, and trajectory context scoped to tools available for the current turn.

## Verification

- `node scripts/run-vitest.mjs extensions/codex/src/app-server/thread-lifecycle.test.ts extensions/codex/src/app-server/run-attempt.test.ts -t 'durable dynamic tool fingerprints|registers heartbeat response durably'`
- `pnpm exec oxfmt --check --threads=1 extensions/codex/src/app-server/thread-lifecycle.ts extensions/codex/src/app-server/thread-lifecycle.test.ts extensions/codex/src/app-server/run-attempt.test.ts`
- `git diff --check`
- `pnpm build`
- `pnpm openclaw gateway restart && pnpm openclaw gateway status --deep`
- Live Telegram/Codex app-server proof on `agent:main:telegram:group:-1003774691294:topic:1`, including normal -> heartbeat with `heartbeat_respond` -> normal.

## Real behavior proof

Behavior addressed: Codex thread rotation caused by per-turn dynamic tool surface changes when heartbeat turns expose `heartbeat_respond`, normal turns do not, and ordinary callable tools such as `message` can move between direct and deferred/searchable presentation modes.

Real environment tested: Local OpenClaw gateway launched by `ai.openclaw.gateway` on macOS from current PR head `bc954055e9`, serving Telegram topic `agent:main:telegram:group:-1003774691294:topic:1` through the Codex app-server harness.

Exact steps or command run after this patch: Rebased the PR onto current `upstream/main`, built the rebased branch in `clawdbot`, restarted the live launchd gateway with `pnpm openclaw gateway restart`, verified `pnpm openclaw gateway status --deep`, waited for gateway connectivity to settle, then ran a normal gateway turn, a diagnostic heartbeat turn with `pnpm openclaw system event --mode now --expect-final`, and a normal gateway follow-up with `pnpm openclaw agent`, while querying `/tmp/openclaw/openclaw-2026-05-22.log` and the persisted Codex app-server binding.

Evidence after fix:

- Gateway status after restart: runtime running as LaunchAgent PID `79271`, gateway version `2026.5.21`, connectivity probe `ok`, admin-capable, listening on `127.0.0.1:18789`.
- Current-head live gateway normal turn replied `PR84681_REBASED_GATEWAY_NORMAL_1`; run output had no `fallbackFrom`, and `agentMeta` reported `provider=openai-codex`, `model=gpt-5.5`, `agentHarnessId=codex`.
- Harness selection log at `2026-05-22T13:59:12-04:00` for the target session reported `selectedHarnessId=codex`, `selectedReason=forced_plugin`, and `runtime=codex`.
- The first current-head gateway turn rotated once from thread `019e50d6-5662-7fd0-9c48-64db716a6638` to `019e50d8-5037-7d03-83d0-3ba50f2b8b03` with `reason=dynamic-tools-mismatch`; that was a one-time migration from the immediately previous stale binding and is not counted as the stability proof.
- Diagnostic heartbeat run returned `{"ok": true}`. Runtime log at `2026-05-22T14:00:51-04:00` for session `478aa0a7-0e5b-4b49-9174-38ca7d77a6ca` showed the existing thread binding matched, previous thread `019e50d8-5037-7d03-83d0-3ba50f2b8b03`, then wrote the same thread with `action=resumed`.
- The session transcript recorded a `heartbeat_respond` tool call with `notify=false`, `outcome=no_change`, and summary `PR 84681 rebased-head live gateway heartbeat proof completed`.
- Current-head live gateway normal follow-up replied `PR84681_REBASED_GATEWAY_NORMAL_2`; run output had no `fallbackFrom`, and `agentMeta` again reported `provider=openai-codex`, `model=gpt-5.5`, `agentHarnessId=codex`.
- Runtime log at `2026-05-22T14:01:05-04:00` for the normal follow-up again showed the existing thread binding matched, previous thread `019e50d8-5037-7d03-83d0-3ba50f2b8b03`, then wrote the same thread with `action=resumed`.
- After the heartbeat and normal follow-up, the persisted binding still had thread `019e50d8-5037-7d03-83d0-3ba50f2b8b03`, `hasNamespaceOrDefer=0`, and `hasHeartbeat=true`.

Observed result after fix: after the one expected current-head migration from a stale binding, a live gateway heartbeat turn that called `heartbeat_respond` and a live gateway normal follow-up reused the same Codex app-server thread. The heartbeat-specific tool surface no longer caused dynamic-tool mismatch rotation, and the normal follow-up did not rotate back after the heartbeat.

Current PR-head validation: Current head `bc954055e9` is rebased on current `upstream/main` and adds the normalized durable fingerprint regression. Targeted Codex app-server tests, oxfmt, `git diff --check`, build, gateway restart, gateway status, and live Telegram/Codex heartbeat proof passed locally. CI has been re-triggered for the rebased head.

What was not tested: This live proof was on the maintainer macOS gateway and Telegram session only. It did not run a second live provider/channel matrix, nor did it prove non-Codex harness behavior because this bug and patch are specific to the Codex app-server dynamic tool binding.
