### PR TITLE
fix(channels): suppress verbose progress and tool summaries on default-mode channel rooms

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -6114,3 +6114,295 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     expect(firstFinalReplyPayload(dispatcher)?.text).toBe("final reply");
   });
 });
+
+describe("channel verbose-progress suppression (issue #85000)", () => {
+  it("suppresses text-only tool summaries on default-mode non-room_event Matrix channel turns", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "allow",
+    };
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      await opts?.onToolResult?.({ text: "🛠️ `pwd (agent)`" });
+      return { text: "final" } satisfies ReplyPayload;
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        Provider: "matrix",
+        Surface: "matrix",
+        ChatType: "channel",
+        SessionKey: "test:matrix:channel:R1",
+      }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
+    expect(result.queuedFinal).toBe(true);
+    expect(firstFinalReplyPayload(dispatcher)?.text).toBe("final");
+  });
+
+  it("preserves configured visibleReplies: message_tool opt-in for channel verbose progress", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "allow",
+      verboseLevel: "on",
+    };
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      await opts?.onToolResult?.({ text: "🛠️ `pwd (agent)`" });
+      return { text: "NO_REPLY" } satisfies ReplyPayload;
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        Provider: "matrix",
+        Surface: "matrix",
+        ChatType: "channel",
+        SessionKey: "test:matrix:channel:R1",
+      }),
+      cfg: {
+        messages: { groupChat: { visibleReplies: "message_tool" } },
+      } as OpenClawConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    expect(result.sourceReplyDeliveryMode).toBe("message_tool_only");
+    expect(dispatcher.sendToolResult).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "🛠️ `pwd (agent)`" }),
+    );
+  });
+
+  it("suppresses plan updates on default-mode Matrix channel turns even with verboseLevel: on", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "allow",
+      verboseLevel: "on",
+    };
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      await opts?.onPlanUpdate?.({ title: "do thing", steps: ["a", "b"] });
+      return { text: "final" } satisfies ReplyPayload;
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        Provider: "matrix",
+        Surface: "matrix",
+        ChatType: "channel",
+        SessionKey: "test:matrix:channel:R1",
+      }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
+    expect(result.queuedFinal).toBe(true);
+  });
+
+  it("suppresses tool summaries on default-mode Discord channel turns (non-room_event)", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "allow",
+    };
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      await opts?.onToolResult?.({ text: "🛠️ `pwd (agent)`" });
+      return { text: "final" } satisfies ReplyPayload;
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        Provider: "discord",
+        Surface: "discord",
+        ChatType: "channel",
+        SessionKey: "test:discord:channel:C1",
+      }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
+    expect(result.queuedFinal).toBe(true);
+  });
+
+  it("delivers final reply on default-mode Matrix channel turns (over-suppression guard)", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "allow",
+    };
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async () => ({ text: "final reply" }) satisfies ReplyPayload);
+
+    const result = await dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        Provider: "matrix",
+        Surface: "matrix",
+        ChatType: "channel",
+        SessionKey: "test:matrix:channel:R1",
+      }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+    expect(result.queuedFinal).toBe(true);
+    expect(firstFinalReplyPayload(dispatcher)?.text).toBe("final reply");
+  });
+
+  it("preserves media-only tool payload pass-through on default-mode Matrix channel turns", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "allow",
+    };
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      await opts?.onToolResult?.({ mediaUrl: "https://example.test/screen.png" });
+      return { text: "final" } satisfies ReplyPayload;
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        Provider: "matrix",
+        Surface: "matrix",
+        ChatType: "channel",
+        SessionKey: "test:matrix:channel:R1",
+      }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+    expect(dispatcher.sendToolResult).toHaveBeenCalledWith(
+      expect.objectContaining({ mediaUrl: "https://example.test/screen.png" }),
+    );
+    expect(result.queuedFinal).toBe(true);
+  });
+
+  it("preserves verbose progress on channel turns when IsForum is true", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "allow",
+      verboseLevel: "on",
+    };
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      await opts?.onToolResult?.({ text: "🛠️ `pwd (agent)`" });
+      return { text: "final" } satisfies ReplyPayload;
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        Provider: "matrix",
+        Surface: "matrix",
+        ChatType: "channel",
+        IsForum: true,
+        SessionKey: "test:matrix:channel:R1",
+      }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+    expect(dispatcher.sendToolResult).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "🛠️ `pwd (agent)`" }),
+    );
+    expect(result.queuedFinal).toBe(true);
+  });
+
+  it("keeps unauthorized text slash command tool summaries suppressed on channel turns", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "allow",
+      verboseLevel: "on",
+    };
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      await opts?.onToolResult?.({ text: "🛠️ `pwd (agent)`" });
+      return { text: "final" } satisfies ReplyPayload;
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        Provider: "matrix",
+        Surface: "matrix",
+        ChatType: "channel",
+        CommandSource: "text",
+        CommandAuthorized: false,
+        CommandBody: "/status",
+        SessionKey: "test:matrix:channel:R1",
+      }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    expect(result.sourceReplyDeliveryMode).toBe("message_tool_only");
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
+  });
+
+  it("suppresses tool summaries when explicit message_tool_only request falls back because message tool is denied", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "allow",
+      verboseLevel: "on",
+    };
+    const dispatcher = createDispatcher();
+    let resolverSawMode: string | undefined;
+    const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      resolverSawMode = opts?.sourceReplyDeliveryMode;
+      await opts?.onToolResult?.({ text: "🛠️ `pwd (agent)`" });
+      return { text: "final" } satisfies ReplyPayload;
+    });
+
+    await dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        Provider: "matrix",
+        Surface: "matrix",
+        ChatType: "channel",
+        SessionKey: "test:matrix:channel:R1",
+      }),
+      cfg: { tools: { allow: ["read"] } } as OpenClawConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: {
+        sourceReplyDeliveryMode: "message_tool_only",
+      },
+    });
+
+    // Resolver sees the fallback mode "automatic" because the message tool is not allowed.
+    // The carve-out's AND on resolved sourceReplyDeliveryMode === "message_tool_only"
+    // is false here, so verbose tool summaries are NOT delivered.
+    expect(resolverSawMode).toBe("automatic");
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
+  });
+});

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1227,8 +1227,28 @@ export async function dispatchReplyFromConfig(
 
     const isSlackNonDirectSurface =
       (ctx.Surface === "slack" || ctx.Provider === "slack") && ctx.ChatType !== "direct";
+    const isMultiParticipantChat = chatType === "group" || chatType === "channel";
+    // Carve out verbose tool progress on channel turns only when ALL of:
+    //   - resolved sourceReplyDeliveryMode is "message_tool_only" (proves the
+    //     message tool is actually available; if denied by tool policy the
+    //     resolver falls back to "automatic")
+    //   - the opt-in source is one of the legitimate paths (per-turn explicit
+    //     `params.replyOptions.sourceReplyDeliveryMode` per PR #80042, OR
+    //     configured `messages.groupChat.visibleReplies: "message_tool"`)
+    //     — NOT the unauthorized-text-slash-command suppression path that
+    //     also resolves to "message_tool_only"
+    //   - inbound event isn't a room_event (those have their own suppression
+    //     path and shouldn't be flagged as carrying explicit verbose tool
+    //     summaries in the reply_dispatch hook payload)
+    const isChannelExplicitMessageToolOptIn =
+      chatType === "channel" &&
+      ctx.InboundEventKind !== "room_event" &&
+      sourceReplyDeliveryMode === "message_tool_only" &&
+      (params.replyOptions?.sourceReplyDeliveryMode === "message_tool_only" ||
+        effectiveVisibleReplies === "message_tool");
     const shouldSendVerboseProgressMessages =
-      !isSlackNonDirectSurface && (ctx.ChatType !== "group" || ctx.IsForum === true);
+      !isSlackNonDirectSurface &&
+      (!isMultiParticipantChat || ctx.IsForum === true || isChannelExplicitMessageToolOptIn);
     const shouldSendToolSummaries = shouldSendVerboseProgressMessages;
     const shouldSendToolStartStatuses = false;
     const shouldDeliverVerboseProgressDespiteSourceSuppression = () =>


### PR DESCRIPTION
## Summary

- **Problem**: Default-mode `ChatType: "channel"` non-`room_event` turns on non-Slack surfaces (Matrix, Discord guild channels, Mattermost, MS Teams, Google Chat, WhatsApp newsletter, Synology Chat, ClickClack, Feishu, QA channel) received internal tool/progress events as visible chat messages.
- **Solution**: Extend the `shouldSendVerboseProgressMessages` predicate at `src/auto-reply/reply/dispatch-from-config.ts:1230` to treat `"channel"` the same as `"group"`, with a guard that preserves both legitimate opt-in paths.
- **What changed**: Inline predicate change in `dispatch-from-config.ts` (no new exported helper — matches the existing `group || channel` pattern in `completion-delivery-policy.ts:64` and `agent-runner-execution.ts:486`).
- **What did NOT change (scope boundary)**: Slack non-DM suppression (`isSlackNonDirectSurface` guard preserved); `IsForum: true` carve-out preserved; existing `room_event` suppression preserved; PR #80042's explicit `message_tool_only` opt-in preserved (test `:5211` stays green); configured `messages.groupChat.visibleReplies: "message_tool"` opt-in preserved.

## Motivation

Closes #85000. Privacy-sensitive: internal tool summaries can carry local file paths, command names, search terms, and operationally sensitive context. Reproduced on Matrix multi-person room with default automatic-delivery mode.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #85000
- Related #80042 (PR #80042's `message_tool_only` contract is preserved by the explicit opt-in path; test `:5211` stays green)
- Related #83498 (the 5/18 commit `1e5450f23e` that exposed this latent predicate gap in default operation)
- Related #69067 (the historical Slack-channel analogue; the carve-out predicate was introduced for it in commit `76a4c167f7e`)
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

Using exact `field: value` labels per AGENTS.md (also matches the PR template's `Behavior or issue addressed:`):

- **Behavior addressed**: default-mode Matrix channel tool/progress leakage per #85000. Reproduced on 2026-05-21 in a private Matrix multi-person room while a Matrix-bound agent did ordinary tool-heavy investigation work (file reads, search, patch apply) with no `params.replyOptions.sourceReplyDeliveryMode` and no `messages.groupChat.visibleReplies` override. The visible Matrix transcript showed internal tool summaries like `🛠️ print lines...`, `🛠️ search...`, `🩹 Apply Patch`, `🔌 Gateway: messages`.

- **Real environment tested**: OpenClaw gateway on macOS 14.7.6 (Darwin 23.6.0), Node 24, Matrix channel adapter bound to a private multi-person Matrix room on an internal Matrix homeserver. Effective ctx redacted snapshot: `ChatType: "channel"`, `InboundEventKind: "regular"` (non-`room_event`), no `params.replyOptions.sourceReplyDeliveryMode`, no `messages.groupChat.visibleReplies` override.

- **Exact steps or command run after this patch**:
  1. Built the branch with `pnpm build`.
  2. Restarted the gateway via `openclaw gateway restart` and verified live with `openclaw gateway status --deep`.
  3. From a session bound to the test Matrix room, triggered a tool-heavy operation (`qmd search` followed by a file read).
  4. Observed the Matrix client (Element) for visible chat messages.

- **Evidence after fix**: Production OpenClaw gateway was restarted at 2026-05-21 14:01 EDT (PID 3063) onto the fix dist (HEAD `2f2b7864f4`). Over the ~1 hour of post-restart Matrix activity, 4 Matrix-bound agent sessions executed tool calls internally (each session's `.jsonl` shows `toolCall` + `toolResult` entries), but the gateway sent only **3 outbound Matrix events** to the test room. **None of those 3 outbound events contained tool/progress markers** (`🛠️`, `🩹`, `🔌`, `Apply Patch`, `Gateway:`, `Exec:`, `tool_use_result`) — they were clean final replies. Pre-fix (yesterday in the same room), the same agent workflow produced the leaked `🛠️ print lines...`, `🛠️ search...`, `🩹 Apply Patch`, `🔌 Gateway: messages` chatter.

  Captured terminal output of the new test suite (9 cases under `channel verbose-progress suppression (issue #85000)`) shows all 9 cases plus the existing `:5211` and `:2243` guards passing:

```
 ✓ channel verbose-progress suppression (issue #85000) > suppresses text-only tool summaries on default-mode non-room_event Matrix channel turns
 ✓ channel verbose-progress suppression (issue #85000) > preserves configured visibleReplies: message_tool opt-in for channel verbose progress
 ✓ channel verbose-progress suppression (issue #85000) > suppresses plan updates on default-mode Matrix channel turns even with verboseLevel: on
 ✓ channel verbose-progress suppression (issue #85000) > suppresses tool summaries on default-mode Discord channel turns (non-room_event)
 ✓ channel verbose-progress suppression (issue #85000) > delivers final reply on default-mode Matrix channel turns (over-suppression guard)
 ✓ channel verbose-progress suppression (issue #85000) > preserves media-only tool payload pass-through on default-mode Matrix channel turns
 ✓ channel verbose-progress suppression (issue #85000) > preserves verbose progress on channel turns when IsForum is true
 ✓ channel verbose-progress suppression (issue #85000) > keeps unauthorized text slash command tool summaries suppressed on channel turns
 ✓ channel verbose-progress suppression (issue #85000) > suppresses tool summaries when explicit message_tool_only request falls back because message tool is denied

 Test Files  1 passed (1)
      Tests  141 passed (141)
```

- **Observed result after fix**: default-mode Matrix channel turns no longer deliver tool/progress events to the visible chat surface. Final assistant reply still delivers normally (verified with 3 clean outbound events post-restart). Explicit `params.replyOptions.sourceReplyDeliveryMode: "message_tool_only"` and configured `messages.groupChat.visibleReplies: "message_tool"` both continue to deliver verbose tool progress (PR #80042 contract preserved — locked by `dispatch-from-config.test.ts:5211`).

- **What was not tested**: separate live repro on the other source-suspect surfaces (Discord guild channels, Mattermost, MS Teams, Google Chat, WhatsApp newsletter, Synology Chat, ClickClack, Feishu, QA channel) — those are covered at the unit-test layer via the same predicate change. No live cross-surface repro performed.

- **Before evidence (optional but encouraged)**: pre-fix Matrix transcript captured 2026-05-20 in the same private Matrix room under identical session config (no `params.replyOptions.sourceReplyDeliveryMode`, no `messages.groupChat.visibleReplies` override) showed the leaked `🛠️ print lines...`, `🛠️ search...`, `🩹 Apply Patch`, `🔌 Gateway: messages` events as visible chat messages — confirming the issue reproduction. Room name and IDs redacted.

## Root Cause (if applicable)

- **Root cause**: The `shouldSendVerboseProgressMessages` predicate at `src/auto-reply/reply/dispatch-from-config.ts:1228-1232` was introduced in commit `76a4c167f7e` (2026-04-24, closing #69067) as a Slack-specific carve-out, with a single non-Slack carve-out for `ChatType === "group"`. Non-Slack `ChatType: "channel"` surfaces were not paired with `"group"` in this predicate, even though other call sites in the same file (`:253, 944, 948`) and sibling files (`source-reply-delivery-mode.ts:59, 65`; `completion-delivery-policy.ts:64`; `agent-runner-execution.ts:486`; `reply-threading.ts:23`; `get-reply-run.ts:109, 691`; `auto-reply/dispatch.ts:132`) already paired them correctly. The gap was visible-masked in default operation until commit `1e5450f23e` / PR #83498 (2026-05-18) removed the `prefersMessageToolDelivery` clause that had been auto-allowing the message tool for group/channel turns.

- **Missing detection / guardrail**: There was no unit test asserting non-Slack channel default-mode tool-progress suppression. Existing channel coverage was scoped to `room_event` (test `:2243`) and explicit `message_tool_only` (test `:5211`).

- **Contributing context (if known)**: #80042 (Discord verbose tool progress restoration) was specifically scoped to `message_tool_only` channel turns; its existence partly explains why the default-mode channel gap wasn't caught at that time.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file**: `src/auto-reply/reply/dispatch-from-config.test.ts` (9 new cases under describe `channel verbose-progress suppression (issue #85000)`).
- **Scenario the test should lock in**: default-mode non-`room_event` `ChatType: "channel"` turn on a non-Slack provider triggers `onToolResult({ text: "🛠️ ..." })` from the resolver; `dispatcher.sendToolResult` must NOT be called; final reply must still deliver.
- **Why this is the smallest reliable guardrail**: the unit test exercises `dispatchReplyFromConfig` end-to-end with the dispatcher mock, which is the closest layer to the user-visible behavior change. Any predicate regression here flips the dispatcher mock assertion directly.
- **Existing test that already covers this (if any)**: `:5211` (PR #80042 explicit-request path) and `:2243` (Discord `room_event` suppression) cover adjacent paths but not the default-mode channel default; this PR adds the missing default-mode guard.
- **If no new test is added, why not**: N/A; 9 new tests added.

## User-visible / Behavior Changes

- Default-mode multi-person channel rooms across non-Slack channel-class surfaces (Matrix, Discord guild channels, Mattermost channels, MS Teams channels, Google Chat groups, WhatsApp newsletter, Synology Chat, ClickClack, Feishu, QA channel) no longer receive internal tool/progress events.
- Both opt-in paths to verbose tool progress on channel turns are preserved: explicit per-turn `params.replyOptions.sourceReplyDeliveryMode: "message_tool_only"` (PR #80042) AND configured `messages.groupChat.visibleReplies: "message_tool"`. Both resolve to `sourceReplyDeliveryMode === "message_tool_only"`, which the new carve-out honors.
- Intentional asymmetry vs `group`: the configured-`message_tool` opt-in path applies to `channel` turns only, NOT `group` turns. Existing `group` behavior (suppress by default unless `IsForum: true`) is unchanged.
- Forum turns unchanged.
- Downstream effect: `hasVisibleRegularVerboseToolProgress` becomes `false` for default-mode channel turns, so the existing auto-suppression of tool error warnings on the assumption that verbose progress is visible no longer applies in that case. Aligned with the suppression intent.

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No** (privacy improvement only — restricts what's projected to visible chat surfaces)

## Repro + Verification

### Environment

- OS: macOS 14.7.6 (Darwin 23.6.0)
- Runtime/container: Node 24
- Model/provider: not load-bearing for this bug; observed across mixed models
- Integration/channel (if any): Matrix
- Relevant config (redacted): Matrix channel adapter bound to a private multi-person room; default `messages.visibleReplies` (no override); no `params.replyOptions.sourceReplyDeliveryMode` per turn

### Steps

1. Configure OpenClaw gateway with the Matrix channel adapter bound to a multi-person Matrix room (not a DM).
2. Bind an agent session to that room (non-`room_event` inbound).
3. Trigger any tool-heavy operation (search, file read, patch apply, exec) in default-mode delivery.

### Expected

- After fix: no tool/progress chat messages in the Matrix room; final assistant reply delivers normally.
- Before fix: visible `🛠️` / `🩹` / `🔌` progress messages appear in the room.

### Actual

- After fix: matches expected (room is clean of tool/progress chatter; final reply delivers).
- Before fix: matches expected (leak observed).

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- **Verified scenarios**: default-mode Matrix channel tool/progress suppression (live + unit); explicit `message_tool_only` still delivers verbose progress (existing `:5211` stays green); final reply still delivers in default-mode channel.
- **Edge cases checked**: media-only tool payloads still pass; exec-approval payloads still pass; `room_event` suppression continues (existing `:2243` stays green); forum-topic (`IsForum: true`) verbose progress continues; unauthorized text slash commands stay suppressed (their resolved `message_tool_only` is now NOT carved out); message-tool-denied fallback stays suppressed (resolved falls back to `"automatic"`).
- **What you did NOT verify**: separate live repro on each of Discord guild channels, Mattermost, MS Teams, Google Chat, WhatsApp newsletter, Synology Chat, ClickClack, Feishu, QA channel — those are covered at the unit-test layer via the shared predicate change.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**

## Risks and Mitigations

- **Risk**: regressing PR #80042 (test `:5211` expects `ChatType: "channel"` + explicit `message_tool_only` + `verboseLevel: "on"` to deliver verbose tool progress).
  - **Mitigation**: explicit-opt-in carve-out keyed on `params.replyOptions.sourceReplyDeliveryMode === "message_tool_only"`; existing test `:5211` continues to pass and the new test #2 explicitly locks in the configured-opt-in lane.
- **Risk**: re-exposing the unauthorized-text-slash-command suppression path (which also resolves to `"message_tool_only"` per `source-reply-delivery-mode.ts:56`).
  - **Mitigation**: the carve-out requires the opt-in source to be one of the legitimate paths (explicit `params.replyOptions` OR configured `effectiveVisibleReplies === "message_tool"`), not the resolved variable alone. Test #8 locks in the unauthorized-command suppression.
- **Risk**: tool summaries delivered when the user's `message_tool_only` request can't be honored (message tool denied by policy → resolved falls back to `"automatic"`).
  - **Mitigation**: the carve-out also requires resolved `sourceReplyDeliveryMode === "message_tool_only"`. Test #9 locks in this fallback path.

---

### Changelog handling

Per CONTRIBUTING, this PR does not edit `CHANGELOG.md`; maintainer or ClawSweeper will add the changelog entry on landing.

---

### Related work

PR #85357 ("Fix heartbeat message-tool delivery policy") merged 2026-05-22 and closes the Discord-side sibling issue #85310, which was filed as the "same class on Matrix: #85000". The two PRs are **complementary, not overlapping**:

| | #85357 (merged) | This PR (#85069) |
|---|---|---|
| **Scope** | Heartbeat scheduled-turn entry path | Default-automatic delivery on multi-person channel rooms |
| **Files** | `src/infra/heartbeat-runner.{ts,*.test.ts}`, `src/infra/outbound/targets.ts` | `src/auto-reply/reply/dispatch-from-config.{ts,test.ts}` |
| **Predicate fix** | Selects `sourceReplyDeliveryMode: "message_tool_only"` correctly at entry | Suppresses tool/progress events at dispatch when no `message_tool_only` opt-in and no `verboseLevel: "on"` |
| **Approach** | "reuses existing runtime policy resolution and existing dispatch suppression rather than adding channel-specific string filtering" | Same principle — single dispatch-layer predicate, surface-agnostic |

No file overlap; no merge conflict. Issue #85000 (Matrix) remains open after #85357 merged; this PR closes it.

### AI-assisted PR

- [x] Built with **Claude Code** (Opus 4.7) + iterative local **Codex** peer review on the plan (9 codex passes to APPROVE) and the committed diff (1 codex pass: "No actionable regressions were identified in the diff").
- [x] `codex review --base upstream/main` run locally; no actionable findings.
- Human verified on production-grade environment (Mercury OpenClaw gateway on macOS, Matrix channel adapter).
- Resolved/replied to bot review conversations per CONTRIBUTING.

