### PR TITLE
fix(ollama): allow Orb host local auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Providers/Ollama: treat Orb VM host aliases as local Ollama endpoints so `ollama-local` marker auth works when OpenClaw runs inside Orb and Ollama runs on the host. Fixes #84875.
 - Agents: cap heartbeat model bleed context hints by the stored session window when runtime model metadata is unavailable, so overflow recovery advice does not suggest a larger window than the active session actually has.
 - Control UI/Web Push: use `https://openclaw.ai` as the generated default VAPID subject instead of the old localhost mailbox so iOS PWA push setup uses an Apple-acceptable subject when `OPENCLAW_VAPID_SUBJECT` is unset. Fixes #83134. (#83317) Thanks @IWhatsskill.
 - Agents/Pi: keep embedded session transcript writes from tripping false takeover detection after packaged npm onboarding agent turns.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Providers/Ollama: treat Orb VM host aliases as local Ollama endpoints so `ollama-local` marker auth works when OpenClaw runs inside Orb and Ollama runs on the host. Fixes #84875.
+- Providers/Ollama: treat OrbStack host aliases as local Ollama endpoints so `ollama-local` marker auth works when OpenClaw runs inside Orb and Ollama runs on the host. Fixes #84875.
 - Agents: cap heartbeat model bleed context hints by the stored session window when runtime model metadata is unavailable, so overflow recovery advice does not suggest a larger window than the active session actually has.
 - Control UI/Web Push: use `https://openclaw.ai` as the generated default VAPID subject instead of the old localhost mailbox so iOS PWA push setup uses an Apple-acceptable subject when `OPENCLAW_VAPID_SUBJECT` is unset. Fixes #83134. (#83317) Thanks @IWhatsskill.
 - Agents/Pi: keep embedded session transcript writes from tripping false takeover detection after packaged npm onboarding agent turns.

--- a/extensions/ollama/index.test.ts
+++ b/extensions/ollama/index.test.ts
@@ -572,6 +572,29 @@ describe("ollama plugin", () => {
     expect(buildOllamaProviderMock).not.toHaveBeenCalled();
   });
 
+  it("skips implicit localhost discovery when a custom Orb host Ollama provider is configured", async () => {
+    const provider = registerProvider();
+
+    const result = await provider.catalog.run({
+      config: {
+        models: {
+          providers: {
+            "ollama-orb": {
+              api: "ollama",
+              baseUrl: "http://host.orb.internal:11434",
+              models: [{ id: "qwen3.5:27b", name: "Qwen 3.5 27B" }],
+            },
+          },
+        },
+      },
+      env: { NODE_ENV: "development", OLLAMA_API_KEY: "ollama-live" },
+      resolveProviderApiKey: () => ({ apiKey: "ollama-live" }),
+    } as never);
+
+    expect(result).toBeNull();
+    expect(buildOllamaProviderMock).not.toHaveBeenCalled();
+  });
+
   it("treats custom 127/8 Ollama providers as loopback for implicit discovery", async () => {
     const provider = registerProvider();
     buildOllamaProviderMock.mockResolvedValueOnce({

--- a/extensions/ollama/index.test.ts
+++ b/extensions/ollama/index.test.ts
@@ -572,28 +572,31 @@ describe("ollama plugin", () => {
     expect(buildOllamaProviderMock).not.toHaveBeenCalled();
   });
 
-  it("skips implicit localhost discovery when a custom Orb host Ollama provider is configured", async () => {
-    const provider = registerProvider();
+  it.each(["docker.orb.internal", "host.orb.internal"])(
+    "skips implicit localhost discovery when a custom Orb host Ollama provider is configured for %s",
+    async (hostname) => {
+      const provider = registerProvider();
 
-    const result = await provider.catalog.run({
-      config: {
-        models: {
-          providers: {
-            "ollama-orb": {
-              api: "ollama",
-              baseUrl: "http://host.orb.internal:11434",
-              models: [{ id: "qwen3.5:27b", name: "Qwen 3.5 27B" }],
+      const result = await provider.catalog.run({
+        config: {
+          models: {
+            providers: {
+              "ollama-orb": {
+                api: "ollama",
+                baseUrl: `http://${hostname}:11434`,
+                models: [{ id: "qwen3.5:27b", name: "Qwen 3.5 27B" }],
+              },
             },
           },
         },
-      },
-      env: { NODE_ENV: "development", OLLAMA_API_KEY: "ollama-live" },
-      resolveProviderApiKey: () => ({ apiKey: "ollama-live" }),
-    } as never);
+        env: { NODE_ENV: "development", OLLAMA_API_KEY: "ollama-live" },
+        resolveProviderApiKey: () => ({ apiKey: "ollama-live" }),
+      } as never);
 
-    expect(result).toBeNull();
-    expect(buildOllamaProviderMock).not.toHaveBeenCalled();
-  });
+      expect(result).toBeNull();
+      expect(buildOllamaProviderMock).not.toHaveBeenCalled();
+    },
+  );
 
   it("treats custom 127/8 Ollama providers as loopback for implicit discovery", async () => {
     const provider = registerProvider();

--- a/extensions/ollama/src/discovery-shared.test.ts
+++ b/extensions/ollama/src/discovery-shared.test.ts
@@ -15,6 +15,7 @@ describe("isLocalOllamaBaseUrl", () => {
     "http://192.168.1.100:11434",
     "http://gpu-node-1:11434",
     "http://mac-studio.local:11434",
+    "http://docker.orb.internal:11434",
     "http://host.orb.internal:11434",
     "http://[fd00::1]:11434",
     "http://[fe90::1]:11434",

--- a/extensions/ollama/src/discovery-shared.test.ts
+++ b/extensions/ollama/src/discovery-shared.test.ts
@@ -15,6 +15,7 @@ describe("isLocalOllamaBaseUrl", () => {
     "http://192.168.1.100:11434",
     "http://gpu-node-1:11434",
     "http://mac-studio.local:11434",
+    "http://host.orb.internal:11434",
     "http://[fd00::1]:11434",
     "http://[fe90::1]:11434",
   ])("classifies %s as local", (baseUrl) => {

--- a/extensions/ollama/src/discovery-shared.ts
+++ b/extensions/ollama/src/discovery-shared.ts
@@ -76,6 +76,7 @@ const LOCAL_OLLAMA_HOSTNAMES = new Set([
   "0.0.0.0",
   "::1",
   "::",
+  "docker.orb.internal",
   "host.orb.internal",
 ]);
 const LOOPBACK_OLLAMA_HOSTNAMES = new Set(["localhost", "127.0.0.1", "0.0.0.0", "::1", "::"]);

--- a/extensions/ollama/src/discovery-shared.ts
+++ b/extensions/ollama/src/discovery-shared.ts
@@ -70,7 +70,15 @@ function shouldSkipAmbientOllamaDiscovery(env: NodeJS.ProcessEnv): boolean {
   return Boolean(env.VITEST) || env.NODE_ENV === "test";
 }
 
-const LOCAL_OLLAMA_HOSTNAMES = new Set(["localhost", "127.0.0.1", "0.0.0.0", "::1", "::"]);
+const LOCAL_OLLAMA_HOSTNAMES = new Set([
+  "localhost",
+  "127.0.0.1",
+  "0.0.0.0",
+  "::1",
+  "::",
+  "host.orb.internal",
+]);
+const LOOPBACK_OLLAMA_HOSTNAMES = new Set(["localhost", "127.0.0.1", "0.0.0.0", "::1", "::"]);
 
 function isIpv4Loopback(host: string): boolean {
   if (!/^\d+\.\d+\.\d+\.\d+$/.test(host)) {
@@ -137,7 +145,7 @@ function isLoopbackOllamaBaseUrl(baseUrl: string | undefined | null): boolean {
   if (host.startsWith("[") && host.endsWith("]")) {
     host = host.slice(1, -1);
   }
-  return LOCAL_OLLAMA_HOSTNAMES.has(host) || isIpv4Loopback(host);
+  return LOOPBACK_OLLAMA_HOSTNAMES.has(host) || isIpv4Loopback(host);
 }
 
 function hasExplicitRemoteOllamaApiProvider(

--- a/src/agents/model-auth.test.ts
+++ b/src/agents/model-auth.test.ts
@@ -1111,40 +1111,43 @@ describe("resolveApiKeyForProvider – synthetic local auth for custom providers
     });
   });
 
-  it("accepts ollama-local marker auth for Orb host aliases", async () => {
-    const auth = await resolveApiKeyForProvider({
-      provider: "ollama",
-      cfg: {
-        models: {
-          providers: {
-            ollama: {
-              baseUrl: "http://host.orb.internal:11434",
-              api: "ollama",
-              apiKey: "ollama-local",
-              models: [
-                {
-                  id: "qwen3.5:27b",
-                  name: "Qwen 3.5 27B",
-                  reasoning: false,
-                  input: ["text"],
-                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-                  contextWindow: 262144,
-                  maxTokens: 8192,
-                },
-              ],
+  it.each(["docker.orb.internal", "host.orb.internal"])(
+    "accepts ollama-local marker auth for Orb host alias %s",
+    async (hostname) => {
+      const auth = await resolveApiKeyForProvider({
+        provider: "ollama",
+        cfg: {
+          models: {
+            providers: {
+              ollama: {
+                baseUrl: `http://${hostname}:11434`,
+                api: "ollama",
+                apiKey: "ollama-local",
+                models: [
+                  {
+                    id: "qwen3.5:27b",
+                    name: "Qwen 3.5 27B",
+                    reasoning: false,
+                    input: ["text"],
+                    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                    contextWindow: 262144,
+                    maxTokens: 8192,
+                  },
+                ],
+              },
             },
           },
         },
-      },
-      store: { version: 1, profiles: {} },
-    });
+        store: { version: 1, profiles: {} },
+      });
 
-    expectAuthFields(auth, {
-      apiKey: "ollama-local",
-      source: "models.json (local marker)",
-      mode: "api-key",
-    });
-  });
+      expectAuthFields(auth, {
+        apiKey: "ollama-local",
+        source: "models.json (local marker)",
+        mode: "api-key",
+      });
+    },
+  );
 
   it("does not accept non-secret local markers for remote custom providers", async () => {
     await expect(

--- a/src/agents/model-auth.test.ts
+++ b/src/agents/model-auth.test.ts
@@ -1111,6 +1111,41 @@ describe("resolveApiKeyForProvider – synthetic local auth for custom providers
     });
   });
 
+  it("accepts ollama-local marker auth for Orb host aliases", async () => {
+    const auth = await resolveApiKeyForProvider({
+      provider: "ollama",
+      cfg: {
+        models: {
+          providers: {
+            ollama: {
+              baseUrl: "http://host.orb.internal:11434",
+              api: "ollama",
+              apiKey: "ollama-local",
+              models: [
+                {
+                  id: "qwen3.5:27b",
+                  name: "Qwen 3.5 27B",
+                  reasoning: false,
+                  input: ["text"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 262144,
+                  maxTokens: 8192,
+                },
+              ],
+            },
+          },
+        },
+      },
+      store: { version: 1, profiles: {} },
+    });
+
+    expectAuthFields(auth, {
+      apiKey: "ollama-local",
+      source: "models.json (local marker)",
+      mode: "api-key",
+    });
+  });
+
   it("does not accept non-secret local markers for remote custom providers", async () => {
     await expect(
       resolveApiKeyForProvider({

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -267,6 +267,7 @@ function isLocalBaseUrl(baseUrl: string): boolean {
       host === "::1" ||
       host === "::ffff:7f00:1" ||
       host === "::ffff:127.0.0.1" ||
+      host === "host.orb.internal" ||
       host.endsWith(".local") ||
       isPrivateIpv4Host(host)
     );

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -267,6 +267,7 @@ function isLocalBaseUrl(baseUrl: string): boolean {
       host === "::1" ||
       host === "::ffff:7f00:1" ||
       host === "::ffff:127.0.0.1" ||
+      host === "docker.orb.internal" ||
       host === "host.orb.internal" ||
       host.endsWith(".local") ||
       isPrivateIpv4Host(host)


### PR DESCRIPTION
## Summary

- Treat `host.orb.internal` as a local Ollama host for `ollama-local` marker auth.
- Keep Orb host aliases out of loopback-only discovery suppression so explicit Orb providers still suppress implicit localhost discovery.
- Add regression coverage and a changelog entry.

Closes #84875

## Verification

- `git diff --check`
- `node scripts/run-vitest.mjs src/agents/model-auth.test.ts extensions/ollama/src/discovery-shared.test.ts extensions/ollama/index.test.ts extensions/ollama/src/setup.test.ts extensions/ollama/src/provider-models.ssrf.test.ts`
- `node --import tsx --input-type=module` source-level auth repro for `http://host.orb.internal:11434`
- `codex review --commit HEAD` accepted one loopback/discovery finding; the patch now separates local-auth hosts from loopback-discovery hosts and the rerun completed its focused Vitest proof before entering the known helper recursion path, which was stopped.

## Real behavior proof

Behavior addressed: `models.providers.ollama` with `baseUrl: "http://host.orb.internal:11434"` and `apiKey: "ollama-local"` now resolves local marker auth instead of falling through to `No API key found for provider "ollama"`.

Real environment tested: Local OpenClaw source worktree on Node 22.22.0; the issue was also reproduced against `v2026.5.19` in a detached local worktree before this patch.

Exact steps or command run after this patch: Ran the focused Vitest command listed above, `git diff --check`, and a source-level `resolveApiKeyForProvider` repro using an explicit empty auth-profile store and the reported Orb base URL.

Evidence after fix: The source-level repro returned `isLocalOllamaBaseUrl: true` and `resolvedAuth: { apiKey: "ollama-local", source: "models.json (local marker)", mode: "api-key" }`; the focused Vitest run passed 6 files and 188 tests.

Observed result after fix: `host.orb.internal` is accepted as local Ollama for auth; explicit Orb host Ollama providers are treated as non-loopback custom providers for discovery suppression.

What was not tested: A live Orb VM with a real host-side Ollama server. Crabbox/Testbox proof was attempted but unavailable locally because no Crabbox coordinator token/AWS broker credentials were present and the Blacksmith CLI was not installed/authenticated.
