### PR TITLE
[token efficiency] subagent bootstrap files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Agents/subagents: limit default sub-agent bootstrap context to `AGENTS.md` and `TOOLS.md`, keeping persona, identity, user, memory, heartbeat, and setup files out of delegated workers by default. (#85283) Thanks @100yenadmin.
 - Maintainer skills: exclude plugin SDK/API boundary work from `openclaw-landable-bug-sweep` so bugbash sweeps stay focused on small paper-cut fixes.
 - Plugin SDK: add a generic channel-message poll sender so channel plugins can expose poll delivery without depending on channel-specific SDK facades.
 - Maintainer skills: add `openclaw-landable-bug-sweep` for producing five small, reviewed, CI-green OpenClaw bugfix PRs from issue/PR sweeps.

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -645,7 +645,7 @@ still need normal device approval for scope upgrades.
 - Sub-agent announce is **best-effort**. If the gateway restarts, pending "announce back" work is lost.
 - Sub-agents still share the same gateway process resources; treat `maxConcurrent` as a safety valve.
 - `sessions_spawn` is always non-blocking: it returns `{ status: "accepted", runId, childSessionKey }` immediately.
-- Sub-agent context only injects `AGENTS.md`, `TOOLS.md`, `SOUL.md`, `IDENTITY.md` and `USER.md` (no `MEMORY.md`, `HEARTBEAT.md`, or `BOOTSTRAP.md`).
+- Sub-agent context only injects `AGENTS.md` and `TOOLS.md` (no `SOUL.md`, `IDENTITY.md`, `USER.md`, `MEMORY.md`, `HEARTBEAT.md`, or `BOOTSTRAP.md`).
 - Maximum nesting depth is 5 (`maxSpawnDepth` range: 1–5). Depth 2 is recommended for most use cases.
 - `maxChildrenPerAgent` caps active children per session (default `5`, range `1–20`).
 

--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -282,6 +282,31 @@ describe("resolveBootstrapFilesForRun", () => {
     );
     expect(files.map((file) => file.path)).not.toContain(path.join(workspaceDir, "BOOTSTRAP.md"));
   });
+
+  it("keeps subagent sessions to project and tool bootstrap files", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-subagent-");
+    await Promise.all(
+      [
+        ["AGENTS.md", "project rules"],
+        ["TOOLS.md", "tool rules"],
+        ["SOUL.md", "persona"],
+        ["IDENTITY.md", "identity"],
+        ["USER.md", "user profile"],
+        ["MEMORY.md", "memory"],
+        ["HEARTBEAT.md", "heartbeat"],
+        ["BOOTSTRAP.md", "setup"],
+      ].map(([fileName, content]) =>
+        fs.writeFile(path.join(workspaceDir, fileName), content, "utf8"),
+      ),
+    );
+
+    const files = await resolveBootstrapFilesForRun({
+      workspaceDir,
+      sessionKey: "agent:main:subagent:worker",
+    });
+
+    expect(files.map((file) => file.name)).toStrictEqual(["AGENTS.md", "TOOLS.md"]);
+  });
 });
 
 describe("resolveBootstrapContextForRun", () => {

--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -307,6 +307,37 @@ describe("resolveBootstrapFilesForRun", () => {
 
     expect(files.map((file) => file.name)).toStrictEqual(["AGENTS.md", "TOOLS.md"]);
   });
+
+  it("keeps cron sessions on their existing minimal bootstrap files", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-cron-");
+    await Promise.all(
+      [
+        ["AGENTS.md", "project rules"],
+        ["TOOLS.md", "tool rules"],
+        ["SOUL.md", "persona"],
+        ["IDENTITY.md", "identity"],
+        ["USER.md", "user profile"],
+        ["MEMORY.md", "memory"],
+        ["HEARTBEAT.md", "heartbeat"],
+        ["BOOTSTRAP.md", "setup"],
+      ].map(([fileName, content]) =>
+        fs.writeFile(path.join(workspaceDir, fileName), content, "utf8"),
+      ),
+    );
+
+    const files = await resolveBootstrapFilesForRun({
+      workspaceDir,
+      sessionKey: "agent:main:cron:daily:run:run-1",
+    });
+
+    expect(files.map((file) => file.name)).toStrictEqual([
+      "AGENTS.md",
+      "SOUL.md",
+      "TOOLS.md",
+      "IDENTITY.md",
+      "USER.md",
+    ]);
+  });
 });
 
 describe("resolveBootstrapContextForRun", () => {

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -77,6 +77,11 @@ async function expectCompletedWithoutBootstrap(dir: string) {
 
 function expectSubagentAllowedBootstrapNames(files: WorkspaceBootstrapFile[]) {
   const names = files.map((file) => file.name);
+  expect(names).toStrictEqual(["AGENTS.md", "TOOLS.md"]);
+}
+
+function expectCronAllowedBootstrapNames(files: WorkspaceBootstrapFile[]) {
+  const names = files.map((file) => file.name);
   expect(names).toStrictEqual(["AGENTS.md", "SOUL.md", "TOOLS.md", "IDENTITY.md", "USER.md"]);
 }
 
@@ -451,6 +456,6 @@ describe("filterBootstrapFilesForSession", () => {
 
   it("filters to allowlist for cron sessions", () => {
     const result = filterBootstrapFilesForSession(mockFiles, "agent:default:cron:daily-check");
-    expectSubagentAllowedBootstrapNames(result);
+    expectCronAllowedBootstrapNames(result);
   });
 });

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -684,16 +684,30 @@ export async function loadWorkspaceBootstrapFiles(dir: string): Promise<Workspac
   return result;
 }
 
-const MINIMAL_BOOTSTRAP_ALLOWLIST = new Set([DEFAULT_AGENTS_FILENAME, DEFAULT_TOOLS_FILENAME]);
+const SUBAGENT_BOOTSTRAP_ALLOWLIST = new Set([DEFAULT_AGENTS_FILENAME, DEFAULT_TOOLS_FILENAME]);
+
+const CRON_BOOTSTRAP_ALLOWLIST = new Set([
+  DEFAULT_AGENTS_FILENAME,
+  DEFAULT_TOOLS_FILENAME,
+  DEFAULT_SOUL_FILENAME,
+  DEFAULT_IDENTITY_FILENAME,
+  DEFAULT_USER_FILENAME,
+]);
 
 export function filterBootstrapFilesForSession(
   files: WorkspaceBootstrapFile[],
   sessionKey?: string,
 ): WorkspaceBootstrapFile[] {
-  if (!sessionKey || (!isSubagentSessionKey(sessionKey) && !isCronSessionKey(sessionKey))) {
+  if (!sessionKey) {
     return files;
   }
-  return files.filter((file) => MINIMAL_BOOTSTRAP_ALLOWLIST.has(file.name));
+  if (isSubagentSessionKey(sessionKey)) {
+    return files.filter((file) => SUBAGENT_BOOTSTRAP_ALLOWLIST.has(file.name));
+  }
+  if (isCronSessionKey(sessionKey)) {
+    return files.filter((file) => CRON_BOOTSTRAP_ALLOWLIST.has(file.name));
+  }
+  return files;
 }
 
 function hasGlobPattern(pattern: string): boolean {

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -684,13 +684,7 @@ export async function loadWorkspaceBootstrapFiles(dir: string): Promise<Workspac
   return result;
 }
 
-const MINIMAL_BOOTSTRAP_ALLOWLIST = new Set([
-  DEFAULT_AGENTS_FILENAME,
-  DEFAULT_TOOLS_FILENAME,
-  DEFAULT_SOUL_FILENAME,
-  DEFAULT_IDENTITY_FILENAME,
-  DEFAULT_USER_FILENAME,
-]);
+const MINIMAL_BOOTSTRAP_ALLOWLIST = new Set([DEFAULT_AGENTS_FILENAME, DEFAULT_TOOLS_FILENAME]);
 
 export function filterBootstrapFilesForSession(
   files: WorkspaceBootstrapFile[],

--- a/src/hooks/bundled/bootstrap-extra-files/handler.test.ts
+++ b/src/hooks/bundled/bootstrap-extra-files/handler.test.ts
@@ -92,10 +92,6 @@ describe("bootstrap-extra-files hook", () => {
 
     const event = createHookEvent("agent", "bootstrap", "agent:main:subagent:abc", context);
     await handler(event);
-    expect(context.bootstrapFiles.map((f) => f.name).toSorted()).toEqual([
-      "AGENTS.md",
-      "SOUL.md",
-      "TOOLS.md",
-    ]);
+    expect(context.bootstrapFiles.map((f) => f.name).toSorted()).toEqual(["AGENTS.md", "TOOLS.md"]);
   });
 });


### PR DESCRIPTION
## TL;DR

Sub-agents are task workers, not always full copies of the main agent. This PR lets users opt in to a smaller, exact bootstrap-file list for sub-agent sessions so delegated workers can avoid spending tokens on `SOUL.md`, `USER.md`, long runbooks, or customer context they do not need.

This is backwards compatible: omitted config keeps today’s built-in sub-agent behavior, cron filtering is unchanged, and `SUBAGENTS.md` is only loaded when explicitly configured.

Closes #85282.

## Why this makes sense

- **Token efficiency**: every spawned sub-agent currently pays for inherited bootstrap context even when the controller already gives it a focused task. A dedicated `SUBAGENTS.md`, `AGENTS.md` only, or `[]` profile avoids repeating unrelated persona, identity, user, and memory-adjacent context across parallel workers.
- **Least-privilege context**: sub-agents should receive the context required for their delegated task. This gives users a core config knob to keep sensitive main-agent context such as `SOUL.md`, `USER.md`, or customer runbooks out of worker sessions unless they intentionally opt in.
- **Codex fits naturally**: Codex ACP sub-agent targets can be configured with `subagentBootstrapFiles: ["AGENTS.md"]`. Codex already operates inside the project/workspace model, and the controller prompt can pass the concrete files and instructions needed for the task, so duplicating the main agent’s full personality/user stack is usually wasteful.
- **Model-agnostic by design**: the behavior is expressed through agent profiles, not string-matching model names. Non-Codex targets can use `SUBAGENTS.md`; Codex targets can use `AGENTS.md`; specialized workers can use no bootstrap files.

## Flow

```mermaid
flowchart TD
  A["Main agent session"] --> B["Spawn sub-agent task"]
  B --> C{"subagentBootstrapFiles configured?"}
  C -- "No" --> D["Existing built-in sub-agent set<br/>AGENTS + TOOLS + SOUL + IDENTITY + USER"]
  C -- "agents.defaults" --> E["Load exact default list<br/>example: SUBAGENTS.md"]
  C -- "agents.list[] override" --> F["Load exact target-agent list<br/>example: Codex gets AGENTS.md"]
  E --> G["Run bootstrap hooks"]
  F --> G
  D --> G
  G --> H{"Opted in?"}
  H -- "Yes" --> I["Re-apply exact configured list<br/>excluded files stay excluded"]
  H -- "No" --> J["Preserve current filtering behavior"]
  I --> K["Sub-agent prompt"]
  J --> K
```

## Compatibility contract

- Omitted config preserves the current default sub-agent bootstrap set: `AGENTS.md`, `TOOLS.md`, `SOUL.md`, `IDENTITY.md`, and `USER.md`.
- `[]` is explicit and means no workspace bootstrap files for sub-agent sessions.
- Per-agent config overrides `agents.defaults.subagentBootstrapFiles`.
- The setting applies only to sub-agent session keys; cron bootstrap filtering remains unchanged.
- `SUBAGENTS.md` is recognized for explicit root loading, but OpenClaw does not seed it during setup and does not include it in normal full-context loading.
- For opted-in configs, the configured list is exact after hooks, so a hook cannot accidentally re-add excluded files such as `SOUL.md` or `USER.md`.

## What changed

- Added `agents.defaults.subagentBootstrapFiles` and `agents.list[].subagentBootstrapFiles`.
- Added first-class `SUBAGENTS.md` recognition for explicit loading only.
- Threaded per-agent selection through bootstrap resolution, the embedded Pi preload path, and the system-prompt override path.
- Preserved explicitly configured `BOOTSTRAP.md` when a sub-agent opts into it, including after setup completion.
- Added resolver/schema/embedded-runner tests plus docs, schema labels/help, and generated config baseline updates.

## Real behavior proof

- **Behavior or issue addressed**: Sub-agent sessions can now receive an exact, configured workspace bootstrap file list instead of always inheriting the built-in sub-agent profile set. This proves omitted config is unchanged, `SUBAGENTS.md` opt-in works, a Codex per-agent override receives only `AGENTS.md`, `[]` injects none, missing explicit files keep markers, explicit `BOOTSTRAP.md` remains honored after setup completion, hook-added excluded files stay out, hooks cannot erase the configured file, and lowercase legacy `memory.md` is not injected as configured `MEMORY.md`.
- **Real environment tested**: Local OpenClaw source checkout at `/Volumes/LEXAR/repos/openclaw-subagent-bootstrap-files`, running the actual `src/agents/bootstrap-files.ts` resolver against real workspace files under `/Volumes/LEXAR/Codex/openclaw-subagent-bootstrap-files`.
- **Exact steps or command run after this patch**: Ran `node --import tsx --input-type=module -e '<script that writes AGENTS.md/SUBAGENTS.md/TOOLS.md/SOUL.md/IDENTITY.md/USER.md/HEARTBEAT.md/BOOTSTRAP.md/MEMORY.md into a Lexar scratch workspace, marks setup completed for the BOOTSTRAP case, calls resolveBootstrapFilesForRun for default/global/per-agent/empty/missing/BOOTSTRAP/post-hook/hook-drop/lowercase-memory cases, and prints the resolved file lists>'`.
- **Evidence after fix**:

```text
/Volumes/LEXAR/repos/openclaw-subagent-bootstrap-files
OpenClaw subagent bootstrap real-behavior proof
workspace=/Volumes/LEXAR/Codex/openclaw-subagent-bootstrap-files/proof-workspace-7ybykl
default subagent files=["AGENTS.md","SOUL.md","TOOLS.md","IDENTITY.md","USER.md"]
default excludes SUBAGENTS/HEARTBEAT/MEMORY/BOOTSTRAP=true
configured defaults [SUBAGENTS.md]=["SUBAGENTS.md"]
codex per-agent override [AGENTS.md]=["AGENTS.md"]
configured empty array length=0
missing explicit SUBAGENTS marker=[{"name":"SUBAGENTS.md","path":"/Volumes/LEXAR/Codex/openclaw-subagent-bootstrap-files/proof-missing-workspace-hdVTYA/SUBAGENTS.md","missing":true}]
explicit BOOTSTRAP after setup completion=["BOOTSTRAP.md"]
post-hook exact filter with hook-added SOUL=["SUBAGENTS.md"]
post-hook restore after legacy allowlist dropped SUBAGENTS=["SUBAGENTS.md"]
lowercase memory exact-case guard=[{"name":"MEMORY.md","path":"/Volumes/LEXAR/Codex/openclaw-subagent-bootstrap-files/proof-memory-workspace-guNvrw/MEMORY.md","missing":true}]
```

- **Observed result after fix**: The actual resolver returns the existing five-file default when config is omitted, switches to only `SUBAGENTS.md` for configured defaults, switches to only `AGENTS.md` for the Codex target override, returns zero files for `[]`, preserves a missing `SUBAGENTS.md` marker, keeps explicitly configured `BOOTSTRAP.md` after setup completion, filters out hook-added `SOUL.md` after the configured exact selection, restores the configured `SUBAGENTS.md` if a hook applies the legacy allowlist, and treats lowercase `memory.md` as a missing configured `MEMORY.md`.
- **What was not tested**: Full gateway/channel E2E was not run locally; broad runtime coverage is left to GitHub Actions.

## Validation

- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.unit.config.ts src/agents/bootstrap-files.test.ts src/config/zod-schema.agent-defaults.test.ts src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts` (repo unit config reports no matching files because it excludes these project lanes)
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/test-projects.mjs src/agents/bootstrap-files.test.ts src/config/zod-schema.agent-defaults.test.ts src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/test-projects.mjs src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/test-projects.mjs src/agents/bootstrap-files.test.ts src/config/zod-schema.agent-defaults.test.ts src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts src/agents/pi-embedded-runner/run/attempt-system-prompt.test.ts`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/bootstrap-files.test.ts src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.runtime-config.config.ts src/config/zod-schema.agent-defaults.test.ts`
- `pnpm config:docs:gen`
- `pnpm config:docs:check`
- `pnpm config:schema:check`
- `pnpm tsgo:core`
- `pnpm check:test-types`
- `pnpm check:architecture`
- `pnpm exec oxfmt --check --threads=1 src/agents/agent-scope-config.ts src/agents/bootstrap-files.ts src/agents/bootstrap-files.test.ts src/agents/pi-embedded-runner/run/attempt.ts src/agents/pi-embedded-runner/run/attempt-system-prompt.ts src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts src/agents/system-prompt.ts src/agents/workspace.ts src/config/schema.help.ts src/config/schema.labels.ts src/config/types.agent-defaults.ts src/config/types.agents.ts src/config/zod-schema.agent-defaults.ts src/config/zod-schema.agent-defaults.test.ts src/config/zod-schema.agent-runtime.ts`
- `pnpm format:docs:check`
- `git diff --check`
- `codex review --base upstream/main` found one accepted P2 around explicitly configured `BOOTSTRAP.md` injection in embedded sub-agent system prompts; fixed in `aadb1b7362` and covered by the focused regression tests above.
