### PR TITLE
fix: redact denied exec failure params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Docs: https://docs.openclaw.ai
 - Codex app-server: mark missing turn completion after observed execution as replay-unsafe and release the session so follow-up turns can run. Fixes #84076. (#85107) Thanks @joshavant.
 - PDF tool: time out idle remote PDF body reads after 120 seconds so stalled remote documents return an error instead of wedging the session. Fixes #68649. (#84768) Thanks @luoyanglang.
 - Diagnostics/OpenTelemetry plugin: suppress handled OTLP exporter promise rejections so collector shutdowns no longer crash the Gateway. (#81085) Thanks @luoyanglang.
+- Agents/exec: omit raw command text and env values from denied exec failure logs while keeping safe correlation metadata. Fixes #85049. (#85140) Thanks @joshavant.
 - Media/audio: skip empty structured sherpa-onnx transcripts instead of treating the raw JSON payload as spoken text. (#84667) Thanks @TurboTheTurtle.
 - Node/Linux: keep `OPENCLAW_GATEWAY_TOKEN` out of generated systemd unit files by writing node service token values to a node-specific env file. (#84408)
 - Memory-core/dreaming: reuse stable narrative subagent session keys per workspace and phase while keeping per-run idempotency and bounded cleanup, so stale `dreaming-narrative-*` sessions do not accumulate. Fixes #68252, #69187, and #70402. (#70464) Thanks @chiyouYCH.

--- a/src/agents/pi-tool-definition-adapter.logging.test.ts
+++ b/src/agents/pi-tool-definition-adapter.logging.test.ts
@@ -110,6 +110,165 @@ describe("pi tool definition adapter logging", () => {
     );
   });
 
+  it("omits raw exec commands and env values from failure logs", async () => {
+    const commandSecret = "issue85049-xai-cleartext-token-ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
+    const envSecret = "issue85049-env-cleartext-token-ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
+    const baseTool = {
+      name: "exec",
+      label: "exec",
+      description: "runs commands",
+      parameters: Type.Object({
+        command: Type.String(),
+        env: Type.Optional(Type.Record(Type.String(), Type.String())),
+        timeout: Type.Optional(Type.Number()),
+      }),
+      execute: async () => {
+        throw new Error("exec denied: allowlist miss");
+      },
+    } satisfies AgentTool;
+    const [def] = toToolDefinitions([baseTool]);
+    if (!def) {
+      throw new Error("missing tool definition");
+    }
+
+    await def.execute(
+      "call-exec-denied",
+      {
+        command: `export XAI_API_KEY=\\"${commandSecret}\\" && echo blocked`,
+        env: {
+          OPENAI_API_KEY: envSecret,
+        },
+        timeout: 5,
+      },
+      undefined,
+      undefined,
+      extensionContext,
+    );
+
+    const message = String(firstLogErrorMessage());
+    expect(message).toContain("[tools] exec failed: exec denied: allowlist miss");
+    expect(message).toContain('"command":{"omitted":true');
+    expect(message).toContain('"reason":"exec command may contain credentials"');
+    expect(message).toContain('"chars":');
+    expect(message).toMatch(/"sha256":"[a-f0-9]{16}"/u);
+    expect(message).toContain('"env":{"OPENAI_API_KEY":"[omitted exec env value]"}');
+    expect(message).toContain('"timeout":5');
+    expect(message).not.toContain(commandSecret);
+    expect(message).not.toContain(envSecret);
+    expect(message).not.toContain("export XAI_API_KEY");
+  });
+
+  it("omits raw exec commands from JSON-string failure params", async () => {
+    const commandSecret = "issue85049-json-cleartext-token-ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
+    const baseTool = {
+      name: "exec",
+      label: "exec",
+      description: "runs commands",
+      parameters: Type.Any(),
+      execute: async () => {
+        throw new Error("exec denied: allowlist miss");
+      },
+    } satisfies AgentTool;
+    const [def] = toToolDefinitions([baseTool]);
+    if (!def) {
+      throw new Error("missing tool definition");
+    }
+
+    await def.execute(
+      "call-exec-denied-json-string",
+      JSON.stringify({
+        command: `export XAI_API_KEY=\\"${commandSecret}\\" && echo blocked`,
+        timeout: 5,
+      }),
+      undefined,
+      undefined,
+      extensionContext,
+    );
+
+    const message = String(firstLogErrorMessage());
+    expect(message).toContain('"command":{"omitted":true');
+    expect(message).toContain('"reason":"exec command may contain credentials"');
+    expect(message).toContain('"timeout":5');
+    expect(message).not.toContain(commandSecret);
+    expect(message).not.toContain("export XAI_API_KEY");
+  });
+
+  it("omits malformed exec command and env values from failure logs", async () => {
+    const commandSecret =
+      "issue85049-malformed-command-cleartext-token-ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
+    const envSecret =
+      "issue85049-malformed-env-cleartext-token-ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
+    const baseTool = {
+      name: "exec",
+      label: "exec",
+      description: "runs commands",
+      parameters: Type.Any(),
+      execute: async () => {
+        throw new Error("exec denied: allowlist miss");
+      },
+    } satisfies AgentTool;
+    const [def] = toToolDefinitions([baseTool]);
+    if (!def) {
+      throw new Error("missing tool definition");
+    }
+
+    await def.execute(
+      "call-exec-denied-malformed",
+      {
+        command: [`export XAI_API_KEY=\\"${commandSecret}\\" && echo blocked`],
+        env: `OPENAI_API_KEY=${envSecret}`,
+      },
+      undefined,
+      undefined,
+      extensionContext,
+    );
+
+    const message = String(firstLogErrorMessage());
+    expect(message).toContain('"command":{"omitted":true');
+    expect(message).toContain('"type":"array"');
+    expect(message).toContain('"env":"[omitted exec env]"');
+    expect(message).not.toContain(commandSecret);
+    expect(message).not.toContain(envSecret);
+    expect(message).not.toContain("export XAI_API_KEY");
+  });
+
+  it("omits cmd-style exec payloads from normalized bash failure logs", async () => {
+    const commandSecret =
+      "issue85049-cmd-alias-cleartext-token-ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
+    const baseTool = {
+      name: "bash",
+      label: "Bash",
+      description: "runs commands",
+      parameters: Type.Any(),
+      execute: async () => {
+        throw new Error("exec denied: allowlist miss");
+      },
+    } satisfies AgentTool;
+    const [def] = toToolDefinitions([baseTool]);
+    if (!def) {
+      throw new Error("missing tool definition");
+    }
+
+    await def.execute(
+      "call-bash-denied-cmd-alias",
+      {
+        cmd: `export XAI_API_KEY=\\"${commandSecret}\\" && echo blocked`,
+        timeout: 5,
+      },
+      undefined,
+      undefined,
+      extensionContext,
+    );
+
+    const message = String(firstLogErrorMessage());
+    expect(message).toContain("[tools] exec failed: exec denied: allowlist miss");
+    expect(message).toContain('"cmd":{"omitted":true');
+    expect(message).toContain('"reason":"exec command may contain credentials"');
+    expect(message).toContain('"timeout":5');
+    expect(message).not.toContain(commandSecret);
+    expect(message).not.toContain("export XAI_API_KEY");
+  });
+
   it("logs provider AbortError failures when the agent run was not aborted", async () => {
     const baseTool = {
       name: "web_search",

--- a/src/agents/pi-tool-definition-adapter.ts
+++ b/src/agents/pi-tool-definition-adapter.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import type {
   AgentTool,
   AgentToolResult,
@@ -40,6 +41,9 @@ type ToolExecuteArgs = ToolDefinition["execute"] extends (...args: infer P) => u
   : ToolExecuteArgsCurrent;
 type ToolExecuteArgsAny = ToolExecuteArgs | ToolExecuteArgsLegacy | ToolExecuteArgsCurrent;
 const TOOL_ERROR_PARAM_PREVIEW_MAX_CHARS = 600;
+const TOOL_ERROR_EXEC_COMMAND_HASH_CHARS = 16;
+const SENSITIVE_EXEC_ENV_VALUE = "[omitted exec env value]";
+const EXEC_COMMAND_PARAM_KEYS = new Set(["command", "cmd"]);
 
 export type ClientToolCallRecorder =
   | ((toolName: string, params: Record<string, unknown>) => void)
@@ -112,15 +116,99 @@ function formatToolParamPreview(label: string, value: unknown): string {
   return `${label}=${preview}`;
 }
 
+function kindForLog(value: unknown): string {
+  if (Array.isArray(value)) {
+    return "array";
+  }
+  if (value === null) {
+    return "null";
+  }
+  return typeof value;
+}
+
+function summarizeSensitiveValueForLog(params: {
+  value: unknown;
+  reason: string;
+}): Record<string, unknown> {
+  const serialized = serializeToolParams(params.value);
+  return {
+    omitted: true,
+    reason: params.reason,
+    type: kindForLog(params.value),
+    chars: serialized.length,
+    sha256: createHash("sha256")
+      .update(serialized)
+      .digest("hex")
+      .slice(0, TOOL_ERROR_EXEC_COMMAND_HASH_CHARS),
+  };
+}
+
+function summarizeExecCommandForLog(command: unknown): Record<string, unknown> {
+  return summarizeSensitiveValueForLog({
+    value: command,
+    reason: "exec command may contain credentials",
+  });
+}
+
+function sanitizeExecEnvForLog(value: unknown): unknown {
+  if (!isPlainObject(value)) {
+    return value === undefined ? undefined : "[omitted exec env]";
+  }
+  return Object.fromEntries(
+    Object.keys(value)
+      .toSorted()
+      .map((key) => [key, SENSITIVE_EXEC_ENV_VALUE]),
+  );
+}
+
+function sanitizeExecFailureParamsForLog(value: unknown): unknown {
+  if (typeof value === "string") {
+    try {
+      const parsed: unknown = JSON.parse(value);
+      if (isPlainObject(parsed)) {
+        return sanitizeExecFailureParamsForLog(parsed);
+      }
+    } catch {
+      // Non-JSON exec params can still be a raw model-supplied command payload.
+    }
+  }
+  if (!isPlainObject(value)) {
+    return summarizeSensitiveValueForLog({
+      value,
+      reason: "exec params may contain command credentials",
+    });
+  }
+  const sanitized: Record<string, unknown> = {};
+  for (const [key, field] of Object.entries(value)) {
+    if (EXEC_COMMAND_PARAM_KEYS.has(key)) {
+      sanitized[key] = summarizeExecCommandForLog(field);
+      continue;
+    }
+    if (key === "env") {
+      sanitized[key] = sanitizeExecEnvForLog(field);
+      continue;
+    }
+    sanitized[key] = field;
+  }
+  return sanitized;
+}
+
+function sanitizeToolFailureParamsForLog(toolName: string, value: unknown): unknown {
+  return toolName === "exec" ? sanitizeExecFailureParamsForLog(value) : value;
+}
+
 function describeToolFailureInputs(params: {
+  toolName: string;
   rawParams: unknown;
   effectiveParams: unknown;
 }): string {
-  const parts = [formatToolParamPreview("raw_params", params.rawParams)];
-  const rawSerialized = serializeToolParams(params.rawParams);
-  const effectiveSerialized = serializeToolParams(params.effectiveParams);
+  const rawParams = sanitizeToolFailureParamsForLog(params.toolName, params.rawParams);
+  const effectiveParams = sanitizeToolFailureParamsForLog(params.toolName, params.effectiveParams);
+  const parts = [formatToolParamPreview("raw_params", rawParams)];
+  const rawSerialized = serializeToolParams(rawParams);
+  const effectiveSerialized = serializeToolParams(effectiveParams);
   if (effectiveSerialized !== rawSerialized) {
-    parts.push(formatToolParamPreview("effective_params", params.effectiveParams));
+    parts.push(formatToolParamPreview("effective_params", effectiveParams));
   }
   return parts.join(" ");
 }
@@ -279,6 +367,7 @@ export function toToolDefinitions(
             logDebug(`tools: ${normalizedName} failed stack:\n${described.stack}`);
           }
           const inputPreview = describeToolFailureInputs({
+            toolName: normalizedName,
             rawParams: params,
             effectiveParams: executeParams,
           });

--- a/src/logging/redact.test.ts
+++ b/src/logging/redact.test.ts
@@ -45,6 +45,21 @@ describe("redactSensitiveText", () => {
     expect(output).toBe("OPENAI_API_KEY=sk-123…cdef");
   });
 
+  it("masks JSON-escaped quoted env assignments while keeping the key", () => {
+    const xai = "issue85049-xai-cleartext-token-ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
+    const brave = "issue85049-brave-cleartext-token-ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
+    const input = `raw_params={"command":"export XAI_API_KEY=\\\"${xai}\\\" && export BRAVE_API_KEY=\\\\\\\"${brave}\\\\\\\" && echo blocked"}`;
+    const output = redactSensitiveText(input, {
+      mode: "tools",
+      patterns: defaults,
+    });
+    expect(output).toContain("XAI_API_KEY=");
+    expect(output).toContain("BRAVE_API_KEY=");
+    expect(output).not.toContain(xai);
+    expect(output).not.toContain(brave);
+    expect(output).toContain("issue8…7890");
+  });
+
   it("masks CLI flags", () => {
     const input = "curl --token abcdef1234567890ghij https://api.test";
     const output = redactSensitiveText(input, {

--- a/src/logging/redact.test.ts
+++ b/src/logging/redact.test.ts
@@ -48,7 +48,7 @@ describe("redactSensitiveText", () => {
   it("masks JSON-escaped quoted env assignments while keeping the key", () => {
     const xai = "issue85049-xai-cleartext-token-ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
     const brave = "issue85049-brave-cleartext-token-ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
-    const input = `raw_params={"command":"export XAI_API_KEY=\\\"${xai}\\\" && export BRAVE_API_KEY=\\\\\\\"${brave}\\\\\\\" && echo blocked"}`;
+    const input = String.raw`raw_params={"command":"export XAI_API_KEY=\"${xai}\" && export BRAVE_API_KEY=\\\"${brave}\\\" && echo blocked"}`;
     const output = redactSensitiveText(input, {
       mode: "tools",
       patterns: defaults,

--- a/src/logging/redact.ts
+++ b/src/logging/redact.ts
@@ -43,6 +43,7 @@ const DEFAULT_REDACT_PATTERNS: string[] = [
   // ENV-style assignments. Keep this case-sensitive so diagnostics like
   // `Unrecognized key: "llm"` do not lose the actual config key.
   String.raw`/\b[A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD|PASSWD|${PAYMENT_CREDENTIAL_ENV_KEYS})\b\s*[=:]\s*(["']?)([^\s"'\\]+)\1/g`,
+  String.raw`/\b[A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD|PASSWD|${PAYMENT_CREDENTIAL_ENV_KEYS})\b\s*[=:]\s*\\+(["'])([^\s"'\\]+)\\+\1/g`,
   // URL query parameters. Keep this separate from ENV-style assignments so
   // lower-case URL secrets stay redacted without hiding config-key diagnostics.
   String.raw`/[?&](?:access[-_]?token|auth[-_]?token|hook[-_]?token|refresh[-_]?token|api[-_]?key|client[-_]?secret|token|key|secret|password|pass|passwd|auth|signature|${PAYMENT_CREDENTIAL_QUERY_KEYS})=([^&\s"'<>]+)/gi`,


### PR DESCRIPTION
## Summary

- Problem: denied `exec` failures logged raw `raw_params`, which could include shell commands and inline credentials.
- Solution: sanitize normalized `exec` failure params before formatting failure logs, omitting command text and env values while retaining safe metadata.
- What changed: `exec`/`bash` failure logging now summarizes `command`/`cmd`, omits env values, handles JSON-string and malformed exec params, and adds escaped env-assignment redaction as defense in depth.
- What did NOT change (scope boundary): non-exec tool failure parameter logging keeps its existing behavior.

## Motivation

- Closes #85049. The reported breakage is a real log-safety issue because denied exec calls can still include model-supplied command text with credentials.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #85049
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior addressed: denied `exec` tool failures still produce a useful failure log, but do not write raw command text or env values containing credentials.
- Real environment tested: AWS Crabbox Linux direct provider, `provider=aws`, lease `cbx_d7bedb291d7a`, run `run_46e34297e3b5`.
- Exact steps or command run after this patch: executed a denied gateway-host `exec` call with fake inline command credentials and fake env credentials, then inspected stderr, the OpenClaw file log, and tool result output.
- Evidence after fix: AWS Crabbox output showed `gatewayErrContainsOmittedCommand=true`, `gatewayErrContainsOmittedEnv=true`, `fileLogContainsOmittedCommand=true`, `fileLogContainsOmittedEnv=true`, and all fake-token/export checks false.
- Observed result after fix: denied exec logged `raw_params={"command":{"omitted":true,...},"env":{"...":"[omitted exec env value]"},"timeout":5}` with no fake token values and no `export XAI_API_KEY` text in combined proof output.
- What was not tested: a full production channel conversation; the proof used the real OpenClaw exec tool path on AWS Crabbox with synthetic credentials.
- Before evidence (optional but encouraged): AWS Crabbox run `run_232c08c997df`, lease `cbx_1e896a6cf0f1`, reproduced current-main leakage where denied exec `raw_params` contained the fake XAI and Brave token strings in stderr and file logs.

## Root Cause (if applicable)

- Root cause: `src/agents/pi-tool-definition-adapter.ts` formatted failed tool `raw_params` before applying any exec-specific command/env omission, so denied exec errors could serialize raw command input into stderr and file logs.
- Missing detection / guardrail: logging tests covered general redaction but did not lock the denied exec failure-log path against raw command/env payloads.
- Contributing context (if known): the generic redaction layer was best-effort pattern matching, but shell commands can contain credentials in arbitrary shapes.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [x] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/pi-tool-definition-adapter.logging.test.ts`, `src/logging/redact.test.ts`, plus AWS Crabbox repro proof.
- Scenario the test should lock in: failed normalized `exec`/`bash` logs omit raw `command`/`cmd` and env values for object, JSON-string, and malformed params.
- Why this is the smallest reliable guardrail: the adapter is the boundary that formats failed tool params for logs.
- Existing test that already covers this (if any): none before this PR.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Failed `exec` logs no longer include raw command text or env values. They now include safe command metadata and env key names for correlation/debugging.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? Yes
- New/changed network calls? No
- Command/tool execution surface changed? Yes
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: this reduces log exposure for command/tool execution failures by omitting command text and env values before log formatting. The tradeoff is less raw diagnostic detail for failed exec calls; retained metadata includes type, length, short hash, env keys, and non-sensitive fields such as timeout.

## Repro + Verification

### Environment

- OS: Linux via AWS Crabbox
- Runtime/container: Node 24 on direct AWS Crabbox checkout
- Model/provider: N/A
- Integration/channel (if any): exec tool path
- Relevant config (redacted): `host=gateway`, `security=allowlist`, `ask=off`, empty safe bins

### Steps

1. Create an exec tool with gateway allowlist security and no safe bins.
2. Execute a denied command containing fake inline credentials plus fake env credentials.
3. Inspect stderr, file logs, and tool result output for omitted command/env markers and absence of fake secrets.

### Expected

Denied exec failure is visible, but raw command text and env values are absent from logs.

### Actual

AWS Crabbox proof passed with omitted command/env markers present and fake-token/export checks false.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: focused Vitest logging/redaction tests; maintainer autoreview; AWS Crabbox denied exec fix proof.
- Edge cases checked: object params, JSON-string params, malformed command/env values, `bash` alias normalized to `exec`, and `cmd` payload alias.
- What you did **not** verify: full production chat/channel flow.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: operators lose raw command text in denied exec failure logs.
  - Mitigation: logs retain safe metadata (`type`, `chars`, short `sha256`), env key names, and non-sensitive fields so repeated failures remain correlatable without exposing secrets.
