### PR TITLE
Speed up /models browse replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Docs: https://docs.openclaw.ai
 - CLI/update: repair managed npm plugin `openclaw` peer links during post-core convergence and reject stale or wrong-target peer links before restart. (#83794) Thanks @fuller-stack-dev.
 - CLI/agents: default new omitted-account bindings to all accounts when the channel has multiple configured accounts, and clarify account-scope docs. (#49769) Thanks @Gcaufy.
 - Codex app-server: let authorized `/codex` control commands such as `/codex detach` escape plugin-owned conversation bindings while keeping unknown or unauthorized slash text routed to the bound plugin. Fixes #85157. (#85188) Thanks @TurboTheTurtle.
+- Auto-reply/models: keep `/models` browse replies fast by sharing the bounded read-only catalog path with Gateway model listing. (#84735) Thanks @safrano9999.
 - Codex app-server: disable native Code Mode when the effective exec host is `node` and keep OpenClaw `exec`/`process` available, so `/exec host=node` routes shell commands through the selected node instead of the gateway. Fixes #85012. (#85090) Thanks @sahilsatralkar.
 - Agents: bound embedded auto-compaction session write-lock watchdogs to the compaction timeout instead of the full run timeout, so stuck compaction cannot hold the live session lock for the whole run window. (#84949) Thanks @luoyanglang.
 - Gateway: defer provider auth-state prewarm until after startup readiness so early gateway tool/session requests are not blocked by provider auth discovery. (#85272) Thanks @dutifulbob.

--- a/src/agents/model-catalog-browse.test.ts
+++ b/src/agents/model-catalog-browse.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { loadModelCatalogForBrowse } from "./model-catalog-browse.js";
+import type { ModelCatalogEntry } from "./model-catalog.types.js";
+
+const readOnlyCatalog: ModelCatalogEntry[] = [
+  { id: "gpt-readonly", name: "GPT Readonly", provider: "openai" },
+];
+const fullCatalog: ModelCatalogEntry[] = [{ id: "gpt-full", name: "GPT Full", provider: "openai" }];
+
+function config(params: { providerWildcard?: boolean } = {}): OpenClawConfig {
+  return {
+    agents: params.providerWildcard
+      ? {
+          defaults: {
+            models: {
+              "openai/*": {},
+            },
+          },
+        }
+      : undefined,
+  } as OpenClawConfig;
+}
+
+describe("loadModelCatalogForBrowse", () => {
+  it("uses the read-only catalog for default browse views", async () => {
+    const loadCatalog = vi.fn(async ({ readOnly }: { readOnly: boolean }) =>
+      readOnly ? readOnlyCatalog : fullCatalog,
+    );
+
+    await expect(loadModelCatalogForBrowse({ cfg: config(), loadCatalog })).resolves.toBe(
+      readOnlyCatalog,
+    );
+
+    expect(loadCatalog).toHaveBeenCalledExactlyOnceWith({ readOnly: true });
+  });
+
+  it("uses the full catalog for all views", async () => {
+    const loadCatalog = vi.fn(async ({ readOnly }: { readOnly: boolean }) =>
+      readOnly ? readOnlyCatalog : fullCatalog,
+    );
+
+    await expect(
+      loadModelCatalogForBrowse({ cfg: config(), view: "all", loadCatalog }),
+    ).resolves.toBe(fullCatalog);
+
+    expect(loadCatalog).toHaveBeenCalledExactlyOnceWith({ readOnly: false });
+  });
+
+  it("uses the full catalog when configured visibility has provider wildcards", async () => {
+    const loadCatalog = vi.fn(async ({ readOnly }: { readOnly: boolean }) =>
+      readOnly ? readOnlyCatalog : fullCatalog,
+    );
+
+    await expect(
+      loadModelCatalogForBrowse({ cfg: config({ providerWildcard: true }), loadCatalog }),
+    ).resolves.toBe(fullCatalog);
+
+    expect(loadCatalog).toHaveBeenCalledExactlyOnceWith({ readOnly: false });
+  });
+
+  it("returns an empty catalog when read-only catalog loading times out", async () => {
+    const onTimeout = vi.fn();
+    const loadCatalog = vi.fn(
+      () =>
+        new Promise<ModelCatalogEntry[]>((_, reject) => {
+          setTimeout(() => reject(new Error("late catalog failure")), 10);
+        }),
+    );
+
+    const resultPromise = loadModelCatalogForBrowse({
+      cfg: config(),
+      loadCatalog,
+      timeoutMs: 5,
+      onTimeout,
+    });
+
+    await expect(resultPromise).resolves.toEqual([]);
+    expect(onTimeout).toHaveBeenCalledExactlyOnceWith(5);
+    await new Promise((resolve) => setTimeout(resolve, 15));
+  });
+});

--- a/src/agents/model-catalog-browse.ts
+++ b/src/agents/model-catalog-browse.ts
@@ -1,0 +1,46 @@
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { ModelCatalogEntry } from "./model-catalog.types.js";
+import { parseConfiguredModelVisibilityEntries } from "./model-selection-shared.js";
+
+export const DEFAULT_MODEL_CATALOG_BROWSE_TIMEOUT_MS = 750;
+
+export type ModelCatalogBrowseView = "default" | "configured" | "all";
+
+export async function loadModelCatalogForBrowse(params: {
+  cfg: OpenClawConfig;
+  view?: ModelCatalogBrowseView;
+  loadCatalog: (params: { readOnly: boolean }) => Promise<ModelCatalogEntry[]>;
+  timeoutMs?: number;
+  onTimeout?: (timeoutMs: number) => void;
+}): Promise<ModelCatalogEntry[]> {
+  const view = params.view ?? "default";
+  if (view === "all") {
+    return await params.loadCatalog({ readOnly: false });
+  }
+  if (parseConfiguredModelVisibilityEntries({ cfg: params.cfg }).providerWildcards.size > 0) {
+    return await params.loadCatalog({ readOnly: false });
+  }
+
+  let timeout: NodeJS.Timeout | undefined;
+  const timeoutMs = params.timeoutMs ?? DEFAULT_MODEL_CATALOG_BROWSE_TIMEOUT_MS;
+  const timedOut = Symbol("model-catalog-browse-timeout");
+  const catalogPromise = params.loadCatalog({ readOnly: true });
+  const timeoutPromise = new Promise<typeof timedOut>((resolve) => {
+    timeout = setTimeout(() => resolve(timedOut), timeoutMs);
+    timeout.unref?.();
+  });
+
+  try {
+    const result = await Promise.race([catalogPromise, timeoutPromise]);
+    if (result === timedOut) {
+      catalogPromise.catch(() => undefined);
+      params.onTimeout?.(timeoutMs);
+      return [];
+    }
+    return result;
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}

--- a/src/auto-reply/reply/commands-models.test.ts
+++ b/src/auto-reply/reply/commands-models.test.ts
@@ -215,6 +215,25 @@ describe("handleModelsCommand", () => {
     expect(authCheckerParams?.discoverExternalCliAuth).toBe(false);
   });
 
+  it("does not block default browse when read-only catalog loading is slow", async () => {
+    vi.useFakeTimers();
+    try {
+      modelCatalogMocks.loadModelCatalog.mockReturnValue(new Promise(() => undefined));
+
+      const resultPromise = handleModelsCommand(buildParams("/models"), true);
+      await vi.advanceTimersByTimeAsync(750);
+      const result = await resultPromise;
+
+      expect(modelCatalogMocks.loadModelCatalog).toHaveBeenCalledTimes(1);
+      expect(modelCatalogMocks.loadModelCatalog.mock.calls[0]?.[0]?.readOnly).toBe(true);
+      expect(result?.shouldContinue).toBe(false);
+      expect(result?.reply?.text).toContain("Providers:");
+      expect(result?.reply?.text).toContain("- anthropic (1)");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("keeps explicit all browse on the full catalog path", async () => {
     await handleModelsCommand(buildParams("/models openai all"), true);
 
@@ -263,6 +282,7 @@ describe("handleModelsCommand", () => {
       true,
     );
 
+    expect(modelCatalogMocks.loadModelCatalog.mock.calls[0]?.[0]?.readOnly).toBe(false);
     expect(result?.reply?.text).toContain("- openai-codex (2)");
     expect(result?.reply?.text).toContain("- vllm (2)");
     expect(result?.reply?.text).not.toContain("- anthropic");

--- a/src/auto-reply/reply/commands-models.test.ts
+++ b/src/auto-reply/reply/commands-models.test.ts
@@ -206,6 +206,21 @@ describe("handleModelsCommand", () => {
     expect(authCheckerParams?.workspaceDir).toBe("/tmp");
   });
 
+  it("uses read-only catalog loading and static auth checks for default browse", async () => {
+    await handleModelsCommand(buildParams("/models"), true);
+
+    expect(modelCatalogMocks.loadModelCatalog.mock.calls[0]?.[0]?.readOnly).toBe(true);
+    const authCheckerParams = firstAuthCheckerParams();
+    expect(authCheckerParams?.allowPluginSyntheticAuth).toBe(false);
+    expect(authCheckerParams?.discoverExternalCliAuth).toBe(false);
+  });
+
+  it("keeps explicit all browse on the full catalog path", async () => {
+    await handleModelsCommand(buildParams("/models openai all"), true);
+
+    expect(modelCatalogMocks.loadModelCatalog.mock.calls[0]?.[0]?.readOnly).toBe(false);
+  });
+
   it("hides unauthenticated providers by default and keeps all as explicit browse", async () => {
     modelProviderAuthMocks.authenticatedProviders = new Set(["anthropic"]);
 

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -149,7 +149,10 @@ export async function buildModelsProviderData(
     agentId,
   });
 
-  const catalog = await loadModelCatalog({ config: cfg });
+  const catalog = await loadModelCatalog({
+    config: cfg,
+    readOnly: options.view !== "all",
+  });
   const visibilityPolicy = createModelVisibilityPolicy({
     cfg,
     catalog,
@@ -168,6 +171,7 @@ export async function buildModelsProviderData(
       (agentId ? resolveAgentWorkspaceDir(cfg, agentId) : undefined) ??
       resolveDefaultAgentWorkspaceDir(),
     view: options.view,
+    runtimeAuthDiscovery: false,
   });
 
   const aliasIndex = buildModelAliasIndex({

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -13,6 +13,7 @@ import {
   isCliRuntimeProvider,
   listLegacyRuntimeModelProviderAliases,
 } from "../../agents/model-runtime-aliases.js";
+import { parseConfiguredModelVisibilityEntries } from "../../agents/model-selection-shared.js";
 import {
   buildModelAliasIndex,
   normalizeProviderId,
@@ -37,8 +38,11 @@ import type { CommandHandler } from "./commands-types.js";
 
 const PAGE_SIZE_DEFAULT = 20;
 const PAGE_SIZE_MAX = 100;
+const MODELS_COMMAND_CATALOG_TIMEOUT_MS = 750;
 const MODELS_ADD_DEPRECATED_TEXT =
   "⚠️ /models add is deprecated. Use /models to browse providers and /model to switch models.";
+
+type ModelsCommandCatalog = Awaited<ReturnType<typeof loadModelCatalog>>;
 
 type ModelsCommandSessionEntry = Partial<
   Pick<SessionEntry, "authProfileOverride" | "modelProvider" | "model">
@@ -139,6 +143,39 @@ function addRuntimeChoice(
   return choices;
 }
 
+async function loadModelsCommandCatalog(
+  cfg: OpenClawConfig,
+  view: "default" | "all",
+): Promise<ModelsCommandCatalog> {
+  if (view === "all") {
+    return await loadModelCatalog({ config: cfg, readOnly: false });
+  }
+  if (parseConfiguredModelVisibilityEntries({ cfg }).providerWildcards.size > 0) {
+    return await loadModelCatalog({ config: cfg, readOnly: false });
+  }
+
+  let timeout: NodeJS.Timeout | undefined;
+  const timedOut = Symbol("models-command-catalog-timeout");
+  const catalogPromise = loadModelCatalog({ config: cfg, readOnly: true });
+  const timeoutPromise = new Promise<typeof timedOut>((resolve) => {
+    timeout = setTimeout(() => resolve(timedOut), MODELS_COMMAND_CATALOG_TIMEOUT_MS);
+    timeout.unref?.();
+  });
+
+  try {
+    const result = await Promise.race([catalogPromise, timeoutPromise]);
+    if (result === timedOut) {
+      catalogPromise.catch(() => undefined);
+      return [];
+    }
+    return result;
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}
+
 export async function buildModelsProviderData(
   cfg: OpenClawConfig,
   agentId?: string,
@@ -149,10 +186,7 @@ export async function buildModelsProviderData(
     agentId,
   });
 
-  const catalog = await loadModelCatalog({
-    config: cfg,
-    readOnly: options.view !== "all",
-  });
+  const catalog = await loadModelsCommandCatalog(cfg, options.view ?? "default");
   const visibilityPolicy = createModelVisibilityPolicy({
     cfg,
     catalog,

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -5,6 +5,7 @@ import {
 } from "../../agents/agent-scope.js";
 import { resolveAgentHarnessPolicy } from "../../agents/harness/policy.js";
 import { resolveModelAuthLabel } from "../../agents/model-auth-label.js";
+import { loadModelCatalogForBrowse } from "../../agents/model-catalog-browse.js";
 import { resolveVisibleModelCatalog } from "../../agents/model-catalog-visibility.js";
 import { loadModelCatalog } from "../../agents/model-catalog.js";
 import { isModelPickerVisibleProvider } from "../../agents/model-picker-visibility.js";
@@ -13,7 +14,6 @@ import {
   isCliRuntimeProvider,
   listLegacyRuntimeModelProviderAliases,
 } from "../../agents/model-runtime-aliases.js";
-import { parseConfiguredModelVisibilityEntries } from "../../agents/model-selection-shared.js";
 import {
   buildModelAliasIndex,
   normalizeProviderId,
@@ -38,11 +38,8 @@ import type { CommandHandler } from "./commands-types.js";
 
 const PAGE_SIZE_DEFAULT = 20;
 const PAGE_SIZE_MAX = 100;
-const MODELS_COMMAND_CATALOG_TIMEOUT_MS = 750;
 const MODELS_ADD_DEPRECATED_TEXT =
   "⚠️ /models add is deprecated. Use /models to browse providers and /model to switch models.";
-
-type ModelsCommandCatalog = Awaited<ReturnType<typeof loadModelCatalog>>;
 
 type ModelsCommandSessionEntry = Partial<
   Pick<SessionEntry, "authProfileOverride" | "modelProvider" | "model">
@@ -143,39 +140,6 @@ function addRuntimeChoice(
   return choices;
 }
 
-async function loadModelsCommandCatalog(
-  cfg: OpenClawConfig,
-  view: "default" | "all",
-): Promise<ModelsCommandCatalog> {
-  if (view === "all") {
-    return await loadModelCatalog({ config: cfg, readOnly: false });
-  }
-  if (parseConfiguredModelVisibilityEntries({ cfg }).providerWildcards.size > 0) {
-    return await loadModelCatalog({ config: cfg, readOnly: false });
-  }
-
-  let timeout: NodeJS.Timeout | undefined;
-  const timedOut = Symbol("models-command-catalog-timeout");
-  const catalogPromise = loadModelCatalog({ config: cfg, readOnly: true });
-  const timeoutPromise = new Promise<typeof timedOut>((resolve) => {
-    timeout = setTimeout(() => resolve(timedOut), MODELS_COMMAND_CATALOG_TIMEOUT_MS);
-    timeout.unref?.();
-  });
-
-  try {
-    const result = await Promise.race([catalogPromise, timeoutPromise]);
-    if (result === timedOut) {
-      catalogPromise.catch(() => undefined);
-      return [];
-    }
-    return result;
-  } finally {
-    if (timeout) {
-      clearTimeout(timeout);
-    }
-  }
-}
-
 export async function buildModelsProviderData(
   cfg: OpenClawConfig,
   agentId?: string,
@@ -186,7 +150,11 @@ export async function buildModelsProviderData(
     agentId,
   });
 
-  const catalog = await loadModelsCommandCatalog(cfg, options.view ?? "default");
+  const catalog = await loadModelCatalogForBrowse({
+    cfg,
+    view: options.view ?? "default",
+    loadCatalog: ({ readOnly }) => loadModelCatalog({ config: cfg, readOnly }),
+  });
   const visibilityPolicy = createModelVisibilityPolicy({
     cfg,
     catalog,

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -10,34 +10,38 @@ const authProfilesStoreMock = vi.hoisted(() => ({
   >,
 }));
 
-vi.mock("../../agents/auth-profiles.js", () => ({
-  clearRuntimeAuthProfileStoreSnapshots: () => {
-    authProfilesStoreMock.profiles = {};
-  },
-  externalCliDiscoveryForProviderAuth: () => ({
-    mode: "scoped",
-    allowKeychainPrompt: false,
-  }),
-  ensureAuthProfileStore: () => ({
+vi.mock("../../agents/auth-profiles.js", () => {
+  const store = () => ({
     version: 1,
     profiles: authProfilesStoreMock.profiles,
-  }),
-  isProfileInCooldown: () => false,
-  listProfilesForProvider: (_store: unknown, provider: string) =>
-    Object.entries(authProfilesStoreMock.profiles)
-      .filter(([, profile]) => profile.provider === provider)
-      .map(([profileId, profile]) => ({ profileId, profile })),
-  replaceRuntimeAuthProfileStoreSnapshots: (
-    snapshots: Array<{
-      store?: { profiles?: Record<string, AuthProfileForTest> };
-    }>,
-  ) => {
-    authProfilesStoreMock.profiles = snapshots[0]?.store?.profiles ?? {};
-  },
-  resolveAuthProfileDisplayLabel: ({ profileId }: { profileId: string }) => profileId,
-  resolveAuthProfileOrder: () => [],
-  resolveAuthStorePathForDisplay: () => "/tmp/auth-profiles.json",
-}));
+  });
+  return {
+    clearRuntimeAuthProfileStoreSnapshots: () => {
+      authProfilesStoreMock.profiles = {};
+    },
+    externalCliDiscoveryForProviderAuth: () => ({
+      mode: "scoped",
+      allowKeychainPrompt: false,
+    }),
+    ensureAuthProfileStore: store,
+    ensureAuthProfileStoreWithoutExternalProfiles: store,
+    isProfileInCooldown: () => false,
+    listProfilesForProvider: (_store: unknown, provider: string) =>
+      Object.entries(authProfilesStoreMock.profiles)
+        .filter(([, profile]) => profile.provider === provider)
+        .map(([profileId, profile]) => ({ profileId, profile })),
+    replaceRuntimeAuthProfileStoreSnapshots: (
+      snapshots: Array<{
+        store?: { profiles?: Record<string, AuthProfileForTest> };
+      }>,
+    ) => {
+      authProfilesStoreMock.profiles = snapshots[0]?.store?.profiles ?? {};
+    },
+    resolveAuthProfileDisplayLabel: ({ profileId }: { profileId: string }) => profileId,
+    resolveAuthProfileOrder: () => [],
+    resolveAuthStorePathForDisplay: () => "/tmp/auth-profiles.json",
+  };
+});
 
 vi.mock("../../agents/auth-profiles/store.js", () => {
   const store = () => ({

--- a/src/gateway/server-methods/models.ts
+++ b/src/gateway/server-methods/models.ts
@@ -1,64 +1,25 @@
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { DEFAULT_PROVIDER } from "../../agents/defaults.js";
+import {
+  loadModelCatalogForBrowse,
+  type ModelCatalogBrowseView,
+} from "../../agents/model-catalog-browse.js";
 import { resolveVisibleModelCatalog } from "../../agents/model-catalog-visibility.js";
-import { parseConfiguredModelVisibilityEntries } from "../../agents/model-selection-shared.js";
 import { resolveDefaultAgentWorkspaceDir } from "../../agents/workspace.js";
-import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   ErrorCodes,
   errorShape,
   formatValidationErrors,
   validateModelsListParams,
 } from "../protocol/index.js";
-import type { GatewayRequestContext } from "./shared-types.js";
 import type { GatewayRequestHandlers } from "./types.js";
 
-type ModelsListView = "default" | "configured" | "all";
-type GatewayModelCatalog = Awaited<ReturnType<GatewayRequestContext["loadGatewayModelCatalog"]>>;
+type ModelsListView = ModelCatalogBrowseView;
 
-const MODELS_LIST_CATALOG_TIMEOUT_MS = 750;
 let loggedSlowModelsListCatalog = false;
 
 function resolveModelsListView(params: Record<string, unknown>): ModelsListView {
   return typeof params.view === "string" ? (params.view as ModelsListView) : "default";
-}
-
-async function loadModelsListCatalog(
-  context: GatewayRequestContext,
-  view: ModelsListView,
-  cfg: OpenClawConfig,
-): Promise<GatewayModelCatalog> {
-  if (view === "all") {
-    return await context.loadGatewayModelCatalog({ readOnly: false });
-  }
-  if (parseConfiguredModelVisibilityEntries({ cfg }).providerWildcards.size > 0) {
-    return await context.loadGatewayModelCatalog({ readOnly: false });
-  }
-  let timeout: NodeJS.Timeout | undefined;
-  const timedOut = Symbol("models-list-catalog-timeout");
-  const catalogPromise = context.loadGatewayModelCatalog({ readOnly: true });
-  const timeoutPromise = new Promise<typeof timedOut>((resolve) => {
-    timeout = setTimeout(() => resolve(timedOut), MODELS_LIST_CATALOG_TIMEOUT_MS);
-    timeout.unref?.();
-  });
-  try {
-    const result = await Promise.race([catalogPromise, timeoutPromise]);
-    if (result === timedOut) {
-      catalogPromise.catch(() => undefined);
-      if (!loggedSlowModelsListCatalog) {
-        loggedSlowModelsListCatalog = true;
-        context.logGateway.debug(
-          `models.list continuing without model catalog after ${MODELS_LIST_CATALOG_TIMEOUT_MS}ms`,
-        );
-      }
-      return [];
-    }
-    return result;
-  } finally {
-    if (timeout) {
-      clearTimeout(timeout);
-    }
-  }
 }
 
 export const modelsHandlers: GatewayRequestHandlers = {
@@ -80,7 +41,20 @@ export const modelsHandlers: GatewayRequestHandlers = {
         resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg)) ??
         resolveDefaultAgentWorkspaceDir();
       const view = resolveModelsListView(params);
-      const catalog = await loadModelsListCatalog(context, view, cfg);
+      const catalog = await loadModelCatalogForBrowse({
+        cfg,
+        view,
+        loadCatalog: context.loadGatewayModelCatalog,
+        onTimeout: (timeoutMs) => {
+          if (loggedSlowModelsListCatalog) {
+            return;
+          }
+          loggedSlowModelsListCatalog = true;
+          context.logGateway.debug(
+            `models.list continuing without model catalog after ${timeoutMs}ms`,
+          );
+        },
+      });
       if (view === "all") {
         respond(true, { models: catalog }, undefined);
         return;


### PR DESCRIPTION
## Summary

- use the read-only model catalog for default `/models` browse replies
- disable runtime auth discovery for that static browse visibility pass, matching the fast Gateway-style behavior
- keep explicit `/models ... all` on the full catalog path

Fixes #84731.

## Local verification

In a LiteLLM-backed environment with about 410 configured models, runtime patch testing reduced the auto-reply command timings from roughly:

- `/models`: ~69s -> ~1.3s
- `/models litellm`: ~28-32s -> ~1.3s
- `/models list litellm`: ~32s -> ~1.3s

Explicit `all` remains on the full path and stayed slow by design.

## Tests

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply-reply.config.ts src/auto-reply/reply/commands-models.test.ts`


## Real behavior proof

Behavior addressed: Default `/models` browse replies no longer wait on full runtime catalog/auth discovery; explicit `all` still uses the full catalog path.

Real environment tested: Local OpenClaw checkout on the PR branch plus Blacksmith Testbox changed-file gate.

Exact steps or command run after this patch:
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/model-catalog-browse.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/server-methods/models.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply-reply.config.ts src/auto-reply/reply/commands-models.test.ts src/auto-reply/reply/directive-handling.model.test.ts`
- `pnpm check:changed` via Blacksmith Testbox `tbx_01ks8bs93c60rjt4ayde91fnjq`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

Evidence after fix: Helper tests passed 4/4; Gateway models tests passed 4/4; auto-reply models/directive tests passed 87/87; Testbox `check:changed` exited 0; autoreview reported no accepted/actionable findings.

Observed result after fix: Gateway and `/models` browse paths now share the bounded read-only catalog loader for default/configured views, while provider wildcard and `all` views still load the full catalog.

What was not tested: No live Telegram/LiteLLM timing run was rerun after the refactor; the contributor's original PR body still records the live LiteLLM timing proof for the same behavior.
