### PR TITLE
fix(infra): skip shell env fallback probe on Windows

### DIFF
--- a/src/infra/shell-env.test.ts
+++ b/src/infra/shell-env.test.ts
@@ -482,6 +482,29 @@ describe("shell env fallback", () => {
     expectSanitizedStartupEnv(receivedEnv);
   });
 
+  it("skips shell env fallback probing on win32", () => {
+    resetShellPathCacheForTests();
+    const env: NodeJS.ProcessEnv = {};
+    const logger = { warn: vi.fn() };
+    const exec = vi.fn(() => {
+      throw new Error("spawnSync /bin/sh ENOENT");
+    });
+
+    const result = loadShellEnvFallback({
+      enabled: true,
+      env,
+      expectedKeys: ["OPENAI_API_KEY"],
+      exec: exec as unknown as Parameters<typeof loadShellEnvFallback>[0]["exec"],
+      logger,
+      platform: "win32",
+    });
+
+    expect(result).toEqual({ ok: true, applied: [] });
+    expect(exec).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(env.OPENAI_API_KEY).toBeUndefined();
+  });
+
   it("returns null without invoking shell on win32", () => {
     const exec = vi.fn(() => Buffer.from("PATH=/usr/local/bin:/usr/bin\0HOME=/tmp\0"));
 

--- a/src/infra/shell-env.ts
+++ b/src/infra/shell-env.ts
@@ -172,7 +172,12 @@ function probeLoginShellEnv(params: {
   env: NodeJS.ProcessEnv;
   timeoutMs?: number;
   exec?: typeof execFileSync;
+  platform?: NodeJS.Platform;
 }): LoginShellEnvProbeResult {
+  const platform = params.platform ?? process.platform;
+  if (platform === "win32") {
+    return { ok: true, shellEnv: new Map() };
+  }
   const exec = params.exec ?? execFileSync;
   const timeoutMs = resolveTimeoutMs(params.timeoutMs);
   const shell = resolveShell(params.env);
@@ -212,6 +217,7 @@ type ShellEnvFallbackOptions = {
   logger?: Pick<typeof console, "warn">;
   timeoutMs?: number;
   exec?: typeof execFileSync;
+  platform?: NodeJS.Platform;
 };
 
 function hasExplicitEnvBinding(env: NodeJS.ProcessEnv, key: string): boolean {
@@ -238,6 +244,7 @@ export function loadShellEnvFallback(opts: ShellEnvFallbackOptions): ShellEnvFal
     env: opts.env,
     timeoutMs: opts.timeoutMs,
     exec: opts.exec,
+    platform: opts.platform,
   });
   if (!probe.ok) {
     logger.warn(`[openclaw] shell env fallback failed: ${probe.error}`);
@@ -298,6 +305,7 @@ export function getShellPathFromLoginShell(opts: {
     env: opts.env,
     timeoutMs: opts.timeoutMs,
     exec: opts.exec,
+    platform: opts.platform,
   });
   if (!probe.ok) {
     cachedShellPath = null;


### PR DESCRIPTION
## Summary
- Skip the login-shell environment probe entirely on `win32` so native Windows startup does not try to spawn `/bin/sh`.
- Thread an optional platform override through the shell-env fallback for deterministic coverage.
- Add regression coverage that verifies Windows fallback returns successfully without invoking the shell probe or logging the ENOENT warning.

Fixes #84795

## Real behavior proof

Behavior addressed: On native Windows, enabling the shell env fallback could call the login-shell probe and warn with `spawnSync /bin/sh ENOENT` because `/bin/sh` does not exist there.

Real environment tested: Local OpenClaw checkout on macOS, branch `fix/windows-shell-env-fallback-skip-84795`, with Vitest simulating `platform: "win32"` through the shell-env fallback path.

Exact steps or command run after fix:

```console
$ node scripts/run-vitest.mjs src/infra/shell-env.test.ts
$ git diff --check
```

Evidence after fix:

```console
✓  infra  ../../src/infra/shell-env.test.ts (21 tests) 70ms
Test Files  1 passed (1)
Tests  21 passed (21)
```

Observed result after fix: The new regression test `skips shell env fallback probing on win32` passes. It exercises `loadShellEnvFallback({ enabled: true, platform: "win32" })` with an exec stub that would throw `spawnSync /bin/sh ENOENT`; after the fix, the exec stub is not called, no warning is logged, and the fallback returns `{ ok: true, applied: [] }`.

What was not tested: I did not boot a native Windows host locally. The platform-specific behavior is covered with the same platform override pattern already used by the existing `getShellPathFromLoginShell` Windows test in this file; Windows CI should cover the native runtime environment.

## Test plan
- `node scripts/run-vitest.mjs src/infra/shell-env.test.ts`
- `git diff --check`

## Duplicate check
- Checked open PRs for `84795`, `"spawnSync /bin/sh ENOENT"`, `"shell env fallback" "Windows"`, `"probeLoginShellEnv" "win32"`, and `"OPENCLAW_LOAD_SHELL_ENV" "win32"` before publishing.
- The only hits were broad/stale tracker or unrelated PRs, not a focused fix for this issue/path.
