### PR TITLE
fix(commands): add argsMenu to /verbose for inline button rendering

### DIFF
--- a/src/auto-reply/commands-registry.shared.ts
+++ b/src/auto-reply/commands-registry.shared.ts
@@ -775,6 +775,7 @@ export function buildBuiltinChatCommands(
           choices: ["on", "off", "full"],
         },
       ],
+      argsMenu: "auto",
     }),
     defineChatCommand({
       key: "trace",


### PR DESCRIPTION
## Summary

The `/verbose` command was missing `argsMenu: "auto"`, so its option choices (on/off/full) were not rendered as inline buttons on Telegram and Feishu. Users had to manually type the option instead of tapping a button.

Note: `/reasoning` already has `argsMenu: "auto"` in current main, so only `/verbose` needed the fix.

## Before

```
Current verbose level: off
Options: on, off, full
```

User must type the option manually.

## After

Inline buttons are rendered for on/off/full choices, matching the behavior of `/think`, `/trace`, `/fast`, etc.

## Testing

- Verified other commands with `argsMenu: "auto"` (think, trace, fast, reasoning) already render buttons correctly
- The fix is a single-line addition matching the established pattern

Fixes #85088