### PR TITLE
feat: add minimal Discord /ask command

### DIFF
--- a/docs/plugins/ask.md
+++ b/docs/plugins/ask.md
@@ -1,0 +1,28 @@
+# Ask plugin
+
+`/ask` is a minimal Discord HITL question UI.
+
+It chooses one Discord interaction style from the prompt:
+
+- Button: quick GO/STOP, Yes/No, or 2–5 option decisions
+- Select: option lists, categories, styles, or more than 5 options
+- Modal: reasons, details, free-form answers, or supplemental notes
+
+Safety defaults:
+
+- `allowedUsers` is the command sender only
+- `reusable=false`
+- session TTL is 30 minutes
+- answer handling is `log_only`
+- `requires_second_go=true`
+- `action_scope=answer_capture_only`
+
+Initial scope deliberately excludes poll routing, select+modal composite flows, approval execution, external send/deploy/config writes, long-running task starts, LLM classification, and presets.
+
+Example:
+
+```text
+/ask Minimal /ask implementation GO? --options=GO:go,STOP:stop
+```
+
+The resulting Discord component uses `callbackData = "ask:<ask_id>"` and is handled by the bundled `ask` plugin interactive handler.

--- a/docs/plugins/ask.md
+++ b/docs/plugins/ask.md
@@ -51,3 +51,19 @@ Example:
 ```text
 /ask grill 曖昧な依頼をSPECと実装タスクまで詰めたい
 ```
+
+## Runtime smoke test
+
+After merge and runtime rollout, verify the Discord path in a private test channel:
+
+1. Restart the gateway/runtime process that loads bundled plugins.
+2. Run `/ask Minimal /ask smoke? --options=GO:go,STOP:stop`.
+3. Confirm the command renders Discord components.
+4. Click an allowed answer as the requester and confirm the session records the answer, clears components, and does not execute any action.
+5. Run `/ask grill Build a small dashboard`.
+6. Submit one Grill modal answer and confirm the next Grill question is shown with progress.
+7. Finish the Grill sequence and confirm the final summary keeps `log_only`, `requires_second_go=true`, and `action_scope=answer_capture_only`.
+8. Confirm a non-requester interaction is rejected privately and does not overwrite the shared prompt.
+
+Rollback is to revert the merge commit or disable/remove the bundled `ask` plugin from the deployed runtime, then restart the gateway/runtime process.
+No data migration is required because the initial Ask sessions are keyed runtime records and no external action is executed.

--- a/docs/plugins/ask.md
+++ b/docs/plugins/ask.md
@@ -26,3 +26,28 @@ Example:
 ```
 
 The resulting Discord component uses `callbackData = "ask:<ask_id>"` and is handled by the bundled `ask` plugin interactive handler.
+
+## Grill Mode
+
+`/ask grill <request>` starts a one-question-at-a-time clarification protocol for ambiguous work.
+It is a prefix mode on the current `/ask` command, not a native Discord subcommand yet.
+
+Grill Mode asks six fixed prompts:
+
+1. Goal
+2. Context
+3. Scope
+4. Risk / HITL
+5. Acceptance
+6. Output format
+
+Each step uses a short modal prompt and stores the answer in `ask.sessions`.
+The visible message only shows the current question and progress; it does not replay the whole answer history on every turn.
+The final summary is still `log_only` and keeps `requires_second_go=true`.
+It must not trigger implementation, external sends, deploys, config writes, deletes, billing, or gateway restarts.
+
+Example:
+
+```text
+/ask grill 曖昧な依頼をSPECと実装タスクまで詰めたい
+```

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -135,6 +135,7 @@ focused channel/runtime subpaths, `config-contracts`, `string-coerce-runtime`,
     | `plugin-sdk/group-access` | Shared group-access decision helpers |
     | `plugin-sdk/direct-dm` | Shared direct-DM auth/guard helpers |
     | `plugin-sdk/discord` | Deprecated Discord compatibility facade for published `@openclaw/discord@2026.3.13` and tracked owner compatibility; new plugins should use generic channel SDK subpaths |
+    | `plugin-sdk/discord-interactions` | Discord interactive component message and handler registration types for bundled Discord component flows |
     | `plugin-sdk/telegram-account` | Deprecated Telegram account-resolution compatibility facade for tracked owner compatibility; new plugins should use injected runtime helpers or generic channel SDK subpaths |
     | `plugin-sdk/zalouser` | Deprecated Zalo Personal compatibility facade for published Lark/Zalo packages that still import sender command authorization; new plugins should use `plugin-sdk/command-auth` |
     | `plugin-sdk/interactive-runtime` | Semantic message presentation, delivery, and legacy interactive reply helpers. See [Message Presentation](/plugins/message-presentation) |

--- a/extensions/ask/classifier.ts
+++ b/extensions/ask/classifier.ts
@@ -1,0 +1,145 @@
+import type { AskOption, AskUiType } from "./types.js";
+
+const GO_STOP_OPTIONS: AskOption[] = [
+  { label: "GO", value: "go" },
+  { label: "STOP", value: "stop" },
+];
+
+const YES_NO_OPTIONS: AskOption[] = [
+  { label: "Yes", value: "yes" },
+  { label: "No", value: "no" },
+];
+
+export type AskClassification = {
+  uiType: AskUiType;
+  questionText: string;
+  options: AskOption[];
+};
+
+export function classifyAskInput(rawArgs: string | undefined): AskClassification {
+  const args = (rawArgs ?? "").trim();
+  if (!args) {
+    return {
+      uiType: "modal",
+      questionText: "What should I ask?",
+      options: [],
+    };
+  }
+
+  const explicit = parseExplicitOptions(args);
+  const questionText = explicit.questionText || args;
+  const lower = questionText.toLowerCase();
+  const options = explicit.options.length > 0 ? explicit.options : inferOptions(questionText);
+
+  if (shouldUseModal(lower, options)) {
+    return { uiType: "modal", questionText, options: [] };
+  }
+  if (shouldUseSelect(lower, options)) {
+    return { uiType: "select", questionText, options: normalizeOptions(options).slice(0, 25) };
+  }
+  return { uiType: "button", questionText, options: normalizeOptions(options).slice(0, 5) };
+}
+
+function parseExplicitOptions(args: string): { questionText: string; options: AskOption[] } {
+  const markerMatch = /(?:^|\s)--options(?:=|\s+)(.+)$/iu.exec(args);
+  if (!markerMatch?.[1]) {
+    return { questionText: args, options: [] };
+  }
+  const optionText = markerMatch[1].trim();
+  const questionText = args.slice(0, markerMatch.index).trim();
+  return { questionText, options: splitOptionText(optionText) };
+}
+
+function inferOptions(text: string): AskOption[] {
+  const lower = text.toLowerCase();
+  if (/\b(go|approve|approval|承認)\b|go\s*\/\s*stop|実装go|進めていい/u.test(lower)) {
+    return GO_STOP_OPTIONS;
+  }
+  if (/\byes\s*\/\s*no\b|\b(y\/n)\b|はい\s*\/\s*いいえ/u.test(lower)) {
+    return YES_NO_OPTIONS;
+  }
+  const slashOptions = extractSlashOptions(text);
+  if (slashOptions.length >= 2) {
+    return slashOptions;
+  }
+  return GO_STOP_OPTIONS;
+}
+
+function extractSlashOptions(text: string): AskOption[] {
+  const compact = text.replace(/[？?。.!！].*$/u, "");
+  const candidates = compact
+    .split(/\s+(?:or|か|または)\s+|\s*\/\s*|\s*[、,]\s*/iu)
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0 && entry.length <= 30);
+  if (candidates.length < 2 || candidates.length > 25) {
+    return [];
+  }
+  const tail = candidates.slice(-Math.min(candidates.length, 5));
+  if (tail.length < 2) {
+    return [];
+  }
+  return tail.map((label) => ({ label, value: slugifyOption(label) }));
+}
+
+function splitOptionText(text: string): AskOption[] {
+  return text
+    .split(/\s*[,|/]\s*|\n+/u)
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .slice(0, 25)
+    .map((entry) => {
+      const [labelRaw, valueRaw] = entry.split(/\s*:\s*/u, 2);
+      const label = (labelRaw ?? entry).trim();
+      const value = (valueRaw ?? slugifyOption(label)).trim();
+      return { label, value };
+    });
+}
+
+function normalizeOptions(options: AskOption[]): AskOption[] {
+  const seen = new Set<string>();
+  const normalized: AskOption[] = [];
+  for (const option of options) {
+    const label = option.label.trim().slice(0, 80);
+    const value = (option.value.trim() || slugifyOption(label)).slice(0, 100);
+    if (!label || seen.has(value)) {
+      continue;
+    }
+    seen.add(value);
+    normalized.push({ label, value });
+  }
+  return normalized.length >= 2 ? normalized : GO_STOP_OPTIONS;
+}
+
+function shouldUseModal(lower: string, options: AskOption[]): boolean {
+  if (
+    /理由|違和感|補足|詳細|説明|入力|書いて|自由記述|why|reason|detail|describe|comment/u.test(
+      lower,
+    )
+  ) {
+    return true;
+  }
+  return options.length === 0;
+}
+
+function shouldUseSelect(lower: string, options: AskOption[]): boolean {
+  if (options.length > 5) {
+    return true;
+  }
+  return /候補|一覧|カテゴリ|方向性|スタイル|選んで|選択|choose|select|category|style/u.test(lower);
+}
+
+function slugifyOption(label: string): string {
+  const ascii = label
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/gu, "-")
+    .replace(/^-+|-+$/gu, "")
+    .slice(0, 80);
+  if (ascii) {
+    return ascii;
+  }
+  const codePoints = Array.from(label)
+    .map((char) => char.codePointAt(0)?.toString(36) ?? "x")
+    .join("-")
+    .slice(0, 80);
+  return `option-${codePoints || "value"}`;
+}

--- a/extensions/ask/classifier.ts
+++ b/extensions/ask/classifier.ts
@@ -11,6 +11,7 @@ const YES_NO_OPTIONS: AskOption[] = [
 ];
 
 export type AskClassification = {
+  mode: "single" | "grill";
   uiType: AskUiType;
   questionText: string;
   options: AskOption[];
@@ -20,8 +21,19 @@ export function classifyAskInput(rawArgs: string | undefined): AskClassification
   const args = (rawArgs ?? "").trim();
   if (!args) {
     return {
+      mode: "single",
       uiType: "modal",
       questionText: "What should I ask?",
+      options: [],
+    };
+  }
+
+  const grill = parseGrillArgs(args);
+  if (grill.isGrill) {
+    return {
+      mode: "grill",
+      uiType: "modal",
+      questionText: grill.initialRequest,
       options: [],
     };
   }
@@ -32,12 +44,31 @@ export function classifyAskInput(rawArgs: string | undefined): AskClassification
   const options = explicit.options.length > 0 ? explicit.options : inferOptions(questionText);
 
   if (shouldUseModal(lower, options)) {
-    return { uiType: "modal", questionText, options: [] };
+    return { mode: "single", uiType: "modal", questionText, options: [] };
   }
   if (shouldUseSelect(lower, options)) {
-    return { uiType: "select", questionText, options: normalizeOptions(options).slice(0, 25) };
+    return {
+      mode: "single",
+      uiType: "select",
+      questionText,
+      options: normalizeOptions(options).slice(0, 25),
+    };
   }
-  return { uiType: "button", questionText, options: normalizeOptions(options).slice(0, 5) };
+  return {
+    mode: "single",
+    uiType: "button",
+    questionText,
+    options: normalizeOptions(options).slice(0, 5),
+  };
+}
+
+function parseGrillArgs(args: string): { isGrill: boolean; initialRequest: string } {
+  const match = /^grill(?:\s+|$)([\s\S]*)$/iu.exec(args);
+  if (!match) {
+    return { isGrill: false, initialRequest: args };
+  }
+  const initialRequest = (match[1] ?? "").trim() || "未指定の依頼";
+  return { isGrill: true, initialRequest };
 }
 
 function parseExplicitOptions(args: string): { questionText: string; options: AskOption[] } {

--- a/extensions/ask/components.ts
+++ b/extensions/ask/components.ts
@@ -1,4 +1,4 @@
-import type { DiscordComponentMessageSpec } from "openclaw/plugin-sdk/discord";
+import type { DiscordComponentMessageSpec } from "openclaw/plugin-sdk/discord-interactions";
 import type { AskSession } from "./types.js";
 
 export function buildAskDiscordComponents(session: AskSession): DiscordComponentMessageSpec {

--- a/extensions/ask/components.ts
+++ b/extensions/ask/components.ts
@@ -1,0 +1,85 @@
+import type { DiscordComponentMessageSpec } from "openclaw/plugin-sdk/discord";
+import type { AskSession } from "./types.js";
+
+export function buildAskDiscordComponents(session: AskSession): DiscordComponentMessageSpec {
+  const callbackData = `ask:${session.askId}`;
+  const allowedUsers = session.allowedUsers.length > 0 ? session.allowedUsers : undefined;
+  const text = [
+    `**/ask** ${session.questionText}`,
+    "-# 回答は記録のみです。実装・送信・設定変更には別GOが必要です。",
+  ].join("\n");
+
+  if (session.uiType === "modal") {
+    return {
+      reusable: false,
+      text,
+      modal: {
+        title: "Answer /ask",
+        callbackData,
+        triggerLabel: "回答する",
+        triggerStyle: "primary",
+        allowedUsers,
+        fields: [
+          {
+            type: "text",
+            name: "answer",
+            label: "回答・理由・補足",
+            required: true,
+            style: "paragraph",
+            maxLength: 1000,
+          },
+        ],
+      },
+    };
+  }
+
+  if (session.uiType === "select") {
+    return {
+      reusable: false,
+      text,
+      blocks: [
+        {
+          type: "actions",
+          select: {
+            type: "string",
+            callbackData,
+            placeholder: "選択してください",
+            minValues: 1,
+            maxValues: 1,
+            allowedUsers,
+            options: session.options.map((option) => ({
+              label: option.label,
+              value: option.value,
+            })),
+          },
+        },
+      ],
+    };
+  }
+
+  return {
+    reusable: false,
+    text,
+    blocks: [
+      {
+        type: "actions",
+        buttons: session.options.slice(0, 5).map((option, index) => ({
+          label: option.label,
+          style: index === 0 ? "primary" : "secondary",
+          callbackData: `${callbackData}:${option.value}`,
+          allowedUsers,
+        })),
+      },
+    ],
+  };
+}
+
+export function formatAskCommandFallback(session: AskSession): string {
+  const expires = new Date(session.expiresAt).toISOString();
+  return [
+    `ask_id: ${session.askId}`,
+    `ui_type: ${session.uiType}`,
+    `expires_at: ${expires}`,
+    "policy: log_only / requires_second_go=true / action_scope=answer_capture_only",
+  ].join("\n");
+}

--- a/extensions/ask/components.ts
+++ b/extensions/ask/components.ts
@@ -1,29 +1,39 @@
 import type { DiscordComponentMessageSpec } from "openclaw/plugin-sdk/discord-interactions";
+import {
+  ASK_GRILL_STEP_COUNT,
+  formatAskGrillQuestion,
+  isAskGrillSession,
+  sanitizeDiscordDisplayText,
+} from "./grill.js";
 import type { AskSession } from "./types.js";
 
 export function buildAskDiscordComponents(session: AskSession): DiscordComponentMessageSpec {
   const callbackData = `ask:${session.askId}`;
   const allowedUsers = session.allowedUsers.length > 0 ? session.allowedUsers : undefined;
-  const text = [
-    `**/ask** ${session.questionText}`,
-    "-# 回答は記録のみです。実装・送信・設定変更には別GOが必要です。",
-  ].join("\n");
+  const text = isAskGrillSession(session)
+    ? formatAskGrillQuestion(session)
+    : [
+        `**/ask** ${sanitizeDiscordDisplayText(session.questionText, 500)}`,
+        "-# 回答は記録のみです。実装・送信・設定変更には別GOが必要です。",
+      ].join("\n");
 
   if (session.uiType === "modal") {
     return {
       reusable: false,
       text,
       modal: {
-        title: "Answer /ask",
+        title: isAskGrillSession(session) ? "Answer /ask grill" : "Answer /ask",
         callbackData,
-        triggerLabel: "回答する",
+        triggerLabel: isAskGrillSession(session) ? "この質問に答える" : "回答する",
         triggerStyle: "primary",
         allowedUsers,
         fields: [
           {
             type: "text",
             name: "answer",
-            label: "回答・理由・補足",
+            label: isAskGrillSession(session)
+              ? `回答 ${((session.grill?.currentStepIndex ?? 0) + 1).toString()}/${ASK_GRILL_STEP_COUNT.toString()}`
+              : "回答・理由・補足",
             required: true,
             style: "paragraph",
             maxLength: 1000,
@@ -78,6 +88,7 @@ export function formatAskCommandFallback(session: AskSession): string {
   const expires = new Date(session.expiresAt).toISOString();
   return [
     `ask_id: ${session.askId}`,
+    `mode: ${session.mode}`,
     `ui_type: ${session.uiType}`,
     `expires_at: ${expires}`,
     "policy: log_only / requires_second_go=true / action_scope=answer_capture_only",

--- a/extensions/ask/grill.ts
+++ b/extensions/ask/grill.ts
@@ -1,0 +1,191 @@
+import type { AskAnswer, AskGrillState, AskSession } from "./types.js";
+
+const GRILL_STEPS: Array<{ id: string; title: string; question: string; label: string }> = [
+  {
+    id: "goal",
+    title: "Goal",
+    question: "この依頼で最終的に何が変われば成功ですか？",
+    label: "成功状態・目的",
+  },
+  {
+    id: "context",
+    title: "Context",
+    question: "前提・背景・対象ユーザー・既存制約で重要なものは何ですか？",
+    label: "前提・背景",
+  },
+  {
+    id: "scope",
+    title: "Scope",
+    question: "今回やること / やらないことの境界はどこですか？",
+    label: "スコープ境界",
+  },
+  {
+    id: "risk",
+    title: "Risk",
+    question: "失敗すると困るリスク、HITLが必要な操作、濫用されると困る点は何ですか？",
+    label: "リスク・HITL",
+  },
+  {
+    id: "acceptance",
+    title: "Acceptance",
+    question: "完了条件とテスト・確認方法は何ですか？",
+    label: "完了条件・検証",
+  },
+  {
+    id: "output",
+    title: "Output",
+    question: "最終アウトプットは SPEC / GOAL / 実装タスク / 提案メモのどれに寄せますか？",
+    label: "アウトプット形式",
+  },
+];
+
+export const ASK_GRILL_STEP_COUNT = GRILL_STEPS.length;
+
+export function createAskGrillState(initialRequest: string): AskGrillState {
+  return {
+    initialRequest: initialRequest.trim() || "未指定の依頼",
+    currentStepIndex: 0,
+    answers: [],
+  };
+}
+
+export function getAskGrillCurrentStep(state: AskGrillState) {
+  return GRILL_STEPS[state.currentStepIndex] ?? GRILL_STEPS[GRILL_STEPS.length - 1];
+}
+
+export function isAskGrillSession(session: AskSession): boolean {
+  return session.mode === "grill" && Boolean(session.grill);
+}
+
+export function formatAskGrillQuestion(session: AskSession): string {
+  const grill = session.grill;
+  if (!grill) {
+    return session.questionText;
+  }
+  const step = getAskGrillCurrentStep(grill);
+  return [
+    `**/ask grill** ${step.title} (${grill.currentStepIndex + 1}/${ASK_GRILL_STEP_COUNT})`,
+    `依頼: ${sanitizeDiscordDisplayText(grill.initialRequest, 300)}`,
+    "",
+    step.question,
+    "-# 1問ずつ仕様を固めます。回答は記録のみで、実装・送信・設定変更には別GOが必要です。",
+  ].join("\n");
+}
+
+export function advanceAskGrillSession(
+  session: AskSession,
+  answer: AskAnswer,
+  now: number,
+): { session: AskSession; completed: boolean } {
+  const grill = session.grill;
+  if (!grill) {
+    return { session: { ...session, status: "answered", result: answer }, completed: true };
+  }
+  const step = getAskGrillCurrentStep(grill);
+  const answerText = summarizeAskAnswerText(answer);
+  const answers = [
+    ...grill.answers,
+    {
+      stepId: step.id,
+      question: step.question,
+      answer: answerText,
+      answeredAt: now,
+    },
+  ];
+  const nextStepIndex = grill.currentStepIndex + 1;
+  if (nextStepIndex >= ASK_GRILL_STEP_COUNT) {
+    return {
+      completed: true,
+      session: {
+        ...session,
+        status: "answered",
+        result: answer,
+        grill: {
+          ...grill,
+          currentStepIndex: grill.currentStepIndex,
+          answers,
+        },
+      },
+    };
+  }
+  const nextGrill = {
+    ...grill,
+    currentStepIndex: nextStepIndex,
+    answers,
+  };
+  const nextStep = getAskGrillCurrentStep(nextGrill);
+  return {
+    completed: false,
+    session: {
+      ...session,
+      status: "open",
+      result: undefined,
+      questionText: nextStep.question,
+      uiType: "modal",
+      options: [],
+      grill: nextGrill,
+    },
+  };
+}
+
+export function formatAskGrillSummary(session: AskSession): string {
+  const grill = session.grill;
+  if (!grill) {
+    return "✅ /ask grill complete.";
+  }
+  const answerById = new Map(grill.answers.map((entry) => [entry.stepId, entry.answer]));
+  return [
+    "✅ /ask grill complete",
+    "",
+    "**GOAL**",
+    safeAnswer(answerById.get("goal")),
+    "",
+    "**SPEC**",
+    `- Initial request: ${sanitizeDiscordDisplayText(grill.initialRequest, 300)}`,
+    `- Context: ${safeAnswer(answerById.get("context"))}`,
+    `- Scope: ${safeAnswer(answerById.get("scope"))}`,
+    "",
+    "**RISKS / HITL**",
+    safeAnswer(answerById.get("risk")),
+    "",
+    "**ACCEPTANCE**",
+    safeAnswer(answerById.get("acceptance")),
+    "",
+    "**NEXT TASK / MEMO FORMAT**",
+    safeAnswer(answerById.get("output")),
+    "",
+    "-# 記録のみ完了。実装・外部送信・削除・上書き・課金・本番反映には別GOが必要です。",
+  ].join("\n");
+}
+
+export function sanitizeDiscordDisplayText(value: string, maxLength = 500): string {
+  const sanitized = value
+    .replace(/@/gu, "@\u200b")
+    .replace(/<@/gu, "<@\u200b")
+    .replace(/<#/gu, "<#\u200b")
+    .replace(/<@&/gu, "<@&\u200b")
+    .trim();
+  if (sanitized.length <= maxLength) {
+    return sanitized || "未回答";
+  }
+  return `${sanitized.slice(0, Math.max(0, maxLength - 1))}…`;
+}
+
+function safeAnswer(value: string | undefined): string {
+  return sanitizeDiscordDisplayText(value ?? "未回答", 700);
+}
+
+function summarizeAskAnswerText(answer: AskAnswer): string {
+  if (answer.fields?.length) {
+    return answer.fields
+      .flatMap((field) => field.values)
+      .map((value) => value.trim())
+      .filter(Boolean)
+      .join("\n")
+      .trim();
+  }
+  if (answer.values?.length) {
+    return answer.values.join(", ");
+  }
+  return answer.kind;
+}

--- a/extensions/ask/index.test.ts
+++ b/extensions/ask/index.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it, vi } from "vitest";
+import { classifyAskInput } from "./classifier.js";
+import { buildAskDiscordComponents } from "./components.js";
+import { createAskInteractiveHandler } from "./interactive-handler.js";
+import type { AskStores } from "./session-store.js";
+import type { AskSession } from "./types.js";
+
+function createMemoryStore<T>() {
+  const map = new Map<string, T>();
+  return {
+    register: vi.fn(async (key: string, value: T) => {
+      map.set(key, value);
+    }),
+    registerIfAbsent: vi.fn(async (key: string, value: T) => {
+      if (map.has(key)) return false;
+      map.set(key, value);
+      return true;
+    }),
+    lookup: vi.fn(async (key: string) => map.get(key)),
+    consume: vi.fn(async (key: string) => {
+      const value = map.get(key);
+      map.delete(key);
+      return value;
+    }),
+    delete: vi.fn(async (key: string) => map.delete(key)),
+    entries: vi.fn(async () =>
+      [...map.entries()].map(([key, value]) => ({ key, value, createdAt: Date.now() })),
+    ),
+    clear: vi.fn(async () => map.clear()),
+    map,
+  };
+}
+
+function createSession(overrides: Partial<AskSession> = {}): AskSession {
+  const now = Date.now();
+  return {
+    askId: "ask_test",
+    createdAt: now,
+    expiresAt: now + 60_000,
+    requesterUserId: "u1",
+    sourceChannel: "discord",
+    questionText: "GO?",
+    uiType: "button",
+    options: [
+      { label: "GO", value: "go" },
+      { label: "STOP", value: "stop" },
+    ],
+    allowedUsers: ["u1"],
+    reusable: false,
+    status: "open",
+    nextActionPolicy: "log_only",
+    requiresSecondGo: true,
+    actionScope: "answer_capture_only",
+    ...overrides,
+  };
+}
+
+describe("ask classifier", () => {
+  it("uses buttons for GO/STOP", () => {
+    expect(classifyAskInput("実装GOでいい？")).toMatchObject({
+      uiType: "button",
+      options: [
+        { label: "GO", value: "go" },
+        { label: "STOP", value: "stop" },
+      ],
+    });
+  });
+
+  it("uses modal for reason prompts", () => {
+    expect(classifyAskInput("違和感と理由を教えて").uiType).toBe("modal");
+  });
+
+  it("uses select for explicit long option lists", () => {
+    expect(classifyAskInput("方向性を選んで --options=a,b,c,d,e,f").uiType).toBe("select");
+  });
+});
+
+describe("ask Discord components", () => {
+  it("builds button callback data and log-only note", () => {
+    const spec = buildAskDiscordComponents(createSession());
+    expect(spec.reusable).toBe(false);
+    expect(spec.text).toContain("別GO");
+    expect(spec.blocks?.[0]).toMatchObject({
+      type: "actions",
+      buttons: [
+        { label: "GO", callbackData: "ask:ask_test:go", allowedUsers: ["u1"] },
+        { label: "STOP", callbackData: "ask:ask_test:stop", allowedUsers: ["u1"] },
+      ],
+    });
+  });
+});
+
+describe("ask interactive handler", () => {
+  it("accepts the allowed actor once and stores the answer", async () => {
+    const sessions = createMemoryStore<AskSession>();
+    const feedback = createMemoryStore<never>();
+    const stores = { sessions, feedback } as unknown as AskStores;
+    await sessions.register("ask_test", createSession());
+    const clearComponents = vi.fn();
+    const handler = createAskInteractiveHandler(stores);
+
+    await handler({
+      channel: "discord",
+      accountId: "default",
+      interactionId: "i1",
+      conversationId: "channel:c1",
+      senderId: "u1",
+      auth: { isAuthorizedSender: true },
+      interaction: {
+        kind: "button",
+        data: "ask:ask_test:go",
+        namespace: "ask",
+        payload: "ask_test:go",
+        messageId: "m1",
+      },
+      respond: {
+        acknowledge: vi.fn(),
+        reply: vi.fn(),
+        followUp: vi.fn(),
+        editMessage: vi.fn(),
+        clearComponents,
+      },
+      requestConversationBinding: vi.fn(),
+      detachConversationBinding: vi.fn(),
+      getCurrentConversationBinding: vi.fn(),
+    });
+
+    expect((await sessions.lookup("ask_test"))?.status).toBe("answered");
+    expect((await sessions.lookup("ask_test"))?.result?.values).toEqual(["go"]);
+    expect(clearComponents).toHaveBeenCalledWith(
+      expect.objectContaining({ text: expect.stringContaining("別GO") }),
+    );
+  });
+
+  it("rejects unauthorized actors", async () => {
+    const sessions = createMemoryStore<AskSession>();
+    const feedback = createMemoryStore<never>();
+    const stores = { sessions, feedback } as unknown as AskStores;
+    await sessions.register("ask_test", createSession());
+    const reply = vi.fn();
+    const handler = createAskInteractiveHandler(stores);
+
+    await handler({
+      channel: "discord",
+      accountId: "default",
+      interactionId: "i2",
+      conversationId: "channel:c1",
+      senderId: "u2",
+      auth: { isAuthorizedSender: true },
+      interaction: {
+        kind: "button",
+        data: "ask:ask_test:go",
+        namespace: "ask",
+        payload: "ask_test:go",
+        messageId: "m1",
+      },
+      respond: {
+        acknowledge: vi.fn(),
+        reply,
+        followUp: vi.fn(),
+        editMessage: vi.fn(),
+        clearComponents: vi.fn(),
+      },
+      requestConversationBinding: vi.fn(),
+      detachConversationBinding: vi.fn(),
+      getCurrentConversationBinding: vi.fn(),
+    });
+
+    expect((await sessions.lookup("ask_test"))?.status).toBe("open");
+    expect(reply).toHaveBeenCalledWith({
+      text: "You are not allowed to answer this /ask.",
+      ephemeral: true,
+    });
+  });
+});

--- a/extensions/ask/index.test.ts
+++ b/extensions/ask/index.test.ts
@@ -12,7 +12,9 @@ function createMemoryStore<T>() {
       map.set(key, value);
     }),
     registerIfAbsent: vi.fn(async (key: string, value: T) => {
-      if (map.has(key)) return false;
+      if (map.has(key)) {
+        return false;
+      }
       map.set(key, value);
       return true;
     }),

--- a/extensions/ask/index.test.ts
+++ b/extensions/ask/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { classifyAskInput } from "./classifier.js";
 import { buildAskDiscordComponents } from "./components.js";
+import askPlugin from "./index.js";
 import { createAskInteractiveHandler } from "./interactive-handler.js";
 import type { AskStores } from "./session-store.js";
 import type { AskSession } from "./types.js";
@@ -37,6 +38,7 @@ function createSession(overrides: Partial<AskSession> = {}): AskSession {
   const now = Date.now();
   return {
     askId: "ask_test",
+    mode: "single",
     createdAt: now,
     expiresAt: now + 60_000,
     requesterUserId: "u1",
@@ -75,6 +77,14 @@ describe("ask classifier", () => {
   it("uses select for explicit long option lists", () => {
     expect(classifyAskInput("方向性を選んで --options=a,b,c,d,e,f").uiType).toBe("select");
   });
+
+  it("detects grill mode from the input prefix", () => {
+    expect(classifyAskInput("grill 曖昧な依頼を仕様にしたい")).toMatchObject({
+      mode: "grill",
+      uiType: "modal",
+      questionText: "曖昧な依頼を仕様にしたい",
+    });
+  });
 });
 
 describe("ask Discord components", () => {
@@ -89,6 +99,43 @@ describe("ask Discord components", () => {
         { label: "STOP", callbackData: "ask:ask_test:stop", allowedUsers: ["u1"] },
       ],
     });
+  });
+
+  it("builds grill mode as a one-question modal", () => {
+    const spec = buildAskDiscordComponents(
+      createSession({
+        mode: "grill",
+        questionText: "この依頼で最終的に何が変われば成功ですか？",
+        uiType: "modal",
+        options: [],
+        grill: {
+          initialRequest: "曖昧な依頼を仕様にしたい",
+          currentStepIndex: 0,
+          answers: [],
+        },
+      }),
+    );
+    expect(spec.text).toContain("**/ask grill** Goal (1/6)");
+    expect(spec.modal?.triggerLabel).toBe("この質問に答える");
+  });
+});
+
+describe("ask plugin registration", () => {
+  it("scopes the command to Discord", () => {
+    const registerCommand = vi.fn();
+    const registerInteractiveHandler = vi.fn();
+    askPlugin.register({
+      registerCommand,
+      registerInteractiveHandler,
+      runtime: { state: { openKeyedStore: vi.fn(() => createMemoryStore<unknown>()) } },
+    } as never);
+
+    expect(registerCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "ask",
+        channels: ["discord"],
+      }),
+    );
   });
 });
 
@@ -173,5 +220,65 @@ describe("ask interactive handler", () => {
       text: "You are not allowed to answer this /ask.",
       ephemeral: true,
     });
+  });
+
+  it("keeps grill sessions open and advances to the next question", async () => {
+    const sessions = createMemoryStore<AskSession>();
+    const feedback = createMemoryStore<never>();
+    const stores = { sessions, feedback } as unknown as AskStores;
+    await sessions.register(
+      "ask_test",
+      createSession({
+        mode: "grill",
+        uiType: "modal",
+        options: [],
+        grill: {
+          initialRequest: "曖昧な依頼を仕様にしたい",
+          currentStepIndex: 0,
+          answers: [],
+        },
+      }),
+    );
+    const editMessage = vi.fn();
+    const handler = createAskInteractiveHandler(stores);
+
+    await handler({
+      channel: "discord",
+      accountId: "default",
+      interactionId: "i3",
+      conversationId: "channel:c1",
+      senderId: "u1",
+      auth: { isAuthorizedSender: true },
+      interaction: {
+        kind: "modal",
+        data: "ask:ask_test",
+        namespace: "ask",
+        payload: "ask_test",
+        messageId: "m1",
+        fields: [{ id: "f1", name: "answer", values: ["成功条件を固めたい"] }],
+      },
+      respond: {
+        acknowledge: vi.fn(),
+        reply: vi.fn(),
+        followUp: vi.fn(),
+        editMessage,
+        clearComponents: vi.fn(),
+      },
+      requestConversationBinding: vi.fn(),
+      detachConversationBinding: vi.fn(),
+      getCurrentConversationBinding: vi.fn(),
+    });
+
+    const stored = await sessions.lookup("ask_test");
+    expect(stored?.status).toBe("open");
+    expect(stored?.grill?.currentStepIndex).toBe(1);
+    expect(stored?.grill?.answers).toHaveLength(1);
+    expect(editMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        components: expect.objectContaining({
+          modal: expect.objectContaining({ triggerLabel: "この質問に答える" }),
+        }),
+      }),
+    );
   });
 });

--- a/extensions/ask/index.ts
+++ b/extensions/ask/index.ts
@@ -1,0 +1,72 @@
+import { randomUUID } from "node:crypto";
+import type { DiscordInteractiveHandlerContext } from "openclaw/plugin-sdk/discord-interactions";
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { classifyAskInput } from "./classifier.js";
+import { buildAskDiscordComponents, formatAskCommandFallback } from "./components.js";
+import { createAskInteractiveHandler } from "./interactive-handler.js";
+import { ASK_SESSION_TTL_MS, openAskStores } from "./session-store.js";
+import type { AskSession } from "./types.js";
+
+export default definePluginEntry({
+  id: "ask",
+  name: "Ask",
+  description: "Minimal HITL question UI for Discord.",
+  register(api) {
+    const stores = openAskStores(api.runtime);
+    const handleAskInteraction = createAskInteractiveHandler(stores);
+
+    api.registerInteractiveHandler({
+      channel: "discord",
+      namespace: "ask",
+      handler: (ctx) => handleAskInteraction(ctx as DiscordInteractiveHandlerContext),
+    });
+
+    api.registerCommand({
+      name: "ask",
+      nativeNames: { default: "ask" },
+      description: "Ask the current Discord user with the safest matching interactive UI.",
+      acceptsArgs: true,
+      requireAuth: true,
+      handler: async (ctx) => {
+        const classified = classifyAskInput(ctx.args);
+        const now = Date.now();
+        const askId = createAskId();
+        const session: AskSession = {
+          askId,
+          createdAt: now,
+          expiresAt: now + ASK_SESSION_TTL_MS,
+          requesterUserId: ctx.senderId,
+          sourceChannel: ctx.channel,
+          sourceChannelId: ctx.channelId,
+          sourceThreadId: ctx.messageThreadId,
+          threadParentId: ctx.threadParentId,
+          accountId: ctx.accountId,
+          sessionKey: ctx.sessionKey,
+          questionText: classified.questionText,
+          uiType: classified.uiType,
+          options: classified.options,
+          allowedUsers: ctx.senderId ? [ctx.senderId] : [],
+          reusable: false,
+          status: "open",
+          nextActionPolicy: "log_only",
+          requiresSecondGo: true,
+          actionScope: "answer_capture_only",
+        };
+        await stores.sessions.register(askId, session, { ttlMs: ASK_SESSION_TTL_MS });
+
+        return {
+          text: formatAskCommandFallback(session),
+          channelData: {
+            discord: {
+              components: buildAskDiscordComponents(session),
+            },
+          },
+        };
+      },
+    });
+  },
+});
+
+function createAskId(): string {
+  return `ask_${randomUUID().replaceAll("-", "").slice(0, 18)}`;
+}

--- a/extensions/ask/index.ts
+++ b/extensions/ask/index.ts
@@ -3,6 +3,7 @@ import type { DiscordInteractiveHandlerContext } from "openclaw/plugin-sdk/disco
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import { classifyAskInput } from "./classifier.js";
 import { buildAskDiscordComponents, formatAskCommandFallback } from "./components.js";
+import { createAskGrillState, getAskGrillCurrentStep } from "./grill.js";
 import { createAskInteractiveHandler } from "./interactive-handler.js";
 import { ASK_SESSION_TTL_MS, openAskStores } from "./session-store.js";
 import type { AskSession } from "./types.js";
@@ -25,14 +26,24 @@ export default definePluginEntry({
       name: "ask",
       nativeNames: { default: "ask" },
       description: "Ask the current Discord user with the safest matching interactive UI.",
+      channels: ["discord"],
       acceptsArgs: true,
       requireAuth: true,
       handler: async (ctx) => {
+        if (!ctx.senderId) {
+          return {
+            text: "/ask needs a Discord user id. Please run it from a normal Discord user account.",
+          };
+        }
         const classified = classifyAskInput(ctx.args);
         const now = Date.now();
         const askId = createAskId();
+        const grill =
+          classified.mode === "grill" ? createAskGrillState(classified.questionText) : undefined;
+        const firstGrillStep = grill ? getAskGrillCurrentStep(grill) : undefined;
         const session: AskSession = {
           askId,
+          mode: classified.mode,
           createdAt: now,
           expiresAt: now + ASK_SESSION_TTL_MS,
           requesterUserId: ctx.senderId,
@@ -42,16 +53,20 @@ export default definePluginEntry({
           threadParentId: ctx.threadParentId,
           accountId: ctx.accountId,
           sessionKey: ctx.sessionKey,
-          questionText: classified.questionText,
+          questionText: firstGrillStep?.question ?? classified.questionText,
           uiType: classified.uiType,
           options: classified.options,
-          allowedUsers: ctx.senderId ? [ctx.senderId] : [],
+          allowedUsers: [ctx.senderId],
           reusable: false,
           status: "open",
           nextActionPolicy: "log_only",
           requiresSecondGo: true,
           actionScope: "answer_capture_only",
+          ...(grill ? { grill } : {}),
         };
+        if (session.mode === "grill") {
+          await closeActiveGrillSessionsForRequester(stores, session);
+        }
         await stores.sessions.register(askId, session, { ttlMs: ASK_SESSION_TTL_MS });
 
         return {
@@ -69,4 +84,30 @@ export default definePluginEntry({
 
 function createAskId(): string {
   return `ask_${randomUUID().replaceAll("-", "").slice(0, 18)}`;
+}
+
+async function closeActiveGrillSessionsForRequester(
+  stores: ReturnType<typeof openAskStores>,
+  session: AskSession,
+): Promise<void> {
+  const entries = await stores.sessions.entries();
+  await Promise.all(
+    entries
+      .map((entry) => entry.value)
+      .filter(
+        (existing) =>
+          existing.mode === "grill" &&
+          existing.status === "open" &&
+          existing.requesterUserId === session.requesterUserId &&
+          existing.accountId === session.accountId &&
+          existing.sourceChannelId === session.sourceChannelId &&
+          existing.sourceThreadId === session.sourceThreadId,
+      )
+      .map((existing) =>
+        stores.sessions.register(existing.askId, {
+          ...existing,
+          status: "rejected",
+        }),
+      ),
+  );
 }

--- a/extensions/ask/interactive-handler.ts
+++ b/extensions/ask/interactive-handler.ts
@@ -1,0 +1,165 @@
+import type { DiscordInteractiveHandlerContext } from "openclaw/plugin-sdk/discord-interactions";
+import type { AskStores } from "./session-store.js";
+import { recordAskFeedback } from "./session-store.js";
+import type { AskAnswer, AskFeedbackEvent, AskSession } from "./types.js";
+
+export function createAskInteractiveHandler(stores: AskStores) {
+  return async function handleAskInteraction(ctx: DiscordInteractiveHandlerContext) {
+    const parsedPayload = parseAskPayload(ctx.interaction.payload);
+    const askId = parsedPayload.askId;
+    const now = Date.now();
+    if (!askId) {
+      await logFeedback(stores, {
+        askId: "unknown",
+        type: "invalid_payload",
+        actorId: ctx.senderId,
+        interactionId: ctx.interactionId,
+        interactionMessageId: ctx.interaction.messageId,
+        createdAt: now,
+        detail: "empty ask payload",
+      });
+      await ctx.respond.reply({ text: "This /ask response is invalid.", ephemeral: true });
+      return { handled: true };
+    }
+
+    const session = await stores.sessions.lookup(askId);
+    if (!session) {
+      await logFeedback(stores, {
+        askId,
+        type: "missing_session",
+        actorId: ctx.senderId,
+        interactionId: ctx.interactionId,
+        interactionMessageId: ctx.interaction.messageId,
+        createdAt: now,
+      });
+      await ctx.respond.reply({
+        text: "This /ask has expired. Please run /ask again.",
+        ephemeral: true,
+      });
+      return { handled: true };
+    }
+
+    const actorAllowed = isActorAllowed(session, ctx.senderId);
+    if (!actorAllowed) {
+      await logFeedback(stores, {
+        askId,
+        type: "unauthorized",
+        actorId: ctx.senderId,
+        interactionId: ctx.interactionId,
+        interactionMessageId: ctx.interaction.messageId,
+        createdAt: now,
+      });
+      await ctx.respond.reply({
+        text: "You are not allowed to answer this /ask.",
+        ephemeral: true,
+      });
+      return { handled: true };
+    }
+
+    if (session.expiresAt <= now) {
+      await stores.sessions.register(askId, { ...session, status: "expired" });
+      await logFeedback(stores, {
+        askId,
+        type: "expired",
+        actorId: ctx.senderId,
+        interactionId: ctx.interactionId,
+        interactionMessageId: ctx.interaction.messageId,
+        createdAt: now,
+      });
+      await ctx.respond.reply({
+        text: "This /ask has expired. Please run /ask again.",
+        ephemeral: true,
+      });
+      return { handled: true };
+    }
+
+    if (session.status === "answered" && !session.reusable) {
+      await logFeedback(stores, {
+        askId,
+        type: "duplicate",
+        actorId: ctx.senderId,
+        interactionId: ctx.interactionId,
+        interactionMessageId: ctx.interaction.messageId,
+        createdAt: now,
+      });
+      await ctx.respond.reply({ text: "This /ask was already answered.", ephemeral: true });
+      return { handled: true };
+    }
+
+    const answer: AskAnswer = {
+      actorId: ctx.senderId,
+      interactionId: ctx.interactionId,
+      interactionMessageId: ctx.interaction.messageId ?? session.interactionMessageId,
+      kind: ctx.interaction.kind,
+      values: parsedPayload.buttonValue ? [parsedPayload.buttonValue] : ctx.interaction.values,
+      fields: ctx.interaction.fields,
+      answeredAt: now,
+    };
+    const answered: AskSession = {
+      ...session,
+      status: "answered",
+      interactionMessageId: answer.interactionMessageId,
+      result: answer,
+    };
+    await stores.sessions.register(askId, answered);
+    await logFeedback(stores, {
+      askId,
+      type: "answered",
+      actorId: ctx.senderId,
+      interactionId: ctx.interactionId,
+      interactionMessageId: answer.interactionMessageId,
+      createdAt: now,
+      detail: summarizeAnswer(answer),
+    });
+
+    await ctx.respond.clearComponents({
+      text: `✅ /ask answered: ${summarizeAnswer(answer)}\n-# 記録のみ完了。次の実行には別GOが必要です。`,
+    });
+    return { handled: true };
+  };
+}
+
+function parseAskPayload(payload: string): { askId: string; buttonValue?: string } {
+  const trimmed = payload.trim();
+  if (!trimmed) {
+    return { askId: "" };
+  }
+  const separatorIndex = trimmed.indexOf(":");
+  if (separatorIndex < 0) {
+    return { askId: trimmed };
+  }
+  return {
+    askId: trimmed.slice(0, separatorIndex),
+    buttonValue: trimmed.slice(separatorIndex + 1),
+  };
+}
+
+function isActorAllowed(session: AskSession, actorId: string | undefined): boolean {
+  if (session.allowedUsers.includes("*")) {
+    return true;
+  }
+  return Boolean(actorId && session.allowedUsers.includes(actorId));
+}
+
+function summarizeAnswer(answer: AskAnswer): string {
+  if (answer.kind === "modal") {
+    const fieldSummary = answer.fields
+      ?.map((field) => `${field.name}: ${field.values.join(", ")}`)
+      .join("; ");
+    return fieldSummary || "modal submitted";
+  }
+  if (answer.values?.length) {
+    return answer.values.join(", ");
+  }
+  return answer.kind;
+}
+
+async function logFeedback(
+  stores: AskStores,
+  event: Omit<AskFeedbackEvent, "eventId">,
+): Promise<void> {
+  await recordAskFeedback(stores, {
+    ...event,
+    eventId: `${event.askId}:${event.type}:${event.interactionId ?? event.createdAt}`,
+  });
+}

--- a/extensions/ask/interactive-handler.ts
+++ b/extensions/ask/interactive-handler.ts
@@ -1,6 +1,12 @@
 import type { DiscordInteractiveHandlerContext } from "openclaw/plugin-sdk/discord-interactions";
-import type { AskStores } from "./session-store.js";
-import { recordAskFeedback } from "./session-store.js";
+import { buildAskDiscordComponents } from "./components.js";
+import {
+  advanceAskGrillSession,
+  formatAskGrillSummary,
+  isAskGrillSession,
+  sanitizeDiscordDisplayText,
+} from "./grill.js";
+import { ASK_SESSION_TTL_MS, recordAskFeedback, type AskStores } from "./session-store.js";
 import type { AskAnswer, AskFeedbackEvent, AskSession } from "./types.js";
 
 export function createAskInteractiveHandler(stores: AskStores) {
@@ -95,13 +101,17 @@ export function createAskInteractiveHandler(stores: AskStores) {
       fields: ctx.interaction.fields,
       answeredAt: now,
     };
+    const advanced = isAskGrillSession(session)
+      ? advanceAskGrillSession(session, answer, now)
+      : { session: { ...session, status: "answered" as const, result: answer }, completed: true };
     const answered: AskSession = {
-      ...session,
-      status: "answered",
+      ...advanced.session,
       interactionMessageId: answer.interactionMessageId,
-      result: answer,
+      expiresAt: isAskGrillSession(advanced.session)
+        ? now + ASK_SESSION_TTL_MS
+        : advanced.session.expiresAt,
     };
-    await stores.sessions.register(askId, answered);
+    await stores.sessions.register(askId, answered, { ttlMs: ASK_SESSION_TTL_MS });
     await logFeedback(stores, {
       askId,
       type: "answered",
@@ -109,14 +119,34 @@ export function createAskInteractiveHandler(stores: AskStores) {
       interactionId: ctx.interactionId,
       interactionMessageId: answer.interactionMessageId,
       createdAt: now,
-      detail: summarizeAnswer(answer),
+      detail: isAskGrillSession(session)
+        ? `grill_step_recorded:${(answered.grill?.answers.length ?? 0).toString()}`
+        : summarizeAnswer(answer),
     });
 
+    if (isAskGrillSession(answered) && !advanced.completed) {
+      await ctx.respond.editMessage({
+        text: formatGrillProgress(answered),
+        components: buildAskDiscordComponents(answered),
+      });
+      return { handled: true };
+    }
+
     await ctx.respond.clearComponents({
-      text: `✅ /ask answered: ${summarizeAnswer(answer)}\n-# 記録のみ完了。次の実行には別GOが必要です。`,
+      text: isAskGrillSession(answered)
+        ? formatAskGrillSummary(answered)
+        : `✅ /ask answered: ${summarizeAnswer(answer)}\n-# 記録のみ完了。次の実行には別GOが必要です。`,
     });
     return { handled: true };
   };
+}
+
+function formatGrillProgress(session: AskSession): string {
+  const answeredCount = session.grill?.answers.length ?? 0;
+  return [
+    `✅ /ask grill answer recorded (${answeredCount.toString()})`,
+    "-# 次の質問へ進みます。ここまでの回答はstateに保存済みです。",
+  ].join("\n");
 }
 
 function parseAskPayload(payload: string): { askId: string; buttonValue?: string } {
@@ -146,10 +176,10 @@ function summarizeAnswer(answer: AskAnswer): string {
     const fieldSummary = answer.fields
       ?.map((field) => `${field.name}: ${field.values.join(", ")}`)
       .join("; ");
-    return fieldSummary || "modal submitted";
+    return fieldSummary ? sanitizeDiscordDisplayText(fieldSummary, 300) : "modal submitted";
   }
   if (answer.values?.length) {
-    return answer.values.join(", ");
+    return sanitizeDiscordDisplayText(answer.values.join(", "), 300);
   }
   return answer.kind;
 }

--- a/extensions/ask/openclaw.plugin.json
+++ b/extensions/ask/openclaw.plugin.json
@@ -1,0 +1,13 @@
+{
+  "id": "ask",
+  "activation": {
+    "onStartup": true
+  },
+  "name": "Ask",
+  "description": "Minimal Discord HITL question UI. Captures answers only; execution requires a separate GO.",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/ask/package.json
+++ b/extensions/ask/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@openclaw/ask",
+  "version": "2026.5.19",
+  "private": true,
+  "description": "OpenClaw minimal Discord HITL ask plugin.",
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/ask/session-store.ts
+++ b/extensions/ask/session-store.ts
@@ -1,0 +1,37 @@
+import type { PluginRuntime } from "openclaw/plugin-sdk/channel-core";
+import type { AskFeedbackEvent, AskSession } from "./types.js";
+
+type AskKeyedStore<T> = {
+  register: (key: string, value: T, opts?: { ttlMs?: number }) => Promise<void>;
+  lookup: (key: string) => Promise<T | undefined>;
+};
+
+export const ASK_SESSION_TTL_MS = 30 * 60 * 1000;
+export const ASK_FEEDBACK_TTL_MS = 14 * 24 * 60 * 60 * 1000;
+
+export type AskStores = {
+  sessions: AskKeyedStore<AskSession>;
+  feedback: AskKeyedStore<AskFeedbackEvent>;
+};
+
+export function openAskStores(runtime: PluginRuntime): AskStores {
+  return {
+    sessions: runtime.state.openKeyedStore<AskSession>({
+      namespace: "ask.sessions",
+      maxEntries: 1000,
+      defaultTtlMs: ASK_SESSION_TTL_MS,
+    }),
+    feedback: runtime.state.openKeyedStore<AskFeedbackEvent>({
+      namespace: "ask.feedback",
+      maxEntries: 2000,
+      defaultTtlMs: ASK_FEEDBACK_TTL_MS,
+    }),
+  };
+}
+
+export async function recordAskFeedback(
+  stores: Pick<AskStores, "feedback">,
+  event: AskFeedbackEvent,
+): Promise<void> {
+  await stores.feedback.register(event.eventId, event, { ttlMs: ASK_FEEDBACK_TTL_MS });
+}

--- a/extensions/ask/session-store.ts
+++ b/extensions/ask/session-store.ts
@@ -4,6 +4,7 @@ import type { AskFeedbackEvent, AskSession } from "./types.js";
 type AskKeyedStore<T> = {
   register: (key: string, value: T, opts?: { ttlMs?: number }) => Promise<void>;
   lookup: (key: string) => Promise<T | undefined>;
+  entries: () => Promise<Array<{ key: string; value: T; createdAt: number }>>;
 };
 
 export const ASK_SESSION_TTL_MS = 30 * 60 * 1000;

--- a/extensions/ask/types.ts
+++ b/extensions/ask/types.ts
@@ -1,0 +1,59 @@
+export type AskUiType = "button" | "select" | "modal";
+
+export type AskOption = {
+  label: string;
+  value: string;
+};
+
+export type AskSessionStatus = "open" | "answered" | "expired" | "rejected";
+
+export type AskAnswer = {
+  actorId?: string;
+  interactionId?: string;
+  interactionMessageId?: string;
+  kind: AskUiType;
+  values?: string[];
+  fields?: Array<{ id: string; name: string; values: string[] }>;
+  answeredAt: number;
+};
+
+export type AskSession = {
+  askId: string;
+  createdAt: number;
+  expiresAt: number;
+  requesterUserId?: string;
+  sourceChannel: string;
+  sourceChannelId?: string | number;
+  sourceThreadId?: string | number;
+  threadParentId?: string;
+  accountId?: string;
+  sessionKey?: string;
+  questionText: string;
+  uiType: AskUiType;
+  options: AskOption[];
+  allowedUsers: string[];
+  reusable: false;
+  status: AskSessionStatus;
+  interactionMessageId?: string;
+  result?: AskAnswer;
+  nextActionPolicy: "log_only";
+  requiresSecondGo: true;
+  actionScope: "answer_capture_only";
+};
+
+export type AskFeedbackEvent = {
+  askId: string;
+  eventId: string;
+  type:
+    | "answered"
+    | "unauthorized"
+    | "expired"
+    | "duplicate"
+    | "missing_session"
+    | "invalid_payload";
+  actorId?: string;
+  interactionId?: string;
+  interactionMessageId?: string;
+  createdAt: number;
+  detail?: string;
+};

--- a/extensions/ask/types.ts
+++ b/extensions/ask/types.ts
@@ -1,3 +1,5 @@
+export type AskMode = "single" | "grill";
+
 export type AskUiType = "button" | "select" | "modal";
 
 export type AskOption = {
@@ -19,6 +21,7 @@ export type AskAnswer = {
 
 export type AskSession = {
   askId: string;
+  mode: AskMode;
   createdAt: number;
   expiresAt: number;
   requesterUserId?: string;
@@ -39,6 +42,20 @@ export type AskSession = {
   nextActionPolicy: "log_only";
   requiresSecondGo: true;
   actionScope: "answer_capture_only";
+  grill?: AskGrillState;
+};
+
+export type AskGrillAnswer = {
+  stepId: string;
+  question: string;
+  answer: string;
+  answeredAt: number;
+};
+
+export type AskGrillState = {
+  initialRequest: string;
+  currentStepIndex: number;
+  answers: AskGrillAnswer[];
 };
 
 export type AskFeedbackEvent = {

--- a/extensions/discord/src/interactive-dispatch.ts
+++ b/extensions/discord/src/interactive-dispatch.ts
@@ -1,55 +1,16 @@
-import type { ChannelStructuredComponents } from "openclaw/plugin-sdk/channel-contract";
+import type {
+  DiscordInteractiveHandlerContext,
+  DiscordInteractiveHandlerRegistration,
+} from "openclaw/plugin-sdk/discord-interactions";
 import {
   createInteractiveConversationBindingHelpers,
   dispatchPluginInteractiveHandler,
-  type PluginConversationBinding,
-  type PluginConversationBindingRequestParams,
-  type PluginConversationBindingRequestResult,
-  type PluginInteractiveRegistration,
 } from "openclaw/plugin-sdk/plugin-runtime";
 
-export type DiscordInteractiveHandlerContext = {
-  channel: "discord";
-  accountId: string;
-  interactionId: string;
-  conversationId: string;
-  parentConversationId?: string;
-  guildId?: string;
-  senderId?: string;
-  senderUsername?: string;
-  auth: {
-    isAuthorizedSender: boolean;
-  };
-  interaction: {
-    kind: "button" | "select" | "modal";
-    data: string;
-    namespace: string;
-    payload: string;
-    messageId?: string;
-    values?: string[];
-    fields?: Array<{ id: string; name: string; values: string[] }>;
-  };
-  respond: {
-    acknowledge: () => Promise<void>;
-    reply: (params: { text: string; ephemeral?: boolean }) => Promise<void>;
-    followUp: (params: { text: string; ephemeral?: boolean }) => Promise<void>;
-    editMessage: (params: {
-      text?: string;
-      components?: ChannelStructuredComponents;
-    }) => Promise<void>;
-    clearComponents: (params?: { text?: string }) => Promise<void>;
-  };
-  requestConversationBinding: (
-    params?: PluginConversationBindingRequestParams,
-  ) => Promise<PluginConversationBindingRequestResult>;
-  detachConversationBinding: () => Promise<{ removed: boolean }>;
-  getCurrentConversationBinding: () => Promise<PluginConversationBinding | null>;
-};
-
-export type DiscordInteractiveHandlerRegistration = PluginInteractiveRegistration<
+export type {
   DiscordInteractiveHandlerContext,
-  "discord"
->;
+  DiscordInteractiveHandlerRegistration,
+} from "openclaw/plugin-sdk/discord-interactions";
 
 type DiscordInteractiveDispatchContext = Omit<
   DiscordInteractiveHandlerContext,

--- a/extensions/discord/src/monitor/agent-components.plugin-interactive.ts
+++ b/extensions/discord/src/monitor/agent-components.plugin-interactive.ts
@@ -1,11 +1,19 @@
 import { ChannelType } from "discord-api-types/v10";
 import { logError } from "openclaw/plugin-sdk/logging-core";
 import {
+  buildDiscordComponentMessage,
+  buildDiscordComponentMessageFlags,
+  readDiscordComponentSpec,
+} from "../components.js";
+import {
   dispatchDiscordPluginInteractiveHandler,
   type DiscordInteractiveHandlerContext,
 } from "../interactive-dispatch.js";
 import type { TopLevelComponents } from "../internal/discord.js";
-import { editDiscordComponentMessage } from "../send.components.js";
+import {
+  editDiscordComponentMessage,
+  registerBuiltDiscordComponentMessage,
+} from "../send.components.js";
 import {
   resolveDiscordInteractionId,
   type AgentComponentContext,
@@ -39,22 +47,89 @@ export async function dispatchPluginDiscordInteractiveEvent(params: {
       : `user:${params.interactionCtx.userId}`;
   let responded = false;
   let acknowledged = false;
+  const resolveComponentPayload = (input: {
+    text?: string;
+    components?: DiscordInteractiveHandlerContext["respond"]["editMessage"] extends (
+      params: infer Params,
+    ) => Promise<void>
+      ? Params extends { components?: infer Components }
+        ? Components
+        : never
+      : never;
+  }) => {
+    if (input.components === undefined) {
+      return {
+        text: input.text,
+        components: undefined,
+        flags: undefined,
+        register: async (_sendResult: unknown, _fallbackMessageId?: string) => {},
+      };
+    }
+    if (Array.isArray(input.components)) {
+      return {
+        text: input.text,
+        components: input.components as TopLevelComponents[],
+        flags: undefined,
+        register: async (_sendResult: unknown, _fallbackMessageId?: string) => {},
+      };
+    }
+    const spec = readDiscordComponentSpec(input.components);
+    if (!spec) {
+      return {
+        text: input.text,
+        components: undefined,
+        flags: undefined,
+        register: async (_sendResult: unknown, _fallbackMessageId?: string) => {},
+      };
+    }
+    const buildResult = buildDiscordComponentMessage({
+      spec: {
+        ...spec,
+        text: spec.text ?? input.text,
+      },
+    });
+    return {
+      text: input.text ?? spec.text,
+      components: buildResult.components,
+      flags: buildDiscordComponentMessageFlags(buildResult.components),
+      register: async (sendResult: unknown, fallbackMessageId?: string) => {
+        const messageId =
+          sendResult &&
+          typeof sendResult === "object" &&
+          typeof (sendResult as { id?: unknown }).id === "string"
+            ? (sendResult as { id: string }).id
+            : fallbackMessageId;
+        if (!messageId) {
+          return;
+        }
+        registerBuiltDiscordComponentMessage({ buildResult, messageId });
+      },
+    };
+  };
   const updateOriginalMessage = async (input: {
     text?: string;
-    components?: TopLevelComponents[];
+    components?: Parameters<
+      DiscordInteractiveHandlerContext["respond"]["editMessage"]
+    >[0]["components"];
   }) => {
+    const componentPayload = resolveComponentPayload(input);
     const payload = {
-      ...(input.text !== undefined ? { content: input.text } : {}),
-      ...(input.components !== undefined ? { components: input.components } : {}),
+      ...(componentPayload.text !== undefined ? { content: componentPayload.text } : {}),
+      ...(componentPayload.components !== undefined
+        ? { components: componentPayload.components }
+        : {}),
+      ...(componentPayload.flags !== undefined ? { flags: componentPayload.flags } : {}),
     };
     if (acknowledged) {
-      await params.interaction.reply(payload);
+      const sendResult = await params.interaction.reply(payload);
+      await componentPayload.register(sendResult);
       return;
     }
     if (!("update" in params.interaction) || typeof params.interaction.update !== "function") {
       throw new Error("Discord interaction cannot update the source message");
     }
-    await params.interaction.update(payload);
+    const sendResult = await params.interaction.update(payload);
+    await componentPayload.register(sendResult, params.messageId ?? params.interaction.message?.id);
   };
   const respond: DiscordInteractiveHandlerContext["respond"] = {
     acknowledge: async () => {
@@ -65,19 +140,31 @@ export async function dispatchPluginDiscordInteractiveEvent(params: {
       acknowledged = true;
       responded = true;
     },
-    reply: async ({ text, ephemeral = true }: { text: string; ephemeral?: boolean }) => {
+    reply: async ({ text, ephemeral = true, components }) => {
+      const componentPayload = resolveComponentPayload({ text, components });
       responded = true;
-      await params.interaction.reply({
-        content: text,
+      const sendResult = await params.interaction.reply({
+        content: componentPayload.text ?? text,
         ephemeral,
+        ...(componentPayload.components !== undefined
+          ? { components: componentPayload.components }
+          : {}),
+        ...(componentPayload.flags !== undefined ? { flags: componentPayload.flags } : {}),
       });
+      await componentPayload.register(sendResult);
     },
-    followUp: async ({ text, ephemeral = true }: { text: string; ephemeral?: boolean }) => {
+    followUp: async ({ text, ephemeral = true, components }) => {
+      const componentPayload = resolveComponentPayload({ text, components });
       responded = true;
-      await params.interaction.followUp({
-        content: text,
+      const sendResult = await params.interaction.followUp({
+        content: componentPayload.text ?? text,
         ephemeral,
+        ...(componentPayload.components !== undefined
+          ? { components: componentPayload.components }
+          : {}),
+        ...(componentPayload.flags !== undefined ? { flags: componentPayload.flags } : {}),
       });
+      await componentPayload.register(sendResult);
     },
     editMessage: async (
       input: Parameters<DiscordInteractiveHandlerContext["respond"]["editMessage"]>[0],

--- a/extensions/discord/src/monitor/monitor.test.ts
+++ b/extensions/discord/src/monitor/monitor.test.ts
@@ -859,6 +859,71 @@ describe("discord component interactions", () => {
     expect(dispatchReplyMock).not.toHaveBeenCalled();
   });
 
+  it("registers plugin Discord interaction component specs returned from editMessage", async () => {
+    registerDiscordComponentEntries({
+      entries: [createButtonEntry({ callbackData: "ask:ask_test" })],
+      modals: [],
+    });
+    dispatchPluginInteractiveHandlerMock.mockImplementation(async (params: unknown) => {
+      const typedParams = params as {
+        respond: {
+          editMessage: (payload: {
+            text: string;
+            components: {
+              blocks: Array<{
+                type: "actions";
+                buttons: Array<{ label: string; callbackData: string }>;
+              }>;
+            };
+          }) => Promise<void>;
+        };
+      };
+      await typedParams.respond.editMessage({
+        text: "Next question",
+        components: {
+          blocks: [
+            {
+              type: "actions",
+              buttons: [{ label: "Answer", callbackData: "ask:ask_test_next" }],
+            },
+          ],
+        },
+      });
+      return {
+        matched: true,
+        handled: true,
+        duplicate: false,
+      };
+    });
+
+    const button = createDiscordComponentButton(createComponentContext());
+    const update = vi.fn().mockResolvedValue({ id: "msg-2" });
+    const baseInteraction = createComponentButtonInteraction().interaction as unknown as Record<
+      string,
+      unknown
+    >;
+    const interaction = {
+      ...baseInteraction,
+      update,
+    } as unknown as ButtonInteraction;
+
+    await button.run(interaction, { cid: "btn_1" } as ComponentData);
+
+    const sent = update.mock.calls[0]?.[0] as {
+      components?: Array<{ serialize: () => unknown }>;
+    };
+    const serialized = sent.components?.[0]?.serialize() as {
+      components?: Array<{ components?: Array<{ custom_id?: string }> }>;
+    };
+    const buttonCustomId = serialized.components?.[1]?.components?.[0]?.custom_id;
+    const componentId = buttonCustomId?.match(/cid=([^;]+)/)?.[1];
+    expect(componentId).toBeTruthy();
+    const entry = resolveDiscordComponentEntry({ id: componentId ?? "", consume: false });
+    expect(entry?.callbackData).toBe("ask:ask_test_next");
+    expect(entry?.messageId).toBe("msg-2");
+    expect(dispatchReplyMock).not.toHaveBeenCalled();
+  });
+
   it("falls through to built-in Discord component routing when a plugin declines handling", async () => {
     registerDiscordComponentEntries({
       entries: [createButtonEntry({ callbackData: "codex:approve" })],

--- a/extensions/discord/src/monitor/native-command-reply.test.ts
+++ b/extensions/discord/src/monitor/native-command-reply.test.ts
@@ -1,4 +1,9 @@
-import { describe, expect, it, vi } from "vitest";
+import { MessageFlags } from "discord-api-types/v10";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearDiscordComponentEntries,
+  resolveDiscordComponentEntry,
+} from "../components-registry.js";
 import { Container, TextDisplay } from "../internal/discord.js";
 import {
   deliverDiscordInteractionReply,
@@ -7,12 +12,18 @@ import {
 
 function createInteraction() {
   return {
-    reply: vi.fn().mockResolvedValue({ ok: true }),
-    followUp: vi.fn().mockResolvedValue({ ok: true }),
+    reply: vi.fn().mockResolvedValue({ id: "reply-1" }),
+    followUp: vi.fn().mockResolvedValue({ id: "follow-up-1" }),
+    fetchReply: vi.fn().mockResolvedValue({ id: "fetched-1" }),
   };
 }
 
 describe("deliverDiscordInteractionReply", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearDiscordComponentEntries();
+  });
+
   it("sends component-only native command replies as follow-ups", async () => {
     const interaction = createInteraction();
     const components = [new Container([new TextDisplay("Pick a model")])];
@@ -64,5 +75,57 @@ describe("deliverDiscordInteractionReply", () => {
       components,
     });
     expect(interaction.followUp).not.toHaveBeenCalled();
+  });
+
+  it("builds and registers channelData Discord component specs for native command replies", async () => {
+    const interaction = createInteraction();
+    const payload = {
+      text: "fallback text",
+      channelData: {
+        discord: {
+          components: {
+            blocks: [
+              {
+                type: "actions",
+                buttons: [{ label: "Answer", callbackData: "ask:ask_test" }],
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    expect(hasRenderableReplyPayload({ channelData: payload.channelData })).toBe(true);
+
+    await deliverDiscordInteractionReply({
+      interaction: interaction as never,
+      payload,
+      textLimit: 2000,
+      preferFollowUp: true,
+      responseEphemeral: true,
+      chunkMode: "length",
+    });
+
+    const sent = interaction.followUp.mock.calls[0]?.[0] as {
+      content?: string;
+      components?: Array<{ serialize: () => unknown }>;
+      flags?: number;
+      ephemeral?: boolean;
+    };
+    expect(sent.content).toBeUndefined();
+    expect(sent.ephemeral).toBe(true);
+    expect(sent.flags).toBe(MessageFlags.IsComponentsV2);
+    expect(sent.components).toHaveLength(1);
+    const serialized = sent.components?.[0]?.serialize() as {
+      components?: Array<{ components?: Array<{ custom_id?: string }> }>;
+    };
+    const buttonCustomId = serialized.components?.[1]?.components?.[0]?.custom_id;
+    expect(buttonCustomId).toMatch(/^occomp:cid=/);
+
+    const componentId = buttonCustomId?.match(/cid=([^;]+)/)?.[1];
+    expect(componentId).toBeTruthy();
+    const entry = resolveDiscordComponentEntry({ id: componentId ?? "", consume: false });
+    expect(entry?.callbackData).toBe("ask:ask_test");
+    expect(entry?.messageId).toBe("follow-up-1");
   });
 });

--- a/extensions/discord/src/monitor/native-command-reply.ts
+++ b/extensions/discord/src/monitor/native-command-reply.ts
@@ -6,12 +6,19 @@ import {
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { loadWebMedia } from "openclaw/plugin-sdk/web-media";
 import { chunkDiscordTextWithMode } from "../chunk.js";
+import {
+  buildDiscordComponentMessage,
+  buildDiscordComponentMessageFlags,
+  readDiscordComponentSpec,
+  type DiscordComponentMessageSpec,
+} from "../components.js";
 import type {
   ButtonInteraction,
   CommandInteraction,
   StringSelectMenuInteraction,
   TopLevelComponents,
 } from "../internal/discord.js";
+import { registerBuiltDiscordComponentMessage } from "../send.components.js";
 
 export const DISCORD_EMPTY_VISIBLE_REPLY_WARNING = "⚠️ Command produced no visible reply.";
 
@@ -42,12 +49,26 @@ export function hasRenderableReplyPayload(payload: ReplyPayload): boolean {
     return true;
   }
   const discordData = payload.channelData?.discord as
-    | { components?: TopLevelComponents[] }
+    | { components?: TopLevelComponents[] | DiscordComponentMessageSpec }
     | undefined;
   if (Array.isArray(discordData?.components) && discordData.components.length > 0) {
     return true;
   }
+  if (readDiscordInteractionComponentSpec(payload)) {
+    return true;
+  }
   return false;
+}
+
+function readDiscordInteractionComponentSpec(
+  payload: ReplyPayload,
+): DiscordComponentMessageSpec | undefined {
+  const discordData = payload.channelData?.discord as { components?: unknown } | undefined;
+  return discordData?.components &&
+    typeof discordData.components === "object" &&
+    !Array.isArray(discordData.components)
+    ? (readDiscordComponentSpec(discordData.components) ?? undefined)
+    : undefined;
 }
 
 export async function safeDiscordInteractionCall<T>(
@@ -78,12 +99,57 @@ export async function deliverDiscordInteractionReply(params: {
   const { interaction, payload, textLimit, maxLinesPerMessage, preferFollowUp, chunkMode } = params;
   const reply = resolveSendableOutboundReplyParts(payload);
   const discordData = payload.channelData?.discord as
-    | { components?: TopLevelComponents[] }
+    | { components?: TopLevelComponents[] | DiscordComponentMessageSpec }
     | undefined;
-  let firstMessageComponents =
-    Array.isArray(discordData?.components) && discordData.components.length > 0
+  const componentSpec = readDiscordInteractionComponentSpec(payload);
+  const componentBuildResult = componentSpec
+    ? buildDiscordComponentMessage({
+        spec: {
+          ...componentSpec,
+          text: componentSpec.text ?? (reply.text?.trim() ? reply.text : undefined),
+        },
+      })
+    : undefined;
+  let firstMessageComponents = componentBuildResult
+    ? componentBuildResult.components
+    : Array.isArray(discordData?.components) && discordData.components.length > 0
       ? discordData.components
       : undefined;
+  const componentFlags = componentBuildResult
+    ? buildDiscordComponentMessageFlags(componentBuildResult.components)
+    : undefined;
+  const chunkSourceText = componentBuildResult ? "" : reply.text;
+
+  let firstMessageRegistered = false;
+  const registerFirstMessageComponents = async (sendResult: unknown) => {
+    if (firstMessageRegistered || !componentBuildResult) {
+      return;
+    }
+    const messageId =
+      sendResult &&
+      typeof sendResult === "object" &&
+      typeof (sendResult as { id?: unknown }).id === "string"
+        ? (sendResult as { id: string }).id
+        : typeof interaction.fetchReply === "function"
+          ? await interaction
+              .fetchReply()
+              .then((replyResult) =>
+                replyResult &&
+                typeof replyResult === "object" &&
+                typeof (replyResult as { id?: unknown }).id === "string"
+                  ? (replyResult as { id: string }).id
+                  : undefined,
+              )
+          : undefined;
+    if (!messageId) {
+      return;
+    }
+    registerBuiltDiscordComponentMessage({
+      buildResult: componentBuildResult,
+      messageId,
+    });
+    firstMessageRegistered = true;
+  };
 
   let hasReplied = false;
   const sendMessage = async (
@@ -92,11 +158,13 @@ export async function deliverDiscordInteractionReply(params: {
     components?: TopLevelComponents[],
   ) => {
     const contentPayload = content ? { content } : {};
+    const messageComponentFlags = components ? componentFlags : undefined;
     const payload =
       files && files.length > 0
         ? {
             ...contentPayload,
             ...(components ? { components } : {}),
+            ...(messageComponentFlags ? { flags: messageComponentFlags } : {}),
             ...(params.responseEphemeral !== undefined
               ? { ephemeral: params.responseEphemeral }
               : {}),
@@ -111,18 +179,21 @@ export async function deliverDiscordInteractionReply(params: {
         : {
             ...contentPayload,
             ...(components ? { components } : {}),
+            ...(messageComponentFlags ? { flags: messageComponentFlags } : {}),
             ...(params.responseEphemeral !== undefined
               ? { ephemeral: params.responseEphemeral }
               : {}),
           };
     await safeDiscordInteractionCall("interaction send", async () => {
       if (!preferFollowUp && !hasReplied) {
-        await interaction.reply(payload);
+        const sendResult = await interaction.reply(payload);
+        await registerFirstMessageComponents(sendResult);
         hasReplied = true;
         firstMessageComponents = undefined;
         return;
       }
-      await interaction.followUp(payload);
+      const sendResult = await interaction.followUp(payload);
+      await registerFirstMessageComponents(sendResult);
       hasReplied = true;
       firstMessageComponents = undefined;
     });
@@ -141,8 +212,8 @@ export async function deliverDiscordInteractionReply(params: {
       }),
     );
     const chunks = resolveTextChunksWithFallback(
-      reply.text,
-      chunkDiscordTextWithMode(reply.text, {
+      chunkSourceText,
+      chunkDiscordTextWithMode(chunkSourceText, {
         maxChars: textLimit,
         maxLines: maxLinesPerMessage,
         chunkMode,
@@ -163,10 +234,10 @@ export async function deliverDiscordInteractionReply(params: {
     return;
   }
   let chunks =
-    reply.text || firstMessageComponents
+    chunkSourceText || firstMessageComponents
       ? resolveTextChunksWithFallback(
-          reply.text,
-          chunkDiscordTextWithMode(reply.text, {
+          chunkSourceText,
+          chunkDiscordTextWithMode(chunkSourceText, {
             maxChars: textLimit,
             maxLines: maxLinesPerMessage,
             chunkMode,

--- a/extensions/openrouter/provider-routing.ts
+++ b/extensions/openrouter/provider-routing.ts
@@ -56,9 +56,9 @@ function mergeOpenRouterProviderRouting(params: {
   const modelRouting = readRecord(params.modelParams?.provider);
   const extraRouting = readRecord(params.extraParams.provider);
   const merged = {
-    ...(providerRouting ?? {}),
-    ...(modelRouting ?? {}),
-    ...(extraRouting ?? {}),
+    ...providerRouting,
+    ...modelRouting,
+    ...extraRouting,
   };
   return Object.keys(merged).length > 0 ? merged : undefined;
 }
@@ -78,8 +78,8 @@ export function resolveOpenRouterExtraParamsForTransport(
   }
   return {
     patch: {
-      ...(providerConfigParams ?? {}),
-      ...(modelParams ?? {}),
+      ...providerConfigParams,
+      ...modelParams,
       ...ctx.extraParams,
       ...(providerRouting ? { provider: providerRouting } : {}),
     },

--- a/package.json
+++ b/package.json
@@ -736,6 +736,10 @@
       "types": "./dist/plugin-sdk/discord.d.ts",
       "default": "./dist/plugin-sdk/discord.js"
     },
+    "./plugin-sdk/discord-interactions": {
+      "types": "./dist/plugin-sdk/discord-interactions.d.ts",
+      "default": "./dist/plugin-sdk/discord-interactions.js"
+    },
     "./plugin-sdk/mattermost": {
       "types": "./dist/plugin-sdk/mattermost.d.ts",
       "default": "./dist/plugin-sdk/mattermost.js"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -370,6 +370,12 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/ask:
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+
   extensions/azure-speech:
     devDependencies:
       '@openclaw/plugin-sdk':

--- a/scripts/lib/plugin-sdk-entrypoints.json
+++ b/scripts/lib/plugin-sdk-entrypoints.json
@@ -159,6 +159,7 @@
   "direct-dm-access",
   "direct-dm-guard-policy",
   "discord",
+  "discord-interactions",
   "mattermost",
   "matrix",
   "device-bootstrap",

--- a/src/plugin-sdk/discord-interactions.ts
+++ b/src/plugin-sdk/discord-interactions.ts
@@ -6,6 +6,17 @@ import type {
   PluginInteractiveRegistration,
 } from "./plugin-runtime.js";
 
+export type DiscordComponentMessageSpec = {
+  text?: string;
+  reusable?: boolean;
+  container?: {
+    accentColor?: string | number;
+    spoiler?: boolean;
+  };
+  blocks?: unknown[];
+  modal?: unknown;
+};
+
 export type DiscordInteractiveHandlerContext = {
   channel: "discord";
   accountId: string;

--- a/src/plugin-sdk/discord-interactions.ts
+++ b/src/plugin-sdk/discord-interactions.ts
@@ -1,0 +1,50 @@
+import type { ChannelStructuredComponents } from "./channel-contract.js";
+import type {
+  PluginConversationBinding,
+  PluginConversationBindingRequestParams,
+  PluginConversationBindingRequestResult,
+  PluginInteractiveRegistration,
+} from "./plugin-runtime.js";
+
+export type DiscordInteractiveHandlerContext = {
+  channel: "discord";
+  accountId: string;
+  interactionId: string;
+  conversationId: string;
+  parentConversationId?: string;
+  guildId?: string;
+  senderId?: string;
+  senderUsername?: string;
+  auth: {
+    isAuthorizedSender: boolean;
+  };
+  interaction: {
+    kind: "button" | "select" | "modal";
+    data: string;
+    namespace: string;
+    payload: string;
+    messageId?: string;
+    values?: string[];
+    fields?: Array<{ id: string; name: string; values: string[] }>;
+  };
+  respond: {
+    acknowledge: () => Promise<void>;
+    reply: (params: { text: string; ephemeral?: boolean }) => Promise<void>;
+    followUp: (params: { text: string; ephemeral?: boolean }) => Promise<void>;
+    editMessage: (params: {
+      text?: string;
+      components?: ChannelStructuredComponents;
+    }) => Promise<void>;
+    clearComponents: (params?: { text?: string }) => Promise<void>;
+  };
+  requestConversationBinding: (
+    params?: PluginConversationBindingRequestParams,
+  ) => Promise<PluginConversationBindingRequestResult>;
+  detachConversationBinding: () => Promise<{ removed: boolean }>;
+  getCurrentConversationBinding: () => Promise<PluginConversationBinding | null>;
+};
+
+export type DiscordInteractiveHandlerRegistration = PluginInteractiveRegistration<
+  DiscordInteractiveHandlerContext,
+  "discord"
+>;

--- a/src/plugin-sdk/discord-interactions.ts
+++ b/src/plugin-sdk/discord-interactions.ts
@@ -6,6 +6,121 @@ import type {
   PluginInteractiveRegistration,
 } from "./plugin-runtime.js";
 
+export type DiscordComponentButtonStyle = "primary" | "secondary" | "success" | "danger" | "link";
+
+export type DiscordComponentSelectType = "string" | "user" | "role" | "mentionable" | "channel";
+
+export type DiscordComponentModalFieldType =
+  | "text"
+  | "checkbox"
+  | "radio"
+  | "select"
+  | "role-select"
+  | "user-select";
+
+export type DiscordComponentButtonSpec = {
+  label: string;
+  style?: DiscordComponentButtonStyle;
+  url?: string;
+  callbackData?: string;
+  emoji?: {
+    name: string;
+    id?: string;
+    animated?: boolean;
+  };
+  disabled?: boolean;
+  allowedUsers?: string[];
+};
+
+export type DiscordComponentSelectOption = {
+  label: string;
+  value: string;
+  description?: string;
+  emoji?: {
+    name: string;
+    id?: string;
+    animated?: boolean;
+  };
+  default?: boolean;
+};
+
+export type DiscordComponentSelectSpec = {
+  type?: DiscordComponentSelectType;
+  callbackData?: string;
+  placeholder?: string;
+  minValues?: number;
+  maxValues?: number;
+  options?: DiscordComponentSelectOption[];
+  allowedUsers?: string[];
+};
+
+export type DiscordComponentSectionAccessory =
+  | {
+      type: "thumbnail";
+      url: string;
+    }
+  | {
+      type: "button";
+      button: DiscordComponentButtonSpec;
+    };
+
+type DiscordComponentSeparatorSpacing = "small" | "large" | 1 | 2;
+
+export type DiscordComponentBlock =
+  | {
+      type: "text";
+      text: string;
+    }
+  | {
+      type: "section";
+      text?: string;
+      texts?: string[];
+      accessory?: DiscordComponentSectionAccessory;
+    }
+  | {
+      type: "separator";
+      spacing?: DiscordComponentSeparatorSpacing;
+      divider?: boolean;
+    }
+  | {
+      type: "actions";
+      buttons?: DiscordComponentButtonSpec[];
+      select?: DiscordComponentSelectSpec;
+    }
+  | {
+      type: "media-gallery";
+      items: Array<{ url: string; description?: string; spoiler?: boolean }>;
+    }
+  | {
+      type: "file";
+      file: `attachment://${string}`;
+      spoiler?: boolean;
+    };
+
+export type DiscordModalFieldSpec = {
+  type: DiscordComponentModalFieldType;
+  name?: string;
+  label: string;
+  description?: string;
+  placeholder?: string;
+  required?: boolean;
+  options?: DiscordComponentSelectOption[];
+  minValues?: number;
+  maxValues?: number;
+  minLength?: number;
+  maxLength?: number;
+  style?: "short" | "paragraph";
+};
+
+export type DiscordModalSpec = {
+  title: string;
+  callbackData?: string;
+  triggerLabel?: string;
+  triggerStyle?: DiscordComponentButtonStyle;
+  allowedUsers?: string[];
+  fields: DiscordModalFieldSpec[];
+};
+
 export type DiscordComponentMessageSpec = {
   text?: string;
   reusable?: boolean;
@@ -13,9 +128,11 @@ export type DiscordComponentMessageSpec = {
     accentColor?: string | number;
     spoiler?: boolean;
   };
-  blocks?: unknown[];
-  modal?: unknown;
+  blocks?: DiscordComponentBlock[];
+  modal?: DiscordModalSpec;
 };
+
+export type DiscordResponseComponents = ChannelStructuredComponents | DiscordComponentMessageSpec;
 
 export type DiscordInteractiveHandlerContext = {
   channel: "discord";
@@ -40,11 +157,19 @@ export type DiscordInteractiveHandlerContext = {
   };
   respond: {
     acknowledge: () => Promise<void>;
-    reply: (params: { text: string; ephemeral?: boolean }) => Promise<void>;
-    followUp: (params: { text: string; ephemeral?: boolean }) => Promise<void>;
+    reply: (params: {
+      text: string;
+      ephemeral?: boolean;
+      components?: DiscordResponseComponents;
+    }) => Promise<void>;
+    followUp: (params: {
+      text: string;
+      ephemeral?: boolean;
+      components?: DiscordResponseComponents;
+    }) => Promise<void>;
     editMessage: (params: {
       text?: string;
-      components?: ChannelStructuredComponents;
+      components?: DiscordResponseComponents;
     }) => Promise<void>;
     clearComponents: (params?: { text?: string }) => Promise<void>;
   };

--- a/src/plugin-sdk/entrypoints.ts
+++ b/src/plugin-sdk/entrypoints.ts
@@ -44,6 +44,7 @@ export const reservedBundledPluginSdkEntrypoints = [
 // until they move to generic, plugin-neutral contracts.
 export const supportedBundledFacadeSdkEntrypoints = [
   "discord",
+  "discord-interactions",
   "lmstudio",
   "lmstudio-runtime",
   "matrix",


### PR DESCRIPTION
## Summary
- add bundled Ask plugin with a Discord-native `/ask` command
- choose button/select/modal from the prompt and store log-only ask sessions/feedback
- add `/ask grill <request>` as a prefix-mode clarification flow that asks one modal question at a time and finishes with a SPEC/GOAL/task/proposal summary
- expose a focused `plugin-sdk/discord-interactions` subpath and register native command reply components so Discord callbacks reach plugin interactive handlers

## Safety
- `/ask` and `/ask grill` are answer-capture only: `nextActionPolicy=log_only`, `requiresSecondGo=true`, `actionScope=answer_capture_only`
- default `allowedUsers` is the invoking sender, components are non-reusable, sessions expire after 30 minutes
- Grill Mode replaces an active Grill session for the same requester/channel/thread instead of running multiple ambiguous flows at once
- no Poll routing, Select+Modal composite, approval execution, external send, config mutation, deploy, billing, gateway restart, or long-running task execution in this PR

## Merge-gate notes
- GitHub checks for commit `9b66324a` were all green/pass or intentionally skipped before this docs-only follow-up.
- OpenRouter diff note: `extensions/openrouter/provider-routing.ts` is a lint-only cleanup for `unicorn(no-useless-fallback-in-spread)`. Reverting it locally made `pnpm lint:extensions:bundled` fail with five errors in that file, so splitting it out cleanly requires a separate lint-baseline/CI strategy. It is intentionally kept in this PR to preserve green lint.
- Runtime rollout is explicitly post-merge only: merge -> install/runtime reflect -> gateway/runtime restart -> live Discord smoke. This PR does not restart or mutate the running gateway.

## Runtime smoke and rollback plan
After merge and runtime rollout, verify in a private Discord test channel:

1. Restart the gateway/runtime process that loads bundled plugins.
2. Run `/ask Minimal /ask smoke? --options=GO:go,STOP:stop`.
3. Confirm the command renders Discord components.
4. Click an allowed answer as the requester and confirm the session records the answer, clears components, and does not execute any action.
5. Run `/ask grill Build a small dashboard`.
6. Submit one Grill modal answer and confirm the next Grill question is shown with progress.
7. Finish the Grill sequence and confirm the final summary keeps `log_only`, `requires_second_go=true`, and `action_scope=answer_capture_only`.
8. Confirm a non-requester interaction is rejected privately and does not overwrite the shared prompt.

Rollback: revert the merge commit or disable/remove the bundled `ask` plugin from the deployed runtime, then restart the gateway/runtime process. No data migration is required because initial Ask sessions are keyed runtime records and no external action is executed.

## Verification
- `corepack pnpm exec vitest run extensions/ask/index.test.ts extensions/discord/src/monitor/native-command-reply.test.ts extensions/discord/src/monitor/monitor.test.ts`
- `corepack pnpm tsgo:extensions`
- `corepack pnpm lint:extensions:bundled`
- `git diff --check`

Earlier branch verification also passed:
- `pnpm install --frozen-lockfile`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts extensions/ask/index.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-discord.config.ts extensions/discord/src/monitor/native-command-reply.test.ts`
- `pnpm tsgo:extensions:test`
- `pnpm check:architecture`
- `node scripts/run-vitest.mjs run src/plugins/contracts/plugin-sdk-package-contract-guardrails.test.ts`
- `node scripts/check-plugin-sdk-subpath-exports.mjs`
- `node scripts/sync-plugin-sdk-exports.mjs --check`
- `pnpm build:strict-smoke`

## Notes
- Local shell in this session did not have a global `pnpm` binary, so `corepack pnpm` was used.
- `build:strict-smoke` previously emitted existing zod locale CommonJS dts warnings from `rolldown-plugin-dts`, but completed successfully.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed:
  - Discord users can run native `/ask` and receive non-reusable interactive buttons/select/modal that record an answer only.
  - Discord users can run `/ask grill <request>` to clarify ambiguous work one question at a time without triggering implementation or external actions.
  - The built runtime includes the bundled Ask plugin and the focused `discord-interactions` SDK export needed by the Discord interactive handler path.
- Real environment tested:
  - macOS local OpenClaw checkout built from this PR branch, Node.js via the repository toolchain, pnpm through corepack.
  - Built OpenClaw dist output, not a mocked unit-test fixture.
- Exact steps or command run after this patch:
  - `pnpm build:strict-smoke`
  - `node dist/index.js --version`
  - node script reading `dist/extensions/ask/openclaw.plugin.json` and checking generated dist files for Ask and `discord-interactions`.
- Evidence after fix:

```text
$ pnpm build:strict-smoke
CLI bootstrap import guard passed.
runtime-postbuild: plugin SDK root alias completed in 0ms
runtime-postbuild: bundled plugin metadata completed in 154ms
runtime-postbuild: official channel catalog completed in 3ms
runtime-postbuild: bundled plugin runtime overlay completed in 163ms
runtime-postbuild: static extension assets completed in 42ms
runtime-postbuild: stable root runtime imports completed in 112ms
runtime-postbuild: stable root runtime aliases completed in 86ms
runtime-postbuild: legacy root runtime compat aliases completed in 28ms
runtime-postbuild: legacy CLI exit compat chunks completed in 0ms
OK: All 4 required plugin-sdk exports verified.

$ node dist/index.js --version
OpenClaw 2026.5.19 (fc78d2d)

$ node - <<'NODE'
OK dist/extensions/ask/index.js
OK dist/extensions/ask/openclaw.plugin.json
OK dist/plugin-sdk/discord-interactions.js
OK dist/plugin-sdk/discord-interactions.d.ts
manifest id=ask name=Ask
export discord-interactions=true
NODE
```

- Observed result after fix:
  - The real built dist contains the Ask bundled plugin manifest/runtime entry and the public `discord-interactions` SDK export.
  - The built CLI starts far enough to report the PR build stamp, confirming the generated runtime artifacts are loadable at the package level.
- What was not tested:
  - Live Discord `/ask` and `/ask grill` smoke against the running production gateway were not tested in this PR branch because the currently running global package is still the published runtime. That smoke should happen after merge/install/restart so the gateway is actually running this build.
- Before evidence:
  - Current production/global runtime does not include this PR build, so `/ask` is not available there yet.
