### PR TITLE
fix: honor skill source install aliases

### DIFF
--- a/src/agents/skills-source-install.test.ts
+++ b/src/agents/skills-source-install.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { withTempDir } from "../test-helpers/temp-dir.js";
 import { installSkillFromSource } from "./skills-source-install.js";
+import { buildWorkspaceSkillStatus } from "./skills-status.js";
 
 async function writeSkill(dir: string, params: { name?: string; description?: string } = {}) {
   await fs.mkdir(dir, { recursive: true });
@@ -96,6 +97,40 @@ describe("installSkillFromSource", () => {
         source: "path",
         targetDir: path.join(workspaceDir, "skills", "custom-name"),
       });
+      const status = buildWorkspaceSkillStatus(workspaceDir, {
+        managedSkillsDir: path.join(root, "managed-skills"),
+      });
+      const skill = status.skills.find((entry) => entry.skillKey === "custom-name");
+      expect(skill).toMatchObject({
+        name: "frontmatter-skill",
+        skillKey: "custom-name",
+      });
+    });
+  });
+
+  it("ignores oversized source-origin metadata while loading skill keys", async () => {
+    await withTempDir({ prefix: "openclaw-skill-source-origin-cap-" }, async (root) => {
+      const workspaceDir = path.join(root, "workspace");
+      const sourceDir = path.join(root, "source");
+      await writeSkill(sourceDir, { name: "frontmatter-skill" });
+
+      const result = await installSkillFromSource({
+        workspaceDir,
+        spec: sourceDir,
+        slug: "custom-name",
+      });
+
+      expect(result).toMatchObject({ ok: true });
+      await fs.writeFile(
+        path.join(workspaceDir, "skills", "custom-name", ".openclaw", "source-origin.json"),
+        "x".repeat(20 * 1024),
+      );
+
+      const status = buildWorkspaceSkillStatus(workspaceDir, {
+        managedSkillsDir: path.join(root, "managed-skills"),
+      });
+      expect(status.skills.find((entry) => entry.skillKey === "custom-name")).toBeUndefined();
+      expect(status.skills.find((entry) => entry.skillKey === "frontmatter-skill")).toBeDefined();
     });
   });
 

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -22,6 +22,7 @@ import { resolvePluginSkillDirs } from "./plugin-skills.js";
 import { serializeByKey } from "./serialize.js";
 import { formatSkillsForPrompt, type Skill } from "./skill-contract.js";
 import type {
+  OpenClawSkillMetadata,
   ParsedSkillFrontmatter,
   SkillEligibilityContext,
   SkillEntry,
@@ -30,6 +31,8 @@ import type {
 
 const fsp = fs.promises;
 const skillsLogger = createSubsystemLogger("skills");
+const SKILL_SOURCE_ORIGIN_RELATIVE_PATH = path.join(".openclaw", "source-origin.json");
+const MAX_SKILL_SOURCE_ORIGIN_BYTES = 16 * 1024;
 
 /**
  * Replace the user's home directory prefix with `~` in skill file paths
@@ -406,6 +409,48 @@ function loadContainedSkillRecords(params: {
   return canonicalSkillDir
     ? records.map((record) => canonicalizeLoadedSkillRecord(record, canonicalSkillDir))
     : records;
+}
+
+function readSourceInstallSkillKey(skillDir: string): string | undefined {
+  try {
+    const sourceOriginPath = path.join(skillDir, SKILL_SOURCE_ORIGIN_RELATIVE_PATH);
+    const stat = fs.lstatSync(sourceOriginPath);
+    if (!stat.isFile() || stat.isSymbolicLink() || stat.size > MAX_SKILL_SOURCE_ORIGIN_BYTES) {
+      return undefined;
+    }
+    const skillDirRealPath = tryRealpath(skillDir);
+    const sourceOriginRealPath = tryRealpath(sourceOriginPath);
+    if (
+      !skillDirRealPath ||
+      !sourceOriginRealPath ||
+      !isPathInside(skillDirRealPath, sourceOriginRealPath)
+    ) {
+      return undefined;
+    }
+    const raw = fs.readFileSync(sourceOriginPath, "utf8");
+    const parsed = JSON.parse(raw) as { slug?: unknown };
+    return normalizeOptionalString(parsed.slug);
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveSkillEntryMetadata(params: {
+  frontmatter: ParsedSkillFrontmatter;
+  skillDir: string;
+}): OpenClawSkillMetadata | undefined {
+  const metadata = resolveOpenClawMetadata(params.frontmatter);
+  if (metadata?.skillKey) {
+    return metadata;
+  }
+  const sourceInstallSkillKey = readSourceInstallSkillKey(params.skillDir);
+  if (!sourceInstallSkillKey) {
+    return metadata;
+  }
+  return {
+    ...metadata,
+    skillKey: sourceInstallSkillKey,
+  };
 }
 
 function canonicalizeLoadedSkillRecord(
@@ -934,7 +979,7 @@ function loadSkillEntries(
       return {
         skill,
         frontmatter,
-        metadata: resolveOpenClawMetadata(frontmatter),
+        metadata: resolveSkillEntryMetadata({ frontmatter, skillDir: skill.baseDir }),
         invocation,
         ...(record.syncSourceDir !== undefined ? { syncSourceDir: record.syncSourceDir } : {}),
         ...(record.syncDirName !== undefined ? { syncDirName: record.syncDirName } : {}),


### PR DESCRIPTION
## Summary

- make source-installed skills expose the installed `--as` slug as their skill key
- keep upstream `SKILL.md` names untouched by reading the installer-written source-origin sidecar
- bound source-origin reads to regular in-root files under a small size cap

## Verification

- `node scripts/run-vitest.mjs src/agents/skills-source-install.test.ts src/cli/skills-cli.commands.test.ts`
- `AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --mode local`

## Real Behavior Proof

Behavior addressed: `openclaw skills install ./path --as custom-name` and `git:` source installs now remain discoverable by the installed alias through skill status/info lookups.

Real environment tested: local Codex worktree on macOS using isolated temporary OpenClaw home directories and focused Vitest coverage.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/skills-source-install.test.ts src/cli/skills-cli.commands.test.ts`.

Evidence after fix: focused tests passed with 3 files and 51 tests, including alias skill-key exposure and oversized source-origin metadata handling.

Observed result after fix: final autoreview reported `autoreview clean: no accepted/actionable findings reported`.

What was not tested: no broad full-suite or remote Testbox run; this is a focused follow-up for source-install alias lookup behavior.
