### PR TITLE
feat(agents): expose estimated context budget status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Docs: https://docs.openclaw.ai
 - Agents/OpenAI Responses: retry non-visible reasoning-only turns for OpenAI Responses API families instead of treating them as empty failed turns. (#85603) Thanks @SebTardif.
 - Directive tags: preserve message and content-part object identity when display stripping makes no directive-tag changes. (#85682) Thanks @willamhou.
 - Telegram: send local `path`/`filePath` and structured attachment media from `sendMessage` actions instead of dropping them or sending text-only messages. (#85219) Thanks @keshavbotagent.
+- Sessions/status: show the estimated context budget when fresh provider usage is unavailable and clear stale estimates across session resets and compaction boundaries. (#84830) Thanks @giodl73-repo.
 - Gateway/config: pin relative `OPENCLAW_STATE_DIR` overrides to an absolute path at startup so later working-directory changes cannot retarget gateway state. (#52264) Thanks @PerfectPan.
 - Checks/Parallels: make changed-lane scripts, shrinkwrap generation, and Parallels package smoke host commands run through native Windows-safe paths and `npm`/`pnpm` shims.
 - Release/package: run npm release, prepublish, and postpublish verification through Windows-safe npm command shims so native Windows checks can execute `npm.cmd` instead of treating it as a binary.

--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -1424,6 +1424,25 @@ describe("recordCliCompactionInStore", () => {
           outputTokens: 100,
           cacheRead: 2_900,
           cacheWrite: 0,
+          contextBudgetStatus: {
+            schemaVersion: 1,
+            source: "pre-prompt-estimate",
+            updatedAt: 123,
+            provider: "codex",
+            model: "gpt-5.5",
+            route: "fits",
+            shouldCompact: false,
+            estimatedPromptTokens: 18_000,
+            contextTokenBudget: 32_000,
+            promptBudgetBeforeReserve: 28_000,
+            reserveTokens: 4_000,
+            effectiveReserveTokens: 4_000,
+            remainingPromptBudgetTokens: 10_000,
+            overflowTokens: 0,
+            toolResultReducibleChars: 0,
+            messageCount: 4,
+            unwindowedMessageCount: 4,
+          },
           cliSessionBindings: {
             codex: {
               sessionId: "stale-cli-session",
@@ -1452,10 +1471,12 @@ describe("recordCliCompactionInStore", () => {
       expect(sessionStore[sessionKey]?.outputTokens).toBeUndefined();
       expect(sessionStore[sessionKey]?.cacheRead).toBeUndefined();
       expect(sessionStore[sessionKey]?.cacheWrite).toBeUndefined();
+      expect(sessionStore[sessionKey]?.contextBudgetStatus).toBeUndefined();
       expect(sessionStore[sessionKey]?.cliSessionBindings?.codex).toBeUndefined();
       expect(sessionStore[sessionKey]?.cliSessionIds?.codex).toBeUndefined();
       expect(persisted[sessionKey]?.totalTokens).toBe(0);
       expect(persisted[sessionKey]?.totalTokensFresh).toBe(true);
+      expect(persisted[sessionKey]?.contextBudgetStatus).toBeUndefined();
     });
   });
 
@@ -1473,6 +1494,25 @@ describe("recordCliCompactionInStore", () => {
           outputTokens: 100,
           cacheRead: 6_900,
           cacheWrite: 0,
+          contextBudgetStatus: {
+            schemaVersion: 1,
+            source: "pre-prompt-estimate",
+            updatedAt: 123,
+            provider: "codex",
+            model: "gpt-5.5",
+            route: "compact_only",
+            shouldCompact: true,
+            estimatedPromptTokens: 48_000,
+            contextTokenBudget: 32_000,
+            promptBudgetBeforeReserve: 28_000,
+            reserveTokens: 4_000,
+            effectiveReserveTokens: 4_000,
+            remainingPromptBudgetTokens: 0,
+            overflowTokens: 20_000,
+            toolResultReducibleChars: 0,
+            messageCount: 40,
+            unwindowedMessageCount: 40,
+          },
         },
       };
       await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2));
@@ -1492,8 +1532,10 @@ describe("recordCliCompactionInStore", () => {
       expect(sessionStore[sessionKey]?.outputTokens).toBeUndefined();
       expect(sessionStore[sessionKey]?.cacheRead).toBeUndefined();
       expect(sessionStore[sessionKey]?.cacheWrite).toBeUndefined();
+      expect(sessionStore[sessionKey]?.contextBudgetStatus).toBeUndefined();
       expect(persisted[sessionKey]?.totalTokens).toBe(37_000);
       expect(persisted[sessionKey]?.totalTokensFresh).toBe(false);
+      expect(persisted[sessionKey]?.contextBudgetStatus).toBeUndefined();
     });
   });
 

--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -636,6 +636,75 @@ describe("updateSessionStoreAfterAgentRun", () => {
     });
   });
 
+  it("persists estimated context budget status without marking stale usage fresh", async () => {
+    await withTempSessionStore(async ({ storePath }) => {
+      const cfg = {} as OpenClawConfig;
+      const sessionKey = "agent:main:explicit:test-context-budget-status";
+      const sessionId = "test-context-budget-status-session";
+      const sessionStore: Record<string, SessionEntry> = {
+        [sessionKey]: {
+          sessionId,
+          updatedAt: 1,
+          totalTokens: 21225,
+          totalTokensFresh: true,
+        },
+      };
+      await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2));
+
+      const result: EmbeddedPiRunResult = {
+        meta: {
+          durationMs: 500,
+          agentMeta: {
+            sessionId,
+            provider: "minimax",
+            model: "MiniMax-M2.7",
+            contextBudgetStatus: {
+              schemaVersion: 1,
+              source: "pre-prompt-estimate",
+              updatedAt: 123,
+              provider: "minimax",
+              model: "MiniMax-M2.7",
+              route: "fits",
+              shouldCompact: false,
+              estimatedPromptTokens: 18_000,
+              contextTokenBudget: 32_000,
+              promptBudgetBeforeReserve: 28_000,
+              reserveTokens: 4_000,
+              effectiveReserveTokens: 4_000,
+              remainingPromptBudgetTokens: 10_000,
+              overflowTokens: 0,
+              toolResultReducibleChars: 0,
+              messageCount: 4,
+              unwindowedMessageCount: 4,
+            },
+          },
+        },
+      };
+
+      await updateSessionStoreAfterAgentRun({
+        cfg,
+        sessionId,
+        sessionKey,
+        storePath,
+        sessionStore,
+        defaultProvider: "minimax",
+        defaultModel: "MiniMax-M2.7",
+        result,
+      });
+
+      expect(sessionStore[sessionKey]?.totalTokens).toBe(21225);
+      expect(sessionStore[sessionKey]?.totalTokensFresh).toBe(false);
+      expect(sessionStore[sessionKey]?.contextBudgetStatus).toMatchObject({
+        source: "pre-prompt-estimate",
+        estimatedPromptTokens: 18_000,
+        contextTokenBudget: 32_000,
+      });
+
+      const persisted = loadSessionStore(storePath);
+      expect(persisted[sessionKey]?.contextBudgetStatus?.estimatedPromptTokens).toBe(18_000);
+    });
+  });
+
   it("does not treat CLI cumulative usage as a fresh context snapshot", async () => {
     await withTempSessionStore(async ({ storePath }) => {
       const cfg = {
@@ -1067,6 +1136,25 @@ describe("updateSessionStoreAfterAgentRun", () => {
           modelProvider: "anthropic",
           model: "claude-opus-4-6",
           contextTokens: 1_000_000,
+          contextBudgetStatus: {
+            schemaVersion: 1,
+            source: "pre-prompt-estimate",
+            updatedAt: 100,
+            provider: "anthropic",
+            model: "claude-opus-4-6",
+            route: "fits",
+            shouldCompact: false,
+            estimatedPromptTokens: 640_000,
+            contextTokenBudget: 1_000_000,
+            promptBudgetBeforeReserve: 900_000,
+            reserveTokens: 100_000,
+            effectiveReserveTokens: 100_000,
+            remainingPromptBudgetTokens: 260_000,
+            overflowTokens: 0,
+            toolResultReducibleChars: 0,
+            messageCount: 12,
+            unwindowedMessageCount: 12,
+          },
         },
       };
       await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2));
@@ -1080,6 +1168,25 @@ describe("updateSessionStoreAfterAgentRun", () => {
             provider: "ollama",
             model: "llama3.2:1b",
             contextTokens: 128_000,
+            contextBudgetStatus: {
+              schemaVersion: 1,
+              source: "pre-prompt-estimate",
+              updatedAt: 200,
+              provider: "ollama",
+              model: "llama3.2:1b",
+              route: "fits",
+              shouldCompact: false,
+              estimatedPromptTokens: 40_000,
+              contextTokenBudget: 128_000,
+              promptBudgetBeforeReserve: 112_000,
+              reserveTokens: 16_000,
+              effectiveReserveTokens: 16_000,
+              remainingPromptBudgetTokens: 72_000,
+              overflowTokens: 0,
+              toolResultReducibleChars: 0,
+              messageCount: 3,
+              unwindowedMessageCount: 3,
+            },
           },
         },
       };
@@ -1100,11 +1207,15 @@ describe("updateSessionStoreAfterAgentRun", () => {
       expect(sessionStore[sessionKey]?.model).toBe("claude-opus-4-6");
       expect(sessionStore[sessionKey]?.modelProvider).toBe("anthropic");
       expect(sessionStore[sessionKey]?.contextTokens).toBe(1_000_000);
+      expect(sessionStore[sessionKey]?.contextBudgetStatus?.provider).toBe("anthropic");
+      expect(sessionStore[sessionKey]?.contextBudgetStatus?.estimatedPromptTokens).toBe(640_000);
 
       const persisted = loadSessionStore(storePath);
       expect(persisted[sessionKey]?.model).toBe("claude-opus-4-6");
       expect(persisted[sessionKey]?.modelProvider).toBe("anthropic");
       expect(persisted[sessionKey]?.contextTokens).toBe(1_000_000);
+      expect(persisted[sessionKey]?.contextBudgetStatus?.provider).toBe("anthropic");
+      expect(persisted[sessionKey]?.contextBudgetStatus?.estimatedPromptTokens).toBe(640_000);
     });
   });
 

--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -705,6 +705,71 @@ describe("updateSessionStoreAfterAgentRun", () => {
     });
   });
 
+  it("clears stale estimated context budget status when a runtime refresh has no current estimate", async () => {
+    await withTempSessionStore(async ({ storePath }) => {
+      const cfg = {} as OpenClawConfig;
+      const sessionKey = "agent:main:explicit:test-clear-context-budget-status";
+      const sessionId = "test-clear-context-budget-status-session";
+      const sessionStore: Record<string, SessionEntry> = {
+        [sessionKey]: {
+          sessionId,
+          updatedAt: 1,
+          totalTokens: 21225,
+          totalTokensFresh: false,
+          contextBudgetStatus: {
+            schemaVersion: 1,
+            source: "pre-prompt-estimate",
+            updatedAt: 123,
+            provider: "anthropic",
+            model: "claude-sonnet-4.6",
+            route: "fits",
+            shouldCompact: false,
+            estimatedPromptTokens: 18_000,
+            contextTokenBudget: 32_000,
+            promptBudgetBeforeReserve: 28_000,
+            reserveTokens: 4_000,
+            effectiveReserveTokens: 4_000,
+            remainingPromptBudgetTokens: 10_000,
+            overflowTokens: 0,
+            toolResultReducibleChars: 0,
+            messageCount: 4,
+            unwindowedMessageCount: 4,
+          },
+        },
+      };
+      await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2));
+
+      const result: EmbeddedPiRunResult = {
+        meta: {
+          durationMs: 500,
+          agentMeta: {
+            sessionId,
+            provider: "minimax",
+            model: "MiniMax-M2.7",
+          },
+        },
+      };
+
+      await updateSessionStoreAfterAgentRun({
+        cfg,
+        sessionId,
+        sessionKey,
+        storePath,
+        sessionStore,
+        defaultProvider: "minimax",
+        defaultModel: "MiniMax-M2.7",
+        result,
+      });
+
+      expect(sessionStore[sessionKey]?.modelProvider).toBe("minimax");
+      expect(sessionStore[sessionKey]?.model).toBe("MiniMax-M2.7");
+      expect(sessionStore[sessionKey]?.contextBudgetStatus).toBeUndefined();
+
+      const persisted = loadSessionStore(storePath);
+      expect(persisted[sessionKey]?.contextBudgetStatus).toBeUndefined();
+    });
+  });
+
   it("does not treat CLI cumulative usage as a fresh context snapshot", async () => {
     await withTempSessionStore(async ({ storePath }) => {
       const cfg = {

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -181,7 +181,7 @@ export async function updateSessionStoreAfterAgentRun(params: {
   if (result.meta.systemPromptReport) {
     next.systemPromptReport = result.meta.systemPromptReport;
   }
-  if (contextBudgetStatus && !preserveRuntimeModel) {
+  if (!preserveRuntimeModel) {
     next.contextBudgetStatus = contextBudgetStatus;
   }
   if (hasNonzeroUsage(usage)) {

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -319,6 +319,7 @@ export async function recordCliCompactionInStore(params: {
     next.sessionFile = explicitNewSessionFile;
   }
   const tokensAfterCompaction = resolveNonNegativeNumber(params.tokensAfter);
+  next.contextBudgetStatus = undefined;
   if (tokensAfterCompaction !== undefined) {
     next.totalTokens = Math.floor(tokensAfterCompaction);
     next.totalTokensFresh = true;

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -101,6 +101,7 @@ export async function updateSessionStoreAfterAgentRun(params: {
   const providerUsed = result.meta.agentMeta?.provider ?? fallbackProvider ?? defaultProvider;
   const agentHarnessId = normalizeOptionalString(result.meta.agentMeta?.agentHarnessId);
   const runtimeContextTokens = resolvePositiveInteger(result.meta.agentMeta?.contextTokens);
+  const contextBudgetStatus = result.meta.agentMeta?.contextBudgetStatus;
   const contextTokens =
     runtimeContextTokens !== undefined
       ? runtimeContextTokens
@@ -179,6 +180,9 @@ export async function updateSessionStoreAfterAgentRun(params: {
   next.abortedLastRun = result.meta.aborted ?? false;
   if (result.meta.systemPromptReport) {
     next.systemPromptReport = result.meta.systemPromptReport;
+  }
+  if (contextBudgetStatus && !preserveRuntimeModel) {
+    next.contextBudgetStatus = contextBudgetStatus;
   }
   if (hasNonzeroUsage(usage)) {
     const { estimateUsageCost, resolveModelCostConfig } = await getUsageFormatModule();

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1030,6 +1030,7 @@ export async function runEmbeddedPiAgent(
       let lastRunPromptUsage: ReturnType<typeof normalizeUsage> | undefined;
       let autoCompactionCount = 0;
       let lastCompactionTokensAfter: number | undefined;
+      let lastContextBudgetStatus: EmbeddedPiAgentMeta["contextBudgetStatus"];
       let runLoopIterations = 0;
       let overloadProfileRotations = 0;
       let planningOnlyRetryAttempts = 0;
@@ -1639,6 +1640,9 @@ export async function runEmbeddedPiAgent(
             attempt.compactionTokensAfter >= 0
           ) {
             lastCompactionTokensAfter = Math.floor(attempt.compactionTokensAfter);
+          }
+          if (attempt.contextBudgetStatus) {
+            lastContextBudgetStatus = attempt.contextBudgetStatus;
           }
           const activeErrorContext = resolveActiveErrorContext({
             provider,
@@ -2676,6 +2680,7 @@ export async function runEmbeddedPiAgent(
             usage: usageMeta.usage,
             lastCallUsage: usageMeta.lastCallUsage,
             promptTokens: usageMeta.promptTokens,
+            ...(lastContextBudgetStatus ? { contextBudgetStatus: lastContextBudgetStatus } : {}),
             compactionCount: autoCompactionCount > 0 ? autoCompactionCount : undefined,
             compactionTokensAfter: lastCompactionTokensAfter,
           };

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -4080,7 +4080,6 @@ export async function runEmbeddedAttempt(
               unwindowedContextEngineMessagesForPrecheck
                 ? { unwindowedMessageCount: unwindowedContextEngineMessagesForPrecheck.length }
                 : {}),
-              ...(params.sessionFile ? { sessionFile: params.sessionFile } : {}),
             });
             log.debug(
               formatPrePromptPrecheckLog({

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -396,6 +396,7 @@ import {
 } from "./midturn-precheck.js";
 import {
   PREEMPTIVE_OVERFLOW_ERROR_TEXT,
+  buildPrePromptContextBudgetStatus,
   formatPrePromptPrecheckLog,
   shouldPreemptivelyCompactBeforePrompt,
 } from "./preemptive-compaction.js";
@@ -3370,6 +3371,7 @@ export async function runEmbeddedAttempt(
       let cacheBreak: PromptCacheBreak | null = null;
       let promptCache: EmbeddedRunAttemptResult["promptCache"];
       let lastCallUsage: NormalizedUsage | undefined;
+      let contextBudgetStatus: EmbeddedRunAttemptResult["contextBudgetStatus"];
       let compactionOccurredThisAttempt = false;
       let finalPromptText: string | undefined;
       if (params.replyOperation) {
@@ -4066,6 +4068,20 @@ export async function runEmbeddedAttempt(
                 }),
               });
           if (preemptiveCompaction) {
+            contextBudgetStatus = buildPrePromptContextBudgetStatus({
+              result: preemptiveCompaction,
+              provider: params.provider,
+              modelId: params.modelId,
+              messageCount: activeSession.messages.length,
+              contextTokenBudget,
+              reserveTokens,
+              ...(params.sessionId ? { sessionId: params.sessionId } : {}),
+              ...(contextEnginePromptAuthority === "preassembly_may_overflow" &&
+              unwindowedContextEngineMessagesForPrecheck
+                ? { unwindowedMessageCount: unwindowedContextEngineMessagesForPrecheck.length }
+                : {}),
+              ...(params.sessionFile ? { sessionFile: params.sessionFile } : {}),
+            });
             log.debug(
               formatPrePromptPrecheckLog({
                 result: preemptiveCompaction,
@@ -4880,6 +4896,7 @@ export async function runEmbeddedAttempt(
         ),
         attemptUsage,
         promptCache,
+        contextBudgetStatus,
         compactionCount: getCompactionCount(),
         compactionTokensAfter: getLastCompactionTokensAfter(),
         // Client tool calls detected (OpenResponses hosted tools).

--- a/src/agents/pi-embedded-runner/run/preemptive-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run/preemptive-compaction.test.ts
@@ -5,6 +5,7 @@ import { estimateToolResultReductionPotential } from "../tool-result-truncation.
 
 let PREEMPTIVE_OVERFLOW_ERROR_TEXT: typeof import("./preemptive-compaction.js").PREEMPTIVE_OVERFLOW_ERROR_TEXT;
 let estimateLlmBoundaryTokenPressure: typeof import("./preemptive-compaction.js").estimateLlmBoundaryTokenPressure;
+let buildPrePromptContextBudgetStatus: typeof import("./preemptive-compaction.js").buildPrePromptContextBudgetStatus;
 let estimatePrePromptTokens: typeof import("./preemptive-compaction.js").estimatePrePromptTokens;
 let estimateRenderedLlmBoundaryTokenPressure: typeof import("./preemptive-compaction.js").estimateRenderedLlmBoundaryTokenPressure;
 let formatPrePromptPrecheckLog: typeof import("./preemptive-compaction.js").formatPrePromptPrecheckLog;
@@ -15,6 +16,7 @@ beforeAll(async () => {
   ({
     PREEMPTIVE_OVERFLOW_ERROR_TEXT,
     estimateLlmBoundaryTokenPressure,
+    buildPrePromptContextBudgetStatus,
     estimatePrePromptTokens,
     estimateRenderedLlmBoundaryTokenPressure,
     formatPrePromptPrecheckLog,
@@ -159,6 +161,51 @@ describe("preemptive-compaction", () => {
     expect(line).toContain("contextTokenBudget=10000");
     expect(line).toContain("messages=1");
     expect(line).toContain("unwindowedMessages=3");
+  });
+
+  it("builds a durable estimated context budget status snapshot", () => {
+    const result = shouldPreemptivelyCompactBeforePrompt({
+      messages: [makeAssistantHistory("short history")],
+      systemPrompt: "sys",
+      prompt: "hello",
+      contextTokenBudget: 10_000,
+      reserveTokens: 1_000,
+    });
+
+    const status = buildPrePromptContextBudgetStatus({
+      result,
+      provider: "anthropic",
+      modelId: "claude-opus-4-6",
+      messageCount: 1,
+      unwindowedMessageCount: 3,
+      contextTokenBudget: 10_000,
+      reserveTokens: 1_000,
+      sessionId: "session-1",
+      sessionFile: "sessions/session-1.json",
+      now: 123,
+    });
+
+    expect(status).toMatchObject({
+      schemaVersion: 1,
+      source: "pre-prompt-estimate",
+      updatedAt: 123,
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      route: "fits",
+      shouldCompact: false,
+      contextTokenBudget: 10_000,
+      promptBudgetBeforeReserve: result.promptBudgetBeforeReserve,
+      reserveTokens: 1_000,
+      effectiveReserveTokens: result.effectiveReserveTokens,
+      overflowTokens: 0,
+      messageCount: 1,
+      unwindowedMessageCount: 3,
+      sessionId: "session-1",
+      sessionFile: "sessions/session-1.json",
+    });
+    expect(status.remainingPromptBudgetTokens).toBe(
+      result.promptBudgetBeforeReserve - result.estimatedPromptTokens,
+    );
   });
 
   it("uses the larger unwindowed message estimate when explicitly provided", () => {

--- a/src/agents/pi-embedded-runner/run/preemptive-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run/preemptive-compaction.test.ts
@@ -181,7 +181,6 @@ describe("preemptive-compaction", () => {
       contextTokenBudget: 10_000,
       reserveTokens: 1_000,
       sessionId: "session-1",
-      sessionFile: "sessions/session-1.json",
       now: 123,
     });
 
@@ -201,7 +200,6 @@ describe("preemptive-compaction", () => {
       messageCount: 1,
       unwindowedMessageCount: 3,
       sessionId: "session-1",
-      sessionFile: "sessions/session-1.json",
     });
     expect(status.remainingPromptBudgetTokens).toBe(
       result.promptBudgetBeforeReserve - result.estimatedPromptTokens,

--- a/src/agents/pi-embedded-runner/run/preemptive-compaction.ts
+++ b/src/agents/pi-embedded-runner/run/preemptive-compaction.ts
@@ -1,4 +1,5 @@
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import type { SessionContextBudgetStatus } from "../../../config/sessions.js";
 import { estimateStringChars } from "../../../utils/cjk-chars.js";
 import { SAFETY_MARGIN } from "../../compaction.js";
 import {
@@ -352,4 +353,47 @@ export function formatPrePromptPrecheckLog(params: {
     `unwindowedMessages=${params.unwindowedMessageCount ?? params.messageCount} ` +
     `sessionFile=${params.sessionFile}`
   );
+}
+
+export function buildPrePromptContextBudgetStatus(params: {
+  result: PreemptiveCompactionDecision;
+  provider: string;
+  modelId: string;
+  messageCount: number;
+  unwindowedMessageCount?: number;
+  contextTokenBudget: number;
+  reserveTokens: number;
+  sessionId?: string;
+  sessionFile?: string;
+  now?: number;
+}): SessionContextBudgetStatus {
+  const { result } = params;
+  const remainingPromptBudgetTokens = Math.max(
+    0,
+    result.promptBudgetBeforeReserve - result.estimatedPromptTokens,
+  );
+  return {
+    schemaVersion: 1,
+    source: "pre-prompt-estimate",
+    updatedAt: params.now ?? Date.now(),
+    provider: params.provider,
+    model: params.modelId,
+    route: result.route,
+    shouldCompact: result.shouldCompact,
+    estimatedPromptTokens: result.estimatedPromptTokens,
+    contextTokenBudget: Math.max(1, Math.floor(params.contextTokenBudget)),
+    promptBudgetBeforeReserve: result.promptBudgetBeforeReserve,
+    reserveTokens: Math.max(0, Math.floor(params.reserveTokens)),
+    effectiveReserveTokens: result.effectiveReserveTokens,
+    remainingPromptBudgetTokens,
+    overflowTokens: result.overflowTokens,
+    toolResultReducibleChars: result.toolResultReducibleChars,
+    messageCount: Math.max(0, Math.floor(params.messageCount)),
+    unwindowedMessageCount: Math.max(
+      0,
+      Math.floor(params.unwindowedMessageCount ?? params.messageCount),
+    ),
+    ...(params.sessionId ? { sessionId: params.sessionId } : {}),
+    ...(params.sessionFile ? { sessionFile: params.sessionFile } : {}),
+  };
 }

--- a/src/agents/pi-embedded-runner/run/preemptive-compaction.ts
+++ b/src/agents/pi-embedded-runner/run/preemptive-compaction.ts
@@ -364,7 +364,6 @@ export function buildPrePromptContextBudgetStatus(params: {
   contextTokenBudget: number;
   reserveTokens: number;
   sessionId?: string;
-  sessionFile?: string;
   now?: number;
 }): SessionContextBudgetStatus {
   const { result } = params;
@@ -394,6 +393,5 @@ export function buildPrePromptContextBudgetStatus(params: {
       Math.floor(params.unwindowedMessageCount ?? params.messageCount),
     ),
     ...(params.sessionId ? { sessionId: params.sessionId } : {}),
-    ...(params.sessionFile ? { sessionFile: params.sessionFile } : {}),
   };
 }

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -3,7 +3,10 @@ import type { Api, AssistantMessage, Model } from "@earendil-works/pi-ai";
 import type { AuthStorage, ModelRegistry } from "@earendil-works/pi-coding-agent";
 import type { HeartbeatToolResponse } from "../../../auto-reply/heartbeat-tool-response.js";
 import type { ThinkLevel } from "../../../auto-reply/thinking.js";
-import type { SessionSystemPromptReport } from "../../../config/sessions/types.js";
+import type {
+  SessionContextBudgetStatus,
+  SessionSystemPromptReport,
+} from "../../../config/sessions/types.js";
 import type { ContextEngine, ContextEnginePromptCacheInfo } from "../../../context-engine/types.js";
 import type { DiagnosticTraceContext } from "../../../infra/diagnostic-trace-context.js";
 import type { PluginHookBeforeAgentStartResult } from "../../../plugins/hook-before-agent-start.types.js";
@@ -157,6 +160,7 @@ export type EmbeddedRunAttemptResult = {
   cloudCodeAssistFormatError: boolean;
   attemptUsage?: NormalizedUsage;
   promptCache?: ContextEnginePromptCacheInfo;
+  contextBudgetStatus?: SessionContextBudgetStatus;
   compactionCount?: number;
   compactionTokensAfter?: number;
   /**

--- a/src/agents/pi-embedded-runner/types.ts
+++ b/src/agents/pi-embedded-runner/types.ts
@@ -1,5 +1,9 @@
 import type { HeartbeatToolResponse } from "../../auto-reply/heartbeat-tool-response.js";
-import type { CliSessionBinding, SessionSystemPromptReport } from "../../config/sessions/types.js";
+import type {
+  CliSessionBinding,
+  SessionContextBudgetStatus,
+  SessionSystemPromptReport,
+} from "../../config/sessions/types.js";
 import type { DiagnosticTraceContext } from "../../infra/diagnostic-trace-context.js";
 import type { AcceptedSessionSpawn } from "../accepted-session-spawn.js";
 import type { FallbackAttempt } from "../model-fallback.types.js";
@@ -54,6 +58,7 @@ export type EmbeddedPiAgentMeta = {
     reasoningTokens?: number;
     total?: number;
   };
+  contextBudgetStatus?: SessionContextBudgetStatus;
 };
 
 export type TraceAttempt = {

--- a/src/auto-reply/reply/agent-runner-session-reset.test.ts
+++ b/src/auto-reply/reply/agent-runner-session-reset.test.ts
@@ -50,6 +50,26 @@ describe("resetReplyRunSession", () => {
       modelProvider: "qwencode",
       model: "qwen",
       contextTokens: 123,
+      contextBudgetStatus: {
+        schemaVersion: 1,
+        source: "pre-prompt-estimate",
+        updatedAt: 1,
+        provider: "qwencode",
+        model: "qwen",
+        route: "compact_then_truncate",
+        shouldCompact: true,
+        estimatedPromptTokens: 120_000,
+        contextTokenBudget: 80_000,
+        promptBudgetBeforeReserve: 70_000,
+        reserveTokens: 10_000,
+        effectiveReserveTokens: 10_000,
+        remainingPromptBudgetTokens: 0,
+        overflowTokens: 50_000,
+        toolResultReducibleChars: 0,
+        messageCount: 10,
+        unwindowedMessageCount: 10,
+        sessionId: "session",
+      },
       fallbackNoticeSelectedModel: "anthropic/claude",
       fallbackNoticeActiveModel: "openai/gpt",
       fallbackNoticeReason: "rate limit",
@@ -94,6 +114,7 @@ describe("resetReplyRunSession", () => {
     expect(activeSessionEntry?.modelProvider).toBeUndefined();
     expect(activeSessionEntry?.model).toBeUndefined();
     expect(activeSessionEntry?.contextTokens).toBeUndefined();
+    expect(activeSessionEntry?.contextBudgetStatus).toBeUndefined();
     expect(activeSessionEntry?.fallbackNoticeSelectedModel).toBeUndefined();
     expect(activeSessionEntry?.fallbackNoticeActiveModel).toBeUndefined();
     expect(activeSessionEntry?.fallbackNoticeReason).toBeUndefined();
@@ -110,6 +131,7 @@ describe("resetReplyRunSession", () => {
       main: SessionEntry;
     };
     expect(persisted.main.sessionId).toBe(activeSessionEntry?.sessionId);
+    expect(persisted.main.contextBudgetStatus).toBeUndefined();
     expect(persisted.main.fallbackNoticeReason).toBeUndefined();
   });
 

--- a/src/auto-reply/reply/agent-runner-session-reset.ts
+++ b/src/auto-reply/reply/agent-runner-session-reset.ts
@@ -79,6 +79,7 @@ export async function resetReplyRunSession(params: {
     cacheRead: undefined,
     cacheWrite: undefined,
     contextTokens: undefined,
+    contextBudgetStatus: undefined,
     systemPromptReport: undefined,
     fallbackNoticeSelectedModel: undefined,
     fallbackNoticeActiveModel: undefined,

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -763,6 +763,28 @@ describe("initSessionState RawBody", () => {
         sessionId: existingSessionId,
         updatedAt: Date.now(),
         systemSent: true,
+        totalTokens: 64_000,
+        totalTokensFresh: false,
+        contextTokens: 128_000,
+        contextBudgetStatus: {
+          schemaVersion: 1,
+          source: "pre-prompt-estimate",
+          updatedAt: Date.now(),
+          provider: "anthropic",
+          model: "claude-sonnet-4.6",
+          route: "fits",
+          shouldCompact: false,
+          estimatedPromptTokens: 64_000,
+          contextTokenBudget: 128_000,
+          promptBudgetBeforeReserve: 112_000,
+          reserveTokens: 16_000,
+          effectiveReserveTokens: 16_000,
+          remainingPromptBudgetTokens: 48_000,
+          overflowTokens: 0,
+          toolResultReducibleChars: 0,
+          messageCount: 8,
+          unwindowedMessageCount: 8,
+        },
         skillsSnapshot: {
           prompt: "<available_skills><skill><name>stale</name></skill></available_skills>",
           skills: [{ name: "stale" }],
@@ -792,12 +814,23 @@ describe("initSessionState RawBody", () => {
     expect(result.resetTriggered).toBe(true);
     expect(result.sessionId).not.toBe(existingSessionId);
     expect(result.sessionEntry.skillsSnapshot).toBeUndefined();
+    expect(result.sessionEntry.totalTokens).toBeUndefined();
+    expect(result.sessionEntry.contextTokens).toBeUndefined();
+    expect(result.sessionEntry.contextBudgetStatus).toBeUndefined();
 
     const store = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
       string,
-      { skillsSnapshot?: unknown }
+      {
+        skillsSnapshot?: unknown;
+        totalTokens?: number;
+        contextTokens?: number;
+        contextBudgetStatus?: unknown;
+      }
     >;
     expect(store[sessionKey]?.skillsSnapshot).toBeUndefined();
+    expect(store[sessionKey]?.totalTokens).toBeUndefined();
+    expect(store[sessionKey]?.contextTokens).toBeUndefined();
+    expect(store[sessionKey]?.contextBudgetStatus).toBeUndefined();
   });
 
   it("drains stale system events when /new rotates an existing session", async () => {

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -804,6 +804,7 @@ export async function initSessionState(params: {
     sessionEntry.outputTokens = undefined;
     sessionEntry.estimatedCostUsd = undefined;
     sessionEntry.contextTokens = undefined;
+    sessionEntry.contextBudgetStatus = undefined;
     // Skills snapshots are prompt/runtime caches. Do not preserve a stale
     // snapshot through /new; the next turn must rebuild the visible skill list.
     sessionEntry.skillsSnapshot = undefined;

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -183,6 +183,139 @@ describe("buildStatusMessage", () => {
     expect(normalized).not.toContain("Context: 3.8m/1.0m");
   });
 
+  it("uses estimated context budget status when fresh totalTokens are unavailable", () => {
+    const text = buildStatusMessage({
+      agent: {
+        model: "anthropic/pi:opus",
+        contextTokens: 1_000_000,
+      },
+      sessionEntry: {
+        sessionId: "abc",
+        updatedAt: 0,
+        inputTokens: 3_800_000,
+        outputTokens: 20_000,
+        totalTokens: 3_800_000,
+        totalTokensFresh: false,
+        contextTokens: 1_000_000,
+        contextBudgetStatus: {
+          schemaVersion: 1,
+          source: "pre-prompt-estimate",
+          updatedAt: 1,
+          provider: "anthropic",
+          model: "pi:opus",
+          route: "fits",
+          shouldCompact: false,
+          estimatedPromptTokens: 640_000,
+          contextTokenBudget: 1_000_000,
+          promptBudgetBeforeReserve: 900_000,
+          reserveTokens: 100_000,
+          effectiveReserveTokens: 100_000,
+          remainingPromptBudgetTokens: 260_000,
+          overflowTokens: 0,
+          toolResultReducibleChars: 0,
+          messageCount: 2,
+          unwindowedMessageCount: 2,
+        },
+      },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+      modelAuth: "api-key",
+      now: 10 * 60_000,
+    });
+    const normalized = normalizeTestText(text);
+
+    expect(normalized).toContain("Context: ~640k/1.0m (64% est)");
+    expect(normalized).not.toContain("Context: ?/1.0m");
+    expect(normalized).not.toContain("Context: 3.8m/1.0m");
+  });
+
+  it("prefers fresh totalTokens over estimated context budget status", () => {
+    const text = buildStatusMessage({
+      agent: {
+        model: "anthropic/pi:opus",
+        contextTokens: 1_000_000,
+      },
+      sessionEntry: {
+        sessionId: "abc",
+        updatedAt: 0,
+        totalTokens: 36_000,
+        totalTokensFresh: true,
+        contextTokens: 1_000_000,
+        contextBudgetStatus: {
+          schemaVersion: 1,
+          source: "pre-prompt-estimate",
+          updatedAt: 1,
+          provider: "anthropic",
+          model: "pi:opus",
+          route: "fits",
+          shouldCompact: false,
+          estimatedPromptTokens: 640_000,
+          contextTokenBudget: 1_000_000,
+          promptBudgetBeforeReserve: 900_000,
+          reserveTokens: 100_000,
+          effectiveReserveTokens: 100_000,
+          remainingPromptBudgetTokens: 260_000,
+          overflowTokens: 0,
+          toolResultReducibleChars: 0,
+          messageCount: 2,
+          unwindowedMessageCount: 2,
+        },
+      },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+      modelAuth: "api-key",
+      now: 10 * 60_000,
+    });
+    const normalized = normalizeTestText(text);
+
+    expect(normalized).toContain("Context: 36k/1.0m (4%)");
+    expect(normalized).not.toContain("~640k");
+  });
+
+  it("uses estimated context budget status when token usage is absent", () => {
+    const text = buildStatusMessage({
+      agent: {
+        model: "anthropic/pi:opus",
+        contextTokens: 1_000_000,
+      },
+      sessionEntry: {
+        sessionId: "abc",
+        updatedAt: 0,
+        contextTokens: 1_000_000,
+        contextBudgetStatus: {
+          schemaVersion: 1,
+          source: "pre-prompt-estimate",
+          updatedAt: 1,
+          provider: "anthropic",
+          model: "pi:opus",
+          route: "fits",
+          shouldCompact: false,
+          estimatedPromptTokens: 125_000,
+          contextTokenBudget: 1_000_000,
+          promptBudgetBeforeReserve: 900_000,
+          reserveTokens: 100_000,
+          effectiveReserveTokens: 100_000,
+          remainingPromptBudgetTokens: 775_000,
+          overflowTokens: 0,
+          toolResultReducibleChars: 0,
+          messageCount: 2,
+          unwindowedMessageCount: 2,
+        },
+      },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+      modelAuth: "api-key",
+      now: 10 * 60_000,
+    });
+    const normalized = normalizeTestText(text);
+
+    expect(normalized).toContain("Context: ~125k/1.0m (13% est)");
+    expect(normalized).not.toContain("Context: 0/1.0m");
+  });
+
   it("shows sanitized TTS provider details in the voice status line", async () => {
     await withTempHome(async () => {
       const text = buildStatusMessage({

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -111,6 +111,34 @@ export type SessionCompactionCheckpoint = {
   postCompaction: SessionCompactionTranscriptReference;
 };
 
+export type SessionContextBudgetStatusRoute =
+  | "fits"
+  | "compact_only"
+  | "truncate_tool_results_only"
+  | "compact_then_truncate";
+
+export type SessionContextBudgetStatus = {
+  schemaVersion: 1;
+  source: "pre-prompt-estimate";
+  updatedAt: number;
+  provider: string;
+  model: string;
+  route: SessionContextBudgetStatusRoute;
+  shouldCompact: boolean;
+  estimatedPromptTokens: number;
+  contextTokenBudget: number;
+  promptBudgetBeforeReserve: number;
+  reserveTokens: number;
+  effectiveReserveTokens: number;
+  remainingPromptBudgetTokens: number;
+  overflowTokens: number;
+  toolResultReducibleChars: number;
+  messageCount: number;
+  unwindowedMessageCount: number;
+  sessionId?: string;
+  sessionFile?: string;
+};
+
 export type SessionPluginDebugEntry = {
   pluginId: string;
   lines: string[];
@@ -336,6 +364,7 @@ export type SessionEntry = {
   fallbackNoticeActiveModel?: string;
   fallbackNoticeReason?: string;
   contextTokens?: number;
+  contextBudgetStatus?: SessionContextBudgetStatus;
   compactionCount?: number;
   compactionCheckpoints?: SessionCompactionCheckpoint[];
   memoryFlushAt?: number;

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -136,7 +136,6 @@ export type SessionContextBudgetStatus = {
   messageCount: number;
   unwindowedMessageCount: number;
   sessionId?: string;
-  sessionFile?: string;
 };
 
 export type SessionPluginDebugEntry = {

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -2345,6 +2345,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
           }
           delete entryToUpdate.inputTokens;
           delete entryToUpdate.outputTokens;
+          delete entryToUpdate.contextBudgetStatus;
           if (
             typeof result.result?.tokensAfter === "number" &&
             Number.isFinite(result.result.tokensAfter)
@@ -2415,6 +2416,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       delete entryToUpdate.outputTokens;
       delete entryToUpdate.totalTokens;
       delete entryToUpdate.totalTokensFresh;
+      delete entryToUpdate.contextBudgetStatus;
       entryToUpdate.updatedAt = Date.now();
     });
 

--- a/src/gateway/server.sessions.compaction.test.ts
+++ b/src/gateway/server.sessions.compaction.test.ts
@@ -245,6 +245,25 @@ test("sessions.compact without maxLines runs embedded manual compaction for chec
       main: sessionStoreEntry("sess-main", {
         thinkingLevel: "medium",
         reasoningLevel: "stream",
+        contextBudgetStatus: {
+          schemaVersion: 1,
+          source: "pre-prompt-estimate",
+          updatedAt: Date.now() - 5_000,
+          provider: "anthropic",
+          model: "claude-opus-4-6",
+          route: "fits",
+          shouldCompact: false,
+          estimatedPromptTokens: 120,
+          contextTokenBudget: 200,
+          promptBudgetBeforeReserve: 180,
+          reserveTokens: 20,
+          effectiveReserveTokens: 20,
+          remainingPromptBudgetTokens: 60,
+          overflowTokens: 0,
+          toolResultReducibleChars: 0,
+          messageCount: 2,
+          unwindowedMessageCount: 2,
+        },
       }),
     },
   });
@@ -357,9 +376,15 @@ test("sessions.compact without maxLines runs embedded manual compaction for chec
 
   const store = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
     string,
-    { compactionCount?: number; totalTokens?: number; totalTokensFresh?: boolean }
+    {
+      compactionCount?: number;
+      contextBudgetStatus?: unknown;
+      totalTokens?: number;
+      totalTokensFresh?: boolean;
+    }
   >;
   expect(store["agent:main:main"]?.compactionCount).toBe(1);
+  expect(store["agent:main:main"]?.contextBudgetStatus).toBeUndefined();
   expect(store["agent:main:main"]?.totalTokens).toBe(80);
   expect(store["agent:main:main"]?.totalTokensFresh).toBe(true);
 

--- a/src/gateway/server.sessions.reset-models.test.ts
+++ b/src/gateway/server.sessions.reset-models.test.ts
@@ -107,6 +107,66 @@ test("sessions.reset recomputes model from defaults instead of stale runtime mod
   expect((await fs.stat(sessionFile)).isFile()).toBe(true);
 });
 
+test("sessions.reset clears stale estimated context budget status", async () => {
+  const { storePath } = await createSessionStoreDir();
+  testState.agentConfig = {
+    model: {
+      primary: "openai/gpt-test-a",
+    },
+  };
+
+  await writeSessionStore({
+    entries: {
+      main: sessionStoreEntry("sess-stale-budget", {
+        totalTokens: 0,
+        totalTokensFresh: false,
+        contextTokens: 123456,
+        contextBudgetStatus: {
+          schemaVersion: 1,
+          source: "pre-prompt-estimate",
+          updatedAt: 1,
+          provider: "qwencode",
+          model: "qwen3.5-plus-2026-02-15",
+          route: "compact_then_truncate",
+          shouldCompact: true,
+          estimatedPromptTokens: 120_000,
+          contextTokenBudget: 80_000,
+          promptBudgetBeforeReserve: 70_000,
+          reserveTokens: 10_000,
+          effectiveReserveTokens: 10_000,
+          remainingPromptBudgetTokens: 0,
+          overflowTokens: 50_000,
+          toolResultReducibleChars: 0,
+          messageCount: 10,
+          unwindowedMessageCount: 10,
+          sessionId: "sess-stale-budget",
+        },
+      }),
+    },
+  });
+
+  const reset = await directSessionReq<{
+    ok: true;
+    entry: {
+      sessionId: string;
+      contextBudgetStatus?: unknown;
+      contextTokens?: number;
+    };
+  }>("sessions.reset", { key: "main" });
+
+  expect(reset.ok).toBe(true);
+  expect(reset.payload?.entry.sessionId).not.toBe("sess-stale-budget");
+  expect(reset.payload?.entry.contextBudgetStatus).toBeUndefined();
+  expect(reset.payload?.entry.contextTokens).toBeUndefined();
+
+  const store = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+    string,
+    { contextBudgetStatus?: unknown; contextTokens?: number }
+  >;
+  expect(store["agent:main:main"]?.contextBudgetStatus).toBeUndefined();
+  expect(store["agent:main:main"]?.contextTokens).toBeUndefined();
+});
+
 test("sessions.reset drops cached skills snapshot so /new rebuilds visible skills", async () => {
   const { storePath } = await createSessionStoreDir();
   testState.agentConfig = {

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -102,6 +102,7 @@ function stripRuntimeModelState(entry?: SessionEntry): SessionEntry | undefined 
     model: undefined,
     modelProvider: undefined,
     contextTokens: undefined,
+    contextBudgetStatus: undefined,
     systemPromptReport: undefined,
   };
 }

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -548,6 +548,48 @@ describe("gateway session utils", () => {
     });
   });
 
+  test("session rows expose estimated context budget status", () => {
+    const row = buildGatewaySessionRow({
+      cfg: createModelDefaultsConfig({ primary: "anthropic/claude-sonnet-4.6" }),
+      storePath: "",
+      store: {},
+      key: "agent:main:main",
+      entry: {
+        sessionId: "session-1",
+        sessionFile: "/tmp/openclaw/agents/main/sessions/session-1.jsonl",
+        updatedAt: 1,
+        contextBudgetStatus: {
+          schemaVersion: 1,
+          source: "pre-prompt-estimate",
+          updatedAt: 2,
+          provider: "anthropic",
+          model: "claude-sonnet-4.6",
+          route: "compact_then_truncate",
+          shouldCompact: true,
+          estimatedPromptTokens: 640_000,
+          contextTokenBudget: 200_000,
+          promptBudgetBeforeReserve: 180_000,
+          reserveTokens: 20_000,
+          effectiveReserveTokens: 20_000,
+          remainingPromptBudgetTokens: 0,
+          overflowTokens: 460_000,
+          toolResultReducibleChars: 12_000,
+          messageCount: 42,
+          unwindowedMessageCount: 39,
+          sessionId: "session-1",
+        },
+      },
+    });
+
+    expect(row.contextBudgetStatus).toMatchObject({
+      provider: "anthropic",
+      model: "claude-sonnet-4.6",
+      estimatedPromptTokens: 640_000,
+      contextTokenBudget: 200_000,
+      sessionId: "session-1",
+    });
+  });
+
   test("session rows use per-agent thinking default from config", () => {
     const cfg = {
       agents: {

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1944,6 +1944,7 @@ export function buildGatewaySessionRow(params: {
     model: rowModel,
     agentRuntime,
     contextTokens,
+    contextBudgetStatus: entry?.contextBudgetStatus,
     deliveryContext: deliveryFields.deliveryContext,
     lastChannel: deliveryFields.lastChannel ?? entry?.lastChannel,
     lastTo: deliveryFields.lastTo ?? entry?.lastTo,

--- a/src/gateway/session-utils.types.ts
+++ b/src/gateway/session-utils.types.ts
@@ -84,6 +84,7 @@ export type GatewaySessionRow = {
   model?: string;
   agentRuntime?: GatewayAgentRuntime;
   contextTokens?: number;
+  contextBudgetStatus?: SessionEntry["contextBudgetStatus"];
   deliveryContext?: DeliveryContext;
   lastChannel?: SessionEntry["lastChannel"];
   lastTo?: string;

--- a/src/plugins/session-entry-slot-keys.ts
+++ b/src/plugins/session-entry-slot-keys.ts
@@ -91,6 +91,7 @@ const SESSION_ENTRY_RESERVED_SLOT_KEY_LIST = [
   "fallbackNoticeActiveModel",
   "fallbackNoticeReason",
   "contextTokens",
+  "contextBudgetStatus",
   "compactionCount",
   "compactionCheckpoints",
   "memoryFlushAt",

--- a/src/sessions/model-overrides.test.ts
+++ b/src/sessions/model-overrides.test.ts
@@ -23,6 +23,33 @@ function expectRuntimeModelFieldsCleared(entry: SessionEntry, before: number) {
   expect((entry.updatedAt ?? 0) > before).toBe(true);
 }
 
+function contextBudgetStatus(params: {
+  updatedAt: number;
+  provider: string;
+  model: string;
+  contextTokenBudget: number;
+}): NonNullable<SessionEntry["contextBudgetStatus"]> {
+  return {
+    schemaVersion: 1,
+    source: "pre-prompt-estimate",
+    updatedAt: params.updatedAt,
+    provider: params.provider,
+    model: params.model,
+    route: "fits",
+    shouldCompact: false,
+    estimatedPromptTokens: Math.floor(params.contextTokenBudget * 0.6),
+    contextTokenBudget: params.contextTokenBudget,
+    promptBudgetBeforeReserve: params.contextTokenBudget - 10_000,
+    reserveTokens: 10_000,
+    effectiveReserveTokens: 10_000,
+    remainingPromptBudgetTokens: Math.floor(params.contextTokenBudget * 0.4),
+    overflowTokens: 0,
+    toolResultReducibleChars: 0,
+    messageCount: 2,
+    unwindowedMessageCount: 2,
+  };
+}
+
 describe("applyModelOverrideToSessionEntry", () => {
   it("clears stale runtime model fields when switching overrides", () => {
     const before = Date.now() - 5_000;
@@ -34,6 +61,12 @@ describe("applyModelOverrideToSessionEntry", () => {
       providerOverride: "anthropic",
       modelOverride: "claude-sonnet-4-6",
       contextTokens: 160_000,
+      contextBudgetStatus: contextBudgetStatus({
+        updatedAt: before,
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+        contextTokenBudget: 200_000,
+      }),
       fallbackNoticeSelectedModel: "anthropic/claude-sonnet-4-6",
       fallbackNoticeActiveModel: "anthropic/claude-sonnet-4-6",
       fallbackNoticeReason: "provider temporary failure",
@@ -44,6 +77,7 @@ describe("applyModelOverrideToSessionEntry", () => {
     expect(result.updated).toBe(true);
     expectRuntimeModelFieldsCleared(entry, before);
     expect(entry.contextTokens).toBeUndefined();
+    expect(entry.contextBudgetStatus).toBeUndefined();
     expect(entry.fallbackNoticeSelectedModel).toBeUndefined();
     expect(entry.fallbackNoticeActiveModel).toBeUndefined();
     expect(entry.fallbackNoticeReason).toBeUndefined();
@@ -60,6 +94,12 @@ describe("applyModelOverrideToSessionEntry", () => {
       providerOverride: "openai",
       modelOverride: "gpt-5.4",
       contextTokens: 160_000,
+      contextBudgetStatus: contextBudgetStatus({
+        updatedAt: before,
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+        contextTokenBudget: 200_000,
+      }),
     };
 
     const result = applyOpenAiSelection(entry);
@@ -67,6 +107,7 @@ describe("applyModelOverrideToSessionEntry", () => {
     expect(result.updated).toBe(true);
     expectRuntimeModelFieldsCleared(entry, before);
     expect(entry.contextTokens).toBeUndefined();
+    expect(entry.contextBudgetStatus).toBeUndefined();
   });
 
   it("retains aligned runtime model fields when selection and runtime already match", () => {
@@ -79,6 +120,12 @@ describe("applyModelOverrideToSessionEntry", () => {
       providerOverride: "openai",
       modelOverride: "gpt-5.4",
       contextTokens: 200_000,
+      contextBudgetStatus: contextBudgetStatus({
+        updatedAt: before,
+        provider: "openai",
+        model: "gpt-5.4",
+        contextTokenBudget: 200_000,
+      }),
     };
 
     const result = applyModelOverrideToSessionEntry({
@@ -94,6 +141,7 @@ describe("applyModelOverrideToSessionEntry", () => {
     expect(entry.model).toBe("gpt-5.4");
     expect(entry.modelOverrideSource).toBe("user");
     expect(entry.contextTokens).toBe(200_000);
+    expect(entry.contextBudgetStatus?.contextTokenBudget).toBe(200_000);
     expect((entry.updatedAt ?? 0) >= before).toBe(true);
   });
 
@@ -105,6 +153,12 @@ describe("applyModelOverrideToSessionEntry", () => {
       providerOverride: "local",
       modelOverride: "sunapi386/llama-3-lexi-uncensored:8b",
       contextTokens: 4_096,
+      contextBudgetStatus: contextBudgetStatus({
+        updatedAt: before,
+        provider: "local",
+        model: "sunapi386/llama-3-lexi-uncensored:8b",
+        contextTokenBudget: 4_096,
+      }),
     };
 
     const result = applyModelOverrideToSessionEntry({
@@ -121,6 +175,7 @@ describe("applyModelOverrideToSessionEntry", () => {
     expect(entry.modelOverride).toBeUndefined();
     expect(entry.modelOverrideSource).toBeUndefined();
     expect(entry.contextTokens).toBeUndefined();
+    expect(entry.contextBudgetStatus).toBeUndefined();
     expect((entry.updatedAt ?? 0) > before).toBe(true);
   });
 

--- a/src/sessions/model-overrides.ts
+++ b/src/sessions/model-overrides.ts
@@ -99,6 +99,13 @@ export function applyModelOverrideToSessionEntry(params: {
     delete entry.contextTokens;
     updated = true;
   }
+  if (
+    entry.contextBudgetStatus !== undefined &&
+    (selectionUpdated || (runtimePresent && !runtimeAligned))
+  ) {
+    delete entry.contextBudgetStatus;
+    updated = true;
+  }
 
   if (profileOverride) {
     if (entry.authProfileOverride !== profileOverride) {

--- a/src/status/status-message.ts
+++ b/src/status/status-message.ts
@@ -213,6 +213,36 @@ const formatTokens = (total: number | null | undefined, contextTokens: number | 
   return `${totalLabel}/${ctxLabel}${pct !== null ? ` (${pct}%)` : ""}`;
 };
 
+const formatEstimatedContextBudgetTokens = (
+  status: SessionEntry["contextBudgetStatus"] | undefined,
+  contextTokens: number | null | undefined,
+) => {
+  if (!status || status.source !== "pre-prompt-estimate") {
+    return null;
+  }
+  const estimatedPromptTokens =
+    typeof status.estimatedPromptTokens === "number" &&
+    Number.isFinite(status.estimatedPromptTokens) &&
+    status.estimatedPromptTokens >= 0
+      ? Math.floor(status.estimatedPromptTokens)
+      : undefined;
+  if (estimatedPromptTokens === undefined) {
+    return null;
+  }
+  const ctx =
+    typeof contextTokens === "number" && Number.isFinite(contextTokens) && contextTokens > 0
+      ? contextTokens
+      : typeof status.contextTokenBudget === "number" &&
+          Number.isFinite(status.contextTokenBudget) &&
+          status.contextTokenBudget > 0
+        ? status.contextTokenBudget
+        : undefined;
+  const pct = ctx ? Math.min(999, Math.round((estimatedPromptTokens / ctx) * 100)) : null;
+  const totalLabel = formatTokenCount(estimatedPromptTokens);
+  const ctxLabel = ctx ? formatTokenCount(ctx) : "?";
+  return `~${totalLabel}/${ctxLabel}${pct !== null ? ` (${pct}% est)` : " (est)"}`;
+};
+
 export const formatContextUsageShort = (
   total: number | null | undefined,
   contextTokens: number | null | undefined,
@@ -822,8 +852,13 @@ export function buildStatusMessage(args: StatusArgs): string {
     ? (args.groupActivation ?? entry?.groupActivation ?? "mention")
     : undefined;
 
+  const contextUsageLabel =
+    totalTokens == null || totalTokens === 0
+      ? (formatEstimatedContextBudgetTokens(entry?.contextBudgetStatus, contextTokens) ??
+        formatTokens(totalTokens, contextTokens ?? null))
+      : formatTokens(totalTokens, contextTokens ?? null);
   const contextLine = [
-    `Context: ${formatTokens(totalTokens, contextTokens ?? null)}`,
+    `Context: ${contextUsageLabel}`,
     `🧹 Compactions: ${entry?.compactionCount ?? 0}`,
   ]
     .filter(Boolean)


### PR DESCRIPTION
## Summary

Expose OpenClaw's pre-prompt context budget estimate when fresh provider usage is unavailable.

- capture a typed, path-free `contextBudgetStatus` snapshot from the pre-prompt estimate
- persist that snapshot on `SessionEntry`
- expose it on gateway session rows
- let `/status` show estimated context usage only when fresh provider usage is unavailable or absent
- keep positive fresh `totalTokens` authoritative
- prevent preserved-runtime heartbeat runs from replacing the main session's budget snapshot
- clear stale `contextBudgetStatus` on runtime refreshes without a current estimate, model override/reset, manual/native CLI compaction, reply-run reset, and `/new` session rotation
- reserve the new top-level session field from plugin session-entry slot mirroring

This is reporting-only. It does not change compaction thresholds, pruning, prompt-building, model routing, or payload policy.

Refs #80594, #54996, #77992, #84490, #83177, #43009, #83526, #8635.

## Verification

- `git diff --check`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/auto-reply/reply/session.test.ts -t "drops cached skills snapshot when /new rotates an existing session" --reporter=verbose`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/agents/command/session-store.test.ts --reporter=verbose`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/auto-reply/status.test.ts -t "estimated context budget" --reporter=verbose`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/gateway/server.sessions.compaction.test.ts src/sessions/model-overrides.test.ts --reporter=verbose`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-session-reset.test.ts -t "rotates the session and clears stale runtime and fallback fields" --reporter=verbose`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/gateway/session-utils.test.ts -t "session rows expose estimated context budget status" --reporter=verbose`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/gateway/server.sessions.reset-models.test.ts -t "sessions.reset clears stale estimated context budget status" --reporter=verbose`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## Real behavior proof

Behavior addressed: Sessions whose model/provider path cannot return fresh context usage can expose OpenClaw's own pre-prompt estimate instead of showing only unknown/zero context usage. Runtime/session lifecycle boundaries now clear the persisted estimate with the rest of stale token/model state so a later session or model cannot show an old budget snapshot.

Real environment tested: WSL2 Ubuntu 24.04 durable PR worktree on refreshed PR head `e1aa1dcd6fb3bebe4b13f206fb6fefff98b397ba`, rebased onto current `origin/main`.

Exact steps or command run after this patch: the verification commands listed above, plus a production status-renderer probe using `node --import tsx --input-type=module` against `src/status/status-message.ts` with a persisted stale `totalTokensFresh: false` session entry and current `contextBudgetStatus`.

Evidence after fix: The production status-renderer probe printed `Context: ~640k/1.0m (64% est)`, proving the user-visible `/status` renderer uses the estimate when fresh usage is unavailable. Focused tests proved current estimates persist and render, fresh `totalTokens` still win, gateway rows expose the field, and stale estimates are cleared on run refresh, model override, gateway/manual compaction, native CLI compaction, reply-run reset, `sessions.reset`, and `/new` rotation. Final Codex autoreview returned `autoreview clean: no accepted/actionable findings reported`.

Observed result after fix: `contextBudgetStatus` remains a path-free reporting object for current session estimates, and reset/refresh boundaries clear stale snapshots before `/status` or gateway rows can expose them.

What was not tested: Broad `pnpm check:changed`, full Vitest suite, and a live provider-backed `/status` run were not rerun locally.