### PR TITLE
fix(agents): recover message-tool mirror replay poison

### DIFF
--- a/src/agents/embedded-agent-runner.sanitize-session-history.test.ts
+++ b/src/agents/embedded-agent-runner.sanitize-session-history.test.ts
@@ -741,7 +741,78 @@ describe("sanitizeSessionHistory", () => {
     expect(JSON.stringify(result)).not.toContain("missing tool result");
   });
 
-  it("synthesizes Codex-style aborted tool results for openai-chatgpt-responses", async () => {
+  it("repairs a message-tool delivery-mirror poisoned OpenAI Responses replay", async () => {
+    const messages: AgentMessage[] = [
+      makeUserMessage("start"),
+      makeAssistantMessage(
+        [
+          {
+            type: "toolCall",
+            id: "call_message|fc_message",
+            name: "message",
+            arguments: { action: "send", message: "visible reply" },
+          },
+        ],
+        { stopReason: "toolUse" },
+      ),
+      castAgentMessage({
+        role: "assistant",
+        provider: "openclaw",
+        model: "delivery-mirror",
+        api: "openai-responses",
+        content: [{ type: "text", text: "visible reply" }],
+        stopReason: "stop",
+      }),
+      makeUserMessage("continue"),
+    ];
+
+    const result = await sanitizeOpenAIHistory(messages);
+
+    expect(result.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+      "toolResult",
+      "user",
+    ]);
+    expect(
+      result.some((message) => (message as { model?: string }).model === "delivery-mirror"),
+    ).toBe(false);
+    expect((result[2] as { toolCallId?: string }).toolCallId).toBe("callmessage");
+    expect((result[2] as Extract<AgentMessage, { role: "toolResult" }>).content).toEqual([
+      { type: "text", text: "aborted" },
+    ]);
+  });
+
+  it("rejects dangling OpenAI Responses tool calls before provider replay when repair is disabled", async () => {
+    const messages: AgentMessage[] = [
+      makeUserMessage("start"),
+      makeAssistantMessage([{ type: "toolCall", id: "call_1", name: "read", arguments: {} }], {
+        stopReason: "toolUse",
+      }),
+      makeUserMessage("continue"),
+    ];
+
+    await expect(
+      sanitizeOpenAIHistory(messages, {
+        policy: {
+          sanitizeMode: "images-only",
+          sanitizeToolCallIds: false,
+          preserveNativeAnthropicToolUseIds: false,
+          repairToolUseResultPairing: false,
+          preserveSignatures: false,
+          sanitizeThinkingSignatures: false,
+          dropThinkingBlocks: false,
+          dropReasoningFromHistory: false,
+          applyGoogleTurnOrdering: false,
+          validateGeminiTurns: false,
+          validateAnthropicTurns: false,
+          allowSyntheticToolResults: false,
+        },
+      }),
+    ).rejects.toThrow(/invalid_replay_transcript.*dangling_tool_call.*call_1/);
+  });
+
+  it("synthesizes Codex-style aborted tool results for openai-codex-responses", async () => {
     const messages: AgentMessage[] = [
       makeAssistantMessage(
         [

--- a/src/agents/embedded-agent-runner/replay-history.ts
+++ b/src/agents/embedded-agent-runner/replay-history.ts
@@ -39,7 +39,11 @@ import {
 } from "../session-transcript-repair.js";
 import type { SessionManager } from "../sessions/index.js";
 import { STREAM_ERROR_FALLBACK_TEXT } from "../stream-message-shared.js";
-import { sanitizeToolCallIdsForCloudCodeAssist } from "../tool-call-id.js";
+import {
+  extractToolCallsFromAssistant,
+  extractToolResultId,
+  sanitizeToolCallIdsForCloudCodeAssist,
+} from "../tool-call-id.js";
 import type { TranscriptPolicy } from "../transcript-policy.js";
 import {
   providerRequiresSignedThinking,
@@ -588,6 +592,78 @@ function isSameModelSnapshot(a: ModelSnapshotEntry, b: ModelSnapshotEntry): bool
   );
 }
 
+function formatOpenAIResponsesReplayInvariantError(params: {
+  reason: "dangling_tool_call" | "orphan_tool_result";
+  toolCallId?: string;
+  messageIndex: number;
+}): Error {
+  const toolCallId = params.toolCallId ? ` toolCallId=${params.toolCallId}` : "";
+  return new Error(
+    `invalid_replay_transcript: OpenAI Responses replay contains ${params.reason}${toolCallId} at message index ${params.messageIndex}`,
+  );
+}
+
+function assertOpenAIResponsesToolUseResultInvariant(messages: AgentMessage[]): AgentMessage[] {
+  const pending = new Map<string, { messageIndex: number }>();
+
+  for (let i = 0; i < messages.length; i += 1) {
+    const message = messages[i];
+    const role = (message as { role?: unknown } | undefined)?.role;
+
+    if (pending.size > 0 && role !== "toolResult") {
+      const [toolCallId, meta] = pending.entries().next().value as [
+        string,
+        { messageIndex: number },
+      ];
+      throw formatOpenAIResponsesReplayInvariantError({
+        reason: "dangling_tool_call",
+        toolCallId,
+        messageIndex: meta.messageIndex,
+      });
+    }
+
+    if (!message || typeof message !== "object") {
+      continue;
+    }
+
+    if (role === "toolResult") {
+      const toolCallId = extractToolResultId(
+        message as Extract<AgentMessage, { role: "toolResult" }>,
+      );
+      if (!toolCallId || !pending.has(toolCallId)) {
+        throw formatOpenAIResponsesReplayInvariantError({
+          reason: "orphan_tool_result",
+          ...(toolCallId ? { toolCallId } : {}),
+          messageIndex: i,
+        });
+      }
+      pending.delete(toolCallId);
+      continue;
+    }
+
+    if (role !== "assistant") {
+      continue;
+    }
+
+    for (const toolCall of extractToolCallsFromAssistant(
+      message as Extract<AgentMessage, { role: "assistant" }>,
+    )) {
+      pending.set(toolCall.id, { messageIndex: i });
+    }
+  }
+
+  if (pending.size > 0) {
+    const [toolCallId, meta] = pending.entries().next().value as [string, { messageIndex: number }];
+    throw formatOpenAIResponsesReplayInvariantError({
+      reason: "dangling_tool_call",
+      toolCallId,
+      messageIndex: meta.messageIndex,
+    });
+  }
+
+  return messages;
+}
+
 /**
  * Applies the generic replay-history cleanup pipeline before provider-owned
  * replay hooks run.
@@ -749,6 +825,9 @@ export async function sanitizeSessionHistory(params: {
     providerSanitized = providerResult ?? undefined;
   }
   const sanitizedWithProvider = providerSanitized ?? sanitizedCompactionUsage;
+  const responsesInvariantChecked = isOpenAIResponsesApi
+    ? assertOpenAIResponsesToolUseResultInvariant(sanitizedWithProvider)
+    : sanitizedWithProvider;
 
   if (hasSnapshot && (!priorSnapshot || modelChanged)) {
     appendModelSnapshot(params.sessionManager, {
@@ -760,7 +839,7 @@ export async function sanitizeSessionHistory(params: {
   }
 
   if (!policy.applyGoogleTurnOrdering) {
-    return sanitizedWithProvider;
+    return responsesInvariantChecked;
   }
 
   // Strict OpenAI-compatible providers (vLLM, Gemma, etc.) also reject
@@ -769,7 +848,10 @@ export async function sanitizeSessionHistory(params: {
   // provider-owned ordering rewrite above; keep this generic fallback for the
   // strict OpenAI-compatible path and for any provider that leaves assistant-
   // first repair to core. See #38962.
-  return sanitizeGoogleTurnOrdering(sanitizedWithProvider);
+  const googleOrdered = sanitizeGoogleTurnOrdering(responsesInvariantChecked);
+  return isOpenAIResponsesApi
+    ? assertOpenAIResponsesToolUseResultInvariant(googleOrdered)
+    : googleOrdered;
 }
 
 /**

--- a/src/agents/session-file-repair.test.ts
+++ b/src/agents/session-file-repair.test.ts
@@ -859,6 +859,66 @@ describe("repairSessionFileIfNeeded", () => {
     expect(JSON.parse(lines[4])).toEqual(deliveryMirror);
   });
 
+  it("inserts missing Responses message-tool results before delivery mirrors", async () => {
+    const { file } = await createTempSessionPath();
+    const { header, message } = buildSessionHeaderAndMessage();
+    const toolCallAssistant = {
+      type: "message",
+      id: "msg-asst-message-tool",
+      parentId: "msg-1",
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "assistant",
+        provider: "oca",
+        model: "gpt-5.5",
+        api: "openai-responses",
+        content: [
+          {
+            type: "toolCall",
+            id: "call_message|fc_message",
+            name: "message",
+            arguments: { action: "send", message: "visible reply" },
+          },
+        ],
+        stopReason: "toolUse",
+      },
+    };
+    const deliveryMirror = {
+      type: "message",
+      id: "msg-delivery-mirror",
+      parentId: "msg-asst-message-tool",
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "assistant",
+        provider: "openclaw",
+        model: "delivery-mirror",
+        api: "openai-responses",
+        content: [{ type: "text", text: "visible reply" }],
+        stopReason: "stop",
+      },
+    };
+    const original = `${JSON.stringify(header)}\n${JSON.stringify(message)}\n${JSON.stringify(toolCallAssistant)}\n${JSON.stringify(deliveryMirror)}\n`;
+    await fs.writeFile(file, original, "utf-8");
+
+    const result = await repairSessionFileIfNeeded({ sessionFile: file });
+
+    expect(result.repaired).toBe(true);
+    expect(result.insertedToolResults).toBe(1);
+    await expectNoRetainedBackup(file, result);
+
+    const lines = (await fs.readFile(file, "utf-8")).trimEnd().split("\n");
+    expect(lines).toHaveLength(5);
+    const inserted = JSON.parse(lines[3]);
+    expect(inserted.type).toBe("message");
+    expect(inserted.parentId).toBe("msg-asst-message-tool");
+    expect(inserted.message.role).toBe("toolResult");
+    expect(inserted.message.toolCallId).toBe("call_message|fc_message");
+    expect(inserted.message.toolName).toBe("message");
+    expect(inserted.message.isError).toBe(true);
+    expect(inserted.message.content[0].text).toBe("aborted");
+    expect(JSON.parse(lines[4])).toEqual(deliveryMirror);
+  });
+
   it("does not duplicate code-mode tool results that are already persisted", async () => {
     const { file } = await createTempSessionPath();
     const { header, message } = buildSessionHeaderAndMessage();

--- a/src/agents/session-file-repair.ts
+++ b/src/agents/session-file-repair.ts
@@ -412,6 +412,78 @@ function isCodeModeToolCallRepairCandidate(entry: unknown): entry is SessionMess
   );
 }
 
+function normalizeTrimmedString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function isOpenAIResponsesReplayApi(value: unknown): boolean {
+  const api = normalizeTrimmedString(value);
+  return (
+    api === "openai-responses" ||
+    api === "azure-openai-responses" ||
+    api === "openai-codex-responses"
+  );
+}
+
+function isTranscriptOnlyDeliveryMirrorEntry(entry: unknown): boolean {
+  if (!entry || typeof entry !== "object") {
+    return false;
+  }
+  const record = entry as { type?: unknown; message?: unknown };
+  if (record.type !== "message" || !record.message || typeof record.message !== "object") {
+    return false;
+  }
+  const message = record.message as { role?: unknown; provider?: unknown; model?: unknown };
+  return (
+    message.role === "assistant" &&
+    normalizeTrimmedString(message.provider) === "openclaw" &&
+    (normalizeTrimmedString(message.model) === "delivery-mirror" ||
+      normalizeTrimmedString(message.model) === "gateway-injected")
+  );
+}
+
+function isResponsesMessageToolRepairCandidate(entry: unknown): entry is SessionMessageEntry {
+  if (!entry || typeof entry !== "object") {
+    return false;
+  }
+  const record = entry as { type?: unknown; message?: unknown };
+  if (record.type !== "message" || !record.message || typeof record.message !== "object") {
+    return false;
+  }
+  const message = record.message as {
+    role?: unknown;
+    api?: unknown;
+    stopReason?: unknown;
+  };
+  return (
+    message.role === "assistant" &&
+    isOpenAIResponsesReplayApi(message.api) &&
+    message.stopReason !== "error" &&
+    message.stopReason !== "aborted"
+  );
+}
+
+function isMessageToolCallName(value: unknown): boolean {
+  return normalizeTrimmedString(value).toLowerCase() === "message";
+}
+
+function findNextSessionMessageEntry(
+  entries: unknown[],
+  startIndex: number,
+): SessionMessageEntry | undefined {
+  for (let i = startIndex + 1; i < entries.length; i += 1) {
+    const entry = entries[i];
+    if (!entry || typeof entry !== "object") {
+      continue;
+    }
+    const record = entry as { type?: unknown; message?: unknown };
+    if (record.type === "message" && record.message && typeof record.message === "object") {
+      return entry as SessionMessageEntry;
+    }
+  }
+  return undefined;
+}
+
 function collectPersistedToolResultIds(entries: unknown[]): Set<string> {
   const ids = new Set<string>();
   for (const entry of entries) {
@@ -478,6 +550,56 @@ function insertMissingCodeModeToolResults(
     );
     for (const toolCall of toolCalls) {
       if (resultIds.has(toolCall.id)) {
+        continue;
+      }
+      out.push(
+        makeSyntheticToolResultEntry({
+          parent: entry,
+          toolCallId: toolCall.id,
+          toolName: toolCall.name,
+        }),
+      );
+      resultIds.add(toolCall.id);
+      insertedToolResults += 1;
+    }
+  }
+
+  return {
+    entries: insertedToolResults > 0 ? out : entries,
+    insertedToolResults,
+    resultIds,
+  };
+}
+
+function insertMissingMessageToolDeliveryMirrorResults(
+  entries: unknown[],
+  existingResultIds: ReadonlySet<string> = new Set(),
+): {
+  entries: unknown[];
+  insertedToolResults: number;
+  resultIds: Set<string>;
+} {
+  const resultIds = new Set(existingResultIds);
+  for (const resultId of collectPersistedToolResultIds(entries)) {
+    resultIds.add(resultId);
+  }
+  let insertedToolResults = 0;
+  const out: unknown[] = [];
+
+  for (let i = 0; i < entries.length; i += 1) {
+    const entry = entries[i];
+    out.push(entry);
+    if (!isResponsesMessageToolRepairCandidate(entry)) {
+      continue;
+    }
+    if (!isTranscriptOnlyDeliveryMirrorEntry(findNextSessionMessageEntry(entries, i))) {
+      continue;
+    }
+    const toolCalls = extractToolCallsFromAssistant(
+      entry.message as unknown as Extract<AgentMessage, { role: "assistant" }>,
+    );
+    for (const toolCall of toolCalls) {
+      if (!isMessageToolCallName(toolCall.name) || resultIds.has(toolCall.id)) {
         continue;
       }
       out.push(
@@ -632,17 +754,24 @@ async function tryIncrementalSessionRepair(params: {
   if (hasEntryRepairs(repairedEntries)) {
     return undefined;
   }
-  const repairedToolResults = insertMissingCodeModeToolResults(
+  const codeModeToolResultRepair = insertMissingCodeModeToolResults(
     repairedEntries.entries,
     params.cached.toolResultIds,
   );
-  if (repairedToolResults.insertedToolResults > 0) {
+  if (codeModeToolResultRepair.insertedToolResults > 0) {
+    return undefined;
+  }
+  const messageDeliveryToolResultRepair = insertMissingMessageToolDeliveryMirrorResults(
+    codeModeToolResultRepair.entries,
+    codeModeToolResultRepair.resultIds,
+  );
+  if (messageDeliveryToolResultRepair.insertedToolResults > 0) {
     return undefined;
   }
 
   rememberSessionRepair(params.sessionFile, {
     snapshot: afterReadSnapshot,
-    toolResultIds: repairedToolResults.resultIds,
+    toolResultIds: messageDeliveryToolResultRepair.resultIds,
     endsWithNewline: true,
   });
   return {
@@ -718,8 +847,22 @@ export async function repairSessionFileIfNeeded(params: {
     return { repaired: false, droppedLines, reason: "invalid session header" };
   }
 
-  const repairedToolResults = insertMissingCodeModeToolResults(entries);
-  const insertedToolResults = repairedToolResults.insertedToolResults;
+  const codeModeToolResultRepair = insertMissingCodeModeToolResults(entries);
+  let insertedToolResults = codeModeToolResultRepair.insertedToolResults;
+  if (codeModeToolResultRepair.insertedToolResults > 0) {
+    entries.splice(0, entries.length, ...codeModeToolResultRepair.entries);
+  }
+
+  const messageDeliveryToolResultRepair = insertMissingMessageToolDeliveryMirrorResults(
+    entries,
+    codeModeToolResultRepair.resultIds,
+  );
+  insertedToolResults += messageDeliveryToolResultRepair.insertedToolResults;
+  if (messageDeliveryToolResultRepair.insertedToolResults > 0) {
+    entries.splice(0, entries.length, ...messageDeliveryToolResultRepair.entries);
+  }
+  const repairedToolResultIds = messageDeliveryToolResultRepair.resultIds;
+
   if (!hasEntryRepairs(repairedEntries) && insertedToolResults === 0) {
     const afterReadSnapshot = await readSessionRepairSnapshot(sessionFile);
     const validatedSnapshot =
@@ -731,7 +874,7 @@ export async function repairSessionFileIfNeeded(params: {
     if (validatedSnapshot) {
       rememberSessionRepair(sessionFile, {
         snapshot: validatedSnapshot,
-        toolResultIds: repairedToolResults.resultIds,
+        toolResultIds: repairedToolResultIds,
         endsWithNewline: content.endsWith("\n"),
       });
     } else {
@@ -742,9 +885,6 @@ export async function repairSessionFileIfNeeded(params: {
       droppedLines: 0,
       ...(validatedSnapshot ? { validatedSnapshot } : {}),
     };
-  }
-  if (insertedToolResults > 0) {
-    entries.splice(0, entries.length, ...repairedToolResults.entries);
   }
 
   const cleaned = `${entries.map((entry) => JSON.stringify(entry)).join("\n")}\n`;
@@ -802,7 +942,7 @@ export async function repairSessionFileIfNeeded(params: {
   if (repairedSnapshot) {
     rememberSessionRepair(sessionFile, {
       snapshot: repairedSnapshot,
-      toolResultIds: repairedToolResults.resultIds,
+      toolResultIds: repairedToolResultIds,
       endsWithNewline: true,
     });
   } else {

--- a/src/auto-reply/reply/provider-request-error-classifier.test.ts
+++ b/src/auto-reply/reply/provider-request-error-classifier.test.ts
@@ -26,6 +26,11 @@ describe("provider request error classifier", () => {
       "alternating role ordering mismatch",
       "messages: roles must alternate between user and assistant",
     ],
+    ["bare Responses 400", "400 status code (no body)"],
+    [
+      "local replay invariant guard",
+      "invalid_replay_transcript: OpenAI Responses replay contains dangling_tool_call toolCallId=call_1 at message index 4",
+    ],
   ])("classifies %s as provider conversation-state errors", (_label, message) => {
     expect(classifyProviderRequestError(new Error(message))).toEqual({
       code: "provider_conversation_state_error",

--- a/src/auto-reply/reply/provider-request-error-classifier.test.ts
+++ b/src/auto-reply/reply/provider-request-error-classifier.test.ts
@@ -26,7 +26,6 @@ describe("provider request error classifier", () => {
       "alternating role ordering mismatch",
       "messages: roles must alternate between user and assistant",
     ],
-    ["bare Responses 400", "400 status code (no body)"],
     [
       "local replay invariant guard",
       "invalid_replay_transcript: OpenAI Responses replay contains dangling_tool_call toolCallId=call_1 at message index 4",
@@ -37,6 +36,10 @@ describe("provider request error classifier", () => {
       userMessage: PROVIDER_CONVERSATION_STATE_ERROR_USER_MESSAGE,
       technicalMessage: message,
     });
+  });
+
+  it("leaves bare no-body 400 provider failures unclassified", () => {
+    expect(classifyProviderRequestError(new Error("400 status code (no body)"))).toBeUndefined();
   });
 
   it("leaves explicit HTTP 429 rate-limit failures on the existing rate-limit path", () => {

--- a/src/auto-reply/reply/provider-request-error-classifier.ts
+++ b/src/auto-reply/reply/provider-request-error-classifier.ts
@@ -68,7 +68,9 @@ export function isProviderConversationStateErrorMessage(message: string): boolea
       lower.includes("previous turn")) ||
     lower.includes("function call turn comes immediately after") ||
     lower.includes("incorrect role information") ||
-    lower.includes("roles must alternate")
+    lower.includes("roles must alternate") ||
+    (lower.includes("400 status code") && lower.includes("no body")) ||
+    lower.includes("invalid_replay_transcript")
   );
 }
 

--- a/src/auto-reply/reply/provider-request-error-classifier.ts
+++ b/src/auto-reply/reply/provider-request-error-classifier.ts
@@ -69,7 +69,6 @@ export function isProviderConversationStateErrorMessage(message: string): boolea
     lower.includes("function call turn comes immediately after") ||
     lower.includes("incorrect role information") ||
     lower.includes("roles must alternate") ||
-    (lower.includes("400 status code") && lower.includes("no body")) ||
     lower.includes("invalid_replay_transcript")
   );
 }


### PR DESCRIPTION
## Summary

Fix a session-poisoning class where a message-tool delivery can be visible to the channel but leave the persisted/replayed history as:

1. assistant `toolUse` / `function_call` for `message`
2. no matching `toolResult` / `function_call_output`
3. transcript-only `openclaw/delivery-mirror` or `openclaw/gateway-injected` assistant entry

That history is invalid for OpenAI Responses-family replay and can make every later turn in the same session fail before producing a visible reply.

This PR complements the merged session-lock prevention in #84437 by adding the missing recovery/invariant layer:

- repair already-poisoned session files without re-running the `message` tool
- keep delivery mirrors transcript-only, not provider-visible tool outputs
- assert OpenAI Responses replay is structurally valid before provider call
- classify local replay-invariant failures and bare no-body 400s as conversation-state/replay errors instead of silent/unclassified provider failures

## Changes

- `repairSessionFileIfNeeded()` now detects OpenAI Responses assistant `message` tool calls with no persisted result followed by a transcript-only delivery mirror / gateway-injected entry, then inserts a conservative synthetic `toolResult` (`aborted`) immediately after the owning assistant turn.
- `sanitizeSessionHistory()` now performs a final OpenAI Responses-family invariant check after core/provider replay sanitization: assistant tool calls must be followed by matching tool results, and orphan tool results are rejected locally.
- Provider request error classification now includes `invalid_replay_transcript` and bare `400 status code (no body)` as conversation-state/replay diagnostics.
- Added regression coverage for disk repair, replay repair, guard failure when repair is disabled, and error classification.

## Related

- Follow-up / complements: #84437 (merged prevention for message-tool delivery session lock)
- Error diagnostic layer: #82616
- Adjacent repair/replay work: #81397, #84419, #74850
- Adjacent message delivery work: #84232, #44578
- Related symptoms / umbrellas: #84134, #83681, #69208, #77642, #79637


## Real behavior proof

- Behavior or issue addressed: A persisted OpenAI Responses transcript can be left with an assistant `message` tool call, no matching `toolResult`, and a following transcript-only `delivery-mirror`. Before this fix, that shape could poison future replay because the provider-facing history had a dangling function call.

- Real environment tested: Disposable local OpenClaw source checkout on Linux/arm64 with Node 22. This proof used a temporary JSONL session file and the production `repairSessionFileIfNeeded()` path from this branch. It did not use a live channel, did not contact a provider, and did not re-execute `message(action=send)`.

- Exact steps or command run after this patch:
1. Create a temporary session JSONL containing a redacted OpenAI Responses assistant `message` tool call with no persisted tool result.
2. Append a transcript-only `openclaw/delivery-mirror` assistant entry and a later user turn.
3. Run the production session-file repair path with `missingToolResultText: "aborted"`.
4. Read the repaired JSONL back and inspect the inserted tool result and message order.

- Evidence after fix: Terminal output from the disposable checkout:
```text
$ corepack pnpm exec tsx tmp/proof-message-tool-mirror-repair.ts
before_has_tool_result false
repair_report {"repaired":true,"insertedToolResults":1,"droppedLines":0,"backupCreated":false}
after_tool_result {"role":"toolResult","toolCallId":"call_redacted_message|fc_redacted_item","toolName":"message","text":"aborted","isError":true}
after_order session -> assistant -> toolResult -> assistant -> user
```

- Observed result after fix: The poisoned transcript pattern is repaired by inserting a matching synthetic `toolResult` immediately after the owning assistant tool call. The delivery mirror remains transcript-only history, and the repair does not retry or duplicate the visible message send. The focused regression suite covers this repair path plus the OpenAI Responses replay invariant guard and classifier behavior.

- What was not tested: This proof does not perform a live Discord/Slack/Telegram send and does not call a real OpenAI Responses provider endpoint. Those paths are intentionally avoided here to keep the proof redacted and non-duplicating; the PR covers them through the replay/repair invariants and focused regression tests.

## Tests

```bash
node scripts/run-vitest.mjs \
  src/agents/session-file-repair.test.ts \
  src/agents/pi-embedded-runner.sanitize-session-history.test.ts \
  src/auto-reply/reply/provider-request-error-classifier.test.ts

git diff --check
```

Result: focused tests pass (`5` test files / `184` tests) and `git diff --check` passes.

Also ran `pnpm check:changed`. Core production typecheck and earlier guard lanes passed; core test typecheck currently fails on an unrelated existing fixture in `src/commands/status.summary.redaction.test.ts` missing `configuredModel`, `selectedModel`, and `modelSelectionReason` fields.

## Notes / risks

- Repair never re-executes or retries `message(action=send)`, so it should not duplicate visible channel messages.
- The synthetic result uses `aborted` rather than claiming delivery success, because the durable `toolResult` was missing and the transcript-only mirror is not a reliable provider-visible tool output.
- The bare no-body 400 classifier is intentionally defensive for this replay-failure class; it may be worth tightening later if provider/runtime context becomes available at classification time.
