### PR TITLE
fix(slack): respect mute / stop-responding requests in shared channel threads

### DIFF
--- a/extensions/slack/src/monitor/message-handler/prepare.mute.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.mute.test.ts
@@ -1,0 +1,197 @@
+import type { App } from "@slack/bolt";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ResolvedSlackAccount } from "../../accounts.js";
+import {
+  clearSlackThreadMuteCache,
+  isSlackThreadMutedWithPersistence,
+  recordSlackThreadMute,
+} from "../../muted-thread-cache.js";
+import {
+  clearSlackThreadParticipationCache,
+  recordSlackThreadParticipation,
+} from "../../sent-thread-cache.js";
+import type { SlackMessageEvent } from "../../types.js";
+import { clearSlackAllowFromCacheForTest } from "../auth.js";
+import { resetSlackThreadStarterCacheForTest } from "../thread.js";
+import { prepareSlackMessage } from "./prepare.js";
+import { createInboundSlackTestContext, createSlackTestAccount } from "./prepare.test-helpers.js";
+import { clearSlackSubteamMentionCacheForTest } from "./subteam-mentions.js";
+
+vi.mock("openclaw/plugin-sdk/system-event-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/system-event-runtime")>();
+  return {
+    ...actual,
+    enqueueSystemEvent: vi.fn(),
+  };
+});
+
+describe("slack prepareSlackMessage mute gate", () => {
+  const channelId = "CMUTETEST01";
+  const rootTs = "9990000000.000001";
+  const account: ResolvedSlackAccount = createSlackTestAccount();
+
+  beforeEach(() => {
+    resetSlackThreadStarterCacheForTest();
+    clearSlackThreadParticipationCache();
+    clearSlackThreadMuteCache();
+    clearSlackAllowFromCacheForTest();
+    clearSlackSubteamMentionCacheForTest();
+  });
+
+  afterEach(() => {
+    clearSlackThreadMuteCache();
+    clearSlackThreadParticipationCache();
+  });
+
+  function createCtxWithReactSpy() {
+    const reactionsAdd = vi.fn().mockResolvedValue({ ok: true });
+    const slackCtx = createInboundSlackTestContext({
+      cfg: {
+        channels: { slack: { enabled: true, groupPolicy: "open" } },
+      } as OpenClawConfig,
+      appClient: { reactions: { add: reactionsAdd } } as unknown as App["client"],
+      defaultRequireMention: false,
+    });
+    slackCtx.resolveChannelName = async () => ({ name: "channel", type: "channel" });
+    slackCtx.resolveUserName = async () => ({ name: "Alice" });
+    return { slackCtx, reactionsAdd };
+  }
+
+  function threadReply(text: string, ts: string): SlackMessageEvent {
+    return {
+      type: "message",
+      channel: channelId,
+      channel_type: "channel",
+      user: "U_ALICE",
+      text,
+      ts,
+      thread_ts: rootTs,
+    } as SlackMessageEvent;
+  }
+
+  it("records the mute, reacts with an emoji, and drops the message", async () => {
+    const { slackCtx, reactionsAdd } = createCtxWithReactSpy();
+    recordSlackThreadParticipation(account.accountId, channelId, rootTs);
+
+    const prepared = await prepareSlackMessage({
+      ctx: slackCtx,
+      account,
+      message: threadReply("monica, stop responding please", "1777244714.000100"),
+      opts: { source: "message" },
+    });
+
+    expect(prepared).toBeNull();
+    expect(reactionsAdd).toHaveBeenCalledWith({
+      channel: channelId,
+      timestamp: "1777244714.000100",
+      name: "zipper_mouth_face",
+    });
+    await expect(
+      isSlackThreadMutedWithPersistence({
+        accountId: account.accountId,
+        channelId,
+        threadTs: rootTs,
+      }),
+    ).resolves.toBe(true);
+  });
+
+  it("drops follow-up messages in a muted thread when the bot is not re-tagged", async () => {
+    const { slackCtx } = createCtxWithReactSpy();
+    recordSlackThreadParticipation(account.accountId, channelId, rootTs);
+    recordSlackThreadMute({ accountId: account.accountId, channelId, threadTs: rootTs });
+
+    const prepared = await prepareSlackMessage({
+      ctx: slackCtx,
+      account,
+      message: threadReply("anyone seen the dashboard?", "1777244720.000100"),
+      opts: { source: "message" },
+    });
+
+    expect(prepared).toBeNull();
+  });
+
+  it("clears the mute and proceeds when the bot is explicitly mentioned again", async () => {
+    const { slackCtx } = createCtxWithReactSpy();
+    recordSlackThreadMute({ accountId: account.accountId, channelId, threadTs: rootTs });
+
+    const prepared = await prepareSlackMessage({
+      ctx: slackCtx,
+      account,
+      message: threadReply("<@B1> what's the latest deploy status?", "1777244730.000100"),
+      opts: { source: "app_mention", wasMentioned: true },
+    });
+
+    expect(prepared).not.toBeNull();
+    await expect(
+      isSlackThreadMutedWithPersistence({
+        accountId: account.accountId,
+        channelId,
+        threadTs: rootTs,
+      }),
+    ).resolves.toBe(false);
+  });
+
+  it("does not mute on DMs (mute is per-thread, DMs have no thread context to silence)", async () => {
+    const { slackCtx, reactionsAdd } = createCtxWithReactSpy();
+
+    const prepared = await prepareSlackMessage({
+      ctx: slackCtx,
+      account,
+      message: {
+        type: "message",
+        channel: "D123",
+        channel_type: "im",
+        user: "U_ALICE",
+        text: "please mute",
+        ts: "1777244740.000100",
+      } as SlackMessageEvent,
+      opts: { source: "message" },
+    });
+
+    expect(prepared).not.toBeNull();
+    expect(reactionsAdd).not.toHaveBeenCalled();
+  });
+
+  it("does not mute on top-level channel messages without a thread", async () => {
+    const { slackCtx, reactionsAdd } = createCtxWithReactSpy();
+
+    await prepareSlackMessage({
+      ctx: slackCtx,
+      account,
+      message: {
+        type: "message",
+        channel: channelId,
+        channel_type: "channel",
+        user: "U_ALICE",
+        text: "<@B1> mute",
+        ts: "1777244750.000100",
+      } as SlackMessageEvent,
+      opts: { source: "app_mention", wasMentioned: true },
+    });
+
+    expect(reactionsAdd).not.toHaveBeenCalled();
+  });
+
+  it("does not record a mute when the bot was not addressed in the message", async () => {
+    const { slackCtx, reactionsAdd } = createCtxWithReactSpy();
+    // No recordSlackThreadParticipation — bot is not in this thread, and the
+    // message has no @mention. The mute text in the body should be ignored.
+
+    await prepareSlackMessage({
+      ctx: slackCtx,
+      account,
+      message: threadReply("please stop responding to all my emails", "1777244760.000100"),
+      opts: { source: "message" },
+    });
+
+    expect(reactionsAdd).not.toHaveBeenCalled();
+    await expect(
+      isSlackThreadMutedWithPersistence({
+        accountId: account.accountId,
+        channelId,
+        threadTs: rootTs,
+      }),
+    ).resolves.toBe(false);
+  });
+});

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -38,6 +38,11 @@ import type { ResolvedSlackAccount } from "../../accounts.js";
 import { reactSlackMessage } from "../../actions.js";
 import { formatSlackError } from "../../errors.js";
 import { formatSlackFileReference } from "../../file-reference.js";
+import {
+  clearSlackThreadMute,
+  isSlackThreadMutedWithPersistence,
+  recordSlackThreadMute,
+} from "../../muted-thread-cache.js";
 import { hasSlackThreadParticipationWithPersistence } from "../../sent-thread-cache.js";
 import type { SlackAttachment, SlackFile, SlackMessageEvent } from "../../types.js";
 import { normalizeAllowListLower, normalizeSlackAllowOwnerEntry } from "../allow-list.js";
@@ -63,6 +68,7 @@ import {
 } from "../context.js";
 import { resolveConversationLabel } from "../conversation.runtime.js";
 import { authorizeSlackDirectMessage } from "../dm-auth.js";
+import { detectSlackMuteIntent } from "../mute-detection.js";
 import { resolveSlackRoomContextHints } from "../room-context.js";
 import { sendMessageSlack } from "../send.runtime.js";
 import { resolveSlackThreadStarter, type SlackThreadStarter } from "../thread.js";
@@ -825,6 +831,56 @@ export async function prepareSlackMessage(params: {
               threadTs: message.thread_ts,
             }),
           );
+  }
+
+  // Thread mute gate. Only relevant for non-DM threads. An explicit @mention or
+  // app_mention clears any prior mute (the user is re-engaging the bot). If the
+  // bot would otherwise respond and the text asks the bot to be quiet, record
+  // the mute and drop silently with an emoji ack instead of replying.
+  const muteKey =
+    !isDirectMessage && message.thread_ts
+      ? {
+          accountId: account.accountId,
+          channelId: message.channel,
+          threadTs: message.thread_ts,
+        }
+      : null;
+  if (muteKey) {
+    const isExplicitReEngagement = wasMentioned || opts.source === "app_mention";
+    const wouldRespond = isExplicitReEngagement || implicitMentionKinds.length > 0;
+    if (wouldRespond && detectSlackMuteIntent(messageText)) {
+      recordSlackThreadMute(muteKey);
+      if (message.ts) {
+        try {
+          await reactSlackMessage(message.channel, message.ts, "zipper_mouth_face", {
+            token: ctx.botToken,
+            client: ctx.app.client,
+          });
+        } catch (err) {
+          logVerbose(
+            `slack mute ack react failed for channel ${message.channel}: ${formatSlackError(err)}`,
+          );
+        }
+      }
+      logInboundDrop({
+        log: logVerbose,
+        channel: "slack",
+        reason: "thread muted by user request",
+        target: message.channel,
+      });
+      return null;
+    }
+    if (isExplicitReEngagement) {
+      await clearSlackThreadMute(muteKey);
+    } else if (await isSlackThreadMutedWithPersistence(muteKey)) {
+      logInboundDrop({
+        log: logVerbose,
+        channel: "slack",
+        reason: "thread muted",
+        target: message.channel,
+      });
+      return null;
+    }
   }
 
   let resolvedSenderName = normalizeOptionalString(message.username);

--- a/extensions/slack/src/monitor/mute-detection.test.ts
+++ b/extensions/slack/src/monitor/mute-detection.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { detectSlackMuteIntent } from "./mute-detection.js";
+
+describe("detectSlackMuteIntent", () => {
+  it("matches bare 'mute'", () => {
+    expect(detectSlackMuteIntent("mute")).toBe("mute");
+    expect(detectSlackMuteIntent("Mute!")).toBe("mute");
+    expect(detectSlackMuteIntent("please mute now")).toBe("mute");
+  });
+
+  it("matches when the bot is tagged before the command", () => {
+    expect(detectSlackMuteIntent("<@U0AHQ49SD38> mute")).toBe("mute");
+    expect(detectSlackMuteIntent("<@U0AHQ49SD38|monica> stop responding")).toBe("mute");
+  });
+
+  it("matches the documented phrasings", () => {
+    expect(detectSlackMuteIntent("Monica, stop responding please")).toBe("mute");
+    expect(detectSlackMuteIntent("hey, stop replying for now")).toBe("mute");
+    expect(detectSlackMuteIntent("monica stop chiming in")).toBe("mute");
+    expect(detectSlackMuteIntent("be quiet for a sec")).toBe("mute");
+    expect(detectSlackMuteIntent("stay quiet")).toBe("mute");
+    expect(detectSlackMuteIntent("stay silent")).toBe("mute");
+    expect(detectSlackMuteIntent("hush")).toBe("mute");
+    expect(detectSlackMuteIntent("shush")).toBe("mute");
+  });
+
+  it("does not match conjugations that are not commands", () => {
+    expect(detectSlackMuteIntent("I muted my mic")).toBeNull();
+    expect(detectSlackMuteIntent("muting the alerts")).toBeNull();
+  });
+
+  it("does not match bare 'stop'", () => {
+    expect(detectSlackMuteIntent("let me stop and think")).toBeNull();
+    expect(detectSlackMuteIntent("stop")).toBeNull();
+  });
+
+  it("does not match unrelated chatter", () => {
+    expect(detectSlackMuteIntent("looks good to me")).toBeNull();
+    expect(detectSlackMuteIntent("how's the deploy going")).toBeNull();
+    expect(detectSlackMuteIntent("")).toBeNull();
+  });
+
+  it("is case-insensitive", () => {
+    expect(detectSlackMuteIntent("MUTE")).toBe("mute");
+    expect(detectSlackMuteIntent("Stop Responding")).toBe("mute");
+    expect(detectSlackMuteIntent("BE QUIET")).toBe("mute");
+  });
+});

--- a/extensions/slack/src/monitor/mute-detection.ts
+++ b/extensions/slack/src/monitor/mute-detection.ts
@@ -1,0 +1,36 @@
+import { stripSlackMentionsForCommandDetection } from "./commands.js";
+
+/**
+ * Phrases that indicate the user is asking the bot to stop responding in the
+ * current thread. Matched after Slack mentions are stripped, so "<@U123> mute"
+ * and "Monica mute" both reduce to text the patterns below recognize.
+ *
+ * Kept conservative: bare "stop" is excluded because it appears in normal
+ * speech ("let me stop and think"). Re-tagging the bot always clears the mute,
+ * so an occasional false positive is recoverable.
+ */
+const SLACK_MUTE_PATTERNS: readonly RegExp[] = [
+  /\bmute\b/i,
+  /\bstop responding\b/i,
+  /\bstop replying\b/i,
+  /\bstop chiming in\b/i,
+  /\bbe quiet\b/i,
+  /\bstay (?:quiet|silent)\b/i,
+  /\bhush\b/i,
+  /\bshush\b/i,
+];
+
+export type SlackMuteIntent = "mute";
+
+export function detectSlackMuteIntent(text: string): SlackMuteIntent | null {
+  const stripped = stripSlackMentionsForCommandDetection(text);
+  if (!stripped) {
+    return null;
+  }
+  for (const pattern of SLACK_MUTE_PATTERNS) {
+    if (pattern.test(stripped)) {
+      return "mute";
+    }
+  }
+  return null;
+}

--- a/extensions/slack/src/muted-thread-cache.test.ts
+++ b/extensions/slack/src/muted-thread-cache.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  clearSlackThreadMute,
+  clearSlackThreadMuteCache,
+  isSlackThreadMutedWithPersistence,
+  recordSlackThreadMute,
+} from "./muted-thread-cache.js";
+import { clearSlackRuntime, setSlackRuntime } from "./runtime.js";
+
+describe("slack muted-thread-cache", () => {
+  afterEach(() => {
+    clearSlackThreadMuteCache();
+    clearSlackRuntime();
+    vi.restoreAllMocks();
+  });
+
+  it("records and detects a muted thread", async () => {
+    recordSlackThreadMute({ accountId: "A1", channelId: "C123", threadTs: "t1" });
+    await expect(
+      isSlackThreadMutedWithPersistence({ accountId: "A1", channelId: "C123", threadTs: "t1" }),
+    ).resolves.toBe(true);
+  });
+
+  it("returns false for unrecorded threads", async () => {
+    await expect(
+      isSlackThreadMutedWithPersistence({ accountId: "A1", channelId: "C123", threadTs: "t1" }),
+    ).resolves.toBe(false);
+  });
+
+  it("scopes mute state by accountId, channel, and thread", async () => {
+    recordSlackThreadMute({ accountId: "A1", channelId: "C123", threadTs: "t1" });
+    await expect(
+      isSlackThreadMutedWithPersistence({ accountId: "A2", channelId: "C123", threadTs: "t1" }),
+    ).resolves.toBe(false);
+    await expect(
+      isSlackThreadMutedWithPersistence({ accountId: "A1", channelId: "C456", threadTs: "t1" }),
+    ).resolves.toBe(false);
+    await expect(
+      isSlackThreadMutedWithPersistence({ accountId: "A1", channelId: "C123", threadTs: "t2" }),
+    ).resolves.toBe(false);
+  });
+
+  it("ignores empty accountId, channelId, or threadTs", async () => {
+    recordSlackThreadMute({ accountId: "", channelId: "C123", threadTs: "t1" });
+    recordSlackThreadMute({ accountId: "A1", channelId: "", threadTs: "t1" });
+    recordSlackThreadMute({ accountId: "A1", channelId: "C123", threadTs: "" });
+    await expect(
+      isSlackThreadMutedWithPersistence({ accountId: "", channelId: "C123", threadTs: "t1" }),
+    ).resolves.toBe(false);
+    await expect(
+      isSlackThreadMutedWithPersistence({ accountId: "A1", channelId: "", threadTs: "t1" }),
+    ).resolves.toBe(false);
+    await expect(
+      isSlackThreadMutedWithPersistence({ accountId: "A1", channelId: "C123", threadTs: "" }),
+    ).resolves.toBe(false);
+  });
+
+  it("clearSlackThreadMute removes the entry from both hot cache and persistent store", async () => {
+    const deletePersistent = vi.fn().mockResolvedValue(true);
+    setSlackRuntime({
+      state: {
+        openKeyedStore: vi.fn(() => ({
+          register: vi.fn().mockResolvedValue(undefined),
+          lookup: vi.fn().mockResolvedValue(undefined),
+          consume: vi.fn(),
+          delete: deletePersistent,
+          entries: vi.fn(),
+          clear: vi.fn(),
+        })),
+      },
+      logging: { getChildLogger: () => ({ warn: vi.fn() }) },
+    } as never);
+
+    recordSlackThreadMute({ accountId: "A1", channelId: "C123", threadTs: "t1" });
+    await clearSlackThreadMute({ accountId: "A1", channelId: "C123", threadTs: "t1" });
+
+    expect(deletePersistent).toHaveBeenCalledWith("A1:C123:t1");
+    await expect(
+      isSlackThreadMutedWithPersistence({ accountId: "A1", channelId: "C123", threadTs: "t1" }),
+    ).resolves.toBe(false);
+  });
+
+  it("writes persistent mute without a TTL so the mute does not expire", async () => {
+    const register = vi.fn().mockResolvedValue(undefined);
+    const openKeyedStore = vi.fn(() => ({
+      register,
+      lookup: vi.fn().mockResolvedValue(undefined),
+      consume: vi.fn(),
+      delete: vi.fn().mockResolvedValue(true),
+      entries: vi.fn(),
+      clear: vi.fn(),
+    }));
+    setSlackRuntime({
+      state: { openKeyedStore },
+      logging: { getChildLogger: () => ({ warn: vi.fn() }) },
+    } as never);
+
+    vi.spyOn(Date, "now").mockReturnValue(1_777_000_000_000);
+    recordSlackThreadMute({ accountId: "A1", channelId: "C123", threadTs: "t1" });
+
+    await vi.waitFor(() => expect(register).toHaveBeenCalledTimes(1));
+    expect(register).toHaveBeenCalledWith("A1:C123:t1", { mutedAt: 1_777_000_000_000 });
+    const firstCall = openKeyedStore.mock.calls[0] as unknown as
+      | [{ defaultTtlMs?: number }]
+      | undefined;
+    expect(firstCall?.[0]?.defaultTtlMs).toBeUndefined();
+  });
+
+  it("falls back to in-memory state when persistent store cannot open", async () => {
+    const warn = vi.fn();
+    setSlackRuntime({
+      state: {
+        openKeyedStore: vi.fn(() => {
+          throw new Error("sqlite unavailable");
+        }),
+      },
+      logging: { getChildLogger: () => ({ warn }) },
+    } as never);
+
+    recordSlackThreadMute({ accountId: "A1", channelId: "C123", threadTs: "t1" });
+    await expect(
+      isSlackThreadMutedWithPersistence({ accountId: "A1", channelId: "C123", threadTs: "t1" }),
+    ).resolves.toBe(true);
+    expect(warn).toHaveBeenCalled();
+  });
+});

--- a/extensions/slack/src/muted-thread-cache.ts
+++ b/extensions/slack/src/muted-thread-cache.ts
@@ -1,0 +1,178 @@
+import { resolveGlobalDedupeCache } from "openclaw/plugin-sdk/dedupe-runtime";
+import { getOptionalSlackRuntime } from "./runtime.js";
+
+/**
+ * Per-thread mute state for Slack. Recorded when a user asks the bot to stop
+ * responding in a shared thread. The persistent layer never expires so the
+ * mute survives restarts and long-quiet threads; the in-memory dedupe cache
+ * is only a hot-path accelerator and may evict entries safely.
+ *
+ * Mute is cleared by an explicit @mention of the bot — see `prepareSlackMessage`.
+ */
+
+const HOT_CACHE_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days; persistent store is the source of truth
+const MAX_ENTRIES = 5000;
+const PERSISTENT_MAX_ENTRIES = 5000;
+const PERSISTENT_NAMESPACE = "slack.thread-mute";
+
+type SlackThreadMuteRecord = {
+  agentId?: string;
+  mutedAt: number;
+};
+
+type SlackThreadMuteStore = {
+  register(key: string, value: SlackThreadMuteRecord, opts?: { ttlMs?: number }): Promise<void>;
+  lookup(key: string): Promise<SlackThreadMuteRecord | undefined>;
+  delete(key: string): Promise<boolean>;
+};
+
+const SLACK_THREAD_MUTE_KEY = Symbol.for("openclaw.slackThreadMute");
+const muteHotCache = resolveGlobalDedupeCache(SLACK_THREAD_MUTE_KEY, {
+  ttlMs: HOT_CACHE_TTL_MS,
+  maxSize: MAX_ENTRIES,
+});
+
+let persistentStore: SlackThreadMuteStore | undefined;
+let persistentStoreDisabled = false;
+
+function makeKey(accountId: string, channelId: string, threadTs: string): string {
+  return `${accountId}:${channelId}:${threadTs}`;
+}
+
+function reportPersistentMuteError(error: unknown): void {
+  try {
+    getOptionalSlackRuntime()
+      ?.logging.getChildLogger({ plugin: "slack", feature: "thread-mute-state" })
+      .warn("Slack persistent thread mute state failed", { error: String(error) });
+  } catch {
+    // Best effort only: persistent state must never break Slack message handling.
+  }
+}
+
+function disablePersistentMute(error: unknown): void {
+  persistentStoreDisabled = true;
+  persistentStore = undefined;
+  reportPersistentMuteError(error);
+}
+
+function getPersistentMuteStore(): SlackThreadMuteStore | undefined {
+  if (persistentStoreDisabled) {
+    return undefined;
+  }
+  if (persistentStore) {
+    return persistentStore;
+  }
+  const runtime = getOptionalSlackRuntime();
+  if (!runtime) {
+    return undefined;
+  }
+  try {
+    persistentStore = runtime.state.openKeyedStore<SlackThreadMuteRecord>({
+      namespace: PERSISTENT_NAMESPACE,
+      maxEntries: PERSISTENT_MAX_ENTRIES,
+      // No defaultTtlMs: mute persists until the user re-engages by tagging the bot.
+    });
+    return persistentStore;
+  } catch (error) {
+    disablePersistentMute(error);
+    return undefined;
+  }
+}
+
+function rememberPersistentMute(params: { key: string; agentId?: string }): void {
+  const store = getPersistentMuteStore();
+  if (!store) {
+    return;
+  }
+  void store
+    .register(params.key, {
+      ...(params.agentId ? { agentId: params.agentId } : {}),
+      mutedAt: Date.now(),
+    })
+    .catch(disablePersistentMute);
+}
+
+async function deletePersistentMute(key: string): Promise<void> {
+  const store = getPersistentMuteStore();
+  if (!store) {
+    return;
+  }
+  try {
+    await store.delete(key);
+  } catch (error) {
+    disablePersistentMute(error);
+  }
+}
+
+function isMuteRecord(value: unknown): value is SlackThreadMuteRecord {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { mutedAt?: unknown }).mutedAt === "number"
+  );
+}
+
+async function lookupPersistentMute(key: string): Promise<boolean> {
+  const store = getPersistentMuteStore();
+  if (!store) {
+    return false;
+  }
+  try {
+    return isMuteRecord(await store.lookup(key));
+  } catch (error) {
+    disablePersistentMute(error);
+    return false;
+  }
+}
+
+export function recordSlackThreadMute(params: {
+  accountId: string;
+  channelId: string;
+  threadTs: string;
+  agentId?: string;
+}): void {
+  if (!params.accountId || !params.channelId || !params.threadTs) {
+    return;
+  }
+  const key = makeKey(params.accountId, params.channelId, params.threadTs);
+  muteHotCache.check(key);
+  rememberPersistentMute({ key, agentId: params.agentId });
+}
+
+export async function clearSlackThreadMute(params: {
+  accountId: string;
+  channelId: string;
+  threadTs: string;
+}): Promise<void> {
+  if (!params.accountId || !params.channelId || !params.threadTs) {
+    return;
+  }
+  const key = makeKey(params.accountId, params.channelId, params.threadTs);
+  muteHotCache.delete(key);
+  await deletePersistentMute(key);
+}
+
+export async function isSlackThreadMutedWithPersistence(params: {
+  accountId: string;
+  channelId: string;
+  threadTs: string;
+}): Promise<boolean> {
+  if (!params.accountId || !params.channelId || !params.threadTs) {
+    return false;
+  }
+  const key = makeKey(params.accountId, params.channelId, params.threadTs);
+  if (muteHotCache.peek(key)) {
+    return true;
+  }
+  const found = await lookupPersistentMute(key);
+  if (found) {
+    muteHotCache.check(key);
+  }
+  return found;
+}
+
+export function clearSlackThreadMuteCache(): void {
+  muteHotCache.clear();
+  persistentStore = undefined;
+  persistentStoreDisabled = false;
+}


### PR DESCRIPTION
## Summary

In shared Slack channel threads, the bot kept replying after users asked it to stop. Two failure modes:

1. After the bot's first reply in a thread, every subsequent message implicitly re-engaged the bot via `bot_thread_participant` in `prepareSlackMessage`, regardless of whether anyone was addressing it.
2. Explicit requests like "mute", "stop responding", or "be quiet" were soft prompt rules, not a pre-model gate, so the runtime kept waking the agent on every message.

This PR adds a pre-model thread-mute gate in `extensions/slack/src/monitor/message-handler/prepare.ts`:

- New `muted-thread-cache` mirrors `sent-thread-cache` (in-memory dedupe + persistent KV via `runtime.state.openKeyedStore`). Persistent entries have no TTL — once muted, a thread stays muted until the user explicitly re-engages.
- New `mute-detection` matches a conservative phrase list: `mute`, `stop responding`, `stop replying`, `stop chiming in`, `be quiet`, `stay quiet`, `stay silent`, `hush`, `shush`. Bare `stop` is excluded to avoid false positives.
- Re-tagging the bot (`@mention` or `app_mention`) clears the mute. That is the only way to un-mute.
- On a detected mute, the bot reacts with `:zipper_mouth_face:` (one-time visual ack) and drops the message instead of replying — so the mute request itself doesn't trigger a reply.

Mute is scoped per-thread (`accountId:channelId:threadTs`). DMs and top-level channel messages are unaffected. Persistent-store lookup validates the record shape so the gate is robust against namespace mock leakage in tests and any cross-record corruption on disk.

## Verification

Local automated checks:

- `pnpm test:extension slack` — 1124/1124 pass
- `pnpm test:contracts:channels` — 29/29 pass
- `pnpm test:contracts:plugins` — 860/860 pass
- `pnpm check:changed` — clean (typecheck, lint, cycles, boundaries)
- `pnpm format:check` (on touched files) — clean
- `pnpm build` — clean

## Real behavior proof

Behavior addressed: bot ignores "mute" / "stop responding" / "be quiet" in shared Slack threads; bot stops auto-chiming after its first reply unless re-tagged.

Real environment tested: _to be filled in by author after running locally against a real Slack workspace._

Exact steps or command run after this patch: _pending._

Evidence after fix: _pending — message permalinks / screenshots will be attached as a comment._

Observed result after fix: _pending._

What was not tested: _pending._

## AI-assisted

Drafted with Claude Code (Opus 4.7). All automated checks above pass locally. Real-behavior proof must be supplied by the human author against a live Slack workspace before this PR is ready for review — explicitly calling that out per `CONTRIBUTING.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
