### PR TITLE
fix(media-understanding): align describeImageWithModel default maxTok…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -267,6 +267,7 @@ Docs: https://docs.openclaw.ai
 - PDF tool: time out idle remote PDF body reads after 120 seconds so stalled remote documents return an error instead of wedging the session. Fixes #68649. (#84768) Thanks @luoyanglang.
 - Diagnostics/OpenTelemetry plugin: suppress handled OTLP exporter promise rejections so collector shutdowns no longer crash the Gateway. (#81085) Thanks @luoyanglang.
 - Agents/exec: omit raw command text and env values from denied exec failure logs while keeping safe correlation metadata. Fixes #85049. (#85140) Thanks @joshavant.
+- Media-understanding: restore the 4096-token default for image descriptions so reasoning-capable vision models no longer truncate before returning text, while preserving smaller model caps. (#84932) Thanks @scotthuang.
 - Media/audio: skip empty structured sherpa-onnx transcripts instead of treating the raw JSON payload as spoken text. (#84667) Thanks @TurboTheTurtle.
 - Agents/exec: preserve inherited XDG base-directory environment values for subprocesses while still rejecting agent-supplied XDG overrides. Fixes #84854. (#85139) Thanks @joshavant.
 - Node/Linux: keep `OPENCLAW_GATEWAY_TOKEN` out of generated systemd unit files by writing node service token values to a node-specific env file. (#84408)

--- a/src/media-understanding/image.test.ts
+++ b/src/media-understanding/image.test.ts
@@ -1291,14 +1291,7 @@ describe("describeImageWithModel", () => {
     expect(contentTypes).toContain("image");
   });
 
-  it("defaults image-describe maxTokens to 4096 so reasoning-capable VLM responses are not truncated at 512", async () => {
-    // Regression for the silent re-introduction of the 512-token cap when the
-    // unified media-understanding pipeline was created — see PR #11770 which
-    // already raised the legacy `image_describe` tool default from 512 to
-    // 4096. With 512 the reasoning blocks of models like
-    // `agent-plan/doubao-seed-2.0-pro` consume the entire budget and the
-    // response comes back with `stopReason: "length"` and zero text content,
-    // surfacing as `Image model returned no text (<provider>/<model>)`.
+  it("defaults image-describe maxTokens to 4096 for reasoning-capable VLMs", async () => {
     discoverModelsMock.mockReturnValue({
       find: vi.fn(() => ({
         api: "openai-completions",
@@ -1335,12 +1328,6 @@ describe("describeImageWithModel", () => {
   });
 
   it("caps image-describe maxTokens by the resolved model's own maxTokens", async () => {
-    // Pairs with the 4096 default test above: when the registry-resolved model
-    // declares a smaller token budget, `resolveImageToolMaxTokens` must take
-    // the floor via `Math.min`. This locks in the shared cap behaviour with
-    // the legacy `image_describe` tool (`src/agents/tools/image-tool.ts`) so
-    // small-budget VLMs keep their own ceiling even after the default is
-    // raised.
     discoverModelsMock.mockReturnValue({
       find: vi.fn(() => ({
         api: "openai-completions",

--- a/src/media-understanding/image.test.ts
+++ b/src/media-understanding/image.test.ts
@@ -811,7 +811,7 @@ describe("describeImageWithModel", () => {
     expect(context.messages).toHaveLength(1);
     expect(Object.keys(options).toSorted()).toEqual(["apiKey", "maxTokens", "signal", "timeoutMs"]);
     expect(options.apiKey).toBe("oauth-test");
-    expect(options.maxTokens).toBe(512);
+    expect(options.maxTokens).toBe(4096);
     expect(options.signal).toBeInstanceOf(AbortSignal);
     expect(options.timeoutMs).toBeGreaterThan(0);
     expect(options.timeoutMs).toBeLessThanOrEqual(1000);
@@ -1289,5 +1289,91 @@ describe("describeImageWithModel", () => {
     const contentTypes = userMessage!.content.map((block) => (block as { type: string }).type);
     expect(contentTypes).not.toContain("text");
     expect(contentTypes).toContain("image");
+  });
+
+  it("defaults image-describe maxTokens to 4096 so reasoning-capable VLM responses are not truncated at 512", async () => {
+    // Regression for the silent re-introduction of the 512-token cap when the
+    // unified media-understanding pipeline was created — see PR #11770 which
+    // already raised the legacy `image_describe` tool default from 512 to
+    // 4096. With 512 the reasoning blocks of models like
+    // `agent-plan/doubao-seed-2.0-pro` consume the entire budget and the
+    // response comes back with `stopReason: "length"` and zero text content,
+    // surfacing as `Image model returned no text (<provider>/<model>)`.
+    discoverModelsMock.mockReturnValue({
+      find: vi.fn(() => ({
+        api: "openai-completions",
+        provider: "agent-plan",
+        id: "doubao-seed-2.0-pro",
+        input: ["text", "image"],
+        baseUrl: "https://ark.cn-beijing.volces.com/api/plan/v3",
+      })),
+    });
+    completeMock.mockResolvedValue({
+      role: "assistant",
+      api: "openai-completions",
+      provider: "agent-plan",
+      model: "doubao-seed-2.0-pro",
+      stopReason: "stop",
+      timestamp: Date.now(),
+      content: [{ type: "text", text: "ok" }],
+    });
+
+    await describeImageWithModel({
+      cfg: {},
+      agentDir: "/tmp/openclaw-agent",
+      provider: "agent-plan",
+      model: "doubao-seed-2.0-pro",
+      buffer: Buffer.from("png-bytes"),
+      fileName: "image.png",
+      mime: "image/png",
+      prompt: "Describe the image.",
+      timeoutMs: 1000,
+    });
+
+    const [, , options] = requireFirstMockCall(completeMock, "image completion");
+    expect(options.maxTokens).toBe(4096);
+  });
+
+  it("caps image-describe maxTokens by the resolved model's own maxTokens", async () => {
+    // Pairs with the 4096 default test above: when the registry-resolved model
+    // declares a smaller token budget, `resolveImageToolMaxTokens` must take
+    // the floor via `Math.min`. This locks in the shared cap behaviour with
+    // the legacy `image_describe` tool (`src/agents/tools/image-tool.ts`) so
+    // small-budget VLMs keep their own ceiling even after the default is
+    // raised.
+    discoverModelsMock.mockReturnValue({
+      find: vi.fn(() => ({
+        api: "openai-completions",
+        provider: "fake",
+        id: "small-vlm",
+        input: ["text", "image"],
+        baseUrl: "https://example.test",
+        maxTokens: 1024,
+      })),
+    });
+    completeMock.mockResolvedValue({
+      role: "assistant",
+      api: "openai-completions",
+      provider: "fake",
+      model: "small-vlm",
+      stopReason: "stop",
+      timestamp: Date.now(),
+      content: [{ type: "text", text: "ok" }],
+    });
+
+    await describeImageWithModel({
+      cfg: {},
+      agentDir: "/tmp/openclaw-agent",
+      provider: "fake",
+      model: "small-vlm",
+      buffer: Buffer.from("png-bytes"),
+      fileName: "image.png",
+      mime: "image/png",
+      prompt: "Describe the image.",
+      timeoutMs: 1000,
+    });
+
+    const [, , options] = requireFirstMockCall(completeMock, "image completion");
+    expect(options.maxTokens).toBe(1024);
   });
 });

--- a/src/media-understanding/image.ts
+++ b/src/media-understanding/image.ts
@@ -518,7 +518,6 @@ async function describeImagesWithModelInternal(
     promptInUserContent: shouldPlaceImagePromptInUserContent(model),
   });
 
-  // Align with `src/agents/tools/image-tool.ts`: defer to `resolveImageToolMaxTokens`'s 4096 default unless the caller overrides it.
   const maxTokens = resolveImageToolMaxTokens(model.maxTokens, params.maxTokens);
   const completeImage = async (onPayload?: ProviderStreamOptions["onPayload"]) => {
     const payloadHandler = composeImageDescriptionPayloadHandlers(onPayload, options.onPayload);

--- a/src/media-understanding/image.ts
+++ b/src/media-understanding/image.ts
@@ -518,7 +518,8 @@ async function describeImagesWithModelInternal(
     promptInUserContent: shouldPlaceImagePromptInUserContent(model),
   });
 
-  const maxTokens = resolveImageToolMaxTokens(model.maxTokens, params.maxTokens ?? 512);
+  // Align with `src/agents/tools/image-tool.ts`: defer to `resolveImageToolMaxTokens`'s 4096 default unless the caller overrides it.
+  const maxTokens = resolveImageToolMaxTokens(model.maxTokens, params.maxTokens);
   const completeImage = async (onPayload?: ProviderStreamOptions["onPayload"]) => {
     const payloadHandler = composeImageDescriptionPayloadHandlers(onPayload, options.onPayload);
     const timeoutMs = resolveImageDescriptionTimeoutMs(params.timeoutMs, startedAtMs);


### PR DESCRIPTION
## Summary

- Problem: `src/media-understanding/image.ts` calls `resolveImageToolMaxTokens(model.maxTokens, params.maxTokens ?? 512)`, explicitly passing `512` and short-circuiting the helper's own `requestedMaxTokens = 4096` default. Reasoning-capable VLMs (doubao-seed-2.0-pro on ark plan, Anthropic with extended thinking, OpenAI o-series) spend most of a 512-token budget inside a `thinking` block, so the response comes back with `stopReason: "length"` and zero text — surfacing as `Image model returned no text (<provider>/<model>)`.
- Fix (1 LOC): drop the caller-side `?? 512` and pass `params.maxTokens` straight through, matching the calling style of `src/agents/tools/image-tool.ts` (which uses `resolveImageToolMaxTokens(undefined)` at all three live call sites). The helper's `Math.min(requestedMaxTokens, modelMaxTokens)` cap is unchanged, so small-budget models keep their own ceiling.
- This restores the behaviour PR #11770 already shipped for `src/agents/tools/image-tool.ts` (Feb 2026) to the unified media-understanding pipeline added five weeks later (commit `2131981230`, Mar 2026), where the caller-side `?? 512` re-introduced the same regression.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Skills / tool execution
- [x] Integrations

## Linked Issue/PR

- Related: #11770 (same root cause, sibling file)
- [x] This PR fixes a bug or regression

## Root Cause

Caller-side `params.maxTokens ?? 512` in `describeImagesWithModelInternal` overrides the `resolveImageToolMaxTokens` helper's 4096 default. Introduced in `2131981230` when `image.ts` was created; none of the live callers (telegram sticker cache, `openclaw infer image describe` CLI, opencode payload-transform) pass an explicit `maxTokens`, so all inherit the regressed 512.

## Regression Coverage

`src/media-understanding/image.test.ts`:
- Updated existing assertion `options.maxTokens === 512` → `4096` (it was pinning the regressed value).
- Added: default-path test driving `describeImageWithModel` with no `maxTokens` against an `agent-plan/doubao-seed-2.0-pro` mock; asserts `streamOptions.maxTokens === 4096` reaching `complete()`.
- Added: cap-path test with `model.maxTokens = 1024`; asserts effective budget is floored to `1024`.

## Security Impact

- New permissions/capabilities? No
- Secrets handling? No
- New/changed network calls? No — same `complete()` call to the same endpoint, only the `max_tokens` field changes.
- Tool execution surface? No

## Real behavior proof

- Behavior addressed: `describeImagesWithModelInternal` no longer returns `Image model returned no text (<provider>/<model>)` for reasoning-capable VLMs whose model token budget is ≥ 4096; default budget now matches `resolveImageToolMaxTokens`'s own 4096 default and the sibling `image_describe` tool.
- Real environment tested: macOS 26.3 arm64, Node v25.8.1, OpenClaw built from `main` (`node scripts/build-all.mjs`), caller `openclaw infer image describe` (CLI surface of `describeImageFileWithModel` → `describeImagesWithModelInternal`), model `agent-plan/doubao-seed-2.0-pro` via real Volcengine ark plan endpoint, image `/tmp/openclaw-pr-repro.png` (885 KB).
- Exact steps or command run after this patch: same image, same model, same `--timeout-ms 120000`; only variable across runs is the caller default in `src/media-understanding/image.ts`.
  1. Build with `?? 512`: `node scripts/build-all.mjs`
  2. `node dist/index.js infer image describe --file /tmp/openclaw-pr-repro.png --model agent-plan/doubao-seed-2.0-pro --timeout-ms 120000 --json` → `Error: Image model returned no text (agent-plan/doubao-seed-2.0-pro).` Diagnostic dump shows resolved request `maxTokens: 512`, assistant message `stopReason: "length"`, `content` is a single `thinking` block.
  3. Apply fix, rebuild, rerun same command → `ok: true` with `outputs[0].text` ≈ 700 chars; diagnostic shows `maxTokens: 4096`, `stopReason: "stop"`, `content` contains a `text` block.
- Evidence after fix: terminal capture below (before / after running the exact same command on the same image, with `?? 512` vs `?? 4096`). The diagnostic-log lines (`maxTokens`, `stopReason`) came from a one-shot `console.log` inside `describeImagesWithModelInternal` that is NOT part of this PR.

```
--- Before (params.maxTokens ?? 512, current main) ---
$ node dist/index.js infer image describe --file /tmp/openclaw-pr-repro.png \
    --model agent-plan/doubao-seed-2.0-pro --timeout-ms 120000 --json
[debug:vision] resolved request {"provider":"agent-plan","modelId":"doubao-seed-2.0-pro","maxTokens":512,...}
[debug:vision] assistant message {"role":"assistant","stopReason":"length","content":[{"type":"thinking","thinking":"...","thinkingSignature":"reasoning_content"}],"usage":{...zeroes...}}
Error: Image model returned no text (agent-plan/doubao-seed-2.0-pro).
$ echo $?
1

--- After (params.maxTokens transparent to helper's 4096 default, this PR) ---
$ node dist/index.js infer image describe --file /tmp/openclaw-pr-repro.png \
    --model agent-plan/doubao-seed-2.0-pro --timeout-ms 120000 --json
[debug:vision] resolved request {"provider":"agent-plan","modelId":"doubao-seed-2.0-pro","maxTokens":4096,...}
[debug:vision] assistant message {"role":"assistant","stopReason":"stop","content":[{"type":"text","text":"这是PC端微信的深色模式界面 ... <~700 chars>"},{"type":"thinking",...}],"usage":{...non-zero output tokens...}}
{"ok":true,"capability":"image.describe","transport":"local","provider":"agent-plan","model":"doubao-seed-2.0-pro","attempts":[],"outputs":[{"path":"/tmp/openclaw-pr-repro.png","text":"这是PC端微信的深色模式界面，分为三栏布局 ... <full ~700-char description omitted>","provider":"agent-plan","model":"doubao-seed-2.0-pro","kind":"image.description"}]}
$ echo $?
0
```

- Observed result after fix: CLI exit code `0`; JSON envelope above has `ok: true`, `outputs[0].text` populated (~700 chars); resolved request carries `maxTokens: 4096`; assistant message ends with `stopReason: "stop"` plus a real `text` content block (was `stopReason: "length"` with a single `thinking` block before the fix).
- What was not tested: telegram sticker cache and opencode payload-transform end-to-end (both share the same pipeline and inherit the same default, but not re-run live); cost/latency impact (the change only raises a cap, not a fixed budget).

## Compatibility / Risks

- Backward compatible: yes — only externally observable change is that responses previously truncated at 512 tokens may now run longer (up to `min(4096, model.maxTokens)`).
- Cost risk: slightly more output tokens billed for previously-truncated calls. Mitigation: same 4096 value PR #11770 already validated for `image_describe`; operators can still pass an explicit `maxTokens` per entry in `tools.media.image.models[]`.
