### PR TITLE
[codex] Update macOS copyright owner

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Peter Steinberger
+Copyright (c) 2026 OpenClaw Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/apps/macos/Sources/OpenClaw/AboutSettings.swift
+++ b/apps/macos/Sources/OpenClaw/AboutSettings.swift
@@ -77,7 +77,7 @@ struct AboutSettings: View {
                 }
             }
 
-            Text("© 2026 Peter Steinberger — MIT License.")
+            Text("© 2026 OpenClaw Foundation — MIT License.")
                 .font(.footnote)
                 .foregroundStyle(.secondary)
                 .padding(.top, 4)


### PR DESCRIPTION
## Summary

- Update the macOS About settings copyright owner from "Peter Steinberger" to "OpenClaw Foundation".
- Align the repository MIT license copyright notice with the same 2026 OpenClaw Foundation owner.

## Why

The copyright year was already corrected in the prior PR, but the displayed owner still named an individual instead of the foundation. The root LICENSE now matches the About footer so the app UI and license source-of-truth do not diverge.

## Visual Proof

After screenshot from a signed local macOS app build:

![OpenClaw About settings showing OpenClaw Foundation copyright](https://raw.githubusercontent.com/pejmanjohn/openclaw/codex/pr-assets-update-mac-copyright-owner/pr-assets/openclaw-about-openclaw-foundation.png)

## Real behavior proof

Behavior addressed: The macOS About settings footer now displays `© 2026 OpenClaw Foundation — MIT License.` instead of `© 2026 Peter Steinberger — MIT License.`, and the repository LICENSE now uses `Copyright (c) 2026 OpenClaw Foundation`.

Real environment tested: Mac mini running macOS 26.4.1 with a signed local `dist/OpenClaw.app` built from this branch using Developer ID Application signing.

Exact steps or command run after this patch: `git diff --check`; `swift build --package-path apps/macos`; `SKIP_PNPM_INSTALL=1 SKIP_UI_BUILD=1 scripts/restart-mac.sh --sign --attach-only`; captured the About settings window with Peekaboo.

Evidence after fix: The screenshot above shows the About settings screen with `© 2026 OpenClaw Foundation — MIT License.` visible. The branch diff also shows the root LICENSE copyright notice aligned to `Copyright (c) 2026 OpenClaw Foundation`.

Observed result after fix: The app built successfully and the About settings footer rendered the updated owner text.

What was not tested: Full `pnpm build && pnpm check && pnpm test` was not run because this is a narrow macOS UI/license-copy fix. Local `codex review --base origin/main` was attempted but blocked by Codex CLI auth returning `401 Unauthorized`.

## Verification

- `git diff --check`
- `swift build --package-path apps/macos`
- Signed local app package/run for screenshot proof: `SKIP_PNPM_INSTALL=1 SKIP_UI_BUILD=1 scripts/restart-mac.sh --sign --attach-only`
- Attempted: `codex review --base origin/main` (blocked by `401 Unauthorized` from the local Codex CLI auth)

AI-assisted with Codex.
