### PR TITLE
Honor scoped agent auth logout

### DIFF
--- a/src/agents/auth-profiles.store.save.test.ts
+++ b/src/agents/auth-profiles.store.save.test.ts
@@ -11,6 +11,7 @@ import {
   ensureAuthProfileStore,
   replaceRuntimeAuthProfileStoreSnapshots,
   saveAuthProfileStore,
+  updateAuthProfileStoreWithLock,
 } from "./auth-profiles/store.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
 
@@ -35,6 +36,104 @@ function expectProfileFields(profile: unknown, expected: Record<string, unknown>
 }
 
 describe("saveAuthProfileStore", () => {
+  it("updates only the scoped agent auth profile store under lock", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-auth-logout-scope-"));
+    const mainAgentDir = path.join(root, "agents", "main", "agent");
+    const scopedAgentDir = path.join(root, "agents", "gap5", "agent");
+    try {
+      await fs.mkdir(mainAgentDir, { recursive: true });
+      await fs.mkdir(scopedAgentDir, { recursive: true });
+      await fs.writeFile(
+        resolveAuthStorePath(mainAgentDir),
+        `${JSON.stringify(
+          {
+            version: 1,
+            profiles: {
+              "xai:main": {
+                type: "oauth",
+                provider: "xai",
+                access: "main-access",
+                refresh: "main-refresh",
+              },
+            },
+          },
+          null,
+          2,
+        )}\n`,
+      );
+      await fs.writeFile(
+        resolveAuthStorePath(scopedAgentDir),
+        `${JSON.stringify(
+          {
+            version: 1,
+            profiles: {
+              "xai:scoped": {
+                type: "oauth",
+                provider: "xai",
+                access: "scoped-access",
+                refresh: "scoped-refresh",
+              },
+              "anthropic:default": {
+                type: "api_key",
+                provider: "anthropic",
+                key: "sk-anthropic",
+              },
+            },
+            order: { xai: ["xai:scoped"] },
+            lastGood: { xai: "xai:scoped" },
+            usageStats: {
+              "xai:scoped": { errorCount: 1 },
+              "anthropic:default": { errorCount: 2 },
+            },
+          },
+          null,
+          2,
+        )}\n`,
+      );
+
+      const removedProfiles: string[] = [];
+      const updated = await updateAuthProfileStoreWithLock({
+        agentDir: scopedAgentDir,
+        updater: (store) => {
+          const profileIds = Object.entries(store.profiles)
+            .filter(([, credential]) => credential.provider === "xai")
+            .map(([profileId]) => profileId);
+          removedProfiles.push(...profileIds);
+          for (const profileId of profileIds) {
+            delete store.profiles[profileId];
+            delete store.usageStats?.[profileId];
+          }
+          delete store.order?.xai;
+          delete store.lastGood?.xai;
+          return profileIds.length > 0;
+        },
+      });
+
+      expect(updated).not.toBeNull();
+      expect(removedProfiles).toEqual(["xai:scoped"]);
+      const mainRaw = JSON.parse(await fs.readFile(resolveAuthStorePath(mainAgentDir), "utf8")) as {
+        profiles: Record<string, unknown>;
+      };
+      const scopedRaw = JSON.parse(
+        await fs.readFile(resolveAuthStorePath(scopedAgentDir), "utf8"),
+      ) as {
+        profiles: Record<string, unknown>;
+        order?: Record<string, string[]>;
+        lastGood?: Record<string, string>;
+        usageStats?: Record<string, unknown>;
+      };
+      expect(mainRaw.profiles).toHaveProperty("xai:main");
+      expect(scopedRaw.profiles).not.toHaveProperty("xai:scoped");
+      expect(scopedRaw.profiles).toHaveProperty("anthropic:default");
+      expect(scopedRaw.order).toBeUndefined();
+      expect(scopedRaw.lastGood).toBeUndefined();
+      expect(scopedRaw.usageStats).toBeUndefined();
+    } finally {
+      clearRuntimeAuthProfileStoreSnapshots();
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("strips plaintext when keyRef/tokenRef are present", async () => {
     const structuredCloneSpy = vi.spyOn(globalThis, "structuredClone");
     const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-auth-save-"));

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -2178,6 +2178,60 @@ describe("capability cli", () => {
     });
   });
 
+  it("logs out provider auth profiles from the OPENCLAW_AGENT_DIR store", async () => {
+    vi.stubEnv("OPENCLAW_AGENT_DIR", "/tmp/scoped-agent");
+    mocks.listProfilesForProvider.mockImplementation(((store: any, provider: string) =>
+      Object.entries(store.profiles)
+        .filter(([, credential]: [string, any]) => credential.provider === provider)
+        .map(([profileId]) => profileId)) as never);
+
+    let updatedStore: Record<string, any> | null = null;
+    mocks.updateAuthProfileStoreWithLock.mockImplementationOnce(
+      async ({ agentDir, updater }: { agentDir?: string; updater: (store: any) => boolean }) => {
+        expect(agentDir).toBe("/tmp/scoped-agent");
+        const store = {
+          version: 1,
+          profiles: {
+            "xai:scoped": { id: "xai:scoped", provider: "xai" },
+            "anthropic:default": { id: "anthropic:default", provider: "anthropic" },
+          },
+          order: { xai: ["xai:scoped"] },
+          lastGood: { xai: "xai:scoped" },
+          usageStats: {
+            "xai:scoped": { errorCount: 1 },
+            "anthropic:default": { errorCount: 2 },
+          },
+        };
+        expect(updater(store)).toBe(true);
+        updatedStore = store;
+        return store;
+      },
+    );
+
+    await runRegisteredCli({
+      register: registerCapabilityCli as (program: Command) => void,
+      argv: ["capability", "model", "auth", "logout", "--provider", "xai", "--json"],
+    });
+
+    if (updatedStore === null) {
+      throw new Error("expected updated auth store");
+    }
+    const storeSnapshot = updatedStore as unknown as Record<string, any>;
+    expect(storeSnapshot.profiles).toEqual({
+      "anthropic:default": { id: "anthropic:default", provider: "anthropic" },
+    });
+    expect(storeSnapshot.order).toEqual({});
+    expect(storeSnapshot.lastGood).toEqual({});
+    expect(storeSnapshot.usageStats).toEqual({
+      "anthropic:default": { errorCount: 2 },
+    });
+    expect(mocks.loadAuthProfileStoreForRuntime).not.toHaveBeenCalled();
+    expect(mocks.runtime.writeJson).toHaveBeenCalledWith({
+      provider: "xai",
+      removedProfiles: ["xai:scoped"],
+    });
+  });
+
   it("fails logout if the auth store update does not complete", async () => {
     mocks.listProfilesForProvider.mockReturnValue(["openai:default"] as never);
     mocks.updateAuthProfileStoreWithLock.mockResolvedValueOnce(null as never);

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -80,6 +80,7 @@ import {
   setTtsProvider,
   textToSpeech,
 } from "../tts/tts.js";
+import { resolveUserPath } from "../utils.js";
 import { generateVideo, listRuntimeVideoGenerationProviders } from "../video-generation/runtime.js";
 import type { VideoGenerationResolution } from "../video-generation/types.js";
 import {
@@ -109,6 +110,11 @@ const IMAGE_OUTPUT_FORMATS = ["png", "jpeg", "webp"] as const;
 const IMAGE_BACKGROUNDS = ["transparent", "opaque", "auto"] as const;
 const LOCAL_MODEL_RUN_SYSTEM_PROMPT = "You are a personal assistant running inside OpenClaw.";
 const HEIC_MODEL_RUN_MIMES = new Set(["image/heic", "image/heif"]);
+
+function resolveEnvAgentDirOverride(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  const override = env.OPENCLAW_AGENT_DIR?.trim() || env.PI_CODING_AGENT_DIR?.trim();
+  return override ? resolveUserPath(override, env) : undefined;
+}
 
 type CapabilityMetadata = {
   id: string;
@@ -922,12 +928,13 @@ async function runModelAuthStatus() {
 
 async function runModelAuthLogout(provider: string) {
   const cfg = getRuntimeConfig();
-  const agentDir = resolveAgentDir(cfg, resolveDefaultAgentId(cfg));
-  const store = loadAuthProfileStoreForRuntime(agentDir);
-  const profileIds = listProfilesForProvider(store, provider);
+  const agentDir = resolveEnvAgentDirOverride() ?? resolveAgentDir(cfg, resolveDefaultAgentId(cfg));
+  let removedProfiles: string[] = [];
   const updated = await updateAuthProfileStoreWithLock({
     agentDir,
     updater: (nextStore) => {
+      const profileIds = listProfilesForProvider(nextStore, provider);
+      removedProfiles = profileIds;
       let changed = false;
       for (const profileId of profileIds) {
         if (nextStore.profiles[profileId]) {
@@ -955,7 +962,7 @@ async function runModelAuthLogout(provider: string) {
   }
   return {
     provider,
-    removedProfiles: profileIds,
+    removedProfiles,
   };
 }
 


### PR DESCRIPTION
## Summary

Fixes #85092.

- honor `OPENCLAW_AGENT_DIR` / `PI_CODING_AGENT_DIR` for `openclaw infer model auth logout`
- compute `removedProfiles` from the locked local store that is actually mutated, instead of a merged runtime store
- add CLI regression coverage for env-scoped logout and disk-backed store coverage proving the scoped auth file is changed while the default agent file is untouched

## Root cause

`runModelAuthLogout` always resolved the configured default agent directory before loading/removing auth profiles. For secondary agents, the runtime store path can merge inherited main-agent profiles, so the command could report profile IDs while the locked writer did not remove anything from the intended scoped agent file.

## Real behavior proof

**Behavior or issue addressed:** `openclaw infer model auth logout --provider xai --json` must honor `OPENCLAW_AGENT_DIR` / `PI_CODING_AGENT_DIR`, remove the provider profile from the scoped agent auth store, report only profiles removed from that scoped store, and leave the default agent auth store untouched.

**Real environment tested:** Local OpenClaw source checkout on branch `fix/scoped-auth-logout-85092`, using the real CLI entry path through `scripts/run-node.mjs`. The run used temporary default/scoped OpenClaw agent directories with redacted fake OAuth/API-key auth profiles, so no real tokens were exposed or mutated.

**Exact steps or command run after this patch:** Created temporary `OPENCLAW_STATE_DIR` with separate `agents/main/agent/auth-profiles.json` and `agents/gap5-canary-agent/agent/auth-profiles.json`, set `OPENCLAW_AGENT_DIR` and `PI_CODING_AGENT_DIR` to the scoped agent dir, then ran:

```bash
/opt/homebrew/bin/node scripts/run-node.mjs infer model auth logout --provider xai --json
```

Also ran the focused validation commands:

- `pnpm install --frozen-lockfile`
- `/opt/homebrew/bin/node scripts/run-vitest.mjs src/cli/capability-cli.test.ts` -> 1 file passed, 77 tests passed
- `/opt/homebrew/bin/node scripts/run-vitest.mjs src/agents/auth-profiles.store.save.test.ts` -> 2 files passed, 20 tests passed
- `/opt/homebrew/bin/node scripts/run-vitest.mjs src/cli/capability-cli.test.ts src/agents/auth-profiles.store.save.test.ts` -> 3 files passed, 97 tests passed
- `pnpm exec oxfmt --check --threads=1 src/cli/capability-cli.ts src/cli/capability-cli.test.ts src/agents/auth-profiles.store.save.test.ts`
- `git diff --check`
- `/opt/homebrew/bin/node scripts/check-changed.mjs --base upstream/main --head HEAD`

`node scripts/crabbox-wrapper.mjs run --shell -- "pnpm check:changed"` could not start in this local environment because the crabbox binary failed its basic `--version` / `--help` sanity check. The equivalent changed-file check passed when run directly against `upstream/main`.

**Evidence after fix:** Redacted terminal output from the real CLI run:

```text
Proof setup: branch=fix/scoped-auth-logout-85092 command=real CLI via scripts/run-node.mjs
Paths: OPENCLAW_STATE_DIR=<temp-state> OPENCLAW_AGENT_DIR=<temp-state>/agents/gap5-canary-agent/agent
Before default profiles: ["xai:main-redacted@example.test"]
Before scoped profiles: ["anthropic:scoped-control","xai:scoped-redacted@example.test"]
Command exit: 0
Command stdout:
{
  "provider": "xai",
  "removedProfiles": [
    "xai:scoped-redacted@example.test"
  ]
}
After default state: {"profiles":["xai:main-redacted@example.test"],"order":{"xai":["xai:main-redacted@example.test"]},"lastGood":{"xai":"xai:main-redacted@example.test"},"usageStats":null}
After scoped state: {"profiles":["anthropic:scoped-control"],"order":null,"lastGood":null,"usageStats":null}
```

**Observed result after fix:** The real CLI command exited 0, reported only the scoped xAI profile in `removedProfiles`, removed that scoped profile from the scoped `auth-profiles.json`, preserved the unrelated scoped Anthropic profile, and left the default agent's xAI profile/order/lastGood intact.

**What was not tested:** No known gaps for this narrow auth-store targeting fix. The proof used redacted temporary auth profiles instead of production OAuth material to avoid exposing or mutating real credentials.

## Attribution

If this PR is squash-merged or reworked, please preserve author attribution or include:

Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>
