### PR TITLE
fix: expose SDK aliases to external plugin runtimes

### DIFF
--- a/src/plugin-sdk/discord.test.ts
+++ b/src/plugin-sdk/discord.test.ts
@@ -40,6 +40,8 @@ const mocks = vi.hoisted(() => {
     editDiscordComponentMessage: vi.fn(async () => ({ id: "message" })),
     listThreadBindingsBySessionKey: vi.fn(() => []),
     registerBuiltDiscordComponentMessage: vi.fn(),
+    sendDiscordComponentMessage: vi.fn(async () => ({ id: "component" })),
+    sendPollDiscord: vi.fn(async () => ({ id: "poll" })),
     unbindThreadBindingsBySessionKey: vi.fn(() => []),
   };
 
@@ -107,6 +109,8 @@ describe("discord plugin-sdk facade", () => {
       "editDiscordComponentMessage",
       "registerBuiltDiscordComponentMessage",
       "resolveConfiguredFromCredentialStatuses",
+      "sendDiscordComponentMessage",
+      "sendPollDiscord",
       "resolveDefaultDiscordAccountId",
       "resolveDiscordAccount",
       "resolveDiscordGroupRequireMention",
@@ -117,11 +121,13 @@ describe("discord plugin-sdk facade", () => {
     }
   });
 
-  it("forwards Discord component helpers through the facade", async () => {
+  it("forwards Discord component and poll helpers through the facade", async () => {
     const {
       buildDiscordComponentMessage,
       editDiscordComponentMessage,
       registerBuiltDiscordComponentMessage,
+      sendDiscordComponentMessage,
+      sendPollDiscord,
     } = await import("./discord.js");
 
     const built = buildDiscordComponentMessage({ spec: { text: "hello" } });
@@ -130,6 +136,12 @@ describe("discord plugin-sdk facade", () => {
       "message",
       { text: "edited" },
       { cfg: mocks.runtimeConfig },
+    );
+    await sendDiscordComponentMessage("channel", { text: "sent" }, { cfg: mocks.runtimeConfig });
+    await sendPollDiscord(
+      "channel",
+      { question: "Ship?", options: ["Yes", "No"] },
+      { cfg: mocks.runtimeConfig, content: "Vote" },
     );
     registerBuiltDiscordComponentMessage({
       buildResult: built,
@@ -144,6 +156,16 @@ describe("discord plugin-sdk facade", () => {
       "message",
       { text: "edited" },
       { cfg: mocks.runtimeConfig },
+    );
+    expect(mocks.runtimeModule.sendDiscordComponentMessage).toHaveBeenCalledWith(
+      "channel",
+      { text: "sent" },
+      { cfg: mocks.runtimeConfig },
+    );
+    expect(mocks.runtimeModule.sendPollDiscord).toHaveBeenCalledWith(
+      "channel",
+      { question: "Ship?", options: ["Yes", "No"] },
+      { cfg: mocks.runtimeConfig, content: "Vote" },
     );
     expect(mocks.runtimeModule.registerBuiltDiscordComponentMessage).toHaveBeenCalledWith({
       buildResult: built,

--- a/src/plugin-sdk/discord.ts
+++ b/src/plugin-sdk/discord.ts
@@ -14,6 +14,7 @@ import {
   createLazyFacadeObjectValue,
   loadBundledPluginPublicSurfaceModuleSync,
 } from "./facade-loader.js";
+import type { PollInput } from "./poll-runtime.js";
 import { getRuntimeConfig, getRuntimeConfigSnapshot } from "./runtime-config-snapshot.js";
 
 /**
@@ -24,6 +25,7 @@ export type { ChannelMessageActionAdapter, ChannelMessageActionName } from "./ch
 export type { ChannelPlugin } from "./channel-core.js";
 export type { OpenClawConfig } from "./config-types.js";
 export type { OpenClawPluginApi, PluginRuntime } from "./channel-plugin-common.js";
+export type { PollInput } from "./poll-runtime.js";
 
 export {
   DEFAULT_ACCOUNT_ID,
@@ -126,6 +128,18 @@ type EditDiscordComponentMessage = (
   opts: DiscordComponentSendOpts,
 ) => Promise<DiscordComponentSendResult>;
 
+type SendDiscordComponentMessage = (
+  to: string,
+  spec: DiscordComponentMessageSpec,
+  opts: DiscordComponentSendOpts,
+) => Promise<DiscordComponentSendResult>;
+
+type SendPollDiscord = (
+  to: string,
+  poll: PollInput,
+  opts: DiscordComponentSendOpts & { content?: string },
+) => Promise<DiscordComponentSendResult>;
+
 type RegisterBuiltDiscordComponentMessage = (params: {
   buildResult: DiscordComponentBuildResult;
   messageId: string;
@@ -158,6 +172,8 @@ type DiscordApiFacadeModule = {
 type DiscordRuntimeFacadeModule = {
   editDiscordComponentMessage: EditDiscordComponentMessage;
   registerBuiltDiscordComponentMessage: RegisterBuiltDiscordComponentMessage;
+  sendDiscordComponentMessage: SendDiscordComponentMessage;
+  sendPollDiscord: SendPollDiscord;
   autoBindSpawnedDiscordSubagent: (params: {
     cfg: OpenClawConfig;
     accountId?: string;
@@ -290,6 +306,17 @@ export const editDiscordComponentMessage: DiscordRuntimeFacadeModule["editDiscor
     loadDiscordRuntimeFacadeModule().editDiscordComponentMessage(
       ...args,
     )) as DiscordRuntimeFacadeModule["editDiscordComponentMessage"];
+
+export const sendDiscordComponentMessage: DiscordRuntimeFacadeModule["sendDiscordComponentMessage"] =
+  ((...args) =>
+    loadDiscordRuntimeFacadeModule().sendDiscordComponentMessage(
+      ...args,
+    )) as DiscordRuntimeFacadeModule["sendDiscordComponentMessage"];
+
+export const sendPollDiscord: DiscordRuntimeFacadeModule["sendPollDiscord"] = ((...args) =>
+  loadDiscordRuntimeFacadeModule().sendPollDiscord(
+    ...args,
+  )) as DiscordRuntimeFacadeModule["sendPollDiscord"];
 
 export const registerBuiltDiscordComponentMessage: DiscordRuntimeFacadeModule["registerBuiltDiscordComponentMessage"] =
   ((...args) =>

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -125,6 +125,7 @@ import {
   serializePluginIdScope,
 } from "./plugin-scope.js";
 import { ensureOpenClawPluginSdkAlias } from "./plugin-sdk-dist-alias.js";
+import { installOpenClawPluginSdkNativeResolver } from "./plugin-sdk-native-resolver.js";
 import { createEmptyPluginRegistry } from "./registry-empty.js";
 import type { PluginRegistryParams } from "./registry-types.js";
 import { createPluginRegistry, type PluginRecord, type PluginRegistry } from "./registry.js";
@@ -519,6 +520,11 @@ function runPluginRegisterSync(
 }
 
 function createPluginModuleLoader(options: Pick<PluginLoadOptions, "pluginSdkResolution">) {
+  installOpenClawPluginSdkNativeResolver({
+    argv1: process.argv[1],
+    moduleUrl: import.meta.url,
+    pluginSdkResolution: options.pluginSdkResolution,
+  });
   const moduleLoaders: PluginModuleLoaderCache = createPluginModuleLoaderCache();
   const createLoaderForModule = (modulePath: string) => {
     return getCachedPluginModuleLoader({

--- a/src/plugins/plugin-sdk-native-resolver.test.ts
+++ b/src/plugins/plugin-sdk-native-resolver.test.ts
@@ -51,6 +51,28 @@ function writeFakeOpenClawPackage(root: string): { distRoot: string; loaderModul
 }
 
 describe("installOpenClawPluginSdkNativeResolver", () => {
+  it("keeps native aliases on JS dist artifacts when source files exist", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sdk-native-source-resolver-"));
+    const { loaderModulePath } = writeFakeOpenClawPackage(root);
+    const sourceDiscordPath = path.join(root, "src", "plugin-sdk", "discord.ts");
+    fs.mkdirSync(path.dirname(sourceDiscordPath), { recursive: true });
+    fs.writeFileSync(sourceDiscordPath, "export const sourceOnly = true;\n", "utf8");
+
+    const installedAliases = installOpenClawPluginSdkNativeResolver({
+      modulePath: loaderModulePath,
+      pluginSdkResolution: "src",
+    });
+
+    expect(installedAliases).toContain("openclaw/plugin-sdk/discord");
+    const externalPluginEntry = path.join(root, "external-plugin", "dist", "runtime-api.js");
+    fs.mkdirSync(path.dirname(externalPluginEntry), { recursive: true });
+    fs.writeFileSync(externalPluginEntry, "export default {};\n", "utf8");
+    const requireFromPlugin = createRequire(externalPluginEntry);
+    expect(fs.realpathSync(requireFromPlugin.resolve("openclaw/plugin-sdk/discord"))).toBe(
+      fs.realpathSync(path.join(root, "dist", "plugin-sdk", "discord.js")),
+    );
+  });
+
   it("lets built external plugins resolve OpenClaw SDK subpaths with createRequire", () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sdk-native-resolver-"));
     const { distRoot, loaderModulePath } = writeFakeOpenClawPackage(root);

--- a/src/plugins/plugin-sdk-native-resolver.test.ts
+++ b/src/plugins/plugin-sdk-native-resolver.test.ts
@@ -1,0 +1,92 @@
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  installOpenClawPluginSdkNativeResolver,
+  resetOpenClawPluginSdkNativeResolverForTest,
+} from "./plugin-sdk-native-resolver.js";
+
+afterEach(() => {
+  resetOpenClawPluginSdkNativeResolverForTest();
+});
+
+function writeJsonFile(targetPath: string, value: unknown): void {
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+  fs.writeFileSync(targetPath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function writeFakeOpenClawPackage(root: string): { distRoot: string; loaderModulePath: string } {
+  writeJsonFile(path.join(root, "package.json"), {
+    name: "openclaw",
+    type: "module",
+    bin: {
+      openclaw: "./openclaw.mjs",
+    },
+    exports: {
+      "./cli-entry": "./dist/cli-entry.js",
+      "./plugin-sdk": "./dist/plugin-sdk/root-alias.cjs",
+      "./plugin-sdk/discord": "./dist/plugin-sdk/discord.js",
+    },
+  });
+  fs.writeFileSync(path.join(root, "openclaw.mjs"), "#!/usr/bin/env node\n", "utf8");
+  const distRoot = path.join(root, "dist");
+  const pluginSdkDir = path.join(distRoot, "plugin-sdk");
+  fs.mkdirSync(pluginSdkDir, { recursive: true });
+  fs.writeFileSync(path.join(pluginSdkDir, "root-alias.cjs"), "module.exports = {};\n", "utf8");
+  fs.writeFileSync(
+    path.join(pluginSdkDir, "discord.js"),
+    [
+      'export const sendDiscordComponentMessage = () => "component";',
+      'export const sendPollDiscord = () => "poll";',
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  const loaderModulePath = path.join(distRoot, "plugins", "loader.js");
+  fs.mkdirSync(path.dirname(loaderModulePath), { recursive: true });
+  fs.writeFileSync(loaderModulePath, "export default {};\n", "utf8");
+  return { distRoot, loaderModulePath };
+}
+
+describe("installOpenClawPluginSdkNativeResolver", () => {
+  it("lets built external plugins resolve OpenClaw SDK subpaths with createRequire", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sdk-native-resolver-"));
+    const { distRoot, loaderModulePath } = writeFakeOpenClawPackage(root);
+    const externalPluginEntry = path.join(root, "external-plugin", "dist", "runtime-api.js");
+    fs.mkdirSync(path.dirname(externalPluginEntry), { recursive: true });
+    fs.writeFileSync(externalPluginEntry, "export default {};\n", "utf8");
+
+    const distMode = fs.statSync(distRoot).mode;
+    if (process.platform !== "win32") {
+      fs.chmodSync(distRoot, 0o555);
+    }
+
+    try {
+      const installedAliases = installOpenClawPluginSdkNativeResolver({
+        modulePath: loaderModulePath,
+        pluginSdkResolution: "dist",
+      });
+
+      expect(installedAliases).toContain("openclaw/plugin-sdk/discord");
+      expect(fs.existsSync(path.join(distRoot, "extensions"))).toBe(false);
+      const requireFromPlugin = createRequire(externalPluginEntry);
+      expect(fs.realpathSync(requireFromPlugin.resolve("openclaw/plugin-sdk/discord"))).toBe(
+        fs.realpathSync(path.join(distRoot, "plugin-sdk", "discord.js")),
+      );
+      const sdk = requireFromPlugin("openclaw/plugin-sdk/discord") as {
+        sendDiscordComponentMessage?: () => string;
+        sendPollDiscord?: () => string;
+      };
+
+      expect(sdk.sendDiscordComponentMessage?.()).toBe("component");
+      expect(sdk.sendPollDiscord?.()).toBe("poll");
+      expect(() => requireFromPlugin.resolve("openclaw/not-plugin-sdk/discord")).toThrow();
+    } finally {
+      if (process.platform !== "win32") {
+        fs.chmodSync(distRoot, distMode);
+      }
+    }
+  });
+});

--- a/src/plugins/plugin-sdk-native-resolver.ts
+++ b/src/plugins/plugin-sdk-native-resolver.ts
@@ -1,0 +1,98 @@
+import Module from "node:module";
+import { fileURLToPath } from "node:url";
+import { buildPluginLoaderAliasMap, type PluginSdkResolutionPreference } from "./sdk-alias.js";
+
+type ResolveFilename = (
+  request: string,
+  parent: NodeJS.Module | undefined,
+  isMain: boolean,
+  options?: { paths?: string[] },
+) => string;
+
+type ModuleWithResolver = typeof Module & {
+  _resolveFilename?: ResolveFilename;
+};
+
+export type InstallOpenClawPluginSdkNativeResolverOptions = {
+  modulePath?: string;
+  argv1?: string;
+  moduleUrl?: string;
+  pluginSdkResolution?: PluginSdkResolutionPreference;
+};
+
+const moduleWithResolver = Module as ModuleWithResolver;
+const PLUGIN_SDK_PACKAGE_PREFIXES = ["openclaw/plugin-sdk", "@openclaw/plugin-sdk"] as const;
+const pluginSdkNativeAliases = new Map<string, string>();
+let installed = false;
+let previousResolveFilename: ResolveFilename | undefined;
+
+function resolveLoaderModulePath(options: InstallOpenClawPluginSdkNativeResolverOptions): string {
+  if (options.modulePath) {
+    return options.modulePath;
+  }
+  return fileURLToPath(options.moduleUrl ?? import.meta.url);
+}
+
+function isPluginSdkAliasSpecifier(specifier: string): boolean {
+  return PLUGIN_SDK_PACKAGE_PREFIXES.some(
+    (prefix) => specifier === prefix || specifier.startsWith(`${prefix}/`),
+  );
+}
+
+function listPluginSdkNativeAliases(
+  options: InstallOpenClawPluginSdkNativeResolverOptions,
+): Array<readonly [string, string]> {
+  const modulePath = resolveLoaderModulePath(options);
+  return Object.entries(
+    buildPluginLoaderAliasMap(
+      modulePath,
+      options.argv1 ?? process.argv[1],
+      options.moduleUrl,
+      options.pluginSdkResolution,
+    ),
+  )
+    .filter(([specifier]) => isPluginSdkAliasSpecifier(specifier))
+    .flatMap(([specifier, target]) => {
+      if (specifier.endsWith(".js")) {
+        return [[specifier, target]] as Array<readonly [string, string]>;
+      }
+      return [
+        [specifier, target],
+        [`${specifier}.js`, target],
+      ] as Array<readonly [string, string]>;
+    });
+}
+
+function installResolver(): void {
+  if (installed || !moduleWithResolver["_resolveFilename"]) {
+    return;
+  }
+  previousResolveFilename = moduleWithResolver["_resolveFilename"];
+  moduleWithResolver["_resolveFilename"] = ((request, parent, isMain, options) => {
+    const aliasTarget = pluginSdkNativeAliases.get(request);
+    if (aliasTarget) {
+      return aliasTarget;
+    }
+    return previousResolveFilename?.(request, parent, isMain, options) ?? request;
+  }) satisfies ResolveFilename;
+  installed = true;
+}
+
+export function installOpenClawPluginSdkNativeResolver(
+  options: InstallOpenClawPluginSdkNativeResolverOptions = {},
+): string[] {
+  for (const [specifier, target] of listPluginSdkNativeAliases(options)) {
+    pluginSdkNativeAliases.set(specifier, target);
+  }
+  installResolver();
+  return [...pluginSdkNativeAliases.keys()].toSorted();
+}
+
+export function resetOpenClawPluginSdkNativeResolverForTest(): void {
+  pluginSdkNativeAliases.clear();
+  if (installed && previousResolveFilename) {
+    moduleWithResolver["_resolveFilename"] = previousResolveFilename;
+  }
+  previousResolveFilename = undefined;
+  installed = false;
+}

--- a/src/plugins/plugin-sdk-native-resolver.ts
+++ b/src/plugins/plugin-sdk-native-resolver.ts
@@ -48,7 +48,9 @@ function listPluginSdkNativeAliases(
       modulePath,
       options.argv1 ?? process.argv[1],
       options.moduleUrl,
-      options.pluginSdkResolution,
+      // Native require hooks must point at JavaScript artifacts, even when the
+      // plugin loader itself is configured to prefer source imports.
+      "dist",
     ),
   )
     .filter(([specifier]) => isPluginSdkAliasSpecifier(specifier))


### PR DESCRIPTION
## Summary

This PR makes external plugin runtimes able to resolve OpenClaw plugin SDK subpaths from built plugin code:

- Adds Discord SDK facade exports for component-message sends and poll sends.
- Installs a narrow native resolver for exact `openclaw/plugin-sdk/*` and `@openclaw/plugin-sdk/*` specifiers so plugin-local `createRequire()` calls can resolve SDK subpaths.
- Avoids runtime writes to the OpenClaw package tree and does not mutate `NODE_PATH`.
- Adds a regression test that keeps the fake OpenClaw `dist` tree read-only and verifies no `dist/extensions` alias tree is created.

## Real Behavior Proof

**Behavior or issue addressed**: Built external plugins can resolve `openclaw/plugin-sdk/discord` from plugin-local `createRequire()` calls at runtime, without a plugin-local `node_modules/openclaw` symlink, without runtime writes to the OpenClaw package tree, and without `NODE_PATH`.

**Real environment tested**: Jafar macOS OpenClaw source checkout at `/tmp/openclaw-mentat-sdk-pr`, head `8cf620cd1d8b6bbb4f6aa3368e6e70641648a28c`, running the built `openclaw.mjs` against the linked Mentat external plugin at `/tmp/mentat-host-proof-2ff049a/packages/mentat-engine`.

**Exact steps or command run after the patch**:

```text
test ! -e /tmp/mentat-host-proof-2ff049a/packages/mentat-engine/node_modules/openclaw
HOME=/tmp/openclaw-mentat-pr-smoke-v2.PDZqMe node /tmp/openclaw-mentat-sdk-pr/openclaw.mjs plugins install --link /tmp/mentat-host-proof-2ff049a/packages/mentat-engine
HOME=/tmp/openclaw-mentat-pr-smoke-v2.PDZqMe node /tmp/openclaw-mentat-sdk-pr/openclaw.mjs plugins inspect mentat-engine --runtime --json
HOME=/tmp/openclaw-mentat-pr-smoke-v2.PDZqMe node /tmp/openclaw-mentat-sdk-pr/openclaw.mjs mentat doctor
HOME=/tmp/openclaw-mentat-pr-smoke-v2.PDZqMe node /tmp/openclaw-mentat-sdk-pr/openclaw.mjs mentat bind --input-json "$INPUT_JSON" --context-json '{"roleBindingId":"discord-smoke","principal":"owner","sessionKind":"owner_cli"}'
HOME=/tmp/openclaw-mentat-pr-smoke-v2.PDZqMe node /tmp/openclaw-mentat-sdk-pr/openclaw.mjs mentat doctor --binding discord-smoke --authority-json '{"roleBindingId":"discord-smoke","principal":"operator_cli","sessionKind":"operator_cli"}'
```

**Evidence after fix**: Terminal output from the real OpenClaw plus linked external Mentat plugin smoke:

```text
$ test ! -e /tmp/mentat-host-proof-2ff049a/packages/mentat-engine/node_modules/openclaw
exit status: 0

$ HOME=/tmp/openclaw-mentat-pr-smoke-v2.PDZqMe node /tmp/openclaw-mentat-sdk-pr/openclaw.mjs plugins inspect mentat-engine --runtime --json
{
  "status": "loaded",
  "toolCount": 18,
  "cliCommands": ["mentat"]
}

$ HOME=/tmp/openclaw-mentat-pr-smoke-v2.PDZqMe node /tmp/openclaw-mentat-sdk-pr/openclaw.mjs mentat doctor
{
  "ok": true,
  "scope": "engine",
  "engineVersion": "0.1.0",
  "issues": []
}

$ HOME=/tmp/openclaw-mentat-pr-smoke-v2.PDZqMe node /tmp/openclaw-mentat-sdk-pr/openclaw.mjs mentat doctor --binding discord-smoke --authority-json '{"roleBindingId":"discord-smoke","principal":"operator_cli","sessionKind":"operator_cli"}'
{
  "ok": true,
  "scope": "binding",
  "engineVersion": "0.1.0",
  "roleBindingId": "discord-smoke",
  "checks": {
    "migrations": true,
    "rolePackSchema": true,
    "adapterAvailability": "ok",
    "discordComponentMessageSendSdk": "ok",
    "discordPollSendSdk": "ok",
    "sourceAvailability": "placeholder"
  },
  "issues": []
}
```

**Observed result after fix**: The external Mentat plugin loaded through OpenClaw, the role binding was created, and binding doctor resolved the Discord adapter plus both new Discord SDK send surfaces: `adapterAvailability: "ok"`, `discordComponentMessageSendSdk: "ok"`, and `discordPollSendSdk: "ok"`.

**What was not tested**: No additional gaps.

## Supplemental Checks

```text
$ node scripts/run-vitest.mjs run --config test/vitest/vitest.plugins.config.ts src/plugins/plugin-sdk-native-resolver.test.ts
PASS src/plugins/plugin-sdk-native-resolver.test.ts (1 test)

$ node scripts/run-vitest.mjs run --config test/vitest/vitest.plugin-sdk.config.ts src/plugin-sdk/discord.test.ts
PASS src/plugin-sdk/discord.test.ts (3 tests)

$ pnpm lint
Found 0 warnings and 0 errors.

$ node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo
exit status: 0

$ node scripts/build-all.mjs
[build-all] check-plugin-sdk-exports
OK: All 4 required plugin-sdk exports verified.
[build-all] write-cli-compat
exit status: 0
```

## Notes

The resolver is intentionally narrower than `NODE_PATH`: it only intercepts exact OpenClaw plugin SDK specifiers and delegates everything else to Node's original resolver.
