### PR TITLE
Strip plaintext model api keys from models.json

### DIFF
--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import { isRecord } from "../utils.js";
+import { isNonSecretApiKeyMarker } from "./model-auth-markers.js";
 import {
   mergeProviders,
   mergeWithExistingProviderSecrets,
@@ -105,6 +106,32 @@ function resolveProvidersForMode(params: {
   });
 }
 
+function stripPlaintextApiKeysFromModelsJson(
+  providers: Record<string, ProviderConfig>,
+  secretRefManagedProviders: ReadonlySet<string>,
+): Record<string, ProviderConfig> {
+  let mutated = false;
+  const sanitized: Record<string, ProviderConfig> = {};
+
+  for (const [providerKey, provider] of Object.entries(providers)) {
+    if (
+      !Object.hasOwn(provider, "apiKey") ||
+      secretRefManagedProviders.has(providerKey.trim()) ||
+      (typeof provider.apiKey === "string" && isNonSecretApiKeyMarker(provider.apiKey))
+    ) {
+      sanitized[providerKey] = provider;
+      continue;
+    }
+
+    mutated = true;
+    const providerWithoutApiKey = { ...provider };
+    delete providerWithoutApiKey.apiKey;
+    sanitized[providerKey] = providerWithoutApiKey;
+  }
+
+  return mutated ? sanitized : providers;
+}
+
 export async function planOpenClawModelsJsonWithDeps(
   params: {
     cfg: OpenClawConfig;
@@ -177,7 +204,10 @@ export async function planOpenClawModelsJsonWithDeps(
       sourceSecretDefaults: params.sourceConfigForSecrets?.secrets?.defaults,
       secretRefManagedProviders,
     }) ?? normalizedMergedProviders;
-  const finalProviders = applyNativeStreamingUsageCompat(secretEnforcedProviders);
+  const finalProviders = stripPlaintextApiKeysFromModelsJson(
+    applyNativeStreamingUsageCompat(secretEnforcedProviders),
+    secretRefManagedProviders,
+  );
   const nextContents = `${JSON.stringify({ providers: finalProviders }, null, 2)}\n`;
 
   if (params.existingRaw === nextContents) {

--- a/src/agents/models-config.skips-writing-models-json-no-env-token.test.ts
+++ b/src/agents/models-config.skips-writing-models-json-no-env-token.test.ts
@@ -190,6 +190,7 @@ describe("models-config", () => {
           string,
           {
             baseUrl?: string;
+            apiKey?: string;
             models?: Array<{
               id?: string;
               cost?: { input?: number; output?: number; cacheRead?: number; cacheWrite?: number };
@@ -199,6 +200,8 @@ describe("models-config", () => {
       };
 
       expect(parsed.providers["custom-proxy"]?.baseUrl).toBe("http://localhost:4000/v1");
+      expect(parsed.providers["custom-proxy"]?.apiKey).toBeUndefined();
+      expect(raw).not.toContain("TEST_KEY");
       const model = parsed.providers["custom-proxy"]?.models?.[0];
       expect(model?.id).toBe("llama-3.1-8b");
       expect(model?.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });


### PR DESCRIPTION
Fixes #11829.

## Summary

- strip plaintext provider `apiKey` values from generated `models.json`
- preserve non-secret auth markers, including secret-ref managed providers and known local/env markers
- add regression coverage proving a configured plaintext provider key is not written to `models.json`

## Why

`models.json` is used as model catalog data and can be serialized into agent prompt context. Persisting resolved provider API keys there can leak LLM provider credentials to the model or chat transcript. This keeps catalog metadata while removing plaintext credentials from the serialized file.

## Real behavior proof

I exercised the actual OpenClaw `models.json` planning path after the fix with a configured provider that includes a plaintext `apiKey: "TEST_KEY"`. The generated `models.json` payload keeps the provider/model catalog metadata, but omits the plaintext key.

Command run locally against this branch:

```powershell
node --import tsx -e "import { planOpenClawModelsJsonWithDeps } from './src/agents/models-config.plan.ts'; const provider = { baseUrl: 'http://127.0.0.1:4000/v1', apiKey: 'TEST_KEY', api: 'openai-completions', models: [{ id: 'proof-model', name: 'Proof Model', api: 'openai-completions', input: ['text'], reasoning: false, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 8192, maxTokens: 2048 }] }; const plan = await planOpenClawModelsJsonWithDeps({ cfg: { models: { mode: 'replace', providers: { 'custom-proof': provider } } }, sourceConfigForSecrets: { models: { mode: 'replace', providers: { 'custom-proof': provider } } }, agentDir: 'C:/tmp/openclaw-proof-agent', env: {}, existingRaw: '', existingParsed: null }, { resolveImplicitProviders: async () => ({}) }); if (plan.action !== 'write') throw new Error('expected write plan'); const parsed = JSON.parse(plan.contents); console.log(JSON.stringify({ action: plan.action, providerKeys: Object.keys(parsed.providers), customProofHasApiKey: Object.hasOwn(parsed.providers['custom-proof'], 'apiKey'), rawContainsTestKey: plan.contents.includes('TEST_KEY'), modelId: parsed.providers['custom-proof']?.models?.[0]?.id }, null, 2));"
```

Output:

```json
{
  "action": "write",
  "providerKeys": ["custom-proof"],
  "customProofHasApiKey": false,
  "rawContainsTestKey": false,
  "modelId": "proof-model"
}
```

## Validation

- `vitest run --config test/vitest/vitest.agents.config.ts src/agents/models-config.skips-writing-models-json-no-env-token.test.ts`
- `oxlint src/agents/models-config.plan.ts src/agents/models-config.skips-writing-models-json-no-env-token.test.ts`
- `git diff --check`