### PR TITLE
Deny sensitive host file mutations

### DIFF
--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -13,7 +13,6 @@ import {
   root as fsRoot,
   FsSafeError,
 } from "../infra/fs-safe.js";
-import { expandHomePrefix, resolveOsHomeDir } from "../infra/home-dir.js";
 import { hasEncodedFileUrlSeparator, trySafeFileURLToPath } from "../infra/local-file-access.js";
 import {
   classifyMediaReferenceSource,
@@ -30,6 +29,13 @@ import {
   wrapToolParamValidation,
 } from "./agent-tools.params.js";
 import type { AnyAgentTool } from "./agent-tools.types.js";
+import {
+  buildSensitiveHostDenyMutations,
+  mkdirHostPathWithDenyMutations,
+  resolveHostToolPath,
+  type SensitiveHostDenyMutationOptions,
+  writeHostFileWithDenyMutations,
+} from "./host-mutation-policy.js";
 import type { ImageSanitizationLimits } from "./image-sanitization.js";
 import { toRelativeWorkspacePath } from "./path-policy.js";
 import type { AgentToolResult } from "./runtime/index.js";
@@ -832,6 +838,11 @@ type SandboxToolParams = {
   imageSanitization?: ImageSanitizationLimits;
 };
 
+type HostToolMutationOptions = {
+  workspaceOnly?: boolean;
+  denyMutationAgentDirs?: readonly string[];
+};
+
 /** Create a sandbox-backed read tool with OpenClaw result normalization. */
 export function createSandboxedReadTool(params: SandboxToolParams) {
   const base = createReadTool(params.root, {
@@ -860,7 +871,7 @@ export function createSandboxedEditTool(params: SandboxToolParams) {
 }
 
 /** Create a host workspace write tool using guarded filesystem operations. */
-export function createHostWorkspaceWriteTool(root: string, options?: { workspaceOnly?: boolean }) {
+export function createHostWorkspaceWriteTool(root: string, options?: HostToolMutationOptions) {
   const base = createWriteTool(root, {
     operations: createHostWriteOperations(root, options),
   }) as unknown as AnyAgentTool;
@@ -868,7 +879,7 @@ export function createHostWorkspaceWriteTool(root: string, options?: { workspace
 }
 
 /** Create a host workspace edit tool using guarded filesystem operations. */
-export function createHostWorkspaceEditTool(root: string, options?: { workspaceOnly?: boolean }) {
+export function createHostWorkspaceEditTool(root: string, options?: HostToolMutationOptions) {
   const base = createEditTool(root, {
     operations: createHostEditOperations(root, options),
   }) as unknown as AnyAgentTool;
@@ -960,19 +971,23 @@ async function assertSandboxFileExists(params: SandboxToolParams, absolutePath: 
   }
 }
 
-function expandTildeToOsHome(filePath: string): string {
-  const home = resolveOsHomeDir();
-  return home ? expandHomePrefix(filePath, { home }) : filePath;
+function hostDenyMutationOptions(
+  options: HostToolMutationOptions | undefined,
+): SensitiveHostDenyMutationOptions {
+  const agentDirs = options?.denyMutationAgentDirs;
+  return agentDirs ? { agentDirs } : {};
 }
 
-function resolveHostPath(filePath: string): string {
-  return path.resolve(expandTildeToOsHome(filePath));
-}
-
-async function writeHostFile(absolutePath: string, content: string) {
-  const resolved = resolveHostPath(absolutePath);
-  await fs.mkdir(path.dirname(resolved), { recursive: true });
-  await fs.writeFile(resolved, content, "utf-8");
+async function writeHostFile(
+  absolutePath: string,
+  content: string,
+  options?: HostToolMutationOptions,
+) {
+  await writeHostFileWithDenyMutations(
+    resolveHostToolPath(absolutePath),
+    content,
+    hostDenyMutationOptions(options),
+  );
 }
 
 async function statHostFile(absolutePath: string) {
@@ -1006,32 +1021,40 @@ async function writeWorkspaceFile(
   await (await rootPromise).write(relative, content, { mkdir: true });
 }
 
-function createHostWriteOperations(root: string, options?: { workspaceOnly?: boolean }) {
+function createHostWriteOperations(root: string, options?: HostToolMutationOptions) {
   const workspaceOnly = options?.workspaceOnly ?? false;
 
   if (!workspaceOnly) {
-    // When workspaceOnly is false, allow writes anywhere on the host
+    // Host writes remain broad, but still honor the sensitive path deny policy.
     return {
       mkdir: async (dir: string) => {
-        const resolved = resolveHostPath(dir);
-        await fs.mkdir(resolved, { recursive: true });
+        await mkdirHostPathWithDenyMutations(
+          resolveHostToolPath(dir),
+          hostDenyMutationOptions(options),
+        );
       },
-      writeFile: writeHostFile,
-      readFile: async (absolutePath: string) =>
-        fs.readFile(path.resolve(expandTildeToOsHome(absolutePath))),
-      statFile: (absolutePath: string) =>
-        statHostFile(path.resolve(expandTildeToOsHome(absolutePath))),
+      writeFile: (absolutePath: string, content: string) =>
+        writeHostFile(absolutePath, content, options),
+      readFile: async (absolutePath: string) => fs.readFile(resolveHostToolPath(absolutePath)),
+      statFile: (absolutePath: string) => statHostFile(resolveHostToolPath(absolutePath)),
     } as const;
   }
 
-  // When workspaceOnly is true, enforce workspace boundary
-  const rootPromise = fsRoot(root);
+  // When workspaceOnly is true, enforce workspace boundary.
+  const rootPromise = fsRoot(root, {
+    denyMutations: buildSensitiveHostDenyMutations(process.env, hostDenyMutationOptions(options)),
+  });
   return {
     mkdir: async (dir: string) => {
       const relative = toRelativeWorkspacePath(root, dir, { allowRoot: true });
       const resolved = relative ? path.resolve(root, relative) : path.resolve(root);
       await assertSandboxPath({ filePath: resolved, cwd: root, root });
-      await fs.mkdir(resolved, { recursive: true });
+      const workspaceRoot = await rootPromise;
+      if (!relative) {
+        await workspaceRoot.ensureRoot();
+        return;
+      }
+      await workspaceRoot.mkdir(relative);
     },
     writeFile: (absolutePath: string, content: string) =>
       writeWorkspaceFile(root, rootPromise, absolutePath, content),
@@ -1046,24 +1069,27 @@ function createHostWriteOperations(root: string, options?: { workspaceOnly?: boo
   } as const;
 }
 
-function createHostEditOperations(root: string, options?: { workspaceOnly?: boolean }) {
+function createHostEditOperations(root: string, options?: HostToolMutationOptions) {
   const workspaceOnly = options?.workspaceOnly ?? false;
 
   if (!workspaceOnly) {
-    // When workspaceOnly is false, allow edits anywhere on the host
+    // Host edits remain broad, but still honor the sensitive path deny policy.
     return {
       readFile: async (absolutePath: string) => {
-        return await fs.readFile(resolveHostPath(absolutePath));
+        return await fs.readFile(resolveHostToolPath(absolutePath));
       },
-      writeFile: writeHostFile,
+      writeFile: (absolutePath: string, content: string) =>
+        writeHostFile(absolutePath, content, options),
       access: async (absolutePath: string) => {
-        await fs.access(resolveHostPath(absolutePath));
+        await fs.access(resolveHostToolPath(absolutePath));
       },
     } as const;
   }
 
-  // When workspaceOnly is true, enforce workspace boundary
-  const rootPromise = fsRoot(root);
+  // When workspaceOnly is true, enforce workspace boundary.
+  const rootPromise = fsRoot(root, {
+    denyMutations: buildSensitiveHostDenyMutations(process.env, hostDenyMutationOptions(options)),
+  });
   return {
     readFile: async (absolutePath: string) => {
       const relative = toRelativeWorkspacePath(root, absolutePath);

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -33,7 +33,6 @@ import {
   buildSensitiveHostDenyMutations,
   mkdirHostPathWithDenyMutations,
   resolveHostToolPath,
-  type SensitiveHostDenyMutationOptions,
   writeHostFileWithDenyMutations,
 } from "./host-mutation-policy.js";
 import type { ImageSanitizationLimits } from "./image-sanitization.js";
@@ -840,7 +839,6 @@ type SandboxToolParams = {
 
 type HostToolMutationOptions = {
   workspaceOnly?: boolean;
-  denyMutationAgentDirs?: readonly string[];
 };
 
 /** Create a sandbox-backed read tool with OpenClaw result normalization. */
@@ -971,23 +969,8 @@ async function assertSandboxFileExists(params: SandboxToolParams, absolutePath: 
   }
 }
 
-function hostDenyMutationOptions(
-  options: HostToolMutationOptions | undefined,
-): SensitiveHostDenyMutationOptions {
-  const agentDirs = options?.denyMutationAgentDirs;
-  return agentDirs ? { agentDirs } : {};
-}
-
-async function writeHostFile(
-  absolutePath: string,
-  content: string,
-  options?: HostToolMutationOptions,
-) {
-  await writeHostFileWithDenyMutations(
-    resolveHostToolPath(absolutePath),
-    content,
-    hostDenyMutationOptions(options),
-  );
+async function writeHostFile(absolutePath: string, content: string) {
+  await writeHostFileWithDenyMutations(resolveHostToolPath(absolutePath), content);
 }
 
 async function statHostFile(absolutePath: string) {
@@ -1028,13 +1011,9 @@ function createHostWriteOperations(root: string, options?: HostToolMutationOptio
     // Host writes remain broad, but still honor the sensitive path deny policy.
     return {
       mkdir: async (dir: string) => {
-        await mkdirHostPathWithDenyMutations(
-          resolveHostToolPath(dir),
-          hostDenyMutationOptions(options),
-        );
+        await mkdirHostPathWithDenyMutations(resolveHostToolPath(dir));
       },
-      writeFile: (absolutePath: string, content: string) =>
-        writeHostFile(absolutePath, content, options),
+      writeFile: writeHostFile,
       readFile: async (absolutePath: string) => fs.readFile(resolveHostToolPath(absolutePath)),
       statFile: (absolutePath: string) => statHostFile(resolveHostToolPath(absolutePath)),
     } as const;
@@ -1042,7 +1021,7 @@ function createHostWriteOperations(root: string, options?: HostToolMutationOptio
 
   // When workspaceOnly is true, enforce workspace boundary.
   const rootPromise = fsRoot(root, {
-    denyMutations: buildSensitiveHostDenyMutations(process.env, hostDenyMutationOptions(options)),
+    denyMutations: buildSensitiveHostDenyMutations(),
   });
   return {
     mkdir: async (dir: string) => {
@@ -1078,8 +1057,7 @@ function createHostEditOperations(root: string, options?: HostToolMutationOption
       readFile: async (absolutePath: string) => {
         return await fs.readFile(resolveHostToolPath(absolutePath));
       },
-      writeFile: (absolutePath: string, content: string) =>
-        writeHostFile(absolutePath, content, options),
+      writeFile: writeHostFile,
       access: async (absolutePath: string) => {
         await fs.access(resolveHostToolPath(absolutePath));
       },
@@ -1088,7 +1066,7 @@ function createHostEditOperations(root: string, options?: HostToolMutationOption
 
   // When workspaceOnly is true, enforce workspace boundary.
   const rootPromise = fsRoot(root, {
-    denyMutations: buildSensitiveHostDenyMutations(process.env, hostDenyMutationOptions(options)),
+    denyMutations: buildSensitiveHostDenyMutations(),
   });
   return {
     readFile: async (absolutePath: string) => {

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -813,7 +813,10 @@ export function createOpenClawCodingTools(options?: {
         if (sandboxRoot) {
           continue;
         }
-        const wrapped = createHostWorkspaceWriteTool(codingRoot, { workspaceOnly });
+        const wrapped = createHostWorkspaceWriteTool(codingRoot, {
+          workspaceOnly,
+          denyMutationAgentDirs: options?.agentDir ? [options.agentDir] : undefined,
+        });
         base.push(workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, codingRoot) : wrapped);
         continue;
       }
@@ -821,7 +824,10 @@ export function createOpenClawCodingTools(options?: {
         if (sandboxRoot) {
           continue;
         }
-        const wrapped = createHostWorkspaceEditTool(codingRoot, { workspaceOnly });
+        const wrapped = createHostWorkspaceEditTool(codingRoot, {
+          workspaceOnly,
+          denyMutationAgentDirs: options?.agentDir ? [options.agentDir] : undefined,
+        });
         base.push(workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, codingRoot) : wrapped);
         continue;
       }

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -813,10 +813,7 @@ export function createOpenClawCodingTools(options?: {
         if (sandboxRoot) {
           continue;
         }
-        const wrapped = createHostWorkspaceWriteTool(codingRoot, {
-          workspaceOnly,
-          denyMutationAgentDirs: options?.agentDir ? [options.agentDir] : undefined,
-        });
+        const wrapped = createHostWorkspaceWriteTool(codingRoot, { workspaceOnly });
         base.push(workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, codingRoot) : wrapped);
         continue;
       }
@@ -824,10 +821,7 @@ export function createOpenClawCodingTools(options?: {
         if (sandboxRoot) {
           continue;
         }
-        const wrapped = createHostWorkspaceEditTool(codingRoot, {
-          workspaceOnly,
-          denyMutationAgentDirs: options?.agentDir ? [options.agentDir] : undefined,
-        });
+        const wrapped = createHostWorkspaceEditTool(codingRoot, { workspaceOnly });
         base.push(workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, codingRoot) : wrapped);
         continue;
       }

--- a/src/agents/agent-tools.workspace-only-false.test.ts
+++ b/src/agents/agent-tools.workspace-only-false.test.ts
@@ -39,6 +39,33 @@ describe("FS tools with workspaceOnly=false", () => {
       return content.text?.toLowerCase().includes("error") ?? false;
     });
 
+  const expectDeniedMutation = async (
+    operation: () => Promise<{ content: Array<{ type: string; text?: string }> }>,
+  ) => {
+    try {
+      const result = await operation();
+      expect(hasToolError(result)).toBe(true);
+      expect(JSON.stringify(result.content)).toMatch(/denied|mutation policy/i);
+    } catch (error) {
+      const text =
+        error instanceof Error
+          ? `${(error as { code?: unknown }).code ?? ""} ${error.message}`
+          : String(error);
+      expect(text).toMatch(/denied-path|denied|mutation policy/i);
+    }
+  };
+
+  const stubHostHome = async () => {
+    const homeDir = path.join(tmpDir, "home");
+    await fs.mkdir(homeDir, { recursive: true });
+    vi.stubEnv("HOME", homeDir);
+    vi.stubEnv("USERPROFILE", homeDir);
+    vi.stubEnv("OPENCLAW_HOME", homeDir);
+    vi.stubEnv("OPENCLAW_STATE_DIR", path.join(tmpDir, "state"));
+    vi.stubEnv("OPENCLAW_OAUTH_DIR", path.join(tmpDir, "oauth"));
+    return homeDir;
+  };
+
   const toolsFor = (workspaceOnly: boolean | undefined): AnyAgentTool[] => {
     const read = createOpenClawReadTool(createReadTool(workspaceDir) as unknown as AnyAgentTool);
     const write = createHostWorkspaceWriteTool(workspaceDir, { workspaceOnly });
@@ -77,6 +104,7 @@ describe("FS tools with workspaceOnly=false", () => {
   });
 
   afterEach(async () => {
+    vi.unstubAllEnvs();
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
@@ -92,6 +120,49 @@ describe("FS tools with workspaceOnly=false", () => {
     );
     const content = await fs.readFile(outsideFile, "utf-8");
     expect(content).toBe("test content");
+  });
+
+  it("should allow write through a non-sensitive symlink when workspaceOnly=false", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const realFile = path.join(tmpDir, "symlink-real.txt");
+    const linkFile = path.join(tmpDir, "symlink-link.txt");
+    await fs.writeFile(realFile, "before");
+    await fs.symlink(realFile, linkFile);
+
+    await runFsTool(
+      "write",
+      "test-call-symlink-write",
+      {
+        path: linkFile,
+        content: "after",
+      },
+      false,
+    );
+
+    await expect(fs.readFile(realFile, "utf-8")).resolves.toBe("after");
+  });
+
+  it("denies writes through hardlink aliases to sensitive host paths when workspaceOnly=false", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const homeDir = await stubHostHome();
+    const target = path.join(homeDir, ".netrc");
+    const alias = path.join(tmpDir, "netrc-hardlink-alias");
+    await fs.writeFile(target, "machine example.com\n", "utf-8");
+    await fs.link(target, alias);
+    const writeTool = requireTool(toolsFor(false), "write");
+
+    await expectDeniedMutation(() =>
+      writeTool.execute("test-call-deny-sensitive-hardlink-write", {
+        path: alias,
+        content: "machine evil.example.com\n",
+      }),
+    );
+
+    await expect(fs.readFile(target, "utf-8")).resolves.toBe("machine example.com\n");
   });
 
   it("should allow write outside workspace via ../ path when workspaceOnly=false", async () => {
@@ -222,6 +293,71 @@ describe("FS tools with workspaceOnly=false", () => {
     );
     const content = await fs.readFile(outsideUnsetFile, "utf-8");
     expect(content).toBe("after");
+  });
+
+  it("denies writes to sensitive host paths when workspaceOnly=false", async () => {
+    const homeDir = await stubHostHome();
+    const target = path.join(homeDir, ".ssh", "authorized_keys");
+    const writeTool = requireTool(toolsFor(false), "write");
+
+    await expectDeniedMutation(() =>
+      writeTool.execute("test-call-deny-sensitive-write", {
+        path: target,
+        content: "ssh-rsa should-not-write",
+      }),
+    );
+
+    await expect(fs.stat(target)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("denies edits to sensitive host paths when workspaceOnly=false", async () => {
+    const homeDir = await stubHostHome();
+    const target = path.join(homeDir, ".netrc");
+    await fs.writeFile(target, "machine example.com\n", "utf-8");
+    const editTool = requireTool(toolsFor(false), "edit");
+
+    await expectDeniedMutation(() =>
+      editTool.execute("test-call-deny-sensitive-edit", {
+        path: target,
+        edits: [{ oldText: "example.com", newText: "evil.example.com" }],
+      }),
+    );
+
+    await expect(fs.readFile(target, "utf-8")).resolves.toBe("machine example.com\n");
+  });
+
+  it("denies writes to configured agent auth stores when workspaceOnly=false", async () => {
+    await stubHostHome();
+    const agentDir = path.join(tmpDir, "configured-agent");
+    const target = path.join(agentDir, "auth-profiles.json");
+    const writeTool = createHostWorkspaceWriteTool(workspaceDir, {
+      workspaceOnly: false,
+      denyMutationAgentDirs: [agentDir],
+    });
+
+    await expectDeniedMutation(() =>
+      writeTool.execute("test-call-deny-configured-agent-auth", {
+        path: target,
+        content: "{}\n",
+      }),
+    );
+
+    await expect(fs.stat(target)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("denies sensitive paths inside the workspace root when workspaceOnly=true", async () => {
+    const homeDir = await stubHostHome();
+    const target = path.join(homeDir, ".ssh", "authorized_keys");
+    const writeTool = createHostWorkspaceWriteTool(homeDir, { workspaceOnly: true });
+
+    await expectDeniedMutation(() =>
+      writeTool.execute("test-call-deny-sensitive-workspace-write", {
+        path: target,
+        content: "ssh-rsa should-not-write",
+      }),
+    );
+
+    await expect(fs.stat(target)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("should block write outside workspace when workspaceOnly=true", async () => {

--- a/src/agents/agent-tools.workspace-only-false.test.ts
+++ b/src/agents/agent-tools.workspace-only-false.test.ts
@@ -58,17 +58,6 @@ describe("FS tools with workspaceOnly=false", () => {
     }
   };
 
-  const stubHostHome = async () => {
-    const homeDir = path.join(tmpDir, "home");
-    await fs.mkdir(homeDir, { recursive: true });
-    vi.stubEnv("HOME", homeDir);
-    vi.stubEnv("USERPROFILE", homeDir);
-    vi.stubEnv("OPENCLAW_HOME", homeDir);
-    vi.stubEnv("OPENCLAW_STATE_DIR", path.join(tmpDir, "state"));
-    vi.stubEnv("OPENCLAW_OAUTH_DIR", path.join(tmpDir, "oauth"));
-    return homeDir;
-  };
-
   const toolsFor = (workspaceOnly: boolean | undefined): AnyAgentTool[] => {
     const read = createOpenClawReadTool(createReadTool(workspaceDir) as unknown as AnyAgentTool);
     const write = createHostWorkspaceWriteTool(workspaceDir, { workspaceOnly });
@@ -147,25 +136,26 @@ describe("FS tools with workspaceOnly=false", () => {
     await expect(fs.readFile(realFile, "utf-8")).resolves.toBe("after");
   });
 
-  it("denies writes through hardlink aliases to sensitive host paths when workspaceOnly=false", async () => {
+  it("should allow write through a non-sensitive hardlink when workspaceOnly=false", async () => {
     if (process.platform === "win32") {
       return;
     }
-    const homeDir = await stubHostHome();
-    const target = path.join(homeDir, ".netrc");
-    const alias = path.join(tmpDir, "netrc-hardlink-alias");
-    await fs.writeFile(target, "machine example.com\n", "utf-8");
-    await fs.link(target, alias);
-    const writeTool = requireTool(toolsFor(false), "write");
+    const realFile = path.join(tmpDir, "hardlink-real.txt");
+    const alias = path.join(tmpDir, "hardlink-alias.txt");
+    await fs.writeFile(realFile, "before", "utf-8");
+    await fs.link(realFile, alias);
 
-    await expectDeniedMutation(() =>
-      writeTool.execute("test-call-deny-sensitive-hardlink-write", {
+    await runFsTool(
+      "write",
+      "test-call-hardlink-write",
+      {
         path: alias,
-        content: "machine evil.example.com\n",
-      }),
+        content: "after",
+      },
+      false,
     );
 
-    await expect(fs.readFile(target, "utf-8")).resolves.toBe("machine example.com\n");
+    await expect(fs.readFile(realFile, "utf-8")).resolves.toBe("after");
   });
 
   it("should allow write outside workspace via ../ path when workspaceOnly=false", async () => {
@@ -298,69 +288,50 @@ describe("FS tools with workspaceOnly=false", () => {
     expect(content).toBe("after");
   });
 
-  it("denies writes to sensitive host paths when workspaceOnly=false", async () => {
-    const homeDir = await stubHostHome();
-    const target = path.join(homeDir, ".ssh", "authorized_keys");
+  it("allows credential-like home paths when workspaceOnly=false", async () => {
+    const target = path.join(tmpDir, "home", ".ssh", "authorized_keys");
+
+    await runFsTool(
+      "write",
+      "test-call-allow-home-credential-like-path",
+      {
+        path: target,
+        content: "ssh-rsa now-allowed-for-scope-control",
+      },
+      false,
+    );
+
+    await expect(fs.readFile(target, "utf-8")).resolves.toBe(
+      "ssh-rsa now-allowed-for-scope-control",
+    );
+  });
+
+  it("denies writes to privilege and login authority paths when workspaceOnly=false", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
     const writeTool = requireTool(toolsFor(false), "write");
 
     await expectDeniedMutation(() =>
-      writeTool.execute("test-call-deny-sensitive-write", {
-        path: target,
-        content: "ssh-rsa should-not-write",
+      writeTool.execute("test-call-deny-login-authority-write", {
+        path: "/etc/sudoers.d/openclaw-test",
+        content: "should-not-write",
       }),
     );
-
-    await expect(fs.stat(target)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
-  it("denies edits to sensitive host paths when workspaceOnly=false", async () => {
-    const homeDir = await stubHostHome();
-    const target = path.join(homeDir, ".netrc");
-    await fs.writeFile(target, "machine example.com\n", "utf-8");
-    const editTool = requireTool(toolsFor(false), "edit");
+  it("denies privilege and login authority paths inside workspaceOnly=true roots", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const writeTool = createHostWorkspaceWriteTool("/etc", { workspaceOnly: true });
 
     await expectDeniedMutation(() =>
-      editTool.execute("test-call-deny-sensitive-edit", {
-        path: target,
-        edits: [{ oldText: "example.com", newText: "evil.example.com" }],
+      writeTool.execute("test-call-deny-login-authority-workspace-write", {
+        path: "/etc/passwd",
+        content: "should-not-write",
       }),
     );
-
-    await expect(fs.readFile(target, "utf-8")).resolves.toBe("machine example.com\n");
-  });
-
-  it("denies writes to configured agent auth stores when workspaceOnly=false", async () => {
-    await stubHostHome();
-    const agentDir = path.join(tmpDir, "configured-agent");
-    const target = path.join(agentDir, "auth-profiles.json");
-    const writeTool = createHostWorkspaceWriteTool(workspaceDir, {
-      workspaceOnly: false,
-      denyMutationAgentDirs: [agentDir],
-    });
-
-    await expectDeniedMutation(() =>
-      writeTool.execute("test-call-deny-configured-agent-auth", {
-        path: target,
-        content: "{}\n",
-      }),
-    );
-
-    await expect(fs.stat(target)).rejects.toMatchObject({ code: "ENOENT" });
-  });
-
-  it("denies sensitive paths inside the workspace root when workspaceOnly=true", async () => {
-    const homeDir = await stubHostHome();
-    const target = path.join(homeDir, ".ssh", "authorized_keys");
-    const writeTool = createHostWorkspaceWriteTool(homeDir, { workspaceOnly: true });
-
-    await expectDeniedMutation(() =>
-      writeTool.execute("test-call-deny-sensitive-workspace-write", {
-        path: target,
-        content: "ssh-rsa should-not-write",
-      }),
-    );
-
-    await expect(fs.stat(target)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("should block write outside workspace when workspaceOnly=true", async () => {

--- a/src/agents/agent-tools.workspace-only-false.test.ts
+++ b/src/agents/agent-tools.workspace-only-false.test.ts
@@ -47,10 +47,13 @@ describe("FS tools with workspaceOnly=false", () => {
       expect(hasToolError(result)).toBe(true);
       expect(JSON.stringify(result.content)).toMatch(/denied|mutation policy/i);
     } catch (error) {
-      const text =
-        error instanceof Error
-          ? `${(error as { code?: unknown }).code ?? ""} ${error.message}`
-          : String(error);
+      if (!(error instanceof Error)) {
+        expect(String(error)).toMatch(/denied-path|denied|mutation policy/i);
+        return;
+      }
+
+      const code = (error as { code?: unknown }).code;
+      const text = `${typeof code === "string" ? code : ""} ${error.message}`;
       expect(text).toMatch(/denied-path|denied|mutation policy/i);
     }
   };

--- a/src/agents/apply-patch.test.ts
+++ b/src/agents/apply-patch.test.ts
@@ -420,6 +420,106 @@ describe("applyPatch", () => {
     });
   });
 
+  it("allows updating a non-sensitive symlink target when workspaceOnly is explicitly disabled", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    await withTempDir(async (dir) => {
+      const realFile = path.join(dir, "real.txt");
+      const linkFile = path.join(dir, "link.txt");
+      await fs.writeFile(realFile, "before\n", "utf8");
+      await fs.symlink(realFile, linkFile);
+
+      const patch = `*** Begin Patch
+*** Update File: ${linkFile}
+@@
+-before
++after
+*** End Patch`;
+
+      const result = await applyPatch(patch, { cwd: dir, workspaceOnly: false });
+
+      expect(result.summary.modified).toEqual(["link.txt"]);
+      await expect(fs.readFile(realFile, "utf8")).resolves.toBe("after\n");
+    });
+  });
+
+  it("denies hardlink aliases to sensitive host paths when workspaceOnly is explicitly disabled", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    await withTempDir(async (dir) => {
+      const homeDir = path.join(dir, "home");
+      await fs.mkdir(homeDir, { recursive: true });
+      vi.stubEnv("HOME", homeDir);
+      vi.stubEnv("USERPROFILE", homeDir);
+      vi.stubEnv("OPENCLAW_HOME", homeDir);
+      vi.stubEnv("OPENCLAW_STATE_DIR", path.join(dir, "state"));
+      vi.stubEnv("OPENCLAW_OAUTH_DIR", path.join(dir, "oauth"));
+
+      const target = path.join(homeDir, ".netrc");
+      const alias = path.join(dir, "netrc-hardlink-alias");
+      await fs.writeFile(target, "machine example.com\n", "utf8");
+      await fs.link(target, alias);
+      const patch = `*** Begin Patch
+*** Update File: ${alias}
+@@
+-machine example.com
++machine evil.example.com
+*** End Patch`;
+
+      try {
+        await expect(applyPatch(patch, { cwd: dir, workspaceOnly: false })).rejects.toThrow(
+          /denied-path|denied|mutation policy/i,
+        );
+        await expect(fs.readFile(target, "utf8")).resolves.toBe("machine example.com\n");
+      } finally {
+        vi.unstubAllEnvs();
+      }
+    });
+  });
+
+  it("denies sensitive host paths when workspaceOnly is explicitly disabled", async () => {
+    await withTempDir(async (dir) => {
+      const homeDir = path.join(dir, "home");
+      await fs.mkdir(homeDir, { recursive: true });
+      vi.stubEnv("HOME", homeDir);
+      vi.stubEnv("USERPROFILE", homeDir);
+      vi.stubEnv("OPENCLAW_HOME", homeDir);
+      vi.stubEnv("OPENCLAW_STATE_DIR", path.join(dir, "state"));
+      vi.stubEnv("OPENCLAW_OAUTH_DIR", path.join(dir, "oauth"));
+
+      const target = path.join(homeDir, ".netrc");
+      const patch = buildAddFilePatch(target);
+
+      try {
+        await expect(applyPatch(patch, { cwd: dir, workspaceOnly: false })).rejects.toThrow(
+          /denied-path|denied|mutation policy/i,
+        );
+        await expectMissingPath(fs.readFile(target, "utf8"));
+      } finally {
+        vi.unstubAllEnvs();
+      }
+    });
+  });
+
+  it("denies configured agent auth stores when workspaceOnly is explicitly disabled", async () => {
+    await withTempDir(async (dir) => {
+      const agentDir = path.join(dir, "configured-agent");
+      const target = path.join(agentDir, "auth-profiles.json");
+      const patch = buildAddFilePatch(target);
+
+      await expect(
+        applyPatch(patch, {
+          cwd: dir,
+          workspaceOnly: false,
+          denyMutationAgentDirs: [agentDir],
+        }),
+      ).rejects.toThrow(/denied-path|denied|mutation policy/i);
+      await expectMissingPath(fs.readFile(target, "utf8"));
+    });
+  });
+
   it("keeps dot-dot-prefixed filenames inside cwd and reports relative paths", async () => {
     await withTempDir(async (dir) => {
       const patch = `*** Begin Patch

--- a/src/agents/apply-patch.test.ts
+++ b/src/agents/apply-patch.test.ts
@@ -444,79 +444,40 @@ describe("applyPatch", () => {
     });
   });
 
-  it("denies hardlink aliases to sensitive host paths when workspaceOnly is explicitly disabled", async () => {
+  it("allows updating a non-sensitive hardlink when workspaceOnly is explicitly disabled", async () => {
     if (process.platform === "win32") {
       return;
     }
     await withTempDir(async (dir) => {
-      const homeDir = path.join(dir, "home");
-      await fs.mkdir(homeDir, { recursive: true });
-      vi.stubEnv("HOME", homeDir);
-      vi.stubEnv("USERPROFILE", homeDir);
-      vi.stubEnv("OPENCLAW_HOME", homeDir);
-      vi.stubEnv("OPENCLAW_STATE_DIR", path.join(dir, "state"));
-      vi.stubEnv("OPENCLAW_OAUTH_DIR", path.join(dir, "oauth"));
-
-      const target = path.join(homeDir, ".netrc");
-      const alias = path.join(dir, "netrc-hardlink-alias");
-      await fs.writeFile(target, "machine example.com\n", "utf8");
-      await fs.link(target, alias);
+      const realFile = path.join(dir, "hardlink-real.txt");
+      const alias = path.join(dir, "hardlink-alias.txt");
+      await fs.writeFile(realFile, "before\n", "utf8");
+      await fs.link(realFile, alias);
       const patch = `*** Begin Patch
 *** Update File: ${alias}
 @@
--machine example.com
-+machine evil.example.com
+-before
++after
 *** End Patch`;
 
-      try {
-        await expect(applyPatch(patch, { cwd: dir, workspaceOnly: false })).rejects.toThrow(
-          /denied-path|denied|mutation policy/i,
-        );
-        await expect(fs.readFile(target, "utf8")).resolves.toBe("machine example.com\n");
-      } finally {
-        vi.unstubAllEnvs();
-      }
+      const result = await applyPatch(patch, { cwd: dir, workspaceOnly: false });
+
+      expect(result.summary.modified).toEqual(["hardlink-alias.txt"]);
+      await expect(fs.readFile(realFile, "utf8")).resolves.toBe("after\n");
     });
   });
 
-  it("denies sensitive host paths when workspaceOnly is explicitly disabled", async () => {
+  it("denies privilege and login authority paths when workspaceOnly is explicitly disabled", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
     await withTempDir(async (dir) => {
-      const homeDir = path.join(dir, "home");
-      await fs.mkdir(homeDir, { recursive: true });
-      vi.stubEnv("HOME", homeDir);
-      vi.stubEnv("USERPROFILE", homeDir);
-      vi.stubEnv("OPENCLAW_HOME", homeDir);
-      vi.stubEnv("OPENCLAW_STATE_DIR", path.join(dir, "state"));
-      vi.stubEnv("OPENCLAW_OAUTH_DIR", path.join(dir, "oauth"));
-
-      const target = path.join(homeDir, ".netrc");
+      const target = "/etc/sudoers.d/openclaw-test";
       const patch = buildAddFilePatch(target);
 
-      try {
-        await expect(applyPatch(patch, { cwd: dir, workspaceOnly: false })).rejects.toThrow(
-          /denied-path|denied|mutation policy/i,
-        );
-        await expectMissingPath(fs.readFile(target, "utf8"));
-      } finally {
-        vi.unstubAllEnvs();
-      }
-    });
-  });
-
-  it("denies configured agent auth stores when workspaceOnly is explicitly disabled", async () => {
-    await withTempDir(async (dir) => {
-      const agentDir = path.join(dir, "configured-agent");
-      const target = path.join(agentDir, "auth-profiles.json");
-      const patch = buildAddFilePatch(target);
-
-      await expect(
-        applyPatch(patch, {
-          cwd: dir,
-          workspaceOnly: false,
-          denyMutationAgentDirs: [agentDir],
-        }),
-      ).rejects.toThrow(/denied-path|denied|mutation policy/i);
-      await expectMissingPath(fs.readFile(target, "utf8"));
+      await expect(applyPatch(patch, { cwd: dir, workspaceOnly: false })).rejects.toThrow(
+        /denied-path|denied|mutation policy/i,
+      );
     });
   });
 

--- a/src/agents/apply-patch.ts
+++ b/src/agents/apply-patch.ts
@@ -11,6 +11,13 @@ import { openRootFile, type RootFileOpenResult } from "../infra/boundary-file-re
 import { root as fsRoot } from "../infra/fs-safe.js";
 import { PATH_ALIAS_POLICIES, type PathAliasPolicy } from "../infra/path-alias-guards.js";
 import { applyUpdateHunk } from "./apply-patch-update.js";
+import {
+  buildSensitiveHostDenyMutations,
+  mkdirHostPathWithDenyMutations,
+  removeHostPathWithDenyMutations,
+  type SensitiveHostDenyMutationOptions,
+  writeHostFileWithDenyMutations,
+} from "./host-mutation-policy.js";
 import { toRelativeSandboxPath, resolvePathFromInput } from "./path-policy.js";
 import type { AgentTool } from "./runtime/index.js";
 import { assertSandboxPath } from "./sandbox-paths.js";
@@ -78,6 +85,7 @@ type ApplyPatchOptions = {
   sandbox?: SandboxApplyPatchConfig;
   /** Restrict patch paths to the workspace root (cwd). Default: true. Set false to opt out. */
   workspaceOnly?: boolean;
+  denyMutationAgentDirs?: readonly string[];
   signal?: AbortSignal;
 };
 
@@ -89,7 +97,12 @@ const applyPatchSchema = Type.Object({
 
 /** Create the agent tool wrapper for applying patch-envelope input. */
 export function createApplyPatchTool(
-  options: { cwd?: string; sandbox?: SandboxApplyPatchConfig; workspaceOnly?: boolean } = {},
+  options: {
+    cwd?: string;
+    sandbox?: SandboxApplyPatchConfig;
+    workspaceOnly?: boolean;
+    denyMutationAgentDirs?: readonly string[];
+  } = {},
 ): AgentTool<typeof applyPatchSchema, ApplyPatchToolDetails> {
   const cwd = options.cwd ?? process.cwd();
   const sandbox = options.sandbox;
@@ -117,6 +130,7 @@ export function createApplyPatchTool(
         cwd,
         sandbox,
         workspaceOnly,
+        denyMutationAgentDirs: options.denyMutationAgentDirs,
         signal,
       });
 
@@ -261,7 +275,14 @@ function resolvePatchFileOps(options: ApplyPatchOptions): PatchFileOps {
     };
   }
   const workspaceOnly = options.workspaceOnly !== false;
-  const rootPromise = workspaceOnly ? fsRoot(options.cwd) : undefined;
+  const denyMutationOptions: SensitiveHostDenyMutationOptions = {
+    agentDirs: options.denyMutationAgentDirs,
+  };
+  const rootPromise = workspaceOnly
+    ? fsRoot(options.cwd, {
+        denyMutations: buildSensitiveHostDenyMutations(process.env, denyMutationOptions),
+      })
+    : undefined;
   return {
     readFile: async (filePath) => {
       if (!workspaceOnly) {
@@ -281,7 +302,7 @@ function resolvePatchFileOps(options: ApplyPatchOptions): PatchFileOps {
     },
     writeFile: async (filePath, content) => {
       if (!workspaceOnly) {
-        await fs.writeFile(filePath, content, "utf8");
+        await writeHostFileWithDenyMutations(filePath, content, denyMutationOptions);
         return;
       }
       const relative = toRelativeSandboxPath(options.cwd, filePath);
@@ -289,7 +310,7 @@ function resolvePatchFileOps(options: ApplyPatchOptions): PatchFileOps {
     },
     remove: async (filePath) => {
       if (!workspaceOnly) {
-        await fs.rm(filePath);
+        await removeHostPathWithDenyMutations(filePath, denyMutationOptions);
         return;
       }
       const relative = toRelativeSandboxPath(options.cwd, filePath);
@@ -297,7 +318,7 @@ function resolvePatchFileOps(options: ApplyPatchOptions): PatchFileOps {
     },
     mkdirp: async (dir) => {
       if (!workspaceOnly) {
-        await fs.mkdir(dir, { recursive: true });
+        await mkdirHostPathWithDenyMutations(dir, denyMutationOptions);
         return;
       }
       const relative = toRelativeSandboxPath(options.cwd, dir, { allowRoot: true });

--- a/src/agents/apply-patch.ts
+++ b/src/agents/apply-patch.ts
@@ -15,7 +15,6 @@ import {
   buildSensitiveHostDenyMutations,
   mkdirHostPathWithDenyMutations,
   removeHostPathWithDenyMutations,
-  type SensitiveHostDenyMutationOptions,
   writeHostFileWithDenyMutations,
 } from "./host-mutation-policy.js";
 import { toRelativeSandboxPath, resolvePathFromInput } from "./path-policy.js";
@@ -85,7 +84,6 @@ type ApplyPatchOptions = {
   sandbox?: SandboxApplyPatchConfig;
   /** Restrict patch paths to the workspace root (cwd). Default: true. Set false to opt out. */
   workspaceOnly?: boolean;
-  denyMutationAgentDirs?: readonly string[];
   signal?: AbortSignal;
 };
 
@@ -101,7 +99,6 @@ export function createApplyPatchTool(
     cwd?: string;
     sandbox?: SandboxApplyPatchConfig;
     workspaceOnly?: boolean;
-    denyMutationAgentDirs?: readonly string[];
   } = {},
 ): AgentTool<typeof applyPatchSchema, ApplyPatchToolDetails> {
   const cwd = options.cwd ?? process.cwd();
@@ -130,7 +127,6 @@ export function createApplyPatchTool(
         cwd,
         sandbox,
         workspaceOnly,
-        denyMutationAgentDirs: options.denyMutationAgentDirs,
         signal,
       });
 
@@ -275,12 +271,9 @@ function resolvePatchFileOps(options: ApplyPatchOptions): PatchFileOps {
     };
   }
   const workspaceOnly = options.workspaceOnly !== false;
-  const denyMutationOptions: SensitiveHostDenyMutationOptions = {
-    agentDirs: options.denyMutationAgentDirs,
-  };
   const rootPromise = workspaceOnly
     ? fsRoot(options.cwd, {
-        denyMutations: buildSensitiveHostDenyMutations(process.env, denyMutationOptions),
+        denyMutations: buildSensitiveHostDenyMutations(),
       })
     : undefined;
   return {
@@ -302,7 +295,7 @@ function resolvePatchFileOps(options: ApplyPatchOptions): PatchFileOps {
     },
     writeFile: async (filePath, content) => {
       if (!workspaceOnly) {
-        await writeHostFileWithDenyMutations(filePath, content, denyMutationOptions);
+        await writeHostFileWithDenyMutations(filePath, content);
         return;
       }
       const relative = toRelativeSandboxPath(options.cwd, filePath);
@@ -310,7 +303,7 @@ function resolvePatchFileOps(options: ApplyPatchOptions): PatchFileOps {
     },
     remove: async (filePath) => {
       if (!workspaceOnly) {
-        await removeHostPathWithDenyMutations(filePath, denyMutationOptions);
+        await removeHostPathWithDenyMutations(filePath);
         return;
       }
       const relative = toRelativeSandboxPath(options.cwd, filePath);
@@ -318,7 +311,7 @@ function resolvePatchFileOps(options: ApplyPatchOptions): PatchFileOps {
     },
     mkdirp: async (dir) => {
       if (!workspaceOnly) {
-        await mkdirHostPathWithDenyMutations(dir, denyMutationOptions);
+        await mkdirHostPathWithDenyMutations(dir);
         return;
       }
       const relative = toRelativeSandboxPath(options.cwd, dir, { allowRoot: true });

--- a/src/agents/host-mutation-policy.test.ts
+++ b/src/agents/host-mutation-policy.test.ts
@@ -1,0 +1,58 @@
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { buildSensitiveHostDenyMutations, resolveHostToolPath } from "./host-mutation-policy.js";
+
+describe("host mutation policy", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("builds exact and recursive deny entries for host credential paths", () => {
+    const osHome = path.resolve("/tmp/openclaw-os-home");
+    const userProfileHome = path.resolve("/tmp/openclaw-userprofile-home");
+    const openclawHome = path.resolve("/tmp/openclaw-effective-home");
+    const stateDir = path.resolve("/tmp/openclaw-state");
+    const oauthDir = path.resolve("/tmp/openclaw-oauth");
+    const agentDir = path.resolve("/tmp/openclaw-agent");
+    const configuredAgentDir = path.resolve("/tmp/openclaw-configured-agent");
+
+    const policy = buildSensitiveHostDenyMutations(
+      {
+        HOME: osHome,
+        USERPROFILE: userProfileHome,
+        OPENCLAW_HOME: openclawHome,
+        OPENCLAW_STATE_DIR: stateDir,
+        OPENCLAW_OAUTH_DIR: oauthDir,
+        OPENCLAW_AGENT_DIR: agentDir,
+      } as NodeJS.ProcessEnv,
+      { agentDirs: [configuredAgentDir] },
+    );
+
+    expect(policy.paths).toContain(path.join(osHome, ".ssh", "authorized_keys"));
+    expect(policy.paths).toContain(path.join(userProfileHome, ".netrc"));
+    expect(policy.paths).toContain(path.join(openclawHome, ".netrc"));
+    expect(policy.paths).toContain(path.join(stateDir, ".env"));
+    expect(policy.paths).toContain(path.join(agentDir, "auth-profiles.json"));
+    expect(policy.paths).toContain(path.join(agentDir, "agent", "auth-profiles.json"));
+    expect(policy.paths).toContain(path.join(configuredAgentDir, "auth-profiles.json"));
+    expect(policy.paths).toContain(path.join(configuredAgentDir, "agent", "auth-profiles.json"));
+    expect(policy.prefixes).toContain(path.join(osHome, ".ssh"));
+    expect(policy.prefixes).toContain(path.join(userProfileHome, ".aws"));
+    expect(policy.prefixes).toContain(path.join(openclawHome, ".aws"));
+    expect(policy.prefixes).toContain(path.join(stateDir, "credentials"));
+    expect(policy.prefixes).toContain(path.join(stateDir, "agents"));
+    expect(policy.prefixes).toContain(oauthDir);
+    expect(policy.paths).toEqual([...(policy.paths ?? [])].toSorted());
+    expect(policy.prefixes).toEqual([...(policy.prefixes ?? [])].toSorted());
+  });
+
+  it("expands model tool tildes against the operating-system home", () => {
+    const osHome = path.resolve("/tmp/openclaw-os-home");
+    const openclawHome = path.resolve("/tmp/openclaw-effective-home");
+    vi.stubEnv("HOME", osHome);
+    vi.stubEnv("USERPROFILE", osHome);
+    vi.stubEnv("OPENCLAW_HOME", openclawHome);
+
+    expect(resolveHostToolPath("~/scratch.txt")).toBe(path.join(osHome, "scratch.txt"));
+  });
+});

--- a/src/agents/host-mutation-policy.test.ts
+++ b/src/agents/host-mutation-policy.test.ts
@@ -1,49 +1,43 @@
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { buildSensitiveHostDenyMutations, resolveHostToolPath } from "./host-mutation-policy.js";
+import {
+  assertHostMutationAllowed,
+  buildSensitiveHostDenyMutations,
+  resolveHostToolPath,
+} from "./host-mutation-policy.js";
 
 describe("host mutation policy", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
   });
 
-  it("builds exact and recursive deny entries for host credential paths", () => {
-    const osHome = path.resolve("/tmp/openclaw-os-home");
-    const userProfileHome = path.resolve("/tmp/openclaw-userprofile-home");
-    const openclawHome = path.resolve("/tmp/openclaw-effective-home");
-    const stateDir = path.resolve("/tmp/openclaw-state");
-    const oauthDir = path.resolve("/tmp/openclaw-oauth");
-    const agentDir = path.resolve("/tmp/openclaw-agent");
-    const configuredAgentDir = path.resolve("/tmp/openclaw-configured-agent");
+  it("builds deny entries only for privilege and login authority paths", () => {
+    const policy = buildSensitiveHostDenyMutations();
 
-    const policy = buildSensitiveHostDenyMutations(
-      {
-        HOME: osHome,
-        USERPROFILE: userProfileHome,
-        OPENCLAW_HOME: openclawHome,
-        OPENCLAW_STATE_DIR: stateDir,
-        OPENCLAW_OAUTH_DIR: oauthDir,
-        OPENCLAW_AGENT_DIR: agentDir,
-      } as NodeJS.ProcessEnv,
-      { agentDirs: [configuredAgentDir] },
+    if (process.platform === "win32") {
+      expect(policy.paths).toEqual([]);
+      expect(policy.prefixes).toEqual([]);
+      return;
+    }
+
+    expect(policy.paths).toEqual(["/etc/passwd", "/etc/shadow", "/etc/sudoers"].toSorted());
+    expect(policy.prefixes).toEqual(["/etc/sudoers.d"]);
+    expect(policy.paths).not.toContain(path.join("/tmp", "openclaw-home", ".netrc"));
+    expect(policy.prefixes).not.toContain("/etc/systemd");
+  });
+
+  it("rejects privilege and login authority mutations", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+
+    await expect(assertHostMutationAllowed("/etc/passwd")).rejects.toThrow(
+      /denied-path|denied|mutation policy/i,
     );
-
-    expect(policy.paths).toContain(path.join(osHome, ".ssh", "authorized_keys"));
-    expect(policy.paths).toContain(path.join(userProfileHome, ".netrc"));
-    expect(policy.paths).toContain(path.join(openclawHome, ".netrc"));
-    expect(policy.paths).toContain(path.join(stateDir, ".env"));
-    expect(policy.paths).toContain(path.join(agentDir, "auth-profiles.json"));
-    expect(policy.paths).toContain(path.join(agentDir, "agent", "auth-profiles.json"));
-    expect(policy.paths).toContain(path.join(configuredAgentDir, "auth-profiles.json"));
-    expect(policy.paths).toContain(path.join(configuredAgentDir, "agent", "auth-profiles.json"));
-    expect(policy.prefixes).toContain(path.join(osHome, ".ssh"));
-    expect(policy.prefixes).toContain(path.join(userProfileHome, ".aws"));
-    expect(policy.prefixes).toContain(path.join(openclawHome, ".aws"));
-    expect(policy.prefixes).toContain(path.join(stateDir, "credentials"));
-    expect(policy.prefixes).toContain(path.join(stateDir, "agents"));
-    expect(policy.prefixes).toContain(oauthDir);
-    expect(policy.paths).toEqual([...(policy.paths ?? [])].toSorted());
-    expect(policy.prefixes).toEqual([...(policy.prefixes ?? [])].toSorted());
+    await expect(assertHostMutationAllowed("/etc/sudoers.d/openclaw-test")).rejects.toThrow(
+      /denied-path|denied|mutation policy/i,
+    );
+    await expect(assertHostMutationAllowed("/tmp/openclaw-not-sensitive")).resolves.toBeUndefined();
   });
 
   it("expands model tool tildes against the operating-system home", () => {

--- a/src/agents/host-mutation-policy.ts
+++ b/src/agents/host-mutation-policy.ts
@@ -1,0 +1,389 @@
+import { constants as fsConstants, type Stats } from "node:fs";
+import fs, { type FileHandle } from "node:fs/promises";
+import path from "node:path";
+import { resolveOAuthDir, resolveStateDir } from "../config/paths.js";
+import {
+  FsSafeError,
+  isPathInside,
+  resolveOpenedFileRealPathForHandle,
+  sameFileIdentity,
+  type DenyMutationPolicy,
+} from "../infra/fs-safe.js";
+import { expandHomePrefix, resolveEffectiveHomeDir, resolveOsHomeDir } from "../infra/home-dir.js";
+
+const HOME_DENIED_PATHS = [
+  [".ssh", "authorized_keys"],
+  [".ssh", "id_rsa"],
+  [".ssh", "id_ed25519"],
+  [".ssh", "config"],
+  [".bashrc"],
+  [".zshrc"],
+  [".profile"],
+  [".bash_profile"],
+  [".zprofile"],
+  [".netrc"],
+  [".pgpass"],
+  [".npmrc"],
+  [".pypirc"],
+] as const;
+
+const HOME_DENIED_PREFIXES = [
+  [".ssh"],
+  [".aws"],
+  [".gnupg"],
+  [".kube"],
+  [".docker"],
+  [".azure"],
+  [".config", "gh"],
+] as const;
+
+const POSIX_DENIED_PATHS = ["/etc/sudoers", "/etc/passwd", "/etc/shadow"] as const;
+const POSIX_DENIED_PREFIXES = ["/etc/sudoers.d", "/etc/systemd"] as const;
+
+export type SensitiveHostDenyMutationOptions = {
+  agentDirs?: readonly string[];
+};
+
+function normalizeEnvPath(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed || trimmed === "undefined" || trimmed === "null") {
+    return undefined;
+  }
+  return trimmed;
+}
+
+function addAbsolutePath(paths: Set<string>, candidate: string | undefined): void {
+  if (!candidate) {
+    return;
+  }
+  const resolved = path.resolve(candidate);
+  if (path.isAbsolute(resolved)) {
+    paths.add(resolved);
+  }
+}
+
+function isNotFoundPathError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException | undefined)?.code;
+  return code === "ENOENT" || code === "ENOTDIR";
+}
+
+function assertNoNulPathInput(filePath: string, message = "path contains a NUL byte") {
+  if (filePath.includes("\0")) {
+    throw new FsSafeError("invalid-path", message);
+  }
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.lstat(filePath);
+    return true;
+  } catch (error) {
+    if (!isNotFoundPathError(error)) {
+      throw error;
+    }
+    return false;
+  }
+}
+
+async function resolvePathViaExistingAncestor(targetPath: string): Promise<string> {
+  const normalized = path.resolve(targetPath);
+  let cursor = normalized;
+  const missingSuffix: string[] = [];
+
+  while (path.dirname(cursor) !== cursor && !(await pathExists(cursor))) {
+    missingSuffix.unshift(path.basename(cursor));
+    cursor = path.dirname(cursor);
+  }
+
+  if (!(await pathExists(cursor))) {
+    return normalized;
+  }
+
+  try {
+    const resolvedAncestor = path.resolve(await fs.realpath(cursor));
+    return missingSuffix.length === 0
+      ? resolvedAncestor
+      : path.resolve(resolvedAncestor, ...missingSuffix);
+  } catch {
+    return normalized;
+  }
+}
+
+async function comparablePaths(rawPath: string): Promise<Set<string>> {
+  assertNoNulPathInput(rawPath, "path contains a NUL byte");
+  const resolved = path.resolve(rawPath);
+  return new Set([resolved, await resolvePathViaExistingAncestor(resolved)]);
+}
+
+function isSamePath(left: string, right: string): boolean {
+  return isPathInside(left, right) && isPathInside(right, left);
+}
+
+function policyPathEntries(entries: readonly string[] | undefined): string[] {
+  const paths: string[] = [];
+  for (const entry of entries ?? []) {
+    if (entry.length === 0) {
+      throw new FsSafeError("invalid-path", "deny mutation paths must be non-empty");
+    }
+    assertNoNulPathInput(entry, "deny mutation path contains a NUL byte");
+    if (!path.isAbsolute(entry)) {
+      throw new FsSafeError("invalid-path", "deny mutation paths must be absolute");
+    }
+    paths.push(entry);
+  }
+  return paths;
+}
+
+function throwDeniedMutation(): never {
+  throw new FsSafeError("denied-path", "path is denied by denyMutations policy");
+}
+
+async function assertMutationNotDenied(
+  filePath: string,
+  policy: DenyMutationPolicy,
+): Promise<void> {
+  const targetPaths = await comparablePaths(filePath);
+  for (const deniedPath of policyPathEntries(policy.paths)) {
+    const deniedPaths = await comparablePaths(deniedPath);
+    for (const target of targetPaths) {
+      for (const denied of deniedPaths) {
+        if (isSamePath(denied, target)) {
+          throwDeniedMutation();
+        }
+      }
+    }
+  }
+
+  for (const deniedPrefix of policyPathEntries(policy.prefixes)) {
+    const deniedPaths = await comparablePaths(deniedPrefix);
+    for (const target of targetPaths) {
+      for (const denied of deniedPaths) {
+        if (isPathInside(denied, target)) {
+          throwDeniedMutation();
+        }
+      }
+    }
+  }
+}
+
+async function statExistingPath(filePath: string): Promise<Stats | undefined> {
+  try {
+    return await fs.stat(filePath);
+  } catch (error) {
+    if (!isNotFoundPathError(error)) {
+      throw error;
+    }
+    return undefined;
+  }
+}
+
+function isHardlinkedRegularFile(stat: Stats): boolean {
+  return stat.isFile() && stat.nlink > 1;
+}
+
+async function assertOpenedFileNotDeniedByIdentity(
+  openedStat: Stats,
+  policy: DenyMutationPolicy,
+): Promise<void> {
+  for (const deniedPath of policyPathEntries(policy.paths)) {
+    const deniedStat = await statExistingPath(deniedPath);
+    if (deniedStat && sameFileIdentity(openedStat, deniedStat)) {
+      throwDeniedMutation();
+    }
+  }
+
+  // Hardlinks have no unique path. Without scanning every sensitive prefix on
+  // each write, a harmless-looking alias can still mutate a denied inode.
+  if (isHardlinkedRegularFile(openedStat)) {
+    throwDeniedMutation();
+  }
+}
+
+async function assertOpenedHostFileMutationAllowed(
+  handle: FileHandle,
+  ioPath: string,
+  policy: DenyMutationPolicy,
+): Promise<void> {
+  const openedRealPath = await resolveOpenedFileRealPathForHandle(handle, ioPath);
+  await assertMutationNotDenied(openedRealPath, policy);
+  await assertOpenedFileNotDeniedByIdentity(await handle.stat(), policy);
+}
+
+async function openExistingHostFileForWrite(filePath: string): Promise<FileHandle | undefined> {
+  try {
+    return await fs.open(filePath, fsConstants.O_WRONLY);
+  } catch (error) {
+    if (!isNotFoundPathError(error)) {
+      throw error;
+    }
+    return undefined;
+  }
+}
+
+async function writeOpenedHostFileWithDenyMutations(
+  handle: FileHandle,
+  ioPath: string,
+  content: string,
+  policy: DenyMutationPolicy,
+): Promise<void> {
+  try {
+    await assertOpenedHostFileMutationAllowed(handle, ioPath, policy);
+    await handle.truncate(0);
+    await handle.writeFile(content, "utf8");
+  } finally {
+    await handle.close();
+  }
+}
+
+function addHomeSensitivePaths(home: string, paths: Set<string>, prefixes: Set<string>): void {
+  const resolvedHome = path.resolve(home);
+  if (resolvedHome === path.parse(resolvedHome).root) {
+    return;
+  }
+  for (const suffix of HOME_DENIED_PATHS) {
+    addAbsolutePath(paths, path.join(resolvedHome, ...suffix));
+  }
+  for (const suffix of HOME_DENIED_PREFIXES) {
+    addAbsolutePath(prefixes, path.join(resolvedHome, ...suffix));
+  }
+}
+
+function addHomeRoot(roots: Set<string>, candidate: string | undefined, env: NodeJS.ProcessEnv) {
+  const normalized = normalizeEnvPath(candidate);
+  if (!normalized) {
+    return;
+  }
+  roots.add(path.resolve(expandHomePrefix(normalized, { env })));
+}
+
+function collectHomeRoots(env: NodeJS.ProcessEnv): string[] {
+  const roots = new Set<string>();
+  for (const candidate of [resolveOsHomeDir(env), resolveEffectiveHomeDir(env)]) {
+    if (candidate) {
+      roots.add(candidate);
+    }
+  }
+  addHomeRoot(roots, env.HOME, env);
+  addHomeRoot(roots, env.USERPROFILE, env);
+  return [...roots];
+}
+
+function collectStatePaths(env: NodeJS.ProcessEnv, paths: Set<string>, prefixes: Set<string>) {
+  const stateDir = resolveStateDir(env);
+  const oauthDir = resolveOAuthDir(env, stateDir);
+  addAbsolutePath(paths, path.join(stateDir, ".env"));
+  addAbsolutePath(prefixes, path.join(stateDir, "credentials"));
+  addAbsolutePath(prefixes, path.join(stateDir, "agents"));
+  addAbsolutePath(prefixes, oauthDir);
+}
+
+function collectAgentAuthProfilePaths(
+  env: NodeJS.ProcessEnv,
+  paths: Set<string>,
+  options?: SensitiveHostDenyMutationOptions,
+) {
+  for (const agentDir of [
+    env.OPENCLAW_AGENT_DIR,
+    env.PI_CODING_AGENT_DIR,
+    ...(options?.agentDirs ?? []),
+  ]) {
+    if (!agentDir?.trim()) {
+      continue;
+    }
+    const resolved = path.resolve(expandHomePrefix(agentDir, { env }));
+    addAbsolutePath(paths, path.join(resolved, "auth-profiles.json"));
+    addAbsolutePath(paths, path.join(resolved, "agent", "auth-profiles.json"));
+  }
+}
+
+export function buildSensitiveHostDenyMutations(
+  env: NodeJS.ProcessEnv = process.env,
+  options?: SensitiveHostDenyMutationOptions,
+): DenyMutationPolicy {
+  const paths = new Set<string>();
+  const prefixes = new Set<string>();
+
+  for (const home of collectHomeRoots(env)) {
+    addHomeSensitivePaths(home, paths, prefixes);
+  }
+  collectStatePaths(env, paths, prefixes);
+  collectAgentAuthProfilePaths(env, paths, options);
+
+  if (process.platform !== "win32") {
+    for (const blockedPath of POSIX_DENIED_PATHS) {
+      addAbsolutePath(paths, blockedPath);
+    }
+    for (const blockedPrefix of POSIX_DENIED_PREFIXES) {
+      addAbsolutePath(prefixes, blockedPrefix);
+    }
+  }
+
+  return {
+    paths: [...paths].toSorted(),
+    prefixes: [...prefixes].toSorted(),
+  };
+}
+
+export function resolveHostToolPath(filePath: string): string {
+  const home = resolveOsHomeDir();
+  const expanded = home ? expandHomePrefix(filePath, { home }) : filePath;
+  return path.resolve(expanded);
+}
+
+export async function assertHostMutationAllowed(
+  absolutePath: string,
+  options?: SensitiveHostDenyMutationOptions,
+): Promise<void> {
+  await assertMutationNotDenied(
+    path.resolve(absolutePath),
+    buildSensitiveHostDenyMutations(process.env, options),
+  );
+}
+
+export async function writeHostFileWithDenyMutations(
+  absolutePath: string,
+  content: string,
+  options?: SensitiveHostDenyMutationOptions,
+): Promise<void> {
+  const resolved = path.resolve(absolutePath);
+  const policy = buildSensitiveHostDenyMutations(process.env, options);
+  await assertMutationNotDenied(resolved, policy);
+  const existingHandle = await openExistingHostFileForWrite(resolved);
+  if (existingHandle) {
+    await writeOpenedHostFileWithDenyMutations(existingHandle, resolved, content, policy);
+    return;
+  }
+
+  await fs.mkdir(path.dirname(resolved), { recursive: true });
+  await assertMutationNotDenied(resolved, policy);
+  try {
+    await fs.writeFile(resolved, content, { encoding: "utf8", flag: "wx" });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException | undefined)?.code !== "EEXIST") {
+      throw error;
+    }
+    const racedHandle = await openExistingHostFileForWrite(resolved);
+    if (!racedHandle) {
+      throw error;
+    }
+    await writeOpenedHostFileWithDenyMutations(racedHandle, resolved, content, policy);
+  }
+}
+
+export async function mkdirHostPathWithDenyMutations(
+  dir: string,
+  options?: SensitiveHostDenyMutationOptions,
+): Promise<void> {
+  const resolved = path.resolve(dir);
+  await assertHostMutationAllowed(resolved, options);
+  await fs.mkdir(resolved, { recursive: true });
+}
+
+export async function removeHostPathWithDenyMutations(
+  filePath: string,
+  options?: SensitiveHostDenyMutationOptions,
+): Promise<void> {
+  const resolved = path.resolve(filePath);
+  await assertHostMutationAllowed(resolved, options);
+  await fs.rm(resolved);
+}

--- a/src/agents/host-mutation-policy.ts
+++ b/src/agents/host-mutation-policy.ts
@@ -1,7 +1,6 @@
 import { constants as fsConstants, type Stats } from "node:fs";
 import fs, { type FileHandle } from "node:fs/promises";
 import path from "node:path";
-import { resolveOAuthDir, resolveStateDir } from "../config/paths.js";
 import {
   FsSafeError,
   isPathInside,
@@ -9,48 +8,10 @@ import {
   sameFileIdentity,
   type DenyMutationPolicy,
 } from "../infra/fs-safe.js";
-import { expandHomePrefix, resolveEffectiveHomeDir, resolveOsHomeDir } from "../infra/home-dir.js";
-
-const HOME_DENIED_PATHS = [
-  [".ssh", "authorized_keys"],
-  [".ssh", "id_rsa"],
-  [".ssh", "id_ed25519"],
-  [".ssh", "config"],
-  [".bashrc"],
-  [".zshrc"],
-  [".profile"],
-  [".bash_profile"],
-  [".zprofile"],
-  [".netrc"],
-  [".pgpass"],
-  [".npmrc"],
-  [".pypirc"],
-] as const;
-
-const HOME_DENIED_PREFIXES = [
-  [".ssh"],
-  [".aws"],
-  [".gnupg"],
-  [".kube"],
-  [".docker"],
-  [".azure"],
-  [".config", "gh"],
-] as const;
+import { expandHomePrefix, resolveOsHomeDir } from "../infra/home-dir.js";
 
 const POSIX_DENIED_PATHS = ["/etc/sudoers", "/etc/passwd", "/etc/shadow"] as const;
-const POSIX_DENIED_PREFIXES = ["/etc/sudoers.d", "/etc/systemd"] as const;
-
-export type SensitiveHostDenyMutationOptions = {
-  agentDirs?: readonly string[];
-};
-
-function normalizeEnvPath(value: string | undefined): string | undefined {
-  const trimmed = value?.trim();
-  if (!trimmed || trimmed === "undefined" || trimmed === "null") {
-    return undefined;
-  }
-  return trimmed;
-}
+const POSIX_DENIED_PREFIXES = ["/etc/sudoers.d"] as const;
 
 function addAbsolutePath(paths: Set<string>, candidate: string | undefined): void {
   if (!candidate) {
@@ -177,10 +138,6 @@ async function statExistingPath(filePath: string): Promise<Stats | undefined> {
   }
 }
 
-function isHardlinkedRegularFile(stat: Stats): boolean {
-  return stat.isFile() && stat.nlink > 1;
-}
-
 async function assertOpenedFileNotDeniedByIdentity(
   openedStat: Stats,
   policy: DenyMutationPolicy,
@@ -190,12 +147,6 @@ async function assertOpenedFileNotDeniedByIdentity(
     if (deniedStat && sameFileIdentity(openedStat, deniedStat)) {
       throwDeniedMutation();
     }
-  }
-
-  // Hardlinks have no unique path. Without scanning every sensitive prefix on
-  // each write, a harmless-looking alias can still mutate a denied inode.
-  if (isHardlinkedRegularFile(openedStat)) {
-    throwDeniedMutation();
   }
 }
 
@@ -235,79 +186,9 @@ async function writeOpenedHostFileWithDenyMutations(
   }
 }
 
-function addHomeSensitivePaths(home: string, paths: Set<string>, prefixes: Set<string>): void {
-  const resolvedHome = path.resolve(home);
-  if (resolvedHome === path.parse(resolvedHome).root) {
-    return;
-  }
-  for (const suffix of HOME_DENIED_PATHS) {
-    addAbsolutePath(paths, path.join(resolvedHome, ...suffix));
-  }
-  for (const suffix of HOME_DENIED_PREFIXES) {
-    addAbsolutePath(prefixes, path.join(resolvedHome, ...suffix));
-  }
-}
-
-function addHomeRoot(roots: Set<string>, candidate: string | undefined, env: NodeJS.ProcessEnv) {
-  const normalized = normalizeEnvPath(candidate);
-  if (!normalized) {
-    return;
-  }
-  roots.add(path.resolve(expandHomePrefix(normalized, { env })));
-}
-
-function collectHomeRoots(env: NodeJS.ProcessEnv): string[] {
-  const roots = new Set<string>();
-  for (const candidate of [resolveOsHomeDir(env), resolveEffectiveHomeDir(env)]) {
-    if (candidate) {
-      roots.add(candidate);
-    }
-  }
-  addHomeRoot(roots, env.HOME, env);
-  addHomeRoot(roots, env.USERPROFILE, env);
-  return [...roots];
-}
-
-function collectStatePaths(env: NodeJS.ProcessEnv, paths: Set<string>, prefixes: Set<string>) {
-  const stateDir = resolveStateDir(env);
-  const oauthDir = resolveOAuthDir(env, stateDir);
-  addAbsolutePath(paths, path.join(stateDir, ".env"));
-  addAbsolutePath(prefixes, path.join(stateDir, "credentials"));
-  addAbsolutePath(prefixes, path.join(stateDir, "agents"));
-  addAbsolutePath(prefixes, oauthDir);
-}
-
-function collectAgentAuthProfilePaths(
-  env: NodeJS.ProcessEnv,
-  paths: Set<string>,
-  options?: SensitiveHostDenyMutationOptions,
-) {
-  for (const agentDir of [
-    env.OPENCLAW_AGENT_DIR,
-    env.PI_CODING_AGENT_DIR,
-    ...(options?.agentDirs ?? []),
-  ]) {
-    if (!agentDir?.trim()) {
-      continue;
-    }
-    const resolved = path.resolve(expandHomePrefix(agentDir, { env }));
-    addAbsolutePath(paths, path.join(resolved, "auth-profiles.json"));
-    addAbsolutePath(paths, path.join(resolved, "agent", "auth-profiles.json"));
-  }
-}
-
-export function buildSensitiveHostDenyMutations(
-  env: NodeJS.ProcessEnv = process.env,
-  options?: SensitiveHostDenyMutationOptions,
-): DenyMutationPolicy {
+export function buildSensitiveHostDenyMutations(): DenyMutationPolicy {
   const paths = new Set<string>();
   const prefixes = new Set<string>();
-
-  for (const home of collectHomeRoots(env)) {
-    addHomeSensitivePaths(home, paths, prefixes);
-  }
-  collectStatePaths(env, paths, prefixes);
-  collectAgentAuthProfilePaths(env, paths, options);
 
   if (process.platform !== "win32") {
     for (const blockedPath of POSIX_DENIED_PATHS) {
@@ -330,23 +211,16 @@ export function resolveHostToolPath(filePath: string): string {
   return path.resolve(expanded);
 }
 
-export async function assertHostMutationAllowed(
-  absolutePath: string,
-  options?: SensitiveHostDenyMutationOptions,
-): Promise<void> {
-  await assertMutationNotDenied(
-    path.resolve(absolutePath),
-    buildSensitiveHostDenyMutations(process.env, options),
-  );
+export async function assertHostMutationAllowed(absolutePath: string): Promise<void> {
+  await assertMutationNotDenied(path.resolve(absolutePath), buildSensitiveHostDenyMutations());
 }
 
 export async function writeHostFileWithDenyMutations(
   absolutePath: string,
   content: string,
-  options?: SensitiveHostDenyMutationOptions,
 ): Promise<void> {
   const resolved = path.resolve(absolutePath);
-  const policy = buildSensitiveHostDenyMutations(process.env, options);
+  const policy = buildSensitiveHostDenyMutations();
   await assertMutationNotDenied(resolved, policy);
   const existingHandle = await openExistingHostFileForWrite(resolved);
   if (existingHandle) {
@@ -370,20 +244,14 @@ export async function writeHostFileWithDenyMutations(
   }
 }
 
-export async function mkdirHostPathWithDenyMutations(
-  dir: string,
-  options?: SensitiveHostDenyMutationOptions,
-): Promise<void> {
+export async function mkdirHostPathWithDenyMutations(dir: string): Promise<void> {
   const resolved = path.resolve(dir);
-  await assertHostMutationAllowed(resolved, options);
+  await assertHostMutationAllowed(resolved);
   await fs.mkdir(resolved, { recursive: true });
 }
 
-export async function removeHostPathWithDenyMutations(
-  filePath: string,
-  options?: SensitiveHostDenyMutationOptions,
-): Promise<void> {
+export async function removeHostPathWithDenyMutations(filePath: string): Promise<void> {
   const resolved = path.resolve(filePath);
-  await assertHostMutationAllowed(resolved, options);
+  await assertHostMutationAllowed(resolved);
   await fs.rm(resolved);
 }

--- a/src/infra/fs-safe.ts
+++ b/src/infra/fs-safe.ts
@@ -25,7 +25,12 @@ export {
 export { isPathInside } from "@openclaw/fs-safe/path";
 export { pathExists, pathExistsSync } from "@openclaw/fs-safe/advanced";
 export { movePathToTrash, type MovePathToTrashOptions } from "@openclaw/fs-safe/advanced";
-export { readLocalFileFromRoots, resolveLocalPathFromRootsSync } from "@openclaw/fs-safe/advanced";
+export {
+  readLocalFileFromRoots,
+  resolveLocalPathFromRootsSync,
+  sameFileIdentity,
+  type FileIdentityStat,
+} from "@openclaw/fs-safe/advanced";
 export {
   appendRegularFile,
   appendRegularFileSync,
@@ -40,6 +45,7 @@ export {
   readLocalFileSafely,
   resolveOpenedFileRealPathForHandle,
   root,
+  type DenyMutationPolicy,
   type OpenResult,
   type ReadResult,
   type Root,


### PR DESCRIPTION
## Summary

- Add a host mutation deny policy for the highest-risk privilege/login authority files only:
  - `/etc/passwd`
  - `/etc/shadow`
  - `/etc/sudoers`
  - `/etc/sudoers.d/**`
- Apply that policy to host write/edit/apply_patch paths, including `workspaceOnly=false` host mutations and `workspaceOnly=true` roots that include denied system paths.
- Keep normal host writes broad for legitimate use cases: home credentials, shell profiles, OpenClaw state/auth stores, non-sensitive symlinks, and non-sensitive hardlinks are not hard-denied in this first pass.

## Real behavior proof

Behavior addressed: Host write/edit/apply_patch mutations now hard-deny the initial privilege/login authority path set while leaving other host paths available for legitimate edits.
Real environment tested: macOS local Codex worktree rebased on current `origin/main`; branch head `8d1ef057a15e4ac774c0c1246db41dc74fd51f26`.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/host-mutation-policy.test.ts src/agents/agent-tools.workspace-only-false.test.ts src/agents/apply-patch.test.ts`
Evidence after fix: Focused Vitest passed 3 files / 45 tests. Tests cover denial of `/etc/passwd` and `/etc/sudoers.d/**`, denial through write/edit/apply_patch policy surfaces, and allowance of credential-like home paths plus non-sensitive hardlinks/symlinks when `workspaceOnly=false`.
Observed result after fix: Denied system authority mutations fail with denied-path/mutation-policy errors; normal host writes, credential-like home paths, non-sensitive symlink writes, and non-sensitive hardlink writes still succeed.
What was not tested: Full `pnpm check`/full CI and remote Testbox were not run; CI should cover broader repository lanes.

## Follow-ups intentionally left out of this PR

Future hardening can add narrower policy entries for SSH access authority, shell startup persistence, credential/token stores, OpenClaw-owned auth/state, additional system persistence/login files, and alias-specific hardening. See the PR discussion comment for the candidate path list.
