### PR TITLE
feat: add Apify web search and web fetch providers

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -315,6 +315,10 @@
   - changed-files:
       - any-glob-to-any-file:
           - "extensions/acpx/**"
+"extensions: apify":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/apify/**"
 "extensions: arcee":
   - changed-files:
       - any-glob-to-any-file:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Plugins/Apify: add bundled Apify plugin with web search (RAG Web Browser actor) and web fetch (Website Content Crawler actor) providers, sharing a single API key at `plugins.entries.apify.config.apiKey` with `playwright:adaptive`/`playwright:firefox`/`cheerio` crawler type selection and configurable timeouts. Thanks @JanHranicky.
 - Discord: let voice sessions follow configured Discord users into voice channels, with allowed-channel checks, multi-user handoff, bounded reconciliation, and DAVE recovery preservation. (#84264) Thanks @fuller-stack-dev.
 - Discord/voice: include bounded `IDENTITY.md`, `USER.md`, and `SOUL.md` profile context in realtime voice session instructions by default, with `voice.realtime.bootstrapContextFiles: []` available to disable it. (#84499) Thanks @fuller-stack-dev.
 - Dependencies: bump the bundled Codex harness to `@openai/codex` `0.132.0` and refresh the app-server model-list docs for the new catalog.

--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -1,5 +1,9 @@
 [
   {
+    "source": "Apify",
+    "target": "Apify"
+  },
+  {
     "source": "OpenClaw",
     "target": "OpenClaw"
   },

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1290,6 +1290,7 @@
                     "pages": [
                       "tools/web-fetch",
                       "tools/web",
+                      "tools/apify",
                       "tools/brave-search",
                       "tools/duckduckgo-search",
                       "tools/exa-search",

--- a/docs/tools/apify.md
+++ b/docs/tools/apify.md
@@ -1,0 +1,106 @@
+---
+summary: "Apify web search and web fetch providers"
+read_when:
+  - You want to use Apify as a web_search or web_fetch provider
+  - You need full-page content extraction with JS rendering
+  - You want to configure the Apify crawler type or timeout
+title: "Apify"
+---
+
+OpenClaw can use **Apify** in two ways:
+
+- as the `web_search` provider (via the [RAG Web Browser](https://apify.com/apify/rag-web-browser) actor)
+- as the `web_fetch` provider (via the [Website Content Crawler](https://apify.com/apify/website-content-crawler) actor)
+
+Both share a single API key stored at `plugins.entries.apify.config.apiKey`.
+
+## Get an API key
+
+1. Create a free [Apify](https://apify.com/) account.
+2. Copy your API token from [Apify Console](https://console.apify.com/settings/integrations).
+3. Store it in config or set `APIFY_API_KEY` in the gateway environment.
+
+## Configure Apify web search
+
+```json5
+{
+  tools: {
+    web: {
+      search: {
+        provider: "apify",
+      },
+    },
+  },
+  plugins: {
+    entries: {
+      apify: {
+        enabled: true,
+        config: {
+          apiKey: "apify_...",
+          webSearch: {
+            maxResults: 5, // 1–10, default: 5
+            timeoutSeconds: 30, // 1–300, default: 30
+          },
+        },
+      },
+    },
+  },
+}
+```
+
+The [RAG Web Browser](https://apify.com/apify/rag-web-browser) Actor returns headless-rendered pages with full Markdown content, providing full context and formatting even from dynamic web pages.
+
+## Configure Apify web fetch
+
+```json5
+{
+  tools: {
+    web: {
+      fetch: {
+        provider: "apify",
+        readability: false, // skip local extraction and go straight to Apify
+      },
+    },
+  },
+  plugins: {
+    entries: {
+      apify: {
+        enabled: true,
+        config: {
+          apiKey: "apify_...",
+          webFetch: {
+            crawlerType: "playwright:adaptive", // "playwright:adaptive" | "playwright:firefox" | "cheerio"
+            timeoutSeconds: 60, // 1–300, default: 60
+          },
+        },
+      },
+    },
+  },
+}
+```
+
+### Crawler types
+
+| Crawler                         | Best for                                | Memory |
+| ------------------------------- | --------------------------------------- | ------ |
+| `playwright:adaptive` (default) | Auto-selects headless vs full rendering | 4 GB   |
+| `playwright:firefox`            | JS-heavy or bot-protected pages         | 4 GB   |
+| `cheerio`                       | Fast plain-HTML pages                   | 1 GB   |
+
+Use `playwright:firefox` when `playwright:adaptive` returns empty or partial content.
+
+Setting `tools.web.fetch.readability: false` skips the local Readability extraction
+step and routes all `web_fetch` calls directly to the Apify actor.
+
+## Notes
+
+- `plugins.entries.apify.config.apiKey` is the shared key for both providers. The env fallback is `APIFY_API_KEY`.
+- Actor memory is chosen automatically: 1 GB for Cheerio raw HTTP requests, 4 GB for Playwright browser.
+- Results from the RAG Web Browser are cached for 15 minutes (controlled by `tools.web.search.cacheTtlMinutes`).
+- Use [Apify OpenClaw plugin](https://docs.apify.com/platform/integrations/openclaw) to let your claws access thousands of other web data extraction and automation tools from [Apify Store](https://apify.com/store)
+
+## Related
+
+- [Web Search](/tools/web) -- all providers and auto-detection
+- [Web Fetch](/tools/web-fetch) -- `web_fetch` tool and provider configuration
+- [Firecrawl](/tools/firecrawl) -- alternative web fetch and search provider

--- a/docs/tools/web-fetch.md
+++ b/docs/tools/web-fetch.md
@@ -85,6 +85,40 @@ Truncate output to this many characters.
 }
 ```
 
+## Apify fallback
+
+If Readability extraction fails (or `readability: false` is set), `web_fetch` can use
+[Apify Website Content Crawler](/tools/apify) for full JS rendering and anti-bot extraction:
+
+```json5
+{
+  tools: {
+    web: {
+      fetch: {
+        provider: "apify", // optional; omit for auto-detect
+        readability: false, // route all fetches through Apify, skip local extraction
+      },
+    },
+  },
+  plugins: {
+    entries: {
+      apify: {
+        enabled: true,
+        config: {
+          apiKey: "apify_...", // optional if APIFY_API_KEY is set
+          webFetch: {
+            crawlerType: "playwright:adaptive", // "playwright:adaptive" | "playwright:firefox" | "cheerio"
+            timeoutSeconds: 60,
+          },
+        },
+      },
+    },
+  },
+}
+```
+
+Use `crawlerType: "playwright:firefox"` when `playwright:adaptive` returns empty or partial content.
+
 ## Firecrawl fallback
 
 If Readability extraction fails, `web_fetch` can fall back to
@@ -95,7 +129,7 @@ If Readability extraction fails, `web_fetch` can fall back to
   tools: {
     web: {
       fetch: {
-        provider: "firecrawl", // optional; omit for auto-detect from available credentials
+        provider: "firecrawl", // "apify" | "firecrawl"; omit for auto-detect from available credentials
       },
     },
   },
@@ -192,4 +226,5 @@ If you use tool profiles or allowlists, add `web_fetch` or `group:web`:
 
 - [Web Search](/tools/web) -- search the web with multiple providers
 - [Web Browser](/tools/browser) -- full browser automation for JS-heavy sites
+- [Apify](/tools/apify) -- Apify web search and web fetch providers
 - [Firecrawl](/tools/firecrawl) -- Firecrawl search and scrape tools

--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -57,6 +57,9 @@ local while `web_search` and `x_search` can use xAI Responses under the hood.
 ## Choosing a provider
 
 <CardGroup cols={2}>
+  <Card title="Apify" icon="globe" href="/tools/apify">
+    Headless-rendered Google Search results with smart Markdown extraction. Free tier available.
+  </Card>
   <Card title="Brave Search" icon="shield" href="/tools/brave-search">
     Structured results with snippets. Supports `llm-context` mode, country/language filters. Free tier available.
   </Card>
@@ -99,6 +102,7 @@ local while `web_search` and `x_search` can use xAI Responses under the hood.
 
 | Provider                                  | Result style                                                   | Filters                                          | API key                                                                                 |
 | ----------------------------------------- | -------------------------------------------------------------- | ------------------------------------------------ | --------------------------------------------------------------------------------------- |
+| [Apify](/tools/apify)                     | Full-page Markdown                                             | --                                               | `APIFY_API_KEY`                                                                         |
 | [Brave](/tools/brave-search)              | Structured snippets                                            | Country, language, time, `llm-context` mode      | `BRAVE_API_KEY`                                                                         |
 | [DuckDuckGo](/tools/duckduckgo-search)    | Structured snippets                                            | --                                               | None (key-free)                                                                         |
 | [Exa](/tools/exa-search)                  | Structured + extracted                                         | Neural/keyword mode, date, content extraction    | `EXA_API_KEY`                                                                           |
@@ -181,15 +185,16 @@ API-backed providers first:
 4. **Grok** -- `XAI_API_KEY` or `plugins.entries.xai.config.webSearch.apiKey` (order 30)
 5. **Kimi** -- `KIMI_API_KEY` / `MOONSHOT_API_KEY` or `plugins.entries.moonshot.config.webSearch.apiKey` (order 40)
 6. **Perplexity** -- `PERPLEXITY_API_KEY` / `OPENROUTER_API_KEY` or `plugins.entries.perplexity.config.webSearch.apiKey` (order 50)
-7. **Firecrawl** -- `FIRECRAWL_API_KEY` or `plugins.entries.firecrawl.config.webSearch.apiKey` (order 60)
-8. **Exa** -- `EXA_API_KEY` or `plugins.entries.exa.config.webSearch.apiKey`; optional `plugins.entries.exa.config.webSearch.baseUrl` overrides the Exa endpoint (order 65)
-9. **Tavily** -- `TAVILY_API_KEY` or `plugins.entries.tavily.config.webSearch.apiKey` (order 70)
+7. **Apify** -- `APIFY_API_KEY` or `plugins.entries.apify.config.apiKey` (order 60)
+8. **Firecrawl** -- `FIRECRAWL_API_KEY` or `plugins.entries.firecrawl.config.webSearch.apiKey` (order 60)
+9. **Exa** -- `EXA_API_KEY` or `plugins.entries.exa.config.webSearch.apiKey`; optional `plugins.entries.exa.config.webSearch.baseUrl` overrides the Exa endpoint (order 65)
+10. **Tavily** -- `TAVILY_API_KEY` or `plugins.entries.tavily.config.webSearch.apiKey` (order 70)
 
 Key-free fallbacks after that:
 
-10. **DuckDuckGo** -- key-free HTML fallback with no account or API key (order 100)
-11. **Ollama Web Search** -- key-free fallback via your configured local Ollama host when it is reachable and signed in with `ollama signin`; can reuse Ollama provider bearer auth when the host needs it, and can call direct `https://ollama.com` search when configured with `OLLAMA_API_KEY` (order 110)
-12. **SearXNG** -- `SEARXNG_BASE_URL` or `plugins.entries.searxng.config.webSearch.baseUrl` (order 200)
+11. **DuckDuckGo** -- key-free HTML fallback with no account or API key (order 100)
+12. **Ollama Web Search** -- key-free fallback via your configured local Ollama host when it is reachable and signed in with `ollama signin`; can reuse Ollama provider bearer auth when the host needs it, and can call direct `https://ollama.com` search when configured with `OLLAMA_API_KEY` (order 110)
+13. **SearXNG** -- `SEARXNG_BASE_URL` or `plugins.entries.searxng.config.webSearch.baseUrl` (order 200)
 
 If no provider is detected, it falls back to Brave (you will get a missing-key
 error prompting you to configure one).
@@ -245,8 +250,7 @@ plugin or run `openclaw doctor --fix` to clean up the stale config.
   provider from available credentials
 - non-sandboxed `web_fetch` can use installed plugin providers that declare
   `contracts.webFetchProviders`; sandboxed fetches stay bundled-only
-- today the bundled web-fetch provider is Firecrawl, configured under
-  `plugins.entries.firecrawl.config.webFetch.*`
+- bundled web-fetch providers are Apify (`plugins.entries.apify.config.webFetch.*`) and Firecrawl (`plugins.entries.firecrawl.config.webFetch.*`); Apify is selected first if `APIFY_API_KEY` is set
 
 When you choose **Kimi** during `openclaw onboard` or
 `openclaw configure --section web`, OpenClaw can also ask for:

--- a/extensions/apify/index.ts
+++ b/extensions/apify/index.ts
@@ -1,0 +1,13 @@
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { createApifyWebFetchProvider } from "./src/apify-fetch-provider.js";
+import { createApifyWebSearchProvider } from "./src/apify-search-provider.js";
+
+export default definePluginEntry({
+  id: "apify",
+  name: "Apify Plugin",
+  description: "Apify RAG Web Browser web search and Website Content Crawler web fetch provider",
+  register(api) {
+    api.registerWebFetchProvider(createApifyWebFetchProvider());
+    api.registerWebSearchProvider(createApifyWebSearchProvider());
+  },
+});

--- a/extensions/apify/openclaw.plugin.json
+++ b/extensions/apify/openclaw.plugin.json
@@ -1,0 +1,61 @@
+{
+  "id": "apify",
+  "providerAuthEnvVars": {
+    "apify": ["APIFY_API_KEY"]
+  },
+  "uiHints": {
+    "apiKey": {
+      "label": "Apify API Token",
+      "help": "Apify personal API token used for both web search and web fetch (fallback: APIFY_API_KEY env var).",
+      "sensitive": true,
+      "placeholder": "apify_..."
+    },
+    "webFetch.crawlerType": {
+      "label": "Fetch Crawler Type",
+      "help": "Crawler engine for web fetch. \"playwright:adaptive\" (default) auto-selects rendering; \"playwright:firefox\" forces full rendering for heavily bot-protected pages; \"cheerio\" is fastest for plain-HTML pages."
+    },
+    "webFetch.timeoutSeconds": {
+      "label": "Fetch Timeout (seconds)",
+      "help": "Maximum seconds to wait for the website-content-crawler actor to respond (1–300)."
+    },
+    "webSearch.maxResults": {
+      "label": "Search Max Results",
+      "help": "Maximum number of search results to return (1–10, capped by OpenClaw core)."
+    },
+    "webSearch.timeoutSeconds": {
+      "label": "Search Timeout (seconds)",
+      "help": "Maximum seconds to wait for the rag-web-browser actor to respond (1–300)."
+    }
+  },
+  "contracts": {
+    "webFetchProviders": ["apify"],
+    "webSearchProviders": ["apify"]
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "apiKey": { "type": ["string", "object"] },
+      "webSearch": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "timeoutSeconds": { "type": "number", "minimum": 1, "maximum": 300, "default": 30 },
+          "maxResults": { "type": "number", "minimum": 1, "maximum": 10, "default": 5 }
+        }
+      },
+      "webFetch": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "crawlerType": {
+            "type": "string",
+            "enum": ["cheerio", "playwright:firefox", "playwright:adaptive"],
+            "default": "playwright:adaptive"
+          },
+          "timeoutSeconds": { "type": "number", "minimum": 1, "maximum": 300, "default": 60 }
+        }
+      }
+    }
+  }
+}

--- a/extensions/apify/package.json
+++ b/extensions/apify/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@openclaw/apify-plugin",
+  "version": "2026.4.27",
+  "private": true,
+  "description": "OpenClaw Apify plugin",
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/apify/src/apify-fetch-provider-shared.ts
+++ b/extensions/apify/src/apify-fetch-provider-shared.ts
@@ -1,0 +1,44 @@
+import type { WebFetchProviderPlugin } from "openclaw/plugin-sdk/provider-web-fetch-contract";
+import {
+  APIFY_CREDENTIAL_LABEL,
+  APIFY_CREDENTIAL_PATH,
+  APIFY_ENV_VARS,
+  APIFY_PLACEHOLDER,
+  APIFY_PLUGIN_ID,
+  APIFY_SIGNUP_URL,
+  ensureRecord,
+  resolveApifyPluginApiKey,
+  setApifyPluginApiKey,
+} from "./apify-shared.js";
+
+type ApifyFetchProviderSharedFields = Omit<
+  WebFetchProviderPlugin,
+  "applySelectionConfig" | "createTool"
+>;
+
+export const APIFY_FETCH_PROVIDER_SHARED = {
+  id: APIFY_PLUGIN_ID,
+  label: "Apify Website Content Crawler",
+  hint: "Fetch pages with full JS rendering and anti-bot protection using Apify.",
+  credentialLabel: APIFY_CREDENTIAL_LABEL,
+  envVars: APIFY_ENV_VARS,
+  placeholder: APIFY_PLACEHOLDER,
+  signupUrl: APIFY_SIGNUP_URL,
+  docsUrl: "https://apify.com/apify/website-content-crawler",
+  autoDetectOrder: 50,
+  credentialPath: APIFY_CREDENTIAL_PATH,
+  inactiveSecretPaths: [APIFY_CREDENTIAL_PATH],
+  getCredentialValue: (fetchConfig?: Record<string, unknown>) => {
+    const apifyConfig = fetchConfig?.apify;
+    return apifyConfig && typeof apifyConfig === "object" && !Array.isArray(apifyConfig)
+      ? (apifyConfig as Record<string, unknown>).apiKey
+      : undefined;
+  },
+  setCredentialValue: (fetchConfigTarget: Record<string, unknown>, value: unknown) => {
+    const apifyConfig = ensureRecord(fetchConfigTarget, "apify");
+    apifyConfig.apiKey = value;
+  },
+  getConfiguredCredentialValue: (config: unknown) => resolveApifyPluginApiKey(config),
+  setConfiguredCredentialValue: (configTarget: unknown, value: unknown) =>
+    setApifyPluginApiKey(configTarget, value),
+} satisfies ApifyFetchProviderSharedFields;

--- a/extensions/apify/src/apify-fetch-provider.test.ts
+++ b/extensions/apify/src/apify-fetch-provider.test.ts
@@ -1,0 +1,243 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createApifyWebFetchProvider as createContractApifyWebFetchProvider } from "../web-fetch-contract-api.js";
+import { createApifyWebFetchProvider } from "./apify-fetch-provider.js";
+
+type MockFetch = (
+  _input?: unknown,
+  _init?: unknown,
+) => Promise<{ ok: boolean; json: () => Promise<unknown>; statusText?: string }>;
+
+function makeFetchMock(items: unknown[]): ReturnType<typeof vi.fn<MockFetch>> {
+  return vi.fn<MockFetch>(async () => ({ ok: true, json: async () => items }));
+}
+
+describe("apify web fetch provider", () => {
+  const priorFetch = global.fetch;
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    global.fetch = priorFetch;
+  });
+
+  it("exposes the expected metadata and credential wiring", () => {
+    const provider = createApifyWebFetchProvider();
+
+    expect(provider.id).toBe("apify");
+    expect(provider.label).toBe("Apify Website Content Crawler");
+    expect(provider.credentialPath).toBe("plugins.entries.apify.config.apiKey");
+    expect(provider.envVars).toEqual(["APIFY_API_KEY"]);
+    expect(provider.autoDetectOrder).toBe(50);
+    expect(typeof provider.getCredentialValue).toBe("function");
+    expect(typeof provider.setCredentialValue).toBe("function");
+  });
+
+  it("keeps the lightweight contract surface aligned with provider metadata", () => {
+    const provider = createApifyWebFetchProvider();
+    const contractProvider = createContractApifyWebFetchProvider();
+
+    expect(contractProvider).toMatchObject({
+      id: provider.id,
+      label: provider.label,
+      hint: provider.hint,
+      envVars: provider.envVars,
+      placeholder: provider.placeholder,
+      signupUrl: provider.signupUrl,
+      docsUrl: provider.docsUrl,
+      autoDetectOrder: provider.autoDetectOrder,
+      credentialPath: provider.credentialPath,
+    });
+    expect(contractProvider.createTool({ config: {} })).toBeNull();
+  });
+
+  it("createTool returns a non-null tool definition", () => {
+    const provider = createApifyWebFetchProvider();
+    const tool = provider.createTool({ config: {} });
+    expect(tool).not.toBeNull();
+    expect(tool?.description).toContain("Apify Website Content Crawler");
+    expect(tool?.parameters).toBeDefined();
+  });
+
+  it("throws when no API key is configured", async () => {
+    vi.stubEnv("APIFY_API_KEY", "");
+    const provider = createApifyWebFetchProvider();
+    const tool = provider.createTool({ config: {} });
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+
+    await expect(tool.execute({ url: "https://example.com" })).rejects.toThrow(
+      "missing Apify API token",
+    );
+  });
+
+  it("resolves the API key from APIFY_API_KEY environment variable", async () => {
+    vi.stubEnv("APIFY_API_KEY", "apify_env_key");
+    const mockFetch = makeFetchMock([
+      { url: "https://example.com", metadata: { title: "Example" }, markdown: "# Example" },
+    ]);
+    global.fetch = mockFetch as unknown as typeof global.fetch;
+
+    const provider = createApifyWebFetchProvider();
+    const tool = provider.createTool({ config: {} });
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+
+    const result = (await tool.execute({ url: "https://example.com" })) as Record<string, unknown>;
+
+    expect(result.provider).toBe("apify");
+    const init = mockFetch.mock.calls[0]?.[1] as RequestInit;
+    expect(init?.headers).toMatchObject({ Authorization: "Bearer apify_env_key" });
+  });
+
+  it("prefers configured plugin apiKey over the environment variable", async () => {
+    vi.stubEnv("APIFY_API_KEY", "apify_env_key");
+    const mockFetch = makeFetchMock([
+      { url: "https://example.com", metadata: { title: "Example" }, markdown: "# Example" },
+    ]);
+    global.fetch = mockFetch as unknown as typeof global.fetch;
+
+    const provider = createApifyWebFetchProvider();
+    const tool = provider.createTool({
+      config: {
+        plugins: {
+          entries: {
+            apify: {
+              config: {
+                apiKey: "apify_configured_key",
+              },
+            },
+          },
+        },
+      },
+    });
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+
+    await tool.execute({ url: "https://example.com" });
+
+    const init = mockFetch.mock.calls[0]?.[1] as RequestInit;
+    expect(init?.headers).toMatchObject({ Authorization: "Bearer apify_configured_key" });
+  });
+
+  it("calls the Apify Website Content Crawler endpoint with the correct request body", async () => {
+    vi.stubEnv("APIFY_API_KEY", "");
+    const mockFetch = makeFetchMock([
+      {
+        url: "https://example.com",
+        metadata: { title: "Example Page" },
+        markdown: "# Example\n\nSome content.",
+      },
+    ]);
+    global.fetch = mockFetch as unknown as typeof global.fetch;
+
+    const provider = createApifyWebFetchProvider();
+    const tool = provider.createTool({
+      config: {
+        plugins: {
+          entries: {
+            apify: {
+              config: {
+                apiKey: "apify_test_key",
+              },
+            },
+          },
+        },
+      },
+    });
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+
+    const result = (await tool.execute({ url: "https://example.com" })) as Record<string, unknown>;
+
+    expect(result.provider).toBe("apify");
+    expect(result.url).toBe("https://example.com");
+
+    const requestUrl = String(mockFetch.mock.calls[0]?.[0]);
+    expect(requestUrl).toContain("apify~website-content-crawler");
+
+    const init = mockFetch.mock.calls[0]?.[1] as RequestInit;
+    const body = JSON.parse(init?.body as string) as Record<string, unknown>;
+    expect(body.startUrls).toEqual([{ url: "https://example.com" }]);
+    expect(body.maxCrawlDepth).toBe(0);
+    expect(body.maxCrawlPages).toBe(1);
+    expect(body.saveMarkdown).toBe(true);
+  });
+
+  it("uses low memory for cheerio and high memory for playwright crawlers", async () => {
+    vi.stubEnv("APIFY_API_KEY", "");
+    const config = {
+      plugins: {
+        entries: {
+          apify: {
+            config: {
+              apiKey: "apify_test_key",
+            },
+          },
+        },
+      },
+    };
+
+    const provider = createApifyWebFetchProvider();
+
+    const cheerioMock = makeFetchMock([
+      { url: "https://example.com", metadata: { title: "" }, markdown: "" },
+    ]);
+    global.fetch = cheerioMock as unknown as typeof global.fetch;
+    const cheerioTool = provider.createTool({ config });
+    await cheerioTool?.execute({ url: "https://example.com", crawlerType: "cheerio" });
+    expect(String(cheerioMock.mock.calls[0]?.[0])).toContain("memory=1024");
+
+    const playwrightMock = makeFetchMock([
+      { url: "https://example.com", metadata: { title: "" }, markdown: "" },
+    ]);
+    global.fetch = playwrightMock as unknown as typeof global.fetch;
+    const playwrightTool = provider.createTool({ config });
+    await playwrightTool?.execute({
+      url: "https://example.com",
+      crawlerType: "playwright:firefox",
+    });
+    expect(String(playwrightMock.mock.calls[0]?.[0])).toContain("memory=4096");
+  });
+
+  it("throws when the API returns an empty array", async () => {
+    vi.stubEnv("APIFY_API_KEY", "");
+    const mockFetch = makeFetchMock([]);
+    global.fetch = mockFetch as unknown as typeof global.fetch;
+
+    const provider = createApifyWebFetchProvider();
+    const tool = provider.createTool({
+      config: {
+        plugins: {
+          entries: {
+            apify: {
+              config: { apiKey: "apify_test_key" },
+            },
+          },
+        },
+      },
+    });
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+
+    await expect(tool.execute({ url: "https://example.com" })).rejects.toThrow(
+      "Website Content Crawler returned no content",
+    );
+  });
+
+  it("setConfiguredCredentialValue writes apiKey into the expected config path", () => {
+    const provider = createApifyWebFetchProvider();
+    const configTarget: Record<string, unknown> = {};
+    provider.setConfiguredCredentialValue?.(configTarget, "apify_written_key");
+    expect(
+      (
+        configTarget as {
+          plugins?: { entries?: { apify?: { config?: { apiKey?: unknown } } } };
+        }
+      ).plugins?.entries?.apify?.config?.apiKey,
+    ).toBe("apify_written_key");
+  });
+});

--- a/extensions/apify/src/apify-fetch-provider.ts
+++ b/extensions/apify/src/apify-fetch-provider.ts
@@ -1,0 +1,97 @@
+import type { WebFetchProviderPlugin } from "openclaw/plugin-sdk/provider-web-fetch";
+import {
+  enablePluginInConfig,
+  readNumberParam,
+  readStringParam,
+  resolveTimeoutSeconds,
+} from "openclaw/plugin-sdk/provider-web-fetch";
+import {
+  readConfiguredSecretString,
+  readProviderEnvValue,
+} from "openclaw/plugin-sdk/provider-web-search";
+import { APIFY_FETCH_PROVIDER_SHARED } from "./apify-fetch-provider-shared.js";
+import type { CrawlerType } from "./apify-fetch-runtime.js";
+import {
+  APIFY_CREDENTIAL_PATH,
+  APIFY_PLUGIN_ID,
+  resolveApifyPluginApiKey,
+} from "./apify-shared.js";
+
+type ApifyFetchRuntime = typeof import("./apify-fetch-runtime.js");
+
+let apifyFetchRuntimePromise: Promise<ApifyFetchRuntime> | undefined;
+
+function loadApifyFetchRuntime(): Promise<ApifyFetchRuntime> {
+  apifyFetchRuntimePromise ??= import("./apify-fetch-runtime.js");
+  return apifyFetchRuntimePromise;
+}
+
+function resolveApifyFetchApiKey(config: unknown): string | undefined {
+  return (
+    readConfiguredSecretString(resolveApifyPluginApiKey(config), APIFY_CREDENTIAL_PATH) ??
+    readProviderEnvValue(["APIFY_API_KEY"])
+  );
+}
+
+function resolveCrawlerType(
+  raw: unknown,
+  fallback: CrawlerType = "playwright:adaptive",
+): CrawlerType {
+  if (raw === "cheerio" || raw === "playwright:firefox" || raw === "playwright:adaptive") {
+    return raw;
+  }
+  return fallback;
+}
+
+const ApifyFetchSchema = {
+  type: "object",
+  properties: {
+    url: { type: "string", description: "HTTP or HTTPS URL to fetch." },
+    crawlerType: {
+      type: "string",
+      enum: ["cheerio", "playwright:firefox", "playwright:adaptive"],
+      description:
+        'Crawler type. "playwright:adaptive" (default) auto-selects between headless and full rendering. "playwright:firefox" forces full rendering for heavily bot-protected pages. "cheerio" is fastest for plain-HTML pages.',
+    },
+    maxChars: {
+      type: "number",
+      description: "Maximum characters to return.",
+      minimum: 100,
+    },
+  },
+  required: ["url"],
+  additionalProperties: false,
+} satisfies Record<string, unknown>;
+
+export function createApifyWebFetchProvider(): WebFetchProviderPlugin {
+  return {
+    ...APIFY_FETCH_PROVIDER_SHARED,
+    applySelectionConfig: (config) => enablePluginInConfig(config, APIFY_PLUGIN_ID).config,
+    createTool: ({ config }) => {
+      const apiKey = resolveApifyFetchApiKey(config);
+      const webFetchConfig = (
+        config as {
+          plugins?: { entries?: { apify?: { config?: { webFetch?: Record<string, unknown> } } } };
+        }
+      )?.plugins?.entries?.apify?.config?.webFetch;
+      const crawlerType = resolveCrawlerType(webFetchConfig?.crawlerType);
+      const timeoutSeconds = resolveTimeoutSeconds(webFetchConfig?.timeoutSeconds, 60);
+      return {
+        description:
+          "Fetch a web page using Apify Website Content Crawler. Returns full page content as markdown. " +
+          'Default crawlerType "playwright:adaptive" auto-selects rendering. Use "playwright:firefox" for heavily bot-protected pages; "cheerio" for fast plain-HTML pages.',
+        parameters: ApifyFetchSchema,
+        execute: async (args: Record<string, unknown>) => {
+          const url = readStringParam(args, "url", { required: true });
+          const crawlerTypeArg = resolveCrawlerType(
+            readStringParam(args, "crawlerType"),
+            crawlerType,
+          );
+          const maxChars = readNumberParam(args, "maxChars", { integer: true });
+          const { executeApifyFetch } = await loadApifyFetchRuntime();
+          return executeApifyFetch(url, apiKey, crawlerTypeArg, timeoutSeconds, maxChars);
+        },
+      };
+    },
+  };
+}

--- a/extensions/apify/src/apify-fetch-runtime.ts
+++ b/extensions/apify/src/apify-fetch-runtime.ts
@@ -1,0 +1,106 @@
+import {
+  readResponseText,
+  truncateText,
+  withTrustedWebToolsEndpoint,
+  wrapWebContent,
+} from "openclaw/plugin-sdk/provider-web-fetch";
+import { APIFY_INTEGRATION_HEADERS, APIFY_PLUGIN_ID } from "./apify-shared.js";
+
+const APIFY_CRAWLER_ENDPOINT =
+  "https://api.apify.com/v2/acts/apify~website-content-crawler/run-sync-get-dataset-items";
+
+export type CrawlerType = "cheerio" | "playwright:firefox" | "playwright:adaptive";
+
+type CrawlerResultItem = {
+  url?: string;
+  metadata?: {
+    title?: string;
+    description?: string;
+    languageCode?: string;
+    canonicalUrl?: string;
+  };
+  markdown?: string;
+  text?: string;
+};
+
+function resolveMemoryMb(crawlerType: CrawlerType): number {
+  return crawlerType.startsWith("playwright:") ? 4096 : 1024;
+}
+
+export async function executeApifyFetch(
+  url: string,
+  apiKey: string | undefined,
+  crawlerType: CrawlerType,
+  timeoutSeconds: number,
+  maxChars?: number,
+): Promise<Record<string, unknown>> {
+  if (!apiKey) {
+    throw new Error(
+      "web_fetch (apify): missing Apify API token. Set APIFY_API_KEY in the environment or configure plugins.entries.apify.config.apiKey.",
+    );
+  }
+
+  const start = Date.now();
+  const memoryMb = resolveMemoryMb(crawlerType);
+  const endpointUrl = `${APIFY_CRAWLER_ENDPOINT}?memory=${memoryMb}`;
+
+  const items = await withTrustedWebToolsEndpoint<CrawlerResultItem[]>(
+    {
+      url: endpointUrl,
+      timeoutSeconds,
+      init: {
+        method: "POST",
+        headers: {
+          Accept: "application/json",
+          Authorization: `Bearer ${apiKey}`,
+          "Content-Type": "application/json",
+          ...APIFY_INTEGRATION_HEADERS,
+        },
+        body: JSON.stringify({
+          startUrls: [{ url }],
+          crawlerType,
+          maxCrawlDepth: 0,
+          maxCrawlPages: 1,
+          maxResults: 1,
+          removeCookieWarnings: true,
+          saveMarkdown: true,
+          requestTimeoutSecs: timeoutSeconds,
+        }),
+      },
+    },
+    async ({ response }) => {
+      if (!response.ok) {
+        const detail = await readResponseText(response, { maxBytes: 64_000 });
+        throw new Error(
+          `Apify Website Content Crawler API error (${response.status}): ${detail.text || response.statusText}`,
+        );
+      }
+      const data = (await response.json()) as CrawlerResultItem[];
+      return Array.isArray(data) ? data : [];
+    },
+  );
+
+  const item = items[0];
+  if (!item) {
+    throw new Error(`web_fetch (apify): Website Content Crawler returned no content for ${url}.`);
+  }
+
+  const title = item.metadata?.title ?? "";
+  const rawContent = item.markdown ?? item.text ?? "";
+  const content = maxChars !== undefined ? truncateText(rawContent, maxChars).text : rawContent;
+  const fetchedUrl = item.url ?? url;
+
+  return {
+    url: fetchedUrl,
+    provider: APIFY_PLUGIN_ID,
+    tookMs: Date.now() - start,
+    title: title ? wrapWebContent(title, "web_fetch") : "",
+    text: content ? wrapWebContent(content, "web_fetch") : "",
+    externalContent: {
+      untrusted: true,
+      source: "web_fetch",
+      provider: APIFY_PLUGIN_ID,
+      wrapped: true,
+    },
+  };
+}

--- a/extensions/apify/src/apify-search-provider.test.ts
+++ b/extensions/apify/src/apify-search-provider.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { __testing } from "../test-api.js";
+import { createApifyWebSearchProvider as createContractApifyWebSearchProvider } from "../web-search-contract-api.js";
+import { createApifyWebSearchProvider } from "./apify-search-provider.js";
+
+describe("apify web search provider", () => {
+  const priorFetch = global.fetch;
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    global.fetch = priorFetch;
+  });
+
+  it("exposes the expected metadata and credential wiring", () => {
+    const provider = createApifyWebSearchProvider();
+
+    expect(provider.id).toBe("apify");
+    expect(provider.label).toBe("Apify RAG Web Browser");
+    expect(provider.credentialPath).toBe("plugins.entries.apify.config.apiKey");
+    expect(provider.envVars).toEqual(["APIFY_API_KEY"]);
+    expect(provider.autoDetectOrder).toBe(60);
+    expect(typeof provider.getCredentialValue).toBe("function");
+    expect(typeof provider.setCredentialValue).toBe("function");
+  });
+
+  it("keeps the lightweight contract surface aligned with provider metadata", () => {
+    const provider = createApifyWebSearchProvider();
+    const contractProvider = createContractApifyWebSearchProvider();
+
+    expect(contractProvider).toMatchObject({
+      id: provider.id,
+      label: provider.label,
+      hint: provider.hint,
+      envVars: provider.envVars,
+      placeholder: provider.placeholder,
+      signupUrl: provider.signupUrl,
+      docsUrl: provider.docsUrl,
+      autoDetectOrder: provider.autoDetectOrder,
+      credentialPath: provider.credentialPath,
+    });
+    expect(contractProvider.createTool({ config: {}, searchConfig: {} })).toBeNull();
+  });
+
+  it("createTool returns a non-null tool definition", () => {
+    const provider = createApifyWebSearchProvider();
+    const tool = provider.createTool({ config: {}, searchConfig: {} });
+    expect(tool).not.toBeNull();
+    expect(tool?.description).toContain("Apify RAG Web Browser");
+    expect(tool?.parameters).toBeDefined();
+  });
+
+  it("returns a soft error payload when no API key is configured", async () => {
+    vi.stubEnv("APIFY_API_KEY", "");
+    const provider = createApifyWebSearchProvider();
+    const tool = provider.createTool({ config: {}, searchConfig: {} });
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+
+    const result = await tool.execute({ query: "test" });
+
+    expect(result).toMatchObject({ error: "missing_apify_api_key" });
+  });
+
+  it("picks up APIFY_API_KEY from the environment", () => {
+    vi.stubEnv("APIFY_API_KEY", "apify_env_key");
+    expect(__testing.resolveApifyApiKey({})).toBe("apify_env_key");
+  });
+
+  it("prefers configured plugin apiKey over the environment variable", () => {
+    vi.stubEnv("APIFY_API_KEY", "apify_env_key");
+    expect(__testing.resolveApifyApiKey({ apiKey: "apify_configured" })).toBe("apify_configured");
+  });
+
+  it("calls the Apify actor endpoint with the query and merged searchConfig", async () => {
+    vi.stubEnv("APIFY_API_KEY", "");
+    const mockFetch = vi.fn(async (_input?: unknown, _init?: unknown) => ({
+      ok: true,
+      json: async () => [
+        {
+          crawl: { httpStatusCode: 200, requestStatus: "handled" },
+          searchResult: {
+            title: "Example",
+            description: "Example description",
+            url: "https://example.com",
+          },
+          metadata: { title: "", url: "https://example.com" },
+          markdown: "Some content",
+        },
+      ],
+    }));
+    global.fetch = mockFetch as unknown as typeof global.fetch;
+
+    const provider = createApifyWebSearchProvider();
+    const tool = provider.createTool({
+      config: {},
+      searchConfig: { apiKey: "apify_test_key" },
+    });
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+
+    const result = (await tool.execute({ query: "openclaw" })) as Record<string, unknown>;
+
+    expect(result.provider).toBe("apify");
+    expect(result.query).toBe("openclaw");
+    expect(Array.isArray(result.results)).toBe(true);
+
+    const requestUrl = String(mockFetch.mock.calls[0]?.[0]);
+    expect(requestUrl).toContain("apify~rag-web-browser");
+
+    const init = mockFetch.mock.calls[0]?.[1] as RequestInit;
+    const body = JSON.parse(init?.body as string) as Record<string, unknown>;
+    expect(body.query).toBe("openclaw");
+  });
+});

--- a/extensions/apify/src/apify-search-provider.ts
+++ b/extensions/apify/src/apify-search-provider.ts
@@ -1,0 +1,92 @@
+import type {
+  SearchConfigRecord,
+  WebSearchProviderPlugin,
+} from "openclaw/plugin-sdk/provider-web-search";
+import {
+  mergeScopedSearchConfig,
+  resolveProviderWebSearchPluginConfig,
+} from "openclaw/plugin-sdk/provider-web-search";
+import { createWebSearchProviderContractFields } from "openclaw/plugin-sdk/provider-web-search-config-contract";
+import { APIFY_FETCH_PROVIDER_SHARED } from "./apify-fetch-provider-shared.js";
+import {
+  APIFY_CREDENTIAL_LABEL,
+  APIFY_CREDENTIAL_PATH,
+  APIFY_ENV_VARS,
+  APIFY_PLACEHOLDER,
+  APIFY_PLUGIN_ID,
+  APIFY_SEARCH_AUTO_DETECT_ORDER,
+  APIFY_SEARCH_DOCS_URL,
+  APIFY_SEARCH_HINT,
+  APIFY_SEARCH_LABEL,
+  APIFY_SIGNUP_URL,
+  resolveApifyPluginApiKey,
+} from "./apify-shared.js";
+
+type ApifySearchRuntime = typeof import("./apify-search-runtime.js");
+
+let apifySearchRuntimePromise: Promise<ApifySearchRuntime> | undefined;
+
+function loadApifySearchRuntime(): Promise<ApifySearchRuntime> {
+  apifySearchRuntimePromise ??= import("./apify-search-runtime.js");
+  return apifySearchRuntimePromise;
+}
+
+const ApifySearchSchema = {
+  type: "object",
+  properties: {
+    query: { type: "string", description: "Search query string." },
+    count: {
+      type: "number",
+      description: "Number of results (1-10). Default: 5.",
+      minimum: 1,
+      maximum: 10,
+    },
+  },
+  required: ["query"],
+  additionalProperties: false,
+} satisfies Record<string, unknown>;
+
+export function createApifyWebSearchProvider(): WebSearchProviderPlugin {
+  return {
+    id: APIFY_PLUGIN_ID,
+    label: APIFY_SEARCH_LABEL,
+    hint: APIFY_SEARCH_HINT,
+    onboardingScopes: ["text-inference"],
+    requiresCredential: true,
+    credentialLabel: APIFY_CREDENTIAL_LABEL,
+    envVars: APIFY_ENV_VARS,
+    placeholder: APIFY_PLACEHOLDER,
+    signupUrl: APIFY_SIGNUP_URL,
+    docsUrl: APIFY_SEARCH_DOCS_URL,
+    autoDetectOrder: APIFY_SEARCH_AUTO_DETECT_ORDER,
+    credentialPath: APIFY_CREDENTIAL_PATH,
+    ...createWebSearchProviderContractFields({
+      credentialPath: APIFY_CREDENTIAL_PATH,
+      searchCredential: { type: "top-level" },
+    }),
+    getConfiguredCredentialValue: APIFY_FETCH_PROVIDER_SHARED.getConfiguredCredentialValue,
+    setConfiguredCredentialValue: APIFY_FETCH_PROVIDER_SHARED.setConfiguredCredentialValue,
+    createTool: (ctx) => {
+      const pluginWebSearchConfig = resolveProviderWebSearchPluginConfig(
+        ctx.config,
+        APIFY_PLUGIN_ID,
+      );
+      const sharedApiKey = resolveApifyPluginApiKey(ctx.config);
+      const searchConfig: SearchConfigRecord | undefined = mergeScopedSearchConfig(
+        ctx.searchConfig,
+        "apify",
+        { ...pluginWebSearchConfig, apiKey: sharedApiKey },
+        { mirrorApiKeyToTopLevel: true },
+      );
+      return {
+        description:
+          "Search the web using Apify RAG Web Browser. Returns headless-rendered pages with full markdown content — better for JS-heavy sites than pure link-list search.",
+        parameters: ApifySearchSchema,
+        execute: async (args) => {
+          const { executeApifySearch } = await loadApifySearchRuntime();
+          return executeApifySearch(args, searchConfig);
+        },
+      };
+    },
+  };
+}

--- a/extensions/apify/src/apify-search-runtime.ts
+++ b/extensions/apify/src/apify-search-runtime.ts
@@ -1,0 +1,125 @@
+import type { SearchConfigRecord } from "openclaw/plugin-sdk/provider-web-search";
+import {
+  buildSearchCacheKey,
+  postTrustedWebToolsJson,
+  readCachedSearchPayload,
+  readConfiguredSecretString,
+  readNumberParam,
+  readProviderEnvValue,
+  readStringParam,
+  resolveSearchCacheTtlMs,
+  resolveSearchCount,
+  resolveSearchTimeoutSeconds,
+  resolveSiteName,
+  wrapWebContent,
+  writeCachedSearchPayload,
+} from "openclaw/plugin-sdk/provider-web-search";
+import {
+  APIFY_CREDENTIAL_PATH,
+  APIFY_INTEGRATION_HEADERS,
+  APIFY_PLUGIN_ID,
+} from "./apify-shared.js";
+
+const APIFY_ACTOR_ENDPOINT =
+  "https://api.apify.com/v2/acts/apify~rag-web-browser/run-sync-get-dataset-items";
+
+const DEFAULT_APIFY_COUNT = 5;
+
+type ApifyResultItem = {
+  searchResult?: { title?: string; description?: string; url?: string };
+  metadata?: { title?: string; url?: string };
+  markdown?: string;
+};
+
+function resolveApifyApiKey(searchConfig?: SearchConfigRecord): string | undefined {
+  return (
+    readConfiguredSecretString(searchConfig?.apiKey, APIFY_CREDENTIAL_PATH) ??
+    readProviderEnvValue(["APIFY_API_KEY"])
+  );
+}
+
+function missingApifyKeyPayload() {
+  return {
+    error: "missing_apify_api_key",
+    message:
+      "web_search (apify) needs an Apify API token. Set APIFY_API_KEY in the environment, or configure plugins.entries.apify.config.apiKey.",
+    docs: "https://apify.com/apify/rag-web-browser",
+  };
+}
+
+export async function executeApifySearch(
+  args: Record<string, unknown>,
+  searchConfig: SearchConfigRecord | undefined,
+): Promise<Record<string, unknown>> {
+  const query = readStringParam(args, "query", { required: true });
+  const apiKey = resolveApifyApiKey(searchConfig);
+  if (!apiKey) {
+    return missingApifyKeyPayload();
+  }
+
+  const countArg = readNumberParam(args, "count", { integer: true });
+  const count = resolveSearchCount(countArg, searchConfig?.maxResults ?? DEFAULT_APIFY_COUNT);
+  const timeoutSeconds = resolveSearchTimeoutSeconds(searchConfig);
+  const cacheTtlMs = resolveSearchCacheTtlMs(searchConfig);
+
+  const cacheKey = buildSearchCacheKey(["apify-rag-search", query, count, timeoutSeconds]);
+  const cached = readCachedSearchPayload(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  const start = Date.now();
+
+  const items = await postTrustedWebToolsJson<ApifyResultItem[]>(
+    {
+      url: APIFY_ACTOR_ENDPOINT,
+      timeoutSeconds,
+      apiKey,
+      body: {
+        query,
+        maxResults: count,
+        outputFormats: ["markdown"],
+        requestTimeoutSecs: timeoutSeconds,
+      },
+      errorLabel: "Apify RAG Web Browser",
+      extraHeaders: APIFY_INTEGRATION_HEADERS,
+    },
+    async (response) => {
+      const data = (await response.json()) as ApifyResultItem[];
+      return Array.isArray(data) ? data : [];
+    },
+  );
+
+  const results = items.map((item) => {
+    const url = item.searchResult?.url ?? item.metadata?.url ?? "";
+    const title = item.searchResult?.title ?? item.metadata?.title ?? "";
+    const description = item.searchResult?.description ?? item.markdown?.slice(0, 500) ?? "";
+    return {
+      title: title ? wrapWebContent(title, "web_search") : "",
+      url,
+      description: description ? wrapWebContent(description, "web_search") : "",
+      siteName: resolveSiteName(url) || undefined,
+    };
+  });
+
+  const payload = {
+    query,
+    provider: APIFY_PLUGIN_ID,
+    count: results.length,
+    tookMs: Date.now() - start,
+    externalContent: {
+      untrusted: true,
+      source: "web_search",
+      provider: APIFY_PLUGIN_ID,
+      wrapped: true,
+    },
+    results,
+  };
+
+  writeCachedSearchPayload(cacheKey, payload, cacheTtlMs);
+  return payload;
+}
+
+export const __testing = {
+  resolveApifyApiKey,
+};

--- a/extensions/apify/src/apify-shared.ts
+++ b/extensions/apify/src/apify-shared.ts
@@ -1,0 +1,46 @@
+export const APIFY_PLUGIN_ID = "apify";
+export const APIFY_ENV_VARS: string[] = ["APIFY_API_KEY"];
+export const APIFY_CREDENTIAL_PATH = "plugins.entries.apify.config.apiKey";
+export const APIFY_CREDENTIAL_LABEL = "Apify API token";
+export const APIFY_PLACEHOLDER = "apify_...";
+export const APIFY_SIGNUP_URL = "https://apify.com/";
+
+export const APIFY_INTEGRATION_HEADERS = {
+  "x-apify-integration-platform": "openclaw",
+  "x-apify-integration-ai-tool": "true",
+} as const;
+
+export const APIFY_SEARCH_LABEL = "Apify RAG Web Browser";
+export const APIFY_SEARCH_HINT =
+  "Headless-rendered search results with full page content extraction.";
+export const APIFY_SEARCH_DOCS_URL = "https://apify.com/apify/rag-web-browser";
+export const APIFY_SEARCH_AUTO_DETECT_ORDER = 60;
+
+export function resolveApifyPluginApiKey(config: unknown): unknown {
+  return (
+    config as {
+      plugins?: { entries?: { apify?: { config?: { apiKey?: unknown } } } };
+    }
+  )?.plugins?.entries?.apify?.config?.apiKey;
+}
+
+export function ensureRecord(
+  target: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> {
+  const current = target[key];
+  if (current && typeof current === "object" && !Array.isArray(current)) {
+    return current as Record<string, unknown>;
+  }
+  const next: Record<string, unknown> = {};
+  target[key] = next;
+  return next;
+}
+
+export function setApifyPluginApiKey(configTarget: unknown, value: unknown): void {
+  const plugins = ensureRecord(configTarget as Record<string, unknown>, "plugins");
+  const entries = ensureRecord(plugins, "entries");
+  const apifyEntry = ensureRecord(entries, "apify");
+  const pluginConfig = ensureRecord(apifyEntry, "config");
+  pluginConfig.apiKey = value;
+}

--- a/extensions/apify/test-api.ts
+++ b/extensions/apify/test-api.ts
@@ -1,0 +1,1 @@
+export { __testing } from "./src/apify-search-runtime.js";

--- a/extensions/apify/tsconfig.json
+++ b/extensions/apify/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../tsconfig.package-boundary.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["./*.ts", "./src/**/*.ts"],
+  "exclude": [
+    "./**/*.test.ts",
+    "./dist/**",
+    "./node_modules/**",
+    "./src/test-support/**",
+    "./src/**/*test-helpers.ts",
+    "./src/**/*test-harness.ts",
+    "./src/**/*test-support.ts"
+  ]
+}

--- a/extensions/apify/web-fetch-contract-api.ts
+++ b/extensions/apify/web-fetch-contract-api.ts
@@ -1,0 +1,13 @@
+import {
+  enablePluginInConfig,
+  type WebFetchProviderPlugin,
+} from "openclaw/plugin-sdk/provider-web-fetch-contract";
+import { APIFY_FETCH_PROVIDER_SHARED } from "./src/apify-fetch-provider-shared.js";
+
+export function createApifyWebFetchProvider(): WebFetchProviderPlugin {
+  return {
+    ...APIFY_FETCH_PROVIDER_SHARED,
+    applySelectionConfig: (config) => enablePluginInConfig(config, "apify").config,
+    createTool: () => null,
+  };
+}

--- a/extensions/apify/web-fetch-provider.ts
+++ b/extensions/apify/web-fetch-provider.ts
@@ -1,0 +1,1 @@
+export { createApifyWebFetchProvider } from "./src/apify-fetch-provider.js";

--- a/extensions/apify/web-search-contract-api.ts
+++ b/extensions/apify/web-search-contract-api.ts
@@ -1,0 +1,42 @@
+import {
+  createWebSearchProviderContractFields,
+  type WebSearchProviderPlugin,
+} from "openclaw/plugin-sdk/provider-web-search-contract";
+import {
+  APIFY_CREDENTIAL_PATH,
+  APIFY_ENV_VARS,
+  APIFY_PLACEHOLDER,
+  APIFY_PLUGIN_ID,
+  APIFY_SEARCH_AUTO_DETECT_ORDER,
+  APIFY_SEARCH_DOCS_URL,
+  APIFY_SEARCH_HINT,
+  APIFY_SEARCH_LABEL,
+  APIFY_SIGNUP_URL,
+  resolveApifyPluginApiKey,
+  setApifyPluginApiKey,
+} from "./src/apify-shared.js";
+
+export function createApifyWebSearchProvider(): WebSearchProviderPlugin {
+  return {
+    id: APIFY_PLUGIN_ID,
+    label: APIFY_SEARCH_LABEL,
+    hint: APIFY_SEARCH_HINT,
+    onboardingScopes: ["text-inference"],
+    requiresCredential: true,
+    envVars: APIFY_ENV_VARS,
+    placeholder: APIFY_PLACEHOLDER,
+    signupUrl: APIFY_SIGNUP_URL,
+    docsUrl: APIFY_SEARCH_DOCS_URL,
+    autoDetectOrder: APIFY_SEARCH_AUTO_DETECT_ORDER,
+    credentialPath: APIFY_CREDENTIAL_PATH,
+    ...createWebSearchProviderContractFields({
+      credentialPath: APIFY_CREDENTIAL_PATH,
+      searchCredential: { type: "top-level" },
+      selectionPluginId: APIFY_PLUGIN_ID,
+    }),
+    getConfiguredCredentialValue: (config: unknown) => resolveApifyPluginApiKey(config),
+    setConfiguredCredentialValue: (configTarget: unknown, value: unknown) =>
+      setApifyPluginApiKey(configTarget, value),
+    createTool: () => null,
+  };
+}

--- a/extensions/apify/web-search-provider.ts
+++ b/extensions/apify/web-search-provider.ts
@@ -1,0 +1,1 @@
+export { createApifyWebSearchProvider } from "./src/apify-search-provider.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -364,6 +364,16 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/apify:
+    dependencies:
+      typebox:
+        specifier: 1.1.33
+        version: 1.1.33
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+
   extensions/arcee:
     devDependencies:
       '@openclaw/plugin-sdk':


### PR DESCRIPTION
## Summary

- Problem: OpenClaw's built-in `web_fetch` (Readability) cannot reach JS-rendered SPAs or bot-protected pages (Cloudflare, PerimeterX, DataDome). The built-in `web_search` returns only link lists with no page content, making agent research shallow on modern sites.
- Solution: Add `extensions/apify/` as a new bundled plugin implementing two provider contracts — `web_search` (RAG Web Browser actor, returns full markdown page content) and `web_fetch` (Website Content Crawler actor). Both providers share a single API key (`plugins.entries.apify.config.apiKey` or `APIFY_API_KEY` env var).
- What changed: New `extensions/apify/` bundled plugin with `web_search` and `web_fetch` provider support. Supports crawler types `cheerio` / `playwright:firefox` / `playwright:adaptive` (default). Can coexist alongside the separately released [`apify-openclaw-plugin`](https://github.com/apify/apify-openclaw-plugin) (different plugin ID; separate config entry).
- What did NOT change (scope boundary): Existing providers (`firecrawl`, `tavily`, built-in Readability) are untouched. Web fetch falls back to local Readability by default — Apify is only invoked when `tools.web.fetch.readability: false` or when Readability fails. No core behavior changes; new surface is purely additive via the plugin manifest.

## Motivation

Agents doing research or summarization on modern sites get titles and snippets instead of full page text, and are blocked entirely on bot-protected pages. Readability covers basic HTML pages but cannot handle JS-rendered content or bot challenges. Apify's cloud actors (RAG Web Browser and Website Content Crawler) solve both problems without requiring users to install a separate third-party plugin.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes N/A
- Related N/A
- [ ] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed:** Apify `web_search` and `web_fetch` providers are selectable and functional via `openclaw configure --section web`.
- **Real environment tested:** macOS, Node 22, local Gateway
- **Exact steps or command run after this patch:**
  ```bash
  pnpm build
  openclaw configure --section web   # select Apify, paste API token
  # or manually:
  openclaw config set tools.web.search.provider apify
  openclaw config set plugins.entries.apify.config.apiKey YOUR_TOKEN
  openclaw config set tools.web.fetch.provider apify

  openclaw gateway restart
  ```
- **Evidence after fix:** See screenshots below.
- **Observed result after fix:** Agent returns full markdown page content from RAG Web Browser; Website Content Crawler reaches bot-protected pages (e.g. Booking.com).
- **What was not tested:** Playwright crawler types under load; Windows runtime.
- **Before evidence (optional):** _(not applicable — new provider)_

## Root Cause (if applicable)

N/A — new feature, not a bug fix.

- Root cause: N/A
- Missing detection / guardrail: N/A
- Contributing context: N/A

## Regression Test Plan (if applicable)

N/A — no regression; new additive surface.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: `extensions/apify/src/apify-search-provider.test.ts`, `extensions/apify/src/apify-fetch-provider.test.ts`
- Scenario the test should lock in: Provider contract compliance — credential resolution, manifest metadata, and provider registration.
- Why this is the smallest reliable guardrail: The providers conform to existing `web_search` and `web_fetch` SDK contracts; the contract test helpers validate the surface boundary. Live actor calls require a real API key and are covered by manual verification above.
- Existing test that already covers this: `src/plugins/web-search-providers.runtime.test.ts`, `src/plugins/web-fetch-providers.runtime.test.ts`
- If no new test is added, why not: Tests are added in `extensions/apify/src/`.

## User-visible / Behavior Changes

- Apify appears as a selectable option in `openclaw configure --section web` alongside existing providers.
- Control UI → Config → Automation → Plugins → Apify shows: API key field, Fetch Crawler Type, Fetch Timeout, Search Max Results, and Search Timeout.
- Web fetch falls back to local Readability by default; Apify is invoked only when `tools.web.fetch.readability: false` or when Readability fails (no behavior change for existing setups).
- Configuring web search automatically unlocks web fetch — no separate credential step.

## Diagram (if applicable)

```text
web_search tool call
  -> provider: apify
  -> RAG Web Browser actor (Apify cloud)
  -> returns full markdown page content (not just link list)

web_fetch tool call
  -> readability: true (default)  -> local Readability first
       |__ success                -> extractor: "readability"
       |__ failure                -> Apify fallback (Website Content Crawler)
  -> readability: false           -> Apify directly (Website Content Crawler)
       -> crawler: playwright:adaptive (default) | playwright:firefox | cheerio
```

## Security Impact (required)

- New permissions/capabilities? `Yes` — plugin can make outbound HTTP calls to `api.apify.com` on behalf of the agent.
- Secrets/tokens handling changed? `Yes` — API key stored at `plugins.entries.apify.config.apiKey`; env fallback `APIFY_API_KEY`. Resolved via `resolveApifyPluginApiKey()` in `apify-shared.ts`, consistent with other provider credential patterns.
- New/changed network calls? `Yes` — two new outbound HTTPS calls to Apify cloud actors (`rag-web-browser`, `website-content-crawler`).
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: Outbound calls go only to `api.apify.com` (Apify's official API). The API key is never logged or returned to the agent in tool output. Calls are gated behind provider selection — no network activity unless the user explicitly configures Apify as their provider. Consistent with how other web provider plugins (Firecrawl, Tavily) handle credentials.

## Repro + Verification

### Environment

- OS: macOS 15
- Runtime/container: Node 22, local Gateway
- Model/provider: Any
- Integration/channel: CLI / Control UI
- Relevant config (redacted):
  ```yaml
  tools.web.search.provider: apify
  tools.web.fetch.provider: apify
  plugins.entries.apify.config.apiKey: "***"
  ```

### Steps

1. `pnpm build && openclaw gateway restart`
2. `openclaw config set tools.web.search.provider apify`
3. `openclaw config set plugins.entries.apify.config.apiKey YOUR_TOKEN`
4. Ask agent: _"Search for the latest Apify SDK changelog and summarize what changed in the last release."_
5. `openclaw config set tools.web.fetch.provider apify`
6. Ask agent to fetch a bot-protected site like _"web fetch me https://www.booking.com/hotel/us/millennium-broadway.html and summarize the listing"_

### Expected

- Step 4: Agent returns a summary drawn from full page markdown content, not just link titles.
- Step 6: Agent successfully retrieves bot-protected page content (unreachable by plain HTTP).

### Actual

Screenshot of the first prompt, with the Actor run in Apify console:
<img width="1180" height="589" alt="Screenshot 2026-05-20 at 13 11 39" src="https://github.com/user-attachments/assets/f0a63ca4-2357-442d-b659-66c685fa50f2" />
<img width="1228" height="500" alt="Screenshot 2026-05-20 at 13 12 47" src="https://github.com/user-attachments/assets/eac73019-0fb8-43db-bbd7-d6db95693892" />

Screenshot of the second prompt, with the Actor run in Apify console:
<img width="1142" height="535" alt="Screenshot 2026-05-20 at 15 54 01" src="https://github.com/user-attachments/assets/ada7bf5e-c96e-4d23-8b3f-8a0eed34f64a" />
<img width="1224" height="418" alt="Screenshot 2026-05-20 at 15 54 15" src="https://github.com/user-attachments/assets/2bd92a14-80bf-4b34-835d-301d850584d2" />

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- **Verified scenarios:** Provider registration (Apify appears in `openclaw configure --section web`); `web_search` returns markdown page content via RAG Web Browser; `web_fetch` reaches protected sites (e.g. Booking.com) via Website Content Crawler; API key shared between both providers; fallback to Readability when `readability: true` (default); `extractor` field in `web_fetch` response correctly reflects which path ran.
- **Edge cases checked:** Missing API key (provider gracefully absent from selection); `readability: false` forces Apify for all fetches; `playwright:adaptive` default crawler type.
- **What you did not verify:** Windows runtime.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `Yes` — new optional keys: `plugins.entries.apify.config.apiKey`, `tools.web.fetch.readability`, `tools.web.search.provider`, `tools.web.fetch.provider`. All optional; existing configs unaffected.
- Migration needed? `No`
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Apify cloud outage or actor deprecation breaks `web_search`/`web_fetch` for users who selected Apify.
  - Mitigation: Provider is opt-in; users can switch back to built-in Readability or another provider via `openclaw configure --section web`. No silent fallback that could mask errors.
- Risk: API key accidentally logged.
  - Mitigation: `resolveApifyPluginApiKey()` is the single credential access point; key is never interpolated into tool output or log messages.
