### PR TITLE
fix(dreaming): open report cards from Memory Palace

### DIFF
--- a/ui/src/ui/views/dreaming.test.ts
+++ b/ui/src/ui/views/dreaming.test.ts
@@ -414,6 +414,98 @@ describe("dreaming view", () => {
     setDreamSubTab("scene");
   });
 
+  it("keeps non-report memory palace card clicks on details", () => {
+    setDreamSubTab("diary");
+    setDreamDiarySubTab("palace");
+    const container = document.createElement("div");
+    let props: DreamingProps;
+    const rerender = () => render(renderDreaming(props), container);
+    props = buildProps({ onRequestUpdate: rerender });
+    rerender();
+
+    const card = expectElement(container, "[data-palace-page='syntheses/travel-system.md']");
+    card.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    expect(textItems(container, ".dreams-diary__insight-list strong")).toContain("Page details");
+    setDreamDiarySubTab("dreams");
+    setDreamSubTab("scene");
+  });
+
+  it("opens report memory palace cards on primary click", async () => {
+    setDreamSubTab("diary");
+    setDreamDiarySubTab("palace");
+    const onOpenWikiPage = vi.fn().mockResolvedValue({
+      title: "Weekly stock report",
+      path: "reports/weekly-stock.md",
+      content: "# Weekly stock report\n\nSummary content.",
+      totalLines: 2,
+      truncated: false,
+    });
+    const container = document.createElement("div");
+    let props: DreamingProps;
+    const rerender = () => render(renderDreaming(props), container);
+    props = buildProps({
+      onOpenWikiPage,
+      onRequestUpdate: rerender,
+      wikiMemoryPalace: {
+        totalItems: 1,
+        totalClaims: 0,
+        totalQuestions: 0,
+        totalContradictions: 0,
+        clusters: [
+          {
+            key: "report",
+            label: "Reports",
+            itemCount: 1,
+            claimCount: 0,
+            questionCount: 0,
+            contradictionCount: 0,
+            items: [
+              {
+                pagePath: "reports/weekly-stock.md",
+                title: "Weekly stock report",
+                kind: "report",
+                claimCount: 0,
+                questionCount: 0,
+                contradictionCount: 0,
+                claims: [],
+                questions: [],
+                contradictions: [],
+                snippet: "Weekly stock summary.",
+                updatedAt: "2026-04-12T10:00:00.000Z",
+              },
+            ],
+          },
+        ],
+      },
+    });
+    rerender();
+
+    const card = expectElement(container, "[data-palace-page='reports/weekly-stock.md']");
+    card.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(onOpenWikiPage).toHaveBeenCalledWith("reports/weekly-stock.md");
+    expect(textItems(container, ".dreams-diary__insight-list strong")).not.toContain(
+      "Page details",
+    );
+    expect(compactText(container.querySelector(".dreams-diary__preview-title"))).toBe(
+      "Weekly stock report",
+    );
+    expect(compactText(container.querySelector(".dreams-diary__preview-body"))).toBe(
+      "# Weekly stock report Summary content.",
+    );
+
+    const closePreviewButton = container.querySelector<HTMLButtonElement>(
+      ".dreams-diary__preview-header .btn",
+    );
+    expect(closePreviewButton).toBeInstanceOf(HTMLButtonElement);
+    closePreviewButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    setDreamDiarySubTab("dreams");
+    setDreamSubTab("scene");
+  });
+
   it("shows a memory-wiki enablement CTA when wiki subtabs are selected but the plugin is disabled", () => {
     setDreamSubTab("diary");
     setDreamDiarySubTab("palace");

--- a/ui/src/ui/views/dreaming.ts
+++ b/ui/src/ui/views/dreaming.ts
@@ -5,6 +5,7 @@ import type {
   DreamingEntry,
   WikiImportInsights,
   WikiMemoryPalace,
+  WikiMemoryPalaceItem,
 } from "../controllers/dreaming.ts";
 import { toSanitizedMarkdownHtml } from "../markdown.ts";
 
@@ -521,6 +522,14 @@ function toggleExpandedCard(bucket: Set<string>, key: string, requestUpdate?: ()
     bucket.add(key);
   }
   requestUpdate?.();
+}
+
+function handleMemoryPalaceCardClick(item: WikiMemoryPalaceItem, props: DreamingProps): void {
+  if (item.kind === "report") {
+    void openWikiPreview(item.pagePath, props);
+    return;
+  }
+  toggleExpandedCard(expandedPalaceCards, item.pagePath, props.onRequestUpdate);
 }
 
 async function openWikiPreview(lookup: string, props: DreamingProps): Promise<void> {
@@ -1180,8 +1189,7 @@ function renderMemoryPalaceSection(props: DreamingProps) {
             <article
               class="dreams-diary__insight-card dreams-diary__insight-card--clickable"
               data-palace-page=${item.pagePath}
-              @click=${() =>
-                toggleExpandedCard(expandedPalaceCards, item.pagePath, props.onRequestUpdate)}
+              @click=${() => handleMemoryPalaceCardClick(item, props)}
             >
               <div class="dreams-diary__insight-topline">
                 <div class="dreams-diary__insight-title">${item.title}</div>


### PR DESCRIPTION
## Summary
- Open Memory Palace report cards through the existing wiki preview flow on primary card click.
- Keep non-report Memory Palace cards on the existing details expansion behavior.
- Add Dreaming view regression coverage for report-card preview clicks and non-report details clicks.

Fixes #54749

## Verification
- `node scripts/run-vitest.mjs ui/src/ui/views/dreaming.test.ts`
- `pnpm exec oxfmt --check --threads=1 ui/src/ui/views/dreaming.ts ui/src/ui/views/dreaming.test.ts`
- `git diff --check origin/main..HEAD`
- `pnpm check:changed`

## Real behavior proof
Behavior addressed: Memory Palace report cards now open the report/wiki content preview on primary click instead of expanding the metadata details panel.

Real environment tested: Local OpenClaw checkout on macOS with Node v24.10.0 and pnpm 11.1.0.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs ui/src/ui/views/dreaming.test.ts`

Evidence after fix: The regression test clicks a `kind: "report"` Memory Palace card and verifies `onOpenWikiPage("reports/weekly-stock.md")` runs, the preview shows "Weekly stock report", and the details panel does not open. The adjacent non-report test clicks a synthesis card and verifies it still opens "Page details".

Observed result after fix: Report-card primary clicks route to the existing wiki preview; non-report card primary clicks preserve the previous details behavior.

What was not tested: I did not run a live mobile browser against a running gateway.
