### PR TITLE
fix(agents): drop unsafe Copilot reasoning replay IDs

### DIFF
--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -2383,7 +2383,7 @@ describe("openai transport stream", () => {
     });
   });
 
-  it("preserves oversized Responses reasoning replay item ids for provider boundary sanitizers", () => {
+  it("drops oversized GitHub Copilot Responses reasoning replay items before send", () => {
     const model = {
       id: "gpt-5.5",
       name: "GPT-5.5",
@@ -2441,9 +2441,7 @@ describe("openai transport stream", () => {
       }>;
     };
 
-    const reasoningItem = params.input?.find((item) => item.type === "reasoning");
-    expect(reasoningItem?.id).toBe(longReasoningId);
-    expect(reasoningItem?.id?.length).toBeGreaterThan(64);
+    expect(params.input?.some((item) => item.type === "reasoning")).toBe(false);
   });
 
   it("strips encrypted reasoning replay when provenance does not match", () => {

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -2383,6 +2383,69 @@ describe("openai transport stream", () => {
     });
   });
 
+  it("preserves oversized Responses reasoning replay item ids for provider boundary sanitizers", () => {
+    const model = {
+      id: "gpt-5.5",
+      name: "GPT-5.5",
+      api: "openai-responses",
+      provider: "github-copilot",
+      baseUrl: "https://api.githubcopilot.com",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 400000,
+      maxTokens: 8192,
+    } satisfies Model<"openai-responses">;
+    const longReasoningId = `rs_${"x".repeat(380)}`;
+
+    const params = buildOpenAIResponsesParams(
+      model,
+      {
+        systemPrompt: "system",
+        messages: [
+          {
+            role: "assistant",
+            api: "openai-responses",
+            provider: "github-copilot",
+            model: "gpt-5.5",
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 0,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            stopReason: "toolUse",
+            timestamp: 1,
+            content: [
+              {
+                type: "thinking",
+                thinking: "Need a tool.",
+                thinkingSignature: JSON.stringify({
+                  type: "reasoning",
+                  id: longReasoningId,
+                  summary: [],
+                }),
+              },
+            ],
+          },
+        ],
+        tools: [],
+      } as never,
+      { sessionId: "session-123" },
+    ) as {
+      input?: Array<{
+        type?: string;
+        id?: string;
+      }>;
+    };
+
+    const reasoningItem = params.input?.find((item) => item.type === "reasoning");
+    expect(reasoningItem?.id).toBe(longReasoningId);
+    expect(reasoningItem?.id?.length).toBeGreaterThan(64);
+  });
+
   it("strips encrypted reasoning replay when provenance does not match", () => {
     const model = {
       id: "gpt-5.4",

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -81,6 +81,7 @@ const RESPONSE_FAILED_NO_DETAILS_MESSAGE = "Unknown error (no error details in r
 const MAX_OPENAI_STRICT_TOOL_DOWNGRADE_DIAGNOSTIC_KEYS = 256;
 const OPENAI_RESPONSES_REASONING_REPLAY_META_KEY = "__openclaw_replay";
 const OPENAI_RESPONSES_REASONING_REPLAY_BLOCK_META_KEY = "openclawReasoningReplay";
+const OPENAI_RESPONSES_REPLAY_ITEM_ID_MAX_LENGTH = 64;
 const log = createSubsystemLogger("openai-transport");
 const loggedOpenAIStrictToolDowngradeDiagnosticKeys = new Set<string>();
 
@@ -940,6 +941,19 @@ function shortHash(value: string): string {
   return createHash("sha256").update(value).digest("hex").slice(0, 16);
 }
 
+function normalizeResponsesReplayItemId(
+  id: string | undefined,
+  prefix: string,
+): string | undefined {
+  if (!id) {
+    return undefined;
+  }
+  if (id.length <= OPENAI_RESPONSES_REPLAY_ITEM_ID_MAX_LENGTH) {
+    return id;
+  }
+  return `${prefix}_${shortHash(id)}`;
+}
+
 function encodeTextSignatureV1(id: string, phase?: "commentary" | "final_answer"): string {
   return JSON.stringify({ v: 1, id, ...(phase ? { phase } : {}) });
 }
@@ -1098,9 +1112,7 @@ function convertResponsesMessages(
           let msgId = shouldReplayResponsesItemIds
             ? (textSignature?.id ?? `msg_${msgIndex}`)
             : undefined;
-          if (msgId && msgId.length > 64) {
-            msgId = `msg_${shortHash(msgId)}`;
-          }
+          msgId = normalizeResponsesReplayItemId(msgId, "msg");
           const messageItem: ReplayableResponseOutputMessage = {
             type: "message",
             role: "assistant",

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -954,6 +954,14 @@ function normalizeResponsesReplayItemId(
   return `${prefix}_${shortHash(id)}`;
 }
 
+function isSafeResponsesReplayItemId(id: unknown): id is string {
+  return (
+    typeof id === "string" &&
+    id.length > 0 &&
+    id.length <= OPENAI_RESPONSES_REPLAY_ITEM_ID_MAX_LENGTH
+  );
+}
+
 function encodeTextSignatureV1(id: string, phase?: "commentary" | "final_answer"): string {
   return JSON.stringify({ v: 1, id, ...(phase ? { phase } : {}) });
 }
@@ -1104,6 +1112,12 @@ function convertResponsesMessages(
             );
             if (!shouldReplayResponsesItemIds) {
               delete replayableReasoningItem.id;
+            }
+            if (
+              model.provider === "github-copilot" &&
+              !isSafeResponsesReplayItemId(replayableReasoningItem.id)
+            ) {
+              continue;
             }
             output.push(replayableReasoningItem as ResponseInputItem);
           }


### PR DESCRIPTION
## Summary

- Problem: GitHub Copilot native Responses can reject resumed Telegram direct sessions when persisted reasoning replay item IDs exceed the provider's 64-character `input[].id` limit.
- Solution: Drop unsafe GitHub Copilot Responses reasoning replay items in the direct request-builder path before the payload can be sent.
- What changed: The regression now asserts a GitHub Copilot `openai-responses` payload built from a 383-character reasoning replay ID does not emit that reasoning item; assistant message replay IDs still use the shared length normalizer.
- What did NOT change (scope boundary): Copilot's provider wrapper still owns connection-bound message ID rewriting and still drops unsafe reasoning items at the wrapped payload boundary.

## Motivation

- The affected Telegram direct session accepted inbound messages but failed before assistant output with `Invalid 'input[112].id': string too long. Expected a string with maximum length 64, but got a string with length 383 instead.`

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #85197
- Related #74665
- Related #81520
- Related #81534
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

Behavior addressed: GitHub Copilot native Responses request building no longer sends overlong replayed reasoning item IDs that can trigger the provider `input[].id` 64-character validation error.

Real environment tested: Local OpenClaw worktree on Linux with Node v24.15.0, using the real `buildOpenAIResponsesParams` request-builder seam plus the existing GitHub Copilot provider-boundary sanitizer tests.

Exact steps or command run after this patch: `pnpm format:fix src/agents/openai-transport-stream.ts src/agents/openai-transport-stream.test.ts`; `node scripts/run-vitest.mjs src/agents/openai-transport-stream.test.ts extensions/github-copilot/connection-bound-ids.test.ts extensions/github-copilot/stream.test.ts`; `git diff --check`.

Evidence after fix: Focused Vitest output from the patched worktree:

```text
Test Files  4 passed (4)
     Tests  363 passed (363)
  Duration  12.31s (transform 6.28s, setup 1.10s, import 9.80s, tests 1.15s, environment 0ms)
```

Observed result after fix: The direct GitHub Copilot Responses builder test drops the overlong reasoning replay item before send, and the existing Copilot wrapper/sanitizer tests continue to prove unsafe reasoning replay items are removed at the wrapped provider boundary.

What was not tested: No live Telegram or GitHub Copilot provider rerun was performed because the failing evidence depends on a private persisted Telegram session and credentials.

Before evidence (optional but encouraged): Redacted runtime log excerpt from the affected setup:

```shell
embedded run prompt start: provider=github-copilot api=openai-responses endpoint=github-copilot-native route=native
context-overflow-precheck: route=fits estimatedPromptTokens=56663 overflowTokens=0
embedded_run_agent_end: isError=true error="OpenAI API error (400): 400 Invalid 'input[112].id': string too long. Expected a string with maximum length 64, but got a string with length 383 instead." model=gpt-5.5 provider=github-copilot rawErrorHash=sha256:2279064209cc
message dispatch completed: channel=telegram outcome=completed
```

## Root Cause (if applicable)

- Root cause: `convertResponsesMessages()` parsed persisted JSON `thinkingSignature` blocks as replayable Responses reasoning items and preserved their `id` whenever Responses item ID replay was enabled. GitHub Copilot native Responses uses that replay path, so overlong historical reasoning IDs could reach `input[].id` in the direct request-builder path.
- Missing detection / guardrail: Existing Copilot replay tests covered provider-boundary dropping, but the direct builder regression originally did not prove the production failing path was fixed.
- Contributing context (if known): Prior replay fixes normalized tool/function and assistant message IDs. Reasoning IDs are different because they can reference server-side encrypted state, so unsafe Copilot reasoning items are dropped instead of rewritten.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/openai-transport-stream.test.ts`, `extensions/github-copilot/connection-bound-ids.test.ts`, `extensions/github-copilot/stream.test.ts`
- Scenario the test should lock in: A GitHub Copilot `openai-responses` payload built from a persisted reasoning `thinkingSignature` with a 383-character `id` does not emit that unsafe reasoning item in the direct builder path, and the Copilot wrapper/sanitizer still drops unsafe reasoning replay items before wrapped sends.
- Why this is the smallest reliable guardrail: The failure happens during request construction before provider generation, and the provider wrapper has separate existing coverage for its send-boundary sanitizer.
- Existing test that already covers this (if any): `extensions/github-copilot/connection-bound-ids.test.ts` covers dropping overlong/missing/non-string reasoning IDs; `extensions/github-copilot/stream.test.ts` covers the wrapper applying that sanitizer before payload send.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Telegram direct sessions with overlong persisted Copilot Responses reasoning replay IDs can continue instead of failing before assistant output; unsafe replayed reasoning state is dropped.

## Diagram (if applicable)

```text
Before:
[persisted reasoning id length 383] -> [Responses input[].id unchanged] -> [provider 400]

Rejected first patch:
[persisted reasoning id length 383] -> [rs_<hash>] -> [Copilot encrypted reasoning lookup rewritten]

After:
[persisted reasoning id length 383] -> [direct builder drops unsafe Copilot reasoning item] -> [request can send]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux local worktree
- Runtime/container: Node v24.15.0
- Model/provider: github-copilot/gpt-5.5
- Integration/channel (if any): Telegram direct session evidence; local request-builder and Copilot-boundary verification
- Relevant config (redacted): GitHub Copilot native Responses route with a redacted private Telegram session

### Steps

1. Build a GitHub Copilot Responses payload from an assistant message with a persisted JSON `thinkingSignature` reasoning item.
2. Use an overlong 383-character reasoning item `id`.
3. Inspect the emitted payload and run the existing Copilot wrapper/sanitizer tests.

### Expected

- The direct GitHub Copilot Responses builder removes unsafe overlong reasoning replay items before send.
- The Copilot boundary also removes unsafe overlong reasoning replay items when wrapping provider sends.

### Actual

- Before this patch, the 383-character ID could reach the provider and be rejected.
- After this patch, the direct builder drops the unsafe reasoning item and the focused tests pass.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Formatted the touched files, ran the focused agent transport and GitHub Copilot wrapper/sanitizer Vitest files, and ran `git diff --check`.
- Edge cases checked: Overlong Copilot reasoning replay items are dropped; assistant message replay IDs still normalize to short `msg_` IDs; existing Copilot wrapper behavior still drops unsafe reasoning replay at the provider boundary.
- What you did **not** verify: Live Telegram replay against the private affected session and live GitHub Copilot credentials.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Dropping unsafe reasoning replay can lose server-side reasoning continuity for that historical item.
  - Mitigation: The provider already rejects the unsafe ID, and the Copilot boundary explicitly treats unsafe reasoning items as invalid or ambiguous server-state lookups.