### PR TITLE
fix(thinking): let authoritative provider profiles override stale catalog reasoning=false

### DIFF
--- a/docs/plugins/sdk-migration.md
+++ b/docs/plugins/sdk-migration.md
@@ -805,7 +805,10 @@ canonical replacement.
     **New**: a single `resolveThinkingProfile(ctx)` that returns a
     `ProviderThinkingProfile` with the canonical `id`, optional `label`, and
     ranked level list. OpenClaw downgrades stale stored values by profile
-    rank automatically.
+    rank automatically. Profiles can set `preserveWhenCatalogReasoningFalse: true`
+    when the provider is the authoritative source for a model's reasoning
+    capability, so stale catalog `reasoning: false` metadata does not force
+    the off-only path on subagent spawn or `/think` validation.
 
     Implement one hook instead of three. The legacy hooks keep working during
     the deprecation window but are not composed with the profile result.

--- a/docs/tools/thinking.md
+++ b/docs/tools/thinking.md
@@ -132,6 +132,7 @@ Malformed local-model reasoning tags are handled conservatively. Closed `<think>
 ## Provider profiles
 
 - Provider plugins can expose `resolveThinkingProfile(ctx)` to define the model's supported levels and default.
+- Set `preserveWhenCatalogReasoningFalse: true` on a returned profile only when the provider owns the canonical reasoning capability for that model. Authoritative profiles win over stale catalog `reasoning: false` metadata; non-authoritative profiles still defer to the catalog opt-out.
 - Provider plugins that proxy Claude models should reuse `resolveClaudeThinkingProfile(modelId)` from `openclaw/plugin-sdk/provider-model-shared` so direct Anthropic and proxy catalogs stay aligned.
 - Each profile level has a stored canonical `id` (`off`, `minimal`, `low`, `medium`, `high`, `xhigh`, `adaptive`, or `max`) and may include a display `label`. Binary providers use `{ id: "low", label: "on" }`.
 - Tool plugins that need to validate an explicit thinking override should use `api.runtime.agent.resolveThinkingPolicy({ provider, model })` plus `api.runtime.agent.normalizeThinkingLevel(...)`; they should not keep their own provider/model level lists.

--- a/extensions/openai/openai-provider.test.ts
+++ b/extensions/openai/openai-provider.test.ts
@@ -464,7 +464,8 @@ describe("buildOpenAIProvider", () => {
       } as never)?.preserveWhenCatalogReasoningFalse,
     ).toBe(true);
 
-    // Non-reasoning chat models leave catalog reasoning=false authoritative.
+    // Non-reasoning chat-latest variants — bundled catalog marks these
+    // reasoning=false, so the provider profile must NOT override.
     expect(
       provider.resolveThinkingProfile?.({
         provider: "openai",
@@ -477,12 +478,36 @@ describe("buildOpenAIProvider", () => {
         modelId: "gpt-5-chat-latest",
       } as never)?.preserveWhenCatalogReasoningFalse,
     ).toBeUndefined();
+    // Regression guard: prior revision matched via "gpt-5.3" prefix and would
+    // have flipped this non-reasoning chat-latest catalog row to reasoning.
+    expect(
+      provider.resolveThinkingProfile?.({
+        provider: "openai",
+        modelId: "gpt-5.3-chat-latest",
+      } as never)?.preserveWhenCatalogReasoningFalse,
+    ).toBeUndefined();
     expect(
       provider.resolveThinkingProfile?.({
         provider: "openai",
         modelId: "gpt-4.1",
       } as never)?.preserveWhenCatalogReasoningFalse,
     ).toBeUndefined();
+
+    // Reasoning chat-latest variants explicitly opted in — catalog marks
+    // these reasoning=true, so a stale reasoning=false row should be
+    // overridden by the authoritative provider profile.
+    expect(
+      provider.resolveThinkingProfile?.({
+        provider: "openai",
+        modelId: "gpt-5.1-chat-latest",
+      } as never)?.preserveWhenCatalogReasoningFalse,
+    ).toBe(true);
+    expect(
+      provider.resolveThinkingProfile?.({
+        provider: "openai",
+        modelId: "gpt-5.2-chat-latest",
+      } as never)?.preserveWhenCatalogReasoningFalse,
+    ).toBe(true);
   });
 
   it("keeps modern live selection on OpenAI 5.2+ and current Codex models", () => {

--- a/extensions/openai/openai-provider.test.ts
+++ b/extensions/openai/openai-provider.test.ts
@@ -435,6 +435,56 @@ describe("buildOpenAIProvider", () => {
     expectNoCatalogEntry(entries, "chat-latest");
   });
 
+  it("flags reasoning model thinking profiles as authoritative over stale catalog reasoning=false", () => {
+    const provider = buildOpenAIProvider();
+
+    // Reasoning-capable models opt in to catalog override (issue #84880).
+    expect(
+      provider.resolveThinkingProfile?.({
+        provider: "openai",
+        modelId: "gpt-5.5",
+      } as never)?.preserveWhenCatalogReasoningFalse,
+    ).toBe(true);
+    expect(
+      provider.resolveThinkingProfile?.({
+        provider: "openai",
+        modelId: "gpt-5.4",
+      } as never)?.preserveWhenCatalogReasoningFalse,
+    ).toBe(true);
+    expect(
+      provider.resolveThinkingProfile?.({
+        provider: "openai",
+        modelId: "gpt-5.4-mini",
+      } as never)?.preserveWhenCatalogReasoningFalse,
+    ).toBe(true);
+    expect(
+      provider.resolveThinkingProfile?.({
+        provider: "openai",
+        modelId: "o3-mini",
+      } as never)?.preserveWhenCatalogReasoningFalse,
+    ).toBe(true);
+
+    // Non-reasoning chat models leave catalog reasoning=false authoritative.
+    expect(
+      provider.resolveThinkingProfile?.({
+        provider: "openai",
+        modelId: "chat-latest",
+      } as never)?.preserveWhenCatalogReasoningFalse,
+    ).toBeUndefined();
+    expect(
+      provider.resolveThinkingProfile?.({
+        provider: "openai",
+        modelId: "gpt-5-chat-latest",
+      } as never)?.preserveWhenCatalogReasoningFalse,
+    ).toBeUndefined();
+    expect(
+      provider.resolveThinkingProfile?.({
+        provider: "openai",
+        modelId: "gpt-4.1",
+      } as never)?.preserveWhenCatalogReasoningFalse,
+    ).toBeUndefined();
+  });
+
   it("keeps modern live selection on OpenAI 5.2+ and current Codex models", () => {
     const provider = buildOpenAIProvider();
     const codexProvider = buildOpenAICodexProviderPlugin();

--- a/extensions/openai/thinking-policy.ts
+++ b/extensions/openai/thinking-policy.ts
@@ -32,10 +32,40 @@ function matchesExactOrPrefix(id: string, values: readonly string[]): boolean {
   });
 }
 
+const OPENAI_NON_REASONING_MODEL_IDS = ["chat-latest", "gpt-5-chat-latest"] as const;
+
+const OPENAI_REASONING_MODEL_PREFIXES = [
+  "gpt-5.5",
+  "gpt-5.4",
+  "gpt-5.3",
+  "gpt-5.2",
+  "gpt-5.1-codex",
+  "gpt-5-codex",
+  "gpt-5-mini",
+  "gpt-5-nano",
+  "gpt-5-pro",
+  "gpt-5.1",
+  "o1",
+  "o3",
+  "o4",
+] as const;
+
+function isOpenAIReasoningModelId(modelId: string): boolean {
+  const normalizedId = normalizeModelId(modelId);
+  if (OPENAI_NON_REASONING_MODEL_IDS.includes(normalizedId as never)) {
+    return false;
+  }
+  if (normalizedId === "gpt-5") {
+    return true;
+  }
+  return matchesExactOrPrefix(normalizedId, OPENAI_REASONING_MODEL_PREFIXES);
+}
+
 function buildOpenAIThinkingProfile(params: {
   modelId: string;
   xhighModelIds: readonly string[];
 }): ProviderThinkingProfile {
+  const preserveWhenCatalogReasoningFalse = isOpenAIReasoningModelId(params.modelId);
   return {
     levels: [
       ...OPENAI_THINKING_BASE_LEVELS,
@@ -43,6 +73,7 @@ function buildOpenAIThinkingProfile(params: {
         ? [{ id: "xhigh" as const }]
         : []),
     ],
+    ...(preserveWhenCatalogReasoningFalse ? { preserveWhenCatalogReasoningFalse } : {}),
   };
 }
 

--- a/extensions/openai/thinking-policy.ts
+++ b/extensions/openai/thinking-policy.ts
@@ -32,7 +32,13 @@ function matchesExactOrPrefix(id: string, values: readonly string[]): boolean {
   });
 }
 
-const OPENAI_NON_REASONING_MODEL_IDS = ["chat-latest", "gpt-5-chat-latest"] as const;
+// Chat-latest variants are matched suffix-aware so a `gpt-5.N` reasoning
+// prefix below does not accidentally flip a non-reasoning catalog row.
+// Only the variants explicitly listed here are treated as reasoning.
+const OPENAI_REASONING_CHAT_LATEST_MODEL_IDS = [
+  "gpt-5.1-chat-latest",
+  "gpt-5.2-chat-latest",
+] as const;
 
 const OPENAI_REASONING_MODEL_PREFIXES = [
   "gpt-5.5",
@@ -52,8 +58,12 @@ const OPENAI_REASONING_MODEL_PREFIXES = [
 
 function isOpenAIReasoningModelId(modelId: string): boolean {
   const normalizedId = normalizeModelId(modelId);
-  if (OPENAI_NON_REASONING_MODEL_IDS.includes(normalizedId as never)) {
-    return false;
+  // Chat-latest variants opt in explicitly. Any other `*-chat-latest` (the
+  // bundled `chat-latest`, `gpt-5-chat-latest`, `gpt-5.3-chat-latest` are all
+  // catalog reasoning=false) stays catalog-authoritative so a stale
+  // `reasoning: false` row keeps forcing off-only as designed.
+  if (normalizedId === "chat-latest" || normalizedId.endsWith("-chat-latest")) {
+    return OPENAI_REASONING_CHAT_LATEST_MODEL_IDS.includes(normalizedId as never);
   }
   if (normalizedId === "gpt-5") {
     return true;

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -189,6 +189,20 @@ describe("listThinkingLevels", () => {
       { provider: "openai", id: "gpt-5.4", name: "GPT-5.4", reasoning: false },
       { provider: "openai-codex", id: "gpt-5.5", name: "GPT-5.5 (Codex)", reasoning: false },
       { provider: "openai", id: "chat-latest", name: "Chat Latest", reasoning: false },
+      // Bundled-catalog non-reasoning chat-latest variants must stay off-only
+      // even after the resolver change so users still get the documented opt-out.
+      {
+        provider: "openai",
+        id: "gpt-5.3-chat-latest",
+        name: "GPT-5.3 Chat (latest)",
+        reasoning: false,
+      },
+      {
+        provider: "openai",
+        id: "gpt-5-chat-latest",
+        name: "GPT-5 Chat Latest",
+        reasoning: false,
+      },
     ];
 
     // Issue #84880 acceptance: sessions_spawn must accept high/xhigh on gpt-5.5/5.4.
@@ -222,6 +236,11 @@ describe("listThinkingLevels", () => {
     // chat-latest is a non-reasoning OpenAI model — provider does NOT override,
     // so stale catalog reasoning=false still wins.
     expect(listThinkingLevels("openai", "chat-latest", staleCatalog)).toEqual(["off"]);
+    // Regression guard for ClawSweeper review on PR #85285: an earlier revision
+    // matched `gpt-5.3-chat-latest` via the `gpt-5.3` reasoning prefix and would
+    // have incorrectly flipped this catalog opt-out.
+    expect(listThinkingLevels("openai", "gpt-5.3-chat-latest", staleCatalog)).toEqual(["off"]);
+    expect(listThinkingLevels("openai", "gpt-5-chat-latest", staleCatalog)).toEqual(["off"]);
   });
 
   it("keeps non-authoritative provider profiles behind catalog reasoning=false", () => {

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -160,6 +160,95 @@ describe("listThinkingLevels", () => {
     expect(listThinkingLevelLabels("demo", "demo-model")).toEqual(["off", "on"]);
   });
 
+  it("lets authoritative provider profiles override stale catalog reasoning=false", () => {
+    providerRuntimeMocks.resolveProviderThinkingProfile.mockImplementation(
+      ({ provider, context }) => {
+        if (provider !== "openai" && provider !== "openai-codex") {
+          return undefined;
+        }
+        const preserveWhenCatalogReasoningFalse =
+          context.modelId === "gpt-5.5" ||
+          context.modelId === "gpt-5.4" ||
+          context.modelId === "gpt-5.3";
+        return {
+          levels: [
+            { id: "off" },
+            { id: "minimal" },
+            { id: "low" },
+            { id: "medium" },
+            { id: "high" },
+            { id: "xhigh" },
+          ],
+          ...(preserveWhenCatalogReasoningFalse ? { preserveWhenCatalogReasoningFalse } : {}),
+          defaultLevel: "medium",
+        };
+      },
+    );
+    const staleCatalog = [
+      { provider: "openai", id: "gpt-5.5", name: "GPT-5.5", reasoning: false },
+      { provider: "openai", id: "gpt-5.4", name: "GPT-5.4", reasoning: false },
+      { provider: "openai-codex", id: "gpt-5.5", name: "GPT-5.5 (Codex)", reasoning: false },
+      { provider: "openai", id: "chat-latest", name: "Chat Latest", reasoning: false },
+    ];
+
+    // Issue #84880 acceptance: sessions_spawn must accept high/xhigh on gpt-5.5/5.4.
+    expect(
+      isThinkingLevelSupported({
+        provider: "openai",
+        model: "gpt-5.4",
+        level: "high",
+        catalog: staleCatalog,
+      }),
+    ).toBe(true);
+    expect(
+      isThinkingLevelSupported({
+        provider: "openai-codex",
+        model: "gpt-5.5",
+        level: "high",
+        catalog: staleCatalog,
+      }),
+    ).toBe(true);
+    expect(
+      isThinkingLevelSupported({
+        provider: "openai-codex",
+        model: "gpt-5.5",
+        level: "xhigh",
+        catalog: staleCatalog,
+      }),
+    ).toBe(true);
+    expect(formatThinkingLevels("openai-codex", "gpt-5.5", ", ", staleCatalog)).toBe(
+      "off, minimal, low, medium, high, xhigh",
+    );
+    // chat-latest is a non-reasoning OpenAI model — provider does NOT override,
+    // so stale catalog reasoning=false still wins.
+    expect(listThinkingLevels("openai", "chat-latest", staleCatalog)).toEqual(["off"]);
+  });
+
+  it("keeps non-authoritative provider profiles behind catalog reasoning=false", () => {
+    providerRuntimeMocks.resolveProviderThinkingProfile.mockReturnValue({
+      levels: [{ id: "off" }, { id: "low" }, { id: "medium" }, { id: "high" }],
+      defaultLevel: "medium",
+    });
+    const catalog = [
+      {
+        provider: "demo",
+        id: "demo-model",
+        name: "Demo",
+        reasoning: false,
+      },
+    ];
+
+    expect(listThinkingLevels("demo", "demo-model", catalog)).toEqual(["off"]);
+    expect(
+      isThinkingLevelSupported({
+        provider: "demo",
+        model: "demo-model",
+        level: "high",
+        catalog,
+      }),
+    ).toBe(false);
+  });
+
   it("treats catalog reasoning=false as an explicit thinking opt-out", () => {
     providerRuntimeMocks.resolveProviderThinkingProfile.mockReturnValue({
       levels: [{ id: "off" }, { id: "low" }, { id: "medium" }, { id: "high" }],


### PR DESCRIPTION
## Summary

Fixes #84880. Subagent spawns and `/think` validation reject non-`off` thinking on canonical `openai/*` and `openai-codex/*` GPT-5 reasoning models when a stale catalog entry has `reasoning: false`. `resolveThinkingProfile` short-circuits to off-only on `reasoning === false` before consulting the provider plugin profile, so persisted catalogs that lag behind runtime augmentation force `Use one of: off.` even for models the provider knows support `high`/`xhigh`.

The opt-in profile flag (`preserveWhenCatalogReasoningFalse`) and the `resolveThinkingProfile` reordering already landed in upstream PR #85300 for the Gemini 3 cron-thinking fix. This PR builds on that infrastructure: it applies the same flag to the OpenAI extension for the GPT-5 reasoning model set and explicitly excludes non-reasoning chat-latest variants. The classifier is **suffix-aware**: any `*-chat-latest` model is catalog-authoritative unless it appears in the explicit `OPENAI_REASONING_CHAT_LATEST_MODEL_IDS = ["gpt-5.1-chat-latest", "gpt-5.2-chat-latest"]` opt-in list (matches bundled catalog reasoning flags in `extensions/openai/openclaw.plugin.json`).

## Real behavior proof

**Behavior or issue addressed**: `sessions_spawn(model="openai-codex/gpt-5.5", thinking="high"|"xhigh")` and `sessions_spawn(model="openai/gpt-5.4", thinking="high")` are rejected with `Thinking level "high" is not supported for openai/gpt-5.5. Use one of: off.` even though the canonical OpenAI/Codex catalog lists these models as reasoning-capable — see live v2026.5.20 repro logs in [issue #84880](https://github.com/openclaw/openclaw/issues/84880). With #85300's resolver reordering in place, this PR flips the relevant OpenAI / OpenAI-Codex profiles to authoritative (via `preserveWhenCatalogReasoningFalse: true`) so they win over stale persisted catalog `reasoning: false` rows.

**Real environment tested**: macOS 25.5.0 (Darwin arm64), Node 24.13.0, pnpm 11.1.0; repository checked out at `fix/subagent-thinking-overrides-catalog-reasoning` head `890ebf8c` rebased on `origin/main` `77a1b762` (which already contains #85300). Runtime probe drives the patched modules end-to-end through the same `resolveOpenAIThinkingProfile` / `resolveOpenAICodexThinkingProfile` entry points that the live Gateway calls on every `sessions_spawn` validation in `src/auto-reply/reply/get-reply-run.ts` and `src/agents/subagent-spawn.ts`.

**Exact steps or command run after this patch**:
```
git checkout fix/subagent-thinking-overrides-catalog-reasoning
node --import tsx probe-thinking.mjs
```

The probe is a small driver script that imports the patched `extensions/openai/thinking-policy.ts` and calls the classifier for each acceptance scenario from #84880 plus the chat-latest regression guards from the ClawSweeper P1 review, then checks the resolved `levels[]` and `preserveWhenCatalogReasoningFalse` flag against expected values.

**Evidence after fix**: Live terminal output from `node --import tsx probe-thinking.mjs` after applying the patch — copied verbatim, no redaction needed since the probe data is synthetic:

```
=== Runtime probe: extensions/openai/thinking-policy.ts ===

PASS | [#84880 §1] openai/gpt-5.4 high
       levels=[off, minimal, low, medium, high, xhigh] preserveWhenCatalogReasoningFalse=true (want true)
PASS | [#84880 §2] openai-codex/gpt-5.5 high
       levels=[off, minimal, low, medium, high, xhigh] preserveWhenCatalogReasoningFalse=true (want true)
PASS | [#84880 §3] openai-codex/gpt-5.5 xhigh
       levels=[off, minimal, low, medium, high, xhigh] preserveWhenCatalogReasoningFalse=true (want true)
PASS | openai/gpt-5.5 minimal/low/medium/high/xhigh
       levels=[off, minimal, low, medium, high, xhigh] preserveWhenCatalogReasoningFalse=true (want true)
PASS | [ClawSweeper P1] openai/chat-latest
       levels=[off, minimal, low, medium, high] preserveWhenCatalogReasoningFalse=false (want false)
PASS | [ClawSweeper P1] openai/gpt-5-chat-latest
       levels=[off, minimal, low, medium, high] preserveWhenCatalogReasoningFalse=false (want false)
PASS | [ClawSweeper P1] openai/gpt-5.3-chat-latest
       levels=[off, minimal, low, medium, high] preserveWhenCatalogReasoningFalse=false (want false)
PASS | openai/gpt-5.1-chat-latest (reasoning catalog row)
       levels=[off, minimal, low, medium, high] preserveWhenCatalogReasoningFalse=true (want true)
PASS | openai/gpt-5.2-chat-latest (reasoning catalog row)
       levels=[off, minimal, low, medium, high, xhigh] preserveWhenCatalogReasoningFalse=true (want true)
PASS | openai/o3-mini
       levels=[off, minimal, low, medium, high] preserveWhenCatalogReasoningFalse=true (want true)
PASS | openai/gpt-5-pro
       levels=[off, minimal, low, medium, high] preserveWhenCatalogReasoningFalse=true (want true)
PASS | openai/gpt-4.1
       levels=[off, minimal, low, medium, high] preserveWhenCatalogReasoningFalse=false (want false)

Summary: 12/12 probes PASS.
```

**Observed result after fix**: 12/12 probes pass. For the canonical GPT-5 reasoning model refs the patch flips `preserveWhenCatalogReasoningFalse` to `true` and surfaces the full `[off, minimal, low, medium, high]` level set (plus `xhigh` on the appropriate models), so a stale catalog row marked `reasoning: false` no longer triggers the off-only short-circuit. For non-reasoning chat-latest variants (`chat-latest`, `gpt-5-chat-latest`, `gpt-5.3-chat-latest`) and legacy non-reasoning models (`gpt-4.1`) the classifier returns `preserveWhenCatalogReasoningFalse=false`, so a stale catalog `reasoning: false` row still wins and the runtime keeps the off-only path documented by the catalog opt-out.

Cross-check against the bundled `extensions/openai/openclaw.plugin.json` shows the classifier verdict matches the catalog truth for every chat-latest variant in the bundle:

| Model | Catalog reasoning | Classifier verdict | Stale-row override |
|---|---|---|---|
| `gpt-5-chat-latest` | `false` | non-authoritative | catalog wins (off-only) |
| `gpt-5.1-chat-latest` | `true` | authoritative | overrides stale `false` |
| `gpt-5.2-chat-latest` | `true` | authoritative | overrides stale `false` |
| `gpt-5.3-chat-latest` | `false` | non-authoritative | catalog wins (off-only) |
| `chat-latest` | `false` | non-authoritative | catalog wins (off-only) |
| `gpt-5.5`, `gpt-5.4`, `gpt-5-codex`, `o3-mini`, … | `true` | authoritative | overrides stale `false` |
| `gpt-4.1`, `gpt-4o`, … | `false` | non-authoritative | catalog wins (off-only) |

**What was not tested**: A redacted `sessions_spawn` live run against a custom-built Gateway binary in my deployment — the probe exercises the same classifier and resolver entry points the live Gateway calls, but I did not build and install a custom Gateway binary into my OrbStack VM for this PR. Also out of scope: the Ollama Cloud variant raised by @SplyzerRB in #84880 where the subagent ignores explicit `thinking: "off"` — that path forwards `thinking` even when the spawn arg is `off` and is a separate runtime bug that does not share a code path with the OpenAI/Codex catalog-override issue this PR fixes.

## What changes

- **`extensions/openai/thinking-policy.ts`** — suffix-aware classifier for chat-latest variants; flags reasoning model refs as authoritative via `isOpenAIReasoningModelId`, setting `preserveWhenCatalogReasoningFalse` on the returned profile.
- **`extensions/openai/openai-provider.test.ts`** — coverage for the four #84880 acceptance scenarios, the three ClawSweeper P1 chat-latest regression guards (`chat-latest`, `gpt-5-chat-latest`, `gpt-5.3-chat-latest` stay non-authoritative), and the two explicit reasoning chat-latest opt-ins (`gpt-5.1-chat-latest`, `gpt-5.2-chat-latest`).
- **`src/auto-reply/thinking.test.ts`** — resolver-level coverage that authoritative provider profiles override stale catalog `reasoning: false`, while non-authoritative profiles still defer to the catalog opt-out.
- **`docs/tools/thinking.md`** and **`docs/plugins/sdk-migration.md`** — document the opt-in flag.

The opt-in flag itself (`preserveWhenCatalogReasoningFalse` on `ProviderThinkingProfile`) and the `resolveThinkingProfile` reordering are already present in `main` via upstream PR #85300. This PR no longer touches `src/plugins/provider-thinking.types.ts` or `src/auto-reply/thinking.ts` runtime — it consumes the existing flag from the OpenAI extension.

## Verification

- `pnpm check:architecture` — clean (0 import cycles).
- `pnpm tsgo:all` — clean.
- `pnpm vitest run src/auto-reply/thinking.test.ts extensions/openai/openai-provider.test.ts` — 63/63 tests pass.
- Runtime probe (above) — 12/12 PASS covering all four #84880 acceptance scenarios plus chat-latest regression guards.