### PR TITLE
fix(commands): show current level in /verbose and /reasoning menus

### DIFF
--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -302,12 +302,20 @@ function formatTelegramCommandArgMenuTitle(params: {
   command: NonNullable<ReturnType<typeof findCommandByNativeName>>;
   menu: NonNullable<ReturnType<typeof resolveCommandArgMenu>>;
   currentThinkingLevel?: string;
+  currentVerboseLevel?: string;
+  currentReasoningLevel?: string;
 }): string {
   const title = formatCommandArgMenuTitle({ command: params.command, menu: params.menu });
-  if (params.command.key !== "think" || !params.currentThinkingLevel) {
-    return title;
+  if (params.command.key === "think" && params.currentThinkingLevel) {
+    return `Current thinking level: ${params.currentThinkingLevel}.\n${title}`;
   }
-  return `Current thinking level: ${params.currentThinkingLevel}.\n${title}`;
+  if (params.command.key === "verbose" && params.currentVerboseLevel) {
+    return `Current verbose level: ${params.currentVerboseLevel}.\n${title}`;
+  }
+  if (params.command.key === "reasoning" && params.currentReasoningLevel) {
+    return `Current reasoning level: ${params.currentReasoningLevel}.\n${title}`;
+  }
+  return title;
 }
 
 function resolveTelegramNativeReplyChannelData(
@@ -1071,6 +1079,19 @@ export const registerTelegramNativeCommands = ({
             })
           : null;
         if (menu && commandDefinition) {
+          const targetSessionKeyForMenu = await resolveTargetSessionKey();
+          const menuStorePath = resolveStorePath(
+            runtimeCfg.session?.store,
+            { agentId: route.agentId },
+          );
+          const menuSessionEntry = (() => {
+            try {
+              const store = loadSessionStore(menuStorePath);
+              return store[targetSessionKeyForMenu];
+            } catch {
+              return undefined;
+            }
+          })();
           const title = formatTelegramCommandArgMenuTitle({
             command: commandDefinition,
             menu,
@@ -1081,6 +1102,14 @@ export const registerTelegramNativeCommands = ({
                     agentId: route.agentId,
                     ...menuModelContext,
                   })
+                : undefined,
+            currentVerboseLevel:
+              commandDefinition.key === "verbose"
+                ? (menuSessionEntry?.verboseLevel as string | undefined) ?? "off"
+                : undefined,
+            currentReasoningLevel:
+              commandDefinition.key === "reasoning"
+                ? (menuSessionEntry?.reasoningLevel as string | undefined) ?? "off"
                 : undefined,
           });
           const rows: Array<Array<{ text: string; callback_data: string }>> = [];

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -1092,6 +1092,14 @@ export const registerTelegramNativeCommands = ({
               return undefined;
             }
           })();
+          const menuAgentCfg = resolveAgentConfig(runtimeCfg, route.agentId);
+          const currentVerboseLevel =
+            (menuSessionEntry?.verboseLevel as string | undefined) ??
+            (menuAgentCfg?.verboseDefault as string | undefined);
+          const currentReasoningLevel =
+            (menuSessionEntry?.reasoningLevel as string | undefined) ??
+            (menuAgentCfg?.reasoningDefault as string | undefined) ??
+            "off";
           const title = formatTelegramCommandArgMenuTitle({
             command: commandDefinition,
             menu,
@@ -1105,11 +1113,11 @@ export const registerTelegramNativeCommands = ({
                 : undefined,
             currentVerboseLevel:
               commandDefinition.key === "verbose"
-                ? (menuSessionEntry?.verboseLevel as string | undefined) ?? "off"
+                ? currentVerboseLevel
                 : undefined,
             currentReasoningLevel:
               commandDefinition.key === "reasoning"
-                ? (menuSessionEntry?.reasoningLevel as string | undefined) ?? "off"
+                ? currentReasoningLevel
                 : undefined,
           });
           const rows: Array<Array<{ text: string; callback_data: string }>> = [];

--- a/src/auto-reply/commands-registry.shared.ts
+++ b/src/auto-reply/commands-registry.shared.ts
@@ -775,6 +775,7 @@ export function buildBuiltinChatCommands(
           choices: ["on", "off", "full"],
         },
       ],
+      argsMenu: "auto",
     }),
     defineChatCommand({
       key: "trace",

--- a/src/auto-reply/commands-registry.test.ts
+++ b/src/auto-reply/commands-registry.test.ts
@@ -628,14 +628,15 @@ describe("commands registry args", () => {
     ]);
   });
 
-  it("keeps verbose full available while preserving no-arg status dispatch", () => {
+  it("shows verbose menu with choices when no-arg", () => {
     const verbose = requireChatCommand("verbose");
 
     const modeArg = requireCommandArgAt(verbose, 0);
     expect(modeArg.choices).toEqual(["on", "off", "full"]);
-    expect(
-      resolveCommandArgMenu({ command: verbose, args: undefined, cfg: {} as never }),
-    ).toBeNull();
+    const menu = resolveCommandArgMenu({ command: verbose, args: undefined, cfg: {} as never });
+    expect(menu).not.toBeNull();
+    expect(menu!.arg.name).toBe("mode");
+    expect(menu!.choices.map((c) => c.value)).toEqual(["on", "off", "full"]);
   });
 
   it("does not show menus when arg already provided", () => {


### PR DESCRIPTION
## Summary

The v1 fix (#85150, closed) added `argsMenu: "auto"` to `/verbose` but bypassed the current status display. This proper fix:

1. Adds `argsMenu: "auto"` to `/verbose` (matching `/think`, `/trace`, `/fast`)
2. Extends `formatTelegramCommandArgMenuTitle` to show current verbose and reasoning levels in the menu title
3. Loads session entry to resolve current levels from session store

## Before

```
Current verbose level: off
Options: on, off, full
```

User must type the option manually.

## After

```
Current verbose level: off.
Choose verbose level: [on] [off] [full]
```

Inline buttons rendered, current level preserved.

## Changes

- `src/auto-reply/commands-registry.shared.ts`: Added `argsMenu: "auto"` to /verbose
- `extensions/telegram/src/bot-native-commands.ts`: Extended menu title to show current verbose/reasoning levels

## Testing

- Verified /think already shows current level with argsMenu
- The pattern is identical to how /think handles currentThinkingLevel

Fixes #85088