### PR TITLE
fix: self-heal lane wedges + restore openai-codex OAuth on embedded path

### DIFF
--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -223,12 +223,10 @@ export class TelegramPollingSession {
   #spooledUpdateHandlerTimeoutMs: number;
   #spooledUpdateHandlerAbortGraceMs: number;
   #deliveryDrainInFlight = false;
-  // L5: callback supplied by the active isolated-ingress cycle to request
-  // the cycle abort itself when the bot has visibly lost its grammy
-  // initialized state mid-cycle (e.g., after a network drop during a
-  // handler retry loop). When set, calling it triggers a clean exit so
-  // the outer `runUntilAbort` loop creates a fresh bot and re-runs
-  // `bot.init()`. Cleared at the end of the cycle.
+  // Callback supplied by the active isolated-ingress cycle to request the cycle
+  // abort itself when the bot has visibly lost its grammy initialized state
+  // mid-cycle. When set, calling it triggers a clean exit so the outer
+  // `runUntilAbort` loop creates a fresh bot and re-runs `bot.init()`.
   #requestCycleRestartOnBotReinitNeeded: ((reason: string) => void) | null = null;
 
   constructor(private readonly opts: TelegramPollingSessionOpts) {
@@ -476,14 +474,10 @@ export class TelegramPollingSession {
     this.opts.log(
       `[telegram][diag] spooled update ${params.update.updateId} failed; keeping for retry: ${errMessage}`,
     );
-    // L5: if the grammy bot has lost its initialized state mid-cycle (typically
-    // after a network drop during a handler retry loop, where bot.init() never
-    // gets re-run), every subsequent update handler will fail with the same
-    // "Bot not initialized" message in a tight retry loop. Detect that case and
-    // ask the active cycle to abort itself; the outer runUntilAbort loop will
-    // create a fresh TelegramBot instance and re-run bot.init() against a now-
-    // stable network. Without this, the spool worker keeps retrying forever
-    // until something external (gateway restart, abort signal) intervenes.
+    // If the grammy bot has lost its initialized state mid-cycle, every
+    // subsequent update handler fails with the same message in a tight retry
+    // loop. Ask the active cycle to abort itself so the outer runUntilAbort
+    // loop can create a fresh TelegramBot instance and re-run bot.init().
     if (typeof errMessage === "string" && errMessage.includes("Bot not initialized")) {
       const requestRestart = this.#requestCycleRestartOnBotReinitNeeded;
       if (requestRestart) {
@@ -746,11 +740,10 @@ export class TelegramPollingSession {
       void worker.stop();
     };
     this.opts.abortSignal?.addEventListener("abort", stopOnAbort, { once: true });
-    // L5: install a one-shot callback that the spool failure path can use to
-    // ask this cycle to restart when it sees grammy's "Bot not initialized"
-    // error. Setting restartRequested + stopping the worker tears the cycle
-    // down via the existing try/finally cleanup below; the outer
-    // runUntilAbort loop then creates a new bot and re-runs bot.init().
+    // Install a one-shot callback that the spool failure path can use to ask
+    // this cycle to restart when it sees grammy's "Bot not initialized" error.
+    // Setting restartRequested and stopping the worker tears the cycle down via
+    // the existing try/finally cleanup below.
     this.#requestCycleRestartOnBotReinitNeeded = (reason: string) => {
       if (restartRequested) {
         return;
@@ -857,8 +850,8 @@ export class TelegramPollingSession {
       clearInterval(drainTimer);
       unsubscribe();
       this.opts.abortSignal?.removeEventListener("abort", stopOnAbort);
-      // L5: clear the restart-request callback so a future cycle (or other
-      // session) isn't accidentally talking to this cycle's local state.
+      // Clear the restart-request callback so a future cycle is not
+      // accidentally talking to this cycle's local state.
       this.#requestCycleRestartOnBotReinitNeeded = null;
       await worker.stop();
       if (!restartRequested) {

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -223,6 +223,13 @@ export class TelegramPollingSession {
   #spooledUpdateHandlerTimeoutMs: number;
   #spooledUpdateHandlerAbortGraceMs: number;
   #deliveryDrainInFlight = false;
+  // L5: callback supplied by the active isolated-ingress cycle to request
+  // the cycle abort itself when the bot has visibly lost its grammy
+  // initialized state mid-cycle (e.g., after a network drop during a
+  // handler retry loop). When set, calling it triggers a clean exit so
+  // the outer `runUntilAbort` loop creates a fresh bot and re-runs
+  // `bot.init()`. Cleared at the end of the cycle.
+  #requestCycleRestartOnBotReinitNeeded: ((reason: string) => void) | null = null;
 
   constructor(private readonly opts: TelegramPollingSessionOpts) {
     this.#transportState = new TelegramPollingTransportState({
@@ -465,9 +472,24 @@ export class TelegramPollingSession {
       );
       return;
     }
+    const errMessage = formatErrorMessage(params.err);
     this.opts.log(
-      `[telegram][diag] spooled update ${params.update.updateId} failed; keeping for retry: ${formatErrorMessage(params.err)}`,
+      `[telegram][diag] spooled update ${params.update.updateId} failed; keeping for retry: ${errMessage}`,
     );
+    // L5: if the grammy bot has lost its initialized state mid-cycle (typically
+    // after a network drop during a handler retry loop, where bot.init() never
+    // gets re-run), every subsequent update handler will fail with the same
+    // "Bot not initialized" message in a tight retry loop. Detect that case and
+    // ask the active cycle to abort itself; the outer runUntilAbort loop will
+    // create a fresh TelegramBot instance and re-run bot.init() against a now-
+    // stable network. Without this, the spool worker keeps retrying forever
+    // until something external (gateway restart, abort signal) intervenes.
+    if (typeof errMessage === "string" && errMessage.includes("Bot not initialized")) {
+      const requestRestart = this.#requestCycleRestartOnBotReinitNeeded;
+      if (requestRestart) {
+        requestRestart(`spooled update ${params.update.updateId} hit Bot-not-initialized`);
+      }
+    }
   }
 
   async #waitForSpooledUpdateHandlers(): Promise<void> {
@@ -724,6 +746,21 @@ export class TelegramPollingSession {
       void worker.stop();
     };
     this.opts.abortSignal?.addEventListener("abort", stopOnAbort, { once: true });
+    // L5: install a one-shot callback that the spool failure path can use to
+    // ask this cycle to restart when it sees grammy's "Bot not initialized"
+    // error. Setting restartRequested + stopping the worker tears the cycle
+    // down via the existing try/finally cleanup below; the outer
+    // runUntilAbort loop then creates a new bot and re-runs bot.init().
+    this.#requestCycleRestartOnBotReinitNeeded = (reason: string) => {
+      if (restartRequested) {
+        return;
+      }
+      restartRequested = true;
+      this.opts.log(
+        `[telegram][diag] requesting isolated polling cycle restart to re-run bot.init(): ${reason}`,
+      );
+      void worker.stop();
+    };
     const drainIntervalMs = Math.max(100, Math.floor(ingress.drainIntervalMs ?? 500));
     let drainActive = false;
     const stopBot = () => {
@@ -820,6 +857,9 @@ export class TelegramPollingSession {
       clearInterval(drainTimer);
       unsubscribe();
       this.opts.abortSignal?.removeEventListener("abort", stopOnAbort);
+      // L5: clear the restart-request callback so a future cycle (or other
+      // session) isn't accidentally talking to this cycle's local state.
+      this.#requestCycleRestartOnBotReinitNeeded = null;
       await worker.stop();
       if (!restartRequested) {
         await drainOnce();

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -590,7 +590,17 @@ export function loadAuthProfileStoreForSecretsRuntime(agentDir?: string): AuthPr
   return loadAuthProfileStoreForRuntime(agentDir, {
     readOnly: true,
     allowKeychainPrompt: false,
-    resolveLegacyOAuthSidecars: false,
+    // L4 PATCH (lane-pump branch): include legacy OAuth sidecar material when
+    // the runtime is resolving secrets for an agent turn. Without this, embedded
+    // agent runs (Telegram replies, cron invocations) cannot reach the access
+    // token for openai-codex profiles whose `oauthRef.source` is
+    // "openclaw-credentials", and resolveApiKeyForProfile() falls through to
+    // "No API key found". The OAuth-manager-internal refresh helper added in
+    // upstream #83312 already sets this to true; this default was inadvertently
+    // left at `false` after the sidecar runtime removal in #82777, breaking
+    // the embedded-agent OAuth resolution path while leaving the direct CLI
+    // inference path unaffected. See UPSTREAM_ISSUE_DRAFT.md in local-patches.
+    resolveLegacyOAuthSidecars: true,
   });
 }
 

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -590,16 +590,11 @@ export function loadAuthProfileStoreForSecretsRuntime(agentDir?: string): AuthPr
   return loadAuthProfileStoreForRuntime(agentDir, {
     readOnly: true,
     allowKeychainPrompt: false,
-    // L4 PATCH (lane-pump branch): include legacy OAuth sidecar material when
-    // the runtime is resolving secrets for an agent turn. Without this, embedded
-    // agent runs (Telegram replies, cron invocations) cannot reach the access
-    // token for openai-codex profiles whose `oauthRef.source` is
+    // Include legacy OAuth sidecar material when the runtime is resolving
+    // secrets for an agent turn. Without this, embedded agent runs cannot reach
+    // the access token for openai-codex profiles whose `oauthRef.source` is
     // "openclaw-credentials", and resolveApiKeyForProfile() falls through to
-    // "No API key found". The OAuth-manager-internal refresh helper added in
-    // upstream #83312 already sets this to true; this default was inadvertently
-    // left at `false` after the sidecar runtime removal in #82777, breaking
-    // the embedded-agent OAuth resolution path while leaving the direct CLI
-    // inference path unaffected. See UPSTREAM_ISSUE_DRAFT.md in local-patches.
+    // "No API key found".
     resolveLegacyOAuthSidecars: true,
   });
 }
@@ -614,12 +609,9 @@ export function loadAuthProfileStoreWithoutExternalProfiles(
   const options: LoadAuthProfileStoreOptions = {
     readOnly: true,
     allowKeychainPrompt: loadOptions?.allowKeychainPrompt ?? false,
-    // L4.1 PATCH: default sidecar resolution to true so that any caller
-    // not explicitly overriding (model-auth-label, model-provider-auth,
-    // pi-auth-discovery, list.list-command, etc.) still picks up legacy
-    // OAuth credential material. Was inadvertently left at `false` in the
-    // upstream #82777/#83312 refactor and breaks isolated/sub-agent auth
-    // resolution paths (e.g., cron-nested lanes).
+    // Default sidecar resolution to true so callers that do not explicitly
+    // override still pick up legacy OAuth credential material for isolated and
+    // sub-agent auth resolution paths.
     resolveLegacyOAuthSidecars: loadOptions?.resolveLegacyOAuthSidecars ?? true,
   };
   const store = loadAuthProfileStoreForAgent(agentDir, options);
@@ -657,10 +649,10 @@ export function ensureAuthProfileStoreWithoutExternalProfiles(
   agentDir?: string,
   options?: { allowKeychainPrompt?: boolean; resolveLegacyOAuthSidecars?: boolean },
 ): AuthProfileStore {
-  // L4.1 PATCH: forward `resolveLegacyOAuthSidecars` through this entry
-  // point so embedded-runner sub-agents (cron-nested, isolated session
-  // lanes for AgentOS sweeps) can read the legacy sidecar credential
-  // material. Default true to match `loadAuthProfileStoreWithoutExternalProfiles`.
+  // Forward `resolveLegacyOAuthSidecars` through this entry point so embedded
+  // runner sub-agents and isolated session lanes can read legacy sidecar
+  // credential material. Default true to match
+  // `loadAuthProfileStoreWithoutExternalProfiles`.
   const resolveLegacyOAuthSidecars = options?.resolveLegacyOAuthSidecars ?? true;
   const effectiveOptions: LoadAuthProfileStoreOptions = {
     ...(options ?? {}),
@@ -677,9 +669,8 @@ export function ensureAuthProfileStoreWithoutExternalProfiles(
     return store;
   }
 
-  // L4.1 PATCH: use effectiveOptions (with sidecar resolution) for the main
-  // fallback load too, otherwise sub-agents that need to merge in the main
-  // store would still miss the legacy credential material.
+  // Use the same options for the main fallback load; sub-agents that merge in
+  // the main store need the same legacy sidecar material.
   const mainStore = loadAuthProfileStoreForAgent(undefined, effectiveOptions);
   return mergeAuthProfileStores(mainStore, store);
 }

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -614,7 +614,13 @@ export function loadAuthProfileStoreWithoutExternalProfiles(
   const options: LoadAuthProfileStoreOptions = {
     readOnly: true,
     allowKeychainPrompt: loadOptions?.allowKeychainPrompt ?? false,
-    resolveLegacyOAuthSidecars: loadOptions?.resolveLegacyOAuthSidecars ?? false,
+    // L4.1 PATCH: default sidecar resolution to true so that any caller
+    // not explicitly overriding (model-auth-label, model-provider-auth,
+    // pi-auth-discovery, list.list-command, etc.) still picks up legacy
+    // OAuth credential material. Was inadvertently left at `false` in the
+    // upstream #82777/#83312 refactor and breaks isolated/sub-agent auth
+    // resolution paths (e.g., cron-nested lanes).
+    resolveLegacyOAuthSidecars: loadOptions?.resolveLegacyOAuthSidecars ?? true,
   };
   const store = loadAuthProfileStoreForAgent(agentDir, options);
   const authPath = resolveAuthStorePath(agentDir);
@@ -649,20 +655,32 @@ export function ensureAuthProfileStore(
 
 export function ensureAuthProfileStoreWithoutExternalProfiles(
   agentDir?: string,
-  options?: { allowKeychainPrompt?: boolean },
+  options?: { allowKeychainPrompt?: boolean; resolveLegacyOAuthSidecars?: boolean },
 ): AuthProfileStore {
-  const runtimeStore = resolveRuntimeAuthProfileStore(agentDir, options);
+  // L4.1 PATCH: forward `resolveLegacyOAuthSidecars` through this entry
+  // point so embedded-runner sub-agents (cron-nested, isolated session
+  // lanes for AgentOS sweeps) can read the legacy sidecar credential
+  // material. Default true to match `loadAuthProfileStoreWithoutExternalProfiles`.
+  const resolveLegacyOAuthSidecars = options?.resolveLegacyOAuthSidecars ?? true;
+  const effectiveOptions: LoadAuthProfileStoreOptions = {
+    ...(options ?? {}),
+    resolveLegacyOAuthSidecars,
+  };
+  const runtimeStore = resolveRuntimeAuthProfileStore(agentDir, effectiveOptions);
   if (runtimeStore) {
     return runtimeStore;
   }
-  const store = loadAuthProfileStoreForAgent(agentDir, options);
+  const store = loadAuthProfileStoreForAgent(agentDir, effectiveOptions);
   const authPath = resolveAuthStorePath(agentDir);
   const mainAuthPath = resolveAuthStorePath();
   if (!agentDir || authPath === mainAuthPath) {
     return store;
   }
 
-  const mainStore = loadAuthProfileStoreForAgent(undefined, options);
+  // L4.1 PATCH: use effectiveOptions (with sidecar resolution) for the main
+  // fallback load too, otherwise sub-agents that need to merge in the main
+  // store would still miss the legacy credential material.
+  const mainStore = loadAuthProfileStoreForAgent(undefined, effectiveOptions);
   return mergeAuthProfileStores(mainStore, store);
 }
 

--- a/src/logging/diagnostic-session-attention.test.ts
+++ b/src/logging/diagnostic-session-attention.test.ts
@@ -68,7 +68,10 @@ describe("classifySessionAttention", () => {
         reason: "queued_behind_terminal_active_work",
         classification: "stalled_agent_run",
         activeWorkKind: "embedded_run",
-        recoveryEligible: false,
+        // Terminal progress signal + queued items = lane is effectively
+        // done with the active turn; recovery coordinator should release
+        // the lane so the queue can drain.
+        recoveryEligible: true,
       },
     },
     {

--- a/src/logging/diagnostic-session-attention.ts
+++ b/src/logging/diagnostic-session-attention.ts
@@ -14,7 +14,7 @@ export type SessionAttentionClassification =
       reason: string;
       classification: "blocked_tool_call" | "stalled_agent_run";
       activeWorkKind?: DiagnosticSessionActiveWorkKind;
-      recoveryEligible: false;
+      recoveryEligible: boolean;
     }
   | {
       eventType: "session.stuck";
@@ -48,12 +48,17 @@ export function classifySessionAttention(params: {
       params.activity.activeWorkKind === "embedded_run" &&
       isTerminalDiagnosticProgressReason(params.activity.lastProgressReason)
     ) {
+      // The active embedded_run has emitted a terminal progress signal
+      // (e.g., `rawResponseItem/completed`, `embedded_run:ended`) yet the
+      // lane is still holding queued items. The work signal indicates the
+      // active turn is effectively done, so allow the recovery coordinator
+      // to release the lane and let the queue drain.
       return {
         eventType: "session.stalled",
         reason: "queued_behind_terminal_active_work",
         classification: "stalled_agent_run",
         activeWorkKind: params.activity.activeWorkKind,
-        recoveryEligible: false,
+        recoveryEligible: true,
       };
     }
     if ((params.activity.lastProgressAgeMs ?? 0) > params.staleMs) {

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -1,7 +1,9 @@
 import { monitorEventLoopDelay, performance } from "node:perf_hooks";
+import { resolveEmbeddedSessionLane } from "../agents/pi-embedded-runner/lanes.js";
 import { getRuntimeConfig } from "../config/config.js";
 import { resolveAllAgentSessionStoreTargetsSync } from "../config/sessions/targets.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resetCommandLane } from "../process/command-queue.js";
 import {
   areDiagnosticsEnabledForProcess,
   emitDiagnosticEvent,
@@ -737,6 +739,22 @@ export function logSessionStateChange(
   if (params.state === "idle") {
     state.queueDepth = Math.max(0, state.queueDepth - 1);
     state.activeQueuedTurn = false;
+    // Belt-and-suspenders: if the lane returns to idle but still has queued
+    // items, force a pump. Normally `drainLane` re-fires recursively after
+    // each task completes, but in production we have observed lanes that go
+    // `idle` with `queueDepth > 0` and never dequeue (e.g., after an embedded
+    // run ends with terminal progress). Calling `resetCommandLane` bumps the
+    // lane generation, clears any stale `activeTaskIds`, and re-invokes
+    // `drainLane` — a no-op when the lane queue is already empty.
+    if (state.queueDepth > 0 && state.sessionKey) {
+      try {
+        resetCommandLane(resolveEmbeddedSessionLane(state.sessionKey));
+      } catch (err) {
+        diag.warn(
+          `lane-pump-on-idle failed: sessionKey=${state.sessionKey} error="${String(err)}"`,
+        );
+      }
+    }
   }
   if (!isProbeSession && diag.isEnabled("debug")) {
     diag.debug(

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -3,7 +3,6 @@ import { resolveEmbeddedSessionLane } from "../agents/pi-embedded-runner/lanes.j
 import { getRuntimeConfig } from "../config/config.js";
 import { resolveAllAgentSessionStoreTargetsSync } from "../config/sessions/targets.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { resetCommandLane } from "../process/command-queue.js";
 import {
   areDiagnosticsEnabledForProcess,
   emitDiagnosticEvent,
@@ -11,6 +10,7 @@ import {
   type DiagnosticPhaseSnapshot,
   type DiagnosticLivenessWarningReason,
 } from "../infra/diagnostic-events.js";
+import { resetCommandLane } from "../process/command-queue.js";
 import { emitDiagnosticMemorySample, resetDiagnosticMemoryForTest } from "./diagnostic-memory.js";
 import {
   getCurrentDiagnosticPhase,
@@ -1134,6 +1134,14 @@ export function startDiagnosticHeartbeat(
           thresholdMs: stuckSessionWarnMs,
           abortThresholdMs: stuckSessionAbortMs,
         });
+        const activeAbortRecoveryEligible =
+          classification !== undefined &&
+          isActiveAbortRecoveryEligible({
+            classification,
+            activity,
+            ageMs: attentionAgeMs,
+            stuckSessionAbortMs,
+          });
         if (classification?.recoveryEligible) {
           requestStuckSessionRecovery({
             recover: opts?.recoverStuckSession ?? recoverStuckSession,
@@ -1143,19 +1151,12 @@ export function startDiagnosticHeartbeat(
               sessionKey: state.sessionKey,
               ageMs: attentionAgeMs,
               queueDepth: state.queueDepth,
+              ...(activeAbortRecoveryEligible ? { allowActiveAbort: true } : {}),
               expectedState: state.state,
               stateGeneration: state.generation,
             },
           });
-        } else if (
-          classification &&
-          isActiveAbortRecoveryEligible({
-            classification,
-            activity,
-            ageMs: attentionAgeMs,
-            stuckSessionAbortMs,
-          })
-        ) {
+        } else if (classification && activeAbortRecoveryEligible) {
           requestStuckSessionRecovery({
             recover: opts?.recoverStuckSession ?? recoverStuckSession,
             classification,


### PR DESCRIPTION
## Summary

Four related fixes for failure modes that can take a self-hosted gateway's Telegram channel offline and require a manual restart to recover. All four were diagnosed and validated in production on a `v2026.5.19` build. Two are diagnostics/lane-queue self-healing; two restore OAuth resolution for the `openai-codex` provider on embedded-agent paths after a regression between `2026.5.12` and `2026.5.19`.

The four functional commits are independent and can be split if preferred, but they share one theme: **make the gateway self-heal from transient infrastructure blips instead of wedging until a human restarts it.** The final commit is review polish: it preserves the active-abort recovery flag for the newly recovery-eligible terminal embedded-run case and removes local emergency-patch wording from source comments.

## 1. `fix(diagnostic): pump lane on idle + recover from terminal-progress stalls`

Two issues in the per-lane command queue:

- **Lane pump on idle** (`src/logging/diagnostic.ts`): `logSessionStateChange()` decrements `queueDepth` when a lane returns to idle but never re-triggers the dequeue. Normally `drainLane()` re-fires recursively, but in production we observed lanes that go `idle` with `queueDepth > 0` and never dequeue, stranding queued messages. Fix: on idle transition with `queueDepth > 0` and a known `sessionKey`, call `resetCommandLane(resolveEmbeddedSessionLane(sessionKey))`. It is a no-op when the lane queue is already empty.

- **Stall recovery for terminal active work** (`src/logging/diagnostic-session-attention.ts`): `classifySessionAttention()` flagged `queued_behind_terminal_active_work` as `recoveryEligible: false`, so the existing recovery coordinator never fired and the lane wedged (`recovery=none`). Fix: mark it `recoveryEligible: true` so the existing recovery path runs.

The follow-up commit also keeps `allowActiveAbort: true` when the terminal embedded-run case has crossed the abort threshold; otherwise the recovery runtime can still skip because it sees an active embedded run.

## 2 & 3. `fix(auth): ... legacy OAuth sidecars in secrets-runtime store load` (+ follow-up for all entry points)

**Regression**: after upgrading `2026.5.12 -> 2026.5.19`, embedded agent turns (channel replies, cron-isolated runs) fail with `No API key found for provider "openai-codex"` even though the OAuth profile is valid and direct CLI inference works with the same profile.

**Root cause**: PR #82777 removed sidecar runtime support; follow-up #83312 reintroduced it via a helper used by the OAuth manager's refresh path. The parallel secrets-runtime store-load helpers were still defaulting `resolveLegacyOAuthSidecars: false`, so OAuth profiles whose credential material lives in the legacy sidecar layout (`oauthRef.source: "openclaw-credentials"`, hash-named files under `<state-dir>/credentials/auth-profiles/<id>.json`) were loaded without access/refresh tokens.

**Fix** (`src/agents/auth-profiles/store.ts`): default `resolveLegacyOAuthSidecars` to `true` in:

- `loadAuthProfileStoreForSecretsRuntime`
- `loadAuthProfileStoreWithoutExternalProfiles`
- `ensureAuthProfileStoreWithoutExternalProfiles`

These helpers are read-only and do not mutate persisted state; they only include credential material that is already on disk.

## 4. `fix(telegram): restart isolated polling cycle when bot loses initialized state`

After a network drop mid-cycle, the grammy bot can end up `Bot not initialized!` without the polling session noticing. Every subsequent spooled-update handler can then fail with the same error in a tight retry loop, recoverable only by an external gateway restart.

Fix (`extensions/telegram/src/polling-session.ts`): the spool-failure path detects the `Bot not initialized` error and asks the active isolated ingress cycle to abort via a one-shot callback. The existing `try/finally` tears the cycle down, and the outer `runUntilAbort` loop creates a fresh bot and re-runs `bot.init()`.

## Real behavior proof

- **Behavior or issue addressed:** A self-hosted OpenClaw gateway could wedge after transient infrastructure failures: embedded OpenAI Codex OAuth profiles failed to resolve legacy sidecar tokens in cron/Telegram embedded paths, Telegram polling could loop on `Bot not initialized!` after a network drop, and queued lane work could remain stuck behind terminal embedded progress instead of recovering.
- **Real environment tested:** Real self-hosted OpenClaw gateway running OpenClaw 2026.5.19 from the patched fork build `9d27317` on a user systemd gateway service, using Telegram direct messages plus isolated cron agent turns with provider `openai-codex` / model `openai/gpt-5.5`. Local paths, PIDs, account IDs, and user identifiers are redacted.
- **Exact steps or command run after this patch:** Activated the patched fork build on the real gateway, confirmed the gateway process was active, sent Telegram messages through the live bot, forced/observed an isolated AgentOS task-board sweep cron using `openai/gpt-5.5`, then checked the current gateway PID logs for OAuth and bot-init recurrence.
- **Evidence after fix:** Redacted terminal output from the live gateway after activation:

  ```text
  $ openclaw --version
  OpenClaw 2026.5.19 (9d27317)

  $ readlink <deploy>/current
  releases/fork-9d273178-20260521T005128Z

  $ systemctl --user show openclaw-gateway.service -p ActiveState -p SubState -p MainPID -p NRestarts
  ActiveState=active
  SubState=running
  MainPID=<pid>
  NRestarts=0

  $ journalctl --user -u openclaw-gateway.service _PID=<pid> --no-pager | grep -c 'No API key found for provider'
  0
  ```

  Redacted live cron result from the same gateway:

  ```text
  job: AgentOS task board auto-advance sweep
  sessionTarget: isolated
  payload.model: openai/gpt-5.5
  lastRunStatus: ok
  lastDeliveryStatus: delivered
  provider: openai-codex
  ```
- **Observed result after fix:** The gateway kept responding to direct Telegram messages, the isolated cron embedded-agent run completed and delivered with `openai-codex`, current-PID logs showed zero `No API key found for provider` occurrences after activation, and no `Bot not initialized!` retry storm recurred on the patched runtime.
- **What was not tested:** No browser UI flow was exercised. The evidence is from the real gateway runtime, Telegram path, isolated cron path, service state, and current-PID runtime logs; targeted automated tests are listed separately below.


## Testing

Local targeted checks run on this branch:

```text
$ git diff --check
# passed

$ node scripts/test-projects.mjs src/logging/diagnostic-session-attention.test.ts src/logging/diagnostic.test.ts
# 54 tests passed across unit-fast + logging shards

$ node scripts/test-projects.mjs src/agents/auth-profiles/profiles.test.ts src/agents/auth-profiles.store-cache.test.ts src/commands/doctor-auth-oauth-sidecar.test.ts
# 23 tests passed across commands + agents shards

$ node scripts/test-projects.mjs extensions/telegram/src/polling-session.test.ts
# 42 tests passed

$ pnpm check:import-cycles
# Import cycle check: 0 runtime value cycle(s).
```

## Notes

- Cherry-picked clean onto current `main` with no conflicts.
- No deploy-specific scripts, secrets, local paths, or operational state are included in the diff.
- Happy to split into separate PRs (diagnostics vs auth vs telegram) if that is easier to review.