### PR TITLE
perf(cli): cache stable subcommand help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Docs: https://docs.openclaw.ai
 - CLI/perf: keep `setup --help`, `onboard --help`, and `configure --help` out of the full wizard runtime while preserving the existing help output. (#84488) Thanks @frankekn.
 - CLI/perf: keep `agents --help` out of agents action/runtime imports so help, completion, and command discovery paths avoid loading the full agents runtime. (#84483) Thanks @frankekn.
 - CLI/perf: keep `secrets --help` and `nodes --help` on the precomputed help path so parent help avoids loading action-heavy command runtime modules. (#84818) Thanks @frankekn.
+- CLI/perf: serve `doctor`, `gateway`, `models`, and `plugins` parent help from startup metadata so common subcommand help avoids full CLI program construction. (#84786) Thanks @frankekn.
 
 ## 2026.5.20
 
@@ -118,7 +119,6 @@ Docs: https://docs.openclaw.ai
 - Codex: respect explicit `models auth order set` and `config.auth.order` precedence over stale `lastGood` in `/codex account`, and show `no working credential` when every explicit-order profile is ineligible instead of marking a lower-ranked profile as active. Fixes #84386. (#84412) Thanks @openperf.
 - Agents: honor `messages.suppressToolErrors` for mutating tool failures so configured chat surfaces do not receive separate warning payloads. (#81561) Thanks @moeedahmed.
 - Agents/fallback: surface billing guidance for mixed rate-limit plus billing fallback exhaustion instead of generic failure copy. Fixes #79396. (#79489) Thanks @aayushprsingh.
-- CLI/perf: serve `doctor`, `gateway`, `models`, and `plugins` parent help from startup metadata so common subcommand help avoids full CLI program construction. (#84786) Thanks @frankekn.
 
 ## 2026.5.19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- CLI/perf: serve `doctor`, `gateway`, `models`, and `plugins` parent help from startup metadata so common subcommand help avoids full CLI program construction. (#84786) Thanks @frankekn.
 - CLI/tasks: include stale-running task maintenance decisions in `openclaw tasks maintenance --json` so retained and reconcile candidates explain backing-session, cron, CLI, and wedged-subagent state. (#84691) Thanks @efpiva.
 - Codex app-server: keep system-prompt reports working when bootstrap hooks provide workspace files with only a path and content, so hook-supplied SOUL/IDENTITY/TOOLS/USER context still reports injected characters correctly. (#84736) Thanks @JARVIS-Glasses.
 - Providers/MiniMax music: stop advertising `durationSeconds` control and remove prompt-injected duration hints, so `music_generate` reports MiniMax duration as an unsupported override instead of suggesting MiniMax can enforce track length. Fixes #84508. Thanks @neeravmakwana.
@@ -119,6 +118,7 @@ Docs: https://docs.openclaw.ai
 - Codex: respect explicit `models auth order set` and `config.auth.order` precedence over stale `lastGood` in `/codex account`, and show `no working credential` when every explicit-order profile is ineligible instead of marking a lower-ranked profile as active. Fixes #84386. (#84412) Thanks @openperf.
 - Agents: honor `messages.suppressToolErrors` for mutating tool failures so configured chat surfaces do not receive separate warning payloads. (#81561) Thanks @moeedahmed.
 - Agents/fallback: surface billing guidance for mixed rate-limit plus billing fallback exhaustion instead of generic failure copy. Fixes #79396. (#79489) Thanks @aayushprsingh.
+- CLI/perf: serve `doctor`, `gateway`, `models`, and `plugins` parent help from startup metadata so common subcommand help avoids full CLI program construction. (#84786) Thanks @frankekn.
 
 ## 2026.5.19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- CLI/perf: serve `doctor`, `gateway`, `models`, and `plugins` parent help from startup metadata so common subcommand help avoids full CLI program construction.
+- CLI/perf: serve `doctor`, `gateway`, `models`, and `plugins` parent help from startup metadata so common subcommand help avoids full CLI program construction. (#84786) Thanks @frankekn.
 - CLI/tasks: include stale-running task maintenance decisions in `openclaw tasks maintenance --json` so retained and reconcile candidates explain backing-session, cron, CLI, and wedged-subagent state. (#84691) Thanks @efpiva.
 - Codex app-server: keep system-prompt reports working when bootstrap hooks provide workspace files with only a path and content, so hook-supplied SOUL/IDENTITY/TOOLS/USER context still reports injected characters correctly. (#84736) Thanks @JARVIS-Glasses.
 - Providers/MiniMax music: stop advertising `durationSeconds` control and remove prompt-injected duration hints, so `music_generate` reports MiniMax duration as an unsupported override instead of suggesting MiniMax can enforce track length. Fixes #84508. Thanks @neeravmakwana.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/perf: serve `doctor`, `gateway`, `models`, and `plugins` parent help from startup metadata so common subcommand help avoids full CLI program construction.
 - CLI/tasks: include stale-running task maintenance decisions in `openclaw tasks maintenance --json` so retained and reconcile candidates explain backing-session, cron, CLI, and wedged-subagent state. (#84691) Thanks @efpiva.
 - Codex app-server: keep system-prompt reports working when bootstrap hooks provide workspace files with only a path and content, so hook-supplied SOUL/IDENTITY/TOOLS/USER context still reports injected characters correctly. (#84736) Thanks @JARVIS-Glasses.
 - Providers/MiniMax music: stop advertising `durationSeconds` control and remove prompt-injected duration hints, so `music_generate` reports MiniMax duration as an unsupported override instead of suggesting MiniMax can enforce track length. Fixes #84508. Thanks @neeravmakwana.

--- a/scripts/write-cli-startup-metadata.ts
+++ b/scripts/write-cli-startup-metadata.ts
@@ -28,6 +28,7 @@ const extensionsDir = path.join(rootDir, "extensions");
 const ROOT_HELP_RENDER_TIMEOUT_MS = 120_000;
 const BROWSER_HELP_RENDER_TIMEOUT_MS = 120_000;
 const COMMAND_HELP_RENDER_TIMEOUT_MS = 120_000;
+const PRECOMPUTED_SUBCOMMAND_HELP_COMMANDS = ["doctor", "gateway", "models", "plugins"] as const;
 const CORE_CHANNEL_ORDER = [
   "telegram",
   "whatsapp",
@@ -50,6 +51,8 @@ type BundledChannelCatalog = {
   signature: string;
 };
 
+type PrecomputedSubcommandHelpCommand = (typeof PRECOMPUTED_SUBCOMMAND_HELP_COMMANDS)[number];
+type PrecomputedSubcommandHelpText = Record<PrecomputedSubcommandHelpCommand, string>;
 type RootHelpRenderContext = Pick<RootHelpRenderOptions, "config" | "env">;
 
 function resolveRootHelpBundleIdentity(
@@ -137,6 +140,30 @@ function resolveNodesHelpSourceSignature(sourceRootDir: string = rootDir): strin
       path.join(sourceRootDir, "src/cli/program/context.ts"),
       path.join(sourceRootDir, "src/cli/banner.ts"),
       path.join(sourceRootDir, "src/plugins/register-plugin-cli-command-groups.ts"),
+    ],
+    sourceRootDir,
+  );
+  return hash.digest("hex");
+}
+
+function resolveSubcommandHelpSourceSignature(sourceRootDir: string = rootDir): string {
+  const hash = createHash("sha1");
+  updateHashFromFiles(
+    hash,
+    [
+      path.join(sourceRootDir, "src/cli/program/help.ts"),
+      path.join(sourceRootDir, "src/cli/program/context.ts"),
+      path.join(sourceRootDir, "src/cli/banner.ts"),
+      path.join(sourceRootDir, "src/cli/help-format.ts"),
+      path.join(sourceRootDir, "src/cli/daemon-cli/register-service-commands.ts"),
+      path.join(sourceRootDir, "src/cli/program/register.maintenance.ts"),
+      path.join(sourceRootDir, "src/cli/gateway-cli.ts"),
+      path.join(sourceRootDir, "src/cli/gateway-cli/register.ts"),
+      path.join(sourceRootDir, "src/cli/gateway-cli/run-command.ts"),
+      path.join(sourceRootDir, "src/cli/models-cli.ts"),
+      path.join(sourceRootDir, "src/cli/plugins-cli.ts"),
+      path.join(sourceRootDir, "src/terminal/links.ts"),
+      path.join(sourceRootDir, "src/terminal/theme.ts"),
     ],
     sourceRootDir,
   );
@@ -362,7 +389,7 @@ function renderSourceBrowserHelpText(
 }
 
 function renderSourceCommandHelpText(
-  command: "nodes" | "secrets",
+  command: "nodes" | "secrets" | PrecomputedSubcommandHelpCommand,
   renderContext: RootHelpRenderContext = createIsolatedRootHelpRenderContext(),
 ): string {
   const result = spawnSync(
@@ -403,6 +430,16 @@ function renderSourceNodesHelpText(
   return renderSourceCommandHelpText("nodes", renderContext);
 }
 
+function renderSourceSubcommandHelpTextRecord(
+  renderContext: RootHelpRenderContext = createIsolatedRootHelpRenderContext(),
+): PrecomputedSubcommandHelpText {
+  const entries = PRECOMPUTED_SUBCOMMAND_HELP_COMMANDS.map((commandName) => [
+    commandName,
+    renderSourceCommandHelpText(commandName, renderContext),
+  ]);
+  return Object.fromEntries(entries) as PrecomputedSubcommandHelpText;
+}
+
 export async function writeCliStartupMetadata(options?: {
   distDir?: string;
   outputPath?: string;
@@ -413,6 +450,7 @@ export async function writeCliStartupMetadata(options?: {
   renderSourceBrowserHelpText?: typeof renderSourceBrowserHelpText;
   renderSourceSecretsHelpText?: typeof renderSourceSecretsHelpText;
   renderSourceNodesHelpText?: typeof renderSourceNodesHelpText;
+  renderSourceSubcommandHelpTextRecord?: typeof renderSourceSubcommandHelpTextRecord;
 }): Promise<void> {
   const resolvedDistDir = options?.distDir ?? distDir;
   const resolvedOutputPath = options?.outputPath ?? outputPath;
@@ -423,6 +461,7 @@ export async function writeCliStartupMetadata(options?: {
   const browserHelpSourceSignature = resolveBrowserHelpSourceSignature(resolvedSourceRootDir);
   const secretsHelpSourceSignature = resolveSecretsHelpSourceSignature(resolvedSourceRootDir);
   const nodesHelpSourceSignature = resolveNodesHelpSourceSignature(resolvedSourceRootDir);
+  const subcommandHelpSourceSignature = resolveSubcommandHelpSourceSignature(resolvedSourceRootDir);
   const bundledPluginsDir = path.join(resolvedDistDir, "extensions");
   const renderContext = createIsolatedRootHelpRenderContext(
     existsSync(bundledPluginsDir) ? bundledPluginsDir : resolvedExtensionsDir,
@@ -435,10 +474,12 @@ export async function writeCliStartupMetadata(options?: {
       browserHelpSourceSignature?: unknown;
       secretsHelpSourceSignature?: unknown;
       nodesHelpSourceSignature?: unknown;
+      subcommandHelpSourceSignature?: unknown;
       channelCatalogSignature?: unknown;
       browserHelpText?: unknown;
       secretsHelpText?: unknown;
       nodesHelpText?: unknown;
+      subcommandHelpText?: unknown;
     };
     if (
       bundleIdentity &&
@@ -446,13 +487,15 @@ export async function writeCliStartupMetadata(options?: {
       existing.browserHelpSourceSignature === browserHelpSourceSignature &&
       existing.secretsHelpSourceSignature === secretsHelpSourceSignature &&
       existing.nodesHelpSourceSignature === nodesHelpSourceSignature &&
+      existing.subcommandHelpSourceSignature === subcommandHelpSourceSignature &&
       existing.channelCatalogSignature === channelCatalog.signature &&
       typeof existing.browserHelpText === "string" &&
       existing.browserHelpText.length > 0 &&
       typeof existing.secretsHelpText === "string" &&
       existing.secretsHelpText.length > 0 &&
       typeof existing.nodesHelpText === "string" &&
-      existing.nodesHelpText.length > 0
+      existing.nodesHelpText.length > 0 &&
+      hasAllPrecomputedSubcommandHelpText(existing.subcommandHelpText)
     ) {
       return;
     }
@@ -478,6 +521,9 @@ export async function writeCliStartupMetadata(options?: {
   const nodesHelpText = (options?.renderSourceNodesHelpText ?? renderSourceNodesHelpText)(
     renderContext,
   );
+  const subcommandHelpText = (
+    options?.renderSourceSubcommandHelpTextRecord ?? renderSourceSubcommandHelpTextRecord
+  )(renderContext);
 
   mkdirSync(resolvedDistDir, { recursive: true });
   writeFileSync(
@@ -491,15 +537,27 @@ export async function writeCliStartupMetadata(options?: {
         browserHelpSourceSignature,
         secretsHelpSourceSignature,
         nodesHelpSourceSignature,
+        subcommandHelpSourceSignature,
         browserHelpText,
         secretsHelpText,
         nodesHelpText,
+        subcommandHelpText,
         rootHelpText,
       },
       null,
       2,
     )}\n`,
     "utf8",
+  );
+}
+
+function hasAllPrecomputedSubcommandHelpText(value: unknown): boolean {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const record = value as Partial<Record<PrecomputedSubcommandHelpCommand, unknown>>;
+  return PRECOMPUTED_SUBCOMMAND_HELP_COMMANDS.every(
+    (commandName) => typeof record[commandName] === "string" && record[commandName].length > 0,
   );
 }
 

--- a/src/cli/root-help-metadata.ts
+++ b/src/cli/root-help-metadata.ts
@@ -1,9 +1,14 @@
 import { readCliStartupMetadata } from "./startup-metadata.js";
 
+export type PrecomputedSubcommandHelpName = "doctor" | "gateway" | "models" | "plugins";
+
 let precomputedRootHelpText: string | null | undefined;
 let precomputedBrowserHelpText: string | null | undefined;
 let precomputedSecretsHelpText: string | null | undefined;
 let precomputedNodesHelpText: string | null | undefined;
+let precomputedSubcommandHelpText:
+  | Partial<Record<PrecomputedSubcommandHelpName, string | null>>
+  | undefined;
 
 type PrecomputedHelpTextKey =
   | "rootHelpText"
@@ -59,6 +64,31 @@ export function loadPrecomputedNodesHelpText(): string | null {
   });
 }
 
+export function loadPrecomputedSubcommandHelpText(commandName: string): string | null {
+  if (!isPrecomputedSubcommandHelpName(commandName)) {
+    return null;
+  }
+  const cache = precomputedSubcommandHelpText?.[commandName];
+  if (cache !== undefined) {
+    return cache;
+  }
+  try {
+    const parsed = readCliStartupMetadata(import.meta.url);
+    const subcommandHelpText = parsed?.subcommandHelpText;
+    if (isSubcommandHelpTextRecord(subcommandHelpText)) {
+      const value = subcommandHelpText[commandName];
+      if (typeof value === "string" && value.length > 0) {
+        setPrecomputedSubcommandHelpText(commandName, value);
+        return value;
+      }
+    }
+  } catch {
+    // Fall back to live help rendering.
+  }
+  setPrecomputedSubcommandHelpText(commandName, null);
+  return null;
+}
+
 export function outputPrecomputedRootHelpText(): boolean {
   const rootHelpText = loadPrecomputedRootHelpText();
   if (!rootHelpText) {
@@ -95,12 +125,49 @@ export function outputPrecomputedNodesHelpText(): boolean {
   return true;
 }
 
+export function outputPrecomputedSubcommandHelpText(commandName: string): boolean {
+  const helpText = loadPrecomputedSubcommandHelpText(commandName);
+  if (!helpText) {
+    return false;
+  }
+  process.stdout.write(helpText);
+  return true;
+}
+
+function isPrecomputedSubcommandHelpName(
+  commandName: string,
+): commandName is PrecomputedSubcommandHelpName {
+  return (
+    commandName === "doctor" ||
+    commandName === "gateway" ||
+    commandName === "models" ||
+    commandName === "plugins"
+  );
+}
+
+function isSubcommandHelpTextRecord(
+  value: unknown,
+): value is Partial<Record<PrecomputedSubcommandHelpName, unknown>> {
+  return typeof value === "object" && value !== null;
+}
+
+function setPrecomputedSubcommandHelpText(
+  commandName: PrecomputedSubcommandHelpName,
+  value: string | null,
+): void {
+  precomputedSubcommandHelpText = {
+    ...precomputedSubcommandHelpText,
+    [commandName]: value,
+  };
+}
+
 export const testing = {
   resetPrecomputedRootHelpTextForTests(): void {
     precomputedRootHelpText = undefined;
     precomputedBrowserHelpText = undefined;
     precomputedSecretsHelpText = undefined;
     precomputedNodesHelpText = undefined;
+    precomputedSubcommandHelpText = undefined;
   },
 };
 export { testing as __testing };

--- a/src/cli/run-main-policy.ts
+++ b/src/cli/run-main-policy.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { consumeRootOptionToken } from "../infra/cli-root-options.js";
 import {
   resolveManifestCommandAliasOwnerInRegistry,
   resolveManifestToolOwnerInRegistry,
@@ -22,10 +23,55 @@ import { getSubCliParentDefaultHelpCommands } from "./program/subcli-descriptors
 
 const ROOT_HELP_ALIASES = new Set(["tools"]);
 const SETUP_ONBOARD_CONFIGURE_HELP_COMMANDS = new Set(["setup", "onboard", "configure"]);
+const PRECOMPUTED_SUBCOMMAND_HELP_COMMANDS = new Set(["doctor", "gateway", "models", "plugins"]);
+const HELP_FLAGS = new Set(["-h", "--help"]);
+const VERSION_FLAGS = new Set(["-V", "--version"]);
 const BARE_PARENT_DEFAULT_HELP_COMMANDS = new Set([
   ...getCoreCliParentDefaultHelpCommands(),
   ...getSubCliParentDefaultHelpCommands(),
 ]);
+
+function hasHelpFlag(argv: string[]): boolean {
+  return hasFlag(argv, "-h") || hasFlag(argv, "--help");
+}
+
+function resolveStrictPrecomputedSubcommandHelpCommand(argv: string[]): string | null {
+  const args = argv.slice(2);
+  let commandName: string | null = null;
+  let sawHelp = false;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (!arg || arg === "--") {
+      return null;
+    }
+    if (VERSION_FLAGS.has(arg)) {
+      return null;
+    }
+    if (!commandName) {
+      const consumed = consumeRootOptionToken(args, index);
+      if (consumed > 0) {
+        index += consumed - 1;
+        continue;
+      }
+      if (arg.startsWith("-")) {
+        return null;
+      }
+      if (!PRECOMPUTED_SUBCOMMAND_HELP_COMMANDS.has(arg)) {
+        return null;
+      }
+      commandName = arg;
+      continue;
+    }
+    if (HELP_FLAGS.has(arg)) {
+      sawHelp = true;
+      continue;
+    }
+    return null;
+  }
+
+  return commandName && sawHelp ? commandName : null;
+}
 
 function isBareParentDefaultHelpArgv(argv: string[]): boolean {
   const invocation = resolveCliArgvInvocation(argv);
@@ -86,7 +132,7 @@ export function shouldUseBrowserHelpFastPath(
   return (
     invocation.commandPath.length === 1 &&
     invocation.commandPath[0] === "browser" &&
-    (hasFlag(argv, "--help") || hasFlag(argv, "-h"))
+    hasHelpFlag(argv)
   );
 }
 
@@ -101,7 +147,7 @@ export function shouldUseSecretsHelpFastPath(
   return (
     invocation.commandPath.length === 1 &&
     invocation.commandPath[0] === "secrets" &&
-    (hasFlag(argv, "--help") || hasFlag(argv, "-h"))
+    hasHelpFlag(argv)
   );
 }
 
@@ -116,7 +162,7 @@ export function shouldUseNodesHelpFastPath(
   return (
     invocation.commandPath.length === 1 &&
     invocation.commandPath[0] === "nodes" &&
-    (hasFlag(argv, "--help") || hasFlag(argv, "-h"))
+    hasHelpFlag(argv)
   );
 }
 
@@ -133,6 +179,16 @@ export function shouldUseSetupOnboardConfigureHelpFastPath(
     SETUP_ONBOARD_CONFIGURE_HELP_COMMANDS.has(invocation.commandPath[0] ?? "") &&
     invocation.hasHelpOrVersion
   );
+}
+
+export function resolvePrecomputedSubcommandHelpFastPath(
+  argv: string[],
+  env: NodeJS.ProcessEnv = process.env,
+): string | null {
+  if (env.OPENCLAW_DISABLE_CLI_STARTUP_HELP_FAST_PATH === "1") {
+    return null;
+  }
+  return resolveStrictPrecomputedSubcommandHelpCommand(argv);
 }
 
 export function shouldStartCrestodianForBareRoot(argv: string[]): boolean {

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -21,6 +21,7 @@ const outputPrecomputedRootHelpTextMock = vi.hoisted(() => vi.fn(() => false));
 const outputPrecomputedBrowserHelpTextMock = vi.hoisted(() => vi.fn(() => false));
 const outputPrecomputedSecretsHelpTextMock = vi.hoisted(() => vi.fn(() => false));
 const outputPrecomputedNodesHelpTextMock = vi.hoisted(() => vi.fn(() => false));
+const outputPrecomputedSubcommandHelpTextMock = vi.hoisted(() => vi.fn(() => false));
 const loadRootHelpRenderOptionsForConfigSensitivePluginsMock = vi.hoisted(() =>
   vi.fn<() => Promise<RootHelpRenderOptions | null>>(async () => null),
 );
@@ -175,6 +176,7 @@ vi.mock("./root-help-metadata.js", () => ({
   outputPrecomputedNodesHelpText: outputPrecomputedNodesHelpTextMock,
   outputPrecomputedRootHelpText: outputPrecomputedRootHelpTextMock,
   outputPrecomputedSecretsHelpText: outputPrecomputedSecretsHelpTextMock,
+  outputPrecomputedSubcommandHelpText: outputPrecomputedSubcommandHelpTextMock,
 }));
 
 vi.mock("./root-help-live-config.js", () => ({
@@ -262,6 +264,7 @@ describe("runCli exit behavior", () => {
     outputPrecomputedNodesHelpTextMock.mockReturnValue(false);
     outputPrecomputedRootHelpTextMock.mockReturnValue(false);
     outputPrecomputedSecretsHelpTextMock.mockReturnValue(false);
+    outputPrecomputedSubcommandHelpTextMock.mockReturnValue(false);
     loadRootHelpRenderOptionsForConfigSensitivePluginsMock.mockResolvedValue(null);
     tryOutputSetupOnboardConfigureHelpMock.mockResolvedValue(true);
     hasEnvHttpProxyAgentConfiguredMock.mockReturnValue(false);
@@ -457,6 +460,17 @@ describe("runCli exit behavior", () => {
     expect(outputPrecomputedNodesHelpTextMock).not.toHaveBeenCalled();
     expect(registerSubCliByNameMock.mock.calls).toEqual([[program, "nodes", argv]]);
     expect(parseAsync).toHaveBeenCalledWith(argv);
+  });
+
+  it("renders selected subcommand help from startup metadata without building the full program", async () => {
+    outputPrecomputedSubcommandHelpTextMock.mockReturnValueOnce(true);
+
+    await runCli(["node", "openclaw", "doctor", "--help"]);
+
+    expect(outputPrecomputedSubcommandHelpTextMock).toHaveBeenCalledWith("doctor");
+    expect(tryRouteCliMock).not.toHaveBeenCalled();
+    expect(buildProgramMock).not.toHaveBeenCalled();
+    expect(closeActiveMemorySearchManagersMock).not.toHaveBeenCalled();
   });
 
   it("keeps root help on the precomputed path without proxy bootstrap", async () => {

--- a/src/cli/run-main.test.ts
+++ b/src/cli/run-main.test.ts
@@ -283,6 +283,7 @@ describe("resolvePrecomputedSubcommandHelpFastPath", () => {
         "openclaw",
         "--profile",
         "work",
+        "--no-color",
         "models",
         "-h",
       ]),
@@ -295,6 +296,27 @@ describe("resolvePrecomputedSubcommandHelpFastPath", () => {
     ).toBeNull();
     expect(
       resolvePrecomputedSubcommandHelpFastPath(["node", "openclaw", "gateway", "-V"]),
+    ).toBeNull();
+    expect(
+      resolvePrecomputedSubcommandHelpFastPath([
+        "node",
+        "openclaw",
+        "doctor",
+        "--help",
+        "--version",
+      ]),
+    ).toBeNull();
+    expect(
+      resolvePrecomputedSubcommandHelpFastPath(["node", "openclaw", "doctor", "--version", "-h"]),
+    ).toBeNull();
+    expect(
+      resolvePrecomputedSubcommandHelpFastPath(["node", "openclaw", "--bogus", "doctor", "--help"]),
+    ).toBeNull();
+    expect(
+      resolvePrecomputedSubcommandHelpFastPath(["node", "openclaw", "doctor", "--help", "--bogus"]),
+    ).toBeNull();
+    expect(
+      resolvePrecomputedSubcommandHelpFastPath(["node", "openclaw", "doctor", "--help", "extra"]),
     ).toBeNull();
     expect(
       resolvePrecomputedSubcommandHelpFastPath(["node", "openclaw", "gateway", "status", "--help"]),

--- a/src/cli/run-main.test.ts
+++ b/src/cli/run-main.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { PluginManifestCommandAliasRegistry } from "../plugins/manifest-command-aliases.js";
 import {
+  resolvePrecomputedSubcommandHelpFastPath,
   rewriteUpdateFlagArgv,
   resolveMissingPluginCommandMessage,
   shouldEnsureCliPath,
@@ -211,6 +212,7 @@ describe("shouldUseBrowserHelpFastPath", () => {
     expect(shouldUseBrowserHelpFastPath(["node", "openclaw", "browser", "status", "--help"])).toBe(
       false,
     );
+    expect(shouldUseBrowserHelpFastPath(["node", "openclaw", "browser", "--version"])).toBe(false);
     expect(shouldUseBrowserHelpFastPath(["node", "openclaw", "status", "--help"])).toBe(false);
     expect(shouldUseBrowserHelpFastPath(["node", "openclaw", "browser", "--version"])).toBe(false);
   });
@@ -264,6 +266,47 @@ describe("shouldUseSetupOnboardConfigureHelpFastPath", () => {
     expect(
       shouldUseSetupOnboardConfigureHelpFastPath(["node", "openclaw", "status", "--help"]),
     ).toBe(false);
+  });
+});
+
+describe("resolvePrecomputedSubcommandHelpFastPath", () => {
+  it("uses the fast path only for allowlisted parent command help", () => {
+    expect(resolvePrecomputedSubcommandHelpFastPath(["node", "openclaw", "doctor", "--help"])).toBe(
+      "doctor",
+    );
+    expect(resolvePrecomputedSubcommandHelpFastPath(["node", "openclaw", "gateway", "-h"])).toBe(
+      "gateway",
+    );
+    expect(
+      resolvePrecomputedSubcommandHelpFastPath([
+        "node",
+        "openclaw",
+        "--profile",
+        "work",
+        "models",
+        "-h",
+      ]),
+    ).toBe("models");
+    expect(
+      resolvePrecomputedSubcommandHelpFastPath(["node", "openclaw", "plugins", "--help"]),
+    ).toBe("plugins");
+    expect(
+      resolvePrecomputedSubcommandHelpFastPath(["node", "openclaw", "doctor", "--version"]),
+    ).toBeNull();
+    expect(
+      resolvePrecomputedSubcommandHelpFastPath(["node", "openclaw", "gateway", "-V"]),
+    ).toBeNull();
+    expect(
+      resolvePrecomputedSubcommandHelpFastPath(["node", "openclaw", "gateway", "status", "--help"]),
+    ).toBeNull();
+    expect(
+      resolvePrecomputedSubcommandHelpFastPath(["node", "openclaw", "status", "--help"]),
+    ).toBeNull();
+    expect(
+      resolvePrecomputedSubcommandHelpFastPath(["node", "openclaw", "doctor", "--help"], {
+        OPENCLAW_DISABLE_CLI_STARTUP_HELP_FAST_PATH: "1",
+      }),
+    ).toBeNull();
   });
 });
 

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -27,6 +27,7 @@ import { applyCliProfileEnv, parseCliProfileArgs } from "./profile.js";
 import { getCoreCliCommandNames } from "./program/core-command-descriptors.js";
 import { getSubCliEntries } from "./program/subcli-descriptors.js";
 import {
+  resolvePrecomputedSubcommandHelpFastPath,
   resolveMissingPluginCommandMessage as resolveMissingPluginCommandMessageFromPolicy,
   rewriteUpdateFlagArgv,
   shouldEnsureCliPath,
@@ -42,6 +43,7 @@ import {
 import { normalizeWindowsArgv } from "./windows-argv.js";
 
 export {
+  resolvePrecomputedSubcommandHelpFastPath,
   rewriteUpdateFlagArgv,
   shouldEnsureCliPath,
   shouldStartCrestodianForBareRoot,
@@ -563,6 +565,14 @@ export async function runCli(argv: string[] = process.argv) {
     if (shouldUseSecretsHelpFastPath(normalizedArgv)) {
       const { outputPrecomputedSecretsHelpText } = await import("./root-help-metadata.js");
       if (outputPrecomputedSecretsHelpText()) {
+        return;
+      }
+    }
+
+    const precomputedSubcommandHelp = resolvePrecomputedSubcommandHelpFastPath(normalizedArgv);
+    if (precomputedSubcommandHelp) {
+      const { outputPrecomputedSubcommandHelpText } = await import("./root-help-metadata.js");
+      if (outputPrecomputedSubcommandHelpText(precomputedSubcommandHelp)) {
         return;
       }
     }

--- a/test/scripts/write-cli-startup-metadata.test.ts
+++ b/test/scripts/write-cli-startup-metadata.test.ts
@@ -19,14 +19,27 @@ function writeStartupMetadataSourceSignatureFixture(rootDir: string): void {
     ["extensions/canvas/src/cli-helpers.ts", "export const canvasHelpers = 'canvas';\n"],
     ["extensions/canvas/src/cli.ts", "export const canvasCliHelp = 'canvas';\n"],
     ["src/cli/banner.ts", "export const banner = 'openclaw';\n"],
+    [
+      "src/cli/daemon-cli/register-service-commands.ts",
+      "export const gatewayServiceCommands = 'gateway';\n",
+    ],
+    ["src/cli/gateway-cli.ts", "export const gatewayHelp = 'gateway';\n"],
+    ["src/cli/gateway-cli/register.ts", "export const gatewayRegister = 'gateway';\n"],
+    ["src/cli/gateway-cli/run-command.ts", "export const gatewayRun = 'gateway';\n"],
+    ["src/cli/help-format.ts", "export const helpFormat = 'help';\n"],
+    ["src/cli/models-cli.ts", "export const modelsHelp = 'models';\n"],
     ["src/cli/nodes-cli/register.ts", "export const nodesHelp = 'nodes';\n"],
+    ["src/cli/program/register.maintenance.ts", "export const maintenanceHelp = 'maintenance';\n"],
     ["src/cli/program/context.ts", "export const context = 'context';\n"],
     ["src/cli/program/help.ts", "export const help = 'help';\n"],
+    ["src/cli/plugins-cli.ts", "export const pluginsHelp = 'plugins';\n"],
     [
       "src/plugins/register-plugin-cli-command-groups.ts",
       "export const pluginCommandGroups = 'plugins';\n",
     ],
     ["src/cli/secrets-cli.ts", "export const secretsHelp = 'secrets';\n"],
+    ["src/terminal/links.ts", "export const links = 'links';\n"],
+    ["src/terminal/theme.ts", "export const theme = 'theme';\n"],
   ]);
   for (const [relativePath, contents] of fixtures) {
     writeFixtureFile(rootDir, relativePath, contents);
@@ -69,6 +82,12 @@ describe("write-cli-startup-metadata", () => {
       renderSourceBrowserHelpText: () => "Usage: openclaw browser\n",
       renderSourceSecretsHelpText: () => "Usage: openclaw secrets\n",
       renderSourceNodesHelpText: () => "Usage: openclaw nodes\n",
+      renderSourceSubcommandHelpTextRecord: () => ({
+        doctor: "Usage: openclaw doctor\n",
+        gateway: "Usage: openclaw gateway\n",
+        models: "Usage: openclaw models\n",
+        plugins: "Usage: openclaw plugins\n",
+      }),
     });
 
     const written = JSON.parse(readFileSync(outputPath, "utf8")) as {
@@ -77,6 +96,12 @@ describe("write-cli-startup-metadata", () => {
       nodesHelpText: string;
       rootHelpText: string;
       secretsHelpText: string;
+      subcommandHelpText: {
+        doctor: string;
+        gateway: string;
+        models: string;
+        plugins: string;
+      };
     };
     expect(written.channelOptions).toContain("matrix");
     expect(written.browserHelpText).toContain("Usage:");
@@ -87,6 +112,10 @@ describe("write-cli-startup-metadata", () => {
     expect(written.nodesHelpText).toContain("openclaw nodes");
     expect(written.rootHelpText).toContain("Usage:");
     expect(written.rootHelpText).toContain("openclaw");
+    expect(written.subcommandHelpText.doctor).toContain("openclaw doctor");
+    expect(written.subcommandHelpText.gateway).toContain("openclaw gateway");
+    expect(written.subcommandHelpText.models).toContain("openclaw models");
+    expect(written.subcommandHelpText.plugins).toContain("openclaw plugins");
   });
 
   it("regenerates nodes help when bundled canvas CLI help sources change", async () => {
@@ -112,6 +141,12 @@ describe("write-cli-startup-metadata", () => {
           nodesRenderCount += 1;
           return `Usage: openclaw nodes ${nodesRenderCount}\n`;
         },
+        renderSourceSubcommandHelpTextRecord: () => ({
+          doctor: "Usage: openclaw doctor\n",
+          gateway: "Usage: openclaw gateway\n",
+          models: "Usage: openclaw models\n",
+          plugins: "Usage: openclaw plugins\n",
+        }),
       });
     };
 


### PR DESCRIPTION
## Summary

- Problem: `doctor --help`, `models --help`, `plugins --help`, and `gateway --help` still built the full CLI path and used about 320MB RSS just to print parent help.
- Solution: extend generated startup help metadata for stable parent help pages and route only those parent `-h`/`--help` invocations through a precomputed fast path.
- What changed: startup metadata now stores help text/signatures for `doctor`, `gateway`, `models`, and `plugins`; `run-main` can emit those pages before full CLI registration; tests cover metadata determinism, routing, disable env, and version passthrough.
- What did NOT change (scope boundary): nested command help and plugin/config-sensitive help stay on the live path; `--version` continues to use the live command path.

## Motivation

- Keeps common subcommand help from paying the full CLI import/registration cost while preserving live help for surfaces that may be dynamic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: selected parent subcommand help no longer imports the full CLI just to print help.
- Real environment tested: local macOS worktree, Node v24.14.0, built `openclaw.mjs`.
- Exact steps or command run after this patch: `pnpm test:startup:bench -- --case doctorHelp --case modelsHelp --case pluginsHelp --case gatewayHelp --runs 3 --warmup 1 --json --output .artifacts/perf-subcommand-help-after-rebase.json`.
- Evidence after fix: benchmark results below.
- Observed result after fix: selected help cases are about 82-88ms and 94.6-94.8MB RSS.
- What was not tested: dynamic nested subcommand/plugin-sensitive help is intentionally not precomputed.
- Before evidence: local pre-change measurement reproduced about 344-369ms and 321-322MB RSS for the same cases.

## Root Cause (if applicable)

- Root cause: generated help metadata and the early startup help path covered only root/browser help, so other stable parent help pages imported `run-main` and built enough CLI state to cost hundreds of MB RSS.
- Missing detection / guardrail: no metadata coverage or startup budget cases for these parent subcommand help paths.
- Contributing context (if known): some CLI help is dynamic, so this PR intentionally allowlists only stable parent help pages.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/cli/run-main.test.ts`, `src/cli/run-main.exit.test.ts`, `test/scripts/write-cli-startup-metadata.test.ts`.
- Scenario the test should lock in: selected parent help routes to precomputed metadata, disable env falls back, nested help is not precomputed, and version output does not get misrouted.
- Why this is the smallest reliable guardrail: it locks the routing seam and generated metadata without expanding full CLI registration tests.
- Existing test that already covers this (if any): root/browser fast path tests covered adjacent behavior only.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- `openclaw doctor --help`, `openclaw gateway --help`, `openclaw models --help`, and `openclaw plugins --help` print materially faster with lower RSS.

## Diagram (if applicable)

```text
Before:
[parent help] -> run-main full CLI registration -> commander help

After:
[allowlisted parent help] -> startup metadata -> precomputed help text
[nested/dynamic help] -> run-main full CLI registration -> commander help
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS local worktree
- Runtime/container: Node v24.14.0
- Model/provider: N/A
- Integration/channel (if any): CLI startup path
- Relevant config (redacted): N/A

### Steps

1. Run selected parent help before/after or with `OPENCLAW_DISABLE_CLI_STARTUP_HELP_FAST_PATH=1` to compare live output.
2. Run the startup benchmark for `doctorHelp`, `modelsHelp`, `pluginsHelp`, and `gatewayHelp`.
3. Run changed-scope tests/gates.

### Expected

- Selected parent help output matches live help and stays under startup budget.

### Actual

- Fast/live help output matched for selected commands.
- Fast/live version output matched for selected commands.
- Startup budget check passed.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [x] Perf numbers (if relevant)

After rebase benchmark (`runs=3`, `warmup=1`):

- `doctor --help`: avg 84.1ms, p95 85.0ms, RSS avg 94.6MB
- `models --help`: avg 87.9ms, p95 92.0ms, RSS avg 94.8MB
- `plugins --help`: avg 82.3ms, p95 84.3ms, RSS avg 94.8MB
- `gateway --help`: avg 82.7ms, p95 82.8ms, RSS avg 94.7MB

Verification run:

- `pnpm test src/cli/run-main.test.ts src/cli/run-main.exit.test.ts src/entry.test.ts src/cli/startup-metadata.test.ts test/scripts/write-cli-startup-metadata.test.ts -- --reporter=default`
- `pnpm build`
- Fast/live help and version equivalence loop for `doctor`, `gateway`, `models`, `plugins`
- `pnpm test:startup:bench -- --case doctorHelp --case modelsHelp --case pluginsHelp --case gatewayHelp --runs 3 --warmup 1 --json --output .artifacts/perf-subcommand-help-after-rebase.json`
- `pnpm test:startup:bench:check --report .artifacts/perf-subcommand-help-after-rebase.json --skip-baseline`
- `pnpm check:changed`

## Human Verification (required)

- Verified scenarios: selected parent help fast path, disable-env live fallback, version passthrough, metadata generation determinism, changed-scope gate.
- Edge cases checked: nested `gateway status --help` remains live; `doctor --version` and `gateway -V` do not use precomputed help.
- What you did **not** verify: every dynamic/plugin-sensitive nested help page, because those are intentionally outside this PR.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: generated precomputed help can become stale when command definitions change.
  - Mitigation: metadata signatures include command source files, startup metadata tests cover deterministic output, and only stable parent help pages are allowlisted.
- Risk: version/help routing could overlap.
  - Mitigation: new precomputed subcommand path requires explicit `-h`/`--help`; version equivalence was verified.