### PR TITLE
perf(tui): defer EmbeddedTuiBackend import, drop dead warmup helpers

### DIFF
--- a/src/agents/context.lookup.test.ts
+++ b/src/agents/context.lookup.test.ts
@@ -201,44 +201,6 @@ describe("lookupContextTokens", () => {
     expect(secondLoadConfigMock).not.toHaveBeenCalled();
   });
 
-  it("only warms eagerly for real openclaw startup commands that need model metadata", async () => {
-    const { shouldEagerWarmContextWindowCache } = await importContextModule();
-
-    expect(shouldEagerWarmContextWindowCache(["node", "openclaw", "chat"])).toBe(true);
-    expect(shouldEagerWarmContextWindowCache(["node", "openclaw", "chat", "--help"])).toBe(false);
-    expect(
-      shouldEagerWarmContextWindowCache(["node", "openclaw", "matrix", "encryption", "help"]),
-    ).toBe(false);
-    expect(shouldEagerWarmContextWindowCache(["node", "openclaw", "help", "matrix"])).toBe(false);
-    expect(
-      shouldEagerWarmContextWindowCache(["node", "openclaw", "browser", "status", "--help"]),
-    ).toBe(false);
-    expect(
-      shouldEagerWarmContextWindowCache([
-        "node",
-        "openclaw",
-        "--profile",
-        "--",
-        "config",
-        "validate",
-      ]),
-    ).toBe(false);
-    expect(shouldEagerWarmContextWindowCache(["node", "openclaw", "logs", "--limit", "5"])).toBe(
-      false,
-    );
-    expect(
-      shouldEagerWarmContextWindowCache(["node", "openclaw", "memory", "search", "--json"]),
-    ).toBe(false);
-    expect(shouldEagerWarmContextWindowCache(["node", "openclaw", "message", "read"])).toBe(false);
-    expect(shouldEagerWarmContextWindowCache(["node", "openclaw", "status", "--json"])).toBe(false);
-    expect(shouldEagerWarmContextWindowCache(["node", "openclaw", "sessions", "--json"])).toBe(
-      false,
-    );
-    expect(
-      shouldEagerWarmContextWindowCache(["node", "scripts/test-built-plugin-singleton.mjs"]),
-    ).toBe(false);
-  });
-
   it("retries config loading after backoff when an initial load fails", async () => {
     vi.useFakeTimers();
     const loadConfigMock = vi

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -1,12 +1,9 @@
 // Lazy-load pi-coding-agent model metadata so we can infer context windows when
 // the agent reports a model id. This includes custom models.json entries.
 
-import path from "node:path";
-import { isHelpOrVersionInvocation } from "../cli/argv.js";
 import { getRuntimeConfig } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { computeBackoff, type BackoffPolicy } from "../infra/backoff.js";
-import { consumeRootOptionToken, FLAG_TERMINATOR } from "../infra/cli-root-options.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { resolveDefaultAgentDir } from "./agent-scope.js";
 import { lookupCachedContextTokens, MODEL_CONTEXT_TOKEN_CACHE } from "./context-cache.js";
@@ -106,82 +103,6 @@ export function applyConfiguredContextWindows(params: {
 
 function loadModelsConfigRuntime() {
   return CONTEXT_WINDOW_RUNTIME_STATE.modelsConfigRuntimeLoader.load();
-}
-
-function isLikelyOpenClawCliProcess(argv: string[] = process.argv): boolean {
-  const entryBasename = normalizeLowercaseStringOrEmpty(path.basename(argv[1] ?? ""));
-  return (
-    entryBasename === "openclaw" ||
-    entryBasename === "openclaw.mjs" ||
-    entryBasename === "entry.js" ||
-    entryBasename === "entry.mjs"
-  );
-}
-
-function getCommandPathFromArgv(argv: string[]): string[] {
-  const args = argv.slice(2);
-  const tokens: string[] = [];
-  for (let i = 0; i < args.length; i += 1) {
-    const arg = args[i];
-    if (!arg || arg === FLAG_TERMINATOR) {
-      break;
-    }
-    const consumed = consumeRootOptionToken(args, i);
-    if (consumed > 0) {
-      i += consumed - 1;
-      continue;
-    }
-    if (arg.startsWith("-")) {
-      continue;
-    }
-    tokens.push(arg);
-    if (tokens.length >= 2) {
-      break;
-    }
-  }
-  return tokens;
-}
-
-const SKIP_EAGER_WARMUP_PRIMARY_COMMANDS = new Set([
-  "agent",
-  "backup",
-  "browser",
-  "completion",
-  "config",
-  "directory",
-  "doctor",
-  "gateway",
-  "health",
-  "hooks",
-  "logs",
-  "memory",
-  "message",
-  "models",
-  "pairing",
-  "plugins",
-  "secrets",
-  "sessions",
-  "status",
-  "update",
-  "webhooks",
-]);
-
-export function shouldEagerWarmContextWindowCache(argv: string[] = process.argv): boolean {
-  // Keep this gate tied to the real OpenClaw CLI entrypoints.
-  //
-  // This module can also land inside shared dist chunks that are imported from
-  // plugin-sdk/library surfaces during smoke tests and plugin loading. If we do
-  // eager warmup for those generic Node script imports, merely importing the
-  // built plugin-sdk can call ensureOpenClawModelsJson(), which cascades into
-  // plugin discovery and breaks dist/source singleton assumptions.
-  if (!isLikelyOpenClawCliProcess(argv)) {
-    return false;
-  }
-  if (isHelpOrVersionInvocation(argv)) {
-    return false;
-  }
-  const [primary] = getCommandPathFromArgv(argv);
-  return Boolean(primary) && !SKIP_EAGER_WARMUP_PRIMARY_COMMANDS.has(primary);
 }
 
 function primeConfiguredContextWindows(): OpenClawConfig | undefined {

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -219,7 +219,7 @@ function primeConfiguredContextWindows(): OpenClawConfig | undefined {
   }
 }
 
-function ensureContextWindowCacheLoaded(): Promise<void> {
+export function ensureContextWindowCacheLoaded(): Promise<void> {
   if (CONTEXT_WINDOW_RUNTIME_STATE.loadPromise) {
     return CONTEXT_WINDOW_RUNTIME_STATE.loadPromise;
   }
@@ -285,12 +285,6 @@ export function lookupContextTokens(
     void ensureContextWindowCacheLoaded();
   }
   return lookupCachedContextTokens(modelId);
-}
-
-if (shouldEagerWarmContextWindowCache()) {
-  // Keep startup warmth for the real CLI, but avoid import-time side effects
-  // when this module is pulled in through library/plugin-sdk surfaces.
-  void ensureContextWindowCacheLoaded();
 }
 
 function resolveProviderModelRef(params: {

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -2391,11 +2391,6 @@ export function loadConfig(options?: { skipPluginValidation?: boolean }): OpenCl
   // First successful load becomes the process snapshot. Long-lived runtimes
   // should swap this snapshot via explicit reload/watcher paths instead of
   // reparsing openclaw.json on hot code paths.
-  //
-  // `skipPluginValidation` lets pure-client callers (e.g. the TUI talking to a
-  // remote gateway) load the config without triggering the plugin metadata
-  // snapshot, which is otherwise pulled in by plugin-aware config validation
-  // and is the dominant cost of cold startup.
   return loadPinnedRuntimeConfig(() =>
     createConfigIO(options?.skipPluginValidation ? { pluginValidation: "skip" } : {}).loadConfig(),
   );

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -2387,15 +2387,22 @@ export function projectConfigOntoRuntimeSourceSnapshot(config: OpenClawConfig): 
   return coerceConfig(applyMergePatch(projectedSource, runtimePatch));
 }
 
-export function loadConfig(): OpenClawConfig {
+export function loadConfig(options?: { skipPluginValidation?: boolean }): OpenClawConfig {
   // First successful load becomes the process snapshot. Long-lived runtimes
   // should swap this snapshot via explicit reload/watcher paths instead of
   // reparsing openclaw.json on hot code paths.
-  return loadPinnedRuntimeConfig(() => createConfigIO().loadConfig());
+  //
+  // `skipPluginValidation` lets pure-client callers (e.g. the TUI talking to a
+  // remote gateway) load the config without triggering the plugin metadata
+  // snapshot, which is otherwise pulled in by plugin-aware config validation
+  // and is the dominant cost of cold startup.
+  return loadPinnedRuntimeConfig(() =>
+    createConfigIO(options?.skipPluginValidation ? { pluginValidation: "skip" } : {}).loadConfig(),
+  );
 }
 
-export function getRuntimeConfig(): OpenClawConfig {
-  return loadConfig();
+export function getRuntimeConfig(options?: { skipPluginValidation?: boolean }): OpenClawConfig {
+  return loadConfig(options);
 }
 
 export async function readBestEffortConfig(): Promise<OpenClawConfig> {

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { agentCommandFromIngress } from "../agents/agent-command.js";
 import { resolveSessionAgentId } from "../agents/agent-scope.js";
+import { ensureContextWindowCacheLoaded } from "../agents/context.js";
 import { DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { buildAllowedModelSet, resolveThinkingDefault } from "../agents/model-selection.js";
 import { createDefaultDeps } from "../cli/deps.js";
@@ -138,6 +139,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
       return;
     }
     setEmbeddedMode(true);
+    void ensureContextWindowCacheLoaded();
     // Suppress console output from logError/logInfo that would pollute the TUI.
     // File logger (getLogger()) still captures everything via logger.ts:35.
     this.previousRuntimeLog = defaultRuntime.log;

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -28,7 +28,6 @@ import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { getSlashCommands } from "./commands.js";
 import { ChatLog } from "./components/chat-log.js";
 import { CustomEditor } from "./components/custom-editor.js";
-import { EmbeddedTuiBackend } from "./embedded-backend.js";
 import { GatewayChatClient } from "./gateway-chat.js";
 import { editorTheme, theme } from "./theme/theme.js";
 import type { TuiBackend } from "./tui-backend.js";
@@ -665,15 +664,19 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
     localBtwRunIds.clear();
   };
 
-  const client: TuiBackend = opts.backend
-    ? opts.backend
-    : opts.local
-      ? new EmbeddedTuiBackend()
-      : await GatewayChatClient.connect({
-          url: opts.url,
-          token: opts.token,
-          password: opts.password,
-        });
+  let client: TuiBackend;
+  if (opts.backend) {
+    client = opts.backend;
+  } else if (opts.local) {
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    client = new EmbeddedTuiBackend();
+  } else {
+    client = await GatewayChatClient.connect({
+      url: opts.url,
+      token: opts.token,
+      password: opts.password,
+    });
+  }
   const previousConsoleSubsystemFilter = isLocalMode
     ? loggingState.consoleSubsystemFilter
       ? [...loggingState.consoleSubsystemFilter]

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -443,7 +443,12 @@ export function resolveTuiCtrlCAction(params: {
 
 export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
   const isLocalMode = opts.local === true || opts.backend !== undefined;
-  const config = opts.config ?? getRuntimeConfig();
+  // Remote-mode TUI is a thin WebSocket client and never resolves plugin
+  // refs locally — skipping plugin-aware validation here removes the synchronous
+  // plugin metadata snapshot load (200k+ file reads) from the event loop.
+  // Embedded (--local) mode still runs the agent runtime in-process, so it
+  // needs the fully validated config.
+  const config = opts.config ?? getRuntimeConfig({ skipPluginValidation: !isLocalMode });
   const initialSessionInput = (opts.session ?? "").trim();
   let sessionScope: SessionScope = (config.session?.scope ?? "per-sender") as SessionScope;
   let sessionMainKey = normalizeMainKey(config.session?.mainKey);

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -443,11 +443,6 @@ export function resolveTuiCtrlCAction(params: {
 
 export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
   const isLocalMode = opts.local === true || opts.backend !== undefined;
-  // Remote-mode TUI is a thin WebSocket client and never resolves plugin
-  // refs locally — skipping plugin-aware validation here removes the synchronous
-  // plugin metadata snapshot load (200k+ file reads) from the event loop.
-  // Embedded (--local) mode still runs the agent runtime in-process, so it
-  // needs the fully validated config.
   const config = opts.config ?? getRuntimeConfig({ skipPluginValidation: !isLocalMode });
   const initialSessionInput = (opts.session ?? "").trim();
   let sessionScope: SessionScope = (config.session?.scope ?? "per-sender") as SessionScope;


### PR DESCRIPTION
Stacked on #84686. Follow-ups from https://github.com/openclaw/openclaw/pull/84686#issuecomment-4502318462.



A further improvement on TUI load speed

BEFORE

<img width="258" height="59" alt="image" src="https://github.com/user-attachments/assets/c1c006c6-e13e-4bb2-9e71-2cc23a69faab" />


AFTER

<img width="1008" height="131" alt="image" src="https://github.com/user-attachments/assets/73ac61bd-0f17-437f-9376-b615d3fc0e40" />

## Changes

**1. Defer `EmbeddedTuiBackend` import (`src/tui/tui.ts`)**
The static import pulled gateway server-side modules (`server-model-catalog`, `session-reset-service`, `sessions-patch`, etc.) into every TUI process at module-eval. Remote-mode TUI never constructs an embedded backend, so the import is now gated behind `opts.local` via `await import()`.

**2. Remove dead helpers (`src/agents/context.ts`, -117 lines)**
`shouldEagerWarmContextWindowCache`, `isLikelyOpenClawCliProcess`, `getCommandPathFromArgv`, `SKIP_EAGER_WARMUP_PRIMARY_COMMANDS` had no production callers after #84686 moved warmup into `EmbeddedTuiBackend.start()`. Deleted them, the corresponding test, and 4 now-unused imports.

## Audited, no change needed

- **`lookupContextTokens` warmup**: every call site is either gateway-server-side (`session-utils.ts`) or passes `allowAsyncLoad: false` (`commands/sessions.ts`, `cron/isolated-agent/run.ts`). Cannot leak into remote TUI.
- **Channel state probes** (`package-state-probes`, `persisted-auth-state`, `configured-state`): only reached via `applyPluginAutoEnable` / `isChannelConfigured`, none of which is called from `runTui()` on the remote path.
- **`materializeRuntimeConfig` defaults with `manifestRegistry: undefined`**: `applyContextPruningDefaults` and `applyModelDefaults` fall through `resolveBundledProviderPolicySurface`, which has a direct bundled-surface fallback; they return config unchanged when no policy applies. Remote TUI's `gateway`/`session`/agent-ID view is untouched.

## Verification

- `pnpm tsgo:core --noEmit` clean
- `pnpm build` clean (no `INEFFECTIVE_DYNAMIC_IMPORT`)
- `node scripts/run-vitest.mjs src/tui/tui.test.ts src/tui/embedded-backend.test.ts src/agents/context.lookup.test.ts src/config/io.meta.test.ts src/config/runtime-snapshot.test.ts` — 100/100 pass
- oxlint + oxfmt clean on changed files

## Real behavior proof

- Behavior addressed: static `EmbeddedTuiBackend` import evaluates gateway server-side modules on remote TUI startup; dead CLI-argv helpers carried over from the pre-deferred warmup design.
- Real environment tested: verified statically that `embedded-backend.js` has no other prod static importer; zero remaining references to deleted helpers across `src`, `scripts`, `test`, `extensions`.
- Exact steps or command run after this patch: `pnpm tsgo:core --noEmit`; `pnpm build`; targeted vitest run above; `node scripts/run-oxlint.mjs src/agents/context.ts src/agents/context.lookup.test.ts src/tui/tui.ts`; `pnpm format:check`.
- Evidence after fix: typecheck clean; build clean; 100 targeted tests pass; lint and format clean.
- Observed result after fix: remote TUI module graph no longer references `embedded-backend.js` or its gateway-side fanout; local TUI behavior unchanged.
- What was not tested: end-to-end manual cold-start timing for `openclaw tui` against a warm gateway; `--local` mode regression check.