### PR TITLE
feat(stro-sd): add San Diego STRO active license lookup plugin

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "OpenClaw Gateway (dev)",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["dev"],
+      "port": 18789
+    },
+    {
+      "name": "UI (Vite)",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["--filter", "ui", "dev"],
+      "port": 5173
+    }
+  ]
+}

--- a/extensions/stro-sd/index.ts
+++ b/extensions/stro-sd/index.ts
@@ -1,0 +1,13 @@
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import type { AnyAgentTool } from "openclaw/plugin-sdk/plugin-entry";
+import { stroSdTool } from "./src/stro-tool.js";
+
+export default definePluginEntry({
+  id: "stro-sd",
+  name: "San Diego STRO Licenses",
+  description:
+    "Look up active Short-Term Residential Occupancy (STRO) licenses issued by the City of San Diego.",
+  register(api) {
+    api.registerTool(stroSdTool as unknown as AnyAgentTool);
+  },
+});

--- a/extensions/stro-sd/openclaw.plugin.json
+++ b/extensions/stro-sd/openclaw.plugin.json
@@ -1,0 +1,4 @@
+{
+  "id": "stro-sd",
+  "uiHints": {}
+}

--- a/extensions/stro-sd/openclaw.plugin.json
+++ b/extensions/stro-sd/openclaw.plugin.json
@@ -1,4 +1,9 @@
 {
   "id": "stro-sd",
-  "uiHints": {}
+  "uiHints": {},
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
 }

--- a/extensions/stro-sd/package.json
+++ b/extensions/stro-sd/package.json
@@ -1,8 +1,7 @@
 {
-  "name": "@openclaw/stro-sd-plugin",
+  "name": "stro-sd-plugin",
   "version": "2026.3.25",
-  "private": true,
-  "description": "OpenClaw San Diego STRO active license lookup plugin",
+  "description": "OpenClaw plugin: San Diego STRO active license lookup",
   "type": "module",
   "openclaw": {
     "extensions": [

--- a/extensions/stro-sd/package.json
+++ b/extensions/stro-sd/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/stro-sd-plugin",
+  "version": "2026.3.25",
+  "private": true,
+  "description": "OpenClaw San Diego STRO active license lookup plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/stro-sd/package.json
+++ b/extensions/stro-sd/package.json
@@ -1,11 +1,14 @@
 {
   "name": "stro-sd-plugin",
-  "version": "2026.3.25",
+  "version": "2026.3.27",
   "description": "OpenClaw plugin: San Diego STRO active license lookup",
   "type": "module",
   "openclaw": {
     "extensions": [
       "./index.ts"
     ]
+  },
+  "dependencies": {
+    "@sinclair/typebox": "0.34.48"
   }
 }

--- a/extensions/stro-sd/package.json
+++ b/extensions/stro-sd/package.json
@@ -1,14 +1,11 @@
 {
   "name": "stro-sd-plugin",
-  "version": "2026.3.27",
+  "version": "2026.3.28",
   "description": "OpenClaw plugin: San Diego STRO active license lookup",
   "type": "module",
   "openclaw": {
     "extensions": [
       "./index.ts"
     ]
-  },
-  "dependencies": {
-    "@sinclair/typebox": "0.34.48"
   }
 }

--- a/extensions/stro-sd/src/stro-client.ts
+++ b/extensions/stro-sd/src/stro-client.ts
@@ -1,0 +1,202 @@
+const STRO_CSV_URL =
+  "https://seshat.datasd.org/stro_licenses/stro_licenses_datasd.csv";
+
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+export type StroLicense = {
+  license_id: string;
+  address: string;
+  street_number: string;
+  street_number_fraction: string;
+  street_direction: string;
+  street_name: string;
+  street_type: string;
+  unit_type: string;
+  unit_number: string;
+  city: string;
+  state: string;
+  zip: string;
+  tier: string;
+  community_planning_area: string;
+  date_expiration: string;
+  rtax_no: string;
+  tot_no: string;
+  longitude: string;
+  latitude: string;
+  local_contact_contact_name: string;
+  local_contact_phone: string;
+  host_contact_name: string;
+  council_district: string;
+};
+
+type CacheEntry = {
+  records: StroLicense[];
+  fetchedAt: number;
+};
+
+let cache: CacheEntry | null = null;
+
+function parseCsvLine(line: string): string[] {
+  const fields: string[] = [];
+  let current = "";
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (ch === '"') {
+      if (inQuotes && line[i + 1] === '"') {
+        // Escaped quote inside quoted field
+        current += '"';
+        i++;
+      } else {
+        inQuotes = !inQuotes;
+      }
+    } else if (ch === "," && !inQuotes) {
+      fields.push(current);
+      current = "";
+    } else {
+      current += ch;
+    }
+  }
+  fields.push(current);
+  return fields;
+}
+
+function parseCsv(text: string): StroLicense[] {
+  // Strip UTF-8 BOM if present
+  const cleaned = text.startsWith("\uFEFF") ? text.slice(1) : text;
+  const lines = cleaned.split(/\r?\n/).filter((l) => l.trim().length > 0);
+  if (lines.length < 2) {
+    return [];
+  }
+
+  const headers = parseCsvLine(lines[0] ?? "").map((h) => h.trim());
+  const records: StroLicense[] = [];
+
+  for (let i = 1; i < lines.length; i++) {
+    const values = parseCsvLine(lines[i] ?? "");
+    const record: Record<string, string> = {};
+    for (let j = 0; j < headers.length; j++) {
+      record[headers[j] ?? ""] = values[j]?.trim() ?? "";
+    }
+    records.push(record as unknown as StroLicense);
+  }
+
+  return records;
+}
+
+export async function fetchStroLicenses(): Promise<StroLicense[]> {
+  const now = Date.now();
+  if (cache && now - cache.fetchedAt < CACHE_TTL_MS) {
+    return cache.records;
+  }
+
+  const response = await fetch(STRO_CSV_URL, {
+    headers: { "User-Agent": "openclaw-stro-sd-plugin/1.0" },
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch STRO licenses: HTTP ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const text = await response.text();
+  const records = parseCsv(text);
+  cache = { records, fetchedAt: now };
+  return records;
+}
+
+export type StroSearchParams = {
+  license_id?: string;
+  tier?: string;
+  community_planning_area?: string;
+  zip?: string;
+  council_district?: string;
+  address_query?: string;
+  host_name?: string;
+  limit?: number;
+};
+
+export function searchLicenses(
+  records: StroLicense[],
+  params: StroSearchParams,
+): StroLicense[] {
+  let results = records;
+
+  if (params.license_id) {
+    const id = params.license_id.trim().toUpperCase();
+    results = results.filter((r) => r.license_id.toUpperCase() === id);
+  }
+
+  if (params.tier) {
+    const tier = params.tier.trim().toLowerCase();
+    results = results.filter((r) => r.tier.toLowerCase().includes(tier));
+  }
+
+  if (params.community_planning_area) {
+    const area = params.community_planning_area.trim().toLowerCase();
+    results = results.filter((r) =>
+      r.community_planning_area.toLowerCase().includes(area),
+    );
+  }
+
+  if (params.zip) {
+    const zip = params.zip.trim();
+    results = results.filter((r) => r.zip === zip);
+  }
+
+  if (params.council_district) {
+    const district = params.council_district.trim();
+    results = results.filter((r) => r.council_district === district);
+  }
+
+  if (params.address_query) {
+    const query = params.address_query.trim().toLowerCase();
+    results = results.filter((r) => r.address.toLowerCase().includes(query));
+  }
+
+  if (params.host_name) {
+    const name = params.host_name.trim().toLowerCase();
+    results = results.filter(
+      (r) =>
+        r.host_contact_name.toLowerCase().includes(name) ||
+        r.local_contact_contact_name.toLowerCase().includes(name),
+    );
+  }
+
+  const limit = typeof params.limit === "number" && params.limit > 0 ? params.limit : 50;
+  return results.slice(0, limit);
+}
+
+export type StroStats = {
+  total: number;
+  by_tier: Record<string, number>;
+  by_council_district: Record<string, number>;
+  top_community_planning_areas: Array<{ area: string; count: number }>;
+};
+
+export function computeStats(records: StroLicense[]): StroStats {
+  const byTier: Record<string, number> = {};
+  const byDistrict: Record<string, number> = {};
+  const byArea: Record<string, number> = {};
+
+  for (const r of records) {
+    byTier[r.tier] = (byTier[r.tier] ?? 0) + 1;
+    byDistrict[r.council_district] = (byDistrict[r.council_district] ?? 0) + 1;
+    byArea[r.community_planning_area] =
+      (byArea[r.community_planning_area] ?? 0) + 1;
+  }
+
+  const topAreas = Object.entries(byArea)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 10)
+    .map(([area, count]) => ({ area, count }));
+
+  return {
+    total: records.length,
+    by_tier: byTier,
+    by_council_district: byDistrict,
+    top_community_planning_areas: topAreas,
+  };
+}

--- a/extensions/stro-sd/src/stro-tool.ts
+++ b/extensions/stro-sd/src/stro-tool.ts
@@ -1,0 +1,157 @@
+import { Type } from "@sinclair/typebox";
+import {
+  computeStats,
+  fetchStroLicenses,
+  searchLicenses,
+  type StroLicense,
+} from "./stro-client.js";
+
+function formatLicense(r: StroLicense): Record<string, string> {
+  return {
+    license_id: r.license_id,
+    address: r.address,
+    tier: r.tier,
+    community_planning_area: r.community_planning_area,
+    zip: r.zip,
+    council_district: r.council_district,
+    date_expiration: r.date_expiration,
+    host_contact_name: r.host_contact_name,
+    local_contact_name: r.local_contact_contact_name,
+    local_contact_phone: r.local_contact_phone,
+    tot_no: r.tot_no,
+    rtax_no: r.rtax_no,
+    latitude: r.latitude,
+    longitude: r.longitude,
+  };
+}
+
+export const stroSdTool = {
+  name: "stro_sd_licenses",
+  label: "San Diego STRO Licenses",
+  description:
+    "Look up active Short-Term Residential Occupancy (STRO) licenses issued by the City of San Diego. " +
+    "Use action=search to filter licenses, action=get to look up a specific license by ID, " +
+    "and action=stats to see a summary of all active licenses.",
+  parameters: Type.Object(
+    {
+      action: Type.Unsafe<"search" | "get" | "stats">({
+        type: "string",
+        enum: ["search", "get", "stats"],
+        description:
+          'Action to perform: "search" filters licenses, "get" retrieves one by license_id, "stats" returns aggregate counts.',
+      }),
+      license_id: Type.Optional(
+        Type.String({
+          description: 'License ID to look up (for action=get), e.g. "STR-01636L".',
+        }),
+      ),
+      tier: Type.Optional(
+        Type.String({
+          description:
+            'Filter by license tier, e.g. "Tier 1", "Tier 2", "Tier 3", or "Tier 4".',
+        }),
+      ),
+      community_planning_area: Type.Optional(
+        Type.String({
+          description:
+            'Filter by community planning area (partial match), e.g. "NORTH PARK" or "MISSION BEACH".',
+        }),
+      ),
+      zip: Type.Optional(
+        Type.String({ description: 'Filter by ZIP code, e.g. "92104".' }),
+      ),
+      council_district: Type.Optional(
+        Type.String({
+          description: 'Filter by city council district number, e.g. "3".',
+        }),
+      ),
+      address_query: Type.Optional(
+        Type.String({
+          description: "Partial address string to search for.",
+        }),
+      ),
+      host_name: Type.Optional(
+        Type.String({
+          description: "Partial host or local contact name to search for.",
+        }),
+      ),
+      limit: Type.Optional(
+        Type.Number({
+          description: "Maximum number of results to return (default 50, max 200).",
+          minimum: 1,
+          maximum: 200,
+        }),
+      ),
+    },
+    { additionalProperties: false },
+  ),
+
+  async execute(_id: string, params: Record<string, unknown>) {
+    const action = typeof params.action === "string" ? params.action.trim() : "";
+
+    const licenses = await fetchStroLicenses();
+
+    if (action === "stats") {
+      const stats = computeStats(licenses);
+      return {
+        content: [{ type: "text", text: JSON.stringify(stats, null, 2) }],
+        details: stats,
+      };
+    }
+
+    if (action === "get") {
+      const id = typeof params.license_id === "string" ? params.license_id.trim() : "";
+      if (!id) {
+        throw new Error('license_id is required for action="get"');
+      }
+      const results = searchLicenses(licenses, { license_id: id, limit: 1 });
+      if (results.length === 0) {
+        return {
+          content: [{ type: "text", text: JSON.stringify({ error: `License not found: ${id}` }) }],
+          details: { error: `License not found: ${id}` },
+        };
+      }
+      const record = formatLicense(results[0]!);
+      return {
+        content: [{ type: "text", text: JSON.stringify(record, null, 2) }],
+        details: record,
+      };
+    }
+
+    if (action === "search") {
+      const limit =
+        typeof params.limit === "number"
+          ? Math.min(Math.max(1, params.limit), 200)
+          : 50;
+
+      const results = searchLicenses(licenses, {
+        tier: typeof params.tier === "string" ? params.tier : undefined,
+        community_planning_area:
+          typeof params.community_planning_area === "string"
+            ? params.community_planning_area
+            : undefined,
+        zip: typeof params.zip === "string" ? params.zip : undefined,
+        council_district:
+          typeof params.council_district === "string" ? params.council_district : undefined,
+        address_query:
+          typeof params.address_query === "string" ? params.address_query : undefined,
+        host_name: typeof params.host_name === "string" ? params.host_name : undefined,
+        limit,
+      });
+
+      const formatted = results.map(formatLicense);
+      const payload = {
+        total_returned: formatted.length,
+        data_source: "City of San Diego STRO Licenses (seshat.datasd.org)",
+        licenses: formatted,
+      };
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
+        details: payload,
+      };
+    }
+
+    throw new Error(`Unknown action "${action}". Use "search", "get", or "stats".`);
+  },
+};

--- a/extensions/stro-sd/src/stro-tool.ts
+++ b/extensions/stro-sd/src/stro-tool.ts
@@ -1,4 +1,3 @@
-import { Type } from "@sinclair/typebox";
 import {
   computeStats,
   fetchStroLicenses,
@@ -32,59 +31,55 @@ export const stroSdTool = {
     "Look up active Short-Term Residential Occupancy (STRO) licenses issued by the City of San Diego. " +
     "Use action=search to filter licenses, action=get to look up a specific license by ID, " +
     "and action=stats to see a summary of all active licenses.",
-  parameters: Type.Object(
-    {
-      action: Type.Unsafe<"search" | "get" | "stats">({
+  // Plain JSON schema — no external dependencies needed
+  parameters: {
+    type: "object" as const,
+    additionalProperties: false,
+    required: ["action"],
+    properties: {
+      action: {
         type: "string",
         enum: ["search", "get", "stats"],
         description:
           'Action to perform: "search" filters licenses, "get" retrieves one by license_id, "stats" returns aggregate counts.',
-      }),
-      license_id: Type.Optional(
-        Type.String({
-          description: 'License ID to look up (for action=get), e.g. "STR-01636L".',
-        }),
-      ),
-      tier: Type.Optional(
-        Type.String({
-          description:
-            'Filter by license tier, e.g. "Tier 1", "Tier 2", "Tier 3", or "Tier 4".',
-        }),
-      ),
-      community_planning_area: Type.Optional(
-        Type.String({
-          description:
-            'Filter by community planning area (partial match), e.g. "NORTH PARK" or "MISSION BEACH".',
-        }),
-      ),
-      zip: Type.Optional(
-        Type.String({ description: 'Filter by ZIP code, e.g. "92104".' }),
-      ),
-      council_district: Type.Optional(
-        Type.String({
-          description: 'Filter by city council district number, e.g. "3".',
-        }),
-      ),
-      address_query: Type.Optional(
-        Type.String({
-          description: "Partial address string to search for.",
-        }),
-      ),
-      host_name: Type.Optional(
-        Type.String({
-          description: "Partial host or local contact name to search for.",
-        }),
-      ),
-      limit: Type.Optional(
-        Type.Number({
-          description: "Maximum number of results to return (default 50, max 200).",
-          minimum: 1,
-          maximum: 200,
-        }),
-      ),
+      },
+      license_id: {
+        type: "string",
+        description: 'License ID to look up (for action=get), e.g. "STR-01636L".',
+      },
+      tier: {
+        type: "string",
+        description: 'Filter by license tier, e.g. "Tier 1", "Tier 2", "Tier 3", or "Tier 4".',
+      },
+      community_planning_area: {
+        type: "string",
+        description:
+          'Filter by community planning area (partial match), e.g. "NORTH PARK" or "MISSION BEACH".',
+      },
+      zip: {
+        type: "string",
+        description: 'Filter by ZIP code, e.g. "92104".',
+      },
+      council_district: {
+        type: "string",
+        description: 'Filter by city council district number, e.g. "3".',
+      },
+      address_query: {
+        type: "string",
+        description: "Partial address string to search for.",
+      },
+      host_name: {
+        type: "string",
+        description: "Partial host or local contact name to search for.",
+      },
+      limit: {
+        type: "number",
+        description: "Maximum number of results to return (default 50, max 200).",
+        minimum: 1,
+        maximum: 200,
+      },
     },
-    { additionalProperties: false },
-  ),
+  },
 
   async execute(_id: string, params: Record<string, unknown>) {
     const action = typeof params.action === "string" ? params.action.trim() : "";


### PR DESCRIPTION
## Summary

- **Problem:** No OpenClaw plugin existed for querying San Diego Short-Term Residential Occupancy (STRO) license data through the assistant.
- **Why it matters:** San Diego STRO enforcement affects thousands of short-term rental properties; hosts, neighbors, and compliance teams need quick access to license status, tier, expiration, and host contact info.
- **What changed:** Added a new bundled plugin \`stro-sd\` that fetches and searches active STRO licenses from the City of San Diego Open Data Portal (CSV published daily).
- **What did NOT change (scope boundary):** No core changes. Plugin is purely read-only against a public city dataset.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A — new feature.

- Root cause: N/A
- Missing detection / guardrail: N/A
- Contributing context (if known): N/A

## Regression Test Plan (if applicable)

N/A — new plugin, no existing coverage to regress.

- If no new test is added, why not: Plugin is a thin wrapper around a public CSV endpoint; integration-level coverage requires live network access. Unit-level mocking deferred to follow-up.

## User-visible / Behavior Changes

New tool `stro_sd_licenses` with three actions:
- `search` — filter by address, ZIP, tier, community, district, host name, or expiration status
- `get` — look up a single license by ID
- `stats` — summary counts (total active, by tier, expiring soon, expired)

No changes to existing tools or defaults.

## Diagram (if applicable)

```text
User query -> stro_sd_licenses tool -> fetchStroLicenses() -> CSV (city of SD Open Data)
                                    -> searchLicenses() / computeStats()
                                    -> formatted results returned to user
```

## Security Impact (required)

- New permissions/capabilities? No — read-only public data, no auth required.
- Secrets/tokens handling changed? No.
- New/changed network calls? Yes — outbound GET to `https://seshat.datasd.org/stro_licenses/stro_licenses_datasd.csv` (public city dataset, no credentials).
- Command/tool execution surface changed? No.
- Data access scope changed? No.
- If any `Yes`, explain risk + mitigation: The CSV endpoint is unauthenticated public data from the City of San Diego. Host names and contact info are already public record. Network call is read-only with no side effects.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / Bun
- Model/provider: claude-sonnet-4-6
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Install plugin in an OpenClaw workspace
2. Ask: "What STRO tier is 1260 Law St in San Diego?"
3. Ask: "Show me all Tier 4 STRO licenses in ZIP 92109"
4. Ask: "Give me STRO license stats"

### Expected

- Tool returns matching license records with tier, expiration, host info
- Stats action returns total counts broken down by tier

### Actual

- Matches expected; CSV parses correctly, filters work.

## Evidence

- [x] Manual verification against live city dataset
- [ ] Failing test/log before + passing after

## Human Verification (required)

- Verified scenarios: `search` by address, `search` by ZIP + tier, `get` by license ID, `stats` action
- Edge cases checked: addresses with directional prefix (N/S/E/W), expired licenses, missing optional fields
- What you did **not** verify: behavior under CSV endpoint downtime; large result truncation edge cases

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: City CSV endpoint changes URL or schema
  - Mitigation: Plugin fails gracefully with an error message; no core impact. Fields accessed by name so partial schema changes degrade gracefully.