### PR TITLE
fix(gateway): surface resolved chat errors

### DIFF
--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -31,6 +31,7 @@ const mockState = vi.hoisted(() => ({
     replyToId?: string;
     replyToCurrent?: boolean;
     isReasoning?: boolean;
+    isError?: boolean;
   } | null,
   dispatchedReplies: [] as Array<{
     kind: "tool" | "block" | "final";
@@ -45,6 +46,7 @@ const mockState = vi.hoisted(() => ({
       replyToId?: string;
       replyToCurrent?: boolean;
       isReasoning?: boolean;
+      isError?: boolean;
     };
   }>,
   dispatchError: null as Error | null,
@@ -744,6 +746,78 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
 
     const register = context.registerToolEventRecipient as unknown as ReturnType<typeof vi.fn>;
     expect(register).not.toHaveBeenCalled();
+  });
+
+  it("broadcasts agent-run error payloads when the dispatch promise resolves", async () => {
+    createTranscriptFixture("openclaw-chat-send-agent-error-payload-");
+    mockState.triggerAgentRunStart = true;
+    mockState.dispatchedReplies = [
+      {
+        kind: "final",
+        payload: {
+          text: "LLM idle timeout (120s): no response from model",
+          isError: true,
+        },
+      },
+    ];
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    const payload = await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-agent-error-payload",
+    });
+
+    expect(payload).toMatchObject({
+      runId: "idem-agent-error-payload",
+      sessionKey: "main",
+      state: "error",
+      errorMessage: "LLM idle timeout (120s): no response from model",
+    });
+    const nodePayload = mockCallAt(
+      context.nodeSendToSession as unknown as ReturnType<typeof vi.fn>,
+      0,
+    )?.[2];
+    expect(nodePayload).toMatchObject({
+      runId: "idem-agent-error-payload",
+      state: "error",
+      errorMessage: "LLM idle timeout (120s): no response from model",
+    });
+  });
+
+  it("joins multiple agent-run error payloads before broadcasting", async () => {
+    createTranscriptFixture("openclaw-chat-send-agent-error-payloads-");
+    mockState.triggerAgentRunStart = true;
+    mockState.dispatchedReplies = [
+      {
+        kind: "block",
+        payload: {
+          text: "first timeout",
+          isError: true,
+        },
+      },
+      {
+        kind: "final",
+        payload: {
+          text: "second timeout",
+          isError: true,
+        },
+      },
+    ];
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    const payload = await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-agent-error-payloads",
+    });
+
+    expect(payload).toMatchObject({
+      state: "error",
+      errorMessage: "first timeout | second timeout",
+    });
   });
 
   it("persists agent-run audio replies emitted as media-bearing block payloads", async () => {

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -65,6 +65,7 @@ const mockState = vi.hoisted(() => ({
     message?: unknown;
     messageId?: string;
   }>,
+  eventOrder: [] as string[],
   savedMediaResults: [] as Array<{ path: string; contentType?: string }>,
   saveMediaError: null as Error | null,
   savedMediaCalls: [] as Array<{ contentType?: string; subdir?: string; size: number }>,
@@ -254,6 +255,10 @@ vi.mock("../../sessions/transcript-events.js", () => ({
       messageId?: string;
     }) => {
       mockState.emittedTranscriptUpdates.push(update);
+      const message = update.message as { role?: unknown } | undefined;
+      if (message?.role === "user") {
+        mockState.eventOrder.push("user-transcript");
+      }
     },
   ),
 }));
@@ -517,7 +522,11 @@ function createChatContext(): Pick<
   | "logGateway"
 > {
   return {
-    broadcast: vi.fn() as unknown as GatewayRequestContext["broadcast"],
+    broadcast: vi.fn((event: string, payload: { state?: string }) => {
+      if (event === "chat" && payload.state === "error") {
+        mockState.eventOrder.push("chat-error");
+      }
+    }) as unknown as GatewayRequestContext["broadcast"],
     nodeSendToSession: vi.fn() as unknown as GatewayRequestContext["nodeSendToSession"],
     agentRunSeq: new Map<string, number>(),
     chatAbortControllers: new Map(),
@@ -645,6 +654,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     mockState.lastDispatchImageOrder = undefined;
     mockState.modelCatalog = null;
     mockState.emittedTranscriptUpdates = [];
+    mockState.eventOrder = [];
     mockState.savedMediaResults = [];
     mockState.saveMediaError = null;
     mockState.savedMediaCalls = [];
@@ -784,6 +794,8 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       state: "error",
       errorMessage: "LLM idle timeout (120s): no response from model",
     });
+    expect(findUserUpdate()).toBeDefined();
+    expect(mockState.eventOrder).toEqual(["user-transcript", "chat-error"]);
   });
 
   it("joins multiple agent-run error payloads before broadcasting", async () => {

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -796,6 +796,27 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     });
     expect(findUserUpdate()).toBeDefined();
     expect(mockState.eventOrder).toEqual(["user-transcript", "chat-error"]);
+
+    (context.broadcast as unknown as ReturnType<typeof vi.fn>).mockClear();
+    respond.mockClear();
+    await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-agent-error-payload",
+      waitFor: "none",
+    });
+
+    const replay = lastRespondCall(respond);
+    expect(replay?.[0]).toBe(false);
+    expect(replay?.[1]).toMatchObject({
+      runId: "idem-agent-error-payload",
+      status: "error",
+      summary: "LLM idle timeout (120s): no response from model",
+    });
+    expect(responseErrorMessage(replay?.[2])).toBe(
+      "LLM idle timeout (120s): no response from model",
+    );
+    expect(context.broadcast).not.toHaveBeenCalled();
   });
 
   it("joins multiple agent-run error payloads before broadcasting", async () => {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -380,6 +380,18 @@ type SideResultPayload = {
   ts: number;
 };
 
+function buildDeliveredReplyErrorMessage(
+  deliveredReplies: Array<{ payload: ReplyPayload }>,
+): string | undefined {
+  const message = deliveredReplies
+    .filter((entry) => entry.payload.isError === true)
+    .map((entry) => entry.payload.text?.trim())
+    .filter((text): text is string => Boolean(text))
+    .join(" | ")
+    .trim();
+  return message || undefined;
+}
+
 function buildTranscriptReplyText(payloads: ReplyPayload[]): string {
   const chunks = payloads
     .map((payload) => {
@@ -2689,6 +2701,7 @@ export const chatHandlers: GatewayRequestHandlers = {
               // duplicate normal Pi assistant turns. The non-agent branch below has no Pi
               // assistant turn, so it appends a gateway-injected assistant entry before
               // broadcasting the final UI event.
+              let deliveredReplyErrorMessage: string | undefined;
               if (!agentRunStarted) {
                 await emitUserTranscriptUpdate();
                 const btwReplies = deliveredReplies
@@ -2879,12 +2892,23 @@ export const chatHandlers: GatewayRequestHandlers = {
                     message,
                   });
                 }
-              } else if (!hasBeforeAgentRunGate) {
-                await emitUserTranscriptUpdate().catch((transcriptErr) => {
-                  context.logGateway.warn(
-                    `webchat user transcript update failed after agent run: ${formatForLog(transcriptErr)}`,
-                  );
-                });
+              } else {
+                const errorMessage = buildDeliveredReplyErrorMessage(deliveredReplies);
+                if (errorMessage) {
+                  deliveredReplyErrorMessage = errorMessage;
+                  broadcastChatError({
+                    context,
+                    runId: clientRunId,
+                    sessionKey,
+                    errorMessage,
+                  });
+                } else if (!hasBeforeAgentRunGate) {
+                  await emitUserTranscriptUpdate().catch((transcriptErr) => {
+                    context.logGateway.warn(
+                      `webchat user transcript update failed after agent run: ${formatForLog(transcriptErr)}`,
+                    );
+                  });
+                }
               }
               if (!context.chatAbortedRuns.has(clientRunId)) {
                 setGatewayDedupeEntry({
@@ -2892,8 +2916,14 @@ export const chatHandlers: GatewayRequestHandlers = {
                   key: `chat:${clientRunId}`,
                   entry: {
                     ts: Date.now(),
-                    ok: true,
-                    payload: { runId: clientRunId, status: "ok" as const },
+                    ok: deliveredReplyErrorMessage === undefined,
+                    payload: deliveredReplyErrorMessage
+                      ? {
+                          runId: clientRunId,
+                          status: "error" as const,
+                          summary: deliveredReplyErrorMessage,
+                        }
+                      : { runId: clientRunId, status: "ok" as const },
                   },
                 });
               }

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -2931,6 +2931,9 @@ export const chatHandlers: GatewayRequestHandlers = {
                           summary: deliveredReplyErrorMessage,
                         }
                       : { runId: clientRunId, status: "ok" as const },
+                    ...(deliveredReplyErrorMessage
+                      ? { error: errorShape(ErrorCodes.UNAVAILABLE, deliveredReplyErrorMessage) }
+                      : {}),
                   },
                 });
               }

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -2896,6 +2896,13 @@ export const chatHandlers: GatewayRequestHandlers = {
                 const errorMessage = buildDeliveredReplyErrorMessage(deliveredReplies);
                 if (errorMessage) {
                   deliveredReplyErrorMessage = errorMessage;
+                  if (!hasBeforeAgentRunGate) {
+                    await emitUserTranscriptUpdate().catch((transcriptErr) => {
+                      context.logGateway.warn(
+                        `webchat user transcript update failed after agent run: ${formatForLog(transcriptErr)}`,
+                      );
+                    });
+                  }
                   broadcastChatError({
                     context,
                     runId: clientRunId,


### PR DESCRIPTION
## Summary
- Broadcast `state: "error"` when a completed agent run delivered `isError` reply payloads, covering idle-timeout failures that resolve instead of throw.
- Preserve the error outcome in the chat dedupe entry and add regression coverage for single and multiple delivered error payloads.
- Preserve the existing user transcript update await/catch path before broadcasting the terminal chat error.

Fixes #84945

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: A completed gateway/ACP agent run can deliver a resolved reply payload with `isError: true` (for example `LLM idle timeout (120s): no response from model`). After this patch, that path emits a terminal chat event with `state: "error"` instead of leaving the web chat stuck as an in-progress run, and it still emits the user transcript update before the terminal error broadcast.
- Real environment tested: Local OpenClaw checkout on Linux, branch `feat/issue-84945`, head `c26ee4098bc851a0f1ee5ef3f36888f69b2f3db6`, Node via repository scripts. The repro exercised the gateway chat send path with an ACP-style delivered error payload.
- Exact steps or command run after this patch:
  1. `node scripts/run-vitest.mjs src/gateway/server-methods/chat.directive-tags.test.ts`
  2. `node scripts/run-vitest.mjs src/gateway/server.chat.gateway-server-chat.test.ts`
  3. `git diff --check`
  4. `node scripts/check-changed.mjs`
- Evidence after fix (terminal capture / copied live output):

```text
Resolved ACP delivered-error payload replayed through gateway chat send:
  delivered reply payload: { text: "LLM idle timeout (120s): no response from model", isError: true }
  observed terminal chat event: { runId: "idem-agent-error-payload", sessionKey: "main", state: "error", errorMessage: "LLM idle timeout (120s): no response from model" }
  observed event order: ["user-transcript", "chat-error"]

Command output after the patch:
  node scripts/run-vitest.mjs src/gateway/server-methods/chat.directive-tags.test.ts
  Test Files  2 passed (2)
  Tests       154 passed (154)

  node scripts/run-vitest.mjs src/gateway/server.chat.gateway-server-chat.test.ts
  Test Files  1 passed (1)
  Tests       24 passed (24)

  git diff --check
  completed with no output

  node scripts/check-changed.mjs
  conflict markers: pass
  changelog attributions: pass
  typecheck all: pass
  lint: pass
  runtime import cycles: 0 runtime value cycle(s)
```

- Observed result after fix: The delivered error payload now produces a visible terminal `chat` broadcast with `state: "error"` and the exact idle-timeout message, and the user transcript update is observed before the error broadcast.
- What was not tested: A live remote provider/network idle timeout against real credentials was not triggered; the local run used the same ACP delivered-error payload shape deterministically to avoid spending external provider quota.

## Test plan
- [x] `node scripts/run-vitest.mjs src/gateway/server-methods/chat.directive-tags.test.ts`
- [x] `node scripts/run-vitest.mjs src/gateway/server.chat.gateway-server-chat.test.ts`
- [x] `git diff --check`
- [x] `node scripts/check-changed.mjs`