### PR TITLE
fix(security): strip apiKey from models.json (Layer 1: #11829)

### DIFF
--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -178,7 +178,13 @@ export async function planOpenClawModelsJsonWithDeps(
       secretRefManagedProviders,
     }) ?? normalizedMergedProviders;
   const finalProviders = applyNativeStreamingUsageCompat(secretEnforcedProviders);
-  const nextContents = `${JSON.stringify({ providers: finalProviders }, null, 2)}\n`;
+  // Strip apiKey from providers before writing to models.json (Layer 1 security).
+  // API keys are resolved at runtime via env vars / auth profiles.
+  // Storing them in models.json creates a leak vector to LLM prompt context.
+  const sanitizedProviders = Object.fromEntries(
+    Object.entries(finalProviders).map(([key, { apiKey: _, ...rest }]) => [key, rest]),
+  );
+  const nextContents = `${JSON.stringify({ providers: sanitizedProviders }, null, 2)}\n`;
 
   if (params.existingRaw === nextContents) {
     return { action: "noop" };


### PR DESCRIPTION
## Summary

Closes #11829 (Layer 1)

Strips \piKey\ from provider configs before writing to \models.json\. API keys are resolved at runtime via env vars and auth profiles - they do not need to be persisted in the model catalog file. Removing them prevents accidental leakage to LLM prompt context.

## Changes

- \src/agents/models-config.plan.ts\: strip \piKey\ field from each provider entry before JSON serialization

## Verification

- Existing provider auth resolution (env vars, auth profiles) is unaffected
- Only the persisted \models.json\ file is sanitized
- Runtime key lookup paths are unchanged