### PR TITLE
fix(plugins): allow disabled migration provider plugins to be discovered and loaded

### DIFF
--- a/src/plugins/manifest-contract-eligibility.ts
+++ b/src/plugins/manifest-contract-eligibility.ts
@@ -16,8 +16,12 @@ export function isManifestPluginAvailableForControlPlane(params: {
     "id" | "origin" | "enabledByDefault" | "enabledByDefaultOnPlatforms"
   >;
   config?: OpenClawConfig;
+  allowDisabled?: boolean;
 }): boolean {
   if (params.plugin.origin === "bundled") {
+    return true;
+  }
+  if (params.allowDisabled) {
     return true;
   }
   return isInstalledPluginEnabled(params.snapshot.index, params.plugin.id, params.config);
@@ -37,6 +41,7 @@ export function listAvailableManifestContractPlugins(params: {
   contract: PluginManifestContractListKey;
   value?: string;
   config?: OpenClawConfig;
+  allowDisabled?: boolean;
 }): PluginManifestRecord[] {
   return params.snapshot.plugins.filter(
     (plugin) =>
@@ -49,6 +54,7 @@ export function listAvailableManifestContractPlugins(params: {
         snapshot: params.snapshot,
         plugin,
         config: params.config,
+        allowDisabled: params.allowDisabled,
       }),
   );
 }

--- a/src/plugins/manifest-contract-runtime.ts
+++ b/src/plugins/manifest-contract-runtime.ts
@@ -40,6 +40,7 @@ export function resolveManifestContractRuntimePluginResolution(params: {
     contract: params.contract,
     value: params.value,
     config: params.cfg,
+    allowDisabled: params.contract === "migrationProviders",
   }).map((plugin) => plugin.id);
   return {
     pluginIds: [...new Set(pluginIds)].toSorted((left, right) => left.localeCompare(right)),

--- a/src/plugins/migration-provider-runtime.test.ts
+++ b/src/plugins/migration-provider-runtime.test.ts
@@ -165,6 +165,53 @@ describe("migration provider runtime", () => {
     });
   });
 
+  it("standalone-loads disabled installed/external migration providers through compat config", () => {
+    mocks.loadPluginRegistrySnapshot.mockReturnValue(
+      createMockPluginIndex([
+        {
+          pluginId: "disabled-migration",
+          origin: "installed",
+          enabled: false,
+        },
+      ]),
+    );
+    mocks.loadPluginManifestRegistry.mockImplementation(() => ({
+      diagnostics: [],
+      plugins: [
+        {
+          id: "disabled-migration",
+          origin: "installed",
+          contracts: { migrationProviders: ["disabled-import"] },
+        },
+      ],
+    }));
+
+    ensureStandaloneMigrationProviderRegistryLoaded({
+      cfg: { plugins: { enabled: false } } as OpenClawConfig,
+    });
+
+    const standaloneParams = requireMockCallArg(
+      mocks.ensureStandaloneRuntimePluginRegistryLoaded,
+      "ensureStandaloneRuntimePluginRegistryLoaded",
+    ) as {
+      surface?: unknown;
+      requiredPluginIds?: unknown;
+      loadOptions?: {
+        activate?: unknown;
+        onlyPluginIds?: unknown;
+        config?: OpenClawConfig;
+      };
+    };
+    expect(standaloneParams.surface).toBe("active");
+    expect(standaloneParams.requiredPluginIds).toEqual(["disabled-migration"]);
+    expect(standaloneParams.loadOptions?.activate).toBe(false);
+    expect(standaloneParams.loadOptions?.onlyPluginIds).toEqual(["disabled-migration"]);
+    expect(standaloneParams.loadOptions?.config?.plugins?.enabled).toBe(true);
+    expect(standaloneParams.loadOptions?.config?.plugins?.entries).toEqual({
+      "disabled-migration": { enabled: true },
+    });
+  });
+
   it("loads configured external migration-provider plugins from manifest contracts", () => {
     const cfg = {
       plugins: { entries: { "external-migration": { enabled: true } } },
@@ -245,7 +292,7 @@ describe("migration provider runtime", () => {
     expect(manifestParams.includeDisabled).toBe(true);
     expect(mocks.resolveRuntimePluginRegistry).toHaveBeenNthCalledWith(1);
     expect(mocks.resolveRuntimePluginRegistry).toHaveBeenCalledWith({
-      onlyPluginIds: ["external-migration"],
+      onlyPluginIds: ["disabled-external-migration", "external-migration"],
     });
   });
 
@@ -369,5 +416,46 @@ describe("migration provider runtime", () => {
       "active-import",
       "external-import",
     ]);
+  });
+
+  it("resolves disabled installed migration providers from manifest contracts", () => {
+    const provider = createMigrationProvider("disabled-import");
+    const active = createEmptyPluginRegistry();
+    const loaded = createEmptyPluginRegistry();
+    loaded.migrationProviders.push({
+      pluginId: "disabled-migration",
+      pluginName: "Disabled Migration",
+      source: "test",
+      provider,
+    } as never);
+    mocks.resolveRuntimePluginRegistry.mockImplementation((params?: unknown) =>
+      params === undefined ? active : loaded,
+    );
+    mocks.loadPluginRegistrySnapshot.mockReturnValue(
+      createMockPluginIndex([
+        {
+          pluginId: "disabled-migration",
+          origin: "installed",
+          enabled: false,
+        },
+      ]),
+    );
+    mocks.loadPluginManifestRegistry.mockImplementation(() => ({
+      diagnostics: [],
+      plugins: [
+        {
+          id: "disabled-migration",
+          origin: "installed",
+          contracts: { migrationProviders: ["disabled-import"] },
+        },
+      ],
+    }));
+
+    const resolved = resolvePluginMigrationProvider({ providerId: "disabled-import" });
+
+    expect(resolved).toBe(provider);
+    expect(mocks.resolveRuntimePluginRegistry).toHaveBeenCalledWith({
+      onlyPluginIds: ["disabled-migration"],
+    });
   });
 });

--- a/src/plugins/migration-provider-runtime.ts
+++ b/src/plugins/migration-provider-runtime.ts
@@ -68,7 +68,7 @@ export function ensureStandaloneMigrationProviderRegistryLoaded(
   }
   const compatConfig = resolveMigrationProviderConfig({
     cfg: params.cfg,
-    bundledCompatPluginIds: resolution.bundledCompatPluginIds,
+    bundledCompatPluginIds: resolution.pluginIds,
   });
   ensureStandaloneRuntimePluginRegistryLoaded({
     surface: "active",


### PR DESCRIPTION
Bypasses enablement check specifically for plugins implementing the migrationProviders contract, allowing them to be discovered and loaded during migration commands even if they are disabled in config.