### PR TITLE
Avoid serializing provider API keys into models.json

### DIFF
--- a/src/agents/models-config.applies-config-env-vars.test.ts
+++ b/src/agents/models-config.applies-config-env-vars.test.ts
@@ -246,6 +246,56 @@ describe("models-config", () => {
     ]);
   });
 
+  it("does not serialize provider apiKey values into models.json", async () => {
+    const plan = await planOpenClawModelsJsonWithDeps(
+      {
+        cfg: {
+          models: {
+            providers: {
+              custom: {
+                baseUrl: "https://custom.example/v1",
+                api: "openai-completions",
+                apiKey: "literal-test-key",
+                models: [],
+              },
+              openai: {
+                baseUrl: "https://api.openai.com/v1",
+                api: "openai-responses",
+                apiKey: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+                models: [],
+              },
+            },
+          },
+        },
+        agentDir: "/tmp/openclaw-models-config-env-vars-test",
+        env: { OPENAI_API_KEY: "resolved-openai-key" } as NodeJS.ProcessEnv,
+        existingRaw: "",
+        existingParsed: null,
+      },
+      {
+        resolveImplicitProviders: async () => ({
+          implicit: {
+            baseUrl: "https://implicit.example/v1",
+            api: "openai-completions",
+            apiKey: "IMPLICIT_API_KEY",
+            models: [],
+          },
+        }),
+      },
+    );
+
+    expect(plan.action).toBe("write");
+    if (plan.action !== "write") {
+      throw new Error("Expected models.json write plan");
+    }
+    const parsed = JSON.parse(plan.contents) as {
+      providers?: Record<string, { apiKey?: unknown }>;
+    };
+    expect(parsed.providers?.custom).not.toHaveProperty("apiKey");
+    expect(parsed.providers?.openai).not.toHaveProperty("apiKey");
+    expect(parsed.providers?.implicit).not.toHaveProperty("apiKey");
+  });
+
   it("uses config env.vars entries for implicit provider discovery without mutating process.env", async () => {
     await withTempEnv(["OPENROUTER_API_KEY", TEST_ENV_VAR], async () => {
       unsetEnv(["OPENROUTER_API_KEY", TEST_ENV_VAR]);

--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -105,6 +105,24 @@ function resolveProvidersForMode(params: {
   });
 }
 
+function stripProviderApiKeysForModelsJson(
+  providers: Record<string, ProviderConfig>,
+): Record<string, ProviderConfig> {
+  let mutated = false;
+  const next: Record<string, ProviderConfig> = {};
+  for (const [key, provider] of Object.entries(providers)) {
+    if (!Object.prototype.hasOwnProperty.call(provider, "apiKey")) {
+      next[key] = provider;
+      continue;
+    }
+    mutated = true;
+    const persistedProvider = { ...provider };
+    delete persistedProvider.apiKey;
+    next[key] = persistedProvider;
+  }
+  return mutated ? next : providers;
+}
+
 export async function planOpenClawModelsJsonWithDeps(
   params: {
     cfg: OpenClawConfig;
@@ -178,7 +196,8 @@ export async function planOpenClawModelsJsonWithDeps(
       secretRefManagedProviders,
     }) ?? normalizedMergedProviders;
   const finalProviders = applyNativeStreamingUsageCompat(secretEnforcedProviders);
-  const nextContents = `${JSON.stringify({ providers: finalProviders }, null, 2)}\n`;
+  const persistedProviders = stripProviderApiKeysForModelsJson(finalProviders);
+  const nextContents = `${JSON.stringify({ providers: persistedProviders }, null, 2)}\n`;
 
   if (params.existingRaw === nextContents) {
     return { action: "noop" };

--- a/src/agents/models-config.runtime-source-snapshot.test.ts
+++ b/src/agents/models-config.runtime-source-snapshot.test.ts
@@ -171,15 +171,11 @@ function withGatewayTokenMode(config: OpenClawConfig): OpenClawConfig {
   };
 }
 
-async function expectGeneratedProviderApiKey(
-  agentDir: string,
-  providerId: string,
-  expected: string,
-) {
+async function expectGeneratedProviderApiKeyOmitted(agentDir: string, providerId: string) {
   const parsed = await readGeneratedModelsJson<{
-    providers: Record<string, { apiKey?: string }>;
+    providers: Record<string, { apiKey?: unknown }>;
   }>(agentDir);
-  expect(parsed.providers[providerId]?.apiKey).toBe(expected);
+  expect(parsed.providers[providerId]).not.toHaveProperty("apiKey");
 }
 
 async function planGeneratedProviders(params: {
@@ -272,7 +268,7 @@ describe("models-config runtime source snapshot", () => {
       try {
         setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
         await ensureOpenClawModelsJson(clonedRuntimeConfig, agentDir);
-        await expectGeneratedProviderApiKey(agentDir, "openai", "OPENAI_API_KEY"); // pragma: allowlist secret
+        await expectGeneratedProviderApiKeyOmitted(agentDir, "openai");
       } finally {
         clearRuntimeConfigSnapshot();
         clearConfigCache();
@@ -325,7 +321,7 @@ describe("models-config runtime source snapshot", () => {
           >;
         }>(agentDir);
         expect(parsed.providers.openai?.baseUrl).toBe("https://api.openai.com/v1");
-        expect(parsed.providers.openai?.apiKey).toBe("OPENAI_API_KEY"); // pragma: allowlist secret
+        expect(parsed.providers.openai).not.toHaveProperty("apiKey");
         expect(parsed.providers.openai?.headers?.["X-OpenClaw-Test"]).toBe("one");
 
         // Header changes still rewrite models.json, but merge mode preserves the existing baseUrl.
@@ -337,7 +333,7 @@ describe("models-config runtime source snapshot", () => {
           >;
         }>(agentDir);
         expect(parsed.providers.openai?.baseUrl).toBe("https://api.openai.com/v1");
-        expect(parsed.providers.openai?.apiKey).toBe("OPENAI_API_KEY"); // pragma: allowlist secret
+        expect(parsed.providers.openai).not.toHaveProperty("apiKey");
         expect(parsed.providers.openai?.headers?.["X-OpenClaw-Test"]).toBe("two");
       } finally {
         clearRuntimeConfigSnapshot();
@@ -354,12 +350,12 @@ describe("models-config runtime source snapshot", () => {
     expectOpenAiHeaderMarkers(providers);
   });
 
-  it("keeps source markers when runtime projection is skipped for incompatible top-level shape", async () => {
+  it("keeps source header markers when runtime projection is skipped for incompatible top-level shape", async () => {
     const providers = await planGeneratedProviders({
       config: createOpenAiRuntimeConfigWithHeadersAndApiKey(),
       sourceConfigForSecrets: withGatewayTokenMode(createOpenAiSourceConfigWithHeadersAndApiKey()),
     });
-    expect(providers.openai?.apiKey).toBe("OPENAI_API_KEY"); // pragma: allowlist secret
+    expect(providers.openai).not.toHaveProperty("apiKey");
     expectOpenAiHeaderMarkers(providers);
   });
 });

--- a/src/agents/models-config.skips-writing-models-json-no-env-token.test.ts
+++ b/src/agents/models-config.skips-writing-models-json-no-env-token.test.ts
@@ -102,7 +102,6 @@ async function runEnvProviderCase(params: {
   envVar: "MINIMAX_API_KEY" | "SYNTHETIC_API_KEY";
   envValue: string;
   providerKey: "minimax" | "synthetic";
-  expectedApiKeyRef: string;
 }) {
   const previousValue = process.env[params.envVar];
   process.env[params.envVar] = params.envValue;
@@ -113,7 +112,8 @@ async function runEnvProviderCase(params: {
     const raw = await fs.readFile(modelPath, "utf8");
     const parsed = JSON.parse(raw) as { providers: Record<string, ParsedProviderConfig> };
     const provider = parsed.providers[params.providerKey];
-    expect(provider?.apiKey).toBe(params.expectedApiKeyRef);
+    expect(provider).toBeDefined();
+    expect(provider).not.toHaveProperty("apiKey");
   } finally {
     if (previousValue === undefined) {
       delete process.env[params.envVar];
@@ -211,7 +211,6 @@ describe("models-config", () => {
         envVar: "MINIMAX_API_KEY",
         envValue: "sk-minimax-test",
         providerKey: "minimax",
-        expectedApiKeyRef: "MINIMAX_API_KEY", // pragma: allowlist secret
       });
     });
   });
@@ -222,7 +221,6 @@ describe("models-config", () => {
         envVar: "SYNTHETIC_API_KEY",
         envValue: "sk-synthetic-test",
         providerKey: "synthetic",
-        expectedApiKeyRef: "SYNTHETIC_API_KEY", // pragma: allowlist secret
       });
     });
   });


### PR DESCRIPTION
Fixes #11829

## Summary
- Strip provider-level `apiKey` fields before writing generated `models.json` while keeping the resolved provider config available in memory.
- Add regression coverage for literal, env-backed, and implicit provider API keys.
- Update runtime/source snapshot expectations so persisted `models.json` no longer contains provider `apiKey` values.

## Testing
- `oxfmt --check --threads=1 src/agents/models-config.plan.ts src/agents/models-config.applies-config-env-vars.test.ts src/agents/models-config.runtime-source-snapshot.test.ts src/agents/models-config.skips-writing-models-json-no-env-token.test.ts`
- `node node_modules/vitest/vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/models-config*.test.ts`