### PR TITLE
fix(telegram): honor table mode while chunking

### DIFF
--- a/extensions/telegram/src/format.test.ts
+++ b/extensions/telegram/src/format.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   markdownToTelegramChunks,
   markdownToTelegramHtml,
+  markdownToTelegramHtmlChunks,
   renderTelegramHtmlText,
   splitTelegramHtmlChunks,
   telegramHtmlToPlainTextFallback,
@@ -172,6 +173,17 @@ describe("markdownToTelegramHtml", () => {
       .join("");
 
     expect(res).toContain("report/draft.\n\n3. Cognee");
+  });
+
+  it("applies tableMode when rendering Telegram HTML chunks", () => {
+    const input = ["| Name | Status |", "| --- | --- |", "| Bot | OK |"].join("\n");
+
+    const chunks = markdownToTelegramHtmlChunks(input, 4096, { tableMode: "bullets" });
+    const rendered = chunks.join("");
+
+    expect(rendered).toContain("<b>Bot</b>");
+    expect(rendered).toContain("• Status: OK");
+    expect(rendered).not.toContain("| --- | --- |");
   });
 
   it("does not insert Telegram list boundary spacing inside fenced code", () => {

--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -766,6 +766,10 @@ export function markdownToTelegramChunks(
   return renderTelegramChunksWithinHtmlLimit(ir, limit);
 }
 
-export function markdownToTelegramHtmlChunks(markdown: string, limit: number): string[] {
-  return markdownToTelegramChunks(markdown, limit).map((chunk) => chunk.html);
+export function markdownToTelegramHtmlChunks(
+  markdown: string,
+  limit: number,
+  options: { tableMode?: MarkdownTableMode } = {},
+): string[] {
+  return markdownToTelegramChunks(markdown, limit, options).map((chunk) => chunk.html);
 }

--- a/extensions/telegram/src/outbound-adapter.test.ts
+++ b/extensions/telegram/src/outbound-adapter.test.ts
@@ -60,6 +60,20 @@ describe("telegramOutbound", () => {
     sendMessageTelegramMock.mockReset();
   });
 
+  it("resolves markdown table config for outbound chunking", () => {
+    const input = ["| Name | Status |", "| --- | --- |", "| Bot | OK |"].join("\n");
+
+    const chunks = telegramOutbound.chunker!(input, 4096, {
+      cfg: { channels: { telegram: { markdown: { tables: "bullets" } } } } as never,
+      accountId: "ops",
+    });
+    const rendered = chunks.join("");
+
+    expect(rendered).toContain("<b>Bot</b>");
+    expect(rendered).toContain("• Status: OK");
+    expect(rendered).not.toContain("| --- | --- |");
+  });
+
   it("forwards mediaLocalRoots in direct media sends", async () => {
     sendMessageTelegramMock.mockResolvedValueOnce({ messageId: "tg-media" });
 

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -7,6 +7,7 @@ import {
   normalizeMessagePresentation,
   renderMessagePresentationFallbackText,
 } from "openclaw/plugin-sdk/interactive-runtime";
+import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
 import type { OutboundDeliveryFormattingOptions } from "openclaw/plugin-sdk/outbound-runtime";
 import {
   resolveOutboundSendDep,
@@ -49,11 +50,20 @@ async function resolveDefaultTelegramSend(deps?: OutboundSendDeps): Promise<Tele
 function chunkTelegramOutboundText(
   text: string,
   limit: number,
-  ctx?: { formatting?: OutboundDeliveryFormattingOptions },
+  ctx?: {
+    formatting?: OutboundDeliveryFormattingOptions;
+    cfg?: NonNullable<TelegramSendOpts>["cfg"];
+    accountId?: string | null;
+  },
 ): string[] {
+  const tableMode = resolveMarkdownTableMode({
+    cfg: ctx?.cfg,
+    channel: "telegram",
+    accountId: ctx?.accountId,
+  });
   return ctx?.formatting?.parseMode === "HTML"
     ? splitTelegramHtmlChunks(text, limit)
-    : markdownToTelegramHtmlChunks(text, limit);
+    : markdownToTelegramHtmlChunks(text, limit, { tableMode });
 }
 
 async function resolveTelegramSendContext(params: {

--- a/src/channels/plugins/outbound.types.ts
+++ b/src/channels/plugins/outbound.types.ts
@@ -132,6 +132,8 @@ export type ChannelOutboundFormattedContext = ChannelOutboundContext & {
 
 export type ChannelOutboundChunkContext = {
   formatting?: OutboundDeliveryFormattingOptions;
+  cfg?: OpenClawConfig;
+  accountId?: string | null;
 };
 
 export type ChannelOutboundNormalizePayloadParams = {

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -1412,6 +1412,8 @@ async function deliverOutboundPayloadsCore(
       textLimit,
       chunkMode,
       formatting: params.formatting,
+      cfg,
+      accountId,
       consumeReplyTo: (value) =>
         applyReplyToConsumption(value, {
           consumeImplicitReply: value.replyToIdSource === "implicit",

--- a/src/infra/outbound/message-plan.test.ts
+++ b/src/infra/outbound/message-plan.test.ts
@@ -103,4 +103,29 @@ describe("outbound message planning", () => {
       },
     ]);
   });
+
+  it("passes config and account context to channel chunkers", () => {
+    const contexts: unknown[] = [];
+
+    planOutboundTextMessageUnits({
+      text: "abcd",
+      textLimit: 2,
+      chunker: (_text, _limit, ctx) => {
+        contexts.push(ctx);
+        return ["ab", "cd"];
+      },
+      overrides: {},
+      formatting: { parseMode: "HTML" },
+      cfg: { channels: { telegram: { markdown: { tables: "bullets" } } } } as never,
+      accountId: "ops",
+    });
+
+    expect(contexts).toEqual([
+      {
+        formatting: { parseMode: "HTML" },
+        cfg: { channels: { telegram: { markdown: { tables: "bullets" } } } },
+        accountId: "ops",
+      },
+    ]);
+  });
 });

--- a/src/infra/outbound/message-plan.ts
+++ b/src/infra/outbound/message-plan.ts
@@ -3,6 +3,7 @@ import {
   chunkMarkdownTextWithMode,
   type ChunkMode,
 } from "../../auto-reply/chunk.js";
+import type { OpenClawConfig } from "../../config/types.js";
 import type { OutboundDeliveryFormattingOptions } from "./formatting.js";
 import type { ReplyToOverride } from "./reply-policy.js";
 
@@ -29,7 +30,11 @@ export type OutboundMessageUnit =
 export type OutboundMessageChunker = (
   text: string,
   limit: number,
-  ctx?: { formatting?: OutboundDeliveryFormattingOptions },
+  ctx?: {
+    formatting?: OutboundDeliveryFormattingOptions;
+    cfg?: OpenClawConfig;
+    accountId?: string | null;
+  },
 ) => string[];
 
 type PlanReplyToConsumption = <T extends OutboundMessageSendOverrides>(overrides: T) => T;
@@ -55,10 +60,14 @@ function chunkTextForPlan(params: {
   limit: number;
   chunker: OutboundMessageChunker;
   formatting?: OutboundDeliveryFormattingOptions;
+  cfg?: OpenClawConfig;
+  accountId?: string | null;
 }): string[] {
-  return params.formatting
-    ? params.chunker(params.text, params.limit, { formatting: params.formatting })
-    : params.chunker(params.text, params.limit);
+  return params.chunker(params.text, params.limit, {
+    formatting: params.formatting,
+    cfg: params.cfg,
+    accountId: params.accountId,
+  });
 }
 
 export function planOutboundTextMessageUnits(params: {
@@ -70,6 +79,8 @@ export function planOutboundTextMessageUnits(params: {
   textLimit?: number;
   chunkMode?: ChunkMode;
   formatting?: OutboundDeliveryFormattingOptions;
+  cfg?: OpenClawConfig;
+  accountId?: string | null;
   consumeReplyTo?: PlanReplyToConsumption;
 }): OutboundMessageUnit[] {
   const planTextUnit = (text: string): OutboundMessageUnit => ({
@@ -106,6 +117,8 @@ export function planOutboundTextMessageUnits(params: {
         limit: params.textLimit,
         chunker: params.chunker,
         formatting: params.formatting,
+        cfg: params.cfg,
+        accountId: params.accountId,
       });
       if (!chunks.length && blockChunk) {
         chunks.push(blockChunk);
@@ -122,6 +135,8 @@ export function planOutboundTextMessageUnits(params: {
     limit: params.textLimit,
     chunker: params.chunker,
     formatting: params.formatting,
+    cfg: params.cfg,
+    accountId: params.accountId,
   }).map(planChunkedTextUnit);
 }
 

--- a/src/plugin-sdk/reply-payload.test.ts
+++ b/src/plugin-sdk/reply-payload.test.ts
@@ -210,6 +210,35 @@ describe("sendTextMediaPayload", () => {
       "explicit-reply",
     ]);
   });
+
+  it("passes config and account context to text payload chunkers", async () => {
+    const sendText = vi.fn(async ({ text }) => ({ channel: "test", messageId: text }));
+    const chunker = vi.fn(() => ["ab", "cd"]);
+    const cfg = { channels: { telegram: { markdown: { tables: "bullets" } } } };
+
+    await sendTextMediaPayload({
+      channel: "test",
+      ctx: {
+        cfg: cfg as never,
+        accountId: "ops",
+        to: "target",
+        text: "",
+        payload: { text: "abcd" },
+        formatting: { parseMode: "HTML" },
+      },
+      adapter: {
+        textChunkLimit: 2,
+        chunker,
+        sendText,
+      },
+    });
+
+    expect(chunker).toHaveBeenCalledWith("abcd", 2, {
+      formatting: { parseMode: "HTML" },
+      cfg,
+      accountId: "ops",
+    });
+  });
 });
 
 describe("normalizeOutboundReplyPayload", () => {

--- a/src/plugin-sdk/reply-payload.ts
+++ b/src/plugin-sdk/reply-payload.ts
@@ -342,7 +342,11 @@ export async function sendTextMediaPayload(params: {
   const limit = params.adapter.textChunkLimit;
   const chunks =
     limit && params.adapter.chunker
-      ? params.adapter.chunker(text, limit, { formatting: params.ctx.formatting })
+      ? params.adapter.chunker(text, limit, {
+          formatting: params.ctx.formatting,
+          cfg: params.ctx.cfg,
+          accountId: params.ctx.accountId,
+        })
       : [text];
   let lastResult: Awaited<ReturnType<NonNullable<typeof params.adapter.sendText>>>;
   for (const chunk of chunks) {


### PR DESCRIPTION
## Summary

- Problem: Telegram outbound chunking ignored `channels.telegram.markdown.tables` for non-HTML/streamed chunked messages.
- Solution: propagate outbound `cfg`/`accountId` into chunker contexts and resolve Telegram table mode before Markdown-to-HTML chunking.
- What changed: `markdownToTelegramHtmlChunks` now accepts chunk options; Telegram chunker forwards resolved `tableMode`; core outbound planning/payload helpers pass config context; regression tests cover both direct format and adapter/core seams.
- What did NOT change (scope boundary): no Telegram send API changes, no media behavior changes, no default table-mode change.

## Motivation

- Fixes raw Markdown tables (`| --- |`) leaking into Telegram chunked/streaming messages even when `markdown.tables` is configured for bullets.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #85085
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Telegram chunked Markdown table rendering now honors `channels.telegram.markdown.tables`.
- Real environment tested: local source checkout with Node v22.19.0.
- Exact steps or command run after this patch: `corepack pnpm exec tsx -e 'import { markdownToTelegramHtmlChunks } from "./extensions/telegram/src/format.ts"; const input=["| Name | Status |","| --- | --- |","| Bot | OK |"].join("\n"); const rendered=markdownToTelegramHtmlChunks(input,4096,{tableMode:"bullets"}).join(""); console.log("OpenClaw Telegram chunk render proof"); console.log("input:"); console.log(input); console.log("rendered:"); console.log(rendered); console.log("contains raw separator:", rendered.includes("| --- | --- |"));'`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

  ```text
  OpenClaw Telegram chunk render proof
  input:
  | Name | Status |
  | --- | --- |
  | Bot | OK |
  rendered:
  <b>Bot</b>
  • Status: OK
  contains raw separator: false
  ```

- Supplemental local tests: `node scripts/run-vitest.mjs extensions/telegram/src/format.test.ts extensions/telegram/src/outbound-adapter.test.ts src/infra/outbound/message-plan.test.ts src/plugin-sdk/reply-payload.test.ts` passed (`Test Files  4 passed (4)` / `Tests  104 passed (104)`).
- Observed result after fix: configured `tables: "bullets"` removes raw table separator output from Telegram chunked HTML and renders the table row as Telegram-safe bullet text.
- What was not tested: live Telegram bot delivery.
- Before evidence (optional but encouraged): issue reproduction documents raw table separators in Telegram chunked/streamed output.

## Root Cause (if applicable)

- Root cause: `markdownToTelegramHtmlChunks` did not accept/pass `tableMode`, and outbound chunker call sites only passed formatting context, not config/account context.
- Missing detection / guardrail: no regression test covered configured Markdown table modes through Telegram chunked outbound paths.
- Contributing context (if known): HTML parse-mode paths bypass Markdown conversion, so the bug affected Markdown chunking/streaming paths specifically.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/telegram/src/format.test.ts`, `extensions/telegram/src/outbound-adapter.test.ts`, `src/infra/outbound/message-plan.test.ts`, `src/plugin-sdk/reply-payload.test.ts`.
- Scenario the test should lock in: configured `tables: "bullets"` flows from outbound config/account context to Telegram Markdown chunk rendering.
- Why this is the smallest reliable guardrail: it covers the format helper plus the adapter and shared outbound context propagation seams without live Telegram credentials.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Telegram chunked/streamed Markdown messages now honor configured table rendering modes instead of emitting raw Markdown tables.

## Diagram (if applicable)

```text
Before:
outbound config -> chunker receives formatting only -> default table mode -> raw table separators may remain

After:
outbound config/account -> chunker context -> resolve table mode -> Telegram HTML chunks use configured table rendering
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux local checkout
- Runtime/container: Node v22.19.0
- Model/provider: N/A
- Integration/channel (if any): Telegram
- Relevant config (redacted): `channels.telegram.markdown.tables = "bullets"`

### Steps

1. Configure Telegram Markdown tables to `bullets`.
2. Send/chunk Markdown table text through Telegram outbound Markdown chunking.
3. Inspect rendered Telegram HTML chunks.

### Expected

- Table rows are converted according to `bullets`; raw `| --- |` separator text is not delivered.

### Actual

- Fixed by this PR; tests verify the configured chunk path.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: targeted unit/seam tests for format helper, Telegram outbound adapter, outbound message planning, and payload chunking context propagation.
- Edge cases checked: HTML parse-mode path remains routed to HTML splitting; Markdown table mode is only applied to Markdown chunking path.
- What you did **not** verify: live Telegram bot delivery and broad full-suite CI.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: shared outbound chunker context type changes could affect channel implementations.
  - Mitigation: additive optional fields only; existing chunkers continue to accept/ignore the third argument.