### PR TITLE
fix(codex): honor tool result cap in app-server transcripts

### DIFF
--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -1515,6 +1515,59 @@ describe("CodexAppServerEventProjector", () => {
     );
   });
 
+  it("keeps streamed native tool transcript truncation size accurate after later chunks", async () => {
+    const projector = await createProjector({
+      ...(await createParams()),
+      config: {
+        agents: {
+          defaults: {
+            contextLimits: {
+              toolResultMaxChars: 16,
+            },
+          },
+        },
+      },
+    } as EmbeddedRunAttemptParams);
+
+    await projector.handleNotification(
+      forCurrentTurn("item/commandExecution/outputDelta", {
+        itemId: "cmd-1",
+        delta: "abcdefghijklmnopqrst",
+      }),
+    );
+    await projector.handleNotification(
+      forCurrentTurn("item/commandExecution/outputDelta", {
+        itemId: "cmd-1",
+        delta: "uvwxyz",
+      }),
+    );
+    await projector.handleNotification(
+      turnCompleted([
+        {
+          type: "commandExecution",
+          id: "cmd-1",
+          command: "python scripts/run_demo_scenario.py",
+          cwd: "/workspace",
+          processId: null,
+          source: "agent",
+          status: "completed",
+          commandActions: [],
+          aggregatedOutput: null,
+          exitCode: 0,
+          durationMs: 42,
+        },
+      ]),
+    );
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+    const toolResultMessage = requireRecord(result.messagesSnapshot[2], "tool result message");
+    const toolResultContent = requireArray(toolResultMessage.content, "tool result content");
+    const toolResultContentItem = requireRecord(toolResultContent[0], "tool result content item");
+    expect(toolResultContentItem.content).toBe(
+      "abcdefghijklmnop\n...(truncated: original 26 chars, limit 16; rerun with narrower tool arguments for omitted output)...",
+    );
+  });
+
   it("uses per-agent toolResultMaxChars for native tool transcript snapshots", async () => {
     const projector = await createProjector({
       ...(await createParams()),

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -1468,6 +1468,146 @@ describe("CodexAppServerEventProjector", () => {
     expect(toolResult.result).toEqual({ status: "completed", exitCode: 0, durationMs: 42 });
   });
 
+  it("uses configured toolResultMaxChars for streamed native tool transcript output", async () => {
+    const projector = await createProjector({
+      ...(await createParams()),
+      config: {
+        agents: {
+          defaults: {
+            contextLimits: {
+              toolResultMaxChars: 16,
+            },
+          },
+        },
+      },
+    } as EmbeddedRunAttemptParams);
+
+    await projector.handleNotification(
+      forCurrentTurn("item/commandExecution/outputDelta", {
+        itemId: "cmd-1",
+        delta: "abcdefghijklmnopqrst",
+      }),
+    );
+    await projector.handleNotification(
+      turnCompleted([
+        {
+          type: "commandExecution",
+          id: "cmd-1",
+          command: "python scripts/run_demo_scenario.py",
+          cwd: "/workspace",
+          processId: null,
+          source: "agent",
+          status: "completed",
+          commandActions: [],
+          aggregatedOutput: null,
+          exitCode: 0,
+          durationMs: 42,
+        },
+      ]),
+    );
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+    const toolResultMessage = requireRecord(result.messagesSnapshot[2], "tool result message");
+    const toolResultContent = requireArray(toolResultMessage.content, "tool result content");
+    const toolResultContentItem = requireRecord(toolResultContent[0], "tool result content item");
+    expect(toolResultContentItem.content).toBe(
+      "abcdefghijklmnop\n...(truncated: original 20 chars, limit 16; rerun with narrower tool arguments for omitted output)...",
+    );
+  });
+
+  it("uses per-agent toolResultMaxChars for native tool transcript snapshots", async () => {
+    const projector = await createProjector({
+      ...(await createParams()),
+      agentId: "linkedin",
+      config: {
+        agents: {
+          defaults: {
+            contextLimits: {
+              toolResultMaxChars: 100,
+            },
+          },
+          list: [
+            {
+              id: "linkedin",
+              contextLimits: {
+                toolResultMaxChars: 5,
+              },
+            },
+          ],
+        },
+      },
+    } as EmbeddedRunAttemptParams);
+
+    await projector.handleNotification(
+      turnCompleted([
+        {
+          type: "commandExecution",
+          id: "cmd-1",
+          command: "python scripts/run_demo_scenario.py",
+          cwd: "/workspace",
+          processId: null,
+          source: "agent",
+          status: "completed",
+          commandActions: [],
+          aggregatedOutput: "abcdefghijkl",
+          exitCode: 0,
+          durationMs: 42,
+        },
+      ]),
+    );
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+    const toolResultMessage = requireRecord(result.messagesSnapshot[2], "tool result message");
+    const toolResultContent = requireArray(toolResultMessage.content, "tool result content");
+    const toolResultContentItem = requireRecord(toolResultContent[0], "tool result content item");
+    expect(toolResultContentItem.content).toBe(
+      "abcde\n...(truncated: original 12 chars, limit 5; rerun with narrower tool arguments for omitted output)...",
+    );
+  });
+
+  it("still caps raw native tool transcript snapshots containing a truncation marker", async () => {
+    const projector = await createProjector({
+      ...(await createParams()),
+      config: {
+        agents: {
+          defaults: {
+            contextLimits: {
+              toolResultMaxChars: 5,
+            },
+          },
+        },
+      },
+    } as EmbeddedRunAttemptParams);
+    const rawOutput =
+      "abcde\n...(truncated: raw tool text should not bypass the cap)..." + "x".repeat(20);
+
+    await projector.handleNotification(
+      turnCompleted([
+        {
+          type: "commandExecution",
+          id: "cmd-1",
+          command: "python scripts/run_demo_scenario.py",
+          cwd: "/workspace",
+          processId: null,
+          source: "agent",
+          status: "completed",
+          commandActions: [],
+          aggregatedOutput: rawOutput,
+          exitCode: 0,
+          durationMs: 42,
+        },
+      ]),
+    );
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+    const toolResultMessage = requireRecord(result.messagesSnapshot[2], "tool result message");
+    const toolResultContent = requireArray(toolResultMessage.content, "tool result content");
+    const toolResultContentItem = requireRecord(toolResultContent[0], "tool result content item");
+    expect(toolResultContentItem.content).toBe(
+      `abcde\n...(truncated: original ${rawOutput.length} chars, limit 5; rerun with narrower tool arguments for omitted output)...`,
+    );
+  });
+
   it("uses streamed command output for failed native tool errors", async () => {
     const projector = await createProjector();
 

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -21,6 +21,7 @@ import {
   type ToolProgressDetailMode,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { emitTrustedDiagnosticEvent } from "openclaw/plugin-sdk/diagnostic-runtime";
+import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
 import { resolveCodexLocalRuntimeAttribution } from "./local-runtime-attribution.js";
 import {
   readCodexNotificationThreadId,
@@ -96,7 +97,8 @@ const CODEX_PROMPT_TOTAL_INPUT_KEYS = [
 ] as const;
 
 const MAX_TOOL_OUTPUT_DELTA_MESSAGES_PER_ITEM = 20;
-const TOOL_TRANSCRIPT_OUTPUT_MAX_CHARS = 12_000;
+const DEFAULT_TOOL_TRANSCRIPT_OUTPUT_MAX_CHARS = 12_000;
+const TOOL_TRANSCRIPT_TRUNCATION_NOTICE_PREFIX = "\n...(truncated:";
 const TRANSCRIPT_PROGRESS_SUPPRESSED_TOOL_NAMES = new Set([
   "message",
   "messages",
@@ -168,13 +170,19 @@ export class CodexAppServerEventProjector {
   private guardianReviewCount = 0;
   private completedCompactionCount = 0;
   private latestRateLimits: JsonValue | undefined;
+  private readonly toolTranscriptOutputMaxChars: number;
 
   constructor(
     private readonly params: EmbeddedRunAttemptParams,
     private readonly threadId: string,
     private readonly turnId: string,
     private readonly options: CodexAppServerEventProjectorOptions = {},
-  ) {}
+  ) {
+    this.toolTranscriptOutputMaxChars = resolveToolTranscriptOutputMaxChars({
+      config: params.config,
+      agentId: params.agentId,
+    });
+  }
 
   async handleNotification(notification: CodexServerNotification): Promise<void> {
     const params = isJsonObject(notification.params) ? notification.params : undefined;
@@ -708,7 +716,12 @@ export class CodexAppServerEventProjector {
     if (!itemId || !delta) {
       return;
     }
-    appendToolOutputDeltaText(this.toolResultOutputTextByItem, itemId, delta);
+    appendToolOutputDeltaText(
+      this.toolResultOutputTextByItem,
+      itemId,
+      delta,
+      this.toolTranscriptOutputMaxChars,
+    );
     if (!this.shouldEmitToolOutput()) {
       return;
     }
@@ -1479,7 +1492,10 @@ export class CodexAppServerEventProjector {
   }
 
   private createToolResultMessage(params: ToolTranscriptResultInput): AgentMessage {
-    const text = truncateToolTranscriptText(params.text?.trim() || toolResultStatusText(params));
+    const text = truncateToolTranscriptText(
+      params.text?.trim() || toolResultStatusText(params),
+      this.toolTranscriptOutputMaxChars,
+    );
     return {
       role: "toolResult",
       toolCallId: params.id,
@@ -1940,13 +1956,20 @@ function appendToolOutputDeltaText(
   outputTextByItem: Map<string, string>,
   itemId: string,
   delta: string,
+  maxChars = DEFAULT_TOOL_TRANSCRIPT_OUTPUT_MAX_CHARS,
 ): void {
   const current = outputTextByItem.get(itemId) ?? "";
-  if (current.length >= TOOL_TRANSCRIPT_OUTPUT_MAX_CHARS) {
+  if (current.length >= maxChars) {
     return;
   }
-  const remaining = TOOL_TRANSCRIPT_OUTPUT_MAX_CHARS - current.length;
-  const next = current + (delta.length > remaining ? delta.slice(0, remaining) : delta);
+  const remaining = maxChars - current.length;
+  const originalChars = current.length + delta.length;
+  const next =
+    delta.length > remaining
+      ? current +
+        delta.slice(0, remaining) +
+        formatToolTranscriptTruncationNotice(originalChars, maxChars)
+      : current + delta;
   outputTextByItem.set(itemId, next);
 }
 
@@ -1972,15 +1995,87 @@ function collectDynamicToolContentText(contentItems: CodexThreadItem["contentIte
     .join("\n");
 }
 
-function truncateToolTranscriptText(text: string): string {
-  if (text.length <= TOOL_TRANSCRIPT_OUTPUT_MAX_CHARS) {
+function truncateToolTranscriptText(
+  text: string,
+  maxChars = DEFAULT_TOOL_TRANSCRIPT_OUTPUT_MAX_CHARS,
+): string {
+  if (hasCompleteToolTranscriptTruncationNotice(text, maxChars)) {
     return text;
   }
-  return `${text.slice(0, TOOL_TRANSCRIPT_OUTPUT_MAX_CHARS)}\n...(truncated)...`;
+  if (text.length <= maxChars) {
+    return text;
+  }
+  return `${text.slice(0, maxChars)}${formatToolTranscriptTruncationNotice(text.length, maxChars)}`;
+}
+
+function hasCompleteToolTranscriptTruncationNotice(text: string, maxChars: number): boolean {
+  if (!text.startsWith(TOOL_TRANSCRIPT_TRUNCATION_NOTICE_PREFIX, maxChars)) {
+    return false;
+  }
+  const notice = text.slice(maxChars);
+  const match = notice.match(
+    /^\n\.\.\.\(truncated: original ([0-9]+) chars, limit ([0-9]+); rerun with narrower tool arguments for omitted output\)\.\.\.$/,
+  );
+  return Boolean(match && Number(match[2]) === maxChars);
 }
 
 function toolResultStatusText(params: ToolTranscriptResultInput): string {
   return params.isError ? `${params.name} failed` : `${params.name} completed`;
+}
+
+function formatToolTranscriptTruncationNotice(originalChars: number, maxChars: number): string {
+  return `\n...(truncated: original ${originalChars} chars, limit ${maxChars}; rerun with narrower tool arguments for omitted output)...`;
+}
+
+function resolveToolTranscriptOutputMaxChars(params: {
+  config: EmbeddedRunAttemptParams["config"] | undefined;
+  agentId?: string;
+}): number {
+  const configured = resolveAgentContextLimitValue({
+    config: params.config,
+    agentId: params.agentId,
+    key: "toolResultMaxChars",
+  });
+  return configured ?? DEFAULT_TOOL_TRANSCRIPT_OUTPUT_MAX_CHARS;
+}
+
+function resolveAgentContextLimitValue(params: {
+  config: EmbeddedRunAttemptParams["config"] | undefined;
+  agentId?: string;
+  key: string;
+}): number | undefined {
+  const agents = readRecord(params.config?.agents);
+  const defaults = readRecord(readRecord(agents?.defaults)?.contextLimits);
+  const defaultValue = readPositiveInteger(defaults?.[params.key]);
+  if (!params.agentId) {
+    return defaultValue;
+  }
+  const list = agents?.list;
+  if (!Array.isArray(list)) {
+    return defaultValue;
+  }
+  const normalizedAgentId = normalizeAgentId(params.agentId);
+  const agent = list.find((entry) => {
+    const entryId = readRecord(entry)?.id;
+    return typeof entryId === "string" && normalizeAgentId(entryId) === normalizedAgentId;
+  });
+  const agentValue = readPositiveInteger(
+    readRecord(readRecord(agent)?.contextLimits)?.[params.key],
+  );
+  return agentValue ?? defaultValue;
+}
+
+function readRecord(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function readPositiveInteger(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return undefined;
+  }
+  return Math.floor(value);
 }
 
 function stringifyJsonValue(value: unknown): string | undefined {

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -1960,6 +1960,12 @@ function appendToolOutputDeltaText(
 ): void {
   const current = outputTextByItem.get(itemId) ?? "";
   if (current.length >= maxChars) {
+    const originalChars =
+      readCompleteToolTranscriptTruncationOriginalChars(current, maxChars) ?? current.length;
+    outputTextByItem.set(
+      itemId,
+      `${current.slice(0, maxChars)}${formatToolTranscriptTruncationNotice(originalChars + delta.length, maxChars)}`,
+    );
     return;
   }
   const remaining = maxChars - current.length;
@@ -2009,14 +2015,24 @@ function truncateToolTranscriptText(
 }
 
 function hasCompleteToolTranscriptTruncationNotice(text: string, maxChars: number): boolean {
+  return readCompleteToolTranscriptTruncationOriginalChars(text, maxChars) !== undefined;
+}
+
+function readCompleteToolTranscriptTruncationOriginalChars(
+  text: string,
+  maxChars: number,
+): number | undefined {
   if (!text.startsWith(TOOL_TRANSCRIPT_TRUNCATION_NOTICE_PREFIX, maxChars)) {
-    return false;
+    return undefined;
   }
   const notice = text.slice(maxChars);
   const match = notice.match(
     /^\n\.\.\.\(truncated: original ([0-9]+) chars, limit ([0-9]+); rerun with narrower tool arguments for omitted output\)\.\.\.$/,
   );
-  return Boolean(match && Number(match[2]) === maxChars);
+  if (!match || Number(match[2]) !== maxChars) {
+    return undefined;
+  }
+  return Number(match[1]);
 }
 
 function toolResultStatusText(params: ToolTranscriptResultInput): string {

--- a/scripts/secrets/openclaw-bws-resolver.mjs
+++ b/scripts/secrets/openclaw-bws-resolver.mjs
@@ -16,7 +16,7 @@ const parseRequest = (input) => {
   try {
     return JSON.parse(input || "{}");
   } catch (error) {
-    throw new Error(`Failed to parse request JSON: ${error.message}`);
+    throw new Error(`Failed to parse request JSON: ${error.message}`, { cause: error });
   }
 };
 
@@ -60,7 +60,7 @@ const main = async () => {
   try {
     secrets = JSON.parse(raw);
   } catch (error) {
-    throw new Error(`Failed to parse bws output: ${error.message}`);
+    throw new Error(`Failed to parse bws output: ${error.message}`, { cause: error });
   }
 
   const byKey = new Map();


### PR DESCRIPTION
## Summary

Codex app-server transcript projection had its own hardcoded tool-output cap (`12_000` chars), so configured OpenClaw limits such as `agents.defaults.contextLimits.toolResultMaxChars = 8000` did not apply before tool output was mirrored into the native app-server thread.

This PR makes `CodexAppServerEventProjector` resolve the configured default/per-agent `toolResultMaxChars` and apply it to both streamed `outputDelta` aggregation and final snapshot tool-result transcript messages. The truncation notice includes the original size and configured limit, with guidance to rerun using narrower tool arguments.

Scope boundary: this does not change dynamic tool execution payloads, the live/display sanitizer, or read-tool behavior. It only bounds the text that gets projected into the Codex app-server/native transcript.

## Motivation / Problem

On a local OpenClaw/Quill WebChat setup, repeated large `bash`/tool results were entering the native app-server transcript at roughly 20K-25K JSON-wrapped characters even though the OpenClaw config set `toolResultMaxChars` to `8000`. Those oversized transcript entries caused avoidable context bloat and lag during WebChat turns.

The latest beta still contains the separate hardcoded path:

- `dist/run-attempt-BMcMyAoZ.js`
- `const TOOL_TRANSCRIPT_OUTPUT_MAX_CHARS = 12e3`
- `appendToolOutputDeltaText(..., delta)` and `truncateToolTranscriptText(text)` both use that local cap

Related to #84659, but not the same bug: #84659 is about live/display/read output clipping, while this PR addresses the Codex app-server/native transcript projection path.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Tests only
- [ ] Chore / maintenance

## Scope

- [x] Gateway / orchestration
- [ ] CLI
- [ ] Web UI / frontend
- [ ] Memory / QMD
- [x] Skills / tool execution
- [ ] Agents / routing
- [ ] Docs
- [ ] Other:

## Linked Issues

Related #84659

- [x] This PR fixes a bug or regression.
- [ ] This PR implements a requested feature.
- [ ] No issue exists yet; details are in the evidence section below.

## Real behavior proof

**Behavior or issue addressed:** The Codex app-server/native transcript path now honors configured default/per-agent `contextLimits.toolResultMaxChars` instead of always using the projector's hardcoded 12K cap for mirrored tool output. The patch also keeps raw tool output from spoofing the truncation marker and bypassing the cap.

**Real environment tested:** Local macOS OpenClaw setup running OpenClaw `2026.5.19` with the same projector logic backported into the installed runtime. Configured `agents.defaults.contextLimits.toolResultMaxChars` was `8000`. Latest npm beta `2026.5.20-beta.1` was inspected for the pre-fix hardcoded cap.

**Exact steps or command run after this patch:** Ran an isolated real OpenClaw agent turn through the Gateway/app-server path, forcing one large `bash` result, then inspected the stored mirrored session transcript:

```bash
openclaw agent --agent main --session-id codex-proof-tool-transcript-cap-20260520 --message 'Local proof for Codex app-server transcript cap. Run exactly this shell command once: node -e "process.stdout.write(\"A\".repeat(12050))". Do not read files. Do not write files. After the command, reply with one sentence saying the command was run.' --thinking minimal --json --timeout 300

node - <<'NODE'
const fs = require('fs');
const storePath = '/Users/han.kim/.openclaw/agents/main/sessions/sessions.json';
const key = 'agent:main:explicit:codex-proof-tool-transcript-cap-20260520';
const store = JSON.parse(fs.readFileSync(storePath, 'utf8'));
const file = store[key].sessionFile;
const rows = fs.readFileSync(file, 'utf8').trim().split(/\n+/).map((line) => JSON.parse(line));
const toolRow = rows.find((row) => row.message?.role === 'toolResult');
const text = toolRow.message.content[0].content;
console.log('sessionFile', file);
console.log('toolResultTextChars', text.length);
console.log(text.match(/truncated: original [^)]*/)?.[0]);
NODE
```

**Evidence after fix:** Copied live terminal output from the local OpenClaw setup after the backport:

```text
$ openclaw config get agents.defaults.contextLimits
{
  "memoryGetMaxChars": 6000,
  "memoryGetDefaultLines": 40,
  "toolResultMaxChars": 8000
}

$ openclaw agent --agent main --session-id codex-proof-tool-transcript-cap-20260520 --message '...' --thinking minimal --json --timeout 300
{
  "runId": "96871952-8a9c-4469-8d70-5296b7cdbc88",
  "status": "ok",
  "summary": "completed",
  "result": {
    "payloads": [{ "text": "The command was run.", "mediaUrl": null }],
    "meta": {
      "agentMeta": {
        "sessionId": "codex-proof-tool-transcript-cap-20260520",
        "provider": "openai-codex",
        "model": "gpt-5.5",
        "agentHarnessId": "codex",
        "toolSummary": { "calls": 1, "tools": ["bash"], "failures": 0 }
      }
    }
  }
}

$ node inspect-codex-proof-session.js
sessionFile /Users/han.kim/.openclaw/agents/main/sessions/codex-proof-tool-transcript-cap-20260520.jsonl
rows 5
toolResultTextChars 8107
truncated: original 12050 chars, limit 8000; rerun with narrower tool arguments for omitted output
```

Additional local runtime/preservation output:

```text
$ /Users/han.kim/.openclaw/workspace/systems/reapply-openclaw-latency-patches.js --dry-run
- codex-app-server-tool-transcript-cap: already patched or pattern not present (run-attempt-DI0_-QFr.js)
- codex-plugin-app-server-tool-transcript-cap: already patched or pattern not present (run-attempt-BqRPAaHk.js)
Done. Changed files: 0.

$ openclaw health --json
{
  "ok": true,
  "eventLoop": { "degraded": false, "reasons": [] },
  "plugins": { "errors": [] }
}
```

Upstream source validation after patch:

```text
event-projector.test.ts: 61 passed
oxfmt --check: passed
oxlint: Found 0 warnings and 0 errors.
pnpm tsgo:extensions:test: exited 0
git diff --check: no whitespace errors
```

**Observed result after fix:** A real OpenClaw agent turn produced 12,050 stdout characters from `bash`; the app-server/native mirrored session transcript stored a bounded tool result of 8,107 characters, which is the 8,000 configured cap plus the truncation notice. The stored transcript included `truncated: original 12050 chars, limit 8000`, confirming the configured cap was applied before the tool result was mirrored into session state.

**What was not tested:** I did not install and run a full OpenClaw build from this PR branch in a separate clean machine. The projector behavior is covered by targeted upstream tests and was locally backported to the installed OpenClaw runtime for live setup validation.

## Root Cause

`CodexAppServerEventProjector` maintained a separate hardcoded transcript cap instead of resolving the existing OpenClaw `contextLimits.toolResultMaxChars` configuration. The dynamic tool/runtime cap and the app-server/native transcript cap had drifted into two different policy paths.

## Regression Test Plan

Added targeted tests in `extensions/codex/src/app-server/event-projector.test.ts`:

- streamed `outputDelta` aggregation honors `agents.defaults.contextLimits.toolResultMaxChars`
- final snapshot/aggregated tool-result transcript projection honors per-agent `contextLimits.toolResultMaxChars`
- oversized raw snapshot output containing the truncation marker is still capped
- truncation notice includes original size and configured limit

## User-visible Behavior

Long tool-output entries mirrored into the Codex app-server/native transcript will now be shorter when OpenClaw is configured with a lower `toolResultMaxChars`. The transcript includes an explicit truncation notice and suggests rerunning with narrower tool arguments when omitted output is needed.

## Architecture / Data Flow

Before:

```text
command output -> app-server projector hardcoded 12K cap -> JSON-wrapped oversized toolResult transcript message
```

After:

```text
command output -> configured default/per-agent toolResultMaxChars -> bounded transcript result with truncation notice
```

## Security / Privacy

- [ ] Handles secrets, tokens, credentials, or auth state
- [ ] Changes external network calls
- [ ] Changes file-system access scope
- [ ] Changes subprocess execution behavior
- [x] None of the above

Notes: This only changes transcript text truncation inside the existing app-server projection path.

## Human Verification

Commands run successfully:

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts extensions/codex/src/app-server/event-projector.test.ts
pnpm exec oxfmt --check --threads=1 extensions/codex/src/app-server/event-projector.ts extensions/codex/src/app-server/event-projector.test.ts
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/codex/src/app-server/event-projector.ts extensions/codex/src/app-server/event-projector.test.ts
pnpm tsgo:extensions:test
git diff --check
```

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Backward Compatibility

- [x] Backward compatible
- [ ] Breaking change
- [ ] Requires config or environment changes
- [ ] Requires migration

Notes: Existing behavior is preserved unless users have configured a lower or higher `contextLimits.toolResultMaxChars`, in which case the app-server transcript now follows that configuration.

## Risk / Rollback

Risk: users may see less tool-output text in the native transcript when their configured cap is lower than the previous hardcoded 12K cap.

Mitigation: truncation now includes the original size, the applied limit, and a clear instruction to rerun with narrower tool arguments for omitted output. Rollback is reverting this patch to restore the previous fixed 12K app-server transcript cap.
