### PR TITLE
perf(models): make provider auth checks non-blocking

### DIFF
--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -661,27 +661,27 @@ describe("getApiKeyForModel", () => {
 
     try {
       await withEnvAsync({ WORKSPACE_CLOUD_CREDENTIALS: credentialsPath }, async () => {
-        expect(
+        await expect(
           hasAuthForModelProvider({
             provider: "workspace-cloud",
             cfg: { plugins: { allow: ["workspace-cloud"] } },
             store,
           }),
-        ).toBe(true);
-        expect(
+        ).resolves.toBe(true);
+        await expect(
           hasAuthForModelProvider({
             provider: "workspace-cloud",
             cfg: { plugins: {} },
             store,
           }),
-        ).toBe(false);
+        ).resolves.toBe(false);
       });
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });
     }
   });
 
-  it("reuses runtime auth availability for provider auth checks", () => {
+  it("reuses runtime auth availability for provider auth checks", async () => {
     const store = { version: 1 as const, profiles: {} };
     const localNoKeyConfig = {
       models: {
@@ -700,30 +700,30 @@ describe("getApiKeyForModel", () => {
       },
     } as OpenClawConfig;
 
-    expect(
+    await expect(
       hasAuthForModelProvider({
         provider: "amazon-bedrock",
         cfg: {} as OpenClawConfig,
         env: {},
         store,
       }),
-    ).toBe(true);
-    expect(
+    ).resolves.toBe(true);
+    await expect(
       hasAuthForModelProvider({
         provider: "vllm",
         cfg: localNoKeyConfig,
         env: {},
         store,
       }),
-    ).toBe(true);
-    expect(
+    ).resolves.toBe(true);
+    await expect(
       hasAuthForModelProvider({
         provider: "remote",
         cfg: localNoKeyConfig,
         env: {},
         store,
       }),
-    ).toBe(false);
+    ).resolves.toBe(false);
   });
 
   it("hasAvailableAuthForProvider('google') accepts GOOGLE_API_KEY fallback", async () => {

--- a/src/agents/model-auth.workspace-plugin.test.ts
+++ b/src/agents/model-auth.workspace-plugin.test.ts
@@ -102,14 +102,14 @@ describe("workspace plugin model auth evidence", () => {
               store,
             }),
           ).resolves.toBe(true);
-          expect(
+          await expect(
             hasAuthForModelProvider({
               provider: "workspace-cloud",
               cfg,
               workspaceDir,
               store,
             }),
-          ).toBe(true);
+          ).resolves.toBe(true);
         },
       );
     } finally {

--- a/src/agents/model-catalog-visibility.test.ts
+++ b/src/agents/model-catalog-visibility.test.ts
@@ -4,15 +4,15 @@ import { resolveVisibleModelCatalog } from "./model-catalog-visibility.js";
 import type { ModelCatalogEntry } from "./model-catalog.types.js";
 
 describe("resolveVisibleModelCatalog", () => {
-  it("can use static auth checks for gateway read-only model lists", () => {
-    const authChecker = vi.fn((provider: string) => provider === "openai");
+  it("can use static auth checks for gateway read-only model lists", async () => {
+    const authChecker = vi.fn(async (provider: string) => provider === "openai");
     const catalog: ModelCatalogEntry[] = [
       { provider: "anthropic", id: "claude-test", name: "Claude Test" },
       { provider: "openai", id: "gpt-test", name: "GPT Test" },
     ];
     const cfg = {} as OpenClawConfig;
 
-    const result = resolveVisibleModelCatalog({
+    const result = await resolveVisibleModelCatalog({
       cfg,
       catalog,
       defaultProvider: "openai",
@@ -26,8 +26,8 @@ describe("resolveVisibleModelCatalog", () => {
     expect(result).toEqual([{ provider: "openai", id: "gpt-test", name: "GPT Test" }]);
   });
 
-  it("limits visible catalog to provider wildcard entries after default discovery", () => {
-    const authChecker = vi.fn((provider: string) => provider !== "blocked");
+  it("limits visible catalog to provider wildcard entries after default discovery", async () => {
+    const authChecker = vi.fn(async (provider: string) => provider !== "blocked");
     const catalog: ModelCatalogEntry[] = [
       { provider: "anthropic", id: "claude-test", name: "Claude Test" },
       { provider: "openai-codex", id: "gpt-codex-test", name: "GPT Codex Test" },
@@ -47,7 +47,7 @@ describe("resolveVisibleModelCatalog", () => {
       },
     } as OpenClawConfig;
 
-    const result = resolveVisibleModelCatalog({
+    const result = await resolveVisibleModelCatalog({
       cfg,
       catalog,
       defaultProvider: "anthropic",
@@ -66,8 +66,8 @@ describe("resolveVisibleModelCatalog", () => {
     ]);
   });
 
-  it("does not broaden visibility when selected providers have no catalog rows", () => {
-    const authChecker = vi.fn(() => true);
+  it("does not broaden visibility when selected providers have no catalog rows", async () => {
+    const authChecker = vi.fn(async () => true);
 
     const cfg = {
       agents: {
@@ -79,7 +79,7 @@ describe("resolveVisibleModelCatalog", () => {
       },
     } as OpenClawConfig;
 
-    const result = resolveVisibleModelCatalog({
+    const result = await resolveVisibleModelCatalog({
       cfg,
       catalog: [{ provider: "anthropic", id: "claude-test", name: "Claude Test" }],
       defaultProvider: "anthropic",

--- a/src/agents/model-catalog-visibility.ts
+++ b/src/agents/model-catalog-visibility.ts
@@ -26,7 +26,7 @@ function dedupeModelCatalogEntries(entries: ModelCatalogEntry[]): ModelCatalogEn
   return next;
 }
 
-export function resolveVisibleModelCatalog(params: {
+export async function resolveVisibleModelCatalog(params: {
   cfg: OpenClawConfig;
   catalog: ModelCatalogEntry[];
   defaultProvider: string;
@@ -36,13 +36,13 @@ export function resolveVisibleModelCatalog(params: {
   env?: NodeJS.ProcessEnv;
   view?: ModelCatalogVisibilityView;
   runtimeAuthDiscovery?: boolean;
-  providerAuthChecker?: (provider: string) => boolean;
-}): ModelCatalogEntry[] {
+  providerAuthChecker?: (provider: string) => Promise<boolean>;
+}): Promise<ModelCatalogEntry[]> {
   if (params.view === "all") {
     return params.catalog;
   }
 
-  const buildDefaultVisibleCatalog = () => {
+  const buildDefaultVisibleCatalog = async () => {
     const configuredCatalog = sortModelCatalogEntries(
       buildConfiguredModelCatalog({ cfg: params.cfg }),
     );
@@ -56,7 +56,12 @@ export function resolveVisibleModelCatalog(params: {
         allowPluginSyntheticAuth: params.runtimeAuthDiscovery,
         discoverExternalCliAuth: params.runtimeAuthDiscovery,
       });
-    const authBackedCatalog = params.catalog.filter((entry) => hasAuth(entry.provider));
+    const authBackedCatalog: ModelCatalogEntry[] = [];
+    for (const entry of params.catalog) {
+      if (await hasAuth(entry.provider)) {
+        authBackedCatalog.push(entry);
+      }
+    }
     return sortModelCatalogEntries(
       dedupeModelCatalogEntries([...configuredCatalog, ...authBackedCatalog]),
     );
@@ -70,7 +75,7 @@ export function resolveVisibleModelCatalog(params: {
     agentId: params.agentId,
   });
   const defaultVisibleCatalog =
-    policy.allowAny || policy.hasProviderWildcards ? buildDefaultVisibleCatalog() : [];
+    policy.allowAny || policy.hasProviderWildcards ? await buildDefaultVisibleCatalog() : [];
   return sortModelCatalogEntries(
     dedupeModelCatalogEntries(
       policy.visibleCatalog({

--- a/src/agents/model-provider-auth.test.ts
+++ b/src/agents/model-provider-auth.test.ts
@@ -73,13 +73,13 @@ describe("prepared provider auth state", () => {
     // hasAuthForModelProvider returns the cached answers without re-running
     // the compute path.
     modelAuthMocks.hasRuntimeAvailableProviderAuth.mockReturnValue(true);
-    expect(hasAuthForModelProvider({ provider: "openai", cfg })).toBe(true);
-    expect(hasAuthForModelProvider({ provider: "anthropic", cfg })).toBe(false);
+    await expect(hasAuthForModelProvider({ provider: "openai", cfg })).resolves.toBe(true);
+    await expect(hasAuthForModelProvider({ provider: "anthropic", cfg })).resolves.toBe(false);
     expect(modelAuthMocks.hasRuntimeAvailableProviderAuth).toHaveBeenCalledTimes(2);
 
     // Clearing the prepared state forces the compute path on the next read.
     clearCurrentProviderAuthState();
-    expect(hasAuthForModelProvider({ provider: "anthropic", cfg })).toBe(true);
+    await expect(hasAuthForModelProvider({ provider: "anthropic", cfg })).resolves.toBe(true);
     expect(modelAuthMocks.hasRuntimeAvailableProviderAuth).toHaveBeenCalledTimes(3);
   });
 
@@ -98,18 +98,18 @@ describe("prepared provider auth state", () => {
     // runtimeAuthDiscovery: false maps to both flags false, and the answer
     // must reflect that narrower scope, not the prepared broad answer.
     modelAuthMocks.hasRuntimeAvailableProviderAuth.mockReturnValue(false);
-    expect(
+    await expect(
       hasAuthForModelProvider({
         provider: "openai",
         cfg,
         discoverExternalCliAuth: false,
         allowPluginSyntheticAuth: false,
       }),
-    ).toBe(false);
+    ).resolves.toBe(false);
     expect(modelAuthMocks.hasRuntimeAvailableProviderAuth).toHaveBeenCalledTimes(2);
 
     // Broad-scope caller (default flags) still hits the prepared map.
-    expect(hasAuthForModelProvider({ provider: "openai", cfg })).toBe(true);
+    await expect(hasAuthForModelProvider({ provider: "openai", cfg })).resolves.toBe(true);
     expect(modelAuthMocks.hasRuntimeAvailableProviderAuth).toHaveBeenCalledTimes(2);
   });
 
@@ -124,7 +124,9 @@ describe("prepared provider auth state", () => {
     expect(modelAuthMocks.hasRuntimeAvailableProviderAuth).toHaveBeenCalledTimes(1);
 
     modelAuthMocks.hasRuntimeAvailableProviderAuth.mockReturnValue(false);
-    expect(hasAuthForModelProvider({ provider: "openai", cfg: clonedCfg })).toBe(true);
+    await expect(hasAuthForModelProvider({ provider: "openai", cfg: clonedCfg })).resolves.toBe(
+      true,
+    );
     expect(modelAuthMocks.hasRuntimeAvailableProviderAuth).toHaveBeenCalledTimes(1);
   });
 
@@ -141,23 +143,23 @@ describe("prepared provider auth state", () => {
     // warmer did not cover; the prepared answer must not leak across
     // workspaces because env/plugin auth resolution depends on workspaceDir.
     modelAuthMocks.hasRuntimeAvailableProviderAuth.mockReturnValue(false);
-    expect(
+    await expect(
       hasAuthForModelProvider({
         provider: "openai",
         cfg,
         workspaceDir: "/different/agent-workspace",
       }),
-    ).toBe(false);
+    ).resolves.toBe(false);
     expect(modelAuthMocks.hasRuntimeAvailableProviderAuth).toHaveBeenCalledTimes(2);
 
     // Same workspaceDir as the warmer (the default) still hits the prepared map.
-    expect(
+    await expect(
       hasAuthForModelProvider({
         provider: "openai",
         cfg,
         workspaceDir: "/warm/default-workspace",
       }),
-    ).toBe(true);
+    ).resolves.toBe(true);
     expect(modelAuthMocks.hasRuntimeAvailableProviderAuth).toHaveBeenCalledTimes(2);
   });
 
@@ -193,9 +195,13 @@ describe("prepared provider auth state", () => {
     expect(modelAuthMocks.hasRuntimeAvailableProviderAuth).toHaveBeenCalledTimes(2);
 
     modelAuthMocks.hasRuntimeAvailableProviderAuth.mockReturnValue(true);
-    expect(hasAuthForModelProvider({ provider: "openai", cfg: secondCfg })).toBe(false);
+    await expect(hasAuthForModelProvider({ provider: "openai", cfg: secondCfg })).resolves.toBe(
+      false,
+    );
     expect(modelAuthMocks.hasRuntimeAvailableProviderAuth).toHaveBeenCalledTimes(2);
-    expect(hasAuthForModelProvider({ provider: "openai", cfg: firstCfg })).toBe(true);
+    await expect(hasAuthForModelProvider({ provider: "openai", cfg: firstCfg })).resolves.toBe(
+      true,
+    );
     expect(modelAuthMocks.hasRuntimeAvailableProviderAuth).toHaveBeenCalledTimes(3);
   });
 });

--- a/src/agents/model-provider-auth.ts
+++ b/src/agents/model-provider-auth.ts
@@ -76,7 +76,7 @@ function resolveProviderAuthConfigFingerprint(cfg: OpenClawConfig | undefined): 
   return fingerprint;
 }
 
-export function hasAuthForModelProvider(params: {
+export async function hasAuthForModelProvider(params: {
   provider: string;
   cfg?: OpenClawConfig;
   workspaceDir?: string;
@@ -85,7 +85,7 @@ export function hasAuthForModelProvider(params: {
   store?: AuthProfileStore;
   allowPluginSyntheticAuth?: boolean;
   discoverExternalCliAuth?: boolean;
-}): boolean {
+}): Promise<boolean> {
   const provider = normalizeProviderId(params.provider);
   // The prepared map is built by warmCurrentProviderAuthState — one entry per
   // configured agent, keyed by agentId. Only consult it when the caller's
@@ -123,6 +123,7 @@ export function hasAuthForModelProvider(params: {
       return preparedAnswer;
     }
   }
+  await new Promise<void>((resolve) => setImmediate(resolve));
   if (
     hasRuntimeAvailableProviderAuth({
       provider,
@@ -158,15 +159,15 @@ export function createProviderAuthChecker(params: {
   env?: NodeJS.ProcessEnv;
   allowPluginSyntheticAuth?: boolean;
   discoverExternalCliAuth?: boolean;
-}): (provider: string) => boolean {
+}): (provider: string) => Promise<boolean> {
   const authCache = new Map<string, boolean>();
-  return (provider: string) => {
+  return async (provider: string) => {
     const key = normalizeProviderId(provider);
     const cached = authCache.get(key);
     if (cached !== undefined) {
       return cached;
     }
-    const value = hasAuthForModelProvider({
+    const value = await hasAuthForModelProvider({
       provider: key,
       cfg: params.cfg,
       workspaceDir: params.workspaceDir,
@@ -210,7 +211,7 @@ export async function warmCurrentProviderAuthState(cfg: OpenClawConfig): Promise
     });
     const state = new Map<string, boolean>();
     for (const provider of providers) {
-      const value = hasAuthForModelProvider({
+      const value = await hasAuthForModelProvider({
         provider,
         cfg,
         workspaceDir,

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -157,7 +157,7 @@ export async function buildModelsProviderData(
     defaultModel: resolvedDefault.model,
     agentId,
   });
-  const visibleCatalog = resolveVisibleModelCatalog({
+  const visibleCatalog = await resolveVisibleModelCatalog({
     cfg,
     catalog,
     defaultProvider: resolvedDefault.provider,
@@ -245,9 +245,9 @@ export async function buildModelsProviderData(
     add(entry.provider, entry.id);
   }
 
-  const hasAuth =
+  const hasAuth: (provider: string) => Promise<boolean> =
     options.view === "all"
-      ? () => true
+      ? async () => true
       : createProviderAuthChecker({
           cfg,
           workspaceDir:
@@ -258,7 +258,7 @@ export async function buildModelsProviderData(
         });
 
   for (const entry of catalog) {
-    if (usesUnfilteredCatalogModels(entry.provider) && hasAuth(entry.provider)) {
+    if (usesUnfilteredCatalogModels(entry.provider) && (await hasAuth(entry.provider))) {
       add(entry.provider, entry.id);
     }
   }

--- a/src/flows/model-picker.ts
+++ b/src/flows/model-picker.ts
@@ -230,7 +230,7 @@ async function resolveLiteralPrefixProviderIds(params: {
   return ids;
 }
 
-function addModelSelectOption(params: {
+async function addModelSelectOption(params: {
   entry: {
     provider: string;
     id: string;
@@ -241,7 +241,7 @@ function addModelSelectOption(params: {
   options: WizardSelectOption[];
   seen: Set<string>;
   aliasIndex: ReturnType<typeof buildModelAliasIndex>;
-  hasAuth: (provider: string) => boolean;
+  hasAuth: (provider: string) => Promise<boolean>;
   literalPrefixProviders: Set<string>;
 }) {
   const normalizedRef = normalizeModelRef(params.entry.provider, params.entry.id);
@@ -271,7 +271,7 @@ function addModelSelectOption(params: {
   if (routeHint) {
     hints.push(routeHint);
   }
-  if (!params.hasAuth(normalizedRef.provider)) {
+  if (!(await params.hasAuth(normalizedRef.provider))) {
     return;
   }
   const label = params.literalPrefixProviders.has(normalizeProviderId(normalizedRef.provider))
@@ -296,12 +296,12 @@ function splitModelKey(key: string): { provider: string; id: string } | undefine
   };
 }
 
-function addModelKeySelectOption(params: {
+async function addModelKeySelectOption(params: {
   key: string;
   options: WizardSelectOption[];
   seen: Set<string>;
   aliasIndex: ReturnType<typeof buildModelAliasIndex>;
-  hasAuth: (provider: string) => boolean;
+  hasAuth: (provider: string) => Promise<boolean>;
   literalPrefixProviders?: Set<string>;
   fallbackHint: string;
 }) {
@@ -310,7 +310,7 @@ function addModelKeySelectOption(params: {
     return;
   }
   const before = params.seen.size;
-  addModelSelectOption({
+  await addModelSelectOption({
     entry,
     options: params.options,
     seen: params.seen,
@@ -725,7 +725,7 @@ export async function promptDefaultModel(
   });
   const models = ignoreAllowlist
     ? catalog
-    : resolveVisibleModelCatalog({
+    : await resolveVisibleModelCatalog({
         cfg,
         catalog,
         defaultProvider: DEFAULT_PROVIDER,
@@ -803,7 +803,7 @@ export async function promptDefaultModel(
 
   const seen = new Set<string>();
   for (const entry of filteredModels) {
-    addModelSelectOption({
+    await addModelSelectOption({
       entry,
       options,
       seen,
@@ -932,11 +932,6 @@ export async function promptModelAllowlist(params: {
     fallbackKeys.length > 0 ||
     (params.initialSelections?.length ?? 0) > 0 ||
     configuredRaw.length > 0;
-  const hasAuth = createProviderAuthChecker({
-    cfg,
-    workspaceDir: params.workspaceDir,
-    env: params.env,
-  });
   const matchesPreferredProvider = preferredProvider
     ? createPreferredProviderMatcher({
         preferredProvider,
@@ -960,8 +955,13 @@ export async function promptModelAllowlist(params: {
     const initialKeys = normalizeModelKeys(initialSeeds.filter((key) => scopeKeySet.has(key)));
     const options: WizardSelectOption[] = [];
     const seen = new Set<string>();
+    const hasAuth = createProviderAuthChecker({
+      cfg,
+      workspaceDir: params.workspaceDir,
+      env: params.env,
+    });
     for (const key of scopeKeys) {
-      addModelKeySelectOption({
+      await addModelKeySelectOption({
         key,
         options,
         seen,
@@ -1052,6 +1052,11 @@ export async function promptModelAllowlist(params: {
     preferredProvider && allowedCatalog.some((entry) => matchesPreferredProvider?.(entry.provider))
       ? allowedCatalog.filter((entry) => matchesPreferredProvider?.(entry.provider))
       : allowedCatalog;
+  const hasAuth = createProviderAuthChecker({
+    cfg,
+    workspaceDir: params.workspaceDir,
+    env: params.env,
+  });
 
   const scopeKeys = allowedKeySet
     ? allowedKeys
@@ -1068,7 +1073,7 @@ export async function promptModelAllowlist(params: {
     : selectableInitialSeeds.filter(isModelPickerVisibleModelRef);
 
   for (const entry of filteredCatalog) {
-    addModelSelectOption({
+    await addModelSelectOption({
       entry,
       options,
       seen,

--- a/src/gateway/server-methods/models.ts
+++ b/src/gateway/server-methods/models.ts
@@ -85,7 +85,7 @@ export const modelsHandlers: GatewayRequestHandlers = {
         respond(true, { models: catalog }, undefined);
         return;
       }
-      const models = resolveVisibleModelCatalog({
+      const models = await resolveVisibleModelCatalog({
         cfg,
         catalog,
         defaultProvider: DEFAULT_PROVIDER,


### PR DESCRIPTION
## Summary

Make the provider-auth check path asynchronous without changing the auth decision logic.

When the prepared provider-auth map misses, model-listing surfaces can walk the catalog and compute auth for many providers. Each provider check can do sync filesystem reads and external-CLI discovery. `hasAuthForModelProvider` now yields once with `setImmediate` before that slow path, and the existing callers now await the same checker so long provider sweeps release the event loop between providers.

This PR intentionally does not change prepared-auth cache semantics, invalidation, auth-profile failure handling, watchers, TTL behavior, or provider eligibility rules.

## Changes

- `hasAuthForModelProvider` now returns `Promise<boolean>`.
- `createProviderAuthChecker` now returns an async checker with the same per-provider cache.
- `warmCurrentProviderAuthState` awaits the existing provider check while preparing the current auth map.
- Model catalog visibility, `/models` provider data, gateway `models.list`, and model-picker call sites now await the async checker directly.
- Tests that call these async paths now await the results.

## Evidence

Before this change, logs showed slow `/models` calls when the prepared auth map missed:

```
14:38:39  buildModelsProviderData done in 22941ms preparedAuth=false agentId=main
14:39:14  buildModelsProviderData done in 22610ms preparedAuth=false agentId=main
14:39:44  buildModelsProviderData done in 22814ms preparedAuth=false agentId=main
14:40:17  buildModelsProviderData done in 22825ms preparedAuth=false agentId=main
```

The matching gateway diagnostic showed the event loop blocked for the same window:

```
14:44:14 [diagnostic] liveness warning: reasons=event_loop_delay,event_loop_utilization,cpu
  eventLoopDelayP99Ms=24461.2
  eventLoopDelayMaxMs=24461.2
  eventLoopUtilization=0.987
```

## Verification

- [x] `node scripts/run-vitest.mjs src/agents/model-provider-auth.test.ts src/agents/model-catalog-visibility.test.ts src/agents/model-auth.profiles.test.ts src/agents/model-auth.workspace-plugin.test.ts`
  - 8 test files passed, 126 tests passed.
- [x] `node scripts/run-vitest.mjs src/commands/model-picker.test.ts src/auto-reply/reply/commands-models.test.ts src/gateway/server-methods/models.test.ts`
  - 4 test files passed, 83 tests passed.
- [ ] Live Discord `/models` interaction during a prepared-auth miss, to confirm the interaction ack is no longer starved while the provider sweep continues.
