### PR TITLE
fix(status): bound sandbox browser docker audit

### DIFF
--- a/src/agents/sandbox/docker.execDockerRaw.enoent.test.ts
+++ b/src/agents/sandbox/docker.execDockerRaw.enoent.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { withEnvAsync } from "../../test-utils/env.js";
 import { execDockerRaw } from "./docker.js";
@@ -20,4 +23,26 @@ describe("execDockerRaw", () => {
       );
     });
   });
+
+  it.runIf(process.platform !== "win32")(
+    "times out and aborts a stalled docker subprocess",
+    async () => {
+      const binDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-docker-timeout-"));
+      try {
+        const dockerPath = path.join(binDir, "docker");
+        await fs.writeFile(dockerPath, "#!/bin/sh\nsleep 5\n", "utf8");
+        await fs.chmod(dockerPath, 0o755);
+
+        await withEnvAsync({ PATH: `${binDir}:${process.env.PATH ?? ""}` }, async () => {
+          const startedAt = Date.now();
+          await expect(execDockerRaw(["ps"], { timeoutMs: 50 })).rejects.toMatchObject({
+            name: "TimeoutError",
+          });
+          expect(Date.now() - startedAt).toBeLessThan(2000);
+        });
+      } finally {
+        await fs.rm(binDir, { recursive: true, force: true });
+      }
+    },
+  );
 });

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -11,6 +11,7 @@ type ExecDockerRawOptions = {
   allowFailure?: boolean;
   input?: Buffer | string;
   signal?: AbortSignal;
+  timeoutMs?: number;
 };
 
 export type ExecDockerRawResult = {
@@ -25,10 +26,26 @@ type ExecDockerRawError = Error & {
   stderr: Buffer;
 };
 
-function createAbortError(): Error {
+function createAbortError(reason?: unknown): Error {
+  if (reason instanceof Error) {
+    return reason;
+  }
   const err = new Error("Aborted");
   err.name = "AbortError";
   return err;
+}
+
+function createDockerTimeoutError(timeoutMs: number): Error {
+  const err = new Error(`docker command timed out after ${timeoutMs}ms`);
+  err.name = "TimeoutError";
+  return err;
+}
+
+function resolveDockerRawTimeoutMs(timeoutMs: number | undefined): number | undefined {
+  if (typeof timeoutMs !== "number" || !Number.isFinite(timeoutMs)) {
+    return undefined;
+  }
+  return Math.max(1, Math.floor(timeoutMs));
 }
 
 type DockerSpawnRuntime = {
@@ -78,14 +95,55 @@ export function execDockerRaw(
     const stdoutChunks: Buffer[] = [];
     const stderrChunks: Buffer[] = [];
     let aborted = false;
+    let abortError: Error | undefined;
+    let settled = false;
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+    let forceKillHandle: ReturnType<typeof setTimeout> | undefined;
 
     const signal = opts?.signal;
-    const handleAbort = () => {
+    const cleanupAbortState = (cleanupOpts?: { clearForceKill?: boolean }) => {
+      if (signal) {
+        signal.removeEventListener("abort", handleAbort);
+      }
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle);
+      }
+      if (cleanupOpts?.clearForceKill !== false && forceKillHandle) {
+        clearTimeout(forceKillHandle);
+      }
+    };
+    const settleReject = (error: unknown, cleanupOpts?: { clearForceKill?: boolean }) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanupAbortState(cleanupOpts);
+      reject(error);
+    };
+    const settleResolve = (result: ExecDockerRawResult) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanupAbortState();
+      resolve(result);
+    };
+    const abortChild = (error: Error) => {
       if (aborted) {
         return;
       }
       aborted = true;
+      abortError = error;
+      child.stdin?.destroy();
+      child.stdout?.destroy();
+      child.stderr?.destroy();
       child.kill("SIGTERM");
+      forceKillHandle = setTimeout(() => child.kill("SIGKILL"), 1000);
+      forceKillHandle.unref?.();
+      settleReject(error, { clearForceKill: false });
+    };
+    const handleAbort = () => {
+      abortChild(createAbortError(signal?.reason));
     };
     if (signal) {
       if (signal.aborted) {
@@ -93,6 +151,13 @@ export function execDockerRaw(
       } else {
         signal.addEventListener("abort", handleAbort, { once: true });
       }
+    }
+    const timeoutMs = resolveDockerRawTimeoutMs(opts?.timeoutMs);
+    if (timeoutMs !== undefined) {
+      timeoutHandle = setTimeout(() => {
+        abortChild(createDockerTimeoutError(timeoutMs));
+      }, timeoutMs);
+      timeoutHandle.unref?.();
     }
 
     child.stdout?.on("data", (chunk) => {
@@ -103,8 +168,9 @@ export function execDockerRaw(
     });
 
     child.on("error", (error) => {
-      if (signal) {
-        signal.removeEventListener("abort", handleAbort);
+      if (settled) {
+        cleanupAbortState();
+        return;
       }
       if (
         error &&
@@ -118,20 +184,21 @@ export function execDockerRaw(
           ),
           { code: "INVALID_CONFIG", cause: error },
         );
-        reject(friendly);
+        settleReject(friendly);
         return;
       }
-      reject(error);
+      settleReject(error);
     });
 
     child.on("close", (code) => {
-      if (signal) {
-        signal.removeEventListener("abort", handleAbort);
+      if (settled) {
+        cleanupAbortState();
+        return;
       }
       const stdout = Buffer.concat(stdoutChunks);
       const stderr = Buffer.concat(stderrChunks);
       if (aborted || signal?.aborted) {
-        reject(createAbortError());
+        settleReject(abortError ?? createAbortError(signal?.reason));
         return;
       }
       const exitCode = code ?? 0;
@@ -145,14 +212,14 @@ export function execDockerRaw(
             stderr,
           },
         );
-        reject(error);
+        settleReject(error);
         return;
       }
-      resolve({ stdout, stderr, code: exitCode });
+      settleResolve({ stdout, stderr, code: exitCode });
     });
 
     const stdin = child.stdin;
-    if (stdin) {
+    if (stdin && !aborted) {
       if (opts?.input !== undefined) {
         stdin.end(opts.input);
       } else {

--- a/src/commands/status-runtime-shared.test.ts
+++ b/src/commands/status-runtime-shared.test.ts
@@ -121,6 +121,25 @@ describe("status-runtime-shared", () => {
     });
   });
 
+  it("passes the status timeout into security audit subprocess probes", async () => {
+    await resolveStatusSecurityAudit({
+      config: { gateway: {} },
+      sourceConfig: { gateway: {} },
+      timeoutMs: 4321,
+    });
+
+    expect(mocks.runSecurityAudit).toHaveBeenCalledWith({
+      config: { gateway: {} },
+      sourceConfig: { gateway: {} },
+      deep: false,
+      includeFilesystem: true,
+      includeChannelSecurity: true,
+      loadPluginSecurityCollectors: false,
+      subprocessTimeoutMs: 4321,
+      plugins: [{ id: "telegram" }],
+    });
+  });
+
   it("resolves usage summaries with the provided timeout", async () => {
     await resolveStatusUsageSummary({
       timeoutMs: 1234,
@@ -329,6 +348,7 @@ describe("status-runtime-shared", () => {
       includeFilesystem: true,
       includeChannelSecurity: true,
       loadPluginSecurityCollectors: false,
+      subprocessTimeoutMs: 1234,
       plugins: [{ id: "telegram" }],
     });
   });

--- a/src/commands/status-runtime-shared.ts
+++ b/src/commands/status-runtime-shared.ts
@@ -27,6 +27,7 @@ function loadGatewayCallModule() {
 export async function resolveStatusSecurityAudit(params: {
   config: OpenClawConfig;
   sourceConfig: OpenClawConfig;
+  timeoutMs?: number;
 }) {
   const { runSecurityAudit } = await loadSecurityAuditModule();
   const readOnlyPlugins = resolveReadOnlyChannelPluginsForConfig(params.config, {
@@ -40,6 +41,7 @@ export async function resolveStatusSecurityAudit(params: {
     includeFilesystem: true,
     includeChannelSecurity: true,
     loadPluginSecurityCollectors: false,
+    ...(params.timeoutMs !== undefined ? { subprocessTimeoutMs: params.timeoutMs } : {}),
     ...(readOnlyPlugins.missingConfiguredChannelIds.length === 0
       ? { plugins: readOnlyPlugins.plugins }
       : {}),
@@ -198,6 +200,7 @@ export async function resolveStatusRuntimeSnapshot(params: {
   resolveSecurityAudit?: (input: {
     config: OpenClawConfig;
     sourceConfig: OpenClawConfig;
+    timeoutMs?: number;
   }) => Promise<StatusSecurityAudit>;
   resolveUsage?: (input: StatusUsageSummaryOptions) => Promise<StatusUsageSummary>;
   resolveHealth?: (input: {
@@ -209,6 +212,7 @@ export async function resolveStatusRuntimeSnapshot(params: {
     ? await (params.resolveSecurityAudit ?? resolveStatusSecurityAudit)({
         config: params.config,
         sourceConfig: params.sourceConfig,
+        timeoutMs: params.timeoutMs,
       })
     : undefined;
   const runtimeDetails = await resolveStatusRuntimeDetails({

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -775,6 +775,7 @@ vi.mock("./status-runtime-shared.ts", () => ({
       resolveSecurityAudit?: (input: unknown) => Promise<unknown>;
       config: unknown;
       sourceConfig: unknown;
+      timeoutMs?: number;
     }) => {
       const securityAudit = params.includeSecurityAudit
         ? await (
@@ -790,6 +791,7 @@ vi.mock("./status-runtime-shared.ts", () => ({
           )({
             config: params.config,
             sourceConfig: params.sourceConfig,
+            timeoutMs: params.timeoutMs,
           })
         : undefined;
       return {

--- a/src/security/audit-extra.async.ts
+++ b/src/security/audit-extra.async.ts
@@ -36,10 +36,18 @@ type SkillScanSummary = Awaited<
 >;
 type ExecDockerRawFn = (
   args: string[],
-  opts?: { allowFailure?: boolean; input?: Buffer | string; signal?: AbortSignal },
+  opts?: {
+    allowFailure?: boolean;
+    input?: Buffer | string;
+    signal?: AbortSignal;
+    timeoutMs?: number;
+  },
 ) => Promise<import("../agents/sandbox/docker.js").ExecDockerRawResult>;
 
 type CodeSafetySummaryCache = Map<string, Promise<unknown>>;
+const DEFAULT_SANDBOX_BROWSER_DOCKER_AUDIT_TIMEOUT_MS = 5000;
+const MIN_SANDBOX_BROWSER_DOCKER_AUDIT_TIMEOUT_MS = 250;
+
 let skillsModulePromise: Promise<typeof import("../agents/skills.js")> | undefined;
 let configModulePromise: Promise<typeof import("../config/config.js")> | undefined;
 let agentScopeModulePromise: Promise<typeof import("../agents/agent-scope.js")> | undefined;
@@ -274,52 +282,115 @@ function normalizeDockerLabelValue(raw: string | undefined): string | null {
   return trimmed;
 }
 
+function resolveSandboxBrowserDockerAuditTimeoutMs(timeoutMs: number | undefined): number {
+  if (typeof timeoutMs !== "number" || !Number.isFinite(timeoutMs)) {
+    return DEFAULT_SANDBOX_BROWSER_DOCKER_AUDIT_TIMEOUT_MS;
+  }
+  return Math.max(MIN_SANDBOX_BROWSER_DOCKER_AUDIT_TIMEOUT_MS, Math.floor(timeoutMs));
+}
+
+function isDockerTimeoutError(err: unknown): boolean {
+  return (
+    err instanceof Error &&
+    (err.name === "TimeoutError" || err.name === "AbortError" || /\btimed out\b/i.test(err.message))
+  );
+}
+
+function buildSandboxBrowserDockerTimeoutFinding(timeoutMs: number): SecurityAuditFinding {
+  return {
+    checkId: "sandbox.browser_container.docker_probe_timeout",
+    severity: "warn",
+    title: "Sandbox browser Docker audit timed out",
+    detail:
+      `Docker did not respond within ${timeoutMs}ms while checking sandbox browser containers. ` +
+      "OpenClaw skipped the remaining container drift checks so status can finish.",
+    remediation:
+      "Check Docker daemon health and rerun " +
+      `${formatCliCommand("openclaw security audit --deep")}.`,
+  };
+}
+
+async function execSandboxBrowserDockerAuditCommand(params: {
+  execDockerRawFn: ExecDockerRawFn;
+  args: string[];
+  timeoutMs: number;
+}): Promise<{
+  result: Awaited<ReturnType<ExecDockerRawFn>> | null;
+  timedOut: boolean;
+}> {
+  try {
+    return {
+      result: await params.execDockerRawFn(params.args, {
+        allowFailure: true,
+        timeoutMs: params.timeoutMs,
+      }),
+      timedOut: false,
+    };
+  } catch (err) {
+    return {
+      result: null,
+      timedOut: isDockerTimeoutError(err),
+    };
+  }
+}
+
 async function listSandboxBrowserContainers(
   execDockerRawFn: ExecDockerRawFn,
-): Promise<string[] | null> {
-  try {
-    const result = await execDockerRawFn(
-      ["ps", "-a", "--filter", "label=openclaw.sandboxBrowser=1", "--format", "{{.Names}}"],
-      { allowFailure: true },
-    );
-    if (result.code !== 0) {
-      return null;
-    }
-    return result.stdout
+  timeoutMs: number,
+): Promise<{ containers: string[] | null; timedOut: boolean }> {
+  const probe = await execSandboxBrowserDockerAuditCommand({
+    execDockerRawFn,
+    timeoutMs,
+    args: ["ps", "-a", "--filter", "label=openclaw.sandboxBrowser=1", "--format", "{{.Names}}"],
+  });
+  if (probe.timedOut) {
+    return { containers: null, timedOut: true };
+  }
+  if (!probe.result || probe.result.code !== 0) {
+    return { containers: null, timedOut: false };
+  }
+  return {
+    containers: probe.result.stdout
       .toString("utf8")
       .split(/\r?\n/)
       .map((entry) => entry.trim())
-      .filter(Boolean);
-  } catch {
-    return null;
-  }
+      .filter(Boolean),
+    timedOut: false,
+  };
 }
 
 async function readSandboxBrowserHashLabels(params: {
   containerName: string;
   execDockerRawFn: ExecDockerRawFn;
-}): Promise<{ configHash: string | null; epoch: string | null } | null> {
-  try {
-    const result = await params.execDockerRawFn(
-      [
-        "inspect",
-        "-f",
-        '{{ index .Config.Labels "openclaw.configHash" }}\t{{ index .Config.Labels "openclaw.browserConfigEpoch" }}',
-        params.containerName,
-      ],
-      { allowFailure: true },
-    );
-    if (result.code !== 0) {
-      return null;
-    }
-    const [hashRaw, epochRaw] = result.stdout.toString("utf8").split("\t");
-    return {
+  timeoutMs: number;
+}): Promise<{
+  labels: { configHash: string | null; epoch: string | null } | null;
+  timedOut: boolean;
+}> {
+  const probe = await execSandboxBrowserDockerAuditCommand({
+    execDockerRawFn: params.execDockerRawFn,
+    timeoutMs: params.timeoutMs,
+    args: [
+      "inspect",
+      "-f",
+      '{{ index .Config.Labels "openclaw.configHash" }}\t{{ index .Config.Labels "openclaw.browserConfigEpoch" }}',
+      params.containerName,
+    ],
+  });
+  if (probe.timedOut) {
+    return { labels: null, timedOut: true };
+  }
+  if (!probe.result || probe.result.code !== 0) {
+    return { labels: null, timedOut: false };
+  }
+  const [hashRaw, epochRaw] = probe.result.stdout.toString("utf8").split("\t");
+  return {
+    labels: {
       configHash: normalizeDockerLabelValue(hashRaw),
       epoch: normalizeDockerLabelValue(epochRaw),
-    };
-  } catch {
-    return null;
-  }
+    },
+    timedOut: false,
+  };
 }
 
 function parsePublishedHostFromDockerPortLine(line: string): string | null {
@@ -349,33 +420,44 @@ function isLoopbackPublishHost(host: string): boolean {
 async function readSandboxBrowserPortMappings(params: {
   containerName: string;
   execDockerRawFn: ExecDockerRawFn;
-}): Promise<string[] | null> {
-  try {
-    const result = await params.execDockerRawFn(["port", params.containerName], {
-      allowFailure: true,
-    });
-    if (result.code !== 0) {
-      return null;
-    }
-    return result.stdout
+  timeoutMs: number;
+}): Promise<{ portMappings: string[] | null; timedOut: boolean }> {
+  const probe = await execSandboxBrowserDockerAuditCommand({
+    execDockerRawFn: params.execDockerRawFn,
+    timeoutMs: params.timeoutMs,
+    args: ["port", params.containerName],
+  });
+  if (probe.timedOut) {
+    return { portMappings: null, timedOut: true };
+  }
+  if (!probe.result || probe.result.code !== 0) {
+    return { portMappings: null, timedOut: false };
+  }
+  return {
+    portMappings: probe.result.stdout
       .toString("utf8")
       .split(/\r?\n/)
       .map((entry) => entry.trim())
-      .filter(Boolean);
-  } catch {
-    return null;
-  }
+      .filter(Boolean),
+    timedOut: false,
+  };
 }
 
 export async function collectSandboxBrowserHashLabelFindings(params?: {
   execDockerRawFn?: ExecDockerRawFn;
+  timeoutMs?: number;
 }): Promise<SecurityAuditFinding[]> {
   const findings: SecurityAuditFinding[] = [];
+  const timeoutMs = resolveSandboxBrowserDockerAuditTimeoutMs(params?.timeoutMs);
   const [execFn, browserHashEpoch] = await Promise.all([
     params?.execDockerRawFn ? Promise.resolve(params.execDockerRawFn) : loadExecDockerRaw(),
     loadSandboxBrowserSecurityHashEpoch(),
   ]);
-  const containers = await listSandboxBrowserContainers(execFn);
+  const containerResult = await listSandboxBrowserContainers(execFn, timeoutMs);
+  if (containerResult.timedOut) {
+    return [buildSandboxBrowserDockerTimeoutFinding(timeoutMs)];
+  }
+  const containers = containerResult.containers;
   if (!containers || containers.length === 0) {
     return findings;
   }
@@ -383,9 +465,19 @@ export async function collectSandboxBrowserHashLabelFindings(params?: {
   const missingHash: string[] = [];
   const staleEpoch: string[] = [];
   const nonLoopbackPublished: string[] = [];
+  let timedOut = false;
 
   for (const containerName of containers) {
-    const labels = await readSandboxBrowserHashLabels({ containerName, execDockerRawFn: execFn });
+    const labelResult = await readSandboxBrowserHashLabels({
+      containerName,
+      execDockerRawFn: execFn,
+      timeoutMs,
+    });
+    if (labelResult.timedOut) {
+      timedOut = true;
+      break;
+    }
+    const labels = labelResult.labels;
     if (!labels) {
       continue;
     }
@@ -398,17 +490,26 @@ export async function collectSandboxBrowserHashLabelFindings(params?: {
     const portMappings = await readSandboxBrowserPortMappings({
       containerName,
       execDockerRawFn: execFn,
+      timeoutMs,
     });
-    if (!portMappings?.length) {
+    if (portMappings.timedOut) {
+      timedOut = true;
+      break;
+    }
+    if (!portMappings.portMappings?.length) {
       continue;
     }
-    const exposedMappings = portMappings.filter((line) => {
+    const exposedMappings = portMappings.portMappings.filter((line) => {
       const host = parsePublishedHostFromDockerPortLine(line);
       return Boolean(host && !isLoopbackPublishHost(host));
     });
     if (exposedMappings.length > 0) {
       nonLoopbackPublished.push(`${containerName} (${exposedMappings.join("; ")})`);
     }
+  }
+
+  if (timedOut) {
+    findings.push(buildSandboxBrowserDockerTimeoutFinding(timeoutMs));
   }
 
   if (missingHash.length > 0) {

--- a/src/security/audit-plugin-readonly-scope.test.ts
+++ b/src/security/audit-plugin-readonly-scope.test.ts
@@ -38,6 +38,7 @@ function createAuditContext(params: {
     includeChannelSecurity: true,
     deep: false,
     deepTimeoutMs: 5000,
+    subprocessTimeoutMs: 5000,
     stateDir: "/tmp/openclaw-test-state",
     configPath: "/tmp/openclaw-test-config.json",
     plugins: params.plugins,

--- a/src/security/audit-sandbox-browser.test.ts
+++ b/src/security/audit-sandbox-browser.test.ts
@@ -7,7 +7,8 @@ function hasFinding(
   checkId:
     | "sandbox.browser_container.hash_label_missing"
     | "sandbox.browser_container.hash_epoch_stale"
-    | "sandbox.browser_container.non_loopback_publish",
+    | "sandbox.browser_container.non_loopback_publish"
+    | "sandbox.browser_container.docker_probe_timeout",
   severity: "warn" | "critical",
   findings: Array<{ checkId: string; severity: string; detail: string }>,
 ) {
@@ -15,7 +16,9 @@ function hasFinding(
 }
 
 function requireFinding(
-  checkId: "sandbox.browser_container.hash_epoch_stale",
+  checkId:
+    | "sandbox.browser_container.hash_epoch_stale"
+    | "sandbox.browser_container.docker_probe_timeout",
   findings: Array<{ checkId: string; severity: string; detail: string }>,
 ) {
   const finding = findings.find((entry) => entry.checkId === checkId);
@@ -23,6 +26,12 @@ function requireFinding(
     throw new Error(`Expected ${checkId} finding`);
   }
   return finding;
+}
+
+function createDockerTimeoutError() {
+  const err = new Error("docker command timed out after 1234ms");
+  err.name = "TimeoutError";
+  return err;
 }
 
 describe("security audit sandbox browser findings", () => {
@@ -74,6 +83,27 @@ describe("security audit sandbox browser findings", () => {
       false,
     );
     expect(hasFinding("sandbox.browser_container.hash_epoch_stale", "warn", findings)).toBe(false);
+  });
+
+  it("warns instead of hanging when the Docker sandbox browser probe times out", async () => {
+    let receivedTimeoutMs: number | undefined;
+    const findings = await collectSandboxBrowserHashLabelFindings({
+      timeoutMs: 1234,
+      execDockerRawFn: async (_args, opts) => {
+        receivedTimeoutMs = opts?.timeoutMs;
+        throw createDockerTimeoutError();
+      },
+    });
+
+    expect(receivedTimeoutMs).toBe(1234);
+    expect(hasFinding("sandbox.browser_container.docker_probe_timeout", "warn", findings)).toBe(
+      true,
+    );
+    const timeoutFinding = requireFinding(
+      "sandbox.browser_container.docker_probe_timeout",
+      findings,
+    );
+    expect(timeoutFinding.detail).toContain("1234ms");
   });
 
   it("flags sandbox browser containers with non-loopback published ports", async () => {

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -56,6 +56,8 @@ export type SecurityAuditOptions = {
   configPath?: string;
   /** Time limit for deep gateway probe. */
   deepTimeoutMs?: number;
+  /** Time limit for audit subprocess probes. */
+  subprocessTimeoutMs?: number;
   /** Dependency injection for tests. */
   plugins?: ChannelPlugin[];
   /** Whether to import plugin modules to discover plugin security audit collectors. */
@@ -85,6 +87,7 @@ export type AuditExecutionContext = {
   includeChannelSecurity: boolean;
   deep: boolean;
   deepTimeoutMs: number;
+  subprocessTimeoutMs: number;
   stateDir: string;
   configPath: string;
   execIcacls?: ExecFn;
@@ -935,6 +938,7 @@ async function createAuditExecutionContext(
   const includeChannelSecurity = opts.includeChannelSecurity !== false;
   const deep = opts.deep === true;
   const deepTimeoutMs = Math.max(250, opts.deepTimeoutMs ?? 5000);
+  const subprocessTimeoutMs = Math.max(250, opts.subprocessTimeoutMs ?? deepTimeoutMs);
   const stateDir = opts.stateDir ?? resolveStateDir(env);
   const configPath = opts.configPath ?? resolveConfigPath(env, stateDir);
   const workspaceDir =
@@ -954,6 +958,7 @@ async function createAuditExecutionContext(
     includeChannelSecurity,
     deep,
     deepTimeoutMs,
+    subprocessTimeoutMs,
     stateDir,
     configPath,
     execIcacls: opts.execIcacls,
@@ -1029,6 +1034,7 @@ export async function runSecurityAudit(opts: SecurityAuditOptions): Promise<Secu
     findings.push(
       ...(await auditNonDeep.collectSandboxBrowserHashLabelFindings({
         execDockerRawFn: context.execDockerRawFn,
+        timeoutMs: context.subprocessTimeoutMs,
       })),
     );
     findings.push(...(await auditNonDeep.collectPluginsTrustFindings({ cfg, stateDir })));


### PR DESCRIPTION
## Summary

- Bound sandbox browser Docker audit subprocesses with a per-call timeout.
- Pass the status timeout into security audit subprocess probes.
- Surface a warning when Docker does not respond instead of letting `openclaw status --deep` hang.

## AI assistance disclosure

This PR was prepared with AI assistance. I inspected the reported status/security-audit path, related issue/PR context, implementation, tests, and real CLI behavior before drafting the change. I reviewed the final patch and understand the affected status/security-audit/Docker subprocess path.

## Real behavior proof

Behavior addressed: `openclaw status --deep` no longer waits indefinitely when the sandbox browser Docker audit probe stalls.

Real environment tested: Built OpenClaw CLI entry from this branch, isolated OpenClaw home/state/config, isolated local OpenClaw gateway on a throwaway loopback port, and a fake `docker` executable that sleeps for 5 seconds.

Exact steps or command run after this patch:

```sh
node dist/entry.js status --deep --timeout 500
```

Evidence after fix:

```text
Security audit
Summary: 1 critical · 4 warn · 1 info
  WARN Sandbox browser Docker audit timed out
    Docker did not respond within 500ms while checking sandbox browser containers. OpenClaw skipped the remaining container drift checks so status can finish.
    Fix: Check Docker daemon health and rerun openclaw security audit --deep.

[proof exit code] 0
```

Observed result after fix: The command returned successfully before the 30s harness guard and printed the bounded Docker audit timeout warning.

What was not tested: A real unhealthy Docker daemon hang; the proof uses a sleeping Docker shim so it is deterministic and does not depend on host Docker state.

## Root Cause

`status --deep` enables the shared status security audit path. That audit includes sandbox browser container drift checks, which call Docker through `execDockerRaw`. The collector had no subprocess timeout for `docker ps`, `docker inspect`, or `docker port`, so a stalled Docker CLI/daemon could hold the status command forever.

## Regression Test Plan

- `execDockerRaw` now has a focused stalled-subprocess test using a fake `docker` executable.
- Sandbox browser security audit tests assert timeout propagation and the warning finding.
- Status runtime tests assert `--timeout` reaches security audit subprocess probes.
- Existing status/security fixtures were updated for the new audit context field.

## Security Impact

This keeps the sandbox browser drift audit best-effort when Docker is unhealthy. It does not weaken existing checks when Docker responds; it only converts an unbounded wait into a warning that tells the operator the Docker-backed part of the audit was skipped.

## Human Verification

Please review the timeout budget choice and wording of the new warning. The fix intentionally uses the existing status timeout as the subprocess budget for this status-triggered audit path.

This touches CODEOWNERS-protected security surfaces (`src/security/` and `src/agents/sandbox/`), so secops review is expected.

## Changelog

Not edited in this contributor PR. Maintainers or ClawSweeper can add the changelog entry during landing if needed.

## Review conversations

ClawSweeper reviewed the draft and found no concrete contributor-facing blocker.
It marked proof sufficient and ready for maintainer look. CODEOWNERS/secops
review remains expected for the timeout budget and warning wording.

## Risks

- The Docker timeout is per subprocess call, not a single global collector budget. This fixes indefinite hangs, but many slow container probes can still add up to multiple bounded waits.

## Behavior tradeoffs

- Timeout/abort now rejects promptly while subprocess cleanup continues in the background. This is intentional so status can finish even when shell children or inherited pipes would delay the child `close` event. The helper still sends `SIGTERM`, destroys stdio, and schedules a short `SIGKILL` fallback.

## Scope boundaries

- Ordinary non-timeout Docker failures remain best-effort and quiet, matching the previous behavior. This PR only changes stalled Docker probes.

## Validation

```sh
corepack pnpm format:check -- src/agents/sandbox/docker.execDockerRaw.enoent.test.ts src/agents/sandbox/docker.ts src/commands/status-runtime-shared.test.ts src/commands/status-runtime-shared.ts src/commands/status.test.ts src/security/audit-extra.async.ts src/security/audit-sandbox-browser.test.ts src/security/audit.ts
OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree corepack pnpm test src/security/audit-sandbox-browser.test.ts src/security/audit-plugin-readonly-scope.test.ts src/commands/status-runtime-shared.test.ts src/agents/sandbox/docker.execDockerRaw.enoent.test.ts src/commands/status.test.ts -- --reporter=verbose
PATH="$PWD/.artifacts/bin:$PATH" OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree corepack pnpm check:changed
codex review --base origin/main
corepack pnpm build
node dist/entry.js status --deep --timeout 500
```

Fixes https://github.com/openclaw/openclaw/issues/84984
