### PR TITLE
feat: handle gemma 4 format tool call

### DIFF
--- a/extensions/lmstudio/src/stream.ts
+++ b/extensions/lmstudio/src/stream.ts
@@ -161,6 +161,7 @@ function couldStillBePlainTextToolCall(text: string): boolean {
     trimmed.startsWith("[") ||
     trimmed.startsWith("<|channel|>") ||
     trimmed.startsWith("commentary") ||
+    trimmed.startsWith("<|tool_call>") ||
     trimmed.startsWith("analysis") ||
     trimmed.startsWith("final")
   );

--- a/src/plugin-sdk/tool-payload.test.ts
+++ b/src/plugin-sdk/tool-payload.test.ts
@@ -105,6 +105,36 @@ describe("parseStandalonePlainTextToolCallBlocks", () => {
 
     expect(blocks).toBeNull();
   });
+
+  it("parses Gemma tool calls", () => {
+    const raw = '<|tool_call>call:exec{command:<|"|>ls -a<|"|>}<tool_call|>';
+    const blocks = parseStandalonePlainTextToolCallBlocks(raw);
+
+    expect(blocks).toEqual([
+      {
+        name: "exec",
+        arguments: { command: "ls -a" },
+        start: 0,
+        end: raw.length,
+        raw,
+      },
+    ]);
+  });
+
+  it("parses Gemma tool calls with response marker", () => {
+    const raw = '<|tool_call>call:exec{command:<|"|>ls -a<|"|>}<tool_call|><|tool_response>';
+    const blocks = parseStandalonePlainTextToolCallBlocks(raw);
+
+    expect(blocks).toEqual([
+      {
+        name: "exec",
+        arguments: { command: "ls -a" },
+        start: 0,
+        end: raw.length,
+        raw,
+      },
+    ]);
+  });
 });
 
 describe("stripPlainTextToolCallBlocks", () => {
@@ -120,6 +150,14 @@ describe("stripPlainTextToolCallBlocks", () => {
     expect(
       stripPlainTextToolCallBlocks(
         'before\ncommentary to=read code {"path":"/tmp/file.txt"}\nafter',
+      ),
+    ).toBe("before\nafter");
+  });
+
+  it("strip gemma tool calls", () => {
+    expect(
+      stripPlainTextToolCallBlocks(
+        'before\n<|tool_call>call:exec{command:<|"|>ls -a<|"|>}<tool_call|>\nafter',
       ),
     ).toBe("before\nafter");
   });

--- a/src/plugin-sdk/tool-payload.ts
+++ b/src/plugin-sdk/tool-payload.ts
@@ -60,11 +60,20 @@ const END_TOOL_REQUEST = "[END_TOOL_REQUEST]";
 const HARMONY_CHANNEL_MARKER = "<|channel|>";
 const HARMONY_MESSAGE_MARKER = "<|message|>";
 const HARMONY_CALL_MARKER = "<|call|>";
+const GEMMA_CALL_OPENING = "<|tool_call>call:";
+const GEMMA_CALL_CLOSING = "<tool_call|>";
+const GEMMA_CALL_CLOSING_RESPONSE = "<|tool_response>";
+
+enum ToolCallFormat {
+  Bracket,
+  Harmony,
+  Gemma,
+}
 
 type PlainTextToolCallOpening = {
+  format: ToolCallFormat;
   end: number;
   name: string;
-  requiresClosing: boolean;
 };
 
 function isToolNameChar(char: string | undefined): boolean {
@@ -116,7 +125,7 @@ function parseBracketOpening(text: string, start: number): PlainTextToolCallOpen
   if (afterLineBreak === null) {
     return null;
   }
-  return { end: afterLineBreak, name, requiresClosing: true };
+  return { format: ToolCallFormat.Bracket, end: afterLineBreak, name };
 }
 
 function parseHarmonyOpening(text: string, start: number): PlainTextToolCallOpening | null {
@@ -154,11 +163,35 @@ function parseHarmonyOpening(text: string, start: number): PlainTextToolCallOpen
   if (text.startsWith(HARMONY_MESSAGE_MARKER, cursor)) {
     cursor = skipWhitespace(text, cursor + HARMONY_MESSAGE_MARKER.length);
   }
-  return { end: cursor, name, requiresClosing: false };
+  return { format: ToolCallFormat.Harmony, end: cursor, name };
+}
+
+function parseGemmaOpening(text: string, start: number): PlainTextToolCallOpening | null {
+  let cursor = start;
+  if (!text.startsWith(GEMMA_CALL_OPENING, cursor)) {
+    return null;
+  }
+  cursor += GEMMA_CALL_OPENING.length;
+  let nameStart = cursor;
+  while (isToolNameChar(text[cursor])) {
+    cursor += 1;
+  }
+  if (cursor === nameStart) {
+    return null;
+  }
+  const name = text.slice(nameStart, cursor);
+  if (text[cursor] !== "{") {
+    return null;
+  }
+  return { format: ToolCallFormat.Gemma, end: cursor, name };
 }
 
 function parseOpening(text: string, start: number): PlainTextToolCallOpening | null {
-  return parseBracketOpening(text, start) ?? parseHarmonyOpening(text, start);
+  return (
+    parseBracketOpening(text, start) ??
+    parseHarmonyOpening(text, start) ??
+    parseGemmaOpening(text, start)
+  );
 }
 
 function consumeJsonObject(
@@ -213,6 +246,113 @@ function consumeJsonObject(
   return null;
 }
 
+/**
+ * Recursively parses Gemma's proprietary argument format, converting
+ * `<|"|>string<|"|>`, unquoted keys, standard strings, and primitives into a JS object.
+ * Ref: https://ai.google.dev/gemma/docs/core/prompt-formatting-gemma4
+ */
+function parseGemmaValue(text: string, cursor: number): { value: unknown; end: number } | null {
+  cursor = skipWhitespace(text, cursor);
+  if (cursor >= text.length) {
+    return null;
+  }
+  if (text.startsWith('<|"|>', cursor)) {
+    const startStr = cursor + 5;
+    const endStr = text.indexOf('<|"|>', startStr);
+    if (endStr === -1) {
+      return null;
+    }
+    return { value: text.slice(startStr, endStr), end: endStr + 5 };
+  }
+  if (text[cursor] === '"' || text[cursor] === "'") {
+    const quoteChar = text[cursor];
+    let strEnd = cursor + 1;
+    while (strEnd < text.length) {
+      if (text[strEnd] === quoteChar && text[strEnd - 1] !== "\\") {
+        break;
+      }
+      strEnd++;
+    }
+    if (strEnd >= text.length) {
+      return null;
+    }
+    const rawVal = text.slice(cursor + 1, strEnd).replace(/\\(.)/g, "$1");
+    return { value: rawVal, end: strEnd + 1 };
+  }
+  if (text[cursor] === "{") {
+    const obj: Record<string, unknown> = {};
+    cursor++;
+    while (cursor < text.length) {
+      cursor = skipWhitespace(text, cursor);
+      if (text[cursor] === "}") {
+        return { value: obj, end: cursor + 1 };
+      }
+      const keyMatch = text.slice(cursor).match(/^(?:["'])?([A-Za-z0-9_-]+)(?:["'])?\s*:/);
+      if (!keyMatch) {
+        return null;
+      }
+      const key = keyMatch[1];
+      cursor += keyMatch[0].length;
+      const valResult = parseGemmaValue(text, cursor);
+      if (!valResult) {
+        return null;
+      }
+      obj[key] = valResult.value;
+      cursor = valResult.end;
+      cursor = skipWhitespace(text, cursor);
+      if (text[cursor] === ",") {
+        cursor++;
+      } else if (text[cursor] !== "}") {
+        return null;
+      }
+    }
+    return null;
+  }
+  if (text[cursor] === "[") {
+    const arr: unknown[] = [];
+    cursor++;
+    while (cursor < text.length) {
+      cursor = skipWhitespace(text, cursor);
+      if (text[cursor] === "]") {
+        return { value: arr, end: cursor + 1 };
+      }
+      const valResult = parseGemmaValue(text, cursor);
+      if (!valResult) {
+        return null;
+      }
+      arr.push(valResult.value);
+      cursor = valResult.end;
+      cursor = skipWhitespace(text, cursor);
+      if (text[cursor] === ",") {
+        cursor++;
+      } else if (text[cursor] !== "]") {
+        return null;
+      }
+    }
+    return null;
+  }
+  const primitiveMatch = text.slice(cursor).match(/^[^,}\]\s]+/);
+  if (!primitiveMatch) {
+    return null;
+  }
+  const rawVal = primitiveMatch[0];
+  cursor += rawVal.length;
+  if (rawVal === "true") {
+    return { value: true, end: cursor };
+  }
+  if (rawVal === "false") {
+    return { value: false, end: cursor };
+  }
+  if (rawVal === "null") {
+    return { value: null, end: cursor };
+  }
+  const num = Number(rawVal);
+  if (!Number.isNaN(num)) {
+    return { value: num, end: cursor };
+  }
+  return { value: rawVal, end: cursor };
+}
+
 function parseClosing(text: string, start: number, name: string): number | null {
   const cursor = skipWhitespace(text, start);
   if (text.startsWith(END_TOOL_REQUEST, cursor)) {
@@ -248,27 +388,57 @@ function parsePlainTextToolCallBlockAt(
   if (allowedToolNames && !allowedToolNames.has(opening.name)) {
     return null;
   }
-  const payload = consumeJsonObject(
-    text,
-    opening.end,
-    options?.maxPayloadBytes ?? DEFAULT_MAX_PLAIN_TEXT_TOOL_PAYLOAD_BYTES,
-  );
-  if (!payload) {
-    return null;
+  if (opening.format == ToolCallFormat.Bracket || opening.format == ToolCallFormat.Harmony) {
+    const payload = consumeJsonObject(
+      text,
+      opening.end,
+      options?.maxPayloadBytes ?? DEFAULT_MAX_PLAIN_TEXT_TOOL_PAYLOAD_BYTES,
+    );
+    if (!payload) {
+      return null;
+    }
+    const closingEnd =
+      opening.format == ToolCallFormat.Bracket
+        ? parseClosing(text, payload.end, opening.name)
+        : parseOptionalHarmonyClosing(text, payload.end);
+    if (closingEnd === null) {
+      return null;
+    }
+    return {
+      arguments: payload.value,
+      end: closingEnd,
+      name: opening.name,
+      raw: text.slice(start, closingEnd),
+      start,
+    };
+  } else if (opening.format == ToolCallFormat.Gemma) {
+    const parsedPayload = parseGemmaValue(text, opening.end);
+    if (!parsedPayload) {
+      return null;
+    }
+    let cursor = skipWhitespace(text, parsedPayload.end);
+    if (!text.startsWith(GEMMA_CALL_CLOSING, cursor)) {
+      return null;
+    }
+    let closingEnd = cursor + GEMMA_CALL_CLOSING.length;
+    if (text.startsWith(GEMMA_CALL_CLOSING_RESPONSE, closingEnd)) {
+      closingEnd += GEMMA_CALL_CLOSING_RESPONSE.length;
+    }
+    if (
+      closingEnd - start >
+      (options?.maxPayloadBytes ?? DEFAULT_MAX_PLAIN_TEXT_TOOL_PAYLOAD_BYTES)
+    ) {
+      return null;
+    }
+    return {
+      arguments: parsedPayload.value as Record<string, unknown>,
+      end: closingEnd,
+      name: opening.name,
+      raw: text.slice(start, closingEnd),
+      start,
+    };
   }
-  const closingEnd = opening.requiresClosing
-    ? parseClosing(text, payload.end, opening.name)
-    : parseOptionalHarmonyClosing(text, payload.end);
-  if (closingEnd === null) {
-    return null;
-  }
-  return {
-    arguments: payload.value,
-    end: closingEnd,
-    name: opening.name,
-    raw: text.slice(start, closingEnd),
-    start,
-  };
+  return null;
 }
 
 export function parseStandalonePlainTextToolCallBlocks(
@@ -292,7 +462,8 @@ export function stripPlainTextToolCallBlocks(text: string): string {
   if (
     !text ||
     (!/\[[A-Za-z0-9_-]+\]/.test(text) &&
-      !/(?:^|\n)\s*(?:<\|channel\|>)?(?:commentary|analysis|final)\s+to=/.test(text))
+      !/(?:^|\n)\s*(?:<\|channel\|>)?(?:commentary|analysis|final)\s+to=/.test(text) &&
+      !text.includes("<|tool_call>call:"))
   ) {
     return text;
   }


### PR DESCRIPTION
## Summary

- Problem: Gemma 4 model might return tool calls in its own format, which are not handled correctly and would leak directly into user prompt
- Solution: Add corresponding parsing logic to intercept these tool calls properly
- What changed: Add parsing logic and corresponding unit test
- What did NOT change: Only add new logic, the original parsing logic didn't change

## Motivation

- Gemma 4 sometimes returns toolcalls with its own format, which makes the toolcall unusable and leaks directly into the user prompt.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: toolcalls in gemma4 format now can be handled correctly
- Real environment tested: using lm studio as provider with model google/gemma-4-e4b
- Exact steps or command run after this patch: tell the openclaw to run command [ls -a]
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): 
 before fix
<img width="1048" height="303" alt="image" src="https://github.com/user-attachments/assets/aca60536-7063-4fcf-93ec-f46cd25b4ee5" />
 after fix
<img width="1061" height="574" alt="image" src="https://github.com/user-attachments/assets/c06f5c60-09ac-4884-adda-6bf3d2651140" />

- Observed result after fix: see above
- What was not tested: test prompt in every scenario
- Before evidence (optional but encouraged): see above

## Root Cause (if applicable)

- Root cause: There is not gemma 4 toolcall format parse in src/plugin-sdk/tool-payload.ts/parsePlainTextToolCallBlockAt
- Missing detection / guardrail:
- Contributing context (if known):

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: ‎src/plugin-sdk/tool-payload.test.ts
- Scenario the test should lock in:
- Why this is the smallest reliable guardrail:
- Existing test that already covers this (if any):
- If no new test is added, why not:

## User-visible / Behavior Changes

None

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: ubuntu
- Runtime/container: OpenClaw 2026.5.18
- Model/provider: lm studio with google/gemma-4-e4b
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1.tell openclaw to run some command

### Expected

- the correcponding command is running

### Actual

- instead of running toolcall, it return a message like <|tool_call>call:exec{command:<|"|>ls -a<|"|>}<tool_call|>

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: 
- Edge cases checked:
- What you did **not** verify:

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

None
