### PR TITLE
fix(agent): treat Anthropic long-context usage errors as context overflow for compact+retry

### DIFF
--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -164,12 +164,15 @@ Look for:
 - Current Anthropic credential is not eligible for long-context usage.
 - Requests fail only on long sessions/model runs that need the 1M context path.
 
+OpenClaw classifies this specific 429 body as a context overflow rather than a transient rate limit, so the runtime automatically attempts **compact + retry** to refit the prompt into the model's window before surfacing the error. If the session fits after compaction, the retry succeeds without operator intervention. If compaction is not enough (or repeated retries keep hitting the same body), the manual options below apply.
+
 Fix options:
 
 <Steps>
   <Step title="Use a standard context window">
     Switch to a standard-window model, or remove legacy `context1m` from older
-    model config that is not GA-capable for 1M context.
+    model config that is not GA-capable for 1M context. Useful when the session
+    keeps tripping this 429 even after compact + retry.
   </Step>
   <Step title="Use an eligible credential">
     Use an Anthropic credential that is eligible for long-context requests, or switch to an Anthropic API key.

--- a/docs/help/faq-first-run.md
+++ b/docs/help/faq-first-run.md
@@ -540,7 +540,9 @@ and troubleshooting see the main [FAQ](/help/faq).
     If the message is specifically `Extra usage is required for long context requests`,
     the request is trying to use Anthropic's 1M context window (a GA-capable 1M Claude 4.x
     model, or legacy `params.context1m: true` config), and your current credential is not
-    eligible for long-context billing.
+    eligible for long-context billing. OpenClaw classifies this body as a context overflow
+    and automatically attempts **compact + retry**, so if the
+    session fits after compaction the retry succeeds without operator intervention.
 
     Set a **fallback model** so OpenClaw keeps replying while a provider is rate-limited.
     See [Models](/cli/models), [OAuth](/concepts/oauth), and

--- a/src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts
@@ -6,6 +6,7 @@ import {
   classifyFailoverReason,
   classifyFailoverReasonFromHttpStatus,
   extractObservedOverflowTokenCount,
+  isAnthropicLongContextUsageError,
   isAuthErrorMessage,
   isAuthPermanentErrorMessage,
   isBillingErrorMessage,
@@ -484,6 +485,28 @@ describe("error classifiers", () => {
   });
 });
 
+describe("isAnthropicLongContextUsageError", () => {
+  it("detects Anthropic long-context usage errors", () => {
+    expect(
+      isAnthropicLongContextUsageError("Extra usage is required for long context requests."),
+    ).toBe(true);
+    expect(
+      isAnthropicLongContextUsageError("extra usage is required for long context requests"),
+    ).toBe(true);
+    expect(
+      isAnthropicLongContextUsageError(
+        "429 Extra usage is required for long context requests. Please contact support.",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not match unrelated rate limit messages", () => {
+    expect(isAnthropicLongContextUsageError("Rate limit exceeded")).toBe(false);
+    expect(isAnthropicLongContextUsageError("429 Too Many Requests")).toBe(false);
+    expect(isAnthropicLongContextUsageError("context length exceeded")).toBe(false);
+  });
+});
+
 describe("isLikelyContextOverflowError", () => {
   it("matches context overflow hints", () => {
     const samples = [
@@ -538,6 +561,20 @@ describe("isLikelyContextOverflowError", () => {
       expect(isBillingErrorMessage(sample)).toBe(true);
       expect(isLikelyContextOverflowError(sample)).toBe(false);
     }
+  });
+
+  it("treats Anthropic long-context 429 as context overflow (not rate limit)", () => {
+    // Anthropic returns HTTP 429 for this message, but it is semantically a context
+    // overflow — the session is too large. It should route to compact+retry, not
+    // model fallback.
+    expect(isLikelyContextOverflowError("Extra usage is required for long context requests.")).toBe(
+      true,
+    );
+    expect(isLikelyContextOverflowError("extra usage is required for long context requests")).toBe(
+      true,
+    );
+    // Standard rate limit messages must still be excluded
+    expect(isLikelyContextOverflowError("Rate limit exceeded")).toBe(false);
   });
 });
 

--- a/src/agents/embedded-agent-helpers.ts
+++ b/src/agents/embedded-agent-helpers.ts
@@ -35,6 +35,7 @@ export {
   isCloudflareOrHtmlErrorPage,
   isCloudCodeAssistFormatError,
   isCompactionFailureError,
+  isAnthropicLongContextUsageError,
   isContextOverflowError,
   isLikelyContextOverflowError,
   isFailoverAssistantError,

--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -170,6 +170,17 @@ const CONTEXT_OVERFLOW_HINT_RE =
 const RATE_LIMIT_HINT_RE =
   /rate limit|too many requests|requests per (?:minute|hour|day)|quota|throttl|429\b|tokens per day/i;
 
+/**
+ * Detects Anthropic's 429 "Extra usage is required for long context requests." error.
+ *
+ * Anthropic returns HTTP 429 for this case, but it is semantically a context overflow
+ * (the session is too large for the standard usage tier), not a transient rate limit.
+ * It should be routed to the compact+retry path instead of the model fallback chain.
+ */
+export function isAnthropicLongContextUsageError(errorMessage: string): boolean {
+  return errorMessage.toLowerCase().includes("extra usage is required for long context");
+}
+
 export function isLikelyContextOverflowError(errorMessage?: string): boolean {
   if (!errorMessage) {
     return false;
@@ -184,6 +195,16 @@ export function isLikelyContextOverflowError(errorMessage?: string): boolean {
     return false;
   }
 
+  // Anthropic returns HTTP 429 for "Extra usage is required for long context requests."
+  // The semantically correct recovery is compact + retry on the standard tier, not
+  // billing-style "out of credits" handling — the request is rejected because the
+  // session is too large for the standard usage tier, not because credits are out.
+  // Check here, before isBillingErrorMessage, because the billing classifier matches
+  // "extra usage is required" via failover-matches.ts and would otherwise short-circuit.
+  if (isAnthropicLongContextUsageError(errorMessage)) {
+    return true;
+  }
+
   // Billing/quota errors can contain patterns like "request size exceeds" or
   // "maximum token limit exceeded" that match the context overflow heuristic.
   // Billing is a more specific error class — exclude it early.
@@ -194,6 +215,7 @@ export function isLikelyContextOverflowError(errorMessage?: string): boolean {
   if (CONTEXT_WINDOW_TOO_SMALL_RE.test(errorMessage)) {
     return false;
   }
+
   // Rate limit errors can match the broad CONTEXT_OVERFLOW_HINT_RE pattern
   // (e.g., "request reached organization TPD rate limit" matches request.*limit).
   // Exclude them before checking context overflow heuristics.

--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -178,7 +178,9 @@ const RATE_LIMIT_HINT_RE =
  * It should be routed to the compact+retry path instead of the model fallback chain.
  */
 export function isAnthropicLongContextUsageError(errorMessage: string): boolean {
-  return errorMessage.toLowerCase().includes("extra usage is required for long context");
+  return normalizeLowercaseStringOrEmpty(errorMessage).includes(
+    "extra usage is required for long context",
+  );
 }
 
 export function isLikelyContextOverflowError(errorMessage?: string): boolean {

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts
@@ -602,6 +602,61 @@ describe("overflow compaction in run loop", () => {
     expect(result.payloads?.[0]?.isError).toBe(true);
   });
 
+  it("routes the Anthropic long-context 429 through compaction and terminates blocked without model fallback", async () => {
+    // Use the REAL classifiers: the harness default mockedIsLikelyContextOverflowError
+    // reimplements only request_too_large-style patterns and never matches this body,
+    // so this test would prove nothing about the reorder without the actual module.
+    const actualErrors = await vi.importActual<
+      typeof import("../embedded-agent-helpers/errors.js")
+    >("../embedded-agent-helpers/errors.js");
+    mockedIsLikelyContextOverflowError.mockImplementation(
+      actualErrors.isLikelyContextOverflowError,
+    );
+    mockedIsCompactionFailureError.mockImplementation(actualErrors.isCompactionFailureError);
+
+    const longContextBody =
+      '429 {"type":"error","error":{"type":"rate_limit_error","message":"Extra usage is required for long context requests."}}';
+    // The billing classifier still matches this body; only the early return inside
+    // isLikelyContextOverflowError reroutes it to overflow recovery instead.
+    expect(actualErrors.isBillingErrorMessage(longContextBody)).toBe(true);
+    expect(actualErrors.isLikelyContextOverflowError(longContextBody)).toBe(true);
+
+    // 4 overflow attempts: 3 compact+retry cycles, then exhausted recovery.
+    mockedRunEmbeddedAttempt.mockResolvedValue(
+      makeAttemptResult({ promptError: makeOverflowError(longContextBody) }),
+    );
+    mockedCompactDirect
+      .mockResolvedValueOnce(
+        makeCompactionSuccess({ summary: "Compacted 1", tokensBefore: 180000 }),
+      )
+      .mockResolvedValueOnce(
+        makeCompactionSuccess({ summary: "Compacted 2", tokensBefore: 160000 }),
+      )
+      .mockResolvedValueOnce(
+        makeCompactionSuccess({ summary: "Compacted 3", tokensBefore: 140000 }),
+      );
+
+    const result = await runEmbeddedAgent(baseParams);
+
+    // Classified as context overflow, not billing/rate-limit: compaction ran.
+    expect(mockedCompactDirect).toHaveBeenCalledTimes(3);
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(4);
+    // Every retry stayed on the original model; overflow never selects a fallback
+    // model (model-fallback.ts rethrows context-overflow so the runner owns it).
+    for (let attemptIndex = 0; attemptIndex < 4; attemptIndex++) {
+      const attemptParams = requireMockCallArg(mockedRunEmbeddedAttempt, attemptIndex);
+      expect(attemptParams.provider).toBe("anthropic");
+      expect(attemptParams.modelId).toBe("test-model");
+      expect(attemptParams.fallbackActive).toBe(false);
+    }
+    // Canonical blocked terminal result after exhausted overflow recovery.
+    expect(result.meta.error?.kind).toBe("context_overflow");
+    expect(result.meta.error?.message).toContain("Extra usage is required for long context");
+    expect(result.meta.livenessState).toBe("blocked");
+    expect(result.payloads?.[0]?.isError).toBe(true);
+    expect(result.payloads?.[0]?.text).toContain("Context overflow");
+  });
+
   it("succeeds after second compaction attempt", async () => {
     const overflowError = makeOverflowError();
 


### PR DESCRIPTION
## Summary

Re-opening as new PR after #52030 was auto-closed by barnaclebot for the 10-PR cap; reviewers and Greptile evaluated the fix positively at the time and the underlying bug still applies on current main.

Anthropic returns HTTP 429 with body `"Extra usage is required for long context requests."` when a request hits the long-context usage tier. Today the runtime classifies this through `isBillingErrorMessage` (which was extended in `failover-matches.ts` to match `/extra usage is required(?: for long context requests)?/i`), short-circuiting before any context-overflow handling. The right recovery is **compact + retry on the standard tier**, the session is too large for the standard usage tier, not a payment failure.

This PR adds `isAnthropicLongContextUsageError(message)` and inserts it into `isLikelyContextOverflowError` BEFORE the `isBillingErrorMessage` exclusion, so the long-context 429 routes to compact+retry rather than the billing fallback path.

## Files

- `src/agents/embedded-agent-helpers/errors.ts`: new classifier + early-return inserted before the billing exclusion
- `src/agents/embedded-agent-helpers.ts`: re-export
- `src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts`: coverage for the new classifier and the overflow short-circuit
- `docs/gateway/troubleshooting.md`, `docs/help/faq-first-run.md`: document the compact+retry recovery path

## Real behavior proof

- Behavior addressed: An Anthropic HTTP 429 with body `Extra usage is required for long context requests.` is currently classified as a billing error by `isBillingErrorMessage` via the regex added in `src/agents/embedded-agent-helpers/failover-matches.ts`. That short-circuits `isLikelyContextOverflowError` and routes the request into the billing/model-fallback chain instead of the compact+retry path. The reorder in this PR detects the long-context body before the billing exclusion runs, so the runtime drives `compactAndRetry` on the standard tier instead of failing over.
- Real environment tested: live deployed openclaw gateway on rh-bot.lan, pid 71842, build SHA 23804e610c (upgrade-v2026.5.28 with this PR cherry-picked). macOS Darwin 25.5.0, Node v25.8.2, `/opt/homebrew/bin/openclaw`. The patched deployed bundle is the local production build of upgrade-v2026.5.28 with PR #84972 layered on top, staged under `/tmp/openclaw-pr-84972/dist/` on the same host as the running gateway; the deployed gateway dist at `/Users/alexm/.openclaw/openclaw/dist/` is the same source tree without this PR and is used as the pre-fix baseline.
- Exact steps or command run after this patch:
  ```
  ssh alexm@rh-bot.lan
  ls -la /Users/alexm/.openclaw/openclaw/dist/.buildstamp
  # -> {"builtAt":...,"head":"23804e610c998a0532e0c90441b130b38e5e8cc8"}
  ps -p 71842 -o pid,etime,command
  grep -l "isAnthropicLongContextUsageError" /tmp/openclaw-pr-84972/dist/*.js
  # -> /tmp/openclaw-pr-84972/dist/errors-Br4OcmFZ.js
  node /tmp/proof-84972-amittell-baseline.mjs   # pre-patch baseline against live deployed bundle
  node /tmp/proof-84972-amittell.mjs            # post-patch behavior against patched deployed bundle
  ```
- Evidence after fix: realistic Anthropic error payloads exercised against the patched deployed bundle on rh-bot.lan. Output of `node /tmp/proof-84972-amittell.mjs`:
  ```
  --- direct isAnthropicLongContextUsageError checks ---
  PASS longContext.isAnthropicLongContextUsageError: true
  PASS rateLimit.isAnthropicLongContextUsageError: false
  PASS promptTooLong.isAnthropicLongContextUsageError: false
  PASS unrelated.isAnthropicLongContextUsageError: false
  --- isLikelyContextOverflowError routing ---
  PASS longContext.isLikelyContextOverflowError: true
  PASS rateLimit.isLikelyContextOverflowError: false
  PASS promptTooLong.isLikelyContextOverflowError: true
  PASS unrelated.isLikelyContextOverflowError: false

  RESULT PASS (all checks)
  ```
  Output of `node /tmp/proof-84972-amittell-baseline.mjs` against the live deployed unpatched bundle on the same host:
  ```
  pre-patch isLikelyContextOverflowError(longContextMessage) = false
  BASELINE CONFIRMED: pre-patch deployed bundle misclassifies Anthropic long-context 429
  ```
- Observed result after fix: `isLikelyContextOverflowError("Extra usage is required for long context requests.")` returns `true` against the patched deployed bundle, where the same call against the live deployed unpatched bundle returns `false`. The canonical Anthropic context-overflow body `prompt is too long` continues to return `true`, the rate-limit body `Number of request tokens exceeds the rate limit` continues to return `false`, and unrelated server errors continue to return `false`, so the reorder only flips the long-context 429 case and leaves every neighboring classifier path untouched.
- What was not tested: end-to-end observation of an Anthropic 429 with the long-context body actually arriving at the deployed gateway and driving `compactAndRetry` through to a successful retry. Reproducing the upstream 429 requires a real Anthropic account above the standard usage tier and a payload large enough to trip the long-context check, which is not reliably reproducible from the lab hosts. The classifier surface that decides the routing has been exercised directly against the patched deployed bundle, and the equivalent in-tree unit suites under `src/agents/embedded-agent-helpers/` pass locally.

## Refs

- Superseded close: #52030 (barnaclebot 10-PR cap auto-close, no merit rejection)
- Original Greptile review on #52030 confirmed the misclassification path


## Post-rebase verification (2026-07-08, head df072e54b6)

Rebased onto current `upstream/main` (d3ff48c51f), conflict-free; none of the intervening commits touch this PR's files or the overflow-recovery harness. The earlier docs conflict resolution (previous rebase onto 22376d80e1) is preserved: `docs/help/faq-first-run.md` re-applies the compact+retry sentence onto main's condensed accordion shape, and `docs/gateway/troubleshooting.md` was trimmed so the fallback-model step no longer implies configured fallback models engage after exhausted compaction, matching the `model-fallback.ts` contract that rethrows context-overflow errors instead of failing over.

### Fixture proof: full runner path with the real classifier

New runner-level test in `src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts`, extending the existing overflow-compaction harness:

> `overflow compaction in run loop > routes the Anthropic long-context 429 through compaction and terminates blocked without model fallback`

The harness's default `mockedIsLikelyContextOverflowError` is a reimplementation that only matches `request_too_large`-style bodies, so the test swaps in the real classifiers via `vi.importActual("../embedded-agent-helpers/errors.js")` and feeds a synthetic Anthropic 429 carrying the exact body `"Extra usage is required for long context requests."` through `runEmbeddedAgent`. It proves, end to end inside the embedded runner:

- the body still matches `isBillingErrorMessage` (asserted as a sanity check); only this PR's early return inside `isLikelyContextOverflowError` reroutes it, so it is classified as context overflow, not billing or rate limit;
- compaction is attempted: 3 compact+retry cycles, 4 attempts total;
- every retry stays on the original `anthropic/test-model` with `fallbackActive: false`; no fallback model is ever selected, matching the `model-fallback.ts:1789-1796` contract that rethrows context-overflow errors so the runner's compaction owns them;
- after exhausted compaction the run terminates with the canonical blocked result: `meta.error.kind === "context_overflow"`, `meta.livenessState === "blocked"`, and an error payload with the standard reset/new guidance.

```
$ node scripts/run-vitest.mjs run src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts
[test] starting test/vitest/vitest.unit-fast.config.ts
 Test Files  1 passed (1)
      Tests  149 passed (149)
[test] starting test/vitest/vitest.agents.config.ts
 Test Files  1 passed (1)
      Tests  30 passed (30)
[test] passed 2 Vitest shards in 34.56s
```

Note on the terminal state: terminating blocked after exhausted compaction (instead of engaging configured fallback models) is the pre-existing `main` contract for ALL context-overflow errors, asserted by the pre-existing exhaustion cases in `run.overflow-compaction.loop.test.ts` (`context_overflow` / `compaction_failure` kinds) and enforced by the deliberate context-overflow rethrow in `model-fallback.ts`. This PR only makes the Anthropic long-context 429 join that existing contract; the exhausted-overflow terminal-state redesign is tracked separately in #9986. Explicitly decided: status quo here.

The classifier suite at the new head still includes main's newer tests asserting the exact long-context body continues to classify as billing via `isBillingErrorMessage` / `classifyFailoverReason` (this PR only reorders `isLikelyContextOverflowError` and leaves those classifiers untouched). Lint (`scripts/run-oxlint.mjs`) and `oxfmt --check` on the touched TS files are clean.

