### PR TITLE
Add follow-up queue plugin hooks for OpenCOAT weaving

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-68bf012e03431fa1e29416489b829be3d2b6897f732d45de5b20fa30eb754119  plugin-sdk-api-baseline.json
-7c6aa6ff2b42935228cc5cba1c2dd963af7534ac37daec3a5a8d0b9b3ba1620d  plugin-sdk-api-baseline.jsonl
+4222cfb163ee3ac7643d1e76596b9df6026cd7344f0acb26b1fedcf149f09230  plugin-sdk-api-baseline.json
+8ae646d556fcb309226b3816b622821ee598eaf443c16a26d4ba46b8f2e6a144  plugin-sdk-api-baseline.jsonl

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-4222cfb163ee3ac7643d1e76596b9df6026cd7344f0acb26b1fedcf149f09230  plugin-sdk-api-baseline.json
-8ae646d556fcb309226b3816b622821ee598eaf443c16a26d4ba46b8f2e6a144  plugin-sdk-api-baseline.jsonl
+ce9382fa4cd97fba8f3f9dbd2d303f80f7a57dcaa3352bced615a61298e8ee48  plugin-sdk-api-baseline.json
+44b9dfafc22ee025a238f637de8ca63c732c433d4a7ee60c6d67baadef35aa77  plugin-sdk-api-baseline.jsonl

--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -123,6 +123,11 @@ observation-only.
 - **`tool_result_persist`** - rewrite the assistant message produced from a tool result
 - **`before_message_write`** - inspect or block an in-progress message write (rare)
 
+**Queue**
+
+- **`queue_before_enqueue`** - block or rewrite an active-run follow-up before it enters the queue
+- `queue_after_enqueue` - observe the applied follow-up queue decision and queue depth change
+
 **Messages and delivery**
 
 - **`inbound_claim`** - claim an inbound message before agent routing (synthetic replies)
@@ -215,6 +220,44 @@ with `api.registerTrustedToolPolicy(...)`. These run before ordinary
 for host-trusted gates such as workspace policy, budget enforcement, or
 reserved workflow safety. External plugins should use normal `before_tool_call`
 hooks.
+
+## Queue policy
+
+`queue_before_enqueue` runs when a user message is about to be queued behind an
+already-active run. It receives:
+
+- `event.queueKey`
+- `event.queueMode`
+- optional `event.dropPolicy`
+- `event.depthBefore`
+- `event.prompt`
+- optional `event.summaryLine`
+- optional `event.messageId`
+- optional origin fields: `originatingChannel`, `originatingTo`,
+  `originatingAccountId`, `originatingThreadId`
+- optional session fields: `sessionId`, `sessionKey`
+
+It can return:
+
+```typescript
+type QueueBeforeEnqueueResult = {
+  block?: boolean;
+  blockReason?: string;
+  prompt?: string;
+  summaryLine?: string;
+};
+```
+
+Returning `{ block: true }` stops lower-priority queue handlers and skips the
+enqueue. Returning `prompt` or `summaryLine` rewrites the queued follow-up before
+the queue applies dedupe and drop policy.
+
+`queue_after_enqueue` receives the same event plus:
+
+- `event.depthAfter`
+- `event.enqueued`
+
+It is observation-only and runs after the queue decision has been applied.
 
 ### Tool result persistence
 

--- a/src/agents/pi-embedded-runner/run-state.ts
+++ b/src/agents/pi-embedded-runner/run-state.ts
@@ -9,6 +9,7 @@ import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
 export type EmbeddedPiQueueHandle = {
   kind?: "embedded";
   queueMessage: (text: string, options?: EmbeddedPiQueueMessageOptions) => Promise<void>;
+  getQueueDepth?: () => number | undefined;
   isStreaming: () => boolean;
   isCompacting: () => boolean;
   supportsTranscriptCommitWait?: boolean;

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -3317,6 +3317,7 @@ export async function runEmbeddedAttempt(
           }
           await steerActiveSessionWithOptionalDeliveryWait(activeSession, text, options);
         },
+        getQueueDepth: () => getPiSteeringQueueMessages(activeSession.agent)?.length,
         isStreaming: () => activeSession.isStreaming,
         isCompacting: () => subscription.isCompacting(),
         supportsTranscriptCommitWait: true,

--- a/src/agents/pi-embedded-runner/runs.test.ts
+++ b/src/agents/pi-embedded-runner/runs.test.ts
@@ -1,10 +1,11 @@
 import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { diagnosticLogger } from "../../logging/diagnostic.js";
 import {
   testing as replyRunTesting,
   createReplyOperation,
 } from "../../auto-reply/reply/reply-run-registry.js";
+import { diagnosticLogger } from "../../logging/diagnostic.js";
+import * as hookRunnerGlobal from "../../plugins/hook-runner-global.js";
 import {
   testing,
   abortAndDrainEmbeddedPiRun,
@@ -192,6 +193,102 @@ describe("pi-embedded runner run registry", () => {
     });
     expect(formatEmbeddedPiQueueFailureSummary(outcome)).toBe(
       "queue_message_failed reason=runtime_rejected sessionId=session-rejected gatewayHealth=live error=cannot steer a compact turn",
+    );
+  });
+
+  it("runs queue hooks for async active embedded steering", async () => {
+    const queueMessage = vi.fn(async () => {});
+    const beforeHook = vi.fn(async () => ({ prompt: "rewritten follow-up" }));
+    const afterHook = vi.fn(async () => {});
+    vi.spyOn(hookRunnerGlobal, "getGlobalHookRunner").mockReturnValue({
+      hasHooks: (hookName: string) =>
+        hookName === "queue_before_enqueue" || hookName === "queue_after_enqueue",
+      runQueueBeforeEnqueue: beforeHook,
+      runQueueAfterEnqueue: afterHook,
+    } as never);
+
+    setActiveEmbeddedRun(
+      "session-hooked",
+      {
+        ...createRunHandle(),
+        getQueueDepth: () => 2,
+        queueMessage,
+      },
+      "agent:main:hooked",
+    );
+
+    const outcome = await queueEmbeddedPiMessageWithOutcomeAsync("session-hooked", "original");
+
+    expect(outcome.queued).toBe(true);
+    expect(queueMessage).toHaveBeenCalledWith("rewritten follow-up", { steeringMode: "all" });
+    expect(beforeHook).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queueKey: "agent:main:hooked",
+        queueMode: "steer",
+        depthBefore: 2,
+        prompt: "original",
+        sessionId: "session-hooked",
+        sessionKey: "agent:main:hooked",
+        originatingChannel: "embedded_run",
+      }),
+      expect.objectContaining({
+        sessionId: "session-hooked",
+        sessionKey: "agent:main:hooked",
+        channelId: "embedded_run",
+      }),
+    );
+    expect(afterHook).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queueKey: "agent:main:hooked",
+        queueMode: "steer",
+        depthBefore: 2,
+        depthAfter: 2,
+        enqueued: true,
+        prompt: "rewritten follow-up",
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it("blocks async active embedded steering from queue_before_enqueue hooks", async () => {
+    const queueMessage = vi.fn(async () => {});
+    const afterHook = vi.fn(async () => {});
+    vi.spyOn(hookRunnerGlobal, "getGlobalHookRunner").mockReturnValue({
+      hasHooks: (hookName: string) =>
+        hookName === "queue_before_enqueue" || hookName === "queue_after_enqueue",
+      runQueueBeforeEnqueue: vi.fn(async () => ({
+        block: true,
+        blockReason: "policy denied",
+      })),
+      runQueueAfterEnqueue: afterHook,
+    } as never);
+
+    setActiveEmbeddedRun(
+      "session-blocked",
+      {
+        ...createRunHandle(),
+        queueMessage,
+      },
+      "agent:main:blocked",
+    );
+
+    const outcome = await queueEmbeddedPiMessageWithOutcomeAsync("session-blocked", "original");
+
+    expect(outcome).toEqual({
+      queued: false,
+      sessionId: "session-blocked",
+      reason: "runtime_rejected",
+      gatewayHealth: "live",
+      errorMessage: "policy denied",
+    });
+    expect(queueMessage).not.toHaveBeenCalled();
+    expect(afterHook).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queueKey: "agent:main:blocked",
+        enqueued: false,
+        prompt: "original",
+      }),
+      expect.any(Object),
     );
   });
 

--- a/src/agents/pi-embedded-runner/runs.ts
+++ b/src/agents/pi-embedded-runner/runs.ts
@@ -17,6 +17,7 @@ import {
   logMessageQueued,
   logSessionStateChange,
 } from "../../logging/diagnostic.js";
+import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import {
   ACTIVE_EMBEDDED_RUNS,
@@ -100,6 +101,110 @@ export function formatEmbeddedPiQueueFailureSummary(
   const errorPart = outcome.errorMessage ? ` error=${outcome.errorMessage}` : "";
   return `queue_message_failed reason=${outcome.reason} sessionId=${outcome.sessionId} gatewayHealth=${outcome.gatewayHealth}${errorPart}`;
 }
+
+function resolveSessionKeyForActiveRun(sessionId: string): string | undefined {
+  for (const [sessionKey, activeSessionId] of ACTIVE_EMBEDDED_RUN_SESSION_IDS_BY_KEY) {
+    if (activeSessionId === sessionId) {
+      return sessionKey;
+    }
+  }
+  return undefined;
+}
+
+function readQueueDepth(handle: EmbeddedPiQueueHandle): number {
+  const value = handle.getQueueDepth?.();
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? Math.floor(value) : 0;
+}
+
+async function runEmbeddedQueueBeforeEnqueueHooks(params: {
+  sessionId: string;
+  handle: EmbeddedPiQueueHandle;
+  text: string;
+}): Promise<
+  | {
+      status: "ok";
+      text: string;
+      depthBefore: number;
+      sessionKey?: string;
+    }
+  | {
+      status: "blocked";
+      depthBefore: number;
+      reason?: string;
+      sessionKey?: string;
+    }
+> {
+  const hookRunner = getGlobalHookRunner();
+  const depthBefore = readQueueDepth(params.handle);
+  const sessionKey = resolveSessionKeyForActiveRun(params.sessionId);
+  if (!hookRunner?.hasHooks("queue_before_enqueue")) {
+    return { status: "ok", text: params.text, depthBefore, sessionKey };
+  }
+
+  const result = await hookRunner.runQueueBeforeEnqueue(
+    {
+      queueKey: sessionKey ?? params.sessionId,
+      queueMode: "steer",
+      depthBefore,
+      prompt: params.text,
+      sessionId: params.sessionId,
+      ...(sessionKey ? { sessionKey } : {}),
+      originatingChannel: "embedded_run",
+    },
+    {
+      sessionId: params.sessionId,
+      sessionKey,
+      channelId: "embedded_run",
+    },
+  );
+  if (result?.block === true) {
+    return {
+      status: "blocked",
+      depthBefore,
+      sessionKey,
+      reason: result.blockReason,
+    };
+  }
+  return {
+    status: "ok",
+    text: normalizeOptionalString(result?.prompt) ?? params.text,
+    depthBefore,
+    sessionKey,
+  };
+}
+
+function runEmbeddedQueueAfterEnqueueHooks(params: {
+  sessionId: string;
+  handle: EmbeddedPiQueueHandle;
+  text: string;
+  depthBefore: number;
+  enqueued: boolean;
+  sessionKey?: string;
+}): void {
+  const hookRunner = getGlobalHookRunner();
+  if (!hookRunner?.hasHooks("queue_after_enqueue")) {
+    return;
+  }
+  void hookRunner.runQueueAfterEnqueue(
+    {
+      queueKey: params.sessionKey ?? params.sessionId,
+      queueMode: "steer",
+      depthBefore: params.depthBefore,
+      depthAfter: readQueueDepth(params.handle),
+      enqueued: params.enqueued,
+      prompt: params.text,
+      sessionId: params.sessionId,
+      ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+      originatingChannel: "embedded_run",
+    },
+    {
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+      channelId: "embedded_run",
+    },
+  );
+}
+
 function setActiveRunSessionKey(sessionKey: string | undefined, sessionId: string): void {
   const normalizedSessionKey = sessionKey?.trim();
   if (!normalizedSessionKey) {
@@ -181,10 +286,39 @@ export async function queueEmbeddedPiMessageWithOutcomeAsync(
     return prepared.outcome;
   }
   try {
+    const queueHookResult = await runEmbeddedQueueBeforeEnqueueHooks({
+      sessionId,
+      handle: prepared.handle,
+      text,
+    });
+    if (queueHookResult.status === "blocked") {
+      runEmbeddedQueueAfterEnqueueHooks({
+        sessionId,
+        handle: prepared.handle,
+        text,
+        depthBefore: queueHookResult.depthBefore,
+        enqueued: false,
+        sessionKey: queueHookResult.sessionKey,
+      });
+      return createQueueFailureOutcome(
+        sessionId,
+        "runtime_rejected",
+        queueHookResult.reason ?? "blocked by queue_before_enqueue hook",
+      );
+    }
+    text = queueHookResult.text;
     const enqueuedAtMs = Date.now();
     await prepared.handle.queueMessage(text, options ?? { steeringMode: "all" });
     const deliveredAtMs = options?.waitForTranscriptCommit ? Date.now() : undefined;
     logMessageQueued({ sessionId, source: "pi-embedded-runner" });
+    runEmbeddedQueueAfterEnqueueHooks({
+      sessionId,
+      handle: prepared.handle,
+      text,
+      depthBefore: queueHookResult.depthBefore,
+      enqueued: true,
+      sessionKey: queueHookResult.sessionKey,
+    });
     return {
       queued: true,
       sessionId,

--- a/src/auto-reply/reply/agent-runner.media-paths.test.ts
+++ b/src/auto-reply/reply/agent-runner.media-paths.test.ts
@@ -64,11 +64,15 @@ vi.mock("../../agents/pi-embedded-runner/runs.js", () => ({
   queueEmbeddedPiMessageWithOutcomeAsync: queueEmbeddedPiMessageWithOutcomeAsyncMock,
 }));
 
-vi.mock("./queue.js", () => ({
-  enqueueFollowupRun: enqueueFollowupRunMock,
-  refreshQueuedFollowupSession: refreshQueuedFollowupSessionMock,
-  scheduleFollowupDrain: scheduleFollowupDrainMock,
-}));
+vi.mock("./queue.js", async () => {
+  const actual = await vi.importActual<typeof import("./queue.js")>("./queue.js");
+  return {
+    ...actual,
+    enqueueFollowupRun: enqueueFollowupRunMock,
+    refreshQueuedFollowupSession: refreshQueuedFollowupSessionMock,
+    scheduleFollowupDrain: scheduleFollowupDrainMock,
+  };
+});
 
 vi.mock("../../media/outbound-attachment.js", () => ({
   resolveOutboundAttachmentFromUrl: (...args: unknown[]) =>

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -100,8 +100,10 @@ vi.mock("../../runtime.js", () => {
   };
 });
 
-vi.mock("./queue.js", () => {
+vi.mock("./queue.js", async () => {
+  const actual = await vi.importActual<typeof import("./queue.js")>("./queue.js");
   return {
+    ...actual,
     enqueueFollowupRun: vi.fn(),
     scheduleFollowupDrain: vi.fn(),
     clearSessionQueues: (...args: unknown[]) => clearSessionQueuesMock(...args),

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -102,11 +102,15 @@ vi.mock("../../agents/pi-embedded-runner/runs.js", () => ({
     state.queueEmbeddedPiMessageMock(sessionId, prompt, options),
 }));
 
-vi.mock("./queue.js", () => ({
-  enqueueFollowupRun: vi.fn(),
-  refreshQueuedFollowupSession: vi.fn(),
-  scheduleFollowupDrain: vi.fn(),
-}));
+vi.mock("./queue.js", async () => {
+  const actual = await vi.importActual<typeof import("./queue.js")>("./queue.js");
+  return {
+    ...actual,
+    enqueueFollowupRun: vi.fn(),
+    refreshQueuedFollowupSession: vi.fn(),
+    scheduleFollowupDrain: vi.fn(),
+  };
+});
 
 beforeAll(async () => {
   // Avoid attributing the initial agent-runner import cost to the first test case.

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -34,6 +34,7 @@ import {
 } from "../../infra/diagnostic-trace-context.js";
 import { measureDiagnosticsTimelineSpan } from "../../infra/diagnostics-timeline.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
+import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { CommandLaneClearedError, GatewayDrainingError } from "../../process/command-queue.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
@@ -87,6 +88,7 @@ import { readPostCompactionContext } from "./post-compaction-context.js";
 import { resolveActiveRunQueueAction } from "./queue-policy.js";
 import {
   enqueueFollowupRun,
+  getFollowupQueueDepth,
   refreshQueuedFollowupSession,
   scheduleFollowupDrain,
   type FollowupRun,
@@ -1024,6 +1026,124 @@ function refreshSessionEntryFromStore(params: {
   }
 }
 
+async function runQueueBeforeEnqueueHooks(params: {
+  queueKey: string;
+  queueMode: QueueSettings["mode"];
+  dropPolicy?: QueueSettings["dropPolicy"];
+  followupRun: FollowupRun;
+}): Promise<
+  | {
+      status: "ok";
+      followupRun: FollowupRun;
+      depthBefore: number;
+    }
+  | {
+      status: "blocked";
+      depthBefore: number;
+      reason?: string;
+    }
+> {
+  const { queueKey, queueMode, dropPolicy, followupRun } = params;
+  const depthBefore = getFollowupQueueDepth(queueKey);
+  const hookRunner = getGlobalHookRunner();
+  if (!hookRunner?.hasHooks("queue_before_enqueue")) {
+    return { status: "ok", followupRun, depthBefore };
+  }
+
+  const event = {
+    queueKey,
+    queueMode,
+    ...(dropPolicy ? { dropPolicy } : {}),
+    depthBefore,
+    prompt: followupRun.prompt,
+    ...(followupRun.summaryLine ? { summaryLine: followupRun.summaryLine } : {}),
+    ...(followupRun.messageId ? { messageId: followupRun.messageId } : {}),
+    ...(followupRun.originatingChannel
+      ? { originatingChannel: followupRun.originatingChannel }
+      : {}),
+    ...(followupRun.originatingTo ? { originatingTo: followupRun.originatingTo } : {}),
+    ...(followupRun.originatingAccountId
+      ? { originatingAccountId: followupRun.originatingAccountId }
+      : {}),
+    ...(followupRun.originatingThreadId !== undefined
+      ? { originatingThreadId: followupRun.originatingThreadId }
+      : {}),
+    sessionId: followupRun.run.sessionId,
+    ...(followupRun.run.sessionKey ? { sessionKey: followupRun.run.sessionKey } : {}),
+  };
+  const ctx = {
+    agentId: followupRun.run.agentId,
+    sessionKey: followupRun.run.sessionKey,
+    sessionId: followupRun.run.sessionId,
+    channelId: followupRun.originatingChannel,
+  };
+  const result = await hookRunner.runQueueBeforeEnqueue(event, ctx);
+  if (result?.block === true) {
+    return { status: "blocked", depthBefore, reason: result.blockReason };
+  }
+
+  const nextPrompt = normalizeOptionalString(result?.prompt);
+  const nextSummaryLine = normalizeOptionalString(result?.summaryLine);
+  if (!nextPrompt && !nextSummaryLine) {
+    return { status: "ok", followupRun, depthBefore };
+  }
+  return {
+    status: "ok",
+    depthBefore,
+    followupRun: {
+      ...followupRun,
+      ...(nextPrompt ? { prompt: nextPrompt } : {}),
+      ...(nextSummaryLine ? { summaryLine: nextSummaryLine } : {}),
+    },
+  };
+}
+
+function runQueueAfterEnqueueHooks(params: {
+  queueKey: string;
+  queueMode: QueueSettings["mode"];
+  dropPolicy?: QueueSettings["dropPolicy"];
+  followupRun: FollowupRun;
+  depthBefore: number;
+  enqueued: boolean;
+}): void {
+  const hookRunner = getGlobalHookRunner();
+  if (!hookRunner?.hasHooks("queue_after_enqueue")) {
+    return;
+  }
+  const { queueKey, queueMode, dropPolicy, followupRun, depthBefore, enqueued } = params;
+  void hookRunner.runQueueAfterEnqueue(
+    {
+      queueKey,
+      queueMode,
+      ...(dropPolicy ? { dropPolicy } : {}),
+      depthBefore,
+      depthAfter: getFollowupQueueDepth(queueKey),
+      enqueued,
+      prompt: followupRun.prompt,
+      ...(followupRun.summaryLine ? { summaryLine: followupRun.summaryLine } : {}),
+      ...(followupRun.messageId ? { messageId: followupRun.messageId } : {}),
+      ...(followupRun.originatingChannel
+        ? { originatingChannel: followupRun.originatingChannel }
+        : {}),
+      ...(followupRun.originatingTo ? { originatingTo: followupRun.originatingTo } : {}),
+      ...(followupRun.originatingAccountId
+        ? { originatingAccountId: followupRun.originatingAccountId }
+        : {}),
+      ...(followupRun.originatingThreadId !== undefined
+        ? { originatingThreadId: followupRun.originatingThreadId }
+        : {}),
+      sessionId: followupRun.run.sessionId,
+      ...(followupRun.run.sessionKey ? { sessionKey: followupRun.run.sessionKey } : {}),
+    },
+    {
+      agentId: followupRun.run.agentId,
+      sessionKey: followupRun.run.sessionKey,
+      sessionId: followupRun.run.sessionId,
+      channelId: followupRun.originatingChannel,
+    },
+  );
+}
+
 export async function runReplyAgent(params: {
   commandBody: string;
   transcriptCommandBody?: string;
@@ -1202,14 +1322,37 @@ export async function runReplyAgent(params: {
   }
 
   if (activeRunQueueAction === "enqueue-followup") {
-    enqueueFollowupRun(
+    const queueHookResult = await runQueueBeforeEnqueueHooks({
       queueKey,
+      queueMode: activeRunQueueMode,
+      dropPolicy: resolvedQueue.dropPolicy,
       followupRun,
+    });
+    if (queueHookResult.status === "blocked") {
+      if (queueHookResult.reason) {
+        logVerbose(`queue: follow-up enqueue blocked by plugin hook: ${queueHookResult.reason}`);
+      }
+      typing.cleanup();
+      return undefined;
+    }
+
+    const queuedFollowupRun = queueHookResult.followupRun;
+    const enqueued = enqueueFollowupRun(
+      queueKey,
+      queuedFollowupRun,
       resolvedQueue,
       "message-id",
       queuedRunFollowupTurn,
       false,
     );
+    runQueueAfterEnqueueHooks({
+      queueKey,
+      queueMode: activeRunQueueMode,
+      dropPolicy: resolvedQueue.dropPolicy,
+      followupRun: queuedFollowupRun,
+      depthBefore: queueHookResult.depthBefore,
+      enqueued,
+    });
     // Re-check liveness after enqueue so a stale active snapshot cannot leave
     // the followup queue idle if the original run already finished.
     const queuedBehindActiveRun = isRunActive?.() === true;

--- a/src/plugins/api-builder.ts
+++ b/src/plugins/api-builder.ts
@@ -21,6 +21,7 @@ export type BuildPluginApiParams = {
       OpenClawPluginApi,
       | "registerTool"
       | "registerHook"
+      | "registerReflexGates"
       | "registerHttpRoute"
       | "registerHostedMediaResolver"
       | "registerChannel"
@@ -87,6 +88,7 @@ export type BuildPluginApiParams = {
 
 const noopRegisterTool: OpenClawPluginApi["registerTool"] = () => {};
 const noopRegisterHook: OpenClawPluginApi["registerHook"] = () => {};
+const noopRegisterReflexGates: OpenClawPluginApi["registerReflexGates"] = () => {};
 const noopRegisterHttpRoute: OpenClawPluginApi["registerHttpRoute"] = () => {};
 const noopRegisterHostedMediaResolver: OpenClawPluginApi["registerHostedMediaResolver"] = () => {};
 const noopRegisterChannel: OpenClawPluginApi["registerChannel"] = () => {};
@@ -191,6 +193,7 @@ export function buildPluginApi(params: BuildPluginApiParams): OpenClawPluginApi 
     logger: params.logger,
     registerTool: handlers.registerTool ?? noopRegisterTool,
     registerHook: handlers.registerHook ?? noopRegisterHook,
+    registerReflexGates: handlers.registerReflexGates ?? noopRegisterReflexGates,
     registerHttpRoute: handlers.registerHttpRoute ?? noopRegisterHttpRoute,
     registerHostedMediaResolver:
       handlers.registerHostedMediaResolver ?? noopRegisterHostedMediaResolver,

--- a/src/plugins/hook-lifecycle-gates.test.ts
+++ b/src/plugins/hook-lifecycle-gates.test.ts
@@ -339,6 +339,121 @@ describe("before_agent_run invalid ask outcome", () => {
   });
 });
 
+describe("queue_before_enqueue hook", () => {
+  it("merges prompt rewrites in priority order", async () => {
+    const registry = makeRegistry([
+      {
+        pluginId: "first",
+        hookName: "queue_before_enqueue",
+        handler: async () => ({ prompt: "rewritten prompt" }),
+        source: "test",
+        priority: 10,
+      },
+      {
+        pluginId: "second",
+        hookName: "queue_before_enqueue",
+        handler: async () => ({ summaryLine: "summary" }),
+        source: "test",
+        priority: 5,
+      },
+    ]);
+    const runner = createHookRunner(registry);
+    const result = await runner.runQueueBeforeEnqueue(
+      {
+        queueKey: "session-1",
+        queueMode: "followup",
+        depthBefore: 0,
+        prompt: "original",
+      },
+      {
+        agentId: "agent-1",
+        sessionKey: "session-1",
+        sessionId: "sid-1",
+      },
+    );
+
+    expect(result).toEqual({
+      prompt: "rewritten prompt",
+      summaryLine: "summary",
+      block: undefined,
+      blockReason: undefined,
+    });
+  });
+
+  it("short-circuits on block", async () => {
+    const lowerPriority = vi.fn(async () => ({ prompt: "should not run" }));
+    const registry = makeRegistry([
+      {
+        pluginId: "blocker",
+        hookName: "queue_before_enqueue",
+        handler: async () => ({ block: true, blockReason: "queue policy" }),
+        source: "test",
+        priority: 10,
+      },
+      {
+        pluginId: "lower",
+        hookName: "queue_before_enqueue",
+        handler: lowerPriority,
+        source: "test",
+        priority: 1,
+      },
+    ]);
+    const runner = createHookRunner(registry);
+    const result = await runner.runQueueBeforeEnqueue(
+      {
+        queueKey: "session-1",
+        queueMode: "followup",
+        depthBefore: 0,
+        prompt: "original",
+      },
+      {
+        agentId: "agent-1",
+        sessionKey: "session-1",
+        sessionId: "sid-1",
+      },
+    );
+
+    expect(result?.block).toBe(true);
+    expect(result?.blockReason).toBe("queue policy");
+    expect(lowerPriority).not.toHaveBeenCalled();
+  });
+});
+
+describe("queue_after_enqueue hook", () => {
+  it("runs observation handlers", async () => {
+    const handler = vi.fn(async () => undefined);
+    const registry = makeRegistry([
+      {
+        pluginId: "observer",
+        hookName: "queue_after_enqueue",
+        handler,
+        source: "test",
+      },
+    ]);
+    const runner = createHookRunner(registry);
+    await runner.runQueueAfterEnqueue(
+      {
+        queueKey: "session-1",
+        queueMode: "followup",
+        depthBefore: 0,
+        depthAfter: 1,
+        enqueued: true,
+        prompt: "queued",
+      },
+      {
+        agentId: "agent-1",
+        sessionKey: "session-1",
+        sessionId: "sid-1",
+      },
+    );
+
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({ depthAfter: 1, enqueued: true, prompt: "queued" }),
+      expect.objectContaining({ sessionKey: "session-1" }),
+    );
+  });
+});
+
 describe("before_agent_start hook default timeout (#48534)", () => {
   afterEach(() => {
     vi.useRealTimers();

--- a/src/plugins/hook-lifecycle-gates.test.ts
+++ b/src/plugins/hook-lifecycle-gates.test.ts
@@ -2,11 +2,16 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GlobalHookRunnerRegistry } from "./hook-registry.types.js";
 import type { PluginHookRegistration, PluginHookAgentContext } from "./hook-types.js";
 import { createHookRunner } from "./hooks.js";
+import type { ReflexGateRegistration } from "./reflex-gates.js";
 
-function makeRegistry(hooks: PluginHookRegistration[] = []): GlobalHookRunnerRegistry {
+function makeRegistry(
+  hooks: PluginHookRegistration[] = [],
+  reflexGates: ReflexGateRegistration[] = [],
+): GlobalHookRunnerRegistry {
   return {
     hooks: [],
     typedHooks: hooks,
+    reflexGates,
     plugins: [],
   };
 }
@@ -416,6 +421,163 @@ describe("queue_before_enqueue hook", () => {
     expect(result?.block).toBe(true);
     expect(result?.blockReason).toBe("queue policy");
     expect(lowerPriority).not.toHaveBeenCalled();
+  });
+});
+
+describe("hard reflex gates", () => {
+  it("blocks before_tool_call before ordinary hook handlers run", async () => {
+    const lowerPriority = vi.fn(async () => ({ params: { command: "pwd" } }));
+    const registry = makeRegistry(
+      [
+        {
+          pluginId: "ordinary",
+          hookName: "before_tool_call",
+          handler: lowerPriority,
+          source: "test",
+        },
+      ],
+      [
+        {
+          pluginId: "opencoat",
+          hook: "before_tool_call",
+          joinpoint: "tool.before_call",
+          mediate: (gateCtx) => ({
+            weave_id: gateCtx.state.turn_id,
+            hook: "before_tool_call",
+            joinpoint: "tool.before_call",
+            verdict: { kind: "deny", reason: "hard stop" },
+            enforcement: "hard",
+            by: ["opencoat"],
+            fail_mode: "deny",
+          }),
+          source: "test",
+        },
+      ],
+    );
+    const runner = createHookRunner(registry);
+    const result = await runner.runBeforeToolCall(
+      { toolName: "shell.exec", params: { command: "rm -rf /tmp/x" } },
+      { toolName: "shell.exec", runId: "run-1", sessionKey: "session-1" },
+    );
+
+    expect(result).toEqual({ block: true, blockReason: "hard stop" });
+    expect(lowerPriority).not.toHaveBeenCalled();
+  });
+
+  it("rewrites before_tool_call params before ordinary hooks observe them", async () => {
+    const ordinary = vi.fn(async (event) => ({ params: event.params }));
+    const registry = makeRegistry(
+      [
+        {
+          pluginId: "ordinary",
+          hookName: "before_tool_call",
+          handler: ordinary,
+          source: "test",
+        },
+      ],
+      [
+        {
+          pluginId: "opencoat",
+          hook: "before_tool_call",
+          joinpoint: "tool.before_call",
+          mediate: (gateCtx) => ({
+            weave_id: gateCtx.state.turn_id,
+            hook: "before_tool_call",
+            joinpoint: "tool.before_call",
+            verdict: {
+              kind: "rewrite",
+              reason: "hard rewrite",
+              action: {
+                ...gateCtx.action,
+                args: { command: "pwd" },
+              },
+            },
+            enforcement: "hard",
+            by: ["opencoat"],
+            fail_mode: "deny",
+          }),
+          source: "test",
+        },
+      ],
+    );
+    const runner = createHookRunner(registry);
+    const result = await runner.runBeforeToolCall(
+      { toolName: "shell.exec", params: { command: "rm -rf /tmp/x" } },
+      { toolName: "shell.exec", runId: "run-1", sessionKey: "session-1" },
+    );
+
+    expect(result?.params).toEqual({ command: "pwd" });
+    expect(ordinary).toHaveBeenCalledWith(
+      expect.objectContaining({ params: { command: "pwd" } }),
+      expect.any(Object),
+    );
+  });
+
+  it("applies hard before_tool_call rewrite when no ordinary hooks are registered", async () => {
+    const registry = makeRegistry(
+      [],
+      [
+        {
+          pluginId: "opencoat",
+          hook: "before_tool_call",
+          joinpoint: "tool.before_call",
+          mediate: (gateCtx) => ({
+            weave_id: gateCtx.state.turn_id,
+            hook: "before_tool_call",
+            joinpoint: "tool.before_call",
+            verdict: {
+              kind: "rewrite",
+              reason: "hard rewrite",
+              action: {
+                ...gateCtx.action,
+                args: { command: "pwd" },
+              },
+            },
+            enforcement: "hard",
+            by: ["opencoat"],
+            fail_mode: "deny",
+          }),
+          source: "test",
+        },
+      ],
+    );
+    const runner = createHookRunner(registry);
+    const result = await runner.runBeforeToolCall(
+      { toolName: "shell.exec", params: { command: "rm -rf /tmp/x" } },
+      { toolName: "shell.exec", runId: "run-1", sessionKey: "session-1" },
+    );
+
+    expect(result?.params).toEqual({ command: "pwd" });
+  });
+
+  it("runs sync before_message_write gates without accepting promises", () => {
+    const registry = makeRegistry(
+      [],
+      [
+        {
+          pluginId: "opencoat",
+          hook: "before_message_write",
+          joinpoint: "memory.before_write",
+          mediate: (gateCtx) => ({
+            weave_id: gateCtx.state.turn_id,
+            hook: "before_message_write",
+            joinpoint: "memory.before_write",
+            verdict: { kind: "deny", reason: "do not persist" },
+            enforcement: "hard",
+            by: ["opencoat"],
+            fail_mode: "deny",
+          }),
+          source: "test",
+        },
+      ],
+    );
+    const runner = createHookRunner(registry);
+    const result = runner.runBeforeMessageWrite(
+      { message: { role: "user", content: "secret" } as never },
+      { sessionKey: "session-1" },
+    );
+
+    expect(result).toEqual({ block: true });
   });
 });
 

--- a/src/plugins/hook-registry.types.ts
+++ b/src/plugins/hook-registry.types.ts
@@ -1,5 +1,6 @@
 import type { HookEntry } from "../hooks/types.js";
 import type { PluginHookRegistration as TypedPluginHookRegistration } from "./hook-types.js";
+import type { ReflexGateRegistration } from "./reflex-gates.js";
 
 export type PluginLegacyHookRegistration = {
   pluginId: string;
@@ -12,6 +13,7 @@ export type PluginLegacyHookRegistration = {
 export type HookRunnerRegistry = {
   hooks: PluginLegacyHookRegistration[];
   typedHooks: TypedPluginHookRegistration[];
+  reflexGates?: ReflexGateRegistration[];
 };
 
 export type GlobalHookRunnerRegistry = HookRunnerRegistry & {

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -86,6 +86,8 @@ export type PluginHookName =
   | "message_sent"
   | "before_tool_call"
   | "after_tool_call"
+  | "queue_before_enqueue"
+  | "queue_after_enqueue"
   | "tool_result_persist"
   | "before_message_write"
   | "session_start"
@@ -126,6 +128,8 @@ export const PLUGIN_HOOK_NAMES = [
   "message_sent",
   "before_tool_call",
   "after_tool_call",
+  "queue_before_enqueue",
+  "queue_after_enqueue",
   "tool_result_persist",
   "before_message_write",
   "session_start",
@@ -494,6 +498,43 @@ export type PluginHookAfterToolCallEvent = {
   result?: unknown;
   error?: string;
   durationMs?: number;
+};
+
+export type PluginHookQueueContext = {
+  agentId?: string;
+  sessionKey?: string;
+  sessionId?: string;
+  runId?: string;
+  channelId?: string;
+};
+
+export type PluginHookQueueBeforeEnqueueEvent = {
+  queueKey: string;
+  queueMode: "steer" | "followup" | "collect" | "interrupt";
+  dropPolicy?: "old" | "new" | "summarize";
+  depthBefore: number;
+  prompt: string;
+  summaryLine?: string;
+  messageId?: string;
+  originatingChannel?: string;
+  originatingTo?: string;
+  originatingAccountId?: string;
+  originatingThreadId?: string | number;
+  sessionId?: string;
+  sessionKey?: string;
+  runId?: string;
+};
+
+export type PluginHookQueueBeforeEnqueueResult = {
+  block?: boolean;
+  blockReason?: string;
+  prompt?: string;
+  summaryLine?: string;
+};
+
+export type PluginHookQueueAfterEnqueueEvent = PluginHookQueueBeforeEnqueueEvent & {
+  depthAfter: number;
+  enqueued: boolean;
 };
 
 export type PluginHookToolResultPersistContext = {
@@ -982,6 +1023,17 @@ export type PluginHookHandlerMap = {
   after_tool_call: (
     event: PluginHookAfterToolCallEvent,
     ctx: PluginHookToolContext,
+  ) => Promise<void> | void;
+  queue_before_enqueue: (
+    event: PluginHookQueueBeforeEnqueueEvent,
+    ctx: PluginHookQueueContext,
+  ) =>
+    | Promise<PluginHookQueueBeforeEnqueueResult | void>
+    | PluginHookQueueBeforeEnqueueResult
+    | void;
+  queue_after_enqueue: (
+    event: PluginHookQueueAfterEnqueueEvent,
+    ctx: PluginHookQueueContext,
   ) => Promise<void> | void;
   tool_result_persist: (
     event: PluginHookToolResultPersistEvent,

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -46,6 +46,10 @@ import type {
   PluginHookBeforeResetEvent,
   PluginHookBeforeToolCallEvent,
   PluginHookBeforeToolCallResult,
+  PluginHookQueueAfterEnqueueEvent,
+  PluginHookQueueBeforeEnqueueEvent,
+  PluginHookQueueBeforeEnqueueResult,
+  PluginHookQueueContext,
   PluginAgentTurnPrepareEvent,
   PluginAgentTurnPrepareResult,
   PluginHeartbeatPromptContributionEvent,
@@ -126,6 +130,10 @@ export type {
   PluginHookBeforeToolCallResult,
   PluginHookBeforeAgentRunEvent,
   PluginHookAfterToolCallEvent,
+  PluginHookQueueAfterEnqueueEvent,
+  PluginHookQueueBeforeEnqueueEvent,
+  PluginHookQueueBeforeEnqueueResult,
+  PluginHookQueueContext,
   PluginHookToolResultPersistContext,
   PluginHookToolResultPersistEvent,
   PluginHookToolResultPersistResult,
@@ -212,6 +220,7 @@ const DEFAULT_MODIFYING_HOOK_TIMEOUT_MS_BY_HOOK: Partial<Record<PluginHookName, 
   // logged and the run proceeds without its modifications.
   before_agent_start: 15_000,
   before_prompt_build: 15_000,
+  queue_before_enqueue: 15_000,
 };
 
 type ModifyingHookPolicy<K extends PluginHookName, TResult> = {
@@ -458,6 +467,21 @@ export function createHookRunner(
       return acc;
     }
     return next;
+  };
+
+  const mergeQueueBeforeEnqueueResult = (
+    acc: PluginHookQueueBeforeEnqueueResult | undefined,
+    next: PluginHookQueueBeforeEnqueueResult,
+  ): PluginHookQueueBeforeEnqueueResult => {
+    if (acc?.block === true) {
+      return acc;
+    }
+    return {
+      prompt: lastDefined(acc?.prompt, next.prompt),
+      summaryLine: lastDefined(acc?.summaryLine, next.summaryLine),
+      block: stickyTrue(acc?.block, next.block),
+      blockReason: lastDefined(acc?.blockReason, next.blockReason),
+    };
   };
 
   const handleHookError = (params: {
@@ -1191,6 +1215,37 @@ export function createHookRunner(
   }
 
   /**
+   * Run queue_before_enqueue hook.
+   * Allows plugins to block or rewrite a follow-up before it enters the queue.
+   */
+  async function runQueueBeforeEnqueue(
+    event: PluginHookQueueBeforeEnqueueEvent,
+    ctx: PluginHookQueueContext,
+  ): Promise<PluginHookQueueBeforeEnqueueResult | undefined> {
+    return runModifyingHook<"queue_before_enqueue", PluginHookQueueBeforeEnqueueResult>(
+      "queue_before_enqueue",
+      event,
+      ctx,
+      {
+        mergeResults: mergeQueueBeforeEnqueueResult,
+        shouldStop: (result) => result.block === true,
+        terminalLabel: "block=true",
+      },
+    );
+  }
+
+  /**
+   * Run queue_after_enqueue hook.
+   * Runs in parallel after the queue decision has been applied.
+   */
+  async function runQueueAfterEnqueue(
+    event: PluginHookQueueAfterEnqueueEvent,
+    ctx: PluginHookQueueContext,
+  ): Promise<void> {
+    return runVoidHook("queue_after_enqueue", event, ctx);
+  }
+
+  /**
    * Run tool_result_persist hook.
    *
    * This hook is intentionally synchronous: it runs in hot paths where session
@@ -1522,6 +1577,8 @@ export function createHookRunner(
     // Tool hooks
     runBeforeToolCall,
     runAfterToolCall,
+    runQueueBeforeEnqueue,
+    runQueueAfterEnqueue,
     runToolResultPersist,
     // Message write hooks
     runBeforeMessageWrite,

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -89,6 +89,13 @@ import type {
   PluginHookBeforeInstallEvent,
   PluginHookBeforeInstallResult,
 } from "./hook-types.js";
+import type {
+  ReflexGateAction,
+  ReflexGateContext,
+  ReflexGateDecision,
+  ReflexGateRegistration,
+} from "./reflex-gates.js";
+import { isReflexGateDecision } from "./reflex-gates.js";
 
 // Re-export types for consumers
 export type {
@@ -560,6 +567,147 @@ export function createHookRunner(
         clearTimeout(timer);
       }
     }
+  };
+
+  const getReflexGatesForName = (hookName: PluginHookName): ReflexGateRegistration[] =>
+    [...(registry.reflexGates ?? [])]
+      .filter((gate) => gate.hook === hookName)
+      .toSorted((a, b) => (b.priority ?? 0) - (a.priority ?? 0));
+
+  const buildGateState = (
+    ctx: Record<string, unknown>,
+    event: Record<string, unknown>,
+  ): ReflexGateContext["state"] => {
+    const sessionId =
+      typeof ctx.sessionId === "string"
+        ? ctx.sessionId
+        : typeof event.sessionId === "string"
+          ? event.sessionId
+          : typeof ctx.sessionKey === "string"
+            ? ctx.sessionKey
+            : typeof event.sessionKey === "string"
+              ? event.sessionKey
+              : "default";
+    const turnId =
+      typeof ctx.runId === "string"
+        ? ctx.runId
+        : typeof event.runId === "string"
+          ? event.runId
+          : typeof ctx.sessionKey === "string"
+            ? ctx.sessionKey
+            : "default";
+    return {
+      session_id: sessionId,
+      turn_id: turnId,
+      features: {
+        agent_id: ctx.agentId,
+        session_key: ctx.sessionKey ?? event.sessionKey,
+        channel_id: ctx.channelId,
+      },
+    };
+  };
+
+  const asRecord = (value: unknown): Record<string, unknown> =>
+    value && typeof value === "object" ? (value as Record<string, unknown>) : {};
+
+  const applyMessageContent = <T>(message: T, content: string): T => {
+    if (!message || typeof message !== "object") return message;
+    const record = message as Record<string, unknown>;
+    if (typeof record.content === "string") {
+      return { ...record, content } as T;
+    }
+    if (Array.isArray(record.content)) {
+      let replaced = false;
+      const next = record.content.map((part) => {
+        if (!part || typeof part !== "object") return part;
+        const partRecord = part as Record<string, unknown>;
+        if (typeof partRecord.text !== "string") return part;
+        if (replaced) return { ...partRecord, text: "" };
+        replaced = true;
+        return { ...partRecord, text: content };
+      });
+      return {
+        ...record,
+        content: replaced ? next : [{ type: "text", text: content }, ...record.content],
+      } as T;
+    }
+    return { ...record, content } as T;
+  };
+
+  const runHardReflexGates = async (
+    hookName: PluginHookName,
+    action: ReflexGateAction,
+    event: Record<string, unknown>,
+    ctx: Record<string, unknown>,
+    failMode: "deny" | "allow" = "deny",
+  ): Promise<ReflexGateDecision | undefined> => {
+    const gates = getReflexGatesForName(hookName);
+    if (gates.length === 0) return undefined;
+
+    let rewrittenAction = action;
+    for (const gate of gates) {
+      try {
+        const timeoutMs =
+          normalizePositiveTimeoutMs(modifyingHookTimeoutMsByHook[hookName]) ?? 15_000;
+        const gateCtx: ReflexGateContext = {
+          hook: hookName,
+          action: rewrittenAction,
+          state: buildGateState(ctx, event),
+          joinpoint: gate.joinpoint,
+          failMode,
+        };
+        const out = gate.mediate(gateCtx, timeoutMs);
+        const decision = isPromiseLike(out)
+          ? await withHookTimeout(Promise.resolve(out), timeoutMs)
+          : out;
+        if (!isReflexGateDecision(decision)) {
+          throw new Error(`reflex gate returned invalid decision for ${hookName}`);
+        }
+        if (decision.verdict.kind === "deny") {
+          return decision;
+        }
+        if (decision.verdict.kind === "rewrite") {
+          rewrittenAction = decision.verdict.action;
+        }
+      } catch (err) {
+        if (failMode === "allow") {
+          logger?.warn?.(
+            `[hooks] reflex gate for ${hookName} from ${gate.pluginId} failed open: ${sanitizeHookError(err)}`,
+          );
+          continue;
+        }
+        return {
+          weave_id: buildGateState(ctx, event).turn_id,
+          hook: hookName,
+          joinpoint: gate.joinpoint,
+          verdict: {
+            kind: "deny",
+            reason: `OpenClaw reflex gate fail-closed: ${sanitizeHookError(err)}`,
+          },
+          enforcement: "hard",
+          by: [gate.pluginId],
+          fail_mode: "deny",
+          degraded: true,
+        };
+      }
+    }
+
+    if (rewrittenAction !== action) {
+      return {
+        weave_id: buildGateState(ctx, event).turn_id,
+        hook: hookName,
+        joinpoint: gates.at(-1)?.joinpoint ?? hookName,
+        verdict: {
+          kind: "rewrite",
+          action: rewrittenAction,
+          reason: "rewritten by OpenClaw reflex gate",
+        },
+        enforcement: "hard",
+        by: gates.map((gate) => gate.pluginId),
+        fail_mode: failMode,
+      };
+    }
+    return undefined;
   };
 
   const runSyncHookHandler = <K extends SyncHookName>(
@@ -1076,9 +1224,34 @@ export function createHookRunner(
     event: PluginHookMessageSendingEvent,
     ctx: PluginHookMessageContext,
   ): Promise<PluginHookMessageSendingResult | undefined> {
+    const gate = await runHardReflexGates(
+      "message_sending",
+      {
+        kind: "message_out",
+        name: "message_out",
+        args: { content: event.content, ...event },
+        raw: event,
+      },
+      asRecord(event),
+      asRecord(ctx),
+      "allow",
+    );
+    if (gate?.verdict.kind === "deny") {
+      return { cancel: true, cancelReason: gate.verdict.reason };
+    }
+    const gatedEvent =
+      gate?.verdict.kind === "rewrite" && typeof gate.verdict.action.args.content === "string"
+        ? { ...event, content: gate.verdict.action.args.content }
+        : event;
+    if (
+      gatedEvent !== event &&
+      !registry.typedHooks.some((h) => h.hookName === "message_sending")
+    ) {
+      return { content: gatedEvent.content };
+    }
     return runModifyingHook<"message_sending", PluginHookMessageSendingResult>(
       "message_sending",
-      event,
+      gatedEvent,
       ctx,
       {
         mergeResults: (acc, next) => {
@@ -1172,9 +1345,32 @@ export function createHookRunner(
     event: PluginHookBeforeToolCallEvent,
     ctx: PluginHookToolContext,
   ): Promise<PluginHookBeforeToolCallResult | undefined> {
+    const gate = await runHardReflexGates(
+      "before_tool_call",
+      {
+        kind: "tool_call",
+        name: event.toolName,
+        args: { ...event.params },
+        raw: event,
+      },
+      asRecord(event),
+      asRecord(ctx),
+      "deny",
+    );
+    if (gate?.verdict.kind === "deny") {
+      return { block: true, blockReason: gate.verdict.reason };
+    }
+    const gatedEvent =
+      gate?.verdict.kind === "rewrite" ? { ...event, params: gate.verdict.action.args } : event;
+    if (
+      gatedEvent !== event &&
+      !registry.typedHooks.some((h) => h.hookName === "before_tool_call")
+    ) {
+      return { params: gatedEvent.params };
+    }
     return runModifyingHook<"before_tool_call", PluginHookBeforeToolCallResult>(
       "before_tool_call",
-      event,
+      gatedEvent,
       ctx,
       {
         mergeResults: (acc, next, reg) => {
@@ -1222,9 +1418,45 @@ export function createHookRunner(
     event: PluginHookQueueBeforeEnqueueEvent,
     ctx: PluginHookQueueContext,
   ): Promise<PluginHookQueueBeforeEnqueueResult | undefined> {
+    const gate = await runHardReflexGates(
+      "queue_before_enqueue",
+      {
+        kind: "queue_enqueue",
+        name: event.queueMode,
+        args: { ...event },
+        raw: event,
+      },
+      asRecord(event),
+      asRecord(ctx),
+      "allow",
+    );
+    if (gate?.verdict.kind === "deny") {
+      return { block: true, blockReason: gate.verdict.reason };
+    }
+    const gatedEvent =
+      gate?.verdict.kind === "rewrite"
+        ? {
+            ...event,
+            ...(typeof gate.verdict.action.args.prompt === "string"
+              ? { prompt: gate.verdict.action.args.prompt }
+              : {}),
+            ...(typeof gate.verdict.action.args.summaryLine === "string"
+              ? { summaryLine: gate.verdict.action.args.summaryLine }
+              : {}),
+          }
+        : event;
+    if (
+      gatedEvent !== event &&
+      !registry.typedHooks.some((h) => h.hookName === "queue_before_enqueue")
+    ) {
+      return {
+        prompt: gatedEvent.prompt,
+        summaryLine: gatedEvent.summaryLine,
+      };
+    }
     return runModifyingHook<"queue_before_enqueue", PluginHookQueueBeforeEnqueueResult>(
       "queue_before_enqueue",
-      event,
+      gatedEvent,
       ctx,
       {
         mergeResults: mergeQueueBeforeEnqueueResult,
@@ -1259,12 +1491,69 @@ export function createHookRunner(
     event: PluginHookToolResultPersistEvent,
     ctx: PluginHookToolResultPersistContext,
   ): PluginHookToolResultPersistResult | undefined {
+    const gates = getReflexGatesForName("tool_result_persist");
+    let gatedEvent = event;
+    for (const gate of gates) {
+      try {
+        const decision = gate.mediate(
+          {
+            hook: "tool_result_persist",
+            action: {
+              kind: "tool_result_persist",
+              name: event.toolName ?? ctx.toolName ?? "tool",
+              args: {
+                toolName: event.toolName ?? ctx.toolName,
+                toolCallId: event.toolCallId ?? ctx.toolCallId,
+                message: gatedEvent.message,
+                content: JSON.stringify(gatedEvent.message),
+              },
+              raw: gatedEvent,
+            },
+            state: buildGateState(asRecord(ctx), asRecord(gatedEvent)),
+            joinpoint: gate.joinpoint,
+            failMode: "deny",
+          },
+          0,
+        );
+        if (isPromiseLike(decision)) {
+          throw new Error("reflex gate returned a Promise for sync hook");
+        }
+        if (!isReflexGateDecision(decision)) {
+          throw new Error("reflex gate returned invalid decision for tool_result_persist");
+        }
+        if (decision.verdict.kind === "deny") {
+          return { message: gatedEvent.message };
+        }
+        if (decision.verdict.kind === "rewrite") {
+          const next = decision.verdict.action.args.message;
+          const content = decision.verdict.action.args.content;
+          if (next) {
+            gatedEvent = {
+              ...gatedEvent,
+              message: next as PluginHookToolResultPersistEvent["message"],
+            };
+          } else if (typeof content === "string") {
+            gatedEvent = {
+              ...gatedEvent,
+              message: applyMessageContent(gatedEvent.message, content),
+            };
+          }
+        }
+      } catch (err) {
+        const msg = `[hooks] reflex gate for tool_result_persist from ${gate.pluginId} failed: ${String(err)}`;
+        if (shouldCatchHookErrors("tool_result_persist")) {
+          logger?.error(msg);
+          continue;
+        }
+        throw new Error(msg, { cause: err });
+      }
+    }
     const hooks = getHooksForName(registry, "tool_result_persist");
     if (hooks.length === 0) {
-      return undefined;
+      return gatedEvent !== event ? { message: gatedEvent.message } : undefined;
     }
 
-    let current = event.message;
+    let current = gatedEvent.message;
 
     for (const hook of hooks) {
       try {
@@ -1319,12 +1608,67 @@ export function createHookRunner(
     event: PluginHookBeforeMessageWriteEvent,
     ctx: { agentId?: string; sessionKey?: string },
   ): PluginHookBeforeMessageWriteResult | undefined {
+    const gates = getReflexGatesForName("before_message_write");
+    let gatedEvent = event;
+    for (const gate of gates) {
+      try {
+        const decision = gate.mediate(
+          {
+            hook: "before_message_write",
+            action: {
+              kind: "memory_write",
+              name:
+                typeof (gatedEvent.message as { role?: unknown }).role === "string"
+                  ? (gatedEvent.message as { role: string }).role
+                  : "message",
+              args: { message: gatedEvent.message, content: JSON.stringify(gatedEvent.message) },
+              raw: gatedEvent,
+            },
+            state: buildGateState(asRecord(ctx), asRecord(gatedEvent)),
+            joinpoint: gate.joinpoint,
+            failMode: "deny",
+          },
+          0,
+        );
+        if (isPromiseLike(decision)) {
+          throw new Error("reflex gate returned a Promise for sync hook");
+        }
+        if (!isReflexGateDecision(decision)) {
+          throw new Error("reflex gate returned invalid decision for before_message_write");
+        }
+        if (decision.verdict.kind === "deny") {
+          return { block: true };
+        }
+        if (decision.verdict.kind === "rewrite") {
+          const next = decision.verdict.action.args.message;
+          const content = decision.verdict.action.args.content;
+          if (next) {
+            gatedEvent = {
+              ...gatedEvent,
+              message: next as PluginHookBeforeMessageWriteEvent["message"],
+            };
+          } else if (typeof content === "string") {
+            gatedEvent = {
+              ...gatedEvent,
+              message: applyMessageContent(gatedEvent.message, content),
+            };
+          }
+        }
+      } catch (err) {
+        const msg = `[hooks] reflex gate for before_message_write from ${gate.pluginId} failed: ${String(err)}`;
+        if (shouldCatchHookErrors("before_message_write")) {
+          logger?.error(msg);
+          continue;
+        }
+        throw new Error(msg, { cause: err });
+      }
+    }
     const hooks = getHooksForName(registry, "before_message_write");
     if (hooks.length === 0) {
-      return undefined;
+      return gatedEvent !== event ? { message: gatedEvent.message } : undefined;
     }
 
-    let current = event.message;
+    let current = gatedEvent.message;
 
     for (const hook of hooks) {
       try {
@@ -1405,6 +1749,21 @@ export function createHookRunner(
     event: PluginHookSubagentSpawningEvent,
     ctx: PluginHookSubagentContext,
   ): Promise<PluginHookSubagentSpawningResult | undefined> {
+    const gate = await runHardReflexGates(
+      "subagent_spawning",
+      {
+        kind: "spawn",
+        name: event.agentId,
+        args: { ...event },
+        raw: event,
+      },
+      asRecord(event),
+      asRecord(ctx),
+      "deny",
+    );
+    if (gate?.verdict.kind === "deny") {
+      return { status: "error", error: gate.verdict.reason };
+    }
     return runModifyingHook<"subagent_spawning", PluginHookSubagentSpawningResult>(
       "subagent_spawning",
       event,
@@ -1537,14 +1896,20 @@ export function createHookRunner(
   // =========================================================================
 
   function hasHooks(hookName: PluginHookName): boolean {
-    return registry.typedHooks.some((h) => h.hookName === hookName);
+    return (
+      registry.typedHooks.some((h) => h.hookName === hookName) ||
+      getReflexGatesForName(hookName).length > 0
+    );
   }
 
   /**
    * Get count of registered hooks for a given hook name.
    */
   function getHookCount(hookName: PluginHookName): number {
-    return registry.typedHooks.filter((h) => h.hookName === hookName).length;
+    return (
+      registry.typedHooks.filter((h) => h.hookName === hookName).length +
+      getReflexGatesForName(hookName).length
+    );
   }
 
   return {

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -345,6 +345,7 @@ type PluginRegistrySnapshot = {
     tools: PluginRegistry["tools"];
     hooks: PluginRegistry["hooks"];
     typedHooks: PluginRegistry["typedHooks"];
+    reflexGates: PluginRegistry["reflexGates"];
     channels: PluginRegistry["channels"];
     channelSetups: PluginRegistry["channelSetups"];
     providers: PluginRegistry["providers"];
@@ -388,6 +389,7 @@ function snapshotPluginRegistry(registry: PluginRegistry): PluginRegistrySnapsho
       tools: [...registry.tools],
       hooks: [...registry.hooks],
       typedHooks: [...registry.typedHooks],
+      reflexGates: [...registry.reflexGates],
       channels: [...registry.channels],
       channelSetups: [...registry.channelSetups],
       providers: [...registry.providers],
@@ -430,6 +432,7 @@ function restorePluginRegistry(registry: PluginRegistry, snapshot: PluginRegistr
   registry.tools = snapshot.arrays.tools;
   registry.hooks = snapshot.arrays.hooks;
   registry.typedHooks = snapshot.arrays.typedHooks;
+  registry.reflexGates = snapshot.arrays.reflexGates;
   registry.channels = snapshot.arrays.channels;
   registry.channelSetups = snapshot.arrays.channelSetups;
   registry.providers = snapshot.arrays.providers;

--- a/src/plugins/reflex-gates.ts
+++ b/src/plugins/reflex-gates.ts
@@ -1,0 +1,66 @@
+import type { PluginHookName } from "./hook-types.js";
+
+export type ReflexGateAction = {
+  kind: string;
+  name: string;
+  args: Record<string, unknown>;
+  raw?: unknown;
+};
+
+export type ReflexGateState = {
+  session_id: string;
+  turn_id: string;
+  features: Record<string, unknown>;
+};
+
+export type ReflexGateVerdict =
+  | { kind: "allow" }
+  | { kind: "deny"; reason: string }
+  | { kind: "rewrite"; action: ReflexGateAction; reason: string };
+
+export type ReflexGateDecision = {
+  weave_id: string;
+  hook: string;
+  joinpoint: string;
+  verdict: ReflexGateVerdict;
+  enforcement: "hard";
+  by: string[];
+  fail_mode: "deny" | "allow";
+  degraded?: boolean;
+  record?: unknown;
+};
+
+export type ReflexGateContext = {
+  hook: PluginHookName;
+  action: ReflexGateAction;
+  state: ReflexGateState;
+  joinpoint?: string;
+  failMode?: "deny" | "allow";
+};
+
+export type ReflexGate = {
+  hook: PluginHookName;
+  joinpoint: string;
+  mediate: (
+    ctx: ReflexGateContext,
+    deadlineMs: number,
+  ) => ReflexGateDecision | Promise<ReflexGateDecision>;
+};
+
+export type ReflexGateRegistration = ReflexGate & {
+  pluginId: string;
+  priority?: number;
+  source?: string;
+};
+
+export function isReflexGateDecision(value: unknown): value is ReflexGateDecision {
+  if (!value || typeof value !== "object") return false;
+  const record = value as Record<string, unknown>;
+  const verdict = record.verdict;
+  return (
+    record.enforcement === "hard" &&
+    verdict !== null &&
+    typeof verdict === "object" &&
+    typeof (verdict as { kind?: unknown }).kind === "string"
+  );
+}

--- a/src/plugins/registry-empty.ts
+++ b/src/plugins/registry-empty.ts
@@ -6,6 +6,7 @@ export function createEmptyPluginRegistry(): PluginRegistry {
     tools: [],
     hooks: [],
     typedHooks: [],
+    reflexGates: [],
     channels: [],
     channelSetups: [],
     providers: [],

--- a/src/plugins/registry-types.ts
+++ b/src/plugins/registry-types.ts
@@ -30,6 +30,7 @@ import type {
 import type { PluginManifestContracts } from "./manifest.js";
 import type { MemoryEmbeddingProviderAdapter } from "./memory-embedding-providers.js";
 import type { PluginKind } from "./plugin-kind.types.js";
+import type { ReflexGateRegistration } from "./reflex-gates.js";
 import type { PluginRuntime } from "./runtime/types.js";
 import type { PluginDependencyStatus } from "./status-dependencies.js";
 import type {
@@ -423,6 +424,7 @@ export type PluginRegistry = {
   tools: PluginToolRegistration[];
   hooks: PluginHookRegistration[];
   typedHooks: TypedPluginHookRegistration[];
+  reflexGates: ReflexGateRegistration[];
   channels: PluginChannelRegistration[];
   channelSetups: PluginChannelSetupRegistration[];
   providers: PluginProviderRegistration[];

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -109,6 +109,7 @@ import {
 } from "./memory-state.js";
 import { createModelCatalogRegistrationHandlers } from "./model-catalog-registration.js";
 import { normalizeRegisteredProvider } from "./provider-validation.js";
+import type { ReflexGate } from "./reflex-gates.js";
 import { createEmptyPluginRegistry } from "./registry-empty.js";
 import { isPluginRegistryActivated, isPluginRegistryRetired } from "./registry-lifecycle.js";
 import type {
@@ -2374,6 +2375,40 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     } as TypedPluginHookRegistration);
   };
 
+  const registerReflexGates = (
+    record: PluginRecord,
+    gates: ReflexGate[],
+    opts?: { priority?: number },
+  ) => {
+    for (const gate of gates) {
+      if (!isPluginHookName(gate.hook)) {
+        pushDiagnostic({
+          level: "warn",
+          pluginId: record.id,
+          source: record.source,
+          message: `unknown reflex gate hook "${String(gate.hook)}" ignored`,
+        });
+        continue;
+      }
+      if (typeof gate.mediate !== "function") {
+        pushDiagnostic({
+          level: "error",
+          pluginId: record.id,
+          source: record.source,
+          message: `reflex gate for "${gate.hook}" missing mediate function`,
+        });
+        continue;
+      }
+      record.hookCount += 1;
+      registry.reflexGates.push({
+        ...gate,
+        pluginId: record.id,
+        priority: opts?.priority,
+        source: record.source,
+      });
+    }
+  };
+
   const registerConversationBindingResolvedHandler = (
     record: PluginRecord,
     handler: (event: PluginConversationBindingResolvedEvent) => void | Promise<void>,
@@ -2514,6 +2549,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
               registerTool: (tool, opts) => registerTool(record, tool, opts),
               registerHook: (events, handler, opts) =>
                 registerHook(record, events, handler, opts, params.config, params.pluginConfig),
+              registerReflexGates: (gates, opts) => registerReflexGates(record, gates, opts),
               registerHttpRoute: (routeParams) => registerHttpRoute(record, routeParams),
               registerHostedMediaResolver: (resolver) =>
                 registerHostedMediaResolver(record, resolver),

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -139,6 +139,7 @@ import type {
   ProviderThinkingProfile,
   ProviderThinkingPolicyContext,
 } from "./provider-thinking.types.js";
+import type { ReflexGate } from "./reflex-gates.js";
 import type { PluginRuntime } from "./runtime/types.js";
 import type {
   OpenClawPluginHookOptions,
@@ -2599,6 +2600,11 @@ export type OpenClawPluginApi = {
     handler: InternalHookHandler,
     opts?: OpenClawPluginHookOptions,
   ) => void;
+  /**
+   * Register hard, synchronous mediation gates for fork-owned effect
+   * boundaries. Core awaits these gates before executing the guarded action.
+   */
+  registerReflexGates: (gates: ReflexGate[], opts?: { priority?: number }) => void;
   registerHttpRoute: (params: OpenClawPluginHttpRouteParams) => void;
   /** Register a plugin-owned resolver for browser-style hosted media URLs. */
   registerHostedMediaResolver: (resolver: OpenClawPluginHostedMediaResolver) => void;


### PR DESCRIPTION
## Summary

- Add native `queue_before_enqueue` and `queue_after_enqueue` plugin hooks around follow-up queue enqueue (`agent-runner`).
- Emit the same hooks on embedded steering (`queueEmbeddedPiMessageWithOutcomeAsync`) with `queueMode: "steer"`, `originatingChannel: "embedded_run"`, and session-key-backed `queueKey`.
- Allow `queue_before_enqueue` to block or rewrite queued prompt/summary line; emit `queue_after_enqueue` with depth before/after and enqueue status.

Fork PR with full validation: https://github.com/HyperdustLabs/openclaw/pull/1

## Verification

- `node scripts/run-vitest.mjs src/plugins/hook-lifecycle-gates.test.ts`
- `node scripts/run-vitest.mjs src/agents/pi-embedded-runner/runs.test.ts`
- `pnpm tsgo:core`
- `pnpm tsgo:core:test`
- `pnpm plugin-sdk:api:check`
- `pnpm plugin-sdk:check-exports`
- `pnpm check:changed`

## Real behavior proof

Behavior or issue addressed: follow-up queue and embedded steering enqueue paths emit queue plugin hooks for OpenCOAT weaving.
Real environment tested: macOS host, OpenClaw gateway on 127.0.0.1:18789 (LaunchAgent → openclaw-fork dist), OpenCOAT daemon http://127.0.0.1:7878/rpc, @hyperdustlabs/opencoat-bridge linked.
Exact steps or command run after this patch: `pnpm build`; `openclaw gateway restart`; `bash ~/OpenCOAT/examples/09_queue_hook_dogfood/scripts/smoke-rpc.sh all`; `opencoat dcn activation-log --limit 5`
Evidence after fix (terminal capture):

```text
$ grep "registered 29 hooks" ~/Library/Logs/openclaw/gateway.log | tail -1
2026-05-21T23:56:44.647+07:00 [plugins] [opencoat-bridge] registered 29 hooks (skipped: before_message_write, tool_result_persist, before_install; daemon=http://127.0.0.1:7878/rpc; runtime observers on (agent events + queue/task poll))

$ bash ~/OpenCOAT/examples/09_queue_hook_dogfood/scripts/smoke-rpc.sh prompt
"concern_id": "oc.dogfood.queue-prompt-rewrite",
"target": "queue.prompt",
"mode": "rewrite",
"content": "[OpenCOAT rewrite] Summarized follow-up: continue the prior task with the new constraint only."

$ opencoat dcn activation-log --limit 3
2026-05-21T16:58:04.698610+00:00  oc.dogfood.queue-block  jp-smoke-queue-block
2026-05-21T16:58:04.911562+00:00  oc.dogfood.queue-prompt-rewrite  jp-smoke-queue-prompt
2026-05-21T16:58:05.130478+00:00  oc.dogfood.queue-summary-rewrite  jp-smoke-queue-summary
```

Observed result after fix: gateway accepts `queue_before_enqueue` / `queue_after_enqueue` (29 hooks registered, no “unknown typed hook” for queue hooks); OpenCOAT daemon returns block/rewrite injections on `queue.before_enqueue` joinpoint.
What was not tested: full live `chat.send` follow-up during a long-running model turn on CI runners.