### PR TITLE
Strip resolved provider api keys from models.json

### DIFF
--- a/extensions/openrouter/provider-routing.ts
+++ b/extensions/openrouter/provider-routing.ts
@@ -56,9 +56,9 @@ function mergeOpenRouterProviderRouting(params: {
   const modelRouting = readRecord(params.modelParams?.provider);
   const extraRouting = readRecord(params.extraParams.provider);
   const merged = {
-    ...(providerRouting ?? {}),
-    ...(modelRouting ?? {}),
-    ...(extraRouting ?? {}),
+    ...providerRouting,
+    ...modelRouting,
+    ...extraRouting,
   };
   return Object.keys(merged).length > 0 ? merged : undefined;
 }
@@ -78,8 +78,8 @@ export function resolveOpenRouterExtraParamsForTransport(
   }
   return {
     patch: {
-      ...(providerConfigParams ?? {}),
-      ...(modelParams ?? {}),
+      ...providerConfigParams,
+      ...modelParams,
       ...ctx.extraParams,
       ...(providerRouting ? { provider: providerRouting } : {}),
     },

--- a/src/agents/models-config.applies-config-env-vars.test.ts
+++ b/src/agents/models-config.applies-config-env-vars.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { createConfigRuntimeEnv } from "../config/env-vars.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
+import { NON_ENV_SECRETREF_MARKER } from "./model-auth-markers.js";
 import { unsetEnv, withTempEnv } from "./models-config.e2e-harness.js";
 import {
   planOpenClawModelsJsonWithDeps,
@@ -186,6 +187,126 @@ describe("models-config", () => {
     );
 
     expect(observedSnapshot).toBe(pluginMetadataSnapshot);
+  });
+
+  it("replaces resolved plaintext apiKey values with a non-secret marker in planned models.json contents", async () => {
+    const plan = await planOpenClawModelsJsonWithDeps(
+      {
+        cfg: { models: { mode: "replace", providers: {} } },
+        agentDir: "/tmp/openclaw-models-config-env-vars-test",
+        env: {},
+        existingRaw: "",
+        existingParsed: null,
+      },
+      {
+        resolveImplicitProviders: async () => ({
+          custom: {
+            baseUrl: "https://custom.example/v1",
+            api: "openai-completions",
+            apiKey: "sk-resolved-runtime-key", // pragma: allowlist secret
+            models: [{ id: "custom-model", name: "Custom model", input: ["text"] }],
+          } as ProviderConfig,
+        }),
+      },
+    );
+
+    expect(plan.action).toBe("write");
+    if (plan.action !== "write") {
+      throw new Error("Expected models.json write plan");
+    }
+    const parsed = JSON.parse(plan.contents) as {
+      providers?: Record<string, { apiKey?: string }>;
+    };
+    expect(parsed.providers?.custom?.apiKey).toBe(NON_ENV_SECRETREF_MARKER);
+    expect(plan.contents).not.toContain("sk-resolved-runtime-key");
+  });
+
+  it("does not preserve old plaintext apiKey values in replace mode", async () => {
+    const plan = await planOpenClawModelsJsonWithDeps(
+      {
+        cfg: { models: { mode: "replace", providers: {} } },
+        agentDir: "/tmp/openclaw-models-config-env-vars-test",
+        env: {},
+        existingRaw: "",
+        existingParsed: {
+          providers: {
+            custom: {
+              baseUrl: "https://custom.example/v1",
+              api: "openai-completions",
+              apiKey: "sk-resolved-runtime-key", // pragma: allowlist secret
+              models: [{ id: "old-model", name: "Old model", input: ["text"] }],
+            },
+          },
+        },
+      },
+      {
+        resolveImplicitProviders: async () => ({
+          custom: {
+            baseUrl: "https://custom.example/v1",
+            api: "openai-completions",
+            apiKey: "sk-resolved-runtime-key", // pragma: allowlist secret
+            models: [{ id: "custom-model", name: "Custom model", input: ["text"] }],
+          } as ProviderConfig,
+        }),
+      },
+    );
+
+    expect(plan.action).toBe("write");
+    if (plan.action !== "write") {
+      throw new Error("Expected models.json write plan");
+    }
+    const parsed = JSON.parse(plan.contents) as {
+      providers?: Record<string, { apiKey?: string }>;
+    };
+    expect(parsed.providers?.custom?.apiKey).toBe(NON_ENV_SECRETREF_MARKER);
+    expect(plan.contents).not.toContain("sk-resolved-runtime-key");
+  });
+
+  it("preserves merge-mode user-authored models.json apiKey values while stripping new plaintext", async () => {
+    const plan = await planOpenClawModelsJsonWithDeps(
+      {
+        cfg: { models: { mode: "merge", providers: {} } },
+        agentDir: "/tmp/openclaw-models-config-env-vars-test",
+        env: {},
+        existingRaw: "",
+        existingParsed: {
+          providers: {
+            kept: {
+              baseUrl: "https://kept.example/v1",
+              api: "openai-completions",
+              apiKey: "sk-user-authored-key", // pragma: allowlist secret
+              models: [],
+            },
+          },
+        },
+      },
+      {
+        resolveImplicitProviders: async () => ({
+          kept: {
+            baseUrl: "https://kept.example/v1",
+            api: "openai-completions",
+            models: [{ id: "kept-model", name: "Kept model", input: ["text"] }],
+          } as ProviderConfig,
+          newprov: {
+            baseUrl: "https://newprov.example/v1",
+            api: "openai-completions",
+            apiKey: "sk-resolved-new-provider-key", // pragma: allowlist secret
+            models: [{ id: "new-model", name: "New model", input: ["text"] }],
+          } as ProviderConfig,
+        }),
+      },
+    );
+
+    expect(plan.action).toBe("write");
+    if (plan.action !== "write") {
+      throw new Error("Expected models.json write plan");
+    }
+    const parsed = JSON.parse(plan.contents) as {
+      providers?: Record<string, { apiKey?: string }>;
+    };
+    expect(parsed.providers?.kept?.apiKey).toBe("sk-user-authored-key");
+    expect(parsed.providers?.newprov?.apiKey).toBe(NON_ENV_SECRETREF_MARKER);
+    expect(plan.contents).not.toContain("sk-resolved-new-provider-key");
   });
 
   it("normalizes retired Gemini ids preserved from existing models.json rows", async () => {

--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import { isRecord } from "../utils.js";
+import { isNonSecretApiKeyMarker, NON_ENV_SECRETREF_MARKER } from "./model-auth-markers.js";
 import {
   mergeProviders,
   mergeWithExistingProviderSecrets,
@@ -105,6 +106,78 @@ function resolveProvidersForMode(params: {
   });
 }
 
+function resolveExistingProviders(
+  existingParsed: unknown,
+): Record<string, ExistingProviderConfig> | undefined {
+  if (!isRecord(existingParsed) || !isRecord(existingParsed.providers)) {
+    return undefined;
+  }
+  return existingParsed.providers as Record<string, ExistingProviderConfig>;
+}
+
+function collectMergePreservedApiKeys(params: {
+  mode: NonNullable<ModelsConfig["mode"]>;
+  existingParsed: unknown;
+  providers: Record<string, ProviderConfig>;
+}): ReadonlyMap<string, string> {
+  if (params.mode !== "merge") {
+    return new Map();
+  }
+
+  const existingProviders = resolveExistingProviders(params.existingParsed);
+  if (!existingProviders) {
+    return new Map();
+  }
+
+  const preserved = new Map<string, string>();
+  for (const [providerKey, existingProvider] of Object.entries(existingProviders)) {
+    const existingApiKey = existingProvider.apiKey;
+    if (
+      typeof existingApiKey !== "string" ||
+      existingApiKey.length === 0 ||
+      isNonSecretApiKeyMarker(existingApiKey, { includeEnvVarName: false })
+    ) {
+      continue;
+    }
+
+    const plannedApiKey = params.providers[providerKey]?.apiKey;
+    if (plannedApiKey === existingApiKey) {
+      preserved.set(providerKey, existingApiKey);
+    }
+  }
+
+  return preserved;
+}
+
+function stripResolvedApiKeysForModelsJson(params: {
+  providers: Record<string, ProviderConfig>;
+  preservedApiKeys: ReadonlyMap<string, string>;
+}): Record<string, ProviderConfig> {
+  const sanitizedProviders: Record<string, ProviderConfig> = {};
+  let changed = false;
+
+  for (const [providerKey, provider] of Object.entries(params.providers)) {
+    const apiKey = provider.apiKey;
+    if (
+      typeof apiKey !== "string" ||
+      apiKey.length === 0 ||
+      isNonSecretApiKeyMarker(apiKey) ||
+      params.preservedApiKeys.get(providerKey) === apiKey
+    ) {
+      sanitizedProviders[providerKey] = provider;
+      continue;
+    }
+
+    sanitizedProviders[providerKey] = {
+      ...provider,
+      apiKey: NON_ENV_SECRETREF_MARKER,
+    };
+    changed = true;
+  }
+
+  return changed ? sanitizedProviders : params.providers;
+}
+
 export async function planOpenClawModelsJsonWithDeps(
   params: {
     cfg: OpenClawConfig;
@@ -178,7 +251,16 @@ export async function planOpenClawModelsJsonWithDeps(
       secretRefManagedProviders,
     }) ?? normalizedMergedProviders;
   const finalProviders = applyNativeStreamingUsageCompat(secretEnforcedProviders);
-  const nextContents = `${JSON.stringify({ providers: finalProviders }, null, 2)}\n`;
+  const preservedApiKeys = collectMergePreservedApiKeys({
+    mode,
+    existingParsed: params.existingParsed,
+    providers: finalProviders,
+  });
+  const serializedProviders = stripResolvedApiKeysForModelsJson({
+    providers: finalProviders,
+    preservedApiKeys,
+  });
+  const nextContents = `${JSON.stringify({ providers: serializedProviders }, null, 2)}\n`;
 
   if (params.existingRaw === nextContents) {
     return { action: "noop" };


### PR DESCRIPTION
## Summary
- Replace runtime-resolved provider `apiKey` values with the non-secret SecretRef marker before writing planned `models.json` contents.
- Keep merge-mode behavior for user-authored existing provider keys while preventing newly resolved plaintext keys from being serialized.
- Add regression coverage for replace-mode stale plaintext removal and merge-mode new provider sanitization.

## Real behavior proof

**Behavior or issue addressed:** Generated `models.json` should not persist a runtime-resolved provider `apiKey`; it should write the existing non-secret marker while preserving the provider/model entry.

**Real environment tested:** Local checkout of `openclaw/openclaw` at PR head `3410456354`, Node `v26.1.0`, pnpm `11.1.0`, Linux x86_64, temporary agent dir `/tmp/openclaw-real-proof-qmMXI3`.

**Exact steps or command run after this patch:**
1. Ran the real `ensureOpenClawModelsJson` writer with a provider config containing `apiKey: "sk-live-proof-value"`.
2. Read the written `<temp-agent-dir>/models.json` file.
3. Parsed `providers.liveproof.apiKey` and checked whether the serialized output contained the input key.

**Evidence after fix:**
```console
$ node --import tsx --input-type=module --eval <real models.json writer proof>
{
  "wrote": true,
  "agentDir": "/tmp/openclaw-real-proof-qmMXI3",
  "serializedApiKey": "secretref-managed",
  "containsSecret": false,
  "modelCount": 1
}
```

**Observed result after fix:** `models.json` was written with `providers.liveproof.apiKey` equal to `secretref-managed`; the serialized file did not contain `sk-live-proof-value`.

**What was not tested:** Full OpenClaw gateway runtime with a live external provider request was not exercised; this proof covers the actual `models.json` writer path and serialization result.

## Validation
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/models-config.applies-config-env-vars.test.ts src/agents/models-config.merge.test.ts` -> 22 passed
- `git diff --check`

Refs #11829

Payment or bounty payout details can be coordinated privately if this is accepted.
