### PR TITLE
perf(plugins): thread install records through plugin load options

### DIFF
--- a/src/plugins/loader-provenance.ts
+++ b/src/plugins/loader-provenance.ts
@@ -75,10 +75,8 @@ export function buildProvenanceIndex(params: {
   }
 
   const installRules = new Map<string, InstallTrackingRule>();
-  const installs = {
-    ...loadInstalledPluginIndexInstallRecordsSync({ env: params.env }),
-    ...params.installRecords,
-  };
+  const installs =
+    params.installRecords ?? loadInstalledPluginIndexInstallRecordsSync({ env: params.env });
   for (const [pluginId, install] of Object.entries(installs)) {
     const rule: InstallTrackingRule = {
       trackedWithoutPaths: false,

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -169,6 +169,7 @@ export type PluginLoadOptions = {
   activationSourceConfig?: OpenClawConfig;
   autoEnabledReasons?: Readonly<Record<string, string[]>>;
   workspaceDir?: string;
+  installRecords?: Record<string, PluginInstallRecord>;
   // Allows callers to resolve plugin roots and load paths against an explicit env
   // instead of the process-global environment.
   env?: NodeJS.ProcessEnv;
@@ -1117,7 +1118,7 @@ function resolvePluginLoadCacheContext(options: PluginLoadOptions = {}) {
   const runtimeSubagentMode = resolveRuntimeSubagentMode(options.runtimeOptions);
   const coreGatewayMethodNames = resolveCoreGatewayMethodNames(options);
   const installRecords = {
-    ...loadInstalledPluginIndexInstallRecordsSync({ env }),
+    ...(options.installRecords ?? loadInstalledPluginIndexInstallRecordsSync({ env })),
     ...cfg.plugins?.installs,
   };
   const cacheKey = buildCacheKey({

--- a/src/plugins/providers.runtime.ts
+++ b/src/plugins/providers.runtime.ts
@@ -2,6 +2,7 @@ import { withActivatedPluginIds } from "./activation-context.js";
 import { resolveBundledPluginCompatibleActivationInputs } from "./activation-context.js";
 import { resolveManifestActivationPluginIds } from "./activation-planner.js";
 import { getLoadedRuntimePluginRegistry } from "./active-runtime-registry.js";
+import { extractPluginInstallRecordsFromInstalledPluginIndex } from "./installed-plugin-index-install-records.js";
 import {
   getRuntimePluginRegistryForLoadOptions,
   isPluginRegistryLoadInFlight,
@@ -202,6 +203,9 @@ function resolveSetupProviderPluginLoadState(
       workspaceDir: base.workspaceDir,
       env: base.env,
       logger: createPluginRuntimeLoaderLogger(),
+      installRecords: params.pluginMetadataSnapshot
+        ? extractPluginInstallRecordsFromInstalledPluginIndex(params.pluginMetadataSnapshot.index)
+        : undefined,
     },
     {
       onlyPluginIds: setupPluginIds,
@@ -277,6 +281,9 @@ function resolveRuntimeProviderPluginLoadState(
       workspaceDir: base.workspaceDir,
       env: base.env,
       logger: createPluginRuntimeLoaderLogger(),
+      installRecords: params.pluginMetadataSnapshot
+        ? extractPluginInstallRecordsFromInstalledPluginIndex(params.pluginMetadataSnapshot.index)
+        : undefined,
     },
     {
       onlyPluginIds: providerPluginIds,

--- a/src/plugins/runtime/load-context.test.ts
+++ b/src/plugins/runtime/load-context.test.ts
@@ -112,6 +112,7 @@ describe("resolvePluginRuntimeLoadContext", () => {
       env,
       logger: context.logger,
       manifestRegistry,
+      installRecords: {},
     });
     expect(loadPluginMetadataSnapshotMock).toHaveBeenCalledWith({
       config: rawConfig,
@@ -155,6 +156,32 @@ describe("resolvePluginRuntimeLoadContext", () => {
     });
   });
 
+  it("threads install records from the metadata snapshot into the context and load options", () => {
+    const snapshotWithRecords = {
+      ...metadataSnapshot,
+      index: {
+        installRecords: {
+          demo: { source: "registry", version: "1.0.0" },
+        },
+        plugins: [],
+        policyHash: "policy",
+      },
+    };
+    loadPluginMetadataSnapshotMock.mockReturnValueOnce(snapshotWithRecords);
+
+    const context = resolvePluginRuntimeLoadContext({
+      config: { plugins: {} },
+      env: { HOME: "/tmp/openclaw-home" } as NodeJS.ProcessEnv,
+    });
+
+    expect(context.installRecords).toEqual({
+      demo: { source: "registry", version: "1.0.0" },
+    });
+    expect(buildPluginRuntimeLoadOptions(context).installRecords).toEqual({
+      demo: { source: "registry", version: "1.0.0" },
+    });
+  });
+
   it("builds plugin load options from the shared runtime context", () => {
     const context = resolvePluginRuntimeLoadContext({
       config: { plugins: {} },
@@ -176,6 +203,7 @@ describe("resolvePluginRuntimeLoadContext", () => {
       env: context.env,
       logger: context.logger,
       manifestRegistry,
+      installRecords: {},
       cache: false,
       activate: false,
       onlyPluginIds: ["demo"],

--- a/src/plugins/runtime/load-context.ts
+++ b/src/plugins/runtime/load-context.ts
@@ -2,12 +2,14 @@ import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/ag
 import { getRuntimeConfig } from "../../config/config.js";
 import { applyPluginAutoEnable } from "../../config/plugin-auto-enable.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { PluginInstallRecord } from "../../config/types.plugins.js";
 import { createSubsystemLogger } from "../../logging.js";
 import { resolvePluginActivationSourceConfig } from "../activation-source-config.js";
 import {
   getCurrentPluginMetadataSnapshot,
   setCurrentPluginMetadataSnapshot,
 } from "../current-plugin-metadata-snapshot.js";
+import { extractPluginInstallRecordsFromInstalledPluginIndex } from "../installed-plugin-index-install-records.js";
 import type { PluginLoadOptions } from "../loader.js";
 import type { PluginManifestRegistry } from "../manifest-registry.js";
 import { loadPluginMetadataSnapshot } from "../plugin-metadata-snapshot.js";
@@ -24,6 +26,7 @@ export type PluginRuntimeLoadContext = {
   env: NodeJS.ProcessEnv;
   logger: PluginLogger;
   manifestRegistry?: PluginManifestRegistry;
+  installRecords?: Record<string, PluginInstallRecord>;
 };
 
 export type PluginRuntimeResolvedLoadValues = Pick<
@@ -35,6 +38,7 @@ export type PluginRuntimeResolvedLoadValues = Pick<
   | "env"
   | "logger"
   | "manifestRegistry"
+  | "installRecords"
 >;
 
 export type PluginRuntimeLoadContextOptions = {
@@ -75,6 +79,9 @@ export function resolvePluginRuntimeLoadContext(
         workspaceDir: rawWorkspaceDir,
       }));
   const manifestRegistry = options?.manifestRegistry ?? metadataSnapshot?.manifestRegistry;
+  const installRecords = metadataSnapshot
+    ? extractPluginInstallRecordsFromInstalledPluginIndex(metadataSnapshot.index)
+    : undefined;
   const activationSourceConfig = resolvePluginActivationSourceConfig({
     config: rawConfig,
     activationSourceConfig: options?.activationSourceConfig,
@@ -104,6 +111,7 @@ export function resolvePluginRuntimeLoadContext(
     env,
     logger: options?.logger ?? createPluginRuntimeLoaderLogger(),
     ...(manifestRegistry ? { manifestRegistry } : {}),
+    installRecords,
   };
 }
 
@@ -126,6 +134,7 @@ export function buildPluginRuntimeLoadOptionsFromValues(
     env: values.env,
     logger: values.logger,
     ...(values.manifestRegistry ? { manifestRegistry: values.manifestRegistry } : {}),
+    installRecords: values.installRecords,
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

Threads install records from a held `PluginMetadataSnapshot` through the plugin loader so downstream paths skip the synchronous `installs.json` read.

- Adds `installRecords?: Record<string, PluginInstallRecord>` to `PluginLoadOptions` (`src/plugins/loader.ts`); `resolvePluginLoadCacheContext` uses it, falling back to `loadInstalledPluginIndexInstallRecordsSync` only when not provided.
- Mirrors the field on `PluginRuntimeLoadContext` / `PluginRuntimeResolvedLoadValues` and forwards through `buildPluginRuntimeLoadOptionsFromValues` (`src/plugins/runtime/load-context.ts`); `resolvePluginRuntimeLoadContext` extracts records from the metadata snapshot via `extractPluginInstallRecordsFromInstalledPluginIndex`.
- Passes the same records through `resolveSetupProviderPluginLoadState` and `resolveRuntimeProviderPluginLoadState` from `params.pluginMetadataSnapshot` (`src/plugins/providers.runtime.ts`).
- `loader-provenance.ts` `buildProvenanceIndex` uses `params.installRecords ?? sync-read` instead of merging both — when the caller already supplied records they replace the read entirely.

Design note: when a snapshot exists with zero install records, the context returns `installRecords: {}`. This is a deliberate positive assertion ("I checked the snapshot, none") so the downstream `??` short-circuits and skips the sync read; `undefined` would re-trigger the disk read.

Net diff: +48/-5 across 5 files, one commit (4 prod files + the updated runtime load-context test).

## Verification

Behavior addressed: redundant `installs.json` reads on the plugin runtime load path when the caller already holds a `PluginMetadataSnapshot`.

Real environment tested: local Node 22.22.0, macOS Darwin 25.2.0, repo checkout on `b0bd33d888` rebased on `origin/main` (`b33deb4159`).

Exact steps or command run after this patch:

- `node scripts/run-vitest.mjs src/plugins/runtime/load-context.test.ts` → 4/4 pass (was 2/3 failing before the test update)
- `node scripts/run-vitest.mjs src/plugins/providers.test.ts src/plugins/active-runtime-registry.test.ts` → 58/58 pass
- `node scripts/run-vitest.mjs src/plugins/loader-records.test.ts src/plugins/loader.test.ts` → 134/134 pass
- `node scripts/run-vitest.mjs src/plugins/provider-runtime.test.ts src/plugins/web-fetch-providers.runtime.test.ts src/plugins/web-search-providers.runtime.test.ts` → 68/68 pass
- `node scripts/check-changed.mjs` → exit 0 (typecheck core + core-tests via tsgo, oxlint core, 13 guards including conflict-markers, dependency-pins, plugin-sdk wildcard re-exports, import cycles)
- `node_modules/.bin/oxfmt --check` on all 5 touched files → clean

Evidence after fix: added new test `threads install records from the metadata snapshot into the context and load options` in `src/plugins/runtime/load-context.test.ts` that injects a snapshot with `installRecords: { demo: { source: "registry", version: "1.0.0" } }` and asserts the records flow through both `resolvePluginRuntimeLoadContext` and `buildPluginRuntimeLoadOptions`. Updated the two pre-existing exact-equality assertions to include `installRecords: {}` (the positive empty-records assertion described above).

Observed result after fix: 264/264 tests pass across the affected loader/runtime/provider suites; full `check:changed` lane is green.

What was not tested: cold-start TUI timing has not been re-measured in this PR — the prior perf-trace audit motivating this work is not part of this diff. Broad/full lanes and crabbox were not run locally (crabbox binary was unavailable in this worktree); CI will exercise those.