### PR TITLE
fix(plugins): resolve native plugin sdk aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Docs: https://docs.openclaw.ai
 
 - CLI/agents: retry transient normal-close Gateway handshakes before falling back to embedded `openclaw agent` execution.
 - CLI/update: keep managed Gateway service stop/restart status lines out of `openclaw update --json` stdout so package-update automation can parse the JSON payload.
+- Plugins: resolve OpenClaw plugin SDK subpaths for native external plugin runtimes without mutating package installs or broadening process-wide module resolution.
 - Providers/Gemini: strip fractional seconds from web-search time range filters so Gemini accepts freshness-bound search requests. (#85071) Thanks @Noerr.
 - OpenAI Codex: preserve image input support for sparse `openai-codex/gpt-5.5` catalog rows. (#85095) Thanks @sercada.
 - Plugins/discovery: strip `-plugin` package suffixes when deriving plugin id hints so package names line up with manifest ids. (#85170) Thanks @JulyanXu.

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -130,6 +130,7 @@ import {
   serializePluginIdScope,
 } from "./plugin-scope.js";
 import { ensureOpenClawPluginSdkAlias } from "./plugin-sdk-dist-alias.js";
+import { installOpenClawPluginSdkNativeResolver } from "./plugin-sdk-native-resolver.js";
 import { createEmptyPluginRegistry } from "./registry-empty.js";
 import type { PluginRegistryParams } from "./registry-types.js";
 import { createPluginRegistry, type PluginRecord, type PluginRegistry } from "./registry.js";
@@ -531,6 +532,12 @@ function runPluginRegisterSync(
 function createPluginModuleLoader(options: Pick<PluginLoadOptions, "pluginSdkResolution">) {
   const moduleLoaders: PluginModuleLoaderCache = createPluginModuleLoaderCache();
   const createLoaderForModule = (modulePath: string) => {
+    installOpenClawPluginSdkNativeResolver({
+      argv1: process.argv[1],
+      moduleUrl: import.meta.url,
+      pluginModulePath: modulePath,
+      pluginSdkResolution: options.pluginSdkResolution,
+    });
     return getCachedPluginModuleLoader({
       cache: moduleLoaders,
       modulePath,

--- a/src/plugins/plugin-sdk-native-resolver.test.ts
+++ b/src/plugins/plugin-sdk-native-resolver.test.ts
@@ -1,0 +1,138 @@
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  installOpenClawPluginSdkNativeResolver,
+  resetOpenClawPluginSdkNativeResolverForTest,
+} from "./plugin-sdk-native-resolver.js";
+
+afterEach(() => {
+  resetOpenClawPluginSdkNativeResolverForTest();
+});
+
+function writeJsonFile(targetPath: string, value: unknown): void {
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+  fs.writeFileSync(targetPath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function writeFakeOpenClawPackage(root: string): { distRoot: string; loaderModulePath: string } {
+  writeJsonFile(path.join(root, "package.json"), {
+    name: "openclaw",
+    type: "module",
+    bin: {
+      openclaw: "./openclaw.mjs",
+    },
+    exports: {
+      "./cli-entry": "./dist/cli-entry.js",
+      "./plugin-sdk": "./dist/plugin-sdk/root-alias.cjs",
+      "./plugin-sdk/channel-message": "./dist/plugin-sdk/channel-message.js",
+    },
+  });
+  fs.writeFileSync(path.join(root, "openclaw.mjs"), "#!/usr/bin/env node\n", "utf8");
+  const distRoot = path.join(root, "dist");
+  const pluginSdkDir = path.join(distRoot, "plugin-sdk");
+  fs.mkdirSync(pluginSdkDir, { recursive: true });
+  fs.writeFileSync(path.join(pluginSdkDir, "root-alias.cjs"), "module.exports = {};\n", "utf8");
+  fs.writeFileSync(
+    path.join(pluginSdkDir, "channel-message.js"),
+    ['export const defineChannelMessageAdapter = () => "adapter";', ""].join("\n"),
+    "utf8",
+  );
+  const loaderModulePath = path.join(distRoot, "plugins", "loader.js");
+  fs.mkdirSync(path.dirname(loaderModulePath), { recursive: true });
+  fs.writeFileSync(loaderModulePath, "export default {};\n", "utf8");
+  return { distRoot, loaderModulePath };
+}
+
+function writeExternalPluginEntry(root: string): string {
+  writeJsonFile(path.join(root, "package.json"), {
+    name: "external-plugin",
+    type: "module",
+  });
+  const entry = path.join(root, "dist", "runtime-api.js");
+  fs.mkdirSync(path.dirname(entry), { recursive: true });
+  fs.writeFileSync(entry, "export default {};\n", "utf8");
+  return entry;
+}
+
+describe("installOpenClawPluginSdkNativeResolver", () => {
+  it("keeps native aliases on JS dist artifacts when source files exist", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sdk-native-source-resolver-"));
+    const { loaderModulePath } = writeFakeOpenClawPackage(root);
+    const sourceChannelMessagePath = path.join(root, "src", "plugin-sdk", "channel-message.ts");
+    fs.mkdirSync(path.dirname(sourceChannelMessagePath), { recursive: true });
+    fs.writeFileSync(sourceChannelMessagePath, "export const sourceOnly = true;\n", "utf8");
+    const externalPluginEntry = writeExternalPluginEntry(path.join(root, "external-plugin"));
+
+    const installedAliases = installOpenClawPluginSdkNativeResolver({
+      modulePath: loaderModulePath,
+      pluginModulePath: externalPluginEntry,
+      pluginSdkResolution: "src",
+    });
+
+    expect(installedAliases).toContain("openclaw/plugin-sdk/channel-message");
+    const requireFromPlugin = createRequire(externalPluginEntry);
+    expect(fs.realpathSync(requireFromPlugin.resolve("openclaw/plugin-sdk/channel-message"))).toBe(
+      fs.realpathSync(path.join(root, "dist", "plugin-sdk", "channel-message.js")),
+    );
+  });
+
+  it("lets built external plugins resolve OpenClaw SDK subpaths with createRequire", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sdk-native-resolver-"));
+    const { distRoot, loaderModulePath } = writeFakeOpenClawPackage(root);
+    const externalPluginEntry = writeExternalPluginEntry(path.join(root, "external-plugin"));
+
+    const distMode = fs.statSync(distRoot).mode;
+    if (process.platform !== "win32") {
+      fs.chmodSync(distRoot, 0o555);
+    }
+
+    try {
+      const installedAliases = installOpenClawPluginSdkNativeResolver({
+        modulePath: loaderModulePath,
+        pluginModulePath: externalPluginEntry,
+        pluginSdkResolution: "dist",
+      });
+
+      expect(installedAliases).toContain("openclaw/plugin-sdk/channel-message");
+      expect(fs.existsSync(path.join(distRoot, "extensions"))).toBe(false);
+      const requireFromPlugin = createRequire(externalPluginEntry);
+      expect(
+        fs.realpathSync(requireFromPlugin.resolve("openclaw/plugin-sdk/channel-message")),
+      ).toBe(fs.realpathSync(path.join(root, "dist", "plugin-sdk", "channel-message.js")));
+      const sdk = requireFromPlugin("openclaw/plugin-sdk/channel-message") as {
+        defineChannelMessageAdapter?: () => string;
+      };
+
+      expect(sdk.defineChannelMessageAdapter?.()).toBe("adapter");
+      expect(() => requireFromPlugin.resolve("openclaw/not-plugin-sdk/channel-message")).toThrow();
+    } finally {
+      if (process.platform !== "win32") {
+        fs.chmodSync(distRoot, distMode);
+      }
+    }
+  });
+
+  it("does not resolve SDK aliases for parents outside registered plugin roots", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sdk-native-guard-"));
+    const { loaderModulePath } = writeFakeOpenClawPackage(root);
+    const externalPluginEntry = writeExternalPluginEntry(path.join(root, "external-plugin"));
+    const unrelatedRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sdk-native-outside-"));
+    const unrelatedEntry = path.join(unrelatedRoot, "runtime-api.js");
+    fs.mkdirSync(path.dirname(unrelatedEntry), { recursive: true });
+    fs.writeFileSync(unrelatedEntry, "export default {};\n", "utf8");
+
+    installOpenClawPluginSdkNativeResolver({
+      modulePath: loaderModulePath,
+      pluginModulePath: externalPluginEntry,
+      pluginSdkResolution: "dist",
+    });
+
+    const requireFromPlugin = createRequire(externalPluginEntry);
+    const requireFromOutside = createRequire(unrelatedEntry);
+    expect(requireFromPlugin.resolve("openclaw/plugin-sdk/channel-message")).toBeTruthy();
+    expect(() => requireFromOutside.resolve("openclaw/plugin-sdk/channel-message")).toThrow();
+  });
+});

--- a/src/plugins/plugin-sdk-native-resolver.test.ts
+++ b/src/plugins/plugin-sdk-native-resolver.test.ts
@@ -28,6 +28,7 @@ function writeFakeOpenClawPackage(root: string): { distRoot: string; loaderModul
       "./cli-entry": "./dist/cli-entry.js",
       "./plugin-sdk": "./dist/plugin-sdk/root-alias.cjs",
       "./plugin-sdk/channel-message": "./dist/plugin-sdk/channel-message.js",
+      "./plugin-sdk/source-only": "./dist/plugin-sdk/source-only.js",
     },
   });
   fs.writeFileSync(path.join(root, "openclaw.mjs"), "#!/usr/bin/env node\n", "utf8");
@@ -134,5 +135,25 @@ describe("installOpenClawPluginSdkNativeResolver", () => {
     const requireFromOutside = createRequire(unrelatedEntry);
     expect(requireFromPlugin.resolve("openclaw/plugin-sdk/channel-message")).toBeTruthy();
     expect(() => requireFromOutside.resolve("openclaw/plugin-sdk/channel-message")).toThrow();
+  });
+
+  it("does not register source-only SDK subpaths for native resolution", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sdk-native-source-only-"));
+    const { loaderModulePath } = writeFakeOpenClawPackage(root);
+    const sourceOnlyPath = path.join(root, "src", "plugin-sdk", "source-only.ts");
+    fs.mkdirSync(path.dirname(sourceOnlyPath), { recursive: true });
+    fs.writeFileSync(sourceOnlyPath, "export const sourceOnly = true;\n", "utf8");
+    const externalPluginEntry = writeExternalPluginEntry(path.join(root, "external-plugin"));
+
+    const installedAliases = installOpenClawPluginSdkNativeResolver({
+      modulePath: loaderModulePath,
+      pluginModulePath: externalPluginEntry,
+      pluginSdkResolution: "src",
+    });
+
+    expect(installedAliases).toContain("openclaw/plugin-sdk/channel-message");
+    expect(installedAliases).not.toContain("openclaw/plugin-sdk/source-only");
+    const requireFromPlugin = createRequire(externalPluginEntry);
+    expect(() => requireFromPlugin.resolve("openclaw/plugin-sdk/source-only")).toThrow();
   });
 });

--- a/src/plugins/plugin-sdk-native-resolver.ts
+++ b/src/plugins/plugin-sdk-native-resolver.ts
@@ -25,6 +25,7 @@ export type InstallOpenClawPluginSdkNativeResolverOptions = {
 };
 
 const moduleWithResolver = Module as ModuleWithResolver;
+const nodeResolveFilenameProperty = "_resolveFilename" as const;
 const PLUGIN_SDK_PACKAGE_PREFIXES = ["openclaw/plugin-sdk", "@openclaw/plugin-sdk"] as const;
 const pluginSdkNativeAliases = new Map<string, string>();
 const allowedParentRoots = new Set<string>();
@@ -117,11 +118,11 @@ function listPluginSdkNativeAliases(
 }
 
 function installResolver(): void {
-  if (installed || !moduleWithResolver._resolveFilename) {
+  if (installed || !moduleWithResolver[nodeResolveFilenameProperty]) {
     return;
   }
-  previousResolveFilename = moduleWithResolver._resolveFilename;
-  moduleWithResolver._resolveFilename = ((request, parent, isMain, options) => {
+  previousResolveFilename = moduleWithResolver[nodeResolveFilenameProperty];
+  moduleWithResolver[nodeResolveFilenameProperty] = ((request, parent, isMain, options) => {
     const aliasTarget = pluginSdkNativeAliases.get(request);
     if (aliasTarget && canResolveForParent(parent)) {
       return aliasTarget;
@@ -146,7 +147,7 @@ export function resetOpenClawPluginSdkNativeResolverForTest(): void {
   pluginSdkNativeAliases.clear();
   allowedParentRoots.clear();
   if (installed && previousResolveFilename) {
-    moduleWithResolver._resolveFilename = previousResolveFilename;
+    moduleWithResolver[nodeResolveFilenameProperty] = previousResolveFilename;
   }
   previousResolveFilename = undefined;
   installed = false;

--- a/src/plugins/plugin-sdk-native-resolver.ts
+++ b/src/plugins/plugin-sdk-native-resolver.ts
@@ -42,6 +42,17 @@ function isPluginSdkAliasSpecifier(specifier: string): boolean {
   );
 }
 
+function isNativeLoadableSdkTarget(targetPath: string): boolean {
+  switch (path.extname(targetPath)) {
+    case ".cjs":
+    case ".js":
+    case ".mjs":
+      return true;
+    default:
+      return false;
+  }
+}
+
 function normalizePathForBoundary(candidate: string): string {
   try {
     return fs.realpathSync(candidate);
@@ -106,6 +117,7 @@ function listPluginSdkNativeAliases(
     ),
   )
     .filter(([specifier]) => isPluginSdkAliasSpecifier(specifier))
+    .filter(([, target]) => isNativeLoadableSdkTarget(target))
     .flatMap(([specifier, target]) => {
       if (specifier.endsWith(".js")) {
         return [[specifier, target]] as Array<readonly [string, string]>;

--- a/src/plugins/plugin-sdk-native-resolver.ts
+++ b/src/plugins/plugin-sdk-native-resolver.ts
@@ -1,0 +1,153 @@
+import fs from "node:fs";
+import Module from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { buildPluginLoaderAliasMap, type PluginSdkResolutionPreference } from "./sdk-alias.js";
+
+type ResolveFilename = (
+  request: string,
+  parent: NodeJS.Module | undefined,
+  isMain: boolean,
+  options?: { paths?: string[] },
+) => string;
+
+type ModuleWithResolver = typeof Module & {
+  _resolveFilename?: ResolveFilename;
+};
+
+export type InstallOpenClawPluginSdkNativeResolverOptions = {
+  modulePath?: string;
+  pluginModulePath?: string;
+  allowedParentRoots?: readonly string[];
+  argv1?: string;
+  moduleUrl?: string;
+  pluginSdkResolution?: PluginSdkResolutionPreference;
+};
+
+const moduleWithResolver = Module as ModuleWithResolver;
+const PLUGIN_SDK_PACKAGE_PREFIXES = ["openclaw/plugin-sdk", "@openclaw/plugin-sdk"] as const;
+const pluginSdkNativeAliases = new Map<string, string>();
+const allowedParentRoots = new Set<string>();
+let installed = false;
+let previousResolveFilename: ResolveFilename | undefined;
+
+function resolveLoaderModulePath(options: InstallOpenClawPluginSdkNativeResolverOptions): string {
+  return options.modulePath ?? fileURLToPath(options.moduleUrl ?? import.meta.url);
+}
+
+function isPluginSdkAliasSpecifier(specifier: string): boolean {
+  return PLUGIN_SDK_PACKAGE_PREFIXES.some(
+    (prefix) => specifier === prefix || specifier.startsWith(`${prefix}/`),
+  );
+}
+
+function normalizePathForBoundary(candidate: string): string {
+  try {
+    return fs.realpathSync(candidate);
+  } catch {
+    return path.resolve(candidate);
+  }
+}
+
+function findNearestPackageRoot(modulePath: string): string {
+  let cursor = path.dirname(path.resolve(modulePath));
+  for (let i = 0; i < 12; i += 1) {
+    if (fs.existsSync(path.join(cursor, "package.json"))) {
+      return cursor;
+    }
+    const parent = path.dirname(cursor);
+    if (parent === cursor) {
+      break;
+    }
+    cursor = parent;
+  }
+  return path.dirname(path.resolve(modulePath));
+}
+
+function addAllowedParentRoot(root: string): void {
+  allowedParentRoots.add(normalizePathForBoundary(root));
+}
+
+function registerAllowedParentRoots(options: InstallOpenClawPluginSdkNativeResolverOptions): void {
+  if (options.pluginModulePath) {
+    addAllowedParentRoot(findNearestPackageRoot(options.pluginModulePath));
+  }
+  for (const root of options.allowedParentRoots ?? []) {
+    addAllowedParentRoot(root);
+  }
+}
+
+function isWithinRoot(candidate: string, root: string): boolean {
+  const relative = path.relative(root, normalizePathForBoundary(candidate));
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function canResolveForParent(parent: NodeJS.Module | undefined): boolean {
+  const parentFilename = parent?.filename;
+  if (!parentFilename || allowedParentRoots.size === 0) {
+    return false;
+  }
+  return [...allowedParentRoots].some((root) => isWithinRoot(parentFilename, root));
+}
+
+function listPluginSdkNativeAliases(
+  options: InstallOpenClawPluginSdkNativeResolverOptions,
+): Array<readonly [string, string]> {
+  const modulePath = resolveLoaderModulePath(options);
+  return Object.entries(
+    buildPluginLoaderAliasMap(
+      modulePath,
+      options.argv1 ?? process.argv[1],
+      options.moduleUrl,
+      // Native require hooks must point at JavaScript artifacts, even when the
+      // plugin loader itself is configured to prefer source imports.
+      "dist",
+    ),
+  )
+    .filter(([specifier]) => isPluginSdkAliasSpecifier(specifier))
+    .flatMap(([specifier, target]) => {
+      if (specifier.endsWith(".js")) {
+        return [[specifier, target]] as Array<readonly [string, string]>;
+      }
+      return [
+        [specifier, target],
+        [`${specifier}.js`, target],
+      ] as Array<readonly [string, string]>;
+    });
+}
+
+function installResolver(): void {
+  if (installed || !moduleWithResolver._resolveFilename) {
+    return;
+  }
+  previousResolveFilename = moduleWithResolver._resolveFilename;
+  moduleWithResolver._resolveFilename = ((request, parent, isMain, options) => {
+    const aliasTarget = pluginSdkNativeAliases.get(request);
+    if (aliasTarget && canResolveForParent(parent)) {
+      return aliasTarget;
+    }
+    return previousResolveFilename?.(request, parent, isMain, options) ?? request;
+  }) satisfies ResolveFilename;
+  installed = true;
+}
+
+export function installOpenClawPluginSdkNativeResolver(
+  options: InstallOpenClawPluginSdkNativeResolverOptions = {},
+): string[] {
+  for (const [specifier, target] of listPluginSdkNativeAliases(options)) {
+    pluginSdkNativeAliases.set(specifier, target);
+  }
+  registerAllowedParentRoots(options);
+  installResolver();
+  return [...pluginSdkNativeAliases.keys()].toSorted();
+}
+
+export function resetOpenClawPluginSdkNativeResolverForTest(): void {
+  pluginSdkNativeAliases.clear();
+  allowedParentRoots.clear();
+  if (installed && previousResolveFilename) {
+    moduleWithResolver._resolveFilename = previousResolveFilename;
+  }
+  previousResolveFilename = undefined;
+  installed = false;
+}


### PR DESCRIPTION
## Summary
- install a narrow native resolver for `openclaw/plugin-sdk/*` and `@openclaw/plugin-sdk/*` when loading plugin modules
- keep native `createRequire()` SDK subpath resolution on built JS dist artifacts, even when the plugin loader prefers source aliases
- guard the resolver to parents under registered plugin roots so unrelated process `require()` calls still use Node's normal resolver
- add regression coverage for read-only dist trees, source/dist preference, and the parent-root guard

Refs #85123.

## Verification
- `node scripts/run-vitest.mjs src/plugins/plugin-sdk-native-resolver.test.ts`
- `git diff --check HEAD~1..HEAD`

## Real behavior proof
Behavior addressed: built external plugin runtimes can resolve OpenClaw plugin SDK subpaths from plugin-local `createRequire()` calls without a plugin-local `node_modules/openclaw` shim, runtime writes to the OpenClaw package tree, or `NODE_PATH`.
Real environment tested: local OpenClaw source checkout using a fake built OpenClaw package and fake built external plugin runtime under `src/plugins/plugin-sdk-native-resolver.test.ts`.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/plugins/plugin-sdk-native-resolver.test.ts`
Evidence after fix: the regression test resolves `openclaw/plugin-sdk/channel-message` from the registered external plugin runtime, verifies the resolved file is `dist/plugin-sdk/channel-message.js` even when source files exist, verifies no `dist/extensions` alias tree is created in a read-only dist tree, and verifies an unrelated parent module cannot resolve the alias through this hook.
Observed result after fix: 1 test file passed, 3 tests passed.
What was not tested: no live third-party Mentat runtime; this PR intentionally covers the generic resolver half only and leaves channel behavior to the generic channel-message PR.
