### PR TITLE
Clamp stream max tokens to remaining context window

### DIFF
--- a/src/agents/pi-embedded-runner/extra-params.sampling.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.sampling.test.ts
@@ -15,6 +15,67 @@ vi.mock("./logger.js", () => ({
   },
 }));
 
+vi.mock("../../plugin-sdk/provider-stream-shared.js", () => ({
+  createDeepSeekV4OpenAICompatibleThinkingWrapper: ({
+    baseStreamFn,
+  }: {
+    baseStreamFn?: StreamFn;
+  }) => baseStreamFn,
+  createThinkingOnlyFinalTextWrapper: ({ baseStreamFn }: { baseStreamFn?: StreamFn }) =>
+    baseStreamFn,
+}));
+
+vi.mock("../../plugins/provider-hook-runtime.js", () => ({
+  prepareProviderExtraParams: () => undefined,
+  resolveProviderExtraParamsForTransport: () => undefined,
+  wrapProviderStreamFn: () => undefined,
+}));
+
+vi.mock("../model-selection-normalize.js", () => ({
+  legacyModelKey: (provider: string, model: string) => {
+    const rawKey = `${provider.trim()}/${model.trim()}`;
+    const canonicalKey = rawKey.toLowerCase();
+    return rawKey === canonicalKey ? null : rawKey;
+  },
+  modelKey: (provider: string, model: string) => `${provider.trim()}/${model.trim()}`.toLowerCase(),
+}));
+
+vi.mock("../provider-request-config.js", () => ({
+  resolveProviderRequestPolicyConfig: () => ({
+    capabilities: {
+      usesKnownNativeOpenAIRoute: true,
+    },
+  }),
+}));
+
+vi.mock("./google-stream-wrappers.js", () => ({
+  createGoogleThinkingPayloadWrapper: (streamFn: StreamFn | undefined) => streamFn,
+}));
+
+vi.mock("./minimax-stream-wrappers.js", () => ({
+  createMinimaxThinkingDisabledWrapper: (streamFn: StreamFn | undefined) => streamFn,
+}));
+
+vi.mock("./moonshot-stream-wrappers.js", () => ({
+  createSiliconFlowThinkingWrapper: (streamFn: StreamFn | undefined) => streamFn,
+  shouldApplySiliconFlowThinkingOffCompat: () => false,
+}));
+
+vi.mock("./openai-stream-wrappers.js", () => ({
+  createOpenAICompletionsStrictMessageKeysWrapper: (streamFn: StreamFn | undefined) => streamFn,
+  createOpenAICompletionsToolsCompatWrapper: (streamFn: StreamFn | undefined) => streamFn,
+  createOpenAIResponsesContextManagementWrapper: (streamFn: StreamFn | undefined) => streamFn,
+  createOpenAIStringContentWrapper: (streamFn: StreamFn | undefined) => streamFn,
+}));
+
+vi.mock("./prompt-cache-retention.js", () => ({
+  resolveCacheRetention: () => undefined,
+}));
+
+vi.mock("./proxy-stream-wrappers.js", () => ({
+  createOpenRouterSystemCacheWrapper: (streamFn: StreamFn | undefined) => streamFn,
+}));
+
 vi.mock("@earendil-works/pi-ai", () => createPiAiStreamSimpleMock());
 
 beforeEach(() => {
@@ -91,6 +152,127 @@ describe("createStreamFnWithExtraParams sampling overrides", () => {
     const callOptions = (underlying as unknown as { mock: { calls: unknown[][] } }).mock
       .calls[0]?.[2] as { maxTokens?: number } | undefined;
     expect(callOptions?.maxTokens).toBe(64_000);
+  });
+
+  it("clamps configured maxTokens to the remaining model context window", () => {
+    const underlying = vi.fn(() => ({
+      push: vi.fn(),
+      result: vi.fn(async () => undefined),
+      [Symbol.asyncIterator]: vi.fn(async function* () {
+        // empty stream
+      }),
+    })) as unknown as StreamFn;
+    const agent: { streamFn?: StreamFn } = { streamFn: underlying };
+
+    applyExtraParamsToAgent(agent, undefined, "openai", "gpt-5.4", {
+      maxTokens: 90,
+    });
+
+    if (!agent.streamFn) {
+      throw new Error("expected extra params to wrap streamFn");
+    }
+
+    void agent.streamFn(
+      {
+        id: "gpt-5.4",
+        api: "openai-completions",
+        provider: "openai",
+        contextWindow: 100,
+      } as never,
+      {
+        messages: [{ role: "user", content: "x".repeat(200), timestamp: 0 }],
+        tools: [],
+      } as never,
+      undefined,
+    );
+
+    const callOptions = (underlying as unknown as { mock: { calls: unknown[][] } }).mock
+      .calls[0]?.[2] as { maxTokens?: number } | undefined;
+    expect(callOptions?.maxTokens).toBe(40);
+  });
+
+  it("keeps a smaller runtime maxTokens override when it fits the remaining context", () => {
+    const underlying = vi.fn(() => ({
+      push: vi.fn(),
+      result: vi.fn(async () => undefined),
+      [Symbol.asyncIterator]: vi.fn(async function* () {
+        // empty stream
+      }),
+    })) as unknown as StreamFn;
+    const agent: { streamFn?: StreamFn } = { streamFn: underlying };
+
+    applyExtraParamsToAgent(agent, undefined, "openai", "gpt-5.4", {
+      maxTokens: 90,
+    });
+
+    if (!agent.streamFn) {
+      throw new Error("expected extra params to wrap streamFn");
+    }
+
+    void agent.streamFn(
+      {
+        id: "gpt-5.4",
+        api: "openai-completions",
+        provider: "openai",
+        contextWindow: 100,
+      } as never,
+      {
+        messages: [{ role: "user", content: "x".repeat(200), timestamp: 0 }],
+        tools: [],
+      } as never,
+      { maxTokens: 30 } as never,
+    );
+
+    const callOptions = (underlying as unknown as { mock: { calls: unknown[][] } }).mock
+      .calls[0]?.[2] as { maxTokens?: number } | undefined;
+    expect(callOptions?.maxTokens).toBe(30);
+  });
+
+  it("clamps model maxTokens to the remaining context window", () => {
+    const underlying = vi.fn(() => ({
+      push: vi.fn(),
+      result: vi.fn(async () => undefined),
+      [Symbol.asyncIterator]: vi.fn(async function* () {
+        // empty stream
+      }),
+    })) as unknown as StreamFn;
+    const agent: { streamFn?: StreamFn } = { streamFn: underlying };
+    const model = {
+      id: "mimo-v2-omni",
+      api: "anthropic-messages",
+      provider: "xiaomi-token-plan-cn",
+      contextWindow: 100,
+      maxTokens: 90,
+    };
+
+    applyExtraParamsToAgent(
+      agent,
+      undefined,
+      "xiaomi-token-plan-cn",
+      "mimo-v2-omni",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      model as never,
+    );
+
+    if (!agent.streamFn) {
+      throw new Error("expected extra params to wrap streamFn");
+    }
+
+    void agent.streamFn(
+      model as never,
+      {
+        messages: [{ role: "user", content: "x".repeat(200), timestamp: 0 }],
+        tools: [],
+      } as never,
+      undefined,
+    );
+
+    const callModel = (underlying as unknown as { mock: { calls: unknown[][] } }).mock
+      .calls[0]?.[0] as { maxTokens?: number } | undefined;
+    expect(callModel?.maxTokens).toBe(40);
   });
 
   it("keeps runtime maxTokens ahead of OpenAI completions token alias defaults", () => {

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -36,6 +36,10 @@ import {
 import { resolveCacheRetention } from "./prompt-cache-retention.js";
 import { createOpenRouterSystemCacheWrapper } from "./proxy-stream-wrappers.js";
 import { streamWithPayloadPatch } from "./stream-payload-utils.js";
+import {
+  clampMaxTokensToContextWindow,
+  clampModelMaxTokensToContextWindow,
+} from "./stream-max-tokens-context-window.js";
 
 const defaultProviderRuntimeDeps = {
   prepareProviderExtraParams: prepareProviderExtraParamsRuntime,
@@ -491,10 +495,20 @@ function createStreamFnWithExtraParams(
     if (Object.keys(streamParams).length === 0 && !cacheRetention) {
       return underlying(callModel, context, options);
     }
-    return underlying(callModel, context, {
+    const mergedOptions = {
       ...streamParams,
       ...(cacheRetention ? { cacheRetention } : {}),
       ...options,
+    };
+    const clampedMaxTokens = clampMaxTokensToContextWindow({
+      maxTokens: mergedOptions.maxTokens,
+      callModel,
+      configuredModel: model,
+      context,
+    });
+    return underlying(callModel, context, {
+      ...mergedOptions,
+      ...(clampedMaxTokens !== undefined ? { maxTokens: clampedMaxTokens } : {}),
     });
   };
 
@@ -708,6 +722,36 @@ function createOpenAICompletionsExtraBodyWrapper(
   };
 }
 
+function createContextWindowMaxTokensWrapper(
+  baseStreamFn: StreamFn | undefined,
+  configuredModel?: ProviderRuntimeModel,
+): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (callModel, context, options) => {
+    const clampedModelMaxTokens = clampModelMaxTokensToContextWindow({
+      callModel,
+      configuredModel,
+      context,
+    });
+    const nextModel =
+      clampedModelMaxTokens !== undefined &&
+      clampedModelMaxTokens !== (callModel as { maxTokens?: unknown }).maxTokens
+        ? { ...callModel, maxTokens: clampedModelMaxTokens }
+        : callModel;
+    const clampedOptionMaxTokens = clampMaxTokensToContextWindow({
+      maxTokens: options?.maxTokens,
+      callModel,
+      configuredModel,
+      context,
+    });
+    const nextOptions =
+      clampedOptionMaxTokens !== undefined && clampedOptionMaxTokens !== options?.maxTokens
+        ? { ...options, maxTokens: clampedOptionMaxTokens }
+        : options;
+    return underlying(nextModel, context, nextOptions);
+  };
+}
+
 type ApplyExtraParamsContext = {
   agent: { streamFn?: StreamFn };
   cfg: OpenClawConfig | undefined;
@@ -757,6 +801,7 @@ function applyPrePluginStreamWrappers(ctx: ApplyExtraParamsContext): void {
 function applyPostPluginStreamWrappers(
   ctx: ApplyExtraParamsContext & { providerWrapperHandled: boolean },
 ): void {
+  ctx.agent.streamFn = createContextWindowMaxTokensWrapper(ctx.agent.streamFn, ctx.model);
   ctx.agent.streamFn = createOpenRouterSystemCacheWrapper(ctx.agent.streamFn);
   ctx.agent.streamFn = createOpenAIStringContentWrapper(ctx.agent.streamFn);
   ctx.agent.streamFn = createOpenAICompletionsStrictMessageKeysWrapper(ctx.agent.streamFn);

--- a/src/agents/pi-embedded-runner/stream-max-tokens-context-window.ts
+++ b/src/agents/pi-embedded-runner/stream-max-tokens-context-window.ts
@@ -1,0 +1,168 @@
+import type { StreamFn } from "@earendil-works/pi-agent-core";
+import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
+import { log } from "./logger.js";
+
+const STREAM_INPUT_CHARS_PER_TOKEN_ESTIMATE = 4;
+const STREAM_INPUT_TOKEN_SAFETY_MARGIN = 1.2;
+const MIN_CONTEXT_REMAINING_OUTPUT_TOKENS = 1;
+
+type StreamContext = Parameters<StreamFn>[1];
+type StreamModel = Parameters<StreamFn>[0];
+type ContextWindowLikeModel = {
+  contextTokens?: unknown;
+  contextWindow?: unknown;
+  maxTokens?: unknown;
+};
+
+function normalizePositiveInt(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return undefined;
+  }
+  const int = Math.floor(value);
+  return int > 0 ? int : undefined;
+}
+
+function estimateSerializableChars(value: unknown): number {
+  if (typeof value === "string") {
+    return value.length;
+  }
+  if (value === undefined || value === null) {
+    return 0;
+  }
+  try {
+    const serialized = JSON.stringify(value);
+    return typeof serialized === "string" ? serialized.length : 0;
+  } catch {
+    return 256;
+  }
+}
+
+function estimateContentBlockChars(block: unknown): number {
+  if (!block || typeof block !== "object") {
+    return estimateSerializableChars(block);
+  }
+  const typed = block as {
+    type?: unknown;
+    text?: unknown;
+    thinking?: unknown;
+    name?: unknown;
+    arguments?: unknown;
+  };
+  if (typed.type === "text" && typeof typed.text === "string") {
+    return typed.text.length;
+  }
+  if (typed.type === "thinking" && typeof typed.thinking === "string") {
+    return typed.thinking.length;
+  }
+  if (typed.type === "toolCall") {
+    return (
+      (typeof typed.name === "string" ? typed.name.length : 0) +
+      estimateSerializableChars(typed.arguments)
+    );
+  }
+  if (typed.type === "image") {
+    return 8_000;
+  }
+  return estimateSerializableChars(block);
+}
+
+function estimateContentChars(content: unknown): number {
+  if (typeof content === "string") {
+    return content.length;
+  }
+  if (!Array.isArray(content)) {
+    return estimateSerializableChars(content);
+  }
+  return content.reduce((sum, block) => sum + estimateContentBlockChars(block), 0);
+}
+
+function estimateMessageChars(message: unknown): number {
+  if (!message || typeof message !== "object") {
+    return 0;
+  }
+  const record = message as { content?: unknown };
+  const contentChars = estimateContentChars(record.content);
+  return contentChars > 0 ? contentChars : estimateSerializableChars(message);
+}
+
+function estimateStreamInputTokens(context: StreamContext): number {
+  const ctx = context as {
+    messages?: unknown;
+    systemPrompt?: unknown;
+    tools?: unknown;
+  };
+  let chars = typeof ctx.systemPrompt === "string" ? ctx.systemPrompt.length : 0;
+  if (Array.isArray(ctx.messages)) {
+    chars += ctx.messages.reduce((sum, message) => sum + estimateMessageChars(message), 0);
+  }
+  if (Array.isArray(ctx.tools) && ctx.tools.length > 0) {
+    chars += estimateSerializableChars(ctx.tools);
+  }
+  return Math.max(
+    0,
+    Math.ceil((chars / STREAM_INPUT_CHARS_PER_TOKEN_ESTIMATE) * STREAM_INPUT_TOKEN_SAFETY_MARGIN),
+  );
+}
+
+function resolveContextWindowTokens(
+  callModel: StreamModel,
+  configuredModel?: ProviderRuntimeModel,
+): number | undefined {
+  const callModelRecord = callModel as ContextWindowLikeModel;
+  return (
+    normalizePositiveInt(callModelRecord.contextTokens) ??
+    normalizePositiveInt(configuredModel?.contextTokens) ??
+    normalizePositiveInt(callModelRecord.contextWindow) ??
+    normalizePositiveInt(configuredModel?.contextWindow)
+  );
+}
+
+function resolveModelMaxTokens(
+  callModel: StreamModel,
+  configuredModel?: ProviderRuntimeModel,
+): number | undefined {
+  const callModelRecord = callModel as ContextWindowLikeModel;
+  return (
+    normalizePositiveInt(callModelRecord.maxTokens) ??
+    normalizePositiveInt(configuredModel?.maxTokens)
+  );
+}
+
+export function clampMaxTokensToContextWindow(params: {
+  maxTokens: number | undefined;
+  callModel: StreamModel;
+  configuredModel?: ProviderRuntimeModel;
+  context: StreamContext;
+}): number | undefined {
+  if (params.maxTokens === undefined || params.maxTokens <= 0) {
+    return params.maxTokens;
+  }
+  const contextWindowTokens = resolveContextWindowTokens(params.callModel, params.configuredModel);
+  if (contextWindowTokens === undefined) {
+    return params.maxTokens;
+  }
+  const inputTokens = estimateStreamInputTokens(params.context);
+  const remainingTokens = contextWindowTokens - inputTokens;
+  if (remainingTokens >= params.maxTokens) {
+    return params.maxTokens;
+  }
+  const clamped = Math.max(MIN_CONTEXT_REMAINING_OUTPUT_TOKENS, remainingTokens);
+  log.debug(
+    `clamping maxTokens to remaining context window: requested=${params.maxTokens} ` +
+      `clamped=${clamped} inputTokens=${inputTokens} contextWindow=${contextWindowTokens}`,
+  );
+  return clamped;
+}
+
+export function clampModelMaxTokensToContextWindow(params: {
+  callModel: StreamModel;
+  configuredModel?: ProviderRuntimeModel;
+  context: StreamContext;
+}): number | undefined {
+  return clampMaxTokensToContextWindow({
+    maxTokens: resolveModelMaxTokens(params.callModel, params.configuredModel),
+    callModel: params.callModel,
+    configuredModel: params.configuredModel,
+    context: params.context,
+  });
+}


### PR DESCRIPTION
Fixes #83086.

## Summary
- clamp configured/requested stream `maxTokens` to the remaining context window instead of forwarding values that exceed the available budget
- clamp `callModel.maxTokens` too so providers that fall back to model defaults cannot bypass the same limit
- add focused unit coverage for both option-level and model-level clamping

## Verification
- `OPENCLAW_VITEST_INCLUDE_FILE=src/agents/pi-embedded-runner/extra-params.sampling.test.ts node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts --passWithNoTests=false`
- `corepack pnpm exec oxfmt --check src/agents/pi-embedded-runner/extra-params.ts src/agents/pi-embedded-runner/extra-params.sampling.test.ts src/agents/pi-embedded-runner/stream-max-tokens-context-window.ts`
- `git diff --check`

## Notes
- `pnpm tsgo:core:test` was not run because the repo's sparse-checkout guard requires a much broader checkout (`packages`, `ui/src`, etc.)