### PR TITLE
fix(gemini): strip sub-second precision from web_search time_range_filter

### DIFF
--- a/extensions/google/src/gemini-web-search-provider.runtime.ts
+++ b/extensions/google/src/gemini-web-search-provider.runtime.ts
@@ -75,6 +75,16 @@ const GEMINI_FRESHNESS_DAYS: Record<GeminiFreshness, number> = {
   year: 365,
 };
 
+// Gemini's google_search.time_range_filter accepts second-precision RFC 3339
+// only. Despite the underlying google.protobuf.Timestamp type accepting "0, 3,
+// 6 or 9 fractional digits", the Search grounding endpoint rejects any
+// non-zero fractional component with
+//   "[FIELD_INVALID] Granularity of nano is not supported".
+// Strip the fractional-second component before serializing.
+function toGeminiTimeRangeTimestamp(date: Date): string {
+  return date.toISOString().replace(/\.\d+Z$/, "Z");
+}
+
 function isoDateStart(value: string): string {
   return `${value}T00:00:00Z`;
 }
@@ -82,13 +92,13 @@ function isoDateStart(value: string): string {
 function isoDateExclusiveEnd(value: string): string {
   const end = new Date(`${value}T00:00:00Z`);
   end.setUTCDate(end.getUTCDate() + 1);
-  return end.toISOString();
+  return toGeminiTimeRangeTimestamp(end);
 }
 
 function freshnessStartTime(freshness: GeminiFreshness, now: Date): string {
   const start = new Date(now);
   start.setUTCDate(start.getUTCDate() - GEMINI_FRESHNESS_DAYS[freshness]);
-  return start.toISOString();
+  return toGeminiTimeRangeTimestamp(start);
 }
 
 function resolveGeminiTimeRangeFilter(
@@ -143,7 +153,7 @@ function resolveGeminiTimeRangeFilter(
     return {
       timeRangeFilter: {
         startTime: freshnessStartTime(freshness, now),
-        endTime: now.toISOString(),
+        endTime: toGeminiTimeRangeTimestamp(now),
       },
     };
   }
@@ -156,7 +166,7 @@ function resolveGeminiTimeRangeFilter(
   return {
     timeRangeFilter: {
       startTime: dateAfter ? isoDateStart(dateAfter) : "1970-01-01T00:00:00Z",
-      endTime: dateBefore ? isoDateExclusiveEnd(dateBefore) : now.toISOString(),
+      endTime: dateBefore ? isoDateExclusiveEnd(dateBefore) : toGeminiTimeRangeTimestamp(now),
     },
   };
 }

--- a/extensions/google/web-search-provider.test.ts
+++ b/extensions/google/web-search-provider.test.ts
@@ -402,7 +402,9 @@ describe("google web search provider", () => {
 
   it("passes freshness to Gemini Google Search grounding as a time range", async () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-04-15T12:00:00Z"));
+    // Use a wall-clock-realistic moment with non-zero milliseconds; the helper
+    // must strip them to avoid Gemini's "Granularity of nano is not supported".
+    vi.setSystemTime(new Date("2026-04-15T12:00:00.123Z"));
     const mockFetch = installGeminiFetch();
     const provider = createGeminiWebSearchProvider();
     const tool = provider.createTool({

--- a/extensions/google/web-search-provider.test.ts
+++ b/extensions/google/web-search-provider.test.ts
@@ -426,8 +426,47 @@ describe("google web search provider", () => {
 
     const body = parseGeminiFetchBody(mockFetch);
     expect(body.tools?.[0]?.google_search?.timeRangeFilter).toEqual({
-      startTime: "2026-04-08T12:00:00.000Z",
-      endTime: "2026-04-15T12:00:00.000Z",
+      startTime: "2026-04-08T12:00:00Z",
+      endTime: "2026-04-15T12:00:00Z",
+    });
+  });
+
+  it("strips sub-second precision from freshness timestamps so Gemini accepts them", async () => {
+    vi.useFakeTimers();
+    // "now" with non-zero milliseconds. Without stripping, toISOString() emits
+    // "2026-04-15T12:00:00.123Z", which Gemini's google_search.time_range_filter
+    // rejects with "Granularity of nano is not supported".
+    vi.setSystemTime(new Date("2026-04-15T12:00:00.123Z"));
+    const mockFetch = installGeminiFetch();
+    const provider = createGeminiWebSearchProvider();
+    const tool = provider.createTool({
+      config: {
+        plugins: {
+          entries: {
+            google: {
+              config: {
+                webSearch: {
+                  apiKey: "AIza-plugin-test",
+                },
+              },
+            },
+          },
+        },
+      },
+      searchConfig: { provider: "gemini" },
+    });
+
+    await tool?.execute({ query: "latest ai news", freshness: "week" });
+
+    const body = parseGeminiFetchBody(mockFetch);
+    const filter = body.tools?.[0]?.google_search?.timeRangeFilter as
+      | { startTime: string; endTime: string }
+      | undefined;
+    expect(filter?.startTime).not.toMatch(/\.\d+Z$/);
+    expect(filter?.endTime).not.toMatch(/\.\d+Z$/);
+    expect(filter).toEqual({
+      startTime: "2026-04-08T12:00:00Z",
+      endTime: "2026-04-15T12:00:00Z",
     });
   });
 
@@ -460,7 +499,7 @@ describe("google web search provider", () => {
     const body = parseGeminiFetchBody(mockFetch);
     expect(body.tools?.[0]?.google_search?.timeRangeFilter).toEqual({
       startTime: "2026-04-01T00:00:00Z",
-      endTime: "2026-05-01T00:00:00.000Z",
+      endTime: "2026-05-01T00:00:00Z",
     });
   });
 


### PR DESCRIPTION
> **AI-assisted PR** — Authored with Claude Opus 4.7 (Anthropic) as a coding agent. Human author reviewed every change, ran the empirical Gemini REST verification personally, and confirms the source change matches the intent.

Fixes: https://github.com/openclaw/openclaw/issues/85061

## Summary

- **Problem:** Every Gemini `web_search` call with `freshness` (and any `date_after`/`date_before` call hitting the `now` fallback for `endTime`) fails with `Gemini API error (400): [FIELD_INVALID] Granularity of nano is not supported`. Introduced by the original fix shipped for #66498 in v2026.5.19.
- **Solution:** Strip the fractional-second component from every timestamp emitted to `google_search.time_range_filter`, via a single helper.
- **What changed:** `extensions/google/src/gemini-web-search-provider.runtime.ts` (one new helper, four call sites). `extensions/google/web-search-provider.test.ts` (two existing test expectations updated; one new dedicated regression test; existing freshness test's fake clock bumped to a realistic non-zero-ms moment).
- **What did NOT change (scope boundary):** No behavior change for `query`, `maxResults`, `country`, `language`, `date_after`/`date_before` parsing, cache keys, citation handling, or any non-Gemini provider. CHANGELOG.md is not edited per contributor rules.

## Motivation

`web_search` with `freshness` is documented as supported on Gemini but unusable end-to-end on the published v2026.5.19. Agents see the 400, retry without `freshness`, succeed — costing ~14s and one wasted grounding quota per affected call. Worse, the documented capability (`freshness: "year"` etc.) is functionally dead. This blocks any agent flow that wants time-bounded grounded search on Gemini, which is the keyless/cheapest API-backed search path for Tier 1 users.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #85061
- Related #66498 (original feature; the helper introduced here completes its intent)
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed:** Gemini-backed `web_search` returns 400 on every call that includes a `freshness` value, despite docs marking it as supported.
- **Real environment tested:** v2026.5.19 gateway in `ghcr.io/openclaw/openclaw:2026.5.19` Docker image, GEMINI_API_KEY on Google AI Studio paid Tier 1. Tested by `curl` directly from inside the running gateway container against `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent`.
- **Exact steps or command run after this patch:** The gateway loads from `/app/dist`; running the curl below from inside the running container exercises the same request shape the patched code emits — `Z`-form vs the previous `.ms`-form.
  ```bash
  docker exec openclaw-gateway sh -c '
    call() {
      curl -sS -X POST "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent" \
        -H "Content-Type: application/json" -H "x-goog-api-key: $GEMINI_API_KEY" \
        -d "{\"contents\":[{\"role\":\"user\",\"parts\":[{\"text\":\"What is one current news headline today?\"}]}],\"tools\":[{\"google_search\":{\"time_range_filter\":{\"start_time\":\"$1\",\"end_time\":\"$2\"}}}]}"
    }
    call "2025-05-21T17:30:45.123Z"    "2026-05-21T17:30:45.456Z"   # ms precision (pre-patch shape)
    call "2025-05-21T17:30:45.000Z"    "2026-05-21T17:30:45.000Z"   # all-zero fractional
    call "2025-05-21T17:30:45Z"        "2026-05-21T17:30:45Z"       # no fractional (post-patch shape)
    call "2025-05-21T17:30:45.123456Z" "2026-05-21T17:30:45.456789Z" # microsecond precision
  '
  ```
- **Evidence after fix:** Terminal output from the `curl` matrix above (live `docker exec` against the running gateway, hitting the Gemini REST endpoint), redacted to the four shapes that matter:
  ```
  ms precision (.123Z) :  ERROR 400  [FIELD_INVALID] Granularity of nano is not supported
  all-zero fractional  :  OK candidates=1 grounded=True
  no fractional (Z)    :  OK candidates=1 grounded=True       ← shape emitted post-patch
  microsecond (.μsZ)   :  ERROR 400  [FIELD_INVALID] Granularity of nano is not supported
  ```
  Also verified end-to-end against a real agent: with the unpatched runtime, every `freshness:"year"` tool call from a chat in the Control UI returned the 400; the agent then retried without `freshness` and the second call succeeded with grounded content. Console output captured in #85061's body.
- **Observed result after fix:** The two failing shapes (any non-zero fractional second) never get emitted; the wire format becomes the `Z` form (or `.000Z` in the date-range path, both of which Gemini accepts).
- **What was not tested:** `pnpm build && pnpm check && pnpm test` — the Mac that ran this work has no Node/pnpm toolchain installed locally, and the production Docker image ships runtime deps only (not dev-only deps like `openclaw/plugin-sdk/test-env`). I did not stand up a full dev environment for this one-line change; CI will execute the full lanes on PR open. I also did not run `codex review --base origin/main` (no Codex access locally). The TypeScript change was reviewed by hand against the surrounding code style.
- **Before evidence:** ms-precision row in the matrix above shows the unpatched failure mode; the agent transcript on #85061 is the same failure from the user-facing path.

## Root Cause (if applicable)

- **Root cause:** `Date.prototype.toISOString()` always emits millisecond precision (e.g. `2026-05-20T17:30:45.123Z`). The Gemini Search grounding endpoint rejects any non-zero fractional component on `google_search.time_range_filter.start_time` / `end_time` with `[FIELD_INVALID] Granularity of nano is not supported`. The underlying `google.protobuf.Timestamp` type's public spec explicitly states it accepts "0, 3, 6 or 9 fractional digits" on input — so a developer reading the type contract would reasonably assume `.123Z` is valid. The grounding endpoint enforces a stricter rule than the type contract, and that constraint is undocumented at the field level.
- **Missing detection / guardrail:** The original CI test for freshness used `vi.setSystemTime(new Date("2026-04-15T12:00:00Z"))` — a moment with zero fractional seconds. `toISOString()` against that moment produces `"...T12:00:00.000Z"`, which is the *one* fractional form Gemini happens to accept (verified above). Wall-clock `new Date()` in production essentially never lands on an exact millisecond boundary, so production always hits a rejecting form. The test was format-correct against the mock but did not exercise a realistic wall-clock value.
- **Contributing context (if known):** The closing comment on #66498 noted a "live Gemini REST smoke" that "returned grounded content and citations." Plausibly that smoke went through the `date_after`/`date_before` path, where `isoDateStart` (no fraction) and `isoDateExclusiveEnd` (always-zero fractional from date arithmetic) both happen to avoid the rejecting form. The `freshness` path with real wall-clock time appears to have only been validated through the unit test that masked the bug.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file:** `extensions/google/web-search-provider.test.ts`
- **Scenario the test should lock in:** When `now` has any non-zero millisecond component, `google_search.time_range_filter.startTime` and `endTime` must not contain a fractional-second suffix.
- **Why this is the smallest reliable guardrail:** The bug is purely in the serialization of `Date` → RFC 3339 string. A unit test that fixes a realistic non-zero-ms fake time and asserts the emitted timestamps don't match `/\.\d+Z$/` is deterministic, fast, and provably catches the regression. No network or live API needed.
- **Existing test that already covers this:** None. The pre-existing freshness test used a zero-ms fake clock.
- **If no new test is added, why not:** N/A — a new test is added in this PR (`strips sub-second precision from freshness timestamps so Gemini accepts them`).

## User-visible / Behavior Changes

For end users: `web_search` with `freshness` (and `date_after`/`date_before` calls that hit the `now` fallback) now succeed against the live Gemini API. The shape of `google_search.time_range_filter` over the wire changes from `"...T12:00:00.000Z"` to `"...T12:00:00Z"` for date-range paths and from `"...T12:00:00.123Z"` to `"...T12:00:00Z"` for freshness/now paths. No config or API surface changes.

## Diagram (if applicable)

```text
Before:
  freshness: "year" → toISOString() → "2026-05-20T17:30:45.123Z"
                                    → Gemini 400 (Granularity of nano)
                                    → agent retries w/o freshness → succeeds (~14s lost)

After:
  freshness: "year" → toISOString().replace(/\.\d+Z$/, "Z")
                    → "2026-05-20T17:30:45Z"
                    → Gemini 200, grounded content + citations
```

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No** (same endpoint, same auth, same shape minus the fractional seconds)
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS 15 (Darwin 25.5.0)
- Runtime/container: Docker image `ghcr.io/openclaw/openclaw:2026.5.19`
- Model/provider: `gemini-2.5-flash` via Google AI Studio paid Tier 1, GEMINI_API_KEY in env
- Integration/channel: Web Control UI + Telegram both observed
- Relevant config (redacted): `tools.web.search.provider = "gemini"`, `GEMINI_API_KEY` from `~/secrets/openclaw_compose.env`, no plugin-level `google.config.webSearch.model` override (defaults to `gemini-2.5-flash`)

### Steps

1. Run gateway 2026.5.19 with Gemini configured as the web_search provider and a valid `GEMINI_API_KEY`.
2. Issue any `web_search` with a non-null `freshness` value (e.g. via `openclaw infer web search` with `--freshness year` if you wire that CLI option through, or any agent that passes `freshness` through the tool surface).
3. Observe Gemini 400 response.

### Expected

`web_search` returns grounded content + citations bounded to the freshness window.

### Actual (pre-patch)

`Gemini API error (400): * GenerateContentRequest.tools[0].google_search.time_range_filter: [FIELD_INVALID] Granularity of nano is not supported [code=INVALID_ARGUMENT]`

## Evidence

- [x] Failing test/log before + passing after (matrix in "Real behavior proof"; agent transcript on #85061)
- [x] Trace/log snippets (above)
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- **Verified scenarios:** The human author personally observed the 400 from a Travel Buddy agent chat in the Control UI before the fix; personally ran the four-shape curl matrix against live Gemini from inside the gateway container; personally read the diff against the surrounding code style.
- **Edge cases checked:** `.000Z` (all-zero fractional) explicitly tested and confirmed Gemini accepts it — this is why `isoDateExclusiveEnd` does not strictly need the helper today; routing it through anyway keeps the contract uniform and prevents future regression if date arithmetic ever changes.
- **What was not verified:** `pnpm build && pnpm check && pnpm test` locally (no Node toolchain on the author's Mac; the production Docker image ships runtime deps only and lacks dev-only test packages). `codex review --base origin/main` was not run locally (no Codex access). Both are deferred to CI / GitHub Codex review.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? **Yes** (the wire change is silently more conservative; previously-passing calls continue to pass, previously-failing calls start passing)
- Config/env changes? **No**
- Migration needed? **No**

## Risks and Mitigations

- **Risk:** Gemini changes its grounding endpoint to *require* fractional digits in the future, breaking the now-stripped form.
  - **Mitigation:** Low probability — the underlying `Timestamp` type accepts both forms and Google's REST conventions favor lenient parsing. If it does happen, the helper is the single point to update.
- **Risk:** Date-range paths that today emit `.000Z` now emit `Z` instead. Cache-key contributions include `startTime`/`endTime`, so existing cached entries against the same query will not be cache-hit after this lands (one-time cache miss per cached entry).
  - **Mitigation:** Acceptable — the cache TTL is bounded and the next call backfills with the new key format.
