### PR TITLE
fix: clarify custom provider HTML responses

### DIFF
--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -1028,7 +1028,7 @@ describe("openai transport stream", () => {
     }
   });
 
-  it("parses JSON chat completions returned to streaming requests", async () => {
+  it("streams OpenAI-compatible non-streaming JSON completions as a fallback", async () => {
     let capturedStreamFlag: unknown;
     const server = createServer((req, res) => {
       let body = "";
@@ -1193,7 +1193,61 @@ describe("openai transport stream", () => {
     }
   });
 
-  it("preserves reasoning tokens without double-counting them", () => {
+  it("adds a base URL hint when OpenAI-compatible streaming returns HTML", async () => {
+    const server = createServer((_req, res) => {
+      res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+      res.end("<html><body>not an API endpoint</body></html>");
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Missing loopback server address");
+      }
+      const model = {
+        id: "deepseek-v4-flash",
+        name: "DeepSeek V4 Flash",
+        api: "openai-completions",
+        provider: "spanagent",
+        baseUrl: `http://127.0.0.1:${address.port}`,
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 128_000,
+        maxTokens: 4096,
+      } satisfies Model<"openai-completions">;
+      const stream = createOpenAICompletionsTransportStreamFn()(
+        model,
+        {
+          systemPrompt: "system",
+          messages: [{ role: "user", content: "Reply ok", timestamp: Date.now() }],
+          tools: [],
+        } as never,
+        { apiKey: "test-key" } as never,
+      );
+
+      let errorMessage = "";
+      for await (const event of stream as AsyncIterable<{
+        type: string;
+        error?: { errorMessage?: string };
+      }>) {
+        if (event.type === "error") {
+          errorMessage = event.error?.errorMessage ?? "";
+        }
+      }
+
+      expect(errorMessage).toContain("returned HTML instead of an API response");
+      expect(errorMessage).toContain("baseUrl includes the provider API path, such as /v1");
+      expect(errorMessage).toContain(`http://127.0.0.1:${address.port}`);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
+  it("does not double-count reasoning tokens and clamps uncached prompt usage at zero", () => {
     const model = {
       id: "gpt-5",
       name: "GPT-5",

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -754,6 +754,30 @@ function summarizeOpenAITransportError(error: unknown): string {
   ].join(" ");
 }
 
+function normalizeOpenAICompatibleErrorMessage(error: unknown, model: Model<Api>): string {
+  const message = error instanceof Error ? error.message : JSON.stringify(error);
+  const cause =
+    error && typeof error === "object" && "cause" in error
+      ? (error as { cause?: unknown }).cause
+      : undefined;
+  const causeMessage =
+    cause instanceof Error ? cause.message : typeof cause === "string" ? cause : "";
+  const normalized = `${message}\n${causeMessage}`.toLowerCase();
+  const pointsAtNonApiHtml =
+    normalized.includes("text/html") ||
+    normalized.includes("unexpected token '<'") ||
+    normalized.includes("provider returned html") ||
+    (normalized.includes("html") && normalized.includes("json"));
+  if (!pointsAtNonApiHtml) {
+    return message;
+  }
+  return (
+    `${message}. The OpenAI-compatible provider returned HTML instead of an API response; ` +
+    `check that baseUrl includes the provider API path, such as /v1. ` +
+    `Configured baseUrl: ${formatModelTransportDebugBaseUrl(model.baseUrl)}`
+  );
+}
+
 function isInvalidEncryptedContentError(error: unknown): boolean {
   if (!error || typeof error !== "object") {
     return false;
@@ -2301,7 +2325,7 @@ function createOpenAICompletionsClient(
     dangerouslyAllowBrowser: true,
     defaultHeaders: clientConfig.defaultHeaders,
     defaultQuery: clientConfig.defaultQuery,
-    fetch: buildGuardedModelFetch(model),
+    fetch: buildGuardedModelFetch(model, undefined, { rejectHtmlAsApiResponse: true }),
     ...buildOpenAISdkClientOptions(model),
   });
 }
@@ -2418,6 +2442,7 @@ export function createOpenAICompletionsTransportStreamFn(): StreamFn {
         stream.end();
       } catch (error) {
         assignTransportErrorDetails(output, error, options?.signal);
+        output.errorMessage = normalizeOpenAICompatibleErrorMessage(error, model);
         stream.push({ type: "error", reason: output.stopReason as never, error: output as never });
         stream.end();
       }

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -495,7 +495,7 @@ function resolveModelTransportSsrFPolicy(params: {
 export function buildGuardedModelFetch(
   model: Model<Api>,
   timeoutMs?: number,
-  options?: { sanitizeSse?: boolean },
+  options?: { sanitizeSse?: boolean; rejectHtmlAsApiResponse?: boolean },
 ): typeof fetch {
   const requestConfig = resolveModelRequestPolicy(model);
   const dispatcherPolicy = buildProviderRequestDispatcherPolicy(requestConfig);
@@ -613,6 +613,16 @@ export function buildGuardedModelFetch(
         statusText: response.statusText,
         headers,
       });
+    }
+    if (
+      options?.rejectHtmlAsApiResponse === true &&
+      response.ok &&
+      /\btext\/html\b/i.test(response.headers.get("content-type") ?? "")
+    ) {
+      await response.body?.cancel().catch(() => undefined);
+      void result.release();
+      localServiceLease?.release();
+      throw new Error("OpenAI-compatible provider returned text/html instead of an API response");
     }
     response = buildManagedResponse(
       response,

--- a/src/commands/onboard-custom.test.ts
+++ b/src/commands/onboard-custom.test.ts
@@ -163,6 +163,35 @@ describe("promptCustomApiConfig", () => {
     expect(prompter.select).toHaveBeenCalledTimes(3);
   });
 
+  it("rejects successful non-json verification responses with a base URL hint", async () => {
+    const prompter = createTestPrompter({
+      text: ["https://spanagent.xyz", "test-key", "bad-model", "good-model", "custom", ""],
+      select: ["plaintext", "openai", "model"],
+    });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => {
+          throw new SyntaxError("Unexpected token '<'");
+        },
+      })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ id: "ok" }) });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await runPromptCustomApi(prompter);
+
+    const stopMessages = prompter.progress.mock.results.flatMap((result) => {
+      const progress = result.value as { stop: ReturnType<typeof vi.fn> };
+      return progress.stop.mock.calls.map(([message]) => message);
+    });
+    expect(stopMessages).toContain(
+      "Verification failed: Verification response was not JSON. Check that the base URL includes the provider API path, for example /v1 for OpenAI-compatible servers.",
+    );
+    expect(prompter.select).toHaveBeenCalledTimes(3);
+  });
+
   it("detects openai compatibility when unknown", async () => {
     const prompter = createTestPrompter({
       text: ["https://example.com/v1", "test-key", "detected-model", "custom", "alias"],

--- a/src/commands/onboard-custom.ts
+++ b/src/commands/onboard-custom.ts
@@ -89,6 +89,24 @@ type VerificationResult = {
   error?: unknown;
 };
 
+const NON_JSON_VERIFICATION_HINT =
+  "Verification response was not JSON. Check that the base URL includes the provider API path, for example /v1 for OpenAI-compatible servers.";
+
+async function validateSuccessfulVerificationResponse(res: Response): Promise<VerificationResult> {
+  if (!res.ok) {
+    return { ok: false, status: res.status };
+  }
+  try {
+    const payload: unknown = await res.json();
+    if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+      return { ok: false, error: new Error(NON_JSON_VERIFICATION_HINT) };
+    }
+  } catch {
+    return { ok: false, error: new Error(NON_JSON_VERIFICATION_HINT) };
+  }
+  return { ok: true, status: res.status };
+}
+
 async function requestVerification(params: {
   endpoint: string;
   headers: Record<string, string>;
@@ -107,7 +125,7 @@ async function requestVerification(params: {
       },
       VERIFY_TIMEOUT_MS,
     );
-    return { ok: res.ok, status: res.status };
+    return await validateSuccessfulVerificationResponse(res);
   } catch (error) {
     return { ok: false, error };
   }


### PR DESCRIPTION
## Summary

- Reject custom-provider verification probes that return successful-looking non-JSON responses, with a `/v1` base URL hint.
- Surface a clearer OpenAI-compatible runtime error when the provider returns HTML instead of an API response.
- Add regression coverage for onboarding verification and OpenAI-compatible streaming HTML responses.

Fixes #84697

## Verification

- `node scripts/run-vitest.mjs src/commands/onboard-custom.test.ts src/commands/onboard-custom-config.test.ts src/agents/openai-transport-stream.test.ts`
- `git diff --check`

## Real behavior proof

Behavior addressed: OpenAI-compatible custom providers that point at a web root can return `text/html`; OpenClaw now rejects that during setup and reports a base URL/API-path hint at runtime instead of falling through to a generic response failure.
Real environment tested: Local checkout with a loopback HTTP server in `src/agents/openai-transport-stream.test.ts` returning `text/html` to the OpenAI-compatible Chat Completions request path.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/commands/onboard-custom.test.ts src/commands/onboard-custom-config.test.ts src/agents/openai-transport-stream.test.ts`
Evidence after fix: The new runtime regression asserts the error includes "returned HTML instead of an API response" and "baseUrl includes the provider API path, such as /v1"; the onboarding regression asserts a successful HTTP response with invalid JSON is rejected with the same base URL guidance.
Observed result after fix: 4 test files passed; 396 tests passed.
What was not tested: Live spanagent.xyz provider traffic; the regression uses a local HTTP server to reproduce the HTML response class safely.
