### PR TITLE
fix(gateway): reject blank session history keys

### DIFF
--- a/src/gateway/sessions-history-http.test.ts
+++ b/src/gateway/sessions-history-http.test.ts
@@ -763,6 +763,24 @@ describe("session history HTTP endpoints", () => {
     });
   });
 
+  test("claims invalid encoded session keys on a listening Gateway", async () => {
+    await withGatewayHarness(async (harness) => {
+      for (const encodedSessionKey of ["%20", "%zz"]) {
+        const response = await fetch(
+          `http://127.0.0.1:${harness.port}/sessions/${encodedSessionKey}/history`,
+        );
+        const body = await response.json();
+        expect(response.status).toBe(400);
+        expect(body).toEqual({
+          error: {
+            type: "invalid_request_error",
+            message: "invalid session key",
+          },
+        });
+      }
+    });
+  });
+
   test("keeps standalone delivery-mirror rows in direct REST history", async () => {
     const { storePath } = await seedSession({ text: "visible history" });
     await appendTranscriptMessage({

--- a/src/gateway/sessions-history-http.ts
+++ b/src/gateway/sessions-history-http.ts
@@ -47,16 +47,26 @@ const log = createSubsystemLogger("gateway/sessions-history-sse");
 
 const MAX_SESSION_HISTORY_LIMIT = 1000;
 
-function resolveSessionHistoryPath(req: IncomingMessage): string | null {
+// Route misses must remain distinct from matched-invalid keys so fallback
+// stages cannot claim malformed session-history requests.
+type SessionHistoryPathResolution =
+  | { matched: false }
+  | { error: "invalid-session-key"; matched: true }
+  | { matched: true; sessionKey: string };
+
+function resolveSessionHistoryPath(req: IncomingMessage): SessionHistoryPathResolution {
   const url = new URL(req.url ?? "/", "http://localhost");
   const match = url.pathname.match(/^\/sessions\/([^/]+)\/history$/);
   if (!match) {
-    return null;
+    return { matched: false };
   }
   try {
-    return normalizeOptionalString(decodeURIComponent(match[1] ?? "")) ?? null;
+    const sessionKey = normalizeOptionalString(decodeURIComponent(match[1] ?? ""));
+    return sessionKey
+      ? { matched: true, sessionKey }
+      : { error: "invalid-session-key", matched: true };
   } catch {
-    return "";
+    return { error: "invalid-session-key", matched: true };
   }
 }
 
@@ -101,14 +111,15 @@ export async function handleSessionHistoryHttpRequest(
     rateLimiter?: AuthRateLimiter;
   },
 ): Promise<boolean> {
-  const sessionKey = resolveSessionHistoryPath(req);
-  if (sessionKey === null) {
+  const sessionKeyResolution = resolveSessionHistoryPath(req);
+  if (!sessionKeyResolution.matched) {
     return false;
   }
-  if (!sessionKey) {
+  if ("error" in sessionKeyResolution) {
     sendInvalidRequest(res, "invalid session key");
     return true;
   }
+  const { sessionKey } = sessionKeyResolution;
   if (req.method !== "GET") {
     sendMethodNotAllowed(res, "GET");
     return true;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a blank encoded session-history key such as `%20` matched the core route but was treated as a route miss, allowing the request to fall through to plugin, Control UI, or generic 404 routing instead of returning the endpoint's owned 400 response.

Malformed percent encoding such as `%zz` already returned 400; the regression proof keeps that behavior covered alongside the repaired blank-key case.

## Why This Change Was Made

The session-history route parser now returns a tagged three-state result for route miss, invalid key, and valid key. This matches the adjacent session-kill route contract and removes the hidden `null`/empty-string sentinel pair that caused the shipped fallthrough.

The rewrite keeps parsing at the owning route boundary and leaves valid-key auth, canonical session lookup, transcript reads, pagination, SSE, plugin routing, and Control UI behavior unchanged.

## User Impact

Blank session-history keys now receive a clear HTTP 400 `invalid session key` response. They no longer escape into unrelated fallback routing. Valid session history requests are unchanged.

The bug originated with the direct session-history endpoint in #50101 and is present in stable `v2026.6.11` and `v2026.7.2-beta.7`.

## Evidence

Validated commit: `2b17804fbd537b75d850bbdd16e146be4bc700a7`

Stable patch ID: `9b37ea9d8aae7cf31acccbed47f9f817c7c91368`. The signed commit is rebased directly onto current main `3faa2b08882319e7eec039eabd21abf7d021b243` and remains patch-identical to the clean P1 autoreview candidate `d1899a6cd63bac4b43fa86f26a152d02ded33297` and prior reviewed head `467e479798f23d6582d9128a553e50ab52ea51e4`.

Failure-first proof on untouched current `main`:

```text
/sessions/%20/history -> HTTP 404
```

Real listening-Gateway proof after the repair:

```text
/sessions/%20/history -> HTTP 400
{"error":{"message":"invalid session key","type":"invalid_request_error"}}

/sessions/%zz/history -> HTTP 400
{"error":{"message":"invalid session key","type":"invalid_request_error"}}
```

Focused and sibling coverage:

- `src/gateway/sessions-history-http.test.ts`: 73 passed
- `src/gateway/session-kill-http.test.ts`: 13 passed
- total: 86 passed

Static and changed-surface proof:

- `oxfmt --check`: passed
- direct scoped `oxlint`: 0 warnings, 0 errors
- `git diff --check`: passed
- `node scripts/check-changed.mjs -- src/gateway/sessions-history-http.ts src/gateway/sessions-history-http.test.ts`: passed with exit 0 on Blacksmith Testbox
- delegated run: https://github.com/openclaw/openclaw/actions/runs/30936296726

The backing Actions job shows `Run Testbox` cancelled because the successful one-shot wrapper stopped its externally owned lease; the wrapper reported `exitCode: 0` and `runStatus: succeeded`.

P1 autoreview on the patch-identical candidate returned no findings with 0.98 confidence. Independent owner-path and history reviews also found no blocking issue.

Production delta: `+18/-7` (net `+11`) for the explicit owner-boundary state contract.

Regression delta: `+18` for real listening-Gateway coverage.

No config, protocol, auth, persistence, migration, or public API changes.



Punchcard-Session: clear-orchard-lantern-bc
