### PR TITLE
Fix Matrix configured two-person room routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Docs: https://docs.openclaw.ai
 - Providers/Ollama: preserve native Ollama tool-call IDs across assistant replay so Gemini over Ollama Cloud can keep its hidden function-call thought-signature handle.
 - Discord: keep session recovery and `/stop` abort ownership on the source dispatch lane while bound ACP turns continue routing to their target session, so stalled pre-run work and late replies are cleared instead of leaking after stop. Fixes #84477. (#85100) Thanks @joshavant.
 - Codex app-server: mark missing turn completion after observed execution as replay-unsafe and release the session so follow-up turns can run. Fixes #84076. (#85107) Thanks @joshavant.
+- Matrix: keep explicitly configured two-person rooms on the room route before stale `m.direct` or strict two-member DM fallback can bypass mention gating. Fixes #85017. (#85137) Thanks @joshavant.
 - PDF tool: time out idle remote PDF body reads after 120 seconds so stalled remote documents return an error instead of wedging the session. Fixes #68649. (#84768) Thanks @luoyanglang.
 - Diagnostics/OpenTelemetry plugin: suppress handled OTLP exporter promise rejections so collector shutdowns no longer crash the Gateway. (#81085) Thanks @luoyanglang.
 - Media/audio: skip empty structured sherpa-onnx transcripts instead of treating the raw JSON payload as spoken text. (#84667) Thanks @TurboTheTurtle.

--- a/extensions/matrix/src/matrix/direct-room.test.ts
+++ b/extensions/matrix/src/matrix/direct-room.test.ts
@@ -41,7 +41,7 @@ describe("inspectMatrixDirectRoomEvidence", () => {
     expect(result.strict).toBe(true);
   });
 
-  it("records only the local member-state direct flag", async () => {
+  it("preserves strict evidence when local is_direct=false provides a promotion veto reason", async () => {
     const client = createClient({
       getRoomStateEvent: vi.fn(async (_roomId: string, _eventType: string, stateKey: string) =>
         stateKey === "@bot:example.org" ? { is_direct: false } : { is_direct: true },

--- a/extensions/matrix/src/matrix/monitor/direct.test.ts
+++ b/extensions/matrix/src/matrix/monitor/direct.test.ts
@@ -97,6 +97,40 @@ describe("createDirectRoomTracker", () => {
     expect(client.getJoinedRoomMembers).toHaveBeenCalledWith("!room:example.org");
   });
 
+  it("lets explicit room config veto stale m.direct classifications", async () => {
+    const client = createMockClient({ isDm: true });
+    const tracker = createDirectRoomTracker(client, {
+      isExplicitlyConfiguredRoom: (roomId) => roomId === "!room:example.org",
+    });
+
+    await expect(
+      tracker.isDirectMessage({
+        roomId: "!room:example.org",
+        senderId: "@alice:example.org",
+      }),
+    ).resolves.toBe(false);
+
+    expect(client.dms.update).not.toHaveBeenCalled();
+    expect(client.getJoinedRoomMembers).not.toHaveBeenCalled();
+  });
+
+  it("lets explicit room config veto strict two-member fallback before dm cache seed", async () => {
+    const client = createMockClient({ isDm: false, dmCacheAvailable: false });
+    const tracker = createDirectRoomTracker(client, {
+      isExplicitlyConfiguredRoom: (roomId) => roomId === "!room:example.org",
+    });
+
+    await expect(
+      tracker.isDirectMessage({
+        roomId: "!room:example.org",
+        senderId: "@alice:example.org",
+      }),
+    ).resolves.toBe(false);
+
+    expect(client.dms.update).not.toHaveBeenCalled();
+    expect(client.getJoinedRoomMembers).not.toHaveBeenCalled();
+  });
+
   it("does not trust stale m.direct classifications for shared rooms", async () => {
     const client = createMockClient({
       isDm: true,

--- a/extensions/matrix/src/matrix/monitor/direct.ts
+++ b/extensions/matrix/src/matrix/monitor/direct.ts
@@ -14,6 +14,7 @@ type DirectMessageCheck = {
 
 type DirectRoomTrackerOptions = {
   log?: (message: string) => void;
+  isExplicitlyConfiguredRoom?: (roomId: string) => boolean | Promise<boolean>;
   canPromoteRecentInvite?: (roomId: string) => boolean | Promise<boolean>;
   canPromoteUnmappedStrictRoom?: (roomId: string) => boolean | Promise<boolean>;
   shouldKeepLocallyPromotedDirectRoom?:
@@ -162,6 +163,15 @@ export function createDirectRoomTracker(client: MatrixClient, opts: DirectRoomTr
     }
   };
 
+  const isExplicitlyConfiguredRoom = async (roomId: string): Promise<boolean> => {
+    try {
+      return (await opts.isExplicitlyConfiguredRoom?.(roomId)) ?? false;
+    } catch (err) {
+      log(`matrix: configured room check failed room=${roomId} (${String(err)})`);
+      return true;
+    }
+  };
+
   const hasLocallyPromotedDirectRoom = (roomId: string, remoteUserId?: string | null): boolean => {
     const normalizedRemoteUserId = remoteUserId?.trim();
     if (!normalizedRemoteUserId) {
@@ -204,6 +214,10 @@ export function createDirectRoomTracker(client: MatrixClient, opts: DirectRoomTr
     },
     isDirectMessage: async (params: DirectMessageCheck): Promise<boolean> => {
       const { roomId, senderId } = params;
+      if (await isExplicitlyConfiguredRoom(roomId)) {
+        log(`matrix: dm rejected via explicit room config room=${roomId}`);
+        return false;
+      }
       const selfUserId = params.selfUserId ?? (await ensureSelfUserId());
       const joinedMembers = await resolveJoinedMembers(roomId);
       const strictDirectMembership = isStrictDirectMembership({

--- a/extensions/matrix/src/matrix/monitor/index.test.ts
+++ b/extensions/matrix/src/matrix/monitor/index.test.ts
@@ -4,6 +4,7 @@ import type { MatrixConfig, MatrixStreamingMode } from "../../types.js";
 import type { MatrixRoomInfo } from "./room-info.js";
 
 type DirectRoomTrackerOptions = {
+  isExplicitlyConfiguredRoom?: (roomId: string) => boolean | Promise<boolean>;
   canPromoteRecentInvite?: (roomId: string) => boolean | Promise<boolean>;
   canPromoteUnmappedStrictRoom?: (roomId: string) => boolean | Promise<boolean>;
   shouldKeepLocallyPromotedDirectRoom?:
@@ -145,7 +146,18 @@ vi.mock("../../runtime-api.js", () => {
     ToolPolicySchema: z.any().optional(),
     addAllowlistUserEntriesFromConfigEntry: vi.fn(),
     buildChannelConfigSchema: (schema: unknown) => schema,
-    buildChannelKeyCandidates: () => [],
+    buildChannelKeyCandidates: (...keys: Array<string | undefined | null>) => {
+      const seen = new Set<string>();
+      return keys
+        .map((key) => (typeof key === "string" ? key.trim() : ""))
+        .filter((key) => {
+          if (!key || seen.has(key)) {
+            return false;
+          }
+          seen.add(key);
+          return true;
+        });
+    },
     buildProbeChannelStatusSummary: (
       snapshot: Record<string, unknown>,
       extra?: Record<string, unknown>,
@@ -959,6 +971,55 @@ describe("monitorMatrixProvider", () => {
     });
 
     await expect(trackerOpts.canPromoteRecentInvite("!room:example.org")).resolves.toBe(false);
+  });
+
+  it("wires exact room config as a direct-room classifier veto", async () => {
+    (hoisted.accountConfig as { rooms?: Record<string, unknown> }).rooms = {
+      "!room:example.org": { requireMention: true },
+      "*": { requireMention: false },
+    };
+
+    await startMonitorAndAbortAfterStartup();
+
+    const trackerOpts = directRoomTrackerOptions();
+    if (!trackerOpts?.isExplicitlyConfiguredRoom) {
+      throw new Error("explicit room config callback was not wired");
+    }
+
+    expect(await trackerOpts.isExplicitlyConfiguredRoom("!room:example.org")).toBe(true);
+    expect(await trackerOpts.isExplicitlyConfiguredRoom("!other:example.org")).toBe(false);
+    expect(hoisted.getRoomInfo).not.toHaveBeenCalled();
+  });
+
+  it("wires alias room config as a direct-room classifier veto", async () => {
+    (hoisted.accountConfig as { rooms?: Record<string, unknown> }).rooms = {
+      "#ops:example.org": { requireMention: true },
+      "*": { requireMention: false },
+    };
+    const { resolveMatrixTargets } = await import("../../resolve-targets.js");
+    vi.mocked(resolveMatrixTargets).mockResolvedValueOnce([
+      {
+        input: "#ops:example.org",
+        resolved: true,
+        id: "!room:example.org",
+      },
+    ]);
+
+    await startMonitorAndAbortAfterStartup();
+
+    const trackerOpts = directRoomTrackerOptions();
+    if (!trackerOpts?.isExplicitlyConfiguredRoom) {
+      throw new Error("explicit room config callback was not wired");
+    }
+
+    hoisted.getRoomInfo.mockResolvedValueOnce({
+      canonicalAlias: "#ops:example.org",
+      altAliases: [],
+      nameResolved: true,
+      aliasesResolved: true,
+    });
+
+    expect(await trackerOpts.isExplicitlyConfiguredRoom("!room:example.org")).toBe(true);
   });
 
   it("wires recent-invite promotion to reject named rooms", async () => {

--- a/extensions/matrix/src/matrix/monitor/index.ts
+++ b/extensions/matrix/src/matrix/monitor/index.ts
@@ -50,6 +50,7 @@ import {
 } from "./inbound-dedupe.js";
 import { shouldPromoteRecentInviteRoom } from "./recent-invite.js";
 import { createMatrixRoomInfoResolver } from "./room-info.js";
+import { resolveMatrixRoomConfig } from "./rooms.js";
 import { runMatrixStartupMaintenance } from "./startup.js";
 import { createMatrixMonitorStatusController } from "./status.js";
 import { createMatrixMonitorSyncLifecycle } from "./sync-lifecycle.js";
@@ -345,8 +346,24 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
     // /sync cursor we want restart backlogs to replay just like other channels.
     const dropPreStartupMessages = !client.hasPersistedSyncState();
     const { getRoomInfo, getMemberDisplayName } = createMatrixRoomInfoResolver(client);
+    const isExplicitlyConfiguredRoom = async (roomId: string): Promise<boolean> => {
+      const roomInfoForConfig = needsRoomAliasesForConfig
+        ? await getRoomInfo(roomId, { includeAliases: true })
+        : undefined;
+      const aliases = roomInfoForConfig
+        ? [roomInfoForConfig.canonicalAlias ?? "", ...roomInfoForConfig.altAliases].filter(Boolean)
+        : [];
+      return (
+        resolveMatrixRoomConfig({
+          rooms: roomsConfig,
+          roomId,
+          aliases,
+        }).matchSource === "direct"
+      );
+    };
     const directTracker = createDirectRoomTracker(client, {
       log: logVerboseMessage,
+      isExplicitlyConfiguredRoom,
       canPromoteRecentInvite: async (roomId) =>
         shouldPromoteRecentInviteRoom({
           roomId,


### PR DESCRIPTION
## Summary

- Problem: Matrix rooms configured in `channels.matrix.groups` could still be classified as DMs when the room had exactly two members.
- Solution: Let explicit Matrix room config veto DM classification before stale `m.direct` or the strict two-member fallback can route the event as a DM.
- What changed: Wired the Matrix direct-room tracker to consult exact room config and resolved alias config, with regression coverage for stale `m.direct` and pre-seed fallback paths.
- What did NOT change (scope boundary): Wildcard room config does not override DM classification, and generic strict-DM evidence/promotion behavior is unchanged.

## Motivation

- Fixes a live Matrix routing bug where unmentioned messages in a configured two-person room could bypass mention gating by being treated as DMs.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #85017
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

Behavior addressed: Matrix two-person rooms explicitly configured as rooms no longer bypass mention gating via DM classification.
Real environment tested: AWS Crabbox `cbx_1098b2400fe1`, run `run_d7af6f2a55c9`; Linux Node 24.15.0; Docker Tuwunel `ghcr.io/matrix-construct/tuwunel:v1.5.1`; OpenClaw gateway with Matrix QA live harness and mock OpenAI provider.
Exact steps or command run after this patch: `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 180m --timing-json --preflight --script-stdin`, which installed dependencies, ran `pnpm build`, booted Tuwunel, provisioned two configured Matrix group rooms, started the gateway, sent mentioned and unmentioned messages, and observed Matrix sync replies.
Evidence after fix: `OPENCLAW_85017_FIX_PROOF_SUMMARY` reported `fixed: true`; the two-person configured room had joined count `2`, `sutMemberIsDirect: null`; mentioned message replied with marker `MATRIX_QA_85017_MENTION_46F1B779`; unmentioned two-person room message had `matched: false`; unmentioned three-person control had `matched: false`.
Observed result after fix: Mentioned room messages still trigger, while unmentioned messages in a configured two-person Matrix room stay silent instead of being routed as DMs.
What was not tested: A public Matrix homeserver outside the disposable Tuwunel QA harness.
Before evidence (optional but encouraged): AWS Crabbox repro on current main `cbx_a29749d91e7d`, run `run_cec1acaaab88`, showed the same two-person configured room replying to an unmentioned message while the three-person control stayed silent.

## Root Cause (if applicable)

- Root cause: Matrix DM classification ran before room policy and treated strict two-member rooms as DMs, so explicit room config and mention gating were never applied.
- Missing detection / guardrail: The direct-room tracker did not have coverage for explicit room config vetoing stale `m.direct` or pre-seed strict fallback classification.
- Contributing context (if known): Matrix rooms can be both two-member conversations and explicitly configured group/room surfaces; operator config needs to win over heuristic DM inference.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [x] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/matrix/src/matrix/monitor/direct.test.ts`, `extensions/matrix/src/matrix/monitor/index.test.ts`.
- Scenario the test should lock in: Exact and alias Matrix room config veto stale `m.direct` and strict two-member fallback before DM routing.
- Why this is the smallest reliable guardrail: The bug is at the Matrix monitor/direct-room classification seam, so these tests pin the classification precedence without needing a full gateway boot for every case.
- Existing test that already covers this (if any): Adjacent direct-room and room-config tests covered strict membership and match-source behavior, but not this precedence path.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Configured Matrix rooms now follow room mention-gating even when the room has exactly two members.

## Diagram (if applicable)

```text
Before:
Matrix room message -> two-member DM classifier -> DM route -> mention gate skipped

After:
Matrix room message -> explicit room config veto -> room route -> mention gate applies
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux on AWS Crabbox
- Runtime/container: Node 24.15.0, Docker Tuwunel `ghcr.io/matrix-construct/tuwunel:v1.5.1`
- Model/provider: mock OpenAI provider via QA live gateway
- Integration/channel (if any): Matrix
- Relevant config (redacted): `groupPolicy: "open"`, configured `groups` for a 2-member room and a 3-member control room, each with `requireMention: true`; Matrix DM allowlist enabled for the driver.

### Steps

1. Boot disposable Tuwunel and provision Matrix driver, SUT, and observer users.
2. Create a configured two-person group room with driver and SUT, and a configured three-person control room.
3. Start the OpenClaw gateway with the Matrix account config generated from those room IDs.
4. Send a mentioned message to the two-person room.
5. Send unmentioned messages to both configured rooms.

### Expected

- The mentioned two-person room message receives a SUT reply.
- The unmentioned two-person room message receives no SUT reply.
- The unmentioned three-person control receives no SUT reply.

### Actual

- Matches expected in AWS Crabbox run `run_d7af6f2a55c9`.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Focused Matrix tests passed on AWS Crabbox; live Matrix proof passed on AWS Crabbox with the original two-person-room repro shape.
- Edge cases checked: stale `m.direct`, strict two-member fallback before DM cache seed, exact room IDs, resolved alias config, wildcard config not overriding DM classification.
- What you did **not** verify: A public Matrix homeserver outside the disposable Tuwunel QA harness.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Alias-configured rooms need room alias metadata before classification.
  - Mitigation: The alias lookup is only used when alias keys are present in Matrix room config, and exact room ID config avoids the extra lookup.
