### PR TITLE
fix(codex): guard path-only bootstrap files [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Codex app-server: keep system-prompt reports working when bootstrap hooks provide workspace files with only a path and content, so hook-supplied SOUL/IDENTITY/TOOLS/USER context still reports injected characters correctly. (#84736) Thanks @JARVIS-Glasses.
 - WhatsApp: update Baileys to `7.0.0-rc12`.
 - Build: suppress per-locale `rolldown-plugin-dts:fake-js` CommonJS dts warnings emitted while bundling the intentionally-inlined `zod/v4/locales/*.d.cts` files, so `pnpm build` output stays readable after the 0.25.1 plugin bump. Thanks @romneyda.
 - CLI/nodes: route lazy plugin-registration logs to stderr for JSON-mode `openclaw nodes` commands so stdout stays parseable. (#84684) Thanks @TurboTheTurtle.

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -22,7 +22,9 @@ import {
   type DiagnosticEventPayload,
 } from "openclaw/plugin-sdk/diagnostic-runtime";
 import {
+  clearInternalHooks,
   initializeGlobalHookRunner,
+  registerInternalHook,
   resetGlobalHookRunner,
 } from "openclaw/plugin-sdk/hook-runtime";
 import { clearPluginCommands, registerPluginCommand } from "openclaw/plugin-sdk/plugin-runtime";
@@ -646,6 +648,7 @@ function extractRelayIdFromThreadRequest(params: unknown): string {
 
 describe("runCodexAppServerAttempt", () => {
   beforeEach(async () => {
+    clearInternalHooks();
     resetAgentEventsForTest();
     resetDiagnosticEventsForTest();
     vi.stubEnv("OPENCLAW_TRAJECTORY", "0");
@@ -663,6 +666,7 @@ describe("runCodexAppServerAttempt", () => {
     resetAgentEventsForTest();
     resetDiagnosticEventsForTest();
     resetGlobalHookRunner();
+    clearInternalHooks();
     defaultCodexAppInventoryCache.clear();
     vi.useRealTimers();
     vi.restoreAllMocks();
@@ -4823,6 +4827,43 @@ describe("runCodexAppServerAttempt", () => {
       injectedChars: agentsGuidance.length,
       truncated: false,
     });
+  });
+
+  it("reports hook-supplied bootstrap files that only expose path and content", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const soulPath = path.join(workspaceDir, "SOUL.md");
+    const soulGuidance = "Hook supplied soul guidance.";
+    await fs.mkdir(workspaceDir, { recursive: true });
+    registerInternalHook("agent:bootstrap", (event) => {
+      const context = event.context as {
+        bootstrapFiles: Array<{ content: string; missing: boolean; path: string }>;
+      };
+      context.bootstrapFiles = [
+        {
+          path: soulPath,
+          content: soulGuidance,
+          missing: false,
+        },
+      ];
+    });
+    const harness = createStartedThreadHarness();
+
+    const run = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir));
+    await harness.waitForMethod("turn/start");
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    const result = await run;
+
+    expect(result.systemPromptReport?.injectedWorkspaceFiles).toEqual([
+      expect.objectContaining({
+        name: "SOUL.md",
+        path: soulPath,
+        rawChars: soulGuidance.length,
+        injectedChars: soulGuidance.length,
+        truncated: false,
+      }),
+    ]);
   });
 
   it("points heartbeat Codex turns at HEARTBEAT.md without injecting its contents", async () => {

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -4440,12 +4440,14 @@ function buildCodexBootstrapInjectionStats(params: {
     params.developerInstructionFiles ?? [],
   );
   return params.bootstrapFiles.map((file) => {
-    const pathValue = readNonEmptyString(file.path) ?? file.name;
-    const baseName = getCodexContextFileBasename(pathValue || file.name);
+    const fileName = readNonEmptyString(file.name);
+    const pathValue = readNonEmptyString(file.path) ?? fileName ?? "";
+    const displayName = (fileName ?? getCodexContextFileDisplayBasename(pathValue)) || pathValue;
+    const baseName = getCodexContextFileBasename(pathValue || fileName || "");
     const rawChars = file.missing ? 0 : (file.content ?? "").trimEnd().length;
     const injected =
-      readCodexIndexedContextFileContent(injectedIndex, pathValue, file.name) ??
-      readCodexIndexedContextFileContent(developerInstructionIndex, pathValue, file.name);
+      readCodexIndexedContextFileContent(injectedIndex, pathValue, fileName) ??
+      readCodexIndexedContextFileContent(developerInstructionIndex, pathValue, fileName);
     let injectedChars = injected?.length ?? 0;
     let truncated = !file.missing && injectedChars < rawChars;
     if (injected === undefined) {
@@ -4458,7 +4460,7 @@ function buildCodexBootstrapInjectionStats(params: {
       }
     }
     return {
-      name: file.name,
+      name: displayName,
       path: pathValue,
       missing: file.missing,
       rawChars,
@@ -4493,13 +4495,20 @@ function indexCodexContextFileContent(files: EmbeddedContextFile[]): {
 function readCodexIndexedContextFileContent(
   index: { byPath: Map<string, string>; byBaseName: Map<string, string> },
   pathValue: string,
-  fileName: string,
+  fileName: string | undefined,
 ): string | undefined {
-  return (
-    index.byPath.get(pathValue) ??
-    index.byPath.get(fileName) ??
-    index.byBaseName.get(getCodexContextFileBasename(fileName))
-  );
+  const pathContent = index.byPath.get(pathValue);
+  if (pathContent !== undefined) {
+    return pathContent;
+  }
+  if (fileName) {
+    const nameContent = index.byPath.get(fileName);
+    if (nameContent !== undefined) {
+      return nameContent;
+    }
+  }
+  const baseName = getCodexContextFileBasename(fileName ?? pathValue);
+  return baseName ? index.byBaseName.get(baseName) : undefined;
 }
 
 function readPositiveNumber(value: unknown): number | undefined {
@@ -4703,6 +4712,10 @@ function compareCodexContextFiles(left: EmbeddedContextFile, right: EmbeddedCont
 
 function normalizeCodexContextFilePath(filePath: string): string {
   return filePath.trim().replaceAll("\\", "/").toLowerCase();
+}
+
+function getCodexContextFileDisplayBasename(filePath: string): string {
+  return filePath.trim().replaceAll("\\", "/").split("/").pop()?.trim() ?? "";
 }
 
 function getCodexContextFileBasename(filePath: string): string {


### PR DESCRIPTION
## Summary

Fixes a Codex app-server startup/reporting crash when bootstrap context files are supplied with `path` and `content` but no `name`.

The patch keeps path-based lookup first, treats the filename as optional, and derives the report display name from the path when needed.

## Why

OpenClaw can carry context files shaped like:

```json
{ "path": "/workspace/AGENTS.md", "content": "..." }
```

The Codex system prompt report path later assumed `name` was always present and could call `.trim()` through the basename helper with `undefined`.

## What changed

- Guard optional bootstrap file names in the Codex injection stats path.
- Keep lookup by full `path` before trying filename or basename lookup.
- Derive a stable display name from `path` when `name` is absent.
- Add a regression test through `runCodexAppServerAttempt()` with a hook-supplied path-only bootstrap file.

## Real behavior proof

Behavior or issue addressed: Codex app-server startup/reporting could crash while building the system prompt report when a bootstrap context file had `path` and `content` but no `name`; the failing path was `runCodexAppServerAttempt -> buildCodexSystemPromptReport -> buildCodexBootstrapInjectionStats -> readCodexIndexedContextFileContent -> getCodexContextFileBasename`.

Real environment tested: isolated Linux OpenClaw testserver clone of `openclaw/openclaw`, Node v22.22.2, pnpm 11.1.0. This was a standalone `node --import tsx` OpenClaw run outside Vitest. It used a provider-free Codex JSON-RPC stdio app-server process, no live provider credentials, no OAuth, and no secrets.

Exact steps or command run after this patch: applied the patch to the isolated OpenClaw checkout, then ran the standalone proof runner:

```text
OPENCLAW_PR84736_PROOF_MODE=after \
OPENCLAW_PR84736_EXPECT=pass \
node --import tsx .artifacts/pr84736-real-proof/proof-runner.mjs
```

Before evidence: the same standalone path-only bootstrap scenario on current main reproduced the crash before the app-server turn could start:

```text
PR84736 standalone OpenClaw Codex app-server proof
mode=before
expect=fail
runner=node --import tsx
vitest=false
appServerTransport=stdio
appServerProcess=provider-free Codex JSON-RPC stdio process
workspace=<tmp>/workspace
bootstrapFileShape={ path, content, missing }
appServerMethods=<none>
result=error
errorName=TypeError
errorMessage=Cannot read properties of undefined (reading 'trim')
stackTop=
TypeError: Cannot read properties of undefined (reading 'trim')
    at normalizeCodexContextFilePath (<repo>/extensions/codex/src/app-server/run-attempt.ts:4705:19)
    at getCodexContextFileBasename (<repo>/extensions/codex/src/app-server/run-attempt.ts:4709:10)
    at readCodexIndexedContextFileContent (<repo>/extensions/codex/src/app-server/run-attempt.ts:4501:26)
    at buildCodexBootstrapInjectionStats (<repo>/extensions/codex/src/app-server/run-attempt.ts:4442:32)
    at buildCodexSystemPromptReport (<repo>/extensions/codex/src/app-server/run-attempt.ts:4366:29)
```

After-fix evidence: copied live terminal output from the same standalone setup after the patch:

```text
PR84736 standalone OpenClaw Codex app-server proof
mode=after
expect=pass
runner=node --import tsx
vitest=false
appServerTransport=stdio
appServerProcess=provider-free Codex JSON-RPC stdio process
workspace=<tmp>/workspace
bootstrapFileShape={ path, content, missing }
[agent/embedded] codex plugin thread config eligibility
appServerMethods=initialize -> initialized -> thread/start -> turn/start
result=success
assistantTextCount=0
reportedFile={"name":"SOUL.md","path":"<tmp>/workspace/SOUL.md","rawChars":50,"injectedChars":50,"truncated":false}
basenameFromPath=true
```

Observed result after fix: the Codex app-server attempt no longer calls the basename helper with `undefined`; the app-server reaches `turn/start`, and the system prompt report emits `SOUL.md` from the path-only bootstrap file with matching raw and injected character counts.

What was not tested: no live provider request, OAuth flow, routing, or config-shape behavior was changed or tested. The broader generic `/context` unnamed-bootstrap display fallback remains separate in https://github.com/openclaw/openclaw/issues/47941 and https://github.com/openclaw/openclaw/pull/48021.

## Additional validation

Focused regression:

```text
node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts --run --testNamePattern "reports hook-supplied bootstrap files"
1 passed | 185 skipped
```

Focused suite:

```text
node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts src/agents/bootstrap-hooks.test.ts src/agents/bootstrap-files.test.ts src/agents/pi-embedded-helpers.buildbootstrapcontextfiles.test.ts
6 files / 301 tests passed
```

Other checks:

```text
node_modules/.bin/oxfmt --check --threads=1 extensions/codex/src/app-server/run-attempt.ts extensions/codex/src/app-server/run-attempt.test.ts
passed

git diff --check
passed

node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo
passed

node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo
passed

node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/codex/src/app-server/run-attempt.ts extensions/codex/src/app-server/run-attempt.test.ts
0 warnings / 0 errors

pnpm check:changed
passed
```

## Notes

No provider, OAuth, routing, config-shape, or fallback behavior is changed.
