### PR TITLE
fix(qqbot): derive outbound watchdog from configured timeouts (#85267)

### DIFF
--- a/extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
+++ b/extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
@@ -171,6 +171,47 @@ describe("dispatchOutbound", () => {
     vi.clearAllMocks();
   });
 
+  it("keeps waiting past 300s when a slow provider timeout is configured", async () => {
+    vi.useFakeTimers();
+    try {
+      const runtime = makeRuntime({
+        onDeliver: async (deliver) => {
+          await new Promise<void>((resolve) => setTimeout(resolve, 301_000));
+          await deliver({ text: "late answer" }, { kind: "block" });
+        },
+      });
+      let settled = false;
+
+      const dispatchPromise = dispatchOutbound(makeInbound(), {
+        runtime,
+        cfg: {
+          models: { providers: { ollama: { timeoutSeconds: 1800 } } },
+        },
+        account,
+      }).finally(() => {
+        settled = true;
+      });
+
+      await vi.advanceTimersByTimeAsync(300_000);
+
+      expect(settled).toBe(false);
+      expect(sendTextMock).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      await dispatchPromise;
+
+      expect(sendTextMock).toHaveBeenCalledWith(
+        expect.anything(),
+        "late answer",
+        expect.anything(),
+        expect.anything(),
+      );
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
+  });
+
   it("marks voice-only inbound as audio without adding voice paths to MediaPaths", async () => {
     let finalized: Record<string, unknown> | undefined;
     const runtime = makeRuntime({ onFinalize: (ctx) => (finalized = ctx) });

--- a/extensions/qqbot/src/engine/gateway/outbound-dispatch.ts
+++ b/extensions/qqbot/src/engine/gateway/outbound-dispatch.ts
@@ -33,6 +33,7 @@ import {
 import { StreamingController, shouldUseOfficialC2cStream } from "../messaging/streaming-c2c.js";
 import { audioFileToSilkBase64 } from "../utils/audio.js";
 import type { InboundContext } from "./inbound-context.js";
+import { resolveResponseTimeoutMs } from "./response-timeout.js";
 import type {
   GatewayAccount,
   EngineLogger,
@@ -42,7 +43,12 @@ import type {
 
 // ============ Config ============
 
-const RESPONSE_TIMEOUT = 300_000;
+// Historical floor for the QQBot outbound response watchdog (5 min). The
+// effective wait budget is now derived from existing
+// `agents.defaults.timeoutSeconds` and `models.providers.<id>.timeoutSeconds`
+// via `resolveResponseTimeoutMs(cfg)` — see issue #85267, where a slow
+// local ollama/qwen3.5:27b turn was capped at 5 min despite a configured
+// 1800s provider timeout.
 const TOOL_ONLY_TIMEOUT = 60_000;
 const MAX_TOOL_RENEWALS = 3;
 const TOOL_MEDIA_SEND_TIMEOUT = 45_000;
@@ -149,12 +155,16 @@ export async function dispatchOutbound(
   };
 
   // ---- Timeout promise ----
+  // #85267: derive watchdog from existing agent / provider timeout config so
+  // a longer configured ceiling (e.g. slow local ollama models) is not
+  // silently undercut by a plugin-local 5-minute cap.
+  const responseTimeoutMs = resolveResponseTimeoutMs(cfg);
   const timeoutPromise = new Promise<void>((_, reject) => {
     timeoutId = setTimeout(() => {
       if (!hasResponse) {
         reject(new Error("Response timeout"));
       }
-    }, RESPONSE_TIMEOUT);
+    }, responseTimeoutMs);
   });
 
   // ---- Deliver deps ----

--- a/extensions/qqbot/src/engine/gateway/response-timeout.test.ts
+++ b/extensions/qqbot/src/engine/gateway/response-timeout.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_RESPONSE_TIMEOUT_MS,
+  resolveResponseTimeoutMs,
+} from "./response-timeout.js";
+
+describe("resolveResponseTimeoutMs", () => {
+  it("falls back to the historical 5-minute floor when no timeouts configured", () => {
+    expect(resolveResponseTimeoutMs({})).toBe(DEFAULT_RESPONSE_TIMEOUT_MS);
+    expect(resolveResponseTimeoutMs(undefined)).toBe(DEFAULT_RESPONSE_TIMEOUT_MS);
+    expect(resolveResponseTimeoutMs(null)).toBe(DEFAULT_RESPONSE_TIMEOUT_MS);
+  });
+
+  it("honors longer agents.defaults.timeoutSeconds", () => {
+    expect(
+      resolveResponseTimeoutMs({ agents: { defaults: { timeoutSeconds: 900 } } }),
+    ).toBe(900_000);
+  });
+
+  it("ignores agents.defaults.timeoutSeconds shorter than the historical floor", () => {
+    // Issue #85267: a configured 60s agent timeout must not undercut the
+    // historical 5-minute watchdog floor for previously-working setups.
+    expect(
+      resolveResponseTimeoutMs({ agents: { defaults: { timeoutSeconds: 60 } } }),
+    ).toBe(DEFAULT_RESPONSE_TIMEOUT_MS);
+  });
+
+  it("honors models.providers.<id>.timeoutSeconds for slow local providers (#85267)", () => {
+    // Direct repro shape: ollama + qwen3.5:27b with 1800s timeout. Without
+    // this fix, QQBot capped at 300s and surfaced "LLM request timed out".
+    expect(
+      resolveResponseTimeoutMs({
+        models: { providers: { ollama: { timeoutSeconds: 1800 } } },
+      }),
+    ).toBe(1_800_000);
+  });
+
+  it("takes the maximum across multiple configured providers and agents", () => {
+    expect(
+      resolveResponseTimeoutMs({
+        agents: { defaults: { timeoutSeconds: 600 } },
+        models: {
+          providers: {
+            ollama: { timeoutSeconds: 1800 },
+            "lm-studio": { timeoutSeconds: 900 },
+            openai: { timeoutSeconds: 60 },
+          },
+        },
+      }),
+    ).toBe(1_800_000);
+  });
+
+  it("ignores non-positive or non-numeric timeout values", () => {
+    expect(
+      resolveResponseTimeoutMs({
+        agents: { defaults: { timeoutSeconds: -1 } },
+        models: {
+          providers: {
+            ollama: { timeoutSeconds: 0 },
+            broken: { timeoutSeconds: "1800" as unknown as number },
+            naN: { timeoutSeconds: Number.NaN },
+          },
+        },
+      }),
+    ).toBe(DEFAULT_RESPONSE_TIMEOUT_MS);
+  });
+
+  it("clamps to MAX_SAFE_TIMEOUT_MS for absurd inputs", () => {
+    const huge = resolveResponseTimeoutMs({
+      models: { providers: { ollama: { timeoutSeconds: 10_000_000 } } },
+    });
+    expect(huge).toBeLessThanOrEqual(2_147_000_000);
+    expect(huge).toBeGreaterThan(DEFAULT_RESPONSE_TIMEOUT_MS);
+  });
+});

--- a/extensions/qqbot/src/engine/gateway/response-timeout.ts
+++ b/extensions/qqbot/src/engine/gateway/response-timeout.ts
@@ -1,0 +1,103 @@
+/**
+ * QQBot outbound response watchdog timeout resolver.
+ *
+ * Background — issue #85267:
+ *   The reporter ran openclaw + ollama + `qwen3.5:27b` (a slow local model)
+ *   with `models.providers.ollama.timeoutSeconds: 1800` and saw the
+ *   QQBot reply path abort at ~5 minutes with "LLM request timed out",
+ *   despite the direct ollama call to the same model working. The
+ *   embedded-runner / idle-timeout layer already honors longer
+ *   provider timeouts (see `src/agents/pi-embedded-runner/run/llm-idle-timeout.ts`),
+ *   but the QQBot outbound dispatcher held an independent hardcoded
+ *   `RESPONSE_TIMEOUT = 300_000` watchdog that quietly undercut the
+ *   configured ceiling.
+ *
+ * Fix shape (clawsweeper `clawsweeper:fix-shape-clear`):
+ *   Don't add a new QQBot-only knob. Instead derive the QQBot wait
+ *   budget from the existing agent/provider timeout settings the user
+ *   already configured:
+ *     - `agents.defaults.timeoutSeconds`
+ *     - `models.providers.<id>.timeoutSeconds` (max across configured providers)
+ *   Take the maximum and clamp to `[DEFAULT_RESPONSE_TIMEOUT_MS, MAX_SAFE_TIMEOUT_MS]`.
+ *   The default floor preserves the existing 5-minute guard for users
+ *   that have not configured any longer ceiling — i.e. a no-op for
+ *   typical cloud-model deployments.
+ */
+
+/**
+ * Default QQBot outbound response watchdog when no config override is
+ * present. Preserves the historical 5-minute guard for unconfigured
+ * deployments.
+ */
+export const DEFAULT_RESPONSE_TIMEOUT_MS = 300_000;
+
+/**
+ * Upper bound to keep the watchdog inside the safe `setTimeout` range
+ * (approximately 24.8 days). Mirrors `MAX_SAFE_TIMEOUT_MS` in
+ * `src/agents/pi-embedded-runner/run/llm-idle-timeout.ts`.
+ */
+const MAX_SAFE_TIMEOUT_MS = 2_147_000_000;
+
+interface AgentsDefaultsLike {
+  timeoutSeconds?: unknown;
+}
+
+interface AgentsBlockLike {
+  defaults?: AgentsDefaultsLike;
+}
+
+interface ProviderEntryLike {
+  timeoutSeconds?: unknown;
+}
+
+interface ModelsBlockLike {
+  providers?: Record<string, ProviderEntryLike | undefined> | undefined;
+}
+
+interface CfgShape {
+  agents?: AgentsBlockLike;
+  models?: ModelsBlockLike;
+}
+
+function positiveSecondsToMs(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return undefined;
+  }
+  return Math.floor(value * 1000);
+}
+
+/**
+ * Resolve the QQBot outbound response watchdog (ms).
+ *
+ * The watchdog is the longest of:
+ *   - `DEFAULT_RESPONSE_TIMEOUT_MS` (5 min, historical floor)
+ *   - `cfg.agents.defaults.timeoutSeconds` converted to ms
+ *   - the maximum `cfg.models.providers.<id>.timeoutSeconds` across
+ *     configured providers, converted to ms
+ *
+ * Returns at most `MAX_SAFE_TIMEOUT_MS` so the chosen value is always
+ * a safe `setTimeout` argument.
+ */
+export function resolveResponseTimeoutMs(cfg: unknown): number {
+  const candidates: number[] = [DEFAULT_RESPONSE_TIMEOUT_MS];
+
+  const typed = (cfg ?? {}) as CfgShape;
+
+  const agentDefaultMs = positiveSecondsToMs(typed.agents?.defaults?.timeoutSeconds);
+  if (agentDefaultMs !== undefined) {
+    candidates.push(agentDefaultMs);
+  }
+
+  const providers = typed.models?.providers;
+  if (providers && typeof providers === "object") {
+    for (const entry of Object.values(providers)) {
+      const providerMs = positiveSecondsToMs(entry?.timeoutSeconds);
+      if (providerMs !== undefined) {
+        candidates.push(providerMs);
+      }
+    }
+  }
+
+  const chosen = Math.max(...candidates);
+  return Math.min(chosen, MAX_SAFE_TIMEOUT_MS);
+}


### PR DESCRIPTION
## Summary

Fixes #85267

Reporter ran `openclaw` + local `ollama` with `qwen3.5:27b` (slow local model) configured as:

```yaml
models:
  providers:
    ollama:
      timeoutSeconds: 1800
```

Direct ollama call to the same model worked fine, but going through openclaw's QQBot channel aborted at ~5 minutes with `LLM request timed out`.

## Root cause

The embedded-runner LLM-idle-timeout layer (`src/agents/pi-embedded-runner/run/llm-idle-timeout.ts`) already honors longer per-provider `timeoutSeconds`. But `extensions/qqbot/src/engine/gateway/outbound-dispatch.ts` held a **separate hardcoded** outbound response watchdog:

```ts
const RESPONSE_TIMEOUT = 300_000;
```

raced against `dispatchPromise`. Slow first block-reply → QQBot rejected the wait at 5 min regardless of the configured longer ceiling. Effectively the per-channel watchdog silently undercut the provider timeout.

## Fix

Don't add a new QQBot-only knob. Derive the watchdog from existing config the user already sets:

- `agents.defaults.timeoutSeconds`
- `max(models.providers.<id>.timeoutSeconds)` across configured providers
- Floored at the historical `300_000ms` so unconfigured deployments keep prior behavior
- Clamped to `MAX_SAFE_TIMEOUT_MS` (~24.8d) so the value is always a safe `setTimeout` argument

Implemented as a small pure resolver `resolveResponseTimeoutMs(cfg)` so it is independently unit-testable and consistent with `resolveLlmIdleTimeoutMs` upstream.

## Files

- **NEW** `extensions/qqbot/src/engine/gateway/response-timeout.ts` — pure resolver
- **NEW** `extensions/qqbot/src/engine/gateway/response-timeout.test.ts` — unit tests
- `extensions/qqbot/src/engine/gateway/outbound-dispatch.ts` — replace `RESPONSE_TIMEOUT` constant with `resolveResponseTimeoutMs(cfg)`

## Tests

`extensions/qqbot/src/engine/gateway/response-timeout.test.ts` covers:

- No config → 5 min floor preserved
- `agents.defaults.timeoutSeconds` longer than floor honored
- `agents.defaults.timeoutSeconds` shorter than floor ignored (no regression for users already on 5-min floor)
- `models.providers.ollama.timeoutSeconds: 1800` honored — **direct #85267 repro shape**
- max-across-providers wins
- non-positive / NaN / wrong-type values ignored
- absurd input clamped to `MAX_SAFE_TIMEOUT_MS`

Acceptance criterion from clawsweeper review (`extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts`) — existing tests untouched, unrelated to the timeout branch.

## Notes

- Behavior change is purely additive for the configured-longer-timeout case; default deployments see no change.
- The existing `agents.defaults.timeoutSeconds < 300s` case is intentionally **not** allowed to undercut the historical floor — staying conservative on the regression direction.


## Real behavior proof

Behavior addressed: QQBot no longer stops waiting at the old 300s outbound watchdog when the existing provider timeout config allows a slower local model response.

Real environment tested: Local OpenClaw PR worktree on macOS using Node 25.9.0. This exercises the actual QQBot `dispatchOutbound()` path with fake timers and mocked QQBot network sends; it is source-level behavior proof, not a live QQBot/Ollama credentialed run.

Exact steps or command run after this patch:

```shell
node scripts/run-vitest.mjs extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts extensions/qqbot/src/engine/gateway/response-timeout.test.ts src/agents/pi-embedded-runner/run/llm-idle-timeout.test.ts
```

Evidence after fix: Terminal output from the PR worktree:

```text
RUN  v4.1.7 /Users/onur/oc/openclaw-pr-85271

Test Files  4 passed (4)
     Tests  155 passed (155)
  Start at  17:58:35
  Duration  1.48s (transform 699ms, setup 431ms, import 611ms, tests 132ms, environment 0ms)
```

Observed result after fix: The added dispatch-level regression test configures `models.providers.ollama.timeoutSeconds: 1800`, advances time to 300s, verifies `dispatchOutbound()` has not settled and no reply was sent, then advances to 301s and verifies the late block reply is delivered. This proves the actual QQBot dispatch path now waits past the old 5-minute cap when a longer provider timeout is configured.

What was not tested: I did not run a live QQBot + Ollama + qwen3.5:27b environment with real QQBot credentials and a real long model response.
