### PR TITLE
docs: add Upstash Box hosting guide

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1040,7 +1040,8 @@
                   "install/oracle",
                   "install/railway",
                   "install/raspberry-pi",
-                  "install/render"
+                  "install/render",
+                  "install/upstash"
                 ]
               },
               {

--- a/docs/install/upstash.md
+++ b/docs/install/upstash.md
@@ -1,0 +1,71 @@
+---
+summary: "Host OpenClaw on Upstash Box with persistent keep-alive and SSH tunnel access"
+read_when:
+  - Deploying OpenClaw to Upstash Box
+  - You want a managed cloud environment for OpenClaw with no server admin overhead
+title: "Upstash Box"
+---
+
+# Upstash Box
+
+Run a persistent OpenClaw Gateway on [Upstash Box](https://upstash.com/docs/box/overall/quickstart), a managed Linux environment that stays alive around the clock.
+
+## Prerequisites
+
+- [Upstash account](https://console.upstash.com)
+- SSH client on your local machine
+
+<Steps>
+  <Step title="Create a keep-alive Box">
+    Log in to the [Upstash Console](https://console.upstash.com), open **Box**, and create a new Box with the **Keep-Alive** option enabled.
+
+    Note your Box ID (for example, `right-flamingo-14486`) and your [Box API key](https://upstash.com/docs/box/overall/quickstart#1-get-your-api-key).
+
+  </Step>
+
+  <Step title="Connect via SSH">
+    The `-L` flag tunnels the OpenClaw dashboard port to your local machine. Use your Box API key as the password when prompted.
+
+    ```bash
+    ssh -L 18789:127.0.0.1:18789 <box-id>@us-east-1.box.upstash.com
+    ```
+
+  </Step>
+
+  <Step title="Install OpenClaw">
+    ```bash
+    sudo npm install -g openclaw
+    ```
+  </Step>
+
+  <Step title="Run onboarding">
+    ```bash
+    openclaw onboard --install-daemon
+    ```
+
+    Follow the prompts to complete setup. Copy the dashboard URL and token when onboarding finishes.
+
+  </Step>
+
+  <Step title="Start the Gateway">
+    ```bash
+    openclaw config set gateway.bind lan
+    openclaw gateway run
+    ```
+  </Step>
+
+  <Step title="Open the dashboard">
+    With the SSH tunnel active, open the dashboard URL in your browser:
+
+    ```
+    http://127.0.0.1:18789/#token=<your-token>
+    ```
+
+  </Step>
+</Steps>
+
+## Next steps
+
+- Set up messaging channels: [Channels](/channels)
+- Configure the Gateway: [Gateway configuration](/gateway/configuration)
+- Keep OpenClaw up to date: [Updating](/install/updating)


### PR DESCRIPTION
## Summary

- Adds `docs/install/upstash.md` — a step-by-step guide for running [OpenClaw on Upstash Box](https://upstash.com/docs/box/guides/openclaw-setup), a managed keep-alive Linux environment
- Registers `install/upstash` in the Hosting group of `docs/docs.json` (alphabetical order, after `render`)

## Verification

Behavior addressed: No existing hosting guide covered Upstash Box.

Real environment tested: Upstash Box environment with SSH tunnel and OpenClaw CLI install, as documented in the existing Upstash-side guide at `box/guides/openclaw-setup.mdx`.

Exact steps or command run after this patch: `pnpm docs:dev` — verified page renders correctly in local Mintlify preview with all steps, links, and navigation entry.

Evidence after fix: Page visible at `/install/upstash` in local preview; nav entry appears under Hosting group.

Observed result after fix: Guide loads, steps render with correct SSH command, dashboard URL, and next-steps links.

What was not tested: Live Upstash Box end-to-end install from scratch.