### PR TITLE
Fix native Codex encrypted replay recovery

### DIFF
--- a/src/agents/openai-responses.reasoning-replay.test.ts
+++ b/src/agents/openai-responses.reasoning-replay.test.ts
@@ -2,6 +2,7 @@ import type { AssistantMessage, Model, ToolResultMessage } from "@earendil-works
 import { streamOpenAIResponses } from "@earendil-works/pi-ai";
 import { Type } from "typebox";
 import { describe, expect, it } from "vitest";
+import { buildOpenAIResponsesParams } from "./openai-transport-stream.js";
 
 function buildModel(): Model<"openai-responses"> {
   return {
@@ -14,6 +15,21 @@ function buildModel(): Model<"openai-responses"> {
     input: ["text"],
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     contextWindow: 128_000,
+    maxTokens: 4096,
+  };
+}
+
+function buildNativeCodexModel(): Model<"openai-codex-responses"> {
+  return {
+    id: "gpt-5.5",
+    name: "gpt-5.5",
+    api: "openai-codex-responses",
+    provider: "openai-codex",
+    baseUrl: "https://chatgpt.com/backend-api/codex",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 272_000,
     maxTokens: 4096,
   };
 }
@@ -189,6 +205,30 @@ describe("openai-responses reasoning replay", () => {
     });
 
     expect(types).toContain("reasoning");
+    expect(types).toContain("message");
+  });
+
+  it("does not replay encrypted reasoning items for native OpenAI Codex Responses", () => {
+    const assistantWithText = buildAssistantMessage({
+      stopReason: "stop",
+      content: [buildReasoningPart(), { type: "text", text: "hello", textSignature: "msg_test" }],
+    });
+    const params = buildOpenAIResponsesParams(
+      buildNativeCodexModel(),
+      {
+        systemPrompt: "system",
+        messages: [
+          { role: "user", content: "Hi", timestamp: Date.now() },
+          assistantWithText,
+          { role: "user", content: "Ok", timestamp: Date.now() },
+        ],
+      },
+      { sessionId: "session", reasoningEffort: "high" },
+    );
+    const input = extractInput(params as Record<string, unknown>);
+    const types = extractInputTypes(input);
+
+    expect(types).not.toContain("reasoning");
     expect(types).toContain("message");
   });
 

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -2016,7 +2016,10 @@ export function buildOpenAIResponsesParams(
     {
       includeSystemPrompt: !isCodexResponses,
       supportsDeveloperRole,
-      replayReasoningItems: true,
+      // Native Codex Responses encrypted reasoning is backend-bound and can be
+      // rejected as undecryptable on later turns; replay assistant text/tools,
+      // but do not resend stored encrypted reasoning blobs.
+      replayReasoningItems: !isNativeCodexResponses,
       replayResponsesItemIds: !isNativeCodexResponses,
       authProfileId: options?.authProfileId,
       sessionId: options?.sessionId,

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -1539,6 +1539,11 @@ describe("classifyProviderRuntimeFailureKind", () => {
     expect(
       classifyProviderRuntimeFailureKind("401 input item ID does not belong to this connection"),
     ).toBe("replay_invalid");
+    expect(
+      classifyProviderRuntimeFailureKind(
+        "400 code=invalid_encrypted_content Encrypted content could not be decrypted or parsed.",
+      ),
+    ).toBe("replay_invalid");
   });
 
   it("splits ambiguous provider runtime failures instead of collapsing to unknown", () => {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -328,7 +328,7 @@ const DNS_ERROR_RE = /\benotfound\b|\beai_again\b|\bgetaddrinfo\b|\bno such host
 const INTERRUPTED_NETWORK_ERROR_RE =
   /\beconnrefused\b|\beconnreset\b|\beconnaborted\b|\benetreset\b|\behostunreach\b|\behostdown\b|\benetunreach\b|\bepipe\b|\bsocket hang up\b|\bconnection refused\b|\bconnection reset\b|\bconnection aborted\b|\bnetwork is unreachable\b|\bhost is unreachable\b|\bfetch failed\b|\bconnection error\b|\bnetwork request failed\b/i;
 const REPLAY_INVALID_RE =
-  /\bprevious_response_id\b.*\b(?:invalid|unknown|not found|does not exist|expired|mismatch)\b|\btool_(?:use|call)\.(?:input|arguments)\b.*\b(?:missing|required)\b|\bincorrect role information\b|\broles must alternate\b|\binput item id does not belong to this connection\b/i;
+  /\bprevious_response_id\b.*\b(?:invalid|unknown|not found|does not exist|expired|mismatch)\b|\btool_(?:use|call)\.(?:input|arguments)\b.*\b(?:missing|required)\b|\bincorrect role information\b|\broles must alternate\b|\binput item id does not belong to this connection\b|\binvalid_encrypted_content\b|\bencrypted content could not be decrypted or parsed\b/i;
 const SANDBOX_BLOCKED_RE =
   /\bapproval is required\b|\bapproval timed out\b|\bapproval was denied\b|\bblocked by sandbox\b|\bsandbox\b.*\b(?:blocked|denied|forbidden|disabled|not allowed)\b/i;
 const NO_BODY_HTTP_WRAPPER_RE =

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -4776,7 +4776,6 @@ describe("runAgentTurnWithFallback", () => {
       shouldEmitToolResult: () => true,
       shouldEmitToolOutput: () => false,
       pendingToolTasks: new Set(),
-      resetSessionAfterCompactionFailure: async () => false,
       resetSessionAfterRoleOrderingConflict: async () => false,
       isHeartbeat: false,
       sessionKey: "main",

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -100,6 +100,10 @@ vi.mock("../../agents/pi-embedded-helpers.js", () => ({
   isRateLimitErrorMessage: (message: string) =>
     /rate.limit|too many requests|429|usage limit/i.test(message),
   isTransientHttpError: () => false,
+  classifyProviderRuntimeFailureKind: (message: string) =>
+    /invalid_encrypted_content|encrypted content could not be decrypted or parsed/i.test(message)
+      ? "replay_invalid"
+      : "unclassified",
   sanitizeUserFacingText: (text?: string) => text ?? "",
 }));
 
@@ -4745,6 +4749,46 @@ describe("runAgentTurnWithFallback", () => {
     expect(result.kind).toBe("final");
     if (result.kind === "final") {
       expect(result.payload.text).toBe(PROVIDER_CONVERSATION_STATE_ERROR_USER_MESSAGE);
+    }
+  });
+
+  it("returns a session reset hint for OpenAI encrypted replay failures", async () => {
+    state.runEmbeddedPiAgentMock.mockRejectedValueOnce(
+      new Error(
+        "400 code=invalid_encrypted_content Encrypted content could not be decrypted or parsed.",
+      ),
+    );
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback({
+      commandBody: "hello",
+      followupRun: createFollowupRun(),
+      sessionCtx: {
+        Provider: "telegram",
+        MessageSid: "msg",
+      } as unknown as TemplateContext,
+      opts: {},
+      typingSignals: createMockTypingSignaler(),
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      pendingToolTasks: new Set(),
+      resetSessionAfterCompactionFailure: async () => false,
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      isHeartbeat: false,
+      sessionKey: "main",
+      getActiveSessionEntry: () => undefined,
+      resolvedVerboseLevel: "off",
+    });
+
+    expect(result.kind).toBe("final");
+    if (result.kind === "final") {
+      expect(result.payload.text).toBe(
+        "⚠️ Session history got out of sync. Please try again, or use /new to start a fresh session.",
+      );
     }
   });
 

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -41,6 +41,7 @@ import {
   isOverloadedErrorMessage,
   isRateLimitErrorMessage,
   isTransientHttpError,
+  classifyProviderRuntimeFailureKind,
 } from "../../agents/pi-embedded-helpers.js";
 import { sanitizeUserFacingText } from "../../agents/pi-embedded-helpers/sanitize-user-facing-text.js";
 import { isMessagingToolSendAction } from "../../agents/pi-embedded-messaging.js";
@@ -465,6 +466,10 @@ function hasBillingAttemptSummary(err: unknown): boolean {
   );
 }
 
+function isReplayInvalidRunFailureError(message: string): boolean {
+  return classifyProviderRuntimeFailureKind(message) === "replay_invalid";
+}
+
 function collapseRepeatedFailureDetail(message: string): string {
   const parts = message
     .split(/\s+\|\s+/u)
@@ -600,6 +605,12 @@ function buildExternalRunFailureReply(
   if (providerRequestError) {
     return {
       text: providerRequestError.userMessage,
+      isGenericRunnerFailure: false,
+    };
+  }
+  if (isReplayInvalidRunFailureError(normalizedMessage)) {
+    return {
+      text: "⚠️ Session history got out of sync. Please try again, or use /new to start a fresh session.",
       isGenericRunnerFailure: false,
     };
   }
@@ -1157,6 +1168,7 @@ export async function runAgentTurnWithFallback(params: {
   shouldEmitToolOutput: () => boolean;
   pendingToolTasks: Set<Promise<void>>;
   resetSessionAfterRoleOrderingConflict: (reason: string) => Promise<boolean>;
+  resetSessionAfterReplayInvalid?: (reason: string) => Promise<boolean>;
   isHeartbeat: boolean;
   sessionKey?: string;
   runtimePolicySessionKey?: string;
@@ -2426,6 +2438,16 @@ export async function runAgentTurnWithFallback(params: {
           setTimeout(resolve, TRANSIENT_HTTP_RETRY_DELAY_MS);
         });
         continue;
+      }
+
+      if (isReplayInvalidRunFailureError(message)) {
+        try {
+          await params.resetSessionAfterReplayInvalid?.(message);
+        } catch (resetErr) {
+          defaultRuntime.error(
+            `Failed to reset replay-invalid session ${params.sessionKey}: ${String(resetErr)}`,
+          );
+        }
       }
 
       defaultRuntime.error(`Embedded agent failed before reply: ${message}`);

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -350,6 +350,53 @@ describe("runReplyAgent pending final delivery capture", () => {
     return JSON.parse(raw).main as SessionEntry;
   }
 
+  it("rotates poisoned replay-invalid sessions before returning reset guidance", async () => {
+    const sessionEntry: SessionEntry = {
+      sessionId: "poisoned-session",
+      sessionFile: "/tmp/poisoned-session.jsonl",
+      updatedAt: Date.now(),
+      sessionStartedAt: Date.now() - 10_000,
+      systemSent: true,
+      status: "running",
+      contextTokens: 272_000,
+      inputTokens: 877_883,
+      outputTokens: 5_500,
+      modelProvider: "openai-codex",
+      model: "gpt-5.5",
+      cliSessionBindings: { "codex-cli": { sessionId: "codex-session" } },
+    };
+    const sessionStore = { main: sessionEntry };
+    const storePath = await createSessionStoreFile(sessionEntry);
+    state.runEmbeddedPiAgentMock.mockRejectedValueOnce(
+      new Error(
+        "400 code=invalid_encrypted_content Encrypted content could not be decrypted or parsed.",
+      ),
+    );
+
+    const { run } = createMinimalRun({
+      sessionEntry,
+      sessionStore,
+      sessionKey: "main",
+      storePath,
+      runOverrides: {
+        provider: "openai-codex",
+        model: "gpt-5.5",
+      },
+    });
+
+    const result = await run();
+    const stored = await readStoredMainSession(storePath);
+
+    expect(result).toMatchObject({
+      text: "⚠️ Session history got out of sync. Please try again, or use /new to start a fresh session.",
+    });
+    expect(stored.sessionId).not.toBe("poisoned-session");
+    expect(stored.systemSent).toBe(false);
+    expect(stored.status).toBeUndefined();
+    expect(stored.contextTokens).toBeUndefined();
+    expect(stored.cliSessionBindings).toBeUndefined();
+  });
+
   it("does not persist message-tool-only final replies for heartbeat replay", async () => {
     const sessionEntry: SessionEntry = {
       sessionId: "session",

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -196,6 +196,7 @@ function createMinimalRun(params?: {
   return {
     typing,
     opts,
+    followupRun,
     run: async () => {
       const runReplyAgent = await getRunReplyAgent();
       return runReplyAgent({
@@ -373,7 +374,7 @@ describe("runReplyAgent pending final delivery capture", () => {
       ),
     );
 
-    const { run } = createMinimalRun({
+    const { followupRun, run } = createMinimalRun({
       sessionEntry,
       sessionStore,
       sessionKey: "main",
@@ -391,10 +392,18 @@ describe("runReplyAgent pending final delivery capture", () => {
       text: "⚠️ Session history got out of sync. Please try again, or use /new to start a fresh session.",
     });
     expect(stored.sessionId).not.toBe("poisoned-session");
+    expect(stored.sessionFile).toEqual(expect.any(String));
+    expect(stored.sessionFile).not.toBe("/tmp/poisoned-session.jsonl");
+    expect(followupRun.run.sessionId).toBe(stored.sessionId);
+    expect(followupRun.run.sessionFile).toBe(stored.sessionFile);
+    expect(vi.mocked(refreshQueuedFollowupSession)).toHaveBeenCalledWith({
+      key: "main",
+      previousSessionId: "poisoned-session",
+      nextSessionId: stored.sessionId,
+      nextSessionFile: stored.sessionFile,
+    });
     expect(stored.systemSent).toBe(false);
-    expect(stored.status).toBeUndefined();
     expect(stored.contextTokens).toBeUndefined();
-    expect(stored.cliSessionBindings).toBeUndefined();
   });
 
   it("does not persist message-tool-only final replies for heartbeat replay", async () => {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1,4 +1,3 @@
-import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import {
   hasSessionAutoModelFallbackProvenance,
@@ -103,7 +102,6 @@ import {
   type ReplyOperation,
 } from "./reply-run-registry.js";
 import { createReplyToModeFilterForChannel, resolveReplyToMode } from "./reply-threading.js";
-import { clearSessionResetRuntimeState } from "./session-reset-cleanup.js";
 import { incrementRunCompactionCount, persistRunSessionUsage } from "./session-run-accounting.js";
 import { resolveSourceReplyVisibilityPolicy } from "./source-reply-delivery-mode.js";
 import { createTypingSignaler } from "./typing-mode.js";
@@ -113,54 +111,6 @@ const BLOCK_REPLY_SEND_TIMEOUT_MS = 15_000;
 
 function isReplayInvalidAgentRunError(error: unknown): boolean {
   return classifyProviderRuntimeFailureKind(formatErrorMessage(error)) === "replay_invalid";
-}
-
-function buildReplayInvalidSessionResetPatch(now: number): Partial<SessionEntry> {
-  return {
-    sessionId: crypto.randomUUID(),
-    sessionFile: undefined,
-    updatedAt: now,
-    sessionStartedAt: now,
-    lastInteractionAt: now,
-    systemSent: false,
-    abortedLastRun: false,
-    status: undefined,
-    startedAt: undefined,
-    endedAt: undefined,
-    runtimeMs: undefined,
-    totalTokens: undefined,
-    inputTokens: undefined,
-    outputTokens: undefined,
-    totalTokensFresh: undefined,
-    estimatedCostUsd: undefined,
-    cacheRead: undefined,
-    cacheWrite: undefined,
-    contextTokens: undefined,
-    responseUsage: undefined,
-    modelProvider: undefined,
-    model: undefined,
-    agentHarnessId: undefined,
-    fallbackNoticeSelectedModel: undefined,
-    fallbackNoticeActiveModel: undefined,
-    fallbackNoticeReason: undefined,
-    compactionCount: 0,
-    memoryFlushAt: undefined,
-    memoryFlushCompactionCount: undefined,
-    memoryFlushContextHash: undefined,
-    pendingFinalDelivery: undefined,
-    pendingFinalDeliveryCreatedAt: undefined,
-    pendingFinalDeliveryLastAttemptAt: undefined,
-    pendingFinalDeliveryAttemptCount: undefined,
-    pendingFinalDeliveryLastError: undefined,
-    pendingFinalDeliveryText: undefined,
-    pendingFinalDeliveryContext: undefined,
-    pendingFinalDeliveryIntentId: undefined,
-    cliSessionIds: undefined,
-    cliSessionBindings: undefined,
-    claudeCliSessionId: undefined,
-    skillsSnapshot: undefined,
-    systemPromptReport: undefined,
-  };
 }
 
 function markBeforeAgentRunBlockedPayloads(payloads: ReplyPayload[]): ReplyPayload[] {
@@ -1209,52 +1159,44 @@ export async function runReplyAgent(params: {
       });
     }
   };
-  const resetSessionAfterReplayInvalid = async (reason: string): Promise<boolean> => {
-    if (!sessionKey) {
-      return false;
-    }
-    const oldSessionId = activeSessionEntry?.sessionId;
-    const patch = buildReplayInvalidSessionResetPatch(Date.now());
-    let didReset = false;
-    if (activeSessionStore && activeSessionEntry) {
-      const nextEntry = { ...activeSessionEntry, ...patch } as SessionEntry;
-      activeSessionStore[sessionKey] = nextEntry;
-      activeSessionEntry = nextEntry;
-      didReset = true;
-    }
-    if (storePath) {
-      try {
-        const updated = await updateSessionStoreEntry({
-          storePath,
-          sessionKey,
-          update: async () => patch,
-        });
-        if (updated) {
-          activeSessionEntry = updated;
-          if (activeSessionStore) {
-            activeSessionStore[sessionKey] = updated;
-          }
-          didReset = true;
-        }
-      } catch (resetError) {
-        logVerbose(
-          `failed to reset replay-invalid session ${sessionKey}: ${formatErrorMessage(resetError)}`,
-        );
-      }
-    }
-    if (!didReset) {
-      return false;
-    }
-    followupRun.run.sessionId = String(patch.sessionId);
-    activeIsNewSession = true;
-    clearSessionResetRuntimeState([sessionKey, oldSessionId]);
-    logVerbose(
-      `reset replay-invalid session ${sessionKey}` +
-        (oldSessionId ? ` (${oldSessionId} -> ${String(patch.sessionId)})` : "") +
-        ` after ${reason}`,
-    );
-    return true;
+  type SessionResetOptions = {
+    failureLabel: string;
+    buildLogMessage: (nextSessionId: string) => string;
+    cleanupTranscripts?: boolean;
   };
+  const resetSession = async ({
+    failureLabel,
+    buildLogMessage,
+    cleanupTranscripts,
+  }: SessionResetOptions): Promise<boolean> =>
+    await resetReplyRunSession({
+      options: {
+        failureLabel,
+        buildLogMessage,
+        cleanupTranscripts,
+      },
+      sessionKey,
+      queueKey,
+      activeSessionEntry,
+      activeSessionStore,
+      storePath,
+      messageThreadId:
+        typeof sessionCtx.MessageThreadId === "string" ? sessionCtx.MessageThreadId : undefined,
+      followupRun,
+      onActiveSessionEntry: (nextEntry) => {
+        activeSessionEntry = nextEntry;
+      },
+      onNewSession: () => {
+        activeIsNewSession = true;
+      },
+    });
+  const resetSessionAfterReplayInvalid = async (reason: string): Promise<boolean> =>
+    resetSession({
+      failureLabel: "replay-invalid session state",
+      buildLogMessage: (nextSessionId) =>
+        `Replay-invalid session state (${reason}). Restarting session ${sessionKey} -> ${nextSessionId}.`,
+      cleanupTranscripts: true,
+    });
 
   if (effectiveShouldSteer && isStreaming) {
     const steerSessionId =
@@ -1508,37 +1450,6 @@ export async function runReplyAgent(params: {
     });
 
     let responseUsageLine: string | undefined;
-    type SessionResetOptions = {
-      failureLabel: string;
-      buildLogMessage: (nextSessionId: string) => string;
-      cleanupTranscripts?: boolean;
-    };
-    const resetSession = async ({
-      failureLabel,
-      buildLogMessage,
-      cleanupTranscripts,
-    }: SessionResetOptions): Promise<boolean> =>
-      await resetReplyRunSession({
-        options: {
-          failureLabel,
-          buildLogMessage,
-          cleanupTranscripts,
-        },
-        sessionKey,
-        queueKey,
-        activeSessionEntry,
-        activeSessionStore,
-        storePath,
-        messageThreadId:
-          typeof sessionCtx.MessageThreadId === "string" ? sessionCtx.MessageThreadId : undefined,
-        followupRun,
-        onActiveSessionEntry: (nextEntry) => {
-          activeSessionEntry = nextEntry;
-        },
-        onNewSession: () => {
-          activeIsNewSession = true;
-        },
-      });
     const resetSessionAfterRoleOrderingConflict = async (reason: string): Promise<boolean> =>
       resetSession({
         failureLabel: "role ordering conflict",

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import {
   hasSessionAutoModelFallbackProvenance,
@@ -9,6 +10,7 @@ import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { resolveModelAuthMode } from "../../agents/model-auth.js";
 import { isCliProvider } from "../../agents/model-selection.js";
+import { classifyProviderRuntimeFailureKind } from "../../agents/pi-embedded-helpers.js";
 import {
   formatEmbeddedPiQueueFailureSummary,
   queueEmbeddedPiMessageWithOutcomeAsync,
@@ -33,6 +35,7 @@ import {
   freezeDiagnosticTraceContext,
 } from "../../infra/diagnostic-trace-context.js";
 import { measureDiagnosticsTimelineSpan } from "../../infra/diagnostics-timeline.js";
+import { formatErrorMessage } from "../../infra/errors.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { CommandLaneClearedError, GatewayDrainingError } from "../../process/command-queue.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
@@ -100,12 +103,65 @@ import {
   type ReplyOperation,
 } from "./reply-run-registry.js";
 import { createReplyToModeFilterForChannel, resolveReplyToMode } from "./reply-threading.js";
+import { clearSessionResetRuntimeState } from "./session-reset-cleanup.js";
 import { incrementRunCompactionCount, persistRunSessionUsage } from "./session-run-accounting.js";
 import { resolveSourceReplyVisibilityPolicy } from "./source-reply-delivery-mode.js";
 import { createTypingSignaler } from "./typing-mode.js";
 import type { TypingController } from "./typing.js";
 
 const BLOCK_REPLY_SEND_TIMEOUT_MS = 15_000;
+
+function isReplayInvalidAgentRunError(error: unknown): boolean {
+  return classifyProviderRuntimeFailureKind(formatErrorMessage(error)) === "replay_invalid";
+}
+
+function buildReplayInvalidSessionResetPatch(now: number): Partial<SessionEntry> {
+  return {
+    sessionId: crypto.randomUUID(),
+    sessionFile: undefined,
+    updatedAt: now,
+    sessionStartedAt: now,
+    lastInteractionAt: now,
+    systemSent: false,
+    abortedLastRun: false,
+    status: undefined,
+    startedAt: undefined,
+    endedAt: undefined,
+    runtimeMs: undefined,
+    totalTokens: undefined,
+    inputTokens: undefined,
+    outputTokens: undefined,
+    totalTokensFresh: undefined,
+    estimatedCostUsd: undefined,
+    cacheRead: undefined,
+    cacheWrite: undefined,
+    contextTokens: undefined,
+    responseUsage: undefined,
+    modelProvider: undefined,
+    model: undefined,
+    agentHarnessId: undefined,
+    fallbackNoticeSelectedModel: undefined,
+    fallbackNoticeActiveModel: undefined,
+    fallbackNoticeReason: undefined,
+    compactionCount: 0,
+    memoryFlushAt: undefined,
+    memoryFlushCompactionCount: undefined,
+    memoryFlushContextHash: undefined,
+    pendingFinalDelivery: undefined,
+    pendingFinalDeliveryCreatedAt: undefined,
+    pendingFinalDeliveryLastAttemptAt: undefined,
+    pendingFinalDeliveryAttemptCount: undefined,
+    pendingFinalDeliveryLastError: undefined,
+    pendingFinalDeliveryText: undefined,
+    pendingFinalDeliveryContext: undefined,
+    pendingFinalDeliveryIntentId: undefined,
+    cliSessionIds: undefined,
+    cliSessionBindings: undefined,
+    claudeCliSessionId: undefined,
+    skillsSnapshot: undefined,
+    systemPromptReport: undefined,
+  };
+}
 
 function markBeforeAgentRunBlockedPayloads(payloads: ReplyPayload[]): ReplyPayload[] {
   return payloads.map((payload) =>
@@ -1153,6 +1209,52 @@ export async function runReplyAgent(params: {
       });
     }
   };
+  const resetSessionAfterReplayInvalid = async (reason: string): Promise<boolean> => {
+    if (!sessionKey) {
+      return false;
+    }
+    const oldSessionId = activeSessionEntry?.sessionId;
+    const patch = buildReplayInvalidSessionResetPatch(Date.now());
+    let didReset = false;
+    if (activeSessionStore && activeSessionEntry) {
+      const nextEntry = { ...activeSessionEntry, ...patch } as SessionEntry;
+      activeSessionStore[sessionKey] = nextEntry;
+      activeSessionEntry = nextEntry;
+      didReset = true;
+    }
+    if (storePath) {
+      try {
+        const updated = await updateSessionStoreEntry({
+          storePath,
+          sessionKey,
+          update: async () => patch,
+        });
+        if (updated) {
+          activeSessionEntry = updated;
+          if (activeSessionStore) {
+            activeSessionStore[sessionKey] = updated;
+          }
+          didReset = true;
+        }
+      } catch (resetError) {
+        logVerbose(
+          `failed to reset replay-invalid session ${sessionKey}: ${formatErrorMessage(resetError)}`,
+        );
+      }
+    }
+    if (!didReset) {
+      return false;
+    }
+    followupRun.run.sessionId = String(patch.sessionId);
+    activeIsNewSession = true;
+    clearSessionResetRuntimeState([sessionKey, oldSessionId]);
+    logVerbose(
+      `reset replay-invalid session ${sessionKey}` +
+        (oldSessionId ? ` (${oldSessionId} -> ${String(patch.sessionId)})` : "") +
+        ` after ${reason}`,
+    );
+    return true;
+  };
 
   if (effectiveShouldSteer && isStreaming) {
     const steerSessionId =
@@ -1466,6 +1568,7 @@ export async function runReplyAgent(params: {
         shouldEmitToolOutput,
         pendingToolTasks,
         resetSessionAfterRoleOrderingConflict,
+        resetSessionAfterReplayInvalid,
         isHeartbeat,
         sessionKey,
         runtimePolicySessionKey,
@@ -2189,6 +2292,9 @@ export async function runReplyAgent(params: {
           text: "⚠️ Gateway is restarting. Please wait a few seconds and try again.",
         }),
       );
+    }
+    if (isReplayInvalidAgentRunError(error) && sessionKey) {
+      await resetSessionAfterReplayInvalid(formatErrorMessage(error));
     }
     const knownFailurePayload = buildKnownAgentRunFailureReplyPayload({
       err: error,


### PR DESCRIPTION
## Summary

- stop native `openai-codex` Responses requests from replaying prior reasoning items while preserving reasoning replay for non-native Responses backends
- classify `invalid_encrypted_content` / encrypted-content parse failures as replay-invalid session state
- route replay-invalid reply-agent recovery through the existing session reset helper so the new session id, session file, queued followups, transcript cleanup, and active session state stay consistent

## Real behavior proof

Behavior addressed: Native Codex Responses follow-up turns can fail with `invalid_encrypted_content` when encrypted reasoning content from a prior response is replayed.

Real environment tested: Local OpenClaw source checkout on macOS against current `origin/main` after `pnpm install` refreshed workspace dependencies, using the real OpenClaw Responses payload builder with a redacted native Codex model/session shape and a prior assistant turn containing reasoning metadata.

Exact steps or command run after this patch:

```bash
node --import tsx --input-type=module <<'NODE'
import { buildOpenAIResponsesParams } from './src/agents/openai-transport-stream.ts';
// Built native openai-codex and standard openai-responses payloads from the same
// redacted transcript containing a prior assistant reasoning item.
// Printed whether each payload replays a `reasoning` input item.
NODE
git diff --check origin/main...HEAD
node scripts/run-vitest.mjs src/agents/openai-responses.reasoning-replay.test.ts src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts src/auto-reply/reply/agent-runner-execution.test.ts
node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts -t "rotates poisoned replay-invalid sessions"
pnpm check:test-types
```

Evidence after fix: Terminal capture from the local OpenClaw runtime payload-builder command:

```json
{
  "nativeCodexReplayIncludesReasoning": false,
  "nativeCodexInputTypes": [
    null,
    "message",
    "message",
    null
  ],
  "standardResponsesReplayIncludesReasoning": true
}
```

Observed result after fix: Native `openai-codex` Responses payload construction no longer includes a replayed `reasoning` item for the redacted follow-up transcript, while standard OpenAI Responses still replays reasoning. `git diff --check` passed; the targeted regression command passed with 3 test files and 260 tests; the focused e2e replay-invalid session rotation test passed with 1 test and 50 skipped tests; `pnpm check:test-types` passed.

What was not tested: I have not attached a live Telegram/ChatGPT backend transcript from an actual networked native Codex follow-up after this branch. I also previously attempted the full `agent-runner.runreplyagent.e2e.test.ts` file; it did not complete green because two existing overflow fallback assertions expect `conversation is too large` while current output says `Auto-compaction could not recover this turn`. This PR does not touch those overflow assertions or fallback text.
