### PR TITLE
Bound Codex app-server bridge retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Docs: https://docs.openclaw.ai
 - Gateway CLI: surface local post-challenge connect assembly failures immediately instead of waiting for the wrapper timeout. Fixes #68944. (#85253) Thanks @samzong.
 - Agents/exec: treat denied exec approvals as terminal instead of feeding them back into agent follow-up work, and recognize Chinese stop phrases in abort handling. Fixes #69386. (#85194) Thanks @samzong.
 - CLI/agents: abort accepted Gateway-backed `openclaw agent` runs on SIGINT/SIGTERM so cron and supervisor timeouts do not leave remote agent work alive. Fixes #71710. (#84381) Thanks @Kaspre.
+- Codex app-server: retry replay-safe stdio client-close turns once using structured failure metadata, while surfacing idle `turn/completed` timeouts instead of blindly replaying active shared-server turns. Thanks @VACInc.
 - Codex app-server: reject command overrides that embed Node or package-manager arguments and point users to `appServer.args`, so Windows startup avoids shell parsing failures. (#84417) Thanks @TurboTheTurtle.
 - Agents/Copilot: drop unsafe GitHub Copilot Responses reasoning replay items before send so Telegram direct sessions no longer fail on overlong replay IDs. Fixes #85197. (#85198) Thanks @galiniliev.
 - UI: add accessible tooltips to the topbar color-mode buttons so System, Light, and Dark choices are labeled on hover and focus. (#85227) Thanks @amknight.

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -307,6 +307,22 @@ describe("CodexAppServerEventProjector", () => {
     expect(result.replayMetadata.replaySafe).toBe(true);
   });
 
+  it("suppresses mirrored user prompt when the inbound message was already persisted", async () => {
+    const params = await createParams();
+    const projector = await createProjector({
+      ...params,
+      suppressNextUserMessagePersistence: true,
+    });
+    await projector.handleNotification(
+      turnCompleted([{ type: "agentMessage", id: "msg-1", text: "retry result" }]),
+    );
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+
+    expect(result.messagesSnapshot.map((message) => message.role)).toEqual(["assistant"]);
+    expect(JSON.stringify(result.messagesSnapshot)).not.toContain(params.prompt);
+  });
+
   it("records canonical OpenAI Codex app-server turns with Codex local attribution", async () => {
     const params = await createParams();
     const projector = await createProjector({

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -287,9 +287,9 @@ export class CodexAppServerEventProjector {
     //   - Two distinct turns where the user repeats verbatim content →
     //     distinct turnIds → distinct identities → both kept.
     const turnId = this.turnId;
-    const messagesSnapshot: AgentMessage[] = [
-      attachCodexMirrorIdentity(buildCodexUserPromptMessage(this.params), `${turnId}:prompt`),
-    ];
+    const messagesSnapshot: AgentMessage[] = this.params.suppressNextUserMessagePersistence
+      ? []
+      : [attachCodexMirrorIdentity(buildCodexUserPromptMessage(this.params), `${turnId}:prompt`)];
     // Codex owns the canonical thread. These mirror records keep enough local
     // context for OpenClaw history, search, and future harness switching.
     if (reasoningText) {

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -4916,10 +4916,18 @@ describe("runCodexAppServerAttempt", () => {
       aborted: result.aborted,
       timedOut: result.timedOut,
       promptError: result.promptError,
+      codexAppServerFailure: result.codexAppServerFailure,
     }).toEqual({
       aborted: true,
       timedOut: true,
       promptError: "codex app-server turn idle timed out waiting for turn/completed",
+      codexAppServerFailure: {
+        kind: "turn_completion_idle_timeout",
+        transport: "stdio",
+        threadId: "thread-1",
+        turnId: "turn-1",
+        replaySafe: true,
+      },
     });
     await vi.waitFor(
       () =>
@@ -7818,6 +7826,13 @@ describe("runCodexAppServerAttempt", () => {
     expect(result.promptError).toBe("codex app-server client closed before turn completed");
     expect(result.aborted).toBe(false);
     expect(result.timedOut).toBe(false);
+    expect(result.codexAppServerFailure).toEqual({
+      kind: "client_closed_before_turn_completed",
+      transport: "stdio",
+      threadId: "thread-1",
+      turnId: "turn-1",
+      replaySafe: true,
+    });
   });
 
   it("does not fail a turn when the client closes after terminal completion is queued", async () => {

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -293,6 +293,31 @@ function hasCodexAppServerPotentialSideEffectEvidence(result: EmbeddedRunAttempt
   return result.replayMetadata.hadPotentialSideEffects;
 }
 
+function resolveCodexAppServerReplayBlockedReason(
+  result: EmbeddedRunAttemptResult,
+):
+  | NonNullable<EmbeddedRunAttemptResult["codexAppServerFailure"]>["replayBlockedReason"]
+  | undefined {
+  if (result.replayMetadata.hadPotentialSideEffects) {
+    return "potential_side_effect";
+  }
+  if (result.assistantTexts.some((text) => text.trim().length > 0)) {
+    return "assistant_output";
+  }
+  if (
+    result.toolMetas.length > 0 ||
+    result.clientToolCalls ||
+    result.lastToolError ||
+    result.didSendDeterministicApprovalPrompt
+  ) {
+    return "tool_activity";
+  }
+  if (result.itemLifecycle.startedCount > 0 || result.itemLifecycle.activeCount > 0) {
+    return "active_item";
+  }
+  return undefined;
+}
+
 type CodexSteeringQueueOptions = {
   debounceMs?: number;
 };
@@ -2805,6 +2830,14 @@ export async function runCodexAppServerAttempt(
     }
     const finalPromptErrorSource =
       timedOut || clientClosedPromptError ? "prompt" : result.promptErrorSource;
+    const codexAppServerFailureKind = clientClosedPromptError
+      ? "client_closed_before_turn_completed"
+      : turnCompletionIdleTimedOut
+        ? "turn_completion_idle_timeout"
+        : undefined;
+    const codexAppServerReplayBlockedReason = codexAppServerFailureKind
+      ? resolveCodexAppServerReplayBlockedReason(result)
+      : undefined;
     const completionIdleTimeoutHadPotentialSideEffects =
       hasCodexAppServerPotentialSideEffectEvidence(result);
     const promptTimeoutOutcome =
@@ -2929,6 +2962,20 @@ export async function runCodexAppServerAttempt(
       aborted: finalAborted,
       promptError: finalPromptError,
       promptErrorSource: finalPromptErrorSource,
+      ...(codexAppServerFailureKind
+        ? {
+            codexAppServerFailure: {
+              kind: codexAppServerFailureKind,
+              transport: appServer.start.transport,
+              threadId: thread.threadId,
+              turnId: activeTurnId,
+              replaySafe: codexAppServerReplayBlockedReason === undefined,
+              ...(codexAppServerReplayBlockedReason
+                ? { replayBlockedReason: codexAppServerReplayBlockedReason }
+                : {}),
+            },
+          }
+        : {}),
       ...(promptTimeoutOutcome ? { promptTimeoutOutcome } : {}),
       systemPromptReport,
     };

--- a/src/agents/pi-embedded-runner/run.codex-app-server-recovery.test.ts
+++ b/src/agents/pi-embedded-runner/run.codex-app-server-recovery.test.ts
@@ -1,0 +1,233 @@
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { makeModelFallbackCfg } from "../test-helpers/model-fallback-config-fixture.js";
+import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
+import {
+  loadRunOverflowCompactionHarness,
+  MockedFailoverError,
+  mockedClassifyFailoverReason,
+  mockedRunEmbeddedAttempt,
+  overflowBaseRunParams,
+  resetRunOverflowCompactionHarnessMocks,
+} from "./run.overflow-compaction.harness.js";
+import type { EmbeddedRunAttemptResult } from "./run/types.js";
+
+let runEmbeddedPiAgent: typeof import("./run.js").runEmbeddedPiAgent;
+
+function codexClientClosedAttempt(
+  overrides: Partial<EmbeddedRunAttemptResult> = {},
+): EmbeddedRunAttemptResult {
+  return makeAttemptResult({
+    assistantTexts: [],
+    promptError: new Error("codex app-server client closed before turn completed"),
+    promptErrorSource: "prompt",
+    codexAppServerFailure: {
+      kind: "client_closed_before_turn_completed",
+      transport: "stdio",
+      threadId: "thread-1",
+      turnId: "turn-1",
+      replaySafe: true,
+    },
+    ...overrides,
+  });
+}
+
+function successAttempt(): EmbeddedRunAttemptResult {
+  return makeAttemptResult({
+    promptError: null,
+    assistantTexts: ["Done."],
+  });
+}
+
+describe("runEmbeddedPiAgent Codex app-server recovery", () => {
+  beforeAll(async () => {
+    ({ runEmbeddedPiAgent } = await loadRunOverflowCompactionHarness());
+  });
+
+  beforeEach(() => {
+    resetRunOverflowCompactionHarnessMocks();
+    mockedClassifyFailoverReason.mockReturnValue(null);
+  });
+
+  it("retries a replay-safe stdio client close once", async () => {
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(codexClientClosedAttempt())
+      .mockResolvedValueOnce(successAttempt());
+
+    await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      provider: "codex",
+      model: "gpt-5.5",
+      runId: "run-codex-client-close-retry",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+  });
+
+  it("suppresses duplicate Codex prompt mirroring on retry", async () => {
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(codexClientClosedAttempt())
+      .mockResolvedValueOnce(successAttempt());
+
+    await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      provider: "codex",
+      model: "gpt-5.5",
+      runId: "run-codex-client-close-retry-mirror",
+    });
+
+    expect(
+      (
+        mockedRunEmbeddedAttempt.mock.calls[1]?.[0] as {
+          suppressNextUserMessagePersistence?: boolean;
+        }
+      ).suppressNextUserMessagePersistence,
+    ).toBe(true);
+  });
+
+  it("suppresses duplicate user persistence when retrying after the inbound message was persisted", async () => {
+    mockedRunEmbeddedAttempt
+      .mockImplementationOnce(async (attemptParams) => {
+        (
+          attemptParams as {
+            onUserMessagePersisted?: (message: { role: "user"; content: string }) => void;
+          }
+        ).onUserMessagePersisted?.({ role: "user", content: overflowBaseRunParams.prompt });
+        return codexClientClosedAttempt();
+      })
+      .mockResolvedValueOnce(successAttempt());
+
+    await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      provider: "codex",
+      model: "gpt-5.5",
+      runId: "run-codex-client-close-retry-persisted",
+      currentMessageId: "msg-1",
+    });
+
+    expect(
+      (
+        mockedRunEmbeddedAttempt.mock.calls[1]?.[0] as {
+          suppressNextUserMessagePersistence?: boolean;
+        }
+      ).suppressNextUserMessagePersistence,
+    ).toBe(true);
+  });
+
+  it("does not retry websocket client closes", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      codexClientClosedAttempt({
+        codexAppServerFailure: {
+          kind: "client_closed_before_turn_completed",
+          transport: "websocket",
+          threadId: "thread-1",
+          turnId: "turn-1",
+          replaySafe: true,
+        },
+      }),
+    );
+
+    await expect(
+      runEmbeddedPiAgent({
+        ...overflowBaseRunParams,
+        provider: "codex",
+        model: "gpt-5.5",
+        runId: "run-codex-client-close-websocket",
+      }),
+    ).rejects.toThrow("codex app-server client closed before turn completed");
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry turn/completed idle timeouts", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: [],
+        promptError: new Error("codex app-server turn idle timed out waiting for turn/completed"),
+        promptErrorSource: "prompt",
+        codexAppServerFailure: {
+          kind: "turn_completion_idle_timeout",
+          transport: "stdio",
+          threadId: "thread-1",
+          turnId: "turn-1",
+          replaySafe: true,
+        },
+      }),
+    );
+
+    await expect(
+      runEmbeddedPiAgent({
+        ...overflowBaseRunParams,
+        provider: "codex",
+        model: "gpt-5.5",
+        runId: "run-codex-turn-completion-idle-timeout",
+      }),
+    ).rejects.toThrow("codex app-server turn idle timed out waiting for turn/completed");
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not hand Codex app-server idle timeouts to model fallback", async () => {
+    mockedClassifyFailoverReason.mockReturnValue("timeout");
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: [],
+        promptError: new Error("codex app-server turn idle timed out waiting for turn/completed"),
+        promptErrorSource: "prompt",
+        codexAppServerFailure: {
+          kind: "turn_completion_idle_timeout",
+          transport: "stdio",
+          threadId: "thread-1",
+          turnId: "turn-1",
+          replaySafe: true,
+        },
+      }),
+    );
+
+    const promise = runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      provider: "codex",
+      model: "gpt-5.5",
+      runId: "run-codex-turn-completion-idle-timeout-fallback",
+      config: makeModelFallbackCfg({
+        agents: {
+          defaults: {
+            model: {
+              primary: "openai-codex/gpt-5.5",
+              fallbacks: ["anthropic/claude-opus-4-6"],
+            },
+          },
+        },
+      }),
+    });
+
+    await expect(promise).rejects.not.toBeInstanceOf(MockedFailoverError);
+    await expect(promise).rejects.toThrow(
+      "codex app-server turn idle timed out waiting for turn/completed",
+    );
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry after visible assistant output", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      codexClientClosedAttempt({
+        assistantTexts: ["partial answer"],
+        codexAppServerFailure: {
+          kind: "client_closed_before_turn_completed",
+          transport: "stdio",
+          threadId: "thread-1",
+          turnId: "turn-1",
+          replaySafe: false,
+          replayBlockedReason: "assistant_output",
+        },
+      }),
+    );
+
+    await expect(
+      runEmbeddedPiAgent({
+        ...overflowBaseRunParams,
+        provider: "codex",
+        model: "gpt-5.5",
+        runId: "run-codex-client-close-visible-output",
+      }),
+    ).rejects.toThrow("codex app-server client closed before turn completed");
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -131,6 +131,7 @@ import { forgetPromptBuildDrainCacheForRun } from "./run/attempt.prompt-helpers.
 import { createEmbeddedRunAuthController } from "./run/auth-controller.js";
 import { resolveAuthProfileFailureReason } from "./run/auth-profile-failure-policy.js";
 import { runEmbeddedAttemptWithBackend } from "./run/backend.js";
+import { resolveCodexAppServerClientCloseRetry } from "./run/codex-app-server-recovery.js";
 import { createFailoverDecisionLogger } from "./run/failover-observation.js";
 import { mergeRetryFailoverReason, resolveRunFailoverDecision } from "./run/failover-policy.js";
 import { hasEmbeddedRunConfiguredModelFallbacks } from "./run/fallbacks.js";
@@ -1077,6 +1078,7 @@ export async function runEmbeddedPiAgent(
       });
       let rateLimitProfileRotations = 0;
       let timeoutCompactionAttempts = 0;
+      let codexAppServerClientCloseRetries = 0;
       // Silent-error retry: non-strict-agentic models (e.g. ollama/glm-5.1) can
       // end a turn with stopReason="error" + zero output tokens, producing no
       // user-visible text. This is an orthogonal, model-agnostic resubmission
@@ -2175,6 +2177,25 @@ export async function runEmbeddedPiAgent(
                 error: { kind: "hook_block", message: errorText },
               },
             };
+          }
+
+          if (promptError && !aborted && promptErrorSource !== "compaction") {
+            const codexClientCloseRetry = resolveCodexAppServerClientCloseRetry({
+              attempt,
+              alreadyRetried: codexAppServerClientCloseRetries > 0,
+            });
+            if (codexClientCloseRetry.retry) {
+              codexAppServerClientCloseRetries += 1;
+              suppressNextUserMessagePersistence = true;
+              log.warn(
+                `codex app-server stdio client closed before turn completion; retrying once ` +
+                  `runId=${params.runId} sessionId=${params.sessionId}`,
+              );
+              continue;
+            }
+            if (attempt.codexAppServerFailure) {
+              throw promptError;
+            }
           }
 
           if (promptError && !aborted && promptErrorSource !== "compaction") {

--- a/src/agents/pi-embedded-runner/run/codex-app-server-recovery.ts
+++ b/src/agents/pi-embedded-runner/run/codex-app-server-recovery.ts
@@ -1,0 +1,41 @@
+import type { EmbeddedRunAttemptResult } from "./types.js";
+
+export function resolveCodexAppServerClientCloseRetry(params: {
+  attempt: EmbeddedRunAttemptResult;
+  alreadyRetried: boolean;
+}): { retry: boolean; reason?: string } {
+  const failure = params.attempt.codexAppServerFailure;
+  if (!failure) {
+    return { retry: false, reason: "not_codex_app_server_failure" };
+  }
+  if (failure.kind !== "client_closed_before_turn_completed") {
+    return { retry: false, reason: failure.kind };
+  }
+  if (failure.transport !== "stdio") {
+    return { retry: false, reason: "non_stdio_transport" };
+  }
+  if (params.alreadyRetried) {
+    return { retry: false, reason: "retry_exhausted" };
+  }
+  if (!failure.replaySafe || !params.attempt.replayMetadata.replaySafe) {
+    return { retry: false, reason: failure.replayBlockedReason ?? "replay_unsafe" };
+  }
+  if (params.attempt.assistantTexts.some((text) => text.trim().length > 0)) {
+    return { retry: false, reason: "assistant_output" };
+  }
+  if (
+    params.attempt.toolMetas.length > 0 ||
+    params.attempt.clientToolCalls ||
+    params.attempt.lastToolError ||
+    params.attempt.didSendDeterministicApprovalPrompt
+  ) {
+    return { retry: false, reason: "tool_activity" };
+  }
+  if (
+    params.attempt.itemLifecycle.startedCount > 0 ||
+    params.attempt.itemLifecycle.activeCount > 0
+  ) {
+    return { retry: false, reason: "active_item" };
+  }
+  return { retry: true };
+}

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -114,6 +114,18 @@ export type EmbeddedRunAttemptResult = {
     replayInvalid?: boolean;
     livenessState?: EmbeddedRunLivenessState;
   };
+  codexAppServerFailure?: {
+    kind: "client_closed_before_turn_completed" | "turn_completion_idle_timeout";
+    transport: "stdio" | "websocket";
+    threadId?: string;
+    turnId?: string;
+    replaySafe: boolean;
+    replayBlockedReason?:
+      | "assistant_output"
+      | "tool_activity"
+      | "potential_side_effect"
+      | "active_item";
+  };
   bootstrapPromptWarningSignaturesSeen?: string[];
   bootstrapPromptWarningSignature?: string;
   systemPromptReport?: SessionSystemPromptReport;

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -4103,6 +4103,35 @@ describe("runAgentTurnWithFallback", () => {
     },
   );
 
+  it.each([
+    {
+      rejection: new Error("codex app-server client closed before turn completed"),
+      expected: "connection closed",
+    },
+    {
+      rejection: new Error("codex app-server turn idle timed out waiting for turn/completed"),
+      expected: "did not replay the turn automatically",
+    },
+  ])(
+    "surfaces Codex app-server bridge failures instead of generic copy",
+    async ({ rejection, expected }) => {
+      state.runWithModelFallbackMock.mockRejectedValueOnce(rejection);
+
+      const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+      const result = await runAgentTurnWithFallback({
+        ...createMinimalRunAgentTurnParams(),
+      });
+
+      expect(result.kind).toBe("final");
+      if (result.kind !== "final") {
+        throw new Error("expected final reply");
+      }
+      expect(result.payload.text).not.toBe(GENERIC_RUN_FAILURE_TEXT);
+      expect(result.payload.text).toContain("Codex app-server");
+      expect(result.payload.text).toContain(expected);
+    },
+  );
+
   it("forwards sanitized generic errors on external chat channels when verbose is on", async () => {
     state.runEmbeddedPiAgentMock.mockRejectedValueOnce(
       new Error("INVALID_ARGUMENT: some other failure"),

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -525,6 +525,21 @@ const CLI_BACKEND_NO_OUTPUT_STALL_RE =
 const CLI_BACKEND_OVERALL_TIMEOUT_RE =
   /\bCLI exceeded timeout\s*\(\s*(\d+)\s*s\s*\)\s+and was terminated\b/iu;
 const CLI_BACKEND_ROUTING_REF_BEFORE_ERROR_RE = /\b([\w.-]+\/[A-Za-z][\w.-]*)\s*:\s*CLI\b/iu;
+const CODEX_APP_SERVER_CLIENT_CLOSED_BEFORE_REPLY_RE =
+  /\bcodex app-server client closed before turn completed\b/iu;
+const CODEX_APP_SERVER_TURN_COMPLETION_IDLE_TIMEOUT_RE =
+  /\bcodex app-server turn idle timed out waiting for turn\/completed\b/iu;
+
+function buildCodexAppServerFailureText(message: string): string | null {
+  const normalizedMessage = collapseRepeatedFailureDetail(message);
+  if (CODEX_APP_SERVER_CLIENT_CLOSED_BEFORE_REPLY_RE.test(normalizedMessage)) {
+    return "⚠️ Codex app-server connection closed before this turn finished. OpenClaw retried once when the stdio turn was still replay-safe; please try again if this keeps happening.";
+  }
+  if (CODEX_APP_SERVER_TURN_COMPLETION_IDLE_TIMEOUT_RE.test(normalizedMessage)) {
+    return "⚠️ Codex app-server stopped before confirming turn completion. OpenClaw did not replay the turn automatically because it may still be active; try again, or use /new if the session stays stuck.";
+  }
+  return null;
+}
 
 function buildCliBackendTimeoutFailureText(message: string): string | null {
   const normalizedMessage = collapseRepeatedFailureDetail(message);
@@ -612,6 +627,10 @@ function buildExternalRunFailureReply(
   const cliBackendTimeoutFailure = buildCliBackendTimeoutFailureText(normalizedMessage);
   if (cliBackendTimeoutFailure) {
     return { text: cliBackendTimeoutFailure, isGenericRunnerFailure: false };
+  }
+  const codexAppServerFailure = buildCodexAppServerFailureText(normalizedMessage);
+  if (codexAppServerFailure) {
+    return { text: codexAppServerFailure, isGenericRunnerFailure: false };
   }
   return {
     text: options?.includeDetails


### PR DESCRIPTION
## Summary

- Replaces #84219 with a narrower Codex app-server recovery boundary and keeps @VACInc credited.
- Adds structured app-server failure metadata for stdio/websocket client-close and idle turn-completion failures.
- Retries only replay-safe stdio client-close turns once, suppressing duplicate prompt mirroring on the retry.
- Leaves websocket/shared-server and idle `turn/completed` failures terminal so active turns are not replayed through retry or model fallback, and surfaces specific user-facing copy.

## Verification

- `./node_modules/.bin/oxfmt --check --threads=1 extensions/codex/src/app-server/event-projector.ts extensions/codex/src/app-server/event-projector.test.ts extensions/codex/src/app-server/run-attempt.ts extensions/codex/src/app-server/run-attempt.test.ts src/agents/pi-embedded-runner/run.ts src/agents/pi-embedded-runner/run/types.ts src/agents/pi-embedded-runner/run/codex-app-server-recovery.ts src/agents/pi-embedded-runner/run.codex-app-server-recovery.test.ts src/auto-reply/reply/agent-runner-execution.ts src/auto-reply/reply/agent-runner-execution.test.ts`
- `git diff --check`
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts extensions/codex/src/app-server/event-projector.test.ts src/agents/pi-embedded-runner/run.codex-app-server-recovery.test.ts src/auto-reply/reply/agent-runner-execution.test.ts` - 5 files, 393 tests passed
- `pnpm build`
- `pnpm check:changed` - Blacksmith Testbox `tbx_01ks7ben51n91s5y6erhy8yq3e`, https://github.com/openclaw/openclaw/actions/runs/26276116576, exit 0
- `AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --mode local` - clean, no accepted/actionable findings

## Real behavior proof

Behavior addressed: Codex app-server bridge failures no longer disappear into generic failure copy or unsafe blanket replay; replay is limited to replay-safe stdio client-close turns.

Real environment tested: Local OpenClaw checkout plus Blacksmith Testbox changed gate.

Exact steps or command run after this patch: Focused Vitest command above, `pnpm build`, and `pnpm check:changed` on Testbox `tbx_01ks7ben51n91s5y6erhy8yq3e`.

Evidence after fix: Tests cover stdio retry once, duplicate prompt mirror suppression, websocket no-retry, idle `turn/completed` no-retry, fallback-configured idle timeout no-fallback, visible assistant output no-retry, structured app-server metadata, and non-generic user-facing failure copy.

Observed result after fix: Replay-safe stdio client-close gets one retry; idle/shared-server/unsafe cases surface terminal app-server failure without replaying an active Codex turn.

What was not tested: A live Codex app-server crash/drop was not forced against a real managed Codex process; behavior is covered by the app-server client/test harness and Testbox changed gate.

Co-authored-by: VACInc <3279061+VACInc@users.noreply.github.com>
