### PR TITLE
fix(matrix): respect is_direct: false in isStrictDirectRoom

### DIFF
--- a/extensions/matrix/src/matrix/direct-room.ts
+++ b/extensions/matrix/src/matrix/direct-room.ts
@@ -117,12 +117,13 @@ export async function isStrictDirectRoom(params: {
   remoteUserId: string;
   selfUserId?: string | null;
 }): Promise<boolean> {
-  return (
-    await inspectMatrixDirectRoomEvidence({
-      client: params.client,
-      roomId: params.roomId,
-      remoteUserId: params.remoteUserId,
-      selfUserId: params.selfUserId,
-    })
-  ).strict;
+  const evidence = await inspectMatrixDirectRoomEvidence({
+    client: params.client,
+    roomId: params.roomId,
+    remoteUserId: params.remoteUserId,
+    selfUserId: params.selfUserId,
+  });
+  if (!evidence.strict) return false;
+  if (evidence.memberStateFlag === false) return false;
+  return true;
 }


### PR DESCRIPTION
## Summary

`isStrictDirectRoom` in `extensions/matrix/src/matrix/direct-room.ts` returned `evidence.strict` directly without checking `memberStateFlag`. When a 2-person Matrix room has `is_direct: false` on the membership event, the function still classified it as a strict DM, causing `requireMention` to be silently bypassed for rooms configured under `groups[]`.

This fix checks `evidence.memberStateFlag === false` before returning `true`, ensuring the explicit `is_direct: false` signal overrides the 2-member heuristic.

Note: There is a related gap in `monitor/direct.ts` where the `m.direct` cache hit path (line 232-238) also bypasses the `is_direct: false` check. This PR addresses only the `isStrictDirectRoom` function used by `verification-events.ts` and `targets.ts`. A follow-up PR should address the `isDirectMessage` gap.

Closes #85017

## Verification

- Single file change: `extensions/matrix/src/matrix/direct-room.ts`
- `inspectMatrixDirectRoomEvidence` already reads `hasDirectMatrixMemberFlag` and stores it in `memberStateFlag` — this fix simply uses the value that was already being fetched
- The `isDirectMessage` path in `monitor/direct.ts` already handles `is_direct: false` at line 252-254 — this brings `isStrictDirectRoom` to parity

## Real behavior proof

- Behavior addressed: 2-person Matrix rooms with `is_direct: false` and `requireMention: true` in groups[] still get classified as DMs, bypassing mention requirements
- Real environment tested: Source-level verification against current main (9f2c0a8)
- Exact steps: Create 2-person Matrix room with `is_direct: false`, add to `groups[]` with `requireMention: true` → after fix, `isStrictDirectRoom` returns `false` when `memberStateFlag === false`
- Evidence after fix: `requireMention` config is respected for 2-person rooms that explicitly set `is_direct: false`
- What was not tested: Live Matrix gateway with patch applied