### PR TITLE
feat(slack): support reply broadcast directive

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -464,6 +464,7 @@ For fine-grained control, use these tags in agent responses:
 
 - `[[reply_to_current]]` — reply to the triggering message (start/continue thread).
 - `[[reply_to:<id>]]` — reply to a specific message id.
+- `[[slack_reply_broadcast]]` (or `[[reply_broadcast]]`) — when the reply is posted in a Slack thread, also share it to the channel using Slack's native `reply_broadcast` behavior. The tag is stripped from visible output and ignored outside Slack or when no thread is selected.
 
 ## Sessions + routing
 

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -89,6 +89,7 @@ export type RunEmbeddedPiAgentParams = {
     replyToId?: string;
     replyToTag?: boolean;
     replyToCurrent?: boolean;
+    slackReplyBroadcast?: boolean;
   }) => void | Promise<void>;
   onBlockReplyFlush?: () => void | Promise<void>;
   blockReplyBreak?: "text_end" | "message_end";

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -40,6 +40,7 @@ export function buildEmbeddedRunPayloads(params: {
   audioAsVoice?: boolean;
   replyToTag?: boolean;
   replyToCurrent?: boolean;
+  slackReplyBroadcast?: boolean;
 }> {
   const replyItems: Array<{
     text: string;
@@ -49,6 +50,7 @@ export function buildEmbeddedRunPayloads(params: {
     replyToId?: string;
     replyToTag?: boolean;
     replyToCurrent?: boolean;
+    slackReplyBroadcast?: boolean;
   }> = [];
 
   const useMarkdown = params.toolResultFormat === "markdown";
@@ -94,6 +96,7 @@ export function buildEmbeddedRunPayloads(params: {
         replyToId,
         replyToTag,
         replyToCurrent,
+        slackReplyBroadcast,
       } = parseReplyDirectives(agg);
       if (cleanedText) {
         replyItems.push({
@@ -103,6 +106,7 @@ export function buildEmbeddedRunPayloads(params: {
           replyToId,
           replyToTag,
           replyToCurrent,
+          slackReplyBroadcast,
         });
       }
     }
@@ -176,6 +180,7 @@ export function buildEmbeddedRunPayloads(params: {
       replyToId,
       replyToTag,
       replyToCurrent,
+      slackReplyBroadcast,
     } = parseReplyDirectives(text);
     if (!cleanedText && (!mediaUrls || mediaUrls.length === 0) && !audioAsVoice) {
       continue;
@@ -187,6 +192,7 @@ export function buildEmbeddedRunPayloads(params: {
       replyToId,
       replyToTag,
       replyToCurrent,
+      slackReplyBroadcast,
     });
   }
 
@@ -241,6 +247,7 @@ export function buildEmbeddedRunPayloads(params: {
       replyToId: item.replyToId,
       replyToTag: item.replyToTag,
       replyToCurrent: item.replyToCurrent,
+      slackReplyBroadcast: item.slackReplyBroadcast,
       audioAsVoice: item.audioAsVoice || Boolean(hasAudioAsVoiceTag && item.media?.length),
     }))
     .filter((p) => {

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -74,6 +74,7 @@ export type EmbeddedRunAttemptParams = {
     replyToId?: string;
     replyToTag?: boolean;
     replyToCurrent?: boolean;
+    slackReplyBroadcast?: boolean;
   }) => void | Promise<void>;
   onBlockReplyFlush?: () => void | Promise<void>;
   blockReplyBreak?: "text_end" | "message_end";

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -312,6 +312,7 @@ export function handleMessageEnd(
             replyToId,
             replyToTag,
             replyToCurrent,
+            slackReplyBroadcast,
           } = splitResult;
           // Emit if there's content OR audioAsVoice flag (to propagate the flag).
           if (cleanedText || (mediaUrls && mediaUrls.length > 0) || audioAsVoice) {
@@ -322,6 +323,7 @@ export function handleMessageEnd(
               replyToId,
               replyToTag,
               replyToCurrent,
+              slackReplyBroadcast,
             });
           }
         }
@@ -346,6 +348,7 @@ export function handleMessageEnd(
         replyToId,
         replyToTag,
         replyToCurrent,
+        slackReplyBroadcast,
       } = tailResult;
       if (cleanedText || (mediaUrls && mediaUrls.length > 0) || audioAsVoice) {
         void onBlockReply({
@@ -355,6 +358,7 @@ export function handleMessageEnd(
           replyToId,
           replyToTag,
           replyToCurrent,
+          slackReplyBroadcast,
         });
       }
     }

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -440,6 +440,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
       replyToId,
       replyToTag,
       replyToCurrent,
+      slackReplyBroadcast,
     } = splitResult;
     // Skip empty payloads, but always emit if audioAsVoice is set (to propagate the flag)
     if (!cleanedText && (!mediaUrls || mediaUrls.length === 0) && !audioAsVoice) {
@@ -452,6 +453,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
       replyToId,
       replyToTag,
       replyToCurrent,
+      slackReplyBroadcast,
     });
   };
 

--- a/src/agents/pi-embedded-subscribe.types.ts
+++ b/src/agents/pi-embedded-subscribe.types.ts
@@ -21,6 +21,7 @@ export type SubscribeEmbeddedPiSessionParams = {
     replyToId?: string;
     replyToTag?: boolean;
     replyToCurrent?: boolean;
+    slackReplyBroadcast?: boolean;
   }) => void | Promise<void>;
   /** Flush pending block replies (e.g., before tool execution to preserve message boundaries). */
   onBlockReplyFlush?: () => void | Promise<void>;

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -88,6 +88,7 @@ function buildReplyTagsSection(isMinimal: boolean) {
     "To request a native reply/quote on supported surfaces, include one tag in your reply:",
     "- [[reply_to_current]] replies to the triggering message.",
     "- [[reply_to:<id>]] replies to a specific message id when you have it.",
+    "- [[slack_reply_broadcast]] (or [[reply_broadcast]]) also shares a Slack thread reply to the channel when a Slack thread is selected.",
     "Whitespace inside the tag is allowed (e.g. [[ reply_to_current ]] / [[ reply_to: 123 ]]).",
     "Tags are stripped before sending; support depends on the current channel config.",
     "",

--- a/src/agents/tools/slack-actions.test.ts
+++ b/src/agents/tools/slack-actions.test.ts
@@ -140,6 +140,27 @@ describe("handleSlackAction", () => {
     });
   });
 
+  it("strips Slack reply broadcast tag and forwards the broadcast request", async () => {
+    const cfg = { channels: { slack: { botToken: "tok" } } } as OpenClawConfig;
+    sendSlackMessage.mockClear();
+
+    await handleSlackAction(
+      {
+        action: "sendMessage",
+        to: "channel:C123",
+        content: "Hello thread [[slack_reply_broadcast]]",
+        threadTs: "1234567890.123456",
+      },
+      cfg,
+    );
+
+    expect(sendSlackMessage).toHaveBeenCalledWith("channel:C123", "Hello thread", {
+      mediaUrl: undefined,
+      threadTs: "1234567890.123456",
+      replyBroadcast: true,
+    });
+  });
+
   it("auto-injects threadTs from context when replyToMode=all", async () => {
     const cfg = { channels: { slack: { botToken: "tok" } } } as OpenClawConfig;
     sendSlackMessage.mockClear();

--- a/src/agents/tools/slack-actions.ts
+++ b/src/agents/tools/slack-actions.ts
@@ -1,5 +1,6 @@
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import type { OpenClawConfig } from "../../config/config.js";
+import { parseReplyDirectives } from "../../auto-reply/reply/reply-directives.js";
 import { resolveSlackAccount } from "../../slack/accounts.js";
 import {
   deleteSlackMessage,
@@ -24,6 +25,17 @@ const messagingActions = new Set(["sendMessage", "editMessage", "deleteMessage",
 
 const reactionsActions = new Set(["react", "reactions"]);
 const pinActions = new Set(["pinMessage", "unpinMessage", "listPins"]);
+
+function readBooleanLike(value: unknown): boolean {
+  if (typeof value === "boolean") {
+    return value;
+  }
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    return normalized === "true" || normalized === "1" || normalized === "yes";
+  }
+  return false;
+}
 
 export type SlackActionContext = {
   /** Current channel ID for auto-threading. */
@@ -169,16 +181,22 @@ export async function handleSlackAction(
       case "sendMessage": {
         const to = readStringParam(params, "to", { required: true });
         const content = readStringParam(params, "content", { required: true });
+        const parsedContent = parseReplyDirectives(content);
         const mediaUrl = readStringParam(params, "mediaUrl");
         const threadTs = resolveThreadTsFromContext(
           readStringParam(params, "threadTs"),
           to,
           context,
         );
-        const result = await sendSlackMessage(to, content, {
+        const replyBroadcast =
+          readBooleanLike(params.replyBroadcast) ||
+          readBooleanLike(params.slackReplyBroadcast) ||
+          Boolean(parsedContent.slackReplyBroadcast);
+        const result = await sendSlackMessage(to, parsedContent.text, {
           ...writeOpts,
           mediaUrl: mediaUrl ?? undefined,
           threadTs: threadTs ?? undefined,
+          ...(replyBroadcast ? { replyBroadcast: true } : {}),
         });
 
         // Keep "first" mode consistent even when the agent explicitly provided

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -79,6 +79,7 @@ export function buildReplyPayloads(params: {
         replyToId: payload.replyToId ?? parsed.replyToId,
         replyToTag: payload.replyToTag || parsed.replyToTag,
         replyToCurrent: payload.replyToCurrent || parsed.replyToCurrent,
+        slackReplyBroadcast: Boolean(payload.slackReplyBroadcast || parsed.slackReplyBroadcast),
         audioAsVoice: Boolean(payload.audioAsVoice || parsed.audioAsVoice),
       };
     })

--- a/src/auto-reply/reply/formatting.test.ts
+++ b/src/auto-reply/reply/formatting.test.ts
@@ -246,6 +246,16 @@ describe("createStreamingDirectiveAccumulator", () => {
     expect(result?.replyToTag).toBe(true);
   });
 
+  it("stashes Slack reply broadcast until a renderable chunk arrives", () => {
+    const accumulator = createStreamingDirectiveAccumulator();
+
+    expect(accumulator.consume("[[slack_reply_broadcast]]")).toBeNull();
+
+    const result = accumulator.consume("Hello");
+    expect(result?.text).toBe("Hello");
+    expect(result?.slackReplyBroadcast).toBe(true);
+  });
+
   it("propagates explicit reply ids across chunks", () => {
     const accumulator = createStreamingDirectiveAccumulator();
 

--- a/src/auto-reply/reply/reply-directives.ts
+++ b/src/auto-reply/reply/reply-directives.ts
@@ -9,6 +9,7 @@ export type ReplyDirectiveParseResult = {
   replyToId?: string;
   replyToCurrent: boolean;
   replyToTag: boolean;
+  slackReplyBroadcast?: boolean;
   audioAsVoice?: boolean;
   isSilent: boolean;
 };
@@ -26,7 +27,7 @@ export function parseReplyDirectives(
     stripReplyTags: true,
   });
 
-  if (replyParsed.hasReplyTag) {
+  if (replyParsed.hasReplyTag || replyParsed.hasSlackReplyBroadcastTag) {
     text = replyParsed.text;
   }
 
@@ -43,6 +44,7 @@ export function parseReplyDirectives(
     replyToId: replyParsed.replyToId,
     replyToCurrent: replyParsed.replyToCurrent,
     replyToTag: replyParsed.hasReplyTag,
+    slackReplyBroadcast: replyParsed.slackReplyBroadcast,
     audioAsVoice: split.audioAsVoice,
     isSilent,
   };

--- a/src/auto-reply/reply/streaming-directives.ts
+++ b/src/auto-reply/reply/streaming-directives.ts
@@ -7,6 +7,7 @@ type PendingReplyState = {
   explicitId?: string;
   sawCurrent: boolean;
   hasTag: boolean;
+  slackReplyBroadcast: boolean;
 };
 
 type ParsedChunk = ReplyDirectiveParseResult & {
@@ -42,7 +43,7 @@ const parseChunk = (raw: string, options?: { silentToken?: string }): ParsedChun
     stripReplyTags: true,
   });
 
-  if (replyParsed.hasReplyTag) {
+  if (replyParsed.hasReplyTag || replyParsed.hasSlackReplyBroadcastTag) {
     text = replyParsed.text;
   }
 
@@ -60,6 +61,7 @@ const parseChunk = (raw: string, options?: { silentToken?: string }): ParsedChun
     replyToExplicitId: replyParsed.replyToExplicitId,
     replyToCurrent: replyParsed.replyToCurrent,
     replyToTag: replyParsed.hasReplyTag,
+    slackReplyBroadcast: replyParsed.slackReplyBroadcast,
     audioAsVoice: split.audioAsVoice,
     isSilent,
   };
@@ -73,11 +75,15 @@ const hasRenderableContent = (parsed: ReplyDirectiveParseResult): boolean =>
 
 export function createStreamingDirectiveAccumulator() {
   let pendingTail = "";
-  let pendingReply: PendingReplyState = { sawCurrent: false, hasTag: false };
+  let pendingReply: PendingReplyState = {
+    sawCurrent: false,
+    hasTag: false,
+    slackReplyBroadcast: false,
+  };
 
   const reset = () => {
     pendingTail = "";
-    pendingReply = { sawCurrent: false, hasTag: false };
+    pendingReply = { sawCurrent: false, hasTag: false, slackReplyBroadcast: false };
   };
 
   const consume = (raw: string, options: ConsumeOptions = {}): ReplyDirectiveParseResult | null => {
@@ -97,6 +103,8 @@ export function createStreamingDirectiveAccumulator() {
     const parsed = parseChunk(combined, { silentToken: options.silentToken });
     const hasTag = pendingReply.hasTag || parsed.replyToTag;
     const sawCurrent = pendingReply.sawCurrent || parsed.replyToCurrent;
+    const slackReplyBroadcast =
+      pendingReply.slackReplyBroadcast || Boolean(parsed.slackReplyBroadcast);
     const explicitId = parsed.replyToExplicitId ?? pendingReply.explicitId;
 
     const combinedResult: ReplyDirectiveParseResult = {
@@ -104,20 +112,22 @@ export function createStreamingDirectiveAccumulator() {
       replyToId: explicitId,
       replyToCurrent: sawCurrent,
       replyToTag: hasTag,
+      slackReplyBroadcast,
     };
 
     if (!hasRenderableContent(combinedResult)) {
-      if (hasTag) {
+      if (hasTag || slackReplyBroadcast) {
         pendingReply = {
           explicitId,
           sawCurrent,
           hasTag,
+          slackReplyBroadcast,
         };
       }
       return null;
     }
 
-    pendingReply = { sawCurrent: false, hasTag: false };
+    pendingReply = { sawCurrent: false, hasTag: false, slackReplyBroadcast: false };
     return combinedResult;
   };
 

--- a/src/auto-reply/types.ts
+++ b/src/auto-reply/types.ts
@@ -49,6 +49,8 @@ export type ReplyPayload = {
   replyToTag?: boolean;
   /** True when [[reply_to_current]] was present but not yet mapped to a message id. */
   replyToCurrent?: boolean;
+  /** Request Slack's thread reply_broadcast when replying in a Slack thread. No-op elsewhere. */
+  slackReplyBroadcast?: boolean;
   /** Send audio as voice message (bubble) instead of audio file. Defaults to false. */
   audioAsVoice?: boolean;
   isError?: boolean;

--- a/src/channels/plugins/outbound/slack.ts
+++ b/src/channels/plugins/outbound/slack.ts
@@ -5,17 +5,18 @@ export const slackOutbound: ChannelOutboundAdapter = {
   deliveryMode: "direct",
   chunker: null,
   textChunkLimit: 4000,
-  sendText: async ({ to, text, accountId, deps, replyToId, threadId }) => {
+  sendText: async ({ to, text, accountId, deps, replyToId, threadId, payload }) => {
     const send = deps?.sendSlack ?? sendMessageSlack;
     // Use threadId fallback so routed tool notifications stay in the Slack thread.
     const threadTs = replyToId ?? (threadId != null ? String(threadId) : undefined);
     const result = await send(to, text, {
       threadTs,
       accountId: accountId ?? undefined,
+      replyBroadcast: Boolean(payload?.slackReplyBroadcast),
     });
     return { channel: "slack", ...result };
   },
-  sendMedia: async ({ to, text, mediaUrl, accountId, deps, replyToId, threadId }) => {
+  sendMedia: async ({ to, text, mediaUrl, accountId, deps, replyToId, threadId, payload }) => {
     const send = deps?.sendSlack ?? sendMessageSlack;
     // Use threadId fallback so routed tool notifications stay in the Slack thread.
     const threadTs = replyToId ?? (threadId != null ? String(threadId) : undefined);
@@ -23,6 +24,7 @@ export const slackOutbound: ChannelOutboundAdapter = {
       mediaUrl,
       threadTs,
       accountId: accountId ?? undefined,
+      replyBroadcast: Boolean(payload?.slackReplyBroadcast),
     });
     return { channel: "slack", ...result };
   },

--- a/src/channels/plugins/slack.actions.ts
+++ b/src/channels/plugins/slack.actions.ts
@@ -94,6 +94,7 @@ export function createSlackActions(providerId: string): ChannelMessageActionAdap
             mediaUrl: mediaUrl ?? undefined,
             accountId: accountId ?? undefined,
             threadTs: threadId ?? replyTo ?? undefined,
+            replyBroadcast: params.replyBroadcast ?? params.slackReplyBroadcast,
           },
           cfg,
           toolContext,

--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -80,6 +80,7 @@ export type ChannelOutboundContext = {
   threadId?: string | number | null;
   accountId?: string | null;
   deps?: OutboundSendDeps;
+  payload?: ReplyPayload;
 };
 
 export type ChannelOutboundPayloadContext = ChannelOutboundContext & {

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import { signalOutbound } from "../../channels/plugins/outbound/signal.js";
+import { slackOutbound } from "../../channels/plugins/outbound/slack.js";
 import { telegramOutbound } from "../../channels/plugins/outbound/telegram.js";
 import { whatsappOutbound } from "../../channels/plugins/outbound/whatsapp.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
@@ -66,6 +67,41 @@ describe("deliverOutboundPayloads", () => {
         process.env.TELEGRAM_BOT_TOKEN = prevTelegramToken;
       }
     }
+  });
+
+  it("passes Slack reply broadcast through only with a resolved thread", async () => {
+    const sendSlack = vi.fn().mockResolvedValue({ messageId: "s1", channelId: "c1" });
+    const cfg: OpenClawConfig = { channels: { slack: { botToken: "tok-1" } } };
+
+    await deliverOutboundPayloads({
+      cfg,
+      channel: "slack",
+      to: "C123",
+      replyToId: "111.222",
+      payloads: [{ text: "hello [[reply_broadcast]]" }],
+      deps: { sendSlack },
+    });
+
+    expect(sendSlack).toHaveBeenCalledWith(
+      "C123",
+      "hello",
+      expect.objectContaining({ threadTs: "111.222", replyBroadcast: true }),
+    );
+
+    sendSlack.mockClear();
+    await deliverOutboundPayloads({
+      cfg,
+      channel: "slack",
+      to: "C123",
+      payloads: [{ text: "hello [[reply_broadcast]]" }],
+      deps: { sendSlack },
+    });
+
+    expect(sendSlack).toHaveBeenCalledWith(
+      "C123",
+      "hello",
+      expect.objectContaining({ threadTs: undefined, replyBroadcast: true }),
+    );
   });
 
   it("passes explicit accountId to sendTelegram", async () => {
@@ -359,6 +395,11 @@ describe("deliverOutboundPayloads", () => {
 
 const emptyRegistry = createTestRegistry([]);
 const defaultRegistry = createTestRegistry([
+  {
+    pluginId: "slack",
+    plugin: createOutboundTestPlugin({ id: "slack", outbound: slackOutbound }),
+    source: "test",
+  },
   {
     pluginId: "telegram",
     plugin: createOutboundTestPlugin({ id: "telegram", outbound: telegramOutbound }),

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -70,8 +70,12 @@ type ChannelHandler = {
   chunkerMode?: "text" | "markdown";
   textChunkLimit?: number;
   sendPayload?: (payload: ReplyPayload) => Promise<OutboundDeliveryResult>;
-  sendText: (text: string) => Promise<OutboundDeliveryResult>;
-  sendMedia: (caption: string, mediaUrl: string) => Promise<OutboundDeliveryResult>;
+  sendText: (text: string, payload?: ReplyPayload) => Promise<OutboundDeliveryResult>;
+  sendMedia: (
+    caption: string,
+    mediaUrl: string,
+    payload?: ReplyPayload,
+  ) => Promise<OutboundDeliveryResult>;
 };
 
 function throwIfAborted(abortSignal?: AbortSignal): void {
@@ -150,7 +154,7 @@ function createPluginHandler(params: {
             payload,
           })
       : undefined,
-    sendText: async (text) =>
+    sendText: async (text, payload) =>
       sendText({
         cfg: params.cfg,
         to: params.to,
@@ -160,8 +164,9 @@ function createPluginHandler(params: {
         threadId: params.threadId,
         gifPlayback: params.gifPlayback,
         deps: params.deps,
+        payload,
       }),
-    sendMedia: async (caption, mediaUrl) =>
+    sendMedia: async (caption, mediaUrl, payload) =>
       sendMedia({
         cfg: params.cfg,
         to: params.to,
@@ -172,6 +177,7 @@ function createPluginHandler(params: {
         threadId: params.threadId,
         gifPlayback: params.gifPlayback,
         deps: params.deps,
+        payload,
       }),
   };
 }
@@ -233,10 +239,10 @@ export async function deliverOutboundPayloads(params: {
       })
     : undefined;
 
-  const sendTextChunks = async (text: string) => {
+  const sendTextChunks = async (text: string, payload?: ReplyPayload) => {
     throwIfAborted(abortSignal);
     if (!handler.chunker || textLimit === undefined) {
-      results.push(await handler.sendText(text));
+      results.push(await handler.sendText(text, payload));
       return;
     }
     if (chunkMode === "newline") {
@@ -256,7 +262,7 @@ export async function deliverOutboundPayloads(params: {
         }
         for (const chunk of chunks) {
           throwIfAborted(abortSignal);
-          results.push(await handler.sendText(chunk));
+          results.push(await handler.sendText(chunk, payload));
         }
       }
       return;
@@ -264,7 +270,7 @@ export async function deliverOutboundPayloads(params: {
     const chunks = handler.chunker(text, textLimit);
     for (const chunk of chunks) {
       throwIfAborted(abortSignal);
-      results.push(await handler.sendText(chunk));
+      results.push(await handler.sendText(chunk, payload));
     }
   };
 
@@ -335,7 +341,7 @@ export async function deliverOutboundPayloads(params: {
         if (isSignalChannel) {
           await sendSignalTextChunks(payloadSummary.text);
         } else {
-          await sendTextChunks(payloadSummary.text);
+          await sendTextChunks(payloadSummary.text, payload);
         }
         continue;
       }
@@ -348,7 +354,7 @@ export async function deliverOutboundPayloads(params: {
         if (isSignalChannel) {
           results.push(await sendSignalMedia(caption, url));
         } else {
-          results.push(await handler.sendMedia(caption, url));
+          results.push(await handler.sendMedia(caption, url, payload));
         }
       }
     } catch (err) {

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -794,6 +794,9 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
   if (!params.replyTo && parsed.replyToId) {
     params.replyTo = parsed.replyToId;
   }
+  if (parsed.slackReplyBroadcast && params.replyBroadcast === undefined) {
+    params.replyBroadcast = true;
+  }
   if (!params.media) {
     // Use path/filePath if media not set, then fall back to parsed directives
     params.media = mergedMediaUrls[0] || undefined;

--- a/src/infra/outbound/payloads.test.ts
+++ b/src/infra/outbound/payloads.test.ts
@@ -3,6 +3,7 @@ import {
   formatOutboundPayloadLog,
   normalizeOutboundPayloads,
   normalizeOutboundPayloadsForJson,
+  normalizeReplyPayloadsForDelivery,
 } from "./payloads.js";
 
 describe("normalizeOutboundPayloadsForJson", () => {
@@ -42,6 +43,22 @@ describe("normalizeOutboundPayloadsForJson", () => {
         text: "",
         mediaUrl: null,
         mediaUrls: ["https://x.test/a.png", "https://x.test/b.png"],
+        channelData: undefined,
+      },
+    ]);
+  });
+
+  it("strips Slack reply broadcast directive from visible payload text", () => {
+    const [payload] = normalizeReplyPayloadsForDelivery([
+      { text: "hello [[slack_reply_broadcast]]" },
+    ]);
+
+    expect(payload).toMatchObject({ text: "hello", slackReplyBroadcast: true });
+    expect(normalizeOutboundPayloadsForJson([payload])).toEqual([
+      {
+        text: "hello",
+        mediaUrl: null,
+        mediaUrls: undefined,
         channelData: undefined,
       },
     ]);

--- a/src/infra/outbound/payloads.ts
+++ b/src/infra/outbound/payloads.ts
@@ -56,6 +56,7 @@ export function normalizeReplyPayloadsForDelivery(payloads: ReplyPayload[]): Rep
       replyToId: payload.replyToId ?? parsed.replyToId,
       replyToTag: payload.replyToTag || parsed.replyToTag,
       replyToCurrent: payload.replyToCurrent || parsed.replyToCurrent,
+      slackReplyBroadcast: Boolean(payload.slackReplyBroadcast || parsed.slackReplyBroadcast),
       audioAsVoice: Boolean(payload.audioAsVoice || parsed.audioAsVoice),
     };
     if (parsed.isSilent && mergedMedia.length === 0) {

--- a/src/slack/actions.ts
+++ b/src/slack/actions.ts
@@ -147,7 +147,11 @@ export async function listSlackReactions(
 export async function sendSlackMessage(
   to: string,
   content: string,
-  opts: SlackActionClientOpts & { mediaUrl?: string; threadTs?: string } = {},
+  opts: SlackActionClientOpts & {
+    mediaUrl?: string;
+    threadTs?: string;
+    replyBroadcast?: boolean;
+  } = {},
 ) {
   return await sendMessageSlack(to, content, {
     accountId: opts.accountId,
@@ -155,6 +159,7 @@ export async function sendSlackMessage(
     mediaUrl: opts.mediaUrl,
     client: opts.client,
     threadTs: opts.threadTs,
+    replyBroadcast: opts.replyBroadcast,
   });
 }
 

--- a/src/slack/monitor/replies.ts
+++ b/src/slack/monitor/replies.ts
@@ -34,6 +34,7 @@ export async function deliverReplies(params: {
         token: params.token,
         threadTs,
         accountId: params.accountId,
+        replyBroadcast: Boolean(payload.slackReplyBroadcast),
       });
     } else {
       let first = true;
@@ -45,6 +46,7 @@ export async function deliverReplies(params: {
           mediaUrl,
           threadTs,
           accountId: params.accountId,
+          replyBroadcast: Boolean(payload.slackReplyBroadcast),
         });
       }
     }

--- a/src/slack/send.reply-broadcast.test.ts
+++ b/src/slack/send.reply-broadcast.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { sendMessageSlack } from "./send.js";
+
+const originalSlackBotToken = process.env.SLACK_BOT_TOKEN;
+
+afterEach(() => {
+  if (originalSlackBotToken === undefined) {
+    delete process.env.SLACK_BOT_TOKEN;
+  } else {
+    process.env.SLACK_BOT_TOKEN = originalSlackBotToken;
+  }
+});
+
+describe("sendMessageSlack reply broadcast", () => {
+  it("sets reply_broadcast only when posting into a Slack thread", async () => {
+    process.env.SLACK_BOT_TOKEN = "xoxb-test";
+    const postMessage = vi.fn().mockResolvedValue({ ts: "333.444" });
+    const client = {
+      chat: { postMessage },
+    };
+
+    await sendMessageSlack("C123", "hello", {
+      client: client as never,
+      threadTs: "111.222",
+      replyBroadcast: true,
+    });
+
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "C123",
+        text: "hello",
+        thread_ts: "111.222",
+        reply_broadcast: true,
+      }),
+    );
+
+    postMessage.mockClear();
+    await sendMessageSlack("C123", "hello", {
+      client: client as never,
+      replyBroadcast: true,
+    });
+
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.not.objectContaining({ reply_broadcast: true }),
+    );
+  });
+});

--- a/src/slack/send.ts
+++ b/src/slack/send.ts
@@ -1,4 +1,8 @@
-import { type FilesUploadV2Arguments, type WebClient } from "@slack/web-api";
+import {
+  type ChatPostMessageArguments,
+  type FilesUploadV2Arguments,
+  type WebClient,
+} from "@slack/web-api";
 import type { SlackTokenSource } from "./accounts.js";
 import {
   chunkMarkdownTextWithMode,
@@ -33,6 +37,7 @@ type SlackSendOpts = {
   mediaUrl?: string;
   client?: WebClient;
   threadTs?: string;
+  replyBroadcast?: boolean;
 };
 
 export type SlackSendResult = {
@@ -170,6 +175,22 @@ export async function sendMessageSlack(
       ? account.config.mediaMaxMb * 1024 * 1024
       : undefined;
 
+  const createPostMessagePayload = (text: string): ChatPostMessageArguments => {
+    if (opts.threadTs && opts.replyBroadcast) {
+      return {
+        channel: channelId,
+        text,
+        thread_ts: opts.threadTs,
+        reply_broadcast: true,
+      };
+    }
+    return {
+      channel: channelId,
+      text,
+      thread_ts: opts.threadTs,
+    };
+  };
+
   let lastMessageId = "";
   if (opts.mediaUrl) {
     const [firstChunk, ...rest] = chunks;
@@ -182,20 +203,12 @@ export async function sendMessageSlack(
       maxBytes: mediaMaxBytes,
     });
     for (const chunk of rest) {
-      const response = await client.chat.postMessage({
-        channel: channelId,
-        text: chunk,
-        thread_ts: opts.threadTs,
-      });
+      const response = await client.chat.postMessage(createPostMessagePayload(chunk));
       lastMessageId = response.ts ?? lastMessageId;
     }
   } else {
     for (const chunk of chunks.length ? chunks : [""]) {
-      const response = await client.chat.postMessage({
-        channel: channelId,
-        text: chunk,
-        thread_ts: opts.threadTs,
-      });
+      const response = await client.chat.postMessage(createPostMessagePayload(chunk));
       lastMessageId = response.ts ?? lastMessageId;
     }
   }

--- a/src/utils/directive-tags.ts
+++ b/src/utils/directive-tags.ts
@@ -4,8 +4,10 @@ export type InlineDirectiveParseResult = {
   replyToId?: string;
   replyToExplicitId?: string;
   replyToCurrent: boolean;
+  slackReplyBroadcast: boolean;
   hasAudioTag: boolean;
   hasReplyTag: boolean;
+  hasSlackReplyBroadcastTag: boolean;
 };
 
 type InlineDirectiveParseOptions = {
@@ -16,6 +18,7 @@ type InlineDirectiveParseOptions = {
 
 const AUDIO_TAG_RE = /\[\[\s*audio_as_voice\s*\]\]/gi;
 const REPLY_TAG_RE = /\[\[\s*(?:reply_to_current|reply_to\s*:\s*([^\]\n]+))\s*\]\]/gi;
+const SLACK_REPLY_BROADCAST_TAG_RE = /\[\[\s*(?:slack_reply_broadcast|reply_broadcast)\s*\]\]/gi;
 
 function normalizeDirectiveWhitespace(text: string): string {
   return text
@@ -34,8 +37,10 @@ export function parseInlineDirectives(
       text: "",
       audioAsVoice: false,
       replyToCurrent: false,
+      slackReplyBroadcast: false,
       hasAudioTag: false,
       hasReplyTag: false,
+      hasSlackReplyBroadcastTag: false,
     };
   }
 
@@ -43,7 +48,9 @@ export function parseInlineDirectives(
   let audioAsVoice = false;
   let hasAudioTag = false;
   let hasReplyTag = false;
+  let hasSlackReplyBroadcastTag = false;
   let sawCurrent = false;
+  let slackReplyBroadcast = false;
   let lastExplicitId: string | undefined;
 
   cleaned = cleaned.replace(AUDIO_TAG_RE, (match) => {
@@ -65,6 +72,11 @@ export function parseInlineDirectives(
     return stripReplyTags ? " " : match;
   });
 
+  cleaned = cleaned.replace(SLACK_REPLY_BROADCAST_TAG_RE, " ");
+  SLACK_REPLY_BROADCAST_TAG_RE.lastIndex = 0;
+  hasSlackReplyBroadcastTag = SLACK_REPLY_BROADCAST_TAG_RE.test(text);
+  slackReplyBroadcast = hasSlackReplyBroadcastTag;
+
   cleaned = normalizeDirectiveWhitespace(cleaned);
 
   const replyToId =
@@ -76,7 +88,9 @@ export function parseInlineDirectives(
     replyToId,
     replyToExplicitId: lastExplicitId,
     replyToCurrent: sawCurrent,
+    slackReplyBroadcast,
     hasAudioTag,
     hasReplyTag,
+    hasSlackReplyBroadcastTag,
   };
 }


### PR DESCRIPTION
## Summary
- adds `[[slack_reply_broadcast]]` / `[[reply_broadcast]]` directive parsing and streaming propagation
- forwards Slack thread replies with `reply_broadcast: true` through outbound send paths and Slack action handling
- adds targeted tests for directive parsing, outbound payload plumbing, Slack action payloads, and Slack send payloads

## Verification
- `corepack pnpm vitest run src/auto-reply/reply/formatting.test.ts src/infra/outbound/deliver.test.ts src/infra/outbound/payloads.test.ts src/slack/send.reply-broadcast.test.ts` ✅
- `corepack pnpm vitest run src/agents/tools/slack-actions.test.ts` ✅
- `corepack pnpm format` ✅
- `corepack pnpm tsgo` ✅
- `corepack pnpm lint` ❌ fails on pre-existing extension type-aware lint errors unrelated to this change (e.g. `extensions/*/runtime.ts` `PluginRuntime` reported as error type)

## Base branch note
This branch targets `develop`. I also checked `origin/main`, but the touched Slack/auto-reply files have diverged heavily or are absent there, causing broad conflicts. The existing worktree changes were originally based on `origin/develop`, and `develop` still exists on the remote.