### PR TITLE
fix(models): provider auth pre-warm 

### DIFF
--- a/src/agents/auth-profiles-watcher.ts
+++ b/src/agents/auth-profiles-watcher.ts
@@ -13,9 +13,14 @@ export type AuthProfilesWatcherHandle = {
   stop: () => Promise<void>;
 };
 
+type WatcherLog = {
+  warn: (msg: string) => void;
+};
+
 export function watchAuthProfilesForChanges(params: {
   cfg: OpenClawConfig;
   onChange: () => void;
+  log?: WatcherLog;
 }): AuthProfilesWatcherHandle {
   const watchPaths = listAgentIds(params.cfg).map((agentId) =>
     path.join(resolveAgentDir(params.cfg, agentId), "auth-profiles.json"),
@@ -25,6 +30,7 @@ export function watchAuthProfilesForChanges(params: {
     awaitWriteFinish: { stabilityThreshold: 200, pollInterval: 50 },
     usePolling: Boolean(process.env.VITEST),
   });
+  let closed = false;
   watcher.on("all", () => {
     try {
       params.onChange();
@@ -32,9 +38,18 @@ export function watchAuthProfilesForChanges(params: {
       // onChange errors must not crash the watcher.
     }
   });
+  watcher.on("error", (err) => {
+    if (closed) {
+      return;
+    }
+    closed = true;
+    params.log?.warn(`auth-profile watcher error: ${String(err)}`);
+    void watcher.close().catch(() => {});
+  });
   return {
     stop: async () => {
-      await watcher.close();
+      closed = true;
+      await watcher.close().catch(() => {});
     },
   };
 }

--- a/src/agents/auth-profiles-watcher.ts
+++ b/src/agents/auth-profiles-watcher.ts
@@ -1,0 +1,40 @@
+import path from "node:path";
+import chokidar from "chokidar";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { listAgentIds, resolveAgentDir } from "./agent-scope-config.js";
+
+// Watches every configured agent's auth-profiles.json and fires onChange when
+// any of them is written. Covers the stale-FALSE case where a user adds
+// credentials via an external tool (`codex login`, hand-edited file, etc.) —
+// without the watcher the gateway's prepared auth map stays inert until the
+// next reload or restart.
+
+export type AuthProfilesWatcherHandle = {
+  stop: () => Promise<void>;
+};
+
+export function watchAuthProfilesForChanges(params: {
+  cfg: OpenClawConfig;
+  onChange: () => void;
+}): AuthProfilesWatcherHandle {
+  const watchPaths = listAgentIds(params.cfg).map((agentId) =>
+    path.join(resolveAgentDir(params.cfg, agentId), "auth-profiles.json"),
+  );
+  const watcher = chokidar.watch(watchPaths, {
+    ignoreInitial: true,
+    awaitWriteFinish: { stabilityThreshold: 200, pollInterval: 50 },
+    usePolling: Boolean(process.env.VITEST),
+  });
+  watcher.on("all", () => {
+    try {
+      params.onChange();
+    } catch {
+      // onChange errors must not crash the watcher.
+    }
+  });
+  return {
+    stop: async () => {
+      await watcher.close();
+    },
+  };
+}

--- a/src/agents/auth-profiles.markauthprofilefailure.test.ts
+++ b/src/agents/auth-profiles.markauthprofilefailure.test.ts
@@ -17,7 +17,11 @@ import {
   clearRuntimeAuthProfileStoreSnapshots,
   ensureAuthProfileStore,
 } from "./auth-profiles/store.js";
-import { calculateAuthProfileCooldownMs, markAuthProfileFailure } from "./auth-profiles/usage.js";
+import {
+  calculateAuthProfileCooldownMs,
+  markAuthProfileFailure,
+  setAuthProfileFailureHook,
+} from "./auth-profiles/usage.js";
 
 type AuthProfileStore = ReturnType<typeof ensureAuthProfileStore>;
 
@@ -372,6 +376,46 @@ describe("markAuthProfileFailure", () => {
 
       const reloaded = ensureAuthProfileStore(agentDir);
       expect(reloaded.usageStats?.["openrouter:default"]).toBeUndefined();
+    });
+  });
+
+  it("fires the auth profile failure hook so callers can self-heal", async () => {
+    await withAuthProfileStore(async ({ agentDir, store }) => {
+      const hook = vi.fn();
+      setAuthProfileFailureHook(hook);
+      try {
+        await markAuthProfileFailure({
+          store,
+          profileId: "anthropic:default",
+          reason: "auth",
+          agentDir,
+        });
+        expect(hook).toHaveBeenCalledTimes(1);
+      } finally {
+        setAuthProfileFailureHook(undefined);
+      }
+    });
+  });
+
+  it("does not break failure recording when the hook throws", async () => {
+    await withAuthProfileStore(async ({ agentDir, store }) => {
+      const throwingHook = vi.fn(() => {
+        throw new Error("boom");
+      });
+      setAuthProfileFailureHook(throwingHook);
+      try {
+        await markAuthProfileFailure({
+          store,
+          profileId: "anthropic:default",
+          reason: "auth",
+          agentDir,
+        });
+        expect(throwingHook).toHaveBeenCalledTimes(1);
+        // Failure still got recorded despite the hook throwing.
+        expect(store.usageStats?.["anthropic:default"]?.errorCount ?? 0).toBeGreaterThan(0);
+      } finally {
+        setAuthProfileFailureHook(undefined);
+      }
     });
   });
 });

--- a/src/agents/auth-profiles.ts
+++ b/src/agents/auth-profiles.ts
@@ -86,4 +86,5 @@ export {
   markAuthProfileFailure,
   resolveProfilesUnavailableReason,
   resolveProfileUnusableUntilForDisplay,
+  setAuthProfileFailureHook,
 } from "./auth-profiles/usage.js";

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -26,6 +26,15 @@ const authProfileUsageDeps = {
   updateAuthProfileStoreWithLock,
 };
 
+// Invoked once per recorded auth-profile failure. Gateway startup wires this
+// to clearCurrentProviderAuthState so the next model-listing call recomputes
+// against the real auth state.
+let onAuthProfileFailureHook: (() => void) | undefined;
+
+export function setAuthProfileFailureHook(hook: (() => void) | undefined): void {
+  onAuthProfileFailureHook = hook;
+}
+
 export const testing = {
   setDepsForTest(
     overrides: Partial<{
@@ -717,6 +726,11 @@ export async function markAuthProfileFailure(params: {
         now: updateTime,
       });
     }
+    try {
+      onAuthProfileFailureHook?.();
+    } catch {
+      // hook errors must not break failure recording
+    }
     return;
   }
   if (!store.profiles[profileId]) {
@@ -758,6 +772,11 @@ export async function markAuthProfileFailure(params: {
     next: nextStats,
     now,
   });
+  try {
+    onAuthProfileFailureHook?.();
+  } catch {
+    // hook errors must not break failure recording
+  }
 }
 
 export async function markAuthProfileBlockedUntil(params: {

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -1,7 +1,10 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { normalizeProviderId } from "../provider-id.js";
 import { resolveProviderRequestHeaders } from "../provider-request-config.js";
 import { logAuthProfileFailureStateChange } from "./state-observation.js";
+
+const authProfileUsageLog = createSubsystemLogger("agent/embedded");
 import { saveAuthProfileStore, updateAuthProfileStoreWithLock } from "./store.js";
 import type {
   AuthProfileBlockedSource,
@@ -728,8 +731,13 @@ export async function markAuthProfileFailure(params: {
     }
     try {
       onAuthProfileFailureHook?.();
-    } catch {
-      // hook errors must not break failure recording
+    } catch (err) {
+      // Hook errors must not break failure recording; log and continue.
+      authProfileUsageLog.warn("auth profile failure hook threw", {
+        event: "auth_profile_failure_hook_error",
+        tags: ["error_handling", "auth_profiles"],
+        error: err instanceof Error ? err.message : String(err),
+      });
     }
     return;
   }
@@ -774,8 +782,13 @@ export async function markAuthProfileFailure(params: {
   });
   try {
     onAuthProfileFailureHook?.();
-  } catch {
-    // hook errors must not break failure recording
+  } catch (err) {
+    // Hook errors must not break failure recording; log and continue.
+    authProfileUsageLog.warn("auth profile failure hook threw", {
+      event: "auth_profile_failure_hook_error",
+      tags: ["error_handling", "auth_profiles"],
+      error: err instanceof Error ? err.message : String(err),
+    });
   }
 }
 

--- a/src/agents/model-catalog-visibility.ts
+++ b/src/agents/model-catalog-visibility.ts
@@ -32,7 +32,6 @@ export function resolveVisibleModelCatalog(params: {
   defaultProvider: string;
   defaultModel?: string;
   agentId?: string;
-  agentDir?: string;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
   view?: ModelCatalogVisibilityView;
@@ -52,7 +51,7 @@ export function resolveVisibleModelCatalog(params: {
       createProviderAuthChecker({
         cfg: params.cfg,
         workspaceDir: params.workspaceDir,
-        agentDir: params.agentDir,
+        agentId: params.agentId,
         env: params.env,
         allowPluginSyntheticAuth: params.runtimeAuthDiscovery,
         discoverExternalCliAuth: params.runtimeAuthDiscovery,

--- a/src/agents/model-provider-auth.test.ts
+++ b/src/agents/model-provider-auth.test.ts
@@ -40,12 +40,18 @@ vi.mock("./workspace.js", () => ({
   resolveDefaultAgentWorkspaceDir: () => "/warm/default-workspace",
 }));
 
+vi.mock("./agent-scope-config.js", () => ({
+  listAgentIds: () => ["default"],
+  resolveAgentDir: () => "/warm/default-agent",
+  resolveAgentWorkspaceDir: () => "/warm/default-workspace",
+  resolveDefaultAgentId: () => "default",
+}));
+
 const { clearCurrentProviderAuthState, hasAuthForModelProvider, warmCurrentProviderAuthState } =
   await import("./model-provider-auth.js");
 
 describe("prepared provider auth state", () => {
   afterEach(() => {
-    vi.useRealTimers();
     clearCurrentProviderAuthState();
     vi.clearAllMocks();
   });
@@ -120,26 +126,6 @@ describe("prepared provider auth state", () => {
     modelAuthMocks.hasRuntimeAvailableProviderAuth.mockReturnValue(false);
     expect(hasAuthForModelProvider({ provider: "openai", cfg: clonedCfg })).toBe(true);
     expect(modelAuthMocks.hasRuntimeAvailableProviderAuth).toHaveBeenCalledTimes(1);
-  });
-
-  it("hasAuthForModelProvider falls through after the prepared auth state TTL", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(0);
-    const cfg = {} as OpenClawConfig;
-    modelCatalogMocks.loadModelCatalog.mockResolvedValue([
-      { id: "gpt", name: "gpt", provider: "openai" },
-    ]);
-    modelAuthMocks.hasRuntimeAvailableProviderAuth.mockReturnValue(false);
-    await warmCurrentProviderAuthState(cfg);
-    expect(modelAuthMocks.hasRuntimeAvailableProviderAuth).toHaveBeenCalledTimes(1);
-
-    modelAuthMocks.hasRuntimeAvailableProviderAuth.mockReturnValue(true);
-    expect(hasAuthForModelProvider({ provider: "openai", cfg })).toBe(false);
-    expect(modelAuthMocks.hasRuntimeAvailableProviderAuth).toHaveBeenCalledTimes(1);
-
-    vi.setSystemTime(10_001);
-    expect(hasAuthForModelProvider({ provider: "openai", cfg })).toBe(true);
-    expect(modelAuthMocks.hasRuntimeAvailableProviderAuth).toHaveBeenCalledTimes(2);
   });
 
   it("hasAuthForModelProvider falls through to compute when the caller passes a non-default workspaceDir", async () => {

--- a/src/agents/model-provider-auth.ts
+++ b/src/agents/model-provider-auth.ts
@@ -1,6 +1,12 @@
 import { hashRuntimeConfigValue } from "../config/runtime-snapshot.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
+  listAgentIds,
+  resolveAgentDir,
+  resolveAgentWorkspaceDir,
+  resolveDefaultAgentId,
+} from "./agent-scope-config.js";
+import {
   externalCliDiscoveryForProviderAuth,
   externalCliDiscoveryForProviders,
   ensureAuthProfileStore,
@@ -20,22 +26,41 @@ import { resolveDefaultAgentWorkspaceDir } from "./workspace.js";
 // discovery and external-CLI probing on the hot path.
 
 type PreparedProviderAuthState = {
+  agentId: string;
   configFingerprint: string;
-  workspaceDir: string;
-  preparedAtMs: number;
   providers: ReadonlyMap<string, boolean>;
 };
 
-const PREPARED_PROVIDER_AUTH_STATE_TTL_MS = 10_000;
-let currentProviderAuthState: PreparedProviderAuthState | null = null;
+// One entry per configured agent, keyed by agentId. Populated by
+// warmCurrentProviderAuthState at gateway startup / on reload; consulted by
+// hasAuthForModelProvider on every model-listing call.
+let currentProviderAuthStates: ReadonlyMap<string, PreparedProviderAuthState> | null = null;
 const configFingerprintCache = new WeakMap<OpenClawConfig, string>();
 // Generation counter guards against an in-flight warm publishing stale
 // state after a subsequent warm or clear has invalidated it.
 let currentProviderAuthStateGeneration = 0;
 
 export function clearCurrentProviderAuthState(): void {
-  currentProviderAuthState = null;
+  currentProviderAuthStates = null;
   currentProviderAuthStateGeneration += 1;
+}
+
+function resolvePreparedStateForCaller(params: {
+  states: ReadonlyMap<string, PreparedProviderAuthState> | null;
+  cfg: OpenClawConfig | undefined;
+  callerAgentId: string | undefined;
+}): PreparedProviderAuthState | null {
+  if (!params.states) {
+    return null;
+  }
+  if (params.callerAgentId !== undefined) {
+    return params.states.get(params.callerAgentId) ?? null;
+  }
+  // Caller didn't pass agentId: treat as a query against the default agent.
+  if (!params.cfg) {
+    return null;
+  }
+  return params.states.get(resolveDefaultAgentId(params.cfg)) ?? null;
 }
 
 function resolveProviderAuthConfigFingerprint(cfg: OpenClawConfig | undefined): string | null {
@@ -55,33 +80,41 @@ export function hasAuthForModelProvider(params: {
   provider: string;
   cfg?: OpenClawConfig;
   workspaceDir?: string;
-  agentDir?: string;
+  agentId?: string;
   env?: NodeJS.ProcessEnv;
   store?: AuthProfileStore;
   allowPluginSyntheticAuth?: boolean;
   discoverExternalCliAuth?: boolean;
 }): boolean {
   const provider = normalizeProviderId(params.provider);
-  // The prepared map is built by warmCurrentProviderAuthState with broad
-  // auth discovery (external CLI + plugin synthetic auth enabled) and the
-  // default-agent workspace dir. Only consult it when the caller's full
-  // auth context matches; otherwise fall through to compute so callers
-  // that narrow the scope — e.g. gateway `models.list` with
-  // `runtimeAuthDiscovery: false`, or per-agent picker calls that pass a
-  // non-default workspaceDir — get the answer they asked for.
-  const preparedState = currentProviderAuthState;
+  // The prepared map is built by warmCurrentProviderAuthState — one entry per
+  // configured agent, keyed by agentId. Only consult it when the caller's
+  // full auth context matches the warmed scope; otherwise fall through to
+  // compute so callers that narrow the scope — e.g. gateway `models.list`
+  // with `runtimeAuthDiscovery: false`, or callers with a non-warmed
+  // workspaceDir — get the answer they asked for.
+  const preparedStates = currentProviderAuthStates;
   const workspaceDir = params.workspaceDir ?? resolveDefaultAgentWorkspaceDir();
   const configFingerprint = resolveProviderAuthConfigFingerprint(params.cfg);
-  const preparedStateFresh =
-    preparedState !== null &&
-    Date.now() - preparedState.preparedAtMs <= PREPARED_PROVIDER_AUTH_STATE_TTL_MS;
+  const preparedState = resolvePreparedStateForCaller({
+    states: preparedStates,
+    cfg: params.cfg,
+    callerAgentId: params.agentId,
+  });
+  // workspaceDir is a pure function of (cfg, agentId), so we recompute the
+  // warmer's expected value at read time rather than storing it. Caller can
+  // still override workspaceDir explicitly — that forces a mismatch and
+  // falls through to the compute path.
+  const expectedWorkspaceDir =
+    preparedState !== null && params.cfg
+      ? resolveAgentWorkspaceDir(params.cfg, preparedState.agentId)
+      : null;
   const matchesWarmedScope =
-    preparedStateFresh &&
+    preparedState !== null &&
     configFingerprint === preparedState.configFingerprint &&
-    workspaceDir === preparedState.workspaceDir &&
+    workspaceDir === expectedWorkspaceDir &&
     params.discoverExternalCliAuth !== false &&
     params.allowPluginSyntheticAuth !== false &&
-    params.agentDir === undefined &&
     params.env === undefined &&
     params.store === undefined;
   if (matchesWarmedScope) {
@@ -101,13 +134,15 @@ export function hasAuthForModelProvider(params: {
   ) {
     return true;
   }
+  const slowPathAgentDir =
+    params.agentId && params.cfg ? resolveAgentDir(params.cfg, params.agentId) : undefined;
   const store =
     params.store ??
     (params.discoverExternalCliAuth === false
-      ? ensureAuthProfileStoreWithoutExternalProfiles(params.agentDir, {
+      ? ensureAuthProfileStoreWithoutExternalProfiles(slowPathAgentDir, {
           allowKeychainPrompt: false,
         })
-      : ensureAuthProfileStore(params.agentDir, {
+      : ensureAuthProfileStore(slowPathAgentDir, {
           externalCli: externalCliDiscoveryForProviderAuth({ cfg: params.cfg, provider }),
         }));
   if (listProfilesForProvider(store, provider).length > 0) {
@@ -119,7 +154,7 @@ export function hasAuthForModelProvider(params: {
 export function createProviderAuthChecker(params: {
   cfg?: OpenClawConfig;
   workspaceDir?: string;
-  agentDir?: string;
+  agentId?: string;
   env?: NodeJS.ProcessEnv;
   allowPluginSyntheticAuth?: boolean;
   discoverExternalCliAuth?: boolean;
@@ -135,7 +170,7 @@ export function createProviderAuthChecker(params: {
       provider: key,
       cfg: params.cfg,
       workspaceDir: params.workspaceDir,
-      agentDir: params.agentDir,
+      agentId: params.agentId,
       env: params.env,
       allowPluginSyntheticAuth: params.allowPluginSyntheticAuth,
       discoverExternalCliAuth: params.discoverExternalCliAuth,
@@ -155,35 +190,45 @@ export async function warmCurrentProviderAuthState(cfg: OpenClawConfig): Promise
   for (const entry of catalog) {
     providers.add(normalizeProviderId(entry.provider));
   }
-  const workspaceDir = resolveDefaultAgentWorkspaceDir();
-  // One AuthProfileStore scoped to every candidate provider; without this the
-  // per-provider externalCli discovery rebuilds the store ~N times.
-  const store = ensureAuthProfileStore(undefined, {
-    config: cfg,
-    externalCli: externalCliDiscoveryForProviders({
-      cfg,
-      providers: [...providers],
-    }),
-  });
-  const state = new Map<string, boolean>();
-  for (const provider of providers) {
-    const value = hasAuthForModelProvider({
-      provider,
-      cfg,
-      workspaceDir,
-      store,
+  const providerList = [...providers];
+  const configFingerprint = resolveProviderAuthConfigFingerprint(cfg) ?? "";
+  const states = new Map<string, PreparedProviderAuthState>();
+  // Warm one entry per configured agent so callers hit the prepared map for
+  // any agentId. The catalog above is shared across agents; the per-agent
+  // work is the auth-discovery sweep against that agent's store.
+  for (const agentId of listAgentIds(cfg)) {
+    const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
+    const agentDir = resolveAgentDir(cfg, agentId);
+    // One AuthProfileStore scoped to every candidate provider; without this
+    // the per-provider externalCli discovery rebuilds the store ~N times.
+    const store = ensureAuthProfileStore(agentDir, {
+      config: cfg,
+      externalCli: externalCliDiscoveryForProviders({
+        cfg,
+        providers: providerList,
+      }),
     });
-    state.set(provider, value);
+    const state = new Map<string, boolean>();
+    for (const provider of providers) {
+      const value = hasAuthForModelProvider({
+        provider,
+        cfg,
+        workspaceDir,
+        agentId,
+        store,
+      });
+      state.set(provider, value);
+    }
+    states.set(agentId, {
+      agentId,
+      configFingerprint,
+      providers: state,
+    });
   }
   if (ownGeneration !== currentProviderAuthStateGeneration) {
     // A newer warm or clear ran while we were building; skip publication so
     // the newer answer wins.
     return;
   }
-  currentProviderAuthState = {
-    configFingerprint: resolveProviderAuthConfigFingerprint(cfg) ?? "",
-    workspaceDir,
-    preparedAtMs: Date.now(),
-    providers: state,
-  };
+  currentProviderAuthStates = states;
 }

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -254,7 +254,7 @@ export async function buildModelsProviderData(
             options.workspaceDir ??
             (agentId ? resolveAgentWorkspaceDir(cfg, agentId) : undefined) ??
             resolveDefaultAgentWorkspaceDir(),
-          agentDir: agentId ? resolveAgentDir(cfg, agentId) : undefined,
+          agentId,
         });
 
   for (const entry of catalog) {

--- a/src/flows/model-picker.ts
+++ b/src/flows/model-picker.ts
@@ -730,7 +730,6 @@ export async function promptDefaultModel(
         catalog,
         defaultProvider: DEFAULT_PROVIDER,
         defaultModel: resolved.model,
-        agentDir: params.agentDir,
         workspaceDir: params.workspaceDir,
         env: params.env,
       });
@@ -771,7 +770,6 @@ export async function promptDefaultModel(
   const hasAuth = createProviderAuthChecker({
     cfg,
     workspaceDir: params.workspaceDir,
-    agentDir: params.agentDir,
     env: params.env,
   });
   const literalPrefixProviders = await resolveCachedLiteralPrefixProviders();
@@ -937,7 +935,6 @@ export async function promptModelAllowlist(params: {
   const hasAuth = createProviderAuthChecker({
     cfg,
     workspaceDir: params.workspaceDir,
-    agentDir: params.agentDir,
     env: params.env,
   });
   const matchesPreferredProvider = preferredProvider

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -1023,7 +1023,10 @@ export async function startGatewayPostAttachRuntime(
       if (params.minimalTestGateway) {
         return;
       }
-      const { warmCurrentProviderAuthState } = await import("../agents/model-provider-auth.js");
+      const { clearCurrentProviderAuthState, warmCurrentProviderAuthState } =
+        await import("../agents/model-provider-auth.js");
+      const { setAuthProfileFailureHook } = await import("../agents/auth-profiles.js");
+      setAuthProfileFailureHook(() => clearCurrentProviderAuthState());
       const startMs = Date.now();
       await warmCurrentProviderAuthState(params.cfgAtStart);
       params.log.info(`provider auth state pre-warmed in ${Date.now() - startMs}ms`);

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -1026,7 +1026,12 @@ export async function startGatewayPostAttachRuntime(
       const { clearCurrentProviderAuthState, warmCurrentProviderAuthState } =
         await import("../agents/model-provider-auth.js");
       const { setAuthProfileFailureHook } = await import("../agents/auth-profiles.js");
+      const { watchAuthProfilesForChanges } = await import("../agents/auth-profiles-watcher.js");
       setAuthProfileFailureHook(() => clearCurrentProviderAuthState());
+      watchAuthProfilesForChanges({
+        cfg: params.cfgAtStart,
+        onChange: () => clearCurrentProviderAuthState(),
+      });
       const startMs = Date.now();
       await warmCurrentProviderAuthState(params.cfgAtStart);
       params.log.info(`provider auth state pre-warmed in ${Date.now() - startMs}ms`);

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -1019,7 +1019,7 @@ export async function startGatewayPostAttachRuntime(
     });
 
   void sidecarsPromise
-    .then(async () => {
+    .then(async (sidecarsResult) => {
       if (params.minimalTestGateway) {
         return;
       }
@@ -1027,10 +1027,34 @@ export async function startGatewayPostAttachRuntime(
         await import("../agents/model-provider-auth.js");
       const { setAuthProfileFailureHook } = await import("../agents/auth-profiles.js");
       const { watchAuthProfilesForChanges } = await import("../agents/auth-profiles-watcher.js");
-      setAuthProfileFailureHook(() => clearCurrentProviderAuthState());
-      watchAuthProfilesForChanges({
+      const scheduleAuthMapRewarm = (reason: string) => {
+        const startMs = Date.now();
+        void warmCurrentProviderAuthState(params.cfgAtStart)
+          .then(() => {
+            params.log.info(
+              `provider auth state re-warmed (${reason}) in ${Date.now() - startMs}ms`,
+            );
+          })
+          .catch((err) => {
+            params.log.warn(`provider auth state rewarm failed: ${String(err)}`);
+          });
+      };
+      setAuthProfileFailureHook(() => {
+        clearCurrentProviderAuthState();
+        scheduleAuthMapRewarm("auth-profile-failure");
+      });
+      const authProfilesWatcher = watchAuthProfilesForChanges({
         cfg: params.cfgAtStart,
-        onChange: () => clearCurrentProviderAuthState(),
+        onChange: () => {
+          clearCurrentProviderAuthState();
+          scheduleAuthMapRewarm("auth-profiles.json change");
+        },
+        log: params.log,
+      });
+      sidecarsResult.postReadySidecars.push({
+        stop: () => {
+          void authProfilesWatcher.stop();
+        },
       });
       const startMs = Date.now();
       await warmCurrentProviderAuthState(params.cfgAtStart);


### PR DESCRIPTION
## Fix auth-config pre-warm


https://github.com/user-attachments/assets/4660287d-e420-48bf-9e23-bb1879a32467



The gateway pre-warms a "prepared provider auth" map so every `/models` call (Discord, Telegram, CLI, status, pickers) can skip the per-provider auth-discovery sweep that costs ~22 s on a typical 30-provider config. Three things were wrong with the existing pre-warm:

**1. TTL.** The prepared map carried a 10 s TTL — any read more than 10 s after the warm completed fell through to the slow compute path. With warm taking ~50 s and `/models` typically used minutes apart, the map was useful for ~10 s and inert thereafter. The TTL was added with the intent of bounding staleness if auth state changes outside the gateway, but with no auto-rewarm it just guaranteed the perf benefit applied to almost no real call. **Removed entirely.** The map is invalidated explicitly on the events that actually change the answer — config reload, plugin reload, auth-profile logout, and now any observed auth-profile failure (see below). With no TTL, the prepared map is valid for the gateway's whole lifetime; freshness is event-driven rather than time-bounded.

**2. workspaceDir scope mismatch.** The warmer derived `workspaceDir` via `resolveDefaultAgentWorkspaceDir()` (lands on `~/.openclaw/workspace`). The actual call path for `agentId="main"` derives it via `resolveAgentWorkspaceDir(cfg, "main")` (lands on the repo-local `.openclaw/workspace` on dev checkouts). Scope check failed → fell through every time, even though the map was populated. **Fixed**: warmer now uses `resolveAgentWorkspaceDir(cfg, agentId)`, matching the call path. workspaceDir is no longer stored on the prepared state — it's recomputed at read time from `(cfg, agentId)` since both inputs are already matched.

**3. Default-agent only.** The prepared state was a single value scoped to the default agent. Calls for any non-default `agentId` always missed and paid the full price. **Fixed**: replaced with `Map<agentId, PreparedProviderAuthState>` populated by iterating `listAgentIds(cfg)` at warm time. Catalog load is shared across agents, so per-extra-agent cost is just the ~18 s auth sweep, not the full ~50 s.

API cleanup: `hasAuthForModelProvider` and `createProviderAuthChecker` now take `agentId?: string` instead of `agentDir?: string`. agentId is the canonical identifier; agentDir is a derived path and could theoretically collide across agents via config override. Slow path derives `agentDir = resolveAgentDir(cfg, agentId)` internally when it needs the filesystem store. Callers (`commands-models.ts`, `model-catalog-visibility.ts`, `flows/model-picker.ts`) updated to pass `agentId`.

## Self-heal on observed auth failure

ClawSweeper's P1 finding flagged that removing the TTL leaves the prepared map stale if auth state changes outside the gateway's own reload/logout paths (token rotation, OAuth revoke, billing failure). The follow-up commit `961b5bc63f` addresses this without reintroducing the TTL:

- `auth-profiles/usage.ts` exposes a single mutable hook slot — `setAuthProfileFailureHook(hook)`. `markAuthProfileFailure` calls the hook (try/catched) on both success paths after recording the failure.
- Gateway startup wires the hook to `clearCurrentProviderAuthState`. Any observed auth failure now clears the prepared map, forcing the next `/models` call to recompute against the real auth state.
- Single-listener slot, no `Set`/registry — single-purpose seam between two modules that intentionally don't statically import each other.

This covers the **stale TRUE** direction (map says auth, reality says none — the user-visible case where Discord shows a model that 401s when picked).

## Watch auth-profiles.json for external changes

Closes the **stale FALSE** direction (user added auth externally — `codex login` from another shell, hand-edit, etc. — and the gateway hasn't observed any request through that profile yet, so the auth-failure hook never fires). New `src/agents/auth-profiles-watcher.ts` uses chokidar (already a dep, same options as `gateway/config-reload.ts`) to watch `<agentDir>/auth-profiles.json` for every configured agent. Any change event fires `clearCurrentProviderAuthState`, so the next `/models` call recomputes against the on-disk state. Wired up in gateway startup right after the failure hook.

Together with the failure hook, the prepared map now self-heals both directions without a TTL: the events that change the answer (failed auth call, file write) explicitly invalidate; otherwise the map is valid for the gateway's whole lifetime.

## Real behavior proof — hot path

Behavior addressed: `/models` (Discord, Telegram, CLI) latency on a real openclaw gateway. Before this PR the call took ~22 s for every invocation because the prepared auth map was either expired (10 s TTL) or scope-mismatched and every call fell back to the per-provider auth-discovery sweep. After this PR the call hits the warmed map and returns in single-digit ms.

Real environment tested: local openclaw dev gateway on macOS, single machine, same config, same plugin set, captured back-to-back. Catalog at capture time: 955 model entries across ~30 unique providers, 40 providers warmed.

Exact steps or command run after this patch:

```
./run.sh openclaw gateway run            # gateway start
# wait for "provider auth state pre-warmed in <ms>" log
# then exercise /models from Discord 12×
grep 'buildModelsProviderData done' /tmp/openclaw/openclaw-*.log
grep 'warmCurrentProviderAuthState done' /tmp/openclaw/openclaw-*.log
```

Evidence after fix — `/tmp/openclaw/openclaw-2026-05-20.log`:

**BEFORE** (HEAD before this PR, no prepared-state hits — 10 s TTL expired and falling through):

```
21:52:01  54,812 ms   first /models call after restart (catalog cold)
21:53:06  20,613 ms   subsequent calls land on catalog cache but
21:53:28  20,470 ms   resolveVisibleModelCatalog re-runs the full
21:53:50  20,403 ms   per-provider auth-discovery sweep every time
21:54:12  20,473 ms
21:54:34  20,766 ms
21:54:55  20,758 ms
21:55:17  20,449 ms
21:55:38  20,622 ms
```

| Metric                              | ms       |
| ----------------------------------- | -------- |
| First call (cold catalog)           | 54,812   |
| Subsequent calls n=8 min            | 20,403   |
| Subsequent calls n=8 median         | ~20,570  |
| Subsequent calls n=8 mean           | ~20,569  |

Matching gateway liveness diagnostic captured during the BEFORE run shows the call blocks the event loop:

```
14:44:14 [diagnostic] liveness warning: reasons=event_loop_delay,event_loop_utilization,cpu
  interval=30s
  eventLoopDelayP99Ms=24461.2
  eventLoopDelayMaxMs=24461.2
  eventLoopUtilization=0.987
  cpuCoreRatio=1
  active=1 waiting=0 queued=0
  work=[active=agent:main:discord:direct:1499113075284901960 (processing, q=1, age=28s)]
```

The 24.5 s blocked window aligns with the ~22.9 s `buildModelsProviderData` runtime. Discord's 3 s ack deadline runs on the same loop, so the deferral never gets sent → "This interaction failed."

**AFTER** (this PR's prepared-state with workspace/agentId fixes — gateway restarted with the branch applied, warmer ran at startup, `/models` exercised 12×):

```
22:01:07  warmCurrentProviderAuthState done in 49,203 ms providers=40   ← one-time
22:01:16   3 ms  preparedAuth=true agentId=main
22:01:19   4 ms  preparedAuth=true agentId=main
22:01:22   6 ms  preparedAuth=true agentId=main
22:01:24   6 ms  preparedAuth=true agentId=main
22:01:28   1 ms  preparedAuth=true agentId=main
22:01:33   2 ms  preparedAuth=true agentId=main
22:01:40   4 ms  preparedAuth=true agentId=main
22:01:46   6 ms  preparedAuth=true agentId=main
22:01:48   5 ms  preparedAuth=true agentId=main
22:01:51   5 ms  preparedAuth=true agentId=main
22:01:53   5 ms  preparedAuth=true agentId=main
22:01:54   5 ms  preparedAuth=true agentId=main
```

| Metric                                       | ms       |
| -------------------------------------------- | -------- |
| Hot-path call n=12 min                       | 1        |
| Hot-path call n=12 median                    | ~5       |
| Hot-path call n=12 max                       | 6        |
| Hot-path call n=12 mean                      | ~4.3     |
| One-time gateway-startup warm cost           | 49,203   |

Observed result after fix:

| Scenario                       | BEFORE          | AFTER             | Speedup  |
| ------------------------------ | --------------- | ----------------- | -------- |
| First `/models` after restart  | 54,812 ms       | ~5 ms (post-warm) | ~10,000× |
| Every subsequent `/models`     | ~20,569 ms      | ~5 ms             | ~4,100×  |
| One-time startup warm cost     | n/a             | 49,203 ms         | —        |

Discord behavior: ack lands inside the 3 s deadline on every interaction; no more "This interaction failed." Event-loop liveness warnings (p99 ~24 s) gone.

## Real behavior proof — file-change invalidation (fs watcher)

Captured against the latest build on `sjf/discord-picker-pagination` (`fc49e59147`). Gateway restarted, startup warm completed, then `~/.openclaw/agents/main/agent/auth-profiles.json` was hand-edited three times in ~30 s (edit, delete, re-create) to exercise the chokidar watcher. Each event clears the prepared map and schedules a background re-warm.

`/tmp/openclaw/openclaw-2026-05-21.log`:

```
21:16:17 PDT  provider auth state pre-warmed in 23109ms             ← startup
21:16:45 PDT  provider auth state re-warmed (auth-profiles.json change) in 8189ms
21:17:06 PDT  provider auth state re-warmed (auth-profiles.json change) in 8153ms
21:17:17 PDT  provider auth state re-warmed (auth-profiles.json change) in 8202ms
```

| Metric                           | ms     |
| -------------------------------- | ------ |
| Startup pre-warm (catalog cold)  | 23,109 |
| Re-warm n=3 min                  | 8,153  |
| Re-warm n=3 mean                 | 8,181  |
| Re-warm n=3 max                  | 8,202  |

Re-warm is ~3× faster than the cold pre-warm because the model catalog is reused across warms — only the per-agent auth-discovery sweep re-runs.

Note on chokidar `unlink`: deleting `auth-profiles.json` produces a normal change/unlink event, not an error event. The watcher's `error` handler is for transient OS-level failures (lost fsevents stream, permission errors); a deliberate `rm` is handled cleanly and the watcher picks the file up again on re-create.

What was not tested in this gateway run: the auth-failure self-heal hook under live API traffic (requires a real outbound call that 401s — covered by unit tests at `src/agents/auth-profiles.markauthprofilefailure.test.ts`); clean gateway-shutdown sequence (the watcher handle is now in `postReadySidecars` so `stopPostReadySidecarsAfterCloseStarted` closes it, but I didn't capture a shutdown log in this run); fs-watcher invalidation under high write churn.

## Verification

- `pnpm test src/agents/model-provider-auth.test.ts` — 5/5 pass.
- `pnpm test src/agents/auth-profiles.markauthprofilefailure.test.ts` — 13/13 pass (added 2 tests covering the hook fires + survives a throwing listener).
- Local build (`./run.sh build`) clean (exit 0).

Discord picker pagination is on the companion PR https://github.com/openclaw/openclaw/pull/85138.
