### PR TITLE
Handle Codex turns missing completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Docs: https://docs.openclaw.ai
 - Update/doctor: prune stale local bundled plugin install records that point at old compiled bundled output so current bundled plugin schemas win after upgrade. (#84863) Thanks @fuller-stack-dev.
 - Providers/Ollama: preserve native Ollama tool-call IDs across assistant replay so Gemini over Ollama Cloud can keep its hidden function-call thought-signature handle.
 - Discord: keep session recovery and `/stop` abort ownership on the source dispatch lane while bound ACP turns continue routing to their target session, so stalled pre-run work and late replies are cleared instead of leaking after stop. Fixes #84477. (#85100) Thanks @joshavant.
+- Codex app-server: mark missing turn completion after observed execution as replay-unsafe and release the session so follow-up turns can run. Fixes #84076. (#85107) Thanks @joshavant.
 - PDF tool: time out idle remote PDF body reads after 120 seconds so stalled remote documents return an error instead of wedging the session. Fixes #68649. (#84768) Thanks @luoyanglang.
 - Diagnostics/OpenTelemetry plugin: suppress handled OTLP exporter promise rejections so collector shutdowns no longer crash the Gateway. (#81085) Thanks @luoyanglang.
 - Media/audio: skip empty structured sherpa-onnx transcripts instead of treating the raw JSON payload as spoken text. (#84667) Thanks @TurboTheTurtle.

--- a/extensions/codex/src/app-server/dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.test.ts
@@ -758,9 +758,60 @@ describe("createCodexDynamicToolBridge", () => {
       success: false,
       contentItems: [{ type: "inputText", text: "failed output" }],
     });
+    expect(result.sideEffectEvidence).toBe(true);
     const event = requireRecord(callArg(handler, 0, 0, "middleware event"), "middleware event");
     expect(event.isError).toBe(true);
     expectContextFields(callArg(handler, 0, 1, "middleware context"), { runtime: "codex" });
+  });
+
+  it("marks executed dynamic tool results as side-effect evidence", async () => {
+    const bridge = createBridgeWithToolResult("exec", textToolResult("done"));
+
+    const result = await bridge.handleToolCall({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      callId: "call-1",
+      namespace: null,
+      tool: "exec",
+      arguments: { command: "pwd" },
+    });
+
+    expect(result).toEqual(expectInputText("done"));
+    expect(result.sideEffectEvidence).toBe(true);
+  });
+
+  it("does not mark pre-execution argument failures as side-effect evidence", async () => {
+    const execute = vi.fn(async () => textToolResult("should not run"));
+    const bridge = createCodexDynamicToolBridge({
+      tools: [
+        createTool({
+          name: "exec",
+          execute,
+          ...({
+            prepareArguments: () => {
+              throw new Error("invalid arguments");
+            },
+          } as { prepareArguments: () => never }),
+        }),
+      ],
+      signal: new AbortController().signal,
+    });
+
+    const result = await bridge.handleToolCall({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      callId: "call-1",
+      namespace: null,
+      tool: "exec",
+      arguments: {},
+    });
+
+    expect(result).toEqual({
+      success: false,
+      contentItems: [{ type: "inputText", text: "invalid arguments" }],
+    });
+    expect(result.sideEffectEvidence).toBeUndefined();
+    expect(execute).not.toHaveBeenCalled();
   });
 
   it("uses raw tool provenance for media trust after middleware rewrites details", async () => {
@@ -1082,6 +1133,7 @@ describe("createCodexDynamicToolBridge", () => {
       success: false,
       contentItems: [{ type: "inputText", text: "blocked by policy" }],
     });
+    expect(result.sideEffectEvidence).toBeUndefined();
     expect(execute).not.toHaveBeenCalled();
     expect(bridge.telemetry.didSendViaMessagingTool).toBe(false);
     await vi.waitFor(() => {

--- a/extensions/codex/src/app-server/dynamic-tools.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.ts
@@ -125,8 +125,10 @@ export function createCodexDynamicToolBridge(params: {
       const args = jsonObjectToRecord(call.arguments);
       const startedAt = Date.now();
       const signal = composeAbortSignals(params.signal, options?.signal);
+      let didStartExecution = false;
       try {
         const preparedArgs = tool.prepareArguments ? tool.prepareArguments(args) : args;
+        didStartExecution = true;
         const rawResult = await tool.execute(call.callId, preparedArgs, signal);
         const rawIsError = isToolResultError(rawResult);
         const middlewareResult = await middlewareRunner.applyToolResultMiddleware({
@@ -167,12 +169,16 @@ export function createCodexDynamicToolBridge(params: {
           result,
           startedAt,
         });
-        return withDiagnosticTerminalType(
-          {
-            contentItems: convertToolContents(result.content, toolResultMaxChars),
-            success: !resultIsError,
-          },
-          inferToolResultDiagnosticTerminalType(result, resultIsError),
+        const terminalType = inferToolResultDiagnosticTerminalType(result, resultIsError);
+        return withSideEffectEvidence(
+          withDiagnosticTerminalType(
+            {
+              contentItems: convertToolContents(result.content, toolResultMaxChars),
+              success: !resultIsError,
+            },
+            terminalType,
+          ),
+          terminalType !== "blocked",
         );
       } catch (error) {
         collectToolTelemetry({
@@ -194,17 +200,20 @@ export function createCodexDynamicToolBridge(params: {
           error: error instanceof Error ? error.message : String(error),
           startedAt,
         });
-        return withDiagnosticTerminalType(
-          {
-            contentItems: [
-              {
-                type: "inputText",
-                text: error instanceof Error ? error.message : String(error),
-              },
-            ],
-            success: false,
-          },
-          "error",
+        return withSideEffectEvidence(
+          withDiagnosticTerminalType(
+            {
+              contentItems: [
+                {
+                  type: "inputText",
+                  text: error instanceof Error ? error.message : String(error),
+                },
+              ],
+              success: false,
+            },
+            "error",
+          ),
+          didStartExecution,
         );
       }
     },
@@ -230,7 +239,6 @@ function createCodexDynamicToolSpec(params: {
     deferLoading: true,
   };
 }
-
 function toToolResultHookContext(
   ctx: CodexDynamicToolHookContext | undefined,
 ): CodexToolResultHookContext {
@@ -459,6 +467,21 @@ function withDiagnosticTerminalType<T extends CodexDynamicToolCallResponse>(
     configurable: true,
     enumerable: false,
     value: terminalType,
+  });
+  return response;
+}
+
+function withSideEffectEvidence<T extends CodexDynamicToolCallResponse>(
+  response: T,
+  sideEffectEvidence: boolean,
+): T {
+  if (!sideEffectEvidence) {
+    return response;
+  }
+  Object.defineProperty(response, "sideEffectEvidence", {
+    configurable: true,
+    enumerable: false,
+    value: true,
   });
   return response;
 }

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -1991,6 +1991,95 @@ describe("CodexAppServerEventProjector", () => {
     expect(payload.text).toContain("```txt\nopened\n```");
   });
 
+  it("keeps side-effect evidence for dynamic tools that error after execution", async () => {
+    const projector = await createProjector();
+
+    projector.recordDynamicToolCall({
+      callId: "call-process-kill",
+      tool: "process",
+      arguments: { action: "kill", sessionId: "session-1" },
+    });
+    projector.recordDynamicToolResult({
+      callId: "call-process-kill",
+      tool: "process",
+      success: false,
+      terminalType: "error",
+      sideEffectEvidence: true,
+      contentItems: [{ type: "inputText", text: "process exited" }],
+    });
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+
+    expect(result.replayMetadata).toEqual({ hadPotentialSideEffects: true, replaySafe: false });
+  });
+
+  it("does not keep side-effect evidence for pre-execution dynamic tool errors", async () => {
+    const projector = await createProjector();
+
+    projector.recordDynamicToolCall({
+      callId: "call-unknown-message",
+      tool: "message",
+      arguments: { action: "send", text: "hello" },
+    });
+    projector.recordDynamicToolResult({
+      callId: "call-unknown-message",
+      tool: "message",
+      success: false,
+      terminalType: "error",
+      contentItems: [{ type: "inputText", text: "Unknown OpenClaw tool: message" }],
+    });
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+
+    expect(result.replayMetadata).toEqual({ hadPotentialSideEffects: false, replaySafe: true });
+  });
+
+  it("does not mark blocked dynamic tools as side-effecting", async () => {
+    const projector = await createProjector();
+
+    projector.recordDynamicToolCall({
+      callId: "call-bash-blocked",
+      tool: "bash",
+      arguments: { command: "touch blocked.txt" },
+    });
+    projector.recordDynamicToolResult({
+      callId: "call-bash-blocked",
+      tool: "bash",
+      success: false,
+      terminalType: "blocked",
+      sideEffectEvidence: true,
+      contentItems: [{ type: "inputText", text: "blocked" }],
+    });
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+
+    expect(result.replayMetadata).toEqual({ hadPotentialSideEffects: false, replaySafe: true });
+  });
+
+  it("treats completed native MCP tool calls as side-effect evidence", async () => {
+    const projector = await createProjector();
+
+    await projector.handleNotification({
+      method: "item/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: {
+          id: "mcp-1",
+          type: "mcpToolCall",
+          server: "github",
+          tool: "create_issue",
+          status: "completed",
+          arguments: { title: "check replay safety" },
+        },
+      },
+    });
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+
+    expect(result.replayMetadata).toEqual({ hadPotentialSideEffects: true, replaySafe: false });
+  });
+
   it("suppresses transcript progress for message-like tools", async () => {
     const onAgentEvent = vi.fn();
     const onToolResult = vi.fn();
@@ -2021,7 +2110,7 @@ describe("CodexAppServerEventProjector", () => {
     expect(onToolResult).not.toHaveBeenCalled();
   });
 
-  it("suppresses transcript progress for activity-log bash commands", async () => {
+  it("does not parse shell command text to suppress transcript progress", async () => {
     const onAgentEvent = vi.fn();
     const onToolResult = vi.fn();
     const projector = await createProjector({
@@ -2047,12 +2136,11 @@ describe("CodexAppServerEventProjector", () => {
       contentItems: [{ type: "inputText", text: "Logged: [web_search] Grilled salmon research" }],
     });
 
-    const toolEvents = onAgentEvent.mock.calls.filter(([event]) => {
-      const record = requireRecord(event, "agent event");
-      return record.stream === "tool";
-    });
-    expect(toolEvents).toHaveLength(0);
-    expect(onToolResult).not.toHaveBeenCalled();
+    expect(onAgentEvent).not.toHaveBeenCalled();
+    const toolProgressText = onToolResult.mock.calls
+      .map(([payload]) => (payload as { text?: string }).text ?? "")
+      .join("\n");
+    expect(toolProgressText).toContain("log_activity.sh");
 
     const result = projector.buildResult(buildEmptyToolTelemetry());
     expect(result.messagesSnapshot.some((message) => message.role === "toolResult")).toBe(true);

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -23,6 +23,10 @@ import {
 import { emitTrustedDiagnosticEvent } from "openclaw/plugin-sdk/diagnostic-runtime";
 import { resolveCodexLocalRuntimeAttribution } from "./local-runtime-attribution.js";
 import { CodexNativeSubagentTaskMirror } from "./native-subagent-task-mirror.js";
+import {
+  readCodexNotificationThreadId,
+  readCodexNotificationTurnId,
+} from "./notification-correlation.js";
 import { readCodexTurn } from "./protocol-validators.js";
 import {
   isJsonObject,
@@ -104,13 +108,9 @@ const TRANSCRIPT_PROGRESS_SUPPRESSED_TOOL_NAMES = new Set([
   "typing",
 ]);
 
-export function shouldEmitTranscriptToolProgress(toolName: unknown, args?: unknown): boolean {
+export function shouldEmitTranscriptToolProgress(toolName: unknown, _args?: unknown): boolean {
   const normalized = typeof toolName === "string" ? toolName.trim().toLowerCase() : "";
-  return Boolean(
-    normalized &&
-    !TRANSCRIPT_PROGRESS_SUPPRESSED_TOOL_NAMES.has(normalized) &&
-    !isActivityLogCommandProgress(normalized, args),
-  );
+  return Boolean(normalized && !TRANSCRIPT_PROGRESS_SUPPRESSED_TOOL_NAMES.has(normalized));
 }
 
 type ToolTranscriptCallInput = {
@@ -148,6 +148,8 @@ export class CodexAppServerEventProjector {
   >();
   private readonly toolResultOutputTextByItem = new Map<string, string>();
   private readonly toolMetas = new Map<string, { toolName: string; meta?: string }>();
+  private readonly sideEffectingToolItemIds = new Set<string>();
+  private readonly sideEffectingDynamicToolCallIds = new Set<string>();
   private readonly toolTranscriptMessages: AgentMessage[] = [];
   private readonly toolTranscriptCallIds = new Set<string>();
   private readonly toolTranscriptResultIds = new Set<string>();
@@ -322,6 +324,12 @@ export class CodexAppServerEventProjector {
       promptError,
       turnCompleted: Boolean(this.completedTurn),
     });
+    const toolMetas = [...this.toolMetas.values()];
+    const hadPotentialSideEffects =
+      toolTelemetry.didSendViaMessagingTool ||
+      (toolTelemetry.successfulCronAdds ?? 0) > 0 ||
+      this.sideEffectingToolItemIds.size > 0 ||
+      this.sideEffectingDynamicToolCallIds.size > 0;
     return {
       aborted: this.aborted || turnInterrupted,
       externalAbort: false,
@@ -337,7 +345,7 @@ export class CodexAppServerEventProjector {
       bootstrapPromptWarningSignature: this.params.bootstrapPromptWarningSignature,
       messagesSnapshot,
       assistantTexts,
-      toolMetas: [...this.toolMetas.values()],
+      toolMetas,
       lastAssistant,
       ...(this.lastNativeToolError ? { lastToolError: this.lastNativeToolError } : {}),
       didSendViaMessagingTool: toolTelemetry.didSendViaMessagingTool,
@@ -352,8 +360,8 @@ export class CodexAppServerEventProjector {
       cloudCodeAssistFormatError: false,
       attemptUsage: this.tokenUsage,
       replayMetadata: {
-        hadPotentialSideEffects: toolTelemetry.didSendViaMessagingTool,
-        replaySafe: !toolTelemetry.didSendViaMessagingTool,
+        hadPotentialSideEffects,
+        replaySafe: !hadPotentialSideEffects,
       },
       itemLifecycle: {
         startedCount: this.activeItemIds.size + this.completedItemIds.size,
@@ -369,10 +377,11 @@ export class CodexAppServerEventProjector {
   }
 
   recordDynamicToolCall(params: { callId: string; tool: string; arguments?: JsonValue }): void {
+    const args = sanitizeCodexToolArguments(params.arguments);
     this.recordToolTranscriptCall({
       id: params.callId,
       name: params.tool,
-      arguments: sanitizeCodexToolArguments(params.arguments),
+      arguments: args,
     });
   }
 
@@ -380,6 +389,8 @@ export class CodexAppServerEventProjector {
     callId: string;
     tool: string;
     success: boolean;
+    terminalType?: "blocked" | "completed" | "error";
+    sideEffectEvidence?: boolean;
     contentItems: CodexDynamicToolCallOutputContentItem[];
   }): void {
     this.recordToolTranscriptResult({
@@ -388,6 +399,10 @@ export class CodexAppServerEventProjector {
       text: collectDynamicToolContentText(params.contentItems),
       isError: !params.success,
     });
+    const terminalType = params.terminalType ?? (params.success ? "completed" : "error");
+    if (terminalType !== "blocked" && params.sideEffectEvidence === true) {
+      this.sideEffectingDynamicToolCallIds.add(params.callId);
+    }
   }
 
   markTimedOut(): void {
@@ -501,6 +516,7 @@ export class CodexAppServerEventProjector {
         },
       });
     }
+    this.recordToolMeta(item);
     this.emitStandardItemEvent({ phase: "start", item });
     this.emitNormalizedToolItemEvent({ phase: "start", item });
     this.recordNativeToolTranscriptCall(item);
@@ -1214,6 +1230,11 @@ export class CodexAppServerEventProjector {
       toolName,
       ...(meta ? { meta } : {}),
     });
+    if (isSideEffectingNativeToolItem(item)) {
+      this.sideEffectingToolItemIds.add(item.id);
+    } else {
+      this.sideEffectingToolItemIds.delete(item.id);
+    }
   }
 
   private recordNativeToolTranscriptCall(item: CodexThreadItem | undefined): void {
@@ -1502,7 +1523,7 @@ export class CodexAppServerEventProjector {
   }
 
   private isNotificationForTurn(params: JsonObject): boolean {
-    const threadId = readString(params, "threadId");
+    const threadId = readCodexNotificationThreadId(params);
     const turnId = readNotificationTurnId(params);
     return threadId === this.threadId && turnId === this.turnId;
   }
@@ -1519,12 +1540,7 @@ function isHookNotificationMethod(method: string): method is "hook/started" | "h
 }
 
 function readNotificationTurnId(record: JsonObject): string | undefined {
-  return readString(record, "turnId") ?? readNestedTurnId(record);
-}
-
-function readNestedTurnId(record: JsonObject): string | undefined {
-  const turn = record.turn;
-  return isJsonObject(turn) ? readString(turn, "id") : undefined;
+  return readCodexNotificationTurnId(record);
 }
 
 function readString(record: JsonObject, key: string): string | undefined {
@@ -1745,6 +1761,13 @@ function itemName(item: CodexThreadItem): string | undefined {
   return undefined;
 }
 
+function isSideEffectingNativeToolItem(item: CodexThreadItem): boolean {
+  return (
+    itemStatus(item) !== "blocked" &&
+    (isMutatingNativeToolItem(item) || item.type === "mcpToolCall")
+  );
+}
+
 function shouldSynthesizeToolProgressForItem(item: CodexThreadItem): boolean {
   switch (item.type) {
     case "commandExecution":
@@ -1814,7 +1837,7 @@ function itemToolArgs(item: CodexThreadItem): Record<string, unknown> | undefine
   if (item.type === "webSearch" && typeof item.query === "string") {
     return sanitizeCodexAgentEventRecord({ query: item.query });
   }
-  if (item.type === "mcpToolCall") {
+  if (item.type === "dynamicToolCall" || item.type === "mcpToolCall") {
     return sanitizeCodexToolArguments(item.arguments);
   }
   return undefined;
@@ -1948,31 +1971,6 @@ function normalizeToolTranscriptArguments(value: unknown): Record<string, unknow
     return {};
   }
   return value as Record<string, unknown>;
-}
-
-function isActivityLogCommandProgress(toolName: string, args: unknown): boolean {
-  if (toolName !== "bash" && toolName !== "exec" && toolName !== "shell") {
-    return false;
-  }
-  const command = readToolCommandText(args);
-  return Boolean(command && command.includes("log_activity.sh"));
-}
-
-function readToolCommandText(value: unknown): string | undefined {
-  if (typeof value === "string") {
-    return value;
-  }
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return undefined;
-  }
-  const record = value as Record<string, unknown>;
-  for (const key of ["command", "cmd", "shellCommand", "script"]) {
-    const text = record[key];
-    if (typeof text === "string" && text) {
-      return text;
-    }
-  }
-  return undefined;
 }
 
 function collectDynamicToolContentText(contentItems: CodexThreadItem["contentItems"]): string {

--- a/extensions/codex/src/app-server/notification-correlation.ts
+++ b/extensions/codex/src/app-server/notification-correlation.ts
@@ -1,0 +1,91 @@
+import {
+  isJsonObject,
+  type CodexServerNotification,
+  type JsonObject,
+  type JsonValue,
+} from "./protocol.js";
+
+export type CodexNotificationCorrelation = {
+  method: string;
+  paramsKeys?: string[];
+  activeThreadId: string;
+  activeTurnId?: string;
+  threadId?: string;
+  turnId?: string;
+  nestedTurnThreadId?: string;
+  nestedTurnId?: string;
+  turnStatus?: string;
+  turnItemCount?: number;
+  matchesActiveThread: boolean;
+  matchesActiveTurn?: boolean;
+};
+
+export function isCodexNotificationForTurn(
+  value: JsonValue | undefined,
+  threadId: string,
+  turnId: string,
+): boolean {
+  if (!isJsonObject(value)) {
+    return false;
+  }
+  return (
+    readCodexNotificationThreadId(value) === threadId &&
+    readCodexNotificationTurnId(value) === turnId
+  );
+}
+
+export function readCodexNotificationThreadId(record: JsonObject): string | undefined {
+  return readNestedTurnThreadId(record) ?? readString(record, "threadId");
+}
+
+export function readCodexNotificationTurnId(record: JsonObject): string | undefined {
+  return readNestedTurnId(record) ?? readString(record, "turnId");
+}
+
+export function describeCodexNotificationCorrelation(
+  notification: CodexServerNotification,
+  active: { threadId: string; turnId?: string },
+): CodexNotificationCorrelation {
+  const params = isJsonObject(notification.params) ? notification.params : undefined;
+  const turn = params && isJsonObject(params.turn) ? params.turn : undefined;
+  const threadId = params ? readString(params, "threadId") : undefined;
+  const turnId = params ? readString(params, "turnId") : undefined;
+  const nestedTurnThreadId = turn ? readString(turn, "threadId") : undefined;
+  const nestedTurnId = turn ? readString(turn, "id") : undefined;
+  const resolvedThreadId = params ? readCodexNotificationThreadId(params) : undefined;
+  const resolvedTurnId = params ? readCodexNotificationTurnId(params) : undefined;
+  const matchesActiveThread = resolvedThreadId === active.threadId;
+  const matchesActiveTurn = active.turnId
+    ? matchesActiveThread && resolvedTurnId === active.turnId
+    : undefined;
+  const items = turn?.items;
+  return {
+    method: notification.method,
+    ...(params ? { paramsKeys: Object.keys(params).toSorted() } : {}),
+    activeThreadId: active.threadId,
+    ...(active.turnId ? { activeTurnId: active.turnId } : {}),
+    ...(threadId ? { threadId } : {}),
+    ...(turnId ? { turnId } : {}),
+    ...(nestedTurnThreadId ? { nestedTurnThreadId } : {}),
+    ...(nestedTurnId ? { nestedTurnId } : {}),
+    ...(turn ? { turnStatus: readString(turn, "status") } : {}),
+    ...(Array.isArray(items) ? { turnItemCount: items.length } : {}),
+    matchesActiveThread,
+    ...(matchesActiveTurn === undefined ? {} : { matchesActiveTurn }),
+  };
+}
+
+function readNestedTurnId(record: JsonObject): string | undefined {
+  const turn = record.turn;
+  return isJsonObject(turn) ? readString(turn, "id") : undefined;
+}
+
+function readNestedTurnThreadId(record: JsonObject): string | undefined {
+  const turn = record.turn;
+  return isJsonObject(turn) ? readString(turn, "threadId") : undefined;
+}
+
+function readString(record: JsonObject, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}

--- a/extensions/codex/src/app-server/protocol.ts
+++ b/extensions/codex/src/app-server/protocol.ts
@@ -256,6 +256,7 @@ export type CodexDynamicToolCallParams = {
 export type CodexDynamicToolCallResponse = {
   contentItems: CodexDynamicToolCallOutputContentItem[];
   diagnosticTerminalType?: CodexDynamicToolDiagnosticTerminalType;
+  sideEffectEvidence?: boolean;
   success: boolean;
 };
 

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -1505,6 +1505,38 @@ describe("runCodexAppServerAttempt", () => {
     ]);
   });
 
+  it("accepts turn completions scoped by nested turn thread id", async () => {
+    const harness = createStartedThreadHarness();
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("turn/start");
+    await harness.notify({
+      method: "turn/completed",
+      params: {
+        threadId: "parent-thread",
+        turn: {
+          id: "turn-1",
+          threadId: "thread-1",
+          status: "completed",
+          items: [{ id: "agent-1", type: "agentMessage", text: "Nested done." }],
+          error: null,
+          startedAt: null,
+          completedAt: null,
+          durationMs: null,
+        },
+      },
+    });
+
+    const result = await run;
+
+    expect(result.promptError).toBeNull();
+    expect(result.assistantTexts).toEqual(["Nested done."]);
+  });
+
   it("keeps forced message dynamic tool when toolsAllow omits it", async () => {
     testing.setOpenClawCodingToolsFactoryForTests(() => [
       createRuntimeDynamicTool("message"),
@@ -2737,44 +2769,6 @@ describe("runCodexAppServerAttempt", () => {
     await run;
   });
 
-  it("suppresses normalized tool progress for activity-log dynamic bash requests", async () => {
-    const harness = createStartedThreadHarness();
-    const onRunAgentEvent = vi.fn();
-    const params = createParams(
-      path.join(tempDir, "session.jsonl"),
-      path.join(tempDir, "workspace"),
-    );
-    params.onAgentEvent = onRunAgentEvent;
-
-    const run = runCodexAppServerAttempt(params);
-    await harness.waitForMethod("thread/start");
-
-    await harness.handleServerRequest({
-      id: "request-tool-activity-log",
-      method: "item/tool/call",
-      params: {
-        threadId: "thread-1",
-        turnId: "turn-1",
-        callId: "call-log-activity-1",
-        namespace: null,
-        tool: "bash",
-        arguments: {
-          command:
-            '/bin/bash -lc \'/home/openclaw/.openclaw/workspace/bin/log_activity.sh "web_search" "Grilled salmon research"\'',
-        },
-      },
-    });
-
-    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
-    await run;
-
-    const toolEvents = onRunAgentEvent.mock.calls.filter(([event]) => {
-      const record = event as { stream?: string };
-      return record.stream === "tool";
-    });
-    expect(toolEvents).toHaveLength(0);
-  });
-
   it("releases the session when Codex never completes after a dynamic tool response", async () => {
     let handleRequest:
       | ((request: { id: string; method: string; params?: unknown }) => Promise<unknown>)
@@ -2856,6 +2850,164 @@ describe("runCodexAppServerAttempt", () => {
       { interval: 1 },
     );
     expect(queueActiveRunMessageForTest("session-1", "after timeout")).toBe(false);
+  });
+
+  it("marks Codex completion-idle timeouts after completed items as replay-invalid", async () => {
+    const harness = createStartedThreadHarness();
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+    params.timeoutMs = 200;
+
+    const run = runCodexAppServerAttempt(params, {
+      pluginConfig: { appServer: { turnCompletionIdleTimeoutMs: 5 } },
+      turnAssistantCompletionIdleTimeoutMs: 1_000,
+    });
+    await harness.waitForMethod("turn/start");
+    await harness.notify({
+      method: "item/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: {
+          id: "cmd-1",
+          type: "commandExecution",
+          command: "touch done.txt",
+          status: "completed",
+        },
+      },
+    });
+
+    const result = await run;
+
+    expect(result.timedOut).toBe(true);
+    expect(result.itemLifecycle.completedCount).toBe(1);
+    expect(result.promptTimeoutOutcome).toEqual({
+      message:
+        "Codex stopped before confirming the turn was complete. Some work may already have been performed; verify the current state before retrying.",
+      replayInvalid: true,
+      livenessState: "abandoned",
+    });
+  });
+
+  it("marks executed dynamic-tool completion-idle timeouts as replay-invalid", async () => {
+    testing.setOpenClawCodingToolsFactoryForTests(() => [createRuntimeDynamicTool("echo")]);
+    const harness = createStartedThreadHarness();
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+    params.disableTools = false;
+    params.runtimePlan = createCodexRuntimePlanFixture();
+    params.timeoutMs = 200;
+
+    const run = runCodexAppServerAttempt(params, {
+      pluginConfig: { appServer: { turnCompletionIdleTimeoutMs: 5 } },
+      turnAssistantCompletionIdleTimeoutMs: 1_000,
+    });
+    await harness.waitForMethod("turn/start");
+    const toolResult = (await harness.handleServerRequest({
+      id: "request-echo-tool",
+      method: "item/tool/call",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        callId: "call-echo-1",
+        namespace: null,
+        tool: "echo",
+        arguments: {},
+      },
+    })) as { success?: boolean };
+    expect(toolResult.success).toBe(true);
+
+    const result = await run;
+
+    expect(result.replayMetadata).toEqual({ hadPotentialSideEffects: true, replaySafe: false });
+    expect(result.promptTimeoutOutcome).toEqual({
+      message:
+        "Codex stopped before confirming the turn was complete. Some work may already have been performed; verify the current state before retrying.",
+      replayInvalid: true,
+      livenessState: "abandoned",
+    });
+  });
+
+  it("marks started mutating item timeouts as replay-invalid", async () => {
+    const harness = createStartedThreadHarness();
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+    params.timeoutMs = 200;
+
+    const run = runCodexAppServerAttempt(params, {
+      turnCompletionIdleTimeoutMs: 500,
+      turnTerminalIdleTimeoutMs: 5,
+    });
+    await harness.waitForMethod("turn/start");
+    await harness.notify({
+      method: "item/started",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: {
+          id: "cmd-1",
+          type: "commandExecution",
+          command: "touch done.txt",
+          status: "inProgress",
+        },
+      },
+    });
+
+    const result = await run;
+
+    expect(result.timedOut).toBe(true);
+    expect(result.itemLifecycle).toMatchObject({ activeCount: 1, completedCount: 0 });
+    expect(result.promptTimeoutOutcome).toEqual({
+      message:
+        "Codex stopped before confirming the turn was complete. Some work may already have been performed; verify the current state before retrying.",
+      replayInvalid: true,
+      livenessState: "abandoned",
+    });
+  });
+
+  it("does not mark assistant-only completion timeouts as replay-invalid", async () => {
+    const harness = createStartedThreadHarness();
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+    params.timeoutMs = 100;
+
+    const run = runCodexAppServerAttempt(params, {
+      turnCompletionIdleTimeoutMs: 500,
+      turnAssistantCompletionIdleTimeoutMs: 1_000,
+      turnTerminalIdleTimeoutMs: 500,
+    });
+    await harness.waitForMethod("turn/start");
+    await harness.notify({
+      method: "item/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: {
+          id: "msg-1",
+          type: "agentMessage",
+          text: "Finished.",
+          status: "completed",
+        },
+      },
+    });
+
+    const result = await run;
+
+    expect(result.timedOut).toBe(true);
+    expect(result.itemLifecycle.completedCount).toBe(1);
+    expect(result.toolMetas).toEqual([]);
+    expect(result.promptTimeoutOutcome).toEqual({
+      message:
+        "Codex stopped before confirming the turn was complete. The response may be incomplete; retry if needed.",
+    });
   });
 
   it("closes the app-server client when the active turn goes idle past the attempt timeout", async () => {

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -114,6 +114,10 @@ import {
   buildCodexNativeHookRelayConfig,
   CODEX_NATIVE_HOOK_RELAY_EVENTS,
 } from "./native-hook-relay.js";
+import {
+  describeCodexNotificationCorrelation,
+  isCodexNotificationForTurn,
+} from "./notification-correlation.js";
 import { buildCodexPluginAppCacheKey } from "./plugin-app-cache-key.js";
 import {
   buildCodexPluginThreadConfig,
@@ -266,6 +270,10 @@ function emitCodexAppServerEvent(
 
 function collectTerminalAssistantText(result: EmbeddedRunAttemptResult): string {
   return result.assistantTexts.join("\n\n").trim();
+}
+
+function hasCodexAppServerPotentialSideEffectEvidence(result: EmbeddedRunAttemptResult): boolean {
+  return result.replayMetadata.hadPotentialSideEffects;
 }
 
 type CodexSteeringQueueOptions = {
@@ -1996,6 +2004,17 @@ export async function runCodexAppServerAttempt(
     }
   };
   const enqueueNotification = (notification: CodexServerNotification): Promise<void> => {
+    const correlation = describeCodexNotificationCorrelation(notification, {
+      threadId: thread.threadId,
+      ...(turnId ? { turnId } : {}),
+    });
+    embeddedAgentLog.debug("codex app-server raw notification received", correlation);
+    if (notification.method === "turn/completed" && correlation.matchesActiveTurn === false) {
+      embeddedAgentLog.warn(
+        "codex app-server turn/completed did not match active turn",
+        correlation,
+      );
+    }
     if (!projector || !turnId) {
       userInputBridge?.handleNotification(notification);
       pendingNotifications.push(notification);
@@ -2177,6 +2196,9 @@ export async function runCodexAppServerAttempt(
           callId: call.callId,
           tool: call.tool,
           success: protocolResponse.success,
+          terminalType:
+            response.diagnosticTerminalType ?? (protocolResponse.success ? "completed" : "error"),
+          sideEffectEvidence: response.sideEffectEvidence === true,
           contentItems: protocolResponse.contentItems,
         });
         if (shouldEmitDynamicToolProgress) {
@@ -2662,6 +2684,23 @@ export async function runCodexAppServerAttempt(
     }
     const finalPromptErrorSource =
       timedOut || clientClosedPromptError ? "prompt" : result.promptErrorSource;
+    const completionIdleTimeoutHadPotentialSideEffects =
+      hasCodexAppServerPotentialSideEffectEvidence(result);
+    const promptTimeoutOutcome =
+      turnCompletionIdleTimedOut &&
+      (result.itemLifecycle.completedCount > 0 || completionIdleTimeoutHadPotentialSideEffects)
+        ? {
+            message: completionIdleTimeoutHadPotentialSideEffects
+              ? CODEX_APP_SERVER_MISSING_TERMINAL_EVENT_SIDE_EFFECT_USER_MESSAGE
+              : CODEX_APP_SERVER_MISSING_TERMINAL_EVENT_USER_MESSAGE,
+            ...(completionIdleTimeoutHadPotentialSideEffects
+              ? {
+                  replayInvalid: true,
+                  livenessState: "abandoned" as const,
+                }
+              : {}),
+          }
+        : undefined;
     recordCodexTrajectoryCompletion(trajectoryRecorder, {
       attempt: params,
       result,
@@ -2769,6 +2808,7 @@ export async function runCodexAppServerAttempt(
       aborted: finalAborted,
       promptError: finalPromptError,
       promptErrorSource: finalPromptErrorSource,
+      ...(promptTimeoutOutcome ? { promptTimeoutOutcome } : {}),
       systemPromptReport,
     };
   } finally {
@@ -2904,7 +2944,7 @@ async function handleDynamicToolCallWithTimeout(params: {
   const abortFromRun = () => {
     const message = "OpenClaw dynamic tool call aborted.";
     controller.abort(params.signal.reason ?? new Error(message));
-    resolveAbort?.(failedDynamicToolResponse(message));
+    resolveAbort?.(failedDynamicToolResponse(message, { sideEffectEvidence: true }));
   };
   const abortPromise = new Promise<CodexDynamicToolCallResponse>((resolve) => {
     resolveAbort = resolve;
@@ -2920,7 +2960,9 @@ async function handleDynamicToolCallWithTimeout(params: {
         ...timeoutDetails.meta,
         consoleMessage: timeoutDetails.consoleMessage,
       });
-      resolve(failedDynamicToolResponse(timeoutDetails.responseMessage));
+      resolve(
+        failedDynamicToolResponse(timeoutDetails.responseMessage, { sideEffectEvidence: true }),
+      );
     }, timeoutMs);
     timeout.unref?.();
   });
@@ -2936,7 +2978,9 @@ async function handleDynamicToolCallWithTimeout(params: {
       timeoutPromise,
     ]);
   } catch (error) {
-    return failedDynamicToolResponse(error instanceof Error ? error.message : String(error));
+    return failedDynamicToolResponse(error instanceof Error ? error.message : String(error), {
+      sideEffectEvidence: true,
+    });
   } finally {
     if (timeout) {
       clearTimeout(timeout);
@@ -2949,7 +2993,10 @@ async function handleDynamicToolCallWithTimeout(params: {
   }
 }
 
-function failedDynamicToolResponse(message: string): CodexDynamicToolCallResponse {
+function failedDynamicToolResponse(
+  message: string,
+  options?: { sideEffectEvidence?: boolean },
+): CodexDynamicToolCallResponse {
   const response: CodexDynamicToolCallResponse = {
     contentItems: [{ type: "inputText", text: message }],
     success: false,
@@ -2959,6 +3006,13 @@ function failedDynamicToolResponse(message: string): CodexDynamicToolCallRespons
     enumerable: false,
     value: "error",
   });
+  if (options?.sideEffectEvidence === true) {
+    Object.defineProperty(response, "sideEffectEvidence", {
+      configurable: true,
+      enumerable: false,
+      value: true,
+    });
+  }
   return response;
 }
 
@@ -4135,10 +4189,7 @@ function isTurnNotification(
   threadId: string,
   turnId: string,
 ): boolean {
-  if (!isJsonObject(value)) {
-    return false;
-  }
-  return readString(value, "threadId") === threadId && readNotificationTurnId(value) === turnId;
+  return isCodexNotificationForTurn(value, threadId, turnId);
 }
 
 function isCurrentThreadTurnRequestParams(
@@ -4187,21 +4238,16 @@ function isTerminalTurnStatus(status: string | undefined): boolean {
   return status === "completed" || status === "interrupted" || status === "failed";
 }
 
-function readNotificationTurnId(record: JsonObject): string | undefined {
-  return readString(record, "turnId") ?? readNestedTurnId(record);
-}
-
-function readNestedTurnId(record: JsonObject): string | undefined {
-  const turn = record.turn;
-  return isJsonObject(turn) ? readString(turn, "id") : undefined;
-}
-
 const CODEX_TURN_ABORT_MARKER_START = "<turn_aborted>";
 const CODEX_TURN_ABORT_MARKER_END = "</turn_aborted>";
 const CODEX_INTERRUPTED_USER_GUIDANCE =
   "The user interrupted the previous turn on purpose. Any running unified exec processes may still be running in the background. If any tools/commands were aborted, they may have partially executed.";
 const CODEX_INTERRUPTED_DEVELOPER_GUIDANCE =
   "The previous turn was interrupted on purpose. Any running unified exec processes may still be running in the background. If any tools/commands were aborted, they may have partially executed.";
+const CODEX_APP_SERVER_MISSING_TERMINAL_EVENT_USER_MESSAGE =
+  "Codex stopped before confirming the turn was complete. The response may be incomplete; retry if needed.";
+const CODEX_APP_SERVER_MISSING_TERMINAL_EVENT_SIDE_EFFECT_USER_MESSAGE =
+  "Codex stopped before confirming the turn was complete. Some work may already have been performed; verify the current state before retrying.";
 
 function isCodexTurnAbortMarkerNotification(
   notification: CodexServerNotification,

--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -10,7 +10,7 @@ import {
 } from "openclaw/plugin-sdk/hook-runtime";
 import { createMockPluginRegistry } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { CodexServerNotification, RpcRequest } from "./protocol.js";
+import type { CodexServerNotification, JsonObject, RpcRequest } from "./protocol.js";
 
 const readCodexAppServerBindingMock = vi.fn();
 const isCodexAppServerNativeAuthProfileMock = vi.fn();
@@ -277,6 +277,16 @@ function turnCompleted(threadId: string, turnId: string, text: string): CodexSer
   };
 }
 
+function turnCompletedWithNestedThread(
+  threadId: string,
+  turnId: string,
+  text: string,
+): CodexServerNotification {
+  const notification = turnCompleted(threadId, turnId, text);
+  const turn = (notification.params as JsonObject).turn;
+  return { method: notification.method, params: { threadId: "parent-thread", turn } };
+}
+
 function sideParams(overrides: Partial<Parameters<typeof runCodexAppServerSideQuestion>[0]> = {}) {
   return {
     cfg: {} as never,
@@ -456,6 +466,33 @@ describe("runCodexAppServerSideQuestion", () => {
     expect(toolOptions).toHaveProperty("messageProvider", "discord-voice");
     expect(toolOptions).toHaveProperty("currentChannelId", "voice-room");
     expect(toolOptions).toHaveProperty("requireExplicitMessageTarget", true);
+  });
+
+  it("returns side-thread completions scoped by nested turn thread id", async () => {
+    const client = createFakeClient();
+    client.request.mockImplementation(async (method: string) => {
+      if (method === "thread/fork") {
+        return threadResult("side-thread");
+      }
+      if (method === "thread/inject_items") {
+        return {};
+      }
+      if (method === "turn/start") {
+        queueMicrotask(() =>
+          client.emit(turnCompletedWithNestedThread("side-thread", "turn-1", "Nested answer.")),
+        );
+        return turnStartResult("turn-1");
+      }
+      if (method === "thread/unsubscribe" || method === "turn/interrupt") {
+        return {};
+      }
+      throw new Error(`unexpected request: ${method}`);
+    });
+    getSharedCodexAppServerClientMock.mockResolvedValue(client);
+
+    const result = await runCodexAppServerSideQuestion(sideParams());
+
+    expect(result).toEqual({ text: "Nested answer." });
   });
 
   it("installs native hook relay config for opted-in side threads", async () => {

--- a/extensions/codex/src/app-server/side-question.ts
+++ b/extensions/codex/src/app-server/side-question.ts
@@ -36,12 +36,16 @@ import {
   buildCodexNativeHookRelayDisabledConfig,
   CODEX_NATIVE_HOOK_RELAY_EVENTS,
 } from "./native-hook-relay.js";
+import {
+  readCodexNotificationThreadId,
+  readCodexNotificationTurnId,
+} from "./notification-correlation.js";
 import { mergeCodexThreadConfigs } from "./plugin-thread-config.js";
 import {
   assertCodexThreadForkResponse,
   assertCodexTurnStartResponse,
   readCodexDynamicToolCallParams,
-  readCodexTurnCompletedNotification,
+  readCodexTurn,
 } from "./protocol-validators.js";
 import {
   isJsonObject,
@@ -913,8 +917,7 @@ class CodexSideQuestionCollector {
   }
 
   private completeFromTurn(params: JsonObject): void {
-    const notification = readCodexTurnCompletedNotification(params);
-    const turn = notification?.turn;
+    const turn = readCodexTurn(params.turn);
     if (!turn || turn.id !== this.turnId) {
       return;
     }
@@ -963,16 +966,13 @@ function collectAssistantText(turn: CodexTurn): string {
 }
 
 function isNotificationForTurn(params: JsonObject, threadId: string, turnId: string): boolean {
-  return readString(params, "threadId") === threadId && readNotificationTurnId(params) === turnId;
+  return (
+    readCodexNotificationThreadId(params) === threadId && readNotificationTurnId(params) === turnId
+  );
 }
 
 function readNotificationTurnId(record: JsonObject): string | undefined {
-  return readString(record, "turnId") ?? readNestedTurnId(record);
-}
-
-function readNestedTurnId(record: JsonObject): string | undefined {
-  const turn = record.turn;
-  return isJsonObject(turn) ? readString(turn, "id") : undefined;
+  return readCodexNotificationTurnId(record);
 }
 
 function readBooleanAlias(record: JsonObject, keys: readonly string[]): boolean | undefined {

--- a/extensions/codex/src/conversation-turn-collector.ts
+++ b/extensions/codex/src/conversation-turn-collector.ts
@@ -1,4 +1,8 @@
 import {
+  readCodexNotificationThreadId,
+  readCodexNotificationTurnId,
+} from "./app-server/notification-correlation.js";
+import {
   isJsonObject,
   type CodexServerNotification,
   type JsonObject,
@@ -51,7 +55,7 @@ export function createCodexConversationTurnCollector(threadId: string) {
 
   const handleNotification = (notification: CodexServerNotification) => {
     const params = isJsonObject(notification.params) ? notification.params : undefined;
-    if (!params || readString(params, "threadId") !== threadId) {
+    if (!params || readCodexNotificationThreadId(params) !== threadId) {
       return;
     }
     if (!turnId) {
@@ -151,7 +155,7 @@ function isNotificationForTurn(
   threadId: string,
   turnId: string | undefined,
 ): boolean {
-  if (readString(params, "threadId") !== threadId) {
+  if (readCodexNotificationThreadId(params) !== threadId) {
     return false;
   }
   if (!turnId) {
@@ -166,7 +170,7 @@ function isNotificationForTurn(
 }
 
 function readNotificationTurnId(params: JsonObject): string | undefined {
-  return readString(params, "turnId") ?? readString(readRecord(params.turn), "id");
+  return readCodexNotificationTurnId(params);
 }
 
 function readRecord(value: unknown): Record<string, unknown> | undefined {

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   makeAttemptResult,
   makeCompactionSuccess,
@@ -589,6 +589,39 @@ describe("overflow compaction in run loop", () => {
 
     expect(result.payloads?.[0]?.isError).toBe(true);
     expect(result.payloads?.[0]?.text).toContain("timed out");
+  });
+
+  it("uses harness-provided prompt timeout outcome metadata", async () => {
+    const setTerminalLifecycleMeta = vi.fn();
+    mockedRunEmbeddedAttempt.mockResolvedValue(
+      makeAttemptResult({
+        aborted: true,
+        timedOut: true,
+        timedOutDuringCompaction: false,
+        assistantTexts: [],
+        promptTimeoutOutcome: {
+          message: "Harness stopped after completed work without terminal confirmation.",
+          replayInvalid: true,
+          livenessState: "abandoned",
+        },
+        setTerminalLifecycleMeta,
+      }),
+    );
+
+    const result = await runEmbeddedPiAgent(baseParams);
+
+    expect(result.payloads).toEqual([
+      {
+        text: "Harness stopped after completed work without terminal confirmation.",
+        isError: true,
+      },
+    ]);
+    expect(result.meta?.replayInvalid).toBe(true);
+    expect(result.meta?.livenessState).toBe("abandoned");
+    expect(setTerminalLifecycleMeta).toHaveBeenCalledWith({
+      replayInvalid: true,
+      livenessState: "abandoned",
+    });
   });
 
   it("does not emit a generic timeout payload after messaging-tool delivery", async () => {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -2686,20 +2686,25 @@ export async function runEmbeddedPiAgent(
           // partial assistant fragment. Emit an explicit timeout error instead,
           // preserving any tool payloads that succeeded before the timeout.
           if (timedOutDuringPrompt && !hasMessagingToolDeliveryEvidence(attempt)) {
-            const timeoutText = idleTimedOut
+            const defaultTimeoutText = idleTimedOut
               ? "The model did not produce a response before the model idle timeout. " +
                 "Please try again, or increase `models.providers.<id>.timeoutSeconds` for slow local or self-hosted providers. " +
                 "If `agents.defaults.timeoutSeconds` or a run-specific timeout is lower, raise that ceiling too; provider timeouts cannot extend the whole agent run."
               : "Request timed out before a response was generated. " +
                 "Please try again, or increase `agents.defaults.timeoutSeconds` in your config.";
-            const replayInvalid = resolveReplayInvalidForAttempt(null);
-            const livenessState = resolveRunLivenessState({
-              payloadCount: hasPartialAssistantTextAfterPromptTimeout ? 0 : payloads.length,
-              aborted,
-              timedOut,
-              attempt,
-              incompleteTurnText: null,
-            });
+            const promptTimeoutMessage = attempt.promptTimeoutOutcome?.message?.trim();
+            const timeoutText = promptTimeoutMessage || defaultTimeoutText;
+            const replayInvalid =
+              attempt.promptTimeoutOutcome?.replayInvalid ?? resolveReplayInvalidForAttempt(null);
+            const livenessState =
+              attempt.promptTimeoutOutcome?.livenessState ??
+              resolveRunLivenessState({
+                payloadCount: hasPartialAssistantTextAfterPromptTimeout ? 0 : payloads.length,
+                aborted,
+                timedOut,
+                attempt,
+                incompleteTurnText: null,
+              });
             attempt.setTerminalLifecycleMeta?.({
               replayInvalid,
               livenessState,

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -108,6 +108,11 @@ export type EmbeddedRunAttemptResult = {
   diagnosticTrace?: DiagnosticTraceContext;
   agentHarnessId?: string;
   agentHarnessResultClassification?: "empty" | "reasoning-only" | "planning-only";
+  promptTimeoutOutcome?: {
+    message?: string;
+    replayInvalid?: boolean;
+    livenessState?: EmbeddedRunLivenessState;
+  };
   bootstrapPromptWarningSignaturesSeen?: string[];
   bootstrapPromptWarningSignature?: string;
   systemPromptReport?: SessionSystemPromptReport;


### PR DESCRIPTION
## Summary

- handle Codex app-server turns that stop before a matching `turn/completed`
- mark missing-terminal timeouts replay-unsafe only from observed execution/delivery facts, not shell command parsing
- preserve retry-safe outcomes for pre-execution dynamic-tool validation and blocked tool calls
- release the session after the timeout so the next turn can run

Fixes #84076.

## Verification

- `node scripts/run-vitest.mjs extensions/codex/src/app-server/dynamic-tools.test.ts extensions/codex/src/app-server/event-projector.test.ts -- --reporter=dot`
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts -- --reporter=dot`
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/side-question.test.ts extensions/codex/src/conversation-turn-collector.test.ts src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts -- --reporter=dot`
- `git diff --check`
- `AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --mode local`
- AWS Crabbox deterministic E2E: run `run_05062ccbfbc4`, provider `aws`, lease `cbx_2de871a3b3ca`, exit `0`
- AWS Crabbox live Codex provider sanity: run `run_b218cba3016f`, provider `aws`, lease `cbx_3bdfe3ed80bf`, exit `0`

## Real behavior proof

Behavior addressed: Codex app-server may produce evidence of work and then stop before OpenClaw receives a matching `turn/completed`; OpenClaw should not leave the session stuck or imply retry safety after possible side effects.

Real environment tested: Direct AWS Crabbox (`provider=aws`) with a built OpenClaw gateway and bundled Codex plugin; then a live Codex provider Docker harness using `OPENCLAW_LIVE_CODEX_HARNESS_AUTH=api-key`.

Exact steps or command run after this patch: Deterministic Crabbox E2E drove a real gateway through the Codex plugin with a fake app-server that completed a command item and withheld `turn/completed`, then sent a second turn. Live sanity ran `pnpm test:docker:live-codex-harness` on AWS with optional image/MCP/subagent/guardian probes disabled.

Evidence after fix: Deterministic run `run_05062ccbfbc4` on lease `cbx_2de871a3b3ca` returned first turn `status=timeout`, `aborted=true`, `replayInvalid=true`, `livenessState=abandoned`, and the replay-unsafe timeout text; second turn returned `status=ok` and `SECOND_RUN_OK`. Live run `run_b218cba3016f` on lease `cbx_3bdfe3ed80bf` passed `src/gateway/gateway-codex-harness.live.test.ts` with 1 passed, 1 skipped.

Observed result after fix: Missing terminal confirmation after possible side effects produces an abandoned replay-invalid timeout and releases the session; normal live Codex app-server turns still complete and resume through the gateway.

What was not tested: A naturally occurring live provider omission of `turn/completed`; the deterministic E2E injects that boundary failure because live reproduction is not reliable on demand.
