### PR TITLE
fix: show empty-state note in Skills wizard when no deps are missing

### DIFF
--- a/src/commands/onboard-skills.ts
+++ b/src/commands/onboard-skills.ts
@@ -116,6 +116,17 @@ export async function setupSkills(
     }
   }
   let next: OpenClawConfig = cfg;
+  if (installable.length === 0 && missing.length === 0) {
+    await prompter.note(
+      [
+        "No missing skill dependencies to install.",
+        `To inspect available skills, run: ${formatCliCommand("openclaw skills list --verbose")}`,
+        `To check skill status, run: ${formatCliCommand("openclaw skills check")}`,
+      ].join("\n"),
+      "All skills ready",
+    );
+    return next;
+  }
   if (installable.length > 0) {
     const toInstall = await prompter.multiselect({
       message: t("wizard.skills.installDeps"),


### PR DESCRIPTION
## Summary

When every skill is already eligible and no dependencies are missing, `openclaw config --section skills` reaches the skills wizard with nothing actionable to install. Before this patch it showed a bare confirmation path that looked like the wizard had stalled.

This adds a small empty-state note for `installable.length === 0 && missing.length === 0`, pointing users to `openclaw skills list --verbose` and `openclaw skills check`, then returns without changing config semantics.

Closes #85015.

## Verification

- `src/commands/onboard-skills.ts` only
- Reuses existing `prompter.note` and `formatCliCommand` patterns in the same command flow

## Real behavior proof

Behavior addressed: The skills config wizard shows no actionable follow-up when all skills are ready and no dependencies are missing.
Real environment tested: Source-level proof against the current skills onboarding command flow.
Exact steps or command run after this patch: Reviewed the all-ready branch in `src/commands/onboard-skills.ts`; the new branch runs before installable-skill prompting and emits the empty-state note.
Evidence after fix: The all-ready state now emits `No missing skill dependencies to install.` plus `openclaw skills list --verbose` and `openclaw skills check` hints.
Observed result after fix: Users get an explicit terminal note instead of a dead-end configuration prompt.
What was not tested: Interactive terminal recording of `openclaw config --section skills` on a machine with every skill dependency already satisfied.
