### PR TITLE
fix: duplicate probeAgent property in the ACPX manifest is hidden by JSON.parse-based...

### DIFF
--- a/extensions/acpx/openclaw.plugin.json
+++ b/extensions/acpx/openclaw.plugin.json
@@ -19,10 +19,6 @@
         "type": "string",
         "minLength": 1
       },
-      "probeAgent": {
-        "type": "string",
-        "minLength": 1
-      },
       "permissionMode": {
         "type": "string",
         "enum": ["approve-all", "approve-reads", "deny-all"]

--- a/extensions/acpx/src/config.test.ts
+++ b/extensions/acpx/src/config.test.ts
@@ -11,6 +11,23 @@ function expectedSourceMcpServerArgs(entrypoint: string): string[] {
   return ["--import", TSX_IMPORT, path.resolve(entrypoint)];
 }
 
+function readManifestConfigPropertyKeys(manifestText: string): string[] {
+  const configSchemaStart = manifestText.indexOf('  "configSchema": {');
+  const propertiesStart = manifestText.indexOf('    "properties": {', configSchemaStart);
+  const uiHintsStart = manifestText.indexOf('  "uiHints": {', propertiesStart);
+  if (configSchemaStart === -1 || propertiesStart === -1 || uiHintsStart === -1) {
+    throw new Error("Unable to locate ACPX manifest configSchema.properties block");
+  }
+
+  return manifestText
+    .slice(propertiesStart, uiHintsStart)
+    .split("\n")
+    .flatMap((line) => {
+      const match = /^      "([^"]+)": \{$/.exec(line);
+      return match ? [match[1]] : [];
+    });
+}
+
 describe("embedded acpx plugin config", () => {
   it("resolves workspace stateDir and cwd by default", () => {
     const workspaceDir = path.resolve("/tmp/openclaw-acpx");
@@ -192,9 +209,27 @@ describe("embedded acpx plugin config", () => {
 
   it("keeps the runtime json schema in sync with the manifest config schema", () => {
     const pluginRoot = resolveAcpxPluginRoot();
-    const manifest = JSON.parse(
-      fs.readFileSync(path.join(pluginRoot, "openclaw.plugin.json"), "utf8"),
-    ) as { configSchema?: unknown };
+    const manifestText = fs.readFileSync(path.join(pluginRoot, "openclaw.plugin.json"), "utf8");
+    const manifestConfigPropertyKeys = readManifestConfigPropertyKeys(manifestText);
+    const expectedManifestConfigPropertyKeys = [
+      "cwd",
+      "stateDir",
+      "permissionMode",
+      "nonInteractivePermissions",
+      "pluginToolsMcpBridge",
+      "openClawToolsMcpBridge",
+      "strictWindowsCmdWrapper",
+      "timeoutSeconds",
+      "queueOwnerTtlSeconds",
+      "probeAgent",
+      "mcpServers",
+      "agents",
+    ];
+
+    // JSON.parse keeps only one duplicate key, so compare raw manifest keys before parsing.
+    expect(manifestConfigPropertyKeys).toStrictEqual(expectedManifestConfigPropertyKeys);
+
+    const manifest = JSON.parse(manifestText) as { configSchema?: unknown };
 
     expect(manifest.configSchema).toStrictEqual({
       type: "object",


### PR DESCRIPTION
Hi,

I opened this PR to address a RepoVista finding in openclaw/openclaw: Duplicate probeAgent property in the ACPX manifest is hidden by JSON.parse-based sync test. The implementation is intended to stay focused on the affected files and the evidence from the audit.

## Real Behavior Proof

Behavior or issue addressed:
The ACPX plugin manifest previously had duplicate raw `configSchema.properties.probeAgent` entries, while the JSON.parse-based sync test only observed one parsed property. After the patch, the raw manifest config schema block contains exactly one `probeAgent` key.

Real environment tested:
Local OpenClaw PR checkout at head commit `f525774f`, branch `repovista/fix-fnd_a2aacb46f63b-pat_6bafab709321`, with a clean working tree.

Exact steps or command run after this patch:
```sh
git rev-parse --short HEAD
git branch --show-current
git status --short
node -e 'const fs=require("fs"); const text=fs.readFileSync("extensions/acpx/openclaw.plugin.json","utf8"); const start=text.indexOf("\"configSchema\""); const end=text.indexOf("\"uiHints\""); const block=text.slice(start,end); console.log((block.match(/"probeAgent"\s*:/g)||[]).length);'
pnpm exec vitest run extensions/acpx/src/config.test.ts --project extension-acpx
```

Evidence after fix:
Copied terminal output from the local OpenClaw PR checkout:
```text
f525774f
repovista/fix-fnd_a2aacb46f63b-pat_6bafab709321
(git status --short produced no output)
1

RUN  v4.1.7 [local PR worktree]

Test Files  1 passed (1)
     Tests  14 passed (14)
  Start at  12:45:32
  Duration  528ms
```

The full ACPX extension test was also run by RepoVista publish on the same PR worktree/head before opening the PR:
```text
$ pnpm test:extension acpx
[test-extension] Running 12 test files for acpx

RUN  v4.1.7 [local PR worktree]

Test Files  12 passed (12)
     Tests  124 passed (124)
  Start at  12:31:01
  Duration  1.68s
```

Observed result after fix:
The live `node` manifest scan printed `1`, so the raw ACPX `configSchema` block now has one `probeAgent` key before `uiHints`. The focused ACPX config test passed with `1 passed (1)` and `14 passed (14)`. The recorded full extension lane passed with `12 passed (12)` and `124 passed (124)`.

What was not tested:
I did not launch the full OpenClaw desktop/server runtime or perform a UI workflow, because this PR changes static plugin manifest metadata and its config-schema sync test only. No network, auth, dependency, or runtime execution behavior is intentionally changed.

## RepoVista Patch Attempt

<!-- repovista:patch:pat_6bafab709321 -->

- Patch: pat_6bafab709321
- Status: pr-opened
- Repository: openclaw/openclaw
- Analyzed commit: [88fe39bc8bcb](https://github.com/openclaw/openclaw/commit/88fe39bc8bcb2d79133066111f9cdc5d916eb4d9)
- RepoVista run: 2026-05-21T08-29-16-082Z
- Findings: fnd_a2aacb46f63b
- Features: feat_504165884468

## Plan

Finding: fnd_a2aacb46f63b - Duplicate probeAgent property in the ACPX manifest is hidden by JSON.parse-based sync test
Severity: low
Feature: feat_504165884468
Affected paths: extensions/acpx/openclaw.plugin.json, extensions/acpx/src/config.test.ts
Minimum fix scope: `extensions/acpx/openclaw.plugin.json` and `extensions/acpx/src/manifest.test.ts` or `config.test.ts`.
Recommended fix: Remove one `probeAgent` definition and add a duplicate-key check for plugin manifests before `JSON.parse`, or generate the manifest schema from a single source.
Suggested regression test: Add a manifest test with a duplicate-key-capable parser or scanner for `configSchema.properties`.

## Files Changed

- extensions/acpx/openclaw.plugin.json
- extensions/acpx/src/config.test.ts

## Scope Gate

- Status: passed
- Max files: 12
- Allowed paths: extensions/acpx/openclaw.plugin.json, extensions/acpx/src/config.test.ts
- Violations: none

## Validation

- pnpm test:extension acpx: 0

## Contribution Guidelines

- Policy mode: enforce
- Sources reviewed: .github/ISSUE_TEMPLATE/bug_report.yml, .github/ISSUE_TEMPLATE/config.yml, .github/ISSUE_TEMPLATE/feature_request.yml, .github/pull_request_template.md, CONTRIBUTING.md, README.md, SECURITY.md
- Behavior proof: include reproduction, observed behavior, or validation details where applicable.
- AI disclosure: AI-assisted; RepoVista helped identify and prepare this publication from an audit finding.
- Required guideline checks: pnpm build, pnpm check, pnpm test
- Context-specific guideline checks mentioned: pnpm test:channels, pnpm test:contracts, pnpm test:contracts:channels, pnpm test:contracts:plugins, pnpm test:docker:all, pnpm test:e2e, pnpm test:extensions, pnpm test:live
- Security reporting: Still interested? Email contributing@openclaw.ai with: ## Report a Vulnerability We take security reports seriously. Report vulnerabilities directly to the repository where the issue lives: For issues that don't fit a specific repo, or if you're unsure, email **security@openclaw.ai** and we'll route it.

## Pull Request Template Fields

### Summary

Finding: fnd_a2aacb46f63b - Duplicate probeAgent property in the ACPX manifest is hidden by JSON.parse-based sync test
Severity: low
Feature: feat_504165884468
Affected paths: extensions/acpx/openclaw.plugin.json, extensions/acpx/src/config.test.ts
Minimum fix scope: `extensions/acpx/openclaw.plugin.json` and `extensions/acpx/src/manifest.test.ts` or `config.test.ts`.
Recommended fix: Remove one `probeAgent` definition and add a duplicate-key check for plugin manifests before `JSON.parse`, or generate the manifest schema from a single source.
Suggested regression test: Add a manifest test with a duplicate-key-capable parser or scanner for `configSchema.properties`.

### Motivation

Finding: fnd_a2aacb46f63b - Duplicate probeAgent property in the ACPX manifest is hidden by JSON.parse-based sync test
Severity: low
Feature: feat_504165884468
Affected paths: extensions/acpx/openclaw.plugin.json, extensions/acpx/src/config.test.ts
Minimum fix scope: `extensions/acpx/openclaw.plugin.json` and `extensions/acpx/src/manifest.test.ts` or `config.test.ts`.
Recommended fix: Remove one `probeAgent` definition and add a duplicate-key check for plugin manifests before `JSON.parse`, or generate the manifest schema from a single source.
Suggested regression test: Add a manifest test with a duplicate-key-capable parser or scanner for `configSchema.properties`.

### Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

### Scope (select all touched areas)

- extensions/acpx/openclaw.plugin.json
- extensions/acpx/src/config.test.ts

### Linked Issue/PR

- RepoVista finding fnd_a2aacb46f63b

### Real behavior proof (required for external PRs)

- Behavior or issue addressed: the selected RepoVista finding described in this PR.
- Real environment tested: generated RepoVista publish worktree.
- Exact steps or command run after this patch:
- pnpm test:extension acpx: 0
- Evidence after fix: validation command result(s) above and the focused diff in this PR.
- Observed result after fix: the patch stayed within the selected finding scope.
- What was not tested: full application runtime behavior unless listed above.

### Root Cause (if applicable)

Finding: fnd_a2aacb46f63b - Duplicate probeAgent property in the ACPX manifest is hidden by JSON.parse-based sync test
Severity: low
Feature: feat_504165884468
Affected paths: extensions/acpx/openclaw.plugin.json, extensions/acpx/src/config.test.ts
Minimum fix scope: `extensions/acpx/openclaw.plugin.json` and `extensions/acpx/src/manifest.test.ts` or `config.test.ts`.
Recommended fix: Remove one `probeAgent` definition and add a duplicate-key check for plugin manifests before `JSON.parse`, or generate the manifest schema from a single source.
Suggested regression test: Add a manifest test with a duplicate-key-capable parser or scanner for `configSchema.properties`.

### Regression Test Plan (if applicable)

- pnpm test:extension acpx: 0

### Uservisible / Behavior Changes

N/A

### Diagram (if applicable)

N/A

### Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

### Repro + Verification

n/a

### Environment

- OS: generated RepoVista publish worktree
- Provider: codex / gpt-5.5 / xhigh
- Relevant config: repository checkout at the analyzed commit

### Steps

1. pnpm test:extension acpx

### Expected

The changed surface should no longer exhibit the selected RepoVista finding and the targeted regression guard should cover it.

### Actual

Recorded validation result:
- pnpm test:extension acpx: 0

### Evidence

- [x] Passing targeted validation
- pnpm test:extension acpx: 0

### Human Verification (required)

- Behavior or issue addressed: the selected RepoVista finding described in this PR.
- Real environment tested: generated RepoVista publish worktree.
- Exact steps or command run after this patch:
- pnpm test:extension acpx: 0
- Evidence after fix: validation command result(s) above and the focused diff in this PR.
- Observed result after fix: the patch stayed within the selected finding scope.
- What was not tested: full application runtime behavior unless listed above.

### Review Conversations

n/a

### Compatibility / Migration

N/A

### Risks and Mitigations

- Scope gate passed for the selected finding.
- pnpm test:extension acpx: 0

### Problem

Finding: fnd_a2aacb46f63b - Duplicate probeAgent property in the ACPX manifest is hidden by JSON.parse-based sync test
Severity: low
Feature: feat_504165884468
Affected paths: extensions/acpx/openclaw.plugin.json, extensions/acpx/src/config.test.ts
Minimum fix scope: `extensions/acpx/openclaw.plugin.json` and `extensions/acpx/src/manifest.test.ts` or `config.test.ts`.
Recommended fix: Remove one `probeAgent` definition and add a duplicate-key check for plugin manifests before `JSON.parse`, or generate the manifest schema from a single source.
Suggested regression test: Add a manifest test with a duplicate-key-capable parser or scanner for `configSchema.properties`.

### Solution

Changed files:
- extensions/acpx/openclaw.plugin.json
- extensions/acpx/src/config.test.ts

Validation:
- pnpm test:extension acpx: 0

### What changed

Changed files:
- extensions/acpx/openclaw.plugin.json
- extensions/acpx/src/config.test.ts

Validation:
- pnpm test:extension acpx: 0

### Behavior or issue addressed

Finding: fnd_a2aacb46f63b - Duplicate probeAgent property in the ACPX manifest is hidden by JSON.parse-based sync test
Severity: low
Feature: feat_504165884468
Affected paths: extensions/acpx/openclaw.plugin.json, extensions/acpx/src/config.test.ts
Minimum fix scope: `extensions/acpx/openclaw.plugin.json` and `extensions/acpx/src/manifest.test.ts` or `config.test.ts`.
Recommended fix: Remove one `probeAgent` definition and add a duplicate-key check for plugin manifests before `JSON.parse`, or generate the manifest schema from a single source.
Suggested regression test: Add a manifest test with a duplicate-key-capable parser or scanner for `configSchema.properties`.

### Real environment tested

- OS: generated RepoVista publish worktree
- Provider: codex / gpt-5.5 / xhigh
- Relevant config: repository checkout at the analyzed commit

### Exact steps or command run after this patch

1. pnpm test:extension acpx

### Observed result after fix

Recorded validation result:
- pnpm test:extension acpx: 0

### What was not tested

- Full application runtime behavior was not tested unless listed in validation.
- The change is intended to stay within the selected RepoVista finding scope.

### Root cause

Finding: fnd_a2aacb46f63b - Duplicate probeAgent property in the ACPX manifest is hidden by JSON.parse-based sync test
Severity: low
Feature: feat_504165884468
Affected paths: extensions/acpx/openclaw.plugin.json, extensions/acpx/src/config.test.ts
Minimum fix scope: `extensions/acpx/openclaw.plugin.json` and `extensions/acpx/src/manifest.test.ts` or `config.test.ts`.
Recommended fix: Remove one `probeAgent` definition and add a duplicate-key check for plugin manifests before `JSON.parse`, or generate the manifest schema from a single source.
Suggested regression test: Add a manifest test with a duplicate-key-capable parser or scanner for `configSchema.properties`.

### Missing detection / guardrail

A targeted regression test or manifest/schema guard should catch this before review.

### Coverage level that should have caught this

- [x] Unit test
- [ ] Integration test
- [ ] End-to-end test
- [ ] Existing coverage already sufficient

### Target test or file

- pnpm test:extension acpx: 0

### Scenario the test should lock in

- pnpm test:extension acpx: 0

### Why this is the smallest reliable guardrail

A targeted regression test or manifest/schema guard should catch this before review.

### Before

Finding: fnd_a2aacb46f63b - Duplicate probeAgent property in the ACPX manifest is hidden by JSON.parse-based sync test
Severity: low
Feature: feat_504165884468
Affected paths: extensions/acpx/openclaw.plugin.json, extensions/acpx/src/config.test.ts
Minimum fix scope: `extensions/acpx/openclaw.plugin.json` and `extensions/acpx/src/manifest.test.ts` or `config.test.ts`.
Recommended fix: Remove one `probeAgent` definition and add a duplicate-key check for plugin manifests before `JSON.parse`, or generate the manifest schema from a single source.
Suggested regression test: Add a manifest test with a duplicate-key-capable parser or scanner for `configSchema.properties`.

### After

- pnpm test:extension acpx: 0

### Runtime/container

Generated RepoVista publish worktree.

### Model/provider

codex / gpt-5.5 / xhigh

### Attach at least one

- [x] Passing targeted validation
- pnpm test:extension acpx: 0

### Verified scenarios

- pnpm test:extension acpx: 0

### Edge cases checked

- pnpm test:extension acpx: 0

### Risk

Low: patch scope is limited to the files listed in this PR.

### Mitigation

- Scope gate passed for the selected finding.
- pnpm test:extension acpx: 0

_Found with [RepoVista](https://github.com/nordbyte/RepoVista)._