### PR TITLE
feat(infra): add reviewer failure recovery seam

### DIFF
--- a/docs/superpowers/plans/2026-05-18-openclaw-multitasking-dgap4-reviewer-failure-recovery.md
+++ b/docs/superpowers/plans/2026-05-18-openclaw-multitasking-dgap4-reviewer-failure-recovery.md
@@ -1,0 +1,130 @@
+# OpenClaw Multitasking — D-GAP-4 Reviewer Failure Recovery
+
+Status: design + implementation notes for gate G-D4
+(`feat(infra): wire reviewer failure recovery`).
+
+## Summary
+
+The multitasking operator loop runs a worker, then runs a **reviewer** over the
+worker's output before reporting a result to the owner. Two distinct failures
+can land at the reviewer stage and they need different recovery, but until this
+slice the loop had no seam that told them apart: a reviewer-run crash was
+indistinguishable from the work itself failing.
+
+Gate G-D4 adds `src/infra/reviewer-failure-recovery.ts`, a thin seam the
+operator loop calls when a reviewer-stage failure is observed. It:
+
+1. Records the failure under a **distinct change-kind** (`reviewer_run_failed`
+   vs `worker_failed`) so the AgentTaskEvent journal separates reviewer-run
+   faults from worker faults.
+2. **Binds the operator-loop supersession filter to a real `PlanAction`**: a
+   non-superseded reviewer-run failure yields a real `reviewer-retry` action
+   carrying the next attempt number; an exhausted budget yields `escalate`; a
+   failure from a superseded loop generation yields `none`.
+3. **Briefs Telegram exactly once per failed-reviewer event** through an
+   injected emitter, so duplicate re-emits of the same reviewer failure do not
+   spam the owner or double-count retries.
+
+The module mirrors the established D-GAP infra style: a self-contained slice on
+top of `resolveGlobalSingleton` state, discriminated-union actions, process-
+local idempotency, and a `*ForTests` reset — the same shape as
+`worker-completion-wake.ts` (D-GAP-3) and `briefing-events.ts` (D-GAP-2).
+
+## Problem
+
+- **Wrong recovery.** A `reviewer_run_failed` (the reviewer agent crashed,
+  timed out, or lost transport before producing a verdict) leaves the work
+  *unjudged* — the loop must retry the reviewer. A `worker_failed` (the work
+  under review failed) has nothing to re-review — the loop must report the
+  worker failure. Conflating them either re-runs a reviewer over a dead worker
+  or silently drops an unjudged result.
+- **Stale retries.** Once a newer operator-loop pass (a higher *generation*)
+  owns a worker, a reviewer retry scheduled by an older pass must not fire. The
+  loop needs a supersession filter that gates whether a reviewer failure
+  becomes a real retry action.
+- **Briefing spam.** Terminal events are re-emitted (retry races, double-
+  finalize). Each *distinct* reviewer failure should brief the owner exactly
+  once.
+
+## Design (implemented + proven)
+
+### Failure discrimination
+
+`ReviewerFailureKind` is a closed union: `"reviewer_run_failed" |
+"worker_failed"`, exported alongside `REVIEWER_RUN_FAILED_CHANGE_KIND` /
+`WORKER_FAILURE_CHANGE_KIND` so callers write the matching AgentTaskEvent change
+kind. `getReviewerFailureStats()` exposes per-kind counts for telemetry/tests.
+
+### Supersession filter
+
+`observeGeneration(workerId, generation)` records the highest loop generation
+seen for a worker; advancing it **resets the reviewer retry budget** (a newer
+pass starts the review afresh). `isSupersededGeneration(workerId, generation)`
+returns `true` when an action from `generation` is stale. Both are exported so
+the operator loop can consult the filter directly, and the planner applies it
+internally.
+
+### Plan actions
+
+`planReviewerFailureRecovery(event, opts)` returns a `PlanAction` discriminated
+union:
+
+- `reviewer-retry` — non-superseded reviewer-run failure within budget; carries
+  the 1-based `attempt`.
+- `escalate` — reviewer retries exhausted (`reason: "reviewer_retry_exhausted"`).
+- `worker-report` — a worker failure; never retries the reviewer, never briefs.
+- `none` — gated out: `superseded`, `duplicate`, `no_worker_id`, or
+  `missing_reviewer_run_id`.
+
+Retry budget defaults to `DEFAULT_MAX_REVIEWER_RETRIES = 2` and is overridable
+via `opts.maxRetries`. Supersession is checked **before** counting so a stale
+retry never consumes the live generation's budget.
+
+### Once-per-event Telegram briefing
+
+Idempotency is keyed on `(workerId, generation, reviewerRunId)`. A duplicate
+collapses to `none{duplicate}` with no second retry and no second briefing. The
+briefing is delivered through an injected `ReviewerFailedBriefingEmitter`
+(`opts.emitBriefing`) carrying a `briefing.reviewer_failed` payload — the
+operator surface binds it to the briefing bus; tests pass a capturing callback.
+A throwing emitter is caught and logged (listener safety), and `briefed`
+reflects whether the emitter was invoked.
+
+### Proof
+
+`src/infra/reviewer-failure-recovery.test.ts` covers: reviewer-retry action +
+single briefing, retry-budget-then-escalate, custom budget, duplicate
+idempotency, supersession drop, budget reset on new generation, worker-failure
+distinct recording (no retry/brief), worker-failure advancing the supersession
+line, malformed-event guards, emitter-less recovery, throwing-emitter safety,
+and the supersession filter in isolation.
+
+## Default-off / integration contract
+
+This slice is a pure decision + notification seam with **no production caller
+yet** — importing it changes no behavior. The operator loop wires it next by:
+
+- calling `planReviewerFailureRecovery` at the reviewer-stage failure point and
+  acting on the returned `PlanAction`;
+- writing `result.changeKind` to the AgentTaskEvent journal;
+- binding `opts.emitBriefing` to the briefing bus. The bus' `BriefingEvent`
+  union (D-GAP-2 `briefing-events.ts`) should gain a `briefing.reviewer_failed`
+  variant matching `ReviewerFailedBriefing` when that wiring lands so the
+  reviewer briefing flows through the same operator surface as
+  `briefing.quarantine` / `briefing.timeout`.
+
+## Residual risk / future work
+
+- **No live operator-loop caller in this slice.** The seam is proven in
+  isolation; the end-to-end retry → escalate → Telegram path is exercised only
+  once the operator loop calls it (next gate). Until then no reviewer briefing
+  reaches a channel.
+- **Briefing bus variant not yet added.** `briefing-events.ts` lives in the
+  unmerged D-GAP-2 slice; adding the `briefing.reviewer_failed` variant is
+  deferred to the wiring gate to avoid editing another worker's file. The
+  injected-emitter seam keeps this slice compile-ready against `main` today.
+- **Process-local state.** Retry budgets and dedup keys are in-memory
+  (`resolveGlobalSingleton`), bounded by `MAX_TRACKED_WORKERS` /
+  `MAX_TRACKED_EVENTS`. They do not survive a gateway restart; pairing with the
+  D-GAP-1 survival boundary or a durable journal is future work if cross-restart
+  retry continuity is required.

--- a/docs/superpowers/plans/2026-05-18-openclaw-multitasking-dgap4-reviewer-failure-recovery.md
+++ b/docs/superpowers/plans/2026-05-18-openclaw-multitasking-dgap4-reviewer-failure-recovery.md
@@ -34,16 +34,16 @@ local idempotency, and a `*ForTests` reset — the same shape as
 
 - **Wrong recovery.** A `reviewer_run_failed` (the reviewer agent crashed,
   timed out, or lost transport before producing a verdict) leaves the work
-  *unjudged* — the loop must retry the reviewer. A `worker_failed` (the work
+  _unjudged_ — the loop must retry the reviewer. A `worker_failed` (the work
   under review failed) has nothing to re-review — the loop must report the
   worker failure. Conflating them either re-runs a reviewer over a dead worker
   or silently drops an unjudged result.
-- **Stale retries.** Once a newer operator-loop pass (a higher *generation*)
+- **Stale retries.** Once a newer operator-loop pass (a higher _generation_)
   owns a worker, a reviewer retry scheduled by an older pass must not fire. The
   loop needs a supersession filter that gates whether a reviewer failure
   becomes a real retry action.
 - **Briefing spam.** Terminal events are re-emitted (retry races, double-
-  finalize). Each *distinct* reviewer failure should brief the owner exactly
+  finalize). Each _distinct_ reviewer failure should brief the owner exactly
   once.
 
 ## Design (implemented + proven)

--- a/scripts/deadcode-unused-files.allowlist.mjs
+++ b/scripts/deadcode-unused-files.allowlist.mjs
@@ -22,6 +22,7 @@ export const KNIP_UNUSED_FILE_ALLOWLIST = [
   "src/gateway/gateway-cli-backend.live-probe-helpers.ts",
   "src/gateway/gateway-codex-harness.live-helpers.ts",
   "src/infra/changelog-unreleased.ts",
+  "src/infra/reviewer-failure-recovery.ts",
   "src/mcp/openclaw-tools-serve.ts",
   "src/mcp/plugin-tools-handlers.ts",
   "src/mcp/plugin-tools-serve.ts",

--- a/src/infra/reviewer-failure-recovery.test.ts
+++ b/src/infra/reviewer-failure-recovery.test.ts
@@ -1,0 +1,277 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_MAX_REVIEWER_RETRIES,
+  REVIEWER_RUN_FAILED_CHANGE_KIND,
+  WORKER_FAILURE_CHANGE_KIND,
+  type ReviewerFailedBriefing,
+  getReviewerFailureStats,
+  isSupersededGeneration,
+  observeGeneration,
+  planReviewerFailureRecovery,
+  resetReviewerFailureRecoveryStateForTests,
+} from "./reviewer-failure-recovery.js";
+
+const OWNER_SESSION_KEY = "agent:ghost:main";
+
+function makeCollector() {
+  const briefings: ReviewerFailedBriefing[] = [];
+  const emitBriefing = (briefing: ReviewerFailedBriefing) => {
+    briefings.push(briefing);
+  };
+  return { briefings, emitBriefing };
+}
+
+describe("reviewer-failure-recovery", () => {
+  beforeEach(() => {
+    resetReviewerFailureRecoveryStateForTests();
+  });
+
+  afterEach(() => {
+    resetReviewerFailureRecoveryStateForTests();
+  });
+
+  it("turns a reviewer-run failure into a real reviewer-retry action and briefs once", () => {
+    const { briefings, emitBriefing } = makeCollector();
+
+    const result = planReviewerFailureRecovery(
+      {
+        kind: "reviewer_run_failed",
+        workerId: "task-42",
+        reviewerRunId: "rev-1",
+        generation: 0,
+        sessionKey: OWNER_SESSION_KEY,
+        summary: "reviewer crashed before verdict",
+        detail: "timeout after 600s",
+      },
+      { emitBriefing },
+    );
+
+    expect(result).toEqual({
+      action: {
+        type: "reviewer-retry",
+        workerId: "task-42",
+        reviewerRunId: "rev-1",
+        attempt: 1,
+        generation: 0,
+      },
+      changeKind: REVIEWER_RUN_FAILED_CHANGE_KIND,
+      briefed: true,
+    });
+
+    expect(briefings).toEqual([
+      {
+        type: "briefing.reviewer_failed",
+        workerId: "task-42",
+        reviewerRunId: "rev-1",
+        generation: 0,
+        recovery: "reviewer-retry",
+        attempt: 1,
+        maxRetries: DEFAULT_MAX_REVIEWER_RETRIES,
+        sessionKey: OWNER_SESSION_KEY,
+        summary: "reviewer crashed before verdict",
+        detail: "timeout after 600s",
+      },
+    ]);
+  });
+
+  it("retries up to the budget then escalates", () => {
+    const { briefings, emitBriefing } = makeCollector();
+    const base = { kind: "reviewer_run_failed" as const, workerId: "task-7", generation: 3 };
+
+    const first = planReviewerFailureRecovery({ ...base, reviewerRunId: "r1" }, { emitBriefing });
+    const second = planReviewerFailureRecovery({ ...base, reviewerRunId: "r2" }, { emitBriefing });
+    const third = planReviewerFailureRecovery({ ...base, reviewerRunId: "r3" }, { emitBriefing });
+
+    expect(first.action).toEqual({
+      type: "reviewer-retry",
+      workerId: "task-7",
+      reviewerRunId: "r1",
+      attempt: 1,
+      generation: 3,
+    });
+    expect(second.action).toMatchObject({ type: "reviewer-retry", attempt: 2 });
+    expect(third.action).toEqual({
+      type: "escalate",
+      workerId: "task-7",
+      reason: "reviewer_retry_exhausted",
+      attempts: 3,
+      generation: 3,
+    });
+
+    expect(briefings).toHaveLength(3);
+    expect(briefings[2]).toMatchObject({ recovery: "escalate", attempt: 3 });
+  });
+
+  it("honors a custom retry budget", () => {
+    const { emitBriefing } = makeCollector();
+    const base = { kind: "reviewer_run_failed" as const, workerId: "task-9", generation: 0 };
+
+    const first = planReviewerFailureRecovery(
+      { ...base, reviewerRunId: "r1" },
+      { maxRetries: 0, emitBriefing },
+    );
+
+    // maxRetries 0 → no retries, escalate on first failure.
+    expect(first.action).toMatchObject({ type: "escalate", attempts: 1 });
+  });
+
+  it("is idempotent for a duplicate reviewer failure event", () => {
+    const { briefings, emitBriefing } = makeCollector();
+    const event = {
+      kind: "reviewer_run_failed" as const,
+      workerId: "task-1",
+      reviewerRunId: "rev-9",
+      generation: 0,
+    };
+
+    const first = planReviewerFailureRecovery(event, { emitBriefing });
+    const second = planReviewerFailureRecovery(event, { emitBriefing });
+
+    expect(first.action).toMatchObject({ type: "reviewer-retry", attempt: 1 });
+    expect(second).toEqual({
+      action: { type: "none", reason: "duplicate" },
+      changeKind: REVIEWER_RUN_FAILED_CHANGE_KIND,
+      briefed: false,
+    });
+    expect(briefings).toHaveLength(1);
+    expect(getReviewerFailureStats().reviewer_run_failed).toBe(1);
+  });
+
+  it("drops reviewer failures from a superseded loop generation", () => {
+    const { briefings, emitBriefing } = makeCollector();
+
+    const live = planReviewerFailureRecovery(
+      { kind: "reviewer_run_failed", workerId: "task-5", reviewerRunId: "r1", generation: 2 },
+      { emitBriefing },
+    );
+    expect(live.action).toMatchObject({ type: "reviewer-retry", attempt: 1 });
+
+    const stale = planReviewerFailureRecovery(
+      { kind: "reviewer_run_failed", workerId: "task-5", reviewerRunId: "r0", generation: 1 },
+      { emitBriefing },
+    );
+    expect(stale.action).toEqual({ type: "none", reason: "superseded" });
+    expect(stale.briefed).toBe(false);
+    expect(briefings).toHaveLength(1);
+  });
+
+  it("resets the retry budget when a newer generation starts", () => {
+    const { emitBriefing } = makeCollector();
+
+    planReviewerFailureRecovery(
+      { kind: "reviewer_run_failed", workerId: "task-6", reviewerRunId: "g1-r1", generation: 1 },
+      { emitBriefing },
+    );
+    const gen1Second = planReviewerFailureRecovery(
+      { kind: "reviewer_run_failed", workerId: "task-6", reviewerRunId: "g1-r2", generation: 1 },
+      { emitBriefing },
+    );
+    expect(gen1Second.action).toMatchObject({ attempt: 2 });
+
+    const gen2First = planReviewerFailureRecovery(
+      { kind: "reviewer_run_failed", workerId: "task-6", reviewerRunId: "g2-r1", generation: 2 },
+      { emitBriefing },
+    );
+    expect(gen2First.action).toMatchObject({ type: "reviewer-retry", attempt: 1, generation: 2 });
+  });
+
+  it("records a worker failure distinctly and does not retry the reviewer or brief", () => {
+    const { briefings, emitBriefing } = makeCollector();
+
+    const result = planReviewerFailureRecovery(
+      {
+        kind: "worker_failed",
+        workerId: "task-3",
+        generation: 0,
+        sessionKey: OWNER_SESSION_KEY,
+        summary: "worker exited non-zero",
+      },
+      { emitBriefing },
+    );
+
+    expect(result).toEqual({
+      action: { type: "worker-report", workerId: "task-3", generation: 0 },
+      changeKind: WORKER_FAILURE_CHANGE_KIND,
+      briefed: false,
+    });
+    expect(briefings).toHaveLength(0);
+
+    const stats = getReviewerFailureStats();
+    expect(stats).toEqual({ reviewer_run_failed: 0, worker_failed: 1 });
+  });
+
+  it("supersedes an older reviewer retry once the worker itself fails in a newer generation", () => {
+    const { emitBriefing } = makeCollector();
+
+    planReviewerFailureRecovery(
+      { kind: "reviewer_run_failed", workerId: "task-8", reviewerRunId: "r1", generation: 0 },
+      { emitBriefing },
+    );
+
+    // A worker failure at a newer generation advances the supersession line.
+    const workerFail = planReviewerFailureRecovery(
+      { kind: "worker_failed", workerId: "task-8", generation: 1 },
+      { emitBriefing },
+    );
+    expect(workerFail.action).toMatchObject({ type: "worker-report", generation: 1 });
+
+    const stale = planReviewerFailureRecovery(
+      { kind: "reviewer_run_failed", workerId: "task-8", reviewerRunId: "r2", generation: 0 },
+      { emitBriefing },
+    );
+    expect(stale.action).toEqual({ type: "none", reason: "superseded" });
+  });
+
+  it("returns no_worker_id and missing_reviewer_run_id for malformed events", () => {
+    const noWorker = planReviewerFailureRecovery({
+      kind: "reviewer_run_failed",
+      workerId: "  ",
+      reviewerRunId: "r1",
+    });
+    expect(noWorker.action).toEqual({ type: "none", reason: "no_worker_id" });
+    expect(noWorker.changeKind).toBe(REVIEWER_RUN_FAILED_CHANGE_KIND);
+
+    const noRun = planReviewerFailureRecovery({
+      kind: "reviewer_run_failed",
+      workerId: "task-x",
+    });
+    expect(noRun.action).toEqual({ type: "none", reason: "missing_reviewer_run_id" });
+  });
+
+  it("computes recovery without an emitter and reports briefed=false", () => {
+    const result = planReviewerFailureRecovery({
+      kind: "reviewer_run_failed",
+      workerId: "task-2",
+      reviewerRunId: "r1",
+      generation: 0,
+    });
+    expect(result.action).toMatchObject({ type: "reviewer-retry", attempt: 1 });
+    expect(result.briefed).toBe(false);
+  });
+
+  it("does not throw when the briefing emitter throws", () => {
+    const emitBriefing = vi.fn(() => {
+      throw new Error("transport down");
+    });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const result = planReviewerFailureRecovery(
+      { kind: "reviewer_run_failed", workerId: "task-4", reviewerRunId: "r1", generation: 0 },
+      { emitBriefing },
+    );
+
+    expect(result.action).toMatchObject({ type: "reviewer-retry" });
+    expect(result.briefed).toBe(true);
+    expect(emitBriefing).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    errorSpy.mockRestore();
+  });
+
+  it("exposes the supersession filter directly", () => {
+    expect(isSupersededGeneration("task-10", 0)).toBe(false);
+    observeGeneration("task-10", 5);
+    expect(isSupersededGeneration("task-10", 4)).toBe(true);
+    expect(isSupersededGeneration("task-10", 5)).toBe(false);
+    expect(isSupersededGeneration("task-10", 6)).toBe(false);
+  });
+});

--- a/src/infra/reviewer-failure-recovery.ts
+++ b/src/infra/reviewer-failure-recovery.ts
@@ -1,0 +1,426 @@
+// Reviewer-failure recovery planner (D-GAP-4).
+//
+// In the OpenClaw multitasking operator loop each worker run is followed by a
+// reviewer run that inspects the worker's output before the result is reported
+// to the owner. Two failures can land at the reviewer stage and they need
+// different recovery:
+//
+//   - worker_failed       — the work under review failed. The reviewer has
+//                           nothing to judge, so the loop reports the worker
+//                           failure to the owner (`worker-report`). It is not
+//                           a reviewer fault and never briefs as one.
+//   - reviewer_run_failed — the reviewer run itself crashed/errored (timeout,
+//                           transport fault, harness crash) without producing a
+//                           verdict. The work is still unjudged, so the loop
+//                           retries the reviewer (`reviewer-retry`) until a
+//                           small budget is spent, then escalates.
+//
+// This module is the seam the operator loop calls when a reviewer-stage failure
+// is observed. It mirrors the thin-seam style of `worker-completion-wake.ts`
+// and the once-per-occurrence briefing style of `briefing-events.ts`, and does
+// three things:
+//
+//   1. Records the failure under a distinct change-kind so the AgentTaskEvent
+//      journal separates reviewer-run faults from worker faults.
+//   2. Binds the operator-loop supersession filter to a real PlanAction: a
+//      reviewer failure from a superseded loop generation yields `none` (a
+//      newer pass already owns the worker), otherwise it yields a real
+//      `reviewer-retry` action carrying the next attempt number — or `escalate`
+//      once the retry budget is exhausted.
+//   3. Briefs Telegram exactly once per failed-reviewer event through an
+//      injected emitter (the operator surface binds it to the briefing bus), so
+//      duplicate re-emits of the same reviewer failure do not spam the owner or
+//      double-count retries.
+
+import { resolveGlobalSingleton } from "../shared/global-singleton.js";
+import { normalizeOptionalString } from "../shared/string-coerce.js";
+
+export const REVIEWER_RUN_FAILED_CHANGE_KIND = "reviewer_run_failed" as const;
+export const WORKER_FAILURE_CHANGE_KIND = "worker_failed" as const;
+
+export type ReviewerFailureKind =
+  | typeof REVIEWER_RUN_FAILED_CHANGE_KIND
+  | typeof WORKER_FAILURE_CHANGE_KIND;
+
+/** Reviewer retries attempted before the loop escalates to the owner. */
+export const DEFAULT_MAX_REVIEWER_RETRIES = 2;
+
+export type ReviewerFailureEvent = {
+  /** Distinguishes a reviewer-run crash from a worker failure. */
+  kind: ReviewerFailureKind;
+  /** Stable id of the worker whose output is under review. Required. */
+  workerId: string;
+  /**
+   * Stable id of the reviewer run that failed. Required for
+   * `reviewer_run_failed`; ignored for `worker_failed`.
+   */
+  reviewerRunId?: string;
+  /**
+   * Operator-loop plan generation that produced this run. A newer generation
+   * supersedes retries planned by older ones. Defaults to 0.
+   */
+  generation?: number;
+  /** Owner session key to wake for retry / report / escalation. */
+  sessionKey?: string | null;
+  /** One-line human summary used in the briefing / report. */
+  summary?: string;
+  /** Free-form failure detail (error message, exit reason). */
+  detail?: string;
+};
+
+export type PlanActionSkipReason =
+  | "superseded"
+  | "duplicate"
+  | "no_worker_id"
+  | "missing_reviewer_run_id";
+
+export type PlanAction =
+  | {
+      type: "reviewer-retry";
+      workerId: string;
+      reviewerRunId: string;
+      /** 1-based number of the retry the loop should now schedule. */
+      attempt: number;
+      generation: number;
+    }
+  | {
+      type: "escalate";
+      workerId: string;
+      reason: "reviewer_retry_exhausted";
+      /** Total reviewer failures seen in this generation. */
+      attempts: number;
+      generation: number;
+    }
+  | {
+      type: "worker-report";
+      workerId: string;
+      generation: number;
+    }
+  | { type: "none"; reason: PlanActionSkipReason };
+
+export type ReviewerFailedBriefing = {
+  type: "briefing.reviewer_failed";
+  workerId: string;
+  reviewerRunId: string;
+  generation: number;
+  /** Recovery chosen for this failure. */
+  recovery: "reviewer-retry" | "escalate";
+  /** Retry number being scheduled, or the exhausted count on escalation. */
+  attempt: number;
+  maxRetries: number;
+  sessionKey?: string;
+  summary?: string;
+  detail?: string;
+};
+
+/**
+ * Transport seam for the once-per-event Telegram briefing. The operator
+ * surface binds this to the briefing bus (`briefing.reviewer_failed`); tests
+ * pass a capturing callback. Omitting it skips the notification but still
+ * records the failure and computes the recovery action.
+ */
+export type ReviewerFailedBriefingEmitter = (briefing: ReviewerFailedBriefing) => void;
+
+export type PlanReviewerFailureOptions = {
+  /** Reviewer retries before escalation. Defaults to {@link DEFAULT_MAX_REVIEWER_RETRIES}. */
+  maxRetries?: number;
+  /** Emitter for the once-per-event Telegram briefing. */
+  emitBriefing?: ReviewerFailedBriefingEmitter;
+};
+
+export type ReviewerFailureRecoveryResult = {
+  /** Next operator-loop action for this failure. */
+  action: PlanAction;
+  /** Distinct change-kind tag for the AgentTaskEvent journal. */
+  changeKind: ReviewerFailureKind;
+  /** Whether a Telegram briefing was emitted on this call. */
+  briefed: boolean;
+};
+
+export type ReviewerFailureStats = {
+  reviewer_run_failed: number;
+  worker_failed: number;
+};
+
+type WorkerReviewState = {
+  /** Highest loop generation observed for this worker. */
+  latestGeneration: number;
+  /** Reviewer failures counted within `latestGeneration`. */
+  attempts: number;
+};
+
+type ReviewerFailureRecoveryState = {
+  byWorker: Map<string, WorkerReviewState>;
+  /** Event keys already handled — gates double-count and double-brief. */
+  handled: Set<string>;
+  counts: ReviewerFailureStats;
+};
+
+const REVIEWER_FAILURE_RECOVERY_STATE_KEY = Symbol.for("openclaw.reviewerFailureRecovery.state.v1");
+
+// Operator loops are bounded in practice; these caps protect a long-lived
+// gateway from unbounded growth if a caller fans out unexpectedly.
+const MAX_TRACKED_WORKERS = 1024;
+const MAX_TRACKED_EVENTS = 4096;
+
+function getState(): ReviewerFailureRecoveryState {
+  return resolveGlobalSingleton<ReviewerFailureRecoveryState>(
+    REVIEWER_FAILURE_RECOVERY_STATE_KEY,
+    () => ({
+      byWorker: new Map<string, WorkerReviewState>(),
+      handled: new Set<string>(),
+      counts: { reviewer_run_failed: 0, worker_failed: 0 },
+    }),
+  );
+}
+
+// Drop the oldest entry once a tracking collection exceeds its cap; insertion
+// order is preserved by Set/Map iteration.
+function capSet(set: Set<string>, max: number): void {
+  if (set.size <= max) {
+    return;
+  }
+  const oldest = set.values().next().value;
+  if (oldest !== undefined) {
+    set.delete(oldest);
+  }
+}
+
+function capWorkerMap(map: Map<string, WorkerReviewState>, max: number): void {
+  if (map.size <= max) {
+    return;
+  }
+  const oldest = map.keys().next().value;
+  if (oldest !== undefined) {
+    map.delete(oldest);
+  }
+}
+
+function normalizeGeneration(generation: number | undefined): number {
+  return typeof generation === "number" && Number.isFinite(generation) ? generation : 0;
+}
+
+/**
+ * Record the latest operator-loop generation seen for a worker. Advancing the
+ * generation resets the reviewer retry budget — a newer loop pass starts the
+ * review afresh. Safe to call before {@link planReviewerFailureRecovery}; the
+ * planner calls it internally as well.
+ */
+export function observeGeneration(workerId: string, generation: number): void {
+  const id = normalizeOptionalString(workerId);
+  if (!id) {
+    return;
+  }
+  const gen = normalizeGeneration(generation);
+  const state = getState();
+  const existing = state.byWorker.get(id);
+  if (!existing) {
+    state.byWorker.set(id, { latestGeneration: gen, attempts: 0 });
+    capWorkerMap(state.byWorker, MAX_TRACKED_WORKERS);
+    return;
+  }
+  if (gen > existing.latestGeneration) {
+    existing.latestGeneration = gen;
+    existing.attempts = 0;
+  }
+}
+
+/**
+ * Operator-loop supersession filter: true when an action from `generation` is
+ * stale because a newer loop pass already owns this worker. The planner uses
+ * this to gate whether a reviewer failure becomes a real `reviewer-retry`.
+ */
+export function isSupersededGeneration(workerId: string, generation: number): boolean {
+  const id = normalizeOptionalString(workerId);
+  if (!id) {
+    return false;
+  }
+  const existing = getState().byWorker.get(id);
+  if (!existing) {
+    return false;
+  }
+  return normalizeGeneration(generation) < existing.latestGeneration;
+}
+
+function buildResult(
+  action: PlanAction,
+  changeKind: ReviewerFailureKind,
+  briefed: boolean,
+): ReviewerFailureRecoveryResult {
+  return { action, changeKind, briefed };
+}
+
+function planWorkerFailure(workerId: string, generation: number): ReviewerFailureRecoveryResult {
+  // A worker failure is a terminal outcome for this generation — advance the
+  // generation so any in-flight reviewer retry from an older pass is superseded.
+  observeGeneration(workerId, generation);
+  if (isSupersededGeneration(workerId, generation)) {
+    return buildResult({ type: "none", reason: "superseded" }, WORKER_FAILURE_CHANGE_KIND, false);
+  }
+  getState().counts.worker_failed += 1;
+  return buildResult(
+    { type: "worker-report", workerId, generation },
+    WORKER_FAILURE_CHANGE_KIND,
+    false,
+  );
+}
+
+function planReviewerFailure(
+  event: ReviewerFailureEvent,
+  workerId: string,
+  generation: number,
+  opts: PlanReviewerFailureOptions,
+): ReviewerFailureRecoveryResult {
+  const reviewerRunId = normalizeOptionalString(event.reviewerRunId);
+  if (!reviewerRunId) {
+    return buildResult(
+      { type: "none", reason: "missing_reviewer_run_id" },
+      REVIEWER_RUN_FAILED_CHANGE_KIND,
+      false,
+    );
+  }
+
+  // Supersession is checked before counting so a stale retry never consumes the
+  // budget of the live generation.
+  if (isSupersededGeneration(workerId, generation)) {
+    return buildResult(
+      { type: "none", reason: "superseded" },
+      REVIEWER_RUN_FAILED_CHANGE_KIND,
+      false,
+    );
+  }
+
+  const state = getState();
+  const eventKey = `${workerId}:${generation}:${reviewerRunId}`;
+  if (state.handled.has(eventKey)) {
+    // Duplicate terminal event (re-emit, retry race, double-finalize). Stay
+    // idempotent: no second retry, no second briefing.
+    return buildResult(
+      { type: "none", reason: "duplicate" },
+      REVIEWER_RUN_FAILED_CHANGE_KIND,
+      false,
+    );
+  }
+
+  observeGeneration(workerId, generation);
+  const worker = state.byWorker.get(workerId);
+  if (!worker) {
+    // observeGeneration always seeds the entry; this is unreachable in practice
+    // but keeps the type non-nullable without a non-null assertion.
+    return buildResult(
+      { type: "none", reason: "no_worker_id" },
+      REVIEWER_RUN_FAILED_CHANGE_KIND,
+      false,
+    );
+  }
+
+  worker.attempts += 1;
+  const attempts = worker.attempts;
+  const maxRetries = opts.maxRetries ?? DEFAULT_MAX_REVIEWER_RETRIES;
+  const canRetry = attempts <= maxRetries;
+
+  const action: PlanAction = canRetry
+    ? { type: "reviewer-retry", workerId, reviewerRunId, attempt: attempts, generation }
+    : {
+        type: "escalate",
+        workerId,
+        reason: "reviewer_retry_exhausted",
+        attempts,
+        generation,
+      };
+
+  state.counts.reviewer_run_failed += 1;
+  state.handled.add(eventKey);
+  capSet(state.handled, MAX_TRACKED_EVENTS);
+
+  const briefed = briefReviewerFailure(event, {
+    workerId,
+    reviewerRunId,
+    generation,
+    recovery: canRetry ? "reviewer-retry" : "escalate",
+    attempt: attempts,
+    maxRetries,
+    emit: opts.emitBriefing,
+  });
+
+  return buildResult(action, REVIEWER_RUN_FAILED_CHANGE_KIND, briefed);
+}
+
+function briefReviewerFailure(
+  event: ReviewerFailureEvent,
+  ctx: {
+    workerId: string;
+    reviewerRunId: string;
+    generation: number;
+    recovery: "reviewer-retry" | "escalate";
+    attempt: number;
+    maxRetries: number;
+    emit?: ReviewerFailedBriefingEmitter;
+  },
+): boolean {
+  if (!ctx.emit) {
+    return false;
+  }
+  const sessionKey = normalizeOptionalString(event.sessionKey);
+  const summary = normalizeOptionalString(event.summary);
+  const detail = normalizeOptionalString(event.detail);
+  const briefing: ReviewerFailedBriefing = {
+    type: "briefing.reviewer_failed",
+    workerId: ctx.workerId,
+    reviewerRunId: ctx.reviewerRunId,
+    generation: ctx.generation,
+    recovery: ctx.recovery,
+    attempt: ctx.attempt,
+    maxRetries: ctx.maxRetries,
+    ...(sessionKey ? { sessionKey } : {}),
+    ...(summary ? { summary } : {}),
+    ...(detail ? { detail } : {}),
+  };
+  try {
+    ctx.emit(briefing);
+  } catch (err) {
+    const message = err instanceof Error ? (err.stack ?? err.message) : String(err);
+    console.error(
+      `[reviewer-failure-recovery] briefing emit failed worker=${ctx.workerId} run=${ctx.reviewerRunId}: ${message}`,
+    );
+  }
+  return true;
+}
+
+/**
+ * Plan recovery for a reviewer-stage failure. Discriminates worker failures
+ * from reviewer-run failures, applies the operator-loop supersession filter and
+ * retry budget, and briefs Telegram exactly once per failed-reviewer event.
+ *
+ * Idempotent per `(workerId, generation, reviewerRunId)` for the lifetime of
+ * the process: duplicate reviewer failures collapse to `none{duplicate}`.
+ */
+export function planReviewerFailureRecovery(
+  event: ReviewerFailureEvent,
+  opts: PlanReviewerFailureOptions = {},
+): ReviewerFailureRecoveryResult {
+  const workerId = normalizeOptionalString(event.workerId);
+  if (!workerId) {
+    return buildResult({ type: "none", reason: "no_worker_id" }, event.kind, false);
+  }
+  const generation = normalizeGeneration(event.generation);
+
+  if (event.kind === WORKER_FAILURE_CHANGE_KIND) {
+    return planWorkerFailure(workerId, generation);
+  }
+  return planReviewerFailure(event, workerId, generation, opts);
+}
+
+/** Snapshot of recorded failures by kind. Reviewer faults are counted apart from worker faults. */
+export function getReviewerFailureStats(): ReviewerFailureStats {
+  const { counts } = getState();
+  return { ...counts };
+}
+
+export function resetReviewerFailureRecoveryStateForTests(): void {
+  const state = getState();
+  state.byWorker.clear();
+  state.handled.clear();
+  state.counts.reviewer_run_failed = 0;
+  state.counts.worker_failed = 0;
+}


### PR DESCRIPTION
## Summary
- Adds a reviewer-failure recovery helper seam for retry/escalation/briefing decisions.
- Adds focused coverage for reviewer retry and failure classification behavior.
- Leaves production wiring deferred to the next gate; this is intentionally seam-only.

## Real behavior proof
- **Behavior or issue addressed:** A reviewer run failure now produces an explicit recovery decision instead of silently leaving the worker lane stuck. The first observed failure creates a reviewer-retry action and briefing event; a duplicate report for the same generation is ignored.
- **Real environment tested:** OpenClaw landing worktree for PR #84806 on The Ghost's Shell, branch `agent/20260521t041614z-land-dgap4-reviewer-failure-recovery/dgap4-landing-captain`, head `dae7f36a8162eb74ecc0033336288a8ecb2af1dd`.
- **Exact steps or command run after this patch:** Ran a live `node`/TypeScript execution against the patched helper in the PR worktree, constructing a reviewer failure snapshot and invoking `planReviewerFailureRecovery` twice for the same reviewer generation.
- **Evidence after fix:** Terminal capture from that live command:

```json
{
  "first": {
    "action": {
      "type": "reviewer-retry",
      "workerId": "proof-worker",
      "reviewerRunId": "proof-reviewer-run",
      "attempt": 1,
      "generation": 7
    },
    "changeKind": "reviewer_run_failed",
    "briefed": true
  },
  "duplicate": {
    "action": {
      "type": "none",
      "reason": "duplicate"
    },
    "changeKind": "reviewer_run_failed",
    "briefed": false
  },
  "briefings": [
    {
      "type": "briefing.reviewer_failed",
      "workerId": "proof-worker",
      "reviewerRunId": "proof-reviewer-run",
      "generation": 7,
      "recovery": "reviewer-retry",
      "attempt": 1,
      "maxRetries": 2
    }
  ]
}
```

- **Observed result after fix:** The first failure produced the retry action and briefing payload for the failed reviewer generation. The duplicate failure produced `type: none` with `reason: duplicate`, so repeated status polling will not repeatedly dispatch recovery for the same failed reviewer.
- **What was not tested:** Full production dispatcher wiring is intentionally deferred to the next D-GAP-4 gate; this PR proves the recovery-decision seam and briefing payload shape.

## Verification
- reviewer-failure-recovery focused coverage: 12/12 pass
- oxfmt clean
- oxlint 0 warnings / 0 errors
- tsgo core and core-test exit 0

AgentOS: OpenClaw Multitasking reviewer failure recovery (D-GAP-4). Landing artifact 9184b525 rebased and pushed; CI gate cleanup added at dae7f36a816.