### PR TITLE
fix(gateway): broadcast idle timeout errors to clients after agent run started

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -2880,11 +2880,26 @@ export const chatHandlers: GatewayRequestHandlers = {
                   });
                 }
               } else if (!hasBeforeAgentRunGate) {
-                await emitUserTranscriptUpdate().catch((transcriptErr) => {
-                  context.logGateway.warn(
-                    `webchat user transcript update failed after agent run: ${formatForLog(transcriptErr)}`,
-                  );
-                });
+                const errorPayloads = deliveredReplies
+                  .filter((entry) => entry.payload.isError);
+                if (errorPayloads.length > 0) {
+                  const errorMsg = errorPayloads
+                    .map((entry) => entry.payload.text)
+                    .filter(Boolean)
+                    .join(" | ");
+                  broadcastChatError({
+                    context,
+                    runId: clientRunId,
+                    sessionKey,
+                    errorMessage: errorMsg,
+                  });
+                } else {
+                  await emitUserTranscriptUpdate().catch((transcriptErr) => {
+                    context.logGateway.warn(
+                      `webchat user transcript update failed after agent run: ${formatForLog(transcriptErr)}`,
+                    );
+                  });
+                }
               }
               if (!context.chatAbortedRuns.has(clientRunId)) {
                 setGatewayDedupeEntry({


### PR DESCRIPTION
## Summary

When an LLM idle timeout occurs after the agent has started (e.g., after tool calls), the error is returned as a normal `{ text, isError: true }` payload via the `deliver` callback — it is NOT thrown. The `.then()` handler at line 2882 only called `emitUserTranscriptUpdate()` in the `agentRunStarted=true` branch, never checking `deliveredReplies` for error payloads and never calling `broadcastChatError`. Connected clients received no error feedback — the response silently stopped.

This fix checks `deliveredReplies` for payloads with `isError: true` when `agentRunStarted=true` and `!hasBeforeAgentRunGate`. If error payloads are found, `broadcastChatError` is called to notify clients. If not, the existing `emitUserTranscriptUpdate()` path is preserved.

Closes #84945

## Verification

- Single file change: `src/gateway/server-methods/chat.ts` (20 lines added, 5 removed)
- `broadcastChatError` is already used in the `.catch()` handler at line 2938 with the same signature
- `deliveredReplies` is already filtered for `isError` in the `!agentRunStarted` branch (btwReplies)
- Normal agent completions (no error payloads) continue through `emitUserTranscriptUpdate()` as before

## Real behavior proof

- Behavior addressed: LLM idle timeout after agent start silently drops — clients receive no error event
- Real environment tested: Source-level verification against current main
- Exact steps: Start agent session, agent makes tool calls, subsequent LLM call times out (120s idle) → after fix, client receives `state: "error"` chat event with the timeout message
- Evidence after fix: `broadcastChatError` fires for timeout errors in the agent-started path
- What was not tested: Live gateway with idle timeout triggered