### PR TITLE
fix(cron): only apply Google preview model normalization for Google providers

### DIFF
--- a/src/config/model-input.test.ts
+++ b/src/config/model-input.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { normalizeAgentModelRefForConfig } from "./model-input.js";
+
+describe("normalizeAgentModelRefForConfig", () => {
+  describe("Google providers", () => {
+    it("should normalize preview model IDs for google provider", () => {
+      const result = normalizeAgentModelRefForConfig("google/gemini-2.0-flash");
+      expect(result).toBeTruthy();
+      expect(typeof result).toBe("string");
+    });
+
+    it("should normalize preview model IDs for google-gemini-cli provider", () => {
+      const result = normalizeAgentModelRefForConfig("google-gemini-cli/gemini-2.0-flash");
+      expect(result).toBeTruthy();
+      expect(typeof result).toBe("string");
+    });
+
+    it("should normalize preview model IDs for google-vertex provider", () => {
+      const result = normalizeAgentModelRefForConfig("google-vertex/gemini-2.0-flash");
+      expect(result).toBeTruthy();
+      expect(typeof result).toBe("string");
+    });
+  });
+
+  describe("Non-Google providers", () => {
+    it("should NOT normalize model IDs for litellm provider", () => {
+      const result = normalizeAgentModelRefForConfig("litellm/gemini-2.0-flash");
+      expect(result).toBe("litellm/gemini-2.0-flash");
+    });
+
+    it("should NOT normalize model IDs for openai provider", () => {
+      const result = normalizeAgentModelRefForConfig("openai/gpt-4");
+      expect(result).toBe("openai/gpt-4");
+    });
+
+    it("should NOT normalize model IDs for anthropic provider", () => {
+      const result = normalizeAgentModelRefForConfig("anthropic/claude-3-5-sonnet");
+      expect(result).toBe("anthropic/claude-3-5-sonnet");
+    });
+
+    it("should NOT normalize model IDs for opencode-go provider", () => {
+      const result = normalizeAgentModelRefForConfig("opencode-go/kimi-k2.6");
+      expect(result).toBe("opencode-go/kimi-k2.6");
+    });
+  });
+
+  describe("Edge cases", () => {
+    it("should return trimmed input when no provider prefix", () => {
+      const result = normalizeAgentModelRefForConfig("  gemini-2.0-flash  ");
+      expect(result).toBe("gemini-2.0-flash");
+    });
+
+    it("should handle empty string", () => {
+      const result = normalizeAgentModelRefForConfig("");
+      expect(result).toBe("");
+    });
+
+    it("should handle model without slash", () => {
+      const result = normalizeAgentModelRefForConfig("gpt-4");
+      expect(result).toBe("gpt-4");
+    });
+  });
+});

--- a/src/config/model-input.ts
+++ b/src/config/model-input.ts
@@ -67,6 +67,14 @@ export function toAgentModelListLike(model?: AgentModelConfig): AgentModelListLi
   return model;
 }
 
+function isGoogleProvider(provider: string): boolean {
+  return (
+    provider === "google" ||
+    provider === "google-gemini-cli" ||
+    provider === "google-vertex"
+  );
+}
+
 export function normalizeAgentModelRefForConfig(model: string): string {
   const trimmed = model.trim();
   const slash = trimmed.indexOf("/");
@@ -75,7 +83,10 @@ export function normalizeAgentModelRefForConfig(model: string): string {
   }
 
   const provider = normalizeProviderId(trimmed.slice(0, slash));
-  const normalizedModel = normalizeGooglePreviewModelId(trimmed.slice(slash + 1));
+  const modelSuffix = trimmed.slice(slash + 1);
+  const normalizedModel = isGoogleProvider(provider)
+    ? normalizeGooglePreviewModelId(modelSuffix)
+    : modelSuffix;
   return modelKeyForConfig(provider, normalizedModel);
 }
 


### PR DESCRIPTION
## Summary

Fixes `normalizeAgentModelRefForConfig()` incorrectly normalizing model IDs for non-Google providers (e.g., LiteLLM), which caused cron jobs to silently fail.

## Changes

- Added `isGoogleProvider()` helper function
- Only apply `normalizeGooglePreviewModelId()` when provider is `google`, `google-gemini-cli`, or `google-vertex`
- Non-Google providers now pass model suffix through unchanged
- Added 10 new test cases covering Google providers, non-Google providers, and edge cases

## Problem

The `normalizeAgentModelRefForConfig()` function was calling `normalizeGooglePreviewModelId()` for ALL providers, including non-Google ones like `litellm`. This caused cron jobs using LiteLLM Gemini models to receive incorrectly normalized model IDs (e.g., `litellm/gemini-2.0-flash-exp` instead of `litellm/gemini-2.0-flash`), leading to silent failures.

## Test Evidence

```
✓ Google providers > should normalize preview model IDs for google provider
✓ Google providers > should normalize preview model IDs for google-gemini-cli provider
✓ Google providers > should normalize preview model IDs for google-vertex provider
✓ Non-Google providers > should NOT normalize model IDs for litellm provider
✓ Non-Google providers > should NOT normalize model IDs for openai provider
✓ Non-Google providers > should NOT normalize model IDs for anthropic provider
✓ Non-Google providers > should NOT normalize model IDs for opencode-go provider
✓ Edge cases > should return trimmed input when no provider prefix
✓ Edge cases > should handle empty string
✓ Edge cases > should handle model without slash

Test Files: 1 passed (1)
Tests:      10 passed (10)
```

Fixes: #84745