### PR TITLE
fix: preserve active webhook request counters

### DIFF
--- a/src/plugin-sdk/webhook-request-guards.test.ts
+++ b/src/plugin-sdk/webhook-request-guards.test.ts
@@ -213,6 +213,44 @@ describe("readWebhookBodyOrReject", () => {
   });
 });
 
+describe("createWebhookInFlightLimiter", () => {
+  it("rejects new keys when active key capacity is full", () => {
+    const limiter = createWebhookInFlightLimiter({
+      maxInFlightPerKey: 1,
+      maxTrackedKeys: 1,
+    });
+
+    expect(limiter.tryAcquire("a")).toBe(true);
+    expect(limiter.tryAcquire("b")).toBe(false);
+    expect(limiter.size()).toBe(1);
+    expect(limiter.tryAcquire("a")).toBe(false);
+
+    limiter.release("a");
+
+    expect(limiter.size()).toBe(0);
+    expect(limiter.tryAcquire("b")).toBe(true);
+    limiter.release("b");
+  });
+
+  it("allows existing keys when active key capacity is full", () => {
+    const limiter = createWebhookInFlightLimiter({
+      maxInFlightPerKey: 2,
+      maxTrackedKeys: 1,
+    });
+
+    expect(limiter.tryAcquire("a")).toBe(true);
+    expect(limiter.tryAcquire("a")).toBe(true);
+    expect(limiter.tryAcquire("b")).toBe(false);
+    expect(limiter.tryAcquire("a")).toBe(false);
+
+    limiter.release("a");
+
+    expect(limiter.tryAcquire("a")).toBe(true);
+    limiter.release("a");
+    limiter.release("a");
+  });
+});
+
 describe("beginWebhookRequestPipelineOrReject", () => {
   it("enforces in-flight request limits and releases slots", () => {
     const limiter = createWebhookInFlightLimiter({

--- a/src/plugin-sdk/webhook-request-guards.ts
+++ b/src/plugin-sdk/webhook-request-guards.ts
@@ -6,7 +6,6 @@ import {
   readRequestBodyWithLimit,
   requestBodyErrorToText,
 } from "../infra/http-body.js";
-import { pruneMapToMaxSize } from "../infra/map-size.js";
 import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
 import type { FixedWindowRateLimiter } from "./webhook-memory-guards.js";
 
@@ -115,8 +114,10 @@ export function createWebhookInFlightLimiter(options?: {
       if (current >= maxInFlightPerKey) {
         return false;
       }
+      if (current === 0 && active.size >= maxTrackedKeys) {
+        return false;
+      }
       active.set(key, current + 1);
-      pruneMapToMaxSize(active, maxTrackedKeys);
       return true;
     },
     release: (key: string) => {


### PR DESCRIPTION
## Summary

- Treat `maxTrackedKeys` as an active-key capacity limit in `createWebhookInFlightLimiter`.
- Reject brand-new keys when the active key table is full instead of pruning active counters.
- Add regression coverage for full-capacity behavior and same-key reacquire behavior.

Fixes #84717.

## Verification

- `ASDF_NODEJS_VERSION=24.15.0 pnpm install --frozen-lockfile`
- `ASDF_NODEJS_VERSION=24.15.0 node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts src/plugin-sdk/webhook-request-guards.test.ts`
- `ASDF_NODEJS_VERSION=24.15.0 pnpm exec oxfmt --check src/plugin-sdk/webhook-request-guards.ts src/plugin-sdk/webhook-request-guards.test.ts`
- `ASDF_NODEJS_VERSION=24.15.0 pnpm lint:core`
- `ASDF_NODEJS_VERSION=24.15.0 pnpm tsgo:core:test`

## Real behavior proof

Behavior addressed: the webhook in-flight limiter no longer deletes active request counters when the tracked-key cap is reached.

Real environment tested: local macOS source checkout with the repo-declared package manager (`pnpm@11.1.0`) and `ASDF_NODEJS_VERSION=24.15.0` for repo tooling.

Exact steps or command run after this patch: ran the focused webhook guard test file through `node scripts/run-vitest.mjs` using `test/vitest/vitest.unit-fast.config.ts`, then ran format, lint, and core test type-check commands listed above.

Evidence after fix: regression tests assert that a new key is rejected when active key capacity is full, while an existing tracked key remains counted and can acquire up to `maxInFlightPerKey`.

Observed result after fix: focused test file passed with 16 tests; format check, core lint, and core test type-check completed with no errors.

What was not tested: full repository test suite and live webhook endpoint traffic.