### PR TITLE
fix(config): validate browser sandbox bind sources [AI]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- fix(config): validate browser sandbox bind sources [AI]. (#84799) Thanks @pgondhi987.
 - doctor: constrain legacy plugin cleanup paths [AI]. (#84801) Thanks @pgondhi987.
 - Media/audio: skip empty structured sherpa-onnx transcripts instead of treating the raw JSON payload as spoken text. (#84667) Thanks @TurboTheTurtle.
 - Node/Linux: keep `OPENCLAW_GATEWAY_TOKEN` out of generated systemd unit files by writing node service token values to a node-specific env file. (#84408)

--- a/src/config/config.sandbox-docker.test.ts
+++ b/src/config/config.sandbox-docker.test.ts
@@ -255,7 +255,10 @@ describe("sandbox browser binds config", () => {
         defaults: {
           sandbox: {
             browser: {
-              binds: ["/home/user/.chrome-profile:/data/chrome:rw"],
+              binds: [
+                "/home/user/.chrome-profile:/data/chrome:rw",
+                "D:/data/openclaw/chrome:/data/chrome-windows:rw",
+              ],
             },
           },
         },
@@ -265,7 +268,28 @@ describe("sandbox browser binds config", () => {
     if (res.ok) {
       expect(res.config.agents?.defaults?.sandbox?.browser?.binds).toEqual([
         "/home/user/.chrome-profile:/data/chrome:rw",
+        "D:/data/openclaw/chrome:/data/chrome-windows:rw",
       ]);
+    }
+  });
+
+  it("rejects relative source paths in browser binds", () => {
+    for (const bind of [
+      "relative/profile:/data/chrome:rw",
+      "D:relative\\profile:/data/chrome:rw",
+    ]) {
+      const res = validateConfigObject({
+        agents: {
+          defaults: {
+            sandbox: {
+              browser: {
+                binds: [bind],
+              },
+            },
+          },
+        },
+      });
+      expect(res.ok, bind).toBe(false);
     }
   });
 

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -20,6 +20,38 @@ import {
 } from "./zod-schema.core.js";
 import { sensitive } from "./zod-schema.sensitive.js";
 
+function validateSandboxBindEntries(
+  binds: readonly string[] | undefined,
+  ctx: z.RefinementCtx,
+): void {
+  if (!binds) {
+    return;
+  }
+  for (let i = 0; i < binds.length; i += 1) {
+    const bind = normalizeOptionalString(binds[i]) ?? "";
+    if (!bind) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["binds", i],
+        message: "Sandbox security: bind mount entry must be a non-empty string.",
+      });
+      continue;
+    }
+
+    const parsed = splitSandboxBindSpec(bind);
+    const source = (parsed ? parsed.host : bind).trim();
+    if (!isSandboxHostPathAbsolute(source)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["binds", i],
+        message:
+          `Sandbox security: bind mount "${bind}" uses a non-absolute source path "${source}". ` +
+          "Only absolute POSIX or Windows drive-letter paths are supported for sandbox binds.",
+      });
+    }
+  }
+}
+
 export const AgentRunRetriesConfigSchema = z
   .object({
     base: z.number().int().positive().optional(),
@@ -168,31 +200,7 @@ const SandboxDockerSchema = z
   })
   .strict()
   .superRefine((data, ctx) => {
-    if (data.binds) {
-      for (let i = 0; i < data.binds.length; i += 1) {
-        const bind = normalizeOptionalString(data.binds[i]) ?? "";
-        if (!bind) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            path: ["binds", i],
-            message: "Sandbox security: bind mount entry must be a non-empty string.",
-          });
-          continue;
-        }
-
-        const parsed = splitSandboxBindSpec(bind);
-        const source = (parsed ? parsed.host : bind).trim();
-        if (!isSandboxHostPathAbsolute(source)) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            path: ["binds", i],
-            message:
-              `Sandbox security: bind mount "${bind}" uses a non-absolute source path "${source}". ` +
-              "Only absolute POSIX or Windows drive-letter paths are supported for sandbox binds.",
-          });
-        }
-      }
-    }
+    validateSandboxBindEntries(data.binds, ctx);
     const blockedNetworkReason = getBlockedNetworkModeReason({
       network: data.network,
       allowContainerNamespaceJoin: data.dangerouslyAllowContainerNamespaceJoin === true,
@@ -253,6 +261,7 @@ const SandboxBrowserSchema = z
     binds: z.array(z.string()).optional(),
   })
   .superRefine((data, ctx) => {
+    validateSandboxBindEntries(data.binds, ctx);
     if (normalizeLowercaseStringOrEmpty(data.network ?? "") === "host") {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,


### PR DESCRIPTION
## Summary

- Problem: Browser sandbox bind entries accepted relative host-source paths even though Docker sandbox binds already required absolute host-source paths.
- Solution: Share the existing sandbox bind-entry validation between Docker and browser sandbox schemas.
- What changed: Browser sandbox binds now reject relative POSIX paths and drive-relative Windows-style paths, while valid absolute POSIX and Windows drive-letter bind entries remain accepted.
- What did NOT change (scope boundary): Runtime bind mounting, Docker bind behavior, network validation, and sandbox merge behavior are unchanged.

## Motivation

- Browser sandbox bind configuration should enforce the same path-shape contract as Docker sandbox bind configuration so invalid host-source paths are rejected at config validation time.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: maintainer-provided branch context
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Browser sandbox bind entries now reject relative host-source paths consistently with Docker sandbox bind entries.
- Real environment tested: Not tested; this is config schema validation and was verified with focused local regression tests.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/config/config.sandbox-docker.test.ts`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): `Test Files 1 passed (1); Tests 26 passed (26)`
- Observed result after fix: Browser sandbox config rejects relative POSIX and drive-relative Windows-style bind sources and accepts valid absolute bind entries.
- What was not tested: Full config check suite, packaged runtime behavior, and live browser sandbox startup.
- Before evidence (optional but encouraged): N/A

## Root Cause (if applicable)

- Root cause: Docker sandbox schema had explicit bind-source validation, while browser sandbox schema only declared `binds` as an array of strings.
- Missing detection / guardrail: Browser sandbox bind regression coverage did not include relative host-source path cases.
- Contributing context (if known): Browser bind configuration has a separate schema path from Docker bind configuration.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/config/config.sandbox-docker.test.ts`
- Scenario the test should lock in: Browser sandbox binds reject `relative/profile:/data/chrome:rw` and `D:relative\\profile:/data/chrome:rw`, while accepting absolute POSIX and Windows drive-letter binds.
- Why this is the smallest reliable guardrail: The behavior is enforced by config schema validation before runtime sandbox creation.
- Existing test that already covers this (if any): Docker sandbox bind validation coverage existed; browser bind coverage only checked string typing and valid bind preservation.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Browser sandbox configuration with relative host-source bind paths is now rejected during config validation.

## Diagram (if applicable)

```text
Before:
[browser bind config] -> [string array validation only] -> [relative host source accepted]

After:
[browser bind config] -> [shared bind source validation] -> [relative host source rejected]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux worktree environment
- Runtime/container: Node test wrapper
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): Browser sandbox bind entries under `agents.defaults.sandbox.browser.binds`

### Steps

1. Configure `agents.defaults.sandbox.browser.binds` with a relative host-source bind.
2. Validate config through the existing config validation path.
3. Run focused regression coverage for sandbox config validation.

### Expected

- Relative browser bind host-source paths are rejected.
- Valid absolute browser bind host-source paths are accepted.

### Actual

- Focused regression coverage passes with the expected accept/reject behavior.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Focused Vitest coverage for sandbox config validation: `node scripts/run-vitest.mjs src/config/config.sandbox-docker.test.ts`.
- Edge cases checked: Relative POSIX bind source, drive-relative Windows-style bind source, absolute POSIX bind source, and absolute Windows drive-letter bind source.
- What you did **not** verify: Full repository checks, packaged runtime behavior, and live browser sandbox startup.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes for valid absolute bind entries; invalid relative browser bind entries are now rejected.
- Config/env changes? (`Yes/No`): Yes, browser sandbox bind validation is stricter for relative host-source paths.
- Migration needed? (`Yes/No`): Only for configs that used relative browser bind host-source paths.
- If yes, exact upgrade steps: Replace relative browser bind host-source paths with absolute POSIX paths or Windows drive-letter paths.

## Risks and Mitigations

- Risk: Existing local configs with relative browser bind host-source paths will fail validation.
  - Mitigation: The validation message points to the absolute path requirement, and absolute POSIX plus Windows drive-letter bind entries remain supported.

AI-assisted: Yes
