### PR TITLE
[Fix] Surface gateway connect assembly failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway CLI: surface local post-challenge connect assembly failures immediately instead of waiting for the wrapper timeout. Fixes #68944. (#85253) Thanks @samzong.
 - Codex app-server: reject command overrides that embed Node or package-manager arguments and point users to `appServer.args`, so Windows startup avoids shell parsing failures. (#84417) Thanks @TurboTheTurtle.
 - Agents/Copilot: drop unsafe GitHub Copilot Responses reasoning replay items before send so Telegram direct sessions no longer fail on overlong replay IDs. Fixes #85197. (#85198) Thanks @galiniliev.
 - UI: add accessible tooltips to the topbar color-mode buttons so System, Light, and Dark choices are labeled on hover and focus. (#85227) Thanks @amknight.

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -42,6 +42,20 @@ const eventLoopReadyState = vi.hoisted(() => ({
   },
 }));
 
+const connectAssemblyErrorState = vi.hoisted(() => {
+  const errors = new WeakSet<Error>();
+  return {
+    create(message: string): Error {
+      const error = new Error(message);
+      errors.add(error);
+      return error;
+    },
+    has(value: unknown): value is Error {
+      return value instanceof Error && errors.has(value);
+    },
+  };
+});
+
 let lastClientOptions: {
   url?: string;
   token?: string;
@@ -56,13 +70,14 @@ let lastClientOptions: {
   deviceIdentity?: unknown;
   onHelloOk?: (hello: { features?: { methods?: string[] } }) => void | Promise<void>;
   onClose?: (code: number, reason: string) => void;
+  onConnectError?: (err: Error) => void;
 } | null = null;
 let lastRequestOptions: {
   method?: string;
   params?: unknown;
   opts?: { expectFinal?: boolean; timeoutMs?: number | null };
 } | null = null;
-type StartMode = "hello" | "close" | "silent" | "startup-retry-then-hello";
+type StartMode = "hello" | "close" | "connect-error" | "silent" | "startup-retry-then-hello";
 let startMode: StartMode = "hello";
 let startCalls = 0;
 let closeCode = 1006;
@@ -79,6 +94,7 @@ vi.mock("./client.js", () => ({
     }
     return undefined;
   },
+  isGatewayConnectAssemblyError: (value: unknown) => connectAssemblyErrorState.has(value),
   GatewayClient: class {
     constructor(opts: {
       url?: string;
@@ -92,6 +108,7 @@ vi.mock("./client.js", () => ({
       scopes?: string[];
       onHelloOk?: (hello: { features?: { methods?: string[] } }) => void | Promise<void>;
       onClose?: (code: number, reason: string) => void;
+      onConnectError?: (err: Error) => void;
     }) {
       lastClientOptions = opts;
     }
@@ -117,6 +134,10 @@ vi.mock("./client.js", () => ({
             methods: helloMethods,
           },
         });
+      } else if (startMode === "connect-error") {
+        lastClientOptions?.onConnectError?.(
+          connectAssemblyErrorState.create("device private key invalid"),
+        );
       } else if (startMode === "close") {
         lastClientOptions?.onClose?.(closeCode, closeReason);
       }
@@ -157,6 +178,7 @@ class StubGatewayClient {
     scopes?: string[];
     onHelloOk?: (hello: { features?: { methods?: string[] } }) => void | Promise<void>;
     onClose?: (code: number, reason: string) => void;
+    onConnectError?: (err: Error) => void;
   }) {
     lastClientOptions = opts;
   }
@@ -182,6 +204,10 @@ class StubGatewayClient {
           methods: helloMethods,
         },
       });
+    } else if (startMode === "connect-error") {
+      lastClientOptions?.onConnectError?.(
+        connectAssemblyErrorState.create("device private key invalid"),
+      );
     } else if (startMode === "close") {
       lastClientOptions?.onClose?.(closeCode, closeReason);
     }
@@ -964,6 +990,20 @@ describe("callGateway error details", () => {
     await expect(callGateway({ method: "health" })).resolves.toEqual({ ok: true });
 
     expect(lastRequestOptions?.method).toBe("health");
+  });
+
+  it("rejects immediately when the client reports a connect error", async () => {
+    startMode = "connect-error";
+    setLocalLoopbackGatewayConfig();
+
+    let err: unknown;
+    await callGateway({ method: "health", timeoutMs: 10_000 }).catch((caught) => {
+      err = caught;
+    });
+
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toBe("device private key invalid");
+    expect(lastRequestOptions).toBeNull();
   });
 
   it("includes connection details on timeout", async () => {

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -20,7 +20,11 @@ import {
 import { resolveSafeTimeoutDelayMs } from "../utils/timer-delay.js";
 import { VERSION } from "../version.js";
 import { startGatewayClientWhenEventLoopReady } from "./client-start-readiness.js";
-import { GatewayClient, type GatewayClientOptions } from "./client.js";
+import {
+  GatewayClient,
+  isGatewayConnectAssemblyError,
+  type GatewayClientOptions,
+} from "./client.js";
 import {
   buildGatewayConnectionDetailsWithResolvers,
   type GatewayConnectionDetails,
@@ -738,6 +742,13 @@ async function executeGatewayRequestWithScopes<T>(params: {
             connectionDetails: params.connectionDetails,
           }),
         );
+      },
+      onConnectError: (err) => {
+        if (settled || !isGatewayConnectAssemblyError(err)) {
+          return;
+        }
+        ignoreClose = true;
+        stop(err);
       },
     });
 

--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -1,4 +1,5 @@
 import { Buffer } from "node:buffer";
+import { generateKeyPairSync } from "node:crypto";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { DeviceIdentity } from "../infra/device-identity.js";
 import { captureEnv } from "../test-utils/env.js";
@@ -188,10 +189,11 @@ type GatewayClientModule = typeof import("./client.js");
 type GatewayClientInstance = InstanceType<GatewayClientModule["GatewayClient"]>;
 
 let GatewayClient: GatewayClientModule["GatewayClient"];
+let isGatewayConnectAssemblyError: GatewayClientModule["isGatewayConnectAssemblyError"];
 
 async function loadGatewayClientModule() {
   vi.resetModules();
-  ({ GatewayClient } = await import("./client.js"));
+  ({ GatewayClient, isGatewayConnectAssemblyError } = await import("./client.js"));
 }
 
 function getLatestWs(): MockWebSocket {
@@ -248,10 +250,11 @@ function createClientWithIdentity(
   onClose: (code: number, reason: string) => void,
   overrides: Partial<ConstructorParameters<typeof GatewayClient>[0]> = {},
 ) {
+  const { privateKey, publicKey } = generateKeyPairSync("ed25519");
   const identity: DeviceIdentity = {
     deviceId,
-    privateKeyPem: "private-key", // pragma: allowlist secret
-    publicKeyPem: "public-key",
+    privateKeyPem: privateKey.export({ type: "pkcs8", format: "pem" }).toString(),
+    publicKeyPem: publicKey.export({ type: "spki", format: "pem" }).toString(),
   };
   return new GatewayClient({
     url: "ws://127.0.0.1:18789",
@@ -836,6 +839,45 @@ describe("GatewayClient close handling", () => {
   });
 });
 
+describe("GatewayClient message dispatch", () => {
+  beforeEach(() => {
+    wsInstances.length = 0;
+    logDebugMock.mockClear();
+  });
+
+  it("keeps event callback errors inside message dispatch", () => {
+    const onEvent = vi.fn(() => {
+      throw new Error("event callback failed");
+    });
+    const client = new GatewayClient({
+      url: "ws://127.0.0.1:18789",
+      deviceIdentity: null,
+      onEvent,
+    });
+
+    try {
+      client.start();
+      const ws = getLatestWs();
+
+      expect(() =>
+        ws.emitMessage(
+          JSON.stringify({
+            type: "event",
+            event: "tick",
+            payload: {},
+          }),
+        ),
+      ).not.toThrow();
+      expect(onEvent).toHaveBeenCalledOnce();
+      expect(logDebugMock).toHaveBeenCalledWith(
+        "gateway client event handler error: Error: event callback failed",
+      );
+    } finally {
+      client.stop();
+    }
+  });
+});
+
 describe("GatewayClient connect auth payload", () => {
   beforeEach(() => {
     vi.useRealTimers();
@@ -926,6 +968,47 @@ describe("GatewayClient connect auth payload", () => {
     ws.emitOpen();
     return { ws, connect: connectRequestFrom(ws) };
   }
+
+  it("surfaces connect assembly errors instead of waiting for the wrapper timeout", async () => {
+    vi.useFakeTimers();
+    let client: GatewayClientInstance | null = null;
+    try {
+      const onClose = vi.fn();
+      const onConnectError = vi.fn();
+      client = new GatewayClient({
+        url: "ws://127.0.0.1:18789",
+        token: "shared-token",
+        deviceIdentity: {
+          deviceId: "bad-device",
+          privateKeyPem: "not a pem",
+          publicKeyPem: "not a pem",
+        },
+        onClose,
+        onConnectError,
+      });
+
+      client.start();
+      const ws = getLatestWs();
+      ws.emitOpen();
+      emitConnectChallenge(ws);
+
+      expect(ws.sent.some((frame) => frame.includes('"method":"connect"'))).toBe(false);
+      const error = firstMockArg(onConnectError, "connect error") as Error;
+      expect(error).toBeInstanceOf(Error);
+      expect(error.message).not.toContain("gateway request timeout");
+      expect(isGatewayConnectAssemblyError(error)).toBe(true);
+      expect(ws.lastClose).toEqual({ code: 1008, reason: "connect failed" });
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(wsInstances).toHaveLength(1);
+      expect(logErrorMock).toHaveBeenCalledWith(expect.stringContaining("gateway connect failed:"));
+      expect(logDebugMock).not.toHaveBeenCalledWith(
+        expect.stringContaining("gateway client parse error:"),
+      );
+    } finally {
+      client?.stop();
+      vi.useRealTimers();
+    }
+  });
 
   function emitConnectFailure(
     ws: MockWebSocket,

--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -253,8 +253,8 @@ function createClientWithIdentity(
   const { privateKey, publicKey } = generateKeyPairSync("ed25519");
   const identity: DeviceIdentity = {
     deviceId,
-    privateKeyPem: privateKey.export({ type: "pkcs8", format: "pem" }).toString(),
-    publicKeyPem: publicKey.export({ type: "spki", format: "pem" }).toString(),
+    privateKeyPem: privateKey.export({ type: "pkcs8", format: "pem" }),
+    publicKeyPem: publicKey.export({ type: "spki", format: "pem" }),
   };
   return new GatewayClient({
     url: "ws://127.0.0.1:18789",
@@ -1007,6 +1007,35 @@ describe("GatewayClient connect auth payload", () => {
     } finally {
       client?.stop();
       vi.useRealTimers();
+    }
+  });
+
+  it("keeps connect error callback throws inside challenge dispatch", () => {
+    const onConnectError = vi.fn(() => {
+      throw new Error("connect callback failed");
+    });
+    const client = new GatewayClient({
+      url: "ws://127.0.0.1:18789",
+      deviceIdentity: null,
+      onConnectError,
+    });
+
+    try {
+      client.start();
+      const ws = getLatestWs();
+      ws.emitOpen();
+
+      expect(() => emitConnectChallenge(ws, " ")).not.toThrow();
+      expect(onConnectError).toHaveBeenCalledOnce();
+      expect(ws.lastClose).toEqual({
+        code: 1008,
+        reason: "connect challenge missing nonce",
+      });
+      expect(logDebugMock).toHaveBeenCalledWith(
+        "gateway client connect error handler error: Error: connect callback failed",
+      );
+    } finally {
+      client.stop();
     }
   });
 

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -117,6 +117,27 @@ export class GatewayClientRequestError extends Error {
   }
 }
 
+const GATEWAY_CONNECT_ASSEMBLY_ERROR = Symbol("gateway.connectAssemblyError");
+
+type GatewayConnectAssemblyError = Error & {
+  [GATEWAY_CONNECT_ASSEMBLY_ERROR]?: true;
+};
+
+function markGatewayConnectAssemblyError(error: Error): Error {
+  Object.defineProperty(error, GATEWAY_CONNECT_ASSEMBLY_ERROR, {
+    configurable: true,
+    value: true,
+  });
+  return error;
+}
+
+export function isGatewayConnectAssemblyError(value: unknown): value is Error {
+  return (
+    value instanceof Error &&
+    (value as GatewayConnectAssemblyError)[GATEWAY_CONNECT_ASSEMBLY_ERROR] === true
+  );
+}
+
 export type GatewayClientOptions = {
   url?: string; // ws://127.0.0.1:18789
   connectChallengeTimeoutMs?: number;
@@ -516,93 +537,108 @@ export class GatewayClient {
       this.ws?.close(1008, "connect challenge missing nonce");
       return;
     }
-    this.connectSent = true;
-    this.clearConnectChallengeTimeout();
     const role = this.opts.role ?? "operator";
-    const {
-      authToken,
-      authBootstrapToken,
-      authDeviceToken,
-      authPassword,
-      authApprovalRuntimeToken,
-      signatureToken,
-      resolvedDeviceToken,
-      storedToken,
-      storedScopes,
-      usingStoredDeviceToken,
-    } = this.selectConnectAuth(role);
-    if (this.pendingDeviceTokenRetry && authDeviceToken) {
-      this.pendingDeviceTokenRetry = false;
-    }
-    const auth =
-      authToken ||
-      authBootstrapToken ||
-      authPassword ||
-      resolvedDeviceToken ||
-      authApprovalRuntimeToken
-        ? {
-            token: authToken,
-            bootstrapToken: authBootstrapToken,
-            deviceToken: authDeviceToken ?? resolvedDeviceToken,
-            password: authPassword,
-            approvalRuntimeToken: authApprovalRuntimeToken,
-          }
-        : undefined;
-    const signedAtMs = Date.now();
-    const scopes = this.resolveConnectScopes({
-      usingStoredDeviceToken,
-      storedScopes,
-    });
-    const platform = this.opts.platform ?? process.platform;
-    const device = (() => {
-      if (!this.opts.deviceIdentity) {
-        return undefined;
+    let authApprovalRuntimeToken: string | undefined;
+    let resolvedDeviceToken: string | undefined;
+    let storedToken: string | undefined;
+    let usingStoredDeviceToken: boolean | undefined;
+    let params: ConnectParams;
+    try {
+      const {
+        authToken,
+        authBootstrapToken,
+        authDeviceToken,
+        authPassword,
+        authApprovalRuntimeToken: selectedAuthApprovalRuntimeToken,
+        signatureToken,
+        resolvedDeviceToken: selectedResolvedDeviceToken,
+        storedToken: selectedStoredToken,
+        storedScopes,
+        usingStoredDeviceToken: selectedUsingStoredDeviceToken,
+      } = this.selectConnectAuth(role);
+      authApprovalRuntimeToken = selectedAuthApprovalRuntimeToken;
+      resolvedDeviceToken = selectedResolvedDeviceToken;
+      storedToken = selectedStoredToken;
+      usingStoredDeviceToken = selectedUsingStoredDeviceToken;
+      if (this.pendingDeviceTokenRetry && authDeviceToken) {
+        this.pendingDeviceTokenRetry = false;
       }
-      const payload = buildDeviceAuthPayloadV3({
-        deviceId: this.opts.deviceIdentity.deviceId,
-        clientId: this.opts.clientName ?? GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
-        clientMode: this.opts.mode ?? GATEWAY_CLIENT_MODES.BACKEND,
+      const auth =
+        authToken ||
+        authBootstrapToken ||
+        authPassword ||
+        resolvedDeviceToken ||
+        authApprovalRuntimeToken
+          ? {
+              token: authToken,
+              bootstrapToken: authBootstrapToken,
+              deviceToken: authDeviceToken ?? resolvedDeviceToken,
+              password: authPassword,
+              approvalRuntimeToken: authApprovalRuntimeToken,
+            }
+          : undefined;
+      const signedAtMs = Date.now();
+      const scopes = this.resolveConnectScopes({
+        usingStoredDeviceToken,
+        storedScopes,
+      });
+      const platform = this.opts.platform ?? process.platform;
+      const device = (() => {
+        if (!this.opts.deviceIdentity) {
+          return undefined;
+        }
+        const payload = buildDeviceAuthPayloadV3({
+          deviceId: this.opts.deviceIdentity.deviceId,
+          clientId: this.opts.clientName ?? GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
+          clientMode: this.opts.mode ?? GATEWAY_CLIENT_MODES.BACKEND,
+          role,
+          scopes,
+          signedAtMs,
+          token: signatureToken ?? null,
+          nonce,
+          platform,
+          deviceFamily: this.opts.deviceFamily,
+        });
+        const signature = signDevicePayload(this.opts.deviceIdentity.privateKeyPem, payload);
+        return {
+          id: this.opts.deviceIdentity.deviceId,
+          publicKey: publicKeyRawBase64UrlFromPem(this.opts.deviceIdentity.publicKeyPem),
+          signature,
+          signedAt: signedAtMs,
+          nonce,
+        };
+      })();
+      params = {
+        minProtocol: this.opts.minProtocol ?? MIN_CLIENT_PROTOCOL_VERSION,
+        maxProtocol: this.opts.maxProtocol ?? PROTOCOL_VERSION,
+        client: {
+          id: this.opts.clientName ?? GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
+          displayName: this.opts.clientDisplayName,
+          version: this.opts.clientVersion ?? VERSION,
+          platform,
+          deviceFamily: this.opts.deviceFamily,
+          mode: this.opts.mode ?? GATEWAY_CLIENT_MODES.BACKEND,
+          instanceId: this.opts.instanceId,
+        },
+        caps: Array.isArray(this.opts.caps) ? this.opts.caps : [],
+        commands: Array.isArray(this.opts.commands) ? this.opts.commands : undefined,
+        permissions:
+          this.opts.permissions && typeof this.opts.permissions === "object"
+            ? this.opts.permissions
+            : undefined,
+        pathEnv: this.opts.pathEnv,
+        auth,
         role,
         scopes,
-        signedAtMs,
-        token: signatureToken ?? null,
-        nonce,
-        platform,
-        deviceFamily: this.opts.deviceFamily,
-      });
-      const signature = signDevicePayload(this.opts.deviceIdentity.privateKeyPem, payload);
-      return {
-        id: this.opts.deviceIdentity.deviceId,
-        publicKey: publicKeyRawBase64UrlFromPem(this.opts.deviceIdentity.publicKeyPem),
-        signature,
-        signedAt: signedAtMs,
-        nonce,
+        device,
       };
-    })();
-    const params: ConnectParams = {
-      minProtocol: this.opts.minProtocol ?? MIN_CLIENT_PROTOCOL_VERSION,
-      maxProtocol: this.opts.maxProtocol ?? PROTOCOL_VERSION,
-      client: {
-        id: this.opts.clientName ?? GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
-        displayName: this.opts.clientDisplayName,
-        version: this.opts.clientVersion ?? VERSION,
-        platform,
-        deviceFamily: this.opts.deviceFamily,
-        mode: this.opts.mode ?? GATEWAY_CLIENT_MODES.BACKEND,
-        instanceId: this.opts.instanceId,
-      },
-      caps: Array.isArray(this.opts.caps) ? this.opts.caps : [],
-      commands: Array.isArray(this.opts.commands) ? this.opts.commands : undefined,
-      permissions:
-        this.opts.permissions && typeof this.opts.permissions === "object"
-          ? this.opts.permissions
-          : undefined,
-      pathEnv: this.opts.pathEnv,
-      auth,
-      role,
-      scopes,
-      device,
-    };
+    } catch (err) {
+      this.handleConnectFailure(err);
+      return;
+    }
+
+    this.connectSent = true;
+    this.clearConnectChallengeTimeout();
 
     void this.request<HelloOk>("connect", params)
       .then((helloOk) => {
@@ -692,6 +728,20 @@ export class GatewayClient {
         }
         this.ws?.close(1008, "connect failed");
       });
+  }
+
+  private handleConnectFailure(err: unknown) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    this.clearConnectChallengeTimeout();
+    this.closed = true;
+    this.opts.onConnectError?.(markGatewayConnectAssemblyError(error));
+    const msg = `gateway connect failed: ${formatGatewayClientErrorForLog(error)}`;
+    if (this.opts.mode === GATEWAY_CLIENT_MODES.PROBE || isGatewayClientStoppedError(error)) {
+      logDebug(msg);
+    } else {
+      logError(msg);
+    }
+    this.ws?.close(1008, "connect failed");
   }
 
   private resolveConnectScopes(params: {
@@ -889,25 +939,31 @@ export class GatewayClient {
   }
 
   private handleMessage(raw: string) {
+    let parsed: unknown;
     try {
-      const parsed = JSON.parse(raw);
-      if (validateEventFrame(parsed)) {
-        this.lastTick = Date.now();
-        const evt = parsed;
-        if (evt.event === "connect.challenge") {
-          const payload = evt.payload as { nonce?: unknown } | undefined;
-          const nonce = payload && typeof payload.nonce === "string" ? payload.nonce : null;
-          if (!nonce || nonce.trim().length === 0) {
-            this.opts.onConnectError?.(new Error("gateway connect challenge missing nonce"));
-            this.ws?.close(1008, "connect challenge missing nonce");
-            return;
-          }
-          this.connectNonce = nonce.trim();
-          if (this.socketOpened) {
-            this.sendConnect();
-          }
+      parsed = JSON.parse(raw);
+    } catch (err) {
+      logDebug(`gateway client parse error: ${formatGatewayClientErrorForLog(err)}`);
+      return;
+    }
+    if (validateEventFrame(parsed)) {
+      this.lastTick = Date.now();
+      const evt = parsed;
+      if (evt.event === "connect.challenge") {
+        const payload = evt.payload as { nonce?: unknown } | undefined;
+        const nonce = payload && typeof payload.nonce === "string" ? payload.nonce : null;
+        if (!nonce || nonce.trim().length === 0) {
+          this.opts.onConnectError?.(new Error("gateway connect challenge missing nonce"));
+          this.ws?.close(1008, "connect challenge missing nonce");
           return;
         }
+        this.connectNonce = nonce.trim();
+        if (this.socketOpened) {
+          this.sendConnect();
+        }
+        return;
+      }
+      try {
         const seq = typeof evt.seq === "number" ? evt.seq : null;
         if (seq !== null) {
           if (this.lastSeq !== null && seq > this.lastSeq + 1) {
@@ -919,40 +975,40 @@ export class GatewayClient {
           this.lastTick = Date.now();
         }
         this.opts.onEvent?.(evt);
+      } catch (err) {
+        logDebug(`gateway client event handler error: ${formatGatewayClientErrorForLog(err)}`);
+      }
+      return;
+    }
+    if (validateResponseFrame(parsed)) {
+      this.lastTick = Date.now();
+      const pending = this.pending.get(parsed.id);
+      if (!pending) {
         return;
       }
-      if (validateResponseFrame(parsed)) {
-        this.lastTick = Date.now();
-        const pending = this.pending.get(parsed.id);
-        if (!pending) {
-          return;
-        }
-        // If the payload is an ack with status accepted, keep waiting for final.
-        const payload = parsed.payload as { status?: unknown } | undefined;
-        const status = payload?.status;
-        if (pending.expectFinal && status === "accepted") {
-          return;
-        }
-        this.pending.delete(parsed.id);
-        if (pending.timeout) {
-          clearTimeout(pending.timeout);
-        }
-        if (parsed.ok) {
-          pending.resolve(parsed.payload);
-        } else {
-          pending.reject(
-            new GatewayClientRequestError({
-              code: parsed.error?.code,
-              message: parsed.error?.message ?? "unknown error",
-              details: parsed.error?.details,
-              retryable: parsed.error?.retryable,
-              retryAfterMs: parsed.error?.retryAfterMs,
-            }),
-          );
-        }
+      // If the payload is an ack with status accepted, keep waiting for final.
+      const payload = parsed.payload as { status?: unknown } | undefined;
+      const status = payload?.status;
+      if (pending.expectFinal && status === "accepted") {
+        return;
       }
-    } catch (err) {
-      logDebug(`gateway client parse error: ${formatGatewayClientErrorForLog(err)}`);
+      this.pending.delete(parsed.id);
+      if (pending.timeout) {
+        clearTimeout(pending.timeout);
+      }
+      if (parsed.ok) {
+        pending.resolve(parsed.payload);
+      } else {
+        pending.reject(
+          new GatewayClientRequestError({
+            code: parsed.error?.code,
+            message: parsed.error?.message ?? "unknown error",
+            details: parsed.error?.details,
+            retryable: parsed.error?.retryable,
+            retryAfterMs: parsed.error?.retryAfterMs,
+          }),
+        );
+      }
     }
   }
 

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -292,7 +292,7 @@ export class GatewayClient {
     this.connectSent = false;
     const url = this.opts.url ?? DEFAULT_GATEWAY_CLIENT_URL;
     if (this.opts.tlsFingerprint && !url.startsWith("wss://")) {
-      this.opts.onConnectError?.(new Error("gateway tls fingerprint requires wss:// gateway url"));
+      this.notifyConnectError(new Error("gateway tls fingerprint requires wss:// gateway url"));
       return;
     }
 
@@ -318,7 +318,7 @@ export class GatewayClient {
             : "Break-glass (trusted private networks only): set OPENCLAW_ALLOW_INSECURE_PRIVATE_WS=1. ") +
           "Run `openclaw doctor --fix` for guidance.",
       );
-      this.opts.onConnectError?.(error);
+      this.notifyConnectError(error);
       return;
     }
     // Allow node screen snapshots and other large responses.
@@ -367,7 +367,7 @@ export class GatewayClient {
       if (url.startsWith("wss://") && this.opts.tlsFingerprint) {
         const tlsError = this.validateTlsFingerprint();
         if (tlsError) {
-          this.opts.onConnectError?.(tlsError);
+          this.notifyConnectError(tlsError);
           this.ws?.close(1008, tlsError.message);
           return;
         }
@@ -432,7 +432,7 @@ export class GatewayClient {
     ws.on("error", (err) => {
       logDebug(`gateway client error: ${formatGatewayClientErrorForLog(err)}`);
       if (!this.connectSent) {
-        this.opts.onConnectError?.(err instanceof Error ? err : new Error(String(err)));
+        this.notifyConnectError(err instanceof Error ? err : new Error(String(err)));
       }
     });
   }
@@ -533,7 +533,7 @@ export class GatewayClient {
     }
     const nonce = normalizeOptionalString(this.connectNonce) ?? "";
     if (!nonce) {
-      this.opts.onConnectError?.(new Error("gateway connect challenge missing nonce"));
+      this.notifyConnectError(new Error("gateway connect challenge missing nonce"));
       this.ws?.close(1008, "connect challenge missing nonce");
       return;
     }
@@ -719,7 +719,7 @@ export class GatewayClient {
           this.ws?.close(1008, "connect retry");
           return;
         }
-        this.opts.onConnectError?.(err instanceof Error ? err : new Error(String(err)));
+        this.notifyConnectError(err instanceof Error ? err : new Error(String(err)));
         const msg = `gateway connect failed: ${formatGatewayClientErrorForLog(err)}`;
         if (this.opts.mode === GATEWAY_CLIENT_MODES.PROBE || isGatewayClientStoppedError(err)) {
           logDebug(msg);
@@ -734,7 +734,7 @@ export class GatewayClient {
     const error = err instanceof Error ? err : new Error(String(err));
     this.clearConnectChallengeTimeout();
     this.closed = true;
-    this.opts.onConnectError?.(markGatewayConnectAssemblyError(error));
+    this.notifyConnectError(markGatewayConnectAssemblyError(error));
     const msg = `gateway connect failed: ${formatGatewayClientErrorForLog(error)}`;
     if (this.opts.mode === GATEWAY_CLIENT_MODES.PROBE || isGatewayClientStoppedError(error)) {
       logDebug(msg);
@@ -742,6 +742,16 @@ export class GatewayClient {
       logError(msg);
     }
     this.ws?.close(1008, "connect failed");
+  }
+
+  private notifyConnectError(error: Error) {
+    try {
+      this.opts.onConnectError?.(error);
+    } catch (err) {
+      logDebug(
+        `gateway client connect error handler error: ${formatGatewayClientErrorForLog(err)}`,
+      );
+    }
   }
 
   private resolveConnectScopes(params: {
@@ -953,7 +963,7 @@ export class GatewayClient {
         const payload = evt.payload as { nonce?: unknown } | undefined;
         const nonce = payload && typeof payload.nonce === "string" ? payload.nonce : null;
         if (!nonce || nonce.trim().length === 0) {
-          this.opts.onConnectError?.(new Error("gateway connect challenge missing nonce"));
+          this.notifyConnectError(new Error("gateway connect challenge missing nonce"));
           this.ws?.close(1008, "connect challenge missing nonce");
           return;
         }
@@ -1047,7 +1057,7 @@ export class GatewayClient {
         return;
       }
       const elapsedMs = Date.now() - armedAt;
-      this.opts.onConnectError?.(
+      this.notifyConnectError(
         new Error(
           `gateway connect challenge timeout (waited ${elapsedMs}ms, limit ${connectChallengeTimeoutMs}ms)`,
         ),


### PR DESCRIPTION
## Summary

- Problem: `GatewayClient` could swallow post-challenge connect assembly failures as debug-only parse errors, leaving `callGateway()` to wait for the outer timeout.
- Solution: separate JSON parsing from message dispatch, surface connect assembly failures through a terminal client failure path, and let `callGateway()` fail immediately for that internal error class.
- What changed: connect params are assembled before `connectSent`/watchdog state changes, assembly failures are internally marked, event callback errors stay contained, and tests now use real Ed25519 identities where signing is expected.
- What did NOT change (scope boundary): no SDK transport callback expansion, no public callback metadata change, and existing socket close / challenge timeout / server connect-rejection behavior remains on the previous transport-error paths.

## Motivation

- Fixes a real Gateway CLI failure mode where a local device identity/signing error after `connect.challenge` appeared to users as a timeout instead of the root connect error.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #68944
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior addressed: malformed post-challenge device identity signing now rejects immediately instead of waiting for the wrapper timeout.
- Real environment tested: Darwin 25.4.0 arm64, Node v25.9.0, local checkout, real `ws.WebSocketServer`, real `callGateway()`.
- Exact steps or command run after this patch: ran `node --import tsx --input-type=module` with an inline script that started a local WebSocket gateway, sent `connect.challenge`, then called `callGateway({ url, token, method: "health", timeoutMs: 10000, deviceIdentity: invalidPemIdentity })`.
- Evidence after fix:

```text
gateway connect failed: Error: error:1E08010C:DECODER routines::unsupported
real-websocket-callGateway: rejected in 40ms: error:1E08010C:DECODER routines::unsupported
connect frames sent: 0
```

- Observed result after fix: the real transport path rejected in 40ms with the crypto/root error, and no `connect` frame was sent after the bad local assembly.
- What was not tested: remote hosted Gateway, OS matrix, packaged binary.
- Before evidence: source-level repro before the patch showed the same assembly failure was caught by `handleMessage()` as `gateway client parse error`, while `callGateway()` had no connect-error observer for that path.

## Root Cause (if applicable)

- Root cause: `GatewayClient.handleMessage()` used one broad `try/catch` for JSON parsing, event dispatch, and `sendConnect()`. If `sendConnect()` threw while building signed connect params, the exception was mislabeled as a parse error and did not reach `callGateway()`.
- Missing detection / guardrail: there was no regression that forced a post-challenge local connect assembly failure to settle the wrapper before the outer timeout.
- Contributing context (if known): tests used placeholder key strings in paths that did not exercise the real signing contract.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/client.test.ts`, `src/gateway/call.test.ts`, `src/gateway/gateway-cli-backend.connect.test.ts`
- Scenario the test should lock in: post-challenge connect assembly errors do not send `connect`, are internally marked, close terminally without reconnect churn, and make `callGateway()` reject immediately.
- Why this is the smallest reliable guardrail: the bug lives between the client handshake dispatch and the wrapper promise settlement, so focused Gateway client/wrapper tests catch it without broad product setup.
- Existing test that already covers this (if any): `src/gateway/gateway-cli-backend.connect.test.ts` covers the successful real WebSocket connect path.
- If no new test is added, why not: N/A - new regression tests were added.

## User-visible / Behavior Changes

Gateway CLI callers now see the underlying local connect assembly error immediately for this failure path instead of a misleading gateway timeout.

## Diagram (if applicable)

```text
Before:
connect.challenge -> sendConnect throws -> handleMessage parse-error catch -> callGateway timeout

After:
connect.challenge -> connect assembly fails -> marked connect failure -> callGateway rejects immediately
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Darwin 25.4.0 arm64
- Runtime/container: Node v25.9.0
- Model/provider: N/A
- Integration/channel (if any): Gateway WebSocket transport
- Relevant config (redacted): local WebSocket URL and synthetic token only

### Steps

1. Start a real local `ws.WebSocketServer` that emits `connect.challenge`.
2. Call `callGateway()` against it with an invalid PEM `deviceIdentity` and `timeoutMs: 10000`.
3. Confirm the call rejects immediately and the server receives no `connect` frame.

### Expected

- `callGateway()` rejects with the root local assembly error before the outer timeout.

### Actual

- `callGateway()` rejected in 40ms with `error:1E08010C:DECODER routines::unsupported`, and `connect frames sent: 0`.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What I personally verified (not just CI), and how:

- Verified scenarios: malformed device identity failure through real WebSocket transport; focused Gateway client/wrapper regression tests; successful minimal real WebSocket connect helper path.
- Edge cases checked: no `connect` frame after local assembly failure; no reconnect loop after deterministic assembly failure; event callback exceptions stay contained in message dispatch.
- What I did **not** verify: remote Gateway deployment, packaged binary, OS matrix.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: narrowing `callGateway()` to fail immediately only for internally marked assembly errors could miss other connect callback errors.
  - Mitigation: this intentionally preserves existing close/timeout behavior for socket errors, server connect rejections, and challenge timeout paths while fixing the proven local assembly hole.

## Verification

- `node scripts/run-vitest.mjs src/gateway/client.test.ts src/gateway/call.test.ts src/gateway/gateway-cli-backend.connect.test.ts --run` (7 files, 350 tests passed)
- `node_modules/.bin/oxfmt --check --threads=1 src/gateway/client.ts src/gateway/call.ts src/gateway/client.test.ts src/gateway/call.test.ts`
- `git diff --check`
- `AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --mode local` (clean)
- `pre-ship --committed` manual gate: default `codex-style`, `coderabbit-style`, and `greptileai-style`; no MUST-FIX or deferred findings
