### PR TITLE
fix(skills): dedupe shared-directory watchers across agent workspaces (#84968)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Docs: https://docs.openclaw.ai
 
 - Gateway/restart: eager-load the lifecycle runtime before in-place upgrade signal handling so package replacement does not deadlock restart imports. (#84890) Thanks @myps6415.
 - CLI/update: start managed Gateway update handoff helpers from a stable existing directory and tolerate deleted cwd/package roots during macOS LaunchAgent handoff. Fixes #83808. (#83875) Thanks @jason-allen-oneal.
+- Skills: watch each shared skill directory once across agent workspaces instead of once per agent, preventing file-descriptor exhaustion (`EMFILE`) that disposed bundle-mcp processes and stalled sessions on multi-agent gateways. Fixes #84968. (#85130) Thanks @openperf.
 - Cron: honor `cron.retry.retryOn: ["network"]` for common network error codes such as `EAI_AGAIN`, `EHOSTUNREACH`, and `ENETUNREACH`.
 - Agents/OpenAI: preserve structured provider error code, type, and redacted body metadata on boundary-aware transport failures.
 - Doctor/Codex: point native Codex asset warnings at the canonical `openclaw migrate plan codex` preview command. Fixes #84948. Thanks @markoa.

--- a/src/agents/skills/refresh.test.ts
+++ b/src/agents/skills/refresh.test.ts
@@ -58,12 +58,13 @@ describe("ensureSkillsWatcher", () => {
   it("watches skill roots and filters non-skill churn", () => {
     refreshModule.ensureSkillsWatcher({ workspaceDir: "/tmp/workspace" });
 
-    expect(watchMock).toHaveBeenCalledTimes(1);
-    const firstCall = (
-      watchMock.mock.calls as unknown as Array<[string[], { depth?: number; ignored?: unknown }]>
-    )[0];
-    const targets = firstCall?.[0] ?? [];
-    const opts = firstCall?.[1] ?? {};
+    // Each unique directory gets its own watcher (one path argument per call).
+    const calls = watchMock.mock.calls as unknown as Array<
+      [string, { depth?: number; ignored?: unknown }]
+    >;
+    expect(calls.length).toBeGreaterThan(0);
+    const targets = calls.map((call) => call[0]);
+    const opts = calls[0]?.[1] ?? {};
 
     expect(opts.ignored).toBe(refreshModule.shouldIgnoreSkillsWatchPath);
     expect(opts.depth).toBe(2);
@@ -110,7 +111,7 @@ describe("ensureSkillsWatcher", () => {
     });
 
     const firstCall = (
-      watchMock.mock.calls as unknown as Array<[string[], { depth?: number; ignored?: unknown }]>
+      watchMock.mock.calls as unknown as Array<[string, { depth?: number; ignored?: unknown }]>
     )[0];
     expect(firstCall?.[1]?.depth).toBe(2);
 
@@ -167,8 +168,13 @@ describe("ensureSkillsWatcher", () => {
       config: { skills: { load: { extraDirs: ["/tmp/shared-b"] } } },
     });
 
-    expect(watchMock).toHaveBeenCalledTimes(2);
-    expect(createdWatchers[0]?.close).toHaveBeenCalledTimes(1);
+    const callPaths = watchMock.mock.calls.map((call) => call[0] as unknown as string);
+    const sharedAIndex = callPaths.findIndex((target) => target.includes("/tmp/shared-a"));
+    // The dropped extra dir is unsubscribed and its watcher closed; the new dir
+    // gets a fresh watcher.
+    expect(sharedAIndex).toBeGreaterThanOrEqual(0);
+    expect(createdWatchers[sharedAIndex]?.close).toHaveBeenCalledTimes(1);
+    expect(callPaths.some((target) => target.includes("/tmp/shared-b"))).toBe(true);
     expect(seen).toEqual([
       {
         workspaceDir: "/tmp/workspace",
@@ -176,5 +182,56 @@ describe("ensureSkillsWatcher", () => {
         changedPath: expect.stringContaining("/tmp/shared-b"),
       },
     ]);
+  });
+
+  it("reuses one watcher when multiple workspaces watch the same shared skill root", () => {
+    refreshModule.ensureSkillsWatcher({
+      workspaceDir: "/tmp/ws-a",
+      config: { skills: { load: { extraDirs: ["/tmp/shared"] } } },
+    });
+    refreshModule.ensureSkillsWatcher({
+      workspaceDir: "/tmp/ws-b",
+      config: { skills: { load: { extraDirs: ["/tmp/shared"] } } },
+    });
+
+    const callPaths = watchMock.mock.calls.map((call) => call[0] as unknown as string);
+    // The shared directory is watched exactly once even though two workspaces
+    // include it, instead of one watcher per workspace (the EMFILE root cause).
+    const sharedWatchers = callPaths.filter((target) => target.includes("/tmp/shared"));
+    expect(sharedWatchers).toHaveLength(1);
+  });
+
+  it("fans out a shared-directory change to every subscribed workspace", async () => {
+    vi.useFakeTimers();
+    const seen: SkillsChangeEvent[] = [];
+    refreshModule.registerSkillsChangeListener((change) => {
+      seen.push(change);
+    });
+    refreshModule.ensureSkillsWatcher({
+      workspaceDir: "/tmp/ws-a",
+      config: { skills: { load: { extraDirs: ["/tmp/shared"], watchDebounceMs: 10 } } },
+    });
+    refreshModule.ensureSkillsWatcher({
+      workspaceDir: "/tmp/ws-b",
+      config: { skills: { load: { extraDirs: ["/tmp/shared"], watchDebounceMs: 10 } } },
+    });
+
+    const callPaths = watchMock.mock.calls.map((call) => call[0] as unknown as string);
+    const sharedIndex = callPaths.findIndex((target) => target.includes("/tmp/shared"));
+    expect(sharedIndex).toBeGreaterThanOrEqual(0);
+
+    createdWatchers[sharedIndex]?.emit("change", "/tmp/shared/demo/SKILL.md");
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(seen).toContainEqual({
+      workspaceDir: "/tmp/ws-a",
+      reason: "watch",
+      changedPath: "/tmp/shared/demo/SKILL.md",
+    });
+    expect(seen).toContainEqual({
+      workspaceDir: "/tmp/ws-b",
+      reason: "watch",
+      changedPath: "/tmp/shared/demo/SKILL.md",
+    });
   });
 });

--- a/src/agents/skills/refresh.test.ts
+++ b/src/agents/skills/refresh.test.ts
@@ -168,7 +168,7 @@ describe("ensureSkillsWatcher", () => {
       config: { skills: { load: { extraDirs: ["/tmp/shared-b"] } } },
     });
 
-    const callPaths = watchMock.mock.calls.map((call) => call[0] as unknown as string);
+    const callPaths = (watchMock.mock.calls as unknown as Array<[string]>).map((call) => call[0]);
     const sharedAIndex = callPaths.findIndex((target) => target.includes("/tmp/shared-a"));
     // The dropped extra dir is unsubscribed and its watcher closed; the new dir
     // gets a fresh watcher.
@@ -194,7 +194,7 @@ describe("ensureSkillsWatcher", () => {
       config: { skills: { load: { extraDirs: ["/tmp/shared"] } } },
     });
 
-    const callPaths = watchMock.mock.calls.map((call) => call[0] as unknown as string);
+    const callPaths = (watchMock.mock.calls as unknown as Array<[string]>).map((call) => call[0]);
     // The shared directory is watched exactly once even though two workspaces
     // include it, instead of one watcher per workspace (the EMFILE root cause).
     const sharedWatchers = callPaths.filter((target) => target.includes("/tmp/shared"));
@@ -216,7 +216,7 @@ describe("ensureSkillsWatcher", () => {
       config: { skills: { load: { extraDirs: ["/tmp/shared"], watchDebounceMs: 10 } } },
     });
 
-    const callPaths = watchMock.mock.calls.map((call) => call[0] as unknown as string);
+    const callPaths = (watchMock.mock.calls as unknown as Array<[string]>).map((call) => call[0]);
     const sharedIndex = callPaths.findIndex((target) => target.includes("/tmp/shared"));
     expect(sharedIndex).toBeGreaterThanOrEqual(0);
 

--- a/src/agents/skills/refresh.test.ts
+++ b/src/agents/skills/refresh.test.ts
@@ -234,4 +234,85 @@ describe("ensureSkillsWatcher", () => {
       changedPath: "/tmp/shared/demo/SKILL.md",
     });
   });
+
+  it("stops fanning a shared-directory change to a workspace after it unsubscribes", async () => {
+    vi.useFakeTimers();
+    const seen: SkillsChangeEvent[] = [];
+    refreshModule.registerSkillsChangeListener((change) => {
+      seen.push(change);
+    });
+    refreshModule.ensureSkillsWatcher({
+      workspaceDir: "/tmp/ws-a",
+      config: { skills: { load: { extraDirs: ["/tmp/shared"], watchDebounceMs: 10 } } },
+    });
+    refreshModule.ensureSkillsWatcher({
+      workspaceDir: "/tmp/ws-b",
+      config: { skills: { load: { extraDirs: ["/tmp/shared"], watchDebounceMs: 10 } } },
+    });
+
+    // ws-a turns watching off: it unsubscribes, but the shared watcher stays
+    // alive for ws-b (torn down only when the last subscriber leaves).
+    refreshModule.ensureSkillsWatcher({
+      workspaceDir: "/tmp/ws-a",
+      config: { skills: { load: { extraDirs: ["/tmp/shared"], watch: false } } },
+    });
+
+    const callPaths = (watchMock.mock.calls as unknown as Array<[string]>).map((call) => call[0]);
+    const sharedIndex = callPaths.findIndex((target) => target.includes("/tmp/shared"));
+    expect(sharedIndex).toBeGreaterThanOrEqual(0);
+
+    createdWatchers[sharedIndex]?.emit("change", "/tmp/shared/demo/SKILL.md");
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(seen).toContainEqual({
+      workspaceDir: "/tmp/ws-b",
+      reason: "watch",
+      changedPath: "/tmp/shared/demo/SKILL.md",
+    });
+    expect(seen.some((change) => change.workspaceDir === "/tmp/ws-a")).toBe(false);
+  });
+
+  it("rebuilds a shared watcher with last-writer debounce while preserving subscribers", async () => {
+    vi.useFakeTimers();
+    const seen: SkillsChangeEvent[] = [];
+    refreshModule.registerSkillsChangeListener((change) => {
+      seen.push(change);
+    });
+    refreshModule.ensureSkillsWatcher({
+      workspaceDir: "/tmp/ws-a",
+      config: { skills: { load: { extraDirs: ["/tmp/shared"], watchDebounceMs: 10 } } },
+    });
+    const callPaths1 = (watchMock.mock.calls as unknown as Array<[string]>).map((call) => call[0]);
+    const firstSharedIndex = callPaths1.findIndex((target) => target.includes("/tmp/shared"));
+
+    // ws-b subscribes to the same path with a different debounce: the shared
+    // watcher is rebuilt once, the previous instance closed, and both
+    // workspaces remain subscribed.
+    refreshModule.ensureSkillsWatcher({
+      workspaceDir: "/tmp/ws-b",
+      config: { skills: { load: { extraDirs: ["/tmp/shared"], watchDebounceMs: 50 } } },
+    });
+
+    expect(createdWatchers[firstSharedIndex]?.close).toHaveBeenCalledTimes(1);
+    const callPaths2 = (watchMock.mock.calls as unknown as Array<[string]>).map((call) => call[0]);
+    const sharedIndices = callPaths2
+      .map((target, index) => (target.includes("/tmp/shared") ? index : -1))
+      .filter((index) => index >= 0);
+    expect(sharedIndices).toHaveLength(2);
+    const liveSharedIndex = sharedIndices[sharedIndices.length - 1] ?? -1;
+
+    createdWatchers[liveSharedIndex]?.emit("change", "/tmp/shared/demo/SKILL.md");
+    await vi.advanceTimersByTimeAsync(50);
+
+    expect(seen).toContainEqual({
+      workspaceDir: "/tmp/ws-a",
+      reason: "watch",
+      changedPath: "/tmp/shared/demo/SKILL.md",
+    });
+    expect(seen).toContainEqual({
+      workspaceDir: "/tmp/ws-b",
+      reason: "watch",
+      changedPath: "/tmp/shared/demo/SKILL.md",
+    });
+  });
 });

--- a/src/agents/skills/refresh.ts
+++ b/src/agents/skills/refresh.ts
@@ -111,6 +111,8 @@ function resolveWatchDebounceMs(config?: OpenClawConfig): number {
   return typeof raw === "number" && Number.isFinite(raw) ? Math.max(0, raw) : 250;
 }
 
+// Requires resolveWatchTargets to produce a stable-order result (it returns a
+// sorted array); positional comparison is intentional for hot-path efficiency.
 function sameWatchTargets(a: string[], b: string[]): boolean {
   if (a.length !== b.length) {
     return false;
@@ -188,7 +190,10 @@ function subscribeWorkspaceToPath(
   }
   if (existing) {
     // Debounce changed (config reload): rebuild the shared watcher while
-    // preserving existing subscribers.
+    // preserving existing subscribers. Debounce is a gateway-global config
+    // value, so all workspaces normally request the same value and this branch
+    // does not fire; if it does, the most recent requested debounce wins for
+    // every subscriber of the shared path (last-writer-wins).
     const next = createSkillsPathWatcher(watchPath, debounceMs);
     for (const subscriber of existing.subscribers) {
       next.subscribers.add(subscriber);
@@ -237,6 +242,7 @@ export function ensureSkillsWatcher(params: { workspaceDir: string; config?: Ope
   const watchTargets = resolveWatchTargets(workspaceDir, params.config);
   const targetsUnchanged = sameWatchTargets(previousTargets, watchTargets);
   const debounceUnchanged = watchTargets.every(
+    // undefined for paths not yet watched -> false -> fall through to subscribe.
     (watchPath) => pathWatchers.get(watchPath)?.debounceMs === debounceMs,
   );
   if (targetsUnchanged && debounceUnchanged) {

--- a/src/agents/skills/refresh.ts
+++ b/src/agents/skills/refresh.ts
@@ -19,16 +19,24 @@ export {
   type SkillsChangeEvent,
 } from "./refresh-state.js";
 
-type SkillsWatchState = {
+type SkillsPathWatchState = {
   watcher: FSWatcher;
-  pathsKey: string;
   debounceMs: number;
   timer?: ReturnType<typeof setTimeout>;
   pendingPath?: string;
+  readonly subscribers: Set<string>;
 };
 
 const log = createSubsystemLogger("gateway/skills");
-const watchers = new Map<string, SkillsWatchState>();
+// One watcher per unique watched directory. Agent workspaces that include the
+// same shared skill root (the global skills dir, the home skills dir, or a
+// configured extra/plugin dir) subscribe to the same watcher instead of each
+// opening its own, so open file descriptors scale with distinct directories
+// rather than with agent count.
+const pathWatchers = new Map<string, SkillsPathWatchState>();
+// Watch targets each workspace is currently subscribed to, used to reconcile
+// subscriptions and to detect watch-target changes across calls.
+const workspaceWatchTargets = new Map<string, string[]>();
 
 setSkillsChangeListenerErrorHandler((err) => {
   log.warn(`skills change listener failed: ${String(err)}`);
@@ -98,45 +106,25 @@ export function shouldIgnoreSkillsWatchPath(
   return path.posix.basename(normalized) !== "SKILL.md";
 }
 
-export function ensureSkillsWatcher(params: { workspaceDir: string; config?: OpenClawConfig }) {
-  const workspaceDir = params.workspaceDir.trim();
-  if (!workspaceDir) {
-    return;
-  }
-  const watchEnabled = params.config?.skills?.load?.watch !== false;
-  const debounceMsRaw = params.config?.skills?.load?.watchDebounceMs;
-  const debounceMs =
-    typeof debounceMsRaw === "number" && Number.isFinite(debounceMsRaw)
-      ? Math.max(0, debounceMsRaw)
-      : 250;
+function resolveWatchDebounceMs(config?: OpenClawConfig): number {
+  const raw = config?.skills?.load?.watchDebounceMs;
+  return typeof raw === "number" && Number.isFinite(raw) ? Math.max(0, raw) : 250;
+}
 
-  const existing = watchers.get(workspaceDir);
-  if (!watchEnabled) {
-    if (existing) {
-      watchers.delete(workspaceDir);
-      if (existing.timer) {
-        clearTimeout(existing.timer);
-      }
-      void existing.watcher.close().catch(() => {});
+function sameWatchTargets(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  for (let index = 0; index < a.length; index++) {
+    if (a[index] !== b[index]) {
+      return false;
     }
-    return;
   }
+  return true;
+}
 
-  const watchTargets = resolveWatchTargets(workspaceDir, params.config);
-  const pathsKey = watchTargets.join("|");
-  if (existing && existing.pathsKey === pathsKey && existing.debounceMs === debounceMs) {
-    return;
-  }
-  const watchTargetsChanged = existing ? existing.pathsKey !== pathsKey : false;
-  if (existing) {
-    watchers.delete(workspaceDir);
-    if (existing.timer) {
-      clearTimeout(existing.timer);
-    }
-    void existing.watcher.close().catch(() => {});
-  }
-
-  const watcher = chokidar.watch(watchTargets, {
+function createSkillsPathWatcher(watchPath: string, debounceMs: number): SkillsPathWatchState {
+  const watcher = chokidar.watch(watchPath, {
     ignoreInitial: true,
     // Skill discovery reads root skills, direct child skills, and one grouped skill level.
     depth: 2,
@@ -147,7 +135,7 @@ export function ensureSkillsWatcher(params: { workspaceDir: string; config?: Ope
     ignored: shouldIgnoreSkillsWatchPath,
   });
 
-  const state: SkillsWatchState = { watcher, pathsKey, debounceMs };
+  const state: SkillsPathWatchState = { watcher, debounceMs, subscribers: new Set<string>() };
 
   const schedule = (changedPath?: string) => {
     state.pendingPath = changedPath ?? state.pendingPath;
@@ -158,11 +146,15 @@ export function ensureSkillsWatcher(params: { workspaceDir: string; config?: Ope
       const pendingPath = state.pendingPath;
       state.pendingPath = undefined;
       state.timer = undefined;
-      bumpSkillsSnapshotVersion({
-        workspaceDir,
-        reason: "watch",
-        changedPath: pendingPath,
-      });
+      // Fan the change out to every workspace subscribed to this directory so a
+      // shared skill root refreshes the snapshot for all agents that use it.
+      for (const workspaceDir of state.subscribers) {
+        bumpSkillsSnapshotVersion({
+          workspaceDir,
+          reason: "watch",
+          changedPath: pendingPath,
+        });
+      }
     }, debounceMs);
   };
 
@@ -171,15 +163,103 @@ export function ensureSkillsWatcher(params: { workspaceDir: string; config?: Ope
   watcher.on("unlink", (p) => schedule(p));
   watcher.on("unlinkDir", (p) => schedule(p));
   watcher.on("error", (err) => {
-    log.warn(`skills watcher error (${workspaceDir}): ${String(err)}`);
+    log.warn(`skills watcher error (${watchPath}): ${String(err)}`);
   });
 
-  watchers.set(workspaceDir, state);
+  return state;
+}
+
+function teardownSkillsPathWatcher(state: SkillsPathWatchState): void {
+  if (state.timer) {
+    clearTimeout(state.timer);
+  }
+  void state.watcher.close().catch(() => {});
+}
+
+function subscribeWorkspaceToPath(
+  workspaceDir: string,
+  watchPath: string,
+  debounceMs: number,
+): void {
+  const existing = pathWatchers.get(watchPath);
+  if (existing && existing.debounceMs === debounceMs) {
+    existing.subscribers.add(workspaceDir);
+    return;
+  }
+  if (existing) {
+    // Debounce changed (config reload): rebuild the shared watcher while
+    // preserving existing subscribers.
+    const next = createSkillsPathWatcher(watchPath, debounceMs);
+    for (const subscriber of existing.subscribers) {
+      next.subscribers.add(subscriber);
+    }
+    next.subscribers.add(workspaceDir);
+    teardownSkillsPathWatcher(existing);
+    pathWatchers.set(watchPath, next);
+    return;
+  }
+  const state = createSkillsPathWatcher(watchPath, debounceMs);
+  state.subscribers.add(workspaceDir);
+  pathWatchers.set(watchPath, state);
+}
+
+function unsubscribeWorkspaceFromPath(workspaceDir: string, watchPath: string): void {
+  const state = pathWatchers.get(watchPath);
+  if (!state) {
+    return;
+  }
+  state.subscribers.delete(workspaceDir);
+  if (state.subscribers.size === 0) {
+    teardownSkillsPathWatcher(state);
+    pathWatchers.delete(watchPath);
+  }
+}
+
+export function ensureSkillsWatcher(params: { workspaceDir: string; config?: OpenClawConfig }) {
+  const workspaceDir = params.workspaceDir.trim();
+  if (!workspaceDir) {
+    return;
+  }
+  const watchEnabled = params.config?.skills?.load?.watch !== false;
+  const debounceMs = resolveWatchDebounceMs(params.config);
+  const previousTargets = workspaceWatchTargets.get(workspaceDir) ?? [];
+
+  if (!watchEnabled) {
+    if (previousTargets.length > 0) {
+      for (const watchPath of previousTargets) {
+        unsubscribeWorkspaceFromPath(workspaceDir, watchPath);
+      }
+      workspaceWatchTargets.delete(workspaceDir);
+    }
+    return;
+  }
+
+  const watchTargets = resolveWatchTargets(workspaceDir, params.config);
+  const targetsUnchanged = sameWatchTargets(previousTargets, watchTargets);
+  const debounceUnchanged = watchTargets.every(
+    (watchPath) => pathWatchers.get(watchPath)?.debounceMs === debounceMs,
+  );
+  if (targetsUnchanged && debounceUnchanged) {
+    return;
+  }
+  const watchTargetsChanged = previousTargets.length > 0 && !targetsUnchanged;
+
+  const nextTargets = new Set(watchTargets);
+  for (const watchPath of previousTargets) {
+    if (!nextTargets.has(watchPath)) {
+      unsubscribeWorkspaceFromPath(workspaceDir, watchPath);
+    }
+  }
+  for (const watchPath of watchTargets) {
+    subscribeWorkspaceToPath(workspaceDir, watchPath, debounceMs);
+  }
+  workspaceWatchTargets.set(workspaceDir, watchTargets);
+
   if (watchTargetsChanged) {
     bumpSkillsSnapshotVersion({
       workspaceDir,
       reason: "watch-targets",
-      changedPath: pathsKey,
+      changedPath: watchTargets.join("|"),
     });
   }
 }
@@ -187,8 +267,9 @@ export function ensureSkillsWatcher(params: { workspaceDir: string; config?: Ope
 export async function resetSkillsRefreshForTest(): Promise<void> {
   resetSkillsRefreshStateForTest();
 
-  const active = Array.from(watchers.values());
-  watchers.clear();
+  const active = Array.from(pathWatchers.values());
+  pathWatchers.clear();
+  workspaceWatchTargets.clear();
   await Promise.all(
     active.map(async (state) => {
       if (state.timer) {


### PR DESCRIPTION
### Summary

- **Problem**: On multi-agent gateways, `ensureSkillsWatcher` in `src/agents/skills/refresh.ts` keeps its active watchers in a map keyed by `workspaceDir` and creates one `chokidar` watcher per workspace. Every workspace's watch-target list also includes the shared skill roots (the global `CONFIG_DIR/skills` directory, the home `~/.agents/skills` directory, configured `skills.load.extraDirs`, and plugin skill dirs). As a result the same shared directory is watched once per agent. At ~28 agents the redundant recursive watchers exhaust file descriptors, `EMFILE` cascades through the gateway, `bundle-mcp` child processes are disposed mid-session, and agent sessions are left stuck in `status=running` until a full gateway restart.
- **Root Cause**: Watcher ownership is per-workspace, but the watched directories are largely shared across workspaces. Because `resolveWatchTargets` returns the shared roots for every workspace and watchers are keyed by `workspaceDir`, the shared roots are watched `N` times for `N` agents. File-descriptor usage therefore scales with agent count instead of with the number of distinct directories, which is the linear-scaling wall the report describes. Raising `LimitNOFILE` only delays the wall; disabling `skills.load.watch` removes the feature. Neither addresses the redundant-watcher mechanism.
- **Fix**: Make watcher ownership per-directory instead of per-workspace. Watchers are now keyed by the normalized watch-target path, and each watcher carries a set of subscriber workspaces. When a workspace is ensured, its target set is reconciled against its previous subscriptions: new targets subscribe to (or create) the shared watcher, dropped targets unsubscribe, and a watcher is torn down only when its last subscriber leaves. A filesystem event fans the snapshot bump out to every subscribed workspace, preserving the existing per-workspace refresh semantics. This removes the per-agent multiplication so descriptors scale with distinct directories, while keeping all previously notified workspaces notified. The runtime resolver, traversal depth, debounce, ignore rules, and `watch-targets` change semantics are unchanged.
- **What changed**:
  - `src/agents/skills/refresh.ts`: replaced the `workspaceDir`-keyed `watchers` map with a path-keyed `pathWatchers` registry plus a `workspaceWatchTargets` reverse index; added `subscribeWorkspaceToPath` / `unsubscribeWorkspaceFromPath` reconciliation, `createSkillsPathWatcher` / `teardownSkillsPathWatcher` lifecycle helpers, and `resolveWatchDebounceMs` / `sameWatchTargets` helpers; the debounced handler now fans the snapshot bump out to all subscribers; `resetSkillsRefreshForTest` closes the path-keyed watchers.
  - `src/agents/skills/refresh.test.ts`: updated existing assertions for the per-directory watcher shape (single-path `chokidar.watch` calls; dropped-extra-dir teardown by path) and added regression tests that a shared directory is watched exactly once across two workspaces, that a shared-directory change fans out to every subscribed workspace, that fan-out stops for a workspace after it unsubscribes while remaining subscribers still fire, and that a debounce change rebuilds the shared watcher once while preserving subscribers.
  - `CHANGELOG.md`: added a single-line `### Fixes` entry for the multi-agent `EMFILE` fix.
- **What did NOT change (scope boundary)**:
  - `resolveWatchPaths` / `resolveWatchTargets` (which directories are watched) are unchanged — only how watchers are owned and shared.
  - Traversal `depth: 2`, `awaitWriteFinish` debounce, `shouldIgnoreSkillsWatchPath` ignore rules, and `DEFAULT_SKILLS_WATCH_IGNORED` are unchanged.
  - The `watch-targets` snapshot-bump behaviour and the `bumpSkillsSnapshotVersion` contract from `refresh-state.ts` are unchanged.
  - `skills.load.watch === false` still tears down the workspace's subscriptions; no config keys, defaults, or public surfaces were added.
  - No change to `LimitNOFILE` guidance or any runtime/auth/provider path.

### Reproduction

1. Run a multi-agent gateway with `agents.list[]` containing ~25+ entries.
2. Have each agent's skills allowlist include a shared directory under `CONFIG_DIR/skills/` (e.g. a shared `master-mcp` skill bundle).
3. Watch gateway logs: `gateway/skills` reports `EMFILE: too many open files, watch '<shared dir>'`, `bundle-mcp` reports `Connection closed`, and sessions stall with `status=running`.

Before the fix, the shared directory is watched once per agent, so descriptors scale with agent count and EMFILE cascades. After the fix, the shared directory is watched once total and changes still refresh every agent that uses it.

### Real behavior proof

- **Behavior addressed**: On a multi-agent gateway every agent workspace opened its own `chokidar` watcher over the shared skills directory, so open file descriptors grew once per agent until `EMFILE` cascaded and disposed `bundle-mcp` sessions.
- **Real environment tested**: Linux, Node.js 22, real `chokidar` 5.0.0 and the real patched `ensureSkillsWatcher` from `src/agents/skills/refresh.ts` driving real on-disk shared and per-workspace skill directories (the watcher layer is not stubbed).
- **Exact steps or command run after this patch**: Ran a `node` (tsx) script that wrapped the real `chokidar.watch` with a pass-through counter, created one shared directory plus N real workspace directories all configured with the shared directory as `skills.load.extraDirs`, then invoked the patched `ensureSkillsWatcher` once per workspace and counted the real `FSWatcher` instances opened on the shared directory for 5, 20, and 50 agents.
- **Evidence after fix**: console output from the run:
  ```
  agents | shared-dir FSWatcher instances (after fix) | before fix
  ----------------------------------------------------------------------
       5 |                                          1 |         5
      20 |                                          1 |        20
      50 |                                          1 |        50
  ```
- **Observed result after fix**: the shared directory keeps exactly one live `FSWatcher` for 5, 20, and 50 agents instead of one per agent. Open descriptors now scale with distinct directories rather than agent count, so the `EMFILE` wall no longer forms, and every subscribed workspace is still notified when the shared directory changes.
- **What was not tested**: a full 28+ agent production gateway under sustained live load was not run; the run exercises the real watcher-ownership path that determines the descriptor count rather than reproducing a live `EMFILE` outage end to end.

### Risk / Mitigation

- **Risk**: A shared watcher is closed while a workspace still needs it, or a shared-directory change stops refreshing some subscribed workspaces.
- **Mitigation**: A watcher is torn down only when its subscriber set becomes empty (reference-counted by workspace), and the debounced handler iterates the live subscriber set at fire time, so every subscribed workspace is refreshed. Existing `refresh.test.ts` cases (root coverage, grouped-depth traversal, per-event refresh, watch-targets change) still pass, and new tests assert single-watcher dedupe and multi-workspace fan-out. `src/auto-reply/reply/session-updates.test.ts` (the caller) passes. Prod typecheck (`tsgo:core`), `oxfmt`, and `oxlint` are clean. No `any` types were introduced.

### Follow-up (out of scope here)

This change collapses redundant watchers on shared roots, so descriptor usage scales with distinct watched directories instead of agent count — the floor for one-watcher-per-directory. A deployment with a very large number of genuinely distinct skill directories would still open one watcher per directory. Pushing past that floor (e.g. a single shared inotify instance with many cheap watches, or an opt-in polling strategy) is a separate watcher-subsystem effort and intentionally not bundled into this fix; `skills.load.watch: false` and a raised descriptor limit remain valid mitigations for that distinct case.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Gateway
- [x] Agents / skills runtime
- [x] Tests

### Linked Issue/PR

Fixes #84968
