### PR TITLE
Forward cron toolsAllow to CLI runs

### DIFF
--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -210,6 +210,7 @@ export function createCronPromptExecutor(params: {
             bootstrapPromptWarningSignaturesSeen,
             bootstrapPromptWarningSignature,
             senderIsOwner: params.senderIsOwner,
+            toolsAllow: params.agentPayload?.toolsAllow,
           });
           bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
             result.meta?.systemPromptReport,

--- a/src/cron/isolated-agent/run.skill-filter.test.ts
+++ b/src/cron/isolated-agent/run.skill-filter.test.ts
@@ -370,6 +370,35 @@ describe("runCronIsolatedAgentTurn — skill filter", () => {
       expect(getFirstMockArg(runCliAgentMock, "CLI run")).toHaveProperty("cliSessionId", undefined);
     });
 
+    it("forwards runtime toolsAllow into CLI cron runs so native CLI tools fail closed", async () => {
+      isCliProviderMock.mockReturnValue(true);
+      runCliAgentMock.mockResolvedValue({
+        payloads: [{ text: "output" }],
+        meta: {
+          agentMeta: { sessionId: "cli-tools-allow-session", usage: { input: 5, output: 10 } },
+        },
+      });
+      mockCliFallbackInvocation();
+
+      await runCronIsolatedAgentTurn(
+        makeSkillParams({
+          job: makeSkillJob({
+            payload: {
+              kind: "agentTurn",
+              message: "fetch weather",
+              toolsAllow: ["web_fetch", "message"],
+            },
+          }),
+        }),
+      );
+
+      expect(runCliAgentMock).toHaveBeenCalledOnce();
+      expect(getFirstMockArg(runCliAgentMock, "CLI run")).toHaveProperty("toolsAllow", [
+        "web_fetch",
+        "message",
+      ]);
+    });
+
     it("reuses stored cliSessionId on continuation runs (isNewSession=false)", async () => {
       getCliSessionIdMock.mockReturnValue("existing-cli-session-def");
       isCliProviderMock.mockReturnValue(true);


### PR DESCRIPTION
## Summary
- Forward isolated cron payload `toolsAllow` into the CLI runner path.
- Keep CLI/native-tool backends fail-closed when a cron job requests a runtime allowlist.
- Add a regression test covering a cron agent turn with `toolsAllow: ["web_fetch", "message"]`.

## Root cause
The embedded cron runner already received `agentPayload.toolsAllow`, but the CLI runner branch dropped it while still passing the normal skill snapshot and prompt context. CLI backends already reject runtime allowlists when they cannot enforce them, so the missing handoff let restricted cron jobs continue through a native-tool harness without the intended policy check.

## Real behavior proof
- **Behavior or issue addressed**: Isolated cron jobs that specify `toolsAllow` must pass that runtime allowlist into the CLI runner path instead of letting a native CLI harness run without the intended restriction.
- **Real environment tested**: Local OpenClaw branch `codex/cron-cli-toolsallow-fail-closed` on macOS, launched from temp HOME `/tmp/openclaw-pr82416-proof` with gateway port `19876` and `OPENCLAW_CONFIG_PATH=/tmp/openclaw-pr82416-proof/.openclaw/openclaw.json`.
- **Exact steps or command run after this patch**: Started `pnpm openclaw gateway --dev --port 19876 --auth none --allow-unconfigured --compact`; added a real cron job with `pnpm openclaw cron add --name cli-toolsallow-proof --every 1h --session isolated --message "fetch weather" --model claude-cli/opus --tools web_fetch,message --json`; manually ran it with `pnpm openclaw cron run beba7234-2487-4378-8744-a0fd3e018454 --expect-final --timeout 30000`; queried the result with `pnpm openclaw cron runs --id beba7234-2487-4378-8744-a0fd3e018454 --limit 5 --expect-final --timeout 30000`.
- **Evidence after fix**: Terminal output from the real local run:

```text
OpenClaw 2026.5.16 (a4f044d)
gateway listening on ws://127.0.0.1:19876
cron job payload: model=claude-cli/opus, toolsAllow=["web_fetch", "message"]

openclaw cron runs --id beba7234-2487-4378-8744-a0fd3e018454 --limit 5 --expect-final --timeout 30000
status: error
error: Error: CLI backend claude-cli cannot enforce runtime toolsAllow; use an embedded runtime for restricted tool policy
diagnostics.summary: CLI backend claude-cli cannot enforce runtime toolsAllow; use an embedded runtime for restricted tool policy
runId: manual:beba7234-2487-4378-8744-a0fd3e018454:1778902107983:1
```

- **Observed result after fix**: The runtime allowlist reaches the CLI path and the CLI backend fails closed before a native CLI harness can run with unrestricted tools.
- **What was not tested**: Nothing else.

## Validation
- `pnpm exec vitest run src/cron/isolated-agent/run.skill-filter.test.ts --maxWorkers=1`
- `git diff --check`
- `pnpm exec oxfmt --check src/cron/isolated-agent/run-executor.ts src/cron/isolated-agent/run.skill-filter.test.ts`

---
Restored from closed PR: https://github.com/openclaw/openclaw/pull/82416
