### PR TITLE
fix(build): include Control UI assets in full source runtime builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ pnpm install
 # First run only (or after resetting local OpenClaw config/workspace)
 pnpm openclaw setup
 
-# Optional: prebuild Control UI before first startup
+# Optional: prebuild Control UI before first startup or after UI-only changes
 pnpm ui:build
 
 # Dev loop (auto-reload on source/config changes)
@@ -237,8 +237,9 @@ If you need a built `dist/` from the checkout (for Node, packaging, or release v
 
 ```bash
 pnpm build
-pnpm ui:build
 ```
+
+`pnpm build` also generates `dist/control-ui/*`; the Control UI build runs after the `tsdown` step because `tsdown` cleans `dist`.
 
 `pnpm openclaw setup` writes the local config/workspace needed for `pnpm gateway:watch`. It is safe to re-run, but you normally only need it on first setup or after resetting local state. `pnpm gateway:watch` does not rebuild `dist/control-ui`, so rerun `pnpm ui:build` after `ui/` changes or use `pnpm ui:dev` when iterating on the Control UI. If you want this checkout to run onboarding directly, use `pnpm openclaw onboard --install-daemon`.
 

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -124,7 +124,7 @@ For contributors or anyone who wants to run from a local checkout:
 ```bash
 git clone https://github.com/openclaw/openclaw.git
 cd openclaw
-pnpm install && pnpm build && pnpm ui:build
+pnpm install && pnpm build
 pnpm link --global
 openclaw onboard --install-daemon
 ```

--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -65,7 +65,7 @@ the maintainer-only release runbook.
    exports, and plugin SDK API baseline in the right order. Commit any generated
    drift before tagging. Then run the local deterministic preflight:
    `pnpm check:test-types`, `pnpm check:architecture`,
-   `pnpm build && pnpm ui:build`, and `pnpm release:check`.
+   `pnpm build`, and `pnpm release:check`.
 6. Run `OpenClaw NPM Release` with `preflight_only=true`. Before a tag exists,
    a full 40-character release-branch SHA is allowed for validation-only
    preflight. The preflight generates dependency release evidence for the
@@ -130,9 +130,8 @@ vYYYY.M.D-beta.N` from the matching `release/YYYY.M.D` branch. The helper runs
   covered outside the faster local `pnpm check` gate
 - Run `pnpm check:architecture` before release preflight so the broader import
   cycle and architecture boundary checks are green outside the faster local gate
-- Run `pnpm build && pnpm ui:build` before `pnpm release:check` so the expected
-  `dist/*` release artifacts and Control UI bundle exist for the pack
-  validation step
+- Run `pnpm build` before `pnpm release:check` so the expected `dist/*`
+  release artifacts and Control UI bundle exist for the pack validation step
 - Run `pnpm release:prep` after the root version bump and before tagging. It
   runs every deterministic release generator that commonly drifts after a
   version/config/API change: plugin versions, plugin inventory, base config

--- a/scripts/build-all.mjs
+++ b/scripts/build-all.mjs
@@ -25,6 +25,9 @@ export const BUILD_ALL_STEPS = [
     kind: "node",
     args: ["scripts/runtime-postbuild-stamp.mjs"],
   },
+  // Keep Control UI generation after tsdown/runtime postbuild: tsdown cleans dist,
+  // so running this earlier can leave a successful build with missing dashboard assets.
+  { label: "ui:build", kind: "pnpm", pnpmArgs: ["ui:build"] },
   {
     label: "build:plugin-sdk:dts",
     kind: "pnpm",
@@ -102,6 +105,7 @@ export const BUILD_ALL_PROFILES = {
     "runtime-postbuild",
     "build-stamp",
     "runtime-postbuild-stamp",
+    "ui:build",
     "build:plugin-sdk:dts",
     "write-plugin-sdk-entry-dts",
     "check-plugin-sdk-exports",

--- a/scripts/openclaw-cross-os-release-checks.ts
+++ b/scripts/openclaw-cross-os-release-checks.ts
@@ -579,8 +579,9 @@ async function prepareCandidate(params) {
   });
 
   if (hasUiBuildScript) {
-    // pnpm build does not regenerate dist/control-ui, and checked-in bundles can
-    // otherwise leak into npm pack when a ref changes UI assets.
+    // Keep an explicit release UI rebuild even though pnpm build also generates
+    // dist/control-ui. This ensures fresh UI assets for older refs and catches
+    // stale checked-in bundles before npm pack.
     logPhase("prepare", "pnpm-ui-build");
     await runCommand(pnpmCommand(), ["ui:build"], {
       cwd: params.sourceDir,

--- a/scripts/openclaw-prepack.ts
+++ b/scripts/openclaw-prepack.ts
@@ -85,7 +85,7 @@ function ensurePreparedArtifacts(): void {
   }
 
   console.error(
-    "prepack: requires an existing build and Control UI bundle. Run `pnpm build && pnpm ui:build` before packing or publishing.",
+    "prepack: requires an existing build and Control UI bundle. Run `pnpm build` before packing or publishing.",
   );
   process.exit(1);
 }
@@ -112,7 +112,6 @@ async function writeDistInventory(): Promise<void> {
 async function main(): Promise<void> {
   const pnpmCommand = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
   run(pnpmCommand, ["build"]);
-  run(pnpmCommand, ["ui:build"]);
   ensurePreparedArtifacts();
   await writeDistInventory();
   runBuildSmoke();

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -622,10 +622,10 @@ export function resolveMissingPackBuildHint(missing: readonly string[]): string 
   }
 
   if (needsControlUiBuild && needsRuntimeBuild) {
-    return "release-check: build and Control UI artifacts are missing. Run `pnpm build && pnpm ui:build` before `pnpm release:check`.";
+    return "release-check: build and Control UI artifacts are missing. Run `pnpm build` before `pnpm release:check`.";
   }
   if (needsControlUiBuild) {
-    return "release-check: Control UI artifacts are missing. Run `pnpm ui:build` before `pnpm release:check`.";
+    return "release-check: Control UI artifacts are missing. Run `pnpm build` before `pnpm release:check`.";
   }
   return "release-check: build artifacts are missing. Run `pnpm build` before `pnpm release:check`.";
 }

--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -418,7 +418,7 @@ describe("gateway run option collisions", () => {
     await runGatewayCli(["gateway", "run", "--allow-unconfigured"]);
 
     expect(gatewayLogMessages).toContain(
-      "Control UI assets are missing; first startup may spend a few seconds building them before the gateway binds. `pnpm gateway:watch` does not rebuild Control UI assets, so rerun `pnpm ui:build` after UI changes or use `pnpm ui:dev` while developing the Control UI. For a full local dist, run `pnpm build && pnpm ui:build`.",
+      "Control UI assets are missing; first startup may spend a few seconds building them before the gateway binds. `pnpm gateway:watch` does not rebuild Control UI assets, so rerun `pnpm ui:build` after UI changes or use `pnpm ui:dev` while developing the Control UI. For a full local dist, run `pnpm build`.",
     );
   });
 

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -244,7 +244,7 @@ async function maybeLogPendingControlUiBuild(cfg: OpenClawConfig): Promise<void>
     return;
   }
   gatewayLog.info(
-    "Control UI assets are missing; first startup may spend a few seconds building them before the gateway binds. `pnpm gateway:watch` does not rebuild Control UI assets, so rerun `pnpm ui:build` after UI changes or use `pnpm ui:dev` while developing the Control UI. For a full local dist, run `pnpm build && pnpm ui:build`.",
+    "Control UI assets are missing; first startup may spend a few seconds building them before the gateway binds. `pnpm gateway:watch` does not rebuild Control UI assets, so rerun `pnpm ui:build` after UI changes or use `pnpm ui:dev` while developing the Control UI. For a full local dist, run `pnpm build`.",
   );
 }
 

--- a/test/openclaw-npm-release-check.test.ts
+++ b/test/openclaw-npm-release-check.test.ts
@@ -325,7 +325,7 @@ describe("parseNpmPackJsonOutput", () => {
       'npm warn Unknown project config "node-linker".',
       "",
       "> openclaw@2026.3.23 prepack",
-      "> pnpm build && pnpm ui:build",
+      "> pnpm build",
       "",
       "[copy-hook-metadata] Copied 4 hook metadata files.",
       '[{"filename":"openclaw.tgz","files":[{"path":"dist/control-ui/index.html"}]}]',

--- a/test/release-check.test.ts
+++ b/test/release-check.test.ts
@@ -578,17 +578,17 @@ describe("resolveMissingPackBuildHint", () => {
     );
   });
 
-  it("points missing Control UI artifacts at pnpm ui:build", () => {
+  it("points missing Control UI artifacts at pnpm build", () => {
     expect(resolveMissingPackBuildHint(["dist/control-ui/index.html"])).toBe(
-      "release-check: Control UI artifacts are missing. Run `pnpm ui:build` before `pnpm release:check`.",
+      "release-check: Control UI artifacts are missing. Run `pnpm build` before `pnpm release:check`.",
     );
   });
 
-  it("points combined runtime and Control UI misses at both build commands", () => {
+  it("points combined runtime and Control UI misses at pnpm build", () => {
     expect(
       resolveMissingPackBuildHint(["dist/build-info.json", "dist/control-ui/index.html"]),
     ).toBe(
-      "release-check: build and Control UI artifacts are missing. Run `pnpm build && pnpm ui:build` before `pnpm release:check`.",
+      "release-check: build and Control UI artifacts are missing. Run `pnpm build` before `pnpm release:check`.",
     );
   });
 

--- a/test/scripts/build-all.test.ts
+++ b/test/scripts/build-all.test.ts
@@ -147,6 +147,7 @@ describe("resolveBuildAllSteps", () => {
       "runtime-postbuild",
       "build-stamp",
       "runtime-postbuild-stamp",
+      "ui:build",
       "build:plugin-sdk:dts",
       "write-plugin-sdk-entry-dts",
       "check-plugin-sdk-exports",
@@ -167,6 +168,14 @@ describe("resolveBuildAllSteps", () => {
       "build-stamp",
       "runtime-postbuild-stamp",
     ]);
+  });
+
+  it("runs Control UI build after tsdown has finished cleaning dist", () => {
+    const labels = resolveBuildAllSteps("full").map((step) => step.label);
+
+    expect(labels).toContain("ui:build");
+    expect(labels.indexOf("ui:build")).toBeGreaterThan(labels.indexOf("tsdown"));
+    expect(labels.indexOf("ui:build")).toBeGreaterThan(labels.indexOf("runtime-postbuild-stamp"));
   });
 
   it("uses a CLI startup profile without generated plugin assets", () => {


### PR DESCRIPTION
### Summary

- Add `ui:build` to the `scripts/build-all.mjs` full and `ciArtifacts` build profiles.
- Place `ui:build` after `tsdown` / runtime postbuild cleanup so `dist/control-ui/*` is not deleted by the backend build.
- Keep `gatewayWatch` backend-only.
- Add regression coverage for the build step ordering.
- Update release/prepack/user-facing guidance so a full local/runtime dist is produced by `pnpm build`.

### Problem

The repository currently documents that a complete source checkout build requires two commands:

```bash
pnpm build
pnpm ui:build
```

That order is correct, but relying on documentation is brittle. `pnpm build` rebuilds the backend runtime under `dist/`, while the gateway also serves Control UI assets from `dist/control-ui/index.html`. Because `tsdown` cleans `dist`, a backend build can remove a previously working Control UI bundle and leave a half-valid runtime tree.

This shows up in source/live runtime operations:

1. A backend-only change is made.
2. The operator runs a backend build or full build step.
3. The gateway/LaunchAgent is restarted and loads the rebuilt `dist/index.js`.
4. The backend is live, but the Control UI route returns:

```text
Control UI assets not found. Build them with `pnpm ui:build` (auto-installs UI deps), or run `pnpm ui:dev` during development.
```

Startup auto-repair can hide this sometimes, but it is not a reliable build contract. It can delay readiness, fail on missing UI dependencies/platform-specific script execution, and creates confusing service-startup failures.

### Why change the current contract

The current documentation-only approach makes `dist/` internally inconsistent after a common command:

- `dist/index.js` exists and is runnable.
- `dist/control-ui/index.html` may be missing unless an extra command was remembered.

For a full source/runtime build, `pnpm build` should produce the runtime artifacts needed by the gateway it builds. Developers and CI should not need to remember an additional UI build step to avoid a dashboard 503 after restart.

This keeps fast backend loops separate: `gatewayWatch` is intentionally left unchanged.

Fixes #85206.

### Related context

- #85206 tracks why the documentation-only contract is brittle for source/live runtimes.
- #65594 reported that `pnpm build` does not emit `dist/control-ui/`.
- #69050 proposed adding `ui:build` to build-all and was closed because the issue was considered covered by docs/startup repair.
- #45063 confirmed the important ordering rule: `tsdown` cleans `dist`, so Control UI must be built after the backend build.
- #73059 shows that startup auto-build/repair has its own platform edge cases and should not be the primary artifact contract.

### Test plan

- [x] `pnpm exec oxfmt --check scripts/build-all.mjs test/scripts/build-all.test.ts scripts/openclaw-cross-os-release-checks.ts scripts/openclaw-prepack.ts scripts/release-check.ts test/release-check.test.ts src/cli/gateway-cli/run.ts src/cli/gateway-cli/run.option-collisions.test.ts test/openclaw-npm-release-check.test.ts`
- [x] `node scripts/run-vitest.mjs run test/scripts/build-all.test.ts test/release-check.test.ts test/openclaw-npm-release-check.test.ts src/cli/gateway-cli/run.option-collisions.test.ts`
- [x] `PATH=/opt/homebrew/opt/node/bin:$PATH pnpm build`
- [x] `test -f dist/control-ui/index.html`

### Real behavior proof

- **Behavior or issue addressed:** A full source/runtime build should produce a complete gateway runtime tree, including `dist/control-ui/index.html`, so restarting the gateway after `pnpm build` does not leave the backend live while the Control UI route returns the missing-assets 503.
- **Real environment tested:** Real local OpenClaw checkout on macOS 26.3 / Darwin arm64, PR branch `fix/control-ui-build-all-assets`, commit `3ffb067ad19e67fb6a06df6da5ef2f05f948f619`, Homebrew Node `v23.11.0`, pnpm `11.1.0`.
- **Exact steps or command run after this patch:**

  ```bash
  cd /Users/wanghekun/src/openclaw-pr-control-ui-build-assets
  PATH=/opt/homebrew/opt/node/bin:$PATH pnpm build
  PATH=/opt/homebrew/opt/node/bin:$PATH test -f dist/control-ui/index.html && echo 'PASS: dist/control-ui/index.html exists after pnpm build on PR branch.'
  stat -f 'artifact: %N | size=%z bytes | modified=%Sm' dist/control-ui/index.html
  ```

- **Evidence after fix:** Copied terminal output from the real local checkout after the patched full build:

  ```text
  $ git rev-parse HEAD
  3ffb067ad19e67fb6a06df6da5ef2f05f948f619

  $ git status --short --branch
  ## fix/control-ui-build-all-assets

  $ PATH=/opt/homebrew/opt/node/bin:$PATH node --version
  v23.11.0

  $ PATH=/opt/homebrew/opt/node/bin:$PATH pnpm --version
  11.1.0

  $ PATH=/opt/homebrew/opt/node/bin:$PATH test -f dist/control-ui/index.html && echo 'PASS: dist/control-ui/index.html exists after pnpm build on PR branch.'
  PASS: dist/control-ui/index.html exists after pnpm build on PR branch.

  $ stat -f 'artifact: %N | size=%z bytes | modified=%Sm' dist/control-ui/index.html
  artifact: dist/control-ui/index.html | size=9803 bytes | modified=May 22 12:09:03 2026
  ```

- **Observed result after fix:** `pnpm build` completed on the PR branch and left `dist/control-ui/index.html` present afterward. This verifies the full build now produces the Control UI assets required by the gateway runtime instead of leaving a backend-only `dist/` tree.
- **What was not tested:** Windows and Linux local builds were not run manually; repository CI covers the normal automated build/test lanes.

### Notes

This intentionally changes the full local/runtime dist contract from `pnpm build && pnpm ui:build` to `pnpm build`. UI-only development should still use `pnpm ui:dev` or `pnpm ui:build`, and backend watch profiles remain backend-only.

Note: local default `node` is v22.16.0, below current `engines.node >=22.19.0`; the full build was run with Homebrew node v23.11.0 by prepending `/opt/homebrew/opt/node/bin` to `PATH`.

