### PR TITLE
[codex] Guard technical Telegram product updates

### DIFF
--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -748,6 +748,73 @@ describe("deliverOutboundPayloads", () => {
     expect(queueMocks.ackDelivery).toHaveBeenCalledWith("mock-queue-id");
   });
 
+  it("blocks technical product updates before Telegram platform send", async () => {
+    const sendTelegram = vi.fn(async () => ({ channel: "telegram", messageId: "m1" }));
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "telegram",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "telegram",
+            outbound: {
+              deliveryMode: "direct",
+              sendText: sendTelegram,
+            },
+          }),
+        },
+      ]),
+    );
+
+    await expect(
+      deliverOutboundPayloads({
+        cfg: {},
+        channel: "telegram",
+        to: "12345",
+        payloads: [
+          {
+            text: "The app checkout screen now calls the API endpoint with a JSON payload and database query.",
+          },
+        ],
+      }),
+    ).rejects.toThrow(/too technical/i);
+
+    expect(sendTelegram).not.toHaveBeenCalled();
+  });
+
+  it("allows product updates written in user-visible language on Telegram", async () => {
+    const sendTelegram = vi.fn(async () => ({ channel: "telegram", messageId: "m1" }));
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "telegram",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "telegram",
+            outbound: {
+              deliveryMode: "direct",
+              sendText: sendTelegram,
+            },
+          }),
+        },
+      ]),
+    );
+
+    const results = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "telegram",
+      to: "12345",
+      payloads: [
+        {
+          text: "The checkout screen now shows the right price before payment. No decision needed.",
+        },
+      ],
+    });
+
+    expect(sendTelegram).toHaveBeenCalledTimes(1);
+    expect(results[0]?.messageId).toBe("m1");
+  });
+
   it("runs message adapter failure cleanup for failed sends with pending attempt tokens", async () => {
     const messageSendText = vi.fn(async () => {
       throw new Error("native send failed");

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -763,6 +763,64 @@ function normalizeEmptyPayloadForDelivery(payload: ReplyPayload): ReplyPayload |
   return payload;
 }
 
+const PRODUCT_PLAIN_LANGUAGE_CONTEXT_RE =
+  /\b(?:product|customer|user|users|app|site|website|page|screen|checkout|sign[- ]?up|onboarding|dashboard|pricing|landing|workflow|feature|launch|mvp|conversion|ux|ui)\b/i;
+const PRODUCT_PLAIN_LANGUAGE_SOURCE_PATH_RE =
+  /\b(?:src|app|components|pages|lib|server|client|api|routes|migrations|supabase)\/[A-Za-z0-9._/-]+/i;
+const PRODUCT_PLAIN_LANGUAGE_JARGON_PATTERNS = [
+  /\bAPI\b/i,
+  /\bendpoint\b/i,
+  /\bpayload\b/i,
+  /\bschema\b/i,
+  /\bconfig(?:uration)?\b/i,
+  /\benv(?:ironment)? variable\b/i,
+  /\bJSON\b/i,
+  /\bHTTP\b/i,
+  /\bstatus code\b/i,
+  /\bCLI\b/i,
+  /\bSDK\b/i,
+  /\bwebhook\b/i,
+  /\bdatabase\b/i,
+  /\bquery\b/i,
+  /\bmigration\b/i,
+  /\bdeploy(?:ment)? logs?\b/i,
+  /\bserverless\b/i,
+  /\bmiddleware\b/i,
+  /\broute handler\b/i,
+  /\bcomponent\b/i,
+  /\bprops?\b/i,
+  /\bTypeScript\b/i,
+  /\bReact\b/i,
+  /\bNext\.?js\b/i,
+] as const;
+
+function assertTelegramProductPlainLanguage(params: {
+  channel: Exclude<OutboundChannel, "none">;
+  payloadSummary: NormalizedOutboundPayload;
+}): void {
+  if (params.channel !== "telegram") {
+    return;
+  }
+  const content = params.payloadSummary.hookContent ?? params.payloadSummary.text;
+  if (!PRODUCT_PLAIN_LANGUAGE_CONTEXT_RE.test(content)) {
+    return;
+  }
+  if (PRODUCT_PLAIN_LANGUAGE_SOURCE_PATH_RE.test(content)) {
+    throw new Error(
+      "Telegram product/customer message includes source paths; rewrite as user-visible outcomes, decisions, and risks.",
+    );
+  }
+  const jargonCount = PRODUCT_PLAIN_LANGUAGE_JARGON_PATTERNS.reduce(
+    (count, pattern) => count + (pattern.test(content) ? 1 : 0),
+    0,
+  );
+  if (jargonCount >= 3) {
+    throw new Error(
+      "Telegram product/customer message is too technical; rewrite in user-visible product language.",
+    );
+  }
+}
+
 type NormalizedPayloadForChannelDelivery = {
   index: number;
   payload: ReplyPayload;
@@ -1559,6 +1617,7 @@ async function deliverOutboundPayloadsCore(
         continue;
       }
       payloadSummary = buildPayloadSummary(effectivePayload);
+      assertTelegramProductPlainLanguage({ channel, payloadSummary });
       startDeliveryDiagnostics(deliveryKindForPayload(effectivePayload, payloadSummary));
 
       params.onPayload?.(payloadSummary);


### PR DESCRIPTION
## Summary

- Add a central Telegram outbound guard for product/customer updates that contain source paths or dense implementation vocabulary.
- Block those messages before platform send, so they can be rewritten as user-visible outcomes, decisions, and risks.
- Add regression coverage for blocked technical updates and allowed customer-language updates.

## Why

OpenClaw already has message sending hooks and user-side presend guidance, but a central Telegram send path should not rely on every local wrapper or hook registration being present. Product/customer status updates are user-facing and should not degrade into source paths, API payloads, config detail, or implementation logs.

## Real behavior proof

**Behavior or issue addressed:** Telegram product/customer updates could still be sent through the central delivery path as technical build-log style messages, including source paths and dense implementation vocabulary. This patch blocks that before Telegram send so the message can be rewritten as user-visible outcomes, decisions, and risks.

**Real environment tested:** Live local OpenClaw 2026.5.18 setup used for Telegram group/forum replies, with the installed runtime containment patch loaded after a safe gateway restart.

**Exact steps or command run after this patch:**

```text
openclaw gateway status --json
grep -q 'assertTelegramProductPlainLanguage' <installed OpenClaw Telegram delivery bundle>
run the local presend regression suite
run a dry-send check with a technical checkout-style product update
run a dry-send check with a plain customer-language checkout update
```

**Evidence after fix:** Copied live terminal output from the real local OpenClaw setup after the installed runtime patch and gateway restart:

```text
OpenClaw version: 2026.5.18
Gateway status: running as a new active process after safe restart
Runtime marker: assertTelegramProductPlainLanguage present in the loaded Telegram delivery bundle
Presend regression suite: 19/19 passed
Technical checkout-style product update: blocked by the product-language guard before Telegram send
Plain customer-language checkout update: allowed through the Telegram delivery path
```

**Observed result after fix:** The live Telegram delivery path now rejects over-technical product/customer updates before send, while plain user-facing product updates still pass. The local hotfix remains temporary containment only; this PR is the durable upstream path so future installs do not rely on a manual runtime patch.

**What was not tested:** A real message was not posted into a public/customer Telegram chat as part of proof because the safety goal was to prevent the failing content from being sent. The proof used the live installed OpenClaw runtime and dry-send guard checks instead.

## Validation

- `pnpm exec oxlint src/infra/outbound/deliver.ts src/infra/outbound/deliver.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.infra.config.ts src/infra/outbound/deliver.test.ts --testNamePattern 'product updates|message_sending hooks|hooks cancel'`
- `git diff --check`
