### PR TITLE
fix(cli): validate tasks audit limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/tasks: reject partially numeric `openclaw tasks audit --limit` values so audit limits must be real positive integers instead of accepting strings like `5abc`. (#84901) Thanks @jbetala7.
 - Twitch: keep stale message-handler cleanup callbacks from removing newer handler registrations for the same account, preserving inbound message delivery after reconnects. Fixes #83888. (#85425) Thanks @alkor2000.
 - Memory/LanceDB: expose public memory artifacts through the active memory provider bridge so memory-wiki imports durable memory files, daily notes, dream reports, and event logs without depending on memory-core internals. Fixes #83604. (#85060) Thanks @brokemac79.
 - Docker setup: stop printing the Gateway bearer token in setup logs and printed follow-up commands.

--- a/src/cli/program/helpers.test.ts
+++ b/src/cli/program/helpers.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   collectOption,
   parsePositiveIntOrUndefined,
+  parseStrictPositiveIntOrUndefined,
   resolveActionArgs,
   resolveCommandOptionArgs,
 } from "./helpers.js";
@@ -29,6 +30,27 @@ describe("program helpers", () => {
     { value: true, expected: undefined },
   ])("parsePositiveIntOrUndefined(%j)", ({ value, expected }) => {
     expect(parsePositiveIntOrUndefined(value)).toBe(expected);
+  });
+
+  it.each([
+    { value: undefined, expected: undefined },
+    { value: null, expected: undefined },
+    { value: "", expected: undefined },
+    { value: 5, expected: 5 },
+    { value: 5.9, expected: undefined },
+    { value: 0, expected: undefined },
+    { value: -1, expected: undefined },
+    { value: Number.NaN, expected: undefined },
+    { value: "10", expected: 10 },
+    { value: " 10 ", expected: 10 },
+    { value: "+10", expected: 10 },
+    { value: "10ms", expected: undefined },
+    { value: "1.5", expected: undefined },
+    { value: "0", expected: undefined },
+    { value: "nope", expected: undefined },
+    { value: true, expected: undefined },
+  ])("parseStrictPositiveIntOrUndefined(%j)", ({ value, expected }) => {
+    expect(parseStrictPositiveIntOrUndefined(value)).toBe(expected);
   });
 
   it("resolveActionArgs returns args when command has arg array", () => {

--- a/src/cli/program/helpers.ts
+++ b/src/cli/program/helpers.ts
@@ -1,4 +1,5 @@
 import type { Command } from "commander";
+import { parseStrictPositiveInteger } from "../../infra/parse-finite-number.js";
 
 export function collectOption(value: string, previous: string[] = []): string[] {
   return [...previous, value];
@@ -23,6 +24,10 @@ export function parsePositiveIntOrUndefined(value: unknown): number | undefined 
     return parsed;
   }
   return undefined;
+}
+
+export function parseStrictPositiveIntOrUndefined(value: unknown): number | undefined {
+  return parseStrictPositiveInteger(value);
 }
 
 export function resolveActionArgs(actionCommand?: Command): string[] {

--- a/src/cli/program/register.status-health-sessions.test.ts
+++ b/src/cli/program/register.status-health-sessions.test.ts
@@ -433,6 +433,16 @@ describe("registerStatusHealthSessionsCommands", () => {
     });
   });
 
+  it("rejects partially numeric tasks audit limits", async () => {
+    await runCli(["tasks", "--json", "audit", "--limit", "5abc"]);
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      "--limit must be a positive integer, for example --limit 25.",
+    );
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(tasksAuditCommand).not.toHaveBeenCalled();
+  });
+
   it("routes tasks flow commands through the TaskFlow handlers", async () => {
     await runCli(["tasks", "flow", "list", "--json", "--status", "blocked"]);
     expectCommandOptions(flowsListCommand, {});

--- a/src/cli/program/register.status-health-sessions.ts
+++ b/src/cli/program/register.status-health-sessions.ts
@@ -5,7 +5,7 @@ import { formatDocsLink } from "../../terminal/links.js";
 import { theme } from "../../terminal/theme.js";
 import { runCommandWithRuntime } from "../cli-utils.js";
 import { formatHelpExamples } from "../help-format.js";
-import { parsePositiveIntOrUndefined } from "./helpers.js";
+import { parsePositiveIntOrUndefined, parseStrictPositiveIntOrUndefined } from "./helpers.js";
 
 function resolveVerbose(opts: { verbose?: boolean; debug?: boolean }): boolean {
   return Boolean(opts.verbose || opts.debug);
@@ -67,6 +67,16 @@ function parseTimeoutMs(timeout: unknown): number | null | undefined {
   const parsed = parsePositiveIntOrUndefined(timeout);
   if (timeout !== undefined && parsed === undefined) {
     defaultRuntime.error("--timeout must be a positive integer (milliseconds)");
+    defaultRuntime.exit(1);
+    return null;
+  }
+  return parsed;
+}
+
+function parseTasksAuditLimit(limit: unknown): number | null | undefined {
+  const parsed = parseStrictPositiveIntOrUndefined(limit);
+  if (limit !== undefined && parsed === undefined) {
+    defaultRuntime.error("--limit must be a positive integer, for example --limit 25.");
     defaultRuntime.exit(1);
     return null;
   }
@@ -444,6 +454,10 @@ export function registerStatusHealthSessionsCommands(program: Command) {
     .option("--limit <n>", "Limit displayed findings")
     .action(async (opts, command) => {
       const parentOpts = command.parent?.opts() as { json?: boolean } | undefined;
+      const limit = parseTasksAuditLimit(opts.limit);
+      if (limit === null) {
+        return;
+      }
       await runCommandWithRuntime(defaultRuntime, async () => {
         const { tasksAuditCommand } = await import("../../commands/tasks.js");
         await tasksAuditCommand(
@@ -464,7 +478,7 @@ export function registerStatusHealthSessionsCommands(program: Command) {
               | "missing_linked_tasks"
               | "blocked_task_missing"
               | undefined,
-            limit: parsePositiveIntOrUndefined(opts.limit),
+            limit,
           },
           defaultRuntime,
         );

--- a/src/cli/program/route-args.ts
+++ b/src/cli/program/route-args.ts
@@ -6,6 +6,7 @@ import {
   getVerboseFlag,
   hasFlag,
 } from "../argv.js";
+import { parseStrictPositiveIntOrUndefined } from "./helpers.js";
 
 type OptionalFlagParse = {
   ok: boolean;
@@ -352,8 +353,12 @@ export function parseTasksAuditRouteArgs(argv: string[]) {
   if (!code.ok) {
     return null;
   }
-  const limit = getPositiveIntFlagValue(argv, "--limit");
-  if (limit === null) {
+  const rawLimit = getFlagValue(argv, "--limit");
+  if (rawLimit === null) {
+    return null;
+  }
+  const limit = rawLimit === undefined ? undefined : parseStrictPositiveIntOrUndefined(rawLimit);
+  if (rawLimit !== undefined && limit === undefined) {
     return null;
   }
   return {

--- a/src/cli/program/routes.test.ts
+++ b/src/cli/program/routes.test.ts
@@ -594,6 +594,10 @@ describe("program routes", () => {
     );
     await expectRunFalse(
       ["tasks", "audit"],
+      ["node", "openclaw", "tasks", "audit", "--json", "--limit", "5abc"],
+    );
+    await expectRunFalse(
+      ["tasks", "audit"],
       ["node", "openclaw", "tasks", "audit", "--json", "--unknown"],
     );
     expect(


### PR DESCRIPTION
## Summary

- add strict positive-integer validation for `tasks audit --limit` using the existing central `parseStrictPositiveInteger` parser
- use it for both the registered Commander path and the lean JSON route
- cover the parser, full command registration path, and fast route fallback behavior

Fixes #84899.

## Real behavior proof

- **Behavior or issue addressed:** `tasks audit --limit` no longer accepts partially numeric values such as `1abc` and silently treats them as `1`.
- **Real environment tested:** Local OpenClaw source checkout on macOS, branch `fix/84899-tasks-audit-limit`, commit `75b4b98a0ac014921ec824cf1bedecc3e3f51f31`, Node v24.11.1.
- **Exact steps or command run after this patch:** Ran the real source-entry CLI with isolated temporary state for invalid, signed-valid, and valid `tasks audit --json --limit` values.
- **Evidence after fix:** Copied terminal output from the local source checkout:

```console
$ OPENCLAW_STATE_DIR=$(mktemp -d) node --import tsx src/entry.ts tasks audit --json --limit 1abc
--limit must be a positive integer, for example --limit 25.
```

```console
$ OPENCLAW_STATE_DIR=$(mktemp -d) node --import tsx src/entry.ts tasks audit --json --limit +1
{
  "count": 0,
  "filteredCount": 0,
  "displayed": 0,
  "filters": {
    "severity": null,
    "code": null,
    "limit": 1
  },
  "findings": []
}
```

```console
$ OPENCLAW_STATE_DIR=$(mktemp -d) node --import tsx src/entry.ts tasks audit --json --limit 1
{
  "count": 0,
  "filteredCount": 0,
  "displayed": 0,
  "filters": {
    "severity": null,
    "code": null,
    "limit": 1
  },
  "findings": []
}
```

- **Observed result after fix:** The invalid partial numeric value exits before running the audit, while central-parser-compatible positive integer forms still reach the audit command and are reflected in the JSON filter payload.
- **What was not tested:** I did not run a packaged release binary. The proof uses the real source-entry CLI on the PR head, which exercises the same command registration and route code changed here.

## Validation

- `node scripts/run-vitest.mjs src/cli/program/helpers.test.ts src/cli/program/routes.test.ts src/cli/program/register.status-health-sessions.test.ts`
- `git diff --check`
- `pnpm check:changed`
- `git merge-tree --write-tree HEAD origin/main`

## Collision checks

- Searched open issues and PRs for `tasks audit --limit`, `tasks audit limit`, `Limit displayed findings`, `parsePositiveIntOrUndefined`, and issue `#84899`.
- Searched open PRs touching or referencing `src/cli/program/route-args.ts`, `src/cli/program/register.status-health-sessions.ts`, and `src/cli/program/helpers.ts`.
- Closest active work is adjacent parser or CLI work such as #54646, #84031, #79593, #83956, and my own #84480; none covers the `tasks audit --limit` behavior or closes #84899.