### PR TITLE
fix(doctor): warn when sandbox hides MCP tools

### DIFF
--- a/docs/gateway/config-tools.md
+++ b/docs/gateway/config-tools.md
@@ -43,6 +43,43 @@ Local onboarding defaults new local configs to `tools.profile: "coding"` when un
 | `group:agents`     | `agents_list`, `update_plan`                                                                                            |
 | `group:media`      | `image`, `image_generate`, `music_generate`, `video_generate`, `tts`                                                    |
 | `group:openclaw`   | All built-in tools (excludes provider plugins)                                                                          |
+| `group:plugins`    | Tools owned by loaded plugins, including configured MCP servers exposed through `bundle-mcp`                            |
+
+### MCP and plugin tools inside sandbox tool policy
+
+Configured MCP servers are exposed as plugin-owned tools under the `bundle-mcp` plugin id. Normal tool profiles can allow them, but `tools.sandbox.tools` is an additional gate for sandboxed sessions. If sandbox mode is `"all"` or `"non-main"`, include one of these entries in the sandbox tool allowlist when MCP/plugin tools should be visible:
+
+- `bundle-mcp` for OpenClaw-managed MCP servers from `mcp.servers`
+- the plugin id for a specific native plugin
+- `group:plugins` for all loaded plugin-owned tools
+- exact MCP server globs such as `outlook__*` when you only want one server
+
+```json5
+{
+  agents: { defaults: { sandbox: { mode: "all" } } },
+  mcp: {
+    servers: {
+      outlook: { command: "node", args: ["./outlook-mcp.js"] },
+    },
+  },
+  tools: {
+    sandbox: {
+      tools: {
+        alsoAllow: [
+          "web_search",
+          "web_fetch",
+          "memory_search",
+          "memory_get",
+          "memory_recall",
+          "bundle-mcp",
+        ],
+      },
+    },
+  },
+}
+```
+
+Without that sandbox-layer entry, the MCP server can still load successfully while its tools are filtered before the provider request. Use `openclaw doctor` to catch this shape.
 
 ### `tools.allow` / `tools.deny`
 

--- a/docs/gateway/config-tools.md
+++ b/docs/gateway/config-tools.md
@@ -54,6 +54,8 @@ Configured MCP servers are exposed as plugin-owned tools under the `bundle-mcp` 
 - `group:plugins` for all loaded plugin-owned tools
 - exact MCP server globs such as `outlook__*` when you only want one server
 
+Server globs use the provider-safe MCP server prefix, not necessarily the raw `mcp.servers` key. Non-`[A-Za-z0-9_-]` characters become `-`, names that do not start with a letter get an `mcp-` prefix, and long or duplicate prefixes may be truncated or suffixed; for example, `mcp.servers["Outlook Graph"]` uses a glob like `outlook-graph__*`.
+
 ```json5
 {
   agents: { defaults: { sandbox: { mode: "all" } } },
@@ -72,7 +74,7 @@ Configured MCP servers are exposed as plugin-owned tools under the `bundle-mcp` 
 }
 ```
 
-Without that sandbox-layer entry, the MCP server can still load successfully while its tools are filtered before the provider request. Use `openclaw doctor` to catch this shape.
+Without that sandbox-layer entry, the MCP server can still load successfully while its tools are filtered before the provider request. Use `openclaw doctor` to catch this shape for OpenClaw-managed servers in `mcp.servers`. MCP servers loaded from bundled plugin manifests or Claude `.mcp.json` use the same sandbox gate, but this diagnostic does not enumerate those sources yet; use the same allowlist entries if their tools disappear in sandboxed turns.
 
 ### `tools.allow` / `tools.deny`
 

--- a/docs/gateway/config-tools.md
+++ b/docs/gateway/config-tools.md
@@ -65,14 +65,7 @@ Configured MCP servers are exposed as plugin-owned tools under the `bundle-mcp` 
   tools: {
     sandbox: {
       tools: {
-        alsoAllow: [
-          "web_search",
-          "web_fetch",
-          "memory_search",
-          "memory_get",
-          "memory_recall",
-          "bundle-mcp",
-        ],
+        alsoAllow: ["web_search", "web_fetch", "memory_search", "memory_get", "bundle-mcp"],
       },
     },
   },

--- a/docs/gateway/sandbox-vs-tool-policy-vs-elevated.md
+++ b/docs/gateway/sandbox-vs-tool-policy-vs-elevated.md
@@ -100,6 +100,9 @@ Available groups:
 - `group:agents`: `agents_list`, `update_plan`
 - `group:media`: `image`, `image_generate`, `music_generate`, `video_generate`, `tts`
 - `group:openclaw`: all built-in OpenClaw tools (excludes provider plugins)
+- `group:plugins`: all loaded plugin-owned tools, including configured MCP servers exposed through `bundle-mcp`
+
+For sandboxed MCP servers, the sandbox tool policy is a second allow gate. If `mcp.servers` is configured but sandboxed turns only show built-in tools, add `bundle-mcp`, `group:plugins`, or a server glob such as `outlook__*` to `tools.sandbox.tools.alsoAllow`, then restart/reload the gateway and recapture the tool list.
 
 ## Elevated: exec-only "run on host"
 

--- a/docs/gateway/sandbox-vs-tool-policy-vs-elevated.md
+++ b/docs/gateway/sandbox-vs-tool-policy-vs-elevated.md
@@ -102,7 +102,9 @@ Available groups:
 - `group:openclaw`: all built-in OpenClaw tools (excludes provider plugins)
 - `group:plugins`: all loaded plugin-owned tools, including configured MCP servers exposed through `bundle-mcp`
 
-For sandboxed MCP servers, the sandbox tool policy is a second allow gate. If `mcp.servers` is configured but sandboxed turns only show built-in tools, add `bundle-mcp`, `group:plugins`, or a server glob such as `outlook__*` to `tools.sandbox.tools.alsoAllow`, then restart/reload the gateway and recapture the tool list.
+For sandboxed MCP servers, the sandbox tool policy is a second allow gate. If `mcp.servers` is configured but sandboxed turns only show built-in tools, add `bundle-mcp`, `group:plugins`, or a server glob such as `outlook__*` to `tools.sandbox.tools.alsoAllow`, then restart/reload the gateway and recapture the tool list. Server globs use the provider-safe MCP server prefix: non-`[A-Za-z0-9_-]` characters become `-`, names that do not start with a letter get an `mcp-` prefix, and long or duplicate prefixes may be truncated or suffixed.
+
+`openclaw doctor` currently checks this shape for OpenClaw-managed servers in `mcp.servers`. MCP servers loaded from bundled plugin manifests or Claude `.mcp.json` use the same sandbox gate, but this diagnostic does not enumerate those sources yet; use the same allowlist entries if their tools disappear in sandboxed turns.
 
 ## Elevated: exec-only "run on host"
 

--- a/src/commands/doctor/shared/plugin-tool-allowlist-warnings.test.ts
+++ b/src/commands/doctor/shared/plugin-tool-allowlist-warnings.test.ts
@@ -115,6 +115,43 @@ describe("collectPluginToolAllowlistWarnings", () => {
     ]);
   });
 
+  it("uses a config-path source label when sandbox allowlist is unset", () => {
+    const warnings = collectPluginToolAllowlistWarnings({
+      cfg: {
+        agents: { defaults: { sandbox: { mode: "all" } } },
+        mcp: { servers: { outlook: { command: "node", args: ["outlook-server.js"] } } },
+      },
+      manifestRegistry,
+    });
+
+    expect(warnings).toEqual([
+      '- mcp.servers defines 1 MCP server ("outlook"), but tools.sandbox.tools.alsoAllow (unset) does not include "bundle-mcp", "group:plugins", or a matching "<server>__*" MCP tool pattern. Sandboxed agents will filter bundled MCP tools before provider requests. Add "bundle-mcp" to tools.sandbox.tools.alsoAllow (or use "group:plugins" / server globs) if those MCP tools should be visible; use tools.sandbox.tools.allow: [] only when you intentionally want no sandbox allow gate.',
+    ]);
+  });
+
+  it("uses plural grammar when multiple sandbox allow sources hide MCP servers", () => {
+    const warnings = collectPluginToolAllowlistWarnings({
+      cfg: {
+        agents: {
+          defaults: { sandbox: { mode: "all" } },
+          list: [
+            {
+              id: "worker",
+              tools: { sandbox: { tools: { alsoAllow: ["web_fetch"] } } },
+            },
+          ],
+        },
+        mcp: { servers: { outlook: { command: "node", args: ["outlook-server.js"] } } },
+        tools: { sandbox: { tools: { alsoAllow: ["web_search"] } } },
+      },
+      manifestRegistry,
+    });
+
+    expect(warnings).toEqual([
+      '- mcp.servers defines 1 MCP server ("outlook"), but agents.list[0].tools.sandbox.tools.alsoAllow, tools.sandbox.tools.alsoAllow do not include "bundle-mcp", "group:plugins", or a matching "<server>__*" MCP tool pattern. Sandboxed agents will filter bundled MCP tools before provider requests. Add "bundle-mcp" to tools.sandbox.tools.alsoAllow (or use "group:plugins" / server globs) if those MCP tools should be visible; use tools.sandbox.tools.allow: [] only when you intentionally want no sandbox allow gate.',
+    ]);
+  });
+
   it("does not warn for sandboxed MCP servers when bundle-mcp is explicitly allowed", () => {
     const warnings = collectPluginToolAllowlistWarnings({
       cfg: {
@@ -191,6 +228,19 @@ describe("collectPluginToolAllowlistWarnings", () => {
         agents: { defaults: { sandbox: { mode: "all" } } },
         mcp: { servers: { outlook: { command: "node", args: ["outlook-server.js"] } } },
         tools: { sandbox: { tools: { alsoAllow: ["outlook__*"] } } },
+      },
+      manifestRegistry,
+    });
+
+    expect(warnings).toStrictEqual([]);
+  });
+
+  it("does not warn when a server glob matches the sanitized MCP server name", () => {
+    const warnings = collectPluginToolAllowlistWarnings({
+      cfg: {
+        agents: { defaults: { sandbox: { mode: "all" } } },
+        mcp: { servers: { "Outlook Graph": { command: "node", args: ["outlook-server.js"] } } },
+        tools: { sandbox: { tools: { alsoAllow: ["outlook-graph__*"] } } },
       },
       manifestRegistry,
     });

--- a/src/commands/doctor/shared/plugin-tool-allowlist-warnings.test.ts
+++ b/src/commands/doctor/shared/plugin-tool-allowlist-warnings.test.ts
@@ -149,6 +149,29 @@ describe("collectPluginToolAllowlistWarnings", () => {
     expect(warnings).toStrictEqual([]);
   });
 
+  it("still warns for inherited allow policy when one agent intentionally denies MCP", () => {
+    const warnings = collectPluginToolAllowlistWarnings({
+      cfg: {
+        agents: {
+          defaults: { sandbox: { mode: "all" } },
+          list: [
+            {
+              id: "worker",
+              tools: { sandbox: { tools: { deny: ["bundle-mcp"] } } },
+            },
+          ],
+        },
+        mcp: { servers: { outlook: { command: "node", args: ["outlook-server.js"] } } },
+        tools: { sandbox: { tools: { alsoAllow: ["web_fetch"] } } },
+      },
+      manifestRegistry,
+    });
+
+    expect(warnings).toEqual([
+      '- mcp.servers defines 1 MCP server ("outlook"), but tools.sandbox.tools.alsoAllow does not include "bundle-mcp", "group:plugins", or a matching "<server>__*" MCP tool pattern. Sandboxed agents will filter bundled MCP tools before provider requests. Add "bundle-mcp" to tools.sandbox.tools.alsoAllow (or use "group:plugins" / server globs) if those MCP tools should be visible; use tools.sandbox.tools.allow: [] only when you intentionally want no sandbox allow gate.',
+    ]);
+  });
+
   it("does not warn for sandboxed MCP servers when group:plugins is explicitly allowed", () => {
     const warnings = collectPluginToolAllowlistWarnings({
       cfg: {

--- a/src/commands/doctor/shared/plugin-tool-allowlist-warnings.test.ts
+++ b/src/commands/doctor/shared/plugin-tool-allowlist-warnings.test.ts
@@ -88,6 +88,91 @@ describe("collectPluginToolAllowlistWarnings", () => {
     ]);
   });
 
+  it("warns when sandbox allowlist hides configured MCP servers", () => {
+    const warnings = collectPluginToolAllowlistWarnings({
+      cfg: {
+        agents: { defaults: { sandbox: { mode: "all" } } },
+        mcp: {
+          servers: {
+            gmail: { command: "node", args: ["gmail-server.js"] },
+            outlook: { command: "node", args: ["outlook-server.js"] },
+          },
+        },
+        tools: {
+          profile: "coding",
+          sandbox: {
+            tools: {
+              alsoAllow: [
+                "web_search",
+                "web_fetch",
+                "memory_search",
+                "memory_get",
+                "memory_recall",
+              ],
+            },
+          },
+        },
+      },
+      manifestRegistry,
+    });
+
+    expect(warnings).toEqual([
+      '- mcp.servers defines 2 MCP servers ("gmail", "outlook"), but tools.sandbox.tools.alsoAllow does not include "bundle-mcp", "group:plugins", or a matching "<server>__*" MCP tool pattern. Sandboxed agents will filter bundled MCP tools before provider requests. Add "bundle-mcp" to tools.sandbox.tools.alsoAllow (or use "group:plugins" / server globs) if those MCP tools should be visible; use tools.sandbox.tools.allow: [] only when you intentionally want no sandbox allow gate.',
+    ]);
+  });
+
+  it("does not warn for sandboxed MCP servers when bundle-mcp is explicitly allowed", () => {
+    const warnings = collectPluginToolAllowlistWarnings({
+      cfg: {
+        agents: { defaults: { sandbox: { mode: "all" } } },
+        mcp: { servers: { outlook: { command: "node", args: ["outlook-server.js"] } } },
+        tools: { sandbox: { tools: { alsoAllow: ["web_search", "bundle-mcp"] } } },
+      },
+      manifestRegistry,
+    });
+
+    expect(warnings).toStrictEqual([]);
+  });
+
+  it("does not warn for sandboxed MCP servers when a server glob is explicitly allowed", () => {
+    const warnings = collectPluginToolAllowlistWarnings({
+      cfg: {
+        agents: { defaults: { sandbox: { mode: "all" } } },
+        mcp: { servers: { outlook: { command: "node", args: ["outlook-server.js"] } } },
+        tools: { sandbox: { tools: { alsoAllow: ["outlook__*"] } } },
+      },
+      manifestRegistry,
+    });
+
+    expect(warnings).toStrictEqual([]);
+  });
+
+  it("does not warn for sandboxed MCP servers when sandbox allow is explicitly allow-all", () => {
+    const warnings = collectPluginToolAllowlistWarnings({
+      cfg: {
+        agents: { defaults: { sandbox: { mode: "all" } } },
+        mcp: { servers: { outlook: { command: "node", args: ["outlook-server.js"] } } },
+        tools: { sandbox: { tools: { allow: [] } } },
+      },
+      manifestRegistry,
+    });
+
+    expect(warnings).toStrictEqual([]);
+  });
+
+  it("does not warn about MCP sandbox allowlists when sandbox mode is off", () => {
+    const warnings = collectPluginToolAllowlistWarnings({
+      cfg: {
+        agents: { defaults: { sandbox: { mode: "off" } } },
+        mcp: { servers: { outlook: { command: "node", args: ["outlook-server.js"] } } },
+        tools: { sandbox: { tools: { alsoAllow: ["web_search"] } } },
+      },
+      manifestRegistry,
+    });
+
+    expect(warnings).toStrictEqual([]);
+  });
+
   it("does not warn when the owning plugin is allowed", () => {
     const warnings = collectPluginToolAllowlistWarnings({
       cfg: {

--- a/src/commands/doctor/shared/plugin-tool-allowlist-warnings.test.ts
+++ b/src/commands/doctor/shared/plugin-tool-allowlist-warnings.test.ts
@@ -102,13 +102,7 @@ describe("collectPluginToolAllowlistWarnings", () => {
           profile: "coding",
           sandbox: {
             tools: {
-              alsoAllow: [
-                "web_search",
-                "web_fetch",
-                "memory_search",
-                "memory_get",
-                "memory_recall",
-              ],
+              alsoAllow: ["web_search", "web_fetch", "memory_search", "memory_get"],
             },
           },
         },
@@ -127,6 +121,40 @@ describe("collectPluginToolAllowlistWarnings", () => {
         agents: { defaults: { sandbox: { mode: "all" } } },
         mcp: { servers: { outlook: { command: "node", args: ["outlook-server.js"] } } },
         tools: { sandbox: { tools: { alsoAllow: ["web_search", "bundle-mcp"] } } },
+      },
+      manifestRegistry,
+    });
+
+    expect(warnings).toStrictEqual([]);
+  });
+
+  it("does not warn when an agent sandbox tools partial override inherits global MCP allow", () => {
+    const warnings = collectPluginToolAllowlistWarnings({
+      cfg: {
+        agents: {
+          defaults: { sandbox: { mode: "all" } },
+          list: [
+            {
+              id: "worker",
+              tools: { sandbox: { tools: { alsoAllow: ["web_fetch"] } } },
+            },
+          ],
+        },
+        mcp: { servers: { outlook: { command: "node", args: ["outlook-server.js"] } } },
+        tools: { sandbox: { tools: { allow: ["bundle-mcp"] } } },
+      },
+      manifestRegistry,
+    });
+
+    expect(warnings).toStrictEqual([]);
+  });
+
+  it("does not warn for sandboxed MCP servers when group:plugins is explicitly allowed", () => {
+    const warnings = collectPluginToolAllowlistWarnings({
+      cfg: {
+        agents: { defaults: { sandbox: { mode: "all" } } },
+        mcp: { servers: { outlook: { command: "node", args: ["outlook-server.js"] } } },
+        tools: { sandbox: { tools: { alsoAllow: ["group:plugins"] } } },
       },
       manifestRegistry,
     });

--- a/src/commands/doctor/shared/plugin-tool-allowlist-warnings.ts
+++ b/src/commands/doctor/shared/plugin-tool-allowlist-warnings.ts
@@ -11,6 +11,17 @@ type ToolAllowlistSource = {
   entries: string[];
 };
 
+type ActiveSandboxToolPolicy = {
+  labels: string[];
+  policy: Record<string, unknown>;
+};
+
+type PickedSandboxToolPolicyField = {
+  value: unknown;
+  label?: string;
+  defined: boolean;
+};
+
 function hasRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === "object" && !Array.isArray(value));
 }
@@ -124,31 +135,85 @@ function getList(value: unknown, key: "allow" | "alsoAllow" | "deny"): string[] 
     .filter(Boolean);
 }
 
-function describeSandboxAllowGateSource(label: string, policy: unknown): string {
-  if (!hasRecord(policy)) {
-    return label;
+function pickSandboxToolPolicyField(params: {
+  agentPolicy: unknown;
+  globalPolicy: unknown;
+  key: "allow" | "alsoAllow" | "deny";
+  agentLabel: string;
+}): PickedSandboxToolPolicyField {
+  const agentValue = hasRecord(params.agentPolicy) ? params.agentPolicy[params.key] : undefined;
+  if (Array.isArray(agentValue)) {
+    return {
+      value: agentValue,
+      label: `${params.agentLabel}.${params.key}`,
+      defined: true,
+    };
   }
-  if (Array.isArray(policy.allow)) {
-    return `${label}.allow`;
+
+  const globalValue = hasRecord(params.globalPolicy) ? params.globalPolicy[params.key] : undefined;
+  if (Array.isArray(globalValue)) {
+    return {
+      value: globalValue,
+      label: `tools.sandbox.tools.${params.key}`,
+      defined: true,
+    };
   }
-  if (Array.isArray(policy.alsoAllow)) {
-    return `${label}.alsoAllow`;
-  }
-  return label;
+
+  return { value: undefined, defined: false };
 }
 
-function collectActiveSandboxToolPolicies(cfg: OpenClawConfig): Array<{
-  label: string;
-  policy: unknown;
-}> {
-  const out = new Map<string, { label: string; policy: unknown }>();
+function buildEffectiveSandboxToolPolicy(params: {
+  agentPolicy?: unknown;
+  agentLabel?: string;
+  globalPolicy: unknown;
+}): ActiveSandboxToolPolicy {
+  const agentLabel = params.agentLabel ?? "agents.list[].tools.sandbox.tools";
+  const allow = pickSandboxToolPolicyField({
+    agentPolicy: params.agentPolicy,
+    globalPolicy: params.globalPolicy,
+    key: "allow",
+    agentLabel,
+  });
+  const alsoAllow = pickSandboxToolPolicyField({
+    agentPolicy: params.agentPolicy,
+    globalPolicy: params.globalPolicy,
+    key: "alsoAllow",
+    agentLabel,
+  });
+  const deny = pickSandboxToolPolicyField({
+    agentPolicy: params.agentPolicy,
+    globalPolicy: params.globalPolicy,
+    key: "deny",
+    agentLabel,
+  });
+
+  const policy: Record<string, unknown> = {};
+  if (allow.defined) {
+    policy.allow = allow.value;
+  }
+  if (alsoAllow.defined) {
+    policy.alsoAllow = alsoAllow.value;
+  }
+  if (deny.defined) {
+    policy.deny = deny.value;
+  }
+
+  const labels = [allow.label, alsoAllow.label].filter((label): label is string => Boolean(label));
+
+  return {
+    labels: labels.length > 0 ? labels : ["default sandbox tool allowlist"],
+    policy,
+  };
+}
+
+function collectActiveSandboxToolPolicies(cfg: OpenClawConfig): ActiveSandboxToolPolicy[] {
+  const out = new Map<string, ActiveSandboxToolPolicy>();
   const globalPolicy = cfg.tools?.sandbox?.tools;
+  const addPolicy = (entry: ActiveSandboxToolPolicy) => {
+    out.set(entry.labels.join("\u0000"), entry);
+  };
   const addGlobalPolicy = () => {
-    const baseLabel = hasRecord(globalPolicy)
-      ? "tools.sandbox.tools"
-      : "default sandbox tool allowlist";
-    const label = describeSandboxAllowGateSource(baseLabel, globalPolicy);
-    out.set(label, { label, policy: globalPolicy });
+    addPolicy(buildEffectiveSandboxToolPolicy({ globalPolicy }));
   };
 
   const defaultSandboxActive = isSandboxModeActive(cfg.agents?.defaults?.sandbox?.mode);
@@ -169,13 +234,13 @@ function collectActiveSandboxToolPolicies(cfg: OpenClawConfig): Array<{
         return;
       }
       const agentPolicy = hasRecord(agent.tools?.sandbox) ? agent.tools.sandbox.tools : undefined;
-      if (hasRecord(agentPolicy)) {
-        const baseLabel = `agents.list[${index}].tools.sandbox.tools`;
-        const label = describeSandboxAllowGateSource(baseLabel, agentPolicy);
-        out.set(label, { label, policy: agentPolicy });
-        return;
-      }
-      addGlobalPolicy();
+      addPolicy(
+        buildEffectiveSandboxToolPolicy({
+          agentPolicy,
+          agentLabel: `agents.list[${index}].tools.sandbox.tools`,
+          globalPolicy,
+        }),
+      );
     });
   }
 
@@ -252,7 +317,7 @@ function collectSandboxMcpAllowlistWarnings(cfg: OpenClawConfig): string[] {
         !sandboxAllowGateAllowsMcp(policy, serverNames) &&
         !sandboxPolicyIntentionallyDeniesMcp(policy, serverNames),
     )
-    .map(({ label }) => label);
+    .flatMap(({ labels }) => labels);
   if (issueSources.length === 0) {
     return [];
   }

--- a/src/commands/doctor/shared/plugin-tool-allowlist-warnings.ts
+++ b/src/commands/doctor/shared/plugin-tool-allowlist-warnings.ts
@@ -1,3 +1,5 @@
+import { compileGlobPatterns, matchesAnyGlobPattern } from "../../../agents/glob-pattern.js";
+import { sanitizeServerName, TOOL_NAME_SEPARATOR } from "../../../agents/pi-bundle-mcp-names.js";
 import { normalizeToolName } from "../../../agents/tool-policy-shared.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { normalizePluginId } from "../../../plugins/config-state.js";
@@ -92,6 +94,173 @@ function collectKnownPluginIds(registry: PluginManifestRegistry): Set<string> {
   return new Set(registry.plugins.map((plugin) => normalizePluginId(plugin.id)));
 }
 
+function collectConfiguredMcpServerNames(cfg: OpenClawConfig): string[] {
+  const servers = cfg.mcp?.servers;
+  if (!hasRecord(servers)) {
+    return [];
+  }
+  return Object.entries(servers)
+    .filter(([, value]) => hasRecord(value))
+    .map(([name]) => name.trim())
+    .filter(Boolean)
+    .toSorted((left, right) => left.localeCompare(right));
+}
+
+function isSandboxModeActive(mode: unknown): boolean {
+  return mode === "all" || mode === "non-main";
+}
+
+function getList(value: unknown, key: "allow" | "alsoAllow" | "deny"): string[] | undefined {
+  if (!hasRecord(value)) {
+    return undefined;
+  }
+  const raw = value[key];
+  if (!Array.isArray(raw)) {
+    return undefined;
+  }
+  return raw
+    .filter((entry): entry is string => typeof entry === "string")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function describeSandboxAllowGateSource(label: string, policy: unknown): string {
+  if (!hasRecord(policy)) {
+    return label;
+  }
+  if (Array.isArray(policy.allow)) {
+    return `${label}.allow`;
+  }
+  if (Array.isArray(policy.alsoAllow)) {
+    return `${label}.alsoAllow`;
+  }
+  return label;
+}
+
+function collectActiveSandboxToolPolicies(cfg: OpenClawConfig): Array<{
+  label: string;
+  policy: unknown;
+}> {
+  const out = new Map<string, { label: string; policy: unknown }>();
+  const globalPolicy = cfg.tools?.sandbox?.tools;
+  const addGlobalPolicy = () => {
+    const baseLabel = hasRecord(globalPolicy)
+      ? "tools.sandbox.tools"
+      : "default sandbox tool allowlist";
+    const label = describeSandboxAllowGateSource(baseLabel, globalPolicy);
+    out.set(label, { label, policy: globalPolicy });
+  };
+
+  const defaultSandboxActive = isSandboxModeActive(cfg.agents?.defaults?.sandbox?.mode);
+  if (defaultSandboxActive) {
+    addGlobalPolicy();
+  }
+
+  const agentList = cfg.agents?.list;
+  if (Array.isArray(agentList)) {
+    agentList.forEach((agent, index) => {
+      if (!hasRecord(agent)) {
+        return;
+      }
+      const explicitMode = agent.sandbox?.mode;
+      const agentSandboxActive =
+        explicitMode === undefined ? defaultSandboxActive : isSandboxModeActive(explicitMode);
+      if (!agentSandboxActive) {
+        return;
+      }
+      const agentPolicy = hasRecord(agent.tools?.sandbox) ? agent.tools.sandbox.tools : undefined;
+      if (hasRecord(agentPolicy)) {
+        const baseLabel = `agents.list[${index}].tools.sandbox.tools`;
+        const label = describeSandboxAllowGateSource(baseLabel, agentPolicy);
+        out.set(label, { label, policy: agentPolicy });
+        return;
+      }
+      addGlobalPolicy();
+    });
+  }
+
+  return [...out.values()];
+}
+
+function buildMcpProbeToolNames(serverNames: readonly string[]): string[] {
+  const usedNames = new Set<string>();
+  return serverNames.map(
+    (serverName) => `${sanitizeServerName(serverName, usedNames)}${TOOL_NAME_SEPARATOR}probe`,
+  );
+}
+
+function entriesMatchAnyMcpTool(
+  entries: readonly string[],
+  serverNames: readonly string[],
+): boolean {
+  const normalizedEntries = entries.map(normalizeToolName).filter(Boolean);
+  if (
+    normalizedEntries.some(
+      (entry) => entry === "*" || entry === "bundle-mcp" || entry === "group:plugins",
+    )
+  ) {
+    return true;
+  }
+  const patterns = compileGlobPatterns({ raw: normalizedEntries, normalize: normalizeToolName });
+  if (patterns.length === 0) {
+    return false;
+  }
+  return buildMcpProbeToolNames(serverNames).some((probeName) =>
+    matchesAnyGlobPattern(normalizeToolName(probeName), patterns),
+  );
+}
+
+function sandboxAllowGateAllowsMcp(policy: unknown, serverNames: readonly string[]): boolean {
+  const allow = getList(policy, "allow");
+  if (Array.isArray(allow) && allow.length === 0) {
+    return true;
+  }
+  const entries = [...(allow ?? []), ...(getList(policy, "alsoAllow") ?? [])];
+  return entriesMatchAnyMcpTool(entries, serverNames);
+}
+
+function sandboxPolicyIntentionallyDeniesMcp(
+  policy: unknown,
+  serverNames: readonly string[],
+): boolean {
+  const deny = getList(policy, "deny") ?? [];
+  return entriesMatchAnyMcpTool(deny, serverNames);
+}
+
+function formatMcpServerSummary(serverNames: readonly string[]): string {
+  const noun = serverNames.length === 1 ? "server" : "servers";
+  const listed = serverNames
+    .slice(0, 3)
+    .map((serverName) => `"${serverName}"`)
+    .join(", ");
+  const suffix = serverNames.length > 3 ? `, +${serverNames.length - 3} more` : "";
+  return `${serverNames.length} MCP ${noun}${listed ? ` (${listed}${suffix})` : ""}`;
+}
+
+function collectSandboxMcpAllowlistWarnings(cfg: OpenClawConfig): string[] {
+  const serverNames = collectConfiguredMcpServerNames(cfg);
+  if (serverNames.length === 0) {
+    return [];
+  }
+  const sandboxPolicies = collectActiveSandboxToolPolicies(cfg);
+  if (sandboxPolicies.length === 0) {
+    return [];
+  }
+  const issueSources = sandboxPolicies
+    .filter(
+      ({ policy }) =>
+        !sandboxAllowGateAllowsMcp(policy, serverNames) &&
+        !sandboxPolicyIntentionallyDeniesMcp(policy, serverNames),
+    )
+    .map(({ label }) => label);
+  if (issueSources.length === 0) {
+    return [];
+  }
+  return [
+    `- mcp.servers defines ${formatMcpServerSummary(serverNames)}, but ${formatSourceLabels(issueSources)} does not include "bundle-mcp", "group:plugins", or a matching "<server>${TOOL_NAME_SEPARATOR}*" MCP tool pattern. Sandboxed agents will filter bundled MCP tools before provider requests. Add "bundle-mcp" to tools.sandbox.tools.alsoAllow (or use "group:plugins" / server globs) if those MCP tools should be visible; use tools.sandbox.tools.allow: [] only when you intentionally want no sandbox allow gate.`,
+  ];
+}
+
 function formatPluginList(pluginIds: readonly string[]): string {
   if (pluginIds.length === 1) {
     return `"${pluginIds[0]}"`;
@@ -113,23 +282,23 @@ export function collectPluginToolAllowlistWarnings(params: {
   if (params.cfg.plugins?.enabled === false) {
     return [];
   }
+  const warnings = collectSandboxMcpAllowlistWarnings(params.cfg);
   const allowedPluginIds = (params.cfg.plugins?.allow ?? [])
     .map(normalizePluginIdMaybe)
     .filter((pluginId): pluginId is string => Boolean(pluginId));
   const allowedPlugins = new Set(allowedPluginIds);
   if (allowedPlugins.size === 0) {
-    return [];
+    return warnings;
   }
 
   const sources = collectToolAllowlistSources(params.cfg);
   if (sources.length === 0) {
-    return [];
+    return warnings;
   }
 
   const wildcardSources = sources
     .filter((source) => source.entries.some((entry) => normalizeToolName(entry) === "*"))
     .map((source) => source.label);
-  const warnings: string[] = [];
   if (wildcardSources.length > 0) {
     warnings.push(
       `- plugins.allow is an exclusive plugin allowlist. ${formatSourceLabels(wildcardSources)} contains "*", but that wildcard only matches tools from plugins that are loaded; plugin tools outside plugins.allow stay unavailable. Add the required plugin ids to plugins.allow or remove plugins.allow.`,

--- a/src/commands/doctor/shared/plugin-tool-allowlist-warnings.ts
+++ b/src/commands/doctor/shared/plugin-tool-allowlist-warnings.ts
@@ -13,6 +13,7 @@ type ToolAllowlistSource = {
 
 type ActiveSandboxToolPolicy = {
   labels: string[];
+  dedupeKey: string;
   policy: Record<string, unknown>;
 };
 
@@ -198,10 +199,15 @@ function buildEffectiveSandboxToolPolicy(params: {
     policy.deny = deny.value;
   }
 
-  const labels = [allow.label, alsoAllow.label].filter((label): label is string => Boolean(label));
+  const allowLabels = [allow.label, alsoAllow.label].filter((label): label is string =>
+    Boolean(label),
+  );
+  const labels = allowLabels.length > 0 ? allowLabels : ["default sandbox tool allowlist"];
+  const dedupeLabels = Array.from(new Set([...labels, deny.label].filter(Boolean)));
 
   return {
-    labels: labels.length > 0 ? labels : ["default sandbox tool allowlist"],
+    labels,
+    dedupeKey: dedupeLabels.join("\u0000"),
     policy,
   };
 }
@@ -210,7 +216,7 @@ function collectActiveSandboxToolPolicies(cfg: OpenClawConfig): ActiveSandboxToo
   const out = new Map<string, ActiveSandboxToolPolicy>();
   const globalPolicy = cfg.tools?.sandbox?.tools;
   const addPolicy = (entry: ActiveSandboxToolPolicy) => {
-    out.set(entry.labels.join("\u0000"), entry);
+    out.set(entry.dedupeKey, entry);
   };
   const addGlobalPolicy = () => {
     addPolicy(buildEffectiveSandboxToolPolicy({ globalPolicy }));

--- a/src/commands/doctor/shared/plugin-tool-allowlist-warnings.ts
+++ b/src/commands/doctor/shared/plugin-tool-allowlist-warnings.ts
@@ -79,12 +79,27 @@ function collectToolAllowlistSources(cfg: OpenClawConfig): ToolAllowlistSource[]
   return sources;
 }
 
-function formatSourceLabels(labels: Iterable<string>): string {
-  const sorted = [...new Set(labels)].toSorted((left, right) => left.localeCompare(right));
+function collectSortedSourceLabels(labels: Iterable<string>): string[] {
+  return [...new Set(labels)].toSorted((left, right) => left.localeCompare(right));
+}
+
+function formatSortedSourceLabels(sorted: readonly string[]): string {
   if (sorted.length <= 3) {
     return sorted.join(", ");
   }
   return `${sorted.slice(0, 3).join(", ")} (+${sorted.length - 3} more)`;
+}
+
+function formatSourceLabels(labels: Iterable<string>): string {
+  return formatSortedSourceLabels(collectSortedSourceLabels(labels));
+}
+
+function formatSourceLabelSubject(labels: Iterable<string>): { text: string; verb: "does" | "do" } {
+  const sorted = collectSortedSourceLabels(labels);
+  return {
+    text: formatSortedSourceLabels(sorted),
+    verb: sorted.length === 1 ? "does" : "do",
+  };
 }
 
 function collectToolOwners(registry: PluginManifestRegistry): Map<string, string[]> {
@@ -202,7 +217,7 @@ function buildEffectiveSandboxToolPolicy(params: {
   const allowLabels = [allow.label, alsoAllow.label].filter((label): label is string =>
     Boolean(label),
   );
-  const labels = allowLabels.length > 0 ? allowLabels : ["default sandbox tool allowlist"];
+  const labels = allowLabels.length > 0 ? allowLabels : ["tools.sandbox.tools.alsoAllow (unset)"];
   const dedupeLabels = Array.from(new Set([...labels, deny.label].filter(Boolean)));
 
   return {
@@ -233,13 +248,16 @@ function collectActiveSandboxToolPolicies(cfg: OpenClawConfig): ActiveSandboxToo
       if (!hasRecord(agent)) {
         return;
       }
-      const explicitMode = agent.sandbox?.mode;
+      const agentSandbox = hasRecord(agent.sandbox) ? agent.sandbox : undefined;
+      const explicitMode = agentSandbox?.mode;
       const agentSandboxActive =
         explicitMode === undefined ? defaultSandboxActive : isSandboxModeActive(explicitMode);
       if (!agentSandboxActive) {
         return;
       }
-      const agentPolicy = hasRecord(agent.tools?.sandbox) ? agent.tools.sandbox.tools : undefined;
+      const agentTools = hasRecord(agent.tools) ? agent.tools : undefined;
+      const agentToolsSandbox = hasRecord(agentTools?.sandbox) ? agentTools.sandbox : undefined;
+      const agentPolicy = hasRecord(agentToolsSandbox?.tools) ? agentToolsSandbox.tools : undefined;
       addPolicy(
         buildEffectiveSandboxToolPolicy({
           agentPolicy,
@@ -327,8 +345,9 @@ function collectSandboxMcpAllowlistWarnings(cfg: OpenClawConfig): string[] {
   if (issueSources.length === 0) {
     return [];
   }
+  const sourceSubject = formatSourceLabelSubject(issueSources);
   return [
-    `- mcp.servers defines ${formatMcpServerSummary(serverNames)}, but ${formatSourceLabels(issueSources)} does not include "bundle-mcp", "group:plugins", or a matching "<server>${TOOL_NAME_SEPARATOR}*" MCP tool pattern. Sandboxed agents will filter bundled MCP tools before provider requests. Add "bundle-mcp" to tools.sandbox.tools.alsoAllow (or use "group:plugins" / server globs) if those MCP tools should be visible; use tools.sandbox.tools.allow: [] only when you intentionally want no sandbox allow gate.`,
+    `- mcp.servers defines ${formatMcpServerSummary(serverNames)}, but ${sourceSubject.text} ${sourceSubject.verb} not include "bundle-mcp", "group:plugins", or a matching "<server>${TOOL_NAME_SEPARATOR}*" MCP tool pattern. Sandboxed agents will filter bundled MCP tools before provider requests. Add "bundle-mcp" to tools.sandbox.tools.alsoAllow (or use "group:plugins" / server globs) if those MCP tools should be visible; use tools.sandbox.tools.allow: [] only when you intentionally want no sandbox allow gate.`,
   ];
 }
 


### PR DESCRIPTION
## Summary

- Problem: sandboxed agents could hide configured MCP server tools even though the MCP servers loaded successfully, and there was no clear `openclaw doctor` warning for the missing sandbox tool allow gate.
- Solution: add a doctor warning when `mcp.servers` are configured but active sandbox tool policy does not allow `bundle-mcp`, `group:plugins`, or a matching server glob such as `outlook__*`.
- What changed: mirror runtime sandbox policy fallback for per-agent partial overrides, preserve warnings when a separate agent intentionally denies MCP, polish warning grammar/source labels, and document sanitized server globs plus the current bundled-plugin/Claude `.mcp.json` diagnostic limitation.
- What did NOT change (scope boundary): no sandbox defaults, provider serialization, MCP runtime behavior, runtime tool policy enforcement, or bundled-plugin/`.mcp.json` MCP discovery logic changed.

## Motivation

- Related to #80909: the reporter confirmed adding `"bundle-mcp"` to `tools.sandbox.tools.alsoAllow` made the real MCP tools visible again in sandboxed turns.
- The failure mode is confusing because the MCP server can load successfully while the sandbox tool policy filters the provider-visible tool list before the request.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #80909
- [x] This PR fixes a bug or regression

## Real behavior proof

- Behavior or issue addressed:

Sandboxed OpenClaw turns with configured `mcp.servers` now surface a doctor warning when the active sandbox tool allow gate would hide bundled MCP tools before provider requests.

- Real environment tested:

Local OpenClaw checkout on branch `fix/80909-sandbox-mcp-docs`, rebased onto current `upstream/main`, using a temp state dir at `/tmp/openclaw-80909-doctor-state` and running the real `pnpm openclaw doctor` CLI.

- Exact steps or command run after this patch:

```bash
OPENCLAW_STATE_DIR=/tmp/openclaw-80909-doctor-state pnpm openclaw doctor --non-interactive --no-workspace-suggestions
```

- Evidence after fix:

Terminal capture from this branch, copied live output:

```text
◇  Doctor warnings ───────────────────────────────────────────────────────╮
│                                                                         │
│  - mcp.servers defines 1 MCP server ("outlook"), but                    │
│    tools.sandbox.tools.alsoAllow does not include "bundle-mcp",         │
│    "group:plugins", or a matching "<server>__*" MCP tool pattern.       │
│    Sandboxed agents will filter bundled MCP tools before provider       │
│    requests. Add "bundle-mcp" to tools.sandbox.tools.alsoAllow (or use  │
│    "group:plugins" / server globs) if those MCP tools should be         │
│    visible; use tools.sandbox.tools.allow: [] only when you             │
│    intentionally want no sandbox allow gate.                            │
│                                                                         │
├─────────────────────────────────────────────────────────────────────────╯
```

The command exited `0`. The run also printed unrelated local temp-state doctor findings such as missing UI assets, gateway auth/connect noise, and existing build warnings from bundled zod locale `.d.cts` files.

- Observed result after fix:

`openclaw doctor` prints the targeted sandbox/MCP warning in the Doctor warnings panel instead of silently allowing the misconfiguration to pass.

- What was not tested:

An end-to-end sandboxed provider turn against a live MCP server was not rerun in this checkout; the reporter's real setup already confirmed `"bundle-mcp"` fixes the missing provider-visible MCP tools. This PR also intentionally does not make doctor enumerate MCP servers loaded from bundled plugin manifests or Claude `.mcp.json`; the docs call that limitation out.

- Before evidence (optional but encouraged):

Before the first fix commit, `/tmp/openclaw-80909-red-check.mjs` returned `[]` for the target config and failed because it expected the sandbox/MCP warning.

## Root Cause (if applicable)

- Root cause: sandbox tool policy is a second allow gate for sandboxed sessions. Configured MCP servers can load under `bundle-mcp`, but if `tools.sandbox.tools` lacks `bundle-mcp`, `group:plugins`, or a matching `<server>__*` pattern, those MCP tools are filtered before provider requests.
- Missing detection / guardrail: `openclaw doctor` did not flag the configuration shape, so users could diagnose it as a provider serialization or MCP loading bug.
- Contributing context: per-agent sandbox tool overrides fall back field-by-field at runtime, so the diagnostic must mirror that behavior to avoid false positives.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/commands/doctor/shared/plugin-tool-allowlist-warnings.test.ts`
- Scenario the test should lock in: sandboxed `mcp.servers` warn when the active sandbox allow gate omits MCP/plugin entries, do not warn for `bundle-mcp`, `group:plugins`, server globs, or explicit allow-all, and do not false-positive on per-agent partial override fallback.
- Why this is the smallest reliable guardrail: the warning helper owns the exact doctor warning logic and can exercise the sandbox policy combinations without a full gateway runtime.
- Existing test that already covers this (if any): none for the new sandbox/MCP warning path before this branch.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

`openclaw doctor` can now warn when sandbox policy is likely hiding configured MCP server tools from sandboxed agents. Docs now clarify which sandbox allow entries expose MCP/plugin tools, how sanitized server globs are formed, and that bundled-plugin/Claude `.mcp.json` MCP sources use the same gate but are not enumerated by this diagnostic yet.

## Diagram (if applicable)

```text
Before:
mcp.servers loads -> sandboxed session tool gate omits bundle-mcp -> provider sees no MCP tools -> doctor has no targeted warning

After:
mcp.servers loads -> doctor compares active sandbox allow policy -> warning explains bundle-mcp / group:plugins / server glob fix
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: N/A.

## Repro + Verification

### Environment

- OS: Linux container/dev host
- Runtime/container: local OpenClaw checkout with pnpm/node toolchain
- Model/provider: N/A for doctor helper/unit coverage
- Integration/channel (if any): configured MCP server shape from #80909
- Relevant config (redacted): temp `OPENCLAW_STATE_DIR=/tmp/openclaw-80909-doctor-state` with sandbox mode enabled and `mcp.servers.outlook` configured

### Steps

1. Run focused warning helper unit tests.
2. Run the original red repro script and verify it emits the target warning.
3. Run the fallback repro script and verify it emits `[]`.
4. Run TS/docs format checks and docs MDX validation.
5. Run real `openclaw doctor` against the temp state dir and inspect the Doctor warnings panel.

### Expected

- Missing sandbox MCP allow entries produce the targeted warning.
- Explicit MCP allow entries and runtime fallback-compatible configs do not warn.
- Docs and formatting checks pass.

### Actual

- `pnpm test:unit:fast -- src/commands/doctor/shared/plugin-tool-allowlist-warnings.test.ts` -> 19 tests passed.
- `node --import tsx /tmp/openclaw-80909-red-check.mjs` -> emitted the target warning.
- `node --import tsx /tmp/openclaw-80909-agent-fallback-red.mjs` -> printed `[]`.
- `pnpm exec oxfmt --check src/commands/doctor/shared/plugin-tool-allowlist-warnings.ts src/commands/doctor/shared/plugin-tool-allowlist-warnings.test.ts` -> all matched files formatted.
- `pnpm format:docs:check -- docs/gateway/config-tools.md docs/gateway/sandbox-vs-tool-policy-vs-elevated.md` -> docs formatting clean.
- `pnpm docs:check-mdx` -> passed.
- `pnpm tsgo:core:test` -> passed.
- `OPENCLAW_STATE_DIR=/tmp/openclaw-80909-doctor-state pnpm openclaw doctor --non-interactive --no-workspace-suggestions` -> printed the target Doctor warnings panel and exited `0`.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What I personally verified (not just CI), and how:

- Verified scenarios: missing sandbox MCP allow entry warning, `bundle-mcp`, `group:plugins`, server glob, explicit allow-all, sandbox off, per-agent fallback inheritance, intentional deny preserving global warning, sanitized server-name glob.
- Edge cases checked: multi-source warning grammar, unset sandbox allowlist source label, sanitized `mcp.servers["Outlook Graph"]` prefix, docs for bundled-plugin/Claude `.mcp.json` diagnostic limitation.
- What I did **not** verify: end-to-end sandboxed provider turn against a live MCP server after this local patch; bundled-plugin manifest or `.mcp.json` MCP discovery expansion, intentionally out of scope.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: N/A.

## Risks and Mitigations

- Risk: doctor warning could false-positive if it diverges from runtime sandbox tool policy fallback.
  - Mitigation: helper now mirrors `allow`, `alsoAllow`, and `deny` fallback field-by-field, with focused regression tests for partial overrides and intentional deny behavior.
- Risk: users with server names containing spaces/non-provider-safe characters could use the raw config key in a server glob.
  - Mitigation: docs now state server globs use the sanitized provider-safe server prefix and tests cover `"Outlook Graph"` -> `outlook-graph__*`.
- Risk: users might expect this diagnostic to cover all MCP sources.
  - Mitigation: docs explicitly state bundled-plugin manifests and Claude `.mcp.json` MCP servers use the same sandbox gate but are not enumerated by this diagnostic yet.

## AI assistance disclosure

This patch and PR draft were prepared with AI assistance and locally verified before submission.
