### PR TITLE
fix(skills): show empty state notice in config wizard

### DIFF
--- a/src/commands/onboard-skills.test.ts
+++ b/src/commands/onboard-skills.test.ts
@@ -169,6 +169,9 @@ describe("setupSkills", () => {
       expect(mocks.installSkill).not.toHaveBeenCalled();
       expect(notes.find((n) => n.title === "Container skill installs")).toBeDefined();
       expect(notes.find((n) => n.title === "Homebrew recommended")).toBeUndefined();
+      expect(
+        notes.find((n) => n.message.includes("No missing skill dependencies to install")),
+      ).toBeUndefined();
     } finally {
       Object.defineProperty(process, "platform", originalPlatformDescriptor);
     }

--- a/src/commands/onboard-skills.test.ts
+++ b/src/commands/onboard-skills.test.ts
@@ -266,16 +266,16 @@ describe("setupSkills", () => {
     expect(brewNote?.title).toBe("Homebrew recommended");
   });
 
-  it("displays a clear empty state note when no dependencies are installable", async () => {
+  it("displays a clear empty state note when all skill dependencies are ready", async () => {
     mockMissingBrewStatus([]);
 
     const { prompter, notes } = createPrompter({});
     await setupSkills({} as OpenClawConfig, "/tmp/ws", runtime, prompter);
 
     expect(prompter.multiselect).not.toHaveBeenCalled();
-    const emptyStateNote = notes.find(
-      (n) => n.message && n.message.includes("No missing skill dependencies to install"),
-    );
-    expect(emptyStateNote).toBeDefined();
+    const emptyStateNote = notes.find((n) => n.title === "All skills ready");
+    expect(emptyStateNote?.message).toContain("No missing skill dependencies to install");
+    expect(emptyStateNote?.message).toContain("openclaw skills list --verbose");
+    expect(emptyStateNote?.message).toContain("openclaw skills check");
   });
 });

--- a/src/commands/onboard-skills.test.ts
+++ b/src/commands/onboard-skills.test.ts
@@ -262,4 +262,17 @@ describe("setupSkills", () => {
     const brewNote = notes.find((n) => n.title === "Homebrew recommended");
     expect(brewNote?.title).toBe("Homebrew recommended");
   });
+
+  it("displays a clear empty state note when no dependencies are installable", async () => {
+    mockMissingBrewStatus([]);
+
+    const { prompter, notes } = createPrompter({});
+    await setupSkills({} as OpenClawConfig, "/tmp/ws", runtime, prompter);
+
+    expect(prompter.multiselect).not.toHaveBeenCalled();
+    const emptyStateNote = notes.find(
+      (n) => n.message && n.message.includes("No missing skill dependencies to install"),
+    );
+    expect(emptyStateNote).toBeDefined();
+  });
 });

--- a/src/commands/onboard-skills.ts
+++ b/src/commands/onboard-skills.ts
@@ -233,7 +233,7 @@ export async function setupSkills(
       );
       runtime.log(t("wizard.skills.docsLine"));
     }
-  } else {
+  } else if (baseInstallable.length === 0) {
     await prompter.note(t("wizard.skills.noDepsToInstall"));
   }
 

--- a/src/commands/onboard-skills.ts
+++ b/src/commands/onboard-skills.ts
@@ -116,6 +116,17 @@ export async function setupSkills(
     }
   }
   let next: OpenClawConfig = cfg;
+  if (installable.length === 0 && missing.length === 0) {
+    await prompter.note(
+      [
+        "No missing skill dependencies to install.",
+        `To inspect available skills, run: ${formatCliCommand("openclaw skills list --verbose")}`,
+        `To check skill status, run: ${formatCliCommand("openclaw skills check")}`,
+      ].join("\n"),
+      t("wizard.skills.allReadyTitle") ?? "All skills ready",
+    );
+    return next;
+  }
   if (installable.length > 0) {
     const toInstall = await prompter.multiselect({
       message: t("wizard.skills.installDeps"),
@@ -233,8 +244,6 @@ export async function setupSkills(
       );
       runtime.log(t("wizard.skills.docsLine"));
     }
-  } else if (baseInstallable.length === 0) {
-    await prompter.note(t("wizard.skills.noDepsToInstall"));
   }
 
   for (const skill of missing) {

--- a/src/commands/onboard-skills.ts
+++ b/src/commands/onboard-skills.ts
@@ -233,6 +233,8 @@ export async function setupSkills(
       );
       runtime.log(t("wizard.skills.docsLine"));
     }
+  } else {
+    await prompter.note(t("wizard.skills.noDepsToInstall"));
   }
 
   for (const skill of missing) {

--- a/src/wizard/i18n/locales/en.ts
+++ b/src/wizard/i18n/locales/en.ts
@@ -326,7 +326,7 @@ export const en = {
       setEnv: "Set {env} for {name}?",
       skipDepsHint: "Continue without installing dependencies",
       statusTitle: "Skills status",
-      noDepsToInstall: "No missing skill dependencies to install.\nTo inspect available skills, run: openclaw skills list --verbose",
+      allReadyTitle: "All skills ready",
     },
     channels: {
       account: "{label} account",

--- a/src/wizard/i18n/locales/en.ts
+++ b/src/wizard/i18n/locales/en.ts
@@ -326,6 +326,7 @@ export const en = {
       setEnv: "Set {env} for {name}?",
       skipDepsHint: "Continue without installing dependencies",
       statusTitle: "Skills status",
+      noDepsToInstall: "No missing skill dependencies to install.\nTo inspect available skills, run: openclaw skills list --verbose",
     },
     channels: {
       account: "{label} account",

--- a/src/wizard/i18n/locales/zh-CN.ts
+++ b/src/wizard/i18n/locales/zh-CN.ts
@@ -318,7 +318,7 @@ export const zh_CN = {
       setEnv: "为 {name} 设置 {env}？",
       skipDepsHint: "继续，不安装依赖",
       statusTitle: "技能状态",
-      noDepsToInstall: "没有需要安装的缺失技能依赖。\n要检查可用技能，请运行：openclaw skills list --verbose",
+      allReadyTitle: "所有技能已就绪",
     },
     channels: {
       account: "{label} 账号",

--- a/src/wizard/i18n/locales/zh-CN.ts
+++ b/src/wizard/i18n/locales/zh-CN.ts
@@ -318,6 +318,7 @@ export const zh_CN = {
       setEnv: "为 {name} 设置 {env}？",
       skipDepsHint: "继续，不安装依赖",
       statusTitle: "技能状态",
+      noDepsToInstall: "没有需要安装的缺失技能依赖。\n要检查可用技能，请运行：openclaw skills list --verbose",
     },
     channels: {
       account: "{label} 账号",

--- a/src/wizard/i18n/locales/zh-TW.ts
+++ b/src/wizard/i18n/locales/zh-TW.ts
@@ -318,7 +318,7 @@ export const zh_TW = {
       setEnv: "為 {name} 設定 {env}？",
       skipDepsHint: "繼續，不安裝依賴",
       statusTitle: "技能狀態",
-      noDepsToInstall: "沒有需要安裝的缺失技能依賴。\n要檢查可用技能，請運行：openclaw skills list --verbose",
+      allReadyTitle: "所有技能已就緒",
     },
     channels: {
       account: "{label} 帳號",

--- a/src/wizard/i18n/locales/zh-TW.ts
+++ b/src/wizard/i18n/locales/zh-TW.ts
@@ -318,6 +318,7 @@ export const zh_TW = {
       setEnv: "為 {name} 設定 {env}？",
       skipDepsHint: "繼續，不安裝依賴",
       statusTitle: "技能狀態",
+      noDepsToInstall: "沒有需要安裝的缺失技能依賴。\n要檢查可用技能，請運行：openclaw skills list --verbose",
     },
     channels: {
       account: "{label} 帳號",


### PR DESCRIPTION
## Summary

- Rebase the skills wizard empty-state fix onto current `main`.
- Show an explicit all-ready note when skill setup has no missing dependencies to install.
- Add localized title copy and focused regression coverage.

## Real behavior proof

Behavior addressed: `setupSkills()` could show the status summary, ask to configure skills, and then exit without any next-step note when every non-blocked skill was already eligible and no requirements were missing.
Real environment tested: local OpenClaw source checkout on macOS, Node/pnpm repo runtime, with a temporary `OPENCLAW_HOME` and the production skills status/setup path exercised directly through `node --import tsx`.
Exact steps or command run after this patch: `OPENCLAW_HOME=$(mktemp -d) TMP_WS=$(mktemp -d) node --import tsx --input-type=module` probe that builds real workspace skill status, disables the few missing non-blocked local skills to create the all-ready state, then calls `setupSkills()` with a recording prompter.
Evidence after fix:
```json
{
  "disabledMissingSkills": [
    "qqbot-channel",
    "qqbot-media",
    "qqbot-remind"
  ],
  "finalNote": {
    "title": "All skills ready",
    "message": "No missing skill dependencies to install.\nTo inspect available skills, run: openclaw skills list --verbose\nTo check skill status, run: openclaw skills check"
  }
}
```
Observed result after fix: the wizard emits an `All skills ready` note with `openclaw skills list --verbose` and `openclaw skills check`, does not show dependency multiselect, and does not call the installer.
What was not tested: no manual interactive terminal wizard session; the direct probe exercises the production setup path with a recording prompter, and the focused test covers the exact prompter calls.

## Verification

- `pnpm test src/commands/onboard-skills.test.ts`
- `pnpm check:test-types`
- `git diff --check`
- Auto Review: clean, no accepted/actionable findings.
