### PR TITLE
fix(messages): strip unsupported citation markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Docs: https://docs.openclaw.ai
 - QA-Lab: isolate multi-scenario suite workers when scenarios need startup config patches, preventing message-routing config from leaking into unrelated scenarios.
 - QA-Lab: make the commitments heartbeat-target-none scenario request an immediate heartbeat instead of waiting for the next scheduled heartbeat.
 - Gateway CLI: surface local post-challenge connect assembly failures immediately instead of waiting for the wrapper timeout. Fixes #68944. (#85253) Thanks @samzong.
+- Messages: strip unsupported web-search citation control markers from outbound replies before they reach WebChat or external channels. Fixes #85193. (#85204) Thanks @neeravmakwana.
 - Agents/exec: treat denied exec approvals as terminal instead of feeding them back into agent follow-up work, and recognize Chinese stop phrases in abort handling. Fixes #69386. (#85194) Thanks @samzong.
 - CLI/agents: abort accepted Gateway-backed `openclaw agent` runs on SIGINT/SIGTERM so cron and supervisor timeouts do not leave remote agent work alive. Fixes #71710. (#84381) Thanks @Kaspre.
 - Codex app-server: retry replay-safe stdio client-close turns once using structured failure metadata, while surfacing idle `turn/completed` timeouts instead of blindly replaying active shared-server turns. Thanks @VACInc.

--- a/src/infra/outbound/message-action-runner.send-validation.test.ts
+++ b/src/infra/outbound/message-action-runner.send-validation.test.ts
@@ -118,6 +118,31 @@ describe("runMessageAction send validation", () => {
     });
   });
 
+  it("strips unsupported citation control markers from internal UI source replies", async () => {
+    const result = await runMessageAction({
+      cfg: emptyConfig,
+      action: "send",
+      params: {
+        message: "v2026.5.20 release note citeturn2view0",
+      },
+      toolContext: {
+        currentChannelProvider: "webchat",
+      },
+      sessionKey: "agent:main",
+      sourceReplyDeliveryMode: "message_tool_only",
+    });
+
+    expect(result).toMatchObject({
+      kind: "send",
+      payload: {
+        sourceReply: {
+          text: "v2026.5.20 release note",
+        },
+      },
+    });
+    expect(JSON.stringify(result.payload)).not.toContain("turn2view0");
+  });
+
   it("does not infer an internal UI sink outside message-tool-only source delivery", async () => {
     await expect(
       runMessageAction({
@@ -158,6 +183,48 @@ describe("runMessageAction send validation", () => {
       handledBy: "core",
       dryRun: true,
     });
+  });
+
+  it("strips unsupported citation control markers from normal channel sends", async () => {
+    const sentText: string[] = [];
+    const sendText: NonNullable<
+      NonNullable<typeof workspaceTestPlugin.outbound>["sendText"]
+    > = async (ctx) => {
+      sentText.push(ctx.text);
+      return { channel: "workspace", messageId: "workspace-test-message" };
+    };
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "workspace",
+          source: "test",
+          plugin: {
+            ...workspaceTestPlugin,
+            outbound: {
+              ...workspaceTestPlugin.outbound,
+              sendText,
+            },
+          },
+        },
+      ]),
+    );
+
+    const result = await runMessageAction({
+      cfg: workspaceConfig,
+      action: "send",
+      params: {
+        channel: "workspace",
+        target: "#C12345678",
+        message: "v2026.5.20 release note citeturn2view0",
+      },
+    });
+
+    expect(result).toMatchObject({
+      kind: "send",
+      channel: "workspace",
+    });
+    expect(sentText).toEqual(["v2026.5.20 release note"]);
+    expect(JSON.stringify(result.payload)).not.toContain("turn2view0");
   });
 
   it.each([

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -37,6 +37,7 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "../../shared/string-coerce.js";
+import { stripUnsupportedCitationControlMarkers } from "../../shared/text/citation-control-markers.js";
 import {
   GATEWAY_CLIENT_MODES,
   GATEWAY_CLIENT_NAMES,
@@ -798,7 +799,7 @@ async function buildSendPayloadParts(params: {
   mergedMediaUrls.length = 0;
   mergedMediaUrls.push(...normalizedMediaUrls);
 
-  message = parsed.text;
+  message = stripUnsupportedCitationControlMarkers(parsed.text);
   actionParams.message = message;
   if (!actionParams.replyTo && parsed.replyToId) {
     actionParams.replyTo = parsed.replyToId;

--- a/src/infra/outbound/payloads.test.ts
+++ b/src/infra/outbound/payloads.test.ts
@@ -52,6 +52,27 @@ describe("normalizeReplyPayloadsForDelivery", () => {
     ]);
   });
 
+  it("strips unsupported citation control markers from reply payload text", () => {
+    const payloads: ReplyPayload[] = [{ text: "v2026.5.20 release note citeturn2view0" }];
+
+    expect(normalizeReplyPayloadsForDelivery(payloads)).toMatchObject([
+      { text: "v2026.5.20 release note" },
+    ]);
+    expect(resolveMirrorProjection(payloads).text).toBe("v2026.5.20 release note");
+    expect(normalizeOutboundPayloadsForJson(payloads)).toMatchObject([
+      { text: "v2026.5.20 release note" },
+    ]);
+  });
+
+  it("suppresses silent replies after removing citation control markers", () => {
+    expect(
+      normalizeReplyPayloadsForDelivery([
+        { text: "NO_REPLY citeturn2view0" },
+        { text: '{"action":"NO_REPLY"} citeturn2view0' },
+      ]),
+    ).toStrictEqual([]);
+  });
+
   it("drops silent payloads without media and suppresses reasoning payloads", () => {
     expect(
       normalizeReplyPayloadsForDelivery([
@@ -602,6 +623,14 @@ describe("summarizeOutboundPayloadForTransport", () => {
     expect(summary.hookContent).toBeUndefined();
   });
 
+  it("strips unsupported citation control markers from transport text", () => {
+    const summary = summarizeOutboundPayloadForTransport({
+      text: "v2026.5.20 release note citeturn2view0",
+    });
+
+    expect(summary.text).toBe("v2026.5.20 release note");
+  });
+
   it("surfaces spokenText only as hook content for audio-only payloads", () => {
     const summary = summarizeOutboundPayloadForTransport({
       mediaUrl: "/tmp/reply.opus",
@@ -613,6 +642,17 @@ describe("summarizeOutboundPayloadForTransport", () => {
     expect(summary.hookContent).toBe("Hi Ivy, good morning.");
     expect(summary.mediaUrls).toEqual(["/tmp/reply.opus"]);
     expect(summary.audioAsVoice).toBe(true);
+  });
+
+  it("strips unsupported citation control markers from hook-only spoken text", () => {
+    const summary = summarizeOutboundPayloadForTransport({
+      mediaUrl: "/tmp/reply.opus",
+      audioAsVoice: true,
+      spokenText: "Hi Ivy citeturn2view0",
+    });
+
+    expect(summary.text).toBe("");
+    expect(summary.hookContent).toBe("Hi Ivy");
   });
 
   it("ignores blank spokenText", () => {

--- a/src/infra/outbound/payloads.ts
+++ b/src/infra/outbound/payloads.ts
@@ -19,6 +19,7 @@ import {
   type ReplyPayloadDelivery,
 } from "../../interactive/payload.js";
 import { type SilentReplyConversationType } from "../../shared/silent-reply-policy.js";
+import { stripUnsupportedCitationControlMarkers } from "../../shared/text/citation-control-markers.js";
 
 export type NormalizedOutboundPayload = {
   text: string;
@@ -220,11 +221,14 @@ function createOutboundPayloadPlanEntry(
     explicitMediaUrls,
     explicitMediaUrl ? [explicitMediaUrl] : undefined,
   );
-  const parsedText = parsed.text ?? "";
+  const strippedText = stripUnsupportedCitationControlMarkers(parsed.text ?? "");
+  const strippedParsed =
+    strippedText === (parsed.text ?? "") ? parsed : parseReplyDirectives(strippedText);
+  const parsedText = strippedParsed.text ?? "";
   if (isSuppressedRelayStatusText(parsedText) && mergedMedia.length === 0) {
     return null;
   }
-  const isSilent = parsed.isSilent && mergedMedia.length === 0;
+  const isSilent = strippedParsed.isSilent && mergedMedia.length === 0;
   const hasMultipleMedia = (explicitMediaUrls?.length ?? 0) > 1;
   const resolvedMediaUrl = hasMultipleMedia ? undefined : explicitMediaUrl;
   const normalizedPayload: ReplyPayload = {
@@ -358,16 +362,21 @@ export function summarizeOutboundPayloadForTransport(
   payload: ReplyPayload,
 ): NormalizedOutboundPayload {
   const parts = resolveSendableOutboundReplyParts(payload);
-  const spokenText = payload.spokenText?.trim() ? payload.spokenText : undefined;
+  const text = stripUnsupportedCitationControlMarkers(parts.text);
+  const strippedSpokenText =
+    typeof payload.spokenText === "string"
+      ? stripUnsupportedCitationControlMarkers(payload.spokenText)
+      : undefined;
+  const spokenText = strippedSpokenText?.trim() ? strippedSpokenText : undefined;
   return {
-    text: parts.text,
+    text,
     mediaUrls: parts.mediaUrls,
     audioAsVoice: payload.audioAsVoice === true ? true : undefined,
     presentation: payload.presentation,
     delivery: payload.delivery,
     interactive: payload.interactive,
     channelData: payload.channelData,
-    ...(parts.text || !spokenText ? {} : { hookContent: spokenText }),
+    ...(text || !spokenText ? {} : { hookContent: spokenText }),
   };
 }
 

--- a/src/plugins/plugin-metadata-snapshot.types.ts
+++ b/src/plugins/plugin-metadata-snapshot.types.ts
@@ -1,5 +1,5 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import type { InstalledPluginIndex } from "./installed-plugin-index.js";
+import type { InstalledPluginIndex } from "./installed-plugin-index-types.js";
 import type { PluginManifestRecord, PluginManifestRegistry } from "./manifest-registry.js";
 import type { PluginDiagnostic } from "./manifest-types.js";
 

--- a/src/shared/text/citation-control-markers.test.ts
+++ b/src/shared/text/citation-control-markers.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { stripUnsupportedCitationControlMarkers } from "./citation-control-markers.js";
+
+describe("stripUnsupportedCitationControlMarkers", () => {
+  it("removes citation control markers and line-end spacing they leave behind", () => {
+    expect(stripUnsupportedCitationControlMarkers("v2026.5.20 citeturn2view0")).toBe(
+      "v2026.5.20",
+    );
+  });
+
+  it("preserves unrelated trailing whitespace", () => {
+    expect(stripUnsupportedCitationControlMarkers("hard break  \nnext")).toBe("hard break  \nnext");
+  });
+});

--- a/src/shared/text/citation-control-markers.ts
+++ b/src/shared/text/citation-control-markers.ts
@@ -1,0 +1,8 @@
+const UNSUPPORTED_CITATION_CONTROL_MARKER_RE = /cite(?:[^]*)?/g;
+const TRAILING_UNSUPPORTED_CITATION_CONTROL_MARKER_RE = /[ \t]*cite(?:[^]*)?(?=\r?\n|$)/g;
+
+export function stripUnsupportedCitationControlMarkers(text: string): string {
+  return text
+    .replace(TRAILING_UNSUPPORTED_CITATION_CONTROL_MARKER_RE, "")
+    .replace(UNSUPPORTED_CITATION_CONTROL_MARKER_RE, "");
+}

--- a/ui/src/ui/markdown.test.ts
+++ b/ui/src/ui/markdown.test.ts
@@ -27,6 +27,16 @@ describe("toSanitizedMarkdownHtml", () => {
     );
   });
 
+  it("strips unsupported citation control markers before display", () => {
+    const html = toSanitizedMarkdownHtml(
+      "v2026.5.20 release note citeturn2view0\n\nStill readable.",
+    );
+
+    expect(html).toBe("<p>v2026.5.20 release note</p>\n<p>Still readable.</p>\n");
+    expect(html).not.toContain("cite");
+    expect(html).not.toContain("turn2view0");
+  });
+
   // ── Additional tests for markdown-it migration ──
   describe("www autolinks", () => {
     it("links www.example.com", () => {

--- a/ui/src/ui/markdown.ts
+++ b/ui/src/ui/markdown.ts
@@ -16,6 +16,7 @@ import xml from "highlight.js/lib/languages/xml";
 import yaml from "highlight.js/lib/languages/yaml";
 import MarkdownIt from "markdown-it";
 import markdownItTaskLists from "markdown-it-task-lists";
+import { stripUnsupportedCitationControlMarkers } from "../../../src/shared/text/citation-control-markers.js";
 import { i18n, t } from "../i18n/index.ts";
 import { truncateText } from "./format.ts";
 import { normalizeLowercaseStringOrEmpty } from "./string-coerce.ts";
@@ -576,7 +577,7 @@ md.renderer.rules.code_block = (tokens, idx) => {
 };
 
 export function toSanitizedMarkdownHtml(markdown: string): string {
-  const input = markdown.trim();
+  const input = stripUnsupportedCitationControlMarkers(markdown).trim();
   if (!input) {
     return "";
   }


### PR DESCRIPTION
## Summary

- Strip unsupported GPT/Codex web-search citation control markers before outbound text reaches WebChat or external channel transports.
- Apply the same cleanup to normalized payload plans, outbound JSON mirrors, transport summaries, hook-only spoken text, and WebChat markdown fallback rendering.
- Add regression coverage for ordinary text, line-end whitespace, silent replies with citation suffixes, internal WebChat replies, normal channel sends, and UI markdown rendering.
- Keep the architecture gate green by importing the plugin metadata snapshot type from the leaf type module instead of the installed-plugin barrel.

## Verification

- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/shared/text/citation-control-markers.test.ts src/infra/outbound/payloads.test.ts src/infra/outbound/message-action-runner.send-validation.test.ts ui/src/ui/markdown.test.ts src/infra/outbound/sanitize-text.test.ts`
- `pnpm check:test-types`
- `pnpm check:architecture`
- `git diff --check origin/main..HEAD`
- `AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview`

## Real behavior proof

Behavior addressed: GPT/Codex web-search citation control markers such as `citeturn0search0` are removed before users see replies in WebChat, Telegram, Discord, Slack, or other message channels.

Real environment tested: Maintainer-reviewed local OpenClaw checkout rebased onto current `origin/main`; proof is focused at the shared outbound delivery and WebChat rendering boundaries. Live external Telegram/Desktop proof was not run for this rewrite; maintainer is applying `proof: override` for this narrow cross-channel text sanitation fix.

Exact steps or command run after this patch: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/shared/text/citation-control-markers.test.ts src/infra/outbound/payloads.test.ts src/infra/outbound/message-action-runner.send-validation.test.ts ui/src/ui/markdown.test.ts src/infra/outbound/sanitize-text.test.ts`; `pnpm check:test-types`; `pnpm check:architecture`; `git diff --check origin/main..HEAD`; `AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview`.

Evidence after fix: Focused Vitest run passed 5 files / 146 tests; `check:test-types` passed; `check:architecture` passed with 0 import cycles and deprecated API/JSDoc guards green; autoreview reported no accepted/actionable findings.

Observed result after fix: Citation marker text is stripped from normalized outbound delivery text, outbound mirrors/JSON, transport summaries, internal WebChat source replies, normal channel sends, hook-only spoken text, and WebChat markdown fallback rendering. Silent replies with citation suffixes remain silent.

What was not tested: No live Telegram/Discord/Slack/WebChat browser session was run for this maintainer rewrite.
