### PR TITLE
fix(cron): fail closed when required tools are unavailable

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -505,6 +505,21 @@ function createRuntimeDynamicTool(name: string): RuntimeDynamicToolForTest {
   };
 }
 
+function createNodeRoutableExecDynamicTool(): RuntimeDynamicToolForTest {
+  const tool = createRuntimeDynamicTool("exec");
+  tool.parameters = {
+    type: "object",
+    properties: {
+      command: { type: "string" },
+      host: { enum: ["auto", "sandbox", "gateway", "node"] },
+      node: { type: "string" },
+    },
+    required: ["command"],
+    additionalProperties: false,
+  };
+  return tool;
+}
+
 function createPluginAppConfigPatch() {
   return {
     apps: {
@@ -761,6 +776,101 @@ describe("runCodexAppServerAttempt", () => {
     expect(tools.find((tool) => tool.name === "sandbox_process")?.description).toContain(
       "sandbox_exec sessions",
     );
+  });
+
+  it("preserves explicitly required dynamic exec while duplicate dynamic read stays excluded", async () => {
+    testing.setOpenClawCodingToolsFactoryForTests(() => [
+      createRuntimeDynamicTool("read"),
+      createNodeRoutableExecDynamicTool(),
+      createRuntimeDynamicTool("message"),
+    ]);
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(sessionFile, workspaceDir);
+    params.disableTools = false;
+    params.runtimePlan = createCodexRuntimePlanFixture();
+    params.toolsAllow = ["exec", "read"];
+
+    const tools = await testing.buildDynamicTools({
+      params,
+      resolvedWorkspace: workspaceDir,
+      effectiveWorkspace: workspaceDir,
+      sandboxSessionKey: params.sessionKey!,
+      sandbox: null as never,
+      nativeToolSurfaceEnabled: true,
+      runAbortController: new AbortController(),
+      sessionAgentId: "main",
+      pluginConfig: { codexDynamicToolsExclude: ["read"] },
+      onYieldDetected: () => undefined,
+    });
+
+    expect(tools.map((tool) => tool.name)).toEqual(["exec"]);
+  });
+
+  it("fails closed when required cron exec/read tools are absent before model dispatch", () => {
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
+    params.trigger = "cron";
+    params.jobId = "cron-job-1";
+    params.bootstrapContextRunKind = "cron";
+    params.toolsAllow = ["exec", "read"];
+
+    let thrown: unknown;
+    try {
+      testing.assertCodexAppServerRequiredToolSurface({
+        tools: [],
+        toolsAllow: params.toolsAllow,
+        nativeToolSurfaceEnabled: false,
+        params,
+      });
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toContain("TOOL_SURFACE_UNAVAILABLE");
+    expect((thrown as Error).message).toContain("jobId=cron-job-1");
+    expect((thrown as Error).message).toContain("trigger=cron");
+    expect((thrown as Error).message).toContain("bootstrapContextRunKind=cron");
+    expect((thrown as Error).message).toContain("execNodeRoutingSchemaAvailable=false");
+    expect((thrown as { diagnostic?: { route?: unknown } }).diagnostic?.route).toEqual({
+      trigger: "cron",
+      bootstrapContextRunKind: "cron",
+      execNodeRoutingSchemaAvailable: false,
+      nativeReadAvailable: false,
+    });
+  });
+
+  it("keeps non-cron finite toolsAllow as a filter instead of a required tool contract", () => {
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
+    params.toolsAllow = ["exec", "read"];
+
+    expect(() =>
+      testing.assertCodexAppServerRequiredToolSurface({
+        tools: [],
+        toolsAllow: params.toolsAllow,
+        nativeToolSurfaceEnabled: false,
+        params,
+      }),
+    ).not.toThrow();
+  });
+
+  it("accepts dynamic exec with node-routing schema and native read surface", () => {
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
+    params.trigger = "cron";
+    params.jobId = "cron-job-1";
+    params.toolsAllow = ["exec", "read"];
+
+    expect(() =>
+      testing.assertCodexAppServerRequiredToolSurface({
+        tools: [createNodeRoutableExecDynamicTool()],
+        toolsAllow: params.toolsAllow,
+        nativeToolSurfaceEnabled: true,
+        params,
+      }),
+    ).not.toThrow();
   });
 
   it("keeps Docker sandbox shell tools hidden when native Code Mode can honor sandbox paths", async () => {
@@ -1326,7 +1436,7 @@ describe("runCodexAppServerAttempt", () => {
     expect(testing.filterCodexDynamicToolsForAllowlist(tools, [" * "])).toEqual(tools);
   });
 
-  it("disables Codex native tool surfaces for restricted runtime allowlists", () => {
+  it("enables Codex native tool surfaces for finite allowlists that require exec", () => {
     const workspaceDir = path.join(tempDir, "workspace");
     const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
     params.disableTools = false;
@@ -1337,6 +1447,12 @@ describe("runCodexAppServerAttempt", () => {
     expect(testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(true);
 
     params.toolsAllow = [];
+    expect(testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
+
+    params.toolsAllow = ["exec", "read"];
+    expect(testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(true);
+
+    params.toolsAllow = ["read"];
     expect(testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
 
     params.toolsAllow = ["message"];

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -943,6 +943,12 @@ export async function runCodexAppServerAttempt(
       yieldDetected = true;
     },
   });
+  assertCodexAppServerRequiredToolSurface({
+    tools,
+    toolsAllow: params.toolsAllow,
+    nativeToolSurfaceEnabled,
+    params,
+  });
   const toolBridge = createCodexDynamicToolBridge({
     tools,
     signal: runAbortController.signal,
@@ -3394,16 +3400,24 @@ async function buildDynamicTools(input: DynamicToolBuildParams) {
       input.runAbortController.abort("sessions_yield");
     },
   });
-  const codexFilteredTools = addSandboxShellDynamicToolsIfAvailable(
-    filterCodexDynamicTools(allTools, input.pluginConfig),
+  const toolsAllow = includeForcedMessageToolAllow(params.toolsAllow, params);
+  const codexFilteredTools = addExplicitlyAllowedCodexDynamicTools(
+    addSandboxShellDynamicToolsIfAvailable(
+      filterCodexDynamicTools(allTools, input.pluginConfig),
+      allTools,
+      input,
+    ),
     allTools,
-    input,
+    {
+      pluginConfig: input.pluginConfig,
+      toolsAllow,
+      nativeToolSurfaceEnabled: input.nativeToolSurfaceEnabled === true,
+    },
   );
   const visionFilteredTools = filterToolsForVisionInputs(codexFilteredTools, {
     modelHasVision,
     hasInboundImages: (params.images?.length ?? 0) > 0,
   });
-  const toolsAllow = includeForcedMessageToolAllow(params.toolsAllow, params);
   const filteredTools = filterCodexDynamicToolsForAllowlist(visionFilteredTools, toolsAllow);
   return normalizeAgentRuntimeTools({
     runtimePlan: params.runtimePlan,
@@ -3444,11 +3458,11 @@ function shouldEnableCodexAppServerNativeToolSurface(
   if (toolsAllow === undefined) {
     return canCodexAppServerNativeToolSurfaceHonorSandbox(sandbox);
   }
-  // Codex native code mode exposes its shell/file surface as one app-server
-  // capability, so narrow OpenClaw allowlists must fail closed rather than
-  // widening `message` or `web_search` into shell access.
+  if (hasWildcardCodexToolsAllow(toolsAllow)) {
+    return canCodexAppServerNativeToolSurfaceHonorSandbox(sandbox);
+  }
   return (
-    hasWildcardCodexToolsAllow(toolsAllow) &&
+    allowlistRequiresCodexNativeToolSurface(toolsAllow) &&
     canCodexAppServerNativeToolSurfaceHonorSandbox(sandbox)
   );
 }
@@ -3523,6 +3537,218 @@ function addSandboxShellDynamicToolsIfAvailable(
       "Manage sandbox_exec sessions that were started through OpenClaw's configured sandbox backend for this session: list, poll, log, write, send-keys, submit, paste, kill, clear, or remove. Use only for sandbox_exec follow-up; use Codex's native shell session handling for normal native shell commands.",
   };
   return [...filteredTools, sandboxExecTool, sandboxProcessTool];
+}
+
+function addExplicitlyAllowedCodexDynamicTools(
+  filteredTools: OpenClawDynamicTool[],
+  allTools: OpenClawDynamicTool[],
+  params: {
+    pluginConfig: CodexPluginConfig;
+    toolsAllow?: string[];
+    nativeToolSurfaceEnabled: boolean;
+  },
+): OpenClawDynamicTool[] {
+  if (
+    !params.toolsAllow ||
+    params.toolsAllow.length === 0 ||
+    hasWildcardCodexToolsAllow(params.toolsAllow)
+  ) {
+    return filteredTools;
+  }
+  const existingNames = new Set(
+    filteredTools.map((tool) => normalizeCodexDynamicToolName(tool.name)),
+  );
+  const additions = allTools.filter((tool) => {
+    const normalized = normalizeCodexDynamicToolName(tool.name);
+    return (
+      !existingNames.has(normalized) &&
+      shouldPreserveCodexDynamicToolForAllowlist(normalized, params)
+    );
+  });
+  return additions.length > 0 ? [...filteredTools, ...additions] : filteredTools;
+}
+
+function shouldPreserveCodexDynamicToolForAllowlist(
+  normalizedToolName: string,
+  params: {
+    pluginConfig: CodexPluginConfig;
+    toolsAllow?: string[];
+    nativeToolSurfaceEnabled: boolean;
+  },
+): boolean {
+  if (isExplicitlyExcludedCodexDynamicTool(params.pluginConfig, normalizedToolName)) {
+    return false;
+  }
+  const allowSet = new Set(
+    (params.toolsAllow ?? []).map((name) => normalizeCodexDynamicToolName(name)).filter(Boolean),
+  );
+  if (normalizedToolName === "exec" || normalizedToolName === "process") {
+    return allowSet.has(normalizedToolName);
+  }
+  return !params.nativeToolSurfaceEnabled && allowSet.has(normalizedToolName);
+}
+
+function isExplicitlyExcludedCodexDynamicTool(
+  pluginConfig: CodexPluginConfig,
+  normalizedToolName: string,
+): boolean {
+  return (pluginConfig.codexDynamicToolsExclude ?? []).some(
+    (name) => normalizeCodexDynamicToolName(name) === normalizedToolName,
+  );
+}
+
+function allowlistRequiresCodexNativeToolSurface(toolsAllow: string[]): boolean {
+  return toolsAllow.some((name) => {
+    const normalized = normalizeCodexDynamicToolName(name);
+    return normalized === "exec" || normalized === "process";
+  });
+}
+
+type CodexRequiredToolSurfaceDiagnostic = {
+  code: "TOOL_SURFACE_UNAVAILABLE";
+  jobId?: string;
+  sessionKey?: string;
+  provider?: string;
+  model?: string;
+  required: string[];
+  available: string[];
+  missing: string[];
+  nativeToolSurfaceEnabled: boolean;
+  route: {
+    trigger?: string;
+    bootstrapContextRunKind?: string;
+    execNodeRoutingSchemaAvailable: boolean;
+    nativeReadAvailable: boolean;
+  };
+};
+
+function assertCodexAppServerRequiredToolSurface(params: {
+  tools: OpenClawDynamicTool[];
+  toolsAllow?: string[];
+  nativeToolSurfaceEnabled: boolean;
+  params: EmbeddedRunAttemptParams;
+}): void {
+  if (!shouldRequireCodexAppServerToolSurface(params.params)) {
+    return;
+  }
+  const required = normalizeRequiredCodexToolNames(
+    includeForcedMessageToolAllow(params.toolsAllow, params.params),
+  );
+  if (required.length === 0) {
+    return;
+  }
+  const available = params.tools.map((tool) => normalizeCodexDynamicToolName(tool.name));
+  const execNodeRoutingSchemaAvailable = params.tools.some((tool) =>
+    isNodeRoutableOpenClawExecTool(tool),
+  );
+  const missing = required.filter((toolName) => {
+    if (toolName === "read" && params.nativeToolSurfaceEnabled) {
+      return false;
+    }
+    if (toolName === "exec") {
+      return !execNodeRoutingSchemaAvailable;
+    }
+    return !available.includes(toolName);
+  });
+  if (missing.length === 0) {
+    return;
+  }
+  const diagnostic: CodexRequiredToolSurfaceDiagnostic = {
+    code: "TOOL_SURFACE_UNAVAILABLE",
+    jobId: params.params.jobId,
+    sessionKey: params.params.sessionKey,
+    provider: params.params.provider,
+    model: params.params.modelId,
+    required,
+    available,
+    missing,
+    nativeToolSurfaceEnabled: params.nativeToolSurfaceEnabled,
+    route: {
+      trigger: params.params.trigger,
+      bootstrapContextRunKind: params.params.bootstrapContextRunKind,
+      execNodeRoutingSchemaAvailable,
+      nativeReadAvailable: params.nativeToolSurfaceEnabled,
+    },
+  };
+  const err = new Error(
+    [
+      "TOOL_SURFACE_UNAVAILABLE: Codex app-server required tool surface unavailable",
+      params.params.jobId ? `jobId=${params.params.jobId}` : undefined,
+      params.params.sessionKey ? `sessionKey=${params.params.sessionKey}` : undefined,
+      params.params.trigger ? `trigger=${params.params.trigger}` : undefined,
+      params.params.bootstrapContextRunKind
+        ? `bootstrapContextRunKind=${params.params.bootstrapContextRunKind}`
+        : undefined,
+      `missing=${missing.join(",") || "(none)"}`,
+      `required=${required.join(",") || "(none)"}`,
+      `available=${available.join(",") || "(none)"}`,
+      `nativeToolSurfaceEnabled=${params.nativeToolSurfaceEnabled}`,
+      `execNodeRoutingSchemaAvailable=${execNodeRoutingSchemaAvailable}`,
+    ]
+      .filter(Boolean)
+      .join("; "),
+  );
+  Object.assign(err, {
+    code: diagnostic.code,
+    diagnostic,
+  });
+  throw err;
+}
+
+function shouldRequireCodexAppServerToolSurface(params: EmbeddedRunAttemptParams): boolean {
+  return (
+    params.trigger === "cron" ||
+    params.bootstrapContextRunKind === "cron" ||
+    Boolean(params.jobId?.trim())
+  );
+}
+
+function normalizeRequiredCodexToolNames(toolsAllow?: string[]): string[] {
+  if (!toolsAllow || toolsAllow.length === 0 || hasWildcardCodexToolsAllow(toolsAllow)) {
+    return [];
+  }
+  return Array.from(
+    new Set(toolsAllow.map((name) => normalizeCodexDynamicToolName(name)).filter(Boolean)),
+  );
+}
+
+function isNodeRoutableOpenClawExecTool(tool: OpenClawDynamicTool): boolean {
+  if (normalizeCodexDynamicToolName(tool.name) !== "exec") {
+    return false;
+  }
+  const schema = tool.parameters;
+  if (!schema || typeof schema !== "object") {
+    return false;
+  }
+  const properties = (schema as { properties?: unknown }).properties;
+  if (!properties || typeof properties !== "object") {
+    return false;
+  }
+  const record = properties as Record<string, unknown>;
+  return hasNodeHostSchema(record.host) && record.node !== undefined;
+}
+
+function hasNodeHostSchema(hostSchema: unknown): boolean {
+  if (!hostSchema || typeof hostSchema !== "object") {
+    return false;
+  }
+  if (schemaContainsEnumValue(hostSchema, "node")) {
+    return true;
+  }
+  const variants =
+    (hostSchema as { anyOf?: unknown; oneOf?: unknown }).anyOf ??
+    (hostSchema as { anyOf?: unknown; oneOf?: unknown }).oneOf;
+  return (
+    Array.isArray(variants) && variants.some((variant) => schemaContainsEnumValue(variant, "node"))
+  );
+}
+
+function schemaContainsEnumValue(schema: unknown, value: string): boolean {
+  if (!schema || typeof schema !== "object") {
+    return false;
+  }
+  const enumValues = (schema as { enum?: unknown }).enum;
+  return Array.isArray(enumValues) && enumValues.includes(value);
 }
 
 function shouldExposeSandboxExecDynamicTool(input: DynamicToolBuildParams): boolean {
@@ -4844,6 +5070,7 @@ export const testing = {
   filterCodexDynamicTools,
   buildDynamicTools,
   addSandboxShellDynamicToolsIfAvailable,
+  assertCodexAppServerRequiredToolSurface,
   filterCodexDynamicToolsForAllowlist,
   filterToolsForVisionInputs,
   hasWildcardCodexToolsAllow,

--- a/src/cron/isolated-agent.helpers.test.ts
+++ b/src/cron/isolated-agent.helpers.test.ts
@@ -1,6 +1,36 @@
 import { describe, expect, it } from "vitest";
 import { setReplyPayloadMetadata } from "../auto-reply/reply-payload.js";
-import { resolveCronPayloadOutcome } from "./isolated-agent/helpers.js";
+import {
+  detectCronMissingToolSummaryToken,
+  resolveCronPayloadOutcome,
+} from "./isolated-agent/helpers.js";
+
+describe("detectCronMissingToolSummaryToken", () => {
+  it("matches success-shaped missing-tool summaries case-insensitively", () => {
+    expect(detectCronMissingToolSummaryToken("EXEC_TOOL_UNAVAILABLE")).toBe(
+      "exec_tool_unavailable",
+    );
+    expect(detectCronMissingToolSummaryToken("OPENCLAW_DYNAMIC_EXEC_UNAVAILABLE")).toBe(
+      "openclaw_dynamic_exec_unavailable",
+    );
+    expect(detectCronMissingToolSummaryToken("No exec/shell tool is available in this run.")).toBe(
+      "no exec/shell tool",
+    );
+    expect(detectCronMissingToolSummaryToken("Unable to run required health commands.")).toBe(
+      "unable to run required",
+    );
+  });
+
+  it("ignores broad narrated denial text", () => {
+    expect(detectCronMissingToolSummaryToken(undefined)).toBeUndefined();
+    expect(
+      detectCronMissingToolSummaryToken("I could not run the requested script."),
+    ).toBeUndefined();
+    expect(
+      detectCronMissingToolSummaryToken("The denied claim was reviewed, then the job succeeded."),
+    ).toBeUndefined();
+  });
+});
 
 describe("resolveCronPayloadOutcome", () => {
   it("uses the last non-empty non-error payload as summary and output", () => {
@@ -376,6 +406,20 @@ describe("resolveCronPayloadOutcome", () => {
     expect(result.hasFatalErrorPayload).toBe(false);
     expect(result.outputText).toBe("I could not run the requested script.");
     expect(result.embeddedRunError).toBeUndefined();
+  });
+
+  it("promotes success-shaped missing-tool summaries as a fatal backstop", () => {
+    const result = resolveCronPayloadOutcome({
+      payloads: [{ text: "Working on it..." }],
+      finalAssistantVisibleText: "No exec/shell tool is available in this run.",
+      preferFinalAssistantVisibleText: true,
+    });
+
+    expect(result.hasFatalErrorPayload).toBe(true);
+    expect(result.outputText).toBe("No exec/shell tool is available in this run.");
+    expect(result.embeddedRunError).toBe(
+      'cron classifier: missing tool token "no exec/shell tool" detected in summary',
+    );
   });
 
   it("prefers typed failure signals over denial-token fallback", () => {

--- a/src/cron/isolated-agent/helpers.ts
+++ b/src/cron/isolated-agent/helpers.ts
@@ -37,6 +37,52 @@ type NormalizedCronFailureSignal = CronFailureSignal & {
   fatalForCron: true;
 };
 
+type CronMissingToolSummarySignal = {
+  token: string;
+  field: string;
+};
+
+const CRON_MISSING_TOOL_SUMMARY_TOKENS = [
+  "exec unavailable",
+  "exec tool unavailable",
+  "exec not available",
+  "no exec/shell tool",
+  "tool unavailable",
+  "unable to run required",
+  "exec_tool_unavailable",
+  "openclaw_dynamic_exec_unavailable",
+] as const;
+
+export function detectCronMissingToolSummaryToken(text: string | undefined): string | undefined {
+  const normalized = normalizeOptionalString(text);
+  if (!normalized) {
+    return undefined;
+  }
+  const lowerText = normalized.toLowerCase();
+  for (const token of CRON_MISSING_TOOL_SUMMARY_TOKENS) {
+    if (lowerText.includes(token)) {
+      return token;
+    }
+  }
+  return undefined;
+}
+
+function resolveCronMissingToolSummarySignal(
+  fields: Array<{ field: string; text?: string | undefined }>,
+): CronMissingToolSummarySignal | undefined {
+  for (const { field, text } of fields) {
+    const token = detectCronMissingToolSummaryToken(text);
+    if (token) {
+      return { token, field };
+    }
+  }
+  return undefined;
+}
+
+function formatCronMissingToolSummarySignal(signal: CronMissingToolSummarySignal): string {
+  return `cron classifier: missing tool token "${signal.token}" detected in ${signal.field}`;
+}
+
 function normalizeCronFailureSignal(
   signal: CronFailureSignal | undefined,
 ): NormalizedCronFailureSignal | undefined {
@@ -309,13 +355,29 @@ export function resolveCronPayloadOutcome(params: {
         : [];
   const failureSignal = normalizeCronFailureSignal(params.failureSignal);
   const runLevelError = formatCronRunLevelError(params.runLevelError);
+  const missingToolSummarySignal =
+    !hasFatalStructuredErrorPayload && failureSignal === undefined && runLevelError === undefined
+      ? resolveCronMissingToolSummarySignal([
+          { field: "summary", text: summary },
+          { field: "outputText", text: outputText },
+          { field: "synthesizedText", text: synthesizedText },
+          { field: "fallbackSummary", text: fallbackSummary },
+          { field: "fallbackOutputText", text: fallbackOutputText },
+        ])
+      : undefined;
   const hasFatalErrorPayload =
-    hasFatalStructuredErrorPayload || failureSignal !== undefined || runLevelError !== undefined;
+    hasFatalStructuredErrorPayload ||
+    failureSignal !== undefined ||
+    missingToolSummarySignal !== undefined ||
+    runLevelError !== undefined;
   const structuredErrorText = hasFatalStructuredErrorPayload
     ? (lastErrorPayloadText ?? "cron isolated run returned an error payload")
     : undefined;
   const shouldUseRunLevelErrorPayload =
-    runLevelError !== undefined && structuredErrorText === undefined && failureSignal === undefined;
+    runLevelError !== undefined &&
+    structuredErrorText === undefined &&
+    failureSignal === undefined &&
+    missingToolSummarySignal === undefined;
   const fatalDeliveryText =
     structuredErrorText ??
     failureSignal?.message ??
@@ -337,7 +399,9 @@ export function resolveCronPayloadOutcome(params: {
       ? structuredErrorText
       : failureSignal
         ? formatCronFailureSignal(failureSignal)
-        : runLevelError,
+        : missingToolSummarySignal
+          ? formatCronMissingToolSummarySignal(missingToolSummarySignal)
+          : runLevelError,
     pendingPresentationWarningError: hasPendingPresentationWarning
       ? lastErrorPayloadText
       : undefined,

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -63,6 +63,17 @@ function resolveCronOwnerOnlyToolAllowlist(toolsAllow: string[] | undefined): st
   return ["cron"];
 }
 
+function hasRequiredRuntimeToolAllowlist(toolsAllow: string[] | undefined): boolean {
+  const normalized = normalizeToolList(toolsAllow);
+  return normalized.length > 0 && !normalized.includes("*");
+}
+
+function createToolSurfaceUnavailableError(message: string): Error {
+  const err = new Error(`TOOL_SURFACE_UNAVAILABLE: ${message}`);
+  Object.assign(err, { code: "TOOL_SURFACE_UNAVAILABLE" });
+  return err;
+}
+
 const COMMAND_STYLE_CRON_PREFIX =
   /^(?:(?:[A-Z_][A-Z0-9_]*=\S+\s+)+)?(?:cd\s+\S+|(?:\.{1,2}|~)?\/\S+|[A-Za-z]:[\\/]\S+|(?:bash|bun|cargo|deno|docker|gh|git|go|make|node|npm|npx|pnpm|python|python3|ruby|sh|tsx|uv|zsh)\b)/u;
 
@@ -193,6 +204,13 @@ export function createCronPromptExecutor(params: {
         const bootstrapPromptWarningSignature =
           bootstrapPromptWarningSignaturesSeen[bootstrapPromptWarningSignaturesSeen.length - 1];
         if (isCliProvider(executionProvider, params.cfgWithAgentDefaults)) {
+          if (hasRequiredRuntimeToolAllowlist(params.agentPayload?.toolsAllow)) {
+            throw createToolSurfaceUnavailableError(
+              `CLI backend ${executionProvider} cannot expose required cron toolsAllow: ${normalizeToolList(
+                params.agentPayload?.toolsAllow,
+              ).join(", ")}`,
+            );
+          }
           const cliSessionId = params.cronSession.isNewSession
             ? undefined
             : await getCliSessionId(params.cronSession.sessionEntry, executionProvider);

--- a/src/cron/isolated-agent/run.message-tool-policy.test.ts
+++ b/src/cron/isolated-agent/run.message-tool-policy.test.ts
@@ -7,6 +7,7 @@ import {
   clearFastTestEnv,
   dispatchCronDeliveryMock,
   getChannelPluginMock,
+  isCliProviderMock,
   isHeartbeatOnlyResponseMock,
   loadRunCronIsolatedAgentTurn,
   makeCronSession,
@@ -16,6 +17,7 @@ import {
   resolveCronDeliveryPlanMock,
   resolveDeliveryTargetMock,
   restoreFastTestEnv,
+  runCliAgentMock,
   runEmbeddedPiAgentMock,
 } from "./run.test-harness.js";
 
@@ -359,6 +361,54 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
       resolvedDelivery,
     });
   }
+
+  it("rejects CLI-backed cron runs that declare required toolsAllow before dispatch", async () => {
+    mockRunCronFallbackPassthrough();
+    isCliProviderMock.mockReturnValue(true);
+
+    const executor = createMessageToolExecutor({
+      agentPayload: {
+        kind: "agentTurn",
+        message: "run health checks",
+        toolsAllow: ["exec", "read"],
+      } as never,
+      liveSelection: {
+        provider: "openai-codex",
+        model: "gpt-5.5",
+      },
+    });
+
+    await expect(executor.runPrompt("run health checks")).rejects.toThrow(
+      /TOOL_SURFACE_UNAVAILABLE: CLI backend openai-codex cannot expose required cron toolsAllow: exec, read/,
+    );
+    expect(runCliAgentMock).not.toHaveBeenCalled();
+    expect(runEmbeddedPiAgentMock).not.toHaveBeenCalled();
+  });
+
+  it("returns tool-surface diagnostics with provider/model for required-tool setup failures", async () => {
+    mockRunCronFallbackPassthrough();
+    isCliProviderMock.mockReturnValue(true);
+
+    const result = await runCronIsolatedAgentTurn({
+      ...makeParams(),
+      job: makeMessageToolPolicyJob(
+        { mode: "none" },
+        {
+          kind: "agentTurn",
+          message: "run health checks",
+          toolsAllow: ["exec", "read"],
+        },
+      ),
+    });
+
+    expect(result.status).toBe("error");
+    expect(result.provider).toBe("openai");
+    expect(result.model).toBe("gpt-5.4");
+    expect(result.diagnostics?.summary).toContain("TOOL_SURFACE_UNAVAILABLE");
+    expect(result.diagnostics?.entries[0]?.source).toBe("tool-surface");
+    expect(runCliAgentMock).not.toHaveBeenCalled();
+    expect(runEmbeddedPiAgentMock).not.toHaveBeenCalled();
+  });
 
   afterEach(() => {
     restoreFastTestEnv(previousFastTestEnv);

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -152,6 +152,18 @@ function isCronNestedLaneTaskTimeoutError(err: unknown): boolean {
   return isCommandLaneTaskTimeoutError(err, CommandLane.CronNested);
 }
 
+function isToolSurfaceUnavailableError(err: unknown): boolean {
+  if (
+    err &&
+    typeof err === "object" &&
+    (err as { code?: unknown }).code === "TOOL_SURFACE_UNAVAILABLE"
+  ) {
+    return true;
+  }
+  const message = err instanceof Error ? err.message : String(err);
+  return message.includes("TOOL_SURFACE_UNAVAILABLE");
+}
+
 async function retireRolledCronSessionMcpRuntime(params: {
   job: CronJob;
   cronSession: MutableCronSession;
@@ -1186,14 +1198,17 @@ export async function runCronIsolatedAgentTurn(params: {
     });
   } catch (err) {
     const isCronLaneTimeout = isAborted() || isCronNestedLaneTaskTimeoutError(err);
+    const isToolSurfaceUnavailable = isToolSurfaceUnavailableError(err);
     const error = isCronLaneTimeout ? abortReason() : String(err);
     return prepared.context.withRunSession({
       status: "error",
       error,
       diagnostics: createCronRunDiagnosticsFromError(
-        isCronLaneTimeout ? "cron-setup" : "agent-run",
+        isCronLaneTimeout ? "cron-setup" : isToolSurfaceUnavailable ? "tool-surface" : "agent-run",
         isCronLaneTimeout ? error : err,
       ),
+      provider: prepared.context.liveSelection.provider,
+      model: prepared.context.liveSelection.model,
     });
   }
 }

--- a/src/cron/run-diagnostics.ts
+++ b/src/cron/run-diagnostics.ts
@@ -23,6 +23,7 @@ function normalizeSource(value: unknown): CronRunDiagnosticSource {
     case "cron-setup":
     case "model-preflight":
     case "agent-run":
+    case "tool-surface":
     case "tool":
     case "exec":
     case "delivery":

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -103,6 +103,7 @@ export type CronRunDiagnosticSource =
   | "cron-setup"
   | "model-preflight"
   | "agent-run"
+  | "tool-surface"
   | "tool"
   | "exec"
   | "delivery";


### PR DESCRIPTION
## Related Issues

- Addresses #84141.
- Related: #60841.

## Summary

- Enables the Codex app-server native/dynamic tool surface for finite cron allowlists that require runtime tools like `exec`.
- Fails cron isolated-agent runs closed with `TOOL_SURFACE_UNAVAILABLE` when declared required tools are not available before model dispatch.
- Hardens cron finalization so success-shaped summaries that mention missing required tools are treated as failures, not healthy cron output.

## Root Cause

Cron `payload.toolsAllow` was being treated as an allowlist/filter, not as a required pre-dispatch capability contract. In the Codex app-server path, finite allowlists such as `["exec", "read"]` disabled the native app-server tool surface, while the default dynamic filter also removed Codex-owned tools like `exec`. That combination could produce empty/no-exec tool surfaces and still allow a model turn to produce operator-facing “exec unavailable” text.

## Real behavior proof

**Behavior or issue addressed:** Cron isolated-agent jobs that declare finite required tools, especially `toolsAllow: ["exec", "read"]`, must either expose the required OpenClaw dynamic tool surface before model dispatch or fail closed with `TOOL_SURFACE_UNAVAILABLE`. They must not produce success-shaped health summaries when no exec/shell tool is available.

**Real environment tested:** Local OpenClaw source checkout on macOS at `/Users/ostemini/projects/openclaw-cron-tool-surface-mainline-20260520`, branch `codex/cron-tool-surface-fail-closed-20260520`, rebased onto `origin/main` commit `6c7fe58468`, Node `v24.15.0`, pnpm `11.1.0`. The live affected OpenClaw install that motivated the patch was OpenClaw `2026.5.18` on the same host; it was inspected but not updated by this PR.

**Before evidence:** Copied live output from the affected host before installing this source patch showed valid exec-required cron payloads but an empty/no-exec Codex app-server tool surface:

```text
Runtime Health Guard payload.toolsAllow: ["exec", "read"]
codexDynamicToolsExclude: ["read", "write", "edit", "apply_patch", "process", "update_plan"]
runtime-guard issues included: "cron_tool_surface_false_ok:9"
runtime-guard issues included: "codex_app_tools_exec_unavailable:empty_manifest"
codexAppToolsCacheToolCount: 0
codexAppToolsCacheHasExec: false
```

**Exact steps or command run after this patch:** In the patched source checkout, I ran:

```bash
node scripts/run-vitest.mjs run extensions/codex/src/app-server/run-attempt.test.ts
node scripts/run-vitest.mjs run src/cron/isolated-agent.helpers.test.ts src/cron/isolated-agent/run.message-tool-policy.test.ts
NODE_OPTIONS=--max-old-space-size=8192 pnpm tsgo:extensions:test
NODE_OPTIONS=--max-old-space-size=8192 pnpm tsgo:core:test
pnpm exec oxfmt --check extensions/codex/src/app-server/run-attempt.ts extensions/codex/src/app-server/run-attempt.test.ts src/cron/isolated-agent.helpers.test.ts src/cron/isolated-agent/helpers.ts src/cron/isolated-agent/run-executor.ts src/cron/isolated-agent/run.message-tool-policy.test.ts src/cron/isolated-agent/run.ts src/cron/run-diagnostics.ts src/cron/types.ts
pnpm exec oxlint extensions/codex/src/app-server/run-attempt.ts extensions/codex/src/app-server/run-attempt.test.ts src/cron/isolated-agent.helpers.test.ts src/cron/isolated-agent/helpers.ts src/cron/isolated-agent/run-executor.ts src/cron/isolated-agent/run.message-tool-policy.test.ts src/cron/isolated-agent/run.ts src/cron/run-diagnostics.ts src/cron/types.ts
git diff --check
```

**Evidence after fix:** Copied terminal output from the patched checkout:

```text
extensions/codex/src/app-server/run-attempt.test.ts:
Test Files  1 passed (1)
Tests       188 passed (188)

src/cron/isolated-agent.helpers.test.ts + src/cron/isolated-agent/run.message-tool-policy.test.ts:
Test Files  2 passed (2)
Tests       63 passed (63)

NODE_OPTIONS=--max-old-space-size=8192 pnpm tsgo:extensions:test: exit 0
NODE_OPTIONS=--max-old-space-size=8192 pnpm tsgo:core:test: exit 0
pnpm exec oxfmt --check <9 changed files>: All matched files use the correct format.
pnpm exec oxlint <9 changed files>: Found 0 warnings and 0 errors.
git diff --check: exit 0

git diff --stat origin/main..HEAD:
9 files changed, 458 insertions(+), 14 deletions(-)
```

**Observed result after fix:** The patched source now preserves explicitly required dynamic `exec`, enables the native surface for finite allowlists that require exec/process, throws `TOOL_SURFACE_UNAVAILABLE` before dispatch when required tools are absent, rejects CLI-backed finite required-tool cron before dispatch, and classifies missing-tool summaries as fatal cron outcomes in the covered scenarios.

**What was not tested:** No local installed-runtime rollout was performed. I did not mutate live cron payloads, `~/.openclaw`, config desired state, node routes, package installs, or Gateway runtime state. After this lands and ships through a supported OpenClaw update path, the live Gateway should be updated/restarted separately and Runtime Health Guard rerun to confirm dynamic `exec` is exposed before accepting health summaries.

## Verification

- `node scripts/run-vitest.mjs run extensions/codex/src/app-server/run-attempt.test.ts`
- `node scripts/run-vitest.mjs run src/cron/isolated-agent.helpers.test.ts src/cron/isolated-agent/run.message-tool-policy.test.ts`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm tsgo:extensions:test`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm tsgo:core:test`
- `pnpm exec oxfmt --check extensions/codex/src/app-server/run-attempt.ts extensions/codex/src/app-server/run-attempt.test.ts src/cron/isolated-agent.helpers.test.ts src/cron/isolated-agent/helpers.ts src/cron/isolated-agent/run-executor.ts src/cron/isolated-agent/run.message-tool-policy.test.ts src/cron/isolated-agent/run.ts src/cron/run-diagnostics.ts src/cron/types.ts`
- `pnpm exec oxlint extensions/codex/src/app-server/run-attempt.ts extensions/codex/src/app-server/run-attempt.test.ts src/cron/isolated-agent.helpers.test.ts src/cron/isolated-agent/helpers.ts src/cron/isolated-agent/run-executor.ts src/cron/isolated-agent/run.message-tool-policy.test.ts src/cron/isolated-agent/run.ts src/cron/run-diagnostics.ts src/cron/types.ts`
- `git diff --check`

## Known gaps

- No local runtime rollout was performed. After this lands and is available through a supported OpenClaw update path, the live Gateway should be updated/restarted separately and Runtime Health Guard rerun to confirm dynamic `exec` is exposed before accepting health summaries.
- This PR does not change cron payload schema; existing `toolsAllow` values remain valid.

## AI assistance

This PR was prepared with AI assistance.

