### PR TITLE
Run memory flush before preflight compaction

### DIFF
--- a/packages/ai/src/providers/anthropic.test.ts
+++ b/packages/ai/src/providers/anthropic.test.ts
@@ -761,7 +761,7 @@ describe("Anthropic provider", () => {
               {
                 type: "resource" as const,
                 resource: { uri: "https://example.com/data.json", text: '{"key":"value"}' },
-              } as unknown as { type: "text"; text: string },
+              },
               { type: "text", text: "after image" },
             ],
             isError: false,

--- a/packages/ai/src/providers/anthropic.test.ts
+++ b/packages/ai/src/providers/anthropic.test.ts
@@ -761,7 +761,7 @@ describe("Anthropic provider", () => {
               {
                 type: "resource" as const,
                 resource: { uri: "https://example.com/data.json", text: '{"key":"value"}' },
-              },
+              } as unknown as { type: "text"; text: string },
               { type: "text", text: "after image" },
             ],
             isError: false,

--- a/src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts
+++ b/src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts
@@ -491,6 +491,29 @@ describe("runReplyAgent runtime config", () => {
     expect(runAgentTurnWithFallbackMock).toHaveBeenCalledOnce();
   });
 
+  it("surfaces unrelated preflight failures after an exhausted memory flush", async () => {
+    const { replyParams } = createDirectRuntimeReplyParams({
+      shouldFollowup: false,
+      isActive: false,
+    });
+    runMemoryFlushIfNeededMock.mockResolvedValue({
+      sessionEntry: { sessionId: "session-1", updatedAt: 1, compactionCount: 4 },
+      outcome: "exhausted",
+    });
+    runPreflightCompactionIfNeededMock.mockRejectedValue(
+      new Error("Preflight compaction required but failed: auth profile mismatch"),
+    );
+
+    const result = await runReplyAgent(replyParams);
+
+    if (!result || Array.isArray(result)) {
+      throw new Error("expected a single preflight compaction failure reply payload");
+    }
+    expect(result.text).toContain("auto-compaction could not recover");
+    expect(resetReplyRunSessionMock).not.toHaveBeenCalled();
+    expect(runAgentTurnWithFallbackMock).not.toHaveBeenCalled();
+  });
+
   it("does not start the main turn after cancellation during memory flush", async () => {
     const { replyParams } = createDirectRuntimeReplyParams({
       shouldFollowup: false,

--- a/src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts
+++ b/src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts
@@ -271,6 +271,13 @@ describe("runReplyAgent runtime config", () => {
       requesterSenderE164: undefined,
     });
     expect(runPreflightCompactionIfNeededMock).toHaveBeenCalledTimes(1);
+    expect(runMemoryFlushIfNeededMock).toHaveBeenCalledTimes(1);
+    expect(runMemoryFlushIfNeededMock.mock.invocationCallOrder[0]).toBeLessThan(
+      runPreflightCompactionIfNeededMock.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
+    const memoryCall = requireMaintenanceCall(runMemoryFlushIfNeededMock, "runMemoryFlushIfNeeded");
+    expect(memoryCall.cfg).toBe(freshCfg);
+    expect(memoryCall.followupRun).toBe(followupRun);
     const preflightCall = requireMaintenanceCall(
       runPreflightCompactionIfNeededMock,
       "runPreflightCompactionIfNeeded",
@@ -289,8 +296,6 @@ describe("runReplyAgent runtime config", () => {
     followupRun.run.runtimePolicySessionKey = runtimePolicySessionKey;
     replyParams.sessionKey = "agent:main:main";
     replyParams.runtimePolicySessionKey = runtimePolicySessionKey;
-    runPreflightCompactionIfNeededMock.mockResolvedValue(undefined);
-    runMemoryFlushIfNeededMock.mockRejectedValue(sentinelError);
 
     await expect(runReplyAgent(replyParams)).rejects.toBe(sentinelError);
 

--- a/src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts
+++ b/src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts
@@ -438,6 +438,59 @@ describe("runReplyAgent runtime config", () => {
     expect(runAgentTurnWithFallbackMock).toHaveBeenCalledOnce();
   });
 
+  it("keeps the compacted session when preflight recovers an exhausted memory flush", async () => {
+    const { replyParams } = createDirectRuntimeReplyParams({
+      shouldFollowup: false,
+      isActive: false,
+    });
+    const sessionEntry = {
+      sessionId: "session-1",
+      updatedAt: 1,
+      compactionCount: 4,
+    };
+    replyParams.sessionEntry = sessionEntry;
+    runMemoryFlushIfNeededMock.mockResolvedValue({
+      sessionEntry,
+      outcome: "exhausted",
+    });
+    runPreflightCompactionIfNeededMock.mockImplementation(
+      async (params: { sessionEntry?: typeof sessionEntry }) => {
+        expect(params.sessionEntry?.sessionId).toBe("session-1");
+        return { ...params.sessionEntry, compactionCount: 5 };
+      },
+    );
+
+    await expect(runReplyAgent(replyParams)).resolves.toEqual({ text: "main reply" });
+
+    expect(resetReplyRunSessionMock).not.toHaveBeenCalled();
+    expect(runAgentTurnWithFallbackMock).toHaveBeenCalledOnce();
+  });
+
+  it("rotates when preflight cannot recover an exhausted memory flush", async () => {
+    const { replyParams } = createDirectRuntimeReplyParams({
+      shouldFollowup: false,
+      isActive: false,
+    });
+    runMemoryFlushIfNeededMock.mockResolvedValue({
+      sessionEntry: { sessionId: "session-1", updatedAt: 1, compactionCount: 4 },
+      outcome: "exhausted",
+    });
+    runPreflightCompactionIfNeededMock.mockRejectedValue(
+      new Error("Preflight compaction required but failed: context_overflow"),
+    );
+
+    await expect(runReplyAgent(replyParams)).resolves.toEqual({ text: "main reply" });
+
+    expect(resetReplyRunSessionMock).toHaveBeenCalledOnce();
+    expect(resetReplyRunSessionMock.mock.calls[0]?.[0]).toMatchObject({
+      options: {
+        failureLabel: "memory flush exhaustion",
+        cleanupTranscripts: false,
+      },
+    });
+    expect(runAgentTurnWithFallbackMock).toHaveBeenCalledOnce();
+  });
+
   it("does not start the main turn after cancellation during memory flush", async () => {
     const { replyParams } = createDirectRuntimeReplyParams({
       shouldFollowup: false,

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -1062,7 +1062,7 @@ type MemoryFlushResult = {
   outcome: MemoryFlushOutcome;
 };
 
-/** Runs post-turn memory flush when transcript state warrants it. */
+/** Runs pre-compaction memory flush when transcript state warrants it. */
 export async function runMemoryFlushIfNeeded(params: {
   cfg: OpenClawConfig;
   followupRun: FollowupRun;

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -10,6 +10,7 @@ import {
 } from "../../agents/agent-scope.js";
 import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
+import { isLikelyContextOverflowError } from "../../agents/embedded-agent-helpers/errors.js";
 import {
   hasCommittedSourceReplyDeliveryEvidence,
   hasVisibleCommittedMessagingToolDeliveryEvidence,
@@ -1661,7 +1662,11 @@ export async function runReplyAgent(params: {
       preflightCompactionApplied =
         (activeSessionEntry?.compactionCount ?? 0) > prePreflightCompactionCount;
     } catch (err) {
-      if (memoryFlushResult.outcome !== "exhausted" || replyOperation.abortSignal.aborted) {
+      const canRotateAfterPreflightFailure =
+        memoryFlushResult.outcome === "exhausted" &&
+        !replyOperation.abortSignal.aborted &&
+        isLikelyContextOverflowError(String(err));
+      if (!canRotateAfterPreflightFailure) {
         throw err;
       }
       logVerbose(`Preflight compaction could not recover exhausted memory flush: ${String(err)}`);

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1639,39 +1639,46 @@ export async function runReplyAgent(params: {
       throw replyOperation.abortSignal.reason ?? new Error("reply operation aborted");
     }
 
-    if (memoryFlushResult.outcome === "exhausted") {
+    const prePreflightCompactionCount = activeSessionEntry?.compactionCount ?? 0;
+    try {
+      activeSessionEntry = await traceAgentPhase("reply.preflight_compaction", () =>
+        runPreflightCompactionIfNeeded({
+          cfg,
+          followupRun,
+          promptForEstimate: followupRun.prompt,
+          defaultModel,
+          agentCfgContextTokens,
+          sessionEntry: activeSessionEntry,
+          sessionStore: activeSessionStore,
+          sessionKey,
+          runtimePolicySessionKey,
+          storePath,
+          isHeartbeat,
+          replyOperation,
+          onCompactionNotice: sendDirectCompactionNotice,
+        }),
+      );
+      preflightCompactionApplied =
+        (activeSessionEntry?.compactionCount ?? 0) > prePreflightCompactionCount;
+    } catch (err) {
+      if (memoryFlushResult.outcome !== "exhausted" || replyOperation.abortSignal.aborted) {
+        throw err;
+      }
+      logVerbose(`Preflight compaction could not recover exhausted memory flush: ${String(err)}`);
+    }
+
+    if (memoryFlushResult.outcome === "exhausted" && !preflightCompactionApplied) {
       await resetSession({
         failureLabel: "memory flush exhaustion",
         buildLogMessage: (nextSessionId) =>
           `Memory flush exhausted. Rotating bloated session ${sessionKey} -> ${nextSessionId}.`,
-        // Rotate away from the bloated context, but preserve its transcript for recovery.
+        // Rotate only when compaction could not recover the bloated context.
         cleanupTranscripts: false,
       });
       if (activeSessionEntry?.sessionId) {
         replyOperation.updateSessionId(activeSessionEntry.sessionId);
       }
     }
-
-    const prePreflightCompactionCount = activeSessionEntry?.compactionCount ?? 0;
-    activeSessionEntry = await traceAgentPhase("reply.preflight_compaction", () =>
-      runPreflightCompactionIfNeeded({
-        cfg,
-        followupRun,
-        promptForEstimate: followupRun.prompt,
-        defaultModel,
-        agentCfgContextTokens,
-        sessionEntry: activeSessionEntry,
-        sessionStore: activeSessionStore,
-        sessionKey,
-        runtimePolicySessionKey,
-        storePath,
-        isHeartbeat,
-        replyOperation,
-        onCompactionNotice: sendDirectCompactionNotice,
-      }),
-    );
-    preflightCompactionApplied =
-      (activeSessionEntry?.compactionCount ?? 0) > prePreflightCompactionCount;
 
     // Exhausted background maintenance is non-terminal: optionally notify, then reply normally.
     if (memoryFlushResult.outcome === "exhausted") {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1602,31 +1602,10 @@ export async function runReplyAgent(params: {
         `Role ordering conflict (${reason}). Restarting session ${sessionKey} -> ${nextSessionId}.`,
       cleanupTranscripts: true,
     });
-  const prePreflightCompactionCount = activeSessionEntry?.compactionCount ?? 0;
   let preflightCompactionApplied;
 
   try {
     await typingSignals.signalRunStart();
-
-    activeSessionEntry = await traceAgentPhase("reply.preflight_compaction", () =>
-      runPreflightCompactionIfNeeded({
-        cfg,
-        followupRun,
-        promptForEstimate: followupRun.prompt,
-        defaultModel,
-        agentCfgContextTokens,
-        sessionEntry: activeSessionEntry,
-        sessionStore: activeSessionStore,
-        sessionKey,
-        runtimePolicySessionKey,
-        storePath,
-        isHeartbeat,
-        replyOperation,
-        onCompactionNotice: sendDirectCompactionNotice,
-      }),
-    );
-    preflightCompactionApplied =
-      (activeSessionEntry?.compactionCount ?? 0) > prePreflightCompactionCount;
 
     const memoryFlushResult = await traceAgentPhase("reply.memory_flush", () =>
       runMemoryFlushIfNeeded({
@@ -1670,6 +1649,27 @@ export async function runReplyAgent(params: {
         replyOperation.updateSessionId(activeSessionEntry.sessionId);
       }
     }
+
+    const prePreflightCompactionCount = activeSessionEntry?.compactionCount ?? 0;
+    activeSessionEntry = await traceAgentPhase("reply.preflight_compaction", () =>
+      runPreflightCompactionIfNeeded({
+        cfg,
+        followupRun,
+        promptForEstimate: followupRun.prompt,
+        defaultModel,
+        agentCfgContextTokens,
+        sessionEntry: activeSessionEntry,
+        sessionStore: activeSessionStore,
+        sessionKey,
+        runtimePolicySessionKey,
+        storePath,
+        isHeartbeat,
+        replyOperation,
+        onCompactionNotice: sendDirectCompactionNotice,
+      }),
+    );
+    preflightCompactionApplied =
+      (activeSessionEntry?.compactionCount ?? 0) > prePreflightCompactionCount;
 
     // Exhausted background maintenance is non-terminal: optionally notify, then reply normally.
     if (memoryFlushResult.outcome === "exhausted") {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1607,6 +1607,8 @@ export async function runReplyAgent(params: {
   try {
     await typingSignals.signalRunStart();
 
+    // Preserve the one-flush-per-compaction-cycle gate: an earlier same-cycle
+    // flush is the checkpoint for this upcoming compaction, not a reason to rerun maintenance.
     const memoryFlushResult = await traceAgentPhase("reply.memory_flush", () =>
       runMemoryFlushIfNeeded({
         cfg,


### PR DESCRIPTION
Fixes #84695.

## Summary

- Run automatic memory flush before preflight compaction in `runReplyAgent`.
- Keep visible memory-flush errors on the same pre-run return path before the main reply.
- Add committed e2e coverage proving memory flush starts before preflight compaction.

## What Problem This Solves

`runReplyAgent` must run the memory-flush phase before preflight compaction so durable memory has a chance to run before aggressive transcript reduction. Before this PR, preflight compaction could run first and reduce transcript context before the automatic memory flush path had a chance to preserve it.

## Evidence

### Real Gateway Proof

- Runtime tested: isolated foreground Gateway, not a Vitest harness.
- Worktree: `/private/tmp/openclaw-pr84792-proof-rebase-20260630`.
- Config/home: `/private/tmp/openclaw-pr84792-live-gateway/home/.openclaw/openclaw.json` with loopback-only gateway auth disabled, channels skipped, and a dummy local OpenAI-compatible provider at `127.0.0.1:9`.
- Base/head: `origin/main` `b63e06f68aa`, PR head `26caf5e60ec2`.
- Gateway command:

```sh
OPENCLAW_HOME=/private/tmp/openclaw-pr84792-live-gateway/home \
OPENCLAW_CONFIG_PATH=/private/tmp/openclaw-pr84792-live-gateway/home/.openclaw/openclaw.json \
OPENCLAW_SKIP_CHANNELS=1 \
OPENCLAW_DIAGNOSTICS=timeline \
OPENCLAW_DIAGNOSTICS_TIMELINE_PATH=/private/tmp/openclaw-pr84792-live-gateway/timeline.jsonl \
OPENCLAW_DIAGNOSTICS_RUN_ID=pr84792-live-gateway \
node scripts/run-node.mjs gateway run --allow-unconfigured --auth none --bind loopback --port 48792 --verbose
```

- Live Gateway call:

```sh
OPENCLAW_HOME=/private/tmp/openclaw-pr84792-live-gateway/home \
OPENCLAW_CONFIG_PATH=/private/tmp/openclaw-pr84792-live-gateway/home/.openclaw/openclaw.json \
node scripts/run-node.mjs gateway call chat.send \
  --url ws://127.0.0.1:48792 \
  --token proof-token \
  --json \
  --timeout 60000 \
  --params '{"sessionKey":"main","message":"PR 84792 live gateway proof: respond with NO_REPLY after diagnostics","idempotencyKey":"pr84792-live-gateway-proof"}'
```

- ACK:

```json
{
  "runId": "pr84792-live-gateway-proof",
  "status": "started"
}
```

- Redacted Gateway diagnostics timeline from `/private/tmp/openclaw-pr84792-live-gateway/timeline.jsonl`:

```json
{"type":"span.start","timestamp":"2026-07-01T07:04:45.661Z","name":"gateway.chat_send.dispatch_inbound","phase":"agent-turn","attributes":{"runId":"pr84792-live-gateway-proof","sessionKey":"agent:main:main","provider":"proof-local","model":"proof-model"}}
{"type":"span.start","timestamp":"2026-07-01T07:04:46.038Z","name":"reply.memory_flush","phase":"agent-turn","attributes":{"provider":"proof-local","hasSessionKey":true,"isHeartbeat":false,"queueMode":"steer"}}
{"type":"span.end","timestamp":"2026-07-01T07:04:46.038Z","name":"reply.memory_flush","phase":"agent-turn","durationMs":0.374}
{"type":"span.start","timestamp":"2026-07-01T07:04:46.038Z","name":"reply.preflight_compaction","phase":"agent-turn","attributes":{"provider":"proof-local","hasSessionKey":true,"isHeartbeat":false,"queueMode":"steer"}}
{"type":"span.end","timestamp":"2026-07-01T07:04:46.041Z","name":"reply.preflight_compaction","phase":"agent-turn","durationMs":2.642}
{"type":"span.start","timestamp":"2026-07-01T07:04:46.043Z","name":"reply.run_agent_turn","phase":"agent-turn"}
```

- Runtime log after the ordering proof reached the model transport:

```text
[agent/embedded] embedded run start: runId=pr84792-live-gateway-proof sessionId=<redacted> provider=proof-local model=proof-model thinking=off messageChannel=webchat
[provider-transport-fetch] [model-fetch] start provider=proof-local api=openai-completions model=proof-model method=POST url=http://127.0.0.1:9/v1/chat/completions
[provider-transport-fetch] [model-fetch] error provider=proof-local api=openai-completions model=proof-model message=fetch failed
```

Observed result after fix: the real Gateway `chat.send` path starts `reply.memory_flush` before `reply.preflight_compaction`, then enters `reply.run_agent_turn` and reaches the provider transport. The provider failure is expected because the isolated proof config intentionally points at an unreachable local endpoint after the pre-run ordering has been proven.

## Verification

```text
node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts src/llm/providers/mistral.test.ts src/llm/providers/anthropic.test.ts src/gateway/server-cron.test.ts src/gateway/server-cron-notifications.test.ts
# passed: 3 Vitest shards, 171 tests

pnpm check:test-types
# passed

pnpm lint
# passed

node node_modules/.bin/oxfmt --check --threads=1 src/gateway/server-cron-notifications.test.ts src/gateway/server-cron.test.ts src/llm/providers/anthropic.test.ts src/llm/providers/mistral.test.ts src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts src/auto-reply/reply/agent-runner.ts src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts
All matched files use the correct format.

git diff --check
# clean
```

