### PR TITLE
feat(secrets): scan backup files for plaintext provider apiKey values

### DIFF
--- a/src/secrets/audit.test.ts
+++ b/src/secrets/audit.test.ts
@@ -459,6 +459,83 @@ describe("secrets audit", () => {
     });
   });
 
+  it("scans backup files for plaintext apiKey values", async () => {
+    const backupPath = path.join(fixture.stateDir, "models.json.20260501.bak");
+    await writeJsonFile(backupPath, {
+      providers: {
+        openai: {
+          baseUrl: "https://api.openai.com/v1",
+          api: "openai-completions",
+          apiKey: "sk-bak...text", // pragma: allowlist secret
+          models: [{ id: "gpt-5", name: "gpt-5" }],
+        },
+      },
+    });
+
+    const report = await runSecretsAudit({ env: fixture.env });
+
+    expect(report.filesScanned).toContain(backupPath);
+    expect(
+      report.findings.some(
+        (entry) =>
+          entry.code === "LEGACY_RESIDUE" &&
+          entry.file === backupPath &&
+          entry.jsonPath === "providers.openai.apiKey" &&
+          entry.message.includes("Backup file contains plaintext"),
+      ),
+    ).toBe(true);
+  });
+
+  it("scans .bak files for plaintext apiKey values", async () => {
+    const backupPath = path.join(fixture.stateDir, "openclaw.json.old");
+    await writeJsonFile(backupPath, {
+      providers: {
+        anthropic: {
+          baseUrl: "https://api.anthropic.com/v1",
+          api: "anthropic-messages",
+          apiKey: "sk-ant...bak", // pragma: allowlist secret
+          models: [{ id: "claude-4", name: "claude-4" }],
+        },
+      },
+    });
+
+    const report = await runSecretsAudit({ env: fixture.env });
+
+    expect(report.filesScanned).toContain(backupPath);
+    expect(
+      report.findings.some(
+        (entry) =>
+          entry.code === "LEGACY_RESIDUE" &&
+          entry.file === backupPath &&
+          entry.jsonPath === "providers.anthropic.apiKey",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not flag non-secret markers in backup files", async () => {
+    const backupPath = path.join(fixture.stateDir, "openclaw.json.bak");
+    await writeJsonFile(backupPath, {
+      providers: {
+        openai: {
+          baseUrl: "https://api.openai.com/v1",
+          api: "openai-completions",
+          apiKey: "OPENAI_API_KEY",
+          models: [{ id: "gpt-5", name: "gpt-5" }],
+        },
+      },
+    });
+
+    const report = await runSecretsAudit({ env: fixture.env });
+
+    expect(report.filesScanned).toContain(backupPath);
+    expect(
+      report.findings.some(
+        (entry) =>
+          entry.code === "LEGACY_RESIDUE" && entry.file === backupPath,
+      ),
+    ).toBe(false);
+  });
+
   it("does not flag models.json marker values as plaintext", async () => {
     await writeModelsProvider();
 

--- a/src/secrets/audit.ts
+++ b/src/secrets/audit.ts
@@ -32,6 +32,7 @@ import { isNonEmptyString, isRecord } from "./shared.js";
 import {
   listAgentModelsJsonPaths,
   listAuthProfileStorePaths,
+  listKnownSecretFileBackups,
   listLegacyAuthJsonPaths,
   parseEnvAssignmentValue,
   readJsonObjectIfExists,
@@ -298,6 +299,69 @@ function collectAuthStoreSecrets(params: {
         profileId: entry.profileId,
       });
       trackAuthProviderState(params.collector, entry.provider, "oauth");
+    }
+  }
+}
+
+function collectBackupResidue(params: { stateDir: string; collector: AuditCollector }): void {
+  for (const backupPath of listKnownSecretFileBackups(params.stateDir)) {
+    params.collector.filesScanned.add(backupPath);
+    const parsedResult = readJsonObjectIfExists(backupPath);
+    if (parsedResult.error) {
+      addFinding(params.collector, {
+        code: "LEGACY_RESIDUE",
+        severity: "warn",
+        file: backupPath,
+        jsonPath: "<root>",
+        message: `Invalid JSON in backup file: ${parsedResult.error}`,
+      });
+      continue;
+    }
+    const parsed = parsedResult.value;
+    if (!parsed) {
+      continue;
+    }
+    // Check for plaintext apiKey in provider configs within backup files
+    const providers = isRecord(parsed) && isRecord(parsed.providers)
+      ? parsed.providers
+      : parsed;
+    if (!isRecord(providers)) {
+      continue;
+    }
+    for (const [providerId, value] of Object.entries(providers)) {
+      if (!isRecord(value)) {
+        continue;
+      }
+      const apiKey = (value as Record<string, unknown>).apiKey;
+      if (isNonEmptyString(apiKey) && !isNonSecretApiKeyMarker(apiKey)) {
+        addFinding(params.collector, {
+          code: "LEGACY_RESIDUE",
+          severity: "warn",
+          file: backupPath,
+          jsonPath: `providers.${providerId}.apiKey`,
+          message: "Backup file contains plaintext provider apiKey.",
+          provider: providerId,
+        });
+      }
+      // Also check sub-keys: some backup formats nest providers
+      if (isRecord(value.providers)) {
+        for (const [subId, subValue] of Object.entries(value.providers)) {
+          if (!isRecord(subValue)) {
+            continue;
+          }
+          const subApiKey = (subValue as Record<string, unknown>).apiKey;
+          if (isNonEmptyString(subApiKey) && !isNonSecretApiKeyMarker(subApiKey)) {
+            addFinding(params.collector, {
+              code: "LEGACY_RESIDUE",
+              severity: "warn",
+              file: backupPath,
+              jsonPath: `providers.${subId}.apiKey`,
+              message: "Backup file contains plaintext provider apiKey.",
+              provider: subId,
+            });
+          }
+        }
+      }
     }
   }
 }
@@ -682,6 +746,10 @@ export async function runSecretsAudit(
     collector,
   });
   collectAuthJsonResidue({
+    stateDir,
+    collector,
+  });
+  collectBackupResidue({
     stateDir,
     collector,
   });

--- a/src/secrets/storage-scan.ts
+++ b/src/secrets/storage-scan.ts
@@ -77,6 +77,33 @@ export function listAgentModelsJsonPaths(
   return [...paths];
 }
 
+export function listKnownSecretFileBackups(stateDir: string): string[] {
+  const out: string[] = [];
+  const searchRoots = [
+    path.join(resolveUserPath(stateDir), "agents"),
+    resolveUserPath(stateDir),
+  ];
+  for (const root of searchRoots) {
+    if (!fs.existsSync(root)) {
+      continue;
+    }
+    for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+      const fullPath = path.join(root, entry.name);
+      if (entry.isDirectory()) {
+        continue;
+      }
+      // Match backup files: models.json.*, openclaw.json.*, *.bak, *.backup, *.old
+      if (
+        /^(models|openclaw)\.json\.\d/.test(entry.name) ||
+        /\.(bak|backup|old)$/.test(entry.name)
+      ) {
+        out.push(fullPath);
+      }
+    }
+  }
+  return out;
+}
+
 export type ReadJsonObjectOptions = {
   maxBytes?: number;
   requireRegularFile?: boolean;


### PR DESCRIPTION
## Summary

Adds backup file secret scanning to the `openclaw secrets audit` command. This addresses a security gap identified in issue #11829 where old backup files (e.g., `models.json.20260501.bak`, `openclaw.json.old`) may retain plaintext provider API keys even after the active config is sanitized.

## Changes

- **storage-scan.ts**: New `listKnownSecretFileBackups()` function that discovers backup files in the config directory and agents directory matching patterns like `models.json.*`, `openclaw.json.*`, `*.bak`, `*.backup`, `*.old`
- **audit.ts**: New `collectBackupResidue()` function that scans backup files for plaintext `apiKey` values and reports them as `LEGACY_RESIDUE` findings
- **audit.test.ts**: 3 test cases covering:
  - Detecting plaintext apiKey in `.bak` files
  - Detecting plaintext apiKey in `.old` files  
  - Not flagging non-secret markers (env var names) in backup files

Part of #11829 - Protecting API Keys from Agent Access