### PR TITLE
fix(sandbox): reduce base64 env warning false positives

### DIFF
--- a/src/agents/sandbox/sanitize-env-vars.test.ts
+++ b/src/agents/sandbox/sanitize-env-vars.test.ts
@@ -28,7 +28,7 @@ describe("sanitizeEnvVars", () => {
     expect(result.blocked).toStrictEqual(["MY_TOKEN", "MY_SECRET"]);
   });
 
-  it("adds warnings for suspicious values", () => {
+  it("does not warn for long base64-like values on non-sensitive env names", () => {
     const base64Like =
       "YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYQ==";
     const result = sanitizeEnvVars({
@@ -39,7 +39,25 @@ describe("sanitizeEnvVars", () => {
 
     expect(result.allowed).toEqual({ USER: "alice", SAFE_TEXT: base64Like });
     expect(result.blocked).toContain("NULL");
-    expect(result.warnings).toContain("SAFE_TEXT: Value looks like base64-encoded credential data");
+    expect(result.warnings).toStrictEqual([]);
+  });
+
+  it("adds warnings for structurally base64 credential-looking values on sensitive env names", () => {
+    const base64Like =
+      "YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYQ==";
+    const result = sanitizeExplicitSandboxEnvVars({
+      CONFIG_TOKEN: base64Like,
+      BUILD_ID: "0123456789abcdef".repeat(8),
+    });
+
+    expect(result.allowed).toEqual({
+      CONFIG_TOKEN: base64Like,
+      BUILD_ID: "0123456789abcdef".repeat(8),
+    });
+    expect(result.blocked).toStrictEqual([]);
+    expect(result.warnings).toContain(
+      "CONFIG_TOKEN: Value looks like base64-encoded credential data",
+    );
   });
 
   it("supports strict mode with explicit allowlist", () => {

--- a/src/agents/sandbox/sanitize-env-vars.test.ts
+++ b/src/agents/sandbox/sanitize-env-vars.test.ts
@@ -47,16 +47,21 @@ describe("sanitizeEnvVars", () => {
       "YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYQ==";
     const result = sanitizeExplicitSandboxEnvVars({
       CONFIG_TOKEN: base64Like,
+      AWS_SECRET_ACCESS_KEY: base64Like,
       BUILD_ID: "0123456789abcdef".repeat(8),
     });
 
     expect(result.allowed).toEqual({
       CONFIG_TOKEN: base64Like,
+      AWS_SECRET_ACCESS_KEY: base64Like,
       BUILD_ID: "0123456789abcdef".repeat(8),
     });
     expect(result.blocked).toStrictEqual([]);
     expect(result.warnings).toContain(
       "CONFIG_TOKEN: Value looks like base64-encoded credential data",
+    );
+    expect(result.warnings).toContain(
+      "AWS_SECRET_ACCESS_KEY: Value looks like base64-encoded credential data",
     );
   });
 

--- a/src/agents/sandbox/sanitize-env-vars.ts
+++ b/src/agents/sandbox/sanitize-env-vars.ts
@@ -42,8 +42,6 @@ export type EnvSanitizationOptions = {
   customAllowedPatterns?: ReadonlyArray<RegExp>;
 };
 
-const SENSITIVE_ENV_VAR_NAME_PATTERN = /_?(API_KEY|TOKEN|PASSWORD|PRIVATE_KEY|SECRET)$/i;
-
 function looksLikeStructuredBase64(value: string): boolean {
   if (value.length < 128 || value.length % 4 !== 0) {
     return false;
@@ -54,6 +52,10 @@ function looksLikeStructuredBase64(value: string): boolean {
   return !value.slice(0, -2).includes("=");
 }
 
+function isSensitiveEnvVarName(key: string): boolean {
+  return matchesAnyPattern(key, BLOCKED_ENV_VAR_PATTERNS);
+}
+
 export function validateEnvVarValue(value: string, key?: string): string | undefined {
   if (value.includes("\0")) {
     return "Contains null bytes";
@@ -61,7 +63,7 @@ export function validateEnvVarValue(value: string, key?: string): string | undef
   if (value.length > 32768) {
     return "Value exceeds maximum length";
   }
-  if (key && SENSITIVE_ENV_VAR_NAME_PATTERN.test(key) && looksLikeStructuredBase64(value)) {
+  if (key && isSensitiveEnvVarName(key) && looksLikeStructuredBase64(value)) {
     return "Value looks like base64-encoded credential data";
   }
   return undefined;

--- a/src/agents/sandbox/sanitize-env-vars.ts
+++ b/src/agents/sandbox/sanitize-env-vars.ts
@@ -42,14 +42,26 @@ export type EnvSanitizationOptions = {
   customAllowedPatterns?: ReadonlyArray<RegExp>;
 };
 
-export function validateEnvVarValue(value: string): string | undefined {
+const SENSITIVE_ENV_VAR_NAME_PATTERN = /_?(API_KEY|TOKEN|PASSWORD|PRIVATE_KEY|SECRET)$/i;
+
+function looksLikeStructuredBase64(value: string): boolean {
+  if (value.length < 128 || value.length % 4 !== 0) {
+    return false;
+  }
+  if (!/^[A-Za-z0-9+/]+={0,2}$/.test(value)) {
+    return false;
+  }
+  return !value.slice(0, -2).includes("=");
+}
+
+export function validateEnvVarValue(value: string, key?: string): string | undefined {
   if (value.includes("\0")) {
     return "Contains null bytes";
   }
   if (value.length > 32768) {
     return "Value exceeds maximum length";
   }
-  if (/^[A-Za-z0-9+/=]{80,}$/.test(value)) {
+  if (key && SENSITIVE_ENV_VAR_NAME_PATTERN.test(key) && looksLikeStructuredBase64(value)) {
     return "Value looks like base64-encoded credential data";
   }
   return undefined;
@@ -86,7 +98,7 @@ export function sanitizeEnvVars(
       continue;
     }
 
-    const warning = validateEnvVarValue(value);
+    const warning = validateEnvVarValue(value, key);
     if (warning) {
       if (warning === "Contains null bytes") {
         blocked.push(key);
@@ -114,7 +126,7 @@ export function sanitizeExplicitSandboxEnvVars(
       continue;
     }
 
-    const warning = validateEnvVarValue(value);
+    const warning = validateEnvVarValue(value, key);
     if (warning) {
       if (warning === "Contains null bytes") {
         blocked.push(key);

--- a/src/agents/skills/env-overrides.ts
+++ b/src/agents/skills/env-overrides.ts
@@ -125,7 +125,7 @@ function sanitizeSkillEnvOverrides(params: {
     if (!value) {
       continue;
     }
-    const warning = validateEnvVarValue(value);
+    const warning = validateEnvVarValue(value, key);
     if (warning) {
       if (warning === "Contains null bytes") {
         blocked.add(key);


### PR DESCRIPTION
## Summary

- Tighten sandbox env value warnings so long base64-like values only warn when the env var name also looks credential-related.
- Reuse the sanitizer credential-name contract for that warning gate, so explicit sandbox/skill env paths still warn for names such as `AWS_SECRET_ACCESS_KEY`.
- Require a more plausible base64 shape: 128+ chars, length divisible by 4, valid padding only at the end.
- Keep null-byte blocking and max-length warnings unchanged, including for explicitly configured sandbox env and skill env override paths.

Fixes #39680.

## Verification

- `pnpm exec oxfmt --check --threads=1 src/agents/sandbox/sanitize-env-vars.ts src/agents/sandbox/sanitize-env-vars.test.ts src/agents/skills/env-overrides.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/sandbox/sanitize-env-vars.ts src/agents/sandbox/sanitize-env-vars.test.ts src/agents/skills/env-overrides.ts`
- `pnpm exec vitest run src/agents/sandbox/sanitize-env-vars.test.ts --config test/vitest/vitest.unit-fast.config.ts`
  - 1 test file passed, 8 tests passed

## Real behavior proof

- **Behavior addressed:** Sandbox env sanitization should stop warning for long base64-like values on non-sensitive env names while preserving warnings for credential-looking explicit sandbox/skill env names.
- **Real environment tested:** Local OpenClaw contributor checkout on this PR branch, Node runtime via `node --import tsx --input-type=module`; dummy values only, no real credentials.
- **Exact steps or command run after this patch:** Ran a direct Node runtime probe against the exported sanitizer functions after commit `b1a9d4875f1134205aaa68c203a61346469118ee`. The probe called `sanitizeExplicitSandboxEnvVars` with `SAFE_TEXT`, `AWS_SECRET_ACCESS_KEY`, `CONFIG_TOKEN`, and `NULL_SECRET`, then called `sanitizeEnvVars` with `SAFE_TEXT` and `NULL_VALUE`.
- **Evidence after fix:** Redacted terminal output from the runtime probe; the dummy 132-character base64-like value is summarized by length instead of printing the value.

```console
$ node --import tsx --input-type=module
{
  "structuredBase64Length": 132,
  "sandbox": {
    "allowedKeys": [
      "SAFE_TEXT",
      "AWS_SECRET_ACCESS_KEY",
      "CONFIG_TOKEN"
    ],
    "blocked": [
      "NULL_SECRET"
    ],
    "warnings": [
      "AWS_SECRET_ACCESS_KEY: Value looks like base64-encoded credential data",
      "CONFIG_TOKEN: Value looks like base64-encoded credential data"
    ]
  },
  "processEnv": {
    "allowedKeys": [
      "SAFE_TEXT"
    ],
    "blocked": [
      "NULL_VALUE"
    ],
    "warnings": []
  }
}
```

- **Observed result after fix:** Non-sensitive `SAFE_TEXT` keeps the long base64-like value without a warning; explicit sandbox credential-looking keys `AWS_SECRET_ACCESS_KEY` and `CONFIG_TOKEN` remain allowed but emit the credential-data warning; null-byte values are still blocked.
- **What was not tested:** No additional gaps.
