### PR TITLE
feat(memory-core): consume generic embedding providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 - Plugin SDK: add row-level session workflow helpers and deprecate `loadSessionStore` so plugins can read and patch sessions without depending on the legacy whole-store shape. (#84693) Thanks @efpiva.
 - Gateway/plugins: reuse a compatible Gateway startup plugin registry during dispatch so safe plugin dispatches avoid redundant registry loading. (#84324) Thanks @ai-hpc.
 - Plugins/SDK: add a general `embeddingProviders` capability contract and registration API so embeddings can become a reusable provider surface outside memory-specific adapters.
+- Memory-core: allow explicit memory embedding configs to use generic plugin embedding providers while preserving memory-specific adapters and auto-selection behavior.
 - Dependencies: refresh provider, plugin, UI, and tooling packages, update `protobufjs` to 8.4.0 to clear the current npm advisory, and carry the Claude ACP completion patch forward to `@agentclientprotocol/claude-agent-acp` 0.36.1.
 - Agents/tools: remove the old sender-owner tool gating path so configured tools stay visible for trusted sessions while command and channel-action auth still carry real sender identity.
 - QA-Lab: add curated mock JSONL replay fixtures and first-drift reporting for runtime-parity audits. (#80323, refs #80176) Thanks @100yenadmin.

--- a/docs/plugins/adding-capabilities.md
+++ b/docs/plugins/adding-capabilities.md
@@ -121,11 +121,10 @@ is intentionally broader than memory: tools, search, retrieval, importers, or
 future feature plugins can consume embeddings without depending on the memory
 engine.
 
-For memory-engine-specific adapters, keep using `memoryEmbeddingProviders`.
-Those adapters own memory indexing details such as query/document split,
-runtime metadata, and local memory engine setup. Do not make a generic
-embedding provider depend on memory-owned modules unless the provider is only
-usable by memory.
+Memory search can consume generic `embeddingProviders`. The older
+`memoryEmbeddingProviders` contract remains for compatibility while existing
+memory-specific providers migrate, but new reusable embedding providers should
+use `embeddingProviders`.
 
 ## Review checklist
 

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -638,24 +638,24 @@ read without importing the plugin runtime.
 
 Each list is optional:
 
-| Field                            | Type       | What it means                                                                                       |
-| -------------------------------- | ---------- | --------------------------------------------------------------------------------------------------- |
-| `embeddedExtensionFactories`     | `string[]` | Codex app-server extension factory ids, currently `codex-app-server`.                               |
-| `agentToolResultMiddleware`      | `string[]` | Runtime ids a bundled plugin may register tool-result middleware for.                               |
-| `externalAuthProviders`          | `string[]` | Provider ids whose external auth profile hook this plugin owns.                                     |
-| `embeddingProviders`             | `string[]` | General embedding provider ids this plugin owns for reusable vector embedding use outside memory.   |
-| `speechProviders`                | `string[]` | Speech provider ids this plugin owns.                                                               |
-| `realtimeTranscriptionProviders` | `string[]` | Realtime-transcription provider ids this plugin owns.                                               |
-| `realtimeVoiceProviders`         | `string[]` | Realtime-voice provider ids this plugin owns.                                                       |
-| `memoryEmbeddingProviders`       | `string[]` | Memory embedding provider ids this plugin owns.                                                     |
-| `mediaUnderstandingProviders`    | `string[]` | Media-understanding provider ids this plugin owns.                                                  |
-| `imageGenerationProviders`       | `string[]` | Image-generation provider ids this plugin owns.                                                     |
-| `videoGenerationProviders`       | `string[]` | Video-generation provider ids this plugin owns.                                                     |
-| `webFetchProviders`              | `string[]` | Web-fetch provider ids this plugin owns.                                                            |
-| `webSearchProviders`             | `string[]` | Web-search provider ids this plugin owns.                                                           |
-| `migrationProviders`             | `string[]` | Import provider ids this plugin owns for `openclaw migrate`.                                        |
-| `gatewayMethodDispatch`          | `string[]` | Reserved entitlement for authenticated plugin HTTP routes that dispatch Gateway methods in-process. |
-| `tools`                          | `string[]` | Agent tool names this plugin owns.                                                                  |
+| Field                            | Type       | What it means                                                                                        |
+| -------------------------------- | ---------- | ---------------------------------------------------------------------------------------------------- |
+| `embeddedExtensionFactories`     | `string[]` | Codex app-server extension factory ids, currently `codex-app-server`.                                |
+| `agentToolResultMiddleware`      | `string[]` | Runtime ids a bundled plugin may register tool-result middleware for.                                |
+| `externalAuthProviders`          | `string[]` | Provider ids whose external auth profile hook this plugin owns.                                      |
+| `embeddingProviders`             | `string[]` | General embedding provider ids this plugin owns for reusable vector embedding use, including memory. |
+| `speechProviders`                | `string[]` | Speech provider ids this plugin owns.                                                                |
+| `realtimeTranscriptionProviders` | `string[]` | Realtime-transcription provider ids this plugin owns.                                                |
+| `realtimeVoiceProviders`         | `string[]` | Realtime-voice provider ids this plugin owns.                                                        |
+| `memoryEmbeddingProviders`       | `string[]` | Legacy memory embedding provider ids this plugin owns.                                               |
+| `mediaUnderstandingProviders`    | `string[]` | Media-understanding provider ids this plugin owns.                                                   |
+| `imageGenerationProviders`       | `string[]` | Image-generation provider ids this plugin owns.                                                      |
+| `videoGenerationProviders`       | `string[]` | Video-generation provider ids this plugin owns.                                                      |
+| `webFetchProviders`              | `string[]` | Web-fetch provider ids this plugin owns.                                                             |
+| `webSearchProviders`             | `string[]` | Web-search provider ids this plugin owns.                                                            |
+| `migrationProviders`             | `string[]` | Import provider ids this plugin owns for `openclaw migrate`.                                         |
+| `gatewayMethodDispatch`          | `string[]` | Reserved entitlement for authenticated plugin HTTP routes that dispatch Gateway methods in-process.  |
+| `tools`                          | `string[]` | Agent tool names this plugin owns.                                                                   |
 
 `contracts.embeddedExtensionFactories` is retained for bundled Codex
 app-server-only extension factories. Bundled tool-result transforms should
@@ -673,17 +673,12 @@ Provider plugins that implement `resolveExternalAuthProfiles` should declare
 through a deprecated compatibility fallback, but that fallback is slower and
 will be removed after the migration window.
 
-Bundled memory embedding providers should declare
-`contracts.memoryEmbeddingProviders` for every adapter id they expose, including
-built-in adapters such as `local`. Standalone CLI paths use this manifest
-contract to load only the owning plugin before the full Gateway runtime has
-registered providers.
-
 General embedding providers should declare `contracts.embeddingProviders` for
 each adapter registered with `api.registerEmbeddingProvider(...)`. Use the
-general contract when vectors are meant to be consumed by multiple features,
-tools, or plugins. Keep `contracts.memoryEmbeddingProviders` for adapters whose
-shape and lifecycle are specific to OpenClaw memory indexing.
+general contract for reusable vector generation, including providers consumed by
+memory search. `contracts.memoryEmbeddingProviders` is the older
+memory-specific compatibility contract and remains while existing providers
+migrate to the generic embedding provider seam.
 
 `contracts.gatewayMethodDispatch` currently accepts
 `"authenticated-request"`. It is an API hygiene gate for native plugin HTTP

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -108,9 +108,11 @@ methods:
 
 Embedding providers registered with `api.registerEmbeddingProvider(...)` must
 also be listed in `contracts.embeddingProviders` in the plugin manifest. This
-is the generic embedding surface for reusable vector generation. Memory-only
-adapters still use `api.registerMemoryEmbeddingProvider(...)` and
-`contracts.memoryEmbeddingProviders`.
+is the generic embedding surface for reusable vector generation. Memory search
+can consume this generic provider surface. The older
+`api.registerMemoryEmbeddingProvider(...)` and
+`contracts.memoryEmbeddingProviders` seam remains as compatibility while
+existing memory-specific providers migrate.
 
 ### Tools and commands
 

--- a/extensions/memory-core/src/memory/embeddings.test.ts
+++ b/extensions/memory-core/src/memory/embeddings.test.ts
@@ -1,10 +1,21 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type { EmbeddingProviderAdapter } from "openclaw/plugin-sdk/embedding-providers";
 import type { MemoryEmbeddingProviderAdapter } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createEmbeddingProvider } from "./embeddings.js";
+import { createEmbeddingProvider, resolveEmbeddingProviderFallbackModel } from "./embeddings.js";
 
 const mockEmbeddingRegistry = vi.hoisted(() => ({
+  genericAdapters: [] as EmbeddingProviderAdapter[],
   adapters: [] as MemoryEmbeddingProviderAdapter[],
+  genericLookupConfigs: [] as Array<OpenClawConfig | undefined>,
+}));
+
+vi.mock("openclaw/plugin-sdk/embedding-providers", () => ({
+  getEmbeddingProvider: (id: string, config?: OpenClawConfig) => {
+    mockEmbeddingRegistry.genericLookupConfigs.push(config);
+    return mockEmbeddingRegistry.genericAdapters.find((adapter) => adapter.id === id);
+  },
+  listEmbeddingProviders: () => [...mockEmbeddingRegistry.genericAdapters],
 }));
 
 vi.mock("openclaw/plugin-sdk/memory-core-host-engine-embeddings", () => ({
@@ -66,7 +77,16 @@ function createMissingCredentialsAdapter(
 }
 
 function clearMemoryEmbeddingProviders(): void {
+  mockEmbeddingRegistry.genericAdapters = [];
   mockEmbeddingRegistry.adapters = [];
+  mockEmbeddingRegistry.genericLookupConfigs = [];
+}
+
+function registerGenericEmbeddingProvider(adapter: EmbeddingProviderAdapter): void {
+  mockEmbeddingRegistry.genericAdapters = mockEmbeddingRegistry.genericAdapters.filter(
+    (candidate) => candidate.id !== adapter.id,
+  );
+  mockEmbeddingRegistry.genericAdapters.push(adapter);
 }
 
 function registerMemoryEmbeddingProvider(adapter: MemoryEmbeddingProviderAdapter): void {
@@ -125,5 +145,111 @@ describe("createEmbeddingProvider", () => {
 
     expect(result.provider?.id).toBe("openai");
     expect(result.requestedProvider).toBe("auto");
+  });
+
+  it("uses a generic embedding provider when no memory-specific provider exists", async () => {
+    registerGenericEmbeddingProvider({
+      id: "openai-compatible",
+      create: async () => ({
+        provider: {
+          id: "generic",
+          model: "generic-model",
+          embed: async (_input, options) => (options?.inputType === "query" ? [1] : [2]),
+          embedBatch: async (inputs, options) =>
+            inputs.map(() => (options?.inputType === "document" ? [3] : [4])),
+        },
+      }),
+    });
+
+    const options = createOptions("openai-compatible");
+    const result = await createEmbeddingProvider(options);
+
+    expect(result.provider?.id).toBe("generic");
+    expect(mockEmbeddingRegistry.genericLookupConfigs).toEqual([options.config]);
+    await expect(result.provider?.embedQuery("hello")).resolves.toEqual([1]);
+    await expect(result.provider?.embedBatch(["doc"])).resolves.toEqual([[3]]);
+  });
+
+  it("keeps memory-specific providers authoritative during dual registration", async () => {
+    registerGenericEmbeddingProvider({
+      id: "openai-compatible",
+      create: async () => ({
+        provider: {
+          id: "generic",
+          model: "generic-model",
+          embed: async (_input, options) => (options?.inputType === "query" ? [1] : [2]),
+          embedBatch: async (inputs, options) =>
+            inputs.map(() => (options?.inputType === "document" ? [3] : [4])),
+        },
+      }),
+    });
+    registerMemoryEmbeddingProvider({
+      id: "openai-compatible",
+      create: async () => ({
+        provider: {
+          id: "legacy",
+          model: "legacy-model",
+          embedQuery: async () => [0],
+          embedBatch: async (texts) => texts.map(() => [0]),
+        },
+      }),
+    });
+
+    const result = await createEmbeddingProvider(createOptions("openai-compatible"));
+
+    expect(result.provider?.id).toBe("legacy");
+    await expect(result.provider?.embedQuery("hello")).resolves.toEqual([0]);
+  });
+
+  it("keeps auto-selection on legacy memory provider policy", async () => {
+    registerMemoryEmbeddingProvider({
+      id: "openai-compatible",
+      transport: "remote",
+      autoSelectPriority: 20,
+      create: async () => ({
+        provider: {
+          id: "legacy",
+          model: "legacy-model",
+          embedQuery: async () => [1],
+          embedBatch: async (texts) => texts.map(() => [1]),
+        },
+      }),
+    });
+    registerGenericEmbeddingProvider({
+      id: "openai-compatible",
+      create: async () => ({
+        provider: {
+          id: "generic",
+          model: "generic-model",
+          embed: async () => [2],
+          embedBatch: async (inputs) => inputs.map(() => [2]),
+        },
+      }),
+    });
+
+    const result = await createEmbeddingProvider(createOptions("auto"));
+
+    expect(result.provider?.id).toBe("legacy");
+    expect(result.requestedProvider).toBe("auto");
+  });
+
+  it("uses config-scoped lookup for generic fallback model resolution", () => {
+    registerGenericEmbeddingProvider({
+      id: "openai-compatible",
+      defaultModel: "generic-default",
+      create: async () => ({
+        provider: null,
+      }),
+    });
+    const options = createOptions("openai-compatible");
+
+    const model = resolveEmbeddingProviderFallbackModel(
+      "openai-compatible",
+      "source-model",
+      options.config,
+    );
+
+    expect(model).toBe("generic-default");
+    expect(mockEmbeddingRegistry.genericLookupConfigs).toEqual([options.config]);
   });
 });

--- a/extensions/memory-core/src/memory/embeddings.ts
+++ b/extensions/memory-core/src/memory/embeddings.ts
@@ -1,6 +1,12 @@
 import {
-  getMemoryEmbeddingProvider,
-  listMemoryEmbeddingProviders,
+  getEmbeddingProvider,
+  type EmbeddingProviderAdapter,
+  type EmbeddingProvider as GenericEmbeddingProvider,
+  type EmbeddingProviderRuntime as GenericEmbeddingProviderRuntime,
+} from "openclaw/plugin-sdk/embedding-providers";
+import {
+  getMemoryEmbeddingProvider as getLegacyMemoryEmbeddingProvider,
+  listMemoryEmbeddingProviders as listLegacyMemoryEmbeddingProviders,
   type MemoryEmbeddingProvider,
   type MemoryEmbeddingProviderAdapter,
   type MemoryEmbeddingProviderCreateOptions,
@@ -29,6 +35,76 @@ type CreateEmbeddingProviderOptions = MemoryEmbeddingProviderCreateOptions & {
   fallback: EmbeddingProviderFallback;
 };
 
+function adaptGenericEmbeddingProvider(
+  provider: GenericEmbeddingProvider,
+): MemoryEmbeddingProvider {
+  return {
+    id: provider.id,
+    model: provider.model,
+    ...(typeof provider.maxInputTokens === "number"
+      ? { maxInputTokens: provider.maxInputTokens }
+      : {}),
+    embedQuery: async (text, options) =>
+      await provider.embed(text, {
+        ...options,
+        inputType: "query",
+      }),
+    embedBatch: async (texts, options) =>
+      await provider.embedBatch(texts, {
+        ...options,
+        inputType: "document",
+      }),
+    embedBatchInputs: async (inputs, options) =>
+      await provider.embedBatch(inputs, {
+        ...options,
+        inputType: "document",
+      }),
+    ...(provider.close ? { close: provider.close } : {}),
+  };
+}
+
+function adaptGenericRuntime(
+  runtime: GenericEmbeddingProviderRuntime | undefined,
+): MemoryEmbeddingProviderRuntime | undefined {
+  if (!runtime) {
+    return undefined;
+  }
+  return {
+    id: runtime.id,
+    ...(runtime.cacheKeyData ? { cacheKeyData: runtime.cacheKeyData } : {}),
+    ...(typeof runtime.inlineQueryTimeoutMs === "number"
+      ? { inlineQueryTimeoutMs: runtime.inlineQueryTimeoutMs }
+      : {}),
+    ...(typeof runtime.inlineBatchTimeoutMs === "number"
+      ? { inlineBatchTimeoutMs: runtime.inlineBatchTimeoutMs }
+      : {}),
+  };
+}
+
+function adaptGenericEmbeddingAdapter(
+  adapter: EmbeddingProviderAdapter,
+): MemoryEmbeddingProviderAdapter {
+  return {
+    id: adapter.id,
+    ...(adapter.defaultModel ? { defaultModel: adapter.defaultModel } : {}),
+    ...(adapter.transport ? { transport: adapter.transport } : {}),
+    ...(adapter.authProviderId ? { authProviderId: adapter.authProviderId } : {}),
+    ...(adapter.formatSetupError ? { formatSetupError: adapter.formatSetupError } : {}),
+    create: async (options) => {
+      const result = await adapter.create({
+        ...options,
+        ...(typeof options.outputDimensionality === "number"
+          ? { dimensions: options.outputDimensionality }
+          : {}),
+      });
+      return {
+        provider: result.provider ? adaptGenericEmbeddingProvider(result.provider) : null,
+        runtime: adaptGenericRuntime(result.runtime),
+      };
+    },
+  };
+}
+
 function formatProviderError(adapter: MemoryEmbeddingProviderAdapter, err: unknown): string {
   return adapter.formatSetupError?.(err) ?? formatErrorMessage(err);
 }
@@ -44,17 +120,21 @@ function getAdapter(
   id: string,
   config?: MemoryEmbeddingProviderCreateOptions["config"],
 ): MemoryEmbeddingProviderAdapter {
-  const adapter = getMemoryEmbeddingProvider(id, config);
-  if (!adapter) {
-    throw new Error(`Unknown memory embedding provider: ${id}`);
+  const adapter = getLegacyMemoryEmbeddingProvider(id, config);
+  if (adapter) {
+    return adapter;
   }
-  return adapter;
+  const genericAdapter = getEmbeddingProvider(id, config);
+  if (genericAdapter) {
+    return adaptGenericEmbeddingAdapter(genericAdapter);
+  }
+  throw new Error(`Unknown memory embedding provider: ${id}`);
 }
 
 function listAutoSelectAdapters(
   options: CreateEmbeddingProviderOptions,
 ): MemoryEmbeddingProviderAdapter[] {
-  return listMemoryEmbeddingProviders(options.config)
+  return listLegacyMemoryEmbeddingProviders(options.config)
     .filter((adapter) => typeof adapter.autoSelectPriority === "number")
     .filter((adapter) =>
       adapter.id === "local" ? canAutoSelectLocal(options.local?.modelPath) : true,
@@ -82,7 +162,9 @@ export function resolveEmbeddingProviderFallbackModel(
   fallbackSourceModel: string,
   config?: MemoryEmbeddingProviderCreateOptions["config"],
 ): string {
-  const adapter = getMemoryEmbeddingProvider(providerId, config);
+  const adapter =
+    getLegacyMemoryEmbeddingProvider(providerId, config) ??
+    getEmbeddingProvider(providerId, config);
   return adapter?.defaultModel ?? fallbackSourceModel;
 }
 

--- a/extensions/memory-core/src/memory/generic-embedding-provider.bridge.test.ts
+++ b/extensions/memory-core/src/memory/generic-embedding-provider.bridge.test.ts
@@ -1,0 +1,187 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type {
+  EmbeddingInput,
+  EmbeddingProviderCallOptions,
+} from "openclaw/plugin-sdk/embedding-providers";
+import {
+  createPluginRegistryFixture,
+  registerVirtualTestPlugin,
+} from "openclaw/plugin-sdk/plugin-test-contracts";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  clearEmbeddingProviders,
+  getRegisteredEmbeddingProvider,
+  listRegisteredEmbeddingProviders,
+  type RegisteredEmbeddingProvider,
+  restoreRegisteredEmbeddingProviders,
+} from "../../../../src/plugins/embedding-providers.js";
+import {
+  clearMemoryEmbeddingProviders,
+  listRegisteredMemoryEmbeddingProviders,
+  type RegisteredMemoryEmbeddingProvider,
+  restoreRegisteredMemoryEmbeddingProviders,
+} from "../../../../src/plugins/memory-embedding-providers.js";
+import { createEmbeddingProvider } from "./embeddings.js";
+
+type CapturedCall = {
+  kind: "embed" | "embedBatch";
+  input: EmbeddingInput | EmbeddingInput[];
+  options: EmbeddingProviderCallOptions | undefined;
+};
+
+let embeddingProvidersSnapshot: RegisteredEmbeddingProvider[];
+let memoryEmbeddingProvidersSnapshot: RegisteredMemoryEmbeddingProvider[];
+
+function createOptions(config: OpenClawConfig) {
+  return {
+    config,
+    agentDir: "/tmp/openclaw-agent",
+    provider: "virtual-generic",
+    fallback: "none",
+    model: "virtual-model",
+    outputDimensionality: 7,
+  };
+}
+
+beforeEach(() => {
+  embeddingProvidersSnapshot = listRegisteredEmbeddingProviders();
+  memoryEmbeddingProvidersSnapshot = listRegisteredMemoryEmbeddingProviders();
+  clearEmbeddingProviders();
+  clearMemoryEmbeddingProviders();
+});
+
+afterEach(() => {
+  restoreRegisteredEmbeddingProviders(embeddingProvidersSnapshot);
+  restoreRegisteredMemoryEmbeddingProviders(memoryEmbeddingProvidersSnapshot);
+});
+
+describe("memory-core generic embedding provider bridge", () => {
+  it("adapts a contract-declared generic embedding plugin into explicit memory requests", async () => {
+    const calls: CapturedCall[] = [];
+    const { config, registry } = createPluginRegistryFixture({
+      plugins: {
+        enabled: false,
+      },
+    } as OpenClawConfig);
+
+    registerVirtualTestPlugin({
+      registry,
+      config,
+      id: "virtual-generic-plugin",
+      name: "Virtual Generic Embeddings",
+      contracts: {
+        embeddingProviders: ["virtual-generic"],
+      },
+      register(api) {
+        api.registerEmbeddingProvider({
+          id: "virtual-generic",
+          transport: "remote",
+          defaultModel: "virtual-default",
+          create: async (options) => {
+            expect(options.model).toBe("virtual-model");
+            expect(options.dimensions).toBe(7);
+            expect(options.config).toBe(config);
+            return {
+              provider: {
+                id: "virtual-generic",
+                model: options.model,
+                dimensions: options.dimensions,
+                maxInputTokens: 2048,
+                embed: async (input, callOptions) => {
+                  calls.push({ kind: "embed", input, options: callOptions });
+                  return callOptions?.inputType === "query" ? [1, 2, 3] : [0];
+                },
+                embedBatch: async (inputs, callOptions) => {
+                  calls.push({ kind: "embedBatch", input: inputs, options: callOptions });
+                  return inputs.map((_input, index) =>
+                    callOptions?.inputType === "document" ? [index, 7] : [0],
+                  );
+                },
+              },
+              runtime: {
+                id: "virtual-generic",
+                inlineQueryTimeoutMs: 1234,
+                inlineBatchTimeoutMs: 5678,
+                cacheKeyData: {
+                  provider: "virtual-generic",
+                  model: options.model,
+                  dimensions: options.dimensions,
+                },
+              },
+            };
+          },
+        });
+      },
+    });
+
+    expect(getRegisteredEmbeddingProvider("virtual-generic")?.ownerPluginId).toBe(
+      "virtual-generic-plugin",
+    );
+    expect(registry.registry.embeddingProviders.map((entry) => entry.provider.id)).toEqual([
+      "virtual-generic",
+    ]);
+    expect(listRegisteredMemoryEmbeddingProviders()).toEqual([]);
+
+    const result = await createEmbeddingProvider(createOptions(config));
+
+    expect(result.requestedProvider).toBe("virtual-generic");
+    expect(result.provider).toMatchObject({
+      id: "virtual-generic",
+      model: "virtual-model",
+      maxInputTokens: 2048,
+    });
+    expect(result.runtime).toEqual({
+      id: "virtual-generic",
+      inlineQueryTimeoutMs: 1234,
+      inlineBatchTimeoutMs: 5678,
+      cacheKeyData: {
+        provider: "virtual-generic",
+        model: "virtual-model",
+        dimensions: 7,
+      },
+    });
+
+    await expect(result.provider?.embedQuery("query")).resolves.toEqual([1, 2, 3]);
+    await expect(result.provider?.embedBatch(["doc-a", "doc-b"])).resolves.toEqual([
+      [0, 7],
+      [1, 7],
+    ]);
+    await expect(
+      result.provider?.embedBatchInputs?.([
+        {
+          text: "ignored",
+          parts: [
+            { type: "text", text: "doc-" },
+            { type: "text", text: "c" },
+          ],
+        },
+      ]),
+    ).resolves.toEqual([[0, 7]]);
+
+    expect(calls).toEqual([
+      {
+        kind: "embed",
+        input: "query",
+        options: { inputType: "query" },
+      },
+      {
+        kind: "embedBatch",
+        input: ["doc-a", "doc-b"],
+        options: { inputType: "document" },
+      },
+      {
+        kind: "embedBatch",
+        input: [
+          {
+            text: "ignored",
+            parts: [
+              { type: "text", text: "doc-" },
+              { type: "text", text: "c" },
+            ],
+          },
+        ],
+        options: { inputType: "document" },
+      },
+    ]);
+  });
+});

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -2859,7 +2859,12 @@ export type OpenClawPluginApi = {
    * @deprecated Use registerMemoryCapability({ runtime }) instead.
    */
   registerMemoryRuntime: (runtime: import("./memory-state.js").MemoryPluginRuntime) => void;
-  /** Register a memory embedding provider adapter. Multiple adapters may coexist. */
+  /**
+   * Register a memory embedding provider adapter. Multiple adapters may coexist.
+   * @deprecated New embedding providers should use `registerEmbeddingProvider`
+   * and `contracts.embeddingProviders`. This memory-specific seam is retained
+   * while existing memory providers migrate.
+   */
   registerMemoryEmbeddingProvider: (
     adapter: import("./memory-embedding-providers.js").MemoryEmbeddingProviderAdapter,
   ) => void;


### PR DESCRIPTION
## Summary

- Teach memory-core to resolve explicit embedding configs from the generic `embeddingProviders` contract added in #84947.
- Preserve the existing memory-specific adapter path and `auto` selection behavior, so generic providers are opt-in for memory until configured explicitly.
- Add non-mocked bridge proof using a virtual plugin that declares `contracts.embeddingProviders`, registers a generic provider through the real plugin API, and is consumed by memory-core through explicit config.

Stacked on #84947 via `mbelinky/84947-general-embedding-providers-base`.

## Verification

Behavior addressed: memory-core can consume a generic embedding provider by explicit provider id without changing memory auto-selection or overriding memory-specific providers.

Real environment tested: Blacksmith Testbox through Crabbox on Linux for both the focused test gate and a non-test temporary plugin/config proof. Provider: `blacksmith-testbox`. Proof ids: `tbx_01ks5qfqmvttp0prg28e7p01ng` (focused gate, Actions run https://github.com/openclaw/openclaw/actions/runs/26240537485) and `tbx_01ks5s24ra7bcez8891q9050b3` (non-test temp plugin proof, Actions run https://github.com/openclaw/openclaw/actions/runs/26241975310). No live third-party endpoint was called in this PR.

Exact steps or command run after this patch: ran the focused Testbox gate for `extensions/memory-core/src/memory/generic-embedding-provider.bridge.test.ts`, `extensions/memory-core/src/memory/embeddings.test.ts`, `src/plugins/contracts/embedding-provider.contract.test.ts`, and `src/plugins/embedding-provider-runtime.test.ts`, plus extension test typecheck, oxlint, oxfmt, and `git diff --check`. Then ran a non-test `node --import tsx` proof that created a temporary plugin directory containing `package.json`, `openclaw.plugin.json`, and `index.cjs`, configured `plugins.load.paths` to that plugin root, declared `contracts.embeddingProviders: ["proof-memory-generic"]`, registered `api.registerEmbeddingProvider(...)`, and called memory-core `createEmbeddingProvider(...)` with `provider: "proof-memory-generic"`.

Evidence after fix from the non-test proof:

```json
{
  "pluginRoot": "<temp>/proof-memory-generic",
  "manifestContracts": [
    "proof-memory-generic"
  ],
  "configuredLoadPaths": [
    "<temp>/proof-memory-generic"
  ],
  "globalGenericProvidersAfterColdLoad": [],
  "globalMemoryProvidersAfterColdLoad": [],
  "requestedProvider": "proof-memory-generic",
  "provider": {
    "id": "proof-memory-generic",
    "model": "proof-model",
    "maxInputTokens": 128
  },
  "runtime": {
    "id": "proof-memory-generic",
    "cacheKeyData": {
      "provider": "proof-memory-generic",
      "model": "proof-model",
      "dimensions": 2
    },
    "inlineQueryTimeoutMs": 111,
    "inlineBatchTimeoutMs": 222
  },
  "query": [
    10,
    1
  ],
  "batch": [
    [
      5,
      0
    ],
    [
      5,
      1
    ]
  ],
  "structured": [
    [
      5,
      0
    ]
  ]
}
```

Observed result after fix: a manifest-owned generic embedding provider from a temporary plugin/config path is resolved by memory-core for explicit provider requests, maps `outputDimensionality` to generic `dimensions`, preserves runtime metadata, routes query calls as query embeddings, routes document batch and structured inputs as document embeddings, and does not register or rely on memory-specific providers. The focused Testbox gate also passed 4 Vitest files / 15 tests covering the virtual-plugin bridge, memory-core adapter behavior, generic embedding provider contract tests, and runtime lookup tests.

What was not tested: no live third-party embedding endpoint was called here; that belongs to the follow-up OpenAI-compatible generic provider PR.
