### PR TITLE
fix(plugins): dedupe provider-prefixed model refs in runtime LLM allowlist policy

### DIFF
--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -1031,6 +1031,36 @@ describe("loadGatewayPlugins", () => {
     );
   });
 
+  test("uses deduped resolved ref in fallback override deny diagnostic (#84887)", async () => {
+    const serverPlugins = serverPluginsModule;
+    const runtime = await createSubagentRuntime(serverPlugins, {
+      plugins: {
+        entries: {
+          "voice-call": {
+            subagent: {
+              allowModelOverride: true,
+              allowedModels: ["openrouter/gpt-5.4-mini"],
+            },
+          },
+        },
+      },
+    });
+    serverPlugins.setFallbackGatewayContext(createTestContext("fallback-prefixed-model-deny"));
+    await expect(
+      gatewayRequestScopeModule.withPluginRuntimePluginIdScope("voice-call", () =>
+        runtime.run({
+          sessionKey: "s-prefixed-model-deny",
+          message: "use trusted override",
+          provider: "openrouter",
+          model: "openrouter/gpt-5.5",
+          deliver: false,
+        }),
+      ),
+    ).rejects.toThrow(
+      'model override "openrouter/gpt-5.5" is not allowlisted for plugin "voice-call".',
+    );
+  });
+
   test("uses least-privilege synthetic fallback scopes without admin", async () => {
     const serverPlugins = serverPluginsModule;
     const runtime = await createSubagentRuntime(serverPlugins);

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { performance } from "node:perf_hooks";
-import { normalizeModelRef, parseModelRef } from "../agents/model-selection.js";
+import { modelKey, normalizeModelRef, parseModelRef } from "../agents/model-selection.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizePluginsConfig } from "../plugins/config-state.js";
@@ -127,7 +127,7 @@ function normalizeAllowedModelRef(raw: string): string | null {
     return null;
   }
   const normalized = normalizeModelRef(providerRaw, modelRaw);
-  return `${normalized.provider}/${normalized.model}`;
+  return modelKey(normalized.provider, normalized.model);
 }
 
 export function setPluginSubagentOverridePolicies(cfg: OpenClawConfig): void {
@@ -227,7 +227,7 @@ function resolveRequestedFallbackModelRef(params: {
 }): string | null {
   if (params.provider && params.model) {
     const normalizedRequest = normalizeModelRef(params.provider, params.model);
-    return `${normalizedRequest.provider}/${normalizedRequest.model}`;
+    return modelKey(normalizedRequest.provider, normalizedRequest.model);
   }
   const rawModel = params.model?.trim();
   if (!rawModel || !rawModel.includes("/")) {
@@ -237,7 +237,7 @@ function resolveRequestedFallbackModelRef(params: {
   if (!parsed?.provider || !parsed.model) {
     return null;
   }
-  return `${parsed.provider}/${parsed.model}`;
+  return modelKey(parsed.provider, parsed.model);
 }
 
 // ── Internal gateway dispatch for plugin runtime ────────────────────

--- a/src/plugins/runtime/runtime-llm.runtime.test.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.test.ts
@@ -306,6 +306,43 @@ describe("runtime.llm.complete", () => {
     expect(hoisted.prepareSimpleCompletionModelForAgent).not.toHaveBeenCalled();
   });
 
+  it("uses the deduped resolved ref in the allowlist deny diagnostic (#84887)", async () => {
+    hoisted.resolveSimpleCompletionSelectionForAgent.mockReturnValue({
+      provider: "openrouter",
+      modelId: "openrouter/gpt-5.5",
+      agentDir: "/tmp/openclaw-agent",
+    });
+
+    const runtimeContext = resolveContextEngineCapabilities({
+      config: {
+        ...cfg,
+        plugins: {
+          entries: {
+            "lossless-claw": {
+              llm: {
+                allowModelOverride: true,
+                allowedModels: ["openrouter/gpt-5.4-mini"],
+              },
+            },
+          },
+        },
+      },
+      sessionKey: "agent:main:session:abc",
+      contextEnginePluginId: "lossless-claw",
+      purpose: "context-engine.compaction",
+    });
+
+    await expect(
+      runtimeContext.llm!.complete({
+        model: "openrouter/gpt-5.5",
+        messages: [{ role: "user", content: "summarize" }],
+      }),
+    ).rejects.toThrow(
+      'model override "openrouter/gpt-5.5" is not allowlisted for plugin "lossless-claw"',
+    );
+    expect(hoisted.prepareSimpleCompletionModelForAgent).not.toHaveBeenCalled();
+  });
+
   it("keeps context-engine attribution and host-derived policy inside plugin runtime scope", async () => {
     const runtimeContext = resolveContextEngineCapabilities({
       config: {

--- a/src/plugins/runtime/runtime-llm.runtime.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.ts
@@ -1,5 +1,5 @@
 import type { Api, Message } from "@earendil-works/pi-ai";
-import { normalizeModelRef } from "../../agents/model-selection.js";
+import { modelKey, normalizeModelRef } from "../../agents/model-selection.js";
 import type { NormalizedUsage, UsageLike } from "../../agents/usage.js";
 import { normalizeUsage } from "../../agents/usage.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -235,7 +235,7 @@ function normalizeAllowedModelRef(raw: string): string | null {
     return null;
   }
   const normalized = normalizeModelRef(provider, model);
-  return `${normalized.provider}/${normalized.model}`;
+  return modelKey(normalized.provider, normalized.model);
 }
 
 function buildPolicyFromEntry(entry: {
@@ -402,7 +402,7 @@ export function createRuntimeLlm(options: CreateRuntimeLlmOptions = {}): PluginR
           ? normalizeModelRef(selection.provider, selection.modelId)
           : null;
         const resolvedModelRef = normalizedSelection
-          ? `${normalizedSelection.provider}/${normalizedSelection.model}`
+          ? modelKey(normalizedSelection.provider, normalizedSelection.model)
           : null;
         assertAllowedModelOverride({
           resolvedModelRef,


### PR DESCRIPTION
## Summary

- Problem: The plugin runtime LLM policy gate (`src/plugins/runtime/runtime-llm.runtime.ts`) and the gateway fallback subagent policy gate (`src/gateway/server-plugins.ts`) each build allowlist `Set` keys and resolved-selection keys via ad-hoc `${normalized.provider}/${normalized.model}` concatenation. When a provider plugin manifest contributes `prefixWhenBare` (e.g. OpenRouter) and the resolved selection's `modelId` already carries the provider segment, the concatenation produces a double-prefixed key (`openrouter/openrouter/gpt-5.4-mini`). The user-typed allowlist entry does not carry the duplicate prefix, so `Set.has` misses and the diagnostic surfaces a confusing `openrouter/openrouter/...` string.
- Solution: Swap the 5 ad-hoc concat sites in the two affected flows to the existing canonical `modelKey()` helper at `src/agents/model-ref-shared.ts:17` (already re-exported via `src/agents/model-selection.ts`). `modelKey` dedupes when `model` already starts with `${provider}/`, so both pair sides remain symmetric: allowlist `Set` construction + resolved-selection lookup produce identical canonical keys, the policy gate keeps the same contract, and the diagnostic surfaces the deduped, user-recognizable ref.
- What changed: 5 `modelKey(p, m)` swaps + 2 named-import additions across `runtime-llm.runtime.ts` (2 sites) and `server-plugins.ts` (3 sites), plus 2 regression tests (one per file) locking in the deduped diagnostic.
- What did NOT change (scope boundary): `legacyModelKey` (intentional raw concat for legacy lookup), the wider set of `normalizeModelRef` callers under `src/agents/**` (each requires its own diagnosis), and the cross-file `normalizeAllowedModelRef` duplication (known smell, separate refactor).

## Motivation

#84887 was opened by `100yenadmin` who reported their plugin LLM allowlist diagnostic surfaced `openrouter/openrouter/gpt-5.4-mini` even though the actionable model ref they had configured was `openrouter/gpt-5.4-mini`. The doubled provider segment confused remediation. The reporter's suggested fix shape ("normalize runtime LLM model refs with a helper that strips only duplicated provider prefixes after `normalizeModelRef()`") matches the canonical `modelKey()` helper that already lives in `src/agents/model-ref-shared.ts` — the bug here is that two flows didn't use it.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #84887
- Related #84934
- [x] This PR fixes a bug or regression

## Real behavior proof

- Behavior or issue addressed: Plugin LLM runtime allowlist policy and gateway fallback subagent policy both build canonical `provider/model` keys via ad-hoc concatenation that does not dedupe when the resolved `modelId` already carries the provider segment, producing a double-prefixed diagnostic and (in the reporter's environment) a wrongly denied allowlist match.

- Real environment tested: Local checkout at `/root/repos/openclaw-84887` rebased onto current `upstream/main` (`f39f56a096`). Direct production-source invocation via `node_modules/.bin/tsx /tmp/proof-84887.mts`, importing the actual production `modelKey` from `src/agents/model-selection.ts` (re-exported from `src/agents/model-ref-shared.ts`). Also focused vitest on the two touched test files.

- Exact steps or command run after this patch:

```
node_modules/.bin/tsx /tmp/proof-84887.mts
node scripts/run-vitest.mjs src/plugins/runtime/runtime-llm.runtime.test.ts src/gateway/server-plugins.test.ts
```

- Evidence after fix:

Terminal capture from this branch, copied live output of the production `modelKey` invocation:

```
=== Pre-fix path (ad-hoc concat) ===
  allowlist Set entry: "openrouter/gpt-5.4-mini"
  resolved ref:        "openrouter/openrouter/gpt-5.4-mini"
  Set.has(resolved):   false  (bug: false; legitimate selection denied)
  diagnostic emitted:  model override "openrouter/openrouter/gpt-5.4-mini" is not allowlisted for plugin "lossless-claw".

=== Post-fix path (modelKey() from src/agents/model-ref-shared.ts) ===
  allowlist Set entry: "openrouter/gpt-5.4-mini"
  resolved ref:        "openrouter/gpt-5.4-mini"
  Set.has(resolved):   true  (fix: true; legitimate selection allowed)

=== Cross-check vs #84887 reporter's verbatim error ===
  reporter wrote: Plugin LLM completion model override "openrouter/openrouter/gpt-5.4-mini" is not allowlisted for plugin "lossless-claw".
  local pre-fix:  Plugin LLM completion model override "openrouter/openrouter/gpt-5.4-mini" is not allowlisted for plugin "lossless-claw".
  match: true
```

Focused regression tests on both touched flows, copied live output:

```
 RUN  v4.1.7 /root/repos/openclaw-84887

 Test Files  2 passed (2)
      Tests  64 passed (64)
   Start at  18:36:29
   Duration  6.18s (transform 1.86s, setup 179ms, import 857ms, tests 4.97s, environment 0ms)
```

- Observed result after fix: The production `modelKey` collapses `(provider="openrouter", model="openrouter/gpt-5.4-mini")` to the single-prefix canonical key `"openrouter/gpt-5.4-mini"`. The `Set.has` lookup that was previously denying legitimate selections now succeeds, and the diagnostic for real deny cases carries the user-recognizable single-prefix ref (matching the reporter's allowlist entry shape). The pre-fix path simulation reproduces the reporter's verbatim diagnostic string character-for-character, confirming the diagnosis end-to-end through the real production helper.

- What was not tested: No live OpenRouter API call or live Lossless plugin invocation; the bug is host-side normalization, so an end-to-end runtime call is not required to validate the fix. The "allow" case end-to-end through `runtimeContext.llm.complete` was not added as a vitest case because in the vitest environment (no OpenRouter plugin manifest loaded) the host's `normalizeProviderModelIdWithRuntime` does not re-prefix bare model ids, so both Set-construction and resolved-side paths produce symmetric output and the bug becomes invisible at the policy gate (it only surfaces in the diagnostic string). The diagnostic-dedup regression tests in both files cover the same concat logic the allow path depends on.

- Before evidence (optional but encouraged): The reporter's `[lcm] runtime.llm.complete error` log in the issue body shows `Plugin LLM completion model override "openrouter/openrouter/gpt-5.4-mini" is not allowlisted for plugin "lossless-claw".`. The pre-fix path simulation in the proof capture above produces this exact string character-for-character.

## Root Cause

- Root cause: Two independent flows (plugin runtime LLM policy + gateway fallback subagent policy) each build canonical `provider/model` keys via local ad-hoc `${normalized.provider}/${normalized.model}` concatenation. The repo already has a canonical helper `modelKey(provider, model)` at `src/agents/model-ref-shared.ts:17` that dedupes when `model` already starts with `${provider}/`. The ad-hoc paths were missing the dedup branch. When OpenRouter's manifest `prefixWhenBare=openrouter` produces a resolved `selection.modelId` of `openrouter/gpt-5.4-mini`, the concatenation generates a doubled key while the user-entered allowlist ref stays single-prefixed; the `Set.has` lookup misses and the diagnostic surfaces the confusing doubled string.
- Missing detection / guardrail: No regression test exercised an allowlist deny diagnostic where the resolved selection's `modelId` already carried the provider segment. Both regression test files in this PR add that coverage.
- Contributing context: The two flows independently re-implement `normalizeAllowedModelRef` (one in `runtime-llm.runtime.ts`, one in `server-plugins.ts`); both implementations carry the same canonical-key bug. Consolidating them is out of scope for this focused fix and left as a follow-up.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/plugins/runtime/runtime-llm.runtime.test.ts` — context-engine LLM deny diagnostic (#84887)
  - `src/gateway/server-plugins.test.ts` — fallback subagent override deny diagnostic (#84887)
- Scenario the test should lock in: When the resolved selection's `modelId` arrives with the provider segment already prepended (simulating OpenRouter's `prefixWhenBare` behavior), an allowlist deny must surface the deduped single-prefix ref in the diagnostic and (transitively) construct symmetric canonical Set keys on both sides of the policy check.
- Why this is the smallest reliable guardrail: The two tests exercise the exact concat sites changed in this PR and lock the canonical-key contract by inspecting the user-visible diagnostic string. Any future regression that reintroduces ad-hoc concat at either site will break the verbatim assertion immediately.
- Existing test that already covers this (if any): None — neither test file previously asserted the deduped form of provider-prefixed resolved refs.
- If no new test is added, why not: N/A — new tests added.

## User-visible / Behavior Changes

Users configuring plugin LLM allowlists or gateway fallback subagent allowlists with single-prefix entries (e.g. `openrouter/gpt-5.4-mini`) will now match their selections correctly when the selection's `modelId` arrives provider-prefixed via a plugin's `prefixWhenBare` hook. Deny diagnostics will surface the deduped single-prefix ref instead of the previously doubled form. Users who deliberately configured legacy double-prefix entries like `openrouter/openrouter/hunter-alpha` will see those entries collapse to the same canonical key as the deduped resolved ref; the policy gate semantics remain consistent (legacy entries continue to match their intended targets via the deduped canonical key).

## Security Impact

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

This is a focused diagnostic + canonical-key contract fix in two host-side normalization paths. No auth, network, permission, or data-access surface is touched.

## Repro + Verification

### Environment

- OS: Linux (x64)
- Runtime/container: Node 22.22.1, pnpm 11.1.0
- Model/provider: N/A (production-source unit invocation; bug is host-side normalization)
- Integration/channel (if any): Plugin runtime LLM API + gateway fallback subagent path
- Relevant config (redacted): N/A

### Steps

1. Configure plugin allowlist `allowedModels: ["openrouter/gpt-5.4-mini"]` for a plugin that calls `api.runtime.llm.complete` (or use a fallback subagent override targeting OpenRouter).
2. Trigger the runtime LLM call with a selection where `selection.modelId` arrives `openrouter/gpt-5.4-mini` (via OpenRouter's manifest `prefixWhenBare=openrouter`).
3. Pre-fix: the policy denies the legitimate selection and emits `model override "openrouter/openrouter/gpt-5.4-mini" is not allowlisted for plugin "X"`.

### Expected

- The legitimate selection is allowed; deny diagnostics for genuinely-out-of-allowlist selections carry the deduped single-prefix ref.

### Actual (before fix)

- Allowlist `Set` lookup misses; diagnostic carries the doubled-prefix ref (verbatim match to reporter's log line above).

## Human Verification

- Verified scenarios: Pre-fix path verbatim match to the reporter's diagnostic string; post-fix `Set.has` succeeds on the rebased branch via production-source `modelKey` invocation; vitest deny-diagnostic regression tests pass in both touched files; full `src/plugins/runtime/` + `src/gateway/` vitest scope passed (242 files / 2672 tests) before rebase, focused 2-file scope (64 tests) reran clean post-rebase. `pnpm build` completes; `dist/runtime-llm.runtime-*.js` and `dist/server-plugins-*.js` contain the `modelKey` reference paths.
- Edge cases checked: Wildcard `*` allowlist entries short-circuit before the concat path (untouched). Empty provider/model inputs are rejected by `normalizeAllowedModelRef` before reaching the concat (untouched). Legacy double-prefix allowlist entries collapse to the same canonical key as the deduped resolved ref. `legacyModelKey` (intentional raw concat for back-compat lookup) is not on the policy-gate path and is untouched.
- What I did **not** verify: Live OpenRouter API traffic (not relevant — host-side normalization fix). Live Lossless plugin invocation (also not on the host-side normalization path). Other ~16 `normalizeModelRef` callers under `src/agents/**` outside the two policy-gate flows fixed here (out of scope; each requires its own diagnosis and proof).

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

Users who had configured legacy double-prefix workaround entries see those entries collapse to the same canonical key now used by both the allowlist Set and the resolved-selection key. Single-prefix entries (which the user-facing diagnostics already encouraged) continue to work, now also matching provider-prefixed resolved selections that previously slipped past the policy gate.

## Risks and Mitigations

- Risk: Two flows independently re-implement `normalizeAllowedModelRef`; this PR fixes the bug in both but does not consolidate them.
  - Mitigation: The duplication is explicitly out of scope and left as a follow-up. Both implementations now share the canonical `modelKey()` helper for key construction, so the contract is consistent across both flows. A separate refactor PR can dedupe the helper body without affecting the canonical-key semantics this PR establishes.
- Risk: Other `normalizeModelRef` callers under `src/agents/**` may have the same ad-hoc concat pattern; this PR does not touch them.
  - Mitigation: Each non-policy-gate caller has different semantics (catalog lookup, alias resolution, fallback observation logging). Mixing them into this fix would expand blast radius beyond #84887's scope. An independent diff review confirmed no third raw-concat site exists in either Set/diagnostic flow this PR is changing.

https://github.com/openclaw/openclaw/issues/84887
