### PR TITLE
fix #84789: sanitize colons in dirName for Telegram forum topic sessions

### DIFF
--- a/src/plugins/public-surface-runtime.test.ts
+++ b/src/plugins/public-surface-runtime.test.ts
@@ -122,6 +122,13 @@ describe("bundled plugin public surface runtime", () => {
     expect(() => normalizeBundledPluginDirName("../outside")).toThrow(/single directory/);
     expect(() => normalizeBundledPluginDirName("nested/plugin")).toThrow(/single directory/);
     expect(() => normalizeBundledPluginDirName("nested\\plugin")).toThrow(/single directory/);
-    expect(() => normalizeBundledPluginDirName("C:plugin")).toThrow(/single directory/);
+  });
+
+  it("sanitizes colons in dirName to dashes", () => {
+    expect(normalizeBundledPluginDirName("C:plugin")).toBe("C-plugin");
+    expect(normalizeBundledPluginDirName("-1003803644436:topic:35526")).toBe(
+      "-1003803644436-topic-35526",
+    );
+    expect(normalizeBundledPluginDirName("a:b:c")).toBe("a-b-c");
   });
 });

--- a/src/plugins/public-surface-runtime.ts
+++ b/src/plugins/public-surface-runtime.ts
@@ -39,14 +39,16 @@ export function normalizeBundledPluginArtifactSubpath(artifactBasename: string):
 }
 
 export function normalizeBundledPluginDirName(dirName: string): string {
-  const normalized = dirName.trim();
+  let normalized = dirName.trim();
+  if (!normalized) {
+    throw new Error(`Bundled plugin dirName must be a single directory: ${dirName}`);
+  }
+  normalized = normalized.replace(/:/g, "-");
   if (
-    !normalized ||
     normalized === "." ||
     normalized === ".." ||
     normalized.includes("/") ||
-    normalized.includes("\\") ||
-    normalized.includes(":")
+    normalized.includes("\\")
   ) {
     throw new Error(`Bundled plugin dirName must be a single directory: ${dirName}`);
   }


### PR DESCRIPTION
## Summary

- Problem: Active memory plugin crashes on Telegram forum (topic-based) group sessions because the session peer ID (e.g. `-1003803644436:topic:35526`) contains colons that fail `normalizeBundledPluginDirName` validation when the value flows through `resolveAgentHookChannelId` → `buildAgentHookContextChannelFields` → channel contract API loading.
- Solution: Sanitize colons to dashes in `normalizeBundledPluginDirName` instead of throwing, so the directory lookup fails gracefully (no matching directory) rather than crashing.
- What changed: `src/plugins/public-surface-runtime.ts` (colon sanitization in `normalizeBundledPluginDirName`), `src/plugins/public-surface-runtime.test.ts` (updated test + regression test).
- What did NOT change: All other path-traversal guards (`/`, `\`, `..`, empty) remain strict. No changes to session key parsing, hook context resolution, or channel contract API logic.

Fixes #84789

## Real behavior proof
- **Behavior or issue addressed:** Active memory crashes with "Bundled plugin dirName must be a single directory: -1003803644436:topic:35526" on Telegram forum topic sessions
- **Real environment tested:** Linux x86_64, Node 24.x, OpenClaw worktree SHA 45cd1bc, shallow clone
- **Exact steps or command run after this patch:**
  ```bash
  pnpm install
  npx vitest run --config test/vitest/vitest.plugins.config.ts src/plugins/public-surface-runtime.test.ts
  node --import tsx -e "import { normalizeBundledPluginDirName } from './src/plugins/public-surface-runtime.ts'; console.log(normalizeBundledPluginDirName('-1003803644436:topic:35526'));"
  ```
- **Evidence after fix:**
  ```
  $ node --import tsx -e "import { normalizeBundledPluginDirName } from './src/plugins/public-surface-runtime.ts'; console.log(normalizeBundledPluginDirName('-1003803644436:topic:35526'));"
  -1003803644436-topic-35526

  $ npx vitest run --config test/vitest/vitest.plugins.config.ts src/plugins/public-surface-runtime.test.ts
   Test Files  1 passed (1)
        Tests  8 passed (8)
  ```
- **Observed result after fix:** Colons in dirName are replaced with dashes. Path traversal (`../`), slashes, and backslashes are still rejected. Regular plugin names (`telegram`, `active-memory`) are unchanged.
- **What was not tested:** no known gaps

## Regression Test Plan

- Coverage level: Unit test
- Target test file: `src/plugins/public-surface-runtime.test.ts`
- Scenario locked in: `normalizeBundledPluginDirName` sanitizes colon-containing Telegram forum topic peer IDs (e.g. `-1003803644436:topic:35526` → `-1003803644436-topic-35526`) instead of throwing
- Why this is the smallest reliable guardrail: The test directly exercises the exact function that was crashing, with the exact input pattern from the issue report.

## Root Cause

- Root cause: `resolveAgentHookChannelId` (hook-agent-context.ts) returns `parseRawSessionConversationRef(sessionKey).rawId` which for Telegram forum topics is `-1003803644436:topic:35526`. This flows as `channelId` through `buildAgentHookContextChannelFields` into channel contract API functions that pass it as `dirName` to `loadBundledPluginPublicArtifactModuleSync`, which calls `normalizeBundledPluginDirName` — and colons triggered a hard throw.
- Missing detection / guardrail: `normalizeBundledPluginDirName` rejected colons outright (to prevent Windows drive-letter / ADS paths) instead of sanitizing them, which is overly strict for scoped conversation IDs that happen to reach this function.
