### PR TITLE
fix #84887: avoid duplicate provider prefix in runtime LLM allowlist diagnostics

### DIFF
--- a/src/plugins/runtime/runtime-llm.runtime.test.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.test.ts
@@ -306,6 +306,92 @@ describe("runtime.llm.complete", () => {
     expect(hoisted.prepareSimpleCompletionModelForAgent).not.toHaveBeenCalled();
   });
 
+  it("matches allowlist entries for provider-qualified model ids without doubling the provider prefix", async () => {
+    const runtimeContext = resolveContextEngineCapabilities({
+      config: {
+        ...cfg,
+        plugins: {
+          entries: {
+            "lossless-claw": {
+              llm: {
+                allowModelOverride: true,
+                allowedModels: ["openrouter/gpt-5.4-mini"],
+              },
+            },
+          },
+        },
+      },
+      sessionKey: "agent:main:session:abc",
+      contextEnginePluginId: "lossless-claw",
+      purpose: "context-engine.compaction",
+    });
+
+    hoisted.prepareSimpleCompletionModelForAgent.mockResolvedValue(
+      createPreparedModel("openrouter/gpt-5.4-mini"),
+    );
+    hoisted.resolveSimpleCompletionSelectionForAgent.mockImplementation(
+      (params: { agentId: string }) => ({
+        provider: "openrouter",
+        modelId: "openrouter/gpt-5.4-mini",
+        agentDir: `/tmp/${params.agentId}`,
+      }),
+    );
+
+    await runtimeContext.llm!.complete({
+      agentId: "main",
+      model: "openrouter/gpt-5.4-mini",
+      messages: [{ role: "user", content: "summarize" }],
+    });
+
+    expectSingleCallFirstArg(hoisted.prepareSimpleCompletionModelForAgent, {
+      agentId: "main",
+      modelRef: "openrouter/gpt-5.4-mini",
+    });
+  });
+
+  it("reports denials for provider-qualified model ids without doubling the provider prefix", async () => {
+    const runtimeContext = resolveContextEngineCapabilities({
+      config: {
+        ...cfg,
+        plugins: {
+          entries: {
+            "lossless-claw": {
+              llm: {
+                allowModelOverride: true,
+                allowedModels: ["openrouter/gpt-5.4-mini"],
+              },
+            },
+          },
+        },
+      },
+      sessionKey: "agent:main:session:abc",
+      contextEnginePluginId: "lossless-claw",
+      purpose: "context-engine.compaction",
+    });
+
+    hoisted.resolveSimpleCompletionSelectionForAgent.mockImplementation(
+      (params: { agentId: string }) => ({
+        provider: "openrouter",
+        modelId: "openrouter/gpt-5.5",
+        agentDir: `/tmp/${params.agentId}`,
+      }),
+    );
+
+    let caught: unknown;
+    try {
+      await runtimeContext.llm!.complete({
+        model: "openrouter/gpt-5.5",
+        messages: [{ role: "user", content: "summarize" }],
+      });
+    } catch (error) {
+      caught = error;
+    }
+    const message = caught instanceof Error ? caught.message : String(caught);
+    expect(message).toContain('"openrouter/gpt-5.5"');
+    expect(message).not.toContain("openrouter/openrouter/");
+    expect(hoisted.prepareSimpleCompletionModelForAgent).not.toHaveBeenCalled();
+  });
+
   it("keeps context-engine attribution and host-derived policy inside plugin runtime scope", async () => {
     const runtimeContext = resolveContextEngineCapabilities({
       config: {

--- a/src/plugins/runtime/runtime-llm.runtime.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.ts
@@ -1,4 +1,5 @@
 import type { Api, Message } from "@earendil-works/pi-ai";
+import { modelKey } from "../../agents/model-ref-shared.js";
 import { normalizeModelRef } from "../../agents/model-selection.js";
 import type { NormalizedUsage, UsageLike } from "../../agents/usage.js";
 import { normalizeUsage } from "../../agents/usage.js";
@@ -235,7 +236,7 @@ function normalizeAllowedModelRef(raw: string): string | null {
     return null;
   }
   const normalized = normalizeModelRef(provider, model);
-  return `${normalized.provider}/${normalized.model}`;
+  return modelKey(normalized.provider, normalized.model);
 }
 
 function buildPolicyFromEntry(entry: {
@@ -402,7 +403,7 @@ export function createRuntimeLlm(options: CreateRuntimeLlmOptions = {}): PluginR
           ? normalizeModelRef(selection.provider, selection.modelId)
           : null;
         const resolvedModelRef = normalizedSelection
-          ? `${normalizedSelection.provider}/${normalizedSelection.model}`
+          ? modelKey(normalizedSelection.provider, normalizedSelection.model)
           : null;
         assertAllowedModelOverride({
           resolvedModelRef,


### PR DESCRIPTION
## Summary

- Problem: when `api.runtime.llm.complete` resolves a selection whose modelId already starts with the provider segment (e.g. OpenRouter resolves `provider="openrouter"`, `modelId="openrouter/gpt-5.4-mini"`), the runtime LLM policy path interpolated `${provider}/${model}` after `normalizeModelRef()`, producing `openrouter/openrouter/gpt-5.4-mini`. The malformed ref both missed the user's allowlist and showed up in the denial diagnostic, sending plugin authors chasing the wrong allowlist key.
- Solution: route both the allowlist normalization site and the resolved-override formatting through the existing `modelKey()` helper, which leaves the model id untouched when it already starts with the provider segment.
- What changed: `src/plugins/runtime/runtime-llm.runtime.ts` (import + two interpolation sites); regression coverage added in `src/plugins/runtime/runtime-llm.runtime.test.ts`.
- What did NOT change: `normalizeModelRef()` semantics, the parallel `normalizeAllowedModelRef` in `src/gateway/server-plugins.ts` (subagent fallback policy), and any other model-ref formatter — kept the change scoped to the runtime LLM policy path the issue narrowed.

Fixes #84887

## Real behavior proof
- **Behavior or issue addressed:** plugin runtime LLM allowlist denial diagnostics reported `openrouter/openrouter/gpt-5.4-mini` for an actionable `openrouter/gpt-5.4-mini` selection, leading users to add the wrong allowlist entries.
- **Real environment tested:** Linux 4.19 x86_64, Node v22.22.0, OpenClaw worktree at HEAD ee9f3b6a52 (rebased onto origin/main bde07ddb15).
- **Exact steps or command run after this patch:**
  ```bash
  pnpm install
  node --import tsx .automation/proof_repro.ts
  node scripts/run-vitest.mjs run src/plugins/runtime/runtime-llm.runtime.test.ts
  ```
  `proof_repro.ts` imports the real source helpers and exercises the exact normalization path the runtime LLM policy uses:
  ```ts
  import { modelKey } from "../src/agents/model-ref-shared.ts";
  import { normalizeModelRef } from "../src/agents/model-selection-normalize.ts";
  const normalized = normalizeModelRef("openrouter", "openrouter/gpt-5.4-mini");
  const oldRef = `${normalized.provider}/${normalized.model}`;     // pre-fix interpolation
  const newRef = modelKey(normalized.provider, normalized.model);  // post-fix
  const allowlist = new Set(["openrouter/gpt-5.4-mini"]);
  console.log({ oldRef, newRef, oldHit: allowlist.has(oldRef), newHit: allowlist.has(newRef) });
  ```
- **Evidence after fix:**
  ```
  Issue #84887 — runtime LLM allowlist double-prefix repro

  --- OpenRouter provider-qualified model id (the bug shape) ---
    input:                provider=openrouter, modelId=openrouter/gpt-5.4-mini
    normalizeModelRef:    { provider: "openrouter", model: "openrouter/gpt-5.4-mini" }
    OLD interpolation:    "openrouter/openrouter/gpt-5.4-mini"
    NEW modelKey():       "openrouter/gpt-5.4-mini"
    allowlist Set:        ["openrouter/gpt-5.4-mini"]
    OLD allowlist match:  false
    NEW allowlist match:  true

  --- Bare model id (existing happy path — must not regress) ---
    input:                provider=openai-codex, modelId=gpt-5.4-mini
    normalizeModelRef:    { provider: "openai-codex", model: "gpt-5.4-mini" }
    OLD interpolation:    "openai-codex/gpt-5.4-mini"
    NEW modelKey():       "openai-codex/gpt-5.4-mini"
    OLD == NEW:           true (no regression on the happy path)

  --- Provider-qualified id whose prefix differs from provider (must not strip) ---
    input:                provider=openrouter, modelId=openai/gpt-5.4-mini
    normalizeModelRef:    { provider: "openrouter", model: "openai/gpt-5.4-mini" }
    OLD interpolation:    "openrouter/openai/gpt-5.4-mini"
    NEW modelKey():       "openrouter/openai/gpt-5.4-mini"
    OLD == NEW:           true (modelKey only collapses when the modelId already starts with the provider)

   RUN  v4.1.7 /media/vdc/code/ai/openclaw
   Test Files  1 passed (1)
        Tests  19 passed (19)
  ```
- **Observed result after fix:** the OpenRouter-shaped selection now resolves to the actionable `openrouter/gpt-5.4-mini`, hits the user's allowlist, and the denial diagnostic (when the model is genuinely outside the allowlist) reports `"openrouter/gpt-5.5"` instead of `"openrouter/openrouter/gpt-5.5"`. The bare-id and prefix-mismatch shapes are unchanged.
- **What was not tested:** no known gaps

## Regression Test Plan

- Coverage level: Unit test (vitest)
- Target test file: `src/plugins/runtime/runtime-llm.runtime.test.ts`
- Scenario locked in: provider-qualified OpenRouter selection (`provider="openrouter"`, `modelId="openrouter/gpt-5.4-mini"`) — one case asserts the allowlist hit no longer doubles the prefix; a second case asserts the denial message contains `"openrouter/gpt-5.5"` and never `openrouter/openrouter/`.
- Why this is the smallest reliable guardrail: the bug is a string-format regression on the policy path; pinning both the hit and the denial message text keeps any future refactor from re-introducing the double prefix without forcing a heavyweight gateway-level fixture.

## Root Cause

- Root cause: `normalizeAllowedModelRef()` and the resolved-override formatter both rebuilt a model ref via `${normalized.provider}/${normalized.model}` after `normalizeModelRef()`, and `normalizeModelRef()` does not collapse a provider segment that the modelId already carries (its job is to normalize provider/model ids, not to dedupe the prefix). The allowlist Set therefore stored `openrouter/openrouter/gpt-5.4-mini` while the user-facing actionable ref was `openrouter/gpt-5.4-mini`.
- Missing detection / guardrail: there was no test on the runtime LLM policy path that exercised a selection whose modelId already begins with the provider — every existing case used bare ids like `openai-codex/gpt-5.4-mini`. The new tests close that gap by pinning the OpenRouter shape on both the hit and denial paths.
