### PR TITLE
Repair orphaned Codex custom tool outputs before resume

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -210,7 +210,10 @@ import {
   readCodexAppServerBinding,
   type CodexAppServerThreadBinding,
 } from "./session-binding.js";
-import { rotateOversizedCodexAppServerStartupBinding } from "./startup-binding.js";
+import {
+  listCodexAppServerRolloutFilesForThread,
+  rotateOversizedCodexAppServerStartupBinding,
+} from "./startup-binding.js";
 import {
   buildDeveloperInstructions,
   buildContextEngineBinding,
@@ -238,6 +241,7 @@ import {
   mirrorPromptAtTurnStartBestEffort,
   mirrorTranscriptBestEffort,
 } from "./transcript-mirror.js";
+import { repairCodexRolloutMissingCustomToolOutputs } from "./transcript-repair.js";
 import {
   formatCodexTurnStartUsageLimitError,
   markCodexAuthProfileBlockedFromRateLimits,
@@ -445,6 +449,31 @@ export async function runCodexAppServerAttempt(
     contextEngineActive: isActiveHarnessContextEngine(params.contextEngine),
   });
   preDynamicStartupStages.mark("rotate-binding");
+  if (startupBinding?.threadId) {
+    try {
+      const rolloutFiles = await listCodexAppServerRolloutFilesForThread(
+        agentDir,
+        startupBinding.threadId,
+        appServer.start.env?.CODEX_HOME,
+      );
+      const repair = await repairCodexRolloutMissingCustomToolOutputs(
+        rolloutFiles.map((file) => file.path),
+      );
+      if (repair.insertedOutputs > 0) {
+        embeddedAgentLog.warn("repaired codex app-server native transcript tool outputs", {
+          threadId: startupBinding.threadId,
+          scannedFiles: repair.scannedFiles,
+          repairedFiles: repair.repairedFiles,
+          insertedOutputs: repair.insertedOutputs,
+        });
+      }
+    } catch (error) {
+      embeddedAgentLog.warn("failed to repair codex app-server native transcript", {
+        threadId: startupBinding.threadId,
+        error,
+      });
+    }
+  }
   const startupAuthProfileCandidate =
     params.runtimePlan?.auth.forwardedAuthProfileId ??
     params.authProfileId ??

--- a/extensions/codex/src/app-server/startup-binding.ts
+++ b/extensions/codex/src/app-server/startup-binding.ts
@@ -52,7 +52,7 @@ function parseCodexAppServerByteLimit(value: unknown): number | undefined {
   return Math.max(1, Math.round(amount * multiplier));
 }
 
-async function listCodexAppServerRolloutFilesForThread(
+export async function listCodexAppServerRolloutFilesForThread(
   agentDir: string,
   threadId: string,
   codexHome?: string,

--- a/extensions/codex/src/app-server/transcript-repair.test.ts
+++ b/extensions/codex/src/app-server/transcript-repair.test.ts
@@ -1,0 +1,151 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { repairCodexRolloutMissingCustomToolOutputs } from "./transcript-repair.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  for (const dir of tempDirs.splice(0)) {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+async function createRolloutFile(lines: readonly Record<string, unknown>[]): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-repair-"));
+  tempDirs.push(dir);
+  const file = path.join(dir, "rollout-2026-05-20T21-29-59-thread-1.jsonl");
+  await fs.writeFile(file, lines.map((line) => JSON.stringify(line)).join("\n") + "\n");
+  return file;
+}
+
+async function readRecords(file: string): Promise<Array<Record<string, unknown>>> {
+  const raw = await fs.readFile(file, "utf8");
+  return raw
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+function responseItem(payload: Record<string, unknown>): Record<string, unknown> {
+  return {
+    timestamp: "2026-05-20T21:31:38.500Z",
+    type: "response_item",
+    payload,
+  };
+}
+
+describe("repairCodexRolloutMissingCustomToolOutputs", () => {
+  it("inserts a synthetic custom tool output after an orphaned custom tool call", async () => {
+    const file = await createRolloutFile([
+      responseItem({
+        type: "custom_tool_call",
+        status: "completed",
+        call_id: "call_missing",
+        name: "exec",
+        input: "date",
+      }),
+      responseItem({ type: "message", role: "assistant", content: "later item" }),
+    ]);
+
+    await expect(repairCodexRolloutMissingCustomToolOutputs([file])).resolves.toEqual({
+      scannedFiles: 1,
+      repairedFiles: 1,
+      insertedOutputs: 1,
+    });
+
+    const records = await readRecords(file);
+    expect(records).toHaveLength(3);
+    expect((records[1].payload as Record<string, unknown>).type).toBe("custom_tool_call_output");
+    expect((records[1].payload as Record<string, unknown>).call_id).toBe("call_missing");
+    expect(JSON.stringify(records[1])).toContain("interrupted by OpenClaw");
+    expect((records[2].payload as Record<string, unknown>).type).toBe("message");
+  });
+
+  it("leaves already paired custom tool calls unchanged", async () => {
+    const file = await createRolloutFile([
+      responseItem({
+        type: "custom_tool_call",
+        status: "completed",
+        call_id: "call_ok",
+        name: "exec",
+        input: "date",
+      }),
+      responseItem({
+        type: "custom_tool_call_output",
+        call_id: "call_ok",
+        output: [{ type: "input_text", text: "done" }],
+      }),
+    ]);
+    const before = await fs.readFile(file, "utf8");
+
+    await expect(repairCodexRolloutMissingCustomToolOutputs([file])).resolves.toEqual({
+      scannedFiles: 1,
+      repairedFiles: 0,
+      insertedOutputs: 0,
+    });
+
+    await expect(fs.readFile(file, "utf8")).resolves.toBe(before);
+  });
+
+  it("stream-scans clean rollout files without reading or rewriting the whole file", async () => {
+    const file = await createRolloutFile([
+      responseItem({
+        type: "custom_tool_call",
+        status: "completed",
+        call_id: "call_ok",
+        name: "exec",
+        input: "date",
+      }),
+      responseItem({
+        type: "custom_tool_call_output",
+        call_id: "call_ok",
+        output: [{ type: "input_text", text: "done" }],
+      }),
+    ]);
+    const readFile = vi.spyOn(fs, "readFile");
+    const writeFile = vi.spyOn(fs, "writeFile");
+    const rename = vi.spyOn(fs, "rename");
+
+    await expect(repairCodexRolloutMissingCustomToolOutputs([file])).resolves.toEqual({
+      scannedFiles: 1,
+      repairedFiles: 0,
+      insertedOutputs: 0,
+    });
+
+    expect(readFile).not.toHaveBeenCalled();
+    expect(writeFile).not.toHaveBeenCalled();
+    expect(rename).not.toHaveBeenCalled();
+  });
+
+  it("writes repaired rollout files through a sibling temp file and rename", async () => {
+    const file = await createRolloutFile([
+      responseItem({
+        type: "custom_tool_call",
+        status: "completed",
+        call_id: "call_missing",
+        name: "exec",
+        input: "date",
+      }),
+    ]);
+    const writeFile = vi.spyOn(fs, "writeFile");
+    const rename = vi.spyOn(fs, "rename");
+
+    await expect(repairCodexRolloutMissingCustomToolOutputs([file])).resolves.toEqual({
+      scannedFiles: 1,
+      repairedFiles: 1,
+      insertedOutputs: 1,
+    });
+
+    expect(writeFile).toHaveBeenCalledWith(
+      expect.stringContaining(path.join(path.dirname(file), ".rollout-")),
+      expect.any(String),
+      "utf8",
+    );
+    expect(rename).toHaveBeenCalledWith(expect.stringContaining(".repair-"), file);
+    await expect(fs.readdir(path.dirname(file))).resolves.toEqual([path.basename(file)]);
+  });
+});

--- a/extensions/codex/src/app-server/transcript-repair.ts
+++ b/extensions/codex/src/app-server/transcript-repair.ts
@@ -1,0 +1,218 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export type CodexRolloutTranscriptRepairResult = {
+  scannedFiles: number;
+  repairedFiles: number;
+  insertedOutputs: number;
+};
+
+type ParsedJsonLine = {
+  raw: string;
+  value?: Record<string, unknown>;
+};
+
+const SYNTHETIC_TOOL_OUTPUT_TEXT =
+  "[openclaw] custom tool call was interrupted by OpenClaw before a tool output was recorded; inserted synthetic output during transcript repair.";
+
+export async function repairCodexRolloutMissingCustomToolOutputs(
+  files: readonly string[],
+): Promise<CodexRolloutTranscriptRepairResult> {
+  const result: CodexRolloutTranscriptRepairResult = {
+    scannedFiles: 0,
+    repairedFiles: 0,
+    insertedOutputs: 0,
+  };
+  const visited = new Set<string>();
+  for (const file of files) {
+    if (visited.has(file)) {
+      continue;
+    }
+    visited.add(file);
+    const repair = await repairCodexRolloutFile(file);
+    if (repair.scanned) {
+      result.scannedFiles += 1;
+    }
+    if (repair.insertedOutputs > 0) {
+      result.repairedFiles += 1;
+      result.insertedOutputs += repair.insertedOutputs;
+    }
+  }
+  return result;
+}
+
+async function repairCodexRolloutFile(
+  file: string,
+): Promise<{ scanned: boolean; insertedOutputs: number }> {
+  const scan = await scanCodexRolloutFileForMissingCustomToolOutputs(file);
+  if (!scan.exists) {
+    return { scanned: false, insertedOutputs: 0 };
+  }
+  if (!scan.hasMissingOutputs) {
+    return { scanned: true, insertedOutputs: 0 };
+  }
+
+  let raw: string;
+  try {
+    raw = await fs.readFile(file, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return { scanned: false, insertedOutputs: 0 };
+    }
+    throw error;
+  }
+  if (!raw.trim()) {
+    return { scanned: true, insertedOutputs: 0 };
+  }
+
+  const endsWithNewline = raw.endsWith("\n");
+  const lines = raw.split(/\r?\n/);
+  if (lines.length > 0 && lines[lines.length - 1] === "") {
+    lines.pop();
+  }
+  const parsedLines = lines.map(parseJsonLine);
+  const outputCallIds = new Set<string>();
+  const toolCalls: Array<{ index: number; callId: string; timestamp?: string }> = [];
+  for (const [index, line] of parsedLines.entries()) {
+    const payload = readPayload(line.value);
+    const type = readString(payload, "type");
+    if (type === "custom_tool_call") {
+      const callId = readString(payload, "call_id");
+      if (callId) {
+        toolCalls.push({ index, callId, timestamp: readString(line.value, "timestamp") });
+      }
+    } else if (type === "custom_tool_call_output") {
+      const callId = readString(payload, "call_id");
+      if (callId) {
+        outputCallIds.add(callId);
+      }
+    }
+  }
+
+  const missingCalls = toolCalls.filter((call) => !outputCallIds.has(call.callId));
+  if (missingCalls.length === 0) {
+    return { scanned: true, insertedOutputs: 0 };
+  }
+
+  const missingByIndex = new Map<number, Array<{ callId: string; timestamp?: string }>>();
+  for (const call of missingCalls) {
+    const calls = missingByIndex.get(call.index) ?? [];
+    calls.push(call);
+    missingByIndex.set(call.index, calls);
+  }
+
+  const repaired: string[] = [];
+  for (const [index, line] of parsedLines.entries()) {
+    repaired.push(line.raw);
+    for (const call of missingByIndex.get(index) ?? []) {
+      repaired.push(JSON.stringify(buildSyntheticCustomToolOutput(call)));
+    }
+  }
+  const nextRaw = repaired.join("\n") + (endsWithNewline ? "\n" : "");
+  await writeFileAtomically(file, nextRaw);
+  return { scanned: true, insertedOutputs: missingCalls.length };
+}
+
+async function scanCodexRolloutFileForMissingCustomToolOutputs(
+  file: string,
+): Promise<{ exists: boolean; hasMissingOutputs: boolean }> {
+  let handle: Awaited<ReturnType<typeof fs.open>>;
+  try {
+    handle = await fs.open(file, "r");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return { exists: false, hasMissingOutputs: false };
+    }
+    throw error;
+  }
+  const outputCallIds = new Set<string>();
+  const toolCallIds = new Set<string>();
+  try {
+    for await (const raw of handle.readLines()) {
+      const payload = readPayload(parseJsonLine(raw).value);
+      const type = readString(payload, "type");
+      if (type === "custom_tool_call") {
+        const callId = readString(payload, "call_id");
+        if (callId) {
+          toolCallIds.add(callId);
+        }
+      } else if (type === "custom_tool_call_output") {
+        const callId = readString(payload, "call_id");
+        if (callId) {
+          outputCallIds.add(callId);
+        }
+      }
+    }
+  } finally {
+    await handle.close();
+  }
+  for (const callId of toolCallIds) {
+    if (!outputCallIds.has(callId)) {
+      return { exists: true, hasMissingOutputs: true };
+    }
+  }
+  return { exists: true, hasMissingOutputs: false };
+}
+
+async function writeFileAtomically(file: string, content: string): Promise<void> {
+  const tempFile = path.join(
+    path.dirname(file),
+    `.${path.basename(file)}.repair-${process.pid}-${Date.now()}.tmp`,
+  );
+  try {
+    await fs.writeFile(tempFile, content, "utf8");
+    await fs.rename(tempFile, file);
+  } catch (error) {
+    await fs.rm(tempFile, { force: true }).catch(() => undefined);
+    throw error;
+  }
+}
+
+function parseJsonLine(raw: string): ParsedJsonLine {
+  try {
+    const value = JSON.parse(raw) as unknown;
+    return {
+      raw,
+      value:
+        value && typeof value === "object" && !Array.isArray(value)
+          ? (value as Record<string, unknown>)
+          : undefined,
+    };
+  } catch {
+    return { raw };
+  }
+}
+
+function buildSyntheticCustomToolOutput(call: {
+  callId: string;
+  timestamp?: string;
+}): Record<string, unknown> {
+  return {
+    timestamp: call.timestamp ?? new Date().toISOString(),
+    type: "response_item",
+    payload: {
+      type: "custom_tool_call_output",
+      call_id: call.callId,
+      output: [
+        {
+          type: "input_text",
+          text: SYNTHETIC_TOOL_OUTPUT_TEXT,
+        },
+      ],
+    },
+  };
+}
+
+function readPayload(
+  value: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  const payload = value?.payload;
+  return payload && typeof payload === "object" && !Array.isArray(payload)
+    ? (payload as Record<string, unknown>)
+    : undefined;
+}
+
+function readString(value: Record<string, unknown> | undefined, key: string): string | undefined {
+  const raw = value?.[key];
+  return typeof raw === "string" && raw.length > 0 ? raw : undefined;
+}


### PR DESCRIPTION
Fixes #84727

## What changed

- Adds a Codex rollout transcript repair helper that stream-scans bound native rollout JSONL files for `custom_tool_call` items missing a matching `custom_tool_call_output`.
- Runs that repair before resuming a bound Codex app-server thread, rewriting only files that actually contain orphaned calls so clean large rollouts stay on the existing streaming path.
- Inserts a synthetic interrupted output immediately after each orphaned custom tool call and logs the repair count.
- Adds focused coverage for orphan repair and for leaving already-paired calls unchanged.

## Proof of the issue

Observed during a live `2026.5.19` gateway restart:

```text
2026-05-20T21:31:38.479Z WARN still draining 2 active task(s) and 1 active embedded run(s) before restart
2026-05-20T21:31:38.506Z WARN active embedded run drain grace reached; aborting active run(s) before restart
2026-05-20T21:31:38.522Z WARN drain timeout reached; proceeding with restart
```

The app-server then repeatedly logged the invalid transcript state:

```text
custom missing count: 29
first: 2026-05-20T21:33:12.565Z ... Custom tool call output is missing for call id: call_[redacted]
last:  2026-05-20T23:12:07.703Z ... Custom tool call output is missing for call id: call_[redacted]
```

The Codex native rollout had the persisted call but no output before local manual repair:

```text
rollout-[timestamp]-[thread-id].jsonl
line 28: payload.type=custom_tool_call call_id=call_[redacted] name=exec
(no matching custom_tool_call_output)
```

## Real behavior proof

**Behavior or issue addressed:** Repair a real Codex native rollout transcript that was corrupted by an OpenClaw gateway restart abort. The rollout contained `custom_tool_call` records without matching `custom_tool_call_output` records, causing repeated Codex app-server stderr errors on resume.

**Real environment tested:** Local OpenClaw setup upgraded to `2026.5.19`; affected rollout backup copied from `$OPENCLAW_HOME/agents/[agent-id]/agent/codex-home/sessions/[date]/rollout-[timestamp]-[thread-id].jsonl.backup`.

**Exact steps or command run after this patch:** Copied the actual bad rollout backup to a temporary file, then ran the new `repairCodexRolloutMissingCustomToolOutputs` helper against that copy with `node --import tsx`.

```bash
tmp=/tmp/openclaw-codex-orphan-proof.jsonl
cp "$OPENCLAW_HOME/agents/[agent-id]/agent/codex-home/sessions/[date]/rollout-[timestamp]-[thread-id].jsonl.backup" "$tmp"
node --import tsx -e 'import { repairCodexRolloutMissingCustomToolOutputs } from "./extensions/codex/src/app-server/transcript-repair.ts"; ...' "$tmp"
```

**Evidence after fix:** Live output from the real rollout copy showed the helper scanned and repaired the affected file, inserting synthetic outputs and specifically covering the observed orphaned call shape. This was rerun after changing the helper to stream-scan before rewriting.

```json
{
  "beforeBytes": 1161612,
  "afterBytes": 1162284,
  "repair": {
    "scannedFiles": 1,
    "repairedFiles": 1,
    "insertedOutputs": 2
  },
  "hasSyntheticOutput": true
}
```

**Observed result after fix:** The observed orphaned call shape had a synthetic `custom_tool_call_output` after repair, proving the new repair path fixes the exact corrupted transcript shape seen during the gateway restart.

**What was not tested:** I did not run a live gateway restart with the patched branch installed; the live proof uses the actual corrupted rollout backup from the incident and the new repair helper directly.

## Automated validation

Focused regression test, including large clean-rollout coverage that asserts no `readFile` and no rewrite/rename on the clean path, plus atomic temp-file/rename coverage for repaired rollouts:

```text
OPENCLAW_VITEST_INCLUDE_FILE=/tmp/openclaw-codex-test-include.json node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts

Test Files  1 passed (1)
Tests       4 passed (4)
```

Additional validation:

```text
pnpm exec oxfmt --check extensions/codex/src/app-server/transcript-repair.ts extensions/codex/src/app-server/transcript-repair.test.ts extensions/codex/src/app-server/run-attempt.ts
All matched files use the correct format.

pnpm exec oxlint extensions/codex/src/app-server/transcript-repair.ts extensions/codex/src/app-server/transcript-repair.test.ts extensions/codex/src/app-server/run-attempt.ts --tsconfig config/tsconfig/oxlint.extensions.json
Found 0 warnings and 0 errors.

pnpm test:extensions:package-boundary:compile -- extensions/codex
extension package boundary check passed
compiled plugins: 108
```



