### PR TITLE
test(macos): cover CLI root command dispatch

### DIFF
--- a/apps/macos/Sources/OpenClawMacCLI/EntryPoint.swift
+++ b/apps/macos/Sources/OpenClawMacCLI/EntryPoint.swift
@@ -1,39 +1,26 @@
 import Foundation
 
-private struct RootCommand {
-    var name: String
-    var args: [String]
-}
-
 @main
 struct OpenClawMacCLI {
     static func main() async {
         let args = Array(CommandLine.arguments.dropFirst())
-        let command = parseRootCommand(args)
-        switch command?.name {
-        case nil:
+        switch resolveRootCommandAction(args) {
+        case .usage:
             printUsage()
-        case "-h", "--help", "help":
-            printUsage()
-        case "connect":
-            await runConnect(command?.args ?? [])
-        case "configure-remote":
-            runConfigureRemote(command?.args ?? [])
-        case "discover":
-            await runDiscover(command?.args ?? [])
-        case "wizard":
-            await runWizardCommand(command?.args ?? [])
-        default:
+        case let .connect(commandArgs):
+            await runConnect(commandArgs)
+        case let .configureRemote(commandArgs):
+            runConfigureRemote(commandArgs)
+        case let .discover(commandArgs):
+            await runDiscover(commandArgs)
+        case let .wizard(commandArgs):
+            await runWizardCommand(commandArgs)
+        case .unknown:
             fputs("openclaw-mac: unknown command\n", stderr)
             printUsage()
             exit(1)
         }
     }
-}
-
-private func parseRootCommand(_ args: [String]) -> RootCommand? {
-    guard let first = args.first else { return nil }
-    return RootCommand(name: first, args: Array(args.dropFirst()))
 }
 
 private func printUsage() {

--- a/apps/macos/Sources/OpenClawMacCLI/RootCommandParser.swift
+++ b/apps/macos/Sources/OpenClawMacCLI/RootCommandParser.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+struct RootCommand: Equatable {
+    var name: String
+    var args: [String]
+}
+
+enum RootCommandAction: Equatable {
+    case usage
+    case connect([String])
+    case configureRemote([String])
+    case discover([String])
+    case wizard([String])
+    case unknown(String)
+}
+
+func parseRootCommand(_ args: [String]) -> RootCommand? {
+    guard let first = args.first else { return nil }
+    return RootCommand(name: first, args: Array(args.dropFirst()))
+}
+
+func resolveRootCommandAction(_ args: [String]) -> RootCommandAction {
+    guard let command = parseRootCommand(args) else { return .usage }
+    switch command.name {
+    case "-h", "--help", "help":
+        return .usage
+    case "connect":
+        return .connect(command.args)
+    case "configure-remote":
+        return .configureRemote(command.args)
+    case "discover":
+        return .discover(command.args)
+    case "wizard":
+        return .wizard(command.args)
+    default:
+        return .unknown(command.name)
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/RootCommandParserTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/RootCommandParserTests.swift
@@ -1,0 +1,37 @@
+import Testing
+@testable import OpenClawMacCLI
+
+struct RootCommandParserTests {
+    @Test func parseRootCommandReturnsNilForEmptyArgs() {
+        #expect(parseRootCommand([]) == nil)
+    }
+
+    @Test func parseRootCommandSplitsNameAndArguments() throws {
+        let command = try #require(parseRootCommand(["connect", "--url", "ws://127.0.0.1:18789", "--json"]))
+
+        #expect(command.name == "connect")
+        #expect(command.args == ["--url", "ws://127.0.0.1:18789", "--json"])
+    }
+
+    @Test func resolveRootCommandActionMapsHelpAliasesToUsage() {
+        #expect(resolveRootCommandAction([]) == .usage)
+        #expect(resolveRootCommandAction(["-h"]) == .usage)
+        #expect(resolveRootCommandAction(["--help"]) == .usage)
+        #expect(resolveRootCommandAction(["help"]) == .usage)
+    }
+
+    @Test func resolveRootCommandActionMapsKnownCommandsWithArguments() {
+        #expect(resolveRootCommandAction(["connect", "--json"]) == .connect(["--json"]))
+        #expect(
+            resolveRootCommandAction(["configure-remote", "--ssh-target", "user@example.com"])
+                == .configureRemote(["--ssh-target", "user@example.com"])
+        )
+        #expect(resolveRootCommandAction(["discover", "--include-local"]) == .discover(["--include-local"]))
+        #expect(resolveRootCommandAction(["wizard", "--mode", "local"]) == .wizard(["--mode", "local"]))
+    }
+
+    @Test func resolveRootCommandActionKeepsUnknownCommandsCaseSensitive() {
+        #expect(resolveRootCommandAction(["Connect"]) == .unknown("Connect"))
+        #expect(resolveRootCommandAction(["unknown", "--flag"]) == .unknown("unknown"))
+    }
+}


### PR DESCRIPTION
## Summary
- Extract the macOS CLI root-command parser/dispatcher into a small testable helper.
- Keep the existing `openclaw-mac` runtime behavior while switching the entrypoint to the resolved action enum.
- Add Swift Testing coverage for empty args, help aliases, subcommand argument splitting, known command dispatch, and case-sensitive unknown commands.

Fixes #83879

## Real behavior proof

Behavior addressed: `parseRootCommand` and the `OpenClawMacCLI.main()` root dispatch table had no unit-testable surface, so regressions in empty args, help aliases, argument splitting, known command dispatch, or unknown-command handling would not be caught.

Real environment tested: Local OpenClaw checkout on macOS, Apple Swift 6.1 installed locally, branch `test/macos-cli-root-command-dispatch-83879`. The package manifest requires Swift tools 6.2, so full `swift test` is expected to run in macOS CI rather than this local Swift 6.1 toolchain.

Exact steps or command run after fix:

```console
$ swift /tmp/openclaw-root-parser-proof.swift
$ cd apps/macos
$ swiftc -parse Sources/OpenClawMacCLI/EntryPoint.swift Sources/OpenClawMacCLI/RootCommandParser.swift
$ swiftc -parse Tests/OpenClawIPCTests/RootCommandParserTests.swift
$ swift test --filter RootCommandParserTests
$ cd ../..
$ git diff --check
```

Evidence after fix: The standalone Swift proof using the same root-command parser/dispatcher logic passed:

```console
root command parser proof passed
```

The changed source and test files also passed Swift parser checks with `swiftc -parse`, and `git diff --check` passed. The local full SwiftPM test command reported the expected toolchain mismatch:

```console
error: 'macos': package 'macos' is using Swift tools version 6.2.0 but the installed version is 6.1.0
```

Observed result after fix: The proof confirms empty args resolve to usage, help aliases resolve to usage, subcommand arguments are preserved after the root command, `configure-remote` dispatches with its arguments, and `Connect` remains a case-sensitive unknown command.

What was not tested: I did not run the full macOS SwiftPM test target locally because the installed Swift toolchain is 6.1 while `apps/macos/Package.swift` requires Swift tools 6.2. CI's macOS Swift lane should provide the required toolchain and run `RootCommandParserTests` as part of the package tests.

## Test plan
- `swift /tmp/openclaw-root-parser-proof.swift`
- `swiftc -parse Sources/OpenClawMacCLI/EntryPoint.swift Sources/OpenClawMacCLI/RootCommandParser.swift` from `apps/macos`
- `swiftc -parse Tests/OpenClawIPCTests/RootCommandParserTests.swift` from `apps/macos`
- `git diff --check`
