### PR TITLE
feat(zalouser): surface inbound photo attachments via media array

### DIFF
--- a/extensions/zalouser/src/inbound-media.ts
+++ b/extensions/zalouser/src/inbound-media.ts
@@ -1,0 +1,62 @@
+import type { ZaloInboundMedia } from "./types.js";
+
+/**
+ * Detect whether an inbound zca-js message carries a photo attachment, and
+ * extract its CDN URL + thumbnail if so. zca-js delivers photos as
+ * `TAttachmentContent` objects with `{type:"photo", href, thumb, ...}` -
+ * see src/models/Message.ts in the zca-js repo. The `href` field is a
+ * public Zalo CDN URL that does not require auth to GET.
+ *
+ * Returns null for plain-text or non-photo content (links, files, stickers
+ * etc.) - those flow through `normalizeMessageContent` as text. Photo
+ * detection is intentionally inclusive: explicit `type === "photo"` wins,
+ * but a missing type with a recognisable image extension in the href OR a
+ * non-empty `thumb` field (only photos carry thumbs in zca-js) also matches.
+ * Defensive about the inclusive path because some clients send photos with
+ * type omitted; better to surface a photo as media than as JSON-stringified
+ * text.
+ */
+export function extractInboundMedia(content: unknown): ZaloInboundMedia | null {
+  if (!content || typeof content !== "object") {
+    return null;
+  }
+  const record = content as Record<string, unknown>;
+  const href = typeof record.href === "string" ? record.href.trim() : "";
+  if (!href) {
+    return null;
+  }
+  const type = typeof record.type === "string" ? record.type : "";
+  const thumbUrl = typeof record.thumb === "string" ? record.thumb.trim() : "";
+  const looksLikeImage =
+    type === "photo" || /\.(jpe?g|png|gif|webp|bmp)(\?|$)/i.test(href) || thumbUrl.length > 0;
+  if (!looksLikeImage) {
+    return null;
+  }
+  return {
+    kind: "image",
+    url: href,
+    thumbUrl: thumbUrl || undefined,
+  };
+}
+
+/**
+ * Resolve a real `image/*` MIME for an inbound Zalo photo even when the CDN
+ * returns `application/octet-stream`. Picks from the URL extension first,
+ * falls back to `image/jpeg` (most common Zalo photo format).
+ */
+export function resolveInboundImageContentType(detected: string | undefined, url: string): string {
+  if (detected && detected.startsWith("image/")) {
+    return detected;
+  }
+  const match = url.match(/\.([a-z]+)(?:\?|$)/i);
+  const ext = (match?.[1] ?? "jpg").toLowerCase();
+  const extMap: Record<string, string> = {
+    jpg: "image/jpeg",
+    jpeg: "image/jpeg",
+    png: "image/png",
+    gif: "image/gif",
+    webp: "image/webp",
+    bmp: "image/bmp",
+  };
+  return extMap[ext] ?? "image/jpeg";
+}

--- a/extensions/zalouser/src/monitor.media.test.ts
+++ b/extensions/zalouser/src/monitor.media.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { resolveInboundImageContentType } from "./monitor.js";
+
+describe("resolveInboundImageContentType", () => {
+  it("trusts a detected image/* MIME from saveRemoteMedia", () => {
+    expect(resolveInboundImageContentType("image/png", "https://x/y.jpg")).toBe("image/png");
+    expect(resolveInboundImageContentType("image/webp", "https://x/y.jpg")).toBe("image/webp");
+  });
+
+  it("overrides application/octet-stream using URL extension (Zalo CDN case)", () => {
+    // Zalo CDN photos arrive with content-type application/octet-stream
+    // (verified live against photo-stal-*.zdn.vn endpoints). Without this
+    // override, kernel.resolveCurrentTurnImages rejects the photo because
+    // MediaType does not start with image/* and the agent never sees the
+    // vision block.
+    expect(
+      resolveInboundImageContentType(
+        "application/octet-stream",
+        "https://photo-stal-22.zdn.vn/gr/abc/photo.jpg",
+      ),
+    ).toBe("image/jpeg");
+    expect(
+      resolveInboundImageContentType("application/octet-stream", "https://x/y.png"),
+    ).toBe("image/png");
+    expect(
+      resolveInboundImageContentType("application/octet-stream", "https://x/y.WEBP"),
+    ).toBe("image/webp");
+  });
+
+  it("falls back to image/jpeg when both detected MIME and URL extension are absent", () => {
+    expect(resolveInboundImageContentType(undefined, "https://x/path/no-extension")).toBe(
+      "image/jpeg",
+    );
+    expect(resolveInboundImageContentType("", "https://x/path/no-extension")).toBe(
+      "image/jpeg",
+    );
+  });
+
+  it("ignores query string when parsing URL extension", () => {
+    expect(
+      resolveInboundImageContentType(
+        "application/octet-stream",
+        "https://x/y.png?token=abc&v=1",
+      ),
+    ).toBe("image/png");
+  });
+
+  it("is case-insensitive on URL extension", () => {
+    expect(resolveInboundImageContentType("application/octet-stream", "https://x/y.JPEG")).toBe(
+      "image/jpeg",
+    );
+    expect(resolveInboundImageContentType("application/octet-stream", "https://x/y.GIF")).toBe(
+      "image/gif",
+    );
+  });
+
+  it("falls back to image/jpeg for unknown image extensions", () => {
+    expect(resolveInboundImageContentType("application/octet-stream", "https://x/y.heic")).toBe(
+      "image/jpeg",
+    );
+    expect(resolveInboundImageContentType("application/octet-stream", "https://x/y.tiff")).toBe(
+      "image/jpeg",
+    );
+  });
+});

--- a/extensions/zalouser/src/monitor.media.test.ts
+++ b/extensions/zalouser/src/monitor.media.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveInboundImageContentType } from "./monitor.js";
+import { resolveInboundImageContentType } from "./inbound-media.js";
 
 describe("resolveInboundImageContentType", () => {
   it("trusts a detected image/* MIME from saveRemoteMedia", () => {
@@ -19,29 +19,24 @@ describe("resolveInboundImageContentType", () => {
         "https://photo-stal-22.zdn.vn/gr/abc/photo.jpg",
       ),
     ).toBe("image/jpeg");
-    expect(
-      resolveInboundImageContentType("application/octet-stream", "https://x/y.png"),
-    ).toBe("image/png");
-    expect(
-      resolveInboundImageContentType("application/octet-stream", "https://x/y.WEBP"),
-    ).toBe("image/webp");
+    expect(resolveInboundImageContentType("application/octet-stream", "https://x/y.png")).toBe(
+      "image/png",
+    );
+    expect(resolveInboundImageContentType("application/octet-stream", "https://x/y.WEBP")).toBe(
+      "image/webp",
+    );
   });
 
   it("falls back to image/jpeg when both detected MIME and URL extension are absent", () => {
     expect(resolveInboundImageContentType(undefined, "https://x/path/no-extension")).toBe(
       "image/jpeg",
     );
-    expect(resolveInboundImageContentType("", "https://x/path/no-extension")).toBe(
-      "image/jpeg",
-    );
+    expect(resolveInboundImageContentType("", "https://x/path/no-extension")).toBe("image/jpeg");
   });
 
   it("ignores query string when parsing URL extension", () => {
     expect(
-      resolveInboundImageContentType(
-        "application/octet-stream",
-        "https://x/y.png?token=abc&v=1",
-      ),
+      resolveInboundImageContentType("application/octet-stream", "https://x/y.png?token=abc&v=1"),
     ).toBe("image/png");
   });
 

--- a/extensions/zalouser/src/monitor.ts
+++ b/extensions/zalouser/src/monitor.ts
@@ -1041,11 +1041,20 @@ async function resolveInboundMediaFacts(params: {
       filePathHint: `zalouser-inbound-${Date.now()}.jpg`,
       maxBytes: 25 * 1024 * 1024,
     });
+    // Zalo CDN returns `application/octet-stream` for photos (verified
+    // 2026-05-21 on photo-stal-*.zdn.vn). The kernel's
+    // `resolveCurrentTurnImages` requires `MediaType` to start with
+    // `image/` to attach the photo as a vision content block, so we
+    // override to a real image MIME derived from the URL extension when
+    // saveRemoteMedia's detected contentType is missing or
+    // octet-stream. extractInboundMedia gated us here so we KNOW this
+    // bytes represent an image (`params.media.kind === "image"`).
+    const contentType = resolveInboundImageContentType(saved.contentType, params.media.url);
     return toInboundMediaFacts([
       {
         path: saved.path,
         url: saved.path,
-        contentType: saved.contentType,
+        contentType,
         kind: params.media.kind,
       },
     ]);
@@ -1054,6 +1063,30 @@ async function resolveInboundMediaFacts(params: {
     params.logVerbose(`zalouser: inbound media fetch failed for ${params.media.url}: ${reason}`);
     return [];
   }
+}
+
+/**
+ * Resolve a real `image/*` MIME for an inbound Zalo photo even when the CDN
+ * returns `application/octet-stream`. Picks from the URL extension first,
+ * falls back to `image/jpeg` (most common Zalo photo format).
+ *
+ * Exported via __testing only; not part of the public plugin surface.
+ */
+export function resolveInboundImageContentType(detected: string | undefined, url: string): string {
+  if (detected && detected.startsWith("image/")) {
+    return detected;
+  }
+  const match = url.match(/\.([a-z]+)(?:\?|$)/i);
+  const ext = (match?.[1] ?? "jpg").toLowerCase();
+  const extMap: Record<string, string> = {
+    jpg: "image/jpeg",
+    jpeg: "image/jpeg",
+    png: "image/png",
+    gif: "image/gif",
+    webp: "image/webp",
+    bmp: "image/bmp",
+  };
+  return extMap[ext] ?? "image/jpeg";
 }
 
 // Re-export internal helper for unit tests only - keep out of public surface

--- a/extensions/zalouser/src/monitor.ts
+++ b/extensions/zalouser/src/monitor.ts
@@ -12,6 +12,7 @@ import { isDangerousNameMatchingEnabled } from "openclaw/plugin-sdk/dangerous-na
 // Zalouser plugin module implements monitor behavior.
 import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { saveRemoteMedia } from "openclaw/plugin-sdk/media-runtime";
 import {
   DEFAULT_GROUP_HISTORY_LIMIT,
   type HistoryEntry,
@@ -22,7 +23,6 @@ import {
   resolveSendableOutboundReplyParts,
   type OutboundReplyPayload,
 } from "openclaw/plugin-sdk/reply-payload";
-import { saveRemoteMedia } from "openclaw/plugin-sdk/media-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime";
 import {
   resolveDefaultGroupPolicy,
@@ -39,6 +39,7 @@ import {
   findZalouserGroupEntry,
   isZalouserGroupEntryAllowed,
 } from "./group-policy.js";
+import { resolveInboundImageContentType } from "./inbound-media.js";
 import { createZalouserIngressMonitor, type ZalouserIngressLifecycle } from "./ingress.js";
 import { formatZalouserMessageSidFull, resolveZalouserMessageSid } from "./message-sid.js";
 import { getZalouserRuntime } from "./runtime.js";
@@ -982,39 +983,6 @@ export async function monitorZalouserProvider(
   return { stop };
 }
 
-export const testing = {
-  processMessage: async (params: {
-    message: ZaloInboundMessage;
-    account: ResolvedZalouserAccount;
-    config: OpenClawConfig;
-    runtime: RuntimeEnv;
-    historyState?: {
-      historyLimit?: number;
-      groupHistories?: Map<string, HistoryEntry[]>;
-    };
-    statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
-  }) => {
-    const historyLimit = Math.max(
-      0,
-      params.historyState?.historyLimit ??
-        params.account.config.historyLimit ??
-        params.config.messages?.groupChat?.historyLimit ??
-        DEFAULT_GROUP_HISTORY_LIMIT,
-    );
-    const groupHistories = params.historyState?.groupHistories ?? new Map<string, HistoryEntry[]>();
-    await processMessage(
-      params.message,
-      params.account,
-      params.config,
-      getZalouserRuntime(),
-      params.runtime,
-      { historyLimit, groupHistories },
-      params.statusSink,
-    );
-  },
-};
-export { testing as __testing };
-
 /**
  * Download an inbound Zalo photo attachment to a local file via
  * `saveRemoteMedia` so the kernel media pipeline can build the standard
@@ -1065,32 +1033,6 @@ async function resolveInboundMediaFacts(params: {
   }
 }
 
-/**
- * Resolve a real `image/*` MIME for an inbound Zalo photo even when the CDN
- * returns `application/octet-stream`. Picks from the URL extension first,
- * falls back to `image/jpeg` (most common Zalo photo format).
- *
- * Exported via __testing only; not part of the public plugin surface.
- */
-export function resolveInboundImageContentType(detected: string | undefined, url: string): string {
-  if (detected && detected.startsWith("image/")) {
-    return detected;
-  }
-  const match = url.match(/\.([a-z]+)(?:\?|$)/i);
-  const ext = (match?.[1] ?? "jpg").toLowerCase();
-  const extMap: Record<string, string> = {
-    jpg: "image/jpeg",
-    jpeg: "image/jpeg",
-    png: "image/png",
-    gif: "image/gif",
-    webp: "image/webp",
-    bmp: "image/bmp",
-  };
-  return extMap[ext] ?? "image/jpeg";
-}
-
-// Re-export internal helper for unit tests only - keep out of public surface
-// by attaching to the testing namespace.
 type InboundMediaFact = ReturnType<typeof toInboundMediaFacts>[number];
 
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/zalouser/src/monitor.ts
+++ b/extensions/zalouser/src/monitor.ts
@@ -3,6 +3,7 @@ import {
   createChannelInboundEnvelopeBuilder,
   implicitMentionKindWhen,
   resolveInboundMentionDecision,
+  toInboundMediaFacts,
 } from "openclaw/plugin-sdk/channel-inbound";
 import { resolveStableChannelMessageIngress } from "openclaw/plugin-sdk/channel-ingress-runtime";
 import { createChannelPairingController } from "openclaw/plugin-sdk/channel-pairing";
@@ -21,6 +22,7 @@ import {
   resolveSendableOutboundReplyParts,
   type OutboundReplyPayload,
 } from "openclaw/plugin-sdk/reply-payload";
+import { saveRemoteMedia } from "openclaw/plugin-sdk/media-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime";
 import {
   resolveDefaultGroupPolicy,
@@ -47,7 +49,7 @@ import {
   sendTypingZalouser,
 } from "./send.js";
 import { resolveZalouserDmSessionScope } from "./session-scope.js";
-import type { ResolvedZalouserAccount, ZaloInboundMessage } from "./types.js";
+import type { ResolvedZalouserAccount, ZaloInboundMedia, ZaloInboundMessage } from "./types.js";
 import {
   listZaloFriends,
   listZaloGroups,
@@ -225,8 +227,12 @@ async function processMessage(
     accountId: account.accountId,
   });
 
-  const rawBody = message.content?.trim();
-  if (!rawBody) {
+  const rawBody = message.content?.trim() ?? "";
+  // Allow processing when there's no text body but the message carries a
+  // media attachment (photo-only messages, common in customer-support flows
+  // where users send a photo of a device label without typing anything).
+  // Drop only when there's neither text nor media.
+  if (!rawBody && !message.media) {
     return;
   }
   const commandBody = message.commandContent?.trim() || rawBody;
@@ -553,12 +559,27 @@ async function processMessage(
     cliMsgId: message.cliMsgId,
   });
 
+  // Download inbound photo attachment (if any) to a local file the kernel
+  // media pipeline can pick up. Failures are non-fatal: we log and proceed
+  // with text-only context so the bot still sees the caption + sender even
+  // when the CDN is temporarily unreachable. Photos that download cleanly
+  // are passed as a top-level `media` array on buildContext - the kernel
+  // then derives the full MediaPath/MediaUrl/MediaType/etc. fact set so
+  // the agent runner can attach the photo as a native vision content block
+  // (no separate `image` tool call required - the model sees the photo in
+  // the user message just like any other vision-capable channel).
+  const inboundMediaFacts = await resolveInboundMediaFacts({
+    media: message.media,
+    logVerbose: (msg: string) => logVerbose(core, runtime, msg),
+  });
+
   const ctxPayload = core.channel.inbound.buildContext({
     channel: "zalouser",
     accountId: route.accountId,
     messageId: messageSid,
     messageIdFull: messageSidFull,
     timestamp: message.timestampMs,
+    media: inboundMediaFacts,
     from: isGroup ? `zalouser:group:${chatId}` : `zalouser:${senderId}`,
     sender: {
       id: senderId,
@@ -960,5 +981,83 @@ export async function monitorZalouserProvider(
 
   return { stop };
 }
+
+export const testing = {
+  processMessage: async (params: {
+    message: ZaloInboundMessage;
+    account: ResolvedZalouserAccount;
+    config: OpenClawConfig;
+    runtime: RuntimeEnv;
+    historyState?: {
+      historyLimit?: number;
+      groupHistories?: Map<string, HistoryEntry[]>;
+    };
+    statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
+  }) => {
+    const historyLimit = Math.max(
+      0,
+      params.historyState?.historyLimit ??
+        params.account.config.historyLimit ??
+        params.config.messages?.groupChat?.historyLimit ??
+        DEFAULT_GROUP_HISTORY_LIMIT,
+    );
+    const groupHistories = params.historyState?.groupHistories ?? new Map<string, HistoryEntry[]>();
+    await processMessage(
+      params.message,
+      params.account,
+      params.config,
+      getZalouserRuntime(),
+      params.runtime,
+      { historyLimit, groupHistories },
+      params.statusSink,
+    );
+  },
+};
+export { testing as __testing };
+
+/**
+ * Download an inbound Zalo photo attachment to a local file via
+ * `saveRemoteMedia` so the kernel media pipeline can build the standard
+ * MediaPath/MediaUrl/MediaType fact set. The path returned by
+ * `saveRemoteMedia` lives under POSIX_OPENCLAW_TMP_DIR which is in the
+ * allowed roots for inbound media (see core/inboundPathAllowed); files
+ * outside that root are silently dropped by the agent runner.
+ *
+ * Returns an array suitable for `buildContext({ media })`. Empty when there
+ * is no inbound media OR when the download failed (logged at verbose;
+ * message processing continues with text only). Exported via __testing for
+ * unit tests; not part of the public plugin surface.
+ */
+async function resolveInboundMediaFacts(params: {
+  media: ZaloInboundMedia | undefined;
+  logVerbose: (msg: string) => void;
+}): Promise<InboundMediaFact[]> {
+  if (!params.media) {
+    return [];
+  }
+  try {
+    const saved = await saveRemoteMedia({
+      url: params.media.url,
+      filePathHint: `zalouser-inbound-${Date.now()}.jpg`,
+      maxBytes: 25 * 1024 * 1024,
+    });
+    return toInboundMediaFacts([
+      {
+        path: saved.path,
+        url: saved.path,
+        contentType: saved.contentType,
+        kind: params.media.kind,
+      },
+    ]);
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    params.logVerbose(`zalouser: inbound media fetch failed for ${params.media.url}: ${reason}`);
+    return [];
+  }
+}
+
+// Re-export internal helper for unit tests only - keep out of public surface
+// by attaching to the testing namespace.
+type InboundMediaFact = ReturnType<typeof toInboundMediaFacts>[number];
 
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/zalouser/src/types.ts
+++ b/extensions/zalouser/src/types.ts
@@ -32,6 +32,21 @@ export type ZaloEventMessage = {
   ts: string | number;
 };
 
+/**
+ * Surface a single inbound attachment from a Zalo message. Currently we only
+ * extract photos because that is the most common attachment type Vietnamese
+ * customer-support bots receive (users sending a photo of a device serial
+ * number, ID card, error screen, etc.). Other attachment kinds (audio, file,
+ * video) can be added later without breaking the existing tuple shape.
+ */
+export type ZaloInboundMedia = {
+  kind: "image";
+  /** Public Zalo CDN URL the media can be downloaded from. No auth required. */
+  url: string;
+  /** Optional thumbnail URL (smaller version of the same image). */
+  thumbUrl?: string;
+};
+
 export type ZaloInboundMessage = {
   threadId: string;
   isGroup: boolean;
@@ -51,6 +66,14 @@ export type ZaloInboundMessage = {
   quotedOwnerId?: string;
   quotedBody?: string;
   eventMessage?: ZaloEventMessage;
+  /**
+   * Set when the inbound message carries an attachment (photo today). The
+   * channel runtime downloads the bytes via `core.channel.media.saveRemoteMedia`
+   * before passing the message to the agent, so the agent receives the photo
+   * as a native vision content block - no separate tool call required.
+   * Undefined for plain text messages.
+   */
+  media?: ZaloInboundMedia;
   raw: unknown;
 };
 

--- a/extensions/zalouser/src/zalo-js.media.test.ts
+++ b/extensions/zalouser/src/zalo-js.media.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { extractInboundMedia } from "./zalo-js.js";
+
+describe("extractInboundMedia", () => {
+  it("returns null for plain string content (text message)", () => {
+    expect(extractInboundMedia("hello world")).toBeNull();
+  });
+
+  it("returns null for null / undefined / non-object content", () => {
+    expect(extractInboundMedia(null)).toBeNull();
+    expect(extractInboundMedia(undefined)).toBeNull();
+    expect(extractInboundMedia(42)).toBeNull();
+  });
+
+  it("returns null for object content with no href (e.g. sticker)", () => {
+    expect(extractInboundMedia({ type: "sticker", id: 123 })).toBeNull();
+  });
+
+  it("returns null for object content with href but no image markers (link preview)", () => {
+    // Link preview from zca-js: type "link" + href to a webpage with no
+    // thumb, no image extension. Should not be misclassified as a photo.
+    expect(
+      extractInboundMedia({
+        type: "link",
+        title: "Tingee",
+        description: "Loa Tingee",
+        href: "https://tingee.vn/products",
+      }),
+    ).toBeNull();
+  });
+
+  it("extracts media when content.type === \"photo\"", () => {
+    const result = extractInboundMedia({
+      type: "photo",
+      href: "https://photo-stal-1.zdn.vn/abc/def.jpg",
+      thumb: "https://photo-stal-1.zdn.vn/abc/def.thumb.jpg",
+      width: 1024,
+      height: 768,
+    });
+    expect(result).toEqual({
+      kind: "image",
+      url: "https://photo-stal-1.zdn.vn/abc/def.jpg",
+      thumbUrl: "https://photo-stal-1.zdn.vn/abc/def.thumb.jpg",
+    });
+  });
+
+  it("extracts media via image file extension fallback", () => {
+    // Some clients omit `type` for photos; rely on URL extension.
+    const result = extractInboundMedia({
+      href: "https://example.com/path/photo.PNG",
+    });
+    expect(result).toEqual({
+      kind: "image",
+      url: "https://example.com/path/photo.PNG",
+      thumbUrl: undefined,
+    });
+  });
+
+  it("extracts media via thumb-presence fallback when type + extension absent", () => {
+    // Some message shapes carry only `thumb` without explicit type; treat as photo.
+    const result = extractInboundMedia({
+      href: "https://photo-stal-7.zdn.vn/some/random/path",
+      thumb: "https://photo-stal-7.zdn.vn/some/random/thumb",
+    });
+    expect(result).toEqual({
+      kind: "image",
+      url: "https://photo-stal-7.zdn.vn/some/random/path",
+      thumbUrl: "https://photo-stal-7.zdn.vn/some/random/thumb",
+    });
+  });
+
+  it("trims whitespace in href + thumb so URL builders downstream don't fail", () => {
+    const result = extractInboundMedia({
+      type: "photo",
+      href: "   https://x/y.jpg   ",
+      thumb: "  https://x/y-thumb.jpg  ",
+    });
+    expect(result?.url).toBe("https://x/y.jpg");
+    expect(result?.thumbUrl).toBe("https://x/y-thumb.jpg");
+  });
+
+  it("matches common image extensions case-insensitively + with query strings", () => {
+    for (const url of [
+      "https://x/y.JPG?token=abc",
+      "https://x/y.jpeg",
+      "https://x/y.png",
+      "https://x/y.gif?v=1",
+      "https://x/y.webp",
+      "https://x/y.bmp",
+    ]) {
+      const result = extractInboundMedia({ href: url });
+      expect(result, `should match: ${url}`).not.toBeNull();
+      expect(result?.url).toBe(url);
+    }
+  });
+
+  it("does not match non-image href without other photo markers", () => {
+    expect(extractInboundMedia({ href: "https://example.com/document.pdf" })).toBeNull();
+    expect(extractInboundMedia({ href: "https://example.com/audio.mp3" })).toBeNull();
+  });
+});

--- a/extensions/zalouser/src/zalo-js.media.test.ts
+++ b/extensions/zalouser/src/zalo-js.media.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { extractInboundMedia } from "./zalo-js.js";
+import { extractInboundMedia } from "./inbound-media.js";
 
 describe("extractInboundMedia", () => {
   it("returns null for plain string content (text message)", () => {
@@ -29,7 +29,7 @@ describe("extractInboundMedia", () => {
     ).toBeNull();
   });
 
-  it("extracts media when content.type === \"photo\"", () => {
+  it('extracts media when content.type === "photo"', () => {
     const result = extractInboundMedia({
       type: "photo",
       href: "https://photo-stal-1.zdn.vn/abc/def.jpg",

--- a/extensions/zalouser/src/zalo-js.ts
+++ b/extensions/zalouser/src/zalo-js.ts
@@ -35,6 +35,7 @@ import type {
   ZaloGroupContext,
   ZaloGroup,
   ZaloGroupMember,
+  ZaloInboundMedia,
   ZaloInboundMessage,
   ZaloSendOptions,
   ZaloSendResult,
@@ -214,6 +215,47 @@ function normalizeMessageContent(content: unknown): string {
   } catch {
     return "";
   }
+}
+
+/**
+ * Detect whether an inbound zca-js message carries a photo attachment, and
+ * extract its CDN URL + thumbnail if so. zca-js delivers photos as
+ * `TAttachmentContent` objects with `{type:"photo", href, thumb, ...}` -
+ * see src/models/Message.ts in the zca-js repo. The `href` field is a
+ * public Zalo CDN URL that does not require auth to GET.
+ *
+ * Returns null for plain-text or non-photo content (links, files, stickers
+ * etc.) - those flow through `normalizeMessageContent` as text. Photo
+ * detection is intentionally inclusive: explicit `type === "photo"` wins,
+ * but a missing type with a recognisable image extension in the href OR a
+ * non-empty `thumb` field (only photos carry thumbs in zca-js) also matches.
+ * Defensive about the inclusive path because some clients send photos with
+ * type omitted; better to surface a photo as media than as JSON-stringified
+ * text.
+ */
+export function extractInboundMedia(content: unknown): ZaloInboundMedia | null {
+  if (!content || typeof content !== "object") {
+    return null;
+  }
+  const record = content as Record<string, unknown>;
+  const href = typeof record.href === "string" ? record.href.trim() : "";
+  if (!href) {
+    return null;
+  }
+  const type = typeof record.type === "string" ? record.type : "";
+  const thumbUrl = typeof record.thumb === "string" ? record.thumb.trim() : "";
+  const looksLikeImage =
+    type === "photo" ||
+    /\.(jpe?g|png|gif|webp|bmp)(\?|$)/i.test(href) ||
+    thumbUrl.length > 0;
+  if (!looksLikeImage) {
+    return null;
+  }
+  return {
+    kind: "image",
+    url: href,
+    thumbUrl: thumbUrl || undefined,
+  };
 }
 
 function resolveInboundTimestamp(rawTs: unknown): number {
@@ -902,6 +944,7 @@ export function normalizeZaloInboundMessage(
     normalizedOwnUserId && quoteOwnerId && quoteOwnerId === normalizedOwnUserId,
   );
   const eventMessage = buildEventMessage(data);
+  const media = extractInboundMedia(data.content);
   return {
     threadId,
     isGroup,
@@ -921,6 +964,7 @@ export function normalizeZaloInboundMessage(
     quotedOwnerId: quoteOwnerId || undefined,
     quotedBody: quotedBody || undefined,
     eventMessage,
+    media: media ?? undefined,
     raw: message,
   };
 }

--- a/extensions/zalouser/src/zalo-js.ts
+++ b/extensions/zalouser/src/zalo-js.ts
@@ -20,6 +20,7 @@ import {
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { sleep, truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+import { extractInboundMedia } from "./inbound-media.js";
 import { normalizeZaloReactionIcon } from "./reaction.js";
 import { createZalouserSendReceipt } from "./send-receipt.js";
 import {
@@ -35,7 +36,6 @@ import type {
   ZaloGroupContext,
   ZaloGroup,
   ZaloGroupMember,
-  ZaloInboundMedia,
   ZaloInboundMessage,
   ZaloSendOptions,
   ZaloSendResult,
@@ -215,47 +215,6 @@ function normalizeMessageContent(content: unknown): string {
   } catch {
     return "";
   }
-}
-
-/**
- * Detect whether an inbound zca-js message carries a photo attachment, and
- * extract its CDN URL + thumbnail if so. zca-js delivers photos as
- * `TAttachmentContent` objects with `{type:"photo", href, thumb, ...}` -
- * see src/models/Message.ts in the zca-js repo. The `href` field is a
- * public Zalo CDN URL that does not require auth to GET.
- *
- * Returns null for plain-text or non-photo content (links, files, stickers
- * etc.) - those flow through `normalizeMessageContent` as text. Photo
- * detection is intentionally inclusive: explicit `type === "photo"` wins,
- * but a missing type with a recognisable image extension in the href OR a
- * non-empty `thumb` field (only photos carry thumbs in zca-js) also matches.
- * Defensive about the inclusive path because some clients send photos with
- * type omitted; better to surface a photo as media than as JSON-stringified
- * text.
- */
-export function extractInboundMedia(content: unknown): ZaloInboundMedia | null {
-  if (!content || typeof content !== "object") {
-    return null;
-  }
-  const record = content as Record<string, unknown>;
-  const href = typeof record.href === "string" ? record.href.trim() : "";
-  if (!href) {
-    return null;
-  }
-  const type = typeof record.type === "string" ? record.type : "";
-  const thumbUrl = typeof record.thumb === "string" ? record.thumb.trim() : "";
-  const looksLikeImage =
-    type === "photo" ||
-    /\.(jpe?g|png|gif|webp|bmp)(\?|$)/i.test(href) ||
-    thumbUrl.length > 0;
-  if (!looksLikeImage) {
-    return null;
-  }
-  return {
-    kind: "image",
-    url: href,
-    thumbUrl: thumbUrl || undefined,
-  };
 }
 
 function resolveInboundTimestamp(rawTs: unknown): number {


### PR DESCRIPTION
## Summary

Surfaces inbound photo attachments on the Zalo personal-account channel as native vision content blocks. Previously the `zalouser` monitor handler dropped Zalo photo metadata, so agents only saw the user's text caption and could not respond to image content. After this PR an inbound Zalo photo lands on the agent's turn as a kernel vision block, and the model can reason about the image directly.

## What changes

- `extensions/zalouser/src/zalo-js.ts`: new `extractInboundMedia(content)` helper that recognises photo content payloads from `zca-js` events. Detects via `type === 'photo'`, image-extension URL pattern, or non-empty `thumb`. Returns `{ kind: 'image', url, thumbUrl? }` for downstream pickup.
- `extensions/zalouser/src/zalo-js.ts`: `toInboundMessage` returns a new `media` field populated from `extractInboundMedia`.
- `extensions/zalouser/src/monitor.ts`: new `resolveInboundImageContentType(detected, url)` helper that trusts a real `image/*` MIME when the CDN returns one, otherwise maps the URL extension (`.jpg|.png|.gif|.webp|.bmp`) to the correct image MIME. Falls back to `image/jpeg` when both signals are absent. Closes the Zalo-CDN-returns-`application/octet-stream` bug where the kernel rejected the photo because `MediaType` did not start with `image/`.
- `extensions/zalouser/src/monitor.ts`: when an inbound message carries a `media` payload, fetch the photo (via existing `saveRemoteMedia` plumbing), persist to the agent volume, and wire `{ path, url, contentType }` into the `core.channel.turn.buildContext({ media: [...] })` call. The kernel auto-derives `MediaPath/MediaUrl/MediaType` so the photo reaches the model as a native vision block.
- `extensions/zalouser/src/monitor.ts`: relax the empty-body guard so a photo-only message (zero text content) is not dropped.

## Tests

- `extensions/zalouser/src/monitor.media.test.ts` - new test file for `resolveInboundImageContentType` with 7 cases covering happy-path image/* trust, Zalo CDN `application/octet-stream` override, URL extension fallback, case-insensitivity, query-string stripping, unknown extensions, and the missing-both fallback to `image/jpeg`.

## Real behavior proof

**Behavior or issue addressed**: Inbound Zalo photo attachments arriving via the `@openclaw/zalouser` channel were silently dropped by `monitor.ts` - the model saw only the user's text caption, never the image. Two compounding bugs: (1) `toInboundMessage` did not surface the photo content at all, (2) the Zalo CDN returns `Content-Type: application/octet-stream` for photos, so even when fetched the kernel's `resolveCurrentTurnImages` rejected the file because `MediaType` did not start with `image/`.

**Real environment tested**: Em Huyen agent (Tingee customer-support bot, Vietnamese) running on the openclaw runtime with `@openclaw/zalouser` paired to a real Zalo personal account, talking to a real Zalo group room (Capypara.AI). Channel `zalouser`, model `dos-ai/dos-ai` (Qwen3.6-35B-a3b). Tested on both Zalo Mobile (Android) and Zalo Desktop on the same conversation.

**Exact steps or command run after this patch**:
1. Apply this PR's `zalo-js.ts` + `monitor.ts` changes to the running zalouser plugin.
2. Restart the agent container so the plugin reloads.
3. From a separate Zalo account, send a photo of a Tingee soundbox bottom plate to the Capypara.AI group with the text `@Em Huyền reset loa cho anh`. The plate has a printed sticker showing `Model: Tingee 3PRO`, `SN: 3PRO175459`.
4. Wait for Em Huyen to reply.
5. Open the same conversation on Zalo Android and on Zalo Desktop; screenshot the inbound photo + bot reply.

**Evidence after fix**:

Zalo Android (Capypara.AI group, dark theme):

![Em Huyen extracts SN from inbound photo on Zalo Android](https://raw.githubusercontent.com/JOY/openclaw/proof/zalouser-em-huyen-screenshots/docs/proof/zalouser-em-huyen/zalo-mobile.jpg)

Zalo Desktop (same conversation):

![Em Huyen extracts SN from inbound photo on Zalo Desktop](https://raw.githubusercontent.com/JOY/openclaw/proof/zalouser-em-huyen-screenshots/docs/proof/zalouser-em-huyen/zalo-desktop.jpg)

**Observed result after fix**: Em Huyen's reply opens with `Dạ anh Le, em đã nhìn rõ ảnh rồi. Mã thiết bị của anh là: SN: 3PRO175459 (Model: Tingee 3PRO).` That SN string is printed on the physical label in the photo - the agent extracted it directly from the inbound vision block, not from prior context. Confirms end-to-end that (a) `extractInboundMedia` recognised the Zalo photo content payload, (b) `resolveInboundImageContentType` overrode the Zalo CDN's `application/octet-stream` to `image/jpeg`, (c) the kernel vision pipeline accepted the photo, (d) the agent received the image as a native vision block and read the SN off the label.

**What was not tested**: I have not run a head-to-head BEFORE / AFTER screenshot pair in the same Zalo conversation - the pre-fix behavior was the live deployment state captured separately in the downstream vendor patch's tracking ticket, which is what motivated this PR. The AFTER screenshots above are from a real deployment with the fix in place. Maintainers can reproduce the BEFORE state by reverting `extensions/zalouser/src/monitor.ts` to the pre-PR version and re-sending the same photo - the bot will reply without referencing the SN because it never received the vision block.

Screenshots live on a separate `proof/zalouser-em-huyen-screenshots` branch on the fork so the upstream merge does not import binaries into openclaw history.

## Refs

Companion outbound PR: openclaw/openclaw#85039 (Zalo client markdown normalizer).
