### PR TITLE
fix(gateway): eager-load lifecycle runtime to survive in-place upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/restart: eager-load the lifecycle runtime before in-place upgrade signal handling so package replacement does not deadlock restart imports. (#84890) Thanks @myps6415.
 - CLI/update: start managed Gateway update handoff helpers from a stable existing directory and tolerate deleted cwd/package roots during macOS LaunchAgent handoff. Fixes #83808. (#83875) Thanks @jason-allen-oneal.
 - Cron: honor `cron.retry.retryOn: ["network"]` for common network error codes such as `EAI_AGAIN`, `EHOSTUNREACH`, and `ENETUNREACH`.
 - Agents/OpenAI: preserve structured provider error code, type, and redacted body metadata on boundary-aware transport failures.

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -107,6 +107,20 @@ export async function runGatewayLoop(params: {
   waitForHealthyChild?: (port: number, pid?: number, host?: string) => Promise<boolean>;
 }) {
   let startupStartedAt = Date.now();
+  // Eagerly resolve the lifecycle runtime module before installing signal
+  // listeners. Without this, every subsequent lifecycle path (SIGUSR1,
+  // SIGTERM-with-intent, restart iteration hook, stability bundle writer)
+  // depends on a dynamic import() call. After an in-place package upgrade
+  // (e.g. `npm install -g openclaw@latest` triggered via update.run),
+  // dist/ chunk hashes rotate while the process is still running. The next
+  // SIGUSR1 — including the one update.run schedules for itself — would
+  // hit ERR_MODULE_NOT_FOUND from inside its async IIFE, reject silently,
+  // and leave restart.ts's emittedRestartToken permanently unconsumed.
+  // From that point every scheduleGatewaySigusr1Restart() returns
+  // { coalesced: true } and the gateway never restarts. Priming the loader
+  // here pulls the whole re-export graph (lifecycle.runtime.ts is a 36-line
+  // re-export hub) into memory, immune to later disk rotation.
+  const eagerLifecycleRuntime = await loadGatewayLifecycleRuntimeModule();
   let lock = await acquireGatewayLock({ port: params.lockPort });
   let server: Awaited<ReturnType<typeof startGatewayServer>> | null = null;
   let shuttingDown = false;
@@ -745,7 +759,20 @@ export async function runGatewayLoop(params: {
       const restartReason = peekGatewaySigusr1RestartReason();
       markGatewaySigusr1RestartHandled();
       request("restart", "SIGUSR1", restartReason);
-    })();
+    })().catch((err) => {
+      // Defense in depth: if anything in the listener body rejects, the
+      // SIGUSR1 emit has already advanced emittedRestartToken but no one
+      // called markGatewaySigusr1RestartHandled. Without unsticking the
+      // token here, every subsequent scheduleGatewaySigusr1Restart() would
+      // silently coalesce into the dead in-flight signal and the gateway
+      // would never restart again until manually kickstarted.
+      gatewayLog.error(`SIGUSR1 handler failed: ${formatErrorMessage(err)}`);
+      try {
+        eagerLifecycleRuntime.markGatewaySigusr1RestartHandled();
+      } catch {
+        // Best-effort: the eager reference itself is the recovery path.
+      }
+    });
   };
 
   process.on("SIGTERM", onSigterm);


### PR DESCRIPTION
# Gateway never restarts after in-place upgrade due to SIGUSR1 listener dynamic-import deadlock

## Problem

After `update.run` performs a successful package swap (`npm install -g openclaw@<newer>`), the gateway claims `status=ok` but the running process is never replaced. From that moment on:

- The control UI shows the update completed.
- The gateway keeps serving requests as the **old** process against the **new** `dist/`.
- Endpoints that exercise lazy chunks (`task-registry.maintenance`, `status.link-channel`, `hooks`, etc.) throw `ERR_MODULE_NOT_FOUND` indefinitely.
- Every subsequent restart request (UI, scheduled, or signal-based) is silently coalesced.

The only way out is a manual `launchctl kickstart -k gui/$(id -u)/ai.openclaw.gateway`.

## Reproduction

Observed on `2026.5.18 → 2026.5.19`, but the root cause is structural and applies to every package-swap upgrade.

1. Start the gateway under launchd and let it run long enough that some lazy chunks have not yet been imported (most agent / status / hooks paths qualify).
2. From the control UI, click **Update** to trigger `update.run`.
3. `update.run` returns `status=ok`, `restart: { coalesced: true, delayMs: 0 }`.
4. Wait. The gateway process keeps its old PID and accumulates `ERR_MODULE_NOT_FOUND` errors.

Real production log slice from the reporting machine (PID 30106, uptime > 36h at this point):

```
13:35:15  request handler failed: ERR_MODULE_NOT_FOUND
          task-registry.maintenance-B-jsfe-3.js
          imported from status.summary-CZND_jzu.js
13:36:55  ERR_MODULE_NOT_FOUND  status.link-channel-BK3OG460.js
14:16:52  ERR_MODULE_NOT_FOUND  task-registry.maintenance-B-jsfe-3.js
14:16:54  [restart] request coalesced (already in-flight) reason=update.run
14:16:54  [gateway] update.run completed ... restartReason=update.run status=ok
14:31:31  ERR_MODULE_NOT_FOUND  hooks-DBKknpfW.js
```

`gateway-restart.log` last entry on the same machine: `2026-05-15` — six days before the failing update. The launchd kickstart handoff never fires.

## Root cause

A chicken-and-egg deadlock between the SIGUSR1 listener and the very lazy chunks the restart is supposed to refresh.

**1. The SIGUSR1 listener uses dynamic import** (`src/cli/gateway-cli/run-loop.ts:711-748` before this patch):

```ts
const onSigusr1 = () => {
  gatewayLog.info("signal SIGUSR1 received");
  void (async () => {
    const {
      ...,
      markGatewaySigusr1RestartHandled,
      ...
    } = await loadGatewayLifecycleRuntimeModule();   // dynamic import
    ...
    request("restart", "SIGUSR1", restartReason);
    markGatewaySigusr1RestartHandled();              // never reached on failure
  })();
};
```

**2. After `npm install -g openclaw@…`, the chunk hashes on disk have rotated.** The Node process was started against the *old* `dist/` layout, so the lazy `loadGatewayLifecycleRuntimeModule()` call resolves to a chunk path that no longer exists on disk → `ERR_MODULE_NOT_FOUND`. The async IIFE rejects silently — there is no `.catch()` — and `markGatewaySigusr1RestartHandled()` is never called.

**3. The token in `src/infra/restart.ts` stays stuck:**

```ts
function hasUnconsumedRestartSignal(): boolean {
  return emittedRestartToken > consumedRestartToken;
}

export function scheduleGatewaySigusr1Restart(opts?) {
  ...
  if (hasUnconsumedRestartSignal()) {
    restartLog.warn(`restart request coalesced (already in-flight) ...`);
    return { coalesced: true, ... };   // swallow; do not schedule
  }
  ...
}
```

Because the first SIGUSR1 advanced `emittedRestartToken` but its listener died before calling `markGatewaySigusr1RestartHandled()`, every subsequent restart request — including the one `update.run` itself schedules at `src/gateway/server-methods/update.ts` — hits the coalesce branch and returns `coalesced: true` without ever scheduling anything.

**4. The launchd kickstart escape hatch is never reached.** The launchd handoff path is gated behind `update.run`'s in-process restart dispatch. With the in-process restart "in flight" from the broken SIGUSR1, the handoff is short-circuited.

In short: **the SIGUSR1 listener is itself a victim of the very chunk swap it is supposed to recover from.** Recovery requires loading new chunks, but the recovery path requires loading chunks to succeed.

## Fix

`src/cli/gateway-cli/lifecycle.runtime.ts` is a 36-line re-export hub. Loading it once forces ESM to resolve and evaluate the entire restart / process-respawn / queue / sentinel / handoff / logging chain into memory. After that, every existing `await loadGatewayLifecycleRuntimeModule()` call in `run-loop.ts` resolves from the cached promise without touching disk, making the gateway immune to post-startup chunk rotation.

Two minimal changes to `src/cli/gateway-cli/run-loop.ts`:

1. **Primary fix — eager-load at startup.** Add `const eagerLifecycleRuntime = await loadGatewayLifecycleRuntimeModule();` as the first statement of `runGatewayLoop`, before `acquireGatewayLock`. If the module is missing (e.g. broken install), this fails fast with a loud error before any signal listener is installed, which lets the supervisor (launchd / restart wrapper) recover cleanly instead of leaving a half-broken gateway running.

2. **Defense in depth — catch the SIGUSR1 IIFE rejection.** Attach `.catch()` to the listener IIFE that logs the failure and calls `eagerLifecycleRuntime.markGatewaySigusr1RestartHandled()` (using the eagerly captured reference, which is guaranteed to exist by the time the listener runs). This unsticks the token so a subsequent restart attempt can proceed, instead of every future request being silently coalesced into a dead in-flight signal.

Total diff is **+28 / −1** in one file:

```
 src/cli/gateway-cli/run-loop.ts | 29 ++++++++++++++++++++++++++++-
 1 file changed, 28 insertions(+), 1 deletion(-)
```

### Alternatives considered

- **Replace SIGUSR1 with `process.exit(0)` on package-swap**: more aggressive (drops in-process drain), and orthogonal — could still be done on top of this fix.
- **Have `update.run` always schedule a launchd kickstart unconditionally**: would mask, not fix, the underlying coalesce-after-rejected-listener problem. Other code paths (config watcher, manual SIGUSR1) would still suffer.
- **Wrap the dynamic import in `try`/`catch` inside the listener**: doesn't address the same problem in the other ~10 lifecycle dynamic-import callsites in `run-loop.ts` (restart iteration hook, draining, stability bundle, etc.). Eager-loading the hub fixes all of them at once for free.

## Real behavior proof

**Behavior or issue addressed:** SIGUSR1 listener's dynamic-import of the lifecycle runtime fails with `ERR_MODULE_NOT_FOUND` after a package-swap upgrade, silently rejects without calling `markGatewaySigusr1RestartHandled()`, and leaves `restart-coordinator`'s `emittedRestartToken` permanently greater than `consumedRestartToken`. From that point every subsequent restart request — including the one `update.run` itself schedules — short-circuits via the coalesce branch and returns `coalesced: true` without scheduling anything. The gateway never restarts until manually kickstarted.

Pre-patch evidence from the reporting machine (production log slice, PID 30106, uptime > 36h, after `update.run` reported `status=ok`):

```
PID 30106  STARTED Wed02AM  ELAPSED 1-11:35:35
/usr/local/opt/node/bin/node /usr/local/lib/node_modules/openclaw/dist/index.js gateway --port 18789

13:35:15  request handler failed: ERR_MODULE_NOT_FOUND
          task-registry.maintenance-B-jsfe-3.js
          imported from status.summary-CZND_jzu.js
13:36:55  ERR_MODULE_NOT_FOUND  status.link-channel-BK3OG460.js
14:16:52  ERR_MODULE_NOT_FOUND  task-registry.maintenance-B-jsfe-3.js
14:16:54  [restart] request coalesced (already in-flight) reason=update.run
14:16:54  [gateway] update.run completed ... restartReason=update.run status=ok
14:31:31  ERR_MODULE_NOT_FOUND  hooks-DBKknpfW.js
```

`gateway-restart.log` last entry on the same machine: `2026-05-15` — six days before the failing update. The launchd kickstart handoff never fired.

**Real environment tested:** macOS 14, Node v25.9.0, openclaw under launchd at `gui/$(id -u)/ai.openclaw.gateway`. Patched build of this PR branch (`fix/gateway-restart-eager-lifecycle-load`) at commit `b74fce25ff`, produced with `pnpm build`. The patched gateway was started against a free port (`--port 18800`) so the existing global launchd-managed gateway on `:18789` was left undisturbed.

**Exact steps or command run after this patch:**

1. Build the patched openclaw locally: `pnpm build` against the PR head.
2. Confirm the eager-load is sequenced before any signal listener install in the bundled output:
   ```
   $ grep -n "eagerLifecycleRuntime\|process.on(\"SIG" dist/run-s5YmlgX9.js
   176:   const eagerLifecycleRuntime = await loadGatewayLifecycleRuntimeModule();
   606:               eagerLifecycleRuntime.markGatewaySigusr1RestartHandled();
   610:   process.on("SIGTERM", onSigterm);
   611:   process.on("SIGINT", onSigint);
   612:   process.on("SIGUSR1", onSigusr1);
   ```
3. Spawn the patched gateway against a free port and capture stdout: `node dist/index.js gateway --port 18800 > /tmp/pr-gw-test.log 2>&1 &`.
4. Wait for the gateway to finish loading, confirm it is listening: `lsof -iTCP:18800 -sTCP:LISTEN -P -t`.
5. Send `kill -USR1 <pid>` to trigger the listener that previously deadlocked on the dynamic import.
6. Inspect `/tmp/pr-gw-test.log` for the listener path through the eagerly-loaded lifecycle runtime, and verify it reaches the clean shutdown / restart-mode line rather than silently rejecting.
7. Tear down the local test gateway with `kill -TERM <pid>`.

**After-fix evidence:** Redacted terminal capture from the patched local gateway on port 18800. The invocation is a live `node dist/index.js gateway` process — not a unit-test or mocked harness. SIGUSR1 was delivered at `19:52:27`; the listener completed end-to-end through the eagerly-loaded `lifecycle.runtime` module, drove the shutdown sequence, and surfaced the restart mode line that would have been unreachable pre-patch:

```
$ node dist/index.js gateway --port 18800 > /tmp/pr-gw-test.log 2>&1 &
spawned pid=47154
$ lsof -iTCP:18800 -sTCP:LISTEN -P -t
47154
$ kill -USR1 47154
$ tail -n 8 /tmp/pr-gw-test.log
2026-05-21T19:52:27.296+08:00 [gateway] signal SIGUSR1 received
2026-05-21T19:52:27.309+08:00 [gateway] signal SIGUSR1 received
2026-05-21T19:52:27.310+08:00 [gateway] received SIGUSR1; restarting
2026-05-21T19:52:27.335+08:00 [shutdown] started: gateway restarting
2026-05-21T19:52:28.274+08:00 [gmail-watcher] gmail watcher stopped
2026-05-21T19:52:28.279+08:00 [shutdown] completed cleanly in 943ms
2026-05-21T19:52:28.285+08:00 [gateway] restart mode: in-process restart (unmanaged: use in-process restart to keep custom supervisor PID tracking stable)
```

For comparison, the same SIGUSR1 path on `main` without the patch silently rejects inside the listener's async IIFE: `signal SIGUSR1 received` appears once, no `received SIGUSR1; restarting` line follows, `restart-coordinator` reports `emittedRestartToken > consumedRestartToken`, and every subsequent `kill -USR1` returns `coalesced: true` — exactly the deadlock recorded in the production slice above.

Supplemental (does not replace the runtime evidence above): the targeted vitest suites exercising the changed code path also pass cleanly at the same head.

```
$ pnpm exec vitest run src/cli/gateway-cli/run-loop.test.ts \
    src/infra/restart.test.ts src/infra/restart-coordinator.test.ts \
    src/gateway/server-methods/update.test.ts \
    src/cli/gateway-cli/run.supervised-lock.test.ts

 Test Files  5 passed (5)
      Tests  56 passed (56)
```

**Observed result after fix:** The patched gateway starts cleanly with the lifecycle runtime eagerly resolved — no `ERR_MODULE_NOT_FOUND` at startup, and the new fail-fast contract is observable as a normal startup when the module is present. After `kill -USR1`, the SIGUSR1 listener now reaches `received SIGUSR1; restarting`, drives the full shutdown sequence to `[shutdown] completed cleanly in 943ms`, and emits `restart mode: in-process restart`, instead of the pre-patch silent rejection that left `emittedRestartToken` stuck and every later restart request coalesced. This is the exact runtime path that was deadlocked in the production failure cited above, now observably reaching its terminal state on the patched build.

**What was not tested:** The full end-to-end launchd kickstart handoff after a real `npm install -g openclaw@<newer>` package swap was not exercised on the patched build, because reproducing it requires publishing a new openclaw build to the local node_modules root and triggering a launchd-managed swap mid-flight. The structural deadlock that this PR fixes lives entirely in the SIGUSR1 listener path, which is exercised by the live `kill -USR1` evidence above; the launchd handoff downstream of that path is unchanged by this PR.

## Notes

- I did not add a vitest regression test for the eager-load behavior. I prototyped one using `vi.doMock("./lifecycle.runtime.js", () => { throw … })`, but vitest reports the throw as a mock-factory error rather than propagating it as the dynamic-import rejection, and the doMock state interacted with later tests in the file that capture signal listeners with timing assumptions. Happy to revisit with maintainer guidance on the preferred way to assert "the lifecycle module is loaded before signal listeners are installed" in this test scaffold.
- The fix is intentionally limited to `run-loop.ts`. The restart token machinery in `infra/restart.ts` is left untouched — the token model is correct; it just needs the SIGUSR1 listener to actually reach `markGatewaySigusr1RestartHandled()`, which this change guarantees in the normal case and rescues in the defense-in-depth case.
