### PR TITLE
Preserve session context and durable Telegram progress

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -1539,10 +1539,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
     await dispatchWithContext({ context: createContext() });
 
-    expect(answerDraftStream.update).toHaveBeenNthCalledWith(
-      1,
-      expect.stringMatching(/`🛠️ Exec`$/),
-    );
+    expect(answerDraftStream.update).toHaveBeenNthCalledWith(1, "Cracking\n\n`🛠️ Exec`");
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(2, "Branch is up to date");
     expect(answerDraftStream.forceNewMessage).toHaveBeenCalledTimes(1);
     expect(answerDraftStream.clear).toHaveBeenCalledTimes(1);
@@ -1574,8 +1571,8 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(rotationOrder).toBeLessThan(finalUpdateOrder);
   });
 
-  it("keeps progress updates in a draft and sends the final answer normally", async () => {
-    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+  it("sends progress updates as durable messages and sends the final answer normally", async () => {
+    setupDraftStreams({ answerMessageId: 2001 });
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
       async ({ dispatcherOptions, replyOptions }) => {
         await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
@@ -1595,18 +1592,15 @@ describe("dispatchTelegramMessage draft streaming", () => {
       telegramCfg: { streaming: { mode: "progress" } },
     });
 
-    expect(answerDraftStream.update).toHaveBeenCalledWith(
-      "Cracking\n\n`🛠️ Exec`\n`🛠️ git rev-parse --abbrev-ref HEAD`",
-    );
-    expect(answerDraftStream.update).not.toHaveBeenCalledWith("Branch is up to date");
-    expect(answerDraftStream.forceNewMessage).toHaveBeenCalledTimes(1);
-    expect(answerDraftStream.clear).toHaveBeenCalledTimes(1);
-    expectDeliveredReply(0, { text: "Branch is up to date" });
+    expect(createTelegramDraftStream).not.toHaveBeenCalled();
+    expectDeliveredReply(0, { text: expect.stringContaining("Exec") }, 0);
+    expectDeliveredReply(0, { text: expect.stringContaining("git rev-parse") }, 1);
+    expectDeliveredReply(0, { text: "Branch is up to date" }, 2);
     expect(editMessageTelegram).not.toHaveBeenCalled();
   });
 
-  it("does not restart progress drafts after final answer delivery", async () => {
-    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+  it("does not send more standalone progress after final answer delivery", async () => {
+    setupDraftStreams({ answerMessageId: 2001 });
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
       async ({ dispatcherOptions, replyOptions }) => {
         await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
@@ -1622,9 +1616,10 @@ describe("dispatchTelegramMessage draft streaming", () => {
       telegramCfg: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
     });
 
-    expect(answerDraftStream.update).toHaveBeenCalledTimes(1);
-    expect(answerDraftStream.update).toHaveBeenCalledWith("Shelling\n\n`🛠️ Exec`");
-    expectDeliveredReply(0, { text: "Branch is up to date" });
+    expect(createTelegramDraftStream).not.toHaveBeenCalled();
+    expectDeliveredReply(0, { text: expect.stringContaining("Exec") }, 0);
+    expectDeliveredReply(0, { text: "Branch is up to date" }, 1);
+    expect(deliverReplies).toHaveBeenCalledTimes(2);
   });
 
   it("uses the transcript final when progress-mode final text is truncated", async () => {
@@ -1656,7 +1651,8 @@ describe("dispatchTelegramMessage draft streaming", () => {
       telegramCfg: { streaming: { mode: "progress" } },
     });
 
-    expectDeliveredReply(0, { text: fullAnswer });
+    expectDeliveredReply(0, { text: expect.stringContaining("Exec") }, 0);
+    expectDeliveredReply(0, { text: fullAnswer }, 1);
   });
 
   it("streams the first long final chunk and sends follow-up chunks", async () => {
@@ -1729,9 +1725,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expectDeliveredReply(0, { text: undefined, mediaUrl: "https://example.com/a.png" });
   });
 
-  it("shows Telegram progress drafts immediately for explicit tool starts", async () => {
-    const draftStream = createSequencedDraftStream(2001);
-    createTelegramDraftStream.mockReturnValue(draftStream);
+  it("sends Telegram progress immediately for explicit tool starts", async () => {
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
       await replyOptions?.onReplyStart?.();
       await replyOptions?.onAssistantMessageStart?.();
@@ -1745,13 +1739,11 @@ describe("dispatchTelegramMessage draft streaming", () => {
       telegramCfg: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
     });
 
-    expect(draftStream.update).toHaveBeenCalledWith("Shelling\n\n`🛠️ Exec`");
-    expect(draftStream.flush).toHaveBeenCalled();
+    expect(createTelegramDraftStream).not.toHaveBeenCalled();
+    expectDeliveredReply(0, { text: expect.stringContaining("Exec") });
   });
 
-  it("keeps the progress draft label when tool progress lines are hidden", async () => {
-    const draftStream = createSequencedDraftStream(2001);
-    createTelegramDraftStream.mockReturnValue(draftStream);
+  it("does not send standalone tool progress when progress lines are hidden", async () => {
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
       await replyOptions?.onReplyStart?.();
       await replyOptions?.onAssistantMessageStart?.();
@@ -1770,46 +1762,11 @@ describe("dispatchTelegramMessage draft streaming", () => {
       },
     });
 
-    expect(draftStream.update).toHaveBeenCalledWith("Shelling");
-    expect(draftStream.flush).toHaveBeenCalled();
+    expect(createTelegramDraftStream).not.toHaveBeenCalled();
+    expect(deliverReplies).not.toHaveBeenCalled();
   });
 
-  it("keeps progress draft labels static while the draft is active", async () => {
-    const draftStream = createSequencedDraftStream(2001);
-    createTelegramDraftStream.mockReturnValue(draftStream);
-    let finishRun: (() => void) | undefined;
-    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
-      await replyOptions?.onReplyStart?.();
-      await replyOptions?.onAssistantMessageStart?.();
-      await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
-      await new Promise<void>((resolve) => {
-        finishRun = resolve;
-      });
-      return { queuedFinal: false };
-    });
-
-    const run = dispatchWithContext({
-      context: createContext(),
-      streamMode: "progress",
-      telegramCfg: {
-        streaming: {
-          mode: "progress",
-          progress: { label: "Working", toolProgress: false },
-        },
-      },
-    });
-
-    await vi.waitFor(() => expect(draftStream.update).toHaveBeenCalledWith("Working"));
-    expect(draftStream.update).not.toHaveBeenCalledWith("Working.");
-    expect(draftStream.update).not.toHaveBeenCalledWith("Working..");
-    expect(draftStream.update).not.toHaveBeenCalledWith("Working...");
-    finishRun?.();
-    await run;
-  });
-
-  it("renders Telegram progress drafts before slow status reactions resolve", async () => {
-    const draftStream = createSequencedDraftStream(2001);
-    createTelegramDraftStream.mockReturnValue(draftStream);
+  it("sends Telegram progress before slow status reactions resolve", async () => {
     let releaseSetTool: (() => void) | undefined;
     const statusReactionController = createStatusReactionController();
     statusReactionController.setTool.mockImplementation(
@@ -1822,10 +1779,14 @@ describe("dispatchTelegramMessage draft streaming", () => {
       const pendingToolStart = replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
       await Promise.resolve();
       await Promise.resolve();
-      const updateBeforeStatusReaction = draftStream.update.mock.calls.at(-1)?.[0];
+      const progressBeforeStatusReaction = deliverReplies.mock.calls.at(-1)?.[0];
       releaseSetTool?.();
       await pendingToolStart;
-      expect(updateBeforeStatusReaction).toMatch(/^Shelling\n`🛠️ Exec`$/);
+      expect(progressBeforeStatusReaction).toEqual(
+        expect.objectContaining({
+          replies: [expect.objectContaining({ text: expect.stringContaining("Exec") })],
+        }),
+      );
       return { queuedFinal: false };
     });
 
@@ -1840,9 +1801,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(statusReactionController.setTool).toHaveBeenCalledWith("exec");
   });
 
-  it("keeps non-command Telegram progress draft lines across post-tool assistant boundaries", async () => {
-    const draftStream = createSequencedDraftStream(2001);
-    createTelegramDraftStream.mockReturnValue(draftStream);
+  it("keeps non-command Telegram progress as durable messages across assistant boundaries", async () => {
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
       async ({ dispatcherOptions, replyOptions }) => {
         await replyOptions?.onReplyStart?.();
@@ -1861,13 +1820,10 @@ describe("dispatchTelegramMessage draft streaming", () => {
       telegramCfg: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
     });
 
-    expect(draftStream.update).toHaveBeenCalledWith(
-      "Shelling\n\n`🔎 Web Search: docs lookup`\n• `tests passed`",
-    );
-    expect(draftStream.forceNewMessage).toHaveBeenCalledTimes(1);
-    expect(draftStream.materialize).not.toHaveBeenCalled();
-    expect(draftStream.clear).toHaveBeenCalledTimes(1);
-    expectDeliveredReply(0, { text: "Final after tool" });
+    expect(createTelegramDraftStream).not.toHaveBeenCalled();
+    expectDeliveredReply(0, { text: expect.stringContaining("docs lookup") }, 0);
+    expectDeliveredReply(0, { text: expect.stringContaining("tests passed") }, 1);
+    expectDeliveredReply(0, { text: "Final after tool" }, 2);
     expect(editMessageTelegram).not.toHaveBeenCalled();
   });
 

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -550,12 +550,14 @@ export const dispatchTelegramMessage = async ({
     }
   }
   const hasTelegramQuoteReply = replyToMode !== "off" && replyQuoteText != null;
+  const canUseDraftLanes = streamMode !== "progress";
   const canStreamAnswerDraft =
+    canUseDraftLanes &&
     streamDeliveryEnabled &&
     !hasTelegramQuoteReply &&
     !accountBlockStreamingEnabled &&
     !forceBlockStreamingForReasoning;
-  const canStreamReasoningDraft = !isRoomEvent && streamReasoningDraft;
+  const canStreamReasoningDraft = canUseDraftLanes && !isRoomEvent && streamReasoningDraft;
   const draftReplyToMessageId =
     replyToMode !== "off" && typeof msg.message_id === "number"
       ? (replyQuoteMessageId ?? msg.message_id)
@@ -600,8 +602,8 @@ export const dispatchTelegramMessage = async ({
   };
   const answerLane = lanes.answer;
   const reasoningLane = lanes.reasoning;
-  const streamToolProgressEnabled =
-    Boolean(answerLane.stream) && resolveChannelStreamingPreviewToolProgress(telegramCfg);
+  const streamToolProgressVisible = resolveChannelStreamingPreviewToolProgress(telegramCfg);
+  const streamToolProgressEnabled = Boolean(answerLane.stream) && streamToolProgressVisible;
   const nativeToolProgressDraft =
     streamToolProgressEnabled &&
     !isRoomEvent &&
@@ -662,19 +664,34 @@ export const dispatchTelegramMessage = async ({
       await renderProgressDraft({ flush: true });
     },
   });
+  let sendStandaloneToolProgress: ((text: string) => Promise<boolean>) | undefined;
   const pushStreamToolProgress = async (
     line?: string | ChannelProgressDraftLine,
     options?: { toolName?: string; startImmediately?: boolean },
-  ) => {
-    if (!answerLane.stream) {
-      return false;
-    }
+  ): Promise<boolean> => {
     if (options?.toolName !== undefined && !isChannelProgressDraftWorkToolName(options.toolName)) {
       return false;
     }
     const rawText = typeof line === "string" ? line : line?.text;
     const normalized = sanitizeProgressMarkdownText(rawText?.replace(/\s+/g, " ").trim() ?? "");
-    if (streamToolProgressSuppressed) {
+    if (!normalized || streamToolProgressSuppressed) {
+      return false;
+    }
+    if (streamMode === "progress" && !answerLane.stream) {
+      if (!streamToolProgressVisible || isRoomEvent) {
+        return false;
+      }
+      const delivered = (await sendStandaloneToolProgress?.(normalized)) ?? false;
+      if (delivered) {
+        void Promise.resolve(sendTyping()).catch((err) => {
+          logVerbose(
+            `telegram typing cue after tool progress failed for chat ${chatId}: ${String(err)}`,
+          );
+        });
+      }
+      return delivered;
+    }
+    if (!answerLane.stream) {
       return false;
     }
     if (streamMode !== "progress" && !streamToolProgressEnabled) {
@@ -1176,6 +1193,16 @@ export const dispatchTelegramMessage = async ({
       }
       return result.delivered;
     };
+    sendStandaloneToolProgress = async (text: string) => {
+      const result = await (telegramDeps.deliverReplies ?? deliverReplies)({
+        ...deliveryBaseOptions,
+        replies: [{ text }],
+        onVoiceRecording: sendRecordVoice,
+        silent: false,
+        mediaLoader: telegramDeps.loadWebMedia,
+      });
+      return result.delivered;
+    };
     const emitPreviewFinalizedHook = (result: LaneDeliveryResult) => {
       if (isDispatchSuperseded() || result.kind !== "preview-finalized") {
         return;
@@ -1243,6 +1270,7 @@ export const dispatchTelegramMessage = async ({
         resetDraftLaneState(answerLane);
       }
       const delivered = await sendPayload(applyTextToPayload(payload, text), { durable: true });
+      streamToolProgressSuppressed = true;
       answerLane.finalized = true;
       return delivered ? { kind: "sent" } : { kind: "skipped" };
     };

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -10,19 +10,15 @@ import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import { clearCliSession, setCliSessionBinding, setCliSessionId } from "../cli-session.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
 import { isCliProvider } from "../model-selection.js";
+import { resolvePreservedSessionContextTokens } from "../session-context-tokens.js";
 import { deriveSessionTotalTokens, hasNonzeroUsage } from "../usage.js";
 
 type RunResult = Awaited<ReturnType<(typeof import("../pi-embedded.js"))["runEmbeddedPiAgent"]>>;
 
 const usageFormatModuleLoader = createLazyImportLoader(() => import("../../utils/usage-format.js"));
-const contextModuleLoader = createLazyImportLoader(() => import("../context.js"));
 
 async function getUsageFormatModule() {
   return await usageFormatModuleLoader.load();
-}
-
-async function getContextModule() {
-  return await contextModuleLoader.load();
 }
 
 function resolveNonNegativeNumber(value: number | undefined): number | undefined {
@@ -95,18 +91,6 @@ export async function updateSessionStoreAfterAgentRun(params: {
   const providerUsed = result.meta.agentMeta?.provider ?? fallbackProvider ?? defaultProvider;
   const agentHarnessId = normalizeOptionalString(result.meta.agentMeta?.agentHarnessId);
   const runtimeContextTokens = resolvePositiveInteger(result.meta.agentMeta?.contextTokens);
-  const contextTokens =
-    runtimeContextTokens !== undefined
-      ? runtimeContextTokens
-      : typeof params.contextTokensOverride === "number" && params.contextTokensOverride > 0
-        ? params.contextTokensOverride
-        : ((await getContextModule()).resolveContextTokensForModel({
-            cfg,
-            provider: providerUsed,
-            model: modelUsed,
-            fallbackContextTokens: DEFAULT_CONTEXT_TOKENS,
-            allowAsyncLoad: false,
-          }) ?? DEFAULT_CONTEXT_TOKENS);
 
   const preserveRuntimeModel = params.preserveRuntimeModel === true;
   const entry = sessionStore[sessionKey] ?? {
@@ -114,6 +98,16 @@ export async function updateSessionStoreAfterAgentRun(params: {
     updatedAt: now,
     sessionStartedAt: now,
   };
+  const contextTokens = resolvePreservedSessionContextTokens({
+    cfg,
+    provider: providerUsed,
+    model: modelUsed,
+    runtimeContextTokens,
+    contextTokensOverride: params.contextTokensOverride,
+    existingEntry: entry,
+    fallbackContextTokens: DEFAULT_CONTEXT_TOKENS,
+    allowAsyncLoad: false,
+  });
   const next: SessionEntry = {
     ...entry,
     sessionId,

--- a/src/agents/session-context-tokens.test.ts
+++ b/src/agents/session-context-tokens.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolvePreservedSessionContextTokens } from "./session-context-tokens.js";
+
+describe("resolvePreservedSessionContextTokens", () => {
+  it("preserves an existing larger session context over smaller runtime metadata", () => {
+    expect(
+      resolvePreservedSessionContextTokens({
+        cfg: { agents: { defaults: { contextTokens: 1_050_000 } } } as OpenClawConfig,
+        provider: "openai-codex",
+        model: "gpt-5.5",
+        runtimeContextTokens: 272_000,
+        existingEntry: {
+          sessionId: "s1",
+          modelProvider: "openai-codex",
+          model: "gpt-5.5",
+          contextTokens: 1_050_000,
+          updatedAt: 1,
+        },
+        fallbackContextTokens: 200_000,
+        allowAsyncLoad: false,
+      }),
+    ).toBe(1_050_000);
+  });
+
+  it("uses the largest explicit candidate instead of blindly trusting runtime", () => {
+    expect(
+      resolvePreservedSessionContextTokens({
+        cfg: {} as OpenClawConfig,
+        runtimeContextTokens: 272_000,
+        contextTokensOverride: 1_050_000,
+        existingContextTokens: 200_000,
+        fallbackContextTokens: 128_000,
+        allowAsyncLoad: false,
+      }),
+    ).toBe(1_050_000);
+  });
+});

--- a/src/agents/session-context-tokens.ts
+++ b/src/agents/session-context-tokens.ts
@@ -1,0 +1,79 @@
+import type { SessionEntry } from "../config/sessions.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveContextTokensForModel } from "./context.js";
+import { DEFAULT_CONTEXT_TOKENS } from "./defaults.js";
+
+function positiveInteger(value: number | undefined): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return undefined;
+  }
+  return Math.floor(value);
+}
+
+function sameRuntimeModel(params: {
+  entry?: SessionEntry;
+  provider?: string;
+  model?: string;
+}): boolean {
+  if (!params.entry) {
+    return false;
+  }
+  const entryModel = params.entry.model?.trim();
+  const nextModel = params.model?.trim();
+  if (entryModel && nextModel && entryModel !== nextModel) {
+    return false;
+  }
+  const entryProvider = params.entry.modelProvider?.trim();
+  const nextProvider = params.provider?.trim();
+  if (entryProvider && nextProvider && entryProvider !== nextProvider) {
+    return false;
+  }
+  return true;
+}
+
+export function resolvePreservedSessionContextTokens(params: {
+  cfg?: OpenClawConfig;
+  provider?: string;
+  model?: string;
+  runtimeContextTokens?: number;
+  contextTokensOverride?: number;
+  existingContextTokens?: number;
+  existingEntry?: SessionEntry;
+  fallbackContextTokens?: number;
+  allowAsyncLoad?: boolean;
+}): number {
+  const candidates: number[] = [];
+  const add = (value: number | undefined) => {
+    const resolved = positiveInteger(value);
+    if (resolved !== undefined) {
+      candidates.push(resolved);
+    }
+  };
+
+  add(params.runtimeContextTokens);
+  add(params.contextTokensOverride);
+  add(params.existingContextTokens);
+  if (
+    sameRuntimeModel({
+      entry: params.existingEntry,
+      provider: params.provider,
+      model: params.model,
+    })
+  ) {
+    add(params.existingEntry?.contextTokens);
+  }
+  add(params.cfg?.agents?.defaults?.contextTokens);
+  add(
+    resolveContextTokensForModel({
+      cfg: params.cfg,
+      provider: params.provider,
+      model: params.model,
+      fallbackContextTokens: params.fallbackContextTokens ?? DEFAULT_CONTEXT_TOKENS,
+      allowAsyncLoad: params.allowAsyncLoad,
+    }),
+  );
+  add(params.fallbackContextTokens);
+  add(DEFAULT_CONTEXT_TOKENS);
+
+  return Math.max(...candidates);
+}

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -5,7 +5,6 @@ import {
   resolveAgentConfig,
   resolveSessionAgentId,
 } from "../../agents/agent-scope.js";
-import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { resolveModelAuthMode } from "../../agents/model-auth.js";
 import { isCliProvider } from "../../agents/model-selection.js";
@@ -13,6 +12,7 @@ import {
   formatEmbeddedPiQueueFailureSummary,
   queueEmbeddedPiMessageWithOutcomeAsync,
 } from "../../agents/pi-embedded-runner/runs.js";
+import { resolvePreservedSessionContextTokens } from "../../agents/session-context-tokens.js";
 import { deriveContextPromptTokens, hasNonzeroUsage, normalizeUsage } from "../../agents/usage.js";
 import { enqueueCommitmentExtraction } from "../../commitments/runtime.js";
 import type { OpenClawConfig } from "../../config/config.js";
@@ -1596,17 +1596,19 @@ export async function runReplyAgent(params: {
       runResult.meta.agentMeta.contextTokens > 0
         ? Math.floor(runResult.meta.agentMeta.contextTokens)
         : undefined;
-    const contextTokensUsed =
-      runtimeContextTokens ??
-      resolveContextTokensForModel({
-        cfg,
-        provider: providerUsed,
-        model: modelUsed,
-        contextTokensOverride: agentCfgContextTokens,
-        fallbackContextTokens: activeSessionEntry?.contextTokens ?? DEFAULT_CONTEXT_TOKENS,
-        allowAsyncLoad: false,
-      }) ??
-      DEFAULT_CONTEXT_TOKENS;
+    const contextTokensUsed = resolvePreservedSessionContextTokens({
+      cfg,
+      provider: providerUsed,
+      model: modelUsed,
+      runtimeContextTokens,
+      contextTokensOverride: agentCfgContextTokens,
+      existingEntry: activeSessionEntry,
+      fallbackContextTokens: activeSessionEntry?.contextTokens ?? DEFAULT_CONTEXT_TOKENS,
+      allowAsyncLoad: false,
+    });
+    if (runResult.meta?.agentMeta) {
+      runResult.meta.agentMeta.contextTokens = contextTokensUsed;
+    }
 
     await persistRunSessionUsage({
       storePath,

--- a/src/auto-reply/reply/session-usage.ts
+++ b/src/auto-reply/reply/session-usage.ts
@@ -1,4 +1,5 @@
 import { setCliSessionBinding, setCliSessionId } from "../../agents/cli-session.js";
+import { resolvePreservedSessionContextTokens } from "../../agents/session-context-tokens.js";
 import {
   deriveSessionTotalTokens,
   hasNonzeroUsage,
@@ -113,7 +114,15 @@ export async function persistSessionUsageUpdate(params: {
         storePath,
         sessionKey,
         update: async (entry) => {
-          const resolvedContextTokens = params.contextTokensUsed ?? entry.contextTokens;
+          const resolvedContextTokens = resolvePreservedSessionContextTokens({
+            cfg,
+            provider: params.providerUsed ?? entry.modelProvider,
+            model: params.modelUsed ?? entry.model,
+            runtimeContextTokens: params.contextTokensUsed,
+            existingEntry: entry,
+            fallbackContextTokens: entry.contextTokens,
+            allowAsyncLoad: false,
+          });
           // Use last-call usage for totalTokens when available. The accumulated
           // `usage.input` sums input tokens from every API call in the run
           // (tool-use loops, compaction retries), overstating actual context.
@@ -189,7 +198,15 @@ export async function persistSessionUsageUpdate(params: {
                 ? entry.modelProvider
                 : (params.providerUsed ?? entry.modelProvider),
             model: params.isHeartbeat === true ? entry.model : (params.modelUsed ?? entry.model),
-            contextTokens: params.contextTokensUsed ?? entry.contextTokens,
+            contextTokens: resolvePreservedSessionContextTokens({
+              cfg,
+              provider: params.providerUsed ?? entry.modelProvider,
+              model: params.modelUsed ?? entry.model,
+              runtimeContextTokens: params.contextTokensUsed,
+              existingEntry: entry,
+              fallbackContextTokens: entry.contextTokens,
+              allowAsyncLoad: false,
+            }),
             systemPromptReport: params.systemPromptReport ?? entry.systemPromptReport,
             updatedAt: Date.now(),
           };


### PR DESCRIPTION
## Summary
- preserve larger configured/session context windows over smaller runtime metadata when provider/model match
- keep Telegram progress mode durable by sending tool progress as standalone messages instead of draft/edit previews
- update Telegram dispatch tests for durable progress behavior on the 2026.5.19 release base

## Test
- ./node_modules/.bin/vitest run src/agents/session-context-tokens.test.ts src/agents/command/session-store.test.ts extensions/telegram/src/bot-message-dispatch.test.ts --maxWorkers=1

## Real behavior proof
- **Behavior or issue addressed:** Windows/Telegram OpenClaw 2026.5.19 was shrinking an explicitly configured 1050k session back to runtime-reported 272k after a successful agent run, and Telegram progress mode hid tool/progress updates in a repeatedly edited draft message instead of leaving durable 5.3-style progress messages.
- **Real environment tested:** Real Windows/ROG OpenClaw gateway running `OpenClaw 2026.5.19 (a185ca2)` on port `18889`, with the real Telegram channel enabled and reporting `ON/OK`. The Mac controller verified Windows gateway/control surfaces over the LAN/Tailscale dashboard path.
- **Exact steps or command run after this patch:** Applied the equivalent Windows dist hotfix, restarted the Windows OpenClaw Gateway, checked `/health`, ran a real `openclaw agent --agent main ...` command against the Windows runtime, inspected `C:\Users\Administrator\.openclaw\agents\main\sessions\sessions.json`, checked recent runtime logs for schema/API errors, and exercised the real Windows Telegram bot path with a tool-progress turn.
- **Evidence after fix:** Copied live output / redacted runtime evidence from the real setup:

  ```text
  Windows Gateway http://127.0.0.1:18889/health: live
  OpenClaw version: 2026.5.19 (a185ca2)
  Telegram channel: ON/OK
  Agent smoke command: returned OK
  agent:main:main.sessionId == agent:main:telegram:default:direct:8589344021.sessionId
  shared sessionId: 6f44523c-fc48-49da-925d-bc8bc1e9f224
  agent:main:main.contextTokens: 1050000
  agent:main:telegram:default:direct:8589344021.contextTokens: 1050000
  verbose: full
  toolProgressDetail: raw
  recent logs: no new provider schema/API errors
  Mac cross-access checks after patch: 18898=200, 18913=200, 18912=200
  Telegram behavior after patch: tool/progress messages remained visible as standalone durable messages instead of being hidden in a repeatedly edited draft.
  ```

- **Observed result after fix:** After the agent run, both main and Telegram direct sessions stayed aligned on the same session id with `contextTokens=1050000`, `verbose=full`, and `toolProgressDetail=raw`; the UI/status context no longer reflected the runtime-reported 272k value; Telegram progress/tool output remained durable and visible.
- **What was not tested:** Full upstream CI on every package was not run locally; the PR relies on GitHub CI for full-matrix coverage. Production deployment was not tested.
