### PR TITLE
fix(cli-runner): only the creating run closes the shared MCP loopback server

### DIFF
--- a/src/agents/cli-runner.bundle-mcp.e2e.test.ts
+++ b/src/agents/cli-runner.bundle-mcp.e2e.test.ts
@@ -230,4 +230,87 @@ describe("runCliAgent bundle MCP e2e", () => {
       }
     },
   );
+
+  it(
+    "leaves a reused MCP loopback server running when a child run cleans up",
+    { timeout: E2E_TIMEOUT_MS },
+    async () => {
+      // Regression for the shared-singleton teardown bug: a run that reuses an
+      // existing loopback server (created by a parent session) must not close
+      // it on run end even when cleanupBundleMcpOnRunEnd is true, otherwise it
+      // tears down a server still in use by the run that created it.
+      const { runCliAgent } = await import("./cli-runner.js");
+      const { ensureMcpLoopbackServer, closeMcpLoopbackServer, getActiveMcpLoopbackRuntime } =
+        await import("../gateway/mcp-http.js");
+      const { resetGlobalHookRunner } = await import("../plugins/hook-runner-global.js");
+      await resetBundleMcpPluginState();
+      const envSnapshot = captureEnv([
+        "HOME",
+        "USERPROFILE",
+        "OPENCLAW_HOME",
+        "OPENCLAW_STATE_DIR",
+        "OPENCLAW_DISABLE_PERSISTED_PLUGIN_REGISTRY",
+      ]);
+      const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-reuse-keep-"));
+      process.env.HOME = tempHome;
+      process.env.USERPROFILE = tempHome;
+      delete process.env.OPENCLAW_HOME;
+      delete process.env.OPENCLAW_STATE_DIR;
+      process.env.OPENCLAW_DISABLE_PERSISTED_PLUGIN_REGISTRY = "1";
+      resetGlobalHookRunner();
+      await closeMcpLoopbackServer();
+
+      const workspaceDir = path.join(tempHome, "workspace");
+      const sessionFile = path.join(tempHome, "session.jsonl");
+      const binDir = path.join(tempHome, "bin");
+      const serverScriptPath = path.join(tempHome, "mcp", "bundle-probe.mjs");
+      const fakeClaudePath = path.join(binDir, "fake-live-claude.mjs");
+      const fakeClaudePidPath = path.join(tempHome, "fake-live-claude.pid");
+      const pluginRoot = path.join(tempHome, ".openclaw", "extensions", "bundle-probe");
+      await fs.mkdir(workspaceDir, { recursive: true });
+      await writeBundleProbeMcpServer(serverScriptPath);
+      await writeFakeClaudeLiveCli({ filePath: fakeClaudePath, pidPath: fakeClaudePidPath });
+      await writeClaudeBundle({ pluginRoot, serverScriptPath });
+      installTestClaudeBackend({ commandPath: fakeClaudePath, liveSession: "claude-stdio" });
+
+      const config: OpenClawConfig = {
+        agents: { defaults: { workspace: workspaceDir } },
+        plugins: {
+          load: { paths: [pluginRoot] },
+          entries: { "bundle-probe": { enabled: true } },
+        },
+      };
+
+      try {
+        // Simulate a parent session that created and still owns the server.
+        const parent = await ensureMcpLoopbackServer(0);
+        expect(parent.created).toBe(true);
+        const parentPort = getActiveMcpLoopbackRuntime()?.port;
+        expect(parentPort).toBeGreaterThan(0);
+
+        const result = await runCliAgent({
+          sessionId: "session:test-reuse-keep",
+          sessionFile,
+          workspaceDir,
+          config,
+          prompt: "Use your configured MCP tools and report the bundle probe text.",
+          provider: "claude-cli",
+          model: "test-live-bundle",
+          timeoutMs: 20_000,
+          runId: "bundle-mcp-reuse-keep-e2e",
+          cleanupBundleMcpOnRunEnd: true,
+          cleanupCliLiveSessionOnRunEnd: true,
+        });
+
+        expect(result.payloads?.[0]?.text).toContain("LIVE BUNDLE MCP OK FROM-BUNDLE");
+        // The child reused the parent's server and must NOT have closed it.
+        expect(getActiveMcpLoopbackRuntime()?.port).toBe(parentPort);
+      } finally {
+        await closeMcpLoopbackServer();
+        resetGlobalHookRunner();
+        await fs.rm(tempHome, { recursive: true, force: true });
+        envSnapshot.restore();
+      }
+    },
+  );
 });

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -241,7 +241,11 @@ export async function runCliAgent(params: RunCliAgentParams): Promise<EmbeddedPi
         await import("./cli-runner/claude-live-session.js");
       await closeClaudeLiveSessionForContext(context);
     }
-    if (params.cleanupBundleMcpOnRunEnd === true) {
+    // Only the run that actually created the shared loopback server may close
+    // it. A run that reused an existing server (e.g. a one-shot child reusing a
+    // parent session's server) must leave it alone, otherwise it tears down a
+    // server still in use by the run that created it.
+    if (params.cleanupBundleMcpOnRunEnd === true && context.ownsBundleMcpLoopbackServer === true) {
       const { closeMcpLoopbackServer } = await import("../gateway/mcp-http.js");
       await closeMcpLoopbackServer();
     }

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -102,8 +102,11 @@ function createTestMcpLoopbackServerConfig(port: number) {
 
 async function createTestMcpLoopbackServer(port = 0) {
   return {
-    port,
-    close: vi.fn(async () => undefined),
+    server: {
+      port,
+      close: vi.fn(async () => undefined),
+    },
+    created: true,
   };
 }
 

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -206,9 +206,11 @@ export async function prepareCliRunContext(
   });
   const bundleMcpEnabled = backendResolved.bundleMcp && params.disableTools !== true;
   let mcpLoopbackRuntime = bundleMcpEnabled ? prepareDeps.getActiveMcpLoopbackRuntime() : undefined;
+  let ownsBundleMcpLoopbackServer = false;
   if (bundleMcpEnabled && !mcpLoopbackRuntime) {
     try {
-      await prepareDeps.ensureMcpLoopbackServer();
+      const ensured = await prepareDeps.ensureMcpLoopbackServer();
+      ownsBundleMcpLoopbackServer = ensured.created;
     } catch (error) {
       cliBackendLog.warn(`mcp loopback server failed to start: ${String(error)}`);
     }
@@ -551,6 +553,7 @@ export async function prepareCliRunContext(
       authEpochVersion: CLI_AUTH_EPOCH_VERSION,
       extraSystemPromptHash,
       promptToolNamesHash,
+      ownsBundleMcpLoopbackServer,
     };
   } catch (err) {
     try {

--- a/src/agents/cli-runner/types.ts
+++ b/src/agents/cli-runner/types.ts
@@ -134,4 +134,11 @@ export type PreparedCliRunContext = {
   authEpochVersion: number;
   extraSystemPromptHash?: string;
   promptToolNamesHash?: string;
+  /**
+   * True only when this run actually started the shared bundle MCP loopback
+   * server. Used to ensure that only the creating run closes it on run end; a
+   * run that merely reused an existing server must never close it (otherwise it
+   * would tear down a server still in use by the run that created it).
+   */
+  ownsBundleMcpLoopbackServer?: boolean;
 };

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -564,9 +564,34 @@ describe("mcp loopback server", () => {
     const first = await ensureMcpLoopbackServer(0);
     const second = await ensureMcpLoopbackServer(0);
 
-    expect(second).toBe(first);
-    expect(getActiveMcpLoopbackRuntime()?.port).toBe(first.port);
+    expect(second.server).toBe(first.server);
+    expect(first.created).toBe(true);
+    expect(second.created).toBe(false);
+    expect(getActiveMcpLoopbackRuntime()?.port).toBe(first.server.port);
 
+    await closeMcpLoopbackServer();
+    expect(getActiveMcpLoopbackRuntime()).toBeUndefined();
+  });
+
+  it("reports created=true only for the caller that started the server", async () => {
+    expect(getActiveMcpLoopbackRuntime()).toBeUndefined();
+
+    // The creating caller (e.g. a parent session) owns the server; a later
+    // reusing caller (e.g. a one-shot child) must learn it did NOT create it so
+    // it never closes a server still held by the run that created it.
+    const owner = await ensureMcpLoopbackServer(0);
+    const reuser = await ensureMcpLoopbackServer(0);
+
+    expect(owner.created).toBe(true);
+    expect(reuser.created).toBe(false);
+    expect(reuser.server).toBe(owner.server);
+
+    await closeMcpLoopbackServer();
+    expect(getActiveMcpLoopbackRuntime()).toBeUndefined();
+
+    // After a full close, the next caller becomes the new creating owner.
+    const next = await ensureMcpLoopbackServer(0);
+    expect(next.created).toBe(true);
     await closeMcpLoopbackServer();
     expect(getActiveMcpLoopbackRuntime()).toBeUndefined();
   });

--- a/src/gateway/mcp-http.ts
+++ b/src/gateway/mcp-http.ts
@@ -216,11 +216,25 @@ export async function startMcpLoopbackServer(port = 0): Promise<{
   return server;
 }
 
-export async function ensureMcpLoopbackServer(port = 0): Promise<McpLoopbackServer> {
+export type EnsureMcpLoopbackServerResult = {
+  server: McpLoopbackServer;
+  /**
+   * True only for the caller whose `ensure` actually started the shared server
+   * (or joined the in-flight start it triggered). Reusers that find an existing
+   * server get `false`. Callers must propagate this so that only a creating run
+   * later closes the server; a reusing run must never close a server it shares
+   * with the run that created it.
+   */
+  created: boolean;
+};
+
+export async function ensureMcpLoopbackServer(port = 0): Promise<EnsureMcpLoopbackServerResult> {
   if (activeMcpLoopbackServer) {
-    return activeMcpLoopbackServer;
+    return { server: activeMcpLoopbackServer, created: false };
   }
+  let createdHere = false;
   if (!activeMcpLoopbackServerPromise) {
+    createdHere = true;
     activeMcpLoopbackServerPromise = startMcpLoopbackServer(port)
       .then((server) => {
         activeMcpLoopbackServer = server;
@@ -230,7 +244,8 @@ export async function ensureMcpLoopbackServer(port = 0): Promise<McpLoopbackServ
         activeMcpLoopbackServerPromise = null;
       });
   }
-  return activeMcpLoopbackServerPromise;
+  const server = await activeMcpLoopbackServerPromise;
+  return { server, created: createdHere };
 }
 
 export async function closeMcpLoopbackServer(): Promise<void> {


### PR DESCRIPTION
## Summary

A run that **reused** an existing in-process MCP loopback server still tore it down on run end, killing a server another run was actively using.

`ensureMcpLoopbackServer()` returns a shared singleton. When a parent session created it and a one-shot child run (subagent, or `openclaw agent` child) reused it, the child still called `closeMcpLoopbackServer()` in its run-end `finally` because `cleanupBundleMcpOnRunEnd` was `true`. That closed the parent's still-live server. Subsequent loopback tool calls from the parent then failed with `fetch failed`, breaking agent-to-agent (A2A) bundle MCP tool use whenever a parent session and a one-shot child overlapped.

Repro signature: a parent agent session triggers a child agent run; after the child finishes, the parent's next bundle MCP tool call fails with `fetch failed` (observed as repeated consecutive failures across A2A invocations).

Regression introduced by `ccf2e77e8d` (*retire one-shot subagent MCP runtimes*), which routed child runs through the shared singleton + unconditional run-end close.

## Fix

Creator-responsible close:

- `ensureMcpLoopbackServer()` now returns `{ server, created }` — `created` is `true` only for the caller that actually started the server (or joined the in-flight start it triggered). Reusers get `created: false`.
- `prepare.ts` records this as `ownsBundleMcpLoopbackServer` on `PreparedCliRunContext`.
- `cli-runner.ts` closes the loopback server on run end only when `cleanupBundleMcpOnRunEnd === true && ownsBundleMcpLoopbackServer === true`. A run that merely reused a shared server never closes it.

Behavior matrix:

| caller | created/owns | cleanup flag | closes? |
|---|---|---|---|
| parent session creates | true | false (session) | no — server kept for reuse |
| one-shot child reuses | false | true (run) | **no — parent server survives (the fix)** |
| standalone CLI creates | true | true | yes |
| gateway shutdown | n/a | shutdown path | yes (unconditional) |

The shutdown path (`server.impl.ts` → `closeMcpLoopbackServer()`) is unchanged and still tears the server down unconditionally.

## Real behavior proof (required for external PRs)

> Honest disclosure: I have **not** re-run the failure on a live gateway A2A round-trip after the fix — the only setup that reproduces it is my own production OpenClaw deployment, which is mid-operation (cron jobs, Telegram channel), and I am not willing to disrupt it or expose its credentials to capture after-fix gateway logs. I have therefore deferred the live-gateway capture (see *What was not tested*) and am requesting a maintainer `proof: override`. The strongest non-production evidence I can give is a real in-process MCP loopback HTTP server lifecycle test, below.

- **Behavior or issue addressed:** A2A bundle MCP tool calls from a parent agent session fail with `fetch failed` after a one-shot child run finishes, because the child closes the shared in-process MCP loopback server the parent created.
- **Real environment tested:** Local repo branch off `main`, real in-process MCP loopback HTTP server (`startMcpLoopbackServer` → live `http.Server`, real port), exercised through the actual `runCliAgent` run lifecycle — not a mocked server. (Live gateway A2A round-trip not re-run; see below.)
- **Exact steps or command run after this patch:** Stand up a loopback server as the parent (`ensureMcpLoopbackServer(0)`), run a one-shot child through `runCliAgent` with `cleanupBundleMcpOnRunEnd: true`, then inspect `getActiveMcpLoopbackRuntime()?.port`. Repeated with the owns-guard removed to reproduce the pre-fix regression.
- **Evidence after fix (terminal output):**
  ```
  With the fix (owns-guard in place):
    Test Files  1 passed (1)
         Tests  3 passed (3)
      Duration  81.93s

  Without the fix (owns-guard removed = the regression):
    × leaves a reused MCP loopback server running when a child run cleans up
    AssertionError: expected undefined to be 57147 // Object.is equality
      307|  expect(getActiveMcpLoopbackRuntime()?.port).toBe(parentPort)
    Tests  1 failed | 2 passed (3)
  ```
- **Observed result after fix:** The parent's live loopback server (port `57147` above) survives the child's run-end cleanup; before the fix that runtime becomes `undefined` (server torn down), which is exactly the state that surfaces as `fetch failed` on the parent's next loopback tool call.
- **What was not tested:** A full live-gateway A2A round-trip after the fix (parent session → one-shot child → parent's next bundle MCP tool call succeeds) on my production deployment — deferred to avoid disrupting a running operational setup and exposing credentials. I will attach redacted live-gateway after-fix logs once this merges, ships, and I upgrade my deployment.
- **Before evidence:** The pre-fix failure above (`expected undefined to be 57147`) reproduces the exact server-teardown that produced `fetch failed` in production A2A use.

## Verification

Local (this branch, off `main`):
- `pnpm test src/gateway/mcp-http.test.ts src/agents/cli-runner/prepare.test.ts` — 25 passed (covers the `created` flag for creator vs reuser, and re-create after full close).
- `pnpm test src/agents/cli-runner.bundle-mcp.e2e.test.ts` — 3 passed; fails as shown above when the owns-guard is removed.
- `pnpm build` — clean, no `[INEFFECTIVE_DYNAMIC_IMPORT]`.
- `pnpm check:changed` — typecheck (core) + core tests green, exit 0.

## Scope note

This is a behavior change in core run lifecycle (CODEOWNERS-sensitive). Kept minimal: the close decision is now gated on a prepared per-run ownership fact rather than the global cleanup flag alone. No new request-time discovery; the `created` fact is produced once in `prepare` and carried on the run context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
