### PR TITLE
docs(install): correct Kynver patch channel guide for seam-only reality

### DIFF
--- a/docs/install/kynver-patch-channel.md
+++ b/docs/install/kynver-patch-channel.md
@@ -1,0 +1,331 @@
+---
+summary: "Patch channel for collaborators who run their own OpenClaw and want the fork runtime fixes, the agent-harness tool seam for Kynver tools, and operator harness visibility"
+read_when:
+  - You already run OpenClaw and want the fork patch set
+  - You need install, update, or rollback for the patch channel
+  - You need to keep stock openclaw update from clobbering the fork
+title: "Kynver patch channel"
+sidebarTitle: "Kynver Patch Channel"
+---
+
+This page is for technical collaborators and dogfood users who already run their
+own OpenClaw and want one place to patch it with the fork runtime fixes, the
+agent-harness tool seam for building Kynver first-class tools, and the operator
+harness visibility that makes long-running coding work manageable.
+
+It is a curated patch line you build and run yourself on top of stock OpenClaw.
+It does not replace stock OpenClaw and it is not a hosted service. This page
+covers what the patch does and how to install, operate, and roll it back. It
+deliberately does not document harness orchestration internals.
+
+## Who this is for
+
+- You already operate an OpenClaw gateway and are comfortable with a source
+  checkout, `pnpm`, and a service manager.
+- You want the fork runtime fixes plus the agent-harness tool seam for Kynver
+  tools in one place instead of cherry-picking patches.
+- You run long coding sessions and need operator visibility into what each
+  worker is doing.
+
+If you only want stock OpenClaw, use the normal [install](/install) and
+[updating](/install/updating) flows instead. This patch channel adds operating
+burden in exchange for the fork patch set.
+
+## Where the patch lives
+
+The patch line is published on the fork remote:
+
+```
+https://github.com/Totalsolutionsync/openclaw
+```
+
+There are currently two relevant lines, and they are not yet unified. Always
+pin to a specific commit, never to a moving branch.
+
+- **Dogfood line.** Branch `agent/phase05b-safe-prep`, current tip commit
+  `d71d84f`. This carries the reproducible build, deploy, and rollback pipeline,
+  the worker-completion wake, the public agent-harness tool seam, and a set of
+  forward-ported runtime fixes. This is the line this page documents.
+- **Runtime line.** Branch `agent/lane-pump-and-stall-recovery`, commit
+  `9d2731780`. This is where the lane pump and stall recovery work lives. It is
+  the source of the local release id `fork-9d273178-...` and is **not** merged
+  into the dogfood line yet.
+
+A release id like `fork-9d273178-...` names the commit it was built from. If you
+are running that release you are on the runtime line (`9d2731780`), not the
+dogfood line (`d71d84f`). Confirm which line you are on before reporting a fix as
+present or missing:
+
+```bash
+git -C <checkout> rev-parse HEAD
+git -C <checkout> log --oneline -1
+```
+
+## What runtime fixes are included
+
+Verified on the dogfood line (`agent/phase05b-safe-prep` at `d71d84f`), phrased
+from an operator point of view:
+
+- **Reproducible deploys with one-command rollback.** Every deploy is one whole
+  consistent build, activated by an atomic symlink swap, and rollback is the same
+  swap in reverse. A half-applied or mixed-commit build is refused before it goes
+  live. See [Deploy pipeline](/reference/deploy-pipeline).
+- **Telegram runtime resilience.** Spool timeout recovery, preserved reply
+  context, topic and queue handling, and native progress drafts so long turns do
+  not spam the transcript or strand a reply.
+- **Auth resilience.** Legacy OAuth sidecar helpers consolidated, xAI
+  device-code OAuth login, and recovery from stuck auth loops and stale
+  release-stability stalls.
+- **Forward-ported stability fixes** from the Tideclaw alpha release line.
+- **Provider robustness.** Per-provider timeout overlays, per-agent local model
+  lean mode, and decoding of remote URL fallback filenames.
+- **Agent runtime hygiene.** Trajectory flush timeout diagnostics, recovery of
+  stale subagent completion announcements, and deduplication of duplicate
+  embedded run clears.
+
+This list reflects one release line. Treat anything not listed here, and
+anything in [What is not guaranteed yet](#what-is-not-guaranteed-yet), as
+unconfirmed until you check the commit you are running.
+
+## What harness and operator capabilities are included
+
+The patch line ships the operator visibility layer that made long-running coding
+work manageable. From an operator point of view you get:
+
+- **Worker board and run view.** See every worker in a run at a glance, with
+  status.
+- **Status and tail.** Check a worker current state and follow its live output.
+- **Heartbeat visibility.** Each worker writes periodic progress heartbeats, so
+  you can tell a slow worker from a stuck one.
+- **Stale and no-start detection.** Workers that never started, or stopped
+  reporting, are surfaced instead of hanging silently.
+- **Changed-file tracking.** See which files each worker has touched.
+- **Owned-path guidance.** Each worker is scoped to a set of owned paths and
+  reports when work would fall outside them.
+- **Multi-worker run view.** One run can fan out to several workers; the board
+  shows them together.
+- **Review and landing visibility.** See which workers are in review and which
+  have landed.
+- **Worker-completion wake.** When a detached worker finishes, the requesting
+  session is woken to review and report rather than waiting for the next poll.
+
+Before this layer existed, a stuck worker was indistinguishable from a slow one
+and long coding runs were impossible to manage. The operator workflow that uses
+these capabilities is described in
+[Agent harness operator workflow](#agent-harness-operator-workflow).
+
+## What is not guaranteed yet
+
+These are referenced by the patch set but are **not** in the dogfood line.
+Confirm support before relying on them.
+
+- **Lane pump and stall recovery.** Lives on
+  `agent/lane-pump-and-stall-recovery` (commit `9d2731780`); not merged into the
+  dogfood line. Run that line, or wait for the merge, if you need it.
+- **Kynver first-class tools and `@kynver-app/openclaw-agent-os`.** The public
+  tool seam ships in the dogfood line, but the Kynver AgentOS plugin package is
+  not wired into it yet. See [Kynver first-class tools](#kynver-first-class-tools)
+  and [Follow-ups](#follow-ups).
+- **Operator-control pipeline and channel auto-restart.** Stale ingress
+  detection and restart of running-but-nonfunctional channels live on
+  `phase1-openclaw-responsiveness`; not in this line.
+
+To check what you actually have:
+
+```bash
+git -C <checkout> rev-parse HEAD          # which commit / line
+openclaw --version
+openclaw plugins list --json              # which plugins loaded
+openclaw doctor --lint --json             # health and config audit
+```
+
+Compare `HEAD` against the commits above to know which line you are on.
+
+## Install
+
+Prerequisites: an existing OpenClaw setup, Node 22.19 or newer (Node 24
+recommended), and `pnpm`.
+
+```bash
+git clone https://github.com/Totalsolutionsync/openclaw.git
+cd openclaw
+git remote rename origin fork    # optional, keeps the source obvious
+git fetch fork
+git checkout <commit>            # pin to a commit, e.g. the dogfood tip
+pnpm install
+```
+
+If the native image dependency fails to build (Homebrew libvips), retry with
+`SHARP_IGNORE_GLOBAL_LIBVIPS=1 pnpm install`.
+
+Build and deploy through the pipeline so you get atomic activation and rollback.
+Choose a deploy root outside the source checkout:
+
+```bash
+node scripts/deploy-pipeline.mjs deploy --clean --deploy-root <deploy-root>
+```
+
+Then point your service start command at `<deploy-root>/current/dist/index.js`
+(the symlink, never a release id) and restart the service once to adopt it. The
+full mechanics, including the first cutover from a live service, are in
+[Deploy pipeline](/reference/deploy-pipeline).
+
+Verify from the active release, not a stray global install:
+
+```bash
+node <deploy-root>/current/dist/index.js --version
+node <deploy-root>/current/dist/index.js doctor
+```
+
+## Update
+
+To move to a newer patch commit:
+
+```bash
+git -C <checkout> fetch fork
+git -C <checkout> checkout <new-commit>
+pnpm install
+node scripts/deploy-pipeline.mjs deploy --clean --deploy-root <deploy-root>
+# restart the service to pick up current
+```
+
+Each deploy is a new immutable release; the previous release stays on disk for
+rollback.
+
+## Rollback
+
+```bash
+node scripts/deploy-pipeline.mjs list --deploy-root <deploy-root>
+node scripts/deploy-pipeline.mjs rollback --deploy-root <deploy-root>
+# restart the service
+```
+
+Rollback is the same atomic symlink swap in reverse. If a deploy looks wrong,
+roll back first, then diagnose.
+
+## Update guard: do not let stock update clobber the fork
+
+This is the most common way to lose the patch line. Stock `openclaw update` is
+built to track upstream OpenClaw, not the fork:
+
+- `openclaw update --channel dev` checks out `main` and rebases on **upstream**,
+  replacing the fork checkout.
+- The stable and beta channels install the upstream npm package.
+
+Either path overwrites the patch line. On a patched install:
+
+- Disable automatic updates and the startup update hint in
+  `~/.openclaw/openclaw.json`:
+
+  ```json5
+  {
+    update: {
+      checkOnStart: false,
+      auto: { enabled: false },
+    },
+  }
+  ```
+
+- Set `OPENCLAW_NO_AUTO_UPDATE=1` in the gateway environment as a hard block
+  against automatic applies.
+- Update **only** through the fork remote and the deploy pipeline shown above. Do
+  not run `openclaw update` on a patched install.
+- If you also run stock OpenClaw, keep the patched install and the stock install
+  in separate checkouts and separate deploy roots, so an update on one cannot
+  touch the other.
+
+## Kynver first-class tools
+
+Status: the public tool seam ships in the dogfood line; the Kynver AgentOS plugin
+is a follow-up (see [Follow-ups](#follow-ups)). Until that plugin is wired in,
+treat Kynver first-class tools as not guaranteed on this line.
+
+OpenClaw exposes a public agent-harness tool seam at
+`openclaw/plugin-sdk/agent-harness` (with a runtime subpath for async paths). A
+plugin can register a custom agent runtime that uses OpenClaw coding tools
+through `createOpenClawCodingTools`, so Kynver tools run as first-class OpenClaw
+tools rather than bolted-on shims. No core patch is required for the mechanism.
+
+When the Kynver AgentOS plugin is available, install and verify it like any other
+OpenClaw plugin:
+
+```bash
+openclaw plugins install @kynver-app/openclaw-agent-os
+openclaw plugins list --json    # confirm it loaded and registered its tools
+```
+
+The plugin registers its tools through the seam above. Confirm the tools appear
+in `openclaw plugins list` and in your agent tool list before relying on them.
+
+## Agent harness operator workflow
+
+The harness runs each task as one or more workers, each in an isolated git
+worktree, scoped to a set of owned paths, and writing progress heartbeats. As an
+operator you work from the run view and the worker board rather than from
+individual processes:
+
+- List the workers in a run and read their status.
+- Tail a worker live output, and check the changed files it has produced.
+- Watch heartbeats; stale or no-start workers are surfaced for you.
+- See which workers are in review and which have landed.
+- When a worker completes, the requesting session is woken to review and report.
+
+This page documents what you see and do as an operator. It does not document how
+the harness schedules or orchestrates workers. For the build, deploy, and
+rollback mechanics that operators and workers share, see
+[Deploy pipeline](/reference/deploy-pipeline).
+
+## Support and troubleshooting
+
+For macOS operators, in rough order of how often they come up:
+
+- **Run doctor from the active release.** Use
+  `node <deploy-root>/current/dist/index.js doctor`. A `doctor` invoked from a
+  different `openclaw` still on `PATH` probes that install, not the running
+  release, and can report false channel-load failures for channels the gateway
+  in fact starts cleanly.
+- **Restart the managed gateway** with `openclaw gateway restart` (add `--deep`
+  for managed installs). Restart means rebuild, reinstall, and relaunch, not kill
+  and launch. Read logs with the gateway log helper.
+- **LaunchAgent installed but not loaded** after an update or deploy: run
+  `openclaw gateway install --force`, then `openclaw gateway restart`.
+- **Native build failures** (sharp or libvips through Homebrew):
+  `SHARP_IGNORE_GLOBAL_LIBVIPS=1 pnpm install`.
+- **pnpm or corepack bootstrap errors** on a source update: install `pnpm`
+  manually (or re-enable corepack) and rerun.
+- **Confirm reachability** of a running gateway:
+
+  ```bash
+  curl -fsS http://127.0.0.1:18789/readyz
+  openclaw gateway status --deep --json
+  ```
+
+- **Something broke right after a patch deploy:** roll back first (it is atomic),
+  restart, then diagnose from the known-good release.
+
+## Follow-ups
+
+These are intentionally out of scope for this docs change and need their own
+branches with build, test, and review proof.
+
+1. **Wire `@kynver-app/openclaw-agent-os` into the dogfood line.** The public
+   seam (`openclaw/plugin-sdk/agent-harness`, `createOpenClawCodingTools`)
+   already exists, so no core seam change is required first. The wiring adds a
+   runtime dependency, lockfile churn, and plugin registration plus config
+   schema, which exceeds a docs-only change and needs its own proof.
+2. **Reconcile the two lines.** Merge lane pump and stall recovery
+   (`agent/lane-pump-and-stall-recovery`, `9d2731780`) into the dogfood line, or
+   document a single unified line. Today the release id `fork-9d273178-...` and
+   the dogfood tip `d71d84f` are different lines, which is easy to confuse.
+3. **Decide on phase 1 responsiveness.** Whether to fold in the operator-control
+   pipeline, stale ingress detection, and channel auto-restart from
+   `phase1-openclaw-responsiveness`. This is gateway runtime behavior and
+   needs separate review.
+
+## Related
+
+- [Deploy pipeline](/reference/deploy-pipeline)
+- [Updating](/install/updating)
+- [Release channels](/install/development-channels)
+- [Doctor](/gateway/doctor)
+- [Troubleshooting](/gateway/troubleshooting)

--- a/docs/reference/deploy-pipeline.md
+++ b/docs/reference/deploy-pipeline.md
@@ -1,0 +1,264 @@
+# Reproducible build / deploy / rollback pipeline
+
+`scripts/deploy-pipeline.mjs` turns one clean OpenClaw build into an immutable,
+versioned, atomically activatable release. Every change ships through it so a
+deploy is always **one whole consistent `dist`**, never an in-place overlay of
+loose files.
+
+Run it directly or via the package script:
+
+```bash
+node scripts/deploy-pipeline.mjs <command> [options]
+pnpm deploy:pipeline <command> [options]
+```
+
+## Why a pipeline
+
+A prior practice of copying freshly compiled files on top of an existing `dist`
+("dist overlays") produced builds that mixed artifacts from two different
+commits and broke at runtime. The pipeline removes that failure mode:
+
+- The build runs to completion or the dist is rejected — no partial dist.
+- Each release is copied **whole** into its own immutable directory. Releases
+  are never re-staged on top of; a new build always gets a new release id.
+- Activation is a single symlink swap, so a release is either fully live or not
+  live at all. Rollback is the same swap in reverse.
+- Every release is a complete runnable package root, verified as such before it
+  goes live — never a bare `dist/` that boots but cannot start a channel.
+
+## Layout
+
+The pipeline owns a **deploy root** — a directory outside the source checkout.
+Pass it with `--deploy-root <path>` or the `OPENCLAW_DEPLOY_ROOT` env var.
+
+```
+<deploy-root>/
+  releases/
+    <release-id>/      a complete, runnable OpenClaw package root:
+      dist/            the build output
+      package.json     + openclaw.mjs, docs/, skills/, … (package.json "files")
+      release.json     manifest: id, version, commit, stagedAt, distHash
+  node_modules/        shared once; releases resolve dependencies through it
+  current -> releases/<release-id>     atomically swapped symlink
+  activations.jsonl    append-only audit log of every activate/rollback
+```
+
+A release id is `<version>-<commit12>-<utc-timestamp>`, e.g.
+`2026.5.19-57ec361682e0-2026-05-18t12-00-00-000z`. The runtime/service should
+run `<deploy-root>/current/dist/index.js` and follow the symlink on each start.
+
+A release is a **complete package root**, not a bare `dist/`. OpenClaw resolves
+bundled channel plugins by walking up from `dist/` for an `openclaw`
+`package.json`, and reads runtime assets (e.g. `docs/reference/templates/`) from
+the package root — a dist-only release boots but cannot start a channel. `stage`
+therefore copies `dist/` plus every top-level entry that `package.json` "files"
+declares. `node_modules` is large and version-stable, so it is shared once at
+the deploy root rather than copied per release; Node resolves it by walking up
+from a release's `dist/`.
+
+## Commands
+
+| Command         | What it does                                                        |
+| --------------- | ------------------------------------------------------------------- |
+| `verify [dir]`  | Check that a dist (default `./dist`) is whole and consistent.       |
+| `build`         | Run `pnpm build` + `pnpm ui:build`, then verify the resulting dist. |
+| `stage`         | Verify `./dist` and copy it as a new immutable release.             |
+| `activate [id]` | Atomically point `current` at a release (default: newest staged).   |
+| `rollback`      | Atomically point `current` back at the previously active release.   |
+| `deploy`        | `build` → `stage` → `activate`, in one step.                        |
+| `list`          | List staged releases and mark the active one.                       |
+| `prune`         | Remove old releases, keeping `--keep` most recent.                  |
+
+### Options
+
+| Option                  | Meaning                                                                                                                                    |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--dry-run`, `-n`       | Print every action; change nothing on disk; run no build. A dry-run `deploy` previews every step even with no `./dist` present.            |
+| `--deploy-root <dir>`   | Deploy root location (or set `OPENCLAW_DEPLOY_ROOT`).                                                                                      |
+| `--dist <dir>`          | Dist directory to verify/stage (default `./dist`).                                                                                         |
+| `--release`             | `verify`: check a staged release _package root_ (the full dist-only guard) instead of a bare dist; default target `<deploy-root>/current`. |
+| `--clean`               | `build`/`deploy`: run `pnpm install --frozen-lockfile` first.                                                                              |
+| `--expect-commit <sha>` | Fail verification unless the dist was built from `<sha>`.                                                                                  |
+| `--keep <n>`            | `prune`: number of recent releases to keep (default 5).                                                                                    |
+| `--id <id>`             | `stage`: use an explicit release id instead of generating one.                                                                             |
+| `--health-cmd <cmd>`    | `activate`/`deploy`: shell command run after activation; on failure `current` rolls back.                                                  |
+| `--health-timeout <s>`  | `--health-cmd` timeout in seconds (default 120).                                                                                           |
+
+## Consistency checks (the anti-overlay guard)
+
+`verify` — run before every `stage` and before every `activate` — refuses a
+dist that is not a single clean build:
+
+1. **Completeness.** `index.js`, `.buildstamp`, `.runtime-postbuildstamp`,
+   `build-info.json`, a non-empty `plugin-sdk/`, `plugins/runtime/index.js`,
+   and the Control UI bundle (`control-ui/index.html` plus a non-empty
+   `control-ui/assets/`) must all be present. These come from distinct build
+   phases, so a missing one means the build was interrupted. The Control UI is
+   built by a separate `pnpm ui:build` (vite) phase — `pnpm build` alone does
+   not emit it — so `build`/`deploy` run `ui:build` after `pnpm build`. A dist
+   without it boots but the gateway logs `Missing Control UI assets at
+<release>/dist/control-ui/index.html` and serves no web UI.
+2. **Single-commit provenance.** `build-info.json`, `.buildstamp`, and
+   `.runtime-postbuildstamp` each record the git commit they were built from.
+   A genuine build writes the same commit to all three. **Divergent commits are
+   the signature of a dist overlay** — files from one build copied on top of
+   another — and verification fails.
+3. **Version match.** `build-info.json`'s version must equal the repo
+   `package.json` version.
+4. **Optional pinning.** `--expect-commit <sha>` fails the dist unless it was
+   built from exactly that commit.
+
+At `stage` time the pipeline records a SHA-256 `distHash` of the whole tree in
+`release.json`. `activate` recomputes it and refuses the release if it differs —
+catching any modification made to an artifact after it was staged.
+
+### Release-package check
+
+Before every `activate`, the staged release is additionally checked as a
+_runnable package_ — not just a dist:
+
+- the dist passes every check above;
+- `package.json` is present and named `openclaw`;
+- every top-level entry `package.json` "files" declares is present
+  (`dist/`, `openclaw.mjs`, `docs/`, `skills/`, …);
+- a `node_modules` is reachable by walking up from the release `dist/`.
+
+A dist-only release boots but cannot start any channel ("Unable to resolve
+plugin runtime module") or dispatch a message ("Missing workspace template").
+This check refuses such a release before it is activated.
+
+The same check is available on demand as `verify --release <release-dir>`. It
+is read-only — it never moves `current` or restarts anything — so a staged
+release can be smoke-checked before a cutover is attempted. With no directory
+argument it checks `<deploy-root>/current`.
+
+```bash
+# Smoke-check a staged release as a runnable package, touching nothing live:
+node scripts/deploy-pipeline.mjs verify --release \
+  /srv/openclaw/releases/2026.5.12-f066dd2f31c0-2026-05-19t00-00-00-000z
+```
+
+## Atomic activation and rollback
+
+`activate` writes a new symlink to a temporary name, then `rename()`s it over
+`current`. On POSIX this replaces the symlink atomically: readers always see a
+complete release. Every activation appends an entry to `activations.jsonl` with
+the release that was active before it, which is what `rollback` reads to find
+its target.
+
+> **Windows.** Directory symlinks are created as junctions, and the swap removes
+> the old `current` before renaming the new one — a sub-millisecond window where
+> `current` is briefly absent. POSIX hosts have no such window.
+
+## Wiring a service to the pipeline
+
+The pipeline stages and activates releases, but it does **not** reconfigure the
+service manager. Activating a release moves the `current` symlink; a running
+service keeps executing whatever path it was started with until it is pointed
+at `current` and restarted.
+
+To put a managed service under the pipeline, do a one-time cutover:
+
+1. Pick a stable deploy root outside the source checkout and stage at least one
+   release into it (`OPENCLAW_DEPLOY_ROOT` or `--deploy-root`).
+2. Change the service start command to run `<deploy-root>/current/dist/index.js`
+   — the symlink, never a release id — so each start follows whatever
+   `activate`/`rollback` last pointed `current` at.
+3. Restart the service once to adopt the new path. This restart is the cutover
+   and causes a brief interruption; schedule it accordingly.
+
+After cutover, `activate` and `rollback` change which release the next service
+start runs; they do not restart the service themselves. Pair an activation with
+a service restart (or reload) to make it take effect.
+
+### The first cutover
+
+Moving a _live_ service onto the pipeline is higher-risk than the
+`activate`/`rollback` swaps that follow it: there is no prior pipeline release
+to fall back to, and a delivery problem can be mistaken for an application bug.
+Reduce that risk:
+
+- **Pin to a known-good build.** Stage and cut over a stock, already-proven
+  build, and do not combine the first cutover with an application upgrade — one
+  variable at a time. Build that commit and `stage --expect-commit <sha>` so a
+  wrong dist is refused. Note that `verify`/`stage` also cross-check the dist's
+  `build-info.json` version against the repo `package.json`, so run the pipeline
+  from the same checkout you built — an older pinned build verified against a
+  newer repo version is rejected.
+- **Verify the release as a package, not a dist.** Run `verify --release` on
+  the staged release before going near the live service.
+- **Run it on an alternate port first.** Start `<release-dir>/dist/index.js`
+  with a non-production gateway port and an isolated config, confirm it boots
+  and that channels start (no "Unable to resolve plugin runtime module"), then
+  stop it. Nothing live has changed yet.
+- **Back up the service config before repointing.** Copy the existing service
+  unit / override file before editing it. For this first cutover, _rollback is
+  restoring that backup_ and restarting — `deploy-pipeline rollback` only has a
+  target from the second pipeline activation onward.
+
+### Post-activation health check
+
+`verify` and the release-package check refuse a structurally broken release
+_before_ activation. To also catch a release that is structurally fine but
+fails to _run_, pass `--health-cmd`: after the symlink swap the pipeline runs
+that command from the deploy root, and if it exits non-zero — or times out
+(`--health-timeout`, default 120 s) — `current` is rolled back to the previous
+release. For a systemd service, a useful check restarts the unit and probes it:
+
+```bash
+node scripts/deploy-pipeline.mjs deploy --deploy-root /srv/openclaw \
+  --health-cmd "systemctl --user restart openclaw-gateway && sleep 8 && systemctl --user is-active openclaw-gateway"
+```
+
+## Verifying a release with doctor
+
+`openclaw doctor` probes bundled channels and providers by walking up from its
+own entrypoint for the `openclaw` package root. Run it **from the active
+release** so it inspects the same package root the live service runs:
+
+```bash
+node <deploy-root>/current/dist/index.js doctor
+```
+
+A `doctor` invoked from a different `openclaw` install (for example a global
+npm package still on `PATH`) probes _that_ install, not the release — its
+bundled-channel checks can then resolve a different root than the running
+gateway and report load errors for channels (e.g. telegram) that the gateway
+in fact starts cleanly. If the gateway logs show a channel started but `doctor`
+reports it failed to load, confirm `doctor` was run from `current/dist/index.js`
+before treating the message as a real fault.
+
+A restricted `plugins.allow` together with `plugins.bundledDiscovery: "compat"`
+also draws a `doctor` note, and is **not** a pipeline fault: `compat` is the
+supported mode for migrated configs and force-loads bundled provider plugins
+regardless of the allowlist. Switching to `"allowlist"` would gate every
+bundled provider behind `plugins.allow`, so keep `compat` unless every required
+bundled provider id is listed in `allow`.
+
+## Typical use
+
+```bash
+# Local dry run — see exactly what a deploy would do, touch nothing:
+node scripts/deploy-pipeline.mjs deploy --dry-run --deploy-root /srv/openclaw
+
+# Real deploy from a clean tree:
+node scripts/deploy-pipeline.mjs deploy --clean --deploy-root /srv/openclaw
+
+# Inspect, then roll back the last activation if needed:
+node scripts/deploy-pipeline.mjs list --deploy-root /srv/openclaw
+node scripts/deploy-pipeline.mjs rollback --deploy-root /srv/openclaw
+
+# Reclaim space, keeping the 5 newest plus the active and rollback targets:
+node scripts/deploy-pipeline.mjs prune --keep 5 --deploy-root /srv/openclaw
+```
+
+Verification and staging can also run as separate steps in CI: `build` produces
+and verifies the dist, `stage` archives it as a release artifact, and a later
+job runs `activate` on the target host.
+
+## Related
+
+Collaborators running the fork patch line install, update, and roll back through
+this pipeline. See [Kynver patch channel](/install/kynver-patch-channel) for the
+repo, branch, and commit guidance, the update guard that keeps stock
+`openclaw update` from clobbering the fork, and the operator workflow.


### PR DESCRIPTION
## Summary

Updates the Kynver patch-channel install guide and adds the linked deploy-pipeline reference.

Changes:

- Clarifies that this patch exposes the public agent-harness extension seam used to add Kynver tooling.
- Keeps Kynver first-class tool support framed as a separate follow-up path, not part of this install guide.
- Corrects the phase-1 responsiveness branch reference to `phase1-openclaw-responsiveness`.
- Adds a deploy-pipeline reference page for setup and verification context.

Added docs:

- `docs/install/kynver-patch-channel.md`
- `docs/reference/deploy-pipeline.md`

## Verification

- `git diff --check origin/main HEAD`
- Confirmed the added docs match the reviewed patch content.
- Confirmed cross-doc links and intra-page anchors resolve within the added docs.