### PR TITLE
fix(config): redact config set secrets in audit argv

### DIFF
--- a/src/config/io.audit.test.ts
+++ b/src/config/io.audit.test.ts
@@ -360,6 +360,133 @@ describe("config io audit helpers", () => {
     ]);
   });
 
+  it("redacts config set positional values for credential-bearing paths", () => {
+    const argv = [
+      "node",
+      "openclaw",
+      "config",
+      "set",
+      "models.providers.openai.apiKey",
+      "boring-provider-key-with-no-token-shape",
+    ];
+    expect(redactConfigAuditArgv(argv)).toEqual([
+      "node",
+      "openclaw",
+      "config",
+      "set",
+      "models.providers.openai.apiKey",
+      "***",
+    ]);
+  });
+
+  it("redacts config set positional values when root and config-set flags are present", () => {
+    const argv = [
+      "node",
+      "openclaw",
+      "--profile",
+      "work",
+      "config",
+      "set",
+      "--strict-json",
+      "channels.slack.botToken",
+      "not-a-token-shaped-secret",
+      "--dry-run",
+    ];
+    expect(redactConfigAuditArgv(argv)).toEqual([
+      "node",
+      "openclaw",
+      "--profile",
+      "work",
+      "config",
+      "set",
+      "--strict-json",
+      "channels.slack.botToken",
+      "***",
+      "--dry-run",
+    ]);
+  });
+
+  it("redacts bracket-notation config set values for plugin API key paths", () => {
+    const argv = [
+      "node",
+      "openclaw",
+      "config",
+      "set",
+      'plugins.entries["higgsfield"].config.apiKey',
+      "plain-higgsfield-key",
+    ];
+    expect(redactConfigAuditArgv(argv)).toEqual([
+      "node",
+      "openclaw",
+      "config",
+      "set",
+      'plugins.entries["higgsfield"].config.apiKey',
+      "***",
+    ]);
+  });
+
+  it("redacts dash-leading config set values for credential-bearing paths", () => {
+    const argv = [
+      "node",
+      "openclaw",
+      "config",
+      "set",
+      "gateway.auth.password",
+      "-plain-password",
+    ];
+    expect(redactConfigAuditArgv(argv)).toEqual([
+      "node",
+      "openclaw",
+      "config",
+      "set",
+      "gateway.auth.password",
+      "***",
+    ]);
+  });
+
+  it("redacts inline config set batch JSON payloads", () => {
+    const argv = [
+      "node",
+      "openclaw",
+      "config",
+      "set",
+      "--batch-json",
+      '[{"path":"models.providers.openai.apiKey","value":"plain-provider-key"}]',
+      "--dry-run",
+    ];
+    expect(redactConfigAuditArgv(argv)).toEqual([
+      "node",
+      "openclaw",
+      "config",
+      "set",
+      "--batch-json",
+      "***",
+      "--dry-run",
+    ]);
+  });
+
+  it("redacts config set batch JSON payloads in equals form", () => {
+    const argv = [
+      "node",
+      "openclaw",
+      "config",
+      "set",
+      '--batch-json=[{"path":"channels.slack.botToken","value":"plain-bot-token"}]',
+    ];
+    expect(redactConfigAuditArgv(argv)).toEqual([
+      "node",
+      "openclaw",
+      "config",
+      "set",
+      "--batch-json=***",
+    ]);
+  });
+
+  it("does not redact config set positional values for non-secret paths", () => {
+    const argv = ["node", "openclaw", "config", "set", "ui.theme", "dark"];
+    expect(redactConfigAuditArgv(argv)).toEqual(argv);
+  });
+
   it("masks the next arg after a secret flag even when it looks like another option", () => {
     const argv = ["openclaw", "--token", "--port", "8080"];
     expect(redactConfigAuditArgv(argv)).toEqual(["openclaw", "--token", "***", "8080"]);

--- a/src/config/io.audit.ts
+++ b/src/config/io.audit.ts
@@ -53,6 +53,68 @@ const SECRET_FLAG_NAMES = new Set([
 const SECRET_FLAG_SUFFIX_PATTERN =
   /^--(?:[a-z0-9]+(?:-[a-z0-9]+)*-)?(?:token|secret|password|passwd|api[-_]?key|api[-_]?secret|webhook|credential|bearer|pat|private[-_]?key|recovery[-_]?key|signing[-_]?key|encryption[-_]?key|master[-_]?key|session[-_]?key|gateway[-_]?key|service[-_]?key|hook[-_]?key)$/;
 
+const CONFIG_SET_BOOLEAN_FLAGS = new Set([
+  "--strict-json",
+  "--json",
+  "--dry-run",
+  "--allow-exec",
+  "--merge",
+  "--replace",
+  "--provider-json-only",
+  "--provider-allow-insecure-path",
+  "--provider-allow-symlink-command",
+]);
+
+const CONFIG_SET_VALUE_FLAGS = new Set([
+  "--ref-provider",
+  "--ref-source",
+  "--ref-id",
+  "--provider-source",
+  "--provider-allowlist",
+  "--provider-path",
+  "--provider-mode",
+  "--provider-timeout-ms",
+  "--provider-max-bytes",
+  "--provider-command",
+  "--provider-arg",
+  "--provider-no-output-timeout-ms",
+  "--provider-max-output-bytes",
+  "--provider-env",
+  "--provider-pass-env",
+  "--provider-trusted-dir",
+  "--batch-json",
+  "--batch-file",
+]);
+
+const CONFIG_SET_REDACT_VALUE_FLAGS = new Set(["--batch-json"]);
+
+const SECRET_PATH_KEY_PREFIXES = new Set([
+  "access",
+  "active",
+  "api",
+  "client",
+  "encryption",
+  "gateway",
+  "hook",
+  "master",
+  "private",
+  "recovery",
+  "refresh",
+  "service",
+  "session",
+  "signing",
+]);
+
+const SECRET_PATH_TERMINAL_WORDS = new Set([
+  "bearer",
+  "credential",
+  "password",
+  "passwd",
+  "pat",
+  "secret",
+  "token",
+]);
+
 function isSecretFlagName(flagName: string | null): boolean {
   if (flagName === null) {
     return false;
@@ -71,6 +133,141 @@ function parseFlagName(arg: string): string | null {
   return (eq === -1 ? arg : arg.slice(0, eq)).toLowerCase();
 }
 
+function splitConfigPathSegments(pathValue: string): string[] {
+  const normalized = pathValue
+    .replace(
+      /\[(?:"([^"]+)"|'([^']+)'|([^\]]+))\]/g,
+      (_match, doubleQuoted, singleQuoted, bare) => {
+        const value = doubleQuoted ?? singleQuoted ?? bare;
+        return `.${String(value).trim()}`;
+      },
+    )
+    .replace(/^\.+|\.+$/g, "");
+  return normalized
+    .split(".")
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0);
+}
+
+function splitConfigPathSegmentWords(segment: string): string[] {
+  const normalized = segment
+    .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+    .replace(/[^a-zA-Z0-9]+/g, "-")
+    .toLowerCase()
+    .replace(/^-+|-+$/g, "");
+  return normalized.split("-").filter((word) => word.length > 0);
+}
+
+function isSecretConfigPathSegment(segment: string): boolean {
+  const words = splitConfigPathSegmentWords(segment);
+  if (words.length === 0) {
+    return false;
+  }
+  const terminal = words[words.length - 1];
+  if (!terminal) {
+    return false;
+  }
+  if (SECRET_PATH_TERMINAL_WORDS.has(terminal)) {
+    return true;
+  }
+  if (terminal !== "key") {
+    return false;
+  }
+  return words.slice(0, -1).some((word) => SECRET_PATH_KEY_PREFIXES.has(word));
+}
+
+function isSecretConfigSetPath(pathValue: string): boolean {
+  return splitConfigPathSegments(pathValue).some(isSecretConfigPathSegment);
+}
+
+function consumeConfigSetOption(argv: readonly string[], index: number): number {
+  const flagName = parseFlagName(argv[index] ?? "");
+  if (flagName === null) {
+    return 0;
+  }
+  if (CONFIG_SET_BOOLEAN_FLAGS.has(flagName)) {
+    return 1;
+  }
+  if (!CONFIG_SET_VALUE_FLAGS.has(flagName)) {
+    return 1;
+  }
+  return argv[index]?.includes("=") ? 1 : 2;
+}
+
+function redactConfigSetOptionValue(argv: readonly string[], redacted: string[], index: number) {
+  const current = argv[index];
+  if (typeof current !== "string") {
+    return;
+  }
+  const eq = current.indexOf("=");
+  if (eq !== -1) {
+    redacted[index] = `${current.slice(0, eq + 1)}***`;
+    return;
+  }
+  if (typeof argv[index + 1] === "string") {
+    redacted[index + 1] = "***";
+  }
+}
+
+function redactConfigSetPositionalSecrets(
+  argv: readonly string[],
+  redacted: string[],
+): string[] {
+  const configIndex = argv.findIndex(
+    (arg, index) => arg === "config" && argv[index + 1] === "set",
+  );
+  if (configIndex === -1) {
+    return redacted;
+  }
+
+  const positionals: Array<{ index: number; value: string }> = [];
+  for (let i = configIndex + 2; i < argv.length; i++) {
+    const current = argv[i];
+    if (typeof current !== "string") {
+      continue;
+    }
+    if (current === "--") {
+      for (let j = i + 1; j < argv.length; j++) {
+        const value = argv[j];
+        if (typeof value === "string") {
+          positionals.push({ index: j, value });
+        }
+      }
+      break;
+    }
+    if (current.startsWith("-") && positionals.length === 0) {
+      const flagName = parseFlagName(current);
+      if (CONFIG_SET_REDACT_VALUE_FLAGS.has(flagName ?? "")) {
+        redactConfigSetOptionValue(argv, redacted, i);
+      }
+      const consumed = consumeConfigSetOption(argv, i);
+      i += Math.max(0, consumed - 1);
+      continue;
+    }
+    if (current.startsWith("-")) {
+      const flagName = parseFlagName(current);
+      const isKnownOption =
+        flagName !== null &&
+        (CONFIG_SET_BOOLEAN_FLAGS.has(flagName) || CONFIG_SET_VALUE_FLAGS.has(flagName));
+      if (isKnownOption) {
+        if (CONFIG_SET_REDACT_VALUE_FLAGS.has(flagName)) {
+          redactConfigSetOptionValue(argv, redacted, i);
+        }
+        const consumed = consumeConfigSetOption(argv, i);
+        i += Math.max(0, consumed - 1);
+        continue;
+      }
+    }
+    positionals.push({ index: i, value: current });
+  }
+
+  const [pathArg, valueArg] = positionals;
+  if (pathArg && valueArg && isSecretConfigSetPath(pathArg.value)) {
+    redacted[valueArg.index] = "***";
+  }
+  return redacted;
+}
+
 // Redacts CLI argv before it lands in the persistent config-audit log.
 // Layers, applied per element:
 //  1. `--flag=value` form for any name matching the explicit list or the
@@ -83,6 +280,9 @@ function parseFlagName(arg: string): string | null {
 //     `KEY=VALUE` env-style assignments, raw token shapes (sk-, ghp_, xox*,
 //     gsk_, AIza*, npm_, Telegram bot tokens, PEM blocks, Bearer headers,
 //     URL query secrets) using the shared redaction patterns.
+//  4. `config set <credential-path> <value>` positional values — mask the
+//     value because plain provider keys/passwords often have no recognizable
+//     token shape for layer 3 to catch.
 export function redactConfigAuditArgv(argv: readonly string[]): string[] {
   const result: string[] = [];
   let redactNext = false;
@@ -111,7 +311,7 @@ export function redactConfigAuditArgv(argv: readonly string[]): string[] {
     }
     result.push(redactToolPayloadText(current));
   }
-  return result;
+  return redactConfigSetPositionalSecrets(argv, result);
 }
 
 function capArgv(argv: readonly string[] | undefined): string[] {


### PR DESCRIPTION
## Summary

- redact `openclaw config set <credential-path> <value>` positional values before they land in `config-audit.jsonl`
- mask inline `--batch-json` payloads because batch entries can contain credential values
- add coverage for API key, bot token, password, bracket notation, dash-leading values, equals-form batch JSON, and non-secret config paths

Contributes to #11829.

## Verification

- `node scripts/run-vitest.mjs src/config/io.audit.test.ts`
- `git diff --check`

## Real behavior proof

Behavior addressed:
Persistent config-audit argv entries could retain plain-looking secrets from `config set` when the credential was supplied as a positional value or inline batch JSON, because the existing redactor only recognized secret flags and token-shaped strings.

Real environment tested:
Local macOS source checkout of this branch, Node 25.9.0, temp `HOME` and `OPENCLAW_STATE_DIR`, actual OpenClaw CLI path through `src/entry.ts`.

Exact steps or command run after this patch:
`HOME=/tmp/openclaw-real-proof.ZBIK8e OPENCLAW_STATE_DIR=/tmp/openclaw-real-proof.ZBIK8e/.openclaw NODE_DISABLE_COMPILE_CACHE=1 node --import tsx src/entry.ts config set models.providers.openai.apiKey plain-provider-key-with-no-token-shape`

`tail -n 2 /tmp/openclaw-real-proof.ZBIK8e/.openclaw/logs/config-audit.jsonl`

`HOME=/tmp/openclaw-real-proof.ZBIK8e OPENCLAW_STATE_DIR=/tmp/openclaw-real-proof.ZBIK8e/.openclaw NODE_DISABLE_COMPILE_CACHE=1 node --import tsx src/entry.ts config set --batch-json '[{"path":"channels.slack.botToken","value":"plain-batch-secret-with-no-token-shape"}]'`

`tail -n 1 /tmp/openclaw-real-proof.ZBIK8e/.openclaw/logs/config-audit.jsonl`

Evidence after fix:
The first real CLI write printed:

```text
Updated models.providers.openai.apiKey. Restart the gateway to apply.
```

The resulting `config-audit.jsonl` record contained a masked positional value:

```json
"argv":["/usr/local/Cellar/node/25.9.0_2/bin/node","/private/tmp/taskbounty-openclaw/src/entry.ts","config","set","models.providers.openai.apiKey","***"]
```

The second real CLI write printed:

```text
Updated channels.slack.botToken. Restart the gateway to apply.
```

The resulting `config-audit.jsonl` record contained a masked inline batch payload:

```json
"argv":["/usr/local/Cellar/node/25.9.0_2/bin/node","/private/tmp/taskbounty-openclaw/src/entry.ts","config","set","--batch-json","***"]
```

Observed result after fix:
The actual persisted config-audit argv no longer contains either plain-looking secret input; both the positional credential value and inline batch JSON payload are persisted as `***`. `src/config/io.audit.test.ts` also passed with 32 tests.

What was not tested:
The full repository suite was not run; this PR was validated with the targeted config-audit test file and whitespace check.
