### PR TITLE
[codex] Clarify inherited thinking off label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Docs: https://docs.openclaw.ai
 - Agents/Codex: promote a completed final assistant response when a prompt timeout races Codex app-server completion instead of returning an empty timeout envelope. Refs #84516.
 - Agents: cap heartbeat model bleed context hints by the stored session window when runtime model metadata is unavailable, so overflow recovery advice does not suggest a larger window than the active session actually has.
 - Control UI/Web Push: use `https://openclaw.ai` as the generated default VAPID subject instead of the old localhost mailbox so iOS PWA push setup uses an Apple-acceptable subject when `OPENCLAW_VAPID_SUBJECT` is unset. Fixes #83134. (#83317) Thanks @IWhatsskill.
+- Control UI: distinguish inherited thinking-off settings from explicit Off selections so the thinking selector no longer shows two identical Off rows. (#85223) Thanks @amknight.
 - Agents/Pi: keep embedded session transcript writes from tripping false takeover detection after packaged npm onboarding agent turns.
 - Codex/TUI: surface Codex-native post-turn compaction failures instead of continuing uncompacted, and keep successful native compaction serialized before local idle/next-turn handling. Fixes #84305. (#85160) Thanks @joshavant.
 - Memory/search: stop recall tracking from writing dreaming side-effect artifacts when `dreaming.enabled=false`, while preserving normal search results. Fixes #84436. (#84444) Thanks @NianJiuZst.

--- a/docs/tools/thinking.md
+++ b/docs/tools/thinking.md
@@ -124,8 +124,8 @@ Malformed local-model reasoning tags are handled conservatively. Closed `<think>
 
 - The web chat thinking selector mirrors the session's stored level from the inbound session store/config when the page loads.
 - Picking another level writes the session override immediately via `sessions.patch`; it does not wait for the next send and it is not a one-shot `thinkingOnce` override.
-- The first option is always the clear-override choice. It shows `Inherited: <resolved level>` when the session is inheriting a non-off effective default, or `Off` when inherited thinking is disabled.
-- Explicit picker choices are labeled as overrides, while preserving provider labels when present (for example `Override: maximum` for a provider-labeled `max` option).
+- The first option is always the clear-override choice. It shows `Inherited: <resolved level>`, including `Inherited: Off` when inherited thinking is disabled.
+- Explicit picker choices use their direct level labels while preserving provider labels when present (for example `Maximum` for a provider-labeled `max` option).
 - The picker uses `thinkingLevels` returned by the gateway session row/defaults, with `thinkingOptions` kept as a legacy label list. The browser UI does not keep its own provider regex list; plugins own model-specific level sets.
 - `/think:<level>` still works and updates the same stored session level, so chat directives and the picker stay in sync.
 

--- a/ui/src/ui/thinking-labels.ts
+++ b/ui/src/ui/thinking-labels.ts
@@ -7,9 +7,6 @@ export function normalizeThinkingOptionValue(raw: string): string {
 
 export function formatInheritedThinkingLabel(effectiveLevel: string | null | undefined): string {
   const normalized = effectiveLevel ? normalizeThinkingOptionValue(effectiveLevel) : "off";
-  if (!normalized || normalized === "off") {
-    return "Off";
-  }
   return `Inherited: ${formatThinkingLevelDisplayLabel(normalized)}`;
 }
 

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -1407,7 +1407,7 @@ describe("chat session controls", () => {
     ]);
     expect(
       [...(thinkingSelect?.options ?? [])].map((option) => option.textContent?.trim()),
-    ).toEqual(["Off", "Off", "Adaptive", "Extra high", "Maximum"]);
+    ).toEqual(["Inherited: Off", "Off", "Adaptive", "Extra high", "Maximum"]);
   });
 
   it("labels chat thinking default from the active session row", () => {


### PR DESCRIPTION
## Summary

- Label the inherited/default thinking selector option as `Inherited: Off` when the effective default is off.
- Keep the explicit `Off` override option available, so users can still distinguish clearing an override from pinning thinking off.
- Update the Web chat UI thinking docs to describe the inherited label and direct explicit option labels.
- Add the Unreleased changelog entry for the user-visible Control UI fix.

## Verification

- `node scripts/run-vitest.mjs ui/src/ui/views/chat.test.ts ui/src/ui/views/sessions.test.ts`
- `pnpm exec oxfmt --check ui/src/ui/thinking-labels.ts ui/src/ui/views/chat.test.ts`
- `git diff --check`
- `pnpm docs:list`
- `AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --mode local`

## Real behavior proof

Behavior addressed: The Control UI thinking selector no longer shows two visually identical `Off` rows when inherited thinking is disabled and explicit `off` is also available.

Real environment tested: Local OpenClaw worktree on macOS with repository dependencies installed via `pnpm install`.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs ui/src/ui/views/chat.test.ts ui/src/ui/views/sessions.test.ts`

Evidence after fix: The chat selector test now expects option labels `Inherited: Off`, `Off`, `Adaptive`, `Extra high`, and `Maximum`; the sessions selector coverage still passes.

Observed result after fix: 2 test files passed, 62 tests passed.

What was not tested: I did not run a full browser/manual Control UI smoke or the full repository check suite; this change is scoped to selector labeling plus matching docs/changelog.