### PR TITLE
doctor: constrain legacy plugin cleanup paths [AI]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- doctor: constrain legacy plugin cleanup paths [AI]. (#84801) Thanks @pgondhi987.
 - Media/audio: skip empty structured sherpa-onnx transcripts instead of treating the raw JSON payload as spoken text. (#84667) Thanks @TurboTheTurtle.
 - Node/Linux: keep `OPENCLAW_GATEWAY_TOKEN` out of generated systemd unit files by writing node service token values to a node-specific env file. (#84408)
 - Memory-core/dreaming: reuse stable narrative subagent session keys per workspace and phase while keeping per-run idempotency and bounded cleanup, so stale `dreaming-narrative-*` sessions do not accumulate. Fixes #68252, #69187, and #70402. (#70464) Thanks @chiyouYCH.

--- a/scripts/e2e/status-corrupt-plugin-deps.sh
+++ b/scripts/e2e/status-corrupt-plugin-deps.sh
@@ -14,7 +14,7 @@ HOME_DIR="$TMP_DIR/home"
 STATE_DIR="$TMP_DIR/state"
 CONFIG_PATH="$TMP_DIR/openclaw.json"
 PLUGIN_DIR="$TMP_DIR/plugin"
-STAGE_DIR="$TMP_DIR/.openclaw-install-stage-corrupt-plugin-deps"
+STAGE_DIR="$TMP_DIR/stage"
 mkdir -p "$HOME_DIR" "$STATE_DIR" "$PLUGIN_DIR" "$STAGE_DIR/node_modules/ansi-escapes"
 printf "corrupt rename residue\n" > "$STAGE_DIR/node_modules/ansi-escapes/.openclaw-rename-tmp"
 

--- a/scripts/e2e/status-corrupt-plugin-deps.sh
+++ b/scripts/e2e/status-corrupt-plugin-deps.sh
@@ -14,7 +14,7 @@ HOME_DIR="$TMP_DIR/home"
 STATE_DIR="$TMP_DIR/state"
 CONFIG_PATH="$TMP_DIR/openclaw.json"
 PLUGIN_DIR="$TMP_DIR/plugin"
-STAGE_DIR="$TMP_DIR/stage"
+STAGE_DIR="$TMP_DIR/.openclaw-install-stage-corrupt-plugin-deps"
 mkdir -p "$HOME_DIR" "$STATE_DIR" "$PLUGIN_DIR" "$STAGE_DIR/node_modules/ansi-escapes"
 printf "corrupt rename residue\n" > "$STAGE_DIR/node_modules/ansi-escapes/.openclaw-rename-tmp"
 

--- a/src/commands/doctor/shared/plugin-dependency-cleanup.test.ts
+++ b/src/commands/doctor/shared/plugin-dependency-cleanup.test.ts
@@ -14,6 +14,10 @@ async function expectPathMissing(targetPath: string): Promise<void> {
   throw new Error(`expected path to be missing: ${targetPath}`);
 }
 
+async function expectDirectoryPresent(targetPath: string): Promise<void> {
+  expect((await fs.stat(targetPath)).isDirectory()).toBe(true);
+}
+
 describe("cleanupLegacyPluginDependencyState", () => {
   let tempDir: string;
 
@@ -27,7 +31,7 @@ describe("cleanupLegacyPluginDependencyState", () => {
 
   it("collects and removes legacy plugin dependency state roots", async () => {
     const stateDir = path.join(tempDir, "state");
-    const explicitStageDir = path.join(tempDir, "explicit-stage");
+    const explicitStageDir = path.join(stateDir, ".openclaw-install-stage-explicit");
     const stateDirectory = path.join(tempDir, "systemd-state");
     const packageRoot = path.join(tempDir, "package");
     const legacyRuntimeRoot = path.join(stateDir, "plugin-runtime-deps");
@@ -93,9 +97,97 @@ describe("cleanupLegacyPluginDependencyState", () => {
     await expectPathMissing(legacyExtensionNodeModules);
     await expectPathMissing(legacyExtensionStamp);
     await expectPathMissing(legacyManifest);
-    expect((await fs.stat(thirdPartyNodeModules)).isDirectory()).toBe(true);
+    await expectDirectoryPresent(thirdPartyNodeModules);
     await expectPathMissing(explicitStageDir);
     await expectPathMissing(path.join(stateDirectory, "plugin-runtime-deps"));
+  });
+
+  it("refuses explicit cleanup paths outside OpenClaw roots", async () => {
+    const stateDir = path.join(tempDir, "state");
+    const packageRoot = path.join(tempDir, "package");
+    const absoluteEscape = path.join(tempDir, "absolute-escape", ".openclaw-install-stage-abs");
+    const dotDotEscape = path.join(
+      stateDir,
+      "..",
+      "dotdot-escape",
+      ".openclaw-install-stage-dotdot",
+    );
+
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.mkdir(packageRoot, { recursive: true });
+    await fs.mkdir(absoluteEscape, { recursive: true });
+    await fs.mkdir(dotDotEscape, { recursive: true });
+
+    const result = await cleanupLegacyPluginDependencyState({
+      env: {
+        OPENCLAW_STATE_DIR: stateDir,
+        OPENCLAW_PLUGIN_STAGE_DIR: [absoluteEscape, dotDotEscape].join(path.delimiter),
+      },
+      packageRoot,
+    });
+
+    expect(result.changes).toStrictEqual([]);
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([
+        `Skipped legacy plugin dependency state ${path.resolve(absoluteEscape)}: outside OpenClaw cleanup roots`,
+        `Skipped legacy plugin dependency state ${path.resolve(dotDotEscape)}: outside OpenClaw cleanup roots`,
+      ]),
+    );
+    await expectDirectoryPresent(absoluteEscape);
+    await expectDirectoryPresent(dotDotEscape);
+  });
+
+  it("does not follow symlinked extension roots outside OpenClaw roots", async () => {
+    const stateDir = path.join(tempDir, "state");
+    const packageRoot = path.join(tempDir, "package");
+    const extensionsRoot = path.join(packageRoot, "extensions");
+    const linkedPlugin = path.join(extensionsRoot, "linked-plugin");
+    const externalPlugin = path.join(tempDir, "external-plugin");
+    const externalNodeModules = path.join(externalPlugin, "node_modules");
+
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.mkdir(extensionsRoot, { recursive: true });
+    await fs.mkdir(externalNodeModules, { recursive: true });
+    await fs.writeFile(path.join(externalPlugin, ".openclaw-runtime-deps.json"), "{}");
+    await fs.symlink(externalPlugin, linkedPlugin, "dir");
+
+    const targets = await testing.collectLegacyPluginDependencyTargets(
+      { OPENCLAW_STATE_DIR: stateDir },
+      { packageRoot },
+    );
+    expect(targets).not.toContain(path.join(linkedPlugin, "node_modules"));
+
+    const result = await cleanupLegacyPluginDependencyState({
+      env: { OPENCLAW_STATE_DIR: stateDir },
+      packageRoot,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    await expectDirectoryPresent(externalNodeModules);
+  });
+
+  it("refuses legacy roots that resolve outside OpenClaw roots", async () => {
+    const stateDir = path.join(tempDir, "state");
+    const packageRoot = path.join(tempDir, "package");
+    const legacyRuntimeRoot = path.join(stateDir, "plugin-runtime-deps");
+    const externalRuntimeRoot = path.join(tempDir, "external-runtime");
+
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.mkdir(packageRoot, { recursive: true });
+    await fs.mkdir(externalRuntimeRoot, { recursive: true });
+    await fs.symlink(externalRuntimeRoot, legacyRuntimeRoot, "dir");
+
+    const result = await cleanupLegacyPluginDependencyState({
+      env: { OPENCLAW_STATE_DIR: stateDir },
+      packageRoot,
+    });
+
+    expect(result.changes).toStrictEqual([]);
+    expect(result.warnings).toContain(
+      `Skipped legacy plugin dependency state ${legacyRuntimeRoot}: resolved outside OpenClaw cleanup roots`,
+    );
+    expect((await fs.lstat(legacyRuntimeRoot)).isSymbolicLink()).toBe(true);
+    await expectDirectoryPresent(externalRuntimeRoot);
   });
 
   it("removes dangling global plugin-runtime symlinks that point at legacy runtime deps", async () => {

--- a/src/commands/doctor/shared/plugin-dependency-cleanup.test.ts
+++ b/src/commands/doctor/shared/plugin-dependency-cleanup.test.ts
@@ -230,6 +230,46 @@ describe("cleanupLegacyPluginDependencyState", () => {
     await expectDirectoryPresent(externalRuntimeRoot);
   });
 
+  it("does not unlink global runtime symlinks through unsafe cleanup roots", async () => {
+    const stateDir = path.join(tempDir, "state");
+    const packageRoot = path.join(tempDir, "prefix", "lib", "node_modules", "openclaw");
+    const nodeModulesRoot = path.dirname(packageRoot);
+    const legacyRuntimeRoot = path.join(stateDir, "plugin-runtime-deps");
+    const externalRuntimeRoot = path.join(tempDir, "external-runtime");
+    const activeRuntimeTarget = path.join(
+      externalRuntimeRoot,
+      "openclaw-external",
+      "node_modules",
+      "left-pad",
+    );
+    const unsafeRuntimeTarget = path.join(
+      legacyRuntimeRoot,
+      "openclaw-external",
+      "node_modules",
+      "left-pad",
+    );
+    const leftPadLink = path.join(nodeModulesRoot, "left-pad");
+
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.mkdir(packageRoot, { recursive: true });
+    await fs.mkdir(activeRuntimeTarget, { recursive: true });
+    await fs.symlink(externalRuntimeRoot, legacyRuntimeRoot, "dir");
+    await fs.symlink(unsafeRuntimeTarget, leftPadLink, "dir");
+
+    const result = await cleanupLegacyPluginDependencyState({
+      env: { OPENCLAW_STATE_DIR: stateDir },
+      packageRoot,
+    });
+
+    expect(result.changes).toStrictEqual([]);
+    expect(result.warnings).toContain(
+      `Skipped legacy plugin dependency state ${legacyRuntimeRoot}: resolved outside OpenClaw cleanup roots`,
+    );
+    expect((await fs.lstat(leftPadLink)).isSymbolicLink()).toBe(true);
+    expect((await fs.lstat(legacyRuntimeRoot)).isSymbolicLink()).toBe(true);
+    await expectDirectoryPresent(activeRuntimeTarget);
+  });
+
   it("removes dangling global plugin-runtime symlinks that point at legacy runtime deps", async () => {
     const stateDir = path.join(tempDir, "state");
     const packageRoot = path.join(tempDir, "prefix", "lib", "node_modules", "openclaw");

--- a/src/commands/doctor/shared/plugin-dependency-cleanup.test.ts
+++ b/src/commands/doctor/shared/plugin-dependency-cleanup.test.ts
@@ -105,7 +105,7 @@ describe("cleanupLegacyPluginDependencyState", () => {
   it("removes configured plugin stage roots outside OpenClaw roots", async () => {
     const stateDir = path.join(tempDir, "state");
     const packageRoot = path.join(tempDir, "package");
-    const stageRoot = path.join(tempDir, "stage");
+    const stageRoot = path.join(tempDir, ".openclaw-install-stage-corrupt");
 
     await fs.mkdir(stateDir, { recursive: true });
     await fs.mkdir(packageRoot, { recursive: true });
@@ -124,10 +124,34 @@ describe("cleanupLegacyPluginDependencyState", () => {
     await expectPathMissing(stageRoot);
   });
 
+  it("refuses arbitrary explicit plugin stage roots outside OpenClaw roots", async () => {
+    const stateDir = path.join(tempDir, "state");
+    const packageRoot = path.join(tempDir, "package");
+    const stageRoot = path.join(tempDir, "stage");
+
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.mkdir(packageRoot, { recursive: true });
+    await fs.mkdir(path.join(stageRoot, "node_modules", "ansi-escapes"), { recursive: true });
+
+    const result = await cleanupLegacyPluginDependencyState({
+      env: {
+        OPENCLAW_STATE_DIR: stateDir,
+        OPENCLAW_PLUGIN_STAGE_DIR: stageRoot,
+      },
+      packageRoot,
+    });
+
+    expect(result.changes).toStrictEqual([]);
+    expect(result.warnings).toContain(
+      `Skipped legacy plugin dependency state ${stageRoot}: unexpected path name`,
+    );
+    await expectDirectoryPresent(stageRoot);
+  });
+
   it("refuses explicit plugin stage paths with parent segments", async () => {
     const stateDir = path.join(tempDir, "state");
     const packageRoot = path.join(tempDir, "package");
-    const dotDotStage = `${stateDir}${path.sep}..${path.sep}dotdot-stage`;
+    const dotDotStage = `${stateDir}${path.sep}..${path.sep}.openclaw-install-stage-dotdot`;
     const resolvedDotDotStage = path.resolve(dotDotStage);
 
     await fs.mkdir(stateDir, { recursive: true });

--- a/src/commands/doctor/shared/plugin-dependency-cleanup.test.ts
+++ b/src/commands/doctor/shared/plugin-dependency-cleanup.test.ts
@@ -105,11 +105,15 @@ describe("cleanupLegacyPluginDependencyState", () => {
   it("removes configured plugin stage roots outside OpenClaw roots", async () => {
     const stateDir = path.join(tempDir, "state");
     const packageRoot = path.join(tempDir, "package");
-    const stageRoot = path.join(tempDir, ".openclaw-install-stage-corrupt");
+    const stageRoot = path.join(tempDir, "stage");
 
     await fs.mkdir(stateDir, { recursive: true });
     await fs.mkdir(packageRoot, { recursive: true });
     await fs.mkdir(path.join(stageRoot, "node_modules", "ansi-escapes"), { recursive: true });
+    await fs.writeFile(
+      path.join(stageRoot, "node_modules", "ansi-escapes", ".openclaw-rename-tmp"),
+      "corrupt rename residue\n",
+    );
 
     const result = await cleanupLegacyPluginDependencyState({
       env: {
@@ -127,7 +131,7 @@ describe("cleanupLegacyPluginDependencyState", () => {
   it("refuses arbitrary explicit plugin stage roots outside OpenClaw roots", async () => {
     const stateDir = path.join(tempDir, "state");
     const packageRoot = path.join(tempDir, "package");
-    const stageRoot = path.join(tempDir, "stage");
+    const stageRoot = path.join(tempDir, "stage-without-marker");
 
     await fs.mkdir(stateDir, { recursive: true });
     await fs.mkdir(packageRoot, { recursive: true });

--- a/src/commands/doctor/shared/plugin-dependency-cleanup.test.ts
+++ b/src/commands/doctor/shared/plugin-dependency-cleanup.test.ts
@@ -102,39 +102,51 @@ describe("cleanupLegacyPluginDependencyState", () => {
     await expectPathMissing(path.join(stateDirectory, "plugin-runtime-deps"));
   });
 
-  it("refuses explicit cleanup paths outside OpenClaw roots", async () => {
+  it("removes configured plugin stage roots outside OpenClaw roots", async () => {
     const stateDir = path.join(tempDir, "state");
     const packageRoot = path.join(tempDir, "package");
-    const absoluteEscape = path.join(tempDir, "absolute-escape", ".openclaw-install-stage-abs");
-    const dotDotEscape = path.join(
-      stateDir,
-      "..",
-      "dotdot-escape",
-      ".openclaw-install-stage-dotdot",
-    );
+    const stageRoot = path.join(tempDir, "stage");
 
     await fs.mkdir(stateDir, { recursive: true });
     await fs.mkdir(packageRoot, { recursive: true });
-    await fs.mkdir(absoluteEscape, { recursive: true });
-    await fs.mkdir(dotDotEscape, { recursive: true });
+    await fs.mkdir(path.join(stageRoot, "node_modules", "ansi-escapes"), { recursive: true });
 
     const result = await cleanupLegacyPluginDependencyState({
       env: {
         OPENCLAW_STATE_DIR: stateDir,
-        OPENCLAW_PLUGIN_STAGE_DIR: [absoluteEscape, dotDotEscape].join(path.delimiter),
+        OPENCLAW_PLUGIN_STAGE_DIR: stageRoot,
+      },
+      packageRoot,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toContain(`Removed legacy plugin dependency state: ${stageRoot}`);
+    await expectPathMissing(stageRoot);
+  });
+
+  it("refuses explicit plugin stage paths with parent segments", async () => {
+    const stateDir = path.join(tempDir, "state");
+    const packageRoot = path.join(tempDir, "package");
+    const dotDotStage = `${stateDir}${path.sep}..${path.sep}dotdot-stage`;
+    const resolvedDotDotStage = path.resolve(dotDotStage);
+
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.mkdir(packageRoot, { recursive: true });
+    await fs.mkdir(resolvedDotDotStage, { recursive: true });
+
+    const result = await cleanupLegacyPluginDependencyState({
+      env: {
+        OPENCLAW_STATE_DIR: stateDir,
+        OPENCLAW_PLUGIN_STAGE_DIR: dotDotStage,
       },
       packageRoot,
     });
 
     expect(result.changes).toStrictEqual([]);
-    expect(result.warnings).toEqual(
-      expect.arrayContaining([
-        `Skipped legacy plugin dependency state ${path.resolve(absoluteEscape)}: outside OpenClaw cleanup roots`,
-        `Skipped legacy plugin dependency state ${path.resolve(dotDotEscape)}: outside OpenClaw cleanup roots`,
-      ]),
+    expect(result.warnings).toContain(
+      `Skipped legacy plugin dependency state ${resolvedDotDotStage}: parent path segments are not allowed`,
     );
-    await expectDirectoryPresent(absoluteEscape);
-    await expectDirectoryPresent(dotDotEscape);
+    await expectDirectoryPresent(resolvedDotDotStage);
   });
 
   it("does not follow symlinked extension roots outside OpenClaw roots", async () => {

--- a/src/commands/doctor/shared/plugin-dependency-cleanup.ts
+++ b/src/commands/doctor/shared/plugin-dependency-cleanup.ts
@@ -296,6 +296,32 @@ async function resolveSafeRemovalTarget(
   return { target: targetPath };
 }
 
+async function prepareCleanupTargets(
+  targets: readonly CleanupTarget[],
+  cleanupRoots: readonly CleanupRoot[],
+): Promise<{ removalTargets: string[]; staleRoots: string[]; warnings: string[] }> {
+  const removalTargets: string[] = [];
+  const staleRoots: string[] = [];
+  const warnings: string[] = [];
+  for (const target of targets) {
+    if (!(await pathExists(target.path))) {
+      continue;
+    }
+    const safeTarget = await resolveSafeRemovalTarget(target, cleanupRoots);
+    if ("warning" in safeTarget) {
+      warnings.push(safeTarget.warning);
+      continue;
+    }
+    removalTargets.push(safeTarget.target);
+    staleRoots.push(safeTarget.target);
+  }
+  return {
+    removalTargets: uniqueSorted(removalTargets),
+    staleRoots: uniqueSorted(staleRoots),
+    warnings,
+  };
+}
+
 async function collectLegacyPluginDependencyTargetEntries(
   env: NodeJS.ProcessEnv = process.env,
   options: { packageRoot?: string | null } = {},
@@ -379,27 +405,19 @@ export async function cleanupLegacyPluginDependencyState(params: {
   const cleanupRoots = await collectExistingCleanupRoots(cleanupRootPaths);
   const staleRootCandidates = filterLegacyStaleRootCandidates(targets, cleanupRootPaths);
   warnings.push(...staleRootCandidates.warnings);
+  const preparedTargets = await prepareCleanupTargets(staleRootCandidates.targets, cleanupRoots);
+  warnings.push(...preparedTargets.warnings);
   const staleSymlinks = await removeStalePluginRuntimeSymlinks(packageRoot, {
-    staleRoots: staleRootCandidates.targets.map((target) => target.path),
+    staleRoots: preparedTargets.staleRoots,
   });
   changes.push(...staleSymlinks.changes);
   warnings.push(...staleSymlinks.warnings);
-  for (const target of staleRootCandidates.targets) {
-    if (!(await pathExists(target.path))) {
-      continue;
-    }
-    const safeTarget = await resolveSafeRemovalTarget(target, cleanupRoots);
-    if ("warning" in safeTarget) {
-      warnings.push(safeTarget.warning);
-      continue;
-    }
+  for (const target of preparedTargets.removalTargets) {
     try {
-      await fs.rm(safeTarget.target, { recursive: true, force: true });
-      changes.push(`Removed legacy plugin dependency state: ${safeTarget.target}`);
+      await fs.rm(target, { recursive: true, force: true });
+      changes.push(`Removed legacy plugin dependency state: ${target}`);
     } catch (error) {
-      warnings.push(
-        `Failed to remove legacy plugin dependency state ${safeTarget.target}: ${String(error)}`,
-      );
+      warnings.push(`Failed to remove legacy plugin dependency state ${target}: ${String(error)}`);
     }
   }
   return { changes, warnings };

--- a/src/commands/doctor/shared/plugin-dependency-cleanup.ts
+++ b/src/commands/doctor/shared/plugin-dependency-cleanup.ts
@@ -57,12 +57,16 @@ function isRuntimeDependencyMarkerName(name: string): boolean {
   );
 }
 
+function isInstallStageDebrisName(name: string): boolean {
+  return /^\.openclaw-install-stage(?:-.+)?$/u.test(name);
+}
+
 function isLegacyDependencyDebrisName(name: string): boolean {
   return (
     isRuntimeDependencyMarkerName(name) ||
     name === ".openclaw-pnpm-store" ||
     name === ".openclaw-install-backups" ||
-    name.startsWith(".openclaw-install-stage-")
+    isInstallStageDebrisName(name)
   );
 }
 
@@ -186,6 +190,10 @@ function filterLegacyStaleRootCandidates(
     }
     seen.add(targetPath);
     if (target.kind === "explicit-stage") {
+      if (!isInstallStageDebrisName(path.basename(targetPath))) {
+        warnings.push(`Skipped legacy plugin dependency state ${targetPath}: unexpected path name`);
+        continue;
+      }
       if (target.rawPath && hasParentPathSegment(target.rawPath)) {
         warnings.push(
           `Skipped legacy plugin dependency state ${targetPath}: parent path segments are not allowed`,

--- a/src/commands/doctor/shared/plugin-dependency-cleanup.ts
+++ b/src/commands/doctor/shared/plugin-dependency-cleanup.ts
@@ -7,6 +7,10 @@ import { removeStalePluginRuntimeSymlinks } from "./plugin-runtime-symlinks.js";
 
 const LEGACY_DIRECT_CHILD_NAMES = new Set(["plugin-runtime-deps", "bundled-plugin-runtime-deps"]);
 
+interface CleanupRoot {
+  readonly realPath: string;
+}
+
 function uniqueSorted(values: Iterable<string | null | undefined>): string[] {
   return [
     ...new Set(
@@ -52,12 +56,43 @@ function isLegacyDependencyDebrisName(name: string): boolean {
   );
 }
 
+function isExpectedLegacyCleanupTargetName(name: string): boolean {
+  return (
+    name === "node_modules" ||
+    LEGACY_DIRECT_CHILD_NAMES.has(name) ||
+    isLegacyDependencyDebrisName(name)
+  );
+}
+
+function isPathInsideRoot(candidate: string, root: string): boolean {
+  const relativePath = path.relative(root, candidate);
+  return relativePath === "" || (!relativePath.startsWith("..") && !path.isAbsolute(relativePath));
+}
+
 async function collectDirectChildren(root: string): Promise<string[]> {
   const entries = await fs.readdir(root, { withFileTypes: true }).catch(() => []);
   return entries.map((entry) => path.join(root, entry.name));
 }
 
-async function collectLegacyExtensionDebris(extensionsRoot: string): Promise<string[]> {
+async function isDirectoryInCleanupRoot(
+  candidate: string,
+  cleanupRootRealPath: string,
+): Promise<boolean> {
+  const stat = await fs.lstat(candidate).catch(() => null);
+  if (!stat?.isDirectory() && !stat?.isSymbolicLink()) {
+    return false;
+  }
+  const realPath = await fs.realpath(candidate).catch(() => null);
+  return realPath !== null && isPathInsideRoot(realPath, cleanupRootRealPath);
+}
+
+async function collectLegacyExtensionDebris(
+  extensionsRoot: string,
+  cleanupRootRealPath: string,
+): Promise<string[]> {
+  if (!(await isDirectoryInCleanupRoot(extensionsRoot, cleanupRootRealPath))) {
+    return [];
+  }
   const pluginDirs = await fs.readdir(extensionsRoot, { withFileTypes: true }).catch(() => []);
   const targets: string[] = [];
   for (const entry of pluginDirs) {
@@ -65,6 +100,9 @@ async function collectLegacyExtensionDebris(extensionsRoot: string): Promise<str
       continue;
     }
     const pluginRoot = path.join(extensionsRoot, entry.name);
+    if (!(await isDirectoryInCleanupRoot(pluginRoot, cleanupRootRealPath))) {
+      continue;
+    }
     const children = await collectDirectChildren(pluginRoot);
     const hasRuntimeDepsMarker = children.some((childPath) =>
       isRuntimeDependencyMarkerName(path.basename(childPath)),
@@ -81,6 +119,84 @@ async function collectLegacyExtensionDebris(extensionsRoot: string): Promise<str
     }
   }
   return targets;
+}
+
+function collectCleanupRootPaths(
+  env: NodeJS.ProcessEnv,
+  packageRoot: string | null | undefined,
+): string[] {
+  const stateDirectoryRoots = splitPathList(env.STATE_DIRECTORY).map((entry) =>
+    resolveUserPath(entry, env),
+  );
+  return uniqueSorted([
+    resolveStateDir(env),
+    resolveConfigDir(env),
+    packageRoot,
+    ...stateDirectoryRoots,
+  ]);
+}
+
+async function collectExistingCleanupRoots(
+  cleanupRootPaths: readonly string[],
+): Promise<CleanupRoot[]> {
+  const roots: CleanupRoot[] = [];
+  for (const rootPath of cleanupRootPaths) {
+    const stat = await fs.stat(rootPath).catch(() => null);
+    if (!stat?.isDirectory()) {
+      continue;
+    }
+    const realPath = await fs.realpath(rootPath).catch(() => null);
+    if (realPath === null) {
+      continue;
+    }
+    roots.push({ realPath });
+  }
+  return roots;
+}
+
+function filterLegacyStaleRootCandidates(
+  targets: readonly string[],
+  cleanupRootPaths: readonly string[],
+): { targets: string[]; warnings: string[] } {
+  const safeTargets: string[] = [];
+  const warnings: string[] = [];
+  for (const target of targets) {
+    const targetPath = path.resolve(target);
+    if (!isExpectedLegacyCleanupTargetName(path.basename(targetPath))) {
+      warnings.push(`Skipped legacy plugin dependency state ${targetPath}: unexpected path name`);
+      continue;
+    }
+    if (!cleanupRootPaths.some((rootPath) => isPathInsideRoot(targetPath, rootPath))) {
+      warnings.push(
+        `Skipped legacy plugin dependency state ${targetPath}: outside OpenClaw cleanup roots`,
+      );
+      continue;
+    }
+    safeTargets.push(targetPath);
+  }
+  return {
+    targets: uniqueSorted(safeTargets),
+    warnings,
+  };
+}
+
+async function resolveSafeRemovalTarget(
+  target: string,
+  cleanupRoots: readonly CleanupRoot[],
+): Promise<{ target: string } | { warning: string }> {
+  const targetPath = path.resolve(target);
+  const realPath = await fs.realpath(targetPath).catch(() => null);
+  if (realPath === null) {
+    return {
+      warning: `Skipped legacy plugin dependency state ${targetPath}: could not resolve path`,
+    };
+  }
+  if (!cleanupRoots.some((root) => isPathInsideRoot(realPath, root.realPath))) {
+    return {
+      warning: `Skipped legacy plugin dependency state ${targetPath}: resolved outside OpenClaw cleanup roots`,
+    };
+  }
+  return { target: targetPath };
 }
 
 async function collectLegacyPluginDependencyTargets(
@@ -110,8 +226,16 @@ async function collectLegacyPluginDependencyTargets(
     ]),
   ];
   for (const root of roots) {
-    targets.push(...(await collectLegacyExtensionDebris(path.join(root, "extensions"))));
-    targets.push(...(await collectLegacyExtensionDebris(path.join(root, "dist", "extensions"))));
+    const rootRealPath = await fs.realpath(root).catch(() => null);
+    if (rootRealPath === null) {
+      continue;
+    }
+    targets.push(
+      ...(await collectLegacyExtensionDebris(path.join(root, "extensions"), rootRealPath)),
+    );
+    targets.push(
+      ...(await collectLegacyExtensionDebris(path.join(root, "dist", "extensions"), rootRealPath)),
+    );
   }
   return uniqueSorted(targets);
 }
@@ -133,20 +257,31 @@ export async function cleanupLegacyPluginDependencyState(params: {
   const targets = await collectLegacyPluginDependencyTargets(env, {
     packageRoot,
   });
+  const cleanupRootPaths = collectCleanupRootPaths(env, packageRoot);
+  const cleanupRoots = await collectExistingCleanupRoots(cleanupRootPaths);
+  const staleRootCandidates = filterLegacyStaleRootCandidates(targets, cleanupRootPaths);
+  warnings.push(...staleRootCandidates.warnings);
   const staleSymlinks = await removeStalePluginRuntimeSymlinks(packageRoot, {
-    staleRoots: targets,
+    staleRoots: staleRootCandidates.targets,
   });
   changes.push(...staleSymlinks.changes);
   warnings.push(...staleSymlinks.warnings);
-  for (const target of targets) {
+  for (const target of staleRootCandidates.targets) {
     if (!(await pathExists(target))) {
       continue;
     }
+    const safeTarget = await resolveSafeRemovalTarget(target, cleanupRoots);
+    if ("warning" in safeTarget) {
+      warnings.push(safeTarget.warning);
+      continue;
+    }
     try {
-      await fs.rm(target, { recursive: true, force: true });
-      changes.push(`Removed legacy plugin dependency state: ${target}`);
+      await fs.rm(safeTarget.target, { recursive: true, force: true });
+      changes.push(`Removed legacy plugin dependency state: ${safeTarget.target}`);
     } catch (error) {
-      warnings.push(`Failed to remove legacy plugin dependency state ${target}: ${String(error)}`);
+      warnings.push(
+        `Failed to remove legacy plugin dependency state ${safeTarget.target}: ${String(error)}`,
+      );
     }
   }
   return { changes, warnings };

--- a/src/commands/doctor/shared/plugin-dependency-cleanup.ts
+++ b/src/commands/doctor/shared/plugin-dependency-cleanup.ts
@@ -78,6 +78,11 @@ function isExpectedLegacyCleanupTargetName(name: string): boolean {
   );
 }
 
+async function isFile(targetPath: string): Promise<boolean> {
+  const stat = await fs.lstat(targetPath).catch(() => null);
+  return stat?.isFile() === true;
+}
+
 function isPathInsideRoot(candidate: string, root: string): boolean {
   const relativePath = path.relative(root, candidate);
   return relativePath === "" || (!relativePath.startsWith("..") && !path.isAbsolute(relativePath));
@@ -176,6 +181,44 @@ function collectExplicitStageTargets(env: NodeJS.ProcessEnv): CleanupTarget[] {
   }));
 }
 
+async function hasOpenClawRenameResidue(root: string): Promise<boolean> {
+  const nodeModulesRoot = path.join(root, "node_modules");
+  if (await isFile(path.join(nodeModulesRoot, ".openclaw-rename-tmp"))) {
+    return true;
+  }
+  const entries = await fs.readdir(nodeModulesRoot, { withFileTypes: true }).catch(() => []);
+  for (const entry of entries) {
+    if (!entry.isDirectory() || entry.isSymbolicLink()) {
+      continue;
+    }
+    const entryPath = path.join(nodeModulesRoot, entry.name);
+    if (await isFile(path.join(entryPath, ".openclaw-rename-tmp"))) {
+      return true;
+    }
+    if (!entry.name.startsWith("@")) {
+      continue;
+    }
+    const scopedEntries = await fs.readdir(entryPath, { withFileTypes: true }).catch(() => []);
+    for (const scopedEntry of scopedEntries) {
+      if (!scopedEntry.isDirectory() || scopedEntry.isSymbolicLink()) {
+        continue;
+      }
+      if (await isFile(path.join(entryPath, scopedEntry.name, ".openclaw-rename-tmp"))) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+async function hasExplicitStageDebrisProof(root: string): Promise<boolean> {
+  const children = await collectDirectChildren(root);
+  if (children.some((childPath) => isRuntimeDependencyMarkerName(path.basename(childPath)))) {
+    return true;
+  }
+  return await hasOpenClawRenameResidue(root);
+}
+
 function filterLegacyStaleRootCandidates(
   targets: readonly CleanupTarget[],
   cleanupRootPaths: readonly string[],
@@ -190,10 +233,6 @@ function filterLegacyStaleRootCandidates(
     }
     seen.add(targetPath);
     if (target.kind === "explicit-stage") {
-      if (!isInstallStageDebrisName(path.basename(targetPath))) {
-        warnings.push(`Skipped legacy plugin dependency state ${targetPath}: unexpected path name`);
-        continue;
-      }
       if (target.rawPath && hasParentPathSegment(target.rawPath)) {
         warnings.push(
           `Skipped legacy plugin dependency state ${targetPath}: parent path segments are not allowed`,
@@ -239,6 +278,14 @@ async function resolveSafeRemovalTarget(
     };
   }
   if (target.kind === "explicit-stage") {
+    if (
+      !isInstallStageDebrisName(path.basename(targetPath)) &&
+      !(await hasExplicitStageDebrisProof(targetPath))
+    ) {
+      return {
+        warning: `Skipped legacy plugin dependency state ${targetPath}: unexpected path name`,
+      };
+    }
     return { target: targetPath };
   }
   if (!cleanupRoots.some((root) => isPathInsideRoot(realPath, root.realPath))) {

--- a/src/commands/doctor/shared/plugin-dependency-cleanup.ts
+++ b/src/commands/doctor/shared/plugin-dependency-cleanup.ts
@@ -11,6 +11,12 @@ interface CleanupRoot {
   readonly realPath: string;
 }
 
+interface CleanupTarget {
+  readonly kind: "explicit-stage" | "legacy";
+  readonly path: string;
+  readonly rawPath?: string;
+}
+
 function uniqueSorted(values: Iterable<string | null | undefined>): string[] {
   return [
     ...new Set(
@@ -28,6 +34,10 @@ function splitPathList(value: string | undefined): string[] {
         .map((entry) => entry.trim())
         .filter(Boolean)
     : [];
+}
+
+function hasParentPathSegment(value: string): boolean {
+  return value.split(/[\\/]+/u).includes("..");
 }
 
 async function pathExists(targetPath: string): Promise<boolean> {
@@ -154,14 +164,37 @@ async function collectExistingCleanupRoots(
   return roots;
 }
 
+function collectExplicitStageTargets(env: NodeJS.ProcessEnv): CleanupTarget[] {
+  return splitPathList(env.OPENCLAW_PLUGIN_STAGE_DIR).map((entry) => ({
+    kind: "explicit-stage",
+    path: resolveUserPath(entry, env),
+    rawPath: entry,
+  }));
+}
+
 function filterLegacyStaleRootCandidates(
-  targets: readonly string[],
+  targets: readonly CleanupTarget[],
   cleanupRootPaths: readonly string[],
-): { targets: string[]; warnings: string[] } {
-  const safeTargets: string[] = [];
+): { targets: CleanupTarget[]; warnings: string[] } {
+  const safeTargets: CleanupTarget[] = [];
   const warnings: string[] = [];
+  const seen = new Set<string>();
   for (const target of targets) {
-    const targetPath = path.resolve(target);
+    const targetPath = path.resolve(target.path);
+    if (seen.has(targetPath)) {
+      continue;
+    }
+    seen.add(targetPath);
+    if (target.kind === "explicit-stage") {
+      if (target.rawPath && hasParentPathSegment(target.rawPath)) {
+        warnings.push(
+          `Skipped legacy plugin dependency state ${targetPath}: parent path segments are not allowed`,
+        );
+        continue;
+      }
+      safeTargets.push({ ...target, path: targetPath });
+      continue;
+    }
     if (!isExpectedLegacyCleanupTargetName(path.basename(targetPath))) {
       warnings.push(`Skipped legacy plugin dependency state ${targetPath}: unexpected path name`);
       continue;
@@ -172,24 +205,33 @@ function filterLegacyStaleRootCandidates(
       );
       continue;
     }
-    safeTargets.push(targetPath);
+    safeTargets.push({ ...target, path: targetPath });
   }
   return {
-    targets: uniqueSorted(safeTargets),
+    targets: safeTargets.toSorted((left, right) => left.path.localeCompare(right.path)),
     warnings,
   };
 }
 
 async function resolveSafeRemovalTarget(
-  target: string,
+  target: CleanupTarget,
   cleanupRoots: readonly CleanupRoot[],
 ): Promise<{ target: string } | { warning: string }> {
-  const targetPath = path.resolve(target);
+  const targetPath = path.resolve(target.path);
+  const stat = await fs.lstat(targetPath).catch(() => null);
+  if (target.kind === "explicit-stage" && stat?.isSymbolicLink()) {
+    return {
+      warning: `Skipped legacy plugin dependency state ${targetPath}: symbolic link roots are not removed`,
+    };
+  }
   const realPath = await fs.realpath(targetPath).catch(() => null);
   if (realPath === null) {
     return {
       warning: `Skipped legacy plugin dependency state ${targetPath}: could not resolve path`,
     };
+  }
+  if (target.kind === "explicit-stage") {
+    return { target: targetPath };
   }
   if (!cleanupRoots.some((root) => isPathInsideRoot(realPath, root.realPath))) {
     return {
@@ -199,10 +241,10 @@ async function resolveSafeRemovalTarget(
   return { target: targetPath };
 }
 
-async function collectLegacyPluginDependencyTargets(
+async function collectLegacyPluginDependencyTargetEntries(
   env: NodeJS.ProcessEnv = process.env,
   options: { packageRoot?: string | null } = {},
-): Promise<string[]> {
+): Promise<CleanupTarget[]> {
   const packageRoot =
     options.packageRoot ??
     resolveOpenClawPackageRootSync({
@@ -211,18 +253,26 @@ async function collectLegacyPluginDependencyTargets(
       cwd: process.cwd(),
     });
   const roots = uniqueSorted([resolveStateDir(env), resolveConfigDir(env), packageRoot]);
-  const explicitStageRoots = splitPathList(env.OPENCLAW_PLUGIN_STAGE_DIR).map((entry) =>
-    resolveUserPath(entry, env),
+  const stateDirectoryRoots = splitPathList(env.STATE_DIRECTORY).map(
+    (entry): CleanupTarget => ({
+      kind: "legacy",
+      path: path.join(resolveUserPath(entry, env), "plugin-runtime-deps"),
+    }),
   );
-  const stateDirectoryRoots = splitPathList(env.STATE_DIRECTORY).map((entry) =>
-    path.join(resolveUserPath(entry, env), "plugin-runtime-deps"),
-  );
-  const targets = [
-    ...explicitStageRoots,
+  const targets: CleanupTarget[] = [
+    ...collectExplicitStageTargets(env),
     ...stateDirectoryRoots,
     ...roots.flatMap((root) => [
-      ...[...LEGACY_DIRECT_CHILD_NAMES].map((name) => path.join(root, name)),
-      path.join(root, ".local", "bundled-plugin-runtime-deps"),
+      ...[...LEGACY_DIRECT_CHILD_NAMES].map(
+        (name): CleanupTarget => ({
+          kind: "legacy",
+          path: path.join(root, name),
+        }),
+      ),
+      {
+        kind: "legacy",
+        path: path.join(root, ".local", "bundled-plugin-runtime-deps"),
+      },
     ]),
   ];
   for (const root of roots) {
@@ -231,13 +281,26 @@ async function collectLegacyPluginDependencyTargets(
       continue;
     }
     targets.push(
-      ...(await collectLegacyExtensionDebris(path.join(root, "extensions"), rootRealPath)),
+      ...(await collectLegacyExtensionDebris(path.join(root, "extensions"), rootRealPath)).map(
+        (targetPath): CleanupTarget => ({ kind: "legacy", path: targetPath }),
+      ),
     );
     targets.push(
-      ...(await collectLegacyExtensionDebris(path.join(root, "dist", "extensions"), rootRealPath)),
+      ...(
+        await collectLegacyExtensionDebris(path.join(root, "dist", "extensions"), rootRealPath)
+      ).map((targetPath): CleanupTarget => ({ kind: "legacy", path: targetPath })),
     );
   }
-  return uniqueSorted(targets);
+  return targets.toSorted((left, right) => left.path.localeCompare(right.path));
+}
+
+async function collectLegacyPluginDependencyTargets(
+  env: NodeJS.ProcessEnv = process.env,
+  options: { packageRoot?: string | null } = {},
+): Promise<string[]> {
+  return uniqueSorted(
+    (await collectLegacyPluginDependencyTargetEntries(env, options)).map((target) => target.path),
+  );
 }
 
 export async function cleanupLegacyPluginDependencyState(params: {
@@ -254,7 +317,7 @@ export async function cleanupLegacyPluginDependencyState(params: {
       moduleUrl: import.meta.url,
       cwd: process.cwd(),
     });
-  const targets = await collectLegacyPluginDependencyTargets(env, {
+  const targets = await collectLegacyPluginDependencyTargetEntries(env, {
     packageRoot,
   });
   const cleanupRootPaths = collectCleanupRootPaths(env, packageRoot);
@@ -262,12 +325,12 @@ export async function cleanupLegacyPluginDependencyState(params: {
   const staleRootCandidates = filterLegacyStaleRootCandidates(targets, cleanupRootPaths);
   warnings.push(...staleRootCandidates.warnings);
   const staleSymlinks = await removeStalePluginRuntimeSymlinks(packageRoot, {
-    staleRoots: staleRootCandidates.targets,
+    staleRoots: staleRootCandidates.targets.map((target) => target.path),
   });
   changes.push(...staleSymlinks.changes);
   warnings.push(...staleSymlinks.warnings);
   for (const target of staleRootCandidates.targets) {
-    if (!(await pathExists(target))) {
+    if (!(await pathExists(target.path))) {
       continue;
     }
     const safeTarget = await resolveSafeRemovalTarget(target, cleanupRoots);

--- a/src/commands/doctor/shared/plugin-dependency-cleanup.ts
+++ b/src/commands/doctor/shared/plugin-dependency-cleanup.ts
@@ -353,7 +353,7 @@ async function collectLegacyPluginDependencyTargetEntries(
       {
         kind: "legacy",
         path: path.join(root, ".local", "bundled-plugin-runtime-deps"),
-      },
+      } satisfies CleanupTarget,
     ]),
   ];
   for (const root of roots) {


### PR DESCRIPTION
## Summary

- Problem: Legacy plugin dependency cleanup could build removal targets from loosely validated state and plugin paths.
- Solution: Gate cleanup candidates by expected legacy names, approved OpenClaw cleanup roots, and resolved realpath containment before removal.
- What changed: Added containment checks for stale cleanup roots, existing removal targets, and symlinked plugin roots before scanning or deleting debris.
- What did NOT change (scope boundary): No plugin install behavior, package layout, registry behavior, or runtime dependency install flow changed.

AI-assisted: Yes

## Motivation

- `openclaw doctor --fix` should only remove known legacy plugin dependency debris that remains within OpenClaw-managed cleanup roots.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Linked issue: Provided separately by maintainer
- Related PR: N/A
- Bug/regression: Yes

## Real behavior proof (required for external PRs)

- Behavior addressed: Legacy plugin dependency cleanup now skips unexpected or out-of-root cleanup candidates before removal.
- Real environment tested: Not run against a live OpenClaw installation; narrow local regression proof only.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/commands/doctor/shared/plugin-dependency-cleanup.test.ts`
- Evidence after fix: `Test Files 1 passed (1)` and `Tests 5 passed (5)`
- Observed result after fix: Escaped explicit paths, dot-dot paths, out-of-root symlinked plugin roots, and out-of-root symlinked legacy roots are refused and left in place.
- What was not tested: Full `openclaw doctor --fix` CLI flow, broad changed checks, and live install cleanup.
- Before evidence (optional but encouraged): N/A

## Root Cause (if applicable)

- Root cause: Cleanup target collection accepted plugin and environment-derived paths, then removal used recursive filesystem deletion without a final realpath containment check.
- Missing detection / guardrail: Tests covered successful legacy cleanup but not escaped paths or symlink roots that resolve outside cleanup roots.
- Contributing context (if known): Legacy repair code handled several cleanup locations in one pass, including plugin extension debris and stale runtime dependency roots.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/commands/doctor/shared/plugin-dependency-cleanup.test.ts`
- Scenario the test should lock in: Cleanup refuses absolute escaped paths, dot-dot escaped paths, symlinked plugin roots outside cleanup roots, and legacy roots whose realpath resolves outside cleanup roots.
- Why this is the smallest reliable guardrail: The cleanup helper owns candidate discovery and removal authorization, so unit coverage can exercise the filesystem edge cases directly.
- Existing test that already covers this (if any): Existing happy-path cleanup tests covered valid legacy debris removal.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

`openclaw doctor --fix` may now skip malformed legacy plugin dependency cleanup candidates and emit a warning instead of removing them.

## Diagram (if applicable)

```text
Before:
[collect cleanup target] -> [recursive removal]

After:
[collect cleanup target] -> [expected name + root containment + realpath check] -> [remove or skip with warning]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): Yes
- If any `Yes`, explain risk + mitigation: Filesystem cleanup scope is narrowed to approved OpenClaw cleanup roots after realpath resolution.

## Repro + Verification

### Environment

- OS: Linux Codex worktree
- Runtime/container: Local Node test wrapper
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): Temporary test directories only

### Steps

1. Create legacy cleanup candidates under temporary OpenClaw state and package roots.
2. Create escaped absolute, dot-dot, and symlinked candidates that resolve outside those roots.
3. Run the focused cleanup regression test file.

### Expected

- Valid legacy dependency debris is removed.
- Escaped or out-of-root candidates are refused and left in place.

### Actual

- Focused regression tests passed with 5 passing cases.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Valid cleanup removal, escaped explicit cleanup paths, dot-dot cleanup paths, out-of-root symlinked plugin roots, out-of-root symlinked legacy roots, and stale global runtime symlink cleanup.
- Edge cases checked: Existing targets require realpath containment before recursive removal; symlinked plugin roots are not scanned unless their realpath stays in-bounds.
- What you did **not** verify: Full CLI repair flow, full check suite, package install/update flow, or cross-platform filesystem behavior.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Some malformed legacy debris outside approved cleanup roots may remain on disk.
  - Mitigation: The repair path now reports skipped candidates and continues removing valid in-root legacy debris.
