### PR TITLE
feat: support git and local skill installs

### DIFF
--- a/docs/cli/skills.md
+++ b/docs/cli/skills.md
@@ -2,14 +2,15 @@
 summary: "CLI reference for `openclaw skills` (search/install/update/list/info/check)"
 read_when:
   - You want to see which skills are available and ready to run
-  - You want to search, install, or update skills from ClawHub
+  - You want to search ClawHub or install skills from ClawHub, Git, or local directories
   - You want to debug missing binaries/env/config for skills
 title: "Skills"
 ---
 
 # `openclaw skills`
 
-Inspect local skills and install/update skills from ClawHub.
+Inspect local skills, search ClawHub, install skills from ClawHub/Git/local directories, and update
+ClawHub-tracked installs.
 
 Related:
 
@@ -24,6 +25,9 @@ openclaw skills search "calendar"
 openclaw skills search --limit 20 --json
 openclaw skills install <slug>
 openclaw skills install <slug> --version <version>
+openclaw skills install git:owner/repo
+openclaw skills install git:owner/repo@main
+openclaw skills install ./path/to/skill --as custom-name
 openclaw skills install <slug> --force
 openclaw skills install <slug> --agent <id>
 openclaw skills install <slug> --global
@@ -45,23 +49,36 @@ openclaw skills check --agent <id>
 openclaw skills check --json
 ```
 
-`search`/`install`/`update` use ClawHub directly. By default, `install` and
-`update` target the active workspace `skills/` directory; with `--global`, they
-target the shared managed skills directory. `list`/`info`/`check` still inspect
-the local skills visible to the current workspace and config. Workspace-backed
-commands resolve the target workspace from `--agent <id>`, then the current
-working directory when it is inside a configured agent workspace, then the
-default agent.
+`search` and `update` use ClawHub directly. `install <slug>` installs a ClawHub
+skill, `install git:owner/repo[@ref]` clones a Git skill, and `install ./path`
+copies a local skill directory. By default, `install` and `update` target the
+active workspace `skills/` directory; with `--global`, they target the shared
+managed skills directory. `list`/`info`/`check` still inspect the local skills
+visible to the current workspace and config. Workspace-backed commands resolve
+the target workspace from `--agent <id>`, then the current working directory
+when it is inside a configured agent workspace, then the default agent.
 
-This CLI `install` command downloads skill folders from ClawHub. Gateway-backed
-skill dependency installs triggered from onboarding or Skills settings use the
-separate `skills.install` request path instead.
+Git and local directory installs expect `SKILL.md` at the source root. The
+install slug comes from `SKILL.md` frontmatter `name` when it is valid, then the
+source directory or repository name; use `--as <slug>` to override it. `--version`
+is ClawHub-only. Skill installs do not support npm package specs or zip/archive
+paths, and `openclaw skills update` updates ClawHub-tracked installs only.
+
+Gateway-backed skill dependency installs triggered from onboarding or Skills
+settings use the separate `skills.install` request path instead.
 
 Notes:
 
 - `search [query...]` accepts an optional query; omit it to browse the default
   ClawHub search feed.
 - `search --limit <n>` caps returned results.
+- `install git:owner/repo[@ref]` installs a Git skill. Branch refs may contain
+  slashes, such as `git:owner/repo@feature/foo`.
+- `install ./path/to/skill` installs a local directory whose root contains
+  `SKILL.md`.
+- `install --as <slug>` overrides the inferred slug for Git and local directory
+  installs.
+- `install --version <version>` applies only to ClawHub skill slugs.
 - `install --force` overwrites an existing workspace skill folder for the same
   slug.
 - `--global` targets the shared managed skills directory and cannot be combined

--- a/docs/tools/skills.md
+++ b/docs/tools/skills.md
@@ -130,14 +130,16 @@ Use native `openclaw skills` commands for discover/install/update, or the
 separate `clawhub` CLI for publish/sync workflows. Full guide:
 [ClawHub](/clawhub).
 
-| Action                                 | Command                                         |
-| -------------------------------------- | ----------------------------------------------- |
-| Install a skill into the workspace     | `openclaw skills install <skill-slug>`          |
-| Install a skill for all local agents   | `openclaw skills install <skill-slug> --global` |
-| Update all workspace-installed skills  | `openclaw skills update --all`                  |
-| Update a single shared managed skill   | `openclaw skills update <skill-slug> --global`  |
-| Update all shared managed/local skills | `openclaw skills update --all --global`         |
-| Sync (scan + publish updates)          | `clawhub sync --all`                            |
+| Action                                 | Command                                                |
+| -------------------------------------- | ------------------------------------------------------ |
+| Install a ClawHub skill into workspace | `openclaw skills install <skill-slug>`                 |
+| Install a Git skill into workspace     | `openclaw skills install git:owner/repo@ref`           |
+| Install a local skill into workspace   | `openclaw skills install ./path/to/skill --as my-tool` |
+| Install a skill for all local agents   | `openclaw skills install <skill-slug> --global`        |
+| Update all workspace-installed skills  | `openclaw skills update --all`                         |
+| Update a single shared managed skill   | `openclaw skills update <skill-slug> --global`         |
+| Update all shared managed/local skills | `openclaw skills update --all --global`                |
+| Sync (scan + publish updates)          | `clawhub sync --all`                                   |
 
 Native `openclaw skills install` installs into the active workspace
 `skills/` directory by default. Add `--global` to install into the shared
@@ -149,6 +151,14 @@ that up as `<workspace>/skills` on the next session.
 Configured skill roots also support one grouping level, such as
 `skills/<group>/<skill>/SKILL.md`, so related third-party skills can be
 kept under a shared folder without broad recursive scanning.
+
+Git and local directory installs expect a `SKILL.md` at the source root. The
+install slug comes from `SKILL.md` frontmatter `name` when it is a valid slug,
+then falls back to the source directory or repository name. Use `--as <slug>` to
+override the inferred slug. `--version` applies only to ClawHub installs. Skill
+installs do not support npm package specs or zip/archive paths. `openclaw skills
+update` updates ClawHub-tracked installs only; reinstall Git or local sources to
+refresh them.
 
 Gateway clients that need private, non-ClawHub delivery can stage a zip skill
 archive with `skills.upload.begin`, `skills.upload.chunk`, and
@@ -183,7 +193,11 @@ Prefer sandboxed runs for untrusted inputs and risky tools. See
   `skills.install.allowUploadedArchives`; normal ClawHub installs do not require
   that setting.
 - Gateway-backed skill dependency installs (`skills.install`, onboarding, and the Skills settings UI) run the built-in dangerous-code scanner before executing installer metadata. `critical` findings block by default unless the caller explicitly sets the dangerous override; suspicious findings still warn only.
-- `openclaw skills install <slug>` is different — it downloads a ClawHub skill folder into the workspace, or into shared managed/local skills with `--global`, and does not use the installer-metadata path above.
+- `openclaw skills install <slug>` is different — it downloads a ClawHub skill
+  folder into the workspace, or into shared managed/local skills with
+  `--global`, and does not use the installer-metadata path above. Git and local
+  directory installs copy a trusted `SKILL.md` directory into the same skills
+  root, but are not tracked by `openclaw skills update`.
 - `skills.entries.*.env` and `skills.entries.*.apiKey` inject secrets into the **host** process for that agent turn (not the sandbox). Keep secrets out of prompts and logs.
 
 For a broader threat model and checklists, see [Security](/gateway/security).

--- a/src/agents/skills-clawhub.ts
+++ b/src/agents/skills-clawhub.ts
@@ -401,3 +401,13 @@ export async function readTrackedClawHubSkillSlugs(workspaceDir: string): Promis
   const lock = await readClawHubSkillsLockfile(workspaceDir);
   return Object.keys(lock.skills).toSorted();
 }
+
+export async function untrackClawHubSkill(workspaceDir: string, slug: string): Promise<void> {
+  const trackedSlug = normalizeTrackedSkillSlug(slug);
+  const lock = await readClawHubSkillsLockfile(workspaceDir);
+  if (!lock.skills[trackedSlug]) {
+    return;
+  }
+  delete lock.skills[trackedSlug];
+  await writeClawHubSkillsLockfile(workspaceDir, lock);
+}

--- a/src/agents/skills-source-install.test.ts
+++ b/src/agents/skills-source-install.test.ts
@@ -1,0 +1,321 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { runCommandWithTimeout } from "../process/exec.js";
+import { withTempDir } from "../test-helpers/temp-dir.js";
+import { installSkillFromSource } from "./skills-source-install.js";
+
+async function writeSkill(dir: string, params: { name?: string; description?: string } = {}) {
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(
+    path.join(dir, "SKILL.md"),
+    [
+      "---",
+      `name: ${params.name ?? path.basename(dir)}`,
+      `description: ${params.description ?? "A local skill"}`,
+      "---",
+      "",
+      "# Skill",
+      "",
+    ].join("\n"),
+  );
+}
+
+async function initGitSkillRepo(repoDir: string, name = "git-skill") {
+  await writeSkill(repoDir, { name });
+  await runCommandWithTimeout(["git", "init"], { cwd: repoDir, timeoutMs: 30_000 });
+  await runCommandWithTimeout(["git", "add", "SKILL.md"], { cwd: repoDir, timeoutMs: 30_000 });
+  const commit = await runCommandWithTimeout(
+    [
+      "git",
+      "-c",
+      "user.email=test@example.com",
+      "-c",
+      "user.name=Test User",
+      "commit",
+      "-m",
+      "add skill",
+    ],
+    { cwd: repoDir, timeoutMs: 30_000 },
+  );
+  if (commit.code !== 0) {
+    throw new Error(commit.stderr || commit.stdout || "git commit failed");
+  }
+}
+
+async function runGitOk(repoDir: string, args: string[]) {
+  const result = await runCommandWithTimeout(["git", ...args], {
+    cwd: repoDir,
+    timeoutMs: 30_000,
+  });
+  if (result.code !== 0) {
+    throw new Error(result.stderr || result.stdout || `git ${args.join(" ")} failed`);
+  }
+  return result.stdout.trim();
+}
+
+describe("installSkillFromSource", () => {
+  it("installs a local skill directory using the SKILL.md frontmatter name", async () => {
+    await withTempDir({ prefix: "openclaw-skill-source-local-" }, async (root) => {
+      const workspaceDir = path.join(root, "workspace");
+      const sourceDir = path.join(root, "source");
+      await writeSkill(sourceDir, { name: "frontmatter-skill" });
+
+      const result = await installSkillFromSource({
+        workspaceDir,
+        spec: sourceDir,
+      });
+
+      expect(result).toMatchObject({
+        ok: true,
+        slug: "frontmatter-skill",
+        source: "path",
+        targetDir: path.join(workspaceDir, "skills", "frontmatter-skill"),
+      });
+      await expect(
+        fs.readFile(path.join(workspaceDir, "skills", "frontmatter-skill", "SKILL.md"), "utf8"),
+      ).resolves.toContain("frontmatter-skill");
+    });
+  });
+
+  it("uses --as slug override for local skill directories", async () => {
+    await withTempDir({ prefix: "openclaw-skill-source-as-" }, async (root) => {
+      const workspaceDir = path.join(root, "workspace");
+      const sourceDir = path.join(root, "source");
+      await writeSkill(sourceDir, { name: "frontmatter-skill" });
+
+      const result = await installSkillFromSource({
+        workspaceDir,
+        spec: sourceDir,
+        slug: "custom-name",
+      });
+
+      expect(result).toMatchObject({
+        ok: true,
+        slug: "custom-name",
+        source: "path",
+        targetDir: path.join(workspaceDir, "skills", "custom-name"),
+      });
+    });
+  });
+
+  it("installs git: file repositories and records the resolved commit", async () => {
+    await withTempDir({ prefix: "openclaw-skill-source-git-" }, async (root) => {
+      const workspaceDir = path.join(root, "workspace");
+      const repoDir = path.join(root, "repo");
+      await fs.mkdir(repoDir, { recursive: true });
+      await initGitSkillRepo(repoDir);
+
+      const result = await installSkillFromSource({
+        workspaceDir,
+        spec: `git:file://${repoDir}`,
+      });
+
+      expect(result).toMatchObject({
+        ok: true,
+        slug: "git-skill",
+        source: "git",
+        targetDir: path.join(workspaceDir, "skills", "git-skill"),
+      });
+      if (!result.ok) {
+        throw new Error(result.error);
+      }
+      expect(result.git?.commit).toMatch(/^[0-9a-f]{40}$/);
+      await expect(
+        fs.readFile(path.join(workspaceDir, "skills", "git-skill", "SKILL.md"), "utf8"),
+      ).resolves.toContain("git-skill");
+      await expect(
+        fs.access(path.join(workspaceDir, "skills", "git-skill", ".git")),
+      ).rejects.toThrow();
+    });
+  });
+
+  it("isolates git commands from inherited Git hook environment", async () => {
+    await withTempDir({ prefix: "openclaw-skill-source-git-env-" }, async (root) => {
+      const workspaceDir = path.join(root, "workspace");
+      const repoDir = path.join(root, "repo");
+      const poisonRepoDir = path.join(root, "poison");
+      await fs.mkdir(repoDir, { recursive: true });
+      await fs.mkdir(poisonRepoDir, { recursive: true });
+      await initGitSkillRepo(repoDir);
+      await initGitSkillRepo(poisonRepoDir);
+      await fs.writeFile(path.join(poisonRepoDir, "extra.txt"), "poison\n");
+      await runGitOk(poisonRepoDir, ["add", "extra.txt"]);
+      await runGitOk(poisonRepoDir, [
+        "-c",
+        "user.email=test@example.com",
+        "-c",
+        "user.name=Test User",
+        "commit",
+        "-m",
+        "poison commit",
+      ]);
+      const expectedCommit = await runGitOk(repoDir, ["rev-parse", "HEAD"]);
+      const oldGitDir = process.env.GIT_DIR;
+      try {
+        process.env.GIT_DIR = path.join(poisonRepoDir, ".git");
+        const result = await installSkillFromSource({
+          workspaceDir,
+          spec: `git:file://${repoDir}`,
+        });
+
+        expect(result).toMatchObject({
+          ok: true,
+          source: "git",
+        });
+        if (!result.ok) {
+          throw new Error(result.error);
+        }
+        expect(result.git?.commit).toBe(expectedCommit);
+      } finally {
+        if (oldGitDir === undefined) {
+          delete process.env.GIT_DIR;
+        } else {
+          process.env.GIT_DIR = oldGitDir;
+        }
+      }
+    });
+  });
+
+  it("disables system git config while preserving sanitized git command env", async () => {
+    await withTempDir({ prefix: "openclaw-skill-source-git-system-config-" }, async (root) => {
+      const workspaceDir = path.join(root, "workspace");
+      const repoDir = path.join(root, "repo");
+      const poisonRepoDir = path.join(root, "poison");
+      await fs.mkdir(repoDir, { recursive: true });
+      await fs.mkdir(poisonRepoDir, { recursive: true });
+      await initGitSkillRepo(repoDir, "good-skill");
+      await initGitSkillRepo(poisonRepoDir, "poison-skill");
+      const systemConfig = path.join(root, "system.gitconfig");
+      await fs.writeFile(
+        systemConfig,
+        `[url "file://${poisonRepoDir}/"]\n\tinsteadOf = file://${repoDir}\n`,
+      );
+      const oldSystemConfig = process.env.GIT_CONFIG_SYSTEM;
+      try {
+        process.env.GIT_CONFIG_SYSTEM = systemConfig;
+        const result = await installSkillFromSource({
+          workspaceDir,
+          spec: `git:file://${repoDir}`,
+        });
+
+        expect(result).toMatchObject({
+          ok: true,
+          slug: "good-skill",
+          source: "git",
+        });
+      } finally {
+        if (oldSystemConfig === undefined) {
+          delete process.env.GIT_CONFIG_SYSTEM;
+        } else {
+          process.env.GIT_CONFIG_SYSTEM = oldSystemConfig;
+        }
+      }
+    });
+  });
+
+  it("installs slash-containing git branch refs from fresh clones", async () => {
+    await withTempDir({ prefix: "openclaw-skill-source-git-ref-" }, async (root) => {
+      const workspaceDir = path.join(root, "workspace");
+      const repoDir = path.join(root, "repo");
+      await fs.mkdir(repoDir, { recursive: true });
+      await initGitSkillRepo(repoDir);
+      await runGitOk(repoDir, ["branch", "-M", "main"]);
+      await runGitOk(repoDir, ["checkout", "-b", "feature/skill"]);
+      await writeSkill(repoDir, { name: "feature-skill", description: "Feature branch skill" });
+      await runGitOk(repoDir, ["add", "SKILL.md"]);
+      await runGitOk(repoDir, [
+        "-c",
+        "user.email=test@example.com",
+        "-c",
+        "user.name=Test User",
+        "commit",
+        "-m",
+        "update skill on branch",
+      ]);
+      await runGitOk(repoDir, ["checkout", "main"]);
+
+      const result = await installSkillFromSource({
+        workspaceDir,
+        spec: `git:file://${repoDir}@feature/skill`,
+      });
+
+      expect(result).toMatchObject({
+        ok: true,
+        slug: "feature-skill",
+        source: "git",
+        targetDir: path.join(workspaceDir, "skills", "feature-skill"),
+      });
+      await expect(
+        fs.readFile(path.join(workspaceDir, "skills", "feature-skill", "SKILL.md"), "utf8"),
+      ).resolves.toContain("Feature branch skill");
+    });
+  });
+
+  it("removes stale ClawHub lock tracking after source installs", async () => {
+    await withTempDir({ prefix: "openclaw-skill-source-untrack-" }, async (root) => {
+      const workspaceDir = path.join(root, "workspace");
+      const sourceDir = path.join(root, "source");
+      await writeSkill(sourceDir, { name: "frontmatter-skill" });
+      await fs.mkdir(path.join(workspaceDir, ".clawhub"), { recursive: true });
+      await fs.mkdir(path.join(sourceDir, ".clawhub"), { recursive: true });
+      await fs.writeFile(
+        path.join(sourceDir, ".clawhub", "origin.json"),
+        JSON.stringify({
+          version: 1,
+          registry: "https://clawhub.example",
+          slug: "frontmatter-skill",
+          installedVersion: "1.0.0",
+          installedAt: 1,
+        }),
+      );
+      await fs.writeFile(
+        path.join(workspaceDir, ".clawhub", "lock.json"),
+        JSON.stringify(
+          {
+            version: 1,
+            skills: {
+              "frontmatter-skill": {
+                version: "1.0.0",
+                installedAt: 1,
+              },
+            },
+          },
+          null,
+          2,
+        ),
+      );
+
+      const result = await installSkillFromSource({
+        workspaceDir,
+        spec: sourceDir,
+      });
+
+      expect(result).toMatchObject({
+        ok: true,
+        slug: "frontmatter-skill",
+      });
+      const lock = JSON.parse(
+        await fs.readFile(path.join(workspaceDir, ".clawhub", "lock.json"), "utf8"),
+      ) as { skills: Record<string, unknown> };
+      expect(lock.skills["frontmatter-skill"]).toBeUndefined();
+      await expect(
+        fs.access(path.join(workspaceDir, "skills", "frontmatter-skill", ".clawhub")),
+      ).rejects.toThrow();
+    });
+  });
+
+  it("rejects missing local skill roots before treating them as ClawHub slugs", async () => {
+    await withTempDir({ prefix: "openclaw-skill-source-missing-" }, async (root) => {
+      const result = await installSkillFromSource({
+        workspaceDir: path.join(root, "workspace"),
+        spec: "./missing-skill",
+      });
+
+      expect(result).toMatchObject({
+        ok: false,
+        error: expect.stringContaining("Skill path not found"),
+      });
+    });
+  });
+});

--- a/src/agents/skills-source-install.ts
+++ b/src/agents/skills-source-install.ts
@@ -1,0 +1,392 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { sanitizeHostExecEnv } from "../infra/host-env-security.js";
+import { withTempDir } from "../infra/install-source-utils.js";
+import { writeJson } from "../infra/json-files.js";
+import { parseGitPluginSpec } from "../plugins/git-install.js";
+import { runCommandWithTimeout } from "../process/exec.js";
+import { redactSensitiveUrlLikeString } from "../shared/net/redact-sensitive-url.js";
+import { normalizeOptionalString } from "../shared/string-coerce.js";
+import { sanitizeForLog } from "../terminal/ansi.js";
+import { resolveUserPath } from "../utils.js";
+import { installExtractedSkillRoot, validateRequestedSkillSlug } from "./skills-archive-install.js";
+import { untrackClawHubSkill } from "./skills-clawhub.js";
+import { parseFrontmatter } from "./skills/frontmatter.js";
+
+type Logger = {
+  info?: (message: string) => void;
+  warn?: (message: string) => void;
+};
+
+type SkillSourceOrigin = {
+  version: 1;
+  source: "path" | "git";
+  spec: string;
+  slug: string;
+  installedAt: number;
+  git?: {
+    url: string;
+    ref?: string;
+    commit?: string;
+    resolvedAt: string;
+  };
+};
+
+export type SkillSourceInstallResult =
+  | {
+      ok: true;
+      slug: string;
+      targetDir: string;
+      source: "path" | "git";
+      git?: SkillSourceOrigin["git"];
+    }
+  | { ok: false; error: string };
+
+const SKILL_SOURCE_ORIGIN_RELATIVE_PATH = path.join(".openclaw", "source-origin.json");
+const DEFAULT_GIT_TIMEOUT_MS = 120_000;
+
+function createGitCommandEnv(): NodeJS.ProcessEnv {
+  return sanitizeHostExecEnv({
+    baseEnv: {
+      ...process.env,
+      GIT_CONFIG_NOSYSTEM: "1",
+      GIT_TERMINAL_PROMPT: "0",
+    },
+    blockPathOverrides: false,
+  });
+}
+
+function formatGitCommandFailure(params: {
+  action: string;
+  label: string;
+  stdout: string;
+  stderr: string;
+}): string {
+  const detail = sanitizeForLog(
+    redactSensitiveUrlLikeString(params.stderr.trim() || params.stdout.trim() || "git failed"),
+  );
+  return `failed to ${params.action} ${sanitizeForLog(redactSensitiveUrlLikeString(params.label))}: ${detail}`;
+}
+
+async function runGitCommand(params: {
+  argv: string[];
+  action: string;
+  label: string;
+  cwd?: string;
+  timeoutMs?: number;
+}): Promise<{ ok: true; stdout: string } | { ok: false; error: string }> {
+  const result = await runCommandWithTimeout(params.argv, {
+    baseEnv: {},
+    cwd: params.cwd,
+    timeoutMs: params.timeoutMs ?? DEFAULT_GIT_TIMEOUT_MS,
+    env: createGitCommandEnv(),
+  });
+  if (result.code !== 0) {
+    return {
+      ok: false,
+      error: formatGitCommandFailure({
+        action: params.action,
+        label: params.label,
+        stdout: result.stdout,
+        stderr: result.stderr,
+      }),
+    };
+  }
+  return { ok: true, stdout: result.stdout };
+}
+
+async function resolveGitCommitish(params: {
+  repoDir: string;
+  ref: string;
+  label: string;
+  timeoutMs?: number;
+}): Promise<{ ok: true; commitish: string } | { ok: false; error: string }> {
+  const candidates = params.ref.startsWith("origin/")
+    ? [params.ref]
+    : [params.ref, `origin/${params.ref}`];
+  for (const candidate of candidates) {
+    const resolved = await runCommandWithTimeout(
+      ["git", "rev-parse", "--verify", "--quiet", `${candidate}^{commit}`],
+      {
+        baseEnv: {},
+        cwd: params.repoDir,
+        timeoutMs: params.timeoutMs ?? DEFAULT_GIT_TIMEOUT_MS,
+        env: createGitCommandEnv(),
+      },
+    );
+    const commit = normalizeOptionalString(resolved.stdout);
+    if (resolved.code === 0 && commit) {
+      return { ok: true, commitish: commit };
+    }
+  }
+
+  return {
+    ok: false,
+    error: `failed to resolve ref ${sanitizeForLog(redactSensitiveUrlLikeString(params.ref))} in ${sanitizeForLog(redactSensitiveUrlLikeString(params.label))}`,
+  };
+}
+
+async function readSkillNameFromFrontmatter(skillDir: string): Promise<string | null> {
+  try {
+    const raw = await fs.readFile(path.join(skillDir, "SKILL.md"), "utf8");
+    const frontmatter = parseFrontmatter(raw);
+    return normalizeOptionalString(frontmatter.name) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function resolveFallbackSlugFromPath(sourcePath: string): string {
+  return path.basename(path.resolve(sourcePath)).trim();
+}
+
+async function resolveSkillInstallSlug(params: {
+  sourceDir: string;
+  fallbackLabel: string;
+  slug?: string;
+}): Promise<string> {
+  const explicit = normalizeOptionalString(params.slug);
+  if (explicit) {
+    return validateRequestedSkillSlug(explicit);
+  }
+
+  const frontmatterName = await readSkillNameFromFrontmatter(params.sourceDir);
+  if (frontmatterName) {
+    try {
+      return validateRequestedSkillSlug(frontmatterName);
+    } catch {
+      // Fall back to the source label when the display name is not a valid install slug.
+    }
+  }
+
+  return validateRequestedSkillSlug(params.fallbackLabel);
+}
+
+async function writeSkillSourceOrigin(targetDir: string, origin: SkillSourceOrigin): Promise<void> {
+  await writeJson(path.join(targetDir, SKILL_SOURCE_ORIGIN_RELATIVE_PATH), origin, {
+    trailingNewline: true,
+  });
+}
+
+async function removeClawHubInstallMetadata(targetDir: string): Promise<void> {
+  await Promise.all([
+    fs.rm(path.join(targetDir, ".clawhub"), { recursive: true, force: true }),
+    fs.rm(path.join(targetDir, ".clawdhub"), { recursive: true, force: true }),
+  ]);
+}
+
+async function copyGitWorktreeExport(params: {
+  repoDir: string;
+  exportDir: string;
+}): Promise<{ ok: true } | { ok: false; error: string }> {
+  try {
+    await fs.cp(params.repoDir, params.exportDir, {
+      recursive: true,
+      filter: (source) => !path.relative(params.repoDir, source).split(path.sep).includes(".git"),
+    });
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: `failed to prepare git skill source: ${String(err)}` };
+  }
+}
+
+async function installLocalSkillDir(params: {
+  workspaceDir: string;
+  sourceDir: string;
+  sourceSpec: string;
+  source: "path" | "git";
+  fallbackLabel: string;
+  slug?: string;
+  force?: boolean;
+  timeoutMs?: number;
+  logger?: Logger;
+  git?: SkillSourceOrigin["git"];
+}): Promise<SkillSourceInstallResult> {
+  const slug = await resolveSkillInstallSlug({
+    sourceDir: params.sourceDir,
+    fallbackLabel: params.fallbackLabel,
+    slug: params.slug,
+  });
+  const install = await installExtractedSkillRoot({
+    workspaceDir: params.workspaceDir,
+    slug,
+    extractedRoot: params.sourceDir,
+    mode: params.force ? "update" : "install",
+    timeoutMs: params.timeoutMs,
+    logger: params.logger,
+    scan: {
+      installId: params.source,
+      origin: params.sourceSpec,
+    },
+  });
+  if (!install.ok) {
+    return { ok: false, error: install.error };
+  }
+
+  await removeClawHubInstallMetadata(install.targetDir);
+  await writeSkillSourceOrigin(install.targetDir, {
+    version: 1,
+    source: params.source,
+    spec: params.sourceSpec,
+    slug,
+    installedAt: Date.now(),
+    ...(params.git ? { git: params.git } : {}),
+  });
+  await untrackClawHubSkill(params.workspaceDir, slug);
+
+  return {
+    ok: true,
+    slug,
+    targetDir: install.targetDir,
+    source: params.source,
+    ...(params.git ? { git: params.git } : {}),
+  };
+}
+
+async function installGitSkill(params: {
+  workspaceDir: string;
+  spec: string;
+  slug?: string;
+  force?: boolean;
+  timeoutMs?: number;
+  logger?: Logger;
+}): Promise<SkillSourceInstallResult> {
+  const parsed = parseGitPluginSpec(params.spec);
+  if (!parsed) {
+    return { ok: false, error: `Unsupported git skill spec: ${params.spec}` };
+  }
+
+  return await withTempDir("openclaw-git-skill-", async (tmpDir) => {
+    const repoDir = path.join(tmpDir, "repo");
+    const exportDir = path.join(tmpDir, "export");
+    params.logger?.info?.(
+      `Cloning ${sanitizeForLog(redactSensitiveUrlLikeString(parsed.label))}...`,
+    );
+    const cloneArgs = parsed.ref
+      ? ["git", "clone", parsed.url, repoDir]
+      : ["git", "clone", "--depth", "1", parsed.url, repoDir];
+    const clone = await runGitCommand({
+      argv: cloneArgs,
+      action: "clone",
+      label: parsed.label,
+      timeoutMs: params.timeoutMs,
+    });
+    if (!clone.ok) {
+      return clone;
+    }
+
+    if (parsed.ref) {
+      const commitish = await resolveGitCommitish({
+        repoDir,
+        ref: parsed.ref,
+        label: parsed.label,
+        timeoutMs: params.timeoutMs,
+      });
+      if (!commitish.ok) {
+        return commitish;
+      }
+      const checkout = await runGitCommand({
+        argv: ["git", "switch", "--detach", "--", commitish.commitish],
+        action: `checkout ${parsed.ref}`,
+        label: parsed.label,
+        cwd: repoDir,
+        timeoutMs: params.timeoutMs,
+      });
+      if (!checkout.ok) {
+        return checkout;
+      }
+    }
+
+    const rev = await runGitCommand({
+      argv: ["git", "rev-parse", "HEAD"],
+      action: "resolve commit for",
+      label: parsed.label,
+      cwd: repoDir,
+      timeoutMs: params.timeoutMs,
+    });
+    if (!rev.ok) {
+      return rev;
+    }
+
+    const git = {
+      url: redactSensitiveUrlLikeString(parsed.url),
+      ...(parsed.ref ? { ref: parsed.ref } : {}),
+      commit: normalizeOptionalString(rev.stdout),
+      resolvedAt: new Date().toISOString(),
+    };
+    const exported = await copyGitWorktreeExport({ repoDir, exportDir });
+    if (!exported.ok) {
+      return exported;
+    }
+
+    return await installLocalSkillDir({
+      workspaceDir: params.workspaceDir,
+      sourceDir: exportDir,
+      sourceSpec: redactSensitiveUrlLikeString(parsed.normalizedSpec),
+      source: "git",
+      fallbackLabel: path.basename(parsed.label),
+      slug: params.slug,
+      force: params.force,
+      timeoutMs: params.timeoutMs,
+      logger: params.logger,
+      git,
+    });
+  });
+}
+
+async function installPathSkill(params: {
+  workspaceDir: string;
+  spec: string;
+  slug?: string;
+  force?: boolean;
+  timeoutMs?: number;
+  logger?: Logger;
+}): Promise<SkillSourceInstallResult> {
+  const sourceDir = resolveUserPath(params.spec);
+  let stat;
+  try {
+    stat = await fs.stat(sourceDir);
+  } catch {
+    return { ok: false, error: `Skill path not found: ${sourceDir}` };
+  }
+  if (!stat.isDirectory()) {
+    return { ok: false, error: `Skill path is not a directory: ${sourceDir}` };
+  }
+  return await installLocalSkillDir({
+    workspaceDir: params.workspaceDir,
+    sourceDir,
+    sourceSpec: params.spec,
+    source: "path",
+    fallbackLabel: resolveFallbackSlugFromPath(sourceDir),
+    slug: params.slug,
+    force: params.force,
+    timeoutMs: params.timeoutMs,
+    logger: params.logger,
+  });
+}
+
+export function isSkillSourceInstallSpec(raw: string): boolean {
+  const trimmed = raw.trim();
+  return (
+    trimmed.toLowerCase().startsWith("git:") ||
+    trimmed.startsWith("./") ||
+    trimmed.startsWith("../") ||
+    trimmed.startsWith("~/") ||
+    path.isAbsolute(trimmed)
+  );
+}
+
+export async function installSkillFromSource(params: {
+  workspaceDir: string;
+  spec: string;
+  slug?: string;
+  force?: boolean;
+  timeoutMs?: number;
+  logger?: Logger;
+}): Promise<SkillSourceInstallResult> {
+  const spec = params.spec.trim();
+  if (spec.toLowerCase().startsWith("git:")) {
+    return await installGitSkill({ ...params, spec });
+  }
+  return await installPathSkill({ ...params, spec });
+}

--- a/src/cli/skills-cli.commands.test.ts
+++ b/src/cli/skills-cli.commands.test.ts
@@ -81,6 +81,7 @@ const mocks = vi.hoisted(() => {
     ),
     searchSkillsFromClawHubMock: vi.fn(),
     installSkillFromClawHubMock: vi.fn(),
+    installSkillFromSourceMock: vi.fn(),
     updateSkillsFromClawHubMock: vi.fn(),
     readTrackedClawHubSkillSlugsMock: vi.fn(),
     buildWorkspaceSkillStatusMock,
@@ -99,6 +100,7 @@ const {
   resolveAgentWorkspaceDirMock,
   searchSkillsFromClawHubMock,
   installSkillFromClawHubMock,
+  installSkillFromSourceMock,
   updateSkillsFromClawHubMock,
   readTrackedClawHubSkillSlugsMock,
   buildWorkspaceSkillStatusMock,
@@ -178,6 +180,16 @@ vi.mock("../agents/skills-clawhub.js", () => ({
     mocks.readTrackedClawHubSkillSlugsMock(...args),
 }));
 
+vi.mock("../agents/skills-source-install.js", () => ({
+  installSkillFromSource: (...args: unknown[]) => mocks.installSkillFromSourceMock(...args),
+  isSkillSourceInstallSpec: (raw: string) =>
+    raw.startsWith("git:") ||
+    raw.startsWith("./") ||
+    raw.startsWith("../") ||
+    raw.startsWith("~/") ||
+    raw.startsWith("/"),
+}));
+
 vi.mock("../agents/skills-status.js", () => ({
   buildWorkspaceSkillStatus: (workspaceDir: string, options?: unknown) =>
     mocks.buildWorkspaceSkillStatusMock(workspaceDir, options),
@@ -212,6 +224,7 @@ describe("skills cli commands", () => {
     resolveAgentWorkspaceDirMock.mockReset();
     searchSkillsFromClawHubMock.mockReset();
     installSkillFromClawHubMock.mockReset();
+    installSkillFromSourceMock.mockReset();
     updateSkillsFromClawHubMock.mockReset();
     readTrackedClawHubSkillSlugsMock.mockReset();
     buildWorkspaceSkillStatusMock.mockReset();
@@ -224,6 +237,10 @@ describe("skills cli commands", () => {
     installSkillFromClawHubMock.mockResolvedValue({
       ok: false,
       error: "install disabled in test",
+    });
+    installSkillFromSourceMock.mockResolvedValue({
+      ok: false,
+      error: "source install disabled in test",
     });
     updateSkillsFromClawHubMock.mockResolvedValue([]);
     readTrackedClawHubSkillSlugsMock.mockResolvedValue([]);
@@ -295,6 +312,98 @@ describe("skills cli commands", () => {
         line.includes("Installed calendar@1.2.3 -> /tmp/workspace/skills/calendar"),
       ),
     ).toBe(true);
+  });
+
+  it("installs a skill from a git source into the active workspace", async () => {
+    installSkillFromSourceMock.mockResolvedValue({
+      ok: true,
+      slug: "tools",
+      targetDir: "/tmp/workspace/skills/tools",
+      source: "git",
+    });
+
+    await runCommand(["skills", "install", "git:owner/tools"]);
+
+    const installArgs = mockFirstObjectArg(installSkillFromSourceMock);
+    expectObjectFields(installArgs, {
+      workspaceDir: "/tmp/workspace",
+      spec: "git:owner/tools",
+      force: false,
+    });
+    expect(installArgs.slug).toBeUndefined();
+    expectLogger(installArgs.logger);
+    expect(installSkillFromClawHubMock).not.toHaveBeenCalled();
+    expect(
+      runtimeLogs.some((line) =>
+        line.includes("Installed tools from git -> /tmp/workspace/skills/tools"),
+      ),
+    ).toBe(true);
+  });
+
+  it("accepts git refs for skill source installs", async () => {
+    installSkillFromSourceMock.mockResolvedValue({
+      ok: true,
+      slug: "tools",
+      targetDir: "/tmp/workspace/skills/tools",
+      source: "git",
+    });
+
+    await runCommand(["skills", "install", "git:owner/tools@main"]);
+
+    expect(mockFirstObjectArg(installSkillFromSourceMock).spec).toBe("git:owner/tools@main");
+    expect(installSkillFromClawHubMock).not.toHaveBeenCalled();
+  });
+
+  it("installs a skill from a local directory", async () => {
+    installSkillFromSourceMock.mockResolvedValue({
+      ok: true,
+      slug: "local-skill",
+      targetDir: "/tmp/workspace/skills/local-skill",
+      source: "path",
+    });
+
+    await runCommand(["skills", "install", "./local-skill"]);
+
+    const installArgs = mockFirstObjectArg(installSkillFromSourceMock);
+    expectObjectFields(installArgs, {
+      workspaceDir: "/tmp/workspace",
+      spec: "./local-skill",
+      force: false,
+    });
+    expect(installArgs.slug).toBeUndefined();
+    expectLogger(installArgs.logger);
+    expect(installSkillFromClawHubMock).not.toHaveBeenCalled();
+    expect(
+      runtimeLogs.some((line) =>
+        line.includes("Installed local-skill from path -> /tmp/workspace/skills/local-skill"),
+      ),
+    ).toBe(true);
+  });
+
+  it("passes --as as the source install slug override", async () => {
+    installSkillFromSourceMock.mockResolvedValue({
+      ok: true,
+      slug: "custom-name",
+      targetDir: "/tmp/workspace/skills/custom-name",
+      source: "path",
+    });
+
+    await runCommand(["skills", "install", "./local-skill", "--as", "custom-name"]);
+
+    expectObjectFields(mockFirstObjectArg(installSkillFromSourceMock), {
+      spec: "./local-skill",
+      slug: "custom-name",
+    });
+  });
+
+  it("rejects --version for git and local source installs", async () => {
+    await expect(
+      runCommand(["skills", "install", "git:owner/tools", "--version", "1.2.3"]),
+    ).rejects.toThrow("__exit__:1");
+
+    expect(runtimeErrors).toContain("--version is only supported for ClawHub skill installs.");
+    expect(installSkillFromClawHubMock).not.toHaveBeenCalled();
+    expect(installSkillFromSourceMock).not.toHaveBeenCalled();
   });
 
   it("installs a skill into the cwd-inferred agent workspace", async () => {

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -10,6 +10,10 @@ import {
   searchSkillsFromClawHub,
   updateSkillsFromClawHub,
 } from "../agents/skills-clawhub.js";
+import {
+  installSkillFromSource,
+  isSkillSourceInstallSpec,
+} from "../agents/skills-source-install.js";
 import { getRuntimeConfig } from "../config/config.js";
 import { defaultRuntime } from "../runtime.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
@@ -149,21 +153,61 @@ export function registerSkillsCli(program: Command) {
 
   skills
     .command("install")
-    .description("Install a skill from ClawHub into the active or shared managed directory")
-    .argument("<slug>", "ClawHub skill slug")
+    .description("Install a skill from ClawHub, git, or a local directory")
+    .argument("<slug>", "ClawHub skill slug, git:<repo>, or local skill directory")
     .option("--version <version>", "Install a specific version")
     .option("--force", "Overwrite an existing workspace skill", false)
     .option("--global", "Install into the shared managed skills directory", false)
     .option("--agent <id>", "Target agent workspace (defaults to cwd-inferred, then default agent)")
+    .option("--as <slug>", "Install a git/local skill under this slug")
     .action(
       async (
         slug: string,
-        opts: { version?: string; force?: boolean; global?: boolean; agent?: string },
+        opts: {
+          version?: string;
+          force?: boolean;
+          global?: boolean;
+          agent?: string;
+          as?: string;
+        },
         command: Command,
       ) => {
         try {
           const workspaceDir = resolveClawHubTargetWorkspaceDir(command, opts);
           if (!workspaceDir) {
+            return;
+          }
+          if (isSkillSourceInstallSpec(slug)) {
+            if (opts.version) {
+              defaultRuntime.error("--version is only supported for ClawHub skill installs.");
+              defaultRuntime.exit(1);
+              return;
+            }
+            const result = await installSkillFromSource({
+              workspaceDir,
+              spec: slug,
+              slug: opts.as,
+              force: Boolean(opts.force),
+              logger: {
+                info: (message) => defaultRuntime.log(message),
+                warn: (message) => defaultRuntime.log(theme.warn(message)),
+              },
+            });
+            if (!result.ok) {
+              defaultRuntime.error(result.error);
+              defaultRuntime.exit(1);
+              return;
+            }
+            defaultRuntime.log(
+              `Installed ${result.slug} from ${result.source} -> ${result.targetDir}`,
+            );
+            return;
+          }
+          if (opts.as) {
+            defaultRuntime.error(
+              "--as is only supported for git and local directory skill installs.",
+            );
+            defaultRuntime.exit(1);
             return;
           }
           const result = await installSkillFromClawHub({

--- a/src/plugins/git-install.test.ts
+++ b/src/plugins/git-install.test.ts
@@ -77,16 +77,28 @@ describe("parseGitPluginSpec", () => {
     expect(explicitRef.label).toBe("acme/demo");
     expect(explicitRef.normalizedSpec).toBe("git:https://github.com/acme/demo.git@v1.2.3");
 
+    const slashRef = expectParsedGitSpec("git:acme/demo@feature/foo");
+    expect(slashRef.url).toBe("https://github.com/acme/demo.git");
+    expect(slashRef.ref).toBe("feature/foo");
+    expect(slashRef.label).toBe("acme/demo");
+
     const hashRef = expectParsedGitSpec("git:acme/demo#main");
     expect(hashRef.url).toBe("https://github.com/acme/demo.git");
     expect(hashRef.ref).toBe("main");
   });
 
+  it("does not treat URL credentials as ref selectors", () => {
+    const parsed = expectParsedGitSpec("git:https://token:secret@github.com/acme/demo.git");
+    expect(parsed.url).toBe("https://token:secret@github.com/acme/demo.git");
+    expect(parsed.ref).toBeUndefined();
+    expect(parsed.label).toBe("github.com/acme/demo");
+  });
+
   it("keeps scp-style clone URLs without treating git@ as a ref", () => {
-    const parsed = expectParsedGitSpec("git:git@github.com:acme/demo.git@release");
+    const parsed = expectParsedGitSpec("git:git@github.com:acme/demo.git@feature/foo");
     expect(parsed.url).toBe("git@github.com:acme/demo.git");
-    expect(parsed.ref).toBe("release");
-    expect(parsed.label).toBe("git@github.com:acme/demo.git");
+    expect(parsed.ref).toBe("feature/foo");
+    expect(parsed.label).toBe("git@github.com:acme/demo");
   });
 });
 

--- a/src/plugins/git-install.ts
+++ b/src/plugins/git-install.ts
@@ -52,16 +52,32 @@ function splitGitSpecRef(input: string): { base: string; ref?: string } {
     };
   }
 
-  const atIndex = input.lastIndexOf("@");
-  const lastSlashIndex = Math.max(input.lastIndexOf("/"), input.lastIndexOf("\\"));
-  if (atIndex > lastSlashIndex && atIndex > 0) {
-    return {
-      base: input.slice(0, atIndex),
-      ref: normalizeOptionalString(input.slice(atIndex + 1)),
-    };
+  for (
+    let atIndex = input.lastIndexOf("@");
+    atIndex > 0;
+    atIndex = input.lastIndexOf("@", atIndex - 1)
+  ) {
+    const base = input.slice(0, atIndex);
+    const ref = normalizeOptionalString(input.slice(atIndex + 1));
+    if (ref && isGitSpecBase(base)) {
+      return { base, ref };
+    }
   }
 
   return { base: input };
+}
+
+function isGitSpecBase(value: string): boolean {
+  return (
+    looksLikeGitHubRepoShorthand(value) ||
+    looksLikeGitHubHostPath(value) ||
+    looksLikeUrlGitSpecBase(value) ||
+    looksLikeScpGitUrl(value) ||
+    value.endsWith(".git") ||
+    value.startsWith("./") ||
+    value.startsWith("../") ||
+    value.startsWith("~/")
+  );
 }
 
 function looksLikeGitHubRepoShorthand(value: string): boolean {
@@ -78,10 +94,27 @@ function isHttpUrl(value: string): boolean {
 
 function isGitUrl(value: string): boolean {
   return (
-    /^(?:ssh|git|file):\/\//i.test(value) ||
-    /^[^@\s]+@[^:\s]+:.+/.test(value) ||
-    value.endsWith(".git")
+    /^(?:ssh|git|file):\/\//i.test(value) || looksLikeScpGitUrl(value) || value.endsWith(".git")
   );
+}
+
+function looksLikeScpGitUrl(value: string): boolean {
+  return /^[^@\s]+@[^:\s]+:.+/.test(value);
+}
+
+function looksLikeUrlGitSpecBase(value: string): boolean {
+  try {
+    const url = new URL(value);
+    if (!["http:", "https:", "ssh:", "git:", "file:"].includes(url.protocol)) {
+      return false;
+    }
+    if (url.protocol === "file:") {
+      return url.pathname.length > 1;
+    }
+    return Boolean(url.hostname) && url.pathname.length > 1;
+  } catch {
+    return false;
+  }
 }
 
 function stripGitSuffix(value: string): string {
@@ -102,10 +135,10 @@ function normalizeGitLabel(value: string): string {
       const url = new URL(value);
       return stripGitSuffix(`${url.hostname}${url.pathname}`).replace(/^\/+/, "");
     } catch {
-      return value;
+      return stripGitSuffix(value);
     }
   }
-  return value;
+  return stripGitSuffix(value);
 }
 
 export function parseGitPluginSpec(raw: string): ParsedGitPluginSpec | null {

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -247,6 +247,7 @@ export type CommandOptions = {
   timeoutMs: number;
   cwd?: string;
   input?: string;
+  baseEnv?: NodeJS.ProcessEnv;
   env?: NodeJS.ProcessEnv;
   windowsVerbatimArguments?: boolean;
   noOutputTimeoutMs?: number;
@@ -319,9 +320,9 @@ export async function runCommandWithTimeout(
 ): Promise<SpawnResult> {
   const options: CommandOptions =
     typeof optionsOrTimeout === "number" ? { timeoutMs: optionsOrTimeout } : optionsOrTimeout;
-  const { timeoutMs, cwd, input, env, noOutputTimeoutMs, signal } = options;
+  const { timeoutMs, cwd, input, baseEnv, env, noOutputTimeoutMs, signal } = options;
   const hasInput = input !== undefined;
-  const resolvedEnv = resolveCommandEnv({ argv, env });
+  const resolvedEnv = resolveCommandEnv({ argv, baseEnv, env });
   const stdio = resolveCommandStdio({ hasInput, preferInherit: true });
   const invocation = resolveChildProcessInvocation({
     argv,


### PR DESCRIPTION
## Summary

- add `openclaw skills install git:owner/repo[@ref]` and local directory source installs
- infer source install slugs from `SKILL.md` frontmatter, with `--as` overrides and ClawHub-only `--version`
- keep non-ClawHub source installs out of ClawHub update tracking and document the new install forms

## Verification

- `node scripts/run-vitest.mjs src/cli/skills-cli.commands.test.ts src/agents/skills-source-install.test.ts src/plugins/git-install.test.ts src/process/exec.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/plugins/git-install.ts src/plugins/git-install.test.ts src/agents/skills-source-install.test.ts`
- `pnpm exec oxfmt --check --threads=1 docs/tools/skills.md docs/cli/skills.md`
- `pnpm docs:list`
- `git diff --check`
- `AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --parallel-tests "node scripts/run-vitest.mjs src/cli/skills-cli.commands.test.ts src/agents/skills-source-install.test.ts src/plugins/git-install.test.ts src/process/exec.test.ts"`

## Real Behavior Proof

Behavior addressed: `openclaw skills install` can install from ClawHub slugs, `git:` specs, and local skill directories while keeping ClawHub update behavior scoped to ClawHub-tracked installs.

Real environment tested: local Codex worktree on macOS using focused Vitest coverage and the repo autoreview helper.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/cli/skills-cli.commands.test.ts src/agents/skills-source-install.test.ts src/plugins/git-install.test.ts src/process/exec.test.ts`.

Evidence after fix: focused tests passed with 5 files and 70 tests, including local directory installs, git installs, slash-containing refs, authenticated URL parsing, stale ClawHub metadata cleanup, and ClawHub route preservation.

Observed result after fix: final autoreview reported `autoreview clean: no accepted/actionable findings reported`.

What was not tested: live network install from a remote GitHub repository was not run; git behavior is covered with local git repositories and parser tests.
