### PR TITLE
fix(gateway): dedupe live tool event mirrors

### DIFF
--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -1519,6 +1519,45 @@ describe("agent event handler", () => {
     resetAgentRunContextForTest();
   });
 
+  it("does not mirror tool events back to run-scoped recipients", () => {
+    const { broadcastToConnIds, sessionEventSubscribers, toolEventRecipients, handler } =
+      createHarness({
+        resolveSessionKeyForRun: () => "session-1",
+      });
+
+    registerAgentRunContext("run-session-tool-dedupe", {
+      sessionKey: "session-1",
+      verboseLevel: "off",
+    });
+    toolEventRecipients.add("run-session-tool-dedupe", "conn-run");
+    sessionEventSubscribers.subscribe("conn-run");
+    sessionEventSubscribers.subscribe("conn-late");
+
+    handler({
+      runId: "run-session-tool-dedupe",
+      seq: 1,
+      stream: "tool",
+      ts: 1_234,
+      data: {
+        phase: "start",
+        name: "exec",
+        toolCallId: "tool-session-dedupe",
+        args: { command: "echo hi" },
+      },
+    });
+
+    expect(broadcastToConnIds).toHaveBeenCalledTimes(2);
+    expect(requireMockArg(broadcastToConnIds, 0, 0, "run tool event")).toBe("agent");
+    expect(requireMockArg(broadcastToConnIds, 0, 2, "run tool recipients")).toEqual(
+      new Set(["conn-run"]),
+    );
+    expect(requireMockArg(broadcastToConnIds, 1, 0, "session tool event")).toBe("session.tool");
+    expect(requireMockArg(broadcastToConnIds, 1, 2, "session tool recipients")).toEqual(
+      new Set(["conn-late"]),
+    );
+    resetAgentRunContextForTest();
+  });
+
   it("suppresses heartbeat tool events for Control UI and verbose node subscribers", () => {
     const {
       broadcastToConnIds,

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -903,11 +903,15 @@ export function createAgentEventHandler({
       // they can render live pending tool cards without polling history.
       if (isControlUiVisible && sessionKey && !suppressHeartbeatToolEvents) {
         const sessionSubscribers = sessionEventSubscribers.getAll();
-        if (sessionSubscribers.size > 0) {
+        const sessionToolRecipients =
+          recipients && recipients.size > 0
+            ? new Set([...sessionSubscribers].filter((connId) => !recipients.has(connId)))
+            : sessionSubscribers;
+        if (sessionToolRecipients.size > 0) {
           broadcastToConnIds(
             "session.tool",
             { ...agentPayload, ...buildSessionEventSnapshot(sessionKey) },
-            sessionSubscribers,
+            sessionToolRecipients,
             { dropIfSlow: true },
           );
         }


### PR DESCRIPTION
## Summary

- Problem: live tool events are broadcast both as run-scoped `agent` events and session-scoped `session.tool` mirrors, so overlapping Control UI subscriptions can receive duplicate websocket frames for the same tool activity.
- Solution: exclude run-scoped tool recipients from the `session.tool` mirror recipient set.
- What changed: `createAgentEventHandler` now sends `session.tool` only to session subscribers that did not already receive the run-scoped tool event, with a regression test for mixed overlapping and late-joining recipients.
- What did NOT change (scope boundary): late-joining session subscribers still receive `session.tool`; node/channel verbose delivery and tool payload shaping are unchanged.

## Motivation

- A live profile showed high websocket event volume during an embedded `exec` tool window while the gateway was CPU-bound. Removing duplicate delivery for overlapping subscriptions reduces avoidable serialization/logging work without changing the UI contract for late joiners.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #84821
- Closes #84850
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior addressed: overlapping run-scoped `agent` tool recipients no longer receive the session-scoped `session.tool` mirror for the same live tool event.
- Real environment tested: local OpenClaw source checkout on Linux/WSL-style environment with Node v24.15.0, focused gateway event handler test run after applying the patch.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/gateway/server-chat.agent-events.test.ts`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): terminal output captured from the patched branch:

```text
RUN  v4.1.6 /home/galini/GitHub/worktrees/bug-032-dedupe-tool-event-mirror

Test Files  1 passed (1)
Tests  69 passed (69)
Start at  05:22:44
Duration  5.86s (transform 4.56s, setup 684ms, import 4.80s, tests 115ms, environment 0ms)
```

- Observed result after fix: the new regression test observed two targeted websocket sends: `agent` to `conn-run` and `session.tool` only to `conn-late`, proving the overlapping `conn-run` subscriber is not mirrored back through `session.tool` while a late session subscriber still receives the tool event.
- What was not tested: no live Control UI/pidstat repro rerun was performed after this patch; the fix was seam-tested at the gateway event handler where recipients are selected. The diagnostic pressure backoff follow-up is covered separately by #84846.
- Before evidence (optional but encouraged): redacted live profile excerpt from the reported bug:

```text
window_lines=109
total=109
ws=92
agent_event=12
command_output=2
session_tool=7
heartbeat_event=31
fetch_timeout=1
embedded_tool=5
session_message=2
sessions_changed=3

2026-05-21T05:07:05.820+00:00 gateway/ws event session.tool seq=targeted clients=1 targets=1 dropIfSlow=true
2026-05-21T05:08:04.299+00:00 gateway/ws event agent seq=per-client clients=1 run=[redacted run id] agent=main-pr-router session=main stream=command_output aseq=69
2026-05-21T05:08:12.700+00:00 gateway/ws event session.tool seq=targeted clients=1 targets=1 dropIfSlow=true
2026-05-21T05:08:12.709+00:00 gateway/ws event agent seq=per-client clients=1 run=[redacted run id] agent=main-pr-router session=main stream=command_output aseq=73
```

## Root Cause (if applicable)

- Root cause: the session-scoped tool mirror used the complete session subscriber set even when some connections had already registered as run-scoped tool recipients.
- Missing detection / guardrail: gateway tests covered run-scoped delivery and session-scoped mirroring independently, but did not cover an overlapping connection subscribed to both surfaces.
- Contributing context (if known): Control UI websocket clients advertise `tool-events` and can also subscribe to session events, so overlap is a normal production state.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/server-chat.agent-events.test.ts`
- Scenario the test should lock in: an overlapping run-scoped and session-scoped websocket connection receives only the run-scoped `agent` event, while a late session-only subscriber receives `session.tool`.
- Why this is the smallest reliable guardrail: recipient selection happens in `createAgentEventHandler`; the test exercises that seam without starting a full gateway server.
- Existing test that already covers this (if any): existing tests covered each delivery path separately, not overlap.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Overlapping Control UI websocket clients receive fewer duplicate live tool frames. Session-only clients still receive live `session.tool` events.

## Diagram (if applicable)

```text
Before:
run tool event -> conn-run via agent
run tool event -> conn-run + conn-late via session.tool

After:
run tool event -> conn-run via agent
run tool event -> conn-late via session.tool
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux/WSL-style local source checkout
- Runtime/container: Node v24.15.0
- Model/provider: N/A for gateway event-handler seam test
- Integration/channel (if any): Gateway websocket event handling
- Relevant config (redacted): N/A

### Steps

1. Apply the patch.
2. Run `node scripts/run-vitest.mjs src/gateway/server-chat.agent-events.test.ts`.
3. Inspect the new overlapping recipient test.

### Expected

- Run-scoped recipient gets `agent`.
- Session-only late subscriber gets `session.tool`.
- Overlapping run-scoped recipient is excluded from `session.tool`.

### Actual

- The focused test file passed with 69 tests.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: focused gateway event handler test; diff hygiene via `git diff --check`; Codex review found no blocking correctness issues.
- Edge cases checked: overlapping run-scoped/session-scoped recipient plus a session-only late recipient.
- What you did **not** verify: live Control UI pidstat/websocket-count rerun.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: a client that relies only on session-scoped events could miss tool updates if it is incorrectly registered as a run-scoped recipient.
  - Mitigation: run-scoped registration is keyed by websocket connection id and only added when the client advertises `tool-events`; the regression test proves non-overlapping session subscribers still receive the mirror.

