### PR TITLE
fix(tools): write through workspace symlink parents

### DIFF
--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -860,6 +860,49 @@ async function writeHostFile(absolutePath: string, content: string) {
   await fs.writeFile(resolved, content, "utf-8");
 }
 
+async function resolveWorkspaceOnlyWriteRelative(
+  root: string,
+  absolutePath: string,
+): Promise<string> {
+  const relative = toRelativeWorkspacePath(root, absolutePath);
+  const resolved = path.resolve(root, relative);
+  await assertSandboxPath({ filePath: resolved, cwd: root, root });
+  const rootReal = await fs.realpath(root);
+  const suffix = [path.basename(resolved)];
+  let parent = path.dirname(resolved);
+
+  while (true) {
+    try {
+      const parentReal = await fs.realpath(parent);
+      const canonicalRelative = path.relative(rootReal, path.join(parentReal, ...suffix));
+      if (
+        !canonicalRelative ||
+        canonicalRelative === ".." ||
+        canonicalRelative.startsWith(`..${path.sep}`) ||
+        path.isAbsolute(canonicalRelative)
+      ) {
+        throw new Error(`Path escapes sandbox root (${rootReal}): ${absolutePath}`);
+      }
+      return canonicalRelative.split(path.sep).join(path.posix.sep);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+      const nextParent = path.dirname(parent);
+      if (nextParent === parent) {
+        throw error;
+      }
+      suffix.unshift(path.basename(parent));
+      parent = nextParent;
+    }
+  }
+}
+
+async function writeWorkspaceOnlyHostFile(root: string, absolutePath: string, content: string) {
+  const safeRelative = await resolveWorkspaceOnlyWriteRelative(root, absolutePath);
+  await (await fsRoot(root)).write(safeRelative, content, { mkdir: true });
+}
+
 function createHostWriteOperations(root: string, options?: { workspaceOnly?: boolean }) {
   const workspaceOnly = options?.workspaceOnly ?? false;
 
@@ -875,7 +918,6 @@ function createHostWriteOperations(root: string, options?: { workspaceOnly?: boo
   }
 
   // When workspaceOnly is true, enforce workspace boundary
-  const rootPromise = fsRoot(root);
   return {
     mkdir: async (dir: string) => {
       const relative = toRelativeWorkspacePath(root, dir, { allowRoot: true });
@@ -884,8 +926,7 @@ function createHostWriteOperations(root: string, options?: { workspaceOnly?: boo
       await fs.mkdir(resolved, { recursive: true });
     },
     writeFile: async (absolutePath: string, content: string) => {
-      const relative = toRelativeWorkspacePath(root, absolutePath);
-      await (await rootPromise).write(relative, content, { mkdir: true });
+      await writeWorkspaceOnlyHostFile(root, absolutePath, content);
     },
   } as const;
 }
@@ -917,8 +958,7 @@ function createHostEditOperations(root: string, options?: { workspaceOnly?: bool
       return safeRead.buffer;
     },
     writeFile: async (absolutePath: string, content: string) => {
-      const relative = toRelativeWorkspacePath(root, absolutePath);
-      await (await rootPromise).write(relative, content, { mkdir: true });
+      await writeWorkspaceOnlyHostFile(root, absolutePath, content);
     },
     access: async (absolutePath: string) => {
       let relative: string;

--- a/src/agents/pi-tools.workspace-paths.test.ts
+++ b/src/agents/pi-tools.workspace-paths.test.ts
@@ -184,6 +184,65 @@ describe("workspace path resolution", () => {
     });
   });
 
+  it("writes through in-workspace symlink directories when workspaceOnly is enabled", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    await withTempDir("openclaw-ws-", async (workspaceDir) => {
+      const realDir = path.join(workspaceDir, "oc_system", "memory");
+      const linkDir = path.join(workspaceDir, "memory");
+      await fs.mkdir(realDir, { recursive: true });
+      await fs.symlink(path.relative(workspaceDir, realDir), linkDir);
+
+      const cfg: OpenClawConfig = { tools: { fs: { workspaceOnly: true } } };
+      const tools = createOpenClawCodingTools({ workspaceDir, config: cfg });
+      const { writeTool, editTool } = expectReadWriteEditTools(tools);
+
+      await writeTool.execute("ws-write-symlink-dir", {
+        path: "memory/2026-05-20.md",
+        content: "workspace symlink write ok",
+      });
+      await editTool.execute("ws-edit-symlink-dir", {
+        path: "memory/2026-05-20.md",
+        edits: [{ oldText: "write", newText: "edit" }],
+      });
+      await writeTool.execute("ws-write-symlink-missing-child-dir", {
+        path: "memory/nested/new.md",
+        content: "nested symlink write ok",
+      });
+
+      await expect(fs.readFile(path.join(realDir, "2026-05-20.md"), "utf8")).resolves.toBe(
+        "workspace symlink edit ok",
+      );
+      await expect(fs.readFile(path.join(realDir, "nested", "new.md"), "utf8")).resolves.toBe(
+        "nested symlink write ok",
+      );
+    });
+  });
+
+  it("rejects workspaceOnly writes through symlink directories that escape the workspace", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    await withTempDir("openclaw-ws-", async (workspaceDir) => {
+      await withTempDir("openclaw-outside-", async (outsideDir) => {
+        await fs.symlink(outsideDir, path.join(workspaceDir, "outside-link"));
+
+        const cfg: OpenClawConfig = { tools: { fs: { workspaceOnly: true } } };
+        const tools = createOpenClawCodingTools({ workspaceDir, config: cfg });
+        const { writeTool } = expectReadWriteEditTools(tools);
+
+        await expect(
+          writeTool.execute("ws-write-symlink-escape", {
+            path: "outside-link/secret.txt",
+            content: "must not escape",
+          }),
+        ).rejects.toThrow(/sandbox|outside|escape|alias/i);
+        await expect(fs.access(path.join(outsideDir, "secret.txt"))).rejects.toThrow();
+      });
+    });
+  });
+
   it("rejects hardlinked file aliases when workspaceOnly is enabled", async () => {
     if (process.platform === "win32") {
       return;


### PR DESCRIPTION
## Summary
- Canonicalize workspace-only host write/edit targets through existing symlink parents before delegating to `@openclaw/fs-safe` pinned writes.
- Keep fs-safe write verification for the final write while allowing in-workspace symlink directories like `memory -> oc_system/memory`.
- Add regressions for write/edit through in-workspace symlink parents, nested missing child directories, symlink escapes, and existing hardlink rejection coverage.

Fixes #84696

## Real behavior proof

Behavior addressed: the host `write` and `edit` tools with `tools.fs.workspaceOnly=true` should write through symlink directory components that resolve inside the workspace, while still rejecting symlink paths that escape the workspace.

Real environment tested: Local OpenClaw checkout on macOS, Node.js v22.22.0. I invoked the real `createOpenClawCodingTools` runtime path with workspace-only filesystem tools and real temp directories/symlinks on disk.

Exact steps or command run after the patch:
```console
$ node --import tsx --input-type=module <<'EOF'
import fs from 'node:fs/promises';
import os from 'node:os';
import path from 'node:path';
import { createOpenClawCodingTools } from './src/agents/pi-tools.ts';
const root = await fs.mkdtemp(path.join(os.tmpdir(), 'openclaw-real-symlink-write-'));
try {
  const realDir = path.join(root, 'oc_system', 'memory');
  const linkDir = path.join(root, 'memory');
  const outside = await fs.mkdtemp(path.join(os.tmpdir(), 'openclaw-outside-'));
  await fs.mkdir(realDir, { recursive: true });
  await fs.symlink(path.relative(root, realDir), linkDir);
  await fs.symlink(outside, path.join(root, 'outside-link'));
  const tools = createOpenClawCodingTools({ workspaceDir: root, config: { tools: { fs: { workspaceOnly: true } } } });
  const writeTool = tools.find((tool) => tool.name === 'write');
  const editTool = tools.find((tool) => tool.name === 'edit');
  if (!writeTool || !editTool) throw new Error('missing fs tools');
  await writeTool.execute('real-write-symlink', { path: 'memory/2026-05-20.md', content: 'workspace symlink write ok' });
  await editTool.execute('real-edit-symlink', { path: 'memory/2026-05-20.md', edits: [{ oldText: 'write', newText: 'edit' }] });
  await writeTool.execute('real-write-nested-symlink', { path: 'memory/nested/new.md', content: 'nested symlink write ok' });
  let escapeBlocked = false;
  try {
    await writeTool.execute('real-write-symlink-escape', { path: 'outside-link/secret.txt', content: 'must not escape' });
  } catch (error) {
    escapeBlocked = /sandbox|outside|escape|alias/i.test(String(error?.message ?? error));
  }
  const direct = await fs.readFile(path.join(realDir, '2026-05-20.md'), 'utf8');
  const nested = await fs.readFile(path.join(realDir, 'nested', 'new.md'), 'utf8');
  const outsideExists = await fs.access(path.join(outside, 'secret.txt')).then(() => true, () => false);
  console.log(JSON.stringify({ direct, nested, escapeBlocked, outsideExists }, null, 2));
  await fs.rm(outside, { recursive: true, force: true });
} finally {
  await fs.rm(root, { recursive: true, force: true });
}
EOF
```

Evidence after fix:
```console
{
  "direct": "workspace symlink edit ok",
  "nested": "nested symlink write ok",
  "escapeBlocked": true,
  "outsideExists": false
}
```

Observed result after fix: Workspace-only `write` and `edit` succeed through `memory/` when it is a symlink to the in-workspace `oc_system/memory/` directory, including a nested directory that did not exist yet. A symlink directory that resolves outside the workspace is blocked and does not create the outside file.

What was not tested: I did not run a live long-running agent session with context compaction; this proof exercises the real host fs tools directly in the same runtime path used by agent file tools.

## Test plan
- `node scripts/run-vitest.mjs src/agents/pi-tools.workspace-paths.test.ts`
- `node scripts/run-vitest.mjs src/agents/pi-tools.workspace-only-false.test.ts src/infra/fs-safe.test.ts`
- `node scripts/run-vitest.mjs src/agents/sandbox/fs-bridge.anchored-ops.test.ts`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/pi-tools.read.ts src/agents/pi-tools.workspace-paths.test.ts`
- `pnpm exec oxfmt --write --threads=1 src/agents/pi-tools.read.ts src/agents/pi-tools.workspace-paths.test.ts`
- `git diff --check`