### PR TITLE
fix(openai): honor provider thinking profiles

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-82df91b00ea3eec0e12fd31047b11e64b0dbe2ab48f80d7b91f91122d072931a  plugin-sdk-api-baseline.json
-e9dcd5969e27a7325f7790a2e1d7db6c3aba40a7cbbb5f7af0368f5cc095d17c  plugin-sdk-api-baseline.jsonl
+77d8b50a7c2fdb9517c9c6f15367a57e78a80993c2c9bbfa668b3a8de1873b99  plugin-sdk-api-baseline.json
+d3196af4a14bb22ca1e4e4c119c8b0ca7f741d3db735bf4b813e0a85ab9728f9  plugin-sdk-api-baseline.jsonl

--- a/docs/plugins/sdk-migration.md
+++ b/docs/plugins/sdk-migration.md
@@ -805,7 +805,9 @@ canonical replacement.
     **New**: a single `resolveThinkingProfile(ctx)` that returns a
     `ProviderThinkingProfile` with the canonical `id`, optional `label`, and
     ranked level list. OpenClaw downgrades stale stored values by profile
-    rank automatically.
+    rank automatically. Profiles can set `overridesCatalogReasoning: true`
+    when the provider is the authoritative source and stale catalog
+    `reasoning: false` metadata should not force off-only thinking.
 
     Implement one hook instead of three. The legacy hooks keep working during
     the deprecation window but are not composed with the profile result.

--- a/docs/tools/thinking.md
+++ b/docs/tools/thinking.md
@@ -132,6 +132,7 @@ Malformed local-model reasoning tags are handled conservatively. Closed `<think>
 ## Provider profiles
 
 - Provider plugins can expose `resolveThinkingProfile(ctx)` to define the model's supported levels and default.
+- Set `overridesCatalogReasoning: true` only when the provider profile is authoritative and must override stale catalog `reasoning: false` metadata for that model.
 - Provider plugins that proxy Claude models should reuse `resolveClaudeThinkingProfile(modelId)` from `openclaw/plugin-sdk/provider-model-shared` so direct Anthropic and proxy catalogs stay aligned.
 - Each profile level has a stored canonical `id` (`off`, `minimal`, `low`, `medium`, `high`, `xhigh`, `adaptive`, or `max`) and may include a display `label`. Binary providers use `{ id: "low", label: "on" }`.
 - Tool plugins that need to validate an explicit thinking override should use `api.runtime.agent.resolveThinkingPolicy({ provider, model })` plus `api.runtime.agent.normalizeThinkingLevel(...)`; they should not keep their own provider/model level lists.

--- a/extensions/openai/openai-provider.test.ts
+++ b/extensions/openai/openai-provider.test.ts
@@ -425,6 +425,30 @@ describe("buildOpenAIProvider", () => {
         } as never)
         ?.levels.map((level) => level.id),
     ).toContain("xhigh");
+    expect(
+      provider.resolveThinkingProfile?.({
+        provider: "openai",
+        modelId: "gpt-5.5",
+      } as never)?.overridesCatalogReasoning,
+    ).toBe(true);
+    expect(
+      provider.resolveThinkingProfile?.({
+        provider: "openai",
+        modelId: "gpt-5-chat-latest",
+      } as never)?.overridesCatalogReasoning,
+    ).toBeUndefined();
+    expect(
+      provider.resolveThinkingProfile?.({
+        provider: "openai",
+        modelId: "gpt-5.2-chat-latest",
+      } as never)?.overridesCatalogReasoning,
+    ).toBe(true);
+    expect(
+      provider.resolveThinkingProfile?.({
+        provider: "openai",
+        modelId: "gpt-5.3-chat-latest",
+      } as never)?.overridesCatalogReasoning,
+    ).toBeUndefined();
 
     const entries = provider.augmentModelCatalog?.({
       env: process.env,

--- a/extensions/openai/openai-provider.test.ts
+++ b/extensions/openai/openai-provider.test.ts
@@ -446,6 +446,12 @@ describe("buildOpenAIProvider", () => {
     expect(
       provider.resolveThinkingProfile?.({
         provider: "openai",
+        modelId: "gpt-5.3",
+      } as never)?.overridesCatalogReasoning,
+    ).toBe(true);
+    expect(
+      provider.resolveThinkingProfile?.({
+        provider: "openai",
         modelId: "gpt-5.3-chat-latest",
       } as never)?.overridesCatalogReasoning,
     ).toBeUndefined();

--- a/extensions/openai/thinking-policy.ts
+++ b/extensions/openai/thinking-policy.ts
@@ -32,10 +32,33 @@ function matchesExactOrPrefix(id: string, values: readonly string[]): boolean {
   });
 }
 
+const OPENAI_REASONING_MODEL_PREFIXES = [
+  "gpt-5.3-codex",
+  "gpt-5.5",
+  "gpt-5.4",
+  "gpt-5.2",
+  "gpt-5.1",
+  "gpt-5.1-codex",
+  "gpt-5-codex",
+  "gpt-5-mini",
+  "gpt-5-nano",
+  "gpt-5-pro",
+  "o1",
+  "o3",
+  "o4",
+] as const;
+
+function isOpenAIReasoningModelId(modelId: string): boolean {
+  const normalizedId = normalizeModelId(modelId);
+  return normalizedId === "gpt-5" ||
+    matchesExactOrPrefix(normalizedId, OPENAI_REASONING_MODEL_PREFIXES);
+}
+
 function buildOpenAIThinkingProfile(params: {
   modelId: string;
   xhighModelIds: readonly string[];
 }): ProviderThinkingProfile {
+  const overridesCatalogReasoning = isOpenAIReasoningModelId(params.modelId);
   return {
     levels: [
       ...OPENAI_THINKING_BASE_LEVELS,
@@ -43,6 +66,7 @@ function buildOpenAIThinkingProfile(params: {
         ? [{ id: "xhigh" as const }]
         : []),
     ],
+    ...(overridesCatalogReasoning ? { overridesCatalogReasoning } : {}),
   };
 }
 

--- a/extensions/openai/thinking-policy.ts
+++ b/extensions/openai/thinking-policy.ts
@@ -33,9 +33,9 @@ function matchesExactOrPrefix(id: string, values: readonly string[]): boolean {
 }
 
 const OPENAI_REASONING_MODEL_PREFIXES = [
-  "gpt-5.3-codex",
   "gpt-5.5",
   "gpt-5.4",
+  "gpt-5.3",
   "gpt-5.2",
   "gpt-5.1",
   "gpt-5.1-codex",
@@ -48,8 +48,13 @@ const OPENAI_REASONING_MODEL_PREFIXES = [
   "o4",
 ] as const;
 
+const OPENAI_NON_REASONING_MODEL_IDS = ["gpt-5-chat-latest", "gpt-5.3-chat-latest"] as const;
+
 function isOpenAIReasoningModelId(modelId: string): boolean {
   const normalizedId = normalizeModelId(modelId);
+  if (OPENAI_NON_REASONING_MODEL_IDS.includes(normalizedId)) {
+    return false;
+  }
   return normalizedId === "gpt-5" ||
     matchesExactOrPrefix(normalizedId, OPENAI_REASONING_MODEL_PREFIXES);
 }

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -160,6 +160,105 @@ describe("listThinkingLevels", () => {
     expect(listThinkingLevelLabels("demo", "demo-model")).toEqual(["off", "on"]);
   });
 
+  it("lets authoritative OpenAI provider profiles override stale off-only catalog metadata", () => {
+    providerRuntimeMocks.resolveProviderThinkingProfile.mockImplementation(
+      ({ provider, context }) => {
+        if (provider !== "openai" && provider !== "openai-codex") {
+          return context.reasoning === true
+            ? { levels: [{ id: "off" }, { id: "low" }] }
+            : undefined;
+        }
+        const overridesCatalogReasoning =
+          context.modelId === "gpt-5.4" || context.modelId === "gpt-5.5";
+        return {
+          levels: [
+            { id: "off" },
+            { id: "minimal" },
+            { id: "low" },
+            { id: "medium" },
+            { id: "high" },
+            { id: "xhigh" },
+          ],
+          ...(overridesCatalogReasoning ? { overridesCatalogReasoning } : {}),
+          defaultLevel: "medium",
+        };
+      },
+    );
+    const staleCatalog = [
+      {
+        provider: "openai",
+        id: "gpt-5.4",
+        name: "GPT-5.4",
+        reasoning: false,
+      },
+      {
+        provider: "openai-codex",
+        id: "gpt-5.5",
+        name: "GPT-5.5",
+        reasoning: false,
+      },
+      {
+        provider: "openai",
+        id: "gpt-4.1-mini",
+        name: "GPT-4.1 mini",
+        reasoning: false,
+      },
+      {
+        provider: "openai",
+        id: "gpt-5-chat-latest",
+        name: "GPT-5 Chat Latest",
+        reasoning: false,
+      },
+    ];
+
+    expect(
+      isThinkingLevelSupported({
+        provider: "openai",
+        model: "gpt-5.4",
+        level: "high",
+        catalog: staleCatalog,
+      }),
+    ).toBe(true);
+    expect(
+      isThinkingLevelSupported({
+        provider: "openai-codex",
+        model: "gpt-5.5",
+        level: "high",
+        catalog: staleCatalog,
+      }),
+    ).toBe(true);
+    expect(
+      isThinkingLevelSupported({
+        provider: "openai-codex",
+        model: "gpt-5.5",
+        level: "xhigh",
+        catalog: staleCatalog,
+      }),
+    ).toBe(true);
+    expect(formatThinkingLevels("openai-codex", "gpt-5.5", ", ", staleCatalog)).toBe(
+      "off, minimal, low, medium, high, xhigh",
+    );
+    expect(listThinkingLevels("openai", "gpt-4.1-mini", staleCatalog)).toEqual(["off"]);
+    expect(listThinkingLevels("openai", "gpt-5-chat-latest", staleCatalog)).toEqual(["off"]);
+  });
+
+  it("keeps non-authoritative provider profiles behind catalog reasoning=false", () => {
+    providerRuntimeMocks.resolveProviderThinkingProfile.mockReturnValue({
+      levels: [{ id: "off" }, { id: "low" }, { id: "medium" }, { id: "high" }],
+      defaultLevel: "medium",
+    });
+    const catalog = [
+      {
+        provider: "demo",
+        id: "demo-model",
+        name: "Demo",
+        reasoning: false,
+      },
+    ];
+
+    expect(listThinkingLevels("demo", "demo-model", catalog)).toEqual(["off"]);
+  });
+
   it("treats catalog reasoning=false as an explicit thinking opt-out", () => {
     providerRuntimeMocks.resolveProviderThinkingProfile.mockReturnValue({
       levels: [{ id: "off" }, { id: "low" }, { id: "medium" }, { id: "high" }],

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -169,7 +169,9 @@ describe("listThinkingLevels", () => {
             : undefined;
         }
         const overridesCatalogReasoning =
-          context.modelId === "gpt-5.4" || context.modelId === "gpt-5.5";
+          context.modelId === "gpt-5.3" ||
+          context.modelId === "gpt-5.4" ||
+          context.modelId === "gpt-5.5";
         return {
           levels: [
             { id: "off" },
@@ -185,6 +187,12 @@ describe("listThinkingLevels", () => {
       },
     );
     const staleCatalog = [
+      {
+        provider: "openai",
+        id: "gpt-5.3",
+        name: "GPT-5.3",
+        reasoning: false,
+      },
       {
         provider: "openai",
         id: "gpt-5.4",
@@ -205,12 +213,26 @@ describe("listThinkingLevels", () => {
       },
       {
         provider: "openai",
+        id: "gpt-5.3-chat-latest",
+        name: "GPT-5.3 Chat Latest",
+        reasoning: false,
+      },
+      {
+        provider: "openai",
         id: "gpt-5-chat-latest",
         name: "GPT-5 Chat Latest",
         reasoning: false,
       },
     ];
 
+    expect(
+      isThinkingLevelSupported({
+        provider: "openai",
+        model: "gpt-5.3",
+        level: "high",
+        catalog: staleCatalog,
+      }),
+    ).toBe(true);
     expect(
       isThinkingLevelSupported({
         provider: "openai",
@@ -239,6 +261,7 @@ describe("listThinkingLevels", () => {
       "off, minimal, low, medium, high, xhigh",
     );
     expect(listThinkingLevels("openai", "gpt-4.1-mini", staleCatalog)).toEqual(["off"]);
+    expect(listThinkingLevels("openai", "gpt-5.3-chat-latest", staleCatalog)).toEqual(["off"]);
     expect(listThinkingLevels("openai", "gpt-5-chat-latest", staleCatalog)).toEqual(["off"]);
   });
 

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -55,6 +55,7 @@ type RankedThinkingLevelOption = ThinkingLevelOption & {
 type ResolvedThinkingProfile = {
   levels: RankedThinkingLevelOption[];
   defaultLevel?: ThinkLevel | null;
+  overridesCatalogReasoning?: boolean;
 };
 
 function resolveThinkingPolicyContext(params: {
@@ -113,7 +114,11 @@ function normalizeThinkingProfile(profile: ProviderThinkingProfile): ResolvedThi
     ? normalizeThinkLevel(profile.defaultLevel)
     : undefined;
   const defaultLevel = rawDefaultLevel && byId.has(rawDefaultLevel) ? rawDefaultLevel : undefined;
-  return { levels, defaultLevel };
+  return {
+    levels,
+    defaultLevel,
+    overridesCatalogReasoning: profile.overridesCatalogReasoning === true,
+  };
 }
 
 function buildBaseThinkingProfile(defaultLevel?: ThinkLevel | null): ResolvedThinkingProfile {
@@ -166,18 +171,23 @@ export function resolveThinkingProfile(params: {
     modelId: context.modelId,
     reasoning: context.reasoning,
   };
-  if (context.reasoning === false) {
-    return buildOffOnlyThinkingProfile();
-  }
   const pluginProfile = resolveProviderThinkingProfile({
     provider: context.normalizedProvider,
     context: providerContext,
   });
-  if (pluginProfile) {
-    const normalized = normalizeThinkingProfile(pluginProfile);
-    if (normalized.levels.length > 0) {
-      return normalized;
-    }
+  const normalizedPluginProfile = pluginProfile ? normalizeThinkingProfile(pluginProfile) : null;
+  if (
+    normalizedPluginProfile &&
+    normalizedPluginProfile.levels.length > 0 &&
+    normalizedPluginProfile.overridesCatalogReasoning
+  ) {
+    return normalizedPluginProfile;
+  }
+  if (context.reasoning === false) {
+    return buildOffOnlyThinkingProfile();
+  }
+  if (normalizedPluginProfile && normalizedPluginProfile.levels.length > 0) {
+    return normalizedPluginProfile;
   }
 
   const defaultLevel = resolveProviderDefaultThinkingLevel({

--- a/src/plugins/provider-thinking.types.ts
+++ b/src/plugins/provider-thinking.types.ts
@@ -49,4 +49,9 @@ export type ProviderThinkingLevel = {
 export type ProviderThinkingProfile = {
   levels: ProviderThinkingLevel[] | ReadonlyArray<ProviderThinkingLevel>;
   defaultLevel?: ProviderThinkingLevelId | null;
+  /**
+   * Set when the provider profile is authoritative for this model and should
+   * win over stale catalog `reasoning: false` metadata.
+   */
+  overridesCatalogReasoning?: boolean;
 };


### PR DESCRIPTION
## Summary

Fixes openclaw/openclaw#84880.

OpenAI/Codex GPT-5 thinking validation was still able to collapse to off-only when the model catalog contained a stale `reasoning: false` row. That made `sessions_spawn(...thinking: "high")` reject supported models such as `openai/gpt-5.4` and `openai-codex/gpt-5.5`, even though the OpenAI provider policy advertises non-off reasoning levels.

This patch makes provider thinking profiles explicitly authoritative only when the provider opts in via `overridesCatalogReasoning`. The shared resolver consults that provider profile before honoring catalog `reasoning: false`, while preserving off-only catalog behavior for non-authoritative providers and non-reasoning OpenAI rows such as `gpt-5-chat-latest` / `gpt-5.3-chat-latest`.

Follow-up review feedback is addressed by including the base `gpt-5.3` family in the authoritative OpenAI reasoning classifier while keeping explicit non-reasoning chat-latest rows off-only.

It also updates the public provider thinking profile type, SDK docs, and API baseline so plugin authors have the contract documented.

## Verification

- `git diff --check`
- `node scripts/run-vitest.mjs src/auto-reply/thinking.test.ts extensions/openai/openai-provider.test.ts --reporter=dot`
  - 2 files, 61 tests passed
- `node scripts/run-vitest.mjs src/auto-reply/thinking.test.ts src/agents/openclaw-tools.subagents.sessions-spawn.model.test.ts src/gateway/sessions-patch.test.ts src/auto-reply/reply/directive-handling.model.test.ts --reporter=dot`
  - 6 files, 231 tests passed
- `PNPM_CONFIG_PM_ON_FAIL=ignore PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm plugin-sdk:api:check`
- Local registry-backed runtime policy probe with OpenAI plugin registration and stale catalog metadata:

```text
openai/gpt-5.3 high: supported | levels=off, minimal, low, medium, high
openai/gpt-5.4 high: supported | levels=off, minimal, low, medium, high, xhigh
openai-codex/gpt-5.5 xhigh: supported | levels=off, minimal, low, medium, high, xhigh
openai/gpt-5.3-chat-latest high: rejected | levels=off
```

## Real behavior proof

Behavior addressed: `sessions_spawn` / `/think` shared thinking validation no longer lets stale OpenAI/Codex catalog `reasoning: false` metadata force supported GPT-5 reasoning models to `off` only.

Real environment tested: local Codex worktree on macOS using the repo Vitest wrapper, SDK API baseline check, and a local registry-backed runtime policy probe that registers the bundled OpenAI plugin and calls the shared thinking resolver with stale catalog metadata.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/auto-reply/thinking.test.ts src/agents/openclaw-tools.subagents.sessions-spawn.model.test.ts src/gateway/sessions-patch.test.ts src/auto-reply/reply/directive-handling.model.test.ts --reporter=dot`, plus the local registry-backed OpenAI thinking policy probe shown above.

Evidence after fix: regression coverage now proves `openai/gpt-5.3` and `openai/gpt-5.4` accept `high`, `openai-codex/gpt-5.5` accepts `high`/`xhigh`, and non-reasoning OpenAI chat-latest rows stay off-only under stale catalog metadata.

Observed result after fix: the acceptance suite passed with 6 files and 231 tests, the focused OpenAI/thinking suite passed with 2 files and 61 tests, the SDK API baseline check passed, and the runtime policy probe printed supported non-off levels for `openai/gpt-5.3`, `openai/gpt-5.4`, and `openai-codex/gpt-5.5` while rejecting `openai/gpt-5.3-chat-latest` as off-only.

What was not tested: no live OpenAI/Codex OAuth subagent run was executed. A broad Testbox/Crabbox changed gate was attempted earlier but blocked because the local Crabbox binary failed basic availability/sanity checks.
