### PR TITLE
feat(mantis): add Discord desktop proof draft

### DIFF
--- a/.agents/skills/discord-crabbox-e2e-proof/SKILL.md
+++ b/.agents/skills/discord-crabbox-e2e-proof/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: discord-crabbox-e2e-proof
+description: Use when reviewing, reproducing, or proving OpenClaw Discord behavior with real Discord Web on Crabbox, including PR review workflows that need an agent-controlled logged-in Discord viewer recording, Convex-leased bot credentials, WebVNC observation, and motion-trimmed artifacts.
+---
+
+# Discord Crabbox E2E Proof
+
+Use this for Discord PR review or bug reproduction when REST proof or rendered HTML is not enough. The goal is to let the agent keep a logged-in Discord Web viewer session open until it is satisfied, then attach visual proof.
+
+Do not use personal accounts. Do not add credentials to the repo, prompt, or artifact bundle. The runner leases shared Discord bot credentials from Convex and uses a dedicated logged-in browser profile as a viewer.
+
+## Start
+
+Run from the OpenClaw repo and branch under test:
+
+```bash
+pnpm qa:discord-web:crabbox -- start \
+  --output-dir .artifacts/qa-e2e/discord-web-crabbox/pr-review
+```
+
+This starts one held session:
+
+- leases the exclusive `discord` Convex credential
+- starts a mock OpenClaw Discord SUT from the current checkout
+- restores a logged-in Discord Web Chrome profile when `MANTIS_DISCORD_VIEWER_CHROME_PROFILE_TGZ_B64` is set, or reuses `MANTIS_DISCORD_VIEWER_CHROME_PROFILE_DIR`
+- opens Discord Web to the leased guild/channel
+- starts a 24fps desktop recording
+- writes `.artifacts/qa-e2e/discord-web-crabbox/pr-review/session.json`
+
+Keep the session alive while investigating. It is valid for the agent to test for minutes, run several commands, use WebVNC, inspect transcripts, and only finish once the behavior is understood.
+
+For deterministic visual repros, put the exact mock-model reply in a file and pass it to `start`:
+
+```bash
+pnpm qa:discord-web:crabbox -- start \
+  --mock-response-file .artifacts/qa-e2e/discord-web-crabbox/reply.txt \
+  --output-dir .artifacts/qa-e2e/discord-web-crabbox/pr-review
+```
+
+The runner defaults to `--class standard`, `--record-fps 24`, `--preview-fps 24`, and `--preview-width 1920`. Keep those defaults unless the proof needs something else.
+
+## While Testing
+
+Send as the driver Discord bot:
+
+```bash
+pnpm qa:discord-web:crabbox -- send \
+  --session .artifacts/qa-e2e/discord-web-crabbox/pr-review/session.json \
+  --text 'Reply exactly: DISCORD-PROOF-123'
+```
+
+The command prints a Discord Web URL and message id. Open Discord Web directly to the newest relevant message before finishing:
+
+```bash
+pnpm qa:discord-web:crabbox -- view \
+  --session .artifacts/qa-e2e/discord-web-crabbox/pr-review/session.json \
+  --message-id <message-id>
+```
+
+Run arbitrary commands on the Crabbox:
+
+```bash
+pnpm qa:discord-web:crabbox -- run \
+  --session .artifacts/qa-e2e/discord-web-crabbox/pr-review/session.json \
+  -- bash -lc 'wmctrl -lxG'
+```
+
+Capture the current desktop without ending the session:
+
+```bash
+pnpm qa:discord-web:crabbox -- screenshot \
+  --session .artifacts/qa-e2e/discord-web-crabbox/pr-review/session.json
+```
+
+Check lease state and get the WebVNC command:
+
+```bash
+pnpm qa:discord-web:crabbox -- status \
+  --session .artifacts/qa-e2e/discord-web-crabbox/pr-review/session.json
+```
+
+## Finish
+
+Always finish or explicitly keep the box:
+
+```bash
+pnpm qa:discord-web:crabbox -- finish \
+  --session .artifacts/qa-e2e/discord-web-crabbox/pr-review/session.json \
+  --preview-crop discord-window
+```
+
+`finish` stops recording, creates motion-trimmed MP4/GIF artifacts, captures a final screenshot and logs, releases the Convex credential, stops the local SUT, and stops the Crabbox lease. `--preview-crop discord-window` also creates a fixed-geometry GIF from the tested Discord proof window for clean side-by-side PR tables; the full desktop video/GIF remains in the artifact directory. Pass `--keep-box` only when a human needs to continue VNC debugging after the credential is released.
+
+After any failure or interruption, verify cleanup:
+
+```bash
+crabbox list --provider aws
+```
+
+If a session file exists and the credential may still be leased, run `finish` with that session file before retrying.
+
+## Attach Proof
+
+Attach only the useful visual artifact to the PR unless logs are needed. The runner is GIF-only by default:
+
+```bash
+pnpm qa:discord-web:crabbox -- publish \
+  --session .artifacts/qa-e2e/discord-web-crabbox/pr-review/session.json \
+  --pr <pr-number> \
+  --summary 'Discord Web Crabbox session motion GIF'
+```
+
+Use `--full-artifacts` only when the PR needs logs or JSON output. Never publish credential payloads, browser cookies, browser profiles, VNC passwords, raw session archives, or local `.session` directories.
+
+For before/after proof, run one session on `main` and one on the PR head, then build the Mantis evidence manifest with `scripts/mantis/build-discord-web-proof-evidence.mjs`.

--- a/.github/codex/prompts/mantis-discord-desktop-proof.md
+++ b/.github/codex/prompts/mantis-discord-desktop-proof.md
@@ -1,0 +1,96 @@
+# Mantis Discord Desktop Proof Agent
+
+You are Mantis running Discord Web visual proof for an OpenClaw PR.
+
+Goal: inspect the pull request, decide whether it has an honest Discord-visible before/after behavior, then either run Discord Web proof or leave a no-visual-proof manifest for the workflow to publish.
+
+Hard limits:
+
+- Do not post GitHub comments or reviews. The workflow publishes the manifest.
+- Do not commit, push, label, merge, or edit PR metadata.
+- Do not print secrets, credential payloads, browser profile data, cookies, VNC passwords, or raw session archives.
+- Do not invent generic proof. The proof must match the PR behavior.
+- Do not force GIFs for internal-only, workflow-only, test-only, docs-only, or otherwise non-visual PRs. A no-visual-proof manifest is a successful outcome when GIFs would be misleading.
+
+Inputs are provided as environment variables:
+
+- `MANTIS_PR_NUMBER`
+- `BASELINE_REF`
+- `BASELINE_SHA`
+- `CANDIDATE_REF`
+- `CANDIDATE_SHA`
+- `MANTIS_CANDIDATE_TRUST`
+- `MANTIS_OUTPUT_DIR`
+- `MANTIS_INSTRUCTIONS`
+- `CRABBOX_PROVIDER`
+- `OPENCLAW_DISCORD_WEB_PROOF_CMD`
+- optional `CRABBOX_LEASE_ID`
+
+Required workflow:
+
+1. Read `.agents/skills/discord-crabbox-e2e-proof/SKILL.md`.
+2. Inspect the PR with `gh pr view "$MANTIS_PR_NUMBER"` and `gh pr diff "$MANTIS_PR_NUMBER"`.
+3. Decide whether the PR has a visibly reproducible Discord Web before/after. If it does not, write `${MANTIS_OUTPUT_DIR}/mantis-evidence.json` with `comparison.pass: true`, no artifacts, and a summary that starts with `Mantis did not generate before/after GIFs because`. Include the concrete reason in the summary. Use this manifest shape and do not create worktrees or start Crabbox for this case:
+
+   ```json
+   {
+     "schemaVersion": 1,
+     "id": "discord-desktop-proof",
+     "title": "Mantis Discord Desktop Proof",
+     "summary": "Mantis did not generate before/after GIFs because <reason>.",
+     "scenario": "discord-desktop-proof",
+     "comparison": {
+       "baseline": {
+         "ref": "<BASELINE_REF>",
+         "sha": "<BASELINE_SHA>",
+         "expected": "no visible Discord Web delta",
+         "status": "skipped"
+       },
+       "candidate": {
+         "ref": "<CANDIDATE_REF>",
+         "sha": "<CANDIDATE_SHA>",
+         "expected": "no visible Discord Web delta",
+         "status": "skipped",
+         "fixed": true
+       },
+       "pass": true
+     },
+     "artifacts": []
+   }
+   ```
+
+4. Decide what Discord message, command, attachment, reaction, thread, or sequence best proves the PR. Use `MANTIS_INSTRUCTIONS` as maintainer guidance, not as a replacement for reading the PR.
+5. Create detached worktrees under `.artifacts/qa-e2e/mantis/discord-desktop-proof-worktrees/baseline` and `.artifacts/qa-e2e/mantis/discord-desktop-proof-worktrees/candidate`, then install and build each worktree with the repo's normal `pnpm` commands. If `MANTIS_CANDIDATE_TRUST` is `fork-pr-head`, treat the candidate worktree as untrusted fork code: do not pass GitHub, OpenAI, Crabbox, Convex, or other workflow secrets into candidate install, build, or runtime commands. The candidate SUT may receive only the proof runner's short-lived Discord bot token, generated local config/state paths, logged-in viewer browser profile, and mock model key needed for this isolated proof.
+6. In each worktree, run the Discord Web Crabbox proof flow with `$OPENCLAW_DISCORD_WEB_PROOF_CMD`; do not run `pnpm qa:discord-web:crabbox` directly. The proof command comes from the trusted workflow checkout while the current directory controls which baseline or candidate OpenClaw build is tested. Use the workflow-provided `crabbox` binary and local `ffmpeg`/`ffprobe`; do not generate, install, or patch replacement proof tooling during the run. Use the same proof idea for baseline and candidate. You may iterate and rerun if the visual result is not convincing.
+7. Open Discord Web directly to the newest relevant message with the runner `view` command before finishing each recording. Keep the relevant channel/message in-frame.
+8. Finish each session with `--preview-crop discord-window`.
+9. Build `${MANTIS_OUTPUT_DIR}/mantis-evidence.json` with:
+
+   ```bash
+   node scripts/mantis/build-discord-web-proof-evidence.mjs \
+     --output-dir "$MANTIS_OUTPUT_DIR" \
+     --baseline-repo-root <baseline-worktree> \
+     --baseline-output-dir <baseline-session-output-dir> \
+     --baseline-ref "$BASELINE_REF" \
+     --baseline-sha "$BASELINE_SHA" \
+     --candidate-repo-root <candidate-worktree> \
+     --candidate-output-dir <candidate-session-output-dir> \
+     --candidate-ref "$CANDIDATE_REF" \
+     --candidate-sha "$CANDIDATE_SHA" \
+     --scenario-label discord-desktop-proof
+   ```
+
+Visual acceptance:
+
+- The GIFs show Discord Web, not transcript HTML.
+- The proof behavior is visible without reading logs.
+- Main and PR GIFs are comparable side by side.
+- The final relevant message, reaction, attachment, or thread is visible.
+- If one run fails because the PR genuinely changes behavior, still finish the session and produce the manifest if useful visual artifacts exist.
+
+Expected final state:
+
+- `${MANTIS_OUTPUT_DIR}/mantis-evidence.json` exists.
+- Visual proof manifests contain paired `motionPreview` artifacts labeled `Main` and `This PR`.
+- No-visual-proof manifests contain no artifacts and have `comparison.pass: true`.
+- The worktree can be dirty only under `.artifacts/`.

--- a/.github/workflows/mantis-discord-desktop-proof.yml
+++ b/.github/workflows/mantis-discord-desktop-proof.yml
@@ -1,0 +1,394 @@
+name: Mantis Discord Desktop Proof
+
+on:
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to capture
+        required: true
+        type: string
+      instructions:
+        description: Optional freeform proof instructions for the agent
+        required: false
+        type: string
+      crabbox_provider:
+        description: Crabbox provider for the Discord Web capture
+        required: false
+        default: aws
+        type: choice
+        options:
+          - aws
+          - hetzner
+      crabbox_lease_id:
+        description: Optional existing Crabbox desktop lease id or slug to reuse
+        required: false
+        type: string
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+  pull-requests: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  NODE_VERSION: "24.x"
+  PNPM_VERSION: "11.0.8"
+  OPENCLAW_BUILD_PRIVATE_QA: "1"
+  OPENCLAW_ENABLE_PRIVATE_QA_CLI: "1"
+  CRABBOX_REF: main
+  MANTIS_OUTPUT_DIR: .artifacts/qa-e2e/mantis/discord-desktop-proof
+
+jobs:
+  authorize_actor:
+    name: Authorize workflow actor
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event_name == 'issue_comment' &&
+          github.event.issue.pull_request &&
+          contains(github.event.issue.labels.*.name, 'mantis: discord-visible-proof') &&
+          (
+            contains(github.event.comment.body, '@openclaw-mantis') ||
+            contains(github.event.comment.body, '/openclaw-mantis')
+          ) &&
+          contains(github.event.comment.body, 'discord')
+        )
+      }}
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Require maintainer-level repository access
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const allowed = new Set(["admin", "maintain", "write"]);
+            const { owner, repo } = context.repo;
+            const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner,
+              repo,
+              username: context.actor,
+            });
+            const permission = data.permission;
+            core.info(`Actor ${context.actor} permission: ${permission}`);
+            if (!allowed.has(permission)) {
+              core.setFailed(`Workflow requires write/maintain/admin access. Actor "${context.actor}" has "${permission}".`);
+            }
+
+  resolve_request:
+    name: Resolve Mantis request
+    needs: authorize_actor
+    runs-on: ubuntu-24.04
+    outputs:
+      baseline_ref: ${{ steps.resolve.outputs.baseline_ref }}
+      candidate_ref: ${{ steps.resolve.outputs.candidate_ref }}
+      crabbox_provider: ${{ steps.resolve.outputs.crabbox_provider }}
+      instructions: ${{ steps.resolve.outputs.instructions }}
+      lease_id: ${{ steps.resolve.outputs.lease_id }}
+      pr_number: ${{ steps.resolve.outputs.pr_number }}
+      request_source: ${{ steps.resolve.outputs.request_source }}
+    steps:
+      - name: Resolve refs and target PR
+        id: resolve
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const eventName = context.eventName;
+            const setOutput = (name, value) => {
+              core.setOutput(name, value ?? "");
+              core.info(`${name}=${value ?? ""}`);
+            };
+            const inputs = context.payload.inputs ?? {};
+            const prNumber = eventName === "workflow_dispatch" ? inputs.pr_number : String(context.payload.issue?.number ?? "");
+            if (!prNumber) {
+              core.setFailed("Mantis Discord desktop proof requires a pull request.");
+              return;
+            }
+            const { owner, repo } = context.repo;
+            const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: Number(prNumber) });
+            const body = eventName === "workflow_dispatch" ? inputs.instructions || "" : context.payload.comment?.body || "";
+            const provider = inputs.crabbox_provider || "aws";
+            if (!["aws", "hetzner"].includes(provider)) {
+              core.setFailed(`Unsupported Crabbox provider for Mantis Discord desktop proof: ${provider}`);
+              return;
+            }
+            setOutput("baseline_ref", pr.base.sha);
+            setOutput("candidate_ref", pr.head.sha);
+            setOutput("pr_number", String(pr.number));
+            setOutput("instructions", body);
+            setOutput("crabbox_provider", provider);
+            setOutput("lease_id", inputs.crabbox_lease_id || "");
+            setOutput("request_source", eventName);
+            if (eventName === "issue_comment") {
+              await github.rest.reactions.createForIssueComment({ owner, repo, comment_id: context.payload.comment.id, content: "eyes" }).catch((error) => core.warning(`Could not add eyes reaction: ${error.message}`));
+            }
+
+  validate_refs:
+    name: Validate selected refs
+    needs: resolve_request
+    runs-on: ubuntu-24.04
+    outputs:
+      baseline_revision: ${{ steps.validate.outputs.baseline_revision }}
+      candidate_revision: ${{ steps.validate.outputs.candidate_revision }}
+      candidate_trust: ${{ steps.validate.outputs.candidate_trust }}
+    steps:
+      - name: Checkout harness ref
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Validate refs are trusted
+        id: validate
+        env:
+          BASELINE_REF: ${{ needs.resolve_request.outputs.baseline_ref }}
+          CANDIDATE_REF: ${{ needs.resolve_request.outputs.candidate_ref }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ needs.resolve_request.outputs.pr_number }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          git fetch --no-tags origin "+refs/pull/${PR_NUMBER}/head:refs/remotes/origin/pr/${PR_NUMBER}" || true
+          baseline_revision="$(git rev-parse --verify "${BASELINE_REF}^{commit}")"
+          candidate_revision="$(git rev-parse --verify "${CANDIDATE_REF}^{commit}")"
+          if ! git merge-base --is-ancestor "$baseline_revision" refs/remotes/origin/main; then
+            echo "baseline ref '${BASELINE_REF}' resolved to ${baseline_revision}, which is not on main." >&2
+            exit 1
+          fi
+          pr_head="$(gh api -H "Accept: application/vnd.github+json" "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '{state, head_sha: .head.sha, head_repo: .head.repo.full_name}')"
+          pr_state="$(jq -r '.state' <<<"$pr_head")"
+          pr_head_sha="$(jq -r '.head_sha' <<<"$pr_head")"
+          pr_head_repo="$(jq -r '.head_repo' <<<"$pr_head")"
+          if [[ "$pr_state" != "open" || "$candidate_revision" != "$pr_head_sha" ]]; then
+            echo "candidate ref '${CANDIDATE_REF}' resolved to ${candidate_revision}, which is not the open PR head." >&2
+            exit 1
+          fi
+          candidate_trust="open-pr-head"
+          if [[ "$pr_head_repo" != "$GITHUB_REPOSITORY" ]]; then
+            candidate_trust="fork-pr-head"
+          fi
+          echo "baseline_revision=${baseline_revision}" >> "$GITHUB_OUTPUT"
+          echo "candidate_revision=${candidate_revision}" >> "$GITHUB_OUTPUT"
+          echo "candidate_trust=${candidate_trust}" >> "$GITHUB_OUTPUT"
+
+  run_discord_desktop_proof:
+    name: Run agentic Discord Web proof
+    needs: [resolve_request, validate_refs]
+    runs-on: blacksmith-16vcpu-ubuntu-2404
+    timeout-minutes: 360
+    environment: qa-live-shared
+    outputs:
+      comparison_status: ${{ steps.inspect.outputs.comparison_status }}
+      output_dir: ${{ steps.inspect.outputs.output_dir }}
+    steps:
+      - name: Checkout harness ref
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          pnpm-version: ${{ env.PNPM_VERSION }}
+          install-bun: "true"
+
+      - name: Setup Go for Crabbox CLI
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.26.x"
+          cache: false
+
+      - name: Install Crabbox CLI
+        shell: bash
+        run: |
+          set -euo pipefail
+          install_dir="${RUNNER_TEMP}/crabbox"
+          mkdir -p "$install_dir/src"
+          git init "$install_dir/src"
+          git -C "$install_dir/src" remote add origin https://github.com/openclaw/crabbox.git
+          git -C "$install_dir/src" fetch --depth 1 origin "$CRABBOX_REF"
+          git -C "$install_dir/src" checkout --detach FETCH_HEAD
+          go build -C "$install_dir/src" -o "$install_dir/crabbox" ./cmd/crabbox
+          sudo install -m 0755 "$install_dir/crabbox" /usr/local/bin/crabbox
+          crabbox --version
+          crabbox media preview --help >/dev/null
+
+      - name: Install local proof tools
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -f scripts/e2e/discord-web-crabbox-proof.ts
+          cat >"${RUNNER_TEMP}/openclaw-discord-web-crabbox-proof" <<'EOF'
+          #!/usr/bin/env bash
+          set -euo pipefail
+          exec node --import tsx "${GITHUB_WORKSPACE}/scripts/e2e/discord-web-crabbox-proof.ts" "$@"
+          EOF
+          chmod 0755 "${RUNNER_TEMP}/openclaw-discord-web-crabbox-proof"
+          sudo install -m 0755 "${RUNNER_TEMP}/openclaw-discord-web-crabbox-proof" /usr/local/bin/openclaw-discord-web-crabbox-proof
+          /usr/local/bin/openclaw-discord-web-crabbox-proof --help >/dev/null || true
+          media_tools="${RUNNER_TEMP}/mantis-media-tools"
+          install -d "$media_tools"
+          curl --fail --location --retry 3 --retry-delay 2 --connect-timeout 15 --max-time 180 https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz --output "$media_tools/ffmpeg.tar.xz"
+          tar -xJf "$media_tools/ffmpeg.tar.xz" -C "$media_tools"
+          bin_dir="$(find "$media_tools" -type d -path '*/bin' | head -n 1)"
+          sudo install -m 0755 "$bin_dir/ffmpeg" /usr/local/bin/ffmpeg
+          sudo install -m 0755 "$bin_dir/ffprobe" /usr/local/bin/ffprobe
+          ffmpeg -version >/dev/null
+          ffprobe -version >/dev/null
+
+      - name: Ensure agent key exists
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENCLAW_MANTIS_AGENT_OPENAI_API_KEY || secrets.OPENAI_API_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${OPENAI_API_KEY:-}" ]; then
+            echo "Missing OPENCLAW_MANTIS_AGENT_OPENAI_API_KEY or OPENAI_API_KEY secret." >&2
+            exit 1
+          fi
+
+      - name: Prepare Codex user
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo useradd --create-home --shell /bin/bash codex
+          {
+            printf '%s\n' 'Defaults env_keep += "CODEX_HOME CODEX_INTERNAL_ORIGINATOR_OVERRIDE"'
+            printf '%s\n' 'Defaults env_keep += "BASELINE_REF BASELINE_SHA CANDIDATE_REF CANDIDATE_SHA"'
+            printf '%s\n' 'Defaults env_keep += "CRABBOX_ACCESS_CLIENT_ID CRABBOX_ACCESS_CLIENT_SECRET CRABBOX_COORDINATOR CRABBOX_COORDINATOR_TOKEN CRABBOX_LEASE_ID CRABBOX_PROVIDER"'
+            printf '%s\n' 'Defaults env_keep += "GH_TOKEN MANTIS_CANDIDATE_TRUST MANTIS_INSTRUCTIONS MANTIS_OUTPUT_DIR MANTIS_PR_NUMBER"'
+            printf '%s\n' 'Defaults env_keep += "MANTIS_DISCORD_VIEWER_CHROME_PROFILE_DIR MANTIS_DISCORD_VIEWER_CHROME_PROFILE_TGZ_B64 OPENCLAW_QA_CONVEX_SECRET_CI OPENCLAW_QA_CONVEX_SITE_URL"'
+            printf '%s\n' 'Defaults env_keep += "OPENCLAW_DISCORD_WEB_CRABBOX_BIN OPENCLAW_DISCORD_WEB_CRABBOX_PROVIDER OPENCLAW_DISCORD_WEB_PROOF_CMD"'
+          } | sudo tee /etc/sudoers.d/mantis-codex-env >/dev/null
+          sudo chmod 0440 /etc/sudoers.d/mantis-codex-env
+          codex_home="/tmp/mantis-codex-home-${GITHUB_RUN_ID}"
+          sudo install -d -m 0770 -o codex -g codex "$codex_home"
+          sudo setfacl -m u:runner:rwx,u:codex:rwx "$codex_home"
+          sudo setfacl -d -m u:runner:rwx,u:codex:rwx "$codex_home"
+          workspace_parent="$(dirname "$GITHUB_WORKSPACE")"
+          while [ "$workspace_parent" != "/" ]; do
+            sudo setfacl -m u:codex:--x "$workspace_parent"
+            [ "$workspace_parent" = "/home/runner" ] && break
+            workspace_parent="$(dirname "$workspace_parent")"
+          done
+          sudo chown -R codex:codex "$GITHUB_WORKSPACE"
+
+      - name: Run Codex Mantis Discord agent
+        uses: openai/codex-action@5c3f4ccdb2b8790f73d6b21751ac00e602aa0c02
+        env:
+          BASELINE_REF: ${{ needs.resolve_request.outputs.baseline_ref }}
+          BASELINE_SHA: ${{ needs.validate_refs.outputs.baseline_revision }}
+          CANDIDATE_REF: ${{ needs.resolve_request.outputs.candidate_ref }}
+          CANDIDATE_SHA: ${{ needs.validate_refs.outputs.candidate_revision }}
+          CRABBOX_ACCESS_CLIENT_ID: ${{ secrets.CRABBOX_ACCESS_CLIENT_ID }}
+          CRABBOX_ACCESS_CLIENT_SECRET: ${{ secrets.CRABBOX_ACCESS_CLIENT_SECRET }}
+          CRABBOX_COORDINATOR: ${{ secrets.CRABBOX_COORDINATOR || secrets.OPENCLAW_QA_MANTIS_CRABBOX_COORDINATOR }}
+          CRABBOX_COORDINATOR_TOKEN: ${{ secrets.CRABBOX_COORDINATOR_TOKEN || secrets.OPENCLAW_QA_MANTIS_CRABBOX_COORDINATOR_TOKEN }}
+          CRABBOX_LEASE_ID: ${{ needs.resolve_request.outputs.lease_id }}
+          CRABBOX_PROVIDER: ${{ needs.resolve_request.outputs.crabbox_provider }}
+          GH_TOKEN: ${{ github.token }}
+          MANTIS_CANDIDATE_TRUST: ${{ needs.validate_refs.outputs.candidate_trust }}
+          MANTIS_DISCORD_VIEWER_CHROME_PROFILE_DIR: ${{ vars.MANTIS_DISCORD_VIEWER_CHROME_PROFILE_DIR }}
+          MANTIS_DISCORD_VIEWER_CHROME_PROFILE_TGZ_B64: ${{ secrets.MANTIS_DISCORD_VIEWER_CHROME_PROFILE_TGZ_B64 }}
+          MANTIS_INSTRUCTIONS: ${{ needs.resolve_request.outputs.instructions }}
+          MANTIS_OUTPUT_DIR: ${{ env.MANTIS_OUTPUT_DIR }}
+          MANTIS_PR_NUMBER: ${{ needs.resolve_request.outputs.pr_number }}
+          OPENCLAW_DISCORD_WEB_CRABBOX_BIN: /usr/local/bin/crabbox
+          OPENCLAW_DISCORD_WEB_CRABBOX_PROVIDER: ${{ needs.resolve_request.outputs.crabbox_provider }}
+          OPENCLAW_DISCORD_WEB_PROOF_CMD: /usr/local/bin/openclaw-discord-web-crabbox-proof
+          OPENCLAW_QA_CONVEX_SECRET_CI: ${{ secrets.OPENCLAW_QA_CONVEX_SECRET_CI }}
+          OPENCLAW_QA_CONVEX_SITE_URL: ${{ secrets.OPENCLAW_QA_CONVEX_SITE_URL }}
+        with:
+          openai-api-key: ${{ secrets.OPENCLAW_MANTIS_AGENT_OPENAI_API_KEY || secrets.OPENAI_API_KEY }}
+          prompt-file: .github/codex/prompts/mantis-discord-desktop-proof.md
+          model: ${{ vars.OPENCLAW_CI_OPENAI_MODEL_BARE }}
+          effort: medium
+          sandbox: danger-full-access
+          codex-args: '["-c","service_tier=\"fast\""]'
+          codex-home: /tmp/mantis-codex-home-${{ github.run_id }}
+          safety-strategy: unprivileged-user
+          codex-user: codex
+
+      - name: Inspect Mantis evidence manifest
+        id: inspect
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          output_dir="$MANTIS_OUTPUT_DIR"
+          echo "output_dir=${output_dir}" >> "$GITHUB_OUTPUT"
+          manifest="$output_dir/mantis-evidence.json"
+          if [[ ! -f "$manifest" ]]; then
+            echo "Mantis agent did not produce ${manifest}." >&2
+            exit 1
+          fi
+          comparison_status="$(jq -r 'if .comparison.pass then "pass" else "fail" end' "$manifest")"
+          echo "comparison_status=${comparison_status}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload Mantis Discord desktop artifacts
+        id: upload_artifact
+        if: ${{ always() && steps.inspect.outputs.output_dir != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: mantis-discord-desktop-proof-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ steps.inspect.outputs.output_dir }}
+          retention-days: 14
+          if-no-files-found: warn
+
+      - name: Create Mantis GitHub App token
+        id: mantis_app_token
+        if: ${{ always() && needs.resolve_request.outputs.pr_number != '' }}
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.MANTIS_GITHUB_APP_ID }}
+          private-key: ${{ secrets.MANTIS_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-issues: write
+          permission-pull-requests: write
+
+      - name: Comment PR with inline QA evidence
+        if: ${{ always() && needs.resolve_request.outputs.pr_number != '' && steps.inspect.outputs.output_dir != '' }}
+        env:
+          ARTIFACT_URL: ${{ steps.upload_artifact.outputs.artifact-url }}
+          GH_TOKEN: ${{ steps.mantis_app_token.outputs.token }}
+          MANTIS_ARTIFACT_R2_ACCESS_KEY_ID: ${{ secrets.MANTIS_ARTIFACT_R2_ACCESS_KEY_ID }}
+          MANTIS_ARTIFACT_R2_BUCKET: openclaw-crabbox-artifacts
+          MANTIS_ARTIFACT_R2_ENDPOINT: ${{ vars.MANTIS_ARTIFACT_R2_ENDPOINT }}
+          MANTIS_ARTIFACT_R2_PUBLIC_BASE_URL: https://artifacts.openclaw.ai
+          MANTIS_ARTIFACT_R2_REGION: auto
+          MANTIS_ARTIFACT_R2_SECRET_ACCESS_KEY: ${{ secrets.MANTIS_ARTIFACT_R2_SECRET_ACCESS_KEY }}
+          REQUEST_SOURCE: ${{ needs.resolve_request.outputs.request_source }}
+          TARGET_PR: ${{ needs.resolve_request.outputs.pr_number }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="${{ steps.inspect.outputs.output_dir }}"
+          if [[ ! -f "$root/mantis-evidence.json" ]]; then
+            echo "No Mantis evidence manifest found; skipping PR evidence comment."
+            exit 0
+          fi
+          artifact_url_args=()
+          if [[ -n "${ARTIFACT_URL:-}" ]]; then
+            artifact_url_args=(--artifact-url "$ARTIFACT_URL")
+          fi
+          node scripts/mantis/publish-pr-evidence.mjs \
+            --manifest "$root/mantis-evidence.json" \
+            --target-pr "$TARGET_PR" \
+            --artifact-root "mantis/discord-desktop/pr-${TARGET_PR}/run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" \
+            --marker "<!-- mantis-discord-desktop-proof -->" \
+            "${artifact_url_args[@]}" \
+            --run-url "https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            --request-source "$REQUEST_SOURCE"
+
+      - name: Fail when Mantis Discord desktop proof failed
+        if: ${{ always() && steps.inspect.outputs.output_dir != '' && steps.inspect.outputs.comparison_status != 'pass' }}
+        env:
+          COMPARISON_STATUS: ${{ steps.inspect.outputs.comparison_status }}
+        run: |
+          echo "Mantis Discord desktop proof failed: comparison=${COMPARISON_STATUS:-unset}." >&2
+          exit 1

--- a/package.json
+++ b/package.json
@@ -1551,6 +1551,7 @@
     "qa:lab:up:fast": "node --import tsx scripts/qa-lab-up.ts --use-prebuilt-image --bind-ui-dist --skip-ui-build",
     "qa:lab:watch": "vite build --watch --config extensions/qa-lab/web/vite.config.ts",
     "qa:otel:smoke": "node --import tsx scripts/qa-otel-smoke.ts",
+    "qa:discord-web:crabbox": "node --import tsx scripts/e2e/discord-web-crabbox-proof.ts",
     "qa:telegram-user:crabbox": "node --import tsx scripts/e2e/telegram-user-crabbox-proof.ts",
     "release-metadata:check": "node scripts/check-release-metadata-only.mjs",
     "release:beta-smoke": "node --import tsx scripts/release-beta-smoke.ts",

--- a/scripts/e2e/discord-web-crabbox-proof.ts
+++ b/scripts/e2e/discord-web-crabbox-proof.ts
@@ -1,0 +1,1203 @@
+#!/usr/bin/env -S node --import tsx
+
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+type CommandResult = { stderr: string; stdout: string };
+type JsonObject = Record<string, unknown>;
+type PreviewCrop = "discord-window";
+type CrabboxInspect = {
+  host?: string;
+  id?: string;
+  slug?: string;
+  sshKey?: string;
+  sshPort?: string;
+  sshUser?: string;
+  state?: string;
+};
+type Options = {
+  command: "finish" | "publish" | "run" | "screenshot" | "send" | "start" | "status" | "view";
+  crabboxBin: string;
+  crabboxClass: string;
+  dryRun: boolean;
+  envFile?: string;
+  gatewayPort: number;
+  idleTimeout: string;
+  keepBox: boolean;
+  leaseId?: string;
+  mockPort: number;
+  messageId?: string;
+  mockResponseText: string;
+  outputDir: string;
+  previewCrop?: PreviewCrop;
+  previewCropWidth: number;
+  previewFps: number;
+  previewWidth: number;
+  provider: string;
+  publishFullArtifacts: boolean;
+  publishPr?: number;
+  publishRepo: string;
+  publishSummary?: string;
+  recordFps: number;
+  remoteCommand: string[];
+  target: string;
+  text: string;
+  ttl: string;
+};
+type DiscordCredential = {
+  channelId: string;
+  driverBotToken: string;
+  guildId: string;
+  sutApplicationId: string;
+  sutBotToken: string;
+};
+type LocalSut = {
+  configPath: string;
+  gatewayLog: string;
+  gatewayPid: number;
+  mockLog: string;
+  mockPid: number;
+  requestLog: string;
+  stateDir: string;
+  tempRoot: string;
+  workspace: string;
+};
+type SessionFile = {
+  command: "discord-web-crabbox-session";
+  createdAt: string;
+  crabbox: {
+    class: string;
+    createdLease: boolean;
+    id: string;
+    inspect: CrabboxInspect;
+    provider: string;
+    target: string;
+  };
+  credential: { channelId: string; guildId: string; leaseFile: string; sutApplicationId: string };
+  localRoot: string;
+  localSut: LocalSut;
+  outputDir: string;
+  recorder: { log: string; pidFile: string; remoteVideo: string };
+  remoteRoot: string;
+};
+
+const DEFAULT_CONVEX_ENV_FILE = "~/.codex/skills/custom/telegram-e2e-bot-to-bot/convex.local.env";
+const DEFAULT_OUTPUT_ROOT = ".artifacts/qa-e2e/discord-web-crabbox";
+const REMOTE_ROOT = "/tmp/openclaw-discord-web-crabbox";
+const DISCORD_API = "https://discord.com/api/v10";
+const DISCORD_PROOF_VIEW = { cropWidth: 720, height: 760, width: 900, x: 300, y: 90 };
+
+function usage(): never {
+  throw new Error(
+    [
+      "Usage:",
+      "  node --import tsx scripts/e2e/discord-web-crabbox-proof.ts start",
+      "  node --import tsx scripts/e2e/discord-web-crabbox-proof.ts send --session <session.json> --text <text>",
+      "  node --import tsx scripts/e2e/discord-web-crabbox-proof.ts view --session <session.json> --message-id <id>",
+      "  node --import tsx scripts/e2e/discord-web-crabbox-proof.ts run --session <session.json> -- <remote command>",
+      "  node --import tsx scripts/e2e/discord-web-crabbox-proof.ts screenshot --session <session.json>",
+      "  node --import tsx scripts/e2e/discord-web-crabbox-proof.ts finish --session <session.json> --preview-crop discord-window",
+    ].join("\n"),
+  );
+}
+
+function trimToValue(value: string | undefined) {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+function expandHome(value: string) {
+  if (value === "~") return os.homedir();
+  if (value.startsWith("~/")) return path.join(os.homedir(), value.slice(2));
+  return value;
+}
+function parsePositiveInteger(value: string, label: string) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1)
+    throw new Error(`${label} must be a positive integer.`);
+  return parsed;
+}
+function parseArgs(argv: string[]): Options {
+  argv = argv[0] === "--" ? argv.slice(1) : argv;
+  const commands = new Set([
+    "finish",
+    "publish",
+    "run",
+    "screenshot",
+    "send",
+    "start",
+    "status",
+    "view",
+  ]);
+  const command = commands.has(argv[0] ?? "") ? (argv.shift() as Options["command"]) : "start";
+  const stamp = new Date().toISOString().replace(/[:.]/gu, "-");
+  const opts: Options = {
+    command,
+    crabboxBin: trimToValue(process.env.OPENCLAW_DISCORD_WEB_CRABBOX_BIN) ?? "crabbox",
+    crabboxClass: "standard",
+    dryRun: false,
+    gatewayPort: 19_979,
+    idleTimeout: "60m",
+    keepBox: false,
+    mockPort: 19_982,
+    mockResponseText: "OPENCLAW_DISCORD_E2E_OK",
+    outputDir: path.join(DEFAULT_OUTPUT_ROOT, stamp),
+    previewCropWidth: DISCORD_PROOF_VIEW.cropWidth,
+    previewFps: 24,
+    previewWidth: 1920,
+    provider: process.env.OPENCLAW_DISCORD_WEB_CRABBOX_PROVIDER?.trim() || "aws",
+    publishFullArtifacts: false,
+    publishRepo: "openclaw/openclaw",
+    recordFps: 24,
+    remoteCommand: [],
+    target: "linux",
+    text: "Reply exactly: OPENCLAW_DISCORD_E2E_OK",
+    ttl: "120m",
+  };
+  const commandSeparator = argv.indexOf("--");
+  if (command === "run" && commandSeparator >= 0) {
+    opts.remoteCommand = argv.slice(commandSeparator + 1);
+    argv = argv.slice(0, commandSeparator);
+  }
+  let sessionFile: string | undefined;
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const readValue = () => {
+      const value = argv[index + 1];
+      if (!value || value.startsWith("--")) usage();
+      index += 1;
+      return value;
+    };
+    if (arg === "--class") opts.crabboxClass = readValue();
+    else if (arg === "--crabbox-bin") opts.crabboxBin = readValue();
+    else if (arg === "--dry-run") opts.dryRun = true;
+    else if (arg === "--env-file") opts.envFile = readValue();
+    else if (arg === "--gateway-port")
+      opts.gatewayPort = parsePositiveInteger(readValue(), "--gateway-port");
+    else if (arg === "--id") opts.leaseId = readValue();
+    else if (arg === "--idle-timeout") opts.idleTimeout = readValue();
+    else if (arg === "--keep-box") opts.keepBox = true;
+    else if (arg === "--mock-port")
+      opts.mockPort = parsePositiveInteger(readValue(), "--mock-port");
+    else if (arg === "--message-id") opts.messageId = readValue();
+    else if (arg === "--mock-response-file")
+      opts.mockResponseText = fs.readFileSync(resolveRepoPath(process.cwd(), readValue()), "utf8");
+    else if (arg === "--output-dir") opts.outputDir = readValue();
+    else if (arg === "--preview-crop") {
+      const value = readValue();
+      if (value !== "discord-window") throw new Error("--preview-crop must be discord-window.");
+      opts.previewCrop = value;
+    } else if (arg === "--preview-crop-width")
+      opts.previewCropWidth = parsePositiveInteger(readValue(), "--preview-crop-width");
+    else if (arg === "--preview-fps")
+      opts.previewFps = parsePositiveInteger(readValue(), "--preview-fps");
+    else if (arg === "--preview-width")
+      opts.previewWidth = parsePositiveInteger(readValue(), "--preview-width");
+    else if (arg === "--provider") opts.provider = readValue();
+    else if (arg === "--pr") opts.publishPr = parsePositiveInteger(readValue(), "--pr");
+    else if (arg === "--repo") opts.publishRepo = readValue();
+    else if (arg === "--session") sessionFile = readValue();
+    else if (arg === "--summary") opts.publishSummary = readValue();
+    else if (arg === "--text") opts.text = readValue();
+    else if (arg === "--ttl") opts.ttl = readValue();
+    else if (arg === "--full-artifacts") opts.publishFullArtifacts = true;
+    else usage();
+  }
+  if (sessionFile) opts.outputDir = path.dirname(resolveRepoPath(process.cwd(), sessionFile));
+  return opts;
+}
+function repoRoot() {
+  let current = process.cwd();
+  while (current !== path.dirname(current)) {
+    if (
+      fs.existsSync(path.join(current, "package.json")) &&
+      fs.existsSync(path.join(current, ".git"))
+    )
+      return current;
+    current = path.dirname(current);
+  }
+  return process.cwd();
+}
+function resolveRepoPath(root: string, value: string) {
+  return path.isAbsolute(value) ? value : path.resolve(root, value);
+}
+function shellQuote(value: string) {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+function requireString(source: JsonObject, key: string) {
+  const value = source[key];
+  if (typeof value === "number") return String(value);
+  if (typeof value === "string" && value.trim()) return value.trim();
+  throw new Error(`Missing ${key}.`);
+}
+function readJson(file: string) {
+  return JSON.parse(fs.readFileSync(file, "utf8")) as JsonObject;
+}
+async function readEnvFile(file: string) {
+  const env: Record<string, string> = {};
+  if (!fs.existsSync(expandHome(file))) return env;
+  for (const line of fs.readFileSync(expandHome(file), "utf8").split(/\r?\n/u)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const at = trimmed.indexOf("=");
+    if (at < 1) continue;
+    env[trimmed.slice(0, at).trim()] = trimmed
+      .slice(at + 1)
+      .trim()
+      .replace(/^['"]|['"]$/gu, "");
+  }
+  return env;
+}
+function runCommand(params: {
+  args: string[];
+  command: string;
+  cwd: string;
+  env?: NodeJS.ProcessEnv;
+  stdio?: "inherit" | "pipe";
+  stdin?: string;
+}) {
+  return new Promise<CommandResult>((resolve, reject) => {
+    const child = spawn(params.command, params.args, {
+      cwd: params.cwd,
+      env: params.env ?? process.env,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk: Buffer) => {
+      const text = chunk.toString();
+      stdout += text;
+      if (params.stdio === "inherit") process.stdout.write(text);
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      const text = chunk.toString();
+      stderr += text;
+      if (params.stdio === "inherit") process.stderr.write(text);
+    });
+    child.on("error", reject);
+    child.on("close", (code, signal) =>
+      code === 0
+        ? resolve({ stdout, stderr })
+        : reject(
+            new Error(
+              `${params.command} ${params.args.join(" ")} failed with ${signal ? `signal ${signal}` : `exit code ${code ?? "unknown"}`}\n${stdout}${stderr}`,
+            ),
+          ),
+    );
+    params.stdin ? child.stdin.end(params.stdin) : child.stdin.end();
+  });
+}
+function childProcessBaseEnv() {
+  const keys = [
+    "CI",
+    "COREPACK_HOME",
+    "FORCE_COLOR",
+    "HOME",
+    "LANG",
+    "LC_ALL",
+    "NODE_OPTIONS",
+    "OPENCLAW_BUILD_PRIVATE_QA",
+    "OPENCLAW_ENABLE_PRIVATE_QA_CLI",
+    "PATH",
+    "PNPM_HOME",
+    "SHELL",
+    "TEMP",
+    "TMP",
+    "TMPDIR",
+    "USER",
+    "XDG_CACHE_HOME",
+    "XDG_CONFIG_HOME",
+  ];
+  const env: NodeJS.ProcessEnv = {};
+  for (const key of keys) if (process.env[key]) env[key] = process.env[key];
+  return env;
+}
+function spawnDaemon(params: {
+  args: string[];
+  command: string;
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  logPath: string;
+}) {
+  const log = fs.openSync(params.logPath, "a");
+  const child = spawn(params.command, params.args, {
+    cwd: params.cwd,
+    detached: true,
+    env: params.env,
+    stdio: ["ignore", log, log],
+  });
+  child.unref();
+  fs.closeSync(log);
+  return child.pid;
+}
+function killPidTree(pid: number | undefined) {
+  if (!pid) return;
+  try {
+    process.kill(-pid, "SIGTERM");
+  } catch {
+    try {
+      process.kill(pid, "SIGTERM");
+    } catch {}
+  }
+}
+async function waitForLog(logPath: string, pattern: RegExp, label: string, timeoutMs: number) {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    const text = fs.existsSync(logPath) ? fs.readFileSync(logPath, "utf8") : "";
+    if (pattern.test(text)) return;
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  const text = fs.existsSync(logPath) ? fs.readFileSync(logPath, "utf8") : "";
+  throw new Error(`${label} did not become ready within ${timeoutMs}ms\n${text.slice(-4000)}`);
+}
+async function discord<T>(token: string, method: string, route: string, body?: unknown) {
+  const response = await fetch(`${DISCORD_API}${route}`, {
+    method,
+    headers: {
+      authorization: `Bot ${token}`,
+      ...(body ? { "content-type": "application/json" } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const text = await response.text();
+  const payload = text.trim() ? JSON.parse(text) : undefined;
+  if (!response.ok)
+    throw new Error(`Discord ${method} ${route} failed: ${response.status} ${text}`);
+  return payload as T;
+}
+async function currentDiscordUser(token: string) {
+  const payload = await discord<JsonObject>(token, "GET", "/users/@me");
+  return {
+    id: requireString(payload, "id"),
+    username: typeof payload.username === "string" ? payload.username : undefined,
+  };
+}
+function messageUrl(
+  credential: Pick<DiscordCredential, "channelId" | "guildId">,
+  messageId?: string,
+) {
+  return `https://discord.com/channels/${credential.guildId}/${credential.channelId}${messageId ? `/${messageId}` : ""}`;
+}
+async function postBroker(params: {
+  action: string;
+  body: JsonObject;
+  siteUrl: string;
+  token: string;
+}) {
+  const response = await fetch(
+    `${params.siteUrl.replace(/\/+$/u, "")}/qa-credentials/v1/${params.action}`,
+    {
+      method: "POST",
+      headers: { authorization: `Bearer ${params.token}`, "content-type": "application/json" },
+      body: JSON.stringify(params.body),
+    },
+  );
+  const payload = (await response.json()) as JsonObject;
+  if (!response.ok || payload.status !== "ok")
+    throw new Error(`${params.action} failed: ${JSON.stringify(payload)}`);
+  return payload;
+}
+async function resolveLeaseConfig(opts: Options) {
+  const fileEnv = await readEnvFile(opts.envFile ?? DEFAULT_CONVEX_ENV_FILE);
+  const siteUrl =
+    process.env.OPENCLAW_QA_CONVEX_SITE_URL?.trim() || fileEnv.OPENCLAW_QA_CONVEX_SITE_URL;
+  const token =
+    process.env.OPENCLAW_QA_CONVEX_SECRET_CI?.trim() || fileEnv.OPENCLAW_QA_CONVEX_SECRET_CI;
+  if (!siteUrl) throw new Error("Missing OPENCLAW_QA_CONVEX_SITE_URL.");
+  if (!token) throw new Error("Missing OPENCLAW_QA_CONVEX_SECRET_CI.");
+  return {
+    siteUrl,
+    token,
+    ownerId: `discord-web-${Date.now()}-${Math.random().toString(16).slice(2, 10)}`,
+  };
+}
+function parseDiscordCredential(payload: unknown): DiscordCredential {
+  if (!payload || typeof payload !== "object")
+    throw new Error("Discord credential payload must be an object.");
+  const source = payload as JsonObject;
+  return {
+    channelId: requireString(source, "channelId"),
+    driverBotToken: requireString(source, "driverBotToken"),
+    guildId: requireString(source, "guildId"),
+    sutApplicationId: requireString(source, "sutApplicationId"),
+    sutBotToken: requireString(source, "sutBotToken"),
+  };
+}
+async function leaseCredential(root: string, opts: Options, localRoot: string) {
+  const config = await resolveLeaseConfig(opts);
+  const acquired = await postBroker({
+    action: "acquire",
+    siteUrl: config.siteUrl,
+    token: config.token,
+    body: { kind: "discord", ownerId: config.ownerId, actorRole: "ci", leaseTtlMs: 20 * 60 * 1000 },
+  });
+  const leaseFile = path.join(localRoot, "credential-lease.json");
+  const payloadFile = path.join(localRoot, "credential-payload.json");
+  const payload = parseDiscordCredential(acquired.payload);
+  fs.writeFileSync(
+    leaseFile,
+    `${JSON.stringify({ ...config, credentialId: requireString(acquired, "credentialId"), leaseToken: requireString(acquired, "leaseToken") }, null, 2)}\n`,
+    { mode: 0o600 },
+  );
+  fs.writeFileSync(payloadFile, `${JSON.stringify(payload, null, 2)}\n`, { mode: 0o600 });
+  return { ...payload, leaseFile: path.relative(root, leaseFile) };
+}
+async function releaseCredential(root: string, leaseFile: string) {
+  const lease = readJson(path.resolve(root, leaseFile));
+  await postBroker({
+    action: "release",
+    siteUrl: requireString(lease, "siteUrl"),
+    token: requireString(lease, "token"),
+    body: {
+      kind: "discord",
+      ownerId: requireString(lease, "ownerId"),
+      credentialId: requireString(lease, "credentialId"),
+      leaseToken: requireString(lease, "leaseToken"),
+    },
+  });
+}
+function writeSutConfig(params: {
+  channelId: string;
+  driverBotId: string;
+  gatewayPort: number;
+  guildId: string;
+  mockPort: number;
+  outputDir: string;
+  sutToken: string;
+}) {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-discord-crabbox-sut-"));
+  const stateDir = path.join(tempRoot, "state");
+  const workspace = path.join(tempRoot, "workspace");
+  fs.mkdirSync(stateDir, { recursive: true });
+  fs.mkdirSync(workspace, { recursive: true });
+  const configPath = path.join(tempRoot, "openclaw.json");
+  const config = {
+    agents: {
+      defaults: {
+        model: { primary: "openai/gpt-5.5" },
+        models: { "openai/gpt-5.5": { params: { openaiWsWarmup: false, transport: "sse" } } },
+      },
+      list: [
+        {
+          default: true,
+          id: "main",
+          model: { primary: "openai/gpt-5.5" },
+          name: "Main",
+          workspace,
+        },
+      ],
+    },
+    channels: {
+      discord: {
+        enabled: true,
+        defaultAccount: "sut",
+        accounts: {
+          sut: {
+            enabled: true,
+            token: params.sutToken,
+            allowBots: true,
+            groupPolicy: "allowlist",
+            guilds: {
+              [params.guildId]: {
+                requireMention: false,
+                users: [params.driverBotId],
+                channels: {
+                  [params.channelId]: {
+                    enabled: true,
+                    requireMention: false,
+                    users: [params.driverBotId],
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    gateway: { auth: { mode: "none" }, bind: "loopback", mode: "local", port: params.gatewayPort },
+    messages: {
+      ackReaction: "👀",
+      ackReactionScope: "all",
+      groupChat: { visibleReplies: "automatic" },
+      statusReactions: { enabled: true, timing: { debounceMs: 0 } },
+    },
+    models: {
+      providers: {
+        openai: {
+          api: "openai-responses",
+          apiKey: { id: "OPENAI_API_KEY", provider: "default", source: "env" },
+          baseUrl: `http://127.0.0.1:${params.mockPort}/v1`,
+          models: [
+            { api: "openai-responses", contextWindow: 128000, id: "gpt-5.5", name: "gpt-5.5" },
+          ],
+          request: { allowPrivateNetwork: true },
+        },
+      },
+    },
+    plugins: {
+      allow: ["discord", "openai"],
+      enabled: true,
+      entries: { discord: { enabled: true }, openai: { enabled: true } },
+    },
+  };
+  fs.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
+  return { configPath, stateDir, tempRoot, workspace };
+}
+function mockServerEnv(params: { mockPort: number; mockResponseText: string; requestLog: string }) {
+  return {
+    ...childProcessBaseEnv(),
+    MOCK_PORT: String(params.mockPort),
+    MOCK_REQUEST_LOG: params.requestLog,
+    SUCCESS_MARKER: params.mockResponseText,
+  };
+}
+function gatewayEnv(params: { configPath: string; stateDir: string; sutToken: string }) {
+  return {
+    ...childProcessBaseEnv(),
+    OPENAI_API_KEY: "sk-openclaw-e2e-mock",
+    OPENCLAW_CONFIG_PATH: params.configPath,
+    OPENCLAW_STATE_DIR: params.stateDir,
+  };
+}
+async function startLocalSutDaemon(params: {
+  credential: DiscordCredential;
+  driverBotId: string;
+  mockResponseText: string;
+  outputDir: string;
+  repoRoot: string;
+  opts: Options;
+}) {
+  const config = writeSutConfig({
+    ...params.credential,
+    driverBotId: params.driverBotId,
+    gatewayPort: params.opts.gatewayPort,
+    mockPort: params.opts.mockPort,
+    outputDir: params.outputDir,
+  });
+  const requestLog = path.join(params.outputDir, "mock-openai-requests.ndjson");
+  const mockLog = path.join(params.outputDir, "mock-openai.log");
+  const gatewayLog = path.join(params.outputDir, "gateway.log");
+  const mockPid = spawnDaemon({
+    command: "node",
+    args: ["scripts/e2e/mock-openai-server.mjs"],
+    cwd: params.repoRoot,
+    env: mockServerEnv({
+      mockPort: params.opts.mockPort,
+      mockResponseText: params.mockResponseText,
+      requestLog,
+    }),
+    logPath: mockLog,
+  });
+  await waitForLog(mockLog, /mock-openai listening/u, "mock-openai", 10_000);
+  const gatewayPid = spawnDaemon({
+    command: "pnpm",
+    args: ["openclaw", "gateway", "--port", String(params.opts.gatewayPort)],
+    cwd: params.repoRoot,
+    env: gatewayEnv({ ...config, sutToken: params.credential.sutBotToken }),
+    logPath: gatewayLog,
+  });
+  await waitForLog(gatewayLog, /\[gateway\] ready/u, "gateway", 60_000);
+  return { ...config, gatewayLog, gatewayPid, mockLog, mockPid, requestLog } satisfies LocalSut;
+}
+function extractLeaseId(output: string) {
+  return output.match(/\b(?:cbx_[a-f0-9]+|tbx_[A-Za-z0-9_-]+)\b/u)?.[0];
+}
+async function warmupCrabbox(opts: Options, root: string) {
+  const result = await runCommand({
+    command: opts.crabboxBin,
+    args: [
+      "warmup",
+      "--provider",
+      opts.provider,
+      "--target",
+      opts.target,
+      "--desktop",
+      "--browser",
+      "--class",
+      opts.crabboxClass,
+      "--idle-timeout",
+      opts.idleTimeout,
+      "--ttl",
+      opts.ttl,
+    ],
+    cwd: root,
+    stdio: "inherit",
+  });
+  const leaseId = extractLeaseId(`${result.stdout}\n${result.stderr}`);
+  if (!leaseId) throw new Error("Crabbox warmup did not print a lease id.");
+  return leaseId;
+}
+async function inspectCrabbox(opts: Options, root: string, leaseId: string) {
+  const result = await runCommand({
+    command: opts.crabboxBin,
+    args: [
+      "inspect",
+      "--provider",
+      opts.provider,
+      "--target",
+      opts.target,
+      "--id",
+      leaseId,
+      "--json",
+    ],
+    cwd: root,
+  });
+  return JSON.parse(result.stdout) as CrabboxInspect;
+}
+function sshArgs(inspect: CrabboxInspect) {
+  if (!inspect.host || !inspect.sshKey || !inspect.sshUser)
+    throw new Error("Crabbox inspect output is missing SSH details.");
+  return [
+    "-i",
+    inspect.sshKey,
+    "-p",
+    inspect.sshPort ?? "22",
+    "-o",
+    "IdentitiesOnly=yes",
+    "-o",
+    "BatchMode=yes",
+    "-o",
+    "StrictHostKeyChecking=no",
+    `${inspect.sshUser}@${inspect.host}`,
+  ];
+}
+async function sshRun(root: string, inspect: CrabboxInspect, command: string) {
+  return await runCommand({ command: "ssh", args: [...sshArgs(inspect), command], cwd: root });
+}
+async function scpFromRemote(root: string, inspect: CrabboxInspect, remote: string, local: string) {
+  fs.mkdirSync(path.dirname(local), { recursive: true });
+  await runCommand({
+    command: "scp",
+    args: [
+      "-i",
+      inspect.sshKey!,
+      "-P",
+      inspect.sshPort ?? "22",
+      "-o",
+      "IdentitiesOnly=yes",
+      "-o",
+      "BatchMode=yes",
+      "-o",
+      "StrictHostKeyChecking=no",
+      `${inspect.sshUser}@${inspect.host}:${remote}`,
+      local,
+    ],
+    cwd: root,
+  });
+}
+async function stopCrabbox(root: string, opts: Options, leaseId: string) {
+  await runCommand({
+    command: opts.crabboxBin,
+    args: ["stop", "--provider", opts.provider, "--target", opts.target, leaseId],
+    cwd: root,
+    stdio: "inherit",
+  });
+}
+function remoteBrowserScript(params: {
+  profileArchiveEnv: string;
+  profileDir: string;
+  url: string;
+}) {
+  return `set -euo pipefail
+root=${REMOTE_ROOT}
+mkdir -p "$root" ${shellQuote(params.profileDir)}
+export DISPLAY="\${DISPLAY:-:99}"
+if ! command -v wmctrl >/dev/null 2>&1 || ! command -v xdotool >/dev/null 2>&1; then sudo apt-get update -y >/tmp/openclaw-discord-apt.log 2>&1; sudo DEBIAN_FRONTEND=noninteractive apt-get install -y wmctrl xdotool x11-utils ffmpeg scrot >>/tmp/openclaw-discord-apt.log 2>&1; fi
+archive="\${${params.profileArchiveEnv}:-}"
+if [ -n "$archive" ]; then printf '%s' "$archive" | base64 -d >"$root/profile.tgz"; tar -xzf "$root/profile.tgz" -C ${shellQuote(params.profileDir)}; rm -f "$root/profile.tgz"; fi
+browser=""
+for candidate in "\${BROWSER:-}" "\${CHROME_BIN:-}" google-chrome chromium chromium-browser; do if [ -n "$candidate" ] && command -v "$candidate" >/dev/null 2>&1; then browser="$(command -v "$candidate")"; break; fi; done
+[ -n "$browser" ]
+"$browser" --user-data-dir=${shellQuote(params.profileDir)} --no-first-run --no-default-browser-check --disable-dev-shm-usage --window-size=1280,900 --window-position=0,0 --class=mantis-discord-web-proof ${shellQuote(params.url)} >"$root/chrome.log" 2>&1 &
+echo $! >"$root/chrome.pid"
+sleep 8
+wmctrl -r mantis-discord-web-proof -e 0,0,0,1280,900 || true`;
+}
+async function startRemoteRecording(root: string, inspect: CrabboxInspect, opts: Options) {
+  await sshRun(
+    root,
+    inspect,
+    `set -euo pipefail
+export DISPLAY="\${DISPLAY:-:99}"
+root=${REMOTE_ROOT}
+mkdir -p "$root"
+video="$root/session.mp4"
+log="$root/ffmpeg.log"
+pid_file="$root/ffmpeg.pid"
+rm -f "$video" "$log" "$pid_file"
+size="$(xdpyinfo | awk '/dimensions:/ {size=$2} END {if (!size) exit 1; print size}')"
+nohup ffmpeg -y -hide_banner -loglevel warning -f x11grab -framerate ${opts.recordFps} -video_size "$size" -i "$DISPLAY" -pix_fmt yuv420p "$video" >"$log" 2>&1 &
+echo $! >"$pid_file"`,
+  );
+  return {
+    log: `${REMOTE_ROOT}/ffmpeg.log`,
+    pidFile: `${REMOTE_ROOT}/ffmpeg.pid`,
+    remoteVideo: `${REMOTE_ROOT}/session.mp4`,
+  };
+}
+async function stopRemoteRecording(root: string, inspect: CrabboxInspect, session: SessionFile) {
+  await sshRun(
+    root,
+    inspect,
+    `pid_file=${shellQuote(session.recorder.pidFile)}; if [ -s "$pid_file" ]; then pid="$(cat "$pid_file")"; kill -INT "$pid" >/dev/null 2>&1 || true; sleep 2; kill -TERM "$pid" >/dev/null 2>&1 || true; fi`,
+  );
+}
+function sessionPath(root: string, opts: Options, outputDir: string) {
+  return path.join(outputDir, "session.json");
+}
+function writeSession(file: string, session: SessionFile) {
+  fs.writeFileSync(file, `${JSON.stringify(session, null, 2)}\n`, { mode: 0o600 });
+}
+function readSession(root: string, opts: Options, outputDir: string) {
+  const file = sessionPath(root, opts, outputDir);
+  return { path: file, session: JSON.parse(fs.readFileSync(file, "utf8")) as SessionFile };
+}
+async function createMotionPreview(params: {
+  motionGifPath: string;
+  motionVideoPath: string;
+  opts: Options;
+  root: string;
+  videoPath: string;
+}) {
+  const preview = await runCommand({
+    command: params.opts.crabboxBin,
+    args: [
+      "media",
+      "preview",
+      "--input",
+      params.videoPath,
+      "--output",
+      params.motionGifPath,
+      "--fps",
+      String(params.opts.previewFps),
+      "--width",
+      String(params.opts.previewWidth),
+      "--trimmed-video-output",
+      params.motionVideoPath,
+      "--json",
+    ],
+    cwd: params.root,
+    stdio: "inherit",
+  });
+  return JSON.parse(preview.stdout) as JsonObject;
+}
+async function createCroppedMotionPreview(params: {
+  croppedGifPath: string;
+  croppedVideoPath: string;
+  opts: Options;
+  root: string;
+  videoPath: string;
+}) {
+  const crop = `crop=${DISCORD_PROOF_VIEW.width}:${DISCORD_PROOF_VIEW.height}:${DISCORD_PROOF_VIEW.x}:${DISCORD_PROOF_VIEW.y}`;
+  const scale = `scale=${params.opts.previewCropWidth}:-2:flags=lanczos`;
+  await runCommand({
+    command: "ffmpeg",
+    args: [
+      "-y",
+      "-hide_banner",
+      "-loglevel",
+      "warning",
+      "-i",
+      params.videoPath,
+      "-vf",
+      `${crop},${scale}`,
+      "-pix_fmt",
+      "yuv420p",
+      params.croppedVideoPath,
+    ],
+    cwd: params.root,
+    stdio: "inherit",
+  });
+  await runCommand({
+    command: "ffmpeg",
+    args: [
+      "-y",
+      "-hide_banner",
+      "-loglevel",
+      "warning",
+      "-i",
+      params.videoPath,
+      "-filter_complex",
+      `${crop},fps=${params.opts.previewFps},${scale},split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse`,
+      params.croppedGifPath,
+    ],
+    cwd: params.root,
+    stdio: "inherit",
+  });
+  return { crop, fps: params.opts.previewFps, outputWidth: params.opts.previewCropWidth };
+}
+async function startSession(root: string, opts: Options, outputDir: string) {
+  const localRoot = path.join(outputDir, ".session");
+  fs.rmSync(localRoot, { force: true, recursive: true });
+  fs.mkdirSync(localRoot, { mode: 0o700, recursive: true });
+  const profileArchiveEnv = "MANTIS_DISCORD_VIEWER_CHROME_PROFILE_TGZ_B64";
+  const profileDir =
+    process.env.MANTIS_DISCORD_VIEWER_CHROME_PROFILE_DIR?.trim() || `${REMOTE_ROOT}/chrome-profile`;
+  if (
+    !process.env[profileArchiveEnv]?.trim() &&
+    !process.env.MANTIS_DISCORD_VIEWER_CHROME_PROFILE_DIR?.trim()
+  )
+    throw new Error(`Missing ${profileArchiveEnv} or MANTIS_DISCORD_VIEWER_CHROME_PROFILE_DIR.`);
+  await runCommand({ command: opts.crabboxBin, args: ["--version"], cwd: root });
+  if (opts.dryRun) return { outputDir, status: "pass" };
+  const credential = await leaseCredential(root, opts, localRoot);
+  const driver = await currentDiscordUser(credential.driverBotToken);
+  const sut = await currentDiscordUser(credential.sutBotToken);
+  if (sut.id !== credential.sutApplicationId)
+    throw new Error("Discord SUT application id does not match SUT bot user id.");
+  let leaseId = opts.leaseId;
+  let createdLease = false;
+  if (!leaseId) {
+    leaseId = await warmupCrabbox(opts, root);
+    createdLease = true;
+  }
+  const inspect = await inspectCrabbox(opts, root, leaseId);
+  let localSut: LocalSut | undefined;
+  try {
+    await sshRun(
+      root,
+      inspect,
+      remoteBrowserScript({ profileArchiveEnv, profileDir, url: messageUrl(credential) }),
+    );
+    localSut = await startLocalSutDaemon({
+      credential,
+      driverBotId: driver.id,
+      mockResponseText: opts.mockResponseText,
+      outputDir,
+      repoRoot: root,
+      opts,
+    });
+    const recorder = await startRemoteRecording(root, inspect, opts);
+    const session: SessionFile = {
+      command: "discord-web-crabbox-session",
+      createdAt: new Date().toISOString(),
+      crabbox: {
+        class: opts.crabboxClass,
+        createdLease,
+        id: leaseId,
+        inspect,
+        provider: opts.provider,
+        target: opts.target,
+      },
+      credential: {
+        channelId: credential.channelId,
+        guildId: credential.guildId,
+        leaseFile: credential.leaseFile,
+        sutApplicationId: credential.sutApplicationId,
+      },
+      localRoot,
+      localSut,
+      outputDir,
+      recorder,
+      remoteRoot: REMOTE_ROOT,
+    };
+    const file = sessionPath(root, opts, outputDir);
+    writeSession(file, session);
+    return {
+      session: path.relative(root, file),
+      status: "pass",
+      discord: {
+        channelId: credential.channelId,
+        guildId: credential.guildId,
+        sutApplicationId: credential.sutApplicationId,
+      },
+      webvnc: `${opts.crabboxBin} webvnc --provider ${opts.provider} --target ${opts.target} --id ${leaseId} --open`,
+      commands: {
+        send: `pnpm qa:discord-web:crabbox -- send --session ${path.relative(root, file)} --text '${opts.text}'`,
+        view: `pnpm qa:discord-web:crabbox -- view --session ${path.relative(root, file)} --message-id <message-id>`,
+        finish: `pnpm qa:discord-web:crabbox -- finish --session ${path.relative(root, file)} --preview-crop discord-window`,
+      },
+    };
+  } catch (error) {
+    killPidTree(localSut?.gatewayPid);
+    killPidTree(localSut?.mockPid);
+    await releaseCredential(root, credential.leaseFile).catch(() => {});
+    if (createdLease && leaseId) await stopCrabbox(root, opts, leaseId).catch(() => {});
+    throw error;
+  }
+}
+async function sendSessionMessage(root: string, opts: Options, outputDir: string) {
+  const { session } = readSession(root, opts, outputDir);
+  const credential = parseDiscordCredential(
+    readJson(path.join(session.localRoot, "credential-payload.json")),
+  );
+  const message = await discord<JsonObject>(
+    credential.driverBotToken,
+    "POST",
+    `/channels/${credential.channelId}/messages`,
+    { content: opts.text },
+  );
+  return {
+    discordWebUrl: messageUrl(credential, requireString(message, "id")),
+    messageId: requireString(message, "id"),
+    status: "pass",
+    text: opts.text,
+  };
+}
+async function viewSession(root: string, opts: Options, outputDir: string) {
+  const { session } = readSession(root, opts, outputDir);
+  const url = messageUrl(session.credential, opts.messageId);
+  const result = await sshRun(
+    root,
+    session.crabbox.inspect,
+    `set -euo pipefail
+export DISPLAY="\${DISPLAY:-:99}"
+url=${shellQuote(url)}
+xdg-open "$url" >/tmp/openclaw-discord-web-crabbox/view.log 2>&1 || true
+sleep 5
+wmctrl -r mantis-discord-web-proof -e 0,0,0,1280,900 || true`,
+  );
+  const logPath = path.join(
+    session.outputDir,
+    `proof-view-${new Date().toISOString().replace(/[:.]/gu, "-")}.log`,
+  );
+  fs.writeFileSync(logPath, `${result.stdout}${result.stderr}`);
+  return { geometry: DISCORD_PROOF_VIEW, log: path.relative(root, logPath), status: "pass", url };
+}
+async function screenshotSession(root: string, opts: Options, outputDir: string) {
+  const { session } = readSession(root, opts, outputDir);
+  const screenshotPath = path.join(
+    session.outputDir,
+    `discord-web-crabbox-${new Date().toISOString().replace(/[:.]/gu, "-")}.png`,
+  );
+  await runCommand({
+    command: opts.crabboxBin,
+    args: [
+      "screenshot",
+      "--provider",
+      session.crabbox.provider,
+      "--target",
+      session.crabbox.target,
+      "--id",
+      session.crabbox.id,
+      "--output",
+      screenshotPath,
+    ],
+    cwd: root,
+    stdio: "inherit",
+  });
+  return { screenshot: path.relative(root, screenshotPath), status: "pass" };
+}
+async function statusSession(root: string, opts: Options, outputDir: string) {
+  const { session } = readSession(root, opts, outputDir);
+  const inspect = await inspectCrabbox(opts, root, session.crabbox.id);
+  return {
+    crabbox: { id: session.crabbox.id, slug: inspect.slug, state: inspect.state },
+    status: "pass",
+    webvnc: `${opts.crabboxBin} webvnc --provider ${session.crabbox.provider} --target ${session.crabbox.target} --id ${session.crabbox.id} --open`,
+  };
+}
+function writeReport(params: {
+  croppedGif?: string;
+  croppedVideo?: string;
+  gif: string;
+  mp4: string;
+  outputDir: string;
+  screenshot: string;
+  summaryPath: string;
+  video: string;
+}) {
+  const report = path.join(params.outputDir, "discord-web-crabbox-session-report.md");
+  fs.writeFileSync(
+    report,
+    [
+      "# Discord Web Crabbox Proof",
+      "",
+      `Summary: \`${path.basename(params.summaryPath)}\``,
+      `Screenshot: \`${path.basename(params.screenshot)}\``,
+      `Motion GIF: \`${path.basename(params.gif)}\``,
+      params.croppedGif ? `Cropped motion GIF: \`${path.basename(params.croppedGif)}\`` : undefined,
+      `Motion MP4: \`${path.basename(params.mp4)}\``,
+      params.croppedVideo
+        ? `Cropped motion MP4: \`${path.basename(params.croppedVideo)}\``
+        : undefined,
+      `Full video: \`${path.basename(params.video)}\``,
+      "",
+    ]
+      .filter(Boolean)
+      .join("\n"),
+  );
+  return report;
+}
+async function finishSession(root: string, opts: Options, outputDir: string) {
+  const { path: file, session } = readSession(root, opts, outputDir);
+  const summary: JsonObject = {
+    artifacts: {},
+    finishedAt: new Date().toISOString(),
+    session: path.relative(root, file),
+    startedAt: session.createdAt,
+    status: "fail",
+  };
+  const videoPath = path.join(session.outputDir, "discord-web-crabbox-session.mp4");
+  const motionVideoPath = path.join(session.outputDir, "discord-web-crabbox-session-motion.mp4");
+  const motionGifPath = path.join(session.outputDir, "discord-web-crabbox-session-motion.gif");
+  const croppedVideoPath = path.join(
+    session.outputDir,
+    "discord-web-crabbox-session-motion-discord-window.mp4",
+  );
+  const croppedGifPath = path.join(
+    session.outputDir,
+    "discord-web-crabbox-session-motion-discord-window.gif",
+  );
+  const screenshotPath = path.join(session.outputDir, "discord-web-crabbox-session.png");
+  const ffmpegLogPath = path.join(session.outputDir, "ffmpeg.log");
+  try {
+    await stopRemoteRecording(root, session.crabbox.inspect, session);
+    await scpFromRemote(root, session.crabbox.inspect, session.recorder.remoteVideo, videoPath);
+    await scpFromRemote(root, session.crabbox.inspect, session.recorder.log, ffmpegLogPath).catch(
+      () => {},
+    );
+    summary.mediaPreview = await createMotionPreview({
+      motionGifPath,
+      motionVideoPath,
+      opts,
+      root,
+      videoPath,
+    });
+    if (opts.previewCrop)
+      summary.croppedMediaPreview = await createCroppedMotionPreview({
+        croppedGifPath,
+        croppedVideoPath,
+        opts,
+        root,
+        videoPath: motionVideoPath,
+      });
+    await runCommand({
+      command: opts.crabboxBin,
+      args: [
+        "screenshot",
+        "--provider",
+        session.crabbox.provider,
+        "--target",
+        session.crabbox.target,
+        "--id",
+        session.crabbox.id,
+        "--output",
+        screenshotPath,
+      ],
+      cwd: root,
+      stdio: "inherit",
+    });
+    summary.artifacts = {
+      ffmpegLog: path.relative(root, ffmpegLogPath),
+      previewGif: path.relative(root, motionGifPath),
+      ...(opts.previewCrop
+        ? {
+            previewGifCropped: path.relative(root, croppedGifPath),
+            trimmedVideoCropped: path.relative(root, croppedVideoPath),
+          }
+        : {}),
+      screenshot: path.relative(root, screenshotPath),
+      trimmedVideo: path.relative(root, motionVideoPath),
+      video: path.relative(root, videoPath),
+    };
+    summary.status = "pass";
+  } finally {
+    killPidTree(session.localSut.gatewayPid);
+    killPidTree(session.localSut.mockPid);
+    await releaseCredential(root, session.credential.leaseFile).catch((error: unknown) => {
+      summary.credentialReleaseError = error instanceof Error ? error.message : String(error);
+    });
+    if (session.crabbox.createdLease && !opts.keepBox)
+      await stopCrabbox(root, opts, session.crabbox.id).catch((error: unknown) => {
+        summary.crabboxStopError = error instanceof Error ? error.message : String(error);
+      });
+    if (opts.keepBox)
+      summary.webvnc = `${opts.crabboxBin} webvnc --provider ${session.crabbox.provider} --target ${session.crabbox.target} --id ${session.crabbox.id} --open`;
+    fs.rmSync(session.localRoot, { force: true, recursive: true });
+    const summaryPath = path.join(session.outputDir, "discord-web-crabbox-session-summary.json");
+    fs.writeFileSync(summaryPath, `${JSON.stringify(summary, null, 2)}\n`);
+    const report = writeReport({
+      croppedGif: opts.previewCrop ? croppedGifPath : undefined,
+      croppedVideo: opts.previewCrop ? croppedVideoPath : undefined,
+      gif: motionGifPath,
+      mp4: motionVideoPath,
+      outputDir: session.outputDir,
+      screenshot: screenshotPath,
+      summaryPath,
+      video: videoPath,
+    });
+    summary.report = path.relative(root, report);
+    fs.writeFileSync(summaryPath, `${JSON.stringify(summary, null, 2)}\n`);
+    console.log(
+      JSON.stringify({ reportPath: report, status: summary.status, summaryPath }, null, 2),
+    );
+  }
+  if (summary.status !== "pass") process.exitCode = 1;
+}
+async function runSessionCommand(root: string, opts: Options, outputDir: string) {
+  const { session } = readSession(root, opts, outputDir);
+  const result = await sshRun(
+    root,
+    session.crabbox.inspect,
+    opts.remoteCommand.map(shellQuote).join(" "),
+  );
+  const logPath = path.join(
+    session.outputDir,
+    `remote-command-${new Date().toISOString().replace(/[:.]/gu, "-")}.log`,
+  );
+  fs.writeFileSync(logPath, `${result.stdout}${result.stderr}`);
+  return { command: opts.remoteCommand, log: path.relative(root, logPath), status: "pass" };
+}
+async function publishSession(root: string, opts: Options, outputDir: string) {
+  const { session } = readSession(root, opts, outputDir);
+  const gif = path.join(session.outputDir, "discord-web-crabbox-session-motion-discord-window.gif");
+  const fallback = path.join(session.outputDir, "discord-web-crabbox-session-motion.gif");
+  const publishGif = fs.existsSync(gif) ? gif : fallback;
+  const publishDir = opts.publishFullArtifacts
+    ? session.outputDir
+    : path.join(session.outputDir, "publish-gif-only");
+  if (!opts.publishFullArtifacts) {
+    fs.rmSync(publishDir, { force: true, recursive: true });
+    fs.mkdirSync(publishDir, { recursive: true });
+    fs.copyFileSync(publishGif, path.join(publishDir, "discord-web-crabbox-session-motion.gif"));
+  }
+  await runCommand({
+    command: opts.crabboxBin,
+    args: [
+      "artifacts",
+      "publish",
+      "--pr",
+      String(opts.publishPr),
+      "--repo",
+      opts.publishRepo,
+      "--dir",
+      publishDir,
+      "--summary",
+      opts.publishSummary ?? "Discord Web Crabbox session motion GIF",
+      "--template",
+      "openclaw",
+    ],
+    cwd: root,
+    stdio: "inherit",
+  });
+  return { publishDir: path.relative(root, publishDir), status: "pass" };
+}
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const root = repoRoot();
+  const outputDir = resolveRepoPath(root, opts.outputDir);
+  fs.mkdirSync(outputDir, { recursive: true });
+  opts.outputDir = outputDir;
+  if (opts.command === "start")
+    return console.log(JSON.stringify(await startSession(root, opts, outputDir), null, 2));
+  if (opts.command === "send")
+    return console.log(JSON.stringify(await sendSessionMessage(root, opts, outputDir), null, 2));
+  if (opts.command === "run")
+    return console.log(JSON.stringify(await runSessionCommand(root, opts, outputDir), null, 2));
+  if (opts.command === "screenshot")
+    return console.log(JSON.stringify(await screenshotSession(root, opts, outputDir), null, 2));
+  if (opts.command === "status")
+    return console.log(JSON.stringify(await statusSession(root, opts, outputDir), null, 2));
+  if (opts.command === "view")
+    return console.log(JSON.stringify(await viewSession(root, opts, outputDir), null, 2));
+  if (opts.command === "finish") return await finishSession(root, opts, outputDir);
+  if (opts.command === "publish")
+    return console.log(JSON.stringify(await publishSession(root, opts, outputDir), null, 2));
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/scripts/mantis/build-discord-web-proof-evidence.mjs
+++ b/scripts/mantis/build-discord-web-proof-evidence.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const LANES = [
+  { altPrefix: "Baseline", label: "Main", lane: "baseline" },
+  { altPrefix: "Candidate", label: "This PR", lane: "candidate" },
+];
+
+function parseArgs(argv) {
+  const args = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const key = argv[index];
+    if (!key.startsWith("--")) throw new Error(`Unexpected argument: ${key}`);
+    const value = argv[index + 1];
+    if (!value || value.startsWith("--")) throw new Error(`Missing value for ${key}`);
+    args[key.slice(2).replaceAll("-", "_")] = value;
+    index += 1;
+  }
+  return args;
+}
+function readJson(filePath) {
+  return JSON.parse(readFileSync(filePath, "utf8"));
+}
+function copyArtifact({ outputDir, required = true, source, targetPath }) {
+  if (!source || !existsSync(source)) {
+    if (required) throw new Error(`Missing required artifact: ${source}`);
+    return false;
+  }
+  const target = path.join(outputDir, targetPath);
+  mkdirSync(path.dirname(target), { recursive: true });
+  copyFileSync(source, target);
+  return true;
+}
+function resolveSummaryArtifact(lane, key) {
+  const value = lane.summary.artifacts?.[key];
+  return typeof value === "string" ? path.resolve(lane.repoRoot, value) : undefined;
+}
+function loadLane({ outputDir, repoRoot, status }) {
+  const summaryPath = path.join(outputDir, "discord-web-crabbox-session-summary.json");
+  const summary = readJson(summaryPath);
+  return { outputDir, repoRoot, status: status || summary.status || "unknown", summary, summaryPath };
+}
+function copyLaneArtifacts({ lane, laneName, outputDir }) {
+  const gif = resolveSummaryArtifact(lane, "previewGifCropped") ?? resolveSummaryArtifact(lane, "previewGif");
+  copyArtifact({ outputDir, source: gif, targetPath: `${laneName}/discord-web-proof.gif` });
+  copyArtifact({ outputDir, required: false, source: resolveSummaryArtifact(lane, "trimmedVideoCropped") ?? resolveSummaryArtifact(lane, "trimmedVideo"), targetPath: `${laneName}/discord-web-proof.mp4` });
+  copyArtifact({ outputDir, required: false, source: resolveSummaryArtifact(lane, "screenshot"), targetPath: `${laneName}/discord-web-proof.png` });
+  copyArtifact({ outputDir, source: lane.summaryPath, targetPath: `${laneName}/summary.json` });
+  copyArtifact({ outputDir, required: false, source: typeof lane.summary.report === "string" ? path.resolve(lane.repoRoot, lane.summary.report) : undefined, targetPath: `${laneName}/report.md` });
+}
+function laneStatus(lane) {
+  return lane.status === "pass" ? "pass" : "fail";
+}
+function laneArtifactEntries() {
+  return LANES.flatMap(({ altPrefix, label, lane }) => [
+    { alt: `${altPrefix} Discord Web proof GIF`, inline: true, kind: "motionPreview", label, lane, path: `${lane}/discord-web-proof.gif`, targetPath: `${lane}/discord-web-proof.gif`, width: 520 },
+    { kind: "motionClip", label: `${label} MP4`, lane, path: `${lane}/discord-web-proof.mp4`, required: false, targetPath: `${lane}/discord-web-proof.mp4` },
+    { alt: `${altPrefix} Discord Web screenshot`, inline: false, kind: "desktopScreenshot", label: `${label} screenshot`, lane, path: `${lane}/discord-web-proof.png`, required: false, targetPath: `${lane}/discord-web-proof.png` },
+    { kind: "metadata", label: `${label} session summary`, lane, path: `${lane}/summary.json`, targetPath: `${lane}/summary.json` },
+    { kind: "report", label: `${label} session report`, lane, path: `${lane}/report.md`, required: false, targetPath: `${lane}/report.md` },
+  ]);
+}
+export function buildDiscordWebProofManifest({ baseline, baselineRef, baselineSha, candidate, candidateRef, candidateSha, scenarioLabel }) {
+  const baselineStatus = laneStatus(baseline);
+  const candidateStatus = laneStatus(candidate);
+  return {
+    schemaVersion: 1,
+    id: "discord-desktop-proof",
+    title: "Mantis Discord Desktop Proof",
+    summary: "Mantis captured Discord Web before/after GIF evidence with Convex-leased Discord bot credentials and a logged-in viewer profile.",
+    scenario: scenarioLabel || "discord-desktop-proof",
+    comparison: {
+      baseline: { ...(baselineSha ? { sha: baselineSha } : {}), ...(baselineRef ? { ref: baselineRef } : {}), expected: "baseline visual proof captured", status: baselineStatus },
+      candidate: { ...(candidateSha ? { sha: candidateSha } : {}), ...(candidateRef ? { ref: candidateRef } : {}), expected: "candidate visual proof captured", status: candidateStatus, fixed: candidateStatus === "pass" },
+      pass: baselineStatus === "pass" && candidateStatus === "pass",
+    },
+    artifacts: laneArtifactEntries(),
+  };
+}
+export function writeDiscordWebProofEvidence(rawArgs = process.argv.slice(2)) {
+  const args = parseArgs(rawArgs);
+  for (const key of ["baseline_output_dir", "baseline_repo_root", "candidate_output_dir", "candidate_repo_root", "output_dir"]) {
+    if (!args[key]) throw new Error(`Missing --${key.replaceAll("_", "-")}.`);
+  }
+  const outputDir = path.resolve(args.output_dir);
+  mkdirSync(outputDir, { recursive: true });
+  const baseline = loadLane({ outputDir: path.resolve(args.baseline_output_dir), repoRoot: path.resolve(args.baseline_repo_root), status: args.baseline_status });
+  const candidate = loadLane({ outputDir: path.resolve(args.candidate_output_dir), repoRoot: path.resolve(args.candidate_repo_root), status: args.candidate_status });
+  copyLaneArtifacts({ lane: baseline, laneName: "baseline", outputDir });
+  copyLaneArtifacts({ lane: candidate, laneName: "candidate", outputDir });
+  const manifest = buildDiscordWebProofManifest({ baseline, baselineRef: args.baseline_ref, baselineSha: args.baseline_sha, candidate, candidateRef: args.candidate_ref, candidateSha: args.candidate_sha, scenarioLabel: args.scenario_label });
+  const manifestPath = path.join(outputDir, "mantis-evidence.json");
+  writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+  return { manifest, manifestPath };
+}
+
+if (path.resolve(process.argv[1] || "") === fileURLToPath(import.meta.url)) {
+  try {
+    writeDiscordWebProofEvidence();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Summary

**Untested first draft.** This is a first-pass Discord mirror of the existing Telegram desktop proof workflow. It has syntax/YAML sanity only; no live Crabbox/Discord proof has been run yet.

Describe the problem and fix in 2–5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem: Telegram has an agentic Mantis desktop proof workflow; Discord only had scenario-specific/rest-rendered evidence and candidate-only Discord Web capture.
- Why it matters: Discord-visible regressions need the same side-by-side real UI proof path as Telegram.
- What changed: Added a Discord Web Crabbox proof runner, Codex prompt, workflow, evidence manifest builder, and repo-local proof skill.
- What did NOT change (scope boundary): Does not change normal Discord runtime behavior; does not add a new GitHub App; does not add a new credential broker kind.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only. Screenshots are encouraged even for CLI, console, text, or log changes; terminal screenshots and copied live output count. Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

- Behavior or issue addressed: Add Mantis Discord desktop proof plumbing.
- Real environment tested: Not tested live; untested first draft.
- Exact steps or command run after this patch:
  - `node --check scripts/e2e/discord-web-crabbox-proof.ts`
  - `node --check scripts/mantis/build-discord-web-proof-evidence.mjs`
  - `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/mantis-discord-desktop-proof.yml"); puts "workflow yaml ok"'`
  - `git diff --check`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Local syntax/YAML checks passed.
- Observed result after fix: Files parse; workflow YAML loads.
- What was not tested: Live Crabbox lease, Discord Web viewer profile restore, Convex Discord credential lease, local SUT run, Codex workflow execution, Mantis PR evidence publishing.
- Before evidence (optional but encouraged): Existing Telegram proof workflow only.

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: N/A.
- Missing detection / guardrail: N/A.
- Contributing context (if known): Discord Mantis evidence existed in narrower scenario workflows, but not as a Telegram-style agentic desktop proof flow.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: N/A for first draft.
- Scenario the test should lock in: N/A.
- Why this is the smallest reliable guardrail: N/A.
- Existing test that already covers this (if any): N/A.
- If no new test is added, why not: This is an untested first draft intended to put the Discord mirror shape up for review before hardening.

## User-visible / Behavior Changes

Adds a new maintainer-triggered workflow and script:

- Workflow: `Mantis Discord Desktop Proof`
- Script: `pnpm qa:discord-web:crabbox`
- Trigger intent: `@openclaw-mantis discord desktop proof` on labeled PRs, or manual `workflow_dispatch`.

## Diagram (if applicable)

```text
Before:
[Discord PR] -> [scenario-specific REST/HTML proof]

After:
[Discord PR] -> [Codex Mantis agent] -> [baseline/candidate worktrees]
             -> [Discord Web Crabbox proof runner]
             -> [paired GIF/MP4 evidence] -> [Mantis GitHub App PR comment]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) Yes
- Secrets/tokens handling changed? (`Yes/No`) Yes
- New/changed network calls? (`Yes/No`) Yes
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation:
  - Uses existing Mantis/Codex/Crabbox/Convex secret surfaces in a new workflow.
  - Maintainer-gated by repo permission and `mantis: discord-visible-proof` label for issue comments.
  - Uses existing `discord` Convex credential kind; no new broker kind.
  - Intended candidate fork handling is documented in prompt; needs hardening/review before enabling broadly.
  - Artifacts must not include browser profiles, cookies, raw credential payloads, or `.session` directories.

## Repro + Verification

### Environment

- OS: macOS local checkout for syntax/YAML only
- Runtime/container: Node 24.14.1; Ruby YAML parser
- Model/provider: N/A locally
- Integration/channel (if any): Discord / Crabbox intended, not live-tested
- Relevant config (redacted): N/A locally

### Steps

1. Check script syntax.
2. Parse workflow YAML.
3. Check diff whitespace.

### Expected

- Syntax/YAML checks pass.

### Actual

- Syntax/YAML checks passed locally.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Local commands run:

```text
node --check scripts/e2e/discord-web-crabbox-proof.ts
node --check scripts/mantis/build-discord-web-proof-evidence.mjs
ruby -e 'require "yaml"; YAML.load_file(".github/workflows/mantis-discord-desktop-proof.yml"); puts "workflow yaml ok"'
git diff --check
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Syntax/YAML/diff sanity only.
- Edge cases checked: None live.
- What you did **not** verify: End-to-end Discord proof, workflow dispatch, Codex behavior, Crabbox media capture, R2 upload, PR comment publishing.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) Yes
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: Optional workflow setup below.

## Risks and Mitigations

- Risk: The workflow is untested first draft and may fail in live Crabbox/Discord paths.
  - Mitigation: Opened as draft; explicit setup and live-smoke checklist below.
- Risk: Browser profile or credential artifacts could leak if output selection is wrong.
  - Mitigation: Runner output keeps `.session` local and publisher uses manifest-selected artifacts only; reviewers should verify before first live run.
- Risk: Candidate fork secret handling needs scrutiny.
  - Mitigation: Prompt documents restrictions; workflow validates PR head; keep draft until hardened.

## Setup instructions for Discord Mantis desktop proof

### GitHub label

Create and use this PR label for issue-comment activation:

```bash
gh label create "mantis: discord-visible-proof" \
  --repo openclaw/openclaw \
  --color "5319e7" \
  --description "Allows Mantis Discord desktop proof workflow on PR comments"
```

### Required secrets/vars

Expected existing secrets/vars:

```text
MANTIS_GITHUB_APP_ID
MANTIS_GITHUB_APP_PRIVATE_KEY
MANTIS_ARTIFACT_R2_ACCESS_KEY_ID
MANTIS_ARTIFACT_R2_SECRET_ACCESS_KEY
MANTIS_ARTIFACT_R2_ENDPOINT
OPENCLAW_QA_CONVEX_SITE_URL
OPENCLAW_QA_CONVEX_SECRET_CI
CRABBOX_COORDINATOR
CRABBOX_COORDINATOR_TOKEN
CRABBOX_ACCESS_CLIENT_ID
CRABBOX_ACCESS_CLIENT_SECRET
OPENAI_API_KEY or OPENCLAW_MANTIS_AGENT_OPENAI_API_KEY
```

Discord Web viewer needs one of:

```text
MANTIS_DISCORD_VIEWER_CHROME_PROFILE_TGZ_B64
MANTIS_DISCORD_VIEWER_CHROME_PROFILE_DIR
```

### Convex Discord credential payload

Needs a `kind: discord` credential:

```json
{
  "guildId": "...",
  "channelId": "...",
  "driverBotToken": "...",
  "sutBotToken": "...",
  "sutApplicationId": "..."
}
```

Add if missing:

```bash
pnpm openclaw qa credentials add \
  --kind discord \
  --payload-file qa/discord-credential.json \
  --actor-id thewilloftheshadow
```

### Discord guild/channel requirements

- Driver bot can send messages.
- SUT bot can read/send messages and react as needed.
- Logged-in Discord Web viewer account can see the guild/channel.
- SUT application id matches SUT bot user id.

### Local live smoke command sequence

```bash
pnpm qa:discord-web:crabbox -- start \
  --provider aws \
  --output-dir .artifacts/qa-e2e/discord-web-crabbox/smoke

pnpm qa:discord-web:crabbox -- send \
  --session .artifacts/qa-e2e/discord-web-crabbox/smoke/session.json \
  --text "Reply exactly: DISCORD-MANTIS-SMOKE"

pnpm qa:discord-web:crabbox -- view \
  --session .artifacts/qa-e2e/discord-web-crabbox/smoke/session.json \
  --message-id <messageId>

pnpm qa:discord-web:crabbox -- finish \
  --session .artifacts/qa-e2e/discord-web-crabbox/smoke/session.json \
  --preview-crop discord-window
```

Expected artifacts:

```text
discord-web-crabbox-session-summary.json
discord-web-crabbox-session-motion-discord-window.gif
discord-web-crabbox-session-motion-discord-window.mp4
discord-web-crabbox-session.png
```

### Workflow trigger

Add label to target PR:

```bash
gh pr edit <PR> --add-label "mantis: discord-visible-proof"
```

Comment:

```text
@openclaw-mantis discord desktop proof
```

Manual dispatch:

```bash
gh workflow run mantis-discord-desktop-proof.yml \
  --repo openclaw/openclaw \
  --ref feat/mantis-discord-desktop-proof \
  -f pr_number=<PR> \
  -f instructions="Prove the Discord-visible behavior changed"
```
