### PR TITLE
[Fix] Persist WhatsApp inbound delivery

### DIFF
--- a/extensions/whatsapp/src/inbound/durable-queue.test.ts
+++ b/extensions/whatsapp/src/inbound/durable-queue.test.ts
@@ -1,0 +1,126 @@
+import type { WAMessage } from "baileys";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+type StoredMessage = {
+  key?: {
+    id?: string;
+    remoteJid?: string;
+    participant?: string;
+    fromMe?: boolean;
+  };
+  messageTimestamp?: number;
+  message?: {
+    conversation?: string;
+  };
+};
+
+type StoredRecord = {
+  id: string;
+  accountId: string;
+  upsertType: "notify" | "append";
+  message: StoredMessage;
+  receivedAt: number;
+};
+
+type TestStore = {
+  pending: StoredRecord[];
+  completed: Record<string, number | { completedAt: number }>;
+};
+
+function cloneStore(store: TestStore): TestStore {
+  return structuredClone(store);
+}
+
+function makeMessage(id: string): WAMessage {
+  return {
+    key: {
+      id,
+      remoteJid: "15551234567@s.whatsapp.net",
+      fromMe: false,
+    },
+    messageTimestamp: 1_779_434_000,
+    message: { conversation: `body ${id}` },
+  } as unknown as WAMessage;
+}
+
+describe("durable inbound queue", () => {
+  afterEach(() => {
+    vi.doUnmock("openclaw/plugin-sdk/file-lock");
+    vi.doUnmock("openclaw/plugin-sdk/json-store");
+    vi.resetModules();
+  });
+
+  it("serializes overlapping accept and complete writes against one store", async () => {
+    vi.resetModules();
+    let store: TestStore = { pending: [], completed: {} };
+    let overlapPhase = false;
+    let overlapWrites = 0;
+    let releaseFirstOverlapWrite!: () => void;
+    let resolveFirstOverlapWriteBlocked!: () => void;
+    const firstOverlapWriteBlocked = new Promise<void>((resolve) => {
+      resolveFirstOverlapWriteBlocked = resolve;
+    });
+    const firstOverlapWriteCanContinue = new Promise<void>((resolve) => {
+      releaseFirstOverlapWrite = resolve;
+    });
+
+    vi.doMock("openclaw/plugin-sdk/file-lock", () => ({
+      withFileLock: async (_filePath: string, _options: unknown, fn: () => Promise<unknown>) =>
+        await fn(),
+    }));
+    vi.doMock("openclaw/plugin-sdk/json-store", () => ({
+      readJsonFileWithFallback: vi.fn(async () => ({ value: cloneStore(store), exists: true })),
+      writeJsonFileAtomically: vi.fn(async (_filePath: string, value: unknown) => {
+        if (overlapPhase) {
+          overlapWrites += 1;
+          if (overlapWrites === 1) {
+            resolveFirstOverlapWriteBlocked();
+            await firstOverlapWriteCanContinue;
+          }
+        }
+        store = cloneStore(value as TestStore);
+      }),
+    }));
+
+    const {
+      acceptDurableInboundMessage,
+      completeDurableInboundMessage,
+      loadPendingDurableInboundMessages,
+    } = await import("./durable-queue.js");
+
+    const oldAccepted = await acceptDurableInboundMessage({
+      authDir: "/tmp/openclaw-durable-inbound-test",
+      accountId: "acct",
+      upsertType: "notify",
+      message: makeMessage("old"),
+    });
+    expect(oldAccepted.kind).toBe("accepted");
+    if (oldAccepted.kind !== "accepted") {
+      throw new Error("old message should be accepted");
+    }
+
+    overlapPhase = true;
+    const acceptNew = acceptDurableInboundMessage({
+      authDir: "/tmp/openclaw-durable-inbound-test",
+      accountId: "acct",
+      upsertType: "notify",
+      message: makeMessage("new"),
+    });
+    await firstOverlapWriteBlocked;
+    const completeOld = completeDurableInboundMessage({
+      authDir: "/tmp/openclaw-durable-inbound-test",
+      record: oldAccepted.record,
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+    releaseFirstOverlapWrite();
+    await Promise.all([acceptNew, completeOld]);
+
+    const pending = await loadPendingDurableInboundMessages({
+      authDir: "/tmp/openclaw-durable-inbound-test",
+      accountId: "acct",
+    });
+    expect(pending.map((record) => record.message.key?.id)).toEqual(["new"]);
+    expect(store.pending.map((record) => record.message.key?.id)).toEqual(["new"]);
+    expect(Object.keys(store.completed)).toHaveLength(1);
+  });
+});

--- a/extensions/whatsapp/src/inbound/durable-queue.ts
+++ b/extensions/whatsapp/src/inbound/durable-queue.ts
@@ -1,0 +1,255 @@
+import { createHash } from "node:crypto";
+import path from "node:path";
+import type { WAMessage } from "baileys";
+import { withFileLock } from "openclaw/plugin-sdk/file-lock";
+import { readJsonFileWithFallback, writeJsonFileAtomically } from "openclaw/plugin-sdk/json-store";
+import { BufferJSON } from "../session.runtime.js";
+
+const STORE_FILE = "inbound-queue.json";
+const LOCK_OPTIONS = {
+  retries: { retries: 6, factor: 1.35, minTimeout: 8, maxTimeout: 180 },
+  stale: 60_000,
+};
+// `withFileLock` is process-local re-entrant; serialize same-file store cycles here.
+const storeOperationQueues = new Map<string, Promise<unknown>>();
+
+export type DurableInboundUpsertType = "notify" | "append";
+
+export type DurableInboundRecord = {
+  id: string;
+  accountId: string;
+  upsertType: DurableInboundUpsertType;
+  message: WAMessage;
+  receivedAt: number;
+};
+
+export type DurableInboundReadReceiptTarget = {
+  id: string;
+  remoteJid: string;
+  participantJid?: string;
+  isSelfChat: boolean;
+};
+
+type DurableInboundCompletedEntry =
+  | number
+  | {
+      completedAt: number;
+      readReceiptTarget?: DurableInboundReadReceiptTarget;
+    };
+
+type QueueStore = {
+  pending: DurableInboundRecord[];
+  completed: Record<string, DurableInboundCompletedEntry>;
+};
+
+export type DurableInboundAcceptResult =
+  | { kind: "accepted"; record: DurableInboundRecord }
+  | { kind: "duplicate"; id: string; readReceiptTarget?: DurableInboundReadReceiptTarget }
+  | { kind: "untracked" };
+
+function isRecordObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function trimNonEmpty(value: string | null | undefined): string | null {
+  return value?.trim() || null;
+}
+
+function durableId(params: {
+  accountId: string;
+  remoteJid?: string | null;
+  messageId?: string | null;
+  participantJid?: string | null;
+}): string | null {
+  const accountId = trimNonEmpty(params.accountId);
+  const remoteJid = trimNonEmpty(params.remoteJid);
+  const messageId = trimNonEmpty(params.messageId);
+  if (!accountId || !remoteJid || !messageId || messageId === "unknown") {
+    return null;
+  }
+  return createHash("sha256")
+    .update([accountId, remoteJid, messageId, trimNonEmpty(params.participantJid) ?? ""].join("\0"))
+    .digest("hex");
+}
+
+function coerceMessageTimestamp(raw: unknown): number | undefined {
+  if (raw == null) {
+    return undefined;
+  }
+  if (typeof raw === "object" && typeof (raw as { toNumber?: unknown }).toNumber === "function") {
+    const value = Number((raw as { toNumber: () => unknown }).toNumber());
+    return Number.isFinite(value) ? value : undefined;
+  }
+  if (isRecordObject(raw) && typeof raw.low === "number" && typeof raw.high === "number") {
+    const low = raw.unsigned === true ? raw.low >>> 0 : raw.low;
+    const high = raw.unsigned === true ? raw.high >>> 0 : raw.high;
+    const value = low + high * 0x100000000;
+    return Number.isSafeInteger(value) ? value : undefined;
+  }
+  const value = Number(raw);
+  return Number.isFinite(value) ? value : undefined;
+}
+
+function prepareMessage(message: WAMessage): WAMessage {
+  const messageTimestamp = coerceMessageTimestamp(message.messageTimestamp);
+  const storable = messageTimestamp === undefined ? message : { ...message, messageTimestamp };
+  return JSON.parse(JSON.stringify(storable, BufferJSON.replacer)) as WAMessage;
+}
+
+function reviveMessage(message: WAMessage): WAMessage {
+  const revived = JSON.parse(JSON.stringify(message), BufferJSON.reviver) as WAMessage;
+  const messageTimestamp = coerceMessageTimestamp(revived.messageTimestamp);
+  return messageTimestamp === undefined ? revived : { ...revived, messageTimestamp };
+}
+
+async function readStore(filePath: string): Promise<QueueStore> {
+  const { value } = await readJsonFileWithFallback<unknown>(filePath, null);
+  if (!isRecordObject(value)) {
+    return { pending: [], completed: {} };
+  }
+  const pending = Array.isArray(value.pending) ? (value.pending as DurableInboundRecord[]) : [];
+  return {
+    pending: pending
+      .filter((record) => isRecordObject(record.message))
+      .map((record) => Object.assign({}, record, { message: reviveMessage(record.message) })),
+    completed: isRecordObject(value.completed)
+      ? (value.completed as Record<string, DurableInboundCompletedEntry>)
+      : {},
+  };
+}
+
+function completedEntryTime(entry: DurableInboundCompletedEntry): number {
+  return typeof entry === "number" ? entry : entry.completedAt;
+}
+
+function pruneCompleted(
+  completed: Record<string, DurableInboundCompletedEntry>,
+): Record<string, DurableInboundCompletedEntry> {
+  return Object.fromEntries(
+    Object.entries(completed)
+      .toSorted(([, a], [, b]) => completedEntryTime(b) - completedEntryTime(a))
+      .slice(0, 10_000),
+  );
+}
+
+function enqueueStoreOperation<T>(filePath: string, fn: () => Promise<T>): Promise<T> {
+  const previous = storeOperationQueues.get(filePath) ?? Promise.resolve();
+  const next = previous.then(fn, fn);
+  storeOperationQueues.set(filePath, next);
+  next
+    .finally(() => {
+      if (storeOperationQueues.get(filePath) === next) {
+        storeOperationQueues.delete(filePath);
+      }
+    })
+    .catch(() => {});
+  return next;
+}
+
+async function updateStore<T>(
+  authDir: string,
+  fn: (store: QueueStore, now: number, filePath: string) => Promise<T>,
+) {
+  const filePath = path.join(authDir, STORE_FILE);
+  return await enqueueStoreOperation(filePath, () =>
+    withFileLock(filePath, LOCK_OPTIONS, async () => {
+      const now = Date.now();
+      const store = await readStore(filePath);
+      store.completed = pruneCompleted(store.completed);
+      return await fn(store, now, filePath);
+    }),
+  );
+}
+
+export async function acceptDurableInboundMessage(params: {
+  authDir: string;
+  accountId: string;
+  upsertType: DurableInboundUpsertType;
+  message: WAMessage;
+  receivedAt?: number;
+}): Promise<DurableInboundAcceptResult> {
+  const messageId = params.message.key?.id ?? undefined;
+  const remoteJid = params.message.key?.remoteJid ?? undefined;
+  const participantJid = params.message.key?.participant ?? undefined;
+  const id = durableId({ accountId: params.accountId, remoteJid, messageId, participantJid });
+  if (!id || !remoteJid || !messageId) {
+    return { kind: "untracked" };
+  }
+  return await updateStore(params.authDir, async (store, now, filePath) => {
+    const completed = store.completed[id];
+    if (completed !== undefined) {
+      return {
+        kind: "duplicate",
+        id,
+        readReceiptTarget: typeof completed === "number" ? undefined : completed.readReceiptTarget,
+      };
+    }
+    const pending = store.pending.find((record) => record.id === id);
+    if (pending) {
+      return { kind: "accepted", record: pending };
+    }
+    const record: DurableInboundRecord = {
+      id,
+      accountId: params.accountId,
+      upsertType: params.upsertType,
+      message: prepareMessage(params.message),
+      receivedAt: params.receivedAt ?? now,
+    };
+    await writeJsonFileAtomically(filePath, {
+      ...store,
+      pending: [...store.pending, record],
+    });
+    return { kind: "accepted", record: { ...record, message: params.message } };
+  });
+}
+
+export async function loadPendingDurableInboundMessages(params: {
+  authDir: string;
+  accountId: string;
+}): Promise<DurableInboundRecord[]> {
+  return await updateStore(params.authDir, async (store) =>
+    store.pending
+      .filter(
+        (record) =>
+          record.accountId === params.accountId && store.completed[record.id] === undefined,
+      )
+      .toSorted((a, b) => a.receivedAt - b.receivedAt || a.id.localeCompare(b.id)),
+  );
+}
+
+export async function completeDurableInboundMessage(params: {
+  authDir: string;
+  record: DurableInboundRecord;
+  readReceiptTarget?: DurableInboundReadReceiptTarget;
+}): Promise<void> {
+  await updateStore(params.authDir, async (store, now, filePath) => {
+    const completedEntry: DurableInboundCompletedEntry = params.readReceiptTarget
+      ? { completedAt: now, readReceiptTarget: params.readReceiptTarget }
+      : now;
+    await writeJsonFileAtomically(filePath, {
+      ...store,
+      pending: store.pending.filter((record) => record.id !== params.record.id),
+      completed: pruneCompleted({ ...store.completed, [params.record.id]: completedEntry }),
+    });
+  });
+}
+
+export async function recordDurableInboundRetry(params: {
+  authDir: string;
+  record: DurableInboundRecord;
+}): Promise<void> {
+  await updateStore(params.authDir, async (store, _now, filePath) => {
+    if (store.completed[params.record.id] !== undefined) {
+      return;
+    }
+    const current = store.pending.find((record) => record.id === params.record.id) ?? params.record;
+    const next = {
+      ...current,
+      message: prepareMessage(current.message),
+    };
+    await writeJsonFileAtomically(filePath, {
+      ...store,
+      pending: [next, ...store.pending.filter((record) => record.id !== next.id)],
+    });
+  });
+}

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -30,6 +30,15 @@ import {
   WhatsAppRetryableInboundError,
 } from "./dedupe.js";
 import {
+  acceptDurableInboundMessage,
+  completeDurableInboundMessage,
+  loadPendingDurableInboundMessages,
+  recordDurableInboundRetry,
+  type DurableInboundReadReceiptTarget,
+  type DurableInboundRecord,
+  type DurableInboundUpsertType,
+} from "./durable-queue.js";
+import {
   describeReplyContext,
   extractLocationData,
   extractContactContext,
@@ -225,6 +234,13 @@ export async function attachWebInboxToSocket(
   type QueuedInboundMessage = WebInboundMessage & {
     dedupeKey?: string;
     debounceKey?: string;
+    durableInboundRecord?: DurableInboundRecord;
+    readReceiptTarget?: InboundReadReceiptTarget;
+  };
+  type InboundReadReceiptTarget = DurableInboundReadReceiptTarget;
+  type DurableInboundCompletion = {
+    record: DurableInboundRecord;
+    readReceiptTarget?: InboundReadReceiptTarget;
   };
   const inboundDebounceMs = Math.max(0, Math.trunc(options.debounceMs ?? 0));
   const pendingDebounceKeys = new Set<string>();
@@ -247,22 +263,63 @@ export async function attachWebInboxToSocket(
   };
   const shouldDebounceInboundMessage = (msg: WebInboundMessage): boolean =>
     options.shouldDebounce?.(msg) ?? true;
+  const retryDurableInboundRecords = async (records: DurableInboundRecord[]): Promise<void> => {
+    for (const record of records) {
+      await recordDurableInboundRetry({
+        authDir: options.authDir,
+        record,
+      });
+    }
+  };
+  const completeDurableInboundCompletions = async (
+    completions: DurableInboundCompletion[],
+  ): Promise<void> => {
+    for (const completion of completions) {
+      await completeDurableInboundMessage({
+        authDir: options.authDir,
+        record: completion.record,
+        readReceiptTarget: completion.readReceiptTarget,
+      });
+    }
+  };
 
-  const finalizeInboundDedupe = async (
+  const finalizeInboundEntries = async (
     entries: QueuedInboundMessage[],
     error?: unknown,
   ): Promise<void> => {
     const dedupeKeys = [
       ...new Set(entries.map((entry) => entry.dedupeKey).filter(isNonEmptyString)),
     ];
-    if (dedupeKeys.length === 0) {
+    const durableCompletions = entries
+      .filter(
+        (entry): entry is QueuedInboundMessage & { durableInboundRecord: DurableInboundRecord } =>
+          Boolean(entry.durableInboundRecord),
+      )
+      .map((entry) => ({
+        record: entry.durableInboundRecord,
+        readReceiptTarget: entry.readReceiptTarget,
+      }));
+    const durableRecords = durableCompletions.map((completion) => completion.record);
+    const readReceiptTargets = entries
+      .map((entry) => entry.readReceiptTarget)
+      .filter((target): target is InboundReadReceiptTarget => Boolean(target));
+
+    if (error) {
+      if (error instanceof WhatsAppRetryableInboundError) {
+        dedupeKeys.forEach((dedupeKey) => releaseRecentInboundMessage(dedupeKey, error));
+        await retryDurableInboundRecords(durableRecords);
+        return;
+      }
+      await completeDurableInboundCompletions(durableCompletions);
+      await Promise.all(dedupeKeys.map((dedupeKey) => commitRecentInboundMessage(dedupeKey)));
+      await Promise.all(readReceiptTargets.map((target) => maybeMarkInboundAsRead(target)));
       return;
     }
-    if (error instanceof WhatsAppRetryableInboundError) {
-      dedupeKeys.forEach((dedupeKey) => releaseRecentInboundMessage(dedupeKey, error));
-      return;
-    }
+
+    await completeDurableInboundCompletions(durableCompletions);
+
     await Promise.all(dedupeKeys.map((dedupeKey) => commitRecentInboundMessage(dedupeKey)));
+    await Promise.all(readReceiptTargets.map((target) => maybeMarkInboundAsRead(target)));
   };
 
   const debouncer = createInboundDebouncer<QueuedInboundMessage>({
@@ -283,7 +340,7 @@ export async function attachWebInboxToSocket(
         try {
           if (entries.length === 1) {
             await options.onMessage(last);
-            await finalizeInboundDedupe(entries);
+            await finalizeInboundEntries(entries);
             return;
           }
           const mentioned = new Set<string>();
@@ -304,9 +361,9 @@ export async function attachWebInboxToSocket(
             isBatched: true,
           };
           await options.onMessage(combinedMessage);
-          await finalizeInboundDedupe(entries);
+          await finalizeInboundEntries(entries);
         } catch (error) {
-          await finalizeInboundDedupe(entries, error);
+          await finalizeInboundEntries(entries, error);
           throw error;
         }
       } finally {
@@ -608,11 +665,13 @@ export async function attachWebInboxToSocket(
     };
   };
 
-  const maybeMarkInboundAsRead = async (inbound: NormalizedInboundMessage) => {
-    const { id, remoteJid, participantJid, access } = inbound;
-    if (id && !access.isSelfChat && options.sendReadReceipts !== false) {
+  const maybeMarkInboundAsRead = async (target: InboundReadReceiptTarget) => {
+    const { id, remoteJid, participantJid, isSelfChat } = target;
+    if (!isSelfChat && options.sendReadReceipts !== false) {
       try {
-        await sock.readMessages([{ remoteJid, id, participant: participantJid, fromMe: false }]);
+        await (getCurrentSock() ?? sock).readMessages([
+          { remoteJid, id, participant: participantJid, fromMe: false },
+        ]);
         const suffix = participantJid ? ` (participant ${participantJid})` : "";
         logWhatsAppVerbose(
           options.verbose,
@@ -621,11 +680,23 @@ export async function attachWebInboxToSocket(
       } catch (err) {
         logWhatsAppVerbose(options.verbose, `Failed to mark message ${id} read: ${String(err)}`);
       }
-    } else if (id && access.isSelfChat && options.verbose) {
+    } else if (isSelfChat && options.verbose) {
       // Self-chat mode: never auto-send read receipts (blue ticks) on behalf of the owner.
       logWhatsAppVerbose(options.verbose, `Self-chat mode: skipping read receipt for ${id}`);
     }
   };
+
+  const buildReadReceiptTarget = (
+    inbound: NormalizedInboundMessage,
+  ): InboundReadReceiptTarget | undefined =>
+    inbound.id
+      ? {
+          id: inbound.id,
+          remoteJid: inbound.remoteJid,
+          participantJid: inbound.participantJid,
+          isSelfChat: inbound.access.isSelfChat,
+        }
+      : undefined;
 
   type EnrichedInboundMessage = {
     body: string;
@@ -696,6 +767,7 @@ export async function attachWebInboxToSocket(
     msg: WAMessage,
     inbound: NormalizedInboundMessage,
     enriched: EnrichedInboundMessage,
+    durableInboundRecord?: DurableInboundRecord,
   ) => {
     const chatJid = inbound.remoteJid;
     const sendComposing = async () => {
@@ -798,6 +870,8 @@ export async function attachWebInboxToSocket(
       mediaType: enriched.mediaType,
       mediaFileName: enriched.mediaFileName,
       dedupeKey: inbound.id ? `${options.accountId}:${inbound.remoteJid}:${inbound.id}` : undefined,
+      durableInboundRecord,
+      readReceiptTarget: buildReadReceiptTarget(inbound),
     };
     const debounceKey = buildInboundDebounceKey(inboundMessage);
     if (debounceKey) {
@@ -828,58 +902,218 @@ export async function attachWebInboxToSocket(
   };
 
   const pendingMessageHandlers = new Set<Promise<void>>();
+  const pendingReadReceiptRetries = new Set<Promise<void>>();
+  let inboundProcessingChain: Promise<void> = Promise.resolve();
+  const completeTerminalDurableRecord = async (record: DurableInboundRecord): Promise<void> =>
+    await completeDurableInboundMessage({
+      authDir: options.authDir,
+      record,
+    });
+  const trackPendingTask = (tasks: Set<Promise<void>>, task: Promise<void>) => {
+    tasks.add(task);
+    void task.finally(() => {
+      tasks.delete(task);
+    });
+  };
+  const trackPendingMessageHandler = (task: Promise<void>) =>
+    trackPendingTask(pendingMessageHandlers, task);
+  const trackPendingReadReceiptRetry = (task: Promise<void>) =>
+    trackPendingTask(pendingReadReceiptRetries, task);
+
+  const maybeMarkInboundMessageAsRead = async (msg: WAMessage): Promise<void> => {
+    const inbound = await normalizeInboundMessage(msg);
+    const readReceiptTarget = inbound ? buildReadReceiptTarget(inbound) : undefined;
+    if (readReceiptTarget) {
+      await maybeMarkInboundAsRead(readReceiptTarget);
+    }
+  };
+
+  const isStaleAppendMessage = (msg: WAMessage): boolean => {
+    const APPEND_RECENT_GRACE_MS = 60_000;
+    const msgTsRaw = msg.messageTimestamp;
+    const msgTsNum = msgTsRaw != null ? Number(msgTsRaw) : Number.NaN;
+    const msgTsMs = Number.isFinite(msgTsNum) ? msgTsNum * 1000 : 0;
+    return msgTsMs < connectedAtMs - APPEND_RECENT_GRACE_MS;
+  };
+
+  const isTrackedOutboundEcho = (msg: WAMessage): boolean => {
+    const id = msg.key?.id;
+    const remoteJid = msg.key?.remoteJid;
+    return Boolean(
+      msg.key?.fromMe &&
+      id &&
+      remoteJid &&
+      isRecentOutboundMessage({
+        accountId: options.accountId,
+        remoteJid,
+        messageId: id,
+      }),
+    );
+  };
+
+  const processInboundMessage = async (params: {
+    msg: WAMessage;
+    upsertType: DurableInboundUpsertType;
+    durableInboundRecord?: DurableInboundRecord;
+  }) => {
+    if (
+      !params.durableInboundRecord &&
+      params.upsertType === "append" &&
+      isStaleAppendMessage(params.msg)
+    ) {
+      await maybeMarkInboundMessageAsRead(params.msg);
+      return;
+    }
+
+    const durableInboundRecord = params.durableInboundRecord;
+
+    const inbound = await normalizeInboundMessage(params.msg);
+    if (!inbound) {
+      if (durableInboundRecord) {
+        await completeTerminalDurableRecord(durableInboundRecord);
+      }
+      return;
+    }
+
+    const enriched = await enrichInboundMessage(params.msg);
+    if (!enriched) {
+      if (durableInboundRecord) {
+        await completeTerminalDurableRecord(durableInboundRecord);
+      }
+      return;
+    }
+
+    const dedupeKey = inbound.id ? `${options.accountId}:${inbound.remoteJid}:${inbound.id}` : "";
+    if (dedupeKey && !(await claimRecentInboundMessage(dedupeKey))) {
+      return;
+    }
+
+    recordAcceptedInboundActivity(options.accountId);
+    await enqueueInboundMessage(params.msg, inbound, enriched, durableInboundRecord);
+  };
+
+  type AcceptedLiveInboundMessage = {
+    msg: WAMessage;
+    upsertType: DurableInboundUpsertType;
+    durableInboundRecord?: DurableInboundRecord;
+  };
+  type LiveInboundAcceptance =
+    | { kind: "accepted"; value: AcceptedLiveInboundMessage }
+    | { kind: "duplicate"; readReceiptTarget: InboundReadReceiptTarget }
+    | { kind: "ignored" };
+
+  const acceptLiveInboundMessage = async (params: {
+    msg: WAMessage;
+    upsertType: DurableInboundUpsertType;
+  }): Promise<LiveInboundAcceptance> => {
+    if (params.upsertType === "append" && isStaleAppendMessage(params.msg)) {
+      return { kind: "accepted", value: params };
+    }
+
+    if (isTrackedOutboundEcho(params.msg)) {
+      logWhatsAppVerbose(
+        options.verbose,
+        `Skipping recent outbound WhatsApp echo ${params.msg.key?.id ?? "unknown"} for ${params.msg.key?.remoteJid ?? "unknown"}`,
+      );
+      return { kind: "ignored" };
+    }
+
+    const accepted = await acceptDurableInboundMessage({
+      authDir: options.authDir,
+      accountId: options.accountId,
+      upsertType: params.upsertType,
+      message: params.msg,
+    });
+    if (accepted.kind === "duplicate") {
+      return accepted.readReceiptTarget
+        ? { kind: "duplicate", readReceiptTarget: accepted.readReceiptTarget }
+        : { kind: "ignored" };
+    }
+    return {
+      kind: "accepted",
+      value: {
+        ...params,
+        durableInboundRecord: accepted.kind === "accepted" ? accepted.record : undefined,
+      },
+    };
+  };
+
+  const replayPendingDurableInboundMessages = async () => {
+    const records = await loadPendingDurableInboundMessages({
+      authDir: options.authDir,
+      accountId: options.accountId,
+    });
+    for (const record of records) {
+      await processInboundMessage({
+        msg: record.message,
+        upsertType: record.upsertType,
+        durableInboundRecord: record,
+      });
+    }
+  };
+
   const handleMessagesUpsert = async (upsert: { type?: string; messages?: Array<WAMessage> }) => {
     if (upsert.type !== "notify" && upsert.type !== "append") {
       return;
     }
+    const upsertType = upsert.type;
+    const acceptedMessages: AcceptedLiveInboundMessage[] = [];
+    const duplicateReadRetryTargets: InboundReadReceiptTarget[] = [];
     for (const msg of upsert.messages ?? []) {
-      const inbound = await normalizeInboundMessage(msg);
-      if (!inbound) {
-        continue;
+      const accepted = await acceptLiveInboundMessage({ msg, upsertType });
+      if (accepted.kind === "accepted") {
+        acceptedMessages.push(accepted.value);
+      } else if (accepted.kind === "duplicate") {
+        duplicateReadRetryTargets.push(accepted.readReceiptTarget);
       }
-
-      await maybeMarkInboundAsRead(inbound);
-
-      // If this is history/offline catch-up, mark read above but skip auto-reply.
-      if (upsert.type === "append") {
-        const APPEND_RECENT_GRACE_MS = 60_000;
-        const msgTsRaw = msg.messageTimestamp;
-        const msgTsNum = msgTsRaw != null ? Number(msgTsRaw) : Number.NaN;
-        const msgTsMs = Number.isFinite(msgTsNum) ? msgTsNum * 1000 : 0;
-        if (msgTsMs < connectedAtMs - APPEND_RECENT_GRACE_MS) {
-          continue;
-        }
-      }
-
-      const enriched = await enrichInboundMessage(msg);
-      if (!enriched) {
-        continue;
-      }
-
-      const dedupeKey = inbound.id ? `${options.accountId}:${inbound.remoteJid}:${inbound.id}` : "";
-      if (dedupeKey && !(await claimRecentInboundMessage(dedupeKey))) {
-        continue;
-      }
-
-      recordAcceptedInboundActivity(options.accountId);
-      await enqueueInboundMessage(msg, inbound, enriched);
     }
+    for (const accepted of acceptedMessages) {
+      await processInboundMessage(accepted);
+    }
+    if (duplicateReadRetryTargets.length > 0) {
+      const retryTask = Promise.all(
+        duplicateReadRetryTargets.map((target) => maybeMarkInboundAsRead(target)),
+      )
+        .then(() => undefined)
+        .catch((err) => {
+          logWhatsAppVerbose(
+            options.verbose,
+            `Failed to retry duplicate read receipt: ${String(err)}`,
+          );
+        });
+      trackPendingReadReceiptRetry(retryTask);
+    }
+  };
+  const enqueueInboundProcessing = (
+    taskFactory: () => Promise<void>,
+    onError: (err: unknown) => void,
+  ) => {
+    // Keep replay, live accept, and finalization ordered around the durable queue.
+    const task = inboundProcessingChain
+      .catch(() => undefined)
+      .then(taskFactory)
+      .catch(onError);
+    inboundProcessingChain = task.catch(() => undefined);
+    trackPendingMessageHandler(task);
   };
   const handleMessagesUpsertEvent = (upsert: { type?: string; messages?: Array<WAMessage> }) => {
-    const task = handleMessagesUpsert(upsert).catch((err) => {
-      inboundLogger.error({ error: String(err) }, "messages.upsert handler error");
-      inboundConsoleLog.error(`Messages upsert handler error: ${String(err)}`);
-    });
-    pendingMessageHandlers.add(task);
-    void task.finally(() => {
-      pendingMessageHandlers.delete(task);
-    });
+    enqueueInboundProcessing(
+      () => handleMessagesUpsert(upsert),
+      (err) => {
+        inboundLogger.error({ error: String(err) }, "messages.upsert handler error");
+        inboundConsoleLog.error(`Messages upsert handler error: ${String(err)}`);
+      },
+    );
   };
-  const waitForPendingMessageHandlers = async () => {
-    while (pendingMessageHandlers.size > 0) {
-      await Promise.all(Array.from(pendingMessageHandlers));
+  const waitForPendingTasks = async (tasks: Set<Promise<void>>) => {
+    while (tasks.size > 0) {
+      await Promise.all(Array.from(tasks));
     }
   };
+  const waitForPendingMessageHandlers = async () =>
+    await waitForPendingTasks(pendingMessageHandlers);
+  const waitForPendingReadReceiptRetries = async () =>
+    await waitForPendingTasks(pendingReadReceiptRetries);
   const drainDebouncedInboundMessages = async () => {
     while (pendingDebounceKeys.size > 0 || activeInboundFlushes.size > 0) {
       const debounceKeys = Array.from(pendingDebounceKeys);
@@ -898,6 +1132,7 @@ export async function attachWebInboxToSocket(
   const drainInboundBeforeSocketClose = async () => {
     await waitForPendingMessageHandlers();
     await drainDebouncedInboundMessages();
+    await waitForPendingReadReceiptRetries();
   };
   const drainInboundBeforeSocketCloseWithTimeout = async () => {
     let timeout: ReturnType<typeof setTimeout> | null = null;
@@ -956,6 +1191,13 @@ export async function attachWebInboxToSocket(
     },
     "connection.update",
     handleConnectionUpdate as unknown as (...args: unknown[]) => void,
+  );
+  enqueueInboundProcessing(
+    () => replayPendingDurableInboundMessages(),
+    (err) => {
+      inboundLogger.error({ error: String(err) }, "durable inbound replay error");
+      inboundConsoleLog.error(`Durable inbound replay error: ${String(err)}`);
+    },
   );
 
   void (async () => {

--- a/extensions/whatsapp/src/monitor-inbox.blocks-messages-from-unauthorized-senders-not-allowfrom.test-support.ts
+++ b/extensions/whatsapp/src/monitor-inbox.blocks-messages-from-unauthorized-senders-not-allowfrom.test-support.ts
@@ -257,7 +257,7 @@ describe("web monitor inbox", () => {
         }),
       ),
     );
-    await settleInboundWork();
+    await waitForMessageCalls(onMessage, 1);
 
     expect(onMessage).toHaveBeenCalledTimes(1);
     const payload = firstInboundPayload(onMessage);
@@ -344,7 +344,7 @@ describe("web monitor inbox", () => {
         }),
       ),
     );
-    await settleInboundWork();
+    await waitForMessageCalls(onMessage, 1);
 
     // Should call onMessage because sender is in groupAllowFrom
     expect(onMessage).toHaveBeenCalledTimes(1);
@@ -378,7 +378,7 @@ describe("web monitor inbox", () => {
         }),
       ),
     );
-    await settleInboundWork();
+    await waitForMessageCalls(onMessage, 1);
 
     // Should call onMessage because wildcard allows all senders
     expect(onMessage).toHaveBeenCalledTimes(1);

--- a/extensions/whatsapp/src/monitor-inbox.captures-media-path-image-messages.test-support.ts
+++ b/extensions/whatsapp/src/monitor-inbox.captures-media-path-image-messages.test-support.ts
@@ -7,6 +7,7 @@ import {
   getSock,
   installWebMonitorInboxUnitTestHooks,
   mockLoadConfig,
+  waitForMessageCalls,
 } from "./monitor-inbox.test-harness.js";
 let monitorWebInbox: typeof import("./inbound.js").monitorWebInbox;
 const inboundLoggerInfoMock = vi.hoisted(() => vi.fn());
@@ -49,7 +50,7 @@ describe("web monitor inbox", () => {
     const listener = await openMonitor(onMessage);
     const sock = getSock();
     sock.ev.emit("messages.upsert", upsert);
-    await new Promise((resolve) => setTimeout(resolve, 25));
+    await waitForMessageCalls(onMessage, 1);
     return { onMessage, listener, sock };
   }
 
@@ -81,14 +82,16 @@ describe("web monitor inbox", () => {
 
     expect(onMessage).toHaveBeenCalledTimes(1);
     expect(onMessage.mock.calls[0]?.[0]?.body).toBe("<media:image>");
-    expect(sock.readMessages).toHaveBeenCalledWith([
-      {
-        remoteJid: "888@s.whatsapp.net",
-        id: "med1",
-        participant: undefined,
-        fromMe: false,
-      },
-    ]);
+    await vi.waitFor(() => {
+      expect(sock.readMessages).toHaveBeenCalledWith([
+        {
+          remoteJid: "888@s.whatsapp.net",
+          id: "med1",
+          participant: undefined,
+          fromMe: false,
+        },
+      ]);
+    });
     expect(sock.sendPresenceUpdate).toHaveBeenNthCalledWith(1, "available");
     await listener.close();
   });
@@ -183,14 +186,16 @@ describe("web monitor inbox", () => {
       ],
     });
 
-    expect(sock.readMessages).toHaveBeenCalledWith([
-      {
-        remoteJid: "12345-67890@g.us",
-        id: "grp1",
-        participant: "111@s.whatsapp.net",
-        fromMe: false,
-      },
-    ]);
+    await vi.waitFor(() => {
+      expect(sock.readMessages).toHaveBeenCalledWith([
+        {
+          remoteJid: "12345-67890@g.us",
+          id: "grp1",
+          participant: "111@s.whatsapp.net",
+          fromMe: false,
+        },
+      ]);
+    });
     await listener.close();
   });
 

--- a/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test-support.ts
+++ b/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test-support.ts
@@ -5,12 +5,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { WhatsAppRetryableInboundError } from "./inbound/dedupe.js";
 import { WHATSAPP_GROUP_METADATA_CACHE_MAX_ENTRIES } from "./inbound/monitor.js";
 import {
+  DEFAULT_WEB_INBOX_CONFIG,
   type InboxMonitorOptions,
   InboxOnMessage,
   buildNotifyMessageUpsert,
   getAuthDir,
   getSock,
   installWebMonitorInboxUnitTestHooks,
+  settleInboundWork,
   startInboxMonitor,
   waitForMessageCalls,
 } from "./monitor-inbox.test-harness.js";
@@ -164,19 +166,21 @@ describe("web monitor inbox", () => {
 
     sock.ev.emit("messages.upsert", upsert);
     await waitForMessageCalls(onMessage, 1);
+    await vi.waitFor(() => {
+      expect(sock.readMessages).toHaveBeenCalledWith([
+        {
+          remoteJid: "999@s.whatsapp.net",
+          id: messageId,
+          participant: undefined,
+          fromMe: false,
+        },
+      ]);
+    });
 
     const inbound = inboundMessage(onMessage);
     expect(inbound.body).toBe("ping");
     expect(inbound.from).toBe("+999");
     expect(inbound.to).toBe("+123");
-    expect(sock.readMessages).toHaveBeenCalledWith([
-      {
-        remoteJid: "999@s.whatsapp.net",
-        id: messageId,
-        participant: undefined,
-        fromMe: false,
-      },
-    ]);
     expect(sock.sendPresenceUpdate).toHaveBeenCalledWith("available");
     expect(sock.sendPresenceUpdate).toHaveBeenCalledWith("composing", "999@s.whatsapp.net");
     expect(sock.sendMessage).toHaveBeenCalledWith("999@s.whatsapp.net", {
@@ -417,7 +421,6 @@ describe("web monitor inbox", () => {
   });
 
   it("flushes pending debounced inbound batches after close", async () => {
-    vi.useFakeTimers();
     try {
       const onMessage = vi.fn(async () => undefined);
       const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
@@ -444,8 +447,8 @@ describe("web monitor inbox", () => {
         }),
       );
 
-      await listener.close();
-      await vi.advanceTimersByTimeAsync(50);
+      const closePromise = listener.close();
+      await closePromise;
       await waitForMessageCalls(onMessage, 1);
       expect(inboundMessage(onMessage).body).toBe("first\nsecond");
     } finally {
@@ -454,7 +457,6 @@ describe("web monitor inbox", () => {
   });
 
   it("lets a drained debounced inbound reply before closing the socket", async () => {
-    vi.useFakeTimers();
     try {
       const onMessage = vi.fn(async (msg) => {
         await msg.reply("pong");
@@ -484,7 +486,8 @@ describe("web monitor inbox", () => {
         }),
       );
 
-      await listener.close();
+      const closePromise = listener.close();
+      await closePromise;
 
       expect(onMessage).toHaveBeenCalledTimes(1);
       expect(inboundMessage(onMessage).body).toBe("first\nsecond");
@@ -504,25 +507,18 @@ describe("web monitor inbox", () => {
   });
 
   it("waits for in-flight inbound handlers before draining on close", async () => {
-    vi.useFakeTimers();
     try {
+      let releaseHandler: (() => void) | undefined;
+      const handlerGate = new Promise<void>((resolve) => {
+        releaseHandler = resolve;
+      });
       const onMessage = vi.fn(async (msg) => {
+        await handlerGate;
         await msg.reply("pong");
       });
       const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
         debounceMs: 50,
       });
-      let releaseRead: (() => void) | undefined;
-      const readGate = new Promise<void>((resolve) => {
-        releaseRead = resolve;
-      });
-      const readStarted = new Promise<void>((resolve) => {
-        sock.readMessages.mockImplementationOnce(async () => {
-          resolve();
-          await readGate;
-        });
-      });
-
       sock.ev.emit(
         "messages.upsert",
         buildNotifyMessageUpsert({
@@ -534,19 +530,17 @@ describe("web monitor inbox", () => {
         }),
       );
 
-      await readStarted;
       const closePromise = listener.close();
-      await Promise.resolve();
+      await waitForMessageCalls(onMessage, 1);
 
       expect(sock.end).not.toHaveBeenCalled();
 
-      if (!releaseRead) {
-        throw new Error("Expected read receipt release callback to be initialized");
+      if (!releaseHandler) {
+        throw new Error("Expected handler release callback to be initialized");
       }
-      releaseRead();
+      releaseHandler();
       await closePromise;
 
-      expect(onMessage).toHaveBeenCalledTimes(1);
       expect(sock.sendMessage).toHaveBeenCalledWith("999@s.whatsapp.net", {
         text: "pong",
       });
@@ -641,6 +635,196 @@ describe("web monitor inbox", () => {
     expect(onMessage).toHaveBeenCalledTimes(1);
 
     await listener.close();
+  });
+
+  it("retries read receipts for durable duplicate deliveries", async () => {
+    const onMessage = vi.fn(async () => {
+      return;
+    });
+    let currentConfig: unknown = DEFAULT_WEB_INBOX_CONFIG;
+
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
+      loadConfig: () => currentConfig as never,
+    });
+    sock.readMessages.mockRejectedValueOnce(new Error("receipt temporarily unavailable"));
+    const messageId = nextMessageId("read-retry-duplicate");
+    const upsert = buildNotifyMessageUpsert({
+      id: messageId,
+      remoteJid: "999@s.whatsapp.net",
+      text: "ping",
+      timestamp: 1_700_000_000,
+      pushName: "Tester",
+    });
+
+    sock.ev.emit("messages.upsert", upsert);
+    await waitForMessageCalls(onMessage, 1);
+    await vi.waitFor(() => {
+      expect(sock.readMessages).toHaveBeenCalledTimes(1);
+    });
+
+    sock.ev.emit("messages.upsert", upsert);
+    await vi.waitFor(() => {
+      expect(sock.readMessages).toHaveBeenCalledTimes(2);
+    });
+
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    expect(sock.readMessages).toHaveBeenNthCalledWith(2, [
+      {
+        remoteJid: "999@s.whatsapp.net",
+        id: messageId,
+        participant: undefined,
+        fromMe: false,
+      },
+    ]);
+
+    const terminalDropId = nextMessageId("read-retry-terminal-drop");
+    const terminalDropUpsert = {
+      type: "notify",
+      messages: [
+        {
+          key: { id: terminalDropId, fromMe: false, remoteJid: "999@s.whatsapp.net" },
+          message: {
+            buttonsResponseMessage: { selectedButtonId: "ok", selectedDisplayText: "OK" },
+          },
+          messageTimestamp: 1_700_000_001,
+          pushName: "Tester",
+        },
+      ],
+    };
+    sock.ev.emit("messages.upsert", terminalDropUpsert);
+    await vi.waitFor(() => {
+      const store = JSON.parse(
+        fsSync.readFileSync(path.join(getAuthDir(), "inbound-queue.json"), "utf8"),
+      );
+      expect(Object.keys(store.completed ?? {})).toHaveLength(2);
+    });
+    sock.ev.emit("messages.upsert", terminalDropUpsert);
+    await settleInboundWork();
+    expect(sock.readMessages).toHaveBeenCalledTimes(2);
+
+    currentConfig = {
+      channels: { whatsapp: { allowFrom: ["+111"] } },
+      messages: DEFAULT_WEB_INBOX_CONFIG.messages,
+    };
+    const blockedId = nextMessageId("read-retry-blocked");
+    const blockedUpsert = buildNotifyMessageUpsert({
+      id: blockedId,
+      remoteJid: "999@s.whatsapp.net",
+      text: "blocked first",
+      timestamp: 1_700_000_002,
+      pushName: "Tester",
+    });
+    sock.ev.emit("messages.upsert", blockedUpsert);
+    await vi.waitFor(() => {
+      const store = JSON.parse(
+        fsSync.readFileSync(path.join(getAuthDir(), "inbound-queue.json"), "utf8"),
+      );
+      expect(Object.keys(store.completed ?? {})).toHaveLength(3);
+    });
+    currentConfig = DEFAULT_WEB_INBOX_CONFIG;
+    sock.ev.emit("messages.upsert", blockedUpsert);
+    await settleInboundWork();
+    expect(sock.readMessages).toHaveBeenCalledTimes(2);
+
+    await listener.close();
+  });
+
+  it("does not block later batch messages while retrying duplicate read receipts", async () => {
+    const onMessage = vi.fn(async () => {
+      return;
+    });
+
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
+      debounceMs: 60_000,
+      shouldDebounce: (msg) => msg.body === "debounced",
+    });
+    const duplicateId = nextMessageId("batch-read-retry-duplicate");
+    const duplicateUpsert = buildNotifyMessageUpsert({
+      id: duplicateId,
+      remoteJid: "999@s.whatsapp.net",
+      text: "first",
+      timestamp: 1_700_000_000,
+      pushName: "Tester",
+    });
+    let blockDuplicateRead = false;
+    let closeAttempt: Promise<void> | undefined;
+    let closeSettled = false;
+    let duplicateReadReleased = false;
+    let releaseDuplicateRead!: () => void;
+    const duplicateReadAttempt = new Promise<void>((resolve) => {
+      releaseDuplicateRead = () => {
+        duplicateReadReleased = true;
+        resolve();
+      };
+    });
+    sock.readMessages.mockImplementation(async (keys: Array<{ id?: string }>) => {
+      if (blockDuplicateRead && keys.at(0)?.id === duplicateId) {
+        await duplicateReadAttempt;
+      }
+    });
+
+    try {
+      sock.ev.emit("messages.upsert", duplicateUpsert);
+      await waitForMessageCalls(onMessage, 1);
+      await vi.waitFor(() => {
+        expect(sock.readMessages).toHaveBeenCalledTimes(1);
+      });
+      blockDuplicateRead = true;
+
+      const freshId = nextMessageId("batch-read-retry-fresh");
+      const freshUpsert = buildNotifyMessageUpsert({
+        id: freshId,
+        remoteJid: "999@s.whatsapp.net",
+        text: "second",
+        timestamp: 1_700_000_001,
+        pushName: "Tester",
+      });
+      sock.ev.emit("messages.upsert", {
+        type: "notify",
+        messages: [...duplicateUpsert.messages, ...freshUpsert.messages],
+      });
+
+      await vi.waitFor(
+        () => {
+          expect(onMessage).toHaveBeenCalledTimes(2);
+        },
+        { timeout: 500, interval: 5 },
+      );
+      await vi.waitFor(() => {
+        expect(sock.readMessages).toHaveBeenCalledTimes(3);
+      });
+
+      const debouncedId = nextMessageId("batch-read-retry-debounced");
+      sock.ev.emit(
+        "messages.upsert",
+        buildNotifyMessageUpsert({
+          id: debouncedId,
+          remoteJid: "999@s.whatsapp.net",
+          text: "debounced",
+          timestamp: 1_700_000_002,
+          pushName: "Tester",
+        }),
+      );
+      await settleInboundWork();
+      expect(onMessage).toHaveBeenCalledTimes(2);
+
+      closeAttempt = listener.close().then(() => {
+        closeSettled = true;
+      });
+      await vi.waitFor(
+        () => {
+          expect(onMessage).toHaveBeenCalledTimes(3);
+        },
+        { timeout: 500, interval: 5 },
+      );
+      await settleInboundWork();
+      expect(closeSettled).toBe(false);
+    } finally {
+      if (!duplicateReadReleased) {
+        releaseDuplicateRead();
+      }
+      await (closeAttempt ?? listener.close());
+    }
   });
 
   it("retries redelivered messages after an explicit retryable inbound failure", async () => {


### PR DESCRIPTION
## Summary

- Fixes WhatsApp inbound message loss by adding an authDir-local durable inbound queue before handler dispatch.
- Serializes every durable queue store operation per `inbound-queue.json` file so accept/complete/retry read-modify-write cycles cannot overwrite each other inside one process.
- Replays pending durable inbound records on monitor startup, completes them only after successful/non-retryable finalization, and delays read receipts until finalization.

Closes #50563.

## Scope

- WhatsApp plugin inbound monitor and durable inbound queue only.
- No WhatsApp auth, outbound delivery, provider, gateway protocol, or public plugin API changes.

## Real behavior proof

- Behavior addressed: A WhatsApp inbound message accepted by the monitor is durably queued before processing, remains pending after a retryable handler failure, replays through the monitor on the next attach, completes after successful replay, and only then sends a read receipt.
- Real environment tested: macOS local OpenClaw checkout, Node v24.14.0, production `extensions/whatsapp/src/inbound/monitor.ts`, production `extensions/whatsapp/src/inbound/durable-queue.ts`, a fake WASocket event emitter, and a real temporary authDir on disk.
- Exact steps or command run after this patch: `AUTH_DIR=$(mktemp -d) node --import tsx --input-type=module <<'EOF' ... EOF`; the script imported production `attachWebInboxToSocket`, `WhatsAppRetryableInboundError`, and `loadPendingDurableInboundMessages`, emitted a real `messages.upsert` event into the monitor, forced a retryable handler failure, closed the monitor, attached a second monitor against the same authDir, and waited for durable replay completion.
- Evidence after fix:

```text
[whatsapp] Failed handling inbound web message: WhatsAppRetryableInboundError: proof retry
{
  "firstRun": {
    "handlerCalls": 1,
    "pendingAfterRetry": 1,
    "readReceiptsBeforeSuccess": 0
  },
  "replayRun": {
    "handlerCalls": 1,
    "pendingAfterReplayComplete": 0,
    "readReceiptsAfterReplayComplete": 1
  },
  "store": {
    "exists": true,
    "pending": 0,
    "completed": 1,
    "file": "inbound-queue.json"
  }
}
```

- Observed result after fix: The first monitor run retained the message in `inbound-queue.json` after retryable failure and did not mark it read. The second monitor attach replayed that pending record through the monitor, completed it, drained pending to `0`, recorded one completed ID, and sent one read receipt after successful replay.
- What was not tested: Live WhatsApp Web crash/restart with real account traffic was not run.
- Before evidence: Source-level issue #50563 documents the ack-before-process message-loss mode; ClawSweeper also confirmed current main marks WhatsApp messages read before handler completion.

## Root Cause

- The old monitor path used in-memory processing state around `messages.upsert`; a crash after receipt but before handler completion left no authDir-backed pending record to replay.
- The first durable queue patch still depended on re-entrant `withFileLock` for same-process read-modify-write serialization, so overlapping accept/complete/retry operations could lose updates.

## Regression Test Plan

- Target test files:
  - `extensions/whatsapp/src/inbound/durable-queue.test.ts`
  - `extensions/whatsapp/src/monitor-inbox.behavior.test.ts`
- Scenario locked in: overlapping durable accept and complete writes against one `inbound-queue.json` store serialize correctly, and the monitor still dispatches/retries/replays inbound messages through the existing behavior harness.

## Verification

- `node scripts/run-vitest.mjs extensions/whatsapp/src/inbound/durable-queue.test.ts extensions/whatsapp/src/monitor-inbox.behavior.test.ts`
  - Result: 2 files passed, 59 tests passed.
- `AUTH_DIR=$(mktemp -d) node --import tsx --input-type=module <<'EOF' ... EOF`
  - Result: monitor-level durable retry/replay proof shown above.

## Security Impact

- New permissions/capabilities? No.
- Secrets/tokens handling changed? No.
- New/changed network calls? No.
- Command/tool execution surface changed? No.
- Data access scope changed? Yes.
- Risk and mitigation: WhatsApp inbound payloads are now persisted under the existing local WhatsApp auth/session directory. The queue is account-scoped, file-locked, same-process serialized, and prunes completed IDs.

## Risks

- Persisting inbound WhatsApp payloads increases local authDir storage sensitivity; this stays inside the existing WhatsApp authDir boundary.
- Live WhatsApp Web crash/restart with a real account remains untested in this PR.
