### PR TITLE
fix(codex): block progress-only completions [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Docs: https://docs.openclaw.ai
 
 - CLI/agents: allow `openclaw agent --session-key` to target explicit session keys, including agent-scoped legacy keys. (#85121) Thanks @Kaspre.
 - Auto-reply/ACP: wait for same-channel block reply delivery before starting tool work, while still honoring ACP dispatch aborts so stopped turns do not wait on slow channel sends. (#83722) Thanks @IWhatsskill.
+- Codex/ACP: mark required child-run completions that only report progress, omit a final deliverable, or fail requester delivery as blocked while preserving real final reports. (#85110) Thanks @IWhatsskill.
 - Agents/subagents: surface blocked child-run completions as errors instead of successful subagent finishes. (#80886) Thanks @TurboTheTurtle.
 - Agents/Pi: treat accepted embedded `sessions_spawn` child-session handoffs as terminal progress so parent turns no longer report false non-deliverable failures. (#85054) Thanks @samzong.
 - WhatsApp: update Baileys to `7.0.0-rc13` and drop the obsolete logger type patch.

--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -12,6 +12,7 @@ import {
   failTaskRunByRunId,
   startTaskRunByRunId,
 } from "../../tasks/detached-task-runtime.js";
+import { resolveRequiredCompletionTerminalResult } from "../../tasks/task-completion-contract.js";
 import type { DeliveryContext } from "../../utils/delivery-context.js";
 import {
   AcpRuntimeError,
@@ -125,6 +126,10 @@ function resolveBackgroundTaskTerminalResult(progressSummary: string): {
   terminalOutcome?: "blocked";
   terminalSummary?: string;
 } {
+  const requiredCompletionResult = resolveRequiredCompletionTerminalResult(progressSummary);
+  if (requiredCompletionResult.terminalOutcome) {
+    return requiredCompletionResult;
+  }
   const normalized = normalizeText(progressSummary)?.replace(/\s+/g, " ").trim();
   if (!normalized) {
     return {};

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -2731,6 +2731,155 @@ describe("AcpSessionManager", () => {
     });
   });
 
+  it("marks completed parented ACP turns blocked when they only contain progress text", async () => {
+    await withAcpManagerTaskStateDir(async () => {
+      const runtimeState = createRuntime();
+      runtimeState.runtime.startTurn = vi.fn((input) => ({
+        requestId: input.requestId,
+        events: (async function* () {
+          yield {
+            type: "text_delta" as const,
+            stream: "output" as const,
+            text: "I'll inspect the repo now.",
+          };
+        })(),
+        result: Promise.resolve({
+          status: "completed" as const,
+          stopReason: "end_turn",
+        }),
+        cancel: vi.fn(async () => {}),
+        closeStream: vi.fn(async () => {}),
+      }));
+      hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+        id: "acpx",
+        runtime: runtimeState.runtime,
+      });
+      hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
+        const sessionKey = (paramsUnknown as { sessionKey?: string }).sessionKey;
+        if (sessionKey === "agent:codex:acp:child-1") {
+          return {
+            sessionKey,
+            storeSessionKey: sessionKey,
+            entry: {
+              sessionId: "child-1",
+              updatedAt: Date.now(),
+              spawnedBy: "agent:quant:telegram:quant:direct:822430204",
+              label: "Progress only",
+            },
+            acp: readySessionMeta(),
+          };
+        }
+        if (sessionKey === "agent:quant:telegram:quant:direct:822430204") {
+          return {
+            sessionKey,
+            storeSessionKey: sessionKey,
+            entry: {
+              sessionId: "parent-1",
+              updatedAt: Date.now(),
+            },
+          };
+        }
+        return null;
+      });
+
+      const events: string[] = [];
+      const manager = new AcpSessionManager();
+      await manager.runTurn({
+        cfg: baseCfg,
+        sessionKey: "agent:codex:acp:child-1",
+        text: "Inspect and report back",
+        mode: "prompt",
+        requestId: "direct-parented-progress-completed-run",
+        onEvent: (event) => {
+          events.push(event.type);
+        },
+      });
+
+      expect(events).toEqual(["text_delta", "done"]);
+      expectRecordFields(requireTaskByRunId("direct-parented-progress-completed-run"), {
+        runtime: "acp",
+        ownerKey: "agent:quant:telegram:quant:direct:822430204",
+        scopeKind: "session",
+        childSessionKey: "agent:codex:acp:child-1",
+        status: "succeeded",
+        progressSummary: "I'll inspect the repo now.",
+        terminalOutcome: "blocked",
+        terminalSummary: "Required completion ended with progress-only text, not a final deliverable.",
+      });
+    });
+  });
+
+  it("marks completed parented ACP turns blocked when final output is missing", async () => {
+    await withAcpManagerTaskStateDir(async () => {
+      const runtimeState = createRuntime();
+      runtimeState.runtime.startTurn = vi.fn((input) => ({
+        requestId: input.requestId,
+        events: (async function* () {})(),
+        result: Promise.resolve({
+          status: "completed" as const,
+          stopReason: "end_turn",
+        }),
+        cancel: vi.fn(async () => {}),
+        closeStream: vi.fn(async () => {}),
+      }));
+      hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+        id: "acpx",
+        runtime: runtimeState.runtime,
+      });
+      hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
+        const sessionKey = (paramsUnknown as { sessionKey?: string }).sessionKey;
+        if (sessionKey === "agent:codex:acp:child-1") {
+          return {
+            sessionKey,
+            storeSessionKey: sessionKey,
+            entry: {
+              sessionId: "child-1",
+              updatedAt: Date.now(),
+              spawnedBy: "agent:quant:telegram:quant:direct:822430204",
+              label: "Missing final",
+            },
+            acp: readySessionMeta(),
+          };
+        }
+        if (sessionKey === "agent:quant:telegram:quant:direct:822430204") {
+          return {
+            sessionKey,
+            storeSessionKey: sessionKey,
+            entry: {
+              sessionId: "parent-1",
+              updatedAt: Date.now(),
+            },
+          };
+        }
+        return null;
+      });
+
+      const events: string[] = [];
+      const manager = new AcpSessionManager();
+      await manager.runTurn({
+        cfg: baseCfg,
+        sessionKey: "agent:codex:acp:child-1",
+        text: "Produce a final result",
+        mode: "prompt",
+        requestId: "direct-parented-empty-completed-run",
+        onEvent: (event) => {
+          events.push(event.type);
+        },
+      });
+
+      expect(events).toEqual(["done"]);
+      expectRecordFields(requireTaskByRunId("direct-parented-empty-completed-run"), {
+        runtime: "acp",
+        ownerKey: "agent:quant:telegram:quant:direct:822430204",
+        scopeKind: "session",
+        childSessionKey: "agent:codex:acp:child-1",
+        status: "succeeded",
+        terminalOutcome: "blocked",
+        terminalSummary: "Required completion did not produce a final deliverable.",
+      });
+    });
+  });
+
   it("closes completed startTurn streams after draining queued output", async () => {
     await withAcpManagerTaskStateDir(async () => {
       const runtimeState = createRuntime();

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -2886,6 +2886,80 @@ describe("AcpSessionManager", () => {
     });
   });
 
+  it("keeps parented ACP turns blocked when progress text only adds follow-up planning", async () => {
+    await withAcpManagerTaskStateDir(async () => {
+      const runtimeState = createRuntime();
+      runtimeState.runtime.startTurn = vi.fn((input) => ({
+        requestId: input.requestId,
+        events: (async function* () {
+          yield {
+            type: "text_delta" as const,
+            stream: "output" as const,
+            text: "I'll inspect the repo now. Then I'll run tests and report back.",
+          };
+        })(),
+        result: Promise.resolve({
+          status: "completed" as const,
+          stopReason: "end_turn",
+        }),
+        cancel: vi.fn(async () => {}),
+        closeStream: vi.fn(async () => {}),
+      }));
+      hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+        id: "acpx",
+        runtime: runtimeState.runtime,
+      });
+      hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
+        const sessionKey = (paramsUnknown as { sessionKey?: string }).sessionKey;
+        if (sessionKey === "agent:codex:acp:child-1") {
+          return {
+            sessionKey,
+            storeSessionKey: sessionKey,
+            entry: {
+              sessionId: "child-1",
+              updatedAt: Date.now(),
+              spawnedBy: "agent:quant:telegram:quant:direct:822430204",
+              label: "Follow-up planning",
+            },
+            acp: readySessionMeta(),
+          };
+        }
+        if (sessionKey === "agent:quant:telegram:quant:direct:822430204") {
+          return {
+            sessionKey,
+            storeSessionKey: sessionKey,
+            entry: {
+              sessionId: "parent-1",
+              updatedAt: Date.now(),
+            },
+          };
+        }
+        return null;
+      });
+
+      const manager = new AcpSessionManager();
+      await manager.runTurn({
+        cfg: baseCfg,
+        sessionKey: "agent:codex:acp:child-1",
+        text: "Inspect and report back",
+        mode: "prompt",
+        requestId: "direct-parented-followup-planning-run",
+      });
+
+      expectRecordFields(requireTaskByRunId("direct-parented-followup-planning-run"), {
+        runtime: "acp",
+        ownerKey: "agent:quant:telegram:quant:direct:822430204",
+        scopeKind: "session",
+        childSessionKey: "agent:codex:acp:child-1",
+        status: "succeeded",
+        progressSummary: "I'll inspect the repo now. Then I'll run tests and report back.",
+        terminalOutcome: "blocked",
+        terminalSummary:
+          "Required completion ended with progress-only text, not a final deliverable.",
+      });
+    });
+  });
+
   it("marks completed parented ACP turns blocked when they only contain progress text", async () => {
     await withAcpManagerTaskStateDir(async () => {
       const runtimeState = createRuntime();

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -2745,7 +2745,7 @@ describe("AcpSessionManager", () => {
           yield {
             type: "text_delta" as const,
             stream: "output" as const,
-            text: "Fixed the crash and verified the regression tests pass.",
+            text: "The crash is a missing null check in src/foo.ts.",
           };
         })(),
         result: Promise.resolve({
@@ -2804,7 +2804,7 @@ describe("AcpSessionManager", () => {
         childSessionKey: "agent:codex:acp:child-1",
         status: "succeeded",
         progressSummary:
-          "I'll inspect the repo now. Fixed the crash and verified the regression tests pass.",
+          "I'll inspect the repo now. The crash is a missing null check in src/foo.ts.",
       });
       expect(record.terminalOutcome).toBeUndefined();
       expect(record.terminalSummary).toBeUndefined();
@@ -2884,7 +2884,8 @@ describe("AcpSessionManager", () => {
         status: "succeeded",
         progressSummary: "I'll inspect the repo now.",
         terminalOutcome: "blocked",
-        terminalSummary: "Required completion ended with progress-only text, not a final deliverable.",
+        terminalSummary:
+          "Required completion ended with progress-only text, not a final deliverable.",
       });
     });
   });

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -2811,6 +2811,81 @@ describe("AcpSessionManager", () => {
     });
   });
 
+  it("keeps parented ACP turns successful when final output follows a separator", async () => {
+    await withAcpManagerTaskStateDir(async () => {
+      const runtimeState = createRuntime();
+      runtimeState.runtime.startTurn = vi.fn((input) => ({
+        requestId: input.requestId,
+        events: (async function* () {
+          yield {
+            type: "text_delta" as const,
+            stream: "output" as const,
+            text: "I'll inspect the repo now: the crash is a missing null check in src/foo.ts.",
+          };
+        })(),
+        result: Promise.resolve({
+          status: "completed" as const,
+          stopReason: "end_turn",
+        }),
+        cancel: vi.fn(async () => {}),
+        closeStream: vi.fn(async () => {}),
+      }));
+      hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+        id: "acpx",
+        runtime: runtimeState.runtime,
+      });
+      hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
+        const sessionKey = (paramsUnknown as { sessionKey?: string }).sessionKey;
+        if (sessionKey === "agent:codex:acp:child-1") {
+          return {
+            sessionKey,
+            storeSessionKey: sessionKey,
+            entry: {
+              sessionId: "child-1",
+              updatedAt: Date.now(),
+              spawnedBy: "agent:quant:telegram:quant:direct:822430204",
+              label: "Separator final",
+            },
+            acp: readySessionMeta(),
+          };
+        }
+        if (sessionKey === "agent:quant:telegram:quant:direct:822430204") {
+          return {
+            sessionKey,
+            storeSessionKey: sessionKey,
+            entry: {
+              sessionId: "parent-1",
+              updatedAt: Date.now(),
+            },
+          };
+        }
+        return null;
+      });
+
+      const manager = new AcpSessionManager();
+      await manager.runTurn({
+        cfg: baseCfg,
+        sessionKey: "agent:codex:acp:child-1",
+        text: "Inspect and report back",
+        mode: "prompt",
+        requestId: "direct-parented-separator-final-run",
+      });
+
+      const record = requireTaskByRunId("direct-parented-separator-final-run");
+      expectRecordFields(record, {
+        runtime: "acp",
+        ownerKey: "agent:quant:telegram:quant:direct:822430204",
+        scopeKind: "session",
+        childSessionKey: "agent:codex:acp:child-1",
+        status: "succeeded",
+        progressSummary:
+          "I'll inspect the repo now: the crash is a missing null check in src/foo.ts.",
+      });
+      expect(record.terminalOutcome).toBeUndefined();
+      expect(record.terminalSummary).toBeUndefined();
+    });
+  });
+
   it("marks completed parented ACP turns blocked when they only contain progress text", async () => {
     await withAcpManagerTaskStateDir(async () => {
       const runtimeState = createRuntime();

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -2731,6 +2731,86 @@ describe("AcpSessionManager", () => {
     });
   });
 
+  it("keeps parented ACP turns successful when final output follows progress text", async () => {
+    await withAcpManagerTaskStateDir(async () => {
+      const runtimeState = createRuntime();
+      runtimeState.runtime.startTurn = vi.fn((input) => ({
+        requestId: input.requestId,
+        events: (async function* () {
+          yield {
+            type: "text_delta" as const,
+            stream: "output" as const,
+            text: "I'll inspect the repo now. ",
+          };
+          yield {
+            type: "text_delta" as const,
+            stream: "output" as const,
+            text: "Fixed the crash and verified the regression tests pass.",
+          };
+        })(),
+        result: Promise.resolve({
+          status: "completed" as const,
+          stopReason: "end_turn",
+        }),
+        cancel: vi.fn(async () => {}),
+        closeStream: vi.fn(async () => {}),
+      }));
+      hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+        id: "acpx",
+        runtime: runtimeState.runtime,
+      });
+      hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
+        const sessionKey = (paramsUnknown as { sessionKey?: string }).sessionKey;
+        if (sessionKey === "agent:codex:acp:child-1") {
+          return {
+            sessionKey,
+            storeSessionKey: sessionKey,
+            entry: {
+              sessionId: "child-1",
+              updatedAt: Date.now(),
+              spawnedBy: "agent:quant:telegram:quant:direct:822430204",
+              label: "Progress then final",
+            },
+            acp: readySessionMeta(),
+          };
+        }
+        if (sessionKey === "agent:quant:telegram:quant:direct:822430204") {
+          return {
+            sessionKey,
+            storeSessionKey: sessionKey,
+            entry: {
+              sessionId: "parent-1",
+              updatedAt: Date.now(),
+            },
+          };
+        }
+        return null;
+      });
+
+      const manager = new AcpSessionManager();
+      await manager.runTurn({
+        cfg: baseCfg,
+        sessionKey: "agent:codex:acp:child-1",
+        text: "Inspect and report back",
+        mode: "prompt",
+        requestId: "direct-parented-progress-then-final-run",
+      });
+
+      const record = requireTaskByRunId("direct-parented-progress-then-final-run");
+      expectRecordFields(record, {
+        runtime: "acp",
+        ownerKey: "agent:quant:telegram:quant:direct:822430204",
+        scopeKind: "session",
+        childSessionKey: "agent:codex:acp:child-1",
+        status: "succeeded",
+        progressSummary:
+          "I'll inspect the repo now. Fixed the crash and verified the regression tests pass.",
+      });
+      expect(record.terminalOutcome).toBeUndefined();
+      expect(record.terminalSummary).toBeUndefined();
+    });
+  });
+
   it("marks completed parented ACP turns blocked when they only contain progress text", async () => {
     await withAcpManagerTaskStateDir(async () => {
       const runtimeState = createRuntime();

--- a/src/agents/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagent-registry-lifecycle.test.ts
@@ -384,6 +384,35 @@ describe("subagent registry lifecycle hardening", () => {
     expect(finalArg.terminalOutcome).toBeUndefined();
   });
 
+  it("keeps required completions successful when final output follows progress text", async () => {
+    const entry = createRunEntry({
+      expectsCompletionMessage: true,
+    });
+
+    await createLifecycleController({
+      entry,
+      captureSubagentCompletionReply: vi.fn(
+        async () => "I'll inspect the repo now. Fixed the crash and verified the tests pass.",
+      ),
+    }).completeSubagentRun({
+      runId: entry.runId,
+      endedAt: 4_000,
+      outcome: { status: "ok" },
+      reason: SUBAGENT_ENDED_REASON_COMPLETE,
+      triggerCleanup: false,
+    });
+
+    const finalArg = firstCallArg(taskExecutorMocks.completeTaskRunByRunId);
+    expectFields(finalArg, {
+      runId: entry.runId,
+      runtime: "subagent",
+      sessionKey: entry.childSessionKey,
+      progressSummary: "I'll inspect the repo now. Fixed the crash and verified the tests pass.",
+      terminalSummary: null,
+    });
+    expect(finalArg.terminalOutcome).toBeUndefined();
+  });
+
   it("does not reject cleanup give-up when task delivery status update throws", async () => {
     const persist = vi.fn();
     const warn = vi.fn();

--- a/src/agents/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagent-registry-lifecycle.test.ts
@@ -305,6 +305,85 @@ describe("subagent registry lifecycle hardening", () => {
     });
   });
 
+  it("marks required progress-only completions blocked without failing the task", async () => {
+    const entry = createRunEntry({
+      expectsCompletionMessage: true,
+    });
+
+    const controller = createLifecycleController({
+      entry,
+      captureSubagentCompletionReply: vi.fn(async () => "I'll inspect the repo now."),
+    });
+
+    await controller.completeSubagentRun({
+      runId: entry.runId,
+      endedAt: 4_000,
+      outcome: { status: "ok" },
+      reason: SUBAGENT_ENDED_REASON_COMPLETE,
+      triggerCleanup: false,
+    });
+
+    expectFields(firstCallArg(taskExecutorMocks.completeTaskRunByRunId), {
+      runId: entry.runId,
+      runtime: "subagent",
+      sessionKey: entry.childSessionKey,
+      progressSummary: "I'll inspect the repo now.",
+      terminalOutcome: "blocked",
+      terminalSummary: "Required completion ended with progress-only text, not a final deliverable.",
+    });
+    expect(taskExecutorMocks.failTaskRunByRunId).not.toHaveBeenCalled();
+  });
+
+  it("marks missing required completions blocked while preserving real final reports", async () => {
+    const missingEntry = createRunEntry({
+      expectsCompletionMessage: true,
+    });
+    await createLifecycleController({
+      entry: missingEntry,
+      captureSubagentCompletionReply: vi.fn(async () => undefined),
+    }).completeSubagentRun({
+      runId: missingEntry.runId,
+      endedAt: 4_000,
+      outcome: { status: "ok" },
+      reason: SUBAGENT_ENDED_REASON_COMPLETE,
+      triggerCleanup: false,
+    });
+
+    expectFields(firstCallArg(taskExecutorMocks.completeTaskRunByRunId), {
+      runId: missingEntry.runId,
+      terminalOutcome: "blocked",
+      terminalSummary: "Required completion did not produce a final deliverable.",
+    });
+
+    taskExecutorMocks.completeTaskRunByRunId.mockClear();
+    const finalEntry = createRunEntry({
+      runId: "run-final",
+      expectsCompletionMessage: true,
+    });
+    await createLifecycleController({
+      entry: finalEntry,
+      captureSubagentCompletionReply: vi.fn(
+        async () => "Fixed the crash and verified the regression tests pass.",
+      ),
+    }).completeSubagentRun({
+      runId: finalEntry.runId,
+      endedAt: 5_000,
+      outcome: { status: "ok" },
+      reason: SUBAGENT_ENDED_REASON_COMPLETE,
+      triggerCleanup: false,
+    });
+
+    const finalArg = firstCallArg(taskExecutorMocks.completeTaskRunByRunId);
+    expectFields(finalArg, {
+      runId: finalEntry.runId,
+      runtime: "subagent",
+      sessionKey: finalEntry.childSessionKey,
+      progressSummary: "Fixed the crash and verified the regression tests pass.",
+      terminalSummary: null,
+    });
+    expect(finalArg.terminalOutcome).toBeUndefined();
+  });
+
   it("does not reject cleanup give-up when task delivery status update throws", async () => {
     const persist = vi.fn();
     const warn = vi.fn();
@@ -810,6 +889,15 @@ describe("subagent registry lifecycle hardening", () => {
       deliveryStatus: "failed",
       error: "gateway request timeout for agent",
     });
+    expectFields(firstCallArg(taskExecutorMocks.completeTaskRunByRunId), {
+      runId: entry.runId,
+      runtime: "subagent",
+      sessionKey: entry.childSessionKey,
+      progressSummary: "final answer",
+      terminalOutcome: "blocked",
+      terminalSummary:
+        "Required completion delivery failed before reaching the requester: gateway request timeout for agent.",
+    });
     expect(persist).toHaveBeenCalled();
   });
 
@@ -986,6 +1074,20 @@ describe("subagent registry lifecycle hardening", () => {
     expect(entry.deliverySuspendedAt).toBeTypeOf("number");
     expect(entry.deliverySuspendedReason).toBe("retry-limit");
     expect(entry.cleanupCompletedAt).toBeUndefined();
+    expectFields(
+      findCallArg(
+        taskExecutorMocks.completeTaskRunByRunId,
+        (arg) => arg.terminalOutcome === "blocked",
+      ),
+      {
+        runId: entry.runId,
+        runtime: "subagent",
+        sessionKey: entry.childSessionKey,
+        terminalOutcome: "blocked",
+        terminalSummary:
+          "Required completion delivery failed before reaching the requester: UNAVAILABLE: requester wake failed; direct-primary: UNAVAILABLE: requester wake failed.",
+      },
+    );
     expect(persist).toHaveBeenCalled();
   });
 

--- a/src/agents/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagent-registry-lifecycle.test.ts
@@ -445,6 +445,35 @@ describe("subagent registry lifecycle hardening", () => {
     expect(finalArg.terminalOutcome).toBeUndefined();
   });
 
+  it("keeps required completions blocked when progress text only adds follow-up planning", async () => {
+    const entry = createRunEntry({
+      expectsCompletionMessage: true,
+    });
+
+    await createLifecycleController({
+      entry,
+      captureSubagentCompletionReply: vi.fn(
+        async () => "I'll inspect the repo now. Then I'll run tests and report back.",
+      ),
+    }).completeSubagentRun({
+      runId: entry.runId,
+      endedAt: 4_000,
+      outcome: { status: "ok" },
+      reason: SUBAGENT_ENDED_REASON_COMPLETE,
+      triggerCleanup: false,
+    });
+
+    expectFields(firstCallArg(taskExecutorMocks.completeTaskRunByRunId), {
+      runId: entry.runId,
+      runtime: "subagent",
+      sessionKey: entry.childSessionKey,
+      progressSummary: "I'll inspect the repo now. Then I'll run tests and report back.",
+      terminalOutcome: "blocked",
+      terminalSummary:
+        "Required completion ended with progress-only text, not a final deliverable.",
+    });
+  });
+
   it("does not reject cleanup give-up when task delivery status update throws", async () => {
     const persist = vi.fn();
     const warn = vi.fn();

--- a/src/agents/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagent-registry-lifecycle.test.ts
@@ -329,7 +329,8 @@ describe("subagent registry lifecycle hardening", () => {
       sessionKey: entry.childSessionKey,
       progressSummary: "I'll inspect the repo now.",
       terminalOutcome: "blocked",
-      terminalSummary: "Required completion ended with progress-only text, not a final deliverable.",
+      terminalSummary:
+        "Required completion ended with progress-only text, not a final deliverable.",
     });
     expect(taskExecutorMocks.failTaskRunByRunId).not.toHaveBeenCalled();
   });
@@ -392,7 +393,7 @@ describe("subagent registry lifecycle hardening", () => {
     await createLifecycleController({
       entry,
       captureSubagentCompletionReply: vi.fn(
-        async () => "I'll inspect the repo now. Fixed the crash and verified the tests pass.",
+        async () => "I'll inspect the repo now. The crash is a missing null check in src/foo.ts.",
       ),
     }).completeSubagentRun({
       runId: entry.runId,
@@ -407,7 +408,8 @@ describe("subagent registry lifecycle hardening", () => {
       runId: entry.runId,
       runtime: "subagent",
       sessionKey: entry.childSessionKey,
-      progressSummary: "I'll inspect the repo now. Fixed the crash and verified the tests pass.",
+      progressSummary:
+        "I'll inspect the repo now. The crash is a missing null check in src/foo.ts.",
       terminalSummary: null,
     });
     expect(finalArg.terminalOutcome).toBeUndefined();

--- a/src/agents/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagent-registry-lifecycle.test.ts
@@ -415,6 +415,36 @@ describe("subagent registry lifecycle hardening", () => {
     expect(finalArg.terminalOutcome).toBeUndefined();
   });
 
+  it("keeps required completions successful when final output follows a separator", async () => {
+    const entry = createRunEntry({
+      expectsCompletionMessage: true,
+    });
+
+    await createLifecycleController({
+      entry,
+      captureSubagentCompletionReply: vi.fn(
+        async () => "I'll inspect the repo now - the crash is a missing null check in src/foo.ts.",
+      ),
+    }).completeSubagentRun({
+      runId: entry.runId,
+      endedAt: 4_000,
+      outcome: { status: "ok" },
+      reason: SUBAGENT_ENDED_REASON_COMPLETE,
+      triggerCleanup: false,
+    });
+
+    const finalArg = firstCallArg(taskExecutorMocks.completeTaskRunByRunId);
+    expectFields(finalArg, {
+      runId: entry.runId,
+      runtime: "subagent",
+      sessionKey: entry.childSessionKey,
+      progressSummary:
+        "I'll inspect the repo now - the crash is a missing null check in src/foo.ts.",
+      terminalSummary: null,
+    });
+    expect(finalArg.terminalOutcome).toBeUndefined();
+  });
+
   it("does not reject cleanup give-up when task delivery status update throws", async () => {
     const persist = vi.fn();
     const warn = vi.fn();

--- a/src/agents/subagent-registry-lifecycle.ts
+++ b/src/agents/subagent-registry-lifecycle.ts
@@ -11,6 +11,10 @@ import {
   failTaskRunByRunId,
   setDetachedTaskDeliveryStatusByRunId,
 } from "../tasks/detached-task-runtime.js";
+import {
+  resolveRequiredCompletionDeliveryFailureTerminalResult,
+  resolveRequiredCompletionTerminalResult,
+} from "../tasks/task-completion-contract.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.shared.js";
 import {
   buildAnnounceIdFromChildRun,
@@ -265,6 +269,10 @@ export function createSubagentRegistryLifecycleController(params: {
     const lastEventAt = endedAt;
     try {
       if (args.outcome.status === "ok") {
+        const terminalResult =
+          args.entry.expectsCompletionMessage === true
+            ? resolveRequiredCompletionTerminalResult(args.entry.frozenResultText)
+            : {};
         completeTaskRunByRunId({
           runId: args.entry.runId,
           runtime: "subagent",
@@ -272,7 +280,8 @@ export function createSubagentRegistryLifecycleController(params: {
           endedAt,
           lastEventAt,
           progressSummary: args.entry.frozenResultText ?? undefined,
-          terminalSummary: null,
+          terminalSummary: terminalResult.terminalSummary ?? null,
+          terminalOutcome: terminalResult.terminalOutcome,
         });
         return;
       }
@@ -293,6 +302,35 @@ export function createSubagentRegistryLifecycleController(params: {
         runId: maskRunId(args.entry.runId),
         childSessionKey: maskSessionKey(args.entry.childSessionKey),
         outcomeStatus: args.outcome.status,
+      });
+    }
+  };
+
+  const safeMarkRequiredCompletionDeliveryBlocked = (args: {
+    entry: SubagentRunRecord;
+    reason?: string;
+  }) => {
+    if (args.entry.expectsCompletionMessage !== true || args.entry.outcome?.status !== "ok") {
+      return;
+    }
+    const endedAt = args.entry.endedAt ?? Date.now();
+    const terminalResult = resolveRequiredCompletionDeliveryFailureTerminalResult(args.reason);
+    try {
+      completeTaskRunByRunId({
+        runId: args.entry.runId,
+        runtime: "subagent",
+        sessionKey: args.entry.childSessionKey,
+        endedAt,
+        lastEventAt: Date.now(),
+        progressSummary: args.entry.frozenResultText ?? undefined,
+        terminalSummary: terminalResult.terminalSummary,
+        terminalOutcome: terminalResult.terminalOutcome,
+      });
+    } catch (err) {
+      params.warn("failed to mark subagent completion delivery blocked", {
+        error: buildSafeLifecycleErrorMeta(err),
+        runId: maskRunId(args.entry.runId),
+        childSessionKey: maskSessionKey(args.entry.childSessionKey),
       });
     }
   };
@@ -483,6 +521,10 @@ export function createSubagentRegistryLifecycleController(params: {
       deliveryStatus: "failed",
       deliveryError: args.entry.lastAnnounceDeliveryError ?? args.reason,
     });
+    safeMarkRequiredCompletionDeliveryBlocked({
+      entry: args.entry,
+      reason: args.entry.lastAnnounceDeliveryError ?? args.reason,
+    });
     logAnnounceGiveUp(args.entry, args.reason);
     params.persist();
   };
@@ -513,6 +555,10 @@ export function createSubagentRegistryLifecycleController(params: {
       childSessionKey: giveUpParams.entry.childSessionKey,
       deliveryStatus: "failed",
       deliveryError: giveUpParams.entry.lastAnnounceDeliveryError,
+    });
+    safeMarkRequiredCompletionDeliveryBlocked({
+      entry: giveUpParams.entry,
+      reason: giveUpParams.entry.lastAnnounceDeliveryError ?? giveUpParams.reason,
     });
     giveUpParams.entry.wakeOnDescendantSettle = undefined;
     giveUpParams.entry.fallbackFrozenResultText = undefined;
@@ -756,6 +802,10 @@ export function createSubagentRegistryLifecycleController(params: {
         childSessionKey: entry.childSessionKey,
         deliveryStatus: "failed",
         deliveryError: entry.lastAnnounceDeliveryError,
+      });
+      safeMarkRequiredCompletionDeliveryBlocked({
+        entry,
+        reason: entry.lastAnnounceDeliveryError ?? deferredDecision.reason,
       });
       entry.wakeOnDescendantSettle = undefined;
       entry.fallbackFrozenResultText = undefined;

--- a/src/tasks/task-completion-contract.ts
+++ b/src/tasks/task-completion-contract.ts
@@ -9,7 +9,10 @@ const PROGRESS_ONLY_PATTERN =
   /^(?:i(?:'|\u2019)ll|i will|i(?:'|\u2019)m|i am|i(?:'|\u2019)m going to|i am going to|let me|i need to)\s+(?:now\s+)?(?:analyz(?:e|ing)|apply|check(?:ing)?|continue|debug(?:ging)?|follow(?:ing)?\s+up|inspect(?:ing)?|investigat(?:e|ing)|look(?:ing)?(?:\s+into)?|map(?:ping)?|open(?:ing)?|read(?:ing)?|report(?:ing)?(?:\s+back)?|review(?:ing)?|run(?:ning)?|start(?:ing)?|test(?:ing)?|trace|trac(?:e|ing)|try(?:ing)?|update|verify(?:ing)?|work(?:ing)?)/i;
 
 const BARE_PROGRESS_ONLY_PATTERN =
-  /^(?:analyz(?:e|ing)|checking|debugging|inspecting|investigating|looking\s+into|mapping|reading|reviewing|running|testing|tracing|verifying|working\s+on)\b/i;
+  /^(?:analyz(?:e|ing)|check(?:ing)?|debug(?:ging)?|inspect(?:ing)?|investigat(?:e|ing)|look(?:ing)?\s+into|map(?:ping)?|read(?:ing)?|report(?:ing)?\s+back|review(?:ing)?|run(?:ning)?|test(?:ing)?|trac(?:e|ing)|verify(?:ing)?|work(?:ing)?\s+on)\b/i;
+
+const FOLLOW_UP_PLANNING_PREFIX_PATTERN =
+  /^(?:after(?:wards|\s+that)?|from\s+there|next|once\s+(?:done|that(?:'|\u2019)?s\s+done|that\s+is\s+done)|then)[,.\s]+/i;
 
 function normalizeCompletionText(value: string | null | undefined): string {
   return value?.replace(/\s+/g, " ").trim() ?? "";
@@ -24,7 +27,14 @@ function normalizeCompletionFailureReason(value: string | null | undefined): str
 }
 
 function matchesProgressOnlyPrefix(value: string): boolean {
-  return PROGRESS_ONLY_PATTERN.test(value) || BARE_PROGRESS_ONLY_PATTERN.test(value);
+  if (PROGRESS_ONLY_PATTERN.test(value) || BARE_PROGRESS_ONLY_PATTERN.test(value)) {
+    return true;
+  }
+  const followup = value.replace(FOLLOW_UP_PLANNING_PREFIX_PATTERN, "").trim();
+  return (
+    followup !== value &&
+    (PROGRESS_ONLY_PATTERN.test(followup) || BARE_PROGRESS_ONLY_PATTERN.test(followup))
+  );
 }
 
 function hasNonProgressFollowupSentence(value: string): boolean {

--- a/src/tasks/task-completion-contract.ts
+++ b/src/tasks/task-completion-contract.ts
@@ -31,11 +31,11 @@ export function isProgressOnlyCompletionText(value: string | null | undefined): 
   if (!normalized) {
     return false;
   }
-  if (PROGRESS_ONLY_PATTERN.test(normalized)) {
-    return true;
-  }
   if (FINAL_DELIVERABLE_INDICATOR_PATTERN.test(normalized)) {
     return false;
+  }
+  if (PROGRESS_ONLY_PATTERN.test(normalized)) {
+    return true;
   }
   return BARE_PROGRESS_ONLY_PATTERN.test(normalized);
 }

--- a/src/tasks/task-completion-contract.ts
+++ b/src/tasks/task-completion-contract.ts
@@ -5,11 +5,8 @@ export type RequiredCompletionTerminalResult = {
   terminalSummary?: string;
 };
 
-const FINAL_DELIVERABLE_INDICATOR_PATTERN =
-  /\b(?:added|already|changed|completed|created|diagnosis|done|failed|finished|fixed|found|implemented|merged|no changes|nothing to change|opened|passed|ready|report|result|results|summary|tested|updated|validated|verified|wrote)\b/i;
-
 const PROGRESS_ONLY_PATTERN =
-  /^(?:i(?:'|’)ll|i will|i(?:'|’)m|i am|i(?:'|’)m going to|i am going to|let me|i need to)\s+(?:now\s+)?(?:analyz(?:e|ing)|apply|check(?:ing)?|continue|debug(?:ging)?|inspect(?:ing)?|investigat(?:e|ing)|look(?:ing)?(?:\s+into)?|map(?:ping)?|open(?:ing)?|read(?:ing)?|review(?:ing)?|run(?:ning)?|start(?:ing)?|test(?:ing)?|trace|trac(?:e|ing)|try(?:ing)?|update|verify(?:ing)?|work(?:ing)?)/i;
+  /^(?:i(?:'|\u2019)ll|i will|i(?:'|\u2019)m|i am|i(?:'|\u2019)m going to|i am going to|let me|i need to)\s+(?:now\s+)?(?:analyz(?:e|ing)|apply|check(?:ing)?|continue|debug(?:ging)?|follow(?:ing)?\s+up|inspect(?:ing)?|investigat(?:e|ing)|look(?:ing)?(?:\s+into)?|map(?:ping)?|open(?:ing)?|read(?:ing)?|report(?:ing)?(?:\s+back)?|review(?:ing)?|run(?:ning)?|start(?:ing)?|test(?:ing)?|trace|trac(?:e|ing)|try(?:ing)?|update|verify(?:ing)?|work(?:ing)?)/i;
 
 const BARE_PROGRESS_ONLY_PATTERN =
   /^(?:analyz(?:e|ing)|checking|debugging|inspecting|investigating|looking\s+into|mapping|reading|reviewing|running|testing|tracing|verifying|working\s+on)\b/i;
@@ -26,18 +23,29 @@ function normalizeCompletionFailureReason(value: string | null | undefined): str
   return normalized.length <= 160 ? normalized : `${normalized.slice(0, 159)}...`;
 }
 
+function matchesProgressOnlyPrefix(value: string): boolean {
+  return PROGRESS_ONLY_PATTERN.test(value) || BARE_PROGRESS_ONLY_PATTERN.test(value);
+}
+
+function hasNonProgressFollowupSentence(value: string): boolean {
+  const boundary = /[.!?]\s+\S/.exec(value);
+  if (!boundary) {
+    return false;
+  }
+  const firstSentence = value.slice(0, boundary.index + 1).trim();
+  const rest = value.slice(boundary.index + 1).trim();
+  return matchesProgressOnlyPrefix(firstSentence) && !isProgressOnlyCompletionText(rest);
+}
+
 export function isProgressOnlyCompletionText(value: string | null | undefined): boolean {
   const normalized = normalizeCompletionText(value);
   if (!normalized) {
     return false;
   }
-  if (FINAL_DELIVERABLE_INDICATOR_PATTERN.test(normalized)) {
+  if (hasNonProgressFollowupSentence(normalized)) {
     return false;
   }
-  if (PROGRESS_ONLY_PATTERN.test(normalized)) {
-    return true;
-  }
-  return BARE_PROGRESS_ONLY_PATTERN.test(normalized);
+  return matchesProgressOnlyPrefix(normalized);
 }
 
 export function resolveRequiredCompletionTerminalResult(
@@ -53,7 +61,8 @@ export function resolveRequiredCompletionTerminalResult(
   if (isProgressOnlyCompletionText(normalized)) {
     return {
       terminalOutcome: "blocked",
-      terminalSummary: "Required completion ended with progress-only text, not a final deliverable.",
+      terminalSummary:
+        "Required completion ended with progress-only text, not a final deliverable.",
     };
   }
   return {};

--- a/src/tasks/task-completion-contract.ts
+++ b/src/tasks/task-completion-contract.ts
@@ -1,0 +1,72 @@
+import type { TaskTerminalOutcome } from "./task-registry.types.js";
+
+export type RequiredCompletionTerminalResult = {
+  terminalOutcome?: Extract<TaskTerminalOutcome, "blocked">;
+  terminalSummary?: string;
+};
+
+const FINAL_DELIVERABLE_INDICATOR_PATTERN =
+  /\b(?:added|already|changed|completed|created|diagnosis|done|failed|finished|fixed|found|implemented|merged|no changes|nothing to change|opened|passed|ready|report|result|results|summary|tested|updated|validated|verified|wrote)\b/i;
+
+const PROGRESS_ONLY_PATTERN =
+  /^(?:i(?:'|’)ll|i will|i(?:'|’)m|i am|i(?:'|’)m going to|i am going to|let me|i need to)\s+(?:now\s+)?(?:analyz(?:e|ing)|apply|check(?:ing)?|continue|debug(?:ging)?|inspect(?:ing)?|investigat(?:e|ing)|look(?:ing)?(?:\s+into)?|map(?:ping)?|open(?:ing)?|read(?:ing)?|review(?:ing)?|run(?:ning)?|start(?:ing)?|test(?:ing)?|trace|trac(?:e|ing)|try(?:ing)?|update|verify(?:ing)?|work(?:ing)?)/i;
+
+const BARE_PROGRESS_ONLY_PATTERN =
+  /^(?:analyz(?:e|ing)|checking|debugging|inspecting|investigating|looking\s+into|mapping|reading|reviewing|running|testing|tracing|verifying|working\s+on)\b/i;
+
+function normalizeCompletionText(value: string | null | undefined): string {
+  return value?.replace(/\s+/g, " ").trim() ?? "";
+}
+
+function normalizeCompletionFailureReason(value: string | null | undefined): string {
+  const normalized = normalizeCompletionText(value);
+  if (!normalized) {
+    return "";
+  }
+  return normalized.length <= 160 ? normalized : `${normalized.slice(0, 159)}...`;
+}
+
+export function isProgressOnlyCompletionText(value: string | null | undefined): boolean {
+  const normalized = normalizeCompletionText(value);
+  if (!normalized) {
+    return false;
+  }
+  if (PROGRESS_ONLY_PATTERN.test(normalized)) {
+    return true;
+  }
+  if (FINAL_DELIVERABLE_INDICATOR_PATTERN.test(normalized)) {
+    return false;
+  }
+  return BARE_PROGRESS_ONLY_PATTERN.test(normalized);
+}
+
+export function resolveRequiredCompletionTerminalResult(
+  resultText: string | null | undefined,
+): RequiredCompletionTerminalResult {
+  const normalized = normalizeCompletionText(resultText);
+  if (!normalized) {
+    return {
+      terminalOutcome: "blocked",
+      terminalSummary: "Required completion did not produce a final deliverable.",
+    };
+  }
+  if (isProgressOnlyCompletionText(normalized)) {
+    return {
+      terminalOutcome: "blocked",
+      terminalSummary: "Required completion ended with progress-only text, not a final deliverable.",
+    };
+  }
+  return {};
+}
+
+export function resolveRequiredCompletionDeliveryFailureTerminalResult(
+  reason: string | null | undefined,
+): RequiredCompletionTerminalResult {
+  const normalizedReason = normalizeCompletionFailureReason(reason);
+  return {
+    terminalOutcome: "blocked",
+    terminalSummary: normalizedReason
+      ? `Required completion delivery failed before reaching the requester: ${normalizedReason}.`
+      : "Required completion delivery failed before reaching the requester.",
+  };
+}

--- a/src/tasks/task-completion-contract.ts
+++ b/src/tasks/task-completion-contract.ts
@@ -28,12 +28,13 @@ function matchesProgressOnlyPrefix(value: string): boolean {
 }
 
 function hasNonProgressFollowupSentence(value: string): boolean {
-  const boundary = /[.!?]\s+\S/.exec(value);
+  const boundary = /(?:[.!?:]|\s[-\u2013\u2014])\s+\S/.exec(value);
   if (!boundary) {
     return false;
   }
-  const firstSentence = value.slice(0, boundary.index + 1).trim();
-  const rest = value.slice(boundary.index + 1).trim();
+  const separatorEnd = boundary.index + boundary[0].length - 1;
+  const firstSentence = value.slice(0, separatorEnd).trim();
+  const rest = value.slice(separatorEnd).trim();
   return matchesProgressOnlyPrefix(firstSentence) && !isProgressOnlyCompletionText(rest);
 }
 


### PR DESCRIPTION
﻿﻿## Summary

- Problem: ACP/Codex and subagent child tasks could be recorded as normal success when the captured completion was only progress text, missing, or never delivered back to the requester.
- Solution: add a narrow required-completion contract that maps missing/progress-only required output and exhausted required delivery to the existing blocked terminal outcome.
- What changed: ACP background task finalization and subagent lifecycle finalization now use the same completion contract; focused regressions cover progress-only, missing output, delivery failure, and real final report preservation.
- What did NOT change (scope boundary): no channel transport rewrite, no provider behavior change, no task status enum change, no new dependency, no external service or credential handling change.

## Motivation

#83863 is a message-loss/session-state bug: a child task can appear successful even though the user never got a real final deliverable. That makes follow-up decisions unsafe because the durable task record says "ok" while the useful completion either never existed or never reached the requester.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #83863
- Related #80879
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Required ACP/Codex and subagent child tasks could end as normal success when the captured completion was only progress text, missing, or when required completion delivery was exhausted.
- Real environment tested: Fresh Linux OpenClaw checkout at pushed PR head `2ea6fec43c42f1bd6f6d778174dfbbfdb80d5bdb`, Node v22.22.2, temporary OpenClaw state only, no persistent services, no external provider credentials, and no secrets printed.
- Exact steps or command run after this patch: Ran a diagnostic runtime script through the real OpenClaw ACP Manager, Task Registry, and Subagent Lifecycle source paths with `node_modules/.bin/tsx proof-round2.mjs`. Also ran focused ACP/subagent, task-registry, format, lint, and typecheck validation on the same pushed head.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Copied live output from the current-head diagnostic run:

  ```text
  proof_timestamp=2026-05-22T02:11:14.000Z
  acp_progress_only: {"status":"succeeded","terminalOutcome":"blocked","progressSummary":"I'll inspect the repo now.","terminalSummary":"Required completion ended with progress-only text, not a final deliverable.","deliveryStatus":"session_queued"}
  acp_progress_prefixed_diagnosis: {"status":"succeeded","progressSummary":"I'll inspect the repo now. The crash is a missing null check in src/foo.ts.","deliveryStatus":"session_queued"}
  acp_separator_diagnosis: {"status":"succeeded","progressSummary":"I'll inspect the repo now: the crash is a missing null check in src/foo.ts.","deliveryStatus":"session_queued"}
  acp_followup_planning: {"status":"succeeded","terminalOutcome":"blocked","progressSummary":"I'll inspect the repo now. Then I'll run tests and report back.","terminalSummary":"Required completion ended with progress-only text, not a final deliverable.","deliveryStatus":"session_queued"}
  subagent_progress_only: {"status":"succeeded","terminalOutcome":"blocked","progressSummary":"I'll inspect the repo now.","terminalSummary":"Required completion ended with progress-only text, not a final deliverable.","deliveryStatus":"pending"}
  subagent_progress_prefixed_diagnosis: {"status":"succeeded","progressSummary":"I'll inspect the repo now. The crash is a missing null check in src/foo.ts.","deliveryStatus":"pending"}
  subagent_separator_diagnosis: {"status":"succeeded","progressSummary":"I'll inspect the repo now - the crash is a missing null check in src/foo.ts.","deliveryStatus":"pending"}
  subagent_followup_planning: {"status":"succeeded","terminalOutcome":"blocked","progressSummary":"I'll inspect the repo now. Then I'll run tests and report back.","terminalSummary":"Required completion ended with progress-only text, not a final deliverable.","deliveryStatus":"pending"}
  subagent_delivery_failed: {"status":"succeeded","terminalOutcome":"blocked","progressSummary":"The crash is a missing null check in src/foo.ts.","terminalSummary":"Required completion delivery failed before reaching the requester: proof requester unreachable.","deliveryStatus":"failed","error":"proof requester unreachable"}
  ```
- Observed result after fix: Progress-only ACP and subagent completions remain visible as completed task records but carry `terminalOutcome=blocked`; progress-prefixed and separator-delimited final diagnoses stay successful while follow-up planning stays blocked; exhausted required subagent delivery records `terminalOutcome=blocked` and `deliveryStatus=failed` in the current-head diagnostic proof.
- What was not tested: No real Telegram, Discord, WhatsApp, or other external transport account was used for a user-visible recording. The current-head evidence uses the real OpenClaw source runtime path without external provider secrets.
- Before evidence (optional but encouraged): #83863 provides the source-repro issue context for current-main false success; this PR body includes after-fix real runtime output from the pushed PR head.
## Root Cause (if applicable)

- Root cause: ACP background task completion and subagent task finalization treated terminal child completion as success even when the required final deliverable contract was not satisfied.
- Missing detection / guardrail: There was no shared required-completion check for missing output, progress-only output, or exhausted required completion delivery.
- Contributing context (if known): Delivery failure state already existed (`deliveryStatus=failed`), but it did not update the terminal outcome, so the durable task still looked successful.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/acp/control-plane/manager.test.ts`
  - `src/agents/subagent-registry-lifecycle.test.ts`
  - `src/agents/subagent-announce.capture-completion-reply.test.ts`
  - `src/tasks/task-registry.test.ts`
  - `src/tasks/task-flow-registry.test.ts`
  - `src/tasks/task-executor-policy.test.ts`
  - `src/tasks/task-executor.test.ts`
- Scenario the test should lock in: required progress-only or missing completions become `terminalOutcome=blocked`; progress-prefixed and separator-delimited final diagnoses stay successful while follow-up planning stays blocked; required delivery give-up becomes blocked and failed-delivery.
- Why this is the smallest reliable guardrail: the bug sits at ACP/subagent task finalization and task-registry delivery state, so these tests cover the contract without needing external provider credentials.
- Existing test that already covers this (if any): existing task policy tests covered blocked-task formatting; this PR adds the missing ACP/subagent finalization cases.
- If no new test is added, why not: New tests are added.

## User-visible / Behavior Changes

Users and maintainers should no longer see a required child task as a plain success when the child only produced interim progress text or when final completion delivery was exhausted. The task remains completed but is marked blocked with a terminal summary that explains what follow-up is needed.

## Diagram (if applicable)

```text
Before:
[child task ends] -> [progress-only or missing completion] -> [task status: succeeded]
[delivery retry exhausted] -> [deliveryStatus: failed] -> [task terminal outcome still success]

After:
[child task ends] -> [required completion contract] -> [real final report: succeeded]
[child task ends] -> [missing/progress-only completion] -> [terminalOutcome: blocked]
[delivery retry exhausted] -> [deliveryStatus: failed] -> [terminalOutcome: blocked]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux testserver
- Runtime/container: Node v22.22.2, fresh OpenClaw checkout at pushed PR head `2ea6fec43c42f1bd6f6d778174dfbbfdb80d5bdb`
- Model/provider: Diagnostic proof uses runtime adapters without external provider secrets
- Integration/channel (if any): ACP Manager, Task Registry, Subagent Lifecycle
- Relevant config (redacted): temporary OpenClaw state only; no secrets printed

### Steps

1. Check out pushed PR head `2ea6fec43c42f1bd6f6d778174dfbbfdb80d5bdb`.
2. Run the current-head diagnostic proof with `node_modules/.bin/tsx proof-round2.mjs`.
3. Run the focused ACP/subagent and task-registry suites requested by ClawSweeper.
4. Run `git diff --check`.
5. Run touched-file `oxfmt --check` and targeted `oxlint`.
6. Run core and core-test typechecks.

### Expected

- Progress-only required completions are blocked.
- Missing required completions are blocked.
- Progress-prefixed and separator-delimited final diagnoses stay successful without depending on allow-list words, while follow-up planning remains blocked.
- Exhausted required completion delivery is blocked and keeps `deliveryStatus=failed`.
- Focused tests, format/lint checks, and typechecks pass.

### Actual

- Diagnostic proof showed ACP progress-only and subagent progress-only as `terminalOutcome=blocked`.
- Diagnostic proof showed ACP/subagent progress-prefixed diagnosis text and colon/dash separator-delimited diagnosis text as normal success, while ACP/subagent follow-up planning text remained `terminalOutcome=blocked`.
- Diagnostic proof showed exhausted required subagent delivery as `terminalOutcome=blocked` with `deliveryStatus=failed`.
- Focused tests, diff-check, format/lint checks, and typechecks passed on pushed PR head `2ea6fec43c42f1bd6f6d778174dfbbfdb80d5bdb`.
## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation output from pushed PR head `2ea6fec43c42f1bd6f6d778174dfbbfdb80d5bdb`:

```text
git diff --check
passed

node_modules/.bin/oxfmt --check --threads=1 src/tasks/task-completion-contract.ts src/acp/control-plane/manager.test.ts src/agents/subagent-registry-lifecycle.test.ts
passed

node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/tasks/task-completion-contract.ts src/acp/control-plane/manager.test.ts src/agents/subagent-registry-lifecycle.test.ts
0 warnings / 0 errors
```

```text
node scripts/run-vitest.mjs src/acp/control-plane/manager.test.ts src/agents/subagent-registry-lifecycle.test.ts
3 files / 141 tests passed
```

```text
node scripts/run-vitest.mjs src/tasks/task-registry.test.ts src/tasks/task-flow-registry.test.ts src/tasks/task-executor-policy.test.ts src/tasks/task-executor.test.ts
4 files / 100 tests passed
```

```text
node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
passed

node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo
passed
```

Runtime proof:

```text
proof_timestamp=2026-05-22T02:11:14.000Z
acp_progress_only: {"status":"succeeded","terminalOutcome":"blocked","progressSummary":"I'll inspect the repo now.","terminalSummary":"Required completion ended with progress-only text, not a final deliverable.","deliveryStatus":"session_queued"}
acp_progress_prefixed_diagnosis: {"status":"succeeded","progressSummary":"I'll inspect the repo now. The crash is a missing null check in src/foo.ts.","deliveryStatus":"session_queued"}
  acp_separator_diagnosis: {"status":"succeeded","progressSummary":"I'll inspect the repo now: the crash is a missing null check in src/foo.ts.","deliveryStatus":"session_queued"}
  acp_followup_planning: {"status":"succeeded","terminalOutcome":"blocked","progressSummary":"I'll inspect the repo now. Then I'll run tests and report back.","terminalSummary":"Required completion ended with progress-only text, not a final deliverable.","deliveryStatus":"session_queued"}
subagent_progress_only: {"status":"succeeded","terminalOutcome":"blocked","progressSummary":"I'll inspect the repo now.","terminalSummary":"Required completion ended with progress-only text, not a final deliverable.","deliveryStatus":"pending"}
subagent_progress_prefixed_diagnosis: {"status":"succeeded","progressSummary":"I'll inspect the repo now. The crash is a missing null check in src/foo.ts.","deliveryStatus":"pending"}
  subagent_separator_diagnosis: {"status":"succeeded","progressSummary":"I'll inspect the repo now - the crash is a missing null check in src/foo.ts.","deliveryStatus":"pending"}
  subagent_followup_planning: {"status":"succeeded","terminalOutcome":"blocked","progressSummary":"I'll inspect the repo now. Then I'll run tests and report back.","terminalSummary":"Required completion ended with progress-only text, not a final deliverable.","deliveryStatus":"pending"}
  subagent_delivery_failed: {"status":"succeeded","terminalOutcome":"blocked","progressSummary":"The crash is a missing null check in src/foo.ts.","terminalSummary":"Required completion delivery failed before reaching the requester: proof requester unreachable.","deliveryStatus":"failed","error":"proof requester unreachable"}
```
## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ACP progress-only blocked; subagent progress-only blocked; ACP progress-prefixed diagnosis success; ACP separator-delimited diagnosis success; ACP follow-up planning blocked; subagent progress-prefixed diagnosis success; subagent separator-delimited diagnosis success; subagent follow-up planning blocked; subagent delivery failure blocked with failed-delivery state; focused test suites and typechecks on the exact pushed PR head.
- Edge cases checked: classifier no longer depends on allow-list words such as `fixed`, `verified`, or `result`; colon/dash final separators are accepted; `Then I'll run tests and report back` follow-up planning still stays blocked; missing required output remains blocked through the existing tests.
- What you did **not** verify: real user-visible transport delivery in Telegram/Discord/WhatsApp/other channels.
## Review Conversations

- [x] I reviewed the latest ClawSweeper feedback.
- [x] I addressed the current P1 finding in this PR update.

Current addressed findings: `[P1] Accept final answers without allow-list words`; `[P1] Accept separator-delimited final answers`; `[P1] Keep follow-up planning blocked`.
## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: overly broad progress-only detection could block a real final report.
  - Mitigation: the classifier is intentionally narrow, only applies in required completion contexts, and tests preserve progress-prefixed final diagnoses without allow-list words as success.
- Risk: delivery retry exhaustion now changes terminal outcome for required completions.
  - Mitigation: this uses the existing `blocked` terminal outcome and preserves `deliveryStatus=failed`, giving maintainers and users a clearer durable record without adding a new task status.







