### PR TITLE
fix(doctor): move Codex CLI assets notice from warnings to info tier (#84859)

### DIFF
--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -250,12 +250,17 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
       warningNotes: repairSequence.warningNotes,
     });
   } else {
-    const { collectDoctorPreviewWarnings } = await import("./doctor/shared/preview-warnings.js");
+    const { collectDoctorPreviewWarnings, collectDoctorPreviewInfoNotes } =
+      await import("./doctor/shared/preview-warnings.js");
     emitDoctorNotes({
       note,
       warningNotes: await collectDoctorPreviewWarnings({
         cfg: candidate,
         doctorFixCommand,
+        env: process.env,
+      }),
+      infoNotes: await collectDoctorPreviewInfoNotes({
+        cfg: candidate,
         env: process.env,
       }),
     });

--- a/src/commands/doctor/emit-notes.test.ts
+++ b/src/commands/doctor/emit-notes.test.ts
@@ -48,11 +48,42 @@ describe("doctor note emission", () => {
     ]);
   });
 
+  it("emits info notes with the Doctor info title", () => {
+    const note = vi.fn();
+
+    emitDoctorNotes({
+      note,
+      infoNotes: ["info one", "info two"],
+    });
+
+    expect(note.mock.calls).toEqual([
+      ["info one", "Doctor info"],
+      ["info two", "Doctor info"],
+    ]);
+  });
+
+  it("emits change, warning, and info notes in order", () => {
+    const note = vi.fn();
+
+    emitDoctorNotes({
+      note,
+      changeNotes: ["change one"],
+      warningNotes: ["warning one"],
+      infoNotes: ["info one"],
+    });
+
+    expect(note.mock.calls).toEqual([
+      ["change one", "Doctor changes"],
+      ["warning one", "Doctor warnings"],
+      ["info one", "Doctor info"],
+    ]);
+  });
+
   it("emits nothing when note groups are omitted or empty", () => {
     const note = vi.fn();
 
     emitDoctorNotes({ note });
-    emitDoctorNotes({ note, changeNotes: [], warningNotes: [] });
+    emitDoctorNotes({ note, changeNotes: [], warningNotes: [], infoNotes: [] });
 
     expect(note).not.toHaveBeenCalled();
   });

--- a/src/commands/doctor/emit-notes.ts
+++ b/src/commands/doctor/emit-notes.ts
@@ -11,11 +11,15 @@ export function emitDoctorNotes(params: {
   note: (message: string, title?: string) => void;
   changeNotes?: string[];
   warningNotes?: string[];
+  infoNotes?: string[];
 }): void {
   for (const change of params.changeNotes ?? []) {
     params.note(sanitizeDoctorNote(change), "Doctor changes");
   }
   for (const warning of params.warningNotes ?? []) {
     params.note(sanitizeDoctorNote(warning), "Doctor warnings");
+  }
+  for (const info of params.infoNotes ?? []) {
+    params.note(sanitizeDoctorNote(info), "Doctor info");
   }
 }

--- a/src/commands/doctor/shared/codex-native-assets.test.ts
+++ b/src/commands/doctor/shared/codex-native-assets.test.ts
@@ -3,7 +3,11 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
-import { collectCodexNativeAssetWarnings, scanCodexNativeAssets } from "./codex-native-assets.js";
+import {
+  collectCodexNativeAssetInfoNotes,
+  collectCodexNativeAssetWarnings,
+  scanCodexNativeAssets,
+} from "./codex-native-assets.js";
 
 const tempRoots = new Set<string>();
 
@@ -107,8 +111,45 @@ describe("scanCodexNativeAssets", () => {
   });
 });
 
-describe("collectCodexNativeAssetWarnings", () => {
+const expectedCodexAssetMessage = (codexHome: string, agentsSkillsDir: string) =>
+  [
+    "- Personal Codex CLI assets were found, but native Codex-mode OpenClaw agents use isolated per-agent Codex homes.",
+    `- Sources: ${codexHome} and ${agentsSkillsDir} (1 skill, 0 plugins, 0 config files, 0 hook files).`,
+    "- These assets will not be loaded by the Codex app-server child unless you intentionally promote them.",
+    "- Run `openclaw migrate codex --dry-run` to inventory them. Applying that migration copies skills into the current OpenClaw agent workspace; Codex plugins, hooks, and config stay manual-review only.",
+  ].join("\n");
+
+describe("collectCodexNativeAssetInfoNotes", () => {
   it("points users at explicit Codex migration instead of auto-copying native assets", async () => {
+    const root = await makeTempRoot();
+    const codexHome = path.join(root, ".codex");
+    await writeFile(path.join(root, ".agents", "skills", "agent-helper", "SKILL.md"));
+
+    const infoNotes = await collectCodexNativeAssetInfoNotes({
+      cfg: codexConfig(),
+      env: { CODEX_HOME: codexHome, HOME: root },
+    });
+
+    expect(infoNotes).toStrictEqual([
+      expectedCodexAssetMessage(codexHome, path.join(root, ".agents", "skills")),
+    ]);
+  });
+
+  it("returns empty when no Codex assets are found", async () => {
+    const root = await makeTempRoot();
+    const codexHome = path.join(root, ".codex");
+
+    const infoNotes = await collectCodexNativeAssetInfoNotes({
+      cfg: codexConfig(),
+      env: { CODEX_HOME: codexHome, HOME: root },
+    });
+
+    expect(infoNotes).toStrictEqual([]);
+  });
+});
+
+describe("collectCodexNativeAssetWarnings", () => {
+  it("delegates to the same logic as collectCodexNativeAssetInfoNotes (deprecated alias)", async () => {
     const root = await makeTempRoot();
     const codexHome = path.join(root, ".codex");
     await writeFile(path.join(root, ".agents", "skills", "agent-helper", "SKILL.md"));
@@ -119,12 +160,7 @@ describe("collectCodexNativeAssetWarnings", () => {
     });
 
     expect(warnings).toStrictEqual([
-      [
-        "- Personal Codex CLI assets were found, but native Codex-mode OpenClaw agents use isolated per-agent Codex homes.",
-        `- Sources: ${codexHome} and ${path.join(root, ".agents", "skills")} (1 skill, 0 plugins, 0 config files, 0 hook files).`,
-        "- These assets will not be loaded by the Codex app-server child unless you intentionally promote them.",
-        "- Run `openclaw migrate codex --dry-run` to inventory them. Applying that migration copies skills into the current OpenClaw agent workspace; Codex plugins, hooks, and config stay manual-review only.",
-      ].join("\n"),
+      expectedCodexAssetMessage(codexHome, path.join(root, ".agents", "skills")),
     ]);
   });
 });

--- a/src/commands/doctor/shared/codex-native-assets.ts
+++ b/src/commands/doctor/shared/codex-native-assets.ts
@@ -181,12 +181,11 @@ function plural(count: number, singular: string): string {
   return `${count} ${singular}${count === 1 ? "" : "s"}`;
 }
 
-export async function collectCodexNativeAssetWarnings(params: {
+async function buildCodexNativeAssetMessages(params: {
   cfg: OpenClawConfig;
-  env?: NodeJS.ProcessEnv;
+  env: NodeJS.ProcessEnv;
 }): Promise<string[]> {
-  const env = params.env ?? process.env;
-  const hits = await scanCodexNativeAssets({ cfg: params.cfg, env });
+  const hits = await scanCodexNativeAssets({ cfg: params.cfg, env: params.env });
   if (hits.length === 0) {
     return [];
   }
@@ -199,9 +198,24 @@ export async function collectCodexNativeAssetWarnings(params: {
   return [
     [
       "- Personal Codex CLI assets were found, but native Codex-mode OpenClaw agents use isolated per-agent Codex homes.",
-      `- Sources: ${resolveCodexHome(env)} and ${resolvePersonalAgentSkillsDir(env)} (${counts.join(", ")}).`,
+      `- Sources: ${resolveCodexHome(params.env)} and ${resolvePersonalAgentSkillsDir(params.env)} (${counts.join(", ")}).`,
       "- These assets will not be loaded by the Codex app-server child unless you intentionally promote them.",
       "- Run `openclaw migrate codex --dry-run` to inventory them. Applying that migration copies skills into the current OpenClaw agent workspace; Codex plugins, hooks, and config stay manual-review only.",
     ].join("\n"),
   ];
+}
+
+/** @deprecated Use {@link collectCodexNativeAssetInfoNotes} instead. */
+export async function collectCodexNativeAssetWarnings(params: {
+  cfg: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+}): Promise<string[]> {
+  return buildCodexNativeAssetMessages({ cfg: params.cfg, env: params.env ?? process.env });
+}
+
+export async function collectCodexNativeAssetInfoNotes(params: {
+  cfg: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+}): Promise<string[]> {
+  return buildCodexNativeAssetMessages({ cfg: params.cfg, env: params.env ?? process.env });
 }

--- a/src/commands/doctor/shared/preview-warnings.ts
+++ b/src/commands/doctor/shared/preview-warnings.ts
@@ -436,8 +436,6 @@ export async function collectDoctorPreviewWarnings(params: {
     const { collectCodexRouteWarnings } = await import("./codex-route-warnings.js");
     warnings.push(...collectCodexRouteWarnings({ cfg: params.cfg, env }));
   }
-  const { collectCodexNativeAssetWarnings } = await import("./codex-native-assets.js");
-  warnings.push(...(await collectCodexNativeAssetWarnings({ cfg: params.cfg, env })));
 
   if (hasPluginLoadPaths(params.cfg)) {
     const { collectBundledPluginLoadPathWarnings, scanBundledPluginLoadPathMigrations } =
@@ -533,4 +531,13 @@ export async function collectDoctorPreviewWarnings(params: {
   }
 
   return warnings;
+}
+
+export async function collectDoctorPreviewInfoNotes(params: {
+  cfg: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+}): Promise<string[]> {
+  const env = params.env ?? process.env;
+  const { collectCodexNativeAssetInfoNotes } = await import("./codex-native-assets.js");
+  return collectCodexNativeAssetInfoNotes({ cfg: params.cfg, env });
 }


### PR DESCRIPTION
## Summary

Fixes #84859

The `openclaw doctor` output categorized the "Personal Codex CLI assets were found" message under **Doctor warnings**, implying action was needed. In practice this message is purely informational and not actionable:

1. It has no discoverable check ID — cannot be suppressed via `--skip <id>`
2. It does not appear in `doctor --lint --json` findings (already 0 warnings there)
3. Codex regenerates `~/.codex/config.toml` on every run, so the check perpetually resurfaces for users who independently use Codex CLI alongside OpenClaw

## Changes

### `emit-notes.ts`
- Add optional `infoNotes` parameter to `emitDoctorNotes`; emitted after warnings under title **"Doctor info"**

### `codex-native-assets.ts`
- Extract private `buildCodexNativeAssetMessages` helper
- Add `collectCodexNativeAssetInfoNotes` as the canonical export
- Keep `collectCodexNativeAssetWarnings` as a `@deprecated` backward-compatible alias (same output, no behavior change for existing callers)

### `preview-warnings.ts`
- Remove Codex assets from `collectDoctorPreviewWarnings`
- Add `collectDoctorPreviewInfoNotes` for info-tier notices

### `doctor-config-flow.ts`
- Plumb `infoNotes` through `emitDoctorNotes` in the preview (non-repair) path

## Tests

- `emit-notes.test.ts`: add cases covering `infoNotes` parameter and emission order
- `codex-native-assets.test.ts`: primary tests now target `collectCodexNativeAssetInfoNotes`; deprecated alias test confirms same output

## Behavior proof

Before this PR, running `openclaw doctor` with Codex configured + `~/.agents/skills/` present would output:

```
Doctor warnings
  - Personal Codex CLI assets were found...
```

After this PR:
```
Doctor info
  - Personal Codex CLI assets were found...
```

No functional change to the message content — only the visual/severity tier changes. The `Doctor warnings` section no longer fires for this check alone.