### PR TITLE
Route Anthropic custom streams through OpenClaw transport

### DIFF
--- a/src/agents/embedded-agent-runner/stream-resolution.test.ts
+++ b/src/agents/embedded-agent-runner/stream-resolution.test.ts
@@ -115,6 +115,19 @@ describe("describeEmbeddedAgentStreamStrategy", () => {
       }),
     ).toBe("boundary-aware:anthropic-messages");
   });
+
+  it("describes Anthropic custom session streams as boundary-aware without pre-resolved auth", () => {
+    expect(
+      describeEmbeddedAgentStreamStrategy({
+        currentStreamFn: vi.fn() as never,
+        model: {
+          api: "anthropic-messages",
+          provider: "anthropic",
+          id: "claude-sonnet-4-6",
+        } as never,
+      }),
+    ).toBe("boundary-aware:anthropic-messages");
+  });
 });
 
 describe("resolveEmbeddedAgentStreamFn", () => {
@@ -243,6 +256,36 @@ describe("resolveEmbeddedAgentStreamFn", () => {
       "runtime auth result",
     );
     expect(result.apiKey).toBe("anthropic-runtime-key");
+    expect(currentStreamFn).not.toHaveBeenCalled();
+    expect(innerStreamFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("routes Anthropic custom session streams through OpenClaw tool shaping without pre-resolved auth", async () => {
+    const currentStreamFn = vi.fn(async (_model, _context, options) => options);
+    const innerStreamFn = vi.fn(async (_model, _context, options) => options);
+    const authStorage = {
+      getApiKey: vi.fn(async () => "stored-anthropic-key"),
+    };
+    overrideBoundaryAwareStreamFnOnce(innerStreamFn as never);
+
+    const streamFn = resolveEmbeddedAgentStreamFn({
+      currentStreamFn: currentStreamFn as never,
+      sessionId: "session-1",
+      model: {
+        api: "anthropic-messages",
+        provider: "anthropic",
+        id: "claude-sonnet-4-6",
+      } as never,
+      authStorage,
+    });
+
+    expect(streamFn).not.toBe(currentStreamFn);
+    const result = await expectStreamResultRecord(
+      streamFn({ provider: "anthropic", id: "claude-sonnet-4-6" } as never, {} as never, {}),
+      "anthropic custom stream result",
+    );
+    expect(result.apiKey).toBe("stored-anthropic-key");
+    expect(authStorage.getApiKey).toHaveBeenCalledWith("anthropic");
     expect(currentStreamFn).not.toHaveBeenCalled();
     expect(innerStreamFn).toHaveBeenCalledTimes(1);
   });

--- a/src/agents/embedded-agent-runner/stream-resolution.ts
+++ b/src/agents/embedded-agent-runner/stream-resolution.ts
@@ -49,6 +49,10 @@ function hasResolvedRuntimeApiKey(apiKey: string | undefined): boolean {
   return typeof apiKey === "string" && apiKey.trim().length > 0;
 }
 
+function requiresOpenClawToolWireShape(model: EmbeddedRunAttemptParams["model"]): boolean {
+  return model.api === "anthropic-messages";
+}
+
 function isOpenAICodexResponsesModel(model: EmbeddedRunAttemptParams["model"]): boolean {
   return model.provider === "openai" && model.api === "openai-chatgpt-responses";
 }
@@ -92,7 +96,8 @@ export function describeEmbeddedAgentStreamStrategy(params: {
       : "stream-simple";
   }
   if (
-    hasResolvedRuntimeApiKey(params.resolvedApiKey) &&
+    (hasResolvedRuntimeApiKey(params.resolvedApiKey) ||
+      requiresOpenClawToolWireShape(params.model)) &&
     createBoundaryAwareStreamFnForModel(params.model)
   ) {
     return `boundary-aware:${params.model.api}`;
@@ -171,7 +176,8 @@ export function resolveEmbeddedAgentStreamFn(params: {
 
   if (
     isDefaultOpenClawStreamFnForModel(params.model, params.currentStreamFn) ||
-    hasResolvedRuntimeApiKey(params.resolvedApiKey)
+    hasResolvedRuntimeApiKey(params.resolvedApiKey) ||
+    requiresOpenClawToolWireShape(params.model)
   ) {
     const boundaryAwareStreamFn = createBoundaryAwareStreamFnForModel(params.model);
     if (boundaryAwareStreamFn) {


### PR DESCRIPTION
## Summary

Fixes #85009.

- route `anthropic-messages` embedded runs through OpenClaw's boundary-aware transport even when the session has a custom stream function and no pre-resolved runtime key
- keep stored/runtime auth injection intact for that path
- add regression coverage proving the custom stream is bypassed and the Anthropic key reaches the OpenClaw transport wrapper

## Root cause

`resolveEmbeddedAgentStreamFn` still returned a session custom stream for Anthropic Messages when `resolvedApiKey` was absent. That let PI/native serialization handle `customTools`, which can emit `tools[].type: "custom"`; Anthropic rejects that shape with `Invalid value: custom`.

## Real behavior proof

**Behavior or issue addressed**: Anthropic Messages embedded runs with a custom session stream and no pre-resolved runtime API key now route through OpenClaw's boundary-aware Anthropic transport instead of the PI/custom stream path that can serialize custom tools as `tools[].type: "custom"`.

**Real environment tested**: Local OpenClaw checkout on macOS at commit `825b8029a5`, rebased onto `origin/main` `fad1c8a071`. Runtime was Node `v24.15.0` and pnpm `11.1.0`. For secret safety, the run used OpenClaw's real `resolveEmbeddedAgentStreamFn` + `createAnthropicMessagesTransportStreamFn` path with a redacted stored-auth value and a local Anthropic Messages-compatible capture endpoint bound to `127.0.0.1`.

**Exact steps or command run after this patch**:

```bash
node --version
pnpm --version
git rev-parse --short HEAD
git rev-parse --short origin/main
pnpm exec tsx .tmp/pr85044-anthropic-boundary-proof.ts
node scripts/run-vitest.mjs run src/agents/pi-embedded-runner/stream-resolution.test.ts
pnpm deadcode:dependencies
```

**Evidence after fix**:

```text
$ node --version && pnpm --version && git rev-parse --short HEAD && git rev-parse --short origin/main && pnpm exec tsx .tmp/pr85044-anthropic-boundary-proof.ts
v24.15.0
11.1.0
825b8029a5
fad1c8a071
strategy=boundary-aware:anthropic-messages
custom_session_stream_calls=0
stored_auth_provider_lookups=anthropic
captured_http_method=POST
captured_http_path=/v1/messages
x_api_key_header=<redacted-present>
authorization_header=absent
request_model=claude-sonnet-4-6
request_stream=true
request_tool_count=1
first_tool_name=proof_lookup
first_tool_has_input_schema=true
first_tool_has_type_custom=false
observed_stop_reason=stop
observed_error=
observed_text=proof-ok

$ node scripts/run-vitest.mjs run src/agents/pi-embedded-runner/stream-resolution.test.ts
Test Files  2 passed (2)
Tests  44 passed (44)

$ pnpm deadcode:dependencies
pnpm --config.minimum-release-age=0 dlx knip@6.8.0 --config config/knip.config.ts --production --no-progress --reporter compact --dependencies --no-config-hints
```

**Observed result after fix**: The strategy resolver selected `boundary-aware:anthropic-messages`, the old custom session stream was not called, stored auth was looked up for `anthropic`, and the Anthropic transport sent an HTTP `POST /v1/messages` with the redacted `x-api-key` header. The captured request had one tool using Anthropic's `input_schema` shape and did not include `type: "custom"`. The stream completed successfully with `observed_stop_reason=stop` and `observed_text=proof-ok`. The rebased branch also passes the dependency check that was failing on stale QA fixture filenames.

**What was not tested**: I did not send Andy's real Anthropic secret to the public Anthropic API in this proof. The capture endpoint verifies OpenClaw's actual embedded-run resolver, stored-auth injection, Anthropic transport selection, and outgoing Anthropic Messages request shape with the API key redacted.

## Attribution

If this PR is squash-merged or reworked, please preserve author attribution or include:

Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>
