### PR TITLE
fix(xai): keep OAuth URL clickable

### DIFF
--- a/extensions/xai/xai-oauth.test.ts
+++ b/extensions/xai/xai-oauth.test.ts
@@ -4,17 +4,27 @@ import {
   createTestWizardPrompter,
 } from "openclaw/plugin-sdk/plugin-test-runtime";
 import type { OAuthCredential } from "openclaw/plugin-sdk/provider-auth";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const waitForLocalOAuthCallbackMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/provider-auth-runtime", () => ({
+  waitForLocalOAuthCallback: waitForLocalOAuthCallbackMock,
+}));
+
 import {
   buildXaiOAuthAuthorizationCodeTokenBody,
   buildXaiOAuthAuthorizeUrl,
   fetchXaiOAuthDiscovery,
   isTrustedXaiOAuthEndpoint,
   loginXaiDeviceCode,
+  loginXaiOAuth,
   refreshXaiOAuthCredential,
   XAI_OAUTH_CALLBACK_CORS_ORIGIN_ALLOWLIST,
+  XAI_OAUTH_CALLBACK_HOST,
   XAI_OAUTH_CALLBACK_PORT,
   XAI_OAUTH_CLIENT_ID,
+  XAI_OAUTH_DISCOVERY_URL,
   XAI_OAUTH_REDIRECT_URI,
   XAI_OAUTH_SCOPE,
 } from "./xai-oauth.js";
@@ -40,7 +50,42 @@ function requireStringBody(init: RequestInit | undefined): string {
   return init.body;
 }
 
+function requestUrl(input: RequestInfo | URL): string {
+  if (typeof input === "string") {
+    return input;
+  }
+  if (input instanceof URL) {
+    return input.href;
+  }
+  return input.url;
+}
+
+function stubSuccessfulXaiOAuthNetwork(): void {
+  const fetchImpl = vi.fn<typeof fetch>(async (url, init) => {
+    if (requestUrl(url) === XAI_OAUTH_DISCOVERY_URL) {
+      return jsonResponse({
+        authorization_endpoint: "https://auth.x.ai/oauth2/authorize",
+        token_endpoint: "https://auth.x.ai/oauth2/token",
+      });
+    }
+
+    expect(requestUrl(url)).toBe("https://auth.x.ai/oauth2/token");
+    expect(init?.method).toBe("POST");
+    expect(requireStringBody(init)).toContain("code=AUTHCODE");
+    return jsonResponse({
+      access_token: "access-token",
+      refresh_token: "refresh-token",
+      expires_in: 3600,
+    });
+  });
+  vi.stubGlobal("fetch", fetchImpl);
+}
+
 describe("xAI OAuth", () => {
+  beforeEach(() => {
+    waitForLocalOAuthCallbackMock.mockReset();
+  });
+
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.unstubAllEnvs();
@@ -163,7 +208,85 @@ describe("xAI OAuth", () => {
     expect(refreshed.access).toBe("access-2");
     expect(refreshed.refresh).toBe("refresh-1");
     expect(refreshed.expires).toBe(121_000);
-    vi.unstubAllEnvs();
+  });
+
+  it("prints the authorize URL through plain prompter output so terminal link detection keeps it whole", async () => {
+    waitForLocalOAuthCallbackMock.mockResolvedValue({ code: "AUTHCODE", state: "state-1" });
+    stubSuccessfulXaiOAuthNetwork();
+
+    const progress = { update: vi.fn(), stop: vi.fn() };
+    const note = vi.fn<(message: string, title?: string) => Promise<void>>(async () => undefined);
+    const plain = vi.fn<(message: string) => Promise<void>>(async () => undefined);
+    const openUrl = vi.fn<(url: string) => Promise<void>>(async () => undefined);
+    const runtimeLog = vi.fn<(message: string) => void>();
+    const ctx = {
+      config: {},
+      isRemote: true,
+      openUrl,
+      prompter: {
+        note,
+        plain,
+        progress: vi.fn(() => progress),
+      },
+      runtime: {
+        log: runtimeLog,
+        error: vi.fn(),
+        exit: vi.fn(),
+      },
+      oauth: { createVpsAwareHandlers: vi.fn() },
+    } as unknown as ProviderAuthContext;
+
+    await loginXaiOAuth(ctx);
+
+    expect(openUrl).not.toHaveBeenCalled();
+    const noteMessage = note.mock.calls[0]?.[0] ?? "";
+    expect(noteMessage).toContain("Open this xAI OAuth URL in your browser:");
+    expect(noteMessage).toContain(
+      `ssh -N -L ${XAI_OAUTH_CALLBACK_PORT}:${XAI_OAUTH_CALLBACK_HOST}:${XAI_OAUTH_CALLBACK_PORT} <host>`,
+    );
+    expect(noteMessage).not.toContain("https://auth.x.ai/oauth2/authorize");
+
+    const plainOutput = plain.mock.calls[0]?.[0] ?? "";
+    expect(plainOutput.trim()).toMatch(/^https:\/\/auth\.x\.ai\/oauth2\/authorize\?/);
+    expect(plainOutput).toContain(`client_id=${encodeURIComponent(XAI_OAUTH_CLIENT_ID)}`);
+    expect(plainOutput).toContain("code_challenge=");
+    expect(runtimeLog).not.toHaveBeenCalled();
+    expect(progress.stop).toHaveBeenCalledWith("xAI OAuth complete");
+  });
+
+  it("keeps the authorize URL visible for prompters without plain output", async () => {
+    waitForLocalOAuthCallbackMock.mockResolvedValue({ code: "AUTHCODE", state: "state-1" });
+    stubSuccessfulXaiOAuthNetwork();
+
+    const progress = { update: vi.fn(), stop: vi.fn() };
+    const note = vi.fn<(message: string, title?: string) => Promise<void>>(async () => undefined);
+    const openUrl = vi.fn<(url: string) => Promise<void>>(async () => undefined);
+    const runtimeLog = vi.fn<(message: string) => void>();
+    const ctx = {
+      config: {},
+      isRemote: false,
+      openUrl,
+      prompter: {
+        note,
+        progress: vi.fn(() => progress),
+      },
+      runtime: {
+        log: runtimeLog,
+        error: vi.fn(),
+        exit: vi.fn(),
+      },
+      oauth: { createVpsAwareHandlers: vi.fn() },
+    } as unknown as ProviderAuthContext;
+
+    await loginXaiOAuth(ctx);
+
+    const authorizeUrl = openUrl.mock.calls[0]?.[0] ?? "";
+    const noteMessage = note.mock.calls[0]?.[0] ?? "";
+    expect(authorizeUrl).toContain("https://auth.x.ai/oauth2/authorize?");
+    expect(noteMessage).toContain("Open this xAI OAuth URL in your browser:");
+    expect(noteMessage).not.toContain(authorizeUrl);
+    expect(runtimeLog.mock.calls[0]?.[0] ?? "").toContain(authorizeUrl);
+    expect(progress.stop).toHaveBeenCalledWith("xAI OAuth complete");
   });
 
   it("logs in with xAI device code without a localhost callback", async () => {

--- a/extensions/xai/xai-oauth.ts
+++ b/extensions/xai/xai-oauth.ts
@@ -511,7 +511,7 @@ function readCredentialString<TKey extends string>(
 }
 
 async function noteXaiOAuthUrl(ctx: ProviderAuthContext, authorizeUrl: string): Promise<void> {
-  const lines = ["Open this xAI OAuth URL in your browser:", authorizeUrl];
+  const lines = ["Open this xAI OAuth URL in your browser:"];
   if (ctx.isRemote) {
     lines.push(
       "",
@@ -520,6 +520,11 @@ async function noteXaiOAuthUrl(ctx: ProviderAuthContext, authorizeUrl: string): 
     );
   }
   await ctx.prompter.note(lines.join("\n"), "xAI OAuth");
+  if (ctx.prompter.plain) {
+    await ctx.prompter.plain(`\n${authorizeUrl}\n`);
+    return;
+  }
+  ctx.runtime.log(`\n${authorizeUrl}\n`);
 }
 
 export async function loginXaiOAuth(ctx: ProviderAuthContext): Promise<ProviderAuthResult> {


### PR DESCRIPTION
## Summary

- Problem: xAI OAuth printed the long authorize URL inside a Clack note box, which hard-wrapped the URL and made Ghostty/tmux Cmd-click stop at the first line.
- Why it matters: users could not reliably open the Grok/xAI browser sign-in link from terminals where wrapped raw URLs otherwise work.
- What changed: preserve the existing xAI OAuth note wording and remote forwarding text, but print the long authorize URL through plain prompter output so the terminal can soft-wrap it as one clickable URL.
- What did NOT change (scope boundary): no OAuth protocol, callback port, credential storage, provider config, new public option, remote/local instruction wording, or current-main xAI device-code auth behavior changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior addressed: xAI/Grok OAuth authorize URLs no longer get hard-wrapped inside Clack note boxes, so Ghostty over tmux can Cmd-click the full wrapped URL.
- Real environment tested: Ghostty over tmux on earlier PR head `4ce3077d70`, which used the same plain-output URL path; current head `58f532af4cfae822b2640704120c69c18756f947` keeps that same URL-output change on current main and preserves current-main xAI device-code auth.
- Exact steps or command run after this patch: from the PR branch, run `pnpm openclaw models auth login --provider xai --method oauth`, wait for the xAI/Grok OAuth URL to print, then Cmd-click the visually wrapped URL in Ghostty over tmux.
- Evidence after fix: terminal live-output proof from the reporter using `openclaw models auth login --provider xai --method oauth`: after the patched command printed the xAI/Grok OAuth URL as plain terminal output, Cmd-click in Ghostty over tmux opened the complete wrapped URL successfully.
- Observed result after fix: reporter confirmed the real terminal path with "yes this works" after testing the patched xAI/Grok OAuth URL in Ghostty over tmux.
- What was not tested: fresh exact-head Ghostty/tmux retest after the current-main rebase; additional terminal/OS matrix; maintainer Testbox run.
- Before evidence: previous xAI OAuth output placed the long URL in `prompter.note`, while OpenAI Codex OAuth used raw/plain output and remained clickable across terminal soft wraps.

## Root Cause (if applicable)

- Root cause: xAI OAuth placed the authorize URL in `prompter.note`; Clack note rendering inserts hard line breaks/prefixes around long note bodies.
- Missing detection / guardrail: no provider auth coverage locked in how the authorize URL is surfaced to terminal clients.
- Contributing context (if known): OpenAI Codex OAuth uses raw runtime output for its long sign-in URL, so terminal soft-wrap link detection keeps working there.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/xai/xai-oauth.test.ts`
- Scenario the test should lock in: the existing note text remains, the long OAuth URL is absent from the wrapped note, the long URL goes through plain prompter output, and current-main xAI device-code auth still passes.
- Why this is the smallest reliable guardrail: it locks the provider-owned auth output contract without requiring a live xAI account.
- Existing test that already covers this (if any): none before this PR.
- If no new test is added, why not: N/A; new focused coverage was added.

## User-visible / Behavior Changes

xAI/Grok OAuth sign-in now prints the long URL outside the styled note so terminals can keep the wrapped URL clickable. Existing note wording is preserved.

## Diagram (if applicable)

```text
Before:
xAI OAuth -> Clack note with URL -> hard-wrapped authorize URL -> terminal link stops at first line

After:
xAI OAuth -> same Clack note without URL + plain URL output -> terminal soft-wrap keeps the full link clickable
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any Yes, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: reporter setup in Ghostty over tmux; local automated proof in Linux worktree
- Runtime/container: Node 22.x, pnpm 11.1.0
- Model/provider: xAI/Grok provider OAuth
- Integration/channel (if any): CLI model auth login
- Relevant config (redacted): no secrets printed or committed

### Steps

1. Run `pnpm openclaw models auth login --provider xai --method oauth` from the PR branch.
2. Cmd-click the printed xAI/Grok OAuth URL in Ghostty over tmux after it wraps visually.
3. Run `node scripts/run-vitest.mjs extensions/xai/xai-oauth.test.ts` for focused regression proof.

### Expected

- The terminal opens the complete xAI/Grok OAuth URL, even when it visually wraps.
- The URL remains visible to wizard clients and fallback prompters.
- Current-main xAI device-code auth remains intact.

### Actual

- User confirmed the Ghostty/tmux Cmd-click path works on this branch before the current-main rebase.
- Focused tests, extension test types, bundled-extension lint, formatting, and Codex review passed on current head.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Terminal/user proof: the reporter tested this branch in Ghostty over tmux and confirmed the wrapped xAI/Grok OAuth URL opens correctly with Cmd-click.

Supplemental local proof on current head:

```text
pnpm format:check extensions/xai/xai-oauth.ts extensions/xai/xai-oauth.test.ts
node scripts/run-bundled-extension-oxlint.mjs
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo
node scripts/run-vitest.mjs extensions/xai/xai-oauth.test.ts
Test Files  1 passed (1)
Tests       9 passed (9)
codex review --base origin/main
No actionable findings.
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reporter verified the real Ghostty-over-tmux wrapped-link click path on the branch before the current-main rebase; agent verified current-head output behavior and current-main device-code coverage through `extensions/xai/xai-oauth.test.ts`.
- Edge cases checked: remote/VPS forwarding note preserved, local-browser path, prompter without `plain`, current-main xAI device-code auth test.
- What you did **not** verify: fresh exact-head manual Ghostty/tmux click after the current-main rebase, additional terminal/OS combinations, and maintainer Testbox lanes.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

None.

