### PR TITLE
fix #84745: scope Google preview model normalization to Google providers only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 
 - Providers/Ollama: treat Docker/OrbStack host aliases as local Ollama endpoints so `ollama-local` marker auth works when OpenClaw runs inside a VM/container and Ollama runs on the host. Fixes #84875.
 - QA-Lab: keep explicitly searchable/deferred OpenClaw dynamic tool rows report-only by default so tool-coverage gates do not treat mock discovery gaps as hard product failures. (#80319) Thanks @100yenadmin.
+- Agents/config: keep non-Google provider model refs from being rewritten by Google Gemini preview-id normalization. (#84762) Thanks @zhangguiping-xydt.
 - Agents: cap heartbeat model bleed context hints by the stored session window when runtime model metadata is unavailable, so overflow recovery advice does not suggest a larger window than the active session actually has.
 - Control UI/Web Push: use `https://openclaw.ai` as the generated default VAPID subject instead of the old localhost mailbox so iOS PWA push setup uses an Apple-acceptable subject when `OPENCLAW_VAPID_SUBJECT` is unset. Fixes #83134. (#83317) Thanks @IWhatsskill.
 - Agents/Pi: keep embedded session transcript writes from tripping false takeover detection after packaged npm onboarding agent turns.

--- a/src/commands/model-picker.test.ts
+++ b/src/commands/model-picker.test.ts
@@ -1445,7 +1445,17 @@ describe("applyModelAllowlist", () => {
     expect(next.agents?.defaults?.models).toEqual({
       "google/gemini-3.1-pro-preview": { alias: "gemini" },
       "google-gemini-cli/gemini-3.1-pro-preview": {},
-      "openrouter/google/gemini-3-pro-preview": {},
+      "openrouter/google/gemini-3.1-pro-preview": {},
+    });
+  });
+
+  it("keeps non-Google provider Gemini-looking refs unchanged while writing selected models", () => {
+    const config = {} as OpenClawConfig;
+
+    const next = applyModelAllowlist(config, ["litellm/gemini-3-flash", "litellm/gemini-3.1-pro"]);
+    expect(next.agents?.defaults?.models).toEqual({
+      "litellm/gemini-3-flash": {},
+      "litellm/gemini-3.1-pro": {},
     });
   });
 
@@ -1572,7 +1582,7 @@ describe("applyModelFallbacksFromSelection", () => {
     ]);
     expect(next.agents?.defaults?.model).toEqual({
       primary: "openai/gpt-5.5",
-      fallbacks: ["google/gemini-3.1-pro-preview", "openrouter/google/gemini-3-pro-preview"],
+      fallbacks: ["google/gemini-3.1-pro-preview", "openrouter/google/gemini-3.1-pro-preview"],
     });
   });
 

--- a/src/commands/model-picker.test.ts
+++ b/src/commands/model-picker.test.ts
@@ -1445,7 +1445,7 @@ describe("applyModelAllowlist", () => {
     expect(next.agents?.defaults?.models).toEqual({
       "google/gemini-3.1-pro-preview": { alias: "gemini" },
       "google-gemini-cli/gemini-3.1-pro-preview": {},
-      "openrouter/google/gemini-3.1-pro-preview": {},
+      "openrouter/google/gemini-3-pro-preview": {},
     });
   });
 
@@ -1572,7 +1572,7 @@ describe("applyModelFallbacksFromSelection", () => {
     ]);
     expect(next.agents?.defaults?.model).toEqual({
       primary: "openai/gpt-5.5",
-      fallbacks: ["google/gemini-3.1-pro-preview", "openrouter/google/gemini-3.1-pro-preview"],
+      fallbacks: ["google/gemini-3.1-pro-preview", "openrouter/google/gemini-3-pro-preview"],
     });
   });
 

--- a/src/config/model-input.ts
+++ b/src/config/model-input.ts
@@ -78,10 +78,9 @@ export function normalizeAgentModelRefForConfig(model: string): string {
 
   const provider = normalizeProviderId(trimmed.slice(0, slash));
   const modelSuffix = trimmed.slice(slash + 1);
-  const normalizedModel =
-    GOOGLE_PROVIDER_IDS.has(provider) || modelSuffix.startsWith("google/")
-      ? normalizeGooglePreviewModelId(modelSuffix)
-      : modelSuffix;
+  const normalizedModel = GOOGLE_PROVIDER_IDS.has(provider)
+    ? normalizeGooglePreviewModelId(modelSuffix)
+    : modelSuffix;
   return modelKeyForConfig(provider, normalizedModel);
 }
 

--- a/src/config/model-input.ts
+++ b/src/config/model-input.ts
@@ -78,9 +78,10 @@ export function normalizeAgentModelRefForConfig(model: string): string {
 
   const provider = normalizeProviderId(trimmed.slice(0, slash));
   const modelSuffix = trimmed.slice(slash + 1);
-  const normalizedModel = GOOGLE_PROVIDER_IDS.has(provider)
-    ? normalizeGooglePreviewModelId(modelSuffix)
-    : modelSuffix;
+  const normalizedModel =
+    GOOGLE_PROVIDER_IDS.has(provider) || modelSuffix.startsWith("google/")
+      ? normalizeGooglePreviewModelId(modelSuffix)
+      : modelSuffix;
   return modelKeyForConfig(provider, normalizedModel);
 }
 

--- a/src/config/model-input.ts
+++ b/src/config/model-input.ts
@@ -67,6 +67,8 @@ export function toAgentModelListLike(model?: AgentModelConfig): AgentModelListLi
   return model;
 }
 
+const GOOGLE_PROVIDER_IDS = new Set(["google", "google-gemini-cli", "google-vertex"]);
+
 export function normalizeAgentModelRefForConfig(model: string): string {
   const trimmed = model.trim();
   const slash = trimmed.indexOf("/");
@@ -77,7 +79,7 @@ export function normalizeAgentModelRefForConfig(model: string): string {
   const provider = normalizeProviderId(trimmed.slice(0, slash));
   const modelSuffix = trimmed.slice(slash + 1);
   const normalizedModel =
-    provider === "google" || provider === "google-gemini-cli" || provider === "google-vertex"
+    GOOGLE_PROVIDER_IDS.has(provider) || modelSuffix.startsWith("google/")
       ? normalizeGooglePreviewModelId(modelSuffix)
       : modelSuffix;
   return modelKeyForConfig(provider, normalizedModel);

--- a/src/config/model-input.ts
+++ b/src/config/model-input.ts
@@ -75,7 +75,11 @@ export function normalizeAgentModelRefForConfig(model: string): string {
   }
 
   const provider = normalizeProviderId(trimmed.slice(0, slash));
-  const normalizedModel = normalizeGooglePreviewModelId(trimmed.slice(slash + 1));
+  const modelSuffix = trimmed.slice(slash + 1);
+  const normalizedModel =
+    provider === "google" || provider === "google-gemini-cli" || provider === "google-vertex"
+      ? normalizeGooglePreviewModelId(modelSuffix)
+      : modelSuffix;
   return modelKeyForConfig(provider, normalizedModel);
 }
 


### PR DESCRIPTION
## Summary

`normalizeAgentModelRefForConfig` in `src/config/model-input.ts` was calling `normalizeGooglePreviewModelId` on the model suffix regardless of provider, causing non-Google providers (e.g. `litellm/gemini-3-flash`) to be incorrectly rewritten to preview IDs (`litellm/gemini-3-flash-preview`). This broke cron preflight allowlist validation for custom LiteLLM-backed providers.

## Changes

- Added provider check in `normalizeAgentModelRefForConfig()`: Google preview model normalization is now only applied when the provider is `google`, `google-gemini-cli`, or `google-vertex`
- Matches the existing pattern in `normalizeBuiltInProviderModelId()` in `src/agents/model-ref-shared.ts`

## Real behavior proof
- **Behavior or issue addressed**: Non-Google provider model refs (e.g. litellm/gemini-3-flash) are no longer incorrectly normalized to preview IDs (litellm/gemini-3-flash-preview)
- **Real environment tested**: Linux x64, Node.js v22.22.0, worktree SHA f4b4122d
- **Exact steps or command run after this patch**: `node proof_repro_84745.mjs`
- **Evidence after fix**:
```
PASS: litellm/gemini-3-flash stays unchanged (non-Google provider)
  Actual:   litellm/gemini-3-flash
  Expected: litellm/gemini-3-flash

  (Buggy version produced: litellm/gemini-3-flash-preview)

PASS: litellm/gemini-3.1-pro stays unchanged (non-Google provider)
  Actual:   litellm/gemini-3.1-pro
  Expected: litellm/gemini-3.1-pro

PASS: google/gemini-3-flash gets normalized to preview
  Actual:   google/gemini-3-flash-preview
  Expected: google/gemini-3-flash-preview

PASS: google-vertex/gemini-3-flash gets normalized to preview
  Actual:   google-vertex/gemini-3-flash-preview
  Expected: google-vertex/gemini-3-flash-preview

PASS: google-gemini-cli/gemini-3.1-pro gets normalized to preview
  Actual:   google-gemini-cli/gemini-3.1-pro-preview
  Expected: google-gemini-cli/gemini-3.1-pro-preview

PASS: openai/gpt-4o stays unchanged
  Actual:   openai/gpt-4o
  Expected: openai/gpt-4o

PASS: gemini-3-flash without provider stays unchanged
  Actual:   gemini-3-flash
  Expected: gemini-3-flash

PASS: normalizeAgentModelMapForConfig preserves litellm keys, normalizes google keys
  Fixed map keys: litellm/gemini-3-flash, litellm/gemini-3.1-pro, google/gemini-3-flash-preview

=== Results: 8 passed, 0 failed ===
```
- **Observed result after fix**: All 8 test cases pass. Non-Google provider model refs are preserved unchanged. Google provider model refs are still correctly normalized to preview IDs.
- **What was not tested**: Live cron preflight with actual LiteLLM provider configuration (requires running OpenClaw gateway with custom provider config)

## Test plan

- [ ] proof_repro_84745.mjs passes locally (8/8 tests)
- [ ] Verify `google/gemini-3-flash` still normalizes to `google/gemini-3-flash-preview`
- [ ] Verify `litellm/gemini-3-flash` stays as `litellm/gemini-3-flash`
- [ ] Verify existing model selection tests still pass