### PR TITLE
fix: strip -plugin suffix in deriveIdHint to match manifest ids

### DIFF
--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -550,7 +550,9 @@ function deriveIdHint(params: {
   const normalizedPackageId =
     unscoped.endsWith("-provider") && unscoped.length > "-provider".length
       ? unscoped.slice(0, -"-provider".length)
-      : unscoped;
+      : unscoped.endsWith("-plugin") && unscoped.length > "-plugin".length
+        ? unscoped.slice(0, -"-plugin".length)
+        : unscoped;
 
   if (!params.hasMultipleExtensions) {
     return normalizedPackageId;


### PR DESCRIPTION
## Summary

`deriveIdHint` already strips `-provider` from package names before comparing inferred ids to plugin manifest ids, but it did not strip the equivalent `-plugin` suffix. Built-in packages such as `@openclaw/xai-plugin` therefore inferred `xai-plugin` instead of `xai`, producing noisy startup id-mismatch warnings even though the manifest id was correct.

This adds `-plugin` to the existing suffix normalization path. It is the same narrow rule as the existing provider suffix handling, with no registry, loading, or manifest semantics changed.

Closes #85048.

## Verification

- `src/plugins/discovery.ts` only
- Existing `-provider` suffix path reviewed as the matching contract

## Real behavior proof

Behavior addressed: Built-in plugin packages whose npm name ends in `-plugin` infer the wrong discovery id hint and produce false plugin id mismatch warnings.
Real environment tested: Source-level proof against the current OpenClaw plugin discovery implementation.
Exact steps or command run after this patch: Reviewed `deriveIdHint` in `src/plugins/discovery.ts` and verified the existing package-suffix normalization now handles both `-provider` and `-plugin`.
Evidence after fix: `@openclaw/xai-plugin` now normalizes to `xai`; `@openclaw/brave-plugin` now normalizes to `brave`; existing `@openclaw/anthropic-provider` normalization remains `anthropic`.
Observed result after fix: False mismatch warnings for correctly-manifested built-in `*-plugin` packages are removed while provider suffix behavior is unchanged.
What was not tested: Full gateway startup log capture was not rerun for every bundled plugin package.
