### PR TITLE
fix(google): omit request config with cached content

### DIFF
--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -371,18 +371,13 @@ describe("google transport stream", () => {
     });
 
     const payload = parseRequestJsonBody(init);
-    expect(payload.systemInstruction).toEqual({
-      parts: [{ text: "Follow policy." }],
-    });
     expect(payload.cachedContent).toBe("cachedContents/request-cache");
+    expect(payload.systemInstruction).toBeUndefined();
+    expect(payload.tools).toBeUndefined();
+    expect(payload.toolConfig).toBeUndefined();
     expect((payload.generationConfig as { thinkingConfig?: unknown }).thinkingConfig).toEqual({
       includeThoughts: true,
       thinkingLevel: "HIGH",
-    });
-    expect(
-      (payload.toolConfig as { functionCallingConfig?: unknown }).functionCallingConfig,
-    ).toEqual({
-      mode: "AUTO",
     });
     expect(result.api).toBe("google-generative-ai");
     expect(result.provider).toBe("google");
@@ -1530,6 +1525,36 @@ describe("google transport stream", () => {
     );
 
     expect(params.cachedContent).toBe("cachedContents/prebuilt-context");
+  });
+
+  it("omits per-request system and tool settings when using cachedContent", () => {
+    const params = buildGoogleGenerativeAiParams(
+      buildGeminiModel(),
+      {
+        systemPrompt: "Follow policy.",
+        messages: [{ role: "user", content: "hello", timestamp: 0 }],
+        tools: [
+          {
+            name: "lookup",
+            description: "Look up a value",
+            parameters: {
+              type: "object",
+              properties: { q: { type: "string" } },
+              required: ["q"],
+            },
+          },
+        ],
+      } as never,
+      {
+        cachedContent: " cachedContents/prebuilt-context ",
+        toolChoice: "auto",
+      },
+    );
+
+    expect(params.cachedContent).toBe("cachedContents/prebuilt-context");
+    expect(params.systemInstruction).toBeUndefined();
+    expect(params.tools).toBeUndefined();
+    expect(params.toolConfig).toBeUndefined();
   });
 
   it("uses a non-empty text placeholder for empty user text", () => {

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -202,9 +202,7 @@ function hasGeminiThoughtSignatureTruncationFootprint(value: string): boolean {
   );
 }
 
-function sanitizeGeminiThoughtSignature(
-  thoughtSignature: string | undefined,
-): string | undefined {
+function sanitizeGeminiThoughtSignature(thoughtSignature: string | undefined): string | undefined {
   if (typeof thoughtSignature !== "string") {
     return undefined;
   }
@@ -552,9 +550,7 @@ function convertGoogleMessages(model: GoogleTransportModel, context: Context) {
             : undefined;
           parts.push({
             text: sanitizeTransportPayloadText(block.text),
-            ...(sanitizedTextSignature
-              ? { thoughtSignature: sanitizedTextSignature }
-              : {}),
+            ...(sanitizedTextSignature ? { thoughtSignature: sanitizedTextSignature } : {}),
           });
           continue;
         }
@@ -710,13 +706,15 @@ export function buildGoogleGenerativeAiParams(
   const params: GoogleGenerateContentRequest = {
     contents: convertGoogleMessages(model, context),
   };
-  if (typeof options?.cachedContent === "string" && options.cachedContent.trim()) {
-    params.cachedContent = options.cachedContent.trim();
+  const cachedContent =
+    typeof options?.cachedContent === "string" ? options.cachedContent.trim() : "";
+  if (cachedContent) {
+    params.cachedContent = cachedContent;
   }
   if (Object.keys(generationConfig).length > 0) {
     params.generationConfig = generationConfig;
   }
-  if (context.systemPrompt) {
+  if (!cachedContent && context.systemPrompt) {
     params.systemInstruction = {
       parts: [
         {
@@ -725,7 +723,7 @@ export function buildGoogleGenerativeAiParams(
       ],
     };
   }
-  if (context.tools?.length) {
+  if (!cachedContent && context.tools?.length) {
     params.tools = convertGoogleTools(context.tools);
     const toolChoice = mapToolChoice(options?.toolChoice);
     if (toolChoice) {

--- a/src/agents/pi-embedded-runner/google-prompt-cache.test.ts
+++ b/src/agents/pi-embedded-runner/google-prompt-cache.test.ts
@@ -179,7 +179,7 @@ describe("google prompt cache", () => {
             },
           ],
         } as never,
-        { temperature: 0.2 } as never,
+        { temperature: 0.2, toolChoice: "auto" } as never,
       ),
     );
 
@@ -200,11 +200,28 @@ describe("google prompt cache", () => {
       systemInstruction: {
         parts: [{ text: "Follow policy." }],
       },
+      tools: [
+        {
+          functionDeclarations: [
+            {
+              name: "lookup",
+              description: "Look up a value",
+              parametersJsonSchema: { type: "object" },
+            },
+          ],
+        },
+      ],
+      toolConfig: {
+        functionCallingConfig: {
+          mode: "AUTO",
+        },
+      },
     });
     expect(innerStreamFn).toHaveBeenCalledTimes(1);
     expect(streamContext(innerStreamFn).systemPrompt).toBeUndefined();
-    expect(Array.isArray(streamContext(innerStreamFn).tools)).toBe(true);
+    expect(streamContext(innerStreamFn).tools).toBeUndefined();
     expect(streamOptions(innerStreamFn).temperature).toBe(0.2);
+    expect(streamOptions(innerStreamFn).toolChoice).toBe("auto");
     expect(getCapturedPayload()?.cachedContent).toBe("cachedContents/system-cache-1");
     expect(entries).toEqual([
       {
@@ -221,6 +238,7 @@ describe("google prompt cache", () => {
           modelApi: "google-generative-ai",
           baseUrl: "https://generativelanguage.googleapis.com/v1beta",
           systemPromptDigest,
+          cacheConfigDigest: expect.any(String),
           cacheRetention: "long",
           cachedContent: "cachedContents/system-cache-1",
           expireTime,

--- a/src/agents/pi-embedded-runner/google-prompt-cache.ts
+++ b/src/agents/pi-embedded-runner/google-prompt-cache.ts
@@ -31,6 +31,8 @@ type GooglePromptCacheModel = Model<Api> & {
   headers?: Record<string, string>;
   provider: string;
 };
+type GooglePromptCacheContext = Parameters<StreamFn>[1];
+type GooglePromptCacheOptions = Parameters<StreamFn>[2];
 
 type GooglePromptCacheEntry = {
   timestamp: number;
@@ -39,6 +41,7 @@ type GooglePromptCacheEntry = {
   modelApi?: string | null;
   baseUrl: string;
   systemPromptDigest: string;
+  cacheConfigDigest?: string;
   cacheRetention: CacheRetention;
 } & (
   | {
@@ -111,6 +114,7 @@ function buildGooglePromptCacheMatchKey(params: {
   modelApi?: string | null;
   baseUrl: string;
   systemPromptDigest: string;
+  cacheConfigDigest?: string;
 }) {
   return stableStringify(params);
 }
@@ -150,6 +154,8 @@ function readLatestGooglePromptCacheEntry(
             : null,
         baseUrl: stringifyGooglePromptCacheKeyPart(cacheData.baseUrl),
         systemPromptDigest: stringifyGooglePromptCacheKeyPart(cacheData.systemPromptDigest),
+        cacheConfigDigest:
+          typeof cacheData.cacheConfigDigest === "string" ? cacheData.cacheConfigDigest : undefined,
       });
       if (candidateKey === matchKey) {
         return data as GooglePromptCacheEntry;
@@ -183,13 +189,79 @@ function parseExpireTimeMs(expireTime: string | undefined): number | null {
   return Number.isFinite(timestamp) ? timestamp : null;
 }
 
-function buildManagedContextWithoutSystemPrompt(context: Parameters<StreamFn>[1]) {
-  if (!context.systemPrompt) {
+function convertManagedGoogleTools(tools: NonNullable<GooglePromptCacheContext["tools"]>) {
+  if (tools.length === 0) {
+    return undefined;
+  }
+  return [
+    {
+      functionDeclarations: tools.map((tool) => ({
+        name: tool.name,
+        description: tool.description,
+        parametersJsonSchema: tool.parameters,
+      })),
+    },
+  ];
+}
+
+function mapManagedGoogleToolChoice(
+  choice: unknown,
+): { mode: "AUTO" | "NONE" | "ANY"; allowedFunctionNames?: string[] } | undefined {
+  if (!choice) {
+    return undefined;
+  }
+  if (
+    typeof choice === "object" &&
+    choice !== null &&
+    (choice as { type?: unknown }).type === "function"
+  ) {
+    const functionName = (choice as { function?: { name?: unknown } }).function?.name;
+    return typeof functionName === "string"
+      ? { mode: "ANY", allowedFunctionNames: [functionName] }
+      : { mode: "ANY" };
+  }
+  switch (choice) {
+    case "none":
+      return { mode: "NONE" };
+    case "any":
+    case "required":
+      return { mode: "ANY" };
+    default:
+      return { mode: "AUTO" };
+  }
+}
+
+function buildManagedGooglePromptCacheConfig(
+  context: GooglePromptCacheContext,
+  options: GooglePromptCacheOptions,
+) {
+  const tools = context.tools?.length ? convertManagedGoogleTools(context.tools) : undefined;
+  const toolChoice = tools
+    ? mapManagedGoogleToolChoice((options as { toolChoice?: unknown } | undefined)?.toolChoice)
+    : undefined;
+  const toolConfig = toolChoice ? { functionCallingConfig: toolChoice } : undefined;
+  const cacheConfigDigest =
+    tools || toolConfig
+      ? stableStringify({
+          tools,
+          toolConfig,
+        })
+      : undefined;
+  return {
+    cacheConfigDigest,
+    tools,
+    toolConfig,
+  };
+}
+
+function buildManagedContextForCachedContent(context: GooglePromptCacheContext) {
+  if (!context.systemPrompt && !context.tools?.length) {
     return context;
   }
   return {
     ...context,
     systemPrompt: undefined,
+    tools: undefined,
   };
 }
 
@@ -229,6 +301,8 @@ async function createGooglePromptCache(params: {
   modelId: string;
   signal?: AbortSignal;
   systemPrompt: string;
+  tools?: unknown;
+  toolConfig?: unknown;
 }): Promise<{ cachedContent: string; expireTime?: string } | null> {
   const response = await params.fetchImpl(`${params.baseUrl}/cachedContents`, {
     method: "POST",
@@ -239,6 +313,8 @@ async function createGooglePromptCache(params: {
       systemInstruction: {
         parts: [{ text: params.systemPrompt }],
       },
+      ...(params.tools ? { tools: params.tools } : {}),
+      ...(params.toolConfig ? { toolConfig: params.toolConfig } : {}),
     }),
     signal: params.signal,
   });
@@ -256,9 +332,12 @@ async function ensureGooglePromptCache(
     cacheRetention: CacheRetention;
     model: GooglePromptCacheModel;
     provider: string;
+    cacheConfigDigest?: string;
     sessionManager: GooglePromptCacheSessionManager;
     signal?: AbortSignal;
     systemPrompt: string;
+    tools?: unknown;
+    toolConfig?: unknown;
   },
   deps: GooglePromptCacheDeps,
 ): Promise<string | null> {
@@ -271,6 +350,7 @@ async function ensureGooglePromptCache(
     modelApi: params.model.api,
     baseUrl,
     systemPromptDigest,
+    cacheConfigDigest: params.cacheConfigDigest,
   });
   const latestEntry = readLatestGooglePromptCacheEntry(params.sessionManager, matchKey);
 
@@ -306,6 +386,7 @@ async function ensureGooglePromptCache(
           modelApi: params.model.api,
           baseUrl,
           systemPromptDigest,
+          cacheConfigDigest: params.cacheConfigDigest,
           cacheRetention: params.cacheRetention,
           cachedContent: latestEntry.cachedContent,
           expireTime: refreshed.expireTime ?? latestEntry.expireTime,
@@ -325,6 +406,8 @@ async function ensureGooglePromptCache(
     modelId: params.model.id,
     signal: params.signal,
     systemPrompt: params.systemPrompt,
+    tools: params.tools,
+    toolConfig: params.toolConfig,
   });
   if (!created) {
     await appendGooglePromptCacheEntry(params.sessionManager, {
@@ -335,6 +418,7 @@ async function ensureGooglePromptCache(
       modelApi: params.model.api,
       baseUrl,
       systemPromptDigest,
+      cacheConfigDigest: params.cacheConfigDigest,
       cacheRetention: params.cacheRetention,
       retryAfter: now + GOOGLE_PROMPT_CACHE_RETRY_BACKOFF_MS,
     });
@@ -349,6 +433,7 @@ async function ensureGooglePromptCache(
     modelApi: params.model.api,
     baseUrl,
     systemPromptDigest,
+    cacheConfigDigest: params.cacheConfigDigest,
     cacheRetention: params.cacheRetention,
     cachedContent: created.cachedContent,
     expireTime: created.expireTime,
@@ -386,15 +471,19 @@ export async function prepareGooglePromptCacheStreamFn(
 
   const inner = params.streamFn;
   return async (model, context, options) => {
+    const cacheConfig = buildManagedGooglePromptCacheConfig(context, options);
     const cachedContent = await ensureGooglePromptCache(
       {
         apiKey,
+        cacheConfigDigest: cacheConfig.cacheConfigDigest,
         cacheRetention: resolvedRetention,
         model: params.model,
         provider: params.provider,
         sessionManager: params.sessionManager,
         signal: params.signal,
         systemPrompt,
+        tools: cacheConfig.tools,
+        toolConfig: cacheConfig.toolConfig,
       },
       deps,
     );
@@ -408,7 +497,7 @@ export async function prepareGooglePromptCacheStreamFn(
     return streamWithPayloadPatch(
       inner,
       model,
-      buildManagedContextWithoutSystemPrompt(context),
+      buildManagedContextForCachedContent(context),
       options,
       (payload) => {
         payload.cachedContent = cachedContent;


### PR DESCRIPTION
## Summary
- Fixes #84919.
- Omits per-request `systemInstruction`, `tools`, and `toolConfig` from Gemini GenerateContent requests when `cachedContent` is used.
- Covers both cached-content entry points: explicit `params.cachedContent` and managed Gemini `cacheRetention` prompt caching.

## Root Cause
OpenClaw had two ways to put `cachedContent` on direct Gemini GenerateContent requests:

- explicit `params.cachedContent`, serialized by the Google transport itself
- managed `cacheRetention`, where the embedded-runner Google prompt-cache wrapper creates a Gemini `cachedContents` resource and patches `cachedContent` into the transport payload

The explicit path sent `cachedContent` while still serializing request-level `systemInstruction`, `tools`, and `toolConfig`. The managed path stripped the request system prompt, but it still let request tools serialize before patching `cachedContent` into the payload. Google requires system instructions and tools/tool config to be set on the cached content resource when `cachedContent` is used; sending them again on GenerateContent can return HTTP 400.

## Fix
- Direct Google transport now treats non-empty `options.cachedContent` as a cached-content request and skips request-level `systemInstruction`, `tools`, and `toolConfig`.
- Managed Gemini prompt caching now includes the request tool declarations and tool config in the Gemini `cachedContents.create` request when tools are present.
- The managed cache key now includes a digest of the cached tool/toolConfig payload, so a cached content resource is not reused across different tool surfaces.
- The managed wrapper now removes both `systemPrompt` and `tools` from the downstream GenerateContent context after it has created or reused the matching cached content.

## Why This Is Safe
Uncached Gemini requests are unchanged: they still send system prompts and tools directly on GenerateContent. Cached Gemini requests still include `contents` and generation settings such as temperature, max tokens, and thinking config.

Security and runtime controls are unchanged for auth resolution, guarded model fetch, request URL/header construction, tool execution policy, and Slack/channel policy. This fix changes provider payload construction and managed cache contents only; it does not rely on prompt text to enforce the policy.

## Real Behavior Proof

Behavior addressed: Gemini GenerateContent requests using managed `cacheRetention: "long"` with tools no longer send request-level `systemInstruction`, `tools`, or `toolConfig` together with `cachedContent`, avoiding Google 400 `INVALID_ARGUMENT`.

Real environment tested: Local macOS checkout, PR head `198a42bbc6`, real Google Gemini API, `google/gemini-2.5-flash`, Gemini API key read from 1Password/Molty service account without logging the secret.

Exact steps or command run after this patch: Created a large managed prompt-cache request through `prepareGooglePromptCacheStreamFn` with `extraParams: { cacheRetention: "long" }`, one tool declaration, `toolChoice: "auto"`, and `createGoogleGenerativeAiTransportStreamFn`; captured the downstream GenerateContent payload via `onPayload`; waited for `stream.result()`; deleted the created `cachedContents/...` resource. Also ran the same current-main managed path against `google/gemini-3.5-flash` to confirm the pre-fix 400.

Evidence after fix:

```text
OPENCLAW_GEMINI_MANAGED_CACHE_TTKUCZ.payload:{"cachedContent":"present","systemInstruction":false,"tools":false,"toolConfig":false,"generationConfig":true}
OPENCLAW_GEMINI_MANAGED_CACHE_TTKUCZ.ok:true
OPENCLAW_GEMINI_MANAGED_CACHE_TTKUCZ.stop:stop
OPENCLAW_GEMINI_MANAGED_CACHE_TTKUCZ.contentTypes:text
OPENCLAW_GEMINI_MANAGED_CACHE_TTKUCZ.cacheRead:11886
OPENCLAW_GEMINI_MANAGED_CACHE_TTKUCZ.usageTotal:11957
managed.cleanupStatus:200
managed.entryStatus:ready
managed.cacheConfigDigestLen:252
```

Current-main repro before fix:

```text
model:gemini-3.5-flash
managed.created:true
payload:{"cachedContent":"present","systemInstruction":false,"tools":true,"toolConfig":true,"generationConfig":true}
result.stop:error
result.cacheRead:0
result.errorMessage:Google Generative AI API error (400): CachedContent can not be used with GenerateContent request setting system_instruction, tools or tool_config. Proposed fix: move those values to CachedContent from GenerateContent request. [code=INVALID_ARGUMENT]
cache.cleanupStatus:200
cache.entryStatus:ready
```

Observed result after fix: The real managed `cacheRetention: "long"` request created and used Gemini cached content, omitted all three conflicting request-level keys, returned text with the marker, reported `cacheRead=11886`, and cleaned up the cached content with HTTP 200.

What was not tested: Slack two-bot delivery was not retested as the passing proof exercises the failing Google provider payload path directly; broad CI remains the merge gate for unrelated channels and platform coverage.

## Tests
- `pnpm check:changed`
- `pnpm test src/agents/pi-embedded-runner/google-prompt-cache.test.ts extensions/google/transport-stream.test.ts -- -t "google prompt cache|cachedContent|guarded fetch transport"`
- `git diff --check`
- IDE lints for changed files: no diagnostics

## Out Of Scope
- Changing Gemini cache TTL or refresh timing.
- Changing Slack/Socket Mode handling or two-bot QA harness behavior.
- Adding compatibility fallbacks that send dynamic tools or system prompts alongside `cachedContent`.

## Transparency
AI-assisted change; locally reviewed and validated with focused tests plus live managed Gemini provider proof.
