### PR TITLE
Fix OpenShell sandbox backend CLI resolution

### DIFF
--- a/extensions/openshell/openclaw.plugin.json
+++ b/extensions/openshell/openclaw.plugin.json
@@ -4,7 +4,7 @@
     "onStartup": true
   },
   "name": "OpenShell Sandbox",
-  "description": "Sandbox backend powered by OpenShell with mirrored local workspaces and SSH-based command execution.",
+  "description": "Sandbox backend powered by the NVIDIA OpenShell CLI with mirrored local workspaces and SSH-based command execution.",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
@@ -67,7 +67,7 @@
     },
     "command": {
       "label": "OpenShell Command",
-      "help": "Path or command name for the openshell CLI."
+      "help": "Path or command name for the NVIDIA OpenShell CLI."
     },
     "gateway": {
       "label": "Gateway Name",

--- a/extensions/openshell/package.json
+++ b/extensions/openshell/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openclaw/openshell-sandbox",
   "version": "2026.5.20",
-  "description": "OpenClaw OpenShell sandbox backend",
+  "description": "OpenClaw sandbox backend for the NVIDIA OpenShell CLI",
   "repository": {
     "type": "git",
     "url": "https://github.com/openclaw/openclaw"

--- a/extensions/openshell/package.json
+++ b/extensions/openshell/package.json
@@ -8,7 +8,6 @@
   },
   "type": "module",
   "dependencies": {
-    "openshell": "0.1.0",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/extensions/openshell/src/backend.test.ts
+++ b/extensions/openshell/src/backend.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { buildOpenShellSshExecEnv } from "./backend.js";
+import { buildOpenShellSandboxName, buildOpenShellSshExecEnv } from "./backend.js";
 
 describe("openshell backend env", () => {
   const originalEnv = { ...process.env };
@@ -25,5 +25,16 @@ describe("openshell backend env", () => {
     expect(env.ANTHROPIC_API_KEY).toBeUndefined();
     expect(env.LANG).toBe("en_US.UTF-8");
     expect(env.NODE_ENV).toBe("test");
+  });
+});
+
+describe("openshell sandbox names", () => {
+  it("generates Kubernetes-safe names from OpenClaw session scope keys", () => {
+    const name = buildOpenShellSandboxName("agent:somalley_alice:dashboard-8");
+
+    expect(name).toMatch(/^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/);
+    expect(name).toContain("somalley-alice");
+    expect(name).not.toContain("_");
+    expect(name.length).toBeLessThanOrEqual(63);
   });
 });

--- a/extensions/openshell/src/backend.ts
+++ b/extensions/openshell/src/backend.ts
@@ -494,10 +494,10 @@ function resolveOpenShellPluginConfigFromConfig(
   return resolveOpenShellPluginConfig(pluginConfig);
 }
 
-function buildOpenShellSandboxName(scopeKey: string): string {
+export function buildOpenShellSandboxName(scopeKey: string): string {
   const trimmed = scopeKey.trim() || "session";
   const safe = normalizeLowercaseStringOrEmpty(trimmed)
-    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/[^a-z0-9-]+/g, "-")
     .replace(/^-+|-+$/g, "")
     .slice(0, 32);
   const hash = Array.from(trimmed).reduce(

--- a/extensions/openshell/src/cli.ts
+++ b/extensions/openshell/src/cli.ts
@@ -1,6 +1,3 @@
-import { createRequire } from "node:module";
-import path from "node:path";
-import { loadJsonFile } from "openclaw/plugin-sdk/json-store";
 import {
   createSshSandboxSessionFromConfigText,
   runPluginCommandWithTimeout,
@@ -11,50 +8,14 @@ import type { ResolvedOpenShellPluginConfig } from "./config.js";
 
 export { buildExecRemoteCommand, shellEscape } from "openclaw/plugin-sdk/sandbox";
 
-const require = createRequire(import.meta.url);
-
-let cachedBundledOpenShellCommand: string | null | undefined;
-let bundledCommandResolverForTest: (() => string | null) | undefined;
-
 export type OpenShellExecContext = {
   config: ResolvedOpenShellPluginConfig;
   sandboxName: string;
   timeoutMs?: number;
 };
 
-export function setBundledOpenShellCommandResolverForTest(resolver?: () => string | null): void {
-  bundledCommandResolverForTest = resolver;
-  cachedBundledOpenShellCommand = undefined;
-}
-
-function resolveBundledOpenShellCommand(): string | null {
-  if (bundledCommandResolverForTest) {
-    return bundledCommandResolverForTest();
-  }
-  if (cachedBundledOpenShellCommand !== undefined) {
-    return cachedBundledOpenShellCommand;
-  }
-  try {
-    const packageJsonPath = require.resolve("openshell/package.json");
-    const packageJson = loadJsonFile<{
-      bin?: string | Record<string, string>;
-    }>(packageJsonPath);
-    const relativeBin =
-      typeof packageJson?.bin === "string" ? packageJson.bin : packageJson?.bin?.openshell;
-    cachedBundledOpenShellCommand = relativeBin
-      ? path.resolve(path.dirname(packageJsonPath), relativeBin)
-      : null;
-  } catch {
-    cachedBundledOpenShellCommand = null;
-  }
-  return cachedBundledOpenShellCommand;
-}
-
 export function resolveOpenShellCommand(command: string): string {
-  if (command !== "openshell") {
-    return command;
-  }
-  return resolveBundledOpenShellCommand() ?? command;
+  return command;
 }
 
 export function buildOpenShellBaseArgv(config: ResolvedOpenShellPluginConfig): string[] {

--- a/extensions/openshell/src/cli.ts
+++ b/extensions/openshell/src/cli.ts
@@ -72,6 +72,25 @@ export function buildRemoteCommand(argv: string[]): string {
   return argv.map((entry) => shellEscape(entry)).join(" ");
 }
 
+export function applyGatewayEndpointToSshConfig(params: {
+  configText: string;
+  gatewayEndpoint?: string;
+}): string {
+  const endpoint = params.gatewayEndpoint?.trim();
+  if (!endpoint) {
+    return params.configText;
+  }
+  return params.configText.replace(/^(\s*ProxyCommand\s+)(.*)$/m, (line, prefix, command) => {
+    if (!command.includes("ssh-proxy")) {
+      return line;
+    }
+    if (/(^|\s)--server(\s|=)|(^|\s)--gateway-endpoint(\s|=)/.test(command)) {
+      return line;
+    }
+    return `${prefix}${command} --server ${shellEscape(endpoint)}`;
+  });
+}
+
 export async function runOpenShellCli(params: {
   context: OpenShellExecContext;
   args: string[];
@@ -97,6 +116,9 @@ export async function createOpenShellSshSession(params: {
     throw new Error(result.stderr.trim() || "openshell sandbox ssh-config failed");
   }
   return await createSshSandboxSessionFromConfigText({
-    configText: result.stdout,
+    configText: applyGatewayEndpointToSshConfig({
+      configText: result.stdout,
+      gatewayEndpoint: params.context.config.gatewayEndpoint,
+    }),
   });
 }

--- a/extensions/openshell/src/openshell-core.test.ts
+++ b/extensions/openshell/src/openshell-core.test.ts
@@ -10,7 +10,6 @@ import {
   buildOpenShellBaseArgv,
   resolveOpenShellCommand,
   runOpenShellCli,
-  setBundledOpenShellCommandResolverForTest,
   shellEscape,
 } from "./cli.js";
 import { resolveOpenShellPluginConfig } from "./config.js";
@@ -25,7 +24,6 @@ describe("openshell cli helpers", () => {
   const originalEnv = { ...process.env };
 
   afterEach(() => {
-    setBundledOpenShellCommandResolverForTest();
     for (const key of Object.keys(process.env)) {
       if (!(key in originalEnv)) {
         delete process.env[key];
@@ -49,18 +47,17 @@ describe("openshell cli helpers", () => {
     ]);
   });
 
-  it("prefers the bundled openshell command when available", () => {
-    setBundledOpenShellCommandResolverForTest(() => "/tmp/node_modules/.bin/openshell");
+  it("uses the configured NVIDIA OpenShell CLI command directly", () => {
     const config = resolveOpenShellPluginConfig(undefined);
 
-    expect(resolveOpenShellCommand("openshell")).toBe("/tmp/node_modules/.bin/openshell");
-    expect(buildOpenShellBaseArgv(config)).toEqual(["/tmp/node_modules/.bin/openshell"]);
+    expect(resolveOpenShellCommand("openshell")).toBe("openshell");
+    expect(buildOpenShellBaseArgv(config)).toEqual(["openshell"]);
   });
 
-  it("falls back to the PATH command when no bundled openshell is present", () => {
-    setBundledOpenShellCommandResolverForTest(() => null);
-
-    expect(resolveOpenShellCommand("openshell")).toBe("openshell");
+  it("preserves an explicit NVIDIA OpenShell CLI path", () => {
+    expect(resolveOpenShellCommand("/opt/openshell/bin/openshell")).toBe(
+      "/opt/openshell/bin/openshell",
+    );
   });
 
   it("shell escapes single quotes", () => {

--- a/extensions/openshell/src/openshell-core.test.ts
+++ b/extensions/openshell/src/openshell-core.test.ts
@@ -5,9 +5,11 @@ import { createSandboxTestContext } from "openclaw/plugin-sdk/test-fixtures";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenShellSandboxBackend } from "./backend.js";
 import {
+  applyGatewayEndpointToSshConfig,
   buildExecRemoteCommand,
   buildOpenShellBaseArgv,
   resolveOpenShellCommand,
+  runOpenShellCli,
   setBundledOpenShellCommandResolverForTest,
   shellEscape,
 } from "./cli.js";
@@ -20,8 +22,16 @@ const cliMocks = vi.hoisted(() => ({
 let createOpenShellSandboxBackendManager: typeof import("./backend.js").createOpenShellSandboxBackendManager;
 
 describe("openshell cli helpers", () => {
+  const originalEnv = { ...process.env };
+
   afterEach(() => {
     setBundledOpenShellCommandResolverForTest();
+    for (const key of Object.keys(process.env)) {
+      if (!(key in originalEnv)) {
+        delete process.env[key];
+      }
+    }
+    Object.assign(process.env, originalEnv);
   });
 
   it("builds base argv with gateway overrides", () => {
@@ -68,6 +78,70 @@ describe("openshell cli helpers", () => {
     expect(command).toContain(`'env'`);
     expect(command).toContain(`'TOKEN=abc 123'`);
     expect(command).toContain(`'cd '"'"'/sandbox/project'"'"' && pwd && printenv TOKEN'`);
+  });
+
+  it("passes direct gateway endpoints to openshell commands without registration", async () => {
+    const calls: string[][] = [];
+    const openshellCommand = await makeExecutable({
+      name: "openshell",
+      script: ["#!/bin/sh", `printf '%s\\n' "$*" >> "__LOG__"`, "exit 0"].join("\n"),
+    });
+
+    await runOpenShellCli({
+      context: {
+        sandboxName: "demo",
+        config: resolveOpenShellPluginConfig({
+          command: openshellCommand,
+          gateway: "alice",
+          gatewayEndpoint: "http://openshell.openshell-alice.svc.cluster.local:8080",
+        }),
+      },
+      args: ["sandbox", "get", "demo"],
+    });
+
+    const log = await fs.readFile(process.env.OPEN_SHELL_CLI_TEST_LOG as string, "utf8");
+    for (const line of log.trim().split("\n")) {
+      calls.push(line.split(" "));
+    }
+    expect(calls[0]).toEqual([
+      "--gateway",
+      "alice",
+      "--gateway-endpoint",
+      "http://openshell.openshell-alice.svc.cluster.local:8080",
+      "sandbox",
+      "get",
+      "demo",
+    ]);
+  });
+
+  it("adds direct gateway endpoints to generated ssh proxy configs", () => {
+    const configText = [
+      "Host openshell-demo",
+      "    User sandbox",
+      "    ProxyCommand /usr/local/bin/openshell ssh-proxy --gateway-name alice --name demo",
+      "",
+    ].join("\n");
+
+    expect(
+      applyGatewayEndpointToSshConfig({
+        configText,
+        gatewayEndpoint: "http://openshell.openshell-alice.svc.cluster.local:8080",
+      }),
+    ).toContain(
+      "ProxyCommand /usr/local/bin/openshell ssh-proxy --gateway-name alice --name demo --server 'http://openshell.openshell-alice.svc.cluster.local:8080'",
+    );
+  });
+
+  it("leaves ssh proxy configs with an explicit endpoint unchanged", () => {
+    const configText =
+      "Host openshell-demo\n    ProxyCommand openshell ssh-proxy --gateway-name alice --name demo --server 'http://existing'\n";
+
+    expect(
+      applyGatewayEndpointToSshConfig({
+        configText,
+        gatewayEndpoint: "http://replacement",
+      }),
+    ).toBe(configText);
   });
 });
 
@@ -198,6 +272,16 @@ async function makeTempDir(prefix: string) {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
   tempDirs.push(dir);
   return dir;
+}
+
+async function makeExecutable(params: { name: string; script: string }): Promise<string> {
+  const dir = await makeTempDir("openclaw-openshell-bin-");
+  const file = path.join(dir, params.name);
+  const logPath = path.join(dir, "openshell.log");
+  await fs.writeFile(file, params.script.replaceAll("__LOG__", logPath), { mode: 0o755 });
+  await fs.chmod(file, 0o755);
+  process.env.OPEN_SHELL_CLI_TEST_LOG = logPath;
+  return file;
 }
 
 async function expectPathMissing(targetPath: string): Promise<void> {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1218,9 +1218,6 @@ importers:
 
   extensions/openshell:
     dependencies:
-      openshell:
-        specifier: 0.1.0
-        version: 0.1.0
       zod:
         specifier: 4.4.3
         version: 4.4.3
@@ -4244,9 +4241,6 @@ packages:
   '@swc/helpers@0.5.21':
     resolution: {integrity: sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==}
 
-  '@telegraf/types@7.1.0':
-    resolution: {integrity: sha512-kGevOIbpMcIlCDeorKGpwZmdH7kHbqlk/Yj6dEpJMKEQw5lk0KVQY0OLXaCswy8GqlIVLd5625OB+rAntP9xVw==}
-
   '@tencent-connect/qqbot-connector@1.1.0':
     resolution: {integrity: sha512-3nQ2mdyzPRKpBHjd3QiKZDwNzw1F7fBN+rSq8Xms2gg+JWZR4SY2Zdf+doqTyXdyVjG4Y0QM7IA4U42zT9xxzw==}
     engines: {node: '>=18.0.0'}
@@ -4851,17 +4845,8 @@ packages:
   bs58@6.0.0:
     resolution: {integrity: sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==}
 
-  buffer-alloc-unsafe@1.1.0:
-    resolution: {integrity: sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==}
-
-  buffer-alloc@1.2.0:
-    resolution: {integrity: sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==}
-
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
-
-  buffer-fill@1.0.0:
-    resolution: {integrity: sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -5146,10 +5131,6 @@ packages:
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
-
-  dotenv@16.6.1:
-    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
-    engines: {node: '>=12'}
 
   dotenv@17.4.2:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
@@ -6270,10 +6251,6 @@ packages:
   mpg123-decoder@1.0.3:
     resolution: {integrity: sha512-+fjxnWigodWJm3+4pndi+KUg9TBojgn31DPk85zEsim7C6s0X5Ztc/hQYdytXkwuGXH+aB0/aEkG40Emukv6oQ==}
 
-  mri@1.2.0:
-    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
-    engines: {node: '>=4'}
-
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
@@ -6420,11 +6397,6 @@ packages:
       zod:
         optional: true
 
-  openshell@0.1.0:
-    resolution: {integrity: sha512-B7jLewH+d73hraWcrSFgNOjvd+frW5JPejkTpqgj2EJBjX/Yk1Y4blgP5pDl4FwrBxfmwsTKR08Uwgrdo+xpSg==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   opus-decoder@0.7.11:
     resolution: {integrity: sha512-+e+Jz3vGQLxRTBHs8YJQPRPc1Tr+/aC6coV/DlZylriA29BdHQAYXhvNRKtjftof17OFng0+P4wsFIqQu3a48A==}
 
@@ -6486,10 +6458,6 @@ packages:
   p-timeout@3.2.0:
     resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
     engines: {node: '>=8'}
-
-  p-timeout@4.1.0:
-    resolution: {integrity: sha512-+/wmHtzJuWii1sXn3HCuH/FTwGhrp4tmJTxSKJbfS+vkipci6osxXM5mY0jUiRzWKMTgUT8l7HFbeSwZAynqHw==}
-    engines: {node: '>=10'}
 
   p-timeout@7.0.1:
     resolution: {integrity: sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==}
@@ -6894,19 +6862,12 @@ packages:
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
-  safe-compare@1.1.4:
-    resolution: {integrity: sha512-b9wZ986HHCo/HbKrRpBJb2kqXMK9CEWIE1egeEvZsYn69ay3kdfl9nG3RyOcR+jInTDf7a86WQ1d4VJX7goSSQ==}
-
   safe-stable-stringify@2.5.0:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
     engines: {node: '>=10'}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
-
-  sandwich-stream@2.0.2:
-    resolution: {integrity: sha512-jLYV0DORrzY3xaz/S9ydJL6Iz7essZeAfnAavsJ+zsJGZ1MOnsS52yRjU3uF3pJa/lla7+wisp//fxOwOH8SKQ==}
-    engines: {node: '>= 0.10'}
 
   sax@1.6.0:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
@@ -7144,11 +7105,6 @@ packages:
 
   teex@1.0.1:
     resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
-
-  telegraf@4.16.3:
-    resolution: {integrity: sha512-yjEu2NwkHlXu0OARWoNhJlIjX09dRktiMQFsM678BAH/PEPVwctzL67+tvXqLCRQQvm3SDtki2saGO9hLlz68w==}
-    engines: {node: ^12.20.0 || >=14.13.1}
-    hasBin: true
 
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
@@ -10268,8 +10224,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@telegraf/types@7.1.0': {}
-
   '@tencent-connect/qqbot-connector@1.1.0':
     dependencies:
       qrcode-terminal: 0.12.0
@@ -10915,16 +10869,7 @@ snapshots:
     dependencies:
       base-x: 5.0.1
 
-  buffer-alloc-unsafe@1.1.0: {}
-
-  buffer-alloc@1.2.0:
-    dependencies:
-      buffer-alloc-unsafe: 1.1.0
-      buffer-fill: 1.0.0
-
   buffer-equal-constant-time@1.0.1: {}
-
-  buffer-fill@1.0.0: {}
 
   buffer-from@1.1.2: {}
 
@@ -11175,8 +11120,6 @@ snapshots:
       dom-serializer: 2.0.0
       domelementtype: 2.3.0
       domhandler: 5.0.3
-
-  dotenv@16.6.1: {}
 
   dotenv@17.4.2: {}
 
@@ -12647,8 +12590,6 @@ snapshots:
     dependencies:
       '@wasm-audio-decoders/common': 9.0.7
 
-  mri@1.2.0: {}
-
   mrmime@2.0.1: {}
 
   ms@2.1.3: {}
@@ -12785,14 +12726,6 @@ snapshots:
       ws: 8.20.1
       zod: 4.4.3
 
-  openshell@0.1.0:
-    dependencies:
-      dotenv: 16.6.1
-      telegraf: 4.16.3
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-
   opus-decoder@0.7.11:
     dependencies:
       '@wasm-audio-decoders/common': 9.0.7
@@ -12887,8 +12820,6 @@ snapshots:
   p-timeout@3.2.0:
     dependencies:
       p-finally: 1.0.0
-
-  p-timeout@4.1.0: {}
 
   p-timeout@7.0.1: {}
 
@@ -13364,15 +13295,9 @@ snapshots:
 
   safe-buffer@5.2.1: {}
 
-  safe-compare@1.1.4:
-    dependencies:
-      buffer-alloc: 1.2.0
-
   safe-stable-stringify@2.5.0: {}
 
   safer-buffer@2.1.2: {}
-
-  sandwich-stream@2.0.2: {}
 
   sax@1.6.0: {}
 
@@ -13668,20 +13593,6 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
-
-  telegraf@4.16.3:
-    dependencies:
-      '@telegraf/types': 7.1.0
-      abort-controller: 3.0.0
-      debug: 4.4.3
-      mri: 1.2.0
-      node-fetch: 2.7.0
-      p-timeout: 4.1.0
-      safe-compare: 1.1.4
-      sandwich-stream: 2.0.2
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
 
   text-decoder@1.2.7:
     dependencies:

--- a/src/agents/sandbox/backend.ts
+++ b/src/agents/sandbox/backend.ts
@@ -22,7 +22,15 @@ export type {
   SandboxBackendHandle,
 } from "./backend-handle.types.js";
 
-const SANDBOX_BACKEND_FACTORIES = new Map<SandboxBackendId, RegisteredSandboxBackend>();
+const SANDBOX_BACKEND_FACTORIES_STATE_KEY = Symbol.for("openclaw.sandboxBackendFactories");
+
+function getSandboxBackendFactories(): Map<SandboxBackendId, RegisteredSandboxBackend> {
+  const globalStore = globalThis as typeof globalThis & {
+    [SANDBOX_BACKEND_FACTORIES_STATE_KEY]?: Map<SandboxBackendId, RegisteredSandboxBackend>;
+  };
+  globalStore[SANDBOX_BACKEND_FACTORIES_STATE_KEY] ??= new Map();
+  return globalStore[SANDBOX_BACKEND_FACTORIES_STATE_KEY];
+}
 
 function normalizeSandboxBackendId(id: string): SandboxBackendId {
   const normalized = normalizeOptionalLowercaseString(id);
@@ -38,23 +46,25 @@ export function registerSandboxBackend(
 ): () => void {
   const normalizedId = normalizeSandboxBackendId(id);
   const resolved = typeof registration === "function" ? { factory: registration } : registration;
-  const previous = SANDBOX_BACKEND_FACTORIES.get(normalizedId);
-  SANDBOX_BACKEND_FACTORIES.set(normalizedId, resolved);
+  const factories = getSandboxBackendFactories();
+  const previous = factories.get(normalizedId);
+  factories.set(normalizedId, resolved);
   return () => {
+    const currentFactories = getSandboxBackendFactories();
     if (previous) {
-      SANDBOX_BACKEND_FACTORIES.set(normalizedId, previous);
+      currentFactories.set(normalizedId, previous);
       return;
     }
-    SANDBOX_BACKEND_FACTORIES.delete(normalizedId);
+    currentFactories.delete(normalizedId);
   };
 }
 
 export function getSandboxBackendFactory(id: string): SandboxBackendFactory | null {
-  return SANDBOX_BACKEND_FACTORIES.get(normalizeSandboxBackendId(id))?.factory ?? null;
+  return getSandboxBackendFactories().get(normalizeSandboxBackendId(id))?.factory ?? null;
 }
 
 export function getSandboxBackendManager(id: string): SandboxBackendManager | null {
-  return SANDBOX_BACKEND_FACTORIES.get(normalizeSandboxBackendId(id))?.manager ?? null;
+  return getSandboxBackendFactories().get(normalizeSandboxBackendId(id))?.manager ?? null;
 }
 
 export function requireSandboxBackendFactory(id: string): SandboxBackendFactory {


### PR DESCRIPTION
## Summary

Fixes #56813.

This removes the accidental dependency on the unrelated npm `openshell` package and makes the OpenShell sandbox backend treat `openshell` as the real NVIDIA OpenShell CLI executable contract.

It also tightens the OpenShell path by:
- resolving the default `openshell` command directly from PATH instead of probing a Node package
- preserving explicit configured OpenShell binary paths
- passing configured gateway endpoints through OpenShell CLI and SSH proxy flows
- making OpenShell sandbox names Kubernetes-safe
- keeping sandbox backend registrations stable across duplicated module loads
- adding targeted regression coverage for the OpenShell backend and CLI helpers

## Real Behavior Proof

Behavior addressed: OpenClaw's OpenShell sandbox backend no longer resolves the unrelated npm `openshell@0.1.0` Telegram bridge package. The plugin now depends on the NVIDIA OpenShell CLI being available as `openshell` on PATH or configured with an explicit binary path.

Real environment tested: Local OpenClaw checkout on branch `fix-pr-84788-nvidia-openshell`; focused OpenShell backend tests run through the repo Vitest wrapper; PR branch updated at `a16fc79138f`.

Exact steps or command run after this patch:
`node scripts/run-vitest.mjs extensions/openshell/src/openshell-core.test.ts extensions/openshell/src/backend.test.ts`
`git diff --check`
`AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

Evidence after fix: The targeted OpenShell backend/CLI regression tests passed: 2 files, 20 tests. The dependency tree no longer contains `openshell@0.1.0`, `telegraf@4.16.3`, or `@telegraf/types`. Autoreview reported no accepted/actionable findings.

Observed result after fix: Default OpenShell command resolution remains `openshell`, explicit binary paths are preserved, and no Node package named `openshell` is resolved or executed.

What was not tested: Remote `pnpm check:changed` did not execute because both remote proof paths failed during sync before running the command: Blacksmith Testbox `tbx_01ks5dvqe54nb3ddq0pds6nyvk` and `tbx_01ks5e2j83w65zzcxgjsvv8b48` hit rsync EOF during delegated sync, and AWS Crabbox `cbx_47633ce2c9b6` hit rsync hangup during sync. GitHub CI is the remaining broad gate for this pushed head.

OpenClaw + standalone OpenShell screenshot proof

<img width="1487" height="897" alt="Screenshot 2026-05-20 at 11 58 17 PM" src="https://github.com/user-attachments/assets/f769788b-4cbc-49c8-8e54-b8b5e37efda6" />
