### PR TITLE
fix(agents): write through workspace symlink parents

### DIFF
--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -4,7 +4,11 @@ import { URL } from "node:url";
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import { createEditTool, createReadTool, createWriteTool } from "@earendil-works/pi-coding-agent";
 import { isWindowsDrivePath } from "../infra/archive-path.js";
-import { root as fsRoot, FsSafeError } from "../infra/fs-safe.js";
+import {
+  canonicalPathFromExistingAncestor,
+  root as fsRoot,
+  FsSafeError,
+} from "../infra/fs-safe.js";
 import { expandHomePrefix, resolveOsHomeDir } from "../infra/home-dir.js";
 import { hasEncodedFileUrlSeparator, trySafeFileURLToPath } from "../infra/local-file-access.js";
 import { detectMime } from "../media/mime.js";
@@ -860,6 +864,45 @@ async function writeHostFile(absolutePath: string, content: string) {
   await fs.writeFile(resolved, content, "utf-8");
 }
 
+function assertCanonicalWorkspaceRelativePath(params: {
+  root: string;
+  candidate: string;
+  relative: string;
+}): string {
+  if (
+    params.relative === "" ||
+    params.relative === "." ||
+    params.relative === ".." ||
+    params.relative.startsWith("../") ||
+    params.relative.startsWith("..\\") ||
+    path.isAbsolute(params.relative)
+  ) {
+    throw new Error(`Path escapes workspace root (${params.root}): ${params.candidate}`);
+  }
+  return params.relative;
+}
+
+async function toCanonicalParentWorkspaceRelativePath(
+  root: string,
+  absolutePath: string,
+): Promise<string> {
+  const relative = toRelativeWorkspacePath(root, absolutePath);
+  const resolvedRoot = path.resolve(root);
+  const lexicalTarget = path.resolve(resolvedRoot, relative);
+  await assertSandboxPath({ filePath: lexicalTarget, cwd: resolvedRoot, root: resolvedRoot });
+
+  const [canonicalRoot, canonicalParent] = await Promise.all([
+    fs.realpath(resolvedRoot),
+    canonicalPathFromExistingAncestor(path.dirname(lexicalTarget)),
+  ]);
+  const canonicalTarget = path.join(canonicalParent, path.basename(lexicalTarget));
+  return assertCanonicalWorkspaceRelativePath({
+    root: canonicalRoot,
+    candidate: absolutePath,
+    relative: path.relative(canonicalRoot, canonicalTarget),
+  });
+}
+
 function createHostWriteOperations(root: string, options?: { workspaceOnly?: boolean }) {
   const workspaceOnly = options?.workspaceOnly ?? false;
 
@@ -884,7 +927,7 @@ function createHostWriteOperations(root: string, options?: { workspaceOnly?: boo
       await fs.mkdir(resolved, { recursive: true });
     },
     writeFile: async (absolutePath: string, content: string) => {
-      const relative = toRelativeWorkspacePath(root, absolutePath);
+      const relative = await toCanonicalParentWorkspaceRelativePath(root, absolutePath);
       await (await rootPromise).write(relative, content, { mkdir: true });
     },
   } as const;
@@ -917,7 +960,7 @@ function createHostEditOperations(root: string, options?: { workspaceOnly?: bool
       return safeRead.buffer;
     },
     writeFile: async (absolutePath: string, content: string) => {
-      const relative = toRelativeWorkspacePath(root, absolutePath);
+      const relative = await toCanonicalParentWorkspaceRelativePath(root, absolutePath);
       await (await rootPromise).write(relative, content, { mkdir: true });
     },
     access: async (absolutePath: string) => {

--- a/src/agents/pi-tools.workspace-paths.test.ts
+++ b/src/agents/pi-tools.workspace-paths.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { configureFsSafePython, getFsSafePythonConfig } from "@openclaw/fs-safe/config";
 import { describe, expect, it, vi } from "vitest";
 import "./test-helpers/fast-coding-tools.js";
 import "./test-helpers/fast-openclaw-tools.js";
@@ -22,6 +23,16 @@ async function withTempDir<T>(prefix: string, fn: (dir: string) => Promise<T>) {
     return await fn(dir);
   } finally {
     await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+async function withFsSafePythonAuto<T>(fn: () => Promise<T>): Promise<T> {
+  const previous = getFsSafePythonConfig();
+  configureFsSafePython({ mode: "auto", pythonPath: previous.pythonPath });
+  try {
+    return await fn();
+  } finally {
+    configureFsSafePython(previous);
   }
 }
 
@@ -223,6 +234,66 @@ describe("workspace path resolution", () => {
       }
     });
   });
+
+  it.runIf(process.platform !== "win32")(
+    "allows workspaceOnly write and edit through symlinked directory parents inside the workspace",
+    async () => {
+      await withFsSafePythonAuto(async () => {
+        await withTempDir("openclaw-ws-symlink-write-", async (workspaceDir) => {
+          const realDir = path.join(workspaceDir, "oc_system", "memory");
+          const linkDir = path.join(workspaceDir, "memory");
+          await fs.mkdir(realDir, { recursive: true });
+          await fs.symlink(path.relative(workspaceDir, realDir), linkDir, "dir");
+
+          const cfg: OpenClawConfig = { tools: { fs: { workspaceOnly: true } } };
+          const tools = createOpenClawCodingTools({ workspaceDir, config: cfg });
+          const { writeTool, editTool } = expectReadWriteEditTools(tools);
+
+          await writeTool.execute("ws-write-symlink-parent", {
+            path: path.join("memory", "note.md"),
+            content: "through symlink",
+          });
+          expect(await fs.readFile(path.join(realDir, "note.md"), "utf8")).toBe("through symlink");
+
+          await editTool.execute("ws-edit-symlink-parent", {
+            path: path.join("memory", "note.md"),
+            edits: [{ oldText: "symlink", newText: "canonical parent" }],
+          });
+          expect(await fs.readFile(path.join(realDir, "note.md"), "utf8")).toBe(
+            "through canonical parent",
+          );
+        });
+      });
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "rejects workspaceOnly writes through symlinked directory parents outside the workspace",
+    async () => {
+      await withTempDir("openclaw-ws-symlink-escape-", async (rootDir) => {
+        const workspaceDir = path.join(rootDir, "workspace");
+        const outsideDir = path.join(rootDir, "outside");
+        const linkDir = path.join(workspaceDir, "escape");
+        await fs.mkdir(workspaceDir, { recursive: true });
+        await fs.mkdir(outsideDir, { recursive: true });
+        await fs.symlink(outsideDir, linkDir, "dir");
+
+        const cfg: OpenClawConfig = { tools: { fs: { workspaceOnly: true } } };
+        const tools = createOpenClawCodingTools({ workspaceDir, config: cfg });
+        const { writeTool } = expectReadWriteEditTools(tools);
+
+        await expect(
+          writeTool.execute("ws-write-symlink-escape", {
+            path: path.join("escape", "outside.md"),
+            content: "outside",
+          }),
+        ).rejects.toThrow(/outside|escape|workspace root|sandbox root/i);
+        await expect(fs.readFile(path.join(outsideDir, "outside.md"), "utf8")).rejects.toThrow(
+          /ENOENT/,
+        );
+      });
+    },
+  );
 
   it("allows workspaceOnly reads for resolved skill roots without allowing other filesystem access", async () => {
     await withTempDir("openclaw-skill-read-", async (rootDir) => {


### PR DESCRIPTION
Fixes #84696

## Summary

- Canonicalize the existing parent path before workspace-only host write/edit calls hand the target to the fs-safe root writer.
- Keep the existing lexical workspace guard and sandbox path guard before canonicalization, so symlink parents that point outside the workspace are still rejected.
- Add regression coverage for write/edit through an in-workspace symlink parent and for rejection of symlink parents that escape the workspace.

## Root cause

`toRelativeWorkspacePath` produced a root-relative path like `memory/note.md` when `memory` was a symlink inside the workspace. The fs-safe root writer operates on pinned root-relative paths and does not treat a symlinked directory component as an ordinary directory for this path, so the write path could fail with `Not a directory: 'memory'` even though the symlink target was still inside the workspace.

This change canonicalizes only the parent directory that already exists, then joins the original basename back on. That lets valid in-workspace symlink parents work while preserving the final-file symlink and hardlink checks in fs-safe.

## Real behavior proof

Behavior or issue addressed: Workspace-only host `write` and `edit` should work when an in-workspace parent directory is a symlink to another in-workspace directory, while still blocking symlink parents that escape the workspace.

Real environment tested: Local OpenClaw source checkout on macOS, temporary filesystem workspace, actual OpenClaw coding tools from `createOpenClawCodingTools`, with `tools.fs.workspaceOnly: true`.

Exact steps or command run after this patch: I ran `node --import tsx --input-type=module <real-tool proof script>`. The script created `memory -> oc_system/memory`, called the real `write` tool for `memory/note.md`, then called the real `edit` tool on the same path. It also created `escape -> <outside workspace>` and attempted a real workspace-only `write` through that escaping parent.

Evidence after fix: Copied live terminal output from the real tool-path proof run:

```json
{
  "command": "node --import tsx --input-type=module <real-tool proof script>",
  "workspaceOnly": true,
  "positiveContent": "through canonical parent",
  "escapeRejected": true,
  "outsideCreated": false,
  "escapeError": "Symlink escapes sandbox root (.../escape-workspace): .../escape-workspace/escape"
}
```

Observed result after fix: The real `write` and `edit` calls completed through the in-workspace symlink parent, and the resulting file content at the real target was `through canonical parent`. The escaping symlink parent was rejected and no outside file was created.

What was not tested: I did not run the full repo-wide `pnpm build && pnpm check && pnpm test` locally. I also attempted `codex review --base upstream/main`, but the local model stream disconnected and retried, then remained active for about 9.5 minutes without emitting findings, so I stopped it before opening this PR.

## Validation

- `node scripts/run-vitest.mjs src/agents/pi-tools.workspace-paths.test.ts --testNamePattern "symlinked directory parents"` passed: 4 tests passed, 20 skipped.
- `OPENCLAW_FS_SAFE_PYTHON_MODE=auto node scripts/run-vitest.mjs src/agents/pi-tools.workspace-paths.test.ts src/agents/pi-tools.workspace-only-false.test.ts src/infra/fs-safe.test.ts` passed: 76 tests passed.
- `node scripts/run-vitest.mjs src/agents/sandbox/fs-bridge.anchored-ops.test.ts` passed: 18 tests passed.
- `node scripts/check-changed.mjs src/agents/pi-tools.read.ts src/agents/pi-tools.workspace-paths.test.ts` passed.
- `git diff --check` passed.

Not completed locally:

- `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --shell -- "pnpm check:changed"` did not reach `pnpm check:changed`; the local crabbox binary failed its sanity check with `version=unknown provider=blacksmith-testbox providers=unknown`.
- `codex review --base upstream/main` was attempted, but the local model stream disconnected and retried, then remained active for about 9.5 minutes without emitting findings, so I stopped it before opening this PR.

AI-assisted: yes. I reviewed the diff and understand the change.
