### PR TITLE
fix(gateway): ignore inherited launchd env for respawn

### DIFF
--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -1306,7 +1306,7 @@ describe("runGatewayLoop", () => {
     peekGatewaySigusr1RestartReason.mockReturnValue(undefined);
     try {
       setPlatform("darwin");
-      process.env.LAUNCH_JOB_LABEL = "ai.openclaw.gateway";
+      process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
       restartGatewayProcessWithFreshPid.mockReturnValueOnce({
         mode: "supervised",
       });
@@ -1331,7 +1331,7 @@ describe("runGatewayLoop", () => {
       });
     } finally {
       vi.useRealTimers();
-      delete process.env.LAUNCH_JOB_LABEL;
+      delete process.env.OPENCLAW_LAUNCHD_LABEL;
       if (originalPlatformDescriptor) {
         Object.defineProperty(process, "platform", originalPlatformDescriptor);
       }
@@ -1343,7 +1343,7 @@ describe("runGatewayLoop", () => {
     consumeGatewayRestartIntentPayloadSync.mockReturnValueOnce({ reason: "gateway.restart" });
     try {
       setPlatform("darwin");
-      process.env.LAUNCH_JOB_LABEL = "ai.openclaw.gateway";
+      process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
       restartGatewayProcessWithFreshPid.mockReturnValueOnce({
         mode: "supervised",
       });
@@ -1365,7 +1365,7 @@ describe("runGatewayLoop", () => {
       });
     } finally {
       vi.useRealTimers();
-      delete process.env.LAUNCH_JOB_LABEL;
+      delete process.env.OPENCLAW_LAUNCHD_LABEL;
       if (originalPlatformDescriptor) {
         Object.defineProperty(process, "platform", originalPlatformDescriptor);
       }

--- a/src/daemon/service-env.test.ts
+++ b/src/daemon/service-env.test.ts
@@ -606,6 +606,16 @@ describe("buildServiceEnvironment", () => {
     }
   });
 
+  it("sets the OpenClaw-owned launchd marker for macOS gateway services", () => {
+    const env = buildServiceEnvironment({
+      env: { HOME: "/Users/user" },
+      port: 18789,
+      platform: "darwin",
+    });
+
+    expect(env.OPENCLAW_LAUNCHD_LABEL).toBe("ai.openclaw.gateway");
+  });
+
   it("passes through OPENCLAW_WRAPPER for gateway services", () => {
     const env = buildServiceEnvironment({
       env: {
@@ -673,6 +683,16 @@ describe("buildServiceEnvironment", () => {
     if (process.platform === "darwin") {
       expect(env.OPENCLAW_LAUNCHD_LABEL).toBe("ai.openclaw.work");
     }
+  });
+
+  it("sets a profile-specific launchd marker for macOS gateway services", () => {
+    const env = buildServiceEnvironment({
+      env: { HOME: "/Users/user", OPENCLAW_PROFILE: "work" },
+      port: 18789,
+      platform: "darwin",
+    });
+
+    expect(env.OPENCLAW_LAUNCHD_LABEL).toBe("ai.openclaw.work");
   });
 
   it("does not persist ambient proxy environment variables for launchd/systemd runtime", () => {
@@ -754,6 +774,15 @@ describe("buildNodeServiceEnvironment", () => {
       env: { HOME: "/home/user" },
     });
     expect(env.HOME).toBe("/home/user");
+  });
+
+  it("sets the OpenClaw-owned launchd marker for macOS node services", () => {
+    const env = buildNodeServiceEnvironment({
+      env: { HOME: "/Users/user" },
+      platform: "darwin",
+    });
+
+    expect(env.OPENCLAW_LAUNCHD_LABEL).toBe("ai.openclaw.node");
   });
 
   it("passes through OPENCLAW_GATEWAY_TOKEN for node services", () => {


### PR DESCRIPTION
## Summary

- Problem: macOS gateway update respawn could treat inherited generic launchd env such as `XPC_SERVICE_NAME` as proof that the gateway itself is launchd-supervised.
- Solution: narrow Darwin respawn-supervisor detection to the OpenClaw-owned `OPENCLAW_LAUNCHD_LABEL`.
- What changed: generic launchd env vars remain in supervisor cleanup lists, but only `OPENCLAW_LAUNCHD_LABEL` now triggers Darwin launchd respawn supervision.
- What did NOT change: systemd and Windows Scheduled Task detection are unchanged.

## Motivation

- Fixes a gateway lifecycle failure where a GUI-spawned gateway can exit expecting launchd to restart it, even though only the parent app's inherited launchd/XPC environment was present.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #85224
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Darwin respawn-supervisor detection no longer classifies inherited generic launchd env (`XPC_SERVICE_NAME` / `LAUNCH_JOB_LABEL`) as OpenClaw gateway supervision, while the OpenClaw-owned launchd marker still works.
- Real environment tested: macOS local OpenClaw source checkout on `darwin`, branch `yuhao/fix-launchd-xpc-supervisor-85224`, commit `041c52846e611dd882328ae2a83bbd12538a7603`.
- Exact steps or command run after this patch:

```bash
node --import tsx -e 'const { detectRespawnSupervisor } = await import("./src/infra/supervisor-markers.ts"); const cases = [{name:"inherited XPC only", env:{XPC_SERVICE_NAME:"ai.openclaw.mac"}}, {name:"generic launch job only", env:{LAUNCH_JOB_LABEL:"ai.openclaw.gateway"}}, {name:"openclaw launchd marker", env:{OPENCLAW_LAUNCHD_LABEL:"ai.openclaw.gateway"}}]; console.log(`platform=${process.platform}`); for (const item of cases) console.log(`${item.name}: ${detectRespawnSupervisor(item.env, "darwin") ?? "null"}`);'
```

- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

Terminal capture from the patched checkout:

```text
platform=darwin
inherited XPC only: null
generic launch job only: null
openclaw launchd marker: launchd
```

- Observed result after fix: inherited `XPC_SERVICE_NAME` and `LAUNCH_JOB_LABEL` return `null`, so update respawn will not take the supervised-exit path from inherited parent launchd state. `OPENCLAW_LAUNCHD_LABEL` still returns `launchd` for real OpenClaw LaunchAgent services.
- What was not tested: I did not run a full GUI-triggered update/restart against a live installed LaunchAgent; the proof validates the production supervisor detector behavior in the local macOS source checkout.
- Before evidence (optional but encouraged): The previous implementation used all launchd hints for Darwin detection, so `XPC_SERVICE_NAME` alone matched the launchd hint list and returned `launchd`.

## Root Cause (if applicable)

- Root cause: `detectRespawnSupervisor` treated generic launchd/XPC environment variables as evidence that the current gateway process was launchd-supervised.
- Missing detection / guardrail: There was no regression test for a gateway child process inheriting `XPC_SERVICE_NAME` from a launchd-managed parent app.
- Contributing context (if known): Generated OpenClaw service environments already set the more specific `OPENCLAW_LAUNCHD_LABEL`, which is the safer marker for respawn supervision.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/infra/supervisor-markers.test.ts`, `src/infra/process-respawn.test.ts`, `src/daemon/service-env.test.ts`.
- Scenario the test should lock in: inherited macOS `XPC_SERVICE_NAME` and generic launch job env do not trigger supervised restart; OpenClaw-owned launchd labels still do.
- Why this is the smallest reliable guardrail: the bug is in the supervisor detector and update respawn branch selection, so source-level tests cover the exact boundary without requiring a live 30-second restart cycle.
- Existing test that already covers this (if any): existing launchd-positive tests covered real markers; this PR adds the inherited-env negative cases.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

macOS gateways spawned from a launchd-managed parent no longer exit under the false assumption that launchd will restart them unless OpenClaw's own launchd service marker is present.

## Diagram (if applicable)

```text
Before:
GUI parent launchd env -> gateway child sees XPC_SERVICE_NAME -> supervised exit -> no gateway restart

After:
GUI parent launchd env -> gateway child sees XPC_SERVICE_NAME -> unmanaged update respawn path -> gateway returns
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS (`darwin`)
- Runtime/container: local Node/tsx source checkout
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): `XPC_SERVICE_NAME=ai.openclaw.mac`, `LAUNCH_JOB_LABEL=ai.openclaw.gateway`, `OPENCLAW_LAUNCHD_LABEL=ai.openclaw.gateway`

### Steps

1. Run the terminal capture command in the Real behavior proof section.
2. Run the regression and changed-check commands listed below.

### Expected

- Generic inherited launchd env returns `null`.
- `OPENCLAW_LAUNCHD_LABEL` returns `launchd`.

### Actual

- The patched checkout produced the terminal output shown above.

## Evidence

- `node scripts/run-vitest.mjs src/cli/gateway-cli/run-loop.test.ts src/infra/supervisor-markers.test.ts src/infra/process-respawn.test.ts src/gateway/server-methods/update-managed-service-handoff.test.ts src/daemon/service-env.test.ts`
- `pnpm check:changed`
- `git diff --check`
