### PR TITLE
fix(codex): await computer use elicitation bridge

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -743,6 +743,11 @@ The default manifest enables the Slack App Home **Home** tab and subscribes to `
       "usage_hint": "host=<auto|sandbox|gateway|node> security=<deny|allowlist|full> ask=<off|on-miss|always> node=<id>"
     },
     {
+      "command": "/approve",
+      "description": "Approve or deny pending approval requests",
+      "usage_hint": "<id> <decision>"
+    },
+    {
       "command": "/model",
       "description": "Show or set the model",
       "usage_hint": "[name|#|status]"

--- a/extensions/codex/src/app-server/elicitation-bridge.test.ts
+++ b/extensions/codex/src/app-server/elicitation-bridge.test.ts
@@ -319,7 +319,6 @@ describe("Codex app-server elicitation bridge", () => {
       threadId: "thread-1",
       turnId: "turn-1",
       pluginAppPolicyContext: createPluginAppPolicyContext({ apps: [] }),
-      computerUseMcpServerName: "computer-use",
     });
 
     expect(result).toEqual({
@@ -347,7 +346,6 @@ describe("Codex app-server elicitation bridge", () => {
       threadId: "thread-1",
       turnId: "turn-1",
       pluginAppPolicyContext: createPluginAppPolicyContext({ apps: [] }),
-      computerUseMcpServerName: "computer-use",
     });
 
     expect(result).toEqual({
@@ -366,37 +364,10 @@ describe("Codex app-server elicitation bridge", () => {
       threadId: "thread-1",
       turnId: "turn-1",
       pluginAppPolicyContext: createPluginAppPolicyContext({ apps: [] }),
-      computerUseMcpServerName: "computer-use",
     });
 
     expect(result).toBeUndefined();
     expect(mockCallGatewayTool).not.toHaveBeenCalled();
-  });
-
-  it("routes configured custom Computer Use server names through plugin approvals", async () => {
-    mockCallGatewayTool
-      .mockResolvedValueOnce({ id: "plugin:approval-custom-computer-use", status: "accepted" })
-      .mockResolvedValueOnce({
-        id: "plugin:approval-custom-computer-use",
-        decision: "allow-once",
-      });
-
-    const result = await handleCodexAppServerElicitationRequest({
-      requestParams: buildComputerUseApprovalElicitation({ serverName: "desktop-control" }),
-      paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
-      pluginAppPolicyContext: createPluginAppPolicyContext({ apps: [] }),
-      computerUseMcpServerName: "desktop-control",
-    });
-
-    expect(result).toEqual({
-      action: "accept",
-      content: null,
-      _meta: null,
-    });
-    const approvalRequest = gatewayToolArg(0, 2) as { description: string };
-    expect(approvalRequest.description).toContain("MCP server: desktop-control");
   });
 
   it("declines approved Computer Use app approvals with unmappable non-empty schemas", async () => {
@@ -422,7 +393,6 @@ describe("Codex app-server elicitation bridge", () => {
       threadId: "thread-1",
       turnId: "turn-1",
       pluginAppPolicyContext: createPluginAppPolicyContext({ apps: [] }),
-      computerUseMcpServerName: "computer-use",
     });
 
     expect(result).toEqual({ action: "decline", content: null, _meta: null });
@@ -439,7 +409,14 @@ describe("Codex app-server elicitation bridge", () => {
     );
   });
 
-  it("does not bridge Computer Use elicitations without an approval form schema", async () => {
+  it("normalizes missing Computer Use schemas to the empty object schema", async () => {
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "plugin:approval-computer-use-schema", status: "accepted" })
+      .mockResolvedValueOnce({
+        id: "plugin:approval-computer-use-schema",
+        decision: "allow-once",
+      });
+
     const result = await handleCodexAppServerElicitationRequest({
       requestParams: buildComputerUseApprovalElicitation({
         requestedSchema: "not-a-schema",
@@ -448,27 +425,13 @@ describe("Codex app-server elicitation bridge", () => {
       threadId: "thread-1",
       turnId: "turn-1",
       pluginAppPolicyContext: createPluginAppPolicyContext({ apps: [] }),
-      computerUseMcpServerName: "computer-use",
     });
 
-    expect(result).toBeUndefined();
-    expect(mockCallGatewayTool).not.toHaveBeenCalled();
-  });
-
-  it("does not bridge Computer Use elicitations outside form mode", async () => {
-    const result = await handleCodexAppServerElicitationRequest({
-      requestParams: buildComputerUseApprovalElicitation({
-        mode: "notification",
-      }),
-      paramsForRun: createParams(),
-      threadId: "thread-1",
-      turnId: "turn-1",
-      pluginAppPolicyContext: createPluginAppPolicyContext({ apps: [] }),
-      computerUseMcpServerName: "computer-use",
+    expect(result).toEqual({
+      action: "accept",
+      content: null,
+      _meta: null,
     });
-
-    expect(result).toBeUndefined();
-    expect(mockCallGatewayTool).not.toHaveBeenCalled();
   });
 
   it("falls back to a Computer Use approval title and sanitizes server names", async () => {
@@ -486,7 +449,6 @@ describe("Codex app-server elicitation bridge", () => {
       threadId: "thread-1",
       turnId: "turn-1",
       pluginAppPolicyContext: createPluginAppPolicyContext({ apps: [] }),
-      computerUseMcpServerName: "computer-use\u009b31m",
     });
 
     expect(result).toEqual({

--- a/extensions/codex/src/app-server/elicitation-bridge.test.ts
+++ b/extensions/codex/src/app-server/elicitation-bridge.test.ts
@@ -319,6 +319,7 @@ describe("Codex app-server elicitation bridge", () => {
       threadId: "thread-1",
       turnId: "turn-1",
       pluginAppPolicyContext: createPluginAppPolicyContext({ apps: [] }),
+      computerUseMcpServerName: "computer-use",
     });
 
     expect(result).toEqual({
@@ -346,6 +347,7 @@ describe("Codex app-server elicitation bridge", () => {
       threadId: "thread-1",
       turnId: "turn-1",
       pluginAppPolicyContext: createPluginAppPolicyContext({ apps: [] }),
+      computerUseMcpServerName: "computer-use",
     });
 
     expect(result).toEqual({
@@ -364,10 +366,37 @@ describe("Codex app-server elicitation bridge", () => {
       threadId: "thread-1",
       turnId: "turn-1",
       pluginAppPolicyContext: createPluginAppPolicyContext({ apps: [] }),
+      computerUseMcpServerName: "computer-use",
     });
 
     expect(result).toBeUndefined();
     expect(mockCallGatewayTool).not.toHaveBeenCalled();
+  });
+
+  it("routes configured custom Computer Use server names through plugin approvals", async () => {
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "plugin:approval-custom-computer-use", status: "accepted" })
+      .mockResolvedValueOnce({
+        id: "plugin:approval-custom-computer-use",
+        decision: "allow-once",
+      });
+
+    const result = await handleCodexAppServerElicitationRequest({
+      requestParams: buildComputerUseApprovalElicitation({ serverName: "desktop-control" }),
+      paramsForRun: createParams(),
+      threadId: "thread-1",
+      turnId: "turn-1",
+      pluginAppPolicyContext: createPluginAppPolicyContext({ apps: [] }),
+      computerUseMcpServerName: "desktop-control",
+    });
+
+    expect(result).toEqual({
+      action: "accept",
+      content: null,
+      _meta: null,
+    });
+    const approvalRequest = gatewayToolArg(0, 2) as { description: string };
+    expect(approvalRequest.description).toContain("MCP server: desktop-control");
   });
 
   it("declines approved Computer Use app approvals with unmappable non-empty schemas", async () => {
@@ -393,6 +422,7 @@ describe("Codex app-server elicitation bridge", () => {
       threadId: "thread-1",
       turnId: "turn-1",
       pluginAppPolicyContext: createPluginAppPolicyContext({ apps: [] }),
+      computerUseMcpServerName: "computer-use",
     });
 
     expect(result).toEqual({ action: "decline", content: null, _meta: null });
@@ -425,6 +455,7 @@ describe("Codex app-server elicitation bridge", () => {
       threadId: "thread-1",
       turnId: "turn-1",
       pluginAppPolicyContext: createPluginAppPolicyContext({ apps: [] }),
+      computerUseMcpServerName: "computer-use",
     });
 
     expect(result).toEqual({
@@ -432,6 +463,22 @@ describe("Codex app-server elicitation bridge", () => {
       content: null,
       _meta: null,
     });
+  });
+
+  it("does not bridge Computer Use elicitations outside form mode", async () => {
+    const result = await handleCodexAppServerElicitationRequest({
+      requestParams: buildComputerUseApprovalElicitation({
+        mode: "notification",
+      }),
+      paramsForRun: createParams(),
+      threadId: "thread-1",
+      turnId: "turn-1",
+      pluginAppPolicyContext: createPluginAppPolicyContext({ apps: [] }),
+      computerUseMcpServerName: "computer-use",
+    });
+
+    expect(result).toBeUndefined();
+    expect(mockCallGatewayTool).not.toHaveBeenCalled();
   });
 
   it("falls back to a Computer Use approval title and sanitizes server names", async () => {
@@ -449,6 +496,7 @@ describe("Codex app-server elicitation bridge", () => {
       threadId: "thread-1",
       turnId: "turn-1",
       pluginAppPolicyContext: createPluginAppPolicyContext({ apps: [] }),
+      computerUseMcpServerName: "computer-use\u009b31m",
     });
 
     expect(result).toEqual({

--- a/extensions/codex/src/app-server/elicitation-bridge.ts
+++ b/extensions/codex/src/app-server/elicitation-bridge.ts
@@ -43,7 +43,9 @@ const MCP_TOOL_APPROVAL_TOOL_PARAMS_DISPLAY_KEY = "tool_params_display";
 const MCP_TOOL_APPROVAL_SOURCE_KEY = "source";
 const MCP_TOOL_APPROVAL_CONNECTOR_SOURCE = "connector";
 const CODEX_APPS_SERVER_NAME = "codex_apps";
+const COMPUTER_USE_SERVER_NAME_FRAGMENT = "computer-use";
 const COMPUTER_USE_APPROVAL_TITLE = "Computer Use approval";
+const EMPTY_OBJECT_SCHEMA: JsonObject = { type: "object", properties: {} };
 const PLUGIN_APP_ID_META_KEYS = ["app_id", "appId", "codex_app_id", "codexAppId"];
 const PLUGIN_CONNECTOR_ID_META_KEYS = ["connector_id", "connectorId"];
 const PLUGIN_NAME_META_KEYS = ["plugin_name", "pluginName", "codex_plugin_name", "codexPluginName"];
@@ -83,7 +85,6 @@ export async function handleCodexAppServerElicitationRequest(params: {
   threadId: string;
   turnId: string;
   pluginAppPolicyContext?: PluginAppPolicyContext;
-  computerUseMcpServerName?: string;
   signal?: AbortSignal;
 }): Promise<JsonValue | undefined> {
   const requestParams = isJsonObject(params.requestParams) ? params.requestParams : undefined;
@@ -113,7 +114,7 @@ export async function handleCodexAppServerElicitationRequest(params: {
   }
 
   const approvalPrompt =
-    readComputerUseApprovalElicitation(requestParams, params.computerUseMcpServerName) ??
+    readComputerUseApprovalElicitation(requestParams) ??
     readBridgeableApprovalElicitation(requestParams);
   if (!approvalPrompt) {
     return undefined;
@@ -356,20 +357,15 @@ function readBridgeableApprovalElicitation(
 
 function readComputerUseApprovalElicitation(
   requestParams: JsonObject | undefined,
-  expectedServerName: string | undefined,
 ): BridgeableApprovalElicitation | undefined {
   const serverName = readString(requestParams, "serverName");
-  if (
-    !serverName ||
-    !expectedServerName ||
-    serverName !== expectedServerName ||
-    readString(requestParams, "mode") !== "form" ||
-    !isJsonObject(requestParams?.requestedSchema)
-  ) {
+  if (!serverName?.includes(COMPUTER_USE_SERVER_NAME_FRAGMENT)) {
     return undefined;
   }
 
-  const requestedSchema = requestParams.requestedSchema;
+  const requestedSchema = isJsonObject(requestParams?.requestedSchema)
+    ? requestParams.requestedSchema
+    : EMPTY_OBJECT_SCHEMA;
   if (
     readString(requestedSchema, "type") !== "object" ||
     !isJsonObject(requestedSchema.properties)

--- a/extensions/codex/src/app-server/elicitation-bridge.ts
+++ b/extensions/codex/src/app-server/elicitation-bridge.ts
@@ -43,7 +43,6 @@ const MCP_TOOL_APPROVAL_TOOL_PARAMS_DISPLAY_KEY = "tool_params_display";
 const MCP_TOOL_APPROVAL_SOURCE_KEY = "source";
 const MCP_TOOL_APPROVAL_CONNECTOR_SOURCE = "connector";
 const CODEX_APPS_SERVER_NAME = "codex_apps";
-const COMPUTER_USE_SERVER_NAME_FRAGMENT = "computer-use";
 const COMPUTER_USE_APPROVAL_TITLE = "Computer Use approval";
 const EMPTY_OBJECT_SCHEMA: JsonObject = { type: "object", properties: {} };
 const PLUGIN_APP_ID_META_KEYS = ["app_id", "appId", "codex_app_id", "codexAppId"];
@@ -85,6 +84,7 @@ export async function handleCodexAppServerElicitationRequest(params: {
   threadId: string;
   turnId: string;
   pluginAppPolicyContext?: PluginAppPolicyContext;
+  computerUseMcpServerName?: string;
   signal?: AbortSignal;
 }): Promise<JsonValue | undefined> {
   const requestParams = isJsonObject(params.requestParams) ? params.requestParams : undefined;
@@ -114,7 +114,7 @@ export async function handleCodexAppServerElicitationRequest(params: {
   }
 
   const approvalPrompt =
-    readComputerUseApprovalElicitation(requestParams) ??
+    readComputerUseApprovalElicitation(requestParams, params.computerUseMcpServerName) ??
     readBridgeableApprovalElicitation(requestParams);
   if (!approvalPrompt) {
     return undefined;
@@ -357,9 +357,15 @@ function readBridgeableApprovalElicitation(
 
 function readComputerUseApprovalElicitation(
   requestParams: JsonObject | undefined,
+  expectedServerName: string | undefined,
 ): BridgeableApprovalElicitation | undefined {
   const serverName = readString(requestParams, "serverName");
-  if (!serverName?.includes(COMPUTER_USE_SERVER_NAME_FRAGMENT)) {
+  if (
+    !serverName ||
+    !expectedServerName ||
+    serverName !== expectedServerName ||
+    readString(requestParams, "mode") !== "form"
+  ) {
     return undefined;
   }
 

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -7071,12 +7071,16 @@ describe("runCodexAppServerAttempt", () => {
         return {
           marketplaces: [
             {
-              name: "openai-curated",
-              path: "/marketplaces/openai-curated",
+              name: "openai-bundled",
+              path: "/marketplaces/openai-bundled",
               plugins: [
                 {
-                  id: "computer-use",
+                  id: "computer-use@openai-bundled",
                   name: "computer-use",
+                  source: {
+                    type: "local",
+                    path: "/marketplaces/openai-bundled/plugins/computer-use",
+                  },
                   installed: true,
                   enabled: true,
                 },
@@ -7090,11 +7094,15 @@ describe("runCodexAppServerAttempt", () => {
       if (method === "plugin/read") {
         return {
           plugin: {
-            marketplaceName: "openai-curated",
-            marketplacePath: "/marketplaces/openai-curated",
+            marketplaceName: "openai-bundled",
+            marketplacePath: "/marketplaces/openai-bundled",
             summary: {
-              id: "computer-use",
+              id: "computer-use@openai-bundled",
               name: "computer-use",
+              source: {
+                type: "local",
+                path: "/marketplaces/openai-bundled/plugins/computer-use",
+              },
               installed: true,
               enabled: true,
             },
@@ -7109,7 +7117,7 @@ describe("runCodexAppServerAttempt", () => {
         return {
           data: [
             {
-              name: "computer-use",
+              name: "desktop-control",
               tools: {
                 "computer-use.get_app_state": {},
               },
@@ -7153,7 +7161,8 @@ describe("runCodexAppServerAttempt", () => {
         pluginConfig: {
           computerUse: {
             enabled: true,
-            marketplaceName: "openai-curated",
+            marketplaceName: "openai-bundled",
+            mcpServerName: "desktop-control",
           },
         },
       },
@@ -7166,7 +7175,7 @@ describe("runCodexAppServerAttempt", () => {
       params: {
         threadId: "thread-1",
         turnId: "turn-1",
-        serverName: "computer-use",
+        serverName: "desktop-control",
         mode: "form",
       },
     });
@@ -7179,13 +7188,15 @@ describe("runCodexAppServerAttempt", () => {
     const [bridgeCall] = mockCall(bridgeSpy, "elicitation bridge") as [
       {
         requestParams?: { serverName?: string };
+        computerUseMcpServerName?: string;
         threadId?: string;
         turnId?: string;
       },
     ];
     expect(bridgeCall.threadId).toBe("thread-1");
     expect(bridgeCall.turnId).toBe("turn-1");
-    expect(bridgeCall.requestParams?.serverName).toBe("computer-use");
+    expect(bridgeCall.requestParams?.serverName).toBe("desktop-control");
+    expect(bridgeCall.computerUseMcpServerName).toBe("desktop-control");
     const requestCalls = request.mock.calls as unknown as Array<[string, unknown, unknown?]>;
     const threadStart = requestCalls.find(([method]) => method === "thread/start");
     const threadStartParams = threadStart?.[1] as

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -7071,16 +7071,12 @@ describe("runCodexAppServerAttempt", () => {
         return {
           marketplaces: [
             {
-              name: "openai-bundled",
-              path: "/marketplaces/openai-bundled",
+              name: "openai-curated",
+              path: "/marketplaces/openai-curated",
               plugins: [
                 {
-                  id: "computer-use@openai-bundled",
+                  id: "computer-use",
                   name: "computer-use",
-                  source: {
-                    type: "local",
-                    path: "/marketplaces/openai-bundled/plugins/computer-use",
-                  },
                   installed: true,
                   enabled: true,
                 },
@@ -7094,15 +7090,11 @@ describe("runCodexAppServerAttempt", () => {
       if (method === "plugin/read") {
         return {
           plugin: {
-            marketplaceName: "openai-bundled",
-            marketplacePath: "/marketplaces/openai-bundled",
+            marketplaceName: "openai-curated",
+            marketplacePath: "/marketplaces/openai-curated",
             summary: {
-              id: "computer-use@openai-bundled",
+              id: "computer-use",
               name: "computer-use",
-              source: {
-                type: "local",
-                path: "/marketplaces/openai-bundled/plugins/computer-use",
-              },
               installed: true,
               enabled: true,
             },
@@ -7117,7 +7109,7 @@ describe("runCodexAppServerAttempt", () => {
         return {
           data: [
             {
-              name: "desktop-control",
+              name: "computer-use",
               tools: {
                 "computer-use.get_app_state": {},
               },
@@ -7161,8 +7153,7 @@ describe("runCodexAppServerAttempt", () => {
         pluginConfig: {
           computerUse: {
             enabled: true,
-            marketplaceName: "openai-bundled",
-            mcpServerName: "desktop-control",
+            marketplaceName: "openai-curated",
           },
         },
       },
@@ -7175,7 +7166,7 @@ describe("runCodexAppServerAttempt", () => {
       params: {
         threadId: "thread-1",
         turnId: "turn-1",
-        serverName: "desktop-control",
+        serverName: "computer-use",
         mode: "form",
       },
     });
@@ -7188,15 +7179,13 @@ describe("runCodexAppServerAttempt", () => {
     const [bridgeCall] = mockCall(bridgeSpy, "elicitation bridge") as [
       {
         requestParams?: { serverName?: string };
-        computerUseMcpServerName?: string;
         threadId?: string;
         turnId?: string;
       },
     ];
     expect(bridgeCall.threadId).toBe("thread-1");
     expect(bridgeCall.turnId).toBe("turn-1");
-    expect(bridgeCall.requestParams?.serverName).toBe("desktop-control");
-    expect(bridgeCall.computerUseMcpServerName).toBe("desktop-control");
+    expect(bridgeCall.requestParams?.serverName).toBe("computer-use");
     const requestCalls = request.mock.calls as unknown as Array<[string, unknown, unknown?]>;
     const threadStart = requestCalls.find(([method]) => method === "thread/start");
     const threadStartParams = threadStart?.[1] as

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -3276,6 +3276,85 @@ describe("runCodexAppServerAttempt", () => {
     expect(result.promptError).toBeNull();
   });
 
+  it("keeps turn request activity active until elicitation handling resolves", async () => {
+    const harness = createStartedThreadHarness();
+    const bridgedResponse = {
+      action: "accept",
+      content: null,
+      _meta: null,
+    } as const;
+    let resolveBridge!: (value: typeof bridgedResponse) => void;
+    const bridgePromise = new Promise<typeof bridgedResponse>((resolve) => {
+      resolveBridge = resolve;
+    });
+    vi.spyOn(elicitationBridge, "handleCodexAppServerElicitationRequest").mockImplementation(
+      async () => await bridgePromise,
+    );
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+    params.timeoutMs = 500;
+    const onRunProgress = vi.fn();
+    params.onRunProgress = onRunProgress;
+
+    const run = runCodexAppServerAttempt(params, {
+      turnCompletionIdleTimeoutMs: 1_000,
+      turnAssistantCompletionIdleTimeoutMs: 1_000,
+      turnTerminalIdleTimeoutMs: 1_000,
+    });
+    await harness.waitForMethod("turn/start");
+
+    const response = harness.handleServerRequest({
+      id: "request-pending-elicitation",
+      method: "mcpServer/elicitation/request",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        mode: "form",
+        message: "Approve?",
+        requestedSchema: { type: "object", properties: {} },
+        serverName: "server-1",
+        _meta: null,
+      },
+    });
+    await vi.waitFor(
+      () =>
+        expect(onRunProgress).toHaveBeenCalledWith(
+          expect.objectContaining({
+            reason: "request:mcpServer/elicitation/request:start",
+          }),
+        ),
+      fastWait,
+    );
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    expect(
+      onRunProgress.mock.calls.some(
+        ([event]) =>
+          (event as { reason?: string }).reason ===
+          "request:mcpServer/elicitation/request:response",
+      ),
+    ).toBe(false);
+
+    resolveBridge(bridgedResponse);
+    await expect(response).resolves.toEqual(bridgedResponse);
+    await vi.waitFor(
+      () =>
+        expect(onRunProgress).toHaveBeenCalledWith(
+          expect.objectContaining({
+            reason: "request:mcpServer/elicitation/request:response",
+          }),
+        ),
+      fastWait,
+    );
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+
+    const result = await run;
+    expect(result.aborted).toBe(false);
+    expect(result.timedOut).toBe(false);
+    expect(result.promptError).toBeNull();
+  });
+
   it("counts pending user input requests as turn attempt progress", async () => {
     const harness = createStartedThreadHarness();
     const params = createParams(

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -2059,7 +2059,7 @@ export async function runCodexAppServerAttempt(
           armCompletionWatchOnResponse = true;
           markCurrentTurnRequestProgress();
         }
-        return handleCodexAppServerElicitationRequest({
+        return await handleCodexAppServerElicitationRequest({
           requestParams: request.params,
           paramsForRun: params,
           threadId: thread.threadId,

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -1239,7 +1239,8 @@ export async function runCodexAppServerAttempt(
     const resolvedPluginPolicy = pluginThreadConfigRequired
       ? resolveCodexPluginsPolicy(pluginThreadConfigPluginConfig)
       : undefined;
-    const computerUseMcpElicitationDelegationRequired = computerUseConfig.enabled;
+    const computerUseMcpElicitationDelegationRequired =
+      computerUseConfig.enabled && computerUseConfig.mcpServerName.includes("computer-use");
     const mcpElicitationDelegationRequired =
       resolvedPluginPolicy?.enabled === true || computerUseMcpElicitationDelegationRequired;
     const enabledPluginConfigKeys = resolvedPluginPolicy
@@ -2065,9 +2066,6 @@ export async function runCodexAppServerAttempt(
           threadId: thread.threadId,
           turnId,
           pluginAppPolicyContext: thread.pluginAppPolicyContext,
-          ...(computerUseConfig.enabled
-            ? { computerUseMcpServerName: computerUseConfig.mcpServerName }
-            : {}),
           signal: runAbortController.signal,
         });
       }

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -1239,8 +1239,7 @@ export async function runCodexAppServerAttempt(
     const resolvedPluginPolicy = pluginThreadConfigRequired
       ? resolveCodexPluginsPolicy(pluginThreadConfigPluginConfig)
       : undefined;
-    const computerUseMcpElicitationDelegationRequired =
-      computerUseConfig.enabled && computerUseConfig.mcpServerName.includes("computer-use");
+    const computerUseMcpElicitationDelegationRequired = computerUseConfig.enabled;
     const mcpElicitationDelegationRequired =
       resolvedPluginPolicy?.enabled === true || computerUseMcpElicitationDelegationRequired;
     const enabledPluginConfigKeys = resolvedPluginPolicy
@@ -2066,6 +2065,9 @@ export async function runCodexAppServerAttempt(
           threadId: thread.threadId,
           turnId,
           pluginAppPolicyContext: thread.pluginAppPolicyContext,
+          ...(computerUseConfig.enabled
+            ? { computerUseMcpServerName: computerUseConfig.mcpServerName }
+            : {}),
           signal: runAbortController.signal,
         });
       }


### PR DESCRIPTION
## Summary

- Problem: configured Computer Use MCP approval elicitations can arrive without a JSON-object `requestedSchema`, and the app-server request handler returned the asynchronous elicitation bridge promise without awaiting it, letting request-response bookkeeping/finally run before the bridge settled.
- Solution: keep the exact configured MCP server-name boundary and form-mode guard, normalize missing or non-object Computer Use schemas to an empty object schema, and use `return await handleCodexAppServerElicitationRequest(...)` so request-response bookkeeping/finally waits for the approval bridge result.
- What changed: schema-less Computer Use form elicitations normalize to `{ type: "object", properties: {} }`, custom configured Computer Use server names remain supported, pending approval elicitations keep the turn request active until the bridge resolves, non-form elicitations remain unhandled, the app-server bridge tests cover those cases, and Slack docs list `/approve`.
- What did NOT change (scope boundary): No native Slack UI behavior, gateway approval transport, broad server-name fragment matching, or non-Computer Use plugin approval policy is changed.

## Motivation

- This preserves the cherry-picked bridge elicitation fix on top of current `main` while keeping the existing configured-server authorization boundary intact and preserving the manual approval request lifetime.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: configured Computer Use app-server MCP form elicitations are routed into plugin approvals even when the elicitation request does not include an object schema, and the app-server request activity remains active until the approval bridge resolves.
- Real environment tested: Local OpenClaw Codex worktree unit/seam tests.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts extensions/codex/src/app-server/elicitation-bridge.test.ts`; `git diff --check`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): `Test Files 2 passed (2); Tests 230 passed (230)` and `git diff --check` exited cleanly.
- Observed result after fix: The focused app-server bridge suites pass with configured Computer Use elicitations bridged through plugin approval handling, including schema-less elicitations, custom configured server names, and pending approval request lifetime tracking.
- What was not tested: Live Slack plus Computer Use roundtrip was not rerun in this cherry-pick PR.
- Before evidence (optional but encouraged): N/A.

## Root Cause (if applicable)

- Root cause: The bridge rejected non-object `requestedSchema` values before plugin approval handling could accept a valid configured Computer Use form elicitation. Separately, returning the bridge promise from inside a `try/finally` without `await` let request-response bookkeeping run before manual approval finished.
- Missing detection / guardrail: Coverage did not lock schema-less Computer Use elicitation requests while preserving exact configured server-name matching, the form-mode guard, and pending request lifetime.
- Contributing context (if known): This change is a current-main cherry-pick of the bridge elicitation fix plus the await fix needed for the async approval bridge callsite.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/codex/src/app-server/elicitation-bridge.test.ts`; `extensions/codex/src/app-server/run-attempt.test.ts`.
- Scenario the test should lock in: configured Computer Use form elicitations bridge with missing schemas normalized to an empty object schema, custom configured server names still work, non-form/non-Computer Use elicitations remain unhandled, and the request `:response` progress marker does not fire until the elicitation bridge promise resolves.
- Why this is the smallest reliable guardrail: The bug is in the app-server bridge decision and request-handler lifetime path, so focused app-server tests exercise the contract without requiring a live channel.
- Existing test that already covers this (if any): Existing bridge tests covered approval roundtrip mapping, but not this schema shape with the configured-server boundary or the async request lifetime.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Slack channel docs now list `/approve` among app commands. Computer Use app-server approval elicitations are more reliably bridged into plugin approval handling when their request schema is omitted or not an object, and pending approval requests are not treated as responded before the approval bridge resolves.

## Diagram (if applicable)

```text
Before:
[configured Computer Use form elicitation] -> [non-object schema rejection] -> [falls through]
[pending approval bridge promise] -> [request finally runs early] -> [turn can idle/complete too soon]

After:
[configured Computer Use form elicitation] -> [empty schema normalization] -> [plugin approval bridge]
[pending approval bridge promise] -> [await bridge] -> [request finally runs after approval response]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node via `scripts/run-vitest.mjs`
- Model/provider: N/A
- Integration/channel (if any): Codex app-server / Computer Use MCP elicitation bridge
- Relevant config (redacted): N/A

### Steps

1. Run `node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts extensions/codex/src/app-server/elicitation-bridge.test.ts`.
2. Run `git diff --check`.

### Expected

- Focused app-server bridge tests pass and the diff has no whitespace errors.

### Actual

- `Test Files 2 passed (2); Tests 230 passed (230)`.
- `git diff --check` exited cleanly.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Focused app-server bridge tests for configured Computer Use elicitation routing, run-attempt delegation, and pending elicitation request lifetime.
- Edge cases checked: Missing or non-object Computer Use schema normalizes to an empty object schema; custom configured `desktop-control` server names work; non-form elicitations remain unhandled; non-Computer Use server names remain unhandled by the Computer Use bridge; request response progress is emitted only after the bridge promise resolves.
- What you did **not** verify: Live Slack plus Computer Use roundtrip for this branch.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: accepting a missing or non-object schema for configured Computer Use elicitations relaxes schema validation for this bridge path.
  - Mitigation: the exact configured MCP server-name check and `mode: "form"` guard remain in place, the normalized response schema has no fields, and focused tests cover custom configured servers plus non-form rejection.
- Risk: awaiting the bridge can keep the app-server request open while manual approval is pending.
  - Mitigation: this is the intended request lifetime; the existing run abort signal and turn idle controls still bound the attempt, and focused coverage verifies response bookkeeping waits for bridge completion.
