### PR TITLE
perf(models): /models 20s → 5ms via pre-warmed provider auth state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 - QA-Lab: add a personal-agent failure recovery scenario that checks honest partial status, retry boundaries, and local recovery artifacts. (#83872) Thanks @iFiras-Max1.
 - QA-Lab: include an opt-in `update.run` package self-upgrade sentinel for destructive latest-package recovery checks.
 - QA-Lab: add Codex plugin lifecycle and auth-profile fixture coverage for missing installs, pinned-version drift, first-turn install ordering, and doctor migration safety. (#80323, refs #80174) Thanks @100yenadmin.
+- Models/perf: pre-warm the provider auth-state map at gateway startup so `/models` and every model-listing call short-circuits the per-provider plugin / external-CLI discovery on the hot path. Per-call cost drops from ~20 s to ~5 ms (~4,100×); the one-time startup warm resets and re-warms after hot reloads. (#84816) Thanks @sjf.
 - Tests/perf: isolate doctor core health check unit coverage from real skills/workspace discovery so `doctor-core-checks` no longer dominates unit perf while keeping one real skills-readiness smoke. (#84493) Thanks @frankekn.
 
 ### Fixes

--- a/src/agents/model-provider-auth.test.ts
+++ b/src/agents/model-provider-auth.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { ModelCatalogEntry } from "./model-catalog.types.js";
+
+const modelCatalogMocks = vi.hoisted(() => ({
+  loadModelCatalog: vi.fn<() => Promise<ModelCatalogEntry[]>>(),
+}));
+
+const modelAuthMocks = vi.hoisted(() => ({
+  hasRuntimeAvailableProviderAuth: vi.fn<(params: { provider: string }) => boolean>(),
+}));
+
+const authProfilesMocks = vi.hoisted(() => ({
+  ensureAuthProfileStore: vi.fn(() => ({ profiles: {} })),
+  ensureAuthProfileStoreWithoutExternalProfiles: vi.fn(() => ({ profiles: {} })),
+  externalCliDiscoveryForProviders: vi.fn(() => ({}) as never),
+  externalCliDiscoveryForProviderAuth: vi.fn(() => ({}) as never),
+  listProfilesForProvider: vi.fn(() => []),
+}));
+
+vi.mock("./model-catalog.js", () => ({
+  loadModelCatalog: modelCatalogMocks.loadModelCatalog,
+}));
+
+vi.mock("./model-auth.js", () => ({
+  hasRuntimeAvailableProviderAuth: modelAuthMocks.hasRuntimeAvailableProviderAuth,
+}));
+
+vi.mock("./auth-profiles.js", () => ({
+  ensureAuthProfileStore: authProfilesMocks.ensureAuthProfileStore,
+  ensureAuthProfileStoreWithoutExternalProfiles:
+    authProfilesMocks.ensureAuthProfileStoreWithoutExternalProfiles,
+  externalCliDiscoveryForProviders: authProfilesMocks.externalCliDiscoveryForProviders,
+  externalCliDiscoveryForProviderAuth: authProfilesMocks.externalCliDiscoveryForProviderAuth,
+  listProfilesForProvider: authProfilesMocks.listProfilesForProvider,
+}));
+
+vi.mock("./workspace.js", () => ({
+  resolveDefaultAgentWorkspaceDir: () => undefined,
+}));
+
+const { clearCurrentProviderAuthState, hasAuthForModelProvider, warmCurrentProviderAuthState } =
+  await import("./model-provider-auth.js");
+
+describe("prepared provider auth state", () => {
+  afterEach(() => {
+    clearCurrentProviderAuthState();
+    vi.clearAllMocks();
+  });
+
+  it("hasAuthForModelProvider returns the prepared answer after warm and falls through to compute after clear", async () => {
+    const cfg = {} as OpenClawConfig;
+    modelCatalogMocks.loadModelCatalog.mockResolvedValue([
+      { id: "gpt", name: "gpt", provider: "openai" },
+      { id: "claude", name: "claude", provider: "anthropic" },
+    ]);
+    modelAuthMocks.hasRuntimeAvailableProviderAuth.mockImplementation(
+      ({ provider }) => provider === "openai",
+    );
+
+    await warmCurrentProviderAuthState(cfg);
+    expect(modelAuthMocks.hasRuntimeAvailableProviderAuth).toHaveBeenCalledTimes(2);
+
+    // Flip the underlying answer; if the prepared map is consulted first,
+    // hasAuthForModelProvider returns the cached answers without re-running
+    // the compute path.
+    modelAuthMocks.hasRuntimeAvailableProviderAuth.mockReturnValue(true);
+    expect(hasAuthForModelProvider({ provider: "openai", cfg })).toBe(true);
+    expect(hasAuthForModelProvider({ provider: "anthropic", cfg })).toBe(false);
+    expect(modelAuthMocks.hasRuntimeAvailableProviderAuth).toHaveBeenCalledTimes(2);
+
+    // Clearing the prepared state forces the compute path on the next read.
+    clearCurrentProviderAuthState();
+    expect(hasAuthForModelProvider({ provider: "anthropic", cfg })).toBe(true);
+    expect(modelAuthMocks.hasRuntimeAvailableProviderAuth).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/agents/model-provider-auth.test.ts
+++ b/src/agents/model-provider-auth.test.ts
@@ -7,7 +7,8 @@ const modelCatalogMocks = vi.hoisted(() => ({
 }));
 
 const modelAuthMocks = vi.hoisted(() => ({
-  hasRuntimeAvailableProviderAuth: vi.fn<(params: { provider: string }) => boolean>(),
+  hasRuntimeAvailableProviderAuth:
+    vi.fn<(params: { provider: string; cfg?: OpenClawConfig; workspaceDir?: string }) => boolean>(),
 }));
 
 const authProfilesMocks = vi.hoisted(() => ({
@@ -44,6 +45,7 @@ const { clearCurrentProviderAuthState, hasAuthForModelProvider, warmCurrentProvi
 
 describe("prepared provider auth state", () => {
   afterEach(() => {
+    vi.useRealTimers();
     clearCurrentProviderAuthState();
     vi.clearAllMocks();
   });
@@ -105,6 +107,41 @@ describe("prepared provider auth state", () => {
     expect(modelAuthMocks.hasRuntimeAvailableProviderAuth).toHaveBeenCalledTimes(2);
   });
 
+  it("hasAuthForModelProvider uses the prepared answer for equivalent runtime config clones", async () => {
+    const cfg = { gateway: { port: 18789 } } as OpenClawConfig;
+    const clonedCfg = structuredClone(cfg);
+    modelCatalogMocks.loadModelCatalog.mockResolvedValue([
+      { id: "gpt", name: "gpt", provider: "openai" },
+    ]);
+    modelAuthMocks.hasRuntimeAvailableProviderAuth.mockReturnValue(true);
+    await warmCurrentProviderAuthState(cfg);
+    expect(modelAuthMocks.hasRuntimeAvailableProviderAuth).toHaveBeenCalledTimes(1);
+
+    modelAuthMocks.hasRuntimeAvailableProviderAuth.mockReturnValue(false);
+    expect(hasAuthForModelProvider({ provider: "openai", cfg: clonedCfg })).toBe(true);
+    expect(modelAuthMocks.hasRuntimeAvailableProviderAuth).toHaveBeenCalledTimes(1);
+  });
+
+  it("hasAuthForModelProvider falls through after the prepared auth state TTL", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const cfg = {} as OpenClawConfig;
+    modelCatalogMocks.loadModelCatalog.mockResolvedValue([
+      { id: "gpt", name: "gpt", provider: "openai" },
+    ]);
+    modelAuthMocks.hasRuntimeAvailableProviderAuth.mockReturnValue(false);
+    await warmCurrentProviderAuthState(cfg);
+    expect(modelAuthMocks.hasRuntimeAvailableProviderAuth).toHaveBeenCalledTimes(1);
+
+    modelAuthMocks.hasRuntimeAvailableProviderAuth.mockReturnValue(true);
+    expect(hasAuthForModelProvider({ provider: "openai", cfg })).toBe(false);
+    expect(modelAuthMocks.hasRuntimeAvailableProviderAuth).toHaveBeenCalledTimes(1);
+
+    vi.setSystemTime(10_001);
+    expect(hasAuthForModelProvider({ provider: "openai", cfg })).toBe(true);
+    expect(modelAuthMocks.hasRuntimeAvailableProviderAuth).toHaveBeenCalledTimes(2);
+  });
+
   it("hasAuthForModelProvider falls through to compute when the caller passes a non-default workspaceDir", async () => {
     const cfg = {} as OpenClawConfig;
     modelCatalogMocks.loadModelCatalog.mockResolvedValue([
@@ -136,5 +173,43 @@ describe("prepared provider auth state", () => {
       }),
     ).toBe(true);
     expect(modelAuthMocks.hasRuntimeAvailableProviderAuth).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not publish an older warm after the prepared auth state is cleared", async () => {
+    const firstCfg = { gateway: { port: 18789 } } as OpenClawConfig;
+    const secondCfg = { gateway: { port: 19001 } } as OpenClawConfig;
+    let resolveFirstCatalog: ((catalog: ModelCatalogEntry[]) => void) | undefined;
+    let resolveSecondCatalog: ((catalog: ModelCatalogEntry[]) => void) | undefined;
+    modelCatalogMocks.loadModelCatalog
+      .mockReturnValueOnce(
+        new Promise<ModelCatalogEntry[]>((resolve) => {
+          resolveFirstCatalog = resolve;
+        }),
+      )
+      .mockReturnValueOnce(
+        new Promise<ModelCatalogEntry[]>((resolve) => {
+          resolveSecondCatalog = resolve;
+        }),
+      );
+    modelAuthMocks.hasRuntimeAvailableProviderAuth.mockImplementation(
+      ({ cfg }) => cfg === firstCfg,
+    );
+
+    const firstWarm = warmCurrentProviderAuthState(firstCfg);
+    await Promise.resolve();
+    clearCurrentProviderAuthState();
+    const secondWarm = warmCurrentProviderAuthState(secondCfg);
+
+    resolveSecondCatalog?.([{ id: "gpt", name: "gpt", provider: "openai" }]);
+    await secondWarm;
+    resolveFirstCatalog?.([{ id: "gpt", name: "gpt", provider: "openai" }]);
+    await firstWarm;
+    expect(modelAuthMocks.hasRuntimeAvailableProviderAuth).toHaveBeenCalledTimes(2);
+
+    modelAuthMocks.hasRuntimeAvailableProviderAuth.mockReturnValue(true);
+    expect(hasAuthForModelProvider({ provider: "openai", cfg: secondCfg })).toBe(false);
+    expect(modelAuthMocks.hasRuntimeAvailableProviderAuth).toHaveBeenCalledTimes(2);
+    expect(hasAuthForModelProvider({ provider: "openai", cfg: firstCfg })).toBe(true);
+    expect(modelAuthMocks.hasRuntimeAvailableProviderAuth).toHaveBeenCalledTimes(3);
   });
 });

--- a/src/agents/model-provider-auth.test.ts
+++ b/src/agents/model-provider-auth.test.ts
@@ -36,7 +36,7 @@ vi.mock("./auth-profiles.js", () => ({
 }));
 
 vi.mock("./workspace.js", () => ({
-  resolveDefaultAgentWorkspaceDir: () => undefined,
+  resolveDefaultAgentWorkspaceDir: () => "/warm/default-workspace",
 }));
 
 const { clearCurrentProviderAuthState, hasAuthForModelProvider, warmCurrentProviderAuthState } =
@@ -102,6 +102,39 @@ describe("prepared provider auth state", () => {
 
     // Broad-scope caller (default flags) still hits the prepared map.
     expect(hasAuthForModelProvider({ provider: "openai", cfg })).toBe(true);
+    expect(modelAuthMocks.hasRuntimeAvailableProviderAuth).toHaveBeenCalledTimes(2);
+  });
+
+  it("hasAuthForModelProvider falls through to compute when the caller passes a non-default workspaceDir", async () => {
+    const cfg = {} as OpenClawConfig;
+    modelCatalogMocks.loadModelCatalog.mockResolvedValue([
+      { id: "gpt", name: "gpt", provider: "openai" },
+    ]);
+    modelAuthMocks.hasRuntimeAvailableProviderAuth.mockReturnValue(true);
+    await warmCurrentProviderAuthState(cfg);
+    expect(modelAuthMocks.hasRuntimeAvailableProviderAuth).toHaveBeenCalledTimes(1);
+
+    // Per-agent picker calls pass an agent-specific workspaceDir that the
+    // warmer did not cover; the prepared answer must not leak across
+    // workspaces because env/plugin auth resolution depends on workspaceDir.
+    modelAuthMocks.hasRuntimeAvailableProviderAuth.mockReturnValue(false);
+    expect(
+      hasAuthForModelProvider({
+        provider: "openai",
+        cfg,
+        workspaceDir: "/different/agent-workspace",
+      }),
+    ).toBe(false);
+    expect(modelAuthMocks.hasRuntimeAvailableProviderAuth).toHaveBeenCalledTimes(2);
+
+    // Same workspaceDir as the warmer (the default) still hits the prepared map.
+    expect(
+      hasAuthForModelProvider({
+        provider: "openai",
+        cfg,
+        workspaceDir: "/warm/default-workspace",
+      }),
+    ).toBe(true);
     expect(modelAuthMocks.hasRuntimeAvailableProviderAuth).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/agents/model-provider-auth.test.ts
+++ b/src/agents/model-provider-auth.test.ts
@@ -74,4 +74,34 @@ describe("prepared provider auth state", () => {
     expect(hasAuthForModelProvider({ provider: "anthropic", cfg })).toBe(true);
     expect(modelAuthMocks.hasRuntimeAvailableProviderAuth).toHaveBeenCalledTimes(3);
   });
+
+  it("hasAuthForModelProvider falls through to compute when the caller narrows the auth-discovery scope", async () => {
+    const cfg = {} as OpenClawConfig;
+    modelCatalogMocks.loadModelCatalog.mockResolvedValue([
+      { id: "gpt", name: "gpt", provider: "openai" },
+    ]);
+    // Warm with the broad answer: provider has CLI/synthetic auth.
+    modelAuthMocks.hasRuntimeAvailableProviderAuth.mockReturnValue(true);
+    await warmCurrentProviderAuthState(cfg);
+    expect(modelAuthMocks.hasRuntimeAvailableProviderAuth).toHaveBeenCalledTimes(1);
+
+    // Flip the underlying compute to false. A narrow-scope caller must NOT
+    // pick up the warmed broad answer — gateway models.list with
+    // runtimeAuthDiscovery: false maps to both flags false, and the answer
+    // must reflect that narrower scope, not the prepared broad answer.
+    modelAuthMocks.hasRuntimeAvailableProviderAuth.mockReturnValue(false);
+    expect(
+      hasAuthForModelProvider({
+        provider: "openai",
+        cfg,
+        discoverExternalCliAuth: false,
+        allowPluginSyntheticAuth: false,
+      }),
+    ).toBe(false);
+    expect(modelAuthMocks.hasRuntimeAvailableProviderAuth).toHaveBeenCalledTimes(2);
+
+    // Broad-scope caller (default flags) still hits the prepared map.
+    expect(hasAuthForModelProvider({ provider: "openai", cfg })).toBe(true);
+    expect(modelAuthMocks.hasRuntimeAvailableProviderAuth).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/agents/model-provider-auth.ts
+++ b/src/agents/model-provider-auth.ts
@@ -1,3 +1,4 @@
+import { hashRuntimeConfigValue } from "../config/runtime-snapshot.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   externalCliDiscoveryForProviderAuth,
@@ -18,16 +19,36 @@ import { resolveDefaultAgentWorkspaceDir } from "./workspace.js";
 // (pickers, /models, status commands, CLI) skips the per-provider plugin
 // discovery and external-CLI probing on the hot path.
 
-let currentProviderAuthState: ReadonlyMap<string, boolean> | null = null;
-let currentProviderAuthStateWorkspaceDir: string | undefined;
+type PreparedProviderAuthState = {
+  configFingerprint: string;
+  workspaceDir: string;
+  preparedAtMs: number;
+  providers: ReadonlyMap<string, boolean>;
+};
+
+const PREPARED_PROVIDER_AUTH_STATE_TTL_MS = 10_000;
+let currentProviderAuthState: PreparedProviderAuthState | null = null;
+const configFingerprintCache = new WeakMap<OpenClawConfig, string>();
 // Generation counter guards against an in-flight warm publishing stale
-// state after a subsequent clear/reload has invalidated it.
+// state after a subsequent warm or clear has invalidated it.
 let currentProviderAuthStateGeneration = 0;
 
 export function clearCurrentProviderAuthState(): void {
   currentProviderAuthState = null;
-  currentProviderAuthStateWorkspaceDir = undefined;
   currentProviderAuthStateGeneration += 1;
+}
+
+function resolveProviderAuthConfigFingerprint(cfg: OpenClawConfig | undefined): string | null {
+  if (!cfg) {
+    return null;
+  }
+  const cached = configFingerprintCache.get(cfg);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const fingerprint = hashRuntimeConfigValue(cfg);
+  configFingerprintCache.set(cfg, fingerprint);
+  return fingerprint;
 }
 
 export function hasAuthForModelProvider(params: {
@@ -48,16 +69,23 @@ export function hasAuthForModelProvider(params: {
   // that narrow the scope — e.g. gateway `models.list` with
   // `runtimeAuthDiscovery: false`, or per-agent picker calls that pass a
   // non-default workspaceDir — get the answer they asked for.
+  const preparedState = currentProviderAuthState;
+  const workspaceDir = params.workspaceDir ?? resolveDefaultAgentWorkspaceDir();
+  const configFingerprint = resolveProviderAuthConfigFingerprint(params.cfg);
+  const preparedStateFresh =
+    preparedState !== null &&
+    Date.now() - preparedState.preparedAtMs <= PREPARED_PROVIDER_AUTH_STATE_TTL_MS;
   const matchesWarmedScope =
+    preparedStateFresh &&
+    configFingerprint === preparedState.configFingerprint &&
+    workspaceDir === preparedState.workspaceDir &&
     params.discoverExternalCliAuth !== false &&
     params.allowPluginSyntheticAuth !== false &&
     params.agentDir === undefined &&
     params.env === undefined &&
-    params.store === undefined &&
-    (params.workspaceDir === undefined ||
-      params.workspaceDir === currentProviderAuthStateWorkspaceDir);
+    params.store === undefined;
   if (matchesWarmedScope) {
-    const preparedAnswer = currentProviderAuthState?.get(provider);
+    const preparedAnswer = preparedState.providers.get(provider);
     if (preparedAnswer !== undefined) {
       return preparedAnswer;
     }
@@ -152,6 +180,10 @@ export async function warmCurrentProviderAuthState(cfg: OpenClawConfig): Promise
     // the newer answer wins.
     return;
   }
-  currentProviderAuthState = state;
-  currentProviderAuthStateWorkspaceDir = workspaceDir;
+  currentProviderAuthState = {
+    configFingerprint: resolveProviderAuthConfigFingerprint(cfg) ?? "",
+    workspaceDir,
+    preparedAtMs: Date.now(),
+    providers: state,
+  };
 }

--- a/src/agents/model-provider-auth.ts
+++ b/src/agents/model-provider-auth.ts
@@ -1,13 +1,28 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   externalCliDiscoveryForProviderAuth,
+  externalCliDiscoveryForProviders,
   ensureAuthProfileStore,
   ensureAuthProfileStoreWithoutExternalProfiles,
   listProfilesForProvider,
   type AuthProfileStore,
 } from "./auth-profiles.js";
 import { hasRuntimeAvailableProviderAuth } from "./model-auth.js";
+import { loadModelCatalog } from "./model-catalog.js";
 import { normalizeProviderId } from "./model-selection.js";
+import { resolveDefaultAgentWorkspaceDir } from "./workspace.js";
+
+// Prepared runtime fact: which providers have available auth given the
+// current cfg + env. Populated explicitly at gateway startup and on config
+// reload; consulted by hasAuthForModelProvider so every model-listing call
+// (pickers, /models, status commands, CLI) skips the per-provider plugin
+// discovery and external-CLI probing on the hot path.
+
+let currentProviderAuthState: ReadonlyMap<string, boolean> | null = null;
+
+export function clearCurrentProviderAuthState(): void {
+  currentProviderAuthState = null;
+}
 
 export function hasAuthForModelProvider(params: {
   provider: string;
@@ -20,6 +35,10 @@ export function hasAuthForModelProvider(params: {
   discoverExternalCliAuth?: boolean;
 }): boolean {
   const provider = normalizeProviderId(params.provider);
+  const preparedAnswer = currentProviderAuthState?.get(provider);
+  if (preparedAnswer !== undefined) {
+    return preparedAnswer;
+  }
   if (
     hasRuntimeAvailableProviderAuth({
       provider,
@@ -73,4 +92,33 @@ export function createProviderAuthChecker(params: {
     authCache.set(key, value);
     return value;
   };
+}
+
+export async function warmCurrentProviderAuthState(cfg: OpenClawConfig): Promise<void> {
+  const catalog = await loadModelCatalog({ config: cfg });
+  const providers = new Set<string>();
+  for (const entry of catalog) {
+    providers.add(normalizeProviderId(entry.provider));
+  }
+  const workspaceDir = resolveDefaultAgentWorkspaceDir();
+  // One AuthProfileStore scoped to every candidate provider; without this the
+  // per-provider externalCli discovery rebuilds the store ~N times.
+  const store = ensureAuthProfileStore(undefined, {
+    config: cfg,
+    externalCli: externalCliDiscoveryForProviders({
+      cfg,
+      providers: [...providers],
+    }),
+  });
+  const state = new Map<string, boolean>();
+  for (const provider of providers) {
+    const value = hasAuthForModelProvider({
+      provider,
+      cfg,
+      workspaceDir,
+      store,
+    });
+    state.set(provider, value);
+  }
+  currentProviderAuthState = state;
 }

--- a/src/agents/model-provider-auth.ts
+++ b/src/agents/model-provider-auth.ts
@@ -19,9 +19,15 @@ import { resolveDefaultAgentWorkspaceDir } from "./workspace.js";
 // discovery and external-CLI probing on the hot path.
 
 let currentProviderAuthState: ReadonlyMap<string, boolean> | null = null;
+let currentProviderAuthStateWorkspaceDir: string | undefined;
+// Generation counter guards against an in-flight warm publishing stale
+// state after a subsequent clear/reload has invalidated it.
+let currentProviderAuthStateGeneration = 0;
 
 export function clearCurrentProviderAuthState(): void {
   currentProviderAuthState = null;
+  currentProviderAuthStateWorkspaceDir = undefined;
+  currentProviderAuthStateGeneration += 1;
 }
 
 export function hasAuthForModelProvider(params: {
@@ -36,17 +42,20 @@ export function hasAuthForModelProvider(params: {
 }): boolean {
   const provider = normalizeProviderId(params.provider);
   // The prepared map is built by warmCurrentProviderAuthState with broad
-  // auth discovery (external CLI + plugin synthetic auth enabled, no
-  // caller-supplied agentDir/env/store). Only consult it when the caller's
-  // scope matches; otherwise fall through to compute so callers that
-  // explicitly narrow the auth scope — e.g. gateway `models.list` with
-  // `runtimeAuthDiscovery: false` — get the answer they asked for.
+  // auth discovery (external CLI + plugin synthetic auth enabled) and the
+  // default-agent workspace dir. Only consult it when the caller's full
+  // auth context matches; otherwise fall through to compute so callers
+  // that narrow the scope — e.g. gateway `models.list` with
+  // `runtimeAuthDiscovery: false`, or per-agent picker calls that pass a
+  // non-default workspaceDir — get the answer they asked for.
   const matchesWarmedScope =
     params.discoverExternalCliAuth !== false &&
     params.allowPluginSyntheticAuth !== false &&
     params.agentDir === undefined &&
     params.env === undefined &&
-    params.store === undefined;
+    params.store === undefined &&
+    (params.workspaceDir === undefined ||
+      params.workspaceDir === currentProviderAuthStateWorkspaceDir);
   if (matchesWarmedScope) {
     const preparedAnswer = currentProviderAuthState?.get(provider);
     if (preparedAnswer !== undefined) {
@@ -109,6 +118,10 @@ export function createProviderAuthChecker(params: {
 }
 
 export async function warmCurrentProviderAuthState(cfg: OpenClawConfig): Promise<void> {
+  // Claim a fresh generation; any concurrent warm or clear bumps this and
+  // turns our published state stale.
+  currentProviderAuthStateGeneration += 1;
+  const ownGeneration = currentProviderAuthStateGeneration;
   const catalog = await loadModelCatalog({ config: cfg });
   const providers = new Set<string>();
   for (const entry of catalog) {
@@ -134,5 +147,11 @@ export async function warmCurrentProviderAuthState(cfg: OpenClawConfig): Promise
     });
     state.set(provider, value);
   }
+  if (ownGeneration !== currentProviderAuthStateGeneration) {
+    // A newer warm or clear ran while we were building; skip publication so
+    // the newer answer wins.
+    return;
+  }
   currentProviderAuthState = state;
+  currentProviderAuthStateWorkspaceDir = workspaceDir;
 }

--- a/src/agents/model-provider-auth.ts
+++ b/src/agents/model-provider-auth.ts
@@ -35,9 +35,23 @@ export function hasAuthForModelProvider(params: {
   discoverExternalCliAuth?: boolean;
 }): boolean {
   const provider = normalizeProviderId(params.provider);
-  const preparedAnswer = currentProviderAuthState?.get(provider);
-  if (preparedAnswer !== undefined) {
-    return preparedAnswer;
+  // The prepared map is built by warmCurrentProviderAuthState with broad
+  // auth discovery (external CLI + plugin synthetic auth enabled, no
+  // caller-supplied agentDir/env/store). Only consult it when the caller's
+  // scope matches; otherwise fall through to compute so callers that
+  // explicitly narrow the auth scope — e.g. gateway `models.list` with
+  // `runtimeAuthDiscovery: false` — get the answer they asked for.
+  const matchesWarmedScope =
+    params.discoverExternalCliAuth !== false &&
+    params.allowPluginSyntheticAuth !== false &&
+    params.agentDir === undefined &&
+    params.env === undefined &&
+    params.store === undefined;
+  if (matchesWarmedScope) {
+    const preparedAnswer = currentProviderAuthState?.get(provider);
+    if (preparedAnswer !== undefined) {
+      return preparedAnswer;
+    }
   }
   if (
     hasRuntimeAvailableProviderAuth({

--- a/src/auto-reply/reply/commands-models.test.ts
+++ b/src/auto-reply/reply/commands-models.test.ts
@@ -42,6 +42,9 @@ vi.mock("../../agents/model-provider-auth.js", () => ({
   createProviderAuthChecker: modelProviderAuthMocks.createProviderAuthChecker,
   hasAuthForModelProvider: ({ provider }: { provider: string }) =>
     modelProviderAuthMocks.authenticatedProviders.has(provider),
+  getCurrentProviderAuthState: () => null,
+  clearCurrentProviderAuthState: () => undefined,
+  warmCurrentProviderAuthState: async () => undefined,
 }));
 
 const telegramModelsTestPlugin: ChannelPlugin = {

--- a/src/gateway/server-methods/models-auth-status.test.ts
+++ b/src/gateway/server-methods/models-auth-status.test.ts
@@ -23,6 +23,8 @@ const mocks = vi.hoisted(() => ({
     (params: { agentDir?: string }) => params.agentDir,
   ),
   refreshActiveSecretsRuntimeSnapshot: vi.fn(async () => false),
+  clearCurrentProviderAuthState: vi.fn(),
+  warmCurrentProviderAuthState: vi.fn(async (_cfg: unknown) => {}),
   buildAuthHealthSummary: vi.fn(
     (): AuthHealthSummary => ({ now: 0, warnAfterMs: 0, profiles: [], providers: [] }),
   ),
@@ -68,6 +70,11 @@ vi.mock("../../infra/provider-usage.load.js", () => ({
 
 vi.mock("../../secrets/runtime.js", () => ({
   refreshActiveSecretsRuntimeSnapshot: mocks.refreshActiveSecretsRuntimeSnapshot,
+}));
+
+vi.mock("../../agents/model-provider-auth.js", () => ({
+  clearCurrentProviderAuthState: mocks.clearCurrentProviderAuthState,
+  warmCurrentProviderAuthState: mocks.warmCurrentProviderAuthState,
 }));
 
 import {
@@ -614,6 +621,8 @@ describe("models.authLogout", () => {
       agentDir: "/tmp/agent",
     });
     expect(mocks.refreshActiveSecretsRuntimeSnapshot).toHaveBeenCalledTimes(1);
+    expect(mocks.clearCurrentProviderAuthState).toHaveBeenCalled();
+    expect(mocks.warmCurrentProviderAuthState).toHaveBeenCalledWith({});
     const [ok, payload] = firstRespondCall(opts) ?? [];
     expect(ok).toBe(true);
     expect((payload as ModelAuthLogoutResult).removedProfiles).toEqual(["openrouter:default"]);

--- a/src/gateway/server-methods/models-auth-status.ts
+++ b/src/gateway/server-methods/models-auth-status.ts
@@ -15,6 +15,10 @@ import {
   removeProviderAuthProfilesWithLock,
   resolvePersistedAuthProfileOwnerAgentDir,
 } from "../../agents/auth-profiles.js";
+import {
+  clearCurrentProviderAuthState,
+  warmCurrentProviderAuthState,
+} from "../../agents/model-provider-auth.js";
 import { resolveProviderIdForAuth } from "../../agents/provider-auth-aliases.js";
 import { normalizeProviderId } from "../../agents/provider-id.js";
 import type { OpenClawConfig } from "../../config/config.js";
@@ -89,6 +93,12 @@ let cached: { ts: number; result: ModelAuthStatusResult } | null = null;
  */
 export function invalidateModelAuthStatusCache(): void {
   cached = null;
+  // The prepared provider-auth map (model-provider-auth.ts) was built from
+  // the pre-mutation auth state, so it must be invalidated alongside this
+  // cache whenever an auth-profile mutation lands (logout, login, token
+  // rotation, etc.). Without this, `/models` and pickers keep advertising
+  // providers the running gateway can no longer authenticate.
+  clearCurrentProviderAuthState();
 }
 
 function readProviderParam(params: Record<string, unknown>): string | null {
@@ -380,6 +390,9 @@ export const modelsAuthStatusHandlers: GatewayRequestHandlers = {
       }
       await refreshActiveSecretsRuntimeSnapshot();
       invalidateModelAuthStatusCache();
+      void warmCurrentProviderAuthState(context.getRuntimeConfig()).catch((err) => {
+        log.warn(`provider auth state rewarm after logout failed: ${formatForLog(err)}`);
+      });
       const { runIds: abortedRunIds } = abortChatRunsForProvider(
         createAuthLogoutAbortOps(context),
         {

--- a/src/gateway/server-methods/models-auth-status.ts
+++ b/src/gateway/server-methods/models-auth-status.ts
@@ -390,6 +390,7 @@ export const modelsAuthStatusHandlers: GatewayRequestHandlers = {
       }
       await refreshActiveSecretsRuntimeSnapshot();
       invalidateModelAuthStatusCache();
+      clearCurrentProviderAuthState();
       void warmCurrentProviderAuthState(context.getRuntimeConfig()).catch((err) => {
         log.warn(`provider auth state rewarm after logout failed: ${formatForLog(err)}`);
       });

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -40,6 +40,10 @@ const hoisted = vi.hoisted(() => ({
   activeEmbeddedRunSessionKeys: [] as string[],
   markRestartAbortedMainSessions: vi.fn(async (_params: unknown) => ({ marked: 1, skipped: 0 })),
   runtimeConfig: { value: { session: { store: "/tmp/active-sessions.json" } } as OpenClawConfig },
+  reloadEvents: [] as string[],
+  resetModelCatalogCache: vi.fn(() => {}),
+  clearCurrentProviderAuthState: vi.fn(() => {}),
+  warmCurrentProviderAuthState: vi.fn(async (_cfg: OpenClawConfig) => {}),
 }));
 
 vi.mock("../hooks/gmail-watcher.js", () => ({
@@ -95,6 +99,24 @@ vi.mock("../config/config.js", () => ({
   getRuntimeConfig: () => hoisted.runtimeConfig.value,
 }));
 
+vi.mock("../agents/model-catalog.js", () => ({
+  resetModelCatalogCache: () => {
+    hoisted.reloadEvents.push("reset-model-catalog");
+    hoisted.resetModelCatalogCache();
+  },
+}));
+
+vi.mock("../agents/model-provider-auth.js", () => ({
+  clearCurrentProviderAuthState: () => {
+    hoisted.reloadEvents.push("clear-provider-auth");
+    hoisted.clearCurrentProviderAuthState();
+  },
+  warmCurrentProviderAuthState: async (cfg: OpenClawConfig) => {
+    hoisted.reloadEvents.push("warm-provider-auth");
+    await hoisted.warmCurrentProviderAuthState(cfg);
+  },
+}));
+
 function createReloadHandlersForTest(logReload = { info: vi.fn(), warn: vi.fn() }) {
   const cron = { start: vi.fn(async () => {}), stop: vi.fn() };
   const heartbeatRunner = {
@@ -139,6 +161,76 @@ afterEach(() => {
   hoisted.activeEmbeddedRunSessionKeys.length = 0;
   hoisted.markRestartAbortedMainSessions.mockClear();
   hoisted.runtimeConfig.value = { session: { store: "/tmp/active-sessions.json" } };
+  hoisted.reloadEvents.length = 0;
+  hoisted.resetModelCatalogCache.mockClear();
+  hoisted.clearCurrentProviderAuthState.mockClear();
+  hoisted.warmCurrentProviderAuthState.mockClear();
+});
+
+describe("gateway hot reload model state", () => {
+  it("resets prepared model runtime state for every hot reload and rewarms after plugin reload", async () => {
+    const reloadPlugins = vi.fn(async (): Promise<GatewayPluginReloadResult> => {
+      hoisted.reloadEvents.push("reload-plugins");
+      return {
+        restartChannels: new Set(),
+        activeChannels: new Set(),
+      };
+    });
+    const { applyHotReload } = createGatewayReloadHandlers({
+      deps: {} as never,
+      broadcast: vi.fn(),
+      getState: () => ({
+        hooksConfig: {} as never,
+        hookClientIpConfig: {} as never,
+        heartbeatRunner: { stop: vi.fn(), updateConfig: vi.fn() } as never,
+        cronState: {
+          cron: { start: vi.fn(async () => {}), stop: vi.fn() },
+          storePath: "/tmp/cron.json",
+          cronEnabled: false,
+        } as never,
+        channelHealthMonitor: null,
+      }),
+      setState: vi.fn(),
+      startChannel: vi.fn(async () => {}),
+      stopChannel: vi.fn(async () => {}),
+      reloadPlugins,
+      logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      logChannels: { info: vi.fn(), error: vi.fn() },
+      logCron: { error: vi.fn() },
+      logReload: { info: vi.fn(), warn: vi.fn() },
+      createHealthMonitor: () => null,
+    });
+
+    const nextConfig = { plugins: { enabled: true } } as OpenClawConfig;
+    await applyHotReload(
+      {
+        changedPaths: ["plugins.enabled"],
+        restartGateway: false,
+        restartReasons: [],
+        hotReasons: ["plugins.enabled"],
+        reloadHooks: false,
+        restartGmailWatcher: false,
+        restartCron: false,
+        restartHeartbeat: false,
+        restartHealthMonitor: false,
+        reloadPlugins: true,
+        restartChannels: new Set(),
+        disposeMcpRuntimes: false,
+        noopPaths: [],
+      },
+      nextConfig,
+    );
+
+    expect(hoisted.reloadEvents).toEqual([
+      "reset-model-catalog",
+      "clear-provider-auth",
+      "reload-plugins",
+      "reset-model-catalog",
+      "clear-provider-auth",
+      "warm-provider-auth",
+    ]);
+    expect(hoisted.warmCurrentProviderAuthState).toHaveBeenCalledWith(nextConfig);
+  });
 });
 
 describe("gateway restart deferral preflight", () => {

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -306,20 +306,28 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
     const state = params.getState();
     const nextState = { ...state };
 
-    if (
-      plan.changedPaths.some(
-        (path) =>
-          path === "models" ||
-          path.startsWith("models.") ||
-          path === "agents.defaults.model" ||
-          path.startsWith("agents.defaults.model.") ||
-          path === "agents.defaults.models" ||
-          path.startsWith("agents.defaults.models."),
-      )
-    ) {
+    const modelConfigChanged = plan.changedPaths.some(
+      (path) =>
+        path === "models" ||
+        path.startsWith("models.") ||
+        path === "agents.defaults.model" ||
+        path.startsWith("agents.defaults.model.") ||
+        path === "agents.defaults.models" ||
+        path.startsWith("agents.defaults.models."),
+    );
+    if (modelConfigChanged) {
       resetModelCatalogCache();
-      clearCurrentProviderAuthState();
       markGatewayModelCatalogStaleForReload();
+    }
+    // Provider-auth answers come from env/synthetic/plugin sources as well
+    // as the model catalog, so plugin config changes (e.g. plugins.entries.*
+    // env vars or synthetic-auth wiring) can also flip the answer. Clear
+    // and rewarm whenever a model OR plugin path mutates.
+    if (
+      modelConfigChanged ||
+      plan.changedPaths.some((path) => path === "plugins" || path.startsWith("plugins."))
+    ) {
+      clearCurrentProviderAuthState();
       void warmCurrentProviderAuthState(nextConfig).catch((err) => {
         params.logReload.warn(`provider auth state rewarm failed: ${String(err)}`);
       });

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -322,15 +322,14 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
     // Provider-auth answers come from env/synthetic/plugin sources as well
     // as the model catalog, so plugin config changes (e.g. plugins.entries.*
     // env vars or synthetic-auth wiring) can also flip the answer. Clear
-    // and rewarm whenever a model OR plugin path mutates.
-    if (
+    // up front so callers don't keep seeing the pre-reload answer; the
+    // matching rewarm runs after plan.reloadPlugins so it reads the new
+    // plugin runtime.
+    const providerAuthStateInvalidated =
       modelConfigChanged ||
-      plan.changedPaths.some((path) => path === "plugins" || path.startsWith("plugins."))
-    ) {
+      plan.changedPaths.some((path) => path === "plugins" || path.startsWith("plugins."));
+    if (providerAuthStateInvalidated) {
       clearCurrentProviderAuthState();
-      void warmCurrentProviderAuthState(nextConfig).catch((err) => {
-        params.logReload.warn(`provider auth state rewarm failed: ${String(err)}`);
-      });
     }
 
     if (plan.reloadHooks) {
@@ -417,6 +416,14 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
         channelsToRestart.add(channel);
       }
       activePluginChannelsAfterReload = pluginReloadResult.activeChannels;
+    }
+
+    if (providerAuthStateInvalidated) {
+      // Schedule the rewarm after plan.reloadPlugins so the warmer reads
+      // the new plugin runtime, not the pre-reload one.
+      void warmCurrentProviderAuthState(nextConfig).catch((err) => {
+        params.logReload.warn(`provider auth state rewarm failed: ${String(err)}`);
+      });
     }
 
     if (plan.restartCron) {

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -90,6 +90,12 @@ const MCP_RUNTIME_RELOAD_DISPOSE_TIMEOUT_MS = 5_000;
 const CHANNEL_RELOAD_DEFERRAL_POLL_MS = 500;
 const CHANNEL_RELOAD_STILL_PENDING_WARN_MS = 30_000;
 
+function resetPreparedModelRuntimeStateForHotReload(): void {
+  resetModelCatalogCache();
+  clearCurrentProviderAuthState();
+  markGatewayModelCatalogStaleForReload();
+}
+
 async function disposeMcpRuntimesWithTimeout(params: {
   dispose: () => Promise<void>;
   timeoutMs: number;
@@ -306,31 +312,7 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
     const state = params.getState();
     const nextState = { ...state };
 
-    const modelConfigChanged = plan.changedPaths.some(
-      (path) =>
-        path === "models" ||
-        path.startsWith("models.") ||
-        path === "agents.defaults.model" ||
-        path.startsWith("agents.defaults.model.") ||
-        path === "agents.defaults.models" ||
-        path.startsWith("agents.defaults.models."),
-    );
-    if (modelConfigChanged) {
-      resetModelCatalogCache();
-      markGatewayModelCatalogStaleForReload();
-    }
-    // Provider-auth answers come from env/synthetic/plugin sources as well
-    // as the model catalog, so plugin config changes (e.g. plugins.entries.*
-    // env vars or synthetic-auth wiring) can also flip the answer. Clear
-    // up front so callers don't keep seeing the pre-reload answer; the
-    // matching rewarm runs after plan.reloadPlugins so it reads the new
-    // plugin runtime.
-    const providerAuthStateInvalidated =
-      modelConfigChanged ||
-      plan.changedPaths.some((path) => path === "plugins" || path.startsWith("plugins."));
-    if (providerAuthStateInvalidated) {
-      clearCurrentProviderAuthState();
-    }
+    resetPreparedModelRuntimeStateForHotReload();
 
     if (plan.reloadHooks) {
       try {
@@ -416,14 +398,7 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
         channelsToRestart.add(channel);
       }
       activePluginChannelsAfterReload = pluginReloadResult.activeChannels;
-    }
-
-    if (providerAuthStateInvalidated) {
-      // Schedule the rewarm after plan.reloadPlugins so the warmer reads
-      // the new plugin runtime, not the pre-reload one.
-      void warmCurrentProviderAuthState(nextConfig).catch((err) => {
-        params.logReload.warn(`provider auth state rewarm failed: ${String(err)}`);
-      });
+      resetPreparedModelRuntimeStateForHotReload();
     }
 
     if (plan.restartCron) {
@@ -524,6 +499,10 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
     }
 
     applyGatewayLaneConcurrency(nextConfig);
+
+    void warmCurrentProviderAuthState(nextConfig).catch((err) => {
+      params.logReload.warn(`provider auth state rewarm failed: ${String(err)}`);
+    });
 
     if (plan.hotReasons.length > 0) {
       params.logReload.info(`config hot reload applied (${plan.hotReasons.join(", ")})`);

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -1,4 +1,5 @@
 import { resetModelCatalogCache } from "../agents/model-catalog.js";
+import { clearCurrentProviderAuthState } from "../agents/model-provider-auth.js";
 import { disposeAllSessionMcpRuntimes } from "../agents/pi-bundle-mcp-tools.js";
 import {
   getActiveEmbeddedRunCount,
@@ -314,6 +315,7 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
       )
     ) {
       resetModelCatalogCache();
+      clearCurrentProviderAuthState();
       markGatewayModelCatalogStaleForReload();
     }
 

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -1,5 +1,8 @@
 import { resetModelCatalogCache } from "../agents/model-catalog.js";
-import { clearCurrentProviderAuthState } from "../agents/model-provider-auth.js";
+import {
+  clearCurrentProviderAuthState,
+  warmCurrentProviderAuthState,
+} from "../agents/model-provider-auth.js";
 import { disposeAllSessionMcpRuntimes } from "../agents/pi-bundle-mcp-tools.js";
 import {
   getActiveEmbeddedRunCount,
@@ -317,6 +320,9 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
       resetModelCatalogCache();
       clearCurrentProviderAuthState();
       markGatewayModelCatalogStaleForReload();
+      void warmCurrentProviderAuthState(nextConfig).catch((err) => {
+        params.logReload.warn(`provider auth state rewarm failed: ${String(err)}`);
+      });
     }
 
     if (plan.reloadHooks) {

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -1018,6 +1018,20 @@ export async function startGatewayPostAttachRuntime(
       params.log.warn(`gateway sidecars failed to start: ${String(err)}`);
     });
 
+  void sidecarsPromise
+    .then(async () => {
+      if (params.minimalTestGateway) {
+        return;
+      }
+      const { warmCurrentProviderAuthState } = await import("../agents/model-provider-auth.js");
+      const startMs = Date.now();
+      await warmCurrentProviderAuthState(params.cfgAtStart);
+      params.log.info(`provider auth state pre-warmed in ${Date.now() - startMs}ms`);
+    })
+    .catch((err) => {
+      params.log.warn(`provider auth state pre-warm failed: ${String(err)}`);
+    });
+
   if (params.deferSidecars !== true) {
     const [, tailscaleCleanup, sidecarsResult] = await Promise.all([
       startupLogPromise,

--- a/src/gateway/server.reload.test.ts
+++ b/src/gateway/server.reload.test.ts
@@ -58,6 +58,8 @@ const hoisted = vi.hoisted(() => {
   const startGmailWatcher = vi.fn(async () => ({ started: true }));
   const stopGmailWatcher = vi.fn(async () => {});
   const resetModelCatalogCache = vi.fn();
+  const clearCurrentProviderAuthState = vi.fn();
+  const warmCurrentProviderAuthState = vi.fn(async (_cfg: unknown) => {});
   const disposeAllSessionMcpRuntimes = vi.fn(async () => {});
   const resolveOpenClawPackageRootSync = vi.fn((_params: unknown) => "/package");
 
@@ -162,6 +164,8 @@ const hoisted = vi.hoisted(() => {
     startGmailWatcher,
     stopGmailWatcher,
     resetModelCatalogCache,
+    clearCurrentProviderAuthState,
+    warmCurrentProviderAuthState,
     disposeAllSessionMcpRuntimes,
     resolveOpenClawPackageRootSync,
     providerManager,
@@ -202,6 +206,11 @@ vi.mock("../agents/model-catalog.js", async () => {
     }),
   };
 });
+
+vi.mock("../agents/model-provider-auth.js", () => ({
+  clearCurrentProviderAuthState: hoisted.clearCurrentProviderAuthState,
+  warmCurrentProviderAuthState: hoisted.warmCurrentProviderAuthState,
+}));
 
 vi.mock("../agents/pi-bundle-mcp-tools.js", async () => {
   const actual = await vi.importActual<typeof import("../agents/pi-bundle-mcp-tools.js")>(
@@ -334,6 +343,9 @@ describe("gateway hot reload", () => {
     hoisted.activeTaskBlockers.length = 0;
     embeddedRunMock.activeIds.clear();
     hoisted.resetModelCatalogCache.mockReset();
+    hoisted.clearCurrentProviderAuthState.mockReset();
+    hoisted.warmCurrentProviderAuthState.mockReset();
+    hoisted.warmCurrentProviderAuthState.mockResolvedValue(undefined);
     hoisted.disposeAllSessionMcpRuntimes.mockReset();
     hoisted.disposeAllSessionMcpRuntimes.mockResolvedValue(undefined);
     hoisted.resolveOpenClawPackageRootSync.mockClear();


### PR DESCRIPTION
Listing models went from **~55 s cold / ~20 s every subsequent call** to **~5 ms (pre-warmed)** — a ~4,100× speedup on the hot path. Every `/models` call (Discord/Telegram pickers, CLI, status commands) now short-circuits through a prepared provider-auth map built once at gateway startup instead of rediscovering every provider's auth state from scratch on every invocation.

This also fixes the "This interaction failed" error in Discord's `/models` picker. Discord requires bots to ack or defer an interaction within 3 seconds. With the gateway's event loop blocked on a ~20 s auth-discovery sweep, the immediate `interaction.acknowledge()` in the picker handler couldn't actually run inside Discord's 3 s window — Discord invalidated the interaction token and the picker rendered the failure state. Cutting the hot-path work to ~5 ms keeps the gateway responsive so the ack happens immediately.

## Summary

`buildModelsProviderData` was spending ~20 s in `resolveVisibleModelCatalog`'s auth-filter loop — 30+ unique providers × ~600 ms each of plugin-runtime / external-CLI / auth-profile-store discovery, redone fresh on every call. The catalog itself was already cached via `modelCatalogPromise`; the per-provider auth check was the duplicate-lookup-branch the user-facing pickers were eating on every interaction.

This moves the canonical fact earlier: compute a `Map<provider, boolean>` once at gateway startup via `warmCurrentProviderAuthState`, hold it module-level, and have `hasAuthForModelProvider` consult it first. If a provider's answer is in the prepared map the function returns immediately; otherwise it falls through to the existing compute path. Invalidated on config reload alongside `resetModelCatalogCache` so the next read after a relevant config change rewarms.

Per CLAUDE.md "move the canonical fact earlier; reuse prepared runtime objects; delete duplicate lookup branches" — no new caches scattered through request-time code, no per-channel plumbing, no new SDK surface. One module-level prepared object with an explicit set / clear lifecycle modeled on `PluginMetadataSnapshot`.

## Verification

Benchmarked on local dev gateway (`./run.sh openclaw gateway run`), catalog of 955 entries / 40 unique providers / 167 visible after auth, single machine same config, captured back-to-back. Trigger was `/models` via Discord (`@sjf_claw`) — same code path every other model-listing call hits.

Behavior addressed: `buildModelsProviderData` (the chokepoint behind `/models` / model pickers) recomputes the per-provider auth state on every call.
Real environment tested: macOS local openclaw dev, catalog with bundled + external plugins, Discord channel live.
Exact steps or command run after this patch: SIGINT the gateway to rebuild on this branch; let warmer complete after `[gateway] gateway ready`; trigger `/models` 12 times in Discord; grep `sjfsjfsjf buildModelsProviderData done` from `/tmp/openclaw/openclaw-*.log` (instrumentation since stripped before commit).
Evidence after fix: see Timings table below. Raw samples preserved in `PICKER-PERF-TIMINGS.md` in the dev workspace.
Observed result after fix: per-call `buildModelsProviderData` dropped from ~20.5 s (n=8) to ~5 ms (n=12). Discord no longer shows "This interaction failed" on the picker.
What was not tested: Telegram + CLI `/models` paths (same code path, expected to benefit identically); Crabbox; multi-agent gateways where multiple `agentId` values flow through the picker (the prepared map is cfg-keyed, not agent-keyed — both before this PR and after, `hasAuthForModelProvider` is agent-agnostic).

### Timings

BEFORE (HEAD without this patch), n=8 subsequent + 1 cold:

| Metric | ms |
|---|---|
| First call (cold catalog) | 54,812 |
| Subsequent calls min | 20,403 |
| Subsequent calls median | ~20,570 |
| Subsequent calls max | 20,766 |
| Subsequent calls mean | ~20,569 |

AFTER (this PR), n=12 post-warm + warmer:

| Metric | ms |
|---|---|
| Hot-path call min | 1 |
| Hot-path call median | ~5 |
| Hot-path call max | 6 |
| Hot-path call mean | ~4.3 |
| One-time gateway-startup warm (40 providers) | 49,203 |

Headline:

| Scenario | BEFORE | AFTER | Speedup |
|---|---|---|---|
| First `/models` after restart | 54,812 ms | ~5 ms (post-warm) | ~10,000× |
| Every subsequent `/models` | ~20,569 ms | ~5 ms | ~4,100× |
| One-time startup warm cost | n/a | 49,203 ms | — |

The 49 s warm cost is not a regression: it's the same auth-discovery sweep the BEFORE workload was paying on every call, plus the cold-catalog `loadModelCatalog` (~26 s) which BEFORE also pays on its first call. AFTER pays both once at startup. On a reload that clears only the auth state (catalog already cached), warm is the ~23 s auth portion only.
