### PR TITLE
fix: strip sub-second precision from Gemini timeRangeFilter timestamps

### DIFF
--- a/extensions/google/src/gemini-web-search-provider.runtime.ts
+++ b/extensions/google/src/gemini-web-search-provider.runtime.ts
@@ -66,6 +66,10 @@ const GEMINI_FRESHNESS_DAYS: Record<GeminiFreshness, number> = {
   year: 365,
 };
 
+function toGeminiTimestamp(date: Date): string {
+  return date.toISOString().replace(/\.\d+Z$/, "Z");
+}
+
 function isoDateStart(value: string): string {
   return `${value}T00:00:00Z`;
 }
@@ -73,13 +77,13 @@ function isoDateStart(value: string): string {
 function isoDateExclusiveEnd(value: string): string {
   const end = new Date(`${value}T00:00:00Z`);
   end.setUTCDate(end.getUTCDate() + 1);
-  return end.toISOString();
+  return toGeminiTimestamp(end);
 }
 
 function freshnessStartTime(freshness: GeminiFreshness, now: Date): string {
   const start = new Date(now);
   start.setUTCDate(start.getUTCDate() - GEMINI_FRESHNESS_DAYS[freshness]);
-  return start.toISOString();
+  return toGeminiTimestamp(start);
 }
 
 function resolveGeminiTimeRangeFilter(
@@ -134,7 +138,7 @@ function resolveGeminiTimeRangeFilter(
     return {
       timeRangeFilter: {
         startTime: freshnessStartTime(freshness, now),
-        endTime: now.toISOString(),
+        endTime: toGeminiTimestamp(now),
       },
     };
   }
@@ -147,7 +151,7 @@ function resolveGeminiTimeRangeFilter(
   return {
     timeRangeFilter: {
       startTime: dateAfter ? isoDateStart(dateAfter) : "1970-01-01T00:00:00Z",
-      endTime: dateBefore ? isoDateExclusiveEnd(dateBefore) : now.toISOString(),
+      endTime: dateBefore ? isoDateExclusiveEnd(dateBefore) : toGeminiTimestamp(now),
     },
   };
 }

--- a/extensions/google/web-search-provider.test.ts
+++ b/extensions/google/web-search-provider.test.ts
@@ -325,8 +325,8 @@ describe("google web search provider", () => {
 
     const body = parseGeminiFetchBody(mockFetch);
     expect(body.tools?.[0]?.google_search?.timeRangeFilter).toEqual({
-      startTime: "2026-04-08T12:00:00.000Z",
-      endTime: "2026-04-15T12:00:00.000Z",
+      startTime: "2026-04-08T12:00:00Z",
+      endTime: "2026-04-15T12:00:00Z",
     });
   });
 
@@ -359,7 +359,7 @@ describe("google web search provider", () => {
     const body = parseGeminiFetchBody(mockFetch);
     expect(body.tools?.[0]?.google_search?.timeRangeFilter).toEqual({
       startTime: "2026-04-01T00:00:00Z",
-      endTime: "2026-05-01T00:00:00.000Z",
+      endTime: "2026-05-01T00:00:00Z",
     });
   });
 


### PR DESCRIPTION
## Summary

Gemini's Search grounding endpoint rejects timestamps with fractional seconds in `timeRangeFilter`, returning:
```
Granularity of nano is not supported [code=INVALID_ARGUMENT]
```

All four call sites that build `timeRangeFilter` values used `Date.toISOString()`, which emits millisecond precision (e.g. `2026-05-20T17:30:45.123Z`). This causes every Gemini web_search call with `freshness`, `date_after`, or `date_before` to fail with a 400 error.

## Fix

Introduce a `toGeminiTimestamp()` helper that strips the fractional-second component from ISO strings, producing second-precision timestamps (e.g. `2026-05-20T17:30:45Z`) that Gemini accepts. Apply it to all four affected sites:

- `freshnessStartTime()` — `start` time for freshness-based ranges
- `isoDateExclusiveEnd()` — `end` time for date-range filters
- `resolveGeminiTimeRangeFilter()` — two `endTime` assignments (`now` reference)

Closes #85061

## Verification

- All 16 existing tests in `extensions/google/web-search-provider.test.ts` pass with updated expectations (timestamps now use second precision)
- `toGeminiTimestamp` correctly strips `.###Z` → `Z` while preserving the rest of the ISO format
