### PR TITLE
fix: summarize internal webchat message tool results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- WebChat: summarize internal message-tool source replies so tool cards no longer duplicate the visible reply body. (#84773) Thanks @jason-allen-oneal.
 - Gateway: preserve deferred lifecycle-error cleanup across later non-terminal events so provider timeouts can persist failed session state instead of leaving sessions stuck running. (#85256, fixes #63819) Thanks @samzong.
 - Agents/subagents: report tool-only child progress during timeout summaries instead of showing no visible output.
 - Telegram/ACP: preserve explicit `:topic:` conversation suffixes when inbound ACP targets do not carry a separate thread id.

--- a/src/infra/outbound/message-action-runner.send-validation.test.ts
+++ b/src/infra/outbound/message-action-runner.send-validation.test.ts
@@ -116,6 +116,25 @@ describe("runMessageAction send validation", () => {
         },
       },
     });
+    if (result.kind !== "send") {
+      throw new Error(`expected send result, got ${result.kind}`);
+    }
+    expect(result.toolResult?.content).toEqual([
+      {
+        type: "text",
+        text: "Sent visible reply to the current webchat conversation via internal-ui.",
+      },
+    ]);
+    expect(result.toolResult?.details).toEqual({
+      status: "ok",
+      deliveryStatus: "sent",
+      channel: "webchat",
+      target: "current-run",
+      sourceReplyDeliveryMode: "message_tool_only",
+      sourceReplySink: "internal-ui",
+      dryRun: false,
+    });
+    expect(JSON.stringify(result.toolResult)).not.toContain("hello from codex");
   });
 
   it("strips unsupported citation control markers from internal UI source replies", async () => {

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -733,7 +733,48 @@ async function handleInternalSourceReplySendAction(
     to: "current-run",
     handledBy: "internal-source",
     payload,
+    toolResult: buildInternalSourceReplyToolResult(payload),
     dryRun,
+  };
+}
+
+function buildInternalSourceReplyToolResult(payload: {
+  status: string;
+  deliveryStatus: string;
+  channel: ChannelId;
+  target: string;
+  sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
+  sourceReplySink?: "internal-ui";
+  dryRun: boolean;
+}): AgentToolResult<{
+  status: string;
+  deliveryStatus: string;
+  channel: ChannelId;
+  target: string;
+  sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
+  sourceReplySink?: "internal-ui";
+  dryRun: boolean;
+}> {
+  const action = payload.dryRun ? "Prepared" : "Sent";
+  const sink = payload.sourceReplySink ? ` via ${payload.sourceReplySink}` : "";
+  return {
+    content: [
+      {
+        type: "text",
+        text: `${action} visible reply to the current webchat conversation${sink}.`,
+      },
+    ],
+    details: {
+      status: payload.status,
+      deliveryStatus: payload.deliveryStatus,
+      channel: payload.channel,
+      target: payload.target,
+      ...(payload.sourceReplyDeliveryMode
+        ? { sourceReplyDeliveryMode: payload.sourceReplyDeliveryMode }
+        : {}),
+      ...(payload.sourceReplySink ? { sourceReplySink: payload.sourceReplySink } : {}),
+      dryRun: payload.dryRun,
+    },
   };
 }
 


### PR DESCRIPTION
## Summary

- Keep internal webchat source-reply delivery payloads intact for the UI sink.
- Return a compact `message` tool result for `message_tool_only` internal webchat sends so tool cards do not duplicate and truncate the full visible reply.
- Cover the internal-source path with a regression assertion that the tool result omits the sent message body while preserving delivery metadata.

## Verification

- `node scripts/run-vitest.mjs src/infra/outbound/message-action-runner.send-validation.test.ts`
- `pnpm format:check src/infra/outbound/message-action-runner.ts src/infra/outbound/message-action-runner.send-validation.test.ts`
- `node scripts/run-oxlint.mjs src/infra/outbound/message-action-runner.ts src/infra/outbound/message-action-runner.send-validation.test.ts`

## Real behavior proof

Behavior addressed: Internal webchat `message_tool_only` sends now return a compact `message` tool receipt instead of echoing the full visible reply body into the tool result. The full reply remains in `payload.sourceReply.text` for the UI delivery path.

Real environment tested: Local OpenClaw checkout for PR #84773 at head `f41e390815ce20589c9f468b30c0bd5f0a060b41`, with dependencies installed via `pnpm install --frozen-lockfile`.

Exact steps or command run after this patch:

```sh
pnpm exec tsx - <<'TS'
import { runMessageAction } from './src/infra/outbound/message-action-runner.ts';
const result = await runMessageAction({
  cfg: {} as any,
  action: 'send',
  params: { message: 'LIVE SECRET BODY' },
  toolContext: { currentChannelProvider: 'webchat' } as any,
  sessionKey: 'agent:main',
  sourceReplyDeliveryMode: 'message_tool_only',
});
console.log(JSON.stringify({
  kind: result.kind,
  channel: result.channel,
  to: result.to,
  handledBy: result.handledBy,
  payloadDeliveryStatus: result.payload.deliveryStatus,
  toolResult: result.toolResult,
  toolResultLeaksMessage: JSON.stringify(result.toolResult).includes('LIVE SECRET BODY'),
}, null, 2));
TS
```

Evidence after fix: Terminal output from the real `runMessageAction` path:

```json
{
  "kind": "send",
  "channel": "webchat",
  "to": "current-run",
  "handledBy": "internal-source",
  "payloadDeliveryStatus": "sent",
  "toolResult": {
    "content": [
      {
        "type": "text",
        "text": "Sent visible reply to the current webchat conversation via internal-ui."
      }
    ],
    "details": {
      "status": "ok",
      "deliveryStatus": "sent",
      "channel": "webchat",
      "target": "current-run",
      "sourceReplyDeliveryMode": "message_tool_only",
      "sourceReplySink": "internal-ui",
      "dryRun": false
    }
  },
  "toolResultLeaksMessage": false
}
```

Observed result after fix: The real internal-source webchat send path returned `kind=send`, `channel=webchat`, `to=current-run`, `handledBy=internal-source`, and a compact tool result with `toolResultLeaksMessage=false`. Supplemental focused regression proof: `node scripts/run-vitest.mjs src/infra/outbound/message-action-runner.send-validation.test.ts` passed 1 file / 10 tests, and `git diff --check` passed.

What was not tested: Browser screenshot capture was not needed; this proof exercises the changed outbound message-action path directly and preserves the visible reply payload while proving the tool-result receipt is summarized.
