### PR TITLE
fix(gateway): avoid duplicate session message broadcasts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,7 @@ Docs: https://docs.openclaw.ai
 - WebChat: scope the visible attachment button to its own composer file input so clicking Upload reliably opens the file picker. (#83952, fixes #47983) Thanks @jason-allen-oneal.
 - Gateway: preserve deferred lifecycle-error cleanup across later non-terminal events so provider timeouts can persist failed session state instead of leaving sessions stuck running. (#85256, fixes #63819) Thanks @samzong.
 - Gateway/update: stop treating inherited macOS `XPC_SERVICE_NAME` values as launchd supervision during update respawn, so GUI-spawned gateways use detached respawn instead of exiting for a missing LaunchAgent. Fixes #85224. Thanks @richardmqq.
+- Gateway: stop sending duplicate message-phase `sessions.changed` websocket events after displayable `session.message` transcript updates. (#84834)
 - Agents/subagents: report tool-only child progress during timeout summaries instead of showing no visible output.
 - Telegram/ACP: preserve explicit `:topic:` conversation suffixes when inbound ACP targets do not carry a separate thread id.
 - Browser/proxy: bypass the managed proxy for the exact local managed Chrome CDP readiness and DevTools WebSocket endpoints, so `openclaw browser start` works when the operator proxy blocks loopback egress. (#83255) Thanks @lightcap.

--- a/src/gateway/server-session-events.ts
+++ b/src/gateway/server-session-events.ts
@@ -150,6 +150,7 @@ async function handleTranscriptUpdateBroadcast(
       connIds,
       { dropIfSlow: true },
     );
+    return;
   }
 
   const sessionEventConnIds = params.sessionEventSubscribers.getAll();

--- a/src/gateway/session-message-events.test.ts
+++ b/src/gateway/session-message-events.test.ts
@@ -93,7 +93,7 @@ function waitForSessionsChangedMessagePhase(
   );
 }
 
-async function emitTranscriptUpdateAndCollectEvents(params: {
+async function emitTranscriptUpdateAndCollectMessageEvent(params: {
   ws: Awaited<ReturnType<Awaited<ReturnType<typeof createGatewaySuiteHarness>>["openWs"]>>;
   sessionKey: string;
   sessionFile: string;
@@ -102,7 +102,6 @@ async function emitTranscriptUpdateAndCollectEvents(params: {
   messageSeq?: number;
 }) {
   const messageEventPromise = waitForSessionMessageEvent(params.ws, params.sessionKey);
-  const changedEventPromise = waitForSessionsChangedMessagePhase(params.ws, params.sessionKey);
 
   emitSessionTranscriptUpdate({
     sessionFile: params.sessionFile,
@@ -112,11 +111,8 @@ async function emitTranscriptUpdateAndCollectEvents(params: {
     ...(typeof params.messageSeq === "number" ? { messageSeq: params.messageSeq } : {}),
   });
 
-  const [messageEvent, changedEvent] = await Promise.all([
-    messageEventPromise,
-    changedEventPromise,
-  ]);
-  return { messageEvent, changedEvent };
+  const messageEvent = await messageEventPromise;
+  return { messageEvent };
 }
 
 async function expectNoMessageWithin(params: {
@@ -317,7 +313,7 @@ describe("session.message websocket events", () => {
     );
 
     await withOperatorSessionSubscriber(async (ws) => {
-      const { messageEvent } = await emitTranscriptUpdateAndCollectEvents({
+      const { messageEvent } = await emitTranscriptUpdateAndCollectMessageEvent({
         ws,
         sessionKey: "agent:main:main",
         sessionFile: transcriptPath,
@@ -441,7 +437,57 @@ describe("session.message websocket events", () => {
     });
   });
 
-  test("includes live usage metadata on session.message and sessions.changed transcript events", async () => {
+  test("does not duplicate displayable transcript updates with sessions.changed", async () => {
+    const storePath = await createSessionStoreFile();
+    await writeSessionStore({
+      entries: {
+        main: {
+          sessionId: "sess-main",
+          updatedAt: Date.now(),
+        },
+      },
+      storePath,
+    });
+
+    await withOperatorSessionSubscriber(async (ws) => {
+      const messageEventPromise = waitForSessionMessageEvent(ws, "agent:main:main");
+      await expectNoMessageWithin({
+        action: () => {
+          emitSessionTranscriptUpdate({
+            sessionFile: path.join(path.dirname(storePath), "sess-main.jsonl"),
+            sessionKey: "agent:main:main",
+            message: {
+              role: "assistant",
+              content: [{ type: "text", text: "single frame" }],
+              timestamp: Date.now(),
+            },
+            messageId: "msg-single-frame",
+            messageSeq: 1,
+          });
+        },
+        watch: (timeoutMs) =>
+          onceMessage(
+            ws,
+            (message) =>
+              message.type === "event" &&
+              message.event === "sessions.changed" &&
+              (message.payload as { phase?: string; sessionKey?: string } | undefined)?.phase ===
+                "message" &&
+              (message.payload as { sessionKey?: string } | undefined)?.sessionKey ===
+                "agent:main:main",
+            timeoutMs,
+          ),
+      });
+      const messageEvent = await messageEventPromise;
+      expectRecordFields(messageEvent.payload, {
+        sessionKey: "agent:main:main",
+        messageId: "msg-single-frame",
+        messageSeq: 1,
+      });
+    });
+  });
+
+  test("includes live usage metadata on session.message transcript events", async () => {
     const storePath = await createSessionStoreFile();
     await writeSessionStore({
       entries: {
@@ -482,7 +528,7 @@ describe("session.message websocket events", () => {
     );
 
     await withOperatorSessionSubscriber(async (ws) => {
-      const { messageEvent, changedEvent } = await emitTranscriptUpdateAndCollectEvents({
+      const { messageEvent } = await emitTranscriptUpdateAndCollectMessageEvent({
         ws,
         sessionKey: "agent:main:main",
         sessionFile: transcriptPath,
@@ -491,18 +537,6 @@ describe("session.message websocket events", () => {
       });
       expectRecordFields(messageEvent.payload, {
         sessionKey: "agent:main:main",
-        messageId: "msg-usage",
-        messageSeq: 1,
-        totalTokens: 2_400,
-        totalTokensFresh: true,
-        contextTokens: 123_456,
-        estimatedCostUsd: 0.0042,
-        modelProvider: "openai",
-        model: "gpt-5.4",
-      });
-      expectRecordFields(changedEvent.payload, {
-        sessionKey: "agent:main:main",
-        phase: "message",
         messageId: "msg-usage",
         messageSeq: 1,
         totalTokens: 2_400,
@@ -528,7 +562,7 @@ describe("session.message websocket events", () => {
     });
 
     await withOperatorSessionSubscriber(async (ws) => {
-      const { messageEvent, changedEvent } = await emitTranscriptUpdateAndCollectEvents({
+      const { messageEvent } = await emitTranscriptUpdateAndCollectMessageEvent({
         ws,
         sessionKey: "agent:main:main",
         sessionFile: path.join(path.dirname(storePath), "missing-transcript.jsonl"),
@@ -540,15 +574,8 @@ describe("session.message websocket events", () => {
         messageId: "msg-carried-seq",
         messageSeq: 7,
       });
-
       expectRecordFields(messageEvent.payload, {
         sessionKey: "agent:main:main",
-        messageId: "msg-carried-seq",
-        messageSeq: 7,
-      });
-      expectRecordFields(changedEvent.payload, {
-        sessionKey: "agent:main:main",
-        phase: "message",
         messageId: "msg-carried-seq",
         messageSeq: 7,
       });
@@ -558,7 +585,7 @@ describe("session.message websocket events", () => {
     });
   });
 
-  test("includes spawnedBy metadata on session.message and sessions.changed transcript events", async () => {
+  test("includes spawnedBy metadata on session.message transcript events", async () => {
     const storePath = await createSessionStoreFile();
     const transcriptPath = path.join(path.dirname(storePath), "sess-child.jsonl");
     await writeSessionStore({
@@ -605,16 +632,6 @@ describe("session.message websocket events", () => {
           (message.payload as { sessionKey?: string } | undefined)?.sessionKey ===
             "agent:main:child",
       );
-      const changedEventPromise = onceMessage(
-        ws,
-        (message) =>
-          message.type === "event" &&
-          message.event === "sessions.changed" &&
-          (message.payload as { phase?: string; sessionKey?: string } | undefined)?.phase ===
-            "message" &&
-          (message.payload as { sessionKey?: string } | undefined)?.sessionKey ===
-            "agent:main:child",
-      );
 
       emitSessionTranscriptUpdate({
         sessionFile: transcriptPath,
@@ -623,23 +640,9 @@ describe("session.message websocket events", () => {
         messageId: "msg-spawn",
       });
 
-      const [messageEvent, changedEvent] = await Promise.all([
-        messageEventPromise,
-        changedEventPromise,
-      ]);
+      const messageEvent = await messageEventPromise;
       expectRecordFields(messageEvent.payload, {
         sessionKey: "agent:main:child",
-        spawnedBy: "agent:main:main",
-        spawnedWorkspaceDir: "/tmp/subagent-workspace",
-        forkedFromParent: true,
-        spawnDepth: 2,
-        subagentRole: "orchestrator",
-        subagentControlScope: "children",
-        parentSessionKey: "agent:main:main",
-      });
-      expectRecordFields(changedEvent.payload, {
-        sessionKey: "agent:main:child",
-        phase: "message",
         spawnedBy: "agent:main:main",
         spawnedWorkspaceDir: "/tmp/subagent-workspace",
         forkedFromParent: true,
@@ -653,7 +656,7 @@ describe("session.message websocket events", () => {
     }
   });
 
-  test("includes route thread metadata on session.message and sessions.changed transcript events", async () => {
+  test("includes route thread metadata on session.message transcript events", async () => {
     const storePath = await createSessionStoreFile();
     const transcriptPath = path.join(path.dirname(storePath), "sess-thread.jsonl");
     await writeSessionStore({
@@ -685,7 +688,7 @@ describe("session.message websocket events", () => {
     );
 
     await withOperatorSessionSubscriber(async (ws) => {
-      const { messageEvent, changedEvent } = await emitTranscriptUpdateAndCollectEvents({
+      const { messageEvent } = await emitTranscriptUpdateAndCollectMessageEvent({
         ws,
         sessionKey: "agent:main:main",
         sessionFile: transcriptPath,
@@ -694,14 +697,6 @@ describe("session.message websocket events", () => {
       });
       expectRecordFields(messageEvent.payload, {
         sessionKey: "agent:main:main",
-        lastChannel: "telegram",
-        lastTo: "-100123",
-        lastAccountId: "acct-1",
-        lastThreadId: 42,
-      });
-      expectRecordFields(changedEvent.payload, {
-        sessionKey: "agent:main:main",
-        phase: "message",
         lastChannel: "telegram",
         lastTo: "-100123",
         lastAccountId: "acct-1",


### PR DESCRIPTION
## Summary

- Problem: displayable transcript updates sent both `session.message` and message-phase `sessions.changed`, duplicating snapshot-bearing websocket frames.
- Solution: after broadcasting a displayable `session.message`, return from the transcript update handler; keep `sessions.changed` for hidden/non-displayable transcript updates.
- What changed: `server-session-events` now sends one websocket event for displayable transcript updates, and regression coverage locks in that no duplicate `sessions.changed` arrives.
- What did NOT change (scope boundary): lifecycle `sessions.changed` events and hidden runtime-context transcript updates still use `sessions.changed`.

## Motivation

- Live gateway logs during the performance investigation showed adjacent `session.message` and `sessions.changed` events for the same message update, adding avoidable websocket work while only one client was connected.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #84832
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior addressed: displayable transcript updates no longer emit both `session.message` and message-phase `sessions.changed` for the same gateway websocket client.
- Real environment tested: local OpenClaw worktree on Ubuntu/WSL2 with Node 24.15.0; gateway websocket suite with real test server/websocket clients.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/gateway/session-message-events.test.ts`
- Evidence after fix: terminal capture from the focused run:

```text
RUN  v4.1.6 /home/galini/GitHub/worktrees/bug-027-dedupe-session-message-events

Test Files  3 passed (3)
     Tests  39 passed (39)
  Start at  05:38:16
  Duration  92.86s (transform 70.38s, setup 1.76s, import 17.26s, tests 73.26s, environment 0ms)
```

- Observed result after fix: the new regression subscribes an operator websocket, emits a displayable transcript update, receives `session.message`, and verifies no message-phase `sessions.changed` arrives for that session. Existing coverage still verifies hidden runtime-context custom messages do not produce live chat messages and still emit `sessions.changed`.
- What was not tested: the original private live background run was not replayed; this was verified at the gateway websocket seam with a real local test server/client.
- Before evidence (optional but encouraged): redacted live log sample showed adjacent duplicate pairs, for example `session.message` at `2026-05-21T03:11:24.515+00:00` followed by `sessions.changed` at `2026-05-21T03:11:24.519+00:00` for the same one-client targeted websocket path.

## Root Cause (if applicable)

- Root cause: `handleTranscriptUpdateBroadcast` always continued to the message-phase `sessions.changed` broadcast after successfully sending `session.message`.
- Missing detection / guardrail: tests asserted metadata on both events but did not assert that one displayable transcript update should only produce one snapshot-bearing frame.
- Contributing context (if known): the Control UI already applies session snapshots from `session.message`, so the duplicate `sessions.changed` was redundant for displayable messages.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/session-message-events.test.ts`
- Scenario the test should lock in: displayable transcript updates send `session.message` and do not send a duplicate message-phase `sessions.changed`; hidden runtime-context updates still send `sessions.changed`.
- Why this is the smallest reliable guardrail: the gateway session-message websocket suite owns the broadcast contract and uses actual websocket clients.
- Existing test that already covers this (if any): existing metadata tests covered both old events but not duplicate suppression.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Subscribed operator websocket clients receive fewer redundant `sessions.changed` frames for displayable transcript updates.

## Diagram (if applicable)

```text
Before:
[transcript message] -> session.message + sessions.changed

After:
[displayable transcript message] -> session.message
[hidden transcript update] -> sessions.changed
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Ubuntu/WSL2
- Runtime/container: Node 24.15.0, local worktree
- Model/provider: N/A for gateway websocket session events
- Integration/channel (if any): Control UI/operator websocket path
- Relevant config (redacted): local gateway websocket test harness

### Steps

1. Connect an operator websocket and subscribe to sessions.
2. Emit a displayable transcript update for a session.
3. Watch for `session.message` and message-phase `sessions.changed` for the same session.

### Expected

The websocket receives `session.message`; it does not receive a duplicate message-phase `sessions.changed` for that displayable message.

### Actual

After this patch, the focused test verifies exactly that behavior.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: displayable transcript event dedupe; hidden runtime-context fallback remains covered; existing session-message metadata tests still pass.
- Edge cases checked: carried message sequence, spawned session metadata, route/thread metadata, and blocked-message projection still flow through `session.message`.
- What you did **not** verify: a private live background run with the original session/client.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: clients that only listened for `sessions.changed` message-phase events could miss displayable transcript snapshots.
  - Mitigation: the bundled UI already applies session snapshots from `session.message`, and hidden/non-displayable updates still emit `sessions.changed`.
