### PR TITLE
fix(update): avoid broad tag fetches for dev updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/update: avoid fetching unrelated tags during dev-channel git updates so moved release tags do not block branch-based updates. (#84737) Thanks @rubencu.
 - MiniMax: store OAuth token expiry as an absolute millisecond timestamp so OAuth profiles no longer appear expired on every request. (#83480) Thanks @NianJiuZst.
 - Agents/Anthropic: strip missing or blank thinking signatures for signed-thinking providers even when recovery supplies a narrow replay policy without signature preservation. Fixes #84430. (#84448) Thanks @NianJiuZst.
 - Agents/channels: send a visible notice when an aborted main session cannot be resumed after restart, including Telegram group targets. (#85805) Thanks @pfrederiksen.

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -386,7 +386,7 @@ describe("runGatewayUpdate", () => {
     { name: "target ref", options: { devTargetRef: "main" } },
   ] as const)("stops dev update when fetch fails before resolving $name", async ({ options }) => {
     await setupGitCheckout();
-    const fetchCommand = `git -C ${tempDir} fetch --all --prune --tags`;
+    const fetchCommand = `git -C ${tempDir} fetch --all --prune --no-tags`;
     const { runner, calls } = createRunner({
       ...buildGitWorktreeProbeResponses(),
       [fetchCommand]: {
@@ -401,6 +401,102 @@ describe("runGatewayUpdate", () => {
     expect(result.reason).toBe("fetch-failed");
     expect(calls).toContain(fetchCommand);
     expect(calls.slice(calls.indexOf(fetchCommand) + 1)).toStrictEqual([]);
+  });
+
+  it("does not fetch tags for dev updates", async () => {
+    await setupGitPackageManagerFixture();
+    const upstreamSha = "upstream123";
+    const doctorNodePath = await resolveStableNodePath(process.execPath);
+    const doctorCommand = `${doctorNodePath} ${path.join(tempDir, "openclaw.mjs")} doctor --non-interactive --fix`;
+    const { runner, calls } = createRunner({
+      ...buildGitWorktreeProbeResponses(),
+      [`git -C ${tempDir} fetch --all --prune --no-tags`]: { stdout: "" },
+      [`git -C ${tempDir} rev-parse --abbrev-ref --symbolic-full-name @{upstream}`]: {
+        stdout: "origin/main",
+      },
+      [`git -C ${tempDir} rev-parse @{upstream}`]: { stdout: upstreamSha },
+      [`git -C ${tempDir} rev-list --max-count=10 ${upstreamSha}`]: {
+        stdout: `${upstreamSha}\n`,
+      },
+      [`git -C ${tempDir} rebase ${upstreamSha}`]: { stdout: "" },
+      "pnpm --version": { stdout: "10.0.0" },
+      "pnpm install": { stdout: "" },
+      "pnpm build": { stdout: "" },
+      "pnpm ui:build": { stdout: "" },
+      [doctorCommand]: { stdout: "" },
+    });
+
+    const result = await runWithRunner(runner, { channel: "dev" });
+
+    expect(result.status).toBe("ok");
+    expect(calls).toContain(`git -C ${tempDir} fetch --all --prune --no-tags`);
+    expect(calls).not.toContain(`git -C ${tempDir} fetch --all --prune --tags`);
+  });
+
+  it("fetches only the requested tag for explicit dev tag target refs", async () => {
+    await setupGitPackageManagerFixture();
+    const targetSha = "2222222222222222222222222222222222222222";
+    const doctorNodePath = await resolveStableNodePath(process.execPath);
+    const doctorCommand = `${doctorNodePath} ${path.join(tempDir, "openclaw.mjs")} doctor --non-interactive --fix`;
+    const { runner, calls } = createRunner({
+      ...buildGitWorktreeProbeResponses(),
+      [`git -C ${tempDir} fetch --all --prune --no-tags`]: { stdout: "" },
+      [`git -C ${tempDir} remote`]: { stdout: "origin\n" },
+      [`git -C ${tempDir} fetch origin +refs/tags/v2026.5.19-beta.2:refs/tags/v2026.5.19-beta.2`]: {
+        stdout: "",
+      },
+      [`git -C ${tempDir} rev-parse refs/tags/v2026.5.19-beta.2^{}`]: {
+        stdout: `${targetSha}\n`,
+      },
+      [`git -C ${tempDir} rev-list --max-count=10 ${targetSha}`]: {
+        stdout: `${targetSha}\n`,
+      },
+      [`git -C ${tempDir} checkout --detach ${targetSha}`]: { stdout: "" },
+      "pnpm --version": { stdout: "10.0.0" },
+      "pnpm install": { stdout: "" },
+      "pnpm build": { stdout: "" },
+      "pnpm ui:build": { stdout: "" },
+      [doctorCommand]: { stdout: "" },
+    });
+
+    const result = await runWithRunner(runner, {
+      channel: "dev",
+      devTargetRef: "refs/tags/v2026.5.19-beta.2",
+    });
+
+    expect(result.status).toBe("ok");
+    expect(calls).toContain(`git -C ${tempDir} fetch --all --prune --no-tags`);
+    expect(calls).not.toContain(`git -C ${tempDir} fetch --all --prune --tags`);
+    expect(calls).toContain(
+      `git -C ${tempDir} fetch origin +refs/tags/v2026.5.19-beta.2:refs/tags/v2026.5.19-beta.2`,
+    );
+    expect(calls).toContain(`git -C ${tempDir} rev-parse refs/tags/v2026.5.19-beta.2^{}`);
+  });
+
+  it("does not resolve stale local dev tag target refs after targeted tag fetch failure", async () => {
+    await setupGitCheckout();
+    const { runner, calls } = createRunner({
+      ...buildGitWorktreeProbeResponses(),
+      [`git -C ${tempDir} fetch --all --prune --no-tags`]: { stdout: "" },
+      [`git -C ${tempDir} remote`]: { stdout: "origin\n" },
+      [`git -C ${tempDir} fetch origin +refs/tags/v2026.5.19-beta.2:refs/tags/v2026.5.19-beta.2`]: {
+        code: 1,
+        stderr: "would clobber existing tag",
+      },
+    });
+
+    const result = await runWithRunner(runner, {
+      channel: "dev",
+      devTargetRef: "refs/tags/v2026.5.19-beta.2",
+    });
+
+    expect(result.status).toBe("error");
+    expect(result.reason).toBe("no-target-sha");
+    expect(calls).toContain(
+      `git -C ${tempDir} fetch origin +refs/tags/v2026.5.19-beta.2:refs/tags/v2026.5.19-beta.2`,
+    );
+    expect(calls).not.toContain(`git -C ${tempDir} rev-parse refs/tags/v2026.5.19-beta.2^{}`);
+    expect(calls).not.toContain(`git -C ${tempDir} rev-parse refs/tags/v2026.5.19-beta.2`);
   });
 
   it("aborts rebase on failure", async () => {
@@ -537,7 +633,7 @@ describe("runGatewayUpdate", () => {
       if (key === `git -C ${tempDir} rev-parse --abbrev-ref --symbolic-full-name @{upstream}`) {
         return { stdout: "origin/main", stderr: "", code: 0 };
       }
-      if (key === `git -C ${tempDir} fetch --all --prune --tags`) {
+      if (key === `git -C ${tempDir} fetch --all --prune --no-tags`) {
         return { stdout: "", stderr: "", code: 0 };
       }
       if (key === `git -C ${tempDir} rev-parse @{upstream}`) {
@@ -758,7 +854,7 @@ describe("runGatewayUpdate", () => {
       if (key === `git -C ${tempDir} rev-parse --abbrev-ref --symbolic-full-name @{upstream}`) {
         return { stdout: "origin/main", stderr: "", code: 0 };
       }
-      if (key === `git -C ${tempDir} fetch --all --prune --tags`) {
+      if (key === `git -C ${tempDir} fetch --all --prune --no-tags`) {
         return { stdout: "", stderr: "", code: 0 };
       }
       if (key === `git -C ${tempDir} rev-parse @{upstream}`) {
@@ -873,7 +969,7 @@ describe("runGatewayUpdate", () => {
       if (key === `git -C ${tempDir} rev-parse --abbrev-ref --symbolic-full-name @{upstream}`) {
         return { stdout: "origin/main", stderr: "", code: 0 };
       }
-      if (key === `git -C ${tempDir} fetch --all --prune --tags`) {
+      if (key === `git -C ${tempDir} fetch --all --prune --no-tags`) {
         return { stdout: "", stderr: "", code: 0 };
       }
       if (key === `git -C ${tempDir} rev-parse @{upstream}`) {
@@ -970,7 +1066,7 @@ describe("runGatewayUpdate", () => {
         if (key === `git -C ${tempDir} rev-parse --abbrev-ref --symbolic-full-name @{upstream}`) {
           return { stdout: "origin/main", stderr: "", code: 0 };
         }
-        if (key === `git -C ${tempDir} fetch --all --prune --tags`) {
+        if (key === `git -C ${tempDir} fetch --all --prune --no-tags`) {
           return { stdout: "", stderr: "", code: 0 };
         }
         if (key === `git -C ${tempDir} rev-parse @{upstream}`) {
@@ -1084,7 +1180,7 @@ describe("runGatewayUpdate", () => {
         if (key === `git -C ${tempDir} rev-parse --abbrev-ref --symbolic-full-name @{upstream}`) {
           return { stdout: "origin/main", stderr: "", code: 0 };
         }
-        if (key === `git -C ${tempDir} fetch --all --prune --tags`) {
+        if (key === `git -C ${tempDir} fetch --all --prune --no-tags`) {
           return { stdout: "", stderr: "", code: 0 };
         }
         if (key === `git -C ${tempDir} rev-parse @{upstream}`) {
@@ -1182,7 +1278,7 @@ describe("runGatewayUpdate", () => {
       if (key === `git -C ${tempDir} rev-parse --abbrev-ref --symbolic-full-name @{upstream}`) {
         return { stdout: "origin/main", stderr: "", code: 0 };
       }
-      if (key === `git -C ${tempDir} fetch --all --prune --tags`) {
+      if (key === `git -C ${tempDir} fetch --all --prune --no-tags`) {
         return { stdout: "", stderr: "", code: 0 };
       }
       if (key === `git -C ${tempDir} rev-parse @{upstream}`) {
@@ -1275,7 +1371,7 @@ describe("runGatewayUpdate", () => {
       if (key === `git -C ${tempDir} rev-parse --abbrev-ref --symbolic-full-name @{upstream}`) {
         return { stdout: "origin/main", stderr: "", code: 0 };
       }
-      if (key === `git -C ${tempDir} fetch --all --prune --tags`) {
+      if (key === `git -C ${tempDir} fetch --all --prune --no-tags`) {
         return { stdout: "", stderr: "", code: 0 };
       }
       if (key === `git -C ${tempDir} rev-parse @{upstream}`) {
@@ -1367,7 +1463,7 @@ describe("runGatewayUpdate", () => {
       if (key === `git -C ${tempDir} status --porcelain -- :!dist/control-ui/`) {
         return { stdout: "", stderr: "", code: 0 };
       }
-      if (key === `git -C ${tempDir} fetch --all --prune --tags`) {
+      if (key === `git -C ${tempDir} fetch --all --prune --no-tags`) {
         return { stdout: "", stderr: "", code: 0 };
       }
       if (key === `git -C ${tempDir} rev-parse ${targetSha}`) {
@@ -1447,7 +1543,7 @@ describe("runGatewayUpdate", () => {
       if (key === `git -C ${tempDir} status --porcelain -- :!dist/control-ui/`) {
         return { stdout: "", stderr: "", code: 0 };
       }
-      if (key === `git -C ${tempDir} fetch --all --prune --tags`) {
+      if (key === `git -C ${tempDir} fetch --all --prune --no-tags`) {
         return { stdout: "", stderr: "", code: 0 };
       }
       if (key === `git -C ${tempDir} rev-parse refs/remotes/origin/main`) {
@@ -1530,7 +1626,7 @@ describe("runGatewayUpdate", () => {
       if (key === `git -C ${gitRoot} status --porcelain -- :!dist/control-ui/`) {
         return { stdout: "", stderr: "", code: 0 };
       }
-      if (key === `git -C ${gitRoot} fetch --all --prune --tags`) {
+      if (key === `git -C ${gitRoot} fetch --all --prune --no-tags`) {
         return { stdout: "", stderr: "", code: 0 };
       }
       if (key === `git -C ${gitRoot} rev-parse refs/remotes/origin/main`) {
@@ -1606,7 +1702,7 @@ describe("runGatewayUpdate", () => {
       if (key === `git -C ${tempDir} rev-parse --abbrev-ref --symbolic-full-name @{upstream}`) {
         return { stdout: "origin/main", stderr: "", code: 0 };
       }
-      if (key === `git -C ${tempDir} fetch --all --prune --tags`) {
+      if (key === `git -C ${tempDir} fetch --all --prune --no-tags`) {
         return { stdout: "", stderr: "", code: 0 };
       }
       if (key === `git -C ${tempDir} rev-parse @{upstream}`) {

--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -442,6 +442,11 @@ function looksLikeFullCommitSha(value: string): boolean {
   return /^[0-9a-f]{40}$/i.test(value.trim());
 }
 
+function resolveTagFetchRef(candidate: string): string | null {
+  const ref = candidate.endsWith("^{}") ? candidate.slice(0, -"^{}".length) : candidate;
+  return ref.startsWith("refs/tags/") ? ref : null;
+}
+
 function buildDevTargetRefResolutionCandidates(devTargetRef: string): string[] {
   const trimmed = devTargetRef.trim();
   const candidates: string[] = [];
@@ -573,7 +578,26 @@ function isSupersededInstallFailure(
 }
 
 function findBlockingGitFailure(steps: readonly UpdateStepResult[]): UpdateStepResult | undefined {
-  return steps.find((step) => step.exitCode !== 0 && !isSupersededInstallFailure(step, steps));
+  return steps.find(
+    (step, index) =>
+      step.exitCode !== 0 &&
+      !isSupersededInstallFailure(step, steps) &&
+      !isSupersededTargetRefFailure(step, steps.slice(index + 1)),
+  );
+}
+
+function isSupersededTargetRefFailure(
+  step: UpdateStepResult,
+  followingSteps: readonly UpdateStepResult[],
+): boolean {
+  const isTargetRefProbe = step.name.startsWith("git rev-parse ");
+  const isTargetTagFetch = step.name.startsWith("git fetch ") && step.name.includes(" refs/tags/");
+  if (!isTargetRefProbe && !isTargetTagFetch) {
+    return false;
+  }
+  return followingSteps.some(
+    (candidate) => candidate.name.startsWith("git rev-parse ") && candidate.exitCode === 0,
+  );
 }
 
 function mergeCommandEnvironments(
@@ -876,7 +900,7 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
 
       const fetchFailure = await runRequiredGitStep(
         "git fetch",
-        ["git", "-C", gitRoot, "fetch", "--all", "--prune", "--tags"],
+        ["git", "-C", gitRoot, "fetch", "--all", "--prune", "--no-tags"],
         "fetch-failed",
       );
       if (fetchFailure) {
@@ -887,6 +911,35 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
       if (devTargetRef) {
         let targetSha: string | null = null;
         for (const targetRefCandidate of buildDevTargetRefResolutionCandidates(devTargetRef)) {
+          const tagFetchRef = resolveTagFetchRef(targetRefCandidate);
+          if (tagFetchRef) {
+            const remoteListStep = await runStep(
+              step("git remote", ["git", "-C", gitRoot, "remote"], gitRoot),
+            );
+            steps.push(remoteListStep);
+            const remotes = (remoteListStep.stdoutTail ?? "")
+              .split("\n")
+              .map((line) => line.trim())
+              .filter(Boolean);
+            let fetchedTag = false;
+            for (const remote of remotes) {
+              const targetTagFetchStep = await runStep(
+                step(
+                  `git fetch ${remote} ${tagFetchRef}`,
+                  ["git", "-C", gitRoot, "fetch", remote, `+${tagFetchRef}:${tagFetchRef}`],
+                  gitRoot,
+                ),
+              );
+              steps.push(targetTagFetchStep);
+              if (targetTagFetchStep.exitCode === 0) {
+                fetchedTag = true;
+                break;
+              }
+            }
+            if (remotes.length > 0 && !fetchedTag) {
+              continue;
+            }
+          }
           const targetShaStep = await runStep(
             step(
               `git rev-parse ${targetRefCandidate}`,


### PR DESCRIPTION
## Summary

- Problem: `openclaw update --channel dev` could fail before updating `main` when a release tag on the remote conflicted with an existing local tag.
- Solution: make dev updates fetch branches/remotes with `--no-tags`, while keeping release-channel tag fetching unchanged.
- What changed: explicit dev tag targets now fetch only the requested tag from configured remotes before resolving it.
- What did NOT change (scope boundary): stable/beta updates remain tag-driven and still fetch tags broadly.

## Motivation

- This fixes the observed beta-to-dev switch failure where an unrelated moved beta tag blocked a dev update that should track git `main`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `openclaw update --channel dev` no longer performs a broad tag fetch that can fail on unrelated moved release tags before updating from `main`.
- Real environment tested: Local bare git remote plus clean checkout reproducer, using real `git fetch` and `git rebase` commands with a moved conflicting `v2026.5.19-beta.2` tag.
- Exact steps or command run after this patch: Created a local bare remote, cloned it, moved the remote beta tag, confirmed current-main-style `git fetch --all --prune --tags` fails, then confirmed PR-style `git fetch --all --prune --no-tags` followed by `git rebase origin/main` succeeds.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
proof_root=<temp-redacted>

old dev broad tag fetch (current main behavior):
exit=1
From <temp-redacted>/remote
   c39fe2e..63b8b7c  main              -> origin/main
 ! [rejected]        v2026.5.19-beta.2 -> v2026.5.19-beta.2  (would clobber existing tag)

reset checkout to before proof fetch:
clean_status=0

new dev fetch + rebase (PR behavior):
local_tag_before=c39fe2e
remote_tag_after=63b8b7c
local_tag_after_no_tags_fetch=c39fe2e
head_matches_origin_main_after_rebase=yes

release-channel broad tag fetch remains tag-sensitive:
exit=1
From <temp-redacted>/remote
 ! [rejected]        v2026.5.19-beta.2 -> v2026.5.19-beta.2  (would clobber existing tag)
```

Supplemental focused test proof:

```text
node scripts/run-vitest.mjs src/infra/update-runner.test.ts
Test Files 1 passed (1)
Tests 46 passed (46)
```

- Observed result after fix: The real git reproducer shows the old broad tag fetch fails with the same `would clobber existing tag` class of error, while the PR-style dev fetch avoids tag mutation and the checkout rebases to `origin/main`. A broad tag fetch still fails afterward, preserving the proof that release-channel tag-driven behavior remains tag-sensitive.
- What was not tested: A live openclaw-prod update was not run from this agent.
- Before evidence (optional but encouraged): User-reported failure showed `openclaw update --channel dev` rejected `v2026.5.19-beta.2` during broad tag fetch with `would clobber existing tag`.

## Root Cause (if applicable)

- Root cause: Dev updates used the same broad tag-fetch behavior as release-channel updates even though dev is branch/main based.
- Missing detection / guardrail: Tests covered dev update fetch failures but did not assert that dev avoids broad tag fetching.
- Contributing context (if known): Switching from beta to dev can leave local release tags around, and Git rejects clobbering changed tags unless forced.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/infra/update-runner.test.ts`
- Scenario the test should lock in: Dev updates fetch with `--no-tags`; explicit dev tag targets fetch only the requested tag; failed targeted tag fetches do not fall back to stale local tags.
- Why this is the smallest reliable guardrail: The update runner already injects the git command runner, so these tests verify the exact command contract without needing a mutable remote fixture.
- Existing test that already covers this (if any): Existing dev update tests covered fetch sequencing but not the tag-fetch mode.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

`openclaw update --channel dev` now ignores unrelated remote tags during the normal branch update path. Explicit dev tag targets still fetch the requested tag.

## Diagram (if applicable)

```text
Before:
openclaw update --channel dev -> git fetch --all --prune --tags -> unrelated tag conflict -> update fails

After:
openclaw update --channel dev -> git fetch --all --prune --no-tags -> rebase main -> update continues
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: The git fetch command changes for dev updates only. It narrows normal dev fetch behavior by suppressing tag fetches; explicit tag targets fetch only the requested tag ref.

## Repro + Verification

### Environment

- OS: Linux worktree
- Runtime/container: Node via repo test wrapper; local git bare remote proof
- Model/provider: N/A
- Integration/channel (if any): update CLI git mode
- Relevant config (redacted): N/A

### Steps

1. Create a local bare git remote and clone it.
2. Create local tag `v2026.5.19-beta.2`, then move the remote tag to a newer commit.
3. Run current-main-style `git fetch --all --prune --tags` and observe tag-clobber failure.
4. Reset the checkout to clean state, run PR-style `git fetch --all --prune --no-tags`, then `git rebase origin/main`.
5. Run `node scripts/run-vitest.mjs src/infra/update-runner.test.ts`.

### Expected

- Current-main-style broad tag fetch fails on the moved tag.
- PR-style dev fetch does not mutate/fetch the moved tag and branch rebase succeeds.
- Stable/beta paths continue to use tag fetching.
- Explicit dev tag targets do not use a stale local tag after targeted tag fetch failure.

### Actual

- Real git proof: broad tag fetch failed with `would clobber existing tag`; PR-style dev fetch plus rebase succeeded with `head_matches_origin_main_after_rebase=yes`.
- `src/infra/update-runner.test.ts` passed 46/46.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: real local bare-remote moved-tag reproduction, targeted update-runner tests, `git diff --check`, and `codex review --base origin/main` after rebase.
- Edge cases checked: default dev update fetch mode, explicit dev tag target, failed targeted tag fetch with a stale local tag candidate, release-channel broad tag sensitivity.
- What you did **not** verify: live update on openclaw-prod.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Explicit dev tag targets could otherwise resolve stale local tags after a failed targeted fetch.
  - Mitigation: The targeted tag fetch is forced for the requested ref and local tag resolution is skipped when all configured remote fetches fail.