### PR TITLE
fix(pi-runner): flush block replies after compaction retry

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -210,6 +210,32 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     vi.restoreAllMocks();
   });
 
+  it("flushes block replies again after compaction retry wait resolves", async () => {
+    const order: string[] = [];
+    let flushCount = 0;
+    const onBlockReplyFlush = vi.fn(async () => {
+      flushCount += 1;
+      order.push(`flush-${flushCount}`);
+    });
+    hoisted.waitForCompactionRetryWithAggregateTimeoutMock.mockImplementation(async () => {
+      order.push("retry-wait");
+      return { timedOut: false };
+    });
+
+    await createContextEngineAttemptRunner({
+      contextEngine: createContextEngineBootstrapAndAssemble(),
+      sessionKey,
+      tempPaths,
+      attemptOverrides: {
+        onBlockReplyFlush,
+      },
+    });
+
+    expect(onBlockReplyFlush).toHaveBeenCalledTimes(2);
+    expect(hoisted.waitForCompactionRetryWithAggregateTimeoutMock).toHaveBeenCalledTimes(1);
+    expect(order).toEqual(["flush-1", "retry-wait", "flush-2"]);
+  });
+
   it("enables Tool Search controls for embedded PI runs when configured", async () => {
     await createContextEngineAttemptRunner({
       contextEngine: {

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
@@ -29,6 +29,8 @@ type AcquireSessionWriteLockFn =
   typeof import("../../session-write-lock.js").acquireSessionWriteLock;
 type ShouldPreemptivelyCompactBeforePromptFn =
   typeof import("./preemptive-compaction.js").shouldPreemptivelyCompactBeforePrompt;
+type WaitForCompactionRetryWithAggregateTimeoutFn =
+  typeof import("./compaction-retry-aggregate-timeout.js").waitForCompactionRetryWithAggregateTimeout;
 
 type SubscriptionMock = ReturnType<SubscribeEmbeddedPiSessionFn>;
 type UnknownMock = Mock<(...args: unknown[]) => unknown>;
@@ -86,6 +88,7 @@ type AttemptSpawnWorkspaceHoisted = {
     (sessionKey: string | undefined, config: unknown) => number | undefined
   >;
   limitHistoryTurnsMock: Mock<<T>(messages: T, limit: number | undefined) => T>;
+  waitForCompactionRetryWithAggregateTimeoutMock: Mock<WaitForCompactionRetryWithAggregateTimeoutFn>;
   preemptiveCompactionCalls: Parameters<ShouldPreemptivelyCompactBeforePromptFn>[0][];
   systemPromptOverrideTexts: string[];
   sessionManager: SessionManagerMocks;
@@ -181,6 +184,10 @@ const hoisted = vi.hoisted((): AttemptSpawnWorkspaceHoisted => {
   const limitHistoryTurnsMock = vi.fn<<T>(messages: T, limit: number | undefined) => T>(
     (messages) => messages,
   );
+  const waitForCompactionRetryWithAggregateTimeoutMock =
+    vi.fn<WaitForCompactionRetryWithAggregateTimeoutFn>(async () => ({
+      timedOut: false,
+    }));
   const preemptiveCompactionCalls: Parameters<ShouldPreemptivelyCompactBeforePromptFn>[0][] = [];
   const systemPromptOverrideTexts: string[] = [];
   const sessionManager = {
@@ -221,6 +228,7 @@ const hoisted = vi.hoisted((): AttemptSpawnWorkspaceHoisted => {
     detectAndLoadPromptImagesMock,
     getHistoryLimitFromSessionKeyMock,
     limitHistoryTurnsMock,
+    waitForCompactionRetryWithAggregateTimeoutMock,
     preemptiveCompactionCalls,
     systemPromptOverrideTexts,
     sessionManager,
@@ -774,10 +782,9 @@ vi.mock("../utils.js", () => ({
 }));
 
 vi.mock("./compaction-retry-aggregate-timeout.js", () => ({
-  waitForCompactionRetryWithAggregateTimeout: async () => ({
-    timedOut: false,
-    aborted: false,
-  }),
+  waitForCompactionRetryWithAggregateTimeout: (
+    ...args: Parameters<WaitForCompactionRetryWithAggregateTimeoutFn>
+  ) => hoisted.waitForCompactionRetryWithAggregateTimeoutMock(...args),
 }));
 
 vi.mock("./compaction-timeout.js", () => ({
@@ -956,6 +963,9 @@ export function resetEmbeddedAttemptHarness(
   hoisted.runContextEngineMaintenanceMock.mockReset().mockResolvedValue(undefined);
   hoisted.getHistoryLimitFromSessionKeyMock.mockReset().mockReturnValue(undefined);
   hoisted.limitHistoryTurnsMock.mockReset().mockImplementation((messages) => messages);
+  hoisted.waitForCompactionRetryWithAggregateTimeoutMock
+    .mockReset()
+    .mockResolvedValue({ timedOut: false });
   hoisted.preemptiveCompactionCalls.length = 0;
   hoisted.systemPromptOverrideTexts.length = 0;
   hoisted.sessionManager.getLeafEntry.mockReset().mockReturnValue(null);

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -4246,6 +4246,11 @@ export async function runEmbeddedAttempt(
                   `proceeding with pre-compaction state runId=${params.runId} sessionId=${params.sessionId}`,
               );
             }
+          } else if (onBlockReplyFlush) {
+            // Retry-generated blocks can still be draining when the compaction
+            // retry wait resolves; this second drain is idempotent when no new
+            // blocks were produced.
+            await onBlockReplyFlush();
           }
         } catch (err) {
           if (isRunnerAbortError(err)) {


### PR DESCRIPTION
## Summary
- Fixes #47335.
- Flushes the block reply pipeline again after the compaction retry wait resolves, so retry-generated block replies cannot still be draining when the attempt returns.
- Skips the extra drain on aggregate timeout to preserve the existing timeout/slow-channel behavior.

## Verification
- `corepack pnpm exec tsx /private/tmp/openclaw-compaction-retry-delivery-proof.ts`
- `node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts -t "flushes block replies again after compaction retry wait resolves"`
- `pnpm check:architecture`
- `node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts src/agents/pi-embedded-runner/run/compaction-retry-aggregate-timeout.test.ts src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts`
- `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-payloads.test.ts src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.splits-long-single-line-fenced-blocks-reopen.test.ts src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.waits-multiple-compaction-retries-before-resolving.test.ts`
- `corepack pnpm exec oxfmt --check --threads=1 src/agents/pi-embedded-runner/run/attempt.ts src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts`
- `git diff --check`

## Real behavior proof
Behavior addressed: Compaction retry can resolve the runner wait before retry-generated block replies finish draining, causing transcript-visible replies to be dropped before channel delivery.

Real environment tested: Local OpenClaw source checkout at commit `70f45ff870e43fbb939c680b74821015ecdccce6`, rebased onto `origin/main` at `e2f82d4d30bbebbf89bdbb94b3e58c7aa0185151` on macOS, with dependencies installed from `pnpm-lock.yaml`.

The log-backed proof uses the real `createBlockReplyPipeline().flush()` delivery barrier and the real `waitForCompactionRetryWithAggregateTimeout()` helper. The local channel adapter deliberately delays send completion so the retry wait / delivery ordering is visible without external provider credentials.

Exact steps or command run after this patch:
- `corepack pnpm exec tsx /private/tmp/openclaw-compaction-retry-delivery-proof.ts`
- `node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts -t "flushes block replies again after compaction retry wait resolves"`
- `pnpm check:architecture`
- `node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts src/agents/pi-embedded-runner/run/compaction-retry-aggregate-timeout.test.ts src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts`
- `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-payloads.test.ts src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.splits-long-single-line-fenced-blocks-reopen.test.ts src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.waits-multiple-compaction-retries-before-resolving.test.ts`
- `corepack pnpm exec oxfmt --check --threads=1 src/agents/pi-embedded-runner/run/attempt.ts src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts`
- `git diff --check`

Evidence after fix:
```txt
pre-wait-flush-start
pre-wait-flush-complete
retry-wait-start
retry-generated-block-enqueued
channel-send-start:retry reply delivered after compaction wait
retry-wait-resolved
aggregate-wait-result:{"timedOut":false}
delivered-before-post-wait-flush:none
delivery-in-flight-before-post-wait-flush-completes:yes
channel-send-complete:retry reply delivered after compaction wait
post-wait-flush-complete:retry reply delivered after compaction wait
```

- Rebased head: `70f45ff870e43fbb939c680b74821015ecdccce6` on `origin/main` `e2f82d4d30bbebbf89bdbb94b3e58c7aa0185151`.
- Target regression after rebase: `Test Files 2 passed (2)`, `Tests 2 passed | 94 skipped (96)`.
- Architecture after rebase: `Import cycle check: 0 runtime value cycle(s).`, `Madge import cycle check: 0 cycle(s).`, `deprecated API usage guard passed`, `deprecated JSDoc guard passed`.
- Runner/lifecycle/compaction selection: `Test Files 6 passed (6)`, `Tests 166 passed (166)`.
- Supplemental payload/subscribe selection: `Test Files 5 passed (5)`, `Tests 62 passed (62)`.
- oxfmt: `All matched files use the correct format.`
- `git diff --check` passed with no output.

Observed result after fix: The retry wait returns with the retry reply still undelivered (`delivered-before-post-wait-flush:none`), then the second idempotent flush waits for the real block reply pipeline send chain to finish (`post-wait-flush-complete:retry reply delivered after compaction wait`). Aggregate-timeout fallback still avoids an extra drain.

What was not tested: A live high-context Discord/Telegram/other external-network compaction retry with real provider credentials was not run. The behavior proof is local and log-backed, using the real block reply pipeline flush and retry wait helper with a delayed local channel adapter.

## AI Assistance Disclosure
This PR was prepared with AI assistance. I reviewed the changed code path and verified the targeted tests above.