### PR TITLE
[codex] fix control ui chat session picker history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Docs: https://docs.openclaw.ai
 
 - Agents/Copilot: drop unsafe GitHub Copilot Responses reasoning replay items before send so Telegram direct sessions no longer fail on overlong replay IDs. Fixes #85197. (#85198) Thanks @galiniliev.
 - fix: constrain Windows task script names [AI]. (#85064) Thanks @pgondhi987.
+- Control UI: keep the chat session picker from hiding older or cross-agent configured conversations while preserving the bounded configured-agent refresh. (#85211) Thanks @amknight.
 - Agents/Anthropic: preserve unsafe integer tool-call input values in streamed Anthropic tool-use JSON, preventing Discord-style IDs from being rounded before dispatch. Fixes #47229. (#83063) Thanks @leno23.
 - Agents/hooks: wait for local one-shot CLI and Codex `agent_end` plugin hooks before process cleanup so terminal observability flushes reliably. (#85007)
 - CLI/agents: allow `openclaw agent --session-key` to target explicit session keys, including agent-scoped legacy keys. (#85121) Thanks @Kaspre.

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -229,9 +229,11 @@ describe("refreshChat", () => {
       "sessions.list",
       "sessions list payload",
     );
-    expect(sessionsListPayload.agentId).toBe("main");
+    expect(sessionsListPayload).not.toHaveProperty("activeMinutes");
+    expect(sessionsListPayload).not.toHaveProperty("agentId");
     expect(sessionsListPayload.includeGlobal).toBe(true);
     expect(sessionsListPayload.includeUnknown).toBe(true);
+    expect(sessionsListPayload).not.toHaveProperty("limit");
     expect(request).toHaveBeenCalledWith("commands.list", {
       agentId: "main",
       includeArgs: true,
@@ -578,11 +580,11 @@ describe("refreshChat", () => {
         "sessions.list",
         "sessions list payload",
       );
-      expect(sessionsListPayload.activeMinutes).toBe(120);
-      expect(sessionsListPayload.agentId).toBe("main");
+      expect(sessionsListPayload).not.toHaveProperty("activeMinutes");
+      expect(sessionsListPayload).not.toHaveProperty("agentId");
       expect(sessionsListPayload.includeGlobal).toBe(true);
       expect(sessionsListPayload.includeUnknown).toBe(true);
-      expect(sessionsListPayload.limit).toBe(100);
+      expect(sessionsListPayload).not.toHaveProperty("limit");
       expect(request).toHaveBeenCalledWith("models.list", { view: "configured" });
       const commandsListPayload = findRequestPayload(
         request as unknown as MockCallSource,

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -233,7 +233,7 @@ describe("refreshChat", () => {
     expect(sessionsListPayload).not.toHaveProperty("agentId");
     expect(sessionsListPayload.includeGlobal).toBe(true);
     expect(sessionsListPayload.includeUnknown).toBe(true);
-    expect(sessionsListPayload).not.toHaveProperty("limit");
+    expect(sessionsListPayload.limit).toBe(100);
     expect(request).toHaveBeenCalledWith("commands.list", {
       agentId: "main",
       includeArgs: true,
@@ -584,7 +584,7 @@ describe("refreshChat", () => {
       expect(sessionsListPayload).not.toHaveProperty("agentId");
       expect(sessionsListPayload.includeGlobal).toBe(true);
       expect(sessionsListPayload.includeUnknown).toBe(true);
-      expect(sessionsListPayload).not.toHaveProperty("limit");
+      expect(sessionsListPayload.limit).toBe(100);
       expect(request).toHaveBeenCalledWith("models.list", { view: "configured" });
       const commandsListPayload = findRequestPayload(
         request as unknown as MockCallSource,

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -85,9 +85,9 @@ export type ChatAbortOptions = {
   preserveDraft?: boolean;
 };
 
-// Chat pickers need the complete session index so older channel chats remain selectable.
+// Chat pickers need recency-free session rows so older channel chats remain selectable.
 export const CHAT_SESSIONS_ACTIVE_MINUTES = 0;
-export const CHAT_SESSIONS_REFRESH_LIMIT = 0;
+export const CHAT_SESSIONS_REFRESH_LIMIT = 100;
 export {
   handleChatDraftChange,
   handleChatInputHistoryKey,

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -85,8 +85,9 @@ export type ChatAbortOptions = {
   preserveDraft?: boolean;
 };
 
-export const CHAT_SESSIONS_ACTIVE_MINUTES = 120;
-export const CHAT_SESSIONS_REFRESH_LIMIT = 100;
+// Chat pickers need the complete session index so older channel chats remain selectable.
+export const CHAT_SESSIONS_ACTIVE_MINUTES = 0;
+export const CHAT_SESSIONS_REFRESH_LIMIT = 0;
 export {
   handleChatDraftChange,
   handleChatInputHistoryKey,
@@ -784,7 +785,6 @@ export async function refreshChat(
       limit: CHAT_SESSIONS_REFRESH_LIMIT,
       includeGlobal: true,
       includeUnknown: true,
-      agentId: resolveAgentIdForSession(host) ?? undefined,
     }),
     refreshChatAvatar(host),
     refreshChatModels(host),

--- a/ui/src/ui/app-gateway.sessions.node.test.ts
+++ b/ui/src/ui/app-gateway.sessions.node.test.ts
@@ -141,7 +141,7 @@ describe("handleGatewayEvent sessions.changed", () => {
     vi.useRealTimers();
   });
 
-  it("scopes post-chat final session refreshes to the run's agent", () => {
+  it("refreshes the full chat session list after a completed chat run", () => {
     loadSessionsMock.mockReset();
     handleChatEventMock.mockReset().mockReturnValue("final");
     const host = createHost();
@@ -157,7 +157,6 @@ describe("handleGatewayEvent sessions.changed", () => {
 
     expect(loadSessionsMock).toHaveBeenCalledWith(host, {
       activeMinutes: 10,
-      agentId: "ops",
       limit: 25,
     });
   });
@@ -557,7 +556,6 @@ describe("handleGatewayEvent session.message", () => {
     expect(loadChatHistoryMock).not.toHaveBeenCalled();
     expect(loadSessionsMock).toHaveBeenCalledWith(host, {
       activeMinutes: 10,
-      agentId: "qa",
       limit: 25,
     });
     await Promise.resolve();

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -690,7 +690,6 @@ function handleTerminalChatEvent(
     if (state === "final") {
       void loadSessions(host as unknown as SessionsState, {
         activeMinutes: CHAT_SESSIONS_ACTIVE_MINUTES,
-        agentId: resolveChatEventSessionListAgentId(host, payload),
         limit: CHAT_SESSIONS_REFRESH_LIMIT,
       });
     }
@@ -718,27 +717,6 @@ function isEventForDifferentActiveRun(
   activeRunId: string | null,
 ): boolean {
   return Boolean(activeRunId && payload && payload.runId !== activeRunId);
-}
-
-function resolveChatEventSessionListAgentId(
-  host: GatewayHost,
-  payload: ChatEventPayload | undefined,
-): string {
-  return resolveSessionListAgentIdForSessionKey(
-    host,
-    payload?.sessionKey?.trim() || host.sessionKey,
-  );
-}
-
-function resolveSessionListAgentIdForSessionKey(host: GatewayHost, sessionKey: string): string {
-  const parsed = parseAgentSessionKey(sessionKey);
-  if (parsed?.agentId) {
-    return parsed.agentId;
-  }
-  const snapshot = host.hello?.snapshot as
-    | { sessionDefaults?: SessionDefaultsSnapshot }
-    | undefined;
-  return normalizeAgentId(snapshot?.sessionDefaults?.defaultAgentId);
 }
 
 function handleChatGatewayEvent(host: GatewayHost, payload: ChatEventPayload | undefined) {
@@ -861,7 +839,6 @@ function handleSessionMessageGatewayEvent(
     const runIdBeforeRefresh = host.chatRunId;
     void loadSessions(host as unknown as SessionsState, {
       activeMinutes: CHAT_SESSIONS_ACTIVE_MINUTES,
-      agentId: resolveSessionListAgentIdForSessionKey(host, sessionKey),
       limit: CHAT_SESSIONS_REFRESH_LIMIT,
     }).finally(() =>
       replayDeferredSessionMessageReloadAfterSessionsRefresh(

--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -775,7 +775,6 @@ describe("createChatSession", () => {
         includeGlobal: true,
         includeUnknown: true,
         showArchived: false,
-        agentId: "ops",
       },
     );
     expect(state.sessionKey).toBe("agent:ops:dashboard:new-chat");
@@ -977,7 +976,6 @@ describe("switchChatSession", () => {
       includeGlobal: true,
       includeUnknown: true,
       showArchived: false,
-      agentId: "main",
     });
     expect(
       (state as unknown as { announceSessionSwitch: ReturnType<typeof vi.fn> })

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -705,7 +705,6 @@ export async function createChatSession(state: AppViewState): Promise<boolean> {
       includeGlobal: true,
       includeUnknown: true,
       showArchived: state.sessionsShowArchived,
-      agentId: resolveAgentIdFromSessionKey(previousSessionKey),
     },
   );
   if (
@@ -738,7 +737,6 @@ async function refreshSessionOptions(state: AppViewState) {
     includeGlobal: true,
     includeUnknown: true,
     showArchived: state.sessionsShowArchived,
-    agentId: parseAgentSessionKey(state.sessionKey)?.agentId,
   });
 }
 

--- a/ui/src/ui/chat/session-controls.ts
+++ b/ui/src/ui/chat/session-controls.ts
@@ -202,14 +202,7 @@ async function refreshSessionOptions(state: AppViewState) {
     includeGlobal: true,
     includeUnknown: true,
     showArchived: state.sessionsShowArchived,
-    agentId: resolveSessionOptionsAgentId(state),
   });
-}
-
-function resolveSessionOptionsAgentId(state: AppViewState): string {
-  return (
-    parseAgentSessionKey(state.sessionKey)?.agentId ?? normalizeAgentId(state.agentsList?.defaultId)
-  );
 }
 
 async function refreshVisibleToolsEffectiveForCurrentSessionLazy(state: AppViewState) {


### PR DESCRIPTION
## Summary
- Stop applying recency and current-agent filters to Control UI chat picker session refreshes.
- Keep the existing explicit 100-row picker cap and configured-agent scope to avoid reintroducing the Control UI responsiveness regression.
- Keep current-agent slash-command refresh behavior unchanged.

## History
The chat session filters were originally performance guardrails, not conversation-visibility policy.

- `57c34a324c` (2026-01-30) introduced `CHAT_SESSIONS_ACTIVE_MINUTES = 10` for chat session refreshes.
- `f8575c401c` (2026-02-01) raised that window to `120` minutes for a longer recent-session window.
- `38456f5f03` (2026-05-10) added current-agent scoping to chat-specific `sessions.list` refreshes to address #79675, where session switching became very slow after the first message.
- `6b3cd9043e` (2026-05-11) added the current bounded refresh shape while improving Control UI/channel responsiveness.

So the filters were intentional as a latency/stability mitigation for large session stores and expensive broad store discovery.

## Issue
The chat picker used the recency and current-agent performance filters as its authoritative conversation list. That hides valid conversations when they are older than the 120-minute window or belong to another configured agent.

This shows up most clearly for channel conversations such as Telegram: the backend still returns those rows from `sessions.list` without `activeMinutes`/`agentId`, but the chat picker never receives them. Unlike the Sessions tab, the chat picker has no visible filter state or “show all” control, so the conversations appear to be missing rather than filtered.

## Fix
This PR removes only the two filters that caused the observed conversation loss in chat picker refreshes:

- no `activeMinutes` on chat picker/session refresh calls
- no current-session `agentId` on chat picker/session refresh calls

The picker still asks for a bounded recent page (`limit: 100`) and still uses configured-agent session stores. The picker also continues to do client-side grouping/filtering for the selected agent. Runtime slash-command refreshes remain scoped to the active agent because that is command discovery behavior, not conversation discovery.

## Performance Guardrails Preserved
This does not make chat refreshes a fully unbounded disk scan:

- Chat picker refreshes explicitly send `limit: 100`.
- `loadSessions` still sends `configuredAgentsOnly: true` by default.
- `configuredAgentsOnly` avoids the disk-only/unconfigured agent store discovery path added around #79675.
- Chat picker refreshes do not request derived titles or last-message transcript previews.
- `sessions.changed` snapshots still update rows without a list refetch where possible.

True older-than-the-first-100 discovery should be handled by a follow-up searchable/paginated picker rather than by loading an unbounded native select.

## Validation
- `pnpm --dir ui exec vitest run --config vitest.config.ts --project unit src/ui/app-chat.test.ts src/ui/views/chat.test.ts` (84 tests passed)
- `pnpm --dir ui exec vitest run --config vitest.config.ts --project unit-node src/ui/app-gateway.sessions.node.test.ts src/ui/app-render.helpers.node.test.ts` (87 tests passed)
- `pnpm ui:build`

Note: an earlier broad UI test invocation expanded to the full suite and hit unrelated environment/preexisting failures: missing `openclaw/plugin-sdk/test-fixtures`, missing `ui/ui/index.html`, missing Playwright browser binaries, and an existing `tool-cards` assertion mismatch.