### PR TITLE
enhance(slack): deliver native plugin approvals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Docs: https://docs.openclaw.ai
 - Trajectory/support: tolerate partial skill snapshot entries when building support metadata so rejected skill path scans no longer abort trajectory capture. (#71185) Thanks @lukeboyett.
 - Telegram: honor `channels.telegram.pollingStallThresholdMs` in the default isolated polling path, restarting silent workers instead of leaving inbound updates wedged. Fixes #83950. (#84861) Thanks @joshavant.
 - Slack: suppress reasoning payloads before reply delivery and dispatch accounting, so Slack monitor, slash-command, fallback, and direct reply paths do not leak model reasoning. Fixes #84319. (#84322) Thanks @ffluk3 and @joshavant.
+- Slack: deliver native plugin approval prompts and updates when Slack native approvals are enabled, while keeping plugin approval authorization separate from exec approvers.
 - Agents/Pi: disable the embedded pi-coding-agent runtime auto-retry so OpenClaw's own retry and failover loop does not replay failed tool calls through a nested SDK retry. Fixes #73781. (#74434) Thanks @yelog.
 - CLI/perf: keep `setup --help`, `onboard --help`, and `configure --help` out of the full wizard runtime while preserving the existing help output. (#84488) Thanks @frankekn.
 - CLI/perf: keep `agents --help` out of agents action/runtime imports so help, completion, and command discovery paths avoid loading the full agents runtime. (#84483) Thanks @frankekn.

--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -1288,13 +1288,15 @@ compact, redacted `Slack interaction: ...` system event. If the handler returns
 fields are included in that compact event so the agent can reference
 plugin-owned storage without seeing the complete form payload.
 
-## Exec approvals in Slack
+## Native approvals in Slack
 
 Slack can act as a native approval client with interactive buttons and interactions, instead of falling back to the Web UI or terminal.
 
-- Exec approvals use `channels.slack.execApprovals.*` for native DM/channel routing.
-- Plugin approvals can still resolve through the same Slack-native button surface when the request already lands in Slack and the approval id kind is `plugin:`.
-- Approver authorization is still enforced: only users identified as approvers can approve or deny requests through Slack.
+- Exec and plugin approvals can render as Slack-native Block Kit prompts.
+- `channels.slack.execApprovals.*` remains the native approval client enablement and DM/channel routing config.
+- Exec approval DMs use `channels.slack.execApprovals.approvers` or `commands.ownerAllowFrom`.
+- Plugin approval DMs use Slack plugin approvers from `channels.slack.allowFrom`, named-account `allowFrom`, or the account default route.
+- Approver authorization is still enforced: exec-only approvers cannot approve plugin requests unless they are also plugin approvers.
 
 This uses the same shared approval button surface as other channels. When `interactivity` is enabled in your Slack app settings, approval prompts render as Block Kit buttons directly in the conversation.
 When those buttons are present, they are the primary approval UX; OpenClaw
@@ -1341,8 +1343,8 @@ opt into origin-chat delivery:
 
 Shared `approvals.exec` forwarding is separate. Use it only when exec approval prompts must also
 route to other chats or explicit out-of-band targets. Shared `approvals.plugin` forwarding is also
-separate; Slack-native buttons can still resolve plugin approvals when those requests already land
-in Slack.
+separate; Slack native delivery suppresses that fallback only when Slack can handle the plugin
+approval request natively.
 
 Same-chat `/approve` also works in Slack channels and DMs that already support commands. See [Exec approvals](/tools/exec-approvals) for the full approval forwarding model.
 

--- a/docs/tools/exec-approvals-advanced.md
+++ b/docs/tools/exec-approvals-advanced.md
@@ -304,9 +304,12 @@ Shared behavior:
 - for Discord and Telegram, only resolved approvers can approve or deny
 - Discord approvers can be explicit (`execApprovals.approvers`) or inferred from `commands.ownerAllowFrom`
 - Telegram approvers can be explicit (`execApprovals.approvers`) or inferred from `commands.ownerAllowFrom`
-- Slack approvers can be explicit (`execApprovals.approvers`) or inferred from `commands.ownerAllowFrom`
-- Slack native buttons preserve approval id kind, so `plugin:` ids can resolve plugin approvals
-  without a second Slack-local fallback layer
+- Slack exec approvers can be explicit (`execApprovals.approvers`) or inferred from `commands.ownerAllowFrom`
+- Slack native approval delivery handles both exec and plugin approval events; `execApprovals.*`
+  remains the native client enablement and target config, while plugin approval DMs use Slack
+  plugin approvers from `allowFrom` / account defaults instead of `execApprovals.approvers`
+- Slack native buttons preserve approval id kind, so `plugin:` ids resolve plugin approvals
+  with the plugin approval decision set and without a second Slack-local fallback layer
 - Matrix native DM/channel routing and reaction shortcuts handle both exec and plugin approvals;
   plugin authorization still comes from `channels.matrix.dm.allowFrom`
 - Matrix native prompts include `com.openclaw.approval` custom event content on the first prompt

--- a/docs/tools/exec-approvals-advanced.md
+++ b/docs/tools/exec-approvals-advanced.md
@@ -304,12 +304,9 @@ Shared behavior:
 - for Discord and Telegram, only resolved approvers can approve or deny
 - Discord approvers can be explicit (`execApprovals.approvers`) or inferred from `commands.ownerAllowFrom`
 - Telegram approvers can be explicit (`execApprovals.approvers`) or inferred from `commands.ownerAllowFrom`
-- Slack exec approvers can be explicit (`execApprovals.approvers`) or inferred from `commands.ownerAllowFrom`
-- Slack native approval delivery handles both exec and plugin approval events; `execApprovals.*`
-  remains the native client enablement and target config, while plugin approval DMs use Slack
-  plugin approvers from `allowFrom` / account defaults instead of `execApprovals.approvers`
-- Slack native buttons preserve approval id kind, so `plugin:` ids resolve plugin approvals
-  with the plugin approval decision set and without a second Slack-local fallback layer
+- Slack approvers can be explicit (`execApprovals.approvers`) or inferred from `commands.ownerAllowFrom`
+- Slack native buttons preserve approval id kind, so `plugin:` ids can resolve plugin approvals
+  without a second Slack-local fallback layer
 - Matrix native DM/channel routing and reaction shortcuts handle both exec and plugin approvals;
   plugin authorization still comes from `channels.matrix.dm.allowFrom`
 - Matrix native prompts include `com.openclaw.approval` custom event content on the first prompt

--- a/extensions/slack/src/approval-auth.ts
+++ b/extensions/slack/src/approval-auth.ts
@@ -6,7 +6,7 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { resolveSlackAccount, resolveSlackAccountAllowFrom } from "./accounts.js";
 import { normalizeSlackApproverId } from "./exec-approvals.js";
 
-function getSlackApprovalApprovers(params: {
+export function getSlackApprovalApprovers(params: {
   cfg: OpenClawConfig;
   accountId?: string | null;
 }): string[] {

--- a/extensions/slack/src/approval-handler.runtime.test.ts
+++ b/extensions/slack/src/approval-handler.runtime.test.ts
@@ -33,6 +33,10 @@ function readChatUpdatePayload(
 }
 
 describe("slackApprovalNativeRuntime", () => {
+  it("subscribes to plugin approval events", () => {
+    expect(slackApprovalNativeRuntime.eventKinds).toEqual(["exec", "plugin"]);
+  });
+
   it("renders only the allowed pending actions", async () => {
     const payload = (await slackApprovalNativeRuntime.presentation.buildPendingPayload({
       cfg: {} as never,
@@ -89,6 +93,75 @@ describe("slackApprovalNativeRuntime", () => {
     expect(JSON.stringify(payload.blocks)).not.toContain("Allow Always");
   });
 
+  it("renders plugin pending approvals with plugin approval actions", async () => {
+    const payload = (await slackApprovalNativeRuntime.presentation.buildPendingPayload({
+      cfg: {} as never,
+      accountId: "default",
+      context: {
+        app: {} as never,
+        config: {} as never,
+      },
+      request: {
+        id: "plugin:req-1",
+        request: {
+          title: "Share screen with Computer Use",
+          description: "Computer Use wants to inspect the desktop.",
+        },
+        createdAtMs: 0,
+        expiresAtMs: 60_000,
+      },
+      approvalKind: "plugin",
+      nowMs: 0,
+      view: {
+        approvalKind: "plugin",
+        phase: "pending",
+        approvalId: "plugin:req-1",
+        title: "Share screen with Computer Use",
+        description: "Computer Use wants to inspect the desktop.",
+        severity: "warning",
+        pluginId: "computer-use",
+        toolName: "screenshot",
+        metadata: [
+          { label: "Severity", value: "Warning" },
+          { label: "Plugin", value: "computer-use" },
+        ],
+        actions: [
+          {
+            decision: "allow-once",
+            label: "Allow Once",
+            command: "/approve plugin:req-1 allow-once",
+            style: "success",
+          },
+          {
+            decision: "deny",
+            label: "Deny",
+            command: "/approve plugin:req-1 deny",
+            style: "danger",
+          },
+        ],
+        expiresAtMs: 60_000,
+      },
+    })) as SlackPayload;
+
+    expect(payload.text).toContain("*Plugin approval required*");
+    expect(payload.text).toContain("Share screen with Computer Use");
+    expect(payload.text).toContain("*Approval ID:* plugin:req-1");
+    expect(payload.text).not.toContain("*Command*");
+    const actionsBlock = findSlackActionsBlock(
+      payload.blocks as Array<{ type?: string; elements?: unknown[] }>,
+    );
+    const labels = (actionsBlock?.elements ?? []).map((element) =>
+      typeof element === "object" &&
+      element &&
+      typeof (element as { text?: { text?: unknown } }).text?.text === "string"
+        ? (element as { text: { text: string } }).text.text
+        : "",
+    );
+
+    expect(labels).toEqual(["Allow Once", "Deny"]);
+    expect(JSON.stringify(payload.blocks)).toContain("plugin:req-1");
+  });
+
   it("renders resolved updates without interactive blocks", async () => {
     const result = await slackApprovalNativeRuntime.presentation.buildResolvedResult({
       cfg: {} as never,
@@ -133,6 +206,101 @@ describe("slackApprovalNativeRuntime", () => {
     expect(payload.text).toContain("Resolved by <@U123APPROVER>.");
     expect(
       (payload.blocks as Array<{ type?: string }>).some((block) => block.type === "actions"),
+    ).toBe(false);
+  });
+
+  it("renders plugin resolved and expired updates without command text", async () => {
+    const resolved = await slackApprovalNativeRuntime.presentation.buildResolvedResult({
+      cfg: {} as never,
+      accountId: "default",
+      context: {
+        app: {} as never,
+        config: {} as never,
+      },
+      request: {
+        id: "plugin:req-1",
+        request: {
+          title: "Share screen with Computer Use",
+          description: "Computer Use wants to inspect the desktop.",
+        },
+        createdAtMs: 0,
+        expiresAtMs: 60_000,
+      },
+      resolved: {
+        id: "plugin:req-1",
+        decision: "allow-once",
+        resolvedBy: "U123APPROVER",
+        ts: 0,
+      } as never,
+      view: {
+        approvalKind: "plugin",
+        phase: "resolved",
+        approvalId: "plugin:req-1",
+        title: "Share screen with Computer Use",
+        description: "Computer Use wants to inspect the desktop.",
+        severity: "warning",
+        pluginId: "computer-use",
+        toolName: "screenshot",
+        metadata: [{ label: "Plugin", value: "computer-use" }],
+        decision: "allow-once",
+        resolvedBy: "U123APPROVER",
+      },
+      entry: {
+        channelId: "D123APPROVER",
+        messageTs: "1712345678.999999",
+      },
+    });
+    const expired = await slackApprovalNativeRuntime.presentation.buildExpiredResult({
+      cfg: {} as never,
+      accountId: "default",
+      context: {
+        app: {} as never,
+        config: {} as never,
+      },
+      request: {
+        id: "plugin:req-1",
+        request: {
+          title: "Share screen with Computer Use",
+          description: "Computer Use wants to inspect the desktop.",
+        },
+        createdAtMs: 0,
+        expiresAtMs: 60_000,
+      },
+      view: {
+        approvalKind: "plugin",
+        phase: "expired",
+        approvalId: "plugin:req-1",
+        title: "Share screen with Computer Use",
+        description: "Computer Use wants to inspect the desktop.",
+        severity: "warning",
+        pluginId: "computer-use",
+        toolName: "screenshot",
+        metadata: [{ label: "Plugin", value: "computer-use" }],
+      },
+      entry: {
+        channelId: "D123APPROVER",
+        messageTs: "1712345678.999999",
+      },
+    });
+
+    expect(resolved.kind).toBe("update");
+    expect(expired.kind).toBe("update");
+    if (resolved.kind !== "update" || expired.kind !== "update") {
+      throw new Error("expected Slack update payloads");
+    }
+    const resolvedPayload = resolved.payload as SlackPayload;
+    const expiredPayload = expired.payload as SlackPayload;
+    expect(resolvedPayload.text).toContain("*Plugin approval: Allowed once*");
+    expect(resolvedPayload.text).toContain("Resolved by <@U123APPROVER>.");
+    expect(resolvedPayload.text).toContain("Share screen with Computer Use");
+    expect(resolvedPayload.text).not.toContain("*Command*");
+    expect(expiredPayload.text).toContain("*Plugin approval expired*");
+    expect(expiredPayload.text).toContain("Share screen with Computer Use");
+    expect(expiredPayload.text).not.toContain("*Command*");
+    expect(
+      (resolvedPayload.blocks as Array<{ type?: string }>).some(
+        (block) => block.type === "actions",
+      ),
     ).toBe(false);
   });
 

--- a/extensions/slack/src/approval-handler.runtime.test.ts
+++ b/extensions/slack/src/approval-handler.runtime.test.ts
@@ -133,6 +133,12 @@ describe("slackApprovalNativeRuntime", () => {
             style: "success",
           },
           {
+            decision: "allow-always",
+            label: "Allow Always",
+            command: "/approve plugin:req-1 allow-always",
+            style: "success",
+          },
+          {
             decision: "deny",
             label: "Deny",
             command: "/approve plugin:req-1 deny",
@@ -158,7 +164,7 @@ describe("slackApprovalNativeRuntime", () => {
         : "",
     );
 
-    expect(labels).toEqual(["Allow Once", "Deny"]);
+    expect(labels).toEqual(["Allow Once", "Allow Always", "Deny"]);
     expect(JSON.stringify(payload.blocks)).toContain("plugin:req-1");
   });
 

--- a/extensions/slack/src/approval-handler.runtime.ts
+++ b/extensions/slack/src/approval-handler.runtime.ts
@@ -5,19 +5,25 @@ import type {
   ExecApprovalExpiredView,
   ExecApprovalPendingView,
   ExecApprovalResolvedView,
+  ExpiredApprovalView,
+  PendingApprovalView,
+  PluginApprovalExpiredView,
+  PluginApprovalPendingView,
+  PluginApprovalResolvedView,
+  ResolvedApprovalView,
 } from "openclaw/plugin-sdk/approval-handler-runtime";
 import { createChannelApprovalNativeRuntimeAdapter } from "openclaw/plugin-sdk/approval-handler-runtime";
 import { buildChannelApprovalNativeTargetKey } from "openclaw/plugin-sdk/approval-native-runtime";
 import { buildApprovalPresentationFromActionDescriptors } from "openclaw/plugin-sdk/approval-reply-runtime";
-import type { ExecApprovalRequest } from "openclaw/plugin-sdk/approval-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { logError } from "openclaw/plugin-sdk/logging-core";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
-  isSlackExecApprovalClientEnabled,
-  shouldHandleSlackExecApprovalRequest,
-  normalizeSlackApproverId,
-} from "./exec-approvals.js";
+  isSlackAnyNativeApprovalClientEnabled,
+  resolveSlackApprovalKind,
+  shouldDeliverSlackNativeApprovalRequest,
+} from "./approval-native-gates.js";
+import { normalizeSlackApproverId } from "./exec-approvals.js";
 import { resolveSlackReplyBlocks } from "./reply-blocks.js";
 import { sendMessageSlack } from "./send.js";
 import { truncateSlackText } from "./truncate.js";
@@ -124,7 +130,19 @@ function resolveSlackApprovalDecisionLabel(
       : "Denied";
 }
 
-function buildSlackPendingApprovalText(view: ExecApprovalPendingView): string {
+function buildSlackPluginMetadata(
+  view: PluginApprovalPendingView | PluginApprovalResolvedView | PluginApprovalExpiredView,
+): { label: string; value: string }[] {
+  return [{ label: "Approval ID", value: view.approvalId }, ...view.metadata];
+}
+
+function resolveSlackPluginDescription(
+  view: PluginApprovalPendingView | PluginApprovalResolvedView | PluginApprovalExpiredView,
+): string {
+  return normalizeOptionalString(view.description) ?? "A plugin action needs your approval.";
+}
+
+function buildSlackExecPendingApprovalText(view: ExecApprovalPendingView): string {
   const metadataLines = buildSlackMetadataLines(view.metadata);
   const lines = [
     "*Exec approval required*",
@@ -137,7 +155,26 @@ function buildSlackPendingApprovalText(view: ExecApprovalPendingView): string {
   return lines.join("\n");
 }
 
-function buildSlackPendingApprovalBlocks(view: ExecApprovalPendingView): SlackBlock[] {
+function buildSlackPluginPendingApprovalText(view: PluginApprovalPendingView): string {
+  const metadataLines = buildSlackMetadataLines(buildSlackPluginMetadata(view));
+  const lines = [
+    "*Plugin approval required*",
+    resolveSlackPluginDescription(view),
+    "",
+    "*Request*",
+    view.title,
+    ...metadataLines,
+  ];
+  return lines.join("\n");
+}
+
+function buildSlackPendingApprovalText(view: PendingApprovalView): string {
+  return view.approvalKind === "plugin"
+    ? buildSlackPluginPendingApprovalText(view)
+    : buildSlackExecPendingApprovalText(view);
+}
+
+function buildSlackExecPendingApprovalBlocks(view: ExecApprovalPendingView): SlackBlock[] {
   const metadataElements = buildSlackMetadataContextElements(view.metadata);
   const interactiveBlocks =
     resolveSlackReplyBlocks({
@@ -171,7 +208,50 @@ function buildSlackPendingApprovalBlocks(view: ExecApprovalPendingView): SlackBl
   ];
 }
 
-function buildSlackResolvedText(view: ExecApprovalResolvedView): string {
+function buildSlackPluginPendingApprovalBlocks(view: PluginApprovalPendingView): SlackBlock[] {
+  const metadataElements = buildSlackMetadataContextElements(buildSlackPluginMetadata(view));
+  const interactiveBlocks =
+    resolveSlackReplyBlocks({
+      text: "",
+      presentation: buildApprovalPresentationFromActionDescriptors(view.actions),
+    }) ?? [];
+  return [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `*Plugin approval required*\n${truncateSlackMrkdwn(
+          resolveSlackPluginDescription(view),
+          2600,
+        )}`,
+      },
+    },
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `*Request*\n${truncateSlackMrkdwn(view.title, 2600)}`,
+      },
+    },
+    ...(metadataElements.length > 0
+      ? [
+          {
+            type: "context",
+            elements: metadataElements,
+          } satisfies SlackBlock,
+        ]
+      : []),
+    ...interactiveBlocks,
+  ];
+}
+
+function buildSlackPendingApprovalBlocks(view: PendingApprovalView): SlackBlock[] {
+  return view.approvalKind === "plugin"
+    ? buildSlackPluginPendingApprovalBlocks(view)
+    : buildSlackExecPendingApprovalBlocks(view);
+}
+
+function buildSlackExecResolvedText(view: ExecApprovalResolvedView): string {
   const resolvedBy = formatSlackApprover(view.resolvedBy);
   const lines = [
     `*Exec approval: ${resolveSlackApprovalDecisionLabel(view.decision)}*`,
@@ -183,7 +263,27 @@ function buildSlackResolvedText(view: ExecApprovalResolvedView): string {
   return lines.join("\n");
 }
 
-function buildSlackResolvedBlocks(view: ExecApprovalResolvedView): SlackBlock[] {
+function buildSlackPluginResolvedText(view: PluginApprovalResolvedView): string {
+  const resolvedBy = formatSlackApprover(view.resolvedBy);
+  const metadataLines = buildSlackMetadataLines(buildSlackPluginMetadata(view));
+  const lines = [
+    `*Plugin approval: ${resolveSlackApprovalDecisionLabel(view.decision)}*`,
+    resolvedBy ? `Resolved by ${resolvedBy}.` : "Resolved.",
+    "",
+    "*Request*",
+    view.title,
+    ...metadataLines,
+  ];
+  return lines.join("\n");
+}
+
+function buildSlackResolvedText(view: ResolvedApprovalView): string {
+  return view.approvalKind === "plugin"
+    ? buildSlackPluginResolvedText(view)
+    : buildSlackExecResolvedText(view);
+}
+
+function buildSlackExecResolvedBlocks(view: ExecApprovalResolvedView): SlackBlock[] {
   const resolvedBy = formatSlackApprover(view.resolvedBy);
   return [
     {
@@ -205,7 +305,44 @@ function buildSlackResolvedBlocks(view: ExecApprovalResolvedView): SlackBlock[] 
   ];
 }
 
-function buildSlackExpiredText(view: ExecApprovalExpiredView): string {
+function buildSlackPluginResolvedBlocks(view: PluginApprovalResolvedView): SlackBlock[] {
+  const resolvedBy = formatSlackApprover(view.resolvedBy);
+  const metadataElements = buildSlackMetadataContextElements(buildSlackPluginMetadata(view));
+  return [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `*Plugin approval: ${resolveSlackApprovalDecisionLabel(view.decision)}*\n${
+          resolvedBy ? `Resolved by ${resolvedBy}.` : "Resolved."
+        }`,
+      },
+    },
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `*Request*\n${truncateSlackMrkdwn(view.title, 2600)}`,
+      },
+    },
+    ...(metadataElements.length > 0
+      ? [
+          {
+            type: "context",
+            elements: metadataElements,
+          } satisfies SlackBlock,
+        ]
+      : []),
+  ];
+}
+
+function buildSlackResolvedBlocks(view: ResolvedApprovalView): SlackBlock[] {
+  return view.approvalKind === "plugin"
+    ? buildSlackPluginResolvedBlocks(view)
+    : buildSlackExecResolvedBlocks(view);
+}
+
+function buildSlackExecExpiredText(view: ExecApprovalExpiredView): string {
   return [
     "*Exec approval expired*",
     "This approval request expired before it was resolved.",
@@ -215,7 +352,25 @@ function buildSlackExpiredText(view: ExecApprovalExpiredView): string {
   ].join("\n");
 }
 
-function buildSlackExpiredBlocks(view: ExecApprovalExpiredView): SlackBlock[] {
+function buildSlackPluginExpiredText(view: PluginApprovalExpiredView): string {
+  const metadataLines = buildSlackMetadataLines(buildSlackPluginMetadata(view));
+  return [
+    "*Plugin approval expired*",
+    "This approval request expired before it was resolved.",
+    "",
+    "*Request*",
+    view.title,
+    ...metadataLines,
+  ].join("\n");
+}
+
+function buildSlackExpiredText(view: ExpiredApprovalView): string {
+  return view.approvalKind === "plugin"
+    ? buildSlackPluginExpiredText(view)
+    : buildSlackExecExpiredText(view);
+}
+
+function buildSlackExecExpiredBlocks(view: ExecApprovalExpiredView): SlackBlock[] {
   return [
     {
       type: "section",
@@ -232,6 +387,40 @@ function buildSlackExpiredBlocks(view: ExecApprovalExpiredView): SlackBlock[] {
       },
     },
   ];
+}
+
+function buildSlackPluginExpiredBlocks(view: PluginApprovalExpiredView): SlackBlock[] {
+  const metadataElements = buildSlackMetadataContextElements(buildSlackPluginMetadata(view));
+  return [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: "*Plugin approval expired*\nThis approval request expired before it was resolved.",
+      },
+    },
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `*Request*\n${truncateSlackMrkdwn(view.title, 2600)}`,
+      },
+    },
+    ...(metadataElements.length > 0
+      ? [
+          {
+            type: "context",
+            elements: metadataElements,
+          } satisfies SlackBlock,
+        ]
+      : []),
+  ];
+}
+
+function buildSlackExpiredBlocks(view: ExpiredApprovalView): SlackBlock[] {
+  return view.approvalKind === "plugin"
+    ? buildSlackPluginExpiredBlocks(view)
+    : buildSlackExecExpiredBlocks(view);
 }
 
 async function updateMessage(params: {
@@ -260,12 +449,12 @@ export const slackApprovalNativeRuntime = createChannelApprovalNativeRuntimeAdap
   never,
   SlackPendingDelivery
 >({
-  eventKinds: ["exec"],
+  eventKinds: ["exec", "plugin"],
   availability: {
     isConfigured: (params) => {
       const resolved = resolveHandlerContext(params);
       return resolved
-        ? isSlackExecApprovalClientEnabled({
+        ? isSlackAnyNativeApprovalClientEnabled({
             cfg: params.cfg,
             accountId: resolved.accountId,
           })
@@ -276,30 +465,31 @@ export const slackApprovalNativeRuntime = createChannelApprovalNativeRuntimeAdap
       if (!resolved) {
         return false;
       }
-      return shouldHandleSlackExecApprovalRequest({
+      return shouldDeliverSlackNativeApprovalRequest({
         cfg: params.cfg,
         accountId: resolved.accountId,
-        request: params.request as ExecApprovalRequest,
+        approvalKind: resolveSlackApprovalKind(params.request),
+        request: params.request,
       });
     },
   },
   presentation: {
     buildPendingPayload: ({ view }) => ({
-      text: buildSlackPendingApprovalText(view as ExecApprovalPendingView),
-      blocks: buildSlackPendingApprovalBlocks(view as ExecApprovalPendingView),
+      text: buildSlackPendingApprovalText(view),
+      blocks: buildSlackPendingApprovalBlocks(view),
     }),
     buildResolvedResult: ({ view }) => ({
       kind: "update",
       payload: {
-        text: buildSlackResolvedText(view as ExecApprovalResolvedView),
-        blocks: buildSlackResolvedBlocks(view as ExecApprovalResolvedView),
+        text: buildSlackResolvedText(view),
+        blocks: buildSlackResolvedBlocks(view),
       },
     }),
     buildExpiredResult: ({ view }) => ({
       kind: "update",
       payload: {
-        text: buildSlackExpiredText(view as ExecApprovalExpiredView),
-        blocks: buildSlackExpiredBlocks(view as ExecApprovalExpiredView),
+        text: buildSlackExpiredText(view),
+        blocks: buildSlackExpiredBlocks(view),
       },
     }),
   },

--- a/extensions/slack/src/approval-native-gates.ts
+++ b/extensions/slack/src/approval-native-gates.ts
@@ -2,12 +2,17 @@ import {
   isChannelExecApprovalClientEnabledFromConfig,
   matchesApprovalRequestFilters,
 } from "openclaw/plugin-sdk/approval-client-runtime";
-import { doesApprovalRequestMatchChannelAccount } from "openclaw/plugin-sdk/approval-native-runtime";
+import {
+  doesApprovalRequestMatchChannelAccount,
+  resolveApprovalRequestSessionConversation,
+} from "openclaw/plugin-sdk/approval-native-runtime";
 import type {
   ExecApprovalRequest,
   PluginApprovalRequest,
 } from "openclaw/plugin-sdk/approval-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { normalizeMessageChannel } from "openclaw/plugin-sdk/routing";
+import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolveSlackAccount } from "./accounts.js";
 import { getSlackApprovalApprovers } from "./approval-auth.js";
 import {
@@ -29,6 +34,10 @@ function resolveSlackNativeApprovalConfig(params: {
   return resolveSlackAccount(params).config.execApprovals;
 }
 
+function resolvePluginApprovalForwardingConfig(cfg: OpenClawConfig) {
+  return cfg.approvals?.plugin;
+}
+
 function getSlackNativeApprovalApprovers(params: {
   cfg: OpenClawConfig;
   accountId?: string | null;
@@ -39,6 +48,174 @@ function getSlackNativeApprovalApprovers(params: {
     : getSlackExecApprovalApprovers(params);
 }
 
+function normalizeAccountId(value?: string | null): string | undefined {
+  return normalizeOptionalString(value)?.toLowerCase();
+}
+
+function matchesSlackAccount(params: {
+  expectedAccountId?: string | null;
+  actualAccountId?: string | null;
+}): boolean {
+  const expected = normalizeAccountId(params.expectedAccountId);
+  const actual = normalizeAccountId(params.actualAccountId);
+  return !expected || !actual || expected === actual;
+}
+
+function modeIncludesSession(mode: "session" | "targets" | "both" | undefined): boolean {
+  return mode === undefined || mode === "session" || mode === "both";
+}
+
+function modeIncludesTargets(mode: "session" | "targets" | "both" | undefined): boolean {
+  return mode === "targets" || mode === "both";
+}
+
+function hasSlackPluginForwardingTarget(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}): boolean {
+  const targets = resolvePluginApprovalForwardingConfig(params.cfg)?.targets ?? [];
+  return targets.some((target) => {
+    const channel = normalizeMessageChannel(target.channel) ?? target.channel;
+    return (
+      channel === "slack" &&
+      matchesSlackAccount({
+        expectedAccountId: params.accountId,
+        actualAccountId: target.accountId,
+      })
+    );
+  });
+}
+
+function requestHasSlackOriginOrSession(params: {
+  request: SlackNativeApprovalRequest;
+  accountId?: string | null;
+}): boolean {
+  const request = params.request.request;
+  const turnSourceChannel = normalizeMessageChannel(request.turnSourceChannel);
+  if (turnSourceChannel) {
+    return (
+      turnSourceChannel === "slack" &&
+      matchesSlackAccount({
+        expectedAccountId: params.accountId,
+        actualAccountId: request.turnSourceAccountId,
+      })
+    );
+  }
+  return (
+    resolveApprovalRequestSessionConversation({
+      request: params.request,
+      channel: "slack",
+      bundledFallback: false,
+    }) !== null
+  );
+}
+
+function isPluginForwardingEnabledForRequest(params: {
+  cfg: OpenClawConfig;
+  request: SlackNativeApprovalRequest;
+}): boolean {
+  const config = resolvePluginApprovalForwardingConfig(params.cfg);
+  if (!config?.enabled) {
+    return false;
+  }
+  return matchesApprovalRequestFilters({
+    request: params.request.request,
+    agentFilter: config.agentFilter,
+    sessionFilter: config.sessionFilter,
+  });
+}
+
+function canPluginForwardingRouteToSlack(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  request: SlackNativeApprovalRequest;
+}): boolean {
+  const config = resolvePluginApprovalForwardingConfig(params.cfg);
+  const mode = config?.mode;
+  if (
+    modeIncludesSession(mode) &&
+    requestHasSlackOriginOrSession({
+      request: params.request,
+      accountId: params.accountId,
+    })
+  ) {
+    return true;
+  }
+  return modeIncludesTargets(mode) && hasSlackPluginForwardingTarget(params);
+}
+
+function isSlackPluginNativeApprovalClientEnabled(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}): boolean {
+  const slackNativeConfig = resolveSlackNativeApprovalConfig(params);
+  if (
+    isChannelExecApprovalClientEnabledFromConfig({
+      enabled: slackNativeConfig?.enabled,
+      approverCount: getSlackApprovalApprovers(params).length,
+    })
+  ) {
+    return true;
+  }
+  const config = resolvePluginApprovalForwardingConfig(params.cfg);
+  if (!config?.enabled || getSlackApprovalApprovers(params).length <= 0) {
+    return false;
+  }
+  const mode = config.mode;
+  return (
+    modeIncludesSession(mode) ||
+    (modeIncludesTargets(mode) && hasSlackPluginForwardingTarget(params))
+  );
+}
+
+function shouldHandleSlackPluginViaNativeClientConfig(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  request: SlackNativeApprovalRequest;
+}): boolean {
+  if (
+    !doesApprovalRequestMatchChannelAccount({
+      cfg: params.cfg,
+      request: params.request,
+      channel: "slack",
+      accountId: params.accountId,
+    })
+  ) {
+    return false;
+  }
+  const config = resolveSlackNativeApprovalConfig(params);
+  if (
+    !isChannelExecApprovalClientEnabledFromConfig({
+      enabled: config?.enabled,
+      approverCount: getSlackApprovalApprovers(params).length,
+    })
+  ) {
+    return false;
+  }
+  return matchesApprovalRequestFilters({
+    request: params.request.request,
+    agentFilter: config?.agentFilter,
+    sessionFilter: config?.sessionFilter,
+  });
+}
+
+function shouldHandleSlackPluginNativeApprovalRequest(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  request: SlackNativeApprovalRequest;
+}): boolean {
+  if (getSlackApprovalApprovers(params).length <= 0) {
+    return false;
+  }
+  if (shouldHandleSlackPluginViaNativeClientConfig(params)) {
+    return true;
+  }
+  if (!isPluginForwardingEnabledForRequest(params)) {
+    return false;
+  }
+  return canPluginForwardingRouteToSlack(params);
+}
+
 export function isSlackNativeApprovalClientEnabled(params: {
   cfg: OpenClawConfig;
   accountId?: string | null;
@@ -47,11 +224,7 @@ export function isSlackNativeApprovalClientEnabled(params: {
   if (params.approvalKind === "exec") {
     return isSlackExecApprovalClientEnabled(params);
   }
-  const config = resolveSlackNativeApprovalConfig(params);
-  return isChannelExecApprovalClientEnabledFromConfig({
-    enabled: config?.enabled,
-    approverCount: getSlackNativeApprovalApprovers(params).length,
-  });
+  return isSlackPluginNativeApprovalClientEnabled(params);
 }
 
 export function isSlackAnyNativeApprovalClientEnabled(params: {
@@ -77,6 +250,13 @@ export function shouldHandleSlackNativeApprovalRequest(params: {
   request: SlackNativeApprovalRequest;
 }): boolean {
   const approvalKind = params.approvalKind ?? resolveSlackApprovalKind(params.request);
+  if (approvalKind === "plugin") {
+    return shouldHandleSlackPluginNativeApprovalRequest({
+      cfg: params.cfg,
+      accountId: params.accountId,
+      request: params.request,
+    });
+  }
   if (
     !doesApprovalRequestMatchChannelAccount({
       cfg: params.cfg,

--- a/extensions/slack/src/approval-native-gates.ts
+++ b/extensions/slack/src/approval-native-gates.ts
@@ -1,0 +1,121 @@
+import {
+  isChannelExecApprovalClientEnabledFromConfig,
+  matchesApprovalRequestFilters,
+} from "openclaw/plugin-sdk/approval-client-runtime";
+import { doesApprovalRequestMatchChannelAccount } from "openclaw/plugin-sdk/approval-native-runtime";
+import type {
+  ExecApprovalRequest,
+  PluginApprovalRequest,
+} from "openclaw/plugin-sdk/approval-runtime";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { resolveSlackAccount } from "./accounts.js";
+import { getSlackApprovalApprovers } from "./approval-auth.js";
+import {
+  getSlackExecApprovalApprovers,
+  isSlackExecApprovalClientEnabled,
+} from "./exec-approvals.js";
+
+export type SlackApprovalKind = "exec" | "plugin";
+export type SlackNativeApprovalRequest = ExecApprovalRequest | PluginApprovalRequest;
+
+export function resolveSlackApprovalKind(request: SlackNativeApprovalRequest): SlackApprovalKind {
+  return request.id.startsWith("plugin:") ? "plugin" : "exec";
+}
+
+function resolveSlackNativeApprovalConfig(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}) {
+  return resolveSlackAccount(params).config.execApprovals;
+}
+
+function getSlackNativeApprovalApprovers(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  approvalKind: SlackApprovalKind;
+}): string[] {
+  return params.approvalKind === "plugin"
+    ? getSlackApprovalApprovers(params)
+    : getSlackExecApprovalApprovers(params);
+}
+
+export function isSlackNativeApprovalClientEnabled(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  approvalKind: SlackApprovalKind;
+}): boolean {
+  if (params.approvalKind === "exec") {
+    return isSlackExecApprovalClientEnabled(params);
+  }
+  const config = resolveSlackNativeApprovalConfig(params);
+  return isChannelExecApprovalClientEnabledFromConfig({
+    enabled: config?.enabled,
+    approverCount: getSlackNativeApprovalApprovers(params).length,
+  });
+}
+
+export function isSlackAnyNativeApprovalClientEnabled(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}): boolean {
+  return (
+    isSlackNativeApprovalClientEnabled({
+      ...params,
+      approvalKind: "exec",
+    }) ||
+    isSlackNativeApprovalClientEnabled({
+      ...params,
+      approvalKind: "plugin",
+    })
+  );
+}
+
+export function shouldHandleSlackNativeApprovalRequest(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  approvalKind?: SlackApprovalKind;
+  request: SlackNativeApprovalRequest;
+}): boolean {
+  const approvalKind = params.approvalKind ?? resolveSlackApprovalKind(params.request);
+  if (
+    !doesApprovalRequestMatchChannelAccount({
+      cfg: params.cfg,
+      request: params.request,
+      channel: "slack",
+      accountId: params.accountId,
+    })
+  ) {
+    return false;
+  }
+  const config = resolveSlackNativeApprovalConfig(params);
+  if (
+    !isChannelExecApprovalClientEnabledFromConfig({
+      enabled: config?.enabled,
+      approverCount: getSlackNativeApprovalApprovers({
+        ...params,
+        approvalKind,
+      }).length,
+    })
+  ) {
+    return false;
+  }
+  return matchesApprovalRequestFilters({
+    request: params.request.request,
+    agentFilter: config?.agentFilter,
+    sessionFilter: config?.sessionFilter,
+  });
+}
+
+export function shouldDeliverSlackNativeApprovalRequest(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  approvalKind: SlackApprovalKind;
+  request: SlackNativeApprovalRequest;
+}): boolean {
+  return shouldHandleSlackNativeApprovalRequest({
+    cfg: params.cfg,
+    accountId: params.accountId,
+    approvalKind: params.approvalKind,
+    request: params.request,
+  });
+}

--- a/extensions/slack/src/approval-native.test.ts
+++ b/extensions/slack/src/approval-native.test.ts
@@ -65,6 +65,10 @@ async function resolveExecOriginTarget(
 }
 
 describe("slack native approval adapter", () => {
+  it("subscribes the native runtime to exec and plugin approval events", () => {
+    expect(slackApprovalCapability.nativeRuntime?.eventKinds).toEqual(["exec", "plugin"]);
+  });
+
   it("keeps approval availability enabled when approvers exist but native delivery is off", () => {
     const cfg = buildConfig({
       execApprovals: {
@@ -198,6 +202,112 @@ describe("slack native approval adapter", () => {
     expect(targets).toEqual([{ to: "user:U123APPROVER" }]);
   });
 
+  it("routes plugin approval dm targets to plugin approvers", async () => {
+    const cfg = buildConfig({
+      allowFrom: ["U123OWNER"],
+      execApprovals: {
+        enabled: true,
+        approvers: ["U999EXEC"],
+        target: "dm",
+      },
+    });
+
+    const targets = await slackNativeApprovalAdapter.native?.resolveApproverDmTargets?.({
+      cfg,
+      accountId: "default",
+      approvalKind: "plugin",
+      request: {
+        id: "plugin:req-1",
+        request: {
+          title: "Plugin approval",
+          description: "Allow access",
+          turnSourceChannel: "slack",
+          turnSourceAccountId: "default",
+        },
+        createdAtMs: 0,
+        expiresAtMs: 1000,
+      },
+    });
+
+    expect(targets).toEqual([{ to: "user:U123OWNER" }]);
+  });
+
+  it("enables native plugin delivery from plugin approvers without exec approvers", async () => {
+    const cfg = buildConfig({
+      allowFrom: ["U123OWNER"],
+      execApprovals: {
+        enabled: true,
+        target: "dm",
+      },
+    });
+    const request = {
+      id: "plugin:req-1",
+      request: {
+        title: "Plugin approval",
+        description: "Allow access",
+        turnSourceChannel: "slack",
+        turnSourceAccountId: "default",
+      },
+      createdAtMs: 0,
+      expiresAtMs: 1000,
+    };
+
+    expect(
+      slackNativeApprovalAdapter.native?.describeDeliveryCapabilities({
+        cfg,
+        accountId: "default",
+        approvalKind: "plugin",
+        request,
+      }).enabled,
+    ).toBe(true);
+    expect(
+      slackNativeApprovalAdapter.native?.describeDeliveryCapabilities({
+        cfg,
+        accountId: "default",
+        approvalKind: "exec",
+        request: {
+          id: "req-1",
+          request: {
+            command: "echo hi",
+            turnSourceChannel: "slack",
+            turnSourceAccountId: "default",
+          },
+          createdAtMs: 0,
+          expiresAtMs: 1000,
+        },
+      }).enabled,
+    ).toBe(false);
+    expect(
+      await slackNativeApprovalAdapter.native?.resolveApproverDmTargets?.({
+        cfg,
+        accountId: "default",
+        approvalKind: "plugin",
+        request,
+      }),
+    ).toEqual([{ to: "user:U123OWNER" }]);
+    expect(
+      slackApprovalCapability.nativeRuntime?.availability.isConfigured({
+        cfg,
+        accountId: "default",
+      }),
+    ).toBe(true);
+    expect(
+      slackApprovalCapability.nativeRuntime?.availability.shouldHandle({
+        cfg,
+        accountId: "default",
+        request,
+      }),
+    ).toBe(true);
+    expect(
+      slackNativeApprovalAdapter.delivery?.shouldSuppressForwardingFallback?.({
+        cfg,
+        approvalKind: "plugin",
+        target: { channel: "slack", to: "channel:C123ROOM", accountId: "default" },
+        request,
+      }),
+    ).toBe(true);
+  });
+
   it("falls back to the session-bound origin target for plugin approvals", async () => {
     writeStore({
       "agent:main:slack:channel:c123": {
@@ -214,7 +324,7 @@ describe("slack native approval adapter", () => {
 
     const target = await slackNativeApprovalAdapter.native?.resolveOriginTarget?.({
       cfg: {
-        ...buildConfig(),
+        ...buildConfig({ allowFrom: ["U123OWNER"] }),
         session: { store: STORE_PATH },
       },
       accountId: "default",
@@ -240,7 +350,7 @@ describe("slack native approval adapter", () => {
   it("falls back to the session-key origin target for plugin approvals when the store is missing", async () => {
     const target = await slackNativeApprovalAdapter.native?.resolveOriginTarget?.({
       cfg: {
-        ...buildConfig(),
+        ...buildConfig({ allowFrom: ["U123OWNER"] }),
         session: { store: STORE_PATH },
       },
       accountId: "default",
@@ -391,6 +501,71 @@ describe("slack native approval adapter", () => {
         },
       }),
     ).toBe(false);
+  });
+
+  it("keeps plugin forwarding fallback when Slack has no plugin approvers", () => {
+    const shouldSuppress = slackNativeApprovalAdapter.delivery?.shouldSuppressForwardingFallback;
+    if (!shouldSuppress) {
+      throw new Error("slack native delivery suppression unavailable");
+    }
+
+    expect(
+      shouldSuppress({
+        cfg: buildConfig({
+          execApprovals: {
+            enabled: true,
+            approvers: ["U999EXEC"],
+            target: "dm",
+          },
+        }),
+        approvalKind: "plugin",
+        target: { channel: "slack", to: "channel:C123ROOM", accountId: "default" },
+        request: {
+          id: "plugin:approval-1",
+          request: {
+            title: "Plugin approval",
+            description: "Allow access",
+            turnSourceChannel: "slack",
+            turnSourceAccountId: "default",
+          },
+          createdAtMs: 0,
+          expiresAtMs: 1_000,
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("suppresses plugin forwarding fallback when Slack can deliver native plugin approvals", () => {
+    const shouldSuppress = slackNativeApprovalAdapter.delivery?.shouldSuppressForwardingFallback;
+    if (!shouldSuppress) {
+      throw new Error("slack native delivery suppression unavailable");
+    }
+
+    expect(
+      shouldSuppress({
+        cfg: buildConfig({
+          allowFrom: ["U123OWNER"],
+          execApprovals: {
+            enabled: true,
+            approvers: ["U999EXEC"],
+            target: "dm",
+          },
+        }),
+        approvalKind: "plugin",
+        target: { channel: "slack", to: "channel:C123ROOM", accountId: "default" },
+        request: {
+          id: "plugin:approval-1",
+          request: {
+            title: "Plugin approval",
+            description: "Allow access",
+            turnSourceChannel: "slack",
+            turnSourceAccountId: "default",
+          },
+          createdAtMs: 0,
+          expiresAtMs: 1_000,
+        },
+      }),
+    ).toBe(true);
   });
 
   it("keeps plugin approval auth independent from exec approvers", () => {

--- a/extensions/slack/src/approval-native.test.ts
+++ b/extensions/slack/src/approval-native.test.ts
@@ -308,6 +308,76 @@ describe("slack native approval adapter", () => {
     ).toBe(true);
   });
 
+  it("enables native plugin delivery from plugin forwarding when exec native delivery is disabled", async () => {
+    const cfg = {
+      ...buildConfig({
+        allowFrom: ["U123OWNER"],
+        execApprovals: {
+          enabled: false,
+          approvers: ["U999EXEC"],
+          target: "both",
+        },
+      }),
+      approvals: {
+        plugin: {
+          enabled: true,
+          mode: "both",
+          agentFilter: ["dev"],
+          targets: [{ channel: "slack", to: "U123OWNER" }],
+        },
+      },
+    } as OpenClawConfig;
+    const request = {
+      id: "plugin:req-1",
+      request: {
+        title: "Plugin approval",
+        description: "Allow access",
+        agentId: "dev",
+      },
+      createdAtMs: 0,
+      expiresAtMs: 1000,
+    };
+
+    expect(
+      slackNativeApprovalAdapter.native?.describeDeliveryCapabilities({
+        cfg,
+        accountId: "default",
+        approvalKind: "exec",
+        request: {
+          id: "req-1",
+          request: {
+            command: "echo hi",
+            turnSourceChannel: "slack",
+            turnSourceAccountId: "default",
+          },
+          createdAtMs: 0,
+          expiresAtMs: 1000,
+        },
+      }).enabled,
+    ).toBe(false);
+    expect(
+      slackNativeApprovalAdapter.native?.describeDeliveryCapabilities({
+        cfg,
+        accountId: "default",
+        approvalKind: "plugin",
+        request,
+      }).enabled,
+    ).toBe(true);
+    expect(
+      slackApprovalCapability.nativeRuntime?.availability.isConfigured({
+        cfg,
+        accountId: "default",
+      }),
+    ).toBe(true);
+    expect(
+      slackApprovalCapability.nativeRuntime?.availability.shouldHandle({
+        cfg,
+        accountId: "default",
+        request,
+      }),
+    ).toBe(true);
+  });
+
   it("falls back to the session-bound origin target for plugin approvals", async () => {
     writeStore({
       "agent:main:slack:channel:c123": {
@@ -560,6 +630,48 @@ describe("slack native approval adapter", () => {
             description: "Allow access",
             turnSourceChannel: "slack",
             turnSourceAccountId: "default",
+          },
+          createdAtMs: 0,
+          expiresAtMs: 1_000,
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("suppresses explicit plugin forwarding targets when native Slack plugin delivery is active", () => {
+    const shouldSuppress = slackNativeApprovalAdapter.delivery?.shouldSuppressForwardingFallback;
+    if (!shouldSuppress) {
+      throw new Error("slack native delivery suppression unavailable");
+    }
+
+    const cfg = {
+      ...buildConfig({
+        allowFrom: ["U123OWNER"],
+        execApprovals: {
+          enabled: false,
+          approvers: ["U999EXEC"],
+          target: "both",
+        },
+      }),
+      approvals: {
+        plugin: {
+          enabled: true,
+          mode: "targets",
+          targets: [{ channel: "slack", to: "U123OWNER" }],
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      shouldSuppress({
+        cfg,
+        approvalKind: "plugin",
+        target: { channel: "slack", to: "U123OWNER", accountId: "default" },
+        request: {
+          id: "plugin:approval-1",
+          request: {
+            title: "Plugin approval",
+            description: "Allow access",
           },
           createdAtMs: 0,
           expiresAtMs: 1_000,

--- a/extensions/slack/src/approval-native.ts
+++ b/extensions/slack/src/approval-native.ts
@@ -5,36 +5,51 @@ import {
 import { createLazyChannelApprovalNativeRuntimeAdapter } from "openclaw/plugin-sdk/approval-handler-adapter-runtime";
 import type { ChannelApprovalNativeRuntimeAdapter } from "openclaw/plugin-sdk/approval-handler-runtime";
 import {
-  createChannelApproverDmTargetResolver,
   createChannelNativeOriginTargetResolver,
   resolveApprovalRequestSessionConversation,
 } from "openclaw/plugin-sdk/approval-native-runtime";
-import type {
-  ExecApprovalRequest,
-  PluginApprovalRequest,
-} from "openclaw/plugin-sdk/approval-runtime";
 import type { ChannelApprovalCapability } from "openclaw/plugin-sdk/channel-contract";
 import {
   channelRouteTargetsMatchExact,
   stringifyRouteThreadId,
 } from "openclaw/plugin-sdk/channel-route";
+import { normalizeMessageChannel } from "openclaw/plugin-sdk/routing";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { listSlackAccountIds } from "./accounts.js";
-import { isSlackApprovalAuthorizedSender } from "./approval-auth.js";
+import { getSlackApprovalApprovers, isSlackApprovalAuthorizedSender } from "./approval-auth.js";
+import {
+  isSlackAnyNativeApprovalClientEnabled,
+  resolveSlackApprovalKind,
+  shouldDeliverSlackNativeApprovalRequest,
+  shouldHandleSlackNativeApprovalRequest,
+  type SlackApprovalKind,
+  type SlackNativeApprovalRequest,
+} from "./approval-native-gates.js";
 import {
   getSlackExecApprovalApprovers,
   isSlackExecApprovalAuthorizedSender,
   isSlackExecApprovalClientEnabled,
   resolveSlackExecApprovalTarget,
-  shouldHandleSlackExecApprovalRequest,
 } from "./exec-approvals.js";
 import { parseSlackTarget } from "./targets.js";
 
-type ApprovalRequest = ExecApprovalRequest | PluginApprovalRequest;
+type ApprovalRequest = SlackNativeApprovalRequest;
+type ApprovalKind = SlackApprovalKind;
 type SlackOriginTarget = { to: string; threadId?: string };
+type SlackDeliverySuppressionInput = {
+  cfg: Parameters<typeof shouldHandleSlackNativeApprovalRequest>[0]["cfg"];
+  approvalKind: ApprovalKind;
+  target: { channel: string; accountId?: string | null };
+  request: {
+    request: {
+      turnSourceChannel?: string | null;
+      turnSourceAccountId?: string | null;
+    };
+  };
+};
 
 function extractSlackSessionKind(
   sessionKey?: string | null,
@@ -133,10 +148,31 @@ function slackTargetsMatch(a: SlackOriginTarget, b: SlackOriginTarget): boolean 
   );
 }
 
+function resolveSlackNativeSuppressionAccountId({
+  target,
+  request,
+}: SlackDeliverySuppressionInput): string | undefined {
+  return (
+    normalizeOptionalString(target.accountId) ??
+    normalizeOptionalString(request.request.turnSourceAccountId)
+  );
+}
+
+function shouldConsiderSlackNativeForwardingSuppression(
+  input: SlackDeliverySuppressionInput,
+): boolean {
+  const channel = normalizeMessageChannel(input.target.channel) ?? input.target.channel;
+  if (channel !== "slack") {
+    return false;
+  }
+  const turnSourceChannel = normalizeMessageChannel(input.request.request.turnSourceChannel);
+  return turnSourceChannel === "slack";
+}
+
 const resolveSlackOriginTarget = createChannelNativeOriginTargetResolver({
   channel: "slack",
   shouldHandleRequest: ({ cfg, accountId, request }) =>
-    shouldHandleSlackExecApprovalRequest({
+    shouldHandleSlackNativeApprovalRequest({
       cfg,
       accountId,
       request,
@@ -148,18 +184,29 @@ const resolveSlackOriginTarget = createChannelNativeOriginTargetResolver({
   resolveFallbackTarget: resolveSlackFallbackOriginTarget,
 });
 
-const resolveSlackApproverDmTargets = createChannelApproverDmTargetResolver({
-  shouldHandleRequest: ({ cfg, accountId, request }) =>
-    shouldHandleSlackExecApprovalRequest({
-      cfg,
-      accountId,
-      request,
-    }),
-  resolveApprovers: getSlackExecApprovalApprovers,
-  mapApprover: (approver) => ({ to: `user:${approver}` }),
-});
+function resolveSlackApproverDmTargets(params: {
+  cfg: Parameters<typeof shouldHandleSlackNativeApprovalRequest>[0]["cfg"];
+  accountId?: string | null;
+  approvalKind: ApprovalKind;
+  request: ApprovalRequest;
+}): SlackOriginTarget[] {
+  if (
+    !shouldHandleSlackNativeApprovalRequest({
+      cfg: params.cfg,
+      accountId: params.accountId,
+      request: params.request,
+    })
+  ) {
+    return [];
+  }
+  const approvers =
+    params.approvalKind === "plugin"
+      ? getSlackApprovalApprovers(params)
+      : getSlackExecApprovalApprovers(params);
+  return approvers.map((approver) => ({ to: `user:${approver}` }));
+}
 
-export const slackApprovalCapability = createApproverRestrictedNativeApprovalCapability({
+const baseSlackApprovalCapability = createApproverRestrictedNativeApprovalCapability({
   channel: "slack",
   channelLabel: "Slack",
   describeExecApprovalSetup: ({
@@ -183,23 +230,22 @@ export const slackApprovalCapability = createApproverRestrictedNativeApprovalCap
   resolveNativeDeliveryMode: ({ cfg, accountId }) =>
     resolveSlackExecApprovalTarget({ cfg, accountId }),
   requireMatchingTurnSourceChannel: true,
-  resolveSuppressionAccountId: ({ target, request }) =>
-    normalizeOptionalString(target.accountId) ??
-    normalizeOptionalString(request.request.turnSourceAccountId),
+  resolveSuppressionAccountId: resolveSlackNativeSuppressionAccountId,
   resolveOriginTarget: resolveSlackOriginTarget,
   resolveApproverDmTargets: resolveSlackApproverDmTargets,
   notifyOriginWhenDmOnly: true,
   nativeRuntime: createLazyChannelApprovalNativeRuntimeAdapter({
-    eventKinds: ["exec"],
+    eventKinds: ["exec", "plugin"],
     isConfigured: ({ cfg, accountId }) =>
-      isSlackExecApprovalClientEnabled({
+      isSlackAnyNativeApprovalClientEnabled({
         cfg,
         accountId,
       }),
     shouldHandle: ({ cfg, accountId, request }) =>
-      shouldHandleSlackExecApprovalRequest({
+      shouldDeliverSlackNativeApprovalRequest({
         cfg,
         accountId,
+        approvalKind: resolveSlackApprovalKind(request),
         request,
       }),
     load: async () =>
@@ -207,5 +253,43 @@ export const slackApprovalCapability = createApproverRestrictedNativeApprovalCap
         .slackApprovalNativeRuntime as unknown as ChannelApprovalNativeRuntimeAdapter,
   }),
 });
+
+const baseSlackNativeAdapter = baseSlackApprovalCapability.native;
+
+export const slackApprovalCapability: ChannelApprovalCapability = {
+  ...baseSlackApprovalCapability,
+  delivery: {
+    ...baseSlackApprovalCapability.delivery,
+    shouldSuppressForwardingFallback: (input) => {
+      const slackInput = input as SlackDeliverySuppressionInput;
+      if (!shouldConsiderSlackNativeForwardingSuppression(slackInput)) {
+        return false;
+      }
+      return shouldDeliverSlackNativeApprovalRequest({
+        cfg: slackInput.cfg,
+        accountId: resolveSlackNativeSuppressionAccountId(slackInput),
+        approvalKind: slackInput.approvalKind,
+        request: slackInput.request as ApprovalRequest,
+      });
+    },
+  },
+  native: baseSlackNativeAdapter
+    ? {
+        ...baseSlackNativeAdapter,
+        describeDeliveryCapabilities: (params) => {
+          const capabilities = baseSlackNativeAdapter.describeDeliveryCapabilities(params);
+          return {
+            ...capabilities,
+            enabled: shouldHandleSlackNativeApprovalRequest({
+              cfg: params.cfg,
+              accountId: params.accountId,
+              approvalKind: params.approvalKind,
+              request: params.request as ApprovalRequest,
+            }),
+          };
+        },
+      }
+    : undefined,
+};
 
 export const slackNativeApprovalAdapter = splitChannelApprovalCapability(slackApprovalCapability);

--- a/extensions/slack/src/approval-native.ts
+++ b/extensions/slack/src/approval-native.ts
@@ -165,6 +165,9 @@ function shouldConsiderSlackNativeForwardingSuppression(
   if (channel !== "slack") {
     return false;
   }
+  if (input.approvalKind === "plugin") {
+    return true;
+  }
   const turnSourceChannel = normalizeMessageChannel(input.request.request.turnSourceChannel);
   return turnSourceChannel === "slack";
 }

--- a/extensions/slack/src/monitor.test-helpers.ts
+++ b/extensions/slack/src/monitor.test-helpers.ts
@@ -1,3 +1,4 @@
+import type { ChannelRuntimeSurface } from "openclaw/plugin-sdk/channel-contract";
 import { Mock, vi } from "vitest";
 import { clearSlackInboundDeliveryStateForTest } from "./monitor/inbound-delivery-state.js";
 
@@ -8,6 +9,7 @@ type SlackProviderMonitor = (params: {
   appToken: string;
   abortSignal: AbortSignal;
   config?: Record<string, unknown>;
+  channelRuntime?: ChannelRuntimeSurface;
 }) => Promise<unknown>;
 
 type SlackTestState = {
@@ -127,7 +129,7 @@ async function waitForSlackEvent(name: string) {
 
 export function startSlackMonitor(
   monitorSlackProvider: SlackProviderMonitor,
-  opts?: { botToken?: string; appToken?: string },
+  opts?: { botToken?: string; appToken?: string; channelRuntime?: ChannelRuntimeSurface },
 ) {
   const controller = new AbortController();
   const run = monitorSlackProvider({
@@ -135,6 +137,7 @@ export function startSlackMonitor(
     appToken: opts?.appToken ?? "app-token",
     abortSignal: controller.signal,
     config: slackTestState.config,
+    channelRuntime: opts?.channelRuntime,
   });
   return { controller, run };
 }

--- a/extensions/slack/src/monitor/provider.allowlist.test.ts
+++ b/extensions/slack/src/monitor/provider.allowlist.test.ts
@@ -1,4 +1,6 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { CHANNEL_APPROVAL_NATIVE_RUNTIME_CONTEXT_CAPABILITY } from "openclaw/plugin-sdk/approval-handler-adapter-runtime";
+import type { ChannelRuntimeSurface } from "openclaw/plugin-sdk/channel-contract";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   flush,
   getSlackHandlerOrThrow,
@@ -15,6 +17,23 @@ const slackTestState = getSlackTestState();
 beforeEach(() => {
   resetSlackTestState();
 });
+
+function createRuntimeContextCapture(): {
+  channelRuntime: ChannelRuntimeSurface;
+  register: ChannelRuntimeSurface["runtimeContexts"]["register"];
+} {
+  const register = vi.fn(() => ({ dispose: vi.fn() }));
+  return {
+    channelRuntime: {
+      runtimeContexts: {
+        register,
+        get: vi.fn(),
+        watch: vi.fn(() => () => {}),
+      },
+    } as unknown as ChannelRuntimeSurface,
+    register,
+  };
+}
 
 function resolveAllowlistCallAt(index: number): { entries?: unknown } {
   const call = slackTestState.resolveSlackUserAllowlistMock.mock.calls[index];
@@ -49,6 +68,49 @@ describe("slack allowlist log formatting", () => {
 });
 
 describe("slack startup user allowlist resolution", () => {
+  it("registers the native approval runtime for plugin-only Slack approvals", async () => {
+    resetSlackTestState({
+      channels: {
+        slack: {
+          enabled: true,
+          allowFrom: ["U123OWNER"],
+          execApprovals: {
+            enabled: false,
+            approvers: ["U999EXEC"],
+            target: "both",
+          },
+        },
+      },
+      approvals: {
+        plugin: {
+          enabled: true,
+          mode: "targets",
+          targets: [{ channel: "slack", to: "U123OWNER" }],
+        },
+      },
+    });
+    const { channelRuntime, register } = createRuntimeContextCapture();
+
+    const monitor = startSlackMonitor(monitorSlackProvider, { channelRuntime });
+    try {
+      await getSlackHandlerOrThrow("message");
+      await flush();
+
+      expect(register).toHaveBeenCalledWith(
+        expect.objectContaining({
+          channelId: "slack",
+          accountId: "default",
+          capability: CHANNEL_APPROVAL_NATIVE_RUNTIME_CONTEXT_CAPABILITY,
+          context: expect.objectContaining({
+            config: expect.objectContaining({ enabled: false }),
+          }),
+        }),
+      );
+    } finally {
+      await stopSlackMonitor(monitor);
+    }
+  });
+
   it("skips user entry resolution when name matching is not enabled", async () => {
     resetSlackTestState({
       messages: {

--- a/extensions/slack/src/monitor/provider.ts
+++ b/extensions/slack/src/monitor/provider.ts
@@ -27,8 +27,8 @@ import {
   resolveSlackAccountAllowFrom,
   resolveSlackAccountDmPolicy,
 } from "../accounts.js";
+import { isSlackAnyNativeApprovalClientEnabled } from "../approval-native-gates.js";
 import { resolveSlackWebClientOptions } from "../client-options.js";
-import { isSlackExecApprovalClientEnabled } from "../exec-approvals.js";
 import { normalizeSlackWebhookPath, registerSlackHttpHandler } from "../http/index.js";
 import { SLACK_TEXT_LIMIT } from "../limits.js";
 import { resolveSlackChannelAllowlist } from "../resolve-channels.js";
@@ -360,7 +360,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
 
   const handleSlackMessage = createSlackMessageHandler({ ctx, account, trackEvent });
   if (
-    isSlackExecApprovalClientEnabled({
+    isSlackAnyNativeApprovalClientEnabled({
       cfg,
       accountId: account.accountId,
     })

--- a/extensions/slack/src/send.blocks.test.ts
+++ b/extensions/slack/src/send.blocks.test.ts
@@ -205,6 +205,7 @@ describe("sendMessageSlack blocks", () => {
   it("posts user-target block messages directly without conversations.open", async () => {
     const client = createSlackSendTestClient();
     client.conversations.open.mockRejectedValueOnce(new Error("missing_scope"));
+    client.chat.postMessage.mockResolvedValueOnce({ ts: "171234.567", channel: "D123" });
 
     const result = await sendMessageSlack("user:U123", "", {
       token: "xoxb-test",
@@ -217,8 +218,9 @@ describe("sendMessageSlack blocks", () => {
     expect(postedMessage(client).channel).toBe("U123");
     expect(postedMessage(client).text).toBe("Shared a Block Kit message");
     expect(result.messageId).toBe("171234.567");
-    expect(result.channelId).toBe("U123");
+    expect(result.channelId).toBe("D123");
     expect(result.receipt.platformMessageIds).toEqual(["171234.567"]);
+    expect(result.receipt.parts[0]?.raw).toMatchObject({ channelId: "D123" });
   });
 
   it("retries Slack postMessage DNS request errors without enabling broad write retries", async () => {

--- a/extensions/slack/src/send.ts
+++ b/extensions/slack/src/send.ts
@@ -493,6 +493,13 @@ function resolveDirectUserPostChannelId(params: {
   return params.recipient.id;
 }
 
+function resolvePostedMessageChannelId(response: { channel?: unknown }, fallback: string): string {
+  return (
+    (typeof response.channel === "string" ? normalizeOptionalString(response.channel) : null) ??
+    fallback
+  );
+}
+
 async function resolveChannelId(
   client: WebClient,
   recipient: SlackRecipient,
@@ -730,12 +737,13 @@ async function sendMessageSlackQueuedInner(params: {
       unfurl,
     });
     const messageId = response.ts ?? "unknown";
+    const deliveredChannelId = resolvePostedMessageChannelId(response, channelId);
     return {
       messageId,
-      channelId,
+      channelId: deliveredChannelId,
       receipt: createSlackSendReceipt({
         platformMessageIds: [messageId],
-        channelId,
+        channelId: deliveredChannelId,
         kind: "card",
         threadTs: opts.threadTs,
       }),
@@ -766,6 +774,7 @@ async function sendMessageSlackQueuedInner(params: {
 
   const sentMessageIds: string[] = [];
   let lastMessageId = "";
+  let deliveredChannelId = channelId;
   if (opts.mediaUrl) {
     const [firstChunk, ...rest] = resolvedChunks;
     lastMessageId = await uploadSlackFile({
@@ -794,6 +803,7 @@ async function sendMessageSlackQueuedInner(params: {
         unfurl,
       });
       lastMessageId = response.ts ?? lastMessageId;
+      deliveredChannelId = resolvePostedMessageChannelId(response, deliveredChannelId);
       if (response.ts) {
         sentMessageIds.push(response.ts);
       }
@@ -811,6 +821,7 @@ async function sendMessageSlackQueuedInner(params: {
         unfurl,
       });
       lastMessageId = response.ts ?? lastMessageId;
+      deliveredChannelId = resolvePostedMessageChannelId(response, deliveredChannelId);
       if (response.ts) {
         sentMessageIds.push(response.ts);
       }
@@ -820,10 +831,10 @@ async function sendMessageSlackQueuedInner(params: {
   const messageId = lastMessageId || "unknown";
   return {
     messageId,
-    channelId,
+    channelId: deliveredChannelId,
     receipt: createSlackSendReceipt({
       platformMessageIds: sentMessageIds.length ? sentMessageIds : [messageId],
-      channelId,
+      channelId: deliveredChannelId,
       kind: opts.mediaUrl ? "media" : "text",
       threadTs: opts.threadTs,
     }),

--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -579,7 +579,7 @@ export type ChannelApprovalDeliveryAdapter = {
     cfg: OpenClawConfig;
     approvalKind: ChannelApprovalKind;
     target: ChannelApprovalForwardTarget;
-    request: ExecApprovalRequest;
+    request: ExecApprovalRequest | PluginApprovalRequest;
   }) => boolean;
 };
 export type ChannelApproveCommandBehavior =


### PR DESCRIPTION
## Summary

- deliver Slack native plugin approval events through the existing native approval runtime and Block Kit approval UI
- route Slack plugin approval DMs to plugin approvers from `allowFrom` / account defaults while keeping exec approval DMs on exec approvers
- align Slack plugin fallback suppression with kind-aware native deliverability, and document the Slack native approval behavior

## Verification

- `node scripts/run-vitest.mjs extensions/slack/src/approval-native.test.ts extensions/slack/src/approval-handler.runtime.test.ts extensions/slack/src/monitor/events/interactions.test.ts extensions/slack/src/monitor/provider.allowlist.test.ts extensions/slack/src/send.blocks.test.ts` passed: 5 files, 100 tests.
- `node scripts/run-vitest.mjs extensions/slack/src/approval-handler.runtime.test.ts` passed: 1 file, 7 tests, including the plugin approval actions `Allow Once`, `Allow Always`, and `Deny`.
- `node scripts/run-vitest.mjs extensions/qa-lab/src/codex-plugin-lifecycle.test.ts extensions/slack/src/approval-handler.runtime.test.ts` passed: 2 files, 16 tests.
- `git diff --check` passed.
- `uvx showboat verify .mem/main/proofs/demo-12-dev-slack-native-plugin-approval/raw/showboat-summary.md` passed.
- `node scripts/check-deadcode-unused-files.mjs` no longer reports the qa-lab Codex fixture files after renaming them to `*.fixture.ts`; the broader local run is still blocked by unrelated existing `extensions/openai-apps` unused-file findings.

## Real behavior proof

Behavior addressed: Slack native approval delivery now handles plugin approval request, resolved, and expired events instead of suppressing shared plugin fallback while subscribing only to exec events. The Slack send receipt also records the channel returned by Slack for DM/user-target sends so resolved approval updates can `chat.update` the delivered message.

Real environment tested: Local OpenClaw source checkout on branch `codex/slack-native-plugin-approval-events`, dev Slack profile, Slack socket mode connected to the configured workspace, `channels.slack.execApprovals.enabled: false`, and global `approvals.plugin` enabled with Slack as a plugin approval target.

Exact steps or command run after this patch: Started the dev gateway with the dev profile, asked the dev Codex agent `open 1 password with computer use`, captured plugin approval `plugin:b127fe77-b624-473e-b1ef-70a054098bdc`, resolved it through the gateway `plugin.approval.resolve` path, and verified the pending/resolved Slack messages plus gateway wait decision with `uvx showboat verify .mem/main/proofs/demo-12-dev-slack-native-plugin-approval/raw/showboat-summary.md`.

Evidence after fix: Showboat proof `.mem/main/proofs/demo-12-dev-slack-native-plugin-approval/raw/showboat-summary.md` passes and records: `PASS pending Slack message used action block`, `PASS pending Slack action labels`, `PASS pending Slack message omitted slash command fallback`, `PASS approval resolve succeeded`, `PASS resolved Slack message omitted slash command fallback`, `PASS resolved Slack message removed actions`, `PASS gateway waitDecision completed`, and `PASS latest gateway update had no message_not_found`. The local proof screenshot is `.mem/main/proofs/demo-12-dev-slack-native-plugin-approval/raw/slack-native-approval-pending-buttons-proof.png` and shows the native Slack buttons `Allow Once`, `Allow Always`, and `Deny` on the pending plugin approval card.

Observed result after fix: The plugin approval request delivered to Slack as native Block Kit UI while exec approvals were disabled, the old `Reply with: /approve <id>` fallback text was absent, the action labels were `Allow Once`, `Allow Always`, and `Deny`, resolving the approval completed `plugin.approval.waitDecision`, and Slack updated the existing approval message without `message_not_found`.

<img width="960" height="488" alt="CleanShot 2026-05-21 at 15 41 44@2x" src="https://github.com/user-attachments/assets/938dab0a-4fa6-459c-b0b9-f25aefc9e073" />
<img width="1034" height="546" alt="CleanShot 2026-05-21 at 15 42 16@2x" src="https://github.com/user-attachments/assets/557e962f-4451-4d29-8c06-be8291577456" />

