### PR TITLE
fix(codex): preserve webSearch query and action metadata in transcript

### DIFF
--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -1888,6 +1888,38 @@ describe("CodexAppServerEventProjector", () => {
     expect(event.result).toEqual({ status: "completed" });
   });
 
+  it("uses sentinel for empty webSearch query and preserves action metadata", async () => {
+    const projector = await createProjector();
+
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "webSearch",
+          id: "search-empty",
+          query: "",
+          status: "completed",
+          durationMs: 3,
+          action: { type: "search", query: "actual search term" },
+        },
+      }),
+    );
+
+    await vi.waitFor(() => expect(afterToolCall).toHaveBeenCalledTimes(1));
+    const event = requireRecord(
+      mockCallArg(afterToolCall, 0, 0, "after_tool_call event"),
+      "after_tool_call event",
+    );
+    expect(event.toolName).toBe("web_search");
+    expect(event.params).toEqual({
+      query: "<native web search \u2014 query not exposed by provider>",
+      action: { type: "search", query: "actual search term" },
+    });
+    expect(event.result).toEqual({
+      status: "completed",
+      action: { type: "search", query: "actual search term" },
+    });
+  });
+
   it("records dynamic OpenClaw tool calls in mirrored transcript snapshots", async () => {
     const projector = await createProjector();
 

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -1834,8 +1834,16 @@ function itemToolArgs(item: CodexThreadItem): Record<string, unknown> | undefine
       changes: itemFileChanges(item),
     });
   }
-  if (item.type === "webSearch" && typeof item.query === "string") {
-    return sanitizeCodexAgentEventRecord({ query: item.query });
+  if (item.type === "webSearch") {
+    const query =
+      typeof item.query === "string" && item.query.length > 0
+        ? item.query
+        : "<native web search — query not exposed by provider>";
+    const action = (item as Record<string, unknown>).action;
+    return sanitizeCodexAgentEventRecord({
+      query,
+      ...(action != null ? { action } : {}),
+    });
   }
   if (item.type === "dynamicToolCall" || item.type === "mcpToolCall") {
     return sanitizeCodexToolArguments(item.arguments);
@@ -1872,7 +1880,13 @@ function itemToolResult(item: CodexThreadItem): { result?: Record<string, unknow
     };
   }
   if (item.type === "webSearch") {
-    return { result: sanitizeCodexAgentEventRecord({ status: "completed" }) };
+    const action = (item as Record<string, unknown>).action;
+    return {
+      result: sanitizeCodexAgentEventRecord({
+        status: "completed",
+        ...(action != null ? { action } : {}),
+      }),
+    };
   }
   return {};
 }


### PR DESCRIPTION
## Summary

Codex-native `web_search` calls were mirrored into session/chat logs with an empty query string `{"query":""}` and a bare `{"status":"completed"}` result, making it impossible to tell what the model actually searched for.

## Fix

1. **Empty query sentinel**: When `query` is empty or not exposed by the provider, use `"<native web search — query not exposed by provider>"` instead of `""`
2. **Action metadata preservation**: Include the `action` field (which carries search queries, URLs, patterns) in both tool args and result when available

## Changes

- `extensions/codex/src/app-server/event-projector.ts`: Updated `itemToolArgs` and `itemToolResult` for `webSearch` type
- `extensions/codex/src/app-server/event-projector.test.ts`: Added regression test for empty query sentinel and action preservation

## Testing

```bash
node scripts/run-vitest.mjs extensions/codex/src/app-server/event-projector.test.ts
```

Fixes #85109