### PR TITLE
fix(auth): skip OAuth refresh adapter when credential has no refresh token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Docs: https://docs.openclaw.ai
 - CLI/perf: keep `secrets --help` and `nodes --help` on the precomputed help path so parent help avoids loading action-heavy command runtime modules. (#84818) Thanks @frankekn.
 - CLI/perf: serve `doctor`, `gateway`, `models`, and `plugins` parent help from startup metadata so common subcommand help avoids full CLI program construction. (#84786) Thanks @frankekn.
 - Codex/Lossless: keep context-engine history on the canonical run session when Telegram DMs use per-peer runtime policy keys. Fixes #84936. (#84954) Thanks @neeravmakwana.
+- Auth/OAuth: skip the refresh adapter when a stored OAuth credential has no refresh token so agent turns fail fast on missing-key instead of waiting on the 120s refresh timeout. Thanks @romneyda.
 
 ## 2026.5.20
 

--- a/src/agents/auth-profiles/oauth-manager.test.ts
+++ b/src/agents/auth-profiles/oauth-manager.test.ts
@@ -555,6 +555,49 @@ describe("createOAuthManager", () => {
     });
   });
 
+  it("skips the refresh adapter when the credential has no refresh token", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "oauth-manager-no-refresh-"));
+    tempDirs.push(tempRoot);
+    process.env.OPENCLAW_STATE_DIR = tempRoot;
+    const agentDir = path.join(tempRoot, "agents", "main", "agent");
+    await fs.mkdir(agentDir, { recursive: true });
+    const profileId = "openai-codex:default";
+    const credential = createCredential({
+      access: "",
+      refresh: "",
+      expires: Date.now() - 60_000,
+    });
+    saveAuthProfileStore(
+      {
+        version: 1,
+        profiles: {
+          [profileId]: credential,
+        },
+      },
+      agentDir,
+      { filterExternalAuthProfiles: false },
+    );
+    const refreshCredential = vi.fn(async () => null);
+    const manager = createOAuthManager({
+      buildApiKey: async (_provider, value) => value.access,
+      refreshCredential,
+      readBootstrapCredential: () => null,
+      isRefreshTokenReusedError: () => false,
+    });
+
+    const result = await manager.resolveOAuthAccess({
+      store: ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {
+        allowKeychainPrompt: false,
+      }),
+      profileId,
+      credential,
+      agentDir,
+    });
+
+    expect(result).toBeNull();
+    expect(refreshCredential).not.toHaveBeenCalled();
+  });
+
   it("redacts the external oauth credential attempted during refresh failures", async () => {
     const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "oauth-manager-refresh-redact-"));
     tempDirs.push(tempRoot);

--- a/src/agents/auth-profiles/oauth-manager.ts
+++ b/src/agents/auth-profiles/oauth-manager.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { normalizeSecretInputString } from "../../config/types.secrets.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { withFileLock } from "../../infra/file-lock.js";
 import { redactSensitiveText } from "../../logging/redact.js";
@@ -533,6 +534,9 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
             }
           }
 
+          if (normalizeSecretInputString(credentialToRefresh.refresh) === undefined) {
+            return null;
+          }
           const refreshedCredentials = await withRefreshCallTimeout(
             `refreshOAuthCredential(${cred.provider})`,
             OAUTH_REFRESH_CALL_TIMEOUT_MS,


### PR DESCRIPTION
## Summary

OAuth credentials that loaded without their sidecar material (no `access`, no `refresh`) still entered the refresh path inside the per-profile lock. The adapter call there is bounded by `OAUTH_REFRESH_CALL_TIMEOUT_MS = 120_000` (`src/agents/auth-profiles/constants.ts:59`), so the eventual `No API key found for provider "..."` surface to the user only landed after a long stall — even though the resolver had no usable refresh material to attempt with in the first place.

Short-circuit `doRefreshOAuthTokenWithLock` (`src/agents/auth-profiles/oauth-manager.ts`) to return `null` when there is no refresh token. The check is placed **after** the in-lock main-store adoption (`oauth-manager.ts:455`) and external bootstrap-credential checks (`:498`), so sub-agents inheriting fresh tokens from the main store and externally-managed credentials still resolve normally. Only the dead-end "nothing to refresh with" case short-circuits.

Companion to #84752 (root cause: re-enabling legacy sidecar rehydration) — this change is the fail-fast layer that improves the diagnostic surface when something else leaves a credential record token-less.

## Verification

- `node scripts/run-vitest.mjs src/agents/auth-profiles/oauth-manager.test.ts` — 38 passed.
- `node scripts/run-vitest.mjs src/agents/model-auth.test.ts src/agents/auth-profiles/store-oauth-sidecar.test.ts` — 104 passed.
- New test `skips the refresh adapter when the credential has no refresh token` asserts `refreshCredential` is not called and the resolver returns `null`.

## Real behavior proof

- Behavior addressed: `No API key found for provider "openai-codex"` surfacing only after several minutes of silent waiting on the bounded OAuth refresh adapter call when the stored credential has no usable refresh token.
- Real environment tested: not exercised end-to-end on a live gateway — the change is gated behind the in-lock refresh adapter and has unit-test coverage that exercises the short-circuit. The matching slow-fail behavior is reproducible by editing an `auth-profiles.json` `openai-codex` entry to drop `access`/`refresh`, but that requires a real OAuth profile to start from.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/auth-profiles/oauth-manager.test.ts src/agents/model-auth.test.ts src/agents/auth-profiles/store-oauth-sidecar.test.ts`.
- Evidence after fix: 142 tests passed across the touched files; new short-circuit case passes (`refreshCredential` not invoked, resolver returns `null` immediately).
- Observed result after fix: the resolver returns `null` for credentials without refresh material without entering the bounded-timeout refresh adapter.
- What was not tested: live gateway turn against a real broken `openai-codex` profile (no live OAuth profile available in this environment).

## Test plan

- [x] Unit: new short-circuit test in `oauth-manager.test.ts`.
- [x] Regression: oauth-manager + model-auth + store-oauth-sidecar suites green.
- [ ] Live: confirm that an `openai-codex` profile with missing access/refresh now fails fast on the user-perceived embedded-runner turn (left for someone with a reproducible live env).