### PR TITLE
fix #84857: skip CLI runtime harness preflight during compaction

### DIFF
--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -597,6 +597,20 @@ describe("selectAgentHarness", () => {
     ).toBe("codex");
   });
 
+  it("skips harness compaction preflight for claude-cli runtime sessions", async () => {
+    await expect(
+      maybeCompactAgentHarnessSession({
+        sessionId: "session-1",
+        sessionKey: "agent:main:main",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: "/tmp/workspace",
+        provider: "anthropic",
+        model: "claude-opus-4-7",
+        config: agentModelRuntimeConfig("anthropic/claude-opus-4-7", "claude-cli"),
+      }),
+    ).resolves.toBeUndefined();
+  });
+
   it("does not compact a plugin-pinned session through PI when the plugin has no compactor", async () => {
     registerFailingCodexHarness();
 

--- a/src/agents/harness/selection.ts
+++ b/src/agents/harness/selection.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { isCliRuntimeAlias } from "../model-runtime-aliases.js";
 import type { CompactEmbeddedPiSessionParams } from "../pi-embedded-runner/compact.types.js";
 import type {
   EmbeddedRunAttemptParams,
@@ -442,6 +443,15 @@ function logAgentHarnessSelection(
 export async function maybeCompactAgentHarnessSession(
   params: CompactEmbeddedPiSessionParams,
 ): Promise<EmbeddedPiCompactResult | undefined> {
+  const runtime = resolveConfiguredAgentHarnessPolicy({
+    provider: params.provider,
+    modelId: params.model,
+    config: params.config,
+    sessionKey: params.sessionKey,
+  }).runtime;
+  if (isCliRuntimeAlias(runtime)) {
+    return undefined;
+  }
   const harness = selectAgentHarness({
     provider: params.provider ?? "",
     modelId: params.model,


### PR DESCRIPTION
## Summary

- Problem: compaction preflight routes `claude-cli` runtime sessions through harness selection and throws `MissingAgentHarnessError`, so over-threshold sessions fail before dispatch and leak the warning text back to users.
- Solution: skip harness compaction preflight when the resolved runtime is a CLI runtime alias.
- What changed: added a CLI runtime bypass in `src/agents/harness/selection.ts` and locked it in with a regression test in `src/agents/harness/selection.test.ts`.
- What did NOT change: no changes to normal harness selection, non-CLI compaction behavior, or runtime policy resolution.

Fixes #84857

## Real behavior proof
- **Behavior or issue addressed:** compaction preflight no longer throws `MissingAgentHarnessError(\"claude-cli\")` for `claude-cli` runtime sessions, which avoids user-visible warning replies and lets the queued compaction path continue.
- **Real environment tested:** Linux 4.19.112-2.el8.x86_64 x86_64 GNU/Linux, Node v22.22.0, OpenClaw v2026.5.20, worktree SHA 79d2597
- **Exact steps or command run after this patch:**
  ```bash
  pnpm install --frozen-lockfile
  node --import tsx <<'EOF'
  import { maybeCompactAgentHarnessSession } from './src/agents/harness/selection.ts';

  const config = {
    agents: {
      defaults: {
        models: {
          'anthropic/claude-opus-4-7': {
            agentRuntime: { id: 'claude-cli' },
          },
        },
      },
    },
  };

  const result = await maybeCompactAgentHarnessSession({
    sessionId: 'session-1',
    sessionKey: 'agent:main:main',
    sessionFile: '/tmp/session.jsonl',
    workspaceDir: '/tmp/workspace',
    provider: 'anthropic',
    model: 'claude-opus-4-7',
    config,
  });

  console.log('RESULT', result === undefined ? 'undefined' : JSON.stringify(result));
  EOF
  npx vitest run src/agents/harness/selection.test.ts
  ```
- **Evidence after fix:**
  ```text
  RESULT undefined

   RUN  v4.1.6 /media/vdc/code/ai/openclaw-84857

   Test Files  2 passed (2)
        Tests  54 passed (54)
     Start at  16:08:07
     Duration  5.37s (transform 2.21s, setup 566ms, import 4.08s, tests 177ms, environment 0ms)
  ```
- **Observed result after fix:** the compaction preflight returns `undefined` instead of throwing `MissingAgentHarnessError`, so the caller can continue into the non-harness compaction path; the regression test covering the `claude-cli` runtime case now passes.
- **What was not tested:** no known gaps

## Regression Test Plan

- Coverage level: Unit test
- Target test file: `src/agents/harness/selection.test.ts`
- Scenario locked in: `maybeCompactAgentHarnessSession` returns `undefined` instead of throwing when the resolved model runtime is `claude-cli`.
- Why this is the smallest reliable guardrail: the failure happens before any live channel or model dispatch, so a focused unit test on the preflight helper covers the exact regression with minimal setup.

## Root Cause

- Root cause: `maybeCompactAgentHarnessSession` unconditionally called `selectAgentHarness`, so model runtime policy values like `claude-cli` were treated as harness ids and triggered `MissingAgentHarnessError`.
- Missing detection / guardrail: compaction preflight lacked the CLI-runtime bypass already present in the main dispatch/fallback path.