### PR TITLE
fix(pdf): time out idle remote PDF reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 - fix(config): validate browser sandbox bind sources [AI]. (#84799) Thanks @pgondhi987.
 - doctor: constrain legacy plugin cleanup paths [AI]. (#84801) Thanks @pgondhi987.
 - Update/doctor: prune stale local bundled plugin install records that point at old compiled bundled output so current bundled plugin schemas win after upgrade. (#84863) Thanks @fuller-stack-dev.
+- PDF tool: time out idle remote PDF body reads after 120 seconds so stalled remote documents return an error instead of wedging the session. Fixes #68649. (#84768) Thanks @luoyanglang.
 - Media/audio: skip empty structured sherpa-onnx transcripts instead of treating the raw JSON payload as spoken text. (#84667) Thanks @TurboTheTurtle.
 - Node/Linux: keep `OPENCLAW_GATEWAY_TOKEN` out of generated systemd unit files by writing node service token values to a node-specific env file. (#84408)
 - Memory-core/dreaming: reuse stable narrative subagent session keys per workspace and phase while keeping per-run idempotency and bounded cleanup, so stale `dreaming-narrative-*` sessions do not accumulate. Fixes #68252, #69187, and #70402. (#70464) Thanks @chiyouYCH.

--- a/src/agents/tools/pdf-tool.test.ts
+++ b/src/agents/tools/pdf-tool.test.ts
@@ -388,7 +388,31 @@ describe("createPdfTool", () => {
       const [loadRef, loadOptions] = firstMockCall(loadSpy, "loadWebMediaRaw");
       expect(loadRef).toBe("http://198.18.0.153/doc.pdf");
       expectFields(loadOptions, {
+        readIdleTimeoutMs: 120_000,
         ssrfPolicy: { allowRfc2544BenchmarkRange: true },
+      });
+    });
+  });
+
+  it("passes the shared remote read idle timeout when loading remote PDFs", async () => {
+    await withTempPdfAgentDir(async (agentDir) => {
+      const { loadSpy } = await stubPdfToolInfra(agentDir, {
+        provider: "anthropic",
+        input: ["text", "document"],
+      });
+      vi.spyOn(pdfNativeProviders, "anthropicAnalyzePdf").mockResolvedValue("native summary");
+      const cfg = withPdfModel(ANTHROPIC_PDF_MODEL);
+      const tool = requirePdfTool((await loadCreatePdfTool())({ config: cfg, agentDir }));
+
+      await tool.execute("t1", {
+        prompt: "summarize",
+        pdf: "https://example.com/stalled.pdf",
+      });
+
+      const [loadRef, loadOptions] = firstMockCall(loadSpy, "loadWebMediaRaw");
+      expect(loadRef).toBe("https://example.com/stalled.pdf");
+      expectFields(loadOptions, {
+        readIdleTimeoutMs: 120_000,
       });
     });
   });

--- a/src/agents/tools/pdf-tool.ts
+++ b/src/agents/tools/pdf-tool.ts
@@ -52,6 +52,7 @@ const DEFAULT_PROMPT = "Analyze this PDF document.";
 const DEFAULT_MAX_PDFS = 10;
 const DEFAULT_MAX_BYTES_MB = 10;
 const DEFAULT_MAX_PAGES = 20;
+const PDF_REMOTE_READ_IDLE_TIMEOUT_MS = 120_000;
 
 const PDF_MIN_TEXT_CHARS = 200;
 const PDF_MAX_PIXELS = 4_000_000;
@@ -444,6 +445,7 @@ export function createPdfTool(options?: {
           : await loadWebMediaRaw(resolvedPathInfo.resolved, {
               maxBytes,
               localRoots,
+              ...(isHttpUrl ? { readIdleTimeoutMs: PDF_REMOTE_READ_IDLE_TIMEOUT_MS } : {}),
               ssrfPolicy: remoteMediaSsrfPolicy,
             });
 

--- a/src/media/web-media.test.ts
+++ b/src/media/web-media.test.ts
@@ -10,6 +10,7 @@ import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plug
 
 let LocalMediaAccessError: typeof import("./web-media.js").LocalMediaAccessError;
 let loadWebMedia: typeof import("./web-media.js").loadWebMedia;
+let loadWebMediaRaw: typeof import("./web-media.js").loadWebMediaRaw;
 let optimizeImageToJpeg: typeof import("./web-media.js").optimizeImageToJpeg;
 
 const TINY_PNG_BASE64 =
@@ -39,7 +40,8 @@ function installCanvasMediaResolver() {
 }
 
 beforeAll(async () => {
-  ({ LocalMediaAccessError, loadWebMedia, optimizeImageToJpeg } = await import("./web-media.js"));
+  ({ LocalMediaAccessError, loadWebMedia, loadWebMediaRaw, optimizeImageToJpeg } =
+    await import("./web-media.js"));
   fixtureRoot = await fs.mkdtemp(path.join(resolvePreferredOpenClawTmpDir(), "web-media-core-"));
   tinyPngFile = path.join(fixtureRoot, "tiny.png");
   await fs.writeFile(tinyPngFile, Buffer.from(TINY_PNG_BASE64, "base64"));
@@ -75,6 +77,47 @@ afterAll(async () => {
 });
 
 describe("loadWebMedia", () => {
+  function makeStallingFetch(firstChunk: Uint8Array) {
+    return vi.fn(
+      async () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(firstChunk);
+            },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/pdf" },
+          },
+        ),
+    );
+  }
+
+  async function expectWebMediaIdleTimeout(
+    createLoadPromise: () => Promise<unknown>,
+    idleTimeoutMs: number,
+  ) {
+    vi.useFakeTimers();
+    try {
+      const outcome = createLoadPromise().then(
+        () => ({ status: "resolved" as const }),
+        (error: unknown) => ({ status: "rejected" as const, error }),
+      );
+      await vi.advanceTimersByTimeAsync(idleTimeoutMs + 5);
+      await expect(
+        Promise.race([outcome, Promise.resolve({ status: "pending" as const })]),
+      ).resolves.toMatchObject({ status: "rejected" });
+      const result = await outcome;
+      expect(result.status).toBe("rejected");
+      if (result.status === "rejected") {
+        expect(String(result.error)).toMatch(/stalled|no data received/i);
+      }
+    } finally {
+      vi.useRealTimers();
+    }
+  }
+
   function createLocalWebMediaOptions() {
     return {
       maxBytes: 1024 * 1024,
@@ -687,6 +730,43 @@ describe("loadWebMedia", () => {
     } finally {
       await fs.rm(filePath, { force: true });
     }
+  });
+
+  it("applies the shared remote read idle timeout for raw web media loads", async () => {
+    const readIdleTimeoutMs = 20;
+    const fetchImpl = makeStallingFetch(new Uint8Array([0x25, 0x50, 0x44, 0x46]));
+
+    await expectWebMediaIdleTimeout(
+      () =>
+        loadWebMediaRaw("https://example.test/stalled.pdf", {
+          maxBytes: 1024 * 1024,
+          fetchImpl,
+          readIdleTimeoutMs,
+          ssrfPolicy: { allowedHostnames: ["example.test"] },
+        }),
+      readIdleTimeoutMs,
+    );
+  });
+
+  it("loads a valid remote PDF when the raw web media read stays active", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(Buffer.from("%PDF-1.4\n%%EOF"), {
+          status: 200,
+          headers: { "content-type": "application/pdf" },
+        }),
+    );
+
+    const result = await loadWebMediaRaw("https://example.test/ok.pdf", {
+      maxBytes: 1024 * 1024,
+      fetchImpl,
+      readIdleTimeoutMs: 20,
+      ssrfPolicy: { allowedHostnames: ["example.test"] },
+    });
+
+    expect(result.kind).toBe("document");
+    expect(result.contentType).toBe("application/pdf");
+    expect(result.buffer.toString()).toContain("%PDF-1.4");
   });
 
   it("rejects unsupported media store URI locations", async () => {

--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -49,6 +49,7 @@ type WebMediaOptions = {
   proxyUrl?: string;
   fetchImpl?: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
   requestInit?: RequestInit;
+  readIdleTimeoutMs?: number;
   trustExplicitProxyDns?: boolean;
   workspaceDir?: string;
   /** Allowed root directories for local path reads. "any" is deprecated; prefer sandboxValidated + readFile. */
@@ -388,6 +389,7 @@ async function loadWebMediaInternal(
     proxyUrl,
     fetchImpl,
     requestInit,
+    readIdleTimeoutMs,
     trustExplicitProxyDns,
     workspaceDir,
     localRoots,
@@ -521,6 +523,7 @@ async function loadWebMediaInternal(
       url: mediaUrl,
       fetchImpl,
       requestInit,
+      readIdleTimeoutMs,
       maxBytes: fetchCap,
       ssrfPolicy,
       dispatcherPolicy,


### PR DESCRIPTION
Remote PDF reads could hang a session when a remote PDF server sent headers and then stopped sending body bytes; this threads the existing shared idle-read timeout through the PDF/web-media path so the tool returns instead of staying stuck.

Fixes #68649

## Affected surface

- `src/agents/tools/pdf-tool.ts`
  - remote PDF load path in `createPdfTool`
- `src/media/web-media.ts`
  - `loadWebMediaRaw` / `readRemoteMediaBuffer` option threading
- `src/agents/tools/pdf-tool.test.ts`
- `src/media/web-media.test.ts`

## Scope

- Reuses the existing shared `readIdleTimeoutMs` / `readResponseWithLimit` contract.
- Adds no PDF-specific config, option, retry policy, or second timeout strategy.
- Keeps local and sandboxed PDF paths unchanged; the idle timeout is only supplied for http(s) PDF references.
- Does not change `/new`, `/restart`, or broader stuck-session recovery policy.

## Real behavior proof

- Behavior or issue addressed: A controlled remote PDF endpoint that sends headers and initial PDF bytes but then stops sending body data now returns from the remote media load path with an idle-read timeout error instead of hanging indefinitely.
- Real environment tested: Linux executor, Node via `node --import tsx`, local HTTP server bound to `127.0.0.1`, URL redacted as `<local-stall-url>`. The exercised OpenClaw path was `loadWebMediaRaw` -> `readRemoteMediaBuffer` -> shared `readResponseWithLimit` idle timeout contract. No secrets were used; SSRF private-network allowance was enabled only for this local controlled harness.
- Exact steps or command run after this patch:
  1. Rebased to latest `origin/main` (`8284c035a0`).
  2. Started a local HTTP server that responds to `/stall.pdf`.
  3. Returned `content-type: application/pdf`, `content-length`, and initial PDF bytes.
  4. Left the response body open without ending it.
  5. Called `loadWebMediaRaw(<local-stall-url>, { maxBytes, readIdleTimeoutMs: 300, ssrfPolicy: { allowPrivateNetwork: true } })`.
  6. Observed whether the call returned with the configured idle timeout.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):
  Controlled stalled remote PDF proof:
  ```text
  $ node --import tsx --input-type=module -e '<local controlled stalled-PDF harness>'
  [proof] method=loadWebMediaRaw url=<local-stall-url> readIdleTimeoutMs=300 maxBytes=10485760
  [server] method=GET path=/stall.pdf
  [proof] result=error elapsedMs=573 errorName=MediaFetchError message=Failed to fetch media from <local-stall-url>: Media download stalled: no data received for 300ms
  ```
  Targeted tests:
  ```text
  $ pnpm test src/agents/tools/pdf-tool.test.ts src/media/web-media.test.ts
  [test] starting test/vitest/vitest.media.config.ts
  Test Files  1 passed (1)
  Tests  47 passed (47)

  [test] starting test/vitest/vitest.agents.config.ts
  Test Files  1 passed (1)
  Tests  20 passed (20)

  [test] passed 2 Vitest shards in 59.97s
  ```
  Full changed-check validation:
  ```text
  $ pnpm check:changed --base origin/main
  [check:changed] lanes=core, coreTests
  [check:changed] src/agents/tools/pdf-tool.test.ts: core test
  [check:changed] src/agents/tools/pdf-tool.ts: core production
  [check:changed] src/media/web-media.test.ts: core test
  [check:changed] src/media/web-media.ts: core production
  ...
  Found 0 warnings and 0 errors.
  runtime-sidecar-loaders: local runtime sidecar loaders look OK.
  Import cycle check: 0 runtime value cycle(s).
  exit 0
  ```
- Observed result after fix: The controlled stalled remote PDF request returned after 573ms with `MediaFetchError: Media download stalled: no data received for 300ms`. That shows the after-fix path does not stay stuck on an idle remote PDF body read.
- What was not tested: I did not reproduce the reporter's original 244-page remote PDF endpoint or WhatsApp production session. I did not test `/new` or `/restart` stuck-session recovery behavior; that is outside this narrow PDF body-read timeout fix.
- Before evidence (optional but encouraged): Issue #68649 includes logs for a remote PDF tool call that never returned. ClawSweeper's source review also confirmed current main omits `readIdleTimeoutMs` on the remote PDF load path even though the lower-level body reader only enforces an idle timeout when that option is supplied.

Additional checks:

```text
$ git diff --check origin/main..HEAD
exit 0

$ node scripts/check-no-conflict-markers.mjs
exit 0

$ gitleaks protect --staged --redact
0 commits scanned; no leaks found

$ gitleaks detect --source . --redact --log-opts origin/main..HEAD
1 commits scanned; no leaks found
```

## Coverage note

Push-before-PR/update search was rerun after syncing `origin/main`; no separate open PR appears to cover this issue/path. The only `Fixes #68649` / `#68649` result is this PR (`#84768`). Other broad media PRs returned by `readResponseWithLimit` search do not cover the PDF `loadWebMediaRaw` caller missing `readIdleTimeoutMs`.

Helper reuse direction: this is a caller-threading fix into the existing shared read-idle timeout contract. It does not alter `fetch.ts` / `readResponseWithLimit` semantics and does not introduce a PDF-only timeout policy.

## What was not tested

- I did not reproduce the reporter's original 244-page remote PDF endpoint or WhatsApp production session.
- I did not test `/new` or `/restart` stuck-session recovery behavior; that is outside this narrow PDF body-read timeout fix.
