### PR TITLE
fix(openrouter): drop empty-object fallbacks from provider-routing spreads

### DIFF
--- a/extensions/openrouter/provider-routing.ts
+++ b/extensions/openrouter/provider-routing.ts
@@ -55,10 +55,13 @@ function mergeOpenRouterProviderRouting(params: {
   const providerRouting = readRecord(params.providerParams?.provider);
   const modelRouting = readRecord(params.modelParams?.provider);
   const extraRouting = readRecord(params.extraParams.provider);
+  // Spreading `undefined` is a no-op in object literals, so the explicit
+  // `?? {}` empty fallback is unnecessary and trips the
+  // `unicorn/no-useless-fallback-in-spread` lint rule.
   const merged = {
-    ...(providerRouting ?? {}),
-    ...(modelRouting ?? {}),
-    ...(extraRouting ?? {}),
+    ...providerRouting,
+    ...modelRouting,
+    ...extraRouting,
   };
   return Object.keys(merged).length > 0 ? merged : undefined;
 }
@@ -76,12 +79,13 @@ export function resolveOpenRouterExtraParamsForTransport(
   if (!providerConfigParams && !modelParams && !providerRouting) {
     return undefined;
   }
-  return {
-    patch: {
-      ...(providerConfigParams ?? {}),
-      ...(modelParams ?? {}),
-      ...ctx.extraParams,
-      ...(providerRouting ? { provider: providerRouting } : {}),
-    },
+  const patch: Record<string, unknown> = {
+    ...providerConfigParams,
+    ...modelParams,
+    ...ctx.extraParams,
   };
+  if (providerRouting) {
+    patch.provider = providerRouting;
+  }
+  return { patch };
 }


### PR DESCRIPTION
## Summary

Removes `...(x ?? {})` and `...(cond ? {x} : {})` empty-fallback patterns from `extensions/openrouter/provider-routing.ts`. Spreading `undefined` / `false` / `null` into an object literal is already a no-op, so the empty-object fallback adds nothing — oxlint's `unicorn/no-useless-fallback-in-spread` rule rejects it.

Introduced by #84579 (\`ac69776330 Add OpenRouter provider routing params\`) after v2026.5.18. Since that landed, every PR rebased onto current main has been failing `check-additional-extension-bundled` with five \`Empty fallbacks in spreads are unnecessary\` errors in `provider-routing.ts:59`, `60`, `61`, `81`, `82`. v2026.5.18 itself is clean.

## Behavior

Identical:
- `{ ...providerRouting }` evaluates to the same thing as `{ ...(providerRouting ?? {}) }` when `providerRouting` is undefined (both produce no keys).
- The conditional `provider: providerRouting` is now set imperatively when the routing record is truthy, matching the prior \`...(providerRouting ? { provider: providerRouting } : {})\` contract that only attached the key on truthy values.

## Test plan

- [x] \`pnpm lint:extensions:bundled\` — 0 errors after fix (5 before)
- [x] \`node scripts/run-vitest.mjs extensions/openrouter/\` — 60/60 tests pass
- [x] \`pnpm tsgo\` on the changed file — no new type errors

## Real behavior proof

- **Behavior or issue addressed**: \`check-additional-extension-bundled\` fails on every PR rebased onto current main with 5 \`unicorn/no-useless-fallback-in-spread\` errors in \`extensions/openrouter/provider-routing.ts\`. The fix removes the redundant empty-object fallbacks. Spreading falsy/undefined into an object literal is a no-op so behavior is unchanged.
- **Real environment tested**: local \`openclaw\` checkout (head of \`upstream/main\`) running \`pnpm lint:extensions:bundled\` and the full openrouter extension test suite via \`node scripts/run-vitest.mjs\`.
- **Exact steps or command run after this patch**:
  \`\`\`bash
  pnpm lint:extensions:bundled
  node scripts/run-vitest.mjs extensions/openrouter/
  \`\`\`
- **Evidence after fix**: captured live from \`pnpm\` against the current \`openclaw\` checkout on \`upstream/main\`:
  \`\`\`
  Found 0 warnings and 0 errors.
  ...
   Test Files  8 passed (8)
        Tests  60 passed (60)
  \`\`\`
- **Observed result after fix**: the bundled lint shard passes on this branch (was 5 errors before). All 60 openrouter tests still pass. No regression in any test that exercised \`mergeOpenRouterProviderRouting\` or \`resolveOpenRouterExtraParamsForTransport\`.
- **What was not tested**: a live OpenRouter API request against the modified merging code (the test suite covers the merge logic with mocked inputs, which is the canonical exercise of these functions).