### PR TITLE
fix(codex): derive terminal-idle watchdog from explicit run timeout

### DIFF
--- a/extensions/codex/src/app-server/attempt-timeouts.test.ts
+++ b/extensions/codex/src/app-server/attempt-timeouts.test.ts
@@ -124,6 +124,9 @@ describe("Codex app-server attempt timeouts", () => {
     expect(resolveCodexTurnTerminalIdleTimeoutMs(undefined, Number.POSITIVE_INFINITY)).toBe(
       CODEX_TURN_TERMINAL_IDLE_TIMEOUT_MS,
     );
+    expect(resolveCodexTurnTerminalIdleTimeoutMs(undefined, Number.MAX_SAFE_INTEGER)).toBe(
+      MAX_TIMER_TIMEOUT_MS,
+    );
     // An explicit override still wins even when a run budget is present.
     expect(resolveCodexTurnTerminalIdleTimeoutMs(5 * 60_000, overFloor)).toBe(5 * 60_000);
   });

--- a/extensions/codex/src/app-server/attempt-timeouts.test.ts
+++ b/extensions/codex/src/app-server/attempt-timeouts.test.ts
@@ -112,6 +112,22 @@ describe("Codex app-server attempt timeouts", () => {
     );
   });
 
+  it("derives the terminal idle timeout from the effective run budget", () => {
+    const overFloor = CODEX_TURN_TERMINAL_IDLE_TIMEOUT_MS + 15 * 60_000;
+    // A run budget above the 30-minute floor extends the watchdog (the #85242 fix).
+    expect(resolveCodexTurnTerminalIdleTimeoutMs(undefined, overFloor)).toBe(overFloor);
+    // A run budget below the floor keeps the 30-minute floor (protection never shortened).
+    expect(resolveCodexTurnTerminalIdleTimeoutMs(undefined, 10 * 60_000)).toBe(
+      CODEX_TURN_TERMINAL_IDLE_TIMEOUT_MS,
+    );
+    // A non-finite budget falls back to the 30-minute default.
+    expect(resolveCodexTurnTerminalIdleTimeoutMs(undefined, Number.POSITIVE_INFINITY)).toBe(
+      CODEX_TURN_TERMINAL_IDLE_TIMEOUT_MS,
+    );
+    // An explicit override still wins even when a run budget is present.
+    expect(resolveCodexTurnTerminalIdleTimeoutMs(5 * 60_000, overFloor)).toBe(5 * 60_000);
+  });
+
   it("caps gateway timeout grace", () => {
     expect(resolveCodexGatewayTimeoutWithGraceMs(120_000)).toBe(130_000);
     expect(resolveCodexGatewayTimeoutWithGraceMs(120_000, 500)).toBe(120_500);

--- a/extensions/codex/src/app-server/attempt-timeouts.ts
+++ b/extensions/codex/src/app-server/attempt-timeouts.ts
@@ -119,15 +119,16 @@ export function resolveCodexPostToolRawAssistantCompletionIdleTimeoutMs(
 /** Resolves the long terminal turn idle timeout. */
 export function resolveCodexTurnTerminalIdleTimeoutMs(
   value: number | undefined,
-  effectiveRunTimeoutMs?: number,
+  runTimeoutOverrideMs?: number,
 ): number {
   // The terminal watchdog is wrapper-owned; Codex turn options do not carry a
-  // timeout budget. Follow the effective run budget without shortening the floor.
-  const effectiveRunBudgetMs = resolvePositiveIntegerTimeoutMs(
-    effectiveRunTimeoutMs,
+  // timeout budget. Follow explicit per-run intent without replacing the floor
+  // with the implicit 48-hour agent default.
+  const explicitRunBudgetMs = resolvePositiveIntegerTimeoutMs(
+    runTimeoutOverrideMs,
     CODEX_TURN_TERMINAL_IDLE_TIMEOUT_MS,
   );
-  const defaultMs = Math.max(CODEX_TURN_TERMINAL_IDLE_TIMEOUT_MS, effectiveRunBudgetMs);
+  const defaultMs = Math.max(CODEX_TURN_TERMINAL_IDLE_TIMEOUT_MS, explicitRunBudgetMs);
   return resolvePositiveIntegerTimeoutMs(value, defaultMs);
 }
 

--- a/extensions/codex/src/app-server/attempt-timeouts.ts
+++ b/extensions/codex/src/app-server/attempt-timeouts.ts
@@ -123,10 +123,11 @@ export function resolveCodexTurnTerminalIdleTimeoutMs(
 ): number {
   // The terminal watchdog is wrapper-owned; Codex turn options do not carry a
   // timeout budget. Follow the effective run budget without shortening the floor.
-  const defaultMs =
-    effectiveRunTimeoutMs !== undefined && Number.isFinite(effectiveRunTimeoutMs)
-      ? Math.max(CODEX_TURN_TERMINAL_IDLE_TIMEOUT_MS, Math.floor(effectiveRunTimeoutMs))
-      : CODEX_TURN_TERMINAL_IDLE_TIMEOUT_MS;
+  const effectiveRunBudgetMs = resolvePositiveIntegerTimeoutMs(
+    effectiveRunTimeoutMs,
+    CODEX_TURN_TERMINAL_IDLE_TIMEOUT_MS,
+  );
+  const defaultMs = Math.max(CODEX_TURN_TERMINAL_IDLE_TIMEOUT_MS, effectiveRunBudgetMs);
   return resolvePositiveIntegerTimeoutMs(value, defaultMs);
 }
 

--- a/extensions/codex/src/app-server/attempt-timeouts.ts
+++ b/extensions/codex/src/app-server/attempt-timeouts.ts
@@ -117,8 +117,17 @@ export function resolveCodexPostToolRawAssistantCompletionIdleTimeoutMs(
 }
 
 /** Resolves the long terminal turn idle timeout. */
-export function resolveCodexTurnTerminalIdleTimeoutMs(value: number | undefined): number {
-  return resolvePositiveIntegerTimeoutMs(value, CODEX_TURN_TERMINAL_IDLE_TIMEOUT_MS);
+export function resolveCodexTurnTerminalIdleTimeoutMs(
+  value: number | undefined,
+  effectiveRunTimeoutMs?: number,
+): number {
+  // The terminal watchdog is wrapper-owned; Codex turn options do not carry a
+  // timeout budget. Follow the effective run budget without shortening the floor.
+  const defaultMs =
+    effectiveRunTimeoutMs !== undefined && Number.isFinite(effectiveRunTimeoutMs)
+      ? Math.max(CODEX_TURN_TERMINAL_IDLE_TIMEOUT_MS, Math.floor(effectiveRunTimeoutMs))
+      : CODEX_TURN_TERMINAL_IDLE_TIMEOUT_MS;
+  return resolvePositiveIntegerTimeoutMs(value, defaultMs);
 }
 
 /** Adds gateway grace time to a caller timeout without overflowing invalid values. */

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -1621,7 +1621,7 @@ export async function runCodexAppServerAttempt(
     );
   const turnTerminalIdleTimeoutMs = resolveCodexTurnTerminalIdleTimeoutMs(
     options.turnTerminalIdleTimeoutMs,
-    params.timeoutMs,
+    params.runTimeoutOverrideMs,
   );
   const turnAttemptIdleTimeoutMs = Math.max(100, Math.floor(params.timeoutMs));
   let nativeHookRelayLastRenewedAt = 0;

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -1621,6 +1621,7 @@ export async function runCodexAppServerAttempt(
     );
   const turnTerminalIdleTimeoutMs = resolveCodexTurnTerminalIdleTimeoutMs(
     options.turnTerminalIdleTimeoutMs,
+    params.timeoutMs,
   );
   const turnAttemptIdleTimeoutMs = Math.max(100, Math.floor(params.timeoutMs));
   let nativeHookRelayLastRenewedAt = 0;

--- a/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
@@ -122,6 +122,42 @@ describe("createCodexAttemptTurnWatchController", () => {
 });
 
 describe("runCodexAppServerAttempt turn watches", () => {
+  it.each([
+    {
+      name: "keeps the 30-minute floor for the implicit 48-hour run timeout",
+      runTimeoutOverrideMs: undefined,
+      expectedTerminalIdleTimeoutMs: 30 * 60_000,
+    },
+    {
+      name: "follows an explicit 45-minute run timeout",
+      runTimeoutOverrideMs: 45 * 60_000,
+      expectedTerminalIdleTimeoutMs: 45 * 60_000,
+    },
+  ])("$name", async ({ runTimeoutOverrideMs, expectedTerminalIdleTimeoutMs }) => {
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const harness = createStartedThreadHarness();
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+    params.timeoutMs = 48 * 60 * 60_000;
+    params.runTimeoutOverrideMs = runTimeoutOverrideMs;
+    const run = runCodexAppServerAttempt(params);
+
+    await harness.waitForMethod("turn/start");
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expectedTerminalIdleTimeoutMs);
+    await harness.notify({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        turn: { id: "turn-1", status: "completed", items: [] },
+      },
+    });
+
+    await expect(run).resolves.toMatchObject({ aborted: false, timedOut: false });
+  });
+
   it("releases the session when Codex never completes after a dynamic tool response", async () => {
     let handleRequest:
       | ((request: { id: string; method: string; params?: unknown }) => Promise<unknown>)


### PR DESCRIPTION
## Summary

Refs #85242. Derives the Codex app-server terminal-idle watchdog from an explicit per-run timeout instead of always using the hardcoded 30-minute default.

This addresses the early-abort half of #85242 as a focused runtime fix. The diagnostic-wording half (naming the terminal-idle watchdog and its effective timeout in surfaced guidance) remains a separate follow-up, so this PR uses `Refs` rather than `Fixes`.

The resolver lives in `attempt-timeouts.ts`. The call site passes `params.runTimeoutOverrideMs`, the existing prepared signal for a deliberate cron/CLI timeout, rather than `params.timeoutMs`, which also carries the implicit 48-hour agent default.

## Real behavior proof

Before this patch, a scheduled Codex turn with an explicit timeout above 30 minutes could still be aborted by the 30-minute terminal-idle watchdog.

After the maintainer repair:

- no explicit run timeout -> 30-minute terminal-idle floor remains unchanged
- explicit 45-minute run timeout -> 45-minute terminal-idle watchdog
- explicit 10-minute run timeout -> 30-minute floor remains unchanged
- internal harness override -> still wins

Focused proof on the real resolver and run-attempt call path:

- `node scripts/run-vitest.mjs extensions/codex/src/app-server/attempt-timeouts.test.ts extensions/codex/src/app-server/run-attempt.turn-watches.test.ts` -> 72 passed
- Blacksmith Testbox `tbx_01kwej31e1mn30y1ahjqb23pbz`: `corepack pnpm check:changed` -> passed
- `oxfmt --check` on the three changed files -> clean
- fresh autoreview -> no findings

A live 30- or 45-minute scheduled turn was not waited out end to end; timer selection is exercised through the production resolver and the real `runCodexAppServerAttempt` path. The diagnostic-wording half of #85242 remains intentionally out of scope.
