### PR TITLE
Add openclaw skills verify for ClawHub trust cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - Discord: allow configuring a bounded `agentComponents.ttlMs` callback registry lifetime for long-running component workflows, with per-account overrides and a 24-hour cap. (#84189) Thanks @100menotu001.
+- CLI/skills: add `openclaw skills verify <slug>` to fetch ClawHub trust cards, defaulting to the installed ClawHub version when `.clawhub/origin.json` is present.
 - Gateway/plugins: reuse a compatible Gateway startup plugin registry during dispatch so safe plugin dispatches avoid redundant registry loading. (#84324) Thanks @ai-hpc.
 - Dependencies: refresh provider, plugin, UI, and tooling packages, update `protobufjs` to 8.4.0 to clear the current npm advisory, and carry the Claude ACP completion patch forward to `@agentclientprotocol/claude-agent-acp` 0.36.1.
 - Agents/tools: remove the old sender-owner tool gating path so configured tools stay visible for trusted sessions while command and channel-action auth still carry real sender identity.

--- a/docs/cli/skills.md
+++ b/docs/cli/skills.md
@@ -1,5 +1,5 @@
 ---
-summary: "CLI reference for `openclaw skills` (search/install/update/list/info/check)"
+summary: "CLI reference for `openclaw skills` (search/install/update/verify/list/info/check)"
 read_when:
   - You want to see which skills are available and ready to run
   - You want to search ClawHub or install skills from ClawHub, Git, or local directories
@@ -9,8 +9,8 @@ title: "Skills"
 
 # `openclaw skills`
 
-Inspect local skills, search ClawHub, install skills from ClawHub/Git/local directories, and update
-ClawHub-tracked installs.
+Inspect local skills, search ClawHub, install skills from ClawHub/Git/local directories, update
+ClawHub-tracked installs, and verify ClawHub trust cards.
 
 Related:
 
@@ -36,6 +36,10 @@ openclaw skills update <slug> --global
 openclaw skills update --all
 openclaw skills update --all --agent <id>
 openclaw skills update --all --global
+openclaw skills verify <slug>
+openclaw skills verify <slug> --version <version>
+openclaw skills verify <slug> --tag <tag>
+openclaw skills verify <slug> --json
 openclaw skills list
 openclaw skills list --eligible
 openclaw skills list --json
@@ -49,14 +53,15 @@ openclaw skills check --agent <id>
 openclaw skills check --json
 ```
 
-`search` and `update` use ClawHub directly. `install <slug>` installs a ClawHub
-skill, `install git:owner/repo[@ref]` clones a Git skill, and `install ./path`
-copies a local skill directory. By default, `install` and `update` target the
-active workspace `skills/` directory; with `--global`, they target the shared
-managed skills directory. `list`/`info`/`check` still inspect the local skills
-visible to the current workspace and config. Workspace-backed commands resolve
-the target workspace from `--agent <id>`, then the current working directory
-when it is inside a configured agent workspace, then the default agent.
+`search`, `update`, and `verify` use ClawHub directly. `install <slug>` installs
+a ClawHub skill, `install git:owner/repo[@ref]` clones a Git skill, and
+`install ./path` copies a local skill directory. By default, `install`, `update`,
+and `verify` target the active workspace `skills/` directory; with `--global`,
+they target the shared managed skills directory. `list`/`info`/`check` still
+inspect the local skills visible to the current workspace and config.
+Workspace-backed commands resolve the target workspace from `--agent <id>`, then
+the current working directory when it is inside a configured agent workspace,
+then the default agent.
 
 Git and local directory installs expect `SKILL.md` at the source root. The
 install slug comes from `SKILL.md` frontmatter `name` when it is valid, then the
@@ -89,6 +94,13 @@ Notes:
   shared managed skills directory instead of the workspace.
 - `update --all` updates tracked ClawHub installs in the selected workspace, or
   in the shared managed skills directory when combined with `--global`.
+- `verify <slug>` fetches the ClawHub trust card. If the skill was installed
+  from ClawHub, OpenClaw verifies the installed version recorded in
+  `.clawhub/origin.json`; otherwise it verifies the latest ClawHub version.
+- `verify --version <version>` and `verify --tag <tag>` override installed
+  version lookup.
+- `verify --json` prints the raw trust-card response for scripts. Human output
+  exits non-zero when the audit status is not `pass`.
 - `check --agent <id>` checks the selected agent's workspace and reports which
   ready skills are actually visible to that agent's prompt or command surface.
 - `list` is the default action when no subcommand is provided.

--- a/src/agents/skills-clawhub.test.ts
+++ b/src/agents/skills-clawhub.test.ts
@@ -4,9 +4,10 @@ import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const fetchClawHubSkillDetailMock = vi.fn();
+const fetchClawHubSkillTrustCardMock = vi.fn();
 const downloadClawHubSkillArchiveMock = vi.fn();
 const listClawHubSkillsMock = vi.fn();
-const resolveClawHubBaseUrlMock = vi.fn(() => "https://clawhub.ai");
+const resolveClawHubBaseUrlMock = vi.fn((baseUrl?: string) => baseUrl ?? "https://clawhub.ai");
 const searchClawHubSkillsMock = vi.fn();
 const archiveCleanupMock = vi.fn();
 const withExtractedArchiveRootMock = vi.fn();
@@ -15,6 +16,7 @@ const pathExistsMock = vi.fn();
 
 vi.mock("../infra/clawhub.js", () => ({
   fetchClawHubSkillDetail: fetchClawHubSkillDetailMock,
+  fetchClawHubSkillTrustCard: fetchClawHubSkillTrustCardMock,
   downloadClawHubSkillArchive: downloadClawHubSkillArchiveMock,
   listClawHubSkills: listClawHubSkillsMock,
   resolveClawHubBaseUrl: resolveClawHubBaseUrlMock,
@@ -33,8 +35,12 @@ vi.mock("../infra/fs-safe.js", () => ({
   pathExists: pathExistsMock,
 }));
 
-const { installSkillFromClawHub, searchSkillsFromClawHub, updateSkillsFromClawHub } =
-  await import("./skills-clawhub.js");
+const {
+  installSkillFromClawHub,
+  searchSkillsFromClawHub,
+  updateSkillsFromClawHub,
+  verifySkillFromClawHub,
+} = await import("./skills-clawhub.js");
 
 function expectInstallPackageSourceDir(sourceDir: string) {
   const call = installPackageDirMock.mock.calls.at(0);
@@ -74,6 +80,7 @@ function expectInvalidSlug(result: Awaited<ReturnType<typeof installSkillFromCla
 describe("skills-clawhub", () => {
   beforeEach(() => {
     fetchClawHubSkillDetailMock.mockReset();
+    fetchClawHubSkillTrustCardMock.mockReset();
     downloadClawHubSkillArchiveMock.mockReset();
     listClawHubSkillsMock.mockReset();
     resolveClawHubBaseUrlMock.mockReset();
@@ -83,7 +90,9 @@ describe("skills-clawhub", () => {
     installPackageDirMock.mockReset();
     pathExistsMock.mockReset();
 
-    resolveClawHubBaseUrlMock.mockReturnValue("https://clawhub.ai");
+    resolveClawHubBaseUrlMock.mockImplementation(
+      (baseUrl?: string) => baseUrl ?? "https://clawhub.ai",
+    );
     pathExistsMock.mockImplementation(async (input: string) => input.endsWith("SKILL.md"));
     fetchClawHubSkillDetailMock.mockResolvedValue({
       skill: {
@@ -95,6 +104,20 @@ describe("skills-clawhub", () => {
       latestVersion: {
         version: "1.0.0",
         createdAt: 3,
+      },
+    });
+    fetchClawHubSkillTrustCardMock.mockResolvedValue({
+      skill: {
+        slug: "agentreceipt",
+        displayName: "AgentReceipt",
+      },
+      version: {
+        version: "1.0.0",
+        createdAt: 3,
+      },
+      trustCard: {
+        audit: { status: "pass" },
+        signature: { status: "unsigned" },
       },
     });
     downloadClawHubSkillArchiveMock.mockResolvedValue({
@@ -375,5 +398,95 @@ describe("skills-clawhub", () => {
       baseUrl: undefined,
     });
     expect(listClawHubSkillsMock).not.toHaveBeenCalled();
+  });
+
+  it("verifies the installed ClawHub skill version when no version is specified", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skills-clawhub-"));
+    const skillDir = path.join(workspaceDir, "skills", "agentreceipt");
+    await fs.mkdir(path.join(skillDir, ".clawhub"), { recursive: true });
+    await fs.writeFile(
+      path.join(skillDir, ".clawhub", "origin.json"),
+      `${JSON.stringify(
+        {
+          version: 1,
+          registry: "https://registry.example",
+          slug: "agentreceipt",
+          installedVersion: "1.2.3",
+          installedAt: 123,
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+
+    try {
+      const result = await verifySkillFromClawHub({
+        workspaceDir,
+        slug: "agentreceipt",
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) {
+        throw new Error(result.error);
+      }
+      expect(result.resolvedFrom).toBe("installed");
+      expect(result.requestedVersion).toBe("1.2.3");
+      expect(result.registry).toBe("https://registry.example");
+      expect(fetchClawHubSkillTrustCardMock).toHaveBeenCalledWith({
+        slug: "agentreceipt",
+        version: "1.2.3",
+        tag: undefined,
+        baseUrl: "https://registry.example",
+      });
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("verifies the latest ClawHub trust card when the skill is not installed", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skills-clawhub-"));
+
+    try {
+      const result = await verifySkillFromClawHub({
+        workspaceDir,
+        slug: "agentreceipt",
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) {
+        throw new Error(result.error);
+      }
+      expect(result.resolvedFrom).toBe("latest");
+      expect(result.requestedVersion).toBeUndefined();
+      expect(fetchClawHubSkillTrustCardMock).toHaveBeenCalledWith({
+        slug: "agentreceipt",
+        version: undefined,
+        tag: undefined,
+        baseUrl: undefined,
+      });
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("lets an explicit trust-card version override the installed version", async () => {
+    const result = await verifySkillFromClawHub({
+      workspaceDir: "/tmp/workspace",
+      slug: "agentreceipt",
+      version: "2.0.0",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error(result.error);
+    }
+    expect(result.resolvedFrom).toBe("version");
+    expect(fetchClawHubSkillTrustCardMock).toHaveBeenCalledWith({
+      slug: "agentreceipt",
+      version: "2.0.0",
+      tag: undefined,
+      baseUrl: undefined,
+    });
   });
 });

--- a/src/agents/skills-clawhub.ts
+++ b/src/agents/skills-clawhub.ts
@@ -2,10 +2,13 @@ import path from "node:path";
 import {
   downloadClawHubSkillArchive,
   fetchClawHubSkillDetail,
+  fetchClawHubSkillTrustCard,
   resolveClawHubBaseUrl,
   searchClawHubSkills,
   type ClawHubSkillDetail,
   type ClawHubSkillSearchResult,
+  type ClawHubSkillTrustCard,
+  type ClawHubSkillTrustCardResponse,
 } from "../infra/clawhub.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { pathExists } from "../infra/fs-safe.js";
@@ -60,6 +63,19 @@ export type UpdateClawHubSkillResult =
       version: string;
       changed: boolean;
       targetDir: string;
+    }
+  | { ok: false; error: string };
+
+export type VerifyClawHubSkillTrustResult =
+  | {
+      ok: true;
+      slug: string;
+      requestedVersion?: string;
+      requestedTag?: string;
+      resolvedFrom: "installed" | "version" | "tag" | "latest";
+      registry: string;
+      response: ClawHubSkillTrustCardResponse;
+      trustCard: ClawHubSkillTrustCard;
     }
   | { ok: false; error: string };
 
@@ -176,6 +192,90 @@ export async function searchSkillsFromClawHub(params: {
     limit: params.limit,
     baseUrl: params.baseUrl,
   });
+}
+
+async function resolveVerifyTarget(params: {
+  workspaceDir: string;
+  slug: string;
+  version?: string;
+  tag?: string;
+  baseUrl?: string;
+}): Promise<{
+  slug: string;
+  version?: string;
+  tag?: string;
+  baseUrl?: string;
+  resolvedFrom: "installed" | "version" | "tag" | "latest";
+}> {
+  const slug = validateRequestedSkillSlug(params.slug);
+  if (params.version && params.tag) {
+    throw new Error("Use either --version or --tag.");
+  }
+  if (params.version) {
+    return {
+      slug,
+      version: params.version,
+      baseUrl: params.baseUrl,
+      resolvedFrom: "version",
+    };
+  }
+  if (params.tag) {
+    return {
+      slug,
+      tag: params.tag,
+      baseUrl: params.baseUrl,
+      resolvedFrom: "tag",
+    };
+  }
+  const origin = await readClawHubSkillOrigin(
+    resolveWorkspaceSkillInstallDir(params.workspaceDir, slug),
+  );
+  if (origin) {
+    return {
+      slug,
+      version: origin.installedVersion,
+      baseUrl: origin.registry,
+      resolvedFrom: "installed",
+    };
+  }
+  return {
+    slug,
+    baseUrl: params.baseUrl,
+    resolvedFrom: "latest",
+  };
+}
+
+export async function verifySkillFromClawHub(params: {
+  workspaceDir: string;
+  slug: string;
+  version?: string;
+  tag?: string;
+  baseUrl?: string;
+}): Promise<VerifyClawHubSkillTrustResult> {
+  try {
+    const target = await resolveVerifyTarget(params);
+    const response = await fetchClawHubSkillTrustCard({
+      slug: target.slug,
+      version: target.version,
+      tag: target.tag,
+      baseUrl: target.baseUrl,
+    });
+    return {
+      ok: true,
+      slug: target.slug,
+      ...(target.version ? { requestedVersion: target.version } : {}),
+      ...(target.tag ? { requestedTag: target.tag } : {}),
+      resolvedFrom: target.resolvedFrom,
+      registry: resolveClawHubBaseUrl(target.baseUrl),
+      response,
+      trustCard: response.trustCard,
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      error: formatErrorMessage(err),
+    };
+  }
 }
 
 async function resolveInstallVersion(params: {

--- a/src/cli/skills-cli.commands.test.ts
+++ b/src/cli/skills-cli.commands.test.ts
@@ -83,6 +83,7 @@ const mocks = vi.hoisted(() => {
     installSkillFromClawHubMock: vi.fn(),
     installSkillFromSourceMock: vi.fn(),
     updateSkillsFromClawHubMock: vi.fn(),
+    verifySkillFromClawHubMock: vi.fn(),
     readTrackedClawHubSkillSlugsMock: vi.fn(),
     buildWorkspaceSkillStatusMock,
     skillStatusReportFixture,
@@ -102,6 +103,7 @@ const {
   installSkillFromClawHubMock,
   installSkillFromSourceMock,
   updateSkillsFromClawHubMock,
+  verifySkillFromClawHubMock,
   readTrackedClawHubSkillSlugsMock,
   buildWorkspaceSkillStatusMock,
   skillStatusReportFixture,
@@ -176,6 +178,7 @@ vi.mock("../agents/skills-clawhub.js", () => ({
   searchSkillsFromClawHub: (...args: unknown[]) => mocks.searchSkillsFromClawHubMock(...args),
   installSkillFromClawHub: (...args: unknown[]) => mocks.installSkillFromClawHubMock(...args),
   updateSkillsFromClawHub: (...args: unknown[]) => mocks.updateSkillsFromClawHubMock(...args),
+  verifySkillFromClawHub: (...args: unknown[]) => mocks.verifySkillFromClawHubMock(...args),
   readTrackedClawHubSkillSlugs: (...args: unknown[]) =>
     mocks.readTrackedClawHubSkillSlugsMock(...args),
 }));
@@ -226,6 +229,7 @@ describe("skills cli commands", () => {
     installSkillFromClawHubMock.mockReset();
     installSkillFromSourceMock.mockReset();
     updateSkillsFromClawHubMock.mockReset();
+    verifySkillFromClawHubMock.mockReset();
     readTrackedClawHubSkillSlugsMock.mockReset();
     buildWorkspaceSkillStatusMock.mockReset();
 
@@ -243,6 +247,10 @@ describe("skills cli commands", () => {
       error: "source install disabled in test",
     });
     updateSkillsFromClawHubMock.mockResolvedValue([]);
+    verifySkillFromClawHubMock.mockResolvedValue({
+      ok: false,
+      error: "verify disabled in test",
+    });
     readTrackedClawHubSkillSlugsMock.mockResolvedValue([]);
     buildWorkspaceSkillStatusMock.mockReturnValue(skillStatusReportFixture);
     defaultRuntime.log.mockClear();
@@ -660,6 +668,123 @@ describe("skills cli commands", () => {
     expect(runtimeErrors).toContain("Use either --global or --agent, not both.");
     expect(readTrackedClawHubSkillSlugsMock).not.toHaveBeenCalled();
     expect(updateSkillsFromClawHubMock).not.toHaveBeenCalled();
+  });
+
+  it("verifies a ClawHub skill trust card from the active workspace", async () => {
+    verifySkillFromClawHubMock.mockResolvedValue({
+      ok: true,
+      slug: "calendar",
+      resolvedFrom: "installed",
+      registry: "https://clawhub.ai",
+      response: {},
+      trustCard: {
+        subject: { slug: "calendar", displayName: "Calendar", version: "1.2.3" },
+        publisher: { handle: "acme" },
+        artifact: {
+          fingerprint: "sha256:release",
+          files: [{ path: "SKILL.md" }],
+        },
+        audit: {
+          status: "pass",
+          summary: "No static findings.",
+          reasonCodes: [],
+        },
+        signature: { status: "unsigned" },
+        capabilities: {
+          tags: ["calendar"],
+          requires: { env: ["CALENDAR_TOKEN"] },
+        },
+      },
+    });
+
+    await runCommand(["skills", "verify", "calendar"]);
+
+    expect(verifySkillFromClawHubMock).toHaveBeenCalledWith({
+      workspaceDir: "/tmp/workspace",
+      slug: "calendar",
+      version: undefined,
+      tag: undefined,
+    });
+    expect(runtimeLogs).toContain("calendar@1.2.3 trust");
+    expect(runtimeLogs).toContain("Resolved: installed");
+    expect(runtimeLogs).toContain("Signature: unsigned");
+    expect(runtimeLogs).toContain("Requires: env=CALENDAR_TOKEN");
+    expect(defaultRuntime.exit).not.toHaveBeenCalledWith(1);
+  });
+
+  it("prints JSON for ClawHub skill trust verification", async () => {
+    verifySkillFromClawHubMock.mockResolvedValue({
+      ok: true,
+      slug: "calendar",
+      resolvedFrom: "version",
+      registry: "https://clawhub.ai",
+      response: { trustCard: { audit: { status: "pass" } } },
+      trustCard: { audit: { status: "pass" } },
+    });
+
+    await runCommand(["skills", "verify", "calendar", "--version", "1.2.3", "--json"]);
+
+    expect(verifySkillFromClawHubMock).toHaveBeenCalledWith({
+      workspaceDir: "/tmp/workspace",
+      slug: "calendar",
+      version: "1.2.3",
+      tag: undefined,
+    });
+    expect(defaultRuntime.writeJson).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ok: true,
+        slug: "calendar",
+        resolvedFrom: "version",
+      }),
+    );
+    expect(defaultRuntime.log).not.toHaveBeenCalled();
+  });
+
+  it("fails verification for non-pass trust card audits", async () => {
+    verifySkillFromClawHubMock.mockResolvedValue({
+      ok: true,
+      slug: "calendar",
+      resolvedFrom: "latest",
+      registry: "https://clawhub.ai",
+      response: {},
+      trustCard: {
+        subject: { slug: "calendar", version: "1.2.3" },
+        artifact: { files: [] },
+        audit: {
+          status: "review",
+          summary: "Needs review.",
+          reasonCodes: ["suspicious.dep_not_found_on_registry"],
+        },
+        signature: { status: "unsigned" },
+      },
+    });
+
+    await expect(runCommand(["skills", "verify", "calendar"])).rejects.toThrow("__exit__:1");
+
+    expect(runtimeLogs).toContain("Audit Reasons: suspicious.dep_not_found_on_registry");
+  });
+
+  it("fails verification when trust card audit status is missing", async () => {
+    verifySkillFromClawHubMock.mockResolvedValue({
+      ok: true,
+      slug: "calendar",
+      resolvedFrom: "latest",
+      registry: "https://clawhub.ai",
+      response: {},
+      trustCard: {
+        subject: { slug: "calendar", version: "1.2.3" },
+        artifact: { files: [] },
+        audit: {
+          summary: "Missing status.",
+          reasonCodes: [],
+        },
+        signature: { status: "unsigned" },
+      },
+    });
+
+    await expect(runCommand(["skills", "verify", "calendar"])).rejects.toThrow("__exit__:1");
+
+    expect(runtimeLogs).toContain("Audit: UNKNOWN");
   });
 
   it.each([

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -9,12 +9,14 @@ import {
   readTrackedClawHubSkillSlugs,
   searchSkillsFromClawHub,
   updateSkillsFromClawHub,
+  verifySkillFromClawHub,
 } from "../agents/skills-clawhub.js";
 import {
   installSkillFromSource,
   isSkillSourceInstallSpec,
 } from "../agents/skills-source-install.js";
 import { getRuntimeConfig } from "../config/config.js";
+import type { ClawHubSkillTrustCard } from "../infra/clawhub.js";
 import { defaultRuntime } from "../runtime.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { formatDocsLink } from "../terminal/links.js";
@@ -104,6 +106,117 @@ function resolveClawHubTargetWorkspaceDir(
     return CONFIG_DIR;
   }
   return resolveActiveWorkspaceDir({ agentId });
+}
+
+function trustAuditStatusLabel(status: string | undefined): string {
+  const label = (status ?? "unknown").toUpperCase();
+  if (status === "pass") {
+    return theme.success(label);
+  }
+  if (status === "review" || status === "pending") {
+    return theme.warn(label);
+  }
+  if (status === "malicious" || status === "error") {
+    return theme.error(label);
+  }
+  return label;
+}
+
+function trustCardString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function trustCardStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string" && item.trim().length > 0)
+    : [];
+}
+
+function formatTrustCardSource(source: ClawHubSkillTrustCard["source"]): string | undefined {
+  if (!source) {
+    return undefined;
+  }
+  const repo = trustCardString(source.repo);
+  const commit = trustCardString(source.commit);
+  const sourcePath = trustCardString(source.path);
+  const url = trustCardString(source.url);
+  if (repo && commit && sourcePath) {
+    return `${repo}@${commit.slice(0, 12)} ${sourcePath}`;
+  }
+  return url;
+}
+
+function formatTrustCardRequirementList(label: string, value: unknown): string | undefined {
+  const items = trustCardStringArray(value);
+  return items.length ? `${label}=${items.join(",")}` : undefined;
+}
+
+function formatTrustCardRequires(
+  requires: Record<string, unknown> | null | undefined,
+): string | undefined {
+  if (!requires || typeof requires !== "object") {
+    return undefined;
+  }
+  const record = requires;
+  const parts = [
+    formatTrustCardRequirementList("env", record.env),
+    formatTrustCardRequirementList("bins", record.bins),
+    formatTrustCardRequirementList("anyBins", record.anyBins),
+    formatTrustCardRequirementList("config", record.config),
+  ].filter((part): part is string => Boolean(part));
+  return parts.length ? parts.join("; ") : undefined;
+}
+
+function printSkillTrustVerification(params: {
+  slug: string;
+  resolvedFrom: "installed" | "version" | "tag" | "latest";
+  registry: string;
+  trustCard: ClawHubSkillTrustCard;
+}): string | undefined {
+  const card = params.trustCard;
+  const subjectSlug = trustCardString(card.subject?.slug) ?? params.slug;
+  const version = trustCardString(card.subject?.version) ?? "?";
+  const displayName = trustCardString(card.subject?.displayName);
+  const auditStatus = trustCardString(card.audit?.status);
+  const signatureStatus = trustCardString(card.signature?.status) ?? "unknown";
+  const fingerprint = trustCardString(card.artifact?.fingerprint);
+  const publisher =
+    trustCardString(card.publisher?.handle) ?? trustCardString(card.publisher?.displayName);
+  const capabilities = trustCardStringArray(card.capabilities?.tags);
+  const source = formatTrustCardSource(card.source);
+  const requires = formatTrustCardRequires(card.capabilities?.requires);
+
+  defaultRuntime.log(`${subjectSlug}@${version} trust`);
+  if (displayName) {
+    defaultRuntime.log(`Name: ${displayName}`);
+  }
+  defaultRuntime.log(`Registry: ${params.registry}`);
+  defaultRuntime.log(`Resolved: ${params.resolvedFrom}`);
+  if (publisher) {
+    defaultRuntime.log(`Publisher: ${publisher}`);
+  }
+  defaultRuntime.log(`Audit: ${trustAuditStatusLabel(auditStatus)}`);
+  if (card.audit?.summary) {
+    defaultRuntime.log(`Audit Summary: ${card.audit.summary}`);
+  }
+  if (card.audit?.reasonCodes?.length) {
+    defaultRuntime.log(`Audit Reasons: ${card.audit.reasonCodes.join(", ")}`);
+  }
+  defaultRuntime.log(`Signature: ${signatureStatus}`);
+  if (fingerprint) {
+    defaultRuntime.log(`Fingerprint: ${fingerprint}`);
+  }
+  defaultRuntime.log(`Files: ${card.artifact?.files?.length ?? 0}`);
+  if (source) {
+    defaultRuntime.log(`Source: ${source}`);
+  }
+  if (capabilities.length) {
+    defaultRuntime.log(`Capabilities: ${capabilities.join(", ")}`);
+  }
+  if (requires) {
+    defaultRuntime.log(`Requires: ${requires}`);
+  }
+  return auditStatus;
 }
 
 /**
@@ -284,6 +397,68 @@ export function registerSkillsCli(program: Command) {
               continue;
             }
             defaultRuntime.log(`${result.slug} already at ${result.version}`);
+          }
+        } catch (err) {
+          defaultRuntime.error(String(err));
+          defaultRuntime.exit(1);
+        }
+      },
+    );
+
+  skills
+    .command("verify")
+    .description("Verify a ClawHub skill trust card")
+    .argument("<slug>", "ClawHub skill slug")
+    .option("--version <version>", "Verify a specific version")
+    .option("--tag <tag>", "Verify a tag")
+    .option("--json", "Output as JSON", false)
+    .option("--global", "Use the shared managed skills directory for installed-version lookup")
+    .option("--agent <id>", "Target agent workspace (defaults to cwd-inferred, then default agent)")
+    .action(
+      async (
+        slug: string,
+        opts: {
+          version?: string;
+          tag?: string;
+          json?: boolean;
+          global?: boolean;
+          agent?: string;
+        },
+        command: Command,
+      ) => {
+        try {
+          if (opts.version && opts.tag) {
+            defaultRuntime.error("Use either --version or --tag.");
+            defaultRuntime.exit(1);
+            return;
+          }
+          const workspaceDir = resolveClawHubTargetWorkspaceDir(command, opts);
+          if (!workspaceDir) {
+            return;
+          }
+          const result = await verifySkillFromClawHub({
+            workspaceDir,
+            slug,
+            version: opts.version,
+            tag: opts.tag,
+          });
+          if (!result.ok) {
+            defaultRuntime.error(result.error);
+            defaultRuntime.exit(1);
+            return;
+          }
+          if (opts.json) {
+            defaultRuntime.writeJson(result);
+            return;
+          }
+          const auditStatus = printSkillTrustVerification({
+            slug: result.slug,
+            resolvedFrom: result.resolvedFrom,
+            registry: result.registry,
+            trustCard: result.trustCard,
+          });
+          if (auditStatus !== "pass") {
+            defaultRuntime.exit(1);
           }
         } catch (err) {
           defaultRuntime.error(String(err));

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -302,6 +302,54 @@ export type ClawHubSkillDetail = {
   } | null;
 };
 
+export type ClawHubSkillTrustCard = {
+  format?: string;
+  generatedAt?: number;
+  subject?: {
+    slug?: string;
+    displayName?: string;
+    version?: string;
+  } | null;
+  publisher?: {
+    handle?: string | null;
+    displayName?: string | null;
+  } | null;
+  source?: {
+    url?: string | null;
+    repo?: string | null;
+    commit?: string | null;
+    path?: string | null;
+  } | null;
+  artifact?: {
+    fingerprint?: string | null;
+    files?: unknown[];
+  } | null;
+  capabilities?: {
+    tags?: string[];
+    requires?: Record<string, unknown> | null;
+  } | null;
+  audit?: {
+    status?: "pass" | "review" | "malicious" | "pending" | "error" | (string & {});
+    summary?: string | null;
+    reasonCodes?: string[];
+  } | null;
+  signature?: {
+    status?: "unsigned" | "verified" | "invalid" | (string & {});
+  } | null;
+};
+
+export type ClawHubSkillTrustCardResponse = {
+  skill: {
+    slug: string;
+    displayName: string;
+  } | null;
+  version: {
+    version: string;
+    createdAt?: number;
+  } | null;
+  trustCard: ClawHubSkillTrustCard;
+};
+
 export type ClawHubSkillListResponse = {
   items: Array<{
     slug: string;
@@ -875,6 +923,28 @@ export async function fetchClawHubSkillDetail(params: {
     token: params.token,
     timeoutMs: params.timeoutMs,
     fetchImpl: params.fetchImpl,
+  });
+}
+
+export async function fetchClawHubSkillTrustCard(params: {
+  slug: string;
+  version?: string;
+  tag?: string;
+  baseUrl?: string;
+  token?: string;
+  timeoutMs?: number;
+  fetchImpl?: FetchLike;
+}): Promise<ClawHubSkillTrustCardResponse> {
+  return await fetchJson<ClawHubSkillTrustCardResponse>({
+    baseUrl: params.baseUrl,
+    path: `/api/v1/skills/${encodeURIComponent(params.slug)}/trust-card`,
+    token: params.token,
+    timeoutMs: params.timeoutMs,
+    fetchImpl: params.fetchImpl,
+    search: {
+      version: params.version,
+      tag: params.version ? undefined : params.tag,
+    },
   });
 }
 


### PR DESCRIPTION
## Summary

Inspired by NVIDIA's Verified Agent Skills write-up:
https://developer.nvidia.com/blog/nvidia-verified-agent-skills-provide-capability-governance-for-ai-agents/

This adds the OpenClaw consumer side for ClawHub skill trust cards.

- Adds `openclaw skills verify <slug>`.
- Verifies an explicitly requested `--version` or `--tag`, or defaults to the installed ClawHub version from `.clawhub/origin.json` when present.
- Fetches ClawHub's `/api/v1/skills/:slug/trust-card` response and prints subject, registry, resolution source, publisher, audit status, signature status, fingerprint, files, capabilities, and requirements.
- Supports `--json` for automation.
- Fails closed in human mode unless `audit.status` is exactly `pass`, including malformed/missing audit status.
- Documents the command in the skills CLI docs and changelog.

Companion ClawHub PR: https://github.com/openclaw/clawhub/pull/2368

## Verification

- `pnpm test src/cli/skills-cli.commands.test.ts src/agents/skills-clawhub.test.ts -- --reporter=dot`
- `pnpm check:changed` via Blacksmith Testbox: `tbx_01ks63swcr58pvsnppxag6s2b4`, GitHub Actions run https://github.com/openclaw/openclaw/actions/runs/26251435064
- `pnpm exec oxfmt --check --threads=1 src/infra/clawhub.ts src/agents/skills-clawhub.ts src/agents/skills-clawhub.test.ts src/cli/skills-cli.ts src/cli/skills-cli.commands.test.ts CHANGELOG.md`
- `pnpm format:docs:check`
- `git diff --check`
- `pnpm build`
- Autoreview: clean after fixing missing-audit-status fail-closed behavior.

## E2E / live notes

Public-live check: `https://clawhub.ai/api/v1/skills/openclaw/trust-card` currently returns 404 because the ClawHub producer route is not deployed yet.

Local contract e2e: ran the real `registerSkillsCli` command path against a live local HTTP server serving the ClawHub trust-card contract. Observed `Audit: PASS` and request `GET /api/v1/skills/calendar/trust-card?version=1.2.3`.

## Real behavior proof

Behavior addressed: Operators can verify the ClawHub trust card for a skill with `openclaw skills verify <slug>` before trusting or automating the installed skill.

Real environment tested: macOS source checkout plus Blacksmith Testbox for changed checks; live local HTTP server for the ClawHub trust-card endpoint contract.

Exact steps or command run after this patch: `openclaw skills verify calendar --version 1.2.3` equivalent through the real skills CLI registration against `OPENCLAW_CLAWHUB_URL=http://127.0.0.1:<port>`.

Evidence after fix: CLI requested `/api/v1/skills/calendar/trust-card?version=1.2.3`, printed `Audit: PASS`, `Signature: unsigned`, `Fingerprint: sha256:release`, `Capabilities: calendar`, and `Requires: env=CALENDAR_TOKEN`, then exited 0.

Observed result after fix: Passing trust cards render as verified human output; non-pass and malformed/missing audit statuses exit non-zero in tests.

What was not tested: Public production ClawHub e2e, because the producer route in https://github.com/openclaw/clawhub/pull/2368 is not deployed yet.
