### PR TITLE
perf(tui): skip plugin metadata + provider catalog on remote TUI startup

### DIFF
--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -219,7 +219,7 @@ function primeConfiguredContextWindows(): OpenClawConfig | undefined {
   }
 }
 
-function ensureContextWindowCacheLoaded(): Promise<void> {
+export function ensureContextWindowCacheLoaded(): Promise<void> {
   if (CONTEXT_WINDOW_RUNTIME_STATE.loadPromise) {
     return CONTEXT_WINDOW_RUNTIME_STATE.loadPromise;
   }
@@ -285,12 +285,6 @@ export function lookupContextTokens(
     void ensureContextWindowCacheLoaded();
   }
   return lookupCachedContextTokens(modelId);
-}
-
-if (shouldEagerWarmContextWindowCache()) {
-  // Keep startup warmth for the real CLI, but avoid import-time side effects
-  // when this module is pulled in through library/plugin-sdk surfaces.
-  void ensureContextWindowCacheLoaded();
 }
 
 function resolveProviderModelRef(params: {

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -2391,11 +2391,6 @@ export function loadConfig(options?: { skipPluginValidation?: boolean }): OpenCl
   // First successful load becomes the process snapshot. Long-lived runtimes
   // should swap this snapshot via explicit reload/watcher paths instead of
   // reparsing openclaw.json on hot code paths.
-  //
-  // `skipPluginValidation` lets pure-client callers (e.g. the TUI talking to a
-  // remote gateway) load the config without triggering the plugin metadata
-  // snapshot, which is otherwise pulled in by plugin-aware config validation
-  // and is the dominant cost of cold startup.
   return loadPinnedRuntimeConfig(() =>
     createConfigIO(options?.skipPluginValidation ? { pluginValidation: "skip" } : {}).loadConfig(),
   );

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -2387,15 +2387,22 @@ export function projectConfigOntoRuntimeSourceSnapshot(config: OpenClawConfig): 
   return coerceConfig(applyMergePatch(projectedSource, runtimePatch));
 }
 
-export function loadConfig(): OpenClawConfig {
+export function loadConfig(options?: { skipPluginValidation?: boolean }): OpenClawConfig {
   // First successful load becomes the process snapshot. Long-lived runtimes
   // should swap this snapshot via explicit reload/watcher paths instead of
   // reparsing openclaw.json on hot code paths.
-  return loadPinnedRuntimeConfig(() => createConfigIO().loadConfig());
+  //
+  // `skipPluginValidation` lets pure-client callers (e.g. the TUI talking to a
+  // remote gateway) load the config without triggering the plugin metadata
+  // snapshot, which is otherwise pulled in by plugin-aware config validation
+  // and is the dominant cost of cold startup.
+  return loadPinnedRuntimeConfig(() =>
+    createConfigIO(options?.skipPluginValidation ? { pluginValidation: "skip" } : {}).loadConfig(),
+  );
 }
 
-export function getRuntimeConfig(): OpenClawConfig {
-  return loadConfig();
+export function getRuntimeConfig(options?: { skipPluginValidation?: boolean }): OpenClawConfig {
+  return loadConfig(options);
 }
 
 export async function readBestEffortConfig(): Promise<OpenClawConfig> {

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { agentCommandFromIngress } from "../agents/agent-command.js";
 import { resolveSessionAgentId } from "../agents/agent-scope.js";
+import { ensureContextWindowCacheLoaded } from "../agents/context.js";
 import { DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { buildAllowedModelSet, resolveThinkingDefault } from "../agents/model-selection.js";
 import { createDefaultDeps } from "../cli/deps.js";
@@ -138,6 +139,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
       return;
     }
     setEmbeddedMode(true);
+    void ensureContextWindowCacheLoaded();
     // Suppress console output from logError/logInfo that would pollute the TUI.
     // File logger (getLogger()) still captures everything via logger.ts:35.
     this.previousRuntimeLog = defaultRuntime.log;

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -443,7 +443,12 @@ export function resolveTuiCtrlCAction(params: {
 
 export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
   const isLocalMode = opts.local === true || opts.backend !== undefined;
-  const config = opts.config ?? getRuntimeConfig();
+  // Remote-mode TUI is a thin WebSocket client and never resolves plugin
+  // refs locally — skipping plugin-aware validation here removes the synchronous
+  // plugin metadata snapshot load (200k+ file reads) from the event loop.
+  // Embedded (--local) mode still runs the agent runtime in-process, so it
+  // needs the fully validated config.
+  const config = opts.config ?? getRuntimeConfig({ skipPluginValidation: !isLocalMode });
   const initialSessionInput = (opts.session ?? "").trim();
   let sessionScope: SessionScope = (config.session?.scope ?? "per-sender") as SessionScope;
   let sessionMainKey = normalizeMainKey(config.session?.mainKey);

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -443,11 +443,6 @@ export function resolveTuiCtrlCAction(params: {
 
 export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
   const isLocalMode = opts.local === true || opts.backend !== undefined;
-  // Remote-mode TUI is a thin WebSocket client and never resolves plugin
-  // refs locally — skipping plugin-aware validation here removes the synchronous
-  // plugin metadata snapshot load (200k+ file reads) from the event loop.
-  // Embedded (--local) mode still runs the agent runtime in-process, so it
-  // needs the fully validated config.
   const config = opts.config ?? getRuntimeConfig({ skipPluginValidation: !isLocalMode });
   const initialSessionInput = (opts.session ?? "").trim();
   let sessionScope: SessionScope = (config.session?.scope ?? "per-sender") as SessionScope;


### PR DESCRIPTION
BEFORE

<img width="689" height="231" alt="image" src="https://github.com/user-attachments/assets/86835bab-acad-4be4-8ce7-ee4a47cf15b7" />

AFTER

<img width="2574" height="830" alt="image" src="https://github.com/user-attachments/assets/ad1fc2a4-65d1-4d13-b868-00adb5337002" />

## Summary

Cold `openclaw tui` against a remote gateway froze the TUI's event loop for tens of seconds after first render. CPU profile showed the dominant cost was provider catalog resolution (`runProviderCatalog`, `resolveProviderSyntheticAuthWithPlugin`, `lstat`, `open`), with secondary cost in plugin manifest snapshot loading via config validation.

Neither of these is needed in remote mode — the TUI is a thin WebSocket client that queries the gateway over RPC for models, slash commands, agents. Both were leaking into the TUI process through two distinct mechanisms:

**1. Plugin-aware config validation triggered by `getRuntimeConfig()`**
`src/tui/tui.ts:451` → `getRuntimeConfig()` → `loadConfig()` → `validateConfigObjectWithPlugins()` → `loadPluginMetadataSnapshot()` (200k+ sync file reads).

`createConfigIO` already supported `pluginValidation: "skip"` (used by `readConfigFileSnapshot`); it just wasn't reachable from the runtime entrypoints. This PR threads an opt-in `skipPluginValidation` through `getRuntimeConfig` / `loadConfig`. The TUI passes `skipPluginValidation: !isLocalMode`.

**2. Top-level eager warmup in `src/agents/context.ts`**
The module fired `void ensureContextWindowCacheLoaded()` at module-eval time for non-skip-listed CLI commands. The TUI transitively imports this module, so the warmup ran on every TUI startup — cascading into `ensureOpenClawModelsJson` → `resolveImplicitProviders` → `runProviderCatalog`, plus credential reads via `resolveProviderSyntheticAuthWithPlugin`. It also called `getRuntimeConfig()` without the skip flag, pinning the full snapshot and nullifying (1).

This PR removes the top-level side effect and triggers the warmup explicitly from `EmbeddedTuiBackend.start()`, so it only fires when an in-process agent runtime actually needs it.

### Mode behavior

- **Remote TUI (`openclaw tui`)**: no plugin metadata load, no provider catalog work, no models.json materialization. Config validation still runs in raw-shape mode (`validateConfigObjectRaw` + basic defaults) — enough for connection settings, session prefs, agent ID resolution.
- **Embedded TUI (`openclaw tui --local`, `chat`, `terminal`)**: unchanged. Full plugin validation runs (in-process agent runtime needs it), and the context window cache is warmed by the embedded backend's `start()`.
- **Gateway boot, other CLI commands**: unchanged — they were already on the warmup skip list.

## Verification

- `pnpm tsgo:core --noEmit` clean
- Targeted tests pass:
  - `src/tui/tui.test.ts` — 46/46
  - `src/tui/embedded-backend.test.ts` + `src/agents/context.lookup.test.ts` — 92/92 combined
  - `src/config/io.meta.test.ts` + `src/config/runtime-snapshot.test.ts` — 10/10

## Real behavior proof

- **Behavior addressed**: cold `openclaw tui` (remote mode) freezes ~55s on event loop after first render
- **Real environment tested**: CPU profile captured before the warmup-move commit confirmed the dominant cost was `runProviderCatalog` / `resolveProviderSyntheticAuthWithPlugin`, with `loadPluginMetadataSnapshot` secondary. Post-fix cold-start timing not yet captured.
- **Exact steps or command run after this patch**: `pnpm tsgo:core --noEmit`; `node scripts/run-vitest.mjs src/tui/tui.test.ts src/tui/embedded-backend.test.ts src/agents/context.lookup.test.ts src/config/io.meta.test.ts src/config/runtime-snapshot.test.ts`
- **Evidence after fix**: typecheck clean; 148 targeted tests pass
- **Observed result after fix**: code paths verified via tests; cold-start time-from-render-to-responsive-input measurement to be captured manually
- **What was not tested**: end-to-end manual `openclaw tui` cold-start timing against a warm gateway; `--local` mode regression check (`chat`/`terminal` aliases auto-enable local and now rely on embedded backend's `start()` for warmup); behavior when `openclaw.json` references plugins that don't exist (errors that previously surfaced at TUI startup will now only surface gateway-side / on first plugin use in remote mode)

## Architectural notes

This is point (1) and a follow-up boundary cut from the architectural analysis: the remote-mode TUI doesn't need the provider catalog, plugin manifest registry, models.json, or plugin-aware config validation — the gateway owns all of that and serves it over RPC. The only legitimate config work in remote mode is reading `openclaw.json`, raw-shape validation, and basic defaults (connection URL, session settings, agent ID).

Two mechanisms were leaking gateway-side work into the TUI process; both are now gated. Further cleanup (e.g. deleting the now-unused `shouldEagerWarmContextWindowCache` + helpers) is left to a follow-up.