### PR TITLE
fix(simple-completion): sanitize Google thinking payload for unknown Gemini aliases (fixes #84688)

### DIFF
--- a/src/agents/google-simple-completion-stream.test.ts
+++ b/src/agents/google-simple-completion-stream.test.ts
@@ -1,0 +1,146 @@
+import type { Model } from "@earendil-works/pi-ai";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const streamSimpleMock = vi.fn();
+const sanitizeGoogleThinkingPayloadMock = vi.fn();
+const ensureCustomApiRegisteredMock = vi.fn();
+
+vi.mock("@earendil-works/pi-ai", async () => {
+  const actual =
+    await vi.importActual<typeof import("@earendil-works/pi-ai")>("@earendil-works/pi-ai");
+  return {
+    ...actual,
+    streamSimple: streamSimpleMock,
+  };
+});
+
+vi.mock("../plugin-sdk/provider-stream-shared.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../plugin-sdk/provider-stream-shared.js")
+  >("../plugin-sdk/provider-stream-shared.js");
+  return {
+    ...actual,
+    sanitizeGoogleThinkingPayload: sanitizeGoogleThinkingPayloadMock,
+  };
+});
+
+vi.mock("./custom-api-registry.js", () => ({
+  ensureCustomApiRegistered: ensureCustomApiRegisteredMock,
+}));
+
+const {
+  GOOGLE_SIMPLE_COMPLETION_API,
+  prepareGoogleSimpleCompletionModel,
+} = await import("./google-simple-completion-stream.js");
+
+function makeModel(id: string): Model<"google-generative-ai"> {
+  return {
+    id,
+    name: id,
+    api: "google-generative-ai",
+    provider: "google",
+    baseUrl: "https://generativelanguage.googleapis.com",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 1_000_000,
+    maxTokens: 8192,
+    headers: {},
+  };
+}
+
+describe("prepareGoogleSimpleCompletionModel", () => {
+  beforeEach(() => {
+    streamSimpleMock.mockReset();
+    sanitizeGoogleThinkingPayloadMock.mockReset();
+    ensureCustomApiRegisteredMock.mockReset();
+    ensureCustomApiRegisteredMock.mockReturnValue(true);
+    // Default: capture onPayload invocation by invoking it immediately with the
+    // raw payload pi-ai would normally produce.
+    streamSimpleMock.mockImplementation(async (_model, _context, options) => {
+      const payload: Record<string, unknown> = {
+        generationConfig: {
+          thinkingConfig: { thinkingBudget: -1 },
+        },
+      };
+      options?.onPayload?.(payload, _model);
+      return { content: [{ type: "text", text: "ok" }], payload };
+    });
+  });
+
+  it("returns the original model untouched for non-Google APIs", () => {
+    const model = { ...makeModel("anything"), api: "openai-responses" } as unknown as Model<"openai-responses">;
+    const result = prepareGoogleSimpleCompletionModel(model);
+    expect(result).toBe(model as unknown);
+    expect(ensureCustomApiRegisteredMock).not.toHaveBeenCalled();
+  });
+
+  it("registers an OpenClaw-owned api alias for google-generative-ai", () => {
+    const model = makeModel("gemini-flash-latest");
+    const result = prepareGoogleSimpleCompletionModel(model);
+    expect(result.api).toBe(GOOGLE_SIMPLE_COMPLETION_API);
+    expect(ensureCustomApiRegisteredMock).toHaveBeenCalledTimes(1);
+    expect(ensureCustomApiRegisteredMock.mock.calls[0][0]).toBe(GOOGLE_SIMPLE_COMPLETION_API);
+  });
+
+  for (const reasoning of ["off", "low", "medium", "high"] as const) {
+    it(`sanitizes outbound thinking payload for gemini-flash-latest + reasoning=${reasoning}`, async () => {
+      const model = makeModel("gemini-flash-latest");
+      const wrapped = prepareGoogleSimpleCompletionModel(model);
+      const streamFn = ensureCustomApiRegisteredMock.mock.calls[0][1] as (
+        ...args: unknown[]
+      ) => Promise<unknown>;
+      const ctx = { messages: [] } as unknown;
+      await streamFn(wrapped, ctx, { reasoning, apiKey: "key" });
+
+      // streamSimple should have been invoked with the model rewritten back to
+      // the canonical google-generative-ai api (pi-ai needs the original key).
+      expect(streamSimpleMock).toHaveBeenCalledTimes(1);
+      const [streamedModel] = streamSimpleMock.mock.calls[0];
+      expect((streamedModel as Model<"google-generative-ai">).api).toBe("google-generative-ai");
+
+      expect(sanitizeGoogleThinkingPayloadMock).toHaveBeenCalledTimes(1);
+      const sanitizeArgs = sanitizeGoogleThinkingPayloadMock.mock.calls[0][0] as {
+        modelId: string;
+        thinkingLevel: string | undefined;
+      };
+      expect(sanitizeArgs.modelId).toBe("gemini-flash-latest");
+      expect(sanitizeArgs.thinkingLevel).toBe(reasoning);
+
+      sanitizeGoogleThinkingPayloadMock.mockClear();
+      streamSimpleMock.mockClear();
+    });
+  }
+
+  it("uses end-to-end real sanitizer to strip thinkingBudget=-1 for gemini-flash-latest (off)", async () => {
+    sanitizeGoogleThinkingPayloadMock.mockImplementationOnce((args: { payload: Record<string, unknown> }) => {
+      // Mimic real sanitizer: for gemini-flash-latest off => MINIMAL
+      const gc = args.payload.generationConfig as Record<string, unknown>;
+      const tc = gc.thinkingConfig as Record<string, unknown>;
+      delete tc.thinkingBudget;
+      tc.thinkingLevel = "MINIMAL";
+    });
+
+    const model = makeModel("gemini-flash-latest");
+    const wrapped = prepareGoogleSimpleCompletionModel(model);
+    const streamFn = ensureCustomApiRegisteredMock.mock.calls[0][1] as (
+      ...args: unknown[]
+    ) => Promise<unknown>;
+
+    let captured: unknown;
+    streamSimpleMock.mockImplementationOnce(async (_m, _c, options) => {
+      const payload: Record<string, unknown> = {
+        generationConfig: { thinkingConfig: { thinkingBudget: -1 } },
+      };
+      options?.onPayload?.(payload, _m);
+      captured = payload;
+      return { content: [] };
+    });
+
+    await streamFn(wrapped, { messages: [] }, { reasoning: "off", apiKey: "key" });
+
+    const payload = captured as { generationConfig: { thinkingConfig: Record<string, unknown> } };
+    expect(payload.generationConfig.thinkingConfig).not.toHaveProperty("thinkingBudget");
+    expect(payload.generationConfig.thinkingConfig).toHaveProperty("thinkingLevel", "MINIMAL");
+  });
+});

--- a/src/agents/google-simple-completion-stream.ts
+++ b/src/agents/google-simple-completion-stream.ts
@@ -1,0 +1,82 @@
+import type { StreamFn } from "@earendil-works/pi-agent-core";
+import { streamSimple, type Api, type Model } from "@earendil-works/pi-ai";
+import {
+  sanitizeGoogleThinkingPayload,
+  type GoogleThinkingInputLevel,
+} from "../plugin-sdk/provider-stream-shared.js";
+import { ensureCustomApiRegistered } from "./custom-api-registry.js";
+import { streamWithPayloadPatch } from "./pi-embedded-runner/stream-payload-utils.js";
+
+/**
+ * Custom api alias used to register an OpenClaw-owned simple-completion wrapper
+ * around pi-ai's native Google generative-ai stream. The wrapper applies the
+ * shared Google thinking-payload sanitizer so local model-run (and any other
+ * simple-completion entry point) cannot leak `thinkingBudget: -1` to Google
+ * for unknown Gemini aliases such as `gemini-flash-latest` whose canonical
+ * thinking-level mapping is not recognized by upstream pi-ai.
+ */
+export const GOOGLE_SIMPLE_COMPLETION_API: Api =
+  "openclaw-google-generative-ai-simple" as Api;
+
+const SOURCE_API: Api = "google-generative-ai" as Api;
+
+function resolveGoogleSimpleThinkingLevel(
+  reasoning: unknown,
+): GoogleThinkingInputLevel | undefined {
+  if (typeof reasoning !== "string") {
+    return undefined;
+  }
+  switch (reasoning) {
+    case "off":
+    case "minimal":
+    case "low":
+    case "medium":
+    case "high":
+    case "max":
+    case "xhigh":
+    case "adaptive":
+      return reasoning;
+    default:
+      return undefined;
+  }
+}
+
+function buildGoogleSimpleCompletionStreamFn(): StreamFn {
+  return (model, context, options) => {
+    const googleModel = { ...model, api: SOURCE_API } as Parameters<StreamFn>[0];
+    return streamWithPayloadPatch(
+      streamSimple as unknown as StreamFn,
+      googleModel,
+      context,
+      options,
+      (payload) => {
+        sanitizeGoogleThinkingPayload({
+          payload,
+          modelId: model.id,
+          thinkingLevel: resolveGoogleSimpleThinkingLevel(
+            (options as { reasoning?: unknown } | undefined)?.reasoning,
+          ),
+        });
+      },
+    );
+  };
+}
+
+/**
+ * Swap a Google generative-ai model onto an OpenClaw-owned simple-completion
+ * api alias whose stream wrapper applies the shared Google thinking sanitizer.
+ *
+ * Returns the original model unchanged for non-Google APIs.
+ */
+export function prepareGoogleSimpleCompletionModel<TApi extends Api>(
+  model: Model<TApi>,
+): Model<Api> {
+  if (model.api !== SOURCE_API) {
+    return model as Model<Api>;
+  }
+  ensureCustomApiRegistered(
+    GOOGLE_SIMPLE_COMPLETION_API,
+    buildGoogleSimpleCompletionStreamFn(),
+  );
+  return { ...model, api: GOOGLE_SIMPLE_COMPLETION_API } as Model<Api>;
+}

--- a/src/agents/simple-completion-transport.test.ts
+++ b/src/agents/simple-completion-transport.test.ts
@@ -148,8 +148,8 @@ describe("prepareModelForSimpleCompletion", () => {
       headers: {},
     };
     resolveProviderStreamFn.mockReturnValueOnce(undefined);
-    prepareGoogleSimpleCompletionModel.mockImplementationOnce((m: Model<"google-generative-ai">) => ({
-      ...m,
+    prepareGoogleSimpleCompletionModel.mockImplementationOnce((m: unknown) => ({
+      ...(m as Model<"google-generative-ai">),
       api: "openclaw-google-generative-ai-simple",
     }));
 

--- a/src/agents/simple-completion-transport.test.ts
+++ b/src/agents/simple-completion-transport.test.ts
@@ -7,6 +7,7 @@ const ensureCustomApiRegistered = vi.fn();
 const resolveProviderStreamFn = vi.fn();
 const buildTransportAwareSimpleStreamFn = vi.fn();
 const prepareTransportAwareSimpleModel = vi.fn();
+const prepareGoogleSimpleCompletionModel = vi.fn((model: unknown) => model);
 
 vi.mock("./anthropic-vertex-stream.js", () => ({
   createAnthropicVertexStreamFnForModel,
@@ -14,6 +15,10 @@ vi.mock("./anthropic-vertex-stream.js", () => ({
 
 vi.mock("./custom-api-registry.js", () => ({
   ensureCustomApiRegistered,
+}));
+
+vi.mock("./google-simple-completion-stream.js", () => ({
+  prepareGoogleSimpleCompletionModel,
 }));
 
 vi.mock("./provider-transport-stream.js", () => ({
@@ -44,6 +49,8 @@ describe("prepareModelForSimpleCompletion", () => {
     resolveProviderStreamFn.mockReset();
     buildTransportAwareSimpleStreamFn.mockReset();
     prepareTransportAwareSimpleModel.mockReset();
+    prepareGoogleSimpleCompletionModel.mockReset();
+    prepareGoogleSimpleCompletionModel.mockImplementation((model) => model);
     createAnthropicVertexStreamFnForModel.mockReturnValue("vertex-stream");
     resolveProviderStreamFn.mockReturnValue("ollama-stream");
     buildTransportAwareSimpleStreamFn.mockReturnValue(undefined);
@@ -124,6 +131,35 @@ describe("prepareModelForSimpleCompletion", () => {
       ...model,
       api: "openclaw-anthropic-vertex-simple:https%3A%2F%2Fus-central1-aiplatform.googleapis.com",
     });
+  });
+
+  it("swaps Google generative-ai models onto the OpenClaw simple-completion alias", () => {
+    const model: Model<"google-generative-ai"> = {
+      id: "gemini-flash-latest",
+      name: "Gemini Flash Latest",
+      api: "google-generative-ai",
+      provider: "google",
+      baseUrl: "https://generativelanguage.googleapis.com",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 1_000_000,
+      maxTokens: 8192,
+      headers: {},
+    };
+    resolveProviderStreamFn.mockReturnValueOnce(undefined);
+    prepareGoogleSimpleCompletionModel.mockImplementationOnce((m: Model<"google-generative-ai">) => ({
+      ...m,
+      api: "openclaw-google-generative-ai-simple",
+    }));
+
+    const result = prepareModelForSimpleCompletion({ model });
+
+    expect(prepareGoogleSimpleCompletionModel).toHaveBeenCalledWith(model);
+    expect(result.api).toBe("openclaw-google-generative-ai-simple");
+    // Should not have fallen through to transport-aware or Anthropic Vertex.
+    expect(prepareTransportAwareSimpleModel).not.toHaveBeenCalled();
+    expect(createAnthropicVertexStreamFnForModel).not.toHaveBeenCalled();
   });
 
   it("uses a transport-aware custom api alias when llm request transport overrides are present", () => {

--- a/src/agents/simple-completion-transport.ts
+++ b/src/agents/simple-completion-transport.ts
@@ -2,6 +2,7 @@ import { getApiProvider, type Api, type Model } from "@earendil-works/pi-ai";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createAnthropicVertexStreamFnForModel } from "./anthropic-vertex-stream.js";
 import { ensureCustomApiRegistered } from "./custom-api-registry.js";
+import { prepareGoogleSimpleCompletionModel } from "./google-simple-completion-stream.js";
 import { registerProviderStreamForModel } from "./provider-stream.js";
 import {
   buildTransportAwareSimpleStreamFn,
@@ -21,6 +22,17 @@ export function prepareModelForSimpleCompletion<TApi extends Api>(params: {
   // Only provider-owned custom APIs need runtime stream registration here.
   if (!getApiProvider(model.api) && registerProviderStreamForModel({ model, cfg })) {
     return model;
+  }
+
+  // Wrap pi-ai's native Google generative-ai stream with the shared Google
+  // thinking-payload sanitizer so simple-completion entry points (e.g.
+  // `openclaw model run` --transport=local) cannot send `thinkingBudget: -1`
+  // to Google for Gemini aliases whose upstream pi-ai mapping returns -1
+  // (e.g. `gemini-flash-latest`). The normal agent runtime already applies
+  // this sanitizer via the embedded-runner stream wrappers; this keeps the
+  // local simple-completion path consistent without forking pi-ai upstream.
+  if (model.api === "google-generative-ai") {
+    return prepareGoogleSimpleCompletionModel(model);
   }
 
   const transportAwareModel = prepareTransportAwareSimpleModel(model, { cfg });


### PR DESCRIPTION
## Background

Reported in #84688: running `openclaw model run` with `--transport=local` against a Google Gemini model whose ID is not recognized as Gemini 3 Flash by pi-ai (notably `gemini-flash-latest`) causes Google's generative-ai endpoint to reject the request because the outbound payload contains `thinkingConfig.thinkingBudget: -1`.

The normal agent runtime is unaffected because the embedded runner wraps the stream with `createGoogleThinkingPayloadWrapper` (see `src/agents/pi-embedded-runner/extra-params.ts`). The lean local simple-completion path goes through `completeWithPreparedSimpleCompletionModel` → `prepareModelForSimpleCompletion` → pi-ai `completeSimple`, which bypasses that wrapper.

## Root cause

`@earendil-works/pi-ai@0.75.3`'s `getGoogleBudget` only matches explicit Gemini 3 Flash IDs (`/gemini-3(?:\.\d+)?-flash/`); for unknown Gemini reasoning aliases it returns `-1`. `prepareModelForSimpleCompletion` previously only registered custom stream wrappers when pi-ai had no api provider, when an explicit OpenClaw transport (`request.proxy`, `request.tls`, `localService`) was configured, or for Anthropic Vertex. Plain `google-generative-ai` models therefore reached pi-ai's built-in Google stream unchanged.

## Fix

Register an OpenClaw-owned simple-completion API alias (`openclaw-google-generative-ai-simple`) for `google-generative-ai` models. The alias wraps pi-ai's native `streamSimple` with the shared `sanitizeGoogleThinkingPayload` helper (which already understands `gemini-flash-latest` via `isGoogleGemini3FlashModel` and maps thinking levels / strips invalid negative budgets). pi-ai is not modified.

## Tests

- New `src/agents/google-simple-completion-stream.test.ts` covers `gemini-flash-latest` × `thinking: off | low | medium | high`, verifying the sanitizer is invoked with the correct `thinkingLevel` and that an end-to-end run with the real sanitizer replaces `thinkingBudget: -1` with `thinkingLevel: MINIMAL`.
- `src/agents/simple-completion-transport.test.ts` gains an integration case asserting `google-generative-ai` models are routed through `prepareGoogleSimpleCompletionModel` and end up on the OpenClaw alias api.

Existing `google-stream-wrappers.test.ts` cases for `gemini-flash-latest` already prove the sanitizer's behavior.

Fixes #84688