### PR TITLE
fix(telegram): cache outbound replies for prompt context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ Docs: https://docs.openclaw.ai
 - Models: prune retired Groq, GitHub Copilot, OpenAI, xAI, and old Claude catalog entries, with doctor migration to upgrade existing configs to current provider refs.
 - Doctor/update: recognize junction-backed source checkouts as git installs by comparing canonical paths before showing package-manager update guidance. Fixes #82215. Thanks @igormf.
 - Channels: honor `/verbose on` for tool/progress summaries across direct chats, groups, channels, and forum topics while preserving quiet default behavior. (#85488) Thanks @kurplunkin.
+- Telegram: persist the prompt-context message cache through plugin state and record bot-authored replies after sends and draft streaming so later turns can include prior assistant replies without relying on the JSON sidecar. (#85231) Thanks @keshavbotagent.
 - CLI/skills: show an all-ready note with next-step commands when skill setup has no missing dependencies to install. (#85032) Thanks @aniruddhaadak80.
 - Microsoft Foundry: route DeepSeek V4 Pro and Flash models through the Foundry Responses API while keeping older DeepSeek models on their existing path. (#85549) Thanks @roslinmahmud.
 - Status/usage: show configured cost estimates for AWS SDK models in full usage output while keeping token-only usage replies cost-free. (#85619) Thanks @ItsOtherMauridian.

--- a/extensions/telegram/src/bot-deps.ts
+++ b/extensions/telegram/src/bot-deps.ts
@@ -24,6 +24,7 @@ import { deliverReplies, emitInternalMessageSentHook } from "./bot/delivery.js";
 import { createTelegramDraftStream } from "./draft-stream.js";
 import { resolveTelegramExecApproval } from "./exec-approval-resolver.js";
 import { createNativeTelegramToolProgressDraft } from "./native-tool-progress-draft.js";
+import { recordOutboundMessageForPromptContext } from "./outbound-message-context.js";
 import { editMessageTelegram } from "./send.js";
 import { wasSentByBot } from "./sent-message-cache.js";
 
@@ -53,6 +54,7 @@ export type TelegramBotDeps = {
   deliverInboundReplyWithMessageSendContext?: typeof deliverInboundReplyWithMessageSendContext;
   emitInternalMessageSentHook?: typeof emitInternalMessageSentHook;
   editMessageTelegram?: typeof editMessageTelegram;
+  recordOutboundMessageForPromptContext?: typeof recordOutboundMessageForPromptContext;
   createChannelMessageReplyPipeline?: typeof createChannelMessageReplyPipeline;
 };
 
@@ -131,6 +133,9 @@ export const defaultTelegramBotDeps: TelegramBotDeps = {
   },
   get editMessageTelegram() {
     return editMessageTelegram;
+  },
+  get recordOutboundMessageForPromptContext() {
+    return recordOutboundMessageForPromptContext;
   },
   get createChannelMessageReplyPipeline() {
     return createChannelMessageReplyPipeline;

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -1024,19 +1024,19 @@ export const registerTelegramHandlers = ({
     is_reply_target: flags?.replyTarget === true ? true : undefined,
   });
 
-  const buildPromptContextForMessage = (
+  const buildPromptContextForMessage = async (
     msg: Message,
     replyChainNodes: TelegramCachedMessageNode[],
     options?: TelegramMessageContextOptions,
-  ): TelegramPromptContextEntry[] => {
+  ): Promise<TelegramPromptContextEntry[]> => {
     const messageId = typeof msg.message_id === "number" ? String(msg.message_id) : undefined;
-    const currentNode = messageCache.get({
+    const currentNode = await messageCache.get({
       accountId,
       chatId: msg.chat.id,
       messageId,
     });
     const threadId = currentNode?.threadId ? Number(currentNode.threadId) : undefined;
-    const conversationContext = buildTelegramConversationContext({
+    const conversationContext = await buildTelegramConversationContext({
       cache: messageCache,
       messageId,
       accountId,
@@ -1119,12 +1119,12 @@ export const registerTelegramHandlers = ({
   }) => {
     let dispatchDedupeCommitted = false;
     try {
-      const replyChainNodes = buildReplyChainForMessage(params.msg);
+      const replyChainNodes = await buildReplyChainForMessage(params.msg);
       const { replyMedia, replyChain } = await resolveReplyMediaForChain(
         params.ctx,
         replyChainNodes,
       );
-      const promptContext = buildPromptContextForMessage(
+      const promptContext = await buildPromptContextForMessage(
         params.msg,
         replyChainNodes,
         params.options,
@@ -2754,7 +2754,7 @@ export const registerTelegramHandlers = ({
       messageThreadId: normalizedMsg.message_thread_id,
     });
     const dmThreadId = !isGroup ? normalizedMsg.message_thread_id : undefined;
-    recordMessageForReplyChain(normalizedMsg, resolvedThreadId ?? dmThreadId);
+    await recordMessageForReplyChain(normalizedMsg, resolvedThreadId ?? dmThreadId);
   };
 
   const handleInboundMessageLike = async (event: InboundTelegramEvent) => {
@@ -2851,7 +2851,7 @@ export const registerTelegramHandlers = ({
         return;
       }
       dispatchDedupeKeys = dispatchDedupe.keys;
-      recordMessageForReplyChain(event.msg, resolvedThreadId ?? dmThreadId);
+      await recordMessageForReplyChain(event.msg, resolvedThreadId ?? dmThreadId);
       await processInboundMessage({
         ctx: event.ctx,
         msg: event.msg,

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import type { Bot } from "grammy";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveAutoTopicLabelConfig as resolveAutoTopicLabelConfigRuntime } from "./auto-topic-label-config.js";
@@ -7,6 +8,12 @@ import {
   createTestDraftStream,
 } from "./draft-stream.test-helpers.js";
 import { notifyTelegramInboundEventOutboundSuccess } from "./inbound-event-delivery.js";
+import {
+  buildTelegramConversationContext,
+  createTelegramMessageCache,
+  resolveTelegramMessageCachePath,
+} from "./message-cache.js";
+import { recordOutboundMessageForPromptContext as recordOutboundMessageForPromptContextActual } from "./outbound-message-context.js";
 
 type DispatchReplyWithBufferedBlockDispatcherArgs = Parameters<
   TelegramBotDeps["dispatchReplyWithBufferedBlockDispatcher"]
@@ -20,6 +27,7 @@ const dispatchReplyWithBufferedBlockDispatcher = vi.hoisted(() =>
 const deliverReplies = vi.hoisted(() => vi.fn());
 const deliverInboundReplyWithMessageSendContext = vi.hoisted(() => vi.fn());
 const emitInternalMessageSentHook = vi.hoisted(() => vi.fn());
+const recordOutboundMessageForPromptContext = vi.hoisted(() => vi.fn());
 const createForumTopicTelegram = vi.hoisted(() => vi.fn());
 const deleteMessageTelegram = vi.hoisted(() => vi.fn());
 const editForumTopicTelegram = vi.hoisted(() => vi.fn());
@@ -189,6 +197,8 @@ const telegramDepsForTest: TelegramBotDeps = {
   emitInternalMessageSentHook:
     emitInternalMessageSentHook as TelegramBotDeps["emitInternalMessageSentHook"],
   editMessageTelegram: editMessageTelegram as TelegramBotDeps["editMessageTelegram"],
+  recordOutboundMessageForPromptContext:
+    recordOutboundMessageForPromptContext as TelegramBotDeps["recordOutboundMessageForPromptContext"],
 };
 
 describe("dispatchTelegramMessage draft streaming", () => {
@@ -207,6 +217,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     deliverReplies.mockReset();
     deliverInboundReplyWithMessageSendContext.mockReset();
     emitInternalMessageSentHook.mockReset();
+    recordOutboundMessageForPromptContext.mockReset();
     createForumTopicTelegram.mockReset();
     deleteMessageTelegram.mockReset();
     editForumTopicTelegram.mockReset();
@@ -970,6 +981,69 @@ describe("dispatchTelegramMessage draft streaming", () => {
       content: "Final answer",
       messageId: 2001,
     });
+    expectRecordFields(mockCallArg(recordOutboundMessageForPromptContext), {
+      chatId: "123",
+      messageId: 2001,
+      text: "Final answer",
+      messageThreadId: 777,
+    });
+  });
+
+  it("records streamed final replies into the prompt context cache", async () => {
+    const storePath = `/tmp/openclaw-telegram-stream-context-${process.pid}-${Date.now()}.json`;
+    const persistedPath = resolveTelegramMessageCachePath(storePath);
+    try {
+      setupDraftStreams({ answerMessageId: 1497 });
+      dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+        await dispatcherOptions.deliver(
+          { text: "Done already: timeoutSeconds is now 7200s." },
+          { kind: "final" },
+        );
+        return { queuedFinal: true };
+      });
+
+      await dispatchWithContext({
+        context: createContext(),
+        cfg: { session: { store: storePath } },
+        telegramDeps: {
+          ...telegramDepsForTest,
+          recordOutboundMessageForPromptContext: recordOutboundMessageForPromptContextActual,
+        },
+      });
+
+      const cache = createTelegramMessageCache({ persistedPath });
+      await cache.record({
+        accountId: "default",
+        chatId: "123",
+        threadId: 777,
+        msg: {
+          chat: { id: 123, type: "private", first_name: "Keshav" },
+          message_thread_id: 777,
+          message_id: 1521,
+          date: 1_779_425_460,
+          text: "Did all Amazon crons run fine",
+          from: { id: 5185575566, is_bot: false, first_name: "Keshav" },
+        },
+      });
+
+      const context = await buildTelegramConversationContext({
+        cache,
+        accountId: "default",
+        chatId: "123",
+        threadId: 777,
+        messageId: "1521",
+        replyChainNodes: [],
+        recentLimit: 10,
+        replyTargetWindowSize: 2,
+      });
+
+      expect(context.map((entry) => entry.node.messageId)).toContain("1497");
+      expect(context.map((entry) => entry.node.body)).toContain(
+        "Done already: timeoutSeconds is now 7200s.",
+      );
+    } finally {
+      fs.rmSync(persistedPath, { force: true });
+    }
   });
 
   it("suppresses text-only tool payloads delivered after the final answer", async () => {
@@ -1778,6 +1852,10 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
     const firstChunk = answerDraftStream.update.mock.calls.at(-1)?.[0] ?? "";
     expect(firstChunk.length).toBeLessThanOrEqual(80);
+    expectRecordFields(mockCallArg(recordOutboundMessageForPromptContext), {
+      messageId: 2001,
+      text: firstChunk,
+    });
     expect(deliverReplies).toHaveBeenCalled();
     const followUpTexts = deliverReplies.mock.calls.flatMap((call: unknown[]) =>
       ((call[0] as { replies?: Array<{ text?: string }> }).replies ?? []).map(

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -105,6 +105,7 @@ import {
   type LaneName,
 } from "./lane-delivery.js";
 import { createNativeTelegramToolProgressDraft } from "./native-tool-progress-draft.js";
+import { recordOutboundMessageForPromptContext } from "./outbound-message-context.js";
 import {
   createTelegramReasoningStepState,
   splitTelegramReasoningText,
@@ -1182,7 +1183,7 @@ export const dispatchTelegramMessage = async ({
       }
       return result.delivered;
     };
-    const emitPreviewFinalizedHook = (result: LaneDeliveryResult) => {
+    const emitPreviewFinalizedHook = async (result: LaneDeliveryResult) => {
       if (isDispatchSuperseded() || result.kind !== "preview-finalized") {
         return;
       }
@@ -1196,6 +1197,26 @@ export const dispatchTelegramMessage = async ({
         isGroup: deliveryBaseOptions.mirrorIsGroup,
         groupId: deliveryBaseOptions.mirrorGroupId,
       });
+      try {
+        await (
+          telegramDeps.recordOutboundMessageForPromptContext ??
+          recordOutboundMessageForPromptContext
+        )({
+          cfg,
+          account: { accountId: route.accountId },
+          chatId: deliveryBaseOptions.chatId,
+          message: { message_id: result.delivery.messageId },
+          messageId: result.delivery.messageId,
+          text: result.delivery.promptContextContent ?? result.delivery.content,
+          ...(threadSpec.id !== undefined ? { messageThreadId: threadSpec.id } : {}),
+        });
+      } catch (error) {
+        logVerbose(
+          `telegram: failed to record streamed reply for prompt context: ${formatErrorMessage(
+            error,
+          )}`,
+        );
+      }
       if (deliveryBaseOptions.transcriptMirror && result.delivery.content) {
         void deliveryBaseOptions
           .transcriptMirror({ text: result.delivery.content })
@@ -1472,7 +1493,7 @@ export const dispatchTelegramMessage = async ({
                               buttons: telegramButtons,
                             });
                       if (info.kind === "final") {
-                        emitPreviewFinalizedHook(result);
+                        await emitPreviewFinalizedHook(result);
                       }
                       blockDelivered = blockDelivered || result.kind !== "skipped";
                       if (segment.lane === "reasoning") {

--- a/extensions/telegram/src/channel.setup.ts
+++ b/extensions/telegram/src/channel.setup.ts
@@ -12,7 +12,6 @@ export const telegramSetupPlugin: ChannelPlugin<ResolvedTelegramAccount, Telegra
     setup: telegramSetupAdapter,
   }),
   lifecycle: {
-    detectLegacyStateMigrations: ({ cfg, env }) =>
-      detectTelegramLegacyStateMigrations({ cfg, env }),
+    detectLegacyStateMigrations: (params) => detectTelegramLegacyStateMigrations(params),
   },
 };

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -784,8 +784,7 @@ export const telegramPlugin = createChatChannelPlugin({
         await resolveTelegramTargets({ cfg, accountId, inputs, kind }),
     },
     lifecycle: {
-      detectLegacyStateMigrations: ({ cfg, env }) =>
-        detectTelegramLegacyStateMigrations({ cfg, env }),
+      detectLegacyStateMigrations: (params) => detectTelegramLegacyStateMigrations(params),
       onAccountConfigChanged: async ({ prevCfg, nextCfg, accountId }) => {
         const previousToken = resolveTelegramAccount({ cfg: prevCfg, accountId }).token.trim();
         const nextToken = resolveTelegramAccount({ cfg: nextCfg, accountId }).token.trim();

--- a/extensions/telegram/src/lane-delivery-text-deliverer.ts
+++ b/extensions/telegram/src/lane-delivery-text-deliverer.ts
@@ -26,6 +26,7 @@ export type DraftLaneState = {
 
 type LanePreviewFinalizedDelivery = {
   content: string;
+  promptContextContent?: string;
   messageId: number;
   buttonsAttached?: boolean;
   receipt: MessageReceipt;
@@ -367,7 +368,12 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         }
         await params.sendPayload(followUpPayload(payload, chunk));
       }
-      return result("preview-finalized", { content: text, messageId, buttonsAttached });
+      return result("preview-finalized", {
+        content: text,
+        promptContextContent: firstChunk,
+        messageId,
+        buttonsAttached,
+      });
     }
 
     return result("preview-updated");

--- a/extensions/telegram/src/lane-delivery.test.ts
+++ b/extensions/telegram/src/lane-delivery.test.ts
@@ -655,6 +655,7 @@ describe("createLaneTextDeliverer", () => {
 
     const delivery = expectPreviewFinalized(result);
     expect(delivery.content).toBe("Hello world again");
+    expect(delivery.promptContextContent).toBe("Hello");
     expect(delivery.messageId).toBe(999);
     expect(harness.answer?.update).toHaveBeenCalledWith("Hello");
     expect(harness.sendPayload).toHaveBeenCalledTimes(2);

--- a/extensions/telegram/src/message-cache.test.ts
+++ b/extensions/telegram/src/message-cache.test.ts
@@ -7,6 +7,7 @@ import {
   createTelegramMessageCache,
   resetTelegramMessageCacheBucketsForTest,
   resolveTelegramMessageCachePath,
+  type TelegramMessageCachePersistentStore,
 } from "./message-cache.js";
 
 type PersistedCacheEntry = {
@@ -15,6 +16,41 @@ type PersistedCacheEntry = {
     sourceMessage: Message;
   };
 };
+
+type PersistedCacheValue = {
+  sourceMessage: Message;
+  threadId?: string;
+};
+
+let persistentStoreId = 0;
+
+function createMemoryPersistentStore(maxEntries = 1000): {
+  bucketKey: string;
+  entries: Map<string, PersistedCacheValue>;
+  store: TelegramMessageCachePersistentStore;
+} {
+  const entries = new Map<string, PersistedCacheValue>();
+  return {
+    bucketKey: `test:${process.pid}:${Date.now()}:${persistentStoreId++}`,
+    entries,
+    store: {
+      async register(key, value) {
+        entries.delete(key);
+        entries.set(key, value);
+        while (entries.size > maxEntries) {
+          const oldest = entries.keys().next().value;
+          if (oldest === undefined) {
+            break;
+          }
+          entries.delete(oldest);
+        }
+      },
+      async entries() {
+        return Array.from(entries, ([key, value]) => ({ key, value }));
+      },
+    },
+  };
+}
 
 function persistedCacheEntry(messageId: number, text: string): PersistedCacheEntry {
   return {
@@ -31,6 +67,10 @@ function persistedCacheEntry(messageId: number, text: string): PersistedCacheEnt
   };
 }
 
+function unscopedPersistentKeys(entries: Map<string, PersistedCacheValue>): string[] {
+  return Array.from(entries.keys(), (key) => key.split(":").slice(-3).join(":")).toSorted();
+}
+
 describe("telegram message cache", () => {
   it("hydrates reply chains from persisted cached messages", async () => {
     const storePath = `/tmp/openclaw-telegram-message-cache-${process.pid}-${Date.now()}.json`;
@@ -38,7 +78,7 @@ describe("telegram message cache", () => {
     await rm(persistedPath, { force: true });
     try {
       const firstCache = createTelegramMessageCache({ persistedPath });
-      firstCache.record({
+      await firstCache.record({
         accountId: "default",
         chatId: 7,
         msg: {
@@ -51,7 +91,7 @@ describe("telegram message cache", () => {
           ],
         } as Message,
       });
-      firstCache.record({
+      await firstCache.record({
         accountId: "default",
         chatId: 7,
         msg: {
@@ -74,7 +114,7 @@ describe("telegram message cache", () => {
 
       resetTelegramMessageCacheBucketsForTest();
       const secondCache = createTelegramMessageCache({ persistedPath });
-      const chain = buildTelegramReplyChain({
+      const chain = await buildTelegramReplyChain({
         cache: secondCache,
         accountId: "default",
         chatId: 7,
@@ -149,7 +189,7 @@ describe("telegram message cache", () => {
     await rm(persistedPath, { force: true });
     try {
       const firstCache = createTelegramMessageCache({ persistedPath });
-      firstCache.record({
+      await firstCache.record({
         accountId: "default",
         chatId: 7,
         msg: {
@@ -192,13 +232,13 @@ describe("telegram message cache", () => {
           from: { id: 2, is_bot: false, first_name: "UserB" },
         } as Message["reply_to_message"],
       } as Message;
-      const chain = buildTelegramReplyChain({
+      const chain = await buildTelegramReplyChain({
         cache: secondCache,
         accountId: "default",
         chatId: 7,
         msg: current,
       });
-      const context = buildTelegramConversationContext({
+      const context = await buildTelegramConversationContext({
         cache: secondCache,
         accountId: "default",
         chatId: 7,
@@ -221,10 +261,10 @@ describe("telegram message cache", () => {
     }
   });
 
-  it("replaces authoritative edited message fields without stale caption carryover", () => {
+  it("replaces authoritative edited message fields without stale caption carryover", async () => {
     const cache = createTelegramMessageCache();
     const chat = { id: 7, type: "group", title: "Ops" } as const;
-    cache.record({
+    await cache.record({
       accountId: "default",
       chatId: 7,
       msg: {
@@ -244,7 +284,7 @@ describe("telegram message cache", () => {
       } as Message,
     });
 
-    const updated = cache.record({
+    const updated = await cache.record({
       accountId: "default",
       chatId: 7,
       msg: {
@@ -279,7 +319,7 @@ describe("telegram message cache", () => {
     try {
       const firstCache = createTelegramMessageCache({ persistedPath });
       const secondCache = createTelegramMessageCache({ persistedPath });
-      firstCache.record({
+      await firstCache.record({
         accountId: "default",
         chatId: 7,
         msg: {
@@ -290,7 +330,7 @@ describe("telegram message cache", () => {
           from: { id: 1, is_bot: false, first_name: "Nora" },
         } as Message,
       });
-      secondCache.record({
+      await secondCache.record({
         accountId: "default",
         chatId: 7,
         msg: {
@@ -310,7 +350,7 @@ describe("telegram message cache", () => {
       });
 
       const reloadedCache = createTelegramMessageCache({ persistedPath });
-      const chain = buildTelegramReplyChain({
+      const chain = await buildTelegramReplyChain({
         cache: reloadedCache,
         accountId: "default",
         chatId: 7,
@@ -335,6 +375,219 @@ describe("telegram message cache", () => {
     }
   });
 
+  it("persists cached records through the plugin state store", async () => {
+    const { bucketKey, store } = createMemoryPersistentStore(3);
+    const cache = createTelegramMessageCache({ bucketKey, persistentStore: store });
+    for (let index = 0; index < 5; index++) {
+      await cache.record({
+        accountId: "default",
+        chatId: 7,
+        msg: {
+          chat: { id: 7, type: "private", first_name: "Nora" },
+          message_id: 9120 + index,
+          date: 1736380700 + index,
+          text: `State message ${index}`,
+          from: { id: 1, is_bot: false, first_name: "Nora" },
+        } as Message,
+      });
+    }
+
+    resetTelegramMessageCacheBucketsForTest();
+    const reloadedCache = createTelegramMessageCache({ bucketKey, persistentStore: store });
+    const recent = await reloadedCache.recentBefore({
+      accountId: "default",
+      chatId: 7,
+      messageId: "9125",
+      limit: 10,
+    });
+
+    expect(recent.map((entry) => entry.messageId)).toEqual(["9122", "9123", "9124"]);
+  });
+
+  it("reads legacy sidecar records as a persistent-store fallback", async () => {
+    const storePath = `/tmp/openclaw-telegram-message-cache-state-migrate-${process.pid}-${Date.now()}.json`;
+    const persistedPath = resolveTelegramMessageCachePath(storePath);
+    const { bucketKey, entries, store } = createMemoryPersistentStore();
+    await rm(persistedPath, { force: true });
+    try {
+      const legacyEntries = [
+        persistedCacheEntry(9130, "legacy one"),
+        persistedCacheEntry(9131, "legacy two"),
+        persistedCacheEntry(9132, "legacy three"),
+      ];
+      await writeFile(persistedPath, JSON.stringify(legacyEntries));
+
+      const cache = createTelegramMessageCache({
+        bucketKey,
+        legacyPersistedPath: persistedPath,
+        persistentStore: store,
+      });
+      const nearby = await cache.around({
+        accountId: "default",
+        chatId: 7,
+        messageId: "9131",
+        before: 1,
+        after: 1,
+      });
+
+      expect(nearby.map((entry) => entry.messageId)).toEqual(["9130", "9131", "9132"]);
+      expect(unscopedPersistentKeys(entries)).toEqual([]);
+
+      resetTelegramMessageCacheBucketsForTest();
+      const reloadedCache = createTelegramMessageCache({
+        bucketKey,
+        legacyPersistedPath: persistedPath,
+        persistentStore: store,
+      });
+      expect(
+        (
+          await reloadedCache.get({
+            accountId: "default",
+            chatId: 7,
+            messageId: "9132",
+          })
+        )?.body,
+      ).toBe("legacy three");
+      expect((await readFile(persistedPath, "utf-8")).startsWith("[")).toBe(true);
+    } finally {
+      await rm(persistedPath, { force: true });
+    }
+  });
+
+  it("keeps plugin state authoritative over legacy sidecar fallback", async () => {
+    const storePath = `/tmp/openclaw-telegram-message-cache-state-authoritative-${process.pid}-${Date.now()}.json`;
+    const persistedPath = resolveTelegramMessageCachePath(storePath);
+    const { bucketKey, entries, store } = createMemoryPersistentStore();
+    await rm(persistedPath, { force: true });
+    try {
+      const initialCache = createTelegramMessageCache({
+        bucketKey,
+        legacyPersistedPath: persistedPath,
+        persistentStore: store,
+      });
+      await initialCache.record({
+        accountId: "default",
+        chatId: 7,
+        msg: {
+          chat: { id: 7, type: "group", title: "Ops" },
+          message_id: 9141,
+          date: 1736389141,
+          text: "new sqlite value",
+          from: { id: 9141, is_bot: false, first_name: "State" },
+        } as Message,
+      });
+      await initialCache.record({
+        accountId: "default",
+        chatId: 7,
+        msg: {
+          chat: { id: 7, type: "group", title: "Ops" },
+          message_id: 9142,
+          date: 1736389142,
+          text: "bot reply kept only in sqlite",
+          from: { id: 0, is_bot: true, first_name: "OpenClaw" },
+        } as Message,
+      });
+      resetTelegramMessageCacheBucketsForTest();
+      await writeFile(
+        persistedPath,
+        JSON.stringify([
+          persistedCacheEntry(9140, "old sidecar only"),
+          persistedCacheEntry(9141, "stale sidecar value"),
+        ]),
+      );
+
+      const cache = createTelegramMessageCache({
+        bucketKey,
+        legacyPersistedPath: persistedPath,
+        persistentStore: store,
+      });
+
+      expect(
+        (
+          await cache.get({
+            accountId: "default",
+            chatId: 7,
+            messageId: "9140",
+          })
+        )?.body,
+      ).toBe("old sidecar only");
+      expect(
+        (
+          await cache.get({
+            accountId: "default",
+            chatId: 7,
+            messageId: "9141",
+          })
+        )?.body,
+      ).toBe("new sqlite value");
+      expect(
+        (
+          await cache.get({
+            accountId: "default",
+            chatId: 7,
+            messageId: "9142",
+          })
+        )?.body,
+      ).toBe("bot reply kept only in sqlite");
+      expect(unscopedPersistentKeys(entries)).toEqual(["default:7:9141", "default:7:9142"]);
+    } finally {
+      await rm(persistedPath, { force: true });
+    }
+  });
+
+  it("loads a legacy sidecar fallback when another plugin-state scope already has entries", async () => {
+    const firstStorePath = `/tmp/openclaw-telegram-message-cache-state-scope-a-${process.pid}-${Date.now()}.json`;
+    const secondStorePath = `/tmp/openclaw-telegram-message-cache-state-scope-b-${process.pid}-${Date.now()}.json`;
+    const firstPersistedPath = resolveTelegramMessageCachePath(firstStorePath);
+    const secondPersistedPath = resolveTelegramMessageCachePath(secondStorePath);
+    const { bucketKey, entries, store } = createMemoryPersistentStore();
+    await rm(firstPersistedPath, { force: true });
+    await rm(secondPersistedPath, { force: true });
+    try {
+      const firstCache = createTelegramMessageCache({
+        bucketKey: `${bucketKey}:first`,
+        legacyPersistedPath: firstPersistedPath,
+        persistentStore: store,
+      });
+      await firstCache.record({
+        accountId: "default",
+        chatId: 7,
+        msg: {
+          chat: { id: 7, type: "group", title: "Ops" },
+          message_id: 9150,
+          date: 1736389150,
+          text: "first store scope",
+          from: { id: 9150, is_bot: false, first_name: "First" },
+        } as Message,
+      });
+      resetTelegramMessageCacheBucketsForTest();
+      await writeFile(
+        secondPersistedPath,
+        JSON.stringify([persistedCacheEntry(9151, "second legacy scope")]),
+      );
+
+      const secondCache = createTelegramMessageCache({
+        bucketKey: `${bucketKey}:second`,
+        legacyPersistedPath: secondPersistedPath,
+        persistentStore: store,
+      });
+
+      expect(
+        (
+          await secondCache.get({
+            accountId: "default",
+            chatId: 7,
+            messageId: "9151",
+          })
+        )?.body,
+      ).toBe("second legacy scope");
+      expect(unscopedPersistentKeys(entries)).toEqual(["default:7:9150"]);
+    } finally {
+      await rm(firstPersistedPath, { force: true });
+      await rm(secondPersistedPath, { force: true });
+    }
+  });
+
   it("appends cached records between compactions and reloads the bounded cache window", async () => {
     const storePath = `/tmp/openclaw-telegram-message-cache-append-${process.pid}-${Date.now()}.json`;
     const persistedPath = resolveTelegramMessageCachePath(storePath);
@@ -342,7 +595,7 @@ describe("telegram message cache", () => {
     try {
       const cache = createTelegramMessageCache({ persistedPath, maxMessages: 4 });
       for (let index = 0; index < 5; index++) {
-        cache.record({
+        await cache.record({
           accountId: "default",
           chatId: 7,
           msg: {
@@ -360,9 +613,12 @@ describe("telegram message cache", () => {
 
       resetTelegramMessageCacheBucketsForTest();
       const reloadedCache = createTelegramMessageCache({ persistedPath, maxMessages: 4 });
-      expect(reloadedCache.get({ accountId: "default", chatId: 7, messageId: "9150" })).toBeNull();
       expect(
-        reloadedCache.get({ accountId: "default", chatId: 7, messageId: "9151" })?.messageId,
+        await reloadedCache.get({ accountId: "default", chatId: 7, messageId: "9150" }),
+      ).toBeNull();
+      expect(
+        (await reloadedCache.get({ accountId: "default", chatId: 7, messageId: "9151" }))
+          ?.messageId,
       ).toBe("9151");
     } finally {
       await rm(persistedPath, { force: true });
@@ -376,7 +632,7 @@ describe("telegram message cache", () => {
     try {
       const cache = createTelegramMessageCache({ persistedPath, maxMessages: 3 });
       for (let index = 0; index < 7; index++) {
-        cache.record({
+        await cache.record({
           accountId: "default",
           chatId: 7,
           msg: {
@@ -425,17 +681,20 @@ describe("telegram message cache", () => {
 
       const cache = createTelegramMessageCache({ persistedPath });
 
-      expect(
-        cache
-          .around({
-            accountId: "default",
-            chatId: 7,
-            messageId: "35035",
-            before: 2,
-            after: 2,
-          })
-          .map((entry) => entry.messageId),
-      ).toEqual(["35033", "35034", "35035", "35036", "35037"]);
+      const nearby = await cache.around({
+        accountId: "default",
+        chatId: 7,
+        messageId: "35035",
+        before: 2,
+        after: 2,
+      });
+      expect(nearby.map((entry) => entry.messageId)).toEqual([
+        "35033",
+        "35034",
+        "35035",
+        "35036",
+        "35037",
+      ]);
 
       const canonical = await readFile(persistedPath, "utf-8");
       expect(canonical.startsWith("[")).toBe(false);
@@ -452,10 +711,10 @@ describe("telegram message cache", () => {
     }
   });
 
-  it("returns recent chat messages before the current message", () => {
+  it("returns recent chat messages before the current message", async () => {
     const cache = createTelegramMessageCache();
     for (const id of [41, 42, 43, 44]) {
-      cache.record({
+      await cache.record({
         accountId: "default",
         chatId: 7,
         threadId: 100,
@@ -469,7 +728,7 @@ describe("telegram message cache", () => {
         } as Message,
       });
     }
-    cache.record({
+    await cache.record({
       accountId: "default",
       chatId: 7,
       threadId: 200,
@@ -483,23 +742,20 @@ describe("telegram message cache", () => {
       } as Message,
     });
 
-    expect(
-      cache
-        .recentBefore({
-          accountId: "default",
-          chatId: 7,
-          threadId: 100,
-          messageId: "44",
-          limit: 2,
-        })
-        .map((entry) => entry.messageId),
-    ).toEqual(["42", "43"]);
+    const recent = await cache.recentBefore({
+      accountId: "default",
+      chatId: 7,
+      threadId: 100,
+      messageId: "44",
+      limit: 2,
+    });
+    expect(recent.map((entry) => entry.messageId)).toEqual(["42", "43"]);
   });
 
-  it("returns nearby messages around a stale reply target", () => {
+  it("returns nearby messages around a stale reply target", async () => {
     const cache = createTelegramMessageCache();
     for (const id of [100, 101, 102, 200, 201]) {
-      cache.record({
+      await cache.record({
         accountId: "default",
         chatId: 7,
         msg: {
@@ -512,23 +768,20 @@ describe("telegram message cache", () => {
       });
     }
 
-    expect(
-      cache
-        .around({
-          accountId: "default",
-          chatId: 7,
-          messageId: "101",
-          before: 1,
-          after: 1,
-        })
-        .map((entry) => entry.messageId),
-    ).toEqual(["100", "101", "102"]);
+    const nearby = await cache.around({
+      accountId: "default",
+      chatId: 7,
+      messageId: "101",
+      before: 1,
+      after: 1,
+    });
+    expect(nearby.map((entry) => entry.messageId)).toEqual(["100", "101", "102"]);
   });
 
-  it("selects reply targets referenced by the current local window", () => {
+  it("selects reply targets referenced by the current local window", async () => {
     const cache = createTelegramMessageCache();
     for (const id of [33867, 33868, 33869]) {
-      cache.record({
+      await cache.record({
         accountId: "default",
         chatId: 7,
         msg: {
@@ -541,7 +794,7 @@ describe("telegram message cache", () => {
       });
     }
     for (let id = 34460; id <= 34475; id++) {
-      cache.record({
+      await cache.record({
         accountId: "default",
         chatId: 7,
         msg: {
@@ -553,7 +806,7 @@ describe("telegram message cache", () => {
         } as Message,
       });
     }
-    cache.record({
+    await cache.record({
       accountId: "default",
       chatId: 7,
       msg: {
@@ -571,7 +824,7 @@ describe("telegram message cache", () => {
         } as Message["reply_to_message"],
       } as Message,
     });
-    cache.record({
+    await cache.record({
       accountId: "default",
       chatId: 7,
       msg: {
@@ -583,7 +836,7 @@ describe("telegram message cache", () => {
       } as Message,
     });
 
-    const context = buildTelegramConversationContext({
+    const context = await buildTelegramConversationContext({
       cache,
       accountId: "default",
       chatId: 7,
@@ -612,7 +865,7 @@ describe("telegram message cache", () => {
     expect(context.find((entry) => entry.node.messageId === "34477")).toBeUndefined();
   });
 
-  it("does not select messages before the latest session reset command", () => {
+  it("does not select messages before the latest session reset command", async () => {
     const cache = createTelegramMessageCache();
     const beforeSession = Date.parse("2026-05-10T12:40:00.000Z");
     const sessionStartedAt = Date.parse("2026-05-10T17:30:43.980Z");
@@ -650,19 +903,23 @@ describe("telegram message cache", () => {
         } as Message,
       });
 
-    record({ id: 84669, text: "earlier topic setup", timestampMs: beforeSession - 1000 });
-    record({ id: 84670, text: staleInstruction, timestampMs: beforeSession });
-    record({ id: 84671, text: "old reply context", timestampMs: beforeSession + 1000 });
-    record({ id: 85000, text: "/new", timestampMs: sessionStartedAt });
-    record({
+    await record({ id: 84669, text: "earlier topic setup", timestampMs: beforeSession - 1000 });
+    await record({ id: 84670, text: staleInstruction, timestampMs: beforeSession });
+    await record({ id: 84671, text: "old reply context", timestampMs: beforeSession + 1000 });
+    await record({ id: 85000, text: "/new", timestampMs: sessionStartedAt });
+    await record({
       id: 87183,
       text: "post-reset context",
       timestampMs: afterSession - 60_000,
       replyTo: { id: 84670, text: staleInstruction, timestampMs: beforeSession },
     });
-    record({ id: 87184, text: "how does this determine stability?", timestampMs: afterSession });
+    await record({
+      id: 87184,
+      text: "how does this determine stability?",
+      timestampMs: afterSession,
+    });
 
-    const replyChainNodes = buildTelegramReplyChain({
+    const replyChainNodes = await buildTelegramReplyChain({
       cache,
       accountId: "default",
       chatId: 7,
@@ -684,7 +941,7 @@ describe("telegram message cache", () => {
       } as Message,
     });
 
-    const context = buildTelegramConversationContext({
+    const context = await buildTelegramConversationContext({
       cache,
       accountId: "default",
       chatId: 7,
@@ -699,7 +956,7 @@ describe("telegram message cache", () => {
     expect(context.map((entry) => entry.node.body)).not.toContain(staleInstruction);
   });
 
-  it("does not select messages before the persisted session start when the reset command is absent", () => {
+  it("does not select messages before the persisted session start when the reset command is absent", async () => {
     const cache = createTelegramMessageCache();
     const beforeSession = Date.parse("2026-05-10T12:40:00.000Z");
     const sessionStartedAt = Date.parse("2026-05-10T17:30:43.127Z");
@@ -747,30 +1004,35 @@ describe("telegram message cache", () => {
         } as Message,
       });
 
-    record({
+    await record({
       id: 84649,
       text: "tools.toolSearch: true",
       timestampMs: beforeSession - 5 * 60_000,
     });
-    record({ id: 84670, text: staleInstruction, timestampMs: beforeSession });
-    record({ id: 87184, text: "how does this determine stability?", timestampMs: afterSession });
-    const current = record({
+    await record({ id: 84670, text: staleInstruction, timestampMs: beforeSession });
+    await record({
+      id: 87184,
+      text: "how does this determine stability?",
+      timestampMs: afterSession,
+    });
+    const currentNode = await record({
       id: 87227,
       text: "what config change?",
       timestampMs: afterSession + 2 * 60 * 60_000,
       replyTo: { id: 84670, text: staleInstruction, timestampMs: beforeSession },
-    })?.sourceMessage;
+    });
+    const current = currentNode?.sourceMessage;
     if (!current) {
       throw new Error("expected current Telegram message");
     }
 
-    const replyChainNodes = buildTelegramReplyChain({
+    const replyChainNodes = await buildTelegramReplyChain({
       cache,
       accountId: "default",
       chatId: -1001234567890,
       msg: current,
     });
-    const context = buildTelegramConversationContext({
+    const context = await buildTelegramConversationContext({
       cache,
       accountId: "default",
       chatId: -1001234567890,

--- a/extensions/telegram/src/message-cache.ts
+++ b/extensions/telegram/src/message-cache.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import type { Message } from "grammy/types";
 import { formatLocationText } from "openclaw/plugin-sdk/channel-inbound";
@@ -11,6 +12,7 @@ import {
   getTelegramTextParts,
   normalizeForwardedContext,
 } from "./bot/helpers.js";
+import { getOptionalTelegramRuntime } from "./runtime.js";
 
 export type TelegramReplyChainEntry = NonNullable<MsgContext["ReplyChain"]>[number];
 
@@ -29,19 +31,19 @@ export type TelegramMessageCache = {
     chatId: string | number;
     msg: Message;
     threadId?: number;
-  }) => TelegramCachedMessageNode | null;
+  }) => Promise<TelegramCachedMessageNode | null>;
   get: (params: {
     accountId: string;
     chatId: string | number;
     messageId?: string;
-  }) => TelegramCachedMessageNode | null;
+  }) => Promise<TelegramCachedMessageNode | null>;
   recentBefore: (params: {
     accountId: string;
     chatId: string | number;
     messageId?: string;
     threadId?: number;
     limit: number;
-  }) => TelegramCachedMessageNode[];
+  }) => Promise<TelegramCachedMessageNode[]>;
   around: (params: {
     accountId: string;
     chatId: string | number;
@@ -49,7 +51,7 @@ export type TelegramMessageCache = {
     threadId?: number;
     before: number;
     after: number;
-  }) => TelegramCachedMessageNode[];
+  }) => Promise<TelegramCachedMessageNode[]>;
 };
 
 type MessageWithExternalReply = Message & { external_reply?: Message };
@@ -57,9 +59,15 @@ type MessageWithExternalReply = Message & { external_reply?: Message };
 type TelegramMessageCacheBucket = {
   messages: Map<string, TelegramCachedMessageNode>;
   persistedEntryCount: number;
+  hydrated: boolean;
+  hydratePromise?: Promise<void>;
+  legacyPersistedPath?: string;
+  persistentStore?: TelegramMessageCachePersistentStore;
 };
 
-type PersistedMessageReadResult = TelegramMessageCacheBucket & {
+type PersistedMessageReadResult = {
+  messages: Map<string, TelegramCachedMessageNode>;
+  persistedEntryCount: number;
   needsRewrite: boolean;
 };
 
@@ -73,23 +81,43 @@ type TelegramCachedMessageObservation = {
 type TelegramEmbeddedReplyMessage = NonNullable<Message["reply_to_message"]>;
 
 const DEFAULT_MAX_MESSAGES = 5000;
+export const TELEGRAM_MESSAGE_CACHE_PERSISTENT_MAX_MESSAGES = 1000;
+export const TELEGRAM_MESSAGE_CACHE_PERSISTENT_NAMESPACE = "telegram.message-cache";
+const PERSISTENT_BUCKET_KEY = `plugin-state:${TELEGRAM_MESSAGE_CACHE_PERSISTENT_NAMESPACE}`;
 const COMPACT_THRESHOLD_RATIO = 2;
 const persistedMessageCacheBuckets = new Map<string, TelegramMessageCacheBucket>();
+
+export type PersistedTelegramMessageCacheValue = {
+  sourceMessage: Message;
+  threadId?: string;
+};
+
+export type TelegramMessageCachePersistentStore = {
+  register(key: string, value: PersistedTelegramMessageCacheValue): Promise<void>;
+  entries(): Promise<Array<{ key: string; value: PersistedTelegramMessageCacheValue }>>;
+};
 
 export function resetTelegramMessageCacheBucketsForTest(): void {
   persistedMessageCacheBuckets.clear();
 }
 
 function telegramMessageCacheKey(params: {
+  scopeKey: string | undefined;
   accountId: string;
   chatId: string | number;
   messageId: string;
 }) {
-  return `${params.accountId}:${params.chatId}:${params.messageId}`;
+  const key = `${params.accountId}:${params.chatId}:${params.messageId}`;
+  return params.scopeKey ? `${params.scopeKey}:${key}` : key;
 }
 
-function telegramMessageCacheKeyPrefix(params: { accountId: string; chatId: string | number }) {
-  return `${params.accountId}:${params.chatId}:`;
+function telegramMessageCacheKeyPrefix(params: {
+  scopeKey: string | undefined;
+  accountId: string;
+  chatId: string | number;
+}) {
+  const prefix = `${params.accountId}:${params.chatId}:`;
+  return params.scopeKey ? `${params.scopeKey}:${prefix}` : prefix;
 }
 
 export function resolveTelegramMessageCachePath(storePath: string): string {
@@ -252,6 +280,25 @@ function parsePersistedEntry(value: unknown): Array<{
     node,
     mode: node.messageId === sourceMessageId ? "authoritative" : mode,
   }));
+}
+
+function persistedValueToEntry(
+  key: string,
+  value: PersistedTelegramMessageCacheValue,
+): {
+  key: string;
+  node: {
+    sourceMessage: Message;
+    threadId?: string;
+  };
+} {
+  return {
+    key,
+    node: {
+      sourceMessage: value.sourceMessage,
+      ...(value.threadId ? { threadId: value.threadId } : {}),
+    },
+  };
 }
 
 function findJsonArrayEnd(text: string): number {
@@ -426,17 +473,23 @@ function readPersistedMessages(filePath: string, maxMessages: number): Persisted
   return { messages, persistedEntryCount, needsRewrite };
 }
 
+function toPersistedCacheValue(
+  node: TelegramCachedMessageNode,
+): PersistedTelegramMessageCacheValue {
+  return {
+    sourceMessage: node.sourceMessage,
+    ...(node.threadId ? { threadId: node.threadId } : {}),
+  };
+}
+
 function serializePersistedEntry(key: string, node: TelegramCachedMessageNode): string {
   return `${JSON.stringify({
     key,
-    node: {
-      sourceMessage: node.sourceMessage,
-      ...(node.threadId ? { threadId: node.threadId } : {}),
-    },
+    node: toPersistedCacheValue(node),
   })}\n`;
 }
 
-function replacePersistedMessages(params: {
+function replaceLegacyPersistedMessages(params: {
   messages: Map<string, TelegramCachedMessageNode>;
   persistedPath?: string;
 }): number {
@@ -459,7 +512,7 @@ function replacePersistedMessages(params: {
   return messages.size;
 }
 
-function appendPersistedMessage(params: {
+function appendLegacyPersistedMessage(params: {
   key: string;
   node: TelegramCachedMessageNode;
   persistedPath?: string;
@@ -475,57 +528,212 @@ function appendPersistedMessage(params: {
   return 1;
 }
 
-function resolveMessageCacheBucket(params: {
-  persistedPath?: string;
-  maxMessages: number;
-}): TelegramMessageCacheBucket {
-  const { persistedPath, maxMessages } = params;
-  if (!persistedPath) {
-    return { messages: new Map<string, TelegramCachedMessageNode>(), persistedEntryCount: 0 };
+function resolvePersistentScopeKey(scope: string): string {
+  return createHash("sha256").update(scope).digest("hex").slice(0, 24);
+}
+
+export function resolveTelegramMessageCachePersistentScopeKey(scope: string): string {
+  return resolvePersistentScopeKey(scope);
+}
+
+export function listTelegramLegacyMessageCacheEntries(params: {
+  persistedPath: string;
+  maxMessages?: number;
+}): Array<{ key: string; value: PersistedTelegramMessageCacheValue }> {
+  const persisted = readPersistedMessages(
+    params.persistedPath,
+    params.maxMessages ?? TELEGRAM_MESSAGE_CACHE_PERSISTENT_MAX_MESSAGES,
+  );
+  return Array.from(persisted.messages, ([key, node]) => ({
+    key,
+    value: toPersistedCacheValue(node),
+  }));
+}
+
+function resolveDefaultPersistentStore(): TelegramMessageCachePersistentStore | undefined {
+  const runtime = getOptionalTelegramRuntime();
+  if (!runtime) {
+    return undefined;
   }
-  const existing = persistedMessageCacheBuckets.get(persistedPath);
+  try {
+    return runtime.state.openKeyedStore<PersistedTelegramMessageCacheValue>({
+      namespace: TELEGRAM_MESSAGE_CACHE_PERSISTENT_NAMESPACE,
+      maxEntries: TELEGRAM_MESSAGE_CACHE_PERSISTENT_MAX_MESSAGES,
+    });
+  } catch (error) {
+    logVerbose(`telegram: failed to open message cache plugin state: ${String(error)}`);
+    return undefined;
+  }
+}
+
+function resolveMessageCacheBucket(params: {
+  bucketKey?: string;
+  legacyPersistedPath?: string;
+  maxMessages: number;
+  persistentStore?: TelegramMessageCachePersistentStore;
+}): TelegramMessageCacheBucket {
+  const { bucketKey } = params;
+  if (!bucketKey) {
+    return {
+      messages: new Map<string, TelegramCachedMessageNode>(),
+      persistedEntryCount: 0,
+      hydrated: true,
+    };
+  }
+  const existing = persistedMessageCacheBuckets.get(bucketKey);
   if (existing) {
-    if (!fs.existsSync(persistedPath)) {
-      existing.messages.clear();
-      existing.persistedEntryCount = 0;
-    }
+    existing.persistentStore = params.persistentStore ?? existing.persistentStore;
+    existing.legacyPersistedPath = params.legacyPersistedPath ?? existing.legacyPersistedPath;
     return existing;
   }
-  const persisted = readPersistedMessages(persistedPath, maxMessages);
   const bucket = {
-    messages: persisted.messages,
-    persistedEntryCount: persisted.persistedEntryCount,
+    messages: new Map<string, TelegramCachedMessageNode>(),
+    persistedEntryCount: 0,
+    hydrated: false,
+    ...(params.legacyPersistedPath ? { legacyPersistedPath: params.legacyPersistedPath } : {}),
+    ...(params.persistentStore ? { persistentStore: params.persistentStore } : {}),
   };
-  if (persisted.needsRewrite) {
-    try {
-      bucket.persistedEntryCount = replacePersistedMessages({
-        messages: bucket.messages,
-        persistedPath,
-      });
-    } catch (error) {
-      logVerbose(`telegram: failed to compact message cache: ${String(error)}`);
-    }
-  }
-  persistedMessageCacheBuckets.set(persistedPath, bucket);
+  persistedMessageCacheBuckets.set(bucketKey, bucket);
   return bucket;
+}
+
+async function hydrateMessageCacheBucket(
+  bucket: TelegramMessageCacheBucket,
+  maxMessages: number,
+  scopeKey?: string,
+): Promise<void> {
+  if (bucket.hydrated) {
+    return;
+  }
+  if (bucket.hydratePromise) {
+    await bucket.hydratePromise;
+    return;
+  }
+  bucket.hydratePromise = (async () => {
+    let storeEntries: Array<{ key: string; value: PersistedTelegramMessageCacheValue }> = [];
+    try {
+      storeEntries = (await bucket.persistentStore?.entries()) ?? [];
+    } catch (error) {
+      logVerbose(`telegram: failed to hydrate message cache from plugin state: ${String(error)}`);
+    }
+    const scopedStoreEntries = scopeKey
+      ? storeEntries.filter(({ key }) => key.startsWith(`${scopeKey}:`))
+      : storeEntries;
+
+    const legacyPath = bucket.legacyPersistedPath;
+    if (legacyPath) {
+      const legacy = readPersistedMessages(legacyPath, maxMessages);
+      if (legacy.messages.size > 0) {
+        for (const [key, node] of legacy.messages) {
+          const cacheKey = bucket.persistentStore && scopeKey ? `${scopeKey}:${key}` : key;
+          upsertCachedMessageNode({
+            messages: bucket.messages,
+            key: cacheKey,
+            node,
+            mode: "authoritative",
+          });
+          trimMessages(bucket.messages, maxMessages);
+        }
+      }
+      if (!bucket.persistentStore && legacy.needsRewrite) {
+        try {
+          bucket.persistedEntryCount = replaceLegacyPersistedMessages({
+            messages: bucket.messages,
+            persistedPath: legacyPath,
+          });
+        } catch (error) {
+          logVerbose(`telegram: failed to compact message cache: ${String(error)}`);
+        }
+      }
+    }
+    for (const { key, value } of scopedStoreEntries) {
+      for (const entry of parsePersistedEntry(persistedValueToEntry(key, value))) {
+        bucket.persistedEntryCount++;
+        upsertCachedMessageNode({
+          messages: bucket.messages,
+          key: entry.key,
+          node: entry.node,
+          mode: entry.mode,
+        });
+        trimMessages(bucket.messages, maxMessages);
+      }
+    }
+    bucket.hydrated = true;
+  })().finally(() => {
+    bucket.hydratePromise = undefined;
+  });
+  await bucket.hydratePromise;
+}
+
+async function persistCachedNode(params: {
+  bucket: TelegramMessageCacheBucket;
+  key: string;
+  maxMessages: number;
+  node: TelegramCachedMessageNode;
+}): Promise<void> {
+  const { persistentStore } = params.bucket;
+  if (!persistentStore) {
+    try {
+      params.bucket.persistedEntryCount += appendLegacyPersistedMessage({
+        key: params.key,
+        node: params.node,
+        persistedPath: params.bucket.legacyPersistedPath,
+      });
+      if (params.bucket.persistedEntryCount > params.maxMessages * COMPACT_THRESHOLD_RATIO) {
+        params.bucket.persistedEntryCount = replaceLegacyPersistedMessages({
+          messages: params.bucket.messages,
+          persistedPath: params.bucket.legacyPersistedPath,
+        });
+      }
+    } catch (error) {
+      logVerbose(`telegram: failed to persist message cache: ${String(error)}`);
+    }
+    return;
+  }
+  try {
+    await persistentStore.register(params.key, toPersistedCacheValue(params.node));
+    params.bucket.persistedEntryCount++;
+  } catch (error) {
+    logVerbose(`telegram: failed to persist message cache: ${String(error)}`);
+  }
 }
 
 export function createTelegramMessageCache(params?: {
   maxMessages?: number;
+  legacyPersistedPath?: string;
   persistedPath?: string;
+  persistentStore?: TelegramMessageCachePersistentStore;
+  bucketKey?: string;
 }): TelegramMessageCache {
-  const maxMessages = params?.maxMessages ?? DEFAULT_MAX_MESSAGES;
+  const persistentStore = params?.persistentStore ?? resolveDefaultPersistentStore();
+  const maxMessages =
+    params?.maxMessages ??
+    (persistentStore ? TELEGRAM_MESSAGE_CACHE_PERSISTENT_MAX_MESSAGES : DEFAULT_MAX_MESSAGES);
+  const legacyPersistedPath = params?.legacyPersistedPath ?? params?.persistedPath;
+  const scopeKey = persistentStore
+    ? resolvePersistentScopeKey(legacyPersistedPath ?? params?.bucketKey ?? "default")
+    : undefined;
+  const bucketKey =
+    params?.bucketKey ??
+    (persistentStore
+      ? `${PERSISTENT_BUCKET_KEY}:${scopeKey}`
+      : legacyPersistedPath
+        ? `legacy:${legacyPersistedPath}`
+        : undefined);
   const bucket = resolveMessageCacheBucket({
-    persistedPath: params?.persistedPath,
+    bucketKey,
+    legacyPersistedPath,
     maxMessages,
+    ...(persistentStore ? { persistentStore } : {}),
   });
   const { messages } = bucket;
 
-  const get: TelegramMessageCache["get"] = ({ accountId, chatId, messageId }) => {
+  const get: TelegramMessageCache["get"] = async ({ accountId, chatId, messageId }) => {
+    await hydrateMessageCacheBucket(bucket, maxMessages, scopeKey);
     if (!messageId) {
       return null;
     }
-    const key = telegramMessageCacheKey({ accountId, chatId, messageId });
+    const key = telegramMessageCacheKey({ scopeKey, accountId, chatId, messageId });
     const entry = messages.get(key);
     if (!entry) {
       return null;
@@ -535,12 +743,13 @@ export function createTelegramMessageCache(params?: {
     return entry;
   };
 
-  const listChatMessages = (params: {
+  const listChatMessages = async (params: {
     accountId: string;
     chatId: string | number;
     threadId?: number;
   }) => {
-    const prefix = telegramMessageCacheKeyPrefix(params);
+    await hydrateMessageCacheBucket(bucket, maxMessages, scopeKey);
+    const prefix = telegramMessageCacheKeyPrefix({ scopeKey, ...params });
     const threadId = params.threadId != null ? String(params.threadId) : undefined;
     return Array.from(messages, ([key, node]) => ({ key, node }))
       .filter(({ key, node }) => {
@@ -554,7 +763,8 @@ export function createTelegramMessageCache(params?: {
   };
 
   return {
-    record: ({ accountId, chatId, msg, threadId }) => {
+    record: async ({ accountId, chatId, msg, threadId }) => {
+      await hydrateMessageCacheBucket(bucket, maxMessages, scopeKey);
       const observations = normalizeMessageNodes(msg, { threadId });
       const currentObservation = observations.at(-1);
       if (!currentObservation) {
@@ -566,32 +776,18 @@ export function createTelegramMessageCache(params?: {
         if (!messageId) {
           continue;
         }
-        const key = telegramMessageCacheKey({ accountId, chatId, messageId });
+        const key = telegramMessageCacheKey({ scopeKey, accountId, chatId, messageId });
         const cachedNode = upsertCachedMessageNode({ messages, key, node, mode });
         if (messageId === currentObservation.node.messageId) {
           recordedEntry = cachedNode;
         }
         trimMessages(messages, maxMessages);
-        try {
-          bucket.persistedEntryCount += appendPersistedMessage({
-            key,
-            node: cachedNode,
-            persistedPath: params?.persistedPath,
-          });
-          if (bucket.persistedEntryCount > maxMessages * COMPACT_THRESHOLD_RATIO) {
-            bucket.persistedEntryCount = replacePersistedMessages({
-              messages,
-              persistedPath: params?.persistedPath,
-            });
-          }
-        } catch (error) {
-          logVerbose(`telegram: failed to persist message cache: ${String(error)}`);
-        }
+        await persistCachedNode({ bucket, key, maxMessages, node: cachedNode });
       }
       return recordedEntry ?? currentObservation.node;
     },
     get,
-    recentBefore: ({ accountId, chatId, messageId, threadId, limit }) => {
+    recentBefore: async ({ accountId, chatId, messageId, threadId, limit }) => {
       if (!messageId || limit <= 0) {
         return [];
       }
@@ -599,18 +795,18 @@ export function createTelegramMessageCache(params?: {
       if (!Number.isFinite(targetId)) {
         return [];
       }
-      return listChatMessages({ accountId, chatId, threadId })
+      return (await listChatMessages({ accountId, chatId, threadId }))
         .filter((entry) => {
           const entryId = Number(entry.messageId);
           return Number.isFinite(entryId) && entryId < targetId;
         })
         .slice(-limit);
     },
-    around: ({ accountId, chatId, messageId, threadId, before, after }) => {
+    around: async ({ accountId, chatId, messageId, threadId, before, after }) => {
       if (!messageId) {
         return [];
       }
-      const entries = listChatMessages({ accountId, chatId, threadId });
+      const entries = await listChatMessages({ accountId, chatId, threadId });
       const targetIndex = entries.findIndex((entry) => entry.messageId === messageId);
       if (targetIndex === -1) {
         return [];
@@ -687,27 +883,27 @@ function isAtOrAfterSessionBoundaryTimestamp(
     : node.timestamp >= boundaryTimestampMs;
 }
 
-function resolveSessionBoundaryNode(params: {
+async function resolveSessionBoundaryNode(params: {
   cache: TelegramMessageCache;
   accountId: string;
   chatId: string | number;
   messageId?: string;
   threadId?: number;
-}): TelegramCachedMessageNode | undefined {
+}): Promise<TelegramCachedMessageNode | undefined> {
   if (!params.messageId) {
     return undefined;
   }
   const { messageId } = params;
-  const candidates = params.cache
-    .recentBefore({
+  const candidates = (
+    await params.cache.recentBefore({
       accountId: params.accountId,
       chatId: params.chatId,
       messageId,
       ...(params.threadId !== undefined ? { threadId: params.threadId } : {}),
       limit: Number.MAX_SAFE_INTEGER,
     })
-    .filter(isSessionBoundaryCommandNode);
-  const current = params.cache.get({
+  ).filter(isSessionBoundaryCommandNode);
+  const current = await params.cache.get({
     accountId: params.accountId,
     chatId: params.chatId,
     messageId,
@@ -718,13 +914,13 @@ function resolveSessionBoundaryNode(params: {
   return candidates.toSorted(compareCachedMessageNodes).at(-1);
 }
 
-export function buildTelegramReplyChain(params: {
+export async function buildTelegramReplyChain(params: {
   cache: TelegramMessageCache;
   accountId: string;
   chatId: string | number;
   msg: Message;
   maxDepth?: number;
-}): TelegramCachedMessageNode[] {
+}): Promise<TelegramCachedMessageNode[]> {
   const replyMessage = resolveReplyMessage(params.msg);
   if (!replyMessage?.message_id) {
     return [];
@@ -733,16 +929,16 @@ export function buildTelegramReplyChain(params: {
   const visited = new Set<string>();
   const chain: TelegramCachedMessageNode[] = [];
   let current =
-    params.cache.get({
+    (await params.cache.get({
       accountId: params.accountId,
       chatId: params.chatId,
       messageId: String(replyMessage.message_id),
-    }) ?? normalizeMessageNode(replyMessage, {});
+    })) ?? normalizeMessageNode(replyMessage, {});
 
   while (current?.messageId && chain.length < maxDepth && !visited.has(current.messageId)) {
     visited.add(current.messageId);
     chain.push(current);
-    current = params.cache.get({
+    current = await params.cache.get({
       accountId: params.accountId,
       chatId: params.chatId,
       messageId: current.replyToId,
@@ -752,7 +948,7 @@ export function buildTelegramReplyChain(params: {
   return chain;
 }
 
-export function buildTelegramConversationContext(params: {
+export async function buildTelegramConversationContext(params: {
   cache: TelegramMessageCache;
   accountId: string;
   chatId: string | number;
@@ -762,10 +958,10 @@ export function buildTelegramConversationContext(params: {
   recentLimit: number;
   replyTargetWindowSize: number;
   minTimestampMs?: number;
-}): TelegramConversationContextNode[] {
+}): Promise<TelegramConversationContextNode[]> {
   const selected = new Map<string, TelegramConversationContextNode>();
   const replyTargetIds = new Set<string>();
-  const sessionBoundary = resolveSessionBoundaryNode(params);
+  const sessionBoundary = await resolveSessionBoundaryNode(params);
   const sessionBoundaryTimestamp = normalizeSessionBoundaryTimestamp(params.minTimestampMs);
   const addNode = (node: TelegramCachedMessageNode, flags?: { replyTarget?: boolean }) => {
     if (!node.messageId || node.messageId === params.messageId) {
@@ -784,9 +980,9 @@ export function buildTelegramConversationContext(params: {
       isReplyTarget: isReplyTarget ? true : undefined,
     });
   };
-  const addReplyTargetWindow = (messageId: string) => {
+  const addReplyTargetWindow = async (messageId: string) => {
     replyTargetIds.add(messageId);
-    for (const node of params.cache.around({
+    for (const node of await params.cache.around({
       accountId: params.accountId,
       chatId: params.chatId,
       messageId,
@@ -798,7 +994,7 @@ export function buildTelegramConversationContext(params: {
     }
   };
 
-  const currentWindow = params.cache.recentBefore({
+  const currentWindow = await params.cache.recentBefore({
     accountId: params.accountId,
     chatId: params.chatId,
     messageId: params.messageId,
@@ -808,22 +1004,22 @@ export function buildTelegramConversationContext(params: {
   for (const node of currentWindow) {
     addNode(node);
     if (node.replyToId) {
-      addReplyTargetWindow(node.replyToId);
+      await addReplyTargetWindow(node.replyToId);
     }
   }
 
-  params.replyChainNodes.forEach((node, index) => {
+  for (const [index, node] of params.replyChainNodes.entries()) {
     addNode(node, { replyTarget: index === 0 });
     if (index === 0 && node.messageId) {
-      addReplyTargetWindow(node.messageId);
+      await addReplyTargetWindow(node.messageId);
     }
     if (node.replyToId) {
       replyTargetIds.add(node.replyToId);
     }
-  });
+  }
 
   for (const messageId of replyTargetIds) {
-    const node = params.cache.get({
+    const node = await params.cache.get({
       accountId: params.accountId,
       chatId: params.chatId,
       messageId,

--- a/extensions/telegram/src/outbound-message-context.ts
+++ b/extensions/telegram/src/outbound-message-context.ts
@@ -1,0 +1,83 @@
+import type { Message } from "grammy/types";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
+import { resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
+import { createTelegramMessageCache, resolveTelegramMessageCachePath } from "./message-cache.js";
+
+export type TelegramOutboundPromptContextMessage = {
+  message_id?: number;
+  chat?: { id?: string | number; type?: string; title?: string; username?: string };
+  date?: number;
+  from?: { id?: number; is_bot?: boolean; first_name?: string; username?: string };
+  text?: string;
+  caption?: string;
+  message_thread_id?: number;
+};
+
+type TelegramOutboundPromptContextAccount = {
+  accountId: string;
+  name?: string;
+};
+
+function inferTelegramChatType(chatId: string | number): "private" | "supergroup" {
+  return String(chatId).startsWith("-") ? "supergroup" : "private";
+}
+
+function buildOutboundCacheMessage(params: {
+  account: TelegramOutboundPromptContextAccount;
+  chatId: string | number;
+  message: TelegramOutboundPromptContextMessage;
+  messageId: number;
+  text?: string;
+  messageThreadId?: number;
+}): TelegramOutboundPromptContextMessage {
+  const chat = params.message.chat ?? {};
+  const text = params.message.text ?? params.message.caption ?? params.text;
+  return {
+    ...params.message,
+    message_id: params.messageId,
+    date:
+      typeof params.message.date === "number" && Number.isFinite(params.message.date)
+        ? params.message.date
+        : Math.floor(Date.now() / 1000),
+    chat: {
+      id: chat.id ?? params.chatId,
+      type: chat.type ?? inferTelegramChatType(params.chatId),
+      ...(chat.title ? { title: chat.title } : {}),
+      ...(chat.username ? { username: chat.username } : {}),
+    },
+    from: params.message.from ?? {
+      id: 0,
+      is_bot: true,
+      first_name: params.account.name ?? "OpenClaw",
+    },
+    ...(text ? { text } : {}),
+    ...(params.messageThreadId !== undefined ? { message_thread_id: params.messageThreadId } : {}),
+  };
+}
+
+export async function recordOutboundMessageForPromptContext(params: {
+  cfg: OpenClawConfig;
+  account: TelegramOutboundPromptContextAccount;
+  chatId: string | number;
+  message: TelegramOutboundPromptContextMessage;
+  messageId: number;
+  text?: string;
+  messageThreadId?: number;
+}): Promise<void> {
+  try {
+    const cache = createTelegramMessageCache({
+      legacyPersistedPath: resolveTelegramMessageCachePath(
+        resolveStorePath(params.cfg.session?.store),
+      ),
+    });
+    await cache.record({
+      accountId: params.account.accountId,
+      chatId: params.chatId,
+      msg: buildOutboundCacheMessage(params) as Message,
+      ...(params.messageThreadId !== undefined ? { threadId: params.messageThreadId } : {}),
+    });
+  } catch (error) {
+    logVerbose(`telegram: failed to record outbound message context: ${String(error)}`);
+  }
+}

--- a/extensions/telegram/src/runtime.ts
+++ b/extensions/telegram/src/runtime.ts
@@ -5,8 +5,9 @@ const {
   setRuntime: setTelegramRuntime,
   clearRuntime: clearTelegramRuntime,
   getRuntime: getTelegramRuntime,
+  tryGetRuntime: getOptionalTelegramRuntime,
 } = createPluginRuntimeStore<TelegramRuntime>({
   pluginId: "telegram",
   errorMessage: "Telegram runtime not initialized",
 });
-export { clearTelegramRuntime, getTelegramRuntime, setTelegramRuntime };
+export { clearTelegramRuntime, getOptionalTelegramRuntime, getTelegramRuntime, setTelegramRuntime };

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -3,6 +3,12 @@ import type { Bot } from "grammy";
 import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  buildTelegramConversationContext,
+  createTelegramMessageCache,
+  resolveTelegramMessageCachePath,
+  resetTelegramMessageCacheBucketsForTest,
+} from "./message-cache.js";
+import {
   getTelegramSendTestMocks,
   importTelegramSendModule,
   installTelegramSendTestHooks,
@@ -182,6 +188,7 @@ function capturedLogText(logFile: string): string {
 afterEach(() => {
   setLoggerOverride(null);
   resetLogger();
+  resetTelegramMessageCacheBucketsForTest();
   vi.restoreAllMocks();
 });
 
@@ -626,6 +633,70 @@ describe("sendMessageTelegram", () => {
 
     const [middleware] = firstMockCall(botConfigUseSpy, "bot config use call");
     expect(middleware).toBeTypeOf("function");
+  });
+
+  it("records sent text messages into the Telegram prompt context cache", async () => {
+    const storePath = `/tmp/openclaw-telegram-send-context-${process.pid}-${Date.now()}.json`;
+    const persistedPath = resolveTelegramMessageCachePath(storePath);
+    const cfg = { session: { store: storePath } };
+    try {
+      botApi.sendMessage.mockResolvedValueOnce({
+        message_id: 1497,
+        date: 1_779_394_740,
+        chat: {
+          id: "-1003966283270",
+          type: "supergroup",
+          title: "Keshav and Kelaw - Keshav's Bot",
+        },
+        from: { id: 42, is_bot: true, first_name: "Kelaw", username: "keshavbotagent" },
+        text: "Done already: timeoutSeconds is now 7200s.",
+        message_thread_id: 1154,
+      });
+
+      await sendMessageTelegram("-1003966283270", "Done already: timeoutSeconds is now 7200s.", {
+        cfg,
+        token: "tok",
+        messageThreadId: 1154,
+      });
+
+      const cache = createTelegramMessageCache({ persistedPath });
+      await cache.record({
+        accountId: "default",
+        chatId: "-1003966283270",
+        threadId: 1154,
+        msg: {
+          chat: {
+            id: -1003966283270,
+            type: "supergroup",
+            title: "Keshav and Kelaw - Keshav's Bot",
+          },
+          message_thread_id: 1154,
+          message_id: 1521,
+          date: 1_779_425_460,
+          text: "Did all Amazon crons run fine",
+          from: { id: 5185575566, is_bot: false, first_name: "Keshav" },
+        },
+      });
+
+      const context = await buildTelegramConversationContext({
+        cache,
+        accountId: "default",
+        chatId: "-1003966283270",
+        threadId: 1154,
+        messageId: "1521",
+        replyChainNodes: [],
+        recentLimit: 10,
+        replyTargetWindowSize: 2,
+      });
+
+      expect(context.map((entry) => entry.node.messageId)).toContain("1497");
+      expect(context.map((entry) => entry.node.body)).toContain(
+        "Done already: timeoutSeconds is now 7200s.",
+      );
+    } finally {
+      fs.rmSync(persistedPath, { force: true });
+      fs.rmSync(`${storePath}.telegram-sent-messages.json`, { force: true });
+    }
   });
 
   it("falls back to plain text when Telegram rejects HTML and preserves send params", async () => {

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -30,6 +30,7 @@ import {
   isTelegramRateLimitError,
   isTelegramServerError,
 } from "./network-errors.js";
+import { recordOutboundMessageForPromptContext } from "./outbound-message-context.js";
 import { makeProxyFetch } from "./proxy.js";
 import {
   buildTelegramThreadReplyParams,
@@ -112,7 +113,12 @@ type TelegramSendResult = {
 
 type TelegramMessageLike = {
   message_id?: number;
-  chat?: { id?: string | number };
+  chat?: { id?: string | number; type?: string; title?: string; username?: string };
+  date?: number;
+  from?: { id?: number; is_bot?: boolean; first_name?: string; username?: string };
+  text?: string;
+  caption?: string;
+  message_thread_id?: number;
 };
 
 type TelegramOutboundSuccessLogParams = {
@@ -708,6 +714,17 @@ export async function sendMessageTelegram(
       );
       const messageId = resolveTelegramMessageIdOrThrow(res, context);
       recordSentMessage(chatId, messageId, cfg);
+      await recordOutboundMessageForPromptContext({
+        cfg,
+        account,
+        chatId,
+        message: res,
+        messageId,
+        text: chunk.plainText,
+        ...(acceptedParams?.message_thread_id !== undefined
+          ? { messageThreadId: acceptedParams.message_thread_id }
+          : {}),
+      });
       lastMessageId = String(messageId);
       lastChatId = String(res?.chat?.id ?? chatId);
       lastAcceptedParams = acceptedParams;
@@ -948,6 +965,17 @@ export async function sendMessageTelegram(
     const mediaMessageId = resolveTelegramMessageIdOrThrow(result, "media send");
     const resolvedChatId = String(result?.chat?.id ?? chatId);
     recordSentMessage(chatId, mediaMessageId, cfg);
+    await recordOutboundMessageForPromptContext({
+      cfg,
+      account,
+      chatId,
+      message: result,
+      messageId: mediaMessageId,
+      ...(caption ? { text: caption } : {}),
+      ...(mediaParams.message_thread_id !== undefined
+        ? { messageThreadId: mediaParams.message_thread_id }
+        : {}),
+    });
     logTelegramOutboundSendOk({
       accountId: account.accountId,
       chatId: resolvedChatId,

--- a/extensions/telegram/src/state-migrations.test.ts
+++ b/extensions/telegram/src/state-migrations.test.ts
@@ -1,0 +1,76 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { Message } from "grammy/types";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
+import { describe, expect, it } from "vitest";
+import { resolveTelegramMessageCachePath } from "./message-cache.js";
+import { detectTelegramLegacyStateMigrations } from "./state-migrations.js";
+
+type PersistedCacheEntry = {
+  key: string;
+  node: {
+    sourceMessage: Message;
+  };
+};
+
+function persistedCacheEntry(messageId: number, text: string): PersistedCacheEntry {
+  return {
+    key: `default:7:${messageId}`,
+    node: {
+      sourceMessage: {
+        chat: { id: 7, type: "group", title: "Ops" },
+        message_id: messageId,
+        date: 1736380000 + messageId,
+        text,
+        from: { id: messageId, is_bot: false, first_name: `User ${messageId}` },
+      } as Message,
+    },
+  };
+}
+
+describe("telegram state migrations", () => {
+  it("detects legacy message-cache import for the runtime sidecar path", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-state-migration-"));
+    const env = { ...process.env, OPENCLAW_STATE_DIR: dir };
+    const storePath = resolveStorePath(undefined, { env });
+    const persistedPath = resolveTelegramMessageCachePath(storePath);
+    try {
+      await mkdir(path.dirname(persistedPath), { recursive: true });
+      await writeFile(
+        persistedPath,
+        JSON.stringify([persistedCacheEntry(9201, "doctor imports this")]),
+      );
+
+      const cfg = {
+        agents: {
+          list: [{ id: "ops", default: true }],
+        },
+      } as OpenClawConfig;
+      const plans = await detectTelegramLegacyStateMigrations({ cfg, env });
+      const messageCachePlan = plans.find(
+        (plan) =>
+          plan.kind === "plugin-state-import" &&
+          plan.label === "Telegram prompt-context message cache",
+      );
+
+      expect(messageCachePlan).toMatchObject({
+        kind: "plugin-state-import",
+        sourcePath: persistedPath,
+        targetPath: "plugin state:telegram.message-cache",
+        pluginId: "telegram",
+        namespace: "telegram.message-cache",
+      });
+      if (!messageCachePlan || messageCachePlan.kind !== "plugin-state-import") {
+        throw new Error("expected Telegram message-cache plugin-state import plan");
+      }
+
+      const entries = await messageCachePlan.readEntries();
+      expect(entries).toHaveLength(1);
+      expect(entries[0]?.key).toBe("default:7:9201");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/extensions/telegram/src/state-migrations.ts
+++ b/extensions/telegram/src/state-migrations.ts
@@ -1,8 +1,17 @@
+import path from "node:path";
 import type { ChannelLegacyStateMigrationPlan } from "openclaw/plugin-sdk/channel-contract";
 import { resolveChannelAllowFromPath } from "openclaw/plugin-sdk/channel-pairing-paths";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { statRegularFileSync } from "openclaw/plugin-sdk/security-runtime";
+import { resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import { resolveDefaultTelegramAccountId } from "./account-selection.js";
+import {
+  listTelegramLegacyMessageCacheEntries,
+  resolveTelegramMessageCachePath,
+  resolveTelegramMessageCachePersistentScopeKey,
+  TELEGRAM_MESSAGE_CACHE_PERSISTENT_MAX_MESSAGES,
+  TELEGRAM_MESSAGE_CACHE_PERSISTENT_NAMESPACE,
+} from "./message-cache.js";
 
 function fileExists(pathValue: string): boolean {
   try {
@@ -12,25 +21,73 @@ function fileExists(pathValue: string): boolean {
   }
 }
 
-export function detectTelegramLegacyStateMigrations(params: {
+function resolveLegacySessionStorePath(params: {
+  env: NodeJS.ProcessEnv;
+  stateDir?: string;
+}): string {
+  const stateDir =
+    params.stateDir ??
+    path.dirname(
+      path.dirname(path.dirname(path.dirname(resolveStorePath(undefined, { env: params.env })))),
+    );
+  return path.join(stateDir, "sessions", "sessions.json");
+}
+
+function detectTelegramMessageCacheLegacyStateMigration(params: {
   cfg: OpenClawConfig;
   env: NodeJS.ProcessEnv;
+  stateDir?: string;
 }): ChannelLegacyStateMigrationPlan[] {
+  const storePath = resolveStorePath(params.cfg.session?.store, { env: params.env });
+  const runtimePersistedPath = resolveTelegramMessageCachePath(storePath);
+  const legacyStorePath = resolveLegacySessionStorePath(params);
+  const legacyPersistedPath = resolveTelegramMessageCachePath(legacyStorePath);
+  const scopeKey = resolveTelegramMessageCachePersistentScopeKey(runtimePersistedPath);
+  const sourcePaths = Array.from(new Set([runtimePersistedPath, legacyPersistedPath]));
+  return sourcePaths.flatMap((persistedPath) => {
+    if (!fileExists(persistedPath)) {
+      return [];
+    }
+    return {
+      kind: "plugin-state-import",
+      label: "Telegram prompt-context message cache",
+      sourcePath: persistedPath,
+      targetPath: `plugin state:${TELEGRAM_MESSAGE_CACHE_PERSISTENT_NAMESPACE}`,
+      pluginId: "telegram",
+      namespace: TELEGRAM_MESSAGE_CACHE_PERSISTENT_NAMESPACE,
+      maxEntries: TELEGRAM_MESSAGE_CACHE_PERSISTENT_MAX_MESSAGES,
+      scopeKey,
+      cleanupSource: "rename",
+      preview: `- Telegram prompt-context message cache: ${persistedPath} → plugin state (${TELEGRAM_MESSAGE_CACHE_PERSISTENT_NAMESPACE})`,
+      readEntries: () => {
+        return listTelegramLegacyMessageCacheEntries({
+          persistedPath,
+          maxMessages: TELEGRAM_MESSAGE_CACHE_PERSISTENT_MAX_MESSAGES,
+        });
+      },
+    };
+  });
+}
+
+export async function detectTelegramLegacyStateMigrations(params: {
+  cfg: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+  stateDir?: string;
+}): Promise<ChannelLegacyStateMigrationPlan[]> {
+  const plans: ChannelLegacyStateMigrationPlan[] = [];
   const legacyPath = resolveChannelAllowFromPath("telegram", params.env);
-  if (!fileExists(legacyPath)) {
-    return [];
+  if (fileExists(legacyPath)) {
+    const accountId = resolveDefaultTelegramAccountId(params.cfg);
+    const targetPath = resolveChannelAllowFromPath("telegram", params.env, accountId);
+    if (!fileExists(targetPath)) {
+      plans.push({
+        kind: "copy",
+        label: "Telegram pairing allowFrom",
+        sourcePath: legacyPath,
+        targetPath,
+      });
+    }
   }
-  const accountId = resolveDefaultTelegramAccountId(params.cfg);
-  const targetPath = resolveChannelAllowFromPath("telegram", params.env, accountId);
-  if (fileExists(targetPath)) {
-    return [];
-  }
-  return [
-    {
-      kind: "copy",
-      label: "Telegram pairing allowFrom",
-      sourcePath: legacyPath,
-      targetPath,
-    },
-  ];
+  plans.push(...detectTelegramMessageCacheLegacyStateMigration(params));
+  return plans;
 }

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -151,12 +151,29 @@ export type ChannelHeartbeatDeps = {
   hasActiveWebListener?: (accountId?: string) => boolean;
 };
 
-export type ChannelLegacyStateMigrationPlan = {
-  kind: "copy" | "move";
-  label: string;
-  sourcePath: string;
-  targetPath: string;
-};
+export type ChannelLegacyStateMigrationPlan =
+  | {
+      kind: "copy" | "move";
+      label: string;
+      sourcePath: string;
+      targetPath: string;
+    }
+  | {
+      kind: "plugin-state-import";
+      label: string;
+      sourcePath: string;
+      targetPath: string;
+      pluginId: string;
+      namespace: string;
+      maxEntries: number;
+      scopeKey: string;
+      stateDir?: string;
+      cleanupSource?: "rename";
+      preview?: string;
+      readEntries: () =>
+        | Array<{ key: string; value: unknown }>
+        | Promise<Array<{ key: string; value: unknown }>>;
+    };
 
 /** User-facing metadata used in docs, pickers, and setup surfaces. */
 export type ChannelMeta = {

--- a/src/commands/doctor-state-migrations.test.ts
+++ b/src/commands/doctor-state-migrations.test.ts
@@ -4,6 +4,10 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import {
+  createPluginStateKeyedStore,
+  resetPluginStateStoreForTests,
+} from "../plugin-state/plugin-state-store.js";
+import {
   autoMigrateLegacyStateDir,
   autoMigrateLegacyState,
   detectLegacyStateMigrations,
@@ -13,6 +17,10 @@ import {
 } from "./doctor-state-migrations.js";
 
 let tempRoots: string[] = [];
+
+const mockedChannelMigrationPlans = vi.hoisted(() => ({
+  plans: [] as Array<Record<string, unknown>>,
+}));
 
 vi.mock("../channels/plugins/bundled.js", async () => {
   const actual = await vi.importActual<typeof import("../channels/plugins/bundled.js")>(
@@ -105,6 +113,7 @@ vi.mock("../channels/plugins/bundled.js", async () => {
       ({ oauthDir }: { oauthDir: string }) => detectWhatsAppLegacyStateMigrations({ oauthDir }),
       ({ cfg, env }: { cfg: OpenClawConfig; env: NodeJS.ProcessEnv }) =>
         detectTelegramAllowFromMigration({ cfg, env }),
+      () => mockedChannelMigrationPlans.plans,
     ]),
     listBundledChannelSetupPluginsByFeature: vi.fn((feature: string) => {
       if (feature === "legacySessionSurfaces") {
@@ -221,6 +230,8 @@ async function runTelegramAllowFromMigration(params: { root: string; cfg: OpenCl
 afterEach(async () => {
   resetAutoMigrateLegacyStateForTest();
   resetAutoMigrateLegacyStateDirForTest();
+  resetPluginStateStoreForTests();
+  mockedChannelMigrationPlans.plans = [];
   await Promise.all(
     tempRoots.map((root) => fs.promises.rm(root, { recursive: true, force: true })),
   );
@@ -256,6 +267,20 @@ async function detectAndRunMigrations(params: {
     env: { OPENCLAW_STATE_DIR: params.root } as NodeJS.ProcessEnv,
   });
   await runLegacyStateMigrations({ detected, now: params.now });
+}
+
+async function withStateDir<T>(root: string, run: () => Promise<T>): Promise<T> {
+  const previous = process.env.OPENCLAW_STATE_DIR;
+  process.env.OPENCLAW_STATE_DIR = root;
+  try {
+    return await run();
+  } finally {
+    if (previous === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = previous;
+    }
+  }
 }
 
 function readSessionsStore(targetDir: string) {
@@ -589,6 +614,70 @@ describe("doctor legacy state migrations", () => {
     });
     const result = await runLegacyStateMigrations({ detected });
     expect(result.changes).toStrictEqual([]);
+  });
+
+  it("imports plugin-state legacy plans through doctor", async () => {
+    const root = await makeTempRoot();
+    const sourcePath = path.join(root, "legacy-cache.json");
+    fs.writeFileSync(sourcePath, "legacy", "utf-8");
+    mockedChannelMigrationPlans.plans = [
+      {
+        kind: "plugin-state-import",
+        label: "Test prompt-context cache",
+        sourcePath,
+        targetPath: "plugin state:test.prompt-cache",
+        pluginId: "telegram",
+        namespace: "test.prompt-cache",
+        maxEntries: 4,
+        scopeKey: "scope",
+        cleanupSource: "rename",
+        readEntries: () => [
+          { key: "old", value: { body: "old" } },
+          { key: "existing", value: { body: "stale" } },
+          { key: "overflow", value: { body: "overflow" } },
+        ],
+      },
+    ];
+
+    await withStateDir(root, async () => {
+      const store = createPluginStateKeyedStore<{ body: string }>("telegram", {
+        namespace: "test.prompt-cache",
+        maxEntries: 4,
+      });
+      await store.register("scope:existing", { body: "fresh" });
+      await store.register("other:keep", { body: "other" });
+    });
+    resetPluginStateStoreForTests();
+
+    const detected = await detectLegacyStateMigrations({
+      cfg: {},
+      env: { OPENCLAW_STATE_DIR: root } as NodeJS.ProcessEnv,
+    });
+    const result = await runLegacyStateMigrations({ detected });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toContain("Migrated 2 Test prompt-context cache entries → plugin state");
+    expect(result.changes).toContain(
+      `Archived Test prompt-context cache legacy source → ${sourcePath}.migrated`,
+    );
+    expect(fs.existsSync(sourcePath)).toBe(false);
+    expect(fs.existsSync(`${sourcePath}.migrated`)).toBe(true);
+
+    await withStateDir(root, async () => {
+      const store = createPluginStateKeyedStore<{ body: string }>("telegram", {
+        namespace: "test.prompt-cache",
+        maxEntries: 4,
+      });
+      const valuesByKey = new Map(
+        (await store.entries()).map(({ key, value }) => [key, value.body]),
+      );
+      expect(Object.fromEntries(valuesByKey)).toEqual({
+        "other:keep": "other",
+        "scope:existing": "fresh",
+        "scope:old": "old",
+        "scope:overflow": "overflow",
+      });
+    });
   });
 
   it("routes legacy state to the default agent entry", async () => {

--- a/src/infra/state-migrations.ts
+++ b/src/infra/state-migrations.ts
@@ -19,6 +19,7 @@ import { canonicalizeMainSessionAlias } from "../config/sessions/main-session.js
 import type { SessionScope } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { createPluginStateKeyedStore } from "../plugin-state/plugin-state-store.js";
 import {
   buildAgentMainSessionKey,
   DEFAULT_AGENT_ID,
@@ -115,7 +116,30 @@ function isLegacyGroupKey(key: string): boolean {
 }
 
 function buildLegacyMigrationPreview(plan: ChannelLegacyStateMigrationPlan): string {
+  if (plan.kind === "plugin-state-import") {
+    return plan.preview ?? `- ${plan.label}: ${plan.sourcePath}`;
+  }
   return `- ${plan.label}: ${plan.sourcePath} → ${plan.targetPath}`;
+}
+
+async function withPluginStateImportEnv<T>(
+  plan: Extract<ChannelLegacyStateMigrationPlan, { kind: "plugin-state-import" }>,
+  run: () => Promise<T>,
+): Promise<T> {
+  if (!plan.stateDir) {
+    return await run();
+  }
+  const previous = process.env.OPENCLAW_STATE_DIR;
+  process.env.OPENCLAW_STATE_DIR = plan.stateDir;
+  try {
+    return await run();
+  } finally {
+    if (previous === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = previous;
+    }
+  }
 }
 
 async function runLegacyMigrationPlans(
@@ -124,6 +148,68 @@ async function runLegacyMigrationPlans(
   const changes: string[] = [];
   const warnings: string[] = [];
   for (const plan of plans) {
+    if (plan.kind === "plugin-state-import") {
+      await withPluginStateImportEnv(plan, async () => {
+        let storeEntries: Array<{ key: string }> = [];
+        const store = createPluginStateKeyedStore<unknown>(plan.pluginId, {
+          namespace: plan.namespace,
+          maxEntries: plan.maxEntries,
+        });
+        try {
+          storeEntries = await store.entries();
+        } catch (err) {
+          warnings.push(
+            `Failed reading ${plan.label} plugin state before migration: ${String(err)}`,
+          );
+          return;
+        }
+        const existingKeys = new Set(storeEntries.map(({ key }) => key));
+        let remainingCapacity = Math.max(0, plan.maxEntries - storeEntries.length);
+        const entries = await plan.readEntries();
+        let imported = 0;
+        for (const entry of entries) {
+          const targetKey = `${plan.scopeKey}:${entry.key}`;
+          if (existingKeys.has(targetKey)) {
+            continue;
+          }
+          if (remainingCapacity <= 0) {
+            break;
+          }
+          try {
+            await store.register(targetKey, entry.value);
+            existingKeys.add(targetKey);
+            remainingCapacity--;
+            imported++;
+          } catch (err) {
+            warnings.push(`Failed migrating ${plan.label} entry ${entry.key}: ${String(err)}`);
+          }
+        }
+        if (imported > 0) {
+          changes.push(
+            `Migrated ${imported} ${plan.label} ${imported === 1 ? "entry" : "entries"} → plugin state`,
+          );
+        }
+        const allEntriesCovered =
+          entries.length > 0 &&
+          entries.every(({ key }) => existingKeys.has(`${plan.scopeKey}:${key}`));
+        if (allEntriesCovered && plan.cleanupSource === "rename" && fileExists(plan.sourcePath)) {
+          const archivedPath = `${plan.sourcePath}.migrated`;
+          if (fileExists(archivedPath)) {
+            warnings.push(
+              `Left migrated ${plan.label} source in place because ${archivedPath} already exists`,
+            );
+            return;
+          }
+          try {
+            fs.renameSync(plan.sourcePath, archivedPath);
+            changes.push(`Archived ${plan.label} legacy source → ${archivedPath}`);
+          } catch (err) {
+            warnings.push(`Failed archiving ${plan.label} legacy source: ${String(err)}`);
+          }
+        }
+      });
+      continue;
+    }
     if (fileExists(plan.targetPath)) {
       continue;
     }
@@ -678,7 +764,13 @@ async function collectChannelLegacyStateMigrationPlans(params: {
       oauthDir: params.oauthDir,
     });
     if (detected?.length) {
-      plans.push(...detected);
+      for (const detectedPlan of detected) {
+        const plan =
+          detectedPlan.kind === "plugin-state-import" && !detectedPlan.stateDir
+            ? { ...detectedPlan, stateDir: params.stateDir }
+            : detectedPlan;
+        plans.push(plan);
+      }
     }
   }
   return plans;
@@ -948,29 +1040,33 @@ export async function migrateLegacyAgentDir(
   return { changes, warnings };
 }
 
-async function migrateChannelLegacyStatePlans(
-  detected: LegacyStateDetection,
-): Promise<{ changes: string[]; warnings: string[] }> {
-  const changes: string[] = [];
-  const warnings: string[] = [];
-  if (!detected.channelPlans.hasLegacy) {
-    return { changes, warnings };
-  }
-  return await runLegacyMigrationPlans(detected.channelPlans.plans);
-}
-
 export async function runLegacyStateMigrations(params: {
   detected: LegacyStateDetection;
   now?: () => number;
 }): Promise<{ changes: string[]; warnings: string[] }> {
   const now = params.now ?? (() => Date.now());
   const detected = params.detected;
+  const preSessionChannelPlans = await runLegacyMigrationPlans(
+    detected.channelPlans.plans.filter((plan) => plan.kind === "plugin-state-import"),
+  );
   const sessions = await migrateLegacySessions(detected, now);
   const agentDir = await migrateLegacyAgentDir(detected, now);
-  const channelPlans = await migrateChannelLegacyStatePlans(detected);
+  const channelPlans = await runLegacyMigrationPlans(
+    detected.channelPlans.plans.filter((plan) => plan.kind !== "plugin-state-import"),
+  );
   return {
-    changes: [...sessions.changes, ...agentDir.changes, ...channelPlans.changes],
-    warnings: [...sessions.warnings, ...agentDir.warnings, ...channelPlans.warnings],
+    changes: [
+      ...preSessionChannelPlans.changes,
+      ...sessions.changes,
+      ...agentDir.changes,
+      ...channelPlans.changes,
+    ],
+    warnings: [
+      ...preSessionChannelPlans.warnings,
+      ...sessions.warnings,
+      ...agentDir.warnings,
+      ...channelPlans.warnings,
+    ],
   };
 }
 


### PR DESCRIPTION
## Summary

- Problem: Telegram prompt context cached inbound messages but not OpenClaw's own outbound Telegram replies, so follow-up turns could see multiple user messages without the assistant answer between them.
- Problem: normal streamed Telegram assistant finals are finalized through the draft-stream/edit path, so caching only `sendMessageTelegram` sends would still miss the central streamed-final path.
- Solution: record successful Telegram outbound sends and preview-finalized streamed finals into the Telegram message-context cache.
- Storage: use plugin runtime state / SQLite KV for new Telegram observed-message cache writes, scoped by session-store path. Legacy JSON sidecars remain read-only runtime fallback; importing them into plugin state is owned by `openclaw doctor --fix`.
- Migration safety: doctor imports only missing keys, preserves newer plugin-state rows, caps imports to available capacity, uses the detected state dir, archives a fully migrated sidecar, and handles old pre-agent session sidecars before session migration moves them.
- Cache accuracy: long streamed finals can split across the preview message and follow-up sends; the prompt-context cache records the actual text visible on the preview message id instead of attributing the full final to that first message.
- Scope boundary: this PR is Telegram-only. It does not change Codex context-engine projection or tool payload rendering.

## Change Type

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX

## Real behavior proof

Behavior addressed: Telegram outbound assistant replies now survive into later Telegram prompt-context windows, including text sends, media sends, and streamed assistant finals. The persisted Telegram observed-message cache now uses the plugin SQLite KV store when available instead of writing a separate sidecar file; legacy JSON import is a doctor migration, not normal runtime mutation.

Real environment tested: Local OpenClaw checkout on branch `fix/codex-context-tool-payloads`, rewritten head `a2ce013335b6cfe651f9d66e9aa7862d4cff745b`.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs run extensions/telegram/src/message-cache.test.ts extensions/telegram/src/state-migrations.test.ts extensions/telegram/src/send.test.ts extensions/telegram/src/bot-message-dispatch.test.ts extensions/telegram/src/lane-delivery.test.ts`; `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=.artifacts/vitest-cache-telegram-message4 pnpm test extensions/telegram/src/message-cache.test.ts`; `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=.artifacts/vitest-cache-telegram-state4 pnpm test extensions/telegram/src/state-migrations.test.ts`.

Evidence after fix: combined focused wrapper run passed earlier with `Test Files 5 passed (5)`, `Tests 233 passed (233)`. After final migration refinements, `message-cache.test.ts` passed with `Test Files 1 passed (1)`, `Tests 16 passed (16)`, and `state-migrations.test.ts` passed with `Test Files 1 passed (1)`, `Tests 1 passed (1)`.

Observed result after fix: Later Telegram context includes the assistant outbound reply body between earlier and later user messages. Long streamed finals record the text attached to the preview message id, avoiding duplicate/misattributed full-final context when follow-up chunks are sent separately. Existing legacy sidecar cache rows can still be read as fallback before doctor runs; `doctor --fix` imports missing rows into the scoped SQLite KV bucket without overriding newer plugin-state rows, then archives fully migrated sidecars so doctor converges.

What was not tested: A full deployed Telegram-to-Codex production turn was not exercised in this rewrite. The proof uses the production Telegram message-cache helper, doctor detector, and dispatch/send seams under focused tests.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/telegram/src/message-cache.test.ts`, `extensions/telegram/src/state-migrations.test.ts`, `extensions/telegram/src/send.test.ts`, `extensions/telegram/src/bot-message-dispatch.test.ts`, `extensions/telegram/src/lane-delivery.test.ts`
- Scenario the test should lock in: successful Telegram sends and preview-finalized streamed finals are recorded into the persisted prompt-context cache; plugin-state persistence is scoped and survives reload; legacy sidecar import is doctor-owned and does not overwrite newer state; long streamed finals cache the actual preview message body.
- Why this is the smallest reliable guardrail: it covers both Telegram delivery paths that can produce visible assistant replies, the doctor migration path, and the selected-context path that later turns consume.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Future Telegram turns should be able to see OpenClaw's own recent Telegram replies in selected chat context, including streamed assistant finals, so a follow-up should not see only the user's earlier requests without the bot answer between them. The Telegram observed-message cache now uses the existing plugin SQLite KV store when available; deleting that state loses only derived Telegram prompt context, not the session transcript. Legacy sidecars are still read as fallback until doctor imports and archives them.

## Verification

- `node scripts/run-vitest.mjs run extensions/telegram/src/message-cache.test.ts extensions/telegram/src/state-migrations.test.ts extensions/telegram/src/send.test.ts extensions/telegram/src/bot-message-dispatch.test.ts extensions/telegram/src/lane-delivery.test.ts`
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=.artifacts/vitest-cache-telegram-message4 pnpm test extensions/telegram/src/message-cache.test.ts`
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=.artifacts/vitest-cache-telegram-state4 pnpm test extensions/telegram/src/state-migrations.test.ts`
- `pnpm check:test-types`
- `git diff --check origin/main`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --engine claude`
- `.agents/skills/autoreview/scripts/autoreview --mode local --engine claude`

