### PR TITLE
feat(tasks): explain stale-running maintenance decisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/tasks: include stale-running task maintenance decisions in `openclaw tasks maintenance --json` so retained and reconcile candidates explain backing-session, cron, CLI, and wedged-subagent state. (#84691) Thanks @efpiva.
 - Codex app-server: keep system-prompt reports working when bootstrap hooks provide workspace files with only a path and content, so hook-supplied SOUL/IDENTITY/TOOLS/USER context still reports injected characters correctly. (#84736) Thanks @JARVIS-Glasses.
 - Providers/MiniMax music: stop advertising `durationSeconds` control and remove prompt-injected duration hints, so `music_generate` reports MiniMax duration as an unsupported override instead of suggesting MiniMax can enforce track length. Fixes #84508. Thanks @neeravmakwana.
 - WhatsApp: update Baileys to `7.0.0-rc12`.

--- a/src/commands/tasks.test.ts
+++ b/src/commands/tasks.test.ts
@@ -200,6 +200,75 @@ describe("tasks commands", () => {
     });
   });
 
+  it("explains task maintenance decisions before applying session registry pruning", async () => {
+    await withTaskCommandStateDir(async (state) => {
+      const now = Date.now();
+      vi.useFakeTimers();
+      vi.setSystemTime(now - 45 * 60_000);
+      const childSessionKey = "agent:main:cron:done-job:run:old-run";
+      const task = createTaskRecord({
+        runtime: "subagent",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        childSessionKey,
+        runId: "run-backed-before-session-sweep",
+        status: "running",
+        task: "Review old cron child session",
+      });
+      vi.setSystemTime(now);
+
+      const sessionsDir = state.sessionsDir("main");
+      const storePath = path.join(sessionsDir, "sessions.json");
+      await fs.mkdir(sessionsDir, { recursive: true });
+      await fs.writeFile(
+        storePath,
+        JSON.stringify(
+          {
+            [childSessionKey]: {
+              sessionId: "old-run",
+              updatedAt: now - 8 * 24 * 60 * 60_000,
+            },
+          },
+          null,
+          2,
+        ),
+        "utf8",
+      );
+
+      const runtime = createRuntime();
+      await tasksMaintenanceCommand({ json: true, apply: true }, runtime);
+
+      const payload = readFirstJsonLog(runtime) as {
+        maintenance: {
+          tasks: { reconciled: number };
+          sessions: { pruned: number };
+        };
+        diagnostics: {
+          staleRunningTasks: Array<{
+            taskId: string;
+            decision: string;
+            reason: string;
+            childSessionKey?: string;
+          }>;
+        };
+      };
+
+      expect(payload.maintenance.tasks.reconciled).toBe(0);
+      expect(payload.maintenance.sessions.pruned).toBe(1);
+      expect(payload.diagnostics.staleRunningTasks).toContainEqual(
+        expect.objectContaining({
+          taskId: task.taskId,
+          decision: "retained",
+          reason: "backing_session_present",
+          childSessionKey,
+        }),
+      );
+
+      const updated = JSON.parse(await fs.readFile(storePath, "utf8")) as Record<string, unknown>;
+      expect(updated[childSessionKey]).toBeUndefined();
+    });
+  });
+
   it("keeps tasks maintenance JSON additive for TaskFlow state", async () => {
     await withTaskCommandStateDir(async () => {
       const now = Date.now();

--- a/src/commands/tasks.test.ts
+++ b/src/commands/tasks.test.ts
@@ -11,6 +11,7 @@ import {
   resetTaskRegistryDeliveryRuntimeForTests,
   resetTaskRegistryForTests,
 } from "../tasks/task-registry.js";
+import * as taskRegistryMaintenance from "../tasks/task-registry.maintenance.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import type { OpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { tasksAuditCommand, tasksMaintenanceCommand } from "./tasks.js";
@@ -266,6 +267,20 @@ describe("tasks commands", () => {
 
       const updated = JSON.parse(await fs.readFile(storePath, "utf8")) as Record<string, unknown>;
       expect(updated[childSessionKey]).toBeUndefined();
+    });
+  });
+
+  it("does not build JSON-only diagnostics for text maintenance output", async () => {
+    await withTaskCommandStateDir(async () => {
+      const diagnosticsSpy = vi.spyOn(
+        taskRegistryMaintenance,
+        "getTaskRegistryMaintenanceDiagnostics",
+      );
+      const runtime = createRuntime();
+
+      await tasksMaintenanceCommand({ json: false, apply: false }, runtime);
+
+      expect(diagnosticsSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/src/commands/tasks.test.ts
+++ b/src/commands/tasks.test.ts
@@ -141,6 +141,65 @@ describe("tasks commands", () => {
     });
   });
 
+  it("explains stale running tasks retained by backing sessions in maintenance JSON", async () => {
+    await withTaskCommandStateDir(async (state) => {
+      const now = Date.now();
+      vi.useFakeTimers();
+      vi.setSystemTime(now - 45 * 60_000);
+      const childSessionKey = "agent:main:subagent:child-retained";
+      const task = createTaskRecord({
+        runtime: "subagent",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        childSessionKey,
+        runId: "run-retained-child",
+        status: "running",
+        task: "Review retained child session",
+      });
+      vi.setSystemTime(now);
+
+      const sessionsDir = state.sessionsDir("main");
+      await fs.mkdir(sessionsDir, { recursive: true });
+      await fs.writeFile(
+        path.join(sessionsDir, "sessions.json"),
+        JSON.stringify(
+          {
+            [childSessionKey]: {
+              sessionId: "child-retained",
+              updatedAt: now,
+            },
+          },
+          null,
+          2,
+        ),
+        "utf8",
+      );
+
+      const runtime = createRuntime();
+      await tasksMaintenanceCommand({ json: true, apply: false }, runtime);
+
+      const payload = readFirstJsonLog(runtime) as {
+        diagnostics: {
+          staleRunningTasks: Array<{
+            taskId: string;
+            decision: string;
+            reason: string;
+            childSessionKey?: string;
+          }>;
+        };
+      };
+
+      expect(payload.diagnostics.staleRunningTasks).toContainEqual(
+        expect.objectContaining({
+          taskId: task.taskId,
+          decision: "retained",
+          reason: "backing_session_present",
+          childSessionKey,
+        }),
+      );
+    });
+  });
+
   it("keeps tasks maintenance JSON additive for TaskFlow state", async () => {
     await withTaskCommandStateDir(async () => {
       const now = Date.now();

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -665,6 +665,9 @@ export async function tasksMaintenanceCommand(
   const taskMaintenance = opts.apply
     ? await runTaskRegistryMaintenance()
     : previewTaskRegistryMaintenance();
+  // Diagnostics explain the task-maintenance decision above, before the
+  // separate session-registry sweep can prune backing session rows.
+  const diagnostics = getTaskRegistryMaintenanceDiagnostics();
   const flowMaintenance = opts.apply
     ? await runTaskFlowRegistryMaintenance()
     : previewTaskFlowRegistryMaintenance();
@@ -672,7 +675,6 @@ export async function tasksMaintenanceCommand(
   const summary = getInspectableTaskRegistrySummary();
   const auditAfter = opts.apply ? getInspectableTaskAuditSummary() : auditBefore;
   const flowAuditAfter = opts.apply ? getInspectableTaskFlowAuditSummary() : flowAuditBefore;
-  const diagnostics = getTaskRegistryMaintenanceDiagnostics();
 
   if (opts.json) {
     runtime.log(

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -665,9 +665,9 @@ export async function tasksMaintenanceCommand(
   const taskMaintenance = opts.apply
     ? await runTaskRegistryMaintenance()
     : previewTaskRegistryMaintenance();
-  // Diagnostics explain the task-maintenance decision above, before the
+  // JSON diagnostics explain the task-maintenance decision above, before the
   // separate session-registry sweep can prune backing session rows.
-  const diagnostics = getTaskRegistryMaintenanceDiagnostics();
+  const diagnostics = opts.json ? getTaskRegistryMaintenanceDiagnostics() : undefined;
   const flowMaintenance = opts.apply
     ? await runTaskFlowRegistryMaintenance()
     : previewTaskFlowRegistryMaintenance();

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -38,6 +38,7 @@ import {
   getInspectableTaskAuditSummary,
   getInspectableTaskRegistrySummary,
   configureTaskRegistryMaintenance,
+  getTaskRegistryMaintenanceDiagnostics,
   previewTaskRegistryMaintenance,
   runTaskRegistryMaintenance,
 } from "../tasks/task-registry.maintenance.js";
@@ -671,6 +672,7 @@ export async function tasksMaintenanceCommand(
   const summary = getInspectableTaskRegistrySummary();
   const auditAfter = opts.apply ? getInspectableTaskAuditSummary() : auditBefore;
   const flowAuditAfter = opts.apply ? getInspectableTaskFlowAuditSummary() : flowAuditBefore;
+  const diagnostics = getTaskRegistryMaintenanceDiagnostics();
 
   if (opts.json) {
     runtime.log(
@@ -683,6 +685,7 @@ export async function tasksMaintenanceCommand(
             sessions: sessionMaintenance,
           },
           tasks: summary,
+          diagnostics,
           auditBefore: {
             ...auditBefore,
             taskFlows: flowAuditBefore,

--- a/src/tasks/task-registry.maintenance.issue-60299.test.ts
+++ b/src/tasks/task-registry.maintenance.issue-60299.test.ts
@@ -316,10 +316,14 @@ describe("task-registry maintenance issue #60299", () => {
 
   it("marks subagent tasks lost when their child session recovery is tombstoned", async () => {
     const childSessionKey = "agent:main:subagent:wedged-child";
+    const staleAt = Date.now() - 45 * 60_000;
     const task = makeStaleTask({
       runtime: "subagent",
       runId: "run-wedged-child",
       childSessionKey,
+      createdAt: staleAt,
+      startedAt: staleAt,
+      lastEventAt: staleAt,
     });
 
     const { currentTasks } = createTaskRegistryMaintenanceHarness({
@@ -341,6 +345,14 @@ describe("task-registry maintenance issue #60299", () => {
     });
 
     expectMaintenanceCounts(previewTaskRegistryMaintenance(), { reconciled: 1 });
+    expect(getTaskRegistryMaintenanceDiagnostics().staleRunningTasks).toContainEqual(
+      expect.objectContaining({
+        taskId: task.taskId,
+        decision: "would_reconcile",
+        reason: "subagent_recovery_wedged",
+        detail: "subagent orphan recovery blocked after 2 rapid accepted resume attempts",
+      }),
+    );
     expectMaintenanceCounts(await runTaskRegistryMaintenance(), { reconciled: 1 });
     const storedTask = requireTaskRecord(currentTasks, task.taskId);
     expect(storedTask.status).toBe("lost");

--- a/src/tasks/task-registry.maintenance.issue-60299.test.ts
+++ b/src/tasks/task-registry.maintenance.issue-60299.test.ts
@@ -11,6 +11,7 @@ import {
 } from "./detached-task-runtime.js";
 import {
   getInspectableActiveTaskRestartBlockers,
+  getTaskRegistryMaintenanceDiagnostics,
   previewTaskRegistryMaintenance,
   reconcileInspectableTasks,
   resetTaskRegistryMaintenanceRuntimeForTests,
@@ -366,7 +367,7 @@ describe("task-registry maintenance issue #60299", () => {
   });
 
   it("recovers finished cron tasks from durable run logs before marking them lost", async () => {
-    const startedAt = Date.now() - GRACE_EXPIRED_MS;
+    const startedAt = Date.now() - 60 * 60_000;
     const task = makeStaleTask({
       runtime: "cron",
       sourceId: "cron-job-run-log-ok",
@@ -399,6 +400,7 @@ describe("task-registry maintenance issue #60299", () => {
     expect(reconciledTasks[0]?.endedAt).toBe(startedAt + 1250);
     expect(reconciledTasks[0]?.terminalSummary).toBe("done");
     expectMaintenanceCounts(previewTaskRegistryMaintenance(), { reconciled: 0, recovered: 1 });
+    expect(getTaskRegistryMaintenanceDiagnostics().staleRunningTasks).toHaveLength(0);
     expectMaintenanceCounts(await runTaskRegistryMaintenance(), { reconciled: 0, recovered: 1 });
     const storedTask = requireTaskRecord(currentTasks, task.taskId);
     expect(storedTask.status).toBe("succeeded");

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -1003,6 +1003,7 @@ function explainActiveTaskRetention(params: {
 export function getTaskRegistryMaintenanceDiagnostics(): TaskRegistryMaintenanceDiagnostics {
   taskRegistryMaintenanceRuntime.ensureTaskRegistryReady();
   const now = Date.now();
+  const cronRecoveryContext = createCronRecoveryContext();
   const backingSessionContext = createBackingSessionLookupContext();
   const staleRunningTasks: TaskRegistryMaintenanceTaskDiagnostic[] = [];
   for (const task of taskRegistryMaintenanceRuntime.listTaskRecords()) {
@@ -1011,6 +1012,9 @@ export function getTaskRegistryMaintenanceDiagnostics(): TaskRegistryMaintenance
     }
     const ageMs = Math.max(0, now - taskReferenceAt(task));
     if (ageMs < TASK_STALE_RUNNING_MS) {
+      continue;
+    }
+    if (resolveDurableCronTaskRecovery(task, cronRecoveryContext)) {
       continue;
     }
     const decision = explainActiveTaskRetention({ task, now, context: backingSessionContext });

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -64,6 +64,7 @@ import type { TaskRecord, TaskRegistrySummary, TaskStatus } from "./task-registr
 const log = createSubsystemLogger("tasks/task-registry-maintenance");
 const TASK_RECONCILE_GRACE_MS = 5 * 60_000;
 const CHILDLESS_CODEX_NATIVE_RECONCILE_GRACE_MS = 30 * 60_000;
+const TASK_STALE_RUNNING_MS = 30 * 60_000;
 const TASK_RETENTION_MS = 7 * 24 * 60 * 60_000;
 const TASK_SWEEP_INTERVAL_MS = 60_000;
 
@@ -160,6 +161,26 @@ export type TaskRegistryMaintenanceSummary = {
   recovered: number;
   cleanupStamped: number;
   pruned: number;
+};
+
+export type TaskRegistryMaintenanceTaskDiagnostic = {
+  taskId: string;
+  runtime: TaskRecord["runtime"];
+  status: TaskRecord["status"];
+  decision: "retained" | "would_reconcile";
+  reason:
+    | "active_cli_run"
+    | "backing_session_missing"
+    | "backing_session_present"
+    | "cron_runtime_not_authoritative"
+    | "lost_grace_pending";
+  ageMs: number;
+  childSessionKey?: string;
+  runId?: string;
+};
+
+export type TaskRegistryMaintenanceDiagnostics = {
+  staleRunningTasks: TaskRegistryMaintenanceTaskDiagnostic[];
 };
 
 type CronExecutionId = {
@@ -562,6 +583,10 @@ function resolveCleanupAfter(task: TaskRecord): number {
   return terminalAt + TASK_RETENTION_MS;
 }
 
+function taskReferenceAt(task: TaskRecord): number {
+  return task.lastEventAt ?? task.startedAt ?? task.createdAt;
+}
+
 function getNormalizedTaskChildSessionKey(task: TaskRecord): string | undefined {
   return normalizeOptionalString(task.childSessionKey);
 }
@@ -950,6 +975,57 @@ export function previewTaskRegistryMaintenance(): TaskRegistryMaintenanceSummary
     }
   }
   return { reconciled, recovered, cleanupStamped, pruned };
+}
+
+function explainActiveTaskRetention(params: {
+  task: TaskRecord;
+  now: number;
+  context: BackingSessionLookupContext;
+}): Pick<TaskRegistryMaintenanceTaskDiagnostic, "decision" | "reason"> {
+  if (!hasLostGraceExpired(params.task, params.now)) {
+    return { decision: "retained", reason: "lost_grace_pending" };
+  }
+  if (!hasBackingSession(params.task, params.context)) {
+    return { decision: "would_reconcile", reason: "backing_session_missing" };
+  }
+  if (
+    params.task.runtime === "cron" &&
+    !taskRegistryMaintenanceRuntime.isCronRuntimeAuthoritative()
+  ) {
+    return { decision: "retained", reason: "cron_runtime_not_authoritative" };
+  }
+  if (params.task.runtime === "cli" && hasActiveCliRun(params.task)) {
+    return { decision: "retained", reason: "active_cli_run" };
+  }
+  return { decision: "retained", reason: "backing_session_present" };
+}
+
+export function getTaskRegistryMaintenanceDiagnostics(): TaskRegistryMaintenanceDiagnostics {
+  taskRegistryMaintenanceRuntime.ensureTaskRegistryReady();
+  const now = Date.now();
+  const backingSessionContext = createBackingSessionLookupContext();
+  const staleRunningTasks: TaskRegistryMaintenanceTaskDiagnostic[] = [];
+  for (const task of taskRegistryMaintenanceRuntime.listTaskRecords()) {
+    if (task.status !== "running") {
+      continue;
+    }
+    const ageMs = Math.max(0, now - taskReferenceAt(task));
+    if (ageMs < TASK_STALE_RUNNING_MS) {
+      continue;
+    }
+    const decision = explainActiveTaskRetention({ task, now, context: backingSessionContext });
+    staleRunningTasks.push({
+      taskId: task.taskId,
+      runtime: task.runtime,
+      status: task.status,
+      decision: decision.decision,
+      reason: decision.reason,
+      ageMs,
+      ...(task.childSessionKey ? { childSessionKey: task.childSessionKey } : {}),
+      ...(task.runId ? { runId: task.runId } : {}),
+    });
+  }
+  return { staleRunningTasks };
 }
 
 /**

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -173,7 +173,9 @@ export type TaskRegistryMaintenanceTaskDiagnostic = {
     | "backing_session_missing"
     | "backing_session_present"
     | "cron_runtime_not_authoritative"
-    | "lost_grace_pending";
+    | "lost_grace_pending"
+    | "subagent_recovery_wedged";
+  detail?: string;
   ageMs: number;
   childSessionKey?: string;
   runId?: string;
@@ -981,9 +983,19 @@ function explainActiveTaskRetention(params: {
   task: TaskRecord;
   now: number;
   context: BackingSessionLookupContext;
-}): Pick<TaskRegistryMaintenanceTaskDiagnostic, "decision" | "reason"> {
+}): Pick<TaskRegistryMaintenanceTaskDiagnostic, "decision" | "reason" | "detail"> {
   if (!hasLostGraceExpired(params.task, params.now)) {
     return { decision: "retained", reason: "lost_grace_pending" };
+  }
+  if (params.task.runtime === "subagent") {
+    const entry = findTaskSessionEntry(params.task, params.context);
+    if (entry && isSubagentRecoveryWedgedEntry(entry)) {
+      return {
+        decision: "would_reconcile",
+        reason: "subagent_recovery_wedged",
+        detail: formatSubagentRecoveryWedgedReason(entry),
+      };
+    }
   }
   if (!hasBackingSession(params.task, params.context)) {
     return { decision: "would_reconcile", reason: "backing_session_missing" };
@@ -1025,6 +1037,7 @@ export function getTaskRegistryMaintenanceDiagnostics(): TaskRegistryMaintenance
       decision: decision.decision,
       reason: decision.reason,
       ageMs,
+      ...(decision.detail ? { detail: decision.detail } : {}),
       ...(task.childSessionKey ? { childSessionKey: task.childSessionKey } : {}),
       ...(task.runId ? { runId: task.runId } : {}),
     });


### PR DESCRIPTION
## Summary

This PR adds task-maintenance diagnostics explaining why stale running tasks are retained or would be reconciled.

This is intentionally independent from the session-store cache PR stack. It addresses the next memory/operations pressure point that became visible after the session-store clone storm was fixed: thousands of retained task records and several stale-running task/task-flow findings.

Changes:

- Add `getTaskRegistryMaintenanceDiagnostics()` output for stale running tasks.
- Include per-task decisions/reasons such as:
  - `backing_session_present`
  - `backing_session_missing`
  - `active_cli_run`
  - `cron_runtime_not_authoritative`
  - `lost_grace_pending`
- Surface diagnostics in `openclaw tasks maintenance --json`.
- Reuse durable cron recovery when building diagnostics so recoverable stale cron tasks are not reported as stale-running retained/reconcile candidates.

## Real behavior proof

- Behavior or issue addressed: make `openclaw tasks maintenance --json` explain why stale running tasks are retained or would be reconciled, instead of only showing stale-running audit counts with zero maintenance changes.
- Real environment tested: live CodeClaw/OpenClaw `codeclaw-triage` deployment with the real task registry and session stores; this is the same production-like setup used for the memory RCA.
- Exact steps or command run after this patch: inspected the live task registry with `openclaw tasks list --json`, `openclaw tasks audit --json`, and `openclaw tasks maintenance --json`, then validated the new diagnostic shape in tests including durable cron recovery cases.
- Evidence after fix: live task registry output and the new diagnostic shape are below.

  ```text
  openclaw tasks list --json / audit / maintenance summary from live codeclaw-triage:
  total tasks: 3356
  running: 12
  terminal: 3344
  succeeded: 2744
  failed: 300
  lost: 275
  timed_out: 25
  stale_running findings: 9
  missing_cleanup: 0

  openclaw tasks maintenance --json diagnostics sample after this change:
  decision=retained
  reason=backing_session_present
  runtime=subagent
  status=running
  childSessionKey=agent:generalist:subagent:...
  runId=...
  ```

- Observed result after fix: the diagnostics make retained stale-running work explainable, e.g. a stale subagent task reports `decision="retained"`, `reason="backing_session_present"`, `childSessionKey`, and `runId`; recoverable cron tasks are excluded from stale-running diagnostics and counted as recovered by maintenance preview.
- What was not tested: this PR does not prune or compact task registry records and does not claim task-registry memory is fixed; it adds operator diagnostics so a follow-up retention/reconciliation policy can be reviewed safely.

## Validation

Worktree:

```text
/home/edpiva/repos/openclaw-worktrees/task-maintenance-diagnostics
```

TDD note:

- Added a failing regression expectation for stale cron diagnostics: a cron task recoverable from durable run logs should be counted as recovered by maintenance preview and should not also appear in stale-running diagnostics.
- The test failed before the fix and passed after reusing durable cron recovery in diagnostics.

Commands/results:

```text
node scripts/run-vitest.mjs \
  src/commands/tasks.test.ts \
  src/tasks/task-registry.test.ts \
  src/tasks/task-registry.maintenance.issue-60299.test.ts \
  --run

Test Files 3 passed
Tests 89 passed
```

```text
corepack pnpm build
PIPE_EXIT:0
```

```text
git diff --check
# no output
```

```text
codex review --base origin/main
# first pass found P2: diagnostics did not account for durable cron recovery
# fixed by reusing cron recovery context in diagnostics
# final pass EXIT:0 — no actionable correctness issues
```

Evidence logs:

```text
/tmp/openclaw-session-store-evidence/split-prs/pr3-targeted-tests-after-codex-fix.log
/tmp/openclaw-session-store-evidence/split-prs/pr3-pnpm-build-after-codex-fix.log
/tmp/openclaw-session-store-evidence/split-prs/pr3-codex-review-after-fix.log
```