### PR TITLE
fix(doctor): preserve runtime pins during codex route repair [AI-assisted]

### DIFF
--- a/src/commands/doctor/shared/codex-route-warnings.test.ts
+++ b/src/commands/doctor/shared/codex-route-warnings.test.ts
@@ -2971,6 +2971,493 @@ describe("collectCodexRouteWarnings", () => {
     ).toBe("pi");
   });
 
+  it("preserves inherited default legacy runtime pins for listed-agent legacy refs", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "openai-codex/gpt-5.4": {
+              agentRuntime: { id: "pi" },
+            },
+          },
+        },
+        list: [
+          {
+            id: "worker",
+            model: "openai-codex/gpt-5.4",
+          },
+        ],
+      },
+    } as unknown as OpenClawConfig;
+
+    expect(
+      resolveAgentHarnessPolicy({
+        provider: "openai-codex",
+        modelId: "gpt-5.4",
+        agentId: "worker",
+        config: cfg,
+      }).runtime,
+    ).toBe("pi");
+
+    const result = maybeRepairCodexRoutes({
+      cfg,
+      shouldRepair: true,
+    });
+
+    expect(result.cfg.agents?.defaults?.models?.["openai/gpt-5.4"]?.agentRuntime).toEqual({
+      id: "pi",
+    });
+    expect(result.cfg.agents?.defaults?.models?.["openai-codex/gpt-5.4"]).toBeUndefined();
+    expect(result.cfg.agents?.list?.[0]?.model).toBe("openai/gpt-5.4");
+    expect(result.cfg.agents?.list?.[0]?.models?.["openai/gpt-5.4"]).toBeUndefined();
+    expect(result.changes.join("\n")).not.toContain(
+      'Set agents.list.worker.models.openai/gpt-5.4.agentRuntime.id to "codex"',
+    );
+    expect(
+      resolveAgentHarnessPolicy({
+        provider: "openai",
+        modelId: "gpt-5.4",
+        agentId: "worker",
+        config: result.cfg,
+      }).runtime,
+    ).toBe("pi");
+  });
+
+  it("preserves listed-agent legacy model-map runtime pins while repairing listed-agent refs", () => {
+    const cfg = {
+      agents: {
+        list: [
+          {
+            id: "worker",
+            model: "openai-codex/gpt-5.4",
+            models: {
+              "openai-codex/gpt-5.4": {
+                agentRuntime: { id: "pi" },
+              },
+            },
+          },
+        ],
+      },
+    } as unknown as OpenClawConfig;
+
+    expect(
+      resolveAgentHarnessPolicy({
+        provider: "openai-codex",
+        modelId: "gpt-5.4",
+        agentId: "worker",
+        config: cfg,
+      }).runtime,
+    ).toBe("pi");
+
+    const result = maybeRepairCodexRoutes({
+      cfg,
+      shouldRepair: true,
+    });
+
+    expect(result.cfg.agents?.list?.[0]?.model).toBe("openai/gpt-5.4");
+    expect(result.cfg.agents?.list?.[0]?.models?.["openai/gpt-5.4"]?.agentRuntime).toEqual({
+      id: "pi",
+    });
+    expect(result.cfg.agents?.list?.[0]?.models?.["openai-codex/gpt-5.4"]).toBeUndefined();
+    expect(result.changes.join("\n")).not.toContain(
+      'Set agents.list.worker.models.openai/gpt-5.4.agentRuntime.id to "codex"',
+    );
+    expect(
+      resolveAgentHarnessPolicy({
+        provider: "openai",
+        modelId: "gpt-5.4",
+        agentId: "worker",
+        config: result.cfg,
+      }).runtime,
+    ).toBe("pi");
+  });
+
+  it("preserves inherited default wildcard runtime pins for listed-agent legacy refs", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "openai-codex/*": {
+              agentRuntime: { id: "pi" },
+            },
+          },
+        },
+        list: [
+          {
+            id: "worker",
+            model: "openai-codex/gpt-5.4",
+          },
+        ],
+      },
+    } as unknown as OpenClawConfig;
+
+    expect(
+      resolveAgentHarnessPolicy({
+        provider: "openai-codex",
+        modelId: "gpt-5.4",
+        agentId: "worker",
+        config: cfg,
+      }).runtime,
+    ).toBe("pi");
+
+    const result = maybeRepairCodexRoutes({
+      cfg,
+      shouldRepair: true,
+    });
+
+    expect(result.cfg.agents?.defaults?.models?.["openai/*"]?.agentRuntime).toEqual({
+      id: "pi",
+    });
+    expect(result.cfg.agents?.defaults?.models?.["openai-codex/*"]).toBeUndefined();
+    expect(result.cfg.agents?.list?.[0]?.model).toBe("openai/gpt-5.4");
+    expect(result.cfg.agents?.list?.[0]?.models?.["openai/gpt-5.4"]).toBeUndefined();
+    expect(result.changes.join("\n")).not.toContain(
+      'Set agents.list.worker.models.openai/gpt-5.4.agentRuntime.id to "codex"',
+    );
+    expect(
+      resolveAgentHarnessPolicy({
+        provider: "openai",
+        modelId: "gpt-5.4",
+        agentId: "worker",
+        config: result.cfg,
+      }).runtime,
+    ).toBe("pi");
+  });
+
+  it("preserves provider-level legacy runtime pins while repairing default legacy refs", () => {
+    const cfg = {
+      models: {
+        providers: {
+          "openai-codex": {
+            agentRuntime: { id: "pi" },
+          },
+        },
+      },
+      agents: {
+        defaults: {
+          model: "openai-codex/gpt-5.4",
+        },
+      },
+      plugins: {
+        entries: { codex: { enabled: false } },
+      },
+    } as unknown as OpenClawConfig;
+
+    expect(
+      resolveAgentHarnessPolicy({
+        provider: "openai-codex",
+        modelId: "gpt-5.4",
+        config: cfg,
+      }).runtime,
+    ).toBe("pi");
+
+    const result = maybeRepairCodexRoutes({
+      cfg,
+      shouldRepair: true,
+    });
+
+    expect(result.cfg.agents?.defaults?.model).toBe("openai/gpt-5.4");
+    expect(result.cfg.agents?.defaults?.models?.["openai/gpt-5.4"]?.agentRuntime).toEqual({
+      id: "pi",
+    });
+    expect(result.changes.join("\n")).toContain(
+      'Set agents.defaults.models.openai/gpt-5.4.agentRuntime.id to "pi"',
+    );
+    expect(
+      resolveAgentHarnessPolicy({
+        provider: "openai",
+        modelId: "gpt-5.4",
+        config: result.cfg,
+      }).runtime,
+    ).toBe("pi");
+  });
+
+  it("preserves legacy provider catalog runtime pins while repairing default legacy refs", () => {
+    const cfg = {
+      models: {
+        providers: {
+          "openai-codex": {
+            models: [
+              {
+                id: "gpt-5.4",
+                agentRuntime: { id: "pi" },
+              },
+            ],
+          },
+        },
+      },
+      agents: {
+        defaults: {
+          model: "openai-codex/gpt-5.4",
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    expect(
+      resolveAgentHarnessPolicy({
+        provider: "openai-codex",
+        modelId: "gpt-5.4",
+        config: cfg,
+      }).runtime,
+    ).toBe("pi");
+
+    const result = maybeRepairCodexRoutes({
+      cfg,
+      shouldRepair: true,
+    });
+
+    expect(result.cfg.agents?.defaults?.model).toBe("openai/gpt-5.4");
+    expect(result.cfg.agents?.defaults?.models?.["openai/gpt-5.4"]?.agentRuntime).toEqual({
+      id: "pi",
+    });
+    expect(result.changes.join("\n")).toContain(
+      'Set agents.defaults.models.openai/gpt-5.4.agentRuntime.id to "pi"',
+    );
+    expect(
+      resolveAgentHarnessPolicy({
+        provider: "openai",
+        modelId: "gpt-5.4",
+        config: result.cfg,
+      }).runtime,
+    ).toBe("pi");
+  });
+
+  it("preserves legacy provider catalog runtime pins while repairing listed-agent legacy refs", () => {
+    const cfg = {
+      models: {
+        providers: {
+          "openai-codex": {
+            models: [
+              {
+                id: "gpt-5.4",
+                agentRuntime: { id: "pi" },
+              },
+            ],
+          },
+        },
+      },
+      agents: {
+        list: [
+          {
+            id: "worker",
+            model: "openai-codex/gpt-5.4",
+          },
+        ],
+      },
+    } as unknown as OpenClawConfig;
+
+    expect(
+      resolveAgentHarnessPolicy({
+        provider: "openai-codex",
+        modelId: "gpt-5.4",
+        agentId: "worker",
+        config: cfg,
+      }).runtime,
+    ).toBe("pi");
+
+    const result = maybeRepairCodexRoutes({
+      cfg,
+      shouldRepair: true,
+    });
+
+    expect(result.cfg.agents?.list?.[0]?.model).toBe("openai/gpt-5.4");
+    expect(result.cfg.agents?.list?.[0]?.models?.["openai/gpt-5.4"]?.agentRuntime).toEqual({
+      id: "pi",
+    });
+    expect(result.changes.join("\n")).toContain(
+      'Set agents.list.worker.models.openai/gpt-5.4.agentRuntime.id to "pi"',
+    );
+    expect(
+      resolveAgentHarnessPolicy({
+        provider: "openai",
+        modelId: "gpt-5.4",
+        agentId: "worker",
+        config: result.cfg,
+      }).runtime,
+    ).toBe("pi");
+  });
+
+  it("shields listed canonical refs when provider-level legacy default pins migrate", () => {
+    const cfg = {
+      models: {
+        providers: {
+          "openai-codex": {
+            agentRuntime: { id: "pi" },
+          },
+        },
+      },
+      agents: {
+        defaults: {
+          model: "openai-codex/gpt-5.4",
+        },
+        list: [
+          {
+            id: "main",
+            default: true,
+          },
+          {
+            id: "regular",
+            model: "openai/gpt-5.4",
+          },
+        ],
+      },
+    } as unknown as OpenClawConfig;
+
+    expect(
+      resolveAgentHarnessPolicy({
+        provider: "openai-codex",
+        modelId: "gpt-5.4",
+        agentId: "main",
+        config: cfg,
+      }).runtime,
+    ).toBe("pi");
+    expect(
+      resolveAgentHarnessPolicy({
+        provider: "openai",
+        modelId: "gpt-5.4",
+        agentId: "regular",
+        config: cfg,
+      }).runtime,
+    ).toBe("codex");
+
+    const result = maybeRepairCodexRoutes({
+      cfg,
+      shouldRepair: true,
+    });
+
+    expect(result.cfg.agents?.defaults?.model).toBe("openai/gpt-5.4");
+    expect(result.cfg.agents?.defaults?.models?.["openai/gpt-5.4"]?.agentRuntime).toEqual({
+      id: "pi",
+    });
+    expect(result.cfg.agents?.list?.[0]?.model).toBeUndefined();
+    expect(result.cfg.agents?.list?.[1]?.model).toBe("openai/gpt-5.4");
+    expect(result.cfg.agents?.list?.[1]?.models?.["openai/gpt-5.4"]?.agentRuntime).toEqual({
+      id: "codex",
+    });
+    expect(result.changes.join("\n")).toContain(
+      'Set agents.list.regular.models.openai/gpt-5.4.agentRuntime.id to "codex"',
+    );
+    expect(
+      resolveAgentHarnessPolicy({
+        provider: "openai",
+        modelId: "gpt-5.4",
+        agentId: "main",
+        config: result.cfg,
+      }).runtime,
+    ).toBe("pi");
+    expect(
+      resolveAgentHarnessPolicy({
+        provider: "openai",
+        modelId: "gpt-5.4",
+        agentId: "regular",
+        config: result.cfg,
+      }).runtime,
+    ).toBe("codex");
+  });
+
+  it("preserves provider-level legacy runtime pins while repairing listed-agent legacy refs", () => {
+    const cfg = {
+      models: {
+        providers: {
+          "openai-codex": {
+            agentRuntime: { id: "pi" },
+          },
+        },
+      },
+      agents: {
+        list: [
+          {
+            id: "worker",
+            model: "openai-codex/gpt-5.4",
+          },
+        ],
+      },
+    } as unknown as OpenClawConfig;
+
+    expect(
+      resolveAgentHarnessPolicy({
+        provider: "openai-codex",
+        modelId: "gpt-5.4",
+        agentId: "worker",
+        config: cfg,
+      }).runtime,
+    ).toBe("pi");
+
+    const result = maybeRepairCodexRoutes({
+      cfg,
+      shouldRepair: true,
+    });
+
+    expect(result.cfg.agents?.list?.[0]?.model).toBe("openai/gpt-5.4");
+    expect(result.cfg.agents?.list?.[0]?.models?.["openai/gpt-5.4"]?.agentRuntime).toEqual({
+      id: "pi",
+    });
+    expect(result.changes.join("\n")).toContain(
+      'Set agents.list.worker.models.openai/gpt-5.4.agentRuntime.id to "pi"',
+    );
+    expect(
+      resolveAgentHarnessPolicy({
+        provider: "openai",
+        modelId: "gpt-5.4",
+        agentId: "worker",
+        config: result.cfg,
+      }).runtime,
+    ).toBe("pi");
+  });
+
+  it("does not apply pre-existing canonical default runtime pins to listed-agent legacy refs", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "openai/*": {
+              agentRuntime: { id: "pi" },
+            },
+          },
+        },
+        list: [
+          {
+            id: "worker",
+            model: "openai-codex/gpt-5.4",
+          },
+        ],
+      },
+    } as unknown as OpenClawConfig;
+
+    expect(
+      resolveAgentHarnessPolicy({
+        provider: "openai-codex",
+        modelId: "gpt-5.4",
+        agentId: "worker",
+        config: cfg,
+      }).runtime,
+    ).toBe("codex");
+
+    const result = maybeRepairCodexRoutes({
+      cfg,
+      shouldRepair: true,
+    });
+
+    expect(result.cfg.agents?.defaults?.models?.["openai/*"]?.agentRuntime).toEqual({
+      id: "pi",
+    });
+    expect(result.cfg.agents?.list?.[0]?.model).toBe("openai/gpt-5.4");
+    expect(result.cfg.agents?.list?.[0]?.models?.["openai/gpt-5.4"]?.agentRuntime).toEqual({
+      id: "codex",
+    });
+    expect(result.changes.join("\n")).toContain(
+      'Set agents.list.worker.models.openai/gpt-5.4.agentRuntime.id to "codex"',
+    );
+    expect(
+      resolveAgentHarnessPolicy({
+        provider: "openai",
+        modelId: "gpt-5.4",
+        agentId: "worker",
+        config: result.cfg,
+      }).runtime,
+    ).toBe("codex");
+  });
+
   it("preserves explicit model-scoped runtime pins when repairing legacy model map keys", () => {
     const result = maybeRepairCodexRoutes({
       cfg: {
@@ -3368,4 +3855,79 @@ describe("collectCodexRouteWarnings", () => {
     expect(result.cfg.agents?.defaults?.model).toBe("openai/gpt-5.5");
     expect(result.cfg.agents?.defaults?.agentRuntime).toBeUndefined();
   });
+
+  it("preserves an explicit non-default agentRuntime pin on the legacy model entry during migration (#84038)", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        agents: {
+          defaults: {
+            model: { primary: "openai-codex/gpt-5.4" },
+            models: {
+              "openai-codex/gpt-5.4": {
+                agentRuntime: { id: "pi" },
+              },
+            },
+          },
+        },
+        auth: {
+          order: {
+            "openai-codex": ["openai-codex:user@example.com"],
+          },
+        },
+        plugins: {
+          entries: { codex: { enabled: false } },
+        },
+      } as unknown as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    const migrated = result.cfg.agents?.defaults?.models?.["openai/gpt-5.4"] as
+      | { agentRuntime?: { id?: string } }
+      | undefined;
+    expect(migrated).toBeDefined();
+    expect(migrated?.agentRuntime).toEqual({ id: "pi" });
+    expect(result.cfg.agents?.defaults?.models?.["openai-codex/gpt-5.4"]).toBeUndefined();
+  });
+
+  for (const canonicalRuntimeId of ["auto", "default"] as const) {
+    it(`preserves an explicit legacy runtime pin over canonical ${canonicalRuntimeId} during model-map migration`, () => {
+      const result = maybeRepairCodexRoutes({
+        cfg: {
+          agents: {
+            defaults: {
+              model: { primary: "openai-codex/gpt-5.4" },
+              models: {
+                "openai-codex/gpt-5.4": {
+                  agentRuntime: { id: "pi" },
+                },
+                "openai/gpt-5.4": {
+                  alias: "canonical-codex",
+                  agentRuntime: { id: canonicalRuntimeId },
+                },
+              },
+            },
+          },
+          plugins: {
+            entries: { codex: { enabled: false } },
+          },
+        } as unknown as OpenClawConfig,
+        shouldRepair: true,
+      });
+
+      expect(result.cfg.agents?.defaults?.model).toEqual({ primary: "openai/gpt-5.4" });
+      expect(result.cfg.agents?.defaults?.models?.["openai/gpt-5.4"]).toEqual({
+        alias: "canonical-codex",
+        agentRuntime: { id: "pi" },
+      });
+      expect(result.cfg.agents?.defaults?.models?.["openai-codex/gpt-5.4"]).toBeUndefined();
+      expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(false);
+      expect(
+        resolveAgentHarnessPolicy({
+          provider: "openai",
+          modelId: "gpt-5.4",
+          config: result.cfg,
+        }).runtime,
+      ).toBe("pi");
+    });
+  }
 });

--- a/src/commands/doctor/shared/codex-route-warnings.ts
+++ b/src/commands/doctor/shared/codex-route-warnings.ts
@@ -1313,10 +1313,36 @@ function rewriteModelsMap(params: {
     const canonicalRecord = asMutableRecord(canonicalEntry);
     params.models[canonicalModel] =
       legacyRecord && canonicalRecord
-        ? { ...legacyRecord, ...canonicalRecord }
+        ? mergeCanonicalModelMapRecord({ legacyRecord, canonicalRecord })
         : (canonicalEntry ?? legacyEntry);
     delete params.models[legacyRef];
   }
+}
+
+function runtimePolicyHasExplicitNonDefaultPin(value: unknown): boolean {
+  const id = normalizeString(asMutableRecord(value)?.id);
+  return Boolean(id && id !== "auto" && id !== "default");
+}
+
+function mergeCanonicalModelMapRecord(params: {
+  legacyRecord: MutableRecord;
+  canonicalRecord: MutableRecord;
+}): MutableRecord {
+  const merged = { ...params.legacyRecord, ...params.canonicalRecord };
+  const legacyRuntime = asMutableRecord(params.legacyRecord.agentRuntime);
+  const canonicalRuntime = asMutableRecord(params.canonicalRecord.agentRuntime);
+  if (
+    legacyRuntime &&
+    runtimePolicyHasExplicitNonDefaultPin(legacyRuntime) &&
+    !runtimePolicyHasExplicitNonDefaultPin(canonicalRuntime)
+  ) {
+    merged.agentRuntime = {
+      ...legacyRuntime,
+      ...canonicalRuntime,
+      id: legacyRuntime.id,
+    };
+  }
+  return merged;
 }
 
 function modelConfigContainsRef(value: unknown, modelRef: string): boolean {
@@ -1493,6 +1519,7 @@ function setModelRuntimePolicy(params: {
 function shieldExplicitListedAgentRefsFromDefaultPolicy(params: {
   cfg: OpenClawConfig;
   modelRef: string;
+  targetRuntimeId: string;
   changes: string[];
 }): void {
   for (const [index, agent] of (params.cfg.agents?.list ?? []).entries()) {
@@ -1505,7 +1532,7 @@ function shieldExplicitListedAgentRefsFromDefaultPolicy(params: {
       modelRef: params.modelRef,
       agentId: id,
     });
-    if (runtimeId === "codex") {
+    if (runtimeId === params.targetRuntimeId) {
       continue;
     }
     setModelRuntimePolicy({
@@ -1514,13 +1541,14 @@ function shieldExplicitListedAgentRefsFromDefaultPolicy(params: {
       modelRef: params.modelRef,
       runtimeId,
       changes: params.changes,
-      reason: "so default Codex route repair does not change explicit agent routing",
+      reason: "so default runtime repair does not change explicit agent routing",
     });
   }
 }
 
 function rewriteAgentModelRefs(params: {
   cfg: OpenClawConfig;
+  preRepairCfg: OpenClawConfig;
   hits: CodexRouteHit[];
   agent: MutableRecord | undefined;
   path: string;
@@ -1546,8 +1574,11 @@ function rewriteAgentModelRefs(params: {
         cfg: params.cfg,
         agent,
         agentPath: params.path,
+        agentId: params.agentId,
         modelRef: hit.canonicalModel,
+        legacyModelRef: hit.model,
         isDefaults: params.path === "agents.defaults",
+        preRepairCfg: params.preRepairCfg,
         changes: params.runtimePolicyChanges,
       });
     }
@@ -1641,8 +1672,10 @@ function rewriteAgentModelRefs(params: {
             cfg: params.cfg,
             agent,
             agentPath: params.path,
+            agentId: params.agentId,
             modelRef: inheritedCanonicalModel,
             isDefaults: params.path === "agents.defaults",
+            preRepairCfg: params.preRepairCfg,
             changes: params.runtimePolicyChanges,
           });
         }
@@ -1838,6 +1871,7 @@ function preserveMigratedLosslessCodexRuntimePolicy(params: {
       cfg: params.cfg,
       agent: owner,
       agentPath: ownerPath,
+      agentId: agentIdFromAgentPath(ownerPath),
       modelRef: params.summaryModel,
       isDefaults: ownerPath === "agents.defaults",
       changes: params.changes,
@@ -1997,32 +2031,235 @@ function maybeMigrateLegacyLosslessCompactionConfig(params: {
   return changes;
 }
 
+function legacyEntryExplicitNonDefaultRuntimeId(
+  models: MutableRecord,
+  canonicalModelRef: string,
+): string | undefined {
+  for (const ref of Object.keys(models)) {
+    if (ref === canonicalModelRef) {
+      continue;
+    }
+    if (toCanonicalOpenAIModelRef(ref) !== canonicalModelRef) {
+      continue;
+    }
+    const legacyEntry = asMutableRecord(models[ref]);
+    const legacyRuntime = asMutableRecord(legacyEntry?.agentRuntime);
+    const id = normalizeString(legacyRuntime?.id);
+    if (id && id !== "auto" && id !== "default") {
+      return id;
+    }
+  }
+  return undefined;
+}
+
+function agentIdFromAgentPath(agentPath: string): string | undefined {
+  const prefix = "agents.list.";
+  return agentPath.startsWith(prefix) ? agentPath.slice(prefix.length) : undefined;
+}
+
+type PreRepairRuntimePin = {
+  runtimeId: string;
+  // Doctor-local refinement: resolver source "model" can mean an agent model map
+  // or a provider catalog entry, but only the latter needs an eager policy write.
+  source: "model" | "provider" | "provider-model";
+};
+
+function modelIdMatchesProviderModelEntry(params: {
+  entryId: unknown;
+  provider: string;
+  modelId: string;
+}): boolean {
+  if (typeof params.entryId !== "string") {
+    return false;
+  }
+  const entryId = params.entryId.trim();
+  if (entryId === params.modelId) {
+    return true;
+  }
+  const slash = entryId.indexOf("/");
+  if (slash <= 0) {
+    return false;
+  }
+  return (
+    normalizeProviderId(entryId.slice(0, slash)) === normalizeProviderId(params.provider) &&
+    entryId.slice(slash + 1).trim() === params.modelId
+  );
+}
+
+function providerModelExplicitNonDefaultRuntimeId(params: {
+  cfg: OpenClawConfig;
+  provider: string;
+  modelId: string;
+}): string | undefined {
+  const providers = asMutableRecord(asMutableRecord(params.cfg.models)?.providers);
+  for (const [providerId, providerConfig] of Object.entries(providers ?? {})) {
+    if (normalizeProviderId(providerId) !== normalizeProviderId(params.provider)) {
+      continue;
+    }
+    const models = asMutableRecord(providerConfig)?.models;
+    if (!Array.isArray(models)) {
+      continue;
+    }
+    for (const model of models) {
+      const record = asMutableRecord(model);
+      if (
+        !modelIdMatchesProviderModelEntry({
+          entryId: record?.id,
+          provider: params.provider,
+          modelId: params.modelId,
+        })
+      ) {
+        continue;
+      }
+      const runtimeId = normalizeRuntimeString(asMutableRecord(record?.agentRuntime)?.id);
+      // Explicit Codex catalog pins already match the repaired OpenAI default.
+      if (runtimeId && runtimeId !== "auto" && runtimeId !== "default" && runtimeId !== "codex") {
+        return runtimeId;
+      }
+    }
+  }
+  return undefined;
+}
+
+function agentModelMapExactRuntimeIdForLegacyRef(params: {
+  cfg: OpenClawConfig;
+  legacyModelRef: string;
+  agentId?: string;
+}): string | undefined {
+  const parsed = parseModelRef(params.legacyModelRef);
+  if (!parsed) {
+    return undefined;
+  }
+  const agentId = normalizeAgentId(params.agentId);
+  const agent = agentId
+    ? (params.cfg.agents?.list ?? []).find((entry) => normalizeAgentId(entry.id) === agentId)
+    : undefined;
+  const modelMaps = [
+    asMutableRecord(agent?.models),
+    asMutableRecord(params.cfg.agents?.defaults?.models),
+  ];
+  for (const models of modelMaps) {
+    for (const [key, entry] of Object.entries(models ?? {})) {
+      if (
+        !modelIdMatchesProviderModelEntry({
+          entryId: key,
+          provider: parsed.provider,
+          modelId: parsed.modelId,
+        })
+      ) {
+        continue;
+      }
+      const runtimeId = normalizeRuntimeString(
+        asMutableRecord(asMutableRecord(entry)?.agentRuntime)?.id,
+      );
+      if (runtimeId && runtimeId !== "auto" && runtimeId !== "default") {
+        return runtimeId;
+      }
+    }
+  }
+  return undefined;
+}
+
+function preRepairLegacyModelPolicyExplicitNonDefaultRuntimePin(params: {
+  cfg: OpenClawConfig;
+  legacyModelRef?: string;
+  agentId?: string;
+}): PreRepairRuntimePin | undefined {
+  if (!params.legacyModelRef || !isOpenAICodexModelRef(params.legacyModelRef)) {
+    return undefined;
+  }
+  const parsed = parseModelRef(params.legacyModelRef);
+  if (!parsed) {
+    return undefined;
+  }
+  const resolved = resolveModelRuntimePolicy({
+    config: params.cfg,
+    provider: parsed.provider,
+    modelId: parsed.modelId,
+    agentId: params.agentId,
+  });
+  const runtimeId = normalizeRuntimeString(resolved.policy?.id);
+  if (!runtimeId || runtimeId === "auto" || runtimeId === "default" || runtimeId === "codex") {
+    return undefined;
+  }
+  if (resolved.source === "model") {
+    const providerModelRuntimeId = providerModelExplicitNonDefaultRuntimeId({
+      cfg: params.cfg,
+      provider: parsed.provider,
+      modelId: parsed.modelId,
+    });
+    const agentModelRuntimeId = agentModelMapExactRuntimeIdForLegacyRef({
+      cfg: params.cfg,
+      legacyModelRef: params.legacyModelRef,
+      agentId: params.agentId,
+    });
+    if (providerModelRuntimeId === runtimeId && !agentModelRuntimeId) {
+      return { runtimeId, source: "provider-model" };
+    }
+  }
+  return { runtimeId, source: resolved.source ?? "model" };
+}
+
 function ensureCodexRuntimePolicy(params: {
   cfg: OpenClawConfig;
   agent: MutableRecord;
   agentPath: string;
+  agentId?: string;
   modelRef: string;
+  legacyModelRef?: string;
   isDefaults?: boolean;
+  preRepairCfg?: OpenClawConfig;
   changes: string[];
 }): void {
+  const models = asMutableRecord(params.agent.models);
+  const entry = asMutableRecord(models?.[params.modelRef]);
+  const priorRuntime = asMutableRecord(entry?.agentRuntime);
+  const runtimeId = normalizeString(priorRuntime?.id);
+  const pinnedRuntimeId =
+    runtimeId && runtimeId !== "auto" && runtimeId !== "default" ? runtimeId : undefined;
+  const legacyModelRuntimeId = models
+    ? legacyEntryExplicitNonDefaultRuntimeId(models, params.modelRef)
+    : undefined;
+  const preRepairRuntimePin = preRepairLegacyModelPolicyExplicitNonDefaultRuntimePin({
+    cfg: params.preRepairCfg ?? params.cfg,
+    legacyModelRef: params.legacyModelRef,
+    agentId: params.agentId,
+  });
+  const targetRuntimeId =
+    pinnedRuntimeId ??
+    legacyModelRuntimeId ??
+    (preRepairRuntimePin?.source === "provider" || preRepairRuntimePin?.source === "provider-model"
+      ? preRepairRuntimePin.runtimeId
+      : undefined) ??
+    "codex";
   if (params.isDefaults) {
     shieldExplicitListedAgentRefsFromDefaultPolicy({
       cfg: params.cfg,
       modelRef: params.modelRef,
+      targetRuntimeId,
       changes: params.changes,
     });
   }
-  const models = asMutableRecord(params.agent.models) ?? {};
-  if (params.agent.models !== models) {
-    params.agent.models = models;
+  if (pinnedRuntimeId) {
+    return;
   }
-  const entry = asMutableRecord(models[params.modelRef]) ?? {};
-  if (models[params.modelRef] !== entry) {
-    models[params.modelRef] = entry;
+  if (legacyModelRuntimeId) {
+    return;
   }
-  const priorRuntime = asMutableRecord(entry.agentRuntime);
-  const runtimeId = normalizeString(priorRuntime?.id);
-  if (runtimeId && runtimeId !== "auto" && runtimeId !== "default") {
+  if (preRepairRuntimePin) {
+    if (
+      preRepairRuntimePin.source === "provider" ||
+      preRepairRuntimePin.source === "provider-model"
+    ) {
+      setModelRuntimePolicy({
+        agent: params.agent,
+        agentPath: params.agentPath,
+        modelRef: params.modelRef,
+        runtimeId: preRepairRuntimePin.runtimeId,
+        changes: params.changes,
+        reason: "so legacy provider runtime pins survive Codex route repair",
+      });
+    }
     return;
   }
   setModelRuntimePolicy({
@@ -2196,6 +2433,7 @@ function rewriteConfigModelRefsWithCompactionPolicy(params: {
   ignoreLegacyAgentRuntimePins?: boolean;
 }): ConfigRouteRepairResult {
   const nextConfig = structuredClone(params.cfg);
+  const preRepairCfg = params.cfg;
   const hits: CodexRouteHit[] = [];
   const runtimePolicyChanges: string[] = [];
   const unsupportedCompactionChanges: string[] = [];
@@ -2225,6 +2463,7 @@ function rewriteConfigModelRefsWithCompactionPolicy(params: {
   const rewrittenInheritedCompactionModels = new Map<string, string>();
   rewriteAgentModelRefs({
     cfg: nextConfig,
+    preRepairCfg,
     hits,
     agent: asMutableRecord(nextConfig.agents?.defaults),
     path: "agents.defaults",
@@ -2249,6 +2488,7 @@ function rewriteConfigModelRefsWithCompactionPolicy(params: {
         : String(index);
     rewriteAgentModelRefs({
       cfg: nextConfig,
+      preRepairCfg,
       hits,
       agent: agentRecord,
       path: `agents.list.${id}`,
@@ -2263,6 +2503,7 @@ function rewriteConfigModelRefsWithCompactionPolicy(params: {
       inheritedModelRef,
       inheritedCompaction: nextConfig.agents?.defaults?.compaction,
       inheritedCompactionPath: "agents.defaults.compaction",
+      rewriteModelsMap: true,
       preserveUnsupportedCompactionPaths: preservedLegacyLosslessCompactionPaths,
       rewrittenInheritedCompactionModels,
       runtimePolicyChanges,


### PR DESCRIPTION
## Summary

- Problem: `openclaw doctor --fix` can rewrite `openai-codex/*` routes to canonical `openai/*` while replacing an explicit non-default `agentRuntime` pin, such as `pi`, with `codex`.
- Solution: carry the pre-repair runtime pin through the route migration and write a narrow canonical model-scoped runtime policy when needed.
- What changed: preserve explicit runtime pins from legacy agent model maps, provider-level runtime policy, and provider catalog model policy; add regression coverage for those cases and for listed-agent shielding.
- What did NOT change (scope boundary): this does not investigate or claim to fix the separate `gpt-5.5` token-usage behavior discussed on #84038, and it does not edit `CHANGELOG.md`.

## Motivation

#84362 is the ClawSweeper replacement for #84142, but that bot-owned branch is currently blocked by a `CHANGELOG.md` conflict. This PR provides the same fix path on current `upstream/main`, deliberately avoiding the contributor-forbidden changelog edit, and includes the tested follow-up runtime-pin cases.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #84038
- Related #84142
- Related #84362
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `openclaw doctor --fix` route repair preserves explicit non-default runtime pins when migrating `openai-codex/gpt-5.4` to `openai/gpt-5.4`.
- Real environment tested: local OpenClaw source checkout on Linux, Node v22.22.1, current `upstream/main` branch with this patch applied.
- Exact steps or command run after this patch:

```bash
OPENCLAW_REPO=/tmp/openclaw-84038-clean-20260521 pnpm exec tsx /tmp/repro-openclaw-84038-runtime-pin-matrix.mjs
```

- Evidence after fix:

Terminal output from the runtime resolver / doctor repair matrix:

```text
scenario: model-map PI pin survives legacy openai-codex model map rewrite
beforeRuntime: pi
defaultPolicy: { id: pi }
afterRuntime: pi
pass: true

scenario: provider-level PI pin survives route repair
beforeRuntime: pi
defaultPolicy: { id: pi }
afterRuntime: pi
pass: true

scenario: provider-catalog model PI pin survives route repair
beforeRuntime: pi
defaultPolicy: { id: pi }
afterRuntime: pi
pass: true

scenario: defaults PI repair does not leak into listed canonical Codex agent
beforeRuntime: { defaults: pi, regular: codex }
defaultPolicy: { id: pi }
listedPolicy: { id: codex }
afterRuntime: { defaults: pi, regular: codex }
pass: true

GREEN: all runtime pin repair scenarios preserved expected runtimes
```

- Observed result after fix: legacy `openai-codex/*` routes are rewritten to canonical `openai/*`, while explicit `pi` runtime pins remain effective for the repaired route. A listed agent that already explicitly uses canonical OpenAI with Codex routing keeps `codex` instead of inheriting the repaired defaults-level `pi` policy.
- What was not tested: full CI, a live PI OAuth login, and the separate `gpt-5.5` token-usage behavior discussed in #84038.
- Before evidence (optional but encouraged): the same matrix on current `upstream/main` repaired all four scenarios to `agentRuntime.id = "codex"` and ended with `RED: one or more runtime pins were not preserved across doctor route repair`.

## Root Cause (if applicable)

- Root cause: route repair synthesized a canonical `openai/*` Codex runtime policy before considering explicit pre-repair non-default runtime pins from legacy `openai-codex/*` model-map entries, provider-level policy, or provider catalog model policy.
- Missing detection / guardrail: existing tests covered the default Codex repair path, but not the explicit non-Codex runtime-pin carriers or the listed-agent shield when defaults repair introduces a non-Codex runtime policy.
- Contributing context (if known): older route-repair behavior needed to preserve Codex auth routing after canonicalization, but that default should not override an explicit user runtime choice.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/commands/doctor/shared/codex-route-warnings.test.ts`
- Scenario the test should lock in: model-map, provider-level, and provider-catalog runtime pins survive route repair; defaults-level preservation does not leak into listed canonical Codex agents.
- Why this is the smallest reliable guardrail: `maybeRepairCodexRoutes` plus the runtime resolver exercises the doctor repair output and the effective runtime selection without needing a live provider credential.
- Existing test that already covers this (if any): existing Codex route-repair tests covered canonical Codex behavior, not these explicit runtime-pin preservation cases.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

`openclaw doctor --fix` still canonicalizes legacy `openai-codex/*` route refs, but now preserves explicit non-default runtime pins instead of silently moving those repaired routes onto Codex runtime.

## Diagram (if applicable)

```text
Before:
openai-codex/gpt-5.4 + explicit pi runtime -> doctor --fix -> openai/gpt-5.4 + codex runtime

After:
openai-codex/gpt-5.4 + explicit pi runtime -> doctor --fix -> openai/gpt-5.4 + pi runtime
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node v22.22.1 local source checkout
- Model/provider: `openai-codex/gpt-5.4` repaired to `openai/gpt-5.4`
- Integration/channel (if any): N/A
- Relevant config (redacted): synthetic doctor config with explicit `agentRuntime.id = "pi"` in model-map, provider-level, and provider-catalog shapes

### Steps

1. Run the runtime-pin matrix against current `upstream/main` and observe RED.
2. Apply this patch.
3. Rerun the runtime-pin matrix and targeted doctor tests.

### Expected

- Repaired canonical `openai/gpt-5.4` routes preserve explicit `pi` runtime pins.
- Existing Codex route repair behavior remains green.

### Actual

- Matrix proof is GREEN after this patch.
- Targeted tests pass.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Verification commands run locally:

```bash
OPENCLAW_REPO=/tmp/openclaw-84038-clean-20260521 pnpm exec tsx /tmp/repro-openclaw-84038-runtime-pin-matrix.mjs
node scripts/run-vitest.mjs src/commands/doctor/shared/codex-route-warnings.test.ts
node scripts/run-vitest.mjs src/commands/doctor/repair-sequencing.test.ts
node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
pnpm exec oxfmt --check --threads=1 src/commands/doctor/shared/codex-route-warnings.ts src/commands/doctor/shared/codex-route-warnings.test.ts
git diff --check upstream/main..HEAD
```

Results:

```text
runtime-pin matrix: GREEN
codex-route-warnings.test.ts: 103 passed
repair-sequencing.test.ts: 10 passed
tsgo core: exit 0
oxfmt touched files: All matched files use the correct format.
git diff --check: passed
```

## Human Verification (required)

- Verified scenarios: model-map runtime pin, provider-level runtime pin, provider-catalog model runtime pin, listed-agent shielding, existing Codex repair tests, repair sequencing tests, typecheck, formatting, and whitespace checks.
- Edge cases checked: `auto` / `default` runtime policy is not treated as an explicit pin; listed canonical agents keep Codex when defaults repair preserves PI; contributor PR avoids `CHANGELOG.md`.
- What you did **not** verify: full CI, live OAuth login, runtime token consumption, and maintainer-side ClawSweeper automerge.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

No bot review conversations exist on this new PR at creation time.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: preserving a non-Codex runtime pin during defaults repair could accidentally affect listed agents that explicitly use canonical OpenAI/Codex routing.
  - Mitigation: the patch shields explicitly listed canonical agents and adds a regression test/proof where defaults remain `pi` while the listed agent remains `codex`.
- Risk: provider-level and provider-catalog policy lookup could be broader than intended.
  - Mitigation: tests cover model-map precedence, provider-level pins, provider-catalog model pins, and existing repair sequencing remains green.

## AI assistance disclosure

This PR is AI-assisted. I reviewed the diff and ran the verification listed above.
