### PR TITLE
fix: gate codex migration doctor hint on provider availability

### DIFF
--- a/src/commands/doctor/shared/codex-native-assets.test.ts
+++ b/src/commands/doctor/shared/codex-native-assets.test.ts
@@ -1,11 +1,18 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { collectCodexNativeAssetWarnings, scanCodexNativeAssets } from "./codex-native-assets.js";
 
 const tempRoots = new Set<string>();
+const mocks = vi.hoisted(() => ({
+  resolvePluginMigrationProvider: vi.fn(),
+}));
+
+vi.mock("../../../plugins/migration-provider-runtime.js", () => ({
+  resolvePluginMigrationProvider: mocks.resolvePluginMigrationProvider,
+}));
 
 async function makeTempRoot(): Promise<string> {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-doctor-codex-assets-"));
@@ -44,6 +51,11 @@ afterEach(async () => {
     await fs.rm(root, { recursive: true, force: true });
   }
   tempRoots.clear();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.resolvePluginMigrationProvider.mockReturnValue(undefined);
 });
 
 describe("scanCodexNativeAssets", () => {
@@ -108,7 +120,33 @@ describe("scanCodexNativeAssets", () => {
 });
 
 describe("collectCodexNativeAssetWarnings", () => {
-  it("points users at explicit Codex migration instead of auto-copying native assets", async () => {
+  it("tells users to run doctor first when the Codex migration provider is unavailable", async () => {
+    const root = await makeTempRoot();
+    const codexHome = path.join(root, ".codex");
+    await writeFile(path.join(root, ".agents", "skills", "agent-helper", "SKILL.md"));
+
+    const warnings = await collectCodexNativeAssetWarnings({
+      cfg: codexConfig(),
+      env: { CODEX_HOME: codexHome, HOME: root },
+    });
+
+    expect(warnings).toStrictEqual([
+      [
+        "- Personal Codex CLI assets were found, but native Codex-mode OpenClaw agents use isolated per-agent Codex homes.",
+        `- Sources: ${codexHome} and ${path.join(root, ".agents", "skills")} (1 skill, 0 plugins, 0 config files, 0 hook files).`,
+        "- These assets will not be loaded by the Codex app-server child unless you intentionally promote them.",
+        "- Run `openclaw doctor --fix` first so OpenClaw can repair the configured Codex plugin install, then rerun `openclaw migrate codex --dry-run` to inventory them. Applying that migration copies skills into the current OpenClaw agent workspace; Codex plugins, hooks, and config stay manual-review only.",
+      ].join("\n"),
+    ]);
+  });
+
+  it("points users at explicit Codex migration when the provider is resolvable", async () => {
+    mocks.resolvePluginMigrationProvider.mockReturnValue({
+      id: "codex",
+      label: "Codex",
+      plan: vi.fn(),
+      apply: vi.fn(),
+    });
     const root = await makeTempRoot();
     const codexHome = path.join(root, ".codex");
     await writeFile(path.join(root, ".agents", "skills", "agent-helper", "SKILL.md"));

--- a/src/commands/doctor/shared/codex-native-assets.ts
+++ b/src/commands/doctor/shared/codex-native-assets.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { collectConfiguredAgentHarnessRuntimes } from "../../../agents/harness-runtimes.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import { resolvePluginMigrationProvider } from "../../../plugins/migration-provider-runtime.js";
 
 export type CodexNativeAssetHit = {
   kind: "skill" | "plugin" | "config" | "hooks";
@@ -181,6 +182,10 @@ function plural(count: number, singular: string): string {
   return `${count} ${singular}${count === 1 ? "" : "s"}`;
 }
 
+function canResolveCodexMigrationProvider(cfg: OpenClawConfig): boolean {
+  return resolvePluginMigrationProvider({ providerId: "codex", cfg }) !== undefined;
+}
+
 export async function collectCodexNativeAssetWarnings(params: {
   cfg: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
@@ -196,12 +201,15 @@ export async function collectCodexNativeAssetWarnings(params: {
     plural(countKind(hits, "config"), "config file"),
     plural(countKind(hits, "hooks"), "hook file"),
   ];
+  const migrationGuidance = canResolveCodexMigrationProvider(params.cfg)
+    ? "- Run `openclaw migrate codex --dry-run` to inventory them. Applying that migration copies skills into the current OpenClaw agent workspace; Codex plugins, hooks, and config stay manual-review only."
+    : "- Run `openclaw doctor --fix` first so OpenClaw can repair the configured Codex plugin install, then rerun `openclaw migrate codex --dry-run` to inventory them. Applying that migration copies skills into the current OpenClaw agent workspace; Codex plugins, hooks, and config stay manual-review only.";
   return [
     [
       "- Personal Codex CLI assets were found, but native Codex-mode OpenClaw agents use isolated per-agent Codex homes.",
       `- Sources: ${resolveCodexHome(env)} and ${resolvePersonalAgentSkillsDir(env)} (${counts.join(", ")}).`,
       "- These assets will not be loaded by the Codex app-server child unless you intentionally promote them.",
-      "- Run `openclaw migrate codex --dry-run` to inventory them. Applying that migration copies skills into the current OpenClaw agent workspace; Codex plugins, hooks, and config stay manual-review only.",
+      migrationGuidance,
     ].join("\n"),
   ];
 }


### PR DESCRIPTION
## Summary
- stop the Codex native-asset doctor warning from recommending `openclaw migrate codex --dry-run` when the `codex` migration provider cannot actually resolve
- switch the warning to tell users to run `openclaw doctor --fix` first in that provider-missing state
- add regression coverage for both provider-missing and provider-available warning paths

## Verification
- node scripts/run-vitest.mjs src/commands/doctor/shared/codex-native-assets.test.ts src/commands/migrate/providers.test.ts src/plugins/migration-provider-runtime.test.ts src/commands/doctor/shared/missing-configured-plugin-install.test.ts
- git diff --check
- ./node_modules/.bin/tsx <temp proof script> <repo> <temp home>

## Real behavior proof
Behavior addressed: `openclaw doctor` no longer points Codex users at `openclaw migrate codex --dry-run` when the `codex` migration provider is not currently resolvable, which previously led straight to `Unknown migration provider "codex"` in issue #84948.
Real environment tested: Local source checkout on May 21, 2026 using a temporary HOME/CODEX_HOME with a personal `~/.agents/skills/.../SKILL.md` asset and `OPENCLAW_DISABLE_BUNDLED_PLUGINS=1` so the `codex` migration provider was unavailable at runtime.
Exact steps or command run after this patch: `./node_modules/.bin/tsx "$tmpdir/proof.mjs" "$PWD" "$proof_root"` where `proof.mjs` imported `src/commands/doctor/shared/codex-native-assets.ts`, created a temporary personal Codex skill hit, and called `collectCodexNativeAssetWarnings(...)` with Codex runtime config plus `OPENCLAW_DISABLE_BUNDLED_PLUGINS=1`.
Evidence after fix: Terminal output from that live run:
```text
- Personal Codex CLI assets were found, but native Codex-mode OpenClaw agents use isolated per-agent Codex homes.
- Sources: /tmp/openclaw-84948-home4.s30I0T/.codex and /tmp/openclaw-84948-home4.s30I0T/.agents/skills (1 skill, 0 plugins, 0 config files, 0 hook files).
- These assets will not be loaded by the Codex app-server child unless you intentionally promote them.
- Run `openclaw doctor --fix` first so OpenClaw can repair the configured Codex plugin install, then rerun `openclaw migrate codex --dry-run` to inventory them. Applying that migration copies skills into the current OpenClaw agent workspace; Codex plugins, hooks, and config stay manual-review only.
```
Observed result after fix: The warning now tells the user to repair the missing Codex plugin/provider state first instead of sending them directly to a `migrate codex` command that cannot resolve in that runtime state.
What was not tested: I did not run a full packaged `openclaw doctor` binary or a full end-to-end `openclaw migrate codex --dry-run` flow after `doctor --fix`; this change is scoped to the warning path plus the focused regression and live warning-output proof above.

Closes #84948
