### PR TITLE
fix(infra): restore symlink rejection in tryReadSecretFileSync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 
 - WhatsApp: update Baileys to `7.0.0-rc12`.
 - Dependencies: update `@openclaw/fs-safe` to `0.2.7` so OpenClaw's default Python-helper-off policy keeps best-effort Node write fallbacks for private stores, secret writes, run logs, and media attachments on Linux/macOS.
+- Infra/secrets: restore the fail-closed contract for `tryReadSecretFileSync` so credential loaders that pass `rejectSymlink: true` (Telegram, LINE, Zalo, IRC, Nextcloud Talk tokens) refuse symlinked credential files instead of silently accepting them, and the infra-state CI shard's secret-file symlink test passes again. Thanks @romneyda.
 - Browser: honor the configured image sanitization limit for screenshots and labeled snapshots so browser-captured images follow the same resize policy as other image results. (#84595)
 - Doctor: remove unrecognized `models.providers.*.models[*].compat.thinkingFormat` values during `doctor --fix` so stale provider model config can validate after upgrade. Fixes #77803.
 - Status: show the configured default, session-selected model, reason, clear hint, and docs link when a session remains pinned to a model that differs from `agents.defaults.model.primary`.

--- a/extensions/irc/src/accounts.test.ts
+++ b/extensions/irc/src/accounts.test.ts
@@ -163,9 +163,7 @@ describe("resolveIrcAccount", () => {
       },
     });
 
-    const account = resolveIrcAccount({ cfg });
-    expect(account.password).toBe("");
-    expect(account.passwordSource).toBe("none");
+    expect(() => resolveIrcAccount({ cfg })).toThrow(/IRC password file.*must not be a symlink/);
     fs.rmSync(dir, { recursive: true, force: true });
   });
 

--- a/extensions/line/src/accounts.test.ts
+++ b/extensions/line/src/accounts.test.ts
@@ -196,10 +196,9 @@ describe("LINE accounts", () => {
         },
       };
 
-      const account = resolveLineAccount({ cfg });
-      expect(account.channelAccessToken).toBe("");
-      expect(account.channelSecret).toBe("");
-      expect(account.tokenSource).toBe("none");
+      expect(() => resolveLineAccount({ cfg })).toThrow(
+        /LINE credential file.*must not be a symlink/,
+      );
     });
   });
 

--- a/extensions/nextcloud-talk/src/setup.test.ts
+++ b/extensions/nextcloud-talk/src/setup.test.ts
@@ -387,9 +387,9 @@ describe("resolveNextcloudTalkAccount", () => {
       },
     } as CoreConfig;
 
-    const account = resolveNextcloudTalkAccount({ cfg });
-    expect(account.secret).toBe("");
-    expect(account.secretSource).toBe("none");
+    expect(() => resolveNextcloudTalkAccount({ cfg })).toThrow(
+      /Nextcloud Talk bot secret file.*must not be a symlink/,
+    );
     fs.rmSync(dir, { recursive: true, force: true });
   });
 

--- a/extensions/telegram/src/account-inspect.ts
+++ b/extensions/telegram/src/account-inspect.ts
@@ -38,9 +38,18 @@ function inspectTokenFile(pathValue: unknown): {
   if (!tokenFile) {
     return null;
   }
-  const token = tryReadSecretFileSync(tokenFile, "Telegram bot token", {
-    rejectSymlink: true,
-  });
+  let token: string | undefined;
+  try {
+    token = tryReadSecretFileSync(tokenFile, "Telegram bot token", {
+      rejectSymlink: true,
+    });
+  } catch {
+    return {
+      token: "",
+      tokenSource: "tokenFile",
+      tokenStatus: "configured_unavailable",
+    };
+  }
   return {
     token: token ?? "",
     tokenSource: "tokenFile",

--- a/extensions/telegram/src/token.test.ts
+++ b/extensions/telegram/src/token.test.ts
@@ -101,9 +101,9 @@ describe("resolveTelegramToken", () => {
     fs.symlinkSync(tokenFile, tokenLink);
 
     const cfg = { channels: { telegram: { tokenFile: tokenLink } } } as OpenClawConfig;
-    const res = resolveTelegramToken(cfg);
-    expect(res.token).toBe("");
-    expect(res.source).toBe("none");
+    expect(() => resolveTelegramToken(cfg)).toThrow(
+      /channels\.telegram\.tokenFile.*must not be a symlink/,
+    );
   });
 
   it("does not fall back to config when tokenFile is missing", () => {

--- a/extensions/zalo/src/token.test.ts
+++ b/extensions/zalo/src/token.test.ts
@@ -84,9 +84,7 @@ describe("resolveZaloToken", () => {
     const cfg = {
       tokenFile: tokenLink,
     } as ZaloConfig;
-    const res = resolveZaloToken(cfg);
-    expect(res.token).toBe("");
-    expect(res.source).toBe("none");
+    expect(() => resolveZaloToken(cfg)).toThrow(/Zalo token file.*must not be a symlink/);
     fs.rmSync(dir, { recursive: true, force: true });
   });
 });

--- a/src/infra/secret-file.ts
+++ b/src/infra/secret-file.ts
@@ -1,8 +1,5 @@
 import "./fs-safe-defaults.js";
-import {
-  readSecretFileSync as readSecretFileSyncImpl,
-  tryReadSecretFileSync as tryReadSecretFileSyncImpl,
-} from "@openclaw/fs-safe/secret";
+import { readSecretFileSync as readSecretFileSyncImpl } from "@openclaw/fs-safe/secret";
 import { resolveUserPath } from "../utils.js";
 
 export {
@@ -10,21 +7,10 @@ export {
   PRIVATE_SECRET_DIR_MODE,
   PRIVATE_SECRET_FILE_MODE,
   readSecretFileSync,
+  tryReadSecretFileSync,
   type SecretFileReadOptions,
 } from "@openclaw/fs-safe/secret";
 export { writeSecretFileAtomic as writePrivateSecretFileAtomic } from "@openclaw/fs-safe/secret";
-
-export function tryReadSecretFileSync(
-  filePath: string | undefined,
-  label: string,
-  options: Parameters<typeof tryReadSecretFileSyncImpl>[2] = {},
-): string | undefined {
-  try {
-    return tryReadSecretFileSyncImpl(filePath, label, options);
-  } catch {
-    return undefined;
-  }
-}
 
 export type SecretFileReadResult =
   | {


### PR DESCRIPTION
## Summary

- Drop the swallow-all `try/catch` wrapper around `tryReadSecretFileSync` so the upstream `@openclaw/fs-safe@0.2.7` contract surfaces: `undefined` for blank/missing/not-found, `FsSafeError` for symlink/oversize/non-regular/hardlink.
- Unblocks the `infra-state` CI shard's `throws from the try helper for rejected files` case.
- Closes the production gap: `rejectSymlink: true` callers (Telegram, LINE, Zalo, IRC, Nextcloud Talk credential loaders) fail closed on symlinked credentials again.
- Align stale plugin caller tests with the same fail-closed contract: 5 runtime resolvers now expect a thrown `FsSafeError`; `inspectTelegramAccount` catches at its boundary and reports `configured_unavailable` (matching its existing return type).

## Behavior change to flag

Operators with a symlinked credential file for Telegram/LINE/Zalo/IRC/Nextcloud Talk will now see a startup-time `FsSafeError` (clear "must not be a symlink" message) instead of the channel silently appearing as "no credentials configured." This is the intended fs-safe 0.2.7 contract and matches the docs claim at `docs/channels/telegram.md:1065` that `tokenFile` symlinks are rejected; `inspectTelegramAccount` (status/doctor surfaces) still reports `configured_unavailable` rather than throwing.

## Verification

- `node scripts/run-vitest.mjs src/infra/secret-file.test.ts extensions/zalo/src/token.test.ts extensions/line/src/accounts.test.ts extensions/telegram/src/token.test.ts extensions/irc/src/accounts.test.ts extensions/telegram/src/account-inspect.test.ts extensions/nextcloud-talk/src/setup.test.ts` → 7 files, 87 tests passing.

ref 9e4eca00ff