### PR TITLE
fix(agent): ignore stale prompt image refs in fallback turns

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt-trajectory-status.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt-trajectory-status.test.ts
@@ -177,12 +177,24 @@ describe("attempt trajectory status", () => {
     ).toEqual({ status: "success" });
   });
 
-  it("preserves prompt errors and interrupts", () => {
+  it("treats external aborts with no delivery/progress as candidate failure", () => {
+    expect(resolveAttemptTrajectoryTerminal(baseParams({ aborted: true }))).toEqual({
+      status: "error",
+      terminalError: NON_DELIVERABLE_TERMINAL_TURN_REASON,
+    });
+  });
+
+  it("preserves prompt errors and true timeouts as interrupts", () => {
     expect(
       resolveAttemptTrajectoryTerminal(baseParams({ promptError: new Error("boom") })),
     ).toEqual({ status: "error" });
     expect(resolveAttemptTrajectoryTerminal(baseParams({ timedOut: true }))).toEqual({
       status: "interrupted",
     });
+    expect(resolveAttemptTrajectoryTerminal(baseParams({ aborted: true, timedOut: true }))).toEqual(
+      {
+        status: "interrupted",
+      },
+    );
   });
 });

--- a/src/agents/pi-embedded-runner/run/attempt-trajectory-status.ts
+++ b/src/agents/pi-embedded-runner/run/attempt-trajectory-status.ts
@@ -77,6 +77,26 @@ export function resolveAttemptTrajectoryTerminal(
   if (params.promptError) {
     return { status: "error" };
   }
+
+  const externallyAbortedWithoutDelivery =
+    params.aborted &&
+    !params.timedOut &&
+    !hasNonEmptyAssistantText(params.assistantTexts) &&
+    !params.didSendDeterministicApprovalPrompt &&
+    !hasCommittedMessagingDeliveryEvidence(params) &&
+    !hasAcceptedSessionSpawn(params.acceptedSessionSpawns) &&
+    params.synthesizedPayloadCount <= 0 &&
+    params.heartbeatToolResponse === undefined &&
+    (params.clientToolCalls?.length ?? 0) === 0 &&
+    params.yieldDetected !== true &&
+    params.lastToolError === undefined;
+  if (externallyAbortedWithoutDelivery) {
+    return {
+      status: "error",
+      terminalError: NON_DELIVERABLE_TERMINAL_TURN_REASON,
+    };
+  }
+
   if (params.aborted || params.timedOut) {
     return { status: "interrupted" };
   }

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -3869,6 +3869,7 @@ export async function runEmbeddedAttempt(
                 maxBytes: MAX_IMAGE_BYTES,
                 maxDimensionPx: resolveImageSanitizationLimits(params.config).maxDimensionPx,
                 workspaceOnly: effectiveFsWorkspaceOnly,
+                includePromptRefImages: false,
                 // Enforce sandbox path restrictions when sandbox is enabled
                 sandbox:
                   sandbox?.enabled && sandbox?.fsBridge

--- a/src/agents/pi-embedded-runner/run/images.test.ts
+++ b/src/agents/pi-embedded-runner/run/images.test.ts
@@ -171,6 +171,35 @@ describe("detectImageReferences", () => {
     expectNoImageReferences("Just some text without any image references");
   });
 
+  it("can skip historical prompt refs while keeping explicit attachments", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "images-skip-history-"));
+    const historyPath = path.join(dir, "history.png");
+    const attachedPath = path.join(dir, "attached.png");
+    const pngB64 =
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=";
+    await fs.writeFile(historyPath, Buffer.from(pngB64, "base64"));
+    await fs.writeFile(attachedPath, Buffer.from(pngB64, "base64"));
+
+    const result = await detectAndLoadPromptImages({
+      prompt:
+        `[media attached: 1 files]\n` +
+        `[media attached 1/1: ${attachedPath} (image/png)]\n` +
+        `[Image: source: ${historyPath}]\n` +
+        "Please answer with text only",
+      workspaceDir: dir,
+      model: { input: ["text", "image"] },
+      includePromptRefImages: false,
+      workspaceOnly: true,
+    });
+
+    expect(result.detectedRefs).toHaveLength(2);
+    expect(result.images).toHaveLength(1);
+    expect(result.loadedCount).toBe(1);
+    expect(result.skippedCount).toBe(1);
+
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
   it("ignores non-image file extensions", () => {
     expectNoImageReferences("Check /path/to/document.pdf and /code/file.ts");
   });

--- a/src/agents/pi-embedded-runner/run/images.ts
+++ b/src/agents/pi-embedded-runner/run/images.ts
@@ -204,6 +204,33 @@ function extractLeadingInlineAttachmentRefs(prompt: string, count: number): Dete
   return detectImageReferences(attachmentPrompt).slice(0, count);
 }
 
+function extractDeclaredAttachmentBlockRefs(prompt: string): DetectedImageRef[] {
+  const lines = prompt.split(/\r?\n/);
+  const refs: DetectedImageRef[] = [];
+  for (let index = 0; index < lines.length; index++) {
+    const header = lines[index]?.trim().match(/^\[media attached:\s*(\d+)\s+files?\]$/i);
+    if (!header?.[1]) {
+      continue;
+    }
+    const expectedCount = Number.parseInt(header[1], 10);
+    if (!Number.isFinite(expectedCount) || expectedCount <= 0) {
+      continue;
+    }
+    const blockLines: string[] = [];
+    for (let offset = 1; offset <= expectedCount; offset++) {
+      const line = lines[index + offset]?.trim();
+      if (!line || !/^\[media attached\s+\d+\/\d+:\s*[^\]]+\]$/i.test(line)) {
+        break;
+      }
+      blockLines.push(line);
+    }
+    if (blockLines.length === expectedCount) {
+      refs.push(...detectImageReferences(blockLines.join("\n")));
+    }
+  }
+  return refs;
+}
+
 function extractTrailingAttachmentMediaUris(prompt: string, count: number): string[] {
   if (count <= 0) {
     return [];
@@ -252,6 +279,9 @@ export function splitPromptAndAttachmentRefs(params: {
   const attachmentUris = new Set(
     offloadedCount > 0 ? extractTrailingAttachmentMediaUris(params.prompt, offloadedCount) : [],
   );
+  const declaredAttachmentRefs = createRefCountMap(
+    extractDeclaredAttachmentBlockRefs(params.prompt),
+  );
 
   const promptRefs: DetectedImageRef[] = [];
   const attachmentRefs: DetectedImageRef[] = [];
@@ -259,7 +289,10 @@ export function splitPromptAndAttachmentRefs(params: {
     if (consumeRefCount(inlineAttachmentRefs, ref)) {
       continue;
     }
-    if (ref.type === "media-uri" && attachmentUris.has(ref.resolved)) {
+    if (
+      (ref.type === "media-uri" && attachmentUris.has(ref.resolved)) ||
+      consumeRefCount(declaredAttachmentRefs, ref)
+    ) {
       attachmentRefs.push(ref);
       continue;
     }
@@ -519,6 +552,7 @@ export async function detectAndLoadPromptImages(params: {
   maxBytes?: number;
   maxDimensionPx?: number;
   workspaceOnly?: boolean;
+  includePromptRefImages?: boolean;
   sandbox?: { root: string; bridge: SandboxFsBridge };
 }): Promise<{
   /** Images for the current prompt (existingImages + detected in current prompt) */
@@ -561,25 +595,33 @@ export async function detectAndLoadPromptImages(params: {
     imageOrder: params.imageOrder,
     existingImageCount: params.existingImages?.length,
   });
+  const includePromptRefImages = params.includePromptRefImages ?? true;
   const promptRefImages: ImageContent[] = [];
   const offloadedImages: Array<ImageContent | null> = [];
 
   let loadedCount = 0;
   let skippedCount = 0;
 
-  for (const ref of promptRefs) {
-    const image = await loadImageFromRef(ref, params.workspaceDir, {
-      maxBytes: params.maxBytes,
-      workspaceOnly: params.workspaceOnly,
-      sandbox: params.sandbox,
-    });
-    if (image) {
-      promptRefImages.push(image);
-      loadedCount++;
-      log.debug(`Native image: loaded ${ref.type} ${ref.resolved}`);
-    } else {
-      skippedCount++;
+  if (includePromptRefImages) {
+    for (const ref of promptRefs) {
+      const image = await loadImageFromRef(ref, params.workspaceDir, {
+        maxBytes: params.maxBytes,
+        workspaceOnly: params.workspaceOnly,
+        sandbox: params.sandbox,
+      });
+      if (image) {
+        promptRefImages.push(image);
+        loadedCount++;
+        log.debug(`Native image: loaded ${ref.type} ${ref.resolved}`);
+      } else {
+        skippedCount++;
+      }
     }
+  } else if (promptRefs.length > 0) {
+    skippedCount += promptRefs.length;
+    log.debug(
+      `Native image: ignored ${promptRefs.length} historical prompt image ref(s) (includePromptRefImages=false)`,
+    );
   }
 
   for (const ref of attachmentRefs) {


### PR DESCRIPTION
## Summary
- skip historical prompt image refs when loading images for embedded attempts so stale Telegram/context refs cannot poison text-only follow-up turns
- keep explicit current-turn attachment refs loadable
- classify externally aborted attempts with no visible text/tool/message side effect as non-deliverable errors instead of success
- add regression coverage for stale image ref skipping and aborted fallback classification

## Verification
- `timeout 300 pnpm vitest src/agents/pi-embedded-runner/run/attempt-trajectory-status.test.ts src/agents/pi-embedded-runner/run/images.test.ts`
  - 3 test files passed
  - 91 tests passed

## Root cause
Telegram image history from earlier context was being reloaded into later text-only fallback prompts, causing Azure Foundry to reject the request with `400 Invalid base64 image_url`. A later fallback abort could then be misclassified as success despite no user-visible delivery.