### PR TITLE
test(infra): align secret symlink try-read contract

### DIFF
--- a/src/infra/secret-file.test.ts
+++ b/src/infra/secret-file.test.ts
@@ -111,21 +111,21 @@ describe("readSecretFileSync", () => {
     await expectSecretFileError({ setup, expectedMessage, options });
   });
 
+  it("throws from the non-throwing helper for symlink validation failures", async () => {
+    const file = await createSecretPath(async (dir) => {
+      const target = path.join(dir, "target.txt");
+      const link = path.join(dir, "secret-link.txt");
+      await fsPromises.writeFile(target, "top-secret\n", "utf8");
+      await fsPromises.symlink(target, link);
+      return link;
+    });
+
+    expect(() =>
+      tryReadSecretFileSync(file, "Telegram bot token", { rejectSymlink: true }),
+    ).toThrow(`Telegram bot token file at ${file} must not be a symlink.`);
+  });
+
   it.each([
-    {
-      name: "returns undefined from the non-throwing helper for rejected files",
-      pathValue: async () =>
-        createSecretPath(async (dir) => {
-          const target = path.join(dir, "target.txt");
-          const link = path.join(dir, "secret-link.txt");
-          await fsPromises.writeFile(target, "top-secret\n", "utf8");
-          await fsPromises.symlink(target, link);
-          return link;
-        }),
-      label: "Telegram bot token",
-      options: { rejectSymlink: true },
-      expected: undefined,
-    },
     {
       name: "returns undefined from the non-throwing helper for blank file paths",
       pathValue: async () => "   ",


### PR DESCRIPTION
## Summary

- Fixes #84685.
- Updates the stale `src/infra/secret-file.test.ts` expectation for `@openclaw/fs-safe@0.2.7`.
- Keeps `tryReadSecretFileSync` fail-closed for symlink validation failures, while preserving `undefined` for blank and missing path values.

## Real behavior proof

- Behavior addressed: the infra secret-file test now matches the fs-safe 0.2.7 contract: rejected symlink validation throws, blank/missing path values still return `undefined`.
- Real environment tested: Local OpenClaw checkout on Linux, Node 22, branch `fix/secret-file-symlink-ci`.
- Exact steps or command run after this patch:

```bash
OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-secret-file-contract node scripts/run-vitest.mjs src/infra/secret-file.test.ts src/plugin-sdk/fs-safe-compat.test.ts
git diff --check
```

- Evidence after fix:

```text
Test Files 2 passed (2)
Tests 17 passed (17)
```

- Observed result after fix: The symlink validation case asserts the `FsSafeError` message, and the compatibility test keeps public SDK secret-file exports covered.
- What was not tested: Full GitHub Actions matrix; this PR is intended to let the affected CI shard verify the same path remotely.

## Verification

- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-secret-file-contract node scripts/run-vitest.mjs src/infra/secret-file.test.ts src/plugin-sdk/fs-safe-compat.test.ts`
- `git diff --check`
