### PR TITLE
fix(models): report oauth markers as effective auth

### DIFF
--- a/src/commands/models/list.auth-overview.ts
+++ b/src/commands/models/list.auth-overview.ts
@@ -5,7 +5,7 @@ import { loadPersistedAuthProfileStore } from "../../agents/auth-profiles/persis
 import { listProfilesForProvider } from "../../agents/auth-profiles/profiles.js";
 import type { AuthProfileStore } from "../../agents/auth-profiles/types.js";
 import { resolveProfileUnusableUntilForDisplay } from "../../agents/auth-profiles/usage.js";
-import { isNonSecretApiKeyMarker } from "../../agents/model-auth-markers.js";
+import { isNonSecretApiKeyMarker, isOAuthApiKeyMarker } from "../../agents/model-auth-markers.js";
 import {
   getCustomProviderApiKey,
   resolveEnvApiKey,
@@ -174,7 +174,7 @@ export function resolveProviderAuthOverview(params: {
     if (usableCustomKey) {
       return { kind: "models.json", detail: formatMarkerOrSecret(usableCustomKey.apiKey) };
     }
-    if (customKey && isNonSecretApiKeyMarker(customKey, { includeEnvVarName: false })) {
+    if (customKey && isOAuthApiKeyMarker(customKey)) {
       return { kind: "models.json", detail: formatMarkerOrSecret(customKey) };
     }
     if (params.syntheticAuth) {

--- a/src/commands/models/list.auth-overview.ts
+++ b/src/commands/models/list.auth-overview.ts
@@ -174,6 +174,9 @@ export function resolveProviderAuthOverview(params: {
     if (usableCustomKey) {
       return { kind: "models.json", detail: formatMarkerOrSecret(usableCustomKey.apiKey) };
     }
+    if (customKey && isNonSecretApiKeyMarker(customKey, { includeEnvVarName: false })) {
+      return { kind: "models.json", detail: formatMarkerOrSecret(customKey) };
+    }
     if (params.syntheticAuth) {
       return { kind: "synthetic", detail: params.syntheticAuth.source };
     }

--- a/src/commands/models/list.status.test.ts
+++ b/src/commands/models/list.status.test.ts
@@ -1156,6 +1156,86 @@ describe("modelsStatusCommand auth overview", () => {
     }
   });
 
+  it("reports oauth delegation markers from models.json as effective auth", async () => {
+    const localRuntime = createRuntime();
+    const originalLoadConfig = mocks.loadConfig.getMockImplementation();
+    const originalProfiles = { ...mocks.store.profiles };
+    const originalEnvImpl = mocks.resolveEnvApiKey.getMockImplementation();
+    const originalCustomKeyImpl = mocks.getCustomProviderApiKey.getMockImplementation();
+    const originalUsableCustomKeyImpl = mocks.resolveUsableCustomProviderApiKey.getMockImplementation();
+
+    mocks.store.profiles = {
+      "openai-codex:default": originalProfiles["openai-codex:default"],
+    };
+    mocks.loadConfig.mockReturnValue({
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.5", fallbacks: [] },
+          models: { "openai/gpt-5.5": {} },
+        },
+      },
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://api.openai.com/v1",
+            apiKey: "oauth:openai-codex",
+            api: "openai-responses",
+            models: [{ id: "gpt-5.5", name: "GPT-5.5", api: "openai-responses" }],
+          },
+          "openai-codex": {
+            baseUrl: "https://chatgpt.com/backend-api",
+            api: "openai-codex-responses",
+          },
+        },
+      },
+      env: { shellEnv: { enabled: true } },
+    });
+    mocks.resolveEnvApiKey.mockImplementation(() => null);
+    mocks.getCustomProviderApiKey.mockImplementation((cfg: unknown, provider: string) => {
+      const providers = (cfg as { models?: { providers?: Record<string, { apiKey?: string }> } }).models
+        ?.providers;
+      return providers?.[provider]?.apiKey;
+    });
+    mocks.resolveUsableCustomProviderApiKey.mockImplementation(() => null);
+
+    try {
+      await modelsStatusCommand({ json: true, check: true }, localRuntime as never);
+      const payload = parseFirstJsonLog(localRuntime);
+      const openaiProvider = requireProvider(payload.auth.providers, "openai");
+      expect(payload.auth.missingProvidersInUse).toStrictEqual([]);
+      expect(requireRecord(openaiProvider.effective, "openai effective auth")).toEqual({
+        kind: "models.json",
+        detail: "marker(oauth:openai-codex)",
+      });
+      expect(requireRecord(openaiProvider.modelsJson, "openai models.json auth").value).toBe(
+        "marker(oauth:openai-codex)",
+      );
+      expect(localRuntime.exit).toHaveBeenCalledWith(0);
+    } finally {
+      mocks.store.profiles = originalProfiles;
+      if (originalLoadConfig) {
+        mocks.loadConfig.mockImplementation(originalLoadConfig);
+      }
+      if (originalEnvImpl) {
+        mocks.resolveEnvApiKey.mockImplementation(originalEnvImpl);
+      } else if (defaultResolveEnvApiKeyImpl) {
+        mocks.resolveEnvApiKey.mockImplementation(defaultResolveEnvApiKeyImpl);
+      } else {
+        mocks.resolveEnvApiKey.mockImplementation(() => null);
+      }
+      if (originalCustomKeyImpl) {
+        mocks.getCustomProviderApiKey.mockImplementation(originalCustomKeyImpl);
+      } else {
+        mocks.getCustomProviderApiKey.mockReturnValue(undefined);
+      }
+      if (originalUsableCustomKeyImpl) {
+        mocks.resolveUsableCustomProviderApiKey.mockImplementation(originalUsableCustomKeyImpl);
+      } else {
+        mocks.resolveUsableCustomProviderApiKey.mockReturnValue(null);
+      }
+    }
+  });
+
   it("does not double-prefix provider-qualified resolved default models", async () => {
     const localRuntime = createRuntime();
     const originalLoadConfig = mocks.loadConfig.getMockImplementation();


### PR DESCRIPTION
## Summary
- Treat explicit non-secret OAuth markers in `models.json` as effective provider auth in the `models status` auth overview.
- Preserve the existing masked `models.json=marker(...)` display while preventing healthy delegated OAuth setups from showing `effective=missing`.
- Add regression coverage for an `openai` provider configured with `apiKey: "oauth:openai-codex"` and a healthy `openai-codex` OAuth profile.

Fixes #83732

## Real behavior proof

Behavior addressed: `openclaw models status` reported the `openai` provider row as `effective=missing:missing` even when `models.json` intentionally configured the non-secret delegated OAuth marker `apiKey: "oauth:openai-codex"` and Codex OAuth auth was available.

Real environment tested: Local OpenClaw checkout on macOS, branch `fix/models-status-oauth-marker-effective-83732`, using the existing `models status` command Vitest suite.

Exact steps or command run after fix:

```console
$ node scripts/run-vitest.mjs src/commands/models/list.status.test.ts
$ node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/commands/models/list.auth-overview.ts src/commands/models/list.status.test.ts
$ git diff --check
```

Evidence after fix:

```console
✓  commands  ../../src/commands/models/list.status.test.ts (22 tests) 8049ms
Test Files  1 passed (1)
Tests  22 passed (22)

Found 0 warnings and 0 errors.
Finished in 2.1s on 2 files with 217 rules using 1 threads.
```

Observed result after fix: The regression test now exercises the reported config shape with `openai` using `oauth:openai-codex`, no direct OpenAI env key, and a valid `openai-codex` OAuth profile. The JSON auth overview reports `openai.effective` as `{ kind: "models.json", detail: "marker(oauth:openai-codex)" }`, keeps `missingProvidersInUse` empty, and `--check` exits 0.

What was not tested: I did not run against a live personal auth profile store or call the OpenAI/Codex network. This change is limited to the local `models status` auth overview classification and is covered by command-level tests.

## Test plan
- `node scripts/run-vitest.mjs src/commands/models/list.status.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/commands/models/list.auth-overview.ts src/commands/models/list.status.test.ts`
- `git diff --check`

## Duplicate check
- Checked open PRs for `83732`, `"oauth:openai-codex" "effective=missing"`, `"oauth delegation markers" "effective auth"`, `"marker(oauth:openai-codex)" "models status"`, and `"models.json" "marker(oauth:openai-codex)" "effective"` immediately before publishing.
