### PR TITLE
fix: audit config backups for plaintext secrets

### DIFF
--- a/src/secrets/audit.test.ts
+++ b/src/secrets/audit.test.ts
@@ -251,6 +251,34 @@ describe("secrets audit", () => {
     expectFindingCode(report, "PLAINTEXT_FOUND");
   });
 
+  it("reports plaintext secrets left in config backup files", async () => {
+    const backupPath = `${fixture.configPath}.pre-secret-migration`;
+    await writeJsonFile(backupPath, {
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://api.openai.com/v1",
+            api: "openai-completions",
+            apiKey: "sk-backup...text",
+            models: [{ id: "gpt-5", name: "gpt-5" }],
+          },
+        },
+      },
+    });
+
+    const report = await runSecretsAudit({ env: fixture.env });
+    expectFindingFile(report, backupPath);
+    expect(
+      hasFinding(
+        report,
+        (entry) =>
+          entry.code === "PLAINTEXT_FOUND" &&
+          entry.file === backupPath &&
+          entry.jsonPath === "models.providers.openai.apiKey",
+      ),
+    ).toBe(true);
+  });
+
   it("does not mutate legacy auth.json during audit", async () => {
     await fs.rm(fixture.authStorePath, { force: true });
     await writeJsonFile(fixture.authJsonPath, {

--- a/src/secrets/audit.ts
+++ b/src/secrets/audit.ts
@@ -32,6 +32,7 @@ import { isNonEmptyString, isRecord } from "./shared.js";
 import {
   listAgentModelsJsonPaths,
   listAuthProfileStorePaths,
+  listConfigBackupPaths,
   listLegacyAuthJsonPaths,
   parseEnvAssignmentValue,
   readJsonObjectIfExists,
@@ -223,6 +224,32 @@ function collectConfigSecrets(params: {
       provider: target.providerId,
     });
   }
+}
+
+function collectConfigBackupSecrets(params: {
+  backupPath: string;
+  collector: AuditCollector;
+}): void {
+  const parsedResult = readJsonObjectIfExists(params.backupPath, { requireRegularFile: true });
+  params.collector.filesScanned.add(params.backupPath);
+  if (parsedResult.error) {
+    addFinding(params.collector, {
+      code: "REF_UNRESOLVED",
+      severity: "error",
+      file: params.backupPath,
+      jsonPath: "<root>",
+      message: `Invalid JSON in config backup: ${parsedResult.error}`,
+    });
+    return;
+  }
+  if (!parsedResult.value) {
+    return;
+  }
+  collectConfigSecrets({
+    config: parsedResult.value as OpenClawConfig,
+    configPath: params.backupPath,
+    collector: params.collector,
+  });
 }
 
 function collectAuthStoreSecrets(params: {
@@ -642,6 +669,12 @@ export async function runSecretsAudit(
       configPath,
       collector,
     });
+    for (const backupPath of listConfigBackupPaths(configPath)) {
+      collectConfigBackupSecrets({
+        backupPath,
+        collector,
+      });
+    }
     for (const authStorePath of listAuthProfileStorePaths(config, stateDir)) {
       collectAuthStoreSecrets({
         authStorePath,

--- a/src/secrets/storage-scan.ts
+++ b/src/secrets/storage-scan.ts
@@ -37,6 +37,27 @@ export function listLegacyAuthJsonPaths(stateDir: string): string[] {
   return out;
 }
 
+export function listConfigBackupPaths(configPath: string): string[] {
+  const resolvedConfigPath = resolveUserPath(configPath);
+  const configDir = path.dirname(resolvedConfigPath);
+  const configBase = path.basename(resolvedConfigPath);
+  if (!fs.existsSync(configDir)) {
+    return [];
+  }
+
+  const backups: string[] = [];
+  for (const entry of fs.readdirSync(configDir, { withFileTypes: true })) {
+    if (!entry.isFile()) {
+      continue;
+    }
+    if (entry.name === configBase || !entry.name.startsWith(`${configBase}.`)) {
+      continue;
+    }
+    backups.push(path.join(configDir, entry.name));
+  }
+  return backups;
+}
+
 function resolveActiveAgentDir(stateDir: string, env: NodeJS.ProcessEnv = process.env): string {
   const override = env.OPENCLAW_AGENT_DIR?.trim() || env.PI_CODING_AGENT_DIR?.trim();
   if (override) {


### PR DESCRIPTION
Fixes one concrete remaining item from #11829.

This extends `openclaw secrets audit` to inspect stale `openclaw.json.*` backup files next to the active config. Those backups can still contain historical plaintext provider keys after a user migrates the active config to env refs or secret refs, which leaves a local secret-exposure surface for agents that can read reachable files.

Changes:
- add config backup discovery for files matching `openclaw.json.*`
- scan backup configs with the same plaintext secret target registry used for active config
- report malformed backup JSON as audit findings instead of crashing
- add coverage for plaintext provider keys in backup config files

Validation:
- `node scripts/run-vitest.mjs src/secrets/audit.test.ts --run`