### PR TITLE
fix(telegram): dedupe replayed message dispatches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Docs: https://docs.openclaw.ai
 - Memory-core/dreaming: reuse stable narrative subagent session keys per workspace and phase while keeping per-run idempotency and bounded cleanup, so stale `dreaming-narrative-*` sessions do not accumulate. Fixes #68252, #69187, and #70402. (#70464) Thanks @chiyouYCH.
 - Trajectory/support: tolerate partial skill snapshot entries when building support metadata so rejected skill path scans no longer abort trajectory capture. (#71185) Thanks @lukeboyett.
 - Telegram: honor `channels.telegram.pollingStallThresholdMs` in the default isolated polling path, restarting silent workers instead of leaving inbound updates wedged. Fixes #83950. (#84861) Thanks @joshavant.
+- Telegram: dedupe replayed message dispatches by Telegram chat/message identity so isolated-ingress replays do not trigger duplicate model dispatches. Fixes #84886. (#85208) Thanks @joshavant.
 - Slack: suppress reasoning payloads before reply delivery and dispatch accounting, so Slack monitor, slash-command, fallback, and direct reply paths do not leak model reasoning. Fixes #84319. (#84322) Thanks @ffluk3 and @joshavant.
 - Slack: deliver native plugin approval prompts and updates when Slack native approvals are enabled, while keeping plugin approval authorization separate from exec approvers.
 - Agents/Pi: disable the embedded pi-coding-agent runtime auto-retry so OpenClaw's own retry and failover loop does not replay failed tool calls through a nested SDK retry. Fixes #73781. (#74434) Thanks @yelog.

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -1117,6 +1117,7 @@ export const registerTelegramHandlers = ({
     options?: TelegramMessageContextOptions;
     dispatchDedupeKeys?: string[];
   }) => {
+    let dispatchDedupeCommitted = false;
     try {
       const replyChainNodes = buildReplyChainForMessage(params.msg);
       const { replyMedia, replyChain } = await resolveReplyMediaForChain(
@@ -1136,14 +1137,20 @@ export const registerTelegramHandlers = ({
         replyMedia,
         replyChain,
         promptContext,
+        {
+          onDispatchStart: async () => {
+            await commitDispatchDedupeKeys(params.dispatchDedupeKeys ?? []);
+            dispatchDedupeCommitted = true;
+          },
+        },
       );
-      if (dispatched) {
-        await commitDispatchDedupeKeys(params.dispatchDedupeKeys ?? []);
-      } else {
+      if (!dispatched && !dispatchDedupeCommitted) {
         releaseDispatchDedupeKeys(params.dispatchDedupeKeys ?? []);
       }
     } catch (err) {
-      releaseDispatchDedupeKeys(params.dispatchDedupeKeys ?? [], err);
+      if (!dispatchDedupeCommitted) {
+        releaseDispatchDedupeKeys(params.dispatchDedupeKeys ?? [], err);
+      }
       throw err;
     }
   };

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -126,6 +126,12 @@ import {
   type TelegramReplyChainEntry,
 } from "./message-cache.js";
 import {
+  claimTelegramMessageDispatchReplay,
+  commitTelegramMessageDispatchReplay,
+  createTelegramMessageDispatchReplayGuard,
+  releaseTelegramMessageDispatchReplay,
+} from "./message-dispatch-dedupe.js";
+import {
   buildModelsKeyboard,
   buildProviderKeyboard,
   calculateTotalPages,
@@ -192,6 +198,7 @@ export const registerTelegramHandlers = ({
     effectiveDmAllow: NormalizedAllowFrom;
     groupConfig?: TelegramGroupConfig;
     topicConfig?: TelegramTopicConfig;
+    dispatchDedupeKeys: string[];
   };
 
   const mediaGroupBuffer = new Map<string, BufferedMediaGroupEntry>();
@@ -201,12 +208,19 @@ export const registerTelegramHandlers = ({
       telegramDeps.resolveStorePath(cfg.session?.store),
     ),
   });
+  const messageDispatchReplayGuard = createTelegramMessageDispatchReplayGuard({
+    storePath: telegramDeps.resolveStorePath(cfg.session?.store),
+    onDiskError: (error) => {
+      runtime.error?.(danger(`[telegram] message dispatch dedupe store failed: ${String(error)}`));
+    },
+  });
 
   type TextFragmentEntry = {
     key: string;
     threadId?: number;
     messages: Array<{ msg: Message; ctx: TelegramContext; receivedAtMs: number }>;
     promptContextMinTimestampMs?: number;
+    dispatchDedupeKeys: string[];
     timer: ReturnType<typeof setTimeout>;
   };
   const textFragmentBuffer = new Map<string, TextFragmentEntry>();
@@ -240,6 +254,7 @@ export const registerTelegramHandlers = ({
     botUsername?: string;
     threadId?: number;
     promptContextMinTimestampMs?: number;
+    dispatchDedupeKeys: string[];
   };
   const normalizePromptContextMinTimestampMs = (timestampMs?: number) =>
     typeof timestampMs === "number" && Number.isFinite(timestampMs) ? timestampMs : undefined;
@@ -261,6 +276,43 @@ export const registerTelegramHandlers = ({
       latest = latest === undefined ? normalized : Math.max(latest, normalized);
     }
     return latest;
+  };
+  const mergeDispatchDedupeKeys = (...groups: Array<readonly string[] | undefined>) => [
+    ...new Set(
+      groups
+        .flatMap((group) => group ?? [])
+        .map((key) => key.trim())
+        .filter(Boolean),
+    ),
+  ];
+  const releaseDispatchDedupeKeys = (keys: readonly string[], error?: unknown) => {
+    releaseTelegramMessageDispatchReplay({
+      guard: messageDispatchReplayGuard,
+      accountId,
+      keys,
+      error,
+    });
+  };
+  const commitDispatchDedupeKeys = async (keys: readonly string[]) => {
+    await commitTelegramMessageDispatchReplay({
+      guard: messageDispatchReplayGuard,
+      accountId,
+      keys,
+    });
+  };
+  const claimMessageDispatchDedupe = async (
+    msg: Message,
+  ): Promise<{ process: true; keys: string[] } | { process: false }> => {
+    const claim = await claimTelegramMessageDispatchReplay({
+      guard: messageDispatchReplayGuard,
+      accountId,
+      msg,
+    });
+    if (claim.kind === "duplicate") {
+      logVerbose(`telegram dispatch dedupe: skipped message ${msg.chat.id}:${msg.message_id}`);
+      return { process: false };
+    }
+    return { process: true, keys: claim.kind === "claimed" ? [claim.key] : [] };
   };
   const resolveTelegramDebounceLane = (msg: Message): TelegramDebounceLane => {
     const forwardMeta = msg as {
@@ -459,10 +511,17 @@ export const registerTelegramHandlers = ({
         return;
       }
       if (entries.length === 1) {
-        await processMessageWithReplyChain(last.ctx, last.msg, last.allMedia, last.storeAllowFrom, {
-          receivedAtMs: last.receivedAtMs,
-          ingressBuffer: "inbound-debounce",
-          ...promptContextBoundaryOptions(last.promptContextMinTimestampMs),
+        await processMessageWithReplyChain({
+          ctx: last.ctx,
+          msg: last.msg,
+          allMedia: last.allMedia,
+          storeAllowFrom: last.storeAllowFrom,
+          options: {
+            receivedAtMs: last.receivedAtMs,
+            ingressBuffer: "inbound-debounce",
+            ...promptContextBoundaryOptions(last.promptContextMinTimestampMs),
+          },
+          dispatchDedupeKeys: last.dispatchDedupeKeys,
         });
         return;
       }
@@ -486,18 +545,21 @@ export const registerTelegramHandlers = ({
       });
       const messageIdOverride = last.msg.message_id ? String(last.msg.message_id) : undefined;
       const syntheticCtx = buildSyntheticContext(baseCtx, syntheticMessage);
-      await processMessageWithReplyChain(
-        syntheticCtx,
-        syntheticMessage,
-        combinedMedia,
-        first.storeAllowFrom,
-        {
+      await processMessageWithReplyChain({
+        ctx: syntheticCtx,
+        msg: syntheticMessage,
+        allMedia: combinedMedia,
+        storeAllowFrom: first.storeAllowFrom,
+        options: {
           ...(messageIdOverride ? { messageIdOverride } : {}),
           receivedAtMs: first.receivedAtMs,
           ingressBuffer: "inbound-debounce",
           ...promptContextBoundaryOptions(promptContextMinTimestampMs),
         },
-      );
+        dispatchDedupeKeys: mergeDispatchDedupeKeys(
+          ...entries.map((entry) => entry.dispatchDedupeKeys),
+        ),
+      });
     },
     onError: (err, items) => {
       runtime.error?.(danger(`telegram debounce flush failed: ${String(err)}`));
@@ -514,6 +576,11 @@ export const registerTelegramHandlers = ({
             logVerbose(`telegram: error fallback send failed: ${String(sendErr)}`);
           });
       }
+    },
+    onCancel: (items) => {
+      releaseDispatchDedupeKeys(
+        mergeDispatchDedupeKeys(...items.map((item) => item.dispatchDedupeKeys)),
+      );
     },
   });
 
@@ -756,6 +823,7 @@ export const registerTelegramHandlers = ({
       const captionMsg = entry.messages.find((m) => m.msg.caption || m.msg.text);
       const primaryEntry = captionMsg ?? entry.messages[0];
       if (!primaryEntry) {
+        releaseDispatchDedupeKeys(entry.dispatchDedupeKeys);
         return;
       }
 
@@ -775,6 +843,7 @@ export const registerTelegramHandlers = ({
           topicConfig: entry.topicConfig,
         })
       ) {
+        releaseDispatchDedupeKeys(entry.dispatchDedupeKeys);
         return;
       }
 
@@ -829,14 +898,16 @@ export const registerTelegramHandlers = ({
         }).catch(() => {});
       }
 
-      await processMessageWithReplyChain(
-        primaryEntry.ctx,
-        primaryEntry.msg,
+      await processMessageWithReplyChain({
+        ctx: primaryEntry.ctx,
+        msg: primaryEntry.msg,
         allMedia,
-        entry.storeAllowFrom,
-        promptContextBoundaryOptions(entry.promptContextMinTimestampMs),
-      );
+        storeAllowFrom: entry.storeAllowFrom,
+        options: promptContextBoundaryOptions(entry.promptContextMinTimestampMs),
+        dispatchDedupeKeys: entry.dispatchDedupeKeys,
+      });
     } catch (err) {
+      releaseDispatchDedupeKeys(entry.dispatchDedupeKeys, err);
       runtime.error?.(danger(`media group handler failed: ${String(err)}`));
     }
   };
@@ -848,11 +919,13 @@ export const registerTelegramHandlers = ({
       const first = entry.messages[0];
       const last = entry.messages.at(-1);
       if (!first || !last) {
+        releaseDispatchDedupeKeys(entry.dispatchDedupeKeys);
         return;
       }
 
       const combinedText = entry.messages.map((m) => m.msg.text ?? "").join("");
       if (!combinedText.trim()) {
+        releaseDispatchDedupeKeys(entry.dispatchDedupeKeys);
         return;
       }
 
@@ -866,13 +939,21 @@ export const registerTelegramHandlers = ({
       const baseCtx = first.ctx;
 
       const syntheticCtx = buildSyntheticContext(baseCtx, syntheticMessage);
-      await processMessageWithReplyChain(syntheticCtx, syntheticMessage, [], storeAllowFrom, {
-        messageIdOverride: String(last.msg.message_id),
-        receivedAtMs: first.receivedAtMs,
-        ingressBuffer: "text-fragment",
-        ...promptContextBoundaryOptions(entry.promptContextMinTimestampMs),
+      await processMessageWithReplyChain({
+        ctx: syntheticCtx,
+        msg: syntheticMessage,
+        allMedia: [],
+        storeAllowFrom,
+        options: {
+          messageIdOverride: String(last.msg.message_id),
+          receivedAtMs: first.receivedAtMs,
+          ingressBuffer: "text-fragment",
+          ...promptContextBoundaryOptions(entry.promptContextMinTimestampMs),
+        },
+        dispatchDedupeKeys: entry.dispatchDedupeKeys,
       });
     } catch (err) {
+      releaseDispatchDedupeKeys(entry.dispatchDedupeKeys, err);
       runtime.error?.(danger(`text fragment handler failed: ${String(err)}`));
     }
   };
@@ -1028,25 +1109,43 @@ export const registerTelegramHandlers = ({
     return { replyMedia, replyChain };
   };
 
-  const processMessageWithReplyChain = async (
-    ctx: TelegramContext,
-    msg: Message,
-    allMedia: TelegramMediaRef[],
-    storeAllowFrom: string[],
-    options?: TelegramMessageContextOptions,
-  ) => {
-    const replyChainNodes = buildReplyChainForMessage(msg);
-    const { replyMedia, replyChain } = await resolveReplyMediaForChain(ctx, replyChainNodes);
-    const promptContext = buildPromptContextForMessage(msg, replyChainNodes, options);
-    await processMessage(
-      ctx,
-      allMedia,
-      storeAllowFrom,
-      options,
-      replyMedia,
-      replyChain,
-      promptContext,
-    );
+  const processMessageWithReplyChain = async (params: {
+    ctx: TelegramContext;
+    msg: Message;
+    allMedia: TelegramMediaRef[];
+    storeAllowFrom: string[];
+    options?: TelegramMessageContextOptions;
+    dispatchDedupeKeys?: string[];
+  }) => {
+    try {
+      const replyChainNodes = buildReplyChainForMessage(params.msg);
+      const { replyMedia, replyChain } = await resolveReplyMediaForChain(
+        params.ctx,
+        replyChainNodes,
+      );
+      const promptContext = buildPromptContextForMessage(
+        params.msg,
+        replyChainNodes,
+        params.options,
+      );
+      const dispatched = await processMessage(
+        params.ctx,
+        params.allMedia,
+        params.storeAllowFrom,
+        params.options,
+        replyMedia,
+        replyChain,
+        promptContext,
+      );
+      if (dispatched) {
+        await commitDispatchDedupeKeys(params.dispatchDedupeKeys ?? []);
+      } else {
+        releaseDispatchDedupeKeys(params.dispatchDedupeKeys ?? []);
+      }
+    } catch (err) {
+      releaseDispatchDedupeKeys(params.dispatchDedupeKeys ?? [], err);
+      throw err;
+    }
   };
 
   const shouldSkipGroupMessage = (params: {
@@ -1528,6 +1627,7 @@ export const registerTelegramHandlers = ({
     sendOversizeWarning: boolean;
     oversizeLogMessage: string;
     promptContextMinTimestampMs?: number;
+    dispatchDedupeKeys: string[];
   }) => {
     const {
       ctx,
@@ -1547,6 +1647,7 @@ export const registerTelegramHandlers = ({
       sendOversizeWarning,
       oversizeLogMessage,
       promptContextMinTimestampMs,
+      dispatchDedupeKeys,
     } = params;
 
     const messageText = getTelegramTextParts(msg).text;
@@ -1616,6 +1717,10 @@ export const registerTelegramHandlers = ({
               existing.promptContextMinTimestampMs,
               promptContextMinTimestampMs,
             );
+            existing.dispatchDedupeKeys = mergeDispatchDedupeKeys(
+              existing.dispatchDedupeKeys,
+              dispatchDedupeKeys,
+            );
             scheduleTextFragmentFlush(existing);
             return;
           }
@@ -1632,6 +1737,7 @@ export const registerTelegramHandlers = ({
         const entry: TextFragmentEntry = {
           key,
           messages: [{ msg, ctx, receivedAtMs: nowMs }],
+          dispatchDedupeKeys,
           ...promptContextBoundaryOptions(promptContextMinTimestampMs),
           timer: setTimeout(() => {}, TELEGRAM_TEXT_FRAGMENT_MAX_GAP_MS),
         };
@@ -1647,6 +1753,7 @@ export const registerTelegramHandlers = ({
       if (existing) {
         clearTimeout(existing.timer);
         textFragmentBuffer.delete(key);
+        releaseDispatchDedupeKeys(existing.dispatchDedupeKeys);
       }
     }
 
@@ -1662,6 +1769,10 @@ export const registerTelegramHandlers = ({
         existing.promptContextMinTimestampMs = latestPromptContextMinTimestampMs(
           existing.promptContextMinTimestampMs,
           promptContextMinTimestampMs,
+        );
+        existing.dispatchDedupeKeys = mergeDispatchDedupeKeys(
+          existing.dispatchDedupeKeys,
+          dispatchDedupeKeys,
         );
         existing.timer = setTimeout(async () => {
           mediaGroupBuffer.delete(mediaGroupKey);
@@ -1682,6 +1793,7 @@ export const registerTelegramHandlers = ({
           effectiveDmAllow,
           groupConfig,
           topicConfig,
+          dispatchDedupeKeys,
           ...promptContextBoundaryOptions(promptContextMinTimestampMs),
           timer: setTimeout(async () => {
             mediaGroupBuffer.delete(mediaGroupKey);
@@ -1711,6 +1823,7 @@ export const registerTelegramHandlers = ({
         topicConfig,
       })
     ) {
+      releaseDispatchDedupeKeys(dispatchDedupeKeys);
       return;
     }
 
@@ -1738,6 +1851,7 @@ export const registerTelegramHandlers = ({
           }).catch(() => {});
         }
         logger.warn({ chatId, error: String(mediaErr) }, oversizeLogMessage);
+        releaseDispatchDedupeKeys(dispatchDedupeKeys);
         return;
       }
       logger.warn({ chatId, error: String(mediaErr) }, "media fetch failed");
@@ -1752,6 +1866,7 @@ export const registerTelegramHandlers = ({
             },
           }),
       }).catch(() => {});
+      releaseDispatchDedupeKeys(dispatchDedupeKeys);
       return;
     }
 
@@ -1760,6 +1875,7 @@ export const registerTelegramHandlers = ({
     const hasText = Boolean(getTelegramTextParts(msg).text.trim());
     if (msg.sticker && !media && !hasText) {
       logVerbose("telegram: skipping sticker-only message (unsupported sticker type)");
+      releaseDispatchDedupeKeys(dispatchDedupeKeys);
       return;
     }
 
@@ -1807,6 +1923,7 @@ export const registerTelegramHandlers = ({
       debounceLane,
       botUsername,
       ...promptContextBoundaryOptions(promptContextMinTimestampMs),
+      dispatchDedupeKeys,
     });
   };
   bot.on("callback_query", async (ctx) => {
@@ -2088,9 +2205,15 @@ export const registerTelegramHandlers = ({
             text: `Multi-select submitted: ${selected.length > 0 ? selected.join(", ") : "none"}`,
             isForum,
           });
-          await processMessageWithReplyChain(synthetic.ctx, synthetic.message, [], storeAllowFrom, {
-            forceWasMentioned: true,
-            messageIdOverride: callback.id,
+          await processMessageWithReplyChain({
+            ctx: synthetic.ctx,
+            msg: synthetic.message,
+            allMedia: [],
+            storeAllowFrom,
+            options: {
+              forceWasMentioned: true,
+              messageIdOverride: callback.id,
+            },
           });
           return;
         }
@@ -2113,9 +2236,15 @@ export const registerTelegramHandlers = ({
           text: `Single-select submitted: ${managedSelectCallback.value}`,
           isForum,
         });
-        await processMessageWithReplyChain(synthetic.ctx, synthetic.message, [], storeAllowFrom, {
-          forceWasMentioned: true,
-          messageIdOverride: callback.id,
+        await processMessageWithReplyChain({
+          ctx: synthetic.ctx,
+          msg: synthetic.message,
+          allMedia: [],
+          storeAllowFrom,
+          options: {
+            forceWasMentioned: true,
+            messageIdOverride: callback.id,
+          },
         });
         return;
       }
@@ -2473,10 +2602,16 @@ export const registerTelegramHandlers = ({
         text: nativeCallbackCommand ?? data,
       });
       const syntheticCtx = buildSyntheticContext(ctx, syntheticMessage);
-      await processMessageWithReplyChain(syntheticCtx, syntheticMessage, [], storeAllowFrom, {
-        ...(nativeCallbackCommand ? { commandSource: "native" as const } : {}),
-        forceWasMentioned: true,
-        messageIdOverride: callback.id,
+      await processMessageWithReplyChain({
+        ctx: syntheticCtx,
+        msg: syntheticMessage,
+        allMedia: [],
+        storeAllowFrom,
+        options: {
+          ...(nativeCallbackCommand ? { commandSource: "native" as const } : {}),
+          forceWasMentioned: true,
+          messageIdOverride: callback.id,
+        },
       });
     } catch (err) {
       if (err instanceof TelegramRetryableCallbackError) {
@@ -2616,6 +2751,7 @@ export const registerTelegramHandlers = ({
   };
 
   const handleInboundMessageLike = async (event: InboundTelegramEvent) => {
+    let dispatchDedupeKeys: string[] = [];
     try {
       if (shouldSkipUpdate(event.ctxForDedupe)) {
         return;
@@ -2703,6 +2839,11 @@ export const registerTelegramHandlers = ({
         }).sessionEntry?.sessionStartedAt,
       );
 
+      const dispatchDedupe = await claimMessageDispatchDedupe(event.msg);
+      if (!dispatchDedupe.process) {
+        return;
+      }
+      dispatchDedupeKeys = dispatchDedupe.keys;
       recordMessageForReplyChain(event.msg, resolvedThreadId ?? dmThreadId);
       await processInboundMessage({
         ctx: event.ctx,
@@ -2721,9 +2862,11 @@ export const registerTelegramHandlers = ({
         topicConfig,
         sendOversizeWarning: event.sendOversizeWarning,
         oversizeLogMessage: event.oversizeLogMessage,
+        dispatchDedupeKeys,
         ...promptContextBoundaryOptions(promptContextMinTimestampMs),
       });
     } catch (err) {
+      releaseDispatchDedupeKeys(dispatchDedupeKeys, err);
       runtime.error?.(danger(`${event.errorMessage}: ${String(err)}`));
     }
   };

--- a/extensions/telegram/src/bot-message.test.ts
+++ b/extensions/telegram/src/bot-message.test.ts
@@ -73,7 +73,7 @@ describe("telegram bot message processor", () => {
   async function processSampleMessage(
     processMessage: ReturnType<typeof createTelegramMessageProcessor>,
   ) {
-    await processMessage(
+    return await processMessage(
       {
         message: {
           chat: { id: 123, type: "private", title: "chat" },
@@ -126,7 +126,7 @@ describe("telegram bot message processor", () => {
     );
 
     const processMessage = createTelegramMessageProcessor(baseDeps);
-    await processSampleMessage(processMessage);
+    await expect(processSampleMessage(processMessage)).resolves.toBe(true);
 
     expect(sendTyping).toHaveBeenCalledTimes(1);
     expect(dispatchTelegramMessage).toHaveBeenCalledTimes(1);
@@ -154,7 +154,7 @@ describe("telegram bot message processor", () => {
     );
 
     const processMessage = createTelegramMessageProcessor(baseDeps);
-    await processSampleMessage(processMessage);
+    await expect(processSampleMessage(processMessage)).resolves.toBe(true);
 
     expect(sendTyping).not.toHaveBeenCalled();
     expect(dispatchTelegramMessage).toHaveBeenCalledTimes(1);
@@ -163,7 +163,7 @@ describe("telegram bot message processor", () => {
   it("skips dispatch when no context is produced", async () => {
     buildTelegramMessageContext.mockResolvedValue(null);
     const processMessage = createTelegramMessageProcessor(baseDeps);
-    await processSampleMessage(processMessage);
+    await expect(processSampleMessage(processMessage)).resolves.toBe(false);
     expect(dispatchTelegramMessage).not.toHaveBeenCalled();
     expect(telegramInboundInfo).not.toHaveBeenCalled();
   });
@@ -197,7 +197,7 @@ describe("telegram bot message processor", () => {
     );
 
     const processMessage = createTelegramMessageProcessor(baseDeps);
-    await processSampleMessage(processMessage);
+    await expect(processSampleMessage(processMessage)).resolves.toBe(true);
 
     expect(sendTyping).toHaveBeenCalledTimes(1);
     expect(dispatchTelegramMessage).toHaveBeenCalledTimes(1);
@@ -213,7 +213,7 @@ describe("telegram bot message processor", () => {
       },
       sendMessage,
     );
-    await expect(processSampleMessage(processMessage)).resolves.toBeUndefined();
+    await expect(processSampleMessage(processMessage)).resolves.toBe(true);
 
     expect(sendMessage).toHaveBeenCalledWith(
       123,
@@ -235,7 +235,7 @@ describe("telegram bot message processor", () => {
       },
       sendMessage,
     );
-    await expect(processSampleMessage(processMessage)).resolves.toBeUndefined();
+    await expect(processSampleMessage(processMessage)).resolves.toBe(true);
 
     expect(sendMessage).toHaveBeenCalledWith(
       123,
@@ -253,7 +253,7 @@ describe("telegram bot message processor", () => {
       },
       sendMessage,
     );
-    await expect(processSampleMessage(processMessage)).resolves.toBeUndefined();
+    await expect(processSampleMessage(processMessage)).resolves.toBe(true);
 
     expect(sendMessage).toHaveBeenCalledWith(
       123,

--- a/extensions/telegram/src/bot-message.test.ts
+++ b/extensions/telegram/src/bot-message.test.ts
@@ -72,6 +72,7 @@ describe("telegram bot message processor", () => {
 
   async function processSampleMessage(
     processMessage: ReturnType<typeof createTelegramMessageProcessor>,
+    lifecycle?: import("./bot-message.js").TelegramMessageProcessorLifecycle,
   ) {
     return await processMessage(
       {
@@ -83,6 +84,10 @@ describe("telegram bot message processor", () => {
       [],
       [],
       {},
+      undefined,
+      undefined,
+      undefined,
+      lifecycle,
     );
   }
 
@@ -136,6 +141,40 @@ describe("telegram bot message processor", () => {
     expect(telegramInboundInfo).toHaveBeenCalledWith(
       "Inbound message telegram:123 -> @openclaw_bot (direct, 11 chars)",
     );
+  });
+
+  it("runs the dispatch-start lifecycle after context creation and before dispatch", async () => {
+    const sendTyping = vi.fn().mockResolvedValue(undefined);
+    const onDispatchStart = vi.fn(async () => undefined);
+    buildTelegramMessageContext.mockResolvedValue(
+      createMessageContext({
+        sendTyping,
+      }),
+    );
+
+    const processMessage = createTelegramMessageProcessor(baseDeps);
+    await expect(processSampleMessage(processMessage, { onDispatchStart })).resolves.toBe(true);
+
+    expect(sendTyping).toHaveBeenCalledTimes(1);
+    expect(onDispatchStart).toHaveBeenCalledTimes(1);
+    expect(dispatchTelegramMessage).toHaveBeenCalledTimes(1);
+    expect(sendTyping.mock.invocationCallOrder[0]).toBeLessThan(
+      onDispatchStart.mock.invocationCallOrder[0],
+    );
+    expect(onDispatchStart.mock.invocationCallOrder[0]).toBeLessThan(
+      dispatchTelegramMessage.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("does not run the dispatch-start lifecycle when no context is produced", async () => {
+    const onDispatchStart = vi.fn(async () => undefined);
+    buildTelegramMessageContext.mockResolvedValue(null);
+
+    const processMessage = createTelegramMessageProcessor(baseDeps);
+    await expect(processSampleMessage(processMessage, { onDispatchStart })).resolves.toBe(false);
+
+    expect(onDispatchStart).not.toHaveBeenCalled();
+    expect(dispatchTelegramMessage).not.toHaveBeenCalled();
   });
 
   it("does not send early typing cues for room events", async () => {

--- a/extensions/telegram/src/bot-message.ts
+++ b/extensions/telegram/src/bot-message.ts
@@ -146,7 +146,7 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
             (options?.ingressBuffer ? ` buffer=${options.ingressBuffer}` : ""),
         );
       }
-      return;
+      return false;
     }
     if (ingressDebugEnabled && ingressReceivedAtMs && ingressContextStartMs) {
       logVerbose(
@@ -200,5 +200,6 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
         );
       } catch {}
     }
+    return true;
   };
 };

--- a/extensions/telegram/src/bot-message.ts
+++ b/extensions/telegram/src/bot-message.ts
@@ -47,6 +47,10 @@ type TelegramMessageProcessorDeps = Omit<
   opts: Pick<TelegramBotOptions, "token">;
 };
 
+export type TelegramMessageProcessorLifecycle = {
+  onDispatchStart?: () => Promise<void> | void;
+};
+
 export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDeps) => {
   const {
     bot,
@@ -104,6 +108,7 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
     replyMedia?: TelegramMediaRef[],
     replyChain?: TelegramReplyChainEntry[],
     promptContext?: TelegramPromptContextEntry[],
+    lifecycle?: TelegramMessageProcessorLifecycle,
   ) => {
     const ingressReceivedAtMs =
       typeof options?.receivedAtMs === "number" && Number.isFinite(options.receivedAtMs)
@@ -171,6 +176,7 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
         mediaType: allMedia[0]?.contentType,
       }),
     );
+    await lifecycle?.onDispatchStart?.();
     try {
       await dispatchTelegramMessage({
         context,

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -429,7 +429,7 @@ export type RegisterTelegramHandlerParams = {
     replyMedia?: TelegramMediaRef[],
     replyChain?: import("./message-cache.js").TelegramReplyChainEntry[],
     promptContext?: import("./bot-message-context.types.js").TelegramPromptContextEntry[],
-  ) => Promise<void>;
+  ) => Promise<boolean>;
   logger: ReturnType<typeof getChildLogger>;
 };
 

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -429,6 +429,7 @@ export type RegisterTelegramHandlerParams = {
     replyMedia?: TelegramMediaRef[],
     replyChain?: import("./message-cache.js").TelegramReplyChainEntry[],
     promptContext?: import("./bot-message-context.types.js").TelegramPromptContextEntry[],
+    lifecycle?: import("./bot-message.js").TelegramMessageProcessorLifecycle,
   ) => Promise<boolean>;
   logger: ReturnType<typeof getChildLogger>;
 };

--- a/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
@@ -1,4 +1,5 @@
-import { rmSync } from "node:fs";
+import { readdirSync, rmSync } from "node:fs";
+import path from "node:path";
 import { buildChannelInboundEventContext } from "openclaw/plugin-sdk/channel-inbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { MockFn } from "openclaw/plugin-sdk/plugin-test-runtime";
@@ -477,11 +478,22 @@ export function makeForumGroupMessageCtx(params?: {
   });
 }
 
+function clearTelegramDispatchDedupeFilesForTest(): void {
+  const dir = path.dirname(sessionStorePath);
+  const prefix = `${path.basename(sessionStorePath)}.telegram-message-dispatch-`;
+  for (const entry of readdirSync(dir)) {
+    if (entry.startsWith(prefix)) {
+      rmSync(path.join(dir, entry), { force: true });
+    }
+  }
+}
+
 beforeEach(() => {
   getRuntimeConfig.mockReset();
   getRuntimeConfig.mockReturnValue(DEFAULT_TELEGRAM_TEST_CONFIG);
   sessionStoreEntries.value = {};
   rmSync(`${sessionStorePath}.telegram-messages.json`, { force: true });
+  clearTelegramDispatchDedupeFilesForTest();
   loadSessionStoreMock.mockReset();
   loadSessionStoreMock.mockImplementation(() => sessionStoreEntries.value);
   resolveStorePathMock.mockReset();

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -796,6 +796,27 @@ describe("createTelegramBot", () => {
         expect(sendMessageSpy.mock.calls.map((call) => String(call[1])).join("\n")).not.toContain(
           "reply:first",
         );
+
+        await runTelegramMiddlewareChain({
+          ctx: {
+            update: { update_id: 103 },
+            message: {
+              chat: { id: 7, type: "private" },
+              text: "first",
+              date: 1736380800,
+              message_id: 101,
+              from: { id: 42, first_name: "Ada" },
+            },
+            me: { username: "openclaw_bot" },
+            getFile: async () => ({}),
+          },
+          finalHandler: messageHandler,
+        });
+
+        const flushReplay = extractLatestDebounceFlush();
+        await flushReplay?.();
+        expect(startedBodies).toHaveLength(2);
+        expect(startedBodies[1]).toContain("first");
       } finally {
         setTimeoutSpy.mockRestore();
       }
@@ -1660,6 +1681,39 @@ describe("createTelegramBot", () => {
       me: { username: "openclaw_bot" },
       getFile: async () => ({}),
     });
+    expect(replySpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("dedupes a replayed Telegram message after handler recreation", async () => {
+    loadConfig.mockReturnValue({
+      channels: { telegram: { dmPolicy: "open", allowFrom: ["*"] } },
+    });
+
+    const replayedCtx = () => ({
+      update: { update_id: 8488601 },
+      message: {
+        chat: { id: 123, type: "private" },
+        from: { id: 456, username: "testuser" },
+        text: "replay me once",
+        date: 1736380800,
+        message_id: 42,
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    createTelegramBot({ token: "tok" });
+    await (getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>)(
+      replayedCtx(),
+    );
+    expect(replySpy).toHaveBeenCalledTimes(1);
+
+    onSpy.mockClear();
+    createTelegramBot({ token: "tok" });
+    await (getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>)(
+      replayedCtx(),
+    );
+
     expect(replySpy).toHaveBeenCalledTimes(1);
   });
 

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -178,6 +178,16 @@ function requireValue<T>(value: T | null | undefined, label: string): T {
   return value;
 }
 
+function createDeferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
 function requireRecord(value: unknown, label: string): Record<string, unknown> {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     throw new Error(`expected ${label} to be an object`);
@@ -1714,6 +1724,52 @@ describe("createTelegramBot", () => {
       replayedCtx(),
     );
 
+    expect(replySpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("dedupes a replayed Telegram message after handler recreation while dispatch is pending", async () => {
+    loadConfig.mockReturnValue({
+      channels: { telegram: { dmPolicy: "open", allowFrom: ["*"] } },
+    });
+
+    const firstDispatchStarted = createDeferred();
+    const finishFirstDispatch = createDeferred();
+    replySpy.mockImplementationOnce(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      await opts?.onReplyStart?.();
+      firstDispatchStarted.resolve();
+      await finishFirstDispatch.promise;
+      return undefined;
+    });
+
+    const replayedCtx = () => ({
+      update: { update_id: 8488602 },
+      message: {
+        chat: { id: 123, type: "private" },
+        from: { id: 456, username: "testuser" },
+        text: "replay while pending",
+        date: 1736380800,
+        message_id: 43,
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    createTelegramBot({ token: "tok" });
+    const firstRun = (getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>)(
+      replayedCtx(),
+    );
+    await firstDispatchStarted.promise;
+    expect(replySpy).toHaveBeenCalledTimes(1);
+
+    onSpy.mockClear();
+    createTelegramBot({ token: "tok" });
+    await (getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>)(
+      replayedCtx(),
+    );
+
+    expect(replySpy).toHaveBeenCalledTimes(1);
+    finishFirstDispatch.resolve();
+    await firstRun;
     expect(replySpy).toHaveBeenCalledTimes(1);
   });
 

--- a/extensions/telegram/src/message-dispatch-dedupe.test.ts
+++ b/extensions/telegram/src/message-dispatch-dedupe.test.ts
@@ -1,0 +1,115 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { Message } from "grammy/types";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildTelegramMessageDispatchReplayKey,
+  claimTelegramMessageDispatchReplay,
+  commitTelegramMessageDispatchReplay,
+  createTelegramMessageDispatchReplayGuard,
+  releaseTelegramMessageDispatchReplay,
+} from "./message-dispatch-dedupe.js";
+
+const tempDirs: string[] = [];
+
+function createStorePath(): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "openclaw-telegram-dispatch-dedupe-"));
+  tempDirs.push(dir);
+  return path.join(dir, "sessions.json");
+}
+
+function message(params?: { chatId?: number; messageId?: number }): Message {
+  return {
+    message_id: params?.messageId ?? 42,
+    date: 1736380800,
+    chat: { id: params?.chatId ?? 1234, type: "private" },
+  } as Message;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("Telegram message dispatch replay guard", () => {
+  it("keys messages by chat id and message id", () => {
+    expect(buildTelegramMessageDispatchReplayKey(message())).toBe(
+      JSON.stringify(["message", "1234", 42]),
+    );
+    expect(buildTelegramMessageDispatchReplayKey(message({ messageId: 0 }))).toBeNull();
+  });
+
+  it("persists committed dispatches across guard recreation", async () => {
+    const storePath = createStorePath();
+    const writer = createTelegramMessageDispatchReplayGuard({ storePath });
+    const first = await claimTelegramMessageDispatchReplay({
+      guard: writer,
+      accountId: "default",
+      msg: message(),
+    });
+
+    expect(first).toEqual({
+      kind: "claimed",
+      key: JSON.stringify(["message", "1234", 42]),
+    });
+    if (first.kind !== "claimed") {
+      throw new Error("expected initial claim");
+    }
+    await commitTelegramMessageDispatchReplay({
+      guard: writer,
+      accountId: "default",
+      keys: [first.key],
+    });
+
+    const reader = createTelegramMessageDispatchReplayGuard({ storePath });
+    await expect(
+      claimTelegramMessageDispatchReplay({
+        guard: reader,
+        accountId: "default",
+        msg: message(),
+      }),
+    ).resolves.toEqual({ kind: "duplicate" });
+  });
+
+  it("keeps accounts isolated and releases retryable pre-dispatch claims", async () => {
+    const storePath = createStorePath();
+    const guard = createTelegramMessageDispatchReplayGuard({ storePath });
+    const first = await claimTelegramMessageDispatchReplay({
+      guard,
+      accountId: "default",
+      msg: message(),
+    });
+    if (first.kind !== "claimed") {
+      throw new Error("expected initial claim");
+    }
+
+    await expect(
+      claimTelegramMessageDispatchReplay({
+        guard,
+        accountId: "work",
+        msg: message(),
+      }),
+    ).resolves.toEqual({
+      kind: "claimed",
+      key: first.key,
+    });
+
+    releaseTelegramMessageDispatchReplay({
+      guard,
+      accountId: "default",
+      keys: [first.key],
+    });
+    await expect(
+      claimTelegramMessageDispatchReplay({
+        guard,
+        accountId: "default",
+        msg: message(),
+      }),
+    ).resolves.toEqual({
+      kind: "claimed",
+      key: first.key,
+    });
+  });
+});

--- a/extensions/telegram/src/message-dispatch-dedupe.ts
+++ b/extensions/telegram/src/message-dispatch-dedupe.ts
@@ -1,0 +1,106 @@
+import path from "node:path";
+import type { Message } from "grammy/types";
+import { createClaimableDedupe, type ClaimableDedupe } from "openclaw/plugin-sdk/persistent-dedupe";
+
+const TELEGRAM_MESSAGE_DISPATCH_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const TELEGRAM_MESSAGE_DISPATCH_MEMORY_MAX = 5000;
+const TELEGRAM_MESSAGE_DISPATCH_FILE_MAX = 50_000;
+
+export type TelegramMessageDispatchReplayGuard = ClaimableDedupe;
+
+export type TelegramMessageDispatchClaim =
+  | { kind: "claimed"; key: string }
+  | { kind: "duplicate" }
+  | { kind: "invalid" };
+
+function sanitizeFileSegment(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return "default";
+  }
+  return trimmed.replace(/[^a-zA-Z0-9_-]/g, "_");
+}
+
+export function buildTelegramMessageDispatchReplayKey(msg: Message): string | null {
+  const chatId = msg.chat?.id;
+  const messageId = msg.message_id;
+  if (chatId == null || typeof messageId !== "number" || messageId <= 0) {
+    return null;
+  }
+  return JSON.stringify(["message", String(chatId), messageId]);
+}
+
+export function createTelegramMessageDispatchReplayGuard(params: {
+  storePath: string;
+  onDiskError?: (error: unknown) => void;
+}): TelegramMessageDispatchReplayGuard {
+  return createClaimableDedupe({
+    ttlMs: TELEGRAM_MESSAGE_DISPATCH_TTL_MS,
+    memoryMaxSize: TELEGRAM_MESSAGE_DISPATCH_MEMORY_MAX,
+    fileMaxEntries: TELEGRAM_MESSAGE_DISPATCH_FILE_MAX,
+    resolveFilePath: (namespace) =>
+      path.join(
+        path.dirname(params.storePath),
+        `${path.basename(params.storePath)}.telegram-message-dispatch-${sanitizeFileSegment(
+          namespace,
+        )}.json`,
+      ),
+    onDiskError: params.onDiskError,
+  });
+}
+
+export async function claimTelegramMessageDispatchReplay(params: {
+  guard: TelegramMessageDispatchReplayGuard;
+  accountId: string;
+  msg: Message;
+}): Promise<TelegramMessageDispatchClaim> {
+  const key = buildTelegramMessageDispatchReplayKey(params.msg);
+  if (!key) {
+    return { kind: "invalid" };
+  }
+
+  let releaseRetries = 0;
+  while (true) {
+    const claim = await params.guard.claim(key, { namespace: params.accountId });
+    if (claim.kind === "claimed") {
+      return { kind: "claimed", key };
+    }
+    if (claim.kind === "duplicate") {
+      return { kind: "duplicate" };
+    }
+    try {
+      await claim.pending;
+      return { kind: "duplicate" };
+    } catch {
+      releaseRetries += 1;
+      if (releaseRetries > 1) {
+        return { kind: "duplicate" };
+      }
+    }
+  }
+}
+
+function normalizeReplayKeys(keys?: readonly string[]): string[] {
+  return [...new Set((keys ?? []).map((key) => key.trim()).filter(Boolean))];
+}
+
+export async function commitTelegramMessageDispatchReplay(params: {
+  guard: TelegramMessageDispatchReplayGuard;
+  accountId: string;
+  keys?: readonly string[];
+}): Promise<void> {
+  const keys = normalizeReplayKeys(params.keys);
+  await Promise.all(keys.map((key) => params.guard.commit(key, { namespace: params.accountId })));
+}
+
+export function releaseTelegramMessageDispatchReplay(params: {
+  guard: TelegramMessageDispatchReplayGuard;
+  accountId: string;
+  keys?: readonly string[];
+  error?: unknown;
+}): void {
+  const keys = normalizeReplayKeys(params.keys);
+  for (const key of keys) {
+    params.guard.release(key, { namespace: params.accountId, error: params.error });
+  }
+}

--- a/src/auto-reply/inbound-debounce.ts
+++ b/src/auto-reply/inbound-debounce.ts
@@ -53,6 +53,7 @@ export type InboundDebounceCreateParams<T> = {
   serializeImmediate?: boolean;
   onFlush: (items: T[]) => Promise<void>;
   onError?: (err: unknown, items: T[]) => void;
+  onCancel?: (items: T[]) => void;
 };
 
 export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>) {
@@ -182,7 +183,14 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
       clearTimeout(buffer.timeout);
       buffer.timeout = null;
     }
+    const canceledItems = buffer.items;
     buffer.items = [];
+    try {
+      params.onCancel?.(canceledItems);
+    } catch {
+      // Cancellation observers release caller-owned resources; debounce state
+      // must still drain even if an observer fails.
+    }
     releaseBuffer(buffer);
     return true;
   };

--- a/src/auto-reply/inbound.test.ts
+++ b/src/auto-reply/inbound.test.ts
@@ -387,6 +387,33 @@ describe("createInboundDebouncer", () => {
     vi.useRealTimers();
   });
 
+  it("reports buffered items when cancelling a key", async () => {
+    vi.useFakeTimers();
+    const calls: Array<string[]> = [];
+    const canceled: Array<string[]> = [];
+
+    const debouncer = createInboundDebouncer<{ key: string; id: string }>({
+      debounceMs: 10,
+      buildKey: (item) => item.key,
+      onFlush: async (items) => {
+        calls.push(items.map((entry) => entry.id));
+      },
+      onCancel: (items) => {
+        canceled.push(items.map((entry) => entry.id));
+      },
+    });
+
+    await debouncer.enqueue({ key: "a", id: "1" });
+    await debouncer.enqueue({ key: "a", id: "2" });
+    expect(debouncer.cancelKey("a")).toBe(true);
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(canceled).toEqual([["1", "2"]]);
+    expect(calls).toEqual([]);
+
+    vi.useRealTimers();
+  });
+
   it("flushes buffered items before non-debounced item", async () => {
     vi.useFakeTimers();
     const calls: Array<string[]> = [];


### PR DESCRIPTION
## Summary

- Problem: Telegram isolated-ingress replays can deliver the same logical Telegram message under a different `update_id`, bypassing update-level dedupe and dispatching the message again.
- Solution: Add account-scoped dispatch dedupe keyed by Telegram `chat.id + message_id`, committed only after the message reaches the real dispatch boundary.
- What changed: Telegram handler paths now claim, release, merge, and commit dispatch dedupe keys across direct messages, inbound debounce, text fragments, media groups, and canceled debounce buffers.
- What did NOT change (scope boundary): Existing Telegram update dedupe remains in place; this does not alter Telegram auth, routing, or visible reply policy.

## Motivation

- Fixes duplicate Telegram dispatch/reply risk from replayed ingress updates after offset or restart edge cases.

## Change Type (select all)

- [x] Bug fix
- [x] Refactor required for the fix

## Scope (select all touched areas)

- [x] Integrations
- [x] API / contracts

## Linked Issue/PR

- Closes #84886
- [x] This PR fixes a bug or regression

## Real behavior proof

Behavior addressed: A replayed Telegram update for the same logical `chat.id/message_id` should not dispatch the message to the model a second time.

Real environment tested: AWS Crabbox, provider `aws`, run `run_8d15e6bb87de`, lease `cbx_33900860a05e`, live Telegram `telegram` credential from Convex, isolated Telegram ingress spool, blocking mock OpenAI-compatible backend.

Exact steps or command run after this patch: Built the patched checkout on AWS Crabbox, leased a Convex `telegram` credential, started OpenClaw gateway with Telegram isolated ingress and a blocking mock OpenAI backend, sent one real Telegram group message to the SUT bot, waited until the first model request reached the backend and stayed pending, crash-restarted the gateway against the same state directory, wrote the same Telegram message object back into the isolated ingress spool with a new synthetic `update_id`, then checked dispatch dedupe logs and mock model request count.

Evidence after fix:

```json
{
  "status": "pass",
  "proofId": "84886-pending-mpgg7ika",
  "groupId": "-5140433623",
  "requestMessageId": 11701,
  "replayUpdateId": 1779425915916,
  "requestsAtFirstDispatch": 1,
  "requestsAfterRestartReplay": 1,
  "firstRequestConnectionClosed": true,
  "skipLogSeen": true
}
```

Observed result after fix: The original live Telegram message reached the model dispatch boundary once and was still pending when the gateway was killed. After restart, the replayed spool update logged the dispatch-dedupe skip and did not create a second mock model request.

What was not tested: A visible second Telegram reply was not required as the pass condition; the proof targeted the dispatch boundary directly by counting model requests.

Before evidence: On current main, the same replay shape was observed to reach the dispatch boundary twice for the same Telegram `chat.id/message_id` under different update deliveries.

## Root Cause

- Root cause: Telegram update-level dedupe uses `update_id` when available, but `update_id` is a delivery cursor rather than stable message identity. Replays of the same logical Telegram message can arrive with different update IDs.
- Missing detection / guardrail: There was no durable message-level dispatch claim keyed by Telegram `chat.id/message_id`.
- Contributing context: Isolated ingress spool replay and offset persistence/restart behavior can make update-level dedupe insufficient.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [x] End-to-end test
- Target test or file:
  - `extensions/telegram/src/message-dispatch-dedupe.test.ts`
  - `extensions/telegram/src/bot.create-telegram-bot.test.ts`
  - `src/auto-reply/inbound.test.ts`
- Scenario the test should lock in: Same Telegram message identity replayed after handler recreation is skipped, while canceled debounce claims are released and can be processed later.
- Why this is the smallest reliable guardrail: It covers the stable identity key, persistence behavior, handler recreation, and the cancellation path that can otherwise strand claims.
- Existing test that already covers this (if any): Existing update-offset tests cover update cursor behavior, but not message-level replay dispatch dedupe.

## User-visible / Behavior Changes

Replayed Telegram messages with the same `chat.id/message_id` no longer trigger duplicate model dispatches/replies within the dispatch dedupe TTL.

## Diagram

```text
Before:
Telegram replay -> new update_id -> update dedupe misses -> duplicate dispatch

After:
Telegram replay -> same chat.id/message_id -> dispatch dedupe skips -> no duplicate dispatch
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux on AWS Crabbox
- Runtime/container: Node 24.15.0 remote Crabbox checkout
- Model/provider: mock OpenAI-compatible `/v1/responses`
- Integration/channel: Telegram live bot credential from Convex `telegram` pool
- Relevant config (redacted): Telegram group allowlist, isolated ingress enabled, mock OpenAI base URL on loopback

### Steps

1. Start OpenClaw gateway with Telegram isolated ingress and mock OpenAI.
2. Send one real Telegram message to the SUT bot.
3. Wait for the original message to reach dispatch and create one pending mock model request.
4. Kill/restart the gateway against the same state directory before the original dispatch completes.
5. Write the same Telegram message into the isolated ingress spool with a new `update_id`.
6. Assert the gateway logs dispatch dedupe skip and mock model request count remains unchanged.

### Expected

- First message reaches dispatch once before the crash-style restart.
- Replayed same `chat.id/message_id` is skipped before a second model dispatch after restart.

### Actual

- First message produced one pending mock model request.
- Replay after restart left model request count unchanged at one and logged the dispatch dedupe skip.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets

## Human Verification (required)

- Verified scenarios:
  - Focused Vitest coverage for dispatch dedupe, Telegram bot handler replay, message processor boundary, and inbound debounce cancellation.
  - `pnpm check:changed`.
  - `$autoreview` until clean.
  - Live AWS Crabbox Telegram pending-dispatch restart replay proof.
- Edge cases checked:
  - Account isolation.
  - Invalid message IDs.
  - Durable persistence across guard recreation.
  - Releasing claims when debounce cancellation drops buffered messages.
  - Releasing claims on pre-dispatch drops/errors.
- What you did **not** verify:
  - Replay behavior after the configured dispatch dedupe TTL expires.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: A legitimate re-delivery after the dedupe TTL can dispatch again.
  - Mitigation: TTL keeps state bounded and covers the restart/offset replay window this bug involves.
- Risk: A claim could be stranded if a buffered message is canceled before dispatch.
  - Mitigation: Debouncer now reports canceled items and Telegram releases dispatch claims for canceled buffers.
