### PR TITLE
docs: point README onboarding link to CLI wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Works with npm, pnpm, or bun.
 
 - **[OpenAI](https://openai.com/)** (ChatGPT/Codex)
 
-Model note: while many providers and models are supported, prefer a current flagship model from the provider you trust and already use. See [Onboarding](https://docs.openclaw.ai/start/onboarding).
+Model note: while many providers and models are supported, prefer a current flagship model from the provider you trust and already use. See [Onboarding](https://docs.openclaw.ai/start/wizard).
 
 ## Install (recommended)
 


### PR DESCRIPTION
## Summary

- Problem: the README model note links "Onboarding" to `/start/onboarding`, which is the macOS app onboarding page, while this README section is describing the CLI setup path.
- Solution: point that link to `/start/wizard`, matching the other CLI onboarding links already used in the README.
- What changed: one README URL.
- What did NOT change (scope boundary): no runtime behavior, generated docs, config, install commands, or app code changed.

## Motivation

Keep first-run README navigation consistent for users following the CLI onboarding path.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes N/A
- Related N/A
- [ ] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: README onboarding links for the CLI path now point to the CLI onboarding wizard.
- Real environment tested: Ubuntu 24.04.4 LTS, local checkout.
- Exact steps or command run after this patch:

```bash
git diff --check
test -f docs/start/wizard.md
rg -n 'docs.openclaw.ai/start/wizard|docs.openclaw.ai/start/onboarding' README.md | sed -n '1,20p'
```

- Evidence after fix:

```text
28:[Website](https://openclaw.ai) ... [Onboarding](https://docs.openclaw.ai/start/wizard) ...
95:Model note: ... See [Onboarding](https://docs.openclaw.ai/start/wizard).
155:- **[Onboarding](https://docs.openclaw.ai/start/wizard) + [skills](https://docs.openclaw.ai/tools/skills)** ...
173:- New here: ... [Onboarding](https://docs.openclaw.ai/start/wizard), ...
```

- Observed result after fix: the README no longer links this CLI onboarding reference to `/start/onboarding`.
- What was not tested: live Mintlify production deployment.
- Before evidence (optional but encouraged): line 95 pointed to `https://docs.openclaw.ai/start/onboarding`.

## Root Cause (if applicable)

N/A

## Regression Test Plan (if applicable)

N/A

## User-visible / Behavior Changes

README readers are sent to the CLI onboarding wizard from the model note.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Ubuntu 24.04.4 LTS
- Runtime/container: N/A
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Inspect `README.md` onboarding links.
2. Verify `docs/start/wizard.md` exists in the docs source.
3. Run `git diff --check`.

### Expected

The README CLI onboarding reference points to `/start/wizard`.

### Actual

The README CLI onboarding reference points to `/start/wizard`.

## Evidence

- [x] Trace/log snippets

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: checked README link target and confirmed the docs source page exists.
- Edge cases checked: no remaining `/start/onboarding` link in README output from the targeted `rg` command.
- What you did **not** verify: live docs deployment after merge.

AI assistance: this PR was prepared with Codex. I reviewed the one-line docs change and ran the verification above locally.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

None
