### PR TITLE
fix(agents): cap heartbeat context hint fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents: cap heartbeat model bleed context hints by the stored session window when runtime model metadata is unavailable, so overflow recovery advice does not suggest a larger window than the active session actually has.
 - Memory/search: stop recall tracking from writing dreaming side-effect artifacts when `dreaming.enabled=false`, while preserving normal search results. Fixes #84436. (#84444) Thanks @NianJiuZst.
 - Diffs: render viewer toolbar icons from a closed icon-name map instead of HTML strings, removing the toolbar icon XSS sink. (#83955) Thanks @tanshanshan.
 - QA: keep `pnpm qa:e2e` self-check runs inside the private QA runtime envelope even when inherited shell env disables bundled plugins.

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -450,6 +450,113 @@ describe("buildContextOverflowRecoveryText", () => {
     expect(text).not.toContain("reserveTokensFloor");
   });
 
+  it("uses the stored session context window as the uncataloged runtime model fallback", () => {
+    const text = buildContextOverflowRecoveryText({
+      cfg: {
+        models: {
+          providers: {
+            openrouter: {
+              baseUrl: "https://openrouter.test",
+              models: [makeTestModel("qwen3.6-plus", 1_000_000)],
+            },
+          },
+        },
+        agents: {
+          defaults: {
+            contextTokens: 100_000,
+            heartbeat: { model: "ollama/custom-32k" },
+          },
+        },
+      },
+      agentId: "agent",
+      primaryProvider: "openrouter",
+      primaryModel: "qwen3.6-plus",
+      activeSessionEntry: {
+        sessionId: "session",
+        updatedAt: 1,
+        modelProvider: "ollama",
+        model: "custom-32k",
+        contextTokens: 32_768,
+      },
+    });
+
+    expect(text).toContain("ollama/custom-32k (32k context)");
+    expect(text).not.toContain("ollama/custom-32k (98k context)");
+    expect(text).toContain("heartbeat model bleed");
+  });
+
+  it("does not blame heartbeat when the stored session fallback matches the capped primary window", () => {
+    const text = buildContextOverflowRecoveryText({
+      cfg: {
+        models: {
+          providers: {
+            openrouter: {
+              baseUrl: "https://openrouter.test",
+              models: [makeTestModel("qwen3.6-plus", 1_000_000)],
+            },
+          },
+        },
+        agents: {
+          defaults: {
+            contextTokens: 100_000,
+            heartbeat: { model: "ollama/custom-large" },
+          },
+        },
+      },
+      agentId: "agent",
+      primaryProvider: "openrouter",
+      primaryModel: "qwen3.6-plus",
+      activeSessionEntry: {
+        sessionId: "session",
+        updatedAt: 1,
+        modelProvider: "ollama",
+        model: "custom-large",
+        contextTokens: 200_000,
+      },
+    });
+
+    expect(text).toContain("reserveTokensFloor");
+    expect(text).not.toContain("heartbeat model bleed");
+  });
+
+  it("does not blame heartbeat when the same agent cap constrains both cataloged models", () => {
+    const text = buildContextOverflowRecoveryText({
+      cfg: {
+        models: {
+          providers: {
+            openrouter: {
+              baseUrl: "https://openrouter.test",
+              models: [makeTestModel("qwen3.6-plus", 1_000_000)],
+            },
+            ollama: {
+              baseUrl: "http://ollama.test",
+              models: [makeTestModel("custom-large", 1_000_000)],
+            },
+          },
+        },
+        agents: {
+          defaults: {
+            contextTokens: 100_000,
+            heartbeat: { model: "ollama/custom-large" },
+          },
+        },
+      },
+      agentId: "agent",
+      primaryProvider: "openrouter",
+      primaryModel: "qwen3.6-plus",
+      activeSessionEntry: {
+        sessionId: "session",
+        updatedAt: 1,
+        modelProvider: "ollama",
+        model: "custom-large",
+        contextTokens: 1_000_000,
+      },
+    });
+
+    expect(text).toContain("reserveTokensFloor");
+    expect(text).not.toContain("heartbeat model bleed");
+  });
+
   it("does not blame heartbeat when the smaller runtime model is not the configured heartbeat model", () => {
     const text = buildContextOverflowRecoveryText({
       cfg: {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -745,26 +745,58 @@ function formatContextWindowLabel(tokens: number): string {
   return `${Math.round(tokens / 1024)}k`;
 }
 
+function normalizePositiveContextTokens(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return undefined;
+  }
+  return Math.floor(value);
+}
+
+function resolveAgentContextTokensForHint(params: {
+  cfg: FollowupRun["run"]["config"];
+  agentId?: string;
+}): number | undefined {
+  const defaultContextTokens = normalizePositiveContextTokens(
+    params.cfg.agents?.defaults?.contextTokens,
+  );
+  const agentId = normalizeLowercaseStringOrEmpty(params.agentId);
+  const agentContextTokens = agentId
+    ? normalizePositiveContextTokens(
+        params.cfg.agents?.list?.find(
+          (entry) => normalizeLowercaseStringOrEmpty(entry?.id) === agentId,
+        )?.contextTokens,
+      )
+    : undefined;
+  return agentContextTokens ?? defaultContextTokens;
+}
+
 function resolveContextWindowForHint(params: {
   cfg: FollowupRun["run"]["config"];
+  agentId?: string;
   ref: ModelRefLike;
   activeSessionEntry?: SessionEntry;
 }) {
-  const activeContextTokens =
-    typeof params.activeSessionEntry?.contextTokens === "number" &&
-    Number.isFinite(params.activeSessionEntry.contextTokens) &&
-    params.activeSessionEntry.contextTokens > 0
-      ? Math.floor(params.activeSessionEntry.contextTokens)
-      : undefined;
-  return (
-    activeContextTokens ??
-    resolveContextTokensForModel({
-      cfg: params.cfg,
-      provider: params.ref.provider,
-      model: params.ref.model,
-      allowAsyncLoad: false,
-    })
+  const sessionContextTokens = normalizePositiveContextTokens(
+    params.activeSessionEntry?.contextTokens,
   );
+  const modelContextTokens = resolveContextTokensForModel({
+    cfg: params.cfg,
+    provider: params.ref.provider,
+    model: params.ref.model,
+    allowAsyncLoad: false,
+  });
+  const contextTokens = modelContextTokens ?? sessionContextTokens;
+  if (contextTokens === undefined) {
+    return undefined;
+  }
+
+  const agentContextTokens = resolveAgentContextTokensForHint({
+    cfg: params.cfg,
+    agentId: params.agentId,
+  });
+  return agentContextTokens !== undefined
+    ? Math.min(agentContextTokens, contextTokens)
+    : contextTokens;
 }
 
 function resolveHeartbeatBleedHint(params: {
@@ -809,14 +841,14 @@ function resolveHeartbeatBleedHint(params: {
 
   const runtimeWindow = resolveContextWindowForHint({
     cfg: params.cfg,
+    agentId: params.agentId,
     ref: runtimeRef,
     activeSessionEntry: params.activeSessionEntry,
   });
-  const primaryWindow = resolveContextTokensForModel({
+  const primaryWindow = resolveContextWindowForHint({
     cfg: params.cfg,
-    provider: primaryRef.provider,
-    model: primaryRef.model,
-    allowAsyncLoad: false,
+    agentId: params.agentId,
+    ref: primaryRef,
   });
   if (
     typeof runtimeWindow === "number" &&


### PR DESCRIPTION
## Summary

- Problem: heartbeat overflow recovery could recommend an agent cap as the runtime window when model metadata was unavailable.
- Solution: resolve the hint window from model metadata first, fall back to the stored session window, then apply the agent context cap with `Math.min`.
- What changed: added focused regression tests for uncataloged heartbeat runtime models and cap-over-session behavior.
- What did NOT change: runtime model selection, heartbeat execution, compaction behavior, and session persistence.

## Motivation

The recovery text should not tell users to fit into a larger context window than the active session is known to have. With uncataloged runtime models, the stored session metadata is the only trustworthy effective window.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior addressed: context-overflow recovery hints for heartbeat model bleed no longer report an agent cap as the runtime context window when the runtime model is uncataloged and the active session has a smaller stored `contextTokens`.
- Real environment tested: local OpenClaw checkout plus Blacksmith Testbox Linux check lane.
- Exact steps or command run after this patch:
  - `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-execution.test.ts`
  - `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --blacksmith-org openclaw --blacksmith-workflow .github/workflows/ci-check-testbox.yml --blacksmith-job check --blacksmith-ref main --idle-timeout 90m --ttl 240m --timing-json -- CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_TEST_PROJECTS_PARALLEL=6 OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 pnpm check:changed`
- Evidence after fix: Vitest passed 108 tests in `agent-runner-execution.test.ts`; Testbox `tbx_01ks51knykwtyf5sqppaqzqdy3` completed `pnpm check:changed` with exit code 0. GitHub Actions run: https://github.com/openclaw/openclaw/actions/runs/26220721794
- Observed result after fix: the uncataloged 32k runtime model case reports `32k context`, while a larger stored session window is still clamped by a lower 100k agent cap.
- What was not tested: no live provider overflow session was replayed; coverage is focused on the recovery text seam.
- Before evidence (optional but encouraged): the review case described `agents.defaults.contextTokens: 1000000` with a stored session window of 32768 producing unsafe larger-window advice.

## Root Cause (if applicable)

- Root cause: the hint path could treat configured agent context tokens as available window evidence when model metadata was missing, instead of using the stored session window as the fallback.
- Missing detection / guardrail: no regression test covered uncataloged heartbeat runtime models with stored `contextTokens`.
- Contributing context (if known): agent `contextTokens` is a cap, not proof that the selected runtime model can support that window.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/reply/agent-runner-execution.test.ts`
- Scenario the test should lock in: uncataloged heartbeat runtime model with stored session `contextTokens` lower than configured agent cap.
- Why this is the smallest reliable guardrail: the bug is in recovery-copy window resolution, so the exported recovery text builder is the narrowest stable seam.
- Existing test that already covers this (if any): none for the uncataloged fallback case.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Overflow recovery advice can now show a smaller, safer context-window label when the active heartbeat runtime model is only known through session metadata.

## Diagram (if applicable)

```text
Before:
[uncataloged heartbeat runtime] -> [agent cap used as window] -> [unsafe larger-context hint]

After:
[uncataloged heartbeat runtime] -> [stored session window] -> [agent cap clamps only downward]
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS local checkout; Linux Blacksmith Testbox for changed gate.
- Runtime/container: Node/Vitest local wrapper; Blacksmith Testbox `tbx_01ks51knykwtyf5sqppaqzqdy3`.
- Model/provider: mocked OpenRouter primary and Ollama heartbeat refs.
- Integration/channel (if any): auto-reply agent runner recovery text.
- Relevant config (redacted): `agents.defaults.contextTokens` plus `agents.defaults.heartbeat.model`.

### Steps

1. Build overflow recovery text for a primary 1M model with a heartbeat runtime model in the active session.
2. Omit heartbeat model metadata while preserving active session `contextTokens`.
3. Assert the hint labels the runtime with the stored session window and clamps only when the agent cap is lower.

### Expected

- Runtime context label uses the model metadata when available, otherwise the stored session window, then applies the agent cap only as a downward cap.

### Actual

- Matches expected after this patch.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: focused recovery text tests; Blacksmith Testbox changed gate.
- Edge cases checked: uncataloged runtime model below cap; stored runtime window above cap.
- What you did **not** verify: live provider overflow replay.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

AI-assisted: yes; reviewed and verified with the commands above.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: the hint could understate a runtime model window if stored session metadata is stale.
  - Mitigation: model metadata still wins when available; the stored session value is only the fallback for uncataloged or metadata-missing models.
