### PR TITLE
fix(docker): pre-create workspace and config dirs for named volumes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -283,10 +283,15 @@ RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,shar
 RUN ln -sf /app/openclaw.mjs /usr/local/bin/openclaw \
  && chmod 755 /app/openclaw.mjs
 
-# Pre-create the default state dir so first-run Docker named volumes mounted
-# here inherit node ownership instead of root-owned state.
+# Pre-create default directories so first-run Docker named volumes mounted
+# here inherit node ownership instead of being root-owned.
+# See: https://github.com/openclaw/openclaw/issues/85076
 RUN install -d -m 0700 -o node -g node /home/node/.openclaw && \
-    stat -c '%U:%G %a' /home/node/.openclaw | grep -qx 'node:node 700'
+    install -d -m 0755 -o node -g node /home/node/.openclaw/workspace && \
+    install -d -m 0755 -o node -g node /home/node/.config/openclaw && \
+    stat -c '%U:%G %a' /home/node/.openclaw | grep -qx 'node:node 700' && \
+    stat -c '%U:%G %a' /home/node/.openclaw/workspace | grep -qx 'node:node 755' && \
+    stat -c '%U:%G %a' /home/node/.config/openclaw | grep -qx 'node:node 755'
 
 ENV NODE_ENV=production
 

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -309,5 +309,17 @@ describe("Dockerfile", () => {
     expect(dockerfile).toContain(
       "stat -c '%U:%G %a' /home/node/.openclaw | grep -qx 'node:node 700'",
     );
+    expect(dockerfile).toContain(
+      "install -d -m 0755 -o node -g node /home/node/.openclaw/workspace",
+    );
+    expect(dockerfile).toContain(
+      "install -d -m 0755 -o node -g node /home/node/.config/openclaw",
+    );
+    expect(dockerfile).toContain(
+      "stat -c '%U:%G %a' /home/node/.openclaw/workspace | grep -qx 'node:node 755'",
+    );
+    expect(dockerfile).toContain(
+      "stat -c '%U:%G %a' /home/node/.config/openclaw | grep -qx 'node:node 755'",
+    );
   });
 });


### PR DESCRIPTION
## Summary

Docker named volumes mounted at `/home/node/.openclaw/workspace` and `/home/node/.config/openclaw` come up `root:root` because only the state dir (`/home/node/.openclaw`) was pre-created in the image. This blocks first-run agent commands with `EACCES` on fresh named-volume deployments.

## Fix

Pre-create both directories with `node:node` ownership before `USER node`, matching the existing pattern from #72662. Add stat verification and structural test coverage.

## Reproduction

```bash
SUFFIX=1779411937
docker run --rm \
  -v test-state-:/home/node/.openclaw \
  -v test-workspace-:/home/node/.openclaw/workspace \
  -v test-cfg-:/home/node/.config/openclaw \
  --user root --entrypoint sh \
  ghcr.io/openclaw/openclaw:2026.5.19 \
  -c 'ls -ldn /home/node/.openclaw /home/node/.openclaw/workspace /home/node/.config/openclaw'
```

Before fix: workspace and config dirs are `root:root 755`.
After fix: all three dirs are `node:node`.

## Testing

- `node scripts/run-vitest.mjs src/dockerfile.test.ts`
- Updated structural test to verify new directories

Fixes #85076