### PR TITLE
fix(gateway): defer provider auth prewarm after startup

### DIFF
--- a/src/agents/model-provider-auth.test.ts
+++ b/src/agents/model-provider-auth.test.ts
@@ -204,4 +204,26 @@ describe("prepared provider auth state", () => {
     );
     expect(modelAuthMocks.hasRuntimeAvailableProviderAuth).toHaveBeenCalledTimes(3);
   });
+
+  it("does not publish a warm that is cancelled before completion", async () => {
+    const cfg = {} as OpenClawConfig;
+    let cancelled = false;
+    modelCatalogMocks.loadModelCatalog.mockResolvedValue([
+      { id: "gpt", name: "gpt", provider: "openai" },
+    ]);
+    modelAuthMocks.hasRuntimeAvailableProviderAuth.mockReturnValue(true);
+
+    await warmCurrentProviderAuthState(cfg, { isCancelled: () => cancelled });
+    await expect(hasAuthForModelProvider({ provider: "openai", cfg })).resolves.toBe(true);
+    expect(modelAuthMocks.hasRuntimeAvailableProviderAuth).toHaveBeenCalledTimes(1);
+
+    clearCurrentProviderAuthState();
+    modelAuthMocks.hasRuntimeAvailableProviderAuth.mockClear();
+    cancelled = true;
+    await warmCurrentProviderAuthState(cfg, { isCancelled: () => cancelled });
+
+    modelAuthMocks.hasRuntimeAvailableProviderAuth.mockReturnValue(false);
+    await expect(hasAuthForModelProvider({ provider: "openai", cfg })).resolves.toBe(false);
+    expect(modelAuthMocks.hasRuntimeAvailableProviderAuth).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/agents/model-provider-auth.ts
+++ b/src/agents/model-provider-auth.ts
@@ -181,7 +181,10 @@ export function createProviderAuthChecker(params: {
   };
 }
 
-export async function warmCurrentProviderAuthState(cfg: OpenClawConfig): Promise<void> {
+export async function warmCurrentProviderAuthState(
+  cfg: OpenClawConfig,
+  options: { isCancelled?: () => boolean } = {},
+): Promise<void> {
   // Claim a fresh generation; any concurrent warm or clear bumps this and
   // turns our published state stale.
   currentProviderAuthStateGeneration += 1;
@@ -226,7 +229,7 @@ export async function warmCurrentProviderAuthState(cfg: OpenClawConfig): Promise
       providers: state,
     });
   }
-  if (ownGeneration !== currentProviderAuthStateGeneration) {
+  if (options.isCancelled?.() || ownGeneration !== currentProviderAuthStateGeneration) {
     // A newer warm or clear ran while we were building; skip publication so
     // the newer answer wins.
     return;

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -221,7 +221,9 @@ describe("gateway hot reload model state", () => {
       nextConfig,
     );
 
-    expect(hoisted.reloadEvents).toEqual([
+    const firstResetIndex = hoisted.reloadEvents.indexOf("reset-model-catalog");
+    expect(firstResetIndex).toBeGreaterThanOrEqual(0);
+    expect(hoisted.reloadEvents.slice(firstResetIndex)).toEqual([
       "reset-model-catalog",
       "clear-provider-auth",
       "reload-plugins",

--- a/src/gateway/server-runtime-handles.ts
+++ b/src/gateway/server-runtime-handles.ts
@@ -17,6 +17,7 @@ export type GatewayServerMutableState = {
   stopGatewayUpdateCheck: () => void;
   tailscaleCleanup: (() => Promise<void>) | null;
   postReadySidecars: GatewayPostReadySidecarHandle[];
+  gatewayLifetimeSidecars: GatewayPostReadySidecarHandle[];
   skillsRefreshTimer: ReturnType<typeof setTimeout> | null;
   skillsRefreshDelayMs: number;
   skillsChangeUnsub: () => void;
@@ -49,6 +50,7 @@ export function createGatewayServerMutableState(): GatewayServerMutableState {
     stopGatewayUpdateCheck: () => {},
     tailscaleCleanup: null as (() => Promise<void>) | null,
     postReadySidecars: [],
+    gatewayLifetimeSidecars: [],
     skillsRefreshTimer: null as ReturnType<typeof setTimeout> | null,
     skillsRefreshDelayMs: 30_000,
     skillsChangeUnsub: () => {},

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -50,6 +50,9 @@ const hoisted = vi.hoisted(() => {
   }));
   const resolveEmbeddedAgentRuntime = vi.fn(() => "pi");
   const ensureOpenClawModelsJson = vi.fn(async () => {});
+  const clearCurrentProviderAuthState = vi.fn();
+  const warmCurrentProviderAuthState = vi.fn(async (_cfg?: unknown, _options?: unknown) => {});
+  const setAuthProfileFailureHook = vi.fn();
   return {
     startPluginServices,
     startGmailWatcherWithLogs,
@@ -79,6 +82,9 @@ const hoisted = vi.hoisted(() => {
     getModelRefStatus,
     resolveEmbeddedAgentRuntime,
     ensureOpenClawModelsJson,
+    clearCurrentProviderAuthState,
+    warmCurrentProviderAuthState,
+    setAuthProfileFailureHook,
   };
 });
 
@@ -193,6 +199,21 @@ vi.mock("../agents/pi-embedded-runner/runtime.js", () => ({
 vi.mock("../agents/models-config.js", () => ({
   ensureOpenClawModelsJson: hoisted.ensureOpenClawModelsJson,
 }));
+
+vi.mock("../agents/model-provider-auth.js", () => ({
+  clearCurrentProviderAuthState: hoisted.clearCurrentProviderAuthState,
+  warmCurrentProviderAuthState: hoisted.warmCurrentProviderAuthState,
+}));
+
+vi.mock("../agents/auth-profiles.js", async () => {
+  const actual = await vi.importActual<typeof import("../agents/auth-profiles.js")>(
+    "../agents/auth-profiles.js",
+  );
+  return {
+    ...actual,
+    setAuthProfileFailureHook: hoisted.setAuthProfileFailureHook,
+  };
+});
 
 vi.mock("./server-tailscale.js", () => ({
   startGatewayTailscaleExposure: hoisted.startGatewayTailscaleExposure,
@@ -324,6 +345,10 @@ describe("startGatewayPostAttachRuntime", () => {
     hoisted.resolveEmbeddedAgentRuntime.mockReturnValue("pi");
     hoisted.ensureOpenClawModelsJson.mockReset();
     hoisted.ensureOpenClawModelsJson.mockResolvedValue(undefined);
+    hoisted.clearCurrentProviderAuthState.mockClear();
+    hoisted.warmCurrentProviderAuthState.mockReset();
+    hoisted.warmCurrentProviderAuthState.mockResolvedValue(undefined);
+    hoisted.setAuthProfileFailureHook.mockClear();
   });
 
   afterEach(() => {
@@ -851,6 +876,179 @@ describe("startGatewayPostAttachRuntime", () => {
       expect(log.warn).toHaveBeenCalledWith(
         "startup model warmup timed out after 25ms; continuing without waiting",
       );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("delays provider auth prewarm so post-ready gateway work can run first", async () => {
+    vi.useFakeTimers();
+    const postReadyRequestTurn = vi.fn();
+    const onPostReadySidecars = vi.fn();
+    const onGatewayLifetimeSidecars = vi.fn();
+    const log = { info: vi.fn(), warn: vi.fn() };
+
+    try {
+      await startGatewayPostAttachRuntime({
+        ...createPostAttachParams(),
+        log,
+        deferSidecars: true,
+        providerAuthPrewarm: { enabled: true, delayMs: 1_000 },
+        onPostReadySidecars,
+        onGatewayLifetimeSidecars,
+        onSidecarsReady: () => {
+          setImmediate(postReadyRequestTurn);
+        },
+      });
+
+      await vi.advanceTimersToNextTimerAsync();
+      await vi.advanceTimersToNextTimerAsync();
+      expect(postReadyRequestTurn).toHaveBeenCalledTimes(1);
+      expect(onPostReadySidecars.mock.calls[0]?.[0]).toHaveLength(0);
+      expect(onGatewayLifetimeSidecars.mock.calls[0]?.[0]).toHaveLength(1);
+      await vi.dynamicImportSettled();
+      await vi.waitFor(() => {
+        expect(hoisted.setAuthProfileFailureHook).toHaveBeenCalledTimes(1);
+      });
+      expect(hoisted.warmCurrentProviderAuthState).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      await vi.waitFor(() => {
+        expect(hoisted.warmCurrentProviderAuthState).toHaveBeenCalledTimes(1);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps provider auth prewarm alive when Gmail post-ready sidecars stop", async () => {
+    vi.useFakeTimers();
+    const onPostReadySidecars = vi.fn();
+    const onGatewayLifetimeSidecars = vi.fn();
+    const log = { info: vi.fn(), warn: vi.fn() };
+
+    try {
+      await startGatewayPostAttachRuntime({
+        ...createPostAttachParams({
+          cfgAtStart: {
+            hooks: {
+              enabled: true,
+              internal: { enabled: false },
+              gmail: { account: "me" },
+            },
+          } as never,
+          gatewayPluginConfigAtStart: {
+            hooks: {
+              enabled: true,
+              internal: { enabled: false },
+              gmail: { account: "me" },
+            },
+          } as never,
+        }),
+        log,
+        deferSidecars: true,
+        providerAuthPrewarm: { enabled: true, delayMs: 1_000 },
+        onPostReadySidecars,
+        onGatewayLifetimeSidecars,
+      });
+
+      await vi.advanceTimersToNextTimerAsync();
+      const gmailSidecars = onPostReadySidecars.mock.calls[0]?.[0] as
+        | { stop: () => void }[]
+        | undefined;
+      const lifetimeSidecars = onGatewayLifetimeSidecars.mock.calls[0]?.[0] as
+        | { stop: () => void }[]
+        | undefined;
+      expect(gmailSidecars).toHaveLength(1);
+      expect(lifetimeSidecars).toHaveLength(1);
+
+      for (const sidecar of gmailSidecars ?? []) {
+        sidecar.stop();
+      }
+      await vi.dynamicImportSettled();
+      await vi.waitFor(() => {
+        expect(hoisted.setAuthProfileFailureHook).toHaveBeenCalledTimes(1);
+      });
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      await vi.waitFor(() => {
+        expect(hoisted.warmCurrentProviderAuthState).toHaveBeenCalledTimes(1);
+      });
+
+      const hook = hoisted.setAuthProfileFailureHook.mock.calls[0]?.[0] as (() => void) | undefined;
+      hook?.();
+      expect(hoisted.clearCurrentProviderAuthState).toHaveBeenCalledTimes(1);
+      expect(hoisted.warmCurrentProviderAuthState).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("cancels delayed provider auth prewarm when the sidecar stops before the timer fires", async () => {
+    vi.useFakeTimers();
+    const log = { info: vi.fn(), warn: vi.fn() };
+
+    try {
+      const sidecar = testing.scheduleProviderAuthStatePrewarm({
+        getConfig: () => ({ marker: "current" }) as never,
+        log,
+        delayMs: 1_000,
+      });
+      await vi.dynamicImportSettled();
+      await vi.waitFor(() => {
+        expect(hoisted.setAuthProfileFailureHook).toHaveBeenCalledTimes(1);
+      });
+
+      sidecar.stop();
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(hoisted.warmCurrentProviderAuthState).not.toHaveBeenCalled();
+
+      const hook = hoisted.setAuthProfileFailureHook.mock.calls[0]?.[0] as (() => void) | undefined;
+      hook?.();
+      expect(hoisted.clearCurrentProviderAuthState).not.toHaveBeenCalled();
+      expect(hoisted.warmCurrentProviderAuthState).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("uses the current provider auth config when the delayed prewarm fires", async () => {
+    vi.useFakeTimers();
+    const startupCfg = { marker: "startup" } as never;
+    const reloadedCfg = { marker: "reloaded" } as never;
+    const afterFailureCfg = { marker: "after-failure" } as never;
+    let currentCfg = startupCfg;
+    const log = { info: vi.fn(), warn: vi.fn() };
+
+    try {
+      testing.scheduleProviderAuthStatePrewarm({
+        getConfig: () => currentCfg,
+        log,
+        delayMs: 0,
+      });
+      currentCfg = reloadedCfg;
+      await vi.dynamicImportSettled();
+      await vi.waitFor(() => {
+        expect(hoisted.setAuthProfileFailureHook).toHaveBeenCalledTimes(1);
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.waitFor(() => {
+        expect(hoisted.warmCurrentProviderAuthState).toHaveBeenCalledTimes(1);
+      });
+
+      const hook = hoisted.setAuthProfileFailureHook.mock.calls[0]?.[0] as (() => void) | undefined;
+      if (!hook) {
+        throw new Error("Expected provider auth failure hook to be registered");
+      }
+
+      hook();
+      currentCfg = afterFailureCfg;
+      hook();
+      expect(hoisted.clearCurrentProviderAuthState).toHaveBeenCalledTimes(2);
+      expect(hoisted.warmCurrentProviderAuthState).toHaveBeenCalledTimes(3);
+      expect(hoisted.warmCurrentProviderAuthState.mock.calls[0]?.[0]).toBe(reloadedCfg);
+      expect(hoisted.warmCurrentProviderAuthState.mock.calls[1]?.[0]).toBe(reloadedCfg);
+      expect(hoisted.warmCurrentProviderAuthState.mock.calls[2]?.[0]).toBe(afterFailureCfg);
     } finally {
       vi.useRealTimers();
     }
@@ -1654,6 +1852,7 @@ function createPostAttachParams(overrides: Partial<PostAttachParams> = {}): Post
       error: vi.fn(),
     },
     unavailableGatewayMethods: new Set<string>(),
+    providerAuthPrewarm: { enabled: false },
     ...overrides,
   };
 }

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -27,6 +27,7 @@ const ACP_BACKEND_READY_TIMEOUT_MS = 5_000;
 const ACP_BACKEND_READY_POLL_MS = 50;
 const PRIMARY_MODEL_PREWARM_TIMEOUT_MS = 5_000;
 const STARTUP_PROVIDER_DISCOVERY_TIMEOUT_MS = 5_000;
+const PROVIDER_AUTH_PREWARM_START_DELAY_MS = 1_000;
 const SKIP_STARTUP_MODEL_PREWARM_ENV = "OPENCLAW_SKIP_STARTUP_MODEL_PREWARM";
 const QMD_STARTUP_IDLE_DELAY_MS = 120_000;
 const RESTART_SENTINEL_FILENAME = "restart-sentinel.json";
@@ -143,6 +144,83 @@ function schedulePostAttachUpdateSentinelRefresh(params: {
     });
   });
   handle.unref?.();
+}
+
+function scheduleProviderAuthStatePrewarm(params: {
+  getConfig: () => OpenClawConfig;
+  log: {
+    info: (msg: string) => void;
+    warn: (msg: string) => void;
+  };
+  delayMs?: number;
+}): GatewayPostReadySidecarHandle {
+  let stopped = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const isStopped = () => stopped;
+  const delayMs = params.delayMs ?? PROVIDER_AUTH_PREWARM_START_DELAY_MS;
+  void (async () => {
+    const { clearCurrentProviderAuthState, warmCurrentProviderAuthState } =
+      await import("../agents/model-provider-auth.js");
+    const { setAuthProfileFailureHook } = await import("../agents/auth-profiles.js");
+    const scheduleAuthMapRewarm = (reason: string) => {
+      if (isStopped()) {
+        return;
+      }
+      const cfg = params.getConfig();
+      const startMs = Date.now();
+      void warmCurrentProviderAuthState(cfg, { isCancelled: isStopped })
+        .then(() => {
+          if (isStopped()) {
+            return;
+          }
+          params.log.info(`provider auth state re-warmed (${reason}) in ${Date.now() - startMs}ms`);
+        })
+        .catch((err) => {
+          params.log.warn(`provider auth state rewarm failed: ${String(err)}`);
+        });
+    };
+    if (isStopped()) {
+      return;
+    }
+    setAuthProfileFailureHook(() => {
+      if (isStopped()) {
+        return;
+      }
+      clearCurrentProviderAuthState();
+      scheduleAuthMapRewarm("auth-profile-failure");
+    });
+    timer = setTimeout(
+      () => {
+        void (async () => {
+          if (isStopped()) {
+            return;
+          }
+          const cfg = params.getConfig();
+          const startMs = Date.now();
+          await warmCurrentProviderAuthState(cfg, { isCancelled: isStopped });
+          if (isStopped()) {
+            return;
+          }
+          params.log.info(`provider auth state pre-warmed in ${Date.now() - startMs}ms`);
+        })().catch((err) => {
+          params.log.warn(`provider auth state pre-warm failed: ${String(err)}`);
+        });
+      },
+      Math.max(0, delayMs),
+    );
+    timer.unref?.();
+  })().catch((err) => {
+    params.log.warn(`provider auth state pre-warm setup failed: ${String(err)}`);
+  });
+  return {
+    stop: () => {
+      stopped = true;
+      if (timer) {
+        clearTimeout(timer);
+        timer = undefined;
+      }
+    },
+  };
 }
 
 function schedulePostReadySidecarTask(params: {
@@ -854,9 +932,15 @@ export async function startGatewayPostAttachRuntime(
     getCronService?: () => PluginHookGatewayCronService | null | undefined;
     onPluginServices?: (pluginServices: PluginServicesHandle | null) => void;
     onPostReadySidecars?: (postReadySidecars: GatewayPostReadySidecarHandle[]) => void;
+    onGatewayLifetimeSidecars?: (sidecars: GatewayPostReadySidecarHandle[]) => void;
     onSidecarsReady?: () => void;
     startupTrace?: GatewayStartupTrace;
     deferSidecars?: boolean;
+    providerAuthPrewarm?: {
+      enabled?: boolean;
+      delayMs?: number;
+      getConfig?: () => OpenClawConfig;
+    };
   },
   runtimeDeps: GatewayPostAttachRuntimeDeps = defaultGatewayPostAttachRuntimeDeps,
 ) {
@@ -966,18 +1050,30 @@ export async function startGatewayPostAttachRuntime(
         if (!pluginServicesReported) {
           reportPluginServices(result.pluginServices);
         }
-        params.onPostReadySidecars?.(result.postReadySidecars);
+        const postReadySidecars = [...result.postReadySidecars];
+        const gatewayLifetimeSidecars: GatewayPostReadySidecarHandle[] = [];
+        if (params.providerAuthPrewarm?.enabled !== false) {
+          gatewayLifetimeSidecars.push(
+            scheduleProviderAuthStatePrewarm({
+              getConfig: params.providerAuthPrewarm?.getConfig ?? (() => params.cfgAtStart),
+              log: params.log,
+              delayMs: params.providerAuthPrewarm?.delayMs,
+            }),
+          );
+        }
+        params.onPostReadySidecars?.(postReadySidecars);
+        params.onGatewayLifetimeSidecars?.(gatewayLifetimeSidecars);
         params.onSidecarsReady?.();
         params.startupTrace?.detail("sidecars.ready", [
           [
             "loadedPluginCount",
             pluginRegistry.plugins.filter((plugin) => plugin.status === "loaded").length,
           ],
-          ["postReadySidecarCount", result.postReadySidecars.length],
+          ["postReadySidecarCount", postReadySidecars.length + gatewayLifetimeSidecars.length],
         ]);
         params.startupTrace?.mark("sidecars.ready");
         params.log.info("gateway ready");
-        return { ...result, pluginRegistry };
+        return { ...result, postReadySidecars, gatewayLifetimeSidecars, pluginRegistry };
       });
 
   void sidecarsPromise
@@ -1018,38 +1114,6 @@ export async function startGatewayPostAttachRuntime(
       params.log.warn(`gateway sidecars failed to start: ${String(err)}`);
     });
 
-  void sidecarsPromise
-    .then(async () => {
-      if (params.minimalTestGateway) {
-        return;
-      }
-      const { clearCurrentProviderAuthState, warmCurrentProviderAuthState } =
-        await import("../agents/model-provider-auth.js");
-      const { setAuthProfileFailureHook } = await import("../agents/auth-profiles.js");
-      const scheduleAuthMapRewarm = (reason: string) => {
-        const startMs = Date.now();
-        void warmCurrentProviderAuthState(params.cfgAtStart)
-          .then(() => {
-            params.log.info(
-              `provider auth state re-warmed (${reason}) in ${Date.now() - startMs}ms`,
-            );
-          })
-          .catch((err) => {
-            params.log.warn(`provider auth state rewarm failed: ${String(err)}`);
-          });
-      };
-      setAuthProfileFailureHook(() => {
-        clearCurrentProviderAuthState();
-        scheduleAuthMapRewarm("auth-profile-failure");
-      });
-      const startMs = Date.now();
-      await warmCurrentProviderAuthState(params.cfgAtStart);
-      params.log.info(`provider auth state pre-warmed in ${Date.now() - startMs}ms`);
-    })
-    .catch((err) => {
-      params.log.warn(`provider auth state pre-warm failed: ${String(err)}`);
-    });
-
   if (params.deferSidecars !== true) {
     const [, tailscaleCleanup, sidecarsResult] = await Promise.all([
       startupLogPromise,
@@ -1080,6 +1144,7 @@ export const testing = {
   prewarmConfiguredPrimaryModelWithTimeout,
   refreshLatestUpdateRestartSentinelIfPresent,
   resolveGatewayMemoryStartupPolicy,
+  scheduleProviderAuthStatePrewarm,
   schedulePrimaryModelPrewarm,
   shouldSkipStartupModelPrewarm,
   stopPostReadySidecarsAfterCloseStarted,

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -981,6 +981,13 @@ export async function startGatewayServer(
       postReadySidecar.stop();
     }
   };
+  const stopRegisteredGatewayLifetimeSidecars = () => {
+    const gatewayLifetimeSidecars = runtimeState.gatewayLifetimeSidecars;
+    runtimeState.gatewayLifetimeSidecars = [];
+    for (const gatewayLifetimeSidecar of gatewayLifetimeSidecars) {
+      gatewayLifetimeSidecar.stop();
+    }
+  };
   const createCloseHandler = () => async (opts?: GatewayCloseOptions) => {
     const channelIds = listLoadedChannelPlugins().map((plugin) => plugin.id as ChannelId);
     const { createGatewayCloseHandler, drainActiveSessionsForShutdown } =
@@ -1024,6 +1031,7 @@ export async function startGatewayServer(
   let clearFallbackGatewayContextForServer = () => {};
   const closeOnStartupFailure = async () => {
     try {
+      stopRegisteredGatewayLifetimeSidecars();
       stopRegisteredPostReadySidecars();
       await runClosePrelude();
       await createCloseHandler()({ reason: "gateway startup failed" });
@@ -1552,12 +1560,23 @@ export async function startGatewayServer(
                 runtimeState.postReadySidecars = [];
               }
             },
+            onGatewayLifetimeSidecars: (gatewayLifetimeSidecars) => {
+              runtimeState.gatewayLifetimeSidecars = gatewayLifetimeSidecars;
+              stopPostReadySidecarsAfterCloseStarted({
+                postReadySidecars: gatewayLifetimeSidecars,
+                closeStarted: closePreludeStarted,
+              });
+              if (closePreludeStarted) {
+                runtimeState.gatewayLifetimeSidecars = [];
+              }
+            },
             onSidecarsReady: () => {
               startupSidecarsReady = true;
               activateScheduledServicesWhenReady();
             },
             startupTrace,
             deferSidecars: opts.deferStartupSidecars === true,
+            providerAuthPrewarm: { getConfig: getRuntimeConfig },
           }),
       ),
     ));
@@ -1671,6 +1690,7 @@ export async function startGatewayServer(
     close: async (opts) => {
       try {
         markClosePreludeStarted();
+        stopRegisteredGatewayLifetimeSidecars();
         stopRegisteredPostReadySidecars();
         // Run gateway_stop plugin hook before shutdown
         const { runGlobalGatewayStopSafely } = await import("../plugins/hook-runner-global.js");


### PR DESCRIPTION
## Summary

This PR narrows issue #63229 to the startup ordering problem we reproduced locally: provider auth-state prewarm can run right as the gateway reports ready and compete with the first `sessions_spawn` request.

The change moves provider auth-state prewarm into delayed gateway-lifetime work that starts after sidecars are ready. The auth-profile failure hook still clears and rewarms provider auth state, the delayed warm uses current runtime config, and shutdown cancellation prevents stopped prewarm work from publishing stale prepared auth state.

The provider-auth handle is intentionally separate from Gmail post-ready sidecars, so a Gmail watcher hot reload cannot disable the long-lived auth failure hook.

## Verification

- `node scripts/run-vitest.mjs src/gateway/server-startup-post-attach.test.ts src/agents/model-provider-auth.test.ts` - passed, 53 tests across 3 files.
- `node scripts/run-vitest.mjs src/gateway/server-startup-post-attach.test.ts src/gateway/server-reload-handlers.test.ts src/gateway/server.reload.test.ts src/gateway/server-methods/models-auth-status.test.ts src/agents/model-provider-auth.test.ts src/gateway/tools-invoke-http.test.ts` - passed, 231 tests across 10 files.
- `node scripts/run-vitest.mjs src/gateway/server-startup-post-attach.test.ts src/agents/model-provider-auth.test.ts src/gateway/server-reload-handlers.test.ts` - passed, 64 tests across 4 files during final review.
- `OPENCLAW_VITEST_MAX_WORKERS=2 NODE_OPTIONS=--max-old-space-size=8192 OPENCLAW_TEST_PROJECTS_PARALLEL=2 OPENCLAW_VITEST_SHARD_NAME=agentic-control-plane-runtime OPENCLAW_VITEST_INCLUDE_FILE=<35-path include file> node scripts/test-projects.mjs test/vitest/vitest.gateway-server.config.ts` - passed, 302 tests across 34 files on the earlier head for the same gateway/runtime surface.
- `git diff --check upstream/main..HEAD && git diff --check` - passed.
- `codex review --base upstream/main` - clean after the lifecycle fix; no introduced correctness issues found.

## Real Behavior Proof

Behavior addressed: Early gateway `sessions_spawn` should not wait behind expensive provider auth-state prewarm when the gateway has just become ready.

Real environment tested: Local OpenClaw gateway against local vLLM serving `Qwen/Qwen2.5-0.5B-Instruct` as `qwen-a` on loopback.

Exact steps or command run after this patch: Started vLLM, started the patched gateway with `OPENCLAW_SKIP_CHANNELS=1`, auth disabled on loopback, and default model `vllm/qwen-a`; waited for `/health`, then immediately invoked `/tools/invoke` with `sessions_spawn`.

Evidence after fix: copied live terminal output and redacted runtime log from the local OpenClaw/vLLM repro:

```text
$ curl -s -o /tmp/spawn-response.json -w 'HTTP %{http_code} time_total=%{time_total}\n' \
  -H 'content-type: application/json' \
  --data '{"jsonrpc":"2.0","id":"spawn-1","method":"tools/invoke","params":{"tool":"sessions_spawn","arguments":{"prompt":"say ready","model":"vllm/qwen-a"}}}' \
  http://127.0.0.1:<gateway-port>/tools/invoke
HTTP 200 time_total=0.443812

$ jq '.result.status' /tmp/spawn-response.json
"accepted"
```

```text
[redacted gateway log]
gateway ready
provider auth state pre-warmed in 36875ms
```

Observed result after fix: The first session spawn was accepted before provider auth-state prewarm completed, proving the startup/prewarm ordering regression is removed for the reproduced slice.

What was not tested: I did not rerun the original large-model repro, and this PR does not claim to fix separate healthy-vLLM false-timeout or fallback-cascade symptoms from #63229.
