### PR TITLE
Policy: add agent workspace conformance checks

### DIFF
--- a/docs/cli/policy.md
+++ b/docs/cli/policy.md
@@ -342,7 +342,7 @@ Example JSON output:
       }
     ]
   },
-  "checksRun": 31,
+  "checksRun": 30,
   "checksSkipped": 0,
   "findings": []
 }

--- a/docs/cli/policy.md
+++ b/docs/cli/policy.md
@@ -133,10 +133,12 @@ provider and SecretRef provenance, config auth profile metadata, and `TOOLS.md`
 declarations as evidence, then reports observed state that does not conform. If
 a policy denies non-loopback Gateway binds, omit `gateway.bind` only when you
 are willing to review the runtime default; set `gateway.bind=loopback` for
-strict config conformance. For read-only agent posture,
-`agents.workspace.denyTools` supports `exec`, `process`, `write`, `edit`, and
-`apply_patch`; OpenClaw config `group:fs` covers file mutation tools and
-`group:runtime` covers shell/process tools. Secret evidence records
+strict config conformance. For read-only agent posture, configure sandbox mode
+on the applicable defaults or agent and set `workspaceAccess` to `none` or
+`ro`; omitted or `off` sandbox mode does not satisfy a read-only/no-write
+policy. `agents.workspace.denyTools` supports `exec`, `process`, `write`,
+`edit`, and `apply_patch`; OpenClaw config `group:fs` covers file mutation tools
+and `group:runtime` covers shell/process tools. Secret evidence records
 provider/source posture and SecretRef metadata, never raw secret values. Policy
 does not read or attest per-agent credential stores such as `auth-profiles.json`;
 those stores remain owned by the existing auth and credential flows.
@@ -289,6 +291,9 @@ Example JSON output:
         "source": "oc://openclaw.config/agents/defaults/sandbox/workspaceAccess",
         "scope": "defaults",
         "value": "ro",
+        "sandboxMode": "all",
+        "sandboxModeSource": "oc://openclaw.config/agents/defaults/sandbox/mode",
+        "sandboxEnabled": true,
         "explicit": true
       },
       {
@@ -409,7 +414,7 @@ Policy currently verifies:
 | `policy/gateway-remote-enabled`              | Gateway remote mode is active when policy denies it.                             |
 | `policy/gateway-http-endpoint-enabled`       | A Gateway HTTP API endpoint is enabled while denied by policy.                   |
 | `policy/gateway-http-url-fetch-unrestricted` | Gateway HTTP URL-fetch input lacks a required URL allowlist.                     |
-| `policy/agents-workspace-access-denied`      | Agent sandbox workspace access is outside the policy allowlist.                  |
+| `policy/agents-workspace-access-denied`      | Agent sandbox mode or workspace access is outside the policy allowlist.          |
 | `policy/agents-tool-not-denied`              | An agent or default config does not deny a tool required by policy.              |
 | `policy/secrets-unmanaged-provider`          | A config SecretRef references a provider not declared under `secrets.providers`. |
 | `policy/secrets-denied-provider-source`      | A config secret provider or SecretRef uses a source denied by policy.            |

--- a/docs/cli/policy.md
+++ b/docs/cli/policy.md
@@ -18,15 +18,17 @@ report drift through `doctor --lint`. The final conformance signal is a clean
 instead of creating a separate health gate.
 
 Policy currently manages configured channels, MCP servers, model providers,
-network SSRF posture, Gateway exposure posture, OpenClaw config secret
-provider/auth profile posture, and governed tool declarations. For example, IT
-or a workspace operator can record that Telegram is not an approved channel
-provider, restrict MCP servers and model refs to approved entries, require
-private-network fetch/browser access to remain disabled, require Gateway
-bind/auth/HTTP exposure to stay within reviewed bounds, require OpenClaw config
-SecretRefs to use managed providers, require config auth profiles to carry
-provider/mode metadata, require governed tools to carry risk and sensitivity
-metadata, then use `doctor --lint` as the shared conformance gate.
+network SSRF posture, Gateway exposure posture, agent workspace posture,
+OpenClaw config secret provider/auth profile posture, and governed tool
+declarations. For example, IT or a workspace operator can record that Telegram
+is not an approved channel provider, restrict MCP servers and model refs to
+approved entries, require private-network fetch/browser access to remain
+disabled, require Gateway bind/auth/HTTP exposure to stay within reviewed
+bounds, require agent workspace access and tool denies to stay in a reviewed
+posture, require OpenClaw config SecretRefs to use managed providers, require
+config auth profiles to carry provider/mode metadata, require governed tools to
+carry risk and sensitivity metadata, then use `doctor --lint` as the shared
+conformance gate.
 
 Use policy when a workspace needs a durable statement such as "these channels
 must not be enabled" or "governed tools must declare approval metadata" and a
@@ -48,8 +50,8 @@ doctor can report the missing artifact.
 
 Policy is authored, not generated from the user's current settings. A minimal
 policy for channels, MCP servers, model providers, network posture, Gateway
-exposure, OpenClaw config secret provider/auth profile posture, and tool
-metadata looks like this:
+exposure, agent workspace posture, OpenClaw config secret provider/auth profile
+posture, and tool metadata looks like this:
 
 ```jsonc
 {
@@ -99,6 +101,12 @@ metadata looks like this:
       "requireUrlAllowlists": true,
     },
   },
+  "agents": {
+    "workspace": {
+      "allowedAccess": ["none", "ro"],
+      "denyTools": ["exec", "process", "write", "edit", "apply_patch"],
+    },
+  },
   "secrets": {
     "requireManagedProviders": true,
     "denySources": ["exec"],
@@ -120,11 +128,15 @@ The rules are the authority. A category block is only a namespace; checks run
 when a concrete rule is present. OpenClaw reads current `channels.*` settings
 `mcp.servers.*`, `models.providers.*`, selected agent model refs, network SSRF
 settings, Gateway bind/auth/Control UI/Tailscale/remote/HTTP posture, OpenClaw
-config secret provider and SecretRef provenance, config auth profile metadata,
-and `TOOLS.md` declarations as evidence, then reports observed state that does
-not conform. If a policy denies non-loopback Gateway binds, omit `gateway.bind`
-only when you are willing to review the runtime default; set
-`gateway.bind=loopback` for strict config conformance. Secret evidence records
+config agent sandbox workspace access and tool deny posture, config secret
+provider and SecretRef provenance, config auth profile metadata, and `TOOLS.md`
+declarations as evidence, then reports observed state that does not conform. If
+a policy denies non-loopback Gateway binds, omit `gateway.bind` only when you
+are willing to review the runtime default; set `gateway.bind=loopback` for
+strict config conformance. For read-only agent posture,
+`agents.workspace.denyTools` supports `exec`, `process`, `write`, `edit`, and
+`apply_patch`; OpenClaw config `group:fs` covers file mutation tools and
+`group:runtime` covers shell/process tools. Secret evidence records
 provider/source posture and SecretRef metadata, never raw secret values. Policy
 does not read or attest per-agent credential stores such as `auth-profiles.json`;
 those stores remain owned by the existing auth and credential flows.
@@ -270,6 +282,25 @@ Example JSON output:
         "explicit": true
       }
     ],
+    "agentWorkspace": [
+      {
+        "id": "agents-defaults-workspace-access",
+        "kind": "workspaceAccess",
+        "source": "oc://openclaw.config/agents/defaults/sandbox/workspaceAccess",
+        "scope": "defaults",
+        "value": "ro",
+        "explicit": true
+      },
+      {
+        "id": "agents-defaults-tool-exec",
+        "kind": "toolDeny",
+        "source": "oc://openclaw.config/tools/deny",
+        "scope": "defaults",
+        "tool": "exec",
+        "denied": true,
+        "explicit": true
+      }
+    ],
     "secrets": [
       {
         "id": "vault",
@@ -306,7 +337,7 @@ Example JSON output:
       }
     ]
   },
-  "checksRun": 28,
+  "checksRun": 31,
   "checksSkipped": 0,
   "findings": []
 }
@@ -338,6 +369,10 @@ Use this lifecycle when accepting policy state:
 If policy rules change intentionally, update both accepted hashes from a clean
 check. If workspace settings change intentionally but policy stays the same,
 only `expectedAttestationHash` usually changes.
+
+Enabling or upgrading `agents.workspace` rules adds `agentWorkspace` evidence to
+the workspace hash and attestation hash. Operators should review the new
+evidence and refresh accepted attestation hashes after enabling these rules.
 
 `openclaw policy watch` runs the same check repeatedly and reports when the
 current evidence no longer matches `expectedAttestationHash`:
@@ -374,6 +409,8 @@ Policy currently verifies:
 | `policy/gateway-remote-enabled`              | Gateway remote mode is active when policy denies it.                             |
 | `policy/gateway-http-endpoint-enabled`       | A Gateway HTTP API endpoint is enabled while denied by policy.                   |
 | `policy/gateway-http-url-fetch-unrestricted` | Gateway HTTP URL-fetch input lacks a required URL allowlist.                     |
+| `policy/agents-workspace-access-denied`      | Agent sandbox workspace access is outside the policy allowlist.                  |
+| `policy/agents-tool-not-denied`              | An agent or default config does not deny a tool required by policy.              |
 | `policy/secrets-unmanaged-provider`          | A config SecretRef references a provider not declared under `secrets.providers`. |
 | `policy/secrets-denied-provider-source`      | A config secret provider or SecretRef uses a source denied by policy.            |
 | `policy/secrets-insecure-provider`           | A secret provider opts into insecure posture when policy denies it.              |
@@ -480,6 +517,21 @@ Example Gateway exposure finding:
   "ocPath": "oc://openclaw.config/gateway/bind",
   "target": "oc://openclaw.config/gateway/bind",
   "requirement": "oc://policy.jsonc/gateway/exposure/allowNonLoopbackBind"
+}
+```
+
+Example agent workspace finding:
+
+```json
+{
+  "checkId": "policy/agents-workspace-access-denied",
+  "severity": "error",
+  "message": "agents.defaults sandbox workspaceAccess 'rw' is not allowed by policy.",
+  "source": "policy",
+  "path": "openclaw config",
+  "ocPath": "oc://openclaw.config/agents/defaults/sandbox/workspaceAccess",
+  "target": "oc://openclaw.config/agents/defaults/sandbox/workspaceAccess",
+  "requirement": "oc://policy.jsonc/agents/workspace/allowedAccess"
 }
 ```
 

--- a/docs/plugins/reference/policy.md
+++ b/docs/plugins/reference/policy.md
@@ -23,8 +23,8 @@ plugin; CLI command: [`openclaw policy`](/cli/policy)
 The Policy plugin contributes doctor health checks for policy-managed OpenClaw
 settings and governed workspace declarations. Policy currently covers channel
 conformance, governed tool metadata, MCP server posture, model-provider posture,
-private-network access posture, Gateway exposure posture, and OpenClaw config
-secret provider/auth profile posture.
+private-network access posture, Gateway exposure posture, agent workspace/tool
+posture, and OpenClaw config secret provider/auth profile posture.
 
 Policy stores authored requirements in `policy.jsonc`, observes existing
 OpenClaw settings and workspace declarations as evidence, and reports drift

--- a/extensions/policy/src/doctor/register.test.ts
+++ b/extensions/policy/src/doctor/register.test.ts
@@ -2135,6 +2135,141 @@ describe("registerPolicyDoctorChecks", () => {
     );
   });
 
+  it("accepts sandbox-scoped tool denies for read-only agent workspace policy", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy(),
+      tools: {
+        sandbox: { tools: { deny: ["group:runtime", "group:fs"] } },
+      },
+      agents: {
+        defaults: {
+          sandbox: { mode: "all", workspaceAccess: "ro" },
+        },
+        list: [
+          {
+            id: "locked",
+            sandbox: { workspaceAccess: "none" },
+            tools: { sandbox: { tools: { deny: ["group:runtime", "group:fs"] } } },
+          },
+        ],
+      },
+    } as unknown as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        agents: {
+          workspace: {
+            allowedAccess: ["none", "ro"],
+            denyTools: ["exec", "process", "write", "edit", "apply_patch"],
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    registerPolicyDoctorChecks();
+    const result = await runDoctorLintChecks(ctx(configPath, cfg));
+    const evidence = collectPolicyEvidence(cfg as unknown as Record<string, unknown>);
+
+    expect(evidence.agentWorkspace).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "agents-defaults-tool-exec",
+          denied: true,
+          source: "oc://openclaw.config/tools/sandbox/tools/deny",
+        }),
+        expect.objectContaining({
+          id: "locked-tool-apply_patch",
+          denied: true,
+          source: "oc://openclaw.config/agents/list/#0/tools/sandbox/tools/deny",
+        }),
+      ]),
+    );
+    expect(result.findings).toEqual([]);
+  });
+
+  it("accepts runtime tool deny globs for agent workspace policy", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy(),
+      tools: {
+        deny: ["e*"],
+      },
+      agents: {
+        defaults: {
+          sandbox: { mode: "all", workspaceAccess: "ro" },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        agents: {
+          workspace: {
+            allowedAccess: ["ro"],
+            denyTools: ["exec"],
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    registerPolicyDoctorChecks();
+    const result = await runDoctorLintChecks(ctx(configPath, cfg));
+
+    expect(result.findings).toEqual([]);
+  });
+
+  it("reports sandbox tool deny overrides outside policy", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy(),
+      tools: {
+        sandbox: { tools: { deny: ["exec"] } },
+      },
+      agents: {
+        defaults: {
+          sandbox: { mode: "all", workspaceAccess: "ro" },
+        },
+        list: [
+          {
+            id: "locked",
+            sandbox: { workspaceAccess: "none" },
+            tools: { sandbox: { tools: { deny: ["group:fs"] } } },
+          },
+        ],
+      },
+    } as unknown as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        agents: {
+          workspace: {
+            allowedAccess: ["none", "ro"],
+            denyTools: ["exec"],
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    registerPolicyDoctorChecks();
+    const result = await runDoctorLintChecks(ctx(configPath, cfg));
+
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        checkId: "policy/agents-tool-not-denied",
+        message: "agent 'locked' does not deny required tool 'exec'.",
+        ocPath: "oc://openclaw.config/agents/list/#0/tools/deny",
+        requirement: "oc://policy.jsonc/agents/workspace/denyTools",
+      }),
+    ]);
+  });
+
   it("accepts read-only agent workspace policy with group denies", async () => {
     const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
@@ -2172,6 +2307,54 @@ describe("registerPolicyDoctorChecks", () => {
     const result = await runDoctorLintChecks(ctx(configPath, cfg));
 
     expect(result.findings).toEqual([]);
+  });
+
+  it("reports read-only workspace policy when sandbox mode skips the main session", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy(),
+      tools: {
+        sandbox: { tools: { deny: ["exec"] } },
+      },
+      agents: {
+        defaults: {
+          sandbox: { mode: "non-main", workspaceAccess: "ro" },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        agents: {
+          workspace: {
+            allowedAccess: ["ro"],
+            denyTools: ["exec"],
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    registerPolicyDoctorChecks();
+    const result = await runDoctorLintChecks(ctx(configPath, cfg));
+
+    expect(result.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "policy/agents-workspace-access-denied",
+          message: "agents.defaults sandbox mode 'non-main' is not allowed by policy.",
+          ocPath: "oc://openclaw.config/agents/defaults/sandbox/mode",
+          requirement: "oc://policy.jsonc/agents/workspace/allowedAccess",
+        }),
+        expect.objectContaining({
+          checkId: "policy/agents-tool-not-denied",
+          message: "agents.defaults does not deny required tool 'exec'.",
+          ocPath: "oc://openclaw.config/tools/deny",
+          requirement: "oc://policy.jsonc/agents/workspace/denyTools",
+        }),
+      ]),
+    );
   });
 
   it("reports read-only workspace policy when sandbox mode is disabled", async () => {

--- a/extensions/policy/src/doctor/register.test.ts
+++ b/extensions/policy/src/doctor/register.test.ts
@@ -2062,7 +2062,7 @@ describe("registerPolicyDoctorChecks", () => {
       },
       agents: {
         defaults: {
-          sandbox: { workspaceAccess: "rw" },
+          sandbox: { mode: "all", workspaceAccess: "rw" },
         },
         list: [
           {
@@ -2097,6 +2097,8 @@ describe("registerPolicyDoctorChecks", () => {
           id: "agents-defaults-workspace-access",
           kind: "workspaceAccess",
           value: "rw",
+          sandboxMode: "all",
+          sandboxEnabled: true,
           source: "oc://openclaw.config/agents/defaults/sandbox/workspaceAccess",
         }),
         expect.objectContaining({
@@ -2142,7 +2144,7 @@ describe("registerPolicyDoctorChecks", () => {
       },
       agents: {
         defaults: {
-          sandbox: { workspaceAccess: "ro" },
+          sandbox: { mode: "all", workspaceAccess: "ro" },
         },
         list: [
           {
@@ -2170,6 +2172,46 @@ describe("registerPolicyDoctorChecks", () => {
     const result = await runDoctorLintChecks(ctx(configPath, cfg));
 
     expect(result.findings).toEqual([]);
+  });
+
+  it("reports read-only workspace policy when sandbox mode is disabled", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy(),
+      tools: {
+        deny: ["group:runtime", "group:fs"],
+      },
+      agents: {
+        defaults: {
+          sandbox: { workspaceAccess: "ro" },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        agents: {
+          workspace: {
+            allowedAccess: ["none", "ro"],
+            denyTools: ["exec", "process", "write", "edit", "apply_patch"],
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    registerPolicyDoctorChecks();
+    const result = await runDoctorLintChecks(ctx(configPath, cfg));
+
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        checkId: "policy/agents-workspace-access-denied",
+        message: "agents.defaults sandbox mode 'off' is not allowed by policy.",
+        ocPath: "oc://openclaw.config/agents/defaults/sandbox/mode",
+        requirement: "oc://policy.jsonc/agents/workspace/allowedAccess",
+      }),
+    ]);
   });
 
   it("reports gateway exposure settings denied by policy", async () => {

--- a/extensions/policy/src/doctor/register.test.ts
+++ b/extensions/policy/src/doctor/register.test.ts
@@ -133,6 +133,8 @@ describe("registerPolicyDoctorChecks", () => {
       "policy/gateway-remote-enabled",
       "policy/gateway-http-endpoint-enabled",
       "policy/gateway-http-url-fetch-unrestricted",
+      "policy/agents-workspace-access-denied",
+      "policy/agents-tool-not-denied",
       "policy/secrets-unmanaged-provider",
       "policy/secrets-denied-provider-source",
       "policy/secrets-insecure-provider",
@@ -303,6 +305,28 @@ describe("registerPolicyDoctorChecks", () => {
       { gateway: { http: { requireUrlAllowlists: "true" } } },
       "oc://policy.jsonc/gateway/http/requireUrlAllowlists",
     ],
+    ["agents array", { agents: [] }, "oc://policy.jsonc/agents"],
+    ["agents workspace array", { agents: { workspace: [] } }, "oc://policy.jsonc/agents/workspace"],
+    [
+      "agents workspace allowedAccess string",
+      { agents: { workspace: { allowedAccess: "ro" } } },
+      "oc://policy.jsonc/agents/workspace/allowedAccess",
+    ],
+    [
+      "agents workspace allowedAccess invalid",
+      { agents: { workspace: { allowedAccess: ["none", "host"] } } },
+      "oc://policy.jsonc/agents/workspace/allowedAccess/#1",
+    ],
+    [
+      "agents workspace denyTools string",
+      { agents: { workspace: { denyTools: "exec" } } },
+      "oc://policy.jsonc/agents/workspace/denyTools",
+    ],
+    [
+      "agents workspace denyTools unsupported",
+      { agents: { workspace: { denyTools: ["exec", "browser"] } } },
+      "oc://policy.jsonc/agents/workspace/denyTools/#1",
+    ],
     ["secrets array", { secrets: [] }, "oc://policy.jsonc/secrets"],
     ["auth array", { auth: [] }, "oc://policy.jsonc/auth"],
     ["auth profiles array", { auth: { profiles: [] } }, "oc://policy.jsonc/auth/profiles"],
@@ -460,7 +484,12 @@ describe("registerPolicyDoctorChecks", () => {
       policyHash,
       evidence: collectPolicyEvidence(
         {},
-        { includeGatewayExposure: false, includeSecrets: false, includeAuthProfiles: false },
+        {
+          includeGatewayExposure: false,
+          includeAgentWorkspace: false,
+          includeSecrets: false,
+          includeAuthProfiles: false,
+        },
       ),
       findings: [],
     }).attestationHash;
@@ -485,7 +514,12 @@ describe("registerPolicyDoctorChecks", () => {
       policyHash,
       evidence: collectPolicyEvidence(
         {},
-        { includeGatewayExposure: false, includeSecrets: false, includeAuthProfiles: false },
+        {
+          includeGatewayExposure: false,
+          includeAgentWorkspace: false,
+          includeSecrets: false,
+          includeAuthProfiles: false,
+        },
       ),
       findings: [],
     }).attestationHash;
@@ -522,7 +556,12 @@ describe("registerPolicyDoctorChecks", () => {
             },
           },
         },
-        { includeGatewayExposure: false, includeSecrets: false, includeAuthProfiles: false },
+        {
+          includeGatewayExposure: false,
+          includeAgentWorkspace: false,
+          includeSecrets: false,
+          includeAuthProfiles: false,
+        },
       ),
       findings: [],
     }).attestationHash;
@@ -547,10 +586,12 @@ describe("registerPolicyDoctorChecks", () => {
     expect(result.findings).toEqual([]);
     const evidence = collectPolicyEvidence(cfg as unknown as Record<string, unknown>, {
       includeGatewayExposure: false,
+      includeAgentWorkspace: false,
       includeSecrets: false,
       includeAuthProfiles: false,
     });
     expect(evidence).not.toHaveProperty("gatewayExposure");
+    expect(evidence).not.toHaveProperty("agentWorkspace");
     expect(evidence).not.toHaveProperty("secrets");
     expect(evidence).not.toHaveProperty("authProfiles");
   });
@@ -2010,6 +2051,125 @@ describe("registerPolicyDoctorChecks", () => {
         }),
       ]),
     );
+  });
+
+  it("reports agent workspace posture denied by policy", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy(),
+      tools: {
+        deny: ["write", "edit"],
+      },
+      agents: {
+        defaults: {
+          sandbox: { workspaceAccess: "rw" },
+        },
+        list: [
+          {
+            id: "reviewer",
+            sandbox: { workspaceAccess: "ro" },
+            tools: { deny: ["group:fs", "group:runtime"] },
+          },
+        ],
+      },
+    } as unknown as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        agents: {
+          workspace: {
+            allowedAccess: ["none", "ro"],
+            denyTools: ["exec", "process", "write", "edit", "apply_patch"],
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    registerPolicyDoctorChecks();
+    const result = await runDoctorLintChecks(ctx(configPath, cfg));
+    const evidence = collectPolicyEvidence(cfg as unknown as Record<string, unknown>);
+
+    expect(evidence.agentWorkspace).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "agents-defaults-workspace-access",
+          kind: "workspaceAccess",
+          value: "rw",
+          source: "oc://openclaw.config/agents/defaults/sandbox/workspaceAccess",
+        }),
+        expect.objectContaining({
+          id: "reviewer-tool-apply_patch",
+          kind: "toolDeny",
+          tool: "apply_patch",
+          denied: true,
+        }),
+      ]),
+    );
+    expect(result.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "policy/agents-workspace-access-denied",
+          severity: "error",
+          ocPath: "oc://openclaw.config/agents/defaults/sandbox/workspaceAccess",
+          requirement: "oc://policy.jsonc/agents/workspace/allowedAccess",
+        }),
+        expect.objectContaining({
+          checkId: "policy/agents-tool-not-denied",
+          severity: "error",
+          ocPath: "oc://openclaw.config/tools/deny",
+          requirement: "oc://policy.jsonc/agents/workspace/denyTools",
+        }),
+      ]),
+    );
+    expect(result.findings).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "policy/agents-tool-not-denied",
+          ocPath: "oc://openclaw.config/agents/list/#0/tools/deny",
+        }),
+      ]),
+    );
+  });
+
+  it("accepts read-only agent workspace policy with group denies", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy(),
+      tools: {
+        deny: ["group:runtime", "group:fs"],
+      },
+      agents: {
+        defaults: {
+          sandbox: { workspaceAccess: "ro" },
+        },
+        list: [
+          {
+            id: "locked",
+            sandbox: { workspaceAccess: "none" },
+          },
+        ],
+      },
+    } as unknown as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        agents: {
+          workspace: {
+            allowedAccess: ["none", "ro"],
+            denyTools: ["exec", "process", "write", "edit", "apply_patch"],
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    registerPolicyDoctorChecks();
+    const result = await runDoctorLintChecks(ctx(configPath, cfg));
+
+    expect(result.findings).toEqual([]);
   });
 
   it("reports gateway exposure settings denied by policy", async () => {

--- a/extensions/policy/src/doctor/register.ts
+++ b/extensions/policy/src/doctor/register.ts
@@ -1770,20 +1770,27 @@ function agentWorkspaceAccessFindings(
   return (evidence.agentWorkspace ?? [])
     .filter(
       (entry) =>
-        entry.kind === "workspaceAccess" && entry.value !== undefined && !allowed.has(entry.value),
+        entry.kind === "workspaceAccess" &&
+        entry.value !== undefined &&
+        (entry.sandboxEnabled !== true || !allowed.has(entry.value)),
     )
     .map((entry): HealthFinding => {
       const label = entry.agentId === undefined ? "agents.defaults" : `agent '${entry.agentId}'`;
+      const sandboxDisabled = entry.sandboxEnabled !== true;
+      const observed = sandboxDisabled
+        ? `sandbox mode '${entry.sandboxMode ?? "off"}'`
+        : `sandbox workspaceAccess '${entry.value ?? ""}'`;
+      const ocPath = sandboxDisabled ? (entry.sandboxModeSource ?? entry.source) : entry.source;
       return {
         checkId: CHECK_IDS.policyAgentsWorkspaceAccessDenied,
         severity: "error",
-        message: `${label} sandbox workspaceAccess '${entry.value ?? ""}' is not allowed by policy.`,
+        message: `${label} ${observed} is not allowed by policy.`,
         source: "policy",
         path: "openclaw config",
-        ocPath: entry.source,
-        target: entry.source,
+        ocPath,
+        target: ocPath,
         requirement: `oc://${policyDocName}/agents/workspace/allowedAccess`,
-        fixHint: "Use sandbox workspaceAccess none/ro or update policy after review.",
+        fixHint: "Enable sandbox mode with workspaceAccess none/ro or update policy after review.",
       };
     });
 }

--- a/extensions/policy/src/doctor/register.ts
+++ b/extensions/policy/src/doctor/register.ts
@@ -34,6 +34,8 @@ const CHECK_IDS = {
   policyGatewayRemoteEnabled: "policy/gateway-remote-enabled",
   policyGatewayHttpEndpointEnabled: "policy/gateway-http-endpoint-enabled",
   policyGatewayHttpUrlFetchUnrestricted: "policy/gateway-http-url-fetch-unrestricted",
+  policyAgentsWorkspaceAccessDenied: "policy/agents-workspace-access-denied",
+  policyAgentsToolNotDenied: "policy/agents-tool-not-denied",
   policySecretsUnmanagedProvider: "policy/secrets-unmanaged-provider",
   policySecretsDeniedProviderSource: "policy/secrets-denied-provider-source",
   policySecretsInsecureProvider: "policy/secrets-insecure-provider",
@@ -65,6 +67,8 @@ export const POLICY_CHECK_IDS = [
   CHECK_IDS.policyGatewayRemoteEnabled,
   CHECK_IDS.policyGatewayHttpEndpointEnabled,
   CHECK_IDS.policyGatewayHttpUrlFetchUnrestricted,
+  CHECK_IDS.policyAgentsWorkspaceAccessDenied,
+  CHECK_IDS.policyAgentsToolNotDenied,
   CHECK_IDS.policySecretsUnmanagedProvider,
   CHECK_IDS.policySecretsDeniedProviderSource,
   CHECK_IDS.policySecretsInsecureProvider,
@@ -83,6 +87,13 @@ const SUPPORTED_TOOL_METADATA = ["risk", "sensitivity", "owner"] as const;
 const SUPPORTED_AUTH_PROFILE_METADATA = ["provider", "mode"] as const;
 const SUPPORTED_AUTH_PROFILE_MODES = ["api_key", "aws-sdk", "oauth", "token"] as const;
 const SUPPORTED_GATEWAY_HTTP_ENDPOINTS = ["chatCompletions", "responses"] as const;
+const SUPPORTED_AGENT_WORKSPACE_DENY_TOOLS = [
+  "exec",
+  "process",
+  "write",
+  "edit",
+  "apply_patch",
+] as const;
 
 let registered = false;
 const policyEvaluationCache = new WeakMap<HealthCheckContext, Promise<PolicyEvaluation>>();
@@ -126,6 +137,8 @@ export function registerPolicyDoctorChecks(host?: PolicyDoctorRegistrationHost):
   registerHealthCheck(policyGatewayRemoteEnabledCheck);
   registerHealthCheck(policyGatewayHttpEndpointEnabledCheck);
   registerHealthCheck(policyGatewayHttpUrlFetchUnrestrictedCheck);
+  registerHealthCheck(policyAgentsWorkspaceAccessDeniedCheck);
+  registerHealthCheck(policyAgentsToolNotDeniedCheck);
   registerHealthCheck(policySecretsUnmanagedProviderCheck);
   registerHealthCheck(policySecretsDeniedProviderSourceCheck);
   registerHealthCheck(policySecretsInsecureProviderCheck);
@@ -361,6 +374,26 @@ const policyGatewayHttpUrlFetchUnrestrictedCheck: HealthCheck = {
   },
 };
 
+const policyAgentsWorkspaceAccessDeniedCheck: HealthCheck = {
+  id: CHECK_IDS.policyAgentsWorkspaceAccessDenied,
+  kind: "plugin",
+  description: "Agent sandbox workspace access matches policy.",
+  source: "policy",
+  async detect(ctx) {
+    return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyAgentsWorkspaceAccessDenied);
+  },
+};
+
+const policyAgentsToolNotDeniedCheck: HealthCheck = {
+  id: CHECK_IDS.policyAgentsToolNotDenied,
+  kind: "plugin",
+  description: "Agent workspace mutation/runtime tools are denied when policy requires it.",
+  source: "policy",
+  async detect(ctx) {
+    return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyAgentsToolNotDenied);
+  },
+};
+
 const policySecretsUnmanagedProviderCheck: HealthCheck = {
   id: CHECK_IDS.policySecretsUnmanagedProvider,
   kind: "plugin",
@@ -469,6 +502,7 @@ async function evaluatePolicyUncached(ctx: HealthCheckContext): Promise<PolicyEv
   const policyPath = policyDisplayName(ctx);
   let evidence: PolicyEvidence = collectPolicyEvidence(ctx.cfg as Record<string, unknown>, {
     includeGatewayExposure: false,
+    includeAgentWorkspace: false,
     includeSecrets: false,
     includeAuthProfiles: false,
   });
@@ -558,17 +592,20 @@ async function evaluatePolicyUncached(ctx: HealthCheckContext): Promise<PolicyEv
   const includeSecrets = policyHasSecretRules(policy);
   const includeAuthProfiles = policyHasAuthProfileRules(policy);
   const includeGatewayExposure = policyHasGatewayRules(policy);
+  const includeAgentWorkspace = policyHasAgentWorkspaceRules(policy);
   if (requiredMetadata.size > 0) {
     const toolsFile = await readWorkspaceFile(ctx, "TOOLS.md");
     evidence = await collectPolicyEvidence(ctx.cfg as Record<string, unknown>, {
       toolsRaw: toolsFile?.raw ?? "",
       includeGatewayExposure,
+      includeAgentWorkspace,
       includeSecrets,
       includeAuthProfiles,
     });
   } else {
     evidence = collectPolicyEvidence(ctx.cfg as Record<string, unknown>, {
       includeGatewayExposure,
+      includeAgentWorkspace,
       includeSecrets,
       includeAuthProfiles,
     });
@@ -579,8 +616,9 @@ async function evaluatePolicyUncached(ctx: HealthCheckContext): Promise<PolicyEv
     ...mcpServerFindings(policy, policyFile.ocDocName, evidence),
     ...modelProviderFindings(policy, policyFile.ocDocName, evidence),
     ...networkFindings(policy, policyFile.ocDocName, evidence),
-    ...secretAuthProvenanceFindings(policy, policyFile.displayName, policyFile.ocDocName, evidence),
     ...gatewayExposureFindings(policy, policyFile.ocDocName, evidence),
+    ...agentWorkspaceFindings(policy, policyFile.displayName, policyFile.ocDocName, evidence),
+    ...secretAuthProvenanceFindings(policy, policyFile.displayName, policyFile.ocDocName, evidence),
     ...authMetadataRequirementFindings,
     ...metadataRequirementFindings,
   ];
@@ -960,7 +998,92 @@ function policyContainerShapeFindings(
   if (gatewayFinding !== undefined) {
     return [gatewayFinding];
   }
+  const agentsFinding = agentsPolicyShapeFinding(policy.agents, {
+    policyDocName,
+    policyPath,
+  });
+  if (agentsFinding !== undefined) {
+    return [agentsFinding];
+  }
   return [];
+}
+
+function agentsPolicyShapeFinding(
+  value: unknown,
+  params: {
+    readonly policyDocName: string;
+    readonly policyPath: string;
+  },
+): HealthFinding | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!isRecord(value)) {
+    return policyShapeFinding(
+      params.policyPath,
+      `oc://${params.policyDocName}/agents`,
+      `${params.policyPath} agents must be an object.`,
+      `Fix ${params.policyPath} so agents is an object.`,
+    );
+  }
+  if (value.workspace !== undefined && !isRecord(value.workspace)) {
+    return policyShapeFinding(
+      params.policyPath,
+      `oc://${params.policyDocName}/agents/workspace`,
+      `${params.policyPath} agents.workspace must be an object.`,
+      `Fix ${params.policyPath} so agents.workspace is an object.`,
+    );
+  }
+  const workspace = isRecord(value.workspace) ? value.workspace : {};
+  const allowedAccess = workspace.allowedAccess;
+  if (allowedAccess !== undefined && !Array.isArray(allowedAccess)) {
+    return policyShapeFinding(
+      params.policyPath,
+      `oc://${params.policyDocName}/agents/workspace/allowedAccess`,
+      `${params.policyPath} agents.workspace.allowedAccess must be an array.`,
+      'Use workspace access values such as ["none", "ro"].',
+    );
+  }
+  if (Array.isArray(allowedAccess)) {
+    const invalidIndex = allowedAccess.findIndex(
+      (entry) => entry !== "none" && entry !== "ro" && entry !== "rw",
+    );
+    if (invalidIndex >= 0) {
+      return policyShapeFinding(
+        params.policyPath,
+        `oc://${params.policyDocName}/agents/workspace/allowedAccess/#${invalidIndex}`,
+        `${params.policyPath} agents.workspace.allowedAccess[${invalidIndex}] must be none, ro, or rw.`,
+        'Use workspace access values such as ["none", "ro"].',
+      );
+    }
+  }
+  const denyTools = workspace.denyTools;
+  if (denyTools !== undefined && !Array.isArray(denyTools)) {
+    return policyShapeFinding(
+      params.policyPath,
+      `oc://${params.policyDocName}/agents/workspace/denyTools`,
+      `${params.policyPath} agents.workspace.denyTools must be an array.`,
+      'Use tool ids such as ["exec", "process", "write", "edit", "apply_patch"].',
+    );
+  }
+  if (Array.isArray(denyTools)) {
+    const invalidIndex = denyTools.findIndex(
+      (entry) =>
+        typeof entry !== "string" ||
+        !SUPPORTED_AGENT_WORKSPACE_DENY_TOOLS.includes(
+          entry.trim() as (typeof SUPPORTED_AGENT_WORKSPACE_DENY_TOOLS)[number],
+        ),
+    );
+    if (invalidIndex >= 0) {
+      return policyShapeFinding(
+        params.policyPath,
+        `oc://${params.policyDocName}/agents/workspace/denyTools/#${invalidIndex}`,
+        `${params.policyPath} agents.workspace.denyTools[${invalidIndex}] must be a supported agent workspace tool id.`,
+        `Use supported tool ids: ${SUPPORTED_AGENT_WORKSPACE_DENY_TOOLS.join(", ")}.`,
+      );
+    }
+  }
+  return undefined;
 }
 
 function gatewayPolicyShapeFinding(
@@ -1615,6 +1738,90 @@ function gatewayHttpUrlFetchFindings(
     });
 }
 
+function agentWorkspaceFindings(
+  policy: unknown,
+  policyPath: string,
+  policyDocName: string,
+  evidence: PolicyEvidence,
+): readonly HealthFinding[] {
+  if (
+    agentsPolicyShapeFinding(isRecord(policy) ? policy.agents : undefined, {
+      policyDocName,
+      policyPath,
+    }) !== undefined
+  ) {
+    return [];
+  }
+  return [
+    ...agentWorkspaceAccessFindings(policy, policyDocName, evidence),
+    ...agentWorkspaceToolDenyFindings(policy, policyDocName, evidence),
+  ];
+}
+
+function agentWorkspaceAccessFindings(
+  policy: unknown,
+  policyDocName: string,
+  evidence: PolicyEvidence,
+): readonly HealthFinding[] {
+  const allowed = new Set(readStringList(policy, ["agents", "workspace", "allowedAccess"]));
+  if (allowed.size === 0) {
+    return [];
+  }
+  return (evidence.agentWorkspace ?? [])
+    .filter(
+      (entry) =>
+        entry.kind === "workspaceAccess" && entry.value !== undefined && !allowed.has(entry.value),
+    )
+    .map((entry): HealthFinding => {
+      const label = entry.agentId === undefined ? "agents.defaults" : `agent '${entry.agentId}'`;
+      return {
+        checkId: CHECK_IDS.policyAgentsWorkspaceAccessDenied,
+        severity: "error",
+        message: `${label} sandbox workspaceAccess '${entry.value ?? ""}' is not allowed by policy.`,
+        source: "policy",
+        path: "openclaw config",
+        ocPath: entry.source,
+        target: entry.source,
+        requirement: `oc://${policyDocName}/agents/workspace/allowedAccess`,
+        fixHint: "Use sandbox workspaceAccess none/ro or update policy after review.",
+      };
+    });
+}
+
+function agentWorkspaceToolDenyFindings(
+  policy: unknown,
+  policyDocName: string,
+  evidence: PolicyEvidence,
+): readonly HealthFinding[] {
+  const requiredDeniedTools = new Set(readStringList(policy, ["agents", "workspace", "denyTools"]));
+  if (requiredDeniedTools.size === 0) {
+    return [];
+  }
+  return (evidence.agentWorkspace ?? [])
+    .filter(
+      (entry) =>
+        entry.kind === "toolDeny" &&
+        entry.tool !== undefined &&
+        requiredDeniedTools.has(entry.tool) &&
+        entry.denied !== true,
+    )
+    .map((entry): HealthFinding => {
+      const label = entry.agentId === undefined ? "agents.defaults" : `agent '${entry.agentId}'`;
+      return {
+        checkId: CHECK_IDS.policyAgentsToolNotDenied,
+        severity: "error",
+        message: `${label} does not deny required tool '${entry.tool ?? ""}'.`,
+        source: "policy",
+        path: "openclaw config",
+        ocPath: entry.source,
+        target: entry.source,
+        requirement: `oc://${policyDocName}/agents/workspace/denyTools`,
+        fixHint:
+          "Add the tool to tools.deny or agents.list[].tools.deny, or update policy after review.",
+      };
+    });
+}
+
 function secretAuthProvenanceFindings(
   policy: unknown,
   policyPath: string,
@@ -1677,6 +1884,16 @@ function policyHasGatewayRules(policy: unknown): boolean {
     (isRecord(gateway.remote) && gateway.remote.allow !== undefined) ||
     (isRecord(gateway.http) &&
       (gateway.http.denyEndpoints !== undefined || gateway.http.requireUrlAllowlists !== undefined))
+  );
+}
+
+function policyHasAgentWorkspaceRules(policy: unknown): boolean {
+  return (
+    isRecord(policy) &&
+    isRecord(policy.agents) &&
+    isRecord(policy.agents.workspace) &&
+    (policy.agents.workspace.allowedAccess !== undefined ||
+      policy.agents.workspace.denyTools !== undefined)
   );
 }
 

--- a/extensions/policy/src/policy-state.ts
+++ b/extensions/policy/src/policy-state.ts
@@ -98,6 +98,9 @@ export type PolicyAgentWorkspaceEvidence = {
   readonly scope: "defaults" | "agent";
   readonly agentId?: string;
   readonly value?: string;
+  readonly sandboxMode?: string;
+  readonly sandboxModeSource?: string;
+  readonly sandboxEnabled?: boolean;
   readonly tool?: string;
   readonly denied?: boolean;
   readonly explicit?: boolean;
@@ -691,6 +694,15 @@ function pushAgentWorkspaceEvidence(
     readonly inheritedToolsSourceBase: string;
   },
 ): void {
+  const explicitSandboxMode = readString(params.sandbox.mode);
+  const inheritedSandboxMode = readString(params.inheritedSandbox.mode);
+  const sandboxMode = explicitSandboxMode ?? inheritedSandboxMode ?? "off";
+  const sandboxModeSource =
+    explicitSandboxMode !== undefined
+      ? `${params.workspaceSourceBase}/sandbox/mode`
+      : inheritedSandboxMode !== undefined
+        ? `${params.inheritedWorkspaceSourceBase}/sandbox/mode`
+        : "oc://openclaw.config/agents/defaults/sandbox/mode";
   const explicitWorkspaceAccess = readString(params.sandbox.workspaceAccess);
   const inheritedWorkspaceAccess = readString(params.inheritedSandbox.workspaceAccess);
   entries.push({
@@ -705,6 +717,9 @@ function pushAgentWorkspaceEvidence(
     scope: params.scope,
     ...(params.agentId === undefined ? {} : { agentId: params.agentId }),
     value: explicitWorkspaceAccess ?? inheritedWorkspaceAccess ?? "none",
+    sandboxMode,
+    sandboxModeSource,
+    sandboxEnabled: sandboxMode !== "off",
     explicit: explicitWorkspaceAccess !== undefined,
   });
 

--- a/extensions/policy/src/policy-state.ts
+++ b/extensions/policy/src/policy-state.ts
@@ -697,6 +697,7 @@ function pushAgentWorkspaceEvidence(
   const explicitSandboxMode = readString(params.sandbox.mode);
   const inheritedSandboxMode = readString(params.inheritedSandbox.mode);
   const sandboxMode = explicitSandboxMode ?? inheritedSandboxMode ?? "off";
+  const sandboxModeCoversAgentMain = sandboxMode === "all";
   const sandboxModeSource =
     explicitSandboxMode !== undefined
       ? `${params.workspaceSourceBase}/sandbox/mode`
@@ -719,28 +720,73 @@ function pushAgentWorkspaceEvidence(
     value: explicitWorkspaceAccess ?? inheritedWorkspaceAccess ?? "none",
     sandboxMode,
     sandboxModeSource,
-    sandboxEnabled: sandboxMode !== "off",
+    sandboxEnabled: sandboxModeCoversAgentMain,
     explicit: explicitWorkspaceAccess !== undefined,
   });
 
   for (const tool of AGENT_WORKSPACE_POLICY_TOOLS) {
-    const inheritedDenied = toolListCoversTool(readStringArray(params.inheritedTools.deny), tool);
-    const localDenied = toolListCoversTool(readStringArray(params.tools.deny), tool);
+    const denyEvidence = agentWorkspaceToolDenyEvidence(params, tool, sandboxModeCoversAgentMain);
     entries.push({
       id: `${params.id}-tool-${tool}`,
       kind: "toolDeny",
-      source: localDenied
-        ? `${params.toolsSourceBase}/deny`
-        : inheritedDenied
-          ? `${params.inheritedToolsSourceBase}/deny`
-          : `${params.toolsSourceBase}/deny`,
+      source: denyEvidence.source,
       scope: params.scope,
       ...(params.agentId === undefined ? {} : { agentId: params.agentId }),
       tool,
-      denied: inheritedDenied || localDenied,
-      explicit: localDenied || inheritedDenied,
+      denied: denyEvidence.denied,
+      explicit: denyEvidence.denied,
     });
   }
+}
+
+function agentWorkspaceToolDenyEvidence(
+  params: {
+    readonly tools: Record<string, unknown>;
+    readonly inheritedTools: Record<string, unknown>;
+    readonly toolsSourceBase: string;
+    readonly inheritedToolsSourceBase: string;
+  },
+  tool: string,
+  sandboxModeCoversAgentMain: boolean,
+): { readonly denied: boolean; readonly source: string } {
+  const localSandboxToolDeny = configuredSandboxToolDenyEntries(params.tools);
+  const inheritedSandboxToolDeny = configuredSandboxToolDenyEntries(params.inheritedTools);
+  const sources = [
+    {
+      entries: readStringArray(params.tools.deny),
+      source: `${params.toolsSourceBase}/deny`,
+    },
+    {
+      entries: readStringArray(params.inheritedTools.deny),
+      source: `${params.inheritedToolsSourceBase}/deny`,
+    },
+    ...(sandboxModeCoversAgentMain
+      ? [
+          localSandboxToolDeny !== undefined
+            ? {
+                entries: localSandboxToolDeny,
+                source: `${params.toolsSourceBase}/sandbox/tools/deny`,
+              }
+            : {
+                entries: inheritedSandboxToolDeny ?? [],
+                source: `${params.inheritedToolsSourceBase}/sandbox/tools/deny`,
+              },
+        ]
+      : []),
+  ];
+  const match = sources.find((entry) => toolListCoversTool(entry.entries, tool));
+  if (match !== undefined) {
+    return { denied: true, source: match.source };
+  }
+  return { denied: false, source: `${params.toolsSourceBase}/deny` };
+}
+
+function configuredSandboxToolDenyEntries(
+  tools: Record<string, unknown>,
+): readonly string[] | undefined {
+  const sandbox = isRecord(tools.sandbox) ? tools.sandbox : {};
+  const sandboxTools = isRecord(sandbox.tools) ? sandbox.tools : {};
+  return Array.isArray(sandboxTools.deny) ? readStringArray(sandboxTools.deny) : undefined;
 }
 
 const AGENT_WORKSPACE_POLICY_TOOLS = ["exec", "process", "write", "edit", "apply_patch"] as const;
@@ -772,6 +818,11 @@ function normalizePolicyToolName(value: string): string {
   return normalized;
 }
 
+function policyToolGlobMatches(tool: string, pattern: string): boolean {
+  const escaped = pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`^${escaped.replaceAll("\\*", ".*")}$`).test(tool);
+}
+
 function toolListCoversTool(list: readonly string[], tool: string): boolean {
   for (const entry of list) {
     const normalized = normalizePolicyToolName(entry);
@@ -779,6 +830,9 @@ function toolListCoversTool(list: readonly string[], tool: string): boolean {
       return true;
     }
     if (POLICY_TOOL_GROUPS[normalized]?.includes(tool)) {
+      return true;
+    }
+    if (normalized.includes("*") && policyToolGlobMatches(tool, normalized)) {
       return true;
     }
   }

--- a/extensions/policy/src/policy-state.ts
+++ b/extensions/policy/src/policy-state.ts
@@ -24,6 +24,7 @@ export type PolicyEvidence = {
   readonly modelRefs: readonly PolicyModelRefEvidence[];
   readonly network: readonly PolicyNetworkEvidence[];
   readonly gatewayExposure?: readonly PolicyGatewayExposureEvidence[];
+  readonly agentWorkspace?: readonly PolicyAgentWorkspaceEvidence[];
   readonly secrets?: readonly PolicySecretEvidence[];
   readonly authProfiles?: readonly PolicyAuthProfileEvidence[];
 };
@@ -88,6 +89,18 @@ export type PolicyGatewayExposureEvidence = {
   readonly explicit?: boolean;
   readonly endpoint?: string;
   readonly hasAllowlist?: boolean;
+};
+
+export type PolicyAgentWorkspaceEvidence = {
+  readonly id: string;
+  readonly kind: "workspaceAccess" | "toolDeny";
+  readonly source: string;
+  readonly scope: "defaults" | "agent";
+  readonly agentId?: string;
+  readonly value?: string;
+  readonly tool?: string;
+  readonly denied?: boolean;
+  readonly explicit?: boolean;
 };
 
 export type PolicySecretEvidence = {
@@ -181,6 +194,7 @@ export function collectPolicyEvidence(
   options?: {
     readonly toolsRaw?: undefined;
     readonly includeGatewayExposure?: boolean;
+    readonly includeAgentWorkspace?: boolean;
     readonly includeSecrets?: boolean;
     readonly includeAuthProfiles?: boolean;
   },
@@ -190,6 +204,7 @@ export function collectPolicyEvidence(
   options: {
     readonly toolsRaw: string;
     readonly includeGatewayExposure?: boolean;
+    readonly includeAgentWorkspace?: boolean;
     readonly includeSecrets?: boolean;
     readonly includeAuthProfiles?: boolean;
   },
@@ -199,6 +214,7 @@ export function collectPolicyEvidence(
   options: {
     readonly toolsRaw?: string;
     readonly includeGatewayExposure?: boolean;
+    readonly includeAgentWorkspace?: boolean;
     readonly includeSecrets?: boolean;
     readonly includeAuthProfiles?: boolean;
   } = {},
@@ -212,6 +228,9 @@ export function collectPolicyEvidence(
     ...(options.includeGatewayExposure === false
       ? {}
       : { gatewayExposure: scanPolicyGatewayExposure(cfg) }),
+    ...(options.includeAgentWorkspace === false
+      ? {}
+      : { agentWorkspace: scanPolicyAgentWorkspace(cfg) }),
     ...(options.includeSecrets === false ? {} : { secrets: scanPolicySecrets(cfg) }),
     ...(options.includeAuthProfiles === false ? {} : { authProfiles: scanPolicyAuthProfiles(cfg) }),
   };
@@ -459,6 +478,53 @@ export function scanPolicyGatewayExposure(
   return entries.toSorted((a, b) => a.source.localeCompare(b.source));
 }
 
+export function scanPolicyAgentWorkspace(
+  cfg: Record<string, unknown>,
+): readonly PolicyAgentWorkspaceEvidence[] {
+  const agents = isRecord(cfg.agents) ? cfg.agents : {};
+  const defaults = isRecord(agents.defaults) ? agents.defaults : {};
+  const defaultSandbox = isRecord(defaults.sandbox) ? defaults.sandbox : {};
+  const defaultTools = isRecord(cfg.tools) ? cfg.tools : {};
+  const entries: PolicyAgentWorkspaceEvidence[] = [];
+  pushAgentWorkspaceEvidence(entries, {
+    id: "agents-defaults",
+    scope: "defaults",
+    sandbox: defaultSandbox,
+    inheritedSandbox: {},
+    tools: defaultTools,
+    inheritedTools: {},
+    workspaceSourceBase: "oc://openclaw.config/agents/defaults",
+    inheritedWorkspaceSourceBase: "oc://openclaw.config/agents/defaults",
+    toolsSourceBase: "oc://openclaw.config/tools",
+    inheritedToolsSourceBase: "oc://openclaw.config/tools",
+  });
+
+  const list = Array.isArray(agents.list) ? agents.list : [];
+  list.forEach((agent, index) => {
+    if (!isRecord(agent)) {
+      return;
+    }
+    const agentId =
+      typeof agent.id === "string" && agent.id.trim() !== "" ? agent.id.trim() : undefined;
+    const sandbox = isRecord(agent.sandbox) ? agent.sandbox : {};
+    const tools = isRecord(agent.tools) ? agent.tools : {};
+    pushAgentWorkspaceEvidence(entries, {
+      id: agentId ?? `agent-${index}`,
+      scope: "agent",
+      agentId,
+      sandbox,
+      inheritedSandbox: defaultSandbox,
+      tools,
+      inheritedTools: defaultTools,
+      workspaceSourceBase: `oc://openclaw.config/agents/list/#${index}`,
+      inheritedWorkspaceSourceBase: "oc://openclaw.config/agents/defaults",
+      toolsSourceBase: `oc://openclaw.config/agents/list/#${index}/tools`,
+      inheritedToolsSourceBase: "oc://openclaw.config/tools",
+    });
+  });
+  return entries.toSorted((a, b) => a.source.localeCompare(b.source) || a.id.localeCompare(b.id));
+}
+
 export function scanPolicySecrets(cfg: Record<string, unknown>): readonly PolicySecretEvidence[] {
   return [...scanPolicySecretProviders(cfg), ...scanPolicySecretInputs(cfg)].toSorted((a, b) =>
     a.source.localeCompare(b.source),
@@ -607,6 +673,101 @@ function isMediaConfiguredProviderRequestSecretPath(path: readonly string[]): bo
     isConfiguredProviderRequestSecretPath(path, ["tools", "media", "video"]) ||
     isConfiguredProviderRequestSecretPath(path, ["tools", "media", "video", "models", "#"])
   );
+}
+
+function pushAgentWorkspaceEvidence(
+  entries: PolicyAgentWorkspaceEvidence[],
+  params: {
+    readonly id: string;
+    readonly scope: "defaults" | "agent";
+    readonly agentId?: string;
+    readonly sandbox: Record<string, unknown>;
+    readonly inheritedSandbox: Record<string, unknown>;
+    readonly tools: Record<string, unknown>;
+    readonly inheritedTools: Record<string, unknown>;
+    readonly workspaceSourceBase: string;
+    readonly inheritedWorkspaceSourceBase: string;
+    readonly toolsSourceBase: string;
+    readonly inheritedToolsSourceBase: string;
+  },
+): void {
+  const explicitWorkspaceAccess = readString(params.sandbox.workspaceAccess);
+  const inheritedWorkspaceAccess = readString(params.inheritedSandbox.workspaceAccess);
+  entries.push({
+    id: `${params.id}-workspace-access`,
+    kind: "workspaceAccess",
+    source:
+      explicitWorkspaceAccess !== undefined
+        ? `${params.workspaceSourceBase}/sandbox/workspaceAccess`
+        : inheritedWorkspaceAccess !== undefined
+          ? `${params.inheritedWorkspaceSourceBase}/sandbox/workspaceAccess`
+          : "oc://openclaw.config/agents/defaults/sandbox/workspaceAccess",
+    scope: params.scope,
+    ...(params.agentId === undefined ? {} : { agentId: params.agentId }),
+    value: explicitWorkspaceAccess ?? inheritedWorkspaceAccess ?? "none",
+    explicit: explicitWorkspaceAccess !== undefined,
+  });
+
+  for (const tool of AGENT_WORKSPACE_POLICY_TOOLS) {
+    const inheritedDenied = toolListCoversTool(readStringArray(params.inheritedTools.deny), tool);
+    const localDenied = toolListCoversTool(readStringArray(params.tools.deny), tool);
+    entries.push({
+      id: `${params.id}-tool-${tool}`,
+      kind: "toolDeny",
+      source: localDenied
+        ? `${params.toolsSourceBase}/deny`
+        : inheritedDenied
+          ? `${params.inheritedToolsSourceBase}/deny`
+          : `${params.toolsSourceBase}/deny`,
+      scope: params.scope,
+      ...(params.agentId === undefined ? {} : { agentId: params.agentId }),
+      tool,
+      denied: inheritedDenied || localDenied,
+      explicit: localDenied || inheritedDenied,
+    });
+  }
+}
+
+const AGENT_WORKSPACE_POLICY_TOOLS = ["exec", "process", "write", "edit", "apply_patch"] as const;
+
+const POLICY_TOOL_GROUPS: Record<string, readonly string[]> = {
+  "group:fs": ["read", "write", "edit", "apply_patch"],
+  "group:runtime": ["exec", "process", "code_execution"],
+};
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() !== "" ? value.trim() : undefined;
+}
+
+function readStringArray(value: unknown): readonly string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((entry): entry is string => typeof entry === "string" && entry.trim() !== "");
+}
+
+function normalizePolicyToolName(value: string): string {
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "bash") {
+    return "exec";
+  }
+  if (normalized === "apply-patch") {
+    return "apply_patch";
+  }
+  return normalized;
+}
+
+function toolListCoversTool(list: readonly string[], tool: string): boolean {
+  for (const entry of list) {
+    const normalized = normalizePolicyToolName(entry);
+    if (normalized === "*" || normalized === tool) {
+      return true;
+    }
+    if (POLICY_TOOL_GROUPS[normalized]?.includes(tool)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function isConfiguredProviderRequestSecretPath(


### PR DESCRIPTION
## Summary

Adds a policy-only conformance surface for locking agent workspace posture down to read-only/no-write configurations.

- records agent/default sandbox `workspaceAccess`, sandbox mode, and tool deny coverage as policy evidence
- adds `agents.workspace.allowedAccess` and `agents.workspace.denyTools` checks
- treats omitted or `off` sandbox mode as nonconforming for read-only/no-write workspace policy
- documents the supported read-only policy shape, evidence payload, and attestation-hash impact

This is stacked after #81981 and intentionally stays at config/policy conformance level; it does not add runtime enforcement.

## Policy syntax

```jsonc
{
  "agents": {
    "workspace": {
      "allowedAccess": ["none", "ro"],
      "denyTools": ["exec", "process", "write", "edit", "apply_patch"],
    },
  },
}
```

For this policy to pass, the matching OpenClaw config must explicitly enable sandbox mode for the applicable defaults or agent and set `workspaceAccess` to an allowed value. A config that omits sandbox mode, or sets it to `off`, does not satisfy a read-only/no-write posture even if `workspaceAccess` is `ro`.

Enabling or upgrading these rules adds `agentWorkspace` evidence to the workspace and attestation hashes. Operators should review the new evidence and refresh accepted attestation hashes after enabling these rules.

## Verification

- `git diff --check`
- `pnpm docs:list`
- `pnpm exec oxfmt --write --threads=1 extensions/policy/src/policy-state.ts extensions/policy/src/doctor/register.ts extensions/policy/src/doctor/register.test.ts docs/cli/policy.md docs/plugins/reference/policy.md`
- `node scripts/run-vitest.mjs extensions/policy/src/doctor/register.test.ts --run --reporter=dot` (114 passed)
- `node scripts/run-vitest.mjs extensions/policy/src/cli.test.ts --run --reporter=dot` (12 passed)
- `pnpm docs:check-mdx docs/cli/policy.md docs/plugins/reference/policy.md`
- `/mnt/c/src/claws-hapi/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --reviewer codex --fallback-reviewer none` (clean: no accepted/actionable findings)

## Real behavior proof

Behavior addressed: Policy conformance can require agent sandbox workspace access to stay within an allowlist and require explicit deny coverage for shell/process/file-mutation tools. It now rejects read-only/no-write workspace policy when sandbox mode is omitted or `off`.
Real environment tested: WSL checkout at `/root/src/openclaw-policy-agent-workspace` on Ubuntu-24.04.
Exact steps or command run after this patch: direct `policyCheckCommand({ cwd, json: true, severityMin: "error" })` against temp OpenClaw configs under `/tmp/policy-proof-85096-refresh`, with `OPENCLAW_CONFIG_PATH` set to each config.
Evidence after fix: Sandbox omitted/off plus `workspaceAccess: "ro"` produced `policy/agents-workspace-access-denied` at `oc://openclaw.config/agents/defaults/sandbox/mode`; explicit sandbox `mode: "all"`, `workspaceAccess: "ro"`, and `group:runtime`/`group:fs` denies produced `ok: true`.
Observed result after fix: The policy check emitted `agentWorkspace` evidence with sandbox mode fields and no longer accepts a default unsandboxed config as read-only/no-write compliant.
What was not tested: No runtime sandbox/tool enforcement was tested because this PR only adds config-level policy conformance.

### Redacted CLI evidence

Sandbox omitted/off:

```json
{
  "exitCode": 1,
  "ok": false,
  "checksRun": 30,
  "findings": [
    {
      "checkId": "policy/agents-workspace-access-denied",
      "message": "agents.defaults sandbox mode 'off' is not allowed by policy.",
      "ocPath": "oc://openclaw.config/agents/defaults/sandbox/mode"
    }
  ]
}
```

Accepted read-only posture:

```json
{
  "exitCode": 0,
  "ok": true,
  "checksRun": 30,
  "findings": []
}
```
