### PR TITLE
fix(webchat): persist message tool source replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - WhatsApp: update Baileys to `7.0.0-rc13` and drop the obsolete logger type patch.
+- WebChat: keep internal message-tool replies visible after history reload while keeping the internal-ui tool result compact. (#84268, #84773) Thanks @100yenadmin and @jason-allen-oneal.
 - Infra/json: retry transient `File changed during read` races while loading JSON state so config and state reads recover instead of failing the turn. (#84285)
 - Providers/Ollama: resolve configured Ollama Cloud `OLLAMA_API_KEY` markers to the real discovery key so cloud provider entries keep authenticated model catalog access. (#85037)
 - Discord: keep persistent component registry fallback warnings actionable by forwarding structured error and cause metadata through the runtime logger. Fixes #84185. (#84190) Thanks @100menotu001.

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
@@ -20,7 +20,10 @@ import {
   normalizeOptionalLowercaseString,
 } from "../../../shared/string-coerce.js";
 import type { EmbeddedContextFile } from "../../pi-embedded-helpers.js";
-import type { MessagingToolSend } from "../../pi-embedded-messaging.types.js";
+import type {
+  MessagingToolSend,
+  MessagingToolSourceReplyPayload,
+} from "../../pi-embedded-messaging.types.js";
 import type { WorkspaceBootstrapFile } from "../../workspace.js";
 
 type SubscribeEmbeddedPiSessionFn =
@@ -103,6 +106,7 @@ export function createSubscriptionMock(): SubscriptionMock {
     getMessagingToolSentTexts: () => [] as string[],
     getMessagingToolSentMediaUrls: () => [] as string[],
     getMessagingToolSentTargets: () => [] as MessagingToolSend[],
+    getMessagingToolSourceReplyPayloads: () => [] as MessagingToolSourceReplyPayload[],
     getHeartbeatToolResponse: () => undefined,
     getPendingToolMediaReply: () => null,
     getVisibleBlockReplyCount: () => 0,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -3189,9 +3189,8 @@ export async function runEmbeddedAttempt(
         prompt: string,
         options?: Parameters<typeof activeSession.prompt>[1],
       ): Promise<void> =>
-        withOwnedSessionTranscriptWrites(
-          ownedTranscriptWriteContext,
-          async () => abortable(trackPromptSettlePromise(activeSession.prompt(prompt, options))),
+        withOwnedSessionTranscriptWrites(ownedTranscriptWriteContext, async () =>
+          abortable(trackPromptSettlePromise(activeSession.prompt(prompt, options))),
         );
       const onBlockReply = params.onBlockReply
         ? bindOwnedSessionTranscriptWrites(ownedTranscriptWriteContext, params.onBlockReply)
@@ -3251,6 +3250,7 @@ export async function runEmbeddedAttempt(
         getMessagingToolSentTexts,
         getMessagingToolSentMediaUrls,
         getMessagingToolSentTargets,
+        getMessagingToolSourceReplyPayloads,
         getHeartbeatToolResponse,
         getPendingToolMediaReply,
         getVisibleBlockReplyCount,
@@ -4820,6 +4820,7 @@ export async function runEmbeddedAttempt(
         messagingToolSentTexts: getMessagingToolSentTexts(),
         messagingToolSentMediaUrls: getMessagingToolSentMediaUrls(),
         messagingToolSentTargets: getMessagingToolSentTargets(),
+        messagingToolSourceReplyPayloads: getMessagingToolSourceReplyPayloads(),
         heartbeatToolResponse,
         toolMediaUrls: pendingToolMediaReply?.mediaUrls,
         toolAudioAsVoice: pendingToolMediaReply?.audioAsVoice,

--- a/src/agents/pi-embedded-subscribe.handlers.tools.media.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.media.test.ts
@@ -37,6 +37,7 @@ function createMockContext(overrides?: {
       messagingToolSentTextsNormalized: [],
       messagingToolSentMediaUrls: [],
       messagingToolSentTargets: [],
+      messagingToolSourceReplyPayloads: [],
       deterministicApprovalPromptPending: false,
       deterministicApprovalPromptSent: false,
     },

--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -1332,6 +1332,61 @@ describe("messaging tool media URL tracking", () => {
     ]);
   });
 
+  it("sanitizes internal UI source reply mirrors like live message sends", async () => {
+    const { ctx } = createTestContext();
+    ctx.params.sourceReplyDeliveryMode = "message_tool_only";
+
+    await handleToolExecutionStart(ctx, {
+      type: "tool_execution_start",
+      toolName: "message",
+      toolCallId: "tool-sanitized-source-reply",
+      args: {
+        action: "send",
+        message: "<think>hidden chain</think>visible reply",
+        presentation: {
+          title: "<think>hidden title</think>Visible title",
+          blocks: [
+            { type: "text", text: "<think>hidden block</think>Visible block" },
+            {
+              type: "buttons",
+              buttons: [{ label: "<think>hidden label</think>Visible label", value: "ok" }],
+            },
+          ],
+        },
+      },
+    });
+
+    await handleToolExecutionEnd(ctx, {
+      type: "tool_execution_end",
+      toolName: "message",
+      toolCallId: "tool-sanitized-source-reply",
+      isError: false,
+      result: {
+        details: {
+          deliveryStatus: "sent",
+          sourceReplySink: "internal-ui",
+        },
+      },
+    });
+
+    expect(ctx.state.messagingToolSourceReplyPayloads).toEqual([
+      {
+        text: "visible reply",
+        presentation: {
+          title: "Visible title",
+          blocks: [
+            { type: "text", text: "Visible block" },
+            {
+              type: "buttons",
+              buttons: [{ label: "Visible label", value: "ok" }],
+            },
+          ],
+        },
+      },
+    ]);
+    expect(JSON.stringify(ctx.state.messagingToolSourceReplyPayloads)).not.toContain("hidden");
+  });
+
   it("does not record routed or dry-run source replies for transcript mirroring", async () => {
     const { ctx } = createTestContext();
     ctx.params.sourceReplyDeliveryMode = "message_tool_only";

--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -1282,6 +1282,9 @@ describe("messaging tool media URL tracking", () => {
         details: {
           deliveryStatus: "sent",
           sourceReplySink: "internal-ui",
+          sourceReplyMediaUrl: "/workspace/reply.png",
+          sourceReplyMediaUrls: ["/workspace/reply.png"],
+          sourceReplyAudioAsVoice: true,
         },
       },
     });
@@ -1325,8 +1328,8 @@ describe("messaging tool media URL tracking", () => {
     expect(ctx.state.messagingToolSourceReplyPayloads).toEqual([
       {
         text: "hello",
-        mediaUrl: "/tmp/reply.png",
-        mediaUrls: ["/tmp/reply.png"],
+        mediaUrl: "/workspace/reply.png",
+        mediaUrls: ["/workspace/reply.png"],
         audioAsVoice: true,
       },
     ]);

--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -1391,6 +1391,59 @@ describe("messaging tool media URL tracking", () => {
     expect(JSON.stringify(ctx.state.messagingToolSourceReplyPayloads)).not.toContain("hidden");
   });
 
+  it("synthesizes durable text for structured-only internal UI source reply mirrors", async () => {
+    const { ctx } = createTestContext();
+    ctx.params.sourceReplyDeliveryMode = "message_tool_only";
+
+    await handleToolExecutionStart(ctx, {
+      type: "tool_execution_start",
+      toolName: "message",
+      toolCallId: "tool-structured-source-reply",
+      args: {
+        action: "send",
+        presentation: {
+          title: "Deploy ready",
+          blocks: [
+            { type: "text", text: "Pick a lane" },
+            {
+              type: "buttons",
+              buttons: [{ label: "Approve", value: "approve" }],
+            },
+          ],
+        },
+      },
+    });
+
+    await handleToolExecutionEnd(ctx, {
+      type: "tool_execution_end",
+      toolName: "message",
+      toolCallId: "tool-structured-source-reply",
+      isError: false,
+      result: {
+        details: {
+          deliveryStatus: "sent",
+          sourceReplySink: "internal-ui",
+        },
+      },
+    });
+
+    expect(ctx.state.messagingToolSourceReplyPayloads).toEqual([
+      {
+        text: "Deploy ready\nPick a lane\nApprove",
+        presentation: {
+          title: "Deploy ready",
+          blocks: [
+            { type: "text", text: "Pick a lane" },
+            {
+              type: "buttons",
+              buttons: [{ label: "Approve", value: "approve" }],
+            },
+          ],
+        },
+      },
+    ]);
+  });
+
   it("does not record routed or dry-run source replies for transcript mirroring", async () => {
     const { ctx } = createTestContext();
     ctx.params.sourceReplyDeliveryMode = "message_tool_only";

--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -1258,6 +1258,43 @@ describe("messaging tool media URL tracking", () => {
     ]);
   });
 
+  it("uses caption text for media-only internal UI source reply mirrors", async () => {
+    const { ctx } = createTestContext();
+    ctx.params.sourceReplyDeliveryMode = "message_tool_only";
+
+    await handleToolExecutionStart(ctx, {
+      type: "tool_execution_start",
+      toolName: "message",
+      toolCallId: "tool-caption-source-reply",
+      args: {
+        action: "send",
+        mediaUrl: "file:///reply.png",
+        caption: "caption from webchat",
+      },
+    });
+
+    await handleToolExecutionEnd(ctx, {
+      type: "tool_execution_end",
+      toolName: "message",
+      toolCallId: "tool-caption-source-reply",
+      isError: false,
+      result: {
+        details: {
+          deliveryStatus: "sent",
+          sourceReplySink: "internal-ui",
+        },
+      },
+    });
+
+    expect(ctx.state.messagingToolSourceReplyPayloads).toEqual([
+      {
+        text: "caption from webchat",
+        mediaUrl: "file:///reply.png",
+        mediaUrls: ["file:///reply.png"],
+      },
+    ]);
+  });
+
   it("does not record routed or dry-run source replies for transcript mirroring", async () => {
     const { ctx } = createTestContext();
     ctx.params.sourceReplyDeliveryMode = "message_tool_only";

--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -63,6 +63,7 @@ function createTestContext(): {
       messagingToolSentTextsNormalized: [],
       messagingToolSentMediaUrls: [],
       messagingToolSentTargets: [],
+      messagingToolSourceReplyPayloads: [],
       successfulCronAdds: 0,
       deterministicApprovalPromptSent: false,
       toolExecutionSinceLastBlockReply: false,
@@ -1214,6 +1215,93 @@ describe("messaging tool media URL tracking", () => {
       mediaUrls: ["file:///img.jpg"],
     });
     expect(ctx.state.pendingMessagingMediaUrls.has("tool-m2")).toBe(false);
+  });
+
+  it("records internal UI message-tool source replies for transcript mirroring", async () => {
+    const { ctx } = createTestContext();
+    ctx.params.sourceReplyDeliveryMode = "message_tool_only";
+
+    const startEvt: ToolExecutionStartEvent = {
+      type: "tool_execution_start",
+      toolName: "message",
+      toolCallId: "tool-source-reply",
+      args: {
+        action: "send",
+        message: "hello from webchat",
+        mediaUrl: "file:///reply.png",
+        idempotencyKey: "reply-key",
+      },
+    };
+    await handleToolExecutionStart(ctx, startEvt);
+
+    await handleToolExecutionEnd(ctx, {
+      type: "tool_execution_end",
+      toolName: "message",
+      toolCallId: "tool-source-reply",
+      isError: false,
+      result: {
+        details: {
+          deliveryStatus: "sent",
+          sourceReplySink: "internal-ui",
+          dryRun: false,
+        },
+      },
+    });
+
+    expect(ctx.state.messagingToolSourceReplyPayloads).toEqual([
+      {
+        text: "hello from webchat",
+        mediaUrl: "file:///reply.png",
+        mediaUrls: ["file:///reply.png"],
+        idempotencyKey: "reply-key",
+      },
+    ]);
+  });
+
+  it("does not record routed or dry-run source replies for transcript mirroring", async () => {
+    const { ctx } = createTestContext();
+    ctx.params.sourceReplyDeliveryMode = "message_tool_only";
+
+    await handleToolExecutionStart(ctx, {
+      type: "tool_execution_start",
+      toolName: "message",
+      toolCallId: "tool-routed-source-reply",
+      args: { action: "send", to: "channel:123", message: "remote" },
+    });
+    await handleToolExecutionEnd(ctx, {
+      type: "tool_execution_end",
+      toolName: "message",
+      toolCallId: "tool-routed-source-reply",
+      isError: false,
+      result: {
+        details: {
+          deliveryStatus: "sent",
+          sourceReplySink: "internal-ui",
+        },
+      },
+    });
+
+    await handleToolExecutionStart(ctx, {
+      type: "tool_execution_start",
+      toolName: "message",
+      toolCallId: "tool-dry-run-source-reply",
+      args: { action: "send", message: "preview", dryRun: true },
+    });
+    await handleToolExecutionEnd(ctx, {
+      type: "tool_execution_end",
+      toolName: "message",
+      toolCallId: "tool-dry-run-source-reply",
+      isError: false,
+      result: {
+        details: {
+          deliveryStatus: "dry_run",
+          sourceReplySink: "internal-ui",
+          dryRun: true,
+        },
+      },
+    });
+
+    expect(ctx.state.messagingToolSourceReplyPayloads).toEqual([]);
   });
 
   it("commits mediaUrls from tool result payload", async () => {

--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -1269,6 +1269,7 @@ describe("messaging tool media URL tracking", () => {
       args: {
         action: "send",
         mediaUrl: "file:///reply.png",
+        message: "   ",
         caption: "caption from webchat",
       },
     });

--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -1282,9 +1282,6 @@ describe("messaging tool media URL tracking", () => {
         details: {
           deliveryStatus: "sent",
           sourceReplySink: "internal-ui",
-          sourceReplyMediaUrl: "/workspace/reply.png",
-          sourceReplyMediaUrls: ["/workspace/reply.png"],
-          sourceReplyAudioAsVoice: true,
         },
       },
     });
@@ -1321,6 +1318,9 @@ describe("messaging tool media URL tracking", () => {
         details: {
           deliveryStatus: "sent",
           sourceReplySink: "internal-ui",
+          sourceReplyMediaUrl: "/workspace/reply.png",
+          sourceReplyMediaUrls: ["/workspace/reply.png"],
+          sourceReplyAudioAsVoice: true,
         },
       },
     });

--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -1295,6 +1295,43 @@ describe("messaging tool media URL tracking", () => {
     ]);
   });
 
+  it("normalizes reply directives before recording source reply mirrors", async () => {
+    const { ctx } = createTestContext();
+    ctx.params.sourceReplyDeliveryMode = "message_tool_only";
+
+    await handleToolExecutionStart(ctx, {
+      type: "tool_execution_start",
+      toolName: "message",
+      toolCallId: "tool-directive-source-reply",
+      args: {
+        action: "send",
+        message: "hello\\nMEDIA: /tmp/reply.png\\n[[audio_as_voice]]",
+      },
+    });
+
+    await handleToolExecutionEnd(ctx, {
+      type: "tool_execution_end",
+      toolName: "message",
+      toolCallId: "tool-directive-source-reply",
+      isError: false,
+      result: {
+        details: {
+          deliveryStatus: "sent",
+          sourceReplySink: "internal-ui",
+        },
+      },
+    });
+
+    expect(ctx.state.messagingToolSourceReplyPayloads).toEqual([
+      {
+        text: "hello",
+        mediaUrl: "/tmp/reply.png",
+        mediaUrls: ["/tmp/reply.png"],
+        audioAsVoice: true,
+      },
+    ]);
+  });
+
   it("does not record routed or dry-run source replies for transcript mirroring", async () => {
     const { ctx } = createTestContext();
     ctx.params.sourceReplyDeliveryMode = "message_tool_only";

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -49,6 +49,10 @@ import {
 import { inferToolMetaFromArgs } from "./pi-embedded-utils.js";
 import { buildToolMutationState, isSameToolMutationAction } from "./tool-mutation.js";
 import { normalizeToolName } from "./tool-policy.js";
+import {
+  sanitizeMessageToolSendArgs,
+  sanitizeMessageToolText,
+} from "./tools/message-tool-sanitize.js";
 
 type ExecApprovalReplyModule = typeof import("../infra/exec-approval-reply.js");
 type HookRunnerGlobalModule = typeof import("../plugins/hook-runner-global.js");
@@ -186,12 +190,14 @@ function buildSourceReplyPayloadFromMessageToolSend(params: {
   pendingText?: string;
   mediaUrls: string[];
 }): MessagingToolSourceReplyPayload | undefined {
+  const args = sanitizeMessageToolSendArgs(params.args);
+  const pendingText = params.pendingText ? sanitizeMessageToolText(params.pendingText) : undefined;
   const rawText =
-    params.pendingText ??
-    readStringValue(params.args.text) ??
-    readStringValue(params.args.message) ??
-    readStringValue(params.args.content) ??
-    readStringValue(params.args.caption);
+    pendingText ??
+    readStringValue(args.text) ??
+    readStringValue(args.message) ??
+    readStringValue(args.content) ??
+    readStringValue(args.caption);
   const parsedText =
     rawText === undefined ? undefined : parseReplyDirectives(rawText.replaceAll("\\n", "\n"));
   const text = parsedText?.text ?? rawText;
@@ -205,29 +211,26 @@ function buildSourceReplyPayloadFromMessageToolSend(params: {
     ...(parsedText?.mediaUrls ?? []),
   ];
   const mediaUrl =
-    readStringValue(params.args.mediaUrl) ??
-    readStringValue(params.args.media_url) ??
-    parsedText?.mediaUrl;
+    readStringValue(args.mediaUrl) ?? readStringValue(args.media_url) ?? parsedText?.mediaUrl;
   if (mediaUrls.length > 0) {
     payload.mediaUrls = Array.from(new Set(mediaUrls));
   }
   if (mediaUrl?.trim()) {
     payload.mediaUrl = mediaUrl;
   }
-  if (params.args.audioAsVoice === true || parsedText?.audioAsVoice === true) {
+  if (args.audioAsVoice === true || parsedText?.audioAsVoice === true) {
     payload.audioAsVoice = true;
   }
-  if (params.args.presentation !== undefined) {
-    payload.presentation = params.args
-      .presentation as MessagingToolSourceReplyPayload["presentation"];
+  if (args.presentation !== undefined) {
+    payload.presentation = args.presentation as MessagingToolSourceReplyPayload["presentation"];
   }
-  if (params.args.interactive !== undefined) {
-    payload.interactive = params.args.interactive as MessagingToolSourceReplyPayload["interactive"];
+  if (args.interactive !== undefined) {
+    payload.interactive = args.interactive as MessagingToolSourceReplyPayload["interactive"];
   }
-  if (params.args.channelData !== undefined) {
-    payload.channelData = params.args.channelData as MessagingToolSourceReplyPayload["channelData"];
+  if (args.channelData !== undefined) {
+    payload.channelData = args.channelData as MessagingToolSourceReplyPayload["channelData"];
   }
-  const idempotencyKey = readStringValue(params.args.idempotencyKey);
+  const idempotencyKey = readStringValue(args.idempotencyKey);
   if (idempotencyKey?.trim()) {
     payload.idempotencyKey = idempotencyKey;
   }

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -185,10 +185,70 @@ function toolResultHasInternalSourceReplyDelivery(result: unknown): boolean {
   return hasInternalSink && isSent && !isDryRun;
 }
 
+function collectInternalSourceReplyMetadata(result: unknown): {
+  mediaUrl?: string;
+  mediaUrls: string[];
+  audioAsVoice?: boolean;
+} {
+  const mediaUrls: string[] = [];
+  const seen = new Set<string>();
+  let mediaUrl: string | undefined;
+  let audioAsVoice = false;
+  const pushMedia = (value: unknown) => {
+    const raw = readStringValue(value);
+    if (!raw?.trim() || seen.has(raw)) {
+      return;
+    }
+    seen.add(raw);
+    mediaUrls.push(raw);
+    mediaUrl ??= raw;
+  };
+  const visit = (value: unknown, depth = 0): void => {
+    if (depth > 4 || value == null) {
+      return;
+    }
+    if (typeof value === "string") {
+      const parsed = parseJsonRecord(value);
+      if (parsed) {
+        visit(parsed, depth + 1);
+      }
+      return;
+    }
+    if (Array.isArray(value)) {
+      value.forEach((item) => visit(item, depth + 1));
+      return;
+    }
+    if (!isPlainRecord(value)) {
+      return;
+    }
+    pushMedia(value.sourceReplyMediaUrl);
+    if (Array.isArray(value.sourceReplyMediaUrls)) {
+      value.sourceReplyMediaUrls.forEach(pushMedia);
+    }
+    if (value.sourceReplyAudioAsVoice === true) {
+      audioAsVoice = true;
+    }
+    for (const key of ["details", "payload", "result", "results", "sendResult", "toolResult"]) {
+      visit(value[key], depth + 1);
+    }
+  };
+  visit(result);
+  return {
+    ...(mediaUrl ? { mediaUrl } : {}),
+    mediaUrls,
+    ...(audioAsVoice ? { audioAsVoice: true } : {}),
+  };
+}
+
 function buildSourceReplyPayloadFromMessageToolSend(params: {
   args: Record<string, unknown>;
   pendingText?: string;
   mediaUrls: string[];
+  resultSourceReply?: {
+    mediaUrl?: string;
+    mediaUrls: string[];
+    audioAsVoice?: boolean;
+  };
 }): MessagingToolSourceReplyPayload | undefined {
   const args = sanitizeMessageToolSendArgs(params.args);
   const pendingText = params.pendingText ? sanitizeMessageToolText(params.pendingText) : undefined;
@@ -205,20 +265,32 @@ function buildSourceReplyPayloadFromMessageToolSend(params: {
   if (text?.trim()) {
     payload.text = text;
   }
-  const mediaUrls = [
-    ...(params.mediaUrls.length > 0 ? params.mediaUrls : []),
-    ...(parsedText?.mediaUrl ? [parsedText.mediaUrl] : []),
-    ...(parsedText?.mediaUrls ?? []),
-  ];
+  const hasResultSourceReplyMedia =
+    Boolean(params.resultSourceReply?.mediaUrl) ||
+    (params.resultSourceReply?.mediaUrls.length ?? 0) > 0;
+  const mediaUrls = hasResultSourceReplyMedia
+    ? (params.resultSourceReply?.mediaUrls ?? [])
+    : [
+        ...(params.mediaUrls.length > 0 ? params.mediaUrls : []),
+        ...(parsedText?.mediaUrl ? [parsedText.mediaUrl] : []),
+        ...(parsedText?.mediaUrls ?? []),
+      ];
   const mediaUrl =
-    readStringValue(args.mediaUrl) ?? readStringValue(args.media_url) ?? parsedText?.mediaUrl;
+    params.resultSourceReply?.mediaUrl ??
+    readStringValue(args.mediaUrl) ??
+    readStringValue(args.media_url) ??
+    parsedText?.mediaUrl;
   if (mediaUrls.length > 0) {
     payload.mediaUrls = Array.from(new Set(mediaUrls));
   }
   if (mediaUrl?.trim()) {
     payload.mediaUrl = mediaUrl;
   }
-  if (args.audioAsVoice === true || parsedText?.audioAsVoice === true) {
+  if (
+    params.resultSourceReply?.audioAsVoice === true ||
+    args.audioAsVoice === true ||
+    parsedText?.audioAsVoice === true
+  ) {
     payload.audioAsVoice = true;
   }
   if (args.presentation !== undefined) {
@@ -1171,6 +1243,7 @@ export async function handleToolExecutionEnd(
         args: startArgs,
         pendingText,
         mediaUrls: committedMediaUrls,
+        resultSourceReply: collectInternalSourceReplyMetadata(result),
       });
       if (sourceReplyPayload) {
         ctx.state.messagingToolSourceReplyPayloads.push(sourceReplyPayload);

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -240,6 +240,56 @@ function collectInternalSourceReplyMetadata(result: unknown): {
   };
 }
 
+function collectStructuredReplyTextParts(value: unknown): string[] {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return [];
+  }
+  const record = value as Record<string, unknown>;
+  const parts: string[] = [];
+  const pushText = (text: unknown) => {
+    const value = readStringValue(text)?.trim();
+    if (value) {
+      parts.push(value);
+    }
+  };
+  pushText(record.title);
+  if (!Array.isArray(record.blocks)) {
+    return parts;
+  }
+  for (const block of record.blocks) {
+    if (!block || typeof block !== "object" || Array.isArray(block)) {
+      continue;
+    }
+    const blockRecord = block as Record<string, unknown>;
+    pushText(blockRecord.text);
+    pushText(blockRecord.placeholder);
+    if (Array.isArray(blockRecord.buttons)) {
+      for (const button of blockRecord.buttons) {
+        if (button && typeof button === "object" && !Array.isArray(button)) {
+          pushText((button as Record<string, unknown>).label);
+        }
+      }
+    }
+    if (Array.isArray(blockRecord.options)) {
+      for (const option of blockRecord.options) {
+        if (option && typeof option === "object" && !Array.isArray(option)) {
+          pushText((option as Record<string, unknown>).label);
+        }
+      }
+    }
+  }
+  return parts;
+}
+
+function synthesizeStructuredSourceReplyText(args: Record<string, unknown>): string | undefined {
+  const parts = [
+    ...collectStructuredReplyTextParts(args.presentation),
+    ...collectStructuredReplyTextParts(args.interactive),
+  ];
+  const uniqueParts = Array.from(new Set(parts));
+  return uniqueParts.length > 0 ? uniqueParts.join("\n") : undefined;
+}
+
 function buildSourceReplyPayloadFromMessageToolSend(params: {
   args: Record<string, unknown>;
   pendingText?: string;
@@ -299,6 +349,9 @@ function buildSourceReplyPayloadFromMessageToolSend(params: {
   }
   if (args.interactive !== undefined) {
     payload.interactive = args.interactive as MessagingToolSourceReplyPayload["interactive"];
+  }
+  if (!payload.text && (payload.presentation || payload.interactive)) {
+    payload.text = synthesizeStructuredSourceReplyText(args);
   }
   if (args.channelData !== undefined) {
     payload.channelData = args.channelData as MessagingToolSourceReplyPayload["channelData"];

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -189,7 +189,8 @@ function buildSourceReplyPayloadFromMessageToolSend(params: {
     params.pendingText ??
     readStringValue(params.args.text) ??
     readStringValue(params.args.message) ??
-    readStringValue(params.args.content);
+    readStringValue(params.args.content) ??
+    readStringValue(params.args.caption);
   const payload: MessagingToolSourceReplyPayload = {};
   if (text?.trim()) {
     payload.text = text;

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -26,6 +26,7 @@ import type { ExecToolDetails } from "./bash-tools.exec-types.js";
 import { parseExecApprovalResultText } from "./exec-approval-result.js";
 import { normalizeTextForComparison } from "./pi-embedded-helpers.js";
 import { isMessagingTool, isMessagingToolSendAction } from "./pi-embedded-messaging.js";
+import type { MessagingToolSourceReplyPayload } from "./pi-embedded-messaging.types.js";
 import { mergeEmbeddedRunReplayState } from "./pi-embedded-runner/replay-state.js";
 import type {
   ToolCallSummary,
@@ -107,6 +108,123 @@ const toolStartData = new Map<string, ToolStartRecord>();
 
 function buildToolStartKey(runId: string, toolCallId: string): string {
   return `${runId}:${toolCallId}`;
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasStringValue(value: unknown): boolean {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function hasExplicitMessageRoute(args: Record<string, unknown>): boolean {
+  if (
+    ["channel", "target", "to", "channelId", "provider"].some((key) => hasStringValue(args[key]))
+  ) {
+    return true;
+  }
+  return Array.isArray(args.targets) && args.targets.some((value) => hasStringValue(value));
+}
+
+function parseJsonRecord(value: string): Record<string, unknown> | undefined {
+  try {
+    const parsed = JSON.parse(value);
+    return isPlainRecord(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function nestedDeliveryRecordMatches(
+  value: unknown,
+  predicate: (record: Record<string, unknown>) => boolean,
+  depth = 0,
+): boolean {
+  if (depth > 4 || value == null) {
+    return false;
+  }
+  if (typeof value === "string") {
+    const parsed = parseJsonRecord(value);
+    return parsed ? nestedDeliveryRecordMatches(parsed, predicate, depth + 1) : false;
+  }
+  if (Array.isArray(value)) {
+    return value.some((item) => nestedDeliveryRecordMatches(item, predicate, depth + 1));
+  }
+  if (!isPlainRecord(value)) {
+    return false;
+  }
+  return (
+    predicate(value) ||
+    ["details", "payload", "result", "results", "sendResult", "toolResult", "content"].some((key) =>
+      nestedDeliveryRecordMatches(value[key], predicate, depth + 1),
+    )
+  );
+}
+
+function toolResultHasInternalSourceReplyDelivery(result: unknown): boolean {
+  const hasInternalSink = nestedDeliveryRecordMatches(
+    result,
+    (record) => normalizeOptionalLowercaseString(record.sourceReplySink) === "internal-ui",
+  );
+  const isSent = nestedDeliveryRecordMatches(
+    result,
+    (record) => normalizeOptionalLowercaseString(record.deliveryStatus) === "sent",
+  );
+  const isDryRun = nestedDeliveryRecordMatches(
+    result,
+    (record) =>
+      record.dryRun === true ||
+      normalizeOptionalLowercaseString(record.deliveryStatus) === "dry_run",
+  );
+  return hasInternalSink && isSent && !isDryRun;
+}
+
+function buildSourceReplyPayloadFromMessageToolSend(params: {
+  args: Record<string, unknown>;
+  pendingText?: string;
+  mediaUrls: string[];
+}): MessagingToolSourceReplyPayload | undefined {
+  const text =
+    params.pendingText ??
+    readStringValue(params.args.text) ??
+    readStringValue(params.args.message) ??
+    readStringValue(params.args.content);
+  const payload: MessagingToolSourceReplyPayload = {};
+  if (text?.trim()) {
+    payload.text = text;
+  }
+  if (params.mediaUrls.length > 0) {
+    payload.mediaUrls = params.mediaUrls.slice();
+  }
+  const mediaUrl = readStringValue(params.args.mediaUrl) ?? readStringValue(params.args.media_url);
+  if (mediaUrl?.trim()) {
+    payload.mediaUrl = mediaUrl;
+  }
+  if (params.args.audioAsVoice === true) {
+    payload.audioAsVoice = true;
+  }
+  if (params.args.presentation !== undefined) {
+    payload.presentation = params.args
+      .presentation as MessagingToolSourceReplyPayload["presentation"];
+  }
+  if (params.args.interactive !== undefined) {
+    payload.interactive = params.args.interactive as MessagingToolSourceReplyPayload["interactive"];
+  }
+  if (params.args.channelData !== undefined) {
+    payload.channelData = params.args.channelData as MessagingToolSourceReplyPayload["channelData"];
+  }
+  const idempotencyKey = readStringValue(params.args.idempotencyKey);
+  if (idempotencyKey?.trim()) {
+    payload.idempotencyKey = idempotencyKey;
+  }
+  return payload.text ||
+    payload.mediaUrl ||
+    payload.mediaUrls?.length ||
+    payload.presentation ||
+    payload.interactive
+    ? payload
+    : undefined;
 }
 
 export function countActiveToolExecutions(runId: string): number {
@@ -1024,6 +1142,24 @@ export async function handleToolExecutionEnd(
     if (committedMediaUrls.length > 0) {
       ctx.state.messagingToolSentMediaUrls.push(...committedMediaUrls);
       ctx.trimMessagingToolSent();
+    }
+    if (
+      ctx.params.sourceReplyDeliveryMode === "message_tool_only" &&
+      toolName === "message" &&
+      isMessagingToolSendAction(toolName, startArgs) &&
+      startArgs.dryRun !== true &&
+      !hasExplicitMessageRoute(startArgs) &&
+      toolResultHasInternalSourceReplyDelivery(result)
+    ) {
+      const sourceReplyPayload = buildSourceReplyPayloadFromMessageToolSend({
+        args: startArgs,
+        pendingText,
+        mediaUrls: committedMediaUrls,
+      });
+      if (sourceReplyPayload) {
+        ctx.state.messagingToolSourceReplyPayloads.push(sourceReplyPayload);
+        ctx.trimMessagingToolSent();
+      }
     }
   }
 

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -252,12 +252,13 @@ function buildSourceReplyPayloadFromMessageToolSend(params: {
 }): MessagingToolSourceReplyPayload | undefined {
   const args = sanitizeMessageToolSendArgs(params.args);
   const pendingText = params.pendingText ? sanitizeMessageToolText(params.pendingText) : undefined;
-  const rawText =
+  const messageText =
     pendingText ??
     readStringValue(args.text) ??
     readStringValue(args.message) ??
-    readStringValue(args.content) ??
-    readStringValue(args.caption);
+    readStringValue(args.content);
+  const captionText = readStringValue(args.caption);
+  const rawText = messageText?.trim() ? messageText : (captionText ?? messageText);
   const parsedText =
     rawText === undefined ? undefined : parseReplyDirectives(rawText.replaceAll("\\n", "\n"));
   const text = parsedText?.text ?? rawText;

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -3,6 +3,7 @@ import {
   HEARTBEAT_RESPONSE_TOOL_NAME,
   normalizeHeartbeatToolResponse,
 } from "../auto-reply/heartbeat-tool-response.js";
+import { parseReplyDirectives } from "../auto-reply/reply/reply-directives.js";
 import type {
   AgentApprovalEventData,
   AgentCommandOutputEventData,
@@ -185,24 +186,35 @@ function buildSourceReplyPayloadFromMessageToolSend(params: {
   pendingText?: string;
   mediaUrls: string[];
 }): MessagingToolSourceReplyPayload | undefined {
-  const text =
+  const rawText =
     params.pendingText ??
     readStringValue(params.args.text) ??
     readStringValue(params.args.message) ??
     readStringValue(params.args.content) ??
     readStringValue(params.args.caption);
+  const parsedText =
+    rawText === undefined ? undefined : parseReplyDirectives(rawText.replaceAll("\\n", "\n"));
+  const text = parsedText?.text ?? rawText;
   const payload: MessagingToolSourceReplyPayload = {};
   if (text?.trim()) {
     payload.text = text;
   }
-  if (params.mediaUrls.length > 0) {
-    payload.mediaUrls = params.mediaUrls.slice();
+  const mediaUrls = [
+    ...(params.mediaUrls.length > 0 ? params.mediaUrls : []),
+    ...(parsedText?.mediaUrl ? [parsedText.mediaUrl] : []),
+    ...(parsedText?.mediaUrls ?? []),
+  ];
+  const mediaUrl =
+    readStringValue(params.args.mediaUrl) ??
+    readStringValue(params.args.media_url) ??
+    parsedText?.mediaUrl;
+  if (mediaUrls.length > 0) {
+    payload.mediaUrls = Array.from(new Set(mediaUrls));
   }
-  const mediaUrl = readStringValue(params.args.mediaUrl) ?? readStringValue(params.args.media_url);
   if (mediaUrl?.trim()) {
     payload.mediaUrl = mediaUrl;
   }
-  if (params.args.audioAsVoice === true) {
+  if (params.args.audioAsVoice === true || parsedText?.audioAsVoice === true) {
     payload.audioAsVoice = true;
   }
   if (params.args.presentation !== undefined) {

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -6,7 +6,10 @@ import type { ReasoningLevel } from "../auto-reply/thinking.js";
 import type { InlineCodeState } from "../markdown/code-spans.js";
 import type { HookRunner } from "../plugins/hooks.js";
 import type { EmbeddedBlockChunker } from "./pi-embedded-block-chunker.js";
-import type { MessagingToolSend } from "./pi-embedded-messaging.types.js";
+import type {
+  MessagingToolSend,
+  MessagingToolSourceReplyPayload,
+} from "./pi-embedded-messaging.types.js";
 import type { BlockReplyPayload } from "./pi-embedded-payloads.js";
 import type { EmbeddedRunReplayState } from "./pi-embedded-runner/replay-state.js";
 import type { EmbeddedRunLivenessState } from "./pi-embedded-runner/types.js";
@@ -96,6 +99,7 @@ export type EmbeddedPiSubscribeState = {
   messagingToolSentTexts: string[];
   messagingToolSentTextsNormalized: string[];
   messagingToolSentTargets: MessagingToolSend[];
+  messagingToolSourceReplyPayloads: MessagingToolSourceReplyPayload[];
   heartbeatToolResponse?: HeartbeatToolResponse;
   messagingToolSentMediaUrls: string[];
   pendingMessagingTexts: Map<string, string>;
@@ -193,6 +197,7 @@ type ToolHandlerParams = Pick<
   | "sessionKey"
   | "sessionId"
   | "agentId"
+  | "sourceReplyDeliveryMode"
   | "toolResultFormat"
   | "toolProgressDetail"
 >;
@@ -219,6 +224,7 @@ type ToolHandlerState = Pick<
   | "messagingToolSentTextsNormalized"
   | "messagingToolSentMediaUrls"
   | "messagingToolSentTargets"
+  | "messagingToolSourceReplyPayloads"
   | "heartbeatToolResponse"
   | "successfulCronAdds"
   | "deterministicApprovalPromptSent"

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -181,6 +181,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     messagingToolSentTexts: [],
     messagingToolSentTextsNormalized: [],
     messagingToolSentTargets: [],
+    messagingToolSourceReplyPayloads: [],
     heartbeatToolResponse: undefined,
     messagingToolSentMediaUrls: [],
     pendingMessagingTexts: new Map(),
@@ -211,6 +212,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
   const messagingToolSentTexts = state.messagingToolSentTexts;
   const messagingToolSentTextsNormalized = state.messagingToolSentTextsNormalized;
   const messagingToolSentTargets = state.messagingToolSentTargets;
+  const messagingToolSourceReplyPayloads = state.messagingToolSourceReplyPayloads;
   const messagingToolSentMediaUrls = state.messagingToolSentMediaUrls;
   const pendingMessagingTexts = state.pendingMessagingTexts;
   const pendingMessagingTargets = state.pendingMessagingTargets;
@@ -372,6 +374,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
   const MAX_MESSAGING_SENT_TEXTS = 200;
   const MAX_MESSAGING_SENT_TARGETS = 200;
   const MAX_MESSAGING_SENT_MEDIA_URLS = 200;
+  const MAX_MESSAGING_SOURCE_REPLY_PAYLOADS = 200;
   const trimMessagingToolSent = () => {
     if (messagingToolSentTexts.length > MAX_MESSAGING_SENT_TEXTS) {
       const overflow = messagingToolSentTexts.length - MAX_MESSAGING_SENT_TEXTS;
@@ -385,6 +388,11 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     if (messagingToolSentMediaUrls.length > MAX_MESSAGING_SENT_MEDIA_URLS) {
       const overflow = messagingToolSentMediaUrls.length - MAX_MESSAGING_SENT_MEDIA_URLS;
       messagingToolSentMediaUrls.splice(0, overflow);
+    }
+    if (messagingToolSourceReplyPayloads.length > MAX_MESSAGING_SOURCE_REPLY_PAYLOADS) {
+      const overflow =
+        messagingToolSourceReplyPayloads.length - MAX_MESSAGING_SOURCE_REPLY_PAYLOADS;
+      messagingToolSourceReplyPayloads.splice(0, overflow);
     }
   };
 
@@ -960,6 +968,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     messagingToolSentTexts.length = 0;
     messagingToolSentTextsNormalized.length = 0;
     messagingToolSentTargets.length = 0;
+    messagingToolSourceReplyPayloads.length = 0;
     messagingToolSentMediaUrls.length = 0;
     pendingMessagingTexts.clear();
     pendingMessagingTargets.clear();
@@ -1119,6 +1128,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     getMessagingToolSentTexts: () => messagingToolSentTexts.slice(),
     getMessagingToolSentMediaUrls: () => messagingToolSentMediaUrls.slice(),
     getMessagingToolSentTargets: () => messagingToolSentTargets.slice(),
+    getMessagingToolSourceReplyPayloads: () => messagingToolSourceReplyPayloads.slice(),
     getHeartbeatToolResponse: () =>
       state.heartbeatToolResponse ? { ...state.heartbeatToolResponse } : undefined,
     getPendingToolMediaReply: () => readPendingToolMediaReply(state),

--- a/src/agents/pi-tool-handler-state.test-helpers.ts
+++ b/src/agents/pi-tool-handler-state.test-helpers.ts
@@ -22,6 +22,7 @@ export function createBaseToolHandlerState() {
     messagingToolSentTextsNormalized: [] as string[],
     messagingToolSentMediaUrls: [] as string[],
     messagingToolSentTargets: [] as unknown[],
+    messagingToolSourceReplyPayloads: [] as unknown[],
     deterministicApprovalPromptSent: false,
     blockBuffer: "",
   };

--- a/src/agents/tools/message-tool-sanitize.ts
+++ b/src/agents/tools/message-tool-sanitize.ts
@@ -1,0 +1,97 @@
+import { stripReasoningTagsFromText } from "../../shared/text/reasoning-tags.js";
+
+export function sanitizeMessageToolText(text: string): string {
+  const stripped = stripReasoningTagsFromText(text);
+  const lines = stripped.split(/\r?\n/u);
+  const prefix = lines[0]?.trim();
+  if (prefix !== "Reasoning:" && !/^Thinking\.{0,3}$/u.test(prefix ?? "")) {
+    return stripped;
+  }
+  if (/^Thinking\.{0,3}$/u.test(prefix ?? "")) {
+    const firstBodyLine = lines.slice(1).find((line) => line.trim());
+    const trimmedBodyLine = firstBodyLine?.trim() ?? "";
+    if (
+      !trimmedBodyLine ||
+      !(
+        trimmedBodyLine.startsWith("_") &&
+        trimmedBodyLine.endsWith("_") &&
+        trimmedBodyLine.length >= 2
+      )
+    ) {
+      return stripped;
+    }
+  }
+
+  let index = 1;
+  while (index < lines.length) {
+    const trimmed = lines[index]?.trim() ?? "";
+    if (!trimmed || (trimmed.startsWith("_") && trimmed.endsWith("_") && trimmed.length >= 2)) {
+      index += 1;
+      continue;
+    }
+    break;
+  }
+  return lines.slice(index).join("\n").trim();
+}
+
+export function sanitizeMessageToolPresentationTextFields(value: unknown): unknown {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return value;
+  }
+  const presentation = { ...(value as Record<string, unknown>) };
+  if (typeof presentation.title === "string") {
+    presentation.title = sanitizeMessageToolText(presentation.title);
+  }
+  if (Array.isArray(presentation.blocks)) {
+    presentation.blocks = presentation.blocks.map((block) => {
+      if (!block || typeof block !== "object" || Array.isArray(block)) {
+        return block;
+      }
+      const sanitizedBlock = { ...(block as Record<string, unknown>) };
+      for (const field of ["text", "placeholder"]) {
+        if (typeof sanitizedBlock[field] === "string") {
+          sanitizedBlock[field] = sanitizeMessageToolText(sanitizedBlock[field]);
+        }
+      }
+      if (Array.isArray(sanitizedBlock.buttons)) {
+        sanitizedBlock.buttons = sanitizedBlock.buttons.map((button) => {
+          if (!button || typeof button !== "object" || Array.isArray(button)) {
+            return button;
+          }
+          const sanitizedButton = { ...(button as Record<string, unknown>) };
+          if (typeof sanitizedButton.label === "string") {
+            sanitizedButton.label = sanitizeMessageToolText(sanitizedButton.label);
+          }
+          return sanitizedButton;
+        });
+      }
+      if (Array.isArray(sanitizedBlock.options)) {
+        sanitizedBlock.options = sanitizedBlock.options.map((option) => {
+          if (!option || typeof option !== "object" || Array.isArray(option)) {
+            return option;
+          }
+          const sanitizedOption = { ...(option as Record<string, unknown>) };
+          if (typeof sanitizedOption.label === "string") {
+            sanitizedOption.label = sanitizeMessageToolText(sanitizedOption.label);
+          }
+          return sanitizedOption;
+        });
+      }
+      return sanitizedBlock;
+    });
+  }
+  return presentation;
+}
+
+export function sanitizeMessageToolSendArgs(
+  args: Record<string, unknown>,
+): Record<string, unknown> {
+  const params = { ...args };
+  for (const field of ["text", "content", "message", "caption"]) {
+    if (typeof params[field] === "string") {
+      params[field] = sanitizeMessageToolText(params[field]);
+    }
+  }
+  params.presentation = sanitizeMessageToolPresentationTextFields(params.presentation);
+  return params;
+}

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -28,7 +28,6 @@ import {
   parseThreadSessionSuffix,
 } from "../../routing/session-key.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
-import { stripReasoningTagsFromText } from "../../shared/text/reasoning-tags.js";
 import { normalizeMessageChannel } from "../../utils/message-channel.js";
 import { resolveSessionAgentId } from "../agent-scope.js";
 import { listAllChannelSupportedActions, listChannelSupportedActions } from "../channel-tools.js";
@@ -36,6 +35,7 @@ import { channelTargetSchema, channelTargetsSchema, stringEnum } from "../schema
 import type { AnyAgentTool } from "./common.js";
 import { jsonResult, readNumberParam, readStringParam } from "./common.js";
 import { resolveGatewayOptions } from "./gateway.js";
+import { sanitizeMessageToolSendArgs } from "./message-tool-sanitize.js";
 
 const AllMessageActions = CHANNEL_MESSAGE_ACTION_NAMES;
 const MESSAGE_TOOL_THREAD_READ_HINT =
@@ -54,95 +54,12 @@ function actionNeedsExplicitTarget(action: ChannelMessageActionName): boolean {
   return EXPLICIT_TARGET_ACTIONS.has(action);
 }
 
-function stripFormattedReasoningMessage(text: string): string {
-  const stripped = stripReasoningTagsFromText(text);
-  const lines = stripped.split(/\r?\n/u);
-  const prefix = lines[0]?.trim();
-  if (prefix !== "Reasoning:" && !/^Thinking\.{0,3}$/u.test(prefix ?? "")) {
-    return stripped;
-  }
-  if (/^Thinking\.{0,3}$/u.test(prefix ?? "")) {
-    const firstBodyLine = lines.slice(1).find((line) => line.trim());
-    const trimmedBodyLine = firstBodyLine?.trim() ?? "";
-    if (
-      !trimmedBodyLine ||
-      !(
-        trimmedBodyLine.startsWith("_") &&
-        trimmedBodyLine.endsWith("_") &&
-        trimmedBodyLine.length >= 2
-      )
-    ) {
-      return stripped;
-    }
-  }
-
-  let index = 1;
-  while (index < lines.length) {
-    const trimmed = lines[index]?.trim() ?? "";
-    if (!trimmed || (trimmed.startsWith("_") && trimmed.endsWith("_") && trimmed.length >= 2)) {
-      index += 1;
-      continue;
-    }
-    break;
-  }
-  return lines.slice(index).join("\n").trim();
-}
-
 function normalizeToolCallIdForIdempotencyKey(toolCallId: unknown): string | undefined {
   const value = normalizeOptionalString(toolCallId);
   if (!value) {
     return undefined;
   }
   return value.replace(/[^A-Za-z0-9._:-]+/gu, "_");
-}
-
-function sanitizePresentationTextFields(value: unknown): unknown {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return value;
-  }
-  const presentation = { ...(value as Record<string, unknown>) };
-  if (typeof presentation.title === "string") {
-    presentation.title = stripFormattedReasoningMessage(presentation.title);
-  }
-  if (Array.isArray(presentation.blocks)) {
-    presentation.blocks = presentation.blocks.map((block) => {
-      if (!block || typeof block !== "object" || Array.isArray(block)) {
-        return block;
-      }
-      const sanitizedBlock = { ...(block as Record<string, unknown>) };
-      for (const field of ["text", "placeholder"]) {
-        if (typeof sanitizedBlock[field] === "string") {
-          sanitizedBlock[field] = stripFormattedReasoningMessage(sanitizedBlock[field]);
-        }
-      }
-      if (Array.isArray(sanitizedBlock.buttons)) {
-        sanitizedBlock.buttons = sanitizedBlock.buttons.map((button) => {
-          if (!button || typeof button !== "object" || Array.isArray(button)) {
-            return button;
-          }
-          const sanitizedButton = { ...(button as Record<string, unknown>) };
-          if (typeof sanitizedButton.label === "string") {
-            sanitizedButton.label = stripFormattedReasoningMessage(sanitizedButton.label);
-          }
-          return sanitizedButton;
-        });
-      }
-      if (Array.isArray(sanitizedBlock.options)) {
-        sanitizedBlock.options = sanitizedBlock.options.map((option) => {
-          if (!option || typeof option !== "object" || Array.isArray(option)) {
-            return option;
-          }
-          const sanitizedOption = { ...(option as Record<string, unknown>) };
-          if (typeof sanitizedOption.label === "string") {
-            sanitizedOption.label = stripFormattedReasoningMessage(sanitizedOption.label);
-          }
-          return sanitizedOption;
-        });
-      }
-      return sanitizedBlock;
-    });
-  }
-  return presentation;
 }
 
 function buildRoutingSchema() {
@@ -953,17 +870,9 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
         err.name = "AbortError";
         throw err;
       }
-      // Shallow-copy so we don't mutate the original event args (used for logging/dedup).
-      const params = { ...(args as Record<string, unknown>) };
-
       // Strip reasoning tags from text fields — models may include <think>…</think>
       // in tool arguments, and the messaging tool send path has no other tag filtering.
-      for (const field of ["text", "content", "message", "caption"]) {
-        if (typeof params[field] === "string") {
-          params[field] = stripFormattedReasoningMessage(params[field]);
-        }
-      }
-      params.presentation = sanitizePresentationTextFields(params.presentation);
+      const params = sanitizeMessageToolSendArgs(args as Record<string, unknown>);
 
       const action = readStringParam(params, "action", {
         required: true,

--- a/src/infra/outbound/message-action-runner.send-validation.test.ts
+++ b/src/infra/outbound/message-action-runner.send-validation.test.ts
@@ -93,6 +93,7 @@ describe("runMessageAction send validation", () => {
       action: "send",
       params: {
         message: "hello from codex",
+        mediaUrl: "file:///reply.png",
       },
       toolContext: {
         currentChannelProvider: "webchat",
@@ -113,6 +114,8 @@ describe("runMessageAction send validation", () => {
         sourceReplySink: "internal-ui",
         sourceReply: {
           text: "hello from codex",
+          mediaUrl: "file:///reply.png",
+          mediaUrls: ["file:///reply.png"],
         },
       },
     });
@@ -132,6 +135,8 @@ describe("runMessageAction send validation", () => {
       target: "current-run",
       sourceReplyDeliveryMode: "message_tool_only",
       sourceReplySink: "internal-ui",
+      sourceReplyMediaUrl: "file:///reply.png",
+      sourceReplyMediaUrls: ["file:///reply.png"],
       dryRun: false,
     });
     expect(JSON.stringify(result.toolResult)).not.toContain("hello from codex");

--- a/src/infra/outbound/message-action-runner.send-validation.test.ts
+++ b/src/infra/outbound/message-action-runner.send-validation.test.ts
@@ -116,6 +116,25 @@ describe("runMessageAction send validation", () => {
         },
       },
     });
+    if (result.kind !== "send") {
+      throw new Error(`expected send result, got ${result.kind}`);
+    }
+    expect(result.toolResult?.content).toEqual([
+      {
+        type: "text",
+        text: "Sent visible reply to the current webchat conversation via internal-ui.",
+      },
+    ]);
+    expect(result.toolResult?.details).toEqual({
+      status: "ok",
+      deliveryStatus: "sent",
+      channel: "webchat",
+      target: "current-run",
+      sourceReplyDeliveryMode: "message_tool_only",
+      sourceReplySink: "internal-ui",
+      dryRun: false,
+    });
+    expect(JSON.stringify(result.toolResult)).not.toContain("hello from codex");
   });
 
   it("does not infer an internal UI sink outside message-tool-only source delivery", async () => {

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -731,7 +731,12 @@ async function handleInternalSourceReplySendAction(
     to: "current-run",
     handledBy: "internal-source",
     payload,
-    toolResult: buildInternalSourceReplyToolResult(payload),
+    toolResult: buildInternalSourceReplyToolResult({
+      ...payload,
+      ...(sourceReply.mediaUrl ? { sourceReplyMediaUrl: sourceReply.mediaUrl } : {}),
+      ...(sourceReply.mediaUrls?.length ? { sourceReplyMediaUrls: sourceReply.mediaUrls } : {}),
+      ...(sourceReply.asVoice ? { sourceReplyAudioAsVoice: true } : {}),
+    }),
     dryRun,
   };
 }
@@ -743,6 +748,9 @@ function buildInternalSourceReplyToolResult(payload: {
   target: string;
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
   sourceReplySink?: "internal-ui";
+  sourceReplyMediaUrl?: string;
+  sourceReplyMediaUrls?: string[];
+  sourceReplyAudioAsVoice?: boolean;
   dryRun: boolean;
 }): AgentToolResult<{
   status: string;
@@ -751,6 +759,9 @@ function buildInternalSourceReplyToolResult(payload: {
   target: string;
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
   sourceReplySink?: "internal-ui";
+  sourceReplyMediaUrl?: string;
+  sourceReplyMediaUrls?: string[];
+  sourceReplyAudioAsVoice?: boolean;
   dryRun: boolean;
 }> {
   const action = payload.dryRun ? "Prepared" : "Sent";
@@ -771,6 +782,11 @@ function buildInternalSourceReplyToolResult(payload: {
         ? { sourceReplyDeliveryMode: payload.sourceReplyDeliveryMode }
         : {}),
       ...(payload.sourceReplySink ? { sourceReplySink: payload.sourceReplySink } : {}),
+      ...(payload.sourceReplyMediaUrl ? { sourceReplyMediaUrl: payload.sourceReplyMediaUrl } : {}),
+      ...(payload.sourceReplyMediaUrls?.length
+        ? { sourceReplyMediaUrls: payload.sourceReplyMediaUrls }
+        : {}),
+      ...(payload.sourceReplyAudioAsVoice ? { sourceReplyAudioAsVoice: true } : {}),
       dryRun: payload.dryRun,
     },
   };

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -731,7 +731,48 @@ async function handleInternalSourceReplySendAction(
     to: "current-run",
     handledBy: "internal-source",
     payload,
+    toolResult: buildInternalSourceReplyToolResult(payload),
     dryRun,
+  };
+}
+
+function buildInternalSourceReplyToolResult(payload: {
+  status: string;
+  deliveryStatus: string;
+  channel: ChannelId;
+  target: string;
+  sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
+  sourceReplySink?: "internal-ui";
+  dryRun: boolean;
+}): AgentToolResult<{
+  status: string;
+  deliveryStatus: string;
+  channel: ChannelId;
+  target: string;
+  sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
+  sourceReplySink?: "internal-ui";
+  dryRun: boolean;
+}> {
+  const action = payload.dryRun ? "Prepared" : "Sent";
+  const sink = payload.sourceReplySink ? ` via ${payload.sourceReplySink}` : "";
+  return {
+    content: [
+      {
+        type: "text",
+        text: `${action} visible reply to the current webchat conversation${sink}.`,
+      },
+    ],
+    details: {
+      status: payload.status,
+      deliveryStatus: payload.deliveryStatus,
+      channel: payload.channel,
+      target: payload.target,
+      ...(payload.sourceReplyDeliveryMode
+        ? { sourceReplyDeliveryMode: payload.sourceReplyDeliveryMode }
+        : {}),
+      ...(payload.sourceReplySink ? { sourceReplySink: payload.sourceReplySink } : {}),
+      dryRun: payload.dryRun,
+    },
   };
 }
 


### PR DESCRIPTION
## Summary
- record successful internal WebChat message-tool replies as `messagingToolSourceReplyPayloads` so the existing `sourceReplyTranscriptMirror` path persists them for reload/history
- keep internal-ui message tool results compact while exposing non-body metadata needed for durable mirrors
- cover text, media, caption fallback, directive-normalized media, sanitized text/presentation, structured-only, routed, and dry-run source reply cases

Fixes #84268
Refs #84773

Autoreview findings fixed:
- caption-only media replies now preserve caption text
- directive/escaped-newline/media/audio sends now mirror normalized payload shape
- mirrored replies reuse the live send sanitizer so hidden reasoning text is not persisted
- normalized runner media metadata is preferred over raw tool args
- whitespace message plus caption fallback mirrors the caption
- structured-only presentations synthesize durable transcript text

## Verification
- `AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --mode branch` -> clean after fixing accepted findings
- `pnpm tsgo:core`
- `node scripts/run-oxlint.mjs ...`
- `./node_modules/.bin/oxfmt --check --threads=1 ...`
- `git diff --check`
- `pnpm exec tsx -e ...` direct handler probes for normal, caption fallback, sanitized text/presentation, normalized media, and structured-only internal-ui message sends

Behavior addressed: WebChat message-tool-only replies now persist through transcript mirroring instead of disappearing after history reload.
Real environment tested: local OpenClaw source checkout.
Exact steps or command run after this patch: direct subscribe handler probes plus core type/lint/format/diff checks listed above.
Evidence after fix: successful internal-ui sends populate `messagingToolSourceReplyPayloads`, which existing payload builder consumes as `sourceReplyTranscriptMirror`.
Observed result after fix: text/media/caption/directive-normalized/sanitized/structured source reply payloads are captured; routed and dry-run sends are ignored.
What was not tested: targeted Vitest runs stalled locally in Rolldown transform/plugin timing before executing; no live browser reload session was run.
