### PR TITLE
Stop writing plaintext provider keys to models.json

### DIFF
--- a/src/agents/models-config.merge.test.ts
+++ b/src/agents/models-config.merge.test.ts
@@ -180,7 +180,7 @@ describe("models-config merge helpers", () => {
     expect(merged["custom-proxy"]?.baseUrl).toBe("http://localhost:4000/v1");
   });
 
-  it("preserves non-empty existing apiKey and baseUrl from models.json", () => {
+  it("drops non-empty existing apiKey while preserving baseUrl from models.json", () => {
     const merged = mergeWithExistingProviderSecrets({
       nextProviders: {
         custom: createConfigProvider(),
@@ -191,7 +191,7 @@ describe("models-config merge helpers", () => {
       secretRefManagedProviders: new Set<string>(),
     });
 
-    expect(merged.custom?.apiKey).toBe(preservedApiKey);
+    expect(merged.custom?.apiKey).toBe(configApiKey);
     expect(merged.custom?.baseUrl).toBe("https://agent.example/v1");
   });
 
@@ -209,7 +209,7 @@ describe("models-config merge helpers", () => {
       secretRefManagedProviders: new Set<string>(),
     });
 
-    expect(merged.custom?.apiKey).toBe(preservedApiKey);
+    expect(merged.custom?.apiKey).toBe(configApiKey);
     expect(merged.custom?.baseUrl).toBe("https://agent.example/v1");
   });
 
@@ -267,7 +267,7 @@ describe("models-config merge helpers", () => {
       secretRefManagedProviders: new Set<string>(),
     });
 
-    expect(merged.custom?.apiKey).toBe(preservedApiKey);
+    expect(merged.custom?.apiKey).toBeUndefined();
     expect(merged.custom?.baseUrl).toBe("https://config.example/v1");
   });
 
@@ -289,7 +289,7 @@ describe("models-config merge helpers", () => {
       secretRefManagedProviders: new Set<string>(),
     });
 
-    expect(merged.custom?.apiKey).toBe(preservedApiKey);
+    expect(merged.custom?.apiKey).toBe(configApiKey);
     expect(merged.custom?.baseUrl).toBe("https://config.example/v1");
   });
 

--- a/src/agents/models-config.merge.ts
+++ b/src/agents/models-config.merge.ts
@@ -1,5 +1,4 @@
 import { normalizeOptionalString } from "../shared/string-coerce.js";
-import { isNonSecretApiKeyMarker } from "./model-auth-markers.js";
 import type { ProviderConfig } from "./models-config.providers.secrets.js";
 
 export type ExistingProviderConfig = ProviderConfig & {
@@ -179,25 +178,6 @@ function resolveProviderApiSurface(
   return resolveProviderApi(entry) ?? resolveModelApiSurface(entry);
 }
 
-function shouldPreserveExistingApiKey(params: {
-  providerKey: string;
-  existing: ExistingProviderConfig;
-  nextEntry: ProviderConfig;
-  secretRefManagedProviders: ReadonlySet<string>;
-}): boolean {
-  const { providerKey, existing, nextEntry, secretRefManagedProviders } = params;
-  const nextApiKey = typeof nextEntry.apiKey === "string" ? nextEntry.apiKey : "";
-  if (nextApiKey && isNonSecretApiKeyMarker(nextApiKey)) {
-    return false;
-  }
-  return (
-    !secretRefManagedProviders.has(providerKey) &&
-    typeof existing.apiKey === "string" &&
-    existing.apiKey.length > 0 &&
-    !isNonSecretApiKeyMarker(existing.apiKey, { includeEnvVarName: false })
-  );
-}
-
 function shouldPreserveExistingBaseUrl(params: {
   existing: ExistingProviderConfig;
   nextEntry: ProviderConfig;
@@ -217,7 +197,7 @@ export function mergeWithExistingProviderSecrets(params: {
   existingProviders: Record<string, ExistingProviderConfig>;
   secretRefManagedProviders: ReadonlySet<string>;
 }): Record<string, ProviderConfig> {
-  const { nextProviders, existingProviders, secretRefManagedProviders } = params;
+  const { nextProviders, existingProviders } = params;
   const mergedProviders: Record<string, ProviderConfig> = {};
   for (const [key, entry] of Object.entries(existingProviders)) {
     mergedProviders[key] = entry;
@@ -229,16 +209,6 @@ export function mergeWithExistingProviderSecrets(params: {
       continue;
     }
     const preserved: Record<string, unknown> = {};
-    if (
-      shouldPreserveExistingApiKey({
-        providerKey: key,
-        existing,
-        nextEntry: newEntry,
-        secretRefManagedProviders,
-      })
-    ) {
-      preserved.apiKey = existing.apiKey;
-    }
     if (
       shouldPreserveExistingBaseUrl({
         existing,

--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import { isRecord } from "../utils.js";
+import { isNonSecretApiKeyMarker } from "./model-auth-markers.js";
 import {
   mergeProviders,
   mergeWithExistingProviderSecrets,
@@ -105,6 +106,24 @@ function resolveProvidersForMode(params: {
   });
 }
 
+function stripPlaintextApiKeys(
+  providers: Record<string, ProviderConfig>,
+): Record<string, ProviderConfig> {
+  let mutated = false;
+  const sanitized: Record<string, ProviderConfig> = {};
+  for (const [key, provider] of Object.entries(providers)) {
+    const apiKey = provider.apiKey;
+    if (typeof apiKey === "string" && apiKey.trim() && !isNonSecretApiKeyMarker(apiKey)) {
+      const { apiKey: _apiKey, ...rest } = provider;
+      sanitized[key] = rest as ProviderConfig;
+      mutated = true;
+      continue;
+    }
+    sanitized[key] = provider;
+  }
+  return mutated ? sanitized : providers;
+}
+
 export async function planOpenClawModelsJsonWithDeps(
   params: {
     cfg: OpenClawConfig;
@@ -177,7 +196,8 @@ export async function planOpenClawModelsJsonWithDeps(
       sourceSecretDefaults: params.sourceConfigForSecrets?.secrets?.defaults,
       secretRefManagedProviders,
     }) ?? normalizedMergedProviders;
-  const finalProviders = applyNativeStreamingUsageCompat(secretEnforcedProviders);
+  const streamingCompatProviders = applyNativeStreamingUsageCompat(secretEnforcedProviders);
+  const finalProviders = stripPlaintextApiKeys(streamingCompatProviders);
   const nextContents = `${JSON.stringify({ providers: finalProviders }, null, 2)}\n`;
 
   if (params.existingRaw === nextContents) {

--- a/src/agents/models-config.providers.normalize-keys.test.ts
+++ b/src/agents/models-config.providers.normalize-keys.test.ts
@@ -318,6 +318,46 @@ describe("normalizeProviders", () => {
     }
   });
 
+  it("does not persist plaintext auth profile keys into provider config", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-agent-"));
+    try {
+      await fs.writeFile(
+        path.join(agentDir, "auth-profiles.json"),
+        `${JSON.stringify(
+          {
+            version: 1,
+            profiles: {
+              "openai:default": {
+                type: "api_key",
+                provider: "openai",
+                key: "sk-profile-plaintext-value",
+              },
+            },
+          },
+          null,
+          2,
+        )}\n`,
+        "utf8",
+      );
+
+      const normalized = normalizeProviders({
+        providers: {
+          openai: {
+            baseUrl: "https://api.openai.com/v1",
+            api: "openai-completions",
+            models: [createModel()],
+          },
+        },
+        agentDir,
+        env: {},
+      });
+
+      expect(normalized?.openai?.apiKey).toBeUndefined();
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
   it("normalizes SecretRef-backed provider headers to non-secret marker values", async () => {
     const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-agent-"));
     try {

--- a/src/agents/models-config.providers.secret-helpers.ts
+++ b/src/agents/models-config.providers.secret-helpers.ts
@@ -306,7 +306,9 @@ export function resolveMissingProviderApiKey(params: {
   }
 
   const fromEnv = resolveEnvApiKeyVarName(params.providerKey, params.env);
-  const apiKey = fromEnv ?? params.profileApiKey?.apiKey;
+  const profileApiKey =
+    params.profileApiKey?.source === "plaintext" ? undefined : params.profileApiKey?.apiKey;
+  const apiKey = fromEnv ?? profileApiKey;
   if (!apiKey?.trim()) {
     return params.provider;
   }

--- a/src/agents/models-config.runtime-source-snapshot.test.ts
+++ b/src/agents/models-config.runtime-source-snapshot.test.ts
@@ -362,4 +362,31 @@ describe("models-config runtime source snapshot", () => {
     expect(providers.openai?.apiKey).toBe("OPENAI_API_KEY"); // pragma: allowlist secret
     expectOpenAiHeaderMarkers(providers);
   });
+
+  it("strips plaintext api keys from planned models.json output", async () => {
+    const providers = await planGeneratedProviders({
+      config: {
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://api.openai.com/v1",
+              apiKey: "sk-inline-runtime-value",
+              api: "openai-completions" as const,
+              models: [],
+            },
+            moonshot: {
+              baseUrl: "https://api.moonshot.ai/v1",
+              apiKey: NON_ENV_SECRETREF_MARKER,
+              api: "openai-completions" as const,
+              models: [],
+            },
+          },
+        },
+      },
+      sourceConfigForSecrets: {},
+    });
+
+    expect(providers.openai?.apiKey).toBeUndefined();
+    expect(providers.moonshot?.apiKey).toBe(NON_ENV_SECRETREF_MARKER);
+  });
 });


### PR DESCRIPTION
## Summary

- Stop preserving stale plaintext provider `apiKey` values from existing `models.json` during merge-mode regeneration.
- Strip plaintext provider keys at the final `models.json` serialization boundary while preserving env, SecretRef, OAuth, AWS, and local non-secret markers.
- Avoid projecting plaintext auth-profile keys into generated provider config; runtime auth can still resolve credentials through the auth profile store.

Fixes #11829.

## Verification

- `pnpm install --frozen-lockfile`
- `node scripts/run-vitest.mjs src/agents/models-config.merge.test.ts`
- `node scripts/run-vitest.mjs src/agents/models-config.providers.normalize-keys.test.ts`
- `node scripts/run-vitest.mjs src/agents/models-config.runtime-source-snapshot.test.ts`
- `node scripts/run-vitest.mjs src/agents/models-config.applies-config-env-vars.test.ts`
- `node scripts/run-vitest.mjs src/agents/models-config.skips-writing-models-json-no-env-token.test.ts`
- `pnpm exec oxfmt --check src/agents/models-config.merge.ts src/agents/models-config.providers.secret-helpers.ts src/agents/models-config.plan.ts src/agents/models-config.merge.test.ts src/agents/models-config.providers.normalize-keys.test.ts src/agents/models-config.runtime-source-snapshot.test.ts`
- `git diff --check`
- `pnpm lint:core`

## Real behavior proof

Behavior addressed: generated `models.json` no longer writes raw provider API key strings where prompt-facing model config can expose them to agents.

Real environment tested: local macOS checkout with the repository lockfile installed via `pnpm install --frozen-lockfile`.

Exact steps or command run after this patch: I ran a live `ensureOpenClawModelsJson` invocation against a temporary agent directory that already contained a merge-mode `models.json` row with a stale plaintext value, then regenerated it with a runtime plaintext value and a SecretRef-managed provider.

Evidence after fix:

```json
{
  "wrote": true,
  "openaiApiKeyPresent": false,
  "moonshotApiKey": "secretref-managed",
  "stalePlaintextPresent": false,
  "runtimePlaintextPresent": false,
  "openaiBaseUrl": "https://stale.example/v1",
  "providers": [
    "moonshot",
    "openai"
  ]
}
```

Observed result after fix: the generated file omitted the plaintext OpenAI provider key, removed the stale plaintext key from the previous `models.json`, preserved the non-secret SecretRef marker for Moonshot, and kept the merge-mode baseUrl behavior intact. All listed tests passed, formatting passed, `git diff --check` passed, and `pnpm lint:core` reported 0 warnings and 0 errors.

What was not tested: full end-to-end provider calls with real API credentials were not run; this patch only changes the generated `models.json` persistence boundary and keeps runtime credential resolution on existing env/profile/config paths.
