### PR TITLE
Preserve authored config intent during update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Docs: https://docs.openclaw.ai
 - Diffs: render viewer toolbar icons from a closed icon-name map instead of HTML strings, removing the toolbar icon XSS sink. (#83955) Thanks @tanshanshan.
 - QA: keep `pnpm qa:e2e` self-check runs inside the private QA runtime envelope even when inherited shell env disables bundled plugins.
 - fix(config): validate browser sandbox bind sources [AI]. (#84799) Thanks @pgondhi987.
+- CLI/update: preserve authored agent model and plugin entry config across updates so customized Codex routing, fallbacks, and plugin settings are not replaced by dist defaults. Fixes #85080. (#85183) Thanks @joshavant.
 - doctor: constrain legacy plugin cleanup paths [AI]. (#84801) Thanks @pgondhi987.
 - Update/doctor: prune stale local bundled plugin install records that point at old compiled bundled output so current bundled plugin schemas win after upgrade. (#84863) Thanks @fuller-stack-dev.
 - Providers/Ollama: preserve native Ollama tool-call IDs across assistant replay so Gemini over Ollama Cloud can keep its hidden function-call thought-signature handle.

--- a/src/cli/plugins-install-record-commit.ts
+++ b/src/cli/plugins-install-record-commit.ts
@@ -90,8 +90,8 @@ export async function commitPluginInstallRecordsWithConfig(params: {
   nextConfig: OpenClawConfig;
   baseHash?: string;
   writeOptions?: ConfigWriteOptions;
-}): Promise<ConfigReplaceResult> {
-  const result = await commitPluginInstallRecordsWithWriter({
+}): Promise<ConfigReplaceResult | void> {
+  return await commitPluginInstallRecordsWithWriter({
     ...params,
     commit: async (nextConfig, writeOptions) => {
       return await replaceConfigFile({
@@ -101,10 +101,6 @@ export async function commitPluginInstallRecordsWithConfig(params: {
       });
     },
   });
-  if (!result) {
-    throw new Error("Plugin install record config commit did not return write metadata.");
-  }
-  return result;
 }
 
 export async function commitConfigWriteWithPendingPluginInstalls(params: {

--- a/src/cli/plugins-install-record-commit.ts
+++ b/src/cli/plugins-install-record-commit.ts
@@ -90,8 +90,8 @@ export async function commitPluginInstallRecordsWithConfig(params: {
   nextConfig: OpenClawConfig;
   baseHash?: string;
   writeOptions?: ConfigWriteOptions;
-}): Promise<void> {
-  await commitPluginInstallRecordsWithWriter({
+}): Promise<ConfigReplaceResult> {
+  const result = await commitPluginInstallRecordsWithWriter({
     ...params,
     commit: async (nextConfig, writeOptions) => {
       return await replaceConfigFile({
@@ -101,6 +101,10 @@ export async function commitPluginInstallRecordsWithConfig(params: {
       });
     },
   });
+  if (!result) {
+    throw new Error("Plugin install record config commit did not return write metadata.");
+  }
+  return result;
 }
 
 export async function commitConfigWriteWithPendingPluginInstalls(params: {

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -4379,7 +4379,7 @@ describe("update-cli", () => {
       },
     );
 
-    const syncConfig = syncPluginCall()?.config as OpenClawConfig | undefined;
+    const syncConfig = syncPluginCall()?.config;
     const persistedConfig = lastReplaceConfigCall()?.nextConfig as OpenClawConfig | undefined;
     for (const config of [syncConfig, persistedConfig]) {
       expect(config?.agents?.defaults?.model).toEqual({
@@ -5041,7 +5041,7 @@ describe("update-cli", () => {
       },
     );
 
-    const syncConfig = syncPluginCall()?.config as OpenClawConfig | undefined;
+    const syncConfig = syncPluginCall()?.config;
     const persistedConfig = lastReplaceConfigCall()?.nextConfig as OpenClawConfig | undefined;
     expect(syncConfig?.plugins?.entries?.["lossless-claw"]?.config).toEqual({
       summaryModel: "openai/gpt-5.4-mini",
@@ -5174,7 +5174,7 @@ describe("update-cli", () => {
       },
     );
 
-    const syncConfig = syncPluginCall()?.config as OpenClawConfig | undefined;
+    const syncConfig = syncPluginCall()?.config;
     const persistedConfig = lastReplaceConfigCall()?.nextConfig as OpenClawConfig | undefined;
     expect(syncConfig?.agents?.defaults?.model).toEqual({
       primary: "openai/gpt-5.5",

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -40,7 +40,7 @@ const probeGateway = vi.fn();
 const pathExists = vi.fn();
 const syncPluginsForUpdateChannel = vi.fn();
 const updateNpmInstalledPlugins = vi.fn();
-const refreshPluginRegistryAfterConfigMutation = vi.fn(async () => undefined);
+const refreshPluginRegistryAfterConfigMutation = vi.fn(async (_params?: unknown) => undefined);
 const loadInstalledPluginIndexInstallRecords = vi.fn(
   async (params: { config?: OpenClawConfig } = {}) => params.config?.plugins?.installs ?? {},
 );
@@ -222,8 +222,8 @@ vi.mock("../plugins/installed-plugin-index-records.js", async (importOriginal) =
 });
 
 vi.mock("./plugins-registry-refresh.js", () => ({
-  refreshPluginRegistryAfterConfigMutation: (...args: unknown[]) =>
-    refreshPluginRegistryAfterConfigMutation(...args),
+  refreshPluginRegistryAfterConfigMutation: (params: unknown) =>
+    refreshPluginRegistryAfterConfigMutation(params),
 }));
 
 vi.mock("../daemon/service.js", () => ({
@@ -4248,7 +4248,7 @@ describe("update-cli", () => {
           },
         },
       },
-    } as OpenClawConfig;
+    } as unknown as OpenClawConfig;
     const preUpdateSourceConfig = {
       ...preUpdateAuthoredConfig,
       agents: {
@@ -4287,7 +4287,7 @@ describe("update-cli", () => {
           },
         },
       },
-    } as OpenClawConfig;
+    } as unknown as OpenClawConfig;
     const postDoctorConfig = {
       update: { channel: "stable" },
       agents: {
@@ -5215,7 +5215,7 @@ describe("update-cli", () => {
         },
         list: [{ $include: "./cron-agent.json5" }],
       },
-    } as OpenClawConfig;
+    } as unknown as OpenClawConfig;
     const preUpdateSourceConfig = {
       update: { channel: "stable" },
       agents: {

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -40,6 +40,7 @@ const probeGateway = vi.fn();
 const pathExists = vi.fn();
 const syncPluginsForUpdateChannel = vi.fn();
 const updateNpmInstalledPlugins = vi.fn();
+const refreshPluginRegistryAfterConfigMutation = vi.fn(async () => undefined);
 const loadInstalledPluginIndexInstallRecords = vi.fn(
   async (params: { config?: OpenClawConfig } = {}) => params.config?.plugins?.installs ?? {},
 );
@@ -219,6 +220,11 @@ vi.mock("../plugins/installed-plugin-index-records.js", async (importOriginal) =
     writePersistedInstalledPluginIndexInstallRecords: vi.fn(async () => undefined),
   };
 });
+
+vi.mock("./plugins-registry-refresh.js", () => ({
+  refreshPluginRegistryAfterConfigMutation: (...args: unknown[]) =>
+    refreshPluginRegistryAfterConfigMutation(...args),
+}));
 
 vi.mock("../daemon/service.js", () => ({
   readGatewayServiceState: async () => {
@@ -438,6 +444,12 @@ describe("update-cli", () => {
     >;
     return calls[index]?.[0];
   };
+  const lastPluginRegistryRefreshCall = () => {
+    const calls = refreshPluginRegistryAfterConfigMutation.mock.calls as unknown as Array<
+      [{ config?: OpenClawConfig }]
+    >;
+    return calls[calls.length - 1]?.[0];
+  };
 
   const npmPluginUpdateCall = (index = 0) => {
     const calls = updateNpmInstalledPlugins.mock.calls as unknown as Array<
@@ -601,6 +613,19 @@ describe("update-cli", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetRuntimeCapture();
+    let replaceConfigHashCounter = 0;
+    vi.mocked(replaceConfigFile).mockImplementation(async (params) => {
+      replaceConfigHashCounter += 1;
+      return {
+        path: baseSnapshot.path,
+        previousHash: params.baseHash ?? null,
+        snapshot: baseSnapshot,
+        nextConfig: params.nextConfig,
+        persistedHash: `replace-config-hash-${replaceConfigHashCounter}`,
+        afterWrite: { mode: "none", reason: "test" },
+        followUp: { mode: "none", reason: "test", requiresRestart: false },
+      };
+    });
     spawn.mockImplementation(() => {
       const child = new EventEmitter() as EventEmitter & {
         once: EventEmitter["once"];
@@ -4172,6 +4197,1337 @@ describe("update-cli", () => {
       | undefined;
     expect(syncConfig?.channels?.whatsapp?.token).toBe("resolved-secret");
     expect(lastWrite?.nextConfig?.channels?.whatsapp?.token).toBe("${WHATSAPP_TOKEN}");
+  });
+
+  it("preserves pre-update agent model routing and plugin entry config across post-core doctor rewrites", async () => {
+    const tempDir = createCaseDir("openclaw-update");
+    const sourceConfigPath = path.join(tempDir, "source-config.json");
+    const preUpdateAuthoredConfig = {
+      update: { channel: "stable" },
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai-codex/gpt-5.5",
+            timeoutMs: 30_000,
+            fallbacks: [
+              "openai-codex/gpt-5.4",
+              "claude-cli/claude-sonnet-4-6",
+              "openai-codex/gpt-5.4-mini",
+            ],
+          },
+          models: {
+            "openai-codex/gpt-5.5": {
+              params: { apiKey: "${CODEX_AGENT_TOKEN}" },
+            },
+          },
+        },
+        list: [
+          {
+            id: "cron",
+            model: {
+              primary: "openai-codex/gpt-5.4",
+              timeoutMs: 30_000,
+            },
+            models: {
+              "openai-codex/gpt-5.4": {
+                params: { apiKey: "${CRON_CODEX_TOKEN}" },
+              },
+            },
+          },
+        ],
+      },
+      plugins: {
+        entries: {
+          "lossless-claw": {
+            enabled: true,
+            config: {
+              summaryModel: "openai-codex/gpt-5.4-mini",
+              apiKey: "${LOSSLESS_TOKEN}",
+              keepLocal: true,
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const preUpdateSourceConfig = {
+      ...preUpdateAuthoredConfig,
+      agents: {
+        defaults: {
+          ...preUpdateAuthoredConfig.agents?.defaults,
+          models: {
+            "openai-codex/gpt-5.5": {
+              params: { apiKey: "resolved-codex-agent-token" },
+            },
+          },
+        },
+        list: [
+          {
+            id: "cron",
+            model: {
+              primary: "openai-codex/gpt-5.4",
+              timeoutMs: 30_000,
+            },
+            models: {
+              "openai-codex/gpt-5.4": {
+                params: { apiKey: "resolved-cron-codex-token" },
+              },
+            },
+          },
+        ],
+      },
+      plugins: {
+        entries: {
+          "lossless-claw": {
+            enabled: true,
+            config: {
+              summaryModel: "openai-codex/gpt-5.4-mini",
+              apiKey: "resolved-lossless-token",
+              keepLocal: true,
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const postDoctorConfig = {
+      update: { channel: "stable" },
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-5.5",
+            fallbacks: ["openai/gpt-5.4"],
+          },
+        },
+        list: [
+          {
+            id: "cron",
+            model: {
+              primary: "openai/gpt-5.5",
+            },
+          },
+        ],
+      },
+      plugins: {
+        entries: {
+          "lossless-claw": {
+            enabled: true,
+            config: {
+              summaryModel: "openai/gpt-5.4-mini",
+              apiKey: "dist-default",
+              distDefault: true,
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    await fs.mkdir(tempDir, { recursive: true });
+    await fs.writeFile(
+      sourceConfigPath,
+      `${JSON.stringify({
+        sourceConfig: preUpdateSourceConfig,
+        authoredConfig: preUpdateAuthoredConfig,
+      })}\n`,
+      "utf-8",
+    );
+    vi.mocked(readConfigFileSnapshot).mockResolvedValue({
+      ...baseSnapshot,
+      sourceConfig: postDoctorConfig,
+      config: postDoctorConfig,
+      runtimeConfig: postDoctorConfig,
+      hash: "post-doctor-hash",
+    });
+    syncPluginsForUpdateChannel.mockImplementation(async ({ config }) => ({
+      changed: true,
+      config: {
+        ...config,
+        plugins: {
+          ...config.plugins,
+          load: { paths: ["/updated/plugin/path"] },
+          entries: {
+            ...config.plugins?.entries,
+            "lossless-claw": {
+              enabled: true,
+              config: {
+                summaryModel: "openai/gpt-5.4-mini",
+                apiKey: "dist-default",
+                distDefault: true,
+              },
+            },
+          },
+        },
+      },
+      summary: {
+        switchedToBundled: [],
+        switchedToNpm: [],
+        warnings: [],
+        errors: [],
+      },
+    }));
+    updateNpmInstalledPlugins.mockImplementation(async ({ config }) => ({
+      changed: false,
+      config,
+      outcomes: [],
+    }));
+
+    await withEnvAsync(
+      {
+        OPENCLAW_UPDATE_POST_CORE: "1",
+        OPENCLAW_UPDATE_POST_CORE_CHANNEL: "stable",
+        OPENCLAW_UPDATE_POST_CORE_SOURCE_CONFIG_PATH: sourceConfigPath,
+      },
+      async () => {
+        await updateCommand({ yes: true, restart: false });
+      },
+    );
+
+    const syncConfig = syncPluginCall()?.config as OpenClawConfig | undefined;
+    const persistedConfig = lastReplaceConfigCall()?.nextConfig as OpenClawConfig | undefined;
+    for (const config of [syncConfig, persistedConfig]) {
+      expect(config?.agents?.defaults?.model).toEqual({
+        primary: "openai/gpt-5.5",
+        fallbacks: ["openai/gpt-5.4", "claude-cli/claude-sonnet-4-6", "openai/gpt-5.4-mini"],
+      });
+      expect(config?.agents?.defaults?.models?.["openai/gpt-5.5"]?.agentRuntime?.id).toBe("codex");
+      expect(config?.agents?.defaults?.models?.["openai/gpt-5.4"]?.agentRuntime?.id).toBe("codex");
+      expect(config?.agents?.defaults?.models?.["openai/gpt-5.4-mini"]?.agentRuntime?.id).toBe(
+        "codex",
+      );
+      expect(config?.agents?.list?.[0]?.model).toEqual({
+        primary: "openai/gpt-5.4",
+      });
+      expect(config?.agents?.list?.[0]?.models?.["openai/gpt-5.4"]?.agentRuntime?.id).toBe("codex");
+    }
+    expect(syncConfig?.plugins?.entries?.["lossless-claw"]?.config).toEqual({
+      summaryModel: "openai-codex/gpt-5.4-mini",
+      apiKey: "resolved-lossless-token",
+      distDefault: true,
+      keepLocal: true,
+    });
+    expect(syncConfig?.agents?.defaults?.models?.["openai/gpt-5.5"]?.params).toEqual({
+      apiKey: "resolved-codex-agent-token",
+    });
+    expect(syncConfig?.agents?.list?.[0]?.models?.["openai/gpt-5.4"]?.params).toEqual({
+      apiKey: "resolved-cron-codex-token",
+    });
+    expect(persistedConfig?.plugins?.entries?.["lossless-claw"]?.config).toEqual({
+      summaryModel: "openai-codex/gpt-5.4-mini",
+      apiKey: "${LOSSLESS_TOKEN}",
+      distDefault: true,
+      keepLocal: true,
+    });
+    expect(persistedConfig?.agents?.defaults?.models?.["openai/gpt-5.5"]?.params).toEqual({
+      apiKey: "${CODEX_AGENT_TOKEN}",
+    });
+    expect(persistedConfig?.agents?.list?.[0]?.models?.["openai/gpt-5.4"]?.params).toEqual({
+      apiKey: "${CRON_CODEX_TOKEN}",
+    });
+  });
+
+  it("keeps authored plugin env refs when only later plugin sync changes the config", async () => {
+    const tempDir = createCaseDir("openclaw-update");
+    const sourceConfigPath = path.join(tempDir, "source-config.json");
+    const preUpdateAuthoredConfig = {
+      update: { channel: "stable" },
+      plugins: {
+        entries: {
+          "lossless-claw": {
+            enabled: true,
+            config: {
+              apiKey: "${LOSSLESS_TOKEN}",
+              keepLocal: true,
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const preUpdateSourceConfig = {
+      update: { channel: "stable" },
+      plugins: {
+        entries: {
+          "lossless-claw": {
+            enabled: true,
+            config: {
+              apiKey: "resolved-lossless-token",
+              keepLocal: true,
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    await fs.mkdir(tempDir, { recursive: true });
+    await fs.writeFile(
+      sourceConfigPath,
+      `${JSON.stringify({
+        sourceConfig: preUpdateSourceConfig,
+        authoredConfig: preUpdateAuthoredConfig,
+      })}\n`,
+      "utf-8",
+    );
+    vi.mocked(readConfigFileSnapshot).mockResolvedValue({
+      ...baseSnapshot,
+      sourceConfig: preUpdateSourceConfig,
+      config: preUpdateSourceConfig,
+      runtimeConfig: preUpdateSourceConfig,
+      hash: "post-doctor-hash",
+    });
+    syncPluginsForUpdateChannel.mockImplementation(async ({ config }) => ({
+      changed: true,
+      config: {
+        ...config,
+        plugins: {
+          ...config.plugins,
+          entries: {
+            ...config.plugins?.entries,
+            "lossless-claw": {
+              enabled: true,
+              config: {
+                apiKey: "resolved-lossless-token",
+                distDefault: true,
+              },
+            },
+          },
+        },
+      },
+      summary: {
+        switchedToBundled: [],
+        switchedToNpm: [],
+        warnings: [],
+        errors: [],
+      },
+    }));
+    updateNpmInstalledPlugins.mockImplementation(async ({ config }) => ({
+      changed: false,
+      config,
+      outcomes: [],
+    }));
+
+    await withEnvAsync(
+      {
+        OPENCLAW_UPDATE_POST_CORE: "1",
+        OPENCLAW_UPDATE_POST_CORE_CHANNEL: "stable",
+        OPENCLAW_UPDATE_POST_CORE_SOURCE_CONFIG_PATH: sourceConfigPath,
+      },
+      async () => {
+        await updateCommand({ yes: true, restart: false });
+      },
+    );
+
+    const persistedConfig = lastReplaceConfigCall()?.nextConfig as OpenClawConfig | undefined;
+    expect(persistedConfig?.plugins?.entries?.["lossless-claw"]?.config).toEqual({
+      apiKey: "${LOSSLESS_TOKEN}",
+      distDefault: true,
+      keepLocal: true,
+    });
+  });
+
+  it("keeps authored plugin env refs from a legacy pre-update file when only plugin sync changes the config", async () => {
+    const tempDir = await createTrackedTempDir("openclaw-update-");
+    const configPath = path.join(tempDir, "openclaw.json");
+    const preUpdatePath = `${configPath}.pre-update`;
+    const preUpdateAuthoredConfig = {
+      update: { channel: "stable" },
+      plugins: {
+        entries: {
+          "lossless-claw": {
+            enabled: true,
+            config: {
+              apiKey: "${LOSSLESS_TOKEN}",
+              keepLocal: true,
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const preUpdateSourceConfig = {
+      update: { channel: "stable" },
+      plugins: {
+        entries: {
+          "lossless-claw": {
+            enabled: true,
+            config: {
+              apiKey: "resolved-lossless-token",
+              keepLocal: true,
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    await fs.writeFile(configPath, `${JSON.stringify(preUpdateSourceConfig)}\n`, "utf-8");
+    await fs.writeFile(
+      preUpdatePath,
+      `${JSON.stringify({
+        sourceConfig: preUpdateSourceConfig,
+        authoredConfig: preUpdateAuthoredConfig,
+      })}\n`,
+      "utf-8",
+    );
+    vi.mocked(readConfigFileSnapshot).mockResolvedValue({
+      ...baseSnapshot,
+      path: configPath,
+      parsed: preUpdateSourceConfig,
+      sourceConfig: preUpdateSourceConfig,
+      config: preUpdateSourceConfig,
+      runtimeConfig: preUpdateSourceConfig,
+      hash: "post-doctor-hash",
+    });
+    syncPluginsForUpdateChannel.mockImplementation(async ({ config }) => ({
+      changed: true,
+      config: {
+        ...config,
+        plugins: {
+          ...config.plugins,
+          entries: {
+            ...config.plugins?.entries,
+            "lossless-claw": {
+              enabled: true,
+              config: {
+                apiKey: "resolved-lossless-token",
+                distDefault: true,
+              },
+            },
+          },
+        },
+      },
+      summary: {
+        switchedToBundled: [],
+        switchedToNpm: [],
+        warnings: [],
+        errors: [],
+      },
+    }));
+    updateNpmInstalledPlugins.mockImplementation(async ({ config }) => ({
+      changed: false,
+      config,
+      outcomes: [],
+    }));
+
+    await withEnvAsync(
+      {
+        OPENCLAW_UPDATE_POST_CORE: "1",
+        OPENCLAW_UPDATE_POST_CORE_CHANNEL: "stable",
+      },
+      async () => {
+        await updateCommand({ yes: true, restart: false });
+      },
+    );
+
+    const persistedConfig = lastReplaceConfigCall()?.nextConfig as OpenClawConfig | undefined;
+    expect(persistedConfig?.plugins?.entries?.["lossless-claw"]?.config).toEqual({
+      apiKey: "${LOSSLESS_TOKEN}",
+      distDefault: true,
+      keepLocal: true,
+    });
+  });
+
+  it("leaves top-level plugin includes to the config writer write-through path", async () => {
+    const tempDir = createCaseDir("openclaw-update");
+    const sourceConfigPath = path.join(tempDir, "source-config.json");
+    const preUpdateAuthoredConfig = {
+      update: { channel: "stable" },
+      plugins: { $include: "./plugins.json5" },
+    } as OpenClawConfig;
+    const preUpdateSourceConfig = {
+      update: { channel: "stable" },
+      plugins: {
+        entries: {
+          "lossless-claw": {
+            enabled: true,
+            config: { keepLocal: true },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const postDoctorConfig = {
+      update: { channel: "stable" },
+      plugins: {
+        entries: {
+          "lossless-claw": {
+            enabled: true,
+            config: { distDefault: true },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    await fs.mkdir(tempDir, { recursive: true });
+    await fs.writeFile(
+      sourceConfigPath,
+      `${JSON.stringify({
+        sourceConfig: preUpdateSourceConfig,
+        authoredConfig: preUpdateAuthoredConfig,
+      })}\n`,
+      "utf-8",
+    );
+    vi.mocked(readConfigFileSnapshot).mockResolvedValue({
+      ...baseSnapshot,
+      sourceConfig: postDoctorConfig,
+      config: postDoctorConfig,
+      runtimeConfig: postDoctorConfig,
+      hash: "post-doctor-hash",
+    });
+    syncPluginsForUpdateChannel.mockImplementation(async ({ config }) => ({
+      changed: true,
+      config: {
+        ...config,
+        plugins: {
+          ...config.plugins,
+          entries: {
+            ...config.plugins?.entries,
+            "lossless-claw": {
+              enabled: true,
+              config: { distDefault: true },
+            },
+          },
+        },
+      },
+      summary: {
+        switchedToBundled: [],
+        switchedToNpm: [],
+        warnings: [],
+        errors: [],
+      },
+    }));
+    updateNpmInstalledPlugins.mockImplementation(async ({ config }) => ({
+      changed: false,
+      config,
+      outcomes: [],
+    }));
+
+    await withEnvAsync(
+      {
+        OPENCLAW_UPDATE_POST_CORE: "1",
+        OPENCLAW_UPDATE_POST_CORE_CHANNEL: "stable",
+        OPENCLAW_UPDATE_POST_CORE_SOURCE_CONFIG_PATH: sourceConfigPath,
+      },
+      async () => {
+        await updateCommand({ yes: true, restart: false });
+      },
+    );
+
+    const persistedConfig = lastReplaceConfigCall()?.nextConfig as OpenClawConfig | undefined;
+    expect(persistedConfig?.plugins).toEqual({
+      entries: {
+        "lossless-claw": {
+          enabled: true,
+          config: { distDefault: true, keepLocal: true },
+        },
+      },
+    });
+  });
+
+  it("splits top-level plugin include writes when other restored sections also changed", async () => {
+    const tempDir = createCaseDir("openclaw-update");
+    const sourceConfigPath = path.join(tempDir, "source-config.json");
+    const preUpdateAuthoredConfig = {
+      update: { channel: "stable" },
+      agents: {
+        defaults: {
+          model: { primary: "openai-codex/gpt-5.5" },
+        },
+      },
+      plugins: { $include: "./plugins.json5" },
+    } as OpenClawConfig;
+    const preUpdateSourceConfig = {
+      update: { channel: "stable" },
+      agents: {
+        defaults: {
+          model: { primary: "openai-codex/gpt-5.5" },
+        },
+      },
+      plugins: {
+        entries: {
+          "lossless-claw": {
+            enabled: true,
+            config: { keepLocal: true },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const postDoctorConfig = {
+      update: { channel: "stable" },
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.4" },
+        },
+      },
+      plugins: {
+        entries: {
+          "lossless-claw": {
+            enabled: true,
+            config: { distDefault: true },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    await fs.mkdir(tempDir, { recursive: true });
+    await fs.writeFile(
+      sourceConfigPath,
+      `${JSON.stringify({
+        sourceConfig: preUpdateSourceConfig,
+        authoredConfig: preUpdateAuthoredConfig,
+      })}\n`,
+      "utf-8",
+    );
+    vi.mocked(readConfigFileSnapshot).mockResolvedValue({
+      ...baseSnapshot,
+      parsed: {
+        update: { channel: "stable" },
+        agents: postDoctorConfig.agents,
+        plugins: { $include: "./plugins.json5" },
+      },
+      sourceConfig: postDoctorConfig,
+      config: postDoctorConfig,
+      runtimeConfig: postDoctorConfig,
+      hash: "post-doctor-hash",
+    });
+    syncPluginsForUpdateChannel.mockImplementation(async ({ config }) => ({
+      changed: true,
+      config: {
+        ...config,
+        plugins: {
+          ...config.plugins,
+          entries: {
+            ...config.plugins?.entries,
+            "lossless-claw": {
+              enabled: true,
+              config: { distDefault: true },
+            },
+          },
+        },
+      },
+      summary: {
+        switchedToBundled: [],
+        switchedToNpm: [],
+        warnings: [],
+        errors: [],
+      },
+    }));
+    updateNpmInstalledPlugins.mockImplementation(async ({ config }) => ({
+      changed: false,
+      config,
+      outcomes: [],
+    }));
+
+    await withEnvAsync(
+      {
+        OPENCLAW_UPDATE_POST_CORE: "1",
+        OPENCLAW_UPDATE_POST_CORE_CHANNEL: "stable",
+        OPENCLAW_UPDATE_POST_CORE_SOURCE_CONFIG_PATH: sourceConfigPath,
+      },
+      async () => {
+        await updateCommand({ yes: true, restart: false });
+      },
+    );
+
+    expect(replaceConfigFile).toHaveBeenCalledTimes(2);
+    const pluginWrite = replaceConfigCall(0)?.nextConfig as OpenClawConfig | undefined;
+    const rootWrite = replaceConfigCall(1)?.nextConfig as OpenClawConfig | undefined;
+    expect(replaceConfigCall(1)?.baseHash).toBe("replace-config-hash-1");
+    expect(pluginWrite?.agents).toEqual(postDoctorConfig.agents);
+    expect(pluginWrite?.plugins?.entries?.["lossless-claw"]?.config).toEqual({
+      distDefault: true,
+      keepLocal: true,
+    });
+    expect(rootWrite?.agents?.defaults?.model).toEqual({ primary: "openai/gpt-5.5" });
+    expect(rootWrite?.agents?.defaults?.models?.["openai/gpt-5.5"]?.agentRuntime?.id).toBe("codex");
+    expect(rootWrite?.plugins?.entries?.["lossless-claw"]?.config).toEqual({
+      distDefault: true,
+      keepLocal: true,
+    });
+  });
+
+  it("uses the pre-restore post-update snapshot for same-process top-level plugin include split writes", async () => {
+    const preUpdateAuthoredConfig = {
+      update: { channel: "stable" },
+      agents: {
+        defaults: {
+          model: { primary: "openai-codex/gpt-5.5" },
+        },
+      },
+      plugins: { $include: "./plugins.json5" },
+    } as OpenClawConfig;
+    const preUpdateSourceConfig = {
+      update: { channel: "stable" },
+      agents: preUpdateAuthoredConfig.agents,
+      plugins: {
+        entries: {
+          "lossless-claw": {
+            enabled: true,
+            config: { keepLocal: true },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const postDoctorConfig = {
+      update: { channel: "stable" },
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.4" },
+        },
+      },
+      plugins: {
+        entries: {
+          "lossless-claw": {
+            enabled: true,
+            config: { distDefault: true },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    vi.mocked(readConfigFileSnapshot)
+      .mockResolvedValueOnce({
+        ...baseSnapshot,
+        parsed: preUpdateAuthoredConfig,
+        sourceConfig: preUpdateSourceConfig,
+        config: preUpdateSourceConfig,
+        runtimeConfig: preUpdateSourceConfig,
+        hash: "pre-update-hash",
+      })
+      .mockResolvedValueOnce({
+        ...baseSnapshot,
+        parsed: {
+          update: { channel: "stable" },
+          agents: postDoctorConfig.agents,
+          plugins: { $include: "./plugins.json5" },
+        },
+        sourceConfig: postDoctorConfig,
+        config: postDoctorConfig,
+        runtimeConfig: postDoctorConfig,
+        hash: "post-doctor-hash",
+      });
+    syncPluginsForUpdateChannel.mockImplementation(async ({ config }) => ({
+      changed: true,
+      config: {
+        ...config,
+        plugins: {
+          ...config.plugins,
+          entries: {
+            ...config.plugins?.entries,
+            "lossless-claw": {
+              enabled: true,
+              config: { distDefault: true },
+            },
+          },
+        },
+      },
+      summary: {
+        switchedToBundled: [],
+        switchedToNpm: [],
+        warnings: [],
+        errors: [],
+      },
+    }));
+    updateNpmInstalledPlugins.mockImplementation(async ({ config }) => ({
+      changed: false,
+      config,
+      outcomes: [],
+    }));
+
+    await updateCommand({ yes: true, restart: false });
+
+    expect(replaceConfigFile).toHaveBeenCalledTimes(2);
+    const pluginWrite = replaceConfigCall(0)?.nextConfig as OpenClawConfig | undefined;
+    const rootWrite = replaceConfigCall(1)?.nextConfig as OpenClawConfig | undefined;
+    expect(replaceConfigCall(1)?.baseHash).toBe("replace-config-hash-1");
+    expect(pluginWrite?.agents).toEqual(postDoctorConfig.agents);
+    expect(pluginWrite?.plugins?.entries?.["lossless-claw"]?.config).toEqual({
+      distDefault: true,
+      keepLocal: true,
+    });
+    expect(rootWrite?.agents?.defaults?.model).toEqual({ primary: "openai/gpt-5.5" });
+    expect(rootWrite?.agents?.defaults?.models?.["openai/gpt-5.5"]?.agentRuntime?.id).toBe("codex");
+    expect(rootWrite?.plugins?.entries?.["lossless-claw"]?.config).toEqual({
+      distDefault: true,
+      keepLocal: true,
+    });
+  });
+
+  it("does not restore plugin entry intent through nested plugin includes", async () => {
+    const tempDir = createCaseDir("openclaw-update");
+    const sourceConfigPath = path.join(tempDir, "source-config.json");
+    const preUpdateAuthoredConfig = {
+      update: { channel: "stable" },
+      plugins: {
+        load: { paths: ["/old/plugin/path"] },
+        entries: { $include: "./plugin-entries.json5" },
+      },
+    } as OpenClawConfig;
+    const preUpdateSourceConfig = {
+      update: { channel: "stable" },
+      plugins: {
+        load: { paths: ["/old/plugin/path"] },
+        entries: {
+          "lossless-claw": {
+            enabled: true,
+            config: {
+              summaryModel: "openai-codex/gpt-5.4-mini",
+              apiKey: "resolved-lossless-token",
+              keepLocal: true,
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const postDoctorConfig = {
+      update: { channel: "stable" },
+      plugins: {
+        entries: {
+          "lossless-claw": {
+            enabled: true,
+            config: {
+              summaryModel: "openai/gpt-5.4-mini",
+              apiKey: "dist-default",
+              distDefault: true,
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    await fs.mkdir(tempDir, { recursive: true });
+    await fs.writeFile(
+      sourceConfigPath,
+      `${JSON.stringify({
+        sourceConfig: preUpdateSourceConfig,
+        authoredConfig: preUpdateAuthoredConfig,
+      })}\n`,
+      "utf-8",
+    );
+    vi.mocked(readConfigFileSnapshot).mockResolvedValue({
+      ...baseSnapshot,
+      sourceConfig: postDoctorConfig,
+      config: postDoctorConfig,
+      runtimeConfig: postDoctorConfig,
+      hash: "post-doctor-hash",
+    });
+    syncPluginsForUpdateChannel.mockImplementation(async ({ config }) => ({
+      changed: true,
+      config: {
+        ...config,
+        plugins: {
+          ...config.plugins,
+          load: { paths: ["/updated/plugin/path"] },
+          entries: {
+            ...config.plugins?.entries,
+            "lossless-claw": {
+              enabled: true,
+              config: {
+                summaryModel: "openai/gpt-5.4-mini",
+                apiKey: "dist-default",
+                distDefault: true,
+              },
+            },
+          },
+        },
+      },
+      summary: {
+        switchedToBundled: [],
+        switchedToNpm: [],
+        warnings: [],
+        errors: [],
+      },
+    }));
+    updateNpmInstalledPlugins.mockImplementation(async ({ config }) => ({
+      changed: false,
+      config,
+      outcomes: [],
+    }));
+
+    await withEnvAsync(
+      {
+        OPENCLAW_UPDATE_POST_CORE: "1",
+        OPENCLAW_UPDATE_POST_CORE_CHANNEL: "stable",
+        OPENCLAW_UPDATE_POST_CORE_SOURCE_CONFIG_PATH: sourceConfigPath,
+      },
+      async () => {
+        await updateCommand({ yes: true, restart: false });
+      },
+    );
+
+    const syncConfig = syncPluginCall()?.config as OpenClawConfig | undefined;
+    const persistedConfig = lastReplaceConfigCall()?.nextConfig as OpenClawConfig | undefined;
+    expect(syncConfig?.plugins?.entries?.["lossless-claw"]?.config).toEqual({
+      summaryModel: "openai/gpt-5.4-mini",
+      apiKey: "dist-default",
+      distDefault: true,
+    });
+    expect(persistedConfig?.plugins).toEqual({
+      load: { paths: ["/updated/plugin/path"] },
+      entries: {
+        "lossless-claw": {
+          enabled: true,
+          config: {
+            summaryModel: "openai/gpt-5.4-mini",
+            apiKey: "dist-default",
+            distDefault: true,
+          },
+        },
+      },
+    });
+    expect(lastPluginRegistryRefreshCall()?.config?.plugins?.entries).toEqual({
+      "lossless-claw": {
+        enabled: true,
+        config: {
+          summaryModel: "openai/gpt-5.4-mini",
+          apiKey: "dist-default",
+          distDefault: true,
+        },
+      },
+    });
+  });
+
+  it("does not restore default agent model intent through nested agent includes", async () => {
+    const tempDir = createCaseDir("openclaw-update");
+    const sourceConfigPath = path.join(tempDir, "source-config.json");
+    const preUpdateAuthoredConfig = {
+      update: { channel: "stable" },
+      agents: {
+        defaults: { $include: "./agent-defaults.json5" },
+        list: [
+          {
+            id: "cron",
+            model: { primary: "openai-codex/gpt-5.4" },
+          },
+        ],
+      },
+    } as OpenClawConfig;
+    const preUpdateSourceConfig = {
+      update: { channel: "stable" },
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai-codex/gpt-5.5",
+            fallbacks: ["openai-codex/gpt-5.4"],
+          },
+        },
+        list: [
+          {
+            id: "cron",
+            model: { primary: "openai-codex/gpt-5.4" },
+          },
+        ],
+      },
+    } as OpenClawConfig;
+    const postDoctorConfig = {
+      update: { channel: "stable" },
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-5.5",
+          },
+        },
+        list: [
+          {
+            id: "cron",
+            model: { primary: "openai/gpt-5.5" },
+          },
+        ],
+      },
+    } as OpenClawConfig;
+    await fs.mkdir(tempDir, { recursive: true });
+    await fs.writeFile(
+      sourceConfigPath,
+      `${JSON.stringify({
+        sourceConfig: preUpdateSourceConfig,
+        authoredConfig: preUpdateAuthoredConfig,
+      })}\n`,
+      "utf-8",
+    );
+    vi.mocked(readConfigFileSnapshot).mockResolvedValue({
+      ...baseSnapshot,
+      sourceConfig: postDoctorConfig,
+      config: postDoctorConfig,
+      runtimeConfig: postDoctorConfig,
+      hash: "post-doctor-hash",
+    });
+    syncPluginsForUpdateChannel.mockImplementation(async ({ config }) => ({
+      changed: true,
+      config: {
+        ...config,
+        plugins: {
+          entries: {
+            "lossless-claw": {
+              enabled: true,
+              config: { distDefault: true },
+            },
+          },
+        },
+      },
+      summary: {
+        switchedToBundled: [],
+        switchedToNpm: [],
+        warnings: [],
+        errors: [],
+      },
+    }));
+    updateNpmInstalledPlugins.mockImplementation(async ({ config }) => ({
+      changed: false,
+      config,
+      outcomes: [],
+    }));
+
+    await withEnvAsync(
+      {
+        OPENCLAW_UPDATE_POST_CORE: "1",
+        OPENCLAW_UPDATE_POST_CORE_CHANNEL: "stable",
+        OPENCLAW_UPDATE_POST_CORE_SOURCE_CONFIG_PATH: sourceConfigPath,
+      },
+      async () => {
+        await updateCommand({ yes: true, restart: false });
+      },
+    );
+
+    const syncConfig = syncPluginCall()?.config as OpenClawConfig | undefined;
+    const persistedConfig = lastReplaceConfigCall()?.nextConfig as OpenClawConfig | undefined;
+    expect(syncConfig?.agents?.defaults?.model).toEqual({
+      primary: "openai/gpt-5.5",
+    });
+    expect(persistedConfig?.agents).toEqual({
+      defaults: {
+        model: {
+          primary: "openai/gpt-5.5",
+        },
+      },
+      list: [
+        {
+          id: "cron",
+          model: {
+            primary: "openai/gpt-5.4",
+          },
+          models: {
+            "openai/gpt-5.4": {
+              agentRuntime: { id: "codex" },
+            },
+          },
+        },
+      ],
+    });
+    expect(persistedConfig?.plugins?.entries?.["lossless-claw"]?.config).toEqual({
+      distDefault: true,
+    });
+  });
+
+  it("does not restore agent list model intent through array entry includes", async () => {
+    const tempDir = createCaseDir("openclaw-update");
+    const sourceConfigPath = path.join(tempDir, "source-config.json");
+    const preUpdateAuthoredConfig = {
+      update: { channel: "stable" },
+      agents: {
+        defaults: {
+          model: { primary: "openai-codex/gpt-5.5" },
+        },
+        list: [{ $include: "./cron-agent.json5" }],
+      },
+    } as OpenClawConfig;
+    const preUpdateSourceConfig = {
+      update: { channel: "stable" },
+      agents: {
+        defaults: {
+          model: { primary: "openai-codex/gpt-5.5" },
+        },
+        list: [
+          {
+            id: "cron",
+            model: { primary: "openai-codex/gpt-5.4" },
+          },
+        ],
+      },
+    } as OpenClawConfig;
+    const postDoctorConfig = {
+      update: { channel: "stable" },
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.4" },
+        },
+        list: [
+          {
+            id: "cron",
+            model: { primary: "openai/gpt-5.5" },
+          },
+        ],
+      },
+    } as OpenClawConfig;
+    await fs.mkdir(tempDir, { recursive: true });
+    await fs.writeFile(
+      sourceConfigPath,
+      `${JSON.stringify({
+        sourceConfig: preUpdateSourceConfig,
+        authoredConfig: preUpdateAuthoredConfig,
+      })}\n`,
+      "utf-8",
+    );
+    vi.mocked(readConfigFileSnapshot).mockResolvedValue({
+      ...baseSnapshot,
+      sourceConfig: postDoctorConfig,
+      config: postDoctorConfig,
+      runtimeConfig: postDoctorConfig,
+      hash: "post-doctor-hash",
+    });
+    syncPluginsForUpdateChannel.mockImplementation(async ({ config }) => ({
+      changed: true,
+      config: {
+        ...config,
+        plugins: {
+          entries: {
+            "lossless-claw": {
+              enabled: true,
+              config: { distDefault: true },
+            },
+          },
+        },
+      },
+      summary: {
+        switchedToBundled: [],
+        switchedToNpm: [],
+        warnings: [],
+        errors: [],
+      },
+    }));
+    updateNpmInstalledPlugins.mockImplementation(async ({ config }) => ({
+      changed: false,
+      config,
+      outcomes: [],
+    }));
+
+    await withEnvAsync(
+      {
+        OPENCLAW_UPDATE_POST_CORE: "1",
+        OPENCLAW_UPDATE_POST_CORE_CHANNEL: "stable",
+        OPENCLAW_UPDATE_POST_CORE_SOURCE_CONFIG_PATH: sourceConfigPath,
+      },
+      async () => {
+        await updateCommand({ yes: true, restart: false });
+      },
+    );
+
+    const persistedConfig = lastReplaceConfigCall()?.nextConfig as OpenClawConfig | undefined;
+    expect(persistedConfig?.agents?.defaults?.model).toEqual({ primary: "openai/gpt-5.5" });
+    expect(persistedConfig?.agents?.defaults?.models?.["openai/gpt-5.5"]?.agentRuntime?.id).toBe(
+      "codex",
+    );
+    expect(persistedConfig?.agents?.list).toEqual([
+      {
+        id: "cron",
+        model: { primary: "openai/gpt-5.5" },
+      },
+    ]);
+  });
+
+  it("does not restore agent model intent through a top-level agent include", async () => {
+    const tempDir = createCaseDir("openclaw-update");
+    const sourceConfigPath = path.join(tempDir, "source-config.json");
+    const preUpdateAuthoredConfig = {
+      update: { channel: "stable" },
+      agents: { $include: "./agents.json5" },
+      plugins: {
+        entries: {
+          "lossless-claw": {
+            enabled: true,
+            config: { keepLocal: true },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const preUpdateSourceConfig = {
+      update: { channel: "stable" },
+      agents: {
+        defaults: {
+          model: { primary: "openai-codex/gpt-5.5" },
+        },
+      },
+      plugins: {
+        entries: {
+          "lossless-claw": {
+            enabled: true,
+            config: { keepLocal: true },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const postDoctorConfig = {
+      update: { channel: "stable" },
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.4" },
+        },
+      },
+      plugins: {
+        entries: {
+          "lossless-claw": {
+            enabled: true,
+            config: { distDefault: true },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    await fs.mkdir(tempDir, { recursive: true });
+    await fs.writeFile(
+      sourceConfigPath,
+      `${JSON.stringify({
+        sourceConfig: preUpdateSourceConfig,
+        authoredConfig: preUpdateAuthoredConfig,
+      })}\n`,
+      "utf-8",
+    );
+    vi.mocked(readConfigFileSnapshot).mockResolvedValue({
+      ...baseSnapshot,
+      parsed: {
+        update: { channel: "stable" },
+        agents: { $include: "./agents.json5" },
+        plugins: postDoctorConfig.plugins,
+      },
+      sourceConfig: postDoctorConfig,
+      config: postDoctorConfig,
+      runtimeConfig: postDoctorConfig,
+      hash: "post-doctor-hash",
+    });
+    syncPluginsForUpdateChannel.mockImplementation(async ({ config }) => ({
+      changed: true,
+      config: {
+        ...config,
+        plugins: {
+          ...config.plugins,
+          entries: {
+            ...config.plugins?.entries,
+            "lossless-claw": {
+              enabled: true,
+              config: { distDefault: true },
+            },
+          },
+        },
+      },
+      summary: {
+        switchedToBundled: [],
+        switchedToNpm: [],
+        warnings: [],
+        errors: [],
+      },
+    }));
+    updateNpmInstalledPlugins.mockImplementation(async ({ config }) => ({
+      changed: false,
+      config,
+      outcomes: [],
+    }));
+
+    await withEnvAsync(
+      {
+        OPENCLAW_UPDATE_POST_CORE: "1",
+        OPENCLAW_UPDATE_POST_CORE_CHANNEL: "stable",
+        OPENCLAW_UPDATE_POST_CORE_SOURCE_CONFIG_PATH: sourceConfigPath,
+      },
+      async () => {
+        await updateCommand({ yes: true, restart: false });
+      },
+    );
+
+    const persistedConfig = lastReplaceConfigCall()?.nextConfig as OpenClawConfig | undefined;
+    expect(persistedConfig?.agents).toEqual(postDoctorConfig.agents);
+    expect(persistedConfig?.plugins?.entries?.["lossless-claw"]?.config).toEqual({
+      distDefault: true,
+      keepLocal: true,
+    });
+  });
+
+  it("does not replay stale authored plugin config after post-core plugin failure disables it", async () => {
+    const tempDir = createCaseDir("openclaw-update");
+    const sourceConfigPath = path.join(tempDir, "source-config.json");
+    const preUpdateConfig = {
+      update: { channel: "stable" },
+      plugins: {
+        entries: {
+          "lossless-claw": {
+            enabled: true,
+            config: {
+              summaryModel: "openai-codex/gpt-5.4-mini",
+              keepLocal: true,
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const postDoctorConfig = {
+      update: { channel: "stable" },
+      plugins: {
+        entries: {
+          "lossless-claw": {
+            enabled: true,
+            config: {
+              summaryModel: "openai/gpt-5.4-mini",
+              distDefault: true,
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const disabledAfterFailureConfig = {
+      update: { channel: "stable" },
+      plugins: {
+        entries: {
+          "lossless-claw": {
+            enabled: false,
+            config: {
+              summaryModel: "openai/gpt-5.4-mini",
+              distDefault: true,
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    await fs.mkdir(tempDir, { recursive: true });
+    await fs.writeFile(
+      sourceConfigPath,
+      `${JSON.stringify({
+        sourceConfig: preUpdateConfig,
+        authoredConfig: preUpdateConfig,
+      })}\n`,
+      "utf-8",
+    );
+    vi.mocked(readConfigFileSnapshot).mockResolvedValue({
+      ...baseSnapshot,
+      sourceConfig: postDoctorConfig,
+      config: postDoctorConfig,
+      runtimeConfig: postDoctorConfig,
+      hash: "post-doctor-hash",
+    });
+    syncPluginsForUpdateChannel.mockImplementation(async ({ config }) => ({
+      changed: false,
+      config,
+      summary: {
+        switchedToBundled: [],
+        switchedToNpm: [],
+        warnings: [],
+        errors: [],
+      },
+    }));
+    updateNpmInstalledPlugins.mockResolvedValue({
+      changed: true,
+      config: disabledAfterFailureConfig,
+      outcomes: [
+        {
+          pluginId: "lossless-claw",
+          status: "skipped",
+          message:
+            'Disabled "lossless-claw" after plugin update failure; OpenClaw will continue without it.',
+        },
+      ],
+    });
+
+    await withEnvAsync(
+      {
+        OPENCLAW_UPDATE_POST_CORE: "1",
+        OPENCLAW_UPDATE_POST_CORE_CHANNEL: "stable",
+        OPENCLAW_UPDATE_POST_CORE_SOURCE_CONFIG_PATH: sourceConfigPath,
+      },
+      async () => {
+        await updateCommand({ yes: true, restart: false });
+      },
+    );
+
+    const persistedConfig = lastReplaceConfigCall()?.nextConfig as OpenClawConfig | undefined;
+    expect(persistedConfig?.plugins?.entries?.["lossless-claw"]).toEqual({
+      enabled: false,
+      config: {
+        summaryModel: "openai/gpt-5.4-mini",
+        distDefault: true,
+      },
+    });
   });
 
   it("resolves included pre-update channels for old post-core parents", async () => {

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -466,7 +466,9 @@ function restorePreUpdateAgentModelIntent(
   const topLevelAuthoredAgentsInclude = isSingleTopLevelInclude(preUpdateAuthoredAgents);
 
   const nextConfig = structuredClone(config);
-  const currentAgents = isRecord(nextConfig.agents) ? structuredClone(nextConfig.agents) : {};
+  const currentAgents: Record<string, unknown> = isRecord(nextConfig.agents)
+    ? structuredClone(nextConfig.agents)
+    : {};
   const originalAgents = structuredClone(currentAgents);
   let authoredAgents: Record<string, unknown> | undefined;
   const ensureAuthoredAgents = () => {

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -2466,7 +2466,7 @@ export async function updatePluginsAfterCoreUpdate(params: {
         nextConfig: pluginOnlyConfig,
         baseHash: writeBaseConfigSnapshot.hash,
       });
-      if (!pluginWriteResult.persistedHash) {
+      if (!pluginWriteResult?.persistedHash) {
         throw new Error("Plugin include update did not return a persisted config hash.");
       }
       await replaceConfigFile({

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -3,6 +3,7 @@ import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { isDeepStrictEqual } from "node:util";
 import { confirm, isCancel } from "@clack/prompts";
 import {
   checkShellCompletionStatus,
@@ -19,6 +20,7 @@ import {
   mutateConfigFileWithRetry,
   parseConfigJson5,
   readConfigFileSnapshot,
+  replaceConfigFile,
   resolveGatewayPort,
 } from "../../config/config.js";
 import { resolveConfigEnvVars } from "../../config/env-substitution.js";
@@ -161,6 +163,8 @@ const POST_INSTALL_DOCTOR_SERVICE_ENV_KEYS = [
   "OPENCLAW_PROFILE",
 ] as const;
 const POST_UPDATE_PLUGIN_REPAIR_GUIDANCE = "Run openclaw doctor --fix to attempt automatic repair.";
+const LEGACY_CODEX_MODEL_PREFIX = "openai-codex/";
+const CANONICAL_OPENAI_MODEL_PREFIX = "openai/";
 
 async function createUpdateConfigSnapshot(): Promise<void> {
   await createPreUpdateConfigSnapshot({
@@ -260,6 +264,559 @@ function normalizeDirectAuthoredChannelConfigMap(value: unknown): Record<string,
   return channels;
 }
 
+function hasAnyInclude(value: unknown): boolean {
+  if (Array.isArray(value)) {
+    return value.some((entry) => hasAnyInclude(entry));
+  }
+  if (!isRecord(value)) {
+    return false;
+  }
+  if (Object.prototype.hasOwnProperty.call(value, "$include")) {
+    return true;
+  }
+  return Object.values(value).some((entry) => hasAnyInclude(entry));
+}
+
+function hasNestedInclude(value: unknown): boolean {
+  if (Array.isArray(value)) {
+    return value.some((entry) => hasAnyInclude(entry));
+  }
+  if (!isRecord(value)) {
+    return false;
+  }
+  return Object.entries(value).some(([key, entry]) => key !== "$include" && hasAnyInclude(entry));
+}
+
+function isSingleTopLevelInclude(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    Object.keys(value).length === 1 &&
+    typeof value.$include === "string" &&
+    value.$include.trim().length > 0
+  );
+}
+
+function omitTopLevelPlugins(config: OpenClawConfig): Omit<OpenClawConfig, "plugins"> {
+  const { plugins: _plugins, ...rest } = config;
+  return rest;
+}
+
+function shouldSplitTopLevelPluginIncludeWrite(params: {
+  snapshot: Awaited<ReturnType<typeof readConfigFileSnapshot>>;
+  preUpdateAuthoredConfig?: OpenClawConfig;
+  hasPendingNonPluginConfigChange?: boolean;
+  pluginOnlyConfig: OpenClawConfig;
+  finalConfig: OpenClawConfig;
+}): boolean {
+  const snapshotHasTopLevelPluginInclude =
+    isRecord(params.snapshot.parsed) &&
+    isSingleTopLevelInclude((params.snapshot.parsed as OpenClawConfig).plugins);
+  const preUpdateHadTopLevelPluginInclude = isSingleTopLevelInclude(
+    params.preUpdateAuthoredConfig?.plugins,
+  );
+  if (!snapshotHasTopLevelPluginInclude && !preUpdateHadTopLevelPluginInclude) {
+    return false;
+  }
+  if (params.hasPendingNonPluginConfigChange === true) {
+    return true;
+  }
+  if (isDeepStrictEqual(params.snapshot.sourceConfig.plugins, params.pluginOnlyConfig.plugins)) {
+    return false;
+  }
+  return !isDeepStrictEqual(
+    omitTopLevelPlugins(params.snapshot.sourceConfig),
+    omitTopLevelPlugins(params.finalConfig),
+  );
+}
+
+function normalizeLegacyCodexModelRef(model: string): { model: string; codexRuntime: boolean } {
+  if (!model.startsWith(LEGACY_CODEX_MODEL_PREFIX)) {
+    return { model, codexRuntime: false };
+  }
+  const modelId = model.slice(LEGACY_CODEX_MODEL_PREFIX.length).trim();
+  if (!modelId) {
+    return { model, codexRuntime: false };
+  }
+  return { model: `${CANONICAL_OPENAI_MODEL_PREFIX}${modelId}`, codexRuntime: true };
+}
+
+function normalizeAgentModelConfigForUpdateIntent(
+  value: unknown,
+  codexRuntimeModels: Set<string>,
+): unknown {
+  if (typeof value === "string") {
+    const normalized = normalizeLegacyCodexModelRef(value);
+    if (normalized.codexRuntime) {
+      codexRuntimeModels.add(normalized.model);
+    }
+    return normalized.model;
+  }
+  if (!isRecord(value)) {
+    return structuredClone(value);
+  }
+  const next: Record<string, unknown> = {};
+  if (typeof value.primary === "string") {
+    const normalized = normalizeLegacyCodexModelRef(value.primary);
+    next.primary = normalized.model;
+    if (normalized.codexRuntime) {
+      codexRuntimeModels.add(normalized.model);
+    }
+  }
+  if (Array.isArray(value.fallbacks)) {
+    next.fallbacks = value.fallbacks.flatMap((fallback) => {
+      if (typeof fallback !== "string") {
+        return [];
+      }
+      const normalized = normalizeLegacyCodexModelRef(fallback);
+      if (normalized.codexRuntime) {
+        codexRuntimeModels.add(normalized.model);
+      }
+      return [normalized.model];
+    });
+  }
+  return next;
+}
+
+function normalizeAgentModelEntryMapForUpdateIntent(
+  value: unknown,
+  codexRuntimeModels: Set<string>,
+): Record<string, unknown> | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const entries: Record<string, unknown> = {};
+  for (const [modelRef, entry] of Object.entries(value)) {
+    const normalized = normalizeLegacyCodexModelRef(modelRef);
+    if (normalized.codexRuntime) {
+      codexRuntimeModels.add(normalized.model);
+    }
+    const nextEntry = isRecord(entry) ? structuredClone(entry) : {};
+    if (normalized.codexRuntime) {
+      const runtime = isRecord(nextEntry.agentRuntime)
+        ? structuredClone(nextEntry.agentRuntime)
+        : {};
+      nextEntry.agentRuntime = {
+        ...runtime,
+        id: "codex",
+      };
+    }
+    entries[normalized.model] = nextEntry;
+  }
+  return entries;
+}
+
+function mergeAgentModelEntryMaps(
+  currentValue: unknown,
+  preUpdateValue: unknown,
+  codexRuntimeModels: Set<string>,
+): unknown {
+  const preUpdateEntries = normalizeAgentModelEntryMapForUpdateIntent(
+    preUpdateValue,
+    codexRuntimeModels,
+  );
+  if (!preUpdateEntries) {
+    return currentValue === undefined ? undefined : structuredClone(currentValue);
+  }
+  const currentEntries = isRecord(currentValue) ? structuredClone(currentValue) : {};
+  for (const [modelRef, preUpdateEntry] of Object.entries(preUpdateEntries)) {
+    const currentEntry = isRecord(currentEntries[modelRef])
+      ? structuredClone(currentEntries[modelRef])
+      : {};
+    currentEntries[modelRef] = isRecord(preUpdateEntry)
+      ? { ...currentEntry, ...structuredClone(preUpdateEntry) }
+      : preUpdateEntry;
+  }
+  return currentEntries;
+}
+
+function applyCodexRuntimeModels(
+  target: Record<string, unknown>,
+  codexRuntimeModels: ReadonlySet<string>,
+) {
+  if (codexRuntimeModels.size === 0) {
+    return;
+  }
+  const models = isRecord(target.models) ? structuredClone(target.models) : {};
+  for (const modelRef of [...codexRuntimeModels].toSorted()) {
+    const entry = isRecord(models[modelRef]) ? structuredClone(models[modelRef]) : {};
+    const runtime = isRecord(entry.agentRuntime) ? structuredClone(entry.agentRuntime) : {};
+    entry.agentRuntime = {
+      ...runtime,
+      id: "codex",
+    };
+    models[modelRef] = entry;
+  }
+  target.models = models;
+}
+
+function restorePreUpdateAgentModelIntent(
+  config: OpenClawConfig,
+  preUpdateSourceConfig: OpenClawConfig,
+  preUpdateAuthoredConfig: OpenClawConfig,
+) {
+  const preUpdateAgents = isRecord(preUpdateSourceConfig.agents)
+    ? preUpdateSourceConfig.agents
+    : undefined;
+  if (!preUpdateAgents) {
+    return { config, changed: false };
+  }
+  const preUpdateAuthoredAgents = isRecord(preUpdateAuthoredConfig.agents)
+    ? preUpdateAuthoredConfig.agents
+    : undefined;
+  const topLevelAuthoredAgentsInclude = isSingleTopLevelInclude(preUpdateAuthoredAgents);
+
+  const nextConfig = structuredClone(config);
+  const currentAgents = isRecord(nextConfig.agents) ? structuredClone(nextConfig.agents) : {};
+  const originalAgents = structuredClone(currentAgents);
+  let authoredAgents: Record<string, unknown> | undefined;
+  const ensureAuthoredAgents = () => {
+    authoredAgents ??= {};
+    return authoredAgents;
+  };
+
+  const preUpdateDefaults = isRecord(preUpdateAgents.defaults)
+    ? preUpdateAgents.defaults
+    : undefined;
+  if (
+    preUpdateDefaults &&
+    !topLevelAuthoredAgentsInclude &&
+    !hasAnyInclude(preUpdateAuthoredAgents?.defaults)
+  ) {
+    const defaults = isRecord(currentAgents.defaults)
+      ? structuredClone(currentAgents.defaults)
+      : {};
+    const codexRuntimeModels = new Set<string>();
+    if (preUpdateDefaults.model !== undefined) {
+      defaults.model = normalizeAgentModelConfigForUpdateIntent(
+        preUpdateDefaults.model,
+        codexRuntimeModels,
+      );
+    }
+    const restoredDefaultModels = mergeAgentModelEntryMaps(
+      defaults.models,
+      preUpdateDefaults.models,
+      codexRuntimeModels,
+    );
+    if (restoredDefaultModels !== undefined) {
+      defaults.models = restoredDefaultModels;
+    }
+    applyCodexRuntimeModels(defaults, codexRuntimeModels);
+    currentAgents.defaults = defaults;
+
+    const preUpdateAuthoredDefaults = isRecord(preUpdateAuthoredAgents?.defaults)
+      ? preUpdateAuthoredAgents.defaults
+      : preUpdateDefaults;
+    const authoredDefaults = structuredClone(defaults);
+    const authoredCodexRuntimeModels = new Set<string>();
+    if (preUpdateAuthoredDefaults.model !== undefined) {
+      authoredDefaults.model = normalizeAgentModelConfigForUpdateIntent(
+        preUpdateAuthoredDefaults.model,
+        authoredCodexRuntimeModels,
+      );
+    }
+    const restoredAuthoredDefaultModels = mergeAgentModelEntryMaps(
+      authoredDefaults.models,
+      preUpdateAuthoredDefaults.models,
+      authoredCodexRuntimeModels,
+    );
+    if (restoredAuthoredDefaultModels !== undefined) {
+      authoredDefaults.models = restoredAuthoredDefaultModels;
+    }
+    applyCodexRuntimeModels(authoredDefaults, authoredCodexRuntimeModels);
+    ensureAuthoredAgents().defaults = authoredDefaults;
+  }
+
+  if (
+    Array.isArray(preUpdateAgents.list) &&
+    !topLevelAuthoredAgentsInclude &&
+    !hasAnyInclude(preUpdateAuthoredAgents?.list)
+  ) {
+    const currentList = Array.isArray(currentAgents.list)
+      ? currentAgents.list.map((entry) => structuredClone(entry))
+      : [];
+    const byId = new Map<string, Record<string, unknown>>();
+    for (const entry of currentList) {
+      if (isRecord(entry) && typeof entry.id === "string") {
+        byId.set(entry.id, entry);
+      }
+    }
+    for (const preUpdateEntry of preUpdateAgents.list) {
+      if (!isRecord(preUpdateEntry) || typeof preUpdateEntry.id !== "string") {
+        continue;
+      }
+      const codexRuntimeModels = new Set<string>();
+      let currentEntry = byId.get(preUpdateEntry.id);
+      if (!currentEntry) {
+        currentEntry = { id: preUpdateEntry.id };
+        currentList.push(currentEntry);
+        byId.set(preUpdateEntry.id, currentEntry);
+      }
+      if (preUpdateEntry.model !== undefined) {
+        currentEntry.model = normalizeAgentModelConfigForUpdateIntent(
+          preUpdateEntry.model,
+          codexRuntimeModels,
+        );
+      }
+      const restoredAgentModels = mergeAgentModelEntryMaps(
+        currentEntry.models,
+        preUpdateEntry.models,
+        codexRuntimeModels,
+      );
+      if (restoredAgentModels !== undefined) {
+        currentEntry.models = restoredAgentModels;
+      }
+      applyCodexRuntimeModels(currentEntry, codexRuntimeModels);
+    }
+    currentAgents.list = currentList;
+
+    const authoredList = currentList.map((entry) => structuredClone(entry));
+    const authoredById = new Map<string, Record<string, unknown>>();
+    for (const entry of authoredList) {
+      if (isRecord(entry) && typeof entry.id === "string") {
+        authoredById.set(entry.id, entry);
+      }
+    }
+    const preUpdateAuthoredList = Array.isArray(preUpdateAuthoredAgents?.list)
+      ? preUpdateAuthoredAgents.list
+      : preUpdateAgents.list;
+    for (const preUpdateAuthoredEntry of preUpdateAuthoredList) {
+      if (!isRecord(preUpdateAuthoredEntry) || typeof preUpdateAuthoredEntry.id !== "string") {
+        continue;
+      }
+      const codexRuntimeModels = new Set<string>();
+      let authoredEntry = authoredById.get(preUpdateAuthoredEntry.id);
+      if (!authoredEntry) {
+        authoredEntry = { id: preUpdateAuthoredEntry.id };
+        authoredList.push(authoredEntry);
+        authoredById.set(preUpdateAuthoredEntry.id, authoredEntry);
+      }
+      if (preUpdateAuthoredEntry.model !== undefined) {
+        authoredEntry.model = normalizeAgentModelConfigForUpdateIntent(
+          preUpdateAuthoredEntry.model,
+          codexRuntimeModels,
+        );
+      }
+      const restoredAgentModels = mergeAgentModelEntryMaps(
+        authoredEntry.models,
+        preUpdateAuthoredEntry.models,
+        codexRuntimeModels,
+      );
+      if (restoredAgentModels !== undefined) {
+        authoredEntry.models = restoredAgentModels;
+      }
+      applyCodexRuntimeModels(authoredEntry, codexRuntimeModels);
+    }
+    ensureAuthoredAgents().list = authoredList;
+  }
+
+  if (isDeepStrictEqual(originalAgents, currentAgents)) {
+    return {
+      config,
+      changed: false,
+      ...(authoredAgents !== undefined ? { authoredAgents } : {}),
+    };
+  }
+  nextConfig.agents = currentAgents as OpenClawConfig["agents"];
+  return {
+    config: nextConfig,
+    changed: true,
+    ...(authoredAgents !== undefined ? { authoredAgents } : {}),
+  };
+}
+
+function mergeUserConfigRecords(
+  current: Record<string, unknown>,
+  preUpdate: Record<string, unknown>,
+) {
+  const merged = structuredClone(current);
+  for (const [key, preUpdateValue] of Object.entries(preUpdate)) {
+    const currentValue = merged[key];
+    merged[key] =
+      isRecord(currentValue) && isRecord(preUpdateValue)
+        ? mergeUserConfigRecords(currentValue, preUpdateValue)
+        : structuredClone(preUpdateValue);
+  }
+  return merged;
+}
+
+function mergeAuthoredPluginEntryForWrite(currentValue: unknown, authoredValue: unknown): unknown {
+  if (!isRecord(authoredValue)) {
+    return structuredClone(authoredValue);
+  }
+  if (!isRecord(currentValue)) {
+    return structuredClone(authoredValue);
+  }
+  const merged = mergeUserConfigRecords(currentValue, authoredValue);
+  if (currentValue.enabled === false && authoredValue.enabled !== false) {
+    merged.enabled = false;
+  }
+  return merged;
+}
+
+function mergeIncludedAuthoredSubpathsForWrite(
+  currentValue: unknown,
+  authoredValue: unknown,
+): unknown {
+  if (!isRecord(authoredValue)) {
+    return structuredClone(currentValue);
+  }
+  if (Object.prototype.hasOwnProperty.call(authoredValue, "$include")) {
+    return structuredClone(authoredValue);
+  }
+  const merged = isRecord(currentValue) ? structuredClone(currentValue) : {};
+  for (const [key, authoredEntry] of Object.entries(authoredValue)) {
+    if (hasAnyInclude(authoredEntry)) {
+      merged[key] = mergeIncludedAuthoredSubpathsForWrite(merged[key], authoredEntry);
+    }
+  }
+  return merged;
+}
+
+function mergeRestoredAuthoredAgentsForWrite(
+  currentAgentsValue: unknown,
+  authoredAgentsValue: unknown,
+): OpenClawConfig["agents"] {
+  if (!isRecord(authoredAgentsValue)) {
+    return structuredClone(authoredAgentsValue) as OpenClawConfig["agents"];
+  }
+  const currentAgents = isRecord(currentAgentsValue) ? structuredClone(currentAgentsValue) : {};
+  return mergeUserConfigRecords(currentAgents, authoredAgentsValue) as OpenClawConfig["agents"];
+}
+
+function mergeRestoredAuthoredPluginsForWrite(
+  currentPluginsValue: unknown,
+  authoredPluginsValue: unknown,
+): OpenClawConfig["plugins"] {
+  if (!isRecord(authoredPluginsValue)) {
+    return structuredClone(authoredPluginsValue) as OpenClawConfig["plugins"];
+  }
+  const currentPlugins = isRecord(currentPluginsValue) ? structuredClone(currentPluginsValue) : {};
+  const authoredPlugins = structuredClone(authoredPluginsValue);
+  const mergedPlugins = mergeIncludedAuthoredSubpathsForWrite(
+    currentPlugins,
+    authoredPlugins,
+  ) as Record<string, unknown>;
+  if (!isRecord(currentPlugins.entries) || !isRecord(authoredPlugins.entries)) {
+    return mergedPlugins as OpenClawConfig["plugins"];
+  }
+
+  const currentEntries = currentPlugins.entries;
+  const authoredEntries = authoredPlugins.entries;
+  if (Object.prototype.hasOwnProperty.call(authoredEntries, "$include")) {
+    const entries = isRecord(mergedPlugins.entries)
+      ? structuredClone(mergedPlugins.entries)
+      : structuredClone(authoredEntries);
+    for (const [pluginId, currentEntry] of Object.entries(currentEntries)) {
+      if (
+        pluginId === "$include" ||
+        !isRecord(currentEntry) ||
+        Object.prototype.hasOwnProperty.call(entries, pluginId)
+      ) {
+        continue;
+      }
+      if (currentEntry.enabled === false) {
+        entries[pluginId] = { enabled: false };
+      }
+    }
+    mergedPlugins.entries = entries;
+    return mergedPlugins as OpenClawConfig["plugins"];
+  }
+
+  const entries = structuredClone(currentEntries);
+  const authoredPluginsHasNestedInclude = hasNestedInclude(authoredPlugins);
+  for (const [pluginId, authoredEntry] of Object.entries(authoredEntries)) {
+    if (pluginId === "$include") {
+      entries[pluginId] = structuredClone(authoredEntry);
+      continue;
+    }
+    if (authoredPluginsHasNestedInclude && !hasAnyInclude(authoredEntry)) {
+      continue;
+    }
+    entries[pluginId] = mergeAuthoredPluginEntryForWrite(currentEntries[pluginId], authoredEntry);
+  }
+
+  mergedPlugins.entries = entries;
+  return mergedPlugins as OpenClawConfig["plugins"];
+}
+
+function restorePreUpdatePluginEntryIntent(
+  config: OpenClawConfig,
+  preUpdateSourceConfig: OpenClawConfig,
+  preUpdateAuthoredConfig: OpenClawConfig,
+) {
+  const preUpdateSourcePlugins = isRecord(preUpdateSourceConfig.plugins)
+    ? preUpdateSourceConfig.plugins
+    : undefined;
+  const preUpdateSourceEntries = isRecord(preUpdateSourcePlugins?.entries)
+    ? preUpdateSourcePlugins.entries
+    : undefined;
+  if (!preUpdateSourceEntries) {
+    return { config, changed: false };
+  }
+  const preUpdateAuthoredPlugins = isRecord(preUpdateAuthoredConfig.plugins)
+    ? preUpdateAuthoredConfig.plugins
+    : undefined;
+  const preUpdateAuthoredEntriesIncludeOwned = hasAnyInclude(preUpdateAuthoredPlugins?.entries);
+  const preUpdateAuthoredEntries =
+    !preUpdateAuthoredEntriesIncludeOwned && isRecord(preUpdateAuthoredPlugins?.entries)
+      ? preUpdateAuthoredPlugins.entries
+      : undefined;
+
+  const nextConfig = structuredClone(config);
+  const currentPlugins = isRecord(nextConfig.plugins) ? structuredClone(nextConfig.plugins) : {};
+  const currentEntries = isRecord(currentPlugins.entries)
+    ? structuredClone(currentPlugins.entries)
+    : {};
+  const originalEntries = structuredClone(currentEntries);
+  const authoredEntries = preUpdateAuthoredEntries ? structuredClone(currentEntries) : undefined;
+  let restoredEntry = false;
+
+  for (const [pluginId, preUpdateSourceEntry] of Object.entries(preUpdateSourceEntries)) {
+    if (preUpdateAuthoredEntriesIncludeOwned) {
+      continue;
+    }
+    if (!isRecord(preUpdateSourceEntry)) {
+      continue;
+    }
+    if (!isRecord(currentEntries[pluginId])) {
+      continue;
+    }
+    const currentEntry = structuredClone(currentEntries[pluginId]);
+    if (currentEntry.enabled === false && preUpdateSourceEntry.enabled !== false) {
+      continue;
+    }
+    const preUpdateAuthoredEntry = preUpdateAuthoredEntries?.[pluginId];
+    if (hasAnyInclude(preUpdateAuthoredEntry)) {
+      continue;
+    }
+    restoredEntry = true;
+    currentEntries[pluginId] = mergeUserConfigRecords(currentEntry, preUpdateSourceEntry);
+    if (authoredEntries && isRecord(preUpdateAuthoredEntry)) {
+      authoredEntries[pluginId] = mergeUserConfigRecords(currentEntry, preUpdateAuthoredEntry);
+    }
+  }
+
+  if (!restoredEntry) {
+    return { config, changed: false };
+  }
+  const changed = !isDeepStrictEqual(originalEntries, currentEntries);
+  if (changed) {
+    currentPlugins.entries = currentEntries;
+    nextConfig.plugins = currentPlugins as OpenClawConfig["plugins"];
+  }
+  if (authoredEntries) {
+    return {
+      config: changed ? nextConfig : config,
+      changed,
+      authoredPlugins: {
+        ...currentPlugins,
+        entries: authoredEntries,
+      },
+    };
+  }
+  return { config: changed ? nextConfig : config, changed };
+}
+
 function restorePreUpdateChannelModelOverrides(params: {
   channels: Record<string, unknown>;
   preUpdateChannels: Record<string, unknown>;
@@ -305,83 +862,156 @@ function restorePreUpdateChannelModelOverrides(params: {
     : { channels: params.channels, changed: false };
 }
 
-function restoreDroppedPreUpdateChannels(
+function applyPreUpdateConfigIntent(params: {
+  config: OpenClawConfig;
+  currentAuthoredConfig: OpenClawConfig;
+  preUpdateConfig: PreUpdateConfigRestoreInput;
+}): {
+  config: OpenClawConfig;
+  changed: boolean;
+  authoredChannels?: unknown;
+  authoredAgents?: unknown;
+  authoredPlugins?: unknown;
+} {
+  let nextConfig = params.config;
+  let changed = false;
+  let authoredChannels: unknown;
+  let authoredAgents: unknown;
+  let authoredPlugins: unknown;
+  const preUpdateChannels = normalizeChannelConfigMap(params.preUpdateConfig.sourceConfig.channels);
+  const postUpdateChannels = normalizeChannelConfigMap(nextConfig.channels) ?? {};
+  let restoredChannels = { ...postUpdateChannels };
+  const restoredChannelIds: string[] = [];
+  let restored = false;
+  if (preUpdateChannels) {
+    for (const [channelId, channelConfig] of Object.entries(preUpdateChannels)) {
+      if (restoredChannels[channelId] !== undefined) {
+        continue;
+      }
+      restoredChannels[channelId] = structuredClone(channelConfig);
+      if (channelId !== "modelByChannel") {
+        restoredChannelIds.push(channelId);
+      }
+      restored = true;
+    }
+    if (restored) {
+      const restoredModelOverrides = restorePreUpdateChannelModelOverrides({
+        channels: restoredChannels,
+        preUpdateChannels,
+        restoredChannelIds,
+      });
+      restoredChannels = restoredModelOverrides.channels;
+
+      authoredChannels = resolveRestoredAuthoredChannels({
+        currentChannels: nextConfig.channels,
+        currentAuthoredChannels: params.currentAuthoredConfig.channels,
+        preUpdateAuthoredChannels: params.preUpdateConfig.authoredConfig.channels,
+        restoredChannelIds,
+      });
+      nextConfig = {
+        ...nextConfig,
+        channels: restoredChannels,
+      } as OpenClawConfig;
+      changed = true;
+    }
+  }
+
+  const restoredAgents = restorePreUpdateAgentModelIntent(
+    nextConfig,
+    params.preUpdateConfig.sourceConfig,
+    params.preUpdateConfig.authoredConfig,
+  );
+  nextConfig = restoredAgents.config;
+  changed ||= restoredAgents.changed;
+  authoredAgents = restoredAgents.authoredAgents;
+
+  const restoredPlugins = restorePreUpdatePluginEntryIntent(
+    nextConfig,
+    params.preUpdateConfig.sourceConfig,
+    params.preUpdateConfig.authoredConfig,
+  );
+  nextConfig = restoredPlugins.config;
+  changed ||= restoredPlugins.changed;
+  authoredPlugins = restoredPlugins.authoredPlugins;
+
+  return {
+    config: nextConfig,
+    changed,
+    ...(authoredChannels !== undefined ? { authoredChannels } : {}),
+    ...(authoredAgents !== undefined ? { authoredAgents } : {}),
+    ...(authoredPlugins !== undefined ? { authoredPlugins } : {}),
+  };
+}
+
+function hasPreUpdateAuthoredRestore(
+  restored: ReturnType<typeof applyPreUpdateConfigIntent>,
+): boolean {
+  return (
+    restored.authoredChannels !== undefined ||
+    restored.authoredAgents !== undefined ||
+    restored.authoredPlugins !== undefined
+  );
+}
+
+function restorePreUpdateConfigIntent(
   snapshot: Awaited<ReturnType<typeof readConfigFileSnapshot>>,
   preUpdateConfig: PreUpdateConfigRestoreInput | undefined,
 ): {
   snapshot: Awaited<ReturnType<typeof readConfigFileSnapshot>>;
   changed: boolean;
   authoredChannels?: unknown;
+  authoredAgents?: unknown;
+  authoredPlugins?: unknown;
+  preUpdateConfig?: PreUpdateConfigRestoreInput | undefined;
 } {
   if (!snapshot.valid || !preUpdateConfig) {
     return { snapshot, changed: false };
   }
-  const preUpdateChannels = normalizeChannelConfigMap(preUpdateConfig.sourceConfig.channels);
-  if (!preUpdateChannels) {
+  const restored = applyPreUpdateConfigIntent({
+    config: snapshot.sourceConfig,
+    currentAuthoredConfig: isRecord(snapshot.parsed)
+      ? (snapshot.parsed as OpenClawConfig)
+      : snapshot.sourceConfig,
+    preUpdateConfig,
+  });
+  const hasAuthoredRestore = hasPreUpdateAuthoredRestore(restored);
+  if (!restored.changed && !hasAuthoredRestore) {
     return { snapshot, changed: false };
   }
-
-  const postUpdateChannels = normalizeChannelConfigMap(snapshot.sourceConfig.channels) ?? {};
-  let restoredChannels = { ...postUpdateChannels };
-  const restoredChannelIds: string[] = [];
-  let restored = false;
-  for (const [channelId, channelConfig] of Object.entries(preUpdateChannels)) {
-    if (restoredChannels[channelId] !== undefined) {
-      continue;
-    }
-    restoredChannels[channelId] = structuredClone(channelConfig);
-    if (channelId !== "modelByChannel") {
-      restoredChannelIds.push(channelId);
-    }
-    restored = true;
-  }
-  if (!restored) {
-    return { snapshot, changed: false };
-  }
-  const restoredModelOverrides = restorePreUpdateChannelModelOverrides({
-    channels: restoredChannels,
-    preUpdateChannels,
-    restoredChannelIds,
-  });
-  restoredChannels = restoredModelOverrides.channels;
-
-  const authoredChannels = resolveRestoredAuthoredChannels({
-    currentChannels: snapshot.sourceConfig.channels,
-    currentAuthoredChannels: isRecord(snapshot.parsed)
-      ? (snapshot.parsed as OpenClawConfig).channels
-      : snapshot.sourceConfig.channels,
-    preUpdateAuthoredChannels: preUpdateConfig.authoredConfig.channels,
-    restoredChannelIds,
-  });
-  const nextConfig = {
-    ...snapshot.sourceConfig,
-    channels: restoredChannels,
-  } as OpenClawConfig;
   return {
-    snapshot: {
-      ...createUpdatedConfigSnapshot(snapshot, nextConfig),
-      hash: snapshot.hash,
-    },
-    changed: true,
-    ...(authoredChannels !== undefined ? { authoredChannels } : {}),
+    snapshot: restored.changed
+      ? {
+          ...createUpdatedConfigSnapshot(snapshot, restored.config),
+          hash: snapshot.hash,
+        }
+      : snapshot,
+    changed: restored.changed,
+    preUpdateConfig,
+    ...(restored.authoredChannels !== undefined
+      ? { authoredChannels: restored.authoredChannels }
+      : {}),
+    ...(restored.authoredAgents !== undefined ? { authoredAgents: restored.authoredAgents } : {}),
+    ...(restored.authoredPlugins !== undefined
+      ? { authoredPlugins: restored.authoredPlugins }
+      : {}),
   };
 }
 
-function hasRestorablePreUpdateChannels(
+function hasRestorablePreUpdateConfigIntent(
   snapshot: Awaited<ReturnType<typeof readConfigFileSnapshot>>,
   preUpdateConfig: PreUpdateConfigRestoreInput,
 ): boolean {
   if (!snapshot.valid) {
     return false;
   }
-  const preUpdateChannels = normalizeChannelConfigMap(preUpdateConfig.sourceConfig.channels);
-  if (!preUpdateChannels) {
-    return false;
-  }
-  const postUpdateChannels = normalizeChannelConfigMap(snapshot.sourceConfig.channels) ?? {};
-  return Object.keys(preUpdateChannels).some(
-    (channelId) => postUpdateChannels[channelId] === undefined,
-  );
+  const restored = applyPreUpdateConfigIntent({
+    config: snapshot.sourceConfig,
+    currentAuthoredConfig: isRecord(snapshot.parsed)
+      ? (snapshot.parsed as OpenClawConfig)
+      : snapshot.sourceConfig,
+    preUpdateConfig,
+  });
+  return restored.changed || hasPreUpdateAuthoredRestore(restored);
 }
 
 function resolveRestoredAuthoredChannels(params: {
@@ -1557,8 +2187,12 @@ export async function updatePluginsAfterCoreUpdate(params: {
   root: string;
   channel: "stable" | "beta" | "dev";
   configSnapshot: Awaited<ReturnType<typeof readConfigFileSnapshot>>;
+  writeBaseConfigSnapshot?: Awaited<ReturnType<typeof readConfigFileSnapshot>>;
   configChanged?: boolean;
   restoredAuthoredChannels?: unknown;
+  restoredAuthoredAgents?: unknown;
+  restoredAuthoredPlugins?: unknown;
+  preUpdateConfig?: PreUpdateConfigRestoreInput | undefined;
   opts: UpdateCommandOptions;
   timeoutMs: number;
   pluginInstallRecords?: Record<string, PluginInstallRecord>;
@@ -1777,20 +2411,76 @@ export async function updatePluginsAfterCoreUpdate(params: {
   if (pluginsChanged) {
     const nextInstallRecords = pluginConfig.plugins?.installs ?? {};
     let nextConfig = withoutPluginInstallRecords(pluginConfig);
+    let restoredAuthoredAgents = params.restoredAuthoredAgents;
+    let restoredAuthoredPlugins = params.restoredAuthoredPlugins;
+    if (params.preUpdateConfig) {
+      const restored = applyPreUpdateConfigIntent({
+        config: nextConfig,
+        currentAuthoredConfig: nextConfig,
+        preUpdateConfig: params.preUpdateConfig,
+      });
+      nextConfig = restored.config;
+      if (restored.authoredAgents !== undefined) {
+        restoredAuthoredAgents = restored.authoredAgents;
+      }
+      restoredAuthoredPlugins = restored.authoredPlugins;
+    }
+    const registryConfig = nextConfig;
     if (params.restoredAuthoredChannels !== undefined) {
       nextConfig = {
         ...nextConfig,
         channels: structuredClone(params.restoredAuthoredChannels) as OpenClawConfig["channels"],
       };
     }
-    await commitPluginInstallRecordsWithConfig({
-      previousInstallRecords: pluginInstallRecords,
-      nextInstallRecords,
-      nextConfig,
-      baseHash: params.configSnapshot.hash,
-    });
+    if (restoredAuthoredAgents !== undefined) {
+      nextConfig = {
+        ...nextConfig,
+        agents: mergeRestoredAuthoredAgentsForWrite(nextConfig.agents, restoredAuthoredAgents),
+      };
+    }
+    const writeBaseConfigSnapshot = params.writeBaseConfigSnapshot ?? params.configSnapshot;
+    const pluginOnlyConfig = {
+      ...writeBaseConfigSnapshot.sourceConfig,
+      plugins: structuredClone(registryConfig.plugins),
+    } as OpenClawConfig;
+    if (restoredAuthoredPlugins !== undefined) {
+      nextConfig = {
+        ...nextConfig,
+        plugins: mergeRestoredAuthoredPluginsForWrite(nextConfig.plugins, restoredAuthoredPlugins),
+      };
+    }
+    if (
+      shouldSplitTopLevelPluginIncludeWrite({
+        snapshot: writeBaseConfigSnapshot,
+        preUpdateAuthoredConfig: params.preUpdateConfig?.authoredConfig,
+        hasPendingNonPluginConfigChange: params.configChanged === true,
+        pluginOnlyConfig,
+        finalConfig: nextConfig,
+      })
+    ) {
+      const pluginWriteResult = await commitPluginInstallRecordsWithConfig({
+        previousInstallRecords: pluginInstallRecords,
+        nextInstallRecords,
+        nextConfig: pluginOnlyConfig,
+        baseHash: writeBaseConfigSnapshot.hash,
+      });
+      if (!pluginWriteResult.persistedHash) {
+        throw new Error("Plugin include update did not return a persisted config hash.");
+      }
+      await replaceConfigFile({
+        nextConfig,
+        baseHash: pluginWriteResult.persistedHash,
+      });
+    } else {
+      await commitPluginInstallRecordsWithConfig({
+        previousInstallRecords: pluginInstallRecords,
+        nextInstallRecords,
+        nextConfig,
+        baseHash: params.configSnapshot.hash,
+      });
+    }
     await refreshPluginRegistryAfterConfigMutation({
-      config: nextConfig,
+      config: registryConfig,
       reason: "source-changed",
       workspaceDir: params.root,
       installRecords: nextInstallRecords,
@@ -2159,8 +2849,12 @@ async function runPostCorePluginUpdate(params: {
   root: string;
   channel: "stable" | "beta" | "dev";
   configSnapshot: Awaited<ReturnType<typeof readConfigFileSnapshot>>;
+  writeBaseConfigSnapshot?: Awaited<ReturnType<typeof readConfigFileSnapshot>>;
   configChanged?: boolean;
   restoredAuthoredChannels?: unknown;
+  restoredAuthoredAgents?: unknown;
+  restoredAuthoredPlugins?: unknown;
+  preUpdateConfig?: PreUpdateConfigRestoreInput | undefined;
   opts: UpdateCommandOptions;
   timeoutMs: number;
   pluginInstallRecords?: Record<string, PluginInstallRecord>;
@@ -2169,8 +2863,12 @@ async function runPostCorePluginUpdate(params: {
     root: params.root,
     channel: params.channel,
     configSnapshot: params.configSnapshot,
+    writeBaseConfigSnapshot: params.writeBaseConfigSnapshot,
     configChanged: params.configChanged,
     restoredAuthoredChannels: params.restoredAuthoredChannels,
+    restoredAuthoredAgents: params.restoredAuthoredAgents,
+    restoredAuthoredPlugins: params.restoredAuthoredPlugins,
+    ...(params.preUpdateConfig ? { preUpdateConfig: params.preUpdateConfig } : {}),
     opts: params.opts,
     timeoutMs: params.timeoutMs,
     pluginInstallRecords: params.pluginInstallRecords,
@@ -2270,7 +2968,8 @@ export async function updateFinalizeCommand(opts: UpdateFinalizeOptions): Promis
         requestedChannel,
       });
     }
-    const restoredConfig = restoreDroppedPreUpdateChannels(configSnapshot, preFinalizeConfig);
+    const writeBaseConfigSnapshot = configSnapshot;
+    const restoredConfig = restorePreUpdateConfigIntent(configSnapshot, preFinalizeConfig);
     configSnapshot = restoredConfig.snapshot;
     const postDoctorStoredChannel = configSnapshot.valid
       ? normalizeUpdateChannel(configSnapshot.config.update?.channel)
@@ -2282,8 +2981,12 @@ export async function updateFinalizeCommand(opts: UpdateFinalizeOptions): Promis
       root,
       channel: postDoctorChannel,
       configSnapshot,
+      writeBaseConfigSnapshot,
       configChanged: restoredConfig.changed,
       restoredAuthoredChannels: restoredConfig.authoredChannels,
+      restoredAuthoredAgents: restoredConfig.authoredAgents,
+      restoredAuthoredPlugins: restoredConfig.authoredPlugins,
+      preUpdateConfig: restoredConfig.preUpdateConfig,
       opts: {
         json: opts.json,
         timeout: opts.timeout,
@@ -2572,7 +3275,7 @@ async function readPostCorePreUpdateSourceConfig(params: {
     });
     if (
       preUpdateConfig &&
-      hasRestorablePreUpdateChannels(params.currentSnapshot, preUpdateConfig)
+      hasRestorablePreUpdateConfigIntent(params.currentSnapshot, preUpdateConfig)
     ) {
       return preUpdateConfig;
     }
@@ -2592,7 +3295,7 @@ async function readPostCorePreUpdateSourceConfig(params: {
     });
     if (
       preUpdateConfig &&
-      hasRestorablePreUpdateChannels(params.currentSnapshot, preUpdateConfig)
+      hasRestorablePreUpdateConfigIntent(params.currentSnapshot, preUpdateConfig)
     ) {
       return preUpdateConfig;
     }
@@ -2662,7 +3365,7 @@ async function continuePostCoreUpdateInFreshProcess(params: {
   requestedChannel: "stable" | "beta" | "dev" | null;
   opts: UpdateCommandOptions;
   pluginInstallRecords: Record<string, PluginInstallRecord>;
-  preUpdateConfig?: PreUpdateConfigRestoreInput;
+  preUpdateConfig?: PreUpdateConfigRestoreInput | undefined;
   updateStartedAtMs: number;
   nodeRunner?: string;
 }): Promise<{ resumed: boolean; pluginUpdate?: PostCorePluginUpdateResult }> {
@@ -2908,7 +3611,8 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
       configSnapshot: postCoreConfigSnapshot,
       requestedChannel: postCoreRequestedChannel,
     });
-    const restoredPostCoreConfig = restoreDroppedPreUpdateChannels(
+    const writeBasePostCoreConfigSnapshot = postCoreConfigSnapshot;
+    const restoredPostCoreConfig = restorePreUpdateConfigIntent(
       postCoreConfigSnapshot,
       preUpdateSourceConfig,
     );
@@ -2926,8 +3630,12 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
       root,
       channel: postCoreUpdateChannel,
       configSnapshot: restoredPostCoreConfig.snapshot,
+      writeBaseConfigSnapshot: writeBasePostCoreConfigSnapshot,
       configChanged: restoredPostCoreConfig.changed,
       restoredAuthoredChannels: restoredPostCoreConfig.authoredChannels,
+      restoredAuthoredAgents: restoredPostCoreConfig.authoredAgents,
+      restoredAuthoredPlugins: restoredPostCoreConfig.authoredPlugins,
+      preUpdateConfig: restoredPostCoreConfig.preUpdateConfig,
       opts,
       timeoutMs: updateStepTimeoutMs,
       pluginInstallRecords,
@@ -3428,7 +4136,8 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
         requestedChannel,
       });
     }
-    const restoredConfig = restoreDroppedPreUpdateChannels(
+    const writeBasePostUpdateConfigSnapshot = postUpdateConfigSnapshot;
+    const restoredConfig = restorePreUpdateConfigIntent(
       postUpdateConfigSnapshot,
       configSnapshot.valid
         ? {
@@ -3444,8 +4153,12 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
       root: postUpdateRoot,
       channel,
       configSnapshot: postUpdateConfigSnapshot,
+      writeBaseConfigSnapshot: writeBasePostUpdateConfigSnapshot,
       configChanged: restoredConfig.changed,
       restoredAuthoredChannels: restoredConfig.authoredChannels,
+      restoredAuthoredAgents: restoredConfig.authoredAgents,
+      restoredAuthoredPlugins: restoredConfig.authoredPlugins,
+      preUpdateConfig: restoredConfig.preUpdateConfig,
       opts,
       timeoutMs: updateStepTimeoutMs,
       pluginInstallRecords: preUpdatePluginInstallRecords,


### PR DESCRIPTION
## Summary

- preserve pre-update authored `agents` model intent after post-core doctor/plugin update rewrites
- keep legacy Codex routes canonicalized to `openai/*` while retaining `agentRuntime.id: "codex"`
- preserve authored plugin/agent `${VAR}` references and avoid flattening include-owned config during update writes
- production diff is `+785 / -70` lines: `src/cli/update-cli/update-command.ts` is `+783 / -68`, and `src/cli/plugins-install-record-commit.ts` is `+2 / -2`

Fixes #85080.

## Verification

- `node scripts/run-vitest.mjs src/cli/update-cli.test.ts src/cli/plugins-install-record-commit.test.ts`
- `AUTOREVIEW_AUTO_TESTS=0 AUTOREVIEW_OPENCLAW_MAINTAINER_VALIDATION=1 .agents/skills/autoreview/scripts/autoreview`
- AWS Crabbox fix proof: provider `aws`, lease `cbx_beb60026694b`, run `run_222493690712`

## Real behavior proof

Behavior addressed: `openclaw update` no longer silently drops user-authored `agents.defaults.model`, per-agent model routing, Codex runtime intent, or plugin entry config during the old-package-to-current update path.

Real environment tested: direct AWS Crabbox Linux, provider `aws`, lease `cbx_beb60026694b`, run `run_222493690712`, Node `v24.15.0`.

Exact steps or command run after this patch: installed `openclaw@2026.5.19`, wrote a config with `openai-codex/*` defaults/fallbacks/per-agent refs plus plugin config and `${VAR}` refs, then ran `openclaw update --tag /tmp/openclaw-proof/openclaw-2026.5.21.tgz --yes --no-restart --json` using the packed branch build.

Evidence after fix: update completed from `OpenClaw 2026.5.19 (a185ca2)` to `OpenClaw 2026.5.21 (15a0156)` and the proof script printed `FIX_PROOF_OK`.

Observed result after fix: default and per-agent models were canonicalized to `openai/*`, fallbacks remained intact, `agentRuntime.id` stayed `codex`, plugin config stayed intact, and raw config retained `${CODEX_AGENT_TOKEN}`, `${CRON_CODEX_TOKEN}`, and `${LOSSLESS_TOKEN}` instead of resolved token values.

What was not tested: full repository CI was not run locally before opening the PR; GitHub CI should provide the broad gate.
