### PR TITLE
[codex] Preserve request SecretRef markers in models.json

### DIFF
--- a/src/agents/model-auth-markers.ts
+++ b/src/agents/model-auth-markers.ts
@@ -1,6 +1,14 @@
-import type { SecretRefSource } from "../config/types.secrets.js";
 import { listOpenClawPluginManifestMetadata } from "../plugins/manifest-metadata-scan.js";
 import { listKnownProviderEnvApiKeyNames } from "./model-auth-env-vars.js";
+import { NON_ENV_SECRETREF_MARKER } from "./secret-ref-auth-markers.js";
+export {
+  isSecretRefHeaderValueMarker,
+  NON_ENV_SECRETREF_MARKER,
+  resolveEnvSecretRefHeaderValueMarker,
+  resolveNonEnvSecretRefApiKeyMarker,
+  resolveNonEnvSecretRefHeaderValueMarker,
+  SECRETREF_ENV_HEADER_MARKER_PREFIX,
+} from "./secret-ref-auth-markers.js";
 
 /** @deprecated MiniMax provider-owned marker; do not use from third-party plugins. */
 export const MINIMAX_OAUTH_MARKER = "minimax-oauth";
@@ -9,8 +17,6 @@ export const OLLAMA_LOCAL_AUTH_MARKER = "ollama-local";
 /** @deprecated Bundled local-provider marker; do not use from third-party plugins. */
 export const CUSTOM_LOCAL_AUTH_MARKER = "custom-local";
 export const GCP_VERTEX_CREDENTIALS_MARKER = "gcp-vertex-credentials";
-export const NON_ENV_SECRETREF_MARKER = "secretref-managed"; // pragma: allowlist secret
-export const SECRETREF_ENV_HEADER_MARKER_PREFIX = "secretref-env:"; // pragma: allowlist secret
 
 const AWS_SDK_ENV_MARKERS = new Set([
   "AWS_BEARER_TOKEN_BEDROCK",
@@ -82,25 +88,6 @@ export function resolveOAuthApiKeyMarker(providerId: string): string {
 
 export function isOAuthApiKeyMarker(value: string): boolean {
   return value.trim().startsWith(OAUTH_API_KEY_MARKER_PREFIX);
-}
-
-export function resolveNonEnvSecretRefApiKeyMarker(_source: SecretRefSource): string {
-  return NON_ENV_SECRETREF_MARKER;
-}
-
-export function resolveNonEnvSecretRefHeaderValueMarker(_source: SecretRefSource): string {
-  return NON_ENV_SECRETREF_MARKER;
-}
-
-export function resolveEnvSecretRefHeaderValueMarker(envVarName: string): string {
-  return `${SECRETREF_ENV_HEADER_MARKER_PREFIX}${envVarName.trim()}`;
-}
-
-export function isSecretRefHeaderValueMarker(value: string): boolean {
-  const trimmed = value.trim();
-  return (
-    trimmed === NON_ENV_SECRETREF_MARKER || trimmed.startsWith(SECRETREF_ENV_HEADER_MARKER_PREFIX)
-  );
 }
 
 export function isNonSecretApiKeyMarker(

--- a/src/agents/models-config.providers.normalize.ts
+++ b/src/agents/models-config.providers.normalize.ts
@@ -9,6 +9,7 @@ import type { ProviderConfig, SecretDefaults } from "./models-config.providers.s
 import {
   normalizeConfiguredProviderApiKey,
   normalizeHeaderValues,
+  normalizeProviderRequestSecrets,
   normalizeResolvedEnvApiKey,
   resolveApiKeyFromProfiles,
   resolveMissingProviderApiKey,
@@ -149,6 +150,14 @@ export function normalizeProviders(params: {
     if (normalizedHeaders.mutated) {
       mutated = true;
       normalizedProvider = { ...normalizedProvider, headers: normalizedHeaders.headers };
+    }
+    const normalizedRequest = normalizeProviderRequestSecrets({
+      request: normalizedProvider.request,
+      secretDefaults: params.secretDefaults,
+    });
+    if (normalizedRequest.mutated) {
+      mutated = true;
+      normalizedProvider = { ...normalizedProvider, request: normalizedRequest.request };
     }
     const providerWithConfiguredApiKey = normalizeConfiguredProviderApiKey({
       providerKey: normalizedKey,

--- a/src/agents/models-config.providers.secret-helpers.ts
+++ b/src/agents/models-config.providers.secret-helpers.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { coerceSecretRef, resolveSecretInputRef } from "../config/types.secrets.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
+import { isRecord } from "../utils.js";
 import { normalizeOptionalSecretInput } from "../utils/normalize-secret-input.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
 import { resolveEnvApiKey } from "./model-auth-env.js";
@@ -43,6 +44,14 @@ export type ProviderAuthResolver = (
   source: "env" | "profile" | "none";
   profileId?: string;
 };
+
+type ProviderRequestConfig = NonNullable<ProviderConfig["request"]>;
+type ProviderRequestAuthConfig = NonNullable<ProviderRequestConfig["auth"]>;
+type ProviderRequestTlsConfig = NonNullable<ProviderRequestConfig["tls"]>;
+type ProviderRequestProxyConfig = NonNullable<ProviderRequestConfig["proxy"]>;
+type RequestTlsSecretKey = "ca" | "cert" | "key" | "passphrase";
+
+const REQUEST_TLS_SECRET_KEYS: readonly RequestTlsSecretKey[] = ["ca", "cert", "key", "passphrase"];
 
 const ENV_VAR_NAME_RE = /^[A-Z_][A-Z0-9_]*$/;
 
@@ -107,6 +116,364 @@ export function normalizeHeaderValues(params: {
     return { headers, mutated: false };
   }
   return { headers: nextHeaders, mutated: true };
+}
+
+function resolveSecretInputMarker(params: {
+  value: unknown;
+  secretDefaults: SecretDefaults | undefined;
+}): string | undefined {
+  const resolvedRef = resolveSecretInputRef({
+    value: params.value,
+    defaults: params.secretDefaults,
+  }).ref;
+  if (!resolvedRef || !resolvedRef.id.trim()) {
+    return undefined;
+  }
+  return resolvedRef.source === "env"
+    ? resolveEnvSecretRefHeaderValueMarker(resolvedRef.id)
+    : resolveNonEnvSecretRefHeaderValueMarker(resolvedRef.source);
+}
+
+function normalizeRequestHeaders(params: {
+  headers: ProviderRequestConfig["headers"] | undefined;
+  secretDefaults: SecretDefaults | undefined;
+  refsOnly?: boolean;
+}): {
+  headers: ProviderRequestConfig["headers"] | undefined;
+  mutated: boolean;
+  hasMarkers: boolean;
+} {
+  const { headers } = params;
+  if (!headers) {
+    return { headers, mutated: false, hasMarkers: false };
+  }
+  let mutated = false;
+  let hasMarkers = false;
+  const nextHeaders: Record<string, NonNullable<ProviderRequestConfig["headers"]>[string]> = {};
+  for (const [headerName, headerValue] of Object.entries(headers)) {
+    const marker = resolveSecretInputMarker({
+      value: headerValue,
+      secretDefaults: params.secretDefaults,
+    });
+    if (marker) {
+      hasMarkers = true;
+      mutated = mutated || marker !== headerValue;
+      nextHeaders[headerName] = marker;
+      continue;
+    }
+    if (!params.refsOnly) {
+      nextHeaders[headerName] = headerValue;
+    }
+  }
+  if (params.refsOnly && !hasMarkers) {
+    return { headers: undefined, mutated: false, hasMarkers: false };
+  }
+  if (!params.refsOnly && !mutated) {
+    return { headers, mutated: false, hasMarkers };
+  }
+  return { headers: nextHeaders, mutated: true, hasMarkers };
+}
+
+function normalizeRequestTlsSecrets(params: {
+  tls: ProviderRequestTlsConfig | undefined;
+  secretDefaults: SecretDefaults | undefined;
+  refsOnly?: boolean;
+}): { tls: ProviderRequestTlsConfig | undefined; mutated: boolean; hasMarkers: boolean } {
+  const { tls } = params;
+  if (!tls) {
+    return { tls, mutated: false, hasMarkers: false };
+  }
+  let mutated = false;
+  let hasMarkers = false;
+  const nextTls: ProviderRequestTlsConfig = params.refsOnly ? {} : { ...tls };
+  for (const key of REQUEST_TLS_SECRET_KEYS) {
+    const marker = resolveSecretInputMarker({
+      value: tls[key],
+      secretDefaults: params.secretDefaults,
+    });
+    if (!marker) {
+      continue;
+    }
+    hasMarkers = true;
+    mutated = mutated || tls[key] !== marker;
+    nextTls[key] = marker;
+  }
+  if (params.refsOnly && !hasMarkers) {
+    return { tls: undefined, mutated: false, hasMarkers: false };
+  }
+  if (!params.refsOnly && !mutated) {
+    return { tls, mutated: false, hasMarkers };
+  }
+  return { tls: nextTls, mutated: true, hasMarkers };
+}
+
+function normalizeRequestAuthSecrets(params: {
+  auth: ProviderRequestAuthConfig | undefined;
+  secretDefaults: SecretDefaults | undefined;
+  refsOnly?: boolean;
+}): { auth: ProviderRequestAuthConfig | undefined; mutated: boolean; hasMarkers: boolean } {
+  const { auth } = params;
+  if (!auth) {
+    return { auth, mutated: false, hasMarkers: false };
+  }
+  if (auth.mode === "authorization-bearer") {
+    const marker = resolveSecretInputMarker({
+      value: auth.token,
+      secretDefaults: params.secretDefaults,
+    });
+    if (!marker) {
+      return params.refsOnly
+        ? { auth: undefined, mutated: false, hasMarkers: false }
+        : { auth, mutated: false, hasMarkers: false };
+    }
+    return {
+      auth: { ...auth, token: marker },
+      mutated: auth.token !== marker,
+      hasMarkers: true,
+    };
+  }
+  if (auth.mode === "header") {
+    const marker = resolveSecretInputMarker({
+      value: auth.value,
+      secretDefaults: params.secretDefaults,
+    });
+    if (!marker) {
+      return params.refsOnly
+        ? { auth: undefined, mutated: false, hasMarkers: false }
+        : { auth, mutated: false, hasMarkers: false };
+    }
+    return {
+      auth: { ...auth, value: marker },
+      mutated: auth.value !== marker,
+      hasMarkers: true,
+    };
+  }
+  return params.refsOnly
+    ? { auth: undefined, mutated: false, hasMarkers: false }
+    : { auth, mutated: false, hasMarkers: false };
+}
+
+function normalizeRequestProxySecrets(params: {
+  proxy: ProviderRequestProxyConfig | undefined;
+  secretDefaults: SecretDefaults | undefined;
+  refsOnly?: boolean;
+}): { proxy: ProviderRequestProxyConfig | undefined; mutated: boolean; hasMarkers: boolean } {
+  const { proxy } = params;
+  if (!proxy) {
+    return { proxy, mutated: false, hasMarkers: false };
+  }
+  const tls = normalizeRequestTlsSecrets({
+    tls: proxy.tls,
+    secretDefaults: params.secretDefaults,
+    refsOnly: params.refsOnly,
+  });
+  if (!tls.hasMarkers) {
+    return params.refsOnly
+      ? { proxy: undefined, mutated: false, hasMarkers: false }
+      : { proxy, mutated: false, hasMarkers: false };
+  }
+  return {
+    proxy: { ...proxy, tls: tls.tls },
+    mutated: tls.mutated,
+    hasMarkers: true,
+  };
+}
+
+export function normalizeProviderRequestSecrets(params: {
+  request: ProviderConfig["request"] | undefined;
+  secretDefaults: SecretDefaults | undefined;
+}): { request: ProviderConfig["request"] | undefined; mutated: boolean; hasMarkers: boolean } {
+  const { request } = params;
+  if (!request) {
+    return { request, mutated: false, hasMarkers: false };
+  }
+  let mutated = false;
+  let hasMarkers = false;
+  const nextRequest: ProviderRequestConfig = { ...request };
+
+  const headers = normalizeRequestHeaders({
+    headers: request.headers,
+    secretDefaults: params.secretDefaults,
+  });
+  if (headers.mutated) {
+    mutated = true;
+    nextRequest.headers = headers.headers;
+  }
+  hasMarkers = hasMarkers || headers.hasMarkers;
+
+  const auth = normalizeRequestAuthSecrets({
+    auth: request.auth,
+    secretDefaults: params.secretDefaults,
+  });
+  if (auth.mutated) {
+    mutated = true;
+    nextRequest.auth = auth.auth;
+  }
+  hasMarkers = hasMarkers || auth.hasMarkers;
+
+  const proxy = normalizeRequestProxySecrets({
+    proxy: request.proxy,
+    secretDefaults: params.secretDefaults,
+  });
+  if (proxy.mutated) {
+    mutated = true;
+    nextRequest.proxy = proxy.proxy;
+  }
+  hasMarkers = hasMarkers || proxy.hasMarkers;
+
+  const tls = normalizeRequestTlsSecrets({
+    tls: request.tls,
+    secretDefaults: params.secretDefaults,
+  });
+  if (tls.mutated) {
+    mutated = true;
+    nextRequest.tls = tls.tls;
+  }
+  hasMarkers = hasMarkers || tls.hasMarkers;
+
+  return mutated ? { request: nextRequest, mutated, hasMarkers } : { request, mutated, hasMarkers };
+}
+
+export function collectProviderRequestSecretMarkerPatch(params: {
+  request: ProviderConfig["request"] | undefined;
+  secretDefaults: SecretDefaults | undefined;
+}): { request: ProviderConfig["request"] | undefined; hasMarkers: boolean } {
+  const { request } = params;
+  if (!request) {
+    return { request: undefined, hasMarkers: false };
+  }
+  let hasMarkers = false;
+  const patch: ProviderRequestConfig = {};
+
+  const headers = normalizeRequestHeaders({
+    headers: request.headers,
+    secretDefaults: params.secretDefaults,
+    refsOnly: true,
+  });
+  if (headers.hasMarkers) {
+    hasMarkers = true;
+    patch.headers = headers.headers;
+  }
+
+  const auth = normalizeRequestAuthSecrets({
+    auth: request.auth,
+    secretDefaults: params.secretDefaults,
+    refsOnly: true,
+  });
+  if (auth.hasMarkers) {
+    hasMarkers = true;
+    patch.auth = auth.auth;
+  }
+
+  const proxy = normalizeRequestProxySecrets({
+    proxy: request.proxy,
+    secretDefaults: params.secretDefaults,
+    refsOnly: true,
+  });
+  if (proxy.hasMarkers) {
+    hasMarkers = true;
+    patch.proxy = proxy.proxy;
+  }
+
+  const tls = normalizeRequestTlsSecrets({
+    tls: request.tls,
+    secretDefaults: params.secretDefaults,
+    refsOnly: true,
+  });
+  if (tls.hasMarkers) {
+    hasMarkers = true;
+    patch.tls = tls.tls;
+  }
+
+  return hasMarkers ? { request: patch, hasMarkers: true } : { request: undefined, hasMarkers };
+}
+
+function mergeTlsSecretMarkerPatch(params: {
+  current: ProviderRequestTlsConfig | undefined;
+  patch: ProviderRequestTlsConfig | undefined;
+}): { tls: ProviderRequestTlsConfig | undefined; mutated: boolean } {
+  if (!params.patch) {
+    return { tls: params.current, mutated: false };
+  }
+  const nextTls: ProviderRequestTlsConfig = isRecord(params.current) ? { ...params.current } : {};
+  let mutated = !params.current;
+  for (const key of REQUEST_TLS_SECRET_KEYS) {
+    const patchValue = params.patch[key];
+    if (patchValue === undefined || nextTls[key] === patchValue) {
+      continue;
+    }
+    mutated = true;
+    nextTls[key] = patchValue;
+  }
+  return { tls: mutated ? nextTls : params.current, mutated };
+}
+
+export function mergeProviderRequestSecretMarkerPatch(params: {
+  request: ProviderConfig["request"] | undefined;
+  markerPatch: ProviderConfig["request"] | undefined;
+}): { request: ProviderConfig["request"] | undefined; mutated: boolean } {
+  if (!params.markerPatch) {
+    return { request: params.request, mutated: false };
+  }
+  const nextRequest: ProviderRequestConfig = isRecord(params.request) ? { ...params.request } : {};
+  let mutated = !params.request;
+
+  if (params.markerPatch.headers) {
+    const nextHeaders: NonNullable<ProviderRequestConfig["headers"]> = isRecord(nextRequest.headers)
+      ? { ...nextRequest.headers }
+      : {};
+    let headersMutated = !nextRequest.headers;
+    for (const [headerName, marker] of Object.entries(params.markerPatch.headers)) {
+      if (nextHeaders[headerName] === marker) {
+        continue;
+      }
+      headersMutated = true;
+      nextHeaders[headerName] = marker;
+    }
+    if (headersMutated) {
+      mutated = true;
+      nextRequest.headers = nextHeaders;
+    }
+  }
+
+  if (params.markerPatch.auth && nextRequest.auth !== params.markerPatch.auth) {
+    mutated = true;
+    nextRequest.auth = params.markerPatch.auth;
+  }
+
+  if (params.markerPatch.proxy) {
+    const currentProxy = isRecord(nextRequest.proxy)
+      ? (nextRequest.proxy as ProviderRequestProxyConfig)
+      : undefined;
+    let nextProxy: ProviderRequestProxyConfig = {
+      ...params.markerPatch.proxy,
+      ...currentProxy,
+    };
+    let proxyMutated = !currentProxy;
+    const mergedProxyTls = mergeTlsSecretMarkerPatch({
+      current: currentProxy?.tls,
+      patch: params.markerPatch.proxy.tls,
+    });
+    if (mergedProxyTls.mutated) {
+      proxyMutated = true;
+      nextProxy = { ...nextProxy, tls: mergedProxyTls.tls };
+    }
+    if (proxyMutated) {
+      mutated = true;
+      nextRequest.proxy = nextProxy;
+    }
+  }
+
+  const mergedTls = mergeTlsSecretMarkerPatch({
+    current: nextRequest.tls,
+    patch: params.markerPatch.tls,
+  });
+  if (mergedTls.mutated) {
+    mutated = true;
+    nextRequest.tls = mergedTls.tls;
+  }
+
+  return { request: mutated ? nextRequest : params.request, mutated };
 }
 
 export function resolveApiKeyFromCredential(

--- a/src/agents/models-config.providers.source-managed.ts
+++ b/src/agents/models-config.providers.source-managed.ts
@@ -6,6 +6,10 @@ import {
   resolveNonEnvSecretRefHeaderValueMarker,
   resolveEnvSecretRefHeaderValueMarker,
 } from "./model-auth-markers.js";
+import {
+  collectProviderRequestSecretMarkerPatch,
+  mergeProviderRequestSecretMarkerPatch,
+} from "./models-config.providers.secret-helpers.js";
 import type { ProviderConfig, SecretDefaults } from "./models-config.providers.secrets.js";
 
 type ModelsConfig = NonNullable<OpenClawConfig["models"]>;
@@ -136,6 +140,25 @@ export function enforceSourceManagedProviderSecrets(params: {
         nextProvider = {
           ...nextProvider,
           headers: nextHeaders,
+        };
+      }
+    }
+
+    const sourceRequestMarkerPatch = collectProviderRequestSecretMarkerPatch({
+      request: sourceProvider.request,
+      secretDefaults: params.sourceSecretDefaults,
+    });
+    if (sourceRequestMarkerPatch.hasMarkers) {
+      params.secretRefManagedProviders?.add(providerKey.trim());
+      const mergedRequest = mergeProviderRequestSecretMarkerPatch({
+        request: nextProvider.request,
+        markerPatch: sourceRequestMarkerPatch.request,
+      });
+      if (mergedRequest.mutated) {
+        providerMutated = true;
+        nextProvider = {
+          ...nextProvider,
+          request: mergedRequest.request,
         };
       }
     }

--- a/src/agents/models-config.runtime-source-snapshot.test.ts
+++ b/src/agents/models-config.runtime-source-snapshot.test.ts
@@ -144,6 +144,78 @@ function createOpenAiHeaderRuntimeConfig(): OpenClawConfig {
   };
 }
 
+function createOpenAiRequestSourceConfig(): OpenClawConfig {
+  return {
+    models: {
+      providers: {
+        openai: {
+          baseUrl: "https://api.openai.com/v1",
+          api: "openai-completions" as const,
+          request: {
+            headers: {
+              Authorization: {
+                source: "env",
+                provider: "default",
+                id: "OPENAI_REQUEST_AUTH_HEADER", // pragma: allowlist secret
+              },
+              "X-Request-Secret": {
+                source: "file",
+                provider: "vault",
+                id: "/providers/openai/requestSecret",
+              },
+            },
+            auth: {
+              mode: "authorization-bearer" as const,
+              token: {
+                source: "env",
+                provider: "default",
+                id: "OPENAI_REQUEST_BEARER", // pragma: allowlist secret
+              },
+            },
+            tls: {
+              key: {
+                source: "file",
+                provider: "vault",
+                id: "/providers/openai/clientKey",
+              },
+              serverName: "api.openai.com",
+            },
+          },
+          models: [],
+        },
+      },
+    },
+  };
+}
+
+function createOpenAiRequestRuntimeConfig(): OpenClawConfig {
+  return {
+    models: {
+      providers: {
+        openai: {
+          baseUrl: "https://api.openai.com/v1",
+          api: "openai-completions" as const,
+          request: {
+            headers: {
+              Authorization: "Bearer runtime-request-header",
+              "X-Request-Secret": "runtime-request-secret",
+            },
+            auth: {
+              mode: "authorization-bearer" as const,
+              token: "runtime-bearer-token",
+            },
+            tls: {
+              key: "runtime-client-key",
+              serverName: "api.openai.com",
+            },
+          },
+          models: [],
+        },
+      },
+    },
+  };
+}
+
 function createOpenAiSourceConfigWithHeadersAndApiKey(): OpenClawConfig {
   const config = createOpenAiHeaderSourceConfig();
   config.models!.providers!.openai.apiKey = {
@@ -205,7 +277,15 @@ async function planGeneratedProviders(params: {
   }
   return JSON.parse(plan.contents).providers as Record<
     string,
-    { apiKey?: string; headers?: Record<string, string> }
+    {
+      apiKey?: string;
+      headers?: Record<string, string>;
+      request?: {
+        headers?: Record<string, string>;
+        auth?: { mode?: string; token?: string; value?: string };
+        tls?: { key?: string; serverName?: string };
+      };
+    }
   >;
 }
 
@@ -216,6 +296,29 @@ function expectOpenAiHeaderMarkers(
     "secretref-env:OPENAI_HEADER_TOKEN", // pragma: allowlist secret
   );
   expect(providers.openai?.headers?.["X-Tenant-Token"]).toBe(NON_ENV_SECRETREF_MARKER);
+}
+
+function expectOpenAiRequestMarkers(
+  providers: Record<
+    string,
+    {
+      request?: {
+        headers?: Record<string, string>;
+        auth?: { mode?: string; token?: string };
+        tls?: { key?: string; serverName?: string };
+      };
+    }
+  >,
+) {
+  expect(providers.openai?.request?.headers?.Authorization).toBe(
+    "secretref-env:OPENAI_REQUEST_AUTH_HEADER", // pragma: allowlist secret
+  );
+  expect(providers.openai?.request?.headers?.["X-Request-Secret"]).toBe(NON_ENV_SECRETREF_MARKER);
+  expect(providers.openai?.request?.auth?.token).toBe(
+    "secretref-env:OPENAI_REQUEST_BEARER", // pragma: allowlist secret
+  );
+  expect(providers.openai?.request?.tls?.key).toBe(NON_ENV_SECRETREF_MARKER);
+  expect(providers.openai?.request?.tls?.serverName).toBe("api.openai.com");
 }
 
 describe("models-config runtime source snapshot", () => {
@@ -352,6 +455,14 @@ describe("models-config runtime source snapshot", () => {
       sourceConfigForSecrets: createOpenAiHeaderSourceConfig(),
     });
     expectOpenAiHeaderMarkers(providers);
+  });
+
+  it("uses request secret markers from runtime source snapshot instead of resolved runtime values", async () => {
+    const providers = await planGeneratedProviders({
+      config: createOpenAiRequestRuntimeConfig(),
+      sourceConfigForSecrets: createOpenAiRequestSourceConfig(),
+    });
+    expectOpenAiRequestMarkers(providers);
   });
 
   it("keeps source markers when runtime projection is skipped for incompatible top-level shape", async () => {

--- a/src/agents/pi-embedded-runner/model.inline-provider.test.ts
+++ b/src/agents/pi-embedded-runner/model.inline-provider.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { getModelProviderRequestTransport } from "../provider-request-config.js";
 import { buildInlineProviderModels, resolveProviderModelInput } from "./model.inline-provider.js";
 import { makeModel } from "./model.test-harness.js";
 
@@ -256,6 +257,43 @@ describe("buildInlineProviderModels", () => {
     const result = buildInlineProviderModels(providers);
 
     expect(result).toHaveLength(1);
+    expect(result[0].headers).toEqual({
+      "X-Static": "tenant-a",
+    });
+  });
+
+  it("drops SecretRef marker request values before attaching inline provider transport", () => {
+    const providers: Parameters<typeof buildInlineProviderModels>[0] = {
+      custom: {
+        request: {
+          headers: {
+            Authorization: "secretref-env:OPENAI_REQUEST_AUTH_HEADER",
+            "X-Static": "tenant-a",
+          },
+          auth: {
+            mode: "authorization-bearer",
+            token: "secretref-env:OPENAI_REQUEST_AUTH_TOKEN",
+          },
+          tls: {
+            cert: "secretref-env:OPENAI_REQUEST_CERT",
+            key: "client-key",
+          },
+        },
+        models: [makeModel("custom-model")],
+      },
+    };
+
+    const result = buildInlineProviderModels(providers);
+
+    expect(result).toHaveLength(1);
+    expect(getModelProviderRequestTransport(result[0])).toEqual({
+      headers: {
+        "X-Static": "tenant-a",
+      },
+      tls: {
+        key: "client-key",
+      },
+    });
     expect(result[0].headers).toEqual({
       "X-Static": "tenant-a",
     });

--- a/src/agents/pi-embedded-runner/model.inline-provider.ts
+++ b/src/agents/pi-embedded-runner/model.inline-provider.ts
@@ -2,13 +2,13 @@ import type { Api } from "@earendil-works/pi-ai";
 import type { ModelDefinitionConfig, ModelProviderConfig } from "../../config/types.js";
 import { normalizeGoogleApiBaseUrl } from "../../infra/google-api-base-url.js";
 import { normalizeOptionalLowercaseString } from "../../shared/string-coerce.js";
-import { isSecretRefHeaderValueMarker } from "../model-auth-markers.js";
 import { attachModelProviderLocalService } from "../provider-local-service.js";
 import {
   attachModelProviderRequestTransport,
   resolveProviderRequestConfig,
   sanitizeConfiguredModelProviderRequest,
 } from "../provider-request-config.js";
+import { isSecretRefHeaderValueMarker } from "../secret-ref-auth-markers.js";
 
 export type InlineModelEntry = Omit<ModelDefinitionConfig, "api"> & {
   api?: Api;

--- a/src/agents/provider-request-config.test.ts
+++ b/src/agents/provider-request-config.test.ts
@@ -296,6 +296,50 @@ describe("provider request config", () => {
     });
   });
 
+  it("drops SecretRef marker strings before request overrides become transport credentials", () => {
+    expect(
+      sanitizeConfiguredProviderRequest({
+        headers: {
+          Authorization: "secretref-env:OPENAI_REQUEST_AUTH_HEADER",
+          "X-Tenant": "acme",
+          "X-Managed": "secretref-managed",
+        },
+        auth: {
+          mode: "authorization-bearer",
+          token: "secretref-env:OPENAI_REQUEST_AUTH_TOKEN",
+        },
+        proxy: {
+          mode: "explicit-proxy",
+          url: "http://proxy.internal:8443",
+          tls: {
+            ca: "secretref-env:OPENAI_PROXY_CA",
+            cert: "proxy-cert",
+            key: "secretref-managed",
+          },
+        },
+        tls: {
+          cert: "secretref-env:OPENAI_REQUEST_CERT",
+          key: "client-key",
+          passphrase: "secretref-managed",
+        },
+      }),
+    ).toEqual({
+      headers: {
+        "X-Tenant": "acme",
+      },
+      proxy: {
+        mode: "explicit-proxy",
+        url: "http://proxy.internal:8443",
+        tls: {
+          cert: "proxy-cert",
+        },
+      },
+      tls: {
+        key: "client-key",
+      },
+    });
+  });
+
   it("fails fast when configured request overrides still contain unresolved SecretRefs", () => {
     const tenantRef: SecretRef = {
       source: "env",

--- a/src/agents/provider-request-config.ts
+++ b/src/agents/provider-request-config.ts
@@ -8,7 +8,6 @@ import { assertSecretInputResolved } from "../config/types.secrets.js";
 import type { PinnedDispatcherPolicy } from "../infra/net/ssrf.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { COPILOT_INTEGRATION_ID, buildCopilotIdeHeaders } from "./copilot-dynamic-headers.js";
-import { isSecretRefHeaderValueMarker } from "./model-auth-markers.js";
 import type {
   ProviderRequestCapabilities,
   ProviderRequestCapability,
@@ -19,6 +18,7 @@ import {
   resolveProviderRequestPolicy,
   type ProviderRequestPolicyResolution,
 } from "./provider-attribution.js";
+import { isSecretRefHeaderValueMarker } from "./secret-ref-auth-markers.js";
 
 type RequestApi = Api | ModelDefinitionConfig["api"];
 

--- a/src/agents/provider-request-config.ts
+++ b/src/agents/provider-request-config.ts
@@ -8,6 +8,7 @@ import { assertSecretInputResolved } from "../config/types.secrets.js";
 import type { PinnedDispatcherPolicy } from "../infra/net/ssrf.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { COPILOT_INTEGRATION_ID, buildCopilotIdeHeaders } from "./copilot-dynamic-headers.js";
+import { isSecretRefHeaderValueMarker } from "./model-auth-markers.js";
 import type {
   ProviderRequestCapabilities,
   ProviderRequestCapability,
@@ -195,6 +196,9 @@ function sanitizeConfiguredRequestString(value: unknown, path: string): string |
     return undefined;
   }
   const trimmed = value.trim();
+  if (isSecretRefHeaderValueMarker(trimmed)) {
+    return undefined;
+  }
   return trimmed ? trimmed : undefined;
 }
 

--- a/src/agents/secret-ref-auth-markers.ts
+++ b/src/agents/secret-ref-auth-markers.ts
@@ -1,0 +1,23 @@
+import type { SecretRefSource } from "../config/types.secrets.js";
+
+export const NON_ENV_SECRETREF_MARKER = "secretref-managed"; // pragma: allowlist secret
+export const SECRETREF_ENV_HEADER_MARKER_PREFIX = "secretref-env:"; // pragma: allowlist secret
+
+export function resolveNonEnvSecretRefApiKeyMarker(_source: SecretRefSource): string {
+  return NON_ENV_SECRETREF_MARKER;
+}
+
+export function resolveNonEnvSecretRefHeaderValueMarker(_source: SecretRefSource): string {
+  return NON_ENV_SECRETREF_MARKER;
+}
+
+export function resolveEnvSecretRefHeaderValueMarker(envVarName: string): string {
+  return `${SECRETREF_ENV_HEADER_MARKER_PREFIX}${envVarName.trim()}`;
+}
+
+export function isSecretRefHeaderValueMarker(value: string): boolean {
+  const trimmed = value.trim();
+  return (
+    trimmed === NON_ENV_SECRETREF_MARKER || trimmed.startsWith(SECRETREF_ENV_HEADER_MARKER_PREFIX)
+  );
+}

--- a/src/secrets/audit.test.ts
+++ b/src/secrets/audit.test.ts
@@ -203,6 +203,7 @@ describe("secrets audit", () => {
     overrides: Partial<{
       apiKey: unknown;
       headers: Record<string, unknown>;
+      request: Record<string, unknown>;
     }> = {},
   ) {
     await writeJsonFile(fixture.modelsPath, {
@@ -441,6 +442,37 @@ describe("secrets audit", () => {
     expectModelsFinding(report, {
       code: "PLAINTEXT_FOUND",
       jsonPath: "providers.openai.headers.Authorization",
+    });
+  });
+
+  it("scans agent models.json files for plaintext provider request secrets", async () => {
+    await writeModelsProvider({
+      request: {
+        headers: {
+          Authorization: "Bearer sk-request-header", // pragma: allowlist secret
+        },
+        auth: {
+          mode: "authorization-bearer",
+          token: "sk-request-auth-token", // pragma: allowlist secret
+        },
+        tls: {
+          key: "request-client-key", // pragma: allowlist secret
+        },
+      },
+    });
+
+    const report = await runSecretsAudit({ env: fixture.env });
+    expectModelsFinding(report, {
+      code: "PLAINTEXT_FOUND",
+      jsonPath: "providers.openai.request.headers.Authorization",
+    });
+    expectModelsFinding(report, {
+      code: "PLAINTEXT_FOUND",
+      jsonPath: "providers.openai.request.auth.token",
+    });
+    expectModelsFinding(report, {
+      code: "PLAINTEXT_FOUND",
+      jsonPath: "providers.openai.request.tls.key",
     });
   });
 

--- a/src/secrets/audit.ts
+++ b/src/secrets/audit.ts
@@ -390,42 +390,162 @@ function collectModelsJsonSecrets(params: {
     }
 
     const headers = isRecord(providerValue.headers) ? providerValue.headers : undefined;
-    if (!headers) {
-      continue;
-    }
-    for (const [headerKey, headerValue] of Object.entries(headers)) {
-      const headerPath = `providers.${providerId}.headers.${headerKey}`;
-      if (coerceSecretRef(headerValue)) {
+    if (headers) {
+      for (const [headerKey, headerValue] of Object.entries(headers)) {
+        const headerPath = `providers.${providerId}.headers.${headerKey}`;
+        if (coerceSecretRef(headerValue)) {
+          addFinding(params.collector, {
+            code: "REF_UNRESOLVED",
+            severity: "error",
+            file: params.modelsJsonPath,
+            jsonPath: headerPath,
+            message:
+              "models.json contains an unresolved SecretRef object for provider headers; regenerate models.json.",
+            provider: providerId,
+          });
+          continue;
+        }
+        if (!isNonEmptyString(headerValue)) {
+          continue;
+        }
+        if (isSecretRefHeaderValueMarker(headerValue)) {
+          continue;
+        }
+        if (!isLikelySensitiveModelProviderHeaderName(headerKey)) {
+          continue;
+        }
         addFinding(params.collector, {
-          code: "REF_UNRESOLVED",
-          severity: "error",
+          code: "PLAINTEXT_FOUND",
+          severity: "warn",
           file: params.modelsJsonPath,
           jsonPath: headerPath,
-          message:
-            "models.json contains an unresolved SecretRef object for provider headers; regenerate models.json.",
+          message: "models.json provider header value is stored as plaintext.",
           provider: providerId,
         });
-        continue;
       }
-      if (!isNonEmptyString(headerValue)) {
-        continue;
-      }
-      if (isSecretRefHeaderValueMarker(headerValue)) {
-        continue;
-      }
-      if (!isLikelySensitiveModelProviderHeaderName(headerKey)) {
-        continue;
-      }
-      addFinding(params.collector, {
-        code: "PLAINTEXT_FOUND",
-        severity: "warn",
-        file: params.modelsJsonPath,
-        jsonPath: headerPath,
-        message: "models.json provider header value is stored as plaintext.",
-        provider: providerId,
+    }
+
+    collectModelsJsonRequestSecrets({
+      request: providerValue.request,
+      modelsJsonPath: params.modelsJsonPath,
+      providerId,
+      collector: params.collector,
+    });
+  }
+}
+
+function collectModelsJsonRequestSecretValue(params: {
+  value: unknown;
+  modelsJsonPath: string;
+  jsonPath: string;
+  providerId: string;
+  collector: AuditCollector;
+}): void {
+  if (isNonEmptyString(params.value) && isSecretRefHeaderValueMarker(params.value)) {
+    return;
+  }
+  if (coerceSecretRef(params.value)) {
+    addFinding(params.collector, {
+      code: "REF_UNRESOLVED",
+      severity: "error",
+      file: params.modelsJsonPath,
+      jsonPath: params.jsonPath,
+      message: "models.json contains an unresolved SecretRef object; regenerate models.json.",
+      provider: params.providerId,
+    });
+    return;
+  }
+  if (!isNonEmptyString(params.value)) {
+    return;
+  }
+  addFinding(params.collector, {
+    code: "PLAINTEXT_FOUND",
+    severity: "warn",
+    file: params.modelsJsonPath,
+    jsonPath: params.jsonPath,
+    message: "models.json provider request secret is stored as plaintext.",
+    provider: params.providerId,
+  });
+}
+
+function collectModelsJsonRequestTlsSecrets(params: {
+  tls: unknown;
+  modelsJsonPath: string;
+  jsonPath: string;
+  providerId: string;
+  collector: AuditCollector;
+}): void {
+  if (!isRecord(params.tls)) {
+    return;
+  }
+  for (const key of ["ca", "cert", "key", "passphrase"] as const) {
+    collectModelsJsonRequestSecretValue({
+      value: params.tls[key],
+      modelsJsonPath: params.modelsJsonPath,
+      jsonPath: `${params.jsonPath}.${key}`,
+      providerId: params.providerId,
+      collector: params.collector,
+    });
+  }
+}
+
+function collectModelsJsonRequestSecrets(params: {
+  request: unknown;
+  modelsJsonPath: string;
+  providerId: string;
+  collector: AuditCollector;
+}): void {
+  if (!isRecord(params.request)) {
+    return;
+  }
+  const headers = isRecord(params.request.headers) ? params.request.headers : undefined;
+  if (headers) {
+    for (const [headerKey, headerValue] of Object.entries(headers)) {
+      collectModelsJsonRequestSecretValue({
+        value: headerValue,
+        modelsJsonPath: params.modelsJsonPath,
+        jsonPath: `providers.${params.providerId}.request.headers.${headerKey}`,
+        providerId: params.providerId,
+        collector: params.collector,
       });
     }
   }
+
+  const auth = isRecord(params.request.auth) ? params.request.auth : undefined;
+  if (auth?.mode === "authorization-bearer") {
+    collectModelsJsonRequestSecretValue({
+      value: auth.token,
+      modelsJsonPath: params.modelsJsonPath,
+      jsonPath: `providers.${params.providerId}.request.auth.token`,
+      providerId: params.providerId,
+      collector: params.collector,
+    });
+  } else if (auth?.mode === "header") {
+    collectModelsJsonRequestSecretValue({
+      value: auth.value,
+      modelsJsonPath: params.modelsJsonPath,
+      jsonPath: `providers.${params.providerId}.request.auth.value`,
+      providerId: params.providerId,
+      collector: params.collector,
+    });
+  }
+
+  collectModelsJsonRequestTlsSecrets({
+    tls: params.request.tls,
+    modelsJsonPath: params.modelsJsonPath,
+    jsonPath: `providers.${params.providerId}.request.tls`,
+    providerId: params.providerId,
+    collector: params.collector,
+  });
+
+  const proxy = isRecord(params.request.proxy) ? params.request.proxy : undefined;
+  collectModelsJsonRequestTlsSecrets({
+    tls: proxy?.tls,
+    modelsJsonPath: params.modelsJsonPath,
+    jsonPath: `providers.${params.providerId}.request.proxy.tls`,
+    providerId: params.providerId,
+    collector: params.collector,
+  });
 }
 
 async function collectUnresolvedRefFindings(params: {


### PR DESCRIPTION
## Summary

- Preserve SecretRef markers for nested provider `request` secrets when generating prompt-visible `models.json`, including request headers, auth token/value, TLS material, and proxy TLS material.
- Strip request SecretRef marker strings before inline/discovered provider request config is converted into runtime transport headers/auth/TLS.
- Apply source snapshot markers over resolved runtime values so generated agent config does not persist request-scoped plaintext secrets.
- Extend `openclaw secrets audit` to flag stale generated `models.json` request secrets that may already exist on disk.

## Why

#11829 tracks reducing agent-visible API key exposure. Current main already protects top-level provider `apiKey` and provider `headers`, but `models.providers.*.request.*` is also part of the documented SecretRef credential surface. Without this patch, resolved request header/auth/TLS secrets can still be serialized into `models.json`.

The latest review also identified a downstream risk: once request markers are written into generated `models.json`, the inline/discovered provider path must treat those marker strings as non-secret placeholders, not as outbound transport credentials. This update closes that consumer path.

This is a focused Layer 1 hardening PR. It does not claim to close the full roadmap while plaintext config remains supported.

## Real behavior proof

- **Behavior or issue addressed:** Request-scoped SecretRef markers are preserved in generated prompt-visible models.json snapshots, but are stripped before inline/discovered provider request config becomes runtime transport headers, auth, TLS, or proxy TLS values. This prevents marker placeholders such as secretref-managed and secretref-env:* from being sent as outbound credentials while still avoiding plaintext request secrets in generated config.
- **Real environment tested:** Local OpenClaw repository checkout on macOS, using the real models/secrets/request transport code paths and a temporary runtime config with source SecretRef snapshot data. No live third-party credentials were used; all sensitive example values were redacted placeholders.
- **Exact steps or command run after this patch:** Ran the models.json generation path with a runtime config containing request header/auth/TLS SecretRefs, then passed the generated provider request block through the runtime request sanitizer and inline provider transport attachment path. Also ran a real openclaw secrets audit --json invocation against a temporary generated models.json containing redacted plaintext request residue.
- **Evidence after fix:** Copied live output from the local run showed generated request markers first, then stripped runtime transport config:

```json
{
  "generatedRequestBlock": {
    "headers": {
      "Authorization": "secretref-env:OPENAI_REQUEST_AUTH_HEADER",
      "X-Static": "tenant-a"
    },
    "auth": {
      "mode": "authorization-bearer",
      "token": "secretref-env:OPENAI_REQUEST_BEARER"
    },
    "tls": {
      "key": "secretref-managed",
      "serverName": "api.openai.com"
    }
  },
  "sanitizedRuntimeRequestBlock": {
    "headers": {
      "X-Static": "tenant-a"
    },
    "tls": {
      "serverName": "api.openai.com"
    }
  },
  "inlineProviderTransportValues": {
    "headers": {
      "X-Static": "tenant-a"
    },
    "tls": {
      "serverName": "api.openai.com"
    }
  }
}
```

The audit command output against a temporary generated models.json with redacted plaintext request residue reported the expected request-secret paths:

```json
{
  "auditCommandExitCode": 0,
  "requestSecretFindings": [
    {
      "code": "PLAINTEXT_FOUND",
      "jsonPath": "providers.openai.request.headers.Authorization",
      "severity": "warn"
    },
    {
      "code": "PLAINTEXT_FOUND",
      "jsonPath": "providers.openai.request.auth.token",
      "severity": "warn"
    },
    {
      "code": "PLAINTEXT_FOUND",
      "jsonPath": "providers.openai.request.tls.key",
      "severity": "warn"
    }
  ]
}
```
- **Observed result after fix:** The generated config keeps SecretRef marker placeholders in request-scoped secret fields, runtime transport conversion drops those placeholders before outbound use, static non-secret request metadata remains attached, and the audit command flags stale plaintext request residue in generated models.json.
- **What was not tested:** None

## Validation

```bash
corepack pnpm vitest run src/agents/provider-request-config.test.ts src/agents/pi-embedded-runner/model.inline-provider.test.ts
corepack pnpm vitest run src/agents/models-config.runtime-source-snapshot.test.ts src/secrets/audit.test.ts src/agents/provider-request-config.test.ts src/agents/pi-embedded-runner/model.inline-provider.test.ts
corepack pnpm exec oxlint src/agents/provider-request-config.ts src/agents/provider-request-config.test.ts src/agents/pi-embedded-runner/model.inline-provider.test.ts
corepack pnpm run tsgo:core
corepack pnpm run tsgo:test:src
git diff --check
corepack pnpm run check:changed
corepack pnpm run test:changed
```

Results:

- Targeted request transport regression tests passed: 2 files, 43 tests.
- Related models/secrets/request tests passed: 5 files, 80 tests.
- Oxlint passed with 0 warnings and 0 errors.
- `tsgo:core`, `tsgo:test:src`, `git diff --check`, and `check:changed` passed.
- `test:changed` ran the affected project shards and failed in two unrelated agent tests after 2021 tests passed:
  - `src/agents/cli-runner.reliability.test.ts`
  - `src/agents/subagent-registry.announce-loop-guard.test.ts`

Those two failing tests are outside the changed models/secrets/request transport paths and were previously reproduced on a clean `origin/main` worktree with the same assertions. The focused regression, security/config, lint, type, and changed checks for this PR pass.

Refs #11829

