### PR TITLE
feat(agents): classify context budget pressure

### DIFF
--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -623,6 +623,75 @@ describe("updateSessionStoreAfterAgentRun", () => {
     });
   });
 
+  it("persists estimated context budget status without marking stale usage fresh", async () => {
+    await withTempSessionStore(async ({ storePath }) => {
+      const cfg = {} as OpenClawConfig;
+      const sessionKey = "agent:main:explicit:test-context-budget-status";
+      const sessionId = "test-context-budget-status-session";
+      const sessionStore: Record<string, SessionEntry> = {
+        [sessionKey]: {
+          sessionId,
+          updatedAt: 1,
+          totalTokens: 21225,
+          totalTokensFresh: true,
+        },
+      };
+      await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2));
+
+      const result: EmbeddedPiRunResult = {
+        meta: {
+          durationMs: 500,
+          agentMeta: {
+            sessionId,
+            provider: "minimax",
+            model: "MiniMax-M2.7",
+            contextBudgetStatus: {
+              schemaVersion: 1,
+              source: "pre-prompt-estimate",
+              updatedAt: 123,
+              provider: "minimax",
+              model: "MiniMax-M2.7",
+              route: "fits",
+              shouldCompact: false,
+              estimatedPromptTokens: 18_000,
+              contextTokenBudget: 32_000,
+              promptBudgetBeforeReserve: 28_000,
+              reserveTokens: 4_000,
+              effectiveReserveTokens: 4_000,
+              remainingPromptBudgetTokens: 10_000,
+              overflowTokens: 0,
+              toolResultReducibleChars: 0,
+              messageCount: 4,
+              unwindowedMessageCount: 4,
+            },
+          },
+        },
+      };
+
+      await updateSessionStoreAfterAgentRun({
+        cfg,
+        sessionId,
+        sessionKey,
+        storePath,
+        sessionStore,
+        defaultProvider: "minimax",
+        defaultModel: "MiniMax-M2.7",
+        result,
+      });
+
+      expect(sessionStore[sessionKey]?.totalTokens).toBe(21225);
+      expect(sessionStore[sessionKey]?.totalTokensFresh).toBe(false);
+      expect(sessionStore[sessionKey]?.contextBudgetStatus).toMatchObject({
+        source: "pre-prompt-estimate",
+        estimatedPromptTokens: 18_000,
+        contextTokenBudget: 32_000,
+      });
+
+      const persisted = loadSessionStore(storePath);
+      expect(persisted[sessionKey]?.contextBudgetStatus?.estimatedPromptTokens).toBe(18_000);
+    });
+  });
+
   it("does not treat CLI cumulative usage as a fresh context snapshot", async () => {
     await withTempSessionStore(async ({ storePath }) => {
       const cfg = {

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -95,6 +95,7 @@ export async function updateSessionStoreAfterAgentRun(params: {
   const providerUsed = result.meta.agentMeta?.provider ?? fallbackProvider ?? defaultProvider;
   const agentHarnessId = normalizeOptionalString(result.meta.agentMeta?.agentHarnessId);
   const runtimeContextTokens = resolvePositiveInteger(result.meta.agentMeta?.contextTokens);
+  const contextBudgetStatus = result.meta.agentMeta?.contextBudgetStatus;
   const contextTokens =
     runtimeContextTokens !== undefined
       ? runtimeContextTokens
@@ -173,6 +174,9 @@ export async function updateSessionStoreAfterAgentRun(params: {
   next.abortedLastRun = result.meta.aborted ?? false;
   if (result.meta.systemPromptReport) {
     next.systemPromptReport = result.meta.systemPromptReport;
+  }
+  if (contextBudgetStatus) {
+    next.contextBudgetStatus = contextBudgetStatus;
   }
   if (hasNonzeroUsage(usage)) {
     const { estimateUsageCost, resolveModelCostConfig } = await getUsageFormatModule();

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1023,6 +1023,7 @@ export async function runEmbeddedPiAgent(
       let lastRunPromptUsage: ReturnType<typeof normalizeUsage> | undefined;
       let autoCompactionCount = 0;
       let lastCompactionTokensAfter: number | undefined;
+      let lastContextBudgetStatus: EmbeddedPiAgentMeta["contextBudgetStatus"];
       let runLoopIterations = 0;
       let overloadProfileRotations = 0;
       let planningOnlyRetryAttempts = 0;
@@ -1622,6 +1623,9 @@ export async function runEmbeddedPiAgent(
             attempt.compactionTokensAfter > 0
           ) {
             lastCompactionTokensAfter = Math.floor(attempt.compactionTokensAfter);
+          }
+          if (attempt.contextBudgetStatus) {
+            lastContextBudgetStatus = attempt.contextBudgetStatus;
           }
           const activeErrorContext = resolveActiveErrorContext({
             provider,
@@ -2627,6 +2631,7 @@ export async function runEmbeddedPiAgent(
             usage: usageMeta.usage,
             lastCallUsage: usageMeta.lastCallUsage,
             promptTokens: usageMeta.promptTokens,
+            ...(lastContextBudgetStatus ? { contextBudgetStatus: lastContextBudgetStatus } : {}),
             compactionCount: autoCompactionCount > 0 ? autoCompactionCount : undefined,
             compactionTokensAfter: lastCompactionTokensAfter,
           };

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -389,6 +389,7 @@ import {
 } from "./midturn-precheck.js";
 import {
   PREEMPTIVE_OVERFLOW_ERROR_TEXT,
+  formatPrePromptPrecheckLog,
   shouldPreemptivelyCompactBeforePrompt,
 } from "./preemptive-compaction.js";
 import {
@@ -4010,6 +4011,25 @@ export async function runEmbeddedAttempt(
                   agentId: sessionAgentId,
                 }),
               });
+          if (preemptiveCompaction) {
+            log.debug(
+              formatPrePromptPrecheckLog({
+                result: preemptiveCompaction,
+                provider: params.provider,
+                modelId: params.modelId,
+                messageCount: activeSession.messages.length,
+                contextTokenBudget,
+                reserveTokens,
+                ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+                ...(params.sessionId ? { sessionId: params.sessionId } : {}),
+                ...(contextEnginePromptAuthority === "preassembly_may_overflow" &&
+                unwindowedContextEngineMessagesForPrecheck
+                  ? { unwindowedMessageCount: unwindowedContextEngineMessagesForPrecheck.length }
+                  : {}),
+                ...(params.sessionFile ? { sessionFile: params.sessionFile } : {}),
+              }),
+            );
+          }
           if (preemptiveCompaction?.route === "truncate_tool_results_only") {
             const toolResultMaxChars = resolveLiveToolResultMaxChars({
               contextWindowTokens: contextTokenBudget,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -389,6 +389,7 @@ import {
 } from "./midturn-precheck.js";
 import {
   PREEMPTIVE_OVERFLOW_ERROR_TEXT,
+  buildPrePromptContextBudgetStatus,
   formatPrePromptPrecheckLog,
   shouldPreemptivelyCompactBeforePrompt,
 } from "./preemptive-compaction.js";
@@ -3320,6 +3321,7 @@ export async function runEmbeddedAttempt(
       let cacheBreak: PromptCacheBreak | null = null;
       let promptCache: EmbeddedRunAttemptResult["promptCache"];
       let lastCallUsage: NormalizedUsage | undefined;
+      let contextBudgetStatus: EmbeddedRunAttemptResult["contextBudgetStatus"];
       let compactionOccurredThisAttempt = false;
       let finalPromptText: string | undefined;
       if (params.replyOperation) {
@@ -4012,6 +4014,20 @@ export async function runEmbeddedAttempt(
                 }),
               });
           if (preemptiveCompaction) {
+            contextBudgetStatus = buildPrePromptContextBudgetStatus({
+              result: preemptiveCompaction,
+              provider: params.provider,
+              modelId: params.modelId,
+              messageCount: activeSession.messages.length,
+              contextTokenBudget,
+              reserveTokens,
+              ...(params.sessionId ? { sessionId: params.sessionId } : {}),
+              ...(contextEnginePromptAuthority === "preassembly_may_overflow" &&
+              unwindowedContextEngineMessagesForPrecheck
+                ? { unwindowedMessageCount: unwindowedContextEngineMessagesForPrecheck.length }
+                : {}),
+              ...(params.sessionFile ? { sessionFile: params.sessionFile } : {}),
+            });
             log.debug(
               formatPrePromptPrecheckLog({
                 result: preemptiveCompaction,
@@ -4818,6 +4834,7 @@ export async function runEmbeddedAttempt(
         ),
         attemptUsage,
         promptCache,
+        contextBudgetStatus,
         compactionCount: getCompactionCount(),
         compactionTokensAfter: getLastCompactionTokensAfter(),
         // Client tool calls detected (OpenResponses hosted tools).

--- a/src/agents/pi-embedded-runner/run/preemptive-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run/preemptive-compaction.test.ts
@@ -5,6 +5,7 @@ import { estimateToolResultReductionPotential } from "../tool-result-truncation.
 
 let PREEMPTIVE_OVERFLOW_ERROR_TEXT: typeof import("./preemptive-compaction.js").PREEMPTIVE_OVERFLOW_ERROR_TEXT;
 let estimatePrePromptTokens: typeof import("./preemptive-compaction.js").estimatePrePromptTokens;
+let formatPrePromptPrecheckLog: typeof import("./preemptive-compaction.js").formatPrePromptPrecheckLog;
 let shouldPreemptivelyCompactBeforePrompt: typeof import("./preemptive-compaction.js").shouldPreemptivelyCompactBeforePrompt;
 
 beforeAll(async () => {
@@ -12,6 +13,7 @@ beforeAll(async () => {
   ({
     PREEMPTIVE_OVERFLOW_ERROR_TEXT,
     estimatePrePromptTokens,
+    formatPrePromptPrecheckLog,
     shouldPreemptivelyCompactBeforePrompt,
   } = await import("./preemptive-compaction.js"));
 });
@@ -91,6 +93,42 @@ describe("preemptive-compaction", () => {
     expect(result.shouldCompact).toBe(false);
     expect(result.route).toBe("fits");
     expect(result.estimatedPromptTokens).toBeLessThan(result.promptBudgetBeforeReserve);
+  });
+
+  it("formats all-route pre-prompt diagnostics for a fits decision", () => {
+    const result = shouldPreemptivelyCompactBeforePrompt({
+      messages: [makeAssistantHistory("short history")],
+      systemPrompt: "sys",
+      prompt: "hello",
+      contextTokenBudget: 10_000,
+      reserveTokens: 1_000,
+    });
+    const line = formatPrePromptPrecheckLog({
+      result,
+      sessionKey: "discord:channel:thread",
+      sessionId: "session-1",
+      provider: "anthropic",
+      modelId: "claude-opus-4-6",
+      messageCount: 1,
+      unwindowedMessageCount: 3,
+      contextTokenBudget: 10_000,
+      reserveTokens: 1_000,
+      sessionFile: "sessions/session-1.json",
+    });
+
+    expect(line).toContain("[context-overflow-precheck] pre-prompt check");
+    expect(line).toContain("sessionKey=discord:channel:thread");
+    expect(line).toContain("provider=anthropic/claude-opus-4-6");
+    expect(line).toContain("route=fits");
+    expect(line).toContain(`estimatedPromptTokens=${result.estimatedPromptTokens}`);
+    expect(line).toContain(`promptBudgetBeforeReserve=${result.promptBudgetBeforeReserve}`);
+    expect(line).toContain("overflowTokens=0");
+    expect(line).toContain(`toolResultReducibleChars=${result.toolResultReducibleChars}`);
+    expect(line).toContain("reserveTokens=1000");
+    expect(line).toContain(`effectiveReserveTokens=${result.effectiveReserveTokens}`);
+    expect(line).toContain("contextTokenBudget=10000");
+    expect(line).toContain("messages=1");
+    expect(line).toContain("unwindowedMessages=3");
   });
 
   it("uses the larger unwindowed message estimate when explicitly provided", () => {

--- a/src/agents/pi-embedded-runner/run/preemptive-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run/preemptive-compaction.test.ts
@@ -4,6 +4,7 @@ import "../../test-helpers/pi-coding-agent-token-mock.js";
 import { estimateToolResultReductionPotential } from "../tool-result-truncation.js";
 
 let PREEMPTIVE_OVERFLOW_ERROR_TEXT: typeof import("./preemptive-compaction.js").PREEMPTIVE_OVERFLOW_ERROR_TEXT;
+let buildPrePromptContextBudgetStatus: typeof import("./preemptive-compaction.js").buildPrePromptContextBudgetStatus;
 let estimatePrePromptTokens: typeof import("./preemptive-compaction.js").estimatePrePromptTokens;
 let formatPrePromptPrecheckLog: typeof import("./preemptive-compaction.js").formatPrePromptPrecheckLog;
 let shouldPreemptivelyCompactBeforePrompt: typeof import("./preemptive-compaction.js").shouldPreemptivelyCompactBeforePrompt;
@@ -12,6 +13,7 @@ beforeAll(async () => {
   vi.resetModules();
   ({
     PREEMPTIVE_OVERFLOW_ERROR_TEXT,
+    buildPrePromptContextBudgetStatus,
     estimatePrePromptTokens,
     formatPrePromptPrecheckLog,
     shouldPreemptivelyCompactBeforePrompt,
@@ -129,6 +131,51 @@ describe("preemptive-compaction", () => {
     expect(line).toContain("contextTokenBudget=10000");
     expect(line).toContain("messages=1");
     expect(line).toContain("unwindowedMessages=3");
+  });
+
+  it("builds a durable estimated context budget status snapshot", () => {
+    const result = shouldPreemptivelyCompactBeforePrompt({
+      messages: [makeAssistantHistory("short history")],
+      systemPrompt: "sys",
+      prompt: "hello",
+      contextTokenBudget: 10_000,
+      reserveTokens: 1_000,
+    });
+
+    const status = buildPrePromptContextBudgetStatus({
+      result,
+      provider: "anthropic",
+      modelId: "claude-opus-4-6",
+      messageCount: 1,
+      unwindowedMessageCount: 3,
+      contextTokenBudget: 10_000,
+      reserveTokens: 1_000,
+      sessionId: "session-1",
+      sessionFile: "sessions/session-1.json",
+      now: 123,
+    });
+
+    expect(status).toMatchObject({
+      schemaVersion: 1,
+      source: "pre-prompt-estimate",
+      updatedAt: 123,
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      route: "fits",
+      shouldCompact: false,
+      contextTokenBudget: 10_000,
+      promptBudgetBeforeReserve: result.promptBudgetBeforeReserve,
+      reserveTokens: 1_000,
+      effectiveReserveTokens: result.effectiveReserveTokens,
+      overflowTokens: 0,
+      messageCount: 1,
+      unwindowedMessageCount: 3,
+      sessionId: "session-1",
+      sessionFile: "sessions/session-1.json",
+    });
+    expect(status.remainingPromptBudgetTokens).toBe(
+      result.promptBudgetBeforeReserve - result.estimatedPromptTokens,
+    );
   });
 
   it("uses the larger unwindowed message estimate when explicitly provided", () => {

--- a/src/agents/pi-embedded-runner/run/preemptive-compaction.ts
+++ b/src/agents/pi-embedded-runner/run/preemptive-compaction.ts
@@ -16,6 +16,16 @@ const TRUNCATION_ROUTE_BUFFER_TOKENS = 512;
 
 export type { PreemptiveCompactionRoute } from "./preemptive-compaction.types.js";
 
+export type PreemptiveCompactionDecision = {
+  route: PreemptiveCompactionRoute;
+  shouldCompact: boolean;
+  estimatedPromptTokens: number;
+  promptBudgetBeforeReserve: number;
+  overflowTokens: number;
+  toolResultReducibleChars: number;
+  effectiveReserveTokens: number;
+};
+
 export function estimatePrePromptTokens(params: {
   messages: AgentMessage[];
   systemPrompt?: string;
@@ -46,15 +56,7 @@ export function shouldPreemptivelyCompactBeforePrompt(params: {
   contextTokenBudget: number;
   reserveTokens: number;
   toolResultMaxChars?: number;
-}): {
-  route: PreemptiveCompactionRoute;
-  shouldCompact: boolean;
-  estimatedPromptTokens: number;
-  promptBudgetBeforeReserve: number;
-  overflowTokens: number;
-  toolResultReducibleChars: number;
-  effectiveReserveTokens: number;
-} {
+}): PreemptiveCompactionDecision {
   let messagesForPressure = params.messages;
   let estimatedPromptTokens = estimatePrePromptTokens({
     messages: params.messages,
@@ -116,4 +118,35 @@ export function shouldPreemptivelyCompactBeforePrompt(params: {
     toolResultReducibleChars,
     effectiveReserveTokens,
   };
+}
+
+export function formatPrePromptPrecheckLog(params: {
+  result: PreemptiveCompactionDecision;
+  sessionKey?: string;
+  sessionId?: string;
+  provider: string;
+  modelId: string;
+  messageCount: number;
+  unwindowedMessageCount?: number;
+  contextTokenBudget: number;
+  reserveTokens: number;
+  sessionFile?: string;
+}): string {
+  const { result } = params;
+  return (
+    `[context-overflow-precheck] pre-prompt check ` +
+    `sessionKey=${params.sessionKey ?? params.sessionId ?? "unknown"} ` +
+    `provider=${params.provider}/${params.modelId} ` +
+    `route=${result.route} ` +
+    `estimatedPromptTokens=${result.estimatedPromptTokens} ` +
+    `promptBudgetBeforeReserve=${result.promptBudgetBeforeReserve} ` +
+    `overflowTokens=${result.overflowTokens} ` +
+    `toolResultReducibleChars=${result.toolResultReducibleChars} ` +
+    `reserveTokens=${params.reserveTokens} ` +
+    `effectiveReserveTokens=${result.effectiveReserveTokens} ` +
+    `contextTokenBudget=${params.contextTokenBudget} ` +
+    `messages=${params.messageCount} ` +
+    `unwindowedMessages=${params.unwindowedMessageCount ?? params.messageCount} ` +
+    `sessionFile=${params.sessionFile}`
+  );
 }

--- a/src/agents/pi-embedded-runner/run/preemptive-compaction.ts
+++ b/src/agents/pi-embedded-runner/run/preemptive-compaction.ts
@@ -1,5 +1,6 @@
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { estimateTokens } from "@earendil-works/pi-coding-agent";
+import type { SessionContextBudgetStatus } from "../../../config/sessions.js";
 import { SAFETY_MARGIN, estimateMessagesTokens } from "../../compaction.js";
 import {
   MIN_PROMPT_BUDGET_RATIO,
@@ -149,4 +150,47 @@ export function formatPrePromptPrecheckLog(params: {
     `unwindowedMessages=${params.unwindowedMessageCount ?? params.messageCount} ` +
     `sessionFile=${params.sessionFile}`
   );
+}
+
+export function buildPrePromptContextBudgetStatus(params: {
+  result: PreemptiveCompactionDecision;
+  provider: string;
+  modelId: string;
+  messageCount: number;
+  unwindowedMessageCount?: number;
+  contextTokenBudget: number;
+  reserveTokens: number;
+  sessionId?: string;
+  sessionFile?: string;
+  now?: number;
+}): SessionContextBudgetStatus {
+  const { result } = params;
+  const remainingPromptBudgetTokens = Math.max(
+    0,
+    result.promptBudgetBeforeReserve - result.estimatedPromptTokens,
+  );
+  return {
+    schemaVersion: 1,
+    source: "pre-prompt-estimate",
+    updatedAt: params.now ?? Date.now(),
+    provider: params.provider,
+    model: params.modelId,
+    route: result.route,
+    shouldCompact: result.shouldCompact,
+    estimatedPromptTokens: result.estimatedPromptTokens,
+    contextTokenBudget: Math.max(1, Math.floor(params.contextTokenBudget)),
+    promptBudgetBeforeReserve: result.promptBudgetBeforeReserve,
+    reserveTokens: Math.max(0, Math.floor(params.reserveTokens)),
+    effectiveReserveTokens: result.effectiveReserveTokens,
+    remainingPromptBudgetTokens,
+    overflowTokens: result.overflowTokens,
+    toolResultReducibleChars: result.toolResultReducibleChars,
+    messageCount: Math.max(0, Math.floor(params.messageCount)),
+    unwindowedMessageCount: Math.max(
+      0,
+      Math.floor(params.unwindowedMessageCount ?? params.messageCount),
+    ),
+    ...(params.sessionId ? { sessionId: params.sessionId } : {}),
+    ...(params.sessionFile ? { sessionFile: params.sessionFile } : {}),
+  };
 }

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -3,7 +3,10 @@ import type { Api, AssistantMessage, Model } from "@earendil-works/pi-ai";
 import type { AuthStorage, ModelRegistry } from "@earendil-works/pi-coding-agent";
 import type { HeartbeatToolResponse } from "../../../auto-reply/heartbeat-tool-response.js";
 import type { ThinkLevel } from "../../../auto-reply/thinking.js";
-import type { SessionSystemPromptReport } from "../../../config/sessions/types.js";
+import type {
+  SessionContextBudgetStatus,
+  SessionSystemPromptReport,
+} from "../../../config/sessions/types.js";
 import type { ContextEngine, ContextEnginePromptCacheInfo } from "../../../context-engine/types.js";
 import type { DiagnosticTraceContext } from "../../../infra/diagnostic-trace-context.js";
 import type { PluginHookBeforeAgentStartResult } from "../../../plugins/hook-before-agent-start.types.js";
@@ -132,6 +135,7 @@ export type EmbeddedRunAttemptResult = {
   cloudCodeAssistFormatError: boolean;
   attemptUsage?: NormalizedUsage;
   promptCache?: ContextEnginePromptCacheInfo;
+  contextBudgetStatus?: SessionContextBudgetStatus;
   compactionCount?: number;
   compactionTokensAfter?: number;
   /**

--- a/src/agents/pi-embedded-runner/types.ts
+++ b/src/agents/pi-embedded-runner/types.ts
@@ -1,5 +1,9 @@
 import type { HeartbeatToolResponse } from "../../auto-reply/heartbeat-tool-response.js";
-import type { CliSessionBinding, SessionSystemPromptReport } from "../../config/sessions/types.js";
+import type {
+  CliSessionBinding,
+  SessionContextBudgetStatus,
+  SessionSystemPromptReport,
+} from "../../config/sessions/types.js";
 import type { DiagnosticTraceContext } from "../../infra/diagnostic-trace-context.js";
 import type { FallbackAttempt } from "../model-fallback.types.js";
 import type {
@@ -50,6 +54,7 @@ export type EmbeddedPiAgentMeta = {
     cacheWrite?: number;
     total?: number;
   };
+  contextBudgetStatus?: SessionContextBudgetStatus;
 };
 
 export type TraceAttempt = {

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -174,7 +174,7 @@ describe("buildStatusMessage", () => {
     });
     const normalized = normalizeTestText(text);
 
-    expect(normalized).toContain("Context: ~640k/1.0m (64% est)");
+    expect(normalized).toContain("Context: ~640k/1.0m (64% est) · Budget: watch");
     expect(normalized).not.toContain("Context: ?/1.0m");
     expect(normalized).not.toContain("Context: 3.8m/1.0m");
   });
@@ -220,6 +220,7 @@ describe("buildStatusMessage", () => {
     const normalized = normalizeTestText(text);
 
     expect(normalized).toContain("Context: 36k/1.0m (4%)");
+    expect(normalized).toContain("Budget: watch");
     expect(normalized).not.toContain("~640k");
   });
 
@@ -261,7 +262,7 @@ describe("buildStatusMessage", () => {
     });
     const normalized = normalizeTestText(text);
 
-    expect(normalized).toContain("Context: ~125k/1.0m (13% est)");
+    expect(normalized).toContain("Context: ~125k/1.0m (13% est) · Budget: safe");
     expect(normalized).not.toContain("Context: 0/1.0m");
   });
 

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -132,6 +132,139 @@ describe("buildStatusMessage", () => {
     expect(normalized).not.toContain("Context: 3.8m/1.0m");
   });
 
+  it("uses estimated context budget status when fresh totalTokens are unavailable", () => {
+    const text = buildStatusMessage({
+      agent: {
+        model: "anthropic/pi:opus",
+        contextTokens: 1_000_000,
+      },
+      sessionEntry: {
+        sessionId: "abc",
+        updatedAt: 0,
+        inputTokens: 3_800_000,
+        outputTokens: 20_000,
+        totalTokens: 3_800_000,
+        totalTokensFresh: false,
+        contextTokens: 1_000_000,
+        contextBudgetStatus: {
+          schemaVersion: 1,
+          source: "pre-prompt-estimate",
+          updatedAt: 1,
+          provider: "anthropic",
+          model: "pi:opus",
+          route: "fits",
+          shouldCompact: false,
+          estimatedPromptTokens: 640_000,
+          contextTokenBudget: 1_000_000,
+          promptBudgetBeforeReserve: 900_000,
+          reserveTokens: 100_000,
+          effectiveReserveTokens: 100_000,
+          remainingPromptBudgetTokens: 260_000,
+          overflowTokens: 0,
+          toolResultReducibleChars: 0,
+          messageCount: 2,
+          unwindowedMessageCount: 2,
+        },
+      },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+      modelAuth: "api-key",
+      now: 10 * 60_000,
+    });
+    const normalized = normalizeTestText(text);
+
+    expect(normalized).toContain("Context: ~640k/1.0m (64% est)");
+    expect(normalized).not.toContain("Context: ?/1.0m");
+    expect(normalized).not.toContain("Context: 3.8m/1.0m");
+  });
+
+  it("prefers fresh totalTokens over estimated context budget status", () => {
+    const text = buildStatusMessage({
+      agent: {
+        model: "anthropic/pi:opus",
+        contextTokens: 1_000_000,
+      },
+      sessionEntry: {
+        sessionId: "abc",
+        updatedAt: 0,
+        totalTokens: 36_000,
+        totalTokensFresh: true,
+        contextTokens: 1_000_000,
+        contextBudgetStatus: {
+          schemaVersion: 1,
+          source: "pre-prompt-estimate",
+          updatedAt: 1,
+          provider: "anthropic",
+          model: "pi:opus",
+          route: "fits",
+          shouldCompact: false,
+          estimatedPromptTokens: 640_000,
+          contextTokenBudget: 1_000_000,
+          promptBudgetBeforeReserve: 900_000,
+          reserveTokens: 100_000,
+          effectiveReserveTokens: 100_000,
+          remainingPromptBudgetTokens: 260_000,
+          overflowTokens: 0,
+          toolResultReducibleChars: 0,
+          messageCount: 2,
+          unwindowedMessageCount: 2,
+        },
+      },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+      modelAuth: "api-key",
+      now: 10 * 60_000,
+    });
+    const normalized = normalizeTestText(text);
+
+    expect(normalized).toContain("Context: 36k/1.0m (4%)");
+    expect(normalized).not.toContain("~640k");
+  });
+
+  it("uses estimated context budget status when token usage is absent", () => {
+    const text = buildStatusMessage({
+      agent: {
+        model: "anthropic/pi:opus",
+        contextTokens: 1_000_000,
+      },
+      sessionEntry: {
+        sessionId: "abc",
+        updatedAt: 0,
+        contextTokens: 1_000_000,
+        contextBudgetStatus: {
+          schemaVersion: 1,
+          source: "pre-prompt-estimate",
+          updatedAt: 1,
+          provider: "anthropic",
+          model: "pi:opus",
+          route: "fits",
+          shouldCompact: false,
+          estimatedPromptTokens: 125_000,
+          contextTokenBudget: 1_000_000,
+          promptBudgetBeforeReserve: 900_000,
+          reserveTokens: 100_000,
+          effectiveReserveTokens: 100_000,
+          remainingPromptBudgetTokens: 775_000,
+          overflowTokens: 0,
+          toolResultReducibleChars: 0,
+          messageCount: 2,
+          unwindowedMessageCount: 2,
+        },
+      },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+      modelAuth: "api-key",
+      now: 10 * 60_000,
+    });
+    const normalized = normalizeTestText(text);
+
+    expect(normalized).toContain("Context: ~125k/1.0m (13% est)");
+    expect(normalized).not.toContain("Context: 0/1.0m");
+  });
+
   it("shows sanitized TTS provider details in the voice status line", async () => {
     await withTempHome(async () => {
       const text = buildStatusMessage({

--- a/src/config/sessions.ts
+++ b/src/config/sessions.ts
@@ -9,6 +9,7 @@ export * from "./sessions/paths.js";
 export * from "./sessions/reset.js";
 export * from "./sessions/session-key.js";
 export * from "./sessions/store.js";
+export * from "./sessions/context-budget-policy.js";
 export * from "./sessions/types.js";
 export * from "./sessions/transcript.js";
 export * from "./sessions/session-file.js";

--- a/src/config/sessions/context-budget-policy.test.ts
+++ b/src/config/sessions/context-budget-policy.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { resolveSessionContextBudgetPolicy } from "./context-budget-policy.js";
+import type { SessionContextBudgetStatus } from "./types.js";
+
+function makeStatus(patch: Partial<SessionContextBudgetStatus> = {}): SessionContextBudgetStatus {
+  return {
+    schemaVersion: 1,
+    source: "pre-prompt-estimate",
+    updatedAt: 1,
+    provider: "anthropic",
+    model: "claude-opus-4-6",
+    route: "fits",
+    shouldCompact: false,
+    estimatedPromptTokens: 100,
+    contextTokenBudget: 1_000,
+    promptBudgetBeforeReserve: 900,
+    reserveTokens: 100,
+    effectiveReserveTokens: 100,
+    remainingPromptBudgetTokens: 800,
+    overflowTokens: 0,
+    toolResultReducibleChars: 0,
+    messageCount: 1,
+    unwindowedMessageCount: 1,
+    ...patch,
+  };
+}
+
+describe("resolveSessionContextBudgetPolicy", () => {
+  it("classifies low estimated prompt usage as safe", () => {
+    expect(
+      resolveSessionContextBudgetPolicy(
+        makeStatus({
+          estimatedPromptTokens: 125_000,
+          contextTokenBudget: 1_000_000,
+          promptBudgetBeforeReserve: 900_000,
+          remainingPromptBudgetTokens: 775_000,
+        }),
+      ),
+    ).toMatchObject({
+      pressure: "safe",
+      contextBudgetPct: 13,
+      promptBudgetPct: 14,
+      remainingPromptBudgetTokens: 775_000,
+    });
+  });
+
+  it("classifies reserve-budget pressure before overflow", () => {
+    expect(
+      resolveSessionContextBudgetPolicy(
+        makeStatus({
+          estimatedPromptTokens: 640_000,
+          contextTokenBudget: 1_000_000,
+          promptBudgetBeforeReserve: 900_000,
+          remainingPromptBudgetTokens: 260_000,
+        }),
+      ),
+    ).toMatchObject({
+      pressure: "watch",
+      contextBudgetPct: 64,
+      promptBudgetPct: 71,
+    });
+
+    expect(
+      resolveSessionContextBudgetPolicy(
+        makeStatus({
+          estimatedPromptTokens: 780_000,
+          contextTokenBudget: 1_000_000,
+          promptBudgetBeforeReserve: 900_000,
+          remainingPromptBudgetTokens: 120_000,
+        }),
+      )?.pressure,
+    ).toBe("pressure");
+  });
+
+  it("classifies non-fitting precheck routes as overflow risk", () => {
+    expect(
+      resolveSessionContextBudgetPolicy(
+        makeStatus({
+          route: "compact_then_truncate",
+          shouldCompact: true,
+          estimatedPromptTokens: 920_000,
+          contextTokenBudget: 1_000_000,
+          promptBudgetBeforeReserve: 900_000,
+          remainingPromptBudgetTokens: 0,
+          overflowTokens: 20_000,
+        }),
+      )?.pressure,
+    ).toBe("overflow-risk");
+  });
+});

--- a/src/config/sessions/context-budget-policy.ts
+++ b/src/config/sessions/context-budget-policy.ts
@@ -1,0 +1,74 @@
+import type { SessionContextBudgetStatus } from "./types.js";
+
+export type SessionContextBudgetPressure = "safe" | "watch" | "pressure" | "overflow-risk";
+
+export type SessionContextBudgetPolicy = {
+  pressure: SessionContextBudgetPressure;
+  estimatedPromptTokens: number;
+  contextBudgetPct?: number;
+  promptBudgetPct?: number;
+  remainingPromptBudgetTokens: number;
+  overflowTokens: number;
+  route: SessionContextBudgetStatus["route"];
+};
+
+const WATCH_PROMPT_BUDGET_PCT = 65;
+const PRESSURE_PROMPT_BUDGET_PCT = 85;
+
+function resolveNonNegativeInteger(value: number | undefined): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    return undefined;
+  }
+  return Math.floor(value);
+}
+
+function resolvePositiveInteger(value: number | undefined): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return undefined;
+  }
+  return Math.floor(value);
+}
+
+function pct(numerator: number, denominator: number | undefined): number | undefined {
+  if (denominator === undefined) {
+    return undefined;
+  }
+  return Math.min(999, Math.max(0, Math.round((numerator / denominator) * 100)));
+}
+
+export function resolveSessionContextBudgetPolicy(
+  status: SessionContextBudgetStatus | undefined,
+): SessionContextBudgetPolicy | undefined {
+  if (!status || status.source !== "pre-prompt-estimate") {
+    return undefined;
+  }
+  const estimatedPromptTokens = resolveNonNegativeInteger(status.estimatedPromptTokens);
+  if (estimatedPromptTokens === undefined) {
+    return undefined;
+  }
+  const contextTokenBudget = resolvePositiveInteger(status.contextTokenBudget);
+  const promptBudgetBeforeReserve = resolvePositiveInteger(status.promptBudgetBeforeReserve);
+  const overflowTokens = resolveNonNegativeInteger(status.overflowTokens) ?? 0;
+  const remainingPromptBudgetTokens =
+    resolveNonNegativeInteger(status.remainingPromptBudgetTokens) ??
+    Math.max(0, (promptBudgetBeforeReserve ?? 0) - estimatedPromptTokens);
+  const promptBudgetPct = pct(estimatedPromptTokens, promptBudgetBeforeReserve);
+  const contextBudgetPct = pct(estimatedPromptTokens, contextTokenBudget);
+  const pressure: SessionContextBudgetPressure =
+    overflowTokens > 0 || status.route !== "fits"
+      ? "overflow-risk"
+      : promptBudgetPct !== undefined && promptBudgetPct >= PRESSURE_PROMPT_BUDGET_PCT
+        ? "pressure"
+        : promptBudgetPct !== undefined && promptBudgetPct >= WATCH_PROMPT_BUDGET_PCT
+          ? "watch"
+          : "safe";
+  return {
+    pressure,
+    estimatedPromptTokens,
+    ...(contextBudgetPct !== undefined ? { contextBudgetPct } : {}),
+    ...(promptBudgetPct !== undefined ? { promptBudgetPct } : {}),
+    remainingPromptBudgetTokens,
+    overflowTokens,
+    route: status.route,
+  };
+}

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -111,6 +111,34 @@ export type SessionCompactionCheckpoint = {
   postCompaction: SessionCompactionTranscriptReference;
 };
 
+export type SessionContextBudgetStatusRoute =
+  | "fits"
+  | "compact_only"
+  | "truncate_tool_results_only"
+  | "compact_then_truncate";
+
+export type SessionContextBudgetStatus = {
+  schemaVersion: 1;
+  source: "pre-prompt-estimate";
+  updatedAt: number;
+  provider: string;
+  model: string;
+  route: SessionContextBudgetStatusRoute;
+  shouldCompact: boolean;
+  estimatedPromptTokens: number;
+  contextTokenBudget: number;
+  promptBudgetBeforeReserve: number;
+  reserveTokens: number;
+  effectiveReserveTokens: number;
+  remainingPromptBudgetTokens: number;
+  overflowTokens: number;
+  toolResultReducibleChars: number;
+  messageCount: number;
+  unwindowedMessageCount: number;
+  sessionId?: string;
+  sessionFile?: string;
+};
+
 export type SessionPluginDebugEntry = {
   pluginId: string;
   lines: string[];
@@ -336,6 +364,7 @@ export type SessionEntry = {
   fallbackNoticeActiveModel?: string;
   fallbackNoticeReason?: string;
   contextTokens?: number;
+  contextBudgetStatus?: SessionContextBudgetStatus;
   compactionCount?: number;
   compactionCheckpoints?: SessionCompactionCheckpoint[];
   memoryFlushAt?: number;

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -335,6 +335,41 @@ describe("gateway session utils", () => {
     });
   });
 
+  test("session rows expose derived context budget pressure", () => {
+    const row = buildGatewaySessionRow({
+      cfg: createModelDefaultsConfig({ primary: "anthropic/claude-opus-4-6" }),
+      storePath: "",
+      store: {},
+      key: "agent:main:main",
+      entry: {
+        sessionId: "session-1",
+        updatedAt: 1,
+        contextBudgetStatus: {
+          schemaVersion: 1,
+          source: "pre-prompt-estimate",
+          updatedAt: 1,
+          provider: "anthropic",
+          model: "claude-opus-4-6",
+          route: "fits",
+          shouldCompact: false,
+          estimatedPromptTokens: 640_000,
+          contextTokenBudget: 1_000_000,
+          promptBudgetBeforeReserve: 900_000,
+          reserveTokens: 100_000,
+          effectiveReserveTokens: 100_000,
+          remainingPromptBudgetTokens: 260_000,
+          overflowTokens: 0,
+          toolResultReducibleChars: 0,
+          messageCount: 2,
+          unwindowedMessageCount: 2,
+        },
+      },
+    });
+
+    expect(row.contextBudgetPressure).toBe("watch");
+    expect(row.contextBudgetStatus?.estimatedPromptTokens).toBe(640_000);
+  });
+
   test("async session list reuses thinking metadata for lightweight rows", async () => {
     const resolveThinkingProfile = vi.fn(() => ({
       levels: [{ id: "off" as const }, { id: "medium" as const }],

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -50,6 +50,7 @@ import {
   resolveAllAgentSessionStoreTargetsSync,
   resolveAgentMainSessionKey,
   resolveFreshSessionTotalTokens,
+  resolveSessionContextBudgetPolicy,
   resolveStorePath,
   type SessionEntry,
   type SessionStoreTarget,
@@ -1861,6 +1862,7 @@ export function buildGatewaySessionRow(params: {
           allowAsyncLoad: false,
         }),
       ));
+  const contextBudgetPolicy = resolveSessionContextBudgetPolicy(entry?.contextBudgetStatus);
 
   let derivedTitle: string | undefined;
   let lastMessagePreview: string | undefined;
@@ -1946,6 +1948,7 @@ export function buildGatewaySessionRow(params: {
     agentRuntime,
     contextTokens,
     contextBudgetStatus: entry?.contextBudgetStatus,
+    contextBudgetPressure: contextBudgetPolicy?.pressure,
     deliveryContext: deliveryFields.deliveryContext,
     lastChannel: deliveryFields.lastChannel ?? entry?.lastChannel,
     lastTo: deliveryFields.lastTo ?? entry?.lastTo,

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1945,6 +1945,7 @@ export function buildGatewaySessionRow(params: {
     model: rowModel,
     agentRuntime,
     contextTokens,
+    contextBudgetStatus: entry?.contextBudgetStatus,
     deliveryContext: deliveryFields.deliveryContext,
     lastChannel: deliveryFields.lastChannel ?? entry?.lastChannel,
     lastTo: deliveryFields.lastTo ?? entry?.lastTo,

--- a/src/gateway/session-utils.types.ts
+++ b/src/gateway/session-utils.types.ts
@@ -84,6 +84,7 @@ export type GatewaySessionRow = {
   model?: string;
   agentRuntime?: GatewayAgentRuntime;
   contextTokens?: number;
+  contextBudgetStatus?: SessionEntry["contextBudgetStatus"];
   deliveryContext?: DeliveryContext;
   lastChannel?: SessionEntry["lastChannel"];
   lastTo?: string;

--- a/src/gateway/session-utils.types.ts
+++ b/src/gateway/session-utils.types.ts
@@ -1,5 +1,9 @@
 import type { ChatType } from "../channels/chat-type.js";
-import type { SessionCompactionCheckpoint, SessionEntry } from "../config/sessions/types.js";
+import type {
+  SessionCompactionCheckpoint,
+  SessionContextBudgetPressure,
+  SessionEntry,
+} from "../config/sessions.js";
 import type { PluginSessionExtensionProjection } from "../plugins/host-hooks.js";
 import type {
   GatewayAgentRuntime,
@@ -85,6 +89,7 @@ export type GatewaySessionRow = {
   agentRuntime?: GatewayAgentRuntime;
   contextTokens?: number;
   contextBudgetStatus?: SessionEntry["contextBudgetStatus"];
+  contextBudgetPressure?: SessionContextBudgetPressure;
   deliveryContext?: DeliveryContext;
   lastChannel?: SessionEntry["lastChannel"];
   lastTo?: string;

--- a/src/plugins/session-entry-slot-keys.ts
+++ b/src/plugins/session-entry-slot-keys.ts
@@ -91,6 +91,7 @@ const SESSION_ENTRY_RESERVED_SLOT_KEY_LIST = [
   "fallbackNoticeActiveModel",
   "fallbackNoticeReason",
   "contextTokens",
+  "contextBudgetStatus",
   "compactionCount",
   "compactionCheckpoints",
   "memoryFlushAt",

--- a/src/status/status-message.ts
+++ b/src/status/status-message.ts
@@ -213,6 +213,36 @@ const formatTokens = (total: number | null | undefined, contextTokens: number | 
   return `${totalLabel}/${ctxLabel}${pct !== null ? ` (${pct}%)` : ""}`;
 };
 
+const formatEstimatedContextBudgetTokens = (
+  status: SessionEntry["contextBudgetStatus"] | undefined,
+  contextTokens: number | null | undefined,
+) => {
+  if (!status || status.source !== "pre-prompt-estimate") {
+    return null;
+  }
+  const estimatedPromptTokens =
+    typeof status.estimatedPromptTokens === "number" &&
+    Number.isFinite(status.estimatedPromptTokens) &&
+    status.estimatedPromptTokens >= 0
+      ? Math.floor(status.estimatedPromptTokens)
+      : undefined;
+  if (estimatedPromptTokens === undefined) {
+    return null;
+  }
+  const ctx =
+    typeof contextTokens === "number" && Number.isFinite(contextTokens) && contextTokens > 0
+      ? contextTokens
+      : typeof status.contextTokenBudget === "number" &&
+          Number.isFinite(status.contextTokenBudget) &&
+          status.contextTokenBudget > 0
+        ? status.contextTokenBudget
+        : undefined;
+  const pct = ctx ? Math.min(999, Math.round((estimatedPromptTokens / ctx) * 100)) : null;
+  const totalLabel = formatTokenCount(estimatedPromptTokens);
+  const ctxLabel = ctx ? formatTokenCount(ctx) : "?";
+  return `~${totalLabel}/${ctxLabel}${pct !== null ? ` (${pct}% est)` : " (est)"}`;
+};
+
 export const formatContextUsageShort = (
   total: number | null | undefined,
   contextTokens: number | null | undefined,
@@ -822,8 +852,13 @@ export function buildStatusMessage(args: StatusArgs): string {
     ? (args.groupActivation ?? entry?.groupActivation ?? "mention")
     : undefined;
 
+  const contextUsageLabel =
+    totalTokens == null || totalTokens === 0
+      ? (formatEstimatedContextBudgetTokens(entry?.contextBudgetStatus, contextTokens) ??
+        formatTokens(totalTokens, contextTokens ?? null))
+      : formatTokens(totalTokens, contextTokens ?? null);
   const contextLine = [
-    `Context: ${formatTokens(totalTokens, contextTokens ?? null)}`,
+    `Context: ${contextUsageLabel}`,
     `🧹 Compactions: ${entry?.compactionCount ?? 0}`,
   ]
     .filter(Boolean)

--- a/src/status/status-message.ts
+++ b/src/status/status-message.ts
@@ -29,7 +29,9 @@ import {
   resolveSessionPluginStatusLines,
   resolveSessionPluginTraceLines,
   resolveFreshSessionTotalTokens,
+  resolveSessionContextBudgetPolicy,
   type SessionEntry,
+  type SessionContextBudgetPressure,
   type SessionScope,
 } from "../config/sessions.js";
 import { hasSessionAutoModelFallbackProvenance } from "../config/sessions/model-override-provenance.js";
@@ -241,6 +243,13 @@ const formatEstimatedContextBudgetTokens = (
   const totalLabel = formatTokenCount(estimatedPromptTokens);
   const ctxLabel = ctx ? formatTokenCount(ctx) : "?";
   return `~${totalLabel}/${ctxLabel}${pct !== null ? ` (${pct}% est)` : " (est)"}`;
+};
+
+const formatContextBudgetPressure = (pressure: SessionContextBudgetPressure | undefined) => {
+  if (!pressure) {
+    return null;
+  }
+  return `Budget: ${pressure}`;
 };
 
 export const formatContextUsageShort = (
@@ -857,8 +866,10 @@ export function buildStatusMessage(args: StatusArgs): string {
       ? (formatEstimatedContextBudgetTokens(entry?.contextBudgetStatus, contextTokens) ??
         formatTokens(totalTokens, contextTokens ?? null))
       : formatTokens(totalTokens, contextTokens ?? null);
+  const contextBudgetPolicy = resolveSessionContextBudgetPolicy(entry?.contextBudgetStatus);
   const contextLine = [
     `Context: ${contextUsageLabel}`,
+    formatContextBudgetPressure(contextBudgetPolicy?.pressure),
     `🧹 Compactions: ${entry?.compactionCount ?? 0}`,
   ]
     .filter(Boolean)


### PR DESCRIPTION
## Summary

Budget 3 in the context-budget stack, logically based on #84785. GitHub base is #84676 because #84785 is currently a fork-head branch; after #84785 lands or its branch is available upstream, this diff should collapse to the final budget-pressure commit.

This keeps budget management reporting-only and adds the first shared policy vocabulary on top of the persisted `contextBudgetStatus` snapshot:

- add `resolveSessionContextBudgetPolicy(...)` with conservative pressure levels: `safe`, `watch`, `pressure`, and `overflow-risk`
- classify against the prompt budget before reserve, so the policy reflects actual pre-prompt room instead of only raw context-window percentage
- show the derived pressure in status as `Budget: ...` without changing the authoritative context token count
- expose `contextBudgetPressure` on gateway session rows for UI/API consumers

This PR intentionally does not change compaction, truncation, or prompt-building behavior. It gives reviewers names and thresholds to tune before a later behavior PR starts acting on the pressure level.

Refs #80594, #54996, #77992, #84490, #83177, #43009, #83526, #8635.

## Verification

Behavior addressed: OpenClaw can now classify the stored pre-prompt estimate into a shared context budget pressure level, and status/gateway consumers can see that level without changing runtime behavior.

Real environment tested: Windows worktree `C:\src\claws-hapi-budget2`, stacked on #84785 (`eb4b8af6f3`). The worktree uses a local `node_modules` junction to the main checkout's installed dependencies; no lockfile or dependency install changes were made.

Exact steps or command run after this patch:

- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/budget3.tsbuildinfo`
- `node_modules\.bin\oxfmt.CMD --check src/config/sessions/context-budget-policy.ts src/config/sessions/context-budget-policy.test.ts src/config/sessions.ts src/status/status-message.ts src/auto-reply/status.test.ts src/gateway/session-utils.ts src/gateway/session-utils.types.ts src/gateway/session-utils.test.ts`
- `git diff --check`
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=.artifacts/vitest-cache/budget3-policy node scripts/run-vitest.mjs src/config/sessions/context-budget-policy.test.ts`
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=.artifacts/vitest-cache/budget3-status node scripts/run-vitest.mjs src/auto-reply/status.test.ts -t "uses estimated context budget status"`
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=.artifacts/vitest-cache/budget3-status-fresh node scripts/run-vitest.mjs src/auto-reply/status.test.ts -t "prefers fresh totalTokens over estimated context budget status"`
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=.artifacts/vitest-cache/budget3-gateway node scripts/run-vitest.mjs src/gateway/session-utils.test.ts -t "session rows expose derived context budget pressure"`

Evidence after fix: Focused tests prove the safe/watch/pressure/overflow-risk classifier, status rendering of `Budget: safe/watch`, fresh-token precedence, and gateway row exposure. `tsgo`, `oxfmt --check`, and `git diff --check` are clean.

Observed result after fix: Status can render lines such as `Context: ~640k/1.0m (64% est) · Budget: watch`, while fresh usage still renders its real total and only adds the budget pressure as separate policy metadata. Gateway rows expose `contextBudgetPressure: "watch"` for the same snapshot.

What was not tested: Broad `pnpm check:changed` and full Vitest files were not run locally. The focused node-wrapper tests were used because broad pnpm-gated proof is expensive in this Codex worktree and direct parallel Vitest has cache-race risk here.

## Review Notes

Automated Codex review was attempted with `codex review --uncommitted`, but nested Codex could not inspect the diff because every shell command failed with Windows sandbox error `CreateProcessAsUserW failed: 1312`. I did a manual diff review after that and tightened the gateway type import to use the sessions barrel.

