### PR TITLE
fix(codex): unsubscribe app-server thread after runs

### DIFF
--- a/extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts
+++ b/extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts
@@ -1,0 +1,197 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  resetAgentEventsForTest,
+  type EmbeddedRunAttemptParams,
+} from "openclaw/plugin-sdk/agent-harness-runtime";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CodexAppServerClientFactory } from "./client-factory.js";
+import type { CodexServerNotification } from "./protocol.js";
+import { runCodexAppServerAttempt } from "./run-attempt.js";
+import { createCodexTestModel } from "./test-support.js";
+
+let tempDir: string;
+
+function createParams(sessionFile: string, workspaceDir: string): EmbeddedRunAttemptParams {
+  return {
+    prompt: "hello",
+    sessionId: "session-1",
+    sessionKey: "agent:main:session-1",
+    sessionFile,
+    workspaceDir,
+    runId: "run-1",
+    provider: "codex",
+    modelId: "gpt-5.4-codex",
+    model: createCodexTestModel("codex"),
+    thinkLevel: "medium",
+    disableTools: true,
+    timeoutMs: 5_000,
+    authStorage: {} as never,
+    authProfileStore: { version: 1, profiles: {} },
+    modelRegistry: {} as never,
+  } as EmbeddedRunAttemptParams;
+}
+
+function threadStartResult(threadId = "thread-1") {
+  return {
+    thread: {
+      id: threadId,
+      sessionId: "session-1",
+      forkedFromId: null,
+      preview: "",
+      ephemeral: false,
+      modelProvider: "openai",
+      createdAt: 1,
+      updatedAt: 1,
+      status: { type: "idle" },
+      path: null,
+      cwd: tempDir || "/tmp/openclaw-codex-test",
+      cliVersion: "0.125.0",
+      source: "unknown",
+      agentNickname: null,
+      agentRole: null,
+      gitInfo: null,
+      name: null,
+      turns: [],
+    },
+    model: "gpt-5.4-codex",
+    modelProvider: "openai",
+    serviceTier: null,
+    cwd: tempDir || "/tmp/openclaw-codex-test",
+    instructionSources: [],
+    approvalPolicy: "never",
+    approvalsReviewer: "user",
+    sandbox: { type: "dangerFullAccess" },
+    permissionProfile: null,
+    reasoningEffort: null,
+  };
+}
+
+function turnStartResult(turnId = "turn-1") {
+  return {
+    turn: {
+      id: turnId,
+      status: "inProgress",
+      items: [],
+      error: null,
+      startedAt: null,
+      completedAt: null,
+      durationMs: null,
+    },
+  };
+}
+
+describe("Codex app-server main thread cleanup", () => {
+  beforeEach(async () => {
+    resetAgentEventsForTest();
+    vi.stubEnv("OPENCLAW_TRAJECTORY", "0");
+    vi.stubEnv("CODEX_API_KEY", "");
+    vi.stubEnv("OPENAI_API_KEY", "");
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-run-cleanup-"));
+  });
+
+  afterEach(async () => {
+    resetAgentEventsForTest();
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("unsubscribes the main Codex thread after a completed turn", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const requests: Array<{ method: string; params: unknown }> = [];
+    let notify: (notification: CodexServerNotification) => Promise<void> = async () => undefined;
+    const request = vi.fn(async (method: string, params?: unknown) => {
+      requests.push({ method, params });
+      if (method === "thread/start") {
+        return threadStartResult();
+      }
+      if (method === "turn/start") {
+        return turnStartResult();
+      }
+      return {};
+    });
+
+    const clientFactory: CodexAppServerClientFactory = async () => {
+      return {
+        request,
+        addNotificationHandler: (handler: typeof notify) => {
+          notify = handler;
+          return () => undefined;
+        },
+        addRequestHandler: () => () => undefined,
+      } as never;
+    };
+
+    const run = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir), {
+      clientFactory,
+    });
+    await vi.waitFor(() => expect(requests.map((entry) => entry.method)).toContain("turn/start"), {
+      interval: 1,
+      timeout: 5_000,
+    });
+    await notify({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        turn: { id: "turn-1", status: "completed" },
+      },
+    });
+
+    const result = await run;
+    expect(result.aborted).toBe(false);
+    expect(request).toHaveBeenCalledWith(
+      "thread/unsubscribe",
+      { threadId: "thread-1" },
+      { timeoutMs: 5_000 },
+    );
+    expect(requests.map((entry) => entry.method)).toEqual([
+      "thread/start",
+      "turn/start",
+      "thread/unsubscribe",
+    ]);
+  });
+
+  it("unsubscribes the main Codex thread when turn start fails", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const requests: Array<{ method: string; params: unknown }> = [];
+    const request = vi.fn(async (method: string, params?: unknown) => {
+      requests.push({ method, params });
+      if (method === "thread/start") {
+        return threadStartResult();
+      }
+      if (method === "turn/start") {
+        throw new Error("turn start exploded");
+      }
+      return {};
+    });
+
+    const clientFactory: CodexAppServerClientFactory = async () => {
+      return {
+        request,
+        addNotificationHandler: () => () => undefined,
+        addRequestHandler: () => () => undefined,
+      } as never;
+    };
+
+    await expect(
+      runCodexAppServerAttempt(createParams(sessionFile, workspaceDir), {
+        clientFactory,
+      }),
+    ).rejects.toThrow("turn start exploded");
+    expect(requests.map((entry) => entry.method)).toEqual([
+      "thread/start",
+      "turn/start",
+      "thread/unsubscribe",
+    ]);
+    expect(request).toHaveBeenCalledWith(
+      "thread/unsubscribe",
+      { threadId: "thread-1" },
+      { timeoutMs: 5_000 },
+    );
+  });
+});

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -8612,7 +8612,10 @@ describe("runCodexAppServerAttempt", () => {
 
     const result = await run;
     expect(result.aborted).toBe(false);
-    expect(requests).toEqual([["thread/resume"], ["thread/resume", "turn/start"]]);
+    expect(requests).toEqual([
+      ["thread/resume"],
+      ["thread/resume", "turn/start", "thread/unsubscribe"],
+    ]);
   });
 
   it("tolerates a second app-server close while retrying startup", async () => {
@@ -8664,7 +8667,7 @@ describe("runCodexAppServerAttempt", () => {
     expect(requests).toEqual([
       ["thread/resume"],
       ["thread/resume"],
-      ["thread/resume", "turn/start"],
+      ["thread/resume", "turn/start", "thread/unsubscribe"],
     ]);
   });
 

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -188,6 +188,7 @@ const CODEX_DYNAMIC_IMAGE_TOOL_TIMEOUT_MS = 60_000;
 const CODEX_APP_SERVER_STARTUP_CONNECTION_CLOSE_MAX_ATTEMPTS = 3;
 const CODEX_APP_SERVER_STARTUP_TIMEOUT_FLOOR_MS = 100;
 const CODEX_APP_SERVER_INTERRUPT_TIMEOUT_MS = 5_000;
+const CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS = 5_000;
 const CODEX_USAGE_LIMIT_RATE_LIMIT_REFRESH_TIMEOUT_MS = 5_000;
 const CODEX_TURN_COMPLETION_IDLE_TIMEOUT_MS = 60_000;
 const CODEX_TURN_ASSISTANT_COMPLETION_IDLE_TIMEOUT_MS = 10_000;
@@ -2474,6 +2475,12 @@ export async function runCodexAppServerAttempt(
         },
         ctx: hookContext,
       });
+      if (!timedOut) {
+        await unsubscribeCodexThreadBestEffort(client, {
+          threadId: thread.threadId,
+          timeoutMs: CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
+        });
+      }
       notificationCleanup();
       requestCleanup();
       nativeHookRelay?.unregister();
@@ -2799,6 +2806,12 @@ export async function runCodexAppServerAttempt(
     });
     if (!timedOut && !runAbortController.signal.aborted) {
       await steeringQueue?.flushPending();
+    }
+    if (!timedOut) {
+      await unsubscribeCodexThreadBestEffort(client, {
+        threadId: thread.threadId,
+        timeoutMs: CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
+      });
     }
     userInputBridge?.cancelPending();
     clearTurnAttemptIdleTimer();
@@ -3250,6 +3263,27 @@ function interruptCodexTurnBestEffort(
     });
   } catch (error) {
     embeddedAgentLog.debug("codex app-server turn interrupt failed during abort", { error });
+  }
+}
+
+async function unsubscribeCodexThreadBestEffort(
+  client: CodexAppServerClient,
+  params: {
+    threadId: string;
+    timeoutMs: number;
+  },
+): Promise<void> {
+  try {
+    await client.request(
+      "thread/unsubscribe",
+      { threadId: params.threadId },
+      { timeoutMs: params.timeoutMs },
+    );
+  } catch (error) {
+    embeddedAgentLog.debug("codex app-server thread unsubscribe cleanup failed", {
+      threadId: params.threadId,
+      error,
+    });
   }
 }
 


### PR DESCRIPTION
Summary
- release the main Codex app-server thread subscription after completed non-timeout turns
- release the subscription when `turn/start` fails after a thread has already been created
- add focused regression coverage for completed-turn and turn-start-failure cleanup

Verification
- `pnpm test extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts`
- `pnpm test extensions/codex/src/app-server/run-attempt.test.ts -- -t "restarts the app-server once|tolerates a second app-server close" --reporter=verbose`
- `git diff --check -- extensions/codex/src/app-server/run-attempt.ts extensions/codex/src/app-server/run-attempt.test.ts extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts`

## Real behavior proof

- Behavior or issue addressed: Repeated Gateway-owned Codex app-server turns with Chrome DevTools MCP should release the main thread subscription after non-timeout completion/failure and should not accumulate `chrome-devtools-mcp` / `npx` sidecars in the short repeated-turn window.
- Real environment tested: Local Linux OpenClaw checkout, Node 22.22.2, isolated Gateway on `127.0.0.1:19743`, isolated state/config under `/tmp/openclaw-84413-repro`, headless Chrome on `127.0.0.1:19744`, Chrome DevTools MCP configured, `codex/gpt-5.5`.
- Exact steps or command run after this patch: Started isolated headless Chrome, started isolated `pnpm openclaw gateway run --allow-unconfigured --cli-backend-logs --port 19743`, ran two `pnpm openclaw agent --agent dev --session-id issue-84413-live-proof ... --json --timeout 300` turns, captured process snapshots before/after.
- Evidence after fix: Terminal transcript:
  ```text
  $ curl -fsS http://127.0.0.1:19743/readyz
  {"ready":true,"failing":[],"eventLoop":{"degraded":false}}

  First completed turn:
  runId: a56c9a0f-e22e-4201-af6b-007eff90b249
  status: ok
  toolSummary.calls: 4
  toolSummary.tools: codex.list_mcp_resources, codex.list_mcp_resource_templates, bash
  finalAssistantVisibleText: about:blank

  Second completed turn:
  runId: 08e8d325-12b7-4f90-9a03-c3be01ba6f14
  status: ok
  toolSummary.calls: 1
  toolSummary.tools: bash
  finalAssistantVisibleText: about:blank

  Post-second-turn process snapshot:
  one Gateway-owned Codex app-server wrapper process
  one Gateway-owned Codex native app-server child process
  no chrome-devtools-mcp process
  no npx -y chrome-devtools process

  Cleanup verification after stopping isolated Gateway and Chrome:
  no 19743 gateway process
  no 19744 Chrome fixture process
  no repo-local Codex app-server proof process
  ```
- Observed result after fix: Two repeated real Gateway turns completed successfully in the isolated setup. The short-window process snapshot did not accumulate `chrome-devtools-mcp` / `npx` sidecars, and all proof processes were gone after cleanup.
- What was not tested: The 30+ minute upstream Codex idle unload/reap delay was not waited out; this patch releases the thread subscription but does not force-kill the app-server immediately.

Fixes #84413
