### PR TITLE
test(secret-file): cover NickServ + account-level symlinks, narrow inspect catch

### DIFF
--- a/extensions/irc/src/accounts.test.ts
+++ b/extensions/irc/src/accounts.test.ts
@@ -167,6 +167,31 @@ describe("resolveIrcAccount", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  it.runIf(process.platform !== "win32")("rejects symlinked NickServ password files", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-irc-nickserv-"));
+    const passwordFile = path.join(dir, "nickserv-password.txt");
+    const passwordLink = path.join(dir, "nickserv-password-link.txt");
+    fs.writeFileSync(passwordFile, "nickserv-pass\n", "utf8");
+    fs.symlinkSync(passwordFile, passwordLink);
+
+    const cfg = asConfig({
+      channels: {
+        irc: {
+          host: "irc.example.com",
+          nick: "claw",
+          nickserv: {
+            passwordFile: passwordLink,
+          },
+        },
+      },
+    });
+
+    expect(() => resolveIrcAccount({ cfg })).toThrow(
+      /IRC NickServ password file.*must not be a symlink/,
+    );
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
   it("preserves shared NickServ config when an account overrides one NickServ field", () => {
     const account = resolveIrcAccount({
       cfg: asConfig({

--- a/extensions/telegram/src/account-inspect.ts
+++ b/extensions/telegram/src/account-inspect.ts
@@ -9,6 +9,7 @@ import {
   normalizeSecretInputString,
 } from "openclaw/plugin-sdk/secret-input";
 import { coerceSecretRef } from "openclaw/plugin-sdk/secret-input-runtime";
+import { FsSafeError } from "openclaw/plugin-sdk/security-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   mergeTelegramAccountConfig,
@@ -43,7 +44,10 @@ function inspectTokenFile(pathValue: unknown): {
     token = tryReadSecretFileSync(tokenFile, "Telegram bot token", {
       rejectSymlink: true,
     });
-  } catch {
+  } catch (error) {
+    if (!(error instanceof FsSafeError)) {
+      throw error;
+    }
     return {
       token: "",
       tokenSource: "tokenFile",

--- a/extensions/telegram/src/token.test.ts
+++ b/extensions/telegram/src/token.test.ts
@@ -106,6 +106,28 @@ describe("resolveTelegramToken", () => {
     );
   });
 
+  it.runIf(process.platform !== "win32")("rejects symlinked account-level tokenFile paths", () => {
+    vi.stubEnv("TELEGRAM_BOT_TOKEN", "");
+    const dir = createTempDir();
+    const tokenFile = path.join(dir, "token.txt");
+    const tokenLink = path.join(dir, "token-link.txt");
+    fs.writeFileSync(tokenFile, "file-token\n", "utf-8");
+    fs.symlinkSync(tokenFile, tokenLink);
+
+    const cfg = {
+      channels: {
+        telegram: {
+          accounts: {
+            work: { tokenFile: tokenLink },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    expect(() => resolveTelegramToken(cfg, { accountId: "work" })).toThrow(
+      /channels\.telegram\.accounts\.work\.tokenFile.*must not be a symlink/,
+    );
+  });
+
   it("does not fall back to config when tokenFile is missing", () => {
     vi.stubEnv("TELEGRAM_BOT_TOKEN", "");
     const dir = createTempDir();


### PR DESCRIPTION
## Summary

Followup to #84711 picking up the three reviewer nits that didn't block the original merge:

1. Narrow the new `inspectTokenFile` catch in `extensions/telegram/src/account-inspect.ts` to `FsSafeError` so only fs-safe validation throws map to `configured_unavailable`; any other throw (programmer error, unexpected I/O) re-raises instead of being silently swallowed.
2. Add a regression test for the IRC NickServ password file symlink path (`extensions/irc/src/accounts.ts:118`), paralleling the existing top-level `passwordFile` symlink test.
3. Add a regression test for the Telegram account-level tokenFile symlink path (`extensions/telegram/src/token.ts:149`), paralleling the existing channel-level `tokenFile` symlink test.

Behavior was already correct after #84711; this just locks coverage on the two latent paths and tightens the catch.

## Verification

- `node scripts/run-vitest.mjs extensions/telegram/src/account-inspect.test.ts extensions/telegram/src/token.test.ts extensions/irc/src/accounts.test.ts` → 3 files, 40 tests passing.

ref #84711