### PR TITLE
fix(agents): bound embedded compaction write locks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Codex app-server: disable native Code Mode when the effective exec host is `node` and keep OpenClaw `exec`/`process` available, so `/exec host=node` routes shell commands through the selected node instead of the gateway. Fixes #85012. (#85090) Thanks @sahilsatralkar.
+- Agents: bound embedded auto-compaction session write-lock watchdogs to the compaction timeout instead of the full run timeout, so stuck compaction cannot hold the live session lock for the whole run window. (#84949) Thanks @luoyanglang.
 - Gateway: defer provider auth-state prewarm until after startup readiness so early gateway tool/session requests are not blocked by provider auth discovery. (#85272) Thanks @dutifulbob.
 - Agents/Codex: show the first plan update as a transient chat status notice without counting it as final assistant content.
 - CLI/update: walk the macOS process ancestry and honor the inherited Gateway runtime PID before package updates stop the managed Gateway service, so nested in-band updater children can refuse instead of killing the LaunchAgent-supervised Gateway that owns them. Fixes #85120.

--- a/src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts
@@ -89,6 +89,34 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(events).toEqual(["prep-release", "post-write", "post-release"]);
   });
 
+  it("keeps settled compaction hooks on the normal acquire-and-release path", async () => {
+    const events: string[] = [];
+    const acquireSessionWriteLock = vi
+      .fn()
+      .mockResolvedValueOnce({ release: vi.fn(async () => events.push("prep-release")) })
+      .mockResolvedValueOnce({ release: vi.fn(async () => events.push("compact-release")) });
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions,
+    });
+    const session = {
+      compact: vi.fn(async () => {
+        events.push("compact");
+      }),
+    };
+
+    installSessionExternalHookWriteLock({
+      session,
+      withSessionWriteLock: controller.withSessionWriteLock,
+    });
+
+    await controller.releaseForPrompt();
+    await session.compact();
+
+    expect(acquireSessionWriteLock).toHaveBeenCalledTimes(2);
+    expect(events).toEqual(["prep-release", "compact", "compact-release"]);
+  });
+
   it("reuses its active post-prompt lock for nested session writes", async () => {
     const events: string[] = [];
     const sessionFile = await createTempSessionFile();

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -131,6 +131,18 @@ describe("buildEmbeddedAttemptToolRunContext", () => {
   });
 });
 
+describe("resolveEmbeddedAttemptSessionWriteLockOptions", () => {
+  it("bounds post-prompt session lock max hold to compaction timeout instead of run timeout", () => {
+    const options = attemptTesting.resolveEmbeddedAttemptSessionWriteLockOptions({
+      config: {},
+      compactionTimeoutMs: 600_000,
+      env: {},
+    });
+
+    expect(options.maxHoldMs).toBe(720_000);
+  });
+});
+
 describe("buildCallableToolNamesForEmptyAllowlistCheck", () => {
   it("ignores auto-added Tool Search controls so bad allowlists still fail", () => {
     expect(

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -796,6 +796,9 @@ function resolveEmbeddedAttemptSessionWriteLockOptions(params: {
   compactionTimeoutMs: number;
   env?: NodeJS.ProcessEnv;
 }): { timeoutMs: number; staleMs: number; maxHoldMs: number } {
+  // Bound embedded-attempt lock holds to the compaction window, not the full run timeout.
+  // With defaults this permits roughly 900s compaction time plus the shared 120s
+  // timeout grace before the watchdog releases a stuck live-process lock.
   return resolveSessionWriteLockOptions(params.config, {
     env: params.env,
     maxHoldMsFallback: resolveSessionLockMaxHoldFromTimeout({

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -8,7 +8,7 @@ import { isAcpRuntimeSpawnAvailable } from "../../../acp/runtime/availability.js
 import { buildHierarchyReinforcementMessage } from "../../../auto-reply/handoff-summarizer.js";
 import { filterHeartbeatTranscriptArtifacts } from "../../../auto-reply/heartbeat-filter.js";
 import { stripInboundMetadata } from "../../../auto-reply/reply/strip-inbound-meta.js";
-import { getRuntimeConfig } from "../../../config/config.js";
+import { getRuntimeConfig, type OpenClawConfig } from "../../../config/config.js";
 import { resolveStorePath } from "../../../config/sessions/paths.js";
 import {
   loadSessionStore,
@@ -372,7 +372,6 @@ import { resolveAttemptTranscriptPolicy } from "./attempt.transcript-policy.js";
 import { waitForCompactionRetryWithAggregateTimeout } from "./compaction-retry-aggregate-timeout.js";
 import {
   resolveRunTimeoutDuringCompaction,
-  resolveRunTimeoutWithCompactionGraceMs,
   selectCompactionTimeoutSnapshot,
   shouldFlagCompactionTimeout,
 } from "./compaction-timeout.js";
@@ -787,9 +786,23 @@ async function cancelQueuedSteeringMessage(
 
 export const testing = {
   cancelQueuedSteeringMessage,
+  resolveEmbeddedAttemptSessionWriteLockOptions,
   resolveAttemptStreamAuthProfileId,
   steerAndWaitForTranscriptCommit,
 };
+
+function resolveEmbeddedAttemptSessionWriteLockOptions(params: {
+  config?: OpenClawConfig;
+  compactionTimeoutMs: number;
+  env?: NodeJS.ProcessEnv;
+}): { timeoutMs: number; staleMs: number; maxHoldMs: number } {
+  return resolveSessionWriteLockOptions(params.config, {
+    env: params.env,
+    maxHoldMsFallback: resolveSessionLockMaxHoldFromTimeout({
+      timeoutMs: params.compactionTimeoutMs,
+    }),
+  });
+}
 
 function resolveAttemptStreamAuthProfileId(
   params: Pick<EmbeddedRunAttemptParams, "authProfileId" | "runtimePlan">,
@@ -2069,13 +2082,10 @@ export async function runEmbeddedAttempt(
     let systemPromptText = systemPromptOverride();
     prepStages.mark("system-prompt");
 
-    const sessionWriteLockOptions = resolveSessionWriteLockOptions(params.config, {
-      maxHoldMsFallback: resolveSessionLockMaxHoldFromTimeout({
-        timeoutMs: resolveRunTimeoutWithCompactionGraceMs({
-          runTimeoutMs: params.timeoutMs,
-          compactionTimeoutMs: resolveCompactionTimeoutMs(params.config),
-        }),
-      }),
+    const compactionTimeoutMs = resolveCompactionTimeoutMs(params.config);
+    const sessionWriteLockOptions = resolveEmbeddedAttemptSessionWriteLockOptions({
+      config: params.config,
+      compactionTimeoutMs,
     });
     const sessionLockController = await createEmbeddedAttemptSessionLockController({
       acquireSessionWriteLock,


### PR DESCRIPTION
Embedded auto-compaction can leave a live Gateway process holding a session write lock for the run-timeout window when the compaction promise does not settle, freezing the session without self-recovery.

Derived from a production incident; no matching upstream issue was found during the pre-push coverage search.

## Affected Surface

- `src/agents/pi-embedded-runner/run/attempt.ts`
  - `runEmbeddedAttempt`
  - `resolveEmbeddedAttemptSessionWriteLockOptions`
- `src/agents/pi-embedded-runner/run/attempt.test.ts`
- `src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts`

## Scope

This adjusts the embedded attempt session write-lock watchdog fallback so post-prompt compaction/session writes use the existing compaction timeout as their bounded fallback instead of inheriting the full run timeout.

This does not add a config field, does not change the global `session.writeLock.maxHoldMs` default, and does not remove locks externally. Explicit `session.writeLock.maxHoldMs` configuration and environment overrides still flow through `resolveSessionWriteLockOptions`.

## Real behavior proof

Behavior or issue addressed: embedded auto-compaction no longer makes the session write-lock watchdog inherit the full run-timeout window; the fallback is bounded by the existing compaction timeout.

Real environment tested: local OpenClaw source checkout on Linux using the actual patched runtime module and local targeted test runner.

Exact steps or command run after this patch:

```text
node --import tsx -e "import { testing } from './src/agents/pi-embedded-runner/run/attempt.ts'; console.log(JSON.stringify(testing.resolveEmbeddedAttemptSessionWriteLockOptions({ config: {}, compactionTimeoutMs: 600000, env: {} })))"
pnpm test src/agents/session-write-lock.test.ts src/agents/pi-embedded-runner/run/attempt.test.ts src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts
pnpm check:changed --base origin/main
```

Evidence after fix:

```text
$ node --import tsx -e "import { testing } from './src/agents/pi-embedded-runner/run/attempt.ts'; console.log(JSON.stringify(testing.resolveEmbeddedAttemptSessionWriteLockOptions({ config: {}, compactionTimeoutMs: 600000, env: {} })))"
{"timeoutMs":60000,"staleMs":1800000,"maxHoldMs":720000}
```

The copied live output comes from the patched OpenClaw runtime module. It shows the embedded attempt write-lock fallback resolves to `720000` ms for a `600000` ms compaction timeout rather than the default 48h run-timeout scale.

Observed result after fix: the embedded attempt session write-lock options now keep the standard acquire timeout and stale policy while bounding `maxHoldMs` to `compactionTimeoutMs + grace` through the existing `resolveSessionWriteLockOptions` / `resolveSessionLockMaxHoldFromTimeout` path.

What was not tested: a live Telegram or Weixin long-session reproduction was not re-run locally; the production incident evidence is included only as a redacted summary below.

### RED/GREEN regression

Before the fix, the new regression failed because the embedded attempt helper did not exist and the call site still derived `maxHoldMsFallback` from the run timeout plus compaction grace:

```text
$ pnpm test src/agents/pi-embedded-runner/run/attempt.test.ts -t resolveEmbeddedAttemptSessionWriteLockOptions
...
FAIL  |agents| src/agents/pi-embedded-runner/run/attempt.test.ts > resolveEmbeddedAttemptSessionWriteLockOptions > bounds post-prompt session lock max hold to compaction timeout instead of run timeout
TypeError: testing.resolveEmbeddedAttemptSessionWriteLockOptions is not a function
...
Test Files  1 failed (1)
Tests  1 failed | 145 skipped (146)
```

After the fix:

```text
$ pnpm test src/agents/session-write-lock.test.ts src/agents/pi-embedded-runner/run/attempt.test.ts src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts

Test Files  3 passed (3)
Tests  195 passed (195)
[test] passed 1 Vitest shard in 35.25s
```

The new regression covers the 48h default run-timeout shape by asserting a 600000ms compaction timeout resolves to a 720000ms write-lock fallback, rather than a run-timeout-scale hold. The companion lifecycle test confirms a normally settling `session.compact()` still takes and releases the post-prompt write lock on the existing path.

### Production incident summary (redacted)

- T+0: embedded auto-compaction started for a long-lived direct session with a very large accumulated context.
- T+56m: no compaction complete event had appeared.
- The Gateway process was still alive and held an fd open for `<workspace>/agents/<agent>/sessions/<session-id>.jsonl.lock`.
- The lock payload shape was `{ "pid": "<redacted-pid>", "createdAt": "<redacted-timestamp>", "starttime": "<redacted-starttime>" }`.
- At the same time, `<session-id>.jsonl` was missing while `<session-id>.trajectory.jsonl` still existed, so the held lock was protecting a zombie transcript target.
- Restarting the Gateway released the lock, which restored the channel entry point.

Redacted fields: host/IP, real PID, real session id, full home path, Telegram identifiers, provider/model config, and raw transcript/trajectory content.

## Coverage Note

Pre-push open PR searches were run with independent queries and no `OR` syntax:

```text
gh search prs --repo openclaw/openclaw --state open "Fixes session write lock" --json number,title,url,body,updatedAt
[]

gh search prs --repo openclaw/openclaw --state open "session write lock embedded compaction" --json number,title,url,body,updatedAt
[]

gh search prs --repo openclaw/openclaw --state open "compaction promise unsettled" --json number,title,url,body,updatedAt
[]

gh search prs --repo openclaw/openclaw --state open "attempt session lock watchdog" --json number,title,url,body,updatedAt
[]

gh search prs --repo openclaw/openclaw --state open "pi-embedded-runner write lock" --json number,title,url,body,updatedAt
[]
```

No open PR was found covering the embedded compaction write-lock watchdog path.

## Verification

```text
$ pnpm test src/agents/session-write-lock.test.ts src/agents/pi-embedded-runner/run/attempt.test.ts src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts

Test Files  3 passed (3)
Tests  195 passed (195)
[test] passed 1 Vitest shard in 35.25s
```

```text
$ pnpm check:changed --base origin/main
[check:changed] lanes=core, coreTests
[check:changed] conflict markers
[check:changed] changelog attributions
[check:changed] guarded extension wildcard re-exports
[check:changed] plugin-sdk wildcard re-exports
[check:changed] duplicate scan target coverage
[check:changed] dependency pin guard
[check:changed] package patch guard
[check:changed] typecheck core
[check:changed] typecheck core tests
[check:changed] lint core
[check:changed] media download helper guard
[check:changed] runtime sidecar loader guard
[check:changed] runtime import cycles
[check:changed] webhook body guard
[check:changed] pairing store guard
[check:changed] pairing account guard
```

```text
$ git diff --check origin/main..HEAD
<no output>

$ node scripts/check-no-conflict-markers.mjs
<no output>

$ gitleaks protect --staged --redact
no leaks found
```

## What Was Not Tested

- A live Telegram or Weixin long-session reproduction was not re-run locally.
- The production host evidence was used only in redacted summary form; raw configs, transcript, trajectory, host identifiers, and channel identifiers were not copied into this PR.
