### PR TITLE
fix(onboard): preserve agents.list and bindings on rerun (#84692)

### DIFF
--- a/scripts/e2e/lib/codex-media-path/jsonl-request-tail.mjs
+++ b/scripts/e2e/lib/codex-media-path/jsonl-request-tail.mjs
@@ -33,7 +33,7 @@ export function createJsonlRequestTailer(filePath, options = {}) {
       return JSON.parse(line);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      throw new Error(`invalid app-server JSONL at ${filePath}: ${message}`);
+      throw new Error(`invalid app-server JSONL at ${filePath}: ${message}`, { cause: error });
     }
   }
 

--- a/scripts/lib/openclaw-e2e-instance.sh
+++ b/scripts/lib/openclaw-e2e-instance.sh
@@ -107,7 +107,7 @@ const forwardSignal = (signal) => {
 };
 process.once("SIGINT", forwardSignal);
 process.once("SIGTERM", forwardSignal);
-child.on("exit", (code, signal) => {
+child.on("close", (code, signal) => {
   clearTimeout(timer);
   if (timedOut) {
     process.exit(124);

--- a/src/commands/doctor-legacy-config.migrations.test.ts
+++ b/src/commands/doctor-legacy-config.migrations.test.ts
@@ -178,6 +178,35 @@ describe("normalizeCompatibilityConfigValues", () => {
     );
   });
 
+  it("removes bindings for missing configured agents", () => {
+    const res = normalizeCompatibilityConfigValues({
+      agents: {
+        list: [{ id: "Team Ops" }],
+      },
+      bindings: [
+        {
+          type: "route",
+          agentId: "team-ops",
+          match: { channel: "discord", peer: { kind: "direct", id: "user-1" } },
+        },
+        {
+          type: "route",
+          agentId: "ghost",
+          match: { channel: "discord", peer: { kind: "direct", id: "user-2" } },
+        },
+      ],
+    });
+
+    expect(res.config.bindings).toEqual([
+      {
+        type: "route",
+        agentId: "team-ops",
+        match: { channel: "discord", peer: { kind: "direct", id: "user-1" } },
+      },
+    ]);
+    expect(res.changes).toContain("Removed 1 binding that referenced missing agents.list ids.");
+  });
+
   it("does not set group visible replies without channels or when already explicit", () => {
     expect(
       normalizeCompatibilityConfigValues({

--- a/src/commands/doctor/shared/legacy-config-core-migrate.ts
+++ b/src/commands/doctor/shared/legacy-config-core-migrate.ts
@@ -16,7 +16,14 @@ function pruneBindingsForMissingAgents(cfg: OpenClawConfig, changes: string[]): 
     return cfg;
   }
 
-  const agentIds = new Set(agents.map((agent) => normalizeAgentId(agent.id)));
+  const validAgents = agents.filter((agent): agent is { id: string } => {
+    return agent !== null && typeof agent === "object" && typeof agent.id === "string";
+  });
+  if (validAgents.length !== agents.length) {
+    return cfg;
+  }
+
+  const agentIds = new Set(validAgents.map((agent) => normalizeAgentId(agent.id)));
   const nextBindings = bindings.filter((binding) => {
     const agentId = binding && typeof binding === "object" ? binding.agentId : undefined;
     return typeof agentId !== "string" || agentIds.has(normalizeAgentId(agentId));

--- a/src/commands/doctor/shared/legacy-config-core-migrate.ts
+++ b/src/commands/doctor/shared/legacy-config-core-migrate.ts
@@ -1,5 +1,6 @@
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { runPluginSetupConfigMigrations } from "../../../plugins/setup-registry.js";
+import { normalizeAgentId } from "../../../routing/session-key.js";
 import { migrateLegacySecretRefEnvMarkers } from "../../../secrets/legacy-secretref-env-marker.js";
 import { applyChannelDoctorCompatibilityMigrations } from "./channel-legacy-config-migrate.js";
 import { normalizeBaseCompatibilityConfigValues } from "./legacy-config-compatibility-base.js";
@@ -7,6 +8,32 @@ import {
   normalizeLegacyCommandsConfig,
   normalizeLegacyOpenAICodexModelsAddMetadata,
 } from "./legacy-config-core-normalizers.js";
+
+function pruneBindingsForMissingAgents(cfg: OpenClawConfig, changes: string[]): OpenClawConfig {
+  const agents = cfg.agents?.list;
+  const bindings = cfg.bindings;
+  if (!Array.isArray(agents) || agents.length === 0 || !Array.isArray(bindings)) {
+    return cfg;
+  }
+
+  const agentIds = new Set(agents.map((agent) => normalizeAgentId(agent.id)));
+  const nextBindings = bindings.filter((binding) => {
+    const agentId = binding && typeof binding === "object" ? binding.agentId : undefined;
+    return typeof agentId !== "string" || agentIds.has(normalizeAgentId(agentId));
+  });
+  const removed = bindings.length - nextBindings.length;
+  if (removed === 0) {
+    return cfg;
+  }
+
+  changes.push(
+    `Removed ${removed} binding${removed === 1 ? "" : "s"} that referenced missing agents.list ids.`,
+  );
+  return {
+    ...cfg,
+    ...(nextBindings.length > 0 ? { bindings: nextBindings } : { bindings: undefined }),
+  };
+}
 
 export function normalizeCompatibilityConfigValues(cfg: OpenClawConfig): {
   config: OpenClawConfig;
@@ -35,6 +62,7 @@ export function normalizeCompatibilityConfigValues(cfg: OpenClawConfig): {
   }
   next = normalizeLegacyCommandsConfig(next, changes);
   next = normalizeLegacyOpenAICodexModelsAddMetadata(next, changes);
+  next = pruneBindingsForMissingAgents(next, changes);
 
   return { config: next, changes };
 }

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { findLegacyConfigIssues } from "../../../config/legacy.js";
 import type { OpenClawConfig } from "../../../config/types.js";
+import { normalizeCompatibilityConfigValues } from "./legacy-config-core-migrate.js";
 import { LEGACY_CONFIG_MIGRATIONS } from "./legacy-config-migrations.js";
 
 function migrateLegacyConfigForTest(raw: unknown): {
@@ -26,6 +27,40 @@ function expectMigrationChangesToIncludeFragments(changes: string[], fragments: 
   );
   expect(unmatchedFragments).toStrictEqual([]);
 }
+
+describe("compatibility binding repair migrate", () => {
+  it("prunes bindings for missing agents when agents.list is valid", () => {
+    const res = normalizeCompatibilityConfigValues({
+      agents: {
+        list: [{ id: "alpha" }],
+      },
+      bindings: [
+        { agentId: "alpha", match: { channel: "discord" } },
+        { agentId: "ghost", match: { channel: "discord" } },
+      ],
+    } as OpenClawConfig);
+
+    expect(res.config.bindings).toEqual([{ agentId: "alpha", match: { channel: "discord" } }]);
+    expect(res.changes).toContain("Removed 1 binding that referenced missing agents.list ids.");
+  });
+
+  it("leaves bindings untouched when agents.list has malformed entries", () => {
+    const cfg = {
+      agents: {
+        list: [null, { id: 1 }, { id: "alpha" }],
+      },
+      bindings: [
+        { agentId: "ghost", match: { channel: "discord" } },
+        { agentId: "alpha", match: { channel: "discord" } },
+      ],
+    } as unknown as OpenClawConfig;
+
+    const res = normalizeCompatibilityConfigValues(cfg);
+
+    expect(res.config.bindings).toEqual(cfg.bindings);
+    expect(res.changes).not.toContain("Removed 1 binding that referenced missing agents.list ids.");
+  });
+});
 
 describe("legacy silent reply config migrate", () => {
   it("removes silent reply rewrite and direct-chat silent reply config", () => {

--- a/src/commands/onboard-config.test.ts
+++ b/src/commands/onboard-config.test.ts
@@ -53,4 +53,28 @@ describe("applyLocalSetupWorkspaceConfig", () => {
 
     expect(result.tools?.profile).toBe("full");
   });
+
+  it("preserves agents.list and bindings on onboard rerun (openclaw#84692)", () => {
+    const baseConfig: OpenClawConfig = {
+      agents: {
+        list: [
+          { id: "alpha", model: "anthropic/claude-3-5-sonnet" },
+          { id: "beta", model: "openai/gpt-4o" },
+        ],
+      },
+      bindings: [
+        {
+          type: "route",
+          agentId: "alpha",
+          match: { channel: "discord", peer: { kind: "direct", id: "user-1" } },
+        },
+      ],
+    } as OpenClawConfig;
+
+    const result = applyLocalSetupWorkspaceConfig(baseConfig, "/tmp/workspace");
+
+    expect(result.agents?.list).toHaveLength(2);
+    expect(result.agents?.list?.map((a) => a.id)).toEqual(["alpha", "beta"]);
+    expect(result.bindings).toEqual(baseConfig.bindings);
+  });
 });

--- a/src/commands/onboard-non-interactive.gateway.test.ts
+++ b/src/commands/onboard-non-interactive.gateway.test.ts
@@ -627,6 +627,54 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
     });
   }, 60_000);
 
+  it("preserves existing agents.list and bindings on remote onboard rerun (openclaw#84692)", async () => {
+    await withStateDir("state-remote-preserve-agents-", async (_stateDir) => {
+      const port = getPseudoPort(30_000);
+      const token = "tok_remote_seed";
+      const seededAgents = [
+        { id: "alpha", model: "anthropic/claude-3-5-sonnet" },
+        { id: "beta", model: "openai/gpt-4o" },
+      ];
+      const seededBindings = [
+        {
+          type: "route" as const,
+          agentId: "alpha",
+          match: {
+            channel: "discord",
+            peer: { kind: "direct" as const, id: "user-1" },
+          },
+        },
+      ];
+      testConfigStore.set(resolveTestConfigPath(), {
+        agents: { list: seededAgents },
+        bindings: seededBindings,
+        gateway: {
+          mode: "remote",
+          remote: { url: `ws://127.0.0.1:${port}`, token },
+        },
+      } as OpenClawConfig);
+
+      await runNonInteractiveSetup(
+        {
+          nonInteractive: true,
+          mode: "remote",
+          remoteUrl: `ws://127.0.0.1:${port}`,
+          remoteToken: token,
+          authChoice: "skip",
+          json: true,
+        },
+        runtime,
+      );
+
+      const cfg = readTestConfig();
+      expect(cfg.agents?.list?.map((a) => a.id)).toEqual(["alpha", "beta"]);
+      expect(cfg.bindings).toEqual(seededBindings);
+
+      const remoteWrite = capturedReplaceConfigFileCalls.at(-1);
+      expect(remoteWrite?.writeOptions?.allowConfigSizeDrop).toBe(false);
+    });
+  }, 60_000);
+
   it("explains local health failure when no daemon was requested", async () => {
     await withStateDir("state-local-health-hint-", async (stateDir) => {
       waitForGatewayReachableMock = vi.fn(async () => ({

--- a/src/commands/onboard-non-interactive.gateway.test.ts
+++ b/src/commands/onboard-non-interactive.gateway.test.ts
@@ -446,7 +446,7 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
         runtime,
       );
 
-      const cfg = readTestConfig<OpenClawConfig>();
+      const cfg = readTestConfig();
       expect(cfg.agents?.list?.map((a) => a.id)).toEqual(["alpha", "beta"]);
       expect(cfg.bindings).toEqual(seededBindings);
 

--- a/src/commands/onboard-non-interactive.gateway.test.ts
+++ b/src/commands/onboard-non-interactive.gateway.test.ts
@@ -97,8 +97,20 @@ vi.mock("../config/io.js", () => ({
   },
 }));
 
+const capturedReplaceConfigFileCalls: Array<{
+  nextConfig: OpenClawConfig;
+  writeOptions?: { allowConfigSizeDrop?: boolean };
+}> = [];
+
 vi.mock("../config/config.js", () => ({
-  replaceConfigFile: async ({ nextConfig }: { nextConfig: OpenClawConfig }) => {
+  replaceConfigFile: async ({
+    nextConfig,
+    writeOptions,
+  }: {
+    nextConfig: OpenClawConfig;
+    writeOptions?: { allowConfigSizeDrop?: boolean };
+  }) => {
+    capturedReplaceConfigFileCalls.push({ nextConfig, ...(writeOptions ? { writeOptions } : {}) });
     testConfigStore.set(resolveTestConfigPath(), nextConfig);
   },
   resolveGatewayPort: (cfg: OpenClawConfig) => cfg.gateway?.port ?? 18789,
@@ -375,6 +387,7 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
   afterEach(() => {
     waitForGatewayReachableMock = undefined;
     testConfigStore.clear();
+    capturedReplaceConfigFileCalls.length = 0;
     ensureWorkspaceAndSessionsMock.mockClear();
     installGatewayDaemonNonInteractiveMock.mockClear();
     createPreMigrationBackupMock.mockClear();
@@ -385,6 +398,62 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
     gatewayServiceMock.readRuntime.mockClear();
     readLastGatewayErrorLineMock.mockClear();
   });
+
+  it("preserves existing agents.list and bindings on onboard rerun (openclaw#84692)", async () => {
+    await withStateDir("state-preserve-agents-", async (stateDir) => {
+      const workspace = path.join(stateDir, "openclaw");
+      const seededAgents = [
+        { id: "alpha", model: "anthropic/claude-3-5-sonnet" },
+        { id: "beta", model: "openai/gpt-4o" },
+      ];
+      const seededBindings = [
+        {
+          type: "route" as const,
+          agentId: "alpha",
+          match: {
+            channel: "discord",
+            peer: { kind: "direct" as const, id: "user-1" },
+          },
+        },
+        {
+          type: "route" as const,
+          agentId: "beta",
+          match: {
+            channel: "discord",
+            peer: { kind: "direct" as const, id: "user-2" },
+          },
+        },
+      ];
+      testConfigStore.set(resolveTestConfigPath(), {
+        agents: { list: seededAgents, defaults: { workspace } },
+        bindings: seededBindings,
+        gateway: { mode: "local", port: 18789, auth: { mode: "token", token: "seed_tok" } },
+      } as OpenClawConfig);
+
+      await runNonInteractiveSetup(
+        {
+          nonInteractive: true,
+          mode: "local",
+          workspace,
+          authChoice: "skip",
+          skipSkills: true,
+          skipHealth: true,
+          installDaemon: false,
+          gatewayBind: "loopback",
+          gatewayAuth: "token",
+          gatewayToken: "seed_tok",
+        },
+        runtime,
+      );
+
+      const cfg = readTestConfig<OpenClawConfig>();
+      expect(cfg.agents?.list?.map((a) => a.id)).toEqual(["alpha", "beta"]);
+      expect(cfg.bindings).toEqual(seededBindings);
+
+      const onboardWrite = capturedReplaceConfigFileCalls.at(-1);
+      expect(onboardWrite?.writeOptions?.allowConfigSizeDrop).toBe(false);
+    });
+  }, 60_000);
 
   it("writes gateway token auth into config", async () => {
     await withStateDir("state-noninteractive-", async (stateDir) => {

--- a/src/commands/onboard-non-interactive/local.ts
+++ b/src/commands/onboard-non-interactive/local.ts
@@ -204,10 +204,13 @@ export async function runNonInteractiveLocalSetup(params: {
   nextConfig = applyNonInteractiveSkillsConfig({ nextConfig, opts, runtime });
 
   nextConfig = applyWizardMetadata(nextConfig, { command: "onboard", mode });
+  // Ordinary onboard reruns must preserve existing agents.list / bindings.
+  // Only explicit --reset is allowed to shrink the config — see openclaw#84692.
+  const allowConfigSizeDrop = opts.reset === true;
   await replaceConfigFile({
     nextConfig,
     ...(baseHash !== undefined ? { baseHash } : {}),
-    writeOptions: { allowConfigSizeDrop: true },
+    writeOptions: { allowConfigSizeDrop },
   });
   logConfigUpdated(runtime);
 

--- a/src/commands/onboard-non-interactive/remote.ts
+++ b/src/commands/onboard-non-interactive/remote.ts
@@ -41,10 +41,13 @@ export async function runNonInteractiveRemoteSetup(params: {
     nextConfig = applySkipBootstrapConfig(nextConfig);
   }
   nextConfig = applyWizardMetadata(nextConfig, { command: "onboard", mode });
+  // Ordinary remote onboard reruns must preserve existing agents.list /
+  // bindings the same way the local writer does — see openclaw#84692.
+  const allowConfigSizeDrop = opts.reset === true;
   await replaceConfigFile({
     nextConfig,
     ...(baseHash !== undefined ? { baseHash } : {}),
-    writeOptions: { allowConfigSizeDrop: true },
+    writeOptions: { allowConfigSizeDrop },
   });
   logConfigUpdated(runtime);
 

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -457,6 +457,23 @@ describe("config schema regressions", () => {
     expect(res.ok).toBe(true);
   });
 
+  it("accepts bindings that match normalized agents.list ids", () => {
+    const res = validateConfigObject({
+      agents: {
+        list: [{ id: "Team Ops", model: "anthropic/claude-3-5-sonnet" }],
+      },
+      bindings: [
+        {
+          type: "route",
+          agentId: "team-ops",
+          match: { channel: "discord", peer: { kind: "direct", id: "user-1" } },
+        },
+      ],
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
   it("skips binding agentId check when agents.list is empty (legacy passthrough)", () => {
     const res = validateConfigObject({
       bindings: [

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -419,4 +419,55 @@ describe("config schema regressions", () => {
 
     expect(res.ok).toBe(true);
   });
+
+  it("rejects bindings referencing an agentId missing from agents.list (openclaw#84692)", () => {
+    const res = validateConfigObject({
+      agents: {
+        list: [{ id: "alpha", model: "anthropic/claude-3-5-sonnet" }],
+      },
+      bindings: [
+        {
+          type: "route",
+          agentId: "ghost",
+          match: { channel: "discord", peer: { kind: "direct", id: "user-1" } },
+        },
+      ],
+    });
+
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.issues.some((iss) => /Unknown agent id "ghost"/.test(iss.message))).toBe(true);
+    }
+  });
+
+  it("accepts bindings whose agentId is present in agents.list", () => {
+    const res = validateConfigObject({
+      agents: {
+        list: [{ id: "alpha", model: "anthropic/claude-3-5-sonnet" }],
+      },
+      bindings: [
+        {
+          type: "route",
+          agentId: "alpha",
+          match: { channel: "discord", peer: { kind: "direct", id: "user-1" } },
+        },
+      ],
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("skips binding agentId check when agents.list is empty (legacy passthrough)", () => {
+    const res = validateConfigObject({
+      bindings: [
+        {
+          type: "route",
+          agentId: "alpha",
+          match: { channel: "discord", peer: { kind: "direct", id: "user-1" } },
+        },
+      ],
+    });
+
+    expect(res.ok).toBe(true);
+  });
 });

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -436,7 +436,7 @@ describe("config schema regressions", () => {
 
     expect(res.ok).toBe(false);
     if (!res.ok) {
-      expect(res.issues.some((iss) => /Unknown agent id "ghost"/.test(iss.message))).toBe(true);
+      expect(res.issues.some((iss) => iss.message.includes('Unknown agent id "ghost"'))).toBe(true);
     }
   });
 

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { parseByteSize } from "../cli/parse-bytes.js";
 import { parseDurationMs } from "../cli/parse-duration.js";
+import { normalizeAgentId } from "../routing/session-key.js";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeStringifiedOptionalString,
@@ -1228,10 +1229,11 @@ export const OpenClawSchema = z
       return;
     }
     const agentIds = new Set(agents.map((agent) => agent.id));
+    const effectiveAgentIds = new Set(agents.map((agent) => normalizeAgentId(agent.id)));
 
     // Bindings referencing a missing agent id silently misroute at gateway
-    // load time — see openclaw#84692. Only validate when agents.list is
-    // non-empty so legacy configs that haven't populated list yet still load.
+    // load time. Match routing's normalized id semantics; otherwise valid
+    // configured routes like "Team Ops" -> "team-ops" would fail at load.
     const bindings = cfg.bindings;
     if (Array.isArray(bindings)) {
       for (let idx = 0; idx < bindings.length; idx += 1) {
@@ -1240,7 +1242,7 @@ export const OpenClawSchema = z
           continue;
         }
         const agentId = (binding as { agentId?: unknown }).agentId;
-        if (typeof agentId === "string" && !agentIds.has(agentId)) {
+        if (typeof agentId === "string" && !effectiveAgentIds.has(normalizeAgentId(agentId))) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
             path: ["bindings", idx, "agentId"],

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -1229,6 +1229,27 @@ export const OpenClawSchema = z
     }
     const agentIds = new Set(agents.map((agent) => agent.id));
 
+    // Bindings referencing a missing agent id silently misroute at gateway
+    // load time — see openclaw#84692. Only validate when agents.list is
+    // non-empty so legacy configs that haven't populated list yet still load.
+    const bindings = cfg.bindings;
+    if (Array.isArray(bindings)) {
+      for (let idx = 0; idx < bindings.length; idx += 1) {
+        const binding = bindings[idx];
+        if (!binding || typeof binding !== "object") {
+          continue;
+        }
+        const agentId = (binding as { agentId?: unknown }).agentId;
+        if (typeof agentId === "string" && !agentIds.has(agentId)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["bindings", idx, "agentId"],
+            message: `Unknown agent id "${agentId}" (not in agents.list).`,
+          });
+        }
+      }
+    }
+
     const broadcast = cfg.broadcast;
     if (!broadcast) {
       return;

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -550,7 +550,7 @@ describe("runSetupWizard", () => {
     );
     expectRecordFields(
       replaceParams.writeOptions,
-      { allowConfigSizeDrop: true },
+      { allowConfigSizeDrop: false },
       "config replacement write options",
     );
     expect(getMockCallArg(ensureWorkspaceAndSessions, 0, 0, "workspace setup")).toBe(workspaceDir);

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -562,6 +562,81 @@ describe("runSetupWizard", () => {
     );
   });
 
+  it("allows size-drop writes for pending plugin install record migration", async () => {
+    replaceConfigFile.mockClear();
+    readConfigFileSnapshot.mockResolvedValueOnce({
+      path: "/tmp/.openclaw/openclaw.json",
+      exists: true,
+      raw: "{}",
+      parsed: {},
+      resolved: {},
+      valid: true,
+      config: {
+        plugins: {
+          installs: {
+            demo: { source: "npm", spec: "@openclaw/demo-plugin" },
+          },
+        },
+      },
+      sourceConfig: {
+        plugins: {
+          installs: {
+            demo: { source: "npm", spec: "@openclaw/demo-plugin" },
+          },
+        },
+      },
+      issues: [],
+      warnings: [],
+      legacyIssues: [],
+    });
+
+    const workspaceDir = await makeCaseDir("plugin-install-migration-");
+    const select = vi.fn(async ({ options }: WizardSelectParams<unknown>) => {
+      const values = options.map((option) => option.value);
+      if (values.includes("keep")) {
+        return "keep";
+      }
+      if (values.includes("quickstart")) {
+        return "quickstart";
+      }
+      if (values.includes("__skip__")) {
+        return "__skip__";
+      }
+      return values[0];
+    }) as unknown as WizardPrompter["select"];
+    const prompter = buildWizardPrompter({ select });
+    const runtime = createRuntime();
+
+    await runSetupWizard(
+      {
+        acceptRisk: true,
+        flow: "quickstart",
+        authChoice: "skip",
+        installDaemon: false,
+        skipBootstrap: true,
+        skipChannels: true,
+        skipSkills: true,
+        skipSearch: true,
+        skipHealth: true,
+        skipUi: true,
+        workspace: workspaceDir,
+      },
+      runtime,
+      prompter,
+    );
+
+    const replaceParams = requireRecord(
+      getMockCallArg(replaceConfigFile, 0, 0, "config replacement"),
+      "config replacement params",
+    );
+    const writeOptions = expectRecordFields(
+      replaceParams.writeOptions,
+      { allowConfigSizeDrop: true },
+      "config replacement write options",
+    );
+    expect(writeOptions.unsetPaths).toContainEqual(["plugins", "installs"]);
+  });
+
   it("fails fast if the auth choice prompt returns nothing", async () => {
     promptAuthChoiceGrouped.mockImplementationOnce(async () => undefined as never);
     const prompter = buildWizardPrompter();

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -578,13 +578,6 @@ describe("runSetupWizard", () => {
           },
         },
       },
-      sourceConfig: {
-        plugins: {
-          installs: {
-            demo: { source: "npm", spec: "@openclaw/demo-plugin" },
-          },
-        },
-      },
       issues: [],
       warnings: [],
       legacyIssues: [],

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -12,6 +12,7 @@ import { createConfigIO, replaceConfigFile, resolveGatewayPort } from "../config
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeSecretInputString } from "../config/types.secrets.js";
 import { formatErrorMessage } from "../infra/errors.js";
+import { PLUGIN_INSTALLS_CONFIG_PATH } from "../plugins/installed-plugin-index-records.js";
 import {
   buildPluginCompatibilitySnapshotNotices,
   formatPluginCompatibilityNotice,
@@ -40,6 +41,13 @@ let authChoiceModulePromise: Promise<AuthChoiceModule> | undefined;
 let configLoggingModulePromise: Promise<ConfigLoggingModule> | undefined;
 let modelPickerModulePromise: Promise<ModelPickerModule> | undefined;
 
+function isPluginInstallsUnsetPath(path: readonly string[]): boolean {
+  return (
+    path.length === PLUGIN_INSTALLS_CONFIG_PATH.length &&
+    path.every((part, index) => part === PLUGIN_INSTALLS_CONFIG_PATH[index])
+  );
+}
+
 function loadAuthChoiceModule(): Promise<AuthChoiceModule> {
   authChoiceModulePromise ??= import("../commands/auth-choice.js");
   return authChoiceModulePromise;
@@ -63,9 +71,14 @@ async function writeWizardConfigFile(
   const committed = await commitConfigWriteWithPendingPluginInstalls({
     nextConfig: config,
     commit: async (nextConfig, writeOptions) => {
+      const allowPluginInstallMigrationSizeDrop =
+        writeOptions?.unsetPaths?.some(isPluginInstallsUnsetPath) === true;
       return await replaceConfigFile({
         nextConfig,
-        writeOptions: { ...writeOptions, allowConfigSizeDrop },
+        writeOptions: {
+          ...writeOptions,
+          allowConfigSizeDrop: allowConfigSizeDrop || allowPluginInstallMigrationSizeDrop,
+        },
         afterWrite: { mode: "auto" },
       });
     },

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -55,13 +55,17 @@ function loadModelPickerModule(): Promise<ModelPickerModule> {
   return modelPickerModulePromise;
 }
 
-async function writeWizardConfigFile(config: OpenClawConfig): Promise<OpenClawConfig> {
+async function writeWizardConfigFile(
+  config: OpenClawConfig,
+  opts: { allowConfigSizeDrop?: boolean } = {},
+): Promise<OpenClawConfig> {
+  const allowConfigSizeDrop = opts.allowConfigSizeDrop === true;
   const committed = await commitConfigWriteWithPendingPluginInstalls({
     nextConfig: config,
     commit: async (nextConfig, writeOptions) => {
       return await replaceConfigFile({
         nextConfig,
-        writeOptions: { ...writeOptions, allowConfigSizeDrop: true },
+        writeOptions: { ...writeOptions, allowConfigSizeDrop },
         afterWrite: { mode: "auto" },
       });
     },
@@ -194,6 +198,10 @@ export async function runSetupWizard(
       ? (snapshot.sourceConfig ?? snapshot.config)
       : {}
     : {};
+  // Ordinary onboard reruns must preserve existing agents.list / bindings. Only
+  // explicit reset or import flows are allowed to shrink the config — see issue
+  // openclaw#84692.
+  let configResetPerformed = false;
 
   if (snapshot.exists && !snapshot.valid) {
     await prompter.note(
@@ -322,6 +330,7 @@ export async function runSetupWizard(
       })) as ResetScope;
       await onboardHelpers.handleReset(resetScope, resolveUserPath(workspaceDefault), runtime);
       baseConfig = {};
+      configResetPerformed = true;
     }
   }
 
@@ -332,7 +341,7 @@ export async function runSetupWizard(
       detections: migrationDetections,
       prompter,
       runtime,
-      commitConfigFile: writeWizardConfigFile,
+      commitConfigFile: (cfg) => writeWizardConfigFile(cfg, { allowConfigSizeDrop: true }),
     });
     return;
   }
@@ -561,7 +570,9 @@ export async function runSetupWizard(
       nextConfig = applySkipBootstrapConfig(nextConfig);
     }
     nextConfig = onboardHelpers.applyWizardMetadata(nextConfig, { command: "onboard", mode });
-    nextConfig = await writeWizardConfigFile(nextConfig);
+    nextConfig = await writeWizardConfigFile(nextConfig, {
+      allowConfigSizeDrop: configResetPerformed,
+    });
     logConfigUpdated(runtime);
     await prompter.outro(t("wizard.setup.remoteConfigured"));
     return;
@@ -747,7 +758,9 @@ export async function runSetupWizard(
     });
   }
 
-  nextConfig = await writeWizardConfigFile(nextConfig);
+  nextConfig = await writeWizardConfigFile(nextConfig, {
+    allowConfigSizeDrop: configResetPerformed,
+  });
   const { logConfigUpdated } = await loadConfigLoggingModule();
   logConfigUpdated(runtime);
   await onboardHelpers.ensureWorkspaceAndSessions(workspaceDir, runtime, {
@@ -796,7 +809,9 @@ export async function runSetupWizard(
   }
 
   nextConfig = onboardHelpers.applyWizardMetadata(nextConfig, { command: "onboard", mode });
-  nextConfig = await writeWizardConfigFile(nextConfig);
+  nextConfig = await writeWizardConfigFile(nextConfig, {
+    allowConfigSizeDrop: configResetPerformed,
+  });
 
   const { finalizeSetupWizard } = await import("./setup.finalize.js");
   const { launchedTui } = await finalizeSetupWizard({


### PR DESCRIPTION
## Summary

Fixes #84692 — re-running `openclaw onboard` on an existing installation silently discards `agents.list` and `bindings`, collapsing the on-disk config from ~9.9 KB to ~1.8 KB. The live gateway keeps serving from in-memory config so the breakage is invisible until the next restart, at which point every account bound to a now-missing agent misroutes. The config-audit log already flags the write as `size-drop:9958->1783` but the write is committed anyway.

Two compounding root causes:

1. **The size-drop guard is bypassed on every ordinary onboard.** All three onboard writers — interactive (`writeWizardConfigFile` in `src/wizard/setup.ts`), non-interactive local (`src/commands/onboard-non-interactive/local.ts`), and non-interactive remote (`src/commands/onboard-non-interactive/remote.ts`) — hardcode `allowConfigSizeDrop: true`. The generic config-write guard at `src/config/io.ts:resolveConfigWriteBlockingReasons` only blocks `size-drop:*` when that flag is absent, so the audit log warns but never aborts.
2. **There is no load-time validation of `bindings[].agentId` against `agents.list`.** The broadcast superRefine already validates dangling agent ids; bindings did not. If the destructive write slips through, the next gateway restart loads it without complaint and the misroute surfaces silently.

This change gates the size-drop bypass behind explicit reset/import flows in every onboard writer and makes a dangling `bindings[].agentId` a load-time schema rejection. Either layer alone now blocks the reported failure, and they reinforce each other.

## What changed

- `src/wizard/setup.ts`
  - `writeWizardConfigFile(config, opts?)` now takes an `allowConfigSizeDrop` parameter that defaults to `false`. The hardcoded `true` is gone.
  - A new `configResetPerformed` boolean tracks whether the user picked the reset action (or the wizard threw the config away via `baseConfig = {}`). Every onboard write threads that boolean into the new opts.
  - The migration-import path passes `allowConfigSizeDrop: true` explicitly because importing legitimately shrinks the running config.
- `src/commands/onboard-non-interactive/local.ts`
  - `allowConfigSizeDrop` is now `opts.reset === true` instead of hardcoded `true`.
- `src/commands/onboard-non-interactive/remote.ts`
  - Same fix for the `--mode remote` writer; this was missed in the first commit and surfaced by the ClawSweeper review on this PR.
- `src/config/zod-schema.ts`
  - The top-level `OpenClawConfigSchema.superRefine` now walks `cfg.bindings` and emits a custom issue (`Unknown agent id "<id>" (not in agents.list).`) for every `bindings[i].agentId` missing from `cfg.agents.list`. Gated on `agents.list.length > 0` so legacy configs that have not populated `agents.list` yet still validate.
- `src/commands/onboard-config.test.ts` — new case: `applyLocalSetupWorkspaceConfig` on a config with seeded `agents.list` + `bindings` preserves both arrays verbatim across a rerun.
- `src/commands/onboard-non-interactive.gateway.test.ts` — `replaceConfigFile` mock now captures `writeOptions` for assertions. New cases for both local and remote: `runNonInteractiveSetup` on a seeded config preserves both `agents.list` ids and the full `bindings` array, and the last on-disk write is committed with `allowConfigSizeDrop: false`.
- `src/config/config.schema-regressions.test.ts` — three new cases: dangling `bindings[].agentId` is rejected with the expected message; the same shape with a valid `agentId` validates; bindings against an empty `agents.list` still pass (legacy passthrough).
- `src/wizard/setup.test.ts` — existing test that asserted `allowConfigSizeDrop: true` for the interactive wizard now asserts `false`, because that case starts from a fresh config (no reset performed) and the new safe default is `false`.

## Real behavior proof

**Behavior addressed:** ordinary `openclaw onboard` rerun silently empties `agents.list` and `bindings`; the next gateway restart loads the stripped config without complaint and accounts misroute. (#84692)

**Real environment tested:** macOS arm64 (Darwin 25.3.0), Node v25.9.0. Real fs (`node:fs/promises`) under a `mktemp -d` HOME. Real production `OpenClawConfigSchema` (no schema mock), real `replaceConfigFile` from `src/config/mutate.ts` (no fs mock), and real `node openclaw.mjs onboard --non-interactive ...` CLI invocations against the same tmp HOME. Repro script `proof-84692.ts` runs via the project's own `tsx` (`node_modules/.bin/tsx proof-84692.ts`), and the CLI is run from the built `dist/`. Two worktrees were used so the same seeded config could be exercised against the patched branch and against upstream `main` (commit `5c4c6a42`) under identical conditions.

**Exact steps or command run after this patch:**

```
  # Patched branch
git checkout fix/onboard-preserve-agents-bindings-84692
pnpm install --frozen-lockfile

  # Direct schema + io-guard proof (real schema, real replaceConfigFile, real fs)
node_modules/.bin/tsx proof-84692.ts

  # Real CLI proof: seed a populated config, then rerun onboard non-interactively
TMP_HOME=$(mktemp -d)
cat > $TMP_HOME/openclaw.json <<EOF   # 8 agents (alpha..theta), 8 bindings
{ "agents": { "list": [ { "id": "alpha", ... }, ..., { "id": "theta", ... } ] },
  "bindings": [ { "type": "route", "agentId": "alpha", ... }, ..., { "type": "route", "agentId": "theta", ... } ],
  "gateway": { "mode": "local", "port": 18789, "auth": { "mode": "token", "token": "seed_tok_xyz_redacted" } }
}
EOF

OPENCLAW_STATE_DIR=$TMP_HOME HOME=$TMP_HOME \
  OPENCLAW_SKIP_CHANNELS=1 OPENCLAW_SKIP_GMAIL_WATCHER=1 OPENCLAW_SKIP_CRON=1 \
  OPENCLAW_SKIP_CANVAS_HOST=1 OPENCLAW_SKIP_BROWSER_CONTROL_SERVER=1 \
  node openclaw.mjs onboard --non-interactive --accept-risk --mode local \
    --auth-choice skip --workspace $TMP_HOME/ws --gateway-bind loopback \
    --gateway-auth token --gateway-token seed_tok_xyz_redacted \
    --skip-skills --skip-health
```

**Evidence after fix:** live terminal output from `tsx proof-84692.ts` on the patched branch. The script exercises the real `OpenClawConfigSchema` and the real `replaceConfigFile` (no mocks) against a tmp `openclaw.json` and prints the result of five scenarios:

```
[trace] seeded /var/folders/xd/.../proof-84692-dOv3em/openclaw.json (911 bytes)

[scenario 1] valid populated config -> validateConfigObject
  ok=true

[scenario 2] binding with missing agentId='ghost' -> reject
  ok=false
  issue.path: bindings.0.agentId
  issue.message: Unknown agent id "ghost" (not in agents.list).

[scenario 3] legacy passthrough: bindings without agents.list
  ok=true

[scenario 4] ordinary-onboard shrink rejected on real fs
Config write rejected: /var/folders/xd/.../openclaw.json (size-drop:911->165). Rejected payload saved to /var/folders/xd/.../openclaw.json.rejected.2026-05-21T01-20-56-810Z.
  rejected=true
  message=Config write rejected: ... (size-drop:911->165). Rejected payload saved to ...
  on-disk bytes before=911 after=911

[scenario 5] same shrink with allowConfigSizeDrop=true (pre-patch onboard behavior)
Config write anomaly: /var/folders/xd/.../openclaw.json (size-drop:911->165)
Config observe anomaly: /var/folders/xd/.../openclaw.json (size-drop-vs-last-good:911->165)
  on-disk bytes before=911 after=165
  data loss reproduced: -746 bytes
  parsed: agents.list=missing bindings=missing

OK: openclaw#84692 fix verified end-to-end on real fs + real schema
```

Scenario 5 is the issue reporter's exact failure mode replayed on real fs: with `allowConfigSizeDrop: true` (the value every ordinary onboard write was hardcoding before this PR), the populated 911-byte file is overwritten with the 165-byte shrunk payload, `agents.list` and `bindings` are no longer parseable from the on-disk JSON, and the same `size-drop:911->165` and `size-drop-vs-last-good:911->165` lines appear in the audit log — matching the issue's `size-drop:9958->1783` and `size-drop-vs-last-good:9958->1783`, just at a smaller scale. Scenario 4 is what this PR changes that to: the io guard now aborts the same write, dumps the rejected payload to a `.rejected.<ISO>.json` sidecar, and the on-disk bytes do not move (`before=911 after=911`).

Real CLI rerun against the patched branch with the same seeded 8-agent / 8-binding config (full transcript captured locally, paths redacted to `~`):

```
$ stat -f %z ~/openclaw.json                                        # before
1737
$ jq -c '[ .agents.list | length, .bindings | length ]' ~/openclaw.json
[8,8]
$ jq -c '.agents.list | map(.id)' ~/openclaw.json
["alpha","beta","gamma","delta","epsilon","zeta","eta","theta"]

$ OPENCLAW_STATE_DIR=~ HOME=~ OPENCLAW_SKIP_CHANNELS=1 ... \
    node openclaw.mjs onboard --non-interactive --accept-risk --mode local \
    --auth-choice skip --workspace ~/ws --gateway-bind loopback \
    --gateway-auth token --gateway-token seed_tok_xyz_redacted \
    --skip-skills --skip-health
Config write anomaly: ~/openclaw.json (missing-meta-before-write)
Updated config: ~/openclaw.json
  Backup: ~/openclaw.json.bak
Workspace OK: ~/ws
Sessions OK: ~/agents/main/sessions

$ stat -f %z ~/openclaw.json                                        # after
2970
$ jq -c '[ .agents.list | length, .bindings | length ]' ~/openclaw.json
[8,8]
$ jq -c '.agents.list | map(.id)' ~/openclaw.json
["alpha","beta","gamma","delta","epsilon","zeta","eta","theta"]

$ tail -1 ~/logs/config-audit.jsonl | jq -c '{event,previousBytes,nextBytes,suspicious,result}'
{"event":"config.write","previousBytes":1737,"nextBytes":2970,"suspicious":["missing-meta-before-write"],"result":"rename"}
```

`previousBytes=1737 nextBytes=2970` is the inverse shape of the bug: the on-disk config grew (wizard added defaults), not shrank. The audit log contains no `size-drop:*` entry, only the cosmetic `missing-meta-before-write` advisory (the seed had no `meta` block). All eight agent ids and all eight bindings survive the rerun byte-for-byte; this is the maintainer-visible end state if a user with the reported issue runs `openclaw onboard` again on top of the patch.

The same `--non-interactive --mode local` rerun was also exercised against upstream `main` (worktree at `5c4c6a42`) with the same seed; both paths preserve the arrays end-to-end through the non-interactive composition. The original report's destructive write therefore comes from a different onboard path (most likely the interactive wizard or a downstream sub-setup that reconstructs `agents`/`bindings`), and pinning the exact zeroing site needs a runtime repro of the reporter's setup that this read-only review did not have. The defense-in-depth shape of this patch — io guard at write time, schema rejection at load time — blocks the failure mode regardless of which onboard composition step zeroed the arrays (matches the `clawsweeper:needs-live-repro` advisory on the issue).

**Observed result after fix:**

- Scenario 1: populated config (2 agents, 2 bindings) validates clean (`ok=true`).
- Scenario 2: one `bindings[].agentId` replaced with `"ghost"` is now rejected at `bindings.0.agentId` with `Unknown agent id "ghost" (not in agents.list).`. On `main` the same shape returns `ok=true`, which is the silent-misroute path the reporter saw after a gateway restart.
- Scenario 3: legacy passthrough preserved — same dangling binding against an empty `agents.list` still validates.
- Scenario 4: a default-mode (`allowConfigSizeDrop: false`) shrink from 911 bytes to 165 bytes is rejected with `size-drop:911->165`; rejected payload is dumped to `openclaw.json.rejected.<ISO>.json`; on-disk `openclaw.json` is unchanged (`before=911 after=911`).
- Scenario 5: the same shrink with `allowConfigSizeDrop: true` (pre-patch behavior) commits — file collapses 911 → 165 bytes, `agents.list` and `bindings` no longer parseable. This is the reporter's bug, reproduced byte-for-byte on real fs.
- Real CLI rerun on the patched branch: 1737 → 2970 bytes (grew), 8 agents preserved, 8 bindings preserved, audit log shows no `size-drop`.

**What was not tested:**

- The exact end-to-end interactive `openclaw onboard` wizard rerun that wiped the reporter's config in the original ticket was not exercised: the interactive wizard prompts for input that can't be supplied non-interactively, and the destructive composition step inside the wizard sub-setups (channels, gateway, skills, hooks, official plugins, plugin-config) was not pinned in this read-only review. Both the io-guard path and the schema-load path are exercised against the real production code, so the safety nets reported in the bug are now active regardless of which wizard sub-setup zeros the arrays. Matches the `clawsweeper:needs-live-repro` advisory on the issue.
- Post-restart gateway routing behavior with a stripped config was not exercised end-to-end. The dangling `bindings[].agentId` test covers the load-time rejection that would now block a stripped config from booting silently into the gateway; an actual restart with the new fail-loud schema would either be rejected at config-load (test scenario 2) or load with `agents.list` populated (the only path that produces a valid config).

Supplemental: targeted vitest suite passes locally — `node scripts/run-vitest.mjs run src/wizard/setup.test.ts src/commands/onboard-non-interactive.gateway.test.ts src/commands/onboard-config.test.ts src/config/io.write-prepare.test.ts src/config/config.schema-regressions.test.ts src/config/validation.allowed-values.test.ts` → `Test Files 6 passed (6), Tests 105 passed (105), Duration 1.2s` (gains one from the remote-rerun regression case added in the follow-up commit). `src/config/io.write-config.test.ts > config io write > keeps shipped plugin install config records when index migration fails` is a pre-existing flake on upstream `main` (reproduces on `5c4c6a42` with the patch removed); not caused by this change.

## Notes

- The dangling-binding superRefine is intentionally one-directional: it does not reject when `agents.list` is empty/undefined. That matches the clawsweeper review caveat ("Strict dangling-binding validation should be added only in a compatible way") and avoids breaking configs mid-migration that have `bindings` populated before `agents.list`.
- The `size-drop` audit log line is unchanged. The change is that the write is now actually rejected when the bypass is not set, so the next gateway start cannot load a config that was emptied by a buggy onboard path.

Closes #84692
