### PR TITLE
docs(media-understanding): clarify provider apiKey source

### DIFF
--- a/docs/nodes/media-understanding.md
+++ b/docs/nodes/media-understanding.md
@@ -137,6 +137,30 @@ Each `models[]` entry can be **provider** or **CLI**:
   </Tab>
 </Tabs>
 
+### Provider credentials (apiKey)
+
+Provider media understanding uses the standard provider auth resolution order: `auth-profiles.json` → env vars → `models.providers.<providerId>.apiKey`.
+
+Important:
+
+- `tools.media.*.models[]` entries do **not** accept an inline `apiKey` field.
+- The `provider` value in your media model entry (for example `openai`, `moonshot`) must have credentials available via one of the sources above.
+
+Minimal example:
+
+```json5
+{
+  models: {
+    providers: {
+      openai: { apiKey: "sk-..." },
+      moonshot: { apiKey: "sk-..." },
+    },
+  },
+}
+```
+
+For the full provider auth reference (profiles, env vars, custom base URLs), see [Tools and custom providers](/gateway/config-tools).
+
 ## Defaults and limits
 
 Recommended defaults:


### PR DESCRIPTION
Fixes #51054.

This adds a short "Provider credentials (apiKey)" section to the Media understanding docs clarifying where provider API keys are resolved from, and that `tools.media.*.models[]` entries do not accept an inline `apiKey`.

Real behavior proof:
- `git diff --check`
- `node scripts/docs-list.js`
- `node scripts/format-docs.mjs --check` (docs formatting clean)
- `npx -y markdownlint-cli2 --config config/markdownlint-cli2.jsonc` (0 errors)

No runtime / build / dependency changes.