### PR TITLE
fix(channels): pass allowBootstrap from channel-selection so in-agent message tool resolves channels in --local processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Docs: https://docs.openclaw.ai
 - Auto-reply/ACP: wait for same-channel block reply delivery before starting tool work, while still honoring ACP dispatch aborts so stopped turns do not wait on slow channel sends. (#83722) Thanks @IWhatsskill.
 - Codex/ACP: mark required child-run completions that only report progress, omit a final deliverable, or fail requester delivery as blocked while preserving real final reports. (#85110) Thanks @IWhatsskill.
 - Channels: treat bare abort messages such as `stop`, `abort`, and `wait` as immediate control commands in inbound debounce paths so stop requests are not delayed behind pending message coalescing. (#83348) Thanks @IWhatsskill.
+- Channels/message tool: resolve configured external channel plugins during in-agent channel selection, so `openclaw agent --local` message-tool sends no longer report an available channel as unavailable. (#85022) Thanks @Kaspre.
 - Agents/subagents: surface blocked child-run completions as errors instead of successful subagent finishes. (#80886) Thanks @TurboTheTurtle.
 - Agents/Pi: treat accepted embedded `sessions_spawn` child-session handoffs as terminal progress so parent turns no longer report false non-deliverable failures. (#85054) Thanks @samzong.
 - WhatsApp: update Baileys to `7.0.0-rc13` and drop the obsolete logger type patch.

--- a/src/infra/outbound/channel-resolution.test.ts
+++ b/src/infra/outbound/channel-resolution.test.ts
@@ -121,6 +121,22 @@ describe("outbound channel resolution", () => {
     expect(resolveRuntimePluginRegistryMock).not.toHaveBeenCalled();
   });
 
+  it("returns a bundled plugin without bootstrapping", async () => {
+    const plugin = { id: "alpha" };
+    getLoadedChannelPluginMock.mockReturnValue(undefined);
+    getChannelPluginMock.mockReturnValue(plugin);
+    const channelResolution = await importChannelResolution("bundled-plugin");
+
+    expect(
+      channelResolution.resolveOutboundChannelPlugin({
+        channel: "alpha",
+        cfg: {} as never,
+        allowBootstrap: true,
+      }),
+    ).toBe(plugin);
+    expect(resolveRuntimePluginRegistryMock).not.toHaveBeenCalled();
+  });
+
   it("falls back to the active registry when getChannelPlugin misses", async () => {
     const plugin = { id: "alpha" };
     getChannelPluginMock.mockReturnValue(undefined);

--- a/src/infra/outbound/channel-resolution.ts
+++ b/src/infra/outbound/channel-resolution.ts
@@ -192,8 +192,13 @@ export function resolveOutboundChannelPlugin(params: {
     return directCurrent;
   }
 
+  const bundledCurrent = resolve();
+  if (bundledCurrent) {
+    return bundledCurrent;
+  }
+
   if (params.allowBootstrap !== true) {
-    return resolve();
+    return undefined;
   }
 
   maybeBootstrapChannelPlugin({ channel: normalized, cfg: params.cfg });

--- a/src/infra/outbound/channel-selection.test.ts
+++ b/src/infra/outbound/channel-selection.test.ts
@@ -245,6 +245,36 @@ describe("resolveMessageChannelSelection", () => {
     verify?.(setupResult as never);
   });
 
+  it("allows bootstrap while checking explicit and fallback channels", async () => {
+    const cfg = {} as never;
+    mocks.resolveOutboundChannelPlugin.mockImplementation(({ channel }: { channel: string }) =>
+      channel === "beta" ? { id: "beta" } : undefined,
+    );
+
+    await expect(
+      expectResolvedSelection({
+        cfg,
+        channel: "alpha",
+        fallbackChannel: "beta",
+      }),
+    ).resolves.toEqual({
+      channel: "beta",
+      configured: [],
+      source: "tool-context-fallback",
+    });
+
+    expect(mocks.resolveOutboundChannelPlugin).toHaveBeenNthCalledWith(1, {
+      channel: "alpha",
+      cfg,
+      allowBootstrap: true,
+    });
+    expect(mocks.resolveOutboundChannelPlugin).toHaveBeenNthCalledWith(2, {
+      channel: "beta",
+      cfg,
+      allowBootstrap: true,
+    });
+  });
+
   it.each([
     {
       params: { cfg: {} as never, channel: "channel:C123", fallbackChannel: "not-a-channel" },

--- a/src/infra/outbound/channel-selection.ts
+++ b/src/infra/outbound/channel-selection.ts
@@ -49,14 +49,13 @@ function resolveAvailableKnownChannel(params: {
   if (!normalized) {
     return undefined;
   }
-  // Pass `allowBootstrap: true` so the in-agent message tool path resolves
-  // outbound channels in processes where channel adapters have not been
-  // eagerly loaded (e.g. `openclaw agent --local`). In gateway context where
-  // the channel plugin is already loaded, this is a no-op fast path. Without
-  // it, `resolveOutboundChannelPlugin` falls through to `getChannelPlugin`
-  // (metadata-only) and `resolveAvailableKnownChannel` treats the channel as
-  // unavailable, surfacing as the recurring "Channel is unavailable" error
-  // on `--local`-routed dispatches that the CLI send-path could deliver to.
+  // Pass `allowBootstrap: true` so the in-agent message tool path can resolve
+  // outbound channels in processes where external channel adapters have not
+  // been eagerly loaded (e.g. `openclaw agent --local`). Already-loaded and
+  // bundled plugins still resolve through side-effect-free fast paths first.
+  // Without the bootstrap fallback, official external channels can surface as
+  // the recurring "Channel is unavailable" error on `--local`-routed
+  // dispatches that the CLI send-path could deliver to.
   // Adjacent to #77254 (cron-announce / final-reply paths); this closes the
   // remaining in-agent caller in the same family.
   return resolveOutboundChannelPlugin({

--- a/src/infra/outbound/channel-selection.ts
+++ b/src/infra/outbound/channel-selection.ts
@@ -49,9 +49,20 @@ function resolveAvailableKnownChannel(params: {
   if (!normalized) {
     return undefined;
   }
+  // Pass `allowBootstrap: true` so the in-agent message tool path resolves
+  // outbound channels in processes where channel adapters have not been
+  // eagerly loaded (e.g. `openclaw agent --local`). In gateway context where
+  // the channel plugin is already loaded, this is a no-op fast path. Without
+  // it, `resolveOutboundChannelPlugin` falls through to `getChannelPlugin`
+  // (metadata-only) and `resolveAvailableKnownChannel` treats the channel as
+  // unavailable, surfacing as the recurring "Channel is unavailable" error
+  // on `--local`-routed dispatches that the CLI send-path could deliver to.
+  // Adjacent to #77254 (cron-announce / final-reply paths); this closes the
+  // remaining in-agent caller in the same family.
   return resolveOutboundChannelPlugin({
     channel: normalized,
     cfg: params.cfg,
+    allowBootstrap: true,
   })
     ? normalized
     : undefined;


### PR DESCRIPTION
## Problem

The in-agent `openclaw_message` tool intermittently throws "Channel is unavailable: <channel>" against a configured channel that the CLI send-path (`openclaw message send`) can deliver to seconds before and after. Six occurrences observed in 14 days, all during ~04:00-05:00 UTC heartbeat windows that route dispatches through `openclaw agent --local`.

Adjacent to #77254 (closed 2026-05-07), which fixed the cron-announce and final-reply paths but did not touch the in-agent message tool caller. The underlying resolver path is the same; the caller surface is different.

## Change and value

`src/infra/outbound/channel-selection.ts`'s `resolveAvailableKnownChannel` called `resolveOutboundChannelPlugin({ channel, cfg })` without `allowBootstrap`. In a process where the external channel adapter has not yet been eagerly loaded, such as `openclaw agent --local`, the resolver cannot load the adapter for that caller and the caller surfaces "Channel is unavailable: <channel>".

Pass `allowBootstrap: true` from this caller. In gateway context, where channels are pre-loaded eagerly, this stays on the loaded-plugin fast path. For bundled plugins, the resolver also keeps the side-effect-free bundled lookup path before any bootstrap attempt. In agent-local context for official external channels, the existing bootstrap branch runs once to lazy-load the channel adapter, and subsequent message-tool calls in that process hit the loaded plugin.

## Who is affected, and who is not

Anyone running agents via `openclaw agent --local` (one-shot dispatches, heartbeats, cron-driven workflows) whose dispatch invokes the message tool against a configured outbound channel is affected.

Gateway-routed invocations are not expected to change because their channel plugin is already loaded eagerly. This PR does not add new channel ids, config, plugin loading policy, or public API surface.

## Why now

Six recurrences in 14 days; the recurring pattern is well-documented and the call chain identified.

## Real behavior proof

- **Behavior or issue addressed**: `openclaw agent --local` message-tool dispatch resolves a configured outbound channel from the current run channel context after this caller opts into channel bootstrap.
- **Real environment tested**: PR head `522d01a45b72b0e5dcf4a852e10643dc3486030c` source build (`pnpm openclaw --version` refreshed stale local dist; `OpenClaw 2026.5.20 (522d01a)`) against a stock local OpenClaw install config with configured `discord` outbound channel. The temporary proof config only removed two legacy `tools.codeMode` keys rejected by the PR-head schema; channel and model settings were preserved.
- **Exact steps or command run after this patch**:
  1. `pnpm openclaw --version` to rebuild stale local `dist` from the exact PR head.
  2. `OPENCLAW_CONFIG_PATH=/tmp/openclaw-pr85022-config.SkBjp8/openclaw.json node openclaw.mjs message send --channel discord --target channel:<redacted> --message "PR 85022 refreshed-dist dry-run channel resolution probe" --dry-run --json`
  3. `OPENCLAW_CONFIG_PATH=/tmp/openclaw-pr85022-config.SkBjp8/openclaw.json node openclaw.mjs agent --local --agent main --session-id pr-85022-e2e-20260521T1640Z --channel discord --model ollama-cloud/deepseek-v3.2 --thinking off --json --message 'Use the message tool exactly once ... dryRun=true. Do not include a channel argument; use the current run channel context ...'`
- **Evidence after fix**: Direct dry-run send resolved the configured channel:

```json
{"action":"send","channel":"discord","dryRun":true,"handledBy":"core","payload":{"channel":"discord","to":"channel:<redacted>","via":"direct","mediaUrl":null,"dryRun":true}}
```

Agent-local transcript from `agents/main/sessions/pr-85022-e2e-20260521T1640Z.jsonl`:

```json
{"toolName":"message","details":{"channel":"discord","to":"channel:<redacted>","via":"direct","mediaUrl":null,"dryRun":true},"isError":false}
```

Final agent text: `PR_85022_AGENT_LOCAL_MESSAGE_TOOL_DRY_RUN_OK`; run metadata: `runner:"embedded"`, `toolSummary.calls:1`, `toolSummary.failures:0`.
- **Observed result after fix**: A real `agent --local` embedded run invoked the `message` tool once with no explicit `channel` argument, resolved the current run channel context to `discord`, and returned a successful dry-run send result instead of `Channel is unavailable: discord`.
- **What was not tested**: No remaining changed-path behavior. Gateway-routed invocations are outside the changed code path because they already eagerly load outbound channels; this PR does not change gateway delivery semantics, channel ids, config, plugin loading policy, or public API surface.

## Implementation

- `resolveAvailableKnownChannel` now passes `allowBootstrap: true` to the outbound channel plugin resolver.
- `resolveOutboundChannelPlugin` still returns already-loaded, active-registry, and bundled plugins before attempting bootstrap, so ordinary direct send paths do not load registries unnecessarily.
- Focused regression tests cover the channel-selection caller and the no-bootstrap bundled-plugin fast path.

## Verification

Final head: `522d01a45b72b0e5dcf4a852e10643dc3486030c`.

- Local: `pnpm test src/infra/outbound/message.test.ts src/infra/outbound/channel-selection.test.ts src/infra/outbound/channel-resolution.test.ts` - 3 files, 42 tests passed
- Local: `git diff --check`
- Live source-head proof: direct `message send --dry-run --json` resolved configured `discord`; real `agent --local` embedded run invoked the `message` tool once without an explicit `channel`, returned `isError:false`, `dryRun:true`, and final text `PR_85022_AGENT_LOCAL_MESSAGE_TOOL_DRY_RUN_OK`
- Remote Crabbox/GCP on-demand, `e2-standard-8`, `us-east4-a`, lease `cbx_e608bc028ab0`, exit `0`: `pnpm check:changed; pnpm test src/infra/outbound/message.test.ts src/infra/outbound/channel-selection.test.ts src/infra/outbound/channel-resolution.test.ts`
- Hosted GitHub checks on final head: green; previously failing `checks-node-core-runtime-infra-state` now passes
- Review swarm: four read-only lanes over correctness, lifecycle/error paths, tests/proof, and security/public surface; no code findings after PR-body proof wording was fixed
- Claude review gate: no actionable findings
- Codex review gate: `codex review --base origin/main`; no discrete correctness issue found

Generated with [Claude Code](https://claude.com/claude-code)

