### PR TITLE
[codex] add color mode tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/Copilot: drop unsafe GitHub Copilot Responses reasoning replay items before send so Telegram direct sessions no longer fail on overlong replay IDs. Fixes #85197. (#85198) Thanks @galiniliev.
-- UI: add accessible tooltips to the topbar color-mode buttons so System, Light, and Dark choices are labeled on hover and focus. (#85227)
+- UI: add accessible tooltips to the topbar color-mode buttons so System, Light, and Dark choices are labeled on hover and focus. (#85227) Thanks @amknight.
 - fix: constrain Windows task script names [AI]. (#85064) Thanks @pgondhi987.
 - Agents/Anthropic: preserve unsafe integer tool-call input values in streamed Anthropic tool-use JSON, preventing Discord-style IDs from being rounded before dispatch. Fixes #47229. (#83063) Thanks @leno23.
 - Agents/hooks: wait for local one-shot CLI and Codex `agent_end` plugin hooks before process cleanup so terminal observability flushes reliably. (#85007)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/Copilot: drop unsafe GitHub Copilot Responses reasoning replay items before send so Telegram direct sessions no longer fail on overlong replay IDs. Fixes #85197. (#85198) Thanks @galiniliev.
+- UI: add accessible tooltips to the topbar color-mode buttons so System, Light, and Dark choices are labeled on hover and focus. (#85227)
 - fix: constrain Windows task script names [AI]. (#85064) Thanks @pgondhi987.
 - Agents/Anthropic: preserve unsafe integer tool-call input values in streamed Anthropic tool-use JSON, preventing Discord-style IDs from being rounded before dispatch. Fixes #47229. (#83063) Thanks @leno23.
 - Agents/hooks: wait for local one-shot CLI and Codex `agent_end` plugin hooks before process cleanup so terminal observability flushes reliably. (#85007)

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -336,6 +336,7 @@
 }
 
 .topbar-theme-mode__btn {
+  position: relative;
   width: 30px;
   height: 30px;
   display: inline-flex;
@@ -377,6 +378,90 @@
   stroke-width: 1.75px;
   stroke-linecap: round;
   stroke-linejoin: round;
+}
+
+.topbar-theme-mode__btn[data-tooltip]::before,
+.topbar-theme-mode__btn[data-tooltip]::after {
+  position: absolute;
+  left: 50%;
+  pointer-events: none;
+  opacity: 0;
+  transition:
+    opacity var(--duration-fast) var(--ease-out),
+    transform var(--duration-fast) var(--ease-out);
+  z-index: 60;
+}
+
+.topbar-theme-mode__btn[data-tooltip]::before {
+  content: "";
+  top: calc(100% + 4px);
+  border-width: 6px;
+  border-style: solid;
+  border-color: transparent transparent color-mix(in srgb, var(--card) 94%, black 6%) transparent;
+  transform: translate(-50%, -3px);
+}
+
+.topbar-theme-mode__btn[data-tooltip]::after {
+  content: attr(data-tooltip);
+  top: calc(100% + 10px);
+  max-width: min(220px, 60vw);
+  padding: 7px 9px;
+  border: 1px solid color-mix(in srgb, var(--border-strong) 84%, transparent);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--card) 94%, black 6%);
+  box-shadow:
+    0 10px 28px rgba(0, 0, 0, 0.24),
+    0 0 0 1px rgba(255, 255, 255, 0.04);
+  color: var(--text);
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.35;
+  text-align: center;
+  white-space: normal;
+  transform: translate(-50%, -4px);
+}
+
+.topbar-theme-mode__btn:last-child[data-tooltip]::before,
+.topbar-theme-mode__btn:last-child[data-tooltip]::after {
+  left: auto;
+}
+
+.topbar-theme-mode__btn:last-child[data-tooltip]::before {
+  right: 9px;
+  transform: translateY(-3px);
+}
+
+.topbar-theme-mode__btn:last-child[data-tooltip]::after {
+  right: 0;
+  transform: translateY(-4px);
+}
+
+@media (hover: hover) {
+  .topbar-theme-mode__btn[data-tooltip]:hover::before,
+  .topbar-theme-mode__btn[data-tooltip]:hover::after {
+    opacity: 1;
+  }
+
+  .topbar-theme-mode__btn[data-tooltip]:hover::before,
+  .topbar-theme-mode__btn[data-tooltip]:hover::after {
+    transform: translate(-50%, 0);
+  }
+
+  .topbar-theme-mode__btn:last-child[data-tooltip]:hover::before,
+  .topbar-theme-mode__btn:last-child[data-tooltip]:hover::after {
+    transform: translateY(0);
+  }
+}
+
+.topbar-theme-mode__btn[data-tooltip]:focus-visible::before,
+.topbar-theme-mode__btn[data-tooltip]:focus-visible::after {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+.topbar-theme-mode__btn:last-child[data-tooltip]:focus-visible::before,
+.topbar-theme-mode__btn:last-child[data-tooltip]:focus-visible::after {
+  transform: translateY(0);
 }
 
 /* ===========================================

--- a/ui/src/styles/layout.mobile.test.ts
+++ b/ui/src/styles/layout.mobile.test.ts
@@ -13,6 +13,13 @@ function readGroupedChatCss(): string {
   return readStyleSheet("ui/src/styles/chat/grouped.css");
 }
 
+function selectorBlocks(css: string, selector: string): string[] {
+  const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return [...css.matchAll(new RegExp(`${escapedSelector}\\s*\\{[^}]*\\}`, "gs"))].map(
+    (match) => match[0],
+  );
+}
+
 describe("chat header responsive mobile styles", () => {
   it("keeps the chat header and session controls from clipping on narrow widths", () => {
     const css = readMobileCss();
@@ -66,6 +73,29 @@ describe("sidebar menu trigger styles", () => {
       /\.sidebar-new-session__icon svg \{[\s\S]*stroke: currentColor;[\s\S]*fill: none;/,
     );
     expect(css).toMatch(/\.sidebar--collapsed \.sidebar-sessions \{[\s\S]*padding: 0;/);
+  });
+});
+
+describe("topbar theme mode tooltip styles", () => {
+  it("clamps the rightmost color mode tooltip inside the viewport edge", () => {
+    const css = readLayoutCss();
+
+    expect(css).toMatch(
+      /\.topbar-theme-mode__btn:last-child\[data-tooltip\]::after \{[\s\S]*right: 0;/,
+    );
+    expect(css).toMatch(
+      /\.topbar-theme-mode__btn:last-child\[data-tooltip\]:hover::after \{[\s\S]*transform: translateY\(0\);/,
+    );
+    expect(css).toMatch(
+      /\.topbar-theme-mode__btn:last-child\[data-tooltip\]:focus-visible::after \{[\s\S]*transform: translateY\(0\);/,
+    );
+    const tooltipBlock =
+      selectorBlocks(css, ".topbar-theme-mode__btn[data-tooltip]::after").find((block) =>
+        block.includes("content: attr(data-tooltip);"),
+      ) ?? "";
+    expect(tooltipBlock).toBeTruthy();
+    expect(tooltipBlock).not.toContain("min-width:");
+    expect(tooltipBlock).toContain("max-width: min(220px, 60vw);");
   });
 });
 

--- a/ui/src/ui/app-render.helpers.browser.test.ts
+++ b/ui/src/ui/app-render.helpers.browser.test.ts
@@ -1,7 +1,12 @@
 import { render } from "lit";
 import { describe, expect, it, vi } from "vitest";
 import { t } from "../i18n/index.ts";
-import { renderChatControls, renderChatMobileToggle, renderTab } from "./app-render.helpers.ts";
+import {
+  renderChatControls,
+  renderChatMobileToggle,
+  renderTab,
+  renderTopbarThemeModeToggle,
+} from "./app-render.helpers.ts";
 import type { AppViewState } from "./app-view-state.ts";
 import type { SessionsListResult } from "./types.ts";
 
@@ -49,6 +54,7 @@ function createState(overrides: Partial<AppViewState> = {}) {
       chatAutoScroll: "near-bottom",
     },
     applySettings: () => undefined,
+    setThemeMode: () => undefined,
     chatMobileControlsOpen: false,
     setChatMobileControlsOpen: () => undefined,
     chatModelCatalog: [],
@@ -134,6 +140,31 @@ describe("chat header controls (browser)", () => {
       expect(button.getAttribute("title")).toBe(button.getAttribute("data-tooltip"));
       expect(button.getAttribute("aria-label")).toBe(button.getAttribute("data-tooltip"));
     }
+  });
+
+  it("renders explicit hover tooltip metadata for the color mode buttons", async () => {
+    const container = document.createElement("div");
+    render(renderTopbarThemeModeToggle(createState({ themeMode: "system" })), container);
+    await Promise.resolve();
+
+    const buttons = Array.from(
+      container.querySelectorAll<HTMLButtonElement>(".topbar-theme-mode__btn[data-tooltip]"),
+    );
+
+    expect(buttons).toHaveLength(3);
+
+    const labels = buttons.map((button) => button.getAttribute("data-tooltip"));
+    expect(labels).toEqual([
+      t("common.colorModeOption", { mode: t("common.system") }),
+      t("common.colorModeOption", { mode: t("common.light") }),
+      t("common.colorModeOption", { mode: t("common.dark") }),
+    ]);
+
+    for (const button of buttons) {
+      expect(button.getAttribute("title")).toBe(button.getAttribute("data-tooltip"));
+      expect(button.getAttribute("aria-label")).toBe(button.getAttribute("data-tooltip"));
+    }
+    expect(buttons[0]?.classList.contains("topbar-theme-mode__btn--active")).toBe(true);
   });
 
   it.each([

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -793,14 +793,16 @@ export function renderTopbarThemeModeToggle(state: AppViewState) {
     <div class="topbar-theme-mode" role="group" aria-label=${t("common.colorMode")}>
       ${THEME_MODE_OPTIONS.map((opt) => {
         const label = t(opt.labelKey);
+        const tooltip = t("common.colorModeOption", { mode: label });
         return html`
           <button
             type="button"
             class="topbar-theme-mode__btn ${opt.id === state.themeMode
               ? "topbar-theme-mode__btn--active"
               : ""}"
-            title=${label}
-            aria-label=${t("common.colorModeOption", { mode: label })}
+            title=${tooltip}
+            aria-label=${tooltip}
+            data-tooltip=${tooltip}
             aria-pressed=${opt.id === state.themeMode}
             @click=${(e: Event) => applyMode(opt.id, e)}
           >


### PR DESCRIPTION
## Summary

- Add explicit hover/focus tooltip metadata to the topbar color-mode selector buttons.
- Reuse the existing localized `common.colorModeOption` text for monitor/system, light, and dark modes.
- Style the custom tooltip bubble and clamp the rightmost tooltip so long localized text can wrap instead of overflowing the viewport edge.
- Add the required Unreleased changelog fix entry for the UI tooltip change.

## Verification

- `pnpm install` (new worktree dependency install after `vitest/package.json` was missing)
- `node scripts/run-vitest.mjs ui/src/ui/app-render.helpers.browser.test.ts ui/src/styles/layout.mobile.test.ts`
- `pnpm exec oxfmt --check --threads=1 ui/src/styles/layout.css ui/src/styles/layout.mobile.test.ts ui/src/ui/app-render.helpers.ts ui/src/ui/app-render.helpers.browser.test.ts`
- `pnpm docs:list`
- `git diff --check`
- `git diff --check origin/main..HEAD`
- Autoreview: native autoreview found tooltip overflow, fixed; bounded no-tools review after final fix reported no accepted/actionable findings.

## Real behavior proof

Behavior addressed: color-mode icon buttons now expose visible hover/focus tooltips and matching `title`/`aria-label` text.
Real environment tested: local macOS worktree on branch `codex/theme-mode-tooltips` after rebasing onto `origin/main`.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs ui/src/ui/app-render.helpers.browser.test.ts ui/src/styles/layout.mobile.test.ts`.
Evidence after fix: renderer test asserts all three color-mode buttons have `data-tooltip`, `title`, and `aria-label`; style test asserts the rightmost tooltip is right-clamped and can wrap via `max-width` without `min-width`; `CHANGELOG.md` includes the Unreleased fix entry.
Observed result after fix: 2 test files passed, 19 tests passed; changelog/docs sanity checks passed.
What was not tested: manual browser screenshot/hover capture and full UI suite were not run.
