### PR TITLE
Fix Telegram isolated polling stall watchdog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 - Media/audio: skip empty structured sherpa-onnx transcripts instead of treating the raw JSON payload as spoken text. (#84667) Thanks @TurboTheTurtle.
 - Memory-core/dreaming: reuse stable narrative subagent session keys per workspace and phase while keeping per-run idempotency and bounded cleanup, so stale `dreaming-narrative-*` sessions do not accumulate. Fixes #68252, #69187, and #70402. (#70464) Thanks @chiyouYCH.
 - Trajectory/support: tolerate partial skill snapshot entries when building support metadata so rejected skill path scans no longer abort trajectory capture. (#71185) Thanks @lukeboyett.
+- Telegram: honor `channels.telegram.pollingStallThresholdMs` in the default isolated polling path, restarting silent workers instead of leaving inbound updates wedged. Fixes #83950. (#84861) Thanks @joshavant.
 - Agents/Pi: disable the embedded pi-coding-agent runtime auto-retry so OpenClaw's own retry and failover loop does not replay failed tool calls through a nested SDK retry. Fixes #73781. (#74434) Thanks @yelog.
 - CLI/perf: keep `setup --help`, `onboard --help`, and `configure --help` out of the full wizard runtime while preserving the existing help output. (#84488) Thanks @frankekn.
 - CLI/perf: keep `agents --help` out of agents action/runtime imports so help, completion, and command discovery paths avoid loading the full agents runtime. (#84483) Thanks @frankekn.

--- a/extensions/telegram/src/polling-liveness.ts
+++ b/extensions/telegram/src/polling-liveness.ts
@@ -12,6 +12,7 @@ type TelegramPollingStall = {
 
 export class TelegramPollingLivenessTracker {
   #lastGetUpdatesAt: number;
+  #lastGetUpdatesActivityAt: number;
   #lastGetUpdatesStartedAt: number | null = null;
   #lastGetUpdatesFinishedAt: number | null = null;
   #lastGetUpdatesDurationMs: number | null = null;
@@ -23,6 +24,7 @@ export class TelegramPollingLivenessTracker {
 
   constructor(private readonly options: TelegramPollingLivenessTrackerOptions = {}) {
     this.#lastGetUpdatesAt = this.#now();
+    this.#lastGetUpdatesActivityAt = this.#lastGetUpdatesAt;
   }
 
   get inFlightGetUpdates() {
@@ -31,6 +33,7 @@ export class TelegramPollingLivenessTracker {
 
   noteGetUpdatesStarted(payload: unknown, at = this.#now()) {
     this.#lastGetUpdatesAt = at;
+    this.#lastGetUpdatesActivityAt = at;
     this.#lastGetUpdatesStartedAt = at;
     this.#lastGetUpdatesOffset = resolveGetUpdatesOffset(payload);
     this.#inFlightGetUpdates += 1;
@@ -39,6 +42,7 @@ export class TelegramPollingLivenessTracker {
   }
 
   noteGetUpdatesSuccess(result: unknown, at = this.#now()) {
+    this.#lastGetUpdatesActivityAt = at;
     this.#lastGetUpdatesFinishedAt = at;
     this.#lastGetUpdatesDurationMs =
       this.#lastGetUpdatesStartedAt == null ? null : at - this.#lastGetUpdatesStartedAt;
@@ -46,7 +50,18 @@ export class TelegramPollingLivenessTracker {
     this.options.onPollSuccess?.(at);
   }
 
+  noteGetUpdatesSuccessCount(count: number, at = this.#now()) {
+    this.#lastGetUpdatesActivityAt = at;
+    this.#lastGetUpdatesFinishedAt = at;
+    this.#lastGetUpdatesDurationMs =
+      this.#lastGetUpdatesStartedAt == null ? null : at - this.#lastGetUpdatesStartedAt;
+    const normalizedCount = Number.isFinite(count) ? Math.max(0, Math.floor(count)) : 0;
+    this.#lastGetUpdatesOutcome = `ok:${normalizedCount}`;
+    this.options.onPollSuccess?.(at);
+  }
+
   noteGetUpdatesError(err: unknown, at = this.#now()) {
+    this.#lastGetUpdatesActivityAt = at;
     this.#lastGetUpdatesFinishedAt = at;
     this.#lastGetUpdatesDurationMs =
       this.#lastGetUpdatesStartedAt == null ? null : at - this.#lastGetUpdatesStartedAt;
@@ -58,11 +73,15 @@ export class TelegramPollingLivenessTracker {
     this.#inFlightGetUpdates = Math.max(0, this.#inFlightGetUpdates - 1);
   }
 
+  noteGetUpdatesActivity(at = this.#now()) {
+    this.#lastGetUpdatesActivityAt = at;
+  }
+
   detectStall(params: { thresholdMs: number; now?: number }): TelegramPollingStall | null {
     const now = params.now ?? this.#now();
     const activeElapsed =
       this.#inFlightGetUpdates > 0 && this.#lastGetUpdatesStartedAt != null
-        ? now - this.#lastGetUpdatesStartedAt
+        ? now - this.#lastGetUpdatesActivityAt
         : 0;
     const idleElapsed =
       this.#inFlightGetUpdates > 0

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import type { ChannelAccountSnapshot } from "openclaw/plugin-sdk/channel-contract";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { TelegramIngressWorkerMessage } from "./telegram-ingress-worker.js";
 
 const runMock = vi.hoisted(() => vi.fn());
 const createTelegramBotMock = vi.hoisted(() => vi.fn());
@@ -90,6 +91,7 @@ type WorkerPollErrorListener = (message: {
   message: string;
   finishedAt: number;
 }) => void;
+type WorkerMessageListener = (message: TelegramIngressWorkerMessage) => void;
 type AsyncVoidFn = () => Promise<void>;
 type MockCallSource = { mock: { calls: Array<Array<unknown>> } };
 
@@ -176,6 +178,7 @@ function installPollingStallWatchdogHarness(dateNowSequence: readonly number[] =
           break;
         }
         await Promise.resolve();
+        await new Promise<void>((resolve) => setImmediate(resolve));
       }
       expect(watchdog).toBeTypeOf("function");
       return watchdog;
@@ -774,6 +777,142 @@ describe("TelegramPollingSession", () => {
 
     abort.abort();
     await runPromise;
+  });
+
+  it("restarts isolated ingress when worker liveness stalls", async () => {
+    const abort = new AbortController();
+    const log = vi.fn();
+    const bot = {
+      api: {
+        deleteWebhook: vi.fn(async () => true),
+        config: { use: vi.fn() },
+      },
+      init: vi.fn(async () => undefined),
+      handleUpdate: vi.fn(async () => undefined),
+      stop: vi.fn(async () => undefined),
+    };
+    createTelegramBotMock.mockReturnValue(bot);
+
+    let firstWorkerDone: (() => void) | undefined;
+    const firstWorkerTask = new Promise<void>((resolve) => {
+      firstWorkerDone = resolve;
+    });
+    const firstWorkerStop = vi.fn(async () => {
+      firstWorkerDone?.();
+    });
+    let workerCycle = 0;
+    const createWorker = vi.fn(() => {
+      workerCycle += 1;
+      if (workerCycle === 1) {
+        return {
+          onMessage: vi.fn(() => () => undefined),
+          stop: firstWorkerStop,
+          task: vi.fn(async () => {
+            await firstWorkerTask;
+          }),
+        };
+      }
+      return {
+        onMessage: vi.fn(() => () => undefined),
+        stop: vi.fn(async () => undefined),
+        task: vi.fn(async () => {
+          abort.abort();
+        }),
+      };
+    });
+    const watchdogHarness = installPollingStallWatchdogHarness([0]);
+    const session = createPollingSession({
+      abortSignal: abort.signal,
+      log,
+      stallThresholdMs: 30_000,
+      isolatedIngress: {
+        enabled: true,
+        createWorker,
+        drainIntervalMs: 500,
+      },
+    });
+
+    try {
+      const runPromise = session.runUntilAbort();
+      const watchdog = await watchdogHarness.waitForWatchdog();
+      watchdogHarness.setNow(31_000);
+      watchdog?.();
+
+      await vi.waitFor(() => expect(firstWorkerStop).toHaveBeenCalledTimes(1));
+      await vi.waitFor(() => expect(createWorker).toHaveBeenCalledTimes(2));
+      await runPromise;
+
+      expectLogIncludes(log, "Polling stall detected");
+      expectLogIncludes(log, "isolated polling ingress finished reason=polling stall detected");
+    } finally {
+      watchdogHarness.restore();
+      abort.abort();
+    }
+  });
+
+  it("keeps isolated ingress alive when spooled messages show worker activity", async () => {
+    const abort = new AbortController();
+    const log = vi.fn();
+    const bot = {
+      api: {
+        deleteWebhook: vi.fn(async () => true),
+        config: { use: vi.fn() },
+      },
+      init: vi.fn(async () => undefined),
+      handleUpdate: vi.fn(async () => undefined),
+      stop: vi.fn(async () => undefined),
+    };
+    createTelegramBotMock.mockReturnValue(bot);
+
+    let onMessage: WorkerMessageListener | undefined;
+    let stopWorker: (() => void) | undefined;
+    const workerDone = new Promise<void>((resolve) => {
+      stopWorker = resolve;
+    });
+    const workerStop = vi.fn(async () => {
+      stopWorker?.();
+    });
+    const createWorker = vi.fn(() => ({
+      onMessage: vi.fn((handler: WorkerMessageListener) => {
+        onMessage = handler;
+        return () => undefined;
+      }),
+      stop: workerStop,
+      task: vi.fn(async () => {
+        await workerDone;
+      }),
+    }));
+    const watchdogHarness = installPollingStallWatchdogHarness([0]);
+    const session = createPollingSession({
+      abortSignal: abort.signal,
+      log,
+      stallThresholdMs: 30_000,
+      isolatedIngress: {
+        enabled: true,
+        createWorker,
+        drainIntervalMs: 500,
+      },
+    });
+
+    try {
+      const runPromise = session.runUntilAbort();
+      const watchdog = await watchdogHarness.waitForWatchdog();
+      onMessage?.({ type: "poll-start", offset: null, startedAt: 0 });
+      watchdogHarness.setNow(31_000);
+      onMessage?.({ type: "spooled", updateId: 42, queued: 1 });
+      watchdogHarness.setNow(45_000);
+      watchdog?.();
+
+      expect(workerStop).not.toHaveBeenCalled();
+      expectLogExcludes(log, "Polling stall detected");
+
+      abort.abort();
+      stopWorker?.();
+      await runPromise;
+    } finally {
+      watchdogHarness.restore();
+      abort.abort();
+    }
   });
 
   it("keeps failed lanes blocked for the rest of the drain pass", async () => {

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -685,6 +685,15 @@ export class TelegramPollingSession {
       network: ingress.network,
       proxy: ingress.proxy,
     });
+    let stopWorkerPromise: Promise<void> | undefined;
+    const stopWorker = () => {
+      stopWorkerPromise ??= Promise.resolve(worker.stop())
+        .then(() => undefined)
+        .catch(() => {
+          // Worker may already be stopped by restart/abort paths.
+        });
+      return stopWorkerPromise;
+    };
     this.opts.log(`[telegram][diag] isolated polling ingress started spool=${spoolDir}`);
     const pollState: {
       startedAt: number | null;
@@ -696,11 +705,19 @@ export class TelegramPollingSession {
       offset: null,
       outcome: "not-started",
     };
+    const liveness = new TelegramPollingLivenessTracker();
     let consecutiveDrainFailures = 0;
     let restartRequested = false;
+    let stalledRestart = false;
+    let forceCycleTimer: ReturnType<typeof setTimeout> | undefined;
+    let forceCycleResolve: (() => void) | undefined;
+    const forceCyclePromise = new Promise<void>((resolve) => {
+      forceCycleResolve = resolve;
+    });
     const stalledBacklogKeys = new Set<string>();
     const unsubscribe = worker.onMessage((message) => {
       if (message.type === "poll-start") {
+        liveness.noteGetUpdatesStarted({ offset: message.offset }, message.startedAt);
         pollState.startedAt = message.startedAt;
         pollState.offset = message.offset;
         pollState.outcome = "started";
@@ -708,6 +725,8 @@ export class TelegramPollingSession {
         return;
       }
       if (message.type === "poll-success") {
+        liveness.noteGetUpdatesSuccessCount(message.count, message.finishedAt);
+        liveness.noteGetUpdatesFinished();
         if (!restartRequested && stalledBacklogKeys.size === 0) {
           this.#status.notePollSuccess(message.finishedAt);
         }
@@ -716,12 +735,18 @@ export class TelegramPollingSession {
         return;
       }
       if (message.type === "poll-error") {
+        liveness.noteGetUpdatesError(new Error(message.message), message.finishedAt);
+        liveness.noteGetUpdatesFinished();
         pollState.outcome = "error";
         pollState.error = message.message;
+        return;
+      }
+      if (message.type === "spooled") {
+        liveness.noteGetUpdatesActivity();
       }
     });
     const stopOnAbort = () => {
-      void worker.stop();
+      void stopWorker();
     };
     this.opts.abortSignal?.addEventListener("abort", stopOnAbort, { once: true });
     const drainIntervalMs = Math.max(100, Math.floor(ingress.drainIntervalMs ?? 500));
@@ -762,7 +787,7 @@ export class TelegramPollingSession {
         const timedOutRecovery = await this.#recoverTimedOutSpooledHandler(drain.blockedByLane);
         if (timedOutRecovery?.restart) {
           restartRequested = true;
-          void worker.stop();
+          void stopWorker();
         } else if (timedOutRecovery) {
           stalledBacklogKeys.add(timedOutRecovery.handlerKey);
         }
@@ -780,9 +805,38 @@ export class TelegramPollingSession {
       void drainOnce();
     }, drainIntervalMs);
     drainTimer.unref?.();
+    const watchdog = setInterval(() => {
+      if (this.opts.abortSignal?.aborted || restartRequested) {
+        return;
+      }
+      const stall = liveness.detectStall({
+        thresholdMs: this.#stallThresholdMs,
+      });
+      if (!stall) {
+        return;
+      }
+      this.#transportState.markDirty();
+      stalledRestart = true;
+      restartRequested = true;
+      this.opts.log(`[telegram] ${stall.message}`);
+      this.#status.notePollingError(stall.message);
+      void stopWorker();
+      if (!forceCycleTimer) {
+        forceCycleTimer = setTimeout(() => {
+          if (this.opts.abortSignal?.aborted) {
+            return;
+          }
+          this.opts.log(
+            `[telegram] Isolated polling ingress stop timed out after ${formatDurationPrecise(POLL_STOP_GRACE_MS)}; forcing restart cycle.`,
+          );
+          forceCycleResolve?.();
+        }, POLL_STOP_GRACE_MS);
+      }
+    }, POLL_WATCHDOG_INTERVAL_MS);
+    watchdog.unref?.();
     try {
       try {
-        await worker.task();
+        await Promise.race([worker.task(), forceCyclePromise]);
       } catch (err) {
         if (this.opts.abortSignal?.aborted) {
           return "exit";
@@ -806,6 +860,11 @@ export class TelegramPollingSession {
         return "exit";
       }
       if (restartRequested) {
+        if (stalledRestart) {
+          this.opts.log(
+            `[telegram][diag] isolated polling ingress finished reason=polling stall detected ${liveness.formatDiagnosticFields("error")}`,
+          );
+        }
         return "continue";
       }
       const errorText = pollState.error ? ` error=${pollState.error}` : "";
@@ -817,10 +876,14 @@ export class TelegramPollingSession {
       );
       return shouldRestart ? "continue" : "exit";
     } finally {
+      clearInterval(watchdog);
       clearInterval(drainTimer);
+      if (forceCycleTimer) {
+        clearTimeout(forceCycleTimer);
+      }
       unsubscribe();
       this.opts.abortSignal?.removeEventListener("abort", stopOnAbort);
-      await worker.stop();
+      await stopWorker();
       if (!restartRequested) {
         await drainOnce();
         await waitForGracefulStop(() => this.#waitForSpooledUpdateHandlers());


### PR DESCRIPTION
## Summary
- Honor Telegram isolated polling `pollingStallThresholdMs` by wiring isolated worker activity into the liveness tracker and restarting silent workers.
- Add regression coverage for silent-worker restart and spooled-message activity.

Fixes #83950

## Verification
- `node scripts/run-vitest.mjs extensions/telegram/src/polling-session.test.ts -- --reporter=verbose`
- `node scripts/run-vitest.mjs extensions/telegram/src/polling-liveness.test.ts -- --reporter=verbose`
- `AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --mode local`
- AWS Crabbox fix proof: provider=aws, leaseId=cbx_a81230ba78bf, run=run_0d6294cf4a6e
- Credentialed AWS Crabbox Telegram proof: provider=aws, leaseId=cbx_d0af75929598, run=run_bc0c4ba2da67, Convex credential kind `telegram`

## Real behavior proof
Behavior addressed: Telegram isolated polling now honors `pollingStallThresholdMs` and restarts a silent isolated ingress worker instead of wedging indefinitely.

Real environment tested: Direct AWS Crabbox Linux. Runtime-level fix proof used provider=aws, leaseId=cbx_a81230ba78bf, run=run_0d6294cf4a6e. Credentialed Telegram proof used provider=aws, leaseId=cbx_d0af75929598, run=run_bc0c4ba2da67, with a Convex-leased `telegram` bot credential.

Exact steps or command run after this patch: First ran a no-credential `TelegramPollingSession` harness on AWS with isolated ingress enabled, `pollingStallThresholdMs=30000`, a fake Telegram API fetch, and a silent worker task, then observed for 65s before explicit abort. Then ran a credentialed AWS harness that leased `telegram` from Convex, validated the SUT bot token against the real Telegram Bot API with `getMe`, `deleteWebhook`, and `getUpdates`, forwarded one live `getUpdates` through a local API proxy, induced a silent hung `getUpdates`, and observed the isolated polling watchdog restart the ingress.

Evidence after fix: `OPENCLAW_ISSUE_83950_FIX_PROOF` beforeAbort showed `stopCount=1`, `workerFactoryCalls=2`, and stall log lines including `Polling stall detected...` plus the isolated ingress restart log. `OPENCLAW_ISSUE_83950_CREDENTIALED_LIVE_FIX_PROOF` showed `tokenValidated=true`, real API preflight methods `getMe`, `deleteWebhook`, and `getUpdates`, `forwardedGetUpdates=1`, `hungGetUpdates=2`, `workerFactoryCalls=2`, `stopCount=1` before abort, and stall/restart logs.

Observed result after fix: Silent worker was stopped and restarted before explicit abort in both proofs; the credentialed live proof exited 0 after the watchdog detected `active getUpdates stuck` and restarted isolated ingress.

What was not tested: A naturally occurring Telegram production outage was not waited on, and no `telegram-user` human/Desktop credential was used. The credentialed proof used the available Convex `telegram` bot credential and a controlled local proxy-induced `getUpdates` hang after validating the real bot token against Telegram.
