### PR TITLE
Clean up isolated cron sessions after runs

### DIFF
--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -1438,6 +1438,7 @@ describe("dispatchCronDelivery — double-announce guard", () => {
 
     expect(state.result).toBeUndefined();
     expect(state.delivered).toBe(true);
+    expect(state.cronRunSessionCleanupAttempted).toBe(true);
     expect(deliverOutboundPayloads).toHaveBeenCalledTimes(1);
     expect(callGateway).toHaveBeenCalledWith({
       method: "sessions.delete",
@@ -1463,6 +1464,7 @@ describe("dispatchCronDelivery — double-announce guard", () => {
       status: "ok",
       delivered: false,
     });
+    expect(state.cronRunSessionCleanupAttempted).toBe(true);
     expect(retireSessionMcpRuntime).toHaveBeenCalledWith({
       sessionId: "test-session-id",
       reason: "cron-delete-after-run-fallback",
@@ -1480,6 +1482,7 @@ describe("dispatchCronDelivery — double-announce guard", () => {
       status: "ok",
       delivered: false,
     });
+    expect(state.cronRunSessionCleanupAttempted).toBe(false);
     expect(callGateway).not.toHaveBeenCalledWith(
       expect.objectContaining({
         method: "sessions.delete",

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -135,6 +135,7 @@ export type DispatchCronDeliveryState = {
   result?: RunCronAgentTurnResult;
   delivered: boolean;
   deliveryAttempted: boolean;
+  cronRunSessionCleanupAttempted: boolean;
   summary?: string;
   outputText?: string;
   synthesizedText?: string;
@@ -915,7 +916,17 @@ export async function dispatchCronDelivery(
 
   let delivered = verifiedMessageToolDelivery;
   let deliveryAttempted = verifiedMessageToolDelivery;
-  let directCronSessionDeleted = false;
+  let directCronSessionCleanupAttempted = false;
+  const buildDeliveryState = (result?: RunCronAgentTurnResult): DispatchCronDeliveryState => ({
+    ...(result ? { result } : {}),
+    delivered,
+    deliveryAttempted,
+    cronRunSessionCleanupAttempted: directCronSessionCleanupAttempted,
+    summary,
+    outputText,
+    synthesizedText,
+    deliveryPayloads,
+  });
   const formatDeliveryTargetError = (error: string) =>
     params.sourceDeliveryOutcome.unverifiedMessageToolDelivery
       ? `${error}; the agent used the message tool, but OpenClaw could not verify that message matched the cron delivery target`
@@ -931,7 +942,7 @@ export async function dispatchCronDelivery(
       ...params.telemetry,
     });
   const cleanupDirectCronSessionIfNeeded = async (): Promise<void> => {
-    if (directCronSessionDeleted) {
+    if (directCronSessionCleanupAttempted) {
       return;
     }
     const cleanupAttempted = await cleanupCronRunSessionAfterRun({
@@ -941,7 +952,7 @@ export async function dispatchCronDelivery(
       reason: "cron-delete-after-run-fallback",
     });
     if (cleanupAttempted) {
-      directCronSessionDeleted = true;
+      directCronSessionCleanupAttempted = true;
     }
   };
   const finishSilentReplyDelivery = async (): Promise<RunCronAgentTurnResult> => {
@@ -1394,32 +1405,18 @@ export async function dispatchCronDelivery(
       // non-deleteAfterRun / non-cron sessions (see cleanupDirectCronSession).
       await cleanupDirectCronSessionIfNeeded();
       if (!params.deliveryBestEffort) {
-        return {
-          result: failDeliveryTarget(params.resolvedDelivery.error.message),
-          delivered,
-          deliveryAttempted,
-          summary,
-          outputText,
-          synthesizedText,
-          deliveryPayloads,
-        };
+        return buildDeliveryState(failDeliveryTarget(params.resolvedDelivery.error.message));
       }
       await logCronDeliveryWarn(`[cron:${params.job.id}] ${params.resolvedDelivery.error.message}`);
-      return {
-        result: params.withRunSession({
+      return buildDeliveryState(
+        params.withRunSession({
           status: "ok",
           summary,
           outputText,
           deliveryAttempted,
           ...params.telemetry,
         }),
-        delivered,
-        deliveryAttempted,
-        summary,
-        outputText,
-        synthesizedText,
-        deliveryPayloads,
-      };
+      );
     }
 
     // Finalize descendant/subagent output first for text-only cron runs, then
@@ -1430,38 +1427,15 @@ export async function dispatchCronDelivery(
     if (useDirectDelivery) {
       const directResult = await deliverViaDirectAndCleanup(params.resolvedDelivery);
       if (directResult) {
-        return {
-          result: directResult,
-          delivered,
-          deliveryAttempted,
-          summary,
-          outputText,
-          synthesizedText,
-          deliveryPayloads,
-        };
+        return buildDeliveryState(directResult);
       }
     } else {
       const finalizedTextResult = await finalizeTextDelivery(params.resolvedDelivery);
       if (finalizedTextResult) {
-        return {
-          result: finalizedTextResult,
-          delivered,
-          deliveryAttempted,
-          summary,
-          outputText,
-          synthesizedText,
-          deliveryPayloads,
-        };
+        return buildDeliveryState(finalizedTextResult);
       }
     }
   }
 
-  return {
-    delivered,
-    deliveryAttempted,
-    summary,
-    outputText,
-    synthesizedText,
-    deliveryPayloads,
-  };
+  return buildDeliveryState();
 }

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -1,7 +1,6 @@
 /** Dispatches isolated cron output to direct delivery, mirrors, and follow-up queues. */
 import { isAudioFileName } from "@openclaw/media-core/mime";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { retireSessionMcpRuntime } from "../../agents/agent-bundle-mcp-tools.js";
 import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
 import {
   isSilentReplyText,
@@ -39,7 +38,6 @@ import { normalizeTargetForProvider } from "../../infra/outbound/target-normaliz
 import { hasReplyPayloadContent } from "../../interactive/payload.js";
 import { stringifyRouteThreadId } from "../../plugin-sdk/channel-route.js";
 import {
-  isCronSessionKey,
   parseThreadSessionSuffix,
   resolveAgentIdFromSessionKey,
 } from "../../routing/session-key.js";
@@ -51,6 +49,7 @@ import type { CronJob, CronRunTelemetry } from "../types.js";
 import type { DeliveryTargetResolution } from "./delivery-target.js";
 import { pickLastNonEmptyTextFromPayloads, pickSummaryFromOutput } from "./helpers.js";
 import type { RunCronAgentTurnResult } from "./run.types.js";
+import { cleanupCronRunSessionAfterRun } from "./session-cleanup.js";
 import { expectsSubagentFollowup, isLikelyInterimCronMessage } from "./subagent-followup-hints.js";
 
 function normalizeDeliveryTarget(channel: string, to: string): string {
@@ -172,9 +171,6 @@ type CompletedDirectCronDelivery = {
   results: OutboundDeliveryResult[];
 };
 
-const gatewayCallRuntimeLoader = createLazyImportLoader(
-  () => import("../../gateway/call.runtime.js"),
-);
 const deliveryOutboundRuntimeLoader = createLazyImportLoader(
   () => import("./delivery-outbound.runtime.js"),
 );
@@ -196,10 +192,6 @@ const subagentFollowupRuntimeLoader = createLazyImportLoader(
 const ttsRuntimeLoader = createLazyImportLoader(() => import("../../tts/tts.runtime.js"));
 
 const COMPLETED_DIRECT_CRON_DELIVERIES = new Map<string, CompletedDirectCronDelivery>();
-
-async function loadGatewayCallRuntime(): Promise<typeof import("../../gateway/call.runtime.js")> {
-  return await gatewayCallRuntimeLoader.load();
-}
 
 async function loadDeliveryOutboundRuntime(): Promise<
   typeof import("./delivery-outbound.runtime.js")
@@ -256,29 +248,12 @@ export async function cleanupDirectCronSession(params: {
   sessionId: string;
   retireReason: string;
 }): Promise<void> {
-  if (!params.job.deleteAfterRun) {
-    return;
-  }
-  if (!isCronSessionKey(params.agentSessionKey)) {
-    return;
-  }
-  try {
-    const { callGateway } = await loadGatewayCallRuntime();
-    await callGateway({
-      method: "sessions.delete",
-      params: {
-        key: params.agentSessionKey,
-        deleteTranscript: true,
-        emitLifecycleHooks: false,
-      },
-      timeoutMs: 10_000,
-    });
-  } catch {
-    await retireSessionMcpRuntime({
-      sessionId: params.sessionId,
-      reason: params.retireReason,
-    });
-  }
+  await cleanupCronRunSessionAfterRun({
+    job: params.job,
+    agentSessionKey: params.agentSessionKey,
+    sessionId: params.sessionId,
+    reason: params.retireReason,
+  });
 }
 
 function logCronDeliveryErrorDeferred(message: string): void {
@@ -959,13 +934,15 @@ export async function dispatchCronDelivery(
     if (directCronSessionDeleted) {
       return;
     }
-    directCronSessionDeleted = true;
-    await cleanupDirectCronSession({
+    const cleanupAttempted = await cleanupCronRunSessionAfterRun({
       job: params.job,
       agentSessionKey: params.agentSessionKey,
       sessionId: params.sessionId,
-      retireReason: "cron-delete-after-run-fallback",
+      reason: "cron-delete-after-run-fallback",
     });
+    if (cleanupAttempted) {
+      directCronSessionDeleted = true;
+    }
   };
   const finishSilentReplyDelivery = async (): Promise<RunCronAgentTurnResult> => {
     deliveryAttempted = true;

--- a/src/cron/isolated-agent/run.fast-mode.test.ts
+++ b/src/cron/isolated-agent/run.fast-mode.test.ts
@@ -6,7 +6,9 @@ import {
   loadRunCronIsolatedAgentTurn,
   makeCronSession,
   callGatewayMock,
+  dispatchCronDeliveryMock,
   retireSessionMcpRuntimeMock,
+  resolveCronDeliveryPlanMock,
   resolveFastModeStateMock,
   resolveCronSessionMock,
   runEmbeddedAgentMock,
@@ -155,8 +157,8 @@ describe("runCronIsolatedAgentTurn — fast mode", () => {
 
   it("deletes the run-scoped cron session after delivery-none deleteAfterRun jobs", async () => {
     const result = await runCronIsolatedAgentTurn(
-      makeIsolatedAgentTurnParams({
-        job: makeIsolatedAgentTurnJob({
+      makeIsolatedAgentParamsFixture({
+        job: makeIsolatedAgentJobFixture({
           deleteAfterRun: true,
           delivery: { mode: "none" },
           payload: { kind: "agentTurn", message: "cleanup me", model: OPENAI_GPT4_MODEL },
@@ -174,6 +176,40 @@ describe("runCronIsolatedAgentTurn — fast mode", () => {
       },
       timeoutMs: 10_000,
     });
+  });
+
+  it("does not repeat deleteAfterRun cleanup after dispatch already handled it", async () => {
+    resolveCronDeliveryPlanMock.mockReturnValue({
+      requested: true,
+      mode: "announce",
+      channel: "messagechat",
+      to: "test-target",
+    });
+    dispatchCronDeliveryMock.mockImplementationOnce(
+      ({ deliveryPayloads, summary, outputText, synthesizedText }) => ({
+        delivered: true,
+        deliveryAttempted: true,
+        cronRunSessionCleanupAttempted: true,
+        summary,
+        outputText,
+        synthesizedText,
+        deliveryPayloads,
+      }),
+    );
+
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentParamsFixture({
+        job: makeIsolatedAgentJobFixture({
+          deleteAfterRun: true,
+          delivery: { mode: "announce", channel: "messagechat", to: "test-target" },
+          payload: { kind: "agentTurn", message: "cleanup once", model: OPENAI_GPT4_MODEL },
+        }),
+      }),
+    );
+
+    expect(result.status).toBe("ok");
+    expect(dispatchCronDeliveryMock).toHaveBeenCalledOnce();
+    expect(callGatewayMock).not.toHaveBeenCalled();
   });
 
   it("passes config-driven fast mode into embedded cron runs", async () => {

--- a/src/cron/isolated-agent/run.fast-mode.test.ts
+++ b/src/cron/isolated-agent/run.fast-mode.test.ts
@@ -5,6 +5,7 @@ import { setupRunCronIsolatedAgentTurnSuite } from "./run.suite-helpers.js";
 import {
   loadRunCronIsolatedAgentTurn,
   makeCronSession,
+  callGatewayMock,
   retireSessionMcpRuntimeMock,
   resolveFastModeStateMock,
   resolveCronSessionMock,
@@ -151,6 +152,29 @@ async function runFastModeCase(params: {
 
 describe("runCronIsolatedAgentTurn — fast mode", () => {
   setupRunCronIsolatedAgentTurnSuite({ fast: true });
+
+  it("deletes the run-scoped cron session after delivery-none deleteAfterRun jobs", async () => {
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentTurnParams({
+        job: makeIsolatedAgentTurnJob({
+          deleteAfterRun: true,
+          delivery: { mode: "none" },
+          payload: { kind: "agentTurn", message: "cleanup me", model: OPENAI_GPT4_MODEL },
+        }),
+      }),
+    );
+
+    expect(result.status).toBe("ok");
+    expect(callGatewayMock).toHaveBeenCalledWith({
+      method: "sessions.delete",
+      params: {
+        key: "agent:default:cron:test",
+        deleteTranscript: true,
+        emitLifecycleHooks: false,
+      },
+      timeoutMs: 10_000,
+    });
+  });
 
   it("passes config-driven fast mode into embedded cron runs", async () => {
     await runFastModeCase({

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -632,6 +632,7 @@ function resetRunOutcomeMocks(): void {
           !sourceDeliveryOutcome?.satisfiesSourceDelivery &&
           resolvedDelivery.ok),
       ),
+      cronRunSessionCleanupAttempted: false,
       summary,
       outputText,
       synthesizedText,

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -78,6 +78,7 @@ export const resolveSessionAuthProfileOverrideMock = createMock();
 export const resolveFastModeStateMock = createMock();
 export const getChannelPluginMock = createMock();
 export const retireSessionMcpRuntimeMock = createMock();
+export const callGatewayMock = createMock();
 export const ensureRuntimePluginsLoadedMock = createMock();
 
 const resolveBootstrapWarningSignaturesSeenMock = createMock();
@@ -293,6 +294,10 @@ vi.mock("../../agents/cli-runner.runtime.js", () => ({
 
 vi.mock("../../agents/agent-bundle-mcp-tools.js", () => ({
   retireSessionMcpRuntime: retireSessionMcpRuntimeMock,
+}));
+
+vi.mock("../../gateway/call.runtime.js", () => ({
+  callGateway: callGatewayMock,
 }));
 
 vi.mock("../../config/sessions/store.runtime.js", () => ({
@@ -652,6 +657,8 @@ function resetRunSessionMocks(): void {
   updateSessionStoreMock.mockResolvedValue(undefined);
   resolveCronSessionMock.mockReset();
   resolveCronSessionMock.mockReturnValue(makeCronSession());
+  callGatewayMock.mockReset();
+  callGatewayMock.mockResolvedValue({ ok: true, deleted: true });
   retireSessionMcpRuntimeMock.mockReset();
   retireSessionMcpRuntimeMock.mockResolvedValue(true);
 }

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -964,6 +964,7 @@ async function finalizeCronRun(params: {
   execution: CronExecutionResult;
   abortReason: () => string;
   isAborted: () => boolean;
+  markCronRunSessionCleanupAttempted: () => void;
 }): Promise<RunCronAgentTurnResult> {
   const { prepared, execution } = params;
   const finalRunResult = execution.runResult;
@@ -1162,6 +1163,7 @@ async function finalizeCronRun(params: {
       sessionId: prepared.currentRunSessionId(),
       retireReason: "cron-delete-after-run-aborted",
     });
+    params.markCronRunSessionCleanupAttempted();
     return prepared.withRunSession({
       status: "error",
       error,
@@ -1246,6 +1248,7 @@ async function finalizeCronRun(params: {
       sessionId: prepared.currentRunSessionId(),
       retireReason: "cron-delete-after-run-fatal-error",
     });
+    params.markCronRunSessionCleanupAttempted();
     const deliveryTrace = buildCronDeliveryTrace({
       deliveryPlan: prepared.deliveryPlan,
       resolvedDelivery: prepared.resolvedDelivery,
@@ -1289,6 +1292,9 @@ async function finalizeCronRun(params: {
     abortReason: params.abortReason,
     withRunSession: prepared.withRunSession,
   });
+  if (deliveryResult.cronRunSessionCleanupAttempted) {
+    params.markCronRunSessionCleanupAttempted();
+  }
   const deliveryTrace = buildCronDeliveryTrace({
     deliveryPlan: prepared.deliveryPlan,
     resolvedDelivery: prepared.resolvedDelivery,
@@ -1441,6 +1447,7 @@ export async function runCronIsolatedAgentTurn(params: {
 
   let outcome: "completed" | "error" = "completed";
   let outcomeError: string | undefined;
+  let cronRunSessionCleanupAttempted = false;
   try {
     assertAgentRunLifecycleGenerationCurrent(runLifecycleGeneration);
     const existingRunContext = getAgentRunContext(initialSessionId);
@@ -1507,6 +1514,9 @@ export async function runCronIsolatedAgentTurn(params: {
       execution,
       abortReason,
       isAborted,
+      markCronRunSessionCleanupAttempted: () => {
+        cronRunSessionCleanupAttempted = true;
+      },
     });
     if (finalized.status === "error") {
       outcome = "error";
@@ -1538,12 +1548,14 @@ export async function runCronIsolatedAgentTurn(params: {
       error: outcomeError,
     });
     try {
-      await cleanupCronRunSessionAfterRun({
-        job: params.job,
-        agentSessionKey: prepared.context.agentSessionKey,
-        sessionId: prepared.context.currentRunSessionId(),
-        reason: "cron-delete-after-run-finally",
-      });
+      if (!cronRunSessionCleanupAttempted) {
+        cronRunSessionCleanupAttempted = await cleanupCronRunSessionAfterRun({
+          job: params.job,
+          agentSessionKey: prepared.context.agentSessionKey,
+          sessionId: prepared.context.currentRunSessionId(),
+          reason: "cron-delete-after-run-finally",
+        });
+      }
     } finally {
       // Release runtime references after the run completes (success or failure).
       // The session entry has already been persisted to disk by this point,

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -106,6 +106,7 @@ import {
   setSessionRuntimeModel,
 } from "./run.runtime.js";
 import type { RunCronAgentTurnResult } from "./run.types.js";
+import { cleanupCronRunSessionAfterRun } from "./session-cleanup.js";
 import { resolveCronAgentSessionKey } from "./session-key.js";
 import { resolveCronSession } from "./session.js";
 
@@ -1536,14 +1537,23 @@ export async function runCronIsolatedAgentTurn(params: {
       ...finalSessionRef,
       error: outcomeError,
     });
-    // Release runtime references after the run completes (success or failure).
-    // The session entry has already been persisted to disk by this point,
-    // so the in-memory store and run context can be safely dropped.
-    await disposeCronRunContext({
-      sessionId: initialSessionId,
-      cronSession: prepared.context.cronSession,
-      ownsRunContext,
-      runContextOwnerToken,
-    });
+    try {
+      await cleanupCronRunSessionAfterRun({
+        job: params.job,
+        agentSessionKey: prepared.context.agentSessionKey,
+        sessionId: prepared.context.currentRunSessionId(),
+        reason: "cron-delete-after-run-finally",
+      });
+    } finally {
+      // Release runtime references after the run completes (success or failure).
+      // The session entry has already been persisted to disk by this point,
+      // so the in-memory store and run context can be safely dropped.
+      await disposeCronRunContext({
+        sessionId: initialSessionId,
+        cronSession: prepared.context.cronSession,
+        ownsRunContext,
+        runContextOwnerToken,
+      });
+    }
   }
 }

--- a/src/cron/isolated-agent/session-cleanup.ts
+++ b/src/cron/isolated-agent/session-cleanup.ts
@@ -21,7 +21,7 @@ export async function cleanupCronRunSessionAfterRun(params: {
     return false;
   }
   if (!isCronSessionKey(params.agentSessionKey)) {
-    return true;
+    return false;
   }
   try {
     const { callGateway } = await loadGatewayCallRuntime();

--- a/src/cron/isolated-agent/session-cleanup.ts
+++ b/src/cron/isolated-agent/session-cleanup.ts
@@ -1,0 +1,44 @@
+import { retireSessionMcpRuntime } from "../../agents/agent-bundle-mcp-tools.js";
+import { isCronSessionKey } from "../../routing/session-key.js";
+import { createLazyImportLoader } from "../../shared/lazy-promise.js";
+import type { CronJob } from "../types.js";
+
+const gatewayCallRuntimeLoader = createLazyImportLoader(
+  () => import("../../gateway/call.runtime.js"),
+);
+
+async function loadGatewayCallRuntime(): Promise<typeof import("../../gateway/call.runtime.js")> {
+  return await gatewayCallRuntimeLoader.load();
+}
+
+export async function cleanupCronRunSessionAfterRun(params: {
+  job: Pick<CronJob, "deleteAfterRun">;
+  agentSessionKey: string;
+  sessionId: string;
+  reason: string;
+}): Promise<boolean> {
+  if (!params.job.deleteAfterRun) {
+    return false;
+  }
+  if (!isCronSessionKey(params.agentSessionKey)) {
+    return true;
+  }
+  try {
+    const { callGateway } = await loadGatewayCallRuntime();
+    await callGateway({
+      method: "sessions.delete",
+      params: {
+        key: params.agentSessionKey,
+        deleteTranscript: true,
+        emitLifecycleHooks: false,
+      },
+      timeoutMs: 10_000,
+    });
+  } catch {
+    await retireSessionMcpRuntime({
+      sessionId: params.sessionId,
+      reason: params.reason,
+    });
+  }
+  return true;
+}


### PR DESCRIPTION
Fixes #84707.

## Summary

- move isolated cron delete-after-run cleanup into a shared helper
- call delete-after-run cleanup from the isolated runner `finally` block, so delivery mode `none`, runner errors, and other terminal paths also delete run sessions
- keep the existing delivery-dispatch cleanup path using the shared helper

## Real behavior proof

- **Behavior or issue addressed:** Isolated cron jobs with `deleteAfterRun: true` and `delivery.mode: "none"` must clean up their run session even though no delivery dispatch is requested.
- **Real environment tested:** Local OpenClaw Gateway on Andy's Mac mini via `ws://127.0.0.1:18789`, PR head `b2214e8b44e8cc7df9ffba4ac3a226d84d6c35a6`, worktree `/tmp/openclaw-proof-84794`; gateway token redacted.
- **Exact steps or command run after this patch:** Created and force-ran a real isolated cron job named `proof-84794-delete-after-run-delivery-none` with `deleteAfterRun: true`, `delivery.mode: "none"`, and an `agentTurn` payload. The finished run produced session id `29c468ca-e22d-4328-9d36-c66136fcae2d`, and `sessions.list` showed the retained cron session before applying this PR head's cleanup helper. Then ran:

```sh
OPENCLAW_GATEWAY_URL=ws://127.0.0.1:18789 OPENCLAW_GATEWAY_TOKEN=<redacted> \
  node --import /Users/andy/src/openclaw/node_modules/tsx/dist/loader.mjs \
  proof-84794-cleanup-live.ts \
  agent:tech:cron:85d5ccb8-1526-4aaf-9623-05835871e5c6 \
  29c468ca-e22d-4328-9d36-c66136fcae2d
```

- **Evidence after fix:** Terminal capture from the command above:

```json
{
  "ok": true,
  "behavior": "cleanupCronRunSessionAfterRun deletes a delivery-none isolated cron session",
  "environment": {
    "branch": "proof-84794",
    "gateway": "local OpenClaw Gateway via ws://127.0.0.1:18789"
  },
  "before": [
    {
      "key": "agent:tech:cron:85d5ccb8-1526-4aaf-9623-05835871e5c6",
      "sessionId": "29c468ca-e22d-4328-9d36-c66136fcae2d"
    }
  ],
  "cleanupResult": true,
  "after": []
}
```

- **Observed result after fix:** `cleanupCronRunSessionAfterRun` returned `true`; the real Gateway `sessions.list` result contained the cron session before cleanup and returned an empty result afterward.
- **What was not tested:** Full Docker packaging was not rerun in this proof pass; the validation section below covers the focused source lane and format/type checks.

## Validation

- `/opt/homebrew/opt/node@22/bin/node scripts/run-vitest.mjs src/cron/isolated-agent/run.fast-mode.test.ts src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts src/cron/service.delivery-plan.test.ts src/cron/service.session-reaper-in-finally.test.ts`
- `/opt/homebrew/opt/node@22/bin/node /Users/andy/openclaw/node_modules/.bin/tsgo -p test/tsconfig/tsconfig.test.src.json --pretty false --declaration false --singleThreaded --checkers 1`
- `/opt/homebrew/opt/node@22/bin/node /Users/andy/openclaw/node_modules/.bin/oxfmt --check --threads=1 ...changed files...`

If this PR is squash-merged or reworked, please preserve author attribution or include:

`Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>`
