### PR TITLE
fix(agent): await local agent_end hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/Anthropic: preserve unsafe integer tool-call input values in streamed Anthropic tool-use JSON, preventing Discord-style IDs from being rounded before dispatch. Fixes #47229. (#83063) Thanks @leno23.
+- Agents/hooks: wait for local one-shot CLI and Codex `agent_end` plugin hooks before process cleanup so terminal observability flushes reliably. (#85007)
 - CLI/agents: allow `openclaw agent --session-key` to target explicit session keys, including agent-scoped legacy keys. (#85121) Thanks @Kaspre.
 - Auto-reply/ACP: wait for same-channel block reply delivery before starting tool work, while still honoring ACP dispatch aborts so stopped turns do not wait on slow channel sends. (#83722) Thanks @IWhatsskill.
 - Codex/ACP: mark required child-run completions that only report progress, omit a final deliverable, or fail requester delivery as blocked while preserving real final reports. (#85110) Thanks @IWhatsskill.

--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -277,11 +277,13 @@ as `discord` or `telegram`, while `ctx.channelId` is the conversation target
 identifier when OpenClaw can derive one from the session key or delivery
 metadata.
 
-`agent_end` is an observation hook and runs fire-and-forget after the turn. The
-hook runner applies a 30 second timeout so a wedged plugin or embedding
-endpoint cannot leave the hook promise pending forever. A timeout is logged and
-OpenClaw continues; it does not cancel plugin-owned network work unless the
-plugin also uses its own abort signal.
+`agent_end` is an observation hook. Gateway and persistent harness paths run it
+fire-and-forget after the turn, while short-lived one-shot CLI paths wait for the
+hook promise before process cleanup so trusted plugins can flush terminal
+observability or capture state. The hook runner applies a 30 second timeout so a
+wedged plugin or embedding endpoint cannot leave the hook promise pending
+forever. A timeout is logged and OpenClaw continues; it does not cancel
+plugin-owned network work unless the plugin also uses its own abort signal.
 
 Use `model_call_started` and `model_call_ended` for provider-call telemetry
 that should not receive raw prompts, history, responses, headers, request

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -6084,12 +6084,11 @@ describe("runCodexAppServerAttempt", () => {
 
     await harness.waitForMethod("turn/start");
     await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
-    await new Promise<void>((resolve) => setImmediate(resolve));
 
-    expect(agentEnd).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(agentEnd).toHaveBeenCalledTimes(1), fastWait);
     expect(settled).toBe(false);
     releaseAgentEnd();
-    await expect(run).resolves.toMatchObject({ promptError: undefined });
+    await expect(run).resolves.toMatchObject({ promptError: null });
     expect(settled).toBe(true);
   });
 
@@ -6114,7 +6113,7 @@ describe("runCodexAppServerAttempt", () => {
     await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
     const result = await run;
 
-    expect(result.promptError).toBeUndefined();
+    expect(result.promptError).toBeNull();
     expect(agentEnd).toHaveBeenCalledTimes(1);
     releaseAgentEnd();
   });

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -6064,6 +6064,93 @@ describe("runCodexAppServerAttempt", () => {
     expect(agentEndContext.sessionId).toBe("session-1");
   });
 
+  it("waits for agent_end hooks before resolving local codex turns", async () => {
+    let releaseAgentEnd: () => void = () => undefined;
+    const agentEndSettled = new Promise<void>((resolve) => {
+      releaseAgentEnd = resolve;
+    });
+    const agentEnd = vi.fn(() => agentEndSettled);
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "agent_end", handler: agentEnd }]),
+    );
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const harness = createStartedThreadHarness();
+    const run = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir));
+    let settled = false;
+    void run.then(() => {
+      settled = true;
+    });
+
+    await harness.waitForMethod("turn/start");
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(agentEnd).toHaveBeenCalledTimes(1);
+    expect(settled).toBe(false);
+    releaseAgentEnd();
+    await expect(run).resolves.toMatchObject({ promptError: undefined });
+    expect(settled).toBe(true);
+  });
+
+  it("does not wait for agent_end hooks before resolving channel-backed codex turns", async () => {
+    let releaseAgentEnd: () => void = () => undefined;
+    const agentEndSettled = new Promise<void>((resolve) => {
+      releaseAgentEnd = resolve;
+    });
+    const agentEnd = vi.fn(() => agentEndSettled);
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "agent_end", handler: agentEnd }]),
+    );
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const harness = createStartedThreadHarness();
+    const params = createParams(sessionFile, workspaceDir);
+    params.messageChannel = "discord";
+    params.messageProvider = "discord";
+    const run = runCodexAppServerAttempt(params);
+
+    await harness.waitForMethod("turn/start");
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    const result = await run;
+
+    expect(result.promptError).toBeUndefined();
+    expect(agentEnd).toHaveBeenCalledTimes(1);
+    releaseAgentEnd();
+  });
+
+  it("waits for agent_end hooks before rejecting local codex turn-start failures", async () => {
+    let releaseAgentEnd: () => void = () => undefined;
+    const agentEndSettled = new Promise<void>((resolve) => {
+      releaseAgentEnd = resolve;
+    });
+    const agentEnd = vi.fn(() => agentEndSettled);
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "agent_end", handler: agentEnd }]),
+    );
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    createStartedThreadHarness(async (method) => {
+      if (method === "turn/start") {
+        throw new Error("turn start exploded");
+      }
+      return undefined;
+    });
+    const run = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir));
+    let rejected = false;
+    void run.catch(() => {
+      rejected = true;
+    });
+
+    await vi.waitFor(() => expect(agentEnd).toHaveBeenCalledTimes(1), fastWait);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(rejected).toBe(false);
+    releaseAgentEnd();
+    await expect(run).rejects.toThrow("turn start exploded");
+    expect(rejected).toBe(true);
+  });
+
   it("forwards Codex app-server verbose tool summaries and completed output", async () => {
     const onToolResult = vi.fn();
     const sessionFile = path.join(tempDir, "session.jsonl");

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -6749,6 +6749,7 @@ describe("runCodexAppServerAttempt", () => {
     expect(harness.requests.map((request) => request.method)).toEqual([
       "thread/start",
       "turn/start",
+      "thread/unsubscribe",
     ]);
     const binding = await readCodexAppServerBinding(sessionFile);
     expect(binding?.threadId).toBe("thread-existing");
@@ -6775,6 +6776,7 @@ describe("runCodexAppServerAttempt", () => {
     expect(harness.requests.map((request) => request.method)).toEqual([
       "thread/resume",
       "turn/start",
+      "thread/unsubscribe",
     ]);
     const binding = await readCodexAppServerBinding(sessionFile);
     expect(binding?.threadId).toBe("thread-existing");

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -28,6 +28,7 @@ import {
   resolveSandboxContext,
   resolveSessionAgentIds,
   resolveUserPath,
+  awaitAgentHarnessAgentEndHook,
   runAgentHarnessAgentEndHook,
   runAgentHarnessLlmInputHook,
   runAgentHarnessLlmOutputHook,
@@ -768,6 +769,23 @@ async function rotateOversizedCodexAppServerStartupBinding(params: {
     return undefined;
   }
   return binding;
+}
+
+type CodexAgentEndHookParams = Parameters<typeof runAgentHarnessAgentEndHook>[0];
+
+function shouldAwaitCodexAgentEndHook(params: EmbeddedRunAttemptParams): boolean {
+  return !params.messageChannel && !params.messageProvider;
+}
+
+async function runCodexAgentEndHook(
+  params: EmbeddedRunAttemptParams,
+  hookParams: CodexAgentEndHookParams,
+): Promise<void> {
+  if (shouldAwaitCodexAgentEndHook(params)) {
+    await awaitAgentHarnessAgentEndHook(hookParams);
+    return;
+  }
+  runAgentHarnessAgentEndHook(hookParams);
 }
 
 export async function runCodexAppServerAttempt(
@@ -2581,7 +2599,7 @@ export async function runCodexAppServerAttempt(
         },
         ctx: hookContext,
       });
-      void runAgentHarnessAgentEndHook({
+      await runCodexAgentEndHook(params, {
         event: {
           messages: buildTurnStartFailureMessages(),
           success: false,
@@ -2894,7 +2912,7 @@ export async function runCodexAppServerAttempt(
       },
       ctx: hookContext,
     });
-    void runAgentHarnessAgentEndHook({
+    await runCodexAgentEndHook(params, {
       event: {
         messages: result.messagesSnapshot,
         success: !finalAborted && !finalPromptError,

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -2581,7 +2581,7 @@ export async function runCodexAppServerAttempt(
         },
         ctx: hookContext,
       });
-      runAgentHarnessAgentEndHook({
+      void runAgentHarnessAgentEndHook({
         event: {
           messages: buildTurnStartFailureMessages(),
           success: false,
@@ -2894,7 +2894,7 @@ export async function runCodexAppServerAttempt(
       },
       ctx: hookContext,
     });
-    runAgentHarnessAgentEndHook({
+    void runAgentHarnessAgentEndHook({
       event: {
         messages: result.messagesSnapshot,
         success: !finalAborted && !finalPromptError,

--- a/scripts/deadcode-unused-files.allowlist.mjs
+++ b/scripts/deadcode-unused-files.allowlist.mjs
@@ -11,6 +11,8 @@ export const KNIP_UNUSED_FILE_ALLOWLIST = [
   "extensions/diffs/src/viewer-payload.ts",
   "extensions/matrix/src/plugin-entry.runtime.js",
   "extensions/memory-core/src/memory-tool-manager-mock.ts",
+  "extensions/qa-lab/src/auth-profile-fixture.ts",
+  "extensions/qa-lab/src/codex-plugin-fixture.ts",
   "src/agents/subagent-registry.runtime.ts",
   "src/auto-reply/inbound.group-require-mention-test-plugins.ts",
   "src/auto-reply/reply/get-reply.test-loader.ts",

--- a/scripts/deadcode-unused-files.allowlist.mjs
+++ b/scripts/deadcode-unused-files.allowlist.mjs
@@ -11,8 +11,6 @@ export const KNIP_UNUSED_FILE_ALLOWLIST = [
   "extensions/diffs/src/viewer-payload.ts",
   "extensions/matrix/src/plugin-entry.runtime.js",
   "extensions/memory-core/src/memory-tool-manager-mock.ts",
-  "extensions/qa-lab/src/auth-profile-fixture.ts",
-  "extensions/qa-lab/src/codex-plugin-fixture.ts",
   "src/agents/subagent-registry.runtime.ts",
   "src/auto-reply/inbound.group-require-mention-test-plugins.ts",
   "src/auto-reply/reply/get-reply.test-loader.ts",

--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -950,9 +950,9 @@ describe("runCliAgent reliability", () => {
       }),
     );
 
-    const result = await runPreparedCliAgent(buildPreparedContext());
-
-    expect(result.payloads).toBeUndefined();
+    await expect(runPreparedCliAgent(buildPreparedContext())).rejects.toThrow(
+      "CLI backend returned an empty response.",
+    );
     expect(hookRunner.runLlmOutput).not.toHaveBeenCalled();
   });
 

--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -706,6 +706,51 @@ describe("runCliAgent reliability", () => {
     }
   });
 
+  it("waits for agent_end hooks before resolving successful CLI runs", async () => {
+    let releaseAgentEnd: () => void = () => undefined;
+    const agentEndSettled = new Promise<void>((resolve) => {
+      releaseAgentEnd = resolve;
+    });
+    const hookRunner = {
+      hasHooks: vi.fn((hookName: string) => hookName === "agent_end"),
+      runLlmInput: vi.fn(async () => undefined),
+      runLlmOutput: vi.fn(async () => undefined),
+      runAgentEnd: vi.fn(() => agentEndSettled),
+    };
+    setHookRunnerForTest(hookRunner);
+
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: "hello from cli",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+
+    let resolved = false;
+    const run = runPreparedCliAgent(buildPreparedContext()).then((result) => {
+      resolved = true;
+      return result;
+    });
+
+    await vi.waitFor(() => {
+      expect(hookRunner.runAgentEnd).toHaveBeenCalledTimes(1);
+    });
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    releaseAgentEnd();
+    await expect(run).resolves.toMatchObject({
+      payloads: [{ text: "hello from cli" }],
+    });
+    expect(resolved).toBe(true);
+  });
+
   it("blocks CLI runs before llm_input and model execution when before_agent_run blocks", async () => {
     supervisorSpawnMock.mockClear();
     const hookRunner = {

--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -751,6 +751,63 @@ describe("runCliAgent reliability", () => {
     expect(resolved).toBe(true);
   });
 
+  it("does not wait for agent_end hooks before resolving channel-backed CLI runs", async () => {
+    let releaseAgentEnd: () => void = () => undefined;
+    const agentEndSettled = new Promise<void>((resolve) => {
+      releaseAgentEnd = resolve;
+    });
+    const hookRunner = {
+      hasHooks: vi.fn((hookName: string) => hookName === "agent_end"),
+      runLlmInput: vi.fn(async () => undefined),
+      runLlmOutput: vi.fn(async () => undefined),
+      runAgentEnd: vi.fn(() => agentEndSettled),
+    };
+    setHookRunnerForTest(hookRunner);
+
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: "hello from cli",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+
+    const context = buildPreparedContext();
+    let resolved = false;
+    const run = runPreparedCliAgent({
+      ...context,
+      params: {
+        ...context.params,
+        messageProvider: "acp",
+        messageChannel: "telegram",
+      },
+    }).then((result) => {
+      resolved = true;
+      return result;
+    });
+
+    await vi.waitFor(() => {
+      expect(hookRunner.runAgentEnd).toHaveBeenCalledTimes(1);
+    });
+    await vi.waitFor(() => {
+      expect(resolved).toBe(true);
+    });
+
+    await expect(run).resolves.toMatchObject({
+      payloads: [{ text: "hello from cli" }],
+    });
+    expect(callArg(hookRunner.runAgentEnd, 0, 2, "agent_end options")).toEqual({
+      unrefTimeout: true,
+    });
+
+    releaseAgentEnd();
+  });
+
   it("blocks CLI runs before llm_input and model execution when before_agent_run blocks", async () => {
     supervisorSpawnMock.mockClear();
     let releaseAgentEnd: () => void = () => undefined;

--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -753,6 +753,10 @@ describe("runCliAgent reliability", () => {
 
   it("blocks CLI runs before llm_input and model execution when before_agent_run blocks", async () => {
     supervisorSpawnMock.mockClear();
+    let releaseAgentEnd: () => void = () => undefined;
+    const agentEndSettled = new Promise<void>((resolve) => {
+      releaseAgentEnd = resolve;
+    });
     const hookRunner = {
       hasHooks: vi.fn((hookName: string) =>
         ["before_agent_run", "llm_input", "agent_end"].includes(hookName),
@@ -766,7 +770,7 @@ describe("runCliAgent reliability", () => {
         },
       })),
       runLlmInput: vi.fn(async () => undefined),
-      runAgentEnd: vi.fn(async () => undefined),
+      runAgentEnd: vi.fn(() => agentEndSettled),
     };
     setHookRunnerForTest(hookRunner);
     const { dir, sessionFile } = createSessionFile({
@@ -774,7 +778,8 @@ describe("runCliAgent reliability", () => {
     });
 
     try {
-      const result = await runPreparedCliAgent({
+      let resolved = false;
+      const run = runPreparedCliAgent({
         ...buildPreparedContext({ sessionKey: "agent:main:main", runId: "run-blocked-cli" }),
         params: {
           ...buildPreparedContext({ sessionKey: "agent:main:main", runId: "run-blocked-cli" })
@@ -784,7 +789,19 @@ describe("runCliAgent reliability", () => {
           workspaceDir: dir,
           prompt: "secret prompt",
         },
+      }).then((result) => {
+        resolved = true;
+        return result;
       });
+
+      await vi.waitFor(() => {
+        expect(hookRunner.runAgentEnd).toHaveBeenCalledTimes(1);
+      });
+      await Promise.resolve();
+      expect(resolved).toBe(false);
+
+      releaseAgentEnd();
+      const result = await run;
 
       expect(result.payloads).toEqual([
         {
@@ -814,9 +831,7 @@ describe("runCliAgent reliability", () => {
       expect(beforeRunContext.runId).toBe("run-blocked-cli");
       expect(beforeRunContext.agentId).toBe("main");
       expect(beforeRunContext.sessionKey).toBe("agent:main:main");
-      await vi.waitFor(() => {
-        expect(hookRunner.runAgentEnd).toHaveBeenCalledTimes(1);
-      });
+      expect(resolved).toBe(true);
       const agentEndEvent = requireRecord(
         callArg(hookRunner.runAgentEnd, 0, 0, "agent_end event"),
         "agent_end event",
@@ -885,11 +900,15 @@ describe("runCliAgent reliability", () => {
   });
 
   it("emits agent_end with failure details when the CLI run fails", async () => {
+    let releaseAgentEnd: () => void = () => undefined;
+    const agentEndSettled = new Promise<void>((resolve) => {
+      releaseAgentEnd = resolve;
+    });
     const hookRunner = {
       hasHooks: vi.fn((hookName: string) => ["llm_input", "agent_end"].includes(hookName)),
       runLlmInput: vi.fn(async () => undefined),
       runLlmOutput: vi.fn(async () => undefined),
-      runAgentEnd: vi.fn(async () => undefined),
+      runAgentEnd: vi.fn(() => agentEndSettled),
     };
     setHookRunnerForTest(hookRunner);
 
@@ -906,15 +925,22 @@ describe("runCliAgent reliability", () => {
       }),
     );
 
-    await expect(runPreparedCliAgent(buildPreparedContext())).rejects.toThrow(
-      "rate limit exceeded",
-    );
+    let settled = false;
+    const run = runPreparedCliAgent(buildPreparedContext()).finally(() => {
+      settled = true;
+    });
 
     await vi.waitFor(() => {
       expect(hookRunner.runLlmInput).toHaveBeenCalledTimes(1);
       expect(hookRunner.runLlmOutput).not.toHaveBeenCalled();
       expect(hookRunner.runAgentEnd).toHaveBeenCalledTimes(1);
     });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    releaseAgentEnd();
+    await expect(run).rejects.toThrow("rate limit exceeded");
+    expect(settled).toBe(true);
 
     const agentEndEvent = requireRecord(
       callArg(hookRunner.runAgentEnd, 0, 0, "agent_end event"),

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -22,6 +22,7 @@ import { buildAgentHookContext } from "./harness/hook-context.js";
 import { buildAgentHookConversationMessages } from "./harness/hook-history.js";
 import {
   awaitAgentHarnessAgentEndHook,
+  runAgentHarnessAgentEndHook,
   runAgentHarnessLlmInputHook,
   runAgentHarnessLlmOutputHook,
 } from "./harness/lifecycle-hook-helpers.js";
@@ -106,6 +107,23 @@ function buildCliContextEngineAssistantMessage(params: {
   };
 }): AgentMessage {
   return buildCliHookAssistantMessage(params) as AgentMessage;
+}
+
+type CliAgentEndHookParams = Parameters<typeof runAgentHarnessAgentEndHook>[0];
+
+function shouldAwaitCliAgentEndHook(params: RunCliAgentParams): boolean {
+  return !params.messageChannel && !params.messageProvider;
+}
+
+async function runCliAgentEndHook(
+  params: RunCliAgentParams,
+  hookParams: CliAgentEndHookParams,
+): Promise<void> {
+  if (shouldAwaitCliAgentEndHook(params)) {
+    await awaitAgentHarnessAgentEndHook(hookParams);
+    return;
+  }
+  runAgentHarnessAgentEndHook(hookParams);
 }
 
 async function finalizeCliContextEngineTurn(params: {
@@ -576,7 +594,7 @@ export async function runPreparedCliAgent(
           message: blockMessage,
           pluginId: "before_agent_run",
         });
-        await awaitAgentHarnessAgentEndHook({
+        await runCliAgentEndHook(params, {
           event: buildBlockedAgentEndEvent(blockMessage),
           ctx: hookContext,
           hookRunner,
@@ -593,7 +611,7 @@ export async function runPreparedCliAgent(
           message: blockMessage,
           pluginId: beforeRunResult?.pluginId ?? "unknown",
         });
-        await awaitAgentHarnessAgentEndHook({
+        await runCliAgentEndHook(params, {
           event: buildBlockedAgentEndEvent(blockMessage),
           ctx: hookContext,
           hookRunner,
@@ -619,7 +637,7 @@ export async function runPreparedCliAgent(
         assistantText,
         output,
       });
-      await awaitAgentHarnessAgentEndHook({
+      await runCliAgentEndHook(params, {
         event: {
           messages: buildAgentEndMessages(lastAssistant),
           success: true,
@@ -651,7 +669,7 @@ export async function runPreparedCliAgent(
               assistantText,
               output,
             });
-            await awaitAgentHarnessAgentEndHook({
+            await runCliAgentEndHook(params, {
               event: {
                 messages: buildAgentEndMessages(lastAssistant),
                 success: true,
@@ -663,7 +681,7 @@ export async function runPreparedCliAgent(
             return buildCliRunResult({ output, effectiveCliSessionId });
           } catch (retryErr) {
             const retryMessage = formatErrorMessage(retryErr);
-            await awaitAgentHarnessAgentEndHook({
+            await runCliAgentEndHook(params, {
               event: buildFailedAgentEndEvent(retryMessage),
               ctx: hookContext,
               hookRunner,
@@ -671,7 +689,7 @@ export async function runPreparedCliAgent(
             return toCliRunFailure(retryErr);
           }
         }
-        await awaitAgentHarnessAgentEndHook({
+        await runCliAgentEndHook(params, {
           event: buildFailedAgentEndEvent(formatErrorMessage(err)),
           ctx: hookContext,
           hookRunner,
@@ -679,7 +697,7 @@ export async function runPreparedCliAgent(
         throw err;
       }
       const message = formatErrorMessage(err);
-      await awaitAgentHarnessAgentEndHook({
+      await runCliAgentEndHook(params, {
         event: buildFailedAgentEndEvent(message),
         ctx: hookContext,
         hookRunner,

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -576,7 +576,7 @@ export async function runPreparedCliAgent(
           message: blockMessage,
           pluginId: "before_agent_run",
         });
-        runAgentHarnessAgentEndHook({
+        await runAgentHarnessAgentEndHook({
           event: buildBlockedAgentEndEvent(blockMessage),
           ctx: hookContext,
           hookRunner,
@@ -593,7 +593,7 @@ export async function runPreparedCliAgent(
           message: blockMessage,
           pluginId: beforeRunResult?.pluginId ?? "unknown",
         });
-        runAgentHarnessAgentEndHook({
+        await runAgentHarnessAgentEndHook({
           event: buildBlockedAgentEndEvent(blockMessage),
           ctx: hookContext,
           hookRunner,
@@ -619,7 +619,7 @@ export async function runPreparedCliAgent(
         assistantText,
         output,
       });
-      runAgentHarnessAgentEndHook({
+      await runAgentHarnessAgentEndHook({
         event: {
           messages: buildAgentEndMessages(lastAssistant),
           success: true,
@@ -651,7 +651,7 @@ export async function runPreparedCliAgent(
               assistantText,
               output,
             });
-            runAgentHarnessAgentEndHook({
+            await runAgentHarnessAgentEndHook({
               event: {
                 messages: buildAgentEndMessages(lastAssistant),
                 success: true,
@@ -663,7 +663,7 @@ export async function runPreparedCliAgent(
             return buildCliRunResult({ output, effectiveCliSessionId });
           } catch (retryErr) {
             const retryMessage = formatErrorMessage(retryErr);
-            runAgentHarnessAgentEndHook({
+            await runAgentHarnessAgentEndHook({
               event: buildFailedAgentEndEvent(retryMessage),
               ctx: hookContext,
               hookRunner,
@@ -671,7 +671,7 @@ export async function runPreparedCliAgent(
             return toCliRunFailure(retryErr);
           }
         }
-        runAgentHarnessAgentEndHook({
+        await runAgentHarnessAgentEndHook({
           event: buildFailedAgentEndEvent(formatErrorMessage(err)),
           ctx: hookContext,
           hookRunner,
@@ -679,7 +679,7 @@ export async function runPreparedCliAgent(
         throw err;
       }
       const message = formatErrorMessage(err);
-      runAgentHarnessAgentEndHook({
+      await runAgentHarnessAgentEndHook({
         event: buildFailedAgentEndEvent(message),
         ctx: hookContext,
         hookRunner,

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -21,7 +21,7 @@ import {
 import { buildAgentHookContext } from "./harness/hook-context.js";
 import { buildAgentHookConversationMessages } from "./harness/hook-history.js";
 import {
-  runAgentHarnessAgentEndHook,
+  awaitAgentHarnessAgentEndHook,
   runAgentHarnessLlmInputHook,
   runAgentHarnessLlmOutputHook,
 } from "./harness/lifecycle-hook-helpers.js";
@@ -576,7 +576,7 @@ export async function runPreparedCliAgent(
           message: blockMessage,
           pluginId: "before_agent_run",
         });
-        await runAgentHarnessAgentEndHook({
+        await awaitAgentHarnessAgentEndHook({
           event: buildBlockedAgentEndEvent(blockMessage),
           ctx: hookContext,
           hookRunner,
@@ -593,7 +593,7 @@ export async function runPreparedCliAgent(
           message: blockMessage,
           pluginId: beforeRunResult?.pluginId ?? "unknown",
         });
-        await runAgentHarnessAgentEndHook({
+        await awaitAgentHarnessAgentEndHook({
           event: buildBlockedAgentEndEvent(blockMessage),
           ctx: hookContext,
           hookRunner,
@@ -619,7 +619,7 @@ export async function runPreparedCliAgent(
         assistantText,
         output,
       });
-      await runAgentHarnessAgentEndHook({
+      await awaitAgentHarnessAgentEndHook({
         event: {
           messages: buildAgentEndMessages(lastAssistant),
           success: true,
@@ -651,7 +651,7 @@ export async function runPreparedCliAgent(
               assistantText,
               output,
             });
-            await runAgentHarnessAgentEndHook({
+            await awaitAgentHarnessAgentEndHook({
               event: {
                 messages: buildAgentEndMessages(lastAssistant),
                 success: true,
@@ -663,7 +663,7 @@ export async function runPreparedCliAgent(
             return buildCliRunResult({ output, effectiveCliSessionId });
           } catch (retryErr) {
             const retryMessage = formatErrorMessage(retryErr);
-            await runAgentHarnessAgentEndHook({
+            await awaitAgentHarnessAgentEndHook({
               event: buildFailedAgentEndEvent(retryMessage),
               ctx: hookContext,
               hookRunner,
@@ -671,7 +671,7 @@ export async function runPreparedCliAgent(
             return toCliRunFailure(retryErr);
           }
         }
-        await runAgentHarnessAgentEndHook({
+        await awaitAgentHarnessAgentEndHook({
           event: buildFailedAgentEndEvent(formatErrorMessage(err)),
           ctx: hookContext,
           hookRunner,
@@ -679,7 +679,7 @@ export async function runPreparedCliAgent(
         throw err;
       }
       const message = formatErrorMessage(err);
-      await runAgentHarnessAgentEndHook({
+      await awaitAgentHarnessAgentEndHook({
         event: buildFailedAgentEndEvent(message),
         ctx: hookContext,
         hookRunner,

--- a/src/agents/harness/lifecycle-hook-helpers.test.ts
+++ b/src/agents/harness/lifecycle-hook-helpers.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  awaitAgentHarnessAgentEndHook,
   clearAgentHarnessFinalizeRetryBudget,
   runAgentHarnessAgentEndHook,
   runAgentHarnessBeforeAgentFinalizeHook,
@@ -69,16 +70,47 @@ describe("agent harness lifecycle hook helpers", () => {
       runAgentEnd: vi.fn(() => agentEndSettled),
     };
 
-    const run = runAgentHarnessAgentEndHook({
+    const run = awaitAgentHarnessAgentEndHook({
       ctx: { runId: "run-1", sessionKey: "agent:main:session-1" },
       event: EVENT,
       hookRunner: hookRunner as never,
     });
+    let resolved = false;
+    void run.then(() => {
+      resolved = true;
+    });
 
     await Promise.resolve();
     expect(hookRunner.runAgentEnd).toHaveBeenCalledTimes(1);
+    expect(hookRunner.runAgentEnd).toHaveBeenCalledWith(
+      EVENT,
+      expect.objectContaining({ runId: "run-1", sessionKey: "agent:main:session-1" }),
+      { unrefTimeout: false },
+    );
+    expect(resolved).toBe(false);
     releaseHook();
     await expect(run).resolves.toBeUndefined();
+    expect(resolved).toBe(true);
+  });
+
+  it("can leave agent_end timeouts unref'd for fire-and-forget callers", async () => {
+    const hookRunner = {
+      hasHooks: vi.fn((hookName: string) => hookName === "agent_end"),
+      runAgentEnd: vi.fn(async () => undefined),
+    };
+
+    runAgentHarnessAgentEndHook({
+      ctx: { runId: "run-1", sessionKey: "agent:main:session-1" },
+      event: EVENT,
+      hookRunner: hookRunner as never,
+    });
+    await Promise.resolve();
+
+    expect(hookRunner.runAgentEnd).toHaveBeenCalledWith(
+      EVENT,
+      expect.objectContaining({ runId: "run-1", sessionKey: "agent:main:session-1" }),
+      { unrefTimeout: true },
+    );
   });
 
   it("continues when legacy hook runners advertise before_agent_finalize without a runner method", async () => {

--- a/src/agents/harness/lifecycle-hook-helpers.test.ts
+++ b/src/agents/harness/lifecycle-hook-helpers.test.ts
@@ -51,12 +51,34 @@ describe("agent harness lifecycle hook helpers", () => {
 
   it("ignores legacy hook runners that advertise agent_end without a runner method", () => {
     const hookRunner = createLegacyHookRunner();
-    runAgentHarnessAgentEndHook({
+    void runAgentHarnessAgentEndHook({
       ctx: {},
       event: {},
       hookRunner,
     } as never);
     expect(hookRunner.hasHooks).toHaveBeenCalledWith("agent_end");
+  });
+
+  it("resolves after agent_end hooks settle", async () => {
+    let releaseHook: () => void = () => undefined;
+    const agentEndSettled = new Promise<void>((resolve) => {
+      releaseHook = resolve;
+    });
+    const hookRunner = {
+      hasHooks: vi.fn((hookName: string) => hookName === "agent_end"),
+      runAgentEnd: vi.fn(() => agentEndSettled),
+    };
+
+    const run = runAgentHarnessAgentEndHook({
+      ctx: { runId: "run-1", sessionKey: "agent:main:session-1" },
+      event: EVENT,
+      hookRunner: hookRunner as never,
+    });
+
+    await Promise.resolve();
+    expect(hookRunner.runAgentEnd).toHaveBeenCalledTimes(1);
+    releaseHook();
+    await expect(run).resolves.toBeUndefined();
   });
 
   it("continues when legacy hook runners advertise before_agent_finalize without a runner method", async () => {

--- a/src/agents/harness/lifecycle-hook-helpers.test.ts
+++ b/src/agents/harness/lifecycle-hook-helpers.test.ts
@@ -23,6 +23,8 @@ const EVENT = {
   transcriptPath: "/tmp/session.jsonl",
   stopHookActive: false,
   lastAssistantMessage: "done",
+  messages: [],
+  success: true,
 };
 
 describe("agent harness lifecycle hook helpers", () => {
@@ -52,7 +54,7 @@ describe("agent harness lifecycle hook helpers", () => {
 
   it("ignores legacy hook runners that advertise agent_end without a runner method", () => {
     const hookRunner = createLegacyHookRunner();
-    void runAgentHarnessAgentEndHook({
+    runAgentHarnessAgentEndHook({
       ctx: {},
       event: {},
       hookRunner,

--- a/src/agents/harness/lifecycle-hook-helpers.ts
+++ b/src/agents/harness/lifecycle-hook-helpers.ts
@@ -8,6 +8,7 @@ import type {
   PluginHookLlmInputEvent,
   PluginHookLlmOutputEvent,
 } from "../../plugins/hook-types.js";
+import type { VoidHookRunOptions } from "../../plugins/hooks.js";
 import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
 import { buildAgentHookContext, type AgentHarnessHookContext } from "./hook-context.js";
 
@@ -88,20 +89,38 @@ export function runAgentHarnessLlmOutputHook(params: {
   });
 }
 
-export async function runAgentHarnessAgentEndHook(params: {
+async function executeAgentHarnessAgentEndHook(params: {
   event: PluginHookAgentEndEvent;
   ctx: AgentHarnessHookContext;
   hookRunner?: AgentHarnessHookRunner;
+  unrefTimeout?: boolean;
 }): Promise<void> {
   const hookRunner = params.hookRunner ?? getGlobalHookRunner();
   if (!hookRunner?.hasHooks("agent_end") || typeof hookRunner.runAgentEnd !== "function") {
     return;
   }
   try {
-    await hookRunner.runAgentEnd(params.event, buildAgentHookContext(params.ctx));
+    const options: VoidHookRunOptions = { unrefTimeout: params.unrefTimeout ?? false };
+    await hookRunner.runAgentEnd(params.event, buildAgentHookContext(params.ctx), options);
   } catch (error) {
     log.warn(`agent_end hook failed: ${String(error)}`);
   }
+}
+
+export function runAgentHarnessAgentEndHook(params: {
+  event: PluginHookAgentEndEvent;
+  ctx: AgentHarnessHookContext;
+  hookRunner?: AgentHarnessHookRunner;
+}): void {
+  void executeAgentHarnessAgentEndHook({ ...params, unrefTimeout: true });
+}
+
+export async function awaitAgentHarnessAgentEndHook(params: {
+  event: PluginHookAgentEndEvent;
+  ctx: AgentHarnessHookContext;
+  hookRunner?: AgentHarnessHookRunner;
+}): Promise<void> {
+  await executeAgentHarnessAgentEndHook({ ...params, unrefTimeout: false });
 }
 
 export type AgentHarnessBeforeAgentFinalizeOutcome =

--- a/src/agents/harness/lifecycle-hook-helpers.ts
+++ b/src/agents/harness/lifecycle-hook-helpers.ts
@@ -88,18 +88,20 @@ export function runAgentHarnessLlmOutputHook(params: {
   });
 }
 
-export function runAgentHarnessAgentEndHook(params: {
+export async function runAgentHarnessAgentEndHook(params: {
   event: PluginHookAgentEndEvent;
   ctx: AgentHarnessHookContext;
   hookRunner?: AgentHarnessHookRunner;
-}): void {
+}): Promise<void> {
   const hookRunner = params.hookRunner ?? getGlobalHookRunner();
   if (!hookRunner?.hasHooks("agent_end") || typeof hookRunner.runAgentEnd !== "function") {
     return;
   }
-  void hookRunner.runAgentEnd(params.event, buildAgentHookContext(params.ctx)).catch((error) => {
+  try {
+    await hookRunner.runAgentEnd(params.event, buildAgentHookContext(params.ctx));
+  } catch (error) {
     log.warn(`agent_end hook failed: ${String(error)}`);
-  });
+  }
 }
 
 export type AgentHarnessBeforeAgentFinalizeOutcome =

--- a/src/plugin-sdk/agent-harness-runtime.ts
+++ b/src/plugin-sdk/agent-harness-runtime.ts
@@ -210,6 +210,7 @@ export {
   runAgentHarnessBeforeMessageWriteHook,
 } from "../agents/harness/hook-helpers.js";
 export {
+  awaitAgentHarnessAgentEndHook,
   runAgentHarnessBeforeAgentFinalizeHook,
   runAgentHarnessAgentEndHook,
   runAgentHarnessLlmInputHook,

--- a/src/plugins/hooks.correlation.test.ts
+++ b/src/plugins/hooks.correlation.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createHookRunner } from "./hooks.js";
 import { addTestHook, TEST_PLUGIN_AGENT_CTX } from "./hooks.test-helpers.js";
@@ -83,6 +84,58 @@ describe("hook correlation fields", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("keeps one-shot agent_end runs alive until a ref'd timeout fires", () => {
+    const script = `
+      import { createHookRunner } from "./src/plugins/hooks.ts";
+      const registry = {
+        typedHooks: [{
+          pluginId: "plugin-a",
+          hookName: "agent_end",
+          handler: () => new Promise(() => {}),
+          priority: 0,
+          source: "test",
+        }],
+      };
+      const logger = {
+        error: (message) => console.error(message),
+        warn: (message) => console.warn(message),
+      };
+      const runner = createHookRunner(registry, {
+        logger,
+        voidHookTimeoutMsByHook: { agent_end: 20 },
+      });
+      await runner.runAgentEnd(
+        { messages: [], success: true },
+        {
+          runId: "test-run-id",
+          agentId: "test-agent",
+          sessionKey: "test-session",
+          sessionId: "test-session-id",
+          workspaceDir: "/tmp/openclaw-test",
+          messageProvider: "test",
+        },
+        { unrefTimeout: false },
+      );
+      console.log("settled-after-timeout");
+    `;
+
+    const child = spawnSync(
+      process.execPath,
+      ["--import", "tsx", "--input-type=module", "-e", script],
+      {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        timeout: 3_000,
+      },
+    );
+
+    expect(child.status).toBe(0);
+    expect(child.stderr).toContain(
+      "[hooks] agent_end handler from plugin-a failed: timed out after 20ms",
+    );
+    expect(child.stdout).toContain("settled-after-timeout");
   });
 
   it("honors per-hook registration timeouts over the default void hook timeout", async () => {

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -160,6 +160,9 @@ export type HookRunnerLogger = {
 };
 
 export type HookFailurePolicy = "fail-open" | "fail-closed";
+export type VoidHookRunOptions = {
+  unrefTimeout?: boolean;
+};
 
 type BeforeAgentFinalizeRetry = NonNullable<PluginHookBeforeAgentFinalizeResult["retry"]>;
 type BeforeAgentFinalizeResultWithRetryCandidates = PluginHookBeforeAgentFinalizeResult & {
@@ -555,6 +558,7 @@ export function createHookRunner(
     hookName: K,
     event: Parameters<NonNullable<PluginHookRegistration<K>["handler"]>>[0],
     ctx: Parameters<NonNullable<PluginHookRegistration<K>["handler"]>>[1],
+    options: VoidHookRunOptions = {},
   ): Promise<void> {
     const hooks = getHooksForName(registry, hookName);
     if (hooks.length === 0) {
@@ -570,7 +574,7 @@ export function createHookRunner(
         );
         const timeoutMs = getVoidHookTimeoutMs(hookName, hook);
         if (timeoutMs) {
-          await withHookTimeout(promise, timeoutMs, { unref: true });
+          await withHookTimeout(promise, timeoutMs, { unref: options.unrefTimeout ?? true });
         } else {
           await promise;
         }
@@ -879,13 +883,14 @@ export function createHookRunner(
   /**
    * Run agent_end hook.
    * Allows plugins to analyze completed conversations.
-   * Runs in parallel (fire-and-forget).
+   * Runs handlers in parallel.
    */
   async function runAgentEnd(
     event: PluginHookAgentEndEvent,
     ctx: PluginHookAgentContext,
+    options?: VoidHookRunOptions,
   ): Promise<void> {
-    return runVoidHook("agent_end", withAgentRunId(event, ctx), ctx);
+    return runVoidHook("agent_end", withAgentRunId(event, ctx), ctx, options);
   }
 
   /**


### PR DESCRIPTION
## Problem

Short-lived `openclaw agent --local` runs have two terminal execution shapes:
the classic local CLI runner and the Codex app-server embedded runner. Both can
finish the one-shot process before async `agent_end` observation hooks have
settled. That is unsafe for trusted plugins that use `agent_end` to close and
flush terminal state such as observability spans, memory capture, or
session-end bookkeeping.

Persistent gateway/channel-backed runs have the opposite constraint: they should
keep their existing fire-and-forget behavior so a slow observational hook does
not delay the channel runtime after the agent turn has already emitted its
terminal lifecycle state.

## Change and value

This PR adds an explicit awaited `agent_end` helper for one-shot drain points
and keeps the existing public helper fire-and-forget. Local CLI terminal paths
and no-channel Codex app-server terminal paths now wait for `agent_end` to
settle, while channel-backed CLI and app-server/gateway paths keep the prior
non-blocking behavior.

The hook runner keeps the existing timeout guardrail. Awaited one-shot callers
use a ref'ed timeout so a wedged hook cannot let Node exit before the timeout
fires; fire-and-forget callers keep unref'ed timeouts.

## Who is affected, and who is not

- Affected: operators and trusted plugins relying on `agent_end` during
  `openclaw agent --local`, especially terminal observability or capture
  plugins.
- Affected: local one-shot runs may wait up to the configured `agent_end`
  timeout when a trusted plugin is slow.
- Not affected: channel-backed CLI/gateway/Codex app-server runs continue to
  fire `agent_end` without blocking the persistent runtime path.
- Not affected: hook failures still log and continue rather than failing the
  agent turn.

## Why now

This fixes a concrete local observability reliability hole: the lifecycle hook
could be registered and the model turn could succeed, but a one-shot local run
still had no deterministic drain point for async terminal hook work. The change
is scoped to lifecycle helper semantics and terminal run paths, with regression
coverage for pending hooks, failure paths, timeout liveness, and the gateway
fire-and-forget split.

## Implementation

- Add `VoidHookRunOptions.unrefTimeout` to void hook execution.
- Keep `runAgentHarnessAgentEndHook()` fire-and-forget and add
  `awaitAgentHarnessAgentEndHook()` for one-shot drain points.
- Await `agent_end` in one-shot local CLI terminal paths, while preserving
  fire-and-forget behavior for channel/provider-backed CLI attempts.
- Await `agent_end` for no-channel Codex app-server terminal paths, while
  preserving fire-and-forget behavior for channel/provider-backed attempts.
- Add focused tests for pending hook settlement, local blocked/failure paths,
  Codex app-server success/startup-failure paths, channel-backed CLI/Codex
  fire-and-forget behavior, and ref'ed timeout liveness.

## Real behavior proof

Behavior addressed: `openclaw agent --local` could return before async
`agent_end` hook work completed, so terminal plugin flush/capture work was not a
reliable part of one-shot local runs.

Real environment tested:
- Source worktree: `/tmp/openclaw-pr-agent-local-otel`
- Live runtime proof head: `57c0e6c0d9ca18383e5ea348f93c6513d8430704`
- Current pushed head: `69d5ca946339c044e6c7fda62ff514ef4c411ab1`
- Behavior validation head: `3879c430fe8108df4426fd0ce935b52f187d05c0`
- Local installed runtime: OpenClaw `2026.5.19 (a185ca2)`, Node `v26.1.0`
- Live model proof: `openai/gpt-5.5` through the installed Codex app-server
  embedded runner, with delivery disabled

Exact steps or command run after this patch:

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.unit.config.ts \
  extensions/codex/src/app-server/run-attempt.test.ts \
  src/plugins/hooks.correlation.test.ts \
  src/agents/harness/lifecycle-hook-helpers.test.ts \
  src/agents/cli-runner.reliability.test.ts \
  --maxWorkers=1

pnpm tsgo:core
pnpm plugin-sdk:api:check
pnpm test:contracts:plugins

pnpm exec oxfmt --check --threads=1 \
  src/plugins/hooks.ts \
  src/plugins/hooks.correlation.test.ts \
  src/agents/harness/lifecycle-hook-helpers.ts \
  src/agents/harness/lifecycle-hook-helpers.test.ts \
  src/agents/cli-runner.ts \
  src/agents/cli-runner.reliability.test.ts \
  extensions/codex/src/app-server/run-attempt.ts \
  extensions/codex/src/app-server/run-attempt.test.ts \
  src/plugin-sdk/agent-harness-runtime.ts

git diff --check

timeout 180s openclaw agent --local --json \
  --session-id otel-agent-end-proof-20260521-6 \
  --model openai/gpt-5.5 \
  --message 'Reply with exactly this marker and no extra words: OTEL_AGENT_END_SPAN_OK_20260521_PROVIDER_TRACER'
```

Evidence after fix:
- Focused Vitest regression suite: pass.
  - Includes local CLI/Codex waits for pending `agent_end`.
  - Includes channel-backed CLI/Codex results returning before a pending
    `agent_end` hook settles.
- `pnpm tsgo:core`: pass.
- `pnpm plugin-sdk:api:check`: pass.
- `pnpm test:contracts:plugins`: pass.
- `oxfmt --check`: pass.
- `git diff --check`: pass.
- Final cleanup head `69d5ca946339c044e6c7fda62ff514ef4c411ab1`: removed two
  stale QA-lab deadcode allowlist entries reported by hosted `check-dependencies`;
  `git diff --check`: pass.
- Live `--local` proof returned
  `OTEL_AGENT_END_SPAN_OK_20260521_PROVIDER_TRACER` from `openai-codex/gpt-5.5`
  with `runner: "embedded"` and `fallbackUsed: false`.
- `workspace/logs/otel/traces.jsonl` appended a real
  `openclaw.agent.turn` span for
  `agent:main:explicit:otel-agent-end-proof-20260521-6` with
  `gen_ai.response.model=gpt-5.5`,
  `gen_ai.usage.input_tokens=13267`,
  `gen_ai.usage.output_tokens=19`,
  `gen_ai.usage.total_tokens=56166`,
  `gen_ai.usage.cache_read_tokens=42880`, and
  `openclaw.agent.success=true`.

Observed result after fix: the one-shot local app-server run stayed alive long
enough for the async `agent_end` span close/flush path to complete, and the
collector wrote the terminal `openclaw.agent.turn` span before command exit. The
unit tests also prove that local CLI/Codex terminal paths remain unresolved
while `agent_end` is pending, and that channel-backed CLI/Codex attempts still
return without waiting.

What was not tested: no production gateway restart was needed for this proof.
The PR does not change gateway startup; its gateway-relevant contract is that
channel-backed attempts keep fire-and-forget `agent_end` semantics. That
contract is covered by the CLI and app-server regression tests that verify
channel-backed attempts still return before a pending `agent_end` hook settles.
Hosted CI should be read from the GitHub check rollup for current head
`69d5ca946339c044e6c7fda62ff514ef4c411ab1`.

## Notes

AI-assisted PR. The live OTel proof used a locally patched external
`otel-observability` plugin so the plugin exports spans through its own tracer
provider in the local app-server process; that plugin-local fix is outside this
OpenClaw core PR. This PR covers the OpenClaw lifecycle contract needed by any
trusted async `agent_end` plugin.

## Risks

One-shot local runs with slow trusted `agent_end` plugins can now take longer to
exit, up to the existing hook timeout. That is intentional for terminal
capture/flush correctness and bounded by the hook runner.
