### PR TITLE
fix(gateway): handle concurrent launchd bootstrap restart race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Gateway/LaunchAgent: wait for launchd reload bootout to finish and fall back to kickstart when bootstrap races, so reload handoff does not leave the service deregistered. Fixes #84630. (#84641) Thanks @NianJiuZst.
+- Gateway/LaunchAgent: treat a concurrent launchd bootstrap as a successful restart when the service is already loaded, avoiding false macOS Gateway restart failures. Fixes #84721. (#84722) Thanks @googlerest.
 - CLI/update: preserve managed Gateway service environment during package cutovers so macOS LaunchAgent repair/restart reads the pre-update service state instead of caller shell state. (#83026)
 - Agents/providers: honor per-model `api` and `baseUrl` overrides in custom provider auth hooks and transport selection. Fixes #80487. (#80488) Thanks @huveewomg.
 - Gateway/restart: eager-load the lifecycle runtime before in-place upgrade signal handling so package replacement does not deadlock restart imports. (#84890) Thanks @myps6415.

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -35,6 +35,7 @@ const state = vi.hoisted(() => ({
   printFailuresRemaining: 0,
   bootstrapError: "",
   bootstrapCode: 1,
+  bootstrapLoadsServiceOnFailure: false,
   kickstartError: "",
   kickstartCode: 1,
   kickstartFailuresRemaining: 0,
@@ -199,6 +200,10 @@ vi.mock("./exec-file.js", () => ({
     }
     if (call[0] === "bootstrap") {
       if (state.bootstrapError) {
+        if (state.bootstrapLoadsServiceOnFailure) {
+          state.serviceLoaded = true;
+          state.serviceRunning = true;
+        }
         return { stdout: "", stderr: state.bootstrapError, code: state.bootstrapCode };
       }
       state.serviceLoaded = true;
@@ -304,6 +309,7 @@ beforeEach(() => {
   state.printFailuresRemaining = 0;
   state.bootstrapError = "";
   state.bootstrapCode = 1;
+  state.bootstrapLoadsServiceOnFailure = false;
   state.kickstartError = "";
   state.kickstartCode = 1;
   state.kickstartFailuresRemaining = 0;
@@ -1258,6 +1264,44 @@ describe("launchd install", () => {
     expect(plist).toContain("<string>/dev/null</string>");
     expect(plist).toContain("<string>/Users/test/Library/Logs/openclaw/gateway.log</string>");
     expect(launchctlCommandNames()).toEqual(["enable", "bootout", "enable", "bootstrap"]);
+    expect(launchctlCommandNames()).not.toContain("kickstart");
+  });
+
+  it("treats a concurrent launchd bootstrap as success when the service is loaded", async () => {
+    const env = {
+      ...createDefaultLaunchdEnv(),
+      OPENCLAW_GATEWAY_PORT: "18789",
+    };
+    const plistPath = resolveLaunchAgentPlistPath(env);
+    state.files.set(
+      plistPath,
+      [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        '<plist version="1.0">',
+        "  <dict>",
+        "    <key>Label</key>",
+        "    <string>ai.openclaw.gateway</string>",
+        "    <key>ProgramArguments</key>",
+        "    <array>",
+        "      <string>node</string>",
+        "      <string>gateway.js</string>",
+        "    </array>",
+        "    <key>StandardOutPath</key>",
+        "    <string>/Users/test/.openclaw-default/logs/gateway.log</string>",
+        "  </dict>",
+        "</plist>",
+      ].join("\n"),
+    );
+    state.bootstrapError = "Bootstrap failed: 37: Operation already in progress";
+    state.bootstrapCode = 5;
+    state.bootstrapLoadsServiceOnFailure = true;
+
+    await restartLaunchAgent({
+      env,
+      stdout: new PassThrough(),
+    });
+
+    expect(launchctlCommandNames()).toEqual(["enable", "bootout", "enable", "bootstrap", "print"]);
     expect(launchctlCommandNames()).not.toContain("kickstart");
   });
 

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -458,6 +458,12 @@ async function bootstrapLaunchAgentOrThrow(params: {
       actionHint: params.actionHint,
     });
   }
+  if (isLaunchctlOperationAlreadyInProgress(detail)) {
+    const state = await probeLaunchAgentState(params.serviceTarget);
+    if (state.state === "running" || state.state === "stopped") {
+      return;
+    }
+  }
   throw new Error(`launchctl bootstrap failed: ${detail}`);
 }
 
@@ -669,6 +675,14 @@ function isUnsupportedGuiDomain(detail: string): boolean {
   return (
     normalized.includes("domain does not support specified action") ||
     normalized.includes("bootstrap failed: 125")
+  );
+}
+
+function isLaunchctlOperationAlreadyInProgress(detail: string): boolean {
+  const normalized = normalizeLowercaseStringOrEmpty(detail);
+  return (
+    normalized.includes("operation already in progress") ||
+    normalized.includes("bootstrap failed: 37")
   );
 }
 


### PR DESCRIPTION
## Summary

- Fixes #84721.
- Treats a launchd bootstrap `Operation already in progress` race as successful when `launchctl print` confirms the Gateway LaunchAgent is loaded.
- Keeps the existing LaunchAgent `KeepAlive` policy intact; this only changes restart/bootstrap error handling.
- Adds a regression test for a concurrent bootstrap that loads the service while the current restart command receives the losing launchctl error.

## Real behavior proof

- Behavior or issue addressed: macOS Gateway restart can surface a losing concurrent `launchctl bootstrap` as a restart failure even when the LaunchAgent is already loaded by the competing bootstrap.
- Real environment tested: local macOS OpenClaw setup, LaunchAgent `ai.openclaw.gateway`, service target `gui/501/ai.openclaw.gateway`, Gateway port `18789`, branch `codex/fix-launchd-restart-race` at `95129293eb`.
- Exact steps or command run after this patch:

```text
pnpm openclaw gateway restart
pnpm openclaw gateway status
node scripts/run-vitest.mjs src/daemon/launchd.test.ts
```

- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
$ pnpm openclaw gateway restart
$ node scripts/run-node.mjs gateway restart
[openclaw] Building TypeScript (dist is stale: missing_build_stamp - build stamp missing).
[openclaw] Building bundled plugin assets.
[restart] killing 1 stale gateway process(es) before restart: 8305
Restarted LaunchAgent: gui/501/ai.openclaw.gateway

$ pnpm openclaw gateway status
$ node scripts/run-node.mjs gateway status
Service: LaunchAgent (loaded)
Service file: ~/Library/LaunchAgents/ai.openclaw.gateway.plist
Gateway: bind=loopback (127.0.0.1), port=18789 (service args)
Probe target: ws://127.0.0.1:18789
CLI version: 2026.5.20 (~/.openclaw/workspace/openclaw-src/openclaw.mjs)
Runtime: running (pid 9673, state active)
Connectivity probe: ok
Listening: 127.0.0.1:18789
```

- Observed result after fix: the patched branch's real Gateway restart command completed without surfacing a bootstrap failure, the LaunchAgent remained loaded, the Gateway runtime was running, and the connectivity probe returned `ok`.
- What was not tested: I did not force a second simultaneous live bootstrap during the after-fix run; that exact race is covered by the added regression test. The live run verifies the patched restart path on the real macOS LaunchAgent setup.
- Before evidence (optional but encouraged):

```text
Gateway restart failed: launchctl bootstrap failed: Bootstrap failed: 5: Input/output error

macOS unified log from the same restart window showed:
Bootstrap ... ai.openclaw.gateway ... succeeded
Bootstrap ... ai.openclaw.gateway ... failed: 37: Operation already in progress
Successfully spawned ai.openclaw.gateway
```

Supplemental regression test:

```text
$ node scripts/run-vitest.mjs src/daemon/launchd.test.ts

Test Files  1 passed (1)
Tests  71 passed (71)
```

## Root Cause

- Root cause: `bootstrapLaunchAgentOrThrow` treated every non-zero `launchctl bootstrap` result as fatal. During concurrent restart/repair, the losing bootstrap can return `Operation already in progress` while another bootstrap has already loaded the same LaunchAgent.
- Missing detection / guardrail: after this specific launchctl race error, restart did not probe `launchctl print <serviceTarget>` before reporting failure.
- Contributing context (if known): local evidence showed CLI and app/helper launchd activity overlapping in the same restart window.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/daemon/launchd.test.ts`
- Scenario the test should lock in: restart reloads an existing plist, bootstrap returns `Bootstrap failed: 37: Operation already in progress`, a follow-up `launchctl print` shows the service loaded/running, and restart completes instead of throwing.
- Why this is the smallest reliable guardrail: the bug is in launchd result classification and service-state probing; the unit test covers that branch deterministically without requiring a timing-sensitive macOS race.
- Existing test that already covers this (if any): none before this PR.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

`openclaw gateway restart` is less likely to report a false failure when a concurrent macOS launchd bootstrap has already loaded the Gateway LaunchAgent.

## Diagram

```text
Before:
restart -> launchctl bootstrap returns Operation already in progress -> throw failure

After:
restart -> launchctl bootstrap returns Operation already in progress -> launchctl print service
        -> loaded/running -> restart succeeds
        -> not loaded/unknown -> preserve existing failure path
```