### PR TITLE
fix(config): scope dry-run bundled channel validation

### DIFF
--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -1527,6 +1527,109 @@ describe("config cli", () => {
       expectErrorIncludes("Dry run failed: config schema validation failed.");
     });
 
+    it("allows an empty config patch dry-run without writing", async () => {
+      const resolved: OpenClawConfig = {
+        gateway: { port: 18789 },
+      };
+      setSnapshot(resolved, resolved);
+      const pathname = writeTempJson5File("openclaw-empty-config-patch", {});
+
+      await runConfigCommand(["config", "patch", "--file", pathname, "--dry-run", "--json"]);
+
+      const payload = parseLastLogPayload() as { ok: boolean; operations: number };
+      expect(payload.ok).toBe(true);
+      expect(payload.operations).toBe(0);
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+    });
+
+    it("does not validate unrelated legacy bundled-channel required fields in JSON dry-run mode", async () => {
+      const resolved: OpenClawConfig = {
+        gateway: { port: 18789 },
+        channels: {
+          telegram: {
+            enabled: true,
+          },
+        },
+      } as unknown as OpenClawConfig;
+      setSnapshot(resolved, resolved);
+
+      await runConfigCommand([
+        "config",
+        "set",
+        "plugins.entries.memory-core.enabled",
+        "false",
+        "--strict-json",
+        "--dry-run",
+        "--json",
+      ]);
+
+      const payload = parseLastLogPayload() as { ok: boolean; operations: number };
+      expect(payload.ok).toBe(true);
+      expect(payload.operations).toBe(1);
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+    });
+
+    it("still validates bundled-channel schemas when JSON dry-run touches a channel path", async () => {
+      const resolved: OpenClawConfig = {
+        gateway: { port: 18789 },
+        channels: {
+          telegram: {
+            enabled: true,
+          },
+        },
+      } as unknown as OpenClawConfig;
+      setSnapshot(resolved, resolved);
+
+      await expect(
+        runConfigCommand([
+          "config",
+          "set",
+          "channels.telegram.dmPolicy",
+          '"definitely-invalid"',
+          "--strict-json",
+          "--dry-run",
+          "--json",
+        ]),
+      ).rejects.toThrow("__exit__:1");
+
+      const payload = parseLastLogPayload() as {
+        ok: boolean;
+        errors?: Array<{ kind: string; message: string }>;
+      };
+      expect(payload.ok).toBe(false);
+      expect(
+        payload.errors?.some((error) => error.message.includes("channels.telegram.dmPolicy")),
+      ).toBe(true);
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+    });
+
+    it("dry-runs memory-core enablement without mutating config", async () => {
+      const resolved: OpenClawConfig = {
+        gateway: { port: 18789 },
+        channels: {
+          telegram: {
+            enabled: true,
+          },
+        },
+      } as unknown as OpenClawConfig;
+      setSnapshot(resolved, resolved);
+
+      await runConfigCommand([
+        "config",
+        "set",
+        "plugins.entries.memory-core.enabled",
+        "true",
+        "--strict-json",
+        "--dry-run",
+        "--json",
+      ]);
+
+      const payload = parseLastLogPayload() as { ok: boolean; operations: number };
+      expect(payload.ok).toBe(true);
+      expect(payload.operations).toBe(1);
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+    });
+
     it("dry-runs config patch channel fields against plugin-owned schemas", async () => {
       setExternalFeishuSchema();
       const resolved: OpenClawConfig = {

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -513,9 +513,7 @@ function schemaAlternatives(
 
 function schemaLooksArray(schema: JsonSchemaRecord): boolean {
   return (
-    schemaTypes(schema).has("array") ||
-    isSchemaRecord(schema.items) ||
-    Array.isArray(schema.items)
+    schemaTypes(schema).has("array") || isSchemaRecord(schema.items) || Array.isArray(schema.items)
   );
 }
 
@@ -1373,6 +1371,7 @@ function buildApplyValueOperation(params: {
 function buildConfigPatchOperations(params: {
   patch: unknown;
   replacePaths: PathSegment[][];
+  allowEmpty?: boolean;
 }): ConfigSetOperation[] {
   if (!isPlainRecord(params.patch)) {
     throw configPatchModeError("input must be a JSON5 object patch.");
@@ -1425,7 +1424,7 @@ function buildConfigPatchOperations(params: {
       `--replace-path ${toDotPath(unusedReplacePath)} did not match any value in the input patch.`,
     );
   }
-  if (operations.length === 0) {
+  if (operations.length === 0 && !params.allowEmpty) {
     throw configPatchModeError("input patch did not contain any config updates.");
   }
   return operations;
@@ -1796,8 +1795,19 @@ async function loadConfigMutationSchema(): Promise<JsonSchemaRecord | undefined>
   }
 }
 
-function collectDryRunSchemaErrors(params: { config: OpenClawConfig }): ConfigSetDryRunError[] {
-  const validated = validateConfigObjectRawWithPlugins(params.config);
+function touchesBundledChannelPath(path: readonly PathSegment[]): boolean {
+  return path[0] === "channels" && typeof path[1] === "string" && path[1].length > 0;
+}
+
+function collectDryRunSchemaErrors(params: {
+  config: OpenClawConfig;
+  operations: readonly ConfigSetOperation[];
+}): ConfigSetDryRunError[] {
+  const touchedPaths = params.operations.map((operation) => operation.setPath);
+  const validated = validateConfigObjectRawWithPlugins(params.config, {
+    touchedPaths,
+    validateBundledChannels: touchedPaths.some(touchesBundledChannelPath),
+  });
   if (validated.ok) {
     return [];
   }
@@ -1958,6 +1968,7 @@ async function runConfigOperations(params: {
       errors.push(
         ...collectDryRunSchemaErrors({
           config: nextConfig,
+          operations,
         }),
       );
     }
@@ -2151,6 +2162,7 @@ export async function runConfigPatch(opts: {
     const operations = buildConfigPatchOperations({
       patch,
       replacePaths: parseReplacePaths(opts.cliOptions.replacePath),
+      allowEmpty: Boolean(opts.cliOptions.dryRun),
     });
     await runConfigOperations({
       runtime,

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -907,6 +907,8 @@ type ValidateConfigWithPluginsParams = {
     config: OpenClawConfig,
   ) => Pick<PluginMetadataSnapshot, "manifestRegistry">;
   sourceRaw?: unknown;
+  touchedPaths?: ReadonlyArray<ReadonlyArray<string>>;
+  validateBundledChannels?: boolean;
   preservedLegacyRootKeys?: readonly string[];
 };
 
@@ -946,6 +948,8 @@ function validateConfigObjectWithPluginsBase(
 ): ValidateConfigWithPluginsResult {
   const base = validateConfigObjectRaw(raw, {
     sourceRaw: opts.sourceRaw,
+    touchedPaths: opts.touchedPaths,
+    validateBundledChannels: opts.validateBundledChannels,
     preservedLegacyRootKeys: opts.preservedLegacyRootKeys,
   });
   if (!base.ok) {


### PR DESCRIPTION
## Summary
- Allow empty/no-op `config patch --dry-run` payloads without writing config.
- Preserve dry-run touched paths and only force bundled-channel validation when a touched path is under `channels.<id>`.
- Forward `touchedPaths` / `validateBundledChannels` through `validateConfigObjectRawWithPlugins` into `validateConfigObjectRaw`.
- Add regression coverage for empty patch, unrelated memory-core dry-run, malformed touched channel failure, and memory-core enable dry-run non-mutation.

## Safety boundary
This PR changes source/tests only. During validation I did not perform any OpenClaw runtime config write, Gateway restart, memory-core enablement, cleanup/reindex/recovery, recurring automation, or restricted-memory path change.

## Test output
- `pnpm install --frozen-lockfile` — completed
- `pnpm exec oxfmt --write src/cli/config-cli.ts src/config/validation.ts src/cli/config-cli.test.ts` — completed
- `pnpm exec vitest run src/cli/config-cli.test.ts src/config/validation.channel-metadata.test.ts` — 2 files passed, 111 tests passed

## Real behavior proof

**Behavior or issue addressed:** Config dry-run validation should permit empty/no-op patch dry-runs, should not fail unrelated `plugins.entries.memory-core.enabled` dry-runs because of legacy bundled-channel required fields, should still reject malformed touched channel config, and should not mutate config or enable memory-core during dry-run.

**Real environment tested:** Real OpenClaw source checkout built from this PR branch at commit `b1cf932ca1d383b14393ef92a4e8944534dab19a`, executed with `node openclaw.mjs` against an isolated temp copy of Eric's real OpenClaw config via `OPENCLAW_CONFIG_PATH`. The isolated copy had stale `silentReply` legacy keys removed only in the temp copy so the current source schema validates; Eric's live config was not touched.

**Exact steps or command run after this patch:** Built the source checkout with `pnpm build`, validated the isolated setup with `node openclaw.mjs config validate`, then ran these live CLI commands against the isolated config: `printf '{}' | node openclaw.mjs config patch --stdin --dry-run --json`; `node openclaw.mjs config set plugins.entries.memory-core.enabled false --dry-run --strict-json --json`; `node openclaw.mjs config set channels.telegram.dmPolicy '"definitely-invalid"' --dry-run --strict-json --json`; `node openclaw.mjs config set plugins.entries.memory-core.enabled true --dry-run --strict-json --json`; finally compared isolated config SHA-256 and `plugins.entries.memory-core.enabled` before/after.

**Evidence after fix:** Redacted terminal output artifact: `/Users/eric_pharr/.openclaw/workspace/forge/artifacts/aeg208-real-behavior-proof-20260522T093200Z/real-behavior-proof-redacted.txt`. Copied live output excerpt:

```text
source_branch=forge/aeg-208-config-dryrun-validation
source_commit=b1cf932ca1d383b14393ef92a4e8944534dab19a
source_config_validate=passed
before_memory_core_enabled=false

01-empty-patch-dry-run: exit_code=0, stdout.ok=true, stdout.operations=0
02-memory-core-disable-dry-run: exit_code=0, stdout.ok=true, stdout.operations=1
03-malformed-touched-channel-dry-run: exit_code=1, stdout.ok=false, error="channels.telegram.dmPolicy: invalid config: must be equal to one of the allowed values"
04-memory-core-enable-dry-run: exit_code=0, stdout.ok=true, stdout.operations=1

after_memory_core_enabled=false
config_mutated=false
memory_core_enabled_changed=false
```

**Observed result after fix:** The previously failing empty patch dry-run and unrelated memory-core disable/enable dry-runs now succeed against the real isolated OpenClaw setup without writes; the malformed touched channel dry-run still fails schema validation; the isolated config SHA-256 was unchanged before/after; `plugins.entries.memory-core.enabled` stayed `false` after the enable dry-run.

**What was not tested:** No Gateway restart, live OpenClaw config write, memory-core enablement, cleanup/reindex/recovery, recurring automation, restricted-memory path change, or external runtime mutation was tested or performed.

Linear: AEG-208
