### PR TITLE
Fix Discord session recovery abort ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Docs: https://docs.openclaw.ai
 - doctor: constrain legacy plugin cleanup paths [AI]. (#84801) Thanks @pgondhi987.
 - Update/doctor: prune stale local bundled plugin install records that point at old compiled bundled output so current bundled plugin schemas win after upgrade. (#84863) Thanks @fuller-stack-dev.
 - Providers/Ollama: preserve native Ollama tool-call IDs across assistant replay so Gemini over Ollama Cloud can keep its hidden function-call thought-signature handle.
+- Discord: keep session recovery and `/stop` abort ownership on the source dispatch lane while bound ACP turns continue routing to their target session, so stalled pre-run work and late replies are cleared instead of leaking after stop. Fixes #84477. (#85100) Thanks @joshavant.
 - PDF tool: time out idle remote PDF body reads after 120 seconds so stalled remote documents return an error instead of wedging the session. Fixes #68649. (#84768) Thanks @luoyanglang.
 - Diagnostics/OpenTelemetry plugin: suppress handled OTLP exporter promise rejections so collector shutdowns no longer crash the Gateway. (#81085) Thanks @luoyanglang.
 - Media/audio: skip empty structured sherpa-onnx transcripts instead of treating the raw JSON payload as spoken text. (#84667) Thanks @TurboTheTurtle.

--- a/src/auto-reply/reply/abort.test.ts
+++ b/src/auto-reply/reply/abort.test.ts
@@ -18,8 +18,14 @@ import {
   shouldSkipMessageByAbortCutoff,
   tryFastAbortFromMessage,
 } from "./abort.js";
+import { testing as acpResetTargetTesting } from "./acp-reset-target.js";
 import { enqueueFollowupRun, getFollowupQueueDepth, type FollowupRun } from "./queue.js";
 import { testing as queueCleanupTesting } from "./queue/cleanup.js";
+import {
+  createReplyOperation,
+  replyRunRegistry,
+  testing as replyRunRegistryTesting,
+} from "./reply-run-registry.js";
 import { buildTestCtx } from "./test-ctx.js";
 
 vi.mock("../../agents/pi-embedded.js", () => ({
@@ -112,7 +118,8 @@ describe("abort detection", () => {
 
   async function runStopCommand(params: {
     cfg: OpenClawConfig;
-    sessionKey: string;
+    sessionKey?: string;
+    parentSessionKey?: string;
     from: string;
     to: string;
     senderId?: string;
@@ -126,11 +133,12 @@ describe("abort detection", () => {
         CommandBody: "/stop",
         RawBody: "/stop",
         CommandAuthorized: true,
-        SessionKey: params.sessionKey,
         Provider: "telegram",
         Surface: "telegram",
         From: params.from,
         To: params.to,
+        ...(params.sessionKey ? { SessionKey: params.sessionKey } : {}),
+        ...(params.parentSessionKey ? { ParentSessionKey: params.parentSessionKey } : {}),
         ...(params.senderId ? { SenderId: params.senderId } : {}),
         ...(params.commandSource ? { CommandSource: params.commandSource } : {}),
         ...(params.targetSessionKey ? { CommandTargetSessionKey: params.targetSessionKey } : {}),
@@ -202,7 +210,9 @@ describe("abort detection", () => {
   afterEach(() => {
     resetAbortMemoryForTest();
     abortTesting.resetDepsForTests();
+    acpResetTargetTesting.setDepsForTest();
     queueCleanupTesting.resetDepsForTests();
+    replyRunRegistryTesting.resetReplyRunRegistry();
     commandQueueMocks.clearCommandLane.mockClear().mockReturnValue(1);
     acpManagerMocks.resolveSession.mockReset().mockReturnValue({ kind: "none" });
     acpManagerMocks.cancelSession.mockReset().mockResolvedValue(undefined);
@@ -512,6 +522,296 @@ describe("abort detection", () => {
     expectSessionLaneCleared(sessionKey);
   });
 
+  it("fast-abort of an ACP target also aborts the bound source dispatch lane", async () => {
+    const sourceSessionKey = "agent:main:discord:channel:C1";
+    const acpSessionKey = "agent:codex:acp:bound-session";
+    const { root, cfg } = await createAbortConfig({
+      sessionIdsByKey: {
+        [sourceSessionKey]: "source-store-session",
+        [acpSessionKey]: "acp-store-session",
+      },
+    });
+    const sourceOperation = createReplyOperation({
+      sessionKey: sourceSessionKey,
+      sessionId: "source-active-session",
+      resetTriggered: false,
+    });
+    enqueueQueuedFollowupRun({
+      root,
+      cfg,
+      sessionId: "source-active-session",
+      sessionKey: sourceSessionKey,
+    });
+    enqueueQueuedFollowupRun({
+      root,
+      cfg,
+      sessionId: "acp-store-session",
+      sessionKey: acpSessionKey,
+    });
+    acpResetTargetTesting.setDepsForTest({
+      getSessionBindingService: () =>
+        ({
+          resolveByConversation: () => ({
+            targetKind: "session",
+            targetSessionKey: acpSessionKey,
+          }),
+        }) as never,
+      listAcpBindings: () => [],
+      resolveConfiguredBindingRecord: () => null,
+    });
+    acpManagerMocks.resolveSession.mockReturnValue({
+      kind: "ready",
+      sessionKey: acpSessionKey,
+      meta: {} as never,
+    });
+
+    const result = await runStopCommand({
+      cfg,
+      sessionKey: sourceSessionKey,
+      from: "discord:C1",
+      to: "discord:C1",
+      targetSessionKey: acpSessionKey,
+      commandSource: "native",
+    });
+
+    expect(result.handled).toBe(true);
+    expect(sourceOperation.result).toEqual({ kind: "aborted", code: "aborted_by_user" });
+    expect(replyRunRegistry.isActive(sourceSessionKey)).toBe(false);
+    expect(getFollowupQueueDepth(sourceSessionKey)).toBe(0);
+    expect(getFollowupQueueDepth(acpSessionKey)).toBe(0);
+    expectSessionLaneCleared(sourceSessionKey);
+    expectSessionLaneCleared(acpSessionKey);
+    expect(acpManagerMocks.cancelSession).toHaveBeenCalledWith({
+      cfg,
+      sessionKey: acpSessionKey,
+      reason: "fast-abort",
+    });
+  });
+
+  it("fast-abort of an ACP target aborts the source stored session when no source reply operation is registered", async () => {
+    const sourceSessionKey = "agent:main:discord:channel:C2";
+    const acpSessionKey = "agent:codex:acp:bound-session-stored-source";
+    const { root, cfg } = await createAbortConfig({
+      sessionIdsByKey: {
+        [sourceSessionKey]: "source-store-session",
+        [acpSessionKey]: "acp-store-session",
+      },
+    });
+    enqueueQueuedFollowupRun({
+      root,
+      cfg,
+      sessionId: "source-store-session",
+      sessionKey: sourceSessionKey,
+    });
+    enqueueQueuedFollowupRun({
+      root,
+      cfg,
+      sessionId: "acp-store-session",
+      sessionKey: acpSessionKey,
+    });
+    acpResetTargetTesting.setDepsForTest({
+      getSessionBindingService: () =>
+        ({
+          resolveByConversation: () => ({
+            targetKind: "session",
+            targetSessionKey: acpSessionKey,
+          }),
+        }) as never,
+      listAcpBindings: () => [],
+      resolveConfiguredBindingRecord: () => null,
+    });
+    acpManagerMocks.resolveSession.mockReturnValue({
+      kind: "ready",
+      sessionKey: acpSessionKey,
+      meta: {} as never,
+    });
+
+    const result = await runStopCommand({
+      cfg,
+      sessionKey: sourceSessionKey,
+      from: "discord:C2",
+      to: "discord:C2",
+      targetSessionKey: acpSessionKey,
+      commandSource: "native",
+    });
+
+    expect(result.handled).toBe(true);
+    expect(runtimeAbortMocks.abortEmbeddedPiRun).toHaveBeenCalledWith("source-store-session");
+    expect(getFollowupQueueDepth(sourceSessionKey)).toBe(0);
+    expect(getFollowupQueueDepth(acpSessionKey)).toBe(0);
+    expectSessionLaneCleared(sourceSessionKey);
+    expectSessionLaneCleared(acpSessionKey);
+  });
+
+  it("does not abort the caller source lane for an unbound explicit ACP target", async () => {
+    const sourceSessionKey = "agent:main:discord:channel:C3";
+    const acpSessionKey = "agent:codex:acp:unbound-explicit-target";
+    const { cfg } = await createAbortConfig({
+      sessionIdsByKey: {
+        [sourceSessionKey]: "source-store-session",
+        [acpSessionKey]: "acp-store-session",
+      },
+    });
+    const sourceOperation = createReplyOperation({
+      sessionKey: sourceSessionKey,
+      sessionId: "source-active-session",
+      resetTriggered: false,
+    });
+    acpManagerMocks.resolveSession.mockReturnValue({
+      kind: "ready",
+      sessionKey: acpSessionKey,
+      meta: {} as never,
+    });
+
+    const result = await runStopCommand({
+      cfg,
+      sessionKey: sourceSessionKey,
+      from: "discord:C3",
+      to: "discord:C3",
+      targetSessionKey: acpSessionKey,
+      commandSource: "native",
+    });
+
+    expect(result.handled).toBe(true);
+    expect(sourceOperation.result).toBeNull();
+    expect(replyRunRegistry.isActive(sourceSessionKey)).toBe(true);
+    expect(acpManagerMocks.cancelSession).toHaveBeenCalledWith({
+      cfg,
+      sessionKey: acpSessionKey,
+      reason: "fast-abort",
+    });
+    sourceOperation.complete();
+  });
+
+  it("uses ParentSessionKey as the source lane for a bound explicit ACP target", async () => {
+    const sourceSessionKey = "agent:main:discord:channel:C4";
+    const acpSessionKey = "agent:codex:acp:bound-parent-source";
+    const { cfg } = await createAbortConfig({
+      sessionIdsByKey: {
+        [sourceSessionKey]: "source-store-session",
+        [acpSessionKey]: "acp-store-session",
+      },
+    });
+    const sourceOperation = createReplyOperation({
+      sessionKey: sourceSessionKey,
+      sessionId: "source-active-session",
+      resetTriggered: false,
+    });
+    acpResetTargetTesting.setDepsForTest({
+      getSessionBindingService: () =>
+        ({
+          resolveByConversation: () => ({
+            targetKind: "session",
+            targetSessionKey: acpSessionKey,
+          }),
+        }) as never,
+      listAcpBindings: () => [],
+      resolveConfiguredBindingRecord: () => null,
+    });
+    acpManagerMocks.resolveSession.mockReturnValue({
+      kind: "ready",
+      sessionKey: acpSessionKey,
+      meta: {} as never,
+    });
+
+    const result = await runStopCommand({
+      cfg,
+      parentSessionKey: sourceSessionKey,
+      from: "discord:C4",
+      to: "discord:C4",
+      targetSessionKey: acpSessionKey,
+      commandSource: "native",
+    });
+
+    expect(result.handled).toBe(true);
+    expect(sourceOperation.result).toEqual({ kind: "aborted", code: "aborted_by_user" });
+    expect(replyRunRegistry.isActive(sourceSessionKey)).toBe(false);
+  });
+
+  it("fast-abort from an ACP-bound source conversation aborts source and bound ACP lanes", async () => {
+    const sourceSessionKey = "agent:main:telegram:direct:source-1";
+    const acpSessionKey = "agent:codex:acp:bound-source-stop";
+    const { root, storePath, cfg } = await createAbortConfig({
+      sessionIdsByKey: {
+        [sourceSessionKey]: "source-store-session",
+        [acpSessionKey]: "acp-store-session",
+      },
+    });
+    const sourceOperation = createReplyOperation({
+      sessionKey: sourceSessionKey,
+      sessionId: "source-active-session",
+      resetTriggered: false,
+    });
+    const acpOperation = createReplyOperation({
+      sessionKey: acpSessionKey,
+      sessionId: "acp-active-session",
+      resetTriggered: false,
+    });
+    enqueueQueuedFollowupRun({
+      root,
+      cfg,
+      sessionId: "source-active-session",
+      sessionKey: sourceSessionKey,
+    });
+    enqueueQueuedFollowupRun({
+      root,
+      cfg,
+      sessionId: "acp-active-session",
+      sessionKey: acpSessionKey,
+    });
+    acpResetTargetTesting.setDepsForTest({
+      getSessionBindingService: () =>
+        ({
+          resolveByConversation: () => ({
+            targetKind: "session",
+            targetSessionKey: acpSessionKey,
+          }),
+        }) as never,
+      listAcpBindings: () => [],
+      resolveConfiguredBindingRecord: () => null,
+    });
+    acpManagerMocks.resolveSession.mockReturnValue({
+      kind: "ready",
+      sessionKey: acpSessionKey,
+      meta: {} as never,
+    });
+
+    const result = await runStopCommand({
+      cfg,
+      sessionKey: sourceSessionKey,
+      from: "telegram:source-1",
+      to: "telegram:source-1",
+      messageSid: "77",
+      timestamp: 1234567890000,
+    });
+
+    expect(result.handled).toBe(true);
+    expect(sourceOperation.result).toEqual({ kind: "aborted", code: "aborted_by_user" });
+    expect(acpOperation.result).toEqual({ kind: "aborted", code: "aborted_by_user" });
+    expect(replyRunRegistry.isActive(sourceSessionKey)).toBe(false);
+    expect(replyRunRegistry.isActive(acpSessionKey)).toBe(false);
+    expect(getFollowupQueueDepth(sourceSessionKey)).toBe(0);
+    expect(getFollowupQueueDepth(acpSessionKey)).toBe(0);
+    expectSessionLaneCleared(sourceSessionKey);
+    expectSessionLaneCleared(acpSessionKey);
+    expect(acpManagerMocks.cancelSession).toHaveBeenCalledWith({
+      cfg,
+      sessionKey: acpSessionKey,
+      reason: "fast-abort",
+    });
+    const store = JSON.parse(await fs.readFile(storePath, "utf8")) as Record<
+      string,
+      {
+        abortCutoffMessageSid?: string;
+        abortCutoffTimestamp?: number;
+      }
+    >;
+    expect(store[sourceSessionKey]?.abortCutoffMessageSid).toBe("77");
+    expect(store[sourceSessionKey]?.abortCutoffTimestamp).toBe(1234567890000);
+    expect(store[acpSessionKey]?.abortCutoffMessageSid).toBeUndefined();
+    expect(store[acpSessionKey]?.abortCutoffTimestamp).toBeUndefined();
+  });
+
   it("persists abort cutoff metadata on /stop when command and target session match", async () => {
     const sessionKey = "telegram:123";
     const sessionId = "session-123";
@@ -538,6 +838,34 @@ describe("abort detection", () => {
     expect(entry.abortedLastRun).toBe(true);
     expect(entry.abortCutoffMessageSid).toBe("55");
     expect(entry.abortCutoffTimestamp).toBe(1234567890000);
+  });
+
+  it("persists abort cutoff metadata when only ParentSessionKey identifies the command session", async () => {
+    const sessionKey = "telegram:parent-only";
+    const sessionId = "session-parent-only";
+    const { storePath, cfg } = await createAbortConfig({
+      sessionIdsByKey: { [sessionKey]: sessionId },
+    });
+
+    const result = await runStopCommand({
+      cfg,
+      parentSessionKey: sessionKey,
+      from: "telegram:parent-only",
+      to: "telegram:parent-only",
+      messageSid: "56",
+      timestamp: 1234567890001,
+    });
+
+    expect(result.handled).toBe(true);
+    const store = JSON.parse(await fs.readFile(storePath, "utf8")) as Record<string, unknown>;
+    const entry = store[sessionKey] as {
+      abortedLastRun?: boolean;
+      abortCutoffMessageSid?: string;
+      abortCutoffTimestamp?: number;
+    };
+    expect(entry.abortedLastRun).toBe(true);
+    expect(entry.abortCutoffMessageSid).toBe("56");
+    expect(entry.abortCutoffTimestamp).toBe(1234567890001);
   });
 
   it("does not persist cutoff metadata when native /stop targets a different session", async () => {

--- a/src/auto-reply/reply/abort.ts
+++ b/src/auto-reply/reply/abort.ts
@@ -24,7 +24,7 @@ import {
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
 import { formatErrorMessage } from "../../infra/errors.js";
-import { parseAgentSessionKey } from "../../routing/session-key.js";
+import { isAcpSessionKey, parseAgentSessionKey } from "../../routing/session-key.js";
 import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
@@ -44,6 +44,8 @@ import {
   resetAbortMemoryForTest,
   setAbortMemory,
 } from "./abort-primitives.js";
+import { resolveEffectiveResetTargetSessionKey } from "./acp-reset-target.js";
+import { resolveConversationBindingContextFromMessage } from "./conversation-binding-input.js";
 import { stripMentions, stripStructuralPrefixes } from "./mentions.js";
 import { clearSessionQueues } from "./queue.js";
 import { replyRunRegistry } from "./reply-run-registry.js";
@@ -150,6 +152,47 @@ export function resolveSessionEntryForKey(
   return {};
 }
 
+function resolveStoredSessionId(params: {
+  cfg: OpenClawConfig;
+  sessionKey: string;
+}): string | undefined {
+  const agentId = resolveSessionAgentId({
+    sessionKey: params.sessionKey,
+    config: params.cfg,
+  });
+  const storePath = resolveStorePath(params.cfg.session?.store, { agentId });
+  try {
+    const store = loadSessionStore(storePath);
+    return resolveSessionEntryForKey(store, params.sessionKey).entry?.sessionId;
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveBoundAcpAbortTargetSessionKey(params: {
+  ctx: FinalizedMsgContext;
+  cfg: OpenClawConfig;
+  activeSessionKey: string;
+}): string | undefined {
+  const bindingContext = resolveConversationBindingContextFromMessage({
+    cfg: params.cfg,
+    ctx: params.ctx,
+  });
+  if (!bindingContext) {
+    return undefined;
+  }
+  return resolveEffectiveResetTargetSessionKey({
+    cfg: params.cfg,
+    channel: bindingContext.channel,
+    accountId: bindingContext.accountId,
+    conversationId: bindingContext.conversationId,
+    parentConversationId: bindingContext.parentConversationId,
+    activeSessionKey: params.activeSessionKey,
+    skipConfiguredFallbackWhenActiveSessionNonAcp: false,
+    fallbackToActiveAcpWhenUnbound: false,
+  });
+}
+
 function normalizeRequesterSessionKey(
   cfg: OpenClawConfig,
   key: string | undefined,
@@ -254,8 +297,9 @@ export async function tryFastAbortFromMessage(params: {
   cfg: OpenClawConfig;
 }): Promise<{ handled: boolean; aborted: boolean; stoppedSubagents?: number }> {
   const { ctx, cfg } = params;
-  const targetKey =
-    normalizeOptionalString(ctx.CommandTargetSessionKey) ?? normalizeOptionalString(ctx.SessionKey);
+  const commandSessionKey =
+    normalizeOptionalString(ctx.SessionKey) ?? normalizeOptionalString(ctx.ParentSessionKey);
+  const targetKey = normalizeOptionalString(ctx.CommandTargetSessionKey) ?? commandSessionKey;
   // Use RawBody/CommandBody for abort detection (clean message without structural context).
   const raw = stripStructuralPrefixes(ctx.CommandBody ?? ctx.RawBody ?? ctx.Body ?? "");
   const isGroup = normalizeOptionalLowercaseString(ctx.ChatType) === "group";
@@ -297,34 +341,86 @@ export async function tryFastAbortFromMessage(params: {
     const store = loadSessionStore(storePath);
     const { entry, key, legacyKeys } = resolveSessionEntryForKey(store, targetKey);
     const resolvedTargetKey = key ?? targetKey;
+    const conversationBoundAcpTargetKey = commandSessionKey
+      ? resolveBoundAcpAbortTargetSessionKey({
+          ctx,
+          cfg,
+          activeSessionKey: commandSessionKey,
+        })
+      : undefined;
+    const boundAcpTargetKey = !isAcpSessionKey(resolvedTargetKey)
+      ? conversationBoundAcpTargetKey
+      : undefined;
+    const abortTargetKeys = [resolvedTargetKey];
+    if (boundAcpTargetKey && boundAcpTargetKey !== resolvedTargetKey) {
+      abortTargetKeys.push(boundAcpTargetKey);
+    }
     const acpManager = abortDeps.getAcpSessionManager();
-    const acpResolution = acpManager.resolveSession({
-      cfg,
-      sessionKey: resolvedTargetKey,
-    });
-    if (acpResolution.kind !== "none") {
+    for (const acpTargetKey of abortTargetKeys.filter(isAcpSessionKey)) {
+      const acpResolution = acpManager.resolveSession({
+        cfg,
+        sessionKey: acpTargetKey,
+      });
+      if (acpResolution.kind === "none") {
+        continue;
+      }
       try {
         await acpManager.cancelSession({
           cfg,
-          sessionKey: resolvedTargetKey,
+          sessionKey: acpTargetKey,
           reason: "fast-abort",
         });
       } catch (error) {
-        logVerbose(
-          `abort: ACP cancel failed for ${resolvedTargetKey}: ${formatErrorMessage(error)}`,
-        );
+        logVerbose(`abort: ACP cancel failed for ${acpTargetKey}: ${formatErrorMessage(error)}`);
       }
     }
-    const sessionId = replyRunRegistry.resolveSessionId(resolvedTargetKey) ?? entry?.sessionId;
-    const aborted = abortSessionRunTarget({ key: resolvedTargetKey, sessionId });
-    const cleared = clearSessionQueues([resolvedTargetKey, sessionId]);
+    const sourceAbortKey =
+      commandSessionKey &&
+      !abortTargetKeys.includes(commandSessionKey) &&
+      conversationBoundAcpTargetKey &&
+      abortTargetKeys.includes(conversationBoundAcpTargetKey)
+        ? commandSessionKey
+        : undefined;
+    const sessionIdsByKey = new Map<string, string | undefined>(
+      abortTargetKeys.map((abortTargetKey) => [
+        abortTargetKey,
+        replyRunRegistry.resolveSessionId(abortTargetKey) ??
+          (abortTargetKey === resolvedTargetKey
+            ? entry?.sessionId
+            : resolveStoredSessionId({ cfg, sessionKey: abortTargetKey })),
+      ]),
+    );
+    let aborted = false;
+    for (const abortTargetKey of abortTargetKeys) {
+      aborted =
+        abortSessionRunTarget({
+          key: abortTargetKey,
+          sessionId: sessionIdsByKey.get(abortTargetKey),
+        }) || aborted;
+    }
+    const sourceSessionId = sourceAbortKey
+      ? (replyRunRegistry.resolveSessionId(sourceAbortKey) ??
+        resolveStoredSessionId({ cfg, sessionKey: sourceAbortKey }))
+      : undefined;
+    if (sourceAbortKey) {
+      aborted =
+        abortSessionRunTarget({ key: sourceAbortKey, sessionId: sourceSessionId }) || aborted;
+    }
+    const cleared = clearSessionQueues(
+      abortTargetKeys
+        .flatMap((abortTargetKey) => [abortTargetKey, sessionIdsByKey.get(abortTargetKey)])
+        .concat(sourceAbortKey, sourceSessionId),
+    );
     if (cleared.followupCleared > 0 || cleared.laneCleared > 0) {
       logVerbose(
         `abort: cleared followups=${cleared.followupCleared} lane=${cleared.laneCleared} keys=${cleared.keys.join(",")}`,
       );
     }
+    // Cutoff metadata is only safe in the command session's message id/time
+    // space. Bound ACP/source stops may abort extra lanes, but those lanes do
+    // not necessarily share the source conversation's message ordering.
     const abortCutoff = shouldPersistAbortCutoff({
-      commandSessionKey: ctx.SessionKey,
+      commandSessionKey,
       targetSessionKey: resolvedTargetKey,
     })
       ? resolveAbortCutoffFromContext(ctx)

--- a/src/auto-reply/reply/dispatch-from-config.acp-abort.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.acp-abort.test.ts
@@ -22,23 +22,28 @@ import {
   sessionBindingMocks,
   sessionStoreMocks,
   setDiscordTestRegistry,
+  ttsMocks,
 } from "./dispatch-from-config.shared.test-harness.js";
 import { buildTestCtx } from "./test-ctx.js";
 
 let dispatchReplyFromConfig: typeof import("./dispatch-from-config.js").dispatchReplyFromConfig;
 let tryDispatchAcpReplyHook: typeof import("../../plugin-sdk/acp-runtime.js").tryDispatchAcpReplyHook;
 let resetInboundDedupe: typeof import("./inbound-dedupe.js").resetInboundDedupe;
+let replyRunRegistry: typeof import("./reply-run-registry.js").replyRunRegistry;
+let getActiveReplyRunCount: typeof import("./reply-run-registry.js").getActiveReplyRunCount;
+let createReplyOperation: typeof import("./reply-run-registry.js").createReplyOperation;
 
 function shouldUseAcpReplyDispatchHook(eventUnknown: unknown): boolean {
   const event = eventUnknown as {
     sessionKey?: string;
+    isTailDispatch?: boolean;
     ctx?: {
       SessionKey?: string;
       CommandTargetSessionKey?: string;
       AcpDispatchTailAfterReset?: boolean;
     };
   };
-  if (event.ctx?.AcpDispatchTailAfterReset) {
+  if (event.isTailDispatch === true) {
     return true;
   }
   return [event.sessionKey, event.ctx?.SessionKey, event.ctx?.CommandTargetSessionKey].some(
@@ -150,6 +155,8 @@ describe("dispatchReplyFromConfig ACP abort", () => {
     ({ dispatchReplyFromConfig } = await import("./dispatch-from-config.js"));
     ({ tryDispatchAcpReplyHook } = await import("../../plugin-sdk/acp-runtime.js"));
     ({ resetInboundDedupe } = await import("./inbound-dedupe.js"));
+    ({ replyRunRegistry, getActiveReplyRunCount, createReplyOperation } =
+      await import("./reply-run-registry.js"));
   });
 
   beforeEach(() => {
@@ -289,5 +296,730 @@ describe("dispatchReplyFromConfig ACP abort", () => {
     await dispatchPromise;
 
     expect(outcome).toBe("settled");
+    expect(getActiveReplyRunCount()).toBe(0);
+  });
+
+  it("completes the dispatch-owned operation when ACP tail dispatch handles the turn", async () => {
+    hookMocks.runner.runReplyDispatch.mockImplementation(async (eventUnknown: unknown) => {
+      const event = eventUnknown as {
+        isTailDispatch?: boolean;
+      };
+      if (event.isTailDispatch === true) {
+        return {
+          handled: true,
+          queuedFinal: false,
+          counts: { tool: 0, block: 0, final: 0 },
+        };
+      }
+      return undefined;
+    });
+
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "discord",
+      Surface: "discord",
+      SessionKey: "agent:regular-tail",
+      BodyForAgent: "/reset continue",
+    });
+    const result = await dispatchReplyFromConfig({
+      ctx,
+      cfg: {
+        acp: {
+          enabled: true,
+          dispatch: { enabled: true },
+        },
+        diagnostics: { enabled: true },
+        session: {
+          sendPolicy: { default: "allow" },
+        },
+      } as OpenClawConfig,
+      dispatcher,
+      replyResolver: async (resolverCtx) => {
+        resolverCtx.AcpDispatchTailAfterReset = true;
+        return undefined;
+      },
+    });
+
+    expect(result.counts.final).toBe(0);
+    expect(hookMocks.runner.runReplyDispatch).toHaveBeenCalledTimes(2);
+    expect(getActiveReplyRunCount()).toBe(0);
+  });
+
+  it("treats an aborted ACP tail dispatch as a handled dispatch", async () => {
+    let tailDispatchStarted!: () => void;
+    const tailDispatchStartedPromise = new Promise<void>((resolve) => {
+      tailDispatchStarted = resolve;
+    });
+    hookMocks.runner.runReplyDispatch.mockImplementation(
+      async (eventUnknown: unknown, hookCtxUnknown: unknown) => {
+        const event = eventUnknown as {
+          isTailDispatch?: boolean;
+        };
+        if (event.isTailDispatch === true) {
+          const hookCtx = hookCtxUnknown as { abortSignal?: AbortSignal };
+          expect(hookCtx.abortSignal).toBeDefined();
+          tailDispatchStarted();
+          return new Promise<never>(() => {});
+        }
+        return undefined;
+      },
+    );
+
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "discord",
+      Surface: "discord",
+      SessionKey: "agent:tail-abort",
+      BodyForAgent: "/reset continue",
+    });
+    const dispatchPromise = dispatchReplyFromConfig({
+      ctx,
+      cfg: {
+        acp: {
+          enabled: true,
+          dispatch: { enabled: true },
+        },
+        diagnostics: { enabled: true },
+        session: {
+          sendPolicy: { default: "allow" },
+        },
+      } as OpenClawConfig,
+      dispatcher,
+      replyResolver: async (resolverCtx) => {
+        resolverCtx.AcpDispatchTailAfterReset = true;
+        return undefined;
+      },
+    });
+
+    await tailDispatchStartedPromise;
+    expect(replyRunRegistry.abort("agent:tail-abort")).toBe(true);
+
+    await expect(dispatchPromise).resolves.toMatchObject({
+      queuedFinal: false,
+      counts: { tool: 0, block: 0, final: 0 },
+    });
+    expect(getActiveReplyRunCount()).toBe(0);
+  });
+
+  it("suppresses late reply_dispatch sends when a hook ignores a dispatch abort", async () => {
+    let hookStarted!: () => void;
+    let releaseHook!: () => void;
+    let hookCompleted!: () => void;
+    const hookStartedPromise = new Promise<void>((resolve) => {
+      hookStarted = resolve;
+    });
+    const releaseHookPromise = new Promise<void>((resolve) => {
+      releaseHook = resolve;
+    });
+    const hookCompletedPromise = new Promise<void>((resolve) => {
+      hookCompleted = resolve;
+    });
+    const lateSendResults: boolean[] = [];
+
+    hookMocks.runner.runReplyDispatch.mockImplementation(
+      async (_eventUnknown: unknown, hookCtxUnknown: unknown) => {
+        const hookCtx = hookCtxUnknown as {
+          dispatcher: {
+            sendToolResult: (payload: { text: string }) => boolean;
+            sendBlockReply: (payload: { text: string }) => boolean;
+            sendFinalReply: (payload: { text: string }) => boolean;
+            getQueuedCounts: () => { tool: number; block: number; final: number };
+          };
+        };
+        hookStarted();
+        await releaseHookPromise;
+        lateSendResults.push(
+          hookCtx.dispatcher.sendToolResult({ text: "late tool should not send" }),
+          hookCtx.dispatcher.sendBlockReply({ text: "late block should not send" }),
+          hookCtx.dispatcher.sendFinalReply({ text: "late final should not send" }),
+        );
+        hookCompleted();
+        return {
+          handled: true,
+          queuedFinal: false,
+          counts: hookCtx.dispatcher.getQueuedCounts(),
+        };
+      },
+    );
+
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "discord",
+      Surface: "discord",
+      SessionKey: "agent:reply-dispatch-abort",
+      BodyForAgent: "hang in reply dispatch",
+    });
+    const dispatchPromise = dispatchReplyFromConfig({
+      ctx,
+      cfg: {
+        diagnostics: { enabled: true },
+        session: {
+          sendPolicy: { default: "allow" },
+        },
+      } as OpenClawConfig,
+      dispatcher,
+      replyResolver: vi.fn(),
+    });
+
+    await hookStartedPromise;
+    expect(replyRunRegistry.abort("agent:reply-dispatch-abort")).toBe(true);
+
+    await expect(dispatchPromise).resolves.toMatchObject({
+      queuedFinal: false,
+      counts: { tool: 0, block: 0, final: 0 },
+    });
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
+    expect(dispatcher.sendBlockReply).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+
+    releaseHook();
+    await hookCompletedPromise;
+    expect(lateSendResults).toEqual([false, false, false]);
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
+    expect(dispatcher.sendBlockReply).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+    expect(getActiveReplyRunCount()).toBe(0);
+  });
+
+  it("keys bound ACP tail abort ownership to the source dispatch session", async () => {
+    const sourceSessionKey = "agent:main:discord:channel:C1";
+    const boundAcpSessionKey = "agent:codex:acp:bound-session";
+    const boundConversation = {
+      bindingId: "binding-acp-tail",
+      targetSessionKey: boundAcpSessionKey,
+      targetKind: "session" as const,
+      status: "active" as const,
+      boundAt: Date.now(),
+      conversation: {
+        channel: "discord",
+        accountId: "default",
+        conversationId: "C1",
+      },
+    };
+    const sessionStore = {
+      [sourceSessionKey]: {
+        sessionId: "source-session-id",
+        updatedAt: Date.now(),
+      },
+      [boundAcpSessionKey]: {
+        sessionId: "acp-session-id",
+        updatedAt: Date.now(),
+      },
+    };
+    sessionBindingMocks.resolveByConversation.mockReturnValue(boundConversation);
+    sessionStoreMocks.loadSessionStore.mockReturnValue(sessionStore);
+    sessionStoreMocks.resolveSessionStoreEntry.mockImplementation((...args: unknown[]) => {
+      const params = args[0] as { store?: Record<string, unknown>; sessionKey?: string };
+      const existing =
+        params.store && params.sessionKey ? params.store[params.sessionKey] : undefined;
+      return {
+        existing:
+          existing && typeof existing === "object"
+            ? (existing as Record<string, unknown>)
+            : undefined,
+      };
+    });
+    acpMocks.readAcpSessionEntry.mockImplementation((params: { sessionKey: string }) =>
+      params.sessionKey === boundAcpSessionKey
+        ? {
+            sessionKey: boundAcpSessionKey,
+            storeSessionKey: boundAcpSessionKey,
+            cfg: {},
+            storePath: "/tmp/mock-sessions.json",
+            entry: sessionStore[boundAcpSessionKey],
+            acp: {
+              backend: "acpx",
+              agent: "codex",
+              runtimeSessionName: "runtime:bound",
+              mode: "persistent",
+              state: "idle",
+              lastActivityAt: Date.now(),
+            },
+          }
+        : null,
+    );
+
+    let tailDispatchStarted!: () => void;
+    const tailDispatchStartedPromise = new Promise<void>((resolve) => {
+      tailDispatchStarted = resolve;
+    });
+    hookMocks.runner.runReplyDispatch.mockImplementation(
+      async (eventUnknown: unknown, hookCtxUnknown: unknown) => {
+        const event = eventUnknown as {
+          sessionKey?: string;
+          isTailDispatch?: boolean;
+        };
+        if (event.isTailDispatch === true) {
+          const hookCtx = hookCtxUnknown as { abortSignal?: AbortSignal };
+          expect(event.sessionKey).toBe(boundAcpSessionKey);
+          expect(hookCtx.abortSignal).toBeDefined();
+          tailDispatchStarted();
+          return new Promise<never>(() => {});
+        }
+        return undefined;
+      },
+    );
+
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "discord",
+      Surface: "discord",
+      OriginatingChannel: "discord",
+      AccountId: "default",
+      To: "C1",
+      SessionKey: sourceSessionKey,
+      BodyForAgent: "/reset continue",
+    });
+    const dispatchPromise = dispatchReplyFromConfig({
+      ctx,
+      cfg: {
+        acp: {
+          enabled: true,
+          dispatch: { enabled: true },
+        },
+        diagnostics: { enabled: true },
+        session: {
+          sendPolicy: { default: "allow" },
+        },
+      } as OpenClawConfig,
+      dispatcher,
+      replyResolver: async (resolverCtx) => {
+        resolverCtx.AcpDispatchTailAfterReset = true;
+        return undefined;
+      },
+    });
+
+    await tailDispatchStartedPromise;
+    expect(replyRunRegistry.abort(boundAcpSessionKey)).toBe(false);
+    expect(replyRunRegistry.abort(sourceSessionKey)).toBe(true);
+
+    await expect(dispatchPromise).resolves.toMatchObject({
+      queuedFinal: false,
+      counts: { tool: 0, block: 0, final: 0 },
+    });
+    expect(getActiveReplyRunCount()).toBe(0);
+  });
+
+  it("treats a pre-dispatch reply operation abort as a handled dispatch", async () => {
+    hookMocks.runner.hasHooks.mockImplementation(
+      (hookName?: string) => hookName === "before_dispatch",
+    );
+    let beforeDispatchStarted!: () => void;
+    const beforeDispatchStartedPromise = new Promise<void>((resolve) => {
+      beforeDispatchStarted = resolve;
+    });
+    hookMocks.runner.runBeforeDispatch.mockImplementation(
+      async () =>
+        new Promise<undefined>(() => {
+          beforeDispatchStarted();
+        }),
+    );
+
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "discord",
+      Surface: "discord",
+      SessionKey: "agent:pre-dispatch-abort",
+      BodyForAgent: "hang in before dispatch",
+    });
+    const dispatchPromise = dispatchReplyFromConfig({
+      ctx,
+      cfg: {
+        diagnostics: { enabled: true },
+        session: {
+          sendPolicy: { default: "allow" },
+        },
+      } as OpenClawConfig,
+      dispatcher,
+      replyResolver: vi.fn(),
+    });
+
+    await beforeDispatchStartedPromise;
+    expect(replyRunRegistry.abort("agent:pre-dispatch-abort")).toBe(true);
+
+    await expect(dispatchPromise).resolves.toMatchObject({
+      queuedFinal: false,
+      counts: { tool: 0, block: 0, final: 0 },
+    });
+    expect(diagnosticMocks.logMessageProcessed).toHaveBeenCalledWith(
+      expect.objectContaining({
+        outcome: "completed",
+        reason: "reply_operation_aborted",
+      }),
+    );
+    expect(getActiveReplyRunCount()).toBe(0);
+  });
+
+  it("registers pre-dispatch abort ownership when diagnostics are disabled", async () => {
+    hookMocks.runner.hasHooks.mockImplementation(
+      (hookName?: string) => hookName === "before_dispatch",
+    );
+    let beforeDispatchStarted!: () => void;
+    const beforeDispatchStartedPromise = new Promise<void>((resolve) => {
+      beforeDispatchStarted = resolve;
+    });
+    hookMocks.runner.runBeforeDispatch.mockImplementation(
+      async () =>
+        new Promise<undefined>(() => {
+          beforeDispatchStarted();
+        }),
+    );
+
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "discord",
+      Surface: "discord",
+      SessionKey: "agent:diagnostics-disabled-abort",
+      BodyForAgent: "hang in before dispatch",
+    });
+    const dispatchPromise = dispatchReplyFromConfig({
+      ctx,
+      cfg: {
+        diagnostics: { enabled: false },
+        session: {
+          sendPolicy: { default: "allow" },
+        },
+      } as OpenClawConfig,
+      dispatcher,
+      replyResolver: vi.fn(),
+    });
+
+    await beforeDispatchStartedPromise;
+    expect(replyRunRegistry.abort("agent:diagnostics-disabled-abort")).toBe(true);
+
+    await expect(dispatchPromise).resolves.toMatchObject({
+      queuedFinal: false,
+      counts: { tool: 0, block: 0, final: 0 },
+    });
+    expect(diagnosticMocks.logMessageProcessed).not.toHaveBeenCalled();
+    expect(getActiveReplyRunCount()).toBe(0);
+  });
+
+  it("uses an already-active source operation to abort pre-dispatch hooks without owning it", async () => {
+    hookMocks.runner.hasHooks.mockImplementation(
+      (hookName?: string) => hookName === "before_dispatch",
+    );
+    let beforeDispatchStarted!: () => void;
+    const beforeDispatchStartedPromise = new Promise<void>((resolve) => {
+      beforeDispatchStarted = resolve;
+    });
+    hookMocks.runner.runBeforeDispatch.mockImplementation(
+      async () =>
+        new Promise<undefined>(() => {
+          beforeDispatchStarted();
+        }),
+    );
+
+    const existingOperation = createReplyOperation({
+      sessionKey: "agent:already-active",
+      sessionId: "already-active-session",
+      resetTriggered: false,
+    });
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "discord",
+      Surface: "discord",
+      SessionKey: "agent:already-active",
+      BodyForAgent: "hang while an operation is already active",
+    });
+    const dispatchPromise = dispatchReplyFromConfig({
+      ctx,
+      cfg: {
+        diagnostics: { enabled: true },
+        session: {
+          sendPolicy: { default: "allow" },
+        },
+      } as OpenClawConfig,
+      dispatcher,
+      replyResolver: vi.fn(),
+    });
+
+    await expect(
+      raceWithTimeoutResult(
+        beforeDispatchStartedPromise.then(() => "started" as const),
+        100,
+        "pending" as const,
+      ),
+    ).resolves.toBe("started");
+    expect(replyRunRegistry.abort("agent:already-active")).toBe(true);
+
+    type DispatchOutcome =
+      | { status: "settled"; result: Awaited<typeof dispatchPromise> }
+      | { status: "pending" };
+    const outcome = await raceWithTimeoutResult<DispatchOutcome>(
+      dispatchPromise.then((result) => ({ status: "settled" as const, result })),
+      100,
+      { status: "pending" as const },
+    );
+    expect(outcome).toMatchObject({
+      status: "settled",
+      result: {
+        queuedFinal: false,
+        counts: { tool: 0, block: 0, final: 0 },
+      },
+    });
+    expect(existingOperation.result).toEqual({ kind: "aborted", code: "aborted_by_user" });
+    expect(getActiveReplyRunCount()).toBe(0);
+  });
+
+  it("suppresses late callback and final replies when the resolver ignores a dispatch abort", async () => {
+    let resolverStarted!: () => void;
+    let releaseResolver!: () => void;
+    const resolverStartedPromise = new Promise<void>((resolve) => {
+      resolverStarted = resolve;
+    });
+    const releaseResolverPromise = new Promise<void>((resolve) => {
+      releaseResolver = resolve;
+    });
+
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "discord",
+      Surface: "discord",
+      SessionKey: "agent:resolver-abort",
+      BodyForAgent: "hang in resolver",
+    });
+    const dispatchPromise = dispatchReplyFromConfig({
+      ctx,
+      cfg: {
+        diagnostics: { enabled: true },
+        session: {
+          sendPolicy: { default: "allow" },
+        },
+      } as OpenClawConfig,
+      dispatcher,
+      replyResolver: async (_resolverCtx, options) => {
+        resolverStarted();
+        await releaseResolverPromise;
+        await options?.onToolResult?.({ text: "late tool should not send" });
+        await options?.onBlockReply?.({ text: "late block should not send" });
+        return { text: "late final should not send" };
+      },
+    });
+
+    await resolverStartedPromise;
+    expect(replyRunRegistry.abort("agent:resolver-abort")).toBe(true);
+
+    await expect(dispatchPromise).resolves.toMatchObject({
+      queuedFinal: false,
+      counts: { tool: 0, block: 0, final: 0 },
+    });
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+
+    releaseResolver();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
+    expect(dispatcher.sendBlockReply).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+    expect(getActiveReplyRunCount()).toBe(0);
+  });
+
+  it("suppresses final reply delivery when dispatch aborts during final normalization", async () => {
+    let ttsStarted!: () => void;
+    let releaseTts!: () => void;
+    const ttsStartedPromise = new Promise<void>((resolve) => {
+      ttsStarted = resolve;
+    });
+    const releaseTtsPromise = new Promise<void>((resolve) => {
+      releaseTts = resolve;
+    });
+    ttsMocks.maybeApplyTtsToPayload.mockImplementation(async (paramsUnknown: unknown) => {
+      const params = paramsUnknown as { payload: { text?: string } };
+      if (params.payload.text === "late final should not send") {
+        ttsStarted();
+        await releaseTtsPromise;
+      }
+      return params.payload;
+    });
+
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "discord",
+      Surface: "discord",
+      SessionKey: "agent:final-normalization-abort",
+      BodyForAgent: "finish while stop races final delivery",
+    });
+    const dispatchPromise = dispatchReplyFromConfig({
+      ctx,
+      cfg: {
+        diagnostics: { enabled: true },
+        session: {
+          sendPolicy: { default: "allow" },
+        },
+      } as OpenClawConfig,
+      dispatcher,
+      replyResolver: async (_resolverCtx, options) => {
+        (
+          options as { replyOperation?: { complete: () => void } } | undefined
+        )?.replyOperation?.complete();
+        return { text: "late final should not send" };
+      },
+    });
+
+    await ttsStartedPromise;
+    expect(replyRunRegistry.abort("agent:final-normalization-abort")).toBe(true);
+    releaseTts();
+
+    await expect(dispatchPromise).resolves.toMatchObject({
+      queuedFinal: false,
+      counts: { tool: 0, block: 0, final: 0 },
+    });
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+    expect(diagnosticMocks.logMessageProcessed).toHaveBeenCalledWith(
+      expect.objectContaining({
+        outcome: "completed",
+        reason: "reply_operation_aborted",
+      }),
+    );
+    expect(getActiveReplyRunCount()).toBe(0);
+  });
+
+  it("treats a resolver AbortError after dispatch abort as a handled dispatch", async () => {
+    let resolverStarted!: () => void;
+    const resolverStartedPromise = new Promise<void>((resolve) => {
+      resolverStarted = resolve;
+    });
+
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "discord",
+      Surface: "discord",
+      SessionKey: "agent:resolver-abort-error",
+      BodyForAgent: "abort in resolver",
+    });
+    const dispatchPromise = dispatchReplyFromConfig({
+      ctx,
+      cfg: {
+        diagnostics: { enabled: true },
+        session: {
+          sendPolicy: { default: "allow" },
+        },
+      } as OpenClawConfig,
+      dispatcher,
+      replyResolver: async (_resolverCtx, options) => {
+        resolverStarted();
+        const abortSignal = options?.abortSignal;
+        if (!abortSignal) {
+          throw new Error("expected dispatch abort signal");
+        }
+        await new Promise<void>((resolve) => {
+          abortSignal.addEventListener("abort", () => resolve(), { once: true });
+        });
+        const err = new Error("resolver aborted");
+        err.name = "AbortError";
+        throw err;
+      },
+    });
+
+    await resolverStartedPromise;
+    expect(replyRunRegistry.abort("agent:resolver-abort-error")).toBe(true);
+
+    await expect(dispatchPromise).resolves.toMatchObject({
+      queuedFinal: false,
+      counts: { tool: 0, block: 0, final: 0 },
+    });
+    expect(diagnosticMocks.logMessageProcessed).toHaveBeenCalledWith(
+      expect.objectContaining({
+        outcome: "completed",
+        reason: "reply_operation_aborted",
+      }),
+    );
+    expect(getActiveReplyRunCount()).toBe(0);
+  });
+
+  it("keys native command pre-dispatch ownership to the command target session", async () => {
+    hookMocks.runner.hasHooks.mockImplementation(
+      (hookName?: string) => hookName === "before_dispatch",
+    );
+    let beforeDispatchStarted!: () => void;
+    const beforeDispatchStartedPromise = new Promise<void>((resolve) => {
+      beforeDispatchStarted = resolve;
+    });
+    hookMocks.runner.runBeforeDispatch.mockImplementation(
+      async () =>
+        new Promise<undefined>(() => {
+          beforeDispatchStarted();
+        }),
+    );
+
+    const sourceSessionKey = "agent:main:discord:slash:user-1";
+    const targetSessionKey = "agent:main:discord:channel:target-1";
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "discord",
+      Surface: "discord",
+      CommandSource: "native",
+      CommandTurn: {
+        kind: "native",
+        source: "native",
+        authorized: true,
+      },
+      SessionKey: sourceSessionKey,
+      CommandTargetSessionKey: targetSessionKey,
+      BodyForAgent: "hang before command target dispatch",
+    });
+    const dispatchPromise = dispatchReplyFromConfig({
+      ctx,
+      cfg: {
+        diagnostics: { enabled: true },
+        session: {
+          sendPolicy: { default: "allow" },
+        },
+      } as OpenClawConfig,
+      dispatcher,
+      replyResolver: vi.fn(),
+    });
+
+    await expect(
+      raceWithTimeoutResult(
+        beforeDispatchStartedPromise.then(() => "started" as const),
+        100,
+        "pending" as const,
+      ),
+    ).resolves.toBe("started");
+    expect(replyRunRegistry.abort(sourceSessionKey)).toBe(false);
+    expect(replyRunRegistry.abort(targetSessionKey)).toBe(true);
+
+    await expect(dispatchPromise).resolves.toMatchObject({
+      queuedFinal: false,
+      counts: { tool: 0, block: 0, final: 0 },
+    });
+    expect(getActiveReplyRunCount()).toBe(0);
+  });
+
+  it("does not let a current-session fast abort abort its own dispatch operation", async () => {
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "discord",
+      Surface: "discord",
+      SessionKey: "agent:self-stop",
+      BodyForAgent: "/stop",
+    });
+    const replyResolver = vi.fn();
+
+    await expect(
+      dispatchReplyFromConfig({
+        ctx,
+        cfg: {
+          diagnostics: { enabled: true },
+          session: {
+            sendPolicy: { default: "allow" },
+          },
+        } as OpenClawConfig,
+        dispatcher,
+        replyResolver,
+        fastAbortResolver: async () => {
+          expect(replyRunRegistry.abort("agent:self-stop")).toBe(false);
+          return { handled: true, aborted: true };
+        },
+        formatAbortReplyTextResolver: () => "stopped",
+      }),
+    ).resolves.toMatchObject({
+      queuedFinal: true,
+    });
+
+    expect(replyResolver).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "stopped" });
+    expect(getActiveReplyRunCount()).toBe(0);
   });
 });

--- a/src/auto-reply/reply/dispatch-from-config.shared.test-harness.ts
+++ b/src/auto-reply/reply/dispatch-from-config.shared.test-harness.ts
@@ -153,6 +153,7 @@ export {
   sessionBindingMocks,
   sessionStoreMocks,
   runtimePluginMocks,
+  ttsMocks,
 };
 
 function parseGenericThreadSessionInfo(sessionKey: string | undefined) {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import {
   hasOutboundReplyContent,
   resolveSendableOutboundReplyParts,
@@ -53,6 +54,7 @@ import { isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
 import { measureDiagnosticsTimelineSpan } from "../../infra/diagnostics-timeline.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { getSessionBindingService } from "../../infra/outbound/session-binding-service.js";
+import { isAbortError } from "../../infra/unhandled-rejections.js";
 import {
   logMessageDispatchCompleted,
   logMessageDispatchStarted,
@@ -118,6 +120,13 @@ import { resolveEffectiveReplyRoute } from "./effective-reply-route.js";
 import { withFullRuntimeReplyConfig } from "./get-reply-fast-path.js";
 import { claimInboundDedupe, commitInboundDedupe, releaseInboundDedupe } from "./inbound-dedupe.js";
 import { resolveOriginMessageProvider } from "./origin-routing.js";
+import type { ReplyDispatcher } from "./reply-dispatcher.types.js";
+import {
+  createReplyOperation,
+  replyRunRegistry,
+  ReplyRunAlreadyActiveError,
+  type ReplyOperation,
+} from "./reply-run-registry.js";
 import { resolveRoutedDeliveryThreadId } from "./routed-delivery-thread.js";
 import { resolveReplyRoutingDecision } from "./routing-policy.js";
 import {
@@ -126,6 +135,19 @@ import {
 } from "./source-reply-delivery-mode.js";
 import { resolveStoredModelOverride } from "./stored-model-override.js";
 import { resolveRunTypingPolicy } from "./typing-policy.js";
+
+class DispatchReplyOperationAbortedError extends Error {
+  constructor() {
+    super("Dispatch reply operation aborted");
+    this.name = "AbortError";
+  }
+}
+
+function isDispatchReplyOperationAbortedError(
+  error: unknown,
+): error is DispatchReplyOperationAbortedError {
+  return error instanceof DispatchReplyOperationAbortedError;
+}
 
 const routeReplyRuntimeLoader = createLazyImportLoader(() => import("./route-reply.runtime.js"));
 const getReplyFromConfigRuntimeLoader = createLazyImportLoader(
@@ -598,6 +620,78 @@ async function mirrorInternalSourceReplyToTranscript(params: {
   }
 }
 
+function runWithReplyOperationAbort<T>(
+  operation: ReplyOperation | undefined,
+  run: () => Promise<T> | T,
+): Promise<T> {
+  if (!operation) {
+    return Promise.resolve().then(run);
+  }
+  const signal = operation.abortSignal;
+  const shouldStopForOperationAbort = () => signal.aborted;
+  if (signal.aborted && shouldStopForOperationAbort()) {
+    return Promise.reject(new DispatchReplyOperationAbortedError());
+  }
+  let settled = false;
+  let abortHandler: (() => void) | undefined;
+  const aborted = new Promise<never>((_, reject) => {
+    abortHandler = () => {
+      if (!settled && shouldStopForOperationAbort()) {
+        reject(new DispatchReplyOperationAbortedError());
+      }
+    };
+    signal.addEventListener("abort", abortHandler, { once: true });
+  });
+  const work = Promise.resolve()
+    .then(run)
+    .then(
+      (value) => {
+        settled = true;
+        return value;
+      },
+      (error: unknown) => {
+        settled = true;
+        if (shouldStopForOperationAbort() && isAbortError(error)) {
+          throw new DispatchReplyOperationAbortedError();
+        }
+        throw error;
+      },
+    );
+  return Promise.race([work, aborted]).finally(() => {
+    settled = true;
+    if (abortHandler) {
+      signal.removeEventListener("abort", abortHandler);
+    }
+  });
+}
+
+function createAbortAwareDispatcher(params: {
+  dispatcher: ReplyDispatcher;
+  isAborted: () => boolean;
+}): ReplyDispatcher {
+  const sendIfActive =
+    (send: (payload: ReplyPayload) => boolean) =>
+    (payload: ReplyPayload): boolean =>
+      params.isAborted() ? false : send(payload);
+  const dispatcher: ReplyDispatcher = {
+    sendToolResult: sendIfActive(params.dispatcher.sendToolResult),
+    sendBlockReply: sendIfActive(params.dispatcher.sendBlockReply),
+    sendFinalReply: sendIfActive(params.dispatcher.sendFinalReply),
+    waitForIdle: () => params.dispatcher.waitForIdle(),
+    getQueuedCounts: () => params.dispatcher.getQueuedCounts(),
+    getFailedCounts: () => params.dispatcher.getFailedCounts(),
+    markComplete: () => {
+      if (!params.isAborted()) {
+        params.dispatcher.markComplete();
+      }
+    },
+  };
+  if (params.dispatcher.getCancelledCounts) {
+    dispatcher.getCancelledCounts = () => params.dispatcher.getCancelledCounts!();
+  }
+  return dispatcher;
+}
+
 export type {
   DispatchFromConfigParams,
   DispatchFromConfigResult,
@@ -715,6 +809,11 @@ export async function dispatchReplyFromConfig(
   const boundAcpDispatchSessionKey = resolveBoundAcpDispatchSessionKey({ ctx, cfg });
   const acpDispatchSessionKey =
     boundAcpDispatchSessionKey ?? initialSessionStoreEntry.sessionKey ?? sessionKey;
+  // initialSessionStoreEntry is command-target-aware, so native command turns
+  // stay target-keyed here. Bound ACP dispatch remains source-key owned while
+  // ACP routing uses acpDispatchSessionKey.
+  const dispatchOperationSessionKey =
+    initialSessionStoreEntry.sessionKey ?? sessionKey ?? acpDispatchSessionKey;
   const markProgress = () => {
     if (!canTrackSession || !sessionKey) {
       return;
@@ -754,6 +853,71 @@ export async function dispatchReplyFromConfig(
   const inboundAudio = isInboundAudioContext(ctx);
   const sessionTtsAuto = normalizeTtsAutoMode(sessionStoreEntry.entry?.ttsAuto);
   const workspaceDir = resolveAgentWorkspaceDir(cfg, sessionAgentId);
+  let dispatchReplyOperation: ReplyOperation | undefined;
+  let dispatchAbortOperation: ReplyOperation | undefined;
+  const ensureDispatchReplyOperation = (): ReplyOperation | undefined => {
+    if (dispatchReplyOperation && !dispatchReplyOperation.result) {
+      return dispatchReplyOperation;
+    }
+    if (dispatchAbortOperation && !dispatchAbortOperation.result) {
+      return dispatchReplyOperation;
+    }
+    if (!dispatchOperationSessionKey) {
+      return undefined;
+    }
+    const operationSessionId =
+      dispatchAbortOperation?.sessionId ??
+      initialSessionStoreEntry.entry?.sessionId ??
+      sessionStoreEntry.entry?.sessionId ??
+      crypto.randomUUID();
+    try {
+      dispatchReplyOperation = createReplyOperation({
+        sessionKey: dispatchOperationSessionKey,
+        sessionId: operationSessionId,
+        resetTriggered: false,
+        upstreamAbortSignal: params.replyOptions?.abortSignal,
+      });
+      dispatchAbortOperation = dispatchReplyOperation;
+    } catch (error) {
+      if (error instanceof ReplyRunAlreadyActiveError) {
+        dispatchAbortOperation = replyRunRegistry.get(dispatchOperationSessionKey);
+        logVerbose(
+          `dispatch-from-config: reply operation already active for ${dispatchOperationSessionKey}; using active operation abort signal without ownership`,
+        );
+        return undefined;
+      }
+      throw error;
+    }
+    return dispatchReplyOperation;
+  };
+  const getReplyOptions = () =>
+    dispatchReplyOperation
+      ? {
+          ...params.replyOptions,
+          abortSignal: dispatchReplyOperation.abortSignal,
+          replyOperation: dispatchReplyOperation,
+        }
+      : params.replyOptions;
+  const completeDispatchReplyOperation = () => {
+    if (dispatchReplyOperation) {
+      dispatchReplyOperation.complete();
+    }
+  };
+  const failDispatchReplyOperation = (error: unknown) => {
+    if (dispatchReplyOperation && !dispatchReplyOperation.result) {
+      dispatchReplyOperation.fail("run_failed", error);
+    }
+  };
+  const isDispatchOperationAborted = () => dispatchAbortOperation?.abortSignal.aborted === true;
+  const throwIfDispatchOperationAborted = () => {
+    if (isDispatchOperationAborted()) {
+      throw new DispatchReplyOperationAbortedError();
+    }
+  };
+  const dispatchHookDispatcher = createAbortAwareDispatcher({
+    dispatcher,
+    isAborted: isDispatchOperationAborted,
+  });
   const { ensureRuntimePluginsLoaded } = await traceReplyPhase("reply.load_runtime_plugins", () =>
     loadRuntimePlugins(),
   );
@@ -895,11 +1059,12 @@ export async function dispatchReplyFromConfig(
     if (!routeReplyRuntime || !routeReplyChannel || !routeReplyTo) {
       return;
     }
-    if (abortSignal?.aborted) {
+    const effectiveAbortSignal = abortSignal ?? dispatchAbortOperation?.abortSignal;
+    if (effectiveAbortSignal?.aborted) {
       return;
     }
     const result = await routeReplyToOriginating(payload, {
-      abortSignal,
+      abortSignal: effectiveAbortSignal,
       mirror,
     });
     if (result && !result.ok) {
@@ -1258,8 +1423,12 @@ export async function dispatchReplyFromConfig(
       recordProcessed("completed", { reason: "fast_abort" });
       markIdle("message_completed");
       commitInboundDedupeIfClaimed();
+      completeDispatchReplyOperation();
       return attachSourceReplyDeliveryMode({ queuedFinal, counts });
     }
+    // Register the dispatch-owned operation before any plugin hook or model work
+    // so /stop can abort pre-run and in-run stalls through the same session lane.
+    ensureDispatchReplyOperation();
 
     const isSlackNonDirectSurface =
       (ctx.Surface === "slack" || ctx.Provider === "slack") && ctx.ChatType !== "direct";
@@ -1305,6 +1474,7 @@ export async function dispatchReplyFromConfig(
     const sendFinalPayload = async (
       payload: ReplyPayload,
     ): Promise<{ queuedFinal: boolean; routedFinalCount: number }> => {
+      throwIfDispatchOperationAborted();
       const sourceReplyTranscriptMirror =
         getReplyPayloadMetadata(payload)?.sourceReplyTranscriptMirror;
       const hasVisibleFinalContent = hasOutboundReplyContent(payload, { trimText: true });
@@ -1322,8 +1492,12 @@ export async function dispatchReplyFromConfig(
         agentId: sessionAgentId,
         accountId: replyRoute.accountId,
       });
+      throwIfDispatchOperationAborted();
       const normalizedPayload = await normalizeReplyMediaPayload(ttsPayload);
-      const result = await routeReplyToOriginating(normalizedPayload);
+      throwIfDispatchOperationAborted();
+      const result = await routeReplyToOriginating(normalizedPayload, {
+        abortSignal: dispatchAbortOperation?.abortSignal,
+      });
       if (result) {
         if (!result.ok) {
           logVerbose(
@@ -1341,6 +1515,7 @@ export async function dispatchReplyFromConfig(
           routedFinalCount: result.ok ? 1 : 0,
         };
       }
+      throwIfDispatchOperationAborted();
       markInboundDedupeReplayUnsafe();
       const queuedFinal = dispatcher.sendFinalReply(normalizedPayload);
       if (queuedFinal) {
@@ -1358,23 +1533,25 @@ export async function dispatchReplyFromConfig(
     // Run before_dispatch hook — let plugins inspect or handle before model dispatch.
     if (hookRunner?.hasHooks("before_dispatch")) {
       const beforeDispatchResult = await traceReplyPhase("reply.before_dispatch_hooks", () =>
-        hookRunner.runBeforeDispatch(
-          {
-            content: hookContext.content,
-            body: hookContext.bodyForAgent ?? hookContext.body,
-            channel: hookContext.channelId,
-            sessionKey: sessionStoreEntry.sessionKey ?? sessionKey,
-            senderId: hookContext.senderId,
-            isGroup: hookContext.isGroup,
-            timestamp: hookContext.timestamp,
-          },
-          {
-            channelId: hookContext.channelId,
-            accountId: hookContext.accountId,
-            conversationId: inboundClaimContext.conversationId,
-            sessionKey: sessionStoreEntry.sessionKey ?? sessionKey,
-            senderId: hookContext.senderId,
-          },
+        runWithReplyOperationAbort(dispatchAbortOperation, () =>
+          hookRunner.runBeforeDispatch(
+            {
+              content: hookContext.content,
+              body: hookContext.bodyForAgent ?? hookContext.body,
+              channel: hookContext.channelId,
+              sessionKey: sessionStoreEntry.sessionKey ?? sessionKey,
+              senderId: hookContext.senderId,
+              isGroup: hookContext.isGroup,
+              timestamp: hookContext.timestamp,
+            },
+            {
+              channelId: hookContext.channelId,
+              accountId: hookContext.accountId,
+              conversationId: inboundClaimContext.conversationId,
+              sessionKey: sessionStoreEntry.sessionKey ?? sessionKey,
+              senderId: hookContext.senderId,
+            },
+          ),
         ),
       );
       if (beforeDispatchResult?.handled) {
@@ -1391,42 +1568,46 @@ export async function dispatchReplyFromConfig(
         recordProcessed("completed", { reason: "before_dispatch_handled" });
         markIdle("message_completed");
         commitInboundDedupeIfClaimed();
+        completeDispatchReplyOperation();
         return attachSourceReplyDeliveryMode({ queuedFinal, counts });
       }
     }
 
     if (hookRunner?.hasHooks("reply_dispatch")) {
       const replyDispatchResult = await traceReplyPhase("reply.reply_dispatch_hooks", () =>
-        hookRunner.runReplyDispatch(
-          {
-            ctx,
-            runId: params.replyOptions?.runId,
-            sessionKey: acpDispatchSessionKey,
-            images: params.replyOptions?.images,
-            inboundAudio,
-            sessionTtsAuto,
-            ttsChannel: deliveryChannel,
-            suppressUserDelivery: suppressHookUserDelivery,
-            suppressReplyLifecycle: suppressHookReplyLifecycle,
-            sourceReplyDeliveryMode,
-            shouldRouteToOriginating,
-            originatingChannel: routeReplyChannel,
-            originatingTo: routeReplyTo,
-            shouldSendToolSummaries,
-            sendPolicy,
-          },
-          {
-            cfg,
-            dispatcher,
-            abortSignal: params.replyOptions?.abortSignal,
-            onReplyStart: params.replyOptions?.onReplyStart,
-            recordProcessed,
-            markIdle,
-          },
+        runWithReplyOperationAbort(dispatchAbortOperation, () =>
+          hookRunner.runReplyDispatch(
+            {
+              ctx,
+              runId: params.replyOptions?.runId,
+              sessionKey: acpDispatchSessionKey,
+              images: params.replyOptions?.images,
+              inboundAudio,
+              sessionTtsAuto,
+              ttsChannel: deliveryChannel,
+              suppressUserDelivery: suppressHookUserDelivery,
+              suppressReplyLifecycle: suppressHookReplyLifecycle,
+              sourceReplyDeliveryMode,
+              shouldRouteToOriginating,
+              originatingChannel: routeReplyChannel,
+              originatingTo: routeReplyTo,
+              shouldSendToolSummaries,
+              sendPolicy,
+            },
+            {
+              cfg,
+              dispatcher: dispatchHookDispatcher,
+              abortSignal: dispatchAbortOperation?.abortSignal ?? params.replyOptions?.abortSignal,
+              onReplyStart: params.replyOptions?.onReplyStart,
+              recordProcessed,
+              markIdle,
+            },
+          ),
         ),
       );
       if (replyDispatchResult?.handled) {
         commitInboundDedupeIfClaimed();
+        completeDispatchReplyOperation();
         return attachSourceReplyDeliveryMode({
           queuedFinal: replyDispatchResult.queuedFinal,
           counts: replyDispatchResult.counts,
@@ -1634,6 +1815,9 @@ export async function dispatchReplyFromConfig(
         return undefined;
       }
       return async (...args: Args) => {
+        if (isDispatchOperationAborted()) {
+          return;
+        }
         markProgress();
         if (shouldForwardProgressCallback(options)) {
           await callback?.(...args);
@@ -1649,247 +1833,289 @@ export async function dispatchReplyFromConfig(
       params.configOverride ? (applyMergePatch(cfg, params.configOverride) as OpenClawConfig) : cfg,
     );
     recordAgentDispatchStarted();
-    const replyResult = await traceReplyPhase("reply.run_reply_resolver", () =>
-      replyResolver(
-        ctx,
-        {
-          ...params.replyOptions,
-          sourceReplyDeliveryMode,
-          suppressToolErrorWarnings,
-          typingPolicy: typing.typingPolicy,
-          suppressTyping: typing.suppressTyping,
-          onPartialReply: wrapProgressCallback(params.replyOptions?.onPartialReply),
-          onReasoningStream: wrapProgressCallback(params.replyOptions?.onReasoningStream),
-          onReasoningEnd: wrapProgressCallback(params.replyOptions?.onReasoningEnd),
-          onAssistantMessageStart: wrapProgressCallback(
-            params.replyOptions?.onAssistantMessageStart,
-          ),
-          onBlockReplyQueued: wrapProgressCallback(params.replyOptions?.onBlockReplyQueued),
-          onToolStart: wrapProgressCallback(params.replyOptions?.onToolStart, {
-            forwardWhenSourceDeliverySuppressed: true,
-          }),
-          onItemEvent: wrapProgressCallback(params.replyOptions?.onItemEvent, {
-            forwardWhenSourceDeliverySuppressed: true,
-          }),
-          onCommandOutput: wrapProgressCallback(params.replyOptions?.onCommandOutput, {
-            forwardWhenSourceDeliverySuppressed: true,
-          }),
-          onCompactionStart: wrapProgressCallback(params.replyOptions?.onCompactionStart, {
-            forwardWhenSourceDeliverySuppressed: true,
-          }),
-          onCompactionEnd: wrapProgressCallback(params.replyOptions?.onCompactionEnd, {
-            forwardWhenSourceDeliverySuppressed: true,
-          }),
-          onToolResult: (payload: ReplyPayload) => {
-            markProgress();
-            const run = async () => {
-              markInboundDedupeReplayUnsafe();
-              if (!suppressAutomaticSourceDelivery) {
-                await onToolResultFromReplyOptions?.(payload);
-              }
-              if (shouldSuppressProgressDelivery()) {
-                return;
-              }
-              const ttsPayload = await maybeApplyTtsToReplyPayload({
-                payload,
-                cfg,
-                channel: deliveryChannel,
-                kind: "tool",
-                inboundAudio,
-                ttsAuto: sessionTtsAuto,
-                agentId: sessionAgentId,
-                accountId: replyRoute.accountId,
-              });
-              const normalizedPayload = await normalizeReplyMediaPayload(ttsPayload);
-              const deliveryPayload = resolveToolDeliveryPayload(normalizedPayload);
-              if (!deliveryPayload) {
-                return;
-              }
-              if (shouldSuppressLateTextOnlyToolProgress(deliveryPayload)) {
-                return;
-              }
-              if (shouldSuppressMessageToolOnlyTextErrorProgress(deliveryPayload)) {
-                return;
-              }
-              if (shouldSuppressDefaultToolProgressMessages()) {
-                const hasMedia = resolveSendableOutboundReplyParts(deliveryPayload).hasMedia;
-                if (!hasMedia && !hasExecApprovalPayload(deliveryPayload)) {
+    const replyResult = await runWithReplyOperationAbort(dispatchAbortOperation, () =>
+      traceReplyPhase("reply.run_reply_resolver", () =>
+        replyResolver(
+          ctx,
+          {
+            ...getReplyOptions(),
+            sourceReplyDeliveryMode,
+            suppressToolErrorWarnings,
+            typingPolicy: typing.typingPolicy,
+            suppressTyping: typing.suppressTyping,
+            onPartialReply: wrapProgressCallback(params.replyOptions?.onPartialReply),
+            onReasoningStream: wrapProgressCallback(params.replyOptions?.onReasoningStream),
+            onReasoningEnd: wrapProgressCallback(params.replyOptions?.onReasoningEnd),
+            onAssistantMessageStart: wrapProgressCallback(
+              params.replyOptions?.onAssistantMessageStart,
+            ),
+            onBlockReplyQueued: wrapProgressCallback(params.replyOptions?.onBlockReplyQueued),
+            onToolStart: wrapProgressCallback(params.replyOptions?.onToolStart, {
+              forwardWhenSourceDeliverySuppressed: true,
+            }),
+            onItemEvent: wrapProgressCallback(params.replyOptions?.onItemEvent, {
+              forwardWhenSourceDeliverySuppressed: true,
+            }),
+            onCommandOutput: wrapProgressCallback(params.replyOptions?.onCommandOutput, {
+              forwardWhenSourceDeliverySuppressed: true,
+            }),
+            onCompactionStart: wrapProgressCallback(params.replyOptions?.onCompactionStart, {
+              forwardWhenSourceDeliverySuppressed: true,
+            }),
+            onCompactionEnd: wrapProgressCallback(params.replyOptions?.onCompactionEnd, {
+              forwardWhenSourceDeliverySuppressed: true,
+            }),
+            onToolResult: (payload: ReplyPayload) => {
+              markProgress();
+              const run = async () => {
+                if (isDispatchOperationAborted()) {
                   return;
                 }
-              }
-              if (shouldRouteToOriginating) {
-                await sendPayloadAsync(deliveryPayload, undefined, false);
-              } else {
                 markInboundDedupeReplayUnsafe();
-                dispatcher.sendToolResult(deliveryPayload);
-              }
-            };
-            return run();
-          },
-          onPlanUpdate: async (payload) => {
-            markProgress();
-            markInboundDedupeReplayUnsafe();
-            if (shouldForwardProgressCallback({ forwardWhenSourceDeliverySuppressed: true })) {
-              await onPlanUpdateFromReplyOptions?.(payload);
-            }
-            if (payload.phase !== "update" || shouldSuppressDefaultToolProgressMessages()) {
-              return;
-            }
-            await sendPlanUpdate({ explanation: payload.explanation, steps: payload.steps });
-          },
-          onApprovalEvent: async (payload) => {
-            markProgress();
-            markInboundDedupeReplayUnsafe();
-            if (shouldForwardProgressCallback({ forwardWhenSourceDeliverySuppressed: true })) {
-              await onApprovalEventFromReplyOptions?.(payload);
-            }
-            if (payload.phase !== "requested" || shouldSuppressDefaultToolProgressMessages()) {
-              return;
-            }
-            const label = summarizeApprovalLabel({
-              status: payload.status,
-              command: payload.command,
-              message: payload.message,
-            });
-            if (!label) {
-              return;
-            }
-            await maybeSendWorkingStatus(label);
-          },
-          onPatchSummary: async (payload) => {
-            markProgress();
-            markInboundDedupeReplayUnsafe();
-            if (shouldForwardProgressCallback({ forwardWhenSourceDeliverySuppressed: true })) {
-              await onPatchSummaryFromReplyOptions?.(payload);
-            }
-            if (payload.phase !== "end" || shouldSuppressDefaultToolProgressMessages()) {
-              return;
-            }
-            const label = summarizePatchLabel({ summary: payload.summary, title: payload.title });
-            if (!label) {
-              return;
-            }
-            await maybeSendWorkingStatus(label);
-          },
-          onBlockReply: (payload: ReplyPayload, context?: BlockReplyContext) => {
-            markProgress();
-            const run = async () => {
-              if (
-                payload.isReasoning !== true &&
-                hasOutboundReplyContent(payload, { trimText: true })
-              ) {
-                markInboundDedupeReplayUnsafe();
-              }
-              if (suppressDelivery) {
-                return;
-              }
-              // Suppress reasoning payloads — channels using this generic dispatch
-              // path (WhatsApp, web, etc.) do not have a dedicated reasoning lane.
-              // Telegram has its own dispatch path that handles reasoning splitting.
-              if (payload.isReasoning === true) {
-                return;
-              }
-              // Accumulate block text for TTS generation after streaming.
-              // Exclude status notices — they are informational UI signals
-              // and must not be synthesised into the spoken reply.
-              const isStatusNotice = payload.isCompactionNotice || payload.isFallbackNotice;
-              if (payload.text && !isStatusNotice) {
-                const joinsBufferedTtsDirective =
-                  cleanBlockTtsDirectiveText?.hasBufferedDirectiveText() === true;
-                if (accumulatedBlockText.length > 0) {
-                  accumulatedBlockText += "\n";
+                if (!suppressAutomaticSourceDelivery) {
+                  await onToolResultFromReplyOptions?.(payload);
                 }
-                accumulatedBlockText += payload.text;
-                if (accumulatedBlockTtsText.length > 0 && !joinsBufferedTtsDirective) {
-                  accumulatedBlockTtsText += "\n";
+                if (isDispatchOperationAborted()) {
+                  return;
                 }
-                accumulatedBlockTtsText += payload.text;
-                blockCount++;
-              }
-              const visiblePayload =
-                payload.text && cleanBlockTtsDirectiveText && !isStatusNotice
-                  ? (() => {
-                      const text = cleanBlockTtsDirectiveText.push(payload.text);
-                      return { ...payload, text: text.trim() ? text : undefined };
-                    })()
-                  : payload;
-              if (!hasOutboundReplyContent(visiblePayload, { trimText: true })) {
+                if (shouldSuppressProgressDelivery()) {
+                  return;
+                }
+                const ttsPayload = await maybeApplyTtsToReplyPayload({
+                  payload,
+                  cfg,
+                  channel: deliveryChannel,
+                  kind: "tool",
+                  inboundAudio,
+                  ttsAuto: sessionTtsAuto,
+                  agentId: sessionAgentId,
+                  accountId: replyRoute.accountId,
+                });
+                const normalizedPayload = await normalizeReplyMediaPayload(ttsPayload);
+                const deliveryPayload = resolveToolDeliveryPayload(normalizedPayload);
+                if (!deliveryPayload) {
+                  return;
+                }
+                if (isDispatchOperationAborted()) {
+                  return;
+                }
+                if (shouldSuppressLateTextOnlyToolProgress(deliveryPayload)) {
+                  return;
+                }
+                if (shouldSuppressMessageToolOnlyTextErrorProgress(deliveryPayload)) {
+                  return;
+                }
+                if (shouldSuppressDefaultToolProgressMessages()) {
+                  const hasMedia = resolveSendableOutboundReplyParts(deliveryPayload).hasMedia;
+                  if (!hasMedia && !hasExecApprovalPayload(deliveryPayload)) {
+                    return;
+                  }
+                }
+                if (shouldRouteToOriginating) {
+                  await sendPayloadAsync(deliveryPayload, undefined, false);
+                } else {
+                  markInboundDedupeReplayUnsafe();
+                  dispatcher.sendToolResult(deliveryPayload);
+                }
+              };
+              return run();
+            },
+            onPlanUpdate: async (payload) => {
+              if (isDispatchOperationAborted()) {
                 return;
               }
-              // Channels that keep a live draft preview may need to rotate their
-              // preview state at the logical block boundary before queued block
-              // delivery drains asynchronously through the dispatcher.
-              const payloadMetadata = getReplyPayloadMetadata(payload);
-              const queuedContext =
-                payloadMetadata?.assistantMessageIndex !== undefined
-                  ? {
-                      ...context,
-                      assistantMessageIndex: payloadMetadata.assistantMessageIndex,
-                    }
-                  : context;
-              if (!suppressAutomaticSourceDelivery) {
-                await params.replyOptions?.onBlockReplyQueued?.(visiblePayload, queuedContext);
+              markProgress();
+              markInboundDedupeReplayUnsafe();
+              if (shouldForwardProgressCallback({ forwardWhenSourceDeliverySuppressed: true })) {
+                await onPlanUpdateFromReplyOptions?.(payload);
               }
-              const ttsPayload = await maybeApplyTtsToReplyPayload({
-                payload: visiblePayload,
-                cfg,
-                channel: deliveryChannel,
-                kind: "block",
-                inboundAudio,
-                ttsAuto: sessionTtsAuto,
-                agentId: sessionAgentId,
-                accountId: replyRoute.accountId,
+              if (isDispatchOperationAborted()) {
+                return;
+              }
+              if (payload.phase !== "update" || shouldSuppressDefaultToolProgressMessages()) {
+                return;
+              }
+              await sendPlanUpdate({ explanation: payload.explanation, steps: payload.steps });
+            },
+            onApprovalEvent: async (payload) => {
+              if (isDispatchOperationAborted()) {
+                return;
+              }
+              markProgress();
+              markInboundDedupeReplayUnsafe();
+              if (shouldForwardProgressCallback({ forwardWhenSourceDeliverySuppressed: true })) {
+                await onApprovalEventFromReplyOptions?.(payload);
+              }
+              if (isDispatchOperationAborted()) {
+                return;
+              }
+              if (payload.phase !== "requested" || shouldSuppressDefaultToolProgressMessages()) {
+                return;
+              }
+              const label = summarizeApprovalLabel({
+                status: payload.status,
+                command: payload.command,
+                message: payload.message,
               });
-              const normalizedPayload = await normalizeReplyMediaPayload(ttsPayload);
-              if (shouldRouteToOriginating) {
-                await sendPayloadAsync(normalizedPayload, context?.abortSignal, false);
-              } else {
-                markInboundDedupeReplayUnsafe();
-                dispatcher.sendBlockReply(normalizedPayload);
+              if (!label) {
+                return;
               }
-            };
-            return run();
+              await maybeSendWorkingStatus(label);
+            },
+            onPatchSummary: async (payload) => {
+              if (isDispatchOperationAborted()) {
+                return;
+              }
+              markProgress();
+              markInboundDedupeReplayUnsafe();
+              if (shouldForwardProgressCallback({ forwardWhenSourceDeliverySuppressed: true })) {
+                await onPatchSummaryFromReplyOptions?.(payload);
+              }
+              if (isDispatchOperationAborted()) {
+                return;
+              }
+              if (payload.phase !== "end" || shouldSuppressDefaultToolProgressMessages()) {
+                return;
+              }
+              const label = summarizePatchLabel({ summary: payload.summary, title: payload.title });
+              if (!label) {
+                return;
+              }
+              await maybeSendWorkingStatus(label);
+            },
+            onBlockReply: (payload: ReplyPayload, context?: BlockReplyContext) => {
+              markProgress();
+              const run = async () => {
+                if (isDispatchOperationAborted()) {
+                  return;
+                }
+                if (
+                  payload.isReasoning !== true &&
+                  hasOutboundReplyContent(payload, { trimText: true })
+                ) {
+                  markInboundDedupeReplayUnsafe();
+                }
+                if (suppressDelivery) {
+                  return;
+                }
+                // Suppress reasoning payloads — channels using this generic dispatch
+                // path (WhatsApp, web, etc.) do not have a dedicated reasoning lane.
+                // Telegram has its own dispatch path that handles reasoning splitting.
+                if (payload.isReasoning === true) {
+                  return;
+                }
+                // Accumulate block text for TTS generation after streaming.
+                // Exclude status notices — they are informational UI signals
+                // and must not be synthesised into the spoken reply.
+                const isStatusNotice = payload.isCompactionNotice || payload.isFallbackNotice;
+                if (payload.text && !isStatusNotice) {
+                  const joinsBufferedTtsDirective =
+                    cleanBlockTtsDirectiveText?.hasBufferedDirectiveText() === true;
+                  if (accumulatedBlockText.length > 0) {
+                    accumulatedBlockText += "\n";
+                  }
+                  accumulatedBlockText += payload.text;
+                  if (accumulatedBlockTtsText.length > 0 && !joinsBufferedTtsDirective) {
+                    accumulatedBlockTtsText += "\n";
+                  }
+                  accumulatedBlockTtsText += payload.text;
+                  blockCount++;
+                }
+                const visiblePayload =
+                  payload.text && cleanBlockTtsDirectiveText && !isStatusNotice
+                    ? (() => {
+                        const text = cleanBlockTtsDirectiveText.push(payload.text);
+                        return { ...payload, text: text.trim() ? text : undefined };
+                      })()
+                    : payload;
+                if (!hasOutboundReplyContent(visiblePayload, { trimText: true })) {
+                  return;
+                }
+                // Channels that keep a live draft preview may need to rotate their
+                // preview state at the logical block boundary before queued block
+                // delivery drains asynchronously through the dispatcher.
+                const payloadMetadata = getReplyPayloadMetadata(payload);
+                const queuedContext =
+                  payloadMetadata?.assistantMessageIndex !== undefined
+                    ? {
+                        ...context,
+                        assistantMessageIndex: payloadMetadata.assistantMessageIndex,
+                      }
+                    : context;
+                if (!suppressAutomaticSourceDelivery) {
+                  await params.replyOptions?.onBlockReplyQueued?.(visiblePayload, queuedContext);
+                }
+                if (isDispatchOperationAborted()) {
+                  return;
+                }
+                const ttsPayload = await maybeApplyTtsToReplyPayload({
+                  payload: visiblePayload,
+                  cfg,
+                  channel: deliveryChannel,
+                  kind: "block",
+                  inboundAudio,
+                  ttsAuto: sessionTtsAuto,
+                  agentId: sessionAgentId,
+                  accountId: replyRoute.accountId,
+                });
+                const normalizedPayload = await normalizeReplyMediaPayload(ttsPayload);
+                if (isDispatchOperationAborted()) {
+                  return;
+                }
+                if (shouldRouteToOriginating) {
+                  await sendPayloadAsync(normalizedPayload, context?.abortSignal, false);
+                } else {
+                  markInboundDedupeReplayUnsafe();
+                  dispatcher.sendBlockReply(normalizedPayload);
+                }
+              };
+              return run();
+            },
           },
-        },
-        replyConfig,
+          replyConfig,
+        ),
       ),
     );
+    ensureDispatchReplyOperation();
 
     if (ctx.AcpDispatchTailAfterReset === true) {
       // Command handling prepared a trailing prompt after ACP in-place reset.
       // Route that tail through ACP now (same turn) instead of embedded dispatch.
       ctx.AcpDispatchTailAfterReset = false;
       if (hookRunner?.hasHooks("reply_dispatch")) {
-        const tailDispatchResult = await hookRunner.runReplyDispatch(
-          {
-            ctx,
-            runId: params.replyOptions?.runId,
-            sessionKey: acpDispatchSessionKey,
-            images: params.replyOptions?.images,
-            inboundAudio,
-            sessionTtsAuto,
-            ttsChannel: deliveryChannel,
-            suppressUserDelivery: suppressHookUserDelivery,
-            suppressReplyLifecycle: suppressHookReplyLifecycle,
-            sourceReplyDeliveryMode,
-            shouldRouteToOriginating,
-            originatingChannel: routeReplyChannel,
-            originatingTo: routeReplyTo,
-            shouldSendToolSummaries,
-            sendPolicy,
-            isTailDispatch: true,
-          },
-          {
-            cfg,
-            dispatcher,
-            abortSignal: params.replyOptions?.abortSignal,
-            onReplyStart: params.replyOptions?.onReplyStart,
-            recordProcessed,
-            markIdle,
-          },
+        const tailDispatchResult = await runWithReplyOperationAbort(dispatchAbortOperation, () =>
+          hookRunner.runReplyDispatch(
+            {
+              ctx,
+              runId: params.replyOptions?.runId,
+              sessionKey: acpDispatchSessionKey,
+              images: params.replyOptions?.images,
+              inboundAudio,
+              sessionTtsAuto,
+              ttsChannel: deliveryChannel,
+              suppressUserDelivery: suppressHookUserDelivery,
+              suppressReplyLifecycle: suppressHookReplyLifecycle,
+              sourceReplyDeliveryMode,
+              shouldRouteToOriginating,
+              originatingChannel: routeReplyChannel,
+              originatingTo: routeReplyTo,
+              shouldSendToolSummaries,
+              sendPolicy,
+              isTailDispatch: true,
+            },
+            {
+              cfg,
+              dispatcher: dispatchHookDispatcher,
+              abortSignal: dispatchAbortOperation?.abortSignal ?? params.replyOptions?.abortSignal,
+              onReplyStart: params.replyOptions?.onReplyStart,
+              recordProcessed,
+              markIdle,
+            },
+          ),
         );
         if (tailDispatchResult?.handled) {
           recordAgentDispatchCompleted("completed");
+          completeDispatchReplyOperation();
           return attachSourceReplyDeliveryMode({
             queuedFinal: tailDispatchResult.queuedFinal,
             counts: tailDispatchResult.counts,
@@ -1913,6 +2139,7 @@ export async function dispatchReplyFromConfig(
       !sendPolicyDenied &&
       getReplyPayloadMetadata(reply)?.deliverDespiteSourceReplySuppression === true;
     for (const reply of replies) {
+      throwIfDispatchOperationAborted();
       // Suppress reasoning payloads from channel delivery — channels using this
       // generic dispatch path do not have a dedicated reasoning lane.
       if (reply.isReasoning === true) {
@@ -1945,6 +2172,7 @@ export async function dispatchReplyFromConfig(
     }
 
     if (attemptedFinalDelivery && !finalDeliveryFailed) {
+      throwIfDispatchOperationAborted();
       await clearPendingFinalDeliveryAfterSuccess({
         storePath: sessionStoreEntry.storePath,
         sessionKey: sessionStoreEntry.sessionKey ?? sessionKey,
@@ -1967,6 +2195,7 @@ export async function dispatchReplyFromConfig(
         accumulatedBlockTtsText.trim()
       ) {
         try {
+          throwIfDispatchOperationAborted();
           const ttsSyntheticReply = await maybeApplyTtsToReplyPayload({
             payload: { text: accumulatedBlockTtsText },
             cfg,
@@ -1977,6 +2206,7 @@ export async function dispatchReplyFromConfig(
             agentId: sessionAgentId,
             accountId: replyRoute.accountId,
           });
+          throwIfDispatchOperationAborted();
           // Only send if TTS was actually applied (mediaUrl exists)
           if (ttsSyntheticReply.mediaUrl) {
             // Send TTS-only payload (no text, just audio) so it doesn't duplicate the block content.
@@ -1992,7 +2222,10 @@ export async function dispatchReplyFromConfig(
               { visibleTextAlreadyDelivered: true },
             );
             const normalizedTtsOnlyPayload = await normalizeReplyMediaPayload(ttsOnlyPayload);
-            const result = await routeReplyToOriginating(normalizedTtsOnlyPayload);
+            throwIfDispatchOperationAborted();
+            const result = await routeReplyToOriginating(normalizedTtsOnlyPayload, {
+              abortSignal: dispatchAbortOperation?.abortSignal,
+            });
             if (result) {
               queuedFinal = result.ok || queuedFinal;
               if (result.ok) {
@@ -2004,12 +2237,16 @@ export async function dispatchReplyFromConfig(
                 );
               }
             } else {
+              throwIfDispatchOperationAborted();
               markInboundDedupeReplayUnsafe();
               const didQueue = dispatcher.sendFinalReply(normalizedTtsOnlyPayload);
               queuedFinal = didQueue || queuedFinal;
             }
           }
         } catch (err) {
+          if (isDispatchReplyOperationAbortedError(err)) {
+            throw err;
+          }
           logVerbose(
             `dispatch-from-config: accumulated block TTS failed: ${formatErrorMessage(err)}`,
           );
@@ -2026,12 +2263,23 @@ export async function dispatchReplyFromConfig(
       pluginFallbackReason ? { reason: pluginFallbackReason } : undefined,
     );
     markIdle("message_completed");
+    completeDispatchReplyOperation();
     return attachSourceReplyDeliveryMode({
       queuedFinal,
       counts,
       ...(beforeAgentRunBlocked ? { beforeAgentRunBlocked } : {}),
     });
   } catch (err) {
+    if (isDispatchReplyOperationAbortedError(err)) {
+      commitInboundDedupeIfClaimed();
+      recordProcessed("completed", { reason: "reply_operation_aborted" });
+      markIdle("message_completed");
+      completeDispatchReplyOperation();
+      return attachSourceReplyDeliveryMode({
+        queuedFinal: false,
+        counts: dispatcher.getQueuedCounts(),
+      });
+    }
     if (inboundDedupeClaim.status === "claimed") {
       if (inboundDedupeReplayUnsafe) {
         commitInboundDedupe(inboundDedupeClaim.key);
@@ -2042,6 +2290,7 @@ export async function dispatchReplyFromConfig(
     recordAgentDispatchCompleted("error", { error: String(err) });
     recordProcessed("error", { error: String(err) });
     markIdle("message_error");
+    failDispatchReplyOperation(err);
     throw err;
   }
 }

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -1157,6 +1157,75 @@ describe("runPreparedReply media-only handling", () => {
     await expect(runPromise).resolves.toEqual({ text: "ok" });
     expect(vi.mocked(runReplyAgent)).toHaveBeenCalledOnce();
   });
+
+  it("does not queue a run behind its provided pre-dispatch reply operation", async () => {
+    const piRuntime = await import("../../agents/pi-embedded.runtime.js");
+    const operation = createReplyOperation({
+      sessionId: "session-pre-dispatch-owner",
+      sessionKey: "session-key",
+      resetTriggered: false,
+    });
+    vi.mocked(piRuntime.resolveActiveEmbeddedRunSessionId).mockReturnValue(
+      "session-pre-dispatch-owner",
+    );
+    vi.mocked(piRuntime.isEmbeddedPiRunActive).mockReturnValue(true);
+
+    try {
+      await expect(
+        runPreparedReply(
+          baseParams({
+            isNewSession: false,
+            sessionId: "session-pre-dispatch-owner",
+            opts: { replyOperation: operation } as never,
+          }),
+        ),
+      ).resolves.toEqual({ text: "ok" });
+
+      const call = requireLastRunReplyAgentCall();
+      expect(call.replyOperation).toBe(operation);
+      expect(vi.mocked(piRuntime.isEmbeddedPiRunActive)).not.toHaveBeenCalled();
+    } finally {
+      operation.complete();
+      vi.mocked(piRuntime.resolveActiveEmbeddedRunSessionId).mockReset().mockReturnValue(undefined);
+      vi.mocked(piRuntime.isEmbeddedPiRunActive).mockReset().mockReturnValue(false);
+    }
+  });
+
+  it("does not interrupt its provided pre-dispatch reply operation for reset turns", async () => {
+    const queueSettings = await import("./queue/settings-runtime.js");
+    const piRuntime = await import("../../agents/pi-embedded.runtime.js");
+    const commandQueue = await import("../../process/command-queue.js");
+    const operation = createReplyOperation({
+      sessionId: "session-reset-owner",
+      sessionKey: "session-key",
+      resetTriggered: false,
+    });
+    vi.mocked(queueSettings.resolveQueueSettings).mockReturnValueOnce({ mode: "followup" });
+    vi.mocked(commandQueue.getQueueSize).mockReturnValueOnce(0);
+    vi.mocked(piRuntime.resolveActiveEmbeddedRunSessionId).mockReturnValue("session-reset-owner");
+
+    try {
+      await expect(
+        runPreparedReply(
+          baseParams({
+            resetTriggered: true,
+            isNewSession: true,
+            sessionId: "session-reset-owner",
+            opts: { replyOperation: operation } as never,
+          }),
+        ),
+      ).resolves.toEqual({ text: "ok" });
+
+      const call = requireLastRunReplyAgentCall();
+      expect(call.replyOperation).toBe(operation);
+      expect(commandQueue.clearCommandLane).not.toHaveBeenCalled();
+      expect(piRuntime.abortEmbeddedPiRun).not.toHaveBeenCalled();
+    } finally {
+      operation.complete();
+      vi.mocked(piRuntime.resolveActiveEmbeddedRunSessionId).mockReset().mockReturnValue(undefined);
+    }
+  });
+
   it("re-resolves auth profile after waiting for a prior run", async () => {
     const { resolveSessionAuthProfileOverride } =
       await import("../../agents/auth-profiles/session-override.js");

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -76,6 +76,7 @@ import { resolveOriginMessageProvider } from "./origin-routing.js";
 import { buildReplyPromptEnvelope, buildReplyPromptEnvelopeBase } from "./prompt-prelude.js";
 import { resolveActiveRunQueueAction } from "./queue-policy.js";
 import { resolveQueueSettings } from "./queue/settings-runtime.js";
+import type { ReplyOperation } from "./reply-run-registry.js";
 import { resolveRoutedDeliveryThreadId } from "./routed-delivery-thread.js";
 import { resolveRuntimePolicySessionKey } from "./runtime-policy-session-key.js";
 import { resolveBareSessionResetPromptState } from "./session-reset-prompt.js";
@@ -86,6 +87,15 @@ import { resolveStoredModelOverride } from "./stored-model-override.js";
 import { resolveTypingMode } from "./typing-mode.js";
 import { resolveRunTypingPolicy } from "./typing-policy.js";
 import type { TypingController } from "./typing.js";
+
+type InternalGetReplyOptions = GetReplyOptions & {
+  /**
+   * Dispatch-owned pre-run operation. This is intentionally not part of the
+   * public reply API; it lets dispatch prep and hook work share the same
+   * diagnostic/abort ownership as the eventual agent run.
+   */
+  replyOperation?: ReplyOperation;
+};
 
 type AgentDefaults = NonNullable<OpenClawConfig["agents"]>["defaults"];
 type ExecOverrides = Pick<ExecToolDefaults, "host" | "security" | "ask" | "node">;
@@ -822,7 +832,14 @@ export async function runPreparedReply(
       }
     }
   }
-  const sessionIdFinal = sessionId ?? crypto.randomUUID();
+  const internalOpts = opts as InternalGetReplyOptions | undefined;
+  const providedReplyOperation = internalOpts?.replyOperation;
+  const isOwnPreDispatchOperationSession = (candidateSessionId: string | undefined): boolean =>
+    providedReplyOperation !== undefined &&
+    providedReplyOperation.result === null &&
+    providedReplyOperation.phase === "queued" &&
+    candidateSessionId === providedReplyOperation.sessionId;
+  const sessionIdFinal = sessionId ?? providedReplyOperation?.sessionId ?? crypto.randomUUID();
   const sessionFilePathOptions = resolveSessionFilePathOptions({ agentId, storePath });
   const resolvePreparedSessionState = (): {
     sessionEntry: SessionEntry | undefined;
@@ -870,7 +887,12 @@ export async function runPreparedReply(
     : undefined;
   const laneSize = sessionLaneKey ? getQueueSize(sessionLaneKey) : 0;
   const activeRunQueueMode = effectiveResetTriggered ? "interrupt" : resolvedQueue.mode;
-  const activeSessionIdForInterrupt = piRuntime?.resolveActiveEmbeddedRunSessionId(sessionKey);
+  const rawActiveSessionIdForInterrupt = piRuntime?.resolveActiveEmbeddedRunSessionId(sessionKey);
+  const activeSessionIdForInterrupt = isOwnPreDispatchOperationSession(
+    rawActiveSessionIdForInterrupt,
+  )
+    ? undefined
+    : rawActiveSessionIdForInterrupt;
   if (
     activeRunQueueMode === "interrupt" &&
     !isRoomEvent &&
@@ -982,6 +1004,9 @@ export async function runPreparedReply(
     const activeSessionId = resolveActiveQueueSessionId();
     if (!activeSessionId || !piRuntime) {
       return { activeSessionId: undefined, isActive: false, isStreaming: false };
+    }
+    if (isOwnPreDispatchOperationSession(activeSessionId)) {
+      return { activeSessionId, isActive: false, isStreaming: false };
     }
     return {
       activeSessionId,
@@ -1209,5 +1234,6 @@ export async function runPreparedReply(
     typingMode,
     resetTriggered: effectiveResetTriggered,
     replyThreadingOverride,
+    replyOperation: providedReplyOperation,
   });
 }

--- a/src/logging/diagnostic-stuck-session-recovery.integration.test.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.integration.test.ts
@@ -60,6 +60,54 @@ describe("stuck session recovery integration", () => {
     await expect(queued).resolves.toBe("drained");
   });
 
+  it("aborts registered pre-run lane work and drains queued messages", async () => {
+    const sessionKey = "agent:main:active-pre-run";
+    const sessionId = "active-pre-run-session";
+    const lane = resolveEmbeddedSessionLane(sessionKey);
+    const operation = createReplyOperation({
+      sessionKey,
+      sessionId,
+      resetTriggered: false,
+    });
+    let markActiveStarted!: () => void;
+    const activeStarted = new Promise<void>((resolve) => {
+      markActiveStarted = resolve;
+    });
+
+    const active = enqueueCommandInLane(
+      lane,
+      () =>
+        new Promise<"aborted">((resolve) => {
+          markActiveStarted();
+          if (operation.abortSignal.aborted) {
+            resolve("aborted");
+            return;
+          }
+          operation.abortSignal.addEventListener("abort", () => resolve("aborted"), { once: true });
+        }),
+      { warnAfterMs: Number.MAX_SAFE_INTEGER },
+    );
+    const queued = enqueueCommandInLane(lane, async () => "drained", {
+      warnAfterMs: Number.MAX_SAFE_INTEGER,
+    });
+
+    expect(getQueueSize(lane)).toBe(2);
+    await activeStarted;
+
+    const outcome = await recoverStuckDiagnosticSession({
+      sessionId,
+      sessionKey,
+      ageMs: 720_000,
+      queueDepth: 1,
+      allowActiveAbort: true,
+    });
+
+    await expect(active).resolves.toBe("aborted");
+    await expect(queued).resolves.toBe("drained");
+    expect(outcome.status).toBe("aborted");
+    expect(getQueueSize(lane)).toBe(0);
+  });
+
   it("does not reset a blocked lane while unregistered lane work is still active", async () => {
     const sessionKey = "agent:main:unregistered-work";
     const sessionId = "unregistered-work-session";


### PR DESCRIPTION
Summary:
- Register dispatch-owned reply operations before hooks/model work so Discord and bound ACP turns can be stopped before the embedded agent run starts.
- Keep abort ownership available through ACP tail dispatch and final delivery, and suppress late hook/resolver dispatcher callbacks after abort.
- Extend /stop to abort bound ACP target work plus the source dispatch lane, including queue/lane cleanup and stuck-session recovery coverage.

Verification:
- codex --dangerously-bypass-approvals-and-sandbox --sandbox danger-full-access review --uncommitted
- node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.acp-abort.test.ts src/auto-reply/reply/abort.test.ts
- node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
- node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo
- git diff --check HEAD~1..HEAD

Behavior addressed: Discord/session-key recovery now has a source-keyed dispatch operation before hooks/model dispatch so /stop and stuck-session recovery can find and abort pre-run work; bound ACP routing remains target-keyed while abort ownership stays source-keyed.

Real environment tested: Discord live QA and ACP live bind/stop scenarios were previously run on this branch during issue proof; AWS Crabbox attempts were made but provider capacity was unavailable for the earlier runs.

Exact steps or command run after this patch: focused local proof commands listed above; earlier live proof covered Discord canary/mention/native-help, Discord status/tool-only, ACP live bind/follow-up, and stop/recovery E2E.

Evidence after fix: focused ACP/abort Vitest passed 40 tests after the final rebase resolution; core and core-test tsgo both passed; final direct Codex review exited with no accepted findings.

Observed result after fix: aborted dispatches resolve as handled without queuing late tool/block/final replies, /stop does not self-abort its own command, and bound ACP source lanes remain abortable while ACP dispatch still routes to the target session.

What was not tested: a fresh AWS Crabbox proof after the final rebase resolution, because the earlier AWS Crabbox provider attempts were unavailable; CI will provide the broad hosted proof for this pushed branch.

Fixes #84477
