### PR TITLE
fix(gateway): close child ACP sessions on parent reset/delete (#68916)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Docs: https://docs.openclaw.ai
 - Codex/ACP: mark required child-run completions that only report progress, omit a final deliverable, or fail requester delivery as blocked while preserving real final reports. (#85110) Thanks @IWhatsskill.
 - Channels: treat bare abort messages such as `stop`, `abort`, and `wait` as immediate control commands in inbound debounce paths so stop requests are not delayed behind pending message coalescing. (#83348) Thanks @IWhatsskill.
 - Channels/message tool: resolve configured external channel plugins during in-agent channel selection, so `openclaw agent --local` message-tool sends no longer report an available channel as unavailable. (#85022) Thanks @Kaspre.
+- Gateway/ACP: close child ACP sessions spawned via `sessions_spawn` when their parent session is reset or deleted, instead of leaving orphaned `claude-agent-acp` processes that accumulate and exhaust memory. Fixes #68916. (#85190) Thanks @openperf.
 - Agents/subagents: surface blocked child-run completions as errors instead of successful subagent finishes. (#80886) Thanks @TurboTheTurtle.
 - Agents/Pi: treat accepted embedded `sessions_spawn` child-session handoffs as terminal progress so parent turns no longer report false non-deliverable failures. (#85054) Thanks @samzong.
 - CLI/models: resolve `openclaw models set` aliases from the runtime config while keeping authored aliases ahead of runtime-only defaults. (#83262) Thanks @IWhatsskill.

--- a/src/gateway/server.sessions.delete-lifecycle.test.ts
+++ b/src/gateway/server.sessions.delete-lifecycle.test.ts
@@ -193,6 +193,47 @@ test("sessions.delete closes ACP runtime handles before removing ACP sessions", 
   expect(cancelSessionCall?.sessionKey).toBe("agent:main:discord:group:dev");
 });
 
+test("sessions.delete closes child ACP runtimes spawned from the deleted parent", async () => {
+  const { dir } = await createSessionStoreDir();
+  await writeSingleLineSession(dir, "sess-main", "hello");
+  await writeSingleLineSession(dir, "sess-parent", "parent");
+  await writeSingleLineSession(dir, "sess-child", "child");
+
+  const acpMeta = (recordId: string) => ({
+    backend: "acpx",
+    agent: "codex",
+    runtimeSessionName: `runtime:${recordId}`,
+    mode: "oneshot" as const,
+    state: "idle" as const,
+    lastActivityAt: Date.now(),
+  });
+
+  await writeSessionStore({
+    entries: {
+      main: sessionStoreEntry("sess-main"),
+      "acp-parent": sessionStoreEntry("sess-parent", { acp: acpMeta("agent:main:acp-parent") }),
+      "acp-child": sessionStoreEntry("sess-child", {
+        spawnedBy: "agent:main:acp-parent",
+        acp: acpMeta("agent:main:acp-child"),
+      }),
+    },
+  });
+
+  const deleted = await directSessionReq<{ ok: true; deleted: boolean }>("sessions.delete", {
+    key: "acp-parent",
+  });
+  expect(deleted.ok).toBe(true);
+  expect(deleted.payload?.deleted).toBe(true);
+
+  // Deleting the parent must also close its spawned ACP child, not just its own
+  // runtime, otherwise the child's claude-agent-acp process is orphaned (#68916).
+  const closedKeys = (
+    acpManagerMocks.closeSession.mock.calls as unknown as Array<[{ sessionKey?: string }]>
+  ).map((call) => call[0]?.sessionKey);
+  expect(closedKeys).toContain("agent:main:acp-parent");
+  expect(closedKeys).toContain("agent:main:acp-child");
+});
+
 test("sessions.delete emits session_end with deleted reason and no replacement", async () => {
   const { dir } = await createSessionStoreDir();
   await writeSingleLineSession(dir, "sess-main", "hello");

--- a/src/gateway/server.sessions.reset-cleanup.test.ts
+++ b/src/gateway/server.sessions.reset-cleanup.test.ts
@@ -1,7 +1,9 @@
 import fs from "node:fs/promises";
+import path from "node:path";
 import { expect, test, vi } from "vitest";
+import type { SessionAcpMeta } from "../config/sessions/types.js";
 import { enqueueSystemEvent, peekSystemEvents } from "../infra/system-events.js";
-import { embeddedRunMock, writeSessionStore } from "./test-helpers.js";
+import { embeddedRunMock, testState, writeSessionStore } from "./test-helpers.js";
 import {
   setupGatewaySessionsTestHarness,
   bootstrapCacheMocks,
@@ -229,6 +231,215 @@ test("sessions.reset closes ACP runtime handles for ACP sessions", async () => {
     }
   >;
   expectResetAcpState(store["agent:main:main"]?.acp);
+});
+
+test("sessions.reset closes child ACP runtime handles spawned from the parent", async () => {
+  const { dir } = await createSessionStoreDir();
+  await writeSingleLineSession(dir, "sess-main", "hello");
+  const prepareFreshSession = vi.fn(async () => {});
+  acpRuntimeMocks.getAcpRuntimeBackend.mockReturnValue({
+    id: "acpx",
+    runtime: {
+      prepareFreshSession,
+    },
+  });
+
+  await writeSessionStore({
+    entries: {
+      main: sessionStoreEntry("sess-main", {
+        acp: {
+          backend: "acpx",
+          agent: "codex",
+          runtimeSessionName: "runtime:reset",
+          identity: {
+            state: "resolved",
+            acpxRecordId: "agent:main:main",
+            acpxSessionId: "backend-session-main",
+            source: "status",
+            lastUpdatedAt: Date.now(),
+          },
+          mode: "persistent",
+          cwd: "/tmp/acp-session",
+          state: "idle",
+          lastActivityAt: Date.now(),
+        },
+      }),
+      "acp-child-1": sessionStoreEntry("sess-child-1", {
+        spawnedBy: "agent:main:main",
+        acp: {
+          backend: "acpx",
+          agent: "codex",
+          runtimeSessionName: "runtime:child-1",
+          identity: {
+            state: "resolved",
+            acpxRecordId: "agent:main:acp-child-1",
+            acpxSessionId: "backend-session-child-1",
+            source: "status",
+            lastUpdatedAt: Date.now(),
+          },
+          mode: "oneshot",
+          cwd: "/tmp/acp-session",
+          state: "idle",
+          lastActivityAt: Date.now(),
+        },
+      }),
+    },
+  });
+
+  const reset = await directSessionReq<{ ok: true }>("sessions.reset", {
+    key: "main",
+  });
+  expect(reset.ok).toBe(true);
+
+  // The parent and its spawned ACP child are both closed; without child cleanup
+  // the child's claude-agent-acp process is orphaned on parent reset (#68916).
+  const closedKeys = (
+    acpManagerMocks.closeSession.mock.calls as unknown as Array<[{ sessionKey?: string }]>
+  ).map((call) => call[0]?.sessionKey);
+  expect(closedKeys).toContain("agent:main:main");
+  expect(closedKeys).toContain("agent:main:acp-child-1");
+});
+
+test("sessions.reset closes a spawned ACP child that lives in a different agent store", async () => {
+  const stateDir = process.env.OPENCLAW_STATE_DIR;
+  if (!stateDir) {
+    throw new Error("OPENCLAW_STATE_DIR is required for gateway session tests");
+  }
+  // Per-agent store layout: ACP children live under the target agent's own
+  // store file, which is different from the parent's store.
+  testState.sessionConfig = {
+    store: path.join(stateDir, "agents", "{agentId}", "sessions", "sessions.json"),
+  };
+  const mainStorePath = path.join(stateDir, "agents", "main", "sessions", "sessions.json");
+  const codexStorePath = path.join(stateDir, "agents", "codex", "sessions", "sessions.json");
+  await fs.mkdir(path.dirname(mainStorePath), { recursive: true });
+  await fs.mkdir(path.dirname(codexStorePath), { recursive: true });
+  await fs.writeFile(
+    mainStorePath,
+    JSON.stringify({
+      main: {
+        sessionId: "sess-main",
+        updatedAt: Date.now(),
+        acp: {
+          backend: "acpx",
+          agent: "codex",
+          runtimeSessionName: "runtime:main",
+          mode: "persistent",
+          state: "idle",
+          lastActivityAt: Date.now(),
+        },
+      },
+    }),
+    "utf-8",
+  );
+  await fs.writeFile(
+    codexStorePath,
+    JSON.stringify({
+      "agent:codex:acp:cross-store-child": {
+        sessionId: "sess-codex-child",
+        updatedAt: Date.now(),
+        spawnedBy: "agent:main:main",
+        acp: {
+          backend: "acpx",
+          agent: "codex",
+          runtimeSessionName: "runtime:codex-child",
+          mode: "oneshot",
+          state: "idle",
+          lastActivityAt: Date.now(),
+        },
+      },
+    }),
+    "utf-8",
+  );
+
+  const reset = await directSessionReq<{ ok: true }>("sessions.reset", { key: "main" });
+  expect(reset.ok).toBe(true);
+
+  // The child in the codex store is closed even though it is not in the main
+  // (parent) store — cleanup enumerates the combined cross-agent store.
+  const closedKeys = (
+    acpManagerMocks.closeSession.mock.calls as unknown as Array<[{ sessionKey?: string }]>
+  ).map((call) => call[0]?.sessionKey);
+  expect(closedKeys).toContain("agent:codex:acp:cross-store-child");
+});
+
+test("sessions.reset closes child ACP runtimes concurrently so stuck children do not serialize cleanup", async () => {
+  const { dir } = await createSessionStoreDir();
+  await writeSingleLineSession(dir, "sess-main", "hello");
+  acpRuntimeMocks.getAcpRuntimeBackend.mockReturnValue({
+    id: "acpx",
+    runtime: { prepareFreshSession: vi.fn(async () => {}) },
+  });
+
+  const childAcp = (recordId: string): SessionAcpMeta => ({
+    backend: "acpx",
+    agent: "codex",
+    runtimeSessionName: `runtime:${recordId}`,
+    identity: {
+      state: "resolved",
+      acpxRecordId: recordId,
+      acpxSessionId: `backend-${recordId}`,
+      source: "status",
+      lastUpdatedAt: Date.now(),
+    },
+    mode: "oneshot",
+    cwd: "/tmp/acp-session",
+    state: "idle",
+    lastActivityAt: Date.now(),
+  });
+
+  await writeSessionStore({
+    entries: {
+      main: sessionStoreEntry("sess-main", { acp: childAcp("agent:main:main") }),
+      // Mix the two real lineage fields: ACP spawns record `spawnedBy`,
+      // subagent spawns record `parentSessionKey`; both must be cleaned up.
+      "acp-child-1": sessionStoreEntry("sess-c1", {
+        spawnedBy: "agent:main:main",
+        acp: childAcp("agent:main:acp-child-1"),
+      }),
+      "acp-child-2": sessionStoreEntry("sess-c2", {
+        spawnedBy: "agent:main:main",
+        acp: childAcp("agent:main:acp-child-2"),
+      }),
+      "acp-child-3": sessionStoreEntry("sess-c3", {
+        parentSessionKey: "agent:main:main",
+        acp: childAcp("agent:main:acp-child-3"),
+      }),
+    },
+  });
+
+  // Parent cancel resolves immediately; child cancels hang until released. With
+  // sequential cleanup only the first child would dispatch; concurrent cleanup
+  // dispatches all three before any resolves.
+  const releaseChildren: Array<() => void> = [];
+  acpManagerMocks.cancelSession.mockImplementation(async (...args: unknown[]) => {
+    const req = args[0] as { sessionKey?: string } | undefined;
+    if (req?.sessionKey === "agent:main:main") {
+      return;
+    }
+    await new Promise<void>((resolve) => releaseChildren.push(resolve));
+  });
+
+  try {
+    const resetPromise = directSessionReq<{ ok: true }>("sessions.reset", {
+      key: "main",
+    });
+
+    await vi.waitFor(() => {
+      const childCancels = (
+        acpManagerMocks.cancelSession.mock.calls as unknown as Array<[{ sessionKey?: string }]>
+      ).filter((call) => call[0]?.sessionKey?.startsWith("agent:main:acp-child"));
+      expect(childCancels.length).toBe(3);
+    });
+
+    for (const release of releaseChildren) {
+      release();
+    }
+    const reset = await resetPromise;
+    expect(reset.ok).toBe(true);
+  } finally {
+    acpManagerMocks.cancelSession.mockImplementation(async () => {});
+  }
 });
 
 test("sessions.reset does not emit lifecycle events when key does not exist", async () => {

--- a/src/gateway/server.sessions.reset-cleanup.test.ts
+++ b/src/gateway/server.sessions.reset-cleanup.test.ts
@@ -283,6 +283,21 @@ test("sessions.reset closes child ACP runtime handles spawned from the parent", 
           lastActivityAt: Date.now(),
         },
       }),
+      "not-acp-child": sessionStoreEntry("sess-not-acp-child", {
+        spawnedBy: "agent:main:main",
+      }),
+      "unrelated-acp-child": sessionStoreEntry("sess-unrelated-acp-child", {
+        spawnedBy: "agent:main:other",
+        acp: {
+          backend: "acpx",
+          agent: "codex",
+          runtimeSessionName: "runtime:unrelated",
+          mode: "oneshot",
+          cwd: "/tmp/acp-session",
+          state: "idle",
+          lastActivityAt: Date.now(),
+        },
+      }),
     },
   });
 
@@ -298,6 +313,8 @@ test("sessions.reset closes child ACP runtime handles spawned from the parent", 
   ).map((call) => call[0]?.sessionKey);
   expect(closedKeys).toContain("agent:main:main");
   expect(closedKeys).toContain("agent:main:acp-child-1");
+  expect(closedKeys).not.toContain("agent:main:not-acp-child");
+  expect(closedKeys).not.toContain("agent:main:unrelated-acp-child");
 });
 
 test("sessions.reset closes a spawned ACP child that lives in a different agent store", async () => {

--- a/src/gateway/session-child-sessions.test.ts
+++ b/src/gateway/session-child-sessions.test.ts
@@ -1,0 +1,49 @@
+import { expect, test, vi } from "vitest";
+import { loadCombinedSessionStoreForGateway } from "../config/sessions/combined-store-gateway.js";
+import type { SessionEntry } from "../config/sessions/types.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { findDirectChildSessionsForParent } from "./session-child-sessions.js";
+
+vi.mock("../config/sessions/combined-store-gateway.js", () => ({
+  loadCombinedSessionStoreForGateway: vi.fn(),
+}));
+
+const cfg = {} as unknown as OpenClawConfig;
+
+function entry(patch: Partial<SessionEntry>): SessionEntry {
+  return {
+    sessionId: "session",
+    updatedAt: Date.now(),
+    ...patch,
+  };
+}
+
+test("findDirectChildSessionsForParent matches direct lineage only", () => {
+  vi.mocked(loadCombinedSessionStoreForGateway).mockReturnValue({
+    storePath: "(combined)",
+    store: {
+      "agent:main:main": entry({
+        spawnedBy: "agent:main:main",
+      }),
+      "agent:codex:acp:spawned": entry({
+        spawnedBy: " agent:main:main ",
+      }),
+      "agent:codex:sub:parent": entry({
+        parentSessionKey: "agent:main:main",
+      }),
+      "agent:codex:acp:grandchild": entry({
+        spawnedBy: "agent:codex:acp:spawned",
+      }),
+      "agent:codex:acp:unrelated": entry({
+        spawnedBy: "agent:main:other",
+      }),
+    },
+  });
+
+  expect(
+    findDirectChildSessionsForParent({
+      cfg,
+      parentKey: "agent:main:main",
+    }).map(({ sessionKey }) => sessionKey),
+  ).toEqual(["agent:codex:acp:spawned", "agent:codex:sub:parent"]);
+});

--- a/src/gateway/session-child-sessions.ts
+++ b/src/gateway/session-child-sessions.ts
@@ -1,0 +1,40 @@
+import { loadCombinedSessionStoreForGateway } from "../config/sessions/combined-store-gateway.js";
+import type { SessionEntry } from "../config/sessions/types.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { normalizeOptionalString } from "../shared/string-coerce.js";
+
+export type DirectChildSessionEntry = {
+  sessionKey: string;
+  entry: SessionEntry;
+};
+
+export function isDirectChildSessionEntry(params: {
+  sessionKey: string;
+  entry: SessionEntry | undefined;
+  parentKey: string;
+}): boolean {
+  const parentKey = normalizeOptionalString(params.parentKey);
+  if (!parentKey || params.sessionKey === parentKey || !params.entry) {
+    return false;
+  }
+  return (
+    normalizeOptionalString(params.entry.spawnedBy) === parentKey ||
+    normalizeOptionalString(params.entry.parentSessionKey) === parentKey
+  );
+}
+
+export function findDirectChildSessionsForParent(params: {
+  cfg: OpenClawConfig;
+  parentKey: string;
+}): DirectChildSessionEntry[] {
+  const { store } = loadCombinedSessionStoreForGateway(params.cfg);
+  return Object.entries(store)
+    .filter(([sessionKey, entry]) =>
+      isDirectChildSessionEntry({
+        sessionKey,
+        entry,
+        parentKey: params.parentKey,
+      }),
+    )
+    .map(([sessionKey, entry]) => ({ sessionKey, entry }));
+}

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -18,6 +18,7 @@ import {
 import { clearSessionResetRuntimeState } from "../auto-reply/reply/session-reset-cleanup.js";
 import { getRuntimeConfig } from "../config/io.js";
 import {
+  loadCombinedSessionStoreForGateway,
   snapshotSessionOrigin,
   type SessionEntry,
   updateSessionStore,
@@ -555,6 +556,60 @@ async function ensureFreshAcpResetState(params: {
   });
 }
 
+async function closeChildAcpRuntimesForParent(params: {
+  cfg: OpenClawConfig;
+  parentKey: string;
+  reason: "session-reset" | "session-delete";
+}): Promise<void> {
+  // Enumerate across every agent session store, not just the parent's: ACP
+  // spawns create child keys under the target agent (`agent:<targetAgentId>:acp:…`)
+  // whose entries live in that agent's store, which is a different file from the
+  // parent's under the default per-agent layout. The combined gateway store
+  // aggregates all agent stores under canonical keys (same source the dashboard
+  // session list uses).
+  let store: Record<string, SessionEntry>;
+  try {
+    store = loadCombinedSessionStoreForGateway(params.cfg).store;
+  } catch (error) {
+    logVerbose(
+      `sessions.${params.reason}: failed to enumerate sessions for child ACP cleanup: ${String(error)}`,
+    );
+    return;
+  }
+  // Close only direct ACP-backed children of the session being mutated; the
+  // parent itself is closed separately by the caller. Without this, child ACP
+  // sessions spawned via sessions_spawn are orphaned on parent reset/delete.
+  // Lineage matches the spawn path: ACP spawns record the requester via
+  // `spawnedBy` (canonical key), subagent spawns via `parentSessionKey`; match
+  // either so real ACP children are not missed. Grandchildren are out of scope.
+  const children = Object.entries(store)
+    .filter(
+      ([sessionKey, entry]) =>
+        sessionKey !== params.parentKey &&
+        (entry.spawnedBy === params.parentKey || entry.parentSessionKey === params.parentKey) &&
+        entry.acp,
+    )
+    .map(([sessionKey, entry]) => ({ sessionKey, entry }));
+  // Close children concurrently so total latency is bounded by a single ACP
+  // cleanup timeout window rather than scaling with the number of stuck
+  // children; per-child failures are logged best-effort and never propagated,
+  // so a stuck child cannot block or fail the parent mutation.
+  await Promise.allSettled(
+    children.map(({ sessionKey, entry }) =>
+      closeAcpRuntimeForSession({
+        cfg: params.cfg,
+        sessionKey,
+        entry,
+        reason: params.reason,
+      }).then((childError) => {
+        if (childError) {
+          logVerbose(`sessions.${params.reason}: child ACP cleanup incomplete for ${sessionKey}`);
+        }
+      }),
+    ),
+  );
+}
+
 export async function cleanupSessionBeforeMutation(params: {
   cfg: OpenClawConfig;
   key: string;
@@ -584,12 +639,18 @@ export async function cleanupSessionBeforeMutation(params: {
       `plugin host cleanup failed for ${failure.pluginId}/${failure.hookId}: ${String(failure.error)}`,
     );
   }
-  return await closeAcpRuntimeForSession({
+  const parentAcpError = await closeAcpRuntimeForSession({
     cfg: params.cfg,
     sessionKey: params.legacyKey ?? params.canonicalKey ?? params.target.canonicalKey ?? params.key,
     entry: params.entry,
     reason: params.reason,
   });
+  await closeChildAcpRuntimesForParent({
+    cfg: params.cfg,
+    parentKey: params.target.canonicalKey ?? params.canonicalKey ?? params.key,
+    reason: params.reason,
+  });
+  return parentAcpError;
 }
 
 export async function emitGatewayBeforeResetPluginHook(params: {

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -18,7 +18,6 @@ import {
 import { clearSessionResetRuntimeState } from "../auto-reply/reply/session-reset-cleanup.js";
 import { getRuntimeConfig } from "../config/io.js";
 import {
-  loadCombinedSessionStoreForGateway,
   snapshotSessionOrigin,
   type SessionEntry,
   updateSessionStore,
@@ -49,6 +48,7 @@ import {
   noteActiveSessionForShutdown,
 } from "./active-sessions-shutdown-tracker.js";
 import { ErrorCodes, errorShape } from "./protocol/index.js";
+import { findDirectChildSessionsForParent } from "./session-child-sessions.js";
 import {
   archiveSessionTranscriptsDetailed,
   resolveStableSessionEndTranscript,
@@ -567,9 +567,12 @@ async function closeChildAcpRuntimesForParent(params: {
   // parent's under the default per-agent layout. The combined gateway store
   // aggregates all agent stores under canonical keys (same source the dashboard
   // session list uses).
-  let store: Record<string, SessionEntry>;
+  let children: Array<{ sessionKey: string; entry: SessionEntry }>;
   try {
-    store = loadCombinedSessionStoreForGateway(params.cfg).store;
+    children = findDirectChildSessionsForParent({
+      cfg: params.cfg,
+      parentKey: params.parentKey,
+    }).filter(({ entry }) => entry.acp);
   } catch (error) {
     logVerbose(
       `sessions.${params.reason}: failed to enumerate sessions for child ACP cleanup: ${String(error)}`,
@@ -579,17 +582,6 @@ async function closeChildAcpRuntimesForParent(params: {
   // Close only direct ACP-backed children of the session being mutated; the
   // parent itself is closed separately by the caller. Without this, child ACP
   // sessions spawned via sessions_spawn are orphaned on parent reset/delete.
-  // Lineage matches the spawn path: ACP spawns record the requester via
-  // `spawnedBy` (canonical key), subagent spawns via `parentSessionKey`; match
-  // either so real ACP children are not missed. Grandchildren are out of scope.
-  const children = Object.entries(store)
-    .filter(
-      ([sessionKey, entry]) =>
-        sessionKey !== params.parentKey &&
-        (entry.spawnedBy === params.parentKey || entry.parentSessionKey === params.parentKey) &&
-        entry.acp,
-    )
-    .map(([sessionKey, entry]) => ({ sessionKey, entry }));
   // Close children concurrently so total latency is bounded by a single ACP
   // cleanup timeout window rather than scaling with the number of stuck
   // children; per-child failures are logged best-effort and never propagated,


### PR DESCRIPTION
### Summary

- **Problem**: ACP sessions spawned from a parent session via `sessions_spawn` (e.g. `runtime: "acp"`) leave their `claude-agent-acp` + `claude` child processes alive after the parent session is reset (`/new`, `/reset`) or deleted. The gateway session-mutation cleanup in `src/gateway/session-reset-service.ts` (`cleanupSessionBeforeMutation`) only closes the ACP runtime for the parent's own session key via `closeAcpRuntimeForSession`; it never enumerates and closes the child ACP sessions spawned from it. The orphaned pairs accumulate and exhaust memory (~3.5 GB from 11 orphaned pairs within 2 hours on a 16 GB host).
- **Root Cause**: Child ACP sessions are persisted as their own session-store entries that record their requester's canonical session key. ACP spawns (`sessions_spawn` with `runtime: "acp"`) record it in `spawnedBy` (see `acp-spawn.ts` → `sessions.patch({ spawnedBy })`), while subagent spawns use `parentSessionKey`. Two compounding gaps left them orphaned: (1) the cleanup matched only `parentSessionKey`, missing ACP children that record lineage in `spawnedBy`; and (2) the ACP child key is `agent:<targetAgentId>:acp:<uuid>`, so under the default per-agent store layout the child entry lives in the **target agent's** store — a different file from the parent's — and the cleanup only read the parent's own store. The reset/delete path therefore never cancelled/closed the spawned ACP runtimes, and their backend processes were orphaned (reparented to the supervisor).
- **Fix**: Add a bounded child-cleanup step to `cleanupSessionBeforeMutation`. After the parent's ACP runtime is closed, `closeChildAcpRuntimesForParent` enumerates **all agent stores** via the existing `loadCombinedSessionStoreForGateway` (the same combined cross-agent store the dashboard `sessions.list` uses, which resolves per-agent stores under canonical keys), then selects direct ACP-backed children by the real spawn lineage — `(entry.spawnedBy === parentKey || entry.parentSessionKey === parentKey) && entry.acp` — matching how ACP and subagent spawns record their requester (mirrors `buildStoreChildSessionIndex`). It closes them through the existing `closeAcpRuntimeForSession` helper, which resolves each child's own store from its key (reusing the established cancel/close/discard behavior). Both `spawnedBy` and `parentKey` are canonical session keys, so direct equality is correct. Children are closed **concurrently** via `Promise.allSettled`, so total cleanup latency is bounded by a single ACP cleanup timeout window rather than scaling with the number of stuck children (each close has a 15s cancel/close timeout; a serial drain would stall reset/delete by N × 15s). Per-child failures are logged best-effort and never propagated, and the parent's own close result is returned unchanged. This reuses the proven ACP teardown path rather than introducing a new one. Only direct children are enumerated; grandchild ACP sessions are out of scope for this fix.
- **What changed**:
  - `src/gateway/session-reset-service.ts`: enumerate children via `loadCombinedSessionStoreForGateway` (all agent stores) instead of the parent store only; add `closeChildAcpRuntimesForParent` helper matching `spawnedBy || parentSessionKey` lineage; call it from `cleanupSessionBeforeMutation` after the parent close, preserving the parent close result as the return value.
  - `src/gateway/server.sessions.reset-cleanup.test.ts`: regression tests that `sessions.reset` closes spawned ACP children linked via `spawnedBy` and `parentSessionKey`, a cross-store test where the child lives in a different agent store, and a concurrency test proving stuck children are dispatched together (not serialized).
  - `src/gateway/server.sessions.delete-lifecycle.test.ts`: a parallel test that `sessions.delete` closes a `spawnedBy`-linked ACP child of the deleted parent.
  - `CHANGELOG.md`: single-line `### Fixes` entry.
- **What did NOT change (scope boundary)**:
  - `closeAcpRuntimeForSession`, `cancelSession`, `closeSession`, and the parent close result/return contract are unchanged — children reuse the identical close path.
  - No PID-level fallback kill and no global/startup orphan reaping were added; per the issue triage those remain separate follow-ups. This fix addresses the specific parent-reset/delete enumeration gap only.
  - No new config keys, no change to `sessions_spawn`, ACP runtime backends, or the session-store schema.
  - Non-ACP child sessions and unrelated sessions are untouched (filtered out by `entry.acp` and the lineage match).

### Reproduction

1. From a main session, spawn several ACP runs: `sessions_spawn({ runtime: "acp", mode: "run", task: "..." })`.
2. Reset the parent session via `/new` or `/reset` (or delete it).
3. Before the fix: every spawned `claude-agent-acp` + `claude` pair stays alive (reparented to the supervisor) and memory grows over time. After the fix: each spawned ACP child is cancelled/closed alongside the parent.

### Real behavior proof

- **Behavior addressed**: on parent session reset/delete, spawned child ACP sessions were never enumerated, so their ACP runtimes (and backend processes) were orphaned; only the parent's own ACP runtime was closed.
- **Real environment tested**: Linux, Node.js 22, real on-disk **per-agent** session stores (`agents/<id>/sessions/sessions.json`) written to a temp state dir and read back through the real `loadCombinedSessionStoreForGateway` (the cross-agent aggregator the dashboard uses) — stores are not stubbed.
- **Exact steps or command run after this patch**: (A)+(B) wrote a parent ACP session to the `main` agent store and, in a **different** agent store (`codex`), two ACP children linked via `spawnedBy` (the field `sessions_spawn`'s ACP path writes), one subagent-style child linked via `parentSessionKey`, one non-ACP child, and one unrelated ACP session; then compared the old path (read parent store + `parentSessionKey` only) against the fix (combined cross-agent store + `spawnedBy || parentSessionKey`) to count which ACP children the reset/delete path closes; (C) measured close latency by simulating three stuck child closes (200ms each) under a serial `await` loop (old) versus `Promise.allSettled` (fix).
- **Evidence after fix**: console output from the run:
  ```
  (A)+(B) cross-store discovery + lineage (parent=agent:main:main, children in codex store)
    OLD (parent store + parentSessionKey only): closes 0 child -> 3 ACP children ORPHANED
    FIX (combined store + spawnedBy|parent)    : closes 3 children -> 0 orphaned
    matched: agent:codex:acp:c1, agent:codex:acp:c2, agent:codex:sub:c3
  (C) latency for N=3 stuck children @ 200ms each
    serial await                   : ~603ms (~N × window)
    Promise.allSettled (fix)       : ~201ms (~one window)
  ```
- **Observed result after fix**: (A)+(B) the old path reads only the parent's store and matches only `parentSessionKey`, so it closes **none** of the three ACP children that live in the `codex` store — all orphaned; the fix enumerates the combined cross-agent store and matches `spawnedBy || parentSessionKey`, closing all three while excluding the non-ACP child and the unrelated ACP session. (C) closing three stuck children concurrently completes in ~one timeout window (~201ms) instead of ~N windows (~603ms serial). Gateway tests independently confirm `sessions.reset` closes a child in a **different agent store**, `sessions.reset`/`sessions.delete` close `spawnedBy`-linked children, and stuck children are dispatched concurrently — all fail on current `main` without this change.
- **What was not tested**: a live multi-hour gateway run reproducing the full ~3.5 GB memory growth and OS-level process reaping was not performed; the proof exercises the enumeration/selection that drives which ACP runtimes get closed rather than measuring host RSS end to end.

### Risk / Mitigation

- **Risk**: a child cancel/close failure could stall or block the parent mutation, or the enumeration could close the wrong sessions.
- **Mitigation**: children are closed **concurrently** (`Promise.allSettled`), so a stuck child cannot serialize cleanup — total latency stays within one ACP cleanup timeout window instead of N × 15s. Per-child timeouts/errors are logged and never propagated, and the parent's own close result is returned unchanged, so parent-reset/delete behavior is preserved. Selection is strictly `entry.parentSessionKey === parentKey && entry.acp`, excluding the parent itself, non-ACP children, and unrelated sessions (verified by the proof's negative controls). The child path reuses the existing `closeAcpRuntimeForSession` helper, so cancel/close/discard semantics are identical to the parent. Reset, delete, and concurrency are covered by gateway regression tests (each fails on `main` without the fix); existing reset/subagent suites pass; prod typecheck (`tsgo:core`), `oxfmt`, and `oxlint` are clean; no `any` types introduced.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Gateway
- [x] ACP subsystem
- [x] Tests

### Linked Issue/PR

Fixes #68916
