### PR TITLE
fix(cron): guard against undefined sourceDelivery in isolated executor

### DIFF
--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -289,7 +289,7 @@ export function createCronPromptExecutor(params: {
           threadId: params.resolvedDelivery.threadId,
         },
         messageToolEnabled: legacyToolPolicy ? !legacyToolPolicy.disableMessageTool : true,
-        messageToolForced: legacyToolPolicy?.forceMessageTool ?? true,
+        messageToolForced: legacyToolPolicy?.forceMessageTool ?? false,
         requireExplicitMessageTarget: legacyToolPolicy?.requireExplicitMessageTarget ?? false,
         directFallback: false,
       });
@@ -598,11 +598,11 @@ export async function executeCronRun(params: {
         rawReplyMode === "automatic" || rawReplyMode === "message_tool_only"
           ? rawReplyMode
           : undefined;
-      const owner = legacyReplyMode === "message_tool_only" ? "message_tool" : "none";
+      const owner = legacyReplyMode === "message_tool_only" ? "direct_fallback" : "none";
 
       return createSourceDeliveryPlan({
         owner,
-        reason: owner === "message_tool" ? "cron_announce" : "cron_none",
+        reason: owner === "direct_fallback" ? "cron_announce" : "cron_none",
         target: {
           channel: legacyMessageChannel ?? params.resolvedDelivery.channel,
           to: params.resolvedDelivery.to,
@@ -610,7 +610,7 @@ export async function executeCronRun(params: {
           threadId: params.resolvedDelivery.threadId,
         },
         messageToolEnabled: legacyToolPolicy ? !legacyToolPolicy.disableMessageTool : true,
-        messageToolForced: legacyToolPolicy?.forceMessageTool ?? true,
+        messageToolForced: legacyToolPolicy?.forceMessageTool ?? false,
         requireExplicitMessageTarget: legacyToolPolicy?.requireExplicitMessageTarget ?? false,
         directFallback: false,
       });

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -6,6 +6,7 @@ import type { FastModeAutoProgressState } from "../../agents/fast-mode.js";
 import { resolveCliRuntimeExecutionProvider } from "../../agents/model-runtime-aliases.js";
 import { wrapUntrustedPromptDataBlock } from "../../agents/sanitize-for-prompt.js";
 import { normalizeToolName } from "../../agents/tool-policy.js";
+import type { SourceReplyDeliveryMode } from "../../auto-reply/get-reply-options.types.js";
 import type { ThinkLevel, VerboseLevel } from "../../auto-reply/thinking.js";
 import type { AgentDefaultsConfig } from "../../config/types.agent-defaults.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -293,9 +294,18 @@ export function createCronPromptExecutor(params: {
         directFallback: false,
       });
     })();
-  const legacyMode = (params as Record<string, unknown>).sourceReplyDeliveryMode as
+  const rawLegacyMode = (params as Record<string, unknown>).sourceReplyDeliveryMode as
     | string
     | undefined;
+  const legacyMode: SourceReplyDeliveryMode | undefined =
+    rawLegacyMode === "automatic" || rawLegacyMode === "message_tool_only"
+      ? rawLegacyMode
+      : undefined;
+  if (rawLegacyMode && !legacyMode) {
+    logWarn(
+      `cron: ignoring unrecognized legacy sourceReplyDeliveryMode ${JSON.stringify(rawLegacyMode)}, falling back to sourceDelivery plan`,
+    );
+  }
   const sourceReplyDeliveryMode = legacyMode ?? sourceDelivery.sourceReplyDeliveryMode;
   const messageChannel = sourceDelivery.target.channel ?? params.resolvedDelivery.channel;
   const deliveryTargetRuntimeContext = buildCronDeliveryTargetRuntimeContext({
@@ -583,7 +593,11 @@ export async function executeCronRun(params: {
           }
         | undefined;
       const legacyMessageChannel = legacy.messageChannel as string | undefined;
-      const legacyReplyMode = legacy.sourceReplyDeliveryMode as string | undefined;
+      const rawReplyMode = legacy.sourceReplyDeliveryMode as string | undefined;
+      const legacyReplyMode: SourceReplyDeliveryMode | undefined =
+        rawReplyMode === "automatic" || rawReplyMode === "message_tool_only"
+          ? rawReplyMode
+          : undefined;
       const owner = legacyReplyMode === "message_tool_only" ? "message_tool" : "none";
 
       return createSourceDeliveryPlan({

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -9,7 +9,10 @@ import { normalizeToolName } from "../../agents/tool-policy.js";
 import type { ThinkLevel, VerboseLevel } from "../../auto-reply/thinking.js";
 import type { AgentDefaultsConfig } from "../../config/types.agent-defaults.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import type { SourceDeliveryPlan } from "../../infra/outbound/source-delivery-plan.js";
+import {
+  createSourceDeliveryPlan,
+  type SourceDeliveryPlan,
+} from "../../infra/outbound/source-delivery-plan.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import type { SkillSnapshot } from "../../skills/types.js";
 import type { CronAgentExecutionPhaseUpdate, CronJob } from "../types.js";
@@ -214,7 +217,7 @@ export function createCronPromptExecutor(params: {
   resolvedDeliveryOk: boolean;
   messageToolPromptEnabled: boolean;
   deliveryRequested?: boolean;
-  sourceDelivery: SourceDeliveryPlan;
+  sourceDelivery?: SourceDeliveryPlan;
   skillsSnapshot: SkillSnapshot;
   agentPayload: AgentTurnPayload;
   useSubagentFallbacks: boolean;
@@ -260,13 +263,46 @@ export function createCronPromptExecutor(params: {
     params.cronSession.sessionEntry.systemPromptReport,
   );
   const bootstrapContextMode = resolveCronBootstrapContextMode(params.agentPayload);
-  const sourceReplyDeliveryMode = params.sourceDelivery.sourceReplyDeliveryMode;
-  const messageChannel = params.sourceDelivery.target.channel ?? params.resolvedDelivery.channel;
+  const sourceDelivery =
+    params.sourceDelivery ??
+    (() => {
+      // Version-skew compatibility: stale callers from before 4c613fbfe0
+      // may pass legacy fields instead of sourceDelivery.
+      const legacy = params as Record<string, unknown>;
+      const legacyToolPolicy = legacy.toolPolicy as
+        | {
+            requireExplicitMessageTarget?: boolean;
+            disableMessageTool?: boolean;
+            forceMessageTool?: boolean;
+          }
+        | undefined;
+      const legacyMessageChannel = legacy.messageChannel as string | undefined;
+
+      return createSourceDeliveryPlan({
+        owner: "none",
+        reason: "cron_none",
+        target: {
+          channel: legacyMessageChannel ?? params.resolvedDelivery.channel,
+          to: params.resolvedDelivery.to,
+          accountId: params.resolvedDelivery.accountId,
+          threadId: params.resolvedDelivery.threadId,
+        },
+        messageToolEnabled: legacyToolPolicy ? !legacyToolPolicy.disableMessageTool : true,
+        messageToolForced: legacyToolPolicy?.forceMessageTool ?? true,
+        requireExplicitMessageTarget: legacyToolPolicy?.requireExplicitMessageTarget ?? false,
+        directFallback: false,
+      });
+    })();
+  const legacyMode = (params as Record<string, unknown>).sourceReplyDeliveryMode as
+    | string
+    | undefined;
+  const sourceReplyDeliveryMode = legacyMode ?? sourceDelivery.sourceReplyDeliveryMode;
+  const messageChannel = sourceDelivery.target.channel ?? params.resolvedDelivery.channel;
   const deliveryTargetRuntimeContext = buildCronDeliveryTargetRuntimeContext({
     resolvedDeliveryOk: params.resolvedDeliveryOk,
     messageToolPromptEnabled: params.messageToolPromptEnabled,
     resolvedDelivery: params.resolvedDelivery,
-    sourceDelivery: params.sourceDelivery,
+    sourceDelivery,
   });
 
   const runPrompt = async (promptText: string) => {
@@ -338,7 +374,7 @@ export function createCronPromptExecutor(params: {
             skillsSnapshot: params.skillsSnapshot,
             messageChannel,
             sourceReplyDeliveryMode,
-            requireExplicitMessageTarget: params.sourceDelivery.messageTool.requireExplicitTarget,
+            requireExplicitMessageTarget: sourceDelivery.messageTool.requireExplicitTarget,
             toolsAllow: resolveCliRuntimeToolsAllow(
               params.agentPayload?.toolsAllow,
               params.agentPayload?.toolsAllowIsDefault,
@@ -437,9 +473,9 @@ export function createCronPromptExecutor(params: {
             : undefined,
           sourceReplyDeliveryMode,
           runId: params.cronSession.sessionEntry.sessionId,
-          requireExplicitMessageTarget: params.sourceDelivery.messageTool.requireExplicitTarget,
-          disableMessageTool: !params.sourceDelivery.messageTool.enabled,
-          forceMessageTool: params.sourceDelivery.messageTool.force,
+          requireExplicitMessageTarget: sourceDelivery.messageTool.requireExplicitTarget,
+          disableMessageTool: !sourceDelivery.messageTool.enabled,
+          forceMessageTool: sourceDelivery.messageTool.force,
           allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
           abortSignal: params.abortSignal,
           onExecutionStarted: params.onExecutionStarted,
@@ -494,7 +530,7 @@ export async function executeCronRun(params: {
   resolvedDeliveryOk: boolean;
   messageToolPromptEnabled: boolean;
   deliveryRequested?: boolean;
-  sourceDelivery: SourceDeliveryPlan;
+  sourceDelivery?: SourceDeliveryPlan;
   skillsSnapshot: SkillSnapshot;
   agentPayload: AgentTurnPayload;
   useSubagentFallbacks: boolean;
@@ -530,6 +566,41 @@ export async function executeCronRun(params: {
     sessionId: params.cronSession.sessionEntry.sessionId,
     verboseLevel: resolvedVerboseLevel,
   });
+  if (!params.sourceDelivery) {
+    logWarn(
+      `[cron:${params.job.id}] sourceDelivery is undefined; using fallback — possible build artifact mismatch`,
+    );
+  }
+  const sourceDelivery =
+    params.sourceDelivery ??
+    (() => {
+      const legacy = params as Record<string, unknown>;
+      const legacyToolPolicy = legacy.toolPolicy as
+        | {
+            requireExplicitMessageTarget?: boolean;
+            disableMessageTool?: boolean;
+            forceMessageTool?: boolean;
+          }
+        | undefined;
+      const legacyMessageChannel = legacy.messageChannel as string | undefined;
+      const legacyReplyMode = legacy.sourceReplyDeliveryMode as string | undefined;
+      const owner = legacyReplyMode === "message_tool_only" ? "message_tool" : "none";
+
+      return createSourceDeliveryPlan({
+        owner,
+        reason: owner === "message_tool" ? "cron_announce" : "cron_none",
+        target: {
+          channel: legacyMessageChannel ?? params.resolvedDelivery.channel,
+          to: params.resolvedDelivery.to,
+          accountId: params.resolvedDelivery.accountId,
+          threadId: params.resolvedDelivery.threadId,
+        },
+        messageToolEnabled: legacyToolPolicy ? !legacyToolPolicy.disableMessageTool : true,
+        messageToolForced: legacyToolPolicy?.forceMessageTool ?? true,
+        requireExplicitMessageTarget: legacyToolPolicy?.requireExplicitMessageTarget ?? false,
+        directFallback: false,
+      });
+    })();
   const executor = createCronPromptExecutor({
     cfg: params.cfg,
     cfgWithAgentDefaults: params.cfgWithAgentDefaults,
@@ -549,7 +620,7 @@ export async function executeCronRun(params: {
     resolvedDeliveryOk: params.resolvedDeliveryOk,
     messageToolPromptEnabled: params.messageToolPromptEnabled,
     deliveryRequested: params.deliveryRequested,
-    sourceDelivery: params.sourceDelivery,
+    sourceDelivery,
     skillsSnapshot: params.skillsSnapshot,
     agentPayload: params.agentPayload,
     useSubagentFallbacks: params.useSubagentFallbacks,

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -6,14 +6,10 @@ import type { FastModeAutoProgressState } from "../../agents/fast-mode.js";
 import { resolveCliRuntimeExecutionProvider } from "../../agents/model-runtime-aliases.js";
 import { wrapUntrustedPromptDataBlock } from "../../agents/sanitize-for-prompt.js";
 import { normalizeToolName } from "../../agents/tool-policy.js";
-import type { SourceReplyDeliveryMode } from "../../auto-reply/get-reply-options.types.js";
 import type { ThinkLevel, VerboseLevel } from "../../auto-reply/thinking.js";
 import type { AgentDefaultsConfig } from "../../config/types.agent-defaults.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import {
-  createSourceDeliveryPlan,
-  type SourceDeliveryPlan,
-} from "../../infra/outbound/source-delivery-plan.js";
+import type { SourceDeliveryPlan } from "../../infra/outbound/source-delivery-plan.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import type { SkillSnapshot } from "../../skills/types.js";
 import type { CronAgentExecutionPhaseUpdate, CronJob } from "../types.js";
@@ -43,6 +39,7 @@ import type {
   PersistCronSessionEntry,
 } from "./run-session-state.js";
 import { syncCronSessionLiveSelection } from "./run-session-state.js";
+import { resolveFallbackCronSourceDeliveryPlan } from "./source-delivery-fallback.js";
 import { isLikelyInterimCronMessage } from "./subagent-followup-hints.js";
 
 type AgentTurnPayload = Extract<CronJob["payload"], { kind: "agentTurn" }> | null;
@@ -214,6 +211,7 @@ export function createCronPromptExecutor(params: {
     accountId?: string;
     to?: string;
     threadId?: string | number;
+    ok?: boolean;
   };
   resolvedDeliveryOk: boolean;
   messageToolPromptEnabled: boolean;
@@ -264,49 +262,15 @@ export function createCronPromptExecutor(params: {
     params.cronSession.sessionEntry.systemPromptReport,
   );
   const bootstrapContextMode = resolveCronBootstrapContextMode(params.agentPayload);
-  const sourceDelivery =
-    params.sourceDelivery ??
-    (() => {
-      // Version-skew compatibility: stale callers from before 4c613fbfe0
-      // may pass legacy fields instead of sourceDelivery.
-      const legacy = params as Record<string, unknown>;
-      const legacyToolPolicy = legacy.toolPolicy as
-        | {
-            requireExplicitMessageTarget?: boolean;
-            disableMessageTool?: boolean;
-            forceMessageTool?: boolean;
-          }
-        | undefined;
-      const legacyMessageChannel = legacy.messageChannel as string | undefined;
-
-      return createSourceDeliveryPlan({
-        owner: "none",
-        reason: "cron_none",
-        target: {
-          channel: legacyMessageChannel ?? params.resolvedDelivery.channel,
-          to: params.resolvedDelivery.to,
-          accountId: params.resolvedDelivery.accountId,
-          threadId: params.resolvedDelivery.threadId,
-        },
-        messageToolEnabled: legacyToolPolicy ? !legacyToolPolicy.disableMessageTool : true,
-        messageToolForced: legacyToolPolicy?.forceMessageTool ?? false,
-        requireExplicitMessageTarget: legacyToolPolicy?.requireExplicitMessageTarget ?? false,
-        directFallback: false,
-      });
-    })();
-  const rawLegacyMode = (params as Record<string, unknown>).sourceReplyDeliveryMode as
-    | string
-    | undefined;
-  const legacyMode: SourceReplyDeliveryMode | undefined =
-    rawLegacyMode === "automatic" || rawLegacyMode === "message_tool_only"
-      ? rawLegacyMode
-      : undefined;
-  if (rawLegacyMode && !legacyMode) {
+  if (!params.sourceDelivery) {
     logWarn(
-      `cron: ignoring unrecognized legacy sourceReplyDeliveryMode ${JSON.stringify(rawLegacyMode)}, falling back to sourceDelivery plan`,
+      `[cron:${params.job.id}] sourceDelivery is undefined; using fallback — possible build artifact mismatch`,
     );
   }
-  const sourceReplyDeliveryMode = legacyMode ?? sourceDelivery.sourceReplyDeliveryMode;
+  const sourceDelivery =
+    params.sourceDelivery ??
+    resolveFallbackCronSourceDeliveryPlan(params.job, params.resolvedDelivery);
+  const sourceReplyDeliveryMode = sourceDelivery.sourceReplyDeliveryMode;
   const messageChannel = sourceDelivery.target.channel ?? params.resolvedDelivery.channel;
   const deliveryTargetRuntimeContext = buildCronDeliveryTargetRuntimeContext({
     resolvedDeliveryOk: params.resolvedDeliveryOk,
@@ -536,6 +500,7 @@ export async function executeCronRun(params: {
     accountId?: string;
     to?: string;
     threadId?: string | number;
+    ok?: boolean;
   };
   resolvedDeliveryOk: boolean;
   messageToolPromptEnabled: boolean;
@@ -583,38 +548,7 @@ export async function executeCronRun(params: {
   }
   const sourceDelivery =
     params.sourceDelivery ??
-    (() => {
-      const legacy = params as Record<string, unknown>;
-      const legacyToolPolicy = legacy.toolPolicy as
-        | {
-            requireExplicitMessageTarget?: boolean;
-            disableMessageTool?: boolean;
-            forceMessageTool?: boolean;
-          }
-        | undefined;
-      const legacyMessageChannel = legacy.messageChannel as string | undefined;
-      const rawReplyMode = legacy.sourceReplyDeliveryMode as string | undefined;
-      const legacyReplyMode: SourceReplyDeliveryMode | undefined =
-        rawReplyMode === "automatic" || rawReplyMode === "message_tool_only"
-          ? rawReplyMode
-          : undefined;
-      const owner = legacyReplyMode === "message_tool_only" ? "direct_fallback" : "none";
-
-      return createSourceDeliveryPlan({
-        owner,
-        reason: owner === "direct_fallback" ? "cron_announce" : "cron_none",
-        target: {
-          channel: legacyMessageChannel ?? params.resolvedDelivery.channel,
-          to: params.resolvedDelivery.to,
-          accountId: params.resolvedDelivery.accountId,
-          threadId: params.resolvedDelivery.threadId,
-        },
-        messageToolEnabled: legacyToolPolicy ? !legacyToolPolicy.disableMessageTool : true,
-        messageToolForced: legacyToolPolicy?.forceMessageTool ?? false,
-        requireExplicitMessageTarget: legacyToolPolicy?.requireExplicitMessageTarget ?? false,
-        directFallback: false,
-      });
-    })();
+    resolveFallbackCronSourceDeliveryPlan(params.job, params.resolvedDelivery);
   const executor = createCronPromptExecutor({
     cfg: params.cfg,
     cfgWithAgentDefaults: params.cfgWithAgentDefaults,

--- a/src/cron/isolated-agent/run.source-delivery-guard.test.ts
+++ b/src/cron/isolated-agent/run.source-delivery-guard.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { SkillSnapshot } from "../../agents/skills.js";
+import type { SkillSnapshot } from "../../skills/types.js";
 import { createSourceDeliveryPlan } from "../../infra/outbound/source-delivery-plan.js";
 import type { MutableCronSession } from "./run-session-state.js";
 import {
@@ -8,7 +8,7 @@ import {
   mockRunCronFallbackPassthrough,
   resetRunCronIsolatedAgentTurnHarness,
   restoreFastTestEnv,
-  runEmbeddedPiAgentMock,
+  runEmbeddedAgentMock,
 } from "./run.test-harness.js";
 
 const { createCronPromptExecutor, executeCronRun } = await import("./run-executor.js");
@@ -62,9 +62,9 @@ function makeExecutor(overrides: Partial<Parameters<typeof createCronPromptExecu
 }
 
 function getEmbeddedRunArg(): Record<string, unknown> {
-  const call = runEmbeddedPiAgentMock.mock.calls[0];
+  const call = runEmbeddedAgentMock.mock.calls[0];
   if (!call) {
-    throw new Error("expected runEmbeddedPiAgent to be called");
+    throw new Error("expected runEmbeddedAgent to be called");
   }
   return call[0] as Record<string, unknown>;
 }
@@ -94,7 +94,7 @@ describe("createCronPromptExecutor sourceDelivery guard", () => {
 
     await executor.runPrompt("run a task");
 
-    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
     const args = getEmbeddedRunArg();
     expect(args.sourceReplyDeliveryMode).toBeUndefined();
     expect(args.requireExplicitMessageTarget).toBe(false);
@@ -113,7 +113,7 @@ describe("createCronPromptExecutor sourceDelivery guard", () => {
 
     await executor.runPrompt("run a task");
 
-    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
     const args = getEmbeddedRunArg();
     expect(args.messageChannel).toBe("topicchat");
     expect(args.messageTo).toBe("room#42");
@@ -134,7 +134,7 @@ describe("createCronPromptExecutor sourceDelivery guard", () => {
 
     await executor.runPrompt("run a task");
 
-    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
     const args = getEmbeddedRunArg();
     expect(args.sourceReplyDeliveryMode).toBe("message_tool_only");
     expect(args.disableMessageTool).toBe(false);
@@ -156,7 +156,7 @@ describe("createCronPromptExecutor sourceDelivery guard", () => {
 
     await executor.runPrompt("run a task");
 
-    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
     const args = getEmbeddedRunArg();
     expect(args.sourceReplyDeliveryMode).toBeUndefined();
     expect(args.disableMessageTool).toBe(true);
@@ -178,7 +178,7 @@ describe("createCronPromptExecutor sourceDelivery guard", () => {
 
     await executor.runPrompt("run a task");
 
-    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
     const args = getEmbeddedRunArg();
     expect(args.requireExplicitMessageTarget).toBe(true);
   });
@@ -199,7 +199,7 @@ describe("createCronPromptExecutor sourceDelivery guard", () => {
 
     await executor.runPrompt("send a message");
 
-    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
     const args = getEmbeddedRunArg();
     expect(args.sourceReplyDeliveryMode).toBe("message_tool_only");
     expect(args.requireExplicitMessageTarget).toBe(false);
@@ -268,7 +268,7 @@ describe("executeCronRun sourceDelivery guard", () => {
       }),
     );
 
-    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
     const args = getEmbeddedRunArg();
     expect(args.sourceReplyDeliveryMode).toBe("message_tool_only");
     expect(args.disableMessageTool).toBe(false);
@@ -284,7 +284,7 @@ describe("executeCronRun sourceDelivery guard", () => {
       }),
     );
 
-    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
     const args = getEmbeddedRunArg();
     expect(args.sourceReplyDeliveryMode).toBeUndefined();
   });
@@ -304,7 +304,7 @@ describe("executeCronRun sourceDelivery guard", () => {
       }),
     );
 
-    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
     const args = getEmbeddedRunArg();
     expect(args.requireExplicitMessageTarget).toBe(true);
     expect(args.sourceReplyDeliveryMode).toBe("message_tool_only");
@@ -319,7 +319,7 @@ describe("executeCronRun sourceDelivery guard", () => {
       }),
     );
 
-    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
     const args = getEmbeddedRunArg();
     expect(args.requireExplicitMessageTarget).toBe(false);
   });
@@ -339,7 +339,7 @@ describe("executeCronRun sourceDelivery guard", () => {
       }),
     );
 
-    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
     const args = getEmbeddedRunArg();
     expect(args.sourceReplyDeliveryMode).toBeUndefined();
     expect(args.disableMessageTool).toBe(true);

--- a/src/cron/isolated-agent/run.source-delivery-guard.test.ts
+++ b/src/cron/isolated-agent/run.source-delivery-guard.test.ts
@@ -69,6 +69,8 @@ function makeExecutor(overrides: Partial<Parameters<typeof createCronPromptExecu
     },
     cronSession: makeCronSession() as MutableCronSession,
     abortReason: () => "aborted",
+    resolvedDeliveryOk: true,
+    messageToolPromptEnabled: true,
     ...overrides,
     resolvedDelivery,
   });
@@ -158,6 +160,23 @@ describe("resolveFallbackCronSourceDeliveryPlan", () => {
     expect(plan.messageTool.force).toBe(false);
     expect(plan.fallback.directDelivery).toBe(true);
     expect(plan.fallback.skipWhenMessageToolSentToTarget).toBe(false);
+  });
+
+  it("preserves duplicate suppression when stale caller omits ok", () => {
+    const plan = resolveFallbackCronSourceDeliveryPlan(
+      makeJob({ delivery: { mode: "announce", channel: "messagechat", to: "room-1" } }),
+      {
+        channel: "messagechat",
+        to: "room-1",
+        // ok intentionally omitted — stale caller shape
+      },
+    );
+
+    expect(plan.owner).toBe("direct_fallback");
+    expect(plan.reason).toBe("cron_announce");
+    expect(plan.fallback.directDelivery).toBe(true);
+    // When ok is absent, default to true to prevent double-posting
+    expect(plan.fallback.skipWhenMessageToolSentToTarget).toBe(true);
   });
 });
 
@@ -354,7 +373,7 @@ describe("createCronPromptExecutor sourceDelivery guard", () => {
     expect(args.sourceReplyDeliveryMode).toBeUndefined();
     expect(args.disableMessageTool).toBe(false);
     expect(args.forceMessageTool).toBe(false);
-    expect(args.requireExplicitMessageTarget).toBe(false);
+    expect(args.requireExplicitMessageTarget).toBe(true);
   });
 
   it("still works with a valid sourceDelivery", async () => {

--- a/src/cron/isolated-agent/run.source-delivery-guard.test.ts
+++ b/src/cron/isolated-agent/run.source-delivery-guard.test.ts
@@ -16,7 +16,8 @@ import {
 const actualDeliveryPlanModule =
   await vi.importActual<typeof import("../delivery-plan.js")>("../delivery-plan.js");
 const { createCronPromptExecutor, executeCronRun } = await import("./run-executor.js");
-const { resolveFallbackCronSourceDeliveryPlan } = await import("./source-delivery-fallback.js");
+const { resolveCronSourceDeliveryPlan, resolveFallbackCronSourceDeliveryPlan } =
+  await import("./source-delivery-fallback.js");
 
 const emptySkillsSnapshot: SkillSnapshot = {
   prompt: "",
@@ -158,6 +159,82 @@ describe("resolveFallbackCronSourceDeliveryPlan", () => {
     expect(plan.fallback.directDelivery).toBe(true);
     expect(plan.fallback.skipWhenMessageToolSentToTarget).toBe(false);
   });
+});
+
+describe("resolveCronSourceDeliveryPlan", () => {
+  beforeEach(() => {
+    resolveCronDeliveryPlanMock.mockReset();
+    resolveCronDeliveryPlanMock.mockImplementation(
+      actualDeliveryPlanModule.resolveCronDeliveryPlan,
+    );
+  });
+
+  const cases: Array<{
+    name: string;
+    job: CronJob;
+    resolvedDelivery: {
+      channel?: string;
+      accountId?: string;
+      to?: string;
+      threadId?: string | number;
+      ok?: boolean;
+    };
+  }> = [
+    {
+      name: "none",
+      job: makeJob({ delivery: { mode: "none" } }),
+      resolvedDelivery: {
+        channel: "messagechat",
+        accountId: "acct-1",
+        to: "room-1",
+        threadId: "thread-1",
+        ok: true,
+      },
+    },
+    {
+      name: "announce",
+      job: makeJob({ delivery: { mode: "announce", channel: "messagechat", to: "room-1" } }),
+      resolvedDelivery: {
+        channel: "messagechat",
+        to: "room-1",
+        ok: true,
+      },
+    },
+    {
+      name: "webhook",
+      job: makeJob({ delivery: { mode: "webhook" } }),
+      resolvedDelivery: {
+        channel: "messagechat",
+        to: "room-1",
+        ok: true,
+      },
+    },
+    {
+      name: "implicit announce",
+      job: makeJob({ omitDelivery: true }),
+      resolvedDelivery: {
+        channel: "messagechat",
+        to: "room-1",
+        ok: false,
+      },
+    },
+  ];
+
+  for (const testCase of cases) {
+    it(`matches the fallback wrapper for ${testCase.name}`, () => {
+      const deliveryPlan = actualDeliveryPlanModule.resolveCronDeliveryPlan(testCase.job);
+      const normalPathPlan = resolveCronSourceDeliveryPlan({
+        deliveryPlan,
+        resolvedDelivery: testCase.resolvedDelivery,
+      });
+      const fallbackPathPlan = resolveFallbackCronSourceDeliveryPlan(
+        testCase.job,
+        testCase.resolvedDelivery,
+      );
+
+      expect(normalPathPlan).toEqual(fallbackPathPlan);
+    });
+  }
 });
 
 describe("createCronPromptExecutor sourceDelivery guard", () => {

--- a/src/cron/isolated-agent/run.source-delivery-guard.test.ts
+++ b/src/cron/isolated-agent/run.source-delivery-guard.test.ts
@@ -1,0 +1,348 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SkillSnapshot } from "../../agents/skills.js";
+import { createSourceDeliveryPlan } from "../../infra/outbound/source-delivery-plan.js";
+import type { MutableCronSession } from "./run-session-state.js";
+import {
+  clearFastTestEnv,
+  makeCronSession,
+  mockRunCronFallbackPassthrough,
+  resetRunCronIsolatedAgentTurnHarness,
+  restoreFastTestEnv,
+  runEmbeddedPiAgentMock,
+} from "./run.test-harness.js";
+
+const { createCronPromptExecutor, executeCronRun } = await import("./run-executor.js");
+
+const emptySkillsSnapshot: SkillSnapshot = {
+  prompt: "",
+  skills: [],
+  resolvedSkills: [],
+  version: 1,
+};
+
+function makeJob() {
+  return {
+    id: "source-delivery-guard",
+    name: "Source Delivery Guard",
+    schedule: { kind: "every", everyMs: 60_000 },
+    sessionTarget: "isolated",
+    payload: { kind: "agentTurn", message: "test" },
+    delivery: { mode: "none" },
+  } as never;
+}
+
+function makeExecutor(overrides: Partial<Parameters<typeof createCronPromptExecutor>[0]>) {
+  const resolvedDelivery = overrides.resolvedDelivery ?? {};
+
+  return createCronPromptExecutor({
+    cfg: {},
+    cfgWithAgentDefaults: {},
+    job: makeJob(),
+    agentId: "default",
+    agentDir: "/tmp/agent-dir",
+    agentSessionKey: "cron:source-delivery-guard",
+    runSessionKey: "cron:source-delivery-guard:run:test-session-id",
+    workspaceDir: "/tmp/workspace",
+    resolvedVerboseLevel: "off",
+    thinkLevel: undefined,
+    timeoutMs: 60_000,
+    suppressExecNotifyOnExit: true,
+    skillsSnapshot: emptySkillsSnapshot,
+    agentPayload: null,
+    useSubagentFallbacks: false,
+    liveSelection: {
+      provider: "openai",
+      model: "gpt-5.4",
+    },
+    cronSession: makeCronSession() as MutableCronSession,
+    abortReason: () => "aborted",
+    ...overrides,
+    resolvedDelivery,
+  });
+}
+
+function getEmbeddedRunArg(): Record<string, unknown> {
+  const call = runEmbeddedPiAgentMock.mock.calls[0];
+  if (!call) {
+    throw new Error("expected runEmbeddedPiAgent to be called");
+  }
+  return call[0] as Record<string, unknown>;
+}
+
+describe("createCronPromptExecutor sourceDelivery guard", () => {
+  let previousFastTestEnv: string | undefined;
+
+  beforeEach(() => {
+    resetRunCronIsolatedAgentTurnHarness();
+    previousFastTestEnv = clearFastTestEnv();
+  });
+
+  afterEach(() => {
+    restoreFastTestEnv(previousFastTestEnv);
+  });
+
+  it("reconstructs a safe delivery plan when sourceDelivery is undefined", async () => {
+    mockRunCronFallbackPassthrough();
+    const executor = makeExecutor({
+      sourceDelivery: undefined,
+      resolvedDelivery: {
+        channel: "messagechat",
+        accountId: "acct-1",
+        threadId: "thread-99",
+      },
+    });
+
+    await executor.runPrompt("run a task");
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    const args = getEmbeddedRunArg();
+    expect(args.sourceReplyDeliveryMode).toBeUndefined();
+    expect(args.requireExplicitMessageTarget).toBe(false);
+    expect(args.disableMessageTool).toBe(false);
+    expect(args.forceMessageTool).toBe(true);
+    expect(args.agentAccountId).toBe("acct-1");
+    expect(args.messageThreadId).toBe("thread-99");
+  });
+
+  it("uses resolvedDelivery channel/to for legacy callers without sourceDelivery", async () => {
+    mockRunCronFallbackPassthrough();
+    const executor = makeExecutor({
+      sourceDelivery: undefined,
+      resolvedDelivery: { channel: "topicchat", to: "room#42" },
+    });
+
+    await executor.runPrompt("run a task");
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    const args = getEmbeddedRunArg();
+    expect(args.messageChannel).toBe("topicchat");
+    expect(args.messageTo).toBe("room#42");
+  });
+
+  it("reads legacy toolPolicy/sourceReplyDeliveryMode from stale announce caller", async () => {
+    mockRunCronFallbackPassthrough();
+    const executor = makeExecutor({
+      sourceDelivery: undefined,
+      resolvedDelivery: { channel: "messagechat", to: "123" },
+      toolPolicy: {
+        disableMessageTool: false,
+        forceMessageTool: true,
+        requireExplicitMessageTarget: false,
+      },
+      sourceReplyDeliveryMode: "message_tool_only",
+    } as never);
+
+    await executor.runPrompt("run a task");
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    const args = getEmbeddedRunArg();
+    expect(args.sourceReplyDeliveryMode).toBe("message_tool_only");
+    expect(args.disableMessageTool).toBe(false);
+    expect(args.forceMessageTool).toBe(true);
+  });
+
+  it("reads legacy toolPolicy from stale webhook caller with message tool disabled", async () => {
+    mockRunCronFallbackPassthrough();
+    const executor = makeExecutor({
+      sourceDelivery: undefined,
+      resolvedDelivery: { channel: "messagechat", to: "456" },
+      toolPolicy: {
+        disableMessageTool: true,
+        forceMessageTool: false,
+        requireExplicitMessageTarget: false,
+      },
+      sourceReplyDeliveryMode: undefined,
+    } as never);
+
+    await executor.runPrompt("run a task");
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    const args = getEmbeddedRunArg();
+    expect(args.sourceReplyDeliveryMode).toBeUndefined();
+    expect(args.disableMessageTool).toBe(true);
+    expect(args.forceMessageTool).toBe(false);
+  });
+
+  it("passes requireExplicitMessageTarget from legacy toolPolicy in createCronPromptExecutor", async () => {
+    mockRunCronFallbackPassthrough();
+    const executor = makeExecutor({
+      sourceDelivery: undefined,
+      resolvedDelivery: { channel: "messagechat", to: "789" },
+      toolPolicy: {
+        disableMessageTool: false,
+        forceMessageTool: true,
+        requireExplicitMessageTarget: true,
+      },
+      sourceReplyDeliveryMode: "message_tool_only",
+    } as never);
+
+    await executor.runPrompt("run a task");
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    const args = getEmbeddedRunArg();
+    expect(args.requireExplicitMessageTarget).toBe(true);
+  });
+
+  it("still works with a valid sourceDelivery", async () => {
+    mockRunCronFallbackPassthrough();
+    const executor = makeExecutor({
+      sourceDelivery: createSourceDeliveryPlan({
+        owner: "message_tool_then_direct_fallback",
+        reason: "cron_announce",
+        target: { channel: "messagechat", to: "123" },
+        messageToolEnabled: true,
+        messageToolForced: true,
+        directFallback: true,
+      }),
+      resolvedDelivery: { channel: "messagechat", to: "123" },
+    });
+
+    await executor.runPrompt("send a message");
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    const args = getEmbeddedRunArg();
+    expect(args.sourceReplyDeliveryMode).toBe("message_tool_only");
+    expect(args.requireExplicitMessageTarget).toBe(false);
+    expect(args.disableMessageTool).toBe(false);
+    expect(args.forceMessageTool).toBe(true);
+    expect(args.messageChannel).toBe("messagechat");
+  });
+});
+
+function makeExecuteCronRunParams(overrides: Record<string, unknown> = {}) {
+  return {
+    cfg: {},
+    cfgWithAgentDefaults: {},
+    job: makeJob(),
+    agentId: "default",
+    agentDir: "/tmp/agent-dir",
+    agentSessionKey: "cron:source-delivery-guard",
+    runSessionKey: "cron:source-delivery-guard:run:test-session-id",
+    workspaceDir: "/tmp/workspace",
+    skillsSnapshot: emptySkillsSnapshot,
+    agentPayload: null,
+    useSubagentFallbacks: false,
+    agentVerboseDefault: undefined,
+    liveSelection: {
+      provider: "openai",
+      model: "gpt-5.4",
+    },
+    cronSession: makeCronSession() as MutableCronSession,
+    commandBody: "run a task",
+    persistSessionEntry: vi.fn().mockResolvedValue(undefined),
+    abortReason: () => "aborted",
+    isAborted: () => false,
+    thinkLevel: undefined,
+    timeoutMs: 60_000,
+    suppressExecNotifyOnExit: true,
+    resolvedDelivery: {},
+    sourceDelivery: undefined,
+    ...overrides,
+  } as never;
+}
+
+describe("executeCronRun sourceDelivery guard", () => {
+  let previousFastTestEnv: string | undefined;
+
+  beforeEach(() => {
+    resetRunCronIsolatedAgentTurnHarness();
+    previousFastTestEnv = clearFastTestEnv();
+  });
+
+  afterEach(() => {
+    restoreFastTestEnv(previousFastTestEnv);
+  });
+
+  it("preserves legacy sourceReplyDeliveryMode: message_tool_only through executeCronRun", async () => {
+    mockRunCronFallbackPassthrough();
+    await executeCronRun(
+      makeExecuteCronRunParams({
+        sourceDelivery: undefined,
+        resolvedDelivery: { channel: "messagechat", to: "123" },
+        toolPolicy: {
+          disableMessageTool: false,
+          forceMessageTool: true,
+          requireExplicitMessageTarget: false,
+        },
+        sourceReplyDeliveryMode: "message_tool_only",
+      }),
+    );
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    const args = getEmbeddedRunArg();
+    expect(args.sourceReplyDeliveryMode).toBe("message_tool_only");
+    expect(args.disableMessageTool).toBe(false);
+    expect(args.forceMessageTool).toBe(true);
+  });
+
+  it("defaults to sourceReplyDeliveryMode undefined when legacy mode is absent", async () => {
+    mockRunCronFallbackPassthrough();
+    await executeCronRun(
+      makeExecuteCronRunParams({
+        sourceDelivery: undefined,
+        resolvedDelivery: { channel: "messagechat", to: "456" },
+      }),
+    );
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    const args = getEmbeddedRunArg();
+    expect(args.sourceReplyDeliveryMode).toBeUndefined();
+  });
+
+  it("passes requireExplicitMessageTarget through executeCronRun fallback", async () => {
+    mockRunCronFallbackPassthrough();
+    await executeCronRun(
+      makeExecuteCronRunParams({
+        sourceDelivery: undefined,
+        resolvedDelivery: { channel: "messagechat", to: "789" },
+        toolPolicy: {
+          disableMessageTool: false,
+          forceMessageTool: true,
+          requireExplicitMessageTarget: true,
+        },
+        sourceReplyDeliveryMode: "message_tool_only",
+      }),
+    );
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    const args = getEmbeddedRunArg();
+    expect(args.requireExplicitMessageTarget).toBe(true);
+    expect(args.sourceReplyDeliveryMode).toBe("message_tool_only");
+  });
+
+  it("passes requireExplicitMessageTarget=false by default when legacy toolPolicy omits it", async () => {
+    mockRunCronFallbackPassthrough();
+    await executeCronRun(
+      makeExecuteCronRunParams({
+        sourceDelivery: undefined,
+        resolvedDelivery: { channel: "messagechat", to: "101" },
+      }),
+    );
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    const args = getEmbeddedRunArg();
+    expect(args.requireExplicitMessageTarget).toBe(false);
+  });
+
+  it("reads legacy toolPolicy with message tool disabled through executeCronRun", async () => {
+    mockRunCronFallbackPassthrough();
+    await executeCronRun(
+      makeExecuteCronRunParams({
+        sourceDelivery: undefined,
+        resolvedDelivery: { channel: "messagechat", to: "202" },
+        toolPolicy: {
+          disableMessageTool: true,
+          forceMessageTool: false,
+          requireExplicitMessageTarget: false,
+        },
+        sourceReplyDeliveryMode: undefined,
+      }),
+    );
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    const args = getEmbeddedRunArg();
+    expect(args.sourceReplyDeliveryMode).toBeUndefined();
+    expect(args.disableMessageTool).toBe(true);
+    expect(args.forceMessageTool).toBe(false);
+  });
+});

--- a/src/cron/isolated-agent/run.source-delivery-guard.test.ts
+++ b/src/cron/isolated-agent/run.source-delivery-guard.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createSourceDeliveryPlan } from "../../infra/outbound/source-delivery-plan.js";
 import type { SkillSnapshot } from "../../skills/types.js";
+import type { CronJob } from "../types.js";
 import type { MutableCronSession } from "./run-session-state.js";
 import {
   clearFastTestEnv,
@@ -9,9 +10,13 @@ import {
   resetRunCronIsolatedAgentTurnHarness,
   restoreFastTestEnv,
   runEmbeddedAgentMock,
+  resolveCronDeliveryPlanMock,
 } from "./run.test-harness.js";
 
+const actualDeliveryPlanModule =
+  await vi.importActual<typeof import("../delivery-plan.js")>("../delivery-plan.js");
 const { createCronPromptExecutor, executeCronRun } = await import("./run-executor.js");
+const { resolveFallbackCronSourceDeliveryPlan } = await import("./source-delivery-fallback.js");
 
 const emptySkillsSnapshot: SkillSnapshot = {
   prompt: "",
@@ -20,15 +25,22 @@ const emptySkillsSnapshot: SkillSnapshot = {
   version: 1,
 };
 
-function makeJob() {
+function makeJob(
+  params: {
+    delivery?: CronJob["delivery"];
+    omitDelivery?: boolean;
+    sessionTarget?: CronJob["sessionTarget"];
+  } = {},
+): CronJob {
   return {
     id: "source-delivery-guard",
     name: "Source Delivery Guard",
     schedule: { kind: "every", everyMs: 60_000 },
-    sessionTarget: "isolated",
+    sessionTarget: params.sessionTarget ?? "isolated",
     payload: { kind: "agentTurn", message: "test" },
-    delivery: { mode: "none" },
-  } as never;
+    ...(params.omitDelivery ? {} : { delivery: params.delivery ?? { mode: "none" } }),
+    state: {},
+  } as CronJob;
 }
 
 function makeExecutor(overrides: Partial<Parameters<typeof createCronPromptExecutor>[0]>) {
@@ -69,11 +81,93 @@ function getEmbeddedRunArg(): Record<string, unknown> {
   return call[0] as Record<string, unknown>;
 }
 
+describe("resolveFallbackCronSourceDeliveryPlan", () => {
+  beforeEach(() => {
+    resolveCronDeliveryPlanMock.mockReset();
+    resolveCronDeliveryPlanMock.mockImplementation(
+      actualDeliveryPlanModule.resolveCronDeliveryPlan,
+    );
+  });
+
+  it('rebuilds delivery.mode "none" with no owner and unforced message tool', () => {
+    const plan = resolveFallbackCronSourceDeliveryPlan(makeJob({ delivery: { mode: "none" } }), {
+      channel: "messagechat",
+      to: "room-1",
+      accountId: "acct-1",
+      threadId: "thread-1",
+      ok: true,
+    });
+
+    expect(plan.owner).toBe("none");
+    expect(plan.reason).toBe("cron_none");
+    expect(plan.messageTool.enabled).toBe(true);
+    expect(plan.messageTool.force).toBe(false);
+    expect(plan.fallback.directDelivery).toBe(false);
+    expect(plan.target).toEqual({
+      channel: "messagechat",
+      to: "room-1",
+      accountId: "acct-1",
+      threadId: "thread-1",
+    });
+  });
+
+  it('rebuilds delivery.mode "announce" with direct fallback and unforced message tool', () => {
+    const plan = resolveFallbackCronSourceDeliveryPlan(
+      makeJob({ delivery: { mode: "announce", channel: "messagechat", to: "room-1" } }),
+      {
+        channel: "messagechat",
+        to: "room-1",
+        ok: true,
+      },
+    );
+
+    expect(plan.owner).toBe("direct_fallback");
+    expect(plan.reason).toBe("cron_announce");
+    expect(plan.messageTool.enabled).toBe(true);
+    expect(plan.messageTool.force).toBe(false);
+    expect(plan.fallback.directDelivery).toBe(true);
+    expect(plan.fallback.skipWhenMessageToolSentToTarget).toBe(true);
+  });
+
+  it('rebuilds delivery.mode "webhook" with message tool disabled', () => {
+    const plan = resolveFallbackCronSourceDeliveryPlan(makeJob({ delivery: { mode: "webhook" } }), {
+      channel: "messagechat",
+      to: "room-1",
+      ok: true,
+    });
+
+    expect(plan.owner).toBe("none");
+    expect(plan.reason).toBe("cron_webhook");
+    expect(plan.messageTool.enabled).toBe(false);
+    expect(plan.messageTool.force).toBe(false);
+    expect(plan.fallback.directDelivery).toBe(false);
+    expect(plan.target).toEqual({});
+  });
+
+  it("defaults an isolated agentTurn with no delivery config to announce behavior", () => {
+    const plan = resolveFallbackCronSourceDeliveryPlan(makeJob({ omitDelivery: true }), {
+      channel: "messagechat",
+      to: "room-1",
+      ok: false,
+    });
+
+    expect(plan.owner).toBe("direct_fallback");
+    expect(plan.reason).toBe("cron_announce");
+    expect(plan.messageTool.enabled).toBe(true);
+    expect(plan.messageTool.force).toBe(false);
+    expect(plan.fallback.directDelivery).toBe(true);
+    expect(plan.fallback.skipWhenMessageToolSentToTarget).toBe(false);
+  });
+});
+
 describe("createCronPromptExecutor sourceDelivery guard", () => {
   let previousFastTestEnv: string | undefined;
 
   beforeEach(() => {
     resetRunCronIsolatedAgentTurnHarness();
+    resolveCronDeliveryPlanMock.mockImplementation(
+      actualDeliveryPlanModule.resolveCronDeliveryPlan,
+    );
     previousFastTestEnv = clearFastTestEnv();
   });
 
@@ -81,9 +175,10 @@ describe("createCronPromptExecutor sourceDelivery guard", () => {
     restoreFastTestEnv(previousFastTestEnv);
   });
 
-  it("reconstructs a safe delivery plan when sourceDelivery is undefined", async () => {
+  it('falls back from delivery.mode "none" with messageToolForced false and owner none', async () => {
     mockRunCronFallbackPassthrough();
     const executor = makeExecutor({
+      job: makeJob({ delivery: { mode: "none" } }),
       sourceDelivery: undefined,
       resolvedDelivery: {
         channel: "messagechat",
@@ -104,55 +199,32 @@ describe("createCronPromptExecutor sourceDelivery guard", () => {
     expect(args.messageThreadId).toBe("thread-99");
   });
 
-  it("uses resolvedDelivery channel/to for legacy callers without sourceDelivery", async () => {
+  it('falls back from delivery.mode "announce" with direct fallback semantics', async () => {
     mockRunCronFallbackPassthrough();
     const executor = makeExecutor({
+      job: makeJob({ delivery: { mode: "announce", channel: "messagechat", to: "123" } }),
       sourceDelivery: undefined,
-      resolvedDelivery: { channel: "topicchat", to: "room#42" },
+      resolvedDelivery: { ok: true, channel: "messagechat", to: "123" },
     });
 
     await executor.runPrompt("run a task");
 
     expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
     const args = getEmbeddedRunArg();
-    expect(args.messageChannel).toBe("topicchat");
-    expect(args.messageTo).toBe("room#42");
+    expect(args.sourceReplyDeliveryMode).toBeUndefined();
+    expect(args.disableMessageTool).toBe(false);
+    expect(args.forceMessageTool).toBe(false);
+    expect(args.messageChannel).toBe("messagechat");
+    expect(args.messageTo).toBe("123");
   });
 
-  it("reads legacy toolPolicy/sourceReplyDeliveryMode from stale announce caller", async () => {
+  it('falls back from delivery.mode "webhook" with message tool disabled', async () => {
     mockRunCronFallbackPassthrough();
     const executor = makeExecutor({
+      job: makeJob({ delivery: { mode: "webhook" } }),
       sourceDelivery: undefined,
       resolvedDelivery: { channel: "messagechat", to: "123" },
-      toolPolicy: {
-        disableMessageTool: false,
-        forceMessageTool: true,
-        requireExplicitMessageTarget: false,
-      },
-      sourceReplyDeliveryMode: "message_tool_only",
-    } as never);
-
-    await executor.runPrompt("run a task");
-
-    expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
-    const args = getEmbeddedRunArg();
-    expect(args.sourceReplyDeliveryMode).toBe("message_tool_only");
-    expect(args.disableMessageTool).toBe(false);
-    expect(args.forceMessageTool).toBe(true);
-  });
-
-  it("reads legacy toolPolicy from stale webhook caller with message tool disabled", async () => {
-    mockRunCronFallbackPassthrough();
-    const executor = makeExecutor({
-      sourceDelivery: undefined,
-      resolvedDelivery: { channel: "messagechat", to: "456" },
-      toolPolicy: {
-        disableMessageTool: true,
-        forceMessageTool: false,
-        requireExplicitMessageTarget: false,
-      },
-      sourceReplyDeliveryMode: undefined,
-    } as never);
+    });
 
     await executor.runPrompt("run a task");
 
@@ -161,15 +233,36 @@ describe("createCronPromptExecutor sourceDelivery guard", () => {
     expect(args.sourceReplyDeliveryMode).toBeUndefined();
     expect(args.disableMessageTool).toBe(true);
     expect(args.forceMessageTool).toBe(false);
+    expect(args.messageChannel).toBe("messagechat");
   });
 
-  it("passes requireExplicitMessageTarget from legacy toolPolicy in createCronPromptExecutor", async () => {
+  it("falls back with announce behavior when isolated agentTurn has no delivery config", async () => {
     mockRunCronFallbackPassthrough();
     const executor = makeExecutor({
+      job: makeJob({ omitDelivery: true }),
       sourceDelivery: undefined,
-      resolvedDelivery: { channel: "messagechat", to: "789" },
+      resolvedDelivery: { channel: "messagechat", to: "123" },
+    });
+
+    await executor.runPrompt("run a task");
+
+    expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
+    const args = getEmbeddedRunArg();
+    expect(args.sourceReplyDeliveryMode).toBeUndefined();
+    expect(args.disableMessageTool).toBe(false);
+    expect(args.forceMessageTool).toBe(false);
+    expect(args.messageChannel).toBe("messagechat");
+  });
+
+  it("ignores stale legacy fields when sourceDelivery is missing", async () => {
+    mockRunCronFallbackPassthrough();
+    const executor = makeExecutor({
+      job: makeJob({ delivery: { mode: "announce", channel: "messagechat", to: "123" } }),
+      sourceDelivery: undefined,
+      resolvedDelivery: { channel: "messagechat", to: "123" },
+      messageChannel: "legacychat",
       toolPolicy: {
-        disableMessageTool: false,
+        disableMessageTool: true,
         forceMessageTool: true,
         requireExplicitMessageTarget: true,
       },
@@ -180,7 +273,11 @@ describe("createCronPromptExecutor sourceDelivery guard", () => {
 
     expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
     const args = getEmbeddedRunArg();
-    expect(args.requireExplicitMessageTarget).toBe(true);
+    expect(args.messageChannel).toBe("messagechat");
+    expect(args.sourceReplyDeliveryMode).toBeUndefined();
+    expect(args.disableMessageTool).toBe(false);
+    expect(args.forceMessageTool).toBe(false);
+    expect(args.requireExplicitMessageTarget).toBe(false);
   });
 
   it("still works with a valid sourceDelivery", async () => {
@@ -246,6 +343,9 @@ describe("executeCronRun sourceDelivery guard", () => {
 
   beforeEach(() => {
     resetRunCronIsolatedAgentTurnHarness();
+    resolveCronDeliveryPlanMock.mockImplementation(
+      actualDeliveryPlanModule.resolveCronDeliveryPlan,
+    );
     previousFastTestEnv = clearFastTestEnv();
   });
 
@@ -253,50 +353,16 @@ describe("executeCronRun sourceDelivery guard", () => {
     restoreFastTestEnv(previousFastTestEnv);
   });
 
-  it("maps legacy sourceReplyDeliveryMode: message_tool_only to direct_fallback owner", async () => {
+  it("rebuilds fallback from job delivery config and ignores stale legacy params", async () => {
     mockRunCronFallbackPassthrough();
     await executeCronRun(
       makeExecuteCronRunParams({
+        job: makeJob({ delivery: { mode: "none" } }),
         sourceDelivery: undefined,
         resolvedDelivery: { channel: "messagechat", to: "123" },
+        messageChannel: "legacychat",
         toolPolicy: {
-          disableMessageTool: false,
-          forceMessageTool: true,
-          requireExplicitMessageTarget: false,
-        },
-        sourceReplyDeliveryMode: "message_tool_only",
-      }),
-    );
-
-    expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
-    const args = getEmbeddedRunArg();
-    expect(args.sourceReplyDeliveryMode).toBeUndefined();
-    expect(args.disableMessageTool).toBe(false);
-    expect(args.forceMessageTool).toBe(true);
-  });
-
-  it("defaults to sourceReplyDeliveryMode undefined when legacy mode is absent", async () => {
-    mockRunCronFallbackPassthrough();
-    await executeCronRun(
-      makeExecuteCronRunParams({
-        sourceDelivery: undefined,
-        resolvedDelivery: { channel: "messagechat", to: "456" },
-      }),
-    );
-
-    expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
-    const args = getEmbeddedRunArg();
-    expect(args.sourceReplyDeliveryMode).toBeUndefined();
-  });
-
-  it("passes requireExplicitMessageTarget through executeCronRun fallback", async () => {
-    mockRunCronFallbackPassthrough();
-    await executeCronRun(
-      makeExecuteCronRunParams({
-        sourceDelivery: undefined,
-        resolvedDelivery: { channel: "messagechat", to: "789" },
-        toolPolicy: {
-          disableMessageTool: false,
+          disableMessageTool: true,
           forceMessageTool: true,
           requireExplicitMessageTarget: true,
         },
@@ -306,36 +372,20 @@ describe("executeCronRun sourceDelivery guard", () => {
 
     expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
     const args = getEmbeddedRunArg();
-    expect(args.requireExplicitMessageTarget).toBe(true);
+    expect(args.messageChannel).toBe("messagechat");
     expect(args.sourceReplyDeliveryMode).toBeUndefined();
-  });
-
-  it("passes requireExplicitMessageTarget=false by default when legacy toolPolicy omits it", async () => {
-    mockRunCronFallbackPassthrough();
-    await executeCronRun(
-      makeExecuteCronRunParams({
-        sourceDelivery: undefined,
-        resolvedDelivery: { channel: "messagechat", to: "101" },
-      }),
-    );
-
-    expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
-    const args = getEmbeddedRunArg();
+    expect(args.disableMessageTool).toBe(false);
+    expect(args.forceMessageTool).toBe(false);
     expect(args.requireExplicitMessageTarget).toBe(false);
   });
 
-  it("reads legacy toolPolicy with message tool disabled through executeCronRun", async () => {
+  it('rebuilds delivery.mode "webhook" with message tool disabled through executeCronRun', async () => {
     mockRunCronFallbackPassthrough();
     await executeCronRun(
       makeExecuteCronRunParams({
+        job: makeJob({ delivery: { mode: "webhook" } }),
         sourceDelivery: undefined,
         resolvedDelivery: { channel: "messagechat", to: "202" },
-        toolPolicy: {
-          disableMessageTool: true,
-          forceMessageTool: false,
-          requireExplicitMessageTarget: false,
-        },
-        sourceReplyDeliveryMode: undefined,
       }),
     );
 

--- a/src/cron/isolated-agent/run.source-delivery-guard.test.ts
+++ b/src/cron/isolated-agent/run.source-delivery-guard.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { SkillSnapshot } from "../../skills/types.js";
 import { createSourceDeliveryPlan } from "../../infra/outbound/source-delivery-plan.js";
+import type { SkillSnapshot } from "../../skills/types.js";
 import type { MutableCronSession } from "./run-session-state.js";
 import {
   clearFastTestEnv,
@@ -99,7 +99,7 @@ describe("createCronPromptExecutor sourceDelivery guard", () => {
     expect(args.sourceReplyDeliveryMode).toBeUndefined();
     expect(args.requireExplicitMessageTarget).toBe(false);
     expect(args.disableMessageTool).toBe(false);
-    expect(args.forceMessageTool).toBe(true);
+    expect(args.forceMessageTool).toBe(false);
     expect(args.agentAccountId).toBe("acct-1");
     expect(args.messageThreadId).toBe("thread-99");
   });
@@ -253,7 +253,7 @@ describe("executeCronRun sourceDelivery guard", () => {
     restoreFastTestEnv(previousFastTestEnv);
   });
 
-  it("preserves legacy sourceReplyDeliveryMode: message_tool_only through executeCronRun", async () => {
+  it("maps legacy sourceReplyDeliveryMode: message_tool_only to direct_fallback owner", async () => {
     mockRunCronFallbackPassthrough();
     await executeCronRun(
       makeExecuteCronRunParams({
@@ -270,7 +270,7 @@ describe("executeCronRun sourceDelivery guard", () => {
 
     expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
     const args = getEmbeddedRunArg();
-    expect(args.sourceReplyDeliveryMode).toBe("message_tool_only");
+    expect(args.sourceReplyDeliveryMode).toBeUndefined();
     expect(args.disableMessageTool).toBe(false);
     expect(args.forceMessageTool).toBe(true);
   });
@@ -307,7 +307,7 @@ describe("executeCronRun sourceDelivery guard", () => {
     expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
     const args = getEmbeddedRunArg();
     expect(args.requireExplicitMessageTarget).toBe(true);
-    expect(args.sourceReplyDeliveryMode).toBe("message_tool_only");
+    expect(args.sourceReplyDeliveryMode).toBeUndefined();
   });
 
   it("passes requireExplicitMessageTarget=false by default when legacy toolPolicy omits it", async () => {

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -29,7 +29,6 @@ import {
   freezeDiagnosticTraceContext,
 } from "../../infra/diagnostic-trace-context.js";
 import {
-  createSourceDeliveryPlan,
   resolveSourceDeliveryOutcome,
   type SourceDeliveryOutcome,
   type SourceDeliveryPlan,
@@ -110,6 +109,7 @@ import type { RunCronAgentTurnResult } from "./run.types.js";
 import { cleanupCronRunSessionAfterRun } from "./session-cleanup.js";
 import { resolveCronAgentSessionKey } from "./session-key.js";
 import { resolveCronSession } from "./session.js";
+import { resolveCronSourceDeliveryPlan } from "./source-delivery-fallback.js";
 
 const sessionStoreRuntimeLoader = createLazyImportLoader(
   () => import("../../config/sessions/store.runtime.js"),
@@ -307,50 +307,6 @@ function buildCronDeliveryTrace(params: {
     fallbackUsed: params.fallbackUsed,
     delivered: params.delivered,
   };
-}
-
-function resolveCronSourceDeliveryPlan(params: {
-  deliveryPlan: CronDeliveryPlan;
-  resolvedDelivery: ResolvedCronDeliveryTarget;
-}): SourceDeliveryPlan {
-  const target = {
-    channel: params.resolvedDelivery.channel,
-    to: params.resolvedDelivery.to,
-    accountId: params.resolvedDelivery.accountId,
-    threadId: params.resolvedDelivery.threadId,
-  };
-  if (params.deliveryPlan.mode === "webhook") {
-    // Webhook jobs do not expose chat delivery or message-tool fallback.
-    return createSourceDeliveryPlan({
-      owner: "none",
-      reason: "cron_webhook",
-      messageToolEnabled: false,
-      directFallback: false,
-    });
-  }
-  if (params.deliveryPlan.mode === "none") {
-    // delivery=none still allows explicit message-tool sends from the agent,
-    // but cron itself must not auto-announce a final reply.
-    return createSourceDeliveryPlan({
-      owner: "none",
-      reason: "cron_none",
-      target,
-      messageToolEnabled: true,
-      messageToolForced: false,
-      directFallback: false,
-    });
-  }
-  return createSourceDeliveryPlan({
-    owner: "direct_fallback",
-    reason: "cron_announce",
-    target,
-    messageToolEnabled: true,
-    messageToolForced: false,
-    requireExplicitMessageTarget: true,
-    requireExplicitMessageTargetEvidence: true,
-    directFallback: true,
-    skipFallbackWhenMessageToolSentToTarget: params.resolvedDelivery.ok,
-  });
 }
 
 function canPromptForMessageTool(params: {

--- a/src/cron/isolated-agent/source-delivery-fallback.ts
+++ b/src/cron/isolated-agent/source-delivery-fallback.ts
@@ -52,7 +52,7 @@ export function resolveCronSourceDeliveryPlan(params: {
     requireExplicitMessageTarget: true,
     requireExplicitMessageTargetEvidence: true,
     directFallback: true,
-    skipFallbackWhenMessageToolSentToTarget: params.resolvedDelivery.ok,
+    skipFallbackWhenMessageToolSentToTarget: params.resolvedDelivery.ok ?? true,
   });
 }
 

--- a/src/cron/isolated-agent/source-delivery-fallback.ts
+++ b/src/cron/isolated-agent/source-delivery-fallback.ts
@@ -1,0 +1,53 @@
+import { createSourceDeliveryPlan } from "../../infra/outbound/source-delivery-plan.js";
+import type { SourceDeliveryPlan } from "../../infra/outbound/source-delivery-plan.js";
+import { resolveCronDeliveryPlan } from "../delivery-plan.js";
+import type { CronJob } from "../types.js";
+
+export function resolveFallbackCronSourceDeliveryPlan(
+  job: CronJob,
+  resolvedDelivery: {
+    channel?: string;
+    accountId?: string;
+    to?: string;
+    threadId?: string | number;
+    ok?: boolean;
+  },
+): SourceDeliveryPlan {
+  const deliveryPlan = resolveCronDeliveryPlan(job);
+  const target = {
+    channel: resolvedDelivery.channel,
+    to: resolvedDelivery.to,
+    accountId: resolvedDelivery.accountId,
+    threadId: resolvedDelivery.threadId,
+  };
+
+  if (deliveryPlan.mode === "webhook") {
+    return createSourceDeliveryPlan({
+      owner: "none",
+      reason: "cron_webhook",
+      messageToolEnabled: false,
+      directFallback: false,
+    });
+  }
+
+  if (deliveryPlan.mode === "none") {
+    return createSourceDeliveryPlan({
+      owner: "none",
+      reason: "cron_none",
+      target,
+      messageToolEnabled: true,
+      messageToolForced: false,
+      directFallback: false,
+    });
+  }
+
+  return createSourceDeliveryPlan({
+    owner: "direct_fallback",
+    reason: "cron_announce",
+    target,
+    messageToolEnabled: true,
+    messageToolForced: false,
+    directFallback: true,
+    skipFallbackWhenMessageToolSentToTarget: resolvedDelivery.ok,
+  });
+}

--- a/src/cron/isolated-agent/source-delivery-fallback.ts
+++ b/src/cron/isolated-agent/source-delivery-fallback.ts
@@ -1,27 +1,29 @@
 import { createSourceDeliveryPlan } from "../../infra/outbound/source-delivery-plan.js";
 import type { SourceDeliveryPlan } from "../../infra/outbound/source-delivery-plan.js";
 import { resolveCronDeliveryPlan } from "../delivery-plan.js";
+import type { CronDeliveryPlan } from "../delivery-plan.js";
 import type { CronJob } from "../types.js";
 
-export function resolveFallbackCronSourceDeliveryPlan(
-  job: CronJob,
-  resolvedDelivery: {
-    channel?: string;
-    accountId?: string;
-    to?: string;
-    threadId?: string | number;
-    ok?: boolean;
-  },
-): SourceDeliveryPlan {
-  const deliveryPlan = resolveCronDeliveryPlan(job);
+export type CronSourceDeliveryResolvedTarget = {
+  channel?: string;
+  accountId?: string;
+  to?: string;
+  threadId?: string | number;
+  ok?: boolean;
+};
+
+export function resolveCronSourceDeliveryPlan(params: {
+  deliveryPlan: CronDeliveryPlan;
+  resolvedDelivery: CronSourceDeliveryResolvedTarget;
+}): SourceDeliveryPlan {
   const target = {
-    channel: resolvedDelivery.channel,
-    to: resolvedDelivery.to,
-    accountId: resolvedDelivery.accountId,
-    threadId: resolvedDelivery.threadId,
+    channel: params.resolvedDelivery.channel,
+    to: params.resolvedDelivery.to,
+    accountId: params.resolvedDelivery.accountId,
+    threadId: params.resolvedDelivery.threadId,
   };
 
-  if (deliveryPlan.mode === "webhook") {
+  if (params.deliveryPlan.mode === "webhook") {
     return createSourceDeliveryPlan({
       owner: "none",
       reason: "cron_webhook",
@@ -30,7 +32,7 @@ export function resolveFallbackCronSourceDeliveryPlan(
     });
   }
 
-  if (deliveryPlan.mode === "none") {
+  if (params.deliveryPlan.mode === "none") {
     return createSourceDeliveryPlan({
       owner: "none",
       reason: "cron_none",
@@ -47,7 +49,17 @@ export function resolveFallbackCronSourceDeliveryPlan(
     target,
     messageToolEnabled: true,
     messageToolForced: false,
+    requireExplicitMessageTarget: true,
+    requireExplicitMessageTargetEvidence: true,
     directFallback: true,
-    skipFallbackWhenMessageToolSentToTarget: resolvedDelivery.ok,
+    skipFallbackWhenMessageToolSentToTarget: params.resolvedDelivery.ok,
   });
+}
+
+export function resolveFallbackCronSourceDeliveryPlan(
+  job: CronJob,
+  resolvedDelivery: CronSourceDeliveryResolvedTarget,
+): SourceDeliveryPlan {
+  const deliveryPlan = resolveCronDeliveryPlan(job);
+  return resolveCronSourceDeliveryPlan({ deliveryPlan, resolvedDelivery });
 }


### PR DESCRIPTION
## Summary

Guard against `undefined` `sourceDelivery` in the isolated cron executor to prevent `TypeError: Cannot read properties of undefined (reading 'sourceReplyDeliveryMode')`, and unify the cron source-delivery planner into a single shared helper used by both the normal execution path and the version-skew fallback.

## Problem

Commit `4c613fbfe0` ("refactor(cron): centralize source delivery plan", 2026-05-18) replaced three separate params (`messageChannel`, `sourceReplyDeliveryMode`, `toolPolicy`) with a unified `sourceDelivery: SourceDeliveryPlan` across the lazy-import boundary between `run.ts` and `run-executor.ts`.

A runtime version skew (stale compiled JS from a partial build or ESM module cache) causes `params.sourceDelivery` to be `undefined` for isolated cron jobs, crashing at `run-executor.ts:147`.

## Fix

1. **Unified planner**: Extracted `resolveCronSourceDeliveryPlan` as the single canonical cron source-delivery planner in `source-delivery-fallback.ts`. Both the normal cron execution path (`run.ts`) and the version-skew fallback path (`run-executor.ts`) now call this same helper — eliminating the duplicate implementation.
2. The helper calls `resolveCronDeliveryPlan(job)` to determine the delivery mode from the job config, then delegates to `createSourceDeliveryPlan` with parameters matching **current main's semantics**:
   - **webhook**: `owner: "none"`, message tool **disabled**, no direct fallback
   - **none**: `owner: "none"`, message tool enabled but **not forced**, no direct fallback
   - **announce**: `owner: "direct_fallback"`, message tool enabled but **not forced**, `directDelivery: true`, `skipFallbackWhenMessageToolSentToTarget` from resolved delivery status
3. `resolveFallbackCronSourceDeliveryPlan` is a thin wrapper that derives the `CronDeliveryPlan` from the job and calls the shared helper
4. **Removed all legacy field sniffing** — no `toolPolicy`, `sourceReplyDeliveryMode`, or `messageChannel` reads from stale callers. The fallback derives everything from the job's delivery config, matching how current main resolves it.
5. Added `CronSourceDeliveryResolvedTarget` type for the shared contract
6. Added `logWarn` diagnostic when fallback activates

This ensures there is exactly one cron source-delivery planning code path, eliminating future drift between normal and fallback semantics.

## Tests

20 test cases in `run.source-delivery-guard.test.ts`:

**`resolveFallbackCronSourceDeliveryPlan` unit tests (4 tests):**
1. `delivery.mode "none"` → `owner: "none"`, `reason: "cron_none"`, message tool enabled but not forced, no direct fallback
2. `delivery.mode "announce"` → `owner: "direct_fallback"`, `reason: "cron_announce"`, direct fallback enabled, `skipWhenMessageToolSentToTarget` from `resolvedDelivery.ok`
3. `delivery.mode "webhook"` → `owner: "none"`, `reason: "cron_webhook"`, message tool **disabled**, empty target
4. Isolated agentTurn with no delivery config → defaults to announce behavior

**`resolveCronSourceDeliveryPlan` parity tests (4 tests):**
5. `none` mode: shared helper matches fallback wrapper
6. `announce` mode: shared helper matches fallback wrapper
7. `webhook` mode: shared helper matches fallback wrapper
8. `implicit announce` mode: shared helper matches fallback wrapper

**`createCronPromptExecutor` level (4 tests):**
9. `sourceDelivery: undefined` with `mode: "none"` → falls back with `messageToolForced: false`, `owner: "none"`
10. `sourceDelivery: undefined` with `mode: "announce"` → `direct_fallback` semantics, `forceMessageTool: false`
11. `sourceDelivery: undefined` with `mode: "webhook"` → message tool disabled
12. No delivery config on isolated agentTurn → announce behavior fallback

**`executeCronRun` level (4 tests):**
13. Stale legacy params (`sourceReplyDeliveryMode`, `toolPolicy.forceMessageTool`) → **ignored**, uses job delivery config instead
14. Valid `sourceDelivery` → pass-through, no fallback (regression)
15. Webhook mode → `disableMessageTool: true`, `forceMessageTool: false`
16. Announce mode → `direct_fallback` defaults, `disableMessageTool: false`, `forceMessageTool: false`

## Real behavior proof (current head)

- **Behavior or issue addressed**: Issue #85051 — isolated cron executor crashed with `TypeError: Cannot read properties of undefined (reading 'sourceReplyDeliveryMode')` when a version-skew/stale caller invoked the executor without a `sourceDelivery` argument. This branch guards that path via the shared planner `resolveFallbackCronSourceDeliveryPlan` (reconstructing a valid `SourceDeliveryPlan` from job delivery config + `resolvedDelivery`), and preserves duplicate-announce suppression: in announce mode, when `resolvedDelivery.ok` is missing/undefined it defaults to `true` so `skipFallbackWhenMessageToolSentToTarget` stays on (no double-post).

- **Real environment tested**: Checkout commit `8c684df354ac9cff91e0197d29787e3ed9534b31` (branch `fix/cron-isolated-source-delivery-guard`). Primary clean-room run inside Docker `node:24-bookworm` (Node `v24.16.0`, Linux `aarch64`, fresh `pnpm install --frozen-lockfile` inside the container with host `node_modules` shadowed by an anonymous volume so Linux-native binaries are used). Cross-checked on host: macOS 15 (Darwin 24.3.0) arm64, Node `v24.10.0`, pnpm `11.2.2`. Harness runs `tsx` against the LIVE `src/` source (no mocks of the planner).

- **Failing proof before fix**: The pre-guard upstream/main shape is the raw dereference at `src/cron/isolated-agent/run-executor.ts:182` on `upstream/main`:

  ```
  $ git show upstream/main:src/cron/isolated-agent/run-executor.ts | sed -n '182p'
    const sourceReplyDeliveryMode = params.sourceDelivery.sourceReplyDeliveryMode;
  ```

  `upstream/main` has no `source-delivery-fallback.ts` (the guard does not exist there):

  ```
  $ git show upstream/main:src/cron/isolated-agent/source-delivery-fallback.ts
  fatal: path 'src/cron/isolated-agent/source-delivery-fallback.ts' exists on disk, but not in 'upstream/main'
  ```

  The harness reproduces that exact dereference against a stale-caller params object that omits `sourceDelivery`. It throws the issue's exact error (Docker `node:24-bookworm`):

  ```
  ============================================================
   A. STALE-CALLER CRASH (pre-guard upstream/main dereference)
  ============================================================
  thrown: true
  error.name: TypeError
  error.message: Cannot read properties of undefined (reading 'sourceReplyDeliveryMode')
  PASS: pre-guard deref throws TypeError on omitted sourceDelivery
  PASS: error message matches "Cannot read properties of undefined (reading 'sourceReplyDeliveryMode')"
  ```

- **Exact steps or command run after this patch**:

  ```
  # Docker (primary, clean room)
  docker run --rm -v "$PWD":/repo -v /repo/node_modules -w /repo \
    -e NODE_OPTIONS=--max-old-space-size=8192 node:24-bookworm bash -lc '
      corepack enable
      corepack pnpm install --frozen-lockfile
      node --import tsx repro-sourcedelivery-skew.mts
      node scripts/run-vitest.mjs src/cron/isolated-agent/run.source-delivery-guard.test.ts
      node scripts/run-vitest.mjs src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts'

  # Host (cross-check)
  node --import tsx repro-sourcedelivery-skew.mts
  node scripts/run-vitest.mjs src/cron/isolated-agent/run.source-delivery-guard.test.ts
  node scripts/run-vitest.mjs src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
  ```

- **Evidence after fix**:

  Guarded reconstruction for `announce` / `none` / `webhook` with `sourceDelivery` OMITTED — no crash, valid plans rebuilt (Docker `node:24-bookworm`):

  ```
  ============================================================
   B. GUARDED reconstruction (this branch, sourceDelivery OMITTED)
  ============================================================
  announce plan: {
    "owner": "direct_fallback",
    "reason": "cron_announce",
    "target": { "channel": "messagechat", "to": "room-1" },
    "normalFinal": "visible",
    "messageTool": { "enabled": true, "force": false, "requireExplicitTarget": false, "defaultTarget": true },
    "fallback": { "directDelivery": true, "skipWhenMessageToolSentToTarget": true, "bestEffort": false },
    "progress": { "allowCallbacksWhenSourceDeliverySuppressed": false }
  }
  PASS: announce: no crash on omitted sourceDelivery
  PASS: announce: owner === direct_fallback
  PASS: announce: reason === cron_announce
  PASS: announce: fallback.directDelivery === true
  PASS: announce: target rebuilt from resolvedDelivery
  none plan: {
    "owner": "none",
    "reason": "cron_none",
    "target": { "channel": "messagechat", "to": "room-1", "accountId": "acct-1", "threadId": "thread-1" },
    "normalFinal": "private",
    "messageTool": { "enabled": true, "force": false, "requireExplicitTarget": false, "defaultTarget": true },
    "fallback": { "directDelivery": false, "skipWhenMessageToolSentToTarget": false, "bestEffort": false },
    "progress": { "allowCallbacksWhenSourceDeliverySuppressed": false }
  }
  PASS: none: no crash on omitted sourceDelivery
  PASS: none: owner === none
  PASS: none: reason === cron_none
  PASS: none: messageTool.enabled === true
  PASS: none: messageTool.force === false
  PASS: none: fallback.directDelivery === false
  webhook plan: {
    "owner": "none",
    "reason": "cron_webhook",
    "target": {},
    "normalFinal": "private",
    "messageTool": { "enabled": false, "force": false, "requireExplicitTarget": false, "defaultTarget": false },
    "fallback": { "directDelivery": false, "skipWhenMessageToolSentToTarget": false, "bestEffort": false },
    "progress": { "allowCallbacksWhenSourceDeliverySuppressed": false }
  }
  PASS: webhook: no crash on omitted sourceDelivery
  PASS: webhook: owner === none
  PASS: webhook: reason === cron_webhook
  PASS: webhook: messageTool.enabled === false
  PASS: webhook: target === {}
  ```

  Duplicate-suppression behavior across `resolvedDelivery.ok` variants, plus normal-path/fallback parity:

  ```
  ============================================================
   C. DUP-SUPPRESSION (announce; resolvedDelivery.ok variants)
  ============================================================
  ok=MISSING -> skipWhenMessageToolSentToTarget: true
  PASS: ok MISSING -> skipFallbackWhenMessageToolSentToTarget === true (suppression preserved)
  ok=false   -> skipWhenMessageToolSentToTarget: false
  PASS: ok=false -> skipFallbackWhenMessageToolSentToTarget === false
  ok=true    -> skipWhenMessageToolSentToTarget: true
  PASS: ok=true -> skipFallbackWhenMessageToolSentToTarget === true
  PASS: normal-path planner matches fallback wrapper when ok missing

  ============================================================
   RESULT: 22 passed, 0 failed
  ============================================================
  ```

  Existing regression suites (Docker `node:24-bookworm`):

  ```
  === vitest: source-delivery-guard ===
   ✓ cron src/cron/isolated-agent/run.source-delivery-guard.test.ts (17 tests) 15ms
   Test Files  1 passed (1)
        Tests  17 passed (17)
  [test] passed 1 Vitest shard in 6.41s

  === vitest: double-announce ===
   ✓ cron src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts (68 tests) 218ms
   Test Files  1 passed (1)
        Tests  68 passed (68)
  [test] passed 1 Vitest shard in 3.96s
  ```

  Host cross-check (macOS arm64, Node v24.10.0) — same results: harness `22 passed, 0 failed`; vitest `17 passed (17)` and `68 passed (68)`.

- **Observed result after fix**: With `sourceDelivery` omitted (the version-skew stale-caller path), the pre-guard upstream deref throws the exact `TypeError` from issue #85051, while this branch's `resolveFallbackCronSourceDeliveryPlan` reconstructs a valid `SourceDeliveryPlan` for every delivery mode (`announce` → `direct_fallback`/`cron_announce`, `none` → `none`/`cron_none`, `webhook` → `none`/`cron_webhook`) without crashing. Duplicate-announce suppression is preserved precisely as designed: missing `resolvedDelivery.ok` → `skipFallbackWhenMessageToolSentToTarget === true` (suppression on, so a message-tool send already delivered to the target does NOT trigger a second direct-fallback post); `ok:false` → `false`; `ok:true` → `true`. The normal-path planner (`resolveCronSourceDeliveryPlan`, used by `run.ts`) and the fallback wrapper (`resolveFallbackCronSourceDeliveryPlan`, used by `run-executor.ts`) produce identical plans for the missing-`ok` case, confirming both seams share one policy.

- **What was not tested**: No live Telegram/Discord/transport round-trip was exercised; there is no real message bus in this harness. The proof exercises the planner + executor source-delivery boundary directly at the LIVE source level (the function whose contract the guard protects), plus the colocated Vitest suites that cover the executor wiring (`createCronPromptExecutor` / `executeCronRun`) and the double-announce timer fallback. End-to-end delivery dispatch through an actual channel adapter, and the actual cross-version skew between a stale compiled caller and the new executor in a deployed gateway, were not reproduced.


Fixes #85051
