### PR TITLE
fix(cli): warn when action reparse uses fallback argv

### DIFF
--- a/src/cli/program/action-reparse.test.ts
+++ b/src/cli/program/action-reparse.test.ts
@@ -5,9 +5,14 @@ import { reparseProgramFromActionArgs } from "./action-reparse.js";
 const buildParseArgvMock = vi.hoisted(() => vi.fn());
 const resolveActionArgsMock = vi.hoisted(() => vi.fn());
 const resolveCommandOptionArgsMock = vi.hoisted(() => vi.fn());
+const logWarnMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../argv.js", () => ({
   buildParseArgv: buildParseArgvMock,
+}));
+
+vi.mock("../../logger.js", () => ({
+  logWarn: logWarnMock,
 }));
 
 vi.mock("./helpers.js", () => ({
@@ -41,6 +46,7 @@ describe("reparseProgramFromActionArgs", () => {
       rawArgs: ["node", "openclaw", "status", "--json"],
       fallbackArgv: ["status", "--json"],
     });
+    expect(logWarnMock).not.toHaveBeenCalled();
     expect(parseAsync).toHaveBeenCalledWith(["node", "openclaw", "status"]);
   });
 
@@ -60,6 +66,9 @@ describe("reparseProgramFromActionArgs", () => {
       rawArgs: undefined,
       fallbackArgv: ["--json"],
     });
+    expect(logWarnMock).toHaveBeenCalledWith(
+      "cli: Commander rawArgs unavailable while reparsing action; falling back to reconstructed argv.",
+    );
     expect(parseAsync).toHaveBeenCalledWith(["node", "openclaw", "status"]);
   });
 
@@ -96,6 +105,7 @@ describe("reparseProgramFromActionArgs", () => {
       rawArgs: [],
       fallbackArgv: [],
     });
+    expect(logWarnMock).not.toHaveBeenCalled();
     expect(parseAsync).toHaveBeenCalledWith(["node", "openclaw", "status"]);
   });
 });

--- a/src/cli/program/action-reparse.ts
+++ b/src/cli/program/action-reparse.ts
@@ -1,4 +1,5 @@
 import type { Command } from "commander";
+import { logWarn } from "../../logger.js";
 import { buildParseArgv } from "../argv.js";
 import { resolveActionArgs, resolveCommandOptionArgs } from "./helpers.js";
 
@@ -19,6 +20,11 @@ export async function reparseProgramFromActionArgs(
   const root = actionCommand?.parent ?? program;
   const rawArgs = (root as Command & { rawArgs?: string[] }).rawArgs;
   const fallbackArgv = buildFallbackArgv(program, actionCommand);
+  if ((!rawArgs || rawArgs.length === 0) && fallbackArgv.length > 0) {
+    logWarn(
+      "cli: Commander rawArgs unavailable while reparsing action; falling back to reconstructed argv.",
+    );
+  }
   const parseArgv = buildParseArgv({
     programName: program.name(),
     rawArgs,


### PR DESCRIPTION
## Summary
- Emit an explicit CLI warning when action reparse cannot read Commander `rawArgs` and must use reconstructed fallback argv.
- Keep the normal `rawArgs` path quiet.
- Extend `action-reparse` tests to cover both the warning and non-warning paths.

Fixes #83893

## Real behavior proof

Behavior addressed: `reparseProgramFromActionArgs` accessed Commander's non-public `rawArgs` field through a cast. If that field is absent or empty, OpenClaw silently falls back to reconstructed argv, making Commander internals drift hard to detect.

Real environment tested: Local OpenClaw checkout on macOS, Node.js v22.22.0, branch `fix/cli-action-reparse-rawargs-warning-83893`, using the real `src/cli/program/action-reparse.ts` implementation under the repo's Vitest runner.

Exact steps or command run after fix:

```console
$ node scripts/run-vitest.mjs src/cli/program/action-reparse.test.ts
$ git diff --check
```

Evidence after fix: Terminal output from the targeted test run:

```console
✓ cli ../../src/cli/program/action-reparse.test.ts (4 tests) 21ms

Test Files 1 passed (1)
Tests 4 passed (4)
```

Observed result after fix: The fallback test now verifies `logWarn` is called with `cli: Commander rawArgs unavailable while reparsing action; falling back to reconstructed argv.` when `rawArgs` is unavailable and fallback argv is used. The normal raw-args test verifies no warning is emitted when Commander provides `rawArgs`.

What was not tested: I did not simulate a future Commander version removing `rawArgs` in a full CLI subprocess; the targeted unit test covers the same missing-field shape directly at the reparse seam.

## Test plan
- `node scripts/run-vitest.mjs src/cli/program/action-reparse.test.ts`
- `git diff --check`
