### PR TITLE
fix(docker): prune omitted plugin runtime deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 - Infra/json: retry transient `File changed during read` races while loading JSON state so config and state reads recover instead of failing the turn. (#84285)
 - Gateway/sessions: preserve compatible session auth profile overrides when switching models within the same provider, including provider-auth aliases. Fixes #81837. (#81886) Thanks @TurboTheTurtle.
 - Gateway/status: surface inbound delivery telemetry counters and transport-liveness warnings in `openclaw status --all`. Fixes #49577. (#72724)
+- Docker: prune package-excluded plugin source workspaces and dependency closures so runtime images do not keep packages for plugins that were not opted in.
 - Providers/Ollama: treat Docker/OrbStack host aliases as local Ollama endpoints so `ollama-local` marker auth works when OpenClaw runs inside a VM/container and Ollama runs on the host. Fixes #84875.
 - QA-Lab: keep explicitly searchable/deferred OpenClaw dynamic tool rows report-only by default so tool-coverage gates do not treat mock discovery gaps as hard product failures. (#80319) Thanks @100yenadmin.
 - Agents: cap heartbeat model bleed context hints by the stored session window when runtime model metadata is unavailable, so overflow recovery advice does not suggest a larger window than the active session actually has.

--- a/Dockerfile
+++ b/Dockerfile
@@ -117,8 +117,8 @@ ENV OPENCLAW_PREFER_PNPM=1
 RUN pnpm_config_verify_deps_before_run=false pnpm ui:build
 RUN pnpm_config_verify_deps_before_run=false pnpm qa:lab:build
 
-# Prune dev dependencies and strip build-only metadata before copying
-# runtime assets into the final image.
+# Prune dev dependencies, omitted plugin runtime packages, and build-only
+# metadata before copying runtime assets into the final image.
 FROM build AS runtime-assets
 ARG OPENCLAW_EXTENSIONS
 ARG OPENCLAW_BUNDLED_PLUGIN_DIR
@@ -128,8 +128,8 @@ RUN --mount=type=cache,id=openclaw-pnpm-store,target=/root/.local/share/pnpm/sto
       --config.supportedArchitectures.os=linux \
       --config.supportedArchitectures.cpu="$(node -p 'process.arch')" \
       --config.supportedArchitectures.libc=glibc && \
+    OPENCLAW_EXTENSIONS="$OPENCLAW_EXTENSIONS" OPENCLAW_BUNDLED_PLUGIN_DIR="$OPENCLAW_BUNDLED_PLUGIN_DIR" node scripts/prune-docker-plugin-dist.mjs && \
     node scripts/postinstall-bundled-plugins.mjs && \
-    OPENCLAW_EXTENSIONS="$OPENCLAW_EXTENSIONS" node scripts/prune-docker-plugin-dist.mjs && \
     find dist -type f \( -name '*.d.ts' -o -name '*.d.mts' -o -name '*.d.cts' -o -name '*.map' \) -delete && \
     node scripts/check-package-dist-imports.mjs /app
 

--- a/scripts/prune-docker-plugin-dist.mjs
+++ b/scripts/prune-docker-plugin-dist.mjs
@@ -4,6 +4,8 @@ import { pathToFileURL } from "node:url";
 import { collectRootPackageExcludedExtensionDirs } from "./lib/bundled-plugin-build-entries.mjs";
 import { removePathIfExists } from "./runtime-postbuild-shared.mjs";
 
+const RUNTIME_DEPENDENCY_FIELDS = ["dependencies", "optionalDependencies"];
+
 function parsePluginList(value) {
   if (typeof value !== "string") {
     return new Set();
@@ -20,27 +22,157 @@ export function parseDockerPluginKeepList(value) {
   return parsePluginList(value);
 }
 
+function readPackageJson(filePath) {
+  if (!fs.existsSync(filePath)) {
+    return null;
+  }
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function collectRuntimeDependencyNames(packageJson) {
+  const dependencies = new Set();
+  for (const field of RUNTIME_DEPENDENCY_FIELDS) {
+    for (const dependencyName of Object.keys(packageJson?.[field] ?? {})) {
+      dependencies.add(dependencyName);
+    }
+  }
+  return dependencies;
+}
+
+function nodeModulePath(repoRoot, packageName) {
+  return path.join(repoRoot, "node_modules", ...packageName.split("/"));
+}
+
+function removeEmptyScopeDir(repoRoot, packageName) {
+  if (!packageName.startsWith("@")) {
+    return;
+  }
+  const [scope] = packageName.split("/");
+  const scopeDir = path.join(repoRoot, "node_modules", scope);
+  try {
+    fs.rmdirSync(scopeDir);
+  } catch {
+    // Scope still has other packages or does not exist.
+  }
+}
+
+function collectPackageRuntimeClosure(repoRoot, seedPackageNames) {
+  const seen = new Set();
+  const stack = [...seedPackageNames];
+
+  while (stack.length > 0) {
+    const packageName = stack.pop();
+    if (!packageName || seen.has(packageName)) {
+      continue;
+    }
+    seen.add(packageName);
+
+    const packageJson = readPackageJson(path.join(nodeModulePath(repoRoot, packageName), "package.json"));
+    for (const dependencyName of collectRuntimeDependencyNames(packageJson)) {
+      if (!seen.has(dependencyName)) {
+        stack.push(dependencyName);
+      }
+    }
+  }
+
+  return seen;
+}
+
+function collectWorkspacePackageRuntimeSeeds(repoRoot, workspaceDir, excludedPluginIds) {
+  const seeds = new Set();
+  const workspaceRoot = path.join(repoRoot, workspaceDir);
+  if (!fs.existsSync(workspaceRoot)) {
+    return seeds;
+  }
+
+  for (const entry of fs.readdirSync(workspaceRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory() || excludedPluginIds.has(entry.name)) {
+      continue;
+    }
+    const packageJson = readPackageJson(path.join(workspaceRoot, entry.name, "package.json"));
+    if (typeof packageJson?.name === "string") {
+      seeds.add(packageJson.name);
+    }
+    for (const dependencyName of collectRuntimeDependencyNames(packageJson)) {
+      seeds.add(dependencyName);
+    }
+  }
+  return seeds;
+}
+
+function pruneNodeModulesForOmittedPlugins(repoRoot, bundledPluginDir, omittedPluginIds) {
+  const rootPackageJson = readPackageJson(path.join(repoRoot, "package.json"));
+  const omittedPackageNames = new Set();
+  const omittedSeeds = new Set();
+
+  for (const pluginId of omittedPluginIds) {
+    const packageJson = readPackageJson(path.join(repoRoot, bundledPluginDir, pluginId, "package.json"));
+    if (typeof packageJson?.name === "string") {
+      omittedPackageNames.add(packageJson.name);
+    }
+    for (const dependencyName of collectRuntimeDependencyNames(packageJson)) {
+      omittedSeeds.add(dependencyName);
+    }
+  }
+
+  const keptSeeds = new Set(collectRuntimeDependencyNames(rootPackageJson));
+  for (const dependencyName of collectWorkspacePackageRuntimeSeeds(repoRoot, "packages", new Set())) {
+    keptSeeds.add(dependencyName);
+  }
+  for (const dependencyName of collectWorkspacePackageRuntimeSeeds(
+    repoRoot,
+    bundledPluginDir,
+    omittedPluginIds,
+  )) {
+    keptSeeds.add(dependencyName);
+  }
+
+  const keptClosure = collectPackageRuntimeClosure(repoRoot, keptSeeds);
+  const omittedClosure = collectPackageRuntimeClosure(repoRoot, omittedSeeds);
+  const removed = [];
+  const removalCandidates = new Set([...omittedPackageNames, ...omittedClosure]);
+
+  for (const packageName of [...removalCandidates].toSorted((left, right) =>
+    left.localeCompare(right),
+  )) {
+    if (keptClosure.has(packageName)) {
+      continue;
+    }
+    const packageDir = nodeModulePath(repoRoot, packageName);
+    if (!fs.existsSync(packageDir)) {
+      continue;
+    }
+    removePathIfExists(packageDir);
+    removeEmptyScopeDir(repoRoot, packageName);
+    removed.push(path.relative(repoRoot, packageDir).replaceAll("\\", "/"));
+  }
+
+  return removed;
+}
+
 export function pruneDockerPluginDist(params = {}) {
   const repoRoot = params.cwd ?? params.repoRoot ?? process.cwd();
   const env = params.env ?? process.env;
+  const bundledPluginDir = env.OPENCLAW_BUNDLED_PLUGIN_DIR ?? "extensions";
   const keepPluginIds = parseDockerPluginKeepList(env.OPENCLAW_EXTENSIONS);
   const excludedPluginIds = collectRootPackageExcludedExtensionDirs({ cwd: repoRoot });
+  const omittedPluginIds = new Set([...excludedPluginIds].filter((pluginId) => !keepPluginIds.has(pluginId)));
   const removed = [];
 
-  for (const pluginId of [...excludedPluginIds].toSorted((left, right) =>
-    left.localeCompare(right),
-  )) {
-    if (keepPluginIds.has(pluginId)) {
-      continue;
-    }
+  removed.push(...pruneNodeModulesForOmittedPlugins(repoRoot, bundledPluginDir, omittedPluginIds));
 
-    for (const root of ["dist", "dist-runtime"]) {
-      const pluginDistDir = path.join(repoRoot, root, "extensions", pluginId);
-      if (!fs.existsSync(pluginDistDir)) {
+  for (const pluginId of [...omittedPluginIds].toSorted((left, right) => left.localeCompare(right))) {
+    for (const pluginPath of [
+      path.join(bundledPluginDir, pluginId),
+      path.join("dist", "extensions", pluginId),
+      path.join("dist-runtime", "extensions", pluginId),
+    ]) {
+      const absolutePluginPath = path.join(repoRoot, pluginPath);
+      if (!fs.existsSync(absolutePluginPath)) {
         continue;
       }
-      removePathIfExists(pluginDistDir);
-      removed.push(path.relative(repoRoot, pluginDistDir).replaceAll("\\", "/"));
+      removePathIfExists(absolutePluginPath);
+      removed.push(path.relative(repoRoot, absolutePluginPath).replaceAll("\\", "/"));
     }
   }
 

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -162,7 +162,7 @@ describe("Dockerfile", () => {
     expect(dockerfile).toContain("pnpm_config_verify_deps_before_run=false pnpm qa:lab:build");
   });
 
-  it("prunes runtime dependencies after the build stage", async () => {
+  it("prunes runtime dependencies and omitted plugin packages after the build stage", async () => {
     const dockerfile = await readFile(dockerfilePath, "utf8");
     expect(dockerfile).toContain("FROM build AS runtime-assets");
     expect(dockerfile).toContain("ARG OPENCLAW_EXTENSIONS");
@@ -180,16 +180,23 @@ describe("Dockerfile", () => {
     expect(dockerfile).toContain(
       "COPY --from=workspace-deps /out/${OPENCLAW_BUNDLED_PLUGIN_DIR}/ ./${OPENCLAW_BUNDLED_PLUGIN_DIR}/",
     );
+    expect(dockerfile).toContain(
+      'OPENCLAW_EXTENSIONS="$OPENCLAW_EXTENSIONS" OPENCLAW_BUNDLED_PLUGIN_DIR="$OPENCLAW_BUNDLED_PLUGIN_DIR" node scripts/prune-docker-plugin-dist.mjs',
+    );
     expect(dockerfile).toContain("CI=true pnpm prune --prod \\");
+    expect(
+      dockerfile.indexOf("CI=true pnpm prune --prod \\"),
+    ).toBeLessThan(
+      dockerfile.indexOf(
+        'OPENCLAW_EXTENSIONS="$OPENCLAW_EXTENSIONS" OPENCLAW_BUNDLED_PLUGIN_DIR="$OPENCLAW_BUNDLED_PLUGIN_DIR" node scripts/prune-docker-plugin-dist.mjs',
+      ),
+    );
     expect(dockerfile).toContain("--config.offline=true");
     expect(dockerfile).toContain("--config.supportedArchitectures.os=linux");
     expect(dockerfile).toContain(
       "--config.supportedArchitectures.cpu=\"$(node -p 'process.arch')\"",
     );
     expect(dockerfile).toContain("--config.supportedArchitectures.libc=glibc");
-    expect(dockerfile).toContain(
-      'OPENCLAW_EXTENSIONS="$OPENCLAW_EXTENSIONS" node scripts/prune-docker-plugin-dist.mjs',
-    );
     expect(dockerfile).not.toContain("pnpm-workspace.runtime.yaml");
     expect(dockerfile).not.toContain("write-runtime-pnpm-workspace");
     expect(dockerfile).not.toContain(

--- a/src/plugins/prune-docker-plugin-dist.test.ts
+++ b/src/plugins/prune-docker-plugin-dist.test.ts
@@ -19,6 +19,29 @@ function writeDistPluginFile(repoRoot: string, root: "dist" | "dist-runtime", pl
   fs.writeFileSync(path.join(pluginDir, "openclaw.plugin.json"), "{}\n", "utf8");
 }
 
+function writePluginSourcePackage(repoRoot: string, pluginId: string) {
+  const pluginDir = path.join(repoRoot, "extensions", pluginId);
+  fs.mkdirSync(pluginDir, { recursive: true });
+  writeJsonFile(path.join(pluginDir, "package.json"), {
+    name: `@openclaw/${pluginId}`,
+    version: "0.0.0",
+  });
+}
+
+function writeNodePackage(
+  repoRoot: string,
+  packageName: string,
+  packageJson: Record<string, unknown> = {},
+) {
+  const packageDir = path.join(repoRoot, "node_modules", ...packageName.split("/"));
+  fs.mkdirSync(packageDir, { recursive: true });
+  writeJsonFile(path.join(packageDir, "package.json"), {
+    name: packageName,
+    version: "0.0.0",
+    ...packageJson,
+  });
+}
+
 afterEach(() => {
   cleanupTempDirs(tempDirs);
 });
@@ -32,11 +55,14 @@ describe("pruneDockerPluginDist", () => {
     ]);
   });
 
-  it("removes package-excluded plugin dist unless Docker explicitly opts it in", () => {
+  it("removes package-excluded plugin runtime artifacts unless Docker explicitly opts it in", () => {
     const repoRoot = makeRepoRoot("openclaw-docker-plugin-dist-");
     writeJsonFile(path.join(repoRoot, "package.json"), {
       files: ["dist/**", "!dist/extensions/diagnostics-otel/**", "!dist/extensions/feishu/**"],
     });
+    writePluginSourcePackage(repoRoot, "diagnostics-otel");
+    writePluginSourcePackage(repoRoot, "feishu");
+    writePluginSourcePackage(repoRoot, "telegram");
     writeDistPluginFile(repoRoot, "dist", "diagnostics-otel");
     writeDistPluginFile(repoRoot, "dist", "feishu");
     writeDistPluginFile(repoRoot, "dist-runtime", "feishu");
@@ -47,10 +73,100 @@ describe("pruneDockerPluginDist", () => {
       env: { OPENCLAW_EXTENSIONS: "diagnostics-otel" } as NodeJS.ProcessEnv,
     });
 
-    expect(removed).toEqual(["dist/extensions/feishu", "dist-runtime/extensions/feishu"]);
+    expect(removed).toEqual([
+      "extensions/feishu",
+      "dist/extensions/feishu",
+      "dist-runtime/extensions/feishu",
+    ]);
+    expect(fs.existsSync(path.join(repoRoot, "extensions", "diagnostics-otel"))).toBe(true);
+    expect(fs.existsSync(path.join(repoRoot, "extensions", "feishu"))).toBe(false);
+    expect(fs.existsSync(path.join(repoRoot, "extensions", "telegram"))).toBe(true);
     expect(fs.existsSync(path.join(repoRoot, "dist", "extensions", "diagnostics-otel"))).toBe(true);
     expect(fs.existsSync(path.join(repoRoot, "dist", "extensions", "feishu"))).toBe(false);
     expect(fs.existsSync(path.join(repoRoot, "dist-runtime", "extensions", "feishu"))).toBe(false);
     expect(fs.existsSync(path.join(repoRoot, "dist", "extensions", "telegram"))).toBe(true);
+  });
+
+  it("honors custom bundled plugin source roots when pruning Docker runtime importers", () => {
+    const repoRoot = makeRepoRoot("openclaw-docker-plugin-source-");
+    writeJsonFile(path.join(repoRoot, "package.json"), {
+      files: ["dist/**", "!dist/extensions/acpx/**"],
+    });
+    const pluginDir = path.join(repoRoot, "plugins", "acpx");
+    fs.mkdirSync(pluginDir, { recursive: true });
+    writeJsonFile(path.join(pluginDir, "package.json"), {
+      name: "@openclaw/acpx",
+      version: "0.0.0",
+    });
+
+    const removed = pruneDockerPluginDist({
+      repoRoot,
+      env: {
+        OPENCLAW_BUNDLED_PLUGIN_DIR: "plugins",
+      } as NodeJS.ProcessEnv,
+    });
+
+    expect(removed).toEqual(["plugins/acpx"]);
+    expect(fs.existsSync(pluginDir)).toBe(false);
+  });
+
+  it("removes node_modules dependency closure that only omitted Docker plugins need", () => {
+    const repoRoot = makeRepoRoot("openclaw-docker-plugin-node-modules-");
+    writeJsonFile(path.join(repoRoot, "package.json"), {
+      files: ["dist/**", "!dist/extensions/acpx/**", "!dist/extensions/codex/**"],
+      dependencies: {
+        zod: "0.0.0",
+      },
+    });
+    writeJsonFile(path.join(repoRoot, "extensions", "acpx", "package.json"), {
+      name: "@openclaw/acpx",
+      version: "0.0.0",
+      dependencies: {
+        "@zed-industries/codex-acp": "0.0.0",
+        zod: "0.0.0",
+      },
+    });
+    writeJsonFile(path.join(repoRoot, "extensions", "codex", "package.json"), {
+      name: "@openclaw/codex",
+      version: "0.0.0",
+      dependencies: {
+        "@openai/codex": "0.0.0",
+        zod: "0.0.0",
+      },
+    });
+    writeNodePackage(repoRoot, "@openclaw/acpx");
+    writeNodePackage(repoRoot, "@openclaw/codex");
+    writeNodePackage(repoRoot, "zod");
+    writeNodePackage(repoRoot, "@openai/codex", {
+      optionalDependencies: {
+        "@openai/codex-linux-x64": "0.0.0",
+      },
+    });
+    writeNodePackage(repoRoot, "@openai/codex-linux-x64");
+    writeNodePackage(repoRoot, "@zed-industries/codex-acp", {
+      optionalDependencies: {
+        "@zed-industries/codex-acp-linux-x64": "0.0.0",
+      },
+    });
+    writeNodePackage(repoRoot, "@zed-industries/codex-acp-linux-x64");
+
+    const removed = pruneDockerPluginDist({
+      repoRoot,
+      env: { OPENCLAW_EXTENSIONS: "codex" } as NodeJS.ProcessEnv,
+    });
+
+    expect(removed).toEqual([
+      "node_modules/@openclaw/acpx",
+      "node_modules/@zed-industries/codex-acp",
+      "node_modules/@zed-industries/codex-acp-linux-x64",
+      "extensions/acpx",
+    ]);
+    expect(fs.existsSync(path.join(repoRoot, "node_modules", "zod"))).toBe(true);
+    expect(fs.existsSync(path.join(repoRoot, "node_modules", "@openai", "codex"))).toBe(true);
+    expect(fs.existsSync(path.join(repoRoot, "node_modules", "@openai", "codex-linux-x64"))).toBe(
+      true,
+    );
+    expect(fs.existsSync(path.join(repoRoot, "node_modules", "@zed-industries"))).toBe(false);
+    expect(fs.existsSync(path.join(repoRoot, "extensions", "codex"))).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- prune dependency closure for package-excluded plugins that are omitted from Docker `OPENCLAW_EXTENSIONS`
- remove omitted plugin source/dist artifacts from runtime images while preserving explicitly opted-in plugins like `codex` and `diagnostics-otel`
- add Dockerfile ordering and pruning coverage plus a changelog entry

## Verification

- `git diff --check`
- `node --check scripts/prune-docker-plugin-dist.mjs`
- `AUTOREVIEW_AUTO_TESTS=0 AUTOREVIEW_OPENCLAW_MAINTAINER_VALIDATION=1 .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- Testbox-through-Crabbox `tbx_01ks5phbr5ctdjfdjnnf99cbe7` / Actions run `26239677598`: `node scripts/run-vitest.mjs src/plugins/prune-docker-plugin-dist.test.ts src/dockerfile.test.ts` passed, 22 tests
- Testbox-through-Crabbox `tbx_01ks5pqag3dmer7ram89t2qcbk` / Actions run `26239844906`: Docker build and runtime audit passed; image size `1171259523` bytes; `/app` `933M`
- Testbox-through-Crabbox `tbx_01ks5q7zrwcak7kdtwr5hd38b7` / Actions run `26240317899`: `pnpm check:changed --base HEAD~1 --head HEAD` passed after fetching branch depth 2

## Real behavior proof

Behavior addressed: Docker runtime images no longer keep source workspaces or dependency closures for package-excluded plugins that were not opted in through `OPENCLAW_EXTENSIONS`.

Real environment tested: Blacksmith Testbox through Crabbox on Linux amd64 with Docker Engine 28.0.4.

Exact steps or command run after this patch: built `openclaw:runtime-prune` with `DOCKER_BUILDKIT=1 docker build --build-arg OPENCLAW_EXTENSIONS=diagnostics-otel,codex -t openclaw:runtime-prune .`, then ran container assertions for kept and omitted plugin paths.

Evidence after fix: the built image kept `/app/extensions/codex`, `/app/extensions/diagnostics-otel`, and `/app/node_modules/@openai/codex-linux-x64`, while omitting `/app/extensions/acpx`, `/app/extensions/memory-lancedb`, `/app/extensions/tlon`, `/app/node_modules/@zed-industries/codex-acp-linux-x64`, `/app/node_modules/@anthropic-ai/claude-agent-sdk-linux-x64`, `/app/node_modules/@lancedb/lancedb-linux-x64-gnu`, and `/app/node_modules/@tloncorp/tlon-skill-linux-x64`.

Observed result after fix: Docker build and runtime audit completed successfully; image size was `1171259523` bytes and `/app` was `933M`.

What was not tested: multi-arch release buildx publication was not run; local macOS Vitest remained blocked by a missing shared optional native dependency, so validation was routed through Testbox.
