### PR TITLE
fix(codex): disable native shell for node exec sessions

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -799,6 +799,44 @@ describe("runCodexAppServerAttempt", () => {
     expect(dockerTools.map((tool) => tool.name)).toEqual(["message"]);
   });
 
+  it("keeps OpenClaw shell tools for node-targeted Codex app-server runs", async () => {
+    testing.setOpenClawCodingToolsFactoryForTests(() => [
+      createRuntimeDynamicTool("exec"),
+      createRuntimeDynamicTool("process"),
+      createRuntimeDynamicTool("message"),
+    ]);
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(sessionFile, workspaceDir);
+    params.disableTools = false;
+    params.runtimePlan = createCodexRuntimePlanFixture();
+    params.execOverrides = {
+      host: "node",
+      node: "mac-mini",
+      security: "full",
+      ask: "off",
+    };
+    const sandboxSessionKey = params.sessionKey;
+    if (!sandboxSessionKey) {
+      throw new Error("createParams must provide a sessionKey for Codex dynamic tool tests.");
+    }
+
+    const tools = await testing.buildDynamicTools({
+      params,
+      resolvedWorkspace: workspaceDir,
+      effectiveWorkspace: workspaceDir,
+      sandboxSessionKey,
+      sandbox: { enabled: false, backendId: "docker" } as never,
+      nativeToolSurfaceEnabled: false,
+      runAbortController: new AbortController(),
+      sessionAgentId: "main",
+      pluginConfig: {},
+      onYieldDetected: () => undefined,
+    });
+
+    expect(tools.map((tool) => tool.name)).toEqual(["message", "exec", "process"]);
+  });
+
   it("exposes Docker sandbox shell tools when native Code Mode cannot honor sandbox paths", async () => {
     testing.setOpenClawCodingToolsFactoryForTests(() => [
       createRuntimeDynamicTool("exec"),
@@ -944,8 +982,11 @@ describe("runCodexAppServerAttempt", () => {
       details: { status: "running" },
     });
     const processTool = createRuntimeDynamicTool("process");
+    const workspaceDir = path.join(tempDir, "workspace");
     const tools = testing.addSandboxShellDynamicToolsIfAvailable([], [execTool, processTool], {
+      params: createParams(path.join(tempDir, "session.jsonl"), workspaceDir),
       sandbox: { enabled: true, backendId: "ssh" },
+      sessionAgentId: "main",
       pluginConfig: {},
     } as never);
 
@@ -1345,6 +1386,44 @@ describe("runCodexAppServerAttempt", () => {
 
     params.toolsAllow = ["message"];
     expect(testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
+  });
+
+  it("disables Codex native tool surface when session exec target is node", () => {
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
+    params.disableTools = false;
+    params.execOverrides = {
+      host: "node",
+      node: "mac-mini",
+      security: "full",
+      ask: "off",
+    };
+
+    expect(testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
+
+    params.toolsAllow = ["*"];
+    expect(testing.shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
+  });
+
+  it("disables Codex native tool surface when configured exec target is node", () => {
+    const workspaceDir = path.join(tempDir, "workspace");
+    const globalParams = createParams(path.join(tempDir, "global-session.jsonl"), workspaceDir);
+    globalParams.disableTools = false;
+    globalParams.config = { tools: { exec: { host: "node" } } } as never;
+
+    expect(testing.shouldEnableCodexAppServerNativeToolSurface(globalParams)).toBe(false);
+
+    const agentParams = createParams(path.join(tempDir, "agent-session.jsonl"), workspaceDir);
+    agentParams.disableTools = false;
+    agentParams.config = {
+      agents: {
+        list: [{ id: "main", tools: { exec: { host: "node" } } }],
+      },
+    } as never;
+
+    expect(
+      testing.shouldEnableCodexAppServerNativeToolSurface(agentParams, undefined, "main"),
+    ).toBe(false);
   });
 
   it("disables Codex native tool surfaces when Docker bind targets need container paths", () => {

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -48,7 +48,11 @@ import {
   type NativeHookRelayEvent,
   type NativeHookRelayRegistrationHandle,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
-import { markAuthProfileBlockedUntil, resolveAgentDir } from "openclaw/plugin-sdk/agent-runtime";
+import {
+  markAuthProfileBlockedUntil,
+  resolveAgentConfig,
+  resolveAgentDir,
+} from "openclaw/plugin-sdk/agent-runtime";
 import {
   emitTrustedDiagnosticEvent,
   hasPendingInternalDiagnosticEvent,
@@ -921,7 +925,11 @@ export async function runCodexAppServerAttempt(
     disableTools: params.disableTools,
     toolsAllow: params.toolsAllow,
   });
-  const nativeToolSurfaceEnabled = shouldEnableCodexAppServerNativeToolSurface(params, sandbox);
+  const nativeToolSurfaceEnabled = shouldEnableCodexAppServerNativeToolSurface(
+    params,
+    sandbox,
+    sessionAgentId,
+  );
   for (const diagnostic of bundleMcpThreadConfig.diagnostics) {
     embeddedAgentLog.warn(`bundle-mcp: ${diagnostic.pluginId}: ${diagnostic.message}`);
   }
@@ -3394,8 +3402,12 @@ async function buildDynamicTools(input: DynamicToolBuildParams) {
       input.runAbortController.abort("sessions_yield");
     },
   });
-  const codexFilteredTools = addSandboxShellDynamicToolsIfAvailable(
-    filterCodexDynamicTools(allTools, input.pluginConfig),
+  const codexFilteredTools = addNodeShellDynamicToolsIfNeeded(
+    addSandboxShellDynamicToolsIfAvailable(
+      filterCodexDynamicTools(allTools, input.pluginConfig),
+      allTools,
+      input,
+    ),
     allTools,
     input,
   );
@@ -3439,7 +3451,11 @@ function includeForcedMessageToolAllow(
 function shouldEnableCodexAppServerNativeToolSurface(
   params: EmbeddedRunAttemptParams,
   sandbox?: OpenClawSandboxContext,
+  agentId?: string,
 ): boolean {
+  if (isEffectiveExecHostNode(params, agentId)) {
+    return false;
+  }
   const toolsAllow = includeForcedMessageToolAllow(params.toolsAllow, params);
   if (toolsAllow === undefined) {
     return canCodexAppServerNativeToolSurfaceHonorSandbox(sandbox);
@@ -3450,6 +3466,14 @@ function shouldEnableCodexAppServerNativeToolSurface(
   return (
     hasWildcardCodexToolsAllow(toolsAllow) &&
     canCodexAppServerNativeToolSurfaceHonorSandbox(sandbox)
+  );
+}
+
+function isEffectiveExecHostNode(params: EmbeddedRunAttemptParams, agentId?: string): boolean {
+  const agentExec =
+    params.config && agentId ? resolveAgentConfig(params.config, agentId)?.tools?.exec : undefined;
+  return (
+    (params.execOverrides?.host ?? agentExec?.host ?? params.config?.tools?.exec?.host) === "node"
   );
 }
 
@@ -3526,20 +3550,53 @@ function addSandboxShellDynamicToolsIfAvailable(
 }
 
 function shouldExposeSandboxExecDynamicTool(input: DynamicToolBuildParams): boolean {
+  if (isEffectiveExecHostNode(input.params, input.sessionAgentId)) {
+    return false;
+  }
   const backendId = input.sandbox?.enabled ? input.sandbox.backendId.trim().toLowerCase() : "";
   return Boolean(backendId && (backendId !== "docker" || input.nativeToolSurfaceEnabled === false));
 }
 
-function isSandboxShellDynamicToolExcluded(config: CodexPluginConfig): boolean {
+function isCodexDynamicToolExcluded(config: CodexPluginConfig, names: string[]): boolean {
+  const normalizedNames = new Set(names.map((name) => normalizeCodexDynamicToolName(name)));
   return (config.codexDynamicToolsExclude ?? []).some((name) => {
     const normalized = normalizeCodexDynamicToolName(name);
-    return (
-      normalized === "exec" ||
-      normalized === "sandbox_exec" ||
-      normalized === "process" ||
-      normalized === "sandbox_process"
-    );
+    return normalizedNames.has(normalized);
   });
+}
+
+function isSandboxShellDynamicToolExcluded(config: CodexPluginConfig): boolean {
+  return isCodexDynamicToolExcluded(config, ["exec", "sandbox_exec", "process", "sandbox_process"]);
+}
+
+function addNodeShellDynamicToolsIfNeeded(
+  filteredTools: OpenClawDynamicTool[],
+  allTools: OpenClawDynamicTool[],
+  input: DynamicToolBuildParams,
+): OpenClawDynamicTool[] {
+  if (!isEffectiveExecHostNode(input.params, input.sessionAgentId)) {
+    return filteredTools;
+  }
+  let next = filteredTools;
+  for (const toolName of ["exec", "process"]) {
+    if (isCodexDynamicToolExcluded(input.pluginConfig, [toolName])) {
+      continue;
+    }
+    if (next.some((tool) => normalizeCodexDynamicToolName(tool.name) === toolName)) {
+      continue;
+    }
+    const tool = allTools.find(
+      (candidate) => normalizeCodexDynamicToolName(candidate.name) === toolName,
+    );
+    if (!tool) {
+      continue;
+    }
+    if (next === filteredTools) {
+      next = [...filteredTools];
+    }
+    next.push(tool);
+  }
+  return next;
 }
 
 function filterCodexDynamicToolsForAllowlist<T extends { name: string }>(


### PR DESCRIPTION
## Summary

  - Problem: Codex app-server native code mode could expose a native shell that runs on the gateway/container even when OpenClaw exec was targeted at
  `host=node`.
  - Solution: Disable Codex native tool surface when the effective exec host is `node`, and preserve the OpenClaw dynamic `exec`/`process` tools so node
  routing still works.
  - What changed: Updated `extensions/codex/src/app-server/run-attempt.ts` and added focused coverage in `extensions/codex/src/app-server/run-
  attempt.test.ts`.
  - What did NOT change (scope boundary): No changes to node-host execution internals, approval policy, docs, changelog, gateway protocol, or non-Codex
  plugins.

  ## Motivation

  - Fixes a real routing failure where `/exec host=node` in Codex app-server sessions could silently use the wrong shell surface instead of the selected
  node-host path.

  ## Change Type (select all)

  - [x] Bug fix
  - [ ] Feature
  - [ ] Refactor required for the fix
  - [ ] Docs
  - [ ] Security hardening
  - [ ] Chore/infra

  ## Scope (select all touched areas)

  - [ ] Gateway / orchestration
  - [x] Skills / tool execution
  - [ ] Auth / tokens
  - [ ] Memory / storage
  - [x] Integrations
  - [ ] API / contracts
  - [ ] UI / DX
  - [ ] CI/CD / infra

  ## Linked Issue/PR

  - Closes #85012
  - Related #
  - [x] This PR fixes a bug or regression

  ## Real behavior proof (required for external PRs)

  - Behavior or issue addressed: Codex app-server sessions with `exec.host=node` should not expose the native Codex shell surface that runs on the
  gateway/container; they should keep the OpenClaw dynamic shell tools that honor node routing.
  - Real environment tested: Local macOS/Darwin source checkout with the repo’s Node/pnpm toolchain.
  - Exact steps or command run after this patch:
    - `node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts -t "node-targeted Codex app-server runs|configured exec target is
  node|session exec target is node"`
    - `node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts`
    - `pnpm build`
    - `pnpm check:changed`
    - `.agents/skills/autoreview/scripts/autoreview --mode auto`
  - Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Local
  terminal output showed the focused tests passing, the full affected test file passing with `189 passed`, `pnpm build` completing successfully, `pnpm
  check:changed` completing successfully, and autoreview reporting no actionable findings.
  - Observed result after fix: Node-targeted Codex app-server runs disable native code mode and retain OpenClaw dynamic `exec`/`process`; config-default
  `tools.exec.host=node` is also covered.
  - What was not tested: A live multi-node setup with a Linux gateway/container and connected macOS node was not run from this local environment.
  - Before evidence (optional but encouraged): Issue #85012 reports the before behavior.

  ## Root Cause (if applicable)

  - Root cause: Codex app-server native tool gating did not consider the effective OpenClaw exec host, so node-targeted sessions could still enable Codex
  native shell/file tooling.
  - Missing detection / guardrail: Tests covered restricted allowlists and Docker sandbox compatibility, but not node-targeted exec sessions.
  - Contributing context (if known): The OpenClaw dynamic `exec` path already had node routing; the gap was selecting the correct shell surface for Codex
  app-server runs.

  ## Regression Test Plan (if applicable)

  - Coverage level that should have caught this:
    - [x] Unit test
    - [ ] Seam / integration test
    - [ ] End-to-end test
    - [ ] Existing coverage already sufficient
  - Target test or file: `extensions/codex/src/app-server/run-attempt.test.ts`
  - Scenario the test should lock in: `host=node` from session overrides or config disables Codex native tool surface while preserving OpenClaw dynamic
  `exec`/`process`.
  - Why this is the smallest reliable guardrail: The failure is in Codex app-server tool-surface selection, so focused tests on that selection catch the
  regression without needing live node infrastructure.
  - Existing test that already covers this (if any): None before this PR.
  - If no new test is added, why not: N/A

  ## User-visible / Behavior Changes

  Codex app-server sessions configured for `exec.host=node` now use OpenClaw dynamic shell tools for command execution instead of Codex native code mode.

  ## Diagram (if applicable)

  ```text
  Before:
  [/exec host=node] -> [Codex native shell enabled] -> [gateway/container shell may run]

  After:
  [/exec host=node] -> [Codex native shell disabled] -> [OpenClaw exec/process] -> [node-host routing]
```

  ## Security Impact (required)

  - New permissions/capabilities? (Yes/No) No
  - Secrets/tokens handling changed? (Yes/No) No
  - New/changed network calls? (Yes/No) No
  - Command/tool execution surface changed? (Yes/No) Yes
  - Data access scope changed? (Yes/No) No
  - If any Yes, explain risk + mitigation: The change narrows Codex native shell exposure for node-targeted sessions and preserves the existing OpenClaw
    exec approval/routing path. No new command capability is introduced.

  ## Repro + Verification

  ### Environment

  - OS: macOS/Darwin local source checkout
  - Runtime/container: Repo Node/pnpm toolchain, no runtime container used for live proof
  - Model/provider: Codex app-server code path
  - Integration/channel (if any): Codex plugin
  - Relevant config (redacted): exec.host=node via session override and config defaults in tests

  ### Steps

  1. Configure or simulate a Codex app-server run with effective exec.host=node.
  2. Build dynamic tools for the run.
  3. Check that native tool surface is disabled and OpenClaw dynamic exec/process remain available.

  ### Expected

  - Codex native shell is disabled for node-targeted exec sessions.
  - OpenClaw dynamic exec/process remain available for node routing.

  ### Actual

  - After this patch, focused tests confirm the expected behavior.

  ## Evidence

  Attach at least one:

  - [x] Failing test/log before + passing after
  - [x] Trace/log snippets
  - [ ] Screenshot/recording
  - [ ] Perf numbers (if relevant)

  ## Human Verification (required)

  What you personally verified (not just CI), and how:

  - Verified scenarios: Session override host=node; global config tools.exec.host=node; agent config tools.exec.host=node; full affected Codex app-server
    test file; build; changed checks; autoreview.
  - Edge cases checked: Wildcard tool allowlist does not re-enable native surface for node-targeted sessions; sandbox shell aliases remain reserved for
    sandbox routing; OpenClaw exec/process remain available for node-targeted runs.
  - What you did not verify: Live multi-node execution against a connected macOS node.

  ## Review Conversations

  - [ ] I replied to or resolved every bot review conversation I addressed in this PR.
  - [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

  If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

  ## Compatibility / Migration

  - Backward compatible? (Yes/No) Yes
  - Config/env changes? (Yes/No) No
  - Migration needed? (Yes/No) No
  - If yes, exact upgrade steps: N/A

  ## Risks and Mitigations

  - Risk: Some node-targeted Codex app-server runs lose Codex native code mode.
      - Mitigation: This only applies when effective exec host is node, where native code mode cannot represent the selected OpenClaw node target. The
        OpenClaw dynamic exec/process tools remain available.