### PR TITLE
Fix Telegram TTS voice-note routing

### DIFF
--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -72,6 +72,11 @@ type TelegramThreadScopedParams = {
 const InputFileCtor = grammy.InputFile;
 const MAX_TELEGRAM_PHOTO_DIMENSION_SUM = 10_000;
 const MAX_TELEGRAM_PHOTO_ASPECT_RATIO = 20;
+const TELEGRAM_TTS_VOICE_OUTPUT_FILENAME_RE = /^voice-[^-]+---/;
+
+function isTelegramTtsVoiceOutputFileName(fileName: string): boolean {
+  return TELEGRAM_TTS_VOICE_OUTPUT_FILENAME_RE.test(fileName);
+}
 
 type TelegramSendOpts = {
   cfg: OpenClawConfig;
@@ -89,6 +94,8 @@ type TelegramSendOpts = {
   plainText?: string;
   /** Send audio as voice message instead of audio file. Defaults to false. */
   asVoice?: boolean;
+  /** Compatibility alias used by generic OpenClaw reply payload delivery. */
+  audioAsVoice?: boolean;
   /** Send video as video note instead of regular video. Defaults to false. */
   asVideoNote?: boolean;
   /** Send message silently (no notification). Defaults to false. */
@@ -905,7 +912,10 @@ export async function sendMessageTelegram(
       }
       if (kind === "audio") {
         const { useVoice } = resolveTelegramVoiceSend({
-          wantsVoice: opts.asVoice === true, // default false (backward compatible)
+          wantsVoice:
+            opts.asVoice === true ||
+            opts.audioAsVoice === true ||
+            isTelegramTtsVoiceOutputFileName(fileName),
           contentType: media.contentType,
           fileName,
           logFallback: logVerbose,

--- a/extensions/telegram/src/voice.test.ts
+++ b/extensions/telegram/src/voice.test.ts
@@ -79,4 +79,17 @@ describe("resolveTelegramVoiceSend", () => {
     expect(result.useVoice).toBe(true);
     expect(logFallback).not.toHaveBeenCalled();
   });
+
+
+  it("keeps voice for generated TTS MP3 output", () => {
+    const logFallback = vi.fn();
+    const result = resolveTelegramVoiceSend({
+      wantsVoice: true,
+      contentType: "audio/mpeg",
+      fileName: "voice-1779334096572---a1d3761f-337e-4d9c-97bd-3edc67690a9a.mp3",
+      logFallback,
+    });
+    expect(result.useVoice).toBe(true);
+    expect(logFallback).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- preserve generic `audioAsVoice` payload intent through Telegram sends
- treat generated TTS voice output filenames as Telegram voice-note intent when routing audio
- add regression coverage for generated TTS MP3 voice compatibility

## Verification
- locally verified OpenClaw Telegram delivery now logs `operation=sendVoice deliveryKind=voice` for Bernard tts-tool replies
- `openclaw config validate` passes after restart

## Context
Bernard/OpenClaw TTS tool replies can produce payloads with `audioAsVoice: true`, but the Telegram send layer only checked `asVoice`, so the request could degrade to `sendAudio`. This keeps explicit voice reply behavior working across generic reply delivery paths.