### PR TITLE
[AI-assisted] Add NEAR AI Cloud provider

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -15,6 +15,11 @@
       - any-glob-to-any-file:
           - "extensions/pixverse/**"
           - "docs/providers/pixverse.md"
+"plugin: nearai":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/nearai/**"
+          - "docs/providers/nearai.md"
 "channel: discord":
   - changed-files:
       - any-glob-to-any-file:

--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -289,6 +289,7 @@ messages and normalizes `stats.cached` into `cacheRead`; legacy
 | MiniMax                                 | `minimax` / `minimax-portal`     | `MINIMAX_API_KEY` / `MINIMAX_OAUTH_TOKEN`            | `minimax/MiniMax-M3`                                       |
 | Mistral                                 | `mistral`                        | `MISTRAL_API_KEY`                                    | `mistral/mistral-large-latest`                             |
 | Moonshot                                | `moonshot`                       | `MOONSHOT_API_KEY`                                   | `moonshot/kimi-k2.6`                                       |
+| NEAR AI Cloud                           | `nearai`                         | `NEARAI_API_KEY`                                     | `nearai/zai-org/GLM-5.1-FP8`                               |
 | NVIDIA                                  | `nvidia`                         | `NVIDIA_API_KEY`                                     | `nvidia/nvidia/nemotron-3-ultra-550b-a55b`                 |
 | NovitaAI                                | `novita`                         | `NOVITA_API_KEY`                                     | `novita/deepseek/deepseek-v3-0324`                         |
 | [Ollama Cloud](/providers/ollama-cloud) | `ollama-cloud`                   | `OLLAMA_API_KEY`                                     | `ollama-cloud/kimi-k2.6`                                   |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1445,6 +1445,7 @@
                   "providers/minimax",
                   "providers/mistral",
                   "providers/moonshot",
+                  "providers/nearai",
                   "providers/novita",
                   "providers/nvidia",
                   "providers/ollama",

--- a/docs/plugins/plugin-inventory.md
+++ b/docs/plugins/plugin-inventory.md
@@ -51,7 +51,7 @@ Each entry lists the package, distribution route, and description.
 
 ## Core npm package
 
-59 plugins
+60 plugins
 
 - **[admin-http-rpc](/plugins/reference/admin-http-rpc)** (`@openclaw/admin-http-rpc`) - included in OpenClaw. OpenClaw admin HTTP RPC endpoint.
 
@@ -118,6 +118,8 @@ Each entry lists the package, distribution route, and description.
 - **[minimax](/plugins/reference/minimax)** (`@openclaw/minimax-provider`) - included in OpenClaw. Adds MiniMax, MiniMax Portal model provider support to OpenClaw.
 
 - **[mistral](/plugins/reference/mistral)** (`@openclaw/mistral-provider`) - included in OpenClaw. Adds Mistral model provider support to OpenClaw.
+
+- **[nearai](/plugins/reference/nearai)** (`@openclaw/nearai-provider`) - included in OpenClaw. Adds NEAR AI Cloud model provider support to OpenClaw.
 
 - **[novita](/plugins/reference/novita)** (`@openclaw/novita-provider`) - included in OpenClaw. Adds Novita, Novita AI, Novitaai model provider support to OpenClaw.
 

--- a/docs/plugins/reference.md
+++ b/docs/plugins/reference.md
@@ -15,5 +15,5 @@ This page is generated from `extensions/*/package.json` and
 pnpm plugins:inventory:gen
 ```
 
-Use [Plugin inventory](/plugins/plugin-inventory) to browse all 129
+Use [Plugin inventory](/plugins/plugin-inventory) to browse all 130
 generated plugin reference pages by distribution, package, and description.

--- a/docs/plugins/reference/nearai.md
+++ b/docs/plugins/reference/nearai.md
@@ -1,0 +1,23 @@
+---
+summary: "Adds NEAR AI Cloud model provider support to OpenClaw."
+read_when:
+  - You are installing, configuring, or auditing the nearai plugin
+title: "Nearai plugin"
+---
+
+# Nearai plugin
+
+Adds NEAR AI Cloud model provider support to OpenClaw.
+
+## Distribution
+
+- Package: `@openclaw/nearai-provider`
+- Install route: included in OpenClaw
+
+## Surface
+
+providers: nearai
+
+## Related docs
+
+- [nearai](/providers/nearai)

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -54,6 +54,7 @@ Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/Mattermost (plugi
 - [MiniMax](/providers/minimax)
 - [Mistral](/providers/mistral)
 - [Moonshot AI (Kimi + Kimi Coding)](/providers/moonshot)
+- [NEAR AI Cloud](/providers/nearai)
 - [NVIDIA](/providers/nvidia)
 - [NovitaAI](/providers/novita)
 - [Ollama (cloud + local models)](/providers/ollama)

--- a/docs/providers/models.md
+++ b/docs/providers/models.md
@@ -36,6 +36,7 @@ model as `provider/model`.
 - [MiniMax](/providers/minimax)
 - [Mistral](/providers/mistral)
 - [Moonshot AI (Kimi + Kimi Coding)](/providers/moonshot)
+- [NEAR AI Cloud](/providers/nearai)
 - [OpenAI (API + Codex)](/providers/openai)
 - [OpenCode (Zen + Go)](/providers/opencode)
 - [OpenRouter](/providers/openrouter)

--- a/docs/providers/nearai.md
+++ b/docs/providers/nearai.md
@@ -1,0 +1,119 @@
+---
+summary: "Use NEAR AI Cloud TEE-backed OpenAI-compatible inference in OpenClaw"
+read_when:
+  - You want NEAR AI Cloud setup guidance
+  - You need the NEARAI_API_KEY env var or CLI auth choice
+title: "NEAR AI Cloud"
+---
+
+NEAR AI Cloud provides an **OpenAI-compatible** inference endpoint with a public model catalog and TEE-backed models. OpenClaw includes a bundled NEAR AI Cloud provider plugin with API-key onboarding, a manifest fallback catalog, and runtime catalog refresh.
+
+| Property        | Value                                    |
+| --------------- | ---------------------------------------- |
+| Provider id     | `nearai`                                 |
+| Auth env var    | `NEARAI_API_KEY`                         |
+| Onboarding flag | `--auth-choice nearai-api-key`           |
+| Direct CLI flag | `--nearai-api-key <key>`                 |
+| API             | OpenAI-compatible (`openai-completions`) |
+| Base URL        | `https://cloud-api.near.ai/v1`           |
+| Default model   | `nearai/zai-org/GLM-5.1-FP8`             |
+
+## Getting started
+
+<Steps>
+  <Step title="Create an API key">
+    Create an API key from [NEAR AI Cloud](https://cloud.near.ai).
+  </Step>
+  <Step title="Run onboarding">
+    <CodeGroup>
+
+```bash Onboarding
+openclaw onboard --auth-choice nearai-api-key
+```
+
+```bash Direct flag
+openclaw onboard --non-interactive \
+  --auth-choice nearai-api-key \
+  --nearai-api-key "$NEARAI_API_KEY"
+```
+
+```bash Env only
+export NEARAI_API_KEY=nai_...
+```
+
+    </CodeGroup>
+
+  </Step>
+  <Step title="Verify models are available">
+    ```bash
+    openclaw models list --all --provider nearai
+    ```
+  </Step>
+</Steps>
+
+## Catalog
+
+The bundled fallback catalog is generated from NEAR AI Cloud's public `GET https://cloud-api.near.ai/v1/model/list` endpoint. When a NEAR AI API key is configured, OpenClaw can refresh the provider catalog at runtime and falls back to the bundled rows if discovery is unavailable.
+
+| Model ref                               | Input       | Context | Max output | Notes                 |
+| --------------------------------------- | ----------- | ------- | ---------- | --------------------- |
+| `nearai/zai-org/GLM-5.1-FP8`            | text        | 202,752 | 65,536     | Default TEE model     |
+| `nearai/Qwen/Qwen3.6-35B-A3B-FP8`       | text        | 262,144 | 65,536     | TEE model             |
+| `nearai/Qwen/Qwen3.5-122B-A10B`         | text        | 131,072 | 65,536     | TEE model             |
+| `nearai/Qwen/Qwen3-VL-30B-A3B-Instruct` | text, image | 256,000 | 65,536     | TEE vision model      |
+| `nearai/openai/gpt-oss-120b`            | text        | 131,000 | 65,536     | TEE open-weight model |
+| `nearai/anthropic/claude-opus-4-7`      | text, image | 1M      | 65,536     | External model        |
+| `nearai/openai/gpt-5.5`                 | text        | 1.05M   | 65,536     | External model        |
+
+Use `openclaw models list --all --provider nearai` for the current local catalog. NEAR AI Cloud's public catalog marks model-level TEE signals with `metadata.verifiable` and `metadata.attestationSupported`; OpenClaw's model rows keep the OpenAI-compatible execution metadata used by the Gateway.
+
+## Compatibility
+
+NEAR AI Cloud uses standard Bearer-token auth and the OpenAI Chat Completions request shape. OpenClaw configures NEAR AI models with provider compatibility flags that use `max_tokens` and avoid newer OpenAI-only fields such as `store`, developer-role shaping, `reasoning_effort`, and strict structured-output mode.
+
+Model refs keep the full upstream model id after the `nearai/` prefix. For example, `nearai/Qwen/Qwen3.6-35B-A3B-FP8` sends `Qwen/Qwen3.6-35B-A3B-FP8` to NEAR AI Cloud.
+
+## Manual config
+
+The bundled plugin usually means you only need the API key. Use explicit provider config only when you want to override model metadata:
+
+```json5
+{
+  env: { NEARAI_API_KEY: "nai_..." },
+  agents: {
+    defaults: {
+      model: { primary: "nearai/zai-org/GLM-5.1-FP8" },
+    },
+  },
+  models: {
+    providers: {
+      nearai: {
+        baseUrl: "https://cloud-api.near.ai/v1",
+        apiKey: "${NEARAI_API_KEY}",
+        api: "openai-completions",
+      },
+    },
+  },
+}
+```
+
+<Note>
+  If the Gateway runs as a daemon or container, make sure `NEARAI_API_KEY` is available to that process. A key exported only in an interactive shell will not help a managed service unless the environment is imported separately.
+</Note>
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Model providers" href="/concepts/model-providers" icon="layers">
+    Choosing providers, model refs, and failover behavior.
+  </Card>
+  <Card title="Models CLI" href="/cli/models" icon="terminal">
+    Listing, setting, and checking provider auth status.
+  </Card>
+  <Card title="Configuration reference" href="/gateway/configuration-reference" icon="gear">
+    Full OpenClaw configuration reference.
+  </Card>
+  <Card title="NEAR AI Cloud" href="https://cloud.near.ai" icon="arrow-up-right-from-square">
+    API keys and account setup.
+  </Card>
+</CardGroup>

--- a/extensions/nearai/api.ts
+++ b/extensions/nearai/api.ts
@@ -1,0 +1,10 @@
+export {
+  applyNearAIModelCompat,
+  buildNearAIModelDefinition,
+  discoverNearAIModels,
+  NEARAI_BASE_URL,
+  NEARAI_DEFAULT_MODEL_REF,
+  NEARAI_MODEL_CATALOG,
+} from "./models.js";
+export { buildNearAIProvider, buildStaticNearAIProvider } from "./provider-catalog.js";
+export { applyNearAIConfig } from "./onboard.js";

--- a/extensions/nearai/index.test.ts
+++ b/extensions/nearai/index.test.ts
@@ -1,0 +1,76 @@
+import {
+  registerSingleProviderPlugin,
+  resolveProviderPluginChoice,
+} from "openclaw/plugin-sdk/plugin-test-runtime";
+import { resolveAgentModelPrimaryValue } from "openclaw/plugin-sdk/provider-onboard";
+import { describe, expect, it } from "vitest";
+import { runSingleProviderCatalog } from "../test-support/provider-model-test-helpers.js";
+import nearAIPlugin from "./index.js";
+import { applyNearAIConfig, NEARAI_DEFAULT_MODEL_REF } from "./onboard.js";
+
+function expectRecord<T>(value: T | null | undefined, label: string): NonNullable<T> {
+  if (!value) {
+    throw new Error(`Expected ${label}`);
+  }
+  return value;
+}
+
+describe("nearai provider plugin", () => {
+  it("registers NEAR AI Cloud with api-key auth wizard metadata", async () => {
+    const provider = await registerSingleProviderPlugin(nearAIPlugin);
+    const resolved = resolveProviderPluginChoice({
+      providers: [provider],
+      choice: "nearai-api-key",
+    });
+
+    expect(provider.id).toBe("nearai");
+    expect(provider.label).toBe("NEAR AI Cloud");
+    expect(provider.docsPath).toBe("/providers/nearai");
+    expect(provider.envVars).toEqual(["NEARAI_API_KEY"]);
+    expect(provider.auth).toHaveLength(1);
+    const resolvedChoice = expectRecord(resolved, "NEAR AI provider choice");
+    expect({
+      providerId: resolvedChoice.provider.id,
+      methodId: resolvedChoice.method.id,
+    }).toEqual({
+      providerId: "nearai",
+      methodId: "api-key",
+    });
+  });
+
+  it("builds the NEAR AI model catalog", async () => {
+    const provider = await registerSingleProviderPlugin(nearAIPlugin);
+    const catalogProvider = await runSingleProviderCatalog(provider);
+
+    expect(catalogProvider.api).toBe("openai-completions");
+    expect(catalogProvider.baseUrl).toBe("https://cloud-api.near.ai/v1");
+    const models = expectRecord(catalogProvider.models, "NEAR AI catalog models");
+    const defaultModel = expectRecord(
+      models.find((model) => model.id === "zai-org/GLM-5.1-FP8"),
+      "default NEAR AI model",
+    );
+    expect(defaultModel).toMatchObject({
+      name: "GLM 5.1",
+      reasoning: true,
+      input: ["text"],
+      contextWindow: 202752,
+      maxTokens: 65536,
+      compat: {
+        maxTokensField: "max_tokens",
+        supportsStore: false,
+        supportsDeveloperRole: false,
+        supportsReasoningEffort: false,
+        supportsStrictMode: false,
+      },
+    });
+  });
+
+  it("applies NEAR AI as the default model during onboarding", () => {
+    const cfg = applyNearAIConfig({});
+    expect(resolveAgentModelPrimaryValue(cfg.agents?.defaults?.model)).toBe(
+      NEARAI_DEFAULT_MODEL_REF,
+    );
+    expect(cfg.models?.providers?.nearai?.baseUrl).toBe("https://cloud-api.near.ai/v1");
+    expect(cfg.models?.providers?.nearai?.api).toBe("openai-completions");
+  });
+});

--- a/extensions/nearai/index.ts
+++ b/extensions/nearai/index.ts
@@ -1,0 +1,55 @@
+import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
+import {
+  buildProviderReplayFamilyHooks,
+  type ModelCompatConfig,
+} from "openclaw/plugin-sdk/provider-model-shared";
+import { applyNearAIModelCompat } from "./models.js";
+import { applyNearAIConfig, NEARAI_DEFAULT_MODEL_REF } from "./onboard.js";
+import { buildNearAIProvider, buildStaticNearAIProvider } from "./provider-catalog.js";
+
+const PROVIDER_ID = "nearai";
+
+export default defineSingleProviderPluginEntry({
+  id: PROVIDER_ID,
+  name: "NEAR AI Provider",
+  description: "Bundled NEAR AI Cloud provider plugin",
+  provider: {
+    label: "NEAR AI Cloud",
+    docsPath: "/providers/nearai",
+    auth: [
+      {
+        methodId: "api-key",
+        label: "NEAR AI API key",
+        hint: "TEE-backed OpenAI-compatible inference",
+        optionKey: "nearaiApiKey",
+        flagName: "--nearai-api-key",
+        envVar: "NEARAI_API_KEY",
+        promptMessage: "Enter NEAR AI API key",
+        defaultModel: NEARAI_DEFAULT_MODEL_REF,
+        applyConfig: (cfg) => applyNearAIConfig(cfg),
+        noteMessage: [
+          "NEAR AI Cloud provides OpenAI-compatible inference with TEE-backed models.",
+          "Get your API key at: https://cloud.near.ai",
+        ].join("\n"),
+        noteTitle: "NEAR AI Cloud",
+        wizard: {
+          groupLabel: "NEAR AI Cloud",
+          groupHint: "TEE-backed OpenAI-compatible inference",
+        },
+      },
+    ],
+    catalog: {
+      buildProvider: buildNearAIProvider,
+      buildStaticProvider: buildStaticNearAIProvider,
+    },
+    normalizeResolvedModel: ({ model }) => {
+      const normalized = applyNearAIModelCompat(
+        model as typeof model & { compat?: ModelCompatConfig },
+      );
+      return normalized === model ? undefined : normalized;
+    },
+    ...buildProviderReplayFamilyHooks({
+      family: "openai-compatible",
+    }),
+  },
+});

--- a/extensions/nearai/models.test.ts
+++ b/extensions/nearai/models.test.ts
@@ -1,0 +1,204 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  buildNearAIModelDefinition,
+  discoverNearAIModels,
+  NEARAI_DEFAULT_MODEL_REF,
+  NEARAI_MODEL_CATALOG,
+} from "./models.js";
+
+const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+const ORIGINAL_VITEST = process.env.VITEST;
+
+function restoreDiscoveryEnv(): void {
+  if (ORIGINAL_NODE_ENV === undefined) {
+    delete process.env.NODE_ENV;
+  } else {
+    process.env.NODE_ENV = ORIGINAL_NODE_ENV;
+  }
+
+  if (ORIGINAL_VITEST === undefined) {
+    delete process.env.VITEST;
+  } else {
+    process.env.VITEST = ORIGINAL_VITEST;
+  }
+}
+
+async function runWithDiscoveryEnabled<T>(operation: () => Promise<T>): Promise<T> {
+  process.env.NODE_ENV = "development";
+  delete process.env.VITEST;
+  try {
+    return await operation();
+  } finally {
+    restoreDiscoveryEnv();
+  }
+}
+
+type NearAITestModel = {
+  modelId: string;
+  displayName?: string;
+  description?: string;
+  inputModalities?: string[];
+  outputModalities?: string[];
+  contextLength?: number;
+  inputCostAmount?: number;
+  outputCostAmount?: number;
+  cacheReadCostAmount?: number;
+};
+
+function makeNearAIModel(params: NearAITestModel) {
+  return {
+    modelId: params.modelId,
+    inputCostPerToken: {
+      amount: params.inputCostAmount ?? 850,
+      scale: 9,
+      currency: "USD",
+    },
+    outputCostPerToken: {
+      amount: params.outputCostAmount ?? 3300,
+      scale: 9,
+      currency: "USD",
+    },
+    cacheReadCostPerToken: {
+      amount: params.cacheReadCostAmount ?? 170,
+      scale: 9,
+      currency: "USD",
+    },
+    metadata: {
+      contextLength: params.contextLength ?? 202752,
+      modelDisplayName: params.displayName ?? params.modelId,
+      modelDescription: params.description ?? "General-purpose model",
+      architecture: {
+        inputModalities: params.inputModalities ?? ["text"],
+        outputModalities: params.outputModalities ?? ["text"],
+      },
+    },
+  };
+}
+
+function stubNearAIModelsFetch(rows: NearAITestModel[]) {
+  const fetchMock = vi.fn(
+    async () =>
+      new Response(
+        JSON.stringify({
+          models: rows.map((row) => makeNearAIModel(row)),
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+  );
+  vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+  return fetchMock;
+}
+
+describe("nearai models", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    restoreDiscoveryEnv();
+  });
+
+  it("buildNearAIModelDefinition applies OpenAI-compatible NEAR compatibility flags", () => {
+    const entry = NEARAI_MODEL_CATALOG.find((model) => model.id === "zai-org/GLM-5.1-FP8");
+    if (!entry) {
+      throw new Error("expected default NEAR AI model");
+    }
+
+    const def = buildNearAIModelDefinition(entry);
+    expect(NEARAI_DEFAULT_MODEL_REF).toBe("nearai/zai-org/GLM-5.1-FP8");
+    expect(def.id).toBe(entry.id);
+    expect(def.input).toEqual(["text"]);
+    expect(def.cost.input).toBe(0.85);
+    expect(def.compat).toMatchObject({
+      supportsStore: false,
+      supportsDeveloperRole: false,
+      supportsReasoningEffort: false,
+      supportsUsageInStreaming: false,
+      supportsStrictMode: false,
+      maxTokensField: "max_tokens",
+    });
+  });
+
+  it("maps public catalog rows to OpenClaw model definitions", async () => {
+    stubNearAIModelsFetch([
+      {
+        modelId: "zai-org/GLM-5.1-FP8",
+        displayName: "GLM 5.1",
+        description: "Built for complex reasoning and coding",
+        inputModalities: ["text"],
+        outputModalities: ["text"],
+        contextLength: 202752,
+        inputCostAmount: 850,
+        outputCostAmount: 3300,
+        cacheReadCostAmount: 170,
+      },
+      {
+        modelId: "Qwen/Qwen3-VL-30B-A3B-Instruct",
+        displayName: "Qwen3 VL",
+        inputModalities: ["text", "image"],
+        outputModalities: ["text"],
+        contextLength: 256000,
+        inputCostAmount: 150,
+        outputCostAmount: 550,
+        cacheReadCostAmount: 30,
+      },
+    ]);
+
+    const models = await runWithDiscoveryEnabled(() => discoverNearAIModels({ retryDelayMs: 0 }));
+    const glm = models.find((model) => model.id === "zai-org/GLM-5.1-FP8");
+    const qwenVl = models.find((model) => model.id === "Qwen/Qwen3-VL-30B-A3B-Instruct");
+
+    expect(glm).toMatchObject({
+      name: "GLM 5.1",
+      reasoning: true,
+      input: ["text"],
+      contextWindow: 202752,
+      maxTokens: 65536,
+      cost: {
+        input: 0.85,
+        output: 3.3,
+        cacheRead: 0.17,
+        cacheWrite: 0,
+      },
+    });
+    expect(qwenVl?.input).toEqual(["text", "image"]);
+    expect(qwenVl?.compat?.maxTokensField).toBe("max_tokens");
+  });
+
+  it("filters non-chat utility rows from discovery", async () => {
+    stubNearAIModelsFetch([
+      {
+        modelId: "openai/privacy-filter",
+        outputModalities: ["text"],
+      },
+      {
+        modelId: "Qwen/Qwen3-Embedding-0.6B",
+        outputModalities: ["embedding"],
+      },
+      {
+        modelId: "black-forest-labs/FLUX.2-klein-4B",
+        outputModalities: ["image"],
+      },
+      {
+        modelId: "zai-org/GLM-5.1-FP8",
+        outputModalities: ["text"],
+      },
+    ]);
+
+    const models = await runWithDiscoveryEnabled(() => discoverNearAIModels({ retryDelayMs: 0 }));
+    expect(models.map((model) => model.id)).toEqual(["zai-org/GLM-5.1-FP8"]);
+  });
+
+  it("falls back to the static catalog after retryable discovery failures", async () => {
+    const fetchMock = vi.fn(async () => {
+      throw Object.assign(new TypeError("fetch failed"), {
+        cause: { code: "ENOTFOUND", message: "getaddrinfo ENOTFOUND cloud-api.near.ai" },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const models = await runWithDiscoveryEnabled(() => discoverNearAIModels({ retryDelayMs: 0 }));
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(models.map((model) => model.id)).toEqual(NEARAI_MODEL_CATALOG.map((model) => model.id));
+  });
+});

--- a/extensions/nearai/models.ts
+++ b/extensions/nearai/models.ts
@@ -1,0 +1,350 @@
+import { buildManifestModelProviderConfig } from "openclaw/plugin-sdk/provider-catalog-shared";
+import type {
+  ModelCompatConfig,
+  ModelDefinitionConfig,
+} from "openclaw/plugin-sdk/provider-model-shared";
+import { createSubsystemLogger, retryAsync } from "openclaw/plugin-sdk/runtime-env";
+import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+import manifest from "./openclaw.plugin.json" with { type: "json" };
+
+const PROVIDER_ID = "nearai";
+const log = createSubsystemLogger("nearai-models");
+
+const NEARAI_MANIFEST_PROVIDER = buildManifestModelProviderConfig({
+  providerId: PROVIDER_ID,
+  catalog: manifest.modelCatalog.providers.nearai,
+});
+
+export const NEARAI_BASE_URL = NEARAI_MANIFEST_PROVIDER.baseUrl;
+const NEARAI_MODEL_LIST_URL = `${NEARAI_BASE_URL}/model/list`;
+const NEARAI_DEFAULT_MODEL_ID = "zai-org/GLM-5.1-FP8";
+export const NEARAI_DEFAULT_MODEL_REF = `${PROVIDER_ID}/${NEARAI_DEFAULT_MODEL_ID}`;
+const NEARAI_ALLOWED_HOSTNAMES = ["cloud-api.near.ai"];
+
+const NEARAI_DEFAULT_CONTEXT_WINDOW = 128_000;
+const NEARAI_DISCOVERY_MAX_TOKENS = 65_536;
+const NEARAI_DISCOVERY_TIMEOUT_MS = 10_000;
+const NEARAI_DISCOVERY_RETRYABLE_HTTP_STATUS = new Set([408, 425, 429, 500, 502, 503, 504]);
+const NEARAI_DISCOVERY_RETRYABLE_NETWORK_CODES = new Set([
+  "ECONNABORTED",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EAI_AGAIN",
+  "ENETDOWN",
+  "ENETUNREACH",
+  "ENOTFOUND",
+  "ETIMEDOUT",
+  "UND_ERR_BODY_TIMEOUT",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_CONNECT_ERROR",
+  "UND_ERR_HEADERS_TIMEOUT",
+  "UND_ERR_SOCKET",
+]);
+
+const NEARAI_OPENAI_COMPAT: ModelCompatConfig = {
+  supportsStore: false,
+  supportsDeveloperRole: false,
+  supportsReasoningEffort: false,
+  supportsUsageInStreaming: false,
+  supportsStrictMode: false,
+  maxTokensField: "max_tokens",
+};
+
+export const NEARAI_MODEL_CATALOG: ModelDefinitionConfig[] = NEARAI_MANIFEST_PROVIDER.models;
+
+type NearAICatalogEntry = ModelDefinitionConfig;
+
+type NearAICost = {
+  amount?: unknown;
+  scale?: unknown;
+};
+
+type NearAIModelMetadata = {
+  contextLength?: unknown;
+  modelDisplayName?: unknown;
+  modelDescription?: unknown;
+  architecture?: {
+    inputModalities?: unknown;
+    outputModalities?: unknown;
+  };
+};
+
+type NearAIModel = {
+  modelId?: unknown;
+  inputCostPerToken?: NearAICost;
+  outputCostPerToken?: NearAICost;
+  cacheReadCostPerToken?: NearAICost;
+  metadata?: NearAIModelMetadata;
+};
+
+type NearAIModelsResponse = {
+  models?: unknown;
+};
+
+class NearAIDiscoveryHttpError extends Error {
+  readonly status: number;
+
+  constructor(status: number) {
+    super(`HTTP ${status}`);
+    this.name = "NearAIDiscoveryHttpError";
+    this.status = status;
+  }
+}
+
+export function applyNearAIModelCompat<T extends { compat?: ModelCompatConfig }>(model: T): T {
+  const nextCompat = {
+    ...model.compat,
+    ...NEARAI_OPENAI_COMPAT,
+  };
+  const currentCompat = model.compat as Record<string, unknown> | undefined;
+  const hasCompat = Object.entries(NEARAI_OPENAI_COMPAT).every(
+    ([key, value]) => currentCompat?.[key] === value,
+  );
+  if (model.compat && hasCompat) {
+    return model;
+  }
+  return {
+    ...model,
+    compat: nextCompat,
+  };
+}
+
+export function buildNearAIModelDefinition(entry: NearAICatalogEntry): ModelDefinitionConfig {
+  return applyNearAIModelCompat({
+    id: entry.id,
+    name: entry.name,
+    reasoning: entry.reasoning,
+    input: [...entry.input],
+    cost: {
+      input: entry.cost.input,
+      output: entry.cost.output,
+      cacheRead: entry.cost.cacheRead,
+      cacheWrite: entry.cost.cacheWrite,
+      ...(entry.cost.tieredPricing ? { tieredPricing: entry.cost.tieredPricing } : {}),
+    },
+    contextWindow: entry.contextWindow,
+    ...(entry.contextTokens !== undefined ? { contextTokens: entry.contextTokens } : {}),
+    maxTokens: entry.maxTokens,
+    ...(entry.compat ? { compat: { ...entry.compat } } : {}),
+  });
+}
+
+function staticNearAIModelDefinitions(): ModelDefinitionConfig[] {
+  return NEARAI_MODEL_CATALOG.map(buildNearAIModelDefinition);
+}
+
+function hasRetryableNetworkCode(err: unknown): boolean {
+  const queue: unknown[] = [err];
+  const seen = new Set<unknown>();
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (!current || typeof current !== "object" || seen.has(current)) {
+      continue;
+    }
+    seen.add(current);
+    const candidate = current as {
+      cause?: unknown;
+      errors?: unknown;
+      code?: unknown;
+      errno?: unknown;
+    };
+    const code =
+      typeof candidate.code === "string"
+        ? candidate.code
+        : typeof candidate.errno === "string"
+          ? candidate.errno
+          : undefined;
+    if (code && NEARAI_DISCOVERY_RETRYABLE_NETWORK_CODES.has(code)) {
+      return true;
+    }
+    if (candidate.cause) {
+      queue.push(candidate.cause);
+    }
+    if (Array.isArray(candidate.errors)) {
+      queue.push(...candidate.errors);
+    }
+  }
+  return false;
+}
+
+function isRetryableNearAIDiscoveryError(err: unknown): boolean {
+  if (err instanceof NearAIDiscoveryHttpError) {
+    return true;
+  }
+  if (err instanceof Error && err.name === "AbortError") {
+    return true;
+  }
+  if (err instanceof TypeError && normalizeLowercaseStringOrEmpty(err.message) === "fetch failed") {
+    return true;
+  }
+  return hasRetryableNetworkCode(err);
+}
+
+function normalizePositiveInt(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return undefined;
+  }
+  return Math.floor(value);
+}
+
+function normalizeStringList(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((item): item is string => typeof item === "string");
+}
+
+function usdPerMillionTokens(cost: NearAICost | undefined): number {
+  if (
+    !cost ||
+    typeof cost.amount !== "number" ||
+    typeof cost.scale !== "number" ||
+    !Number.isFinite(cost.amount) ||
+    !Number.isFinite(cost.scale)
+  ) {
+    return 0;
+  }
+  return Number((cost.amount * 10 ** (6 - cost.scale)).toPrecision(12));
+}
+
+function resolveModelInput(metadata: NearAIModelMetadata | undefined): Array<"text" | "image"> {
+  const input = normalizeStringList(metadata?.architecture?.inputModalities).filter(
+    (item): item is "text" | "image" => item === "text" || item === "image",
+  );
+  return input.length > 0 ? [...new Set(input)] : ["text"];
+}
+
+function outputSupportsText(metadata: NearAIModelMetadata | undefined): boolean {
+  const output = normalizeStringList(metadata?.architecture?.outputModalities);
+  return output.length === 0 || output.includes("text");
+}
+
+function shouldSkipNearAIModel(modelId: string): boolean {
+  const lower = normalizeLowercaseStringOrEmpty(modelId);
+  return (
+    lower === "openai/privacy-filter" ||
+    lower.includes("embedding") ||
+    lower.includes("reranker") ||
+    lower.includes("whisper") ||
+    lower.includes("flux")
+  );
+}
+
+function resolveNearAIReasoning(model: NearAIModel, modelId: string): boolean {
+  const text = [
+    modelId,
+    typeof model.metadata?.modelDisplayName === "string" ? model.metadata.modelDisplayName : "",
+    typeof model.metadata?.modelDescription === "string" ? model.metadata.modelDescription : "",
+  ]
+    .join(" ")
+    .toLowerCase();
+  return /\breason|\bthinking|gpt-5|\bo3\b|\bo4\b|\bopus\b|\bsonnet\b|\bgemini\b|\bglm\b|qwen3\.5|qwen3\.6/.test(
+    text,
+  );
+}
+
+function buildNearAIModelDefinitionFromApi(model: NearAIModel): ModelDefinitionConfig | undefined {
+  if (typeof model.modelId !== "string" || !model.modelId.trim()) {
+    return undefined;
+  }
+  const modelId = model.modelId.trim();
+  if (shouldSkipNearAIModel(modelId) || !outputSupportsText(model.metadata)) {
+    return undefined;
+  }
+  const contextWindow =
+    normalizePositiveInt(model.metadata?.contextLength) ?? NEARAI_DEFAULT_CONTEXT_WINDOW;
+  const name =
+    typeof model.metadata?.modelDisplayName === "string" && model.metadata.modelDisplayName.trim()
+      ? model.metadata.modelDisplayName.trim()
+      : modelId;
+  return applyNearAIModelCompat({
+    id: modelId,
+    name,
+    reasoning: resolveNearAIReasoning(model, modelId),
+    input: resolveModelInput(model.metadata),
+    cost: {
+      input: usdPerMillionTokens(model.inputCostPerToken),
+      output: usdPerMillionTokens(model.outputCostPerToken),
+      cacheRead: usdPerMillionTokens(model.cacheReadCostPerToken),
+      cacheWrite: 0,
+    },
+    contextWindow,
+    maxTokens: Math.min(contextWindow, NEARAI_DISCOVERY_MAX_TOKENS),
+  });
+}
+
+type NearAIModelDiscoveryOptions = {
+  retryDelayMs?: number;
+};
+
+export async function discoverNearAIModels(
+  options: NearAIModelDiscoveryOptions = {},
+): Promise<ModelDefinitionConfig[]> {
+  if (process.env.NODE_ENV === "test" || process.env.VITEST) {
+    return staticNearAIModelDefinitions();
+  }
+
+  try {
+    const { response, release } = await retryAsync(
+      async () => {
+        const result = await fetchWithSsrFGuard({
+          url: NEARAI_MODEL_LIST_URL,
+          signal: AbortSignal.timeout(NEARAI_DISCOVERY_TIMEOUT_MS),
+          init: {
+            headers: {
+              Accept: "application/json",
+            },
+          },
+          policy: { allowedHostnames: NEARAI_ALLOWED_HOSTNAMES },
+          auditContext: "nearai-model-discovery",
+        });
+        const currentResponse = result.response;
+        if (
+          !currentResponse.ok &&
+          NEARAI_DISCOVERY_RETRYABLE_HTTP_STATUS.has(currentResponse.status)
+        ) {
+          await result.release();
+          throw new NearAIDiscoveryHttpError(currentResponse.status);
+        }
+        return result;
+      },
+      {
+        attempts: 3,
+        minDelayMs: options.retryDelayMs ?? 300,
+        maxDelayMs: options.retryDelayMs ?? 2000,
+        jitter: options.retryDelayMs === undefined ? 0.2 : 0,
+        label: "nearai-model-discovery",
+        shouldRetry: isRetryableNearAIDiscoveryError,
+      },
+    );
+
+    try {
+      if (!response.ok) {
+        log.warn(`Failed to discover models: HTTP ${response.status}, using static catalog`);
+        return staticNearAIModelDefinitions();
+      }
+
+      const data = (await response.json()) as NearAIModelsResponse;
+      if (!Array.isArray(data.models) || data.models.length === 0) {
+        log.warn("No models found from API, using static catalog");
+        return staticNearAIModelDefinitions();
+      }
+
+      const models = data.models
+        .map((row) => buildNearAIModelDefinitionFromApi(row as NearAIModel))
+        .filter((row): row is ModelDefinitionConfig => row !== undefined);
+
+      return models.length > 0 ? models : staticNearAIModelDefinitions();
+    } finally {
+      await release();
+    }
+  } catch (error) {
+    if (error instanceof NearAIDiscoveryHttpError) {
+      log.warn(`Failed to discover models: HTTP ${error.status}, using static catalog`);
+      return staticNearAIModelDefinitions();
+    }
+    log.warn(`Discovery failed: ${String(error)}, using static catalog`);
+    return staticNearAIModelDefinitions();
+  }
+}

--- a/extensions/nearai/models.ts
+++ b/extensions/nearai/models.ts
@@ -258,7 +258,7 @@ function buildNearAIModelDefinitionFromApi(model: NearAIModel): ModelDefinitionC
     typeof model.metadata?.modelDisplayName === "string" && model.metadata.modelDisplayName.trim()
       ? model.metadata.modelDisplayName.trim()
       : modelId;
-  return applyNearAIModelCompat({
+  const definition: ModelDefinitionConfig = {
     id: modelId,
     name,
     reasoning: resolveNearAIReasoning(model, modelId),
@@ -271,7 +271,8 @@ function buildNearAIModelDefinitionFromApi(model: NearAIModel): ModelDefinitionC
     },
     contextWindow,
     maxTokens: Math.min(contextWindow, NEARAI_DISCOVERY_MAX_TOKENS),
-  });
+  };
+  return applyNearAIModelCompat(definition);
 }
 
 type NearAIModelDiscoveryOptions = {

--- a/extensions/nearai/onboard.ts
+++ b/extensions/nearai/onboard.ts
@@ -1,0 +1,27 @@
+import {
+  createModelCatalogPresetAppliers,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/provider-onboard";
+import {
+  buildNearAIModelDefinition,
+  NEARAI_BASE_URL,
+  NEARAI_DEFAULT_MODEL_REF,
+  NEARAI_MODEL_CATALOG,
+} from "./api.js";
+
+export { NEARAI_DEFAULT_MODEL_REF };
+
+const nearAIPresetAppliers = createModelCatalogPresetAppliers({
+  primaryModelRef: NEARAI_DEFAULT_MODEL_REF,
+  resolveParams: (_cfg: OpenClawConfig) => ({
+    providerId: "nearai",
+    api: "openai-completions",
+    baseUrl: NEARAI_BASE_URL,
+    catalogModels: NEARAI_MODEL_CATALOG.map(buildNearAIModelDefinition),
+    aliases: [{ modelRef: NEARAI_DEFAULT_MODEL_REF, alias: "NEAR AI GLM 5.1" }],
+  }),
+});
+
+export function applyNearAIConfig(cfg: OpenClawConfig): OpenClawConfig {
+  return nearAIPresetAppliers.applyConfig(cfg);
+}

--- a/extensions/nearai/onboard.ts
+++ b/extensions/nearai/onboard.ts
@@ -7,7 +7,7 @@ import {
   NEARAI_BASE_URL,
   NEARAI_DEFAULT_MODEL_REF,
   NEARAI_MODEL_CATALOG,
-} from "./api.js";
+} from "./models.js";
 
 export { NEARAI_DEFAULT_MODEL_REF };
 

--- a/extensions/nearai/openclaw.plugin.json
+++ b/extensions/nearai/openclaw.plugin.json
@@ -1,0 +1,786 @@
+{
+  "id": "nearai",
+  "name": "NEAR AI Cloud",
+  "description": "Adds NEAR AI Cloud model provider support to OpenClaw.",
+  "activation": {
+    "onStartup": false
+  },
+  "enabledByDefault": true,
+  "providers": ["nearai"],
+  "providerRequest": {
+    "providers": {
+      "nearai": {
+        "family": "nearai"
+      }
+    }
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "nearai",
+      "method": "api-key",
+      "choiceId": "nearai-api-key",
+      "choiceLabel": "NEAR AI API key",
+      "choiceHint": "TEE-backed OpenAI-compatible inference",
+      "groupId": "nearai",
+      "groupLabel": "NEAR AI Cloud",
+      "groupHint": "TEE-backed OpenAI-compatible inference",
+      "optionKey": "nearaiApiKey",
+      "cliFlag": "--nearai-api-key",
+      "cliOption": "--nearai-api-key <key>",
+      "cliDescription": "NEAR AI API key"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  },
+  "setup": {
+    "providers": [
+      {
+        "id": "nearai",
+        "authMethods": ["api-key"],
+        "envVars": ["NEARAI_API_KEY"]
+      }
+    ]
+  },
+  "modelCatalog": {
+    "providers": {
+      "nearai": {
+        "baseUrl": "https://cloud-api.near.ai/v1",
+        "api": "openai-completions",
+        "models": [
+          {
+            "id": "anthropic/claude-haiku-4-5",
+            "name": "Claude Haiku 4.5",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 200000,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 1,
+              "output": 5,
+              "cacheRead": 0.1,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "supportsStore": false,
+              "supportsDeveloperRole": false,
+              "supportsReasoningEffort": false,
+              "supportsUsageInStreaming": false,
+              "supportsStrictMode": false,
+              "maxTokensField": "max_tokens"
+            }
+          },
+          {
+            "id": "anthropic/claude-opus-4-6",
+            "name": "Claude Opus 4.6",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 200000,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 5,
+              "output": 25,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "supportsStore": false,
+              "supportsDeveloperRole": false,
+              "supportsReasoningEffort": false,
+              "supportsUsageInStreaming": false,
+              "supportsStrictMode": false,
+              "maxTokensField": "max_tokens"
+            }
+          },
+          {
+            "id": "anthropic/claude-opus-4-7",
+            "name": "Claude Opus 4.7",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1000000,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 5,
+              "output": 25,
+              "cacheRead": 0.5,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "supportsStore": false,
+              "supportsDeveloperRole": false,
+              "supportsReasoningEffort": false,
+              "supportsUsageInStreaming": false,
+              "supportsStrictMode": false,
+              "maxTokensField": "max_tokens"
+            }
+          },
+          {
+            "id": "anthropic/claude-sonnet-4-5",
+            "name": "Claude Sonnet 4.5",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 200000,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 3,
+              "output": 15.5,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "supportsStore": false,
+              "supportsDeveloperRole": false,
+              "supportsReasoningEffort": false,
+              "supportsUsageInStreaming": false,
+              "supportsStrictMode": false,
+              "maxTokensField": "max_tokens"
+            }
+          },
+          {
+            "id": "anthropic/claude-sonnet-4-6",
+            "name": "Claude Sonnet 4.6",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1000000,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 3,
+              "output": 15,
+              "cacheRead": 0.3,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "supportsStore": false,
+              "supportsDeveloperRole": false,
+              "supportsReasoningEffort": false,
+              "supportsUsageInStreaming": false,
+              "supportsStrictMode": false,
+              "maxTokensField": "max_tokens"
+            }
+          },
+          {
+            "id": "google/gemini-2.5-flash",
+            "name": "Gemini 2.5 Flash",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1000000,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 0.3,
+              "output": 2.5,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "supportsStore": false,
+              "supportsDeveloperRole": false,
+              "supportsReasoningEffort": false,
+              "supportsUsageInStreaming": false,
+              "supportsStrictMode": false,
+              "maxTokensField": "max_tokens"
+            }
+          },
+          {
+            "id": "google/gemini-2.5-flash-lite",
+            "name": "Gemini 2.5 Flash Lite",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 1048576,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 0.1,
+              "output": 0.4,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "supportsStore": false,
+              "supportsDeveloperRole": false,
+              "supportsReasoningEffort": false,
+              "supportsUsageInStreaming": false,
+              "supportsStrictMode": false,
+              "maxTokensField": "max_tokens"
+            }
+          },
+          {
+            "id": "google/gemini-2.5-pro",
+            "name": "Gemini 2.5 Pro",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1000000,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 1.25,
+              "output": 10,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "supportsStore": false,
+              "supportsDeveloperRole": false,
+              "supportsReasoningEffort": false,
+              "supportsUsageInStreaming": false,
+              "supportsStrictMode": false,
+              "maxTokensField": "max_tokens"
+            }
+          },
+          {
+            "id": "google/gemini-3.1-flash-lite",
+            "name": "Gemini 3.1 Flash Lite",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 1048576,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 0.25,
+              "output": 1.5,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "supportsStore": false,
+              "supportsDeveloperRole": false,
+              "supportsReasoningEffort": false,
+              "supportsUsageInStreaming": false,
+              "supportsStrictMode": false,
+              "maxTokensField": "max_tokens"
+            }
+          },
+          {
+            "id": "google/gemini-3.5-flash",
+            "name": "Gemini 3.5 Flash",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1000000,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 1.5,
+              "output": 9,
+              "cacheRead": 0.15,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "supportsStore": false,
+              "supportsDeveloperRole": false,
+              "supportsReasoningEffort": false,
+              "supportsUsageInStreaming": false,
+              "supportsStrictMode": false,
+              "maxTokensField": "max_tokens"
+            }
+          },
+          {
+            "id": "google/gemini-3-pro",
+            "name": "Gemini 3 Pro Preview",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 1000000,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 1.25,
+              "output": 15,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "supportsStore": false,
+              "supportsDeveloperRole": false,
+              "supportsReasoningEffort": false,
+              "supportsUsageInStreaming": false,
+              "supportsStrictMode": false,
+              "maxTokensField": "max_tokens"
+            }
+          },
+          {
+            "id": "google/gemma-4-31B-it",
+            "name": "Gemma 4 31B Instruct",
+            "reasoning": false,
+            "input": ["text"],
+            "contextWindow": 262144,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 0.13,
+              "output": 0.4,
+              "cacheRead": 0.026,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "supportsStore": false,
+              "supportsDeveloperRole": false,
+              "supportsReasoningEffort": false,
+              "supportsUsageInStreaming": false,
+              "supportsStrictMode": false,
+              "maxTokensField": "max_tokens"
+            }
+          },
+          {
+            "id": "openai/gpt-4.1",
+            "name": "OpenAI GPT-4.1",
+            "reasoning": false,
+            "input": ["text", "image"],
+            "contextWindow": 1000000,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 2,
+              "output": 8,
+              "cacheRead": 0.5,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "supportsStore": false,
+              "supportsDeveloperRole": false,
+              "supportsReasoningEffort": false,
+              "supportsUsageInStreaming": false,
+              "supportsStrictMode": false,
+              "maxTokensField": "max_tokens"
+            }
+          },
+          {
+            "id": "openai/gpt-4.1-mini",
+            "name": "OpenAI GPT-4.1 Mini",
+            "reasoning": false,
+            "input": ["text", "image"],
+            "contextWindow": 1000000,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 0.4,
+              "output": 1.6,
+              "cacheRead": 0.1,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "supportsStore": false,
+              "supportsDeveloperRole": false,
+              "supportsReasoningEffort": false,
+              "supportsUsageInStreaming": false,
+              "supportsStrictMode": false,
+              "maxTokensField": "max_tokens"
+            }
+          },
+          {
+            "id": "openai/gpt-4.1-nano",
+            "name": "OpenAI GPT-4.1 Nano",
+            "reasoning": false,
+            "input": ["text", "image"],
+            "contextWindow": 1000000,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 0.1,
+              "output": 0.4,
+              "cacheRead": 0.025,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "supportsStore": false,
+              "supportsDeveloperRole": false,
+              "supportsReasoningEffort": false,
+              "supportsUsageInStreaming": false,
+              "supportsStrictMode": false,
+              "maxTokensField": "max_tokens"
+            }
+          },
+          {
+            "id": "openai/gpt-5",
+            "name": "OpenAI GPT-5",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 400000,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 1.25,
+              "output": 10,
+              "cacheRead": 0.125,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "supportsStore": false,
+              "supportsDeveloperRole": false,
+              "supportsReasoningEffort": false,
+              "supportsUsageInStreaming": false,
+              "supportsStrictMode": false,
+              "maxTokensField": "max_tokens"
+            }
+          },
+          {
+            "id": "openai/gpt-5.1",
+            "name": "GPT-5.1",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 400000,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 1.25,
+              "output": 10,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "supportsStore": false,
+              "supportsDeveloperRole": false,
+              "supportsReasoningEffort": false,
+              "supportsUsageInStreaming": false,
+              "supportsStrictMode": false,
+              "maxTokensField": "max_tokens"
+            }
+          },
+          {
+            "id": "openai/gpt-5.2",
+            "name": "OpenAI GPT-5.2",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 400000,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 1.8,
+              "output": 15.5,
+              "cacheRead": 0.18,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "supportsStore": false,
+              "supportsDeveloperRole": false,
+              "supportsReasoningEffort": false,
+              "supportsUsageInStreaming": false,
+              "supportsStrictMode": false,
+              "maxTokensField": "max_tokens"
+            }
+          },
+          {
+            "id": "openai/gpt-5.4",
+            "name": "GPT-5.4",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 1050000,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 2.5,
+              "output": 15,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "supportsStore": false,
+              "supportsDeveloperRole": false,
+              "supportsReasoningEffort": false,
+              "supportsUsageInStreaming": false,
+              "supportsStrictMode": false,
+              "maxTokensField": "max_tokens"
+            }
+          },
+          {
+            "id": "openai/gpt-5.4-mini",
+            "name": "GPT-5.4 Mini",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 400000,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 0.75,
+              "output": 4.5,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "supportsStore": false,
+              "supportsDeveloperRole": false,
+              "supportsReasoningEffort": false,
+              "supportsUsageInStreaming": false,
+              "supportsStrictMode": false,
+              "maxTokensField": "max_tokens"
+            }
+          },
+          {
+            "id": "openai/gpt-5.4-nano",
+            "name": "GPT-5.4 Nano",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 400000,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 0.2,
+              "output": 1.25,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "supportsStore": false,
+              "supportsDeveloperRole": false,
+              "supportsReasoningEffort": false,
+              "supportsUsageInStreaming": false,
+              "supportsStrictMode": false,
+              "maxTokensField": "max_tokens"
+            }
+          },
+          {
+            "id": "openai/gpt-5.5",
+            "name": "GPT-5.5",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 1050000,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 5,
+              "output": 30,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "supportsStore": false,
+              "supportsDeveloperRole": false,
+              "supportsReasoningEffort": false,
+              "supportsUsageInStreaming": false,
+              "supportsStrictMode": false,
+              "maxTokensField": "max_tokens"
+            }
+          },
+          {
+            "id": "openai/gpt-5-mini",
+            "name": "GPT-5 Mini",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 400000,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 0.25,
+              "output": 2,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "supportsStore": false,
+              "supportsDeveloperRole": false,
+              "supportsReasoningEffort": false,
+              "supportsUsageInStreaming": false,
+              "supportsStrictMode": false,
+              "maxTokensField": "max_tokens"
+            }
+          },
+          {
+            "id": "openai/gpt-5-nano",
+            "name": "GPT-5 Nano",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 400000,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 0.05,
+              "output": 0.4,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "supportsStore": false,
+              "supportsDeveloperRole": false,
+              "supportsReasoningEffort": false,
+              "supportsUsageInStreaming": false,
+              "supportsStrictMode": false,
+              "maxTokensField": "max_tokens"
+            }
+          },
+          {
+            "id": "openai/gpt-oss-120b",
+            "name": "GPT OSS 120B",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 131000,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 0.15,
+              "output": 0.55,
+              "cacheRead": 0.03,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "supportsStore": false,
+              "supportsDeveloperRole": false,
+              "supportsReasoningEffort": false,
+              "supportsUsageInStreaming": false,
+              "supportsStrictMode": false,
+              "maxTokensField": "max_tokens"
+            }
+          },
+          {
+            "id": "openai/o3",
+            "name": "OpenAI o3",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 200000,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 2,
+              "output": 8,
+              "cacheRead": 1,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "supportsStore": false,
+              "supportsDeveloperRole": false,
+              "supportsReasoningEffort": false,
+              "supportsUsageInStreaming": false,
+              "supportsStrictMode": false,
+              "maxTokensField": "max_tokens"
+            }
+          },
+          {
+            "id": "openai/o3-mini",
+            "name": "o3 Mini",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 200000,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 1.1,
+              "output": 4.4,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "supportsStore": false,
+              "supportsDeveloperRole": false,
+              "supportsReasoningEffort": false,
+              "supportsUsageInStreaming": false,
+              "supportsStrictMode": false,
+              "maxTokensField": "max_tokens"
+            }
+          },
+          {
+            "id": "openai/o4-mini",
+            "name": "OpenAI o4 Mini",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 200000,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 1.1,
+              "output": 4.4,
+              "cacheRead": 0.55,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "supportsStore": false,
+              "supportsDeveloperRole": false,
+              "supportsReasoningEffort": false,
+              "supportsUsageInStreaming": false,
+              "supportsStrictMode": false,
+              "maxTokensField": "max_tokens"
+            }
+          },
+          {
+            "id": "Qwen/Qwen3-30B-A3B-Instruct-2507",
+            "name": "Qwen3 30B A3B Instruct 2507",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 262144,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 0.15,
+              "output": 0.55,
+              "cacheRead": 0.03,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "supportsStore": false,
+              "supportsDeveloperRole": false,
+              "supportsReasoningEffort": false,
+              "supportsUsageInStreaming": false,
+              "supportsStrictMode": false,
+              "maxTokensField": "max_tokens"
+            }
+          },
+          {
+            "id": "Qwen/Qwen3.5-122B-A10B",
+            "name": "Qwen3.5 122B A10B",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 131072,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 0.4,
+              "output": 3.2,
+              "cacheRead": 0.08,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "supportsStore": false,
+              "supportsDeveloperRole": false,
+              "supportsReasoningEffort": false,
+              "supportsUsageInStreaming": false,
+              "supportsStrictMode": false,
+              "maxTokensField": "max_tokens"
+            }
+          },
+          {
+            "id": "Qwen/Qwen3.6-35B-A3B-FP8",
+            "name": "Qwen 3.6 35B A3B FP8",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 262144,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 0.17,
+              "output": 1.1,
+              "cacheRead": 0.056,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "supportsStore": false,
+              "supportsDeveloperRole": false,
+              "supportsReasoningEffort": false,
+              "supportsUsageInStreaming": false,
+              "supportsStrictMode": false,
+              "maxTokensField": "max_tokens"
+            }
+          },
+          {
+            "id": "Qwen/Qwen3-VL-30B-A3B-Instruct",
+            "name": "Qwen3-VL-30B-A3B-Instruct",
+            "reasoning": false,
+            "input": ["text", "image"],
+            "contextWindow": 256000,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 0.15,
+              "output": 0.55,
+              "cacheRead": 0.03,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "supportsStore": false,
+              "supportsDeveloperRole": false,
+              "supportsReasoningEffort": false,
+              "supportsUsageInStreaming": false,
+              "supportsStrictMode": false,
+              "maxTokensField": "max_tokens"
+            }
+          },
+          {
+            "id": "zai-org/GLM-5.1-FP8",
+            "name": "GLM 5.1",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 202752,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 0.85,
+              "output": 3.3,
+              "cacheRead": 0.17,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "supportsStore": false,
+              "supportsDeveloperRole": false,
+              "supportsReasoningEffort": false,
+              "supportsUsageInStreaming": false,
+              "supportsStrictMode": false,
+              "maxTokensField": "max_tokens"
+            }
+          }
+        ]
+      }
+    },
+    "discovery": {
+      "nearai": "refreshable"
+    }
+  }
+}

--- a/extensions/nearai/package.json
+++ b/extensions/nearai/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@openclaw/nearai-provider",
+  "version": "2026.5.20",
+  "private": true,
+  "description": "OpenClaw NEAR AI Cloud provider plugin",
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/nearai/provider-catalog.ts
+++ b/extensions/nearai/provider-catalog.ts
@@ -1,0 +1,24 @@
+import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import {
+  buildNearAIModelDefinition,
+  discoverNearAIModels,
+  NEARAI_BASE_URL,
+  NEARAI_MODEL_CATALOG,
+} from "./models.js";
+
+export function buildStaticNearAIProvider(): ModelProviderConfig {
+  return {
+    baseUrl: NEARAI_BASE_URL,
+    api: "openai-completions",
+    models: NEARAI_MODEL_CATALOG.map(buildNearAIModelDefinition),
+  };
+}
+
+export async function buildNearAIProvider(): Promise<ModelProviderConfig> {
+  const models = await discoverNearAIModels();
+  return {
+    baseUrl: NEARAI_BASE_URL,
+    api: "openai-completions",
+    models,
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1160,6 +1160,12 @@ importers:
         specifier: 2026.5.28
         version: 2026.5.28
 
+  extensions/nearai:
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+
   extensions/nextcloud-talk:
     dependencies:
       zod:

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -460,6 +460,7 @@ const BUILT_IN_MODEL_PROVIDER_OVERLAY_IDS = new Set([
   "mistral",
   "modelstudio",
   "moonshot",
+  "nearai",
   "nvidia",
   "ollama",
   "openai",

--- a/test/vitest-scoped-config.test.ts
+++ b/test/vitest-scoped-config.test.ts
@@ -660,6 +660,7 @@ describe("scoped vitest configs", () => {
       "mistral/**/*.test.ts",
       "qwen/**/*.test.ts",
       "moonshot/**/*.test.ts",
+      "nearai/**/*.test.ts",
       "nvidia/**/*.test.ts",
       "ollama/**/*.test.ts",
       "openrouter/**/*.test.ts",

--- a/test/vitest/vitest.extension-provider-paths.mjs
+++ b/test/vitest/vitest.extension-provider-paths.mjs
@@ -22,6 +22,7 @@ export const providerExtensionIds = [
   "mistral",
   "qwen",
   "moonshot",
+  "nearai",
   "nvidia",
   "ollama",
   "openrouter",


### PR DESCRIPTION
## Summary

- Problem: OpenClaw does not currently expose NEAR AI Cloud as a bundled model provider.
- Solution: Adds a bundled `nearai` provider plugin for NEAR AI Cloud's OpenAI-compatible API at `https://cloud-api.near.ai/v1`.
- What changed: Adds API-key onboarding for `NEARAI_API_KEY`, dynamic public model catalog discovery with a static fallback, OpenAI-compatible replay/compat metadata, provider docs, generated plugin inventory entries, and focused tests.
- What did NOT change (scope boundary): No generic Gateway transport changes and no live provider use unless a user explicitly configures NEAR AI Cloud.
- Review note: AI-assisted.

## Motivation

- Users can configure NEAR AI Cloud TEE-backed inference through the same provider onboarding and model catalog surfaces as other bundled OpenAI-compatible providers.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: NEAR AI Cloud appears as a built-in provider and exposes its model catalog.
- Real environment tested: Linux source checkout using the project CLI.
- Exact steps or command run after this patch: `pnpm openclaw models list --all --provider nearai`
- Evidence after fix:

```text
Model                                      Input      Ctx         Local Auth  Tags
nearai/anthropic/claude-haiku-4-5          text+image 195k        no    no
nearai/openai/gpt-5.5                      text       1025k       no    no
nearai/Qwen/Qwen3.6-35B-A3B-FP8            text       256k        no    no
nearai/zai-org/GLM-5.1-FP8                 text       198k        no    no
```

- Observed result after fix: The `nearai` provider resolves and lists NEAR AI Cloud model refs, including the default `nearai/zai-org/GLM-5.1-FP8`.
- What was not tested: Live inference, because `NEARAI_API_KEY` was not available in the test environment.
- Before evidence optional: Previous versions do not expose a bundled nearai provider, so the post-patch CLI output above is the after-fix proof for the newly added provider.

## Root Cause (if applicable)

N/A

## Regression Test Plan (if applicable)

N/A

## User-visible / Behavior Changes

- Adds `NEAR AI Cloud` / `nearai` as a built-in provider option.
- Adds `NEARAI_API_KEY`, `--auth-choice nearai-api-key`, and `--nearai-api-key <key>` setup paths.
- Adds provider documentation at `/providers/nearai`.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes`)
- Secrets/tokens handling changed? (`Yes`)
- New/changed network calls? (`Yes`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: This adds an optional outbound model provider that uses the existing provider auth path for `NEARAI_API_KEY`. Runtime catalog refresh is pinned to `cloud-api.near.ai` through the existing SSRF guard, and inference only occurs when the user chooses/configures the provider.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local source checkout with project scripts
- Model/provider: `nearai`
- Integration/channel (if any): N/A
- Relevant config (redacted): No live NEAR AI API key configured

### Steps

1. `node scripts/run-vitest.mjs extensions/nearai`
2. `node scripts/run-vitest.mjs src/plugins/contracts/registry.contract.test.ts src/plugins/contracts/provider-family-plugin-tests.test.ts`
3. `node scripts/generate-plugin-inventory-doc.mjs --check`
4. `pnpm docs:list`
5. `pnpm docs:check-mdx`
6. `pnpm plugins:sync:check`
7. `pnpm openclaw models list --all --provider nearai`
8. `git diff --check`
9. `pnpm tsgo:prod`
10. `pnpm check:test-types`
11. `pnpm check:architecture`
12. `pnpm build:plugin-sdk:strict-smoke`
13. `node scripts/run-vitest.mjs test/vitest-scoped-config.test.ts`
14. `pnpm build:ci-artifacts`
15. `pnpm ui:build`

### Expected

- NEAR AI provider tests and plugin registry/provider-family contracts pass.
- Docs/plugin inventory checks pass.
- CLI lists `nearai/*` models.

### Actual

- All listed steps passed.
- Additional caveat: a broader bundled metadata test including `src/plugins/bundled-plugin-metadata.test.ts` currently fails on an unrelated `policy` startup-plugin expectation; this PR does not touch that plugin or expectation.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: provider registration/onboarding, catalog build, public catalog mapping/filtering/fallback, docs/plugin inventory generation, and CLI provider model listing.
- Edge cases checked: retryable discovery failure falls back to the static catalog; non-chat utility rows are filtered; model compatibility flags use `max_tokens` and disable unsupported OpenAI-only fields.
- What you did **not** verify: live chat completion against NEAR AI Cloud because no `NEARAI_API_KEY` was available.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`Yes`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: Users who want NEAR AI Cloud can set `NEARAI_API_KEY` or run `openclaw onboard --auth-choice nearai-api-key`.

## Risks and Mitigations

- Risk: The bundled static fallback catalog may become stale as NEAR AI Cloud changes models.
  - Mitigation: The provider refreshes from NEAR AI Cloud's public model list at runtime and falls back to the bundled catalog only when discovery is unavailable.
- Risk: Live inference behavior was not exercised in this environment.
  - Mitigation: The implementation uses OpenClaw's existing OpenAI-compatible provider transport and includes unit coverage for request-shape compatibility metadata.



