### PR TITLE
feat(web-search): expose Perplexity search context size

### DIFF
--- a/docs/tools/perplexity-search.md
+++ b/docs/tools/perplexity-search.md
@@ -140,6 +140,8 @@ Per-page token limit.
 For the legacy Sonar/OpenRouter compatibility path:
 
 - `query`, `count`, and `freshness` are accepted
+- `search_context_size` accepts `low`, `medium`, or `high` and is forwarded as
+  `web_search_options.search_context_size`
 - `count` is compatibility-only there; the response is still one synthesized
   answer with citations rather than an N-result list
 - Search API-only filters such as `country`, `language`, `date_after`,
@@ -186,6 +188,12 @@ await web_search({
   query: "detailed AI research",
   max_tokens: 50000,
   max_tokens_per_page: 4096,
+});
+
+// Perplexity Sonar/OpenRouter context budget
+await web_search({
+  query: "compare current AI browser agents",
+  search_context_size: "high",
 });
 ```
 

--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -97,20 +97,20 @@ local while `web_search` and `x_search` can use xAI Responses under the hood.
 
 ### Provider comparison
 
-| Provider                                  | Result style                                                   | Filters                                          | API key                                                                                 |
-| ----------------------------------------- | -------------------------------------------------------------- | ------------------------------------------------ | --------------------------------------------------------------------------------------- |
-| [Brave](/tools/brave-search)              | Structured snippets                                            | Country, language, time, `llm-context` mode      | `BRAVE_API_KEY`                                                                         |
-| [DuckDuckGo](/tools/duckduckgo-search)    | Structured snippets                                            | --                                               | None (key-free)                                                                         |
-| [Exa](/tools/exa-search)                  | Structured + extracted                                         | Neural/keyword mode, date, content extraction    | `EXA_API_KEY`                                                                           |
-| [Firecrawl](/tools/firecrawl)             | Structured snippets                                            | Via `firecrawl_search` tool                      | `FIRECRAWL_API_KEY`                                                                     |
-| [Gemini](/tools/gemini-search)            | AI-synthesized + citations                                     | --                                               | `GEMINI_API_KEY`                                                                        |
-| [Grok](/tools/grok-search)                | AI-synthesized + citations                                     | --                                               | `XAI_API_KEY`                                                                           |
-| [Kimi](/tools/kimi-search)                | AI-synthesized + citations; fails on ungrounded chat fallbacks | --                                               | `KIMI_API_KEY` / `MOONSHOT_API_KEY`                                                     |
-| [MiniMax Search](/tools/minimax-search)   | Structured snippets                                            | Region (`global` / `cn`)                         | `MINIMAX_CODE_PLAN_KEY` / `MINIMAX_CODING_API_KEY` / `MINIMAX_OAUTH_TOKEN`              |
-| [Ollama Web Search](/tools/ollama-search) | Structured snippets                                            | --                                               | None for signed-in local hosts; `OLLAMA_API_KEY` for direct `https://ollama.com` search |
-| [Perplexity](/tools/perplexity-search)    | Structured snippets                                            | Country, language, time, domains, content limits | `PERPLEXITY_API_KEY` / `OPENROUTER_API_KEY`                                             |
-| [SearXNG](/tools/searxng-search)          | Structured snippets                                            | Categories, language                             | None (self-hosted)                                                                      |
-| [Tavily](/tools/tavily)                   | Structured snippets                                            | Via `tavily_search` tool                         | `TAVILY_API_KEY`                                                                        |
+| Provider                                  | Result style                                                   | Filters                                                              | API key                                                                                 |
+| ----------------------------------------- | -------------------------------------------------------------- | -------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| [Brave](/tools/brave-search)              | Structured snippets                                            | Country, language, time, `llm-context` mode                          | `BRAVE_API_KEY`                                                                         |
+| [DuckDuckGo](/tools/duckduckgo-search)    | Structured snippets                                            | --                                                                   | None (key-free)                                                                         |
+| [Exa](/tools/exa-search)                  | Structured + extracted                                         | Neural/keyword mode, date, content extraction                        | `EXA_API_KEY`                                                                           |
+| [Firecrawl](/tools/firecrawl)             | Structured snippets                                            | Via `firecrawl_search` tool                                          | `FIRECRAWL_API_KEY`                                                                     |
+| [Gemini](/tools/gemini-search)            | AI-synthesized + citations                                     | --                                                                   | `GEMINI_API_KEY`                                                                        |
+| [Grok](/tools/grok-search)                | AI-synthesized + citations                                     | --                                                                   | `XAI_API_KEY`                                                                           |
+| [Kimi](/tools/kimi-search)                | AI-synthesized + citations; fails on ungrounded chat fallbacks | --                                                                   | `KIMI_API_KEY` / `MOONSHOT_API_KEY`                                                     |
+| [MiniMax Search](/tools/minimax-search)   | Structured snippets                                            | Region (`global` / `cn`)                                             | `MINIMAX_CODE_PLAN_KEY` / `MINIMAX_CODING_API_KEY` / `MINIMAX_OAUTH_TOKEN`              |
+| [Ollama Web Search](/tools/ollama-search) | Structured snippets                                            | --                                                                   | None for signed-in local hosts; `OLLAMA_API_KEY` for direct `https://ollama.com` search |
+| [Perplexity](/tools/perplexity-search)    | Structured snippets or Sonar answer with citations             | Country, language, time, domains, content limits, Sonar context size | `PERPLEXITY_API_KEY` / `OPENROUTER_API_KEY`                                             |
+| [SearXNG](/tools/searxng-search)          | Structured snippets                                            | Categories, language                                                 | None (self-hosted)                                                                      |
+| [Tavily](/tools/tavily)                   | Structured snippets                                            | Via `tavily_search` tool                                             | `TAVILY_API_KEY`                                                                        |
 
 ## Auto-detection
 
@@ -229,6 +229,13 @@ Provider-specific config (API keys, base URLs, modes) lives under
 `models.providers.google.apiKey` and `models.providers.google.baseUrl` as lower-priority
 fallbacks after its dedicated web-search config and `GEMINI_API_KEY`. See the
 provider pages for examples.
+
+Provider-specific tool parameters are accepted only by the providers that
+declare support for them. For Perplexity Sonar/OpenRouter compatibility,
+`search_context_size` may be `low`, `medium`, or `high`; OpenClaw forwards it
+as `web_search_options.search_context_size` on the chat-completions request.
+Native Perplexity Search API requests reject that parameter because the Search
+API path uses `max_tokens` and `max_tokens_per_page` instead.
 
 `tools.web.search.provider` is validated against the web-search provider ids
 declared by bundled and installed plugin manifests. A typo such as `"brvae"`

--- a/extensions/perplexity/src/perplexity-web-search-provider.runtime.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.runtime.ts
@@ -33,6 +33,7 @@ import {
 
 const PERPLEXITY_SEARCH_ENDPOINT = "https://api.perplexity.ai/search";
 const DEFAULT_PERPLEXITY_MODEL = "perplexity/sonar-pro";
+const PERPLEXITY_SEARCH_CONTEXT_SIZES = new Set(["low", "medium", "high"]);
 
 type PerplexityConfig = {
   apiKey?: string;
@@ -197,6 +198,35 @@ function extractPerplexityCitations(data: PerplexitySearchResponse): string[] {
   return [...new Set(citations)];
 }
 
+function normalizePerplexitySearchContextSize(
+  value: unknown,
+): "low" | "medium" | "high" | undefined {
+  const normalized = normalizeOptionalString(value)?.toLowerCase();
+  return normalized && PERPLEXITY_SEARCH_CONTEXT_SIZES.has(normalized)
+    ? (normalized as "low" | "medium" | "high")
+    : undefined;
+}
+
+function buildPerplexityChatCompletionsBody(params: {
+  query: string;
+  baseUrl: string;
+  model: string;
+  freshness?: string;
+  searchContextSize?: "low" | "medium" | "high";
+}): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    model: resolvePerplexityRequestModel(params.baseUrl, params.model),
+    messages: [{ role: "user", content: params.query }],
+  };
+  if (params.freshness) {
+    body.search_recency_filter = params.freshness;
+  }
+  if (params.searchContextSize) {
+    body.web_search_options = { search_context_size: params.searchContextSize };
+  }
+  return body;
+}
+
 async function runPerplexitySearchApi(params: {
   query: string;
   apiKey: string;
@@ -276,15 +306,10 @@ async function runPerplexitySearch(params: {
   model: string;
   timeoutSeconds: number;
   freshness?: string;
+  searchContextSize?: "low" | "medium" | "high";
 }): Promise<{ content: string; citations: string[] }> {
   const endpoint = `${params.baseUrl.trim().replace(/\/$/, "")}/chat/completions`;
-  const body: Record<string, unknown> = {
-    model: resolvePerplexityRequestModel(params.baseUrl, params.model),
-    messages: [{ role: "user", content: params.query }],
-  };
-  if (params.freshness) {
-    body.search_recency_filter = params.freshness;
-  }
+  const body = buildPerplexityChatCompletionsBody(params);
 
   return withTrustedWebSearchEndpoint(
     {
@@ -344,7 +369,20 @@ export async function executePerplexitySearch(
   const rawDateBefore = readStringParam(args, "date_before");
   const domainFilter = readStringArrayParam(args, "domain_filter");
   const maxTokens = readNumberParam(args, "max_tokens", { integer: true });
-  const maxTokensPerPage = readNumberParam(args, "max_tokens_per_page", { integer: true });
+  const maxTokensPerPage = readNumberParam(args, "max_tokens_per_page", {
+    integer: true,
+  });
+  const rawSearchContextSize = readStringParam(args, "search_context_size");
+  const searchContextSize = rawSearchContextSize
+    ? normalizePerplexitySearchContextSize(rawSearchContextSize)
+    : undefined;
+  if (rawSearchContextSize && !searchContextSize) {
+    return {
+      error: "invalid_search_context_size",
+      message: "search_context_size must be low, medium, or high.",
+      docs: "https://docs.openclaw.ai/tools/web",
+    };
+  }
 
   if (!structured) {
     if (country) {
@@ -387,6 +425,13 @@ export async function executePerplexitySearch(
         docs: "https://docs.openclaw.ai/tools/web",
       };
     }
+  } else if (searchContextSize) {
+    return {
+      error: "unsupported_search_context_size",
+      message:
+        "search_context_size is only supported by Perplexity Sonar chat-completions mode. Configure a Perplexity model/baseUrl override to enable it.",
+      docs: "https://docs.openclaw.ai/tools/web",
+    };
   }
 
   if (language && !/^[a-z]{2}$/iu.test(language)) {
@@ -462,6 +507,7 @@ export async function executePerplexitySearch(
     domainFilter?.join(","),
     maxTokens,
     maxTokensPerPage,
+    searchContextSize,
   ]);
   const cached = readCachedSearchPayload(cacheKey);
   if (cached) {
@@ -491,6 +537,7 @@ export async function executePerplexitySearch(
               model: runtime.model,
               timeoutSeconds,
               freshness,
+              searchContextSize,
             });
             return {
               content: wrapWebContent(result.content, "web_search"),
@@ -545,6 +592,8 @@ export const testing = {
   resolvePerplexityRequestModel,
   resolvePerplexityApiKey,
   readPerplexityJsonResponse,
+  normalizePerplexitySearchContextSize,
+  buildPerplexityChatCompletionsBody,
   normalizeToIsoDate,
   isoToPerplexityDate,
 } as const;

--- a/extensions/perplexity/src/perplexity-web-search-provider.test.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.test.ts
@@ -162,7 +162,11 @@ describe("perplexity web search provider", () => {
     const tool = provider.createTool({
       config: {},
       searchConfig: { perplexity: { model: "perplexity/sonar-pro" } },
-      runtimeMetadata: { perplexityTransport: "chat_completions" },
+      runtimeMetadata: {
+        providerSource: "configured",
+        perplexityTransport: "chat_completions",
+        diagnostics: [],
+      },
     });
     if (!tool) {
       throw new Error("Expected tool definition");

--- a/extensions/perplexity/src/perplexity-web-search-provider.test.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.test.ts
@@ -73,7 +73,10 @@ describe("perplexity web search provider", () => {
 
   it("resolves OpenRouter env auth and transport", () => {
     withEnv(
-      { [perplexityApiKeyEnv]: undefined, [openRouterApiKeyEnv]: openRouterPerplexityApiKey },
+      {
+        [perplexityApiKeyEnv]: undefined,
+        [openRouterApiKeyEnv]: openRouterPerplexityApiKey,
+      },
       () => {
         expect(testing.resolvePerplexityApiKey(undefined)).toEqual({
           apiKey: openRouterPerplexityApiKey,
@@ -92,7 +95,10 @@ describe("perplexity web search provider", () => {
 
   it("uses native Search API for direct Perplexity when no legacy overrides exist", () => {
     withEnv(
-      { [perplexityApiKeyEnv]: directPerplexityApiKey, [openRouterApiKeyEnv]: undefined },
+      {
+        [perplexityApiKeyEnv]: directPerplexityApiKey,
+        [openRouterApiKeyEnv]: undefined,
+      },
       () => {
         expect(testing.resolvePerplexityTransport(undefined)).toEqual({
           apiKey: directPerplexityApiKey,
@@ -106,9 +112,11 @@ describe("perplexity web search provider", () => {
   });
 
   it("switches direct Perplexity to chat completions when model override is configured", () => {
-    expect(testing.resolvePerplexityModel({ model: "perplexity/sonar-reasoning-pro" })).toBe(
-      "perplexity/sonar-reasoning-pro",
-    );
+    expect(
+      testing.resolvePerplexityModel({
+        model: "perplexity/sonar-reasoning-pro",
+      }),
+    ).toBe("perplexity/sonar-reasoning-pro");
     expect(
       testing.resolvePerplexityTransport({
         apiKey: directPerplexityApiKey,
@@ -147,5 +155,75 @@ describe("perplexity web search provider", () => {
     await expect(
       testing.readPerplexityJsonResponse(new Response("{ nope"), "Perplexity"),
     ).rejects.toThrow("Perplexity: malformed JSON response");
+  });
+
+  it("exposes search_context_size for Sonar chat-completions tool schemas", () => {
+    const provider = createPerplexityWebSearchProvider();
+    const tool = provider.createTool({
+      config: {},
+      searchConfig: { perplexity: { model: "perplexity/sonar-pro" } },
+      runtimeMetadata: { perplexityTransport: "chat_completions" },
+    });
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+
+    const properties = (tool.parameters as { properties?: Record<string, unknown> }).properties;
+    expect(properties?.search_context_size).toEqual({
+      type: "string",
+      enum: ["low", "medium", "high"],
+      description:
+        "Perplexity Sonar only. Content budget hint passed as web_search_options.search_context_size.",
+    });
+  });
+
+  it("normalizes and validates Perplexity search context size", () => {
+    expect(testing.normalizePerplexitySearchContextSize("HIGH")).toBe("high");
+    expect(testing.normalizePerplexitySearchContextSize(" medium ")).toBe("medium");
+    expect(testing.normalizePerplexitySearchContextSize("deep")).toBeUndefined();
+  });
+
+  it("passes search_context_size through chat completions web_search_options", () => {
+    expect(
+      testing.buildPerplexityChatCompletionsBody({
+        query: "market sizing",
+        baseUrl: "https://api.perplexity.ai",
+        model: "perplexity/sonar-pro",
+        freshness: "week",
+        searchContextSize: "high",
+      }),
+    ).toEqual({
+      model: "sonar-pro",
+      messages: [{ role: "user", content: "market sizing" }],
+      search_recency_filter: "week",
+      web_search_options: { search_context_size: "high" },
+    });
+  });
+
+  it("rejects invalid search_context_size values before provider calls", async () => {
+    await withEnvAsync(
+      {
+        [perplexityApiKeyEnv]: directPerplexityApiKey,
+        [openRouterApiKeyEnv]: undefined,
+      },
+      async () => {
+        const provider = createPerplexityWebSearchProvider();
+        const tool = provider.createTool({
+          config: {},
+          searchConfig: { perplexity: { model: "perplexity/sonar-pro" } },
+        });
+        if (!tool) {
+          throw new Error("Expected tool definition");
+        }
+
+        await expect(
+          tool.execute({ query: "market sizing", search_context_size: "deep" }),
+        ).resolves.toEqual({
+          error: "invalid_search_context_size",
+          message: "search_context_size must be low, medium, or high.",
+          docs: "https://docs.openclaw.ai/tools/web",
+        });
+      },
+    );
   });
 });

--- a/extensions/perplexity/src/perplexity-web-search-provider.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.ts
@@ -73,6 +73,14 @@ function createPerplexityParameters(transport?: string): Record<string, unknown>
       minimum: 1,
     };
   }
+  if (transport === "chat_completions") {
+    properties.search_context_size = {
+      type: "string",
+      enum: ["low", "medium", "high"],
+      description:
+        "Perplexity Sonar only. Content budget hint passed as web_search_options.search_context_size.",
+    };
+  }
 
   return {
     type: "object",

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -61,6 +61,11 @@ const WebSearchSchema = {
       description: "Perplexity tokens per page.",
       minimum: 1,
     },
+    search_context_size: {
+      type: "string",
+      enum: ["low", "medium", "high"],
+      description: "Perplexity Sonar search context budget.",
+    },
   },
 } satisfies Record<string, unknown>;
 

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
@@ -1165,6 +1165,11 @@
           "description": "Search query.",
           "type": "string"
         },
+        "search_context_size": {
+          "description": "Perplexity Sonar search context budget.",
+          "enum": ["low", "medium", "high"],
+          "type": "string"
+        },
         "search_lang": {
           "description": "Brave result language.",
           "type": "string"

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
@@ -1197,6 +1197,11 @@
           "description": "Search query.",
           "type": "string"
         },
+        "search_context_size": {
+          "description": "Perplexity Sonar search context budget.",
+          "enum": ["low", "medium", "high"],
+          "type": "string"
+        },
         "search_lang": {
           "description": "Brave result language.",
           "type": "string"

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -1161,6 +1161,11 @@
           "description": "Search query.",
           "type": "string"
         },
+        "search_context_size": {
+          "description": "Perplexity Sonar search context budget.",
+          "enum": ["low", "medium", "high"],
+          "type": "string"
+        },
         "search_lang": {
           "description": "Brave result language.",
           "type": "string"

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -218,8 +218,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 40441,
-    "roughTokens": 10111
+    "chars": 40673,
+    "roughTokens": 10169
   },
   "openClawDeveloperInstructions": {
     "chars": 3184,
@@ -230,8 +230,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6591
   },
   "totalWithDynamicToolsJson": {
-    "chars": 66805,
-    "roughTokens": 16702
+    "chars": 67037,
+    "roughTokens": 16760
   },
   "userInputText": {
     "chars": 1530,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -218,8 +218,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 40216,
-    "roughTokens": 10054
+    "chars": 40448,
+    "roughTokens": 10112
   },
   "openClawDeveloperInstructions": {
     "chars": 2160,
@@ -230,8 +230,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6210
   },
   "totalWithDynamicToolsJson": {
-    "chars": 65056,
-    "roughTokens": 16264
+    "chars": 65288,
+    "roughTokens": 16322
   },
   "userInputText": {
     "chars": 1030,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -219,8 +219,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 41311,
-    "roughTokens": 10328
+    "chars": 41543,
+    "roughTokens": 10386
   },
   "openClawDeveloperInstructions": {
     "chars": 2179,
@@ -231,8 +231,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6677
   },
   "totalWithDynamicToolsJson": {
-    "chars": 68020,
-    "roughTokens": 17005
+    "chars": 68252,
+    "roughTokens": 17063
   },
   "userInputText": {
     "chars": 1268,


### PR DESCRIPTION
## Summary
- add `search_context_size` to the generic `web_search` tool schema
- expose the field on Perplexity Sonar chat-completions tool schemas
- validate `low|medium|high` and pass it to `web_search_options.search_context_size`
- include the option in the Perplexity cache key

Fixes #84872

## Real behavior proof

**Behavior addressed:** Perplexity Sonar chat-completions web_search exposes `search_context_size`, normalizes accepted values, and sends the selected value as `web_search_options.search_context_size`.

**Real environment tested:** OpenClaw source checkout on this PR branch (`b83f0d5b56738371fe192b788cc1f6577b0cb95d`) using `node --import tsx` from the repository root.

**Exact steps or command run after the patch:**
1. Imported the actual Perplexity web-search provider source from `extensions/perplexity/src/perplexity-web-search-provider.ts`.
2. Created the provider tool with `runtimeMetadata.perplexityTransport="chat_completions"` and `model="perplexity/sonar-pro"`.
3. Inspected the generated tool schema for `search_context_size`.
4. Built the actual chat-completions request body with `searchContextSize="high"`.

**Evidence after fix:**
```console
$ node --import tsx -e 'import { createPerplexityWebSearchProvider } from "./extensions/perplexity/src/perplexity-web-search-provider.ts"; import { testing } from "./extensions/perplexity/src/perplexity-web-search-provider.runtime.ts"; const provider=createPerplexityWebSearchProvider(); const tool=provider.createTool({config:{}, searchConfig:{perplexity:{model:"perplexity/sonar-pro"}}, runtimeMetadata:{perplexityTransport:"chat_completions"}}); const properties=tool.parameters.properties; const body=testing.buildPerplexityChatCompletionsBody({query:"market sizing", baseUrl:"https://api.perplexity.ai", model:"perplexity/sonar-pro", freshness:"week", searchContextSize:"high"}); console.log(JSON.stringify({schema:properties.search_context_size, normalized:testing.normalizePerplexitySearchContextSize("HIGH"), requestBody:body}, null, 2));'
{
  "schema": {
    "type": "string",
    "enum": [
      "low",
      "medium",
      "high"
    ],
    "description": "Perplexity Sonar only. Content budget hint passed as web_search_options.search_context_size."
  },
  "normalized": "high",
  "requestBody": {
    "model": "sonar-pro",
    "messages": [
      {
        "role": "user",
        "content": "market sizing"
      }
    ],
    "search_recency_filter": "week",
    "web_search_options": {
      "search_context_size": "high"
    }
  }
}
```

**Observed result after fix:** The generated tool schema contains `enum: ["low", "medium", "high"]`; uppercase input normalizes to `high`; the generated Sonar chat-completions body contains `web_search_options: { search_context_size: "high" }`.

**What was not tested:** I did not make a live Perplexity network request because that requires a real API key and would spend external provider quota. The proof verifies the actual OpenClaw provider schema and request-body construction path before network dispatch.

## Verification
- `node scripts/test-projects.mjs extensions/perplexity/src/perplexity-web-search-provider.test.ts`
- `git diff --check`
- `NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit 2>&1 | rg 'src/agents/tools/web-search.ts|extensions/perplexity/src/perplexity-web-search-provider' || true`

## Notes
- Perplexity docs currently describe `web_search_options.search_context_size` with `low`, `medium`, and `high` values: https://docs.perplexity.ai/docs/grounded-llm/chat-completions/filters/context-size
