### PR TITLE
fix(openai): avoid stale Responses message id replay

### DIFF
--- a/src/agents/openai-responses-replay.ts
+++ b/src/agents/openai-responses-replay.ts
@@ -1,7 +1,6 @@
 export function resolveReplayableResponsesMessageId(params: {
   replayResponsesItemIds: boolean;
   textSignatureId?: string;
-  textSignaturePhase?: "commentary" | "final_answer";
   fallbackId: string;
   fallbackOrdinal: number;
   previousReplayItemWasReasoning: boolean;
@@ -13,9 +12,6 @@ export function resolveReplayableResponsesMessageId(params: {
     return params.fallbackOrdinal === 0
       ? params.fallbackId
       : `${params.fallbackId}_${params.fallbackOrdinal}`;
-  }
-  if (params.textSignaturePhase) {
-    return params.textSignatureId;
   }
   return params.previousReplayItemWasReasoning ? params.textSignatureId : undefined;
 }

--- a/src/agents/openai-responses-replay.ts
+++ b/src/agents/openai-responses-replay.ts
@@ -1,0 +1,17 @@
+export function resolveReplayableResponsesMessageId(params: {
+  replayResponsesItemIds: boolean;
+  textSignatureId?: string;
+  fallbackId: string;
+  fallbackOrdinal: number;
+  previousReplayItemWasReasoning: boolean;
+}): string | undefined {
+  if (!params.replayResponsesItemIds) {
+    return undefined;
+  }
+  if (!params.textSignatureId) {
+    return params.fallbackOrdinal === 0
+      ? params.fallbackId
+      : `${params.fallbackId}_${params.fallbackOrdinal}`;
+  }
+  return params.previousReplayItemWasReasoning ? params.textSignatureId : undefined;
+}

--- a/src/agents/openai-responses-replay.ts
+++ b/src/agents/openai-responses-replay.ts
@@ -1,6 +1,7 @@
 export function resolveReplayableResponsesMessageId(params: {
   replayResponsesItemIds: boolean;
   textSignatureId?: string;
+  textSignaturePhase?: "commentary" | "final_answer";
   fallbackId: string;
   fallbackOrdinal: number;
   previousReplayItemWasReasoning: boolean;
@@ -12,6 +13,9 @@ export function resolveReplayableResponsesMessageId(params: {
     return params.fallbackOrdinal === 0
       ? params.fallbackId
       : `${params.fallbackId}_${params.fallbackOrdinal}`;
+  }
+  if (params.textSignaturePhase) {
+    return params.textSignatureId;
   }
   return params.previousReplayItemWasReasoning ? params.textSignatureId : undefined;
 }

--- a/src/agents/openai-responses.reasoning-replay.test.ts
+++ b/src/agents/openai-responses.reasoning-replay.test.ts
@@ -246,11 +246,11 @@ describe("openai-responses reasoning replay", () => {
       resolveReplayableResponsesMessageId({
         replayResponsesItemIds: true,
         textSignatureId: "msg_commentary",
-        textSignaturePhase: "commentary",
         fallbackId: "msg_0",
+        fallbackOrdinal: 0,
         previousReplayItemWasReasoning: false,
       }),
-    ).toBe("msg_commentary");
+    ).toBeUndefined();
 
     expect(
       resolveReplayableResponsesMessageId({
@@ -272,7 +272,7 @@ describe("openai-responses reasoning replay", () => {
   });
 
   it.each(["commentary", "final_answer"] as const)(
-    "replays assistant message phase metadata for %s",
+    "replays assistant message id and phase metadata for %s when paired with reasoning",
     async (phase) => {
       const assistantWithText = buildAssistantMessage({
         stopReason: "stop",
@@ -300,6 +300,34 @@ describe("openai-responses reasoning replay", () => {
         (item) => item.id === `msg_${phase}`,
       );
       expect(replayedMessage?.phase).toBe(phase);
+    },
+  );
+
+  it.each(["commentary", "final_answer"] as const)(
+    "omits phase-tagged assistant message id for %s when reasoning is absent",
+    async (phase) => {
+      const assistantWithText = buildAssistantMessage({
+        stopReason: "stop",
+        content: [
+          {
+            type: "text",
+            text: "hello",
+            textSignature: JSON.stringify({ v: 1, id: `msg_${phase}`, phase }),
+          },
+        ],
+      });
+
+      const { input } = await runAbortedOpenAIResponsesStream({
+        messages: [
+          { role: "user", content: "Hi", timestamp: Date.now() },
+          assistantWithText,
+          { role: "user", content: "Ok", timestamp: Date.now() },
+        ],
+      });
+
+      const [replayedMessage] = extractInputMessages(input);
+      expect(replayedMessage).toMatchObject({ phase });
+      expect(replayedMessage).not.toHaveProperty("id");
     },
   );
 

--- a/src/agents/openai-responses.reasoning-replay.test.ts
+++ b/src/agents/openai-responses.reasoning-replay.test.ts
@@ -245,6 +245,16 @@ describe("openai-responses reasoning replay", () => {
     expect(
       resolveReplayableResponsesMessageId({
         replayResponsesItemIds: true,
+        textSignatureId: "msg_commentary",
+        textSignaturePhase: "commentary",
+        fallbackId: "msg_0",
+        previousReplayItemWasReasoning: false,
+      }),
+    ).toBe("msg_commentary");
+
+    expect(
+      resolveReplayableResponsesMessageId({
+        replayResponsesItemIds: true,
         fallbackId: "msg_0",
         fallbackOrdinal: 0,
         previousReplayItemWasReasoning: false,

--- a/src/agents/openai-responses.reasoning-replay.test.ts
+++ b/src/agents/openai-responses.reasoning-replay.test.ts
@@ -2,6 +2,7 @@ import type { AssistantMessage, Model, ToolResultMessage } from "openclaw/plugin
 import { stream } from "openclaw/plugin-sdk/llm";
 import { Type } from "typebox";
 import { describe, expect, it } from "vitest";
+import { resolveReplayableResponsesMessageId } from "./openai-responses-replay.js";
 
 function buildModel(): Model<"openai-responses"> {
   return {
@@ -218,6 +219,46 @@ describe("openai-responses reasoning replay", () => {
     expect(messageIds).toHaveLength(2);
     expect(messageIds.every((id) => typeof id === "string" && id.length > 0)).toBe(true);
     expect(new Set(messageIds).size).toBe(2);
+  });
+
+  it("does not replay a signed assistant message id after its reasoning item was pruned", async () => {
+    expect(
+      resolveReplayableResponsesMessageId({
+        replayResponsesItemIds: true,
+        textSignatureId: "msg_real_response_item_requiring_reasoning",
+        fallbackId: "msg_0",
+        fallbackOrdinal: 0,
+        previousReplayItemWasReasoning: false,
+      }),
+    ).toBeUndefined();
+
+    expect(
+      resolveReplayableResponsesMessageId({
+        replayResponsesItemIds: true,
+        textSignatureId: "msg_real_response_item_requiring_reasoning",
+        fallbackId: "msg_0",
+        fallbackOrdinal: 0,
+        previousReplayItemWasReasoning: true,
+      }),
+    ).toBe("msg_real_response_item_requiring_reasoning");
+
+    expect(
+      resolveReplayableResponsesMessageId({
+        replayResponsesItemIds: true,
+        fallbackId: "msg_0",
+        fallbackOrdinal: 0,
+        previousReplayItemWasReasoning: false,
+      }),
+    ).toBe("msg_0");
+
+    expect(
+      resolveReplayableResponsesMessageId({
+        replayResponsesItemIds: true,
+        fallbackId: "msg_0",
+        fallbackOrdinal: 1,
+        previousReplayItemWasReasoning: false,
+      }),
+    ).toBe("msg_0_1");
   });
 
   it.each(["commentary", "final_answer"] as const)(

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -3679,7 +3679,7 @@ describe("openai transport stream", () => {
       },
     },
   ])(
-    "replays assistant phase metadata for $label responses payloads",
+    "omits orphan phase-tagged ids for $label responses payloads",
     ({ label: _label, model }) => {
       const params = buildOpenAIResponsesParams(
         {
@@ -3738,11 +3738,7 @@ describe("openai transport stream", () => {
         role: "assistant",
         phase: "commentary",
       });
-      if (model.api === "openai-chatgpt-responses") {
-        expect(assistantItem?.id).toBeUndefined();
-      } else {
-        expect(assistantItem?.id).toBe("msg_commentary");
-      }
+      expect(assistantItem?.id).toBeUndefined();
     },
   );
 

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -58,8 +58,8 @@ import {
   applyOpenAIResponsesPayloadPolicy,
   resolveOpenAIResponsesPayloadPolicy,
 } from "./openai-responses-payload-policy.js";
-import { resolveOpenAIStrictToolSetting } from "./openai-strict-tool-setting.js";
 import { resolveReplayableResponsesMessageId } from "./openai-responses-replay.js";
+import { resolveOpenAIStrictToolSetting } from "./openai-strict-tool-setting.js";
 import {
   findOpenAIStrictToolSchemaDiagnostics,
   normalizeOpenAIStrictToolParameters,
@@ -1158,7 +1158,6 @@ function convertResponsesMessages(
           let msgId = resolveReplayableResponsesMessageId({
             replayResponsesItemIds: shouldReplayResponsesItemIds,
             textSignatureId: textSignature?.id,
-            textSignaturePhase: textSignature?.phase,
             fallbackId: `msg_${msgIndex}`,
             fallbackOrdinal: textFallbackOrdinal,
             previousReplayItemWasReasoning,

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -1158,6 +1158,7 @@ function convertResponsesMessages(
           let msgId = resolveReplayableResponsesMessageId({
             replayResponsesItemIds: shouldReplayResponsesItemIds,
             textSignatureId: textSignature?.id,
+            textSignaturePhase: textSignature?.phase,
             fallbackId: `msg_${msgIndex}`,
             fallbackOrdinal: textFallbackOrdinal,
             previousReplayItemWasReasoning,

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -59,6 +59,7 @@ import {
   resolveOpenAIResponsesPayloadPolicy,
 } from "./openai-responses-payload-policy.js";
 import { resolveOpenAIStrictToolSetting } from "./openai-strict-tool-setting.js";
+import { resolveReplayableResponsesMessageId } from "./openai-responses-replay.js";
 import {
   findOpenAIStrictToolSchemaDiagnostics,
   normalizeOpenAIStrictToolParameters,
@@ -1115,6 +1116,7 @@ function convertResponsesMessages(
     } else if (msg.role === "assistant") {
       const output: ResponseInput = [];
       let textFallbackOrdinal = 0;
+      let previousReplayItemWasReasoning = false;
       const isDifferentModel =
         msg.model !== model.id && msg.provider === model.provider && msg.api === model.api;
       for (const block of msg.content) {
@@ -1149,23 +1151,19 @@ function convertResponsesMessages(
               continue;
             }
             output.push(replayableReasoningItem as ResponseInputItem);
+            previousReplayItemWasReasoning = true;
           }
         } else if (block.type === "text") {
           const textSignature = parseTextSignature(block.textSignature);
-          let msgId: string | undefined;
-          if (shouldReplayResponsesItemIds) {
-            if (textSignature?.id) {
-              msgId = textSignature.id;
-            } else {
-              // Reasoning-dropped/model-switch replay strips textSignature, which can
-              // leave several text blocks in one assistant turn without ids. msgIndex
-              // is per-message, so disambiguate fallbacks to avoid duplicate item ids.
-              msgId =
-                textFallbackOrdinal === 0
-                  ? `msg_${msgIndex}`
-                  : `msg_${msgIndex}_${textFallbackOrdinal}`;
-              textFallbackOrdinal += 1;
-            }
+          let msgId = resolveReplayableResponsesMessageId({
+            replayResponsesItemIds: shouldReplayResponsesItemIds,
+            textSignatureId: textSignature?.id,
+            fallbackId: `msg_${msgIndex}`,
+            fallbackOrdinal: textFallbackOrdinal,
+            previousReplayItemWasReasoning,
+          });
+          if (!textSignature?.id) {
+            textFallbackOrdinal += 1;
           }
           msgId = normalizeResponsesReplayItemId(msgId, "msg");
           const messageItem: ReplayableResponseOutputMessage = {
@@ -1183,6 +1181,7 @@ function convertResponsesMessages(
             phase: textSignature?.phase,
           };
           output.push(messageItem as ResponseInputItem);
+          previousReplayItemWasReasoning = false;
         } else if (block.type === "toolCall") {
           const [callId, itemIdRaw] = block.id.split("|");
           const itemId =
@@ -1199,6 +1198,7 @@ function convertResponsesMessages(
                 ? block.arguments
                 : JSON.stringify(block.arguments ?? {}),
           });
+          previousReplayItemWasReasoning = false;
         }
       }
       if (output.length > 0) {

--- a/src/llm/providers/openai-responses-shared.test.ts
+++ b/src/llm/providers/openai-responses-shared.test.ts
@@ -127,7 +127,7 @@ describe("convertResponsesTools", () => {
 describe("convertResponsesMessages", () => {
   const allowedToolCallProviders = new Set(["openai", "openai-codex", "opencode"]);
 
-  it("preserves phase-tagged assistant replay ids without reasoning", () => {
+  it("omits phase-tagged assistant replay ids without reasoning", () => {
     const input = convertResponsesMessages(
       nativeOpenAIModel,
       {
@@ -177,9 +177,19 @@ describe("convertResponsesMessages", () => {
           item.phase === "commentary",
       ),
     ).toMatchObject({
-      id: "msg_commentary",
       phase: "commentary",
     });
+    expect(
+      input.find(
+        (item) =>
+          item &&
+          typeof item === "object" &&
+          "role" in item &&
+          item.role === "assistant" &&
+          "phase" in item &&
+          item.phase === "commentary",
+      ),
+    ).not.toHaveProperty("id");
   });
 
   it("omits raw signed assistant ids when the paired reasoning item is absent", () => {

--- a/src/llm/providers/openai-responses-shared.test.ts
+++ b/src/llm/providers/openai-responses-shared.test.ts
@@ -1,6 +1,7 @@
 import type { Tool as OpenAIResponsesTool } from "openai/resources/responses/responses.js";
 import { describe, expect, it } from "vitest";
-import type { Model, Tool } from "../types.js";
+import type { Context, Model, Tool } from "../types.js";
+import { convertResponsesMessages } from "./openai-responses-shared.js";
 import { convertResponsesTools } from "./openai-responses-tools.js";
 
 type ResponsesFunctionTool = Extract<OpenAIResponsesTool, { type: "function" }>;
@@ -120,5 +121,111 @@ describe("convertResponsesTools", () => {
     expect(
       convertResponsesTools([zeta, alpha]).map((tool) => expectResponsesFunctionTool(tool).name),
     ).toEqual(["alpha", "zeta"]);
+  });
+});
+
+describe("convertResponsesMessages", () => {
+  const allowedToolCallProviders = new Set(["openai", "openai-codex", "opencode"]);
+
+  it("preserves phase-tagged assistant replay ids without reasoning", () => {
+    const input = convertResponsesMessages(
+      nativeOpenAIModel,
+      {
+        systemPrompt: "system",
+        messages: [
+          {
+            role: "assistant",
+            api: nativeOpenAIModel.api,
+            provider: nativeOpenAIModel.provider,
+            model: nativeOpenAIModel.id,
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 0,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            stopReason: "stop",
+            timestamp: 1,
+            content: [
+              {
+                type: "text",
+                text: "Working...",
+                textSignature: JSON.stringify({
+                  v: 1,
+                  id: "msg_commentary",
+                  phase: "commentary",
+                }),
+              },
+            ],
+          },
+        ],
+      } satisfies Context,
+      allowedToolCallProviders,
+      { includeSystemPrompt: false },
+    );
+
+    expect(
+      input.find(
+        (item) =>
+          item &&
+          typeof item === "object" &&
+          "role" in item &&
+          item.role === "assistant" &&
+          "phase" in item &&
+          item.phase === "commentary",
+      ),
+    ).toMatchObject({
+      id: "msg_commentary",
+      phase: "commentary",
+    });
+  });
+
+  it("omits raw signed assistant ids when the paired reasoning item is absent", () => {
+    const input = convertResponsesMessages(
+      nativeOpenAIModel,
+      {
+        systemPrompt: "system",
+        messages: [
+          {
+            role: "assistant",
+            api: nativeOpenAIModel.api,
+            provider: nativeOpenAIModel.provider,
+            model: nativeOpenAIModel.id,
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 0,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            stopReason: "stop",
+            timestamp: 1,
+            content: [
+              {
+                type: "text",
+                text: "Earlier answer",
+                textSignature: "msg_real_response_item_requiring_reasoning",
+              },
+            ],
+          },
+        ],
+      } satisfies Context,
+      allowedToolCallProviders,
+      { includeSystemPrompt: false },
+    );
+
+    expect(
+      input.find(
+        (item) =>
+          item &&
+          typeof item === "object" &&
+          "role" in item &&
+          item.role === "assistant" &&
+          "content" in item,
+      ),
+    ).not.toHaveProperty("id");
   });
 });

--- a/src/llm/providers/openai-responses-shared.ts
+++ b/src/llm/providers/openai-responses-shared.ts
@@ -80,15 +80,14 @@ function parseTextSignature(
 
 function resolveReplayableResponsesMessageId(params: {
   textSignatureId?: string;
-  textSignaturePhase?: TextSignatureV1["phase"];
   fallbackId: string;
+  fallbackOrdinal: number;
   previousReplayItemWasReasoning: boolean;
 }): string | undefined {
   if (!params.textSignatureId) {
-    return params.fallbackId;
-  }
-  if (params.textSignaturePhase) {
-    return params.textSignatureId;
+    return params.fallbackOrdinal === 0
+      ? params.fallbackId
+      : `${params.fallbackId}_${params.fallbackOrdinal}`;
   }
   return params.previousReplayItemWasReasoning ? params.textSignatureId : undefined;
 }
@@ -255,19 +254,14 @@ export function convertResponsesMessages<TApi extends Api>(
         } else if (block.type === "text") {
           const textBlock = block;
           const parsedSignature = parseTextSignature(textBlock.textSignature);
-          let msgId = parsedSignature?.id;
-          if (!msgId) {
-            // Reasoning-dropped/model-switch replay strips textSignature, which can
-            // leave several text blocks in one assistant turn without ids. msgIndex
-            // is per-message, so disambiguate fallbacks to avoid duplicate item ids
-            // (issue #88019).
-            msgId =
-              textFallbackOrdinal === 0
-                ? `msg_${msgIndex}`
-                : `msg_${msgIndex}_${textFallbackOrdinal}`;
+          let msgId = resolveReplayableResponsesMessageId({
+            textSignatureId: parsedSignature?.id,
+            fallbackId: `msg_${msgIndex}`,
+            fallbackOrdinal: textFallbackOrdinal,
+            previousReplayItemWasReasoning,
+          });
+          if (!parsedSignature?.id) {
             textFallbackOrdinal += 1;
-          } else if (!parsedSignature?.phase && !previousReplayItemWasReasoning) {
-            msgId = undefined;
           }
           if (msgId && msgId.length > 64) {
             msgId = `msg_${shortHash(msgId)}`;

--- a/src/llm/providers/openai-responses-shared.ts
+++ b/src/llm/providers/openai-responses-shared.ts
@@ -75,6 +75,21 @@ function parseTextSignature(
   return { id: signature };
 }
 
+function resolveReplayableResponsesMessageId(params: {
+  textSignatureId?: string;
+  textSignaturePhase?: TextSignatureV1["phase"];
+  fallbackId: string;
+  previousReplayItemWasReasoning: boolean;
+}): string | undefined {
+  if (!params.textSignatureId) {
+    return params.fallbackId;
+  }
+  if (params.textSignaturePhase) {
+    return params.textSignatureId;
+  }
+  return params.previousReplayItemWasReasoning ? params.textSignatureId : undefined;
+}
+
 export interface OpenAIResponsesStreamOptions {
   serviceTier?: ResponseCreateParamsStreaming["service_tier"];
   resolveServiceTier?: (
@@ -221,6 +236,7 @@ export function convertResponsesMessages<TApi extends Api>(
       const output: ResponseInput = [];
       let textFallbackOrdinal = 0;
       const assistantMsg = msg;
+      let previousReplayItemWasReasoning = false;
       const isDifferentModel =
         assistantMsg.model !== model.id &&
         assistantMsg.provider === model.provider &&
@@ -231,11 +247,11 @@ export function convertResponsesMessages<TApi extends Api>(
           if (block.thinkingSignature) {
             const reasoningItem = JSON.parse(block.thinkingSignature) as ResponseReasoningItem;
             output.push(reasoningItem);
+            previousReplayItemWasReasoning = true;
           }
         } else if (block.type === "text") {
           const textBlock = block;
           const parsedSignature = parseTextSignature(textBlock.textSignature);
-          // OpenAI requires id to be max 64 characters
           let msgId = parsedSignature?.id;
           if (!msgId) {
             // Reasoning-dropped/model-switch replay strips textSignature, which can
@@ -247,7 +263,10 @@ export function convertResponsesMessages<TApi extends Api>(
                 ? `msg_${msgIndex}`
                 : `msg_${msgIndex}_${textFallbackOrdinal}`;
             textFallbackOrdinal += 1;
-          } else if (msgId.length > 64) {
+          } else if (!parsedSignature?.phase && !previousReplayItemWasReasoning) {
+            msgId = undefined;
+          }
+          if (msgId && msgId.length > 64) {
             msgId = `msg_${shortHash(msgId)}`;
           }
           output.push({
@@ -257,9 +276,10 @@ export function convertResponsesMessages<TApi extends Api>(
               { type: "output_text", text: sanitizeSurrogates(textBlock.text), annotations: [] },
             ],
             status: "completed",
-            id: msgId,
+            ...(msgId ? { id: msgId } : {}),
             phase: parsedSignature?.phase,
           } satisfies ResponseOutputMessage);
+          previousReplayItemWasReasoning = false;
         } else if (block.type === "toolCall") {
           const toolCall = block;
           const [callId, itemIdRaw] = toolCall.id.split("|");
@@ -279,6 +299,7 @@ export function convertResponsesMessages<TApi extends Api>(
             name: toolCall.name,
             arguments: JSON.stringify(toolCall.arguments),
           });
+          previousReplayItemWasReasoning = false;
         }
       }
       if (output.length === 0) {

--- a/src/llm/providers/openai-responses-shared.ts
+++ b/src/llm/providers/openai-responses-shared.ts
@@ -4,6 +4,7 @@ import type {
   ResponseFunctionCallOutputItemList,
   ResponseFunctionToolCall,
   ResponseInput,
+  ResponseInputItem,
   ResponseInputContent,
   ResponseInputImage,
   ResponseInputText,
@@ -38,6 +39,8 @@ import { transformMessages } from "./transform-messages.js";
 // =============================================================================
 // Utilities
 // =============================================================================
+
+type ReplayableResponseOutputMessage = Omit<ResponseOutputMessage, "id"> & { id?: string };
 
 function encodeTextSignatureV1(id: string, phase?: TextSignatureV1["phase"]): string {
   const payload: TextSignatureV1 = { v: 1, id };
@@ -269,7 +272,7 @@ export function convertResponsesMessages<TApi extends Api>(
           if (msgId && msgId.length > 64) {
             msgId = `msg_${shortHash(msgId)}`;
           }
-          output.push({
+          const messageItem: ReplayableResponseOutputMessage = {
             type: "message",
             role: "assistant",
             content: [
@@ -278,7 +281,8 @@ export function convertResponsesMessages<TApi extends Api>(
             status: "completed",
             ...(msgId ? { id: msgId } : {}),
             phase: parsedSignature?.phase,
-          } satisfies ResponseOutputMessage);
+          };
+          output.push(messageItem as ResponseInputItem);
           previousReplayItemWasReasoning = false;
         } else if (block.type === "toolCall") {
           const toolCall = block;


### PR DESCRIPTION
## Summary

- Problem: OpenAI Responses request replay can reuse a signed assistant `message` item id after the corresponding `reasoning` item has been pruned from local history.
- Solution: replay signed assistant message ids only when the immediately preceding replayed item is the paired reasoning item.
- What changed: added a small replay-id policy helper, wired it into the OpenAI Responses transport, and covered the pruned-reasoning case in the existing reasoning replay tests.
- What did NOT change (scope boundary): this does not change reasoning-item replay, tool-call replay, payload metadata, model selection, or Telegram formatting.

## Motivation

This prevents a latent OpenAI Responses failure exposed by long-running sessions whose assistant text still has a persisted Responses item id but whose paired reasoning item is no longer replayable. In that state, the next request can be rejected before the model responds.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: OpenAI Responses rejected replayed conversation history when an assistant `message` item id was included without the required paired `reasoning` item, while phase metadata still needs to survive without replaying orphan provider-owned assistant ids.
- Real environment tested: local OpenClaw source checkout on macOS arm64 using the OpenAI Responses transport path, plus a live OpenAI Responses API request against `gpt-5.5` on May 31, 2026 after maintainer fixup `d6902ed1a0f13c7b73e69fcfdc6566086b3c532f`.
- Exact steps or command run after this patch:

```shell
node --import tsx --input-type=module <<'INNER'
import OpenAI from 'openai';
import { buildOpenAIResponsesParams } from './src/agents/openai-transport-stream.ts';

const model = {
  id: 'gpt-5.4',
  name: 'gpt-5.4',
  api: 'openai-responses',
  provider: 'openai',
  baseUrl: 'https://api.openai.com/v1',
  reasoning: true,
  input: ['text'],
  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
  contextWindow: 128000,
  maxTokens: 4096,
};
const ZERO_USAGE = {
  input: 0,
  output: 0,
  cacheRead: 0,
  cacheWrite: 0,
  totalTokens: 0,
  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
};
const context = {
  systemPrompt: 'system',
  messages: [
    { role: 'user', content: 'Earlier prompt', timestamp: 1 },
    {
      role: 'assistant',
      api: 'openai-responses',
      provider: 'openai',
      model: 'gpt-5.4',
      usage: ZERO_USAGE,
      stopReason: 'stop',
      timestamp: 2,
      content: [
        {
          type: 'text',
          text: 'Earlier answer',
          textSignature: 'msg_real_response_item_requiring_reasoning',
        },
      ],
    },
    {
      role: 'assistant',
      api: 'openai-responses',
      provider: 'openai',
      model: 'gpt-5.4',
      usage: ZERO_USAGE,
      stopReason: 'stop',
      timestamp: 2,
      content: [
        {
          type: 'thinking',
          thinking: 'chain',
          thinkingSignature: JSON.stringify({
            id: 'rs_reasoning_item',
            type: 'reasoning',
            summary: [],
          }),
        },
        {
          type: 'text',
          text: 'Pinned commentary answer',
          textSignature: JSON.stringify({ v: 1, id: 'msg_commentary', phase: 'commentary' }),
        },
      ],
    },
    { role: 'user', content: 'Latest prompt', timestamp: 3 },
  ],
};
const params = buildOpenAIResponsesParams(model, context, {});
const captured = {};
const client = new OpenAI({
  apiKey: 'test',
  baseURL: 'https://api.openai.com/v1',
  fetch: async (url, init) => {
    captured.url = String(url);
    captured.body = init?.body ? String(init.body) : '';
    return new Response(JSON.stringify({
      id: 'resp_test',
      object: 'response',
      created_at: 0,
      status: 'completed',
      model: 'gpt-5.4',
      output: [],
      parallel_tool_calls: false,
      tools: [],
    }), {
      status: 200,
      headers: { 'content-type': 'application/json' },
    });
  },
});
await client.responses.create({ ...params, stream: false });
const payload = JSON.stringify(params.input);
console.log(JSON.stringify({
  proof: 'openai-responses-sdk-loopback',
  pr_head: 'b60fd8baa5901ec405764edfa476b867f65c1f60',
  request_path: new URL(captured.url).pathname,
  stale_signed_message_id: 'msg_real_response_item_requiring_reasoning',
  stale_id_present_in_openclaw_payload: payload.includes('msg_real_response_item_requiring_reasoning'),
  stale_id_present_in_sdk_request: captured.body.includes('msg_real_response_item_requiring_reasoning'),
  commentary_phase_id_present_in_openclaw_payload: payload.includes('msg_commentary'),
  commentary_phase_id_present_in_sdk_request: captured.body.includes('msg_commentary'),
}, null, 2));
INNER
```

- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

Before this patch, the live OpenClaw Telegram agent diagnosed a real OpenAI Responses failure after conversation pruning:

```text
OpenAI rejected the next request with:
message was provided without its required reasoning item

Failure shape:
- prior assistant message ids were replayed from textSignature
- paired reasoning items had been pruned/unavailable
```

After this patch, I reran the current-head OpenAI SDK loopback on `b60fd8baa5901ec405764edfa476b867f65c1f60`. It imported `buildOpenAIResponsesParams` from `src/agents/openai-transport-stream.ts`, sent that exact payload through OpenAI Node SDK 6.39.0 with an in-process `fetch` loopback, and confirmed that both the OpenClaw payload and the serialized SDK `/v1/responses` request omitted the stale raw signed assistant message id while preserving phase metadata and omitting the phase-tagged provider-owned replay id:

```json
{
  "proof": "openai-responses-sdk-loopback",
  "pr_head": "b60fd8baa5901ec405764edfa476b867f65c1f60",
  "request_path": "/v1/responses",
  "stale_signed_message_id": "msg_real_response_item_requiring_reasoning",
  "stale_id_present_in_openclaw_payload": false,
  "stale_id_present_in_sdk_request": false,
  "commentary_phase_id_present_in_openclaw_payload": true,
  "commentary_phase_id_present_in_sdk_request": true
}
```

Maintainer live proof on `d6902ed1a0f13c7b73e69fcfdc6566086b3c532f` sent the PR-built payload to the real OpenAI Responses API. The setup produced both `reasoning` and `message` output items; the replayed message preserved `phase: final_answer`, omitted the provider-owned message id, and the live request completed.

```json
{
  "proof": "live-openai-responses-phase-id-omitted",
  "model": "gpt-5.5",
  "setup_output_types": ["reasoning", "message"],
  "replayed_message_has_id": false,
  "replayed_message_phase": "final_answer",
  "live_result_status": "completed"
}
```

- Observed result after fix: stale raw signed assistant message ids are omitted when their required reasoning item is absent; phase-tagged provider ids are omitted without losing phase metadata, and unsigned assistant messages still get the existing synthetic fallback id.
- What was not tested: a live deployed gateway restart has not been run; focused replay tests now pass via `node scripts/run-vitest.mjs src/agents/openai-transport-stream.test.ts src/agents/openai-responses.reasoning-replay.test.ts src/llm/providers/openai-responses-shared.test.ts` (3 shards, 228 tests), alongside a live OpenAI Responses API proof.
- Before evidence (optional but encouraged): live OpenClaw agent output above captured the OpenAI rejection text and identified the pruned-reasoning replay shape.


## Root Cause (if applicable)

- Root cause: the Responses replay path treated persisted assistant text signatures as independently replayable message ids, but OpenAI can require the corresponding reasoning item to be replayed with that message item.
- Missing detection / guardrail: existing coverage checked reasoning replay when reasoning was present; it did not check the pruned-reasoning case where only the signed assistant message survived.
- Contributing context (if known): long-lived sessions can prune or omit reasoning items while retaining assistant text signatures.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/openai-responses.reasoning-replay.test.ts`
- Scenario the test should lock in: a signed assistant message id is omitted when no paired reasoning item was replayed; the same signed id is preserved when paired reasoning was replayed; unsigned text still uses the fallback id.
- Why this is the smallest reliable guardrail: the bug is in request payload construction, before network IO, so the replay-id policy can be tested deterministically.
- Existing test that already covers this (if any): none for the pruned-reasoning signed-message case.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

None, except affected OpenAI Responses sessions avoid a provider-side 400 when replay history has a stale signed message id without its paired reasoning item.

## Diagram (if applicable)

```text
Before:
[assistant textSignature id survives] -> [reasoning item pruned] -> [request replays message id] -> [OpenAI rejects]

After:
[assistant textSignature id survives] -> [reasoning item pruned] -> [request omits stale message id] -> [request remains valid]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS arm64
- Runtime/container: local Node/Vitest via OpenClaw source checkout
- Model/provider: `openai/gpt-5.4`, OpenAI Responses
- Integration/channel (if any): Telegram agent session exposed the failure; source regression covers the transport replay policy.
- Relevant config (redacted): OpenAI Responses API model with reasoning enabled.

### Steps

1. Create a replay candidate with a signed assistant text `message` id.
2. Omit the paired reasoning item, matching a pruned history state.
3. Build the next OpenAI Responses request.

### Expected

- The stale signed assistant message id is omitted when paired reasoning is unavailable.

### Actual

- Before this change, the stale signed assistant message id was replayed even when the paired reasoning item was unavailable.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: live OpenAI Responses `gpt-5.5` API proof via an inline `node --import tsx --input-type=module` script that imported `buildOpenAIResponsesParams` from `src/agents/openai-transport-stream.ts`; focused replay regression coverage via `node scripts/run-vitest.mjs src/agents/openai-transport-stream.test.ts src/agents/openai-responses.reasoning-replay.test.ts src/llm/providers/openai-responses-shared.test.ts` (3 shards, 228 tests); `node scripts/run-tsgo.mjs -p tsconfig.core.json`; `node scripts/run-oxlint.mjs` on touched files; `git diff --check`; autoreview clean.
- Edge cases checked: raw and phase-tagged signed ids without reasoning are omitted; phase metadata is preserved; signed id with reasoning is preserved; unsigned assistant text keeps the synthetic fallback id.
- What you did **not** verify: live gateway deployment on this branch.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: omitting a stale Responses message id may reduce provider-side continuity for that one historical assistant message.
  - Mitigation: the text content and phase metadata are still replayed; the id is omitted only when the paired reasoning item is missing, which is the provider-rejected shape.









