### PR TITLE
fix(doctor): prune stale bundled plugin load paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -233,6 +233,7 @@ Docs: https://docs.openclaw.ai
 - CLI/update: pre-pack GitHub/git package update targets before the staged npm install, restoring `openclaw update --tag main` for one-off package updates. (#81296) Thanks @fuller-stack-dev.
 - Gateway: mirror successful same-source message-tool sends into session transcripts so delivered replies stay in later history/context. (#84837) Thanks @iFiras-Max1.
 - Media generation: keep image, music, and video completion delivery from duplicating or losing task ownership when generated media finishes through active session replies. (#84006) Thanks @fuller-stack-dev.
+- CLI/doctor: remove stale bundled plugin load paths from old versioned OpenClaw package roots after pnpm/npm upgrades. Fixes #58626. Thanks @solink7.
 - Infra/json: retry transient `File changed during read` races while loading JSON state so config and state reads recover instead of failing the turn. (#84285)
 - Plugins/providers: fail closed for workspace provider plugins during setup-mode discovery unless explicitly trusted, preventing untrusted workspace plugin code from running during provider setup. (#81069) Thanks @mmaps.
 - Providers/Ollama: resolve configured Ollama Cloud `OLLAMA_API_KEY` markers to the real discovery key so cloud provider entries keep authenticated model catalog access. (#85037)

--- a/src/commands/doctor/shared/bundled-plugin-load-paths.test.ts
+++ b/src/commands/doctor/shared/bundled-plugin-load-paths.test.ts
@@ -103,6 +103,61 @@ describe("bundled plugin load path repair", () => {
     expect(result.config.plugins?.load?.paths).toStrictEqual([]);
   });
 
+  it("removes stale bundled paths from old versioned OpenClaw package roots", () => {
+    const currentPackageRoot = path.resolve("node_modules", "openclaw");
+    const stalePackageRoot = path.resolve(
+      "pnpm-global",
+      ".pnpm",
+      "openclaw@2026.3.28_@napi-rs+canvas@0.1.97",
+      "node_modules",
+      "openclaw",
+    );
+    const currentBundledPath = bundledDistPluginRootAt(currentPackageRoot, "feishu");
+    const staleBundledPath = bundledDistPluginRootAt(stalePackageRoot, "feishu");
+    mockBundledSource("feishu", currentBundledPath);
+
+    const result = maybeRepairBundledPluginLoadPaths(
+      createPluginLoadPathConfig([staleBundledPath, "/custom/path"]),
+    );
+
+    expect(result.changes).toEqual([
+      `- plugins.load.paths: removed bundled feishu path alias ${staleBundledPath}`,
+    ]);
+    expect(result.config.plugins?.load?.paths).toStrictEqual(["/custom/path"]);
+  });
+
+  it("removes stale legacy bundled paths from old versioned OpenClaw package roots", () => {
+    const currentPackageRoot = path.resolve("node_modules", "openclaw");
+    const stalePackageRoot = path.resolve(
+      "pnpm-global",
+      ".pnpm",
+      "openclaw@2026.3.28_@napi-rs+canvas@0.1.97",
+      "node_modules",
+      "openclaw",
+    );
+    const currentBundledPath = bundledDistPluginRootAt(currentPackageRoot, "feishu");
+    const staleLegacyPath = bundledPluginRootAt(stalePackageRoot, "feishu");
+    mockBundledSource("feishu", currentBundledPath);
+
+    const result = maybeRepairBundledPluginLoadPaths(createPluginLoadPathConfig([staleLegacyPath]));
+
+    expect(result.changes).toEqual([
+      `- plugins.load.paths: removed bundled feishu path alias ${staleLegacyPath}`,
+    ]);
+    expect(result.config.plugins?.load?.paths).toStrictEqual([]);
+  });
+
+  it("does not remove arbitrary missing paths that happen to use the bundled dist layout", () => {
+    const currentPackageRoot = path.resolve("node_modules", "openclaw");
+    const customPath = path.resolve("elsewhere", "dist", "extensions", "feishu");
+    mockBundledSource("feishu", bundledDistPluginRootAt(currentPackageRoot, "feishu"));
+
+    const result = maybeRepairBundledPluginLoadPaths(createPluginLoadPathConfig([customPath]));
+
+    expect(result.changes).toEqual([]);
+    expect(result.config).toEqual(createPluginLoadPathConfig([customPath]));
+  });
+
   it("derives legacy paths from the bundled directory name instead of plugin id", () => {
     const packageRoot = path.resolve("app-node-modules", "openclaw");
     const legacyPath = bundledPluginRootAt(packageRoot, "kimi-coding");

--- a/src/commands/doctor/shared/bundled-plugin-load-paths.ts
+++ b/src/commands/doctor/shared/bundled-plugin-load-paths.ts
@@ -1,8 +1,11 @@
+import path from "node:path";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../../agents/agent-scope.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import {
   buildBundledPluginLoadPathAliases,
   normalizeBundledLookupPath,
+  parseLegacyBundledPluginPath,
+  parsePackagedBundledPluginPath,
 } from "../../../plugins/bundled-load-path-aliases.js";
 import { resolveBundledPluginSources } from "../../../plugins/bundled-sources.js";
 import { sanitizeForLog } from "../../../terminal/ansi.js";
@@ -18,6 +21,13 @@ type BundledPluginLoadPathHit = {
 
 function resolveBundledWorkspaceDir(cfg: OpenClawConfig): string | undefined {
   return resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg)) ?? undefined;
+}
+
+function isOpenClawNodeModulesPackageRoot(packageRoot: string): boolean {
+  const normalized = normalizeBundledLookupPath(packageRoot);
+  const packageDir = path.basename(normalized);
+  const parentDir = path.basename(path.dirname(normalized));
+  return packageDir === "openclaw" && parentDir === "node_modules";
 }
 
 export function scanBundledPluginLoadPathMigrations(
@@ -40,9 +50,17 @@ export function scanBundledPluginLoadPathMigrations(
   }
 
   const bundledPathMap = new Map<string, { pluginId: string; toPath: string }>();
+  const packagedBundledLeafMap = new Map<string, { pluginId: string; toPath: string }>();
   for (const source of bundled.values()) {
     for (const alias of buildBundledPluginLoadPathAliases(source.localPath)) {
       bundledPathMap.set(normalizeBundledLookupPath(alias.path), {
+        pluginId: source.pluginId,
+        toPath: source.localPath,
+      });
+    }
+    const packaged = parsePackagedBundledPluginPath(source.localPath);
+    if (packaged) {
+      packagedBundledLeafMap.set(normalizeBundledLookupPath(packaged.bundledLeaf), {
         pluginId: source.pluginId,
         toPath: source.localPath,
       });
@@ -57,6 +75,23 @@ export function scanBundledPluginLoadPathMigrations(
     const normalized = normalizeBundledLookupPath(resolveUserPath(rawPath, env));
     const match = bundledPathMap.get(normalized);
     if (!match) {
+      const oldPackaged = parsePackagedBundledPluginPath(normalized);
+      const oldLegacy = oldPackaged ? null : parseLegacyBundledPluginPath(normalized);
+      const oldPackageRoot = oldPackaged?.packageRoot ?? oldLegacy?.packageRoot;
+      const oldBundledLeaf = oldPackaged?.bundledLeaf ?? oldLegacy?.bundledLeaf;
+      const oldPackageMatch =
+        oldPackageRoot && oldBundledLeaf && isOpenClawNodeModulesPackageRoot(oldPackageRoot)
+          ? packagedBundledLeafMap.get(normalizeBundledLookupPath(oldBundledLeaf))
+          : undefined;
+      if (!oldPackageMatch) {
+        continue;
+      }
+      hits.push({
+        pluginId: oldPackageMatch.pluginId,
+        fromPath: rawPath,
+        toPath: oldPackageMatch.toPath,
+        pathLabel: "plugins.load.paths",
+      });
       continue;
     }
     hits.push({

--- a/src/plugins/bundled-load-path-aliases.ts
+++ b/src/plugins/bundled-load-path-aliases.ts
@@ -8,6 +8,18 @@ export type BundledPluginLoadPathAlias = {
   path: string;
 };
 
+export type PackagedBundledPluginPath = {
+  packageRoot: string;
+  bundledRoot: string;
+  bundledLeaf: string;
+};
+
+export type LegacyBundledPluginPath = {
+  packageRoot: string;
+  legacyRoot: string;
+  bundledLeaf: string;
+};
+
 const PACKAGED_BUNDLED_ROOTS = [
   path.join("dist", "extensions"),
   path.join("dist-runtime", "extensions"),
@@ -46,22 +58,52 @@ function findPackagedBundledRoot(localPath: string): {
   return null;
 }
 
-export function buildLegacyBundledPath(localPath: string): string | null {
+export function parsePackagedBundledPluginPath(
+  localPath: string,
+): PackagedBundledPluginPath | null {
   const packaged = findPackagedBundledRoot(localPath);
   if (!packaged) {
     return null;
   }
   const normalized = normalizeBundledLookupPath(localPath);
-  const bundledLeaf =
-    normalized === packaged.bundledRoot
-      ? ""
-      : normalized.slice(packaged.bundledRoot.length + path.sep.length);
-  return bundledLeaf ? path.join(packaged.packageRoot, "extensions", bundledLeaf) : null;
+  if (normalized === packaged.bundledRoot) {
+    return null;
+  }
+  return {
+    ...packaged,
+    bundledLeaf: normalized.slice(packaged.bundledRoot.length + path.sep.length),
+  };
+}
+
+export function buildLegacyBundledPath(localPath: string): string | null {
+  const packaged = parsePackagedBundledPluginPath(localPath);
+  if (!packaged) {
+    return null;
+  }
+  return path.join(packaged.packageRoot, "extensions", packaged.bundledLeaf);
 }
 
 export function buildLegacyBundledRootPath(localPath: string): string | null {
   const packaged = findPackagedBundledRoot(localPath);
   return packaged ? path.join(packaged.packageRoot, "extensions") : null;
+}
+
+export function parseLegacyBundledPluginPath(localPath: string): LegacyBundledPluginPath | null {
+  const normalized = normalizeBundledLookupPath(localPath);
+  const marker = `${path.sep}extensions`;
+  const markerIndex = normalized.lastIndexOf(marker);
+  if (markerIndex === -1) {
+    return null;
+  }
+  const markerEnd = markerIndex + marker.length;
+  if (normalized.length === markerEnd || normalized[markerEnd] !== path.sep) {
+    return null;
+  }
+  return {
+    packageRoot: normalized.slice(0, markerIndex),
+    legacyRoot: normalized.slice(0, markerEnd),
+    bundledLeaf: normalized.slice(markerEnd + path.sep.length),
+  };
 }
 
 export function buildBundledPluginLoadPathAliases(localPath: string): BundledPluginLoadPathAlias[] {


### PR DESCRIPTION
## Summary

- Treat stale `plugins.load.paths` entries from old versioned `node_modules/openclaw` package roots as bundled-plugin aliases during doctor detection and repair.
- Reuse the bundled path parser for current packaged roots, old packaged roots, and legacy `extensions/<plugin>` roots while keeping arbitrary custom plugin paths untouched.
- Add regression coverage for stale packaged paths, stale legacy paths, and unrelated paths with similar layouts.

Fixes #58626.

## Verification

2026-05-23 update after rebasing onto `origin/main` (`1a60c19743`), head `425fb15c7d`:

- `node scripts/run-vitest.mjs src/commands/doctor/shared/bundled-plugin-load-paths.test.ts --reporter=verbose` (1 file, 12 tests passed)
- `./node_modules/.bin/oxfmt --check --threads=1 CHANGELOG.md src/commands/doctor/shared/bundled-plugin-load-paths.ts src/commands/doctor/shared/bundled-plugin-load-paths.test.ts src/plugins/bundled-load-path-aliases.ts`
- `./node_modules/.bin/oxlint src/commands/doctor/shared/bundled-plugin-load-paths.ts src/commands/doctor/shared/bundled-plugin-load-paths.test.ts src/plugins/bundled-load-path-aliases.ts`
- `git diff --check origin/main...HEAD`

Earlier verification before the rebase:

- `CI=true pnpm install`
- `git diff --check upstream/main...HEAD`
- `pnpm exec oxfmt --check --threads=1 src/commands/doctor/shared/bundled-plugin-load-paths.ts src/commands/doctor/shared/bundled-plugin-load-paths.test.ts src/commands/doctor/shared/preview-warnings.ts src/commands/doctor/shared/preview-warnings.test.ts src/commands/doctor/repair-sequencing.ts CHANGELOG.md`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/commands/doctor/shared/bundled-plugin-load-paths.test.ts src/commands/doctor/shared/preview-warnings.test.ts src/commands/doctor/repair-sequencing.test.ts src/cli/plugins-install-config.test.ts --reporter=verbose` (59 tests passed)
- `.agents/skills/autoreview/scripts/autoreview --mode branch` (clean: no accepted/actionable findings)

## Real behavior proof

Behavior addressed: stale bundled plugin load paths from old versioned OpenClaw package roots are removed by doctor repair instead of remaining as `plugins.load.paths` config errors after upgrade.

Real environment tested: WSL Ubuntu-24.04 checkout at `/root/src/openclaw-85038`, Node/Vitest via repo wrapper.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/commands/doctor/shared/bundled-plugin-load-paths.test.ts --reporter=verbose`

Evidence after fix: The focused tests cover old-version packaged path repair, old-version legacy path repair, current packaged path repair, and preserving unrelated custom paths with similar `dist/extensions/<plugin>` layouts.

Observed result after fix: old `.../node_modules/openclaw/dist/extensions/<plugin>` and old `.../node_modules/openclaw/extensions/<plugin>` entries are pruned when they match a current bundled plugin leaf, while unrelated `elsewhere/dist/extensions/<plugin>` paths are preserved. The focused suite passed 12 tests; static checks were clean.

What was not tested: I did not rerun the broader 59-test doctor/config group after this rebase; the focused behavior and touched-file static checks passed.
