### PR TITLE
fix(agents): drop throttled exec update events

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -1103,6 +1103,62 @@ describe("handleToolExecutionEnd derived tool events", () => {
     resetAgentEventsForTest();
   });
 
+  it("does not emit generic exec update events while live output is throttled", async () => {
+    resetAgentEventsForTest();
+    const events: Array<{ stream?: string; data?: Record<string, unknown> }> = [];
+    registerAgentEventListener((evt) => {
+      events.push(evt as never);
+    });
+    const { ctx, onAgentEvent } = createTestContext();
+
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "exec",
+        toolCallId: "tool-exec-throttled-update",
+        args: { command: "yes" },
+      } as never,
+    );
+
+    handleToolExecutionUpdate(
+      ctx as never,
+      {
+        type: "tool_execution_update",
+        toolName: "exec",
+        toolCallId: "tool-exec-throttled-update",
+        partialResult: {
+          details: {
+            status: "running",
+            aggregated: "first chunk",
+          },
+        },
+      } as never,
+    );
+    const eventCountAfterFirstUpdate = events.length;
+    const onAgentEventCountAfterFirstUpdate = onAgentEvent.mock.calls.length;
+
+    handleToolExecutionUpdate(
+      ctx as never,
+      {
+        type: "tool_execution_update",
+        toolName: "exec",
+        toolCallId: "tool-exec-throttled-update",
+        partialResult: {
+          details: {
+            status: "running",
+            aggregated: "second chunk",
+          },
+        },
+      } as never,
+    );
+
+    expect(events).toHaveLength(eventCountAfterFirstUpdate);
+    expect(onAgentEvent).toHaveBeenCalledTimes(onAgentEventCountAfterFirstUpdate);
+
+    resetAgentEventsForTest();
+  });
+
   it("caps exec final output before result and command output events", async () => {
     resetAgentEventsForTest();
     const events: Array<{ stream?: string; data?: Record<string, unknown> }> = [];

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -944,6 +944,10 @@ export function handleToolExecutionUpdate(
   const isExecTool = isExecToolName(toolName);
   const liveResult = isExecTool ? capLiveExecResult(sanitized) : sanitized;
   const emitDetailedLiveUpdate = !isExecTool || shouldEmitLiveExecUpdate(ctx, toolCallId);
+  if (isExecTool && !emitDetailedLiveUpdate) {
+    // Throttled exec updates carry no new visible state; the final result closes the command item.
+    return;
+  }
   if (emitDetailedLiveUpdate) {
     emitAgentEvent({
       runId: ctx.params.runId,


### PR DESCRIPTION
## Summary

- Problem: exec live output throttling capped detailed payloads, but throttled `tool_execution_update` events still emitted generic tool/item updates with no new user-visible payload.
- Solution: make throttled exec updates a true no-op until the next allowed live update or final result.
- What changed: `handleToolExecutionUpdate` now returns before emitting generic exec update traffic when the live exec update throttle suppresses the detailed output, with regression coverage for global agent events and `onAgentEvent` emissions.
- What did NOT change (scope boundary): final exec result events, command completion items, non-exec tool updates, and the existing live exec output size cap are unchanged.

## Motivation

- #84850 captured a 60s gateway sample with average CPU at 83.66%, 42/60 samples at or above 100% CPU, and 0.00 kB/s average read I/O during an embedded exec tool run. Dropping redundant throttled update events reduces avoidable gateway projection/broadcast work in that hot path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #84850
- Related #78645
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Gateway CPU saturation from #84850 during embedded exec tool output. Throttled exec updates should not continue producing generic tool/item event traffic when they carry no new visible output.
- Real environment tested: Local Linux OpenClaw worktree on Node 24, using the repo Vitest wrapper plus the redacted pidstat/gateway log evidence from the affected run.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/pi-embedded-subscribe.handlers.tools.test.ts`, `git diff --check`, and `codex --dangerously-bypass-approvals-and-sandbox --sandbox danger-full-access review --uncommitted`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Copied terminal capture from the patched worktree:

```text
$ node scripts/run-vitest.mjs src/agents/pi-embedded-subscribe.handlers.tools.test.ts

Test Files  2 passed (2)
     Tests  76 passed (76)

$ git diff --check
(no output; exit 0)

$ codex --dangerously-bypass-approvals-and-sandbox --sandbox danger-full-access review --uncommitted
No discrete correctness issues were found in the current local changes.
```

- Observed result after fix: The regression test proves the first exec live update still emits visible output, while the next update inside the throttle window emits no additional global agent events and no additional `onAgentEvent` traffic. Final result handling remains covered by the existing exec result tests.
- What was not tested: I did not rerun the private 60s live CPU-saturation gateway session because the original setup/session details are local and redacted; the fix was verified at the exec tool update seam that emits the redundant events.
- Before evidence (optional but encouraged): Redacted source evidence from #84850:

```text
pidstat summary:
rows=60
avg_cpu=83.66
avg_usr=79.42
avg_sys=4.25
avg_rd=0.00
cpu_ge_100_count=42
max_cpu=190.0

redacted gateway correlation:
2026-05-21T05:07:47.187+00:00 agent/embedded embedded run tool start: runId=[redacted run id] tool=exec toolCallId=REDACTED
2026-05-21T05:08:04.330+00:00 agent/embedded embedded run tool end: runId=[redacted run id] tool=exec toolCallId=REDACTED
```

## Root Cause (if applicable)

- Root cause: the live exec throttle suppressed detailed output but still allowed generic exec update item/tool events to be emitted for every throttled update.
- Missing detection / guardrail: existing coverage checked output truncation/throttling but did not assert that suppressed updates stop all generic event emission.
- Contributing context (if known): #78645 bounded live exec output payloads, but redundant event emission could still keep gateway event projection hot during high-volume exec output.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/pi-embedded-subscribe.handlers.tools.test.ts`
- Scenario the test should lock in: a second exec update inside `LIVE_EXEC_UPDATE_MIN_INTERVAL_MS` emits no global agent events and no `onAgentEvent` traffic.
- Why this is the smallest reliable guardrail: the redundant CPU work starts at the embedded tool update handler before gateway websocket fanout sees the event.
- Existing test that already covers this (if any): existing exec output throttling tests cover payload capping but not generic event suppression.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Exec tool output updates inside the live update throttle window are dropped completely instead of sending generic no-payload progress events. Start, allowed live update, and final result events are preserved.

## Diagram (if applicable)

```text
Before:
[exec update inside throttle] -> [generic tool/item events] -> [gateway projection/broadcast work]

After:
[exec update inside throttle] -> [no emitted event] -> [next allowed update or final result closes state]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 24 local worktree
- Model/provider: NOT_ENOUGH_INFO for the original runtime sample; tests do not require provider credentials.
- Integration/channel (if any): Embedded exec tool event handling
- Relevant config (redacted): Original private session details were redacted.

### Steps

1. Run `node scripts/run-vitest.mjs src/agents/pi-embedded-subscribe.handlers.tools.test.ts`.
2. Run `git diff --check`.
3. Run `codex --dangerously-bypass-approvals-and-sandbox --sandbox danger-full-access review --uncommitted`.

### Expected

- First exec live update emits visible command output.
- A throttled follow-up exec update emits no generic event traffic.
- Final exec result behavior remains unchanged.

### Actual

- Targeted wrapper passed: 2 files, 76 tests.
- `git diff --check` passed with no output.
- Autoreview found no discrete correctness issues.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [x] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: allowed exec live update still emits output; throttled exec update emits no global or local agent event traffic; final exec output/result tests still pass.
- Edge cases checked: existing large-output truncation and final output redaction coverage still passes in the same target file.
- What you did **not** verify: private live CPU-saturation rerun from the original affected setup.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Suppressing throttled updates could hide command progress between allowed live updates.
  - Mitigation: the first allowed update and final command result remain emitted; only no-payload updates inside the existing throttle window are dropped.
