### PR TITLE
fix(doctor): show Codex native assets as info

### DIFF
--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -251,8 +251,14 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
     });
   } else {
     const { collectDoctorPreviewWarnings } = await import("./doctor/shared/preview-warnings.js");
+    const { collectCodexNativeAssetInfoNotes } =
+      await import("./doctor/shared/codex-native-assets.js");
     emitDoctorNotes({
       note,
+      infoNotes: await collectCodexNativeAssetInfoNotes({
+        cfg: candidate,
+        env: process.env,
+      }),
       warningNotes: await collectDoctorPreviewWarnings({
         cfg: candidate,
         doctorFixCommand,

--- a/src/commands/doctor/emit-notes.test.ts
+++ b/src/commands/doctor/emit-notes.test.ts
@@ -8,12 +8,14 @@ describe("doctor note emission", () => {
     emitDoctorNotes({
       note,
       changeNotes: ["change one", "change two"],
+      infoNotes: ["info one"],
       warningNotes: ["warning one"],
     });
 
     expect(note.mock.calls).toEqual([
       ["change one", "Doctor changes"],
       ["change two", "Doctor changes"],
+      ["info one", "Doctor info"],
       ["warning one", "Doctor warnings"],
     ]);
   });
@@ -52,7 +54,7 @@ describe("doctor note emission", () => {
     const note = vi.fn();
 
     emitDoctorNotes({ note });
-    emitDoctorNotes({ note, changeNotes: [], warningNotes: [] });
+    emitDoctorNotes({ note, changeNotes: [], infoNotes: [], warningNotes: [] });
 
     expect(note).not.toHaveBeenCalled();
   });

--- a/src/commands/doctor/emit-notes.ts
+++ b/src/commands/doctor/emit-notes.ts
@@ -10,10 +10,14 @@ export function sanitizeDoctorNote(note: string): string {
 export function emitDoctorNotes(params: {
   note: (message: string, title?: string) => void;
   changeNotes?: string[];
+  infoNotes?: string[];
   warningNotes?: string[];
 }): void {
   for (const change of params.changeNotes ?? []) {
     params.note(sanitizeDoctorNote(change), "Doctor changes");
+  }
+  for (const info of params.infoNotes ?? []) {
+    params.note(sanitizeDoctorNote(info), "Doctor info");
   }
   for (const warning of params.warningNotes ?? []) {
     params.note(sanitizeDoctorNote(warning), "Doctor warnings");

--- a/src/commands/doctor/shared/codex-native-assets.test.ts
+++ b/src/commands/doctor/shared/codex-native-assets.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
-import { collectCodexNativeAssetWarnings, scanCodexNativeAssets } from "./codex-native-assets.js";
+import { collectCodexNativeAssetInfoNotes, scanCodexNativeAssets } from "./codex-native-assets.js";
 
 const tempRoots = new Set<string>();
 
@@ -107,18 +107,18 @@ describe("scanCodexNativeAssets", () => {
   });
 });
 
-describe("collectCodexNativeAssetWarnings", () => {
-  it("points users at explicit Codex migration instead of auto-copying native assets", async () => {
+describe("collectCodexNativeAssetInfoNotes", () => {
+  it("points users at explicit Codex migration without classifying native assets as warnings", async () => {
     const root = await makeTempRoot();
     const codexHome = path.join(root, ".codex");
     await writeFile(path.join(root, ".agents", "skills", "agent-helper", "SKILL.md"));
 
-    const warnings = await collectCodexNativeAssetWarnings({
+    const infoNotes = await collectCodexNativeAssetInfoNotes({
       cfg: codexConfig(),
       env: { CODEX_HOME: codexHome, HOME: root },
     });
 
-    expect(warnings).toStrictEqual([
+    expect(infoNotes).toStrictEqual([
       [
         "- Personal Codex CLI assets were found, but native Codex-mode OpenClaw agents use isolated per-agent Codex homes.",
         `- Sources: ${codexHome} and ${path.join(root, ".agents", "skills")} (1 skill, 0 plugins, 0 config files, 0 hook files).`,

--- a/src/commands/doctor/shared/codex-native-assets.ts
+++ b/src/commands/doctor/shared/codex-native-assets.ts
@@ -181,7 +181,7 @@ function plural(count: number, singular: string): string {
   return `${count} ${singular}${count === 1 ? "" : "s"}`;
 }
 
-export async function collectCodexNativeAssetWarnings(params: {
+export async function collectCodexNativeAssetInfoNotes(params: {
   cfg: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
 }): Promise<string[]> {

--- a/src/commands/doctor/shared/preview-warnings.ts
+++ b/src/commands/doctor/shared/preview-warnings.ts
@@ -436,8 +436,6 @@ export async function collectDoctorPreviewWarnings(params: {
     const { collectCodexRouteWarnings } = await import("./codex-route-warnings.js");
     warnings.push(...collectCodexRouteWarnings({ cfg: params.cfg, env }));
   }
-  const { collectCodexNativeAssetWarnings } = await import("./codex-native-assets.js");
-  warnings.push(...(await collectCodexNativeAssetWarnings({ cfg: params.cfg, env })));
 
   if (hasPluginLoadPaths(params.cfg)) {
     const { collectBundledPluginLoadPathWarnings, scanBundledPluginLoadPathMigrations } =


### PR DESCRIPTION
## Summary

- Move the personal Codex CLI asset notice out of the doctor warning collector.
- Add a `Doctor info` note lane and emit the Codex native asset notice there during doctor preview runs.
- Keep the existing scan and migration guidance unchanged.

Fixes #84859

## Real behavior proof

- **Behavior addressed:** `openclaw doctor` preview routed the personal Codex CLI asset notice through `collectDoctorPreviewWarnings()`, so it rendered under `Doctor warnings` even though the notice is informational and not a lint finding.
- **Real environment tested:** Local OpenClaw source checkout on Linux, Node v22.22.0, branch `fix-doctor-codex-assets-info-84859` at commit `76cc15cf4220045dd6044e3988385b28a3b4e20c`.
- **Exact steps or command run after this patch:** Ran the patched note emitter and the patched doctor preview collectors directly with `npx tsx --eval`, using a temporary `CODEX_HOME`/`HOME` containing a personal `.agents/skills/agent-helper/SKILL.md` asset. Also ran the focused command test shard.
- **Evidence after fix:**
  ```text
  $ npx tsx --eval "import { emitDoctorNotes } from './src/commands/doctor/emit-notes.ts'; const calls = []; emitDoctorNotes({ note: (message, title) => calls.push([title, message]), infoNotes: ['- Personal Codex CLI assets were found.'], warningNotes: [] }); console.log(JSON.stringify(calls)); if (calls[0]?.[0] !== 'Doctor info') process.exit(1);"
  [["Doctor info","- Personal Codex CLI assets were found."]]
  
  $ CODEX_HOME="$tmp/.codex" HOME="$tmp" npx tsx --eval "...collectCodexNativeAssetInfoNotes + collectDoctorPreviewWarnings..."
  {"infoTitle":"- Personal Codex CLI assets were found, but native Codex-mode OpenClaw agents use isolated per-agent Codex homes.","infoCount":1,"warningContainsCodexAssets":false}
  
  $ node scripts/test-projects.mjs src/commands/doctor/emit-notes.test.ts src/commands/doctor/shared/codex-native-assets.test.ts src/commands/doctor/shared/preview-warnings.test.ts
  Test Files  3 passed (3)
  Tests  33 passed (33)
  ```
- **Observed result after fix:** Codex native asset text is emitted on the `Doctor info` lane, `collectDoctorPreviewWarnings()` no longer contains the personal Codex asset message, and the focused command tests pass.
- **What was not tested:** Full interactive `openclaw doctor` terminal rendering was not run; this patch verifies the shared note emitter and doctor preview collectors that feed that output.

## Typecheck

```text
$ NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit 2>&1 | rg 'src/commands/doctor-config-flow.ts|src/commands/doctor/emit-notes.ts|src/commands/doctor/shared/codex-native-assets.ts|src/commands/doctor/shared/preview-warnings.ts' || true
<no output>
```

## Scope

- No scan behavior changes.
- No migration behavior changes.
- No lint/check-ID behavior changes.