### PR TITLE
fix(codex): expose bound conversation dynamic tools

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tool-timeout.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-timeout.ts
@@ -1,0 +1,234 @@
+import { embeddedAgentLog } from "openclaw/plugin-sdk/agent-harness-runtime";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type { CodexDynamicToolBridge } from "./dynamic-tools.js";
+import {
+  isJsonObject,
+  type CodexDynamicToolCallParams,
+  type CodexDynamicToolCallResponse,
+  type JsonValue,
+} from "./protocol.js";
+
+const CODEX_DYNAMIC_TOOL_TIMEOUT_MS = 30_000;
+const CODEX_DYNAMIC_TOOL_MAX_TIMEOUT_MS = 600_000;
+const CODEX_DYNAMIC_IMAGE_TOOL_TIMEOUT_MS = 60_000;
+const LOG_FIELD_MAX_LENGTH = 160;
+
+export {
+  CODEX_DYNAMIC_TOOL_TIMEOUT_MS,
+  CODEX_DYNAMIC_TOOL_MAX_TIMEOUT_MS,
+  CODEX_DYNAMIC_IMAGE_TOOL_TIMEOUT_MS,
+};
+
+export type CodexDynamicToolTimeoutConfig = OpenClawConfig | undefined;
+
+type DynamicToolTimeoutDetails = {
+  responseMessage: string;
+  consoleMessage: string;
+  meta: Record<string, unknown>;
+};
+
+function normalizeLogField(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const normalized = value
+    .replaceAll(String.fromCharCode(27), " ")
+    .replaceAll("\r", " ")
+    .replaceAll("\n", " ")
+    .replaceAll("\t", " ")
+    .trim();
+  if (!normalized) {
+    return undefined;
+  }
+  return normalized.length > LOG_FIELD_MAX_LENGTH
+    ? `${normalized.slice(0, LOG_FIELD_MAX_LENGTH - 3)}...`
+    : normalized;
+}
+
+function readNumericTimeoutMs(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.max(0, Math.floor(value));
+  }
+  if (typeof value === "string") {
+    const parsed = Number.parseInt(value.trim(), 10);
+    if (Number.isFinite(parsed)) {
+      return Math.max(0, Math.floor(parsed));
+    }
+  }
+  return undefined;
+}
+
+function formatDynamicToolTimeoutDetails(params: {
+  call: CodexDynamicToolCallParams;
+  timeoutMs: number;
+}): DynamicToolTimeoutDetails {
+  const tool = normalizeLogField(params.call.tool) ?? "unknown";
+  const baseMeta: Record<string, unknown> = {
+    tool: params.call.tool,
+    toolCallId: params.call.callId,
+    threadId: params.call.threadId,
+    turnId: params.call.turnId,
+    timeoutMs: params.timeoutMs,
+    timeoutKind: "codex_dynamic_tool_rpc",
+  };
+
+  if (tool !== "process" || !isJsonObject(params.call.arguments)) {
+    return {
+      responseMessage: `OpenClaw dynamic tool call timed out after ${params.timeoutMs}ms while running tool ${tool}.`,
+      consoleMessage: `codex dynamic tool timeout: tool=${tool} toolTimeoutMs=${params.timeoutMs}; per-tool-call watchdog, not session idle`,
+      meta: baseMeta,
+    };
+  }
+
+  const action = normalizeLogField(params.call.arguments.action);
+  const sessionId = normalizeLogField(params.call.arguments.sessionId);
+  const requestedTimeoutMs = readNumericTimeoutMs(params.call.arguments.timeout);
+  const actionPart = action ? ` action=${action}` : "";
+  const sessionPart = sessionId ? ` sessionId=${sessionId}` : "";
+  const requestedPart =
+    requestedTimeoutMs === undefined ? "" : ` requestedWaitMs=${requestedTimeoutMs}`;
+  const retryHint =
+    action === "poll"
+      ? "; repeated lines usually mean process-poll retry churn, not model progress"
+      : "";
+  const responseTarget =
+    action || sessionId
+      ? ` while waiting for process${actionPart}${sessionPart}`
+      : " while waiting for the process tool";
+
+  return {
+    responseMessage: `OpenClaw dynamic tool call timed out after ${params.timeoutMs}ms${responseTarget}. This is a tool RPC timeout, not a session idle timeout.`,
+    consoleMessage: `codex process tool timeout:${actionPart}${sessionPart} toolTimeoutMs=${params.timeoutMs}${requestedPart}; per-tool-call watchdog, not session idle${retryHint}`,
+    meta: {
+      ...baseMeta,
+      processAction: action,
+      processSessionId: sessionId,
+      processRequestedTimeoutMs: requestedTimeoutMs,
+    },
+  };
+}
+
+export function failedDynamicToolResponse(message: string): CodexDynamicToolCallResponse {
+  return {
+    success: false,
+    contentItems: [{ type: "inputText", text: message }],
+  };
+}
+
+export async function handleDynamicToolCallWithTimeout(params: {
+  call: CodexDynamicToolCallParams;
+  toolBridge: Pick<CodexDynamicToolBridge, "handleToolCall">;
+  signal: AbortSignal;
+  timeoutMs: number;
+  onTimeout?: () => void;
+}): Promise<CodexDynamicToolCallResponse> {
+  if (params.signal.aborted) {
+    return failedDynamicToolResponse("OpenClaw dynamic tool call aborted before execution.");
+  }
+
+  const controller = new AbortController();
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  let timedOut = false;
+  let resolveAbort: ((response: CodexDynamicToolCallResponse) => void) | undefined;
+  const abortFromRun = () => {
+    const message = "OpenClaw dynamic tool call aborted.";
+    controller.abort(params.signal.reason ?? new Error(message));
+    resolveAbort?.(failedDynamicToolResponse(message));
+  };
+  const abortPromise = new Promise<CodexDynamicToolCallResponse>((resolve) => {
+    resolveAbort = resolve;
+  });
+  const timeoutPromise = new Promise<CodexDynamicToolCallResponse>((resolve) => {
+    const timeoutMs = clampDynamicToolTimeoutMs(params.timeoutMs);
+    timeout = setTimeout(() => {
+      timedOut = true;
+      const timeoutDetails = formatDynamicToolTimeoutDetails({ call: params.call, timeoutMs });
+      controller.abort(new Error(timeoutDetails.responseMessage));
+      params.onTimeout?.();
+      embeddedAgentLog.warn("codex dynamic tool call timed out", {
+        ...timeoutDetails.meta,
+        consoleMessage: timeoutDetails.consoleMessage,
+      });
+      resolve(failedDynamicToolResponse(timeoutDetails.responseMessage));
+    }, timeoutMs);
+    timeout.unref?.();
+  });
+
+  try {
+    params.signal.addEventListener("abort", abortFromRun, { once: true });
+    if (params.signal.aborted) {
+      abortFromRun();
+    }
+    return await Promise.race([
+      params.toolBridge.handleToolCall(params.call, { signal: controller.signal }),
+      abortPromise,
+      timeoutPromise,
+    ]);
+  } catch (error) {
+    return failedDynamicToolResponse(error instanceof Error ? error.message : String(error));
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+    params.signal.removeEventListener("abort", abortFromRun);
+    resolveAbort = undefined;
+    if (!timedOut && !controller.signal.aborted) {
+      controller.abort(new Error("OpenClaw dynamic tool call finished."));
+    }
+  }
+}
+
+export function resolveDynamicToolCallTimeoutMs(params: {
+  call: CodexDynamicToolCallParams;
+  config: CodexDynamicToolTimeoutConfig;
+}): number {
+  return clampDynamicToolTimeoutMs(
+    readDynamicToolCallTimeoutMs(params.call.arguments) ??
+      readConfiguredDynamicToolTimeoutMs(params.call.tool, params.config) ??
+      CODEX_DYNAMIC_TOOL_TIMEOUT_MS,
+  );
+}
+
+function readDynamicToolCallTimeoutMs(value: JsonValue | undefined): number | undefined {
+  if (!isJsonObject(value)) {
+    return undefined;
+  }
+  return readPositiveFiniteTimeoutMs(value.timeoutMs);
+}
+
+function readConfiguredDynamicToolTimeoutMs(
+  toolName: string,
+  config: CodexDynamicToolTimeoutConfig,
+): number | undefined {
+  if (toolName === "image_generate") {
+    const imageGenerationModel = config?.agents?.defaults?.imageGenerationModel;
+    if (!imageGenerationModel || typeof imageGenerationModel !== "object") {
+      return undefined;
+    }
+    return readPositiveFiniteTimeoutMs(imageGenerationModel.timeoutMs);
+  }
+
+  if (toolName === "image") {
+    return (
+      readTimeoutSecondsAsMs(config?.tools?.media?.image?.timeoutSeconds) ??
+      CODEX_DYNAMIC_IMAGE_TOOL_TIMEOUT_MS
+    );
+  }
+
+  return undefined;
+}
+
+function readTimeoutSecondsAsMs(value: unknown): number | undefined {
+  const seconds = readPositiveFiniteTimeoutMs(value);
+  return seconds === undefined ? undefined : seconds * 1000;
+}
+
+function readPositiveFiniteTimeoutMs(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? Math.floor(value)
+    : undefined;
+}
+
+function clampDynamicToolTimeoutMs(timeoutMs: number): number {
+  return Math.max(1, Math.min(CODEX_DYNAMIC_TOOL_MAX_TIMEOUT_MS, Math.floor(timeoutMs)));
+}

--- a/extensions/codex/src/app-server/session-binding.ts
+++ b/extensions/codex/src/app-server/session-binding.ts
@@ -40,6 +40,7 @@ export type CodexAppServerThreadBinding = {
   sandbox?: CodexAppServerSandboxMode;
   serviceTier?: CodexServiceTier;
   dynamicToolsFingerprint?: string;
+  threadBindingOrigin?: "explicit" | "managed";
   userMcpServersFingerprint?: string;
   mcpServersFingerprint?: string;
   pluginAppsFingerprint?: string;
@@ -110,6 +111,10 @@ export async function readCodexAppServerBinding(
         typeof parsed.dynamicToolsFingerprint === "string"
           ? parsed.dynamicToolsFingerprint
           : undefined,
+      threadBindingOrigin:
+        parsed.threadBindingOrigin === "explicit" || parsed.threadBindingOrigin === "managed"
+          ? parsed.threadBindingOrigin
+          : undefined,
       userMcpServersFingerprint:
         typeof parsed.userMcpServersFingerprint === "string"
           ? parsed.userMcpServersFingerprint
@@ -164,6 +169,7 @@ export async function writeCodexAppServerBinding(
     sandbox: binding.sandbox,
     serviceTier: binding.serviceTier,
     dynamicToolsFingerprint: binding.dynamicToolsFingerprint,
+    threadBindingOrigin: binding.threadBindingOrigin,
     userMcpServersFingerprint: binding.userMcpServersFingerprint,
     mcpServersFingerprint: binding.mcpServersFingerprint,
     pluginAppsFingerprint: binding.pluginAppsFingerprint,

--- a/extensions/codex/src/command-handlers.ts
+++ b/extensions/codex/src/command-handlers.ts
@@ -680,6 +680,7 @@ async function resumeThread(
     cwd: readString(thread, "cwd") ?? "",
     model: isJsonObject(response) ? readString(response, "model") : undefined,
     modelProvider: isJsonObject(response) ? readString(response, "modelProvider") : undefined,
+    threadBindingOrigin: "explicit",
   });
   return `Attached this OpenClaw session to Codex thread ${formatCodexDisplayText(
     effectiveThreadId,

--- a/extensions/codex/src/conversation-binding.test.ts
+++ b/extensions/codex/src/conversation-binding.test.ts
@@ -18,8 +18,13 @@ const agentRuntimeMocks = vi.hoisted(() => ({
   saveAuthProfileStore: vi.fn(),
 }));
 
+const agentHarnessMocks = vi.hoisted(() => ({
+  createOpenClawCodingTools: vi.fn(() => []),
+}));
+
 vi.mock("./app-server/shared-client.js", () => sharedClientMocks);
 vi.mock("openclaw/plugin-sdk/agent-runtime", () => agentRuntimeMocks);
+vi.mock("openclaw/plugin-sdk/agent-harness", () => agentHarnessMocks);
 
 import {
   handleCodexConversationBindingResolved,
@@ -37,6 +42,30 @@ function mockCallArg(mock: ReturnType<typeof vi.fn>, callIndex = 0, argIndex = 0
   return call[argIndex];
 }
 
+function createEchoTool(
+  execute = vi.fn(async (_callId: string, params: unknown) => {
+    const text =
+      params && typeof params === "object" && "text" in params
+        ? String((params as { text?: unknown }).text)
+        : "";
+    return { content: [{ type: "text" as const, text: `echo:${text}` }] };
+  }),
+) {
+  return {
+    name: "test_plugin_echo",
+    description: "Echo test plugin tool",
+    parameters: {
+      type: "object",
+      properties: {
+        text: { type: "string" },
+      },
+      required: ["text"],
+      additionalProperties: false,
+    },
+    execute,
+  };
+}
+
 describe("codex conversation binding", () => {
   beforeEach(async () => {
     tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-binding-"));
@@ -52,6 +81,8 @@ describe("codex conversation binding", () => {
     agentRuntimeMocks.resolvePersistedAuthProfileOwnerAgentDir.mockReset();
     agentRuntimeMocks.resolveProviderIdForAuth.mockClear();
     agentRuntimeMocks.saveAuthProfileStore.mockReset();
+    agentHarnessMocks.createOpenClawCodingTools.mockReset();
+    agentHarnessMocks.createOpenClawCodingTools.mockReturnValue([]);
     await fs.rm(tempDir, { recursive: true, force: true });
   });
 
@@ -202,6 +233,50 @@ describe("codex conversation binding", () => {
     expect(data.agentDir).toBe(agentDir);
   });
 
+  it("starts native bound Codex threads with OpenClaw plugin dynamic tools", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const pluginTool = createEchoTool();
+    agentHarnessMocks.createOpenClawCodingTools.mockReturnValue([pluginTool] as never);
+    const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
+    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({
+      request: vi.fn(async (method: string, requestParams: Record<string, unknown>) => {
+        requests.push({ method, params: requestParams });
+        return {
+          thread: { id: "thread-new", sessionId: "session-1", cwd: tempDir },
+          model: "gpt-5.4-mini",
+        };
+      }),
+    });
+
+    await startCodexConversationThread({
+      sessionFile,
+      workspaceDir: tempDir,
+      model: "gpt-5.4-mini",
+    });
+
+    expect(agentHarnessMocks.createOpenClawCodingTools).toHaveBeenCalledWith(
+      expect.objectContaining({
+        includeCoreTools: false,
+        workspaceDir: tempDir,
+        spawnWorkspaceDir: tempDir,
+      }),
+    );
+    expect(requests[0]?.method).toBe("thread/start");
+    expect(requests[0]?.params.dynamicTools).toEqual([
+      expect.objectContaining({
+        name: "test_plugin_echo",
+        inputSchema: expect.objectContaining({
+          type: "object",
+          required: ["text"],
+        }),
+      }),
+    ]);
+    const savedBinding = JSON.parse(
+      await fs.readFile(sessionFile + ".codex-app-server.json", "utf8"),
+    );
+    expect(savedBinding.dynamicToolsFingerprint).toContain("test_plugin_echo");
+  });
+
   it("clears the Codex app-server sidecar when a pending bind is denied", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const sidecar = `${sessionFile}.codex-app-server.json`;
@@ -305,6 +380,728 @@ describe("codex conversation binding", () => {
       cwd: "/repo",
       timeoutMs: 1234,
     });
+  });
+
+  it("dispatches native bound Codex dynamic tool calls to OpenClaw plugin handlers", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const execute = vi.fn(async (_callId: string, params: unknown) => ({
+      content: [
+        {
+          type: "text" as const,
+          text:
+            params && typeof params === "object" && "text" in params
+              ? `echo:${String((params as { text?: unknown }).text)}`
+              : "echo:",
+        },
+      ],
+    }));
+    agentHarnessMocks.createOpenClawCodingTools.mockReturnValue([createEchoTool(execute)] as never);
+    await fs.writeFile(
+      sessionFile + ".codex-app-server.json",
+      JSON.stringify({
+        schemaVersion: 1,
+        threadId: "thread-old",
+        cwd: tempDir,
+        dynamicToolsFingerprint: "[]",
+      }),
+    );
+    const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
+    let notificationHandler: ((notification: unknown) => void) | undefined;
+    let requestHandler:
+      | ((request: { method: string; params?: unknown }) => Promise<unknown>)
+      | undefined;
+    let foreignThreadResponse: unknown;
+    let foreignTurnResponse: unknown;
+    let toolResponse: unknown;
+    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({
+      request: vi.fn(async (method: string, requestParams: Record<string, unknown>) => {
+        requests.push({ method, params: requestParams });
+        if (method === "thread/start") {
+          return {
+            thread: { id: "thread-new", sessionId: "session-1", cwd: tempDir },
+            model: "gpt-5.4-mini",
+          };
+        }
+        if (method === "turn/start") {
+          setImmediate(async () => {
+            foreignThreadResponse = await requestHandler?.({
+              method: "item/tool/call",
+              params: {
+                threadId: "thread-foreign",
+                turnId: "turn-1",
+                callId: "call-foreign-thread",
+                namespace: null,
+                tool: "test_plugin_echo",
+                arguments: { text: "wrong thread" },
+              },
+            });
+            foreignTurnResponse = await requestHandler?.({
+              method: "item/tool/call",
+              params: {
+                threadId: "thread-new",
+                turnId: "turn-foreign",
+                callId: "call-foreign-turn",
+                namespace: null,
+                tool: "test_plugin_echo",
+                arguments: { text: "wrong turn" },
+              },
+            });
+            toolResponse = await requestHandler?.({
+              method: "item/tool/call",
+              params: {
+                threadId: "thread-new",
+                turnId: "turn-1",
+                callId: "call-1",
+                namespace: null,
+                tool: "test_plugin_echo",
+                arguments: { text: "hello" },
+              },
+            });
+            notificationHandler?.({
+              method: "turn/completed",
+              params: {
+                threadId: "thread-new",
+                turn: {
+                  id: "turn-1",
+                  status: "completed",
+                  items: [{ type: "agentMessage", id: "item-1", text: "done" }],
+                },
+              },
+            });
+          });
+          return { turn: { id: "turn-1" } };
+        }
+        throw new Error(`unexpected method: ${method}`);
+      }),
+      addNotificationHandler: vi.fn((handler: (notification: unknown) => void) => {
+        notificationHandler = handler;
+        return () => undefined;
+      }),
+      addRequestHandler: vi.fn((handler) => {
+        requestHandler = handler;
+        return () => undefined;
+      }),
+    });
+
+    const result = await handleCodexConversationInboundClaim(
+      {
+        content: "call the echo tool",
+        bodyForAgent: "call the echo tool",
+        channel: "telegram",
+        isGroup: false,
+        commandAuthorized: true,
+        conversationId: "5185575566",
+        messageId: "msg-1",
+        senderId: "sender-1",
+      },
+      {
+        channelId: "telegram",
+        conversationId: "5185575566",
+        sessionKey: "telegram:direct:5185575566",
+        pluginBinding: {
+          bindingId: "binding-1",
+          pluginId: "codex",
+          pluginRoot: tempDir,
+          channel: "telegram",
+          accountId: "default",
+          conversationId: "5185575566",
+          boundAt: Date.now(),
+          data: {
+            kind: "codex-app-server-session",
+            version: 1,
+            sessionFile,
+            workspaceDir: tempDir,
+          },
+        },
+      },
+      { timeoutMs: 500 },
+    );
+
+    expect(result).toEqual({ handled: true, reply: { text: "done" } });
+    expect(requests.map((request) => request.method)).toEqual(["thread/start", "turn/start"]);
+    const toolFactoryOptions = mockCallArg(agentHarnessMocks.createOpenClawCodingTools) as {
+      currentChannelId?: unknown;
+      messageTo?: unknown;
+      sessionId?: unknown;
+    };
+    expect(toolFactoryOptions.currentChannelId).toBe("5185575566");
+    expect(toolFactoryOptions.messageTo).toBe("5185575566");
+    expect(toolFactoryOptions.sessionId).toBe("5185575566");
+    expect(foreignThreadResponse).toBeUndefined();
+    expect(foreignTurnResponse).toBeUndefined();
+    expect(execute).toHaveBeenCalledWith(
+      "call-1",
+      { text: "hello" },
+      expect.any(AbortSignal),
+      undefined,
+    );
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(toolResponse).toEqual({
+      contentItems: [{ type: "inputText", text: "echo:hello" }],
+      success: true,
+    });
+  });
+
+  it("scopes bound turn dynamic tools to the binding conversation, not the provider channel", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    await fs.writeFile(
+      sessionFile + ".codex-app-server.json",
+      JSON.stringify({
+        schemaVersion: 1,
+        threadId: "thread-1",
+        cwd: tempDir,
+        threadBindingOrigin: "explicit",
+      }),
+    );
+    let notificationHandler: ((notification: unknown) => void) | undefined;
+    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({
+      request: vi.fn(async (method: string) => {
+        if (method === "turn/start") {
+          setImmediate(() =>
+            notificationHandler?.({
+              method: "turn/completed",
+              params: {
+                threadId: "thread-1",
+                turn: {
+                  id: "turn-1",
+                  status: "completed",
+                  items: [{ type: "agentMessage", id: "item-1", text: "done" }],
+                },
+              },
+            }),
+          );
+          return { turn: { id: "turn-1" } };
+        }
+        throw new Error("unexpected method: " + method);
+      }),
+      addNotificationHandler: vi.fn((handler: (notification: unknown) => void) => {
+        notificationHandler = handler;
+        return () => undefined;
+      }),
+      addRequestHandler: vi.fn(() => () => undefined),
+    });
+
+    const result = await handleCodexConversationInboundClaim(
+      {
+        content: "scope check",
+        bodyForAgent: "scope check",
+        channel: "telegram",
+        isGroup: false,
+        commandAuthorized: true,
+      },
+      {
+        channelId: "telegram",
+        pluginBinding: {
+          bindingId: "binding-1",
+          pluginId: "codex",
+          pluginRoot: tempDir,
+          channel: "telegram",
+          accountId: "default",
+          conversationId: "conv-scoped-77",
+          boundAt: Date.now(),
+          data: {
+            kind: "codex-app-server-session",
+            version: 1,
+            sessionFile,
+            workspaceDir: tempDir,
+          },
+        },
+      },
+      { timeoutMs: 50 },
+    );
+
+    expect(result).toEqual({ handled: true, reply: { text: "done" } });
+    const toolFactoryOptions = mockCallArg(agentHarnessMocks.createOpenClawCodingTools) as {
+      currentChannelId?: unknown;
+      messageTo?: unknown;
+      sessionId?: unknown;
+    };
+    expect(toolFactoryOptions.sessionId).toBe("conv-scoped-77");
+    expect(toolFactoryOptions.messageTo).toBe("conv-scoped-77");
+    expect(toolFactoryOptions.currentChannelId).toBe("conv-scoped-77");
+  });
+
+  it("upgrades managed native bound Codex threads without dynamic tool fingerprints", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    agentHarnessMocks.createOpenClawCodingTools.mockReturnValue([createEchoTool()] as never);
+    agentRuntimeMocks.ensureAuthProfileStore.mockReturnValue({
+      version: 1,
+      profiles: {
+        work: {
+          type: "oauth",
+          provider: "openai-codex",
+          access: "access-token",
+        },
+      },
+    });
+    await fs.writeFile(
+      sessionFile + ".codex-app-server.json",
+      JSON.stringify({
+        schemaVersion: 1,
+        threadId: "thread-old",
+        cwd: tempDir,
+        authProfileId: "work",
+        model: "gpt-5.4-mini",
+        modelProvider: "openai",
+        approvalPolicy: "on-request",
+        sandbox: "workspace-write",
+        serviceTier: "fast",
+        threadBindingOrigin: "managed",
+      }),
+    );
+    const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
+    let notificationHandler: ((notification: unknown) => void) | undefined;
+    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({
+      request: vi.fn(async (method: string, requestParams: Record<string, unknown>) => {
+        requests.push({ method, params: requestParams });
+        if (method === "thread/start") {
+          return {
+            thread: { id: "thread-new", sessionId: "session-1", cwd: tempDir },
+            model: "gpt-5.4-mini",
+          };
+        }
+        if (method === "turn/start") {
+          setImmediate(() => {
+            notificationHandler?.({
+              method: "turn/completed",
+              params: {
+                threadId: "thread-new",
+                turn: {
+                  id: "turn-1",
+                  status: "completed",
+                  items: [{ type: "agentMessage", id: "item-1", text: "upgraded" }],
+                },
+              },
+            });
+          });
+          return { turn: { id: "turn-1" } };
+        }
+        throw new Error(`unexpected method: ${method}`);
+      }),
+      addNotificationHandler: vi.fn((handler: (notification: unknown) => void) => {
+        notificationHandler = handler;
+        return () => undefined;
+      }),
+      addRequestHandler: vi.fn(() => () => undefined),
+    });
+
+    const result = await handleCodexConversationInboundClaim(
+      {
+        content: "continue",
+        bodyForAgent: "continue",
+        channel: "telegram",
+        isGroup: false,
+        commandAuthorized: true,
+        conversationId: "5185575566",
+      },
+      {
+        channelId: "telegram",
+        conversationId: "5185575566",
+        sessionKey: "telegram:direct:5185575566",
+        pluginBinding: {
+          bindingId: "binding-1",
+          pluginId: "codex",
+          pluginRoot: tempDir,
+          channel: "telegram",
+          accountId: "default",
+          conversationId: "5185575566",
+          boundAt: Date.now(),
+          data: {
+            kind: "codex-app-server-session",
+            version: 1,
+            sessionFile,
+            workspaceDir: tempDir,
+          },
+        },
+      },
+      { timeoutMs: 500 },
+    );
+
+    expect(result).toEqual({ handled: true, reply: { text: "upgraded" } });
+    expect(requests.map((request) => request.method)).toEqual(["thread/start", "turn/start"]);
+    expect(requests[0]?.params.model).toBe("gpt-5.4-mini");
+    expect(requests[0]?.params.approvalPolicy).toBe("on-request");
+    expect(requests[0]?.params.sandbox).toBe("workspace-write");
+    expect(requests[0]?.params.serviceTier).toBe("priority");
+    expect(requests[0]?.params).not.toHaveProperty("modelProvider");
+    expect(requests[0]?.params.dynamicTools).toEqual([
+      expect.objectContaining({ name: "test_plugin_echo" }),
+    ]);
+    expect(requests[1]?.params.threadId).toBe("thread-new");
+    const savedBinding = JSON.parse(
+      await fs.readFile(sessionFile + ".codex-app-server.json", "utf8"),
+    );
+    expect(savedBinding.threadId).toBe("thread-new");
+    expect(savedBinding.authProfileId).toBe("work");
+    expect(savedBinding.model).toBe("gpt-5.4-mini");
+    expect(savedBinding.approvalPolicy).toBe("on-request");
+    expect(savedBinding.sandbox).toBe("workspace-write");
+    expect(savedBinding.serviceTier).toBe("priority");
+    expect(savedBinding.dynamicToolsFingerprint).toContain("test_plugin_echo");
+  });
+
+  it("preserves legacy no-origin Codex threads without dynamic tool fingerprints", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    agentHarnessMocks.createOpenClawCodingTools.mockReturnValue([createEchoTool()] as never);
+    await fs.writeFile(
+      sessionFile + ".codex-app-server.json",
+      JSON.stringify({
+        schemaVersion: 1,
+        threadId: "thread-legacy-explicit",
+        cwd: tempDir,
+        model: "gpt-5.4-mini",
+      }),
+    );
+    const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
+    let notificationHandler: ((notification: unknown) => void) | undefined;
+    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({
+      request: vi.fn(async (method: string, requestParams: Record<string, unknown>) => {
+        requests.push({ method, params: requestParams });
+        if (method === "turn/start") {
+          setImmediate(() => {
+            notificationHandler?.({
+              method: "turn/completed",
+              params: {
+                threadId: "thread-legacy-explicit",
+                turn: {
+                  id: "turn-1",
+                  status: "completed",
+                  items: [{ type: "agentMessage", id: "item-1", text: "legacy explicit" }],
+                },
+              },
+            });
+          });
+          return { turn: { id: "turn-1" } };
+        }
+        throw new Error(`unexpected method: ${method}`);
+      }),
+      addNotificationHandler: vi.fn((handler: (notification: unknown) => void) => {
+        notificationHandler = handler;
+        return () => undefined;
+      }),
+      addRequestHandler: vi.fn(() => () => undefined),
+    });
+
+    const result = await handleCodexConversationInboundClaim(
+      {
+        content: "continue",
+        bodyForAgent: "continue",
+        channel: "telegram",
+        isGroup: false,
+        commandAuthorized: true,
+        conversationId: "5185575566",
+      },
+      {
+        channelId: "telegram",
+        conversationId: "5185575566",
+        sessionKey: "telegram:direct:5185575566",
+        pluginBinding: {
+          bindingId: "binding-1",
+          pluginId: "codex",
+          pluginRoot: tempDir,
+          channel: "telegram",
+          accountId: "default",
+          conversationId: "5185575566",
+          boundAt: Date.now(),
+          data: {
+            kind: "codex-app-server-session",
+            version: 1,
+            sessionFile,
+            workspaceDir: tempDir,
+          },
+        },
+      },
+      { timeoutMs: 500 },
+    );
+
+    expect(result).toEqual({ handled: true, reply: { text: "legacy explicit" } });
+    expect(requests.map((request) => request.method)).toEqual(["turn/start"]);
+    expect(requests[0]?.params.threadId).toBe("thread-legacy-explicit");
+    const savedBinding = JSON.parse(
+      await fs.readFile(sessionFile + ".codex-app-server.json", "utf8"),
+    );
+    expect(savedBinding.threadId).toBe("thread-legacy-explicit");
+    expect(savedBinding).not.toHaveProperty("threadBindingOrigin");
+    expect(savedBinding).not.toHaveProperty("dynamicToolsFingerprint");
+  });
+
+  it("preserves explicitly bound Codex threads without dynamic tool fingerprints", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    agentHarnessMocks.createOpenClawCodingTools.mockReturnValue([createEchoTool()] as never);
+    await fs.writeFile(
+      sessionFile + ".codex-app-server.json",
+      JSON.stringify({
+        schemaVersion: 1,
+        threadId: "thread-explicit",
+        cwd: tempDir,
+        model: "gpt-5.4-mini",
+        threadBindingOrigin: "explicit",
+      }),
+    );
+    const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
+    let notificationHandler: ((notification: unknown) => void) | undefined;
+    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({
+      request: vi.fn(async (method: string, requestParams: Record<string, unknown>) => {
+        requests.push({ method, params: requestParams });
+        if (method === "turn/start") {
+          setImmediate(() => {
+            notificationHandler?.({
+              method: "turn/completed",
+              params: {
+                threadId: "thread-explicit",
+                turn: {
+                  id: "turn-1",
+                  status: "completed",
+                  items: [{ type: "agentMessage", id: "item-1", text: "preserved explicit" }],
+                },
+              },
+            });
+          });
+          return { turn: { id: "turn-1" } };
+        }
+        throw new Error(`unexpected method: ${method}`);
+      }),
+      addNotificationHandler: vi.fn((handler: (notification: unknown) => void) => {
+        notificationHandler = handler;
+        return () => undefined;
+      }),
+      addRequestHandler: vi.fn(() => () => undefined),
+    });
+
+    const result = await handleCodexConversationInboundClaim(
+      {
+        content: "continue",
+        bodyForAgent: "continue",
+        channel: "telegram",
+        isGroup: false,
+        commandAuthorized: true,
+        conversationId: "5185575566",
+      },
+      {
+        channelId: "telegram",
+        conversationId: "5185575566",
+        sessionKey: "telegram:direct:5185575566",
+        pluginBinding: {
+          bindingId: "binding-1",
+          pluginId: "codex",
+          pluginRoot: tempDir,
+          channel: "telegram",
+          accountId: "default",
+          conversationId: "5185575566",
+          boundAt: Date.now(),
+          data: {
+            kind: "codex-app-server-session",
+            version: 1,
+            sessionFile,
+            workspaceDir: tempDir,
+          },
+        },
+      },
+      { timeoutMs: 500 },
+    );
+
+    expect(result).toEqual({ handled: true, reply: { text: "preserved explicit" } });
+    expect(requests.map((request) => request.method)).toEqual(["turn/start"]);
+    expect(requests[0]?.params.threadId).toBe("thread-explicit");
+    const savedBinding = JSON.parse(
+      await fs.readFile(sessionFile + ".codex-app-server.json", "utf8"),
+    );
+    expect(savedBinding.threadId).toBe("thread-explicit");
+    expect(savedBinding.threadBindingOrigin).toBe("explicit");
+    expect(savedBinding).not.toHaveProperty("dynamicToolsFingerprint");
+  });
+
+  it("times out bound Codex dynamic tool calls with per-call timeout budgets", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const execute = vi.fn(
+      (_callId: string, _params: unknown, signal?: AbortSignal) =>
+        new Promise<{ content: Array<{ type: "text"; text: string }> }>((resolve) => {
+          signal?.addEventListener(
+            "abort",
+            () => resolve({ content: [{ type: "text", text: "aborted by timeout" }] }),
+            { once: true },
+          );
+        }),
+    );
+    agentHarnessMocks.createOpenClawCodingTools.mockReturnValue([createEchoTool(execute)] as never);
+    await fs.writeFile(
+      sessionFile + ".codex-app-server.json",
+      JSON.stringify({
+        schemaVersion: 1,
+        threadId: "thread-1",
+        cwd: tempDir,
+        threadBindingOrigin: "explicit",
+      }),
+    );
+    let notificationHandler: ((notification: unknown) => void) | undefined;
+    let requestHandler:
+      | ((request: { method: string; params?: unknown }) => Promise<unknown>)
+      | undefined;
+    let toolResponse: unknown;
+    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({
+      request: vi.fn(async (method: string) => {
+        if (method === "turn/start") {
+          setImmediate(async () => {
+            toolResponse = await requestHandler?.({
+              method: "item/tool/call",
+              params: {
+                threadId: "thread-1",
+                turnId: "turn-1",
+                callId: "call-1",
+                namespace: null,
+                tool: "test_plugin_echo",
+                arguments: { text: "slow", timeoutMs: 1 },
+              },
+            });
+            notificationHandler?.({
+              method: "turn/completed",
+              params: {
+                threadId: "thread-1",
+                turn: {
+                  id: "turn-1",
+                  status: "completed",
+                  items: [{ type: "agentMessage", id: "item-1", text: "done" }],
+                },
+              },
+            });
+          });
+          return { turn: { id: "turn-1" } };
+        }
+        throw new Error("unexpected method: " + method);
+      }),
+      addNotificationHandler: vi.fn((handler: (notification: unknown) => void) => {
+        notificationHandler = handler;
+        return () => undefined;
+      }),
+      addRequestHandler: vi.fn((handler) => {
+        requestHandler = handler;
+        return () => undefined;
+      }),
+    });
+
+    const result = await handleCodexConversationInboundClaim(
+      {
+        content: "call slow echo",
+        bodyForAgent: "call slow echo",
+        channel: "telegram",
+        isGroup: false,
+        commandAuthorized: true,
+      },
+      {
+        channelId: "telegram",
+        pluginBinding: {
+          bindingId: "binding-1",
+          pluginId: "codex",
+          pluginRoot: tempDir,
+          channel: "telegram",
+          accountId: "default",
+          conversationId: "5185575566",
+          boundAt: Date.now(),
+          data: {
+            kind: "codex-app-server-session",
+            version: 1,
+            sessionFile,
+            workspaceDir: tempDir,
+          },
+        },
+      },
+      { timeoutMs: 500 },
+    );
+
+    expect(result).toEqual({ handled: true, reply: { text: "done" } });
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(toolResponse).toEqual({
+      success: false,
+      contentItems: [
+        {
+          type: "inputText",
+          text: "OpenClaw dynamic tool call timed out after 1ms while running tool test_plugin_echo.",
+        },
+      ],
+    });
+  });
+
+  it("preserves older native bound Codex threads when no dynamic tools are available", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    await fs.writeFile(
+      sessionFile + ".codex-app-server.json",
+      JSON.stringify({
+        schemaVersion: 1,
+        threadId: "thread-old",
+        cwd: tempDir,
+        model: "gpt-5.4-mini",
+      }),
+    );
+    const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
+    let notificationHandler: ((notification: unknown) => void) | undefined;
+    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({
+      request: vi.fn(async (method: string, requestParams: Record<string, unknown>) => {
+        requests.push({ method, params: requestParams });
+        if (method === "turn/start") {
+          setImmediate(() => {
+            notificationHandler?.({
+              method: "turn/completed",
+              params: {
+                threadId: "thread-old",
+                turn: {
+                  id: "turn-1",
+                  status: "completed",
+                  items: [{ type: "agentMessage", id: "item-1", text: "preserved" }],
+                },
+              },
+            });
+          });
+          return { turn: { id: "turn-1" } };
+        }
+        throw new Error(`unexpected method: ${method}`);
+      }),
+      addNotificationHandler: vi.fn((handler: (notification: unknown) => void) => {
+        notificationHandler = handler;
+        return () => undefined;
+      }),
+      addRequestHandler: vi.fn(() => () => undefined),
+    });
+
+    const result = await handleCodexConversationInboundClaim(
+      {
+        content: "continue",
+        bodyForAgent: "continue",
+        channel: "telegram",
+        isGroup: false,
+        commandAuthorized: true,
+        conversationId: "5185575566",
+      },
+      {
+        channelId: "telegram",
+        conversationId: "5185575566",
+        sessionKey: "telegram:direct:5185575566",
+        pluginBinding: {
+          bindingId: "binding-1",
+          pluginId: "codex",
+          pluginRoot: tempDir,
+          channel: "telegram",
+          accountId: "default",
+          conversationId: "5185575566",
+          boundAt: Date.now(),
+          data: {
+            kind: "codex-app-server-session",
+            version: 1,
+            sessionFile,
+            workspaceDir: tempDir,
+          },
+        },
+      },
+      { timeoutMs: 500 },
+    );
+
+    expect(result).toEqual({ handled: true, reply: { text: "preserved" } });
+    expect(requests.map((request) => request.method)).toEqual(["turn/start"]);
+    expect(requests[0]?.params.threadId).toBe("thread-old");
+    const savedBinding = JSON.parse(
+      await fs.readFile(sessionFile + ".codex-app-server.json", "utf8"),
+    );
+    expect(savedBinding.threadId).toBe("thread-old");
+    expect(savedBinding.dynamicToolsFingerprint).toBe("[]");
   });
 
   it("blocks bound Codex app-server turns when the current OpenClaw session is sandboxed", async () => {
@@ -429,6 +1226,7 @@ describe("codex conversation binding", () => {
         approvalPolicy: "on-request",
         sandbox: "workspace-write",
         serviceTier: "fast",
+        dynamicToolsFingerprint: "[]",
       }),
     );
     const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
@@ -546,6 +1344,7 @@ describe("codex conversation binding", () => {
         threadId: "thread-1",
         cwd: tempDir,
         authProfileId: "openai-codex:work",
+        dynamicToolsFingerprint: "[]",
       }),
     );
     const unhandledRejections: unknown[] = [];
@@ -623,6 +1422,7 @@ describe("codex conversation binding", () => {
         schemaVersion: 1,
         threadId: "thread-1",
         cwd: tempDir,
+        dynamicToolsFingerprint: "[]",
       }),
     );
     let notificationHandler: ((notification: unknown) => void) | undefined;

--- a/extensions/codex/src/conversation-binding.ts
+++ b/extensions/codex/src/conversation-binding.ts
@@ -10,11 +10,26 @@ import { resolveCodexAppServerAuthProfileIdForAgent } from "./app-server/auth-br
 import { CODEX_CONTROL_METHODS } from "./app-server/capabilities.js";
 import {
   codexSandboxPolicyForTurn,
+  readCodexPluginConfig,
   resolveCodexAppServerRuntimeOptions,
   type CodexAppServerApprovalPolicy,
   type CodexAppServerSandboxMode,
 } from "./app-server/config.js";
 import {
+  filterCodexDynamicTools,
+  resolveCodexDynamicToolsLoading,
+} from "./app-server/dynamic-tool-profile.js";
+import {
+  handleDynamicToolCallWithTimeout,
+  resolveDynamicToolCallTimeoutMs,
+} from "./app-server/dynamic-tool-timeout.js";
+import {
+  createCodexDynamicToolBridge,
+  type CodexDynamicToolBridge,
+} from "./app-server/dynamic-tools.js";
+import { readCodexDynamicToolCallParams } from "./app-server/protocol-validators.js";
+import {
+  type CodexDynamicToolSpec,
   type CodexServiceTier,
   type CodexThreadResumeResponse,
   type CodexThreadStartResponse,
@@ -31,6 +46,10 @@ import {
   type CodexAppServerAuthProfileLookup,
 } from "./app-server/session-binding.js";
 import { getSharedCodexAppServerClient } from "./app-server/shared-client.js";
+import {
+  areCodexDynamicToolFingerprintsCompatible,
+  codexDynamicToolsFingerprint,
+} from "./app-server/thread-lifecycle.js";
 import { formatCodexDisplayText } from "./command-formatters.js";
 import {
   createCodexConversationBindingData,
@@ -65,7 +84,7 @@ type ResumeCodexCliSessionOnNodeFn = (
 
 type CodexConversationStartParams = {
   pluginConfig?: unknown;
-  config?: Parameters<typeof resolveCodexAppServerAuthProfileIdForAgent>[0]["config"];
+  config?: OpenClawConfig;
   sessionFile: string;
   workspaceDir?: string;
   agentDir?: string;
@@ -126,6 +145,12 @@ export async function startCodexConversationThread(
       config: params.config,
     });
   } else {
+    const dynamicToolBridge = await buildConversationDynamicToolBridge({
+      pluginConfig: params.pluginConfig,
+      config: params.config,
+      workspaceDir,
+      ...(agentDir ? { agentDir } : {}),
+    });
     await createThread({
       pluginConfig: params.pluginConfig,
       sessionFile: params.sessionFile,
@@ -138,6 +163,8 @@ export async function startCodexConversationThread(
       sandbox: params.sandbox,
       serviceTier: params.serviceTier,
       config: params.config,
+      dynamicTools: dynamicToolBridge.specs,
+      dynamicToolsFingerprint: codexDynamicToolsFingerprint(dynamicToolBridge.specs),
     });
   }
   return createCodexConversationBindingData({
@@ -211,7 +238,9 @@ export async function handleCodexConversationInboundClaim(
         data,
         prompt,
         event,
+        ctx,
         pluginConfig: options.pluginConfig,
+        config: options.config,
         timeoutMs: options.timeoutMs,
       }),
     );
@@ -252,6 +281,8 @@ async function attachExistingThread(params: {
   sandbox?: CodexAppServerSandboxMode;
   serviceTier?: CodexServiceTier;
   config?: CodexAppServerAuthProfileLookup["config"];
+  dynamicTools?: CodexDynamicToolSpec[];
+  dynamicToolsFingerprint?: string;
 }): Promise<void> {
   const runtime = resolveCodexAppServerRuntimeOptions({
     pluginConfig: params.pluginConfig,
@@ -302,6 +333,7 @@ async function attachExistingThread(params: {
       approvalPolicy: params.approvalPolicy ?? runtimeApprovalPolicy,
       sandbox: params.sandbox ?? runtime.sandbox,
       serviceTier: params.serviceTier ?? runtime.serviceTier,
+      threadBindingOrigin: "explicit",
     },
     {
       ...agentLookup,
@@ -321,6 +353,8 @@ async function createThread(params: {
   sandbox?: CodexAppServerSandboxMode;
   serviceTier?: CodexServiceTier;
   config?: CodexAppServerAuthProfileLookup["config"];
+  dynamicTools?: CodexDynamicToolSpec[];
+  dynamicToolsFingerprint?: string;
 }): Promise<void> {
   const runtime = resolveCodexAppServerRuntimeOptions({
     pluginConfig: params.pluginConfig,
@@ -351,6 +385,7 @@ async function createThread(params: {
         : {}),
       developerInstructions:
         "This Codex thread is bound to an OpenClaw conversation. Answer normally; OpenClaw will deliver your final response back to the conversation.",
+      dynamicTools: params.dynamicTools ?? [],
       experimentalRawEvents: true,
       persistExtendedHistory: true,
     },
@@ -373,6 +408,8 @@ async function createThread(params: {
       approvalPolicy: params.approvalPolicy ?? runtimeApprovalPolicy,
       sandbox: params.sandbox ?? runtime.sandbox,
       serviceTier: params.serviceTier ?? runtime.serviceTier,
+      dynamicToolsFingerprint: params.dynamicToolsFingerprint ?? codexDynamicToolsFingerprint([]),
+      threadBindingOrigin: "managed",
     },
     {
       ...agentLookup,
@@ -384,41 +421,125 @@ async function runBoundTurn(params: {
   data: CodexAppServerConversationBindingData;
   prompt: string;
   event: PluginHookInboundClaimEvent;
+  ctx: PluginHookInboundClaimContext;
   pluginConfig?: unknown;
+  config?: OpenClawConfig;
   timeoutMs?: number;
 }): Promise<BoundTurnResult> {
   const runtime = resolveCodexAppServerRuntimeOptions({
     pluginConfig: params.pluginConfig,
   });
   const agentLookup = buildAgentLookup({ agentDir: params.data.agentDir });
-  const binding = await readCodexAppServerBinding(params.data.sessionFile, agentLookup);
-  const threadId = binding?.threadId;
+  let binding = await readCodexAppServerBinding(params.data.sessionFile, agentLookup);
+  let threadId = binding?.threadId;
   if (!threadId) {
     throw new Error("bound Codex conversation has no thread binding");
+  }
+  if (!binding) {
+    throw new Error("bound Codex conversation has no sidecar binding");
+  }
+  const turnAbortController = new AbortController();
+  const toolBridge = await buildConversationDynamicToolBridge({
+    pluginConfig: params.pluginConfig,
+    config: params.config,
+    workspaceDir: binding?.cwd || params.data.workspaceDir,
+    ...(params.data.agentDir ? { agentDir: params.data.agentDir } : {}),
+    event: params.event,
+    ctx: params.ctx,
+    signal: turnAbortController.signal,
+  });
+  const dynamicToolsFingerprint = codexDynamicToolsFingerprint(toolBridge.specs);
+  // Older bound sidecars predate dynamic-tool fingerprints and origin markers.
+  // Only known managed sidecars may be refreshed automatically; no-origin
+  // legacy bindings might be explicit /codex resume selections and must keep
+  // their selected thread until the user refreshes it deliberately.
+  // Empty catalogs are recorded in place to avoid losing bound thread context.
+  if (binding.dynamicToolsFingerprint === undefined && toolBridge.specs.length === 0) {
+    await writeCodexAppServerBinding(
+      params.data.sessionFile,
+      {
+        ...binding,
+        dynamicToolsFingerprint,
+      },
+      agentLookup,
+    );
+    binding = await readCodexAppServerBinding(params.data.sessionFile, agentLookup);
+    if (!binding) {
+      throw new Error(
+        "bound Codex conversation has no sidecar binding after dynamic tool fingerprint update",
+      );
+    }
+  }
+  const shouldRefreshDynamicTools =
+    (binding.dynamicToolsFingerprint === undefined &&
+      binding.threadBindingOrigin === "managed" &&
+      toolBridge.specs.length > 0) ||
+    (binding.dynamicToolsFingerprint !== undefined &&
+      !areCodexDynamicToolFingerprintsCompatible({
+        previous: binding.dynamicToolsFingerprint,
+        next: dynamicToolsFingerprint,
+      }));
+  if (shouldRefreshDynamicTools) {
+    await createThread({
+      pluginConfig: params.pluginConfig,
+      sessionFile: params.data.sessionFile,
+      workspaceDir: binding.cwd || params.data.workspaceDir,
+      ...(params.data.agentDir ? { agentDir: params.data.agentDir } : {}),
+      model: binding.model,
+      modelProvider: binding.modelProvider,
+      authProfileId: binding.authProfileId,
+      approvalPolicy: binding.approvalPolicy,
+      sandbox: binding.sandbox,
+      serviceTier: binding.serviceTier,
+      config: params.config,
+      dynamicTools: toolBridge.specs,
+      dynamicToolsFingerprint,
+    });
+    binding = await readCodexAppServerBinding(params.data.sessionFile, agentLookup);
+    threadId = binding?.threadId;
+    if (!threadId) {
+      throw new Error("bound Codex conversation has no thread binding after dynamic tool refresh");
+    }
+  }
+  const activeBinding = binding;
+  if (!activeBinding) {
+    throw new Error("bound Codex conversation has no sidecar binding after dynamic tool refresh");
   }
 
   const client = await getSharedCodexAppServerClient({
     startOptions: runtime.start,
     timeoutMs: runtime.requestTimeoutMs,
-    authProfileId: binding.authProfileId,
+    authProfileId: activeBinding.authProfileId,
     ...agentLookup,
   });
   const collector = createCodexConversationTurnCollector(threadId);
+  let activeTurnId: string | undefined;
   const notificationCleanup = client.addNotificationHandler((notification) =>
     collector.handleNotification(notification),
   );
   const requestCleanup = client.addRequestHandler(
     async (request): Promise<JsonValue | undefined> => {
       if (request.method === "item/tool/call") {
-        return {
-          contentItems: [
-            {
-              type: "inputText",
-              text: "OpenClaw native Codex conversation binding does not expose dynamic OpenClaw tools yet.",
-            },
-          ],
-          success: false,
-        };
+        // Other bound turns may share this app-server client, so only dispatch
+        // tool calls that target this turn's thread and active turn id.
+        const call = readCodexDynamicToolCallParams(request.params);
+        if (
+          !call ||
+          call.threadId !== threadId ||
+          activeTurnId === undefined ||
+          call.turnId !== activeTurnId
+        ) {
+          return undefined;
+        }
+        return handleDynamicToolCallWithTimeout({
+          call,
+          toolBridge,
+          signal: turnAbortController.signal,
+          timeoutMs: resolveDynamicToolCallTimeoutMs({
+            call,
+            config: params.config,
+          }),
+        });
       }
       if (
         request.method === "item/commandExecution/requestApproval" ||
@@ -452,21 +573,22 @@ async function runBoundTurn(params: {
           prompt: params.prompt,
           event: params.event,
         }),
-        cwd: binding.cwd || params.data.workspaceDir,
-        approvalPolicy: binding.approvalPolicy ?? runtime.approvalPolicy,
+        cwd: activeBinding.cwd || params.data.workspaceDir,
+        approvalPolicy: activeBinding.approvalPolicy ?? runtime.approvalPolicy,
         approvalsReviewer: runtime.approvalsReviewer,
         sandboxPolicy: codexSandboxPolicyForTurn(
-          binding.sandbox ?? runtime.sandbox,
-          binding.cwd || params.data.workspaceDir,
+          activeBinding.sandbox ?? runtime.sandbox,
+          activeBinding.cwd || params.data.workspaceDir,
         ),
-        ...(binding.model ? { model: binding.model } : {}),
-        ...((binding.serviceTier ?? runtime.serviceTier)
-          ? { serviceTier: binding.serviceTier ?? runtime.serviceTier }
+        ...(activeBinding.model ? { model: activeBinding.model } : {}),
+        ...((activeBinding.serviceTier ?? runtime.serviceTier)
+          ? { serviceTier: activeBinding.serviceTier ?? runtime.serviceTier }
           : {}),
       },
       { timeoutMs: runtime.requestTimeoutMs },
     );
     const turnId = response.turn.id;
+    activeTurnId = turnId;
     const activeCleanup = trackCodexConversationActiveTurn({
       sessionFile: params.data.sessionFile,
       threadId,
@@ -485,6 +607,7 @@ async function runBoundTurn(params: {
       },
     };
   } finally {
+    turnAbortController.abort("codex conversation turn finished");
     notificationCleanup();
     requestCleanup();
   }
@@ -494,7 +617,9 @@ async function runBoundTurnWithMissingThreadRecovery(params: {
   data: CodexAppServerConversationBindingData;
   prompt: string;
   event: PluginHookInboundClaimEvent;
+  ctx: PluginHookInboundClaimContext;
   pluginConfig?: unknown;
+  config?: OpenClawConfig;
   timeoutMs?: number;
 }): Promise<BoundTurnResult> {
   try {
@@ -516,9 +641,65 @@ async function runBoundTurnWithMissingThreadRecovery(params: {
       approvalPolicy: binding?.approvalPolicy,
       sandbox: binding?.sandbox,
       serviceTier: binding?.serviceTier,
+      config: params.config,
     });
     return await runBoundTurn(params);
   }
+}
+
+async function buildConversationDynamicToolBridge(params: {
+  pluginConfig?: unknown;
+  config?: OpenClawConfig;
+  workspaceDir: string;
+  agentDir?: string;
+  event?: PluginHookInboundClaimEvent;
+  ctx?: PluginHookInboundClaimContext;
+  signal?: AbortSignal;
+}): Promise<CodexDynamicToolBridge> {
+  const signal = params.signal ?? new AbortController().signal;
+  const codexConfig = readCodexPluginConfig(params.pluginConfig);
+  const { createOpenClawCodingTools } = await import("openclaw/plugin-sdk/agent-harness");
+  // The bound conversation is the security boundary for tool replies and
+  // session state. ctx.channelId is only the provider id (for example,
+  // "telegram"), so it must never be used as a conversation fallback.
+  const boundConversationId =
+    params.ctx?.pluginBinding?.conversationId ??
+    params.ctx?.conversationId ??
+    params.event?.conversationId;
+  const allTools = createOpenClawCodingTools({
+    includeCoreTools: false,
+    config: params.config,
+    ...(params.agentDir ? { agentDir: params.agentDir } : {}),
+    workspaceDir: params.workspaceDir,
+    spawnWorkspaceDir: params.workspaceDir,
+    sessionId: boundConversationId,
+    sessionKey: params.ctx?.sessionKey,
+    runId: params.ctx?.runId,
+    messageProvider: params.event?.channel,
+    agentAccountId: params.event?.accountId,
+    messageTo: boundConversationId,
+    messageThreadId: params.event?.threadId,
+    currentChannelId: boundConversationId,
+    currentMessageId: params.event?.messageId,
+    senderId: params.event?.senderId,
+    senderName: params.event?.senderName,
+    senderUsername: params.event?.senderUsername,
+    allowGatewaySubagentBinding: true,
+    abortSignal: signal,
+  });
+  const tools = filterCodexDynamicTools(allTools, codexConfig);
+  return createCodexDynamicToolBridge({
+    tools,
+    signal,
+    hookContext: {
+      config: params.config,
+      sessionId: boundConversationId,
+      sessionKey: params.ctx?.sessionKey,
+      runId: params.ctx?.runId,
+      channelId: boundConversationId,
+    },
+    loading: resolveCodexDynamicToolsLoading(codexConfig),
+  });
 }
 
 function isCodexThreadNotFoundError(error: unknown): boolean {

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -586,6 +586,60 @@ describe("loadPluginManifestRegistry", () => {
     expect(registry.plugins[0]?.origin).toBe("global");
   });
 
+  it("prefers bundled official plugins over stale installed official globals", () => {
+    const bundledDir = makeTempDir();
+    const globalDir = makeTempDir();
+    writeManifest(bundledDir, {
+      id: "codex",
+      version: "2026.5.19",
+      configSchema: { type: "object" },
+    });
+    writeManifest(globalDir, {
+      id: "codex",
+      version: "2026.5.12",
+      configSchema: { type: "object" },
+    });
+
+    const registry = loadPluginManifestRegistry({
+      env: hermeticEnv({ OPENCLAW_VERSION: "2026.5.19" }),
+      installRecords: {
+        codex: {
+          source: "npm",
+          installPath: globalDir,
+          resolvedName: "@openclaw/codex",
+          resolvedVersion: "2026.5.12",
+        },
+      },
+      candidates: [
+        createPluginCandidate({
+          idHint: "codex",
+          rootDir: globalDir,
+          packageName: "@openclaw/codex",
+          packageVersion: "2026.5.12",
+          origin: "global",
+        }),
+        createPluginCandidate({
+          idHint: "codex",
+          rootDir: bundledDir,
+          packageName: "@openclaw/codex",
+          packageVersion: "2026.5.19",
+          origin: "bundled",
+        }),
+      ],
+    });
+
+    expect(countDuplicateWarnings(registry)).toBe(1);
+    expect(registry.plugins).toHaveLength(1);
+    expectRecordFields(registry.plugins[0], "plugin", {
+      origin: "bundled",
+      version: "2026.5.19",
+    });
+    expectRegistryDiagnosticContains(
+      registry,
+      "global plugin will be overridden by bundled plugin",
+    );
+  });
+
   it("marks official installed npm globals as trusted official installs", () => {
     const dir = makeTempDir();
     writeManifest(dir, { id: "diagnostics-prometheus", configSchema: { type: "object" } });

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import type { OpenClawConfig } from "../config/types.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
+import { compareOpenClawVersions } from "../config/version.js";
 import { isBlockedObjectKey } from "../infra/prototype-keys.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { normalizeOptionalTrimmedStringList } from "../shared/string-normalization.js";
@@ -837,6 +838,38 @@ function isTrustedOfficialPluginInstall(params: {
   return false;
 }
 
+function resolveCandidateInstallVersion(params: {
+  pluginId: string;
+  candidate: PluginCandidate;
+  installRecords: Record<string, PluginInstallRecord>;
+}): string | undefined {
+  const candidateVersion = normalizeOptionalString(params.candidate.packageVersion);
+  if (candidateVersion) {
+    return candidateVersion;
+  }
+  const record = params.installRecords[params.pluginId];
+  return (
+    normalizeOptionalString(record?.resolvedVersion) ??
+    normalizeOptionalString(record?.version) ??
+    normalizeOptionalString(record?.resolvedSpec?.split("@").at(-1))
+  );
+}
+
+function isStaleTrustedOfficialPluginInstall(params: {
+  pluginId: string;
+  candidate: PluginCandidate;
+  env: NodeJS.ProcessEnv;
+  installRecords: Record<string, PluginInstallRecord>;
+}): boolean {
+  if (!isTrustedOfficialPluginInstall(params)) {
+    return false;
+  }
+  const installedVersion = resolveCandidateInstallVersion(params);
+  const hostVersion = resolveCompatibilityHostVersion(params.env);
+  const comparison = compareOpenClawVersions(installedVersion, hostVersion);
+  return comparison !== null && comparison < 0;
+}
+
 function resolveDuplicatePrecedenceRank(params: {
   pluginId: string;
   candidate: PluginCandidate;
@@ -857,6 +890,12 @@ function resolveDuplicatePrecedenceRank(params: {
       installRecords: params.installRecords,
     })
   ) {
+    if (isStaleTrustedOfficialPluginInstall(params)) {
+      // Official plugin packages can lag behind a linked or upgraded host. In
+      // duplicate resolution, prefer the bundled host copy over stale official
+      // installs so old runtime packages do not silently shadow current fixes.
+      return 3.5;
+    }
     return 1;
   }
   if (params.candidate.origin === "bundled") {
@@ -891,6 +930,18 @@ function isIntentionalInstalledBundledDuplicate(params: {
     env: params.env,
     installRecords: params.installRecords,
   });
+  const installedCandidate = leftIsInstalled ? params.left : rightIsInstalled ? params.right : null;
+  if (
+    installedCandidate &&
+    isStaleTrustedOfficialPluginInstall({
+      pluginId: params.pluginId,
+      candidate: installedCandidate,
+      env: params.env,
+      installRecords: params.installRecords,
+    })
+  ) {
+    return false;
+  }
   return (
     (leftIsInstalled && params.right.origin === "bundled") ||
     (rightIsInstalled && params.left.origin === "bundled")

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -991,7 +991,7 @@ describe("resolvePluginTools optional tools", () => {
     expectResolvedToolNames(tools, ["optional_tool"]);
   });
 
-  it("keeps default non-optional plugin tools when alsoAllow opts into optional tools", () => {
+  it("does not widen alsoAllow discovery to unrelated default plugin tools", () => {
     const defaultEntry: MockRegistryToolEntry = {
       pluginId: "multi",
       optional: false,
@@ -1008,10 +1008,10 @@ describe("resolvePluginTools optional tools", () => {
       }),
     );
 
-    expectResolvedToolNames(tools, ["other_tool", "optional_tool"]);
+    expectResolvedToolNames(tools, ["optional_tool"]);
   });
 
-  it("cold-loads default plugin tools when alsoAllow opts into optional tools", () => {
+  it("cold-loads only selected plugins when alsoAllow opts into optional tools", () => {
     const context = createContext();
     const config = context.config;
     const defaultEntry: MockRegistryToolEntry = {
@@ -1058,8 +1058,8 @@ describe("resolvePluginTools optional tools", () => {
       }),
     );
 
-    expectResolvedToolNames(tools, ["other_tool", "optional_tool"]);
-    expectLoaderSelectedOnlyPluginIds(["multi", "optional-demo"]);
+    expectResolvedToolNames(tools, ["optional_tool"]);
+    expectLoaderSelectedOnlyPluginIds(["optional-demo"]);
   });
 
   it("does not cold-load unrelated manifest-optional plugins when alsoAllow opts into one optional tool", () => {

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -361,7 +361,8 @@ function listManifestToolNamesForAllowlist(params: {
     return [...params.toolNames];
   }
   const pluginKey = normalizeToolName(params.pluginId);
-  if (params.allowlist.has(pluginKey)) {
+  const pluginSelected = params.allowlist.has(pluginKey);
+  if (pluginSelected) {
     return [...params.toolNames];
   }
   const matchedToolNames = params.toolNames.filter((name) =>
@@ -369,6 +370,9 @@ function listManifestToolNamesForAllowlist(params: {
   );
   if (!allowlistIncludesDefaultPluginTools(params.allowlist)) {
     return matchedToolNames;
+  }
+  if (params.allowlist.size > 1 && matchedToolNames.length === 0) {
+    return [];
   }
   const defaultToolNames = params.toolNames.filter(
     (name) => !isManifestToolOptional(params.plugin, name),


### PR DESCRIPTION
## Summary
- expose OpenClaw dynamic plugin tools to native bound Codex conversation threads
- refresh managed Codex bindings when the dynamic-tool surface changes
- route Codex app-server dynamic tool calls back through OpenClaw plugin handlers with bounded timeouts
- keep bundled Codex host manifests from being shadowed by stale official global plugin installs

## Motivation
On macOS, the Kynver AgentOS OpenClaw plugin could be loaded and runtime inspection could see its `agent_os_*` contracts, but native Codex conversation threads did not receive those dynamic tool specs as callable tools. That meant `agent_os_get_context` and related tools were visible to OpenClaw inspection but missing from the Codex-visible tool surface.

This PR recovers the working local Track 2 patch from a macOS OpenClaw/Codex install where the AgentOS tools became callable after the Codex bridge change.

## Before / After
Before:
- plugin runtime inspection could see imported Kynver AgentOS tool contracts
- native bound Codex threads did not expose the imported dynamic tools to Codex tool calls

After:
- managed Codex conversation bindings include the current OpenClaw dynamic-tool surface
- tool-surface changes trigger binding refresh instead of leaving stale Codex-visible tools
- Codex dynamic tool calls dispatch through OpenClaw plugin handlers rather than failing as missing tools

## Verification
Focused tests run in the prepared recovery checkout:

```bash
node scripts/test-projects.mjs extensions/codex/src/conversation-binding.test.ts src/plugins/manifest-registry.test.ts src/plugins/tools.optional.test.ts
```

Result:
- plugin shard: 125 passed
- Codex extension shard: 19 passed

Additional checks:

```bash
git diff --cached --check -- .
```

The same whitespace check passed again after replaying the patch onto a fresh `openclaw/openclaw` clone. The fresh clone did not have dependencies installed, so the focused test command there stopped at missing `vitest/package.json` before tests started.

MacOS smoke from the patched local setup:
- fresh OpenClaw/Codex tool discovery exposed `agent_os_get_context`
- calling it reached the tool bridge successfully instead of failing as a missing tool

## Scope
The patch is limited to the Codex conversation binding / dynamic tool bridge and supporting plugin registry behavior needed for that path. No secrets or local machine paths are included.
