### PR TITLE
refactor(crabbox): parse provider list from binary help instead of hardcoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Docs: https://docs.openclaw.ai
 - Agents/subagents: limit default sub-agent bootstrap context to `AGENTS.md` and `TOOLS.md`, keeping persona, identity, user, memory, heartbeat, and setup files out of delegated workers by default. (#85283) Thanks @100yenadmin.
 - Maintainer skills: exclude plugin SDK/API boundary work from `openclaw-landable-bug-sweep` so bugbash sweeps stay focused on small paper-cut fixes.
 - Plugin SDK: add a generic channel-message poll sender so channel plugins can expose poll delivery without depending on channel-specific SDK facades.
+- Crabbox: keep the local wrapper's provider validation synced with the installed Crabbox binary while preserving supported aliases such as `docker` and `blacksmith`. (#85302) Thanks @hxy91819.
 - Maintainer skills: add `openclaw-landable-bug-sweep` for producing five small, reviewed, CI-green OpenClaw bugfix PRs from issue/PR sweeps.
 - Control UI/chat: add search and Load More pagination to the chat session picker, keeping initial session loads bounded while making older conversations reachable. (#85237) Thanks @amknight.
 - Discord: allow configuring a bounded `agentComponents.ttlMs` callback registry lifetime for long-running component workflows, with per-account overrides and a 24-hour cap. (#84189) Thanks @100menotu001.

--- a/scripts/crabbox-wrapper.mjs
+++ b/scripts/crabbox-wrapper.mjs
@@ -285,12 +285,36 @@ function addProviderNames(names, text) {
   }
 }
 
+function providerListContinuation(line, previousText) {
+  const match = line.match(
+    /^\s*((?:or\s+)?[a-z0-9][a-z0-9-]*(?:\s*(?:,|\||\bor\b)\s*(?:or\s+)?[a-z0-9][a-z0-9-]*)*\s*(?:,|\|)?)(?:\s+\(default\b.*)?\s*$/u,
+  );
+  if (!match) {
+    return "";
+  }
+  if (/[,|]\s*$/u.test(previousText) || /[,|]|\bor\b|\(default\b/u.test(line)) {
+    return match[1];
+  }
+  return "";
+}
+
 function parseProvidersFromHelp(text) {
   const names = new Set();
-  for (const line of text.split(/\r?\n/u)) {
+  const lines = text.split(/\r?\n/u);
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
     const providerMatch = line.match(/provider:\s*([a-z0-9][a-z0-9, -]*)(?:\s*\(default\b|$)/u);
     if (providerMatch) {
-      addProviderNames(names, providerMatch[1]);
+      let providerText = providerMatch[1];
+      while (!/\(default\b/u.test(lines[index]) && index + 1 < lines.length) {
+        const continuation = providerListContinuation(lines[index + 1], providerText);
+        if (!continuation) {
+          break;
+        }
+        index += 1;
+        providerText = `${providerText} ${continuation}`;
+      }
+      addProviderNames(names, providerText);
       continue;
     }
 

--- a/scripts/crabbox-wrapper.mjs
+++ b/scripts/crabbox-wrapper.mjs
@@ -268,9 +268,19 @@ const version = checkedOutput(binary, ["--version"]);
 const help = checkedOutput(binary, ["run", "--help"]);
 const providerAliases = new Map([
   ["blacksmith", "blacksmith-testbox"],
+  ["cf", "cloudflare"],
   ["container", "local-container"],
   ["docker", "local-container"],
+  ["exe", "exe-dev"],
+  ["exedev", "exe-dev"],
+  ["google", "gcp"],
   ["local-docker", "local-container"],
+  ["namespace", "namespace-devbox"],
+  ["rail", "railway"],
+  ["railwayapp", "railway"],
+  ["sem", "semaphore"],
+  ["static", "ssh"],
+  ["static-ssh", "ssh"],
 ]);
 
 function addProviderNames(names, text) {

--- a/scripts/crabbox-wrapper.mjs
+++ b/scripts/crabbox-wrapper.mjs
@@ -266,26 +266,18 @@ function commandRuntimeEntrypoint(commandArgs) {
 
 const version = checkedOutput(binary, ["--version"]);
 const help = checkedOutput(binary, ["run", "--help"]);
-const knownProviders = [
-  "hetzner",
-  "aws",
-  "azure",
-  "gcp",
-  "proxmox",
-  "ssh",
-  "blacksmith-testbox",
-  "namespace-devbox",
-  "semaphore",
-  "daytona",
-  "islo",
-  "e2b",
-  "modal",
-  "sprites",
-  "cloudflare",
-];
-const providers = knownProviders.filter((provider) =>
-  new RegExp(`\\b${provider.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`).test(help.text),
-);
+function parseProvidersFromHelp(text) {
+  const match = text.match(/provider:\s*([\w, -]+)(?:\s*\(default\b|\n|$)/u);
+  if (!match) {
+    return [];
+  }
+  return match[1]
+    .split(/,\s*|\s+or\s+/u)
+    .map((s) => s.replace(/^or\s+/u, "").trim())
+    .filter(Boolean);
+}
+
+const providers = parseProvidersFromHelp(help.text);
 const displayBinary = binary === "crabbox" ? "crabbox" : relative(repoRoot, binary);
 const provider = selectedProvider(args);
 const commandProviderValue = commandProvider(args);
@@ -299,7 +291,13 @@ if (version.status !== 0 || help.status !== 0) {
   process.exit(2);
 }
 
-if (provider && knownProviders.includes(provider) && !providers.includes(provider)) {
+if (provider && !providers.includes(provider)) {
+  if (providers.length === 0) {
+    console.error(
+      "[crabbox] could not parse provider list from --help; refusing to run with --provider without validation",
+    );
+    process.exit(2);
+  }
   console.error(
     `[crabbox] selected binary does not advertise provider ${provider}; update Crabbox or choose a supported provider`,
   );

--- a/scripts/crabbox-wrapper.mjs
+++ b/scripts/crabbox-wrapper.mjs
@@ -277,12 +277,19 @@ const providerAliases = new Map([
   ["google-cloud", "gcp"],
   ["local-docker", "local-container"],
   ["namespace", "namespace-devbox"],
+  ["namespace-devboxes", "namespace-devbox"],
   ["rail", "railway"],
   ["railwayapp", "railway"],
+  ["run-pod", "runpod"],
+  ["runpodio", "runpod"],
   ["sem", "semaphore"],
   ["static", "ssh"],
   ["static-ssh", "ssh"],
+  ["tensorlake-sbx", "tensorlake"],
+  ["tl", "tensorlake"],
 ]);
+// Crabbox providerHelpAll can omit Tensorlake even when the binary accepts it.
+const providerHelpOmissions = new Set(["tensorlake"]);
 
 function addProviderNames(names, text) {
   for (const name of text
@@ -340,9 +347,11 @@ function parseProvidersFromHelp(text) {
 }
 
 function isProviderAdvertised(provider, advertisedProviders) {
+  const canonicalProvider = providerAliases.get(provider) ?? provider;
   return (
     advertisedProviders.includes(provider) ||
-    advertisedProviders.includes(providerAliases.get(provider) ?? "")
+    advertisedProviders.includes(canonicalProvider) ||
+    providerHelpOmissions.has(canonicalProvider)
   );
 }
 

--- a/scripts/crabbox-wrapper.mjs
+++ b/scripts/crabbox-wrapper.mjs
@@ -274,6 +274,7 @@ const providerAliases = new Map([
   ["exe", "exe-dev"],
   ["exedev", "exe-dev"],
   ["google", "gcp"],
+  ["google-cloud", "gcp"],
   ["local-docker", "local-container"],
   ["namespace", "namespace-devbox"],
   ["rail", "railway"],

--- a/scripts/crabbox-wrapper.mjs
+++ b/scripts/crabbox-wrapper.mjs
@@ -266,15 +266,49 @@ function commandRuntimeEntrypoint(commandArgs) {
 
 const version = checkedOutput(binary, ["--version"]);
 const help = checkedOutput(binary, ["run", "--help"]);
-function parseProvidersFromHelp(text) {
-  const match = text.match(/provider:\s*([\w, -]+)(?:\s*\(default\b|\n|$)/u);
-  if (!match) {
-    return [];
+const providerAliases = new Map([
+  ["blacksmith", "blacksmith-testbox"],
+  ["container", "local-container"],
+  ["docker", "local-container"],
+  ["local-docker", "local-container"],
+]);
+
+function addProviderNames(names, text) {
+  for (const name of text
+    .replace(/\s+\(default\b.*$/u, "")
+    .split(/\s*(?:,|\||\bor\b)\s*/u)
+    .map((s) => s.trim())
+    .filter(Boolean)) {
+    if (/^[a-z0-9][a-z0-9-]*$/u.test(name)) {
+      names.add(name);
+    }
   }
-  return match[1]
-    .split(/,\s*|\s+or\s+/u)
-    .map((s) => s.replace(/^or\s+/u, "").trim())
-    .filter(Boolean);
+}
+
+function parseProvidersFromHelp(text) {
+  const names = new Set();
+  for (const line of text.split(/\r?\n/u)) {
+    const providerMatch = line.match(/provider:\s*([a-z0-9][a-z0-9, -]*)(?:\s*\(default\b|$)/u);
+    if (providerMatch) {
+      addProviderNames(names, providerMatch[1]);
+      continue;
+    }
+
+    const flagMatch = line.match(
+      /^\s+-{1,2}provider(?:[=\s]+)([a-z0-9][a-z0-9|, -]*)(?:\s{2,}|\s+\(|$)/u,
+    );
+    if (flagMatch && /[,|]|\bor\b/u.test(flagMatch[1])) {
+      addProviderNames(names, flagMatch[1]);
+    }
+  }
+  return [...names];
+}
+
+function isProviderAdvertised(provider, advertisedProviders) {
+  return (
+    advertisedProviders.includes(provider) ||
+    advertisedProviders.includes(providerAliases.get(provider) ?? "")
+  );
 }
 
 const providers = parseProvidersFromHelp(help.text);
@@ -291,7 +325,7 @@ if (version.status !== 0 || help.status !== 0) {
   process.exit(2);
 }
 
-if (provider && !providers.includes(provider)) {
+if (provider && !isProviderAdvertised(provider, providers)) {
   if (providers.length === 0) {
     console.error(
       "[crabbox] could not parse provider list from --help; refusing to run with --provider without validation",

--- a/test/scripts/crabbox-wrapper.test.ts
+++ b/test/scripts/crabbox-wrapper.test.ts
@@ -83,7 +83,7 @@ describe("scripts/crabbox-wrapper", () => {
   it("accepts Crabbox provider aliases when their canonical provider is advertised", () => {
     const helpText = [
       "provider: hetzner, aws, gcp, local-container, blacksmith-testbox,",
-      "  namespace-devbox, semaphore, cloudflare, railway, exe-dev, or ssh",
+      "  namespace-devbox, runpod, semaphore, cloudflare, railway, exe-dev, or ssh",
       "",
     ].join("\n");
     const aliases = [
@@ -97,8 +97,11 @@ describe("scripts/crabbox-wrapper", () => {
       "google-cloud",
       "local-docker",
       "namespace",
+      "namespace-devboxes",
       "rail",
       "railwayapp",
+      "run-pod",
+      "runpodio",
       "sem",
       "static",
       "static-ssh",
@@ -109,6 +112,21 @@ describe("scripts/crabbox-wrapper", () => {
 
       expect(result.status, alias).toBe(0);
       expect(result.stdout).toContain(`"${alias}"`);
+    }
+  });
+
+  it("accepts Crabbox provider aliases when upstream help omits Tensorlake", () => {
+    const helpText = [
+      "provider: hetzner, aws, gcp, local-container, blacksmith-testbox,",
+      "  namespace-devbox, runpod, semaphore, cloudflare, railway, exe-dev, or ssh",
+      "",
+    ].join("\n");
+
+    for (const provider of ["tensorlake", "tl", "tensorlake-sbx"]) {
+      const result = runWrapper(helpText, ["run", "--provider", provider, "--", "echo ok"]);
+
+      expect(result.status, provider).toBe(0);
+      expect(result.stdout).toContain(`"${provider}"`);
     }
   });
 

--- a/test/scripts/crabbox-wrapper.test.ts
+++ b/test/scripts/crabbox-wrapper.test.ts
@@ -81,12 +81,34 @@ describe("scripts/crabbox-wrapper", () => {
   });
 
   it("accepts Crabbox provider aliases when their canonical provider is advertised", () => {
-    const helpText = "provider: hetzner, aws, local-container, blacksmith-testbox, or cloudflare\n";
+    const helpText = [
+      "provider: hetzner, aws, gcp, local-container, blacksmith-testbox,",
+      "  namespace-devbox, semaphore, cloudflare, railway, exe-dev, or ssh",
+      "",
+    ].join("\n");
+    const aliases = [
+      "blacksmith",
+      "cf",
+      "container",
+      "docker",
+      "exe",
+      "exedev",
+      "google",
+      "local-docker",
+      "namespace",
+      "rail",
+      "railwayapp",
+      "sem",
+      "static",
+      "static-ssh",
+    ];
 
-    expect(runWrapper(helpText, ["run", "--provider", "docker", "--", "echo ok"]).status).toBe(0);
-    expect(runWrapper(helpText, ["run", "--provider", "blacksmith", "--", "echo ok"]).status).toBe(
-      0,
-    );
+    for (const alias of aliases) {
+      const result = runWrapper(helpText, ["run", "--provider", alias, "--", "echo ok"]);
+
+      expect(result.status, alias).toBe(0);
+      expect(result.stdout).toContain(`"${alias}"`);
+    }
   });
 
   it("keeps unsupported provider selections rejected", () => {

--- a/test/scripts/crabbox-wrapper.test.ts
+++ b/test/scripts/crabbox-wrapper.test.ts
@@ -94,6 +94,7 @@ describe("scripts/crabbox-wrapper", () => {
       "exe",
       "exedev",
       "google",
+      "google-cloud",
       "local-docker",
       "namespace",
       "rail",

--- a/test/scripts/crabbox-wrapper.test.ts
+++ b/test/scripts/crabbox-wrapper.test.ts
@@ -63,6 +63,23 @@ describe("scripts/crabbox-wrapper", () => {
     expect(result.stdout).toContain('"local-container"');
   });
 
+  it("accepts advertised providers from wrapped Crabbox help", () => {
+    const result = runWrapper(
+      [
+        "provider: hetzner, aws, local-container, blacksmith-testbox,",
+        "  docker, or cloudflare (default: aws)",
+        "",
+      ].join("\n"),
+      ["run", "--provider", "docker", "--", "echo ok"],
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('"docker"');
+    expect(result.stderr).toContain(
+      "providers=hetzner,aws,local-container,blacksmith-testbox,docker,cloudflare",
+    );
+  });
+
   it("accepts Crabbox provider aliases when their canonical provider is advertised", () => {
     const helpText = "provider: hetzner, aws, local-container, blacksmith-testbox, or cloudflare\n";
 

--- a/test/scripts/crabbox-wrapper.test.ts
+++ b/test/scripts/crabbox-wrapper.test.ts
@@ -1,0 +1,96 @@
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const tempDirs: string[] = [];
+const repoRoot = process.cwd();
+
+function makeFakeCrabbox(helpText: string): string {
+  const binDir = mkdtempSync(path.join(tmpdir(), "openclaw-fake-crabbox-"));
+  tempDirs.push(binDir);
+  const crabboxPath = path.join(binDir, "crabbox");
+  const script = [
+    "#!/usr/bin/env node",
+    "const args = process.argv.slice(2);",
+    'if (args[0] === "--version") {',
+    '  console.log("crabbox 0.15.0");',
+    "  process.exit(0);",
+    "}",
+    'if (args[0] === "run" && args[1] === "--help") {',
+    `  process.stdout.write(${JSON.stringify(helpText)});`,
+    "  process.exit(0);",
+    "}",
+    "console.log(JSON.stringify(args));",
+  ].join("\n");
+  writeFileSync(crabboxPath, `${script}\n`, "utf8");
+  writeFileSync(
+    `${crabboxPath}.cmd`,
+    `@echo off\r\n"${process.execPath}" "%~dp0crabbox" %*\r\n`,
+    "utf8",
+  );
+  chmodSync(crabboxPath, 0o755);
+  return binDir;
+}
+
+function runWrapper(helpText: string, args: string[]) {
+  const binDir = makeFakeCrabbox(helpText);
+  return spawnSync(process.execPath, ["scripts/crabbox-wrapper.mjs", ...args], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+    },
+  });
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("scripts/crabbox-wrapper", () => {
+  it("accepts advertised canonical providers from Crabbox help", () => {
+    const result = runWrapper(
+      "provider: hetzner, aws, local-container, blacksmith-testbox, or cloudflare\n",
+      ["run", "--provider", "local-container", "--", "echo ok"],
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('"local-container"');
+  });
+
+  it("accepts Crabbox provider aliases when their canonical provider is advertised", () => {
+    const helpText = "provider: hetzner, aws, local-container, blacksmith-testbox, or cloudflare\n";
+
+    expect(runWrapper(helpText, ["run", "--provider", "docker", "--", "echo ok"]).status).toBe(0);
+    expect(runWrapper(helpText, ["run", "--provider", "blacksmith", "--", "echo ok"]).status).toBe(
+      0,
+    );
+  });
+
+  it("keeps unsupported provider selections rejected", () => {
+    const result = runWrapper(
+      "provider: hetzner, aws, local-container, blacksmith-testbox, or cloudflare\n",
+      ["run", "--provider", "bogus", "--", "echo ok"],
+    );
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain("selected binary does not advertise provider bogus");
+  });
+
+  it("parses provider choices from the --provider flag help format", () => {
+    const result = runWrapper(
+      "Usage: crabbox run [options]\n  --provider hetzner|aws|local-container|blacksmith-testbox|cloudflare\n",
+      ["run", "--provider", "aws", "--", "echo ok"],
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain(
+      "providers=hetzner,aws,local-container,blacksmith-testbox,cloudflare",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Replace the hardcoded `knownProviders` array in `scripts/crabbox-wrapper.mjs` with dynamic parsing from `crabbox run --help` output.

The wrapper previously maintained a manual list of known providers that had to be updated whenever crabbox added new ones (e.g. `docker`, `railway`, `exe-dev` were missing). Now the provider list is parsed directly from the binary's help text, keeping the wrapper automatically in sync.

The provider validation logic is also simplified: instead of checking against both a hardcoded list and a filtered list, it checks directly whether the binary advertises the selected provider.

## Verification

- Behavior addressed: wrapper stays in sync with crabbox binary providers without manual updates
- Real environment tested: local crabbox 0.15.0
- Exact steps or command run after this patch:
  - `CRABBOX_PROVIDER=docker node scripts/crabbox-wrapper.mjs --version` — correctly lists all providers including docker, railway, exe-dev
  - `CRABBOX_PROVIDER=nonexistent node scripts/crabbox-wrapper.mjs --version` — correctly rejects with exit 2
- Observed result after fix: providers list matches binary output; unsupported provider detection works
- What was not tested: CI/remote crabbox runs
