### PR TITLE
fix(codex): restore restricted dynamic tool fallbacks

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -726,6 +726,95 @@ describe("runCodexAppServerAttempt", () => {
     expect(testing.resolveCodexDynamicToolsLoading({}, privateQaCodexEnv)).toBe("direct");
   });
 
+  it("exposes restricted OpenClaw exec fallbacks when native Code Mode is disabled", async () => {
+    testing.setOpenClawCodingToolsFactoryForTests(() => [
+      createRuntimeDynamicTool("read"),
+      createRuntimeDynamicTool("exec"),
+      createRuntimeDynamicTool("process"),
+      createRuntimeDynamicTool("message"),
+    ]);
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(sessionFile, workspaceDir);
+    params.disableTools = false;
+    params.runtimePlan = createCodexRuntimePlanFixture();
+    params.toolsAllow = ["exec"];
+
+    const tools = await testing.buildDynamicTools({
+      params,
+      resolvedWorkspace: workspaceDir,
+      effectiveWorkspace: workspaceDir,
+      sandboxSessionKey: params.sessionKey!,
+      sandbox: null as never,
+      nativeToolSurfaceEnabled: false,
+      runAbortController: new AbortController(),
+      sessionAgentId: "main",
+      pluginConfig: {},
+      onYieldDetected: () => undefined,
+    });
+
+    expect(tools.map((tool) => tool.name)).toEqual(["exec", "process"]);
+  });
+
+  it("keeps restricted OpenClaw native fallbacks scoped to the runtime allowlist", async () => {
+    testing.setOpenClawCodingToolsFactoryForTests(() => [
+      createRuntimeDynamicTool("read"),
+      createRuntimeDynamicTool("exec"),
+      createRuntimeDynamicTool("process"),
+      createRuntimeDynamicTool("message"),
+    ]);
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(sessionFile, workspaceDir);
+    params.disableTools = false;
+    params.runtimePlan = createCodexRuntimePlanFixture();
+    params.toolsAllow = ["read"];
+
+    const tools = await testing.buildDynamicTools({
+      params,
+      resolvedWorkspace: workspaceDir,
+      effectiveWorkspace: workspaceDir,
+      sandboxSessionKey: params.sessionKey!,
+      sandbox: null as never,
+      nativeToolSurfaceEnabled: false,
+      runAbortController: new AbortController(),
+      sessionAgentId: "main",
+      pluginConfig: {},
+      onYieldDetected: () => undefined,
+    });
+
+    expect(tools.map((tool) => tool.name)).toEqual(["read"]);
+  });
+
+  it("respects explicit Codex dynamic tool excludes for restricted native fallbacks", async () => {
+    testing.setOpenClawCodingToolsFactoryForTests(() => [
+      createRuntimeDynamicTool("exec"),
+      createRuntimeDynamicTool("process"),
+      createRuntimeDynamicTool("message"),
+    ]);
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(sessionFile, workspaceDir);
+    params.disableTools = false;
+    params.runtimePlan = createCodexRuntimePlanFixture();
+    params.toolsAllow = ["exec"];
+
+    const tools = await testing.buildDynamicTools({
+      params,
+      resolvedWorkspace: workspaceDir,
+      effectiveWorkspace: workspaceDir,
+      sandboxSessionKey: params.sessionKey!,
+      sandbox: null as never,
+      nativeToolSurfaceEnabled: false,
+      runAbortController: new AbortController(),
+      sessionAgentId: "main",
+      pluginConfig: { codexDynamicToolsExclude: ["exec"] } as never,
+      onYieldDetected: () => undefined,
+    });
+
+    expect(tools.map((tool) => tool.name)).toEqual([]);
+  });
+
   it("exposes OpenClaw sandbox shell tools under distinct names for non-Docker sandbox backends", async () => {
     testing.setOpenClawCodingToolsFactoryForTests(() => [
       createRuntimeDynamicTool("read"),

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -3394,16 +3394,21 @@ async function buildDynamicTools(input: DynamicToolBuildParams) {
       input.runAbortController.abort("sessions_yield");
     },
   });
-  const codexFilteredTools = addSandboxShellDynamicToolsIfAvailable(
-    filterCodexDynamicTools(allTools, input.pluginConfig),
+  const toolsAllow = includeForcedMessageToolAllow(params.toolsAllow, params);
+  const codexFilteredTools = addRestrictedNativeToolDynamicFallbacksIfNeeded(
+    addSandboxShellDynamicToolsIfAvailable(
+      filterCodexDynamicTools(allTools, input.pluginConfig),
+      allTools,
+      input,
+    ),
     allTools,
     input,
+    toolsAllow,
   );
   const visionFilteredTools = filterToolsForVisionInputs(codexFilteredTools, {
     modelHasVision,
     hasInboundImages: (params.images?.length ?? 0) > 0,
   });
-  const toolsAllow = includeForcedMessageToolAllow(params.toolsAllow, params);
   const filteredTools = filterCodexDynamicToolsForAllowlist(visionFilteredTools, toolsAllow);
   return normalizeAgentRuntimeTools({
     runtimePlan: params.runtimePlan,
@@ -3525,6 +3530,62 @@ function addSandboxShellDynamicToolsIfAvailable(
   return [...filteredTools, sandboxExecTool, sandboxProcessTool];
 }
 
+const RESTRICTED_NATIVE_TOOL_DYNAMIC_FALLBACKS = [
+  "read",
+  "write",
+  "edit",
+  "apply_patch",
+  "exec",
+  "process",
+  "update_plan",
+] as const;
+
+function addRestrictedNativeToolDynamicFallbacksIfNeeded(
+  filteredTools: OpenClawDynamicTool[],
+  allTools: OpenClawDynamicTool[],
+  input: DynamicToolBuildParams,
+  toolsAllow: string[] | undefined,
+): OpenClawDynamicTool[] {
+  if (input.nativeToolSurfaceEnabled !== false || !toolsAllow || toolsAllow.length === 0) {
+    return filteredTools;
+  }
+  const allowSet = new Set(
+    toolsAllow.map((name) => normalizeCodexDynamicToolName(name)).filter(Boolean),
+  );
+  if (allowSet.size === 0 || hasWildcardCodexToolsAllow(toolsAllow)) {
+    return filteredTools;
+  }
+  const explicitExcludes = new Set(
+    (input.pluginConfig.codexDynamicToolsExclude ?? [])
+      .map((name) => normalizeCodexDynamicToolName(name))
+      .filter(Boolean),
+  );
+  const existingNames = new Set(
+    filteredTools.map((tool) => normalizeCodexDynamicToolName(tool.name)),
+  );
+  const fallbackNames = new Set<string>();
+  for (const name of RESTRICTED_NATIVE_TOOL_DYNAMIC_FALLBACKS) {
+    if (allowSet.has(name)) {
+      fallbackNames.add(name);
+    }
+  }
+  if (allowSet.has("exec") && !explicitExcludes.has("exec") && !explicitExcludes.has("process")) {
+    fallbackNames.add("process");
+  }
+  if (fallbackNames.size === 0) {
+    return filteredTools;
+  }
+  const fallbackTools = allTools.filter((tool) => {
+    const normalized = normalizeCodexDynamicToolName(tool.name);
+    return (
+      fallbackNames.has(normalized) &&
+      !existingNames.has(normalized) &&
+      !explicitExcludes.has(normalized)
+    );
+  });
+  return fallbackTools.length === 0 ? filteredTools : [...filteredTools, ...fallbackTools];
+}
+
 function shouldExposeSandboxExecDynamicTool(input: DynamicToolBuildParams): boolean {
   const backendId = input.sandbox?.enabled ? input.sandbox.backendId.trim().toLowerCase() : "";
   return Boolean(backendId && (backendId !== "docker" || input.nativeToolSurfaceEnabled === false));
@@ -3562,6 +3623,7 @@ function filterCodexDynamicToolsForAllowlist<T extends { name: string }>(
     const normalized = normalizeCodexDynamicToolName(tool.name);
     return (
       allowSet.has(normalized) ||
+      (normalized === "process" && allowSet.has("exec")) ||
       (normalized === "sandbox_exec" && allowSet.has("exec")) ||
       (normalized === "sandbox_process" && (allowSet.has("exec") || allowSet.has("process")))
     );


### PR DESCRIPTION
## Summary

- Problem: Codex app-server disables its native tool surface for restricted runtime allowlists such as `toolsAllow: ["exec"]`, but the Codex dynamic tool filter also removed the OpenClaw `exec` fallback.
- Solution: When the native surface is disabled and a restricted allowlist explicitly asks for an app-server-owned tool, add back only that OpenClaw dynamic fallback.
- What changed: `exec` allowlists now expose `exec` plus its `process` follow-up; other restricted fallbacks such as `read` stay scoped to the allowlist; explicit `codexDynamicToolsExclude` still wins.
- What did NOT change (scope boundary): This does not enable the broad native Codex shell/file surface for narrow allowlists, and it does not change cron scheduling or recovered-tool-call outcome handling.

AI-assisted PR: yes, authored with Codex under human direction.

## Motivation

- OpenClaw cron jobs that set narrow tool allowlists, especially shell-oriented jobs with `toolsAllow: ["exec"]`, can start without any usable shell tool. That makes scheduled jobs look like shell access was denied even though the cron intended to allow shell execution.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: A cron/agent run with `toolsAllow: ["exec"]` could lose shell access because native Code Mode failed closed and the dynamic `exec` fallback was filtered out.
- Real environment tested: macOS local OpenClaw setup, Codex provider, OpenClaw `2026.5.20-beta.1` for the observed cron failure; upstream source checkout on this branch for the patched codepath.
- Exact steps or command run after this patch:
  - Real source-checkout CLI smoke: `node --import tsx src/entry.ts cron add --help | sed -n '1,80p'`
  - Tool-builder regression guard: `CI=true node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts extensions/codex/src/app-server/run-attempt.test.ts -t "restricted OpenClaw|native tool surfaces for restricted|normalizes Codex dynamic toolsAllow"`
  - Changed-lane validation: `CI=true pnpm check:changed`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):
  - Copied console output from patched source checkout:

    ```text
    OpenClaw 2026.5.20 (9304975) — All your chats, one OpenClaw.

    Usage: openclaw cron add|create [options]

    Add a cron job

    Options:
      --message <text>       Agent message payload
      --model <model>        Model override for agent jobs (provider/model or alias)
      --name <name>          Job name
      --tools <list>         Tool allow-list (e.g. exec,read,write or exec read write)
    ```

  - Targeted tool-builder output: `Test Files 1 passed (1); Tests 4 passed | 185 skipped (189)`
  - Changed checks output: `Found 0 warnings and 0 errors`; `runtime-sidecar-loaders: local runtime sidecar loaders look OK`; `Import cycle check: 0 runtime value cycle(s).`
- Observed result after fix: The restricted `exec` scenario builds dynamic tools `exec` and `process`; the restricted `read` scenario exposes only `read`; explicit dynamic-tool excludes prevent the fallback from being restored.
- What was not tested: I did not run a live patched cron against a real model from this source checkout. A full `run-attempt.test.ts` run also hit two existing-looking auth-binding failures outside the changed tool-building path, listed under Human Verification.
- Before evidence (optional but encouraged): In the live OpenClaw setup before this patch, a disposable cron without `toolsAllow` returned `SMOKE_OK:cron-shell-ok`; the same cron shape with `toolsAllow: ["exec"]` returned `SMOKE_NO_SHELL`, matching the upstream codepath where native tools were disabled and dynamic `exec` was filtered out.

## Root Cause (if applicable)

- Root cause: Restricted runtime allowlists intentionally disable Codex app-server native Code Mode because that surface cannot represent only one narrow OpenClaw tool. Separately, Codex dynamic tool filtering removed app-server-owned tools such as `exec`, `process`, and `read` by default. Combined, `toolsAllow: ["exec"]` produced no shell surface at all.
- Missing detection / guardrail: Existing tests covered native-surface disabling and allowlist normalization separately, but not the combined restricted-native-disabled fallback path.
- Contributing context (if known): Cron jobs often use narrow allowlists for safety, which made this more visible in scheduled jobs than in broad interactive runs.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/codex/src/app-server/run-attempt.test.ts`
- Scenario the test should lock in: Native Code Mode disabled plus restricted `toolsAllow` restores only explicitly allowed OpenClaw dynamic fallbacks.
- Why this is the smallest reliable guardrail: The bug is in dynamic tool construction before a model turn starts, so the app-server tool builder test catches the exact regression without needing a live model.
- Existing test that already covers this (if any): Existing tests covered sandbox shell fallbacks, allowlist normalization, and native surface disabling, but not this combined restricted fallback case.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Cron or agent runs that explicitly allow `exec` while Codex native tools are disabled now receive the OpenClaw `exec` fallback and its `process` follow-up instead of having no shell tool.

## Diagram (if applicable)

```text
Before:
toolsAllow: ["exec"] -> native Code Mode disabled -> dynamic exec filtered -> no shell

After:
toolsAllow: ["exec"] -> native Code Mode disabled -> dynamic exec/process fallback -> shell works within the allowlist
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) Yes
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation: This restores only tools explicitly requested by the runtime allowlist when the broad native surface is disabled. It does not widen `message`/`web_search` into shell/file access, keeps wildcard behavior unchanged, and respects explicit `codexDynamicToolsExclude` config.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local source checkout, pnpm workspace
- Model/provider: Codex provider codepath; no live patched model turn run
- Integration/channel (if any): Cron failure observed from Gateway cron path
- Relevant config (redacted): cron/agent runtime with `toolsAllow: ["exec"]`

### Steps

1. Configure a Codex run or cron with restricted `toolsAllow: ["exec"]`.
2. Ensure Codex native Code Mode is disabled for the run because the allowlist is restricted.
3. Build the dynamic tool list.

### Expected

- The run receives the OpenClaw `exec` dynamic fallback and `process` follow-up.

### Actual

- Before this patch, the run received neither native shell nor dynamic `exec`.
- After this patch, the restricted fallback tests return `exec` and `process` for `toolsAllow: ["exec"]`.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `CI=true node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts extensions/codex/src/app-server/run-attempt.test.ts -t "restricted OpenClaw|native tool surfaces for restricted|normalizes Codex dynamic toolsAllow"` passed with 4 tests.
  - `pnpm exec oxfmt --check extensions/codex/src/app-server/run-attempt.ts extensions/codex/src/app-server/run-attempt.test.ts` passed.
  - `CI=true pnpm check:changed` passed.
- Edge cases checked:
  - `toolsAllow: ["read"]` does not expose shell or message.
  - `codexDynamicToolsExclude: ["exec"]` keeps the fallback disabled.
  - Existing native-surface restricted allowlist behavior remains fail-closed.
- What you did **not** verify:
  - I did not run the full repository `pnpm build && pnpm check && pnpm test` suite.
  - A full single-file run, `CI=true node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts extensions/codex/src/app-server/run-attempt.test.ts`, had 187 passing tests and 2 failures in auth-binding tests (`preserves bound auth when rotating an over-budget native rollout`, `reuses the bound auth profile for app-server startup when params omit it`). Those failures are outside the touched dynamic tool path; the targeted tests and `check:changed` passed afterward.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Restoring dynamic fallbacks could expose broader tools than intended for restricted runs.
  - Mitigation: The fallback path activates only when native tools are disabled and the runtime allowlist explicitly includes the normalized tool name. Explicit dynamic-tool excludes still take precedence.

