### PR TITLE
fix(agents): preserve accepted spawn terminal success

### DIFF
--- a/scripts/deadcode-unused-files.allowlist.mjs
+++ b/scripts/deadcode-unused-files.allowlist.mjs
@@ -37,4 +37,8 @@ export const KNIP_UNUSED_FILE_ALLOWLIST = [
 // Knip can disagree across supported local/CI platforms for files that are
 // only reachable through test-only import graphs. Ignore these when reported,
 // but do not require them to be reported.
-export const KNIP_OPTIONAL_UNUSED_FILE_ALLOWLIST = ["src/gateway/test/server-sessions-helpers.ts"];
+export const KNIP_OPTIONAL_UNUSED_FILE_ALLOWLIST = [
+  "extensions/qa-lab/src/auth-profile-fixture.ts",
+  "extensions/qa-lab/src/codex-plugin-fixture.ts",
+  "src/gateway/test/server-sessions-helpers.ts",
+];

--- a/src/agents/accepted-session-spawn.ts
+++ b/src/agents/accepted-session-spawn.ts
@@ -1,0 +1,35 @@
+import { normalizeOptionalString } from "../shared/string-coerce.js";
+
+export type AcceptedSessionSpawn = {
+  runId: string;
+  childSessionKey: string;
+};
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+export function normalizeAcceptedSessionSpawnResult(result: unknown): AcceptedSessionSpawn | null {
+  const details = asRecord(asRecord(result)?.details);
+  if (!details || details.status !== "accepted") {
+    return null;
+  }
+  const runId = normalizeOptionalString(details.runId);
+  const childSessionKey = normalizeOptionalString(details.childSessionKey);
+  if (!runId || !childSessionKey) {
+    return null;
+  }
+  return { runId, childSessionKey };
+}
+
+export function hasAcceptedSessionSpawn(
+  acceptedSessionSpawns?: readonly AcceptedSessionSpawn[],
+): boolean {
+  return (acceptedSessionSpawns ?? []).some((spawn) => {
+    return Boolean(
+      normalizeOptionalString(spawn.runId) && normalizeOptionalString(spawn.childSessionKey),
+    );
+  });
+}

--- a/src/agents/pi-embedded-runner/delivery-evidence.ts
+++ b/src/agents/pi-embedded-runner/delivery-evidence.ts
@@ -1,3 +1,5 @@
+import { hasAcceptedSessionSpawn } from "../accepted-session-spawn.js";
+
 type AgentPayloadLike = {
   text?: unknown;
   mediaUrl?: unknown;
@@ -19,6 +21,7 @@ export type AgentDeliveryEvidence = {
   messagingToolSentTexts?: unknown;
   messagingToolSentMediaUrls?: unknown;
   messagingToolSentTargets?: unknown;
+  acceptedSessionSpawns?: unknown;
   successfulCronAdds?: unknown;
   meta?: {
     toolSummary?: {
@@ -129,6 +132,7 @@ function hasAgentDeliveryEvidenceShape(value: object): boolean {
     "messagingToolSentTexts" in value ||
     "messagingToolSentMediaUrls" in value ||
     "messagingToolSentTargets" in value ||
+    "acceptedSessionSpawns" in value ||
     "successfulCronAdds" in value ||
     "meta" in value
   );
@@ -186,6 +190,8 @@ export function hasCommittedMessagingToolDeliveryEvidence(
 export function hasOutboundDeliveryEvidence(result: AgentDeliveryEvidence): boolean {
   return (
     hasMessagingToolDeliveryEvidence(result) ||
+    (Array.isArray(result.acceptedSessionSpawns) &&
+      hasAcceptedSessionSpawn(result.acceptedSessionSpawns)) ||
     hasPositiveNumber(result.successfulCronAdds) ||
     hasPositiveNumber(result.meta?.toolSummary?.calls)
   );

--- a/src/agents/pi-embedded-runner/result-fallback-classifier.test.ts
+++ b/src/agents/pi-embedded-runner/result-fallback-classifier.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { classifyEmbeddedPiRunResultForModelFallback } from "./result-fallback-classifier.js";
+
+describe("classifyEmbeddedPiRunResultForModelFallback", () => {
+  it("does not fallback when sessions_spawn accepted a child session", () => {
+    expect(
+      classifyEmbeddedPiRunResultForModelFallback({
+        provider: "mock-openai",
+        model: "gpt-5.5",
+        result: {
+          meta: { durationMs: 1 },
+          acceptedSessionSpawns: [
+            {
+              runId: "run-child",
+              childSessionKey: "agent:qa:subagent:child",
+            },
+          ],
+        },
+      }),
+    ).toBeNull();
+  });
+});

--- a/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
+++ b/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
@@ -1,6 +1,9 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
-import { hasCommittedMessagingToolDeliveryEvidence } from "./delivery-evidence.js";
+import {
+  hasCommittedMessagingToolDeliveryEvidence,
+  hasOutboundDeliveryEvidence,
+} from "./delivery-evidence.js";
 import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
 import {
   loadRunOverflowCompactionHarness,
@@ -1484,6 +1487,34 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
     expect(retryInstruction).toBe(EMPTY_RESPONSE_RETRY_INSTRUCTION);
   });
 
+  it("does not retry empty turns after an accepted sessions_spawn delivery", () => {
+    const retryInstruction = resolveEmptyResponseRetryInstruction({
+      provider: "ollama",
+      modelId: "gemma4:31b",
+      payloadCount: 0,
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: [],
+        acceptedSessionSpawns: [
+          {
+            runId: "run-child",
+            childSessionKey: "agent:claude:subagent:child",
+          },
+        ],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "end_turn",
+          provider: "ollama",
+          model: "gemma4:31b",
+          content: [{ type: "text", text: "" }],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    });
+
+    expect(retryInstruction).toBeNull();
+  });
+
   it("retries generic empty OpenAI-compatible turns from custom endpoints", () => {
     const retryInstruction = resolveEmptyResponseRetryInstruction({
       provider: "llama-cpp-local",
@@ -1654,6 +1685,100 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
     expect(incompleteTurnText).toBeNull();
   });
 
+  it("suppresses the incomplete-turn warning after an accepted sessions_spawn terminal success", () => {
+    const attemptWithAcceptedSpawn: Partial<EmbeddedRunAttemptResult> & {
+      acceptedSessionSpawns: Array<{ runId: string; childSessionKey: string }>;
+    } = {
+      assistantTexts: [],
+      acceptedSessionSpawns: [
+        {
+          runId: "run-child",
+          childSessionKey: "agent:claude:subagent:child",
+        },
+      ],
+      lastAssistant: {
+        role: "assistant",
+        stopReason: "stop",
+        provider: "anthropic",
+        model: "sonnet-4.6",
+        content: [],
+      } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+    };
+
+    const incompleteTurnText = resolveIncompleteTurnPayloadText({
+      payloadCount: 0,
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult(attemptWithAcceptedSpawn),
+    });
+
+    expect(incompleteTurnText).toBeNull();
+  });
+
+  it("still returns a timeout payload when the parent prompt times out after an accepted sessions_spawn", async () => {
+    const acceptedSessionSpawns = [
+      {
+        runId: "run-child",
+        childSessionKey: "agent:claude:subagent:child",
+      },
+    ];
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: [],
+        acceptedSessionSpawns,
+        timedOut: true,
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "toolUse",
+          provider: "openai",
+          model: "gpt-5.4",
+          content: [],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    );
+
+    const result = await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.4",
+      runId: "run-timeout-after-accepted-spawn",
+    });
+
+    expect(result.payloads).toEqual([
+      {
+        text: "Request timed out before a response was generated. Please try again, or increase `agents.defaults.timeoutSeconds` in your config.",
+        isError: true,
+      },
+    ]);
+    expect(result.acceptedSessionSpawns).toEqual(acceptedSessionSpawns);
+  });
+
+  it("still surfaces the incomplete-turn warning without an accepted sessions_spawn success", () => {
+    const attemptWithMalformedSpawn: Partial<EmbeddedRunAttemptResult> & {
+      acceptedSessionSpawns: Array<{ runId: string; childSessionKey: string }>;
+    } = {
+      assistantTexts: [],
+      acceptedSessionSpawns: [],
+      lastAssistant: {
+        role: "assistant",
+        stopReason: "stop",
+        provider: "anthropic",
+        model: "sonnet-4.6",
+        content: [],
+      } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+    };
+
+    const incompleteTurnText = resolveIncompleteTurnPayloadText({
+      payloadCount: 0,
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult(attemptWithMalformedSpawn),
+    });
+
+    expect(incompleteTurnText).toContain("couldn't generate a response");
+  });
+
   it("still surfaces the incomplete-turn warning when no messaging delivery was committed", () => {
     const incompleteTurnText = resolveIncompleteTurnPayloadText({
       payloadCount: 0,
@@ -1736,6 +1861,26 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
         messagingToolSentTargets: [{ tool: "message", provider: "slack", to: "channel-1" }],
       }),
     ).toEqual({ hadPotentialSideEffects: true, replaySafe: false });
+  });
+
+  it("treats accepted sessions_spawn as replay-invalid outbound delivery", () => {
+    const acceptedSessionSpawns = [
+      {
+        runId: "run-child",
+        childSessionKey: "agent:claude:subagent:child",
+      },
+    ];
+
+    expect(
+      buildAttemptReplayMetadata({
+        toolMetas: [],
+        didSendViaMessagingTool: false,
+        messagingToolSentTexts: [],
+        messagingToolSentMediaUrls: [],
+        acceptedSessionSpawns,
+      }),
+    ).toEqual({ hadPotentialSideEffects: true, replaySafe: false });
+    expect(hasOutboundDeliveryEvidence({ acceptedSessionSpawns })).toBe(true);
   });
 
   it("leaves committed delivery plus tool errors to the tool-error payload path", () => {

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.fixture.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.fixture.ts
@@ -39,6 +39,7 @@ export function makeAttemptResult(
   const messagingToolSentMediaUrls = overrides.messagingToolSentMediaUrls ?? [];
   const messagingToolSentTargets = overrides.messagingToolSentTargets ?? [];
   const successfulCronAdds = overrides.successfulCronAdds;
+  const acceptedSessionSpawns = overrides.acceptedSessionSpawns ?? [];
   return {
     aborted: false,
     externalAbort: false,
@@ -51,6 +52,7 @@ export function makeAttemptResult(
     sessionIdUsed: "test-session",
     assistantTexts: ["Hello!"],
     toolMetas,
+    acceptedSessionSpawns,
     lastAssistant: undefined,
     messagesSnapshot: [],
     replayMetadata:
@@ -61,6 +63,7 @@ export function makeAttemptResult(
         messagingToolSentTexts,
         messagingToolSentMediaUrls,
         messagingToolSentTargets,
+        acceptedSessionSpawns,
         successfulCronAdds,
       }),
     itemLifecycle: {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -106,7 +106,10 @@ import {
 } from "./compaction-safety-timeout.js";
 import { resolveContextEngineCapabilities } from "./context-engine-capabilities.js";
 import { runContextEngineMaintenance } from "./context-engine-maintenance.js";
-import { hasMessagingToolDeliveryEvidence } from "./delivery-evidence.js";
+import {
+  hasMessagingToolDeliveryEvidence,
+  hasOutboundDeliveryEvidence,
+} from "./delivery-evidence.js";
 import { resolveEmbeddedRunFailureSignal } from "./failure-signal.js";
 import { resolveGlobalLane, resolveSessionLane } from "./lanes.js";
 import { log } from "./logger.js";
@@ -251,6 +254,7 @@ function normalizeEmbeddedRunAttemptResult(
   const raw = attempt as EmbeddedRunAttemptForRunner & {
     assistantTexts?: EmbeddedRunAttemptForRunner["assistantTexts"] | null;
     toolMetas?: EmbeddedRunAttemptForRunner["toolMetas"] | null;
+    acceptedSessionSpawns?: EmbeddedRunAttemptForRunner["acceptedSessionSpawns"] | null;
     messagesSnapshot?: EmbeddedRunAttemptForRunner["messagesSnapshot"] | null;
     messagingToolSentTexts?: EmbeddedRunAttemptForRunner["messagingToolSentTexts"] | null;
     messagingToolSentMediaUrls?: EmbeddedRunAttemptForRunner["messagingToolSentMediaUrls"] | null;
@@ -264,6 +268,7 @@ function normalizeEmbeddedRunAttemptResult(
     ...attempt,
     assistantTexts: raw.assistantTexts ?? [],
     toolMetas: raw.toolMetas ?? [],
+    acceptedSessionSpawns: raw.acceptedSessionSpawns ?? [],
     messagesSnapshot: raw.messagesSnapshot ?? [],
     messagingToolSentTexts: raw.messagingToolSentTexts ?? [],
     messagingToolSentMediaUrls: raw.messagingToolSentMediaUrls ?? [],
@@ -283,7 +288,7 @@ function hasCompletedModelProgressForIdleBreaker(attempt: EmbeddedRunAttemptForR
     attempt.assistantTexts.some((text) => text.trim().length > 0) ||
     attempt.toolMetas.length > 0 ||
     (attempt.clientToolCalls?.length ?? 0) > 0 ||
-    hasMessagingToolDeliveryEvidence(attempt) ||
+    hasOutboundDeliveryEvidence(attempt) ||
     attempt.itemLifecycle.completedCount > 0
   );
 }
@@ -1652,7 +1657,7 @@ export async function runEmbeddedPiAgent(
               ? sessionLastAssistant.errorMessage?.trim() || formattedAssistantErrorText
               : undefined;
           const canRestartForLiveSwitch =
-            !hasMessagingToolDeliveryEvidence(attempt) &&
+            !hasOutboundDeliveryEvidence(attempt) &&
             !attempt.didSendDeterministicApprovalPrompt &&
             !attempt.lastToolError &&
             (attempt.toolMetas?.length ?? 0) === 0 &&
@@ -2734,6 +2739,7 @@ export async function runEmbeddedPiAgent(
               messagingToolSourceReplyPayloads: attempt.messagingToolSourceReplyPayloads,
               heartbeatToolResponse: attempt.heartbeatToolResponse,
               successfulCronAdds: attempt.successfulCronAdds,
+              acceptedSessionSpawns: attempt.acceptedSessionSpawns,
             };
           }
 
@@ -2957,6 +2963,7 @@ export async function runEmbeddedPiAgent(
               messagingToolSourceReplyPayloads: attempt.messagingToolSourceReplyPayloads,
               heartbeatToolResponse: attempt.heartbeatToolResponse,
               successfulCronAdds: attempt.successfulCronAdds,
+              acceptedSessionSpawns: attempt.acceptedSessionSpawns,
             };
           }
           if (reasoningOnlyRetriesExhausted && !finalAssistantVisibleText) {
@@ -3009,6 +3016,7 @@ export async function runEmbeddedPiAgent(
               messagingToolSourceReplyPayloads: attempt.messagingToolSourceReplyPayloads,
               heartbeatToolResponse: attempt.heartbeatToolResponse,
               successfulCronAdds: attempt.successfulCronAdds,
+              acceptedSessionSpawns: attempt.acceptedSessionSpawns,
             };
           }
           if (
@@ -3120,6 +3128,7 @@ export async function runEmbeddedPiAgent(
               messagingToolSourceReplyPayloads: attempt.messagingToolSourceReplyPayloads,
               heartbeatToolResponse: attempt.heartbeatToolResponse,
               successfulCronAdds: attempt.successfulCronAdds,
+              acceptedSessionSpawns: attempt.acceptedSessionSpawns,
             };
           }
 
@@ -3236,6 +3245,7 @@ export async function runEmbeddedPiAgent(
             messagingToolSourceReplyPayloads: attempt.messagingToolSourceReplyPayloads,
             heartbeatToolResponse: attempt.heartbeatToolResponse,
             successfulCronAdds: attempt.successfulCronAdds,
+            acceptedSessionSpawns: attempt.acceptedSessionSpawns,
           };
         }
       } finally {

--- a/src/agents/pi-embedded-runner/run/attempt-trajectory-status.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt-trajectory-status.test.ts
@@ -50,6 +50,22 @@ describe("attempt trajectory status", () => {
     ).toEqual({ status: "success" });
   });
 
+  it("keeps accepted session spawns as terminal progress", () => {
+    expect(
+      resolveAttemptTrajectoryTerminal(
+        baseParams({
+          acceptedSessionSpawns: [
+            {
+              runId: "run-child",
+              childSessionKey: "agent:claude:subagent:child",
+            },
+          ],
+          lastAssistantStopReason: "toolUse",
+        }),
+      ),
+    ).toEqual({ status: "success" });
+  });
+
   it("does not treat an uncommitted messaging tool attempt as delivery", () => {
     expect(
       resolveAttemptTrajectoryTerminal(

--- a/src/agents/pi-embedded-runner/run/attempt-trajectory-status.ts
+++ b/src/agents/pi-embedded-runner/run/attempt-trajectory-status.ts
@@ -1,3 +1,8 @@
+import {
+  hasAcceptedSessionSpawn,
+  type AcceptedSessionSpawn,
+} from "../../accepted-session-spawn.js";
+
 export type AttemptTrajectoryTerminalStatus = "success" | "error" | "interrupted";
 
 export const NON_DELIVERABLE_TERMINAL_TURN_REASON = "non_deliverable_terminal_turn";
@@ -20,6 +25,7 @@ export type ResolveAttemptTrajectoryTerminalParams = {
   messagingToolSentTargets: unknown[];
   successfulCronAdds: number;
   synthesizedPayloadCount: number;
+  acceptedSessionSpawns?: readonly AcceptedSessionSpawn[];
   heartbeatToolResponse?: unknown;
   clientToolCalls?: Array<unknown>;
   yieldDetected?: boolean;
@@ -80,6 +86,7 @@ export function resolveAttemptTrajectoryTerminal(
     params.emptyAssistantReplyIsSilent === true ||
     params.didSendDeterministicApprovalPrompt ||
     hasCommittedMessagingDeliveryEvidence(params) ||
+    hasAcceptedSessionSpawn(params.acceptedSessionSpawns) ||
     params.synthesizedPayloadCount > 0 ||
     params.heartbeatToolResponse !== undefined ||
     (params.clientToolCalls?.length ?? 0) > 0 ||

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
@@ -100,6 +100,7 @@ export function createSubscriptionMock(): SubscriptionMock {
     unsubscribe: () => {},
     setTerminalLifecycleMeta: () => {},
     waitForCompactionRetry: async () => {},
+    getAcceptedSessionSpawns: () => [],
     getMessagingToolSentTexts: () => [] as string[],
     getMessagingToolSentMediaUrls: () => [] as string[],
     getMessagingToolSentTargets: () => [] as MessagingToolSend[],

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -3189,9 +3189,8 @@ export async function runEmbeddedAttempt(
         prompt: string,
         options?: Parameters<typeof activeSession.prompt>[1],
       ): Promise<void> =>
-        withOwnedSessionTranscriptWrites(
-          ownedTranscriptWriteContext,
-          async () => abortable(trackPromptSettlePromise(activeSession.prompt(prompt, options))),
+        withOwnedSessionTranscriptWrites(ownedTranscriptWriteContext, async () =>
+          abortable(trackPromptSettlePromise(activeSession.prompt(prompt, options))),
         );
       const onBlockReply = params.onBlockReply
         ? bindOwnedSessionTranscriptWrites(ownedTranscriptWriteContext, params.onBlockReply)
@@ -3243,6 +3242,7 @@ export async function runEmbeddedAttempt(
       const {
         assistantTexts,
         toolMetas,
+        getAcceptedSessionSpawns,
         runToolLifecycle,
         unsubscribe,
         waitForCompactionRetry,
@@ -4635,11 +4635,13 @@ export async function runEmbeddedAttempt(
           });
       }
 
+      const acceptedSessionSpawns = getAcceptedSessionSpawns();
       const observedReplayMetadata = buildAttemptReplayMetadata({
         toolMetas: toolMetasNormalized,
         didSendViaMessagingTool: didSendViaMessagingTool(),
         messagingToolSentTexts: getMessagingToolSentTexts(),
         messagingToolSentMediaUrls: getMessagingToolSentMediaUrls(),
+        acceptedSessionSpawns,
         successfulCronAdds: getSuccessfulCronAdds(),
       });
       const pendingToolMediaReply = getPendingToolMediaReply();
@@ -4698,6 +4700,7 @@ export async function runEmbeddedAttempt(
           messagingToolSentTexts: getMessagingToolSentTexts(),
           messagingToolSentMediaUrls: getMessagingToolSentMediaUrls(),
           messagingToolSentTargets: getMessagingToolSentTargets(),
+          acceptedSessionSpawns,
           lastToolError,
           lastAssistant,
           replayMetadata,
@@ -4723,6 +4726,7 @@ export async function runEmbeddedAttempt(
         messagingToolSentTargets: getMessagingToolSentTargets(),
         successfulCronAdds: getSuccessfulCronAdds(),
         synthesizedPayloadCount,
+        acceptedSessionSpawns,
         heartbeatToolResponse,
         clientToolCalls: completedClientToolCalls,
         yieldDetected,
@@ -4812,6 +4816,7 @@ export async function runEmbeddedAttempt(
         messagesSnapshot,
         assistantTexts,
         toolMetas: toolMetasNormalized,
+        acceptedSessionSpawns,
         lastAssistant,
         currentAttemptAssistant,
         lastToolError,

--- a/src/agents/pi-embedded-runner/run/incomplete-turn.ts
+++ b/src/agents/pi-embedded-runner/run/incomplete-turn.ts
@@ -6,6 +6,7 @@ import {
 } from "../../../auto-reply/tokens.js";
 import type { EmbeddedPiExecutionContract } from "../../../config/types.agent-defaults.js";
 import { normalizeLowercaseStringOrEmpty } from "../../../shared/string-coerce.js";
+import { hasAcceptedSessionSpawn } from "../../accepted-session-spawn.js";
 import { collectTextContentBlocks } from "../../content-blocks.js";
 import {
   isStrictAgenticSupportedProviderModel,
@@ -29,7 +30,7 @@ type ReplayMetadataAttempt = Pick<
   | "messagingToolSentMediaUrls"
   | "successfulCronAdds"
 > &
-  Partial<Pick<EmbeddedRunAttemptResult, "messagingToolSentTargets">>;
+  Partial<Pick<EmbeddedRunAttemptResult, "messagingToolSentTargets" | "acceptedSessionSpawns">>;
 
 type IncompleteTurnAttempt = Pick<
   EmbeddedRunAttemptResult,
@@ -47,7 +48,8 @@ type IncompleteTurnAttempt = Pick<
   | "replayMetadata"
   | "promptErrorSource"
   | "timedOutDuringCompaction"
->;
+> &
+  Partial<Pick<EmbeddedRunAttemptResult, "acceptedSessionSpawns">>;
 
 type PlanningOnlyAttempt = Pick<
   EmbeddedRunAttemptResult,
@@ -206,6 +208,7 @@ export function buildAttemptReplayMetadata(
   const hadPotentialSideEffects =
     hadMutatingTools ||
     hasMessagingToolDeliveryEvidence(params) ||
+    hasAcceptedSessionSpawn(params.acceptedSessionSpawns) ||
     (params.successfulCronAdds ?? 0) > 0;
   return {
     hadPotentialSideEffects,
@@ -249,6 +252,10 @@ export function resolveIncompleteTurnPayloadText(params: {
   }
 
   if (hasCommittedMessagingToolDeliveryEvidence(params.attempt)) {
+    return null;
+  }
+
+  if (hasAcceptedSessionSpawn(params.attempt.acceptedSessionSpawns)) {
     return null;
   }
 
@@ -484,6 +491,7 @@ function shouldSkipPlanningOnlyRetry(params: {
     params.attempt.yieldDetected ||
     params.attempt.didSendDeterministicApprovalPrompt ||
     params.attempt.lastToolError ||
+    hasAcceptedSessionSpawn(params.attempt.acceptedSessionSpawns) ||
     resolveAttemptReplayMetadata(params.attempt).hadPotentialSideEffects,
   );
 }

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -7,6 +7,7 @@ import type { SessionSystemPromptReport } from "../../../config/sessions/types.j
 import type { ContextEngine, ContextEnginePromptCacheInfo } from "../../../context-engine/types.js";
 import type { DiagnosticTraceContext } from "../../../infra/diagnostic-trace-context.js";
 import type { PluginHookBeforeAgentStartResult } from "../../../plugins/hook-before-agent-start.types.js";
+import type { AcceptedSessionSpawn } from "../../accepted-session-spawn.js";
 import type { AuthProfileStore } from "../../auth-profiles/types.js";
 import type {
   MessagingToolSend,
@@ -115,6 +116,7 @@ export type EmbeddedRunAttemptResult = {
   messagesSnapshot: AgentMessage[];
   assistantTexts: string[];
   toolMetas: Array<{ toolName: string; meta?: string }>;
+  acceptedSessionSpawns?: AcceptedSessionSpawn[];
   lastAssistant: AssistantMessage | undefined;
   currentAttemptAssistant?: AssistantMessage | undefined;
   lastToolError?: ToolErrorSummary;

--- a/src/agents/pi-embedded-runner/types.ts
+++ b/src/agents/pi-embedded-runner/types.ts
@@ -1,6 +1,7 @@
 import type { HeartbeatToolResponse } from "../../auto-reply/heartbeat-tool-response.js";
 import type { CliSessionBinding, SessionSystemPromptReport } from "../../config/sessions/types.js";
 import type { DiagnosticTraceContext } from "../../infra/diagnostic-trace-context.js";
+import type { AcceptedSessionSpawn } from "../accepted-session-spawn.js";
 import type { FallbackAttempt } from "../model-fallback.types.js";
 import type {
   MessagingToolSend,
@@ -191,6 +192,8 @@ export type EmbeddedPiRunResult = {
   messagingToolSentTargets?: MessagingToolSend[];
   // Message-tool replies delivered to the active internal UI source.
   messagingToolSourceReplyPayloads?: MessagingToolSourceReplyPayload[];
+  // Child sessions successfully accepted by sessions_spawn during the run.
+  acceptedSessionSpawns?: AcceptedSessionSpawn[];
   // Structured heartbeat outcome recorded by the heartbeat response tool.
   heartbeatToolResponse?: HeartbeatToolResponse;
   // Count of successful cron.add tool calls in this run.

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
@@ -351,6 +351,31 @@ describe("handleAgentEnd", () => {
     });
   });
 
+  it("keeps accepted session spawns from being marked abandoned", async () => {
+    const onAgentEvent = vi.fn();
+    const ctx = createContext(undefined, { onAgentEvent });
+    ctx.state.replayState = { ...ctx.state.replayState, replayInvalid: true };
+    ctx.state.livenessState = "working";
+    ctx.state.assistantTexts = [];
+    ctx.state.acceptedSessionSpawns = [
+      {
+        runId: "run-child",
+        childSessionKey: "agent:claude:subagent:child",
+      },
+    ];
+
+    await handleAgentEnd(ctx);
+
+    expect(onAgentEvent).toHaveBeenCalledWith({
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        livenessState: "working",
+        replayInvalid: true,
+      },
+    });
+  });
+
   it("flushes orphaned tool media as a media-only block reply", async () => {
     const ctx = createContext(undefined);
     ctx.state.pendingToolMediaUrls = ["/tmp/reply.opus"];

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
@@ -1,5 +1,6 @@
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { createInlineCodeState } from "../markdown/code-spans.js";
+import { hasAcceptedSessionSpawn } from "./accepted-session-spawn.js";
 import {
   buildApiErrorObservationFields,
   buildTextObservationFields,
@@ -47,6 +48,7 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext): void | Promise<
   const hadDeterministicSideEffect =
     ctx.state.hadDeterministicSideEffect === true ||
     hasCommittedMessagingToolDeliveryEvidence(ctx.state) ||
+    hasAcceptedSessionSpawn(ctx.state.acceptedSessionSpawns) ||
     (ctx.state.successfulCronAdds ?? 0) > 0;
   const incompleteTerminalAssistant = isIncompleteTerminalAssistantTurn({
     hasAssistantVisibleText,

--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -47,6 +47,7 @@ function createTestContext(): {
     state: {
       toolMetaById: new Map<string, ToolCallSummary>(),
       toolMetas: [],
+      acceptedSessionSpawns: [],
       toolSummaryById: new Set<string>(),
       itemActiveIds: new Set<string>(),
       itemStartedCount: 0,
@@ -277,6 +278,79 @@ describe("handleToolExecutionEnd cron.add commitment tracking", () => {
     expect(ctx.state.successfulCronAdds).toBe(0);
     expect(ctx.state.itemCompletedCount).toBe(1);
     expect(ctx.state.itemActiveIds.size).toBe(0);
+  });
+});
+
+describe("handleToolExecutionEnd sessions_spawn terminal success tracking", () => {
+  it("records accepted sessions_spawn identifiers", async () => {
+    const { ctx } = createTestContext();
+
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "sessions_spawn",
+        toolCallId: "tool-spawn-accepted",
+        isError: false,
+        result: {
+          details: {
+            status: "accepted",
+            runId: " run-child ",
+            childSessionKey: " agent:claude:subagent:child ",
+          },
+        },
+      } as never,
+    );
+
+    expect(ctx.state.acceptedSessionSpawns).toEqual([
+      {
+        runId: "run-child",
+        childSessionKey: "agent:claude:subagent:child",
+      },
+    ]);
+    expect(ctx.state.replayState).toEqual({
+      replayInvalid: true,
+      hadPotentialSideEffects: true,
+    });
+  });
+
+  it("does not record failed or malformed sessions_spawn results", async () => {
+    const { ctx } = createTestContext();
+
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "sessions_spawn",
+        toolCallId: "tool-spawn-failed",
+        isError: false,
+        result: {
+          details: {
+            status: "error",
+            runId: "run-child",
+            childSessionKey: "agent:claude:subagent:child",
+          },
+        },
+      } as never,
+    );
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "sessions_spawn",
+        toolCallId: "tool-spawn-malformed",
+        isError: false,
+        result: {
+          details: {
+            status: "accepted",
+            runId: "run-child",
+            childSessionKey: " ",
+          },
+        },
+      } as never,
+    );
+
+    expect(ctx.state.acceptedSessionSpawns).toEqual([]);
   });
 });
 

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -21,6 +21,7 @@ import type { PluginHookAfterToolCallEvent } from "../plugins/types.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import { normalizeOptionalLowercaseString, readStringValue } from "../shared/string-coerce.js";
 import { truncateUtf16Safe } from "../utils.js";
+import { normalizeAcceptedSessionSpawnResult } from "./accepted-session-spawn.js";
 import type { ApplyPatchSummary } from "./apply-patch.js";
 import type { ExecToolDetails } from "./bash-tools.exec-types.js";
 import { parseExecApprovalResultText } from "./exec-approval-result.js";
@@ -944,6 +945,13 @@ export async function handleToolExecutionEnd(
   const completedMutatingAction = !isToolError && Boolean(callSummary?.mutatingAction);
   const meta = callSummary?.meta;
   ctx.state.toolMetas.push({ toolName, meta });
+  const acceptedSessionSpawn =
+    toolName === "sessions_spawn" && !isToolError
+      ? normalizeAcceptedSessionSpawnResult(sanitizedResult)
+      : null;
+  if (acceptedSessionSpawn) {
+    ctx.state.acceptedSessionSpawns.push(acceptedSessionSpawn);
+  }
   ctx.state.toolMetaById.delete(toolCallId);
   ctx.state.toolSummaryById.delete(toolCallId);
   if (isToolError) {
@@ -977,7 +985,7 @@ export async function handleToolExecutionEnd(
       ctx.state.lastToolError = undefined;
     }
   }
-  if (completedMutatingAction) {
+  if (completedMutatingAction || acceptedSessionSpawn) {
     ctx.state.replayState = mergeEmbeddedRunReplayState(ctx.state.replayState, {
       replayInvalid: true,
       hadPotentialSideEffects: true,

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -5,6 +5,7 @@ import type { ReplyDirectiveParseResult } from "../auto-reply/reply/reply-direct
 import type { ReasoningLevel } from "../auto-reply/thinking.js";
 import type { InlineCodeState } from "../markdown/code-spans.js";
 import type { HookRunner } from "../plugins/hooks.js";
+import type { AcceptedSessionSpawn } from "./accepted-session-spawn.js";
 import type { EmbeddedBlockChunker } from "./pi-embedded-block-chunker.js";
 import type { MessagingToolSend } from "./pi-embedded-messaging.types.js";
 import type { BlockReplyPayload } from "./pi-embedded-payloads.js";
@@ -33,6 +34,7 @@ export type ToolCallSummary = {
 export type EmbeddedPiSubscribeState = {
   assistantTexts: string[];
   toolMetas: Array<{ toolName?: string; meta?: string }>;
+  acceptedSessionSpawns: AcceptedSessionSpawn[];
   toolMetaById: Map<string, ToolCallSummary>;
   toolSummaryById: Set<string>;
   execLiveUpdateStateById?: Map<string, { lastEmittedAtMs: number }>;
@@ -201,6 +203,7 @@ type ToolHandlerState = Pick<
   EmbeddedPiSubscribeState,
   | "toolMetaById"
   | "toolMetas"
+  | "acceptedSessionSpawns"
   | "toolSummaryById"
   | "execLiveUpdateStateById"
   | "itemActiveIds"

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
@@ -1175,4 +1175,47 @@ describe("subscribeEmbeddedPiSession", () => {
       replayInvalid: true,
     });
   });
+
+  it("preserves accepted session spawn terminal evidence across compaction retries", () => {
+    const { session, emit } = createStubSessionHarness();
+    const onAgentEvent = vi.fn();
+    const subscription = subscribeEmbeddedPiSession({
+      session,
+      runId: "run-spawn-side-effect-compaction",
+      onAgentEvent,
+      sessionKey: "test-session",
+    });
+
+    emitToolRun({
+      emit,
+      toolName: "sessions_spawn",
+      toolCallId: "spawn-1",
+      args: { prompt: "continue in a child session" },
+      isError: false,
+      result: {
+        details: {
+          status: "accepted",
+          runId: "run-child",
+          childSessionKey: "agent:claude:subagent:child",
+        },
+      },
+    });
+    emit({ type: "compaction_end", willRetry: true, result: { summary: "compacted" } });
+
+    expect(subscription.getAcceptedSessionSpawns()).toEqual([
+      {
+        runId: "run-child",
+        childSessionKey: "agent:claude:subagent:child",
+      },
+    ]);
+
+    emit({ type: "agent_end" });
+
+    const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
+    expectLifecyclePayload(payloads, {
+      phase: "end",
+      livenessState: "working",
+      replayInvalid: true,
+    });
+  });
 });

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -131,6 +131,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
   const state: EmbeddedPiSubscribeState = {
     assistantTexts: [],
     toolMetas: [],
+    acceptedSessionSpawns: [],
     toolMetaById: new Map(),
     toolSummaryById: new Set(),
     itemActiveIds: new Set(),
@@ -948,6 +949,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
         messagingToolSentTargets,
       }) ||
       state.successfulCronAdds > 0 ||
+      state.acceptedSessionSpawns.length > 0 ||
       state.visibleBlockReplyCount > 0;
     assistantTexts.length = 0;
     toolMetas.length = 0;
@@ -1061,6 +1063,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
   return {
     assistantTexts,
     toolMetas,
+    getAcceptedSessionSpawns: () => state.acceptedSessionSpawns.slice(),
     runToolLifecycle: async <T>(toolParams: {
       toolName: string;
       toolCallId: string;

--- a/src/agents/pi-tool-handler-state.test-helpers.ts
+++ b/src/agents/pi-tool-handler-state.test-helpers.ts
@@ -5,6 +5,7 @@ export function createBaseToolHandlerState() {
     replayState: createEmbeddedRunReplayState(),
     toolMetaById: new Map<string, unknown>(),
     toolMetas: [] as Array<{ toolName?: string; meta?: string }>,
+    acceptedSessionSpawns: [],
     toolSummaryById: new Set<string>(),
     itemActiveIds: new Set<string>(),
     itemStartedCount: 0,


### PR DESCRIPTION
## Summary

- Problem: pure-relay agents that successfully accepted a `sessions_spawn` child session could still be classified as an incomplete empty parent turn.
- Solution: carry a structured accepted-spawn fact from tool completion through the embedded runner and fallback/replay classifiers.
- What changed: valid accepted `sessions_spawn` results now require `status: "accepted"`, non-empty `runId`, and non-empty `childSessionKey`; that evidence suppresses only the false incomplete-turn path and prevents duplicate/replay fallback paths.
- CI drift fixed after rebasing to current `main`: two qa-lab Codex lifecycle fixtures are now optional Knip unused-file entries so the dependency shard matches the scenario-driven fixture contract.
- What did NOT change (scope boundary): failed/malformed spawns, parent prompt timeouts, messaging delivery errors, and unrelated tool side effects still use the existing safety/error paths.

## Motivation

- Fixes a real session-state false negative where the runtime accepted a child session but the parent run surfaced `Agent couldn't generate a response` anyway.

## Change Type (select all)

- [x] Bug fix
- [x] Refactor required for the fix
- [ ] Feature
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Fixes #72541
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior addressed: accepted `sessions_spawn` terminal success no longer trips incomplete-turn fallback, abandoned lifecycle state, replay/fallback retries, or duplicate child-session spawn paths.
- Real environment tested: OpenClaw QA Lab host runner on macOS Darwin 25.4.0, Node v24.14.0, pnpm 11.1.0, using `qa-channel` + qa-lab bus + real gateway child + `mock-openai` provider.
- Exact steps or command run after this patch:

```sh
pnpm openclaw qa suite --scenario runtime-tool-sessions-spawn --provider-mode mock-openai --transport qa-channel --concurrency 1 --output-dir .artifacts/real-proof/issue-72541-runtime-tool-sessions-spawn-rebased-final
pnpm openclaw qa suite --scenario subagent-handoff --provider-mode mock-openai --transport qa-channel --concurrency 1 --output-dir .artifacts/real-proof/issue-72541-subagent-handoff-rebased-final
```

- Evidence after fix:

```text
Runtime tool fixture - sessions_spawn
Status: pass
Passed: 1
Failed: 0
Details: sessions_spawn happy planned args and denied-input failure path were exercised through the QA channel.

Subagent handoff
Status: pass
Passed: 1
Failed: 0
Result: { "status": "accepted", "childSessionKey": "agent:qa:subagent:10b50ee2-860b-45e4-9a9b-1737a6b28d7a", "runId": "f4a2e737-0922-458d-bb44-98a4ad2c3d45", "mode": "run", "modelApplied": true }
Foldback result: The child result was folded back into the main thread exactly once.
```

- Observed result after fix: the real gateway/QA-channel path preserves the accepted child session result and reports it without producing `Agent couldn't generate a response` or re-running the spawn.
- What was not tested: live provider credentials, Discord thread-bound behavior, and the broader `subagent-completion-direct-fallback` QA path; that broader path was not used as final proof because a separate announce empty-response timeout was observed outside this patch's changed surface.
- Before evidence (optional but encouraged): issue #72541 documents the pre-fix false negative; regression tests now cover accepted spawn suppression and the parent-timeout edge case.

## Root Cause (if applicable)

- Root cause: the runtime produced an accepted child-session fact but dropped it before the incomplete-turn classifier, replay metadata, fallback classifier, and terminal trajectory checks could use it.
- Missing detection / guardrail: no structured accepted-spawn evidence existed on `EmbeddedRunAttemptResult` or final run results.
- Contributing context (if known): the classifier correctly avoided treating arbitrary successful tools as completion, but had no narrow contract for accepted `sessions_spawn`.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [x] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/pi-embedded-runner/run.incomplete-turn.test.ts`, `src/agents/pi-embedded-subscribe.handlers.tools.test.ts`, `src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts`, `src/agents/pi-embedded-runner/result-fallback-classifier.test.ts`, `src/agents/pi-embedded-runner/run/attempt-trajectory-status.test.ts`.
- Scenario the test should lock in: accepted `sessions_spawn` is terminal outbound progress, malformed/error spawns are not, replay/fallback retries are blocked after acceptance, and prompt timeout still returns timeout payload.
- Why this is the smallest reliable guardrail: it exercises the contract where the tool fact is produced and every runner classifier that previously lost it.
- Existing test that already covers this (if any): none before this PR.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Pure-relay subagent handoffs no longer show a false `Agent couldn't generate a response` message after a child session was accepted.

## Diagram (if applicable)

```text
Before:
sessions_spawn accepted -> accepted child fact dropped -> empty parent turn -> false incomplete-turn error / retry risk

After:
sessions_spawn accepted -> structured accepted-spawn evidence -> terminal success / replay blocked -> child result folded once
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS Darwin 25.4.0
- Runtime/container: local OpenClaw QA suite, Node v24.14.0, pnpm 11.1.0
- Model/provider: `mock-openai/gpt-5.5`
- Integration/channel (if any): `qa-channel` + qa-lab bus + real gateway child
- Relevant config (redacted): no secrets used

### Steps

1. Run the focused regression tests and type/format checks.
2. Run the two QA suite scenarios listed in Real behavior proof.
3. Confirm both QA reports show `Passed: 1`, `Failed: 0`.

### Expected

- Accepted `sessions_spawn` is preserved as terminal evidence.
- The parent does not synthesize the false incomplete-turn error.
- Prompt timeout after accepted spawn still returns a timeout payload.

### Actual

- Matches expected.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `codex review --commit HEAD` found no actionable regressions after fixes.
  - `node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run/attempt-trajectory-status.test.ts src/agents/pi-embedded-subscribe.handlers.tools.test.ts src/agents/pi-embedded-runner/run.incomplete-turn.test.ts src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts src/agents/pi-embedded-runner/result-fallback-classifier.test.ts --run` passed: 10 files, 425 tests.
  - `pnpm exec tsgo -p test/tsconfig/tsconfig.core.test.json --noEmit --pretty false` passed.
  - `pnpm exec oxfmt --check ...` passed on all touched files.
  - `git diff --check` passed.
  - `pnpm deadcode:dependencies`, `pnpm deadcode:unused-files`, and `pnpm deadcode:report:ci:ts-unused` passed after rebasing to current `upstream/main`.
  - `node scripts/run-vitest.mjs test/scripts/check-deadcode-unused-files.test.ts --run` passed: 1 file, 7 tests.
  - Both QA suite Real Proof commands passed.
- Edge cases checked: malformed accepted spawns, errored tool results, compaction retry preservation, replay invalidation, model fallback classification, terminal trajectory status, lifecycle abandonment, and timeout after accepted spawn.
- What you did **not** verify: live provider credentials, Discord thread-bound behavior, and broad full-suite/Testbox gates.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: accepting `sessions_spawn` as terminal evidence could hide unrelated timeout failures.
  - Mitigation: timeout guard remains tied to real messaging delivery, and a regression test proves parent prompt timeout still returns a timeout payload after accepted spawn.
