### PR TITLE
fix(ollama): preserve tool call ids [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 - fix(config): validate browser sandbox bind sources [AI]. (#84799) Thanks @pgondhi987.
 - doctor: constrain legacy plugin cleanup paths [AI]. (#84801) Thanks @pgondhi987.
 - Update/doctor: prune stale local bundled plugin install records that point at old compiled bundled output so current bundled plugin schemas win after upgrade. (#84863) Thanks @fuller-stack-dev.
+- Providers/Ollama: preserve native Ollama tool-call IDs across assistant replay so Gemini over Ollama Cloud can keep its hidden function-call thought-signature handle.
 - PDF tool: time out idle remote PDF body reads after 120 seconds so stalled remote documents return an error instead of wedging the session. Fixes #68649. (#84768) Thanks @luoyanglang.
 - Diagnostics/OpenTelemetry plugin: suppress handled OTLP exporter promise rejections so collector shutdowns no longer crash the Gateway. (#81085) Thanks @luoyanglang.
 - Media/audio: skip empty structured sherpa-onnx transcripts instead of treating the raw JSON payload as spoken text. (#84667) Thanks @TurboTheTurtle.

--- a/extensions/ollama/index.test.ts
+++ b/extensions/ollama/index.test.ts
@@ -783,8 +783,8 @@ describe("ollama plugin", () => {
       modelApi: "ollama",
       modelId: "qwen3.5:9b",
     } as never);
-    expect(nativePolicy?.sanitizeToolCallIds).toBe(true);
-    expect(nativePolicy?.toolCallIdMode).toBe("strict");
+    expect(nativePolicy?.sanitizeToolCallIds).toBe(false);
+    expect(nativePolicy?.toolCallIdMode).toBeUndefined();
     expect(nativePolicy?.applyAssistantFirstOrderingFix).toBe(true);
     expect(nativePolicy?.validateGeminiTurns).toBe(true);
     expect(nativePolicy?.validateAnthropicTurns).toBe(true);

--- a/extensions/ollama/index.ts
+++ b/extensions/ollama/index.ts
@@ -7,6 +7,7 @@ import {
   type ProviderAuthMethodNonInteractiveContext,
   type ProviderAuthResult,
   type ProviderCatalogContext,
+  type ProviderReplayPolicy,
   type ProviderRuntimeModel,
 } from "openclaw/plugin-sdk/plugin-entry";
 import { buildApiKeyCredential } from "openclaw/plugin-sdk/provider-auth";
@@ -64,6 +65,15 @@ function usesOllamaOpenAICompatTransport(model: {
       api: "openai-completions",
     })
   );
+}
+
+function buildNativeOllamaReplayPolicy(): ProviderReplayPolicy {
+  return {
+    ...buildOpenAICompatibleReplayPolicy("openai-completions", {
+      sanitizeToolCallIds: false,
+    }),
+    sanitizeToolCallIds: false,
+  };
 }
 
 const dynamicModelCache = new Map<string, ProviderRuntimeModel[]>();
@@ -245,7 +255,7 @@ export default definePluginEntry({
       ...OPENAI_COMPATIBLE_REPLAY_HOOKS,
       buildReplayPolicy: (ctx) =>
         ctx.modelApi === "ollama"
-          ? buildOpenAICompatibleReplayPolicy("openai-completions")
+          ? buildNativeOllamaReplayPolicy()
           : buildOpenAICompatibleReplayPolicy(ctx.modelApi),
       contributeResolvedModelCompat: ({ model }) =>
         usesOllamaOpenAICompatTransport(model) ? { supportsUsageInStreaming: true } : undefined,

--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -693,7 +693,27 @@ describe("convertToOllamaMessages", () => {
     expect(result[0].role).toBe("assistant");
     expect(result[0].content).toBe("Let me check.");
     expect(result[0].tool_calls).toEqual([
-      { function: { name: "bash", arguments: { command: "ls" } } },
+      { id: "call_1", function: { name: "bash", arguments: { command: "ls" } } },
+    ]);
+  });
+
+  it("preserves assistant tool-call ids before Ollama replay", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "fc_ollama_123",
+            name: "bash",
+            arguments: { command: "pwd" },
+          },
+        ],
+      },
+    ];
+    const result = convertToOllamaMessages(messages);
+    expect(result[0].tool_calls).toEqual([
+      { id: "fc_ollama_123", function: { name: "bash", arguments: { command: "pwd" } } },
     ]);
   });
 
@@ -709,8 +729,8 @@ describe("convertToOllamaMessages", () => {
     ];
     const result = convertToOllamaMessages(messages);
     expect(result[0].tool_calls).toEqual([
-      { function: { name: "exec", arguments: { command: "pwd" } } },
-      { function: { name: "read", arguments: { path: "README.md" } } },
+      { id: "call_1", function: { name: "exec", arguments: { command: "pwd" } } },
+      { id: "call_2", function: { name: "read", arguments: { path: "README.md" } } },
     ]);
   });
 
@@ -729,9 +749,9 @@ describe("convertToOllamaMessages", () => {
       availableToolNames: new Set(["tool_a", "tools_invoke_test", "function-run"]),
     });
     expect(result[0].tool_calls).toEqual([
-      { function: { name: "tool_a", arguments: { value: 1 } } },
-      { function: { name: "tools_invoke_test", arguments: { value: 2 } } },
-      { function: { name: "function-run", arguments: { value: 3 } } },
+      { id: "call_1", function: { name: "tool_a", arguments: { value: 1 } } },
+      { id: "call_2", function: { name: "tools_invoke_test", arguments: { value: 2 } } },
+      { id: "call_3", function: { name: "function-run", arguments: { value: 3 } } },
     ]);
   });
 
@@ -750,9 +770,9 @@ describe("convertToOllamaMessages", () => {
       availableToolNames: new Set(["exec", "read"]),
     });
     expect(result[0].tool_calls).toEqual([
-      { function: { name: "exec", arguments: { command: "pwd" } } },
-      { function: { name: "read", arguments: { path: "." } } },
-      { function: { name: "tool_missing", arguments: {} } },
+      { id: "call_1", function: { name: "exec", arguments: { command: "pwd" } } },
+      { id: "call_2", function: { name: "read", arguments: { path: "." } } },
+      { id: "call_3", function: { name: "tool_missing", arguments: {} } },
     ]);
   });
 
@@ -770,10 +790,10 @@ describe("convertToOllamaMessages", () => {
     ];
     const result = convertToOllamaMessages(messages);
     expect(result[0].tool_calls).toEqual([
-      { function: { name: "functionshell", arguments: {} } },
-      { function: { name: "tooling", arguments: {} } },
-      { function: { name: "tools", arguments: {} } },
-      { function: { name: "tool_a", arguments: {} } },
+      { id: "call_1", function: { name: "functionshell", arguments: {} } },
+      { id: "call_2", function: { name: "tooling", arguments: {} } },
+      { id: "call_3", function: { name: "tools", arguments: {} } },
+      { id: "call_4", function: { name: "tool_a", arguments: {} } },
     ]);
   });
 
@@ -795,7 +815,7 @@ describe("convertToOllamaMessages", () => {
     ];
     const result = convertToOllamaMessages(messages);
     expect(result[0].tool_calls).toEqual([
-      { function: { name: "Read", arguments: { file_path: "/tmp/test.txt" } } },
+      { id: "call_2", function: { name: "Read", arguments: { file_path: "/tmp/test.txt" } } },
     ]);
   });
 
@@ -810,7 +830,7 @@ describe("convertToOllamaMessages", () => {
     ];
     const result = convertToOllamaMessages(messages);
     expect(result[0].tool_calls).toEqual([
-      { function: { name: "exec", arguments: { command: "echo hello" } } },
+      { id: "toolu_1", function: { name: "exec", arguments: { command: "echo hello" } } },
     ]);
   });
 
@@ -831,6 +851,7 @@ describe("convertToOllamaMessages", () => {
     const result = convertToOllamaMessages(messages);
     expect(result[0].tool_calls).toEqual([
       {
+        id: "call_3",
         function: {
           name: "read",
           arguments: {
@@ -979,6 +1000,47 @@ describe("buildAssistantMessage", () => {
     expect(toolCall.name).toBe("bash");
     expect(toolCall.arguments).toEqual({ command: "ls -la" });
     expect(toolCall.id).toMatch(/^ollama_call_[0-9a-f-]{36}$/);
+  });
+
+  it("preserves Ollama response tool-call ids", () => {
+    const response = {
+      model: "gemini-3-flash-preview:cloud",
+      created_at: "2026-01-01T00:00:00Z",
+      message: {
+        role: "assistant" as const,
+        content: "",
+        tool_calls: [
+          { id: "fc_ollama_real_1", function: { name: "bash", arguments: { command: "pwd" } } },
+        ],
+      },
+      done: true,
+    };
+    const result = buildAssistantMessage(response, modelInfo);
+    expectToolCallContent(result.content[0], { name: "bash", arguments: { command: "pwd" } });
+    expect((result.content[0] as { id?: string }).id).toBe("fc_ollama_real_1");
+  });
+
+  it("preserves parallel Ollama response tool-call ids independently", () => {
+    const response = {
+      model: "gemini-3-flash-preview:cloud",
+      created_at: "2026-01-01T00:00:00Z",
+      message: {
+        role: "assistant" as const,
+        content: "",
+        tool_calls: [
+          { id: "fc_ollama_real_1", function: { name: "read", arguments: { path: "a.txt" } } },
+          { id: "fc_ollama_real_2", function: { name: "exec", arguments: { command: "date" } } },
+        ],
+      },
+      done: true,
+    };
+    const result = buildAssistantMessage(response, modelInfo);
+    expect(result.content.map((part) => (part as { id?: string }).id)).toEqual([
+      "fc_ollama_real_1",
+      "fc_ollama_real_2",
+    ]);
+    expectToolCallContent(result.content[0], { name: "read", arguments: { path: "a.txt" } });
+    expectToolCallContent(result.content[1], { name: "exec", arguments: { command: "date" } });
   });
 
   it("normalizes provider-prefixed tool-call names in Ollama responses", () => {

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -534,6 +534,7 @@ interface OllamaTool {
 }
 
 interface OllamaToolCall {
+  id?: string;
   function: {
     name: string;
     arguments: Record<string, unknown> | string;
@@ -789,6 +790,10 @@ type OllamaToolCallNameOptions = {
   availableToolNames?: ReadonlySet<string>;
 };
 
+function readOllamaToolCallId(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
 function extractToolCalls(
   content: unknown,
   options: OllamaToolCallNameOptions = {},
@@ -800,14 +805,18 @@ function extractToolCalls(
   const result: OllamaToolCall[] = [];
   for (const part of parts) {
     if (part.type === "toolCall") {
+      const id = readOllamaToolCallId(part.id);
       result.push({
+        ...(id ? { id } : {}),
         function: {
           name: normalizeOllamaToolCallName(part.name, options),
           arguments: ensureArgsObject(part.arguments),
         },
       });
     } else if (part.type === "tool_use") {
+      const id = readOllamaToolCallId(part.id);
       result.push({
+        ...(id ? { id } : {}),
         function: {
           name: normalizeOllamaToolCallName(part.name, options),
           arguments: ensureArgsObject(part.input),
@@ -952,7 +961,7 @@ export function buildAssistantMessage(
     for (const toolCall of toolCalls) {
       content.push({
         type: "toolCall",
-        id: `ollama_call_${randomUUID()}`,
+        id: readOllamaToolCallId(toolCall.id) ?? `ollama_call_${randomUUID()}`,
         name: normalizeOllamaToolCallName(toolCall.function.name, options),
         arguments: normalizeOllamaToolCallArguments(toolCall.function.arguments),
       });

--- a/src/agents/pi-embedded-runner/run/attempt.tool-call-normalization.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.tool-call-normalization.test.ts
@@ -1,6 +1,9 @@
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { describe, expect, it } from "vitest";
-import { sanitizeReplayToolCallIdsForStream } from "./attempt.tool-call-normalization.js";
+import {
+  sanitizeReplayToolCallIdsForStream,
+  shouldApplyReplayToolCallIdSanitizer,
+} from "./attempt.tool-call-normalization.js";
 
 type AssistantMessage = Extract<AgentMessage, { role: "assistant" }>;
 type ToolResultMessage = Extract<AgentMessage, { role: "toolResult" }>;
@@ -47,6 +50,29 @@ function toolResultSummary(message: AgentMessage | undefined) {
 }
 
 describe("sanitizeReplayToolCallIdsForStream", () => {
+  it("skips strict stream id sanitization when provider policy opts out", () => {
+    expect(
+      shouldApplyReplayToolCallIdSanitizer({
+        sanitizeToolCallIds: false,
+        isOpenAIResponsesApi: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldApplyReplayToolCallIdSanitizer({
+        sanitizeToolCallIds: true,
+        toolCallIdMode: "strict",
+        isOpenAIResponsesApi: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldApplyReplayToolCallIdSanitizer({
+        sanitizeToolCallIds: true,
+        toolCallIdMode: "strict",
+        isOpenAIResponsesApi: true,
+      }),
+    ).toBe(false);
+  });
+
   it("drops orphaned tool results after strict id sanitization", () => {
     const messages: AgentMessage[] = [
       {

--- a/src/agents/pi-embedded-runner/run/attempt.tool-call-normalization.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.tool-call-normalization.ts
@@ -879,6 +879,20 @@ export function wrapStreamFnTrimToolCallNames(
   };
 }
 
+type ReplayToolCallIdSanitizerDecision = {
+  sanitizeToolCallIds: boolean;
+  toolCallIdMode?: ToolCallIdMode;
+  isOpenAIResponsesApi: boolean;
+};
+
+export function shouldApplyReplayToolCallIdSanitizer(
+  params: ReplayToolCallIdSanitizerDecision,
+): params is ReplayToolCallIdSanitizerDecision & { toolCallIdMode: ToolCallIdMode } {
+  return (
+    params.sanitizeToolCallIds && Boolean(params.toolCallIdMode) && !params.isOpenAIResponsesApi
+  );
+}
+
 export function sanitizeReplayToolCallIdsForStream(params: {
   messages: AgentMessage[];
   mode: ToolCallIdMode;

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -355,6 +355,7 @@ import {
   wrapStreamFnRepairMalformedToolCallArguments,
 } from "./attempt.tool-call-argument-repair.js";
 import {
+  shouldApplyReplayToolCallIdSanitizer,
   sanitizeReplayToolCallIdsForStream,
   wrapStreamFnSanitizeMalformedToolCalls,
   wrapStreamFnTrimToolCallNames,
@@ -2779,13 +2780,14 @@ export async function runEmbeddedAttempt(
         params.model.api === "azure-openai-responses" ||
         params.model.api === "openai-codex-responses";
 
-      if (
-        transcriptPolicy.sanitizeToolCallIds &&
-        transcriptPolicy.toolCallIdMode &&
-        !isOpenAIResponsesApi
-      ) {
+      const replayToolCallIdSanitizerDecision = {
+        sanitizeToolCallIds: transcriptPolicy.sanitizeToolCallIds,
+        toolCallIdMode: transcriptPolicy.toolCallIdMode,
+        isOpenAIResponsesApi,
+      };
+      if (shouldApplyReplayToolCallIdSanitizer(replayToolCallIdSanitizerDecision)) {
         const inner = activeSession.agent.streamFn;
-        const mode = transcriptPolicy.toolCallIdMode;
+        const mode = replayToolCallIdSanitizerDecision.toolCallIdMode;
         activeSession.agent.streamFn = (model, context, options) => {
           const ctx = context as unknown as { messages?: unknown };
           const messages = ctx?.messages;


### PR DESCRIPTION
## Summary

- Problem: Gemini over native Ollama can return real tool call IDs while keeping the thought signature hidden; OpenClaw replaced those IDs with new `ollama_call_*` values, then the native Ollama replay path could also run through the OpenAI strict ID sanitizer before replay.
- Solution: Preserve non-empty native Ollama tool call IDs on ingest, replay stored IDs back as `tool_calls[].id`, and make the native Ollama replay policy opt out of strict tool-call ID sanitization so the provider-owned ID reaches Ollama unchanged.
- What changed: `extensions/ollama/src/stream.ts` carries `tool_calls[].id` through both directions; `extensions/ollama/index.ts` keeps native Ollama's replay ordering/turn validation rules but disables strict ID rewriting; focused regression coverage now covers inbound IDs, outbound replay IDs, native policy, and the agent-wrapper sanitizer gate.
- What did NOT change (scope boundary): No provider routing, config, auth, model selection, tool-name normalization, argument parsing, or network behavior changed.

## Motivation

- Gemini over Ollama Cloud can reject follow-up turns with `400 Function call is missing a thought_signature` when the prior assistant tool call is replayed without the original Ollama tool call ID. Preserving that exact ID keeps the provider's hidden thought-signature handle intact.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #34008
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: native Ollama assistant tool call IDs were not preserved through the full replay path, so a Gemini/Ollama Cloud follow-up turn could lose the hidden thought-signature handle and fail on replay.
- Real environment tested: isolated OpenClaw checkout on the OpenClaw PR test server, using the real native Ollama plugin replay policy, the agent-wrapper sanitizer decision, and the real `extensions/ollama/src/stream.ts` conversion path. No secrets or live Ollama credentials were used.
- Exact steps or command run after this patch:

```bash
OPENCLAW_PROOF_REPO="$PWD" node --import tsx ./ollama-tool-call-id-proof.mjs
node scripts/run-vitest.mjs extensions/ollama/src/stream-runtime.test.ts extensions/ollama/src/stream.test.ts
node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run/attempt.tool-call-normalization.test.ts extensions/ollama/index.test.ts
```

- Evidence after fix:

```text
OPENCLAW Ollama tool-call id wrapped replay proof
mode=after
nativePolicy.sanitizeToolCallIds=false
nativePolicy.toolCallIdMode=undefined
wrapperWouldSanitize=false
wrapperReplayIds=["fc_ollama_real_1","fc_ollama_real_2"]
storedIds=["fc_ollama_real_1","fc_ollama_real_2"]
replayIds=["fc_ollama_real_1","fc_ollama_real_2"]
preservedIncoming=true
preservedThroughWrapper=true
preservedReplay=true
fallbackGenerated=true
result=pass
```

- Observed result after fix: two real Ollama tool call IDs survive native policy selection, the agent replay wrapper, assistant message storage, and Ollama replay as `tool_calls[].id`; responses without an ID still receive an `ollama_call_*` fallback.
- What was not tested: no live Ollama Cloud secret or real Gemini account was used in this PR run.
- Before evidence:

```text
OPENCLAW Ollama tool-call id wrapped replay proof
mode=before
nativePolicy.sanitizeToolCallIds=true
nativePolicy.toolCallIdMode=strict
wrapperWouldSanitize=true
wrapperReplayIds=["fcollamareal1","fcollamareal2"]
storedIds=["ollama_call_db12f159-85b7-472e-a47c-14f86fd97060","ollama_call_06a25cc2-2c9f-40ec-8a85-c1caad54a3bb"]
replayIds=[null,null]
preservedIncoming=false
preservedThroughWrapper=false
preservedReplay=false
fallbackGenerated=true
result=fail
```

## Root Cause (if applicable)

- Root cause: the native Ollama adapter treated incoming tool call IDs as disposable and generated fresh local IDs, omitted IDs when converting stored assistant tool calls back into Ollama chat messages, and reused the OpenAI-compatible strict replay policy that rewrites `fc_ollama_real_1` into `fcollamareal1` before provider replay.
- Missing detection / guardrail: tests covered tool names and argument normalization but not native Ollama tool call ID roundtrip behavior or the native Ollama policy's interaction with the agent replay sanitizer.
- Contributing context (if known): Gemini/Ollama Cloud may use the returned tool call ID as an opaque handle for a hidden thought signature when the explicit signature is not surfaced.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/ollama/src/stream-runtime.test.ts`, `extensions/ollama/index.test.ts`, and `src/agents/pi-embedded-runner/run/attempt.tool-call-normalization.test.ts`.
- Scenario the test should lock in: inbound Ollama tool call IDs are preserved, parallel IDs remain distinct, stored assistant tool call IDs are replayed to Ollama, missing IDs still get the existing fallback, and native Ollama opts out of strict replay ID sanitization while OpenAI-compatible routes keep it.
- Why this is the smallest reliable guardrail: the bug crosses the native Ollama converter and provider-owned replay policy, so both sides now have focused coverage.
- Existing test that already covers this (if any): existing Ollama conversion tests covered tool calls but intentionally did not assert IDs before this PR.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Native Ollama Gemini tool-call conversations should continue across tool-result turns instead of failing because the original tool call ID was lost or rewritten. OpenAI-compatible Ollama routes still use strict replay ID sanitization.

## Diagram (if applicable)

```text
Before:
Ollama tool_call.id -> OpenClaw ollama_call_<uuid> -> strict replay sanitizer rewrites provider IDs -> replay without id -> Gemini/Ollama loses hidden signature handle

After:
Ollama tool_call.id -> OpenClaw stores same id -> native Ollama policy skips strict ID rewrite -> replay with same id -> provider can match the tool-result turn
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux test server
- Runtime/container: Node 22.22.2, isolated OpenClaw checkout
- Model/provider: native Ollama path, simulated Gemini/Ollama Cloud tool call IDs
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Resolve native Ollama's replay policy from the plugin.
2. Pass simulated Gemini/Ollama Cloud IDs through the same replay sanitizer gate used by the agent wrapper.
3. Convert an Ollama response containing two tool calls with IDs through `buildAssistantMessage`.
4. Replay the stored assistant content through `convertToOllamaMessages`.
5. Repeat without an incoming ID and confirm the existing `ollama_call_*` fallback remains.

### Expected

- Native Ollama does not run strict tool-call ID rewriting.
- Stored IDs, wrapper-visible IDs, and replay IDs equal the real Ollama IDs.
- Missing incoming IDs still generate `ollama_call_*`.

### Actual

- Before the patch, native Ollama used strict replay ID sanitization, stored IDs were random, and replay IDs were absent.
- After the patch, native Ollama keeps IDs exact through policy, wrapper, storage, and replay.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

```text
node scripts/run-vitest.mjs extensions/ollama/src/stream-runtime.test.ts extensions/ollama/src/stream.test.ts
2 files / 90 tests passed
```

```text
node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run/attempt.tool-call-normalization.test.ts extensions/ollama/index.test.ts
2 files / 37 tests passed
```

```text
git diff --check
node_modules/.bin/oxfmt --check --threads=1 extensions/ollama/index.ts extensions/ollama/index.test.ts extensions/ollama/src/stream.ts extensions/ollama/src/stream-runtime.test.ts src/agents/pi-embedded-runner/run/attempt.ts src/agents/pi-embedded-runner/run/attempt.tool-call-normalization.ts src/agents/pi-embedded-runner/run/attempt.tool-call-normalization.test.ts
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/ollama/index.ts extensions/ollama/index.test.ts extensions/ollama/src/stream.ts extensions/ollama/src/stream-runtime.test.ts
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/pi-embedded-runner/run/attempt.ts src/agents/pi-embedded-runner/run/attempt.tool-call-normalization.ts src/agents/pi-embedded-runner/run/attempt.tool-call-normalization.test.ts
node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo
node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo
```

All passed.

## Human Verification (required)

- Verified scenarios: inbound ID preservation, outbound ID replay, native Ollama policy skipping strict ID rewriting, agent-wrapper sanitizer gate, parallel tool call IDs, and fallback ID generation when Ollama does not send an ID.
- Edge cases checked: OpenAI-compatible Ollama policy still keeps strict ID sanitization; provider-prefixed tool names still normalize; stringified arguments still deserialize; unsafe integer parsing remains covered by existing tests updated for IDs.
- What you did **not** verify: live Ollama Cloud credentials or a real Gemini account.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Some native Ollama-compatible model might emit a blank or non-string ID.
  - Mitigation: only non-empty string IDs are preserved; existing `ollama_call_*` fallback remains for missing/invalid IDs.
- Risk: OpenAI-compatible Ollama routes still need strict replay ID compatibility.
  - Mitigation: the policy change is scoped to `modelApi === "ollama"`; OpenAI-compatible and Responses routes keep their existing strict policy.
