### PR TITLE
fix(codex): recover final text after prompt timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Docs: https://docs.openclaw.ai
 - QA-Lab: keep explicitly searchable/deferred OpenClaw dynamic tool rows report-only by default so tool-coverage gates do not treat mock discovery gaps as hard product failures. (#80319) Thanks @100yenadmin.
 - Agents/config: keep non-Google provider model refs from being rewritten by Google Gemini preview-id normalization. (#84762) Thanks @zhangguiping-xydt.
 - Installer: require a real controlling terminal before launching onboarding so headless `curl | bash` installs finish cleanly after installing the CLI.
+- Agents/Codex: promote a completed final assistant response when a prompt timeout races Codex app-server completion instead of returning an empty timeout envelope. Refs #84516.
 - Agents: cap heartbeat model bleed context hints by the stored session window when runtime model metadata is unavailable, so overflow recovery advice does not suggest a larger window than the active session actually has.
 - Control UI/Web Push: use `https://openclaw.ai` as the generated default VAPID subject instead of the old localhost mailbox so iOS PWA push setup uses an Apple-acceptable subject when `OPENCLAW_VAPID_SUBJECT` is unset. Fixes #83134. (#83317) Thanks @IWhatsskill.
 - Agents/Pi: keep embedded session transcript writes from tripping false takeover detection after packaged npm onboarding agent turns.

--- a/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
+++ b/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
@@ -318,6 +318,46 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
     expect(result.meta.replayInvalid).toBe(false);
   });
 
+  it("promotes successful final assistant text when a prompt timeout races completion", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    const finalText =
+      "1. Verdict: the answer completed cleanly. 2. Evidence: the runner captured final text.";
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: [],
+        timedOut: true,
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "openai-codex",
+          model: "gpt-5.5",
+          content: [{ type: "text", text: finalText }],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    );
+
+    const result = await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      provider: "openai-codex",
+      model: "gpt-5.5",
+      runId: "run-prompt-timeout-final-assistant-recovered",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    expect(result.payloads).toEqual([{ text: finalText }]);
+    expect(result.meta.finalAssistantVisibleText).toBe(finalText);
+    expect(result.meta.finalAssistantRawText).toBe(finalText);
+    expect(result.meta.livenessState).toBe("working");
+    expect(result.meta.completion).toEqual({
+      stopReason: "stop",
+      finishReason: "stop",
+    });
+    expect(result.meta.executionTrace?.attempts?.at(-1)).toMatchObject({
+      result: "success",
+      stage: "assistant",
+    });
+  });
+
   it("auto-activates strict-agentic for unconfigured GPT-5 openai runs and surfaces the blocked state", async () => {
     // Criterion 1 of the GPT-5.4 parity gate ("no stalls after planning") must
     // cover out-of-the-box installs, not only users who opted in. An

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -2669,6 +2669,35 @@ export async function runEmbeddedPiAgent(
           });
           const timedOutDuringPrompt =
             timedOut && !timedOutDuringCompaction && !timedOutDuringToolExecution;
+          const finalAssistantStopReason = (sessionLastAssistant?.stopReason ?? "")
+            .trim()
+            .toLowerCase();
+          const recoveredFinalAssistantTextAfterPromptTimeout =
+            timedOutDuringPrompt &&
+            ["completed", "end_turn", "stop"].includes(finalAssistantStopReason)
+              ? (finalAssistantVisibleText ?? finalAssistantRawText)?.trim()
+              : undefined;
+          const payloadAlreadyContainsRecoveredFinalAssistant =
+            recoveredFinalAssistantTextAfterPromptTimeout
+              ? (payloadsWithToolMedia ?? []).some(
+                  (payload) =>
+                    payload?.isError !== true &&
+                    payload?.isReasoning !== true &&
+                    typeof payload.text === "string" &&
+                    payload.text.trim() === recoveredFinalAssistantTextAfterPromptTimeout,
+                )
+              : false;
+          const recoveredFinalAssistantPayloadsAfterPromptTimeout =
+            recoveredFinalAssistantTextAfterPromptTimeout &&
+            !payloadAlreadyContainsRecoveredFinalAssistant
+              ? [{ text: recoveredFinalAssistantTextAfterPromptTimeout }]
+              : undefined;
+          const hasSuccessfulFinalAssistantAfterPromptTimeout =
+            timedOutDuringPrompt &&
+            Boolean(
+              payloadAlreadyContainsRecoveredFinalAssistant ||
+              recoveredFinalAssistantPayloadsAfterPromptTimeout?.length,
+            );
           const hasPartialAssistantTextAfterPromptTimeout =
             timedOutDuringPrompt &&
             (attempt.assistantTexts ?? []).some((text) => text.trim().length > 0) &&
@@ -2690,7 +2719,11 @@ export async function runEmbeddedPiAgent(
           // Timeout aborts can leave the run without payloads or with only a
           // partial assistant fragment. Emit an explicit timeout error instead,
           // preserving any tool payloads that succeeded before the timeout.
-          if (timedOutDuringPrompt && !hasMessagingToolDeliveryEvidence(attempt)) {
+          if (
+            timedOutDuringPrompt &&
+            !hasSuccessfulFinalAssistantAfterPromptTimeout &&
+            !hasMessagingToolDeliveryEvidence(attempt)
+          ) {
             const defaultTimeoutText = idleTimedOut
               ? "The model did not produce a response before the model idle timeout. " +
                 "Please try again, or increase `models.providers.<id>.timeoutSeconds` for slow local or self-hosted providers. " +
@@ -2755,11 +2788,13 @@ export async function runEmbeddedPiAgent(
             timedOut,
             attempt,
           });
-          const payloadsForTerminalPath = payloadsWithToolMedia?.length
-            ? payloadsWithToolMedia
-            : silentToolResultReplyPayload
-              ? [silentToolResultReplyPayload]
-              : payloadsWithToolMedia;
+          const payloadsForTerminalPath = recoveredFinalAssistantPayloadsAfterPromptTimeout
+            ? recoveredFinalAssistantPayloadsAfterPromptTimeout
+            : payloadsWithToolMedia?.length
+              ? payloadsWithToolMedia
+              : silentToolResultReplyPayload
+                ? [silentToolResultReplyPayload]
+                : payloadsWithToolMedia;
           const payloadCount = payloadsForTerminalPath?.length ?? 0;
           const emptyAssistantReplyIsSilent = shouldTreatEmptyAssistantReplyAsSilent({
             allowEmptyAssistantReplyAsSilent: params.allowEmptyAssistantReplyAsSilent,


### PR DESCRIPTION
Summary
- Recover a completed final assistant text payload when a prompt timeout races Codex app-server completion and the runner already has final `stop`/`end_turn`/`completed` assistant text.
- Keep pure prompt silence, or timeout cases without successful final assistant text, on the existing timeout error path.
- Add regression coverage and a changelog entry for the #84516 Form B failure mode.

Verification
- `git diff --check`
- GitHub checks on current rebased head `e926a5eede0bb7e7e094f5a1c24eab6ab4d35206`: passing, including `Real behavior proof`, `check-lint`, `check-test-types`, changed-path shards, Critical Quality `agent-runtime-boundary`/`network-runtime-boundary`, and Security High shards. Merge state is `CLEAN`.
- Local focused Vitest attempt after rebase was blocked by the shared local `node_modules` missing `@rolldown/binding-darwin-arm64`; I did not repair deps from this Codex worktree.
- Pre-rebase local proof on the same code path: `CI=1 timeout 300s node scripts/run-vitest.mjs run src/agents/pi-embedded-runner/run.incomplete-turn.test.ts -t "prompt timeout races completion|strict-agentic blocked exit|empty assistant"` passed.
- Pre-rebase local full incomplete-turn suite: `CI=1 timeout 300s node scripts/run-vitest.mjs run src/agents/pi-embedded-runner/run.incomplete-turn.test.ts` passed.
- AWS Crabbox fresh PR focused regression on `c4f3de33346b0c5bf8120ec473f0ee08d9d811b9`: `run_04d5b2255fed` / `cbx_c13825905dfc` passed.
- AWS Crabbox fresh PR changed gate on `c4f3de33346b0c5bf8120ec473f0ee08d9d811b9`: `run_75e05edd563a` / `cbx_db171cdf8b82` passed `pnpm check:changed -- CHANGELOG.md src/agents/pi-embedded-runner/run.ts src/agents/pi-embedded-runner/run.incomplete-turn.test.ts`.
- Post-rebase Crabbox retry `run_3bd54ab0e602` / `cbx_e2f1ea4c2d88` failed in rsync transport before running tests; no code failure was observed there.
- Blacksmith Testbox: first run `tbx_01ks5hcrs4fr53ebnn8thsybqd` found a lint issue before the amend; after the amend, `tbx_01ks5hmhf173mzsmrjgz3f5h0p`, `tbx_01ks5hwd53t9dj88d6q2075sr3`, and `tbx_01ks5j3h0rrdxn3yd2f3b3y9n4` failed in the Blacksmith rsync/sync layer before running the gate.

Real behavior proof
Behavior addressed: Codex app-server timeout race where final assistant text is captured with a successful `stop`/`end_turn`/`completed` finish, but payload projection is empty and downstream channels receive an empty timeout envelope.
Real environment tested: local OpenClaw focused runner tests before rebase; AWS Crabbox fresh PR Linux runs before rebase; GitHub CI on current rebased head.
Exact steps or command run after this patch: ran the focused timeout-race regression, the full incomplete-turn runner suite, AWS Crabbox fresh-PR focused regression, AWS Crabbox fresh-PR `pnpm check:changed` on the touched files, then rebased and verified current-head GitHub checks.
Evidence after fix: the new regression returns `payloads: [{ text: finalText }]`, preserves `finalAssistantVisibleText`/`finalAssistantRawText`, reports liveness `working`, and records the execution attempt as assistant-stage success.
Observed result after fix: completed final assistant text is promoted into the terminal payload path instead of being replaced by a timeout error when completion and prompt timeout race.
What was not tested: live reporter gpt-5.5 OAuth long reply / Telegram outbound; fresh post-rebase Crabbox/Testbox execution because both remote sync layers failed before executing commands. The Form A pure-silence case with no assistant text remains timeout behavior by design.

Refs #84516.
