### PR TITLE
fix(memory-lancedb): expose public memory artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Memory/LanceDB: expose public memory artifacts through the active memory provider bridge so memory-wiki imports durable memory files, daily notes, dream reports, and event logs without depending on memory-core internals. Fixes #83604. (#85060) Thanks @brokemac79.
 - Agents: let embedded compaction fallback retries proceed when PI-compatible candidates do not need agent harness plugin preparation.
 - Agents/tools: honor configured custom provider API keys when deciding whether media, image-generation, video-generation, music-generation, and PDF tools are available. (#85570)
 - StepFun: stop advertising stale generic API key auth choices so onboarding only offers runtime-backed Standard and Step Plan choices.

--- a/extensions/memory-core/src/public-artifacts.ts
+++ b/extensions/memory-core/src/public-artifacts.ts
@@ -1,96 +1,11 @@
-import fs from "node:fs/promises";
-import path from "node:path";
-import { resolveMemoryDreamingWorkspaces } from "openclaw/plugin-sdk/memory-core-host-status";
-import type { MemoryPluginPublicArtifact } from "openclaw/plugin-sdk/memory-host-core";
-import { resolveMemoryHostEventLogPath } from "openclaw/plugin-sdk/memory-host-events";
-import { pathExists } from "openclaw/plugin-sdk/security-runtime";
+import {
+  listMemoryHostPublicArtifacts,
+  type MemoryPluginPublicArtifact,
+} from "openclaw/plugin-sdk/memory-host-core";
 import type { OpenClawConfig } from "../api.js";
-
-async function listMarkdownFilesRecursive(rootDir: string): Promise<string[]> {
-  const entries = await fs.readdir(rootDir, { withFileTypes: true }).catch(() => []);
-  const files: string[] = [];
-  for (const entry of entries) {
-    const fullPath = path.join(rootDir, entry.name);
-    if (entry.isDirectory()) {
-      files.push(...(await listMarkdownFilesRecursive(fullPath)));
-      continue;
-    }
-    if (entry.isFile() && entry.name.endsWith(".md")) {
-      files.push(fullPath);
-    }
-  }
-  return files.toSorted((left, right) => left.localeCompare(right));
-}
-
-async function collectWorkspaceArtifacts(params: {
-  workspaceDir: string;
-  agentIds: string[];
-}): Promise<MemoryPluginPublicArtifact[]> {
-  const artifacts: MemoryPluginPublicArtifact[] = [];
-  const workspaceEntries = new Set(
-    (await fs.readdir(params.workspaceDir, { withFileTypes: true }).catch(() => []))
-      .filter((entry) => entry.isFile())
-      .map((entry) => entry.name),
-  );
-  for (const relativePath of ["MEMORY.md"]) {
-    if (!workspaceEntries.has(relativePath)) {
-      continue;
-    }
-    const absolutePath = path.join(params.workspaceDir, relativePath);
-    artifacts.push({
-      kind: "memory-root",
-      workspaceDir: params.workspaceDir,
-      relativePath,
-      absolutePath,
-      agentIds: [...params.agentIds],
-      contentType: "markdown",
-    });
-  }
-
-  const memoryDir = path.join(params.workspaceDir, "memory");
-  for (const absolutePath of await listMarkdownFilesRecursive(memoryDir)) {
-    const relativePath = path.relative(params.workspaceDir, absolutePath).replace(/\\/g, "/");
-    artifacts.push({
-      kind: relativePath.startsWith("memory/dreaming/") ? "dream-report" : "daily-note",
-      workspaceDir: params.workspaceDir,
-      relativePath,
-      absolutePath,
-      agentIds: [...params.agentIds],
-      contentType: "markdown",
-    });
-  }
-
-  const eventLogPath = resolveMemoryHostEventLogPath(params.workspaceDir);
-  if (await pathExists(eventLogPath)) {
-    artifacts.push({
-      kind: "event-log",
-      workspaceDir: params.workspaceDir,
-      relativePath: path.relative(params.workspaceDir, eventLogPath).replace(/\\/g, "/"),
-      absolutePath: eventLogPath,
-      agentIds: [...params.agentIds],
-      contentType: "json",
-    });
-  }
-
-  const deduped = new Map<string, MemoryPluginPublicArtifact>();
-  for (const artifact of artifacts) {
-    deduped.set(`${artifact.workspaceDir}\0${artifact.relativePath}\0${artifact.kind}`, artifact);
-  }
-  return [...deduped.values()];
-}
 
 export async function listMemoryCorePublicArtifacts(params: {
   cfg: OpenClawConfig;
 }): Promise<MemoryPluginPublicArtifact[]> {
-  const workspaces = resolveMemoryDreamingWorkspaces(params.cfg);
-  const artifacts: MemoryPluginPublicArtifact[] = [];
-  for (const workspace of workspaces) {
-    artifacts.push(
-      ...(await collectWorkspaceArtifacts({
-        workspaceDir: workspace.workspaceDir,
-        agentIds: workspace.agentIds,
-      })),
-    );
-  }
-  return artifacts;
+  return await listMemoryHostPublicArtifacts(params);
 }

--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -9,7 +9,16 @@
  */
 
 import { Buffer } from "node:buffer";
-import { describe, test, expect, vi } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import {
+  clearMemoryPluginState,
+  getMemoryCapabilityRegistration,
+  listActiveMemoryPublicArtifacts,
+  registerMemoryCapability,
+  type MemoryPluginCapability,
+} from "openclaw/plugin-sdk/memory-host-core";
+import { afterEach, describe, test, expect, vi } from "vitest";
 import memoryPlugin, {
   detectCategory,
   formatRelevantMemoriesContext,
@@ -164,7 +173,11 @@ async function withMockedOpenAiMemoryPlugin<T>(params: {
 }
 
 describe("memory plugin e2e", () => {
-  const { getDbPath } = installTmpDirHarness({ prefix: "openclaw-memory-test-" });
+  const { getDbPath, getTmpDir } = installTmpDirHarness({ prefix: "openclaw-memory-test-" });
+
+  afterEach(() => {
+    clearMemoryPluginState();
+  });
 
   function parseConfig(overrides: Record<string, unknown> = {}) {
     return memoryPlugin.configSchema?.parse?.({
@@ -338,6 +351,165 @@ describe("memory plugin e2e", () => {
 
     expectHookRegistered(on, "before_prompt_build");
     expectHookNotRegistered(on, "before_agent_start");
+  });
+
+  test("registers memory public artifact provider for memory-wiki bridge parity", async () => {
+    const workspaceDir = path.join(getTmpDir(), "workspace-public-artifacts");
+    await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+    await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), "# Durable Memory\n", "utf8");
+    await fs.writeFile(path.join(workspaceDir, "memory", "2026-05-18.md"), "# Daily\n", "utf8");
+    const registerMemoryCapability = vi.fn();
+    const mockApi = {
+      id: "memory-lancedb",
+      name: "Memory (LanceDB)",
+      source: "test",
+      config: {},
+      pluginConfig: {
+        embedding: {
+          apiKey: OPENAI_API_KEY,
+          model: "text-embedding-3-small",
+        },
+        dbPath: getDbPath(),
+        autoCapture: false,
+        autoRecall: false,
+      },
+      runtime: {},
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+      registerMemoryCapability,
+      registerTool: vi.fn(),
+      registerCli: vi.fn(),
+      registerService: vi.fn(),
+      on: vi.fn(),
+      resolvePath: (filePath: string) => filePath,
+    };
+
+    memoryPlugin.register(mockApi as any);
+    const capability = firstObjectArg(
+      registerMemoryCapability as unknown as MockCallSource,
+      "memory capability",
+    );
+    const publicArtifacts = capability.publicArtifacts as
+      | { listArtifacts?: (params: { cfg: unknown }) => Promise<unknown> }
+      | undefined;
+    expect(publicArtifacts?.listArtifacts).toBeTypeOf("function");
+
+    await expect(
+      publicArtifacts?.listArtifacts?.({
+        cfg: {
+          agents: {
+            list: [{ id: "main", default: true, workspace: workspaceDir }],
+          },
+        },
+      }),
+    ).resolves.toEqual([
+      {
+        kind: "memory-root",
+        workspaceDir,
+        relativePath: "MEMORY.md",
+        absolutePath: path.join(workspaceDir, "MEMORY.md"),
+        agentIds: ["main"],
+        contentType: "markdown",
+      },
+      {
+        kind: "daily-note",
+        workspaceDir,
+        relativePath: "memory/2026-05-18.md",
+        absolutePath: path.join(workspaceDir, "memory", "2026-05-18.md"),
+        agentIds: ["main"],
+        contentType: "markdown",
+      },
+    ]);
+  });
+
+  test("preserves memory-core sidecar capability when registering public artifacts", async () => {
+    const workspaceDir = path.join(getTmpDir(), "workspace-sidecar-public-artifacts");
+    await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+    await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), "# Durable Memory\n", "utf8");
+    await fs.writeFile(path.join(workspaceDir, "memory", "2026-05-18.md"), "# Daily\n", "utf8");
+    const runtime = {
+      async getMemorySearchManager() {
+        return { manager: null, error: "test" };
+      },
+      resolveMemoryBackendConfig() {
+        return { backend: "builtin" as const };
+      },
+    };
+    const flushPlanResolver = vi.fn(() => ({
+      softThresholdTokens: 1,
+      forceFlushTranscriptBytes: 2,
+      reserveTokensFloor: 3,
+      prompt: "flush",
+      systemPrompt: "flush",
+      relativePath: "memory/sidecar.md",
+    }));
+    registerMemoryCapability("memory-core", {
+      flushPlanResolver,
+      runtime,
+    });
+    const registerMemoryCapabilityForPlugin = vi.fn((capability: MemoryPluginCapability) => {
+      registerMemoryCapability("memory-lancedb", capability);
+    });
+    const mockApi = {
+      id: "memory-lancedb",
+      name: "Memory (LanceDB)",
+      source: "test",
+      config: {},
+      pluginConfig: {
+        embedding: {
+          apiKey: OPENAI_API_KEY,
+          model: "text-embedding-3-small",
+        },
+        dbPath: getDbPath(),
+        autoCapture: false,
+        autoRecall: false,
+      },
+      runtime: {},
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+      registerMemoryCapability: registerMemoryCapabilityForPlugin,
+      registerTool: vi.fn(),
+      registerCli: vi.fn(),
+      registerService: vi.fn(),
+      on: vi.fn(),
+      resolvePath: (filePath: string) => filePath,
+    };
+
+    memoryPlugin.register(mockApi as any);
+
+    expect(registerMemoryCapabilityForPlugin).toHaveBeenCalledOnce();
+    expect(
+      getMemoryCapabilityRegistration()?.capability.flushPlanResolver?.({})?.relativePath,
+    ).toBe("memory/sidecar.md");
+    expect(getMemoryCapabilityRegistration()?.capability.runtime).toBe(runtime);
+    await expect(
+      listActiveMemoryPublicArtifacts({
+        cfg: {
+          agents: {
+            list: [{ id: "main", default: true, workspace: workspaceDir }],
+          },
+        },
+      }),
+    ).resolves.toMatchObject([
+      {
+        kind: "memory-root",
+        workspaceDir,
+        relativePath: "MEMORY.md",
+      },
+      {
+        kind: "daily-note",
+        workspaceDir,
+        relativePath: "memory/2026-05-18.md",
+      },
+    ]);
   });
 
   test("uses provider adapter auth when embedding apiKey is omitted", async () => {

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -11,7 +11,6 @@ import { randomUUID } from "node:crypto";
 import type * as LanceDB from "@lancedb/lancedb";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { MemoryEmbeddingProvider } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
-import { getMemoryCapabilityRegistration } from "openclaw/plugin-sdk/memory-host-core";
 import { resolveLivePluginConfigObject } from "openclaw/plugin-sdk/plugin-config-runtime";
 import { ensureGlobalUndiciEnvProxyDispatcher } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -695,9 +694,7 @@ export default definePluginEntry({
     };
 
     api.logger.info(`memory-lancedb: plugin registered (db: ${resolvedDbPath}, lazy init)`);
-    const existingMemoryCapability = getMemoryCapabilityRegistration()?.capability;
     api.registerMemoryCapability?.({
-      ...existingMemoryCapability,
       publicArtifacts: {
         async listArtifacts(params) {
           const { listMemoryHostPublicArtifacts } = await loadMemoryHostCoreModule();

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -11,6 +11,7 @@ import { randomUUID } from "node:crypto";
 import type * as LanceDB from "@lancedb/lancedb";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { MemoryEmbeddingProvider } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
+import { getMemoryCapabilityRegistration } from "openclaw/plugin-sdk/memory-host-core";
 import { resolveLivePluginConfigObject } from "openclaw/plugin-sdk/plugin-config-runtime";
 import { ensureGlobalUndiciEnvProxyDispatcher } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -694,6 +695,16 @@ export default definePluginEntry({
     };
 
     api.logger.info(`memory-lancedb: plugin registered (db: ${resolvedDbPath}, lazy init)`);
+    const existingMemoryCapability = getMemoryCapabilityRegistration()?.capability;
+    api.registerMemoryCapability?.({
+      ...existingMemoryCapability,
+      publicArtifacts: {
+        async listArtifacts(params) {
+          const { listMemoryHostPublicArtifacts } = await loadMemoryHostCoreModule();
+          return await listMemoryHostPublicArtifacts(params);
+        },
+      },
+    });
 
     // ========================================================================
     // Tools

--- a/src/plugin-sdk/memory-host-core.test.ts
+++ b/src/plugin-sdk/memory-host-core.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   clearMemoryPluginState,
@@ -7,8 +10,10 @@ import {
 import * as memoryCoreAlias from "./memory-core.js";
 import {
   buildActiveMemoryPromptSection,
+  listMemoryHostPublicArtifacts,
   listActiveMemoryPublicArtifacts,
 } from "./memory-host-core.js";
+import { appendMemoryHostEvent, resolveMemoryHostEventLogPath } from "./memory-host-events.js";
 
 describe("memory-host-core helpers", () => {
   afterEach(() => {
@@ -58,6 +63,77 @@ describe("memory-host-core helpers", () => {
         contentType: "markdown",
       },
     ]);
+  });
+
+  it("lists shared public artifacts from memory workspaces", async () => {
+    const fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "memory-host-public-artifacts-"));
+    try {
+      const workspaceDir = path.join(fixtureRoot, "workspace");
+      await fs.mkdir(path.join(workspaceDir, "memory", "dreaming"), { recursive: true });
+      await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), "# Durable Memory\n", "utf8");
+      await fs.writeFile(
+        path.join(workspaceDir, "memory", "2026-05-18.md"),
+        "# Daily Note\n",
+        "utf8",
+      );
+      await fs.writeFile(
+        path.join(workspaceDir, "memory", "dreaming", "2026-05-18.md"),
+        "# Dream Report\n",
+        "utf8",
+      );
+      await appendMemoryHostEvent(workspaceDir, {
+        type: "memory.recall.recorded",
+        timestamp: "2026-05-18T12:00:00.000Z",
+        query: "bridge",
+        resultCount: 0,
+        results: [],
+      });
+
+      await expect(
+        listMemoryHostPublicArtifacts({
+          cfg: {
+            agents: {
+              list: [{ id: "main", default: true, workspace: workspaceDir }],
+            },
+          },
+        }),
+      ).resolves.toEqual([
+        {
+          kind: "memory-root",
+          workspaceDir,
+          relativePath: "MEMORY.md",
+          absolutePath: path.join(workspaceDir, "MEMORY.md"),
+          agentIds: ["main"],
+          contentType: "markdown",
+        },
+        {
+          kind: "daily-note",
+          workspaceDir,
+          relativePath: "memory/2026-05-18.md",
+          absolutePath: path.join(workspaceDir, "memory", "2026-05-18.md"),
+          agentIds: ["main"],
+          contentType: "markdown",
+        },
+        {
+          kind: "dream-report",
+          workspaceDir,
+          relativePath: "memory/dreaming/2026-05-18.md",
+          absolutePath: path.join(workspaceDir, "memory", "dreaming", "2026-05-18.md"),
+          agentIds: ["main"],
+          contentType: "markdown",
+        },
+        {
+          kind: "event-log",
+          workspaceDir,
+          relativePath: "memory/.dreams/events.jsonl",
+          absolutePath: resolveMemoryHostEventLogPath(workspaceDir),
+          agentIds: ["main"],
+          contentType: "json",
+        },
+      ]);
+    } finally {
+      await fs.rm(fixtureRoot, { recursive: true, force: true });
+    }
   });
 
   it("keeps the deprecated memory-core alias wired to memory-host-core", () => {

--- a/src/plugin-sdk/memory-host-core.ts
+++ b/src/plugin-sdk/memory-host-core.ts
@@ -1,1 +1,104 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { OpenClawConfig } from "../config/config.js";
+import type { MemoryPluginPublicArtifact } from "../plugins/memory-state.js";
+import { resolveMemoryDreamingWorkspaces } from "./memory-core-host-status.js";
+import { resolveMemoryHostEventLogPath } from "./memory-host-events.js";
+
 export * from "./memory-core-host-runtime-core.js";
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function listMarkdownFilesRecursive(rootDir: string): Promise<string[]> {
+  const entries = await fs.readdir(rootDir, { withFileTypes: true }).catch(() => []);
+  const files: string[] = [];
+  for (const entry of entries) {
+    const fullPath = path.join(rootDir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await listMarkdownFilesRecursive(fullPath)));
+      continue;
+    }
+    if (entry.isFile() && entry.name.endsWith(".md")) {
+      files.push(fullPath);
+    }
+  }
+  return files.toSorted((left, right) => left.localeCompare(right));
+}
+
+export async function listMemoryWorkspacePublicArtifacts(params: {
+  workspaceDir: string;
+  agentIds: string[];
+}): Promise<MemoryPluginPublicArtifact[]> {
+  const artifacts: MemoryPluginPublicArtifact[] = [];
+  const workspaceEntries = new Set(
+    (await fs.readdir(params.workspaceDir, { withFileTypes: true }).catch(() => []))
+      .filter((entry) => entry.isFile())
+      .map((entry) => entry.name),
+  );
+
+  if (workspaceEntries.has("MEMORY.md")) {
+    const absolutePath = path.join(params.workspaceDir, "MEMORY.md");
+    artifacts.push({
+      kind: "memory-root",
+      workspaceDir: params.workspaceDir,
+      relativePath: "MEMORY.md",
+      absolutePath,
+      agentIds: [...params.agentIds],
+      contentType: "markdown",
+    });
+  }
+
+  const memoryDir = path.join(params.workspaceDir, "memory");
+  for (const absolutePath of await listMarkdownFilesRecursive(memoryDir)) {
+    const relativePath = path.relative(params.workspaceDir, absolutePath).replace(/\\/g, "/");
+    artifacts.push({
+      kind: relativePath.startsWith("memory/dreaming/") ? "dream-report" : "daily-note",
+      workspaceDir: params.workspaceDir,
+      relativePath,
+      absolutePath,
+      agentIds: [...params.agentIds],
+      contentType: "markdown",
+    });
+  }
+
+  const eventLogPath = resolveMemoryHostEventLogPath(params.workspaceDir);
+  if (await pathExists(eventLogPath)) {
+    artifacts.push({
+      kind: "event-log",
+      workspaceDir: params.workspaceDir,
+      relativePath: path.relative(params.workspaceDir, eventLogPath).replace(/\\/g, "/"),
+      absolutePath: eventLogPath,
+      agentIds: [...params.agentIds],
+      contentType: "json",
+    });
+  }
+
+  const deduped = new Map<string, MemoryPluginPublicArtifact>();
+  for (const artifact of artifacts) {
+    deduped.set(`${artifact.workspaceDir}\0${artifact.relativePath}\0${artifact.kind}`, artifact);
+  }
+  return [...deduped.values()];
+}
+
+export async function listMemoryHostPublicArtifacts(params: {
+  cfg: OpenClawConfig;
+}): Promise<MemoryPluginPublicArtifact[]> {
+  const workspaces = resolveMemoryDreamingWorkspaces(params.cfg);
+  const artifacts: MemoryPluginPublicArtifact[] = [];
+  for (const workspace of workspaces) {
+    artifacts.push(
+      ...(await listMemoryWorkspacePublicArtifacts({
+        workspaceDir: workspace.workspaceDir,
+        agentIds: workspace.agentIds,
+      })),
+    );
+  }
+  return artifacts;
+}

--- a/src/plugins/memory-state.test.ts
+++ b/src/plugins/memory-state.test.ts
@@ -204,6 +204,46 @@ describe("memory plugin state", () => {
     ]);
   });
 
+  it("preserves sidecar runtime fields when a memory plugin adds public artifacts only", async () => {
+    const runtime = createMemoryRuntime();
+    const flushPlanResolver = () => createMemoryFlushPlan("memory/sidecar.md");
+
+    registerMemoryCapability("memory-core", {
+      flushPlanResolver,
+      runtime,
+    });
+    registerMemoryCapability("memory-lancedb", {
+      publicArtifacts: {
+        async listArtifacts() {
+          return [
+            {
+              kind: "memory-root",
+              workspaceDir: "/tmp/workspace",
+              relativePath: "MEMORY.md",
+              absolutePath: "/tmp/workspace/MEMORY.md",
+              agentIds: ["main"],
+              contentType: "markdown" as const,
+            },
+          ];
+        },
+      },
+    });
+
+    expect(resolveMemoryFlushPlan({})?.relativePath).toBe("memory/sidecar.md");
+    expect(getMemoryRuntime()).toBe(runtime);
+    expect(getMemoryCapabilityRegistration()?.pluginId).toBe("memory-lancedb");
+    await expect(listActiveMemoryPublicArtifacts({ cfg: {} as never })).resolves.toEqual([
+      {
+        kind: "memory-root",
+        workspaceDir: "/tmp/workspace",
+        relativePath: "MEMORY.md",
+        absolutePath: "/tmp/workspace/MEMORY.md",
+        agentIds: ["main"],
+        contentType: "markdown",
+      },
+    ]);
+  });
+
   it("passes citations mode through to the prompt builder", () => {
     registerMemoryPromptSection(({ citationsMode }) => [
       `citations: ${citationsMode ?? "default"}`,

--- a/src/plugins/memory-state.ts
+++ b/src/plugins/memory-state.ts
@@ -166,7 +166,21 @@ export function registerMemoryCapability(
   pluginId: string,
   capability: MemoryPluginCapability,
 ): void {
-  memoryPluginState.capability = { pluginId, capability: { ...capability } };
+  const existingCapability = memoryPluginState.capability?.capability;
+  // A selected memory plugin can add bridge artifacts while memory-core owns sidecar runtime hooks.
+  const shouldPreserveExisting =
+    existingCapability &&
+    Boolean(capability.publicArtifacts) &&
+    !capability.promptBuilder &&
+    !capability.flushPlanResolver &&
+    !capability.runtime;
+  memoryPluginState.capability = {
+    pluginId,
+    capability: {
+      ...(shouldPreserveExisting ? existingCapability : {}),
+      ...capability,
+    },
+  };
 }
 
 function patchMemoryCapability(pluginId: string, patch: MemoryPluginCapability): void {


### PR DESCRIPTION
## Summary

Fixes https://github.com/openclaw/openclaw/issues/83604.

This adds `publicArtifacts.listArtifacts` support to bundled `@openclaw/memory-lancedb`, using a shared memory-host artifact helper instead of importing `memory-core` internals. `memory-core` now delegates to the same helper so the bundled memory providers stay in parity for `MEMORY.md`, daily notes, dream reports, and event-log artifacts.

Follow-up to ClawSweeper's lazy-loading finding: `memory-lancedb` no longer statically imports `openclaw/plugin-sdk/memory-host-core`; it keeps the existing cached dynamic loader. Preservation of existing `memory-core` sidecar flush/runtime hooks now lives in `src/plugins/memory-state.ts`, where memory capability registration ownership already belongs.

## Real behavior proof

Behavior addressed: With `memory-lancedb` selected as the active memory provider, `memory-wiki` should be able to import public memory artifacts from the active provider bridge without depending on `memory-core` internals, while the existing `memory-core` sidecar runtime/flush hooks stay available.

Real environment tested: Disposable local OpenClaw runtime on the Windows desktop checkout after this patch, using the real plugin loader (`loadOpenClawPlugins`) and real bridge importer (`syncMemoryWikiImportedSources`). The script created a temporary OpenClaw home/config/workspace under `%TEMP%/openclaw-pr-85060-proof-*` and removed it after the run.

Exact steps or command run after this patch: Ran a `node --import tsx --input-type=module` proof script that created `MEMORY.md`, a daily note, and a dream report; loaded `memory-core`, `memory-lancedb`, and `memory-wiki`; selected `memory-lancedb` as the memory slot; then ran `syncMemoryWikiImportedSources` twice against the temporary workspace.

Evidence after fix:

```json
{
  "activeMemoryCapabilityPlugin": "memory-lancedb",
  "preservedSidecarRuntime": true,
  "hasPublicArtifactsProvider": true,
  "firstImport": {
    "importedCount": 3,
    "artifactCount": 3,
    "workspaces": 1,
    "pagePaths": [
      "sources/bridge-.../MEMORY.md",
      "sources/bridge-.../memory/daily/2026-05-21.md",
      "sources/bridge-.../memory/dreaming/report.md"
    ]
  },
  "secondImport": {
    "importedCount": 0,
    "skippedCount": 3,
    "artifactCount": 3
  },
  "sourceFileCount": 3,
  "sourceSamples": [
    { "hasMemoryBridgeFrontmatter": true },
    { "hasMemoryBridgeFrontmatter": true },
    { "hasMemoryBridgeFrontmatter": true }
  ]
}
```

Observed result after fix: The active memory capability was `memory-lancedb`; the sidecar runtime was still present; the first wiki sync imported exactly three bridge artifacts from the live public-artifacts provider; the second sync was idempotent and skipped the same three artifacts; and the generated source markdown files all included memory bridge frontmatter.

What was not tested: This proof used a disposable local OpenClaw home rather than the user's live production profile, so it did not mutate any real memory database, live workspace, or VPS state.

## Verification

Environment: local Windows desktop worktree, Node 24.13.0, pnpm 11.1.0.

Commands run:

```bash
pnpm install --frozen-lockfile --prefer-offline
node scripts/run-vitest.mjs extensions/memory-lancedb/index.test.ts src/plugin-sdk/memory-host-core.test.ts extensions/memory-core/src/public-artifacts.test.ts src/plugins/memory-state.test.ts
node scripts/run-vitest.mjs extensions/memory-wiki/src/bridge.test.ts -t "imports public memory artifacts"
pnpm exec oxfmt --check src/plugins/memory-state.ts src/plugins/memory-state.test.ts src/plugin-sdk/memory-host-core.ts src/plugin-sdk/memory-host-core.test.ts extensions/memory-core/src/public-artifacts.ts extensions/memory-lancedb/index.ts extensions/memory-lancedb/index.test.ts
pnpm exec oxlint src/plugins/memory-state.ts src/plugins/memory-state.test.ts src/plugin-sdk/memory-host-core.ts src/plugin-sdk/memory-host-core.test.ts extensions/memory-core/src/public-artifacts.ts extensions/memory-lancedb/index.ts extensions/memory-lancedb/index.test.ts
git diff --check
node scripts/check-dynamic-import-warts.mjs
codex review --uncommitted
```

Results:

- Focused suite: 4 files passed, 66 tests passed.
- Direct bridge import behavior: 1 test passed, 9 skipped.
- Formatting, lint, whitespace, and focused dynamic-import review passed for the changed files. `check-dynamic-import-warts` still reports existing advisory-only repo findings, but no longer reports this PR's `memory-lancedb` static + dynamic `memory-host-core` pattern.
- Codex review reported no actionable correctness issues in the changed memory capability registration path or LanceDB public artifact registration.

Caveat: the full `extensions/memory-wiki/src/bridge.test.ts` suite was not used as local proof on Windows because unrelated Windows/environment-sensitive tests fail there: one symlink `EPERM` case and two path-safety label expectations returning `invalid-path` instead of the Unix-oriented labels. The targeted bridge import test named above passes and covers this issue's bridge path.

## Duplicate scan

Before coding and again immediately before opening this PR, `gh pr list --repo openclaw/openclaw --state open --search "83604 in:title,body"` returned no competing open PRs.