### PR TITLE
fix(install): handle npm min-release-age in hosted installers

### DIFF
--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -666,6 +666,62 @@ fix_npm_prefix_if_needed() {
   log "Configured npm prefix to ${target}"
 }
 
+resolve_npm_config_path() {
+  local raw="$1"
+  if [[ -z "$raw" || "$raw" == "null" || "$raw" == "undefined" ]]; then
+    return 1
+  fi
+  if [[ "$raw" == \~/* && -n "${HOME:-}" ]]; then
+    printf '%s\n' "${HOME}/${raw#"~/"}"
+    return 0
+  fi
+  if [[ "$raw" == "\${HOME}/"* && -n "${HOME:-}" ]]; then
+    printf '%s\n' "${HOME}/${raw#"\${HOME}/"}"
+    return 0
+  fi
+  printf '%s\n' "$raw"
+}
+
+npm_config_file_has_key() {
+  local file="$1"
+  local key="$2"
+  [[ -f "$file" ]] || return 1
+  grep -Eiq "^[[:space:]]*${key}[[:space:]]*=" "$file"
+}
+
+npm_config_has_raw_key() {
+  local npm_cmd="$1"
+  local key="$2"
+  local raw=""
+  local file=""
+  local -a files=()
+
+  raw="${NPM_CONFIG_USERCONFIG:-${npm_config_userconfig:-}}"
+  if [[ -n "$raw" ]]; then
+    file="$(resolve_npm_config_path "$raw" 2>/dev/null || true)"
+    [[ -n "$file" ]] && files+=("$file")
+  elif [[ -n "${HOME:-}" ]]; then
+    files+=("${HOME}/.npmrc")
+  fi
+
+  raw="${NPM_CONFIG_GLOBALCONFIG:-${npm_config_globalconfig:-}}"
+  if [[ -n "$raw" ]]; then
+    file="$(resolve_npm_config_path "$raw" 2>/dev/null || true)"
+    [[ -n "$file" ]] && files+=("$file")
+  fi
+
+  raw="$(env -u NPM_CONFIG_BEFORE -u npm_config_before -u NPM_CONFIG_MIN_RELEASE_AGE -u npm_config_min_release_age -u npm_config_min-release-age "$npm_cmd" config get globalconfig --global 2>/dev/null || true)"
+  file="$(resolve_npm_config_path "$raw" 2>/dev/null || true)"
+  [[ -n "$file" ]] && files+=("$file")
+
+  for file in "${files[@]}"; do
+    if npm_config_file_has_key "$file" "$key"; then
+      return 0
+    fi
+  done
+  return 1
+}
+
 install_openclaw() {
   local requested="${OPENCLAW_VERSION:-latest}"
   if is_openclaw_source_package_install_spec "$requested"; then
@@ -673,10 +729,12 @@ install_openclaw() {
   fi
   local freshness_flag="--min-release-age=0"
   local min_release_age=""
-  min_release_age="$(env -u NPM_CONFIG_BEFORE -u npm_config_before "$(npm_bin)" config get min-release-age 2>/dev/null || true)"
-  if [[ -z "$min_release_age" || "$min_release_age" == "null" || "$min_release_age" == "undefined" ]]; then
+  min_release_age="$(env -u NPM_CONFIG_BEFORE -u npm_config_before "$(npm_bin)" config get min-release-age --global 2>/dev/null || true)"
+  if npm_config_has_raw_key "$(npm_bin)" "min-release-age"; then
+    freshness_flag="--min-release-age=0"
+  elif [[ -z "$min_release_age" || "$min_release_age" == "null" || "$min_release_age" == "undefined" ]]; then
     local before_value=""
-    before_value="$(env -u NPM_CONFIG_MIN_RELEASE_AGE -u npm_config_min_release_age -u npm_config_min-release-age "$(npm_bin)" config get before 2>/dev/null || true)"
+    before_value="$(env -u NPM_CONFIG_MIN_RELEASE_AGE -u npm_config_min_release_age -u npm_config_min-release-age "$(npm_bin)" config get before --global 2>/dev/null || true)"
     if [[ -n "$before_value" && "$before_value" != "null" && "$before_value" != "undefined" ]]; then
       freshness_flag="--before=$(date -u '+%Y-%m-%dT%H:%M:%S.000Z')"
     fi

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -930,6 +930,63 @@ function Test-OpenClawSourcePackageInstallSpec {
     )
 }
 
+function Resolve-NpmConfigPath {
+    param([string]$RawPath)
+    if ([string]::IsNullOrWhiteSpace($RawPath) -or $RawPath -eq "null" -or $RawPath -eq "undefined") {
+        return $null
+    }
+    if (($RawPath.StartsWith("~/") -or $RawPath.StartsWith("~\")) -and -not [string]::IsNullOrWhiteSpace($HOME)) {
+        return (Join-Path $HOME $RawPath.Substring(2))
+    }
+    if (($RawPath.StartsWith('${HOME}/') -or $RawPath.StartsWith('${HOME}\')) -and -not [string]::IsNullOrWhiteSpace($HOME)) {
+        return (Join-Path $HOME $RawPath.Substring(8))
+    }
+    return $RawPath
+}
+
+function Test-NpmConfigFileKey {
+    param(
+        [string]$Path,
+        [string]$Key
+    )
+    if ([string]::IsNullOrWhiteSpace($Path) -or -not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        return $false
+    }
+    $escapedKey = [regex]::Escape($Key)
+    return [bool](Select-String -LiteralPath $Path -Pattern "^\s*$escapedKey\s*=" -Quiet)
+}
+
+function Test-NpmConfigRawKey {
+    param([string]$Key)
+    $files = New-Object System.Collections.Generic.List[string]
+    $userConfig = if ($env:NPM_CONFIG_USERCONFIG) { $env:NPM_CONFIG_USERCONFIG } else { $env:npm_config_userconfig }
+    if ($userConfig) {
+        $resolvedUserConfig = Resolve-NpmConfigPath $userConfig
+        if ($resolvedUserConfig) { $files.Add($resolvedUserConfig) }
+    } elseif (-not [string]::IsNullOrWhiteSpace($HOME)) {
+        $files.Add((Join-Path $HOME ".npmrc"))
+    }
+
+    $globalConfig = if ($env:NPM_CONFIG_GLOBALCONFIG) { $env:NPM_CONFIG_GLOBALCONFIG } else { $env:npm_config_globalconfig }
+    if ($globalConfig) {
+        $resolvedGlobalConfig = Resolve-NpmConfigPath $globalConfig
+        if ($resolvedGlobalConfig) { $files.Add($resolvedGlobalConfig) }
+    }
+
+    $detectedGlobalConfig = (Invoke-NpmCommand -Arguments @("config", "get", "globalconfig", "--global") 2>$null)
+    if ($LASTEXITCODE -eq 0) {
+        $resolvedDetectedGlobalConfig = Resolve-NpmConfigPath $detectedGlobalConfig
+        if ($resolvedDetectedGlobalConfig) { $files.Add($resolvedDetectedGlobalConfig) }
+    }
+
+    foreach ($file in ($files | Select-Object -Unique)) {
+        if (Test-NpmConfigFileKey -Path $file -Key $Key) {
+            return $true
+        }
+    }
+    return $false
+}
+
 function Install-OpenClaw {
     if ([string]::IsNullOrWhiteSpace($Tag)) {
         $Tag = "latest"
@@ -951,9 +1008,12 @@ function Install-OpenClaw {
     $installSpec = Resolve-NpmOpenClawInstallSpec -PackageName $packageName -RequestedTag $Tag
     Write-Host "[*] Installing OpenClaw ($installSpec)..." -ForegroundColor Yellow
     $freshnessArgs = @("--min-release-age=0")
-    $minReleaseAge = (Invoke-NpmCommand -Arguments @("config", "get", "min-release-age") 2>$null)
-    if ($LASTEXITCODE -ne 0 -or -not $minReleaseAge -or $minReleaseAge.Trim() -eq "null" -or $minReleaseAge.Trim() -eq "undefined") {
-        $beforeValue = (Invoke-NpmCommand -Arguments @("config", "get", "before") 2>$null)
+    $minReleaseAge = (Invoke-NpmCommand -Arguments @("config", "get", "min-release-age", "--global") 2>$null)
+    $minReleaseAgeStatus = $LASTEXITCODE
+    if (Test-NpmConfigRawKey -Key "min-release-age") {
+        $freshnessArgs = @("--min-release-age=0")
+    } elseif ($minReleaseAgeStatus -ne 0 -or -not $minReleaseAge -or $minReleaseAge.Trim() -eq "null" -or $minReleaseAge.Trim() -eq "undefined") {
+        $beforeValue = (Invoke-NpmCommand -Arguments @("config", "get", "before", "--global") 2>$null)
         if ($LASTEXITCODE -eq 0 -and $beforeValue -and $beforeValue.Trim() -ne "null" -and $beforeValue.Trim() -ne "undefined") {
             $freshnessArgs = @("--before=$((Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffZ"))")
         }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -736,16 +736,74 @@ auto_install_build_tools_for_npm_failure() {
     return 0
 }
 
+resolve_npm_config_path() {
+    local raw="$1"
+    if [[ -z "$raw" || "$raw" == "null" || "$raw" == "undefined" ]]; then
+        return 1
+    fi
+    if [[ "$raw" == \~/* && -n "${HOME:-}" ]]; then
+        printf '%s\n' "${HOME}/${raw#"~/"}"
+        return 0
+    fi
+    if [[ "$raw" == "\${HOME}/"* && -n "${HOME:-}" ]]; then
+        printf '%s\n' "${HOME}/${raw#"\${HOME}/"}"
+        return 0
+    fi
+    printf '%s\n' "$raw"
+}
+
+npm_config_file_has_key() {
+    local file="$1"
+    local key="$2"
+    [[ -f "$file" ]] || return 1
+    grep -Eiq "^[[:space:]]*${key}[[:space:]]*=" "$file"
+}
+
+npm_config_has_raw_key() {
+    local npm_cmd="$1"
+    local key="$2"
+    local raw=""
+    local file=""
+    local -a files=()
+
+    raw="${NPM_CONFIG_USERCONFIG:-${npm_config_userconfig:-}}"
+    if [[ -n "$raw" ]]; then
+        file="$(resolve_npm_config_path "$raw" 2>/dev/null || true)"
+        [[ -n "$file" ]] && files+=("$file")
+    elif [[ -n "${HOME:-}" ]]; then
+        files+=("${HOME}/.npmrc")
+    fi
+
+    raw="${NPM_CONFIG_GLOBALCONFIG:-${npm_config_globalconfig:-}}"
+    if [[ -n "$raw" ]]; then
+        file="$(resolve_npm_config_path "$raw" 2>/dev/null || true)"
+        [[ -n "$file" ]] && files+=("$file")
+    fi
+
+    raw="$(env -u NPM_CONFIG_BEFORE -u npm_config_before -u NPM_CONFIG_MIN_RELEASE_AGE -u npm_config_min_release_age -u npm_config_min-release-age "$npm_cmd" config get globalconfig --global 2>/dev/null || true)"
+    file="$(resolve_npm_config_path "$raw" 2>/dev/null || true)"
+    [[ -n "$file" ]] && files+=("$file")
+
+    for file in "${files[@]}"; do
+        if npm_config_file_has_key "$file" "$key"; then
+            return 0
+        fi
+    done
+    return 1
+}
+
 run_npm_global_install() {
     local spec="$1"
     local log="$2"
 
     local freshness_flag="--min-release-age=0"
     local min_release_age=""
-    min_release_age="$(env -u NPM_CONFIG_BEFORE -u npm_config_before npm config get min-release-age 2>/dev/null || true)"
-    if [[ -z "$min_release_age" || "$min_release_age" == "null" || "$min_release_age" == "undefined" ]]; then
+    min_release_age="$(env -u NPM_CONFIG_BEFORE -u npm_config_before npm config get min-release-age --global 2>/dev/null || true)"
+    if npm_config_has_raw_key npm "min-release-age"; then
+        freshness_flag="--min-release-age=0"
+    elif [[ -z "$min_release_age" || "$min_release_age" == "null" || "$min_release_age" == "undefined" ]]; then
         local before_value=""
-        before_value="$(env -u NPM_CONFIG_MIN_RELEASE_AGE -u npm_config_min_release_age -u npm_config_min-release-age npm config get before 2>/dev/null || true)"
+        before_value="$(env -u NPM_CONFIG_MIN_RELEASE_AGE -u npm_config_min_release_age -u npm_config_min-release-age npm config get before --global 2>/dev/null || true)"
         if [[ -n "$before_value" && "$before_value" != "null" && "$before_value" != "undefined" ]]; then
             freshness_flag="--before=$(date -u '+%Y-%m-%dT%H:%M:%S.000Z')"
         fi

--- a/src/infra/npm-install-env.test.ts
+++ b/src/infra/npm-install-env.test.ts
@@ -41,6 +41,17 @@ function expectUnsetOrZeroNpmJsonConfig(value: unknown): void {
   expect(value == null || value === false || value === 0 || value === "0").toBe(true);
 }
 
+function createIsolatedNpmConfigEnv(dir: string): NodeJS.ProcessEnv {
+  const home = path.join(dir, "home");
+  const globalconfig = path.join(dir, "global-npmrc");
+  fsSync.mkdirSync(home, { recursive: true });
+  fsSync.writeFileSync(globalconfig, "", "utf-8");
+  return {
+    HOME: home,
+    NPM_CONFIG_GLOBALCONFIG: globalconfig,
+  };
+}
+
 describe("npm project install env", () => {
   it("uses an absolute POSIX script shell for npm lifecycle scripts", () => {
     withMockedPlatform("linux", () => {
@@ -163,10 +174,12 @@ describe("npm project install env", () => {
   it("uses a current before override for explicit npm before policy", () => {
     const dir = fsSync.mkdtempSync(path.join(os.tmpdir(), "openclaw-npmrc-"));
     try {
+      const baseEnv = createIsolatedNpmConfigEnv(dir);
       const npmrc = path.join(dir, "npmrc");
       fsSync.writeFileSync(npmrc, "before=2026-01-01T00:00:00.000Z\n", "utf-8");
       const env = createNpmProjectInstallEnv(
         {
+          ...baseEnv,
           NPM_CONFIG_USERCONFIG: npmrc,
         },
         {},
@@ -180,6 +193,7 @@ describe("npm project install env", () => {
 
       const envWithParentAge = createNpmProjectInstallEnv(
         {
+          ...baseEnv,
           NPM_CONFIG_USERCONFIG: npmrc,
           NPM_CONFIG_MIN_RELEASE_AGE: "7",
         },
@@ -200,12 +214,14 @@ describe("npm project install env", () => {
   it("uses before args for stale npm before policies", () => {
     const dir = fsSync.mkdtempSync(path.join(os.tmpdir(), "openclaw-npmrc-"));
     try {
+      const baseEnv = createIsolatedNpmConfigEnv(dir);
       const npmrc = path.join(dir, "npmrc");
       fsSync.writeFileSync(npmrc, "before=2026-01-01T00:00:00.000Z\n", "utf-8");
 
       expect(
         createNpmFreshnessBypassArgs(
           {
+            ...baseEnv,
             NPM_CONFIG_USERCONFIG: npmrc,
           },
           FROZEN_NOW,
@@ -219,11 +235,13 @@ describe("npm project install env", () => {
   it("uses before args for expanded npm userconfig paths", () => {
     const dir = fsSync.mkdtempSync(path.join(os.tmpdir(), "openclaw-home-npmrc-"));
     try {
+      const baseEnv = createIsolatedNpmConfigEnv(dir);
       fsSync.writeFileSync(path.join(dir, ".npmrc"), "before=2026-01-01T00:00:00.000Z\n", "utf-8");
 
       expect(
         createNpmFreshnessBypassArgs(
           {
+            ...baseEnv,
             HOME: dir,
             NPM_CONFIG_USERCONFIG: "~/.npmrc",
           },
@@ -233,6 +251,7 @@ describe("npm project install env", () => {
       expect(
         createNpmFreshnessBypassArgs(
           {
+            ...baseEnv,
             HOME: dir,
             NPM_CONFIG_USERCONFIG: "${HOME}/.npmrc",
           },
@@ -247,7 +266,9 @@ describe("npm project install env", () => {
   it("uses before args for npm default globalconfig before policies", () => {
     const dir = fsSync.mkdtempSync(path.join(os.tmpdir(), "openclaw-npm-prefix-"));
     try {
+      const home = path.join(dir, "home");
       const npmrcDir = path.join(dir, "etc");
+      fsSync.mkdirSync(home, { recursive: true });
       fsSync.mkdirSync(npmrcDir, { recursive: true });
       fsSync.writeFileSync(
         path.join(npmrcDir, "npmrc"),
@@ -258,6 +279,7 @@ describe("npm project install env", () => {
       expect(
         createNpmFreshnessBypassArgs(
           {
+            HOME: home,
             NPM_CONFIG_PREFIX: dir,
           },
           FROZEN_NOW,
@@ -271,13 +293,14 @@ describe("npm project install env", () => {
   it("uses before args for command project npmrc before policies", () => {
     const dir = fsSync.mkdtempSync(path.join(os.tmpdir(), "openclaw-project-npmrc-"));
     try {
+      const baseEnv = createIsolatedNpmConfigEnv(dir);
       fsSync.writeFileSync(path.join(dir, ".npmrc"), "before=2026-01-01T00:00:00.000Z\n", "utf-8");
 
-      expect(createNpmFreshnessBypassArgs({}, FROZEN_NOW, { npmConfigCwd: dir })).toEqual([
+      expect(createNpmFreshnessBypassArgs(baseEnv, FROZEN_NOW, { npmConfigCwd: dir })).toEqual([
         `--before=${FROZEN_NOW.toISOString()}`,
       ]);
 
-      const env = createNpmProjectInstallEnv({}, { npmConfigCwd: dir }, FROZEN_NOW);
+      const env = createNpmProjectInstallEnv(baseEnv, { npmConfigCwd: dir }, FROZEN_NOW);
       expect(env.npm_config_min_release_age).toBe("");
       expect(env.npm_config_before).toBe(FROZEN_NOW.toISOString());
     } finally {
@@ -288,10 +311,11 @@ describe("npm project install env", () => {
   it("uses before args for the current project npmrc by default", () => {
     const dir = fsSync.mkdtempSync(path.join(os.tmpdir(), "openclaw-current-npmrc-"));
     try {
+      const baseEnv = createIsolatedNpmConfigEnv(dir);
       fsSync.writeFileSync(path.join(dir, ".npmrc"), "before=2026-01-01T00:00:00.000Z\n", "utf-8");
       const cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(dir);
       withRestoredMocks([cwdSpy], () => {
-        expect(createNpmFreshnessBypassArgs({}, FROZEN_NOW)).toEqual([
+        expect(createNpmFreshnessBypassArgs(baseEnv, FROZEN_NOW)).toEqual([
           `--before=${FROZEN_NOW.toISOString()}`,
         ]);
       });
@@ -303,6 +327,7 @@ describe("npm project install env", () => {
   it("uses before args for scoped npm prefix before policies", () => {
     const dir = fsSync.mkdtempSync(path.join(os.tmpdir(), "openclaw-prefix-npmrc-"));
     try {
+      const baseEnv = createIsolatedNpmConfigEnv(dir);
       const npmrcDir = path.join(dir, "etc");
       fsSync.mkdirSync(npmrcDir, { recursive: true });
       fsSync.writeFileSync(
@@ -311,7 +336,7 @@ describe("npm project install env", () => {
         "utf-8",
       );
 
-      expect(createNpmFreshnessBypassArgs({}, FROZEN_NOW, { npmConfigPrefix: dir })).toEqual([
+      expect(createNpmFreshnessBypassArgs(baseEnv, FROZEN_NOW, { npmConfigPrefix: dir })).toEqual([
         `--before=${FROZEN_NOW.toISOString()}`,
       ]);
     } finally {
@@ -322,10 +347,12 @@ describe("npm project install env", () => {
   it("overrides stale npmrc before config without emitting release-age config", () => {
     const dir = fsSync.mkdtempSync(path.join(os.tmpdir(), "openclaw-npmrc-"));
     try {
+      const baseEnv = createIsolatedNpmConfigEnv(dir);
       const npmrc = path.join(dir, "npmrc");
       fsSync.writeFileSync(npmrc, "before=2026-01-01T00:00:00.000Z\n", "utf-8");
       const env = createNpmProjectInstallEnv(
         {
+          ...baseEnv,
           NPM_CONFIG_USERCONFIG: npmrc,
         },
         {},

--- a/test/scripts/install-cli.test.ts
+++ b/test/scripts/install-cli.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -15,6 +15,74 @@ function runInstallCliShell(script: string, env: NodeJS.ProcessEnv = {}) {
       ...env,
     },
   });
+}
+
+function writeNpmFreshnessConflictFixture(path: string, argsLog: string) {
+  writeFileSync(
+    path,
+    [
+      "#!/usr/bin/env bash",
+      "set -euo pipefail",
+      `printf '%s\\n' "$*" >> ${JSON.stringify(argsLog)}`,
+      'if [[ "$1" == "config" && "$2" == "get" && "$3" == "min-release-age" ]]; then',
+      "  printf 'null\\n'",
+      "  exit 0",
+      "fi",
+      'if [[ "$1" == "config" && "$2" == "get" && "$3" == "before" ]]; then',
+      "  printf 'Wed May 13 2026 21:25:20 GMT-0300 (Brasilia Standard Time)\\n'",
+      "  exit 0",
+      "fi",
+      'for arg in "$@"; do',
+      '  if [[ "$arg" == --before=* ]]; then',
+      "    printf '%s\\n' 'Exit prior to config file resolving' >&2",
+      "    printf '%s\\n' 'cause' >&2",
+      "    printf '%s\\n' '--min-release-age cannot be provided when using --before' >&2",
+      "    exit 64",
+      "  fi",
+      "done",
+      'for arg in "$@"; do',
+      '  if [[ "$arg" == "--min-release-age=0" ]]; then',
+      "    exit 0",
+      "  fi",
+      "done",
+      "exit 65",
+      "",
+    ].join("\n"),
+  );
+  chmodSync(path, 0o755);
+}
+
+function writeNpmBeforePolicyFixture(path: string, argsLog: string) {
+  writeFileSync(
+    path,
+    [
+      "#!/usr/bin/env bash",
+      "set -euo pipefail",
+      `printf '%s\\n' "$*" >> ${JSON.stringify(argsLog)}`,
+      'if [[ "$1" == "config" && "$2" == "get" && "$3" == "min-release-age" ]]; then',
+      "  printf 'null\\n'",
+      "  exit 0",
+      "fi",
+      'if [[ "$1" == "config" && "$2" == "get" && "$3" == "before" ]]; then',
+      "  printf 'Wed May 13 2026 21:25:20 GMT-0300 (Brasilia Standard Time)\\n'",
+      "  exit 0",
+      "fi",
+      'for arg in "$@"; do',
+      '  if [[ "$arg" == "--min-release-age=0" ]]; then',
+      "    printf '%s\\n' 'min-release-age should not be selected for project-only npmrc' >&2",
+      "    exit 64",
+      "  fi",
+      "done",
+      'for arg in "$@"; do',
+      '  if [[ "$arg" == --before=* ]]; then',
+      "    exit 0",
+      "  fi",
+      "done",
+      "exit 65",
+      "",
+    ].join("\n"),
+  );
+  chmodSync(path, 0o755);
 }
 
 describe("install-cli.sh", () => {
@@ -142,5 +210,79 @@ describe("install-cli.sh", () => {
     expect(result.status).toBe(1);
     expect(result.stdout).toContain("npm installs do not support OpenClaw GitHub source targets");
     expect(result.stdout).toContain("--install-method git --version main");
+  });
+
+  it("does not emit before args when npmrc min-release-age computes a before cutoff", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "openclaw-install-cli-freshness-"));
+    const prefix = join(tmp, "prefix");
+    const home = join(tmp, "home");
+    const nodeBin = join(prefix, "tools/node-v22.22.0/bin");
+    const argsLog = join(tmp, "npm-args.log");
+    mkdirSync(nodeBin, { recursive: true });
+    mkdirSync(home, { recursive: true });
+    writeFileSync(join(home, ".npmrc"), "min-release-age=7\n");
+    writeNpmFreshnessConflictFixture(join(nodeBin, "npm"), argsLog);
+
+    let result: ReturnType<typeof runInstallCliShell> | undefined;
+    let argsOutput = "";
+    try {
+      result = runInstallCliShell(
+        [
+          "set -euo pipefail",
+          `HOME=${JSON.stringify(home)}`,
+          `OPENCLAW_PREFIX=${JSON.stringify(prefix)}`,
+          "OPENCLAW_VERSION=2026.5.19",
+          `source ${JSON.stringify(SCRIPT_PATH)}`,
+          "ensure_git() { return 0; }",
+          "install_openclaw",
+        ].join("\n"),
+      );
+      argsOutput = readFileSync(argsLog, "utf8");
+    } finally {
+      rmSync(tmp, { force: true, recursive: true });
+    }
+
+    expect(result?.status).toBe(0);
+    expect(argsOutput).toContain("--min-release-age=0");
+    expect(argsOutput).not.toContain("--before=");
+  });
+
+  it("ignores project npmrc when choosing global install freshness args", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "openclaw-install-cli-global-freshness-"));
+    const prefix = join(tmp, "prefix");
+    const home = join(tmp, "home");
+    const project = join(tmp, "project");
+    const nodeBin = join(prefix, "tools/node-v22.22.0/bin");
+    const argsLog = join(tmp, "npm-args.log");
+    mkdirSync(nodeBin, { recursive: true });
+    mkdirSync(home, { recursive: true });
+    mkdirSync(project, { recursive: true });
+    writeFileSync(join(home, ".npmrc"), "before=2026-01-01T00:00:00.000Z\n");
+    writeFileSync(join(project, ".npmrc"), "min-release-age=7\n");
+    writeNpmBeforePolicyFixture(join(nodeBin, "npm"), argsLog);
+
+    let result: ReturnType<typeof runInstallCliShell> | undefined;
+    let argsOutput = "";
+    try {
+      result = runInstallCliShell(
+        [
+          "set -euo pipefail",
+          `cd ${JSON.stringify(project)}`,
+          `HOME=${JSON.stringify(home)}`,
+          `OPENCLAW_PREFIX=${JSON.stringify(prefix)}`,
+          "OPENCLAW_VERSION=2026.5.19",
+          `source ${JSON.stringify(process.cwd() + "/" + SCRIPT_PATH)}`,
+          "ensure_git() { return 0; }",
+          "install_openclaw",
+        ].join("\n"),
+      );
+      argsOutput = readFileSync(argsLog, "utf8");
+    } finally {
+      rmSync(tmp, { force: true, recursive: true });
+    }
+
+    expect(result?.status).toBe(0);
+    expect(argsOutput).toContain("--before=");
+    expect(argsOutput).not.toContain("--min-release-age=0");
   });
 });

--- a/test/scripts/install-ps1.test.ts
+++ b/test/scripts/install-ps1.test.ts
@@ -152,6 +152,30 @@ describe("install.ps1 failure handling", () => {
     expect(npmInstallBody).toContain("-InstallMethod git -Tag main");
   });
 
+  it("does not read project npmrc when choosing global install freshness args", () => {
+    const rawKeyBody = extractFunctionBody(source, "Test-NpmConfigRawKey");
+    expect(rawKeyBody).not.toContain("Get-Location");
+    expect(rawKeyBody).not.toContain('Join-Path (Get-Location) ".npmrc"');
+  });
+
+  it("preserves the min-release-age probe status before raw npmrc detection", () => {
+    const npmInstallBody = extractFunctionBody(source, "Install-OpenClaw");
+    const probeStatusCapture = npmInstallBody.indexOf("$minReleaseAgeStatus = $LASTEXITCODE");
+    const rawKeyProbe = npmInstallBody.indexOf("Test-NpmConfigRawKey -Key");
+    expect(probeStatusCapture).toBeGreaterThan(-1);
+    expect(rawKeyProbe).toBeGreaterThan(-1);
+    expect(probeStatusCapture).toBeLessThan(rawKeyProbe);
+    expect(npmInstallBody).toContain(
+      "} elseif ($minReleaseAgeStatus -ne 0 -or -not $minReleaseAge",
+    );
+    expect(npmInstallBody).toContain(
+      'Invoke-NpmCommand -Arguments @("config", "get", "min-release-age", "--global")',
+    );
+    expect(npmInstallBody).toContain(
+      'Invoke-NpmCommand -Arguments @("config", "get", "before", "--global")',
+    );
+  });
+
   it("preserves caller-relative local tarball install specs before safe-cwd npm calls", () => {
     const resolveSpecBody = extractFunctionBody(source, "Resolve-NpmOpenClawInstallSpec");
     const localSpecBody = extractFunctionBody(source, "Resolve-LocalNpmPackageInstallSpec");

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -17,6 +17,74 @@ function runInstallShell(script: string, env: NodeJS.ProcessEnv = {}) {
   });
 }
 
+function writeNpmFreshnessConflictFixture(path: string, argsLog: string) {
+  writeFileSync(
+    path,
+    [
+      "#!/usr/bin/env bash",
+      "set -euo pipefail",
+      `printf '%s\\n' "$*" >> ${JSON.stringify(argsLog)}`,
+      'if [[ "$1" == "config" && "$2" == "get" && "$3" == "min-release-age" ]]; then',
+      "  printf 'null\\n'",
+      "  exit 0",
+      "fi",
+      'if [[ "$1" == "config" && "$2" == "get" && "$3" == "before" ]]; then',
+      "  printf 'Wed May 13 2026 21:25:20 GMT-0300 (Brasilia Standard Time)\\n'",
+      "  exit 0",
+      "fi",
+      'for arg in "$@"; do',
+      '  if [[ "$arg" == --before=* ]]; then',
+      "    printf '%s\\n' 'Exit prior to config file resolving' >&2",
+      "    printf '%s\\n' 'cause' >&2",
+      "    printf '%s\\n' '--min-release-age cannot be provided when using --before' >&2",
+      "    exit 64",
+      "  fi",
+      "done",
+      'for arg in "$@"; do',
+      '  if [[ "$arg" == "--min-release-age=0" ]]; then',
+      "    exit 0",
+      "  fi",
+      "done",
+      "exit 65",
+      "",
+    ].join("\n"),
+  );
+  chmodSync(path, 0o755);
+}
+
+function writeNpmBeforePolicyFixture(path: string, argsLog: string) {
+  writeFileSync(
+    path,
+    [
+      "#!/usr/bin/env bash",
+      "set -euo pipefail",
+      `printf '%s\\n' "$*" >> ${JSON.stringify(argsLog)}`,
+      'if [[ "$1" == "config" && "$2" == "get" && "$3" == "min-release-age" ]]; then',
+      "  printf 'null\\n'",
+      "  exit 0",
+      "fi",
+      'if [[ "$1" == "config" && "$2" == "get" && "$3" == "before" ]]; then',
+      "  printf 'Wed May 13 2026 21:25:20 GMT-0300 (Brasilia Standard Time)\\n'",
+      "  exit 0",
+      "fi",
+      'for arg in "$@"; do',
+      '  if [[ "$arg" == "--min-release-age=0" ]]; then',
+      "    printf '%s\\n' 'min-release-age should not be selected for project-only npmrc' >&2",
+      "    exit 64",
+      "  fi",
+      "done",
+      'for arg in "$@"; do',
+      '  if [[ "$arg" == --before=* ]]; then',
+      "    exit 0",
+      "  fi",
+      "done",
+      "exit 65",
+      "",
+    ].join("\n"),
+  );
+  chmodSync(path, 0o755);
+}
+
 describe("install.sh", () => {
   const script = readFileSync(SCRIPT_PATH, "utf8");
 
@@ -137,6 +205,80 @@ describe("install.sh", () => {
     expect(result.stdout).toContain("status=1");
     expect(result.stdout).toContain("npm installs do not support OpenClaw GitHub source targets");
     expect(result.stdout).toContain("--install-method git --version main");
+  });
+
+  it("does not emit before args when npmrc min-release-age computes a before cutoff", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "openclaw-install-npm-freshness-"));
+    const bin = join(tmp, "bin");
+    const home = join(tmp, "home");
+    const argsLog = join(tmp, "npm-args.log");
+    mkdirSync(bin, { recursive: true });
+    mkdirSync(home, { recursive: true });
+    writeFileSync(join(home, ".npmrc"), "min-release-age=7\n");
+    writeNpmFreshnessConflictFixture(join(bin, "npm"), argsLog);
+
+    let result: ReturnType<typeof runInstallShell> | undefined;
+    let argsOutput = "";
+    try {
+      result = runInstallShell(
+        [
+          "set -euo pipefail",
+          `source ${JSON.stringify(SCRIPT_PATH)}`,
+          `HOME=${JSON.stringify(home)}`,
+          `PATH=${JSON.stringify(`${bin}:/usr/bin:/bin`)}`,
+          "NPM_LOGLEVEL=error",
+          "NPM_SILENT_FLAG=",
+          "SHARP_IGNORE_GLOBAL_LIBVIPS=1",
+          `run_npm_global_install openclaw@latest ${JSON.stringify(join(tmp, "install.log"))}`,
+        ].join("\n"),
+      );
+      argsOutput = readFileSync(argsLog, "utf8");
+    } finally {
+      rmSync(tmp, { force: true, recursive: true });
+    }
+
+    expect(result?.status).toBe(0);
+    expect(argsOutput).toContain("--min-release-age=0");
+    expect(argsOutput).not.toContain("--before=");
+  });
+
+  it("ignores project npmrc when choosing global install freshness args", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "openclaw-install-global-freshness-"));
+    const bin = join(tmp, "bin");
+    const home = join(tmp, "home");
+    const project = join(tmp, "project");
+    const argsLog = join(tmp, "npm-args.log");
+    mkdirSync(bin, { recursive: true });
+    mkdirSync(home, { recursive: true });
+    mkdirSync(project, { recursive: true });
+    writeFileSync(join(home, ".npmrc"), "before=2026-01-01T00:00:00.000Z\n");
+    writeFileSync(join(project, ".npmrc"), "min-release-age=7\n");
+    writeNpmBeforePolicyFixture(join(bin, "npm"), argsLog);
+
+    let result: ReturnType<typeof runInstallShell> | undefined;
+    let argsOutput = "";
+    try {
+      result = runInstallShell(
+        [
+          "set -euo pipefail",
+          `cd ${JSON.stringify(project)}`,
+          `source ${JSON.stringify(process.cwd() + "/" + SCRIPT_PATH)}`,
+          `HOME=${JSON.stringify(home)}`,
+          `PATH=${JSON.stringify(`${bin}:/usr/bin:/bin`)}`,
+          "NPM_LOGLEVEL=error",
+          "NPM_SILENT_FLAG=",
+          "SHARP_IGNORE_GLOBAL_LIBVIPS=1",
+          `run_npm_global_install openclaw@latest ${JSON.stringify(join(tmp, "install.log"))}`,
+        ].join("\n"),
+      );
+      argsOutput = readFileSync(argsLog, "utf8");
+    } finally {
+      rmSync(tmp, { force: true, recursive: true });
+    }
+
+    expect(result?.status).toBe(0);
+    expect(argsOutput).toContain("--before=");
+    expect(argsOutput).not.toContain("--min-release-age=0");
   });
 
   it("exports noninteractive apt env during Linux startup", () => {


### PR DESCRIPTION
## Summary

- Problem: `install.sh` / `install-cli.sh` could still emit `--before=<now>` when npm only exposed a computed `before` cutoff from a raw `min-release-age` npmrc entry.
- Solution: inspect raw npm config files for `min-release-age` before choosing the installer freshness bypass mode.
- What changed: shell and PowerShell installers now keep `--min-release-age=0` when a raw `min-release-age` policy is present, instead of trusting npm's computed `before` output.
- What did NOT change (scope boundary): installer package selection and managed TypeScript helper runtime behavior are unchanged; the TypeScript tests were made hermetic for machines that already have npm freshness policy in user/global npmrc.

## Motivation

- Fixes the remaining hosted-installer path reported in #84743 after #82641 / #83761.
- npm 11 can report `npm config get min-release-age` as `null` while `npm config get before` returns a computed cutoff from `min-release-age=7`; using that computed cutoff as `--before=<now>` still conflicts with the raw npmrc policy.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #84743
- Related #82630
- Related #82641
- Related #83761
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: hosted installer npm calls no longer choose `--before=<now>` when a raw npmrc `min-release-age` setting is what produced npm's computed `before` cutoff.
- Real environment tested: macOS arm64, Node `v26.0.0`, npm `11.12.1`, disposable OpenClaw checkout under `/private/tmp/openclaw-installer-freshness-pr`.
- Exact steps or command run after this patch:
  - `node scripts/run-vitest.mjs test/scripts/install-sh.test.ts test/scripts/install-cli.test.ts test/scripts/install-ps1.test.ts src/infra/npm-install-env.test.ts`
  - `bash -n scripts/install.sh scripts/install-cli.sh`
  - `git diff --check`
  - Mixed-config regression proof: project `.npmrc` has `min-release-age=7`, user `.npmrc` has `before=2026-01-01T00:00:00.000Z`, and the installer still chooses the global-install `--before=<now>` path.
  - Real npm installer-function proof with `OPENCLAW_INSTALL_SH_NO_RUN=1`, `HOME=<tmp>` containing `.npmrc` with `min-release-age=7`, `NPM_CONFIG_PREFIX=<tmp-prefix>`, and a local no-script package to avoid network/global mutation.
- Evidence after fix:

```text
node scripts/run-vitest.mjs test/scripts/install-sh.test.ts test/scripts/install-cli.test.ts test/scripts/install-ps1.test.ts src/infra/npm-install-env.test.ts

Test Files  4 passed (4)
Tests  51 passed | 4 skipped (55)
```

```text
bash -n scripts/install.sh scripts/install-cli.sh
exit status 0

git diff --check
exit status 0
```

```text
OPENCLAW_INSTALL_SH_NO_RUN=1 HOME=<tmp with .npmrc min-release-age=7> \
  NPM_CONFIG_PREFIX=<tmp-prefix> NPM_LOGLEVEL=error \
  bash -c 'source scripts/install.sh; run_npm_global_install <local no-script package> <tmp-log>'

LAST_NPM_INSTALL_CMD=env -u NPM_CONFIG_BEFORE -u npm_config_before -u NPM_CONFIG_MIN_RELEASE_AGE -u npm_config_min_release_age -u npm_config_min-release-age SHARP_IGNORE_GLOBAL_LIBVIPS=1 npm --loglevel error --silent --no-fund --no-audit --min-release-age=0 install -g <local no-script package>
exit=0
home_npmrc=min-release-age=7
```

```text
npm --version
11.12.1

HOME=<tmp with .npmrc min-release-age=7> npm config get min-release-age
null

HOME=<tmp with .npmrc min-release-age=7> npm config get before
Wed May 13 2026 21:45:21 GMT-0300 (Brasilia Standard Time)
```

- Observed result after fix: the patched `scripts/install.sh` npm path uses `--min-release-age=0`, emits no `--before=`, and real npm exits 0 under a raw user `min-release-age=7` npmrc. For a mixed project-only `min-release-age` plus user `before` policy, the patched global-install path ignores project `.npmrc`, emits `--before=<now>`, and real npm exits 0.
- What was not tested: PowerShell runtime execution; neither `pwsh` nor `powershell` is installed in this environment. `test/scripts/install-ps1.test.ts` still passed its static coverage.
- Before evidence: the new shell installer fixture tests failed before the implementation with status `64`, matching npm's `--min-release-age cannot be provided when using --before` conflict.

## Root Cause (if applicable)

- Root cause: the shell installer freshness bypass checked npm's resolved config output instead of raw npmrc keys. npm 11 can compute `before` from `min-release-age`, so the installer mistook a release-age policy for an explicit `before` policy.
- Missing detection / guardrail: installer tests asserted strings existed but did not execute the installer npm path against a fixture that reproduces npm's computed `before` behavior.
- Contributing context (if known): the TypeScript helper already scans raw npm config files; the hosted shell installers did not have equivalent detection.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `test/scripts/install-sh.test.ts`
  - `test/scripts/install-cli.test.ts`
  - `test/scripts/install-ps1.test.ts`
  - `src/infra/npm-install-env.test.ts`
- Scenario the test should lock in: fake npm reports `min-release-age` as `null`, reports a computed `before`, and fails if the installer emits `--before=`.
- Why this is the smallest reliable guardrail: it exercises the installer shell function directly without hitting the network or mutating a real npm install.
- Existing test that already covers this (if any): the TypeScript helper had this guardrail; the hosted installer execution path did not.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

OpenClaw hosted installers should now work for users whose npmrc contains `min-release-age`.

## Diagram (if applicable)

```text
Before:
[npmrc min-release-age] -> [npm computes before] -> [installer emits --before] -> [npm config conflict]

After:
[npmrc min-release-age] -> [installer detects raw key] -> [installer emits --min-release-age=0] -> [npm accepts command]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS arm64
- Runtime/container: Node `v26.0.0`, npm `11.12.1`
- Model/provider: N/A
- Integration/channel (if any): installer
- Relevant config (redacted): npmrc with `min-release-age=7`

### Steps

1. Configure npm with a raw `min-release-age` setting.
2. Run the hosted installer npm path.
3. Observe npm rejecting `--before=<now>` before this patch because `min-release-age` is still present in npmrc.
4. Observe the patched installer choosing `--min-release-age=0` and real npm exiting 0.

### Expected

- Installer-owned npm install command bypasses npm freshness quarantine without passing mutually-exclusive npm config.

### Actual

- Before this patch, the installer could pass `--before=<now>` and trigger npm's `--min-release-age cannot be provided when using --before` failure.
- After this patch, the installer passes `--min-release-age=0` for raw `min-release-age` npmrc policy and avoids the conflict.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Red test failed on current behavior for both shell installer paths.
  - Green test passed after the patch.
  - Shell syntax passed.
  - Whitespace check passed.
  - Real npm installer-function proof passed under a temporary `.npmrc` with `min-release-age=7` and temporary npm prefix.
- Edge cases checked:
  - npm 11.12.1 reports `min-release-age=7` as `min-release-age -> null` and `before -> computed date`.
  - npm accepts `--min-release-age=0` for that raw `min-release-age` case.
  - npm rejects `--before=<date>` for that raw `min-release-age` case.
  - Existing TypeScript helper tests now isolate user/global npmrc so they are not dependent on the contributor machine's npm policy.
  - Hosted global installers no longer scan project `.npmrc` when selecting the global install freshness bypass, and their `npm config get` probes use `--global` to match `npm install -g` scope.
- What you did **not** verify:
  - PowerShell runtime execution, because PowerShell is not installed here.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: installer freshness detection now reads npmrc files directly.
  - Mitigation: this mirrors the existing TypeScript helper shape and only affects the bypass flag choice for OpenClaw-owned installer npm commands.

AI-assisted: prepared with Codex and reviewed with `codex review --base origin/main`.


