### PR TITLE
test(cli): cover node daemon lifecycle helpers

### DIFF
--- a/src/cli/node-cli/daemon.test.ts
+++ b/src/cli/node-cli/daemon.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { runNodeDaemonInstall, runNodeDaemonStatus } from "./daemon.js";
+
+const serviceMock = vi.hoisted(() => ({
+  install: vi.fn(),
+  isLoaded: vi.fn(),
+  readCommand: vi.fn(),
+  readRuntime: vi.fn(),
+  restart: vi.fn(),
+  stage: vi.fn(),
+  stop: vi.fn(),
+  uninstall: vi.fn(),
+}));
+
+const runtimeMock = vi.hoisted(() => ({
+  error: vi.fn(),
+  log: vi.fn(),
+  writeJson: vi.fn(),
+}));
+
+const loadNodeHostConfigMock = vi.hoisted(() => vi.fn());
+const buildNodeInstallPlanMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../runtime.js", () => ({
+  defaultRuntime: runtimeMock,
+}));
+
+vi.mock("../../node-host/config.js", () => ({
+  loadNodeHostConfig: loadNodeHostConfigMock,
+}));
+
+vi.mock("../../commands/node-daemon-install-helpers.js", () => ({
+  buildNodeInstallPlan: buildNodeInstallPlanMock,
+}));
+
+vi.mock("../../daemon/node-service.js", () => ({
+  resolveNodeService: () => ({
+    label: "com.openclaw.node",
+    loadedText: "loaded",
+    notLoadedText: "not loaded",
+    ...serviceMock,
+  }),
+}));
+
+describe("node daemon CLI", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    loadNodeHostConfigMock.mockResolvedValue(null);
+    buildNodeInstallPlanMock.mockResolvedValue({
+      description: "OpenClaw Node",
+      environment: {},
+      programArguments: ["openclaw", "node", "run"],
+      workingDirectory: "/tmp/openclaw-node",
+    });
+    serviceMock.isLoaded.mockResolvedValue(false);
+    serviceMock.readCommand.mockResolvedValue(null);
+    serviceMock.readRuntime.mockResolvedValue({ status: "running", pid: 123 });
+  });
+
+  it("short-circuits install when the node service is already loaded", async () => {
+    serviceMock.isLoaded.mockResolvedValue(true);
+
+    await runNodeDaemonInstall({ json: true });
+
+    expect(buildNodeInstallPlanMock).not.toHaveBeenCalled();
+    expect(serviceMock.install).not.toHaveBeenCalled();
+    expect(runtimeMock.writeJson).toHaveBeenCalledWith({
+      action: "install",
+      ok: true,
+      result: "already-installed",
+      message: "Node service already loaded.",
+      service: {
+        label: "com.openclaw.node",
+        loaded: true,
+        loadedText: "loaded",
+        notLoadedText: "not loaded",
+      },
+      hintItems: undefined,
+      warnings: undefined,
+    });
+  });
+
+  it("renders status JSON from the resolved node service", async () => {
+    serviceMock.isLoaded.mockResolvedValue(true);
+    serviceMock.readCommand.mockResolvedValue({
+      environment: { OPENCLAW_LOG_PREFIX: "node" },
+      programArguments: ["openclaw", "node", "run"],
+      sourcePath: "/tmp/openclaw-node.plist",
+      workingDirectory: "/tmp/openclaw-node",
+    });
+    serviceMock.readRuntime.mockResolvedValue({ status: "running", pid: 123 });
+
+    await runNodeDaemonStatus({ json: true });
+
+    expect(runtimeMock.writeJson).toHaveBeenCalledWith({
+      service: {
+        label: "com.openclaw.node",
+        loaded: true,
+        loadedText: "loaded",
+        notLoadedText: "not loaded",
+        command: {
+          environment: { OPENCLAW_LOG_PREFIX: "node" },
+          programArguments: ["openclaw", "node", "run"],
+          sourcePath: "/tmp/openclaw-node.plist",
+          workingDirectory: "/tmp/openclaw-node",
+        },
+        runtime: { status: "running", pid: 123 },
+      },
+    });
+  });
+});

--- a/src/cli/node-cli/daemon.test.ts
+++ b/src/cli/node-cli/daemon.test.ts
@@ -20,6 +20,7 @@ const runtimeMock = vi.hoisted(() => ({
 
 const loadNodeHostConfigMock = vi.hoisted(() => vi.fn());
 const buildNodeInstallPlanMock = vi.hoisted(() => vi.fn());
+const resolveIsNixModeMock = vi.hoisted(() => vi.fn(() => false));
 
 vi.mock("../../runtime.js", () => ({
   defaultRuntime: runtimeMock,
@@ -31,6 +32,10 @@ vi.mock("../../node-host/config.js", () => ({
 
 vi.mock("../../commands/node-daemon-install-helpers.js", () => ({
   buildNodeInstallPlan: buildNodeInstallPlanMock,
+}));
+
+vi.mock("../../config/paths.js", () => ({
+  resolveIsNixMode: resolveIsNixModeMock,
 }));
 
 vi.mock("../../daemon/node-service.js", () => ({
@@ -45,6 +50,7 @@ vi.mock("../../daemon/node-service.js", () => ({
 describe("node daemon CLI", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resolveIsNixModeMock.mockReturnValue(false);
     loadNodeHostConfigMock.mockResolvedValue(null);
     buildNodeInstallPlanMock.mockResolvedValue({
       description: "OpenClaw Node",


### PR DESCRIPTION
## Summary
- Add focused tests for the node daemon CLI helper surface.
- Cover the already-installed `node install --json` short-circuit so it does not rebuild or reinstall the service.
- Cover `node status --json` payload construction from the resolved node service.

Refs #83924

## Real behavior proof

Behavior addressed: the node daemon lifecycle helper file had no direct tests for service install/status behavior. This left paths such as the already-installed install short-circuit and JSON status payload construction uncovered.

Real environment tested: Local OpenClaw checkout on macOS, Node.js v22.22.0, branch `test/node-cli-daemon-lifecycle-83924`, using the real `src/cli/node-cli/daemon.ts` implementation with mocked service/config boundaries under the repo's Vitest wrapper.

Exact steps or command run after fix:

```console
$ node scripts/run-vitest.mjs src/cli/node-cli/daemon.test.ts src/cli/node-cli/register.test.ts
$ git diff --check
```

Evidence after fix: Targeted test output:

```console
✓ cli ../../src/cli/node-cli/daemon.test.ts (2 tests) 7ms
✓ cli ../../src/cli/node-cli/register.test.ts (1 test) 2ms

Test Files 2 passed (2)
Tests 3 passed (3)
```

Observed result after fix: The new daemon tests verify `runNodeDaemonInstall({ json: true })` skips install planning and service installation when the node service is already loaded, and verify `runNodeDaemonStatus({ json: true })` emits a JSON payload containing loaded service metadata, command details, and runtime status.

What was not tested: I did not exercise real launchd/systemd/schtasks commands; the tests intentionally mock the service boundary to cover CLI decision logic without installing or managing a real service.

## Test plan
- `node scripts/run-vitest.mjs src/cli/node-cli/daemon.test.ts src/cli/node-cli/register.test.ts`
- `git diff --check`

