### PR TITLE
fix(codex): beta blocker - keep context engine on canonical session key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Docs: https://docs.openclaw.ai
 - CLI/perf: keep `agents --help` out of agents action/runtime imports so help, completion, and command discovery paths avoid loading the full agents runtime. (#84483) Thanks @frankekn.
 - CLI/perf: keep `secrets --help` and `nodes --help` on the precomputed help path so parent help avoids loading action-heavy command runtime modules. (#84818) Thanks @frankekn.
 - CLI/perf: serve `doctor`, `gateway`, `models`, and `plugins` parent help from startup metadata so common subcommand help avoids full CLI program construction. (#84786) Thanks @frankekn.
+- Codex/Lossless: keep context-engine history on the canonical run session when Telegram DMs use per-peer runtime policy keys. Fixes #84936. (#84954) Thanks @neeravmakwana.
 
 ## 2026.5.20
 

--- a/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
@@ -348,6 +348,39 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
     expect(openSpy).not.toHaveBeenCalled();
   });
 
+  it("keeps context-engine history bound to the run session when sandbox key differs", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    SessionManager.open(sessionFile).appendMessage(
+      assistantMessage("canonical main context", Date.now()) as never,
+    );
+    const contextEngine = createContextEngine();
+    const harness = createStartedThreadHarness();
+    const params = createParams(sessionFile, workspaceDir);
+    params.sessionKey = "agent:main:main";
+    params.sandboxSessionKey = "agent:main:telegram:default:direct:12345";
+    params.contextEngine = contextEngine;
+
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("turn/start");
+
+    if (!contextEngine.bootstrap) {
+      throw new Error("expected bootstrap hook");
+    }
+    const bootstrapParams = requireFirstCallArg(contextEngine.bootstrap, "bootstrap") as Parameters<
+      NonNullable<ContextEngine["bootstrap"]>
+    >[0];
+    expect(bootstrapParams.sessionKey).toBe("agent:main:main");
+
+    const assembleParams = requireFirstCallArg(contextEngine.assemble, "assemble") as Parameters<
+      ContextEngine["assemble"]
+    >[0];
+    expect(assembleParams.sessionKey).toBe("agent:main:main");
+
+    await harness.completeTurn();
+    await run;
+  });
+
   it("uses the runtime token budget for large Codex context-engine projections", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -808,6 +808,7 @@ export async function runCodexAppServerAttempt(
   await fs.mkdir(resolvedWorkspace, { recursive: true });
   const sandboxSessionKey =
     params.sandboxSessionKey?.trim() || params.sessionKey?.trim() || params.sessionId;
+  const contextSessionKey = params.sessionKey?.trim() || sandboxSessionKey;
   const sandbox = await resolveSandboxContext({
     config: params.config,
     sessionKey: sandboxSessionKey,
@@ -882,7 +883,7 @@ export async function runCodexAppServerAttempt(
       });
   const runtimeParams = {
     ...params,
-    sessionKey: sandboxSessionKey,
+    sessionKey: contextSessionKey,
     ...(startupAuthProfileId ? { authProfileId: startupAuthProfileId } : {}),
   };
   let activeSessionId = params.sessionId;
@@ -1000,7 +1001,7 @@ export async function runCodexAppServerAttempt(
       hadSessionFile,
       contextEngine: activeContextEngine,
       sessionId: activeSessionId,
-      sessionKey: sandboxSessionKey,
+      sessionKey: contextSessionKey,
       sessionFile: activeSessionFile,
       runtimeContext: buildActiveContextEngineRuntimeContext(),
       runMaintenance: runHarnessContextEngineMaintenance,
@@ -1014,7 +1015,7 @@ export async function runCodexAppServerAttempt(
     params,
     resolvedWorkspace,
     effectiveWorkspace,
-    sessionKey: sandboxSessionKey,
+    sessionKey: contextSessionKey,
     sessionAgentId,
   });
   const baseDeveloperInstructions = joinPresentSections(
@@ -1047,7 +1048,7 @@ export async function runCodexAppServerAttempt(
     const assembled = await assembleHarnessContextEngine({
       contextEngine: activeContextEngine,
       sessionId: activeSessionId,
-      sessionKey: sandboxSessionKey,
+      sessionKey: contextSessionKey,
       messages: historyMessages,
       tokenBudget: params.contextTokenBudget,
       availableTools: new Set(toolBridge.specs.map((tool) => tool.name).filter(isNonEmptyString)),
@@ -1087,7 +1088,7 @@ export async function runCodexAppServerAttempt(
       : { project: true, reason: "per-turn-projection" };
     embeddedAgentLog.info("codex app-server context-engine projection decision", {
       sessionId: params.sessionId,
-      sessionKey: sandboxSessionKey,
+      sessionKey: contextSessionKey,
       engineId: activeContextEngine.info.id,
       mode: contextEngineProjection?.mode ?? assembled.contextProjection?.mode ?? "per_turn",
       epoch: contextEngineProjection?.epoch,
@@ -1148,7 +1149,7 @@ export async function runCodexAppServerAttempt(
   };
   const systemPromptReport = buildCodexSystemPromptReport({
     attempt: params,
-    sessionKey: sandboxSessionKey,
+    sessionKey: contextSessionKey,
     workspaceDir: effectiveWorkspace,
     developerInstructions: promptBuild.developerInstructions,
     workspaceBootstrapContext,
@@ -2254,7 +2255,7 @@ export async function runCodexAppServerAttempt(
       "codex app-server context-engine turn overflowed; forcing context-engine compaction",
       {
         sessionId: activeSessionId,
-        sessionKey: sandboxSessionKey,
+        sessionKey: contextSessionKey,
         threadId: thread.threadId,
         engineId: activeContextEngine.info.id,
         tokenBudget: params.contextTokenBudget,
@@ -2273,7 +2274,7 @@ export async function runCodexAppServerAttempt(
         activeContextEngine,
         {
           sessionId: activeSessionId,
-          sessionKey: sandboxSessionKey,
+          sessionKey: contextSessionKey,
           sessionFile: activeSessionFile,
           tokenBudget: params.contextTokenBudget,
           force: true,
@@ -2291,7 +2292,7 @@ export async function runCodexAppServerAttempt(
       );
       embeddedAgentLog.info("codex app-server context-engine forced compaction result", {
         sessionId: activeSessionId,
-        sessionKey: sandboxSessionKey,
+        sessionKey: contextSessionKey,
         engineId: activeContextEngine.info.id,
         ok: compactResult.ok,
         compacted: compactResult.compacted,
@@ -2307,7 +2308,7 @@ export async function runCodexAppServerAttempt(
       await runHarnessContextEngineMaintenance({
         contextEngine: activeContextEngine,
         sessionId: activeSessionId,
-        sessionKey: sandboxSessionKey,
+        sessionKey: contextSessionKey,
         sessionFile: activeSessionFile,
         reason: "compaction",
         runtimeContext: maintenanceRuntimeContext,
@@ -2317,7 +2318,7 @@ export async function runCodexAppServerAttempt(
     } catch (compactErr) {
       embeddedAgentLog.warn("codex app-server context-engine forced compaction failed", {
         sessionId: params.sessionId,
-        sessionKey: sandboxSessionKey,
+        sessionKey: contextSessionKey,
         engineId: activeContextEngine.info.id,
         error: formatErrorMessage(compactErr),
       });
@@ -2682,7 +2683,7 @@ export async function runCodexAppServerAttempt(
       params,
       agentId: sessionAgentId,
       result,
-      sessionKey: sandboxSessionKey,
+      sessionKey: contextSessionKey,
       threadId: thread.threadId,
       turnId: activeTurnId,
     });
@@ -2715,7 +2716,7 @@ export async function runCodexAppServerAttempt(
         aborted: finalAborted,
         yieldAborted: Boolean(result.yieldDetected),
         sessionIdUsed: activeSessionId,
-        sessionKey: sandboxSessionKey,
+        sessionKey: contextSessionKey,
         sessionFile: activeSessionFile,
         messagesSnapshot: finalMessages,
         prePromptMessageCount,


### PR DESCRIPTION
## Summary

- Problem: Telegram DM runs can carry a per-peer `runtimePolicySessionKey` for sandbox/runtime policy decisions, and Codex was reusing that key for context-engine history.
- Solution: keep a separate `contextSessionKey` derived from the canonical run `sessionKey`, and use it for context-engine/bootstrap/finalization surfaces.
- What changed: Codex context-engine calls, workspace bootstrap context, prompt reporting, compaction/maintenance, transcript mirroring, and finalization now use the canonical context session key.
- What did NOT change (scope boundary): sandbox resolution, tool/runtime policy scoping, channel routing, Telegram allowlisting, model selection, and provider/network behavior are unchanged.

## Motivation

- Closes #84936. This fixes the beta-blocking failure mode where a per-peer runtime policy key can leak into LCM/context-engine lookup and make Telegram DMs select the wrong or stale conversation history.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #84936
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Telegram DM dispatch should keep the conversation/context session on `agent:main:main` even when runtime policy derives a per-peer Telegram key.
- Real environment tested: local OpenClaw gateway on macOS with only Telegram enabled in an isolated temporary config/state directory; bot token was loaded from local `.env` and not printed; Telegram DM sender was allowlisted by numeric ID.
- Exact steps or command run after this patch:
  1. Built and ran the patched local gateway with a Telegram-only config.
  2. Sent one unique Telegram DM from the allowlisted user to the local bot.
  3. Captured verbose gateway/runtime logs and checked for canonical `sessionKey=agent:main:main` on dispatch, compaction checks, embedded pre-prompt diagnostics, and completion.
- Evidence after fix (redacted runtime log):

```text
Focused regression:
- pnpm test src/auto-reply/reply/runtime-policy-session-key.test.ts extensions/codex/src/app-server/run-attempt.context-engine.test.ts -- --reporter=verbose
- Passed: 2 Vitest shards, 21 tests.
- New regression: keeps context-engine history bound to the run session when sandbox key differs.

Redacted live Telegram gateway logs from the patched local build:

2026-05-21T08:54:56.797-04:00 [gateway] agent model: google/gemini-2.5-flash (thinking=medium, fast=off)
2026-05-21T08:54:56.798-04:00 [gateway] http server listening (10 plugins: acpx, bonjour, browser, canvas, device-pair, file-transfer, memory-core, phone-control, talk-voice, telegram; 4.9s)
2026-05-21T08:54:57.599-04:00 [telegram] [default] starting provider (@openclaw_local_telegram_bot)
2026-05-21T08:54:58.026-04:00 [gateway] ready

2026-05-21T08:55:42.819-04:00 [telegram] update: {"update_id":580665149,"message":{"message_id":53,"from":"[redacted]","chat":{"id":"[redacted]","first_name":"[redacted]","username":"[redacted]","type":"private"},"date":1779368142,"text":"[redacted]"}}
2026-05-21T08:55:42.828-04:00 [routing] resolveAgentRoute: channel=telegram accountId=default peer=direct:<redacted-user-id> guildId=none teamId=none bindings=0
2026-05-21T08:55:42.860-04:00 [telegram] Inbound message telegram:<redacted-user-id> -> @openclaw_local_telegram_bot (direct, 30 chars)
2026-05-21T08:55:43.058-04:00 [diagnostic] message queued: sessionId=unknown sessionKey=agent:main:main source=dispatch queueDepth=1 sessionState=idle
2026-05-21T08:55:43.059-04:00 [diagnostic] session state: sessionId=unknown sessionKey=agent:main:main prev=idle new=processing reason="message_start" queueDepth=1

2026-05-21T08:55:59.208-04:00 preflightCompaction check: sessionKey=agent:main:main tokenCount=undefined contextWindow=200000 threshold=176000 ...
2026-05-21T08:55:59.218-04:00 memoryFlush check: sessionKey=agent:main:main tokenCount=undefined contextWindow=200000 threshold=176000 ...
2026-05-21T08:56:07.191-04:00 [diagnostic] session state: sessionId=<redacted-session-id> sessionKey=agent:main:main prev=processing new=processing reason="run_started" queueDepth=1
2026-05-21T08:56:07.212-04:00 [agent/embedded] [context-diag] pre-prompt: sessionKey=agent:main:main messages=0 roleCounts=none historyTextChars=0 ... provider=google/gemini-2.5-flash sessionFile=<redacted-session-file>
2026-05-21T08:56:07.215-04:00 [agent/embedded] [context-overflow-precheck] pre-prompt check sessionKey=agent:main:main provider=google/gemini-2.5-flash route=fits ...

2026-05-21T08:56:14.901-04:00 [diagnostic] message processed: channel=telegram chatId=telegram:<redacted-user-id> messageId=53 sessionId=unknown sessionKey=agent:main:main outcome=completed duration=32014ms
2026-05-21T08:56:14.903-04:00 [diagnostic] session state: sessionId=<redacted-session-id> sessionKey=agent:main:main prev=idle new=idle reason="message_completed" queueDepth=0

I also checked the proof log for sessionKey=agent:main:telegram... during this turn and did not find the per-peer Telegram key in the runtime/context lines above.
```

- Observed result after fix: the live Telegram DM stayed on canonical `sessionKey=agent:main:main` through queueing, run start, context diagnostics, and message completion. The focused Codex context-engine regression verifies bootstrap and assemble also receive `agent:main:main` when `sandboxSessionKey` differs.
- What was not tested: the isolated live proof config did not select Lossless/LCM as `plugins.slots.contextEngine`, so the exact LCM bootstrap/assemble split is covered by the focused regression rather than the Telegram proof run.
- Before evidence (optional but encouraged): source tracing showed `runtimePolicySessionKey` could be assigned to `sandboxSessionKey`, and Codex previously reused `sandboxSessionKey` for context-engine calls.

## Root Cause (if applicable)

- Root cause: `runCodexAppServerAttempt` used the sandbox session key as the effective `sessionKey` for context-engine and workspace-context surfaces. For Telegram DMs, that sandbox key can be a derived per-peer runtime policy key, not the canonical conversation key.
- Missing detection / guardrail: existing Codex context-engine tests did not cover the case where `sessionKey` and `sandboxSessionKey` intentionally differ.
- Contributing context: the runtime policy key is valid for sandbox/tool scoping, but context continuity needs the run session key.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/codex/src/app-server/run-attempt.context-engine.test.ts`
- Scenario the test should lock in: `sessionKey=agent:main:main` and `sandboxSessionKey=agent:main:telegram:default:direct:12345` still pass `agent:main:main` to context-engine bootstrap and assemble.
- Why this is the smallest reliable guardrail: it exercises the Codex app-server context-engine handoff directly without requiring a live provider or Telegram bot.
- Existing test that already covers this (if any): none before this PR.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Telegram DM runs that derive per-peer runtime policy keys keep context/history selection on the canonical run session. No config, defaults, CLI flags, or generated files change.

## Diagram (if applicable)

```text
Before:
Telegram DM -> runtimePolicySessionKey -> sandboxSessionKey -> context engine sessionKey -> possible stale/per-peer history

After:
Telegram DM -> runtimePolicySessionKey -> sandbox/tool policy only
Telegram DM -> canonical run sessionKey -> context engine sessionKey -> intended conversation history
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: N/A.

Security/runtime controls unchanged: sandbox resolution still receives `sandboxSessionKey`; runtime policy, tool selection, channel authorization, Telegram allowlisting, and provider credentials handling are unchanged. This PR only separates the context-engine session key from the runtime policy key.

## Repro + Verification

### Environment

- OS: macOS (darwin 25.3.0)
- Runtime/container: local Node/pnpm workspace, local OpenClaw gateway
- Model/provider: google/gemini-2.5-flash in the live proof; tests use mocked harnesses
- Integration/channel (if any): Telegram-only isolated gateway proof
- Relevant config (redacted): `channels.telegram.enabled=true`, `dmPolicy=allowlist`, only the proof Telegram user ID in `allowFrom`; other channels disabled; token loaded from `.env` without printing it

### Steps

1. Run focused policy-key and Codex context-engine tests.
2. Run changed-file checks.
3. Start patched local Telegram-only gateway in an isolated config/state directory.
4. Send a unique Telegram DM from the allowlisted user.
5. Inspect redacted runtime logs for the dispatch and embedded context session key.

### Expected

- Telegram DM runtime/context logs use `sessionKey=agent:main:main`.
- Codex context-engine bootstrap and assemble receive the canonical run session key even when `sandboxSessionKey` differs.
- Sandbox/tool policy remains scoped to the sandbox key.

### Actual

- Expected behavior observed in the focused regression and live Telegram proof logs above.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Exact checks run:

```text
git diff --check
pnpm test src/auto-reply/reply/runtime-policy-session-key.test.ts extensions/codex/src/app-server/run-attempt.context-engine.test.ts -- --reporter=verbose
pnpm check:changed
```

Results:

```text
git diff --check: passed
focused tests: passed, 2 Vitest shards, 21 tests
pnpm check:changed: passed; lanes=extensions, extensionTests
```

## Human Verification (required)

- Verified scenarios: direct Codex context-engine handoff when `sessionKey` and `sandboxSessionKey` differ; live Telegram DM dispatch through the patched gateway.
- Edge cases checked: proof log was checked for per-peer `sessionKey=agent:main:telegram...` in runtime/context lines, and none were found for the proof turn.
- What you did **not** verify: a full live Lossless/LCM Telegram run with `plugins.slots.contextEngine` set to Lossless; this remains covered by the focused regression test.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: N/A.

## Risks and Mitigations

- Risk: future Codex context-engine call sites might accidentally reintroduce sandbox key usage.
  - Mitigation: added a regression test that directly asserts context-engine bootstrap and assemble receive the canonical run session key when the sandbox key differs.

## Out of Scope

- Investigating the unrelated `EmbeddedAttemptSessionTakeoverError` seen after message-tool activity during live proof exploration.
- Adding a dedicated live LCM/Telegram E2E lane.
- Changing runtime policy, sandbox, tool, Telegram authorization, provider, config default, docs, or generated artifacts.

Made with [Cursor](https://cursor.com)