### PR TITLE
Bypass stale auth gates for external CLI harnesses

### DIFF
--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -813,6 +813,67 @@ describe("runWithModelFallback", () => {
     }
   });
 
+  it("lets auto-selected non-Codex plugin harnesses bypass stale provider auth cooldowns", async () => {
+    const { clearAgentHarnesses, registerAgentHarness } = await import("./harness/registry.js");
+    clearAgentHarnesses();
+    registerAgentHarness({
+      id: "claude-tmux",
+      label: "Claude tmux",
+      supports: ({ provider }) =>
+        provider === "anthropic" ? { supported: true, priority: 10 } : { supported: false },
+      runAttempt: async () => ({ result: { text: "" } }) as never,
+    });
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          models: {
+            "anthropic/*": { agentRuntime: { id: "auto" } },
+          },
+          model: {
+            primary: "anthropic/claude-sonnet-4-6",
+          },
+        },
+      },
+    });
+    const tempDir = await makeAuthTempDir();
+    setAuthRuntimeStore(tempDir, {
+      version: AUTH_STORE_VERSION,
+      profiles: {
+        "anthropic:claude-cli": {
+          type: "oauth",
+          provider: "anthropic",
+          access: "stale-access",
+          refresh: "stale-refresh",
+          expires: Date.now() - 60_000,
+        },
+      },
+      usageStats: {
+        "anthropic:claude-cli": {
+          disabledUntil: Date.now() + 60_000,
+          disabledReason: "billing",
+          failureCounts: { billing: 1 },
+        },
+      },
+    });
+    const run = vi.fn().mockResolvedValueOnce("auto external cli ok");
+
+    try {
+      const result = await runWithModelFallback({
+        cfg,
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+        agentDir: tempDir,
+        run,
+      });
+
+      expect(result.result).toBe("auto external cli ok");
+      expect(run).toHaveBeenCalledTimes(1);
+      expect(run.mock.calls[0]).toEqual(["anthropic", "claude-sonnet-4-6"]);
+    } finally {
+      clearAgentHarnesses();
+    }
+  });
+
   it("does not treat command-lane watchdog timeouts as model fallback failures", async () => {
     const cfg = makeCfg();
     const timeoutError = new CommandLaneTaskTimeoutError("cron-nested", 330_000);

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -753,6 +753,60 @@ describe("runWithModelFallback", () => {
     expect(run.mock.calls[0]).toEqual(["anthropic", "claude-sonnet-4-6"]);
   });
 
+  it("lets registered non-Codex plugin harnesses bypass stale provider auth cooldowns", async () => {
+    const { clearAgentHarnesses, registerAgentHarness } = await import("./harness/registry.js");
+    clearAgentHarnesses();
+    registerAgentHarness({
+      id: "claude-tmux",
+      label: "Claude tmux",
+      supports: () => ({ supported: true }),
+      runAttempt: async () => ({ result: { text: "" } }) as never,
+    });
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          models: {
+            "anthropic/*": { agentRuntime: { id: "claude-tmux" } },
+          },
+          model: {
+            primary: "anthropic/claude-sonnet-4-6",
+          },
+        },
+      },
+    });
+    const tempDir = await makeAuthTempDir();
+    setAuthRuntimeStore(tempDir, {
+      version: AUTH_STORE_VERSION,
+      profiles: {
+        "anthropic:claude-cli": { type: "oauth", provider: "anthropic", token: "stale" },
+      },
+      usageStats: {
+        "anthropic:claude-cli": {
+          disabledUntil: Date.now() + 60_000,
+          disabledReason: "billing",
+          failureCounts: { billing: 1 },
+        },
+      },
+    });
+    const run = vi.fn().mockResolvedValueOnce("external cli ok");
+
+    try {
+      const result = await runWithModelFallback({
+        cfg,
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+        agentDir: tempDir,
+        run,
+      });
+
+      expect(result.result).toBe("external cli ok");
+      expect(run).toHaveBeenCalledTimes(1);
+      expect(run.mock.calls[0]).toEqual(["anthropic", "claude-sonnet-4-6"]);
+    } finally {
+      clearAgentHarnesses();
+    }
+  });
+
   it("does not treat command-lane watchdog timeouts as model fallback failures", async () => {
     const cfg = makeCfg();
     const timeoutError = new CommandLaneTaskTimeoutError("cron-nested", 330_000);

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -778,7 +778,13 @@ describe("runWithModelFallback", () => {
     setAuthRuntimeStore(tempDir, {
       version: AUTH_STORE_VERSION,
       profiles: {
-        "anthropic:claude-cli": { type: "oauth", provider: "anthropic", token: "stale" },
+        "anthropic:claude-cli": {
+          type: "oauth",
+          provider: "anthropic",
+          access: "stale-access",
+          refresh: "stale-refresh",
+          expires: Date.now() - 60_000,
+        },
       },
       usageStats: {
         "anthropic:claude-cli": {

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -30,6 +30,7 @@ import {
 import { MissingAgentHarnessError, isMissingAgentHarnessError } from "./harness/errors.js";
 import { resolveAgentHarnessPolicy } from "./harness/policy.js";
 import { getRegisteredAgentHarness } from "./harness/registry.js";
+import { selectAgentHarness } from "./harness/selection.js";
 import { LiveSessionModelSwitchError } from "./live-model-switch-error.js";
 import {
   isModelFallbackDecisionLogEnabled,
@@ -355,6 +356,40 @@ function isCliAgentRuntime(runtime: string | undefined, cfg: OpenClawConfig | un
   return isCliRuntimeAlias(normalized) || isCliProvider(normalized, cfg);
 }
 
+function isRegisteredNonCodexPluginHarness(runtime: string | undefined): boolean {
+  return Boolean(
+    runtime &&
+    runtime !== "auto" &&
+    runtime !== "pi" &&
+    runtime !== "codex" &&
+    getRegisteredAgentHarness(runtime),
+  );
+}
+
+function resolvesToRegisteredNonCodexPluginHarness(
+  params: ModelFallbackRuntimeContext &
+    ModelCandidate & {
+      agentRuntime?: string;
+      agentHarnessRuntimeOverride?: string;
+    },
+): boolean {
+  if (isRegisteredNonCodexPluginHarness(params.agentRuntime)) {
+    return true;
+  }
+  if (params.agentRuntime !== "auto" || !params.cfg) {
+    return false;
+  }
+  const selectedHarness = selectAgentHarness({
+    provider: params.provider,
+    modelId: params.model,
+    config: params.cfg,
+    agentId: params.agentId,
+    sessionKey: params.sessionKey,
+    agentHarnessRuntimeOverride: params.agentHarnessRuntimeOverride,
+  });
+  return isRegisteredNonCodexPluginHarness(selectedHarness.id);
+}
+
 function resolveModelFallbackCandidateHarnessInfo(
   params: ModelFallbackRuntimeContext & ModelCandidate,
 ): ModelFallbackCandidateHarnessInfo {
@@ -382,12 +417,11 @@ function resolveModelFallbackCandidateHarnessInfo(
     agentRuntime,
     agentRuntimeSource,
     agentHarnessRuntimeOverride,
-    registeredPluginHarness: Boolean(
-      agentRuntime &&
-      agentRuntime !== "auto" &&
-      agentRuntime !== "pi" &&
-      getRegisteredAgentHarness(agentRuntime),
-    ),
+    registeredPluginHarness: resolvesToRegisteredNonCodexPluginHarness({
+      ...params,
+      agentRuntime,
+      agentHarnessRuntimeOverride,
+    }),
   };
 }
 
@@ -421,22 +455,16 @@ async function assertModelFallbackCandidateHarnessAvailable(
   }
   return {
     ...info,
-    registeredPluginHarness: Boolean(
-      agentRuntime &&
-      agentRuntime !== "auto" &&
-      agentRuntime !== "pi" &&
-      getRegisteredAgentHarness(agentRuntime),
-    ),
+    registeredPluginHarness: resolvesToRegisteredNonCodexPluginHarness({
+      ...params,
+      agentRuntime,
+      agentHarnessRuntimeOverride,
+    }),
   };
 }
 
 function shouldBypassModelFallbackAuthCooldown(info: ModelFallbackCandidateHarnessInfo): boolean {
-  return Boolean(
-    info.registeredPluginHarness &&
-    info.agentRuntime &&
-    info.agentRuntime !== "codex" &&
-    info.agentRuntime !== "pi",
-  );
+  return info.registeredPluginHarness;
 }
 
 function recordFailedCandidateAttempt(params: {

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -29,8 +29,7 @@ import {
 } from "./failover-policy.js";
 import { MissingAgentHarnessError, isMissingAgentHarnessError } from "./harness/errors.js";
 import { resolveAgentHarnessPolicy } from "./harness/policy.js";
-import { getRegisteredAgentHarness } from "./harness/registry.js";
-import { selectAgentHarness } from "./harness/selection.js";
+import { getRegisteredAgentHarness, listRegisteredAgentHarnesses } from "./harness/registry.js";
 import { LiveSessionModelSwitchError } from "./live-model-switch-error.js";
 import {
   isModelFallbackDecisionLogEnabled,
@@ -366,6 +365,35 @@ function isRegisteredNonCodexPluginHarness(runtime: string | undefined): boolean
   );
 }
 
+function resolveAutoSelectedRegisteredHarnessId(
+  params: ModelFallbackRuntimeContext & ModelCandidate & { agentHarnessRuntimeOverride?: string },
+): string | undefined {
+  const runtimeOverride = params.agentHarnessRuntimeOverride?.trim();
+  if (runtimeOverride && runtimeOverride !== "auto" && runtimeOverride !== "default") {
+    return runtimeOverride;
+  }
+
+  return listRegisteredAgentHarnesses()
+    .map((entry) => {
+      const support = entry.harness.supports({
+        provider: params.provider,
+        modelId: params.model,
+        requestedRuntime: "auto",
+      });
+      return support.supported
+        ? {
+            id: entry.harness.id,
+            priority: support.priority ?? 0,
+          }
+        : undefined;
+    })
+    .filter((entry): entry is { id: string; priority: number } => Boolean(entry))
+    .toSorted((left, right) => {
+      const priorityDelta = right.priority - left.priority;
+      return priorityDelta !== 0 ? priorityDelta : left.id.localeCompare(right.id);
+    })[0]?.id;
+}
+
 function resolvesToRegisteredNonCodexPluginHarness(
   params: ModelFallbackRuntimeContext &
     ModelCandidate & {
@@ -379,15 +407,7 @@ function resolvesToRegisteredNonCodexPluginHarness(
   if (params.agentRuntime !== "auto" || !params.cfg) {
     return false;
   }
-  const selectedHarness = selectAgentHarness({
-    provider: params.provider,
-    modelId: params.model,
-    config: params.cfg,
-    agentId: params.agentId,
-    sessionKey: params.sessionKey,
-    agentHarnessRuntimeOverride: params.agentHarnessRuntimeOverride,
-  });
-  return isRegisteredNonCodexPluginHarness(selectedHarness.id);
+  return isRegisteredNonCodexPluginHarness(resolveAutoSelectedRegisteredHarnessId(params));
 }
 
 function resolveModelFallbackCandidateHarnessInfo(

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -115,6 +115,13 @@ type ModelFallbackRunFn<T> = (
   options?: ModelFallbackRunOptions,
 ) => Promise<T>;
 
+type ModelFallbackCandidateHarnessInfo = {
+  agentRuntime?: string;
+  agentRuntimeSource?: string;
+  agentHarnessRuntimeOverride?: string;
+  registeredPluginHarness: boolean;
+};
+
 /**
  * Fallback abort check. Only treats explicit AbortError names as user aborts.
  * Message-based checks (e.g., "aborted") can mask timeouts and skip fallback.
@@ -348,18 +355,18 @@ function isCliAgentRuntime(runtime: string | undefined, cfg: OpenClawConfig | un
   return isCliRuntimeAlias(normalized) || isCliProvider(normalized, cfg);
 }
 
-async function assertModelFallbackCandidateHarnessAvailable(
+function resolveModelFallbackCandidateHarnessInfo(
   params: ModelFallbackRuntimeContext & ModelCandidate,
-): Promise<void> {
-  if (!params.cfg) {
-    return;
-  }
+): ModelFallbackCandidateHarnessInfo {
   const agentHarnessRuntimeOverride = params.resolveAgentHarnessRuntimeOverride?.(
     params.provider,
     params.model,
   );
-  if (isCliProvider(params.provider, params.cfg)) {
-    return;
+  if (!params.cfg || isCliProvider(params.provider, params.cfg)) {
+    return {
+      agentHarnessRuntimeOverride,
+      registeredPluginHarness: false,
+    };
   }
   const agentRuntimeOverride = normalizeOptionalString(agentHarnessRuntimeOverride);
   const harnessPolicy = resolveAgentHarnessPolicy({
@@ -371,8 +378,32 @@ async function assertModelFallbackCandidateHarnessAvailable(
   });
   const agentRuntime = agentRuntimeOverride ?? harnessPolicy.runtime;
   const agentRuntimeSource = agentRuntimeOverride ? "model" : harnessPolicy.runtimeSource;
+  return {
+    agentRuntime,
+    agentRuntimeSource,
+    agentHarnessRuntimeOverride,
+    registeredPluginHarness: Boolean(
+      agentRuntime &&
+      agentRuntime !== "auto" &&
+      agentRuntime !== "pi" &&
+      getRegisteredAgentHarness(agentRuntime),
+    ),
+  };
+}
+
+async function assertModelFallbackCandidateHarnessAvailable(
+  params: ModelFallbackRuntimeContext & ModelCandidate,
+): Promise<ModelFallbackCandidateHarnessInfo> {
+  const info = resolveModelFallbackCandidateHarnessInfo(params);
+  if (!params.cfg) {
+    return info;
+  }
+  const { agentRuntime, agentRuntimeSource, agentHarnessRuntimeOverride } = info;
+  if (isCliProvider(params.provider, params.cfg)) {
+    return info;
+  }
   if (isCliAgentRuntime(agentRuntime, params.cfg)) {
-    return;
+    return info;
   }
   await params.prepareAgentHarnessRuntime?.({
     provider: params.provider,
@@ -387,6 +418,24 @@ async function assertModelFallbackCandidateHarnessAvailable(
   ) {
     throw new MissingAgentHarnessError(agentRuntime);
   }
+  return {
+    ...info,
+    registeredPluginHarness: Boolean(
+      agentRuntime &&
+      agentRuntime !== "auto" &&
+      agentRuntime !== "pi" &&
+      getRegisteredAgentHarness(agentRuntime),
+    ),
+  };
+}
+
+function shouldBypassModelFallbackAuthCooldown(info: ModelFallbackCandidateHarnessInfo): boolean {
+  return Boolean(
+    info.registeredPluginHarness &&
+    info.agentRuntime &&
+    info.agentRuntime !== "codex" &&
+    info.agentRuntime !== "pi",
+  );
 }
 
 function recordFailedCandidateAttempt(params: {
@@ -977,7 +1026,7 @@ export async function runWithModelFallback<T>(
 
   for (let i = 0; i < candidates.length; i += 1) {
     const candidate = candidates[i];
-    await assertModelFallbackCandidateHarnessAvailable({
+    const harnessInfo = await assertModelFallbackCandidateHarnessAvailable({
       cfg: params.cfg,
       agentId: params.agentId,
       sessionKey: params.sessionKey,
@@ -985,6 +1034,7 @@ export async function runWithModelFallback<T>(
       prepareAgentHarnessRuntime: params.prepareAgentHarnessRuntime,
       ...candidate,
     });
+    const bypassAuthCooldown = shouldBypassModelFallbackAuthCooldown(harnessInfo);
     const isPrimary = i === 0;
     const requestedModel = requestedCandidate
       ? sameModelCandidate(candidate, requestedCandidate)
@@ -992,7 +1042,7 @@ export async function runWithModelFallback<T>(
     let runOptions: ModelFallbackRunOptions | undefined;
     let attemptedDuringCooldown = false;
     let transientProbeProviderForAttempt: string | null = null;
-    if (authRuntime && authStore) {
+    if (authRuntime && authStore && !bypassAuthCooldown) {
       const profileIds = authRuntime.resolveAuthProfileOrder({
         cfg: params.cfg,
         store: authStore,

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -411,6 +411,7 @@ async function assertModelFallbackCandidateHarnessAvailable(
     agentHarnessRuntimeOverride,
   });
   if (
+    agentRuntime &&
     agentRuntime !== "auto" &&
     agentRuntime !== "pi" &&
     !(agentRuntime === "codex" && agentRuntimeSource === "implicit") &&


### PR DESCRIPTION
## Summary

Fixes #85105.

- detect registered non-Codex plugin harnesses before model-fallback auth cooldown checks
- skip stale OpenClaw provider auth cooldown gates for those plugin-owned transport candidates
- preserve missing-harness fail-closed behavior, CLI runtime bypass behavior, and Codex auth bootstrap behavior
- add regression coverage for an Anthropic external CLI harness blocked by a disabled stale OpenClaw auth profile

## Root cause

`runWithModelFallback` loaded OpenClaw auth profile state and applied provider cooldown/disabled checks before the embedded plugin harness path could use its lightweight/empty auth store. External CLI harnesses own their transport and credentials, so stale OpenClaw auth-state could prevent the harness from starting even though the CLI would authenticate independently.

## Real behavior proof

Behavior addressed: A registered non-Codex plugin harness for `anthropic/claude-sonnet-4-6` can start even when the OpenClaw Anthropic auth profile store contains a disabled stale `anthropic:claude-cli` profile.

Real environment tested: Local macOS OpenClaw worktree on this PR branch, Node v24.15.0, using the real `runWithModelFallback`, auth-profile store writer, and harness registry. The external harness side was represented by an executable shell harness registered as `claude-tmux`.

Exact steps or command run after this patch: Ran a `node --import tsx -e ...` proof script that created a temporary agent directory, wrote a disabled stale Anthropic OAuth profile, registered `claude-tmux`, configured Anthropic to use that registered harness, and invoked `runWithModelFallback`.

Evidence after fix: Terminal output from the after-fix proof command:

```json
{
  "agentDir": "/var/folders/sl/5dkd3zq12dv65j6jx57zq1hc0000gn/T/openclaw-pr85127-proof-Ts61m7",
  "staleOpenClawAuthState": "anthropic:claude-cli disabledUntil in future",
  "selectedRuntime": "claude-tmux",
  "runReachedExternalHarness": true,
  "result": {
    "result": {
      "provider": "anthropic",
      "model": "claude-sonnet-4-6",
      "stdout": "claude-tmux external harness started"
    },
    "provider": "anthropic",
    "model": "claude-sonnet-4-6",
    "attempts": []
  }
}
```

Observed result after fix: The stale OpenClaw Anthropic auth state did not suspend or skip the candidate. The selected registered external harness path was reached and the executable harness printed `claude-tmux external harness started`.

What was not tested: I did not run a real Anthropic network request or a real `claude-tmux` third-party package against a live account; this proof covers the OpenClaw fallback/auth gate allowing a registered external CLI harness to start while stale OpenClaw auth state is present.

## Verification

- `npm run test -- src/agents/model-fallback.test.ts` -> 1 file passed, 65 tests passed
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
- `node scripts/run-tsgo.mjs -p tsconfig.plugin-sdk.dts.json --declaration true`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src ui packages`
- `node scripts/check-extension-package-tsc-boundary.mjs --mode=compile`
- `node scripts/run-bundled-extension-oxlint.mjs`
- `node scripts/run-extension-channel-oxlint.mjs`
- `pnpm build:plugin-sdk:strict-smoke`
- `git diff --check`

## Attribution

If this PR is squash-merged or reworked, please preserve author attribution or include:

Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>
