### PR TITLE
fix(plugins): break plugin metadata snapshot type cycle

### DIFF
--- a/src/plugins/plugin-metadata-snapshot.types.ts
+++ b/src/plugins/plugin-metadata-snapshot.types.ts
@@ -2,8 +2,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { InstalledPluginIndex } from "./installed-plugin-index.js";
 import type { PluginManifestRecord, PluginManifestRegistry } from "./manifest-registry.js";
 import type { PluginDiagnostic } from "./manifest-types.js";
-
-export type PluginRegistrySnapshotSource = "provided" | "persisted" | "derived";
+import type { PluginRegistrySnapshotSource } from "./plugin-registry-snapshot.types.js";
 
 export type PluginMetadataSnapshotOwnerMaps = {
   channels: ReadonlyMap<string, readonly string[]>;

--- a/src/plugins/plugin-registry-snapshot.ts
+++ b/src/plugins/plugin-registry-snapshot.ts
@@ -26,7 +26,7 @@ import {
   type LoadInstalledPluginIndexParams,
   type RefreshInstalledPluginIndexParams,
 } from "./installed-plugin-index.js";
-import type { PluginRegistrySnapshotSource } from "./plugin-metadata-snapshot.types.js";
+import type { PluginRegistrySnapshotSource } from "./plugin-registry-snapshot.types.js";
 
 export type PluginRegistrySnapshot = InstalledPluginIndex;
 export type PluginRegistryRecord = InstalledPluginIndexRecord;

--- a/src/plugins/plugin-registry-snapshot.types.ts
+++ b/src/plugins/plugin-registry-snapshot.types.ts
@@ -1,0 +1,1 @@
+export type PluginRegistrySnapshotSource = "provided" | "persisted" | "derived";


### PR DESCRIPTION
## Summary
- Extract `PluginRegistrySnapshotSource` into a leaf type module.
- Update plugin metadata and registry snapshot modules to import the leaf type instead of routing through each other.
- Break the pre-existing Madge cycle blocking architecture CI.

## Verification
- `pnpm check:architecture` — passed (0 runtime value cycles, 0 Madge cycles, deprecated guards passed)
- `pnpm tsgo:prod` — passed

## Real behavior proof

**Behavior or issue addressed:** The architecture gate failed because Madge detected a plugin metadata import cycle: `src/plugins/current-plugin-metadata-snapshot.ts -> src/plugins/plugin-metadata-snapshot.types.ts -> src/plugins/plugin-registry-snapshot.ts`. This PR moves the shared source enum type into a leaf module so the plugin metadata type file no longer imports the registry snapshot implementation module.

**Real environment tested:** Real OpenClaw source checkout on branch `forge/fix-plugin-metadata-madge-cycle` at commit `4b2a25db`, run locally on Eric's Mac Studio workspace with repository dependencies already installed. No OpenClaw runtime config, Gateway process, memory-core state, or external service was changed.

**Exact steps or command run after this patch:** Ran `pnpm check:architecture` from the source checkout to exercise the same architecture/Madge gate that failed on PR #85292, then ran `pnpm tsgo:prod` to verify production TypeScript type-checking after the type extraction.

**Evidence after fix:** Copied terminal output from the real source checkout:

```text
$ pnpm check:architecture
Import cycle check: 0 runtime value cycle(s).
Madge import cycle check: 0 cycle(s).
deprecated API usage guard passed
deprecated JSDoc guard passed

$ pnpm tsgo:prod
$ pnpm tsgo:core && pnpm tsgo:extensions
$ node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
$ node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo
```

**Observed result after fix:** The previously reported Madge cycle count dropped to 0, the architecture gate completed successfully, and production TypeScript checks completed successfully. The change is limited to source/type imports and does not execute or mutate OpenClaw runtime state.

**What was not tested:** No Gateway restart, live OpenClaw config write, memory-core enablement, cleanup/reindex/recovery, recurring automation, restricted-memory path change, or external runtime mutation was tested or performed.

## Context
This fixes the unrelated/pre-existing `src/plugins/*` cycle observed on PR #85292's `check-additional-runtime-topology-architecture` gate.
