### PR TITLE
Gate private QA descriptors for argv classification

### DIFF
--- a/src/cli/argv.test.ts
+++ b/src/cli/argv.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   buildParseArgv,
   getFlagValue,
@@ -20,6 +20,20 @@ import {
 } from "./argv.js";
 
 describe("argv helpers", () => {
+  let originalPrivateQaCli: string | undefined;
+
+  beforeEach(() => {
+    originalPrivateQaCli = process.env.OPENCLAW_ENABLE_PRIVATE_QA_CLI;
+  });
+
+  afterEach(() => {
+    if (originalPrivateQaCli === undefined) {
+      delete process.env.OPENCLAW_ENABLE_PRIVATE_QA_CLI;
+    } else {
+      process.env.OPENCLAW_ENABLE_PRIVATE_QA_CLI = originalPrivateQaCli;
+    }
+  });
+
   it.each([
     {
       name: "help flag",
@@ -233,6 +247,18 @@ describe("argv helpers", () => {
     },
   ])("detects help/version invocations: $name", ({ argv, expected }) => {
     expect(isHelpOrVersionInvocation(argv)).toBe(expected);
+  });
+
+  it("keeps private qa descriptors out of root command classification unless enabled", () => {
+    delete process.env.OPENCLAW_ENABLE_PRIVATE_QA_CLI;
+    expect(isHelpOrVersionInvocation(["node", "openclaw", "qa", "scenario", "help"])).toBe(
+      true,
+    );
+
+    process.env.OPENCLAW_ENABLE_PRIVATE_QA_CLI = "1";
+    expect(isHelpOrVersionInvocation(["node", "openclaw", "qa", "scenario", "help"])).toBe(
+      false,
+    );
   });
 
   it.each([

--- a/src/cli/argv.ts
+++ b/src/cli/argv.ts
@@ -6,20 +6,24 @@ import {
 } from "../infra/cli-root-options.js";
 import { parseStrictPositiveInteger } from "../infra/parse-finite-number.js";
 import { CORE_CLI_COMMAND_DESCRIPTORS } from "./program/core-command-descriptors.js";
-import { SUB_CLI_DESCRIPTORS } from "./program/subcli-descriptors.js";
+import { getSubCliEntries } from "./program/subcli-descriptors.js";
 
 const HELP_FLAGS = new Set(["-h", "--help"]);
 const VERSION_FLAGS = new Set(["-V", "--version"]);
 const ROOT_VERSION_ALIAS_FLAG = "-v";
-const ROOT_COMMAND_DESCRIPTORS = [...CORE_CLI_COMMAND_DESCRIPTORS, ...SUB_CLI_DESCRIPTORS];
-const KNOWN_ROOT_COMMANDS: ReadonlySet<string> = new Set(
-  ROOT_COMMAND_DESCRIPTORS.map((descriptor) => descriptor.name),
-);
-const ROOT_COMMANDS_WITH_SUBCOMMANDS: ReadonlySet<string> = new Set(
-  ROOT_COMMAND_DESCRIPTORS.filter((descriptor) => descriptor.hasSubcommands).map(
-    (descriptor) => descriptor.name,
-  ),
-);
+function getRootCommandDescriptors() {
+  return [...CORE_CLI_COMMAND_DESCRIPTORS, ...getSubCliEntries()];
+}
+
+function isKnownRootCommand(command: string): boolean {
+  return getRootCommandDescriptors().some((descriptor) => descriptor.name === command);
+}
+
+function rootCommandHasSubcommands(command: string): boolean {
+  return getRootCommandDescriptors().some(
+    (descriptor) => descriptor.name === command && descriptor.hasSubcommands,
+  );
+}
 
 export function hasHelpOrVersion(argv: string[]): boolean {
   return (
@@ -65,10 +69,10 @@ export function isHelpOrVersionInvocation(argv: string[]): boolean {
     const [primary] = positionals;
     // Positional `help` may be a command argument for known leaf commands.
     // Unknown roots are treated as plugin command namespaces.
-    if (!primary || !KNOWN_ROOT_COMMANDS.has(primary)) {
+    if (!primary || !isKnownRootCommand(primary)) {
       return true;
     }
-    if (positionals.length === 2 && ROOT_COMMANDS_WITH_SUBCOMMANDS.has(primary)) {
+    if (positionals.length === 2 && rootCommandHasSubcommands(primary)) {
       return true;
     }
     return false;

--- a/src/infra/secret-file.test.ts
+++ b/src/infra/secret-file.test.ts
@@ -144,6 +144,20 @@ describe("readSecretFileSync", () => {
     const file = await pathValue();
     expect(tryReadSecretFileSync(file, label, options)).toBe(expected);
   });
+
+  it("throws from the non-throwing helper for rejected symlinks", async () => {
+    const link = await createSecretPath(async (dir) => {
+      const target = path.join(dir, "target.txt");
+      const symlink = path.join(dir, "secret-link.txt");
+      await fsPromises.writeFile(target, "top-secret\n", "utf8");
+      await fsPromises.symlink(target, symlink);
+      return symlink;
+    });
+
+    expect(() =>
+      tryReadSecretFileSync(link, "Telegram bot token", { rejectSymlink: true }),
+    ).toThrow("must not be a symlink");
+  });
 });
 
 describe("writePrivateSecretFileAtomic", () => {


### PR DESCRIPTION
Fixes #83927

## Summary

- remove the raw exported sub-CLI descriptor list that bypassed the private QA gate
- make argv root-command classification consult the gated sub-CLI accessor at decision time
- add regression coverage for private QA disabled/enabled behavior

## Real behavior proof

Behavior or issue addressed:
The raw `SUB_CLI_DESCRIPTORS` export exposed the private `qa` descriptor to consumers even when `OPENCLAW_ENABLE_PRIVATE_QA_CLI` was unset.

Real environment tested:
Local OpenClaw source checkout on macOS using the bundled Node runtime.

Exact steps or command run after this patch:
`node scripts/run-vitest.mjs src/cli/argv.test.ts src/cli/program/register.subclis.test.ts src/cli/program/root-help.test.ts`

Evidence after fix:
The focused CLI descriptor suite passed: 3 test files, 108 tests.

Runtime proof:

```json
{
  "disabled": {
    "qaListed": false,
    "qaNestedHelpLooksLikePluginHelp": true
  },
  "enabled": {
    "qaListed": true,
    "qaNestedHelpLooksLikePluginHelp": false
  }
}
```

Observed result after fix:
With the private QA flag disabled, `qa` is not listed and argv classification treats `qa scenario help` like an unknown/plugin-root help path. With the flag enabled, `qa` is listed and classified as a known private subcommand root.

What was not tested:
I did not run the private QA command implementation itself; this patch is limited to descriptor exposure and argv classification.

## Checks

- `git diff --check`

Author attribution note: if this PR is squashed or reworked, please preserve author attribution or include `Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>`.
