### PR TITLE
fix(memory-core): bound managed dreaming under pressure

### DIFF
--- a/docs/concepts/dreaming.md
+++ b/docs/concepts/dreaming.md
@@ -121,9 +121,11 @@ deep-phase promotion engine.
 
 ## Scheduling
 
-When enabled, `memory-core` auto-manages one cron job for a full dreaming sweep. Each sweep runs phases in order: light → REM → deep.
+When enabled, `memory-core` auto-manages one cron job for scheduled dreaming. Each cron tick runs phases in order: light → REM → deep.
 
-The sweep includes the primary runtime workspace and any configured agent workspaces, deduped by path, so subagent workspace fan-out does not exclude the main agent's `DREAMS.md` and memory state.
+Scheduled dreaming includes the primary runtime workspace and any configured agent workspaces, deduped by path, so subagent workspace fan-out does not exclude the main agent's `DREAMS.md` and memory state.
+
+For cron-triggered runs, `memory-core` preserves the full scheduled sweep. If gateway RSS or heap usage is above the warning threshold before a workspace starts, scheduled dreaming backs off before continuing. The backoff starts at 30 seconds and doubles up to a 5 minute maximum delay between workspace attempts. It keeps retrying at the capped delay until pressure clears or the enclosing cron run stops. Direct non-cron dreaming requests are not delayed by this scheduler guard.
 
 Default cadence behavior:
 

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -310,7 +310,7 @@ restart after changing native plugin config.
   - `model`: Grok model to use for search (e.g. `"grok-4-1-fast"`).
 - `plugins.entries.memory-core.config.dreaming`: memory dreaming settings. See [Dreaming](/concepts/dreaming) for phases and thresholds.
   - `enabled`: master dreaming switch (default `false`).
-  - `frequency`: cron cadence for each full dreaming sweep (`"0 3 * * *"` by default).
+  - `frequency`: cron cadence for scheduled dreaming sweeps (`"0 3 * * *"` by default). A scheduled sweep includes all configured dreaming workspaces. If gateway RSS or heap usage is above the warning threshold between workspaces, the sweep backs off from 30 seconds up to a 5 minute maximum delay before continuing; it keeps retrying at the capped delay until pressure clears or the enclosing cron run stops.
   - `model`: optional Dream Diary subagent model override. Requires `plugins.entries.memory-core.subagent.allowModelOverride: true`; pair with `allowedModels` to restrict targets. Model-unavailable errors retry once with the session default model; trust or allowlist failures do not fall back silently.
   - phase policy and thresholds are implementation details (not user-facing config keys).
 - Full memory config lives in [Memory configuration reference](/reference/memory-config):

--- a/extensions/memory-core/src/dreaming.test.ts
+++ b/extensions/memory-core/src/dreaming.test.ts
@@ -10,9 +10,9 @@ import {
   testing,
   reconcileShortTermDreamingCronJob,
   registerShortTermPromotionDreaming,
-  resetManagedDreamingWorkspaceCursorForTest,
   resolveShortTermPromotionDreamingConfig,
   runShortTermDreamingPromotionIfTriggered,
+  setDreamingPressureBackoffSleepForTest,
 } from "./dreaming.js";
 import { recordShortTermRecalls } from "./short-term-promotion.js";
 import { createMemoryCoreTestHarness } from "./test-helpers.js";
@@ -22,7 +22,7 @@ const { createTempWorkspace } = createMemoryCoreTestHarness();
 
 afterEach(() => {
   resetSystemEventsForTest();
-  resetManagedDreamingWorkspaceCursorForTest();
+  setDreamingPressureBackoffSleepForTest();
   vi.restoreAllMocks();
 });
 
@@ -1301,11 +1301,12 @@ describe("gateway startup reconciliation", () => {
     }
   });
 
-  it("treats queued managed dreaming heartbeat events as cron work for pressure deferral", async () => {
+  it("treats queued managed dreaming heartbeat events as cron work for pressure backoff", async () => {
     clearInternalHooks();
     const logger = createLogger();
     const harness = createCronHarness();
     const onMock = vi.fn();
+    const workspaceDir = await createTempWorkspace("memory-dreaming-cron-heartbeat-pressure-");
     const api: DreamingPluginApiTestDouble = {
       config: {
         plugins: {
@@ -1325,12 +1326,27 @@ describe("gateway startup reconciliation", () => {
       runtime: {},
       on: onMock,
     };
-    vi.spyOn(process, "memoryUsage").mockReturnValue({
-      rss: 2 * 1024 * 1024 * 1024,
+    const lowPressure = {
+      rss: 64 * 1024 * 1024,
       heapTotal: 64 * 1024 * 1024,
       heapUsed: 32 * 1024 * 1024,
       external: 0,
       arrayBuffers: 0,
+    };
+    const highPressure = {
+      ...lowPressure,
+      rss: 2 * 1024 * 1024 * 1024,
+    };
+    const pressureSequence = [highPressure, lowPressure];
+    vi.spyOn(process, "memoryUsage").mockImplementation(() => {
+      return pressureSequence.shift() ?? lowPressure;
+    });
+    const backoffDelays: number[] = [];
+    setDreamingPressureBackoffSleepForTest(async (delayMs) => {
+      backoffDelays.push(delayMs);
+      if (backoffDelays.length > 6) {
+        throw new Error("pressure backoff test did not clear memory pressure");
+      }
     });
 
     try {
@@ -1349,13 +1365,14 @@ describe("gateway startup reconciliation", () => {
       const beforeAgentReply = getBeforeAgentReplyHandler(onMock);
       const result = await beforeAgentReply(
         { cleanedBody: constants.DREAMING_SYSTEM_EVENT_TEXT },
-        { trigger: "heartbeat", workspaceDir: ".", sessionKey },
+        { trigger: "heartbeat", workspaceDir, sessionKey },
       );
 
       expect(result).toEqual({
         handled: true,
-        reason: "memory-core: short-term dreaming deferred by pressure",
+        reason: "memory-core: short-term dreaming processed",
       });
+      expect(backoffDelays).toEqual([30_000]);
     } finally {
       clearInternalHooks();
     }
@@ -2635,9 +2652,9 @@ describe("short-term dreaming trigger", () => {
     );
   });
 
-  it("limits managed cron dreaming to a rotating workspace batch", async () => {
+  it("keeps managed cron dreaming as a full workspace sweep when pressure is low", async () => {
     const logger = createLogger();
-    const workspaceRoot = await createTempWorkspace("memory-dreaming-cron-batch-");
+    const workspaceRoot = await createTempWorkspace("memory-dreaming-cron-full-sweep-");
     const mainWorkspace = path.join(workspaceRoot, "main");
     const alphaWorkspace = path.join(workspaceRoot, "alpha");
     const betaWorkspace = path.join(workspaceRoot, "beta");
@@ -2705,54 +2722,29 @@ describe("short-term dreaming trigger", () => {
     });
 
     expect(result?.handled).toBe(true);
+    expect(await fs.readFile(path.join(mainWorkspace, "MEMORY.md"), "utf-8")).toContain(
+      "Main cron note.",
+    );
     expect(await fs.readFile(path.join(alphaWorkspace, "MEMORY.md"), "utf-8")).toContain(
       "Alpha cron note.",
     );
     expect(await fs.readFile(path.join(betaWorkspace, "MEMORY.md"), "utf-8")).toContain(
       "Beta cron note.",
     );
-    await expect(fs.access(path.join(mainWorkspace, "MEMORY.md"))).rejects.toThrow();
     expect(logger.info).toHaveBeenCalledWith(
-      "memory-core: dreaming promotion limited to 2/3 workspace(s); deferred 1 workspace(s) to a later cron tick.",
-    );
-    expect(logger.info).toHaveBeenCalledWith(
-      "memory-core: dreaming promotion complete (workspaces=2/3, candidates=2, applied=2, failed=0, deferred=1).",
-    );
-
-    await runShortTermDreamingPromotionIfTriggered({
-      cleanedBody: constants.DREAMING_SYSTEM_EVENT_TEXT,
-      trigger: "cron",
-      workspaceDir: mainWorkspace,
-      cfg,
-      config: {
-        enabled: true,
-        cron: constants.DEFAULT_DREAMING_CRON_EXPR,
-        limit: 10,
-        minScore: 0,
-        minRecallCount: 0,
-        minUniqueQueries: 0,
-        recencyHalfLifeDays: constants.DEFAULT_DREAMING_RECENCY_HALF_LIFE_DAYS,
-        verboseLogging: false,
-      },
-      logger,
-    });
-
-    expect(await fs.readFile(path.join(mainWorkspace, "MEMORY.md"), "utf-8")).toContain(
-      "Main cron note.",
+      "memory-core: dreaming promotion complete (workspaces=3, candidates=3, applied=3, failed=0).",
     );
   });
 
-  it("does not advance the managed cron workspace cursor past pressure-deferred work", async () => {
+  it("backs off between managed cron workspaces and continues when pressure clears", async () => {
     const logger = createLogger();
-    const workspaceRoot = await createTempWorkspace("memory-dreaming-cron-pressure-cursor-");
+    const workspaceRoot = await createTempWorkspace("memory-dreaming-cron-pressure-backoff-");
     const alphaWorkspace = path.join(workspaceRoot, "alpha");
     const betaWorkspace = path.join(workspaceRoot, "beta");
-    const mainWorkspace = path.join(workspaceRoot, "main");
 
     for (const [workspaceDir, query, snippet] of [
-      [alphaWorkspace, "alpha cursor", "Alpha cursor note."],
-      [betaWorkspace, "beta cursor", "Beta cursor note."],
-      [mainWorkspace, "main cursor", "Main cursor note."],
+      [alphaWorkspace, "alpha backoff", "Alpha backoff note."],
+      [betaWorkspace, "beta backoff", "Beta backoff note."],
     ] as const) {
       await writeDailyMemoryNote(workspaceDir, "2026-04-02", [snippet]);
       await recordShortTermRecalls({
@@ -2778,10 +2770,6 @@ describe("short-term dreaming trigger", () => {
             id: "alpha",
             workspace: alphaWorkspace,
           },
-          {
-            id: "beta",
-            workspace: betaWorkspace,
-          },
         ],
       },
     } as OpenClawConfig;
@@ -2796,10 +2784,16 @@ describe("short-term dreaming trigger", () => {
       ...lowPressure,
       rss: 2 * 1024 * 1024 * 1024,
     };
-    let memoryChecks = 0;
-    const memorySpy = vi.spyOn(process, "memoryUsage").mockImplementation(() => {
-      memoryChecks += 1;
-      return memoryChecks >= 3 ? highPressure : lowPressure;
+    const pressureSequence = [lowPressure, highPressure, highPressure, lowPressure];
+    vi.spyOn(process, "memoryUsage").mockImplementation(() => {
+      return pressureSequence.shift() ?? lowPressure;
+    });
+    const backoffDelays: number[] = [];
+    setDreamingPressureBackoffSleepForTest(async (delayMs) => {
+      backoffDelays.push(delayMs);
+      if (backoffDelays.length > 6) {
+        throw new Error("pressure backoff test did not clear memory pressure");
+      }
     });
 
     const config = {
@@ -2816,60 +2810,102 @@ describe("short-term dreaming trigger", () => {
     await runShortTermDreamingPromotionIfTriggered({
       cleanedBody: constants.DREAMING_SYSTEM_EVENT_TEXT,
       trigger: "cron",
-      workspaceDir: mainWorkspace,
+      workspaceDir: betaWorkspace,
       cfg,
       config,
       logger,
     });
     expect(await fs.readFile(path.join(alphaWorkspace, "MEMORY.md"), "utf-8")).toContain(
-      "Alpha cursor note.",
+      "Alpha backoff note.",
     );
-    await expect(fs.access(path.join(betaWorkspace, "MEMORY.md"))).rejects.toThrow();
-
-    memorySpy.mockReturnValue(lowPressure);
-    await runShortTermDreamingPromotionIfTriggered({
-      cleanedBody: constants.DREAMING_SYSTEM_EVENT_TEXT,
-      trigger: "cron",
-      workspaceDir: mainWorkspace,
-      cfg,
-      config,
-      logger,
-    });
     expect(await fs.readFile(path.join(betaWorkspace, "MEMORY.md"), "utf-8")).toContain(
-      "Beta cursor note.",
+      "Beta backoff note.",
+    );
+    expect(backoffDelays).toEqual([30_000, 60_000]);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "memory-core: dreaming promotion waiting 30000ms because gateway memory pressure is high",
+      ),
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "memory-core: dreaming promotion waiting 60000ms because gateway memory pressure is high",
+      ),
     );
   });
 
-  it("defers managed cron dreaming while memory pressure is above warning threshold", async () => {
+  it("keeps retrying capped pressure backoff until the next workspace can run", async () => {
     const logger = createLogger();
-    const workspaceDir = await createTempWorkspace("memory-dreaming-cron-pressure-");
-    await writeDailyMemoryNote(workspaceDir, "2026-04-02", ["Pressure note."]);
-    await recordShortTermRecalls({
-      workspaceDir,
-      query: "pressure",
-      results: [
-        {
-          path: "memory/2026-04-02.md",
-          startLine: 1,
-          endLine: 1,
-          score: 0.9,
-          snippet: "Pressure note.",
-          source: "memory",
-        },
-      ],
-    });
-    vi.spyOn(process, "memoryUsage").mockReturnValue({
-      rss: 2 * 1024 * 1024 * 1024,
+    const workspaceRoot = await createTempWorkspace("memory-dreaming-cron-pressure-defer-");
+    const alphaWorkspace = path.join(workspaceRoot, "alpha");
+    const betaWorkspace = path.join(workspaceRoot, "beta");
+    for (const [workspaceDir, query, snippet] of [
+      [alphaWorkspace, "alpha defer", "Alpha defer note."],
+      [betaWorkspace, "beta defer", "Beta defer note."],
+    ] as const) {
+      await writeDailyMemoryNote(workspaceDir, "2026-04-02", [snippet]);
+      await recordShortTermRecalls({
+        workspaceDir,
+        query,
+        results: [
+          {
+            path: "memory/2026-04-02.md",
+            startLine: 1,
+            endLine: 1,
+            score: 0.9,
+            snippet,
+            source: "memory",
+          },
+        ],
+      });
+    }
+    const cfg = {
+      agents: {
+        list: [
+          {
+            id: "alpha",
+            workspace: alphaWorkspace,
+          },
+        ],
+      },
+    } as OpenClawConfig;
+    const lowPressure = {
+      rss: 64 * 1024 * 1024,
       heapTotal: 64 * 1024 * 1024,
       heapUsed: 32 * 1024 * 1024,
       external: 0,
       arrayBuffers: 0,
+    };
+    const highPressure = {
+      ...lowPressure,
+      rss: 2 * 1024 * 1024 * 1024,
+    };
+    const pressureSequence = [
+      lowPressure,
+      highPressure,
+      highPressure,
+      highPressure,
+      highPressure,
+      highPressure,
+      highPressure,
+      lowPressure,
+    ];
+    vi.spyOn(process, "memoryUsage").mockImplementation(() => {
+      return pressureSequence.shift() ?? lowPressure;
+    });
+    const backoffDelays: number[] = [];
+    setDreamingPressureBackoffSleepForTest(async (delayMs) => {
+      backoffDelays.push(delayMs);
+      if (backoffDelays.length > 6) {
+        throw new Error("pressure backoff test did not clear memory pressure");
+      }
     });
 
     const result = await runShortTermDreamingPromotionIfTriggered({
       cleanedBody: constants.DREAMING_SYSTEM_EVENT_TEXT,
       trigger: "cron",
-      workspaceDir,
+      workspaceDir: betaWorkspace,
+      cfg,
       config: {
         enabled: true,
         cron: constants.DEFAULT_DREAMING_CRON_EXPR,
@@ -2885,12 +2921,18 @@ describe("short-term dreaming trigger", () => {
 
     expect(result).toEqual({
       handled: true,
-      reason: "memory-core: short-term dreaming deferred by pressure",
+      reason: "memory-core: short-term dreaming processed",
     });
-    await expect(fs.access(path.join(workspaceDir, "MEMORY.md"))).rejects.toThrow();
+    expect(await fs.readFile(path.join(alphaWorkspace, "MEMORY.md"), "utf-8")).toContain(
+      "Alpha defer note.",
+    );
+    expect(await fs.readFile(path.join(betaWorkspace, "MEMORY.md"), "utf-8")).toContain(
+      "Beta defer note.",
+    );
+    expect(backoffDelays).toEqual([30_000, 60_000, 120_000, 240_000, 300_000, 300_000]);
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining(
-        "memory-core: dreaming promotion deferred because gateway memory pressure is high",
+        "memory-core: dreaming promotion waiting 300000ms because gateway memory pressure is high",
       ),
     );
   });

--- a/extensions/memory-core/src/dreaming.test.ts
+++ b/extensions/memory-core/src/dreaming.test.ts
@@ -10,6 +10,7 @@ import {
   testing,
   reconcileShortTermDreamingCronJob,
   registerShortTermPromotionDreaming,
+  resetManagedDreamingWorkspaceCursorForTest,
   resolveShortTermPromotionDreamingConfig,
   runShortTermDreamingPromotionIfTriggered,
 } from "./dreaming.js";
@@ -21,6 +22,8 @@ const { createTempWorkspace } = createMemoryCoreTestHarness();
 
 afterEach(() => {
   resetSystemEventsForTest();
+  resetManagedDreamingWorkspaceCursorForTest();
+  vi.restoreAllMocks();
 });
 
 function clearInternalHooks(): void {}
@@ -1298,6 +1301,66 @@ describe("gateway startup reconciliation", () => {
     }
   });
 
+  it("treats queued managed dreaming heartbeat events as cron work for pressure deferral", async () => {
+    clearInternalHooks();
+    const logger = createLogger();
+    const harness = createCronHarness();
+    const onMock = vi.fn();
+    const api: DreamingPluginApiTestDouble = {
+      config: {
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                },
+              },
+            },
+          },
+        },
+      } as OpenClawConfig,
+      pluginConfig: {},
+      logger,
+      runtime: {},
+      on: onMock,
+    };
+    vi.spyOn(process, "memoryUsage").mockReturnValue({
+      rss: 2 * 1024 * 1024 * 1024,
+      heapTotal: 64 * 1024 * 1024,
+      heapUsed: 32 * 1024 * 1024,
+      external: 0,
+      arrayBuffers: 0,
+    });
+
+    try {
+      registerShortTermPromotionDreamingForTest(api);
+      await triggerGatewayStart(onMock, {
+        config: api.config,
+        getCron: () => harness.cron,
+      });
+
+      const sessionKey = "agent:main:main";
+      enqueueSystemEvent(constants.DREAMING_SYSTEM_EVENT_TEXT, {
+        sessionKey,
+        contextKey: "cron:memory-dreaming",
+      });
+
+      const beforeAgentReply = getBeforeAgentReplyHandler(onMock);
+      const result = await beforeAgentReply(
+        { cleanedBody: constants.DREAMING_SYSTEM_EVENT_TEXT },
+        { trigger: "heartbeat", workspaceDir: ".", sessionKey },
+      );
+
+      expect(result).toEqual({
+        handled: true,
+        reason: "memory-core: short-term dreaming deferred by pressure",
+      });
+    } finally {
+      clearInternalHooks();
+    }
+  });
+
   it("does not emit the cron-unavailable warning on gateway_start when cron is missing (regression #69939)", async () => {
     clearInternalHooks();
     const logger = createLogger();
@@ -2569,6 +2632,266 @@ describe("short-term dreaming trigger", () => {
     );
     expect(logger.info).toHaveBeenCalledWith(
       "memory-core: dreaming promotion complete (workspaces=3, candidates=3, applied=3, failed=0).",
+    );
+  });
+
+  it("limits managed cron dreaming to a rotating workspace batch", async () => {
+    const logger = createLogger();
+    const workspaceRoot = await createTempWorkspace("memory-dreaming-cron-batch-");
+    const mainWorkspace = path.join(workspaceRoot, "main");
+    const alphaWorkspace = path.join(workspaceRoot, "alpha");
+    const betaWorkspace = path.join(workspaceRoot, "beta");
+
+    await writeDailyMemoryNote(mainWorkspace, "2026-04-02", ["Main cron note."]);
+    await writeDailyMemoryNote(alphaWorkspace, "2026-04-02", ["Alpha cron note."]);
+    await writeDailyMemoryNote(betaWorkspace, "2026-04-02", ["Beta cron note."]);
+    for (const [workspaceDir, query, snippet] of [
+      [mainWorkspace, "main cron", "Main cron note."],
+      [alphaWorkspace, "alpha cron", "Alpha cron note."],
+      [betaWorkspace, "beta cron", "Beta cron note."],
+    ] as const) {
+      await recordShortTermRecalls({
+        workspaceDir,
+        query,
+        results: [
+          {
+            path: "memory/2026-04-02.md",
+            startLine: 1,
+            endLine: 1,
+            score: 0.9,
+            snippet,
+            source: "memory",
+          },
+        ],
+      });
+    }
+
+    const cfg = {
+      agents: {
+        defaults: {
+          memorySearch: {
+            enabled: true,
+          },
+        },
+        list: [
+          {
+            id: "alpha",
+            workspace: alphaWorkspace,
+          },
+          {
+            id: "beta",
+            workspace: betaWorkspace,
+          },
+        ],
+      },
+    } as OpenClawConfig;
+
+    const result = await runShortTermDreamingPromotionIfTriggered({
+      cleanedBody: constants.DREAMING_SYSTEM_EVENT_TEXT,
+      trigger: "cron",
+      workspaceDir: mainWorkspace,
+      cfg,
+      config: {
+        enabled: true,
+        cron: constants.DEFAULT_DREAMING_CRON_EXPR,
+        limit: 10,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+        recencyHalfLifeDays: constants.DEFAULT_DREAMING_RECENCY_HALF_LIFE_DAYS,
+        verboseLogging: false,
+      },
+      logger,
+    });
+
+    expect(result?.handled).toBe(true);
+    expect(await fs.readFile(path.join(alphaWorkspace, "MEMORY.md"), "utf-8")).toContain(
+      "Alpha cron note.",
+    );
+    expect(await fs.readFile(path.join(betaWorkspace, "MEMORY.md"), "utf-8")).toContain(
+      "Beta cron note.",
+    );
+    await expect(fs.access(path.join(mainWorkspace, "MEMORY.md"))).rejects.toThrow();
+    expect(logger.info).toHaveBeenCalledWith(
+      "memory-core: dreaming promotion limited to 2/3 workspace(s); deferred 1 workspace(s) to a later cron tick.",
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      "memory-core: dreaming promotion complete (workspaces=2/3, candidates=2, applied=2, failed=0, deferred=1).",
+    );
+
+    await runShortTermDreamingPromotionIfTriggered({
+      cleanedBody: constants.DREAMING_SYSTEM_EVENT_TEXT,
+      trigger: "cron",
+      workspaceDir: mainWorkspace,
+      cfg,
+      config: {
+        enabled: true,
+        cron: constants.DEFAULT_DREAMING_CRON_EXPR,
+        limit: 10,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+        recencyHalfLifeDays: constants.DEFAULT_DREAMING_RECENCY_HALF_LIFE_DAYS,
+        verboseLogging: false,
+      },
+      logger,
+    });
+
+    expect(await fs.readFile(path.join(mainWorkspace, "MEMORY.md"), "utf-8")).toContain(
+      "Main cron note.",
+    );
+  });
+
+  it("does not advance the managed cron workspace cursor past pressure-deferred work", async () => {
+    const logger = createLogger();
+    const workspaceRoot = await createTempWorkspace("memory-dreaming-cron-pressure-cursor-");
+    const alphaWorkspace = path.join(workspaceRoot, "alpha");
+    const betaWorkspace = path.join(workspaceRoot, "beta");
+    const mainWorkspace = path.join(workspaceRoot, "main");
+
+    for (const [workspaceDir, query, snippet] of [
+      [alphaWorkspace, "alpha cursor", "Alpha cursor note."],
+      [betaWorkspace, "beta cursor", "Beta cursor note."],
+      [mainWorkspace, "main cursor", "Main cursor note."],
+    ] as const) {
+      await writeDailyMemoryNote(workspaceDir, "2026-04-02", [snippet]);
+      await recordShortTermRecalls({
+        workspaceDir,
+        query,
+        results: [
+          {
+            path: "memory/2026-04-02.md",
+            startLine: 1,
+            endLine: 1,
+            score: 0.9,
+            snippet,
+            source: "memory",
+          },
+        ],
+      });
+    }
+
+    const cfg = {
+      agents: {
+        list: [
+          {
+            id: "alpha",
+            workspace: alphaWorkspace,
+          },
+          {
+            id: "beta",
+            workspace: betaWorkspace,
+          },
+        ],
+      },
+    } as OpenClawConfig;
+    const lowPressure = {
+      rss: 64 * 1024 * 1024,
+      heapTotal: 64 * 1024 * 1024,
+      heapUsed: 32 * 1024 * 1024,
+      external: 0,
+      arrayBuffers: 0,
+    };
+    const highPressure = {
+      ...lowPressure,
+      rss: 2 * 1024 * 1024 * 1024,
+    };
+    let memoryChecks = 0;
+    const memorySpy = vi.spyOn(process, "memoryUsage").mockImplementation(() => {
+      memoryChecks += 1;
+      return memoryChecks >= 3 ? highPressure : lowPressure;
+    });
+
+    const config = {
+      enabled: true,
+      cron: constants.DEFAULT_DREAMING_CRON_EXPR,
+      limit: 10,
+      minScore: 0,
+      minRecallCount: 0,
+      minUniqueQueries: 0,
+      recencyHalfLifeDays: constants.DEFAULT_DREAMING_RECENCY_HALF_LIFE_DAYS,
+      verboseLogging: false,
+    };
+
+    await runShortTermDreamingPromotionIfTriggered({
+      cleanedBody: constants.DREAMING_SYSTEM_EVENT_TEXT,
+      trigger: "cron",
+      workspaceDir: mainWorkspace,
+      cfg,
+      config,
+      logger,
+    });
+    expect(await fs.readFile(path.join(alphaWorkspace, "MEMORY.md"), "utf-8")).toContain(
+      "Alpha cursor note.",
+    );
+    await expect(fs.access(path.join(betaWorkspace, "MEMORY.md"))).rejects.toThrow();
+
+    memorySpy.mockReturnValue(lowPressure);
+    await runShortTermDreamingPromotionIfTriggered({
+      cleanedBody: constants.DREAMING_SYSTEM_EVENT_TEXT,
+      trigger: "cron",
+      workspaceDir: mainWorkspace,
+      cfg,
+      config,
+      logger,
+    });
+    expect(await fs.readFile(path.join(betaWorkspace, "MEMORY.md"), "utf-8")).toContain(
+      "Beta cursor note.",
+    );
+  });
+
+  it("defers managed cron dreaming while memory pressure is above warning threshold", async () => {
+    const logger = createLogger();
+    const workspaceDir = await createTempWorkspace("memory-dreaming-cron-pressure-");
+    await writeDailyMemoryNote(workspaceDir, "2026-04-02", ["Pressure note."]);
+    await recordShortTermRecalls({
+      workspaceDir,
+      query: "pressure",
+      results: [
+        {
+          path: "memory/2026-04-02.md",
+          startLine: 1,
+          endLine: 1,
+          score: 0.9,
+          snippet: "Pressure note.",
+          source: "memory",
+        },
+      ],
+    });
+    vi.spyOn(process, "memoryUsage").mockReturnValue({
+      rss: 2 * 1024 * 1024 * 1024,
+      heapTotal: 64 * 1024 * 1024,
+      heapUsed: 32 * 1024 * 1024,
+      external: 0,
+      arrayBuffers: 0,
+    });
+
+    const result = await runShortTermDreamingPromotionIfTriggered({
+      cleanedBody: constants.DREAMING_SYSTEM_EVENT_TEXT,
+      trigger: "cron",
+      workspaceDir,
+      config: {
+        enabled: true,
+        cron: constants.DEFAULT_DREAMING_CRON_EXPR,
+        limit: 10,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+        recencyHalfLifeDays: constants.DEFAULT_DREAMING_RECENCY_HALF_LIFE_DAYS,
+        verboseLogging: false,
+      },
+      logger,
+    });
+
+    expect(result).toEqual({
+      handled: true,
+      reason: "memory-core: short-term dreaming deferred by pressure",
+    });
+    await expect(fs.access(path.join(workspaceDir, "MEMORY.md"))).rejects.toThrow();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "memory-core: dreaming promotion deferred because gateway memory pressure is high",
+      ),
     );
   });
 });

--- a/extensions/memory-core/src/dreaming.test.ts
+++ b/extensions/memory-core/src/dreaming.test.ts
@@ -217,11 +217,14 @@ async function expectPathMissing(targetPath: string): Promise<void> {
   throw new Error(`expected path to be missing: ${targetPath}`);
 }
 
-function getBeforeAgentReplyHandler(
-  onMock: ReturnType<typeof vi.fn>,
-): (
+function getBeforeAgentReplyHandler(onMock: ReturnType<typeof vi.fn>): (
   event: { cleanedBody: string },
-  ctx: { trigger?: string; workspaceDir?: string; sessionKey?: string },
+  ctx: {
+    trigger?: string;
+    workspaceDir?: string;
+    sessionKey?: string;
+    abortSignal?: AbortSignal;
+  },
 ) => Promise<unknown> {
   const call = onMock.mock.calls.find(([eventName]) => eventName === "before_agent_reply");
   if (!call) {
@@ -229,7 +232,12 @@ function getBeforeAgentReplyHandler(
   }
   return call[1] as (
     event: { cleanedBody: string },
-    ctx: { trigger?: string; workspaceDir?: string; sessionKey?: string },
+    ctx: {
+      trigger?: string;
+      workspaceDir?: string;
+      sessionKey?: string;
+      abortSignal?: AbortSignal;
+    },
   ) => Promise<unknown>;
 }
 
@@ -2395,6 +2403,85 @@ describe("short-term dreaming trigger", () => {
     expect(subagent.run.mock.calls[0]?.[0]?.model).toBe("anthropic/claude-sonnet-4-6");
   });
 
+  it("still schedules managed cron dream diary prose when pressure rises after promotion", async () => {
+    const logger = createLogger();
+    const workspaceDir = await createTempWorkspace("memory-dreaming-cron-pressure-narrative-");
+    await writeDailyMemoryNote(workspaceDir, "2026-04-02", ["Archive router backups weekly."]);
+
+    await recordShortTermRecalls({
+      workspaceDir,
+      query: "router backups",
+      results: [
+        {
+          path: "memory/2026-04-02.md",
+          startLine: 1,
+          endLine: 1,
+          score: 0.9,
+          snippet: "Archive router backups weekly.",
+          source: "memory",
+        },
+      ],
+    });
+
+    const lowPressure = {
+      rss: 64 * 1024 * 1024,
+      heapTotal: 64 * 1024 * 1024,
+      heapUsed: 32 * 1024 * 1024,
+      external: 0,
+      arrayBuffers: 0,
+    };
+    const highPressure = {
+      ...lowPressure,
+      rss: 2 * 1024 * 1024 * 1024,
+    };
+    const pressureSequence = [lowPressure, highPressure, lowPressure];
+    vi.spyOn(process, "memoryUsage").mockImplementation(() => {
+      return pressureSequence.shift() ?? lowPressure;
+    });
+    const backoffDelays: number[] = [];
+    setDreamingPressureBackoffSleepForTest(async (delayMs) => {
+      backoffDelays.push(delayMs);
+    });
+
+    const subagent = {
+      run: vi.fn(async (_params: { model?: string }) => ({ runId: "narrative-run-1" })),
+      waitForRun: vi.fn(async () => ({ status: "ok" })),
+      getSessionMessages: vi.fn(async () => ({
+        messages: [{ role: "assistant", content: "The backups settled into the archive." }],
+      })),
+      deleteSession: vi.fn(async () => {}),
+    };
+
+    const result = await runShortTermDreamingPromotionIfTriggered({
+      cleanedBody: constants.DREAMING_SYSTEM_EVENT_TEXT,
+      trigger: "cron",
+      workspaceDir,
+      config: {
+        enabled: true,
+        cron: constants.DEFAULT_DREAMING_CRON_EXPR,
+        limit: 10,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+        recencyHalfLifeDays: constants.DEFAULT_DREAMING_RECENCY_HALF_LIFE_DAYS,
+        verboseLogging: false,
+      },
+      logger,
+      subagent,
+    });
+
+    expect(result?.handled).toBe(true);
+    await vi.waitFor(async () => {
+      expect(subagent.run).toHaveBeenCalled();
+      const dreamsText = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
+      expect(dreamsText).toContain("The backups settled into the archive.");
+    });
+    expect(logger.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("deferred detached dream narrative"),
+    );
+    expect(backoffDelays).toEqual([30_000]);
+  });
+
   it("skips dreaming promotion cleanly when limit is zero", async () => {
     const logger = createLogger();
     const workspaceDir = await createTempWorkspace("memory-dreaming-limit-zero-");
@@ -2933,6 +3020,89 @@ describe("short-term dreaming trigger", () => {
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining(
         "memory-core: dreaming promotion waiting 300000ms because gateway memory pressure is high",
+      ),
+    );
+  });
+
+  it("stops managed cron backoff when the cron abort signal fires", async () => {
+    const logger = createLogger();
+    const abortController = new AbortController();
+    const workspaceRoot = await createTempWorkspace("memory-dreaming-cron-pressure-abort-");
+    const alphaWorkspace = path.join(workspaceRoot, "alpha");
+    const betaWorkspace = path.join(workspaceRoot, "beta");
+    for (const [workspaceDir, query, snippet] of [
+      [alphaWorkspace, "alpha abort", "Alpha abort note."],
+      [betaWorkspace, "beta abort", "Beta abort note."],
+    ] as const) {
+      await writeDailyMemoryNote(workspaceDir, "2026-04-02", [snippet]);
+      await recordShortTermRecalls({
+        workspaceDir,
+        query,
+        results: [
+          {
+            path: "memory/2026-04-02.md",
+            startLine: 1,
+            endLine: 1,
+            score: 0.9,
+            snippet,
+            source: "memory",
+          },
+        ],
+      });
+    }
+    const cfg = {
+      agents: {
+        list: [
+          {
+            id: "alpha",
+            workspace: alphaWorkspace,
+          },
+        ],
+      },
+    } as OpenClawConfig;
+    const highPressure = {
+      rss: 2 * 1024 * 1024 * 1024,
+      heapTotal: 64 * 1024 * 1024,
+      heapUsed: 32 * 1024 * 1024,
+      external: 0,
+      arrayBuffers: 0,
+    };
+    vi.spyOn(process, "memoryUsage").mockReturnValue(highPressure);
+    const backoffDelays: number[] = [];
+    setDreamingPressureBackoffSleepForTest(async (delayMs) => {
+      backoffDelays.push(delayMs);
+      abortController.abort("test cron timeout");
+    });
+
+    const result = await runShortTermDreamingPromotionIfTriggered({
+      cleanedBody: constants.DREAMING_SYSTEM_EVENT_TEXT,
+      trigger: "cron",
+      workspaceDir: betaWorkspace,
+      cfg,
+      config: {
+        enabled: true,
+        cron: constants.DEFAULT_DREAMING_CRON_EXPR,
+        limit: 10,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+        recencyHalfLifeDays: constants.DEFAULT_DREAMING_RECENCY_HALF_LIFE_DAYS,
+        verboseLogging: false,
+      },
+      logger,
+      abortSignal: abortController.signal,
+    });
+
+    expect(result).toEqual({
+      handled: true,
+      reason: "memory-core: short-term dreaming aborted",
+    });
+    expect(backoffDelays).toEqual([30_000]);
+    await expectPathMissing(path.join(alphaWorkspace, "MEMORY.md"));
+    await expectPathMissing(path.join(betaWorkspace, "MEMORY.md"));
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "memory-core: dreaming promotion stopped while waiting for gateway memory pressure to ease",
       ),
     );
   });

--- a/extensions/memory-core/src/dreaming.ts
+++ b/extensions/memory-core/src/dreaming.ts
@@ -50,9 +50,25 @@ const DREAMING_PRESSURE_HEAP_WARNING_BYTES = 1024 * BYTES_PER_MIB;
 const DREAMING_PRESSURE_BACKOFF_INITIAL_MS = 30_000;
 const DREAMING_PRESSURE_BACKOFF_MAX_MS = 5 * 60_000;
 
-let dreamingPressureBackoffSleep: (delayMs: number) => Promise<void> = (delayMs) =>
+let dreamingPressureBackoffSleep: (delayMs: number, abortSignal?: AbortSignal) => Promise<void> = (
+  delayMs,
+  abortSignal,
+) =>
   new Promise((resolve) => {
-    setTimeout(resolve, delayMs);
+    if (abortSignal?.aborted) {
+      resolve();
+      return;
+    }
+    const timer = setTimeout(() => {
+      abortSignal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, delayMs);
+    const onAbort = () => {
+      clearTimeout(timer);
+      abortSignal?.removeEventListener("abort", onAbort);
+      resolve();
+    };
+    abortSignal?.addEventListener("abort", onAbort, { once: true });
   });
 
 type Logger = Pick<OpenClawPluginApi["logger"], "info" | "warn" | "error">;
@@ -182,36 +198,63 @@ function formatDreamingResourcePressure(pressure: DreamingResourcePressure): str
 async function waitForDreamingPressureToEase(params: {
   logger: Logger;
   workspaceDir: string;
-}): Promise<void> {
+  abortSignal?: AbortSignal;
+}): Promise<"ready" | "aborted"> {
   let pressure = detectDreamingResourcePressure();
   let delayMs = DREAMING_PRESSURE_BACKOFF_INITIAL_MS;
   while (pressure) {
+    if (params.abortSignal?.aborted) {
+      params.logger.warn(
+        `memory-core: dreaming promotion stopped while waiting for gateway memory pressure to ease [workspace=${params.workspaceDir}].`,
+      );
+      return "aborted";
+    }
     params.logger.warn(
       `memory-core: dreaming promotion waiting ${delayMs}ms because gateway memory pressure is high (${formatDreamingResourcePressure(pressure)}) [workspace=${params.workspaceDir}].`,
     );
-    await dreamingPressureBackoffSleep(delayMs);
+    await dreamingPressureBackoffSleep(delayMs, params.abortSignal);
+    if (params.abortSignal?.aborted) {
+      params.logger.warn(
+        `memory-core: dreaming promotion stopped while waiting for gateway memory pressure to ease [workspace=${params.workspaceDir}].`,
+      );
+      return "aborted";
+    }
     pressure = detectDreamingResourcePressure();
     delayMs = Math.min(delayMs * 2, DREAMING_PRESSURE_BACKOFF_MAX_MS);
   }
+  return "ready";
 }
 
 export function setDreamingPressureBackoffSleepForTest(
-  sleep?: (delayMs: number) => Promise<void>,
+  sleep?: (delayMs: number, abortSignal?: AbortSignal) => Promise<void>,
 ): void {
   if (sleep) {
     let calls = 0;
-    dreamingPressureBackoffSleep = async (delayMs) => {
+    dreamingPressureBackoffSleep = async (delayMs, abortSignal) => {
       calls += 1;
       if (calls > 100) {
         throw new Error("dreaming pressure backoff test sleep exceeded 100 calls");
       }
-      await sleep(delayMs);
+      await sleep(delayMs, abortSignal);
     };
     return;
   }
-  dreamingPressureBackoffSleep = (delayMs) =>
+  dreamingPressureBackoffSleep = (delayMs, abortSignal) =>
     new Promise((resolve) => {
-      setTimeout(resolve, delayMs);
+      if (abortSignal?.aborted) {
+        resolve();
+        return;
+      }
+      const timer = setTimeout(() => {
+        abortSignal?.removeEventListener("abort", onAbort);
+        resolve();
+      }, delayMs);
+      const onAbort = () => {
+        clearTimeout(timer);
+        abortSignal?.removeEventListener("abort", onAbort);
+        resolve();
+      };
+      abortSignal?.addEventListener("abort", onAbort, { once: true });
     });
 }
 
@@ -576,6 +619,7 @@ export async function runShortTermDreamingPromotionIfTriggered(params: {
   config: ShortTermPromotionDreamingConfig;
   logger: Logger;
   subagent?: Parameters<typeof generateAndAppendDreamNarrative>[0]["subagent"];
+  abortSignal?: AbortSignal;
 }): Promise<{ handled: true; reason: string } | undefined> {
   if (params.trigger !== "heartbeat" && params.trigger !== "cron") {
     return undefined;
@@ -631,10 +675,14 @@ export async function runShortTermDreamingPromotionIfTriggered(params: {
   const detachNarratives = params.trigger === "cron";
   for (const workspaceDir of workspaces) {
     if (params.trigger === "cron") {
-      await waitForDreamingPressureToEase({
+      const pressureStatus = await waitForDreamingPressureToEase({
         logger: params.logger,
         workspaceDir,
+        abortSignal: params.abortSignal,
       });
+      if (pressureStatus === "aborted") {
+        return { handled: true, reason: "memory-core: short-term dreaming aborted" };
+      }
     }
     try {
       const sweepNowMs = Date.now();
@@ -718,20 +766,20 @@ export async function runShortTermDreamingPromotionIfTriggered(params: {
       });
       // Generate dream diary narrative from promoted memories.
       if (params.subagent && (candidates.length > 0 || applied.applied > 0)) {
-        const narrativePressure =
-          params.trigger === "cron" ? detectDreamingResourcePressure() : null;
-        if (narrativePressure) {
-          params.logger.warn(
-            `memory-core: deferred detached dream narrative because gateway memory pressure is high (${formatDreamingResourcePressure(narrativePressure)}) [workspace=${workspaceDir}].`,
-          );
-          continue;
-        }
         const data: NarrativePhaseData = {
           phase: "deep",
           snippets: candidates.map((c) => c.snippet).filter(Boolean),
           promotions: applied.appliedCandidates.map((c) => c.snippet).filter(Boolean),
         };
         if (detachNarratives) {
+          const narrativePressureStatus = await waitForDreamingPressureToEase({
+            logger: params.logger,
+            workspaceDir,
+            abortSignal: params.abortSignal,
+          });
+          if (narrativePressureStatus === "aborted") {
+            return { handled: true, reason: "memory-core: short-term dreaming aborted" };
+          }
           runDetachedDreamNarrative({
             subagent: params.subagent,
             workspaceDir,
@@ -995,6 +1043,7 @@ export function registerShortTermPromotionDreaming(api: OpenClawPluginApi): void
         config,
         logger: api.logger,
         subagent: config.enabled ? api.runtime?.subagent : undefined,
+        abortSignal: ctx.abortSignal,
       });
     } catch (err) {
       api.logger.error(`memory-core: dreaming trigger failed: ${formatErrorMessage(err)}`);

--- a/extensions/memory-core/src/dreaming.ts
+++ b/extensions/memory-core/src/dreaming.ts
@@ -44,6 +44,12 @@ const RUNTIME_CRON_RECONCILE_INTERVAL_MS = 60_000;
 const STARTUP_CRON_RETRY_DELAY_MS = 5_000;
 const STARTUP_CRON_RETRY_MAX_ATTEMPTS = 12;
 const HEARTBEAT_ISOLATED_SESSION_SUFFIX = ":heartbeat";
+const BYTES_PER_MIB = 1024 * 1024;
+const DREAMING_PRESSURE_RSS_WARNING_BYTES = 1536 * BYTES_PER_MIB;
+const DREAMING_PRESSURE_HEAP_WARNING_BYTES = 1024 * BYTES_PER_MIB;
+const MANAGED_DREAMING_WORKSPACE_BATCH_LIMIT = 2;
+
+let managedDreamingWorkspaceCursor = 0;
 
 type Logger = Pick<OpenClawPluginApi["logger"], "info" | "warn" | "error">;
 
@@ -136,6 +142,74 @@ type ReconcileResult =
   | { status: "noop"; removed: number };
 
 type LegacyPhaseMigrationMode = "enabled" | "disabled";
+
+type DreamingResourcePressure = {
+  reason: "rss_threshold" | "heap_threshold";
+  rssBytes: number;
+  heapUsedBytes: number;
+  thresholdBytes: number;
+};
+
+function detectDreamingResourcePressure(): DreamingResourcePressure | null {
+  const memory = process.memoryUsage();
+  if (memory.rss >= DREAMING_PRESSURE_RSS_WARNING_BYTES) {
+    return {
+      reason: "rss_threshold",
+      rssBytes: memory.rss,
+      heapUsedBytes: memory.heapUsed,
+      thresholdBytes: DREAMING_PRESSURE_RSS_WARNING_BYTES,
+    };
+  }
+  if (memory.heapUsed >= DREAMING_PRESSURE_HEAP_WARNING_BYTES) {
+    return {
+      reason: "heap_threshold",
+      rssBytes: memory.rss,
+      heapUsedBytes: memory.heapUsed,
+      thresholdBytes: DREAMING_PRESSURE_HEAP_WARNING_BYTES,
+    };
+  }
+  return null;
+}
+
+function formatDreamingResourcePressure(pressure: DreamingResourcePressure): string {
+  return `reason=${pressure.reason} rssBytes=${pressure.rssBytes} heapUsedBytes=${pressure.heapUsedBytes} thresholdBytes=${pressure.thresholdBytes}`;
+}
+
+function selectManagedDreamingWorkspaces(
+  workspaces: string[],
+  trigger: string | undefined,
+): {
+  selected: string[];
+  deferred: number;
+  start: number;
+} {
+  if (trigger !== "cron" || workspaces.length <= MANAGED_DREAMING_WORKSPACE_BATCH_LIMIT) {
+    return { selected: workspaces, deferred: 0, start: 0 };
+  }
+
+  const start = managedDreamingWorkspaceCursor % workspaces.length;
+  const selected: string[] = [];
+  for (let index = 0; index < MANAGED_DREAMING_WORKSPACE_BATCH_LIMIT; index += 1) {
+    selected.push(workspaces[(start + index) % workspaces.length] as string);
+  }
+  return { selected, deferred: workspaces.length - selected.length, start };
+}
+
+function advanceManagedDreamingWorkspaceCursor(params: {
+  batch: ReturnType<typeof selectManagedDreamingWorkspaces>;
+  attemptedWorkspaces: number;
+  totalWorkspaces: number;
+}): void {
+  if (params.batch.deferred <= 0 || params.attemptedWorkspaces <= 0) {
+    return;
+  }
+  managedDreamingWorkspaceCursor =
+    (params.batch.start + params.attemptedWorkspaces) % params.totalWorkspaces;
+}
+
+export function resetManagedDreamingWorkspaceCursorForTest(): void {
+  managedDreamingWorkspaceCursor = 0;
+}
 
 function formatRepairSummary(repair: {
   rewroteStore: boolean;
@@ -540,18 +614,42 @@ export async function runShortTermDreamingPromotionIfTriggered(params: {
     return { handled: true, reason: "memory-core: short-term dreaming disabled by limit" };
   }
 
+  const initialPressure = params.trigger === "cron" ? detectDreamingResourcePressure() : null;
+  if (initialPressure) {
+    params.logger.warn(
+      `memory-core: dreaming promotion deferred because gateway memory pressure is high (${formatDreamingResourcePressure(initialPressure)}).`,
+    );
+    return { handled: true, reason: "memory-core: short-term dreaming deferred by pressure" };
+  }
+
+  const workspaceBatch = selectManagedDreamingWorkspaces(workspaces, params.trigger);
+  if (workspaceBatch.deferred > 0) {
+    params.logger.info(
+      `memory-core: dreaming promotion limited to ${workspaceBatch.selected.length}/${workspaces.length} workspace(s); deferred ${workspaceBatch.deferred} workspace(s) to a later cron tick.`,
+    );
+  }
+
   if (params.config.verboseLogging) {
     params.logger.info(
-      `memory-core: dreaming verbose enabled (cron=${params.config.cron}, limit=${params.config.limit}, minScore=${params.config.minScore.toFixed(3)}, minRecallCount=${params.config.minRecallCount}, minUniqueQueries=${params.config.minUniqueQueries}, recencyHalfLifeDays=${recencyHalfLifeDays}, maxAgeDays=${params.config.maxAgeDays ?? "none"}, workspaces=${workspaces.length}).`,
+      `memory-core: dreaming verbose enabled (cron=${params.config.cron}, limit=${params.config.limit}, minScore=${params.config.minScore.toFixed(3)}, minRecallCount=${params.config.minRecallCount}, minUniqueQueries=${params.config.minUniqueQueries}, recencyHalfLifeDays=${recencyHalfLifeDays}, maxAgeDays=${params.config.maxAgeDays ?? "none"}, workspaces=${workspaceBatch.selected.length}/${workspaces.length}).`,
     );
   }
 
   let totalCandidates = 0;
   let totalApplied = 0;
   let failedWorkspaces = 0;
+  let attemptedWorkspaces = 0;
   const pluginConfig = params.cfg ? resolveMemoryCorePluginConfig(params.cfg) : undefined;
   const detachNarratives = params.trigger === "cron";
-  for (const workspaceDir of workspaces) {
+  for (const workspaceDir of workspaceBatch.selected) {
+    const loopPressure = params.trigger === "cron" ? detectDreamingResourcePressure() : null;
+    if (loopPressure) {
+      params.logger.warn(
+        `memory-core: dreaming promotion stopped before workspace because gateway memory pressure is high (${formatDreamingResourcePressure(loopPressure)}).`,
+      );
+      break;
+    }
+    attemptedWorkspaces += 1;
     try {
       const sweepNowMs = Date.now();
       await runDreamingSweepPhases({
@@ -634,6 +732,14 @@ export async function runShortTermDreamingPromotionIfTriggered(params: {
       });
       // Generate dream diary narrative from promoted memories.
       if (params.subagent && (candidates.length > 0 || applied.applied > 0)) {
+        const narrativePressure =
+          params.trigger === "cron" ? detectDreamingResourcePressure() : null;
+        if (narrativePressure) {
+          params.logger.warn(
+            `memory-core: deferred detached dream narrative because gateway memory pressure is high (${formatDreamingResourcePressure(narrativePressure)}) [workspace=${workspaceDir}].`,
+          );
+          continue;
+        }
         const data: NarrativePhaseData = {
           phase: "deep",
           snippets: candidates.map((c) => c.snippet).filter(Boolean),
@@ -668,8 +774,19 @@ export async function runShortTermDreamingPromotionIfTriggered(params: {
       );
     }
   }
+  advanceManagedDreamingWorkspaceCursor({
+    batch: workspaceBatch,
+    attemptedWorkspaces,
+    totalWorkspaces: workspaces.length,
+  });
+  const workspaceSummary =
+    workspaceBatch.deferred > 0
+      ? `${workspaceBatch.selected.length}/${workspaces.length}`
+      : workspaces.length;
+  const deferredSummary =
+    workspaceBatch.deferred > 0 ? `, deferred=${workspaceBatch.deferred}` : "";
   params.logger.info(
-    `memory-core: dreaming promotion complete (workspaces=${workspaces.length}, candidates=${totalCandidates}, applied=${totalApplied}, failed=${failedWorkspaces}).`,
+    `memory-core: dreaming promotion complete (workspaces=${workspaceSummary}, candidates=${totalCandidates}, applied=${totalApplied}, failed=${failedWorkspaces}${deferredSummary}).`,
   );
 
   return { handled: true, reason: "memory-core: short-term dreaming processed" };
@@ -897,7 +1014,7 @@ export function registerShortTermPromotionDreaming(api: OpenClawPluginApi): void
       }
       return await runShortTermDreamingPromotionIfTriggered({
         cleanedBody: event.cleanedBody,
-        trigger: ctx.trigger,
+        trigger: isManagedHeartbeatTrigger ? "cron" : ctx.trigger,
         workspaceDir: ctx.workspaceDir,
         cfg: currentConfig,
         config,

--- a/extensions/memory-core/src/dreaming.ts
+++ b/extensions/memory-core/src/dreaming.ts
@@ -47,9 +47,13 @@ const HEARTBEAT_ISOLATED_SESSION_SUFFIX = ":heartbeat";
 const BYTES_PER_MIB = 1024 * 1024;
 const DREAMING_PRESSURE_RSS_WARNING_BYTES = 1536 * BYTES_PER_MIB;
 const DREAMING_PRESSURE_HEAP_WARNING_BYTES = 1024 * BYTES_PER_MIB;
-const MANAGED_DREAMING_WORKSPACE_BATCH_LIMIT = 2;
+const DREAMING_PRESSURE_BACKOFF_INITIAL_MS = 30_000;
+const DREAMING_PRESSURE_BACKOFF_MAX_MS = 5 * 60_000;
 
-let managedDreamingWorkspaceCursor = 0;
+let dreamingPressureBackoffSleep: (delayMs: number) => Promise<void> = (delayMs) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, delayMs);
+  });
 
 type Logger = Pick<OpenClawPluginApi["logger"], "info" | "warn" | "error">;
 
@@ -175,40 +179,40 @@ function formatDreamingResourcePressure(pressure: DreamingResourcePressure): str
   return `reason=${pressure.reason} rssBytes=${pressure.rssBytes} heapUsedBytes=${pressure.heapUsedBytes} thresholdBytes=${pressure.thresholdBytes}`;
 }
 
-function selectManagedDreamingWorkspaces(
-  workspaces: string[],
-  trigger: string | undefined,
-): {
-  selected: string[];
-  deferred: number;
-  start: number;
-} {
-  if (trigger !== "cron" || workspaces.length <= MANAGED_DREAMING_WORKSPACE_BATCH_LIMIT) {
-    return { selected: workspaces, deferred: 0, start: 0 };
+async function waitForDreamingPressureToEase(params: {
+  logger: Logger;
+  workspaceDir: string;
+}): Promise<void> {
+  let pressure = detectDreamingResourcePressure();
+  let delayMs = DREAMING_PRESSURE_BACKOFF_INITIAL_MS;
+  while (pressure) {
+    params.logger.warn(
+      `memory-core: dreaming promotion waiting ${delayMs}ms because gateway memory pressure is high (${formatDreamingResourcePressure(pressure)}) [workspace=${params.workspaceDir}].`,
+    );
+    await dreamingPressureBackoffSleep(delayMs);
+    pressure = detectDreamingResourcePressure();
+    delayMs = Math.min(delayMs * 2, DREAMING_PRESSURE_BACKOFF_MAX_MS);
   }
-
-  const start = managedDreamingWorkspaceCursor % workspaces.length;
-  const selected: string[] = [];
-  for (let index = 0; index < MANAGED_DREAMING_WORKSPACE_BATCH_LIMIT; index += 1) {
-    selected.push(workspaces[(start + index) % workspaces.length] as string);
-  }
-  return { selected, deferred: workspaces.length - selected.length, start };
 }
 
-function advanceManagedDreamingWorkspaceCursor(params: {
-  batch: ReturnType<typeof selectManagedDreamingWorkspaces>;
-  attemptedWorkspaces: number;
-  totalWorkspaces: number;
-}): void {
-  if (params.batch.deferred <= 0 || params.attemptedWorkspaces <= 0) {
+export function setDreamingPressureBackoffSleepForTest(
+  sleep?: (delayMs: number) => Promise<void>,
+): void {
+  if (sleep) {
+    let calls = 0;
+    dreamingPressureBackoffSleep = async (delayMs) => {
+      calls += 1;
+      if (calls > 100) {
+        throw new Error("dreaming pressure backoff test sleep exceeded 100 calls");
+      }
+      await sleep(delayMs);
+    };
     return;
   }
-  managedDreamingWorkspaceCursor =
-    (params.batch.start + params.attemptedWorkspaces) % params.totalWorkspaces;
-}
-
-export function resetManagedDreamingWorkspaceCursorForTest(): void {
-  managedDreamingWorkspaceCursor = 0;
+  dreamingPressureBackoffSleep = (delayMs) =>
+    new Promise((resolve) => {
+      setTimeout(resolve, delayMs);
+    });
 }
 
 function formatRepairSummary(repair: {
@@ -614,42 +618,24 @@ export async function runShortTermDreamingPromotionIfTriggered(params: {
     return { handled: true, reason: "memory-core: short-term dreaming disabled by limit" };
   }
 
-  const initialPressure = params.trigger === "cron" ? detectDreamingResourcePressure() : null;
-  if (initialPressure) {
-    params.logger.warn(
-      `memory-core: dreaming promotion deferred because gateway memory pressure is high (${formatDreamingResourcePressure(initialPressure)}).`,
-    );
-    return { handled: true, reason: "memory-core: short-term dreaming deferred by pressure" };
-  }
-
-  const workspaceBatch = selectManagedDreamingWorkspaces(workspaces, params.trigger);
-  if (workspaceBatch.deferred > 0) {
-    params.logger.info(
-      `memory-core: dreaming promotion limited to ${workspaceBatch.selected.length}/${workspaces.length} workspace(s); deferred ${workspaceBatch.deferred} workspace(s) to a later cron tick.`,
-    );
-  }
-
   if (params.config.verboseLogging) {
     params.logger.info(
-      `memory-core: dreaming verbose enabled (cron=${params.config.cron}, limit=${params.config.limit}, minScore=${params.config.minScore.toFixed(3)}, minRecallCount=${params.config.minRecallCount}, minUniqueQueries=${params.config.minUniqueQueries}, recencyHalfLifeDays=${recencyHalfLifeDays}, maxAgeDays=${params.config.maxAgeDays ?? "none"}, workspaces=${workspaceBatch.selected.length}/${workspaces.length}).`,
+      `memory-core: dreaming verbose enabled (cron=${params.config.cron}, limit=${params.config.limit}, minScore=${params.config.minScore.toFixed(3)}, minRecallCount=${params.config.minRecallCount}, minUniqueQueries=${params.config.minUniqueQueries}, recencyHalfLifeDays=${recencyHalfLifeDays}, maxAgeDays=${params.config.maxAgeDays ?? "none"}, workspaces=${workspaces.length}).`,
     );
   }
 
   let totalCandidates = 0;
   let totalApplied = 0;
   let failedWorkspaces = 0;
-  let attemptedWorkspaces = 0;
   const pluginConfig = params.cfg ? resolveMemoryCorePluginConfig(params.cfg) : undefined;
   const detachNarratives = params.trigger === "cron";
-  for (const workspaceDir of workspaceBatch.selected) {
-    const loopPressure = params.trigger === "cron" ? detectDreamingResourcePressure() : null;
-    if (loopPressure) {
-      params.logger.warn(
-        `memory-core: dreaming promotion stopped before workspace because gateway memory pressure is high (${formatDreamingResourcePressure(loopPressure)}).`,
-      );
-      break;
+  for (const workspaceDir of workspaces) {
+    if (params.trigger === "cron") {
+      await waitForDreamingPressureToEase({
+        logger: params.logger,
+        workspaceDir,
+      });
     }
-    attemptedWorkspaces += 1;
     try {
       const sweepNowMs = Date.now();
       await runDreamingSweepPhases({
@@ -774,19 +760,8 @@ export async function runShortTermDreamingPromotionIfTriggered(params: {
       );
     }
   }
-  advanceManagedDreamingWorkspaceCursor({
-    batch: workspaceBatch,
-    attemptedWorkspaces,
-    totalWorkspaces: workspaces.length,
-  });
-  const workspaceSummary =
-    workspaceBatch.deferred > 0
-      ? `${workspaceBatch.selected.length}/${workspaces.length}`
-      : workspaces.length;
-  const deferredSummary =
-    workspaceBatch.deferred > 0 ? `, deferred=${workspaceBatch.deferred}` : "";
   params.logger.info(
-    `memory-core: dreaming promotion complete (workspaces=${workspaceSummary}, candidates=${totalCandidates}, applied=${totalApplied}, failed=${failedWorkspaces}${deferredSummary}).`,
+    `memory-core: dreaming promotion complete (workspaces=${workspaces.length}, candidates=${totalCandidates}, applied=${totalApplied}, failed=${failedWorkspaces}).`,
   );
 
   return { handled: true, reason: "memory-core: short-term dreaming processed" };

--- a/src/agents/cli-runner.before-agent-reply-cron.test.ts
+++ b/src/agents/cli-runner.before-agent-reply-cron.test.ts
@@ -115,11 +115,13 @@ describe("runCliAgent cron before_agent_reply seam", () => {
       reply: { text: "dreaming claimed via cli runner" },
     });
     const onExecutionPhase = vi.fn();
+    const abortController = new AbortController();
 
     const result = await runCliAgent({
       ...baseRunParams,
       trigger: "cron",
       jobId: "cron-job-123",
+      abortSignal: abortController.signal,
       onExecutionPhase,
     });
 
@@ -138,6 +140,7 @@ describe("runCliAgent cron before_agent_reply seam", () => {
     expect(hookContext?.sessionKey).toBe(baseRunParams.sessionKey);
     expect(hookContext?.workspaceDir).toBe(baseRunParams.workspaceDir);
     expect(hookContext?.trigger).toBe("cron");
+    expect(hookContext?.abortSignal).toBe(abortController.signal);
     expect(executePreparedCliRunMock).not.toHaveBeenCalled();
     expect(result.payloads?.[0]?.text).toBe("dreaming claimed via cli runner");
   });

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -198,6 +198,7 @@ export async function runCliAgent(params: RunCliAgentParams): Promise<EmbeddedPi
         sessionId: params.sessionId,
         workspaceDir: params.workspaceDir,
         trigger: params.trigger,
+        abortSignal: params.abortSignal,
         ...buildAgentHookContextChannelFields(params),
       } as const;
       params.onExecutionPhase?.({

--- a/src/agents/pi-embedded-runner/run.before-agent-reply-cron.test.ts
+++ b/src/agents/pi-embedded-runner/run.before-agent-reply-cron.test.ts
@@ -47,12 +47,14 @@ describe("runEmbeddedPiAgent cron before_agent_reply seam", () => {
       reply: { text: "dreaming claimed" },
     });
     const onExecutionPhase = vi.fn();
+    const abortController = new AbortController();
 
     const result = await runEmbeddedPiAgent({
       ...overflowBaseRunParams,
       trigger: "cron",
       jobId: "cron-job-123",
       prompt: "__openclaw_memory_core_short_term_promotion_dream__",
+      abortSignal: abortController.signal,
       onExecutionPhase,
     });
 
@@ -70,6 +72,7 @@ describe("runEmbeddedPiAgent cron before_agent_reply seam", () => {
     expect(hookContext?.sessionKey).toBe("test-key");
     expect(hookContext?.workspaceDir).toBe("/tmp/workspace");
     expect(hookContext?.trigger).toBe("cron");
+    expect(hookContext?.abortSignal).toBe(abortController.signal);
     expect(mockedRunEmbeddedAttempt).not.toHaveBeenCalled();
     expect(result.payloads?.[0]?.text).toBe("dreaming claimed");
   });

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -570,6 +570,7 @@ export async function runEmbeddedPiAgent(
         modelProviderId: provider,
         modelId,
         trigger: params.trigger,
+        abortSignal: params.abortSignal,
         ...buildAgentHookContextChannelFields(params),
       };
       if (params.trigger === "cron" && hookRunner?.hasHooks("before_agent_reply")) {

--- a/src/auto-reply/reply/get-reply.before-agent-reply.test.ts
+++ b/src/auto-reply/reply/get-reply.before-agent-reply.test.ts
@@ -77,12 +77,15 @@ describe("getReplyFromConfig before_agent_reply wiring", () => {
   });
 
   it("returns a plugin reply and invokes the hook after inline actions", async () => {
+    const abortController = new AbortController();
     mocks.runBeforeAgentReply.mockResolvedValue({
       handled: true,
       reply: { text: "plugin reply" },
     });
 
-    const result = await getReplyFromConfig(buildGetReplyGroupCtx(), undefined, {});
+    const result = await getReplyFromConfig(buildGetReplyGroupCtx(), undefined, {
+      abortSignal: abortController.signal,
+    });
 
     expect(result).toEqual({ text: "plugin reply" });
     expect(mocks.runBeforeAgentReply).toHaveBeenCalledTimes(1);
@@ -97,6 +100,7 @@ describe("getReplyFromConfig before_agent_reply wiring", () => {
           messageProvider?: string;
           trigger?: string;
           channelId?: string;
+          abortSignal?: AbortSignal;
         },
       ]
     >;
@@ -108,6 +112,7 @@ describe("getReplyFromConfig before_agent_reply wiring", () => {
     expect(hookCtx.messageProvider).toBe("telegram");
     expect(hookCtx.trigger).toBe("user");
     expect(hookCtx.channelId).toBe("-100123");
+    expect(hookCtx.abortSignal).toBe(abortController.signal);
     expect(mocks.handleInlineActions.mock.invocationCallOrder[0]).toBeLessThan(
       mocks.runBeforeAgentReply.mock.invocationCallOrder[0] ?? 0,
     );

--- a/src/auto-reply/reply/get-reply.before-agent-reply.test.ts
+++ b/src/auto-reply/reply/get-reply.before-agent-reply.test.ts
@@ -83,9 +83,11 @@ describe("getReplyFromConfig before_agent_reply wiring", () => {
       reply: { text: "plugin reply" },
     });
 
-    const result = await getReplyFromConfig(buildGetReplyGroupCtx(), undefined, {
-      abortSignal: abortController.signal,
-    });
+    const result = await getReplyFromConfig(
+      buildGetReplyGroupCtx(),
+      { abortSignal: abortController.signal },
+      {},
+    );
 
     expect(result).toEqual({ text: "plugin reply" });
     expect(mocks.runBeforeAgentReply).toHaveBeenCalledTimes(1);

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -843,23 +843,22 @@ export async function getReplyFromConfig(
         originatingChannel: sessionCtx.OriginatingChannel,
         provider: sessionCtx.Provider,
       });
+      const beforeAgentReplyContext = {
+        agentId,
+        sessionKey: agentSessionKey,
+        sessionId,
+        workspaceDir,
+        trigger: opts?.isHeartbeat ? "heartbeat" : "user",
+        abortSignal: opts?.abortSignal,
+        ...buildAgentHookContextChannelFields({
+          sessionKey: agentSessionKey,
+          messageProvider: hookMessageProvider,
+          currentChannelId: sessionCtx.OriginatingTo ?? ctx.OriginatingTo ?? ctx.To,
+          messageTo: sessionCtx.OriginatingTo ?? ctx.OriginatingTo ?? ctx.To,
+        }),
+      };
       const hookResult = await traceGetReplyPhase("reply.before_agent_reply_hooks", () =>
-        hookRunner.runBeforeAgentReply(
-          { cleanedBody },
-          {
-            agentId,
-            sessionKey: agentSessionKey,
-            sessionId,
-            workspaceDir,
-            trigger: opts?.isHeartbeat ? "heartbeat" : "user",
-            ...buildAgentHookContextChannelFields({
-              sessionKey: agentSessionKey,
-              messageProvider: hookMessageProvider,
-              currentChannelId: sessionCtx.OriginatingTo ?? ctx.OriginatingTo ?? ctx.To,
-              messageTo: sessionCtx.OriginatingTo ?? ctx.OriginatingTo ?? ctx.To,
-            }),
-          },
-        ),
+        hookRunner.runBeforeAgentReply({ cleanedBody }, beforeAgentReplyContext),
       );
       if (hookResult?.handled) {
         return hookResult.reply ?? { text: SILENT_REPLY_TOKEN };

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -199,6 +199,8 @@ export type PluginHookAgentContext = {
   messageProvider?: string;
   trigger?: string;
   channelId?: string;
+  /** Abort signal for the current agent turn, when the caller can cancel it. */
+  abortSignal?: AbortSignal;
   /** Resolved effective context-token budget after model/config/agent caps. */
   contextTokenBudget?: number;
   /** Source that supplied the resolved context-token budget. */


### PR DESCRIPTION
## Summary

- Problem: managed memory dreaming cron could keep adding workspace and Dream Diary work while the gateway was already under RSS/heap pressure, and the pressure wait path did not observe the enclosing cron timeout/cancellation.
- Solution: preserve the existing full scheduled sweep, but add abort-aware bounded memory-pressure backoff before each cron workspace attempt and before detached Dream Diary scheduling.
- Exact behavior now: each cron-triggered managed dreaming run still iterates every configured workspace in the same cron invocation. Before starting each workspace, memory-core checks process RSS and heap usage. Before scheduling the detached deep Dream Diary narrative, it checks the same pressure again because promotion/report work may have raised memory usage. If RSS is at least 1536 MiB or heap used is at least 1024 MiB, it waits and retries with exponential backoff: 30s, 60s, 120s, 240s, then capped at 300s between retries. It keeps retrying at the capped delay until pressure clears or the enclosing cron run aborts/times out.
- Cron cancellation behavior now: the cron run abort signal is forwarded through before_agent_reply hook contexts for getReply, CLI cron, and embedded Pi cron paths. If that signal fires while memory-core is sleeping in pressure backoff, the sleep resolves immediately, the dreaming hook stops, and the timed-out cron run does not later resume memory mutations after pressure clears.
- Dream Diary behavior now: Dream Diary generation is not dropped just because pressure is high after promotion. Detached narrative scheduling waits with the same bounded backoff and proceeds after pressure clears; if the cron timeout/cancellation arrives first, the cron run stops cleanly.
- What did NOT change: direct non-cron dreaming requests are not delayed by this scheduler guard; the dreaming frequency/config switches are unchanged; memory storage formats are unchanged; cron still owns one scheduled managed dreaming job; memory-core does not intentionally defer remaining workspaces to a later cron tick.

## Motivation

- Observed gateway performance logs showed managed memory dreaming processing 10 workspaces in one background tick, taking 69621 ms, while nearby diagnostics reported high RSS and saturated event-loop/CPU conditions.
- The desired fix is to avoid adding more work while the process is under pressure, without dropping the existing full-sweep semantics for multi-workspace users or dropping Dream Diary output under pressure.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #84847
- Closes #84849
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior addressed: Managed memory-core dreaming cron keeps the existing all-workspace sweep, waits under gateway RSS/heap pressure before each workspace and before detached Dream Diary scheduling, and exits pressure backoff promptly when the enclosing cron abort signal fires.
- Real environment tested: Local OpenClaw worktree with focused static/type proof and autoreview; before evidence comes from redacted runtime diagnostics captured from the affected gateway.
- Exact steps or command run after this patch: `pnpm format:fix extensions/memory-core/src/dreaming.ts extensions/memory-core/src/dreaming.test.ts src/auto-reply/reply/get-reply.ts src/auto-reply/reply/get-reply.before-agent-reply.test.ts src/agents/cli-runner.ts src/agents/cli-runner.before-agent-reply-cron.test.ts src/agents/pi-embedded-runner/run.ts src/agents/pi-embedded-runner/run.before-agent-reply-cron.test.ts src/plugins/hook-types.ts`; `git diff --check`; `pnpm run lint:extensions:bundled`; `node scripts/run-oxlint.mjs src/plugins/hook-types.ts src/auto-reply/reply/get-reply.ts src/auto-reply/reply/get-reply.before-agent-reply.test.ts src/agents/cli-runner.ts src/agents/cli-runner.before-agent-reply-cron.test.ts src/agents/pi-embedded-runner/run.ts src/agents/pi-embedded-runner/run.before-agent-reply-cron.test.ts`; `pnpm tsgo:extensions`; `pnpm tsgo:core`; `AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --mode local`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```shell
$ git diff --check
# no output

$ pnpm run lint:extensions:bundled
# passed

$ node scripts/run-oxlint.mjs src/plugins/hook-types.ts src/auto-reply/reply/get-reply.ts src/auto-reply/reply/get-reply.before-agent-reply.test.ts src/agents/cli-runner.ts src/agents/cli-runner.before-agent-reply-cron.test.ts src/agents/pi-embedded-runner/run.ts src/agents/pi-embedded-runner/run.before-agent-reply-cron.test.ts
# passed

$ pnpm tsgo:extensions
# passed

$ pnpm tsgo:core
# passed

$ AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --mode local
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.81)
```

- Observed result after fix: The changed tests cover abort-aware pressure backoff, propagation of abort signals through before_agent_reply hook contexts, continued full-workspace cron iteration after pressure clears, capped pressure retry behavior, and Dream Diary scheduling after pressure clears instead of being dropped.
- What was not tested: Local Vitest execution is currently blocked in this worktree: `OPENCLAW_VITEST_MAX_WORKERS=1 timeout 180s node scripts/run-vitest.mjs ...` timed out after printing only the Vitest banner. Remote focused Vitest proof was also blocked here: Blacksmith Testbox is unavailable because the `blacksmith` CLI is not installed, and direct AWS Crabbox is unavailable because AWS credentials/IMDS are not present. A live multi-workspace gateway run with private agent/session data was not rerun.
- Before evidence (optional but encouraged):

```shell
memory-core: dreaming promotion complete (workspaces=10, candidates=10, applied=1, failed=0)
observed managed background task duration: 69621ms
memory pressure warning: rssBytes=1827979264 heapUsedBytes=684072312 thresholdBytes=1610612736
liveness warning: eventLoopUtilization=0.991 cpuCoreRatio=1.107 active=0 waiting=0 queued=0
```

## Root Cause (if applicable)

- Root cause: Managed cron dreaming collected every configured workspace and processed them in one cron delivery without pausing between workspaces when process memory was already above warning thresholds. The new pressure backoff initially had no cancellation/deadline awareness, so a timed-out cron run could keep sleeping and later mutate memory after pressure cleared.
- Missing detection / guardrail: Existing tests covered short-term dreaming promotion but did not exercise multi-workspace managed cron sweeps, pressure backoff cancellation, detached Dream Diary pressure handling, or hook-context abort propagation.
- Contributing context (if known): The managed cron system event can be claimed through before-agent-reply hooks in getReply, CLI cron, and embedded Pi cron paths, so all three hook contexts need the same abort signal.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/memory-core/src/dreaming.test.ts`, `src/auto-reply/reply/get-reply.before-agent-reply.test.ts`, `src/agents/cli-runner.before-agent-reply-cron.test.ts`, `src/agents/pi-embedded-runner/run.before-agent-reply-cron.test.ts`
- Scenario the test should lock in: managed cron dreaming keeps the full configured workspace sweep, waits under RSS/heap pressure before workspace and detached narrative work, doubles retry delay from 30 seconds to a 5 minute cap, continues in the same cron invocation after pressure clears, and stops without later memory mutation when the cron abort signal fires.
- Why this is the smallest reliable guardrail: The behavior is owned inside the memory-core dreaming cron seam and before-agent-reply hook contexts, so it can be exercised without private gateway sessions or provider credentials.
- Existing test that already covers this (if any): Existing dreaming tests covered promotion behavior but not the pressure, cancellation, and detached narrative cases.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Scheduled memory dreaming still uses `dreaming.frequency` as the cadence for a full configured-workspace sweep. When gateway RSS or heap usage is above the warning threshold before a workspace starts, or before the detached Dream Diary narrative is scheduled, scheduled dreaming waits before continuing. The wait starts at 30 seconds, doubles, and caps at 5 minutes between retries. No remaining workspaces are intentionally deferred to a later cron tick by memory-core; the run continues when pressure clears unless the enclosing cron run aborts/times out.

## Diagram (if applicable)

```text
Before:
cron tick -> workspace A -> workspace B -> workspace C -> detached diary work, without pressure-aware waits or abort-aware pressure sleep

After:
cron tick -> pressure check before workspace A -> workspace A -> pressure check before detached diary A -> pressure wait if needed -> diary A -> pressure check before workspace B -> ... full sweep continues until clear/completed or cron aborts
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux worktree
- Runtime/container: Node via repo wrappers for static/type checks
- Model/provider: N/A
- Integration/channel (if any): memory-core plugin cron seam and before-agent-reply hook contexts
- Relevant config (redacted): memory-core dreaming enabled with multiple agent workspaces

### Steps

1. Run the focused formatting, lint, and TS checks listed above.
2. Review the memory-core pressure tests and hook-context tests added for the cron abort path.
3. Confirm full-sweep semantics are preserved, pressure waits happen before workspace and Dream Diary scheduling, backoff caps at 5 minutes, and abort signals are available to memory-core from all cron before-agent-reply paths.

### Expected

- Cron-triggered managed dreaming preserves the full configured workspace sweep, waits under RSS/heap pressure before adding workspace or detached narrative work, and stops promptly when cron cancellation fires during pressure backoff.

### Actual

- After the patch, static/type proof and autoreview are clean. Focused Vitest could not be executed in this environment because the local Vitest runner hung before test execution and remote providers were unavailable.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [x] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: code-path review for memory-core pressure waits and before-agent-reply abort propagation, focused formatting/lint/type checks, and autoreview closeout.
- Edge cases checked: queued cron work receives abort signals through all relevant hook paths, pressure backoff exits on abort, detached Dream Diary scheduling waits under pressure rather than being dropped, and full-sweep behavior remains in the same cron invocation.
- What you did **not** verify: focused Vitest execution and private live multi-workspace gateway run, for the blockers listed in Real behavior proof.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: If memory pressure remains high for a long time, a scheduled dreaming cron run may take longer because it waits before starting the next workspace or detached Dream Diary work.
  - Mitigation: The backoff is capped at 5 minutes per retry, logs each wait with RSS/heap context, preserves the existing full-sweep behavior instead of skipping workspaces, preserves Dream Diary generation instead of dropping it, and now observes cron abort/cancellation.
