### PR TITLE
fix(cron): accept unknown payload.kind in persisted store validation

### DIFF
--- a/src/cron/persisted-shape.test.ts
+++ b/src/cron/persisted-shape.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import { getInvalidPersistedCronJobReason } from "./persisted-shape.js";
+
+describe("getInvalidPersistedCronJobReason", () => {
+  const validSchedule = { kind: "cron", expr: "0 9 * * *" };
+
+  it("accepts systemEvent with text", () => {
+    expect(
+      getInvalidPersistedCronJobReason({
+        id: "job-1",
+        schedule: validSchedule,
+        payload: { kind: "systemEvent", text: "hello" },
+      }),
+    ).toBeNull();
+  });
+
+  it("accepts agentTurn with message", () => {
+    expect(
+      getInvalidPersistedCronJobReason({
+        id: "job-2",
+        schedule: validSchedule,
+        payload: { kind: "agentTurn", message: "run task" },
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects systemEvent missing text", () => {
+    expect(
+      getInvalidPersistedCronJobReason({
+        id: "job-3",
+        schedule: validSchedule,
+        payload: { kind: "systemEvent" },
+      }),
+    ).toBe("invalid-payload");
+  });
+
+  it("rejects agentTurn with empty message", () => {
+    expect(
+      getInvalidPersistedCronJobReason({
+        id: "job-4",
+        schedule: validSchedule,
+        payload: { kind: "agentTurn", message: "   " },
+      }),
+    ).toBe("invalid-payload");
+  });
+
+  it("accepts legacy payload.kind 'command'", () => {
+    expect(
+      getInvalidPersistedCronJobReason({
+        id: "legacy-command",
+        schedule: validSchedule,
+        payload: { kind: "command", text: "/usr/bin/run.sh" },
+      }),
+    ).toBeNull();
+  });
+
+  it("accepts legacy payload.kind 'agentmessage'", () => {
+    expect(
+      getInvalidPersistedCronJobReason({
+        id: "legacy-agentmessage",
+        schedule: validSchedule,
+        payload: { kind: "agentmessage", message: "Daily standup" },
+      }),
+    ).toBeNull();
+  });
+
+  it("accepts arbitrary non-empty string payload.kind", () => {
+    expect(
+      getInvalidPersistedCronJobReason({
+        id: "custom-kind",
+        schedule: validSchedule,
+        payload: { kind: "customWebhook", url: "https://example.com" },
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects missing payload.kind", () => {
+    expect(
+      getInvalidPersistedCronJobReason({
+        id: "job-5",
+        schedule: validSchedule,
+        payload: {},
+      }),
+    ).toBe("invalid-payload");
+  });
+
+  it("rejects empty string payload.kind", () => {
+    expect(
+      getInvalidPersistedCronJobReason({
+        id: "job-6",
+        schedule: validSchedule,
+        payload: { kind: "" },
+      }),
+    ).toBe("invalid-payload");
+  });
+
+  it("rejects numeric payload.kind", () => {
+    expect(
+      getInvalidPersistedCronJobReason({
+        id: "job-7",
+        schedule: validSchedule,
+        payload: { kind: 123 },
+      }),
+    ).toBe("invalid-payload");
+  });
+});

--- a/src/cron/persisted-shape.ts
+++ b/src/cron/persisted-shape.ts
@@ -53,7 +53,7 @@ export function getInvalidPersistedCronJobReason(
   }
   const payloadRecord = payload as Record<string, unknown>;
   const payloadKind = payloadRecord.kind;
-  if (payloadKind !== "systemEvent" && payloadKind !== "agentTurn") {
+  if (typeof payloadKind !== "string" || !payloadKind.trim()) {
     return "invalid-payload";
   }
   if (payloadKind === "systemEvent") {


### PR DESCRIPTION
## Summary

- `getInvalidPersistedCronJobReason` in `src/cron/persisted-shape.ts` rejected any `payload.kind` that was not exactly `"systemEvent"` or `"agentTurn"`, silently dropping cron jobs with legacy kinds (e.g. `"command"`, `"agentmessage"`) from the loaded set on every store reload cycle.
- Relax the validation to only reject missing or non-string `payload.kind` values. Known kinds (`systemEvent`, `agentTurn`) retain their structural validation; unknown kinds pass through so that `doctor-cron-store-migration` can normalize them later.
- This is a **preservation-only fix**: legacy-kind jobs survive store reload but are not yet converted to runnable canonical payloads by the existing doctor migration. A separate follow-up can add migration for specific legacy kinds.
- What did NOT change: schedule validation, payload object presence check, `systemEvent` text validation, `agentTurn` message validation, store reload cycle, sessionTarget defaulting logic, runtime execution path.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security
- [ ] Chore

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Real behavior proof

**Behavior addressed:** Cron jobs with legacy `payload.kind` values (e.g. `"command"`, `"agentmessage"`) were silently dropped from the loaded set because the persisted store validation only accepted `"systemEvent"` or `"agentTurn"`. Three production cron jobs were lost for 12 days before discovery.

**Real environment tested:** Node 22.x on Linux, `node --import tsx` against the actual `getInvalidPersistedCronJobReason` production function from source.

**Exact steps or command run after the patch:**

1. Ran `node --import tsx` calling `getInvalidPersistedCronJobReason` directly from `src/cron/persisted-shape.ts` with 10 different payload inputs (legacy kinds, valid kinds, invalid kinds)
2. Ran regression test suite `src/cron/persisted-shape.test.ts` (10 test cases)

**Evidence after fix:**

Terminal output from `node --import tsx` calling the actual production function:

    getInvalidPersistedCronJobReason — live production function output:

      [legacy-command] VALID (null)
      [legacy-agentmsg] VALID (null)
      [valid-systemEvent] VALID (null)
      [valid-agentTurn] VALID (null)
      [arbitrary-kind] VALID (null)
      [empty-kind] INVALID: invalid-payload
      [numeric-kind] INVALID: invalid-payload
      [missing-payload] INVALID: missing-payload
      [systemEvent-no-text] INVALID: invalid-payload
      [agentTurn-empty-msg] INVALID: invalid-payload

Regression test suite:

    RUN  v4.1.7
     Test Files  1 passed (1)
          Tests  10 passed (10)
      Duration  1.37s

**Observed result after the fix:** Legacy payload kinds `"command"` and `"agentmessage"` now return VALID (null) — they survive the validate → load cycle. Invalid inputs (missing kind, empty kind, numeric kind) are still correctly rejected. Known kinds retain structural validation (systemEvent requires text, agentTurn requires non-empty message). All 10 regression tests pass.

**What was not tested:** Live cron store file write/read cycle on disk; `doctor --fix` migration of legacy kinds to canonical forms; runtime execution of non-canonical payload kinds.

## Root Cause

- Root cause: `getInvalidPersistedCronJobReason` used a strict two-kind whitelist that rejected all legacy/custom payload kinds, causing `ensureLoaded` to silently skip them via the `continue` at `src/cron/service/store.ts:104`.
- Missing detection: no allowlist extensibility or passthrough for unknown-but-valid kinds; `saveCronStore` then persisted the filtered in-memory set, making the data loss durable.

## Regression Test Plan

- Coverage level: unit test
- Target test file: `src/cron/persisted-shape.test.ts` (new, 10 test cases)
- Scenario: legacy kinds (`command`, `agentmessage`) and arbitrary string kinds return `null` (valid); missing/empty/numeric kinds return `"invalid-payload"`; known kinds retain structural checks.
- Why this is the smallest reliable guardrail: locks the relaxed validation contract without requiring a live cron store.

## Compatibility Note

This PR is intentionally **preservation-only**: it prevents data loss by allowing legacy-kind jobs to survive the store reload cycle, but does not add execution or migration for non-canonical payload kinds. The existing `doctor-cron-store-migration` can be extended in a follow-up to convert specific legacy kinds to runnable canonical payloads.

Closes #84922
