### PR TITLE
[codex] Fix empty result after exec stdout turns

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -7706,6 +7706,51 @@ describe("runCodexAppServerAttempt", () => {
     expect(result.timedOut).toBe(false);
   });
 
+  it("defers turn completion until an active native tool item completes", async () => {
+    const harness = createStartedThreadHarness();
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+    params.timeoutMs = 60_000;
+
+    let settled = false;
+    const run = runCodexAppServerAttempt(params, {
+      turnCompletionIdleTimeoutMs: 60_000,
+      turnTerminalIdleTimeoutMs: 60_000,
+    }).then((result) => {
+      settled = true;
+      return result;
+    });
+
+    await harness.waitForMethod("turn/start");
+    await harness.notify({
+      method: "item/started",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: { id: "cmd-1", type: "commandExecution", status: "inProgress" },
+      },
+    });
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(settled).toBe(false);
+
+    await harness.notify({
+      method: "item/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: { id: "cmd-1", type: "commandExecution", status: "completed" },
+      },
+    });
+
+    const result = await run;
+    expect(result.promptError ?? undefined).toBeUndefined();
+    expect(result.aborted).toBe(false);
+    expect(result.timedOut).toBe(false);
+  });
+
   it("does not time out when turn progress arrives before turn/start returns", async () => {
     let harness: ReturnType<typeof createAppServerHarness>;
     harness = createAppServerHarness(async (method) => {

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -1561,6 +1561,8 @@ export async function runCodexAppServerAttempt(
     resolveCompletion = resolve;
   });
   let notificationQueue: Promise<void> = Promise.resolve();
+  let deferredTerminalTurnNotification: CodexServerNotification | undefined;
+  let replayingPendingNotifications = false;
   const turnCompletionIdleTimeoutMs = resolveCodexTurnCompletionIdleTimeoutMs(
     options.turnCompletionIdleTimeoutMs ?? appServer.turnCompletionIdleTimeoutMs,
   );
@@ -2009,6 +2011,31 @@ export async function runCodexAppServerAttempt(
     );
   };
 
+  const completeDeferredTerminalTurn = async (): Promise<void> => {
+    if (!deferredTerminalTurnNotification || completed || !projector) {
+      return;
+    }
+    const terminalNotification = deferredTerminalTurnNotification;
+    deferredTerminalTurnNotification = undefined;
+    try {
+      await waitForCodexNotificationDispatchTurn();
+      await projector.handleNotification(terminalNotification);
+    } catch (error) {
+      embeddedAgentLog.debug("codex app-server deferred terminal projector notification threw", {
+        method: terminalNotification.method,
+        error,
+      });
+    }
+    if (!timedOut && !runAbortController.signal.aborted) {
+      await steeringQueue?.flushPending();
+    }
+    completed = true;
+    clearTurnCompletionIdleTimer();
+    clearTurnAssistantCompletionIdleTimer();
+    clearTurnTerminalIdleTimer();
+    resolveCompletion?.();
+  };
+
   const handleNotification = async (notification: CodexServerNotification) => {
     userInputBridge?.handleNotification(notification);
     if (!projector || !turnId) {
@@ -2127,6 +2154,26 @@ export async function runCodexAppServerAttempt(
     if (isTurnTerminal) {
       terminalTurnNotificationQueued = true;
     }
+    const shouldDeferTerminalForActiveNativeTools =
+      isTurnTerminal &&
+      notification.method === "turn/completed" &&
+      !isTurnAbortMarker &&
+      activeTurnItemIds.size > 0 &&
+      turnCrossedToolHandoff &&
+      !replayingPendingNotifications;
+    if (shouldDeferTerminalForActiveNativeTools) {
+      deferredTerminalTurnNotification = notification;
+      armTurnCompletionIdleWatch();
+      embeddedAgentLog.warn(
+        "codex app-server turn/completed arrived while native tools are still active; waiting for tool completion",
+        {
+          threadId: thread.threadId,
+          turnId,
+          activeItems: activeTurnItemIds.size,
+        },
+      );
+      return;
+    }
     try {
       await waitForCodexNotificationDispatchTurn();
       await projector.handleNotification(notification);
@@ -2148,6 +2195,14 @@ export async function runCodexAppServerAttempt(
         clearTurnAssistantCompletionIdleTimer();
         clearTurnTerminalIdleTimer();
         resolveCompletion?.();
+      } else if (
+        deferredTerminalTurnNotification &&
+        isCurrentTurnNotification &&
+        notification.method === "item/completed" &&
+        activeTurnItemIds.size === 0 &&
+        !completed
+      ) {
+        await completeDeferredTerminalTurn();
       }
     }
   };
@@ -2731,6 +2786,17 @@ export async function runCodexAppServerAttempt(
       addCloseHandler?: (handler: (client: CodexAppServerClient) => void) => () => void;
     }
   ).addCloseHandler?.(() => {
+    if (!completed && terminalTurnNotificationQueued && !runAbortController.signal.aborted) {
+      notificationQueue = notificationQueue.then(
+        async () => {
+          await completeDeferredTerminalTurn();
+        },
+        async () => {
+          await completeDeferredTerminalTurn();
+        },
+      );
+      return;
+    }
     if (completed || terminalTurnNotificationQueued || runAbortController.signal.aborted) {
       return;
     }
@@ -2756,8 +2822,13 @@ export async function runCodexAppServerAttempt(
   const activeProjector = projector;
   turnTerminalIdleWatchArmed = true;
   touchTurnCompletionActivity("turn:start", { arm: true });
-  for (const notification of pendingNotifications.splice(0)) {
-    await enqueueNotification(notification);
+  replayingPendingNotifications = true;
+  try {
+    for (const notification of pendingNotifications.splice(0)) {
+      await enqueueNotification(notification);
+    }
+  } finally {
+    replayingPendingNotifications = false;
   }
   if (!completed && isTerminalTurnStatus(turn.turn.status)) {
     await enqueueNotification({

--- a/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
+++ b/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
@@ -158,7 +158,7 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
     expect(payload).toEqual({ text: "NO_REPLY" });
   });
 
-  it("promotes a trailing exec stdout tool result when explicitly allowed", () => {
+  it("promotes a trailing app-server exec stdout tool result when explicitly allowed", () => {
     const payload = resolveSilentToolResultReplyPayload({
       isCronTrigger: false,
       allowTrailingToolResultPayload: true,
@@ -171,8 +171,14 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
         messagesSnapshot: [
           {
             role: "toolResult",
-            content: [{ type: "text", text: "STDOUT_OK" }],
-            details: { aggregated: "STDOUT_OK" },
+            content: [
+              {
+                type: "toolResult",
+                toolCallId: "call-1",
+                content: "STDOUT_OK",
+                text: "STDOUT_OK",
+              },
+            ],
           } as unknown as EmbeddedRunAttemptResult["messagesSnapshot"][number],
           {
             role: "assistant",

--- a/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
+++ b/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
@@ -36,6 +36,7 @@ import {
   resolveReplayInvalidFlag,
   resolveRunLivenessState,
   resolveSilentToolResultReplyPayload,
+  shouldPromoteTrailingToolResultPayload,
   shouldTreatEmptyAssistantReplyAsSilent,
 } from "./run/incomplete-turn.js";
 import type { EmbeddedRunAttemptResult } from "./run/types.js";
@@ -155,6 +156,111 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
     });
 
     expect(payload).toEqual({ text: "NO_REPLY" });
+  });
+
+  it("promotes a trailing exec stdout tool result when explicitly allowed", () => {
+    const payload = resolveSilentToolResultReplyPayload({
+      isCronTrigger: false,
+      allowTrailingToolResultPayload: true,
+      payloadCount: 0,
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: [],
+        toolMetas: [{ toolName: "exec" }],
+        messagesSnapshot: [
+          {
+            role: "toolResult",
+            content: [{ type: "text", text: "STDOUT_OK" }],
+            details: { aggregated: "STDOUT_OK" },
+          } as unknown as EmbeddedRunAttemptResult["messagesSnapshot"][number],
+          {
+            role: "assistant",
+            stopReason: "stop",
+            provider: "openai",
+            model: "gpt-5.4",
+            content: [],
+          } as unknown as EmbeddedRunAttemptResult["messagesSnapshot"][number],
+        ],
+      }),
+    });
+
+    expect(payload).toEqual({ text: "STDOUT_OK" });
+  });
+
+  it("does not promote a trailing stdout tool result unless explicitly allowed", () => {
+    const payload = resolveSilentToolResultReplyPayload({
+      isCronTrigger: false,
+      payloadCount: 0,
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: [],
+        toolMetas: [{ toolName: "exec" }],
+        messagesSnapshot: [
+          {
+            role: "toolResult",
+            content: [{ type: "text", text: "STDOUT_OK" }],
+          } as unknown as EmbeddedRunAttemptResult["messagesSnapshot"][number],
+        ],
+      }),
+    });
+
+    expect(payload).toBeNull();
+  });
+
+  it("does not promote failed trailing tool results", () => {
+    const payload = resolveSilentToolResultReplyPayload({
+      isCronTrigger: false,
+      allowTrailingToolResultPayload: true,
+      payloadCount: 0,
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: [],
+        toolMetas: [{ toolName: "exec" }],
+        messagesSnapshot: [
+          {
+            role: "toolResult",
+            isError: true,
+            content: [{ type: "text", text: "STDOUT_OK" }],
+          } as unknown as EmbeddedRunAttemptResult["messagesSnapshot"][number],
+        ],
+      }),
+    });
+
+    expect(payload).toBeNull();
+  });
+
+  it("only allows trailing stdout promotion for explicit exec-only stdout prompts", () => {
+    const execAttempt = makeAttemptResult({
+      assistantTexts: [],
+      toolMetas: [{ toolName: "bash" }],
+    });
+    expect(
+      shouldPromoteTrailingToolResultPayload({
+        prompt: "Run this command and use stdout as the final reply.",
+        toolsAllow: ["bash"],
+        attempt: execAttempt,
+      }),
+    ).toBe(true);
+    expect(
+      shouldPromoteTrailingToolResultPayload({
+        prompt: "Run this command and summarize it.",
+        toolsAllow: ["bash"],
+        attempt: execAttempt,
+      }),
+    ).toBe(false);
+    expect(
+      shouldPromoteTrailingToolResultPayload({
+        prompt: "Run this command and use stdout as the final reply.",
+        toolsAllow: ["message"],
+        attempt: makeAttemptResult({
+          assistantTexts: [],
+          toolMetas: [{ toolName: "message" }],
+        }),
+      }),
+    ).toBe(false);
   });
 
   it("does not reuse an older NO_REPLY tool result without current-attempt tool activity", () => {

--- a/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
+++ b/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
@@ -252,6 +252,14 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
     ).toBe(true);
     expect(
       shouldPromoteTrailingToolResultPayload({
+        prompt:
+          "Use the exec tool to run this command: hostname. Reply with the exact stdout only (trim trailing newline).",
+        toolsAllow: ["exec"],
+        attempt: execAttempt,
+      }),
+    ).toBe(true);
+    expect(
+      shouldPromoteTrailingToolResultPayload({
         prompt: "Run this command and summarize it.",
         toolsAllow: ["bash"],
         attempt: execAttempt,

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -168,6 +168,7 @@ import {
   resolvePlanningOnlyRetryInstruction,
   resolveReasoningOnlyRetryInstruction,
   resolveSilentToolResultReplyPayload,
+  shouldPromoteTrailingToolResultPayload,
   STRICT_AGENTIC_BLOCKED_TEXT,
   resolveReplayInvalidFlag,
   resolveRunLivenessState,
@@ -2810,8 +2811,14 @@ export async function runEmbeddedPiAgent(
             };
           }
 
+          const allowTrailingToolResultPayload = shouldPromoteTrailingToolResultPayload({
+            prompt: params.prompt,
+            toolsAllow: params.toolsAllow,
+            attempt,
+          });
           const silentToolResultReplyPayload = resolveSilentToolResultReplyPayload({
             isCronTrigger: params.trigger === "cron",
+            allowTrailingToolResultPayload,
             payloadCount: payloadsWithToolMedia?.length ?? 0,
             aborted,
             timedOut,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -385,6 +385,7 @@ import { detectAndLoadPromptImages } from "./images.js";
 import {
   buildAttemptReplayMetadata,
   resolveSilentToolResultReplyPayload,
+  shouldPromoteTrailingToolResultPayload,
   shouldTreatEmptyAssistantReplyAsSilent,
 } from "./incomplete-turn.js";
 import { resolveLlmIdleTimeoutMs, streamWithIdleTimeout } from "./llm-idle-timeout.js";
@@ -4685,19 +4686,28 @@ export async function runEmbeddedAttempt(
         ? 1
         : 0;
       const visibleBlockReplyCount = getVisibleBlockReplyCount();
+      const silentToolResultAttempt = {
+        clientToolCalls: completedClientToolCallsForAttempt,
+        assistantTexts,
+        yieldDetected,
+        didSendViaMessagingTool: didSendViaMessagingTool(),
+        didSendDeterministicApprovalPrompt: didSendDeterministicApprovalPromptNow,
+        lastToolError,
+        messagesSnapshot,
+        toolMetas: toolMetasNormalized,
+      };
+      const allowTrailingToolResultPayload = shouldPromoteTrailingToolResultPayload({
+        prompt: params.prompt,
+        toolsAllow: params.toolsAllow,
+        attempt: silentToolResultAttempt,
+      });
       const silentToolResultReplyPayload = resolveSilentToolResultReplyPayload({
         isCronTrigger: params.trigger === "cron",
+        allowTrailingToolResultPayload,
         payloadCount: pendingToolMediaPayloadCount,
         aborted,
         timedOut,
-        attempt: {
-          clientToolCalls: completedClientToolCallsForAttempt,
-          yieldDetected,
-          didSendDeterministicApprovalPrompt: didSendDeterministicApprovalPromptNow,
-          lastToolError,
-          messagesSnapshot,
-          toolMetas: toolMetasNormalized,
-        },
+        attempt: silentToolResultAttempt,
       });
       const synthesizedPayloadCount =
         visibleBlockReplyCount +

--- a/src/agents/pi-embedded-runner/run/incomplete-turn.ts
+++ b/src/agents/pi-embedded-runner/run/incomplete-turn.ts
@@ -436,9 +436,17 @@ function promptRequestsStdoutFinalReply(prompt?: string): boolean {
   if (!normalized.includes("stdout")) {
     return false;
   }
+  const requestsReply =
+    normalized.includes("reply") ||
+    normalized.includes("respond") ||
+    normalized.includes("answer") ||
+    prompt.includes("回复");
+  const requestsExactStdoutOnly =
+    requestsReply && (normalized.includes("exact stdout") || normalized.includes("stdout only"));
   return (
     normalized.includes("final reply") ||
     normalized.includes("final response") ||
+    requestsExactStdoutOnly ||
     prompt.includes("最终回复") ||
     prompt.includes("原样")
   );

--- a/src/agents/pi-embedded-runner/run/incomplete-turn.ts
+++ b/src/agents/pi-embedded-runner/run/incomplete-turn.ts
@@ -337,8 +337,51 @@ function readToolResultAggregatedText(message: AgentMessage): string | undefined
   return trimmed || undefined;
 }
 
+function readToolResultBlockText(block: unknown): string | undefined {
+  if (!block || typeof block !== "object") {
+    return undefined;
+  }
+  const rec = block as { type?: unknown; text?: unknown; content?: unknown };
+  if (rec.type !== "toolResult") {
+    return undefined;
+  }
+  if (typeof rec.text === "string") {
+    const text = rec.text.trim();
+    if (text.length > 0) {
+      return text;
+    }
+  }
+  if (typeof rec.content === "string") {
+    const text = rec.content.trim();
+    if (text.length > 0) {
+      return text;
+    }
+  }
+  const text = collectTextContentBlocks(rec.content)
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0)
+    .join("\n");
+  return text || undefined;
+}
+
+function readToolResultContentText(message: AgentMessage): string | undefined {
+  const content = (message as { content?: unknown }).content;
+  if (!Array.isArray(content)) {
+    return undefined;
+  }
+  const text = content
+    .map((block) => readToolResultBlockText(block))
+    .filter((item): item is string => typeof item === "string" && item.length > 0)
+    .join("\n");
+  return text || undefined;
+}
+
 function readToolResultText(message: AgentMessage): string | undefined {
-  return readMessageTextContent(message) ?? readToolResultAggregatedText(message);
+  return (
+    readMessageTextContent(message) ??
+    readToolResultContentText(message) ??
+    readToolResultAggregatedText(message)
+  );
 }
 
 function readTrailingSuccessfulToolResultText(

--- a/src/agents/pi-embedded-runner/run/incomplete-turn.ts
+++ b/src/agents/pi-embedded-runner/run/incomplete-turn.ts
@@ -72,9 +72,22 @@ type SilentToolResultAttempt = Pick<
   EmbeddedRunAttemptResult,
   | "clientToolCalls"
   | "yieldDetected"
+  | "assistantTexts"
+  | "didSendViaMessagingTool"
   | "didSendDeterministicApprovalPrompt"
   | "lastToolError"
   | "messagesSnapshot"
+  | "toolMetas"
+>;
+
+type TrailingToolResultPromotionAttempt = Pick<
+  EmbeddedRunAttemptResult,
+  | "assistantTexts"
+  | "clientToolCalls"
+  | "yieldDetected"
+  | "didSendViaMessagingTool"
+  | "didSendDeterministicApprovalPrompt"
+  | "lastToolError"
   | "toolMetas"
 >;
 
@@ -184,6 +197,7 @@ const ACTIONABLE_PROMPT_DIRECTIVE_RE =
   /^\s*(?:please\s+)?(?:check|look(?:\s+into|\s+at)?|read|write|edit|update|fix|investigate|debug|run|search|find|implement|add|remove|refactor|explain|summari(?:s|z)e|analy(?:s|z)e|review|tell|show|make|restart|deploy|prepare)\b/i;
 const ACTIONABLE_PROMPT_REQUEST_RE =
   /\b(?:can|could|would|will)\s+you\b|\b(?:please|pls)\b|\b(?:help|explain|summari(?:s|z)e|analy(?:s|z)e|review|investigate|debug|fix|check|look(?:\s+into|\s+at)?|read|write|edit|update|run|search|find|implement|add|remove|refactor|show|tell me|walk me through)\b/i;
+const EXEC_LIKE_TOOL_NAMES = new Set(["bash", "exec"]);
 
 export const PLANNING_ONLY_RETRY_INSTRUCTION =
   "The previous assistant turn only described the plan. Do not restate the plan. Act now: take the first concrete tool action you can. If a real blocker prevents action, reply with the exact blocker in one sentence.";
@@ -323,7 +337,13 @@ function readToolResultAggregatedText(message: AgentMessage): string | undefined
   return trimmed || undefined;
 }
 
-function hasTrailingSilentToolResult(messages: readonly AgentMessage[]): boolean {
+function readToolResultText(message: AgentMessage): string | undefined {
+  return readMessageTextContent(message) ?? readToolResultAggregatedText(message);
+}
+
+function readTrailingSuccessfulToolResultText(
+  messages: readonly AgentMessage[],
+): string | undefined {
   for (let i = messages.length - 1; i >= 0; i -= 1) {
     const message = messages[i];
     if (!message) {
@@ -332,34 +352,94 @@ function hasTrailingSilentToolResult(messages: readonly AgentMessage[]): boolean
     const role = normalizeLowercaseStringOrEmpty(message?.role);
     if (isToolResultRole(role)) {
       if ((message as { isError?: boolean }).isError === true) {
-        return false;
+        return undefined;
       }
-      const text = readMessageTextContent(message) ?? readToolResultAggregatedText(message);
-      return isSilentReplyText(text, SILENT_REPLY_TOKEN);
+      return readToolResultText(message);
     }
     if (role === "assistant" && !readMessageTextContent(message)) {
       continue;
     }
+    return undefined;
+  }
+  return undefined;
+}
+
+function isExecLikeToolName(toolName: string | undefined): boolean {
+  const normalized = normalizeLowercaseStringOrEmpty(toolName ?? "");
+  return EXEC_LIKE_TOOL_NAMES.has(normalized);
+}
+
+function isExecOnlyToolsAllow(toolsAllow?: readonly string[]): boolean {
+  const normalized = (toolsAllow ?? [])
+    .map((toolName) => normalizeLowercaseStringOrEmpty(toolName))
+    .filter((toolName) => toolName.length > 0);
+  return (
+    normalized.length > 0 && normalized.every((toolName) => EXEC_LIKE_TOOL_NAMES.has(toolName))
+  );
+}
+
+function attemptUsedOnlyExecLikeTools(attempt: TrailingToolResultPromotionAttempt): boolean {
+  const toolNames = (attempt.toolMetas ?? [])
+    .map((toolMeta) => normalizeLowercaseStringOrEmpty(toolMeta.toolName))
+    .filter((toolName) => toolName.length > 0);
+  return toolNames.length > 0 && toolNames.every((toolName) => isExecLikeToolName(toolName));
+}
+
+function promptRequestsStdoutFinalReply(prompt?: string): boolean {
+  if (typeof prompt !== "string") {
     return false;
   }
-  return false;
+  const normalized = normalizeLowercaseStringOrEmpty(prompt);
+  if (!normalized.includes("stdout")) {
+    return false;
+  }
+  return (
+    normalized.includes("final reply") ||
+    normalized.includes("final response") ||
+    prompt.includes("最终回复") ||
+    prompt.includes("原样")
+  );
+}
+
+export function shouldPromoteTrailingToolResultPayload(params: {
+  prompt?: string;
+  toolsAllow?: readonly string[];
+  attempt: TrailingToolResultPromotionAttempt;
+}): boolean {
+  if (
+    joinAssistantTexts(params.attempt.assistantTexts).length > 0 ||
+    params.attempt.clientToolCalls ||
+    params.attempt.yieldDetected ||
+    params.attempt.didSendViaMessagingTool ||
+    params.attempt.didSendDeterministicApprovalPrompt ||
+    params.attempt.lastToolError ||
+    !promptRequestsStdoutFinalReply(params.prompt)
+  ) {
+    return false;
+  }
+  return isExecOnlyToolsAllow(params.toolsAllow) || attemptUsedOnlyExecLikeTools(params.attempt);
 }
 
 export function resolveSilentToolResultReplyPayload(params: {
   isCronTrigger: boolean;
+  allowTrailingToolResultPayload?: boolean;
   payloadCount: number;
   aborted: boolean;
   timedOut: boolean;
   attempt: SilentToolResultAttempt;
-}): { text: typeof SILENT_REPLY_TOKEN } | null {
+}): { text: string } | null {
+  const canUseTrailingToolResult =
+    params.isCronTrigger || params.allowTrailingToolResultPayload === true;
   if (
-    !params.isCronTrigger ||
+    !canUseTrailingToolResult ||
     params.payloadCount !== 0 ||
     params.aborted ||
     params.timedOut ||
     (params.attempt.toolMetas?.length ?? 0) === 0 ||
+    joinAssistantTexts(params.attempt.assistantTexts).length > 0 ||
     params.attempt.clientToolCalls ||
     params.attempt.yieldDetected ||
+    params.attempt.didSendViaMessagingTool ||
     params.attempt.didSendDeterministicApprovalPrompt ||
     params.attempt.lastToolError ||
     (params.attempt.messagesSnapshot?.length ?? 0) === 0
@@ -367,9 +447,16 @@ export function resolveSilentToolResultReplyPayload(params: {
     return null;
   }
 
-  return hasTrailingSilentToolResult(params.attempt.messagesSnapshot)
-    ? { text: SILENT_REPLY_TOKEN }
-    : null;
+  const trailingToolResultText = readTrailingSuccessfulToolResultText(
+    params.attempt.messagesSnapshot,
+  );
+  if (isSilentReplyText(trailingToolResultText, SILENT_REPLY_TOKEN)) {
+    return { text: SILENT_REPLY_TOKEN };
+  }
+  if (params.allowTrailingToolResultPayload === true && trailingToolResultText) {
+    return { text: trailingToolResultText };
+  }
+  return null;
 }
 
 export function resolveReplayInvalidFlag(params: {


### PR DESCRIPTION
## Summary

Fixes empty user-visible results from Codex exec-only turns where the harness can finish with tool output recorded but no final assistant text.

## Root cause

Two ordering/result-shaping gaps could surface as `payloads=0` even though the command itself succeeded:

- Codex app-server `turn/completed` can arrive while a native tool item is still active, so the projector may finalize before the native `item/completed` is reflected in the snapshot.
- Some exec/bash-only prompts explicitly ask for stdout to be used as the final reply, but the runner previously only promoted trailing tool results for cron `NO_REPLY`.

## Changes

- Defer live `turn/completed` handling until active native tool items complete, while preserving existing buffered-terminal/client-close behavior.
- Add a narrow trailing tool-result promotion path for successful exec/bash stdout when the prompt asks for stdout as the final reply and no assistant/message/client-tool side effects are present.
- Read the real Codex app-server `toolResult` block shape.
- Cover both `final reply` wording and the existing Docker-smoke wording: `Reply with the exact stdout only (trim trailing newline)`.
- Keep existing cron `NO_REPLY` behavior.

## Real behavior proof

- **Behavior or issue addressed:** Codex exec-only turns could finish with successful native command stdout but no final assistant payload, surfacing upstream as `payloads=0` / `empty_result`. This proof covers the exact stdout-only wording ClawSweeper called out: `Reply with the exact stdout only (trim trailing newline)`.
- **Real environment tested:** Local macOS source checkout of this PR head `d6dd2ada0f3c2e09e3fe178ef4285b857416ec76`, using OpenClaw's local embedded agent command with the real Codex app-server harness, `/opt/homebrew/bin/codex app-server --listen stdio://`, `CODEX_HOME=$HOME/.codex`, and a temp OpenClaw config that explicitly enables `plugins.entries.codex` plus `agents.defaults.models.openai/gpt-5.5.agentRuntime.id = "codex"`.
- **Exact steps or command run after this patch:**

```text
HEAD=d6dd2ada0f3c2e09e3fe178ef4285b857416ec76
OPENCLAW_CONFIG_PATH=<temp>/openclaw.json
OPENCLAW_STATE_DIR=<temp>/state
OPENCLAW_WORKSPACE_DIR=<temp>/workspace
CODEX_HOME=$HOME/.codex
OPENCLAW_LOG_LEVEL=debug
OPENCLAW_CODEX_DISCOVERY_LIVE=0
OPENCLAW_CODEX_APP_SERVER_BIN=/opt/homebrew/bin/codex
OPENCLAW_CODEX_APP_SERVER_APPROVAL_POLICY=never
OPENCLAW_CODEX_APP_SERVER_SANDBOX=danger-full-access
node scripts/run-node.mjs agent --local \
  --session-id stdout-proof-20260522T170908Z \
  --model openai/gpt-5.5 \
  --thinking off \
  --json \
  --timeout 360 \
  --message "Use the exec tool to run this command: cat <temp>/stdout-token.txt. Reply with the exact stdout only (trim trailing newline)."
```

- **Evidence after fix:** Redacted runtime log excerpt from `.artifacts/codex-stdout-proof-20260522T170908Z.log`:

```text
HEAD=d6dd2ada0f3c2e09e3fe178ef4285b857416ec76
EXPECTED_STDOUT=OPENCLAW_STDOUT_PROOF_20260522T170908Z_26472
[agents/harness] agent harness selected
[agent/embedded] codex app-server raw notification received
...
"text": "OPENCLAW_STDOUT_PROOF_20260522T170908Z_26472"
"finalAssistantVisibleText": "OPENCLAW_STDOUT_PROOF_20260522T170908Z_26472"
"finalAssistantRawText": "OPENCLAW_STDOUT_PROOF_20260522T170908Z_26472"
"winnerProvider": "openai-codex"
"fallbackUsed": false
"toolSummary": {
  "calls": 1,
  "tools": ["bash"],
  "failures": 0
}
```

- **Observed result after fix:** A real Codex app-server exec stdout-only turn produced one visible final payload exactly equal to the command stdout token, with one successful `bash` tool call, `winnerProvider=openai-codex`, and `fallbackUsed=false`.
- **What was not tested:** No known real-behavior gaps for this patch. I did not run the full Docker install E2E; the live proof directly exercises the same exact-stdout-only prompt contract through the real Codex app-server harness from this PR head.

## Validation

```text
./node_modules/.bin/vitest run src/agents/pi-embedded-runner/run.incomplete-turn.test.ts --config vitest.config.ts
=> Test Files  2 passed (2)
=> Tests  216 passed (216)

./node_modules/.bin/vitest run extensions/codex/src/app-server/run-attempt.test.ts --config vitest.config.ts -t 'defers turn completion until an active native tool item completes'
=> Test Files  1 passed (1)
=> Tests  1 passed | 206 skipped (207)

./node_modules/.bin/oxfmt --check --threads=1 src/agents/pi-embedded-runner/run/incomplete-turn.ts src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
=> All matched files use the correct format.

./node_modules/.bin/oxlint src/agents/pi-embedded-runner/run/incomplete-turn.ts src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
=> exit 0

node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo
=> exit 0

node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
=> exit 0

node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo
=> exit 0

node scripts/generate-npm-shrinkwrap.mjs --all --check
=> all checked npm-shrinkwrap.json files are current

git diff --check
=> exit 0
```

Pre-fix red check for the new P1 regression: the exact-stdout-only detector case failed before this commit with `expected false to be true`; it passes after the detector change.

---
Restored from closed PR: https://github.com/openclaw/openclaw/pull/84539
