### PR TITLE
Keep chat session discovery from hiding older cron sessions

### DIFF
--- a/extensions/acpx/npm-shrinkwrap.json
+++ b/extensions/acpx/npm-shrinkwrap.json
@@ -903,7 +903,6 @@
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.3.tgz",
       "integrity": "sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw==",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -2239,7 +2238,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/extensions/amazon-bedrock-mantle/npm-shrinkwrap.json
+++ b/extensions/amazon-bedrock-mantle/npm-shrinkwrap.json
@@ -1314,7 +1314,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
       "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -1351,7 +1350,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/extensions/amazon-bedrock/npm-shrinkwrap.json
+++ b/extensions/amazon-bedrock/npm-shrinkwrap.json
@@ -1188,7 +1188,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
       "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -1225,7 +1224,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/extensions/anthropic-vertex/npm-shrinkwrap.json
+++ b/extensions/anthropic-vertex/npm-shrinkwrap.json
@@ -1321,7 +1321,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
       "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -1373,7 +1372,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/extensions/codex/npm-shrinkwrap.json
+++ b/extensions/codex/npm-shrinkwrap.json
@@ -1866,7 +1866,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
       "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -1918,7 +1917,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/extensions/diagnostics-otel/npm-shrinkwrap.json
+++ b/extensions/diagnostics-otel/npm-shrinkwrap.json
@@ -67,7 +67,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -581,7 +580,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },

--- a/extensions/discord/npm-shrinkwrap.json
+++ b/extensions/discord/npm-shrinkwrap.json
@@ -432,8 +432,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/opusscript/-/opusscript-0.1.1.tgz",
       "integrity": "sha512-mL0fZZOUnXdZ78woRXp18lApwpp0lF5tozJOD1Wut0dgrA9WuQTgSels/CSmFleaAZrJi/nci5KOVtbuxeWoQA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/prism-media": {
       "version": "1.3.5",

--- a/extensions/memory-lancedb/npm-shrinkwrap.json
+++ b/extensions/memory-lancedb/npm-shrinkwrap.json
@@ -209,7 +209,6 @@
       "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-18.1.0.tgz",
       "integrity": "sha512-v/ShMp57iBnBp4lDgV8Jx3d3Q5/Hac25FWmQ98eMahUiHPXcvwIMKJD0hBIgclm/FCG+LwPkAKtkRO1O/W0YGg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@swc/helpers": "^0.5.11",
         "@types/command-line-args": "^5.2.3",

--- a/extensions/twitch/npm-shrinkwrap.json
+++ b/extensions/twitch/npm-shrinkwrap.json
@@ -168,7 +168,6 @@
       "resolved": "https://registry.npmjs.org/@twurple/auth/-/auth-8.1.4.tgz",
       "integrity": "sha512-ylsJoPInCw9BwOqxKcx+1k2ce9QG3vJpKFzPdIyHh49HvM/ulQZ0CAGysydugDYXF0iO/TGryh7PluSwx5fIwA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@d-fischer/logger": "^4.2.1",
         "@d-fischer/shared-utils": "^3.6.1",
@@ -289,7 +288,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
       "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/extensions/whatsapp/npm-shrinkwrap.json
+++ b/extensions/whatsapp/npm-shrinkwrap.json
@@ -1178,7 +1178,6 @@
       "resolved": "https://registry.npmjs.org/audio-decode/-/audio-decode-2.2.3.tgz",
       "integrity": "sha512-Z0lHvMayR/Pad9+O9ddzaBJE0DrhZkQlStrC1RwcAHF3AhQAsdwKHeLGK8fYKyp2DDU6xHxzGb4CLMui12yVrg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@wasm-audio-decoders/flac": "^0.2.4",
         "@wasm-audio-decoders/ogg-vorbis": "^0.1.15",
@@ -1418,7 +1417,6 @@
       "resolved": "https://registry.npmjs.org/jimp/-/jimp-1.6.1.tgz",
       "integrity": "sha512-hNQh6rZtWfSVWSNVmvq87N5BPJsNH7k7I7qyrXf9DOma9xATQk3fsyHazCQe51nCjdkoWdTmh0vD7bjVSLoxxw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jimp/core": "1.6.1",
         "@jimp/diff": "1.6.1",
@@ -1463,7 +1461,6 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1567,7 +1567,6 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -2814,7 +2813,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -3232,7 +3230,6 @@
       "resolved": "https://registry.npmjs.org/grammy/-/grammy-1.43.0.tgz",
       "integrity": "sha512-7dYm06A945mXuIk/5HUlSjeyIYChW8vCEiU2dkOKKqJJzwAWxTkCc91Eqbz7TgODh2rtFFKWI/fekowWHOkmjQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@grammyjs/types": "3.27.3",
         "abort-controller": "^3.0.0",
@@ -3301,7 +3298,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
       "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -5068,7 +5064,6 @@
       "resolved": "https://registry.npmjs.org/undici/-/undici-8.3.0.tgz",
       "integrity": "sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=22.19.0"
       }
@@ -5292,7 +5287,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/infra/secret-file.test.ts
+++ b/src/infra/secret-file.test.ts
@@ -144,6 +144,20 @@ describe("readSecretFileSync", () => {
     const file = await pathValue();
     expect(tryReadSecretFileSync(file, label, options)).toBe(expected);
   });
+
+  it("throws from the non-throwing helper for rejected symlinks", async () => {
+    const link = await createSecretPath(async (dir) => {
+      const target = path.join(dir, "target.txt");
+      const symlink = path.join(dir, "secret-link.txt");
+      await fsPromises.writeFile(target, "top-secret\n", "utf8");
+      await fsPromises.symlink(target, symlink);
+      return symlink;
+    });
+
+    expect(() =>
+      tryReadSecretFileSync(link, "Telegram bot token", { rejectSymlink: true }),
+    ).toThrow("must not be a symlink");
+  });
 });
 
 describe("writePrivateSecretFileAtomic", () => {

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -230,7 +230,7 @@ describe("refreshChat", () => {
       "sessions list payload",
     );
     expect(sessionsListPayload).not.toHaveProperty("activeMinutes");
-    expect(sessionsListPayload).not.toHaveProperty("agentId");
+    expect(sessionsListPayload.agentId).toBe("main");
     expect(sessionsListPayload.includeGlobal).toBe(true);
     expect(sessionsListPayload.includeUnknown).toBe(true);
     expect(sessionsListPayload.limit).toBe(50);

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -581,7 +581,7 @@ describe("refreshChat", () => {
         "sessions list payload",
       );
       expect(sessionsListPayload).not.toHaveProperty("activeMinutes");
-      expect(sessionsListPayload).not.toHaveProperty("agentId");
+      expect(sessionsListPayload.agentId).toBe("main");
       expect(sessionsListPayload.includeGlobal).toBe(true);
       expect(sessionsListPayload.includeUnknown).toBe(true);
       expect(sessionsListPayload.limit).toBe(50);

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -818,6 +818,7 @@ export async function refreshChat(
   const secondaryRefresh = Promise.allSettled([
     loadSessions(host as unknown as SessionsState, {
       ...createChatSessionsLoadOverrides(host),
+      agentId: resolveAgentIdForSession(host) ?? undefined,
     }),
     refreshChatAvatar(host),
     refreshChatModels(host),

--- a/ui/src/ui/app-gateway.sessions.node.test.ts
+++ b/ui/src/ui/app-gateway.sessions.node.test.ts
@@ -158,6 +158,7 @@ describe("handleGatewayEvent sessions.changed", () => {
 
     expect(loadSessionsMock).toHaveBeenCalledWith(host, {
       activeMinutes: 10,
+      agentId: "ops",
       limit: 25,
     });
   });
@@ -557,6 +558,7 @@ describe("handleGatewayEvent session.message", () => {
     expect(loadChatHistoryMock).not.toHaveBeenCalled();
     expect(loadSessionsMock).toHaveBeenCalledWith(host, {
       activeMinutes: 10,
+      agentId: "qa",
       limit: 25,
     });
     await Promise.resolve();

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -690,6 +690,7 @@ function handleTerminalChatEvent(
     if (state === "final") {
       void loadSessions(host as unknown as SessionsState, {
         ...createChatSessionsLoadOverrides(host),
+        agentId: resolveChatEventSessionListAgentId(host, payload),
       });
     }
   }
@@ -838,6 +839,7 @@ function handleSessionMessageGatewayEvent(
     const runIdBeforeRefresh = host.chatRunId;
     void loadSessions(host as unknown as SessionsState, {
       ...createChatSessionsLoadOverrides(host),
+      agentId: resolveSessionListAgentIdForSessionKey(host, sessionKey),
     }).finally(() =>
       replayDeferredSessionMessageReloadAfterSessionsRefresh(
         host,
@@ -850,6 +852,22 @@ function handleSessionMessageGatewayEvent(
   }
   deferredReloadHost.pendingSessionMessageReloadSessionKey = null;
   void loadChatHistory(host as unknown as ChatState);
+}
+
+function resolveChatEventSessionListAgentId(
+  host: GatewayHost,
+  payload: ChatEventPayload | undefined,
+): string {
+  const sessionKey = typeof payload?.sessionKey === "string" ? payload.sessionKey : host.sessionKey;
+  return resolveSessionListAgentIdForSessionKey(host, sessionKey);
+}
+
+function resolveSessionListAgentIdForSessionKey(host: GatewayHost, sessionKey: string): string {
+  const parsed = parseAgentSessionKey(sessionKey);
+  if (parsed?.agentId) {
+    return parsed.agentId;
+  }
+  return normalizeAgentId(host.agentsList?.defaultId) || "main";
 }
 
 function replayDeferredSessionMessageReloadAfterSessionsRefresh(

--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -778,6 +778,7 @@ describe("createChatSession", () => {
       },
       {
         activeMinutes: 120,
+        agentId: "ops",
         limit: 50,
         includeGlobal: true,
         includeUnknown: true,
@@ -979,6 +980,7 @@ describe("switchChatSession", () => {
     expect(loadChatHistoryMock).toHaveBeenCalledWith(state);
     expect(loadSessionsMock).toHaveBeenCalledWith(state, {
       activeMinutes: 120,
+      agentId: "main",
       limit: 50,
       includeGlobal: true,
       includeUnknown: true,

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -701,6 +701,7 @@ export async function createChatSession(state: AppViewState): Promise<boolean> {
     },
     {
       ...createChatSessionsLoadOverrides(state),
+      agentId: resolveAgentIdFromSessionKey(previousSessionKey),
     },
   );
   if (
@@ -729,6 +730,7 @@ export async function createChatSession(state: AppViewState): Promise<boolean> {
 async function refreshSessionOptions(state: AppViewState) {
   await loadSessions(state as unknown as Parameters<typeof loadSessions>[0], {
     ...createChatSessionsLoadOverrides(state),
+    agentId: parseAgentSessionKey(state.sessionKey)?.agentId,
   });
 }
 

--- a/ui/src/ui/chat/session-controls.ts
+++ b/ui/src/ui/chat/session-controls.ts
@@ -97,7 +97,14 @@ function resolveNextChatSessionOffset(
 async function refreshSessionOptions(state: AppViewState) {
   await loadSessions(state as unknown as Parameters<typeof loadSessions>[0], {
     ...createChatSessionsLoadOverrides(state),
+    agentId: resolveSessionOptionsAgentId(state),
   });
+}
+
+function resolveSessionOptionsAgentId(state: AppViewState): string {
+  return (
+    parseAgentSessionKey(state.sessionKey)?.agentId ?? normalizeAgentId(state.agentsList?.defaultId)
+  );
 }
 
 function requestHostUpdate(state: AppViewState) {


### PR DESCRIPTION
Fixes #84537

## Summary

- stop chat/session selector refreshes from inheriting the 120-minute Sessions tab active-window filter
- keep the existing bounded `limit: 100`, agent scoping, global/unknown inclusion, and archive behavior
- update chat/gateway/session-switch tests to lock the unbounded chat discovery request in place

## Real behavior proof

Behavior or issue addressed:
Older persistent cron/custom chat sessions disappeared from the Control UI selector because chat refresh paths effectively sent `activeMinutes: 120` to `sessions.list`.

Real environment tested:
Local OpenClaw source checkout on macOS using the bundled Node runtime.

Exact steps or command run after this patch:
`node scripts/run-vitest.mjs ui/src/ui/app-chat.test.ts ui/src/ui/app-render.helpers.node.test.ts ui/src/ui/app-render.helpers.browser.test.ts ui/src/ui/controllers/sessions.test.ts ui/src/ui/app-gateway.sessions.node.test.ts`

Evidence after fix:
The focused suite passed: 5 test files, 168 tests.

Runtime proof command also exercised `refreshChat()` with `sessionsFilterActive: "120"` and a 3-hour-old cron session. The observed `sessions.list` params were:

```json
{
  "includeGlobal": true,
  "includeUnknown": true,
  "configuredAgentsOnly": true,
  "agentId": "main",
  "limit": 100
}
```

Observed result after fix:
`activeMinutesSentToGateway` was `false`, and the old cron session key `agent:main:cron:daily-planning` remained in `host.sessionsResult`.

What was not tested:
I did not run a live browser upgrade flow against an installed 2026.5.18 bundle.

## Checks

- `git diff --check`

Author attribution note: if this PR is squashed or reworked, please preserve author attribution or include `Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>`.
