### PR TITLE
fix(qqbot): deliver partial tool progress

### DIFF
--- a/extensions/qqbot/src/engine/api/messages.ts
+++ b/extensions/qqbot/src/engine/api/messages.ts
@@ -98,6 +98,7 @@ export class MessageApi {
       msgId?: string;
       messageReference?: string;
       inlineKeyboard?: InlineKeyboard;
+      forcePlainText?: boolean;
     },
   ): Promise<MessageResponse> {
     const token = await this.tokenManager.getAccessToken(creds.appId, creds.clientSecret);
@@ -108,6 +109,7 @@ export class MessageApi {
       msgSeq,
       opts?.messageReference,
       opts?.inlineKeyboard,
+      opts?.forcePlainText,
     );
     const path = messagePath(scope, targetId);
     return this.sendAndNotify(creds.appId, token, "POST", path, body, { text: content });
@@ -119,12 +121,13 @@ export class MessageApi {
     targetId: string,
     content: string,
     creds: Credentials,
+    opts?: { forcePlainText?: boolean },
   ): Promise<MessageResponse> {
     if (!content?.trim()) {
       throw new Error("Proactive message content must not be empty");
     }
     const token = await this.tokenManager.getAccessToken(creds.appId, creds.clientSecret);
-    const body = this.buildProactiveBody(content);
+    const body = this.buildProactiveBody(content, opts?.forcePlainText);
     const path = messagePath(scope, targetId);
     return this.sendAndNotify(creds.appId, token, "POST", path, body, { text: content });
   }
@@ -262,15 +265,17 @@ export class MessageApi {
     msgSeq: number,
     messageReference?: string,
     inlineKeyboard?: InlineKeyboard,
+    forcePlainText = false,
   ): Record<string, unknown> {
-    const body: Record<string, unknown> = this.markdownSupport
+    const useMarkdown = this.markdownSupport && !forcePlainText;
+    const body: Record<string, unknown> = useMarkdown
       ? { markdown: { content }, msg_type: 2, msg_seq: msgSeq }
       : { content, msg_type: 0, msg_seq: msgSeq };
 
     if (msgId) {
       body.msg_id = msgId;
     }
-    if (messageReference && !this.markdownSupport) {
+    if (messageReference && !useMarkdown) {
       body.message_reference = { message_id: messageReference };
     }
     if (inlineKeyboard) {
@@ -279,8 +284,10 @@ export class MessageApi {
     return body;
   }
 
-  private buildProactiveBody(content: string): Record<string, unknown> {
-    return this.markdownSupport ? { markdown: { content }, msg_type: 2 } : { content, msg_type: 0 };
+  private buildProactiveBody(content: string, forcePlainText = false): Record<string, unknown> {
+    return this.markdownSupport && !forcePlainText
+      ? { markdown: { content }, msg_type: 2 }
+      : { content, msg_type: 0 };
   }
 }
 

--- a/extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
+++ b/extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
@@ -311,6 +311,26 @@ describe("dispatchOutbound", () => {
     expect(sendMediaMock).not.toHaveBeenCalled();
   });
 
+  it("keeps immediate tool progress media-like text inert with markdown support enabled", async () => {
+    const progress = "progress ![x](http://internal.example/progress.png)";
+    const runtime = makeRuntime({
+      onDeliver: async (deliver) => {
+        await deliver({ text: progress }, { kind: "tool" });
+        await deliver({ text: "final answer" }, { kind: "block" });
+      },
+    });
+
+    await dispatchOutbound(makeInbound(), {
+      runtime,
+      cfg: {},
+      account: { ...account, markdownSupport: true, config: { streaming: { mode: "partial" } } },
+    });
+
+    expect(sendTextMock.mock.calls.map((call) => call[1])).toEqual([progress, "final answer"]);
+    expect(sendTextMock.mock.calls[0]?.[3]).toMatchObject({ forcePlainText: true });
+    expect(sendMediaMock).not.toHaveBeenCalled();
+  });
+
   it("keeps text-only tool progress buffered when streaming is off", async () => {
     const runtime = makeRuntime({
       onDeliver: async (deliver) => {

--- a/extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
+++ b/extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import type { InboundContext } from "./inbound-context.js";
 import { dispatchOutbound } from "./outbound-dispatch.js";
 import type { GatewayAccount, GatewayPluginRuntime } from "./types.js";
@@ -10,7 +10,10 @@ const sendMediaMock = vi.hoisted(() =>
   vi.fn(async (_params: unknown) => ({ id: "media-1", timestamp: "2026-04-25T00:00:00.000Z" })),
 );
 const sendTextMock = vi.hoisted(() =>
-  vi.fn(async (_params: unknown) => ({ id: "text-1", timestamp: "2026-04-25T00:00:00.000Z" })),
+  vi.fn(async (..._params: unknown[]) => ({
+    id: "text-1",
+    timestamp: "2026-04-25T00:00:00.000Z",
+  })),
 );
 const audioFileToSilkBase64Mock = vi.hoisted(() => vi.fn(async () => "silk-base64"));
 
@@ -107,7 +110,7 @@ function makeRuntime(params: {
   isControlCommandMessage?: (text?: string, cfg?: unknown) => boolean;
   onDeliver?: (
     deliver: (
-      payload: { text?: string; audioAsVoice?: boolean },
+      payload: { text?: string; mediaUrl?: string; mediaUrls?: string[]; audioAsVoice?: boolean },
       info: { kind: string },
     ) => Promise<void>,
   ) => Promise<void>;
@@ -127,7 +130,12 @@ function makeRuntime(params: {
             rawParams as {
               dispatcherOptions: {
                 deliver: (
-                  payload: { text?: string; audioAsVoice?: boolean },
+                  payload: {
+                    text?: string;
+                    mediaUrl?: string;
+                    mediaUrls?: string[];
+                    audioAsVoice?: boolean;
+                  },
                   info: { kind: string },
                 ) => Promise<void>;
               };
@@ -169,6 +177,10 @@ function makeRuntime(params: {
 describe("dispatchOutbound", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("keeps waiting past 300s when a slow provider timeout is configured", async () => {
@@ -255,6 +267,93 @@ describe("dispatchOutbound", () => {
     expect(sentMedia?.msgId).toBe("msg-1");
     expect(sentMedia?.ttsText).toBe("read this aloud");
     expect(sendTextMock).not.toHaveBeenCalled();
+  });
+
+  it("delivers text-only tool progress immediately in partial streaming mode", async () => {
+    const runtime = makeRuntime({
+      onDeliver: async (deliver) => {
+        await deliver({ text: "Working: checking logs" }, { kind: "tool" });
+        await deliver({ text: "final answer" }, { kind: "block" });
+      },
+    });
+
+    await dispatchOutbound(makeInbound(), {
+      runtime,
+      cfg: {},
+      account: { ...account, config: { streaming: { mode: "partial" } } },
+    });
+
+    expect(sendTextMock.mock.calls.map((call) => call[1])).toEqual([
+      "Working: checking logs",
+      "final answer",
+    ]);
+    expect(sendMediaMock).not.toHaveBeenCalled();
+  });
+
+  it("delivers text-only tool progress immediately in recommended C2C streaming mode", async () => {
+    const runtime = makeRuntime({
+      onDeliver: async (deliver) => {
+        await deliver({ text: "Working: checking logs" }, { kind: "tool" });
+        await deliver({ text: "final answer" }, { kind: "block" });
+      },
+    });
+
+    await dispatchOutbound(makeInbound(), {
+      runtime,
+      cfg: {},
+      account: { ...account, config: { streaming: true } },
+    });
+
+    expect(sendTextMock.mock.calls.map((call) => call[1])).toEqual([
+      "Working: checking logs",
+      "final answer",
+    ]);
+    expect(sendMediaMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps text-only tool progress buffered when streaming is off", async () => {
+    const runtime = makeRuntime({
+      onDeliver: async (deliver) => {
+        await deliver({ text: "Working: checking logs" }, { kind: "tool" });
+        await deliver({ text: "final answer" }, { kind: "block" });
+      },
+    });
+
+    await dispatchOutbound(makeInbound(), {
+      runtime,
+      cfg: {},
+      account: { ...account, config: { streaming: false } },
+    });
+
+    expect(sendTextMock.mock.calls.map((call) => call[1])).toEqual(["final answer"]);
+    expect(sendMediaMock).not.toHaveBeenCalled();
+  });
+
+  it("renews pending tool-media fallback when partial progress is delivered", async () => {
+    vi.useFakeTimers();
+    const mediaUrl = "https://example.com/progress.png";
+    const runtime = makeRuntime({
+      onDeliver: async (deliver) => {
+        await deliver({ mediaUrl }, { kind: "tool" });
+        await vi.advanceTimersByTimeAsync(59_000);
+        await deliver({ text: "Working: checking logs" }, { kind: "tool" });
+        await vi.advanceTimersByTimeAsync(1_000);
+        expect(sendMediaMock).not.toHaveBeenCalled();
+        await deliver({ text: "final answer" }, { kind: "block" });
+      },
+    });
+
+    await dispatchOutbound(makeInbound(), {
+      runtime,
+      cfg: {},
+      account: { ...account, config: { streaming: { mode: "partial" } } },
+    });
+
+    expect(sendTextMock.mock.calls.map((call) => call[1])).toEqual([
+      "Working: checking logs",
+      "final answer",
+    ]);
+    expect(sendMediaMock).toHaveBeenCalledTimes(1);
   });
 
   it("marks recognized C2C framework slash commands as text commands", async () => {

--- a/extensions/qqbot/src/engine/gateway/outbound-dispatch.ts
+++ b/extensions/qqbot/src/engine/gateway/outbound-dispatch.ts
@@ -68,7 +68,27 @@ type ReplyDeliverPayload = {
   mediaUrls?: string[];
   mediaUrl?: string;
   audioAsVoice?: boolean;
+  isError?: boolean;
 };
+
+function shouldDeliverToolProgressImmediately(account: GatewayAccount): boolean {
+  const streaming = account.config?.streaming;
+  if (streaming === true) {
+    return true;
+  }
+  return typeof streaming === "object" && streaming !== null && streaming.mode !== "off";
+}
+
+function immediateToolProgressText(payload: ReplyDeliverPayload): string | undefined {
+  const text = (payload.text ?? "").trim();
+  if (!text || payload.isError || payload.audioAsVoice) {
+    return undefined;
+  }
+  if (payload.mediaUrl || payload.mediaUrls?.length) {
+    return undefined;
+  }
+  return text;
+}
 
 // ============ dispatchOutbound ============
 
@@ -155,6 +175,31 @@ export async function dispatchOutbound(
     }
   };
 
+  const hasPendingToolFallbackPayload = (): boolean =>
+    toolTexts.length > 0 || toolMediaUrls.length > 0;
+
+  const renewToolOnlyFallback = (): boolean => {
+    if (toolFallbackSent) {
+      return false;
+    }
+    if (toolOnlyTimeoutId) {
+      if (toolRenewalCount >= MAX_TOOL_RENEWALS) {
+        return false;
+      }
+      clearTimeout(toolOnlyTimeoutId);
+      toolRenewalCount++;
+    }
+    toolOnlyTimeoutId = setTimeout(async () => {
+      if (!hasBlockResponse && !toolFallbackSent) {
+        toolFallbackSent = true;
+        try {
+          await sendToolFallback();
+        } catch {}
+      }
+    }, TOOL_ONLY_TIMEOUT);
+    return true;
+  };
+
   // ---- Timeout promise ----
   // #85267: derive watchdog from existing agent / provider timeout config so
   // a longer configured ceiling (e.g. slow local ollama models) is not
@@ -208,6 +253,7 @@ export async function dispatchOutbound(
         ? ("group" as const)
         : ("channel" as const);
   const useOfficialC2cStream = shouldUseOfficialC2cStream(account, targetType);
+  const deliverToolProgressImmediately = shouldDeliverToolProgressImmediately(account);
   let streamingController: StreamingController | null = null;
   if (useOfficialC2cStream) {
     streamingController = new StreamingController({
@@ -275,6 +321,31 @@ export async function dispatchOutbound(
                 if (info.kind === "tool") {
                   toolDeliverCount++;
                   const toolText = (payload.text ?? "").trim();
+                  const textOnlyProgress = immediateToolProgressText(payload);
+                  if (!hasBlockResponse && deliverToolProgressImmediately && textOnlyProgress) {
+                    if (toolOnlyTimeoutId || hasPendingToolFallbackPayload()) {
+                      renewToolOnlyFallback();
+                    }
+                    await sendPlainReply(
+                      { text: textOnlyProgress },
+                      textOnlyProgress,
+                      {
+                        type: event.type,
+                        senderId: event.senderId,
+                        messageId: event.messageId,
+                        channelId: event.channelId,
+                        groupOpenid: event.groupOpenid,
+                        msgIdx: event.msgIdx,
+                      },
+                      { account, qualifiedTarget, log },
+                      sendWithRetry,
+                      () => undefined,
+                      [],
+                      deliverDeps,
+                    );
+                    recordOutbound();
+                    return;
+                  }
                   if (toolText) {
                     toolTexts.push(toolText);
                   }
@@ -305,22 +376,7 @@ export async function dispatchOutbound(
                   if (toolFallbackSent) {
                     return;
                   }
-                  if (toolOnlyTimeoutId) {
-                    if (toolRenewalCount < MAX_TOOL_RENEWALS) {
-                      clearTimeout(toolOnlyTimeoutId);
-                      toolRenewalCount++;
-                    } else {
-                      return;
-                    }
-                  }
-                  toolOnlyTimeoutId = setTimeout(async () => {
-                    if (!hasBlockResponse && !toolFallbackSent) {
-                      toolFallbackSent = true;
-                      try {
-                        await sendToolFallback();
-                      } catch {}
-                    }
-                  }, TOOL_ONLY_TIMEOUT);
+                  renewToolOnlyFallback();
                   return;
                 }
 

--- a/extensions/qqbot/src/engine/gateway/outbound-dispatch.ts
+++ b/extensions/qqbot/src/engine/gateway/outbound-dispatch.ts
@@ -15,6 +15,7 @@ import type { FinalizedMsgContext } from "openclaw/plugin-sdk/reply-runtime";
 import {
   parseAndSendMediaTags,
   sendPlainReply,
+  sendTextOnlyReply,
   type DeliverDeps,
 } from "../messaging/outbound-deliver.js";
 import {
@@ -326,8 +327,7 @@ export async function dispatchOutbound(
                     if (toolOnlyTimeoutId || hasPendingToolFallbackPayload()) {
                       renewToolOnlyFallback();
                     }
-                    await sendPlainReply(
-                      { text: textOnlyProgress },
+                    await sendTextOnlyReply(
                       textOnlyProgress,
                       {
                         type: event.type,
@@ -340,7 +340,6 @@ export async function dispatchOutbound(
                       { account, qualifiedTarget, log },
                       sendWithRetry,
                       () => undefined,
-                      [],
                       deliverDeps,
                     );
                     recordOutbound();

--- a/extensions/qqbot/src/engine/messaging/outbound-deliver.ts
+++ b/extensions/qqbot/src/engine/messaging/outbound-deliver.ts
@@ -173,8 +173,9 @@ async function sendTextChunkToTarget(params: {
   text: string;
   consumeQuoteRef: ConsumeQuoteRefFn;
   allowDm: boolean;
+  forcePlainText?: boolean;
 }): Promise<unknown> {
-  const { account, event, text, consumeQuoteRef, allowDm } = params;
+  const { account, event, text, consumeQuoteRef, allowDm, forcePlainText } = params;
   const ref = consumeQuoteRef();
   const target = buildDeliveryTarget(event);
   if (target.type === "dm" && !allowDm) {
@@ -184,6 +185,7 @@ async function sendTextChunkToTarget(params: {
   return await senderSendText(target, text, creds, {
     msgId: event.messageId,
     messageReference: ref,
+    forcePlainText,
   });
 }
 
@@ -211,6 +213,35 @@ async function sendTextChunks(
   });
 }
 
+export async function sendTextOnlyReply(
+  text: string,
+  event: DeliverEventContext,
+  actx: DeliverAccountContext,
+  sendWithRetry: SendWithRetryFn,
+  consumeQuoteRef: ConsumeQuoteRefFn,
+  deps: DeliverDeps,
+): Promise<void> {
+  const safeText = filterInternalMarkers(text).trim();
+  if (!safeText) {
+    return;
+  }
+  const { account, log } = actx;
+  const chunks = deps.chunkText(safeText, TEXT_CHUNK_LIMIT);
+  await sendTextChunksWithRetry({
+    account,
+    event,
+    chunks,
+    sendWithRetry,
+    consumeQuoteRef,
+    allowDm: true,
+    forcePlainText: true,
+    log,
+    onSuccess: (chunk) =>
+      `Sent text-only chunk (${chunk.length}/${safeText.length} chars): ${chunk.slice(0, 50)}...`,
+    onError: (err) => `Failed to send text-only chunk: ${formatErrorMessage(err)}`,
+  });
+}
+
 async function sendTextChunksWithRetry(params: {
   account: GatewayAccount;
   event: DeliverEventContext;
@@ -218,11 +249,13 @@ async function sendTextChunksWithRetry(params: {
   sendWithRetry: SendWithRetryFn;
   consumeQuoteRef: ConsumeQuoteRefFn;
   allowDm: boolean;
+  forcePlainText?: boolean;
   log?: DeliverAccountContext["log"];
   onSuccess: (chunk: string) => string;
   onError: (err: unknown) => string;
 }): Promise<void> {
-  const { account, event, chunks, sendWithRetry, consumeQuoteRef, allowDm, log } = params;
+  const { account, event, chunks, sendWithRetry, consumeQuoteRef, allowDm, forcePlainText, log } =
+    params;
   for (const chunk of chunks) {
     try {
       await sendWithRetry((token) =>
@@ -233,6 +266,7 @@ async function sendTextChunksWithRetry(params: {
           text: chunk,
           consumeQuoteRef,
           allowDm,
+          forcePlainText,
         }),
       );
       log?.info(params.onSuccess(chunk));

--- a/extensions/qqbot/src/engine/messaging/sender.ts
+++ b/extensions/qqbot/src/engine/messaging/sender.ts
@@ -383,7 +383,7 @@ export async function sendText(
   target: DeliveryTarget,
   content: string,
   creds: AccountCreds,
-  opts?: { msgId?: string; messageReference?: string },
+  opts?: { msgId?: string; messageReference?: string; forcePlainText?: boolean },
 ): Promise<MessageResponse> {
   const api = resolveAccount(creds.appId).messageApi;
   const c: Credentials = { appId: creds.appId, clientSecret: creds.clientSecret };
@@ -394,9 +394,12 @@ export async function sendText(
       return api.sendMessage(scope, target.id, content, c, {
         msgId: opts.msgId,
         messageReference: opts.messageReference,
+        forcePlainText: opts.forcePlainText,
       });
     }
-    return api.sendProactiveMessage(scope, target.id, content, c);
+    return api.sendProactiveMessage(scope, target.id, content, c, {
+      forcePlainText: opts?.forcePlainText,
+    });
   }
 
   if (target.type === "dm") {


### PR DESCRIPTION
## Summary
- Fixes #66509.
- QQBot now delivers text-only `kind: "tool"` progress immediately when streaming progress is enabled.
- Forces immediate tool progress through QQ plain-text sends so markdown-enabled accounts do not expand media-like tool output.
- Keeps streaming-off behavior buffered/final-only and leaves media, voice, final block, and official C2C stream-controller ownership unchanged.

## Root Cause
`extensions/qqbot/src/engine/gateway/outbound-dispatch.ts` buffered text-only tool deliveries in `toolTexts` and started a fallback timer. When a later block reply arrived, the final block path cleared that timer and delivered the final answer without flushing the buffered tool text, so users saw silence until the final response even with partial streaming enabled.

## Real Behavior Proof
Behavior addressed: QQBot text-only `kind: "tool"` progress no longer disappears when a later `kind: "block"` response arrives under legacy partial streaming or recommended `streaming: true` C2C streaming. Immediate progress is also forced to QQ plain text so markdown-enabled accounts cannot reinterpret media-like tool output as rich content.

Real environment tested: local OpenClaw source checkout and AWS Crabbox Linux validation for the QQBot outbound dispatcher and changed extension lanes at head `e8c65c38521cf5daa930d700de81dc4eab049220`.

Exact steps or command run after this patch:
- `git diff --check`
- `node scripts/run-vitest.mjs extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts -- --reporter=verbose`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo`
- `AUTOREVIEW_OPENCLAW_MAINTAINER_VALIDATION=1 AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- AWS Crabbox fresh-pr run `run_30b6aa679f71` on provider `aws`, lease `cbx_20e4bc805308`: `pnpm install --frozen-lockfile; node scripts/run-vitest.mjs extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts -- --reporter=verbose; node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo; CI=1 pnpm check:changed`

Evidence after fix:
```text
streaming true:
sendText -> Working: checking logs
sendText -> final answer

partial streaming object:
sendText -> Working: checking logs
sendText -> final answer

markdown-enabled progress containing ![x](http://internal.example/progress.png):
sendText -> forcePlainText: true
sendMedia -> not called

streaming off:
sendText -> final answer
```

Observed result after fix: recommended `streaming: true` and legacy `{ mode: "partial" }` send text-only tool progress before the final answer; `streaming: false` preserves final-only behavior. AWS Crabbox passed the QQBot regression test, extension test typecheck, and `pnpm check:changed`.

What was not tested: live QQBot network transport.

## Security Impact
- New permissions/capabilities: No
- Secrets/tokens handling changed: No
- New/changed network calls: No
- Command/tool execution surface changed: No
- Data access scope changed: No

## Scope Boundary
Only QQBot outbound dispatch and QQBot text-send formatting plumbing changed. Shared reply semantics, media fallback, final block delivery, and official C2C streaming controller paths stay unchanged.
