### PR TITLE
[codex] Skip ACP timeout session config

### DIFF
--- a/src/acp/control-plane/runtime-options.test.ts
+++ b/src/acp/control-plane/runtime-options.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { buildRuntimeConfigOptionPairs } from "./runtime-options.js";
 
 describe("buildRuntimeConfigOptionPairs timeout advertisement", () => {
-  it("omits the timeout pair when advertised keys exclude every timeout alias", () => {
+  it("omits the timeout pair even when advertised keys exclude every timeout alias", () => {
     const pairs = buildRuntimeConfigOptionPairs({ timeoutSeconds: 60 }, [
       "model",
       "thinking",
@@ -11,22 +11,22 @@ describe("buildRuntimeConfigOptionPairs timeout advertisement", () => {
     expect(pairs).toEqual([]);
   });
 
-  it("keeps the timeout pair when advertised keys include `timeout`", () => {
+  it("omits the timeout pair when advertised keys include `timeout`", () => {
     const pairs = buildRuntimeConfigOptionPairs({ timeoutSeconds: 60 }, ["model", "timeout"]);
-    expect(pairs).toEqual([["timeout", "60"]]);
+    expect(pairs).toEqual([]);
   });
 
-  it("keeps the timeout pair using the advertised `timeout_seconds` alias", () => {
+  it("omits the timeout pair using the advertised `timeout_seconds` alias", () => {
     const pairs = buildRuntimeConfigOptionPairs({ timeoutSeconds: 60 }, [
       "model",
       "timeout_seconds",
     ]);
-    expect(pairs).toEqual([["timeout_seconds", "60"]]);
+    expect(pairs).toEqual([]);
   });
 
-  it("keeps the timeout pair when advertised keys are unknown (empty or undefined)", () => {
-    expect(buildRuntimeConfigOptionPairs({ timeoutSeconds: 60 })).toEqual([["timeout", "60"]]);
-    expect(buildRuntimeConfigOptionPairs({ timeoutSeconds: 60 }, [])).toEqual([["timeout", "60"]]);
+  it("omits the timeout pair when advertised keys are unknown (empty or undefined)", () => {
+    expect(buildRuntimeConfigOptionPairs({ timeoutSeconds: 60 })).toEqual([]);
+    expect(buildRuntimeConfigOptionPairs({ timeoutSeconds: 60 }, [])).toEqual([]);
   });
 
   it("does not affect model or thinking emission when only timeout is unadvertised", () => {

--- a/src/acp/control-plane/runtime-options.ts
+++ b/src/acp/control-plane/runtime-options.ts
@@ -340,15 +340,9 @@ export function buildRuntimeConfigOptionPairs(
       normalized.permissionProfile,
     );
   }
-  if (
-    typeof normalized.timeoutSeconds === "number" &&
-    shouldEmitTimeoutConfigOption(advertisedConfigOptionKeys)
-  ) {
-    pairs.set(
-      resolveRuntimeConfigOptionKey("timeout", advertisedConfigOptionKeys),
-      String(normalized.timeoutSeconds),
-    );
-  }
+  // OpenClaw enforces runtime timeouts with its own manager/gateway watchdogs.
+  // Do not forward them as ACP session config: some adapters advertise a
+  // timeout-like option but still reject `session/set_config` with `timeout`.
   for (const [key, value] of Object.entries(normalized.backendExtras ?? {})) {
     const wireKey = resolveRuntimeConfigOptionKey(key, advertisedConfigOptionKeys);
     if (!pairs.has(wireKey)) {
@@ -356,16 +350,6 @@ export function buildRuntimeConfigOptionPairs(
     }
   }
   return [...pairs.entries()];
-}
-
-function shouldEmitTimeoutConfigOption(advertisedConfigOptionKeys?: readonly string[]): boolean {
-  const advertisedKeys = buildAdvertisedConfigOptionKeyMap(advertisedConfigOptionKeys);
-  return (
-    advertisedKeys.size === 0 ||
-    RUNTIME_CONFIG_OPTION_ALIASES.timeoutSeconds.some((alias) =>
-      advertisedKeys.has(normalizeLowercaseStringOrEmpty(alias)),
-    )
-  );
 }
 
 function buildAdvertisedConfigOptionKeyMap(

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -929,7 +929,7 @@ describe("spawnAcpDirect", () => {
     expect(initInput.sessionKey).toMatch(/^agent:codex:acp:/);
   });
 
-  it("applies ACP spawn run timeout to runtime options and dispatch", async () => {
+  it("applies ACP spawn run timeout to dispatch without setting ACP runtime options", async () => {
     const result = await spawnAcpDirect(
       {
         task: "Investigate flaky tests",
@@ -944,9 +944,7 @@ describe("spawnAcpDirect", () => {
     expectAcceptedSpawn(result);
     const initInput = expectInitializeSessionFields({
       agent: "codex",
-      runtimeOptions: {
-        timeoutSeconds: 45,
-      },
+      runtimeOptions: undefined,
     });
     expect(initInput.sessionKey).toMatch(/^agent:codex:acp:/);
     const agentCall = findAgentGatewayCall();

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -981,11 +981,10 @@ async function initializeAcpSpawnRuntime(params: {
     mode: params.runtimeMode,
     resumeSessionId: params.resumeSessionId,
     runtimeOptions:
-      params.model || params.thinking || params.runTimeoutSeconds
+      params.model || params.thinking
         ? {
             ...(params.model ? { model: params.model } : {}),
             ...(params.thinking ? { thinking: params.thinking } : {}),
-            ...(params.runTimeoutSeconds ? { timeoutSeconds: params.runTimeoutSeconds } : {}),
           }
         : undefined,
     cwd: params.cwd,


### PR DESCRIPTION
## Summary

This PR stops OpenClaw from sending runtime timeouts as ACP `session/set_config` options.

OpenClaw still enforces timeouts through its own manager/gateway run watchdogs. The change only removes the ACP session config emission for `timeout` / `timeout_seconds`, because at least one real ACP adapter can fail a turn with `Unknown config option: timeout` even when timeout-like config metadata is present.

Also updates ACP `sessions_spawn` so `runTimeoutSeconds` remains a dispatch/run timeout instead of becoming persistent ACP runtime options for the child session.

## Root Cause

A real Claude ACP background task was started with a run timeout. OpenClaw converted the timeout into ACP runtime config and then called `session/set_config` with `timeout`. The ACP runtime rejected that config option before the model call started, surfacing as `ACP_TURN_FAILED`.

The timeout does not need to be forwarded to the ACP backend: OpenClaw already owns the run-level timeout behavior at the manager/gateway layer.

## Real Behavior Proof

behavior: ACP background runs with a run timeout should start normally and should not send `timeout` as an ACP session config option. Run timeout enforcement should remain owned by OpenClaw's run/gateway watchdog.

environment: Local OpenClaw gateway setup on Linux using OpenClaw `2026.5.17-local`, Claude via ACP, and an isolated scheduled OpenClaw cron run that spawns a Claude ACP background task. Hostname, chat identifiers, token values, and full machine details are intentionally omitted.

steps:
1. Observed a real scheduled OpenClaw run fail during a Claude ACP background task before the first useful model response.
2. Traced the failed ACP stream record and parent session trajectory locally.
3. Confirmed the failing child run had a run timeout and failed immediately when ACP runtime config attempted to set `timeout`.
4. Applied the patch locally so runtime timeout values are no longer emitted as ACP config options.
5. Restarted the local OpenClaw gateway and verified the patched runtime bundle no longer contains an active `timeout` config emission path.
6. Ran the focused unit tests for ACP runtime options and ACP spawn behavior.

evidence:
```text
Real failure log, redacted:
Background task failed: dash-hyperl-guarded-send (run 328951f0).
AcpRuntimeError [ACP_TURN_FAILED]: Internal error: Unknown config option: timeout <- RequestError [-32603]: Internal error
```

```text
Focused verification:
pnpm exec vitest run src/acp/control-plane/runtime-options.test.ts src/agents/acp-spawn.test.ts

Test Files  3 passed (3)
Tests       119 passed (119)
```

observedResult: After the patch, `buildRuntimeConfigOptionPairs({ timeoutSeconds: 60 })` returns no ACP config option pairs for timeout, including when `timeout` or `timeout_seconds` appears in advertised config keys. `sessions_spawn` still passes `runTimeoutSeconds` to gateway dispatch as the run timeout, but no longer persists it as ACP runtime options.

## Validation

- `pnpm exec vitest run src/acp/control-plane/runtime-options.test.ts src/agents/acp-spawn.test.ts`

## Not Tested

- Full repo `pnpm build && pnpm check && pnpm test` was not run locally for this small ACP runtime-options fix.
- A fresh post-merge package build was not installed from this branch; validation used the local source tests plus a live local runtime patch matching this behavior.

## AI Assistance

AI-assisted with Codex. I reviewed the changed code paths and understand the behavior: OpenClaw keeps timeout enforcement at its own run/gateway layer and avoids sending unsupported timeout config through ACP session config.