### PR TITLE
[Fix] Preserve deferred lifecycle errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway: preserve deferred lifecycle-error cleanup across later non-terminal events so provider timeouts can persist failed session state instead of leaving sessions stuck running. (#85256, fixes #63819) Thanks @samzong.
 - Agents/subagents: report tool-only child progress during timeout summaries instead of showing no visible output.
 - Telegram/ACP: preserve explicit `:topic:` conversation suffixes when inbound ACP targets do not carry a separate thread id.
 - Ollama: bypass the managed proxy for configured local embedding origins while keeping SSRF guardrails on unconfigured targets. Thanks @Kaspre.

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -2110,6 +2110,117 @@ describe("agent event handler", () => {
     expect(agentRunSeq.has("run-terminal-error")).toBe(false);
   });
 
+  it("keeps deferred lifecycle-error cleanup across later non-terminal events", () => {
+    vi.useFakeTimers();
+    const { broadcast, clearAgentRunContext, agentRunSeq, handler } = createHarness({
+      resolveSessionKeyForRun: () => "session-terminal-error",
+      lifecycleErrorRetryGraceMs: 100,
+    });
+    registerAgentRunContext("run-terminal-late-tool", {
+      sessionKey: "session-terminal-error",
+    });
+
+    handler({
+      runId: "run-terminal-late-tool",
+      seq: 1,
+      stream: "lifecycle",
+      ts: Date.now(),
+      data: { phase: "start" },
+    });
+    handler({
+      runId: "run-terminal-late-tool",
+      seq: 2,
+      stream: "lifecycle",
+      ts: Date.now(),
+      data: { phase: "error", error: "request timed out" },
+    });
+    handler({
+      runId: "run-terminal-late-tool",
+      seq: 3,
+      stream: "tool",
+      ts: Date.now(),
+      data: { phase: "result", name: "exec" },
+    });
+
+    vi.advanceTimersByTime(99);
+
+    expect(clearAgentRunContext).not.toHaveBeenCalled();
+    expect(agentRunSeq.get("run-terminal-late-tool")).toBe(3);
+    expect(
+      chatBroadcastCalls(broadcast).some(
+        ([, payload]) => (payload as { state?: string }).state === "error",
+      ),
+    ).toBe(false);
+
+    vi.advanceTimersByTime(1);
+
+    const finalPayload = chatBroadcastCalls(broadcast).at(-1)?.[1] as {
+      state?: string;
+      runId?: string;
+      errorMessage?: string;
+    };
+    expect(finalPayload.state).toBe("error");
+    expect(finalPayload.runId).toBe("run-terminal-late-tool");
+    expect(finalPayload.errorMessage).toContain("request timed out");
+    expect(clearAgentRunContext).toHaveBeenCalledWith("run-terminal-late-tool");
+    expect(agentRunSeq.has("run-terminal-late-tool")).toBe(false);
+    expect(
+      persistGatewaySessionLifecycleEventMock.mock.calls.some(
+        ([params]) =>
+          (params as { event?: { data?: { phase?: string } } }).event?.data?.phase === "error",
+      ),
+    ).toBe(true);
+  });
+
+  it("cancels deferred lifecycle-error cleanup when the run restarts", () => {
+    vi.useFakeTimers();
+    const { broadcast, clearAgentRunContext, agentRunSeq, handler } = createHarness({
+      resolveSessionKeyForRun: () => "session-terminal-retry",
+      lifecycleErrorRetryGraceMs: 100,
+    });
+    registerAgentRunContext("run-terminal-retry", {
+      sessionKey: "session-terminal-retry",
+    });
+
+    handler({
+      runId: "run-terminal-retry",
+      seq: 1,
+      stream: "lifecycle",
+      ts: Date.now(),
+      data: { phase: "start" },
+    });
+    handler({
+      runId: "run-terminal-retry",
+      seq: 2,
+      stream: "lifecycle",
+      ts: Date.now(),
+      data: { phase: "error", error: "attempt failed" },
+    });
+    handler({
+      runId: "run-terminal-retry",
+      seq: 3,
+      stream: "lifecycle",
+      ts: Date.now(),
+      data: { phase: "start" },
+    });
+
+    vi.advanceTimersByTime(100);
+
+    expect(
+      chatBroadcastCalls(broadcast).some(
+        ([, payload]) => (payload as { state?: string }).state === "error",
+      ),
+    ).toBe(false);
+    expect(clearAgentRunContext).not.toHaveBeenCalled();
+    expect(agentRunSeq.get("run-terminal-retry")).toBe(3);
+    expect(
+      persistGatewaySessionLifecycleEventMock.mock.calls.filter(
+        ([params]) =>
+          (params as { event?: { data?: { phase?: string } } }).event?.data?.phase === "error",
+      ),
+    ).toHaveLength(0);
+  });
+
   it("adds detected errorKind to chat lifecycle error payloads", () => {
     const { broadcast, nodeSendToSession, handler } = createHarness({
       resolveSessionKeyForRun: () => "session-detected-error",

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -2050,6 +2050,20 @@ describe("agent event handler", () => {
     expect(fallbackPayload.runId).toBe("run-fallback-client");
     expect(fallbackPayload.data?.phase).toBe("fallback");
 
+    vi.advanceTimersByTime(100);
+
+    expect(chatRunState.registry.peek("run-fallback-retry")).toEqual({
+      sessionKey: "session-fallback",
+      clientRunId: "run-fallback-client",
+    });
+    expect(
+      chatBroadcastCalls(broadcast).some(
+        ([, payload]) => (payload as { state?: string }).state === "error",
+      ),
+    ).toBe(false);
+    expect(clearAgentRunContext).not.toHaveBeenCalled();
+    expect(agentRunSeq.get("run-fallback-retry")).toBe(3);
+
     emitLifecycleEnd(handler, "run-fallback-retry", 4);
 
     expect(
@@ -2170,6 +2184,52 @@ describe("agent event handler", () => {
           (params as { event?: { data?: { phase?: string } } }).event?.data?.phase === "error",
       ),
     ).toBe(true);
+  });
+
+  it("keeps deferred lifecycle-error cleanup across phase-less lifecycle events", () => {
+    vi.useFakeTimers();
+    const { broadcast, clearAgentRunContext, agentRunSeq, handler } = createHarness({
+      resolveSessionKeyForRun: () => "session-terminal-error",
+      lifecycleErrorRetryGraceMs: 100,
+    });
+    registerAgentRunContext("run-terminal-late-lifecycle", {
+      sessionKey: "session-terminal-error",
+    });
+
+    handler({
+      runId: "run-terminal-late-lifecycle",
+      seq: 1,
+      stream: "lifecycle",
+      ts: Date.now(),
+      data: { phase: "start" },
+    });
+    handler({
+      runId: "run-terminal-late-lifecycle",
+      seq: 2,
+      stream: "lifecycle",
+      ts: Date.now(),
+      data: { phase: "error", error: "request timed out" },
+    });
+    handler({
+      runId: "run-terminal-late-lifecycle",
+      seq: 3,
+      stream: "lifecycle",
+      ts: Date.now(),
+      data: { msg: "status update" },
+    });
+
+    vi.advanceTimersByTime(100);
+
+    const finalPayload = chatBroadcastCalls(broadcast).at(-1)?.[1] as {
+      state?: string;
+      runId?: string;
+      errorMessage?: string;
+    };
+    expect(finalPayload.state).toBe("error");
+    expect(finalPayload.runId).toBe("run-terminal-late-lifecycle");
+    expect(finalPayload.errorMessage).toContain("request timed out");
+    expect(clearAgentRunContext).toHaveBeenCalledWith("run-terminal-late-lifecycle");
+    expect(agentRunSeq.has("run-terminal-late-lifecycle")).toBe(false);
   });
 
   it("cancels deferred lifecycle-error cleanup when the run restarts", () => {

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -229,7 +229,14 @@ export function createAgentEventHandler({
   lifecycleErrorRetryGraceMs = AGENT_LIFECYCLE_ERROR_RETRY_GRACE_MS,
   isChatSendRunActive = () => false,
 }: AgentEventHandlerOptions) {
-  const pendingTerminalLifecycleErrors = new Map<string, NodeJS.Timeout>();
+  type TerminalLifecycleOptions = { skipChatErrorFinal?: boolean };
+  type PendingTerminalLifecycleError = {
+    timer: NodeJS.Timeout;
+    event: AgentEventPayload;
+    opts?: TerminalLifecycleOptions;
+  };
+
+  const pendingTerminalLifecycleErrors = new Map<string, PendingTerminalLifecycleError>();
 
   type AgentTextThrottleStream = "assistant" | "thinking";
 
@@ -263,7 +270,7 @@ export function createAgentEventHandler({
     if (!pending) {
       return;
     }
-    clearTimeout(pending);
+    clearTimeout(pending.timer);
     pendingTerminalLifecycleErrors.delete(runId);
   };
 
@@ -362,10 +369,7 @@ export function createAgentEventHandler({
     };
   };
 
-  const finalizeLifecycleEvent = (
-    evt: AgentEventPayload,
-    opts?: { skipChatErrorFinal?: boolean },
-  ) => {
+  const finalizeLifecycleEvent = (evt: AgentEventPayload, opts?: TerminalLifecycleOptions) => {
     const lifecyclePhase =
       evt.stream === "lifecycle" && typeof evt.data?.phase === "string" ? evt.data.phase : null;
     if (lifecyclePhase !== "end" && lifecyclePhase !== "error") {
@@ -458,15 +462,19 @@ export function createAgentEventHandler({
 
   const scheduleTerminalLifecycleError = (
     evt: AgentEventPayload,
-    opts?: { skipChatErrorFinal?: boolean },
+    opts?: TerminalLifecycleOptions,
   ) => {
     clearPendingTerminalLifecycleError(evt.runId);
     const timer = setSafeTimeout(() => {
+      const pending = pendingTerminalLifecycleErrors.get(evt.runId);
+      if (!pending || pending.timer !== timer) {
+        return;
+      }
       pendingTerminalLifecycleErrors.delete(evt.runId);
-      finalizeLifecycleEvent(evt, opts);
+      finalizeLifecycleEvent(pending.event, pending.opts);
     }, lifecycleErrorRetryGraceMs);
     timer.unref?.();
-    pendingTerminalLifecycleErrors.set(evt.runId, timer);
+    pendingTerminalLifecycleErrors.set(evt.runId, { timer, event: evt, opts });
   };
 
   const emitChatDelta = (
@@ -806,7 +814,7 @@ export function createAgentEventHandler({
   return (evt: AgentEventPayload) => {
     const lifecyclePhase =
       evt.stream === "lifecycle" && typeof evt.data?.phase === "string" ? evt.data.phase : null;
-    if (evt.stream !== "lifecycle" || lifecyclePhase !== "error") {
+    if (lifecyclePhase === "start") {
       clearPendingTerminalLifecycleError(evt.runId);
     }
 

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -814,7 +814,7 @@ export function createAgentEventHandler({
   return (evt: AgentEventPayload) => {
     const lifecyclePhase =
       evt.stream === "lifecycle" && typeof evt.data?.phase === "string" ? evt.data.phase : null;
-    if (lifecyclePhase === "start") {
+    if (lifecyclePhase !== null && lifecyclePhase !== "error") {
       clearPendingTerminalLifecycleError(evt.runId);
     }
 


### PR DESCRIPTION
## Summary

- Problem: Gateway lifecycle errors can be deferred during the retry grace window, then a later non-terminal event can clear the only pending terminal cleanup timer.
- Solution: Store pending terminal lifecycle errors with their timer, event, and options, and cancel them only when the run actually restarts with lifecycle `start`.
- What changed: Added focused regression coverage for `error -> tool -> grace expires` and `error -> start` retry ordering.
- What did NOT change (scope boundary): No Telegram, provider, watchdog, stale-row recovery, or channel-specific behavior changed.

## Motivation

- Closes #63819. Provider timeouts can leave gateway sessions stuck in `running`; this fixes the lifecycle state transition that drops the terminal cleanup.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #63819
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior addressed: A Gateway run that emits lifecycle `error`, then later emits a non-terminal event, still reaches terminal cleanup after the retry grace window instead of remaining `running`.
- Real environment tested: Maintainer local OpenClaw source checkout on macOS 26.4.1 with Node v25.9.0; real Gateway process started on loopback with an isolated `OPENCLAW_CONFIG_PATH`, isolated `OPENCLAW_STATE_DIR`, and isolated `sessions.json`.
- Exact steps or command run after this patch: Ran a one-off Node script through `node --import tsx --input-type=module` that started `startGatewayServer(...)`, registered a run context for `agent:main:main`, emitted `lifecycle:start`, `lifecycle:error`, then `tool:end`, waited for the 15s Gateway retry grace, and read the persisted session store from disk.
- Evidence after fix: Terminal output from the real Gateway run:

```text
openclaw real gateway lifecycle proof
gateway.process: started on 127.0.0.1:64575
event.path: real gateway agent-event subscription
event.order: lifecycle:start -> lifecycle:error -> tool:end
session.store: isolated sessions.json
session.key: agent:main:main
session.status.after.grace: failed
session.endedAt.persisted: true
session.runtimeMs.persisted: true
run.context.after.grace: cleared
result: PASS
```

- Observed result after fix: The running Gateway kept the deferred lifecycle error through the later tool event, persisted `agent:main:main` as `failed`, recorded terminal timing fields, and cleared the run context after the grace window.
- What was not tested: Live Telegram plus llama.cpp transport; this proof exercises the Gateway lifecycle/event persistence path directly.
- Before evidence: The new regression failed on the old implementation with `TypeError: Cannot read properties of undefined (reading 'state')` because no final error payload was emitted after the later tool event cleared the pending timer.

## Root Cause (if applicable)

- Root cause: `pendingTerminalLifecycleErrors` stored only a timer, and the handler cleared that timer for any event that was not lifecycle `error`.
- Missing detection / guardrail: Existing tests covered grace-expiry cleanup and fallback recovery, but not lifecycle `error` followed by a later non-terminal event with no lifecycle `end`.
- Contributing context (if known): Retry grace handling needs to distinguish a real retry lifecycle `start` from ordinary tool/item/assistant events for the same run.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/server-chat.agent-events.test.ts`
- Scenario the test should lock in: lifecycle `error` schedules terminal cleanup; a later `tool` event does not cancel it; a later lifecycle `start` still cancels it as a retry.
- Why this is the smallest reliable guardrail: The bug is entirely in gateway agent-event lifecycle ordering; no channel/provider transport participates in the state transition.
- Existing test that already covers this (if any): None covered this exact event ordering.
- If no new test is added, why not: New tests are added.

## User-visible / Behavior Changes

Gateway sessions are less likely to remain stuck in `running` after provider timeout/error ordering where non-terminal events arrive after lifecycle `error`.

## Diagram (if applicable)

```text
Before:
lifecycle start -> lifecycle error -> tool result -> pending terminal cleanup cleared -> session can stay running

After:
lifecycle start -> lifecycle error -> tool result -> grace expires -> terminal cleanup persists failed state
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS 26.4.1
- Runtime/container: Node v25.9.0, local source checkout
- Model/provider: N/A
- Integration/channel (if any): Gateway lifecycle handler
- Relevant config (redacted): N/A

### Steps

1. Emit lifecycle `start`.
2. Emit lifecycle `error` with retry grace enabled.
3. Emit a later non-terminal `tool` event for the same run.
4. Advance the retry grace timer.

### Expected

- Terminal error cleanup runs and the session can persist a failed terminal state.

### Actual

- Before this patch, the later non-terminal event cleared the only pending terminal cleanup timer.
- After this patch, the terminal cleanup remains pending and runs after the grace window.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `error -> tool -> grace expires`; `error -> start` retry; existing lifecycle chat/fallback behavior in `server-chat.agent-events.test.ts`; real Gateway agent-event subscription persisted `failed` to an isolated `sessions.json` after the 15s grace.
- Edge cases checked: Timer replacement guard, restart cancellation, persistence of terminal error after delayed cleanup.
- What you did **not** verify: Live Telegram plus llama.cpp timeout path.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: A recoverable retry attempt could be finalized too early.
  - Mitigation: The fix keeps lifecycle `start` as the cancellation signal and adds regression coverage that restart still cancels the deferred error.
