### PR TITLE
feat: add provider-aware MiniMax rate limiter

### DIFF
--- a/docs/providers/minimax.md
+++ b/docs/providers/minimax.md
@@ -503,3 +503,40 @@ More help: [Troubleshooting](/help/troubleshooting) and [FAQ](/help/faq).
     General troubleshooting and FAQ.
   </Card>
 </CardGroup>
+
+## Provider-aware limiter
+
+OpenClaw applies a proactive provider-aware limiter to MiniMax text models on the
+shared model transport path. The limiter is keyed by provider, auth profile when
+known, capability, and model so MiniMax throttling does not slow unrelated
+providers.
+
+Defaults follow MiniMax's published text limits for `MiniMax-M2.7` and
+`MiniMax-M2.7-highspeed`: 500 RPM and 20,000,000 TPM. OpenClaw uses 85% headroom
+by default to avoid running exactly at the provider edge. The limiter also tracks
+MiniMax's documented weekly allowance as `10 × the 5-hour usage quota`, derived
+as:
+
+- weekly requests: `RPM × 60 × 5 × 10`
+- weekly tokens: `TPM × 60 × 5 × 10`
+
+The limiter still observes response headers when providers send them. Standard
+`Retry-After`, `x-ratelimit-limit`, `x-ratelimit-remaining`, and
+`x-ratelimit-reset` variants can adjust the in-memory bucket/cooldown state for
+future requests.
+
+Environment overrides are intentionally narrow and optional:
+
+- `OPENCLAW_PROVIDER_LIMITER_ENABLED=0` disables the proactive limiter.
+- `OPENCLAW_PROVIDER_LIMITER_HEADROOM=0.9` changes the global limiter headroom.
+- `OPENCLAW_PROVIDER_LIMITER_MINIMAX_RPM=500` overrides MiniMax RPM.
+- `OPENCLAW_PROVIDER_LIMITER_MINIMAX_TPM=20000000` overrides MiniMax TPM.
+- `OPENCLAW_PROVIDER_LIMITER_MINIMAX_WEEKLY=0` disables weekly accounting.
+- `OPENCLAW_PROVIDER_LIMITER_MINIMAX_WEEKLY_REQUESTS=1500000` overrides the
+  derived weekly request allowance.
+- `OPENCLAW_PROVIDER_LIMITER_MINIMAX_WEEKLY_TOKENS=60000000000` overrides the
+  derived weekly token allowance.
+
+This complements, rather than replaces, `auth.cooldowns`: proactive limiting
+slows requests before provider limits are hit, while cooldowns/fallbacks still
+handle provider-side 429s, overloads, and account-specific failures.

--- a/src/agents/provider-rate-limiter.test.ts
+++ b/src/agents/provider-rate-limiter.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  buildProviderLimiterBucketKey,
+  estimateProviderRequestTokens,
+  observeProviderLimiterResponse,
+  parseProviderRateLimitHeaders,
+  parseRetryAfterMs,
+  reserveProviderLimiterSlot,
+  resetProviderLimiterForTests,
+  resolveProviderLimiterPolicy,
+} from "./provider-rate-limiter.js";
+
+describe("provider rate limiter", () => {
+  afterEach(() => {
+    resetProviderLimiterForTests();
+    vi.useRealTimers();
+    delete process.env.OPENCLAW_PROVIDER_LIMITER_HEADROOM;
+    delete process.env.OPENCLAW_PROVIDER_LIMITER_MINIMAX_WEEKLY;
+  });
+
+  it("selects MiniMax M2.7 and highspeed policies with documented defaults", () => {
+    const policy = resolveProviderLimiterPolicy({ provider: "minimax", model: "MiniMax-M2.7" });
+    const highspeed = resolveProviderLimiterPolicy({
+      provider: "minimax-portal",
+      model: "MiniMax-M2.7-highspeed",
+    });
+    expect(policy).toMatchObject({ rpm: 500, tpm: 20_000_000, headroom: 0.85 });
+    expect(policy?.weeklyRequestLimit).toBe(500 * 60 * 5 * 10);
+    expect(policy?.weeklyTokenLimit).toBe(20_000_000 * 60 * 5 * 10);
+    expect(highspeed?.rpm).toBe(500);
+    expect(resolveProviderLimiterPolicy({ provider: "openai", model: "gpt-5.4" })).toBeUndefined();
+  });
+
+  it("builds provider/profile/capability/model bucket keys", () => {
+    expect(
+      buildProviderLimiterBucketKey({
+        provider: "MiniMax",
+        profile: "acct-A",
+        capability: "LLM",
+        model: "MiniMax-M2.7",
+      }),
+    ).toBe("minimax|acct-a|llm|MiniMax-M2.7");
+  });
+
+  it("delays when RPM headroom is exhausted", () => {
+    const policy = {
+      enabled: true,
+      provider: "minimax",
+      model: "MiniMax-M2.7",
+      rpm: 2,
+      tpm: 1_000,
+      headroom: 0.5,
+      weeklyEnabled: false,
+    };
+    const key = { provider: "minimax", model: "MiniMax-M2.7", capability: "llm" };
+    expect(reserveProviderLimiterSlot({ key, policy, tokens: 1, nowMs: 1_000 }).delayMs).toBe(0);
+    const second = reserveProviderLimiterSlot({ key, policy, tokens: 1, nowMs: 1_001 });
+    expect(second.reason).toBe("rpm");
+    expect(second.delayMs).toBe(59_999);
+  });
+
+  it("delays when TPM headroom is exhausted", () => {
+    const policy = {
+      enabled: true,
+      provider: "minimax",
+      model: "MiniMax-M2.7",
+      rpm: 100,
+      tpm: 10,
+      headroom: 1,
+      weeklyEnabled: false,
+    };
+    const key = { provider: "minimax", model: "MiniMax-M2.7", capability: "llm" };
+    expect(reserveProviderLimiterSlot({ key, policy, tokens: 8, nowMs: 2_000 }).delayMs).toBe(0);
+    const second = reserveProviderLimiterSlot({ key, policy, tokens: 3, nowMs: 2_500 });
+    expect(second.reason).toBe("tpm");
+    expect(second.delayMs).toBe(59_500);
+  });
+
+  it("accounts for weekly request allowance", () => {
+    const policy = {
+      enabled: true,
+      provider: "minimax",
+      model: "MiniMax-M2.7",
+      rpm: 100,
+      tpm: 1_000,
+      headroom: 1,
+      weeklyEnabled: true,
+      weeklyRequestLimit: 1,
+      weeklyTokenLimit: 1_000,
+    };
+    const key = { provider: "minimax", model: "MiniMax-M2.7", capability: "llm" };
+    expect(reserveProviderLimiterSlot({ key, policy, tokens: 1, nowMs: 10_000 }).delayMs).toBe(0);
+    const second = reserveProviderLimiterSlot({ key, policy, tokens: 1, nowMs: 11_000 });
+    expect(second.reason).toBe("weekly-requests");
+    expect(second.delayMs).toBe(7 * 24 * 60 * 60 * 1000 - 1_000);
+  });
+
+  it("parses Retry-After seconds and HTTP-date", () => {
+    expect(parseRetryAfterMs("2.5", 1_000)).toBe(2_500);
+    expect(parseRetryAfterMs("Thu, 01 Jan 1970 00:00:03 GMT", 1_000)).toBe(2_000);
+    expect(parseRetryAfterMs("nonsense", 1_000)).toBeUndefined();
+  });
+
+  it("parses standard rate-limit headers", () => {
+    const headers = new Headers({
+      "x-ratelimit-limit": "123",
+      "x-ratelimit-remaining": "0",
+      "x-ratelimit-reset": "5",
+      "retry-after": "2",
+    });
+    expect(parseProviderRateLimitHeaders(headers, 10_000)).toEqual({
+      retryAfterMs: 2_000,
+      limit: 123,
+      remaining: 0,
+      resetAtMs: 15_000,
+    });
+  });
+
+  it("learns Retry-After cooldowns from 429 responses", () => {
+    const policy = {
+      enabled: true,
+      provider: "minimax",
+      model: "MiniMax-M2.7",
+      rpm: 100,
+      tpm: 1_000,
+      headroom: 1,
+      weeklyEnabled: false,
+    };
+    const key = { provider: "minimax", model: "MiniMax-M2.7", capability: "llm" };
+    observeProviderLimiterResponse({
+      key,
+      policy,
+      status: 429,
+      headers: new Headers({ "retry-after": "3" }),
+      nowMs: 10_000,
+    });
+    const next = reserveProviderLimiterSlot({ key, policy, tokens: 1, nowMs: 11_000 });
+    expect(next.reason).toBe("retry-after");
+    expect(next.delayMs).toBe(2_000);
+  });
+
+  it("estimates request tokens conservatively from JSON payloads", () => {
+    expect(estimateProviderRequestTokens(JSON.stringify({ input: "abcdefgh" }))).toBeGreaterThan(1);
+    expect(estimateProviderRequestTokens(undefined)).toBe(1);
+  });
+});

--- a/src/agents/provider-rate-limiter.ts
+++ b/src/agents/provider-rate-limiter.ts
@@ -1,0 +1,362 @@
+import { createSubsystemLogger } from "../logging/subsystem.js";
+
+const log = createSubsystemLogger("provider-rate-limiter");
+
+const MINUTE_MS = 60_000;
+const HOUR_MS = 60 * MINUTE_MS;
+const WEEK_MS = 7 * 24 * HOUR_MS;
+const DEFAULT_HEADROOM = 0.85;
+const MINIMAX_TEXT_RPM = 500;
+const MINIMAX_TEXT_TPM = 20_000_000;
+
+type LimitRecord = { at: number; requests: number; tokens: number };
+
+type RateLimitReason = "rpm" | "tpm" | "weekly-requests" | "weekly-tokens" | "retry-after";
+
+export type ProviderLimiterPolicy = {
+  enabled: boolean;
+  provider: string;
+  model: string;
+  rpm?: number;
+  tpm?: number;
+  headroom: number;
+  weeklyEnabled: boolean;
+  weeklyRequestLimit?: number;
+  weeklyTokenLimit?: number;
+};
+
+export type ProviderLimiterKey = {
+  provider: string;
+  model: string;
+  profile?: string;
+  capability?: string;
+};
+
+export type ProviderLimiterDecision = {
+  delayMs: number;
+  reason?: RateLimitReason;
+  bucketKey: string;
+};
+
+export type ParsedRateLimitHeaders = {
+  retryAfterMs?: number;
+  limit?: number;
+  remaining?: number;
+  resetAtMs?: number;
+};
+
+type BucketState = {
+  minute: LimitRecord[];
+  week: LimitRecord[];
+  cooldownUntilMs?: number;
+  learnedRpm?: number;
+};
+
+const buckets = new Map<string, BucketState>();
+
+function readBooleanEnv(name: string, defaultValue: boolean): boolean {
+  const value = process.env[name]?.trim();
+  if (!value) return defaultValue;
+  return !/^(?:0|false|off|no|disabled)$/i.test(value);
+}
+
+function readNumberEnv(name: string): number | undefined {
+  const value = process.env[name]?.trim();
+  if (!value) return undefined;
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
+}
+
+function clampHeadroom(value: number | undefined): number {
+  if (value === undefined) return DEFAULT_HEADROOM;
+  if (!Number.isFinite(value) || value <= 0) return DEFAULT_HEADROOM;
+  return Math.min(1, value);
+}
+
+export function buildProviderLimiterBucketKey(key: ProviderLimiterKey): string {
+  return [
+    key.provider.trim().toLowerCase(),
+    key.profile?.trim().toLowerCase() || "default",
+    key.capability?.trim().toLowerCase() || "llm",
+    key.model.trim(),
+  ].join("|");
+}
+
+export function resolveProviderLimiterPolicy(params: {
+  provider: string;
+  model: string;
+}): ProviderLimiterPolicy | undefined {
+  const provider = params.provider.trim().toLowerCase();
+  const model = params.model.trim();
+  if (provider !== "minimax" && provider !== "minimax-portal") return undefined;
+  if (!/^MiniMax-M2\.(?:7|5|1)(?:-highspeed)?$/.test(model) && model !== "MiniMax-M2") {
+    return undefined;
+  }
+
+  const rpm = readNumberEnv("OPENCLAW_PROVIDER_LIMITER_MINIMAX_RPM") ?? MINIMAX_TEXT_RPM;
+  const tpm = readNumberEnv("OPENCLAW_PROVIDER_LIMITER_MINIMAX_TPM") ?? MINIMAX_TEXT_TPM;
+  const weeklyEnabled = readBooleanEnv("OPENCLAW_PROVIDER_LIMITER_MINIMAX_WEEKLY", true);
+  const weeklyRequestLimit =
+    readNumberEnv("OPENCLAW_PROVIDER_LIMITER_MINIMAX_WEEKLY_REQUESTS") ?? rpm * 60 * 5 * 10;
+  const weeklyTokenLimit =
+    readNumberEnv("OPENCLAW_PROVIDER_LIMITER_MINIMAX_WEEKLY_TOKENS") ?? tpm * 60 * 5 * 10;
+
+  return {
+    enabled: readBooleanEnv("OPENCLAW_PROVIDER_LIMITER_ENABLED", true),
+    provider,
+    model,
+    rpm,
+    tpm,
+    headroom: clampHeadroom(readNumberEnv("OPENCLAW_PROVIDER_LIMITER_HEADROOM")),
+    weeklyEnabled,
+    weeklyRequestLimit,
+    weeklyTokenLimit,
+  };
+}
+
+export function parseRetryAfterMs(
+  value: string | null | undefined,
+  nowMs = Date.now(),
+): number | undefined {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  const seconds = Number.parseFloat(trimmed);
+  if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1000;
+  const retryAt = Date.parse(trimmed);
+  if (Number.isNaN(retryAt)) return undefined;
+  return Math.max(0, retryAt - nowMs);
+}
+
+function parseHeaderNumber(headers: Headers, names: string[]): number | undefined {
+  for (const name of names) {
+    const raw = headers.get(name);
+    if (!raw) continue;
+    const parsed = Number.parseFloat(raw);
+    if (Number.isFinite(parsed) && parsed >= 0) return parsed;
+  }
+  return undefined;
+}
+
+export function parseProviderRateLimitHeaders(
+  headers: Headers,
+  nowMs = Date.now(),
+): ParsedRateLimitHeaders {
+  const resetSeconds = parseHeaderNumber(headers, [
+    "x-ratelimit-reset",
+    "x-rate-limit-reset",
+    "ratelimit-reset",
+  ]);
+  const resetAtMs =
+    resetSeconds === undefined
+      ? undefined
+      : resetSeconds > 10_000_000_000
+        ? resetSeconds
+        : resetSeconds > 10_000_000
+          ? resetSeconds * 1000
+          : nowMs + resetSeconds * 1000;
+  return {
+    retryAfterMs:
+      parseRetryAfterMs(headers.get("retry-after-ms"), nowMs) ??
+      parseRetryAfterMs(headers.get("retry-after"), nowMs),
+    limit: parseHeaderNumber(headers, [
+      "x-ratelimit-limit",
+      "x-rate-limit-limit",
+      "ratelimit-limit",
+    ]),
+    remaining: parseHeaderNumber(headers, [
+      "x-ratelimit-remaining",
+      "x-rate-limit-remaining",
+      "ratelimit-remaining",
+    ]),
+    resetAtMs,
+  };
+}
+
+function prune(records: LimitRecord[], nowMs: number, windowMs: number): void {
+  while (records.length > 0 && records[0]!.at <= nowMs - windowMs) records.shift();
+}
+
+function usage(records: LimitRecord[]): { requests: number; tokens: number } {
+  return records.reduce(
+    (acc, record) => ({
+      requests: acc.requests + record.requests,
+      tokens: acc.tokens + record.tokens,
+    }),
+    { requests: 0, tokens: 0 },
+  );
+}
+
+function delayUntilBudget(params: {
+  records: LimitRecord[];
+  nowMs: number;
+  windowMs: number;
+  current: number;
+  cost: number;
+  limit: number | undefined;
+  read: (record: LimitRecord) => number;
+}): number {
+  if (!params.limit || params.limit <= 0 || params.current + params.cost <= params.limit) return 0;
+  let overflow = params.current + params.cost - params.limit;
+  for (const record of params.records) {
+    overflow -= params.read(record);
+    if (overflow <= 0) return Math.max(0, record.at + params.windowMs - params.nowMs);
+  }
+  return params.windowMs;
+}
+
+export function estimateProviderRequestTokens(body: unknown): number {
+  if (typeof body !== "string") return 1;
+  const trimmed = body.trim();
+  if (!trimmed) return 1;
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    const text = JSON.stringify(parsed);
+    return Math.max(1, Math.ceil(text.length / 4));
+  } catch {
+    return Math.max(1, Math.ceil(trimmed.length / 4));
+  }
+}
+
+export function reserveProviderLimiterSlot(params: {
+  key: ProviderLimiterKey;
+  policy: ProviderLimiterPolicy;
+  tokens: number;
+  nowMs?: number;
+}): ProviderLimiterDecision {
+  const nowMs = params.nowMs ?? Date.now();
+  const bucketKey = buildProviderLimiterBucketKey(params.key);
+  const state = buckets.get(bucketKey) ?? { minute: [], week: [] };
+  buckets.set(bucketKey, state);
+  prune(state.minute, nowMs, MINUTE_MS);
+  prune(state.week, nowMs, WEEK_MS);
+
+  const effectiveRpm = (state.learnedRpm ?? params.policy.rpm ?? 0) * params.policy.headroom;
+  const effectiveTpm = (params.policy.tpm ?? 0) * params.policy.headroom;
+  const effectiveWeeklyRequests = params.policy.weeklyEnabled
+    ? (params.policy.weeklyRequestLimit ?? 0) * params.policy.headroom
+    : undefined;
+  const effectiveWeeklyTokens = params.policy.weeklyEnabled
+    ? (params.policy.weeklyTokenLimit ?? 0) * params.policy.headroom
+    : undefined;
+
+  const minuteUsage = usage(state.minute);
+  const weekUsage = usage(state.week);
+  const cooldownDelay = state.cooldownUntilMs ? Math.max(0, state.cooldownUntilMs - nowMs) : 0;
+  const candidates: Array<{ delayMs: number; reason: RateLimitReason }> = [
+    { delayMs: cooldownDelay, reason: "retry-after" },
+    {
+      delayMs: delayUntilBudget({
+        records: state.minute,
+        nowMs,
+        windowMs: MINUTE_MS,
+        current: minuteUsage.requests,
+        cost: 1,
+        limit: effectiveRpm,
+        read: (record) => record.requests,
+      }),
+      reason: "rpm",
+    },
+    {
+      delayMs: delayUntilBudget({
+        records: state.minute,
+        nowMs,
+        windowMs: MINUTE_MS,
+        current: minuteUsage.tokens,
+        cost: params.tokens,
+        limit: effectiveTpm,
+        read: (record) => record.tokens,
+      }),
+      reason: "tpm",
+    },
+    {
+      delayMs: delayUntilBudget({
+        records: state.week,
+        nowMs,
+        windowMs: WEEK_MS,
+        current: weekUsage.requests,
+        cost: 1,
+        limit: effectiveWeeklyRequests,
+        read: (record) => record.requests,
+      }),
+      reason: "weekly-requests",
+    },
+    {
+      delayMs: delayUntilBudget({
+        records: state.week,
+        nowMs,
+        windowMs: WEEK_MS,
+        current: weekUsage.tokens,
+        cost: params.tokens,
+        limit: effectiveWeeklyTokens,
+        read: (record) => record.tokens,
+      }),
+      reason: "weekly-tokens",
+    },
+  ];
+  const selected = candidates.reduce((best, candidate) =>
+    candidate.delayMs > best.delayMs ? candidate : best,
+  );
+  const reserveAt = nowMs + selected.delayMs;
+  state.minute.push({ at: reserveAt, requests: 1, tokens: params.tokens });
+  state.week.push({ at: reserveAt, requests: 1, tokens: params.tokens });
+  return {
+    bucketKey,
+    delayMs: selected.delayMs,
+    ...(selected.delayMs > 0 ? { reason: selected.reason } : {}),
+  };
+}
+
+export function observeProviderLimiterResponse(params: {
+  key: ProviderLimiterKey;
+  policy: ProviderLimiterPolicy;
+  status: number;
+  headers: Headers;
+  nowMs?: number;
+}): void {
+  const nowMs = params.nowMs ?? Date.now();
+  const bucketKey = buildProviderLimiterBucketKey(params.key);
+  const state = buckets.get(bucketKey) ?? { minute: [], week: [] };
+  buckets.set(bucketKey, state);
+  const parsed = parseProviderRateLimitHeaders(params.headers, nowMs);
+  if (parsed.limit !== undefined && parsed.limit > 0) state.learnedRpm = parsed.limit;
+  if (params.status === 429 && parsed.retryAfterMs !== undefined) {
+    state.cooldownUntilMs = Math.max(state.cooldownUntilMs ?? 0, nowMs + parsed.retryAfterMs);
+  }
+  if (parsed.remaining === 0 && parsed.resetAtMs !== undefined) {
+    state.cooldownUntilMs = Math.max(state.cooldownUntilMs ?? 0, parsed.resetAtMs);
+  }
+}
+
+export async function waitForProviderLimiter(params: {
+  key: ProviderLimiterKey;
+  policy: ProviderLimiterPolicy;
+  tokens: number;
+  signal?: AbortSignal | null;
+}): Promise<ProviderLimiterDecision> {
+  if (!params.policy.enabled) {
+    return { delayMs: 0, bucketKey: buildProviderLimiterBucketKey(params.key) };
+  }
+  const decision = reserveProviderLimiterSlot(params);
+  if (decision.delayMs <= 0) return decision;
+  log.info(
+    `[provider-limiter] delaying provider=${params.key.provider} model=${params.key.model} ` +
+      `bucket=${decision.bucketKey} delayMs=${Math.ceil(decision.delayMs)} reason=${decision.reason}`,
+  );
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(resolve, decision.delayMs);
+    if (params.signal) {
+      const abort = () => {
+        clearTimeout(timeout);
+        reject(params.signal?.reason ?? new Error("Provider rate limiter wait aborted"));
+      };
+      if (params.signal.aborted) abort();
+      else params.signal.addEventListener("abort", abort, { once: true });
+    }
+  });
+  return decision;
+}
+
+export function resetProviderLimiterForTests(): void {
+  buckets.clear();
+}

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -24,6 +24,12 @@ import {
   type ProviderLocalServiceLease,
 } from "./provider-local-service.js";
 import {
+  estimateProviderRequestTokens,
+  observeProviderLimiterResponse,
+  resolveProviderLimiterPolicy,
+  waitForProviderLimiter,
+} from "./provider-rate-limiter.js";
+import {
   buildProviderRequestDispatcherPolicy,
   getModelProviderRequestTransport,
   mergeModelProviderRequestOverrides,
@@ -570,6 +576,26 @@ export function buildGuardedModelFetch(
       ...(policy ? { policy } : {}),
     };
     let result: Awaited<ReturnType<typeof fetchWithSsrFGuard>>;
+    const limiterPolicy = resolveProviderLimiterPolicy({
+      provider: model.provider,
+      model: model.id,
+    });
+    const limiterKey = {
+      provider: model.provider,
+      model: model.id,
+      profile: (model as { authProfileId?: unknown; profileId?: unknown }).authProfileId as
+        | string
+        | undefined,
+      capability: "llm",
+    };
+    if (limiterPolicy) {
+      await waitForProviderLimiter({
+        key: limiterKey,
+        policy: limiterPolicy,
+        tokens: estimateProviderRequestTokens((requestInit ?? init)?.body),
+        signal: (requestInit ?? init)?.signal ?? undefined,
+      });
+    }
     const fetchStartedAt = Date.now();
     const useEnvProxy = !dispatcherPolicy && shouldUseEnvHttpProxyForUrl(url);
     emitModelTransportDebug(
@@ -605,6 +631,14 @@ export function buildGuardedModelFetch(
         `status=${response.status} elapsedMs=${Date.now() - fetchStartedAt} ` +
         `contentType=${response.headers.get("content-type") ?? ""}`,
     );
+    if (limiterPolicy) {
+      observeProviderLimiterResponse({
+        key: limiterKey,
+        policy: limiterPolicy,
+        status: response.status,
+        headers: response.headers,
+      });
+    }
     if (shouldBypassLongSdkRetry(response)) {
       const headers = new Headers(response.headers);
       headers.set("x-should-retry", "false");


### PR DESCRIPTION
## Summary

Adds a proactive provider-aware limiter on the shared model transport path, starting with MiniMax text models.

The limiter is keyed by provider, auth profile when available, capability, and model so MiniMax throttling does not slow unrelated providers. It includes:

- MiniMax policy resolver for `minimax` / `minimax-portal` M2 text models
- documented defaults for `MiniMax-M2.7` and `MiniMax-M2.7-highspeed`: 500 RPM, 20,000,000 TPM
- 85% default headroom
- weekly allowance accounting derived from MiniMax docs: `10 × the 5-hour usage quota`
  - weekly requests = `RPM × 60 × 5 × 10`
  - weekly tokens = `TPM × 60 × 5 × 10`
- `Retry-After` parsing for seconds and HTTP-date values
- standard rate-limit header parsing / learning for `x-ratelimit-*`, `x-rate-limit-*`, and `ratelimit-*`
- response observation for 429 / exhausted remaining quota
- safe delay logging without secrets
- MiniMax provider docs with environment overrides

This complements existing `auth.cooldowns`: proactive limiting slows requests before provider limits are hit, while cooldowns/fallbacks still handle provider-side 429s, overloads, and account-specific failures.

## Verification

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit.config.ts src/agents/provider-rate-limiter.test.ts src/agents/provider-transport-fetch.test.ts`
- `corepack pnpm exec oxfmt --check src/agents/provider-rate-limiter.ts src/agents/provider-rate-limiter.test.ts src/agents/provider-transport-fetch.ts`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.src.json --incremental false --pretty false`

## Notes

The first policy is MiniMax-specific, but the limiter module is generic so later provider/model policies can be added without changing the transport seam again.