### PR TITLE
Strip plaintext provider keys from generated models.json

### DIFF
--- a/src/agents/models-config.applies-config-env-vars.test.ts
+++ b/src/agents/models-config.applies-config-env-vars.test.ts
@@ -246,6 +246,64 @@ describe("models-config", () => {
     ]);
   });
 
+  it("strips plaintext api keys from planned models.json contents", async () => {
+    const plan = await planOpenClawModelsJsonWithDeps(
+      {
+        cfg: {
+          models: {
+            mode: "merge",
+            providers: {
+              custom: {
+                baseUrl: "https://custom.example/v1",
+                api: "openai-completions",
+                apiKey: "plain-config-key",
+                models: [{ id: "custom-model", name: "Custom Model", input: ["text"] }],
+              },
+              vllm: {
+                baseUrl: "http://127.0.0.1:8000/v1",
+                api: "openai-completions",
+                apiKey: "${MY_VLLM_KEY}",
+                models: [{ id: "vllm-model", name: "vLLM Model", input: ["text"] }],
+              },
+            },
+          },
+        },
+        agentDir: "/tmp/openclaw-models-config-env-vars-test",
+        env: {
+          MY_VLLM_KEY: "resolved-vllm-key",
+        } as NodeJS.ProcessEnv,
+        existingRaw: "",
+        existingParsed: {
+          providers: {
+            legacy: {
+              baseUrl: "https://legacy.example/v1",
+              api: "openai-completions",
+              apiKey: "plain-existing-key",
+              models: [{ id: "legacy-model", name: "Legacy Model", input: ["text"] }],
+            },
+          },
+        },
+      },
+      {
+        resolveImplicitProviders: async () => ({}),
+      },
+    );
+
+    expect(plan.action).toBe("write");
+    if (plan.action !== "write") {
+      throw new Error("Expected models.json write plan");
+    }
+    expect(plan.contents).not.toContain("plain-config-key");
+    expect(plan.contents).not.toContain("plain-existing-key");
+
+    const parsed = JSON.parse(plan.contents) as {
+      providers?: Record<string, { apiKey?: string }>;
+    };
+    expect(parsed.providers?.custom?.apiKey).toBeUndefined();
+    expect(parsed.providers?.legacy?.apiKey).toBeUndefined();
+    expect(parsed.providers?.vllm?.apiKey).toBe("MY_VLLM_KEY");
+  });
+
   it("uses config env.vars entries for implicit provider discovery without mutating process.env", async () => {
     await withTempEnv(["OPENROUTER_API_KEY", TEST_ENV_VAR], async () => {
       unsetEnv(["OPENROUTER_API_KEY", TEST_ENV_VAR]);

--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import { isRecord } from "../utils.js";
+import { isNonSecretApiKeyMarker } from "./model-auth-markers.js";
 import {
   mergeProviders,
   mergeWithExistingProviderSecrets,
@@ -105,6 +106,30 @@ function resolveProvidersForMode(params: {
   });
 }
 
+function stripPlaintextProviderApiKeysForModelsJson(params: {
+  providers: Record<string, ProviderConfig>;
+  secretRefManagedProviders: ReadonlySet<string>;
+}): Record<string, ProviderConfig> {
+  let mutated = false;
+  const sanitized: Record<string, ProviderConfig> = {};
+  for (const [providerKey, provider] of Object.entries(params.providers)) {
+    const apiKey = provider.apiKey;
+    const shouldKeepApiKey =
+      typeof apiKey === "string" &&
+      apiKey.trim().length > 0 &&
+      (params.secretRefManagedProviders.has(providerKey.trim()) || isNonSecretApiKeyMarker(apiKey));
+    if (apiKey === undefined || shouldKeepApiKey) {
+      sanitized[providerKey] = provider;
+      continue;
+    }
+
+    mutated = true;
+    const { apiKey: _apiKey, ...providerWithoutApiKey } = provider;
+    sanitized[providerKey] = providerWithoutApiKey as ProviderConfig;
+  }
+  return mutated ? sanitized : params.providers;
+}
+
 export async function planOpenClawModelsJsonWithDeps(
   params: {
     cfg: OpenClawConfig;
@@ -178,7 +203,11 @@ export async function planOpenClawModelsJsonWithDeps(
       secretRefManagedProviders,
     }) ?? normalizedMergedProviders;
   const finalProviders = applyNativeStreamingUsageCompat(secretEnforcedProviders);
-  const nextContents = `${JSON.stringify({ providers: finalProviders }, null, 2)}\n`;
+  const safeProviders = stripPlaintextProviderApiKeysForModelsJson({
+    providers: finalProviders,
+    secretRefManagedProviders,
+  });
+  const nextContents = `${JSON.stringify({ providers: safeProviders }, null, 2)}\n`;
 
   if (params.existingRaw === nextContents) {
     return { action: "noop" };


### PR DESCRIPTION
Addresses #11829 (Layer 1).

## Summary
- remove plaintext provider `apiKey` values from generated `models.json` after provider normalization/merge
- keep non-secret auth markers and secret-ref/env markers so discovery can still use safe placeholders
- add a regression covering configured plaintext keys, legacy existing `models.json` keys, and env secret-ref marker preservation

## Tests
- `git diff --check`
- Not run: targeted Vitest could not be executed locally because dependency installation was blocked by the local safety reviewer.