### PR TITLE
fix: hydrate current turn image attachments

### DIFF
--- a/src/auto-reply/reply/current-turn-images.ts
+++ b/src/auto-reply/reply/current-turn-images.ts
@@ -2,6 +2,7 @@ import type { ImageContent } from "@earendil-works/pi-ai";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
 import { formatErrorMessage } from "../../infra/errors.js";
+import { mimeTypeFromFilePath } from "../../media/mime.js";
 import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import type { MsgContext } from "../templating.js";
@@ -12,6 +13,30 @@ type CurrentImageAttachment = {
   path: string;
   mediaType: string;
 };
+
+function isGenericMediaType(mediaType: string | undefined): boolean {
+  if (!mediaType) {
+    return true;
+  }
+  const normalized = mediaType.split(";")[0]?.trim().toLowerCase();
+  return normalized === "application/octet-stream" || normalized === "binary/octet-stream";
+}
+
+function resolveCurrentImageMediaType(pathValue: unknown, mediaType?: unknown): string | undefined {
+  const mediaPath = normalizeOptionalString(pathValue);
+  if (!mediaPath) {
+    return undefined;
+  }
+  const normalizedMediaType = normalizeOptionalString(mediaType);
+  if (normalizedMediaType?.startsWith("image/")) {
+    return normalizedMediaType;
+  }
+  if (!isGenericMediaType(normalizedMediaType)) {
+    return undefined;
+  }
+  const inferredType = mimeTypeFromFilePath(mediaPath);
+  return inferredType?.startsWith("image/") ? inferredType : undefined;
+}
 
 function collectCurrentImageAttachments(ctx: MsgContext): CurrentImageAttachment[] {
   const pathsFromArray = Array.isArray(ctx.MediaPaths) ? ctx.MediaPaths : undefined;
@@ -31,8 +56,8 @@ function collectCurrentImageAttachments(ctx: MsgContext): CurrentImageAttachment
   const attachments: CurrentImageAttachment[] = [];
   for (const [index, pathValue] of paths.entries()) {
     const mediaPath = normalizeOptionalString(pathValue);
-    const mediaType = normalizeOptionalString(types?.[index] ?? ctx.MediaType);
-    if (mediaPath && mediaType?.startsWith("image/")) {
+    const mediaType = resolveCurrentImageMediaType(pathValue, types?.[index] ?? ctx.MediaType);
+    if (mediaPath && mediaType) {
       attachments.push({ index, path: mediaPath, mediaType });
     }
   }

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -878,7 +878,7 @@ describe("runPreparedReply media-only handling", () => {
     expect(call?.followupRun.prompt).toContain("[User sent media without caption]");
   });
 
-  it("hydrates current MediaPaths into queued followup images", async () => {
+  it("hydrates current image MediaPaths by extension when MediaTypes are missing", async () => {
     const tmpDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-followup-image-"));
     cleanupPaths.push(tmpDir);
     const imagePath = path.join(tmpDir, "inbound.png");
@@ -897,7 +897,6 @@ describe("runPreparedReply media-only handling", () => {
           RawBody: "describe this",
           CommandBody: "describe this",
           MediaPaths: [imagePath],
-          MediaTypes: ["image/png"],
           MediaWorkspaceDir: tmpDir,
           OriginatingChannel: "discord",
           OriginatingTo: "C123",
@@ -911,7 +910,6 @@ describe("runPreparedReply media-only handling", () => {
           OriginatingTo: "C123",
           ChatType: "group",
           MediaPaths: [imagePath],
-          MediaTypes: ["image/png"],
           MediaWorkspaceDir: tmpDir,
         },
       }),


### PR DESCRIPTION
## Root cause
Current inbound images from Feishu/IM can arrive with structured `MediaPaths` but without reliable `image/*` MIME metadata. After #76659 limited prompt image scanning to the visible prompt, those images should be passed through the current-turn media path instead of being rediscovered by scanning reply/runtime context text.

## Fix
- Keep `detectAndLoadPromptImages` scoped to the visible prompt; this does not restore runtime/reply context scanning.
- In `current-turn-images.ts`, infer an image MIME from the current-turn `MediaPath`/`MediaPaths` extension only when the declared media type is missing or generic binary.
- Preserve explicit non-image MIME values such as `application/pdf`, `audio/*`, or `video/*`; those are not upgraded to images based on extension.
- Pass the narrowed, current-turn-only MIME hint into the existing `resolveAgentTurnAttachments` path; `agent-turn-attachments.ts` stays unchanged.

## Real behavior proof

- Behavior or issue addressed: Feishu/IM-style current-turn image attachments with `MediaPaths` but no `MediaTypes` are hydrated as native image input instead of relying on prompt/runtime-context path scanning.
- Real environment tested: Local OpenClaw checkout at PR head `b338d73c97`, macOS, Node.js v22.22.2, pnpm/tsx from the repository install.
- Exact steps or command run after this patch: Created a temporary 1x1 PNG file, then invoked `resolveCurrentTurnImages` from `src/auto-reply/reply/current-turn-images.ts` with a Feishu-like context containing `MediaPaths: [imagePath]`, `MediaWorkspaceDir`, and no `MediaTypes`.
- Evidence after fix (terminal output from the local OpenClaw checkout):

```json
{
  "images": 1,
  "mimeType": "image/png",
  "imageOrder": [
    "inline"
  ],
  "base64Length": 92
}
```

- Observed result after fix: The current-turn attachment path produced one native image input with MIME `image/png` and inline image order, proving the attachment no longer depends on scanning reply/runtime context text.
- What was not tested: A live Feishu production message was not sent from the real Feishu bot; this proof exercises the OpenClaw current-turn media hydration path with the same structured fields that Feishu/IM provide.

## Verification
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm exec oxfmt --check --threads=1 src/auto-reply/reply/current-turn-images.ts src/auto-reply/reply/get-reply-run.media-only.test.ts`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm exec vitest run src/auto-reply/reply/get-reply-run.media-only.test.ts --testNamePattern "hydrates current image MediaPaths by extension" --reporter=verbose`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm exec vitest run src/auto-reply/reply/dispatch-acp.test.ts --testNamePattern "does not fall back to recent history images when the current turn has non-image media" --reporter=verbose`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm exec vitest run src/auto-reply/reply/get-reply-run.media-only.test.ts src/auto-reply/reply/agent-runner.media-paths.test.ts src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts --reporter=verbose`
- Direct module check: `MediaTypes: ["application/pdf"]` with a `.png` path returns `{ "images": 0, "imageOrder": [] }`.
